### PR TITLE
feat(reconcile): ALL-merged multi-PR derivation + declared-done stability [D1]

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -55,7 +55,7 @@ def _parse_pr_number(pr_ref: Optional[str]) -> Optional[int]:
 def _parse_pr_numbers(pr_ref: Optional[str]) -> FrozenSet[int]:
     """Parse a single ref OR a comma/space-separated list ('#908,#909') into a
     set of ints. A track that landed across multiple PRs ('#908,#909') is done
-    when ANY of them is merged. Empty set when nothing parses."""
+    only when ALL of them are merged. Empty set when nothing parses."""
     if not pr_ref:
         return frozenset()
     nums: set = set()
@@ -264,9 +264,10 @@ def _compute_derived_status(
         # Historical dispatches stored 'A'/'B'/'C' in the track column instead of
         # feature track_ids, so the join above is empty for all pre-1.0 tracks.
         # If the track's own pr_ref (single or a '#911,#912' multi-PR list) is
-        # confirmed merged via any evidence source, derive 'done' without a
-        # dispatch match.
-        if _parse_pr_numbers(track_pr_ref) & merged_pr_numbers:
+        # confirmed merged via all evidence sources, derive 'done' without a
+        # dispatch match. ALL parsed PRs must be merged; partial merge = not done.
+        nums = _parse_pr_numbers(track_pr_ref)
+        if nums and nums <= merged_pr_numbers:
             return "done"
         # Absence of evidence is not evidence of queued. Historical dispatches may
         # be archived, so defer to declared phase (2026-06-15 migration panel).
@@ -302,9 +303,17 @@ def _compute_derived_status(
         if merged_event:
             return "done"
 
-        # Also accept the track's own pr_ref being confirmed merged via any
-        # evidence source (NDJSON / ROADMAP / git) — same as the no-dispatch path.
-        if _parse_pr_numbers(track_pr_ref) & merged_pr_numbers:
+        # Declared-done stability: a declared-done track with all terminal dispatches
+        # stays done even when PR evidence is incomplete (partial multi-PR merge or
+        # no coordination event). Blocker/dependency checks still win (run above).
+        if track_phase == "done":
+            return "done"
+
+        # Also accept the track's own pr_ref being confirmed merged via all
+        # evidence sources (NDJSON / ROADMAP / git) — same as the no-dispatch path.
+        # ALL parsed PRs must be merged; partial merge = not done.
+        nums = _parse_pr_numbers(track_pr_ref)
+        if nums and nums <= merged_pr_numbers:
             return "done"
 
         # All dispatches terminal but PR not confirmed merged yet.

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -425,13 +425,13 @@ def _close_evidence(state_dir: Path, track_id: str, project_id: str) -> dict[str
             conn.close()
     except Exception as exc:
         logger.debug("close evidence query failed: %s", exc)
-    # Match the reconciler's OTHER merge source: pr_ref against the local
-    # merged-PR set (not only coordination_events), so the signal does not
-    # falsely read 'no merge' when the reconciler in fact saw one.
+    # Match the reconciler's ALL-merged subset semantics: ALL parsed PRs must be
+    # merged (subset check), mirroring _compute_derived_status so a multi-PR
+    # track ('#908,#909', both merged) is not falsely reported as unmerged.
     try:
         if ev["pr_ref"]:
-            num = track_reconciler._parse_pr_number(ev["pr_ref"])
-            if num is not None and num in track_reconciler._load_merged_pr_numbers(state_dir):
+            nums = track_reconciler._parse_pr_numbers(ev["pr_ref"])
+            if nums and nums <= track_reconciler._load_merged_pr_numbers(state_dir):
                 ev["pr_merged"] = True
     except Exception as exc:
         logger.debug("close evidence merged-PR check failed: %s", exc)

--- a/tests/test_objective_close.py
+++ b/tests/test_objective_close.py
@@ -271,3 +271,38 @@ def test_phase_path_unreachable_returns_none():
     assert planning_cli._phase_path_to("done", "active") is None
     assert planning_cli._phase_path_to("active", "active") == []
     assert planning_cli._phase_path_to("queued", "done") == ["active", "done"]
+
+
+def _write_pr_merged_ndjson(state_dir: Path, pr_numbers: list) -> None:
+    """Seed pr_merged.ndjson so _load_merged_pr_numbers sees the given PR numbers."""
+    import json as _json
+    events_dir = state_dir.parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    lines = [_json.dumps({"event_type": "pr_merged", "pr_number": n}) for n in pr_numbers]
+    (events_dir / "pr_merged.ndjson").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def test_evidence_multi_pr_both_merged_signals_success(tmp_path):
+    # Multi-PR pr_ref '#908,#909' with BOTH in the merged set → pr_merged=True,
+    # has_success_signal=True (mirrors _compute_derived_status subset semantics).
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-multi", PROJECT_ID, title="x", goal_state="y",
+                            phase="active", pr_ref="#908,#909")
+    _write_pr_merged_ndjson(sd, [908, 909])
+
+    ev = planning_cli._close_evidence(sd, "T-multi", PROJECT_ID)
+    assert ev["pr_merged"] is True
+    assert ev["has_success_signal"] is True
+
+
+def test_evidence_multi_pr_partial_merge_no_success_signal(tmp_path):
+    # Multi-PR pr_ref '#908,#909' with only ONE merged → pr_merged stays False;
+    # the subset check requires ALL PRs to be merged (not just any).
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-partial", PROJECT_ID, title="x", goal_state="y",
+                            phase="active", pr_ref="#908,#909")
+    _write_pr_merged_ndjson(sd, [908])  # 909 not merged
+
+    ev = planning_cli._close_evidence(sd, "T-partial", PROJECT_ID)
+    assert ev["pr_merged"] is False
+    assert ev["has_success_signal"] is False

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -291,17 +291,24 @@ def test_done_when_pr_ref_merged_zero_dispatches(tmp_path):
 
 
 def test_done_when_pr_ref_merged_with_terminal_dispatches(tmp_path):
-    """all-terminal-dispatch path also derives 'done' from a merged pr_ref,
-    including a multi-PR list where only one PR is merged (D-RECON)."""
+    """all-terminal-dispatch path derives 'done' only when ALL PRs in pr_ref are merged."""
     state_dir = _build_db(tmp_path)
     _seed_track(state_dir, "T-ev-term", pr_ref="#908,#909")
     _seed_dispatch(state_dir, "d-term-1", "T-ev-term", state="completed")
 
+    # Both PRs merged → done.
     result = track_reconciler.reconcile_track(
+        state_dir, "T-ev-term", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908, 909}),
+    )
+    assert result["derived_status"] == "done"
+
+    # Only one PR merged → in_progress (ALL-merged rule; was 'done' before this change).
+    result_partial = track_reconciler.reconcile_track(
         state_dir, "T-ev-term", PROJECT_ID,
         _merged_pr_numbers=frozenset({909}),  # only the 2nd PR of the list merged
     )
-    assert result["derived_status"] == "done"
+    assert result_partial["derived_status"] == "in_progress"
 
 
 def test_done_when_declared_done_without_evidence(tmp_path):
@@ -560,3 +567,138 @@ def test_gh_silent_on_failure(tmp_path, monkeypatch):
     monkeypatch.setattr(track_reconciler.subprocess, "run",
                         lambda *a, **k: (_ for _ in ()).throw(FileNotFoundError("gh")))
     assert track_reconciler._load_merged_prs_from_gh(state) == frozenset()
+
+
+# ---------------------------------------------------------------------------
+# D1: ALL-merged multi-PR derivation + declared-done stability
+# ---------------------------------------------------------------------------
+
+def test_single_pr_merged_done_no_dispatch(tmp_path):
+    """Single PR in pr_ref — merged → done (unchanged single-PR behaviour, no dispatch)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-single-nd", pr_ref="#800")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-single-nd", PROJECT_ID,
+        _merged_pr_numbers=frozenset({800}),
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_single_pr_merged_done_terminal_dispatch(tmp_path):
+    """Single PR in pr_ref — merged → done (unchanged single-PR behaviour, terminal dispatch)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-single-td", pr_ref="#800")
+    _seed_dispatch(state_dir, "D-single-td-1", "T-single-td", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-single-td", PROJECT_ID,
+        _merged_pr_numbers=frozenset({800}),
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_multi_pr_partial_merge_no_dispatch_not_done(tmp_path):
+    """Multi-PR '#908,#909', only #908 merged, no dispatches → NOT done (ALL-merged rule)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-multi-nd", pr_ref="#908,#909")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-multi-nd", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908}),  # only first PR merged
+    )
+    assert result["derived_status"] != "done"
+
+
+def test_multi_pr_partial_merge_terminal_dispatch_not_done(tmp_path):
+    """Multi-PR '#908,#909', only #908 merged, terminal dispatch, no event → NOT done."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-multi-td", pr_ref="#908,#909")
+    _seed_dispatch(state_dir, "D-multi-td-1", "T-multi-td", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-multi-td", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908}),  # only first PR merged
+    )
+    # Was 'done' before this change (ANY-merged); now 'in_progress' (ALL-merged rule).
+    assert result["derived_status"] == "in_progress"
+
+
+def test_multi_pr_all_merged_done_no_dispatch(tmp_path):
+    """Multi-PR '#908,#909', both merged, no dispatch → done."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-multi-all-nd", pr_ref="#908,#909")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-multi-all-nd", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908, 909}),
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_multi_pr_all_merged_done_terminal_dispatch(tmp_path):
+    """Multi-PR '#908,#909', both merged, terminal dispatch → done."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-multi-all-td", pr_ref="#908,#909")
+    _seed_dispatch(state_dir, "D-multi-all-td-1", "T-multi-all-td", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-multi-all-td", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908, 909}),
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_declared_done_terminal_partial_merge_no_event_done(tmp_path):
+    """Declared-done + terminal dispatch + partial multi-PR merge + no pr_merged event → done.
+
+    This is the phantom-drift regression introduced by the ALL-merged change: without the
+    declared-done short-circuit in the all-terminal branch, this would return 'in_progress'.
+    """
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-decl-stab", phase="done", pr_ref="#908,#909")
+    _seed_dispatch(state_dir, "D-decl-stab-1", "T-decl-stab", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-decl-stab", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908}),  # partial merge, no pr_merged event
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_declared_done_no_dispatch_partial_merge_done(tmp_path):
+    """Declared-done, no dispatches, partial multi-PR merge → done (existing fallback)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-decl-nd", phase="done", pr_ref="#908,#909")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-decl-nd", PROJECT_ID,
+        _merged_pr_numbers=frozenset({908}),  # partial merge
+    )
+    assert result["derived_status"] == "done"
+
+
+def test_unparseable_pr_ref_not_done_no_dispatch(tmp_path):
+    """Unparseable pr_ref produces an empty set → does not derive done via the pr_ref path."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-unparse-nd", phase="active", pr_ref="PR-FUT-99")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-unparse-nd", PROJECT_ID,
+        _merged_pr_numbers=frozenset({1, 2, 3}),
+    )
+    # Empty parse result cannot derive done via pr_ref path.
+    assert result["derived_status"] != "done"
+
+
+def test_unparseable_pr_ref_not_done_terminal_dispatch(tmp_path):
+    """Unparseable pr_ref + terminal dispatch → in_progress (no pr_ref evidence path)."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-unparse-td", phase="active", pr_ref="PR-FUT-99")
+    _seed_dispatch(state_dir, "D-unparse-td-1", "T-unparse-td", state="completed")
+
+    result = track_reconciler.reconcile_track(
+        state_dir, "T-unparse-td", PROJECT_ID,
+        _merged_pr_numbers=frozenset({1, 2, 3}),
+    )
+    assert result["derived_status"] == "in_progress"


