### PR TITLE
fix(dashboard): exclude benchmark from rework per-role FPY (honest panel)

### DIFF
--- a/dashboard/api_observability.py
+++ b/dashboard/api_observability.py
@@ -183,18 +183,30 @@ def _runtime() -> dict:
 def _rework(limit: int, project_id: str) -> dict:
     """Rework→skill attribution (slice 1): per-role first-pass success, rework-by-origin-role
     (self-join over parent_dispatch), and recent rework edges. Read-only, fail-open."""
-    out: dict = {"by_role": [], "by_origin_role": [], "recent": []}
+    out: dict = {"by_role": [], "by_origin_role": [], "recent": [], "benchmark_excluded": 0}
     conn = _ro_conn(_qi_db())
     if conn is None:
         out["degraded"] = True
         return out
     try:
+        # GOVERNED only: the model-benchmark + headless review-gates run on the `headless` track/terminal
+        # and carry ~99% of role-stamped rows; including them would measure benchmark difficulty, not rework.
         roles = conn.execute(
-            "SELECT role, total_dispatches, successes, success_rate "
-            "FROM dispatch_success_by_role WHERE role IS NOT NULL ORDER BY total_dispatches DESC LIMIT ?",
+            "SELECT role, COUNT(*) AS total_dispatches, "
+            "       SUM(CASE WHEN outcome_status='success' THEN 1 ELSE 0 END) AS successes, "
+            "       ROUND(AVG(CASE WHEN outcome_status='success' THEN 1.0 ELSE 0.0 END), 3) AS success_rate "
+            "FROM dispatch_metadata "
+            "WHERE outcome_status IS NOT NULL AND role IS NOT NULL "
+            "  AND (track IS NULL OR track != 'headless') AND (terminal IS NULL OR terminal != 'headless') "
+            "GROUP BY role ORDER BY total_dispatches DESC LIMIT ?",
             (limit,),
         ).fetchall()
         out["by_role"] = [dict(r) for r in roles]
+        bench = conn.execute(
+            "SELECT COUNT(*) FROM dispatch_metadata WHERE outcome_status IS NOT NULL AND role IS NOT NULL "
+            "  AND (track = 'headless' OR terminal = 'headless')"
+        ).fetchone()
+        out["benchmark_excluded"] = int(bench[0]) if bench and bench[0] is not None else 0
     except sqlite3.Error:
         out["degraded"] = True
     try:

--- a/dashboard/token-dashboard/__tests__/observability-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/observability-page.test.tsx
@@ -31,9 +31,10 @@ function envelope(over: Partial<ObservabilityEnvelope> = {}): ObservabilityEnvel
       recent: [{ dispatch_id: 'D-2', receipt_id: 'r2', commit_sha: 'abc12345def', pr_number: 99, chain_status: 'complete', gaps: [], registered_at: '2026-06-28T08:00:00Z' }],
     },
     rework: {
-      by_role: [{ role: 'security-engineer', total_dispatches: 187, successes: 50, success_rate: 0.267 }],
+      by_role: [{ role: 'reviewer', total_dispatches: 6, successes: 5, success_rate: 0.833 }],
       by_origin_role: [{ origin_role: 'backend-developer', reworked: 3 }],
       recent: [{ rework_dispatch: 'D-rw', rework_role: 'debugger', origin_dispatch: 'D-or', origin_role: 'backend-developer', dispatched_at: '2026-06-28T07:00:00Z' }],
+      benchmark_excluded: 1644,
     },
     runtime: {
       cron: [{ schedule: '0 4 * * *', command: 'nightly_intelligence_pipeline.sh', last_run: '2026-06-28T04:00:00Z' }],
@@ -61,8 +62,9 @@ describe('ObservabilityPage', () => {
     expect(screen.getByTestId('obs-tagging-row')).toHaveTextContent('security');
     expect(screen.getByTestId('obs-chain-complete')).toHaveTextContent('complete: 4');
     expect(screen.getByTestId('obs-provenance-row')).toHaveTextContent('D-2');
-    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('security-engineer');
-    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('27%');
+    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('reviewer');
+    expect(screen.getByTestId('obs-rework-role-row')).toHaveTextContent('83%');
+    expect(screen.getByTestId('obs-rework-benchmark-note')).toHaveTextContent('1644 benchmark rows excluded');
     expect(screen.getByTestId('obs-rework-origin')).toHaveTextContent('backend-developer: 3');
     expect(screen.getByTestId('obs-rework-edge')).toHaveTextContent('debugger');
     expect(screen.getByTestId('obs-daemons')).toHaveTextContent('1 daemon');
@@ -74,7 +76,7 @@ describe('ObservabilityPage', () => {
       tagging: { events: [], degraded: true },
       provenance: { by_status: {}, recent: [], degraded: true },
       self_learning: { events: [], proposals: 0 },
-      rework: { by_role: [], by_origin_role: [], recent: [], degraded: true },
+      rework: { by_role: [], by_origin_role: [], recent: [], benchmark_excluded: 0, degraded: true },
       runtime: { cron: [], daemons: [], daemons_running: 0 },
     }));
     expect(screen.getByTestId('obs-degraded-tagging-agent')).toBeInTheDocument();

--- a/dashboard/token-dashboard/app/operator/observability/page.tsx
+++ b/dashboard/token-dashboard/app/operator/observability/page.tsx
@@ -113,9 +113,16 @@ function Body({ data }: { data: ObservabilityEnvelope }) {
 
         {/* Rework / skill attribution */}
         <Section title="Rework / skill" count={rw.by_role.length} degraded={rw.degraded}>
-          <div style={{ fontSize: 11, color: 'var(--color-muted)' }}>First-pass success by role (low = rework-prone)</div>
+          <div style={{ fontSize: 11, color: 'var(--color-muted)' }}>
+            First-pass success by role — governed only
+            {rw.benchmark_excluded > 0 && (
+              <span data-testid="obs-rework-benchmark-note" style={{ color: 'rgba(244,244,249,0.4)' }}>
+                {' '}· {rw.benchmark_excluded} benchmark rows excluded
+              </span>
+            )}
+          </div>
           {rw.by_role.length === 0 ? (
-            <div style={_muted}>No role outcomes recorded.</div>
+            <div style={_muted}>No governed role-stamped dispatches yet (governed lanes barely stamp role).</div>
           ) : rw.by_role.slice(0, 8).map((r, i) => (
             <div key={i} data-testid="obs-rework-role-row" style={_row}>
               <span style={{ fontWeight: 700, minWidth: 120 }}>{r.role}</span>

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -347,6 +347,8 @@ export interface ObservabilityEnvelope {
     by_role: ReworkRoleStat[];
     by_origin_role: ReworkOriginRole[];
     recent: ReworkEdge[];
+    /** Count of benchmark/headless rows excluded from by_role (governed-only scope). */
+    benchmark_excluded: number;
     degraded?: boolean;
   };
   runtime: {

--- a/scripts/attribute_rework.py
+++ b/scripts/attribute_rework.py
@@ -35,6 +35,7 @@ from project_root import (  # noqa: E402
     resolve_project_root,
 )
 from rework_attribution import (  # noqa: E402
+    benchmark_excluded_count,
     compute_rework_edges,
     rework_by_origin_role,
     success_by_role,
@@ -86,6 +87,7 @@ def main(argv: "list[str] | None" = None) -> int:
             qi_conn.commit()
         roles = success_by_role(qi_conn)
         rework_roles = rework_by_origin_role(qi_conn, project_id)
+        benchmark_excluded = benchmark_excluded_count(qi_conn)
     finally:
         qi_conn.close()
         if rc_conn is not None:
@@ -96,7 +98,8 @@ def main(argv: "list[str] | None" = None) -> int:
         "scanned": result["scanned"],
         "edges": result["edges"],
         "persisted": result["persisted"],
-        "success_by_role": roles,
+        "success_by_role_governed": roles,
+        "benchmark_excluded": benchmark_excluded,
         "rework_by_origin_role": rework_roles,
     }
     if args.json:
@@ -112,7 +115,9 @@ def main(argv: "list[str] | None" = None) -> int:
         print("rework by origin role:")
         for r in rework_roles:
             print(f"  {r['origin_role']}: {r['reworked']} reworked")
-    print("first-pass success by role (top 8):")
+    print(f"first-pass success by role — GOVERNED only ({benchmark_excluded} benchmark rows excluded):")
+    if not roles:
+        print("  (no governed role-stamped dispatches yet — governed lanes barely stamp role; see fix 2/3)")
     for r in roles[:8]:
         print(f"  {r['role']}: {r['successes']}/{r['total']} ({r['success_rate']})")
     return EXIT_OK

--- a/scripts/lib/rework_attribution.py
+++ b/scripts/lib/rework_attribution.py
@@ -181,12 +181,29 @@ def compute_rework_edges(
     return {"scanned": scanned, "edges": edges, "persisted": persisted}
 
 
+# The model-benchmark (field-test) and headless review-gates run on the `headless` track/terminal and
+# carry ~99% of the role-stamped rows. They are NOT governed feature work, so per-role first-pass
+# success must exclude them or the numbers measure benchmark difficulty, not production rework.
+_GOVERNED_PREDICATE = (
+    "(track IS NULL OR track != 'headless') AND (terminal IS NULL OR terminal != 'headless')"
+)
+_BENCHMARK_PREDICATE = "(track = 'headless' OR terminal = 'headless')"
+
+
 def success_by_role(qi_conn: sqlite3.Connection) -> List[dict]:
-    """Per-role first-pass success from the existing dispatch_success_by_role view (already populated)."""
+    """Per-role first-pass success for GOVERNED dispatches only (benchmark/headless excluded).
+
+    Computed directly off dispatch_metadata (not the unfiltered dispatch_success_by_role view) so the
+    benchmark runs don't dominate the rate.
+    """
     try:
         rows = qi_conn.execute(
-            "SELECT role, total_dispatches, successes, success_rate "
-            "FROM dispatch_success_by_role WHERE role IS NOT NULL"
+            "SELECT role, COUNT(*) AS total, "
+            "       SUM(CASE WHEN outcome_status='success' THEN 1 ELSE 0 END) AS successes, "
+            "       ROUND(AVG(CASE WHEN outcome_status='success' THEN 1.0 ELSE 0.0 END), 3) AS success_rate "
+            "FROM dispatch_metadata "
+            "WHERE outcome_status IS NOT NULL AND role IS NOT NULL AND " + _GOVERNED_PREDICATE + " "
+            "GROUP BY role ORDER BY total DESC"
         ).fetchall()
     except sqlite3.Error:
         return []
@@ -194,6 +211,18 @@ def success_by_role(qi_conn: sqlite3.Connection) -> List[dict]:
         {"role": r[0], "total": r[1], "successes": r[2], "success_rate": r[3]}
         for r in rows
     ]
+
+
+def benchmark_excluded_count(qi_conn: sqlite3.Connection) -> int:
+    """How many role-stamped, outcome-bearing rows are benchmark/headless (excluded from success_by_role)."""
+    try:
+        row = qi_conn.execute(
+            "SELECT COUNT(*) FROM dispatch_metadata "
+            "WHERE outcome_status IS NOT NULL AND role IS NOT NULL AND " + _BENCHMARK_PREDICATE
+        ).fetchone()
+    except sqlite3.Error:
+        return 0
+    return int(row[0]) if row and row[0] is not None else 0
 
 
 def rework_by_origin_role(qi_conn: sqlite3.Connection, project_id: str) -> List[dict]:

--- a/tests/test_observability_rework_section.py
+++ b/tests/test_observability_rework_section.py
@@ -22,6 +22,8 @@ CREATE TABLE dispatch_metadata (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
     dispatch_id TEXT NOT NULL,
     project_id  TEXT NOT NULL,
+    terminal TEXT,
+    track TEXT,
     role TEXT,
     parent_dispatch TEXT,
     pattern_count INTEGER DEFAULT 0,
@@ -47,11 +49,14 @@ def _qi(tmp_path) -> Path:
     conn.executescript(_QI_SCHEMA)
     conn.executemany(
         "INSERT INTO dispatch_metadata "
-        "(dispatch_id, project_id, role, parent_dispatch, dispatched_at, outcome_status) "
-        "VALUES (?, ?, ?, ?, ?, ?)",
+        "(dispatch_id, project_id, terminal, track, role, parent_dispatch, dispatched_at, outcome_status) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
         [
-            ("D-origin", "vnx-dev", "backend-developer", None, "2026-06-28T07:00:00Z", "success"),
-            ("D-rework", "vnx-dev", "debugger", "D-origin", "2026-06-28T08:00:00Z", "success"),
+            # governed feature dispatches (track A / terminal T1) — counted
+            ("D-origin", "vnx-dev", "T1", "A", "backend-developer", None, "2026-06-28T07:00:00Z", "success"),
+            ("D-rework", "vnx-dev", "T2", "B", "debugger", "D-origin", "2026-06-28T08:00:00Z", "success"),
+            # benchmark run (headless track) — must be EXCLUDED from by_role, counted in benchmark_excluded
+            ("D-bench", "vnx-dev", "headless", "headless", "security-engineer", None, "2026-06-28T06:00:00Z", "failure"),
         ],
     )
     conn.commit()
@@ -67,6 +72,9 @@ def test_rework_section_surfaces_roles_origin_and_edges(tmp_path, monkeypatch):
     assert not out.get("degraded")
     roles = {r["role"]: r for r in out["by_role"]}
     assert roles["backend-developer"]["success_rate"] == 1.0
+    # benchmark (headless) role is excluded from governed by_role but counted separately
+    assert "security-engineer" not in roles
+    assert out["benchmark_excluded"] == 1
     assert {"origin_role": "backend-developer", "reworked": 1} in out["by_origin_role"]
     assert len(out["recent"]) == 1
     edge = out["recent"][0]

--- a/tests/test_rework_attribution.py
+++ b/tests/test_rework_attribution.py
@@ -18,6 +18,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts" / "lib"))
 
 from rework_attribution import (  # noqa: E402
+    benchmark_excluded_count,
     compute_rework_edges,
     rework_by_origin_role,
     success_by_role,
@@ -215,6 +216,30 @@ def test_bad_repo_is_fail_open(tmp_path):
         assert result["edges"] == []  # git fails -> no edges, no raise
     finally:
         rc.close()
+        qi.close()
+
+
+def test_success_by_role_excludes_benchmark(tmp_path):
+    qi = sqlite3.connect(tmp_path / "qi.db")
+    qi.executescript(_QI_SCHEMA)
+    qi.executemany(
+        "INSERT INTO dispatch_metadata (dispatch_id, project_id, terminal, track, role, outcome_status) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        [
+            ("g1", "vnx-dev", "T1", "A", "backend-developer", "success"),
+            ("g2", "vnx-dev", "T2", "B", "backend-developer", "failure"),
+            # benchmark run on the headless track — must not pollute governed FPY
+            ("b1", "vnx-dev", "headless", "headless", "security-engineer", "failure"),
+        ],
+    )
+    qi.commit()
+    try:
+        roles = {r["role"]: r for r in success_by_role(qi)}
+        assert "security-engineer" not in roles  # benchmark excluded
+        assert roles["backend-developer"]["total"] == 2
+        assert roles["backend-developer"]["successes"] == 1
+        assert benchmark_excluded_count(qi) == 1
+    finally:
         qi.close()
 
 


### PR DESCRIPTION
## Summary

Makes the rework/skill panel honest. Investigation (operator-prompted) found the per-role first-pass-success numbers were ~99% benchmark-contaminated: **1644 of ~1654 role-stamped rows live on the `headless` track/terminal** (the model-benchmark + headless review-gates), not governed feature dispatches. So `security-engineer 0.267` measured benchmark difficulty across all tested models, not production rework.

This filters benchmark/headless rows out of the FPY query and reports the excluded count, so the panel shows the true governed scope — which is thin (the real signal that governed lanes barely stamp role, addressed next in fix 2).

## Changes

- `rework_attribution.py` — `success_by_role` computes directly off `dispatch_metadata` with a governed predicate (not the unfiltered view); new `benchmark_excluded_count`.
- `api_observability.py` — `_rework` FPY query gets the governed filter + a `benchmark_excluded` count.
- `attribute_rework.py` — CLI prints "GOVERNED only (N benchmark rows excluded)".
- `types.ts` + `page.tsx` — `benchmark_excluded` field + note; empty-state copy reflects the thin reality.
- tests — both Python suites add `track`/`terminal` + a benchmark row proving exclusion; frontend note assertion.

## Verification

- `pytest` → **8 passed**. API smoke: `benchmark_excluded=1644`, governed `by_role` collapses to the real 10 rows. kimi-diff-gate → **PASS**.

## Open Items

- Governed FPY is nearly empty by design now — the honest state, and the motivation for fix 2 (lanes must stamp role).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC