### PR TITLE
fix(providers): harden harness lanes against empty rc=0 completions

### DIFF
--- a/scripts/lib/provider_spawns/deepseek_harness_spawn.py
+++ b/scripts/lib/provider_spawns/deepseek_harness_spawn.py
@@ -231,15 +231,47 @@ def spawn_deepseek_harness(
         **kwargs,
     )
 
+    # Harden the harness lane: an rc=0 spawn with no assistant text is an
+    # empty/garbled provider response, not a success. Make it retryable + loud
+    # so the adapter retries instead of emitting a silent empty report.
+    rc, err = _coerce_empty_completion_to_retryable(
+        claude_result.returncode, claude_result.timed_out,
+        claude_result.completion, claude_result.error, "deepseek-harness",
+    )
     return DeepSeekHarnessSpawnResult(
-        returncode=claude_result.returncode,
+        returncode=rc,
         completion=claude_result.completion,
         events_written=claude_result.events_written,
         session_id=claude_result.session_id,
         timed_out=claude_result.timed_out,
         model=resolved_model,
         stopped_early=claude_result.stopped_early,
-        error=claude_result.error,
+        error=err,
         token_usage=claude_result.token_usage,
         _adapter=getattr(claude_result, "_adapter", None),
     )
+
+
+def _coerce_empty_completion_to_retryable(
+    returncode: int,
+    timed_out: bool,
+    completion: Any,
+    error: Optional[str],
+    lane: str,
+) -> "tuple[int, Optional[str]]":
+    """Turn an rc=0 spawn with an empty completion into a retryable, loud failure.
+
+    The harness lanes (claude CLI → litellm/OpenRouter) occasionally return a
+    successful exit with no assistant text; left as-is that is a silent empty
+    report with no retry. Returning (1, error) makes the flake visible and lets
+    the adapter's retry budget re-attempt. Timeouts keep their own signal.
+    """
+    if returncode != 0 or timed_out:
+        return returncode, error
+    text = ""
+    if isinstance(completion, dict):
+        text = completion.get("text", "") or ""
+    if text.strip():
+        return returncode, error
+    logger.error("%s: empty completion on a returncode-0 spawn — marking retryable", lane)
+    return 1, error or f"{lane} returned an empty completion (retryable; provider flake)"

--- a/scripts/lib/provider_spawns/glm_harness_spawn.py
+++ b/scripts/lib/provider_spawns/glm_harness_spawn.py
@@ -163,15 +163,49 @@ def spawn_glm_harness(
         scrub_env_keys=_HARNESS_SCRUB_KEYS,
         **kwargs,
     )
+    # Harden the flaky OpenRouter→GLM lane: a returncode-0 spawn that produced no
+    # assistant text is an empty/garbled response (the recurrent glm-harness flake),
+    # not a success. Surface it as a RETRYABLE, loud failure so the adapter retries
+    # and we never silently emit an empty report. Timeouts keep their own signal.
+    rc, err = _coerce_empty_completion_to_retryable(
+        claude_result.returncode, claude_result.timed_out,
+        claude_result.completion, claude_result.error, "glm-harness",
+    )
     return GLMHarnessSpawnResult(
-        returncode=claude_result.returncode,
+        returncode=rc,
         completion=claude_result.completion,
         events_written=claude_result.events_written,
         session_id=claude_result.session_id,
         timed_out=claude_result.timed_out,
         model=resolved_model,
         stopped_early=claude_result.stopped_early,
-        error=claude_result.error,
+        error=err,
         token_usage=claude_result.token_usage,
         _adapter=getattr(claude_result, "_adapter", None),
     )
+
+
+def _coerce_empty_completion_to_retryable(
+    returncode: int,
+    timed_out: bool,
+    completion: Any,
+    error: Optional[str],
+    lane: str,
+) -> "tuple[int, Optional[str]]":
+    """Turn an rc=0 spawn with an empty completion into a retryable, loud failure.
+
+    The harness lanes (claude CLI → litellm/OpenRouter) occasionally return a
+    successful exit with no assistant text. Left as-is that becomes a silent
+    empty report with no retry. Returning (1, error) makes the flake visible and
+    lets the dispatch adapter's retry budget re-attempt. Timeouts are left alone
+    (they already carry their own returncode/timed_out signal).
+    """
+    if returncode != 0 or timed_out:
+        return returncode, error
+    text = ""
+    if isinstance(completion, dict):
+        text = completion.get("text", "") or ""
+    if text.strip():
+        return returncode, error
+    logger.error("%s: empty completion on a returncode-0 spawn — marking retryable", lane)
+    return 1, error or f"{lane} returned an empty completion (retryable; provider flake)"

--- a/tests/test_harness_empty_completion.py
+++ b/tests/test_harness_empty_completion.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Harness lanes coerce an empty rc=0 completion into a retryable, loud failure.
+
+Dispatch-ID: 20260627-harness-empty-completion
+
+The glm/deepseek harness lanes (claude CLI → litellm/OpenRouter) occasionally
+return a successful exit with no assistant text. Left as-is that is a silent
+empty report with no retry. `_coerce_empty_completion_to_retryable` turns it into
+returncode=1 + a clear error so the adapter retries and the flake is visible.
+Timeouts and non-zero exits are passed through unchanged.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from provider_spawns.glm_harness_spawn import _coerce_empty_completion_to_retryable as glm_coerce  # noqa: E402
+from provider_spawns.deepseek_harness_spawn import _coerce_empty_completion_to_retryable as ds_coerce  # noqa: E402
+
+_BOTH = pytest.mark.parametrize("coerce,lane", [(glm_coerce, "glm-harness"), (ds_coerce, "deepseek-harness")])
+
+
+@_BOTH
+def test_empty_rc0_becomes_retryable(coerce, lane):
+    rc, err = coerce(0, False, {"text": ""}, None, lane)
+    assert rc == 1
+    assert err and "empty completion" in err and "retryable" in err
+
+
+@_BOTH
+def test_whitespace_only_rc0_becomes_retryable(coerce, lane):
+    rc, err = coerce(0, False, {"text": "   \n  "}, None, lane)
+    assert rc == 1
+
+
+@_BOTH
+def test_missing_text_key_becomes_retryable(coerce, lane):
+    rc, err = coerce(0, False, {}, None, lane)
+    assert rc == 1
+
+
+@_BOTH
+def test_non_dict_completion_becomes_retryable(coerce, lane):
+    rc, err = coerce(0, False, None, None, lane)
+    assert rc == 1
+
+
+@_BOTH
+def test_real_text_passes_through(coerce, lane):
+    rc, err = coerce(0, False, {"text": "a real answer"}, None, lane)
+    assert rc == 0
+    assert err is None
+
+
+@_BOTH
+def test_nonzero_rc_passes_through(coerce, lane):
+    # An existing failure is left exactly as-is (don't mask its error/code).
+    rc, err = coerce(2, False, {"text": ""}, "boom", lane)
+    assert rc == 2
+    assert err == "boom"
+
+
+@_BOTH
+def test_timeout_passes_through(coerce, lane):
+    # A timeout keeps its own signal; we don't relabel it as an empty-completion flake.
+    rc, err = coerce(0, True, {"text": ""}, "timeout after 600s", lane)
+    assert rc == 0
+    assert err == "timeout after 600s"
+
+
+@_BOTH
+def test_preexisting_error_preserved_on_empty(coerce, lane):
+    rc, err = coerce(0, False, {"text": ""}, "upstream said X", lane)
+    assert rc == 1
+    assert err == "upstream said X"  # don't clobber a more-specific error


### PR DESCRIPTION
## Summary

Hardens the **glm-harness** (and the identical **deepseek-harness**) provider lane against its recurrent flake: the lane (claude CLI → litellm/OpenRouter) sometimes exits **0 with no assistant text**, which became a silent empty report with no retry — the "glm fails too often / returns nothing" friction.

`_coerce_empty_completion_to_retryable` turns an rc=0 spawn with an empty completion into **returncode=1 + a clear error**, so the dispatch adapter's retry budget re-attempts and the flake is loud, not silent. Timeouts and non-zero exits pass through unchanged (they keep their own signal); a pre-existing error is never clobbered.

Diagnosis confirmed the other two flake causes are **already handled**: proxy-unreachable refuses with a clear error (`glm_harness_spawn.py:140`), and the plan-gate parse-flake already abstains/quorums (`plan_gate_panel.py::apply_panel_rule`). This closes the remaining gap.

## Changes

- `scripts/lib/provider_spawns/glm_harness_spawn.py` — `_coerce_empty_completion_to_retryable` before the return.
- `scripts/lib/provider_spawns/deepseek_harness_spawn.py` — same hardening (identical lane gap).
- `tests/test_harness_empty_completion.py` (new) — 16 tests (8 cases × both lanes): empty/whitespace/missing-key/non-dict → retryable; real text / non-zero rc / timeout / pre-existing error → passthrough.

## Verification

- `pytest tests/test_harness_empty_completion.py` — **16 passed**.
- kimi-diff-gate: **PASS** (0 blocking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)