### PR TITLE
feat(dashboard): scout-enrichment indicator per dispatch in the kanban

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -56,11 +56,25 @@ try:
     import shadow_logger as _op_shadow_logger       # type: ignore[import]
     from vnx_paths import resolve_central_data_dir as _op_resolve_central  # type: ignore[import]
     from vnx_paths import project_id_from_state_dir as _op_project_id_from_state_dir  # type: ignore[import]
+    from scout_prepass import scout_sidecar_path as _op_scout_sidecar_path  # type: ignore[import]
 except Exception:
     _op_shadow_verifier = None   # type: ignore[assignment]
     _op_shadow_logger = None     # type: ignore[assignment]
     _op_resolve_central = None   # type: ignore[assignment]
     _op_project_id_from_state_dir = None  # type: ignore[assignment]
+    _op_scout_sidecar_path = None  # type: ignore[assignment]
+
+
+def _is_scout_enriched(dispatch_id: str) -> bool:
+    """True when a scout pre-pass sidecar exists for this dispatch
+    (``<state_dir>/scout/<dispatch_id>.json``). Fail-open: any error → False, so a
+    missing scout layer never breaks the kanban. Mirrors the door's scout producer."""
+    if _op_scout_sidecar_path is None:
+        return False
+    try:
+        return _op_scout_sidecar_path(CANONICAL_STATE_DIR, dispatch_id).exists()
+    except (ValueError, OSError):
+        return False
 
 _SYSTEM_HEALTH_COUNT_SQL_TEMPLATE = "SELECT COUNT(*) AS cnt FROM {table}"
 _SYSTEM_HEALTH_COUNT_CENTRAL_SQL_TEMPLATE = "SELECT COUNT(*) AS cnt FROM {table} WHERE project_id = ?"
@@ -239,6 +253,7 @@ def _scan_dispatches() -> dict:
                     "duration_label": _format_duration(duration_secs),
                     "has_receipt": receipt is not None,
                     "receipt_status": receipt.get("status") if receipt else None,
+                    "scout_enriched": _is_scout_enriched(dispatch_id),
                 }
                 candidates[dispatch_id].append((stage, mtime, entry))
             except Exception as exc:

--- a/dashboard/token-dashboard/__tests__/kanban-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/kanban-page.test.tsx
@@ -232,6 +232,24 @@ describe('KanbanPage — dispatch cards', () => {
     expect(screen.getByTestId('card-gate')).toHaveTextContent('gate_pr1_lifecycle');
   });
 
