### PR TITLE
fix(tests): time-bomb fixture + corrected codex misdiagnosis (PR C)

### DIFF
--- a/tests/test_dashboard_ui_operator_flows.py
+++ b/tests/test_dashboard_ui_operator_flows.py
@@ -38,6 +38,7 @@ from dashboard_read_model import (
     register_project,
     FRESH_THRESHOLD,
     AGING_THRESHOLD,
+    REGISTRY_AGING_THRESHOLD,
 )
 from dashboard_actions import (
     ActionOutcome,
@@ -471,17 +472,23 @@ class TestAggregateOpenItemsView(unittest.TestCase):
 class TestDegradedStateRendering(unittest.TestCase):
 
     def test_stale_open_items_triggers_degraded(self):
-        """open_items.json older than AGING_THRESHOLD marks envelope as degraded."""
+        """open_items.json older than its registry threshold marks degraded.
+
+        open_items.json is a slowly-changing registry file, so OpenItemsView
+        applies REGISTRY_AGING_THRESHOLD (24h), not the default AGING_THRESHOLD —
+        consistently with the pr_queue / projects registry sources. Backdate
+        beyond the registry threshold to trigger the degraded path.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             oi_path = Path(tmp) / "open_items.json"
             _make_open_items_file(oi_path, [])
-            # Backdate file mtime to beyond AGING_THRESHOLD
-            old_ts = (datetime.now(timezone.utc) - timedelta(seconds=AGING_THRESHOLD + 60)).timestamp()
+            # Backdate file mtime to beyond the registry aging threshold.
+            old_ts = (datetime.now(timezone.utc) - timedelta(seconds=REGISTRY_AGING_THRESHOLD + 60)).timestamp()
             os.utime(oi_path, (old_ts, old_ts))
 
             view = OpenItemsView(tmp)
             env = view.get_items()
-            self.assertTrue(env.degraded, "File older than AGING_THRESHOLD must produce degraded=True")
+            self.assertTrue(env.degraded, "File older than REGISTRY_AGING_THRESHOLD must produce degraded=True")
             self.assertTrue(any("stale" in r for r in env.degraded_reasons), "Degraded reason must mention 'stale'")
 
     def test_freshness_envelope_fields_always_present(self):

--- a/tests/test_pattern_diversity.py
+++ b/tests/test_pattern_diversity.py
@@ -15,6 +15,7 @@ import sqlite3
 import sys
 import tempfile
 import unittest
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
@@ -115,14 +116,20 @@ def _seed_pattern(
     usage_count: int = 3,
 ) -> int:
     conn = sqlite3.connect(str(db_path))
+    # Relative timestamps: hardcoded dates were a time bomb — once last_used aged
+    # past the recency-decay window the seeded confidence dropped below the
+    # proven-pattern threshold, leaving zero eligible items and failing the test.
+    now = datetime.now(timezone.utc)
+    first_seen = (now - timedelta(days=2)).isoformat()
+    last_used = now.isoformat()
     cur = conn.execute(
         """
         INSERT INTO success_patterns
             (title, description, category, confidence_score, usage_count,
              pattern_data, first_seen, last_used)
-        VALUES (?, ?, ?, ?, ?, '{}', '2026-04-01T00:00:00Z', '2026-04-29T00:00:00Z')
+        VALUES (?, ?, ?, ?, ?, '{}', ?, ?)
         """,
-        (title, description, category, confidence, usage_count),
+        (title, description, category, confidence, usage_count, first_seen, last_used),
     )
     conn.commit()
     pid = cur.lastrowid


### PR DESCRIPTION
## Summary

**Test-sweep PR C of 3** — the two codex "real findings." Both verified against production before acting: one was a genuine time-bomb, the other a codex misdiagnosis (production is correct → fix the test). Findings are verified, not trusted.

## Changes

- **`test_pattern_diversity.py` — time-bomb fixture fixed.** The seed used hardcoded `last_used='2026-04-29'`; once that date aged past the recency-decay window the seeded confidence (0.85/0.90) dropped below the proven-pattern threshold → zero eligible items → fail. Now uses relative timestamps (`last_used=now`, `first_seen=now-2d`) so it can't rot again.
- **`test_dashboard_ui_operator_flows.py` — codex misdiagnosis corrected.** Codex called this a production bug (`OpenItemsView.get_items` using `REGISTRY_AGING_THRESHOLD`/24h for `open_items.json`). Verification: the 24h registry threshold is **intentional and consistent** across all four registry call sites (`dashboard_read_model.py:438/544/607/730`) — `open_items.json` is a slowly-changing registry source. The **test** was stale (used the 300s default). Fixed the test to backdate beyond `REGISTRY_AGING_THRESHOLD`; **production code untouched.**

## Verification

- `pytest` on both files — **60 passed**.
- kimi-diff-gate: **PASS** (0 blocking).

## Note

Additional pre-existing bare-FAILs found beyond the codex-16 (test_build_project_status, test_build_t0_brief_output ×3, test_fsr_b_tenant_guard, test_feedback_loop learning-summary) — a follow-up sweep to reach zero bare-FAIL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)