### PR DESCRIPTION
## Summary

D1 of the `status-git-reality-reconcile` track (plan rev 4, operator-approved after a 3-round 5-family plan-gate, 0 BLOCK).

- `_compute_derived_status` now derives `done` from the pr_ref-intersection paths only when EVERY parsed PR is in the merged-set (subset check; was ANY). Both call sites: the no-dispatch branch and the all-terminal branch. Empty parse never derives done.
- Declared-done stability short-circuit added to the all-terminal branch (after the blocker/dependency and coordination-event checks, before pr_ref evidence): a declared=done track with terminal dispatches and a partial multi-PR merge no longer flips to derived `in_progress` — this exact phantom-drift regression was caught by the opus panelist in gate round 3.
- Deliberate semantic shift of the SHARED derivation: `objective drift` and the human-gated `objective close` (which gates on derived==done) now treat a half-landed multi-PR track as `in_progress`. Documented follow-up: the D3 `objective reconcile` command with exact gh verification is the close path (later PR in this track).

## Verification

- 57 passed: `tests/test_track_reconciler_prref_evidence.py` + `tests/test_track_reconciler.py` (10 new cases incl. the round-3 regression case; verified independently by the orchestrator in the dispatch worktree).
- `pytest -k reconcil`: 428 passed, 8 failed — all 8 verified pre-existing on origin/main (stash check by the worker).

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-d1-allmerged`, claude-sonnet-4-6, ephemeral worktree, unified report + receipt on file). Plan: `claudedocs/2026-07-03-status-git-reality-reconcile-PLAN.md` (rev 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC