### PR TITLE
feat(intelligence): wire LLM tagger at persist-time (deepseek default)

### DIFF
--- a/scripts/intelligence_daemon.py
+++ b/scripts/intelligence_daemon.py
@@ -233,6 +233,19 @@ class GovernanceDigestRunner:
             except Exception as exc:
                 logger.warning("GovernanceDigestRunner: signal persistence failed (non-fatal): %s", exc)
 
+            # LLM-tagger enrichment (opt-in VNX_TAGGER_ENABLED): tag any newly
+            # persisted / still-untagged patterns so the rank-then-budget selector
+            # can match them on stored tags. No-op + non-fatal when disabled.
+            try:
+                from vnx_tagger import enrich_pattern_tags, is_enabled as _tagger_enabled
+                tagger_db = self.state_dir / "quality_intelligence.db"
+                if _tagger_enabled() and tagger_db.exists():
+                    tag_result = enrich_pattern_tags(tagger_db, limit=100)
+                    if any(v for k, v in tag_result.items() if not k.startswith("_")):
+                        logger.info("GovernanceDigestRunner: tagger enriched patterns: %s", tag_result)
+            except Exception as exc:
+                logger.warning("GovernanceDigestRunner: tagger enrichment failed (non-fatal): %s", exc)
+
             digest = build_digest(signals)
 
             self.last_run = datetime.now()

--- a/scripts/lib/intelligence_sources/_common.py
+++ b/scripts/lib/intelligence_sources/_common.py
@@ -184,6 +184,31 @@ def _normalize_for_hash(text: str) -> str:
     return " ".join((text or "").lower().split())
 
 
+def _merge_stored_tags(category: str, raw_tags: Any) -> List[str]:
+    """Build an item's scope_tags from its category + the persisted ``tags`` column.
+
+    The stored tags (deterministic floor + optional LLM enrichment from vnx_tagger,
+    a JSON array string) feed the rank-then-budget tag_overlap so a pattern with no
+    derivable tags is still matchable. Category leads; stored tags are appended,
+    deduped. Malformed/empty tags degrade to category-only.
+    """
+    out: List[str] = [category] if category else []
+    if not raw_tags:
+        return out
+    parsed: Any = raw_tags
+    if isinstance(raw_tags, str):
+        try:
+            parsed = json.loads(raw_tags)
+        except (json.JSONDecodeError, TypeError, ValueError):
+            return out
+    if isinstance(parsed, list):
+        for t in parsed:
+            ts = str(t).strip()
+            if ts and ts not in out:
+                out.append(ts)
+    return out
+
+
 def _content_hash(*parts: str) -> str:
     joined = "\n".join(_normalize_for_hash(p) for p in parts)
     return hashlib.sha256(joined.encode("utf-8")).hexdigest()

--- a/scripts/lib/intelligence_sources/failure_prevention.py
+++ b/scripts/lib/intelligence_sources/failure_prevention.py
@@ -21,6 +21,7 @@ from ._common import (
     _now_utc,
     _project_scope_clause,
     _scope_matches,
+    _merge_stored_tags,
     _stable_item_id,
     _table_has_column,
 )
