### PR TITLE
fix(tests): stale-update sweep — tests follow refactored code (PR A)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1313,6 +1313,7 @@ def _build_recent_receipts(
         view: Dict[str, Any] = {
             "timestamp": r.get("timestamp"),
             "dispatch_id": r.get("dispatch_id"),
+            "event_type": r.get("event_type") or r.get("event"),
             "status": r.get("status"),
             "terminal": r.get("terminal"),
             "commit_hash": r.get("commit_hash") or r.get("commit"),

--- a/tests/test_auto_rebuild_trigger.py
+++ b/tests/test_auto_rebuild_trigger.py
@@ -179,7 +179,7 @@ def test_task_complete_survives_100_state_mutations(tmp_path: Path) -> None:
         }))
     receipts_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 
-    result = bts._build_recent_receipts(state_dir, n=3)
+    result = bts._build_recent_receipts(state_dir, limit=3)
     types = [r.get("event_type") for r in result]
     assert "task_complete" in types, f"task_complete disappeared after 100 state_mutations: {result}"
     assert "state_mutation" not in types, f"state_mutation leaked into recency summary: {result}"

--- a/tests/test_gemini_prompt_renderer.py
+++ b/tests/test_gemini_prompt_renderer.py
@@ -473,6 +473,7 @@ class TestRecordResultAdvisoryBlockingIntegration:
         monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
         monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
         monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+        monkeypatch.setenv("VNX_HEADLESS_REPORTS_DIR", str(data_dir / "unified_reports" / "headless"))
         monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
         monkeypatch.setattr(rgm, "emit_governance_receipt", lambda *args, **kwargs: None)
 
@@ -480,6 +481,9 @@ class TestRecordResultAdvisoryBlockingIntegration:
 
     def test_record_result_emits_advisory_and_blocking_fields(self, manager):
         report_path = str((manager.reports_dir / "manual-pr2-gemini.md").resolve())
+        # record_result now requires the report file to exist on disk.
+        manager.reports_dir.mkdir(parents=True, exist_ok=True)
+        Path(report_path).write_text("# gemini report\n", encoding="utf-8")
         result = manager.record_result(
             gate="gemini_review",
             pr_number=2,
@@ -501,6 +505,9 @@ class TestRecordResultAdvisoryBlockingIntegration:
 
     def test_record_result_persists_with_advisory_blocking_fields(self, manager, tmp_path):
         report_path = str((manager.reports_dir / "manual-pr3-gemini.md").resolve())
+        # record_result now requires the report file to exist on disk.
+        manager.reports_dir.mkdir(parents=True, exist_ok=True)
+        Path(report_path).write_text("# gemini report\n", encoding="utf-8")
         manager.record_result(
             gate="gemini_review",
             pr_number=3,
@@ -528,7 +535,9 @@ class TestRecordResultAdvisoryBlockingIntegration:
         contract = _make_minimal_contract()
         payload = manager.request_gemini_with_contract(contract=contract, mode="per_pr")
 
-        assert payload["status"] == "queued"
+        # Gemini-available requests now emit 'requested' (was 'queued'); the
+        # per-gate vocabulary is 'requested' if available else 'not_executable'.
+        assert payload["status"] == "requested"
         assert "prompt" in payload
         assert len(payload["prompt"]) > 100
         # The prompt file should be persisted to disk
@@ -537,7 +546,8 @@ class TestRecordResultAdvisoryBlockingIntegration:
         saved = json.loads(request_files[0].read_text(encoding="utf-8"))
         assert "prompt" in saved
         assert "PR-2" in saved["pr_id"]
-        assert saved["report_path"].startswith(str(manager.reports_dir.resolve()))
+        # Headless gates write under the dedicated headless reports dir.
+        assert saved["report_path"].startswith(str(manager.headless_reports_dir.resolve()))
 
     def test_request_gemini_with_contract_blocked_when_gemini_unavailable(self, manager, monkeypatch):
         import review_gate_manager as rgm
@@ -546,8 +556,10 @@ class TestRecordResultAdvisoryBlockingIntegration:
 
         contract = _make_minimal_contract()
         payload = manager.request_gemini_with_contract(contract=contract)
-        assert payload["status"] == "blocked"
-        assert payload["reason"] == "gemini_not_available"
+        # Unavailable gemini now emits 'not_executable' (was 'blocked'); with the
+        # review flag disabled the reason is 'provider_disabled'.
+        assert payload["status"] == "not_executable"
+        assert payload["reason"] == "provider_disabled"
 
     def test_request_gemini_with_contract_raises_on_missing_field(self, manager):
         bad_contract = _make_minimal_contract(pr_id="")

--- a/tests/test_pr311_round2_codex_fixes.py
+++ b/tests/test_pr311_round2_codex_fixes.py
@@ -481,20 +481,25 @@ class TestOfferedDoesNotIncrementUsedCount:
 class TestSourceLevelGuards:
     """Cheap source-level checks that protect against regressions."""
 
-    def test_subprocess_dispatch_calls_record_injection(self):
-        src = (SCRIPTS_LIB / "subprocess_dispatch.py").read_text(encoding="utf-8")
+    def test_broker_calls_record_injection(self):
+        # The injection/audit wiring moved out of subprocess_dispatch.py (now a
+        # thin facade) into dispatch_broker.py, the dispatch-creation owner.
+        src = (SCRIPTS_LIB / "dispatch_broker.py").read_text(encoding="utf-8")
         assert "record_injection(" in src, (
-            "Finding 1: subprocess_dispatch.py must call record_injection()"
+            "Finding 1: dispatch_broker.py must call record_injection()"
         )
         assert "emit_event(" in src, (
-            "Finding 1: subprocess_dispatch.py must call emit_event()"
+            "Finding 1: dispatch_broker.py must call emit_event()"
         )
 
-    def test_intelligence_selector_uses_stable_item_id(self):
-        src = (SCRIPTS_LIB / "intelligence_selector.py").read_text(encoding="utf-8")
+    def test_source_builders_use_stable_item_id(self):
+        # Deterministic, content-derived ids are generated in the per-source
+        # builders via intelligence_sources._common._stable_item_id (was inlined
+        # in intelligence_selector.py before the per-source split).
+        src = (SCRIPTS_LIB / "intelligence_sources" / "_common.py").read_text(encoding="utf-8")
         assert "_stable_item_id(" in src, (
-            "Finding 2: intelligence_selector.py must use _stable_item_id() "
-            "for content-derived ids"
+            "Finding 2: intelligence_sources._common must define/use "
+            "_stable_item_id() for content-derived ids"
         )
         # The old random helper must no longer be used as the item_id source.
         assert "item_id=_item_id()" not in src, (

--- a/tests/test_state_mutation_receipt.py
+++ b/tests/test_state_mutation_receipt.py
@@ -191,7 +191,7 @@ def test_state_mutation_excluded_from_recency_summary(tmp_path: Path) -> None:
     ]
     receipts_path.write_text("\n".join(json.dumps(e) for e in events) + "\n", encoding="utf-8")
 
-    result = bts._build_recent_receipts(state_dir, n=3)
+    result = bts._build_recent_receipts(state_dir, limit=3)
 
     returned_types = [r.get("event_type") for r in result]
     assert "state_mutation" not in returned_types, f"state_mutation leaked into recency summary: {result}"


### PR DESCRIPTION
## Summary

**Test-sweep PR A of 3** — the STALE-UPDATE cluster from the codex-reviewer triage of the bare-FAIL backlog. Standard going forward: every test **GREEN | skip+reason | xfail+reason**, never a bare FAIL. Each fix verified against current production code.

## Changes

- **`_build_recent_receipts` rename** — `n=3` → `limit=3` in `test_state_mutation_receipt.py` + `test_auto_rebuild_trigger.py`. The `n` param was renamed to `limit`.
- **`scripts/build_t0_state.py`** — surface `event_type` in the recent-receipts T0 view (additive). The two tests verify the `state_mutation` filter keeps `task_complete`/`review_gate_request` while dropping `state_mutation`; the filter works but the view had stopped carrying the event type, so the invariant was unobservable. Restoring the field makes the check real.
- **`test_gemini_prompt_renderer.py`** — per-gate status vocab updated (`queued`→`requested`, `blocked`→`not_executable`, reason→`provider_disabled`); `record_result` tests create the report file the parser now requires; persisted `report_path` assertion + fixture target the headless reports dir (`VNX_HEADLESS_REPORTS_DIR`).
- **`test_pr311_round2_codex_fixes.py`** — retarget structural guards to the new owners: `record_injection()`/`emit_event()` now in `dispatch_broker.py` (was thin-facade `subprocess_dispatch.py`); `_stable_item_id()` now in `intelligence_sources._common` (was `intelligence_selector.py`).

## Verification

- `pytest` on all 4 files — **84 passed**.
- 5 other build_t0-area failures confirmed **pre-existing** on origin/main (diff stashed) — outside the codex-16, captured for a follow-up sweep.
- kimi-diff-gate: **PASS** (0 blocking, 0 advisory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)