### PR TITLE
fix(audit): clear medium bugs (C2,C5,D7,F6,F9)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ watchdog>=6.0.0
 opentelemetry-api>=1.20
 opentelemetry-sdk>=1.20
 opentelemetry-exporter-otlp-proto-http>=1.20
+jinja2>=3.0
+pyyaml>=6.0

--- a/scripts/lib/config_store_db.py
+++ b/scripts/lib/config_store_db.py
@@ -157,7 +157,14 @@ def set_config(
     # share ONE snapshot: no concurrent writer can slip between them and stale the audit's old_value.
     conn.execute("BEGIN IMMEDIATE")
     try:
-        old = read_config(conn, project_id, key)
+        # Audit C2: read old_value DIRECTLY (not via the fail-open read_config). read_config swallows
+        # sqlite errors -> None, which would write a FALSIFIED audit old_value=NULL on a real read
+        # failure. Here a read error must propagate and roll the txn back (the write fails loudly).
+        _old_row = conn.execute(
+            "SELECT config_value FROM project_config WHERE project_id = ? AND config_key = ?",
+            (project_id, key),
+        ).fetchone()
+        old = _old_row[0] if _old_row else None
         conn.execute(
             """
             INSERT INTO project_config (project_id, config_key, config_value, config_type, updated_by, approval_id)

--- a/scripts/lib/intelligence_persist.py
+++ b/scripts/lib/intelligence_persist.py
@@ -535,6 +535,10 @@ def _append_to_json_list(existing_json: Optional[str], new_item: str) -> str:
     if existing_json:
         try:
             items = json.loads(existing_json)
+            if not isinstance(items, list):
+                # Audit C5: a valid-but-non-list JSON value (e.g. {} or "x") would otherwise crash
+                # items.append() and abort the whole persist batch. Treat it as empty.
+                items = []
         except (json.JSONDecodeError, TypeError):
             items = []
     if new_item and new_item not in items:

--- a/scripts/lib/providers/smart_router/__init__.py
+++ b/scripts/lib/providers/smart_router/__init__.py
@@ -54,7 +54,9 @@ def route_dispatch(
     TierRoute via resolve_tier_route().
     """
     _env = env if env is not None else dict(_os.environ)
-    if not _env.get("VNX_AUTO_ROUTE"):
+    # Audit D7: a bare truthiness check treated VNX_AUTO_ROUTE=0/false as ENABLING (any non-empty
+    # string is truthy). Honour only the canonical truthy values, matching the docstring.
+    if _env.get("VNX_AUTO_ROUTE", "").strip().lower() not in ("1", "true", "yes", "on"):
         return None
     tier = classify_dispatch(task_spec, file_paths or [], loc_estimate)
     return resolve_tier_route(tier, _env)

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -31,13 +31,21 @@ class Check(NamedTuple):
 
 def _check_tools() -> list[Check]:
     results = []
-    for tool in ("python3", "git", "jq"):
+    for tool in ("python3", "git"):
         found = shutil.which(tool)
         results.append(Check(
             name=f"tool:{tool}",
             status=PASS if found else FAIL,
             detail=found or f"{tool} not found in PATH",
         ))
+    # Audit F9: jq is used only by the bash operator surface; the pip CLI is pure Python, so a
+    # missing jq must not hard-FAIL `vnx doctor`. WARN instead.
+    jq = shutil.which("jq")
+    results.append(Check(
+        name="tool:jq",
+        status=PASS if jq else WARN,
+        detail=jq or "jq not found in PATH; only the bash operator surface (./bin/vnx) needs it",
+    ))
     shellcheck = shutil.which("shellcheck")
     results.append(Check(
         name="tool:shellcheck",


### PR DESCRIPTION
## Summary
The clear, low-risk, verified subset of the audit's **medium** findings. By-design / debatable /
refactor findings stay in the `audit-sweep-medium` track for prioritisation.

## Changes
- **C2 `config_store_db.py`** — `set_config` read old_value via the fail-open `read_config` (swallows
  sqlite errors → None) → a **falsified** audit `old_value=NULL` on a real read failure. Now a direct
  read inside the `BEGIN IMMEDIATE` txn so an error propagates + rolls back. (My own code.)
- **C5 `intelligence_persist.py`** — `_append_to_json_list` crashed on a valid-but-non-list JSON value
  and aborted the persist batch → `isinstance` guard.
- **D7 `smart_router/__init__.py`** — `VNX_AUTO_ROUTE=0`/`false` was treated as **enabling** (truthy
  string). Now honours only canonical truthy values.
- **F9 `doctor.py`** — `jq` hard-FAIL → WARN (pip CLI is pure Python).
- **F6 `requirements.txt`** — added `jinja2` (`vnx init` needs it) + `pyyaml` to match pyproject.

## Verification
- **kimi-diff-gate: PASS**; 47 config/doctor tests green; pre-existing smart_router failures unrelated to D7.

## Open Items
Remaining medium/low findings (external-lane security, architecture refactors, hardening, governance
G2–G5, dead-code, nits) are held in `audit-sweep-medium` / `audit-sweep-low`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)