@@ -109,12 +110,13 @@ def _query_antipatterns(
     ap_scope_clause, ap_scope_params = _project_scope_clause(
         has_column_fn("antipatterns", "project_id")
     )
+    tags_col = ", tags" if has_column_fn("antipatterns", "tags") else ""
     try:
         rows = db.execute(
             f"""
             SELECT id, title, description, category, severity,
                    why_problematic, better_alternative,
-                   occurrence_count, first_seen, last_seen
+                   occurrence_count, first_seen, last_seen{tags_col}
             FROM antipatterns
             WHERE occurrence_count >= 1
               AND (valid_until IS NULL OR valid_until > datetime('now'))
@@ -138,9 +140,11 @@ def _query_antipatterns(
     for row in rows:
         row_d = dict(row)
         category = row_d.get("category", "")
-        pattern_scope = [category] if category else []
-        if not _scope_matches(pattern_scope, scope_tags):
+        # Inclusion filter is category-only (consistent with proven_pattern);
+        # the merged tags are used for the item's scope_tags (ranking) only.
+        if not _scope_matches([category] if category else [], scope_tags):
             continue
+        pattern_scope = _merge_stored_tags(category, row_d.get("tags"))
         content_parts = []
         if row_d.get("why_problematic"):
             content_parts.append(row_d["why_problematic"])

--- a/scripts/lib/intelligence_sources/proven_pattern.py
+++ b/scripts/lib/intelligence_sources/proven_pattern.py
@@ -22,6 +22,7 @@ from ._common import (
     _stable_item_id,
     _table_has_column,
     classify_pattern_category,
+    _merge_stored_tags,
 )
 try:
     from project_scope import current_project_id, project_filter_enabled
@@ -138,6 +139,7 @@ def _query_per_project(
     has_pattern_cat = has_column_fn("success_patterns", "pattern_category")
     has_content_hash_col = has_column_fn("success_patterns", "content_hash")
     has_project_id_col = has_column_fn("success_patterns", "project_id")
+    has_tags_col = has_column_fn("success_patterns", "tags")
     select_cols = (
         "id, title, description, category, confidence_score, "
         "usage_count, source_dispatch_ids, first_seen, last_used"
@@ -148,6 +150,8 @@ def _query_per_project(
         select_cols += ", content_hash"
     if has_project_id_col:
         select_cols += ", project_id"
+    if has_tags_col:
+        select_cols += ", tags"
     scope_clause, scope_params = _project_scope_clause(has_project_id_col)
     active_project_id = current_project_id() if has_project_id_col else None
     try:
@@ -212,6 +216,7 @@ def _per_project_row_to_item(
     last_seen = canonical_row_d.get("last_used") or canonical_row_d.get("first_seen") or _now_utc()
     stored_cat = canonical_row_d.get("pattern_category")
     pattern_category = stored_cat or classify_pattern_category(canonical_title, canonical_content)
+    item_tags = _merge_stored_tags(canonical_category, canonical_row_d.get("tags"))
     return IntelligenceItem(
         item_id=_stable_item_id("sp", canonical_key),
         item_class="proven_pattern",
@@ -220,7 +225,7 @@ def _per_project_row_to_item(
         confidence=float(canonical_row_d.get("confidence_score", 0.0)),
         evidence_count=int(canonical_row_d.get("usage_count", 0)),
         last_seen=last_seen,
-        scope_tags=[canonical_category] if canonical_category else [],
+        scope_tags=item_tags,
         source_refs=source_refs[:5],
         task_class_filter=[],
         pattern_category=pattern_category,

--- a/scripts/lib/vnx_tagger.py
+++ b/scripts/lib/vnx_tagger.py
@@ -45,6 +45,7 @@ ENV_ENABLED = "VNX_TAGGER_ENABLED"
 ENV_PROVIDER = "VNX_TAGGER_PROVIDER"
 _DEFAULT_PROVIDER = "deepseek"
 _MAX_TAGS = 6
+_TAGGABLE_TABLES = frozenset({"success_patterns", "antipatterns"})
 
 
 def is_enabled() -> bool:
@@ -114,3 +115,73 @@ def enrich_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:
         if t not in tags:
             tags.append(t)
     return tags
+
+
+def enrich_pattern_tags(
+    db_path: "object",
+    *,
+    limit: int = 200,
+    only_untagged: bool = True,
+    tables: "Optional[List[str]]" = None,
+) -> dict:
+    """Persist enriched tags onto success_patterns/antipatterns (`tags` JSON column).
+
+    Serves both the one-time BACKFILL and ongoing enrichment: for each pattern
+    (by default only those with no stored tags) it computes ``enrich_tags`` and
+    writes the result as a JSON array. NO-OP when the tagger is disabled — storing
+    the deterministic floor alone adds nothing the selector doesn't already derive
+    on the fly, so the stored column is only worth populating when the LLM enriches.
+    Best-effort + never raises; missing ``tags`` column → skipped.
+
+    Returns a per-table count dict, e.g. ``{"success_patterns": 12, "antipatterns": 7}``.
+    """
+    if not is_enabled():
+        return {"_skipped": "tagger_disabled"}
+    import json as _json
+    import sqlite3 as _sqlite3
+
+    # Whitelist: only these identifiers are ever interpolated into SQL, so the
+    # public ``tables`` arg can never reach an arbitrary table name (no injection).
+    requested = tables or ["success_patterns", "antipatterns"]
+    tbls = [t for t in requested if t in _TAGGABLE_TABLES]
+    # Clamp into [1, 1_000_000]: the upper bound keeps the value SQLite-bindable
+    # (a too-large int raises on bind) while staying far above any real table size.
+    try:
+        safe_limit = max(1, min(int(limit), 1_000_000))
+    except (TypeError, ValueError, OverflowError):
+        safe_limit = 200
+    out: dict = {}
+    try:
+        conn = _sqlite3.connect(str(db_path))
+    except _sqlite3.Error:
+        return {"_skipped": "db_open_failed"}
+    try:
+        for tbl in tbls:
+            try:
+                cols = {r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()}
+            except _sqlite3.Error:
+                continue
+            if "tags" not in cols or "title" not in cols:
+                continue
+            where = "WHERE tags IS NULL OR tags = '' OR tags = '[]'" if only_untagged else ""
+            desc_col = "COALESCE(description,'')" if "description" in cols else "''"
+            try:
+                rows = conn.execute(
+                    f"SELECT id, title, {desc_col} FROM {tbl} {where} ORDER BY id DESC LIMIT ?",
+                    (safe_limit,),
+                ).fetchall()
+            except _sqlite3.Error:
+                continue
+            n = 0
+            for pid, title, desc in rows:
+                tags = enrich_tags(f"{title or ''} {desc or ''}".strip())
+                try:
+                    conn.execute(f"UPDATE {tbl} SET tags = ? WHERE id = ?", (_json.dumps(tags), pid))
+                    n += 1
+                except _sqlite3.Error:
+                    continue
+            conn.commit()
+            out[tbl] = n
+    finally:
+        conn.close()
+    return out

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -25,7 +25,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 24
+HIGHEST_QI_VERSION = 25
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -970,6 +970,27 @@ def _migrate_v24(conn: sqlite3.Connection) -> None:
         log('INFO', 'Migrated confidence_events: added grounding_source column (outcome-grounding v2, v24)')
 
 
+def _migrate_v25(conn: sqlite3.Connection) -> None:
+    """V25: tags column on success_patterns + antipatterns (LLM-tagger persist).
+
+    Stores the model-agnostic VNX tags (deterministic floor + optional LLM
+    enrichment via vnx_tagger) as a JSON array string, so a pattern with no
+    deterministic tags can still be matched by the rank-then-budget tag_overlap.
+    Additive nullable column; existing rows read NULL until the enrichment pass
+    backfills them. ALTER TABLE only (no rebuild). Both tables exist from the
+    base schema; the existence guard is cheap insurance for partial DBs.
+    """
+    for tbl in ("success_patterns", "antipatterns"):
+        if not conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (tbl,)
+        ).fetchone():
+            continue
+        cols = {r[1] for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()}
+        if "tags" not in cols:
+            conn.execute(f"ALTER TABLE {tbl} ADD COLUMN tags TEXT")
+            log('INFO', f'Migrated {tbl}: added tags column (LLM-tagger persist, v25)')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -996,6 +1017,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     22: _migrate_v22,
     23: _migrate_v23,
     24: _migrate_v24,
+    25: _migrate_v25,
 }
 
 

--- a/tests/test_tagger_persist.py
+++ b/tests/test_tagger_persist.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Tests for the LLM-tagger persist wiring (v25 tags column + enrich + selector read).
+
+Dispatch-ID: 20260627-wire-llm-tagger-persist
+
+Covers:
+- _merge_stored_tags: category + stored JSON tags → item scope_tags (deduped, fail-safe)
+- migration v25: tags column added to success_patterns + antipatterns
+- enrich_pattern_tags: no-op when the tagger is disabled; stores enriched tags when enabled
+  (only the still-untagged rows by default)
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from intelligence_sources._common import _merge_stored_tags  # noqa: E402
+import vnx_tagger  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# _merge_stored_tags
+# ---------------------------------------------------------------------------
+
+def test_merge_category_plus_json_tags():
+    assert _merge_stored_tags("coding_runtime", '["review_audit","intelligence"]') == [
+        "coding_runtime", "review_audit", "intelligence"
+    ]
+
+
+def test_merge_dedup_category_already_in_tags():
+    assert _merge_stored_tags("review_audit", '["review_audit","intelligence"]') == [
+        "review_audit", "intelligence"
+    ]
+
+
+def test_merge_empty_category_and_tags():
+    assert _merge_stored_tags("", None) == []
+    assert _merge_stored_tags("", "[]") == []
+
+
+def test_merge_category_only_when_tags_absent():
+    assert _merge_stored_tags("x", None) == ["x"]
+
+
+def test_merge_malformed_json_degrades_to_category():
+    assert _merge_stored_tags("x", "not json") == ["x"]
+
+
+def test_merge_non_list_json_degrades_to_category():
+    assert _merge_stored_tags("x", '{"a":1}') == ["x"]
+
+
+def test_merge_accepts_list_directly():
+    assert _merge_stored_tags("c", ["a", "b", "a"]) == ["c", "a", "b"]
+
+
+# ---------------------------------------------------------------------------
+# migration v25
+# ---------------------------------------------------------------------------
+
+def test_migration_v25_adds_tags_columns(tmp_path):
+    from quality_db_init import bootstrap_qi_db, HIGHEST_QI_VERSION
+    db = tmp_path / "qi.db"
+    bootstrap_qi_db(db)
+    conn = sqlite3.connect(str(db))
+    try:
+        assert conn.execute("PRAGMA user_version").fetchone()[0] == HIGHEST_QI_VERSION
+        assert HIGHEST_QI_VERSION >= 25
+        sp = {r[1] for r in conn.execute("PRAGMA table_info(success_patterns)")}
+        ap = {r[1] for r in conn.execute("PRAGMA table_info(antipatterns)")}
+        assert "tags" in sp
+        assert "tags" in ap
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# enrich_pattern_tags
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE success_patterns (id INTEGER PRIMARY KEY, title TEXT, description TEXT, tags TEXT);
+CREATE TABLE antipatterns (id INTEGER PRIMARY KEY, title TEXT, description TEXT, tags TEXT);
+"""
+
+
+def _seed(db):
+    conn = sqlite3.connect(str(db))
+    conn.executescript(_SCHEMA)
+    conn.execute("INSERT INTO success_patterns(id,title,description) VALUES (1,'TDD workflow','tests first')")
+    conn.execute("INSERT INTO success_patterns(id,title,description,tags) VALUES (2,'already','x','[\"keep\"]')")
+    conn.execute("INSERT INTO antipatterns(id,title,description) VALUES (1,'silent except','swallows errors')")
+    conn.commit()
+    conn.close()
+
+
+def test_enrich_noop_when_disabled(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+    db = tmp_path / "qi.db"
+    _seed(db)
+    result = vnx_tagger.enrich_pattern_tags(db)
+    assert result == {"_skipped": "tagger_disabled"}
+
+
+def test_enrich_tags_only_untagged_when_enabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    # Mock the LLM enrichment so the test is deterministic + offline.
+    monkeypatch.setattr(vnx_tagger, "enrich_tags", lambda text, paths=None: ["tests_harness", "add_test"])
+    db = tmp_path / "qi.db"
+    _seed(db)
+
+    result = vnx_tagger.enrich_pattern_tags(db)
+
+    assert result.get("success_patterns") == 1  # only the untagged row (id=1)
+    assert result.get("antipatterns") == 1
+    conn = sqlite3.connect(str(db))
+    try:
+        # untagged row got enriched
+        row1 = conn.execute("SELECT tags FROM success_patterns WHERE id=1").fetchone()[0]
+        assert json.loads(row1) == ["tests_harness", "add_test"]
+        # already-tagged row left untouched (only_untagged default)
+        row2 = conn.execute("SELECT tags FROM success_patterns WHERE id=2").fetchone()[0]
+        assert json.loads(row2) == ["keep"]
+        ap = conn.execute("SELECT tags FROM antipatterns WHERE id=1").fetchone()[0]
+        assert json.loads(ap) == ["tests_harness", "add_test"]
+    finally:
+        conn.close()
+
+
+def test_enrich_all_rows_when_only_untagged_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    monkeypatch.setattr(vnx_tagger, "enrich_tags", lambda text, paths=None: ["redone"])
+    db = tmp_path / "qi.db"
+    _seed(db)
+    result = vnx_tagger.enrich_pattern_tags(db, only_untagged=False)
+    assert result.get("success_patterns") == 2  # both rows re-tagged
+    conn = sqlite3.connect(str(db))
+    try:
+        assert json.loads(conn.execute("SELECT tags FROM success_patterns WHERE id=2").fetchone()[0]) == ["redone"]
+    finally:
+        conn.close()
+
+
+def test_enrich_missing_tags_column_skipped(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    monkeypatch.setattr(vnx_tagger, "enrich_tags", lambda text, paths=None: ["x"])
+    db = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE success_patterns (id INTEGER PRIMARY KEY, title TEXT)")  # no tags col
+    conn.commit(); conn.close()
+    # No tags column → that table is skipped; never raises.
+    result = vnx_tagger.enrich_pattern_tags(db)
+    assert "success_patterns" not in result


### PR DESCRIPTION
## Summary
Wires the model-agnostic LLM tagger (build-step 3b) into the persist path so enriched
VNX-vocabulary tags are stored on `success_patterns`/`antipatterns` and read back by the
selector for tag-overlap ranking. Default provider DeepSeek (cheap key-auth harness lane),
fully opt-in via `VNX_TAGGER_ENABLED` — no-op + never-raises when disabled.

## Changes
- **`scripts/quality_db_init.py`** — migration v25 adds a `tags` TEXT column to
  `success_patterns` + `antipatterns` (ALTER-only, existence-guarded); `HIGHEST_QI_VERSION`→25.
- **`scripts/lib/vnx_tagger.py`** — `enrich_pattern_tags(db_path, *, limit, only_untagged, tables)`:
  no-op when the tagger is disabled, else stores `enrich_tags()` JSON on untagged rows.
  Hardened: `tables=` whitelisted against `_TAGGABLE_TABLES` (no SQL-injection on the public
  param), `limit` clamped into `[1, 1_000_000]` and guarded against `TypeError/ValueError/
  OverflowError` so the documented "never raises" contract holds for every input.
- **`scripts/lib/intelligence_sources/_common.py`** — `_merge_stored_tags(category, raw_tags)`
  merges `[category] + parsed JSON tags` (deduped, fail-safe).
- **`scripts/lib/intelligence_sources/{proven_pattern,failure_prevention}.py`** — read the
  stored `tags` column (existence-guarded) and feed merged tags as the item's `scope_tags`
  for ranking. Inclusion filter stays category-only in BOTH sources (consistent).
- **`scripts/intelligence_daemon.py`** — `GovernanceDigestRunner` auto-triggers
  `enrich_pattern_tags` after `persist_signals_to_db` (gated by `is_enabled()`, non-fatal).

## Verification
- `tests/test_tagger_persist.py` — 12 tests (merge logic, v25 migration, enrich
  enabled/disabled/only_untagged/missing-column). All green.
- `tests/test_pattern_diversity.py` selector regression — green (16 total green).
- never-raises verified across `limit ∈ {inf,'nan',None,'abc',1<<70,1<<200,-5,0}`.
- kimi-diff-gate: PASS (SQL-injection closed, consistency confirmed; the OverflowError
  edge that flipped pr-2 to REVISE is fixed and re-gated PASS at pr-3).

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)