### PR TITLE
feat(intelligence): rework-attribution engine (slice 1a)

### DIFF
--- a/scripts/attribute_rework.py
+++ b/scripts/attribute_rework.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Attribute rework to the originating dispatch + role, and persist the origin link.
+
+Slice 1 of the rework->skill loop. Traverses git same-line churn over commits carrying a Dispatch-ID
+trace token (post-#969), blames the replaced lines back to the origin token-commit, and writes the
+dominant origin into ``dispatch_metadata.parent_dispatch`` so "rework -> original dispatch -> role" is a
+persistent, auditable edge. Also prints per-role first-pass success (already-populated data) so the
+pattern is visible immediately.
+
+Usage:
+    python3 scripts/attribute_rework.py                 # attribute + persist for this project
+    python3 scripts/attribute_rework.py --no-persist    # dry: compute + print, write nothing
+    python3 scripts/attribute_rework.py --json
+    python3 scripts/attribute_rework.py --project-id mission-control --max-commits 500
+
+Read-git + a single fill-once UPDATE per rework edge. Idempotent. No LLM, no Anthropic SDK.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIB_DIR = SCRIPT_DIR / "lib"
+sys.path.insert(0, str(LIB_DIR))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from project_root import (  # noqa: E402
+    resolve_central_data_dir,
+    resolve_project_id,
+    resolve_project_root,
+)
+from rework_attribution import (  # noqa: E402
+    compute_rework_edges,
+    rework_by_origin_role,
+    success_by_role,
+)
+
+EXIT_OK = 0
+EXIT_ERROR = 1
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--max-commits", type=int, default=300)
+    parser.add_argument("--project-id", default=None)
+    parser.add_argument("--no-persist", action="store_true", help="compute only; do not write parent_dispatch")
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args(argv)
+
+    repo_root = resolve_project_root(__file__)
+    try:
+        project_id = args.project_id or resolve_project_id(repo_root)
+    except RuntimeError as exc:
+        print(f"attribute_rework: cannot resolve project_id: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    state = resolve_central_data_dir(project_id) / "state"
+    rc_path = state / "runtime_coordination.db"
+    qi_path = state / "quality_intelligence.db"
+    if not qi_path.exists():
+        msg = {"degraded": f"no quality_intelligence.db at {qi_path}", "edges": [], "persisted": 0}
+        print(json.dumps(msg) if args.json else f"attribute_rework: {msg['degraded']} — nothing to do")
+        return EXIT_OK
+
+    # Open inside try: a corrupted DB file must fail-open like a missing one, not exit with an error.
+    try:
+        rc_conn = sqlite3.connect(f"file:{rc_path}?mode=ro", uri=True) if rc_path.exists() else None
+        qi_conn = sqlite3.connect(str(qi_path))
+    except sqlite3.Error as exc:
+        msg = {"degraded": f"cannot open store: {exc}", "edges": [], "persisted": 0}
+        print(json.dumps(msg) if args.json else f"attribute_rework: {msg['degraded']} — nothing to do")
+        return EXIT_OK
+    try:
+        if rc_conn is None:
+            result = {"scanned": 0, "edges": [], "persisted": 0}
+        else:
+            result = compute_rework_edges(
+                repo_root, rc_conn, qi_conn, project_id,
+                max_commits=args.max_commits, persist=not args.no_persist,
+            )
+            qi_conn.commit()
+        roles = success_by_role(qi_conn)
+        rework_roles = rework_by_origin_role(qi_conn, project_id)
+    finally:
+        qi_conn.close()
+        if rc_conn is not None:
+            rc_conn.close()
+
+    payload = {
+        "project_id": project_id,
+        "scanned": result["scanned"],
+        "edges": result["edges"],
+        "persisted": result["persisted"],
+        "success_by_role": roles,
+        "rework_by_origin_role": rework_roles,
+    }
+    if args.json:
+        print(json.dumps(payload))
+        return EXIT_OK
+
+    print(f"attribute_rework[{project_id}]: scanned {result['scanned']} token-commit(s), "
+          f"found {len(result['edges'])} rework edge(s), persisted {result['persisted']}")
+    for e in result["edges"]:
+        print(f"  rework {e['rework_dispatch']} ({e['rework_role']}) "
+              f"<- origin {e['origin_dispatch']} ({e['origin_role']}) [{e['lines']} line(s)]")
+    if rework_roles:
+        print("rework by origin role:")
+        for r in rework_roles:
+            print(f"  {r['origin_role']}: {r['reworked']} reworked")
+    print("first-pass success by role (top 8):")
+    for r in roles[:8]:
+        print(f"  {r['role']}: {r['successes']}/{r['total']} ({r['success_rate']})")
+    return EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/rework_attribution.py
+++ b/scripts/lib/rework_attribution.py
@@ -1,0 +1,213 @@
+"""Attribute rework back to the originating dispatch and the role/skill that governed it.
+
+This is the read-only attribution engine (slice 1 of the rework→skill loop). It is unlocked by the
+provenance chain (#969): now that commit→dispatch is queryable, rework can be traced from the commit
+that reworks code back to the commit (and dispatch, and role) that originally wrote it.
+
+Signal: git same-line churn. For each commit carrying a Dispatch-ID trace token, the lines it
+*replaced* are blamed against its parent; whichever earlier token-commit introduced those lines is the
+origin. The dominant origin becomes the dispatch's ``parent_dispatch`` (an existing, dormant column),
+making the "rework → original dispatch" edge persistent and auditable.
+
+Forward-looking by construction: only commits stamped with a token (governed lanes, post-#969) carry
+the link, so edges accrue as governed dispatches land. No new table (ADR-007-free); rework-by-role is a
+self-join over ``parent_dispatch``. Read-git + a single fill-once UPDATE; best-effort, never raises.
+
+DBs (central per-project store):
+  - provenance_registry  -> runtime_coordination.db   (commit_sha -> dispatch_id)
+  - dispatch_metadata    -> quality_intelligence.db   (dispatch_id -> role; parent_dispatch sink)
+"""
+
+from __future__ import annotations
+
+import re
+import sqlite3
+import subprocess
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, List, Optional
+
+_HUNK_RE = re.compile(r"^@@ -(\d+)(?:,(\d+))? ")
+_SHA_RE = re.compile(r"^([0-9a-f]{40}) ")
+
+
+def _run_git(repo_root: "str | Path", args: List[str], *, timeout: int = 20) -> Optional[str]:
+    """Run a git subcommand; return stdout or None on any failure (fail-open)."""
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), *args],
+            capture_output=True, text=True, timeout=timeout,
+        )
+    except (subprocess.SubprocessError, OSError):
+        return None
+    if result.returncode != 0:
+        return None
+    return result.stdout
+
+
+def _changed_regions(repo_root: "str | Path", commit: str) -> "Dict[str, List[tuple]]":
+    """Pre-image file -> list of (old_start, old_count) regions this commit replaced.
+
+    old_count == 0 (a pure insertion) reworks nothing and is skipped. New files (--- /dev/null) have
+    no pre-image and are skipped. -M lets git follow renames so blame targets the right pre-image path.
+    """
+    # core.quotepath=false keeps non-ASCII paths literal (otherwise git octal-quotes them and blame misses).
+    out = _run_git(repo_root, ["-c", "core.quotepath=false", "show", commit, "--unified=0", "--format=", "-M"])
+    regions: "Dict[str, List[tuple]]" = defaultdict(list)
+    if not out:
+        return regions
+    cur_pre: Optional[str] = None
+    for line in out.splitlines():
+        if line.startswith("--- "):
+            path = line[4:].strip()
+            # git C-quotes paths with special chars: --- "a/has space.py". Drop the quotes (best-effort).
+            if len(path) >= 2 and path[0] == '"' and path[-1] == '"':
+                path = path[1:-1]
+            cur_pre = None if path == "/dev/null" else (path[2:] if path.startswith(("a/", "b/")) else path)
+        elif line.startswith("@@ ") and cur_pre:
+            m = _HUNK_RE.match(line)
+            if not m:
+                continue
+            old_start = int(m.group(1))
+            old_count = int(m.group(2)) if m.group(2) is not None else 1
+            if old_count > 0 and old_start > 0:
+                regions[cur_pre].append((old_start, old_count))
+    return regions
+
+
+def _blame_origin_counts(
+    repo_root: "str | Path", commit: str, regions: "Dict[str, List[tuple]]"
+) -> "Dict[str, int]":
+    """Blame the replaced regions against ``commit``'s parent; count lines per origin commit SHA."""
+    counts: "Dict[str, int]" = defaultdict(int)
+    parent = f"{commit}^"
+    for pre_file, spans in regions.items():
+        for old_start, old_count in spans:
+            out = _run_git(
+                repo_root,
+                ["blame", "-L", f"{old_start},+{old_count}", "--porcelain", parent, "--", pre_file],
+            )
+            if not out:
+                continue
+            for line in out.splitlines():
+                m = _SHA_RE.match(line)
+                if m:
+                    counts[m.group(1)] += 1
+    return counts
+
+
+def load_commit_dispatch_map(rc_conn: sqlite3.Connection) -> "Dict[str, str]":
+    """commit_sha -> dispatch_id from the provenance_registry (only rows with a commit)."""
+    try:
+        rows = rc_conn.execute(
+            "SELECT commit_sha, dispatch_id FROM provenance_registry "
+            "WHERE commit_sha IS NOT NULL AND commit_sha != ''"
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+    return {sha: did for sha, did in rows if sha and did}
+
+
+def load_dispatch_roles(qi_conn: sqlite3.Connection, project_id: str) -> "Dict[str, str]":
+    """dispatch_id -> role from dispatch_metadata for this project."""
+    try:
+        rows = qi_conn.execute(
+            "SELECT dispatch_id, role FROM dispatch_metadata WHERE project_id = ?",
+            (project_id,),
+        ).fetchall()
+    except sqlite3.Error:
+        return {}
+    return {did: role for did, role in rows if did}
+
+
+def _persist_parent(qi_conn: sqlite3.Connection, project_id: str, rework_did: str, origin_did: str) -> bool:
+    """Fill-once: set parent_dispatch only when currently empty. Returns True if a row was updated."""
+    try:
+        cur = qi_conn.execute(
+            "UPDATE dispatch_metadata SET parent_dispatch = ? "
+            "WHERE project_id = ? AND dispatch_id = ? "
+            "AND (parent_dispatch IS NULL OR parent_dispatch = '')",
+            (origin_did, project_id, rework_did),
+        )
+        return cur.rowcount > 0
+    except sqlite3.Error:
+        return False
+
+
+def compute_rework_edges(
+    repo_root: "str | Path",
+    rc_conn: sqlite3.Connection,
+    qi_conn: sqlite3.Connection,
+    project_id: str,
+    *,
+    max_commits: int = 300,
+    persist: bool = True,
+) -> "Dict[str, object]":
+    """Traverse git churn over token-commits, attribute each to its dominant origin dispatch/role.
+
+    Returns {scanned, edges:[{rework_dispatch, rework_role, origin_dispatch, origin_role, lines}],
+    persisted}. Best-effort; a bad repo / empty registry yields zero edges, never raises.
+    """
+    commit_to_dispatch = load_commit_dispatch_map(rc_conn)
+    roles = load_dispatch_roles(qi_conn, project_id)
+    edges: List[dict] = []
+    persisted = 0
+    scanned = 0
+    # Rework candidates are exactly the token-commits in the registry, newest-first for determinism.
+    for commit_sha, rework_did in sorted(commit_to_dispatch.items(), key=lambda kv: kv[1], reverse=True)[:max_commits]:
+        scanned += 1
+        regions = _changed_regions(repo_root, commit_sha)
+        if not regions:
+            continue
+        origin_counts = _blame_origin_counts(repo_root, commit_sha, regions)
+        # Keep origins that are themselves token-commits of a *different* dispatch.
+        cross: "Dict[str, int]" = defaultdict(int)
+        for origin_sha, n in origin_counts.items():
+            origin_did = commit_to_dispatch.get(origin_sha)
+            if origin_did and origin_did != rework_did:
+                cross[origin_did] += n
+        if not cross:
+            continue
+        origin_did, lines = max(cross.items(), key=lambda kv: kv[1])
+        edges.append({
+            "rework_dispatch": rework_did,
+            "rework_role": roles.get(rework_did),
+            "origin_dispatch": origin_did,
+            "origin_role": roles.get(origin_did),
+            "lines": lines,
+        })
+        if persist and _persist_parent(qi_conn, project_id, rework_did, origin_did):
+            persisted += 1
+    return {"scanned": scanned, "edges": edges, "persisted": persisted}
+
+
+def success_by_role(qi_conn: sqlite3.Connection) -> List[dict]:
+    """Per-role first-pass success from the existing dispatch_success_by_role view (already populated)."""
+    try:
+        rows = qi_conn.execute(
+            "SELECT role, total_dispatches, successes, success_rate "
+            "FROM dispatch_success_by_role WHERE role IS NOT NULL"
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [
+        {"role": r[0], "total": r[1], "successes": r[2], "success_rate": r[3]}
+        for r in rows
+    ]
+
+
+def rework_by_origin_role(qi_conn: sqlite3.Connection, project_id: str) -> List[dict]:
+    """Self-join over parent_dispatch: how often each origin role's work was later reworked."""
+    try:
+        rows = qi_conn.execute(
+            "SELECT p.role AS origin_role, COUNT(*) AS reworked "
+            "FROM dispatch_metadata d "
+            "JOIN dispatch_metadata p "
+            "  ON d.parent_dispatch = p.dispatch_id AND d.project_id = p.project_id "
+            "WHERE d.project_id = ? AND d.parent_dispatch IS NOT NULL AND d.parent_dispatch != '' "
+            "GROUP BY p.role ORDER BY reworked DESC",
+            (project_id,),
+        ).fetchall()
+    except sqlite3.Error:
+        return []
+    return [{"origin_role": r[0], "reworked": r[1]} for r in rows]

--- a/tests/test_rework_attribution.py
+++ b/tests/test_rework_attribution.py
@@ -1,0 +1,222 @@
+#!/usr/bin/env python3
+"""Tests for the rework-attribution engine (slice 1 of the rework->skill loop).
+
+Builds a throwaway git repo with two Dispatch-ID-stamped commits where the second reworks the first's
+lines, both registered in provenance_registry + dispatch_metadata, and asserts the engine attributes
+the rework to the origin dispatch/role and persists the edge into parent_dispatch.
+"""
+
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from rework_attribution import (  # noqa: E402
+    compute_rework_edges,
+    rework_by_origin_role,
+    success_by_role,
+)
+
+_REGISTRY_SCHEMA = """
+CREATE TABLE provenance_registry (
+    dispatch_id TEXT NOT NULL,
+    commit_sha  TEXT,
+    chain_status TEXT NOT NULL DEFAULT 'incomplete',
+    PRIMARY KEY (dispatch_id)
+);
+"""
+
+_QI_SCHEMA = """
+CREATE TABLE dispatch_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    project_id  TEXT NOT NULL,
+    terminal TEXT NOT NULL DEFAULT 'T1',
+    track    TEXT NOT NULL DEFAULT 'A',
+    role TEXT,
+    parent_dispatch TEXT,
+    pattern_count INTEGER DEFAULT 0,
+    prevention_rule_count INTEGER DEFAULT 0,
+    instruction_char_count INTEGER DEFAULT 0,
+    outcome_status TEXT,
+    UNIQUE (project_id, dispatch_id)
+);
+CREATE VIEW dispatch_success_by_role AS
+SELECT role,
+       COUNT(*) AS total_dispatches,
+       SUM(CASE WHEN outcome_status='success' THEN 1 ELSE 0 END) AS successes,
+       ROUND(AVG(CASE WHEN outcome_status='success' THEN 1.0 ELSE 0.0 END), 3) AS success_rate,
+       AVG(pattern_count) AS avg_patterns
+FROM dispatch_metadata WHERE outcome_status IS NOT NULL
+GROUP BY role ORDER BY total_dispatches DESC;
+"""
+
+_GIT_ENV = {
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+
+
+def _git(repo, *args, env_home):
+    # Inherit os.environ (notably PATH, so `git` resolves) and overlay the deterministic git identity.
+    subprocess.run(["git", "-C", str(repo), *args], env={**os.environ, **_GIT_ENV, "HOME": str(env_home)},
+                   check=True, capture_output=True, text=True)
+
+
+def _head(repo):
+    return subprocess.run(["git", "-C", str(repo), "rev-parse", "HEAD"],
+                          capture_output=True, text=True).stdout.strip()
+
+
+def _churn_repo(tmp_path):
+    """init -> base file -> origin commit (rewrites lines 2-3) -> rework commit (rewrites them again).
+
+    Returns (repo, origin_sha, rework_sha).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    f = repo / "mod.py"
+    _git(repo, "init", "-q", env_home=tmp_path)
+
+    f.write_text("L1\nL2\nL3\nL4\nL5\n")
+    _git(repo, "add", ".", env_home=tmp_path)
+    _git(repo, "commit", "-q", "-m", "base", env_home=tmp_path)
+
+    f.write_text("L1\nORIGIN-A\nORIGIN-B\nL4\nL5\n")
+    _git(repo, "add", ".", env_home=tmp_path)
+    _git(repo, "commit", "-q", "-m", "origin work\n\nDispatch-ID: 20260628-100000-origin\n", env_home=tmp_path)
+    origin_sha = _head(repo)
+
+    f.write_text("L1\nREWORK-A\nREWORK-B\nL4\nL5\n")
+    _git(repo, "add", ".", env_home=tmp_path)
+    _git(repo, "commit", "-q", "-m", "rework it\n\nDispatch-ID: 20260628-110000-rework\n", env_home=tmp_path)
+    rework_sha = _head(repo)
+    return repo, origin_sha, rework_sha
+
+
+def _dbs(tmp_path, origin_sha, rework_sha):
+    rc = sqlite3.connect(tmp_path / "runtime_coordination.db")
+    rc.executescript(_REGISTRY_SCHEMA)
+    rc.executemany("INSERT INTO provenance_registry (dispatch_id, commit_sha) VALUES (?, ?)", [
+        ("20260628-100000-origin", origin_sha),
+        ("20260628-110000-rework", rework_sha),
+    ])
+    rc.commit()
+
+    qi = sqlite3.connect(tmp_path / "quality_intelligence.db")
+    qi.executescript(_QI_SCHEMA)
+    qi.executemany(
+        "INSERT INTO dispatch_metadata (dispatch_id, project_id, role, outcome_status) VALUES (?, ?, ?, ?)",
+        [
+            ("20260628-100000-origin", "vnx-dev", "backend-developer", "success"),
+            ("20260628-110000-rework", "vnx-dev", "debugger", "success"),
+        ],
+    )
+    qi.commit()
+    return rc, qi
+
+
+def test_attributes_rework_to_origin_role_and_persists(tmp_path):
+    repo, origin_sha, rework_sha = _churn_repo(tmp_path)
+    rc, qi = _dbs(tmp_path, origin_sha, rework_sha)
+    try:
+        result = compute_rework_edges(repo, rc, qi, "vnx-dev", max_commits=50)
+        qi.commit()
+
+        assert len(result["edges"]) == 1
+        edge = result["edges"][0]
+        assert edge["rework_dispatch"] == "20260628-110000-rework"
+        assert edge["origin_dispatch"] == "20260628-100000-origin"
+        assert edge["rework_role"] == "debugger"
+        assert edge["origin_role"] == "backend-developer"
+        assert edge["lines"] >= 1
+        assert result["persisted"] == 1
+
+        # parent_dispatch persisted (the "rework -> original dispatch" edge made durable)
+        parent = qi.execute(
+            "SELECT parent_dispatch FROM dispatch_metadata WHERE dispatch_id = ?",
+            ("20260628-110000-rework",),
+        ).fetchone()[0]
+        assert parent == "20260628-100000-origin"
+
+        # self-join rollup attributes the rework to the origin role
+        rollup = rework_by_origin_role(qi, "vnx-dev")
+        assert {"origin_role": "backend-developer", "reworked": 1} in rollup
+    finally:
+        rc.close()
+        qi.close()
+
+
+def test_persist_is_fill_once_idempotent(tmp_path):
+    repo, origin_sha, rework_sha = _churn_repo(tmp_path)
+    rc, qi = _dbs(tmp_path, origin_sha, rework_sha)
+    try:
+        compute_rework_edges(repo, rc, qi, "vnx-dev", max_commits=50)
+        qi.commit()
+        # second pass: parent already set -> nothing new persisted
+        second = compute_rework_edges(repo, rc, qi, "vnx-dev", max_commits=50)
+        qi.commit()
+        assert len(second["edges"]) == 1  # edge still computed
+        assert second["persisted"] == 0   # but fill-once: no new write
+    finally:
+        rc.close()
+        qi.close()
+
+
+def test_no_persist_dry_run(tmp_path):
+    repo, origin_sha, rework_sha = _churn_repo(tmp_path)
+    rc, qi = _dbs(tmp_path, origin_sha, rework_sha)
+    try:
+        result = compute_rework_edges(repo, rc, qi, "vnx-dev", max_commits=50, persist=False)
+        assert len(result["edges"]) == 1
+        assert result["persisted"] == 0
+        parent = qi.execute(
+            "SELECT parent_dispatch FROM dispatch_metadata WHERE dispatch_id = ?",
+            ("20260628-110000-rework",),
+        ).fetchone()[0]
+        assert parent is None
+    finally:
+        rc.close()
+        qi.close()
+
+
+def test_empty_registry_yields_no_edges(tmp_path):
+    repo, origin_sha, rework_sha = _churn_repo(tmp_path)
+    rc = sqlite3.connect(tmp_path / "rc.db")
+    rc.executescript(_REGISTRY_SCHEMA)  # no rows
+    qi = sqlite3.connect(tmp_path / "qi.db")
+    qi.executescript(_QI_SCHEMA)
+    try:
+        result = compute_rework_edges(repo, rc, qi, "vnx-dev", max_commits=50)
+        assert result == {"scanned": 0, "edges": [], "persisted": 0}
+        assert success_by_role(qi) == []  # view exists but empty -> []
+    finally:
+        rc.close()
+        qi.close()
+
+
+def test_bad_repo_is_fail_open(tmp_path):
+    rc = sqlite3.connect(tmp_path / "rc.db")
+    rc.executescript(_REGISTRY_SCHEMA)
+    rc.execute("INSERT INTO provenance_registry (dispatch_id, commit_sha) VALUES (?, ?)",
+               ("20260628-110000-rework", "deadbeef" * 5))
+    rc.commit()
+    qi = sqlite3.connect(tmp_path / "qi.db")
+    qi.executescript(_QI_SCHEMA)
+    try:
+        result = compute_rework_edges(tmp_path / "not-a-repo", rc, qi, "vnx-dev", max_commits=50)
+        assert result["edges"] == []  # git fails -> no edges, no raise
+    finally:
+        rc.close()
+        qi.close()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Slice 1a of the rework→skill loop. A read-only engine that traces rework back to the dispatch and role/skill that originally wrote the reworked code — unlocked by the provenance chain (#969), which made commit→dispatch queryable.

Signal is git same-line churn: for each commit carrying a `Dispatch-ID` trace token, the lines it replaced are blamed against its parent; the dominant origin token-commit becomes the dispatch's `parent_dispatch` (a dormant existing column), making the "rework → original dispatch → role" edge persistent and auditable. **No new table** (ADR-007-free); rework-by-role is a self-join over `parent_dispatch`. Read-git + a single fill-once UPDATE; best-effort, never raises.

Forward-looking by construction: edges accrue for token-stamped commits (governed lanes, post-#969). The CLI also surfaces per-role first-pass success from already-populated data, so the pattern is visible immediately — e.g. `security-engineer 50/187 (0.267)`, `debugger 129/287 (0.449)`, `plan-reviewer 204/214 (0.953)`.

## Changes

- `scripts/lib/rework_attribution.py` — `compute_rework_edges` (churn→blame→attribute→persist), `success_by_role`, `rework_by_origin_role`.
- `scripts/attribute_rework.py` — operator/cron CLI (`--no-persist`, `--json`, `--project-id`, `--max-commits`).
- `tests/test_rework_attribution.py` — 5 tests (attribution+persist, fill-once idempotency, dry-run, empty-registry, bad-repo fail-open).

## Verification

- `pytest tests/test_rework_attribution.py` → **5 passed**.
- CLI smoke on live store: `scanned 1, 0 edges` (honest — only #969 carries a token yet); FPY-by-role surfaced.
- kimi-diff-gate → **PASS** (round 1 raised 3 findings — test PATH, CLI fail-open on corrupt DB, quoted paths — all fixed; round 2 clean).

## Open Items

- Forward-looking: rework edges need token-stamped commits. Run `scripts/attribute_rework.py` from nightly cron to accrue.
- Slice 1b (Observability panel) and slice 2 (skill-refinement proposal tier) tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC