### PR TITLE
feat(reconcile): advisory-first continuous wiring — tick, review log, flip streak [D4]

### DIFF
--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -36,6 +36,7 @@ Efficiency: risk ≤ 0.3 + success + no blockers → fast path, skip deep verifi
 - **Review-gate evidence (3 surfaces, all required):** request in `.vnx-data/state/review_gates/requests/`, result in `.../results/`, normalized report in `$VNX_DATA_DIR/unified_reports/`. A result with empty `contract_hash` or empty `report_path`, or a report with no matching structured result, is **incomplete evidence → blocks completion**. `queued`/`requested` ≠ executing.
 - **CI workflow conclusion (mandatory):** `gh run list --branch <head> --workflow "VNX CI" --limit 1 --json conclusion --jq '.[0].conclusion'` must equal `success`. `gh pr checks` listing green names is NOT sufficient — a multi-step job can still produce a `failure` conclusion.
 - **Receipt status:** `done`/`success`=review; `failed`/`failure`=REJECT+investigate; `unknown`=WAIT for finale (TTL 30 min, re-poll) — **`unknown` is NEVER `failure`**.
+- **Post-merge sequence (mandatory):** after `gh pr merge`, run `git pull --ff-only` then `vnx objective reconcile --project-id <pid>` to auto-close any track whose `pr_ref` points to the just-merged PR (advisory CHECK by default; add `--apply` to write).
 
 ## 3. PR size + iteration caps
 

--- a/docs/operations/UNIFIED_SUPERVISOR.md
+++ b/docs/operations/UNIFIED_SUPERVISOR.md
@@ -197,6 +197,58 @@ poll. Inspect `pending/` and move or delete the offending file.
 
 ---
 
+## Objective reconcile tick (D4 — advisory-first)
+
+When `VNX_SUPERVISOR_MODE=unified`, the dispatcher prelude fires `_maybe_objective_reconcile`
+as the last tick helper. This periodically runs `objective reconcile` against the live
+project state so tracks whose PRs merge between manual reconcile calls close automatically.
+
+### Interval
+
+```
+VNX_OBJECTIVE_RECONCILE_INTERVAL=900   # seconds between reconcile runs; default 900 (15 min)
+```
+
+State file: `.vnx-data/state/.last_objective_reconcile_ts`.
+Log: `.vnx-data/logs/objective_reconcile.log`.
+
+### Default mode: CHECK (advisory)
+
+By default the tick runs in CHECK mode — it verifies PR states and reports candidates but does
+**not** advance declared phases. This is the safe default: an operator can review the output
+in `objective_reconcile.log` or via `vnx objective reconcile --json` before enabling writes.
+
+### Enabling auto-close: VNX_AUTO_CLOSE
+
+To enable automatic phase advancement, set `VNX_AUTO_CLOSE=1` in `bin/vnx`. The tick then
+appends `--apply` to the reconcile command and closes CONFIRMED tracks on each run.
+
+**Before setting VNX_AUTO_CLOSE=1**, verify the flip criterion is met:
+
+```bash
+vnx objective reconcile-streak --project-id <pid>
+```
+
+The flip criterion requires:
+- A consecutive streak of clean runs (gh=ok, zero unverified, no false-candidate reviews).
+- At least one run in the streak has a confirmed candidate with an `ok` operator review.
+
+Record operator reviews with:
+
+```bash
+vnx objective reconcile-review <run_id> --reviewer <name> --verdict ok
+vnx objective reconcile-review <run_id> --reviewer <name> --verdict false-candidate --note "..."
+```
+
+`run_id` comes from the `run_id` field in `reconcile_history.ndjson` or `reconcile_summary.json`.
+
+### Rollback
+
+Unset `VNX_AUTO_CLOSE` (or remove it from `bin/vnx`) to revert to CHECK mode without
+restarting the supervisor. The next tick will omit `--apply`.
+
+---
+
 ## Architecture summary
 
 ```
@@ -205,8 +257,9 @@ bin/vnx
 
 scripts/dispatcher_supervisor.sh           ← wrapper (backoff + respawn)
   └── scripts/dispatcher_minimal.sh     ← inner loop
-        ├── _maybe_expire_stale_leases()   ← every 30s → scripts/lib/lease_sweep.py
-        └── _maybe_runtime_supervise()     ← every 60s → scripts/lib/runtime_supervise.py
+        ├── _maybe_expire_stale_leases()      ← every 30s → scripts/lib/lease_sweep.py
+        ├── _maybe_runtime_supervise()        ← every 60s → scripts/lib/runtime_supervise.py
+        └── _maybe_objective_reconcile()      ← every 900s → planning_cli.py objective reconcile
 
 scripts/receipt_processor_supervisor.sh    ← wrapper (backoff + respawn)
   └── scripts/receipt_processor.sh     ← inner poll loop
@@ -218,10 +271,12 @@ scripts/lib/cleanup_worker_exit.py         ← called by both adapters on worker
 ```
 
 State files: `.vnx-data/state/.last_lease_sweep_ts`,
-`.vnx-data/state/.last_runtime_supervise_ts`.
+`.vnx-data/state/.last_runtime_supervise_ts`,
+`.vnx-data/state/.last_objective_reconcile_ts`.
 
 Logs: `.vnx-data/logs/dispatcher_supervisor.log`,
 `.vnx-data/logs/receipt_processor_supervisor.log`,
-`.vnx-data/logs/lease_sweep.log`.
+`.vnx-data/logs/lease_sweep.log`,
+`.vnx-data/logs/objective_reconcile.log`.
 
 Full design rationale: `claudedocs/2026-04-29-unified-supervisor-research.md`.

--- a/scripts/dispatcher_minimal.sh
+++ b/scripts/dispatcher_minimal.sh
@@ -602,6 +602,7 @@ process_dispatches() {
     _cleanup_stuck_dispatches
     _unified_supervisor_lease_sweep_tick
     _maybe_auto_seed_tracks
+    _maybe_objective_reconcile
 
     for dispatch in "$PENDING_DIR"/*.md; do
         [ -f "$dispatch" ] || continue

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -53,6 +53,41 @@ _maybe_auto_seed_tracks() {
         >> "$log_file" 2>&1 || true
 }
 
+# _maybe_objective_reconcile — throttled advisory-first git-grounded reconcile tick (D4).
+# Invokes `objective reconcile` at most once per VNX_OBJECTIVE_RECONCILE_INTERVAL seconds
+# when VNX_SUPERVISOR_MODE=unified. Default CHECK mode only; --apply added when
+# VNX_AUTO_CLOSE=1 (operator must set this after `objective reconcile-streak` confirms the
+# flip criterion). Best-effort (|| true); logged to objective_reconcile.log.
+# Default (unset/legacy) = no behaviour change.
+_maybe_objective_reconcile() {
+    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
+    local interval="${VNX_OBJECTIVE_RECONCILE_INTERVAL:-900}"
+    local state_file="$STATE_DIR/.last_objective_reconcile_ts"
+    local now last
+    now=$(date +%s)
+    last=0
+    if [[ -f "$state_file" ]]; then
+        last=$(cat "$state_file" 2>/dev/null || echo 0)
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    fi
+    if (( now - last < interval )); then
+        return 0
+    fi
+    local log_file="$VNX_LOGS_DIR/objective_reconcile.log"
+    mkdir -p "$(dirname "$log_file")"
+    local -a cmd=(
+        python3 "$VNX_DIR/scripts/planning_cli.py"
+        objective reconcile
+        --project-id "$VNX_PROJECT_ID"
+        --state-dir "$STATE_DIR"
+    )
+    if [[ "${VNX_AUTO_CLOSE:-0}" == "1" ]]; then
+        cmd+=(--apply)
+    fi
+    "${cmd[@]}" >> "$log_file" 2>&1 || true
+    echo "$now" > "$state_file"
+}
+
 # _unified_supervisor_lease_sweep_tick — throttled lease_sweep tick (SUP-PR2).
 # Invokes scripts/lib/lease_sweep.py at most once per
 # VNX_LEASE_SWEEP_INTERVAL_SEC seconds when VNX_SUPERVISOR_MODE=unified.

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -44,10 +44,201 @@ _PR_STATE_CACHE_FILE = "pr_state_cache.json"
 _SUMMARY_FILE = "reconcile_summary.json"
 _HISTORY_FILE = "reconcile_history.ndjson"
 _SKIP_PHASES: FrozenSet[str] = frozenset({"done", "parked"})
+_VALID_VERDICTS: FrozenSet[str] = frozenset({"ok", "false-candidate"})
 
 
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Operator review recording
+# ---------------------------------------------------------------------------
+
+def record_review(
+    state_dir: Path,
+    run_id: str,
+    reviewer: str,
+    verdict: str,
+    note: Optional[str],
+    ts: Optional[str] = None,
+) -> None:
+    """Append an operator review record to reconcile_history.ndjson.
+
+    Raises ValueError when run_id does not appear as a reconcile-run record in
+    the history file (callers translate this to CLI exit 2). Raises ValueError
+    for an invalid verdict. Raises OSError on I/O failure.
+    """
+    if verdict not in _VALID_VERDICTS:
+        raise ValueError(
+            f"invalid verdict {verdict!r}: must be one of {sorted(_VALID_VERDICTS)}"
+        )
+
+    history_path = state_dir / _HISTORY_FILE
+
+    run_found = False
+    try:
+        with open(history_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                # Review records themselves carry record="review"; skip them.
+                if rec.get("record") == "review":
+                    continue
+                if rec.get("run_id") == run_id:
+                    run_found = True
+                    break
+    except FileNotFoundError:
+        pass
+
+    if not run_found:
+        raise ValueError(f"run_id {run_id!r} not found in reconcile history")
+
+    review_record: Dict[str, Any] = {
+        "record": "review",
+        "run_id": run_id,
+        "reviewer": reviewer,
+        "verdict": verdict,
+        "note": note or "",
+        "ts": ts or _now_utc(),
+    }
+
+    try:
+        with open(history_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(review_record) + "\n")
+    except OSError as exc:
+        raise OSError(f"cannot append review to {history_path}: {exc}") from exc
+
+
+# ---------------------------------------------------------------------------
+# Streak computation (flip criterion)
+# ---------------------------------------------------------------------------
+
+def compute_streak(
+    state_dir: Path,
+    project_id: str,
+) -> Dict[str, Any]:
+    """Compute the consecutive clean-run streak from reconcile_history.ndjson.
+
+    A run enters the streak when:
+      (a) evidence_source_health.gh == "ok" AND counts.unverified == 0
+      (b) it has zero "false-candidate" reviews
+
+    A degraded run (gh != "ok", unverified > 0, or any false-candidate review)
+    breaks the streak.
+
+    The VNX_AUTO_CLOSE flip criterion is met when the streak has ≥1 run with
+    ≥1 confirmed candidate that received an "ok" review.
+
+    Returns:
+      {
+        "streak_length": int,
+        "has_reviewed_confirmed": bool,
+        "flip_criterion_met": bool,
+        "runs": [...],     # run entries in streak (newest first)
+        "project_id": str,
+      }
+    """
+    history_path = state_dir / _HISTORY_FILE
+
+    summaries: List[Dict[str, Any]] = []
+    reviews_by_run: Dict[str, List[Dict[str, Any]]] = {}
+
+    try:
+        with open(history_path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rec = json.loads(line)
+                except (json.JSONDecodeError, ValueError):
+                    continue
+                if rec.get("record") == "review":
+                    rid = rec.get("run_id", "")
+                    reviews_by_run.setdefault(rid, []).append(rec)
+                elif "run_id" in rec and "counts" in rec:
+                    if rec.get("project_id") == project_id:
+                        summaries.append(rec)
+    except FileNotFoundError:
+        pass
+
+    # Walk from newest run to oldest
+    summaries_newest_first = list(reversed(summaries))
+
+    streak_runs: List[Dict[str, Any]] = []
+    has_reviewed_confirmed = False
+
+    for run in summaries_newest_first:
+        run_id = run.get("run_id", "")
+        gh_ok = run.get("evidence_source_health", {}).get("gh") == "ok"
+        counts = run.get("counts") or {}
+        unverified = counts.get("unverified", 0)
+        confirmed = counts.get("confirmed", 0)
+        is_clean = gh_ok and unverified == 0
+
+        run_reviews = reviews_by_run.get(run_id, [])
+        has_false_candidate = any(r.get("verdict") == "false-candidate" for r in run_reviews)
+        has_ok_review = any(r.get("verdict") == "ok" for r in run_reviews)
+
+        if not is_clean or has_false_candidate:
+            break
+
+        streak_runs.append({
+            "run_id": run_id,
+            "started_at": run.get("started_at"),
+            "gh": run.get("evidence_source_health", {}).get("gh"),
+            "confirmed": confirmed,
+            "unverified": unverified,
+            "reviews": run_reviews,
+        })
+
+        if confirmed > 0 and has_ok_review:
+            has_reviewed_confirmed = True
+
+    streak_length = len(streak_runs)
+    flip_criterion_met = streak_length >= 1 and has_reviewed_confirmed
+
+    return {
+        "streak_length": streak_length,
+        "has_reviewed_confirmed": has_reviewed_confirmed,
+        "flip_criterion_met": flip_criterion_met,
+        "runs": streak_runs,
+        "project_id": project_id,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tick command builder (testable helper)
+# ---------------------------------------------------------------------------
+
+def build_tick_command(
+    vnx_dir: str,
+    project_id: str,
+    state_dir: str,
+    *,
+    auto_close: bool = False,
+) -> List[str]:
+    """Return the argv list the supervisor tick executes for `objective reconcile`.
+
+    CHECK mode by default; --apply appended only when auto_close=True
+    (i.e. VNX_AUTO_CLOSE=1 in the environment).
+    """
+    cmd = [
+        "python3",
+        str(Path(vnx_dir) / "scripts" / "planning_cli.py"),
+        "objective", "reconcile",
+        "--project-id", project_id,
+        "--state-dir", state_dir,
+    ]
+    if auto_close:
+        cmd.append("--apply")
+    return cmd
 
 
 def _make_run_id() -> str:

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -394,6 +394,82 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
     return exit_code
 
 
+def cmd_objective_reconcile_review(args: argparse.Namespace) -> int:
+    """Record an operator review of a reconcile run (ok or false-candidate).
+
+    Appends a review record to reconcile_history.ndjson. Exits 2 when the
+    run_id is not found in the history file.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    run_id = args.run_id
+    reviewer = args.reviewer
+    verdict = args.verdict
+    note = getattr(args, "note", None) or ""
+
+    try:
+        objective_reconcile.record_review(state_dir, run_id, reviewer, verdict, note)
+    except ValueError as exc:
+        print(f"reconcile-review: {exc}", file=sys.stderr)
+        return 2
+    except OSError as exc:
+        print(f"reconcile-review: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Recorded review: run_id={run_id}  verdict={verdict}  reviewer={reviewer}")
+    return 0
+
+
+def cmd_objective_reconcile_streak(args: argparse.Namespace) -> int:
+    """Compute the consecutive clean-run streak for the VNX_AUTO_CLOSE flip decision.
+
+    A streak run is clean (gh==ok, zero unverified) with no false-candidate reviews.
+    The flip criterion is met when the streak has ≥1 confirmed candidate with an ok review.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+
+    result = objective_reconcile.compute_streak(state_dir, project_id)
+
+    if args.json:
+        print(json.dumps(result, indent=2, default=str))
+        return 0
+
+    streak = result["streak_length"]
+    flip = result["flip_criterion_met"]
+    reviewed_confirmed = result["has_reviewed_confirmed"]
+
+    print(f"\nvnx objective reconcile-streak (project '{project_id}')\n")
+    print(f"  streak_length         : {streak}")
+    print(f"  has_reviewed_confirmed: {reviewed_confirmed}")
+    print(f"  flip_criterion_met    : {flip}")
+
+    if flip:
+        print(
+            "\n  [ok] VNX_AUTO_CLOSE flip criterion met: the current streak has a "
+            "confirmed candidate with an ok review."
+        )
+    else:
+        if streak == 0:
+            print(
+                "\n  [!] no clean consecutive runs yet "
+                "(degraded run or false-candidate review breaks the streak)"
+            )
+        if not reviewed_confirmed:
+            print(
+                "\n  [!] no confirmed candidate with an ok review in the current streak"
+            )
+
+    if result["runs"]:
+        print(f"\n  streak runs (newest first):")
+        for r in result["runs"]:
+            conf = r.get("confirmed", 0)
+            rev_count = len(r.get("reviews", []))
+            print(f"    {r['run_id']}  confirmed={conf}  reviews={rev_count}")
+
+    print()
+    return 0
+
+
 def cmd_objective_drift(args: argparse.Namespace) -> int:
     """ADVISORY drift-gate: report tracks where declared phase != derived_status.
 
@@ -1348,7 +1424,7 @@ def _build_parser() -> argparse.ArgumentParser:
 
     p_drift = obj_sub.add_parser(
         "drift",
-        help="advisory drift-gate: report declared-vs-derived divergence (exit 0)",
+        help="advisory drift-gate: report declared-vs-derived divergence (exit 0); drift reports, `objective reconcile` fixes",
     )
     _common(p_drift)
     p_drift.set_defaults(func=cmd_objective_drift)
@@ -1419,6 +1495,28 @@ def _build_parser() -> argparse.ArgumentParser:
     p_add.add_argument("--horizon", choices=_HORIZON_ORDER, default=None)
     p_add.add_argument("--priority", default=None)
     p_add.set_defaults(func=cmd_objective_add)
+
+    p_rec_review = obj_sub.add_parser(
+        "reconcile-review",
+        help="record an operator review of a reconcile run (ok or false-candidate)",
+    )
+    _common(p_rec_review)
+    p_rec_review.add_argument("run_id", help="run_id from reconcile_history.ndjson")
+    p_rec_review.add_argument("--reviewer", required=True, help="reviewer name or id")
+    p_rec_review.add_argument(
+        "--verdict", required=True,
+        choices=["ok", "false-candidate"],
+        help="ok = candidate is correct; false-candidate = reconcile over-nominated this track",
+    )
+    p_rec_review.add_argument("--note", default="", help="optional review note")
+    p_rec_review.set_defaults(func=cmd_objective_reconcile_review)
+
+    p_rec_streak = obj_sub.add_parser(
+        "reconcile-streak",
+        help="compute the consecutive clean-run streak for the VNX_AUTO_CLOSE flip decision",
+    )
+    _common(p_rec_streak)
+    p_rec_streak.set_defaults(func=cmd_objective_reconcile_streak)
 
     # ------------------------------------------------------------------
     # deliverable subcommand (Phase 2)

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -922,3 +922,259 @@ def test_stamp_roundtrip_prref_with_double_quote_unchanged_guarded(tmp_path, mon
     assert summary["counts"].get("reopened_guard", 0) == 1
     assert summary["counts"].get("closed", 0) == 0
     assert _phase(sd, "T-rt6") == "active"
+
+
+# ---------------------------------------------------------------------------
+# D4 tests: review recording, streak computation, tick command builder
+# ---------------------------------------------------------------------------
+
+def _run_reconcile_and_get_run_id(sd: Path, tmp_path: Path, monkeypatch, pr_num: int, track_id: str) -> str:
+    """Helper: run reconcile in check mode and return the run_id."""
+    _seed_track(sd, track_id, phase="active", pr_ref=f"#{pr_num}")
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({pr_num: _merged_pr(pr_num)}),
+    )
+    summary, _ = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+    return summary["run_id"]
+
+
+class TestRecordReview:
+    """objective_reconcile.record_review — happy path and unknown-run_id refusal."""
+
+    def test_happy_path_appends_review_record(self, tmp_path, monkeypatch):
+        """record_review appends the review JSON line to reconcile_history.ndjson."""
+        sd = _build_db(tmp_path)
+        run_id = _run_reconcile_and_get_run_id(sd, tmp_path, monkeypatch, 5001, "T-rev1")
+
+        objective_reconcile.record_review(
+            sd, run_id, reviewer="alice", verdict="ok", note="looks good"
+        )
+
+        history_path = sd / "reconcile_history.ndjson"
+        lines = [l for l in history_path.read_text().splitlines() if l.strip()]
+        review_lines = [json.loads(l) for l in lines if json.loads(l).get("record") == "review"]
+        assert len(review_lines) == 1
+        r = review_lines[0]
+        assert r["run_id"] == run_id
+        assert r["reviewer"] == "alice"
+        assert r["verdict"] == "ok"
+        assert r["note"] == "looks good"
+        assert "ts" in r
+
+    def test_unknown_run_id_raises_value_error(self, tmp_path, monkeypatch):
+        """record_review raises ValueError when run_id is not in history."""
+        sd = _build_db(tmp_path)
+        # No reconcile run has been performed; history file does not exist.
+        with pytest.raises(ValueError, match="not found in reconcile history"):
+            objective_reconcile.record_review(
+                sd, "nonexistent-run-id", reviewer="bob", verdict="ok", note=""
+            )
+
+    def test_unknown_run_id_after_existing_runs(self, tmp_path, monkeypatch):
+        """Raises ValueError when run_id is absent even when history has other runs."""
+        sd = _build_db(tmp_path)
+        _run_reconcile_and_get_run_id(sd, tmp_path, monkeypatch, 5002, "T-rev2")
+
+        with pytest.raises(ValueError, match="not found in reconcile history"):
+            objective_reconcile.record_review(
+                sd, "wrong-run-id-xyz", reviewer="bob", verdict="false-candidate", note=""
+            )
+
+    def test_invalid_verdict_raises_value_error(self, tmp_path, monkeypatch):
+        """record_review raises ValueError for an invalid verdict value."""
+        sd = _build_db(tmp_path)
+        run_id = _run_reconcile_and_get_run_id(sd, tmp_path, monkeypatch, 5003, "T-rev3")
+
+        with pytest.raises(ValueError, match="invalid verdict"):
+            objective_reconcile.record_review(
+                sd, run_id, reviewer="carol", verdict="maybe", note=""
+            )
+
+    def test_review_record_does_not_count_as_run_id_source(self, tmp_path, monkeypatch):
+        """A review record's run_id does not satisfy the run_id existence check."""
+        sd = _build_db(tmp_path)
+        run_id = _run_reconcile_and_get_run_id(sd, tmp_path, monkeypatch, 5004, "T-rev4")
+
+        # Record a review so a "review" record with run_id exists in history.
+        objective_reconcile.record_review(sd, run_id, reviewer="dave", verdict="ok", note="")
+
+        # A made-up run_id must still fail even though history has review records.
+        with pytest.raises(ValueError, match="not found in reconcile history"):
+            objective_reconcile.record_review(
+                sd, "invented-id", reviewer="dave", verdict="ok", note=""
+            )
+
+
+class TestComputeStreak:
+    """objective_reconcile.compute_streak — streak logic and flip criterion."""
+
+    def _write_summary(self, sd: Path, run_id: str, *, gh: str = "ok", confirmed: int = 0, unverified: int = 0) -> None:
+        """Directly append a synthetic summary to reconcile_history.ndjson."""
+        history_path = sd / "reconcile_history.ndjson"
+        rec = {
+            "run_id": run_id,
+            "project_id": PROJECT_ID,
+            "mode": "check",
+            "started_at": "2026-07-04T10:00:00Z",
+            "finished_at": "2026-07-04T10:00:01Z",
+            "evidence_source_health": {"gh": gh},
+            "counts": {
+                "tracks": 1, "nominated": 1,
+                "confirmed": confirmed, "closed": 0,
+                "closed_sibling": 0, "open_pr": 0,
+                "unverified": unverified, "deferred": 0, "stale": 0,
+            },
+            "per_track": [],
+        }
+        with open(history_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+
+    def _write_review(self, sd: Path, run_id: str, verdict: str) -> None:
+        history_path = sd / "reconcile_history.ndjson"
+        rec = {"record": "review", "run_id": run_id, "reviewer": "test", "verdict": verdict, "note": "", "ts": "2026-07-04T10:01:00Z"}
+        with open(history_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(rec) + "\n")
+
+    def test_empty_history_returns_zero_streak(self, tmp_path):
+        sd = _build_db(tmp_path)
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 0
+        assert result["flip_criterion_met"] is False
+        assert result["runs"] == []
+
+    def test_single_clean_run_counts_in_streak(self, tmp_path):
+        sd = _build_db(tmp_path)
+        self._write_summary(sd, "run-A", gh="ok", unverified=0)
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 1
+
+    def test_degraded_run_resets_streak_to_zero(self, tmp_path):
+        """A degraded run (gh != ok) anywhere in the sequence resets the streak."""
+        sd = _build_db(tmp_path)
+        # Oldest to newest: clean, degraded, clean, clean
+        self._write_summary(sd, "run-old", gh="ok", unverified=0)
+        self._write_summary(sd, "run-deg", gh="absent", unverified=0)
+        self._write_summary(sd, "run-c1", gh="ok", unverified=0)
+        self._write_summary(sd, "run-c2", gh="ok", unverified=0)
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        # Only the two clean runs after the degraded run count; oldest degraded breaks it.
+        assert result["streak_length"] == 2
+        assert result["runs"][0]["run_id"] == "run-c2"
+        assert result["runs"][1]["run_id"] == "run-c1"
+
+    def test_unverified_run_resets_streak(self, tmp_path):
+        """A run with unverified > 0 resets the streak."""
+        sd = _build_db(tmp_path)
+        self._write_summary(sd, "run-unv", gh="ok", unverified=1)
+        self._write_summary(sd, "run-ok", gh="ok", unverified=0)
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 1
+        assert result["runs"][0]["run_id"] == "run-ok"
+
+    def test_false_candidate_review_breaks_streak(self, tmp_path):
+        """A false-candidate review on a run breaks the streak even if the run was clean."""
+        sd = _build_db(tmp_path)
+        self._write_summary(sd, "run-1", gh="ok", unverified=0)
+        self._write_review(sd, "run-1", verdict="false-candidate")
+        self._write_summary(sd, "run-2", gh="ok", unverified=0)
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        # run-2 is clean and unreviewd; run-1 has a false-candidate → breaks streak.
+        assert result["streak_length"] == 1
+        assert result["runs"][0]["run_id"] == "run-2"
+
+    def test_ok_review_without_confirmed_does_not_meet_flip_criterion(self, tmp_path):
+        """Even with an ok review, flip criterion requires confirmed > 0."""
+        sd = _build_db(tmp_path)
+        self._write_summary(sd, "run-X", gh="ok", unverified=0, confirmed=0)
+        self._write_review(sd, "run-X", verdict="ok")
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 1
+        assert result["has_reviewed_confirmed"] is False
+        assert result["flip_criterion_met"] is False
+
+    def test_flip_criterion_met_when_ok_reviewed_confirmed(self, tmp_path):
+        """Flip criterion met: streak has ≥1 confirmed candidate with ok review."""
+        sd = _build_db(tmp_path)
+        self._write_summary(sd, "run-Y", gh="ok", unverified=0, confirmed=1)
+        self._write_review(sd, "run-Y", verdict="ok")
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 1
+        assert result["has_reviewed_confirmed"] is True
+        assert result["flip_criterion_met"] is True
+
+    def test_flip_criterion_requires_reviewed_run_in_current_streak(self, tmp_path):
+        """Reviewed confirmed run before the degraded gap does not count for current streak."""
+        sd = _build_db(tmp_path)
+        # Oldest: clean + confirmed + ok review; then degraded; then clean (no review)
+        self._write_summary(sd, "run-before", gh="ok", unverified=0, confirmed=1)
+        self._write_review(sd, "run-before", verdict="ok")
+        self._write_summary(sd, "run-deg", gh="absent", unverified=0)
+        self._write_summary(sd, "run-after", gh="ok", unverified=0, confirmed=0)
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 1
+        assert result["runs"][0]["run_id"] == "run-after"
+        assert result["has_reviewed_confirmed"] is False
+        assert result["flip_criterion_met"] is False
+
+    def test_project_id_scoping(self, tmp_path):
+        """compute_streak only counts runs for the requested project_id."""
+        sd = _build_db(tmp_path)
+        # Write a run for a different project.
+        history_path = sd / "reconcile_history.ndjson"
+        other_run = {
+            "run_id": "run-other-proj",
+            "project_id": "other-project",
+            "mode": "check",
+            "started_at": "2026-07-04T10:00:00Z",
+            "finished_at": "2026-07-04T10:00:01Z",
+            "evidence_source_health": {"gh": "ok"},
+            "counts": {"tracks": 1, "nominated": 1, "confirmed": 1, "closed": 0,
+                       "closed_sibling": 0, "open_pr": 0, "unverified": 0, "deferred": 0, "stale": 0},
+            "per_track": [],
+        }
+        with open(history_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(other_run) + "\n")
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 0, "other-project run must not count"
+
+
+class TestBuildTickCommand:
+    """objective_reconcile.build_tick_command — command construction without VNX_AUTO_CLOSE."""
+
+    def test_check_mode_no_apply_when_auto_close_absent(self, tmp_path):
+        """VNX_AUTO_CLOSE absent (auto_close=False) → --apply not in command."""
+        cmd = objective_reconcile.build_tick_command(
+            str(tmp_path), "vnx-dev", str(tmp_path / "state"), auto_close=False,
+        )
+        assert "--apply" not in cmd
+        assert "objective" in cmd
+        assert "reconcile" in cmd
+
+    def test_apply_appended_when_auto_close_true(self, tmp_path):
+        """auto_close=True → --apply present in command."""
+        cmd = objective_reconcile.build_tick_command(
+            str(tmp_path), "vnx-dev", str(tmp_path / "state"), auto_close=True,
+        )
+        assert "--apply" in cmd
+
+    def test_project_id_and_state_dir_in_command(self, tmp_path):
+        """--project-id and --state-dir are always present."""
+        sd = str(tmp_path / "state")
+        cmd = objective_reconcile.build_tick_command(
+            str(tmp_path), "my-project", sd, auto_close=False,
+        )
+        assert "--project-id" in cmd
+        assert "my-project" in cmd
+        assert "--state-dir" in cmd
+        assert sd in cmd


### PR DESCRIPTION
## Summary

D4 of the `status-git-reality-reconcile` track (plan rev 4): the continuous loop, advisory-first.

- `_maybe_objective_reconcile` supervisor tick in `scripts/lib/dispatcher_supervisor_ticks.sh` (the `_maybe_runtime_supervise` pattern; `VNX_OBJECTIVE_RECONCILE_INTERVAL` default 900s; only under `VNX_SUPERVISOR_MODE=unified`; ordered last). Check-mode always; `--apply` ONLY when `VNX_AUTO_CLOSE=1` (default OFF).
- `objective reconcile-review <run_id>` records the operator review as an append to `reconcile_history.ndjson` (refuses unknown run-ids); `objective reconcile-streak` computes the documented flip criterion from disk: consecutive clean runs (gh ok, zero unverified, zero false-candidate reviews) plus the ≥1-reviewed-confirmed requirement. Degraded runs reset the streak.
- Docs: post-merge reconcile step in the DISPATCH_RULES merge sequence; tick + flag semantics in UNIFIED_SUPERVISOR; drift-help cross-ref ("drift reports; reconcile fixes").

## Verification

196 passed (independently re-run by the orchestrator in a clean worktree at the commit).

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-d4-wiring`, claude-sonnet-4-6). Plan: `claudedocs/2026-07-03-status-git-reality-reconcile-PLAN.md` (rev 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC