### PR TITLE
feat(config): runtime honours UI-set config — gate/dispatch flags (P0 PR 6b)

### DIFF
--- a/scripts/headless_trigger.py
+++ b/scripts/headless_trigger.py
@@ -211,7 +211,8 @@ def _haiku_enabled() -> bool:
 
 
 def _autopilot_enabled() -> bool:
-    return os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("0", "", "false", "False")
+    import config_runtime
+    return config_runtime.get("VNX_ROADMAP_AUTOPILOT") not in ("0", "", "false", "False")
 
 
 def _maybe_autopilot_tick(state_dir: Path, dry_run: bool) -> None:

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -80,7 +80,9 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "Require the wiring gate.", approval=True),
     "VNX_USE_CENTRAL_DB": _e(
         "VNX_USE_CENTRAL_DB", "enum", "", "dispatch",
-        "Central-DB read mode (''=per-project | '1'=central | 'shadow').", approval=True),
+        "Central-DB read mode (''=per-project | '1'=central | 'shadow'). Process-start routing — "
+        "env-only, surfaced read-only: live-toggling would split reads across DBs mid-process.",
+        writable=False),
     "VNX_USE_FEDERATION": _e(
         "VNX_USE_FEDERATION", "bool", "0", "intelligence",
         "Cross-project intelligence federation (NOT yet implemented).",

--- a/scripts/lib/gate_request_handler.py
+++ b/scripts/lib/gate_request_handler.py
@@ -52,7 +52,8 @@ class GateRequestHandlerMixin:
         return os.environ.get("VNX_CLAUDE_GITHUB_REVIEW_ENABLED", "0") == "1" and shutil.which("gh") is not None
 
     def _ci_gate_available(self) -> bool:
-        return os.environ.get("VNX_CI_GATE_REQUIRED", "0") == "1" and shutil.which("gh") is not None
+        import config_runtime
+        return config_runtime.get_bool("VNX_CI_GATE_REQUIRED") and shutil.which("gh") is not None
 
     def _dispatch_one_review(
         self,

--- a/scripts/lib/wiring_gate.py
+++ b/scripts/lib/wiring_gate.py
@@ -267,7 +267,8 @@ def check_pr_wiring(pr_number: int, *, state_dir: Optional[Path] = None) -> Wiri
     must catch this and mark the gate outcome as FAILED, never PASS with 0 checks.
     """
     skip_list = _load_skip_list(state_dir)
-    required = os.environ.get("VNX_WIRING_GATE_REQUIRED", "0") == "1"
+    import config_runtime
+    required = config_runtime.get_bool("VNX_WIRING_GATE_REQUIRED")
 
     diff_text = _get_pr_diff(pr_number)
     if not diff_text:

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -11,7 +11,6 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 import re
 import secrets
 import shutil
@@ -34,7 +33,8 @@ from gate_report_generator import GateReportGeneratorMixin
 
 def _build_default_review_stack() -> List[str]:
     stack = ["gemini_review", "codex_gate", "claude_github_optional"]
-    if os.environ.get("VNX_CI_GATE_REQUIRED", "0") == "1":
+    import config_runtime
+    if config_runtime.get_bool("VNX_CI_GATE_REQUIRED"):
         stack.append("ci_gate")
     return stack
 

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -687,7 +687,8 @@ Implement the minimum blocking fix required before the roadmap may advance.
         ADR-007: project_id-scoped via existing primitives — no extra scoping needed.
         ADR-018 Rule 2: single-claim, no loop. Caller (silence_watchdog) schedules repetition.
         """
-        if os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("1", "true", "True"):
+        import config_runtime
+        if config_runtime.get("VNX_ROADMAP_AUTOPILOT") not in ("1", "true", "True"):
             return {"status": "disabled", "reason": "VNX_ROADMAP_AUTOPILOT not set"}
 
         state = self.load_state()
@@ -808,7 +809,8 @@ Implement the minimum blocking fix required before the roadmap may advance.
 
         Returns {"status": "disabled"} when VNX_ROADMAP_AUTOPILOT is unset/off.
         """
-        if os.environ.get("VNX_ROADMAP_AUTOPILOT", "0") not in ("1", "true", "True"):
+        import config_runtime
+        if config_runtime.get("VNX_ROADMAP_AUTOPILOT") not in ("1", "true", "True"):
             return {"status": "disabled", "reason": "VNX_ROADMAP_AUTOPILOT not set"}
 
         from track_reconciler import reconcile_all_tracks  # noqa: PLC0415

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -60,6 +60,12 @@ def test_federation_is_planned_and_not_writable():
     assert fed.writable_from_ui is False
 
 
+def test_central_db_is_env_only_routing():
+    # VNX_USE_CENTRAL_DB is a process-start routing decision, surfaced read-only — never UI-writable
+    # (live-toggling would split reads across DBs mid-process).
+    assert cr.CONFIG_REGISTRY["VNX_USE_CENTRAL_DB"].writable_from_ui is False
+
+
 # ---------------------------------------------------------------------------
 # Resolution precedence
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
**Completes the runtime-honour wiring** (6a #952 did the fail-safe intelligence toggles). Migrates the
**gate flags** to the `config_runtime` façade so a dashboard toggle is honoured by the running
gate/dispatch path, and makes a deliberate safety call on the central-db routing flag.
**Behaviour-preserving**: with no UI/DB value, every read-site resolves to exactly the old env/default.

## Changes
Migrations (each preserves the EXACT comparison; `config_runtime.get/get_bool` autowire the DB
resolver, fail-soft — see #952):
- **`VNX_CI_GATE_REQUIRED`** — `review_gate_manager._build_default_review_stack` +
  `gate_request_handler._ci_gate_available` → `get_bool`.
- **`VNX_WIRING_GATE_REQUIRED`** — `wiring_gate` → `get_bool`.
- **`VNX_ROADMAP_AUTOPILOT`** — `roadmap_manager` ×2 (`not in ("1","true","True")`) +
  `headless_trigger._autopilot_enabled` (`not in ("0","","false","False")`). The two truthy-sets
  differ by file and are preserved **verbatim** via `config_runtime.get()`.
- Dropped now-dead `import os` from `review_gate_manager`.

**Deliberate design call — `VNX_USE_CENTRAL_DB` stays ENV-ONLY (not migrated).** It selects the DB
read mode (`''`=per-project | `'1'`=central | `'shadow'`) at ~10 sites and is a **process-start**
routing decision — live-toggling it would split reads across different DBs mid-run (a consistency
hazard). Its read-sites stay on env; the registry now marks it `writable_from_ui=False` (surfaced
**read-only** in the UI; `api_config.set` already rejects non-writable keys → 403; the page renders it
locked). This corrects #947 which had it writable.

## Verification
- **kimi-diff-gate: PASS** — per-read-site behaviour-preservation (incl. the two distinct autopilot
  truthy-sets), the central-db env-only decision consistent across registry/API/UI, fail-soft.
- Config suites (registry/runtime/store/dao/api) + gate/roadmap/autopilot suites → green; silent-except
  scanner clean. The pre-existing `test_ci_gate` (closure_verifier) + `test_strategy_roadmap` failures
  are on origin/main (stash-baseline verified), not this diff.

## Open Items
None. **This completes PR 6 — the config control-plane is now end-to-end: UI → DB → audit → the
runtime acts on it.** (central-db remains a deploy-time env setting by design.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)