### PR TITLE
feat(observability): tagging audit event — per-action tagger trail

### DIFF
--- a/scripts/lib/vnx_tagger.py
+++ b/scripts/lib/vnx_tagger.py
@@ -46,6 +46,24 @@ _DEFAULT_PROVIDER = "deepseek"
 _MAX_TAGS = 6
 _TAGGABLE_TABLES = frozenset({"success_patterns", "antipatterns"})
 
+# Per-action tagging audit trail (observability). One row per pattern the tagger actually tags, so
+# the dashboard can show "what did the tagging agent do, and with which model". ADR-007: composite
+# UNIQUE over project_id. Lives in the same quality_intelligence.db the tagger already writes.
+_TAGGING_EVENTS_SCHEMA = """
+CREATE TABLE IF NOT EXISTS tagging_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id    TEXT NOT NULL DEFAULT 'vnx-dev',
+    table_name    TEXT NOT NULL,
+    pattern_id    INTEGER NOT NULL,
+    pattern_title TEXT,
+    tags_json     TEXT NOT NULL,
+    provider      TEXT,
+    tagged_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (project_id, table_name, pattern_id, tagged_at)
+);
+CREATE INDEX IF NOT EXISTS idx_tagging_events_recent ON tagging_events(project_id, tagged_at DESC);
+"""
+
 
 def is_enabled() -> bool:
     import config_runtime
