### PR TITLE
feat(governance): pre-assigned --session-id on the leaseless tmux spawn (F1.1)

### DIFF
--- a/scripts/lib/dispatch_metadata_db.py
+++ b/scripts/lib/dispatch_metadata_db.py
@@ -116,6 +116,7 @@ def upsert_dispatch_provider_row(
     outcome_status: Optional[str] = None,
     report_path: Optional[str] = None,
     project_id: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> bool:
     """Create-if-absent and provider/model-stamp a ``dispatch_metadata`` row.
 
@@ -127,6 +128,8 @@ def upsert_dispatch_provider_row(
                "kimi"). Stamped when the ``model`` column exists (migration
                v23 / GAP-2). Optional — callers that don't know the model
                may omit it.
+        session_id: Pre-assigned worker session UUID (F1.1). Stamped when the
+               ``session_id`` column exists. Optional — ignored when absent/None.
 
     Raises:
         ValueError: ``dispatch_id``, ``terminal``, or ``provider`` is empty —
@@ -156,6 +159,7 @@ def upsert_dispatch_provider_row(
         has_report_path = _has_column(conn, "dispatch_metadata", "outcome_report_path")
         has_outcome = _has_column(conn, "dispatch_metadata", "outcome_status")
         has_completed = _has_column(conn, "dispatch_metadata", "completed_at")
+        has_session_id = _has_column(conn, "dispatch_metadata", "session_id")
 
         # Tenant-stamp only when the column exists (old column-less stores are
         # left untouched). Fail-closed: an unresolvable tenant logs + skips the
@@ -178,6 +182,9 @@ def upsert_dispatch_provider_row(
         if has_model and model:
             insert_cols.append("model")
             insert_vals.append(model)
+        if has_session_id and session_id:
+            insert_cols.append("session_id")
+            insert_vals.append(session_id)
         if has_project:
             insert_cols.append("project_id")
             insert_vals.append(resolved_project_id)
@@ -197,6 +204,9 @@ def upsert_dispatch_provider_row(
         if has_model and model:
             set_clauses.append("model = COALESCE(model, ?)")
             params.append(model)
+        if has_session_id and session_id:
+            set_clauses.append("session_id = COALESCE(session_id, ?)")
+            params.append(session_id)
         set_clauses.append("role = COALESCE(role, ?)")
         params.append(role or None)
         set_clauses.append("gate = COALESCE(gate, ?)")

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -26,6 +26,7 @@ import sys
 import tempfile
 import threading
 import time
+import uuid
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Callable
@@ -204,6 +205,7 @@ def _default_launch_command(
     role: "str | None" = None,
     requires_mcp: bool = False,
     working_tree_only: bool = False,
+    session_uuid: "str | None" = None,
 ) -> str:
     """Build the interactive ``claude`` launch line (NOT ``claude -p``).
 
@@ -218,6 +220,10 @@ def _default_launch_command(
 
     ``requires_mcp``: when True, ``--strict-mcp-config --mcp-config {}`` is omitted
     so the worker keeps its normal ambient MCP config.
+
+    ``session_uuid``: when provided, ``--session-id <uuid>`` is injected after
+    ``--model`` so the worker's transcript is deterministically joinable. The uuid
+    is shlex-quoted; a None/empty value appends nothing (fail-open).
     """
     if not _SAFE_MODEL_RE.match(model):
         raise ValueError(
@@ -263,7 +269,10 @@ def _default_launch_command(
             flags = " --dangerously-skip-permissions"
     if extra_flags:
         flags = f"{flags} {extra_flags}".rstrip()
-    return f"source ~/.zshrc 2>/dev/null; claude --model {model}{flags}"
+    session_arg = ""
+    if session_uuid:
+        session_arg = f" --session-id {shlex.quote(session_uuid)}"
+    return f"source ~/.zshrc 2>/dev/null; claude --model {model}{session_arg}{flags}"
 
 
 def _sanitize_session_name(raw: str) -> str:
@@ -484,6 +493,7 @@ class TmuxInteractiveDispatch:
         pr_id: "str | None" = None,
         outcome_status: "str | None" = None,
         report_path: "str | Path | None" = None,
+        session_id: "str | None" = None,
     ) -> None:
         """Best-effort dispatch_metadata row for the leaseless tmux lane.
 
@@ -491,6 +501,9 @@ class TmuxInteractiveDispatch:
         default OFF preserves the lane's legacy behaviour (no row written).
         Uses the shared writer's COALESCE/INSERT-OR-IGNORE pattern so re-calls
         are idempotent and never clobber a richer provider-lane row.
+
+        ``session_id``: the pre-assigned worker session UUID (F1.1), stamped only
+        when the column exists and a non-empty value is provided.
 
         Fail-open: any error is logged at DEBUG and swallowed; the write must
         never block, delay, or fail the dispatch.
@@ -522,6 +535,7 @@ class TmuxInteractiveDispatch:
                 pr_id=pr_id,
                 outcome_status=outcome_status,
                 report_path=str(report_path) if report_path else None,
+                session_id=session_id,
             )
         except Exception as exc:  # noqa: BLE001 — metadata stamp is best-effort; must never block dispatch
             logger.debug(
@@ -545,6 +559,7 @@ class TmuxInteractiveDispatch:
         failure_reason: str = "tmux_receipt_deadline_exceeded",
         token_usage: "dict | None" = None,
         role: "str | None" = None,
+        session_id: "str | None" = None,
     ) -> "Path | None":
         """Emit governance unified_report via the shared govern() step.
 
@@ -557,6 +572,9 @@ class TmuxInteractiveDispatch:
 
         ``role`` is forwarded to GovernSpec so govern() can apply role-specific
         validation logic (e.g. plan-reviewer bodies skip standard heading validation).
+
+        ``session_id``: pre-assigned worker session UUID (F1.1), threaded through to
+        the dispatch_metadata stamp.
         """
         try:
             from dispatch_govern import GovernRaw, GovernSpec, govern  # noqa: PLC0415
@@ -594,6 +612,7 @@ class TmuxInteractiveDispatch:
             pr_id=pr_id,
             outcome_status=outcome.contract_status,
             report_path=outcome.report_path,
+            session_id=session_id,
         )
         if outcome.report_path:
             logger.info(
@@ -756,7 +775,11 @@ class TmuxInteractiveDispatch:
 
     # -- tmux primitives ---------------------------------------------------
     def _spawn_session(
-        self, session: str, cwd: Path, dispatch_id: str = ""
+        self,
+        session: str,
+        cwd: Path,
+        dispatch_id: str = "",
+        session_uuid: "str | None" = None,
     ) -> "tuple[str, str] | None":
         """Create a detached session; return (pane_id, window_id) or None.
 
@@ -764,10 +787,15 @@ class TmuxInteractiveDispatch:
         ``VNX_CURRENT_DISPATCH_ID`` so the worker's ``git commit`` carries a provenance
         trace token (read by the prepare-commit-msg hook / trace_token_validator), closing
         the dispatch->commit link in the provenance_registry.
+
+        When ``session_uuid`` is provided it is exported as ``VNX_CLAUDE_SESSION_ID``
+        so the SessionStart hook can verify the pre-assigned id took (F1.1).
         """
         args = ["new-session", "-d", "-s", session, "-c", str(cwd)]
         if dispatch_id:
             args += ["-e", f"VNX_CURRENT_DISPATCH_ID={dispatch_id}"]
+        if session_uuid:
+            args += ["-e", f"VNX_CLAUDE_SESSION_ID={session_uuid}"]
         args += ["-P", "-F", "#{pane_id}"]
         res = self._runner.run(args)
         if res.returncode != 0:
@@ -1557,6 +1585,13 @@ class TmuxInteractiveDispatch:
                 f"'claude-opus-4-8'); whitespace and shell metacharacters are not allowed"
             )
 
+        # F1.1: pre-assign the worker's Claude session id when the session-linkage
+        # flag is on. uuid4 is always valid; a None value keeps the launch line and
+        # pane env byte-for-byte unchanged when the flag is off.
+        session_uuid: "str | None" = None
+        if os.environ.get("VNX_TMUX_SESSION_ID", "").strip().lower() in ("1", "true"):
+            session_uuid = str(uuid.uuid4())
+
         # Worktree isolation: allocate before session creation so a failed add
         # never spawns a tmux session with an uncontrolled cwd.
         worktree_handle: "WorktreeHandle | None" = None
@@ -1708,7 +1743,7 @@ class TmuxInteractiveDispatch:
         window_id: "str | None" = None
         try:
             # 1. Spawn detached session
-            spawned = self._spawn_session(session, cwd, dispatch_id)
+            spawned = self._spawn_session(session, cwd, dispatch_id, session_uuid=session_uuid)
             if spawned is None:
                 self._emit_event(
                     "interactive_spawn_failed",
@@ -1772,6 +1807,7 @@ class TmuxInteractiveDispatch:
                 role=role,
                 requires_mcp=requires_mcp,
                 working_tree_only=working_tree_only,
+                session_uuid=session_uuid,
             )
 
             # FIX 1: Final-command guard — bites regardless of how the command
@@ -1859,6 +1895,7 @@ class TmuxInteractiveDispatch:
                     model=model,
                     failure_reason="interactive_ready_timeout",
                     role=role,
+                    session_id=session_uuid,
                 )
                 _teardown("ready_timeout")
                 return InteractiveDispatchResult(
@@ -1968,6 +2005,7 @@ class TmuxInteractiveDispatch:
                     model=model,
                     failure_reason="submit_failed",
                     role=role,
+                    session_id=session_uuid,
                 )
                 _teardown("submit_failed")
                 return InteractiveDispatchResult(
@@ -2025,6 +2063,7 @@ class TmuxInteractiveDispatch:
                     model=model,
                     failure_reason="interactive_no_progress",
                     role=role,
+                    session_id=session_uuid,
                 )
                 _teardown("no_progress")
                 return InteractiveDispatchResult(
@@ -2066,6 +2105,7 @@ class TmuxInteractiveDispatch:
                     worktree_path=worktree_handle.path if worktree_handle else None,
                     model=model,
                     role=role,
+                    session_id=session_uuid,
                 )
                 _teardown("timeout")
                 return InteractiveDispatchResult(
@@ -2107,6 +2147,7 @@ class TmuxInteractiveDispatch:
                 model=model,
                 token_usage=_pane_tokens,
                 role=role,
+                session_id=session_uuid,
             )
             # A governed-completion path (worker OK) with no linked report is an
             # audit-trail gap — do not report success with an unlinked report.

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -544,6 +544,94 @@ class TestNoDashP(_LaneTestCase):
         self.assertIn("--verbose", safe)
         self.assertNotIn("-p", safe.split())
 
+    def test_session_uuid_injected_when_set(self):
+        """F1.1 slice B: --session-id <uuid> is injected after --model and passes the headless guard."""
+        session_uuid = "11111111-2222-3333-4444-555555555555"
+        cmd = _default_launch_command("sonnet", session_uuid=session_uuid)
+
+        self.assertIn("claude --model sonnet", cmd)
+        # Exactly one --session-id occurrence, immediately followed by the quoted uuid.
+        self.assertEqual(cmd.count("--session-id"), 1)
+        self.assertIn(f"--session-id {session_uuid}", cmd)
+        # Must still be an interactive launch (no -p/--print).
+        _assert_no_headless_flags(cmd)
+        # The uuid is shlex-quoted; uuid4 chars are safe, but quote must not add unwanted wrappers here.
+        self.assertNotIn("'", cmd.split("--session-id")[1].split()[0])
+
+    def test_session_uuid_none_unchanged_launch(self):
+        """F1.1 slice B: when session_uuid is None the launch line is byte-for-byte unchanged."""
+        cmd_without = _default_launch_command("sonnet")
+        cmd_with_none = _default_launch_command("sonnet", session_uuid=None)
+        self.assertEqual(cmd_with_none, cmd_without)
+        self.assertNotIn("--session-id", cmd_with_none)
+
+
+class TestSessionLinkageDispatch(_LaneTestCase):
+    """F1.1 slice B: end-to-end session linkage through a dispatch() call."""
+
+    def test_session_id_flag_on_injects_uuid(self):
+        """VNX_TMUX_SESSION_ID=1: launch command has --session-id and new-session exports VNX_CLAUDE_SESSION_ID."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            ready_content=_READY_AND_WORKING,
+        )
+        lane = self._make_lane(fake)
+        with patch.dict(os.environ, {"VNX_TMUX_SESSION_ID": "1"}):
+            result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
+
+        # Extract the literal launch command sent to the pane.
+        literal_cmds = [c for c in fake.commands if c and c[0] == "send-keys" and "-l" in c]
+        self.assertTrue(literal_cmds, "literal send-keys for launch command not found")
+        launch_cmd = literal_cmds[0][-1]
+
+        # Exactly one --session-id <uuid4>.
+        self.assertEqual(launch_cmd.count("--session-id"), 1)
+        parts = launch_cmd.split()
+        idx = parts.index("--session-id")
+        session_arg = parts[idx + 1]
+        self.assertRegex(
+            session_arg,
+            r"^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$",
+        )
+
+        # new-session exports both VNX_CURRENT_DISPATCH_ID and VNX_CLAUDE_SESSION_ID.
+        new_session_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertTrue(new_session_cmds)
+        ns_cmd = new_session_cmds[0]
+        self.assertIn("-e", ns_cmd)
+        dispatch_env = f"VNX_CURRENT_DISPATCH_ID={self.DISPATCH_ID}"
+        session_env = f"VNX_CLAUDE_SESSION_ID={session_arg}"
+        self.assertIn(dispatch_env, ns_cmd)
+        self.assertIn(session_env, ns_cmd)
+
+        # _assert_no_headless_flags must accept the assembled command (interactive only).
+        _assert_no_headless_flags(launch_cmd)
+
+    def test_session_id_flag_off_unchanged(self):
+        """VNX_TMUX_SESSION_ID unset: no --session-id in launch, no VNX_CLAUDE_SESSION_ID env."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            ready_content=_READY_AND_WORKING,
+        )
+        lane = self._make_lane(fake)
+        with patch.dict(os.environ, {"VNX_TMUX_SESSION_ID": "0"}):
+            result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
+
+        literal_cmds = [c for c in fake.commands if c and c[0] == "send-keys" and "-l" in c]
+        launch_cmd = literal_cmds[0][-1]
+        self.assertNotIn("--session-id", launch_cmd)
+
+        new_session_cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        ns_cmd = new_session_cmds[0]
+        self.assertNotIn("VNX_CLAUDE_SESSION_ID", " ".join(ns_cmd))
+        self.assertIn("VNX_CURRENT_DISPATCH_ID", " ".join(ns_cmd))
+
 
 class TestStaleReceiptGuard(_LaneTestCase):
     def test_stale_receipt_does_not_complete(self):

--- a/tests/test_tmux_interactive_dispatch_metadata.py
+++ b/tests/test_tmux_interactive_dispatch_metadata.py
@@ -88,6 +88,7 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
     monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
     state_dir = _bootstrap_state(tmp_path)
     lane = _make_lane(state_dir)
+    session_id = "11111111-2222-3333-4444-555555555555"
 
     report_path = lane._govern_report(
         dispatch_id="20260628-tmux-meta-1",
@@ -98,6 +99,7 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
         model="sonnet",
         role="backend-developer",
         pr_id="42",
+        session_id=session_id,
     )
 
     assert report_path == fake_govern.report_path
@@ -114,7 +116,7 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
     assert row["outcome_status"] == "authored"
     assert row["outcome_report_path"] == str(fake_govern.report_path)
     assert row["project_id"] == "vnx-dev"
-    assert row["session_id"] is None
+    assert row["session_id"] == session_id
 
 
 def test_metadata_row_not_written_when_flag_unset(tmp_path, monkeypatch, fake_govern):
@@ -191,6 +193,42 @@ def test_metadata_track_defaults_to_headless_for_non_terminal_label(
     assert row is not None
     assert row["terminal"] == "ephemeral"
     assert row["track"] == "headless"
+
+
+def test_metadata_session_id_coalesce_preserved_on_second_call(
+    tmp_path, monkeypatch, fake_govern
+):
+    """A pre-assigned session_id must never be clobbered by a later call with None."""
+    monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+    session_id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"
+
+    lane._govern_report(
+        dispatch_id="20260628-tmux-meta-coalesce",
+        terminal_id="T1",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="backend-developer",
+        session_id=session_id,
+    )
+    lane._govern_report(
+        dispatch_id="20260628-tmux-meta-coalesce",
+        terminal_id="T1",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="backend-developer",
+        session_id=None,
+    )
+
+    db = state_dir / "quality_intelligence.db"
+    row = _read_row(db, "20260628-tmux-meta-coalesce")
+    assert row is not None
+    assert row["session_id"] == session_id
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

F1.1 slice B. VNX pre-assigns the worker's Claude session id so the transcript is deterministically joinable. Flag-gated `VNX_TMUX_SESSION_ID` (default OFF = byte-for-byte unchanged spawn). When on: uuid4 in `dispatch()`, `--session-id <uuid>` injected into the launch line (shlex-quoted, after `--model`, stays interactive), `VNX_CLAUDE_SESSION_ID` exported as pane env (for the later hook-verifier), and the id stamped into the dispatch_metadata row (slice A #975) via the shared writer.

Built by Kimi under operator direction (Claude-usage conservation); codex-gated independently → PASS.

## Changes

- `tmux_interactive_dispatch.py` — uuid4 (flag-gated); `_default_launch_command` injects `--session-id`; `_spawn_session` exports the env; session_id threaded through `_govern_report`→`_stamp_dispatch_metadata` at all call-sites.
- `dispatch_metadata_db.py` — `upsert_dispatch_provider_row` gains a column-guarded `session_id` (INSERT + COALESCE), same pattern as the other optional columns.
- tests — flag-on injects exactly one `--session-id <uuid>` + env + stamp; flag-off identical.

## Verification

- `pytest` lane suites → **176 passed** (no hot-path regression). Flag-off no-op proven. Scanner + py_compile clean. Stays interactive (no `-p`).

## Open Items

- SessionStart hook-verifier (compare hook-reported id vs `VNX_CLAUDE_SESSION_ID`) is the next slice — the panel's mandatory mitigation before flipping the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC