### PR TITLE
feat(smart-router): hybrid routing — capability-threshold, then cheapest (+ 2 missing classes)

### DIFF
--- a/scripts/lib/providers/routing_recommendations.yaml
+++ b/scripts/lib/providers/routing_recommendations.yaml
@@ -516,6 +516,66 @@ routing_by_task:
       launch_success_rate: 0.33
       n: 2
     min_quality_tier: 3
+  04_documentation:
+    # No dedicated field-test benchmark coverage yet (n: 0) — default routing to capable
+    # general-purpose models above the capability bar. Replaced when export_routing_matrix.py
+    # gains documentation-task runs.
+    candidates:
+    - model_id: claude-sonnet-4-6
+      runner: subscription
+      composite_score: 8.0
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 300.0
+      launch_success_rate: 1.0
+      n: 0
+    - model_id: deepseek-v4-pro
+      runner: claude-harness
+      composite_score: 7.8
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 250.0
+      launch_success_rate: 1.0
+      n: 0
+    - model_id: kimi-k2-7-code
+      runner: kimi-cli
+      composite_score: 7.5
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 200.0
+      launch_success_rate: 1.0
+      n: 0
+    min_quality_tier: 3
+  07_translation:
+    # No dedicated field-test benchmark coverage yet (n: 0) — default routing to capable
+    # general-purpose models above the capability bar. Replaced when export_routing_matrix.py
+    # gains translation-task runs.
+    candidates:
+    - model_id: claude-sonnet-4-6
+      runner: subscription
+      composite_score: 8.0
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 300.0
+      launch_success_rate: 1.0
+      n: 0
+    - model_id: deepseek-v4-pro
+      runner: claude-harness
+      composite_score: 7.8
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 250.0
+      launch_success_rate: 1.0
+      n: 0
+    - model_id: glm-5-2
+      runner: claude-harness
+      composite_score: 7.5
+      quality_tier: 3
+      cost_usd_per_call: null
+      avg_duration_seconds: 220.0
+      launch_success_rate: 1.0
+      n: 0
+    min_quality_tier: 3
 _meta:
   source: field-tests t1-t6 benchmark (export_routing_matrix.py)
   scale: composite_score 0-10 (benchmark 0-5 x2)

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -172,6 +172,12 @@ def classify_task(
 # Composite score at or below which a model is considered incapable for the task class.
 _INCAPABLE_SCORE_FLOOR = 1.0
 
+# Operator-chosen capability threshold (2026-06-28): a model scoring at/above this clears the
+# "capable enough" bar and competes on COST; models below it are ranked by capability instead, so a
+# cheap-but-weak model can never beat a much stronger one. On the 0-10 composite scale, 7.0 = solidly
+# capable. Tunable; kept absolute so the per-candidate sort key stays composable.
+_CAPABILITY_THRESHOLD = 7.0
+
 
 def _compute_quality_tier(composite_score: float, cost_tier: Optional[int]) -> int:
     """Derive quality tier (1-3) from composite_score and cost_tier.
@@ -189,17 +195,21 @@ def _compute_quality_tier(composite_score: float, cost_tier: Optional[int]) -> i
 
 
 def _cost_aware_sort_key(c: "RouteCandidate") -> tuple:
-    """Sort key for cost-aware candidate ranking.
+    """Sort key for cost-aware candidate ranking — capability-threshold, then cheapest.
 
-    Capable models (score > _INCAPABLE_SCORE_FLOOR) are ranked first by composite_score
-    DESC, with cost ASC as a secondary tiebreaker. Null cost is treated as 0 (sort-neutral)
-    so models without measured cost never collapse behind the single cheapest entry.
-    Incapable models trail, sorted by score descending.
+    Operator-chosen policy (2026-06-28, the hybrid):
+      1. Models at/above _CAPABILITY_THRESHOLD clear the capability bar (band 0). Among them the
+         CHEAPEST wins (cost ASC), with composite_score DESC as the tiebreaker on equal cost. A
+         null/unknown cost ranks LAST within the band (+inf) — an unmeasured model is never assumed
+         free. This is why a cheap-and-strong model beats an expensive-and-stronger one, but a
+         cheap-and-WEAK model (below the bar) cannot beat a strong one.
+      2. Models below the threshold (band 1) are ranked by capability DESC (best available), cost ASC
+         as a tiebreaker — so the strongest sub-bar model still wins when nothing clears the bar.
     """
-    if c.composite_score > _INCAPABLE_SCORE_FLOOR:
-        cost = c.cost_usd_per_call if c.cost_usd_per_call is not None else 0.0
-        return (0, -c.composite_score, cost)
-    return (1, -c.composite_score, float("inf"))
+    cost = c.cost_usd_per_call if c.cost_usd_per_call is not None else float("inf")
+    if c.composite_score >= _CAPABILITY_THRESHOLD:
+        return (0, cost, -c.composite_score)
+    return (1, -c.composite_score, cost)
 
 
 def _filter_by_constraints(
@@ -248,10 +258,12 @@ def _load_recommendations(
 ) -> Dict[str, List[RouteCandidate]]:
     """Load routing_recommendations.yaml and return parsed candidates per task class.
 
-    Candidates are enriched with cost_usd_per_call from wave7_models.yaml (via
-    cost_loader) and sorted cost-first within the capable tier (score > 1.0).
-    When wave7_models.yaml is absent, costs remain None and the sort falls back
-    to score-descending — identical to pre-cost-aware behavior.
+    Candidates are enriched with cost_usd_per_call from wave7_models.yaml (via cost_loader) and
+    sorted by the operator-chosen hybrid (see _cost_aware_sort_key): models at/above the
+    _CAPABILITY_THRESHOLD (7.0) compete on cost (cheapest first, null/unknown cost last), while
+    models below the threshold are ranked by capability descending. When costs are all None (no
+    wave7 data), every above-bar candidate ties on cost and the order collapses to score-descending
+    — identical to the pre-cost-aware behaviour.
     """
     from cost_loader import enrich_candidates as _enrich  # noqa: PLC0415
 

--- a/tests/test_smart_router.py
+++ b/tests/test_smart_router.py
@@ -411,12 +411,12 @@ class TestNullCostSortKey:
         c_expensive = self._make(score=9.5, cost=0.050)
         assert _cost_aware_sort_key(c_cheap) < _cost_aware_sort_key(c_expensive)
 
-    def test_equal_score_null_cost_treated_as_zero_beats_positive_cost(self):
-        """Null cost is treated as 0, so a null-cost candidate ties on score but
-        sorts before a positive-cost candidate of the same score."""
+    def test_equal_score_null_cost_ranks_after_measured_cost(self):
+        """Hybrid policy: a null/unknown cost ranks LAST within the capable band (never assumed
+        free), so a same-score MEASURED-cost candidate sorts before the null-cost one."""
         c_null = self._make(score=9.5, cost=None)
         c_with_cost = self._make(score=9.5, cost=0.001)
-        assert _cost_aware_sort_key(c_null) < _cost_aware_sort_key(c_with_cost)
+        assert _cost_aware_sort_key(c_with_cost) < _cost_aware_sort_key(c_null)
 
     def test_incapable_candidates_always_trail_capable(self):
         """Incapable candidates (score <= 1.0) must sort after all capable candidates
@@ -426,11 +426,10 @@ class TestNullCostSortKey:
         assert _cost_aware_sort_key(capable_low_score) < _cost_aware_sort_key(incapable_high_implied)
 
     def test_real_yaml_02_code_review_not_collapsed_to_deepseek(self, recommendations_yaml):
-        """Regression: decide() for code_review must return claude-opus-4-6, not deepseek-v4-flash.
-
-        The recommendations_yaml fixture has 02_code_review with claude-opus-4-6 at
-        composite_score=10.0 and claude-sonnet-4-6 at 9.5 — both null-cost. Before the
-        null-cost fix, any model with a measured cost would collapse the null-cost majority.
+        """Hybrid policy: code_review must NOT collapse to deepseek-v4-flash (5.5, below the 7.0
+        capability bar). Both opus (10.0, ~$0.225) and sonnet (9.5, ~$0.045) clear the bar; among
+        the band the CHEAPEST wins, so sonnet is chosen — a strong model at a fraction of opus's cost.
+        deepseek never wins (it is below the bar), which is the regression this guards.
         """
         decision = decide(
             "Code review: audit security",
@@ -439,5 +438,6 @@ class TestNullCostSortKey:
         )
         assert decision.task_class == "02_code_review"
         assert decision.primary is not None
-        assert decision.primary.model_id == "claude-opus-4-6"
-        assert decision.primary.composite_score == 10.0
+        assert decision.primary.model_id == "claude-sonnet-4-6"
+        assert decision.primary.composite_score == 9.5
+        assert decision.primary.model_id != "deepseek-v4-flash"

--- a/tests/test_smart_router_cost_aware.py
+++ b/tests/test_smart_router_cost_aware.py
@@ -186,7 +186,9 @@ class TestCostAwareSortKey:
 class TestRecommendCostAware:
 
     def test_cheapest_capable_model_ranks_first(self, tmp_path):
-        """With cost data populated, cheapest capable model wins."""
+        """Hybrid policy: among models that clear the capability threshold (>=7.0), the cheapest wins.
+        deepseek-flash (5.5) is BELOW the bar so it cannot beat the band despite being cheapest;
+        sonnet (8.0, ~$0.045) beats opus (9.0, ~$0.225) within the band."""
         entries = {
             "01_code_generation": [
                 {"model_id": "claude-opus-4-6", "composite_score": 9.0,
@@ -200,15 +202,15 @@ class TestRecommendCostAware:
         rec_path = _yaml_with_costs(tmp_path, entries)
         candidates = recommend("01_code_generation", recommendations_path=rec_path)
 
-        # After cost enrichment: deepseek-v4-flash should be cheapest capable
-        # deepseek-flash ≈ $0.0014/call << sonnet $0.045 << opus $0.225
+        # After cost enrichment: deepseek-flash ≈ $0.0014, sonnet ≈ $0.045, opus ≈ $0.225.
+        # deepseek (5.5) is below the 7.0 capability bar, so sonnet (cheapest in the band) wins.
         assert len(candidates) >= 3
-        assert candidates[0].model_id == "deepseek-v4-flash"
+        assert candidates[0].model_id == "claude-sonnet-4-6"
         assert candidates[0].cost_usd_per_call is not None
-        # Verify price ordering within capable models
-        capable = [c for c in candidates if c.composite_score > _INCAPABLE_SCORE_FLOOR]
-        costs = [c.cost_usd_per_call or float("inf") for c in capable]
-        assert costs == sorted(costs), "Capable candidates must be sorted by cost ascending"
+        # Within the capable band (score >= 7.0), cost ascending.
+        band = [c for c in candidates if c.composite_score >= 7.0]
+        costs = [c.cost_usd_per_call or float("inf") for c in band]
+        assert costs == sorted(costs), "Band candidates must be sorted by cost ascending"
 
     def test_incapable_models_trail_despite_low_cost(self, tmp_path):
         """Models at score=1.0 rank after all capable ones even with zero cost."""


### PR DESCRIPTION
## Summary
Operator-chosen routing policy: **capability-threshold, then cheapest**. Surfaced when I found the
cost-aware sort + its two test suites encoded **opposite** policies (cheapest-wins vs capability-wins).

## Changes
- **`smart_router.py` `_cost_aware_sort_key`** — hybrid. `_CAPABILITY_THRESHOLD = 7.0`: models ≥ 7.0
  clear the bar (band 0) and compete on **cost** (cheapest first, score DESC tiebreak; null cost ranks
  **last** — never assumed free). Below the bar → capability DESC. Strong+cheap beats strong+expensive;
  cheap+weak (below bar) never beats strong. `code_review` → **sonnet** (clears the bar, ~5× cheaper
  than opus); deepseek (5.5) never wins.
- **`routing_recommendations.yaml`** — added the 2 missing classes `04_documentation` +
  `07_translation` (benchmark-generated yaml never covered them) as honest defaults (`n: 0`).
- **Tests** — reconciled the two contradictory suites to the one chosen policy (no test weakened).

## Verification
- **kimi-diff-gate: PASS** (round 2; round 1 only asked for the `_load_recommendations` docstring, applied).
- Policy/sort tests: **117 passed**. Smart-router suite went from ~11 failed → 3. The 3 remaining are
  **pre-existing** `--auto-route` e2e/wiring integration failures (4 on main → 3 now), unrelated to the
  routing policy.

## Open Items
The cost-aware path is **dormant** until `export_routing_matrix.py` populates costs (all-null today =
behaviour-neutral). The 3 pre-existing `--auto-route` e2e/wiring failures remain (separate plumbing concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)