### PR TITLE
fix(governance): audit batch G2-G5 — phantom outcome-stamp, contract_hash gate, guard-error audit, exhaustive side-door scan

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -461,10 +461,19 @@ def _govern(
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
         )
     except Exception as exc:  # noqa: BLE001
-        logger.warning(
+        logger.error(
             "envelope._govern: phantom-guard check failed (non-fatal) dispatch=%s: %s",
             spec.dispatch_id, exc,
         )
+        try:
+            from phantom_guard import record_guard_error  # noqa: PLC0415
+            record_guard_error(
+                dispatch_id=spec.dispatch_id,
+                receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
+                error=exc,
+            )
+        except Exception:  # noqa: BLE001 — the guard-error audit signal must never make _govern fatal
+            logger.error("envelope._govern: guard-error audit signal itself failed dispatch=%s", spec.dispatch_id)
     return report_path, receipt_path
 
 

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -282,7 +282,16 @@ def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
         )
     except Exception as exc:  # noqa: BLE001
-        logger.warning("govern: phantom-guard check failed (non-fatal) dispatch=%s: %s", dispatch_id, exc)
+        logger.error("govern: phantom-guard check failed (non-fatal) dispatch=%s: %s", dispatch_id, exc)
+        try:
+            from phantom_guard import record_guard_error  # noqa: PLC0415
+            record_guard_error(
+                dispatch_id=dispatch_id,
+                receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
+                error=exc,
+            )
+        except Exception:  # noqa: BLE001 — the guard-error audit signal must never make govern fatal
+            logger.error("govern: guard-error audit signal itself failed dispatch=%s", dispatch_id)
     return outcome
 
 

--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -37,6 +37,61 @@ _DELIVERY_PATTERNS = [
     re.compile(r"\b[A-Za-z_]*(provider_dispatch|pd)\.main\s*\("),
 ]
 
+# G5: the raw receipt-bypass primitive. A NON-INTERACTIVE claude spawn (`claude -p` /
+# `claude --print`) delivers work WITHOUT a governance receipt. Interactive `claude` (the
+# sanctioned subscription lane) is NOT matched, and provider_mix lists like ["claude","claude"]
+# carry no -p/--print flag so they are NOT matched. The flag need NOT sit adjacent to `claude`:
+# `["claude", "--model", m, "--print", p]` and `claude --model opus --print` are caught too
+# (a trivially-reordered argv must not evade an exhaustiveness gate — codex G5-2). Patterns run on
+# the file's code-only text (docstrings/comments stripped) so multi-line argv lists match.
+# NOTE ON REACH: these patterns catch literal argv lists, shell command lines, and the split
+# binary/args config idiom below. A FULLY dynamic construction (e.g. a binary name assembled from
+# fragments, or flags read from an untyped external source) is out of static-regex reach — the
+# runtime pretooluse hooks (`scripts/hooks/pretooluse_block_raw_claude_spawn.sh`) are the enforcing
+# backstop for those; this static scan is the audit-surface ledger for the reachable shapes.
+_RAW_CLAUDE_PATTERNS = [
+    # Python argv list containing a "claude" element AND a standalone "-p"/"--print" element before
+    # the list closes — claude need NOT be first (a `["timeout","3s","claude","-p"]` wrapper is caught
+    # too — codex G5-8). `[^\]]*?` spans newlines but never crosses `]`, so both tokens belong to the
+    # SAME list, and the flag must be a whole quoted token (so "--print-config" or a -p inside a string
+    # value does NOT match, and a bare ["claude"] provider_mix with no flag does NOT match).
+    re.compile(r"""\[[^\]]*?["']claude["'][^\]]*?["'](?:-p|--print)["']"""),
+    # Shell: `claude` followed by a -p/--print flag anywhere later on the same command line.
+    re.compile(r"\bclaude\b[^\n]*?\s(?:-p|--print)\b"),
+    # Split binary/args construction: a CLI-config dict `"binary": "claude"` whose argv is assembled
+    # elsewhere (headless_adapter builds `cmd = [binary] + args` with args carrying --print). A literal
+    # argv/shell regex can't see the assembled command, so match the config idiom directly (codex G5-6).
+    re.compile(r"""["']binary["']\s*:\s*["']claude["']"""),
+]
+
+# Audited NON-delivery raw-claude callers: haiku/deepseek classifiers, weekly digest, headless
+# T0 orchestration, conversation analysis, benchmark/replay harnesses, and the auth probe. A
+# scanned file outside this set that spawns `claude -p` is a NEW receipt-bypass side door and
+# fails the gate until audited here (or routed via a governed lane).
+KNOWN_RAW_CLAUDE_CALLERS = frozenset({
+    "scripts/claude_auth_check_v2.sh",             # auth probe (claude --print "echo test")
+    "scripts/conversation_analyzer/deep_analyzer.py",
+    "scripts/f39/replay_harness/single_replay.py",
+    "scripts/headless_trigger.py",
+    "scripts/lib/classifier_providers/deepseek_provider.py",
+    "scripts/lib/classifier_providers/haiku_provider.py",
+    "scripts/lib/llm_decision_router.py",
+    "scripts/lib/report_classifier.py",
+    "scripts/lib/headless_adapter.py",             # the GOVERNED headless lane's spawner (binary=claude + --print args) — receipt-producing, NOT a bypass
+    "scripts/lib/subprocess_adapter.py",           # the GOVERNED subprocess lane's spawner — emits receipts, NOT a bypass
+    "scripts/lib/t0_decision_summarizer.py",       # haiku T0 decision-log summarizer (non-delivery)
+    "scripts/llm_benchmark.py",
+    "scripts/weekly_digest.py",
+    # benchmark harnesses — spawn claude to BENCHMARK it, not to deliver governed work (codex G5-3):
+    "scripts/benchmark/judge_quality.py",
+    "scripts/benchmark/field-tests/runners/scorer.py",
+    "scripts/benchmark/field-tests/runners/harvest_t6_reviews.py",
+    # audited MENTION-only (the pattern trips on prose/keyword text, not an executable spawn) — kept
+    # in the allowlist rather than line-suppressed, so a REAL spawn added here still matches (codex G5-8):
+    "scripts/commands/dispatch.sh",                # burst-lane help text mentions "(claude -p)"; delivery already audited
+    "scripts/lib/vnx_tag_vocabulary.py",           # "claude -p" appears as a keyword-taxonomy string literal
+})
+
 _EXCLUDE_SUBSTR = (
     "/subprocess_dispatch_internals/",  # the lane's own internals
     "/dispatch_bridge.py",              # the SANCTIONED door bridge
@@ -49,6 +104,18 @@ _EXCLUDE_SUBSTR = (
     "/provider_spawns/", "/providers/", # provider_dispatch's own spawn machinery
 )
 _EXCLUDE_BASENAMES = {f"{n}.py" for n in _LANES}
+
+# G5: the raw scan does NOT inherit the delivery `_EXCLUDE_SUBSTR` — that hides benchmark harnesses
+# and lane machinery, but a raw `claude -p` spawn ANYWHERE is worth auditing for exhaustiveness
+# (codex G5-3: silent /benchmark/ inheritance suppressed 3 real spawns). The raw scan excludes ONLY
+# non-spawns: compiled caches, the guard hooks that DETECT the primitive (they hold the pattern but
+# never spawn), and this auditor itself. Every real spawn — production auxiliary, benchmark harness,
+# sanctioned lane spawner — is AUDITED in KNOWN_RAW_CLAUDE_CALLERS instead of hidden.
+_RAW_SCAN_EXCLUDE_SUBSTR = (
+    "/__pycache__/",
+    "/hooks/pretooluse_",           # guards that DETECT raw spawns (hold the pattern, do not spawn)
+    "/dispatch_sidedoor_audit.py",  # this auditor (holds the patterns as source)
+)
 
 # Audited delivery callers (PR-2). A scanned file outside this set is a NEW side door and
 # fails the gate until it is audited (added here) and wired through dispatch_bridge.
@@ -80,12 +147,15 @@ def _code_lines(text: str):
             continue
         if s.startswith("#"):
             continue
-        # opening triple-quote with no matching close on the same line → enter docstring
+        # skip one-line docstrings as well as opening docstrings
+        is_doc = False
         for q in ('"""', "'''"):
-            if s.startswith(q) and line.count(q) == 1:
-                in_doc, quote = True, q
+            if s.startswith(q):
+                if line.count(q) == 1:
+                    in_doc, quote = True, q
+                is_doc = True
                 break
-        if in_doc:
+        if is_doc:
             continue
         yield line
 
@@ -112,13 +182,62 @@ def scan_delivery_callers(root: Path | None = None) -> Set[str]:
     return callers
 
 
+def _raw_scannable(path: Path) -> bool:
+    """A file is scannable if it is a .py/.sh source OR an extensionless shebang script (e.g. bin/vnx
+    — an entry point that can spawn claude too; codex G5-7 flagged the extensionless blind spot)."""
+    if path.suffix in (".py", ".sh"):
+        return True
+    if path.suffix == "":
+        try:
+            with path.open("rb") as fh:
+                return fh.read(2) == b"#!"
+        except OSError:
+            return False
+    return False
+
+
+def scan_raw_claude_spawns(root: Path | None = None) -> Set[str]:
+    """Return repo-relative paths of files that spawn a raw `claude -p`/`--print` (receipt bypass)."""
+    root = root or _repo_root()
+    callers: Set[str] = set()
+    for base in ("scripts", "bin", "vnx_cli"):
+        for path in (root / base).rglob("*"):
+            if not path.is_file() or not _raw_scannable(path):
+                continue
+            rel = path.relative_to(root).as_posix()
+            # NB: unlike the delivery scan, the raw scan does NOT skip lane-script basenames — a raw
+            # `claude -p` added to a lane script must still be audited, not hidden (codex G5-4).
+            if any(s in f"/{rel}" for s in _RAW_SCAN_EXCLUDE_SUBSTR):
+                continue
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except OSError:
+                continue
+            # Join code-only lines so a multi-line argv list is matchable as one blob; the argv
+            # pattern is bounded by `]` and the shell pattern by `\n`, so joining is safe. Files that
+            # only MENTION the primitive (a "claude -p" keyword literal, help text) still match — they
+            # are AUDITED in KNOWN_RAW_CLAUDE_CALLERS, not line-suppressed: suppressing a quoted
+            # "claude -p" would also hide a real `subprocess.run("claude -p", shell=True)` (codex G5-8).
+            code_text = "\n".join(_code_lines(text))
+            if any(p.search(code_text) for p in _RAW_CLAUDE_PATTERNS):
+                callers.add(rel)
+    return callers
+
+
 def audit(root: Path | None = None) -> dict:
-    """Return {known, found, unaudited}. `unaudited` non-empty = a new side door = gate fails."""
+    """Return delivery-caller and raw-claude spawn scan results.
+
+    `unaudited` or `raw_claude_unaudited` non-empty = a new side door = gate fails.
+    """
     found = scan_delivery_callers(root)
+    raw = scan_raw_claude_spawns(root)
     return {
         "known": set(KNOWN_DELIVERY_CALLERS),
         "found": found,
         "unaudited": found - KNOWN_DELIVERY_CALLERS,
+        "raw_claude_known": set(KNOWN_RAW_CLAUDE_CALLERS),
+        "raw_claude_found": raw,
+        "raw_claude_unaudited": raw - KNOWN_RAW_CLAUDE_CALLERS,
     }
 
 
@@ -128,11 +247,24 @@ def main() -> int:
     for c in sorted(result["found"]):
         flag = "  [UNAUDITED — new side door]" if c in result["unaudited"] else ""
         print(f"  {c}{flag}")
+
+    print(f"\nraw claude -p/--print spawns found: {len(result['raw_claude_found'])}")
+    for c in sorted(result["raw_claude_found"]):
+        flag = "  [UNAUDITED — new receipt-bypass side door]" if c in result["raw_claude_unaudited"] else ""
+        print(f"  {c}{flag}")
+
+    fail = False
     if result["unaudited"]:
         print(f"\nFAIL: {len(result['unaudited'])} unaudited delivery caller(s); audit + wire "
               "through dispatch_bridge before flipping VNX_SINGLE_ENTRY_DISPATCH.", file=sys.stderr)
+        fail = True
+    if result["raw_claude_unaudited"]:
+        print(f"\nFAIL: {len(result['raw_claude_unaudited'])} unaudited raw claude -p/--print spawn(s); "
+              "route via a governed lane (provider_dispatch) or audit here.", file=sys.stderr)
+        fail = True
+    if fail:
         return 1
-    print("\nOK: no unaudited delivery callers — exhaustiveness holds.")
+    print("\nOK: no unaudited delivery callers and no unaudited raw claude spawns — exhaustiveness holds.")
     return 0
 
 

--- a/scripts/lib/headless_review_receipt.py
+++ b/scripts/lib/headless_review_receipt.py
@@ -191,8 +191,8 @@ def validate_gate_result(d: Dict[str, Any]) -> List[ValidationError]:
     if not contract_hash and status == "pass":
         errors.append(ValidationError(
             field="contract_hash",
-            severity="warning",
-            message="contract_hash is empty for a passing gate",
+            severity="error",
+            message="contract_hash is required for a passing gate",
         ))
 
     # Contradictory: pass + blocking findings

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -260,6 +260,46 @@ def record_phantom_if_any(
     return verdict
 
 
+def record_guard_error(
+    *,
+    dispatch_id: str,
+    receipts_file: Optional[str],
+    error: object,
+) -> None:
+    """Best-effort audit signal that the phantom-guard itself errored (fail-open backstop, G4).
+
+    The guard is the single completion chokepoint; if it raises, detection fails open. This
+    appends a non-actionable ``phantom_guard_error`` receipt so the failure is recoverable from
+    the ledger, not just a scrolled log line. Never raises.
+    """
+    _LOG.error("phantom_guard: GUARD ERROR dispatch=%s — %s", dispatch_id, error)
+    if not receipts_file:
+        return
+    try:
+        import os  # noqa: PLC0415
+        import sys  # noqa: PLC0415
+        from datetime import datetime, timezone  # noqa: PLC0415
+        _scripts = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        if _scripts not in sys.path:
+            sys.path.insert(0, _scripts)
+        from append_receipt import append_receipt_payload  # noqa: PLC0415
+        append_receipt_payload(
+            {
+                "event_type": "phantom_guard_error",
+                "dispatch_id": dispatch_id,
+                "status": "guard_error",
+                "guard_error": str(error),
+                "source": "phantom_guard",
+                "synthesized": False,
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+            receipts_file=str(receipts_file),
+            cache_window_seconds=0,
+        )
+    except Exception as exc:  # noqa: BLE001 — never break the caller on an audit-append failure
+        _LOG.error("phantom_guard: guard-error signal append failed dispatch=%s: %s", dispatch_id, exc)
+
+
 def _extract_token_usage(receipt: Mapping[str, Any]) -> Optional[int]:
     """Best-effort total token count from a receipt; None when unmeasured (e.g. kimi-cli)."""
     tu = receipt.get("token_usage")

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -154,22 +154,49 @@ _psr_update_dispatch_outcome() {
     local dispatch_id="$1" event_type="$2" status="$3" report_path="$4" timestamp="$5"
     [ -n "$dispatch_id" ] || return 0
     case "$event_type" in task_complete|task_failed|task_timeout) ;; *) return 0 ;; esac
-    python3 -c "
-import sqlite3, sys
+    # Report-derived values (dispatch_id/status/report_path/timestamp) are passed as argv, NOT
+    # interpolated into the Python source (a crafted report status must not be able to inject Python
+    # at the shell→heredoc boundary — codex G2-boundary). The quoted <<'PY' delimiter disables all
+    # shell expansion inside the body.
+    python3 - "$SCRIPTS_DIR" "$dispatch_id" "$status" "${report_path:-}" "$timestamp" <<'PY' 2>/dev/null || log "WARN" "Failed to update dispatch_metadata outcome (non-fatal)"
+import json, sqlite3, sys
 from pathlib import Path
-sys.path.insert(0, str(Path('$SCRIPTS_DIR') / 'lib'))
+scripts_dir, dispatch_id, status, report_path, timestamp = sys.argv[1:6]
+sys.path.insert(0, str(Path(scripts_dir) / 'lib'))
 from vnx_paths import ensure_env
 p = ensure_env()
+# G2: if a phantom-guard corrective receipt already rejected this dispatch,
+# downgrade the persisted outcome_status to failed. Fail-open: any read error
+# leaves the original status untouched.
+ledger = Path(p['VNX_STATE_DIR']) / 't0_receipts.ndjson'
+try:
+    if ledger.exists():
+        with ledger.open('r', encoding='utf-8', errors='replace') as f:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    r = json.loads(line)
+                except Exception:
+                    continue
+                if not isinstance(r, dict):
+                    continue
+                if r.get('dispatch_id') == dispatch_id and r.get('phantom_rejected') is True:
+                    status = 'failed'
+                    break
+except Exception:
+    pass
 db = Path(p['VNX_STATE_DIR']) / 'quality_intelligence.db'
 if not db.exists(): sys.exit(0)
 conn = sqlite3.connect(str(db))
 conn.execute(
     'UPDATE dispatch_metadata SET outcome_status=?, outcome_report_path=?, completed_at=? WHERE dispatch_id=? AND outcome_status IS NULL',
-    ('$3', '${4:-}', '$5', '$1')
+    (status, report_path, timestamp, dispatch_id)
 )
 conn.commit()
 conn.close()
-" 2>/dev/null || log "WARN" "Failed to update dispatch_metadata outcome (non-fatal)"
+PY
     python3 "$SCRIPTS_DIR/update_dispatch_cqs.py" --dispatch-id "$dispatch_id" 2>/dev/null \
         || log "WARN" "Failed to update dispatch CQS (non-fatal)"
 }

--- a/tests/test_dispatch_sidedoor_audit.py
+++ b/tests/test_dispatch_sidedoor_audit.py
@@ -47,3 +47,106 @@ def test_docstring_mention_is_not_a_caller():
         "scripts/lib/dispatch_cli.py",      # the door itself (excluded)
     ):
         assert reference_only not in found, f"{reference_only} false-flagged as a caller"
+
+
+def test_no_unaudited_raw_claude_spawns():
+    result = audit_mod.audit()
+    assert result["raw_claude_unaudited"] == set(), (
+        "New raw claude -p/--print spawn(s) appeared — route via a governed lane or audit them: "
+        + ", ".join(sorted(result["raw_claude_unaudited"]))
+    )
+
+
+def test_scan_detects_known_raw_claude_spawns():
+    found = audit_mod.scan_raw_claude_spawns()
+    for caller in (
+        "scripts/lib/report_classifier.py",
+        "scripts/headless_trigger.py",
+    ):
+        assert caller in found, f"scanner no longer detects {caller}"
+
+
+def test_raw_claude_docstring_only_not_flagged():
+    # a file that only mentions the primitive in a docstring/comment must NOT be flagged.
+    found = audit_mod.scan_raw_claude_spawns()
+    assert "scripts/lib/decision_parser.py" not in found, (
+        "docstring-only mention false-flagged as raw claude spawn"
+    )
+
+
+def test_provider_mix_list_not_flagged():
+    # provider_mix lists like ["claude"] carry no -p/--print flag and must NOT be flagged.
+    found = audit_mod.scan_raw_claude_spawns()
+    assert "scripts/lib/pool_state_repo.py" not in found, (
+        "provider_mix list false-flagged as raw claude spawn"
+    )
+
+
+def _raw_match(s: str) -> bool:
+    return any(p.search(s) for p in audit_mod._RAW_CLAUDE_PATTERNS)
+
+
+def test_raw_claude_pattern_catches_nonadjacent_and_multiline():
+    # codex G5-2/G5-8: reordered/multi-line/wrapped argv + shell-string spawns must not evade the gate.
+    assert _raw_match('cmd = ["claude", "--model", model, "--print", prompt]')      # flag not adjacent
+    assert _raw_match('cmd = [\n    "claude",\n    "--model", m,\n    "-p", prompt,\n]')  # multi-line
+    assert _raw_match('subprocess.run("claude --model opus --print hi", shell=True)')  # reordered shell
+    assert _raw_match('subprocess.run("claude -p", shell=True)')                    # shell-string (was over-suppressed)
+    assert _raw_match('cmd = ["timeout", "3s", "claude", "-p", prompt]')            # claude wrapped, not first
+    assert _raw_match('["claude", "-p", "--verbose"]')                              # adjacent still caught
+
+
+def test_raw_claude_pattern_no_false_positives():
+    assert not _raw_match('provider_mix = ["claude", "claude", "codex"]')           # no flag
+    assert not _raw_match('subprocess.Popen(["claude", "--dangerously-skip-permissions", p])')  # interactive
+    assert not _raw_match("provider_mix = json.loads(row or '[\"claude\"]')")       # data literal
+    assert not _raw_match('["claude", "--print-config", "x"]')                      # --print-config != the print flag
+    assert not _raw_match('x = "claude"\ny = "-p"')                                 # unrelated statements, no shared list
+
+
+def test_raw_scan_does_not_skip_lane_basenames(tmp_path):
+    # codex G5-4: a raw claude -p spawn in a lane-named script must be audited, not hidden.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "subprocess_dispatch.py").write_text('cmd = ["claude", "-p", "x"]\n', encoding="utf-8")
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "scripts/subprocess_dispatch.py" in found, (
+        "raw scan must not blind-spot a raw spawn added to a lane-named script"
+    )
+
+
+def test_raw_scan_detects_split_binary_args_idiom(tmp_path):
+    # codex G5-6: `"binary": "claude"` + args=[..., "--print"] assembled as [binary]+args is a real
+    # claude spawn a literal-argv regex can't see; the config idiom must be detected + audited.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "some_adapter.py").write_text(
+        'CFG = {"binary": "claude", "args": ["--print", "--output-format", "text"]}\n',
+        encoding="utf-8",
+    )
+    assert "scripts/some_adapter.py" in audit_mod.scan_raw_claude_spawns(root=tmp_path)
+
+
+def test_real_headless_adapter_is_audited():
+    # headless_adapter's split binary/args construction is detected and audited (not unaudited).
+    assert "scripts/lib/headless_adapter.py" in audit_mod.scan_raw_claude_spawns()
+    assert "scripts/lib/headless_adapter.py" in audit_mod.KNOWN_RAW_CLAUDE_CALLERS
+
+
+def test_real_mention_files_are_audited_not_hidden():
+    # codex G5-8: dispatch.sh (help text) + vnx_tag_vocabulary (keyword) trip the pattern; they are
+    # AUDITED in the allowlist (not line-suppressed), so a real spawn added there still matches.
+    for f in ("scripts/commands/dispatch.sh", "scripts/lib/vnx_tag_vocabulary.py"):
+        assert f in audit_mod.KNOWN_RAW_CLAUDE_CALLERS
+
+
+def test_raw_scan_covers_extensionless_shebang_scripts(tmp_path):
+    # codex G5-7: bin/vnx-style extensionless executables can spawn claude too and must be scanned.
+    binp = tmp_path / "bin"
+    binp.mkdir()
+    vnx = binp / "vnx"
+    vnx.write_text('#!/usr/bin/env bash\nclaude -p "$@"\n', encoding="utf-8")
+    assert "bin/vnx" in audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    # an extensionless NON-shebang data file is not scanned as a script
+    (binp / "data").write_text('claude -p something\n', encoding="utf-8")
+    assert "bin/data" not in audit_mod.scan_raw_claude_spawns(root=tmp_path)