@@ -156,6 +174,14 @@ def enrich_pattern_tags(
         conn = _sqlite3.connect(str(db_path))
     except _sqlite3.Error:
         return {"_skipped": "db_open_failed"}
+    # Best-effort tagging audit log (never blocks tagging). project_id + provider captured per run.
+    import os as _os
+    try:
+        conn.executescript(_TAGGING_EVENTS_SCHEMA)
+    except _sqlite3.Error:
+        pass
+    _project_id = _os.environ.get("VNX_PROJECT_ID") or "vnx-dev"
+    _provider = get_tagger_provider_name()
     try:
         for tbl in tbls:
             try:
@@ -178,6 +204,14 @@ def enrich_pattern_tags(
                 tags = enrich_tags(f"{title or ''} {desc or ''}".strip())
                 try:
                     conn.execute(f"UPDATE {tbl} SET tags = ? WHERE id = ?", (_json.dumps(tags), pid))
+                    if tags:
+                        # Audit event for the dashboard — only meaningful taggings (non-empty).
+                        conn.execute(
+                            "INSERT OR IGNORE INTO tagging_events "
+                            "(project_id, table_name, pattern_id, pattern_title, tags_json, provider) "
+                            "VALUES (?, ?, ?, ?, ?, ?)",
+                            (_project_id, tbl, pid, title, _json.dumps(tags), _provider),
+                        )
                     n += 1
                 except _sqlite3.Error:
                     continue

--- a/tests/test_tagging_events.py
+++ b/tests/test_tagging_events.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for the tagging audit event (observability producer).
+
+Dispatch-ID: 20260628-tagging-events
+
+enrich_pattern_tags must, in addition to writing the `tags` column, append a per-pattern row to a
+`tagging_events` audit table (what the tagger tagged, with which provider) so the dashboard can show
+the tagging agent's activity. Best-effort: a missing column / db error never blocks tagging.
+"""
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import vnx_tagger  # noqa: E402
+
+
+def _qi_db(tmp_path) -> Path:
+    db = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "CREATE TABLE success_patterns (id INTEGER PRIMARY KEY, title TEXT, description TEXT, tags TEXT)"
+    )
+    conn.execute("INSERT INTO success_patterns (id, title, description, tags) VALUES (1, 'fix the auth bug', 'security work', NULL)")
+    conn.commit()
+    conn.close()
+    return db
+
+
+@pytest.fixture(autouse=True)
+def _enable_tagger(monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "1")
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    # Deterministic tags without an LLM call.
+    monkeypatch.setattr(vnx_tagger, "enrich_tags", lambda *a, **k: ["security", "testing"])
+    monkeypatch.setattr(vnx_tagger, "get_tagger_provider_name", lambda: "deepseek")
+    yield
+
+
+def test_tagging_event_recorded(tmp_path):
+    db = _qi_db(tmp_path)
+    out = vnx_tagger.enrich_pattern_tags(db, tables=["success_patterns"])
+    assert out.get("success_patterns") == 1
+
+    conn = sqlite3.connect(db)
+    rows = conn.execute(
+        "SELECT project_id, table_name, pattern_id, pattern_title, tags_json, provider FROM tagging_events"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    project_id, table_name, pattern_id, title, tags_json, provider = rows[0]
+    assert project_id == "vnx-dev"
+    assert table_name == "success_patterns"
+    assert pattern_id == 1
+    assert title == "fix the auth bug"
+    assert json.loads(tags_json) == ["security", "testing"]
+    assert provider == "deepseek"
+
+
+def test_adr007_composite_unique_over_project_id(tmp_path):
+    db = _qi_db(tmp_path)
+    vnx_tagger.enrich_pattern_tags(db, tables=["success_patterns"])
+    conn = sqlite3.connect(db)
+    # The audit table carries project_id + a composite UNIQUE over it (ADR-007).
+    idx_cols = [r[1] for r in conn.execute("PRAGMA table_info(tagging_events)") if r[1] == "project_id"]
+    assert idx_cols == ["project_id"]
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tagging_events (project_id, table_name, pattern_id, tags_json, tagged_at) "
+            "VALUES ('vnx-dev', 'success_patterns', 1, '[]', '2026-06-28T00:00:00.000Z')"
+        )
+        conn.execute(
+            "INSERT INTO tagging_events (project_id, table_name, pattern_id, tags_json, tagged_at) "
+            "VALUES ('vnx-dev', 'success_patterns', 1, '[]', '2026-06-28T00:00:00.000Z')"
+        )
+    conn.close()
+
+
+def test_empty_tags_emit_no_event(tmp_path, monkeypatch):
+    monkeypatch.setattr(vnx_tagger, "enrich_tags", lambda *a, **k: [])
+    db = _qi_db(tmp_path)
+    vnx_tagger.enrich_pattern_tags(db, tables=["success_patterns"])
+    conn = sqlite3.connect(db)
+    n = conn.execute("SELECT COUNT(*) FROM tagging_events").fetchone()[0]
+    conn.close()
+    assert n == 0  # only meaningful (non-empty) taggings are audited
+
+
+def test_disabled_tagger_no_table_required(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_TAGGER_ENABLED", "0")
+    db = _qi_db(tmp_path)
+    out = vnx_tagger.enrich_pattern_tags(db, tables=["success_patterns"])
+    assert out == {"_skipped": "tagger_disabled"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Part 1 of the observability/audit-trail build. The tagger wrote only the resulting `tags` column with
no per-action audit; this adds a `tagging_events` table so the dashboard can show **what the tagging
agent did** + with which model.

## Changes (`scripts/lib/vnx_tagger.py`)
- New `tagging_events` table (idempotent `executescript`, in `quality_intelligence.db`). **ADR-007**:
  `project_id` + composite `UNIQUE(project_id, table_name, pattern_id, tagged_at)` + a recent-index.
- `enrich_pattern_tags` emits one row per **non-empty** tagging (project_id, table, pattern_id, title,
  tags_json, provider) right after the tags `UPDATE`. **Best-effort** — schema/insert never block tagging.

## Verification
- `tests/test_tagging_events.py` (4) — event recorded, ADR-007 composite unique, empty-tags-no-event,
  disabled-tagger-skip → all pass; existing tagger tests green; scanner clean.
- **kimi-diff-gate: PASS** (ADR-007, no injection, fail-silent confirmed).

## Open Items
None. Next: provenance light-up (registry population) + the observability dashboard page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)