### PR TITLE
feat(config): config control-plane API — GET inventory/audit + POST set (P0 PR 4)

### DIFF
--- a/dashboard/api_config.py
+++ b/dashboard/api_config.py
@@ -1,0 +1,190 @@
+"""Config control-plane API handlers (P0 PR 4).
+
+The HTTP surface over the config DAO (config_registry #947 + config_store_db #948/#949):
+
+  GET  /api/operator/config        -> the registry inventory with effective values + provenance
+  POST /api/operator/config/set    -> set_config (validate vs registry, write value + mandatory audit)
+  GET  /api/operator/config/audit  -> recent project_config_audit rows for this project (newest first)
+
+Single-tenant: the dashboard serves one project (CANONICAL_STATE_DIR). Every write is tenant-scoped
+to that project_id and lands in its runtime_coordination.db. Handlers accept optional ``project_id``
+/ ``db_path`` overrides for testing (mirrors api_operator's ``config_path=None`` gate handlers).
+"""
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+# One source of truth for "which project / which state dir" — reuse the operator module's derivation.
+from api_operator import CANONICAL_STATE_DIR, VNX_DIR, _op_dashboard_project_id
+
+_logger = logging.getLogger(__name__)
+
+_CFG_SCRIPTS_LIB = str(VNX_DIR / "scripts" / "lib")
+if _CFG_SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, _CFG_SCRIPTS_LIB)
+
+try:
+    import config_registry as _cr   # type: ignore[import]
+    import config_store_db as _cs    # type: ignore[import]
+    _CONFIG_AVAILABLE = True
+except Exception:
+    # Optional dependency: the config-store modules may be absent in a stripped install. Log so a
+    # real init error is visible (not silently mistaken for "registry unavailable") but stay non-fatal.
+    _logger.warning("config control-plane modules unavailable; config API will report 503", exc_info=True)
+    _cr = None  # type: ignore[assignment]
+    _cs = None  # type: ignore[assignment]
+    _CONFIG_AVAILABLE = False
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _config_db_path(db_path: "Path | None" = None) -> Path:
+    return db_path or (CANONICAL_STATE_DIR / "runtime_coordination.db")
+
+
+def _wire_resolver(state_dir: "Path | None" = None) -> None:
+    """Wire config_registry's DB layer (precedence step 2) to a state dir so the inventory reflects
+    UI-set values. Single-tenant: every project_id maps to this one dir. Idempotent; fail-soft."""
+    if not _CONFIG_AVAILABLE:
+        return
+    target = state_dir or CANONICAL_STATE_DIR
+    try:
+        _cr.set_db_resolver(_cs.make_db_resolver(lambda _pid: target))
+    except Exception:  # vnx-silent-except: resolver wiring is best-effort; a failure must never break dashboard import
+        pass
+
+
+# Wire at import for the production dashboard process.
+_wire_resolver()
+
+
+def operator_get_config(params: dict, *, project_id: "str | None" = None) -> "tuple[dict, int]":
+    """GET /api/operator/config -- every operator flag with its effective value + provenance.
+
+    Returns (body, status): 200 on success; 503 when the registry is unavailable / errors (the body
+    carries a generic message — the exception detail is logged server-side, never returned)."""
+    pid = project_id or _op_dashboard_project_id()
+    if not _CONFIG_AVAILABLE:
+        return {"project_id": pid, "config": [], "queried_at": _now(),
+                "error": "config registry unavailable"}, 503
+    try:
+        rows = _cr.all_effective(pid)
+    except Exception:
+        _logger.exception("config inventory failed for project_id=%s", pid)
+        return {"project_id": pid, "config": [], "queried_at": _now(),
+                "error": "config inventory failed"}, 503
+    return {"project_id": pid, "config": rows, "queried_at": _now()}, 200
+
+
+def operator_post_config_set(
+    body: dict, *, project_id: "str | None" = None, db_path: "Path | None" = None,
+) -> "tuple[dict, int]":
+    """POST /api/operator/config/set -- validate vs registry, then write value + mandatory audit row.
+
+    Body: ``{key, value, actor?, approval_id?}``. Maps the DAO's exceptions to HTTP:
+    ValueError (unknown key / bad value) -> 400; PermissionError (not writable / approval required)
+    -> 403; success -> 200.
+    """
+    now = _now()
+    if not _CONFIG_AVAILABLE:
+        return {"status": "failed", "message": "config store unavailable", "timestamp": now}, 503
+
+    key = body.get("key", "")
+    if not key or not isinstance(key, str):
+        return {"status": "failed", "message": "key is required", "timestamp": now}, 400
+    if "value" not in body:
+        return {"status": "failed", "message": "value is required", "timestamp": now}, 400
+    value = body.get("value")
+    actor = body.get("actor") or "operator"
+    approval_id = body.get("approval_id") or None
+
+    pid = project_id or _op_dashboard_project_id()
+    if not pid:
+        return {"status": "failed", "message": "could not resolve project_id", "timestamp": now}, 500
+
+    path = _config_db_path(db_path)
+    try:
+        conn = sqlite3.connect(str(path))
+    except sqlite3.Error:
+        _logger.exception("config db open failed (project_id=%s)", pid)
+        return {"status": "failed", "message": "database unavailable", "timestamp": now}, 500
+    try:
+        result = _cs.set_config(conn, pid, key, value, actor=actor, approval_id=approval_id)
+    except ValueError as exc:
+        # Validation messages are caller-facing by design (echo the supplied key + a static reason).
+        return {"status": "failed", "message": str(exc), "timestamp": now}, 400
+    except PermissionError as exc:
+        return {"status": "failed", "message": str(exc), "timestamp": now}, 403
+    except Exception:
+        _logger.exception("config set failed (key=%s project_id=%s)", key, pid)
+        return {"status": "failed", "message": "config write failed", "timestamp": now}, 500
+    finally:
+        conn.close()
+
+    return {
+        "status": "success",
+        "action": "config/set",
+        "project_id": pid,
+        "key": key,
+        "old_value": result["old_value"],
+        "new_value": result["new_value"],
+        "event_id": result["event_id"],
+        "actor": actor,
+        "approval_id": approval_id,
+        "timestamp": now,
+    }, 200
+
+
+def operator_get_config_audit(
+    params: dict, *, project_id: "str | None" = None, db_path: "Path | None" = None,
+) -> "tuple[dict, int]":
+    """GET /api/operator/config/audit -- recent config changes for this project (newest first).
+
+    Query: ``?limit=<1..500>`` (default 50), optional ``?key=<config_key>`` filter. Fail-open: a
+    missing DB / missing tables -> empty audit (200). A real DB error logs server-side and returns
+    an empty, ``degraded``-flagged body (200) — the exception detail is never returned to clients."""
+    pid = project_id or _op_dashboard_project_id()
+    limit_raw = (params.get("limit") or ["50"])[0]
+    try:
+        limit = max(1, min(int(limit_raw), 500))
+    except (TypeError, ValueError):
+        limit = 50
+    key_filter = (params.get("key") or [None])[0]
+
+    out: dict = {"project_id": pid, "audit": [], "queried_at": _now()}
+    path = _config_db_path(db_path)
+    if not _CONFIG_AVAILABLE or not path.exists():
+        return out, 200
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        _logger.exception("config audit db open failed (project_id=%s)", pid)
+        out["degraded"] = True
+        return out, 200
+    try:
+        if not _cs.has_config_tables(conn):
+            return out, 200
+        conn.row_factory = sqlite3.Row
+        sql = (
+            "SELECT config_key, old_value, new_value, changed_by, changed_at, approval_id, event_id "
+            "FROM project_config_audit WHERE project_id = ?"
+        )
+        args: list = [pid]
+        if key_filter:
+            sql += " AND config_key = ?"
+            args.append(key_filter)
+        sql += " ORDER BY id DESC LIMIT ?"
+        args.append(limit)
+        out["audit"] = [dict(r) for r in conn.execute(sql, args).fetchall()]
+    except sqlite3.Error:
+        _logger.exception("config audit query failed (project_id=%s)", pid)
+        out["degraded"] = True
+    finally:
+        conn.close()
+    return out, 200

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -165,6 +165,12 @@ from api_planning import (  # noqa: E402
     _operator_get_planning,
 )
 
+from api_config import (  # noqa: E402
+    operator_get_config,
+    operator_post_config_set,
+    operator_get_config_audit,
+)
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -356,6 +362,16 @@ class DashboardHandler(SimpleHTTPRequestHandler):
             _json_response(self, HTTPStatus.OK, get_operator_recommendations())
             return
 
+        if path == "/api/operator/config/audit":
+            result, status_int = operator_get_config_audit(params)
+            _json_response(self, HTTPStatus(status_int), result)
+            return
+
+        if path == "/api/operator/config":
+            result, status_int = operator_get_config(params)
+            _json_response(self, HTTPStatus(status_int), result)
+            return
+
         if path == "/api/operator/planning":
             _json_response(self, HTTPStatus.OK, _operator_get_planning())
             return
@@ -545,6 +561,18 @@ class DashboardHandler(SimpleHTTPRequestHandler):
                 self.send_error(HTTPStatus.BAD_REQUEST, "Invalid JSON body")
                 return
             result, status_int = _operator_post_gate_toggle(body_data)
+            _json_response(self, HTTPStatus(status_int), result)
+            return
+
+        if parsed_path == "/api/operator/config/set":
+            length = int(self.headers.get("Content-Length", "0") or "0")
+            body_bytes = self.rfile.read(length) if length else b"{}"
+            try:
+                body_data = json.loads(body_bytes.decode("utf-8"))
+            except json.JSONDecodeError:
+                self.send_error(HTTPStatus.BAD_REQUEST, "Invalid JSON body")
+                return
+            result, status_int = operator_post_config_set(body_data)
             _json_response(self, HTTPStatus(status_int), result)
             return
 

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Tests for api_config — the config control-plane HTTP handlers (P0, PR 4).
+
+Dispatch-ID: 20260627-api-config
+
+Covers GET inventory (shape + DB-set value surfacing), POST set (success + the 400/403 error mapping
+for unknown / not-writable / approval-required keys), and GET audit (newest-first, key filter,
+fail-open on a missing DB).
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "dashboard"))
+
+import config_registry as cr  # noqa: E402
+import api_config as ac  # noqa: E402
+
+PID = "vnx-dev"
+
+
+@pytest.fixture
+def db(tmp_path):
+    """A per-project runtime_coordination.db path + its state dir wired into the registry resolver."""
+    state_dir = tmp_path
+    db_path = state_dir / "runtime_coordination.db"
+    sqlite3.connect(db_path).close()  # create the file
+    ac._wire_resolver(state_dir)
+    yield db_path
+    cr.set_db_resolver(None)
+
+
+# ---------------------------------------------------------------------------
+# POST /api/operator/config/set
+# ---------------------------------------------------------------------------
+
+def test_set_success_returns_200_and_persists(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_SCOUT_PREPASS", "value": "1", "actor": "alice"},
+        project_id=PID, db_path=db,
+    )
+    assert status == 200
+    assert res["status"] == "success"
+    assert res["new_value"] == "1"
+    assert res["event_id"]
+    conn = sqlite3.connect(db)
+    assert conn.execute(
+        "SELECT config_value FROM project_config WHERE project_id=? AND config_key='VNX_SCOUT_PREPASS'",
+        (PID,),
+    ).fetchone()[0] == "1"
+    conn.close()
+
+
+def test_set_unknown_key_returns_400(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_NOPE", "value": "1"}, project_id=PID, db_path=db)
+    assert status == 400
+    assert res["status"] == "failed"
+
+
+def test_set_non_writable_key_returns_403(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_USE_FEDERATION", "value": "1"}, project_id=PID, db_path=db)
+    assert status == 403
+
+
+def test_set_requires_approval_without_id_returns_403(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_CI_GATE_REQUIRED", "value": "1"}, project_id=PID, db_path=db)
+    assert status == 403
+
+
+def test_set_requires_approval_with_id_succeeds(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_CI_GATE_REQUIRED", "value": "1", "approval_id": "appr-9"},
+        project_id=PID, db_path=db)
+    assert status == 200
+    assert res["approval_id"] == "appr-9"
+
+
+def test_set_bad_bool_value_returns_400(db):
+    res, status = ac.operator_post_config_set(
+        {"key": "VNX_SCOUT_PREPASS", "value": "perhaps"}, project_id=PID, db_path=db)
+    assert status == 400
+
+
+def test_set_missing_key_returns_400(db):
+    res, status = ac.operator_post_config_set({"value": "1"}, project_id=PID, db_path=db)
+    assert status == 400
+
+
+def test_set_missing_value_returns_400(db):
+    res, status = ac.operator_post_config_set({"key": "VNX_SCOUT_PREPASS"}, project_id=PID, db_path=db)
+    assert status == 400
+
+
+# ---------------------------------------------------------------------------
+# GET /api/operator/config
+# ---------------------------------------------------------------------------
+
+def test_get_config_inventory_shape(db):
+    out, status = ac.operator_get_config({}, project_id=PID)
+    assert status == 200
+    assert out["project_id"] == PID
+    keys = {row["key"] for row in out["config"]}
+    assert "VNX_SCOUT_PREPASS" in keys
+    row = next(r for r in out["config"] if r["key"] == "VNX_CI_GATE_REQUIRED")
+    assert row["requires_approval"] is True
+
+
+def test_get_config_reflects_db_value(db):
+    # write via the DAO, then the inventory (through the wired resolver) must show it as non-default
+    ac.operator_post_config_set(
+        {"key": "VNX_SCOUT_PREPASS", "value": "1"}, project_id=PID, db_path=db)
+    out, status = ac.operator_get_config({}, project_id=PID)
+    assert status == 200
+    row = next(r for r in out["config"] if r["key"] == "VNX_SCOUT_PREPASS")
+    assert row["value"] == "1"
+    assert row["is_default"] is False
+
+
+# ---------------------------------------------------------------------------
+# GET /api/operator/config/audit
+# ---------------------------------------------------------------------------
+
+def test_audit_returns_changes_newest_first(db):
+    ac.operator_post_config_set({"key": "VNX_SCOUT_PREPASS", "value": "1", "actor": "a"}, project_id=PID, db_path=db)
+    ac.operator_post_config_set({"key": "VNX_SCOUT_PREPASS", "value": "0", "actor": "b"}, project_id=PID, db_path=db)
+    out, status = ac.operator_get_config_audit({}, project_id=PID, db_path=db)
+    assert status == 200
+    assert out["project_id"] == PID
+    assert len(out["audit"]) == 2
+    assert out["audit"][0]["new_value"] == "0"  # newest first
+    assert out["audit"][0]["changed_by"] == "b"
+
+
+def test_audit_key_filter(db):
+    ac.operator_post_config_set({"key": "VNX_SCOUT_PREPASS", "value": "1"}, project_id=PID, db_path=db)
+    ac.operator_post_config_set({"key": "VNX_TAGGER_ENABLED", "value": "1"}, project_id=PID, db_path=db)
+    out, status = ac.operator_get_config_audit({"key": ["VNX_TAGGER_ENABLED"]}, project_id=PID, db_path=db)
+    assert len(out["audit"]) == 1
+    assert out["audit"][0]["config_key"] == "VNX_TAGGER_ENABLED"
+
+
+def test_audit_fail_open_when_db_missing(tmp_path):
+    missing = tmp_path / "no-such.db"
+    out, status = ac.operator_get_config_audit({}, project_id=PID, db_path=missing)
+    assert status == 200
+    assert out["audit"] == []
+
+
+def test_audit_is_tenant_scoped(db):
+    ac.operator_post_config_set({"key": "VNX_SCOUT_PREPASS", "value": "1"}, project_id="proj-a", db_path=db)
+    out, status = ac.operator_get_config_audit({}, project_id="proj-b", db_path=db)
+    assert out["audit"] == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
PR 4/5 of the operator config control-plane: the **HTTP surface** over the DAO (registry #947, DAO
#949). Three handlers on the stdlib dashboard server, single-tenant (the dashboard serves one
project = `CANONICAL_STATE_DIR`).

## Changes
**`dashboard/api_config.py`** (new)
- `operator_get_config` → **GET `/api/operator/config`** — the registry inventory with effective
  values + provenance via `config_registry.all_effective`. Returns `(body, status)`: 200 ok / **503**
  when the registry is unavailable or errors (generic message; detail logged server-side).
- `operator_post_config_set` → **POST `/api/operator/config/set`** — validates vs the registry then
  `config_store_db.set_config`. Maps the DAO exceptions: `ValueError` (unknown key / bad value) →
  **400**; `PermissionError` (not writable / approval required) → **403**; success → **200**.
- `operator_get_config_audit` → **GET `/api/operator/config/audit`** — recent `project_config_audit`
  rows (newest-first, `?limit=1..500`, optional `?key=` filter). Fail-open: missing DB/tables → empty
  (200); a real DB error → empty + `degraded` flag (200), never leaks exception detail.
- `_wire_resolver()` — wires `config_registry`'s step-2 DB-resolver to the dashboard's state dir so
  the inventory reflects UI-set values (single-tenant, fail-soft at import).

**`dashboard/serve_dashboard.py`** — the three routes (existing gate/toggle POST pattern; exact `==`
matches, `/config/audit` before `/config`).

**`tests/test_api_config.py`** (14) — set success + the 400/403/400 error mapping, inventory shape +
DB-value surfacing through the resolver, audit newest-first / key-filter / tenant-scope / fail-open.

## Verification
- `pytest tests/test_api_config.py` → **14 passed**; `py_compile` + `ruff` clean; silent-except scanner clean
- **kimi-diff-gate: PASS** (round 2). Round 1 caught two real bugs: GET returned 200-on-failure (now
  503 via `(body, status)` tuples) and raw `str(exc)` leaked to clients (now generic message +
  `_logger.exception`). The 400/403 DAO validation messages are kept (caller-facing by design).

## Open Items
None. Next: PR 5 (Next.js config page — category toggles + approval modal + audit drawer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)