### PR TITLE
fix(governance): architecture batch A7+A6 — surface door-invariant breaches distinctly

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -51,6 +51,12 @@ from dispatch_envelope import run_envelope_plan, run_envelope_headless_plan  # n
 from dispatch_serialization import force_release, serialize_lane  # noqa: E402
 
 
+class _InvariantViolation(Exception):
+    """A door closed-set or permit invariant was breached — a should-never-happen,
+    security-relevant event, categorically distinct from a transient runtime error.
+    Surfaced with its own reject code so the audit signal is not masked (audit finding A7)."""
+
+
 # ---------------------------------------------------------------------------
 # Path resolution
 # ---------------------------------------------------------------------------
@@ -587,7 +593,10 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                 logger.debug("[dispatch_cli] scout pre-pass skipped: %s", exc)
 
         permit = issue_permit(plan)
-        require_permit(plan, permit)  # P1-#6: door backstop for BOTH lanes
+        try:
+            require_permit(plan, permit)  # P1-#6: door backstop for BOTH lanes
+        except PermissionError as exc:
+            raise _InvariantViolation(f"permit invariant breached: {exc}") from exc
         fp = fingerprint(permit)
         logger.info("[dispatch_cli] permit fingerprint: %s", fp)
 
@@ -616,10 +625,17 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                     role=vspec.spec.role,
                 )
             else:
-                raise ValueError(
-                    f"[dispatch_cli] closed set violated — unknown lane: {plan.lane!r}"
+                raise _InvariantViolation(
+                    f"closed set violated — unknown lane: {plan.lane!r}"
                 )
 
+    except _InvariantViolation as exc:
+        logger.error(
+            "[dispatch_cli] INVARIANT VIOLATION dispatch=%s: %s",
+            getattr(getattr(vspec, "spec", None), "dispatch_id", "?"), exc,
+        )
+        print(f"[dispatch_cli] REJECT [invariant-violation]: {exc}", file=sys.stderr)
+        return 1
     except Exception as exc:
         print(f"[dispatch_cli] REJECT [runtime-error]: {exc}", file=sys.stderr)
         return 1

--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -29,6 +29,12 @@ from typing import Set
 
 _LANES = ("subprocess_dispatch", "provider_dispatch", "tmux_interactive_dispatch")
 
+# NOTE ON REACH: these patterns catch literal lane-script filename references in spawn/exec
+# contexts and direct delivery-function calls. A FULLY dynamic construction (e.g. a lane name
+# assembled from fragments, or an `importlib.import_module` / `__import__` caller) is out of
+# static-regex reach by design. The runtime pretooluse spawn-guard hooks are the enforcing
+# backstop for those; this static scan is the audit-surface ledger for the reachable shapes.
+#
 # Real DELIVERY invocations (not a docstring mention): the lane script named in a spawn/exec
 # context, or a delivery-function CALL. Comment/docstring lines are skipped before matching.
 _DELIVERY_PATTERNS = [


### PR DESCRIPTION
## Summary

Fixes the two genuinely-open **Architecture** findings (A7, A6) from the 2026-06-27 repo audit, each verified against current code.

- **A7** — the single-entry door (`dispatch_cli.run_dispatch`) wrapped everything after `validate()` in one broad `except Exception → REJECT [runtime-error]`. That also caught two categorically-different, security-relevant invariant breaches — the closed-set violation (unknown lane) and `require_permit`'s `PermissionError` (permit / TOCTOU / forgery invariant) — collapsing them into an indistinguishable generic soft reject, so an operator could not tell a door-invariant breach (investigate) from a transient error (retry). A new `_InvariantViolation` marker now carries both; a distinct `except _InvariantViolation` handler logs at ERROR and emits `REJECT [invariant-violation]`, still `return 1`. **"Door never panics" (P1-#1) is preserved** — every path returns 1, nothing re-raises. Only the door-level `require_permit` call is translated, so a stray filesystem `PermissionError` stays a generic runtime-error.
- **A6** — doc-only `NOTE ON REACH` above `_DELIVERY_PATTERNS` (consistency with the raw-claude scan): the delivery scan catches literal lane-script references + delivery-function calls; assembled-name / `importlib` callers are out of static-regex reach by design and backstopped by the runtime pretooluse spawn-guard hooks.

**Deliberately skipped (verified NOT-open):** A3 (raw-file legacy lane is the intentional ADR-024 / Option-X1 design, allowlisting is correct) and A4 (`deliver_via_door` has a fixed signature → `TypeError` on an unknown kwarg, not a silent drop; and no caller passes those params — no active bug).

## Governance

Built through the governed `provider_dispatch` **Kimi** lane. Adversarially gated by a **different** model (**codex gpt-5.5**) — no blocking findings (confirmed handler ordering, no stray-`PermissionError` promotion, never-panic preserved). One advisory (executor-layer permit failures still go generic) is out of A7's door-level scope and deliberately not expanded.

## Verification

- `ast` parse clean; `python3 scripts/lib/dispatch_sidedoor_audit.py` exits 0 (A6 no behaviour change)
- A7 structure check: closed-set + permit → `_InvariantViolation` → `[invariant-violation]`; generic → `[runtime-error]`; both `return 1`
- `tests/test_dispatch_sidedoor_audit.py` → 14 passed
- Targeted audit: every `pytest.raises(PermissionError)` in `test_dispatch_cli.py` is on the **executor layer** / direct `require_permit` calls (unchanged); no test asserts the door-level closed-set / `[runtime-error]` message that A7 changed. (The local full `test_dispatch_cli.py` run hangs on an account-level `serialize_lane` flock held by leftover processes — structurally upstream of A7, unchanged line 607; CI runs the suite in an isolated lock dir.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)