### PR TITLE
feat(intelligence): scout pre-pass producer + door wiring (build-step 5b)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -566,6 +566,26 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             _emit_reject(plan)
             return 1
 
+        # Scout pre-pass (opt-in VNX_SCOUT_PREPASS, fail-open): a cheap key-auth
+        # model ranks the deterministic anchors into a sidecar BEFORE the permit
+        # is issued. It reads vspec.instruction_text in-memory and writes a
+        # SEPARATE sidecar file — it never touches the instruction, so the
+        # permit / instruction_sha256 TOCTOU below is untouched. Never blocks the
+        # door (best-effort, never raises).
+        if not dry_run:
+            try:
+                from scout_prepass import maybe_run_scout
+                maybe_run_scout(
+                    dispatch_id=plan.dispatch_id,
+                    instruction_text=vspec.instruction_text,
+                    dispatch_paths=[dp.path for dp in vspec.spec.dispatch_paths],
+                    state_dir=state_dir,
+                    task_class=getattr(vspec.spec, "task_class", None),
+                    lane=plan.lane,
+                )
+            except Exception as exc:
+                logger.debug("[dispatch_cli] scout pre-pass skipped: %s", exc)
+
         permit = issue_permit(plan)
         require_permit(plan, permit)  # P1-#6: door backstop for BOTH lanes
         fp = fingerprint(permit)

