### PR TITLE
docs(reconcile): closed-loop backward closure — reconcile, reopen valve, operational notes [D5]

### DIFF
--- a/docs/core/STATE_FABRIC.md
+++ b/docs/core/STATE_FABRIC.md
@@ -63,9 +63,11 @@ system actor) or an explicit human close (`vnx objective close --apply --approva
    merged` (10-min cache). No local receipt is required — git reality suffices.
 6. **Reconcile (derived refresh).** `track_reconciler` computes `derived_status`
    independently of `phase`: blocker OI unresolved → `blocked`; unmet dependency
-   → `blocked`; all dispatches terminal AND all PRs in `pr_ref` merged → `done`.
-   This runs in both check and apply mode; it only writes `tracks.derived_status`,
-   never `tracks.phase`.
+   → `blocked`; all dispatches terminal → `done` when any of: no `pr_ref` set,
+   a `pr_merged` coordination event exists, declared phase is already `done`, or
+   all parsed PRs are confirmed merged via local evidence sources. This runs in
+   both check and apply mode; it only writes `tracks.derived_status`, never
+   `tracks.phase`.
 7. **See the drift.** `vnx objective drift` reports every track where
    `phase ≠ derived_status` — the list of "done in reality, not yet closed."
    `objective reconcile` (default: check mode) shows what *would* close.
@@ -79,8 +81,7 @@ system actor) or an explicit human close (`vnx objective close --apply --approva
      `parked` tracks are never nominated.
    - **Human gate**: `vnx objective close <id> --apply --approval-id <id>` walks
      the phase to `done` along the shortest legal path, stamping `approval_id` +
-     reason in `track_phase_history`. Requires `derived_status='done'` unless
-     invoked with gh evidence from the reconciler.
+     reason in `track_phase_history`. Requires `derived_status='done'`.
 
    Either path writes to `track_phase_history`. ROADMAP stays untouched; views
    regenerate.

--- a/docs/core/STATE_FABRIC.md
+++ b/docs/core/STATE_FABRIC.md
@@ -32,8 +32,10 @@ rewritten (ADR-005). The past is evidence: it is what governance verifies agains
   `related`); an unresolved `blocks` item keeps a track out of `done`.
 
 The split between **declared** `phase` and **derived** `derived_status` is the
-core of drift control: the reconciler may compute "this is done," but advancing
-the declared phase to `done` is always a human-gated act.
+core of drift control: the reconciler computes "this is done" independently of
+whether declared phase has caught up. Declared phase advances to `done` via two
+paths: the automated reconcile loop (`vnx objective reconcile --apply`, gh-verified,
+system actor) or an explicit human close (`vnx objective close --apply --approval-id`).
 
 ### Future — authored intent
 `ROADMAP.yaml` is the only hand-edited planning surface. `FEATURE_PLAN.md` and
@@ -59,32 +61,48 @@ the declared phase to `done` is always a human-gated act.
    in order: `pr_merged.ndjson` events → `t0_receipts.ndjson` → ROADMAP
    `pr_queue` status → (opt-in `VNX_RECONCILE_GIT`) live `gh pr list --state
    merged` (10-min cache). No local receipt is required — git reality suffices.
-6. **Reconcile.** `track_reconciler` computes `derived_status` independently of
-   `phase`: blocker open → `blocked`; unmet dependency → `blocked`; all
-   dispatches terminal AND PR merged → `done`. This is advisory; it never touches
-   `phase`.
+6. **Reconcile (derived refresh).** `track_reconciler` computes `derived_status`
+   independently of `phase`: blocker OI unresolved → `blocked`; unmet dependency
+   → `blocked`; all dispatches terminal AND all PRs in `pr_ref` merged → `done`.
+   This runs in both check and apply mode; it only writes `tracks.derived_status`,
+   never `tracks.phase`.
 7. **See the drift.** `vnx objective drift` reports every track where
    `phase ≠ derived_status` — the list of "done in reality, not yet closed."
-8. **Close (your gate).** `vnx objective close <id> --apply --approval-id <id>`
-   walks the phase to `done` along the shortest legal path, atomically per step,
-   stamping `approval_id` + reason in `track_phase_history`. Only a track whose
-   `derived_status='done'` can close. ROADMAP stays untouched; the views
+   `objective reconcile` (default: check mode) shows what *would* close.
+8. **Close — two paths:**
+   - **Automated loop** (recommended): `vnx objective reconcile --project-id <pid>
+     --apply` nominates every eligible track (non-empty `pr_ref`, declared phase
+     not `done`/`parked`), verifies each PR with `gh pr view --json state,mergedAt`,
+     and calls `close_track_if_done(actor=system, approval_id=auto-reconcile-<run-id>)`
+     for every CONFIRMED candidate. gh absent or degraded → exit 3, nothing closes
+     (fail-closed). Blocker OIs and non-done dependencies refuse at close time;
+     `parked` tracks are never nominated.
+   - **Human gate**: `vnx objective close <id> --apply --approval-id <id>` walks
+     the phase to `done` along the shortest legal path, stamping `approval_id` +
+     reason in `track_phase_history`. Requires `derived_status='done'` unless
+     invoked with gh evidence from the reconciler.
+
+   Either path writes to `track_phase_history`. ROADMAP stays untouched; views
    regenerate.
 
 The only place structural drift can open is between step 6 (derived done) and
-step 8 (you close). That window is deliberate — it is your human gate — and
-`objective drift` keeps it visible so it never sits silently.
+step 8 (close). That window is deliberate — it is the boundary between advisory
+evidence and authoritative state — and `objective drift` keeps it visible so it
+never sits silently. The reconcile loop (`--apply`) collapses the window
+automatically when wired into a cron or post-merge hook.
 
 ## Drift-prevention mechanisms
 
 - **Write separation.** `phase` (declared) and `derived_status` (computed) are
   different columns with different writers. The reconciler can never silently
   flip your declared status.
-- **Phase immutability.** `done` is terminal for auto-close; the reconciler
-  never calls `done → active`. The operator-only reopen edge (`objective reopen
-  --approval-id --reason`) exists but stamps the pr_ref at reopen time — the
-  re-close guard disarms auto-close on the next reconcile run until the pr_ref
-  changes.
+- **Phase immutability.** `done` is terminal for auto-close; neither the
+  reconciler nor `close_track_if_done` ever touches a track already at `done`.
+  The operator reopen valve (`objective reopen --approval-id --reason`) is the
+  only `done → active` edge; it stamps the current `pr_ref` in the history row.
+  The re-close guard reads that stamp on every subsequent reconcile run and skips
+  the track (verdict `reopened_guard`) as long as `pr_ref` is unchanged — re-close
+  is re-armed only when the operator sets a new `pr_ref`.
 - **Multi-source merge detection.** Four evidence sources mean a PR merged any
   way (receipt, ledger, ROADMAP, or raw `gh pr merge`) still grounds the track.
 - **Blocker + dependency gating.** Open `blocks` items and unmet `depends_on`
@@ -92,8 +110,11 @@ step 8 (you close). That window is deliberate — it is your human gate — and
 - **Generated views + CI guard.** `FEATURE_PLAN.md` / `PR_QUEUE.md` are generated
   and drift-checked; status lives in one place (ROADMAP `launch_state` +
   `features[]`).
-- **Human-gated closure.** Advancing declared phase to `done` requires an
-  operator `approval_id` — the last set is always human.
+- **Closure authority.** Declared phase advances to `done` via two paths: the
+  automated reconcile loop (system actor, gh-verified evidence, `approval_id`
+  stamped `auto-reconcile-<run-id>`) or a human `objective close` (explicit
+  `approval_id`). Both write to `track_phase_history`; neither can bypass the
+  blocker-OI and dependency gates.
 
 ## Automated vs human-gated
 
@@ -105,30 +126,31 @@ step 8 (you close). That window is deliberate — it is your human gate — and
 | Dispatch created/run | Auto | ready-promotion (you) |
 | PR merged | Auto (git) | — |
 | Merge detected / derived_status | Auto (reconciler) | advisory only |
-| Track closed (phase → done) | **Human-gated** | `approval_id` |
+| Track closed — reconcile loop | Auto (`--apply`) | gh evidence + system `approval_id` |
+| Track closed — human gate | Manual | explicit operator `approval_id` |
 
 ## Known gaps / roadmap
 
-Two ergonomics would tighten the fabric further (candidate tracks, not yet built):
+One ergonomic improvement would tighten the fabric further (candidate track, not yet built):
 
 1. **`vnx open-item add --track <id> --title … --severity blocker`** — a single
    command that writes straight to `track_open_items`, so a new issue is captured
    the moment you hit it. Today it is two steps (`open_items_manager add` →
    `import_open_items_to_tracks`).
-2. **Multi-PR `ALL`-merged closure.** A track that lists several PRs in its
-   `pr_queue` currently derives `done` when **any** one merges
-   (`_parse_pr_numbers(pr_ref) & merged_pr_numbers`). For a feature that genuinely
-   needs all of them, `done` should require **all** required `pr_queue` entries
-   merged. The human close-gate catches the premature case today, but the derived
-   signal is looser than ideal.
+
+The multi-PR ALL-merged gap (any vs all) was fixed in the D1 derivation update:
+both the reconcile loop (`_decide_candidate`) and `track_reconciler` (`_parse_pr_numbers`
+subset check) require every PR in `pr_ref` to be MERGED before deriving or closing as done.
 
 ## Where the mechanisms live
 
 - Track DAL + phase state machine: `scripts/lib/tracks.py`
-- Reconciler + 4-source merge detection: `scripts/lib/track_reconciler.py`
-- `vnx objective list|show|sync|drift|close`: `scripts/planning_cli.py`
+- Derived-status reconciler + 4-source merge detection: `scripts/lib/track_reconciler.py`
+- Batch auto-close reconcile loop: `scripts/lib/objective_reconcile.py`
+- `vnx objective list|show|sync|drift|close|reconcile|reopen`: `scripts/planning_cli.py`
 - ROADMAP → tracks projection: `scripts/seed_tracks_from_roadmap.py`
 - Generated views: `scripts/build_feature_plan.py`, `scripts/build_pr_queue.py`
+- Operational guide + known behaviours: `docs/operations/OBJECTIVE_RECONCILE.md`
 - Receipt / audit ledger contract: ADR-005, `docs/core/11_RECEIPT_FORMAT.md`
 - Tenant scoping on all of the above: ADR-007
 - Dispatch + intelligence flow this feeds: `docs/core/DISPATCH_AND_INTELLIGENCE_ARCHITECTURE.md`

--- a/docs/operations/OBJECTIVE_RECONCILE.md
+++ b/docs/operations/OBJECTIVE_RECONCILE.md
@@ -52,8 +52,10 @@ vnx objective reconcile --project-id <pid> --apply --allow-closed-siblings
    states are re-checked on every run.
 5. **Close** (apply only) — `close_track_if_done(actor=system, approval_id=
    auto-reconcile-<run-id>)` for each CONFIRMED candidate, with the gh evidence
-   snapshot. Performs close-time revalidation before any DB write (blocker OIs,
-   dependency phases, pr_ref unchanged).
+   snapshot. Performs close-time revalidation before any DB write: `pr_ref`
+   unchanged, no unresolved blocker OIs, dependency phases all `done`, and every
+   parsed PR in the gh evidence snapshot still MERGED or an allowed CLOSED
+   sibling (when `--allow-closed-siblings` was passed).
 6. **Summary** — atomic write to `reconcile_summary.json` + NDJSON append to
    `reconcile_history.ndjson`.
 
@@ -63,13 +65,13 @@ vnx objective reconcile --project-id <pid> --apply --allow-closed-siblings
 
 | Verdict | Meaning |
 |---|---|
-| `CONFIRMED` | All PRs in `pr_ref` are MERGED; eligible for close |
+| `CONFIRMED` | All PRs in `pr_ref` are MERGED; eligible for close. With `--allow-closed-siblings`, also CONFIRMED when ≥1 PR is MERGED and all remaining PRs are CLOSED (unmerged) |
 | `closed_sibling` | A PR is CLOSED (not merged) alongside a MERGED one; skipped unless `--allow-closed-siblings` |
 | `open_pr` | At least one PR is still OPEN |
 | `unverified` | gh call failed or returned an unexpected state |
 | `deferred` | Would exceed the `--max-gh-calls` cap (default 50); skipped this run |
 | `reopened_guard` | Track was reopened (`done → active`) and `pr_ref` is unchanged since the reopen — skip to prevent immediate re-close |
-| `stale_candidate` | Close-time revalidation found a mismatch (pr_ref changed, blocker OI appeared, or dependency not done); zero DB writes |
+| `stale_candidate` | Close-time revalidation found a mismatch (`pr_ref` changed, blocker OI appeared, dependency not done, or gh evidence state changed); zero DB writes |
 | `closed` | Phase walked to `done` (apply mode only) |
 
 ---
@@ -79,7 +81,7 @@ vnx objective reconcile --project-id <pid> --apply --allow-closed-siblings
 | Code | Meaning |
 |---|---|
 | `0` | Clean: gh available, zero unverified tracks |
-| `2` | Usage or state error (unknown project, unreadable state dir, migration missing) |
+| `2` | Repo-root resolution failure, or missing `derived_status` migration (migration 0028 must be applied first) |
 | `3` | Degraded: gh absent / auth-failed / timed out, OR ≥1 unverified skip |
 
 Exit 3 is the fail-closed path: if gh is unavailable, **nothing closes**. Re-run
@@ -91,12 +93,18 @@ when gh is healthy.
 
 - **gh degraded → exit 3, zero closes.** Auth failure, timeout, or absence all
   produce exit 3. The summary records the reason; no track advances.
+- **`gh` authentication and repo-root scope.** `gh` must be authenticated and
+  `--repo-root` (or the auto-resolved CWD) must point to the intended GitHub
+  remote. A wrong repo root silently looks up PR numbers in the wrong
+  repository; `gh auth status` returning exit 0 is a prerequisite for any run.
 - **Blocker OIs refuse.** A track with an unresolved `link_type='blocks'` open
   item returns `stale_candidate` at close time, even if all PRs are MERGED.
 - **Unmet dependencies refuse.** Every `track_dependencies` row must have a
   dependency whose declared `phase='done'`; any non-done dependency → `stale_candidate`.
-- **`parked` never touched.** Parked tracks are excluded at nomination; they
-  require an explicit `objective reopen` before the reconciler will consider them.
+- **`parked` never touched.** Parked tracks are excluded at nomination. A parked
+  track must be moved out of `parked` (to `queued` or `active`) before the
+  reconciler will nominate it. `objective reopen` applies only to `done` tracks
+  (the `done → active` edge); it cannot move a `parked` track.
 - **Re-close guard.** After `objective reopen` (`done → active`), the history
   row stamps the current `pr_ref`. The next reconcile run skips the track if
   `pr_ref` is unchanged (verdict `reopened_guard`). A new `pr_ref` re-arms the
@@ -117,6 +125,11 @@ This writes a `done → active` history row. The reconciler reads the stamped
 `pr_ref` from that row on every subsequent run. Set a new `pr_ref` on the track
 to re-arm auto-close; leave it unchanged to keep the guard active indefinitely.
 
+**Sentinel note:** when `pr_ref` is empty at reopen time, the guard stamps `-`
+as a sentinel. Clearing `pr_ref` after a reopen therefore re-arms auto-close
+(the current `pr_ref` no longer matches the stamped `-`), so a subsequent
+reconcile run will nominate the track again on the next eligible PR.
+
 **Drift view before and after reopen:**
 - `objective drift` shows the track as drifted (declared=active, derived=done)
   until the new PR merges.
@@ -128,9 +141,10 @@ to re-arm auto-close; leave it unchanged to keep the guard active indefinitely.
 
 ### `stale_candidate` without a visible reason field
 
-The summary entry for a stale candidate shows `action=stale_candidate` but does
-not embed a human-readable reason string — the revalidation returns early before
-building one. To diagnose:
+A CONFIRMED nomination that fails close-time revalidation appears in the
+per-track summary with `verdict=CONFIRMED` and `close_result=stale_candidate`;
+no human-readable reason string is embedded — the revalidation returns early
+before building one. To diagnose:
 
 1. Check `track_phase_history` for that `track_id` — a recent `done → active`
    row means the re-close guard fired (confirm by comparing the stamped `pr_ref`).
@@ -142,15 +156,15 @@ The first matching condition is the actual rejection reason.
 ### Intra-run dependency ordering: re-run to converge
 
 When track B depends on track A, and both are nominated in the same reconcile
-run, the dependency check runs against the declared phase at nomination time.
-If track A closes in step 5 of the same run, track B's close-time revalidation
-still sees A's old phase (the DB write for A just completed) — the read in
-`close_track_if_done` hits the already-committed state, so B may close in the
-same run if the dependency check happens after A's commit.
+run, `close_track_if_done` reads B's dependency phases fresh from the DB at
+close time — not from the nomination snapshot. Whether B can close in the same
+pass depends on processing order: if A is committed first, B's fresh DB read
+sees `phase='done'` and B may close; if B is processed before A, the fresh
+read still sees A's old phase and B gets `stale_candidate`.
 
-In practice, intra-run ordering is not guaranteed: if B is processed before A,
-it gets `stale_candidate`; re-running the reconcile converges B on the next pass
-(idempotent — A is now `done`, B's CONFIRMED status holds).
+In practice, processing order is not guaranteed: re-running the reconcile
+converges B on the next pass (idempotent — A is now `done`, B's CONFIRMED
+status holds).
 
 ### Single-repo scope per project
 

--- a/docs/operations/OBJECTIVE_RECONCILE.md
+++ b/docs/operations/OBJECTIVE_RECONCILE.md
@@ -1,0 +1,203 @@
+# OBJECTIVE_RECONCILE — operational guide
+
+`vnx objective reconcile` is the batch git-grounded auto-close loop for the
+tracks layer. It closes tracks whose PRs are verified merged on GitHub, writing
+to `track_phase_history` with a system actor — no human approval-id needed.
+
+The STATE_FABRIC overview is in `docs/core/STATE_FABRIC.md`; this document
+covers operational usage, exit codes, and known behaviours from production.
+
+---
+
+## Running the reconcile loop
+
+**Check mode (default):** refreshes `derived_status` and `pr_state_cache` for
+every nominated track, reports what *would* close, writes nothing to `phase`.
+
+```bash
+vnx objective reconcile --project-id <pid>
+```
+
+**Apply mode:** same as check, plus closes every CONFIRMED candidate.
+
+```bash
+vnx objective reconcile --project-id <pid> --apply
+```
+
+**Repo root override** (`pr_ref` carries no repo path; defaults to CWD):
+
+```bash
+vnx objective reconcile --project-id <pid> --apply --repo-root /path/to/repo
+```
+
+**Closed-sibling allowance** (a CLOSED PR alongside ≥1 MERGED PR is acceptable):
+
+```bash
+vnx objective reconcile --project-id <pid> --apply --allow-closed-siblings
+```
+
+---
+
+## Steps per run (in order)
+
+1. **Provenance sweep** — best-effort; never blocks remaining steps.
+2. **Derived refresh** — `reconcile_all_tracks` persists `derived_status` for
+   every track in the project. Runs in both check and apply mode.
+3. **Nomination** — tracks with a non-empty `pr_ref` whose declared phase is not
+   `done` or `parked`. Window-independent: every qualifying track is nominated
+   on every run regardless of when it was last checked.
+4. **Verification** — `gh pr view <n> --json state,mergedAt` per PR number.
+   MERGED results are cached persistently in `pr_state_cache.json` (keyed by
+   repo, scoped so repo-A cache cannot satisfy a repo-B lookup). Non-MERGED
+   states are re-checked on every run.
+5. **Close** (apply only) — `close_track_if_done(actor=system, approval_id=
+   auto-reconcile-<run-id>)` for each CONFIRMED candidate, with the gh evidence
+   snapshot. Performs close-time revalidation before any DB write (blocker OIs,
+   dependency phases, pr_ref unchanged).
+6. **Summary** — atomic write to `reconcile_summary.json` + NDJSON append to
+   `reconcile_history.ndjson`.
+
+---
+
+## Verdict taxonomy
+
+| Verdict | Meaning |
+|---|---|
+| `CONFIRMED` | All PRs in `pr_ref` are MERGED; eligible for close |
+| `closed_sibling` | A PR is CLOSED (not merged) alongside a MERGED one; skipped unless `--allow-closed-siblings` |
+| `open_pr` | At least one PR is still OPEN |
+| `unverified` | gh call failed or returned an unexpected state |
+| `deferred` | Would exceed the `--max-gh-calls` cap (default 50); skipped this run |
+| `reopened_guard` | Track was reopened (`done → active`) and `pr_ref` is unchanged since the reopen — skip to prevent immediate re-close |
+| `stale_candidate` | Close-time revalidation found a mismatch (pr_ref changed, blocker OI appeared, or dependency not done); zero DB writes |
+| `closed` | Phase walked to `done` (apply mode only) |
+
+---
+
+## Exit codes
+
+| Code | Meaning |
+|---|---|
+| `0` | Clean: gh available, zero unverified tracks |
+| `2` | Usage or state error (unknown project, unreadable state dir, migration missing) |
+| `3` | Degraded: gh absent / auth-failed / timed out, OR ≥1 unverified skip |
+
+Exit 3 is the fail-closed path: if gh is unavailable, **nothing closes**. Re-run
+when gh is healthy.
+
+---
+
+## Fail-closed properties
+
+- **gh degraded → exit 3, zero closes.** Auth failure, timeout, or absence all
+  produce exit 3. The summary records the reason; no track advances.
+- **Blocker OIs refuse.** A track with an unresolved `link_type='blocks'` open
+  item returns `stale_candidate` at close time, even if all PRs are MERGED.
+- **Unmet dependencies refuse.** Every `track_dependencies` row must have a
+  dependency whose declared `phase='done'`; any non-done dependency → `stale_candidate`.
+- **`parked` never touched.** Parked tracks are excluded at nomination; they
+  require an explicit `objective reopen` before the reconciler will consider them.
+- **Re-close guard.** After `objective reopen` (`done → active`), the history
+  row stamps the current `pr_ref`. The next reconcile run skips the track if
+  `pr_ref` is unchanged (verdict `reopened_guard`). A new `pr_ref` re-arms the
+  guard — the operator signals readiness by setting a new PR reference.
+
+---
+
+## Operator reopen valve
+
+To reopen a closed track for additional work:
+
+```bash
+vnx objective reopen <track-id> --project-id <pid> \
+  --approval-id <your-id> --reason "reason text"
+```
+
+This writes a `done → active` history row. The reconciler reads the stamped
+`pr_ref` from that row on every subsequent run. Set a new `pr_ref` on the track
+to re-arm auto-close; leave it unchanged to keep the guard active indefinitely.
+
+**Drift view before and after reopen:**
+- `objective drift` shows the track as drifted (declared=active, derived=done)
+  until the new PR merges.
+- `objective reconcile` shows `reopened_guard` until `pr_ref` changes.
+
+---
+
+## Known behaviours (from first production runs, 2026-07-04)
+
+### `stale_candidate` without a visible reason field
+
+The summary entry for a stale candidate shows `action=stale_candidate` but does
+not embed a human-readable reason string — the revalidation returns early before
+building one. To diagnose:
+
+1. Check `track_phase_history` for that `track_id` — a recent `done → active`
+   row means the re-close guard fired (confirm by comparing the stamped `pr_ref`).
+2. Check `track_open_items` for unresolved `link_type='blocks'` rows.
+3. Check `track_dependencies` for dependencies with `phase != 'done'`.
+
+The first matching condition is the actual rejection reason.
+
+### Intra-run dependency ordering: re-run to converge
+
+When track B depends on track A, and both are nominated in the same reconcile
+run, the dependency check runs against the declared phase at nomination time.
+If track A closes in step 5 of the same run, track B's close-time revalidation
+still sees A's old phase (the DB write for A just completed) — the read in
+`close_track_if_done` hits the already-committed state, so B may close in the
+same run if the dependency check happens after A's commit.
+
+In practice, intra-run ordering is not guaranteed: if B is processed before A,
+it gets `stale_candidate`; re-running the reconcile converges B on the next pass
+(idempotent — A is now `done`, B's CONFIRMED status holds).
+
+### Single-repo scope per project
+
+`pr_ref` stores only PR numbers, not repo identifiers. The reconcile loop calls
+`gh pr view <n>` against the repo at `--repo-root` (defaults to CWD). A
+multi-repo project must run the reconcile separately per repo, with the matching
+`--repo-root`. The persistent `pr_state_cache.json` is keyed by repo remote URL
+(or resolved path when no remote), so cache entries from different repos are
+isolated.
+
+---
+
+## First production backfill — worked example (2026-07-04)
+
+On 2026-07-04 the first `vnx objective reconcile --project-id vnx-dev --apply`
+run against the `vnx-orchestration` repo closed 6 tracks automatically and
+refused 1:
+
+- **6 tracks closed:** `gh pr view` returned `MERGED` for all PRs in each
+  `pr_ref`; `close_track_if_done` returned `action=closed` for each.
+- **1 refused:** Track had a queued dependency whose declared phase was not yet
+  `done`. The revalidation returned `stale_candidate`. A second run after the
+  dependency closed converged the track.
+
+This demonstrates the fail-closed design: a track whose dependency is not yet
+confirmed closed is never silently advanced, even when its own PRs are merged.
+
+---
+
+## Pairing with `objective drift`
+
+`objective drift` reports declared-vs-derived divergence (what is stale in the
+view). `objective reconcile` (check mode) shows what the auto-close would do.
+`objective reconcile --apply` acts on it.
+
+The typical operator cadence:
+
+```bash
+# 1. See what is stale
+vnx objective drift --project-id <pid>
+
+# 2. Confirm what would close
+vnx objective reconcile --project-id <pid>
+
+# 3. Auto-close confirmed tracks
+vnx objective reconcile --project-id <pid> --apply
+```
+
+Wire `reconcile --apply` into a cron or post-merge hook to keep the fabric
+current without manual steps.


### PR DESCRIPTION
## Summary

D5 of the `status-git-reality-reconcile` track (plan rev 4): the documentation catch-up now the loop is real.

- `docs/core/STATE_FABRIC.md`: the backward-closure section no longer says a human closes every track — it describes the reconcile loop (window-independent nomination → exact `gh pr view` verification → close through the single-writer with actor=system and the auto-reconcile approval-id), the fail-closed properties (degraded gh = exit 3 and nothing closes; blocker OIs, non-done deps and parked always refuse), the operator reopen valve with the re-close guard, the check-mode write boundary, and the drift-reports/reconcile-fixes pairing.
- New `docs/operations/OBJECTIVE_RECONCILE.md`: operator guide including the two known behaviours from the first production runs (stale outcomes carry no reason field yet; intra-run dependency ordering needs a second idempotent pass), the single-repo scope, and the 2026-07-04 backfill as a worked example (6 closed, 1 refused on a queued dependency).

## Verification

Docs-only. Claim→code map in the dispatch report (every statement verified against `objective_reconcile.py` / `track_reconciler.py`); sanity pytest run green.

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-d5-docs`, claude-sonnet-4-6). Plan: `claudedocs/2026-07-03-status-git-reality-reconcile-PLAN.md` (rev 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC