### PR TITLE
feat(governance): leaseless tmux lane writes its dispatch_metadata row with role

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -91,8 +91,19 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
     def _dedup_receipts(receipts):  # type: ignore[misc]
         return receipts[-1] if receipts else None
 
+# Shared dispatch_metadata writer — keeps the leaseless tmux lane provider-aware.
+# Imported defensively; if unavailable the lane degrades to its prior behaviour.
+try:
+    from dispatch_metadata_db import upsert_dispatch_provider_row as _upsert_dispatch_metadata  # noqa: E402
+except Exception:  # pragma: no cover - sibling import is available in-tree
+    _upsert_dispatch_metadata = None  # type: ignore[misc]
+
 # Only simple identifiers are valid model names (no whitespace or shell metacharacters).
 _SAFE_MODEL_RE = re.compile(r"^[a-zA-Z0-9][a-zA-Z0-9._-]*$")
+
+# Terminal → track mapping shared with headless provider lanes. The leaseless
+# tmux lane borrows it so T1/T2/T3 dispatches land in tracks A/B/C.
+_TERMINAL_TRACK = {"T1": "A", "T2": "B", "T3": "C"}
 
 # Allowlist for extra_flags tokens: long flags (--foo, --foo=bar, --foo=bar.baz-qux),
 # short flags (-f), and short flags with values (-f val treated as two tokens).
@@ -463,6 +474,62 @@ class TmuxInteractiveDispatch:
         import report_body_contract as _rbc  # noqa: PLC0415
         return body + "\n\n" + _rbc.build_directive(dispatch_id or "", pr_id=pr_id)
 
+    def _stamp_dispatch_metadata(
+        self,
+        dispatch_id: str,
+        terminal_id: str,
+        *,
+        model: "str | None" = None,
+        role: "str | None" = None,
+        pr_id: "str | None" = None,
+        outcome_status: "str | None" = None,
+        report_path: "str | Path | None" = None,
+    ) -> None:
+        """Best-effort dispatch_metadata row for the leaseless tmux lane.
+
+        Flag-gated by ``VNX_TMUX_SESSION_ID`` (truthy values: "1"/"true");
+        default OFF preserves the lane's legacy behaviour (no row written).
+        Uses the shared writer's COALESCE/INSERT-OR-IGNORE pattern so re-calls
+        are idempotent and never clobber a richer provider-lane row.
+
+        Fail-open: any error is logged at DEBUG and swallowed; the write must
+        never block, delay, or fail the dispatch.
+        """
+        if os.environ.get("VNX_TMUX_SESSION_ID", "").strip().lower() not in ("1", "true"):
+            return
+
+        if _upsert_dispatch_metadata is None:
+            logger.debug(
+                "interactive: dispatch_metadata writer unavailable for dispatch=%s",
+                dispatch_id,
+            )
+            return
+
+        try:
+            # All setup inside the guard: the metadata stamp must be fully fail-open,
+            # including db_path/track computation (gate finding) — never propagate to dispatch.
+            db_path = self._state_dir / "quality_intelligence.db"
+            track = _TERMINAL_TRACK.get(terminal_id, "headless")
+            _upsert_dispatch_metadata(
+                db_path,
+                dispatch_id=dispatch_id,
+                terminal=terminal_id,
+                provider="claude",
+                model=model,
+                track=track,
+                role=role,
+                gate=None,
+                pr_id=pr_id,
+                outcome_status=outcome_status,
+                report_path=str(report_path) if report_path else None,
+            )
+        except Exception as exc:  # noqa: BLE001 — metadata stamp is best-effort; must never block dispatch
+            logger.debug(
+                "interactive: dispatch_metadata stamp failed for dispatch=%s (non-fatal): %s",
+                dispatch_id,
+                exc,
+            )
+
     def _govern_report(
         self,
         dispatch_id: str,
@@ -519,6 +586,15 @@ class TmuxInteractiveDispatch:
             token_usage=token_usage,
         )
         outcome = govern(spec, raw, lane="tmux_interactive")
+        self._stamp_dispatch_metadata(
+            dispatch_id=dispatch_id,
+            terminal_id=terminal_id,
+            model=model,
+            role=role,
+            pr_id=pr_id,
+            outcome_status=outcome.contract_status,
+            report_path=outcome.report_path,
+        )
         if outcome.report_path:
             logger.info(
                 "interactive: govern() emitted report dispatch=%s "

--- a/tests/test_tmux_interactive_dispatch_metadata.py
+++ b/tests/test_tmux_interactive_dispatch_metadata.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""Tests for leaseless tmux lane dispatch_metadata stamping (F1.1 metadata slice).
+
+Covers:
+- With VNX_TMUX_SESSION_ID=1, _govern_report stamps a dispatch_metadata row
+  carrying provider='claude', role, model, terminal, track, outcome_status.
+- With the flag unset, no row is written (legacy behaviour preserved).
+- The metadata stamp is fail-open: a writer exception is swallowed and the
+  dispatch/govern path returns normally.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT_LIB = REPO / "scripts" / "lib"
+SCRIPT_DIR = REPO / "scripts"
+for _p in (SCRIPT_LIB, SCRIPT_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import quality_db_init  # noqa: E402
+from tmux_interactive_dispatch import (  # noqa: E402
+    TmuxInteractiveDispatch,
+    TmuxResult,
+)
+
+
+class _FakeRunner:
+    """Minimal runner stub so TmuxInteractiveDispatch never calls real tmux."""
+
+    def available(self) -> bool:
+        return True
+
+    def run(self, args, *, timeout: int = 10, input_text: str | None = None) -> TmuxResult:
+        return TmuxResult(0)
+
+
+def _bootstrap_state(tmp_path: Path) -> Path:
+    """Create a canonical vnx-dev state dir with a bootstrapped QI DB."""
+    state_dir = tmp_path / ".vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db = state_dir / "quality_intelligence.db"
+    assert quality_db_init.bootstrap_qi_db(db, REPO / "schemas" / "quality_intelligence.sql")
+    return state_dir
+
+
+def _make_lane(state_dir: Path) -> TmuxInteractiveDispatch:
+    return TmuxInteractiveDispatch(
+        state_dir,
+        runner=_FakeRunner(),
+        project_root=state_dir.parent.parent.parent,
+    )
+
+
+def _read_row(db: Path, dispatch_id: str):
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    try:
+        return conn.execute(
+            "SELECT * FROM dispatch_metadata WHERE dispatch_id = ?", (dispatch_id,)
+        ).fetchone()
+    finally:
+        conn.close()
+
+
+@pytest.fixture
+def fake_govern():
+    """Patch dispatch_govern.govern to return a deterministic GovernedOutcome."""
+    from dispatch_govern import GovernedOutcome  # noqa: PLC0415
+
+    report_path = Path("/tmp/fake-report.md")
+    outcome = GovernedOutcome(
+        report_path=report_path,
+        contract_status="authored",
+    )
+    with patch("dispatch_govern.govern", return_value=outcome):
+        yield outcome
+
+
+def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fake_govern):
+    monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+
+    report_path = lane._govern_report(
+        dispatch_id="20260628-tmux-meta-1",
+        terminal_id="T1",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="backend-developer",
+        pr_id="42",
+    )
+
+    assert report_path == fake_govern.report_path
+    db = state_dir / "quality_intelligence.db"
+    row = _read_row(db, "20260628-tmux-meta-1")
+    assert row is not None
+    assert row["provider"] == "claude"
+    assert row["model"] == "sonnet"
+    assert row["role"] == "backend-developer"
+    assert row["terminal"] == "T1"
+    assert row["track"] == "A"
+    assert row["gate"] is None
+    assert row["pr_id"] == "42"
+    assert row["outcome_status"] == "authored"
+    assert row["outcome_report_path"] == str(fake_govern.report_path)
+    assert row["project_id"] == "vnx-dev"
+    assert row["session_id"] is None
+
+
+def test_metadata_row_not_written_when_flag_unset(tmp_path, monkeypatch, fake_govern):
+    monkeypatch.delenv("VNX_TMUX_SESSION_ID", raising=False)
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+
+    lane._govern_report(
+        dispatch_id="20260628-tmux-meta-0",
+        terminal_id="T1",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="backend-developer",
+    )
+
+    db = state_dir / "quality_intelligence.db"
+    row = _read_row(db, "20260628-tmux-meta-0")
+    assert row is None
+
+
+def test_metadata_stamp_fail_open_swallows_writer_error(
+    tmp_path, monkeypatch, fake_govern, caplog
+):
+    monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+
+    with patch(
+        "tmux_interactive_dispatch._upsert_dispatch_metadata",
+        side_effect=RuntimeError("DB unreachable"),
+    ):
+        with caplog.at_level("DEBUG", logger="tmux_interactive_dispatch"):
+            report_path = lane._govern_report(
+                dispatch_id="20260628-tmux-meta-fail",
+                terminal_id="T2",
+                instruction="do the thing",
+                receipt={"status": "done"},
+                duration_seconds=1.0,
+                model="sonnet",
+                role="debugger",
+            )
+
+    # Govern path must still complete normally.
+    assert report_path == fake_govern.report_path
+    # The swallowed error must be observable in DEBUG logs.
+    assert any(
+        "dispatch_metadata stamp failed" in r.message
+        and "DB unreachable" in r.message
+        for r in caplog.records
+    )
+
+
+def test_metadata_track_defaults_to_headless_for_non_terminal_label(
+    tmp_path, monkeypatch, fake_govern
+):
+    monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+
+    lane._govern_report(
+        dispatch_id="20260628-tmux-meta-track",
+        terminal_id="ephemeral",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="frontend-developer",
+    )
+
+    db = state_dir / "quality_intelligence.db"
+    row = _read_row(db, "20260628-tmux-meta-track")
+    assert row is not None
+    assert row["terminal"] == "ephemeral"
+    assert row["track"] == "headless"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The default leaseless tmux lane wrote no `dispatch_metadata` row, so default-lane dispatches recorded no role — this is why #974's role-recovery (on the legacy bash daemon path) never helped the default lane (F1.1 panel finding). This makes the lane persist its own row carrying `role`, via the shared `dispatch_metadata_db.upsert_dispatch_provider_row`, at govern time. Flag-gated `VNX_TMUX_SESSION_ID` (default OFF = no behavior change). Foundation for the session_id slice next.

Built by Kimi (kimi-k2-7-code) under operator direction (Claude-usage conservation); codex-gated independently.

## Changes

- `tmux_interactive_dispatch.py` — `_stamp_dispatch_metadata` (flag-gated, fully fail-open, idempotent via the writer's COALESCE/INSERT-OR-IGNORE), called from `_govern_report`. Spawn/launch keystroke path untouched.
- `tests/test_tmux_interactive_dispatch_metadata.py` (NEW) — flag-on writes the row; flag-off writes nothing.

## Verification

- `pytest` → 4 passed; py_compile + silent-except scanner clean; lane imports.
- `project_id` resolved fail-closed by the writer (ADR-007); codex-gate → PASS (round 1 caught a pre-try fail-open gap, fixed).

## Open Items

- `--session-id` spawn slice is separate (metadata-write only here). Default OFF; flip after soak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC