### PR TITLE
feat(dashboard): surface system health as an operator page

### DIFF
--- a/dashboard/token-dashboard/__tests__/health-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/health-page.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for app/operator/health/page.tsx — surfaces /api/operator/system-health.
+ *
+ * - Renders overall status + score + per-component status badges
+ * - Loading + error states render
+ * - Unknown status strings never throw (fall back to muted)
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/lib/hooks', () => ({
+  useSystemHealth: jest.fn(),
+}));
+
+import { useSystemHealth } from '@/lib/hooks';
+import SystemHealthPage from '@/app/operator/health/page';
+import type { SystemHealthEnvelope } from '@/lib/types';
+
+const mockUseSystemHealth = useSystemHealth as jest.MockedFunction<typeof useSystemHealth>;
+
+function envelope(overrides: Partial<SystemHealthEnvelope> = {}): SystemHealthEnvelope {
+  return {
+    status: 'healthy',
+    queried_at: '2026-06-27T15:00:00Z',
+    health_score: 0.9,
+    components: {
+      intelligence_db: { status: 'healthy', details: { rows: 240 } },
+      governance_digest: { status: 'degraded', details: { reason: 'stale' } },
+    },
+    ...overrides,
+  };
+}
+
+function renderWith(data: SystemHealthEnvelope | undefined, opts: { isLoading?: boolean; error?: Error } = {}) {
+  mockUseSystemHealth.mockReturnValue({
+    data,
+    isLoading: opts.isLoading ?? false,
+    error: opts.error,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useSystemHealth>);
+  return render(<SystemHealthPage />);
+}
+
+describe('SystemHealthPage', () => {
+  test('renders overall status, score, and component badges', () => {
+    renderWith(envelope());
+
+    expect(screen.getByTestId('health-overall')).toHaveTextContent('healthy');
+    expect(screen.getByTestId('health-score')).toHaveTextContent('90%');
+    expect(screen.getByTestId('health-component-intelligence_db')).toBeInTheDocument();
+    expect(screen.getByTestId('health-status-governance_digest')).toHaveTextContent('degraded');
+  });
+
+  test('loading state', () => {
+    renderWith(undefined, { isLoading: true });
+    expect(screen.getByTestId('health-loading')).toBeInTheDocument();
+  });
+
+  test('error state', () => {
+    renderWith(undefined, { error: new Error('boom') });
+    expect(screen.getByTestId('health-error')).toBeInTheDocument();
+  });
+
+  test('unknown component status string does not throw', () => {
+    renderWith(envelope({ components: { weird: { status: 'totally-new-status', details: {} } } }));
+    expect(screen.getByTestId('health-status-weird')).toHaveTextContent('totally-new-status');
+  });
+
+  test('empty components renders placeholder', () => {
+    renderWith(envelope({ components: {} }));
+    expect(screen.getByTestId('health-empty')).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/app/operator/health/page.tsx
+++ b/dashboard/token-dashboard/app/operator/health/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+import { useSystemHealth } from '@/lib/hooks';
+import type { SystemHealthComponent } from '@/lib/types';
+
+// Status → color. Unknown statuses fall back to muted (never throws on a new status string).
+function statusColor(status: string): string {
+  switch (status) {
+    case 'healthy': return 'var(--color-success, #50fa7b)';
+    case 'degraded': return 'var(--color-warning, #facc15)';
+    case 'dead': return 'var(--color-danger, #ff5555)';
+    default: return 'var(--color-muted, rgba(244,244,249,0.5))';
+  }
+}
+
+function ComponentCard({ name, comp }: { name: string; comp: SystemHealthComponent }) {
+  const detailKeys = Object.keys(comp.details ?? {});
+  return (
+    <div
+      data-testid={`health-component-${name}`}
+      style={{
+        borderRadius: 10,
+        padding: '12px 14px',
+        background: 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)' }}>{name}</span>
+        <span
+          data-testid={`health-status-${name}`}
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            padding: '2px 8px',
+            borderRadius: 6,
+            color: statusColor(comp.status),
+            border: `1px solid ${statusColor(comp.status)}`,
+          }}
+        >
+          {comp.status}
+        </span>
+      </div>
+      {detailKeys.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {detailKeys.slice(0, 8).map((k) => (
+            <span key={k} style={{ fontSize: 10, color: 'var(--color-muted)' }}>
+              {k}: {String((comp.details as Record<string, unknown>)[k])}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function SystemHealthPage() {
+  const { data, isLoading, error } = useSystemHealth();
+
+  if (isLoading) {
+    return <div data-testid="health-loading" style={{ padding: 24, color: 'var(--color-muted)' }}>Loading system health…</div>;
+  }
+  if (error || !data) {
+    return <div data-testid="health-error" style={{ padding: 24, color: 'var(--color-danger, #ff5555)' }}>Failed to load system health.</div>;
+  }
+
+  const components = data.components ?? {};
+  const names = Object.keys(components).sort();
+  const scorePct = Math.round((data.health_score ?? 0) * 100);
+
+  return (
+    <div data-testid="health-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>System Health</h1>
+        <span
+          data-testid="health-overall"
+          style={{ fontSize: 12, fontWeight: 700, color: statusColor(data.status) }}
+        >
+          {data.status}
+        </span>
+        <span data-testid="health-score" style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+          score {scorePct}%
+        </span>
+        {data.queried_at && (
+          <span style={{ fontSize: 11, color: 'rgba(244,244,249,0.4)' }}>· {data.queried_at}</span>
+        )}
+      </div>
+
+      {names.length === 0 ? (
+        <div data-testid="health-empty" style={{ color: 'var(--color-muted)' }}>No components reported.</div>
+      ) : (
+        <div
+          data-testid="health-grid"
+          style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 12 }}
+        >
+          {names.map((name) => (
+            <ComponentCard key={name} name={name} comp={components[name]} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse } from 'lucide-react';
 
 const DOMAINS = ['All', 'Coding', 'Analytics'] as const;
 type Domain = typeof DOMAINS[number];
@@ -16,6 +16,7 @@ const OPERATOR_NAV = [
   { href: '/operator/dispatches', label: 'Dispatches', icon: ClipboardList },
   { href: '/operator/improvements', label: 'Improvements', icon: Lightbulb },
   { href: '/operator/reports', label: 'Reports', icon: FileText },
+  { href: '/operator/health', label: 'System Health', icon: HeartPulse },
   { href: '/agent-stream', label: 'Agent Stream', icon: Activity },
 ];
 

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -9,6 +9,7 @@ import {
   fetchKanban,
   fetchGateConfig,
   fetchGovernanceDigest,
+  fetchSystemHealth,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -28,7 +29,7 @@ import type {
   TokenStats, SessionDetail, GroupBy, SortOrder, ConversationsResponse, TranscriptResponse,
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
-  GateConfigResponse, GovernanceDigestEnvelope,
+  GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
@@ -165,6 +166,14 @@ export function useGovernanceDigest() {
     'operator-governance-digest',
     fetchGovernanceDigest,
     { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 15000 }
+  );
+}
+
+export function useSystemHealth() {
+  return useSWR<SystemHealthEnvelope>(
+    'operator-system-health',
+    fetchSystemHealth,
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
   );
 }
 

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -11,6 +11,7 @@ import type {
   GateToggleRequest,
   GateToggleResponse,
   GovernanceDigestEnvelope,
+  SystemHealthEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
   PatternsResponse,
@@ -123,6 +124,10 @@ export function postGateToggle(req: GateToggleRequest): Promise<GateToggleRespon
 
 export function fetchGovernanceDigest(): Promise<GovernanceDigestEnvelope> {
   return get(`${BASE}/governance-digest`);
+}
+
+export function fetchSystemHealth(): Promise<SystemHealthEnvelope> {
+  return get(`${BASE}/system-health`);
 }
 
 export function fetchReports(params?: {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -263,6 +263,19 @@ export interface KanbanCard {
   promoted?: boolean;
 }
 
+// ---- System health ----
+export interface SystemHealthComponent {
+  status: string; // healthy | degraded | dead
+  details: Record<string, unknown>;
+}
+
+export interface SystemHealthEnvelope {
+  status: string; // overall: healthy | degraded | dead
+  queried_at: string;
+  components: Record<string, SystemHealthComponent>;
+  health_score: number;
+}
+
 export type KanbanStageName = 'queued' | 'staging' | 'pending' | 'active' | 'review' | 'done';
 
 export interface KanbanEnvelope {


### PR DESCRIPTION
## Summary
Dashboard quick win (#1 of the verbeterblad's "already built, not surfaced" set): the
`/api/operator/system-health` endpoint returns overall status + per-component `status`/`details`
+ `health_score`, but had no Next.js page. This adds a read-only `/operator/health` page + sidebar
link, following the established hook/fetch/page pattern.

## Changes
- **`lib/types.ts`** — `SystemHealthEnvelope` + `SystemHealthComponent`.
- **`lib/operator-api.ts`** — `fetchSystemHealth`.
- **`lib/hooks.ts`** — `useSystemHealth` (SWR, 30s refresh).
- **`app/operator/health/page.tsx`** — overall status + score + per-component status badges;
  `statusColor` default branch (unknown status → muted, never throws); loading/error/empty guards.
- **`components/sidebar.tsx`** — "System Health" nav link.
- **`__tests__/health-page.test.tsx`** — 5 tests.

## Verification
- Source files typecheck clean (test-env type noise is pre-existing/local-only).
- kimi-diff-gate: PASS (re-gate; the first run glitched — praised the code + "Findings: None" but
  emitted an empty BLOCKING/REVISE).

## Open Items
None for this PR. Next quick wins: register-stream consumer, recommendations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)