### PR TITLE
fix(reconcile): flip criterion requires 7 consecutive clean runs [Tier-2 finding]

### DIFF
--- a/docs/operations/UNIFIED_SUPERVISOR.md
+++ b/docs/operations/UNIFIED_SUPERVISOR.md
@@ -230,7 +230,7 @@ vnx objective reconcile-streak --project-id <pid>
 ```
 
 The flip criterion requires:
-- A consecutive streak of clean runs (gh=ok, zero unverified, no false-candidate reviews).
+- A consecutive streak of at least 7 clean runs (gh=ok, zero unverified, no false-candidate reviews).
 - At least one run in the streak has a confirmed candidate with an `ok` operator review.
 
 Record operator reviews with:

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -46,6 +46,9 @@ _HISTORY_FILE = "reconcile_history.ndjson"
 _SKIP_PHASES: FrozenSet[str] = frozenset({"done", "parked"})
 _VALID_VERDICTS: FrozenSet[str] = frozenset({"ok", "false-candidate"})
 
+# Number of consecutive clean advisory runs required before VNX_AUTO_CLOSE may flip.
+FLIP_STREAK_REQUIRED = 7
+
 
 def _now_utc() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
@@ -132,12 +135,14 @@ def compute_streak(
     A degraded run (gh != "ok", unverified > 0, or any false-candidate review)
     breaks the streak.
 
-    The VNX_AUTO_CLOSE flip criterion is met when the streak has ≥1 run with
-    ≥1 confirmed candidate that received an "ok" review.
+    The VNX_AUTO_CLOSE flip criterion is met when the streak has at least
+    FLIP_STREAK_REQUIRED (7) consecutive clean runs AND at least one run in
+    the streak has a confirmed candidate that received an "ok" review.
 
     Returns:
       {
         "streak_length": int,
+        "required_streak": int,    # always FLIP_STREAK_REQUIRED (7)
         "has_reviewed_confirmed": bool,
         "flip_criterion_met": bool,
         "runs": [...],     # run entries in streak (newest first)
@@ -202,10 +207,11 @@ def compute_streak(
             has_reviewed_confirmed = True
 
     streak_length = len(streak_runs)
-    flip_criterion_met = streak_length >= 1 and has_reviewed_confirmed
+    flip_criterion_met = streak_length >= FLIP_STREAK_REQUIRED and has_reviewed_confirmed
 
     return {
         "streak_length": streak_length,
+        "required_streak": FLIP_STREAK_REQUIRED,
         "has_reviewed_confirmed": has_reviewed_confirmed,
         "flip_criterion_met": flip_criterion_met,
         "runs": streak_runs,

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -423,7 +423,8 @@ def cmd_objective_reconcile_streak(args: argparse.Namespace) -> int:
     """Compute the consecutive clean-run streak for the VNX_AUTO_CLOSE flip decision.
 
     A streak run is clean (gh==ok, zero unverified) with no false-candidate reviews.
-    The flip criterion is met when the streak has ≥1 confirmed candidate with an ok review.
+    The flip criterion is met when the streak has ≥7 clean runs AND ≥1 confirmed
+    candidate with an ok review in the current streak.
     """
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
@@ -435,24 +436,30 @@ def cmd_objective_reconcile_streak(args: argparse.Namespace) -> int:
         return 0
 
     streak = result["streak_length"]
+    required = result["required_streak"]
     flip = result["flip_criterion_met"]
     reviewed_confirmed = result["has_reviewed_confirmed"]
 
     print(f"\nvnx objective reconcile-streak (project '{project_id}')\n")
-    print(f"  streak_length         : {streak}")
+    print(f"  streak_length         : {streak}/{required}")
     print(f"  has_reviewed_confirmed: {reviewed_confirmed}")
     print(f"  flip_criterion_met    : {flip}")
 
     if flip:
         print(
-            "\n  [ok] VNX_AUTO_CLOSE flip criterion met: the current streak has a "
-            "confirmed candidate with an ok review."
+            "\n  [ok] VNX_AUTO_CLOSE flip criterion met: streak reached "
+            f"{required} consecutive clean runs with a confirmed ok-reviewed candidate."
         )
     else:
         if streak == 0:
             print(
                 "\n  [!] no clean consecutive runs yet "
                 "(degraded run or false-candidate review breaks the streak)"
+            )
+        elif streak < required:
+            print(
+                f"\n  [!] streak {streak}/{required}: need {required - streak} more "
+                "consecutive clean run(s) before the flip criterion can be met"
             )
         if not reviewed_confirmed:
             print(

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1100,14 +1100,35 @@ class TestComputeStreak:
         assert result["has_reviewed_confirmed"] is False
         assert result["flip_criterion_met"] is False
 
-    def test_flip_criterion_met_when_ok_reviewed_confirmed(self, tmp_path):
-        """Flip criterion met: streak has ≥1 confirmed candidate with ok review."""
+    def test_required_streak_field_present(self, tmp_path):
+        """compute_streak always returns required_streak == FLIP_STREAK_REQUIRED."""
         sd = _build_db(tmp_path)
-        self._write_summary(sd, "run-Y", gh="ok", unverified=0, confirmed=1)
-        self._write_review(sd, "run-Y", verdict="ok")
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["required_streak"] == objective_reconcile.FLIP_STREAK_REQUIRED
+
+    def test_flip_criterion_not_met_with_six_clean_runs(self, tmp_path):
+        """Six consecutive clean runs with a reviewed confirmed candidate is NOT enough."""
+        sd = _build_db(tmp_path)
+        for i in range(5):
+            self._write_summary(sd, f"run-c{i}", gh="ok", unverified=0, confirmed=0)
+        self._write_summary(sd, "run-c5", gh="ok", unverified=0, confirmed=1)
+        self._write_review(sd, "run-c5", verdict="ok")
 
         result = objective_reconcile.compute_streak(sd, PROJECT_ID)
-        assert result["streak_length"] == 1
+        assert result["streak_length"] == 6
+        assert result["has_reviewed_confirmed"] is True
+        assert result["flip_criterion_met"] is False, "6 runs is below the 7-run threshold"
+
+    def test_flip_criterion_met_when_ok_reviewed_confirmed(self, tmp_path):
+        """Flip criterion met: 7 consecutive clean runs with ≥1 confirmed ok-reviewed run."""
+        sd = _build_db(tmp_path)
+        for i in range(6):
+            self._write_summary(sd, f"run-Y{i}", gh="ok", unverified=0, confirmed=0)
+        self._write_summary(sd, "run-Y6", gh="ok", unverified=0, confirmed=1)
+        self._write_review(sd, "run-Y6", verdict="ok")
+
+        result = objective_reconcile.compute_streak(sd, PROJECT_ID)
+        assert result["streak_length"] == 7
         assert result["has_reviewed_confirmed"] is True
         assert result["flip_criterion_met"] is True
 


### PR DESCRIPTION
## Summary

Tier-2 closeout finding (deepseek, confirmed against the code): the approved plan requires SEVEN consecutive clean advisory runs before `VNX_AUTO_CLOSE` may flip; `compute_streak` shipped `streak_length >= 1`.

- `FLIP_STREAK_REQUIRED = 7` module constant; criterion now `streak_length >= FLIP_STREAK_REQUIRED and has_reviewed_confirmed`; `required_streak` in the result so the CLI shows progress (`3/7`).
- Docstring + `reconcile-streak` output + UNIFIED_SUPERVISOR doc aligned.
- Tests: 6 clean runs + reviewed confirmed → NOT met; 7 → met. 198 passed (independently re-run by the orchestrator in a clean worktree).

## Provenance

Built via the governed tmux-spawn lane (dispatch `D-reconcile-fix-streak-seven`). Track: `status-git-reality-reconcile` Tier-2 revise round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC