### PR TITLE
fix(doctor): make consumer-setup checks layout-aware (standalone-dev WARN)

### DIFF
--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -187,6 +187,28 @@ def _resolve_venv_path(paths: Dict[str, str]) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
+# Layout detection
+# ---------------------------------------------------------------------------
+
+def _is_central_install(vnx_home: Path) -> bool:
+    """True when VNX_HOME is a central install (carries .vnx-install-mode=central)."""
+    marker = vnx_home / ".vnx-install-mode"
+    try:
+        return marker.is_file() and marker.read_text(encoding="utf-8").strip() == "central"
+    except OSError:
+        return False
+
+
+def _is_standalone_dev(project_root: Path, vnx_home: Path) -> bool:
+    """True for the vnx-orchestration source checkout: PROJECT_ROOT == VNX_HOME and no
+    central-install marker. Here the consumer bootstrap (config.yml, sessionstart hook,
+    .claude/skills/skills.yaml) is legitimately absent — the repo is the SOURCE, not a
+    `vnx init`-ed consumer — so those checks must not read as failures. A central install
+    with PROJECT_ROOT == VNX_HOME is instead a real mis-detection (run from a project dir)."""
+    return project_root == vnx_home and not _is_central_install(vnx_home)
+
+
+# ---------------------------------------------------------------------------
 # Directory checks
 # ---------------------------------------------------------------------------
 
@@ -212,7 +234,10 @@ def check_directories(paths: Dict[str, str]) -> List[CheckResult]:
 
     # Central-install mis-detection hint: if PROJECT_ROOT == VNX_HOME, all dirs will fail
     # because no project has been initialized there. Give a single actionable message.
-    central_misdetect = (project_root == vnx_home)
+    # But the vnx-orchestration source checkout also has PROJECT_ROOT == VNX_HOME (no
+    # central marker) — there it is the expected layout, not a mis-detection.
+    standalone_dev = _is_standalone_dev(project_root, vnx_home)
+    central_misdetect = (project_root == vnx_home) and not standalone_dev
 
     for label, dir_path in required_dirs:
         if dir_path.is_dir():
@@ -232,16 +257,20 @@ def check_directories(paths: Dict[str, str]) -> List[CheckResult]:
     config_file = project_root / ".vnx" / "config.yml"
     if config_file.exists():
         results.append(CheckResult("file", PASS, f"Config: {config_file}"))
+    elif standalone_dev:
+        results.append(CheckResult("file", WARN,
+            "Config not present (standalone-dev checkout)",
+            "VNX_HOME == PROJECT_ROOT and no central marker — the source repo is not a "
+            "`vnx init`-ed consumer, so .vnx/config.yml is not expected here."))
+    elif central_misdetect:
+        results.append(CheckResult("file", FAIL,
+            f"Missing config at PROJECT_ROOT={project_root}",
+            f"PROJECT_ROOT equals VNX_HOME — run vnx from your project directory. "
+            f"Expected: {config_file}"))
     else:
-        if central_misdetect:
-            results.append(CheckResult("file", FAIL,
-                f"Missing config at PROJECT_ROOT={project_root}",
-                f"PROJECT_ROOT equals VNX_HOME — run vnx from your project directory. "
-                f"Expected: {config_file}"))
-        else:
-            results.append(CheckResult("file", FAIL,
-                f"Missing config: {config_file}",
-                f"Run: cd {project_root} && vnx init"))
+        results.append(CheckResult("file", FAIL,
+            f"Missing config: {config_file}",
+            f"Run: cd {project_root} && vnx init"))
 
     return results
 
@@ -265,6 +294,11 @@ def check_templates(paths: Dict[str, str]) -> List[CheckResult]:
     skills_yaml = Path(paths.get("VNX_SKILLS_DIR", vnx_home / "skills")) / "skills.yaml"
     if skills_yaml.exists():
         results.append(CheckResult("template", PASS, "Skills registry present"))
+    elif _is_standalone_dev(Path(paths["PROJECT_ROOT"]), vnx_home):
+        results.append(CheckResult("template", WARN,
+            "Skills registry not present (standalone-dev checkout)",
+            "The source repo ships skills under skills/; the per-project .claude/skills/ "
+            "registry is created by `vnx bootstrap-skills` in a consumer project."))
     else:
         results.append(CheckResult("template", FAIL, f"Missing: {skills_yaml}",
                                    "Run: vnx bootstrap-skills"))
@@ -345,6 +379,11 @@ def check_hooks(paths: Dict[str, str]) -> List[CheckResult]:
     hook_file = project_root / ".claude" / "hooks" / "sessionstart.sh"
     if hook_file.exists():
         return [CheckResult("hooks", PASS, f"SessionStart hook: {hook_file}")]