--- a/scripts/lib/scout_prepass.py
+++ b/scripts/lib/scout_prepass.py
@@ -1,12 +1,12 @@
 """scout_prepass — sidecar contract for the cheap-model scout pre-pass.
 
-Build-step 5 (consumption side). The scout pre-pass is a cheap-model recon that
-ranks the deterministic code-anchor candidates for a dispatch into
-INCLUDE/MAYBE/EXCLUDE verdicts plus a short plan sketch, written to a per-dispatch
-``scout_context.json`` sidecar BEFORE the permit is issued. The producer (the
-door call + provider invocation) lands in a follow-up; this module owns the
-sidecar location, the read path, and the rendering of the injected sketch so the
-intelligence layer can consume a sidecar the moment one exists.
+The scout pre-pass is a cheap-model recon that ranks the deterministic
+code-anchor candidates for a dispatch into INCLUDE/MAYBE/EXCLUDE verdicts plus a
+short plan sketch, written to a per-dispatch ``scout_context.json`` sidecar
+BEFORE the permit is issued. This module owns both ends: the producer
+(``maybe_run_scout`` — the door pre-pass + key-auth provider invocation, 5b) and
+the consumer (sidecar location, fail-open read, and the rendering of the injected
+sketch, 5a) so the intelligence layer consumes a sidecar the moment one exists.
 
 Design contract:
   - The sidecar is a SEPARATE file keyed by dispatch_id — it never mutates the
@@ -36,7 +36,9 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import re
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -236,3 +238,214 @@ def _ref_line(item: Dict[str, str]) -> str:
     ref = item.get("ref", "")
     why = item.get("why", "")
     return f"- `{ref}` — {why}" if why else f"- `{ref}`"
+
+
+# ---------------------------------------------------------------------------
+# Producer — the door pre-pass (build-step 5b)
+# ---------------------------------------------------------------------------
+#
+# Runs AFTER compile_plan / BEFORE issue_permit in dispatch_cli.run_dispatch.
+# A cheap, key-auth model (DeepSeek-Flash via the classifier harness — NEVER a
+# claude/subscription lane) ranks the deterministic code-anchor candidates into
+# INCLUDE/MAYBE/EXCLUDE + a plan sketch, written to the sidecar. Opt-in, gated,
+# fail-open (any miss → no sidecar → the deterministic code_anchor injection
+# stands). It never reads or rewrites the instruction file, so the permit /
+# instruction_sha256 TOCTOU is untouched.
+
+_DEFAULT_MIN_PATHS = 2
+_MIN_INSTRUCTION_CHARS = 40
+# task_classes where a code-anchor recon adds little (no source to rank).
+_SKIP_TASK_CLASSES = frozenset({"docs_synthesis", "channel_response", "ops_watchdog"})
+# Dispatch lanes the scout skips — claude_headless is the rare API-metered opt-in
+# path; do not spend a scout call there.
+_SKIP_LANES = frozenset({"claude_headless"})
+# Allowlist of cheap key-auth classifier lanes the scout may use. Default-deny so
+# a subscription lane (e.g. 'haiku') can NEVER run the scout, per the hard
+# constraint "never a claude/subscription lane for the scout".
+_ALLOWED_SCOUT_PROVIDERS = frozenset({"deepseek", "ollama", "gemini", "codex"})
+
+
+def scout_prepass_enabled() -> bool:
+    """Opt-in flag for the scout producer (default OFF)."""
+    return os.environ.get("VNX_SCOUT_PREPASS", "0") == "1"
+
+
+def _scout_provider_name() -> str:
+    name = (os.environ.get("VNX_SCOUT_PROVIDER") or "deepseek").strip().lower()
+    if name not in _ALLOWED_SCOUT_PROVIDERS:
+        # Default-deny: anything not a sanctioned key-auth lane (incl. the
+        # subscription 'haiku') falls back to the key-auth default.
+        logger.debug("scout: provider %r is not an allowed key-auth lane — using deepseek", name)
+        return "deepseek"
+    return name
+
+
+def _scout_gate_ok(
+    dispatch_paths: "List[str] | None",
+    instruction_text: str,
+    task_class: "str | None",
+    lane: "str | None",
+) -> bool:
+    """Scope/lane/task_class gate — skip trivial, non-code, or headless dispatches."""
+    try:
+        min_paths = int(os.environ.get("VNX_SCOUT_MIN_PATHS", _DEFAULT_MIN_PATHS))
+    except (TypeError, ValueError):
+        min_paths = _DEFAULT_MIN_PATHS
+    if not dispatch_paths or len(dispatch_paths) < max(1, min_paths):
+        return False
+    if not instruction_text or len(instruction_text.strip()) < _MIN_INSTRUCTION_CHARS:
+        return False
+    if task_class and str(task_class).strip().lower() in _SKIP_TASK_CLASSES:
+        return False
+    if lane and str(lane).strip().lower() in _SKIP_LANES:
+        return False
+    return True
+
+
+def _candidate_refs(dispatch_paths: List[str], instruction_text: str) -> List[str]:
+    """Deterministic code-anchor candidate refs (file:line ranges), pointer-only."""
+    try:
+        import code_anchor_finder as _caf
+    except ImportError:
+        return []
+    anchors = _caf.fetch_code_anchors(dispatch_paths, instruction_text, refs_only=True)
+    return [f"{a.file_path}:{a.line_start}-{a.line_end}" for a in anchors]
+
+
+def _build_scout_prompt(instruction_text: str, candidate_refs: List[str]) -> str:
+    """Bounded recon prompt — rank the candidates, JSON-only output."""
+    refs_block = "\n".join(f"- {r}" for r in candidate_refs)
+    instr = instruction_text.strip()
+    if len(instr) > 2000:
+        instr = instr[:2000] + " […]"
+    return (
+        "You are a fast code-recon scout. Rank the candidate code ranges below by "
+        "how relevant each is to the task. Do NOT write code or summarize file "
+        "contents — only rank the given pointers and name relevant tests/docs.\n\n"
+        f"TASK:\n{instr}\n\n"
+        f"CANDIDATE RANGES (use these exact refs, do not invent files):\n{refs_block}\n\n"
+        "Respond with ONLY a JSON object of this shape:\n"
+        '{"include":[{"ref":"<one of the candidates>","why":"<=12 words"}],'
+        '"maybe":[{"ref":"...","why":"..."}],'
+        '"exclude":[{"ref":"..."}],'
+        '"tests":["tests/..."],"docs":["docs/..."],'
+        '"plan_sketch":"<=2 sentence approach"}\n'
+        "Only use refs from the candidate list. Keep it short."
+    )
+
+
+def _invoke_scout_model(prompt: str, provider_name: str) -> "tuple[Optional[Dict[str, Any]], str]":
+    """Call the cheap key-auth classifier. Returns (parsed JSON | None, model)."""
+    try:
+        from classifier_providers import get_provider
+    except ImportError:
+        return None, ""
+    try:
+        provider = get_provider(provider_name)
+    except ValueError:
+        logger.debug("scout: unknown provider %r", provider_name)
+        return None, ""
+    if not provider.is_available():
+        logger.debug("scout: provider %r unavailable (no key / CLI)", provider_name)
+        return None, ""
+    result = provider.classify(prompt)
+    model = str((result.extra or {}).get("model") or "")
+    if result.error or not result.parsed_json:
+        logger.debug("scout: provider %r returned no usable JSON (%s)", provider_name, result.error)
+        return None, model
+    return result.parsed_json, model
+
+
+def _snap_refs(bucket: Any, allowed: "set[str]") -> List[Dict[str, str]]:
+    """Keep only model verdicts whose ref is a real candidate (anti-hallucination).
+
+    Producer-side caps (bucket length, why length) mirror normalize_sidecar so the
+    on-disk sidecar is bounded even before the consumer re-normalizes it.
+    """
+    out: List[Dict[str, str]] = []
+    if not isinstance(bucket, list):
+        return out
+    for entry in bucket:
+        if len(out) >= _MAX_REFS_PER_BUCKET:
+            break
+        if isinstance(entry, dict):
+            ref = str(entry.get("ref") or "").strip()
+            why = str(entry.get("why") or "").strip()
+        elif isinstance(entry, str):
+            ref, why = entry.strip(), ""
+        else:
+            continue
+        if ref in allowed:
+            out.append({"ref": ref, "why": why[:_MAX_WHY_CHARS]})
+    return out
+
+
+def _assemble_sidecar(
+    dispatch_id: str,
+    parsed: Dict[str, Any],
+    candidate_refs: List[str],
+    provider_name: str,
+    model: str,
+) -> Dict[str, Any]:
+    """Build the sidecar from the model verdicts, snapped to real candidates."""
+    allowed = set(candidate_refs)
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "dispatch_id": dispatch_id,
+        "generated_at": datetime.now(timezone.utc).isoformat(),
+        "provider": provider_name,
+        "model": model,
+        "include": _snap_refs(parsed.get("include"), allowed),
+        "maybe": _snap_refs(parsed.get("maybe"), allowed),
+        "exclude": _snap_refs(parsed.get("exclude"), allowed),
+        "tests": [str(t).strip() for t in (parsed.get("tests") or []) if str(t).strip()][:_MAX_AUX_ITEMS],
+        "docs": [str(d).strip() for d in (parsed.get("docs") or []) if str(d).strip()][:_MAX_AUX_ITEMS],
+        "plan_sketch": str(parsed.get("plan_sketch") or "").strip()[:_MAX_PLAN_CHARS],
+    }
+
+
+def write_scout_sidecar(state_dir: "Path | str", dispatch_id: str, sidecar: Dict[str, Any]) -> Path:
+    """Atomically write the sidecar (tmp + os.replace). Raises ValueError on unsafe id."""
+    path = scout_sidecar_path(state_dir, dispatch_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_name(f"{path.name}.{os.getpid()}.tmp")
+    tmp.write_text(json.dumps(sidecar, separators=(",", ":")), encoding="utf-8")
+    os.replace(tmp, path)
+    return path
+
+
+def maybe_run_scout(
+    *,
+    dispatch_id: str,
+    instruction_text: str,
+    dispatch_paths: "List[str] | None",
+    state_dir: "Path | str",
+    task_class: "str | None" = None,
+    lane: "str | None" = None,
+) -> "Optional[Path]":
+    """Run the scout pre-pass and write a sidecar. Best-effort — NEVER raises.
+
+    Returns the sidecar path on success, else None (fail-open → the deterministic
+    code_anchor injection stands). Opt-in (``VNX_SCOUT_PREPASS=1``) and gated on
+    scope/lane/task_class. Uses a cheap key-auth lane only (never the subscription).
+    """
+    if not scout_prepass_enabled():
+        return None
+    try:
+        if not _scout_gate_ok(dispatch_paths, instruction_text, task_class, lane):
+            return None
+        candidate_refs = _candidate_refs(list(dispatch_paths or []), instruction_text)
+        if not candidate_refs:
+            return None
+        provider_name = _scout_provider_name()
+        prompt = _build_scout_prompt(instruction_text, candidate_refs)
+        parsed, model = _invoke_scout_model(prompt, provider_name)
+        if not parsed:
+            return None
+        sidecar = _assemble_sidecar(dispatch_id, parsed, candidate_refs, provider_name, model)
+        if not (sidecar["include"] or sidecar["maybe"] or sidecar["plan_sketch"]):
+            return None  # nothing useful — don't write an empty sidecar
+        return write_scout_sidecar(state_dir, dispatch_id, sidecar)
+    except Exception as exc:  # fail-open: a scout failure must never block the door
+        logger.debug("maybe_run_scout: fail-open for %s (%s)", dispatch_id, exc)
+        return None

--- a/tests/test_scout_prepass_producer.py
+++ b/tests/test_scout_prepass_producer.py
@@ -1,0 +1,210 @@
+#!/usr/bin/env python3
+"""Tests for the scout pre-pass PRODUCER (build-step 5b).
+
+Dispatch-ID: 20260626-scout-prepass-producer
+
+Covers maybe_run_scout: opt-in flag, scope/task_class gating, key-auth provider
+invocation (mocked), anti-hallucination ref-snapping, atomic sidecar write, and
+the never-raises fail-open contract. The producer never uses a subscription lane.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import scout_prepass  # noqa: E402
+import classifier_providers  # noqa: E402
+
+_REFS = ["scripts/lib/foo.py:10-20", "scripts/lib/bar.py:50-60"]
+_INSTRUCTION = "Refactor foo() to stream rows and update its single caller in bar."
+
+
+class _FakeResult:
+    def __init__(self, parsed=None, error=None, model="deepseek-v4-flash"):
+        self.parsed_json = parsed
+        self.error = error
+        self.extra = {"model": model}
+
+
+class _FakeProvider:
+    def __init__(self, *, parsed=None, available=True, error=None):
+        self._parsed, self._available, self._error = parsed, available, error
+
+    def is_available(self):
+        return self._available
+
+    def classify(self, prompt, _max_tokens=1500):
+        return _FakeResult(parsed=self._parsed, error=self._error)
+
+
+@pytest.fixture
+def enabled(monkeypatch):
+    monkeypatch.setenv("VNX_SCOUT_PREPASS", "1")
+    monkeypatch.setattr(scout_prepass, "_candidate_refs", lambda paths, instr: list(_REFS))
+
+
+def _patch_provider(monkeypatch, provider):
+    monkeypatch.setattr(classifier_providers, "get_provider", lambda name=None: provider)
+
+
+def _run(state_dir, **over):
+    kw = dict(
+        dispatch_id="D-1",
+        instruction_text=_INSTRUCTION,
+        dispatch_paths=["scripts/lib/foo.py", "scripts/lib/bar.py"],
+        state_dir=state_dir,
+        task_class="coding_interactive",
+    )
+    kw.update(over)
+    return scout_prepass.maybe_run_scout(**kw)
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_default(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_SCOUT_PREPASS", raising=False)
+    assert _run(tmp_path) is None
+
+
+def test_gate_too_few_paths(tmp_path, enabled):
+    assert _run(tmp_path, dispatch_paths=["scripts/lib/foo.py"]) is None
+
+
+def test_gate_short_instruction(tmp_path, enabled):
+    assert _run(tmp_path, instruction_text="fix it") is None
+
+
+def test_gate_skips_docs_task_class(tmp_path, enabled, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider(parsed={"include": [{"ref": _REFS[0]}]}))
+    assert _run(tmp_path, task_class="docs_synthesis") is None
+
+
+def test_gate_skips_headless_lane(tmp_path, enabled, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider(parsed={"include": [{"ref": _REFS[0]}]}))
+    assert _run(tmp_path, lane="claude_headless") is None
+
+
+# ---------------------------------------------------------------------------
+# Provider invocation + fail-open
+# ---------------------------------------------------------------------------
+
+def test_provider_unavailable_no_sidecar(tmp_path, enabled, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider(available=False))
+    assert _run(tmp_path) is None
+
+
+def test_provider_error_no_sidecar(tmp_path, enabled, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider(error="boom", parsed=None))
+    assert _run(tmp_path) is None
+
+
+def test_provider_unparseable_no_sidecar(tmp_path, enabled, monkeypatch):
+    _patch_provider(monkeypatch, _FakeProvider(parsed=None))
+    assert _run(tmp_path) is None
+
+
+def test_no_candidates_no_sidecar(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_SCOUT_PREPASS", "1")
+    monkeypatch.setattr(scout_prepass, "_candidate_refs", lambda paths, instr: [])
+    _patch_provider(monkeypatch, _FakeProvider(parsed={"include": [{"ref": _REFS[0]}]}))
+    assert _run(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Happy path + anti-hallucination
+# ---------------------------------------------------------------------------
+
+def test_happy_path_writes_sidecar(tmp_path, enabled, monkeypatch):
+    parsed = {
+        "include": [{"ref": _REFS[0], "why": "core change site"}],
+        "maybe": [{"ref": _REFS[1], "why": "caller"}],
+        "exclude": [],
+        "tests": ["tests/test_foo.py"],
+        "docs": ["docs/foo.md"],
+        "plan_sketch": "Stream rows in foo, update bar's call.",
+    }
+    _patch_provider(monkeypatch, _FakeProvider(parsed=parsed))
+
+    path = _run(tmp_path)
+    assert path is not None and path.is_file()
+
+    sidecar = scout_prepass.read_scout_sidecar(tmp_path, "D-1")
+    assert sidecar is not None
+    assert sidecar["dispatch_id"] == "D-1"
+    assert sidecar["provider"] == "deepseek"
+    assert sidecar["model"] == "deepseek-v4-flash"
+    assert [i["ref"] for i in sidecar["include"]] == [_REFS[0]]
+    assert sidecar["tests"] == ["tests/test_foo.py"]
+    rendered = scout_prepass.format_scout_sketch(sidecar)
+    assert _REFS[0] in rendered
+
+
+def test_hallucinated_refs_snapped_out(tmp_path, enabled, monkeypatch):
+    # Model invents a ref not in the candidate list → snapped out; nothing useful → no sidecar.
+    parsed = {
+        "include": [{"ref": "scripts/lib/evil.py:1-9", "why": "made up"}],
+        "maybe": [{"ref": "another/invented.py:1-2"}],
+        "plan_sketch": "",
+    }
+    _patch_provider(monkeypatch, _FakeProvider(parsed=parsed))
+    assert _run(tmp_path) is None
+
+
+def test_hallucinated_refs_dropped_but_plan_kept(tmp_path, enabled, monkeypatch):
+    parsed = {
+        "include": [{"ref": "scripts/lib/evil.py:1-9"}],   # dropped
+        "maybe": [{"ref": _REFS[1], "why": "real"}],         # kept
+        "plan_sketch": "Do the thing.",
+    }
+    _patch_provider(monkeypatch, _FakeProvider(parsed=parsed))
+    path = _run(tmp_path)
+    assert path is not None
+    sidecar = scout_prepass.read_scout_sidecar(tmp_path, "D-1")
+    assert sidecar["include"] == []
+    assert [i["ref"] for i in sidecar["maybe"]] == [_REFS[1]]
+
+
+# ---------------------------------------------------------------------------
+# Provider safety + atomic write
+# ---------------------------------------------------------------------------
+
+def test_subscription_provider_refused(monkeypatch):
+    # 'haiku' rides the Claude subscription → default-denied back to deepseek.
+    monkeypatch.setenv("VNX_SCOUT_PROVIDER", "haiku")
+    assert scout_prepass._scout_provider_name() == "deepseek"
+
+
+def test_unknown_provider_defaults_to_deepseek(monkeypatch):
+    monkeypatch.setenv("VNX_SCOUT_PROVIDER", "totally-made-up")
+    assert scout_prepass._scout_provider_name() == "deepseek"
+
+
+@pytest.mark.parametrize("name", ["deepseek", "ollama", "gemini", "codex"])
+def test_allowed_keyauth_providers_passthrough(monkeypatch, name):
+    monkeypatch.setenv("VNX_SCOUT_PROVIDER", name)
+    assert scout_prepass._scout_provider_name() == name
+
+
+def test_write_sidecar_atomic_and_sanitized(tmp_path):
+    sc = {"schema_version": 1, "dispatch_id": "D-2", "include": [{"ref": "a.py:1-2"}]}
+    p = scout_prepass.write_scout_sidecar(tmp_path, "D-2", sc)
+    assert p.is_file()
+    assert scout_prepass.read_scout_sidecar(tmp_path, "D-2")["include"][0]["ref"] == "a.py:1-2"
+    with pytest.raises(ValueError):
+        scout_prepass.write_scout_sidecar(tmp_path, "../escape", sc)
+
+
+def test_maybe_run_scout_never_raises(tmp_path, enabled, monkeypatch):
+    def _boom(name=None):
+        raise RuntimeError("provider blew up")
+    monkeypatch.setattr(classifier_providers, "get_provider", _boom)
+    # Must swallow the error and fail open.
+    assert _run(tmp_path) is None


### PR DESCRIPTION
## Summary

**Build-step 5b — completes the scout pre-pass** (5a consumer was #930).

`scout_prepass.maybe_run_scout` runs in the door (`dispatch_cli.run_dispatch`, **AFTER `compile_plan` / BEFORE `issue_permit`**). A cheap **key-auth** model (DeepSeek-Flash via the classifier harness — **never** a claude/subscription lane) ranks the deterministic `code_anchor_finder` candidates into INCLUDE/MAYBE/EXCLUDE + a plan sketch, **snapped to real candidate refs** (anti-hallucination), and writes the per-dispatch sidecar that 5a consumes.

## Safety / contract

- **TOCTOU-safe:** reads `vspec.instruction_text` in-memory and writes a **separate** sidecar file — never touches the instruction, so the permit / `instruction_sha256` check is untouched.
- **Opt-in, default OFF** (`VNX_SCOUT_PREPASS=1`). Ships inert.
- **Gated** on scope (min paths), task_class (skips docs/channel/ops), and lane (skips `claude_headless`).
- **Fail-open, never raises:** any miss (disabled / gated out / no candidates / provider unavailable / error / unparseable / hallucinated-only) → no sidecar → the deterministic `code_anchor` injection stands.
- **Provider default-deny allowlist** `{deepseek, ollama, gemini, codex}` — a subscription lane (`haiku`) can never run the scout.
- **Atomic** sidecar write (tmp + `os.replace`), path-sanitized dispatch_id.

## Changes

- `scripts/lib/scout_prepass.py` — producer (`maybe_run_scout` + helpers).
- `scripts/lib/dispatch_cli.py` — best-effort `maybe_run_scout` call between compile_plan and issue_permit (skipped on dry_run).
- `tests/test_scout_prepass_producer.py` (new) — 20 tests.

## Verification

- `pytest tests/test_scout_prepass_producer.py tests/test_scout_sketch_injection.py` — **48 passed**; door/dispatch_cli suite — 129 passed.
- kimi-diff-gate: **PASS** (0 blocking). First pass caught a real blocking bug — malformed JSON in the prompt example (`["tests/...":]`) that would have made the model emit unparseable output and fail every sidecar. Fixed + advisory hardening; re-gated clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)