### PR TITLE
feat(dashboard): planning (future-state) operator page

### DIFF
--- a/dashboard/token-dashboard/__tests__/planning-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/planning-page.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Tests for app/operator/planning/page.tsx — surfaces /api/operator/planning.
+ *
+ * - Renders Now/Next/Later horizons with track cards (phase, deliverables, OIs, deps)
+ * - Drift indicator + degraded banner
+ * - Loading + error states; empty horizons render a placeholder
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/lib/hooks', () => ({
+  usePlanning: jest.fn(),
+}));
+
+import { usePlanning } from '@/lib/hooks';
+import PlanningPage from '@/app/operator/planning/page';
+import type { PlanningEnvelope, PlanningCard } from '@/lib/types';
+
+const mockUsePlanning = usePlanning as jest.MockedFunction<typeof usePlanning>;
+
+const TRACK_A: PlanningCard = {
+  track_id: 'track-1',
+  title: 'Config control-plane',
+  phase: 'active',
+  horizon: 'now',
+  priority: 'P1',
+  next_up: true,
+  pr_ref: 'PR-100',
+  dispatch_count: 2,
+  depends_on: [{ to_track_id: 'track-0', to_project_id: null, kind: 'blocks', confidence: 1 }],
+  deliverables: [{ deliverable_ref: 'del-1', output_kind: 'pr', derived_status: 'in_progress', dispatch_count: 1 }],
+  open_items: [{ oi_id: 'oi-1', link_type: 'blocks', title: 'tenant guard missing', severity: 'blocker', status: 'open' }],
+};
+
+function envelope(overrides: Partial<PlanningEnvelope> = {}): PlanningEnvelope {
+  return {
+    queried_at: '2026-06-27T15:00:00Z',
+    project_id: 'vnx-dev',
+    horizons: { now: [TRACK_A], next: [], later: [] },
+    total_tracks: 1,
+    degraded: false,
+    ...overrides,
+  };
+}
+
+function renderWith(data: PlanningEnvelope | undefined, opts: { isLoading?: boolean; error?: Error } = {}) {
+  mockUsePlanning.mockReturnValue({
+    data,
+    isLoading: opts.isLoading ?? false,
+    error: opts.error,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof usePlanning>);
+  return render(<PlanningPage />);
+}
+
+describe('PlanningPage', () => {
+  test('renders horizons and a track card with phase', () => {
+    renderWith(envelope());
+    expect(screen.getByTestId('horizon-now')).toBeInTheDocument();
+    expect(screen.getByTestId('horizon-next')).toBeInTheDocument();
+    expect(screen.getByTestId('horizon-later')).toBeInTheDocument();
+    expect(screen.getByTestId('track-track-1')).toBeInTheDocument();
+    expect(screen.getByTestId('track-phase-track-1')).toHaveTextContent('active');
+    expect(screen.getByTestId('track-nextup-track-1')).toBeInTheDocument();
+  });
+
+  test('renders drift indicator from divergent_count', () => {
+    renderWith(envelope({
+      drift: { generated_at: '2026-06-27T15:00:00Z', divergent_count: 2, total_tracks: 5, divergent: ['track-1', 'track-2'] },
+    }));
+    expect(screen.getByTestId('planning-drift')).toHaveTextContent('2 drift');
+  });
+
+  test('no drift indicator when divergent_count is 0', () => {
+    renderWith(envelope({
+      drift: { generated_at: null, divergent_count: 0, total_tracks: 5, divergent: [] },
+    }));
+    expect(screen.queryByTestId('planning-drift')).toBeNull();
+  });
+
+  test('renders degraded banner', () => {
+    renderWith(envelope({ degraded: true, degraded_reasons: ['runtime_coordination.db not found'] }));
+    expect(screen.getByTestId('planning-degraded')).toHaveTextContent('runtime_coordination.db not found');
+  });
+
+  test('empty horizons render placeholders', () => {
+    renderWith(envelope({ horizons: { now: [], next: [], later: [] }, total_tracks: 0 }));
+    expect(screen.getByTestId('horizon-empty-now')).toBeInTheDocument();
+    expect(screen.getByTestId('horizon-empty-later')).toBeInTheDocument();
+  });
+
+  test('loading state', () => {
+    renderWith(undefined, { isLoading: true });
+    expect(screen.getByTestId('planning-loading')).toBeInTheDocument();
+  });
+
+  test('error state', () => {
+    renderWith(undefined, { error: new Error('boom') });
+    expect(screen.getByTestId('planning-error')).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/app/operator/planning/page.tsx
+++ b/dashboard/token-dashboard/app/operator/planning/page.tsx
@@ -1,0 +1,149 @@
+'use client';
+
+import { usePlanning } from '@/lib/hooks';
+import type { PlanningCard, PlanningHorizon } from '@/lib/types';
+
+const HORIZONS: { key: PlanningHorizon; label: string; accent: string }[] = [
+  { key: 'now', label: 'Now', accent: 'rgba(249, 115, 22, 0.6)' },
+  { key: 'next', label: 'Next', accent: 'rgba(107, 138, 230, 0.6)' },
+  { key: 'later', label: 'Later', accent: 'rgba(155, 107, 230, 0.6)' },
+];
+
+// Declared phase → color. Unknown phases fall back to muted (never throws).
+function phaseColor(phase: string): string {
+  switch (phase) {
+    case 'done': return 'var(--color-success, #50fa7b)';
+    case 'active': case 'in_progress': return 'var(--color-accent, #f97316)';
+    case 'blocked': case 'failed': return 'var(--color-danger, #ff5555)';
+    case 'queued': case 'proposed': return 'rgba(108,168,255,0.85)';
+    default: return 'var(--color-muted, rgba(244,244,249,0.5))';
+  }
+}
+
+function severityColor(sev: string | null): string {
+  switch (sev) {
+    case 'blocker': case 'critical': return 'var(--color-danger, #ff5555)';
+    case 'warn': case 'high': return 'var(--color-warning, #facc15)';
+    default: return 'var(--color-muted, rgba(244,244,249,0.5))';
+  }
+}
+
+function TrackCard({ card }: { card: PlanningCard }) {
+  const deliverables = card.deliverables ?? [];
+  const ois = card.open_items ?? [];
+  const deps = card.depends_on ?? [];
+  return (
+    <div
+      data-testid={`track-${card.track_id}`}
+      style={{
+        borderRadius: 10,
+        padding: '12px 14px',
+        background: 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)',
+        border: '1px solid rgba(255,255,255,0.08)',
+        marginBottom: 8,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 6 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }} title={card.title}>
+          {card.title || card.track_id}
+        </span>
+        <span
+          data-testid={`track-phase-${card.track_id}`}
+          style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 6, color: phaseColor(card.phase), border: `1px solid ${phaseColor(card.phase)}`, flexShrink: 0 }}
+        >
+          {card.phase}
+        </span>
+      </div>
+
+      <div style={{ display: 'flex', alignItems: 'center', gap: 8, flexWrap: 'wrap', fontSize: 10, color: 'var(--color-muted)' }}>
+        {card.next_up && <span data-testid={`track-nextup-${card.track_id}`} style={{ color: 'var(--color-accent, #f97316)', fontWeight: 700 }}>next-up</span>}
+        {card.priority && <span>· {card.priority}</span>}
+        <span>· {card.dispatch_count} dispatch{card.dispatch_count === 1 ? '' : 'es'}</span>
+        {card.pr_ref && <span>· {card.pr_ref}</span>}
+      </div>
+
+      {deps.length > 0 && (
+        <div style={{ fontSize: 10, color: 'rgba(244,244,249,0.45)' }}>
+          depends on: {deps.map((d) => d.to_track_id).join(', ')}
+        </div>
+      )}
+
+      {deliverables.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {deliverables.slice(0, 6).map((d) => (
+            <span key={d.deliverable_ref} style={{ fontSize: 10, color: 'var(--color-muted)' }}>
+              {d.output_kind} · {d.deliverable_ref} — <span style={{ color: phaseColor(d.derived_status) }}>{d.derived_status}</span>
+            </span>
+          ))}
+        </div>
+      )}
+
+      {ois.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+          {ois.slice(0, 6).map((oi) => (
+            <span key={oi.oi_id} style={{ fontSize: 10, color: severityColor(oi.severity) }} title={oi.title}>
+              OI: {oi.title}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function PlanningPage() {
+  const { data, isLoading, error } = usePlanning();
+
+  if (isLoading) {
+    return <div data-testid="planning-loading" style={{ padding: 24, color: 'var(--color-muted)' }}>Loading planning…</div>;
+  }
+  if (error || !data) {
+    return <div data-testid="planning-error" style={{ padding: 24, color: 'var(--color-danger, #ff5555)' }}>Failed to load planning.</div>;
+  }
+
+  const horizons = data.horizons ?? { now: [], next: [], later: [] };
+  const driftCount = data.drift?.divergent_count ?? 0;
+
+  return (
+    <div data-testid="planning-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Planning</h1>
+        <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>{data.total_tracks ?? 0} tracks</span>
+        {driftCount > 0 && (
+          <span data-testid="planning-drift" style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-warning, #facc15)' }}>
+            · {driftCount} drift
+          </span>
+        )}
+      </div>
+
+      {data.degraded && (
+        <div data-testid="planning-degraded" style={{ fontSize: 12, color: 'var(--color-warning, #facc15)' }}>
+          Degraded: {(data.degraded_reasons ?? []).join('; ')}
+        </div>
+      )}
+
+      <div data-testid="planning-grid" style={{ display: 'grid', gridTemplateColumns: 'repeat(3, 1fr)', gap: 16, alignItems: 'start' }}>
+        {HORIZONS.map(({ key, label, accent }) => {
+          const cards = horizons[key] ?? [];
+          return (
+            <div key={key} data-testid={`horizon-${key}`} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)', borderBottom: `2px solid ${accent}`, paddingBottom: 6 }}>
+                {label} <span style={{ color: 'var(--color-muted)', fontWeight: 400 }}>({cards.length})</span>
+              </div>
+              {cards.length === 0 ? (
+                <div data-testid={`horizon-empty-${key}`} style={{ padding: '24px 12px', textAlign: 'center', color: 'rgba(244,244,249,0.3)', fontSize: 12, border: '1px dashed rgba(255,255,255,0.06)', borderRadius: 10 }}>
+                  No tracks
+                </div>
+              ) : (
+                cards.map((c) => <TrackCard key={c.track_id} card={c} />)
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse, Map } from 'lucide-react';
 
 const DOMAINS = ['All', 'Coding', 'Analytics'] as const;
 type Domain = typeof DOMAINS[number];
@@ -11,6 +11,7 @@ const OPERATOR_NAV = [
   { href: '/operator', label: 'Control Surface', icon: Radio },
   { href: '/operator/open-items', label: 'Open Items', icon: AlertTriangle },
   { href: '/operator/kanban', label: 'Kanban Board', icon: Kanban },
+  { href: '/operator/planning', label: 'Planning', icon: Map },
   { href: '/operator/governance', label: 'Governance', icon: ShieldAlert },
   { href: '/operator/intelligence', label: 'Intelligence', icon: Brain },
   { href: '/operator/dispatches', label: 'Dispatches', icon: ClipboardList },

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -10,6 +10,7 @@ import {
   fetchGateConfig,
   fetchGovernanceDigest,
   fetchSystemHealth,
+  fetchPlanning,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -29,7 +30,7 @@ import type {
   TokenStats, SessionDetail, GroupBy, SortOrder, ConversationsResponse, TranscriptResponse,
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
-  GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope,
+  GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
@@ -173,6 +174,14 @@ export function useSystemHealth() {
   return useSWR<SystemHealthEnvelope>(
     'operator-system-health',
     fetchSystemHealth,
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function usePlanning() {
+  return useSWR<PlanningEnvelope>(
+    'operator-planning',
+    fetchPlanning,
     { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -12,6 +12,7 @@ import type {
   GateToggleResponse,
   GovernanceDigestEnvelope,
   SystemHealthEnvelope,
+  PlanningEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
   PatternsResponse,
@@ -128,6 +129,10 @@ export function fetchGovernanceDigest(): Promise<GovernanceDigestEnvelope> {
 
 export function fetchSystemHealth(): Promise<SystemHealthEnvelope> {
   return get(`${BASE}/system-health`);
+}
+
+export function fetchPlanning(): Promise<PlanningEnvelope> {
+  return get(`${BASE}/planning`);
 }
 
 export function fetchReports(params?: {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -276,6 +276,62 @@ export interface SystemHealthEnvelope {
   health_score: number;
 }
 
+// ---- Planning / future-state ----
+export interface PlanningDeliverable {
+  deliverable_ref: string;
+  output_kind: string;
+  derived_status: string;
+  dispatch_count: number;
+}
+
+export interface PlanningOpenItem {
+  oi_id: string;
+  link_type: string;
+  title: string;
+  severity: string | null;
+  status: string | null;
+}
+
+export interface PlanningDependency {
+  to_track_id: string;
+  to_project_id: string | null;
+  kind: string;
+  confidence: number | null;
+}
+
+export interface PlanningCard {
+  track_id: string;
+  title: string;
+  phase: string;
+  horizon: string;
+  priority: string | null;
+  next_up: boolean;
+  pr_ref: string | null;
+  dispatch_count: number;
+  depends_on: PlanningDependency[];
+  deliverables: PlanningDeliverable[];
+  open_items: PlanningOpenItem[];
+}
+
+export type PlanningHorizon = 'now' | 'next' | 'later';
+
+export interface PlanningDrift {
+  generated_at: string | null;
+  divergent_count: number;
+  total_tracks: number;
+  divergent: unknown[];
+}
+
+export interface PlanningEnvelope {
+  queried_at: string;
+  project_id: string;
+  horizons: Record<PlanningHorizon, PlanningCard[]>;
+  total_tracks: number;
+  drift?: PlanningDrift;
+  degraded?: boolean;
+  degraded_reasons?: string[];
+}
+
 export type KanbanStageName = 'queued' | 'staging' | 'pending' | 'active' | 'review' | 'done';
 
 export interface KanbanEnvelope {


### PR DESCRIPTION
## Summary
#2 of the dashboard verbeterblad: a read-only `/operator/planning` page that makes the
tracks/objectives **future-state** layer navigable, complementing the kanban Queued lane (#944).
It surfaces the existing `/api/operator/planning` endpoint — no backend change.

## Changes
- **types** — `PlanningEnvelope`/`PlanningCard`/`PlanningDependency`/`PlanningDeliverable`/
  `PlanningOpenItem`/`PlanningDrift`, matched to the real backend shapes.
- **`fetchPlanning` + `usePlanning`** (SWR, 30s).
- **`app/operator/planning/page.tsx`** — three horizon columns (Now/Next/Later); track cards with
  phase badge, next-up, priority, dispatch_count, `depends_on` (→ `to_track_id`), deliverables
  (`derived_status`), open items (`severity`); `divergent_count` drift indicator; degraded banner.
  `phaseColor`/`severityColor` default branches (unknown → muted, never throws); `?? {}`/`?? []` guards.
- **`components/sidebar.tsx`** — a "Planning" link after Kanban.
- **7 frontend tests**.

## Verification
- Source (page.tsx, types.ts) typechecks clean (test-runner globals are local-env-only; resolved in CI).
- kimi-diff-gate: PASS on re-gate. The first pass caught two real shape bugs (depends_on object-array,
  drift divergent_count) — both fixed + verified against `_fetch_dependencies` / `_load_planning_drift`.

## Open Items
None. Completes #2. Remaining: #3 config-store (needs the codex spec revision first).

🤖 Generated with [Claude Code](https://claude.com/claude-code)