### PR TITLE
fix(audit): correctness batch — override truthy, cross-project autowire, idempotency keys + clear-context

### DIFF
--- a/scripts/lib/append_receipt_internals/idempotency.py
+++ b/scripts/lib/append_receipt_internals/idempotency.py
@@ -105,7 +105,17 @@ def _compute_idempotency_key(receipt: Dict[str, Any], event_name: str) -> str:
         and "task_id" not in digest_fields
         and "report_path" not in digest_fields
     ):
-        digest_fields["timestamp"] = receipt.get("timestamp")
+        ts = receipt.get("timestamp")
+        if ts and str(ts).strip():
+            digest_fields["timestamp"] = ts
+        else:
+            # No stable identifying field and no timestamp: use a content hash of the full receipt
+            # so that two genuinely distinct receipts still get distinct idempotency keys instead
+            # of collapsing to the same null/empty hash and silently dropping the second one.
+            content_hash = hashlib.sha256(
+                json.dumps(receipt, sort_keys=True, separators=(",", ":")).encode("utf-8")
+            ).hexdigest()
+            digest_fields["_content_hash"] = content_hash
 
     if not digest_fields:
         digest_fields = receipt
@@ -178,7 +188,9 @@ def _write_receipt_under_lock(
             recent_keys = {entry["key"] for entry in cache_entries}
 
             if idempotency_key in recent_keys:
-                _write_cache(cache_path, cache_entries)
+                # Do NOT rewrite the cache on a duplicate hit: rewriting would trim it to
+                # max_entries=2048 and could evict in-window keys we still need for dedup.
+                # The cache is already correct and fresh — just skip the append.
                 return AppendResult(
                     status="duplicate",
                     receipts_file=receipt_path,

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -143,9 +143,19 @@ def get(key: str, project_id: Optional[str] = None) -> Optional[str]:
     return entry.default if entry is not None else None
 
 
+_TRUTHY = frozenset(("1", "true", "yes", "on"))
+
+
 def get_bool(key: str, project_id: Optional[str] = None) -> bool:
-    """Bool view of get(): true only for the canonical truthy "1" (matches the read-sites)."""
-    return get(key, project_id) == "1"
+    """Bool view of get(): true for canonical truthy values (1/true/yes/on, case-insensitive).
+
+    Applies to every source the precedence chain returns (VNX_OVERRIDE_* env vars, regular env
+    vars, and per-project DB values): any truthy spelling resolves True, not just the literal "1".
+    """
+    val = get(key, project_id)
+    if val is None:
+        return False
+    return val.strip().lower() in _TRUTHY
 
 
 def all_effective(project_id: Optional[str] = None) -> List[dict]:

--- a/scripts/lib/config_runtime.py
+++ b/scripts/lib/config_runtime.py
@@ -24,7 +24,9 @@ if _LIB not in sys.path:
 
 import config_registry  # noqa: E402  (after the scripts/lib path guard above)
 
-_wired = False
+# Keyed by (state_dir_str, project_id) so a second project in the same process gets its own store.
+# Value is True when that (state_dir, project_id) pair is wired; False / absent otherwise.
+_wired_for: "dict[tuple[str, str], bool]" = {}
 
 
 def _resolve_state_dir(state_dir: "str | Path | None") -> Optional[Path]:
@@ -50,12 +52,10 @@ def _resolve_project_id(state_dir: Path, project_id: Optional[str]) -> Optional[
 def autowire(state_dir: "str | Path | None" = None, project_id: Optional[str] = None) -> bool:
     """Wire config_registry's DB resolver + default project for this runtime process.
 
-    Returns True once wired. Idempotent (subsequent calls are O(1)); fail-soft — any missing state
-    dir / project_id / DB leaves the registry env-only and returns False (it may succeed on a later
-    call once the runtime state exists)."""
-    global _wired
-    if _wired:
-        return True
+    Keyed by (state_dir, project_id): if the same pair is requested again it is a fast no-op
+    (idempotent); a DIFFERENT project_id re-wires to that project's store. Fail-soft — any missing
+    state dir / project_id / DB leaves the registry env-only and returns False."""
+    global _wired_for
     try:
         sd = _resolve_state_dir(state_dir)
         if sd is None:
@@ -63,14 +63,19 @@ def autowire(state_dir: "str | Path | None" = None, project_id: Optional[str] = 
         pid = _resolve_project_id(sd, project_id)
         if not pid:
             return False
-        db = sd / "runtime_coordination.db"
-        if not db.exists():
-            return False
+        wire_key = (str(sd), pid)
+        if not _wired_for.get(wire_key):
+            # First time for this pair: confirm the DB exists before wiring.
+            if not (sd / "runtime_coordination.db").exists():
+                return False
+        # Always (re)apply the global registry state for the requested pair, so a switch
+        # back to a previously-wired project restores ITS resolver + default — a bare cache
+        # hit would otherwise leave the registry pointed at the last-wired project.
         import config_store_db
         resolved = sd
         config_registry.set_db_resolver(config_store_db.make_db_resolver(lambda _pid: resolved))
         config_registry.set_default_project_id(pid)
-        _wired = True
+        _wired_for[wire_key] = True
         return True
     except Exception:
         return False
@@ -83,6 +88,6 @@ def get(key: str) -> Optional[str]:
 
 
 def get_bool(key: str) -> bool:
-    """Bool view of get() — true only for the canonical "1" (matches the read-sites)."""
+    """Bool view of get() — true for any truthy spelling (1/true/yes/on), via config_registry.get_bool."""
     autowire()
     return config_registry.get_bool(key)

--- a/tests/test_audit_correctness_fixes.py
+++ b/tests/test_audit_correctness_fixes.py
@@ -1,0 +1,298 @@
+#!/usr/bin/env python3
+"""Regression tests for the four audit-correctness fixes (C3, C4, C6, C7).
+
+Dispatch-ID: feat/audit-correctness-fixes
+
+C3 — VNX_OVERRIDE_* truthy spellings (config_registry.get_bool)
+C4 — two project_ids in one process get distinct stores (config_runtime.autowire)
+C6 — two receipts with a missing timestamp get distinct idempotency keys
+C7 — an in-window key survives a duplicate receipt append
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import config_registry as cr  # noqa: E402
+import config_store_db as cs  # noqa: E402
+import config_runtime as crt  # noqa: E402
+from append_receipt_internals.idempotency import (  # noqa: E402
+    _compute_idempotency_key,
+    _write_receipt_under_lock,
+    _cache_file_for,
+    _load_cache,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fixture: isolate registry / runtime state between each test
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _isolate(monkeypatch):
+    # Clear all registry env vars and overrides so tests start clean.
+    for k in list(cr.CONFIG_REGISTRY):
+        monkeypatch.delenv(k, raising=False)
+        monkeypatch.delenv(f"VNX_OVERRIDE_{cr._bare(k)}", raising=False)
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    crt._wired_for.clear()
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+    yield
+    crt._wired_for.clear()
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+
+
+def _state_dir_with(tmp_path: Path, key: str, value: str, project_id: str = "proj-a") -> Path:
+    sd = tmp_path / project_id / "state"
+    sd.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    cs.set_config(conn, project_id, key, value, actor="op")
+    conn.close()
+    return sd
+
+
+# ===========================================================================
+# C3 — VNX_OVERRIDE_* must accept all truthy spellings, not just "1"
+# ===========================================================================
+
+class TestC3OverrideTruthySpellings:
+    """C3: VNX_OVERRIDE_X=true / =yes / =on must resolve truthy; =false must resolve falsy."""
+
+    def test_override_true_is_truthy(self, monkeypatch):
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "true")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+    def test_override_TRUE_upper_is_truthy(self, monkeypatch):
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "TRUE")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+    def test_override_yes_is_truthy(self, monkeypatch):
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "yes")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+    def test_override_on_is_truthy(self, monkeypatch):
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "on")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+    def test_override_1_is_truthy(self, monkeypatch):
+        """The canonical "1" must still work."""
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "1")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+    def test_override_false_is_falsy(self, monkeypatch):
+        """VNX_OVERRIDE_X=false disables even when VNX_X=1."""
+        monkeypatch.setenv("VNX_SCOUT_PREPASS", "1")
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "false")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is False
+
+    def test_override_0_is_falsy(self, monkeypatch):
+        monkeypatch.setenv("VNX_SCOUT_PREPASS", "1")
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "0")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is False
+
+    def test_get_returns_raw_string_for_override(self, monkeypatch):
+        """get() itself still returns the raw string — only get_bool() interprets truthy."""
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "true")
+        assert cr.get("VNX_SCOUT_PREPASS") == "true"
+
+    def test_override_beats_db_and_env_with_truthy_spelling(self, monkeypatch):
+        """Override with spelling=true must beat both a DB "0" and env "0"."""
+        monkeypatch.setenv("VNX_SCOUT_PREPASS", "0")
+        cr.set_db_resolver(lambda pid, key: "0" if key == "VNX_SCOUT_PREPASS" else None)
+        monkeypatch.setenv("VNX_OVERRIDE_SCOUT_PREPASS", "true")
+        assert cr.get_bool("VNX_SCOUT_PREPASS") is True
+
+
+# ===========================================================================
+# C4 — two project_ids in one process resolve different stores
+# ===========================================================================
+
+class TestC4TwoProjectsDistinctStores:
+    """C4: autowire keyed by (state_dir, project_id) — second project gets its own store."""
+
+    def test_two_project_ids_resolve_distinct_db_values(self, tmp_path):
+        sd_a = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "1", project_id="proj-a")
+        sd_b = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "0", project_id="proj-b")
+
+        # Wire project A
+        assert crt.autowire(state_dir=sd_a, project_id="proj-a") is True
+        val_a = cr.get("VNX_SCOUT_PREPASS", project_id="proj-a")
+
+        # Wire project B (different state_dir + project_id)
+        assert crt.autowire(state_dir=sd_b, project_id="proj-b") is True
+        val_b = cr.get("VNX_SCOUT_PREPASS", project_id="proj-b")
+
+        assert val_a == "1", f"proj-a expected '1', got {val_a!r}"
+        assert val_b == "0", f"proj-b expected '0', got {val_b!r}"
+        assert val_a != val_b
+
+    def test_same_pair_is_idempotent(self, tmp_path):
+        sd = _state_dir_with(tmp_path, "VNX_TAGGER_ENABLED", "1", project_id="proj-a")
+        assert crt.autowire(state_dir=sd, project_id="proj-a") is True
+        # Same args a second time must return True without error.
+        assert crt.autowire(state_dir=sd, project_id="proj-a") is True
+
+    def test_bogus_dir_returns_false_after_first_project_wired(self, tmp_path):
+        sd = _state_dir_with(tmp_path, "VNX_TAGGER_ENABLED", "1", project_id="proj-a")
+        assert crt.autowire(state_dir=sd, project_id="proj-a") is True
+        # A different (bogus, other-proj) key must not piggyback on the first wiring.
+        result = crt.autowire(state_dir=tmp_path / "bogus", project_id="other-proj")
+        assert result is False
+
+    def test_rewire_back_to_first_project_restores_its_default(self, tmp_path):
+        # Gate finding: A -> B -> A must restore A's resolver+default on the cache hit,
+        # not leave the registry pointed at B. Checks the DEFAULT (no explicit project_id).
+        sd_a = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "1", project_id="proj-a")
+        sd_b = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "0", project_id="proj-b")
+        assert crt.autowire(state_dir=sd_a, project_id="proj-a") is True
+        assert crt.autowire(state_dir=sd_b, project_id="proj-b") is True
+        assert cr.get("VNX_SCOUT_PREPASS") == "0"  # default now resolves B
+        assert crt.autowire(state_dir=sd_a, project_id="proj-a") is True  # cache hit
+        assert cr.get("VNX_SCOUT_PREPASS") == "1", "re-wire to A must restore A's default, not stay on B"
+
+
+# ===========================================================================
+# C6 — two receipts with a missing timestamp get distinct keys
+# ===========================================================================
+
+class TestC6MissingTimestampDistinctKeys:
+    """C6: receipts without timestamp (and no dispatch_id/task_id/report_path) must get distinct
+    idempotency keys so the second is not silently dropped."""
+
+    def _receipt_no_ts(self, extra: dict | None = None) -> dict:
+        base = {"event_type": "task_complete", "status": "success", "source": "pytest"}
+        if extra:
+            base.update(extra)
+        return base
+
+    def test_two_distinct_receipts_without_timestamp_get_distinct_keys(self):
+        r1 = self._receipt_no_ts({"terminal": "T1", "note": "alpha"})
+        r2 = self._receipt_no_ts({"terminal": "T2", "note": "beta"})
+        k1 = _compute_idempotency_key(r1, "task_complete")
+        k2 = _compute_idempotency_key(r2, "task_complete")
+        assert k1 != k2, "Distinct receipts without timestamp must not share an idempotency key"
+
+    def test_identical_receipts_without_timestamp_get_the_same_key(self):
+        """Truly identical receipts (same content) must still deduplicate correctly."""
+        r = self._receipt_no_ts({"terminal": "T1"})
+        k1 = _compute_idempotency_key(r, "task_complete")
+        k2 = _compute_idempotency_key(dict(r), "task_complete")
+        assert k1 == k2
+
+    def test_receipt_with_null_timestamp_gets_content_based_key(self):
+        """A receipt where timestamp is explicitly None must not collapse with a different receipt."""
+        r1 = {"event_type": "task_complete", "terminal": "T1", "timestamp": None}
+        r2 = {"event_type": "task_complete", "terminal": "T2", "timestamp": None}
+        k1 = _compute_idempotency_key(r1, "task_complete")
+        k2 = _compute_idempotency_key(r2, "task_complete")
+        assert k1 != k2
+
+    def test_receipt_with_blank_timestamp_behaves_like_missing(self):
+        r1 = {"event_type": "task_complete", "terminal": "T1", "timestamp": "  "}
+        r2 = {"event_type": "task_complete", "terminal": "T2", "timestamp": "  "}
+        k1 = _compute_idempotency_key(r1, "task_complete")
+        k2 = _compute_idempotency_key(r2, "task_complete")
+        assert k1 != k2
+
+    def test_receipt_with_valid_timestamp_uses_timestamp_based_key(self):
+        """When a valid timestamp exists, the key should differ only when the timestamp differs."""
+        r_ts = {"event_type": "task_complete", "timestamp": "2026-06-30T10:00:00Z"}
+        r_no_ts = {"event_type": "task_complete"}
+        k_ts = _compute_idempotency_key(r_ts, "task_complete")
+        k_no_ts = _compute_idempotency_key(r_no_ts, "task_complete")
+        assert k_ts != k_no_ts
+
+    def test_two_receipts_without_timestamp_both_append_to_file(self, tmp_path):
+        """End-to-end: both receipts must appear in the NDJSON file, not just the first."""
+        receipt_path = tmp_path / "t0_receipts.ndjson"
+        cache_path = _cache_file_for(receipt_path)
+        window = 300
+
+        r1 = {"event_type": "task_complete", "terminal": "T1", "status": "success"}
+        r2 = {"event_type": "task_complete", "terminal": "T2", "status": "success"}
+
+        k1 = _compute_idempotency_key(r1, "task_complete")
+        k2 = _compute_idempotency_key(r2, "task_complete")
+        assert k1 != k2, "pre-condition: distinct receipts must have distinct keys"
+
+        res1 = _write_receipt_under_lock(r1, receipt_path, cache_path, k1, window)
+        res2 = _write_receipt_under_lock(r2, receipt_path, cache_path, k2, window)
+
+        assert res1.status == "appended"
+        assert res2.status == "appended", f"Second receipt was {res2.status!r} — must be 'appended'"
+
+        lines = [l for l in receipt_path.read_text().splitlines() if l.strip()]
+        assert len(lines) == 2, f"Expected 2 receipts in file, got {len(lines)}"
+
+
+# ===========================================================================
+# C7 — in-window key survives a duplicate receipt append
+# ===========================================================================
+
+class TestC7InWindowKeyNotEvicted:
+    """C7: the duplicate path must NOT rewrite/trim the cache so in-window keys are preserved."""
+
+    def test_in_window_key_survives_duplicate_append(self, tmp_path):
+        receipt_path = tmp_path / "t0_receipts.ndjson"
+        cache_path = _cache_file_for(receipt_path)
+        window = 300
+
+        # First append: write a unique receipt to establish an in-window key.
+        r_unique = {"event_type": "task_complete", "dispatch_id": "unique-dispatch-001"}
+        k_unique = _compute_idempotency_key(r_unique, "task_complete")
+        res_unique = _write_receipt_under_lock(r_unique, receipt_path, cache_path, k_unique, window)
+        assert res_unique.status == "appended"
+
+        # Second append: a different receipt to be repeated as a duplicate.
+        r_dup = {"event_type": "task_complete", "dispatch_id": "dup-dispatch-002"}
+        k_dup = _compute_idempotency_key(r_dup, "task_complete")
+        res_first = _write_receipt_under_lock(r_dup, receipt_path, cache_path, k_dup, window)
+        assert res_first.status == "appended"
+
+        # Third append: duplicate of the second (triggers the duplicate path).
+        res_dup = _write_receipt_under_lock(r_dup, receipt_path, cache_path, k_dup, window)
+        assert res_dup.status == "duplicate"
+
+        # The in-window key for the FIRST receipt must still be in the cache.
+        entries = _load_cache(cache_path, min_epoch=time.time() - window)
+        cached_keys = {e["key"] for e in entries}
+        assert k_unique in cached_keys, (
+            "In-window key from the first append was evicted by the duplicate path"
+        )
+        assert k_dup in cached_keys
+
+    def test_duplicate_append_does_not_write_additional_line_to_receipt_file(self, tmp_path):
+        """The duplicate path must not write to the NDJSON file."""
+        receipt_path = tmp_path / "t0_receipts.ndjson"
+        cache_path = _cache_file_for(receipt_path)
+        window = 300
+
+        r = {"event_type": "task_complete", "dispatch_id": "dispatch-c7-check"}
+        k = _compute_idempotency_key(r, "task_complete")
+
+        _write_receipt_under_lock(r, receipt_path, cache_path, k, window)
+        line_count_before = len([l for l in receipt_path.read_text().splitlines() if l.strip()])
+
+        res = _write_receipt_under_lock(r, receipt_path, cache_path, k, window)
+        assert res.status == "duplicate"
+
+        line_count_after = len([l for l in receipt_path.read_text().splitlines() if l.strip()])
+        assert line_count_before == line_count_after, (
+            f"Duplicate append wrote to the receipt file: {line_count_before} → {line_count_after} lines"
+        )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_config_runtime.py
+++ b/tests/test_config_runtime.py
@@ -31,11 +31,11 @@ def _clean(monkeypatch):
         monkeypatch.delenv(f"VNX_OVERRIDE_{cr._bare(k)}", raising=False)
     monkeypatch.delenv("VNX_STATE_DIR", raising=False)
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
-    crt._wired = False
+    crt._wired_for.clear()
     cr.set_db_resolver(None)
     cr.set_default_project_id(None)
     yield
-    crt._wired = False
+    crt._wired_for.clear()
     cr.set_db_resolver(None)
     cr.set_default_project_id(None)
 
@@ -95,8 +95,8 @@ def test_autowire_failsoft_without_db(tmp_path):
 def test_autowire_is_idempotent(tmp_path):
     sd = _state_dir_with(tmp_path, "VNX_SCOUT_PREPASS", "1")
     assert crt.autowire(state_dir=sd, project_id=PID) is True
-    # a second call (even with a bogus dir) keeps the first wiring and returns True
-    assert crt.autowire(state_dir=tmp_path / "bogus", project_id="other") is True
+    # A second call with the same (state_dir, project_id) is a fast no-op and still returns True.
+    assert crt.autowire(state_dir=sd, project_id=PID) is True
     assert crt.get_bool("VNX_SCOUT_PREPASS") is True
 
 

--- a/tests/test_dispatch_metadata_lib.sh
+++ b/tests/test_dispatch_metadata_lib.sh
@@ -54,7 +54,10 @@ missing_file="$(mktemp)"
 assert_eq "P1" "$(vnx_dispatch_extract_priority "$missing_file")" "default priority"
 assert_eq "normal" "$(vnx_dispatch_extract_cognition "$missing_file")" "default cognition"
 assert_eq "none" "$(vnx_dispatch_extract_mode "$missing_file")" "default mode"
-assert_eq "false" "$(vnx_dispatch_extract_clear_context "$missing_file")" "default clear-context"
+# Default is clear=true (fresh context per dispatch = isolation): the extractor returns
+# ${clear:-true} and dispatch_deliver.sh resets the pane when clear_context == "true". A headerless
+# dispatch therefore gets a clean context. The test follows that production semantics.
+assert_eq "true" "$(vnx_dispatch_extract_clear_context "$missing_file")" "default clear-context"
 assert_eq "$(basename "$missing_file")" "$(vnx_dispatch_extract_dispatch_id "$missing_file")" "dispatch-id fallback to filename"
 
 rm -f "$tmp_file" "$missing_file"


### PR DESCRIPTION
## Summary

First audit-tail fix batch (Claude subagent built, kimi-gated). Four open Correctness findings + the pre-existing clear-context test mismatch flagged during fix-2. Each finding re-verified against current code first (the 2026-06-27 doc is partly stale).

## Changes

- **C3** `config_registry.get_bool` — honoured only exact `"1"`; `VNX_OVERRIDE_X=true` resolved False (opposite of intent). Now truthy = 1/true/yes/on (case-insensitive); `"1"` still truthy (provider `VNX_OVERRIDE=1` safe), None→False.
- **C4** `config_runtime.autowire` — module-global `_wired` bound the resolver to the FIRST project forever; now keyed `_wired_for[(state_dir, project_id)]`, and **always re-applies** the resolver/default for the requested pair so A→B→A restores A (round-1 gate finding).
- **C6** `idempotency.py` — missing-timestamp fallback passed None, collapsing distinct receipts; now a content-hash component gives distinct keys (identical still dedupe).
- **C7** `idempotency.py` — duplicate path rewrote+truncated the cache, evicting in-window keys; removed the redundant `_write_cache` on the duplicate branch.
- **clear-context** — `tests/test_dispatch_metadata_lib.sh` assertion corrected to `true` (code+reader default-clear semantics: headerless = fresh context).

## Verification

- `pytest` (audit fixes + config + receipt suites) → green (incl. the A→B→A re-wire test). Scanner + py_compile clean; clear-context bash test passes.
- kimi-gate → **PASS** (round 1 caught the C4 cache-hit re-wire gap + docstrings, fixed).

## Open Items

- Remaining audit medium/low tail (Hardening, Governance, Docs-drift, DX) — next batches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019qnMRuLPqtg8dvXt4uo7WC