### PR TITLE
feat(config): config control-plane page — toggles + approval modal + audit drawer (P0 PR 5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,8 +86,9 @@ CHANGELOG_QUALITY_ADVISORY.md
 /.pr_state.json
 /PR_QUEUE.md
 
-# Old config directory (merged into configs/)
-config/
+# Old config directory (merged into configs/) — root-anchored so it does not match
+# nested app routes like dashboard/token-dashboard/app/operator/config/
+/config/
 
 # Old testing directory (merged into tests/)
 testing/

--- a/dashboard/token-dashboard/__tests__/config-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/config-page.test.tsx
@@ -1,0 +1,139 @@
+/**
+ * Tests for app/operator/config/page.tsx — the config control-plane UI over /api/operator/config.
+ *
+ * - Renders category sections + bool toggle / string input / locked (planned) rows
+ * - A non-approval toggle posts the flipped value directly
+ * - An approval-required toggle opens the modal; confirm posts with the approval_id
+ * - Audit drawer toggles + lists recent changes
+ * - Loading + error states
+ */
+
+import React from 'react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/lib/hooks', () => ({
+  useConfig: jest.fn(),
+  useConfigAudit: jest.fn(),
+}));
+jest.mock('@/lib/operator-api', () => ({
+  postConfigSet: jest.fn(),
+}));
+
+import { useConfig, useConfigAudit } from '@/lib/hooks';
+import { postConfigSet } from '@/lib/operator-api';
+import ConfigPage from '@/app/operator/config/page';
+import type { ConfigEntryRow, ConfigEnvelope, ConfigAuditEnvelope } from '@/lib/types';
+
+const mockUseConfig = useConfig as jest.MockedFunction<typeof useConfig>;
+const mockUseAudit = useConfigAudit as jest.MockedFunction<typeof useConfigAudit>;
+const mockPost = postConfigSet as jest.MockedFunction<typeof postConfigSet>;
+
+function entry(over: Partial<ConfigEntryRow>): ConfigEntryRow {
+  return {
+    key: 'VNX_X', type: 'bool', category: 'intelligence', description: 'desc',
+    default: '0', value: '0', is_default: true, writable_from_ui: true,
+    requires_approval: false, planned: false, ...over,
+  };
+}
+
+const ROWS: ConfigEntryRow[] = [
+  entry({ key: 'VNX_SCOUT_PREPASS', category: 'intelligence', description: 'scout pre-pass' }),
+  entry({ key: 'VNX_TAGGER_PROVIDER', type: 'string', category: 'intelligence', default: 'deepseek', value: 'deepseek', description: 'tagger provider' }),
+  entry({ key: 'VNX_USE_FEDERATION', category: 'intelligence', planned: true, writable_from_ui: false, description: 'federation' }),
+  entry({ key: 'VNX_CI_GATE_REQUIRED', category: 'gate', requires_approval: true, description: 'require CI gate' }),
+];
+
+function configEnv(rows = ROWS): ConfigEnvelope {
+  return { project_id: 'vnx-dev', config: rows, queried_at: '2026-06-27T15:00:00Z' };
+}
+
+function auditEnv(rows: ConfigAuditEnvelope['audit'] = []): ConfigAuditEnvelope {
+  return { project_id: 'vnx-dev', audit: rows, queried_at: '2026-06-27T15:00:00Z' };
+}
+
+function setup(opts: {
+  data?: ConfigEnvelope; isLoading?: boolean; error?: Error; audit?: ConfigAuditEnvelope;
+} = {}) {
+  mockUseConfig.mockReturnValue({
+    data: opts.data, isLoading: opts.isLoading ?? false, error: opts.error,
+    mutate: jest.fn(), isValidating: false,
+  } as ReturnType<typeof useConfig>);
+  mockUseAudit.mockReturnValue({
+    data: opts.audit ?? auditEnv(), isLoading: false, error: undefined,
+    mutate: jest.fn(), isValidating: false,
+  } as ReturnType<typeof useConfigAudit>);
+  return render(<ConfigPage />);
+}
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockPost.mockResolvedValue({ status: 'success', new_value: '1', timestamp: 't' });
+});
+
+describe('ConfigPage', () => {
+  test('renders category sections + the row controls', () => {
+    setup({ data: configEnv() });
+    expect(screen.getByTestId('config-section-intelligence')).toBeInTheDocument();
+    expect(screen.getByTestId('config-section-gate')).toBeInTheDocument();
+    expect(screen.getByTestId('config-toggle-VNX_SCOUT_PREPASS')).toHaveTextContent('OFF');
+    expect(screen.getByTestId('config-input-VNX_TAGGER_PROVIDER')).toHaveValue('deepseek');
+    expect(screen.getByTestId('config-locked-VNX_USE_FEDERATION')).toBeInTheDocument();
+  });
+
+  test('non-approval toggle posts the flipped value directly', async () => {
+    setup({ data: configEnv() });
+    fireEvent.click(screen.getByTestId('config-toggle-VNX_SCOUT_PREPASS'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith({ key: 'VNX_SCOUT_PREPASS', value: '1' }));
+    expect(screen.queryByTestId('config-approval-modal')).not.toBeInTheDocument();
+  });
+
+  test('approval-required toggle opens the modal and posts with approval_id on confirm', async () => {
+    setup({ data: configEnv() });
+    fireEvent.click(screen.getByTestId('config-toggle-VNX_CI_GATE_REQUIRED'));
+    expect(screen.getByTestId('config-approval-modal')).toBeInTheDocument();
+    // confirm is disabled until an approval id is entered
+    expect(screen.getByTestId('config-approval-confirm')).toBeDisabled();
+    fireEvent.change(screen.getByTestId('config-approval-input'), { target: { value: 'appr-7' } });
+    fireEvent.click(screen.getByTestId('config-approval-confirm'));
+    await waitFor(() =>
+      expect(mockPost).toHaveBeenCalledWith({ key: 'VNX_CI_GATE_REQUIRED', value: '1', approval_id: 'appr-7' }),
+    );
+  });
+
+  test('approval modal cancel does not post', () => {
+    setup({ data: configEnv() });
+    fireEvent.click(screen.getByTestId('config-toggle-VNX_CI_GATE_REQUIRED'));
+    fireEvent.click(screen.getByTestId('config-approval-cancel'));
+    expect(screen.queryByTestId('config-approval-modal')).not.toBeInTheDocument();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  test('string save posts the edited value', async () => {
+    setup({ data: configEnv() });
+    fireEvent.change(screen.getByTestId('config-input-VNX_TAGGER_PROVIDER'), { target: { value: 'kimi' } });
+    fireEvent.click(screen.getByTestId('config-save-VNX_TAGGER_PROVIDER'));
+    await waitFor(() => expect(mockPost).toHaveBeenCalledWith({ key: 'VNX_TAGGER_PROVIDER', value: 'kimi' }));
+  });
+
+  test('audit drawer toggles and lists changes', () => {
+    setup({
+      data: configEnv(),
+      audit: auditEnv([
+        { config_key: 'VNX_SCOUT_PREPASS', old_value: '0', new_value: '1', changed_by: 'op', changed_at: 't', approval_id: null, event_id: 'evt-1' },
+      ]),
+    });
+    expect(screen.queryByTestId('config-audit-drawer')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByTestId('config-audit-toggle'));
+    expect(screen.getByTestId('config-audit-drawer')).toBeInTheDocument();
+    expect(screen.getByTestId('config-audit-row-evt-1')).toHaveTextContent('VNX_SCOUT_PREPASS');
+  });
+
+  test('loading and error states', () => {
+    const { rerender } = setup({ isLoading: true });
+    expect(screen.getByTestId('config-loading')).toBeInTheDocument();
+    mockUseConfig.mockReturnValue({ data: undefined, isLoading: false, error: new Error('x'), mutate: jest.fn(), isValidating: false } as ReturnType<typeof useConfig>);
+    rerender(<ConfigPage />);
+    expect(screen.getByTestId('config-error')).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/app/operator/config/page.tsx
+++ b/dashboard/token-dashboard/app/operator/config/page.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+import React, { useState } from 'react';
+import { useConfig, useConfigAudit } from '@/lib/hooks';
+import { postConfigSet } from '@/lib/operator-api';
+import type { ConfigEntryRow, ConfigSetRequest } from '@/lib/types';
+
+const CATEGORY_ORDER = ['intelligence', 'dispatch', 'gate'];
+const CATEGORY_LABEL: Record<string, string> = {
+  intelligence: 'Intelligence',
+  dispatch: 'Dispatch',
+  gate: 'Gates',
+};
+
+const PANEL = 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)';
+
+function isOn(row: ConfigEntryRow): boolean {
+  return row.value === '1';
+}
+
+type Msg = { kind: 'ok' | 'err'; text: string } | null;
+
+function ConfigRow({
+  row,
+  busy,
+  edit,
+  onEdit,
+  onApply,
+}: {
+  row: ConfigEntryRow;
+  busy: boolean;
+  edit: string | undefined;
+  onEdit: (v: string) => void;
+  onApply: (value: string) => void;
+}) {
+  const locked = row.planned || !row.writable_from_ui;
+  const current = row.value ?? '';
+  return (
+    <div
+      data-testid={`config-row-${row.key}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'space-between',
+        gap: 12,
+        padding: '10px 12px',
+        borderRadius: 8,
+        background: PANEL,
+        border: '1px solid rgba(255,255,255,0.08)',
+      }}
+    >
+      <div style={{ display: 'flex', flexDirection: 'column', gap: 3, minWidth: 0 }}>
+        <div style={{ display: 'flex', alignItems: 'center', gap: 8 }}>
+          <code style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)' }}>{row.key}</code>
+          {row.is_default ? (
+            <span data-testid={`config-default-${row.key}`} style={{ fontSize: 9, color: 'var(--color-muted)', border: '1px solid rgba(255,255,255,0.12)', borderRadius: 5, padding: '1px 5px' }}>
+              default
+            </span>
+          ) : (
+            <span data-testid={`config-changed-${row.key}`} style={{ fontSize: 9, color: 'var(--color-accent, #f97316)', border: '1px solid var(--color-accent, #f97316)', borderRadius: 5, padding: '1px 5px' }}>
+              modified
+            </span>
+          )}
+          {row.requires_approval && (
+            <span style={{ fontSize: 9, color: 'var(--color-warning, #facc15)', border: '1px solid var(--color-warning, #facc15)', borderRadius: 5, padding: '1px 5px' }}>
+              approval
+            </span>
+          )}
+          {row.planned && (
+            <span style={{ fontSize: 9, color: 'var(--color-muted)', border: '1px dashed rgba(255,255,255,0.2)', borderRadius: 5, padding: '1px 5px' }}>
+              planned
+            </span>
+          )}
+        </div>
+        <span style={{ fontSize: 11, color: 'var(--color-muted)', overflow: 'hidden', textOverflow: 'ellipsis' }}>{row.description}</span>
+      </div>
+
+      <div style={{ flexShrink: 0 }}>
+        {locked ? (
+          <span data-testid={`config-locked-${row.key}`} style={{ fontSize: 11, color: 'var(--color-muted)' }}>
+            {row.planned ? 'not yet available' : 'read-only'} · {current || '—'}
+          </span>
+        ) : row.type === 'bool' ? (
+          <button
+            data-testid={`config-toggle-${row.key}`}
+            disabled={busy}
+            onClick={() => onApply(isOn(row) ? '0' : '1')}
+            style={{
+              cursor: busy ? 'wait' : 'pointer',
+              fontSize: 11,
+              fontWeight: 700,
+              padding: '4px 12px',
+              borderRadius: 6,
+              border: `1px solid ${isOn(row) ? 'var(--color-success, #50fa7b)' : 'rgba(255,255,255,0.2)'}`,
+              color: isOn(row) ? 'var(--color-success, #50fa7b)' : 'var(--color-muted)',
+              background: 'transparent',
+            }}
+          >
+            {isOn(row) ? 'ON' : 'OFF'}
+          </button>
+        ) : (
+          <div style={{ display: 'flex', gap: 6, alignItems: 'center' }}>
+            <input
+              data-testid={`config-input-${row.key}`}
+              value={edit ?? current}
+              onChange={(e) => onEdit(e.target.value)}
+              style={{ fontSize: 11, padding: '4px 8px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.2)', background: 'rgba(0,0,0,0.3)', color: 'var(--color-foreground)', width: 120 }}
+            />
+            <button
+              data-testid={`config-save-${row.key}`}
+              disabled={busy}
+              onClick={() => onApply(edit ?? current)}
+              style={{ cursor: busy ? 'wait' : 'pointer', fontSize: 11, fontWeight: 700, padding: '4px 10px', borderRadius: 6, border: '1px solid var(--color-accent, #f97316)', color: 'var(--color-accent, #f97316)', background: 'transparent' }}
+            >
+              Save
+            </button>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default function ConfigPage() {
+  const { data, isLoading, error, mutate } = useConfig();
+  const auditQuery = useConfigAudit();
+  const [pending, setPending] = useState<{ row: ConfigEntryRow; value: string } | null>(null);
+  const [approvalId, setApprovalId] = useState('');
+  const [busyKey, setBusyKey] = useState<string | null>(null);
+  const [msg, setMsg] = useState<Msg>(null);
+  const [auditOpen, setAuditOpen] = useState(false);
+  const [edits, setEdits] = useState<Record<string, string>>({});
+
+  async function submit(row: ConfigEntryRow, value: string, approval_id?: string) {
+    setBusyKey(row.key);
+    setMsg(null);
+    try {
+      const req: ConfigSetRequest = { key: row.key, value, ...(approval_id ? { approval_id } : {}) };
+      const res = await postConfigSet(req);
+      if (res.status === 'success') {
+        setMsg({ kind: 'ok', text: `${row.key} → ${res.new_value}` });
+        mutate();
+        auditQuery.mutate();
+      } else {
+        setMsg({ kind: 'err', text: res.message || 'change rejected' });
+      }
+    } catch (e) {
+      setMsg({ kind: 'err', text: e instanceof Error ? e.message : 'request failed' });
+    } finally {
+      setBusyKey(null);
+    }
+  }
+
+  function onApply(row: ConfigEntryRow, value: string) {
+    if (row.requires_approval) {
+      setPending({ row, value });
+      setApprovalId('');
+    } else {
+      submit(row, value);
+    }
+  }
+
+  if (isLoading) {
+    return <div data-testid="config-loading" style={{ padding: 24, color: 'var(--color-muted)' }}>Loading config…</div>;
+  }
+  if (error || !data) {
+    return <div data-testid="config-error" style={{ padding: 24, color: 'var(--color-danger, #ff5555)' }}>Failed to load config.</div>;
+  }
+
+  const byCat: Record<string, ConfigEntryRow[]> = {};
+  for (const r of data.config) (byCat[r.category] ??= []).push(r);
+  const categories = [
+    ...CATEGORY_ORDER.filter((c) => byCat[c]),
+    ...Object.keys(byCat).filter((c) => !CATEGORY_ORDER.includes(c)),
+  ];
+  const auditRows = auditQuery.data?.audit ?? [];
+
+  return (
+    <div data-testid="config-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Config</h1>
+        <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>{data.project_id}</span>
+        <button
+          data-testid="config-audit-toggle"
+          onClick={() => setAuditOpen((v) => !v)}
+          style={{ marginLeft: 'auto', cursor: 'pointer', fontSize: 11, fontWeight: 700, padding: '4px 12px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.2)', color: 'var(--color-foreground)', background: 'transparent' }}
+        >
+          {auditOpen ? 'Hide audit' : 'Audit log'}
+        </button>
+      </div>
+
+      {msg && (
+        <div
+          data-testid="config-msg"
+          style={{ fontSize: 12, color: msg.kind === 'ok' ? 'var(--color-success, #50fa7b)' : 'var(--color-danger, #ff5555)' }}
+        >
+          {msg.text}
+        </div>
+      )}
+
+      <div style={{ display: 'flex', gap: 16, alignItems: 'flex-start' }}>
+        <div style={{ flex: 1, display: 'flex', flexDirection: 'column', gap: 16, minWidth: 0 }}>
+          {categories.map((cat) => (
+            <section key={cat} data-testid={`config-section-${cat}`} style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+              <div style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)', borderBottom: '2px solid rgba(107,138,230,0.6)', paddingBottom: 6 }}>
+                {CATEGORY_LABEL[cat] ?? cat} <span style={{ color: 'var(--color-muted)', fontWeight: 400 }}>({byCat[cat].length})</span>
+              </div>
+              {byCat[cat].map((row) => (
+                <ConfigRow
+                  key={row.key}
+                  row={row}
+                  busy={busyKey === row.key}
+                  edit={edits[row.key]}
+                  onEdit={(v) => setEdits((e) => ({ ...e, [row.key]: v }))}
+                  onApply={(value) => onApply(row, value)}
+                />
+              ))}
+            </section>
+          ))}
+        </div>
+
+        {auditOpen && (
+          <aside
+            data-testid="config-audit-drawer"
+            style={{ width: 320, flexShrink: 0, display: 'flex', flexDirection: 'column', gap: 8, padding: 12, borderRadius: 10, background: PANEL, border: '1px solid rgba(255,255,255,0.08)' }}
+          >
+            <div style={{ fontSize: 12, fontWeight: 700 }}>Recent changes</div>
+            {auditRows.length === 0 ? (
+              <div data-testid="config-audit-empty" style={{ fontSize: 11, color: 'var(--color-muted)' }}>No changes recorded.</div>
+            ) : (
+              auditRows.map((a) => (
+                <div key={a.event_id} data-testid={`config-audit-row-${a.event_id}`} style={{ fontSize: 11, borderBottom: '1px solid rgba(255,255,255,0.06)', paddingBottom: 6 }}>
+                  <code style={{ fontWeight: 700 }}>{a.config_key}</code>
+                  <span style={{ color: 'var(--color-muted)' }}> {a.old_value ?? '∅'} → {a.new_value}</span>
+                  <div style={{ color: 'var(--color-muted)' }}>{a.changed_by}{a.approval_id ? ` · ${a.approval_id}` : ''} · {a.changed_at}</div>
+                </div>
+              ))
+            )}
+          </aside>
+        )}
+      </div>
+
+      {pending && (
+        <div
+          data-testid="config-approval-modal"
+          style={{ position: 'fixed', inset: 0, background: 'rgba(0,0,0,0.6)', display: 'flex', alignItems: 'center', justifyContent: 'center', zIndex: 50 }}
+        >
+          <div style={{ width: 380, padding: 20, borderRadius: 12, background: 'rgba(10,20,48,0.98)', border: '1px solid rgba(255,255,255,0.12)', display: 'flex', flexDirection: 'column', gap: 12 }}>
+            <div style={{ fontSize: 14, fontWeight: 700 }}>Approval required</div>
+            <div style={{ fontSize: 12, color: 'var(--color-muted)' }}>
+              <code style={{ color: 'var(--color-foreground)' }}>{pending.row.key}</code> → <strong>{pending.value}</strong>. This flag changes governed behaviour; enter an approval reference to proceed.
+            </div>
+            <input
+              data-testid="config-approval-input"
+              value={approvalId}
+              placeholder="approval id / reference"
+              onChange={(e) => setApprovalId(e.target.value)}
+              style={{ fontSize: 12, padding: '6px 10px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.2)', background: 'rgba(0,0,0,0.3)', color: 'var(--color-foreground)' }}
+            />
+            <div style={{ display: 'flex', gap: 8, justifyContent: 'flex-end' }}>
+              <button
+                data-testid="config-approval-cancel"
+                onClick={() => setPending(null)}
+                style={{ cursor: 'pointer', fontSize: 11, fontWeight: 700, padding: '6px 14px', borderRadius: 6, border: '1px solid rgba(255,255,255,0.2)', color: 'var(--color-muted)', background: 'transparent' }}
+              >
+                Cancel
+              </button>
+              <button
+                data-testid="config-approval-confirm"
+                disabled={!approvalId.trim()}
+                onClick={() => {
+                  const p = pending;
+                  setPending(null);
+                  submit(p.row, p.value, approvalId.trim());
+                }}
+                style={{ cursor: approvalId.trim() ? 'pointer' : 'not-allowed', fontSize: 11, fontWeight: 700, padding: '6px 14px', borderRadius: 6, border: '1px solid var(--color-warning, #facc15)', color: 'var(--color-warning, #facc15)', background: 'transparent', opacity: approvalId.trim() ? 1 : 0.5 }}
+              >
+                Confirm change
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse, Map } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse, Map, SlidersHorizontal } from 'lucide-react';
 
 const DOMAINS = ['All', 'Coding', 'Analytics'] as const;
 type Domain = typeof DOMAINS[number];
@@ -12,6 +12,7 @@ const OPERATOR_NAV = [
   { href: '/operator/open-items', label: 'Open Items', icon: AlertTriangle },
   { href: '/operator/kanban', label: 'Kanban Board', icon: Kanban },
   { href: '/operator/planning', label: 'Planning', icon: Map },
+  { href: '/operator/config', label: 'Config', icon: SlidersHorizontal },
   { href: '/operator/governance', label: 'Governance', icon: ShieldAlert },
   { href: '/operator/intelligence', label: 'Intelligence', icon: Brain },
   { href: '/operator/dispatches', label: 'Dispatches', icon: ClipboardList },

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -11,6 +11,8 @@ import {
   fetchGovernanceDigest,
   fetchSystemHealth,
   fetchPlanning,
+  fetchConfig,
+  fetchConfigAudit,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -31,6 +33,7 @@ import type {
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
   GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
+  ConfigEnvelope, ConfigAuditEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
@@ -182,6 +185,22 @@ export function usePlanning() {
   return useSWR<PlanningEnvelope>(
     'operator-planning',
     fetchPlanning,
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function useConfig() {
+  return useSWR<ConfigEnvelope>(
+    'operator-config',
+    fetchConfig,
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function useConfigAudit(key?: string) {
+  return useSWR<ConfigAuditEnvelope>(
+    key ? `operator-config-audit:${key}` : 'operator-config-audit',
+    () => fetchConfigAudit(key ? { key } : undefined),
     { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -13,6 +13,10 @@ import type {
   GovernanceDigestEnvelope,
   SystemHealthEnvelope,
   PlanningEnvelope,
+  ConfigEnvelope,
+  ConfigSetRequest,
+  ConfigSetResponse,
+  ConfigAuditEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
   PatternsResponse,
@@ -133,6 +137,21 @@ export function fetchSystemHealth(): Promise<SystemHealthEnvelope> {
 
 export function fetchPlanning(): Promise<PlanningEnvelope> {
   return get(`${BASE}/planning`);
+}
+
+export function fetchConfig(): Promise<ConfigEnvelope> {
+  return get(`${BASE}/config`);
+}
+
+export function postConfigSet(req: ConfigSetRequest): Promise<ConfigSetResponse> {
+  return post(`${BASE}/config/set`, req as unknown as Record<string, unknown>);
+}
+
+export function fetchConfigAudit(params?: { limit?: number; key?: string }): Promise<ConfigAuditEnvelope> {
+  const p: Record<string, string> = {};
+  if (params?.limit != null) p.limit = String(params.limit);
+  if (params?.key) p.key = params.key;
+  return get(`${BASE}/config/audit`, Object.keys(p).length ? p : undefined);
 }
 
 export function fetchReports(params?: {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -235,6 +235,67 @@ export interface GateToggleResponse {
   timestamp: string;
 }
 
+// ===== Config Control-Plane Types =====
+// Mirrors config_registry.all_effective() rows + the config DAO/API contract.
+
+export interface ConfigEntryRow {
+  key: string;
+  type: 'bool' | 'string' | 'enum';
+  category: string; // 'intelligence' | 'dispatch' | 'gate'
+  description: string;
+  default: string;
+  value: string | null;
+  is_default: boolean;
+  writable_from_ui: boolean;
+  requires_approval: boolean;
+  planned: boolean;
+}
+
+export interface ConfigEnvelope {
+  project_id: string;
+  config: ConfigEntryRow[];
+  queried_at: string;
+  error?: string;
+}
+
+export interface ConfigSetRequest {
+  key: string;
+  value: string;
+  actor?: string;
+  approval_id?: string;
+}
+
+export interface ConfigSetResponse {
+  status: 'success' | 'failed';
+  action?: string;
+  project_id?: string;
+  key?: string;
+  old_value?: string | null;
+  new_value?: string;
+  event_id?: string;
+  actor?: string;
+  approval_id?: string | null;
+  message?: string;
+  timestamp: string;
+}
+
+export interface ConfigAuditRow {
+  config_key: string;
+  old_value: string | null;
+  new_value: string;
+  changed_by: string;
+  changed_at: string;
+  approval_id: string | null;
+  event_id: string;
+}
+
+export interface ConfigAuditEnvelope {
+  project_id: string;
+  audit: ConfigAuditRow[];
+  queried_at: string;
+  degraded?: boolean;
+}
+
 // ===== Kanban Board Types =====
 
 export interface KanbanCard {

--- a/scripts/benchmark/field-tests/tasks/t1_trivial/01_yaml_config_refactor/seed/config/worker_queues.yaml
+++ b/scripts/benchmark/field-tests/tasks/t1_trivial/01_yaml_config_refactor/seed/config/worker_queues.yaml
@@ -1,0 +1,5 @@
+queues:
+  - default
+  - scoring
+  - ingestion
+  - indexing


### PR DESCRIPTION
## Summary
**PR 5/5 — completes the operator config control-plane.** The Next.js UI over `/api/operator/config`
(#950), closing the chain: registry (#947) → DAO (#949) → API (#950) → **this page**. Operators can
now flip scout/tagger/gate toggles per-project from the dashboard, with approval gating on governed
flags and a full audit trail.

## Changes
**`dashboard/token-dashboard/`**
- `lib/types.ts` — `ConfigEntryRow` / `ConfigEnvelope` / `ConfigSetRequest` / `ConfigSetResponse` /
  `ConfigAuditRow` / `ConfigAuditEnvelope` (mirror `config_registry.all_effective` + the #950 contract).
- `lib/operator-api.ts` — `fetchConfig` / `postConfigSet` / `fetchConfigAudit`.
- `lib/hooks.ts` — `useConfig` / `useConfigAudit` (useSWR, 30s).
- `app/operator/config/page.tsx` — flags grouped by category (intelligence/dispatch/gate); per flag a
  **bool toggle** / **string input** / **locked badge** (planned or `!writable_from_ui`). A
  `requires_approval` flag opens an **approval modal** (confirm disabled until a non-empty
  approval_id) before POSTing — no bypass via the direct path. **Audit drawer** lists recent changes.
  Loading/error states + a success/failure banner.
- `components/sidebar.tsx` — a "Config" nav link.
- `__tests__/config-page.test.tsx` (7) — sections, direct toggle posts flipped value, approval modal
  flow + cancel, string save, audit drawer, loading/error.

**`.gitignore`** — anchored `config/` → `/config/` (root only). The blanket rule was matching **any**
nested `config/` dir, masking both the new app route and a benchmark seed fixture.

**`scripts/benchmark/.../01_yaml_config_refactor/seed/config/worker_queues.yaml`** — the seed fixture
the anchor unmasked. The task's `seed/worker_runner.py` references `config/worker_queues.yaml`, so it
belongs tracked (latent masking bug, fixed as a consequence of the anchor).

## Verification
- `npx tsc --noEmit` on source → clean (only the test file shows the known local jest-types noise)
- **kimi-diff-gate: PASS** — type fidelity vs the Python contract, no approval-modal bypass, no PII in
  the audit drawer, `.gitignore` anchor correct.
- Frontend jest runs in CI (no local `jest-environment-jsdom`); CI's Dashboard TS Lint + jest verify.

## Open Items
None. **This completes the P0 config control-plane (all 5 PRs).**

🤖 Generated with [Claude Code](https://claude.com/claude-code)