### PR TITLE
feat(dashboard): future-ready (Queued) lane in the kanban

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -76,6 +76,73 @@ def _is_scout_enriched(dispatch_id: str) -> bool:
     except (ValueError, OSError):
         return False
 
+
+# Coordination-DB states that mean "planned, not yet executing" — the future-ready lane.
+# 'ready' = promoted (human-gated, dispatchable); 'proposed' = awaiting promotion.
+_QUEUED_STATES = ("proposed", "ready", "queued")
+
+
+def _scan_queued_dispatches(exclude_ids: "set[str]") -> list:
+    """Future-ready deliverables: rows in runtime_coordination.db whose state is planned
+    (proposed/ready/queued) and which are NOT yet a file in the kanban dirs. These are the
+    dispatches 'staged to run in the future' — the planning layer's promoted-but-undispatched
+    work. Fail-open: a missing DB / missing column / any error → [], never breaks the kanban."""
+    import sqlite3
+    db_path = CANONICAL_STATE_DIR / "runtime_coordination.db"
+    if not db_path.exists():
+        return []
+    entries: list = []
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return []
+    try:
+        conn.row_factory = sqlite3.Row
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(dispatches)").fetchall()}
+        if "state" not in cols or "dispatch_id" not in cols:
+            return []
+        placeholders = ",".join("?" * len(_QUEUED_STATES))
+        rows = conn.execute(
+            f"SELECT dispatch_id, state, track, terminal_id, priority, gate, "
+            f"output_kind, operator_approved_at "
+            f"FROM dispatches WHERE state IN ({placeholders}) ORDER BY created_at DESC",
+            _QUEUED_STATES,
+        ).fetchall()
+        for r in rows:
+            d = dict(r)
+            did = d.get("dispatch_id")
+            if not did or did in exclude_ids:
+                continue
+            entries.append({
+                "id": did,
+                "file": "—",
+                "pr_id": "—",
+                "track": d.get("track") or "—",
+                "terminal": d.get("terminal_id") or "—",
+                "role": "—",
+                "gate": d.get("gate") or "—",
+                "priority": d.get("priority") or "—",
+                "status": d.get("state"),
+                "reason": "—",
+                "domain": "coding",
+                "dir": "queued",
+                "stage": "queued",
+                "output_kind": d.get("output_kind") or "—",
+                "state": d.get("state"),
+                "promoted": d.get("operator_approved_at") is not None,
+                "duration_secs": 0,
+                "duration_label": "—",
+                "has_receipt": False,
+                "receipt_status": None,
+                "scout_enriched": _is_scout_enriched(did),
+            })
+    except sqlite3.Error as exc:
+        print(f"[kanban] queued scan failed: {exc}", file=sys.stderr)
+        return []
+    finally:
+        conn.close()
+    return entries
+
 _SYSTEM_HEALTH_COUNT_SQL_TEMPLATE = "SELECT COUNT(*) AS cnt FROM {table}"
 _SYSTEM_HEALTH_COUNT_CENTRAL_SQL_TEMPLATE = "SELECT COUNT(*) AS cnt FROM {table} WHERE project_id = ?"
 
@@ -209,10 +276,12 @@ def _scan_dispatches() -> dict:
     Ties broken by most-recent mtime.
     """
     receipts = _scan_receipts()
-    stages: dict[str, list] = {s: [] for s in ["staging", "pending", "active", "review", "done", "rejected"]}
+    stages: dict[str, list] = {s: [] for s in ["queued", "staging", "pending", "active", "review", "done", "rejected"]}
 
     if not DISPATCHES_DIR.exists():
-        return {"stages": stages, "total": 0}
+        # No file-based dispatches, but the future-ready lane is DB-backed and independent.
+        stages["queued"] = _scan_queued_dispatches(set())
+        return {"stages": stages, "total": len(stages["queued"])}
 
     now = datetime.now(timezone.utc).timestamp()
 
@@ -270,6 +339,10 @@ def _scan_dispatches() -> dict:
             key=lambda e: (_STAGE_PRIORITY.get(e[0], 99), -e[1]),
         )
         stages[winner_stage].append(winner_entry)
+
+    # Future-ready lane: planned (proposed/ready/queued) coordination-DB rows that are NOT
+    # already a file in the stages above. Deduped against the file-based dispatch ids.
+    stages["queued"] = _scan_queued_dispatches(set(candidates.keys()))
 
     # Restore mtime-descending order within each stage (most recent first)
     for stage_name in stages:

--- a/dashboard/token-dashboard/__tests__/kanban-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/kanban-page.test.tsx
@@ -2,7 +2,7 @@
  * Tests for app/operator/kanban/page.tsx
  *
  * Quality gate: gate_pr2_kanban_frontend
- * - Kanban page renders 5 columns under test
+ * - Kanban page renders 6 columns under test
  * - Dispatch cards show PR-id, track, terminal, gate, duration under test
  * - Empty, loading, and error states render correctly under test
  * - SWR hook polls /api/operator/kanban endpoint
@@ -173,10 +173,11 @@ beforeEach(() => {
   setSearchParams('');
 });
 
-describe('KanbanPage — 5 columns', () => {
-  test('renders all 5 column headers', () => {
+describe('KanbanPage — 6 columns', () => {
+  test('renders all 6 column headers (incl. future-ready Queued)', () => {
     renderWithData(makeEnvelope());
 
+    expect(screen.getByTestId('column-queued')).toBeInTheDocument();
     expect(screen.getByTestId('column-staging')).toBeInTheDocument();
     expect(screen.getByTestId('column-pending')).toBeInTheDocument();
     expect(screen.getByTestId('column-active')).toBeInTheDocument();
@@ -187,6 +188,7 @@ describe('KanbanPage — 5 columns', () => {
   test('renders column labels', () => {
     renderWithData(makeEnvelope());
 
+    expect(screen.getByText('Queued')).toBeInTheDocument();
     expect(screen.getByText('Staging')).toBeInTheDocument();
     expect(screen.getByText('Pending')).toBeInTheDocument();
     expect(screen.getByText('Active')).toBeInTheDocument();
@@ -250,6 +252,25 @@ describe('KanbanPage — dispatch cards', () => {
     expect(screen.queryByTestId('card-scout')).toBeNull();
   });
 
+  test('renders future-ready queued card with output_kind + state badge', () => {
+    const queuedCard: KanbanCard = {
+      ...CARD_A,
+      id: 'deliverable-1',
+      stage: 'queued',
+      state: 'ready',
+      output_kind: 'pr',
+      promoted: true,
+    };
+    renderWithData(makeEnvelope({
+      stages: { queued: [queuedCard] },
+      total: 1,
+    }));
+
+    const badge = screen.getByTestId('card-queued-state');
+    expect(badge).toHaveTextContent('pr');
+    expect(badge).toHaveTextContent('ready');
+  });
+
   test('renders duration label', () => {
     renderWithData(makeEnvelope({
       stages: { active: [CARD_A] },
@@ -301,12 +322,13 @@ describe('KanbanPage — empty state', () => {
     renderWithData(makeEnvelope());
 
     const emptyPlaceholders = screen.getAllByText('No dispatches');
-    expect(emptyPlaceholders).toHaveLength(5);
+    expect(emptyPlaceholders).toHaveLength(6);
   });
 
   test('each empty column has its own testid', () => {
     renderWithData(makeEnvelope());
 
+    expect(screen.getByTestId('empty-queued')).toBeInTheDocument();
     expect(screen.getByTestId('empty-staging')).toBeInTheDocument();
     expect(screen.getByTestId('empty-pending')).toBeInTheDocument();
     expect(screen.getByTestId('empty-active')).toBeInTheDocument();

--- a/dashboard/token-dashboard/app/operator/kanban/page.tsx
+++ b/dashboard/token-dashboard/app/operator/kanban/page.tsx
@@ -30,6 +30,7 @@ const TRACK_COLORS: Record<string, { bg: string; border: string; text: string }>
 
 // ---- Column definitions ----
 const COLUMNS: { key: KanbanStageName; label: string; accentColor: string }[] = [
+  { key: 'queued',   label: 'Queued',   accentColor: 'rgba(108, 168, 255, 0.55)' },
   { key: 'staging',  label: 'Staging',  accentColor: 'rgba(107, 138, 230, 0.6)' },
   { key: 'pending',  label: 'Pending',  accentColor: 'rgba(249, 115, 22, 0.6)'  },
   { key: 'active',   label: 'Active',   accentColor: 'rgba(249, 115, 22, 1)'    },
@@ -228,6 +229,20 @@ function DispatchCard({ card }: { card: KanbanCard }) {
             </span>
           )}
         </div>
+        {card.stage === 'queued' && card.state && (
+          <span
+            data-testid="card-queued-state"
+            title={card.promoted ? 'Promoted — ready to dispatch' : 'Awaiting promotion'}
+            style={{
+              fontSize: 10,
+              fontWeight: 600,
+              color: card.promoted ? 'var(--color-success)' : 'rgba(244,244,249,0.55)',
+            }}
+          >
+            {card.output_kind && card.output_kind !== '—' ? `${card.output_kind} · ` : ''}
+            {card.state}
+          </span>
+        )}
         {card.has_receipt && card.receipt_status && (
           <span
             style={{
@@ -489,12 +504,12 @@ function KanbanContent() {
         })}
       </div>
 
-      {/* 5-column grid */}
+      {/* 6-column grid */}
       <div
         data-testid="kanban-grid"
         style={{
           display: 'grid',
-          gridTemplateColumns: 'repeat(5, 1fr)',
+          gridTemplateColumns: 'repeat(6, 1fr)',
           gap: 16,
           alignItems: 'start',
         }}

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -255,9 +255,15 @@ export interface KanbanCard {
   receipt_status: string | null;
   /** True when a scout pre-pass sidecar exists for this dispatch (door scout producer). */
   scout_enriched?: boolean;
+  /** Future-ready lane only: the deliverable output kind (pr|post|deal|doc). */
+  output_kind?: string;
+  /** Future-ready lane only: coordination-DB state (proposed|ready|queued). */
+  state?: string;
+  /** Future-ready lane only: true when human-gated promoted (operator_approved_at set). */
+  promoted?: boolean;
 }
 
-export type KanbanStageName = 'staging' | 'pending' | 'active' | 'review' | 'done';
+export type KanbanStageName = 'queued' | 'staging' | 'pending' | 'active' | 'review' | 'done';
 
 export interface KanbanEnvelope {
   stages: Partial<Record<KanbanStageName, KanbanCard[]>>;

--- a/tests/test_kanban_future_ready.py
+++ b/tests/test_kanban_future_ready.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+"""Tests for the kanban future-ready (queued) lane.
+
+Dispatch-ID: 20260627-kanban-future-ready
+
+The kanban now surfaces a "queued" stage: planned coordination-DB rows (state proposed/ready/
+queued) that are not yet a file in the dispatch dirs — the work "staged to run in the future"
+(promoted-but-undispatched deliverables). 'ready' = promoted (human-gated). Fail-open: a missing
+DB / column / any error yields an empty queued lane and never breaks the kanban.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "dashboard"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import api_operator as op  # noqa: E402
+
+_SCHEMA = """
+CREATE TABLE dispatches (
+    dispatch_id TEXT, state TEXT, track TEXT, terminal_id TEXT, priority TEXT,
+    gate TEXT, output_kind TEXT, operator_approved_at TEXT, created_at TEXT
+);
+"""
+
+
+def _make_db(path, rows):
+    conn = sqlite3.connect(str(path))
+    conn.executescript(_SCHEMA)
+    conn.executemany(
+        "INSERT INTO dispatches(dispatch_id,state,track,terminal_id,priority,gate,"
+        "output_kind,operator_approved_at,created_at) VALUES (?,?,?,?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture
+def state_dir(tmp_path, monkeypatch):
+    monkeypatch.setattr(op, "CANONICAL_STATE_DIR", tmp_path)
+    return tmp_path
+
+
+def test_ready_dispatch_appears_in_queued(state_dir):
+    _make_db(state_dir / "runtime_coordination.db", [
+        ("20260627-ready-pr", "ready", "A", "T1", "P1", "gate_x", "pr", "2026-06-27T10:00:00Z", "2026-06-27T09:00:00Z"),
+        ("20260627-proposed-doc", "proposed", "B", "T2", "P2", "—", "doc", None, "2026-06-27T08:00:00Z"),
+    ])
+    entries = op._scan_queued_dispatches(set())
+    ids = {e["id"] for e in entries}
+    assert ids == {"20260627-ready-pr", "20260627-proposed-doc"}
+    ready = next(e for e in entries if e["id"] == "20260627-ready-pr")
+    assert ready["stage"] == "queued"
+    assert ready["state"] == "ready"
+    assert ready["promoted"] is True          # operator_approved_at set
+    assert ready["output_kind"] == "pr"
+    proposed = next(e for e in entries if e["id"] == "20260627-proposed-doc")
+    assert proposed["promoted"] is False       # not yet promoted
+
+
+def test_non_planned_states_excluded(state_dir):
+    _make_db(state_dir / "runtime_coordination.db", [
+        ("active-1", "active", "A", "T1", "P1", "—", "pr", None, "2026-06-27T09:00:00Z"),
+        ("done-1", "completed", "A", "T1", "P1", "—", "pr", None, "2026-06-27T09:00:00Z"),
+    ])
+    assert op._scan_queued_dispatches(set()) == []
+
+
+def test_exclude_ids_dedup(state_dir):
+    # A planned row whose id is already a file-stage entry must NOT appear in queued.
+    _make_db(state_dir / "runtime_coordination.db", [
+        ("dup-1", "ready", "A", "T1", "P1", "—", "pr", None, "2026-06-27T09:00:00Z"),
+    ])
+    assert op._scan_queued_dispatches({"dup-1"}) == []
+
+
+def test_missing_db_fails_open(state_dir):
+    # No runtime_coordination.db at all → empty, never raises.
+    assert op._scan_queued_dispatches(set()) == []
+
+
+def test_missing_state_column_fails_open(state_dir):
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE dispatches (dispatch_id TEXT)")  # no state column
+    conn.commit()
+    conn.close()
+    assert op._scan_queued_dispatches(set()) == []
+
+
+def test_scan_dispatches_includes_queued_stage(state_dir, monkeypatch, tmp_path):
+    _make_db(state_dir / "runtime_coordination.db", [
+        ("20260627-future", "ready", "A", "T1", "P1", "—", "pr", "2026-06-27T10:00:00Z", "2026-06-27T09:00:00Z"),
+    ])
+    monkeypatch.setattr(op, "DISPATCHES_DIR", tmp_path / "no-dispatches")  # empty file-stages
+    result = op._scan_dispatches()
+    assert "queued" in result["stages"]
+    queued_ids = {c["id"] for c in result["stages"]["queued"]}
+    assert "20260627-future" in queued_ids
+    assert result["total"] >= 1
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Completes the operator's kanban request (part A, after the scout indicator in #943): see which
dispatches are **staged to run in the future** — the planning layer's promoted-but-undispatched
deliverables. A new "Queued" column shows them, with a per-card `output_kind · state` badge that
goes green once promoted (human-gated, dispatchable).

## Changes
- **`dashboard/api_operator.py`** — `_scan_queued_dispatches(exclude_ids)` reads
  `runtime_coordination.db` READ-ONLY (`file:...?mode=ro`) for `dispatches WHERE state IN
  ('proposed','ready','queued')`, returns kanban entries (`stage='queued'`, output_kind/state/
  promoted), **deduped** against the file-stage ids. **Fail-open** (missing DB / `state` column /
  any sqlite error → `[]`, never breaks the kanban). States bound via placeholders (no injection).
  Wired into `_scan_dispatches` (new "queued" stage, incl. the no-DISPATCHES_DIR path).
- **Frontend** — `KanbanStageName` gains `'queued'`; a "Queued" column (6-column grid); a
  `card-queued-state` badge; optional `output_kind`/`state`/`promoted` on `KanbanCard`.
- **Tests** — `tests/test_kanban_future_ready.py` (6: ready-appears, non-planned-excluded, dedup,
  missing-db / missing-column fail-open, scan-includes-queued) + 4 frontend tests.

## Verification
- `pytest tests/test_kanban_future_ready.py tests/test_kanban_scout_enriched.py` — 11/11 green.
- ruff: 0 new errors (2 pre-existing E402 unchanged). Source files typecheck clean.
- kimi-diff-gate: PASS (caught + fixed the 5→6 grid CSS; safety/read-only/dedup/injection verified).

## Open Items
None for this PR. Pre-existing: `tests/test_dashboard_kanban_certification.py` imports
`_scan_dispatches`/`_DIR_TO_STAGE` from `serve_dashboard` (they live in `api_operator.py`) — a
stale test broken on HEAD, out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)