### PR TITLE
feat(reconcile): audited done→active reopen valve + re-close guard [D6]

### DIFF
--- a/docs/contracts/MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md
+++ b/docs/contracts/MULTI_TRACK_PARALLEL_EXECUTION_CONTRACT.md
@@ -26,7 +26,7 @@ phases: queued → active → parked → done
   queued  → {active, parked}
   active  → {done, parked}
   parked  → {queued}
-  done    → {} (terminal)
+  done    → {active}  (operator-only reopen edge)
 ```
 
 | Phase    | Description |
@@ -34,7 +34,7 @@ phases: queued → active → parked → done
 | `queued` | Track is ready; dependencies may not yet be satisfied |
 | `active` | Track is being executed; dispatches are live |
 | `parked` | Execution paused (context-switch or blocked); resumes via `queued` |
-| `done`   | Track is complete; all PRs merged to main |
+| `done`   | Track is complete; all PRs merged to main. Operator may reopen via `objective reopen --approval-id --reason` (`done → active`); the reconciler never calls this edge and the re-close guard disarms auto-close on the next run until pr_ref changes. |
 
 ### 1.2 Track Identity
 

--- a/docs/core/STATE_FABRIC.md
+++ b/docs/core/STATE_FABRIC.md
@@ -21,7 +21,9 @@ rewritten (ADR-005). The past is evidence: it is what governance verifies agains
 ### Current — the declared and derived present
 `runtime_coordination.db` holds the live state:
 - `tracks.phase` — the operator-authoritative **declared** status
-  (`queued → active → done`, plus `parked`). `done` is terminal.
+  (`queued → active → done`, plus `parked`). `done` is terminal for the
+  reconciler; an operator may reopen it via `objective reopen --approval-id
+  --reason` (the `done → active` edge), which re-arms the re-close guard.
 - `tracks.derived_status` — the reconciler-**computed** status (`done` / `blocked`
   / `in_progress` / `queued`), written independently of `phase`.
 - `dispatches.state` — in-flight work (`proposed → ready → active → completed`,
@@ -78,7 +80,11 @@ step 8 (you close). That window is deliberate — it is your human gate — and
 - **Write separation.** `phase` (declared) and `derived_status` (computed) are
   different columns with different writers. The reconciler can never silently
   flip your declared status.
-- **Phase immutability.** `done` is terminal; a closed track cannot regress.
+- **Phase immutability.** `done` is terminal for auto-close; the reconciler
+  never calls `done → active`. The operator-only reopen edge (`objective reopen
+  --approval-id --reason`) exists but stamps the pr_ref at reopen time — the
+  re-close guard disarms auto-close on the next reconcile run until the pr_ref
+  changes.
 - **Multi-source merge detection.** Four evidence sources mean a PR merged any
   way (receipt, ledger, ROADMAP, or raw `gh pr merge`) still grounds the track.
 - **Blocker + dependency gating.** Open `blocks` items and unmet `depends_on`

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -186,6 +186,58 @@ def _is_merged(pr_data: Optional[Dict[str, Any]]) -> bool:
 
 
 # ---------------------------------------------------------------------------
+# Re-close guard helpers (D6)
+# ---------------------------------------------------------------------------
+
+def _get_latest_done_to_active_history(
+    state_dir: Path, track_id: str, project_id: str
+) -> Optional[Dict[str, Any]]:
+    """Return the latest track_phase_history row (from_phase=done, to_phase=active)
+    for this track, project-scoped. Returns None when no such row exists or on error."""
+    db_path = state_dir / track_reconciler.DB_FILENAME
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            row = conn.execute(
+                """
+                SELECT reason, approval_id, occurred_at
+                FROM track_phase_history
+                WHERE track_id = ? AND project_id = ?
+                  AND from_phase = 'done' AND to_phase = 'active'
+                ORDER BY occurred_at DESC
+                LIMIT 1
+                """,
+                (track_id, project_id),
+            ).fetchone()
+            return dict(row) if row else None
+        finally:
+            conn.close()
+    except Exception as exc:
+        log.debug("reopen guard DB lookup failed for %s: %s", track_id, exc)
+        return None
+
+
+def _parse_reopen_stamp(reason: str) -> Optional[str]:
+    """Parse the stamped pr_ref from a reopen history reason string.
+
+    Expected format: 'reopen pr_ref=<value> | <operator text>'
+    Returns the pr_ref value string, or None when the format is unrecognised.
+    """
+    if not reason:
+        return None
+    prefix = "reopen pr_ref="
+    if not reason.startswith(prefix):
+        return None
+    rest = reason[len(prefix):]
+    sep = " | "
+    idx = rest.find(sep)
+    if idx < 0:
+        return None
+    return rest[:idx]
+
+
+# ---------------------------------------------------------------------------
 # Decision logic
 # ---------------------------------------------------------------------------
 
@@ -337,10 +389,12 @@ def run_reconcile(
 
     # ------------------------------------------------------------------ step 3
     # Nomination: non-empty pr_ref + declared phase not in {done, parked}.
-    # No gate on derived_status or aggregate merged-set.
+    # Re-close guard: skip tracks reopened from done→active when pr_ref
+    # matches the stamp (unchanged) — reported as reopened_guard, not closed.
     # ------------------------------------------------------------------ step 3
     all_tracks = tracks_lib.list_tracks(state_dir, project_id)
     candidates: List[Dict[str, Any]] = []
+    guarded_tracks: List[Dict[str, Any]] = []
     for t in all_tracks:
         phase = (t.get("phase") or "").strip()
         pr_ref = (t.get("pr_ref") or "").strip()
@@ -349,6 +403,32 @@ def run_reconcile(
         pr_numbers = _parse_pr_numbers(pr_ref)
         if not pr_numbers:
             continue
+
+        # Re-close guard: if a done→active reopen history row exists, compare
+        # its stamped pr_ref against the current pr_ref.
+        reopen_hist = _get_latest_done_to_active_history(state_dir, t["track_id"], project_id)
+        if reopen_hist is not None:
+            stamped_pr_ref = _parse_reopen_stamp(reopen_hist.get("reason") or "")
+            if stamped_pr_ref is None:
+                # Unparseable stamp — fail-closed.
+                guarded_tracks.append({
+                    "track_id": t["track_id"],
+                    "verdict": "reopened_guard",
+                    "pr_ref": pr_ref,
+                    "reason": "unparseable_reopen_stamp",
+                })
+                continue
+            if stamped_pr_ref == pr_ref:
+                # pr_ref unchanged since reopen — skip.
+                guarded_tracks.append({
+                    "track_id": t["track_id"],
+                    "verdict": "reopened_guard",
+                    "pr_ref": pr_ref,
+                    "reason": "pr_ref_unchanged_since_reopen",
+                })
+                continue
+            # pr_ref changed — re-armed; fall through to normal nomination.
+
         candidates.append({
             "track_id": t["track_id"],
             "pr_ref": pr_ref,
@@ -371,11 +451,12 @@ def run_reconcile(
                 "reason": gh_health,
             }
             for c in candidates
-        ]
+        ] + guarded_tracks
         counts = {
             "tracks": total_tracks, "nominated": nominated, "confirmed": 0,
             "closed": 0, "closed_sibling": 0, "open_pr": 0,
             "unverified": len(candidates), "deferred": 0, "stale": 0,
+            "reopened_guard": len(guarded_tracks),
         }
         summary = {
             "run_id": run_id, "project_id": project_id, "mode": mode,
@@ -398,6 +479,7 @@ def run_reconcile(
         "tracks": total_tracks, "nominated": nominated, "confirmed": 0,
         "closed": 0, "closed_sibling": 0, "open_pr": 0,
         "unverified": 0, "deferred": 0, "stale": 0,
+        "reopened_guard": len(guarded_tracks),
     }
     confirmed_candidates: List[Dict[str, Any]] = []
     per_track: List[Dict[str, Any]] = []
@@ -486,6 +568,9 @@ def run_reconcile(
                 counts["closed"] += 1
             elif action == "stale_candidate":
                 counts["stale"] += 1
+
+    # Add re-close guarded tracks to the per-track report.
+    per_track.extend(guarded_tracks)
 
     # ------------------------------------------------------------------ step 6
     # Summary + history.

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -249,6 +249,10 @@ def _parse_reopen_stamp(reason: str) -> Optional[str]:
         val = json.loads(m.group(0))
     except (json.JSONDecodeError, ValueError):
         return None
+    # Remainder must be empty or start with ' | ' — anything else is garbled.
+    remainder = rest[m.end():]
+    if remainder and not remainder.startswith(" | "):
+        return None
     # '-' is the sentinel for empty pr_ref
     return "" if val == "-" else val
 

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import sqlite3
 import subprocess
 from datetime import datetime, timezone
@@ -218,23 +219,38 @@ def _get_latest_done_to_active_history(
         return None
 
 
+_REOPEN_STAMP_PREFIX = "reopen pr_ref="
+_JSON_STRING_RE = re.compile(r'^"((?:[^"\\]|\\.)*)"')
+
+
 def _parse_reopen_stamp(reason: str) -> Optional[str]:
     """Parse the stamped pr_ref from a reopen history reason string.
 
-    Expected format: 'reopen pr_ref=<value> | <operator text>'
-    Returns the pr_ref value string, or None when the format is unrecognised.
+    New format: 'reopen pr_ref="<json-string>" | <operator text>'
+    The value is a JSON string literal so embedded pipes/quotes are safe.
+
+    Backwards-compat: old-format raw stamps (no leading quote) and garbled
+    stamps return None — callers treat None as GUARDED (fail-closed).
+
+    Returns the decoded pr_ref string ('' for the '-' sentinel), or None
+    when the format is not the new JSON format.
     """
     if not reason:
         return None
-    prefix = "reopen pr_ref="
-    if not reason.startswith(prefix):
+    if not reason.startswith(_REOPEN_STAMP_PREFIX):
         return None
-    rest = reason[len(prefix):]
-    sep = " | "
-    idx = rest.find(sep)
-    if idx < 0:
+    rest = reason[len(_REOPEN_STAMP_PREFIX):]
+    # New format: JSON string literal starting with '"'
+    m = _JSON_STRING_RE.match(rest)
+    if not m:
+        # Old-format (no leading quote) or malformed → fail-closed
         return None
-    return rest[:idx]
+    try:
+        val = json.loads(m.group(0))
+    except (json.JSONDecodeError, ValueError):
+        return None
+    # '-' is the sentinel for empty pr_ref
+    return "" if val == "-" else val
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -33,7 +33,7 @@ ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "queued":  frozenset({"active", "parked"}),
     "active":  frozenset({"done", "parked"}),
     "parked":  frozenset({"queued"}),
-    "done":    frozenset(),
+    "done":    frozenset({"active"}),
 }
 
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -691,7 +691,7 @@ def cmd_objective_reopen(args: argparse.Namespace) -> int:
         return 2
 
     current_pr_ref = (track.get("pr_ref") or "").strip() or "-"
-    stamped_reason = f"reopen pr_ref={current_pr_ref} | {reason_text}"
+    stamped_reason = f"reopen pr_ref={json.dumps(current_pr_ref)} | {reason_text}"
 
     try:
         tracks_lib.transition_phase(

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -371,6 +371,7 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
         f"  open_pr={c.get('open_pr', 0)}"
         f"  unverified={c.get('unverified', 0)}"
         f"  deferred={c.get('deferred', 0)}"
+        f"  reopened_guard={c.get('reopened_guard', 0)}"
     )
 
     per_track = summary.get("per_track", [])
@@ -640,6 +641,77 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
 
     return _emit(lib_action or "unknown", False,
                  f"unexpected result from library: {lib_action}", 2)
+
+
+def cmd_objective_reopen(args: argparse.Namespace) -> int:
+    """Reopen a done track: done -> active (operator-gated, audited).
+
+    Both --approval-id and --reason are mandatory; exit 2 without them or
+    when the track is not in phase done. The reason stored in track_phase_history
+    is prefixed with a machine-parseable stamp: 'reopen pr_ref=<value> | <text>'
+    so the re-close guard in objective reconcile can detect when the pr_ref
+    changes (re-arming the track for the next auto-close cycle).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    approval_id = (getattr(args, "approval_id", None) or "").strip()
+    if not approval_id:
+        print(
+            "objective reopen: --approval-id is required (the operator's gate token). "
+            "No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    reason_text = (getattr(args, "reason", None) or "").strip()
+    if not reason_text:
+        print(
+            "objective reopen: --reason is required. No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"objective reopen: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if track["phase"] != "done":
+        print(
+            f"objective reopen: track {track_id!r} is not in phase 'done' "
+            f"(current phase: {track['phase']!r}). Only done tracks can be reopened.",
+            file=sys.stderr,
+        )
+        return 2
+
+    current_pr_ref = (track.get("pr_ref") or "").strip() or "-"
+    stamped_reason = f"reopen pr_ref={current_pr_ref} | {reason_text}"
+
+    try:
+        tracks_lib.transition_phase(
+            state_dir, track_id, project_id, "active",
+            actor="operator",
+            reason=stamped_reason,
+            approval_id=approval_id,
+        )
+    except tracks_lib.InvalidTransitionError as exc:
+        print(f"objective reopen: transition failed: {exc}", file=sys.stderr)
+        return 2
+    except Exception as exc:
+        print(f"objective reopen: unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+    print(
+        f"Reopened {track_id}: done -> active  "
+        f"(pr_ref={current_pr_ref}, approval={approval_id})"
+    )
+    return 0
 
 
 def maybe_auto_seed(
@@ -1319,6 +1391,22 @@ def _build_parser() -> argparse.ArgumentParser:
     p_close.add_argument("--include-parked", action="store_true",
                          help="allow closing a PARKED track (un-parks it; off by default)")
     p_close.set_defaults(func=cmd_objective_close)
+
+    p_reopen = obj_sub.add_parser(
+        "reopen",
+        help="reopen a done track: done -> active (operator-gated, audited)",
+    )
+    _common(p_reopen)
+    p_reopen.add_argument("track_id")
+    p_reopen.add_argument(
+        "--approval-id", default="", dest="approval_id",
+        help="operator approval token (REQUIRED)",
+    )
+    p_reopen.add_argument(
+        "--reason", default="",
+        help="reason for reopening (REQUIRED); stored with a pr_ref stamp for the re-close guard",
+    )
+    p_reopen.set_defaults(func=cmd_objective_reopen)
 
     p_add = obj_sub.add_parser(
         "add",

--- a/tests/test_objective_close.py
+++ b/tests/test_objective_close.py
@@ -266,11 +266,17 @@ def test_evidence_success_signal_from_merged_pr_without_completed_dispatch(tmp_p
     assert ev["has_success_signal"] is True
 
 
-def test_phase_path_unreachable_returns_none():
-    # 'done' is terminal (no outgoing transitions) so it can reach nothing.
-    assert planning_cli._phase_path_to("done", "active") is None
+def test_phase_path_bfs():
+    # Same-phase returns empty path.
     assert planning_cli._phase_path_to("active", "active") == []
+    # Standard close path.
     assert planning_cli._phase_path_to("queued", "done") == ["active", "done"]
+    # done→active is the reopen valve — one step.
+    assert planning_cli._phase_path_to("done", "active") == ["active"]
+    # done→queued via done→active→parked→queued (BFS finds shortest).
+    assert planning_cli._phase_path_to("done", "queued") == ["active", "parked", "queued"]
+    # Invalid start phase returns None.
+    assert planning_cli._phase_path_to("nonexistent", "done") is None
 
 
 def _write_pr_merged_ndjson(state_dir: Path, pr_numbers: list) -> None:

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -610,12 +610,12 @@ def test_reopened_track_unchanged_prref_skipped_as_reopened_guard(tmp_path, monk
     sd = _build_db(tmp_path)
     _seed_track(sd, "T-guard", phase="active", pr_ref="#1100")
 
-    # Transition to done, then reopen with the stamp format cmd_objective_reopen uses.
+    # Transition to done, then reopen with the JSON-encoded stamp format.
     tracks_lib.transition_phase(sd, "T-guard", PROJECT_ID, "done", actor="T0")
     tracks_lib.transition_phase(
         sd, "T-guard", PROJECT_ID, "active",
         actor="operator",
-        reason="reopen pr_ref=#1100 | test reopening",
+        reason='reopen pr_ref="#1100" | test reopening',
         approval_id="appr-guard-001",
     )
     assert _phase(sd, "T-guard") == "active"
@@ -645,12 +645,12 @@ def test_reopened_track_changed_prref_eligible_and_closes(tmp_path, monkeypatch)
     sd = _build_db(tmp_path)
     _seed_track(sd, "T-rearmed", phase="active", pr_ref="#1200")
 
-    # Transition to done, reopen with old pr_ref stamp.
+    # Transition to done, reopen with JSON-encoded stamp of the old pr_ref.
     tracks_lib.transition_phase(sd, "T-rearmed", PROJECT_ID, "done", actor="T0")
     tracks_lib.transition_phase(
         sd, "T-rearmed", PROJECT_ID, "active",
         actor="operator",
-        reason="reopen pr_ref=#1200 | follow-up needed",
+        reason='reopen pr_ref="#1200" | follow-up needed',
         approval_id="appr-rearmed-001",
     )
     # Change pr_ref to a new value — re-arms the track for auto-close.
@@ -704,3 +704,201 @@ def test_reopened_track_unparseable_stamp_guarded_fail_closed(tmp_path, monkeypa
     assert "T-badstamp" in per
     assert per["T-badstamp"]["verdict"] == "reopened_guard"
     assert _phase(sd, "T-badstamp") == "active"  # not auto-closed
+
+
+def test_old_format_stamp_treated_as_guarded(tmp_path, monkeypatch):
+    """Old-format stamp (no JSON quotes) → fail-closed (reopened_guard), not re-armed."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-oldfmt", phase="active", pr_ref="#1400")
+
+    # Stamp uses the old raw format (no json.dumps)
+    tracks_lib.transition_phase(sd, "T-oldfmt", PROJECT_ID, "done", actor="T0")
+    tracks_lib.transition_phase(
+        sd, "T-oldfmt", PROJECT_ID, "active",
+        actor="operator",
+        reason="reopen pr_ref=#1400 | old format stamp",
+        approval_id="appr-oldfmt-001",
+    )
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1400: _merged_pr(1400)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    per = {pt["track_id"]: pt for pt in summary["per_track"]}
+    assert per["T-oldfmt"]["verdict"] == "reopened_guard"
+    assert _phase(sd, "T-oldfmt") == "active"
+
+
+# ---------------------------------------------------------------------------
+# JSON stamp round-trip tests (D6 gate round 2)
+# ---------------------------------------------------------------------------
+
+def _json_reopen_stamp(pr_ref_value: str) -> str:
+    """Build a new-format JSON-encoded stamp (mirrors planning_cli.py)."""
+    import json as _json
+    encoded = pr_ref_value if pr_ref_value else "-"
+    return f"reopen pr_ref={_json.dumps(encoded)} | test-reason"
+
+
+def _do_reopen_with_stamp(sd: Path, track_id: str, pr_ref_at_reopen: str) -> None:
+    """Transition track done→active with a new-format JSON stamp."""
+    tracks_lib.transition_phase(sd, track_id, PROJECT_ID, "done", actor="T0")
+    tracks_lib.transition_phase(
+        sd, track_id, PROJECT_ID, "active",
+        actor="operator",
+        reason=_json_reopen_stamp(pr_ref_at_reopen),
+        approval_id=f"appr-{track_id}",
+    )
+
+
+def test_stamp_roundtrip_simple_prref_unchanged_guarded(tmp_path, monkeypatch):
+    """Simple pr_ref=#994: unchanged after reopen → reopened_guard."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-rt1", phase="active", pr_ref="#994")
+    _do_reopen_with_stamp(sd, "T-rt1", "#994")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({994: _merged_pr(994)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    assert _phase(sd, "T-rt1") == "active"
+
+
+def test_stamp_roundtrip_prref_with_pipe_unchanged_guarded(tmp_path, monkeypatch):
+    """pr_ref containing ' | ' (#1400 | #1401): unchanged after reopen → reopened_guard.
+    This is the core Fix 1 case: old format would misparse and disarm the guard."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-rt2", phase="active", pr_ref="#1400 | #1401")
+    _do_reopen_with_stamp(sd, "T-rt2", "#1400 | #1401")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1400: _merged_pr(1400), 1401: _merged_pr(1401)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    assert _phase(sd, "T-rt2") == "active"
+
+
+def test_stamp_roundtrip_prref_with_pipe_changed_rearmed(tmp_path, monkeypatch):
+    """pr_ref was '#1400 | #1401' at reopen; changed to '#1402' → re-armed, closes."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-rt3", phase="active", pr_ref="#1400 | #1401")
+    _do_reopen_with_stamp(sd, "T-rt3", "#1400 | #1401")
+    # Update pr_ref — re-arms the track for auto-close
+    tracks_lib.update_authored_fields(sd, "T-rt3", PROJECT_ID, pr_ref="#1402", actor="operator")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1402: _merged_pr(1402)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 0
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 1
+    assert _phase(sd, "T-rt3") == "done"
+
+
+def test_stamp_roundtrip_comma_separated_unchanged_guarded(tmp_path, monkeypatch):
+    """Comma-separated pr_ref (#908,#909): unchanged after reopen → reopened_guard."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-rt4", phase="active", pr_ref="#908,#909")
+    _do_reopen_with_stamp(sd, "T-rt4", "#908,#909")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({908: _merged_pr(908), 909: _merged_pr(909)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    assert _phase(sd, "T-rt4") == "active"
+
+
+def test_stamp_roundtrip_empty_prref_unchanged_guarded(tmp_path, monkeypatch):
+    """Empty pr_ref (sentinel '-'): reopened with empty, still empty → reopened_guard.
+    Note: empty pr_ref tracks are not nominated for reconcile (pr_ref is required),
+    so this verifies the guard is correct when pr_ref is subsequently filled in
+    but matches the sentinel after round-trip."""
+    sd = _build_db(tmp_path)
+    # Create with empty pr_ref, reopen (stamps '-')
+    _seed_track(sd, "T-rt5", phase="active", pr_ref="")
+    _do_reopen_with_stamp(sd, "T-rt5", "")
+    # Now give it a pr_ref matching the empty-equivalent round-trip:
+    # Empty → stamped as '-' → parses back as '' → current pr_ref '' → guarded
+    # But to nominate it, we must set a non-empty pr_ref.
+    # Set pr_ref to a new value → different from '' → re-armed.
+    tracks_lib.update_authored_fields(sd, "T-rt5", PROJECT_ID, pr_ref="#2000", actor="operator")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({2000: _merged_pr(2000)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    # pr_ref changed from '' to '#2000' → re-armed → closes
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 0
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 1
+    assert _phase(sd, "T-rt5") == "done"
+
+
+def test_stamp_roundtrip_prref_with_double_quote_unchanged_guarded(tmp_path, monkeypatch):
+    """pr_ref containing a double quote: JSON encoding handles it safely.
+    Unchanged after reopen → reopened_guard."""
+    sd = _build_db(tmp_path)
+    # pr_ref that embeds a double-quote character (unusual but must not break parser)
+    tricky_pr_ref = '#994 "extra"'
+    _seed_track(sd, "T-rt6", phase="active", pr_ref=tricky_pr_ref)
+    _do_reopen_with_stamp(sd, "T-rt6", tricky_pr_ref)
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({994: _merged_pr(994)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    # '#994 "extra"' parses to PR 994, but unchanged pr_ref → guarded
+    assert code == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    assert _phase(sd, "T-rt6") == "active"

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -598,3 +598,109 @@ def test_cache_is_repo_scoped(tmp_path, monkeypatch):
     assert summary2["counts"]["confirmed"] == 1
     pr_view_calls_2 = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
     assert len(pr_view_calls_2) == 1, "repo-b run must trigger its own gh pr view (different repo key)"
+
+
+# ---------------------------------------------------------------------------
+# Re-close guard tests (D6)
+# ---------------------------------------------------------------------------
+
+def test_reopened_track_unchanged_prref_skipped_as_reopened_guard(tmp_path, monkeypatch):
+    """Reopened track (done→active) with unchanged pr_ref → verdict=reopened_guard;
+    not closed under --apply even when gh confirms all PRs merged."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-guard", phase="active", pr_ref="#1100")
+
+    # Transition to done, then reopen with the stamp format cmd_objective_reopen uses.
+    tracks_lib.transition_phase(sd, "T-guard", PROJECT_ID, "done", actor="T0")
+    tracks_lib.transition_phase(
+        sd, "T-guard", PROJECT_ID, "active",
+        actor="operator",
+        reason="reopen pr_ref=#1100 | test reopening",
+        approval_id="appr-guard-001",
+    )
+    assert _phase(sd, "T-guard") == "active"
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1100: _merged_pr(1100)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0, f"expected exit 0, got {code}"
+    # Guarded track is NOT nominated (pr_ref unchanged since reopen).
+    assert summary["counts"]["nominated"] == 0
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    per = {pt["track_id"]: pt for pt in summary["per_track"]}
+    assert "T-guard" in per
+    assert per["T-guard"]["verdict"] == "reopened_guard"
+    assert _phase(sd, "T-guard") == "active"  # not auto-closed
+
+
+def test_reopened_track_changed_prref_eligible_and_closes(tmp_path, monkeypatch):
+    """Reopened track whose pr_ref changed after reopen is re-armed and eligible for close."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-rearmed", phase="active", pr_ref="#1200")
+
+    # Transition to done, reopen with old pr_ref stamp.
+    tracks_lib.transition_phase(sd, "T-rearmed", PROJECT_ID, "done", actor="T0")
+    tracks_lib.transition_phase(
+        sd, "T-rearmed", PROJECT_ID, "active",
+        actor="operator",
+        reason="reopen pr_ref=#1200 | follow-up needed",
+        approval_id="appr-rearmed-001",
+    )
+    # Change pr_ref to a new value — re-arms the track for auto-close.
+    tracks_lib.update_authored_fields(
+        sd, "T-rearmed", PROJECT_ID, pr_ref="#1201", actor="operator",
+    )
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1201: _merged_pr(1201)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0, f"expected exit 0, got {code}"
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 1
+    assert summary["counts"].get("reopened_guard", 0) == 0
+    assert _phase(sd, "T-rearmed") == "done"
+
+
+def test_reopened_track_unparseable_stamp_guarded_fail_closed(tmp_path, monkeypatch):
+    """Unparseable reopen stamp (no 'reopen pr_ref=' prefix) → fail-closed (reopened_guard)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-badstamp", phase="active", pr_ref="#1300")
+
+    # Transition to done, then reopen with a NON-STANDARD reason (missing stamp).
+    tracks_lib.transition_phase(sd, "T-badstamp", PROJECT_ID, "done", actor="T0")
+    tracks_lib.transition_phase(
+        sd, "T-badstamp", PROJECT_ID, "active",
+        actor="operator",
+        reason="manually reopened without proper stamp format",
+        approval_id="appr-badstamp-001",
+    )
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1300: _merged_pr(1300)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0, f"expected exit 0, got {code}"
+    assert summary["counts"].get("reopened_guard", 0) == 1
+    assert summary["counts"].get("closed", 0) == 0
+    per = {pt["track_id"]: pt for pt in summary["per_track"]}
+    assert "T-badstamp" in per
+    assert per["T-badstamp"]["verdict"] == "reopened_guard"
+    assert _phase(sd, "T-badstamp") == "active"  # not auto-closed

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -879,6 +879,26 @@ def test_stamp_roundtrip_empty_prref_unchanged_guarded(tmp_path, monkeypatch):
     assert _phase(sd, "T-rt5") == "done"
 
 
+@pytest.mark.parametrize("garbled_reason", [
+    'reopen pr_ref="#1400"garbled',
+    'reopen pr_ref="#1400"|missing-spaces',
+    'reopen pr_ref="#1400"x',
+])
+def test_stamp_garbled_trailing_chars_guarded(tmp_path, monkeypatch, garbled_reason):
+    """Trailing garbage after JSON string literal → fail-closed (reopened_guard)."""
+    from objective_reconcile import _parse_reopen_stamp
+    assert _parse_reopen_stamp(garbled_reason) is None, (
+        f"Expected None for garbled stamp: {garbled_reason!r}"
+    )
+
+
+def test_stamp_valid_bare_and_with_separator():
+    """Valid shapes: bare JSON string and JSON string + ' | text' both parse."""
+    from objective_reconcile import _parse_reopen_stamp
+    assert _parse_reopen_stamp('reopen pr_ref="#1400"') == "#1400"
+    assert _parse_reopen_stamp('reopen pr_ref="#1400" | operator note') == "#1400"
+
+
 def test_stamp_roundtrip_prref_with_double_quote_unchanged_guarded(tmp_path, monkeypatch):
     """pr_ref containing a double quote: JSON encoding handles it safely.
     Unchanged after reopen → reopened_guard."""

--- a/tests/test_objective_reopen.py
+++ b/tests/test_objective_reopen.py
@@ -166,7 +166,7 @@ def test_reopen_happy_path(tmp_path):
     assert reopen_row is not None
     assert reopen_row["actor"] == "operator"
     assert reopen_row["approval_id"] == "appr-001"
-    assert reopen_row["reason"].startswith("reopen pr_ref=#42 | ")
+    assert reopen_row["reason"].startswith('reopen pr_ref="#42" | ')
     assert "follow-up work needed" in reopen_row["reason"]
 
 
@@ -238,5 +238,5 @@ def test_reopen_pr_ref_none_uses_dash(tmp_path):
     hist = _history(sd, "T-noref")
     reopen_row = next((h for h in hist if h["to_phase"] == "active"), None)
     assert reopen_row is not None
-    assert reopen_row["reason"].startswith("reopen pr_ref=- | ")
+    assert reopen_row["reason"].startswith('reopen pr_ref="-" | ')
     assert "reopening" in reopen_row["reason"]

--- a/tests/test_objective_reopen.py
+++ b/tests/test_objective_reopen.py
@@ -1,0 +1,242 @@
+"""tests/test_objective_reopen.py — vnx objective reopen CLI command (D6).
+
+Verifies:
+- happy path: done→active, track_phase_history carries approval_id + stamped reason
+- refusal without --approval-id (exit 2, no write)
+- refusal without --reason (exit 2, no write)
+- refusal when track is not in phase done (exit 2, no write)
+- when track has no pr_ref, stamp uses '-'
+"""
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for _p in (_LIB, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import planning_cli  # noqa: E402
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-reopen-proj"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _build_db(tmp_path: Path) -> Path:
+    """State dir with migrations 0022 + 0024 + 0027 + 0028 applied."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT,
+            event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    for ver, fname in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for ver, fname in (
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    approval_id: str = "",
+    reason: str = "",
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=PROJECT_ID,
+        track_id=track_id,
+        approval_id=approval_id,
+        reason=reason,
+        json=False,
+    )
+
+
+def _phase(state_dir: Path, track_id: str) -> str:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT phase FROM tracks WHERE track_id=? AND project_id=?",
+        (track_id, PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else ""
+
+
+def _history(state_dir: Path, track_id: str) -> list:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    rows = conn.execute(
+        "SELECT from_phase, to_phase, actor, reason, approval_id "
+        "FROM track_phase_history "
+        "WHERE track_id=? AND project_id=? ORDER BY rowid",
+        (track_id, PROJECT_ID),
+    ).fetchall()
+    conn.close()
+    return [
+        {
+            "from_phase": r[0],
+            "to_phase": r[1],
+            "actor": r[2],
+            "reason": r[3],
+            "approval_id": r[4],
+        }
+        for r in rows
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_reopen_happy_path(tmp_path):
+    """Happy path: done→active, history row carries approval_id and stamped reason."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T-reopen", PROJECT_ID, "Title", "Goal",
+        phase="active", pr_ref="#42",
+    )
+    tracks_lib.transition_phase(sd, "T-reopen", PROJECT_ID, "done", actor="T0")
+    assert _phase(sd, "T-reopen") == "done"
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-reopen", approval_id="appr-001", reason="follow-up work needed")
+    )
+
+    assert rc == 0, f"expected exit 0, got {rc}"
+    assert _phase(sd, "T-reopen") == "active"
+
+    hist = _history(sd, "T-reopen")
+    reopen_row = next((h for h in hist if h["to_phase"] == "active"), None)
+    assert reopen_row is not None
+    assert reopen_row["actor"] == "operator"
+    assert reopen_row["approval_id"] == "appr-001"
+    assert reopen_row["reason"].startswith("reopen pr_ref=#42 | ")
+    assert "follow-up work needed" in reopen_row["reason"]
+
+
+def test_reopen_refusal_no_approval_id(tmp_path):
+    """Refuse with exit 2 when --approval-id is absent; track stays done."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-noappr", PROJECT_ID, "T", "G", phase="active")
+    tracks_lib.transition_phase(sd, "T-noappr", PROJECT_ID, "done", actor="T0")
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-noappr", approval_id="", reason="some reason")
+    )
+
+    assert rc == 2
+    assert _phase(sd, "T-noappr") == "done"
+
+
+def test_reopen_refusal_no_reason(tmp_path):
+    """Refuse with exit 2 when --reason is absent; track stays done."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-noreason", PROJECT_ID, "T", "G", phase="active")
+    tracks_lib.transition_phase(sd, "T-noreason", PROJECT_ID, "done", actor="T0")
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-noreason", approval_id="appr-002", reason="")
+    )
+
+    assert rc == 2
+    assert _phase(sd, "T-noreason") == "done"
+
+
+def test_reopen_refusal_not_done(tmp_path):
+    """Refuse with exit 2 when track is not in phase done; track stays active."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-notdone", PROJECT_ID, "T", "G", phase="active")
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-notdone", approval_id="appr-003", reason="some reason")
+    )
+
+    assert rc == 2
+    assert _phase(sd, "T-notdone") == "active"
+
+
+def test_reopen_refusal_not_done_queued(tmp_path):
+    """Refuse with exit 2 when track is in phase queued (not done)."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-queued", PROJECT_ID, "T", "G", phase="queued")
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-queued", approval_id="appr-004", reason="some reason")
+    )
+
+    assert rc == 2
+    assert _phase(sd, "T-queued") == "queued"
+
+
+def test_reopen_pr_ref_none_uses_dash(tmp_path):
+    """When track has no pr_ref, the stamp uses '-' as the pr_ref value."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T-noref", PROJECT_ID, "T", "G", phase="active")
+    tracks_lib.transition_phase(sd, "T-noref", PROJECT_ID, "done", actor="T0")
+
+    rc = planning_cli.cmd_objective_reopen(
+        _args(sd, "T-noref", approval_id="appr-005", reason="reopening")
+    )
+
+    assert rc == 0
+    hist = _history(sd, "T-noref")
+    reopen_row = next((h for h in hist if h["to_phase"] == "active"), None)
+    assert reopen_row is not None
+    assert reopen_row["reason"].startswith("reopen pr_ref=- | ")
+    assert "reopening" in reopen_row["reason"]

--- a/tests/test_track_oi_lifecycle.py
+++ b/tests/test_track_oi_lifecycle.py
@@ -166,17 +166,31 @@ class TestTrackDone:
         evt = transition_events[-1]
         assert evt["details"]["to"] == "done"
 
-    def test_done_to_any_is_rejected(self, state_dir):
-        """Phase 'done' has no allowed outgoing transitions."""
+    def test_done_to_active_allowed_other_transitions_rejected(self, state_dir):
+        """done → active is the operator-gated reopen edge (allowed).
+        done → parked remains rejected."""
         tracks_lib.create_track(state_dir, "feat-4", PROJECT_ID, "T4", "G4", phase="active")
         tracks_lib.transition_phase(
             state_dir, "feat-4", PROJECT_ID, "done",
             actor="operator", reason="closed"
         )
+        # done → active is the operator reopen edge — must succeed
+        t = tracks_lib.transition_phase(
+            state_dir, "feat-4", PROJECT_ID, "active",
+            actor="operator", reason="reopen",
+        )
+        assert t["phase"] == "active"
+
+        # Separate track: done → parked remains rejected
+        tracks_lib.create_track(state_dir, "feat-4b", PROJECT_ID, "T4b", "G4b", phase="active")
+        tracks_lib.transition_phase(
+            state_dir, "feat-4b", PROJECT_ID, "done",
+            actor="operator", reason="closed"
+        )
         with pytest.raises(tracks_lib.InvalidTransitionError):
             tracks_lib.transition_phase(
-                state_dir, "feat-4", PROJECT_ID, "active",
-                actor="operator", reason="reopen attempt"
+                state_dir, "feat-4b", PROJECT_ID, "parked",
+                actor="operator", reason="should fail"
             )
 
     def test_done_to_done_is_noop(self, state_dir):

--- a/tests/test_tracks_lib.py
+++ b/tests/test_tracks_lib.py
@@ -188,11 +188,38 @@ class TestTransitionPhase:
         t = tracks.transition_phase(state_dir, "track-01", "vnx-dev", "queued", actor="operator")
         assert t["phase"] == "queued"
 
-    def test_done_is_terminal(self, state_dir):
+    def test_done_to_queued_still_illegal(self, state_dir):
+        """done→queued is NOT an allowed transition (only done→active is)."""
         tracks.create_track(state_dir, "track-01", "vnx-dev", "T1", "G1", phase="active")
         tracks.transition_phase(state_dir, "track-01", "vnx-dev", "done", actor="T0")
         with pytest.raises(tracks.InvalidTransitionError):
-            tracks.transition_phase(state_dir, "track-01", "vnx-dev", "active", actor="operator")
+            tracks.transition_phase(state_dir, "track-01", "vnx-dev", "queued", actor="operator")
+
+    def test_done_to_active_allowed(self, state_dir):
+        """done→active is the reopen valve — allowed and writes a history row."""
+        tracks.create_track(state_dir, "track-01", "vnx-dev", "T1", "G1", phase="active")
+        tracks.transition_phase(state_dir, "track-01", "vnx-dev", "done", actor="T0")
+        t = tracks.transition_phase(
+            state_dir, "track-01", "vnx-dev", "active",
+            actor="operator",
+            reason="reopen pr_ref=#42 | follow-up work needed",
+            approval_id="reopen-approval-001",
+        )
+        assert t["phase"] == "active"
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = conn.execute(
+            "SELECT from_phase, to_phase, actor, reason, approval_id "
+            "FROM track_phase_history "
+            "WHERE track_id='track-01' AND from_phase='done' AND to_phase='active'"
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "done"
+        assert row[1] == "active"
+        assert row[2] == "operator"
+        assert row[3] == "reopen pr_ref=#42 | follow-up work needed"
+        assert row[4] == "reopen-approval-001"
 
     def test_invalid_actor_raises(self, state_dir):
         tracks.create_track(state_dir, "track-01", "vnx-dev", "T1", "G1", phase="queued")


### PR DESCRIPTION
## Summary

D6 of the `status-git-reality-reconcile` track (plan rev 4): the recovery path the plan-gate panel argued into slice 1 — `done` is no longer a trap state, but reopening stays a strictly operator-gated, fully audited act.

- `ALLOWED_TRANSITIONS` gains exactly one edge: `done → active`.
- New `vnx objective reopen <track> --project-id --approval-id --reason` (both mandatory; refuses when the track is not done). The stored reason starts with a machine-parseable stamp of the track's pr_ref at reopen time.
- Re-close guard in `objective reconcile`: a reopened track with unchanged pr_ref is skipped as `reopened_guard` — even when gh confirms every PR merged — so the reconciler can never undo an operator override. A pr_ref edit re-arms; an unparseable stamp is treated as guarded (fail-closed). The reconciler never calls reopen.

## Verification

140 passed (new `test_objective_reopen.py`, reopened-guard cases in `test_objective_reconcile.py`, transition tests; independently re-run by the orchestrator in a clean worktree). Includes a done-is-terminal assumption sweep across `_phase_path_to`, derived-status stability guards, seeders and dashboards.

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-d6-reopen-valve`, claude-sonnet-4-6). Plan: `claudedocs/2026-07-03-status-git-reality-reconcile-PLAN.md` (rev 4). Context: the one-time backfill ran today — 6 tracks auto-closed on gh-verified evidence; this valve is the safety net for any future false close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC