### PR TITLE
feat(provenance): close dispatch→commit half of the chain

### DIFF
--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -456,6 +456,57 @@ def register_provenance_link(
     )
 
 
+def reconcile_commit_provenance(
+    repo_root: "str | Path",
+    conn: sqlite3.Connection,
+    *,
+    max_commits: int = 300,
+) -> Dict[str, int]:
+    """Close the dispatch->commit link: scan recent git commits for a ``Dispatch-ID:`` trace token
+    and register each commit's SHA against its dispatch_id in the provenance_registry.
+
+    This is the merge-side half of the chain (B1 wrote dispatch_id+receipt_id at append; this writes
+    commit_sha so chain_status can reach 'complete'). Read-git + upsert-registry; best-effort — git
+    errors yield ``{scanned: 0, linked: 0}``. Idempotent: register_provenance_link upserts per dispatch_id.
+    """
+    try:
+        from trace_token_validator import extract_trace_tokens  # noqa: PLC0415
+    except Exception:
+        return {"scanned": 0, "linked": 0}
+    try:
+        # Null-record-separated SHA + full body, so multi-line commit bodies stay intact.
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "log", f"-{int(max_commits)}", "--no-merges",
+             "--format=%H%x1f%B%x1e"],
+            capture_output=True, text=True, timeout=20,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return {"scanned": 0, "linked": 0}
+    if result.returncode != 0:
+        return {"scanned": 0, "linked": 0}
+
+    scanned = linked = 0
+    for entry in result.stdout.split("\x1e"):
+        entry = entry.strip()
+        if not entry:
+            continue
+        sha, _sep, body = entry.partition("\x1f")
+        sha = sha.strip()
+        if not sha:
+            continue
+        scanned += 1
+        tokens = extract_trace_tokens(body)
+        dispatch_id = tokens.preferred or tokens.legacy_dispatch
+        if not dispatch_id:
+            continue
+        try:
+            register_provenance_link(conn, dispatch_id=dispatch_id, commit_sha=sha)
+            linked += 1
+        except sqlite3.Error:
+            continue
+    return {"scanned": scanned, "linked": linked}
+
+
 def get_provenance_link(
     conn: sqlite3.Connection,
     dispatch_id: str,

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -334,10 +334,14 @@ class SubprocessAdapter:
         }
         if cwd is not None:
             popen_kwargs["cwd"] = str(cwd)
-        if extra_env or scrub_env_keys:
+        # Always export the dispatch id so worker commits carry a provenance trace token
+        # (prepare-commit-msg hook -> trace_token_validator), closing the dispatch->commit link.
+        if extra_env or scrub_env_keys or dispatch_id:
             merged_env = os.environ.copy()
             if extra_env:
                 merged_env.update({k: v for k, v in extra_env.items() if v is not None})
+            if dispatch_id:
+                merged_env["VNX_CURRENT_DISPATCH_ID"] = dispatch_id
             for _scrub_key in (scrub_env_keys or ()):
                 merged_env.pop(_scrub_key, None)
             popen_kwargs["env"] = merged_env

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -679,21 +679,21 @@ class TmuxInteractiveDispatch:
         )
 
     # -- tmux primitives ---------------------------------------------------
-    def _spawn_session(self, session: str, cwd: Path) -> "tuple[str, str] | None":
-        """Create a detached session; return (pane_id, window_id) or None."""
-        res = self._runner.run(
-            [
-                "new-session",
-                "-d",
-                "-s",
-                session,
-                "-c",
-                str(cwd),
-                "-P",
-                "-F",
-                "#{pane_id}",
-            ]
-        )
+    def _spawn_session(
+        self, session: str, cwd: Path, dispatch_id: str = ""
+    ) -> "tuple[str, str] | None":
+        """Create a detached session; return (pane_id, window_id) or None.
+
+        When ``dispatch_id`` is provided it is exported into the pane environment as
+        ``VNX_CURRENT_DISPATCH_ID`` so the worker's ``git commit`` carries a provenance
+        trace token (read by the prepare-commit-msg hook / trace_token_validator), closing
+        the dispatch->commit link in the provenance_registry.
+        """
+        args = ["new-session", "-d", "-s", session, "-c", str(cwd)]
+        if dispatch_id:
+            args += ["-e", f"VNX_CURRENT_DISPATCH_ID={dispatch_id}"]
+        args += ["-P", "-F", "#{pane_id}"]
+        res = self._runner.run(args)
         if res.returncode != 0:
             logger.warning(
                 "interactive: new-session %s failed: %s", session, res.stderr.strip()
@@ -1632,7 +1632,7 @@ class TmuxInteractiveDispatch:
         window_id: "str | None" = None
         try:
             # 1. Spawn detached session
-            spawned = self._spawn_session(session, cwd)
+            spawned = self._spawn_session(session, cwd, dispatch_id)
             if spawned is None:
                 self._emit_event(
                     "interactive_spawn_failed",

--- a/scripts/reconcile_provenance.py
+++ b/scripts/reconcile_provenance.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Reconcile the dispatch->commit half of the provenance chain.
+
+The receipt path already writes ``dispatch_id`` + ``receipt_id`` into the provenance_registry
+at append time (B1). The commit half lands later: a governed worker commits with a
+``Dispatch-ID:`` trace token (stamped by the prepare-commit-msg hook, which reads
+``VNX_CURRENT_DISPATCH_ID`` set by the dispatch lane). This script scans recent git commits for
+those tokens and writes each commit's SHA back into the registry so ``chain_status`` can reach
+``complete`` and the dashboard Observability panel shows the closed chain.
+
+Usage:
+    python3 scripts/reconcile_provenance.py                 # reconcile central store for this project
+    python3 scripts/reconcile_provenance.py --max-commits 500
+    python3 scripts/reconcile_provenance.py --project-id mission-control
+    python3 scripts/reconcile_provenance.py --json          # structured output
+
+Idempotent: register_provenance_link upserts per dispatch_id. Read-git + write-registry only.
+
+BILLING SAFETY: No Anthropic SDK. No LLM calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIB_DIR = SCRIPT_DIR / "lib"
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from project_root import (  # noqa: E402
+    resolve_central_data_dir,
+    resolve_project_id,
+    resolve_project_root,
+)
+from receipt_provenance import reconcile_commit_provenance  # noqa: E402
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+def _table_exists(conn: sqlite3.Connection, name: str) -> bool:
+    row = conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone()
+    return row is not None
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-commits", type=int, default=300,
+                        help="how many recent commits to scan (default: 300)")
+    parser.add_argument("--project-id", default=None,
+                        help="central-store project_id (default: resolved for this repo)")
+    parser.add_argument("--json", action="store_true", help="emit a JSON result line")
+    args = parser.parse_args(argv)
+
+    repo_root = resolve_project_root(__file__)
+    try:
+        project_id = args.project_id or resolve_project_id(repo_root)
+    except RuntimeError as exc:
+        print(f"reconcile_provenance: cannot resolve project_id: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    db_path = resolve_central_data_dir(project_id) / "state" / "runtime_coordination.db"
+    if not db_path.exists():
+        result = {"scanned": 0, "linked": 0, "degraded": f"no registry db at {db_path}"}
+        print(json.dumps(result) if args.json else
+              f"reconcile_provenance: no registry db ({db_path}) — nothing to do")
+        return EXIT_OK
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        if not _table_exists(conn, "provenance_registry"):
+            result = {"scanned": 0, "linked": 0, "degraded": "provenance_registry table missing"}
+            print(json.dumps(result) if args.json else
+                  "reconcile_provenance: provenance_registry table missing — nothing to do")
+            return EXIT_OK
+        result = reconcile_commit_provenance(repo_root, conn, max_commits=args.max_commits)
+        conn.commit()
+    finally:
+        conn.close()
+
+    result["project_id"] = project_id
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(f"reconcile_provenance[{project_id}]: scanned {result['scanned']} commit(s), "
+              f"linked {result['linked']} dispatch->commit edge(s)")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -110,5 +110,70 @@ def test_missing_db_is_fail_open(tmp_path):
     enrichment._register_provenance_link({"dispatch_id": "D-y", "run_id": "r"}, sd)  # must not raise
 
 
+import subprocess  # noqa: E402
+
+from receipt_provenance import reconcile_commit_provenance  # noqa: E402
+
+
+def _git_repo_with_commit(tmp_path, body: str) -> Path:
+    """Init a throwaway git repo and create one commit with the given message body. Returns repo path."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    env = {
+        "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+        "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+        "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+        "HOME": str(tmp_path),
+    }
+    subprocess.run(["git", "init", "-q"], cwd=repo, env=env, check=True)
+    (repo / "f.txt").write_text("x")
+    subprocess.run(["git", "add", "."], cwd=repo, env=env, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", body], cwd=repo, env=env, check=True)
+    return repo
+
+
+def test_reconcile_links_commit_sha_from_trace_token(tmp_path):
+    sd = _state_dir(tmp_path)
+    # Receipt half is already written (dispatch_id known, commit not yet).
+    enrichment._register_provenance_link({"dispatch_id": "20260628-120000-feat", "run_id": "r-1"}, sd)
+    repo = _git_repo_with_commit(tmp_path, "feat: a thing\n\nDispatch-ID: 20260628-120000-feat\n")
+    expected_sha = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, capture_output=True, text=True,
+    ).stdout.strip()
+
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    result = reconcile_commit_provenance(repo, conn, max_commits=50)
+    conn.commit()
+    row = conn.execute(
+        "SELECT commit_sha FROM provenance_registry WHERE dispatch_id = ?",
+        ("20260628-120000-feat",),
+    ).fetchone()
+    conn.close()
+
+    assert result["linked"] == 1
+    assert result["scanned"] >= 1
+    assert row is not None and row[0] == expected_sha
+
+
+def test_reconcile_ignores_tokenless_commits(tmp_path):
+    sd = _state_dir(tmp_path)
+    repo = _git_repo_with_commit(tmp_path, "chore: no token here\n")
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    result = reconcile_commit_provenance(repo, conn, max_commits=50)
+    n = conn.execute("SELECT COUNT(*) FROM provenance_registry").fetchone()[0]
+    conn.close()
+    assert result["linked"] == 0
+    assert n == 0  # no token -> no registry write
+
+
+def test_reconcile_bad_repo_is_fail_open(tmp_path):
+    # Not a git repo -> git log fails -> {scanned:0, linked:0}, never raises.
+    sd = _state_dir(tmp_path)
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    result = reconcile_commit_provenance(tmp_path / "not-a-repo", conn, max_commits=50)
+    conn.close()
+    assert result == {"scanned": 0, "linked": 0}
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -10,6 +10,7 @@ are known (the commit happens later), so chain_status stays 'incomplete' until m
 """
 
 import sqlite3
+import subprocess
 import sys
 from pathlib import Path
 
@@ -19,6 +20,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts" / "lib"))
 
 from append_receipt_internals import enrichment  # noqa: E402
+from receipt_provenance import reconcile_commit_provenance  # noqa: E402
 
 _REGISTRY_SCHEMA = """
 CREATE TABLE provenance_registry (
@@ -108,11 +110,6 @@ def test_missing_db_is_fail_open(tmp_path):
     sd = tmp_path / "empty"
     sd.mkdir()
     enrichment._register_provenance_link({"dispatch_id": "D-y", "run_id": "r"}, sd)  # must not raise
-
-
-import subprocess  # noqa: E402
-
-from receipt_provenance import reconcile_commit_provenance  # noqa: E402
 
 
 def _git_repo_with_commit(tmp_path, body: str) -> Path:


### PR DESCRIPTION
## Summary

Completes the provenance light-up ("Maak af"). B1 (#967) already wrote the receipt half (dispatch_id + receipt_id) into `provenance_registry` at append time, but the commit half stayed empty — nothing populated `commit_sha`, and the dispatch lanes never exported `VNX_CURRENT_DISPATCH_ID`, so worker commits carried no trace token. This wires the missing half so `chain_status` can reach `complete` and the Observability panel shows a closed dispatch→receipt→commit chain. Read-git + write-registry only; no LLM, no Anthropic SDK.

## Changes

- **`receipt_provenance.py`** — new `reconcile_commit_provenance(repo_root, conn, *, max_commits=300)`: scans recent git commits for a `Dispatch-ID:` trace token and upserts each commit's SHA into the registry. Best-effort + idempotent (upsert).
- **`tmux_interactive_dispatch.py`** — `_spawn_session` exports `tmux new-session -e VNX_CURRENT_DISPATCH_ID=<id>` (default tmux-spawn lane), so the worker pane's `git commit` gets the trace token stamped by the prepare-commit-msg hook.
- **`subprocess_adapter.py`** — `deliver()` exports `VNX_CURRENT_DISPATCH_ID` into the worker subprocess env (opt-in subprocess lane).
- **`scripts/reconcile_provenance.py`** — new operator/cron CLI; targets the central per-project store; fail-open when DB/table absent.
- **tests** — 3 new (token→commit_sha link, tokenless ignored, non-git fail-open).

## Verification

- `pytest tests/test_provenance_registry_population.py` → **7 passed** (4 existing + 3 new).
- `pytest -k "provenance or trace_token" --timeout=60` → **147 passed, 0 failed**.
- CLI smoke → `{"scanned": 20, "linked": 0, "project_id": "vnx-dev"}` (linked 0 is honest — lanes now stamp going forward).
- silent-except scanner → clean; kimi-diff-gate → **VERDICT: PASS**.

## Open Items

- B3 enforcement deliberately NOT force-flipped: `VNX_PROVENANCE_ENFORCEMENT` stays shadow-default (`0`), surfaced read-only in Observability. Flipping to `1` would block tokenless operator commits.
- Reconcile runs on-demand via CLI; wire into nightly cron to auto-close (not added here — env-specific).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC