### PR TITLE
feat(skills): trigger-rich future-state skill descriptions + pm model-invocable

### DIFF
--- a/.claude/skills/featureplan-kickoff/SKILL.md
+++ b/.claude/skills/featureplan-kickoff/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: featureplan-kickoff
 description: >
-  Generic VNX kickoff preflight for a new or resumed feature execution. Use when
-  starting a feature from FEATURE_PLAN.md, initializing PR_QUEUE.md, checking
-  worktree/queue/staging health, identifying the first promoteable dispatch, and
-  handing off immediately to t0-orchestrator after kickoff is complete.
+  VNX feature-execution kickoff preflight. USE THIS when starting or resuming a feature or
+  track from its plan: checking worktree/queue/staging health, finding the first promoteable
+  dispatch, and handing off to @t0-orchestrator. Reads the feature's track + plan doc from the
+  tracks DB (`vnx objective`); the repo FEATURE_PLAN.md/PR_QUEUE.md are generic examples, not
+  the source.
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
 paths: ["FEATURE_PLAN.md", ".vnx-data/**"]

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -1,6 +1,11 @@
 ---
 name: planner
-description: Planning specialist for PR-based feature breakdown and FEATURE_PLAN.md generation
+description: >
+  Planning specialist that breaks a VNX feature or track into small, independently-shippable
+  PRs with dependencies and per-PR task-class routing. USE THIS when the user wants to break a
+  feature down into PRs, sequence the work, or turn a plan into a PR queue. Delegated to by
+  @pm. Works from the tracks DB (`vnx objective`); the repo FEATURE_PLAN.md is a generated
+  generic example, not the source.
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 paths: ["FEATURE_PLAN.md", "claudedocs/**"]
 ---

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,12 +1,15 @@
 ---
 name: pm
 description: >
-  Strategic project manager for the VNX FUTURE-state layer. Owns the roadmap ->
-  objectives/tracks -> deliverables lifecycle, the mandatory plan-first gate per
-  feature, the per-task-type routing FLOOR, and the feature queue. Plans and gates;
-  never dispatches, never edits FEATURE_PLAN.md, never closes open-items.
+  Strategic owner of the VNX FUTURE-state layer (roadmap -> tracks -> deliverables) and the
+  plan-first gate. USE THIS when the user wants to plan the next VNX feature, decide what to
+  build next, add something to the roadmap, prioritize or schedule (inplannen) work into
+  now/next/later horizons, break a feature into deliverables, set the routing FLOOR, or run the
+  plan-gate on a feature. The tracks DB (`vnx objective`) is the source of truth; the repo
+  ROADMAP.yaml is a generic example, not the SSOT. Plans and gates only: never dispatches,
+  never closes open-items. The heavy multi-model plan-gate panel runs only on an explicit
+  plan-gate step.
 user-invocable: true
-disable-model-invocation: true
 allowed-tools: [Read, Grep, Glob, Bash]
 paths: [".vnx-data/**", "claudedocs/**", "ROADMAP.yaml"]
 ---


### PR DESCRIPTION
Slice 1 of the future-state streamlining. Makes the planning skills actually fire when the user talks about roadmap/planning/features/scheduling.

- **pm**: drop `disable-model-invocation:true` (it never auto-fired), rewrite the description as a scoped trigger list, name the tracks DB (`vnx objective`) as the SSOT (not the now-generic ROADMAP.yaml). The heavy plan-gate panel still runs only on an explicit step.
- **planner** + **featureplan-kickoff**: same trigger-rich + source-accurate description rewrite.

Deeper body/source reconcile (ROADMAP.yaml/FEATURE_PLAN.md flows) + the 29 doc-reference triage is slice 2, tracked as `post10-skill-doc-reconcile` (plan-gated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)