### PR TITLE
fix(install): missing pyyaml dep + pip-install docs (audit high #4,#5)

### DIFF
--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -6,8 +6,13 @@ are limited to the stable pip surface: `init`, `migrate`, `doctor`, `status`,
 
 ## Step 1: Install
 
+The package is not on PyPI yet — publishing is the final 1.0 ship gate. Until
+then, install from a checkout:
+
 ```bash
-python3 -m pip install vnx-orchestration
+git clone https://github.com/Vinix24/vnx-orchestration
+cd vnx-orchestration
+pip install -e .
 vnx version
 ```
 

--- a/docs/onboarding/ONBOARDING_GUIDE.md
+++ b/docs/onboarding/ONBOARDING_GUIDE.md
@@ -14,8 +14,13 @@ through `./bin/vnx` from a cloned `vnx-orchestration` repository.
 
 ### Step 1: Install
 
+The package is not on PyPI yet — publishing is the final 1.0 ship gate. Until
+then, install from a checkout:
+
 ```bash
-python3 -m pip install vnx-orchestration
+git clone https://github.com/Vinix24/vnx-orchestration
+cd vnx-orchestration
+pip install -e .
 vnx version
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "opentelemetry-sdk>=1.20",
     "opentelemetry-exporter-otlp>=1.20",
     "jinja2>=3.0",
+    "pyyaml>=6.0",
 ]
 
 # Full quality advisory/local-CI audit tools.


### PR DESCRIPTION
## Summary
Two install-path ship-blockers from the audit. Closes `audit-dep-pyyaml` + `audit-docs-pip-install`.

## Changes
- **`pyproject.toml`** — add `pyyaml>=6.0` to `dependencies`. Both `constraint_enforcer.py` modules
  `import yaml` in `_load_yaml` (run at dispatch pre-flight by the door); the omission killed the
  headline hello-world dispatch with `No module named 'yaml'` on a clean install. (#5)
- **`docs/QUICKSTART.md` + `docs/onboarding/ONBOARDING_GUIDE.md`** — Step 1 switched from
  `pip install vnx-orchestration` (fails, not on PyPI) to the checkout install + "not on PyPI yet"
  caveat, matching README. (#4)

## Verification
- **kimi-diff-gate: PASS** — pyyaml confirmed a genuine runtime dep, docs now agree with README, no pin conflict.
- `pyyaml` imports locally (6.0.2); Profile D pip-smoke installs it.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)