### PR TITLE
fix(test): teach docs-command validation about the pip-only CLI surface (follow-up #958)

### DIFF
--- a/tests/test_docs_command_validation.py
+++ b/tests/test_docs_command_validation.py
@@ -150,7 +150,10 @@ class TestReadmeVsModeTiers:
         # Also check bin/vnx for commands README mentions
         vnx_path = REPO_ROOT / "bin" / "vnx"
         bin_cmds = _extract_bin_vnx_commands(vnx_path) if vnx_path.exists() else set()
-        all_known = mode_cmds | bin_cmds
+        # Pip-CLI-only commands (vnx_cli/main.py) — real commands the README documents that are not
+        # in the bash mode tiers or bin/vnx case branches (they route through `python -m vnx_cli.main`).
+        pip_surface = {"dispatch-agent", "version"}
+        all_known = mode_cmds | bin_cmds | pip_surface
         # Remove non-command words and subcommand prefixes that regex picks up
         noise = {"clone", "install", "path", "cd", "brew", "ref", "pip", "worktree"}
         readme_cmds -= noise


### PR DESCRIPTION
## Summary
Follow-up to #958 (which merged with a red Profile C — my mistake on the check gate). The README
Prerequisites block added an inline `` `vnx dispatch-agent` ``; `test_readme_commands_exist_in_mode_tiers`
extracts it and flagged it as non-existent — but `dispatch-agent` is a **real** pip-CLI command. The
test's known-command model was only the bash mode tiers + bin/vnx case branches, missing the pip-only
surface (`dispatch-agent`, `version`) that routes through `python -m vnx_cli.main`.

## Changes
- `tests/test_docs_command_validation.py` — add a `pip_surface` set to `all_known`.

## Verification
- `pytest tests/test_docs_command_validation.py` → 11 passed (was 1 failed).

## Open Items
None. Greens Profile C.

🤖 Generated with [Claude Code](https://claude.com/claude-code)