### PR TITLE
feat(config): config_registry SSOT — config control-plane foundation (P0)

### DIFF
--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -1,0 +1,152 @@
+"""config_registry — the single source of truth for operator-toggleable VNX config (P0).
+
+The dashboard control-plane needs a persistent, audited, per-project config store the runtime
+honours. This module is its foundation: the flag inventory (which flags are operator-facing, their
+type, their default, who may flip them) + the resolution precedence the runtime reads at decision
+time.
+
+SCOPE — only operator FEATURE toggles live here. Paths (VNX_DATA_DIR, VNX_HOME), provider-model
+pins (VNX_CODEX_MODEL…), timeouts, internal plumbing, and the `VNX_OVERRIDE_*` constraint brakes
+are deliberately OUT: they stay env-only and are never UI-settable.
+
+DEFAULTS MIRROR THE CURRENT CODE. Every default here is the literal fallback the read-site uses
+today (e.g. `VNX_CI_GATE_REQUIRED` defaults to "0" — off — exactly as `review_gate_manager.py`
+reads it). Changing a default here must never change runtime behaviour vs the env-only world.
+
+Precedence (highest first), implemented by `get()`:
+  1. ``VNX_OVERRIDE_<BARE>`` env var — the operator emergency brake (e.g. VNX_OVERRIDE_SCOUT_PREPASS).
+  2. ``project_config`` DB value — the UI-set value (wired in a later PR; injected via ``db_resolver``).
+  3. ``VNX_<BARE>`` env var — the process-start value (today's behaviour; never broken).
+  4. the registry default.
+
+Until the DB layer lands, ``db_resolver`` is None and step 2 is skipped — so this module is a
+behaviour-preserving overlay on the env-only world.
+"""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from typing import Callable, Dict, List, Optional
+
+
+@dataclass(frozen=True)
+class ConfigEntry:
+    key: str
+    type: str  # "bool" | "string" | "enum"
+    default: str
+    category: str  # "intelligence" | "dispatch" | "gate"
+    description: str
+    writable_from_ui: bool
+    requires_approval: bool
+    planned: bool = False  # exists in the registry/UI but not yet a live runtime flag
+
+
+def _e(key, type_, default, category, description, *, writable=True, approval=False, planned=False):
+    return ConfigEntry(key, type_, default, category, description, writable, approval, planned)
+
+
+# The inventory. Defaults verified against the read-sites (codex review finding: defaults must
+# match current code). All feature toggles are off ("0") today; the tagger provider is deepseek.
+CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
+    "VNX_SCOUT_PREPASS": _e(
+        "VNX_SCOUT_PREPASS", "bool", "0", "intelligence",
+        "Cheap-model scout recon pre-pass in the door (fail-open)."),
+    "VNX_TAGGER_ENABLED": _e(
+        "VNX_TAGGER_ENABLED", "bool", "0", "intelligence",
+        "Persist-time LLM tagging over the closed VNX vocabulary."),
+    "VNX_TAGGER_PROVIDER": _e(
+        "VNX_TAGGER_PROVIDER", "string", "deepseek", "intelligence",
+        "Provider for the LLM tagger (model-agnostic)."),
+    "VNX_INTEL_RANK_THEN_BUDGET": _e(
+        "VNX_INTEL_RANK_THEN_BUDGET", "bool", "0", "intelligence",
+        "Rank intelligence candidates by tag-overlap, then budget."),
+    "VNX_OUTCOME_GROUNDING_V2": _e(
+        "VNX_OUTCOME_GROUNDING_V2", "bool", "0", "intelligence",
+        "Junction-grounded confidence updates from receipts."),
+    "VNX_HAIKU_CLASSIFY": _e(
+        "VNX_HAIKU_CLASSIFY", "bool", "0", "intelligence",
+        "Use Haiku for high-volume receipt classification."),
+    "VNX_ROADMAP_AUTOPILOT": _e(
+        "VNX_ROADMAP_AUTOPILOT", "bool", "0", "dispatch",
+        "Autonomous roadmap auto-next loading (starts work).", approval=True),
+    "VNX_HEADLESS_ROUTING": _e(
+        "VNX_HEADLESS_ROUTING", "string", "0", "dispatch",
+        "Headless dispatch routing mode."),
+    "VNX_CI_GATE_REQUIRED": _e(
+        "VNX_CI_GATE_REQUIRED", "bool", "0", "gate",
+        "Require the CI gate before merge.", approval=True),
+    "VNX_WIRING_GATE_REQUIRED": _e(
+        "VNX_WIRING_GATE_REQUIRED", "bool", "0", "gate",
+        "Require the wiring gate.", approval=True),
+    "VNX_USE_CENTRAL_DB": _e(
+        "VNX_USE_CENTRAL_DB", "enum", "", "dispatch",
+        "Central-DB read mode (''=per-project | '1'=central | 'shadow').", approval=True),
+    "VNX_USE_FEDERATION": _e(
+        "VNX_USE_FEDERATION", "bool", "0", "intelligence",
+        "Cross-project intelligence federation (NOT yet implemented).",
+        writable=False, planned=True),
+}
+
+# A resolver for the per-project DB layer (step 2). Signature: (project_id, key) -> str | None.
+# None until the project_config DAO is wired (a later PR), so step 2 is a no-op today.
+DbResolver = Callable[[Optional[str], str], Optional[str]]
+_db_resolver: Optional[DbResolver] = None
+
+
+def set_db_resolver(resolver: Optional[DbResolver]) -> None:
+    """Wire the per-project DB layer (step 2 of the precedence chain)."""
+    global _db_resolver
+    _db_resolver = resolver
+
+
+def _bare(key: str) -> str:
+    return key[len("VNX_"):] if key.startswith("VNX_") else key
+
+
+def get(key: str, project_id: Optional[str] = None) -> Optional[str]:
+    """Resolve a config value via the precedence chain. Returns the registry default (or None for
+    an unknown key) when nothing overrides it. Never raises."""
+    entry = CONFIG_REGISTRY.get(key)
+    # 1. operator emergency-brake override (always wins, even for unknown keys)
+    override = os.environ.get(f"VNX_OVERRIDE_{_bare(key)}")
+    if override is not None:
+        return override
+    # 2. per-project DB value (wired later)
+    if _db_resolver is not None:
+        try:
+            db_val = _db_resolver(project_id, key)
+        except Exception:
+            db_val = None
+        if db_val is not None:
+            return db_val
+    # 3. process-start env value (today's behaviour, never broken)
+    env_val = os.environ.get(key)
+    if env_val is not None:
+        return env_val
+    # 4. registry default
+    return entry.default if entry is not None else None
+
+
+def get_bool(key: str, project_id: Optional[str] = None) -> bool:
+    """Bool view of get(): true only for the canonical truthy "1" (matches the read-sites)."""
+    return get(key, project_id) == "1"
+
+
+def all_effective(project_id: Optional[str] = None) -> List[dict]:
+    """Every registry flag with its effective value + provenance — for the config API/UI."""
+    out: List[dict] = []
+    for key, entry in CONFIG_REGISTRY.items():
+        value = get(key, project_id)
+        out.append({
+            "key": key,
+            "type": entry.type,
+            "category": entry.category,
+            "description": entry.description,
+            "default": entry.default,
+            "value": value,
+            "is_default": value == entry.default,
+            "writable_from_ui": entry.writable_from_ui,
+            "requires_approval": entry.requires_approval,
+            "planned": entry.planned,
+        })
+    return out

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -1,0 +1,127 @@
+#!/usr/bin/env python3
+"""Tests for config_registry — the operator config SSOT (P0 config control-plane foundation).
+
+Dispatch-ID: 20260627-config-registry
+
+Covers the flag inventory (defaults must MIRROR the current read-site fallbacks), the resolution
+precedence chain (override > DB > env > default), and the behaviour-preserving guarantee: with no
+override / no DB layer / no env, get() returns exactly the current-code default.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import config_registry as cr  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    # Drop any inherited VNX_* / overrides so tests resolve against the registry, and reset the DB layer.
+    for k in list(cr.CONFIG_REGISTRY):
+        monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv(f"VNX_OVERRIDE_{cr._bare(k)}", raising=False)
+    cr.set_db_resolver(None)
+    yield
+    cr.set_db_resolver(None)
+
+
+# ---------------------------------------------------------------------------
+# Inventory: defaults mirror the current code (codex finding #2)
+# ---------------------------------------------------------------------------
+
+def test_gate_flags_default_off_matching_code():
+    # The read-sites read these as `get("VNX_CI_GATE_REQUIRED", "0")` — off. Registry must match.
+    assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].default == "0"
+    assert cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"].default == "0"
+
+
+def test_feature_toggles_default_off_and_provider_deepseek():
+    assert cr.CONFIG_REGISTRY["VNX_SCOUT_PREPASS"].default == "0"
+    assert cr.CONFIG_REGISTRY["VNX_TAGGER_ENABLED"].default == "0"
+    assert cr.CONFIG_REGISTRY["VNX_TAGGER_PROVIDER"].default == "deepseek"
+    assert cr.CONFIG_REGISTRY["VNX_USE_CENTRAL_DB"].default == ""
+
+
+def test_gate_and_autopilot_require_approval():
+    assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].requires_approval is True
+    assert cr.CONFIG_REGISTRY["VNX_ROADMAP_AUTOPILOT"].requires_approval is True
+    # fail-safe intelligence toggles do not require approval
+    assert cr.CONFIG_REGISTRY["VNX_SCOUT_PREPASS"].requires_approval is False
+
+
+def test_federation_is_planned_and_not_writable():
+    fed = cr.CONFIG_REGISTRY["VNX_USE_FEDERATION"]
+    assert fed.planned is True
+    assert fed.writable_from_ui is False
+
+
+# ---------------------------------------------------------------------------
+# Resolution precedence
+# ---------------------------------------------------------------------------
+
+def test_default_when_nothing_set():
+    assert cr.get("VNX_SCOUT_PREPASS") == "0"  # = current-code behaviour
+    assert cr.get_bool("VNX_SCOUT_PREPASS") is False
+
+
+def test_env_overrides_default():
+    import os
+    os.environ["VNX_SCOUT_PREPASS"] = "1"
+    try:
+        assert cr.get("VNX_SCOUT_PREPASS") == "1"
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+    finally:
+        del os.environ["VNX_SCOUT_PREPASS"]
+
+
+def test_override_beats_env(monkeypatch):
+    monkeypatch.setenv("VNX_SCOUT_PREPASS", "1")
+    monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "0")
+    assert cr.get("VNX_SCOUT_PREPASS") == "0"  # the emergency brake wins
+
+
+def test_db_layer_beats_env_but_loses_to_override(monkeypatch):
+    monkeypatch.setenv("VNX_SCOUT_PREPASS", "0")
+    cr.set_db_resolver(lambda pid, key: "1" if key == "VNX_SCOUT_PREPASS" else None)
+    assert cr.get("VNX_SCOUT_PREPASS") == "1"          # DB beats env
+    monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "0")
+    assert cr.get("VNX_SCOUT_PREPASS") == "0"           # override beats DB
+
+
+def test_db_resolver_error_falls_through(monkeypatch):
+    def _boom(pid, key):
+        raise RuntimeError("db down")
+    cr.set_db_resolver(_boom)
+    # DB error must not raise — falls through to the default.
+    assert cr.get("VNX_SCOUT_PREPASS") == "0"
+
+
+def test_unknown_key_returns_none():
+    assert cr.get("VNX_NOT_A_REAL_FLAG") is None
+
+
+# ---------------------------------------------------------------------------
+# all_effective
+# ---------------------------------------------------------------------------
+
+def test_all_effective_marks_defaults_and_planned():
+    rows = {r["key"]: r for r in cr.all_effective()}
+    assert rows["VNX_SCOUT_PREPASS"]["is_default"] is True
+    assert rows["VNX_USE_FEDERATION"]["planned"] is True
+    assert rows["VNX_CI_GATE_REQUIRED"]["requires_approval"] is True
+
+
+def test_all_effective_reflects_env(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    rows = {r["key"]: r for r in cr.all_effective()}
+    assert rows["VNX_TAGGER_ENABLED"]["value"] == "1"
+    assert rows["VNX_TAGGER_ENABLED"]["is_default"] is False
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
First PR of the P0 config control-plane (#3 of the dashboard verbeterblad). Adds `config_registry` —
the single source of truth for operator-toggleable VNX feature flags + the runtime resolution
precedence chain. Pure module: no DB, no API, no frontend yet (those are the next PRs). It is
**behaviour-preserving** — a behaviour-preserving overlay on today's env-only world.

## Changes
- **`scripts/lib/config_registry.py`** — `ConfigEntry` + `CONFIG_REGISTRY` (in-scope feature toggles
  only; paths/provider-models/timeouts/`VNX_OVERRIDE_*` deliberately OUT). **Defaults mirror the
  current read-sites** — the codex finding: gate flags `VNX_CI_GATE_REQUIRED`/`VNX_WIRING_GATE_REQUIRED`
  default `"0"` (off), not on. `get()/get_bool()/all_effective()` with precedence
  `VNX_OVERRIDE_<bare>` > DB resolver (injected, `None` for now) > `VNX_<key>` env > default; never
  raises. `requires_approval` on gate/autopilot/central-db; `VNX_USE_FEDERATION` is `planned` + not writable.
- **`tests/test_config_registry.py`** — 12 tests.

## Verification
- `pytest tests/test_config_registry.py` — 12/12 green; `ruff check` clean.
- kimi-diff-gate: PASS (behaviour-preservation + precedence + fail-through verified).

## Open Items
None. Next PRs: 0032 migration (project_config + project_config_audit, ADR-007 composite key —
the codex findings; on the 0NNN track since the live DB is at user_version 31), the DAO (audit +
event emission), the config API, the config page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)