+  test('renders scout badge when dispatch is scout-enriched', () => {
+    renderWithData(makeEnvelope({
+      stages: { active: [{ ...CARD_A, scout_enriched: true }] },
+      total: 1,
+    }));
+
+    expect(screen.getByTestId('card-scout')).toHaveTextContent('scout');
+  });
+
+  test('omits scout badge when not scout-enriched', () => {
+    renderWithData(makeEnvelope({
+      stages: { active: [CARD_A] },
+      total: 1,
+    }));
+
+    expect(screen.queryByTestId('card-scout')).toBeNull();
+  });
+
   test('renders duration label', () => {
     renderWithData(makeEnvelope({
       stages: { active: [CARD_A] },

--- a/dashboard/token-dashboard/app/operator/kanban/page.tsx
+++ b/dashboard/token-dashboard/app/operator/kanban/page.tsx
@@ -209,14 +209,25 @@ function DispatchCard({ card }: { card: KanbanCard }) {
         )}
       </div>
 
-      {/* Bottom row: duration + receipt status */}
+      {/* Bottom row: duration (+ scout badge) + receipt status */}
       <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between' }}>
-        <span
-          data-testid="card-duration"
-          style={{ fontSize: 10, color: 'rgba(244,244,249,0.45)' }}
-        >
-          {card.duration_label || '—'}
-        </span>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 6 }}>
+          <span
+            data-testid="card-duration"
+            style={{ fontSize: 10, color: 'rgba(244,244,249,0.45)' }}
+          >
+            {card.duration_label || '—'}
+          </span>
+          {card.scout_enriched && (
+            <span
+              data-testid="card-scout"
+              title="Scout-verrijkt: deze dispatch heeft een scout pre-pass sidecar"
+              style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-info, #6ca8ff)' }}
+            >
+              🔍 scout
+            </span>
+          )}
+        </div>
         {card.has_receipt && card.receipt_status && (
           <span
             style={{

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -253,6 +253,8 @@ export interface KanbanCard {
   duration_label: string;
   has_receipt: boolean;
   receipt_status: string | null;
+  /** True when a scout pre-pass sidecar exists for this dispatch (door scout producer). */
+  scout_enriched?: boolean;
 }
 
 export type KanbanStageName = 'staging' | 'pending' | 'active' | 'review' | 'done';

--- a/tests/test_kanban_scout_enriched.py
+++ b/tests/test_kanban_scout_enriched.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Tests for the kanban scout-enrichment indicator.
+
+Dispatch-ID: 20260627-kanban-scout-enriched
+
+The kanban (``_scan_dispatches``) now stamps each dispatch entry with ``scout_enriched``:
+True when a scout pre-pass sidecar exists (``<state_dir>/scout/<dispatch_id>.json``), so the
+operator can see at a glance which queued/running dispatches were grounded by the cheap scout
+recon. Fail-open: a missing scout layer or an unsafe dispatch_id never breaks the kanban.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "dashboard"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import api_operator as op  # noqa: E402
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(op, "CANONICAL_STATE_DIR", tmp_path)
+    return tmp_path
+
+
+def test_scout_enriched_true_when_sidecar_exists(state_dir):
+    (state_dir / "scout").mkdir()
+    (state_dir / "scout" / "20260627-feat-x.json").write_text('{"sketch": "..."}')
+    assert op._is_scout_enriched("20260627-feat-x") is True
+
+
+def test_scout_enriched_false_when_missing(state_dir):
+    assert op._is_scout_enriched("20260627-no-scout") is False
+
+
+def test_scout_enriched_false_on_unsafe_dispatch_id(state_dir):
+    # Path-traversal id → the sidecar-path guard raises → fail-open False (never crashes).
+    assert op._is_scout_enriched("../../etc/passwd") is False
+
+
+def test_scout_enriched_false_when_scout_layer_absent(state_dir, monkeypatch):
+    # If the scout helper failed to import, the kanban must still work (False, no crash).
+    monkeypatch.setattr(op, "_op_scout_sidecar_path", None)
+    assert op._is_scout_enriched("anything") is False
+
+
+def test_scan_dispatches_entries_carry_scout_enriched(state_dir, monkeypatch, tmp_path):
+    # A dispatch in pending/ with a matching scout sidecar → its kanban entry is scout_enriched.
+    disp = tmp_path / "dispatches" / "pending"
+    disp.mkdir(parents=True)
+    (disp / "20260627-grounded.md").write_text(
+        "---\ndispatch_id: 20260627-grounded\nterminal: T1\n---\n# task\n"
+    )
+    (state_dir / "scout").mkdir()
+    (state_dir / "scout" / "20260627-grounded.json").write_text("{}")
+    monkeypatch.setattr(op, "DISPATCHES_DIR", tmp_path / "dispatches")
+    result = op._scan_dispatches()
+    cards = [c for stage in result["stages"].values() for c in stage]
+    grounded = next((c for c in cards if c["id"] == "20260627-grounded"), None)
+    assert grounded is not None, "the pending dispatch should appear in the kanban"
+    assert grounded["scout_enriched"] is True
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Operator-requested dashboard improvement: in the kanban, every dispatch now shows whether it was
enriched by the cheap **scout pre-pass** (a "🔍 scout" badge). This answers "are the queued/running
dispatches scout-grounded or not?" at a glance.

## Changes
- **`dashboard/api_operator.py`** — lazy-import `scout_prepass.scout_sidecar_path` (same graceful
  try/except as the vnx_paths import). `_is_scout_enriched(dispatch_id)` checks
  `<state_dir>/scout/<dispatch_id>.json`; **fail-open** (traversal-guard ValueError / OSError /
  absent scout layer → False, never crashes the kanban). `scout_enriched` added to each
  `_scan_dispatches` entry.
- **Frontend** — `scout_enriched?: boolean` on `KanbanCard`; a `data-testid="card-scout"` badge in
  the card's bottom row, rendered only when truthy.
- **Tests** — `tests/test_kanban_scout_enriched.py` (5: true/false/unsafe-id/no-scout-layer/
  entry-carries-field) + 2 frontend tests.

## Verification
- `pytest tests/test_kanban_scout_enriched.py` — 5/5 green.
- ruff: 0 new errors (the 2 E402 in api_operator.py are pre-existing — same count on HEAD).
- Source files (page.tsx, types.ts) typecheck clean; frontend jest tests run in CI.
- kimi-diff-gate: PASS.

## Open Items
None. Part B of the kanban request (scout indicator). Part A (surface promoted/future-ready
deliverables in the kanban) is the planned follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)