### PR TITLE
refactor(reconcile): extract close_track_if_done with close-time revalidation [D2]

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -612,13 +612,20 @@ def close_track_if_done(
     the shortest legal phase path to 'done' via transition_phase.
 
     evidence (optional nomination snapshot): when provided, performs CLOSE-TIME
-    REVALIDATION immediately before the walk — a fresh DB read checking:
+    REVALIDATION as the very first step — BEFORE reconcile_track — so that a
+    stale candidate causes zero DB writes (reconcile_track persists
+    derived_status; it must not run on a track that will return stale_candidate).
+    Fresh DB read checks:
       (a) track's pr_ref unchanged vs evidence['pr_ref'],
       (b) no unresolved blocker OI (link_type='blocks' AND resolved_at IS NULL),
       (c) declared phase still eligible (queued/active; parked only with include_parked).
-    Any mismatch returns action='stale_candidate', applied=False, no write.
+    Any mismatch returns action='stale_candidate', applied=False, BEFORE
+    reconcile_track — so a stale candidate causes zero DB writes, derived_status
+    included.
 
-    When evidence is None (human objective-close path), no revalidation is done.
+    When evidence is None (human objective-close path), no revalidation is done
+    and the flow is byte-for-byte identical to the pre-revalidation behaviour:
+    reconcile_track first, then the derived/declared/parked gates, then the walk.
 
     The walk is NOT atomic with the checks: transition_phase (tracks.py) opens its
     own connection and commits per step. A mid-walk failure leaves the track at an
@@ -638,6 +645,78 @@ def close_track_if_done(
       rejected_walk_failed  transition failed mid-walk; declared_phase=stop-phase
       closed                walk completed; declared_phase updated to 'done'
     """
+    # Close-time revalidation runs FIRST when evidence is provided — before
+    # reconcile_track — so a stale candidate causes zero DB writes (reconcile_track
+    # persists derived_status; it must not run for a track that will be rejected).
+    if evidence is not None:
+        conn = _get_conn(state_dir)
+        try:
+            track_row = conn.execute(
+                "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
+                (track_id, project_id),
+            ).fetchone()
+
+            # (a) pr_ref must match the nomination snapshot.
+            current_pr_ref = track_row["pr_ref"] if track_row else None
+            if current_pr_ref != evidence.get("pr_ref"):
+                return {
+                    "track_id": track_id,
+                    "project_id": project_id,
+                    "declared_phase": track_row["phase"] if track_row else None,
+                    "derived_status": None,
+                    "action": "stale_candidate",
+                    "applied": False,
+                }
+
+            # (b) no unresolved blocker OI.
+            has_resolved = _has_col(conn, "track_open_items", "resolved_at")
+            has_pid = _has_col(conn, "track_open_items", "project_id")
+            if has_pid and has_resolved:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
+                    "AND link_type='blocks' AND resolved_at IS NULL LIMIT 1",
+                    (track_id, project_id),
+                ).fetchone()
+            elif has_pid:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
+                    "AND link_type='blocks' LIMIT 1",
+                    (track_id, project_id),
+                ).fetchone()
+            else:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? "
+                    "AND link_type='blocks' LIMIT 1",
+                    (track_id,),
+                ).fetchone()
+            if blocker:
+                return {
+                    "track_id": track_id,
+                    "project_id": project_id,
+                    "declared_phase": track_row["phase"] if track_row else None,
+                    "derived_status": None,
+                    "action": "stale_candidate",
+                    "applied": False,
+                }
+
+            # (c) declared phase still eligible after fresh read.
+            fresh_phase = track_row["phase"] if track_row else None
+            eligible = fresh_phase in ("queued", "active") or (
+                fresh_phase == "parked" and include_parked
+            )
+            if not eligible:
+                return {
+                    "track_id": track_id,
+                    "project_id": project_id,
+                    "declared_phase": fresh_phase,
+                    "derived_status": None,
+                    "action": "stale_candidate",
+                    "applied": False,
+                }
+        finally:
+            conn.close()
+
+    # Revalidation passed (or evidence=None path): reconcile derived_status now.
     result = reconcile_track(state_dir, track_id, project_id)
     derived = result["derived_status"]
     declared = result["declared_phase"]
@@ -663,57 +742,6 @@ def close_track_if_done(
     if declared == "parked" and not include_parked:
         payload["action"] = "rejected_parked"
         return payload
-
-    # Close-time revalidation: fresh read + three invariant checks.
-    if evidence is not None:
-        conn = _get_conn(state_dir)
-        try:
-            track_row = conn.execute(
-                "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
-                (track_id, project_id),
-            ).fetchone()
-
-            # (a) pr_ref must match the nomination snapshot.
-            current_pr_ref = track_row["pr_ref"] if track_row else None
-            if current_pr_ref != evidence.get("pr_ref"):
-                payload["action"] = "stale_candidate"
-                return payload
-
-            # (b) no unresolved blocker OI.
-            has_resolved = _has_col(conn, "track_open_items", "resolved_at")
-            has_pid = _has_col(conn, "track_open_items", "project_id")
-            if has_pid and has_resolved:
-                blocker = conn.execute(
-                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
-                    "AND link_type='blocks' AND resolved_at IS NULL LIMIT 1",
-                    (track_id, project_id),
-                ).fetchone()
-            elif has_pid:
-                blocker = conn.execute(
-                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
-                    "AND link_type='blocks' LIMIT 1",
-                    (track_id, project_id),
-                ).fetchone()
-            else:
-                blocker = conn.execute(
-                    "SELECT 1 FROM track_open_items WHERE track_id=? "
-                    "AND link_type='blocks' LIMIT 1",
-                    (track_id,),
-                ).fetchone()
-            if blocker:
-                payload["action"] = "stale_candidate"
-                return payload
-
-            # (c) declared phase still eligible after fresh read.
-            fresh_phase = track_row["phase"] if track_row else None
-            eligible = fresh_phase in ("queued", "active") or (
-                fresh_phase == "parked" and include_parked
-            )
-            if not eligible:
-                payload["action"] = "stale_candidate"
-                return payload
-        finally:
-            conn.close()
 
     payload["evidence"] = _close_evidence(state_dir, track_id, project_id)
 

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -30,7 +30,9 @@ import sqlite3
 import subprocess
 import time
 from pathlib import Path
-from typing import Any, Dict, FrozenSet, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional, TypedDict
+
+import tracks as tracks_lib  # same package; importable whenever scripts/lib/ is in sys.path
 
 log = logging.getLogger(__name__)
 
@@ -491,3 +493,257 @@ def reconcile_all_tracks(
         project_id, len(results), sum(1 for r in results if r["drifted"]),
     )
     return results
+
+
+# ---------------------------------------------------------------------------
+# Shared close-walk helpers
+# ---------------------------------------------------------------------------
+
+class EvidenceSnapshot(TypedDict, total=False):
+    """Nomination snapshot passed to close_track_if_done for close-time revalidation.
+
+    pr_ref:     the pr_ref value from the track row at nomination time.
+    pr_results: optional per-PR GitHub results (number, state, mergedAt) from gh.
+    verified_at: ISO-8601 timestamp when the nomination was taken.
+    """
+
+    pr_ref: str
+    pr_results: List[Dict[str, Any]]
+    verified_at: str
+
+
+def _close_evidence(
+    state_dir: "str | Path",
+    track_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """Summarize WHY a track derives terminal, so the operator gate is informed.
+
+    The reconciler's 'done' counts ALL terminal dispatch states — including
+    expired/dead_letter. A track whose every dispatch failed still derives 'done'.
+    Surface the breakdown + a has_success_signal flag. Best-effort; never raises.
+    """
+    ev: Dict[str, Any] = {
+        "completed": 0, "failed_terminal": 0, "in_flight": 0,
+        "pr_ref": None, "pr_merged": False, "has_success_signal": False,
+    }
+    db = Path(state_dir) / DB_FILENAME
+    try:
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        try:
+            for r in conn.execute(
+                "SELECT state, COUNT(*) c FROM dispatches "
+                "WHERE track=? AND project_id=? GROUP BY state",
+                (track_id, project_id),
+            ):
+                st = (r["state"] or "").lower()
+                if st == "completed":
+                    ev["completed"] += r["c"]
+                elif st in ("expired", "dead_letter"):
+                    ev["failed_terminal"] += r["c"]
+                else:
+                    ev["in_flight"] += r["c"]
+            row = conn.execute(
+                "SELECT pr_ref FROM tracks WHERE track_id=? AND project_id=?",
+                (track_id, project_id),
+            ).fetchone()
+            ev["pr_ref"] = row["pr_ref"] if row else None
+            merged = conn.execute(
+                "SELECT COUNT(*) FROM coordination_events "
+                "WHERE event_type='pr_merged' AND project_id=? AND entity_id IN "
+                "(SELECT dispatch_id FROM dispatches WHERE track=? AND project_id=?)",
+                (project_id, track_id, project_id),
+            ).fetchone()[0]
+            ev["pr_merged"] = merged > 0
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.debug("close evidence query failed: %s", exc)
+    # ALL parsed PRs must be merged (subset check), mirroring _compute_derived_status.
+    try:
+        if ev["pr_ref"]:
+            nums = _parse_pr_numbers(ev["pr_ref"])
+            if nums and nums <= _load_merged_pr_numbers(state_dir):
+                ev["pr_merged"] = True
+    except Exception as exc:
+        log.debug("close evidence merged-PR check failed: %s", exc)
+    ev["has_success_signal"] = ev["completed"] > 0 or ev["pr_merged"]
+    return ev
+
+
+def _phase_path_to(start: str, target: str) -> Optional[List[str]]:
+    """Shortest list of phases to transition THROUGH to reach target from start,
+    following ALLOWED_TRANSITIONS. Excludes start; returns [] when already at
+    target, None when unreachable.
+
+    BFS over the (tiny, fixed) phase graph; seen guards the parked<->queued cycle.
+    """
+    if start == target:
+        return []
+    seen = {start}
+    queue: List[tuple] = [(start, [])]
+    while queue:
+        node, path = queue.pop(0)
+        for nxt in sorted(tracks_lib.ALLOWED_TRANSITIONS.get(node, frozenset())):
+            if nxt in seen:
+                continue
+            new_path = path + [nxt]
+            if nxt == target:
+                return new_path
+            seen.add(nxt)
+            queue.append((nxt, new_path))
+    return None
+
+
+def close_track_if_done(
+    state_dir: "str | Path",
+    track_id: str,
+    project_id: str,
+    *,
+    actor: str,
+    evidence: Optional[EvidenceSnapshot] = None,
+    approval_id: Optional[str] = None,
+    include_parked: bool = False,
+) -> Dict[str, Any]:
+    """Attempt to close a track by walking its declared phase to 'done'.
+
+    Reconciles derived_status, gates on it being terminal ('done'), then walks
+    the shortest legal phase path to 'done' via transition_phase.
+
+    evidence (optional nomination snapshot): when provided, performs CLOSE-TIME
+    REVALIDATION immediately before the walk — a fresh DB read checking:
+      (a) track's pr_ref unchanged vs evidence['pr_ref'],
+      (b) no unresolved blocker OI (link_type='blocks' AND resolved_at IS NULL),
+      (c) declared phase still eligible (queued/active; parked only with include_parked).
+    Any mismatch returns action='stale_candidate', applied=False, no write.
+
+    When evidence is None (human objective-close path), no revalidation is done.
+
+    The walk is NOT atomic with the checks: transition_phase (tracks.py) opens its
+    own connection and commits per step. A mid-walk failure leaves the track at an
+    intermediate phase; re-calling this function re-walks from the current declared
+    phase (bounded TOCTOU-narrowing, not atomicity).
+
+    Returns a dict with keys: track_id, project_id, action, applied, declared_phase,
+    derived_status, path (when applicable), evidence (when computed), error (on failure).
+
+    Possible action values:
+      noop_not_terminal     derived != 'done', nothing to close
+      noop_already_closed   declared already 'done'
+      rejected_parked       declared='parked' and include_parked=False
+      stale_candidate       revalidation mismatch (evidence path only); no write
+      rejected_no_path      no legal phase-graph path from declared to 'done'
+      rejected_not_found    track deleted during walk
+      rejected_walk_failed  transition failed mid-walk; declared_phase=stop-phase
+      closed                walk completed; declared_phase updated to 'done'
+    """
+    result = reconcile_track(state_dir, track_id, project_id)
+    derived = result["derived_status"]
+    declared = result["declared_phase"]
+    target = "done"
+
+    payload: Dict[str, Any] = {
+        "track_id": track_id,
+        "project_id": project_id,
+        "declared_phase": declared,
+        "derived_status": derived,
+        "action": None,
+        "applied": False,
+    }
+
+    if derived != target:
+        payload["action"] = "noop_not_terminal"
+        return payload
+
+    if declared == target:
+        payload["action"] = "noop_already_closed"
+        return payload
+
+    if declared == "parked" and not include_parked:
+        payload["action"] = "rejected_parked"
+        return payload
+
+    # Close-time revalidation: fresh read + three invariant checks.
+    if evidence is not None:
+        conn = _get_conn(state_dir)
+        try:
+            track_row = conn.execute(
+                "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
+                (track_id, project_id),
+            ).fetchone()
+
+            # (a) pr_ref must match the nomination snapshot.
+            current_pr_ref = track_row["pr_ref"] if track_row else None
+            if current_pr_ref != evidence.get("pr_ref"):
+                payload["action"] = "stale_candidate"
+                return payload
+
+            # (b) no unresolved blocker OI.
+            has_resolved = _has_col(conn, "track_open_items", "resolved_at")
+            has_pid = _has_col(conn, "track_open_items", "project_id")
+            if has_pid and has_resolved:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
+                    "AND link_type='blocks' AND resolved_at IS NULL LIMIT 1",
+                    (track_id, project_id),
+                ).fetchone()
+            elif has_pid:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? AND project_id=? "
+                    "AND link_type='blocks' LIMIT 1",
+                    (track_id, project_id),
+                ).fetchone()
+            else:
+                blocker = conn.execute(
+                    "SELECT 1 FROM track_open_items WHERE track_id=? "
+                    "AND link_type='blocks' LIMIT 1",
+                    (track_id,),
+                ).fetchone()
+            if blocker:
+                payload["action"] = "stale_candidate"
+                return payload
+
+            # (c) declared phase still eligible after fresh read.
+            fresh_phase = track_row["phase"] if track_row else None
+            eligible = fresh_phase in ("queued", "active") or (
+                fresh_phase == "parked" and include_parked
+            )
+            if not eligible:
+                payload["action"] = "stale_candidate"
+                return payload
+        finally:
+            conn.close()
+
+    payload["evidence"] = _close_evidence(state_dir, track_id, project_id)
+
+    path = _phase_path_to(declared, target)
+    if path is None:
+        payload["action"] = "rejected_no_path"
+        return payload
+    payload["path"] = [declared, *path]
+
+    cur = declared
+    try:
+        for step in path:
+            tracks_lib.transition_phase(
+                state_dir, track_id, project_id, step,
+                actor=actor,
+                reason=f"close-the-loop ({declared}->{target}, derived={derived})",
+                approval_id=approval_id,
+            )
+            cur = step
+    except tracks_lib.TrackNotFoundError as exc:
+        payload["action"] = "rejected_not_found"
+        payload["error"] = str(exc)
+        return payload
+    except Exception as exc:
+        payload["declared_phase"] = cur
+        payload["action"] = "rejected_walk_failed"
+        payload["error"] = f"{type(exc).__name__}: {exc}"
+        return payload
+
+    payload["declared_phase"] = target
+    payload["action"] = "closed"
+    payload["applied"] = True
+    return payload

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -379,89 +379,10 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
     return 0
 
 
-def _close_evidence(state_dir: Path, track_id: str, project_id: str) -> dict[str, Any]:
-    """Summarize WHY a track derives terminal, so the operator gate is INFORMED.
-
-    The reconciler's 'done' counts ALL terminal dispatch states — including the
-    FAILURE states expired/dead_letter (track_reconciler.TERMINAL_DISPATCH_STATES).
-    So a track whose every dispatch failed (no completed run, no merged PR) still
-    derives 'done'. Surface the breakdown + a ``has_success_signal`` flag so the
-    operator does not blind-close a failed track. Best-effort; never raises.
-    """
-    ev: dict[str, Any] = {
-        "completed": 0, "failed_terminal": 0, "in_flight": 0,
-        "pr_ref": None, "pr_merged": False, "has_success_signal": False,
-    }
-    db = Path(state_dir) / "runtime_coordination.db"
-    try:
-        conn = sqlite3.connect(str(db))
-        conn.row_factory = sqlite3.Row
-        try:
-            for r in conn.execute(
-                "SELECT state, COUNT(*) c FROM dispatches "
-                "WHERE track=? AND project_id=? GROUP BY state",
-                (track_id, project_id),
-            ):
-                st = (r["state"] or "").lower()
-                if st == "completed":
-                    ev["completed"] += r["c"]
-                elif st in ("expired", "dead_letter"):
-                    ev["failed_terminal"] += r["c"]
-                else:
-                    ev["in_flight"] += r["c"]
-            row = conn.execute(
-                "SELECT pr_ref FROM tracks WHERE track_id=? AND project_id=?",
-                (track_id, project_id),
-            ).fetchone()
-            ev["pr_ref"] = row["pr_ref"] if row else None
-            merged = conn.execute(
-                "SELECT COUNT(*) FROM coordination_events "
-                "WHERE event_type='pr_merged' AND project_id=? AND entity_id IN "
-                "(SELECT dispatch_id FROM dispatches WHERE track=? AND project_id=?)",
-                (project_id, track_id, project_id),
-            ).fetchone()[0]
-            ev["pr_merged"] = merged > 0
-        finally:
-            conn.close()
-    except Exception as exc:
-        logger.debug("close evidence query failed: %s", exc)
-    # Match the reconciler's ALL-merged subset semantics: ALL parsed PRs must be
-    # merged (subset check), mirroring _compute_derived_status so a multi-PR
-    # track ('#908,#909', both merged) is not falsely reported as unmerged.
-    try:
-        if ev["pr_ref"]:
-            nums = track_reconciler._parse_pr_numbers(ev["pr_ref"])
-            if nums and nums <= track_reconciler._load_merged_pr_numbers(state_dir):
-                ev["pr_merged"] = True
-    except Exception as exc:
-        logger.debug("close evidence merged-PR check failed: %s", exc)
-    ev["has_success_signal"] = ev["completed"] > 0 or ev["pr_merged"]
-    return ev
-
-
-def _phase_path_to(start: str, target: str) -> Optional[list[str]]:
-    """Shortest list of phases to transition THROUGH to reach ``target`` from
-    ``start``, following ``tracks.ALLOWED_TRANSITIONS``. Excludes ``start``;
-    returns ``[]`` when already at target, ``None`` when unreachable.
-
-    BFS over the (tiny, fixed) phase graph; ``seen`` guards the parked<->queued
-    cycle.
-    """
-    if start == target:
-        return []
-    seen = {start}
-    queue: list[tuple[str, list[str]]] = [(start, [])]
-    while queue:
-        node, path = queue.pop(0)
-        for nxt in sorted(tracks_lib.ALLOWED_TRANSITIONS.get(node, frozenset())):
-            if nxt in seen:
-                continue
-            new_path = path + [nxt]
-            if nxt == target:
-                return new_path
-            seen.add(nxt)
-            queue.append((nxt, new_path))
-    return None
+# Re-exported for callers that reference planning_cli._close_evidence / _phase_path_to.
+# The implementations live in track_reconciler so close_track_if_done can use them.
+_close_evidence = track_reconciler._close_evidence
+_phase_path_to = track_reconciler._phase_path_to
 
 
 def cmd_objective_close(args: argparse.Namespace) -> int:
@@ -577,36 +498,67 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
             "ERROR: --apply requires --approval-id (the human gate). No change made.", 2,
         )
 
-    # The walk is NOT atomic: each transition_phase commits on its own
-    # (tracks.py), so a mid-path failure (e.g. a concurrent writer moved the
-    # phase) leaves the track at an intermediate phase. That is recoverable —
-    # this command re-walks from the CURRENT declared phase, so re-running it
-    # resumes and finishes. We surface where it stopped so the operator can.
-    cur = declared
-    try:
-        for step in path:
-            tracks_lib.transition_phase(
-                state_dir, track_id, project_id, step,
-                actor="operator",
-                reason=f"close-the-loop ({declared}->{target}, derived={derived})",
-                approval_id=args.approval_id,
-            )
-            cur = step
-    except tracks_lib.TrackNotFoundError as exc:
-        return _emit("rejected_not_found", False, f"ERROR: {exc}", 2)
-    except Exception as exc:
-        # Any mid-walk failure (illegal transition from a concurrent writer, a DB
-        # error, etc.) leaves the track at the last committed phase. Never crash
-        # with a traceback — report where it stopped; the walk is resumable.
+    # Delegate the walk (and a fresh reconcile) to the shared library function.
+    # close_track_if_done reconciles fresh before walking so the transition acts on
+    # current state; the second reconcile is idempotent with the one above.
+    lib = track_reconciler.close_track_if_done(
+        state_dir, track_id, project_id,
+        actor="operator",
+        approval_id=args.approval_id,
+        include_parked=getattr(args, "include_parked", False),
+    )
+    lib_action = lib.get("action")
+
+    # Merge updated fields from the library result into payload for JSON output.
+    for _k in ("declared_phase", "applied", "path", "evidence"):
+        if _k in lib:
+            payload[_k] = lib[_k]
+
+    if lib_action == "closed":
+        final_path = lib.get("path", [declared, *path])
+        return _emit("closed", True,
+                     f"closed: {' -> '.join(final_path)} "
+                     f"(actor=operator, approval={args.approval_id}).", 0)
+
+    if lib_action == "rejected_walk_failed":
+        cur = lib.get("declared_phase", declared)
+        error_detail = lib.get("error", "unknown error")
         payload["declared_phase"] = cur
         return _emit("rejected_walk_failed", False,
-                     f"ERROR: transition failed at '{cur}': {type(exc).__name__}: {exc}. "
+                     f"ERROR: transition failed at '{cur}': {error_detail}. "
                      f"Track left at '{cur}' — re-run `objective close` to resume.", 2)
 
-    payload["declared_phase"] = target
-    return _emit("closed", True,
-                 f"closed: {' -> '.join([declared, *path])} "
-                 f"(actor=operator, approval={args.approval_id}).", 0)
+    if lib_action == "rejected_not_found":
+        return _emit("rejected_not_found", False,
+                     f"ERROR: {lib.get('error', 'track not found')}", 2)
+
+    if lib_action == "stale_candidate":
+        return _emit("stale_candidate", False,
+                     "close aborted: stale candidate (state changed after nomination). "
+                     "No change made.", 2)
+
+    # Race-condition early-returns: reconcile in close_track_if_done computed a
+    # different result than our initial reconcile above. Map to the same messages.
+    _race_msgs: dict = {
+        "noop_not_terminal": (
+            f"nothing to close: derived_status="
+            f"{lib.get('derived_status', derived)} is not terminal ('{target}').", 0),
+        "noop_already_closed": (
+            f"already closed (phase={lib.get('declared_phase', declared)}).", 0),
+        "rejected_parked": (
+            "track is PARKED (a deliberate stop). Pass --include-parked to close "
+            "it anyway, or un-park it first. No change made.", 2),
+        "rejected_no_path": (
+            f"ERROR: no legal transition path "
+            f"{lib.get('declared_phase', declared)} -> {target} "
+            f"(ALLOWED_TRANSITIONS). No change made.", 2),
+    }
+    if lib_action in _race_msgs:
+        msg, rc = _race_msgs[lib_action]
+        return _emit(lib_action, False, msg, rc)
+
+    return _emit(lib_action or "unknown", False,
+                 f"unexpected result from library: {lib_action}", 2)
 
 
 def maybe_auto_seed(

--- a/tests/test_close_track_if_done.py
+++ b/tests/test_close_track_if_done.py
@@ -119,6 +119,16 @@ def _phase(state_dir: Path, track_id: str) -> str:
     return row[0] if row else ""
 
 
+def _derived_status(state_dir: Path, track_id: str) -> "str | None":
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT derived_status FROM tracks WHERE track_id=? AND project_id=?",
+        (track_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
 def _history(state_dir: Path, track_id: str) -> list:
     conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
     rows = conn.execute(
@@ -207,14 +217,51 @@ def test_revalidation_pr_ref_changed_stale_candidate(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Revalidation: stale_candidate causes no derived_status write (pr_ref variant)
+# ---------------------------------------------------------------------------
+
+def test_revalidation_stale_causes_no_derived_write(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-pr-stale", phase="active")
+
+    # Set pr_ref="#994" in DB + add pr_merged event so reconcile would derive "done".
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET pr_ref=? WHERE track_id=? AND project_id=?",
+        ("#994", "T-pr-stale", PROJECT_ID),
+    )
+    conn.execute(
+        "INSERT INTO coordination_events "
+        "(event_id, event_type, entity_type, entity_id, occurred_at, project_id) "
+        "VALUES ('ev-994','pr_merged','dispatch',?,strftime('%Y-%m-%dT%H:%M:%fZ','now'),?)",
+        ("D-T-pr-stale", PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+
+    # Evidence snapshot carries a different pr_ref -> stale candidate.
+    evidence = {"pr_ref": "#993", "verified_at": "2026-07-04T10:00:00Z"}
+    result = track_reconciler.close_track_if_done(
+        sd, "T-pr-stale", PROJECT_ID, actor="system", evidence=evidence
+    )
+    assert result["action"] == "stale_candidate"
+    assert result["applied"] is False
+    assert _phase(sd, "T-pr-stale") == "active"
+    assert _derived_status(sd, "T-pr-stale") is None   # reconcile_track was not called
+
+
+# ---------------------------------------------------------------------------
 # Revalidation: stale_candidate on blocker OI
 # ---------------------------------------------------------------------------
 
-def test_revalidation_blocker_oi_appeared_stale_candidate(tmp_path, monkeypatch):
+def test_revalidation_blocker_oi_appeared_stale_candidate(tmp_path):
     sd = _build_db(tmp_path)
     _seed_done_track(sd, "T-blocked", phase="active")
 
-    # Add a blocker OI (arrived after the nomination snapshot was taken).
+    # Snapshot was taken before the blocker appeared (pr_ref=None matches current row).
+    evidence = {"pr_ref": None, "verified_at": "2026-07-04T10:00:00Z"}
+
+    # Blocker OI arrives AFTER nomination — post-nomination change.
     conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
     conn.execute(
         "INSERT INTO track_open_items "
@@ -225,29 +272,13 @@ def test_revalidation_blocker_oi_appeared_stale_candidate(tmp_path, monkeypatch)
     conn.commit()
     conn.close()
 
-    # Snapshot was taken before the blocker appeared.
-    evidence = {"pr_ref": None, "verified_at": "2026-07-04T10:00:00Z"}
-
-    # Monkeypatch reconcile_track to return "done" regardless of the blocker, simulating
-    # the TOCTOU window: blocker arrived after the nomination reconcile but before the
-    # revalidation fresh read inside close_track_if_done.
-    def fake_reconcile(state_dir, track_id, project_id, **kw):
-        return {
-            "track_id": track_id,
-            "project_id": project_id,
-            "derived_status": "done",
-            "declared_phase": "active",
-            "drifted": True,
-        }
-
-    monkeypatch.setattr(track_reconciler, "reconcile_track", fake_reconcile)
-
     result = track_reconciler.close_track_if_done(
         sd, "T-blocked", PROJECT_ID, actor="system", evidence=evidence
     )
     assert result["action"] == "stale_candidate"
     assert result["applied"] is False
-    assert _phase(sd, "T-blocked") == "active"  # no write
+    assert _phase(sd, "T-blocked") == "active"          # phase unchanged
+    assert _derived_status(sd, "T-blocked") is None     # reconcile_track was not called
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_close_track_if_done.py
+++ b/tests/test_close_track_if_done.py
@@ -1,0 +1,308 @@
+"""tests/test_close_track_if_done.py — shared close helper + close-time revalidation.
+
+Verifies track_reconciler.close_track_if_done:
+- evidence=None path: derived-done -> walks; derived!=done -> noop_not_terminal;
+  parked without include_parked -> rejected_parked.
+- revalidation: snapshot pr_ref differs from current row -> stale_candidate, no write.
+- revalidation: blocker OI appeared after nomination -> stale_candidate, no write.
+- revalidation clean -> closes, track_phase_history rows carry given actor + approval_id.
+- mid-walk failure resumability (monkeypatch transition_phase on second step).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration  # noqa: E402
+import track_reconciler  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-close-proj"
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _build_db(tmp_path: Path) -> Path:
+    """State dir with migrations 0022 + 0024 + 0027 + 0028 + 0030 applied."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    for ver, fname in (
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    conn.close()
+    return state_dir
+
+
+def _seed_done_track(state_dir: Path, track_id: str, *, phase: str) -> None:
+    """Track whose work is terminal (completed dispatch, no pr_ref) => derived 'done'."""
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID, title=track_id, goal_state="ship", phase=phase
+    )
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?,?,?,?)",
+        (f"D-{track_id}", PROJECT_ID, "completed", track_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _phase(state_dir: Path, track_id: str) -> str:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT phase FROM tracks WHERE track_id=? AND project_id=?",
+        (track_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else ""
+
+
+def _history(state_dir: Path, track_id: str) -> list:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    rows = conn.execute(
+        "SELECT from_phase, to_phase, actor, approval_id "
+        "FROM track_phase_history "
+        "WHERE track_id=? AND project_id=? ORDER BY rowid",
+        (track_id, PROJECT_ID),
+    ).fetchall()
+    conn.close()
+    return [
+        {"from_phase": r[0], "to_phase": r[1], "actor": r[2], "approval_id": r[3]}
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# evidence=None path
+# ---------------------------------------------------------------------------
+
+def test_none_evidence_derived_done_walks_to_done(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-active", phase="active")
+    result = track_reconciler.close_track_if_done(
+        sd, "T-active", PROJECT_ID, actor="operator", approval_id="APR-1"
+    )
+    assert result["action"] == "closed"
+    assert result["applied"] is True
+    assert _phase(sd, "T-active") == "done"
+
+
+def test_none_evidence_derived_not_done_noop_not_terminal(tmp_path):
+    sd = _build_db(tmp_path)
+    # No dispatches => derived='queued' (not terminal) => noop_not_terminal.
+    tracks_lib.create_track(sd, "T-q", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    result = track_reconciler.close_track_if_done(
+        sd, "T-q", PROJECT_ID, actor="operator", approval_id="X"
+    )
+    assert result["action"] == "noop_not_terminal"
+    assert result["applied"] is False
+    assert _phase(sd, "T-q") == "queued"
+
+
+def test_none_evidence_parked_without_include_flag_rejected_parked(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-parked", phase="parked")
+    result = track_reconciler.close_track_if_done(
+        sd, "T-parked", PROJECT_ID, actor="operator", approval_id="X"
+    )
+    assert result["action"] == "rejected_parked"
+    assert result["applied"] is False
+    assert _phase(sd, "T-parked") == "parked"
+
+
+# ---------------------------------------------------------------------------
+# Revalidation: stale_candidate on pr_ref mismatch
+# ---------------------------------------------------------------------------
+
+def test_revalidation_pr_ref_changed_stale_candidate(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-pr", phase="active")
+
+    # Set pr_ref="#994" AND add a pr_merged coordination event so reconcile still
+    # derives "done" (all-terminal dispatches + pr_merged event = done).
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET pr_ref=? WHERE track_id=? AND project_id=?",
+        ("#994", "T-pr", PROJECT_ID),
+    )
+    conn.execute(
+        "INSERT INTO coordination_events "
+        "(event_id, event_type, entity_type, entity_id, occurred_at, project_id) "
+        "VALUES ('ev-994','pr_merged','dispatch',?,strftime('%Y-%m-%dT%H:%M:%fZ','now'),?)",
+        ("D-T-pr", PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+
+    # Snapshot carries a DIFFERENT pr_ref -> stale candidate.
+    evidence = {"pr_ref": "#993", "verified_at": "2026-07-04T10:00:00Z"}
+    result = track_reconciler.close_track_if_done(
+        sd, "T-pr", PROJECT_ID, actor="system", evidence=evidence
+    )
+    assert result["action"] == "stale_candidate"
+    assert result["applied"] is False
+    assert _phase(sd, "T-pr") == "active"  # no write
+
+
+# ---------------------------------------------------------------------------
+# Revalidation: stale_candidate on blocker OI
+# ---------------------------------------------------------------------------
+
+def test_revalidation_blocker_oi_appeared_stale_candidate(tmp_path, monkeypatch):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-blocked", phase="active")
+
+    # Add a blocker OI (arrived after the nomination snapshot was taken).
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO track_open_items "
+        "(track_id, project_id, oi_id, link_type, link_source) "
+        "VALUES (?,?,?,'blocks','manual')",
+        ("T-blocked", PROJECT_ID, "OI-001"),
+    )
+    conn.commit()
+    conn.close()
+
+    # Snapshot was taken before the blocker appeared.
+    evidence = {"pr_ref": None, "verified_at": "2026-07-04T10:00:00Z"}
+
+    # Monkeypatch reconcile_track to return "done" regardless of the blocker, simulating
+    # the TOCTOU window: blocker arrived after the nomination reconcile but before the
+    # revalidation fresh read inside close_track_if_done.
+    def fake_reconcile(state_dir, track_id, project_id, **kw):
+        return {
+            "track_id": track_id,
+            "project_id": project_id,
+            "derived_status": "done",
+            "declared_phase": "active",
+            "drifted": True,
+        }
+
+    monkeypatch.setattr(track_reconciler, "reconcile_track", fake_reconcile)
+
+    result = track_reconciler.close_track_if_done(
+        sd, "T-blocked", PROJECT_ID, actor="system", evidence=evidence
+    )
+    assert result["action"] == "stale_candidate"
+    assert result["applied"] is False
+    assert _phase(sd, "T-blocked") == "active"  # no write
+
+
+# ---------------------------------------------------------------------------
+# Revalidation: clean -> closes, records actor + approval_id
+# ---------------------------------------------------------------------------
+
+def test_revalidation_clean_closes_and_records_actor_and_approval(tmp_path):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-ok", phase="active")
+
+    # Snapshot matches current DB state exactly (no pr_ref, no blockers).
+    evidence = {"pr_ref": None, "verified_at": "2026-07-04T10:00:00Z"}
+    result = track_reconciler.close_track_if_done(
+        sd, "T-ok", PROJECT_ID,
+        actor="T0",
+        approval_id="AUTO-1",
+        evidence=evidence,
+    )
+    assert result["action"] == "closed"
+    assert result["applied"] is True
+    assert _phase(sd, "T-ok") == "done"
+
+    hist = _history(sd, "T-ok")
+    assert len(hist) == 1
+    assert hist[0]["actor"] == "T0"
+    assert hist[0]["approval_id"] == "AUTO-1"
+
+
+# ---------------------------------------------------------------------------
+# Mid-walk failure resumability
+# ---------------------------------------------------------------------------
+
+def test_mid_walk_failure_leaves_intermediate_and_is_resumable(tmp_path, monkeypatch):
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-q2", phase="queued")  # queued -> active -> done (two steps)
+
+    real = tracks_lib.transition_phase
+
+    def flaky(state_dir, tid, pid, to_phase, **kw):
+        if to_phase == "done":
+            raise tracks_lib.InvalidTransitionError("injected mid-walk failure")
+        return real(state_dir, tid, pid, to_phase, **kw)
+
+    monkeypatch.setattr(tracks_lib, "transition_phase", flaky)
+
+    result = track_reconciler.close_track_if_done(
+        sd, "T-q2", PROJECT_ID, actor="operator", approval_id="A"
+    )
+    assert result["action"] == "rejected_walk_failed"
+    assert _phase(sd, "T-q2") == "active"  # non-atomic: stuck at intermediate phase
+
+    # Recovery: re-call resumes walk from the current declared phase.
+    monkeypatch.setattr(tracks_lib, "transition_phase", real)
+    result2 = track_reconciler.close_track_if_done(
+        sd, "T-q2", PROJECT_ID, actor="operator", approval_id="A"
+    )
+    assert result2["action"] == "closed"
+    assert _phase(sd, "T-q2") == "done"


### PR DESCRIPTION
## Summary

D2 of the `status-git-reality-reconcile` track (plan rev 4, operator-approved gate). Pure refactor plus the revalidation contract — no behavior change on the human path.

- New `track_reconciler.close_track_if_done(state_dir, track_id, project_id, *, actor, evidence=None, approval_id=None, include_parked=False)`: the extracted close-walk (derived-done gate, parked guard, evidence surfacing, phase-graph path, resumable transition loop).
- `EvidenceSnapshot` (TypedDict) + close-time revalidation: with a nomination snapshot the helper does a fresh read immediately before the walk and aborts as `stale_candidate` (no write) when pr_ref changed, a blocker OI appeared, or the phase is no longer eligible. Documented honestly as bounded TOCTOU-narrowing, not atomicity (`transition_phase` opens its own connection).
- `cmd_objective_close` rewired onto the helper; `_close_evidence` / `_phase_path_to` moved to the lib with module-level aliases preserved. CLI contract unchanged.
- This is the foundation for D3 (`vnx objective reconcile` batch auto-close), which will pass gh-verified evidence snapshots into the same single-writer path.

## Verification

- 79 passed: the 15 existing `test_objective_close.py` tests UNMODIFIED (0-line diff, verified), 7 new lib tests (incl. both stale_candidate paths + mid-walk resumability), full reconciler suite.
- Independently re-run by the orchestrator in a clean worktree at the commit.

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-d2-closewalk`, claude-sonnet-4-6, ephemeral worktree, unified report + receipt on file). Plan: `claudedocs/2026-07-03-status-git-reality-reconcile-PLAN.md` (rev 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC