### PR TITLE
fix(dashboard): loopback bind + CSRF/token guard on mutations (audit critical #1)

### DIFF
--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -21,6 +21,7 @@ import json
 import os
 import socket
 import subprocess
+import hmac
 import sys
 from functools import partial
 from http import HTTPStatus
@@ -202,9 +203,46 @@ def _json_response(handler: "DashboardHandler", status: HTTPStatus, payload_obj:
     handler.send_response(status)
     handler.send_header("Content-Type", "application/json")
     handler.send_header("Content-Length", str(len(payload)))
-    handler.send_header("Access-Control-Allow-Origin", "*")
+    # No blanket Access-Control-Allow-Origin: the dashboard serves its own UI same-origin. A wildcard
+    # ACAO let any web page read these responses; an explicit allowlist can be added via env if needed.
     handler.end_headers()
     handler.wfile.write(payload)
+
+
+# --- Mutation auth (audit critical #1) ---------------------------------------
+# The dashboard exposes process-control + governance-mutation POSTs. Default-bind is loopback
+# (main()), and every mutating POST is guarded below: cross-origin requests are rejected (CSRF), and
+# a shared-secret token is required when one is configured or when bound to a non-loopback address.
+_LOOPBACK_HOSTS = frozenset({"127.0.0.1", "::1", "localhost"})
+_LOOPBACK_BIND = True  # set in main() from the resolved bind address
+_DASHBOARD_TOKEN = os.environ.get("VNX_DASHBOARD_TOKEN", "")
+
+
+def _bind_is_loopback(bind: str) -> bool:
+    return bind in _LOOPBACK_HOSTS
+
+
+def _origin_same_site(handler: "DashboardHandler") -> bool:
+    """True when the request has no Origin (curl/native client) or its host matches the request Host
+    (same-origin). Blocks a cross-origin page from POSTing to the dashboard (CSRF)."""
+    origin = handler.headers.get("Origin")
+    if not origin:
+        return True
+    host = handler.headers.get("Host", "")
+    return bool(host) and urlsplit(origin).netloc == host
+
+
+def _mutation_forbidden(handler: "DashboardHandler") -> "str | None":
+    """Return an error string if a mutating request must be refused, else None. Guards every POST."""
+    if not _origin_same_site(handler):
+        return "cross-origin request rejected"
+    if not _LOOPBACK_BIND and not _DASHBOARD_TOKEN:
+        return "mutation endpoints are disabled on a non-loopback bind without VNX_DASHBOARD_TOKEN"
+    if _DASHBOARD_TOKEN:
+        provided = handler.headers.get("X-VNX-Dashboard-Token", "")
+        if not hmac.compare_digest(provided, _DASHBOARD_TOKEN):
+            return "missing or invalid dashboard token"
+    return None
 
 
 class DashboardHandler(SimpleHTTPRequestHandler):
@@ -504,6 +542,13 @@ class DashboardHandler(SimpleHTTPRequestHandler):
     def do_POST(self) -> None:
         parsed_path = unquote(urlsplit(self.path).path)
 
+        # Audit critical #1: guard every mutating POST (CSRF + token). Loopback default bind makes
+        # the token optional locally; a non-loopback bind requires it.
+        _auth_err = _mutation_forbidden(self)
+        if _auth_err is not None:
+            _json_response(self, HTTPStatus.FORBIDDEN, {"error": "forbidden", "reason": _auth_err})
+            return
+
         # /api/jump/{terminal} — switch tmux focus to terminal
         if parsed_path.startswith("/api/jump/"):
             terminal_id = parsed_path[len("/api/jump/"):]
@@ -676,17 +721,33 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
 
 def main() -> None:
+    global _LOOPBACK_BIND, _DASHBOARD_TOKEN
     port = int(os.environ.get("PORT", "4173"))
+    # Audit critical #1: default to loopback. The old all-interfaces bind exposed process-control +
+    # governance mutations to the LAN. Opt into remote with VNX_DASHBOARD_BIND (and a token).
+    bind = os.environ.get("VNX_DASHBOARD_BIND", "127.0.0.1")
+    _LOOPBACK_BIND = _bind_is_loopback(bind)
+    _DASHBOARD_TOKEN = os.environ.get("VNX_DASHBOARD_TOKEN", "")
 
     # Serve from `.claude/vnx-system` regardless of where the script is launched from.
     service_dir = Path(__file__).resolve().parents[1]
     handler = partial(DashboardHandler, directory=str(service_dir))
 
-    server = DualStackHTTPServer(("::", port), handler)
+    # IPv6 bind forms (``::``, ``::1``) use the dual-stack server; IPv4 forms use the plain server.
+    if ":" in bind:
+        server: ThreadingHTTPServer = DualStackHTTPServer((bind, port), handler)
+    else:
+        server = ThreadingHTTPServer((bind, port), handler)
+
     print(
-        f"Serving dashboard from {service_dir} on http://localhost:{port} (dashboard at /dashboard/index.html)",
+        f"Serving dashboard from {service_dir} on http://{bind}:{port}/dashboard/index.html",
         flush=True,
     )
+    if not _LOOPBACK_BIND:
+        if _DASHBOARD_TOKEN:
+            print(f"[security] non-loopback bind {bind}: mutations require X-VNX-Dashboard-Token header", flush=True)
+        else:
+            print(f"[security] WARNING: non-loopback bind {bind} without VNX_DASHBOARD_TOKEN — mutation endpoints are DISABLED", flush=True)
     try:
         server.serve_forever()
     finally:

--- a/tests/test_dashboard_security.py
+++ b/tests/test_dashboard_security.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Tests for the dashboard mutation-auth guard (audit critical #1).
+
+Dispatch-ID: 20260627-audit-dashboard-auth
+
+Covers the loopback-bind classifier, the same-origin (CSRF) check, and _mutation_forbidden across
+loopback/non-loopback + token-configured/absent + same/cross-origin.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "dashboard"))
+
+import serve_dashboard as sd  # noqa: E402
+
+
+class _FakeHandler:
+    """Minimal stand-in: the guard only touches handler.headers.get(...)."""
+    def __init__(self, headers=None):
+        self.headers = headers or {}
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    orig = (sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN)
+    yield
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = orig
+
+
+# ---------------------------------------------------------------------------
+# bind classifier
+# ---------------------------------------------------------------------------
+
+def test_bind_is_loopback():
+    assert sd._bind_is_loopback("127.0.0.1") is True
+    assert sd._bind_is_loopback("::1") is True
+    assert sd._bind_is_loopback("localhost") is True
+    assert sd._bind_is_loopback("0.0.0.0") is False
+    assert sd._bind_is_loopback("::") is False
+    assert sd._bind_is_loopback("192.168.1.5") is False
+
+
+# ---------------------------------------------------------------------------
+# same-origin / CSRF
+# ---------------------------------------------------------------------------
+
+def test_origin_same_site():
+    assert sd._origin_same_site(_FakeHandler({})) is True  # no Origin (curl)
+    assert sd._origin_same_site(_FakeHandler({"Origin": "http://127.0.0.1:4173", "Host": "127.0.0.1:4173"})) is True
+    assert sd._origin_same_site(_FakeHandler({"Origin": "http://evil.example", "Host": "127.0.0.1:4173"})) is False
+
+
+# ---------------------------------------------------------------------------
+# _mutation_forbidden
+# ---------------------------------------------------------------------------
+
+def test_loopback_no_token_same_origin_allowed():
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = True, ""
+    assert sd._mutation_forbidden(_FakeHandler({})) is None
+
+
+def test_cross_origin_rejected_even_on_loopback():
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = True, ""
+    err = sd._mutation_forbidden(_FakeHandler({"Origin": "http://evil.example", "Host": "127.0.0.1:4173"}))
+    assert err and "cross-origin" in err
+
+
+def test_non_loopback_without_token_disables_mutations():
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = False, ""
+    err = sd._mutation_forbidden(_FakeHandler({}))
+    assert err and "VNX_DASHBOARD_TOKEN" in err
+
+
+def test_token_required_when_configured():
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = True, "s3cret"
+    assert sd._mutation_forbidden(_FakeHandler({})) is not None  # missing token
+    assert sd._mutation_forbidden(_FakeHandler({"X-VNX-Dashboard-Token": "wrong"})) is not None
+    assert sd._mutation_forbidden(_FakeHandler({"X-VNX-Dashboard-Token": "s3cret"})) is None
+
+
+def test_non_loopback_with_valid_token_allowed():
+    sd._LOOPBACK_BIND, sd._DASHBOARD_TOKEN = False, "s3cret"
+    assert sd._mutation_forbidden(_FakeHandler({"X-VNX-Dashboard-Token": "s3cret"})) is None
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Fixes the audit's single **CRITICAL** (`audit-sec-dashboard-auth`): the operator dashboard was an
unauthenticated remote-control plane bound to **all interfaces** with `Access-Control-Allow-Origin: *`
on every mutation. `POST /api/restart-process` pkills+respawns the daemon fleet and `/api/operator/*`
flips governance — any LAN host, or any web page the operator visited, could take over the fleet.

## Changes (`dashboard/serve_dashboard.py`)
- **Default loopback bind** — `VNX_DASHBOARD_BIND` (default `127.0.0.1`) replaces `("::", port)`. IPv6
  forms use the dual-stack server. Banner prints the real bind; a non-loopback bind warns and (without
  a token) disables mutations.
- **CSRF + token guard on every mutating POST** — `do_POST` calls `_mutation_forbidden(self)` before
  any side-effect: rejects cross-origin (Origin host ≠ Host) and requires a shared-secret token
  (`X-VNX-Dashboard-Token`, `hmac.compare_digest`) when configured or on a non-loopback bind. Covers
  restart-process / jump / operator config-set / gate-toggle uniformly.
- **Dropped blanket `Access-Control-Allow-Origin: *`** (the dashboard is same-origin).

## Verification
- `tests/test_dashboard_security.py` (7) — bind classifier, same-origin/CSRF, the `_mutation_forbidden`
  matrix → all pass; compile + silent-except scanner clean.
- **kimi-diff-gate: PASS** — confirmed the guard is uniform (no mutating POST reaches a side-effect
  first), the CSRF model is sound, fail-closed on non-loopback-without-token, no GET/static bypass.
  codex lane flaked on spawn (stdin) — infra, not a REVISE; treated as flake.
- Default local operator path unchanged: loopback, no token, same-origin UI works.

## Open Items
None. Closes track `audit-sec-dashboard-auth`. A follow-up could add the token to the dashboard's own
fetch layer for remote deployments (out of scope here; loopback default needs none).

🤖 Generated with [Claude Code](https://claude.com/claude-code)