### PR TITLE
feat(intelligence): scout sidecar contract + injection (build-step 5a)

### DIFF
--- a/scripts/lib/intelligence_injection.py
+++ b/scripts/lib/intelligence_injection.py
@@ -391,11 +391,12 @@ def format_intelligence_items(items: list) -> str:
             parts.append(f"- **{item.title}**: {item.content}")
         parts.append("")
     # Direct-injection classes carry a fully-formatted markdown section in
-    # item.content (code anchors as file:line pointers, ADRs, schema sections,
-    # operator memories, prior-round findings). They are selected + budgeted by
-    # IntelligenceSelector but were previously never rendered here — emit their
-    # content verbatim so the worker actually receives them.
-    for cls in ("prior_round_finding", "adr_relevant", "schema_section",
+    # item.content (the scout pre-pass sketch, code anchors as file:line pointers,
+    # ADRs, schema sections, operator memories, prior-round findings). They are
+    # selected + budgeted by IntelligenceSelector but were previously never
+    # rendered here — emit their content verbatim so the worker actually receives
+    # them. scout_sketch leads: it is the curated "start here" recon over the rest.
+    for cls in ("scout_sketch", "prior_round_finding", "adr_relevant", "schema_section",
                 "code_anchor", "doc_relevant", "operator_memory"):
         for item in by_class.get(cls, []):
             content = (getattr(item, "content", "") or "").rstrip()

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -33,7 +33,7 @@ from intelligence_sources import (  # noqa: F401  (re-exported for backward comp
     query_proven_patterns, query_failure_prevention, query_recent_comparable,
     build_adr_item, build_schema_section_item,
     build_code_anchor_item, build_operator_memory_item, build_prior_round_item,
-    build_doc_relevant_item,
+    build_doc_relevant_item, build_scout_sketch_item,
     record_injection_audit, record_pattern_usage,
 )
 from intelligence_sources import stamp_source_dispatch_ids as _stamp
@@ -79,6 +79,10 @@ _DIRECT_SOURCES = [
     ("doc_relevant",        ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant"]),
     ("operator_memory",     ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant", "operator_memory"]),
     ("schema_section",      ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant", "operator_memory", "schema_section"]),
+    # scout_sketch is the curated recon over the deterministic anchors — added
+    # last so its eviction order is the longest (it survives a budget squeeze
+    # over the other direct classes) while still being droppable as a last resort.
+    ("scout_sketch",        ["prior_round_finding", "adr_relevant", "code_anchor", "doc_relevant", "operator_memory", "schema_section", "scout_sketch"]),
 ]
 
 # Build-step 1: rank-then-budget (opt-in via VNX_INTEL_RANK_THEN_BUDGET=1).
@@ -89,6 +93,7 @@ _DIRECT_SOURCES = [
 # Score = confidence * (1 + tag_overlap) * recency_decay * class_weight.
 _CLASS_WEIGHT: Dict[str, float] = {
     "failure_prevention": 1.5,
+    "scout_sketch": 1.45,
     "prior_round_finding": 1.4,
     "proven_pattern": 1.2,
     "adr_relevant": 1.1,
@@ -239,6 +244,7 @@ class IntelligenceSelector:
             "doc_relevant": build_doc_relevant_item(self._get_quality_db(), dispatch_id, paths, instruction_text or "", now_ts) if (paths or instruction_text) else None,
             "operator_memory": build_operator_memory_item(dispatch_id, skill_name, paths, instruction_text or "", now_ts) if (skill_name or paths or instruction_text) else None,
             "schema_section": build_schema_section_item(dispatch_id, paths, instruction_text or "", now_ts) if (paths or instruction_text) else None,
+            "scout_sketch": build_scout_sketch_item(self._coord_state_dir, dispatch_id, now_ts),
         }
 
         if _rank_then_budget_enabled():

--- a/scripts/lib/intelligence_sources/__init__.py
+++ b/scripts/lib/intelligence_sources/__init__.py
@@ -50,6 +50,7 @@ from .recent_comparable import query_recent_comparable
 from .adr_relevant import build_adr_item, build_schema_section_item
 from .code_anchor import build_code_anchor_item, build_operator_memory_item, build_prior_round_item
 from .doc_relevant import build_doc_relevant_item
+from .scout_sketch import build_scout_sketch_item
 
 __all__ = [
     "CONFIDENCE_THRESHOLDS", "EVIDENCE_THRESHOLDS", "GOVERNANCE_CONFIDENCE_PENALTY",
@@ -70,5 +71,5 @@ __all__ = [
     "query_proven_patterns", "query_failure_prevention", "query_recent_comparable",
     "build_adr_item", "build_schema_section_item",
     "build_code_anchor_item", "build_operator_memory_item", "build_prior_round_item",
-    "build_doc_relevant_item",
+    "build_doc_relevant_item", "build_scout_sketch_item",
 ]

--- a/scripts/lib/intelligence_sources/_common.py
+++ b/scripts/lib/intelligence_sources/_common.py
@@ -41,6 +41,7 @@ _DIRECT_INJECTION_CLASSES = frozenset({
     "operator_memory",
     "schema_section",
     "doc_relevant",
+    "scout_sketch",
 })
 
 CONFIDENCE_THRESHOLDS = {

--- a/scripts/lib/intelligence_sources/scout_sketch.py
+++ b/scripts/lib/intelligence_sources/scout_sketch.py
@@ -1,0 +1,58 @@
+"""
+scout_sketch source — cheap-model scout pre-pass grounding.
+
+Direct-injection builder that reads a per-dispatch ``scout_context.json`` sidecar
+(written by the scout pre-pass in the door) and renders it as a ranked
+INCLUDE/MAYBE pointer block + plan sketch. Fail-open: no sidecar → None, and the
+worker falls back to the deterministic code_anchor injection.
+"""
+from __future__ import annotations
+
+from typing import Optional
+
+from ._common import PATTERN_CATEGORY_CODE, IntelligenceItem
+
+try:
+    import scout_prepass as _scout_prepass
+except ImportError:  # pragma: no cover - lib path bootstrap
+    _scout_prepass = None  # type: ignore[assignment]
+
+
+def build_scout_sketch_item(
+    state_dir: object,
+    dispatch_id: str,
+    now_ts: str,
+) -> Optional[IntelligenceItem]:
+    """Return a scout_sketch IntelligenceItem, or None when no sidecar exists.
+
+    Reads the scout sidecar for ``dispatch_id`` under ``state_dir`` and renders
+    the bounded, pointer-only sketch. Confidence is 1.0 (model-curated recon over
+    deterministic candidates); evidence_count is the number of ranked pointers.
+    """
+    if _scout_prepass is None or state_dir is None or not dispatch_id:
+        return None
+    sidecar = _scout_prepass.read_scout_sidecar(state_dir, dispatch_id)
+    if not sidecar:
+        return None
+    content = _scout_prepass.format_scout_sketch(sidecar)
+    if not content:
+        return None
+    last_seen = str(sidecar.get("generated_at") or now_ts)
+    return IntelligenceItem(
+        item_id=f"intel_scout_{dispatch_id}",
+        item_class="scout_sketch",
+        title="Scout pre-pass — ranked context for this dispatch",
+        content=content,
+        confidence=1.0,
+        evidence_count=_scout_prepass.sidecar_evidence_count(sidecar),
+        last_seen=last_seen,
+        scope_tags=[],
+        source_refs=[
+            str(it.get("ref", ""))
+            for it in (sidecar.get("include") or [])
+            if isinstance(it, dict) and it.get("ref")
+        ],
+        task_class_filter=[],
+        pattern_category=PATTERN_CATEGORY_CODE,
+        content_hash="",
+    )

--- a/scripts/lib/scout_prepass.py
+++ b/scripts/lib/scout_prepass.py
@@ -1,0 +1,238 @@
+"""scout_prepass — sidecar contract for the cheap-model scout pre-pass.
+
+Build-step 5 (consumption side). The scout pre-pass is a cheap-model recon that
+ranks the deterministic code-anchor candidates for a dispatch into
+INCLUDE/MAYBE/EXCLUDE verdicts plus a short plan sketch, written to a per-dispatch
+``scout_context.json`` sidecar BEFORE the permit is issued. The producer (the
+door call + provider invocation) lands in a follow-up; this module owns the
+sidecar location, the read path, and the rendering of the injected sketch so the
+intelligence layer can consume a sidecar the moment one exists.
+
+Design contract:
+  - The sidecar is a SEPARATE file keyed by dispatch_id — it never mutates the
+    instruction, so the permit / instruction_sha256 TOCTOU is untouched.
+  - Reading is best-effort and fail-open: a missing / malformed sidecar yields
+    None and the worker falls back to the deterministic code_anchor injection.
+  - The rendered sketch is bounded (SCOUT_SKETCH_MAX_CHARS) and pointer-only —
+    file:line ranges, never code bodies.
+
+Sidecar schema (v1):
+    {
+      "schema_version": 1,
+      "dispatch_id": "<id>",
+      "generated_at": "<ISO8601>",
+      "provider": "deepseek",
+      "model": "deepseek-v4-flash",
+      "include": [{"ref": "scripts/lib/foo.py:10-20", "why": "..."}],
+      "maybe":   [{"ref": "scripts/lib/foo.py:50-60", "why": "..."}],
+      "exclude": [{"ref": "...", "why": "..."}],
+      "tests":   ["tests/test_foo.py"],
+      "docs":    ["docs/foo.md"],
+      "plan_sketch": "one or two line sketch"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+SCOUT_SUBDIR = "scout"
+SCOUT_SIDECAR_SUFFIX = ".json"
+SCHEMA_VERSION = 1
+
+# Path-containment contract: a dispatch_id becomes a filesystem path segment, so
+# it must not carry separators, '..', or absolute-path markers. Mirrors
+# worker_permission_relay._safe_dispatch_id so the scout sidecar can never escape
+# <state_dir>/scout/ via a malformed / hostile id (kimi-gate finding).
+_SAFE_DISPATCH_ID = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _safe_dispatch_id(dispatch_id: str) -> str:
+    """Return *dispatch_id* unchanged if safe as a path segment, else raise ValueError."""
+    if not isinstance(dispatch_id, str) or not dispatch_id:
+        raise ValueError("dispatch_id must be a non-empty string")
+    if dispatch_id in (".", ".."):
+        raise ValueError(f"unsafe dispatch_id {dispatch_id!r}: '.'/'..' are path-traversal segments")
+    if not _SAFE_DISPATCH_ID.match(dispatch_id):
+        raise ValueError(
+            f"unsafe dispatch_id {dispatch_id!r}: must match [A-Za-z0-9._-]+ "
+            "(no path separators, '..', or absolute paths)"
+        )
+    return dispatch_id
+
+# The rendered sketch competes for the 2000-char direct-injection payload budget,
+# so keep it well under that. Pointers + a one-line plan fit comfortably.
+SCOUT_SKETCH_MAX_CHARS = 1200
+
+# Defensive caps so a malformed / oversized sidecar can never blow the budget.
+_MAX_REFS_PER_BUCKET = 8
+_MAX_AUX_ITEMS = 5
+_MAX_WHY_CHARS = 120
+_MAX_PLAN_CHARS = 300
+
+
+def scout_sidecar_path(state_dir: "Path | str", dispatch_id: str) -> Path:
+    """Return the per-dispatch sidecar path: ``<state_dir>/scout/<dispatch_id>.json``.
+
+    Raises ValueError when dispatch_id is not a safe path segment (traversal
+    guard). Callers on the read path catch this and fail open.
+    """
+    return Path(state_dir) / SCOUT_SUBDIR / f"{_safe_dispatch_id(dispatch_id)}{SCOUT_SIDECAR_SUFFIX}"
+
+
+def read_scout_sidecar(state_dir: "Path | str | None", dispatch_id: str) -> Optional[Dict[str, Any]]:
+    """Best-effort read of a scout sidecar. Returns a dict, or None on any miss.
+
+    Fail-open: a missing file, unreadable file, malformed JSON, or non-object
+    payload all return None so the caller degrades to the deterministic anchors.
+    """
+    if state_dir is None or not dispatch_id:
+        return None
+    try:
+        path = scout_sidecar_path(state_dir, dispatch_id)
+    except ValueError as exc:
+        # Hostile / malformed dispatch_id — fail open, never read outside scope.
+        logger.debug("read_scout_sidecar: rejected unsafe dispatch_id %r: %s", dispatch_id, exc)
+        return None
+    try:
+        if not path.is_file():
+            return None
+        raw = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.debug("read_scout_sidecar: unreadable sidecar %s: %s", path, exc)
+        return None
+    try:
+        data = json.loads(raw)
+    except (json.JSONDecodeError, ValueError) as exc:
+        logger.debug("read_scout_sidecar: malformed sidecar %s: %s", path, exc)
+        return None
+    if not isinstance(data, dict):
+        return None
+    # Defense-in-depth (kimi-gate advisory): ignore a sidecar from a future
+    # schema or a different dispatch — a misplaced / stale file must never be
+    # misread as this dispatch's context.
+    sv = data.get("schema_version")
+    if sv is not None and sv != SCHEMA_VERSION:
+        logger.debug("read_scout_sidecar: unsupported schema_version %r for %s", sv, dispatch_id)
+        return None
+    sid = data.get("dispatch_id")
+    if sid is not None and str(sid) != str(dispatch_id):
+        logger.debug("read_scout_sidecar: sidecar dispatch_id %r != requested %r", sid, dispatch_id)
+        return None
+    return data
+
+
+def _coerce_ref_list(value: Any) -> List[Dict[str, str]]:
+    """Normalize an include/maybe/exclude bucket to a list of {ref, why} dicts."""
+    out: List[Dict[str, str]] = []
+    if not isinstance(value, list):
+        return out
+    for entry in value[:_MAX_REFS_PER_BUCKET]:
+        if isinstance(entry, dict):
+            ref = str(entry.get("ref") or "").strip()
+            why = str(entry.get("why") or "").strip()
+        elif isinstance(entry, str):
+            ref, why = entry.strip(), ""
+        else:
+            continue
+        if not ref:
+            continue
+        out.append({"ref": ref, "why": why[:_MAX_WHY_CHARS]})
+    return out
+
+
+def _coerce_str_list(value: Any) -> List[str]:
+    out: List[str] = []
+    if not isinstance(value, list):
+        return out
+    for entry in value[:_MAX_AUX_ITEMS]:
+        s = str(entry).strip()
+        if s:
+            out.append(s)
+    return out
+
+
+def normalize_sidecar(sidecar: Dict[str, Any]) -> Dict[str, Any]:
+    """Return a defensively-normalized view of the sidecar buckets.
+
+    Coerces shapes, caps list lengths and string sizes, and drops junk — so the
+    renderer (and any other consumer) works against a known-bounded structure
+    regardless of what the producing model emitted.
+    """
+    return {
+        "provider": str(sidecar.get("provider") or "").strip(),
+        "include": _coerce_ref_list(sidecar.get("include")),
+        "maybe": _coerce_ref_list(sidecar.get("maybe")),
+        "exclude": _coerce_ref_list(sidecar.get("exclude")),
+        "tests": _coerce_str_list(sidecar.get("tests")),
+        "docs": _coerce_str_list(sidecar.get("docs")),
+        "plan_sketch": str(sidecar.get("plan_sketch") or "").strip()[:_MAX_PLAN_CHARS],
+    }
+
+
+def sidecar_evidence_count(sidecar: Dict[str, Any]) -> int:
+    """Number of ranked pointers the sketch carries (include + maybe)."""
+    norm = normalize_sidecar(sidecar)
+    return len(norm["include"]) + len(norm["maybe"])
+
+
+def format_scout_sketch(sidecar: Dict[str, Any]) -> str:
+    """Render the injected scout sketch markdown (pointer-only, bounded).
+
+    EXCLUDE verdicts are intentionally NOT rendered — they only shrink the
+    INCLUDE set and would add noise the worker should not anchor on. Returns ""
+    when there is nothing useful to inject.
+    """
+    norm = normalize_sidecar(sidecar)
+    if not (norm["include"] or norm["maybe"] or norm["plan_sketch"]
+            or norm["tests"] or norm["docs"]):
+        return ""
+
+    provider = norm["provider"] or "cheap recon model"
+    lines: List[str] = [
+        "## SCOUT PRE-PASS (cheap-model recon — ranked grounding)",
+        "",
+        f"> A {provider} pre-pass ranked the candidate ranges below. Start with "
+        "INCLUDE, skim MAYBE. These are pointers to live code — open each range "
+        "and re-read if it looks stale.",
+        "",
+    ]
+    if norm["include"]:
+        lines.append("**Start here (INCLUDE):**")
+        for it in norm["include"]:
+            lines.append(_ref_line(it))
+        lines.append("")
+    if norm["maybe"]:
+        lines.append("**Maybe relevant:**")
+        for it in norm["maybe"]:
+            lines.append(_ref_line(it))
+        lines.append("")
+    if norm["tests"]:
+        lines.append("**Relevant tests:** " + ", ".join(f"`{t}`" for t in norm["tests"]))
+    if norm["docs"]:
+        lines.append("**Relevant docs:** " + ", ".join(f"`{d}`" for d in norm["docs"]))
+    if norm["plan_sketch"]:
+        lines.append("")
+        lines.append(f"**Plan sketch:** {norm['plan_sketch']}")
+
+    rendered = "\n".join(lines).rstrip()
+    if len(rendered) <= SCOUT_SKETCH_MAX_CHARS:
+        return rendered
+    # Hard cap: truncate on a line boundary so we never emit a half-pointer.
+    clipped = rendered[:SCOUT_SKETCH_MAX_CHARS]
+    nl = clipped.rfind("\n")
+    if nl > 0:
+        clipped = clipped[:nl]
+    return clipped.rstrip()
+
+
+def _ref_line(item: Dict[str, str]) -> str:
+    ref = item.get("ref", "")
+    why = item.get("why", "")
+    return f"- `{ref}` — {why}" if why else f"- `{ref}`"

--- a/tests/test_scout_sketch_injection.py
+++ b/tests/test_scout_sketch_injection.py
@@ -1,0 +1,271 @@
+#!/usr/bin/env python3
+"""Tests for the scout pre-pass sidecar contract + injection path (build-step 5a).
+
+Dispatch-ID: 20260626-scout-sidecar-contract
+
+Covers the consumption side:
+- scout_prepass: sidecar path, fail-open read, defensive normalization, bounded render
+- scout_sketch source: build_scout_sketch_item returns an item or None
+- format_intelligence_items: scout_sketch renders, and leads the direct-injection block
+- IntelligenceSelector.select: a sidecar surfaces as a scout_sketch item in the result
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import scout_prepass  # noqa: E402
+from intelligence_sources.scout_sketch import build_scout_sketch_item  # noqa: E402
+from intelligence_injection import format_intelligence_items  # noqa: E402
+
+
+def _write_sidecar(state_dir: Path, dispatch_id: str, payload: dict) -> Path:
+    path = scout_prepass.scout_sidecar_path(state_dir, dispatch_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Self-identify so the read-side dispatch_id check passes for the id we wrote under.
+    body = {**payload, "dispatch_id": dispatch_id}
+    path.write_text(json.dumps(body), encoding="utf-8")
+    return path
+
+
+_GOOD_SIDECAR = {
+    "schema_version": 1,
+    "dispatch_id": "D-1",
+    "generated_at": "2026-06-26T12:00:00+00:00",
+    "provider": "deepseek",
+    "model": "deepseek-v4-flash",
+    "include": [{"ref": "scripts/lib/foo.py:10-20", "why": "core change site"}],
+    "maybe": [{"ref": "scripts/lib/bar.py:50-60", "why": "caller"}],
+    "exclude": [{"ref": "scripts/lib/legacy.py:1-5", "why": "unrelated"}],
+    "tests": ["tests/test_foo.py"],
+    "docs": ["docs/foo.md"],
+    "plan_sketch": "Edit foo, update caller, add a test.",
+}
+
+
+# ---------------------------------------------------------------------------
+# scout_prepass: path + read
+# ---------------------------------------------------------------------------
+
+def test_sidecar_path_shape(tmp_path):
+    p = scout_prepass.scout_sidecar_path(tmp_path, "D-abc")
+    assert p == tmp_path / "scout" / "D-abc.json"
+
+
+def test_read_missing_sidecar_is_none(tmp_path):
+    assert scout_prepass.read_scout_sidecar(tmp_path, "nope") is None
+
+
+@pytest.mark.parametrize("evil", ["../../etc/passwd", "..", ".", "a/b", "x\\y", "/abs", ""])
+def test_sidecar_path_rejects_unsafe_dispatch_id(tmp_path, evil):
+    """A dispatch_id that is not a safe path segment must not build a path."""
+    with pytest.raises(ValueError):
+        scout_prepass.scout_sidecar_path(tmp_path, evil)
+
+
+def test_read_unsafe_dispatch_id_fails_open(tmp_path):
+    """Traversal id on the read path degrades to None, never reads outside scope."""
+    assert scout_prepass.read_scout_sidecar(tmp_path, "../../etc/passwd") is None
+
+
+def test_read_none_state_dir_is_none():
+    assert scout_prepass.read_scout_sidecar(None, "D-1") is None
+
+
+def test_read_malformed_json_is_none(tmp_path):
+    path = scout_prepass.scout_sidecar_path(tmp_path, "D-bad")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{ not json", encoding="utf-8")
+    assert scout_prepass.read_scout_sidecar(tmp_path, "D-bad") is None
+
+
+def test_read_non_object_is_none(tmp_path):
+    path = scout_prepass.scout_sidecar_path(tmp_path, "D-arr")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("[1, 2, 3]", encoding="utf-8")
+    assert scout_prepass.read_scout_sidecar(tmp_path, "D-arr") is None
+
+
+def test_read_good_sidecar_roundtrips(tmp_path):
+    _write_sidecar(tmp_path, "D-1", _GOOD_SIDECAR)
+    data = scout_prepass.read_scout_sidecar(tmp_path, "D-1")
+    assert data["provider"] == "deepseek"
+
+
+def test_read_rejects_future_schema_version(tmp_path):
+    path = scout_prepass.scout_sidecar_path(tmp_path, "D-fut")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"schema_version": 999, "dispatch_id": "D-fut"}), encoding="utf-8")
+    assert scout_prepass.read_scout_sidecar(tmp_path, "D-fut") is None
+
+
+def test_read_rejects_dispatch_id_mismatch(tmp_path):
+    path = scout_prepass.scout_sidecar_path(tmp_path, "D-here")
+    path.parent.mkdir(parents=True, exist_ok=True)
+    # Sidecar self-identifies as a DIFFERENT dispatch → must not be misread.
+    path.write_text(json.dumps({"schema_version": 1, "dispatch_id": "D-other",
+                                "include": [{"ref": "a.py:1-2"}]}), encoding="utf-8")
+    assert scout_prepass.read_scout_sidecar(tmp_path, "D-here") is None
+
+
+# ---------------------------------------------------------------------------
+# scout_prepass: normalize + render
+# ---------------------------------------------------------------------------
+
+def test_normalize_coerces_and_caps():
+    messy = {
+        "include": ["scripts/a.py:1-2", {"ref": "scripts/b.py:3-4", "why": "x" * 500}],
+        "maybe": "not a list",
+        "tests": ["t1", "t2", "t3", "t4", "t5", "t6", "t7"],  # > cap
+        "plan_sketch": "y" * 1000,
+    }
+    norm = scout_prepass.normalize_sidecar(messy)
+    assert norm["include"][0] == {"ref": "scripts/a.py:1-2", "why": ""}
+    assert len(norm["include"][1]["why"]) <= 120
+    assert norm["maybe"] == []  # non-list coerced to empty
+    assert len(norm["tests"]) <= 5
+    assert len(norm["plan_sketch"]) <= 300
+
+
+def test_format_renders_include_maybe_tests_docs_plan():
+    out = scout_prepass.format_scout_sketch(_GOOD_SIDECAR)
+    assert "SCOUT PRE-PASS" in out
+    assert "scripts/lib/foo.py:10-20" in out
+    assert "core change site" in out
+    assert "scripts/lib/bar.py:50-60" in out
+    assert "tests/test_foo.py" in out
+    assert "docs/foo.md" in out
+    assert "Edit foo" in out
+
+
+def test_format_omits_exclude():
+    out = scout_prepass.format_scout_sketch(_GOOD_SIDECAR)
+    # EXCLUDE refs are deliberately not injected (noise the worker shouldn't anchor on).
+    assert "legacy.py" not in out
+
+
+def test_format_empty_sidecar_is_blank():
+    assert scout_prepass.format_scout_sketch({}) == ""
+    assert scout_prepass.format_scout_sketch({"exclude": [{"ref": "x:1-2"}]}) == ""
+
+
+def test_format_is_bounded():
+    big = {
+        "provider": "deepseek",
+        "include": [{"ref": f"scripts/f{i}.py:1-9", "why": "w" * 119} for i in range(8)],
+        "maybe": [{"ref": f"scripts/g{i}.py:1-9", "why": "w" * 119} for i in range(8)],
+        "plan_sketch": "p" * 300,
+    }
+    out = scout_prepass.format_scout_sketch(big)
+    assert len(out) <= scout_prepass.SCOUT_SKETCH_MAX_CHARS
+    # truncation lands on a line boundary (no dangling half-pointer backtick line)
+    assert not out.endswith("`")
+
+
+def test_evidence_count_counts_include_and_maybe():
+    assert scout_prepass.sidecar_evidence_count(_GOOD_SIDECAR) == 2
+
+
+# ---------------------------------------------------------------------------
+# scout_sketch source builder
+# ---------------------------------------------------------------------------
+
+def test_build_item_none_without_sidecar(tmp_path):
+    assert build_scout_sketch_item(tmp_path, "absent", "2026-06-26T00:00:00Z") is None
+
+
+def test_build_item_none_for_none_state_dir():
+    assert build_scout_sketch_item(None, "D-1", "2026-06-26T00:00:00Z") is None
+
+
+def test_build_item_from_sidecar(tmp_path):
+    _write_sidecar(tmp_path, "D-1", _GOOD_SIDECAR)
+    item = build_scout_sketch_item(tmp_path, "D-1", "2026-06-26T00:00:00Z")
+    assert item is not None
+    assert item.item_class == "scout_sketch"
+    assert item.item_id == "intel_scout_D-1"
+    assert item.evidence_count == 2
+    assert item.last_seen == "2026-06-26T12:00:00+00:00"  # from generated_at
+    assert "scripts/lib/foo.py:10-20" in item.content
+    assert item.source_refs == ["scripts/lib/foo.py:10-20"]
+
+
+# ---------------------------------------------------------------------------
+# render integration
+# ---------------------------------------------------------------------------
+
+def test_format_intelligence_items_renders_scout_sketch_first(tmp_path):
+    _write_sidecar(tmp_path, "D-1", _GOOD_SIDECAR)
+    scout = build_scout_sketch_item(tmp_path, "D-1", "2026-06-26T00:00:00Z")
+
+    class _Anchor:
+        item_class = "code_anchor"
+        title = "anchors"
+        content = "## CODE ANCHORS\n- `scripts/lib/zzz.py:1-2`"
+
+    rendered = format_intelligence_items([_Anchor(), scout])
+    assert "SCOUT PRE-PASS" in rendered
+    assert "CODE ANCHORS" in rendered
+    # scout_sketch leads the direct-injection block
+    assert rendered.index("SCOUT PRE-PASS") < rendered.index("CODE ANCHORS")
+
+
+# ---------------------------------------------------------------------------
+# selector integration — a sidecar surfaces as a scout_sketch item
+# ---------------------------------------------------------------------------
+
+def test_selector_surfaces_scout_sketch(tmp_path):
+    from intelligence_selector import IntelligenceSelector
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _write_sidecar(state_dir, "D-sel", _GOOD_SIDECAR)
+
+    selector = IntelligenceSelector(
+        quality_db_path=state_dir / "quality_intelligence.db",  # absent → no standard items
+        coord_db_state_dir=state_dir,
+    )
+    try:
+        result = selector.select(
+            dispatch_id="D-sel",
+            injection_point="dispatch_create",
+            skill_name="python-expert",
+            dispatch_paths=[],
+            instruction_text="",
+        )
+    finally:
+        selector.close()
+
+    classes = [i.item_class for i in result.items]
+    assert "scout_sketch" in classes
+    scout = next(i for i in result.items if i.item_class == "scout_sketch")
+    assert "scripts/lib/foo.py:10-20" in scout.content
+
+
+def test_selector_no_sidecar_no_scout_item(tmp_path):
+    from intelligence_selector import IntelligenceSelector
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    selector = IntelligenceSelector(
+        quality_db_path=state_dir / "quality_intelligence.db",
+        coord_db_state_dir=state_dir,
+    )
+    try:
+        result = selector.select(
+            dispatch_id="D-none",
+            injection_point="dispatch_create",
+            skill_name="python-expert",
+            dispatch_paths=[],
+            instruction_text="",
+        )
+    finally:
+        selector.close()
+    assert "scout_sketch" not in [i.item_class for i in result.items]


### PR DESCRIPTION
## Summary

Build-step 5 (scout pre-pass), split into two PRs for size + safety. **This is 5a, the consumption side.**

A per-dispatch `scout_context.json` sidecar — written by the cheap-model scout pre-pass in the door (producer is **5b**) — is read and rendered into the worker's intelligence payload as a new `scout_sketch` direct-injection item. The sidecar is a **separate file keyed by dispatch_id**, so it never mutates the instruction and the permit / `instruction_sha256` TOCTOU is untouched.

**Default-inert:** with no sidecar on disk the source returns `None` and selection is byte-identical to today. Reading is **fail-open** — a missing / malformed / future-schema / wrong-dispatch sidecar degrades to the deterministic `code_anchor` anchors.

## Changes

- `scripts/lib/scout_prepass.py` (new) — sidecar contract: `scout_sidecar_path` (path-sanitized via `_safe_dispatch_id`, mirrors `worker_permission_relay`), `read_scout_sidecar` (fail-open; rejects future `schema_version` + mismatched `dispatch_id`), `normalize_sidecar` (defensive coercion + caps), `format_scout_sketch` (bounded, pointer-only, omits EXCLUDE), `sidecar_evidence_count`.
- `scripts/lib/intelligence_sources/scout_sketch.py` (new) — `build_scout_sketch_item` → a `scout_sketch` IntelligenceItem or `None`.
- `intelligence_sources/__init__.py`, `_common.py` — export + add `scout_sketch` to `_DIRECT_INJECTION_CLASSES`.
- `intelligence_selector.py` — wire into `_DIRECT_SOURCES` (last → highest retention, still droppable), the `direct` dict, `_CLASS_WEIGHT` (1.45).
- `intelligence_injection.py` — render `scout_sketch` first in the direct-injection block (it leads as the curated "start here" recon).
- `tests/test_scout_sketch_injection.py` (new) — 28 tests.

## Security

The kimi-diff-gate caught a real **path-traversal**: `scout_sidecar_path` built a path from an unsanitized `dispatch_id`. Fixed by mirroring the project's `_safe_dispatch_id` contract (`[A-Za-z0-9._-]+`, rejects separators / `..`); the read path fails open on rejection. Tests cover the traversal rejection + fail-open.

## Verification

- `pytest tests/test_scout_sketch_injection.py` — **28 passed**.
- Full-suite regression: same 23 pre-existing failures as `origin/main` (branch adds only passing scout tests).
- kimi-diff-gate: **PASS** (0 blocking) after the traversal fix + schema/dispatch read-validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)