### PR TITLE
feat(observability): light up the provenance chain (registry population + upsert fix)

### DIFF
--- a/scripts/lib/append_receipt_internals/enrichment.py
+++ b/scripts/lib/append_receipt_internals/enrichment.py
@@ -61,7 +61,7 @@ def _enrich_session_metadata(enriched: Dict[str, Any], state_dir: Path) -> None:
         }
 
 
-def _enrich_provenance_linkage(enriched: Dict[str, Any]) -> None:
+def _enrich_provenance_linkage(enriched: Dict[str, Any], state_dir: Path) -> None:
     try:
         facade.enrich_receipt_provenance(enriched)
         prov_validation = facade.validate_receipt_provenance(enriched)
@@ -76,8 +76,46 @@ def _enrich_provenance_linkage(enriched: Dict[str, Any]) -> None:
                     _emit("WARN", "provenance_gap_detected",
                            gap_type=gap.gap_type, entity_id=gap.entity_id,
                            description=gap.description)
+        # Light up the provenance chain: write the registry row so dispatch -> receipt -> commit -> PR
+        # is queryable (and its gaps visible). At append time only dispatch_id + receipt_id + trace_token
+        # are known (the commit happens later), so chain_status stays 'incomplete' until merge fills
+        # commit_sha. Best-effort; never blocks the append.
+        _register_provenance_link(enriched, state_dir)
     except Exception as exc:
         _emit("WARN", "provenance_enrichment_failed", error=str(exc))
