### PR TITLE
fix(launch): dependency + doc launch-blockers from the pre-1.0 provider-panel sweep

### DIFF
--- a/docs/manifesto/EVOLUTION_TIMELINE.md
+++ b/docs/manifesto/EVOLUTION_TIMELINE.md
@@ -224,7 +224,7 @@ Skills are just prompts. Worker skills and manager skills use the identical mech
 **Representative implementations**
 - `hooks/stop_hook.py`
 - `scripts/lib/report_assembler.py`
-- `scripts/lib/haiku_classifier.py`
+- `scripts/lib/classifier_providers/haiku_provider.py`
 - `scripts/lib/t0_state_builder.py`
 
 **Outcome**
@@ -261,11 +261,11 @@ Skills are just prompts. Worker skills and manager skills use the identical mech
 - Benchmark scores: Level-1 100%, Level-2 73–87%, Level-3 67–78%.
 - Fixture-mode tagging separates benchmark runs from production execution.
 
-**Representative implementations**
-- `scripts/lib/t0_decision_framework.py`
-- `scripts/lib/t0_gate_locks.py`
-- `scripts/lib/t0_context_assembler.py`
-- `scripts/benchmark/t0_replay_harness.py`
+**Representative components**
+- T0 decision pre-filter + taxonomy (the deterministic pre-LLM filter)
+- Gate locks: `.vnx-data/state/gate_locks/<gate-id>.lock`, enforced by the closure/gate machinery (`scripts/closure_verifier.py`)
+- Context assembler: `scripts/lib/context_assembler.py`
+- F39 replay harness: `scripts/f39/replay_harness/`
 
 **Outcome**
 - T0 can make correct decisions autonomously in the majority of cases.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,12 +30,18 @@ dependencies = [
     "opentelemetry-exporter-otlp>=1.20",
     "jinja2>=3.0",
     "pyyaml>=6.0",
+    "jsonschema>=4.20",   # governed report schema validation (governance_emit → unified_report_schema)
+    "psutil>=5.9",        # runtime supervision + intelligence daemon monitoring
 ]
 
 # Full quality advisory/local-CI audit tools.
 # Install via `pip install vnx-orchestration[quality]`.
 [project.optional-dependencies]
 quality = ["vulture>=2.10", "ruff>=0.6"]
+
+# Opt-in aggregator dashboard (scripts/aggregator/aggregator_dashboard.py).
+# Install via `pip install vnx-orchestration[dashboard]`.
+dashboard = ["fastapi>=0.110", "uvicorn>=0.27"]
 
 # Smart Lanes — modular provider submodules for local/cost-zero inference.
 # Install individual lanes: pip install vnx-orchestration[local-gemma]

--- a/scripts/aggregator/aggregator_dashboard.py
+++ b/scripts/aggregator/aggregator_dashboard.py
@@ -13,8 +13,14 @@ from __future__ import annotations
 import datetime as _dt
 from pathlib import Path
 
-from fastapi import FastAPI
-from fastapi.responses import HTMLResponse
+try:
+    from fastapi import FastAPI
+    from fastapi.responses import HTMLResponse
+except ImportError as _exc:  # opt-in dashboard extra
+    raise SystemExit(
+        "The aggregator dashboard needs the optional dashboard deps. "
+        "Install them with:  pip install 'vnx-orchestration[dashboard]'"
+    ) from _exc
 from jinja2 import Environment, FileSystemLoader, select_autoescape
 
 from scripts.aggregator import DEFAULT_AGGREGATOR_DB, DEFAULT_AGGREGATOR_DIR

--- a/scripts/lib/dispatch_broker.py
+++ b/scripts/lib/dispatch_broker.py
@@ -122,7 +122,7 @@ def _write_atomic(path: Path, content: str) -> None:
     tmp = path.with_suffix(path.suffix + ".tmp")
     try:
         tmp.write_text(content, encoding="utf-8")
-        tmp.rename(path)
+        os.replace(tmp, path)  # atomic; overwrites an existing target (unlike Path.rename on some platforms)
     except Exception:
         try:
             tmp.unlink(missing_ok=True)


### PR DESCRIPTION
## Summary

The final multi-provider codebase sweep (codex/kimi/deepseek via the governed lanes) before the 1.0 HN launch. The **deepseek** lens caught real pip-install / HN-credibility blockers — all verified against the code:

- **P0 — missing runtime deps.** `jsonschema` (governed happy path: `governance_emit → unified_report_schema`) and `psutil` (runtime supervision / intelligence daemon) were imported at runtime but **not declared** → a fresh `pip install` + one dispatch crashes with `ImportError`. Added both to core `dependencies`.
- **P0 — `fastapi`** (opt-in aggregator dashboard) undeclared → crash. Added a `[dashboard]` extras group and guarded the import with an install hint instead of a raw `ImportError`.
- **P0 — falsifiable docs.** `EVOLUTION_TIMELINE.md` cited 5 files that don't exist under those names — repointed to the real components (`classifier_providers/haiku_provider.py`, `context_assembler.py`, `f39/replay_harness/`, gate-locks + `closure_verifier.py`).
- **P0 — `dispatch_broker`** used `Path.rename()` (fails on existing target / cross-device) → `os.replace()`.

**Sweep false positive (verified, NOT changed):** the README "isolated git worktrees" pitch is accurate — the **default tmux lane isolates by default** (`isolated_worktree=True`); only the opt-in subprocess lane gates on `VNX_ISOLATED_WORKTREE`.

Build re-verified clean (sdist + wheel, 1.0.0). P1 robustness findings (fsync on the receipt mirror, idempotency crash-dup, dep version bounds, `MANIFEST.in`) are tracked for a post-launch batch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)