### PR TITLE
feat(config): config_store_db — config control-plane persistence (P0, PR 2)

### DIFF
--- a/scripts/lib/config_store_db.py
+++ b/scripts/lib/config_store_db.py
@@ -1,0 +1,87 @@
+"""config_store_db — persistence for the operator config control-plane (P0, PR 2).
+
+The two tables that back the UI-set, per-project, audited config:
+  - ``project_config``       : the live values (one row per (project_id, config_key)).
+  - ``project_config_audit`` : append-only history of every change (who/when/old→new + event link).
+
+SCHEMA HOME — these tables are created via an idempotent ``ensure_config_tables`` (CREATE TABLE
+IF NOT EXISTS), NOT via the numbered track-layer migration walk. Reasoning (and a deliberate
+deviation from the "put it in 0032" review suggestion):
+
+  * The track-layer migration system (migrate_future_system.py + schema_manifest.py) governs the
+    track-layer schema (tracks/dispatches/…): its reconciler validates the FULL expected shape for
+    a claimed ``user_version`` and DOWNGRADES on mismatch. Bolting orthogonal config tables onto
+    that machinery means extending the full-shape manifest for an unrelated feature (high blast
+    radius on every project's runtime_coordination.db).
+  * The original review flagged a real bug — a ``runtime_coordination_v11.sql`` migration would be
+    SKIPPED on a DB already at user_version 31. An idempotent ``CREATE TABLE IF NOT EXISTS`` is not
+    user_version-gated at all, so it addresses that concern MORE robustly (it can never be skipped),
+    while staying out of the manifest's full-shape contract.
+
+ADR-007 (tenant stamping): both tables carry ``project_id`` and a composite key over it —
+``project_config`` PK ``(project_id, config_key)``; ``project_config_audit`` UNIQUE
+``(project_id, event_id)``.
+"""
+from __future__ import annotations
+
+import sqlite3
+from typing import Optional
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS project_config (
+    project_id   TEXT NOT NULL,
+    config_key   TEXT NOT NULL,
+    config_value TEXT NOT NULL,
+    config_type  TEXT NOT NULL DEFAULT 'string',
+    updated_by   TEXT NOT NULL,
+    updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    approval_id  TEXT,
+    PRIMARY KEY (project_id, config_key)
+);
+
+CREATE TABLE IF NOT EXISTS project_config_audit (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id  TEXT NOT NULL,
+    config_key  TEXT NOT NULL,
+    old_value   TEXT,
+    new_value   TEXT NOT NULL,
+    changed_by  TEXT NOT NULL,
+    changed_at  TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    approval_id TEXT,
+    event_id    TEXT NOT NULL,
+    UNIQUE (project_id, event_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_pca_project_key ON project_config_audit(project_id, config_key);
+"""
+
+
+def ensure_config_tables(conn: sqlite3.Connection) -> None:
+    """Create the config-store tables if absent. Idempotent; safe to call on every open."""
+    conn.executescript(_SCHEMA)
+
+
+def has_config_tables(conn: sqlite3.Connection) -> bool:
+    """True when project_config exists (so callers can fail-open before ensure)."""
+    row = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='project_config'"
+    ).fetchone()
+    return row is not None
+
+
+def read_config(conn: sqlite3.Connection, project_id: str, key: str) -> Optional[str]:
+    """Return the stored config_value for (project_id, key), or None when unset / table absent.
+
+    This is the DB layer (step 2) of config_registry's precedence chain. Fail-open: any sqlite
+    error (including a missing table) yields None so the runtime falls through to the env/default.
+    """
+    try:
+        if not has_config_tables(conn):
+            return None
+        row = conn.execute(
+            "SELECT config_value FROM project_config WHERE project_id = ? AND config_key = ?",
+            (project_id, key),
+        ).fetchone()
+    except sqlite3.Error:
+        return None
+    return row[0] if row else None

--- a/tests/test_config_store_db.py
+++ b/tests/test_config_store_db.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Tests for config_store_db — the config control-plane persistence layer (P0, PR 2).
+
+Dispatch-ID: 20260627-config-store-db
+
+Covers: idempotent ensure_config_tables, ADR-007 composite keys on both tables, and read_config
+fail-open (missing table / unset key → None, never raises).
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import config_store_db as cs  # noqa: E402
+
+
+@pytest.fixture
+def conn():
+    c = sqlite3.connect(":memory:")
+    yield c
+    c.close()
+
+
+def test_ensure_creates_tables_idempotently(conn):
+    cs.ensure_config_tables(conn)
+    cs.ensure_config_tables(conn)  # second call must not raise
+    tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    assert {"project_config", "project_config_audit"} <= tables
+
+
+def test_project_config_pk_is_composite_over_project_id(conn):
+    cs.ensure_config_tables(conn)
+    pk_cols = [r[1] for r in conn.execute("PRAGMA table_info(project_config)") if r[5] > 0]
+    assert pk_cols == ["project_id", "config_key"]  # ADR-007 composite PK over project_id
+
+
+def test_project_config_audit_has_composite_unique_over_project_id(conn):
+    cs.ensure_config_tables(conn)
+    # The audit table is append-only (id PK) + a composite UNIQUE(project_id, event_id) for ADR-007.
+    cs.read_config  # keep import used
+    conn.execute(
+        "INSERT INTO project_config_audit(project_id, config_key, new_value, changed_by, event_id) "
+        "VALUES ('p', 'k', 'v', 'op', 'evt-1')"
+    )
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO project_config_audit(project_id, config_key, new_value, changed_by, event_id) "
+            "VALUES ('p', 'k2', 'v2', 'op', 'evt-1')"  # same (project_id, event_id) → rejected
+        )
+    # a different project may reuse the event_id
+    conn.execute(
+        "INSERT INTO project_config_audit(project_id, config_key, new_value, changed_by, event_id) "
+        "VALUES ('other', 'k', 'v', 'op', 'evt-1')"
+    )
+
+
+def test_project_config_pk_rejects_duplicate_key_per_project(conn):
+    cs.ensure_config_tables(conn)
+    conn.execute("INSERT INTO project_config(project_id, config_key, config_value, updated_by) VALUES ('p','k','0','op')")
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute("INSERT INTO project_config(project_id, config_key, config_value, updated_by) VALUES ('p','k','1','op')")
+    # same key, different project is fine
+    conn.execute("INSERT INTO project_config(project_id, config_key, config_value, updated_by) VALUES ('p2','k','1','op')")
+
+
+def test_read_config_returns_value_and_none(conn):
+    cs.ensure_config_tables(conn)
+    conn.execute("INSERT INTO project_config(project_id, config_key, config_value, updated_by) VALUES ('vnx-dev','VNX_SCOUT_PREPASS','1','operator')")
+    assert cs.read_config(conn, "vnx-dev", "VNX_SCOUT_PREPASS") == "1"
+    assert cs.read_config(conn, "vnx-dev", "VNX_TAGGER_ENABLED") is None  # unset
+    assert cs.read_config(conn, "other-proj", "VNX_SCOUT_PREPASS") is None  # tenant-scoped
+
+
+def test_read_config_fail_open_when_table_absent(conn):
+    # No ensure_config_tables call → table missing → read must return None, not raise.
+    assert cs.has_config_tables(conn) is False
+    assert cs.read_config(conn, "vnx-dev", "VNX_SCOUT_PREPASS") is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
PR 2 of the P0 config control-plane (after config_registry #947): the two tables backing the
per-project, audited config store + a fail-open read (the DB layer of config_registry's precedence
chain). Backend only; the DAO write-path + API + UI are the next PRs.

## Changes
- **`scripts/lib/config_store_db.py`** — `ensure_config_tables` (idempotent CREATE TABLE IF NOT
  EXISTS): `project_config` + `project_config_audit`, both **ADR-007** composite over `project_id`
  (PK `(project_id, config_key)`; UNIQUE `(project_id, event_id)` for the append-only audit). +
  `read_config` (tenant-scoped, **fail-open** — missing table / sqlite error → None, never raises).
- **`tests/test_config_store_db.py`** — 6 tests.

## Deliberate deviation (gate-reviewed)
A prior codex note said "use the 0032 track". I instead use an idempotent `ensure_config_tables`
OUTSIDE the numbered track-layer migration: the `migrate_future_system`/`schema_manifest` reconciler
validates the FULL per-version track-layer shape and downgrades on mismatch — bolting orthogonal
config tables onto it is high blast radius. `CREATE TABLE IF NOT EXISTS` is not user_version-gated,
so it can never be skipped on a DB at v31 (the original concern), without extending the manifest.
The kimi-diff-gate reviewed this deviation explicitly: **PASS**.

## Verification
- `pytest tests/test_config_store_db.py` — 6/6 green; `ruff check` clean.

## Open Items
None. Next PRs: the DAO (`set_config` + audit row + coordination_event), the config API, the config page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)