+
+
+def _register_provenance_link(enriched: Dict[str, Any], state_dir: Path) -> None:
+    dispatch_id = enriched.get("dispatch_id")
+    if not dispatch_id or str(dispatch_id) in ("", "unknown", "none", "null"):
+        return
+    db_path = state_dir / "runtime_coordination.db"
+    if not db_path.exists():
+        return
+    try:
+        import sqlite3 as _sqlite3
+        from receipt_provenance import register_provenance_link  # noqa: PLC0415
+        receipt_id = str(enriched.get("run_id") or enriched.get("task_id") or "") or None
+        pr_number = enriched.get("pr_number")
+        try:
+            pr_number = int(pr_number) if pr_number is not None else None
+        except (TypeError, ValueError):
+            pr_number = None
+        conn = _sqlite3.connect(str(db_path))
+        try:
+            register_provenance_link(
+                conn,
+                dispatch_id=str(dispatch_id),
+                receipt_id=receipt_id,
+                trace_token=enriched.get("trace_token"),
+                pr_number=pr_number,
+                feature_plan_pr=enriched.get("feature_plan_pr"),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        _emit("WARN", "provenance_register_failed", error=str(exc))
 
 
 def _enrich_terminal_snapshot(enriched: Dict[str, Any], state_dir: Path) -> None:
@@ -257,7 +295,7 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
 
     _enrich_project_id_and_git(enriched, paths, repo_root)
     _enrich_session_metadata(enriched, state_dir)
-    _enrich_provenance_linkage(enriched)
+    _enrich_provenance_linkage(enriched, state_dir)
     _enrich_terminal_snapshot(enriched, state_dir)
 
     if _is_subprocess_intermediate_completion(receipt):

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -348,14 +348,17 @@ def register_provenance_link(
     now = _now_utc()
     gaps_json = json.dumps(gaps or [])
 
-    existing = conn.execute(
+    _cur = conn.execute(
         "SELECT * FROM provenance_registry WHERE dispatch_id = ?",
         (dispatch_id,),
-    ).fetchone()
+    )
+    existing = _cur.fetchone()
 
     if existing:
-        # Merge: only overwrite fields that are currently NULL
-        merged = dict(existing)
+        # Merge: only overwrite fields that are currently NULL. ``existing`` is a plain tuple (the
+        # caller's connection has no Row factory), so build the dict from the cursor's column names —
+        # dict(tuple) would raise "dictionary update sequence element ... length N".
+        merged = dict(zip([d[0] for d in _cur.description], existing))
         if receipt_id and not merged.get("receipt_id"):
             merged["receipt_id"] = receipt_id
         if commit_sha and not merged.get("commit_sha"):

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for the provenance-registry light-up (observability).
+
+Dispatch-ID: 20260628-provenance-lightup
+
+register_provenance_link existed but nothing called it, so provenance_registry stayed empty. The
+receipt-append enrichment now writes the registry row (best-effort) so dispatch -> receipt -> commit
+-> PR is queryable and its gaps visible. At append time only dispatch_id + receipt_id + trace_token
+are known (the commit happens later), so chain_status stays 'incomplete' until merge fills commit_sha.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from append_receipt_internals import enrichment  # noqa: E402
+
+_REGISTRY_SCHEMA = """
+CREATE TABLE provenance_registry (
+    dispatch_id     TEXT NOT NULL,
+    receipt_id      TEXT,
+    commit_sha      TEXT,
+    pr_number       INTEGER,
+    feature_plan_pr TEXT,
+    trace_token     TEXT,
+    chain_status    TEXT NOT NULL DEFAULT 'incomplete',
+    gaps_json       TEXT DEFAULT '[]',
+    registered_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    verified_at     TEXT,
+    verified_by     TEXT,
+    PRIMARY KEY (dispatch_id)
+);
+CREATE TABLE coordination_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    event_id      TEXT NOT NULL UNIQUE,
+    event_type    TEXT NOT NULL,
+    entity_type   TEXT NOT NULL,
+    entity_id     TEXT NOT NULL,
+    from_state    TEXT,
+    to_state      TEXT,
+    actor         TEXT NOT NULL DEFAULT 'runtime',
+    reason        TEXT,
+    metadata_json TEXT DEFAULT '{}',
+    occurred_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+    project_id    TEXT NOT NULL DEFAULT 'vnx-dev'
+);
+"""
+
+
+def _state_dir(tmp_path) -> Path:
+    sd = tmp_path / "state"
+    sd.mkdir()
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    conn.executescript(_REGISTRY_SCHEMA)
+    conn.commit()
+    conn.close()
+    return sd
+
+
+def test_append_registers_provenance_link(tmp_path):
+    sd = _state_dir(tmp_path)
+    receipt = {"dispatch_id": "D-abc123", "run_id": "r-1", "trace_token": "Dispatch-ID: D-abc123"}
+    enrichment._register_provenance_link(receipt, sd)
+
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    row = conn.execute(
+        "SELECT dispatch_id, receipt_id, trace_token, commit_sha, chain_status FROM provenance_registry"
+    ).fetchone()
+    conn.close()
+    assert row is not None
+    dispatch_id, receipt_id, trace_token, commit_sha, chain_status = row
+    assert dispatch_id == "D-abc123"
+    assert receipt_id == "r-1"
+    assert trace_token == "Dispatch-ID: D-abc123"
+    assert commit_sha is None  # the commit happens later — chain not yet complete
+    assert chain_status in ("incomplete", "broken")  # missing commit/PR -> not complete
+
+
+def test_upsert_merges_incrementally(tmp_path):
+    sd = _state_dir(tmp_path)
+    enrichment._register_provenance_link({"dispatch_id": "D-x", "run_id": "r-x"}, sd)
+    # A later receipt for the same dispatch carrying a pr_number merges, not duplicates.
+    enrichment._register_provenance_link({"dispatch_id": "D-x", "run_id": "r-x", "pr_number": 42}, sd)
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    rows = conn.execute("SELECT dispatch_id, pr_number FROM provenance_registry").fetchall()
+    conn.close()
+    assert len(rows) == 1  # upsert, one row per dispatch_id
+    assert rows[0] == ("D-x", 42)
+
+
+def test_no_dispatch_id_skips(tmp_path):
+    sd = _state_dir(tmp_path)
+    enrichment._register_provenance_link({"dispatch_id": "unknown"}, sd)
+    enrichment._register_provenance_link({}, sd)
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    n = conn.execute("SELECT COUNT(*) FROM provenance_registry").fetchone()[0]
+    conn.close()
+    assert n == 0
+
+
+def test_missing_db_is_fail_open(tmp_path):
+    # No runtime_coordination.db -> best-effort no-op, never raises.
+    sd = tmp_path / "empty"
+    sd.mkdir()
+    enrichment._register_provenance_link({"dispatch_id": "D-y", "run_id": "r"}, sd)  # must not raise
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
Populates provenance_registry at receipt-append (dispatch_id+receipt_id+trace_token), fail-open. Fixes a latent dict(tuple) upsert bug the light-up exposed. B1 of the provenance light-up. kimi-gate PASS; 113 provenance tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)