+    if _is_standalone_dev(project_root, vnx_home):
+        return [CheckResult("hooks", WARN,
+                            "SessionStart hook not present (standalone-dev checkout)",
+                            "The source repo is not a `vnx init`-ed consumer; the hook is "
+                            "deployed by `vnx bootstrap-hooks` in a consumer project.")]
     if project_root == vnx_home:
         return [CheckResult("hooks", FAIL,
                             f"Missing hook: {hook_file}",

--- a/tests/test_doctor_standalone_dev.py
+++ b/tests/test_doctor_standalone_dev.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+"""Tests for `vnx doctor` standalone-dev layout awareness.
+
+Dispatch-ID: 20260627-doctor-standalone-dev
+
+The vnx-orchestration source checkout has PROJECT_ROOT == VNX_HOME and carries no
+.vnx-install-mode=central marker. There the consumer bootstrap (config.yml, the SessionStart
+hook, .claude/skills/skills.yaml) is legitimately absent — the repo is the SOURCE, not a
+`vnx init`-ed consumer. Those checks must read as WARN (doctor stays green), NOT FAIL, so
+`vnx doctor` is a trustworthy pre-cutover gate: green means green in every layout. A central
+install with PROJECT_ROOT == VNX_HOME remains a real mis-detection (still FAIL).
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+
+import vnx_doctor as d  # noqa: E402
+
+
+def _statuses(results, name):
+    return [r.status for r in results if r.name == name]
+
+
+# ---------------------------------------------------------------------------
+# Layout detection
+# ---------------------------------------------------------------------------
+
+def test_standalone_dev_true_without_marker(tmp_path):
+    # PROJECT_ROOT == VNX_HOME, no .vnx-install-mode marker → source checkout.
+    assert d._is_standalone_dev(tmp_path, tmp_path) is True
+
+
+def test_standalone_dev_false_with_central_marker(tmp_path):
+    (tmp_path / ".vnx-install-mode").write_text("central\n")
+    assert d._is_central_install(tmp_path) is True
+    assert d._is_standalone_dev(tmp_path, tmp_path) is False
+
+
+def test_standalone_dev_false_when_project_differs(tmp_path):
+    proj = tmp_path / "proj"
+    home = tmp_path / "home"
+    proj.mkdir()
+    home.mkdir()
+    assert d._is_standalone_dev(proj, home) is False
+
+
+# ---------------------------------------------------------------------------
+# Checks downgrade to WARN in standalone-dev, stay FAIL for a real consumer
+# ---------------------------------------------------------------------------
+
+def test_hooks_warn_in_standalone_dev(tmp_path):
+    paths = {"PROJECT_ROOT": str(tmp_path), "VNX_HOME": str(tmp_path)}
+    res = d.check_hooks(paths)
+    assert _statuses(res, "hooks") == [d.WARN]
+    assert "standalone-dev" in res[0].message
+
+
+def test_hooks_fail_in_consumer_missing_bootstrap(tmp_path):
+    proj = tmp_path / "proj"
+    home = tmp_path / "home"
+    proj.mkdir()
+    home.mkdir()
+    paths = {"PROJECT_ROOT": str(proj), "VNX_HOME": str(home)}
+    res = d.check_hooks(paths)
+    assert _statuses(res, "hooks") == [d.FAIL]
+
+
+def test_templates_skills_warn_in_standalone_dev(tmp_path):
+    # No skills.yaml, standalone-dev → the skills-registry check is WARN (not FAIL).
+    paths = {"PROJECT_ROOT": str(tmp_path), "VNX_HOME": str(tmp_path),
+             "VNX_SKILLS_DIR": str(tmp_path / ".claude" / "skills")}
+    res = d.check_templates(paths)
+    assert _statuses(res, "template")[-1] == d.WARN  # the trailing skills check
+    assert any("standalone-dev" in r.message for r in res if r.status == d.WARN)
+
+
+def test_templates_skills_fail_in_consumer(tmp_path):
+    # A real consumer (PROJECT_ROOT != VNX_HOME) missing skills.yaml → still FAIL.
+    proj = tmp_path / "proj"
+    home = tmp_path / "home"
+    proj.mkdir()
+    home.mkdir()
+    paths = {"PROJECT_ROOT": str(proj), "VNX_HOME": str(home),
+             "VNX_SKILLS_DIR": str(proj / ".claude" / "skills")}
+    res = d.check_templates(paths)
+    assert _statuses(res, "template")[-1] == d.FAIL
+
+
+def test_config_warn_in_standalone_dev(tmp_path):
+    # All required dirs present (so dir checks PASS) but no .vnx/config.yml, standalone-dev.
+    for sub in ("state", "logs", "pids", "locks", "dispatches", "reports"):
+        (tmp_path / sub).mkdir(parents=True, exist_ok=True)
+    (tmp_path / ".vnx").mkdir(exist_ok=True)
+    paths = {
+        "PROJECT_ROOT": str(tmp_path), "VNX_HOME": str(tmp_path),
+        "VNX_DATA_DIR": str(tmp_path), "VNX_STATE_DIR": str(tmp_path / "state"),
+        "VNX_LOGS_DIR": str(tmp_path / "logs"), "VNX_PIDS_DIR": str(tmp_path / "pids"),
+        "VNX_LOCKS_DIR": str(tmp_path / "locks"),
+        "VNX_DISPATCH_DIR": str(tmp_path / "dispatches"),
+        "VNX_REPORTS_DIR": str(tmp_path / "reports"),
+    }
+    (tmp_path / "dispatches" / "pending").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "dispatches" / "active").mkdir(parents=True, exist_ok=True)
+    (tmp_path / "dispatches" / "completed").mkdir(parents=True, exist_ok=True)
+    res = d.check_directories(paths)
+    config_status = _statuses(res, "file")
+    assert config_status == [d.WARN], f"expected config WARN in standalone-dev, got {config_status}"
+    # And no FAILs leaked from the dir checks.
+    assert d.FAIL not in [r.status for r in res]
+
+
+def test_central_install_misdetect_still_fails(tmp_path):
+    # Central install with PROJECT_ROOT == VNX_HOME (marker present) is a REAL mis-detection:
+    # config, hooks, skills, and directories must all still FAIL (never downgraded to WARN).
+    (tmp_path / ".vnx-install-mode").write_text("central\n")
+    home = tmp_path
+    paths = {
+        "PROJECT_ROOT": str(home), "VNX_HOME": str(home),
+        "VNX_DATA_DIR": str(home / "missing-data"),
+        "VNX_STATE_DIR": str(home / "missing-data" / "state"),
+        "VNX_LOGS_DIR": str(home / "missing-data" / "logs"),
+        "VNX_PIDS_DIR": str(home / "missing-data" / "pids"),
+        "VNX_LOCKS_DIR": str(home / "missing-data" / "locks"),
+        "VNX_DISPATCH_DIR": str(home / "missing-data" / "dispatches"),
+        "VNX_REPORTS_DIR": str(home / "missing-data" / "reports"),
+        "VNX_SKILLS_DIR": str(home / ".claude" / "skills"),
+    }
+    assert d._is_standalone_dev(home, home) is False
+    assert _statuses(d.check_hooks(paths), "hooks") == [d.FAIL]
+    assert _statuses(d.check_templates(paths), "template")[-1] == d.FAIL
+    dir_res = d.check_directories(paths)
+    assert _statuses(dir_res, "file") == [d.FAIL]  # config is FAIL, not WARN
+    assert d.WARN not in [r.status for r in dir_res]  # nothing downgraded
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Makes `vnx doctor` a trustworthy pre-cutover gate by distinguishing the vnx-orchestration
**source checkout** (standalone-dev: `PROJECT_ROOT == VNX_HOME`, no central marker) from a real
mis-detection or an un-bootstrapped consumer. Fleet-unification F0.4.

**Context:** a fresh `vnx init` against the v1.0.0 central install already passes doctor green
(0 FAILs — verified). The only remaining FAILs were in the source checkout, where the consumer
bootstrap (config.yml, hook, skills.yaml) is legitimately absent — making "doctor green" mean
different things in different layouts. The big F0.4 worries (dual-install, missing dirs) were
already resolved in the 1.0.0 doctor (contamination is WARN, not FAIL; dirs resolve per-project).

## Changes
- **`scripts/vnx_doctor.py`** — `_is_central_install(vnx_home)` (reads `.vnx-install-mode`) +
  `_is_standalone_dev(project_root, vnx_home)`. The config (`check_directories`), skills-registry
  (`check_templates`), and SessionStart-hook (`check_hooks`) checks now emit **WARN** in the
  standalone-dev layout (doctor stays green) and keep **FAIL** for a real consumer missing its
  bootstrap or a central-install mis-detection (`PROJECT_ROOT == VNX_HOME` with the marker).
- **`tests/test_doctor_standalone_dev.py`** — 9 tests incl. FAIL-in-consumer and a
  central-install-misdetect guard.

## Verification
- `pytest tests/test_doctor_standalone_dev.py` — 9/9 green; `ruff check` clean.
- Dev-repo `vnx doctor`: 0 FAILs (the 3 are now WARN "standalone-dev checkout"). Fresh consumer:
  still 0 FAILs (no regression).
- kimi-diff-gate: PASS (behavior verified live; the REVISE was test-quality only, addressed).

## Open Items
Pre-existing failures in `tests/test_vnx_doctor_strict.py` (SkillCoverage/ActiveDrain) are
unrelated to this diff (they fail on HEAD without it), not in the CI gate, and out of scope —
part of the known leftover bare-FAIL backlog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)