### PR TITLE
feat(governance): SessionStart hook-verifier for pre-assigned session id (F1.1)

### DIFF
--- a/scripts/hooks/tmux_signal_session_ready.sh
+++ b/scripts/hooks/tmux_signal_session_ready.sh
@@ -6,26 +6,46 @@
 # the stable HOOK CONTRACT instead of scraping version-specific TUI banners
 # (which break on ~weekly Claude Code bumps).
 #
+# F1.1: also taps the hook's stdin JSON to extract the session_id Claude actually
+# used and writes it to "session_id" alongside the sentinel. The lane compares
+# this against the pre-assigned VNX_CLAUDE_SESSION_ID; a mismatch means the CLI
+# silently ignored --session-id.
+#
 # Scoped HARD to tmux-spawn workers: fires ONLY when BOTH VNX_TMUX_SIGNAL_DIR and
 # VNX_DISPATCH_ID are set. For any normal T0/interactive session (env unset) it
 # drains stdin and exits 0 — completely no-op, no behavior change.
 #
 # Atomic write (.tmp then mv). Never blocks. Any error -> exit 0.
 
-# Drain stdin so the hook caller never blocks on an unread pipe.
-cat >/dev/null 2>&1 || true
+# Capture stdin JSON (best-effort). Claude passes hook payload on stdin.
+STDIN_JSON=""
+if command -v jq &>/dev/null; then
+    STDIN_JSON=$(cat 2>/dev/null) || STDIN_JSON=""
+else
+    # jq missing: drain the pipe so the caller never blocks, then continue to
+    # write the sentinel. Session-id verification is unavailable, not fatal.
+    cat >/dev/null 2>&1 || true
+fi
 
 # ── Guard: only fire for tmux-spawn workers ──────────────────────────────────
 if [ -z "${VNX_TMUX_SIGNAL_DIR:-}" ] || [ -z "${VNX_DISPATCH_ID:-}" ]; then
-  exit 0
+    exit 0
 fi
 
-# Best-effort atomic sentinel write.
+# Best-effort atomic writes. The sentinel is PRIMARY; session_id is SECONDARY.
 {
-  mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
-  _tmp="$VNX_TMUX_SIGNAL_DIR/session_ready.$$.tmp"
-  printf '%s\n' "${VNX_DISPATCH_ID}" >"$_tmp" 2>/dev/null \
-    && mv -f "$_tmp" "$VNX_TMUX_SIGNAL_DIR/session_ready" 2>/dev/null
+    mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
+
+    # F1.1: extract the session_id the CLI reported and persist it for verification.
+    if [ -n "$STDIN_JSON" ]; then
+        _sid_tmp="$VNX_TMUX_SIGNAL_DIR/session_id.$$.tmp"
+        echo "$STDIN_JSON" | jq -r '.session_id // ""' 2>/dev/null >"$_sid_tmp" \
+            && mv -f "$_sid_tmp" "$VNX_TMUX_SIGNAL_DIR/session_id" 2>/dev/null
+    fi
+
+    _ready_tmp="$VNX_TMUX_SIGNAL_DIR/session_ready.$$.tmp"
+    printf '%s\n' "${VNX_DISPATCH_ID}" >"$_ready_tmp" 2>/dev/null \
+        && mv -f "$_ready_tmp" "$VNX_TMUX_SIGNAL_DIR/session_ready" 2>/dev/null
 } || true
 
 exit 0

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -820,6 +820,51 @@ class TmuxInteractiveDispatch:
         # Enter ALWAYS as a separate keystroke.
         return self._runner.run(["send-keys", "-t", pane_id, "Enter"]).returncode == 0
 
+    def _verify_session_id(
+        self,
+        signal_dir: "Path | None",
+        session_uuid: "str | None",
+        *,
+        dispatch_id: str,
+        label: str,
+    ) -> None:
+        """Compare the hook-reported session id to the pre-assigned uuid (F1.1).
+
+        Fires only when ``session_uuid`` is set (``VNX_TMUX_SESSION_ID`` flag ON).
+        A missing or empty ``session_id`` sentinel is fail-open: older CLIs may not
+        report the id. Only a non-empty DIFFERENT value emits a ``session_id_mismatch``
+        audit event. Never raises and never blocks the dispatch.
+        """
+        if not session_uuid:
+            return
+        if signal_dir is None:
+            return
+        sid_path = signal_dir / "session_id"
+        try:
+            if not sid_path.exists():
+                return
+            hook_session_id = sid_path.read_text(encoding="utf-8").strip()
+        except OSError as exc:
+            logger.debug(
+                "interactive: failed to read hook session_id for %s: %s",
+                dispatch_id,
+                exc,
+            )
+            return
+        if not hook_session_id:
+            return
+        if hook_session_id != session_uuid:
+            self._emit_event(
+                "session_id_mismatch",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason="Claude CLI session_id differs from pre-assigned VNX session_uuid",
+                metadata={
+                    "pre_assigned_session_id": session_uuid,
+                    "hook_session_id": hook_session_id,
+                },
+            )
+
     def _wait_ready(
         self,
         pane_id: str,
@@ -1872,6 +1917,14 @@ class TmuxInteractiveDispatch:
                 warmup_timeout=warmup_timeout,
                 poll_interval=warmup_poll_interval,
                 signal_dir=signal_dir,
+            )
+            # F1.1: verify the pre-assigned session id actually took (hook-reported id
+            # must match). Fail-open: only emit an audit event, never block dispatch.
+            self._verify_session_id(
+                signal_dir,
+                session_uuid,
+                dispatch_id=dispatch_id,
+                label=label,
             )
             _strict = os.environ.get("VNX_TMUX_READY_STRICT", "1").strip().lower() not in (
                 "0", "false", "no", "off"

--- a/tests/test_tmux_lane_signals.py
+++ b/tests/test_tmux_lane_signals.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -28,6 +29,7 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from tmux_interactive_dispatch import TmuxInteractiveDispatch, TmuxResult  # noqa: E402
+from runtime_coordination import get_connection, get_events, init_schema  # noqa: E402
 
 HOOKS_DIR = SCRIPT_DIR / "hooks"
 SESSION_READY_HOOK = HOOKS_DIR / "tmux_signal_session_ready.sh"
@@ -187,12 +189,18 @@ class TestHookGuards(unittest.TestCase):
         self.addCleanup(self._tmp.cleanup)
         self.root = Path(self._tmp.name)
 
-    def _run_hook(self, script: Path, env: dict, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    def _run_hook(
+        self,
+        script: Path,
+        env: dict,
+        cwd: Path | None = None,
+        input_text: str = "{}",
+    ) -> subprocess.CompletedProcess:
         full_env = {"PATH": os.environ.get("PATH", "")}
         full_env.update(env)
         return subprocess.run(
             ["bash", str(script)],
-            input="{}",
+            input=input_text,
             capture_output=True,
             text=True,
             env=full_env,
@@ -241,6 +249,168 @@ class TestHookGuards(unittest.TestCase):
     def test_prompt_received_noop_when_env_unset(self) -> None:
         proc = self._run_hook(PROMPT_RECEIVED_HOOK, env={})
         self.assertEqual(proc.returncode, 0)
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_session_ready_captures_session_id_from_stdin(self) -> None:
+        sig = self.root / "sig-sid"
+        session_id = "123e4567-e89b-12d3-a456-426614174000"
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-sid",
+            },
+            input_text=json.dumps({"session_id": session_id, "transcript_path": "/tmp/t.json"}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "session_ready").is_file())
+        self.assertEqual((sig / "session_ready").read_text(encoding="utf-8").strip(), "disp-sid")
+        self.assertTrue((sig / "session_id").is_file())
+        self.assertEqual((sig / "session_id").read_text(encoding="utf-8").strip(), session_id)
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_session_ready_empty_stdin_still_writes_sentinel(self) -> None:
+        sig = self.root / "sig-empty"
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-empty",
+            },
+            input_text="",
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "session_ready").is_file())
+        self.assertFalse((sig / "session_id").exists())
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_session_ready_garbage_stdin_still_writes_sentinel(self) -> None:
+        sig = self.root / "sig-garbage"
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-garbage",
+            },
+            input_text="not json {",
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "session_ready").is_file())
+
+    def test_session_ready_no_jq_still_writes_sentinel(self) -> None:
+        sig = self.root / "sig-nojq"
+        session_id = "123e4567-e89b-12d3-a456-426614174000"
+        # Place a fake jq earlier in PATH so command -v jq succeeds but it fails
+        # to parse, simulating a broken/missing jq installation.
+        fake_bin = self.root / "fakebin"
+        fake_bin.mkdir()
+        (fake_bin / "jq").write_text("#!/bin/sh\nexit 1\n", encoding="utf-8")
+        (fake_bin / "jq").chmod(0o755)
+        proc = self._run_hook(
+            SESSION_READY_HOOK,
+            env={
+                "VNX_TMUX_SIGNAL_DIR": str(sig),
+                "VNX_DISPATCH_ID": "disp-nojq",
+                "PATH": f"{fake_bin}:{os.environ.get('PATH', '')}",
+            },
+            input_text=json.dumps({"session_id": session_id}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertTrue((sig / "session_ready").is_file())
+        # With a failing jq we cannot extract the id, but the pipe must be
+        # drained and the primary sentinel still written.
+        self.assertFalse((sig / "session_id").exists())
+
+
+# ---------------------------------------------------------------------------
+# F1.1 session_id verifier: lane-side comparison
+# ---------------------------------------------------------------------------
+class TestSessionIdVerifier(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.root = Path(self._tmp.name)
+        init_schema(self.root)
+        self.lane = _make_lane(_CaptureRunner(), self.root)
+
+    def _events(self, dispatch_id: str, event_type: str) -> list[dict]:
+        with get_connection(self.root) as conn:
+            return get_events(conn, entity_id=dispatch_id, event_type=event_type)
+
+    def test_matching_session_id_emits_no_event(self) -> None:
+        session_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        sig = self.root / "sig-match"
+        sig.mkdir()
+        (sig / "session_id").write_text(session_uuid + "\n", encoding="utf-8")
+
+        self.lane._verify_session_id(
+            sig, session_uuid, dispatch_id="disp-match", label="T1"
+        )
+        self.assertEqual(
+            len(self._events("disp-match", "session_id_mismatch")), 0
+        )
+
+    def test_different_session_id_emits_mismatch_event(self) -> None:
+        session_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        sig = self.root / "sig-mismatch"
+        sig.mkdir()
+        (sig / "session_id").write_text("00000000-0000-0000-0000-000000000000\n", encoding="utf-8")
+
+        self.lane._verify_session_id(
+            sig, session_uuid, dispatch_id="disp-mismatch", label="T1"
+        )
+        events = self._events("disp-mismatch", "session_id_mismatch")
+        self.assertEqual(len(events), 1)
+        meta = json.loads(events[0]["metadata_json"])
+        self.assertEqual(meta["pre_assigned_session_id"], session_uuid)
+        self.assertEqual(meta["hook_session_id"], "00000000-0000-0000-0000-000000000000")
+
+    def test_missing_session_id_file_emits_no_event(self) -> None:
+        session_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        sig = self.root / "sig-missing"
+        sig.mkdir()
+
+        self.lane._verify_session_id(
+            sig, session_uuid, dispatch_id="disp-missing", label="T1"
+        )
+        self.assertEqual(
+            len(self._events("disp-missing", "session_id_mismatch")), 0
+        )
+
+    def test_empty_session_id_file_emits_no_event(self) -> None:
+        session_uuid = "123e4567-e89b-12d3-a456-426614174000"
+        sig = self.root / "sig-empty"
+        sig.mkdir()
+        (sig / "session_id").write_text("\n", encoding="utf-8")
+
+        self.lane._verify_session_id(
+            sig, session_uuid, dispatch_id="disp-empty", label="T1"
+        )
+        self.assertEqual(
+            len(self._events("disp-empty", "session_id_mismatch")), 0
+        )
+
+    def test_none_session_uuid_skips_verification(self) -> None:
+        sig = self.root / "sig-none"
+        sig.mkdir()
+        (sig / "session_id").write_text("unexpected-value\n", encoding="utf-8")
+
+        self.lane._verify_session_id(
+            sig, None, dispatch_id="disp-none", label="T1"
+        )
+        self.assertEqual(
+            len(self._events("disp-none", "session_id_mismatch")), 0
+        )
+
+    def test_none_signal_dir_skips_verification(self) -> None:
+        session_uuid = "123e4567-e89b-12d3-a456-426614174000"
+
+        self.lane._verify_session_id(
+            None, session_uuid, dispatch_id="disp-no-sig", label="T1"
+        )
+        self.assertEqual(
+            len(self._events("disp-no-sig", "session_id_mismatch")), 0
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes F1.1: the verifier the panel marked mandatory before flipping the flag — detect a Claude CLI that silently ignores `--session-id`. The SessionStart hook taps its stdin, extracts the id Claude actually used, writes it beside the unconditional `session_ready` sentinel; the lane compares it to the pre-assigned `VNX_CLAUDE_SESSION_ID` and emits a `session_id_mismatch` audit event on a non-empty difference. Fail-open throughout; gated `VNX_TMUX_SESSION_ID`.

Built by Kimi under operator direction; codex-gated independently → PASS.

## Changes

- `scripts/hooks/tmux_signal_session_ready.sh` — taps stdin (jq), writes `session_id` atomically; drains + no-ops when jq/stdin absent; sentinel stays unconditional; exit 0 always.
- `scripts/lib/tmux_interactive_dispatch.py` — `_verify_session_id`: missing/empty = fail-open (older CLI), only a non-empty different value emits one event; never raises/blocks.
- `tests/test_tmux_lane_signals.py` — hook write/no-op; lane match/mismatch/missing.

## Verification

- `pytest tests/test_tmux_lane_signals.py` → **28 passed**. py_compile + scanner clean; hook `bash -n` OK.

## Open Items

- F1.1 complete (A #975, B #976, C this), all behind `VNX_TMUX_SESSION_ID` default OFF. Soak → flip.
- F1.2 (copy the transcript into the VNX store at completion) is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC