### PR TITLE
feat(governance): governed tmux lane stamps agent role forward

### DIFF
--- a/scripts/lib/dispatch_lifecycle.sh
+++ b/scripts/lib/dispatch_lifecycle.sh
@@ -498,6 +498,11 @@ _fdd_log_dispatch_metadata() {
     local agent_role="$5" gate="$6" pr_id="$7" instruction_content="$8"
     local intelligence_data="$9"
 
+    # Parity with subprocess/provider/headless lanes: if the role was not threaded through to the
+    # governed tmux delivery path, recover it from the dispatch file's "Role:" header so per-role
+    # rework attribution is not blind to governed feature work. Honest: empty stays empty if no header.
+    agent_role=$(vnx_dispatch_resolve_agent_role "$agent_role" "$dispatch_file" 2>/dev/null || echo "$agent_role")
+
     local _dm_cognition _dm_priority _dm_pattern_count _dm_rule_count _dm_instr_chars
     _dm_cognition=$(vnx_dispatch_extract_cognition "$dispatch_file" 2>/dev/null || echo "normal")
     _dm_priority=$(vnx_dispatch_extract_priority "$dispatch_file" 2>/dev/null || echo "P1")

--- a/scripts/lib/dispatch_metadata.sh
+++ b/scripts/lib/dispatch_metadata.sh
@@ -39,6 +39,19 @@ vnx_dispatch_extract_agent_role() {
     echo "$role"
 }
 
+# vnx_dispatch_resolve_agent_role — prefer an explicitly threaded role; else recover it from the
+# dispatch file's "Role:" header. Parity with the subprocess/provider/headless lanes (OI-1107) so the
+# governed tmux delivery path stamps a role into dispatch_metadata for per-role rework attribution.
+# No invented fallback: empty stays empty when the file carries no Role: header (honest over guessed).
+vnx_dispatch_resolve_agent_role() {
+    local explicit_role="$1" file="$2"
+    if [ -n "$explicit_role" ]; then
+        echo "$explicit_role"
+        return 0
+    fi
+    [ -n "$file" ] && [ -f "$file" ] && vnx_dispatch_extract_agent_role "$file"
+}
+
 vnx_dispatch_normalize_role() {
     local role="$1"
     echo "$role" | tr -d '[:space:][:punct:]' | tr '[:upper:]' '[:lower:]'

--- a/tests/test_dispatch_resolve_role.sh
+++ b/tests/test_dispatch_resolve_role.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#
+# Tests for vnx_dispatch_resolve_agent_role — the governed tmux delivery path recovers the agent role
+# from the dispatch file's "Role:" header when none was threaded through, so dispatch_metadata stamps a
+# role for per-role rework attribution (parity with the subprocess/provider/headless lanes, OI-1107).
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../scripts/lib/dispatch_metadata.sh"
+
+assert_eq() {
+  local expected="$1" actual="$2" msg="$3"
+  if [ "$expected" != "$actual" ]; then
+    echo "FAIL: $msg (expected='$expected' actual='$actual')"
+    exit 1
+  fi
+}
+
+with_role="$(mktemp)"
+printf 'Role: backend-developer\nGate: implementation\n' > "$with_role"
+no_header="$(mktemp)"   # empty file, no Role: header
+
+# explicit role always wins, even when the file carries a different header
+assert_eq "debugger" "$(vnx_dispatch_resolve_agent_role "debugger" "$with_role")" "explicit role wins over file header"
+# no explicit role -> recover from the file's Role: header
+assert_eq "backend-developer" "$(vnx_dispatch_resolve_agent_role "" "$with_role")" "empty role recovers from file header"
+# no explicit role and no header -> empty (honest: no invented fallback)
+assert_eq "" "$(vnx_dispatch_resolve_agent_role "" "$no_header")" "empty role + no header stays empty"
+# missing file path -> empty, never errors
+assert_eq "" "$(vnx_dispatch_resolve_agent_role "" "/nonexistent/path")" "missing file stays empty"
+
+rm -f "$with_role" "$no_header"
+echo "PASS: vnx_dispatch_resolve_agent_role"


### PR DESCRIPTION
## Summary

Closes the root cause behind the thin governed role data that fix 1 (#973) exposed. The governed tmux delivery path wrote `dispatch_metadata` with whatever `agent_role` was threaded through, and it usually arrived empty — so governed feature dispatches stamped a role only **10 of ~352** times, leaving per-role rework attribution blind to real work.

The subprocess/provider/headless lanes already recover the role from the dispatch file's `Role:` header (OI-1107); the tmux lane did not. This brings it to parity: `_fdd_log_dispatch_metadata` recovers the role via the existing (tested) extractor when none was threaded through. **No invented fallback** — honest empty when the file carries no header.

## Changes

- `dispatch_metadata.sh` — new `vnx_dispatch_resolve_agent_role(explicit_role, file)`: explicit wins, else recover from `Role:` header, else empty.
- `dispatch_lifecycle.sh` — `_fdd_log_dispatch_metadata` resolves the role before the metadata write.
- `tests/test_dispatch_resolve_role.sh` (NEW) — 4 cases (explicit wins, recover-from-header, no-header empty, missing-file empty).

## Verification

- `bash tests/test_dispatch_resolve_role.sh` → **PASS** (4/4); verified against a real pending dispatch file. `bash -n` clean. kimi-diff-gate → **PASS**.

## Open Items

- Forward-only: stamps NEW governed dispatches; historical rows stay role-less.
- Pre-existing/unrelated: `test_dispatch_metadata_lib.sh` fails on `default clear-context` on main (a code-vs-test semantics question about the ClearContext default) — NOT touched here, flagged for an explicit decision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC