### PR TITLE
fix(tests): env-isolation, flaky-ordering, tmux baseline (PR B)

### DIFF
--- a/tests/test_failure_decay_recency.py
+++ b/tests/test_failure_decay_recency.py
@@ -46,7 +46,29 @@ def _live_db_path() -> Path | None:
     except RuntimeError:
         return None
     candidate = root / ".vnx-data" / "state" / "quality_intelligence.db"
-    return candidate if candidate.exists() else None
+    if not candidate.exists():
+        return None
+    # A live DB can predate the confidence_events migration; the canary needs
+    # that table, so treat a too-old (un-migrated) DB as "not available" rather
+    # than letting the query raise an OperationalError.
+    if not _has_table(candidate, "confidence_events"):
+        return None
+    return candidate
+
+
+def _has_table(db_path: Path, table: str) -> bool:
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name=?",
+                (table,),
+            ).fetchone()
+            return row is not None
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return False
 
 
 class FailureDecayRecencyCanary(unittest.TestCase):

--- a/tests/test_intelligence_pipeline_e2e.py
+++ b/tests/test_intelligence_pipeline_e2e.py
@@ -121,8 +121,12 @@ def _create_test_db(db_path: Path) -> sqlite3.Connection:
 
 
 @pytest.fixture
-def test_env(tmp_path):
+def test_env(tmp_path, monkeypatch):
     """Set up test environment with temp dirs and DB."""
+    # The test DB is project-scoped (project_id DEFAULT 'vnx-dev'); pin the
+    # project so the persist/query path is not affected by a VNX_PROJECT_ID
+    # leaked from an earlier test in the same process (order-independence).
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
     state_dir = tmp_path / "state"
     state_dir.mkdir()
     db_path = state_dir / "quality_intelligence.db"

--- a/tests/test_runtime_adapter_certification.py
+++ b/tests/test_runtime_adapter_certification.py
@@ -238,11 +238,22 @@ class TestDirectCouplingFreeze:
                     continue
                 if "subprocess" in line and "tmux" in line:
                     violations.append(f"{py_file.name}:{i}: {line.strip()}")
-        # Known pre-existing violations (predating Feature 16):
+        # Baseline of files that reference tmux directly. Refreshed 2026-06-27
+        # (operator-approved): the leaseless tmux-spawn lane is now first-class,
+        # so the door/spawn/governance modules below legitimately couple to tmux.
+        # The set guards against NEW, unexpected coupling outside this lane.
         known_preexisting = {
+            "cleanup_worker_exit.py",
             "dashboard_actions.py",
-            "terminal_snapshot.py",
-            "terminal_state_reconciler.py",
+            "dispatch_govern.py",
+            "dispatch_prepare.py",
+            "dispatch_sidedoor_audit.py",
+            "governance_emit.py",
+            "plan_gate_panel.py",
+            "provider_dispatch.py",
+            "staging_validator.py",
+            "tmux_interactive_dispatch.py",
+            "worker_permission_relay.py",
         }
         new_violations = [
             v for v in violations
@@ -254,11 +265,21 @@ class TestDirectCouplingFreeze:
         )
 
     def test_count_preexisting_violations_stable(self) -> None:
-        """Pre-existing violations count must not increase."""
+        """Direct-tmux-coupling file set must not grow beyond the approved baseline."""
+        # Refreshed 2026-06-27 (operator-approved) — see the note in
+        # test_no_direct_tmux_subprocess_in_protected_modules. Kept in sync with it.
         known_files = {
+            "cleanup_worker_exit.py",
             "dashboard_actions.py",
-            "terminal_snapshot.py",
-            "terminal_state_reconciler.py",
+            "dispatch_govern.py",
+            "dispatch_prepare.py",
+            "dispatch_sidedoor_audit.py",
+            "governance_emit.py",
+            "plan_gate_panel.py",
+            "provider_dispatch.py",
+            "staging_validator.py",
+            "tmux_interactive_dispatch.py",
+            "worker_permission_relay.py",
         }
         found: set[str] = set()
         for py_file in sorted(LIB_DIR.glob("*.py")):

--- a/tests/test_vnx_cli.py
+++ b/tests/test_vnx_cli.py
@@ -88,22 +88,32 @@ def test_init_writes_governance_profiles(tmp_path):
 
 
 def test_init_creates_vnx_data_subdirs(tmp_path):
-    """vnx init creates dispatches/pending, receipts, unified_reports, logs."""
+    """vnx init creates the project-local .vnx-data scaffold subdirs.
+
+    receipts/ and logs/ now live under the resolved (external) state root, not
+    project-local; the local scaffold is VNX_DATA_INIT_SUBDIRS.
+    """
     vnx_init(_init_args(tmp_path))
 
     vnx_data = tmp_path / ".vnx-data"
-    for subdir in ("dispatches/pending", "dispatches/active", "receipts", "unified_reports", "logs"):
+    for subdir in ("state", "dispatches/pending", "dispatches/active",
+                   "dispatches/completed", "events", "unified_reports"):
         assert (vnx_data / subdir).is_dir(), f"missing {subdir}"
 
 
-def test_init_idempotent(tmp_path):
-    """Running vnx init twice does not raise or overwrite existing files."""
+def test_init_refuses_reinit_without_force(tmp_path):
+    """A second vnx init refuses (rc=1) without --force and never clobbers files.
+
+    init is no longer silently idempotent: once .vnx-version exists it requires
+    --force to reinitialise, protecting an existing project from accidental
+    overwrite. The existing governance profile must be left untouched.
+    """
     vnx_init(_init_args(tmp_path))
     profiles_before = (tmp_path / ".vnx" / "governance_profiles.yaml").read_text()
 
     rc = vnx_init(_init_args(tmp_path))
 
-    assert rc == 0
+    assert rc == 1
     profiles_after = (tmp_path / ".vnx" / "governance_profiles.yaml").read_text()
     assert profiles_before == profiles_after
 

--- a/tests/test_vnx_paths_shell_worktree.py
+++ b/tests/test_vnx_paths_shell_worktree.py
@@ -41,8 +41,13 @@ def test_shell_resolver_keeps_runtime_local_and_intelligence_canonical(tmp_path)
         capture_output=True,
     )
 
+    # Isolate HOME to an empty tmp dir so the resolver's central-store probe
+    # ($HOME/.vnx-data/<project_id>) cannot find the operator's live store and
+    # wrongly resolve VNX_DATA_DIR there instead of the worktree-local path.
+    fake_home = tmp_path / "home"
+    fake_home.mkdir()
     env = {
-        "HOME": os.environ["HOME"],
+        "HOME": str(fake_home),
         "PATH": os.environ["PATH"],
         "TERM": os.environ.get("TERM", "xterm-256color"),
     }
@@ -66,5 +71,13 @@ printf 'VNX_INTELLIGENCE_DIR=%s\n' "$VNX_INTELLIGENCE_DIR"
     lines = dict(line.split("=", 1) for line in result.stdout.strip().splitlines())
     assert Path(lines["PROJECT_ROOT"]).resolve() == worktree_root.resolve()
     assert Path(lines["VNX_CANONICAL_ROOT"]).resolve() == canonical_root.resolve()
-    assert Path(lines["VNX_DATA_DIR"]).resolve() == (worktree_root / ".vnx-data").resolve()
+    # With a resolvable project_id but no local/central store, runtime resolves
+    # to the per-project data home (XDG: $HOME/.local/share/vnx/<pid>) — the
+    # central-store model shares project state across worktrees rather than
+    # keeping a separate per-worktree .vnx-data. HOME is isolated above so this
+    # never touches the operator's real profile or live store.
+    assert Path(lines["VNX_DATA_DIR"]).resolve() == (
+        fake_home / ".local" / "share" / "vnx" / "vnx-dev"
+    ).resolve()
+    # Intelligence stays anchored to the canonical root regardless.
     assert Path(lines["VNX_INTELLIGENCE_DIR"]).resolve() == (canonical_root / ".vnx-intelligence").resolve()


### PR DESCRIPTION
## Summary

**Test-sweep PR B of 3** — the ENV-QUARANTINE + flaky-ordering cluster from the codex triage, plus the operator-approved tmux-coupling baseline refresh.

## Changes

- **`test_intelligence_pipeline_e2e.py`** — root-caused the flaky 0-pattern failures (green in isolation, failed full-suite): `test_feedback_loop` leaks a `VNX_PROJECT_ID` into the process; the pipeline's project-scoped temp DB (`project_id DEFAULT 'vnx-dev'`) then queried the wrong project. Fix: pin `VNX_PROJECT_ID='vnx-dev'` in the fixture → order-independent.
- **`test_failure_decay_recency.py`** — the live-DB canary skipped only on a missing DB, not a too-old DB missing `confidence_events`. Added a table-existence guard → skips instead of raising `OperationalError`.
- **`test_runtime_adapter_certification.py`** — refreshed the frozen tmux-coupling baseline (**operator-approved**): the leaseless tmux-spawn lane is now first-class, so 11 door/spawn/governance modules legitimately reference tmux. Computed from the live tree; still guards against NEW coupling outside the lane.
- **`test_vnx_paths_shell_worktree.py`** — isolated `HOME` to a tmp dir so the resolver's central-store probe can't hit the operator's live store; updated the `VNX_DATA_DIR` assertion to the central-store XDG data-home resolution (worktrees share project state; the per-worktree-local premise predates the central store).
- **`test_vnx_cli.py`** — current `vnx init` contract: local scaffold subdirs are `VNX_DATA_INIT_SUBDIRS` (receipts/logs moved to the external state root); re-init refuses without `--force` (rc=1) and never clobbers (`test_init_idempotent` → `test_init_refuses_reinit_without_force`).

## Verification

- `pytest` on all 5 files — **54 passed, 1 skipped** (canary).
- Pipeline order-independence verified (`test_feedback_loop` → pipeline: 10/10 pass).
- kimi-diff-gate: **PASS** (0 blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)