### PR DESCRIPTION
## Summary

Fixes the four medium **Governance** findings (G2-G5) from the 2026-06-27 repo audit, each verified against current code (the audit doc was partly stale). Vincent's governance stokpaardje — care taken to fix the real gaps without over-fixing.

- **G2** — the persisted `dispatch_metadata.outcome_status` was stamped from the report status and ignored a govern-time phantom rejection recorded in `t0_receipts.ndjson`. It now downgrades to `failed` when the ledger holds a `phantom_rejected: true` receipt for the dispatch (fail-open; non-dict lines skipped). Report-derived values now pass via `python3 - … <<'PY'` argv instead of being interpolated into the Python source (removes a shell→Python injection vector).
- **G3** — an empty `contract_hash` on a `status == "pass"` gate result is now severity `error` (was `warning`), matching the production ci_gate closure which already hard-FAILs on it.
- **G4** — a phantom-guard exception is now audit-visible: `record_guard_error` logs at ERROR and appends a non-actionable `phantom_guard_error` receipt. Both call sites keep it strictly non-fatal (nested try/except) so the guard stays fail-open.
- **G5** — the side-door audit now exhaustively scans for the raw `claude -p`/`--print` receipt-bypass primitive: literal argv (claude anywhere in a bounded list), shell command lines, shell-strings, the `binary: "claude"` config idiom, multi-line + wrapped argv, and extensionless shebang scripts. Its own minimal exclusions (no inherited benchmark/lane blind spots); 18 audited raw sites; documents the static-reach boundary (fully-dynamic spawns are backstopped by the runtime pretooluse hooks).

## Governance

Built through the governed `provider_dispatch` **Kimi** lane (build-receipt). Adversarially gated by a **different** model (**codex gpt-5.5**) — 8 rounds of REVISE each caught a real defect (G4 non-fatal edge, G5 non-adjacent/benchmark/basename/split/whole-file/bin/wrapped, G2 injection + non-dict-ledger) → **round-9 PASS**. Independent **deepseek-harness** gate also PASS.

## Verification

- `python3 scripts/lib/dispatch_sidedoor_audit.py` → exit 0 (8 delivery callers, 18 audited raw sites)
- `pytest tests/test_dispatch_sidedoor_audit.py tests/test_headless_review_receipt.py tests/test_phantom_guard.py tests/test_phantom_guard_inline.py` → 60 passed
- G2 proven in isolation (both forms, `/bin/bash`): phantom→failed, absent→unchanged, malformed→fail-open, cross-dispatch→no downgrade

## Open items

- Follow-up: `scripts/link_sessions_dispatches.py` has a pre-existing outcome-stamp path without the phantom downgrade (outside this diff; can't overwrite already-stamped rows). Worth a later pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)