### PR TITLE
docs(audit): VNX_AUTOPILOT flag + SECURITY email + CONTRIBUTING marker + PyPI metadata (#16,O1,O2,O5)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,7 +89,7 @@ Before requesting review:
 - [ ] Tests added or updated: `python3 -m pytest tests/<related>`
 - [ ] `gh pr checks` shows VNX CI workflow conclusion = success
 - [ ] No new TODO/FIXME in committed files
-- [ ] No new `except Exception: pass` (or justified with `# noqa: vnx-silent-except`)
+- [ ] No new `except Exception: pass` (or justified with a plain `# vnx-silent-except: <reason>` marker — NOT the `# noqa:` form, which the scanner rejects)
 - [ ] No new direct `open(..., "w")` for state files without tmp-then-rename
 
 ## CI gates

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a vulnerability
 
-Please report security issues privately to the maintainer at **vincentvd@gmail.com** (or via GitHub's private security-advisory flow on the repository). Do not open a public issue for a security report.
+Please report security issues privately to the maintainer at **advies@vincentvandeth.nl** (or via GitHub's private security-advisory flow on the repository). Do not open a public issue for a security report.
 
 Include:
 

--- a/docs/contracts/MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md
+++ b/docs/contracts/MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md
@@ -122,7 +122,7 @@ These invariants replace the four chain-contract invariants (C-1..C-4) from `MUL
 - Worktree isolation (`scripts/lib/dispatch_worktree_isolation.py`, `VNX_ISOLATED_WORKTREE=1`)
 - Atomic dispatch claim (`claim_next_queued_dispatch`)
 - N-worker lanes (elastic pool ADR-018, subprocess adapter, tmux)
-- Autopilot-tick (`RA-6`, ships dark, gated by `VNX_AUTOPILOT=1`)
+- Autopilot-tick (`RA-6`, ships dark, gated by `VNX_ROADMAP_AUTOPILOT=1`)
 - Human-gate primitive (RA-4)
 
 ### Needs Building for True Parallel Activation

--- a/docs/governance/decisions/ADR-020-parallel-track-execution.md
+++ b/docs/governance/decisions/ADR-020-parallel-track-execution.md
@@ -18,7 +18,7 @@ Since then the substrate changed materially:
 | Atomic project_id-scoped dispatch claiming | Shipped | `claim_next_queued_dispatch` (BEGIN IMMEDIATE) |
 | N-worker lanes | Shipped | Elastic pool (ADR-018), subprocess adapter, tmux |
 | Track DAL + CLI + state machine | Shipped | `scripts/lib/tracks.py`, FUT-1/FUT-2 |
-| Autopilot-tick (dark) | Shipped | `autopilot_tick.py`, RA-6, gated by `VNX_AUTOPILOT=1` |
+| Autopilot-tick (dark) | Shipped | `autopilot_tick.py`, RA-6, gated by `VNX_ROADMAP_AUTOPILOT=1` |
 | Human-gate primitive | Shipped | RA-4 |
 
 The planning unit is now the **track**, not the chain. Tracks are independent, project-scoped (`(track_id, project_id)` composite key per ADR-007), individually dispatchable, and structurally isolated per worktree. The substrate is ready for concurrent activation under three safety conditions.

--- a/docs/manifesto/ROADMAP.md
+++ b/docs/manifesto/ROADMAP.md
@@ -95,7 +95,7 @@ Key deliverables: `smart_router.py`, `hard_constraints.py`, `route_decisions_wat
 ~40 PRs completing the 1.0 capability surface. Major additions:
 
 **Roadmap Autopilot (RA-1..6 + RA-3b)**
-Gate-enforced autopilot primitives for the roadmap advance flow. RA-1 stamps `project_id` on `roadmap_state.json` and receipts (ADR-007 compliance). RA-2 provisions branch + worktree on `load_feature`. RA-3 enforces review-gate evidence in reconcile/advance. RA-3b closes 4 advance-gate bypass holes. RA-4 adds a human-approval gate primitive. RA-5 adds a `step` subcommand driving the active feature PR queue. RA-6 wires `autopilot_tick` + scheduler — ships dark (default off), gated by `VNX_AUTOPILOT=1`.
+Gate-enforced autopilot primitives for the roadmap advance flow. RA-1 stamps `project_id` on `roadmap_state.json` and receipts (ADR-007 compliance). RA-2 provisions branch + worktree on `load_feature`. RA-3 enforces review-gate evidence in reconcile/advance. RA-3b closes 4 advance-gate bypass holes. RA-4 adds a human-approval gate primitive. RA-5 adds a `step` subcommand driving the active feature PR queue. RA-6 wires `autopilot_tick` + scheduler — ships dark (default off), gated by `VNX_ROADMAP_AUTOPILOT=1`.
 
 **N-Scaling Foundation (N-1/2/3)**
 N-1: atomic `claim_next_queued_dispatch` + migration 0026 for race-free queue consumption. N-2: `pool_worker_runner` single-claim entrypoint. N-3: `VNX_POOL_TASK_CONSUMER` wiring from pool worker spawn. Full pool-task-consumer path is opt-in; single-worker default unchanged.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,19 @@ name = "vnx-orchestration"
 dynamic = ["version"]
 description = "Governance-first runtime for AI agents (NDJSON receipts, SPC-grade quality gates)"
 readme = "README.md"
+keywords = ["ai-agents", "orchestration", "governance", "llm", "multi-agent", "audit-trail", "ndjson", "claude"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Topic :: Software Development :: Quality Assurance",
+    "Topic :: Software Development :: Build Tools",
+]
 requires-python = ">=3.11,<3.14"
 license = {text = "MIT"}
 authors = [{name = "Vincent van Deth", email = "advies@vincentvandeth.nl"}]


### PR DESCRIPTION
## Summary
OSS-launch-readiness sweep from the audit (docs-drift + oss-readiness). Closes `audit-docs-autopilot-flag`.

## Changes
- **#16/D1** — `VNX_AUTOPILOT=1` → `VNX_ROADMAP_AUTOPILOT=1` (the real flag) in
  `MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md`, `ADR-020`, `ROADMAP.md`.
- **O1** — `SECURITY.md` vuln-report email → `advies@vincentvandeth.nl` (published business email).
- **O2** — `CONTRIBUTING.md` checklist fixed from the scanner-rejected `# noqa: vnx-silent-except` to
  the plain `# vnx-silent-except:` marker.
- **O5** — `pyproject.toml` gains PyPI `keywords` + `classifiers`.

## Verification
- **kimi-diff-gate: PASS** — flag confirmed against the code, classifiers are valid trove classifiers,
  email matches pyproject. No code/behaviour change; pyproject parses.

## Open Items
`atomic_io.py` + `ADR-021` reference the `# noqa:` marker form (a possibly-separate legacy convention)
— left for a convention-clarifying follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)