### PR TITLE
fix(dx): worker-CLI doctor probe + dispatch preflight + prereqs (audit high #6,#7,#8)

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,8 +72,17 @@ pip install -e .                          # editable install of the pip CLI
 vnx init                                  # scaffold a VNX project in the current dir
 vnx migrate                               # apply runtime DB migrations
 vnx doctor                                # environment and dependency checks
-vnx dispatch-agent --agent hello-world    # works via the examples/ fallback
+vnx dispatch-agent --agent hello-world    # needs a worker CLI (see Prerequisites)
 ```
+
+### Prerequisites
+
+VNX does not run models itself — it drives existing coding CLIs as subprocesses and governs the
+result. The default dispatch lane needs an **installed + authenticated `claude` CLI** on your PATH
+(other lanes: `codex`, `gemini`, `kimi`), and using it incurs that provider's subscription/credit
+usage. `vnx dispatch-agent` fails at spawn if no worker CLI is present — `vnx doctor` flags this with
+a `tool:worker-cli` warning. (Zero-key exploration of the governance flow is not currently shipped;
+the old replay demo was retired.)
 
 There are two binaries on purpose. The pip `vnx` covers the essentials (`init`, `migrate`, `doctor`, `status`, `dispatch-agent`, `track`, `pool`, `dream`). Checkout-only operator commands live behind `./bin/vnx`, including `gate-check` and `new-worktree`. When the package publishes, `pip install vnx-orchestration` replaces the clone step.
 

--- a/docs/onboarding/ONBOARDING_GUIDE.md
+++ b/docs/onboarding/ONBOARDING_GUIDE.md
@@ -24,6 +24,12 @@ pip install -e .
 vnx version
 ```
 
+**Prerequisites.** VNX drives existing coding CLIs as subprocesses — it does not run models itself.
+The default dispatch lane needs an **installed + authenticated `claude` CLI** on your PATH (other
+lanes: `codex`, `gemini`, `kimi`), and using it incurs that provider's subscription/credit usage.
+`vnx dispatch-agent` (Step 4) fails at spawn without one; `vnx doctor` flags this as a
+`tool:worker-cli` warning.
+
 ### Step 2: Initialize a Project
 
 ```bash

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -90,7 +90,7 @@ def _log(check: CheckResult) -> None:
 # ---------------------------------------------------------------------------
 
 REQUIRED_TOOLS = ["bash", "python3"]
-RECOMMENDED_TOOLS = ["rg", "jq", "tmux", "codex", "gemini", "sqlite3"]
+RECOMMENDED_TOOLS = ["rg", "jq", "tmux", "claude", "codex", "gemini", "kimi", "sqlite3"]
 
 
 def check_tools() -> List[CheckResult]:

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 """vnx dispatch-agent — dispatch a task to a named agent."""
 
+import shutil
 import sys
 import uuid
 from pathlib import Path
@@ -85,6 +86,17 @@ def vnx_dispatch_agent(args) -> int:
         )
         return 1
 
+    # Preflight (audit high #6): the default lane drives an installed, authenticated `claude` CLI as
+    # a subprocess. A missing binary otherwise surfaces only as a bare "status: failed".
+    if shutil.which("claude") is None:
+        print(
+            "Warning: 'claude' CLI not found on PATH. The default dispatch lane drives an installed, "
+            "authenticated `claude` CLI as a subprocess.\n"
+            "Install + authenticate it (or select a different lane via the model/provider), then "
+            "re-run. Run `vnx doctor` to check worker CLIs.",
+            file=sys.stderr,
+        )
+
     print(f"Dispatching to agent '{agent}' (dispatch_id={dispatch_id}) ...")
 
     # Route through the single-entry door (gated by VNX_SINGLE_ENTRY_DISPATCH / VNX_DISPATCH_LEGACY);
@@ -108,5 +120,13 @@ def vnx_dispatch_agent(args) -> int:
     status = "done" if success else "failed"
     print(f"dispatch_id : {dispatch_id}")
     print(f"status      : {status}")
+
+    if not success:
+        print(
+            "\nDispatch failed. A common cause is a missing or unauthenticated worker CLI. "
+            "Run `vnx doctor` to check worker CLIs,\nand see the dispatch log under "
+            ".vnx-data/ for the classified failure reason.",
+            file=sys.stderr,
+        )
 
     return 0 if success else 1

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -44,6 +44,19 @@ def _check_tools() -> list[Check]:
         status=PASS if shellcheck else WARN,
         detail=shellcheck or "shellcheck not found in PATH; shell lint checks will emit tool_unavailable warnings",
     ))
+    # Worker CLIs the dispatch lanes drive as subprocesses (audit high #7). WARN, not FAIL: an
+    # operator may use a non-Claude lane, but `vnx dispatch-agent` fails at spawn if NONE is present.
+    worker_clis = ("claude", "codex", "gemini", "kimi")
+    found_workers = [c for c in worker_clis if shutil.which(c)]
+    results.append(Check(
+        name="tool:worker-cli",
+        status=PASS if found_workers else WARN,
+        detail=(
+            f"found: {', '.join(found_workers)}" if found_workers
+            else "no worker CLI (claude/codex/gemini/kimi) on PATH; `vnx dispatch-agent` will fail at "
+                 "spawn. Install + authenticate the lane you use (default: claude)."
+        ),
+    ))
     return results
 
 


### PR DESCRIPTION
## Summary
First-run DX cluster. A new adopter ran `vnx dispatch-agent`, got a bare `status: failed` (no worker
CLI installed), and nothing flagged it. Closes `audit-dx-doctor-worker-cli` + `audit-dx-dispatch-preflight`
+ `audit-dx-prerequisites-docs`.

## Changes
- **`vnx_cli/commands/doctor.py`** (#7) — `_check_tools` adds a `tool:worker-cli` probe
  (claude/codex/gemini/kimi) as **WARN** (not FAIL; non-Claude lanes are valid). PASS if any worker is
  on PATH, WARN if none. `scripts/vnx_doctor.py` RECOMMENDED_TOOLS gains `claude`+`kimi` for consistency.
- **`vnx_cli/commands/dispatch_agent.py`** (#6) — a `shutil.which('claude')` preflight **warning**
  before dispatch, and on a failed door result an actionable message (`vnx doctor` + the dispatch log)
  instead of a reasonless "failed". Success path unchanged.
- **`README.md` + `docs/onboarding/ONBOARDING_GUIDE.md`** (#8) — a **Prerequisites** block (VNX drives
  existing coding CLIs as subprocesses; default lane needs an installed+authenticated `claude` CLI +
  incurs usage). Fixed the misleading "works via the examples/ fallback" comment.

## Verification
- **kimi-diff-gate: PASS** — WARN semantics correct, preflight is a warning (door may route elsewhere),
  failure message honest, success path unchanged.
- 27 doctor tests green; scanner clean.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)