### PR TITLE
fix(status): resolve data dir via ensure_env, not install-relative (#225)

### DIFF
--- a/scripts/cli/vnx_status.py
+++ b/scripts/cli/vnx_status.py
@@ -16,7 +16,7 @@ import sys
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "lib"))
-from project_root import resolve_data_dir  # noqa: E402
+from vnx_paths import ensure_env  # noqa: E402
 
 
 # ── Color helpers ──────────────────────────────────────────────────────
@@ -203,7 +203,11 @@ def main(argv: list[str] | None = None, data_dir: Path | None = None) -> int:
     args, _extra = parser.parse_known_args(argv)
 
     if data_dir is None:
-        data_dir = resolve_data_dir(__file__)
+        # Resolve VNX_DATA_DIR the same way `vnx doctor` does (vnx_paths.ensure_env →
+        # the per-project central store ~/.vnx-data/<project_id>), not via
+        # resolve_data_dir(__file__) which, under a central install, resolves relative to
+        # the install dir and misses the project's store entirely (issue #225).
+        data_dir = Path(ensure_env()["VNX_DATA_DIR"])
 
     strategy_dir = data_dir / "strategy"
     state_dir = data_dir / "state"

--- a/tests/test_vnx_status_resolver.py
+++ b/tests/test_vnx_status_resolver.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+"""Tests for `vnx status` data-dir resolution (issue #225).
+
+Dispatch-ID: 20260627-vnx-status-resolver
+
+`vnx status` used `resolve_data_dir(__file__)`, which returns `$PROJECT_ROOT/.vnx-data` —
+under a central install (`__file__` in ~/.vnx-system/versions/<v>/...) that resolves relative
+to the INSTALL, missing the project's per-project central store, so status always printed
+"not initialised". It now resolves via `vnx_paths.ensure_env()` (the same resolver `vnx doctor`
+uses), so status reads `~/.vnx-data/<project_id>` — green where doctor is green.
+"""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "cli"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import vnx_status  # noqa: E402
+
+
+def test_status_module_uses_ensure_env_not_caller_file_resolver():
+    # The fix swaps the install-relative resolver for the per-project one.
+    assert hasattr(vnx_status, "ensure_env")
+    assert not hasattr(vnx_status, "resolve_data_dir")
+
+
+def test_status_reads_ensure_env_data_dir(tmp_path, capsys, monkeypatch):
+    # ensure_env resolves to a per-project store that HAS runtime state → status renders it,
+    # never "not initialised".
+    state = tmp_path / "state"
+    state.mkdir(parents=True)
+    (state / "t0_state.json").write_text("{}")
+    monkeypatch.setattr(vnx_status, "ensure_env", lambda: {"VNX_DATA_DIR": str(tmp_path)})
+    rc = vnx_status.main([])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "not initialised" not in out
+
+
+def test_status_json_resolves_via_ensure_env(tmp_path, capsys, monkeypatch):
+    # An empty store resolved via ensure_env → the not_initialised JSON payload. This proves the
+    # JSON path consults the ensure_env-resolved dir (tmp_path has no strategy/ or t0_state.json).
+    monkeypatch.setattr(vnx_status, "ensure_env", lambda: {"VNX_DATA_DIR": str(tmp_path)})
+    rc = vnx_status.main(["--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out.strip())
+    assert payload["error"] == "not_initialised"
+
+
+def test_status_honours_explicit_data_dir_arg(tmp_path, capsys, monkeypatch):
+    # The explicit data_dir parameter still wins (ensure_env not consulted).
+    called = {"n": 0}
+
+    def _boom():
+        called["n"] += 1
+        return {"VNX_DATA_DIR": "/should/not/be/used"}
+
+    monkeypatch.setattr(vnx_status, "ensure_env", _boom)
+    rc = vnx_status.main([], data_dir=tmp_path)
+    assert rc == 0
+    assert called["n"] == 0  # explicit arg short-circuits resolution
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
`vnx status` printed "not initialised" under the central-install model (and in the dev-repo)
because `vnx_status.py` resolved its data dir via `resolve_data_dir(__file__)` — for a central
install `__file__` lives in `~/.vnx-system/versions/<v>/`, so it resolved relative to the INSTALL
and missed the per-project central store. Surfaced by the **sales-copilot pilot cutover**; it
affects every central-install command on that resolver, so it would also hit SEOcrawler + MC.

## Changes
- **`scripts/cli/vnx_status.py`** — resolve `VNX_DATA_DIR` via `vnx_paths.ensure_env()` (exactly
  what `vnx doctor` uses → `~/.vnx-data/<project_id>`), replacing `resolve_data_dir(__file__)`.
  The explicit `data_dir` parameter still short-circuits. Read-only contract unchanged.
- **`tests/test_vnx_status_resolver.py`** — 4 tests.

## Verification
- Dev-repo `vnx status` now renders the dashboard (was "not initialised").
- `pytest tests/test_vnx_status_resolver.py` — 4/4 green; `ruff check` clean.
- kimi-diff-gate: PASS.

Note: a freshly-cutover project whose central store has no `t0_state.json` yet will still show
"not initialised" — that is accurate runtime state, not the resolver bug fixed here.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)