### PR TITLE
feat(observability): governance/audit-trail dashboard page

### DIFF
--- a/dashboard/api_observability.py
+++ b/dashboard/api_observability.py
@@ -1,0 +1,198 @@
+"""Observability dashboard API — the governance/audit-trail panel.
+
+GET /api/operator/observability returns four read-only, fail-open sections:
+  - self_learning : recent confidence_events (what the self-learning loop adjusted) + proposal count
+  - tagging       : recent tagging_events (what the tagging agent tagged + with which model)
+  - runtime       : cron jobs (schedule + last-run) + VNX daemon liveness
+  - provenance    : provenance_registry chain_status counts + recent rows with their gaps
+
+Single-tenant: reads this dashboard's project (CANONICAL_STATE_DIR). Every section is best-effort —
+a missing table / db / command yields an empty section + a `degraded` flag, never an error.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import sqlite3
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from api_operator import CANONICAL_STATE_DIR, _op_dashboard_project_id
+
+_logger = logging.getLogger(__name__)
+_PROJECT_ROOT = Path(CANONICAL_STATE_DIR).resolve().parent.parent  # …/<repo or project>
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _qi_db() -> Path:
+    return CANONICAL_STATE_DIR / "quality_intelligence.db"
+
+
+def _runtime_db() -> Path:
+    return CANONICAL_STATE_DIR / "runtime_coordination.db"
+
+
+def _ro_conn(path: Path):
+    if not path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+        conn.row_factory = sqlite3.Row
+        return conn
+    except sqlite3.Error:
+        return None
+
+
+def _self_learning(limit: int, project_id: str) -> dict:
+    out: dict = {"events": [], "proposals": 0}
+    conn = _ro_conn(_qi_db())
+    if conn is None:
+        out["degraded"] = True
+        return out
+    try:
+        rows = conn.execute(
+            "SELECT dispatch_id, outcome, confidence_change, patterns_boosted, patterns_decayed, occurred_at "
+            "FROM confidence_events WHERE project_id = ? ORDER BY occurred_at DESC LIMIT ?",
+            (project_id, limit),
+        ).fetchall()
+        out["events"] = [dict(r) for r in rows]
+    except sqlite3.Error:
+        out["degraded"] = True
+    finally:
+        conn.close()
+    # Operator-gated proposals (pending_rules.json) — best-effort.
+    try:
+        pr = CANONICAL_STATE_DIR / "pending_rules.json"
+        if pr.exists():
+            data = json.loads(pr.read_text())
+            out["proposals"] = len(data) if isinstance(data, list) else len(data.get("rules", data))
+    except Exception:  # vnx-silent-except: the proposals count is an optional best-effort enrichment
+        pass
+    return out
+
+
+def _tagging(limit: int, project_id: str) -> dict:
+    out: dict = {"events": []}
+    conn = _ro_conn(_qi_db())
+    if conn is None:
+        out["degraded"] = True
+        return out
+    try:
+        rows = conn.execute(
+            "SELECT table_name, pattern_id, pattern_title, tags_json, provider, tagged_at "
+            "FROM tagging_events WHERE project_id = ? ORDER BY tagged_at DESC LIMIT ?",
+            (project_id, limit),
+        ).fetchall()
+        out["events"] = [
+            {**dict(r), "tags": _safe_tags(r["tags_json"])} for r in rows
+        ]
+    except sqlite3.Error:
+        # table absent (tagger never ran / older schema) → empty, not an error
+        out["degraded"] = True
+    finally:
+        conn.close()
+    return out
+
+
+def _safe_tags(tags_json) -> list:
+    try:
+        v = json.loads(tags_json) if tags_json else []
+        return v if isinstance(v, list) else []
+    except (TypeError, ValueError):
+        return []
+
+
+def _provenance(limit: int) -> dict:
+    out: dict = {"by_status": {}, "recent": []}
+    conn = _ro_conn(_runtime_db())
+    if conn is None:
+        out["degraded"] = True
+        return out
+    try:
+        for r in conn.execute(
+            "SELECT chain_status, COUNT(*) AS n FROM provenance_registry GROUP BY chain_status"
+        ).fetchall():
+            out["by_status"][r["chain_status"]] = r["n"]
+        rows = conn.execute(
+            "SELECT dispatch_id, receipt_id, commit_sha, pr_number, chain_status, gaps_json, registered_at "
+            "FROM provenance_registry ORDER BY registered_at DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        out["recent"] = [
+            {**dict(r), "gaps": _safe_tags(r["gaps_json"])} for r in rows
+        ]
+    except sqlite3.Error:
+        out["degraded"] = True
+    finally:
+        conn.close()
+    return out
+
+
+def _runtime() -> dict:
+    """Cron jobs + VNX daemon liveness for this host. Filtered to VNX-relevant entries; honest that
+    cron/daemons are host + cross-project."""
+    out: dict = {"cron": [], "daemons": []}
+    # Cron jobs (host crontab), VNX-relevant lines only.
+    try:
+        cron = subprocess.run(["crontab", "-l"], capture_output=True, text=True, timeout=5)
+        for line in (cron.stdout or "").splitlines():
+            s = line.strip()
+            if not s or s.startswith("#"):
+                continue
+            if re.search(r"vnx|dispatch|receipt|intelligence|shadow|compact_state", s, re.I):
+                m = re.match(r"^(\S+\s+\S+\s+\S+\s+\S+\s+\S+)\s+(.*)$", s)
+                schedule, cmd = (m.group(1), m.group(2)) if m else ("?", s)
+                # last-run from the log mtime if the command redirects to one
+                log_m = re.search(r">>?\s*(\S+\.log)", cmd)
+                last_run = None
+                if log_m:
+                    try:
+                        lp = Path(log_m.group(1))
+                        if lp.exists():
+                            last_run = datetime.fromtimestamp(lp.stat().st_mtime, timezone.utc).isoformat()
+                    except OSError:
+                        pass
+                out["cron"].append({"schedule": schedule, "command": cmd[:160], "last_run": last_run})
+    except Exception:
+        out["cron_degraded"] = True
+    # VNX daemon liveness (this project's paths only).
+    try:
+        ps = subprocess.run(["ps", "-eo", "pid,command"], capture_output=True, text=True, timeout=5)
+        proj = str(_PROJECT_ROOT)
+        wanted = ("dispatcher", "receipt_processor", "intelligence_daemon", "headless_trigger", "recommendations_engine")
+        for line in (ps.stdout or "").splitlines():
+            if proj in line and any(w in line for w in wanted):
+                parts = line.strip().split(None, 1)
+                if len(parts) == 2:
+                    name = next((w for w in wanted if w in parts[1]), "daemon")
+                    out["daemons"].append({"pid": parts[0], "name": name})
+    except Exception:
+        out["daemons_degraded"] = True
+    out["daemons_running"] = len(out["daemons"])
+    return out
+
+
+def operator_get_observability(params: dict, *, project_id: "str | None" = None) -> "tuple[dict, int]":
+    """GET /api/operator/observability — the four governance/audit sections. Always 200 (fail-open;
+    each section self-reports `degraded`)."""
+    pid = project_id or _op_dashboard_project_id() or "vnx-dev"
+    try:
+        limit = max(1, min(int((params.get("limit") or ["25"])[0]), 200))
+    except (TypeError, ValueError):
+        limit = 25
+    body = {
+        "project_id": pid,
+        "queried_at": _now(),
+        "self_learning": _self_learning(limit, pid),
+        "tagging": _tagging(limit, pid),
+        "provenance": _provenance(limit),
+        "runtime": _runtime(),
+    }
+    return body, 200

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -172,6 +172,8 @@ from api_config import (  # noqa: E402
     operator_get_config_audit,
 )
 
+from api_observability import operator_get_observability  # noqa: E402
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -402,6 +404,11 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/config/audit":
             result, status_int = operator_get_config_audit(params)
+            _json_response(self, HTTPStatus(status_int), result)
+            return
+
+        if path == "/api/operator/observability":
+            result, status_int = operator_get_observability(params)
             _json_response(self, HTTPStatus(status_int), result)
             return
 

--- a/dashboard/token-dashboard/__tests__/observability-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/observability-page.test.tsx
@@ -1,0 +1,81 @@
+/**
+ * Tests for app/operator/observability/page.tsx — the governance/audit-trail panel over
+ * /api/operator/observability (self-learning, tagging, provenance, runtime).
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/lib/hooks', () => ({ useObservability: jest.fn() }));
+
+import { useObservability } from '@/lib/hooks';
+import ObservabilityPage from '@/app/operator/observability/page';
+import type { ObservabilityEnvelope } from '@/lib/types';
+
+const mockUse = useObservability as jest.MockedFunction<typeof useObservability>;
+
+function envelope(over: Partial<ObservabilityEnvelope> = {}): ObservabilityEnvelope {
+  return {
+    project_id: 'vnx-dev',
+    queried_at: '2026-06-28T10:00:00Z',
+    self_learning: {
+      events: [{ dispatch_id: 'D-1', outcome: 'success', confidence_change: 0.05, patterns_boosted: 2, patterns_decayed: 0, occurred_at: '2026-06-28T09:00:00Z' }],
+      proposals: 3,
+    },
+    tagging: {
+      events: [{ table_name: 'success_patterns', pattern_id: 7, pattern_title: 'fix auth bug', tags: ['security', 'testing'], provider: 'deepseek', tagged_at: '2026-06-28T09:30:00Z' }],
+    },
+    provenance: {
+      by_status: { complete: 4, incomplete: 2 },
+      recent: [{ dispatch_id: 'D-2', receipt_id: 'r2', commit_sha: 'abc12345def', pr_number: 99, chain_status: 'complete', gaps: [], registered_at: '2026-06-28T08:00:00Z' }],
+    },
+    runtime: {
+      cron: [{ schedule: '0 4 * * *', command: 'nightly_intelligence_pipeline.sh', last_run: '2026-06-28T04:00:00Z' }],
+      daemons: [{ pid: '4883', name: 'receipt_processor' }],
+      daemons_running: 1,
+    },
+    ...over,
+  };
+}
+
+function renderWith(data: ObservabilityEnvelope | undefined, opts: { isLoading?: boolean; error?: Error } = {}) {
+  mockUse.mockReturnValue({ data, isLoading: opts.isLoading ?? false, error: opts.error, mutate: jest.fn(), isValidating: false } as ReturnType<typeof useObservability>);
+  return render(<ObservabilityPage />);
+}
+
+describe('ObservabilityPage', () => {
+  test('renders all four sections with data', () => {
+    renderWith(envelope());
+    expect(screen.getByTestId('observability-page')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-section-self-learning')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-section-tagging-agent')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-section-provenance')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-section-runtime-health')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-learning-row')).toHaveTextContent('D-1');
+    expect(screen.getByTestId('obs-tagging-row')).toHaveTextContent('security');
+    expect(screen.getByTestId('obs-chain-complete')).toHaveTextContent('complete: 4');
+    expect(screen.getByTestId('obs-provenance-row')).toHaveTextContent('D-2');
+    expect(screen.getByTestId('obs-daemons')).toHaveTextContent('1 daemon');
+    expect(screen.getByTestId('obs-cron-row')).toHaveTextContent('nightly_intelligence_pipeline');
+  });
+
+  test('shows degraded flag + empty states', () => {
+    renderWith(envelope({
+      tagging: { events: [], degraded: true },
+      provenance: { by_status: {}, recent: [], degraded: true },
+      self_learning: { events: [], proposals: 0 },
+      runtime: { cron: [], daemons: [], daemons_running: 0 },
+    }));
+    expect(screen.getByTestId('obs-degraded-tagging-agent')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-daemons')).toHaveTextContent('0 daemon');
+  });
+
+  test('loading and error states', () => {
+    const { rerender } = renderWith(undefined, { isLoading: true });
+    expect(screen.getByTestId('observability-loading')).toBeInTheDocument();
+    mockUse.mockReturnValue({ data: undefined, isLoading: false, error: new Error('x'), mutate: jest.fn(), isValidating: false } as ReturnType<typeof useObservability>);
+    rerender(<ObservabilityPage />);
+    expect(screen.getByTestId('observability-error')).toBeInTheDocument();
+  });
+});

--- a/dashboard/token-dashboard/app/operator/observability/page.tsx
+++ b/dashboard/token-dashboard/app/operator/observability/page.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React from 'react';
+import { useObservability } from '@/lib/hooks';
+import type { ObservabilityEnvelope } from '@/lib/types';
+
+const PANEL = 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)';
+
+function Section({ title, count, degraded, children }: {
+  title: string; count?: number; degraded?: boolean; children: React.ReactNode;
+}) {
+  return (
+    <section
+      data-testid={`obs-section-${title.toLowerCase().replace(/\s+/g, '-')}`}
+      style={{ borderRadius: 10, padding: 14, background: PANEL, border: '1px solid rgba(255,255,255,0.08)', display: 'flex', flexDirection: 'column', gap: 8 }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <h2 style={{ fontSize: 13, fontWeight: 700, margin: 0, color: 'var(--color-foreground)' }}>{title}</h2>
+        {count != null && <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>({count})</span>}
+        {degraded && (
+          <span data-testid={`obs-degraded-${title.toLowerCase().replace(/\s+/g, '-')}`} style={{ fontSize: 10, color: 'var(--color-warning, #facc15)', border: '1px solid var(--color-warning, #facc15)', borderRadius: 5, padding: '1px 6px' }}>
+            degraded
+          </span>
+        )}
+      </div>
+      {children}
+    </section>
+  );
+}
+
+const _muted: React.CSSProperties = { fontSize: 11, color: 'rgba(244,244,249,0.4)', padding: '6px 0' };
+const _row: React.CSSProperties = { fontSize: 11, borderBottom: '1px solid rgba(255,255,255,0.06)', paddingBottom: 4, display: 'flex', gap: 8, flexWrap: 'wrap' };
+
+function chainColor(status: string): string {
+  switch (status) {
+    case 'complete': return 'var(--color-success, #50fa7b)';
+    case 'broken': return 'var(--color-danger, #ff5555)';
+    default: return 'var(--color-warning, #facc15)';  // incomplete
+  }
+}
+
+function Body({ data }: { data: ObservabilityEnvelope }) {
+  const sl = data.self_learning;
+  const tg = data.tagging;
+  const pv = data.provenance;
+  const rt = data.runtime;
+  return (
+    <div data-testid="observability-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Observability</h1>
+        <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>{data.project_id} · governance & audit trail</span>
+      </div>
+
+      <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16, alignItems: 'start' }}>
+        {/* Self-learning loop */}
+        <Section title="Self-learning" count={sl.events.length} degraded={sl.degraded}>
+          <div style={{ fontSize: 11, color: 'var(--color-muted)' }}>{sl.proposals} pending rule proposal(s)</div>
+          {sl.events.length === 0 ? (
+            <div style={_muted}>No confidence adjustments recorded.</div>
+          ) : sl.events.map((e, i) => (
+            <div key={i} data-testid="obs-learning-row" style={_row}>
+              <code style={{ fontWeight: 700 }}>{e.dispatch_id}</code>
+              <span style={{ color: e.confidence_change >= 0 ? 'var(--color-success, #50fa7b)' : 'var(--color-danger, #ff5555)' }}>
+                {e.confidence_change >= 0 ? '+' : ''}{e.confidence_change.toFixed(3)}
+              </span>
+              <span style={{ color: 'var(--color-muted)' }}>{e.outcome} · ↑{e.patterns_boosted} ↓{e.patterns_decayed} · {e.occurred_at}</span>
+            </div>
+          ))}
+        </Section>
+
+        {/* Tagging agent */}
+        <Section title="Tagging agent" count={tg.events.length} degraded={tg.degraded}>
+          {tg.events.length === 0 ? (
+            <div style={_muted}>{tg.degraded ? 'No tagging_events table yet (tagger has not run since the audit trail was added).' : 'No taggings recorded.'}</div>
+          ) : tg.events.map((e, i) => (
+            <div key={i} data-testid="obs-tagging-row" style={_row}>
+              <span style={{ fontWeight: 700 }} title={e.pattern_title ?? ''}>{(e.pattern_title ?? `#${e.pattern_id}`).slice(0, 40)}</span>
+              <span style={{ color: 'var(--color-accent, #f97316)' }}>{e.tags.join(', ')}</span>
+              <span style={{ color: 'var(--color-muted)' }}>{e.provider} · {e.tagged_at}</span>
+            </div>
+          ))}
+        </Section>
+
+        {/* Provenance / traceability */}
+        <Section title="Provenance" degraded={pv.degraded}>
+          <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+            {Object.keys(pv.by_status).length === 0 ? (
+              <span style={_muted}>Registry empty — dispatch→receipt→commit chain not yet populated.</span>
+            ) : Object.entries(pv.by_status).map(([status, n]) => (
+              <span key={status} data-testid={`obs-chain-${status}`} style={{ fontSize: 10, fontWeight: 700, color: chainColor(status), border: `1px solid ${chainColor(status)}`, borderRadius: 5, padding: '1px 7px' }}>
+                {status}: {n}
+              </span>
+            ))}
+          </div>
+          {pv.recent.map((r, i) => (
+            <div key={i} data-testid="obs-provenance-row" style={_row}>
+              <code style={{ fontWeight: 700 }}>{r.dispatch_id}</code>
+              <span style={{ color: chainColor(r.chain_status) }}>{r.chain_status}</span>
+              <span style={{ color: 'var(--color-muted)' }}>
+                {r.commit_sha ? `commit ${r.commit_sha.slice(0, 8)}` : 'no commit'}{r.pr_number ? ` · PR#${r.pr_number}` : ''}
+                {r.gaps.length ? ` · gaps: ${r.gaps.length}` : ''}
+              </span>
+            </div>
+          ))}
+        </Section>
+
+        {/* Runtime health */}
+        <Section title="Runtime health">
+          <div data-testid="obs-daemons" style={{ fontSize: 11 }}>
+            <span style={{ color: rt.daemons_running > 0 ? 'var(--color-success, #50fa7b)' : 'var(--color-muted)' }}>
+              {rt.daemons_running} daemon(s) running for this project
+            </span>
+            {rt.daemons.map((d, i) => (
+              <span key={i} style={{ color: 'var(--color-muted)' }}> · {d.name} ({d.pid})</span>
+            ))}
+          </div>
+          <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-muted)', marginTop: 4 }}>Cron ({rt.cron.length})</div>
+          {rt.cron.length === 0 ? (
+            <div style={_muted}>No VNX cron jobs found.</div>
+          ) : rt.cron.map((c, i) => (
+            <div key={i} data-testid="obs-cron-row" style={_row}>
+              <code style={{ fontWeight: 700 }}>{c.schedule}</code>
+              <span style={{ color: 'var(--color-muted)', overflow: 'hidden', textOverflow: 'ellipsis' }} title={c.command}>{c.command.slice(0, 64)}</span>
+              <span style={{ color: c.last_run ? 'var(--color-success, #50fa7b)' : 'rgba(244,244,249,0.4)' }}>{c.last_run ? `last ${c.last_run.slice(0, 16)}` : 'never run'}</span>
+            </div>
+          ))}
+        </Section>
+      </div>
+    </div>
+  );
+}
+
+export default function ObservabilityPage() {
+  const { data, isLoading, error } = useObservability();
+  if (isLoading) {
+    return <div data-testid="observability-loading" style={{ padding: 24, color: 'var(--color-muted)' }}>Loading observability…</div>;
+  }
+  if (error || !data) {
+    return <div data-testid="observability-error" style={{ padding: 24, color: 'var(--color-danger, #ff5555)' }}>Failed to load observability.</div>;
+  }
+  return <Body data={data} />;
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -2,7 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname, useRouter, useSearchParams } from 'next/navigation';
-import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse, Map, SlidersHorizontal } from 'lucide-react';
+import { LayoutDashboard, Coins, Monitor, Cpu, DollarSign, MessageSquare, Radio, AlertTriangle, Kanban, ShieldAlert, Activity, FileText, Brain, Lightbulb, ClipboardList, HeartPulse, Map, SlidersHorizontal, Eye } from 'lucide-react';
 
 const DOMAINS = ['All', 'Coding', 'Analytics'] as const;
 type Domain = typeof DOMAINS[number];
@@ -13,6 +13,7 @@ const OPERATOR_NAV = [
   { href: '/operator/kanban', label: 'Kanban Board', icon: Kanban },
   { href: '/operator/planning', label: 'Planning', icon: Map },
   { href: '/operator/config', label: 'Config', icon: SlidersHorizontal },
+  { href: '/operator/observability', label: 'Observability', icon: Eye },
   { href: '/operator/governance', label: 'Governance', icon: ShieldAlert },
   { href: '/operator/intelligence', label: 'Intelligence', icon: Brain },
   { href: '/operator/dispatches', label: 'Dispatches', icon: ClipboardList },

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -13,6 +13,7 @@ import {
   fetchPlanning,
   fetchConfig,
   fetchConfigAudit,
+  fetchObservability,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -33,7 +34,7 @@ import type {
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
   GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
-  ConfigEnvelope, ConfigAuditEnvelope,
+  ConfigEnvelope, ConfigAuditEnvelope, ObservabilityEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
@@ -194,6 +195,14 @@ export function useConfig() {
     'operator-config',
     fetchConfig,
     { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function useObservability() {
+  return useSWR<ObservabilityEnvelope>(
+    'operator-observability',
+    fetchObservability,
+    { refreshInterval: 20000, revalidateOnFocus: true, dedupingInterval: 8000 }
   );
 }
 

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -17,6 +17,7 @@ import type {
   ConfigSetRequest,
   ConfigSetResponse,
   ConfigAuditEnvelope,
+  ObservabilityEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
   PatternsResponse,
@@ -141,6 +142,10 @@ export function fetchPlanning(): Promise<PlanningEnvelope> {
 
 export function fetchConfig(): Promise<ConfigEnvelope> {
   return get(`${BASE}/config`);
+}
+
+export function fetchObservability(): Promise<ObservabilityEnvelope> {
+  return get(`${BASE}/observability`);
 }
 
 export function postConfigSet(req: ConfigSetRequest): Promise<ConfigSetResponse> {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -296,6 +296,62 @@ export interface ConfigAuditEnvelope {
   degraded?: boolean;
 }
 
+// ===== Observability (governance / audit-trail) Types =====
+
+export interface ConfidenceEvent {
+  dispatch_id: string;
+  outcome: string;
+  confidence_change: number;
+  patterns_boosted: number;
+  patterns_decayed: number;
+  occurred_at: string;
+}
+
+export interface TaggingEvent {
+  table_name: string;
+  pattern_id: number;
+  pattern_title: string | null;
+  tags: string[];
+  provider: string | null;
+  tagged_at: string;
+}
+
+export interface ProvenanceRow {
+  dispatch_id: string;
+  receipt_id: string | null;
+  commit_sha: string | null;
+  pr_number: number | null;
+  chain_status: string;
+  gaps: unknown[];
+  registered_at: string;
+}
+
+export interface CronJob {
+  schedule: string;
+  command: string;
+  last_run: string | null;
+}
+
+export interface DaemonProc {
+  pid: string;
+  name: string;
+}
+
+export interface ObservabilityEnvelope {
+  project_id: string;
+  queried_at: string;
+  self_learning: { events: ConfidenceEvent[]; proposals: number; degraded?: boolean };
+  tagging: { events: TaggingEvent[]; degraded?: boolean };
+  provenance: { by_status: Record<string, number>; recent: ProvenanceRow[]; degraded?: boolean };
+  runtime: {
+    cron: CronJob[];
+    daemons: DaemonProc[];
+    daemons_running: number;
+    cron_degraded?: boolean;
+    daemons_degraded?: boolean;
+  };
+}
+
 // ===== Kanban Board Types =====
 
 export interface KanbanCard {


### PR DESCRIPTION
## Summary
The dashboard audit-trail panel Vincent requested: **what the self-learning loop adjusts, what the
tagging agent does, whether cron jobs run, + the provenance/traceability chain.**

## Changes
- **`dashboard/api_observability.py`** (new) — `GET /api/operator/observability`, 4 **read-only,
  fail-open** sections: self-learning (`confidence_events` + pending_rules), tagging (`tagging_events`,
  #966), provenance (`provenance_registry` chain_status + gaps, #967), runtime (host crontab filtered to
  VNX + VNX daemon liveness via `ps`, scoped to this project). Always 200; each section self-reports
  `degraded`.
- **`serve_dashboard.py`** — wired the GET route.
- **`token-dashboard`** — `ObservabilityEnvelope` + fetch + `useObservability` (20s) + the
  `/operator/observability` page (4 sections, empty/degraded states, chain-status colour, daemon
  liveness) + sidebar link + a 3-test page test.

## Verification
- **kimi-diff-gate: PASS** — fail-open, no injection, subprocess bounded (timeout=5) + project-scoped,
  no PII. Live functional check: 200 with cron=3, daemons=0, tagging degraded, provenance empty (the
  honest current state). Source typechecks; scanner clean.

## Open Items
The three data sections fill as the producers run for vnx-dev. Remaining: provenance B2/B3 (commit-hook
+ enforcement flip) to drive `chain_status` to `complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)