### PR TITLE
docs(launch): 1.0 HN-launch readiness — reconcile release status + refresh stale manifesto stamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,9 +50,11 @@ Filed and tracked in `ROADMAP.yaml`; not part of this batch:
 - **#869** — operator-runbook automation (automating the §7.2 runtime-migration runbook).
 - Additional follow-ups **#865**, **#870**, **#874** are filed against the 1.x line.
 
-## [1.0.0] — 2026-06-10
+## [1.0.0] — Unreleased (release candidate)
 
-First public release. Everything below is the rc9 → 1.0.0 delta; the rc-series
+The 1.0.0 release candidate. The code is at 1.0.0 and pip-installable from a
+checkout; the PyPI publish is the one remaining ship gate (this date is set when
+the tag is cut). Everything below is the rc9 → 1.0.0 delta; the rc-series
 entries that follow document the road there.
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ I wrote the architecture down as I built it. The full series is on [vincentvande
 
 ## What works today vs what is opt-in
 
-I am honest about maturity because the audit trail is the whole point and an overclaim would undercut it. The following is verified against code and receipts as of 2026-06-22.
+I am honest about maturity because the audit trail is the whole point and an overclaim would undercut it. The following is verified against code and receipts as of the 1.0 launch (July 2026).
 
 **Tier 1, in production.** Append-only NDJSON receipts with hash-chain verification tooling (`audit_chain`); per-append chain enforcement lands in 1.0.1. Multi-CLI provider hub with no vendor SDK (claude, codex, kimi, gemini, ollama). Review gates (codex and gemini) with deterministic CI as the third gate. Per-worker git worktree isolation with teardown classification (lane-specific; `VNX_ISOLATED_WORKTREE` defaults off). The interactive tmux worker lane: it is the default Claude worker lane (`scripts/commands/dispatch.sh` selects it unless a dispatch opts into the headless burst lane), runs on the subscription, and its PREPARE/GOVERN/RECEIPT/CAPTURE structural work has shipped. It is still being hardened; I do not yet claim it matches the headless lane on every surface. The headless `claude -p` burst lane is opt-in and blocked by default (`claude-headless` constraint; `VNX_OVERRIDE_CLAUDE_HEADLESS=1` to open it). The provider-constraint YAML source of truth. Zero-LLM context injection and repo map. Cost tracking per gate invocation. Governed memory PAST and CURRENT.
 
@@ -120,7 +120,7 @@ The leaseless single-shot tmux dispatch lane lives in `scripts/lib/tmux_interact
 
 Memory is the unsolved problem in agentic AI. Most systems bolt a vector store onto a stateless model and call it memory. I treat memory as a governed state machine with three tenses, each with its own store and its own audit guarantees.
 
-The PAST is append-only NDJSON receipts: a forensic ledger of every dispatch, gate, and merge, with hash-chain verification tooling (`audit_chain`) over it. Per-append chain enforcement lands in 1.0.1. It is forensic, not lossy. This is in production now, with 13,000+ receipts in the audit trail behind it.
+The PAST is append-only NDJSON receipts: a forensic ledger of every dispatch, gate, and merge, with hash-chain verification tooling (`audit_chain`) over it. Per-append chain enforcement lands in 1.0.1. It is forensic, not lossy. This is in production now, with 14,000+ receipts in the audit trail behind it.
 
 The CURRENT is `runtime_coordination.db` (SQLite WAL): real-time orchestration state, leases, tracks, and dispatch status that any terminal can read for situational awareness. As of 1.0.1 the `dispatches` table is ADR-007 tenant-scoped on a composite `UNIQUE(dispatch_id, project_id)`, rebuilt in place by a crash-safe migration (#859).
 
@@ -132,7 +132,7 @@ The point is not that the AI remembers. The point is that what it remembers is g
 
 ## Architecture decisions
 
-The decisions behind VNX are written down, not implied. There are 25 Architecture Decision Records under [docs/governance/decisions/](docs/governance/decisions/). The ones that shape the system most:
+The decisions behind VNX are written down, not implied. There are 26 Architecture Decision Records under [docs/governance/decisions/](docs/governance/decisions/). The ones that shape the system most:
 
 - [ADR-005](docs/governance/decisions/ADR-005-ndjson-audit-ledger-primary.md): append-only NDJSON ledger as the primary observability surface
 - [ADR-006](docs/governance/decisions/ADR-006-staging-promote-human-gate.md): staging then promote, with a mandatory human approval gate
@@ -168,7 +168,7 @@ The closest spiritual cousin is [dmux](https://github.com/standardagents/dmux), 
 
 ## Status
 
-1.0 release candidate as of this README on 2026-06-26: `VERSION` is `1.0.0`, the package builds from this tree, and the operator binary is still required for the full command surface. **Publishing to PyPI is the one remaining 1.0 ship gate** — human-gated, and not done yet. The two other gates it once sat alongside have both landed: the single-entry dispatch door is merged and default-ON (ADR-024, 2026-06-24), and the Mission Control central-store cutover completed (2026-06-23). The 1.0.1 future-state reconciliation batch (ADR-007 composite-key `dispatches`, the open-item → track bridge, and its autopilot wiring) has also landed on `main` — see [CHANGELOG.md](CHANGELOG.md) — but `VERSION` stays `1.0.0` until that milestone is cut. Open governance and release items are tracked in [ROADMAP.md](ROADMAP.md), [FEATURE_PLAN.md](FEATURE_PLAN.md), and the open-items tooling under [scripts/open_items_manager.py](scripts/open_items_manager.py).
+1.0 release candidate as of the 1.0 launch (July 2026): `VERSION` is `1.0.0`, the package builds from this tree, and the operator binary is still required for the full command surface. **Publishing to PyPI is the one remaining 1.0 ship gate** — human-gated, and not done yet. The two other gates it once sat alongside have both landed: the single-entry dispatch door is merged and default-ON (ADR-024, 2026-06-24), and the Mission Control central-store cutover completed (2026-06-23). The 1.0.1 future-state reconciliation batch (ADR-007 composite-key `dispatches`, the open-item → track bridge, and its autopilot wiring) has also landed on `main` — see [CHANGELOG.md](CHANGELOG.md) — but `VERSION` stays `1.0.0` until that milestone is cut. Open governance and release items are tracked in [ROADMAP.md](ROADMAP.md), [FEATURE_PLAN.md](FEATURE_PLAN.md), and the open-items tooling under [scripts/open_items_manager.py](scripts/open_items_manager.py).
 
 I built this for my own work. Use at your own discretion.
 

--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -113,7 +113,7 @@ Startup reconciliation, post-crash lease recovery, orphaned-dispatch handling, O
 
 ## 11. 1.0 transition-flag sunset list
 
-The single-entry-door rollout ships behind transition flags. At the 1.0 release these are retired so the door is the one and only path (no dual-path branches left to drift). Disposition per flag:
+The single-entry-door rollout ships behind transition flags. They are retired in a post-1.0 release (target 1.0.1), after the door has run stably as the default, so it becomes the one and only path (no dual-path branches left to drift). At 1.0.0 the flags below are still live — the `REMOVE` disposition is the plan, not a done deal. Disposition per flag:
 
 | Flag | Disposition at 1.0 |
 |---|---|

--- a/docs/manifesto/ARCHITECTURE.md
+++ b/docs/manifesto/ARCHITECTURE.md
@@ -1,9 +1,9 @@
 # Glass Box Governance: An Append-Only Audit Architecture for Multi-Agent AI Workflows
 
-**Author**: Vincent van de Th
+**Author**: Vincent van Deth
 **Date**: February 2026
-**Status**: Reference Architecture — pip-installable production release (1.0.0)
-**Usage**: 6+ months daily use on a local system · 13,000+ governed receipts in the audit trail · ephemeral per-dispatch workers (the old fixed 4-terminal model is now opt-in)
+**Status**: Reference Architecture — 1.0.0 release candidate, pip-installable from a checkout (PyPI publish pending)
+**Usage**: 6+ months daily use on a local system · 14,000+ governed receipts in the audit trail · ephemeral per-dispatch workers (the old fixed 4-terminal model is now opt-in)
 
 ---
 
@@ -91,7 +91,7 @@ VNX uses a **dual-input bridge**:
 - **Push (Optional Hooks)**: If a provider supports hooks, they can emit receipts directly.
 - **Pull (External Watcher)**: For providers without hooks (Codex, Gemini, future models), VNX watches the filesystem for agent output reports and generates receipts from them.
 
-This **External Watcher Pattern** means that even if an agent process crashes, the orchestration layer remains alive and aware. It also means you can swap models per-task — use Claude for architecture, Codex for implementation, Gemini for review — without changing any orchestration logic. The next planned experiment is adding Kimi 2.5 as a worker terminal to further validate the watcher pattern across provider ecosystems.
+This **External Watcher Pattern** means that even if an agent process crashes, the orchestration layer remains alive and aware. It also means you can swap models per-task — use Claude for architecture, Codex for implementation, Gemini for review — without changing any orchestration logic. Kimi runs as a first-class production worker lane via its CLI OAuth path (the `kimi-via-cli-only` constraint), one of several providers the watcher pattern already validates across ecosystems.
 
 Intelligence and usage signals are derived from receipts and watchers, not from provider hooks. Hooks can optionally enrich metadata, but they are never dependencies.
 

--- a/docs/manifesto/HEADLESS_TRANSITION.md
+++ b/docs/manifesto/HEADLESS_TRANSITION.md
@@ -4,6 +4,8 @@
 **Scope**: The shift from interactive tmux-based execution to headless subprocess workers  
 **Status**: Retrospective — written after the transition completed
 
+> **Update (post-June-15 2026):** Anthropic's June-15 billing change moved headless `claude -p` onto paid API credits while interactive Claude Code stayed on the subscription. That reversed the end-state for the **Claude** worker: the default Claude lane is now the interactive **tmux-spawn** lane (subscription-preserving), and headless `claude -p` is opt-in and blocked by default. "Headless" below still describes the non-Claude provider lanes (`provider_dispatch`: kimi/glm/deepseek/codex) and the opt-in burst lane — not the default for the Claude worker. Read this doc as the evolution story, with that correction applied.
+
 ---
 
 ## The "Before" Picture

--- a/docs/manifesto/LIMITATIONS.md
+++ b/docs/manifesto/LIMITATIONS.md
@@ -1,10 +1,12 @@
 # Known Limitations & Scope
 
+> **Note on the model below (2026-07):** the fixed T0 + Track A/B/C + T-MANAGER terminal layout described in this "Tested" section is the **opt-in subprocess lane** (`VNX_ADAPTER_T{n}=subprocess`). The **default** since the door-flip is the single-entry dispatch door with **ephemeral per-dispatch workers** (spawned per task, leaving receipts + worktree state behind), not fixed terminals. See the README and `docs/core/DISPATCH_RULES.md` for the current lanes; live per-feature status lives in `ROADMAP.yaml`.
+
 ## Tested
 - 5 terminals: T0 (orchestrator) + Track A / Track B / Track C (workers) + T-MANAGER (system maintenance)
 - Claude Code + Codex CLI + Gemini CLI + Kimi CLI (provider auto-detection via session_resolver)
 - Single-repository workflows (one VNX instance per project)
-- Deployed across 3 independent projects (SaaS SEO tool, marketing website, VNX itself) via `vnx update`
+- Deployed across 4 independent projects (SaaS SEO tool, marketing website, Mission Control, VNX itself)
 - Receipt-based cost observability (V4 — receipt_processor with git provenance per receipt)
 - Graceful crash recovery via ledger replay
 - T0 orchestrator: Claude Opus via Claude Code

--- a/docs/manifesto/ROADMAP.md
+++ b/docs/manifesto/ROADMAP.md
@@ -1,5 +1,7 @@
 # VNX Roadmap
 
+> **This file is the architecture-principles + wave-history roadmap. Live, per-feature status is the SSOT in [`ROADMAP.yaml`](../../ROADMAP.yaml)** — some milestone stamps below are historical (written April–May 2026) and may lag the current tree; trust `ROADMAP.yaml` and the README for what is actually shipped.
+
 **Status**: Public roadmap  
 **Planning Horizon**: 2026 (rolling)  
 **Principle**: Governance-first, model-agnostic, local-first
@@ -128,7 +130,7 @@ Key deliverables: `autopilot_tick.py`, `pool_worker_runner.py`, `auto_dream` pac
 ## Milestones
 
 ### 1.0.0 Public Release
-**Status**: `Completed` — 2026-05-29
+**Status**: `Release candidate` — pip-installable from a checkout; the PyPI publish is the one remaining ship gate (human-gated, not yet done).
 
 pip-installable, 5-provider production, governance receipts, elastic pool, smart routing (opt-in), roadmap-autopilot gate hardening (RA-1..5 active, RA-6 dark), auto-dream self-learning loop runnable. See [1.0 Sprint section](#10-sprint--roadmap-autopilot-n-scaling-foundation-auto-dream) for full capability list.
 


### PR DESCRIPTION
## Summary

Adversarial pre-1.0-launch doc audit (HN-scrutiny lens) — fixes the docs a hostile HN commenter would pounce on. **Docs only, no code.**

### P0 (launch-blockers)
- **Three conflicting 1.0-release states.** `docs/manifesto/ROADMAP.md` said "1.0.0 **Completed** 2026-05-29"; `CHANGELOG.md` said "[1.0.0] — 2026-06-10 First public release"; the README (correctly) says release-candidate, PyPI-ship pending. Aligned all three to the honest **release-candidate** framing (date set at tag-cut).
- **Misspelled author byline** "Vincent van de Th" → "Vincent van Deth" on the flagship ARCHITECTURE.md.
- **Kimi called a "next planned experiment"** in ARCHITECTURE.md while the same doc (and the README) treat it as a production lane — reworded; dropped stale "Kimi 2.5".

### P1
- README ADR count **25 → 26** (falsifiable front-page number).
- `DISPATCH_RULES.md` §11 sunset table reworded — the transition flags are **still live at 1.0.0**; removal is post-1.0 (target 1.0.1), matching the table's own closing sentence.
- `ROADMAP.md` banner → `ROADMAP.yaml` is the live-status SSOT; `LIMITATIONS.md` reframed (fixed T0-T3 = the opt-in subprocess lane; default is ephemeral-per-dispatch), project count **3 → 4**; `HEADLESS_TRANSITION.md` gets a post-June-15 reconciliation note (interactive tmux is the default Claude lane now).

### P2
- Receipt count **13,000+ → 14,000+** (README + ARCHITECTURE); README "as of" date stamps bumped to the launch window.

Verified NOT-a-problem (left as-is): D1 (`VNX_AUTOPILOT`) already fixed in #962; README install/PyPI honesty is solid; flag names correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)