### PR TITLE
feat(dashboard): rework/skill-attribution observability panel (slice 1b)

### DIFF
--- a/dashboard/api_observability.py
+++ b/dashboard/api_observability.py
@@ -1,10 +1,11 @@
 """Observability dashboard API — the governance/audit-trail panel.
 
-GET /api/operator/observability returns four read-only, fail-open sections:
+GET /api/operator/observability returns five read-only, fail-open sections:
   - self_learning : recent confidence_events (what the self-learning loop adjusted) + proposal count
   - tagging       : recent tagging_events (what the tagging agent tagged + with which model)
   - runtime       : cron jobs (schedule + last-run) + VNX daemon liveness
   - provenance    : provenance_registry chain_status counts + recent rows with their gaps
+  - rework        : per-role first-pass success + rework-by-origin-role + recent rework edges
 
 Single-tenant: reads this dashboard's project (CANONICAL_STATE_DIR). Every section is best-effort —
 a missing table / db / command yields an empty section + a `degraded` flag, never an error.
@@ -179,8 +180,53 @@ def _runtime() -> dict:
     return out
 
 
+def _rework(limit: int, project_id: str) -> dict:
+    """Rework→skill attribution (slice 1): per-role first-pass success, rework-by-origin-role
+    (self-join over parent_dispatch), and recent rework edges. Read-only, fail-open."""
+    out: dict = {"by_role": [], "by_origin_role": [], "recent": []}
+    conn = _ro_conn(_qi_db())
+    if conn is None:
+        out["degraded"] = True
+        return out
+    try:
+        roles = conn.execute(
+            "SELECT role, total_dispatches, successes, success_rate "
+            "FROM dispatch_success_by_role WHERE role IS NOT NULL ORDER BY total_dispatches DESC LIMIT ?",
+            (limit,),
+        ).fetchall()
+        out["by_role"] = [dict(r) for r in roles]
+    except sqlite3.Error:
+        out["degraded"] = True
+    try:
+        origin = conn.execute(
+            "SELECT p.role AS origin_role, COUNT(*) AS reworked "
+            "FROM dispatch_metadata d JOIN dispatch_metadata p "
+            "  ON d.parent_dispatch = p.dispatch_id AND d.project_id = p.project_id "
+            "WHERE d.project_id = ? AND d.parent_dispatch IS NOT NULL AND d.parent_dispatch != '' "
+            "GROUP BY p.role ORDER BY reworked DESC",
+            (project_id,),
+        ).fetchall()
+        out["by_origin_role"] = [dict(r) for r in origin]
+        edges = conn.execute(
+            "SELECT d.dispatch_id AS rework_dispatch, d.role AS rework_role, "
+            "       p.dispatch_id AS origin_dispatch, p.role AS origin_role, d.dispatched_at "
+            "FROM dispatch_metadata d JOIN dispatch_metadata p "
+            "  ON d.parent_dispatch = p.dispatch_id AND d.project_id = p.project_id "
+            "WHERE d.project_id = ? AND d.parent_dispatch IS NOT NULL AND d.parent_dispatch != '' "
+            "ORDER BY d.dispatched_at DESC LIMIT ?",
+            (project_id, limit),
+        ).fetchall()
+        out["recent"] = [dict(r) for r in edges]
+    except sqlite3.Error:
+        # parent_dispatch self-join unavailable on older schema → empty, not an error
+        out["degraded"] = True
+    finally:
+        conn.close()
+    return out
+
+
 def operator_get_observability(params: dict, *, project_id: "str | None" = None) -> "tuple[dict, int]":
-    """GET /api/operator/observability — the four governance/audit sections. Always 200 (fail-open;
+    """GET /api/operator/observability — the five governance/audit sections. Always 200 (fail-open;
     each section self-reports `degraded`)."""
     pid = project_id or _op_dashboard_project_id() or "vnx-dev"
     try:
@@ -193,6 +239,7 @@ def operator_get_observability(params: dict, *, project_id: "str | None" = None)
         "self_learning": _self_learning(limit, pid),
         "tagging": _tagging(limit, pid),
         "provenance": _provenance(limit),
+        "rework": _rework(limit, pid),
         "runtime": _runtime(),
     }
     return body, 200

--- a/dashboard/token-dashboard/__tests__/observability-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/observability-page.test.tsx
@@ -30,6 +30,11 @@ function envelope(over: Partial<ObservabilityEnvelope> = {}): ObservabilityEnvel
       by_status: { complete: 4, incomplete: 2 },
       recent: [{ dispatch_id: 'D-2', receipt_id: 'r2', commit_sha: 'abc12345def', pr_number: 99, chain_status: 'complete', gaps: [], registered_at: '2026-06-28T08:00:00Z' }],
     },
+    rework: {
+      by_role: [{ role: 'security-engineer', total_dispatches: 187, successes: 50, success_rate: 0.267 }],
+      by_origin_role: [{ origin_role: 'backend-developer', reworked: 3 }],
+      recent: [{ rework_dispatch: 'D-rw', rework_role: 'debugger', origin_dispatch: 'D-or', origin_role: 'backend-developer', dispatched_at: '2026-06-28T07:00:00Z' }],
+    },
     runtime: {
       cron: [{ schedule: '0 4 * * *', command: 'nightly_intelligence_pipeline.sh', last_run: '2026-06-28T04:00:00Z' }],
       daemons: [{ pid: '4883', name: 'receipt_processor' }],
@@ -56,6 +61,10 @@ describe('ObservabilityPage', () => {
     expect(screen.getByTestId('obs-tagging-row')).toHaveTextContent('security');
     expect(screen.getByTestId('obs-chain-complete')).toHaveTextContent('complete: 4');
     expect(screen.getByTestId('obs-provenance-row')).toHaveTextContent('D-2');
+    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('security-engineer');
+    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('27%');
+    expect(screen.getByTestId('obs-rework-origin')).toHaveTextContent('backend-developer: 3');
+    expect(screen.getByTestId('obs-rework-edge')).toHaveTextContent('debugger');
     expect(screen.getByTestId('obs-daemons')).toHaveTextContent('1 daemon');
     expect(screen.getByTestId('obs-cron-row')).toHaveTextContent('nightly_intelligence_pipeline');
   });
@@ -65,9 +74,11 @@ describe('ObservabilityPage', () => {
       tagging: { events: [], degraded: true },
       provenance: { by_status: {}, recent: [], degraded: true },
       self_learning: { events: [], proposals: 0 },
+      rework: { by_role: [], by_origin_role: [], recent: [], degraded: true },
       runtime: { cron: [], daemons: [], daemons_running: 0 },
     }));
     expect(screen.getByTestId('obs-degraded-tagging-agent')).toBeInTheDocument();
+    expect(screen.getByTestId('obs-degraded-rework-/-skill')).toBeInTheDocument();
     expect(screen.getByTestId('obs-daemons')).toHaveTextContent('0 daemon');
   });
 

--- a/dashboard/token-dashboard/app/operator/observability/page.tsx
+++ b/dashboard/token-dashboard/app/operator/observability/page.tsx
@@ -39,10 +39,17 @@ function chainColor(status: string): string {
   }
 }
 
+function fpyColor(rate: number): string {
+  if (rate >= 0.8) return 'var(--color-success, #50fa7b)';
+  if (rate >= 0.5) return 'var(--color-warning, #facc15)';
+  return 'var(--color-danger, #ff5555)';  // low first-pass success = rework-prone role
+}
+
 function Body({ data }: { data: ObservabilityEnvelope }) {
   const sl = data.self_learning;
   const tg = data.tagging;
   const pv = data.provenance;
+  const rw = data.rework;
   const rt = data.runtime;
   return (
     <div data-testid="observability-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -100,6 +107,40 @@ function Body({ data }: { data: ObservabilityEnvelope }) {
                 {r.commit_sha ? `commit ${r.commit_sha.slice(0, 8)}` : 'no commit'}{r.pr_number ? ` · PR#${r.pr_number}` : ''}
                 {r.gaps.length ? ` · gaps: ${r.gaps.length}` : ''}
               </span>
+            </div>
+          ))}
+        </Section>
+
+        {/* Rework / skill attribution */}
+        <Section title="Rework / skill" count={rw.by_role.length} degraded={rw.degraded}>
+          <div style={{ fontSize: 11, color: 'var(--color-muted)' }}>First-pass success by role (low = rework-prone)</div>
+          {rw.by_role.length === 0 ? (
+            <div style={_muted}>No role outcomes recorded.</div>
+          ) : rw.by_role.slice(0, 8).map((r, i) => (
+            <div key={i} data-testid="obs-rework-role-row" style={_row}>
+              <span style={{ fontWeight: 700, minWidth: 120 }}>{r.role}</span>
+              <span style={{ color: fpyColor(r.success_rate), fontWeight: 700 }}>{Math.round(r.success_rate * 100)}%</span>
+              <span style={{ color: 'var(--color-muted)' }}>{r.successes}/{r.total_dispatches}</span>
+            </div>
+          ))}
+          {rw.by_origin_role.length > 0 && (
+            <>
+              <div style={{ fontSize: 11, fontWeight: 700, color: 'var(--color-muted)', marginTop: 6 }}>Reworked by origin role</div>
+              <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                {rw.by_origin_role.map((r, i) => (
+                  <span key={i} data-testid="obs-rework-origin" style={{ fontSize: 10, fontWeight: 700, color: 'var(--color-accent, #f97316)', border: '1px solid var(--color-accent, #f97316)', borderRadius: 5, padding: '1px 7px' }}>
+                    {r.origin_role}: {r.reworked}
+                  </span>
+                ))}
+              </div>
+            </>
+          )}
+          {rw.recent.slice(0, 6).map((e, i) => (
+            <div key={`edge-${i}`} data-testid="obs-rework-edge" style={_row}>
+              <code style={{ fontWeight: 700 }}>{e.rework_role ?? '?'}</code>
+              <span style={{ color: 'var(--color-muted)' }}>reworked</span>
+              <span style={{ color: 'var(--color-accent, #f97316)' }}>{e.origin_role ?? '?'}</span>
+              <span style={{ color: 'var(--color-muted)' }}>{e.rework_dispatch} ← {e.origin_dispatch}</span>
             </div>
           ))}
         </Section>

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -343,6 +343,12 @@ export interface ObservabilityEnvelope {
   self_learning: { events: ConfidenceEvent[]; proposals: number; degraded?: boolean };
   tagging: { events: TaggingEvent[]; degraded?: boolean };
   provenance: { by_status: Record<string, number>; recent: ProvenanceRow[]; degraded?: boolean };
+  rework: {
+    by_role: ReworkRoleStat[];
+    by_origin_role: ReworkOriginRole[];
+    recent: ReworkEdge[];
+    degraded?: boolean;
+  };
   runtime: {
     cron: CronJob[];
     daemons: DaemonProc[];
@@ -350,6 +356,26 @@ export interface ObservabilityEnvelope {
     cron_degraded?: boolean;
     daemons_degraded?: boolean;
   };
+}
+
+export interface ReworkRoleStat {
+  role: string;
+  total_dispatches: number;
+  successes: number;
+  success_rate: number;
+}
+
+export interface ReworkOriginRole {
+  origin_role: string;
+  reworked: number;
+}
+
+export interface ReworkEdge {
+  rework_dispatch: string;
+  rework_role: string | null;
+  origin_dispatch: string;
+  origin_role: string | null;
+  dispatched_at: string | null;
 }
 
 // ===== Kanban Board Types =====

--- a/tests/test_observability_rework_section.py
+++ b/tests/test_observability_rework_section.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Tests for the observability API's _rework section (slice 1b).
+
+Covers the inline SQL (per-role first-pass success view, rework-by-origin-role self-join, recent edges)
+and the fail-open contract. Isolates from the canonical store by monkeypatching _qi_db at a temp DB.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "dashboard"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+api_observability = pytest.importorskip("api_observability")
+
+_QI_SCHEMA = """
+CREATE TABLE dispatch_metadata (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    project_id  TEXT NOT NULL,
+    role TEXT,
+    parent_dispatch TEXT,
+    pattern_count INTEGER DEFAULT 0,
+    prevention_rule_count INTEGER DEFAULT 0,
+    instruction_char_count INTEGER DEFAULT 0,
+    dispatched_at DATETIME,
+    outcome_status TEXT,
+    UNIQUE (project_id, dispatch_id)
+);
+CREATE VIEW dispatch_success_by_role AS
+SELECT role,
+       COUNT(*) AS total_dispatches,
+       SUM(CASE WHEN outcome_status='success' THEN 1 ELSE 0 END) AS successes,
+       ROUND(AVG(CASE WHEN outcome_status='success' THEN 1.0 ELSE 0.0 END), 3) AS success_rate
+FROM dispatch_metadata WHERE outcome_status IS NOT NULL
+GROUP BY role ORDER BY total_dispatches DESC;
+"""
+
+
+def _qi(tmp_path) -> Path:
+    db = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(db)
+    conn.executescript(_QI_SCHEMA)
+    conn.executemany(
+        "INSERT INTO dispatch_metadata "
+        "(dispatch_id, project_id, role, parent_dispatch, dispatched_at, outcome_status) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("D-origin", "vnx-dev", "backend-developer", None, "2026-06-28T07:00:00Z", "success"),
+            ("D-rework", "vnx-dev", "debugger", "D-origin", "2026-06-28T08:00:00Z", "success"),
+        ],
+    )
+    conn.commit()
+    conn.close()
+    return db
+
+
+def test_rework_section_surfaces_roles_origin_and_edges(tmp_path, monkeypatch):
+    db = _qi(tmp_path)
+    monkeypatch.setattr(api_observability, "_qi_db", lambda: db)
+    out = api_observability._rework(10, "vnx-dev")
+
+    assert not out.get("degraded")
+    roles = {r["role"]: r for r in out["by_role"]}
+    assert roles["backend-developer"]["success_rate"] == 1.0
+    assert {"origin_role": "backend-developer", "reworked": 1} in out["by_origin_role"]
+    assert len(out["recent"]) == 1
+    edge = out["recent"][0]
+    assert edge["rework_dispatch"] == "D-rework"
+    assert edge["origin_dispatch"] == "D-origin"
+    assert edge["rework_role"] == "debugger"
+    assert edge["origin_role"] == "backend-developer"
+
+
+def test_rework_section_fail_open_when_db_missing(tmp_path, monkeypatch):
+    monkeypatch.setattr(api_observability, "_qi_db", lambda: tmp_path / "nope.db")
+    out = api_observability._rework(10, "vnx-dev")
+    assert out["degraded"] is True
+    assert out["by_role"] == [] and out["by_origin_role"] == [] and out["recent"] == []
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Surfaces the rework-attribution engine (slice 1a, #970) in the dashboard Observability panel. A fifth read-only, fail-open section shows:
- **per-role first-pass success** (low rate = rework-prone role/skill) — populated now from 1654 historical rows
- **rework-by-origin-role** (self-join over `dispatch_metadata.parent_dispatch`)
- **recent rework edges** (which role reworked which role's dispatch)

Audit-first: the operator sees where rework concentrates by role before any skill change is proposed (slice 2). E.g. `security-engineer 50/187 (0.267)`, `debugger 129/287 (0.449)`, `plan-reviewer 204/214 (0.953)`.

## Changes

- `dashboard/api_observability.py` — `_rework` section (FPY view + rework-by-origin-role self-join + recent edges), wired into the envelope; docstrings four→five.
- `lib/types.ts` — `ReworkRoleStat`/`ReworkOriginRole`/`ReworkEdge` + `rework` on `ObservabilityEnvelope`.
- `app/operator/observability/page.tsx` — fifth section + `fpyColor` helper (≥0.8 green / ≥0.5 amber / else red).
- `__tests__/observability-page.test.tsx` — rework mock + assertions.
- `tests/test_observability_rework_section.py` (NEW) — Python test of the inline SQL + fail-open.

## Verification

- `pytest tests/test_observability_rework_section.py` → **2 passed**.
- API smoke vs central store: `degraded=None`, `by_role` populated; `by_origin_role`/`recent` empty (forward-looking).
- `tsc` clean on source; py_compile + silent-except scanner clean; kimi-diff-gate → **PASS**.

## Open Items

- Rework-by-role/edges populate as `scripts/attribute_rework.py` runs; per-role FPY is populated now.
- Slice 2 (skill-refinement proposal tier) is the next roadmap item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC