### PR TITLE
refactor(intel): drop dead success_rate column, reversible migration v26 [D2]

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -170,7 +170,6 @@ CREATE TABLE IF NOT EXISTS success_patterns (
     outcomes TEXT, -- JSON array of expected outcomes
 
     -- Metrics
-    success_rate REAL DEFAULT 0.0, -- 0-1.0
     usage_count INTEGER DEFAULT 0,
     avg_completion_time INTEGER, -- seconds
     confidence_score REAL DEFAULT 0.0, -- 0-1.0
@@ -183,7 +182,7 @@ CREATE TABLE IF NOT EXISTS success_patterns (
 );
 
 -- Indexes for success_patterns table
-CREATE INDEX IF NOT EXISTS idx_patterns_category ON success_patterns (category, success_rate DESC);
+CREATE INDEX IF NOT EXISTS idx_patterns_category ON success_patterns (category);
 CREATE INDEX IF NOT EXISTS idx_patterns_usage ON success_patterns (usage_count DESC);
 
 -- Anti-patterns to avoid

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1010,18 +1010,18 @@ def _collect_recent_dispatches(
 
 _INTELLIGENCE_BRIEF_SQL = (
     "SELECT id, pattern_type, category, title, description, "
-    "success_rate, confidence_score "
+    "confidence_score "
     "FROM success_patterns "
-    "ORDER BY confidence_score DESC, success_rate DESC "
+    "ORDER BY confidence_score DESC "
     "LIMIT 10"
 )
 
 _INTELLIGENCE_BRIEF_CENTRAL_SQL = (
     "SELECT id, pattern_type, category, title, description, "
-    "success_rate, confidence_score "
+    "confidence_score "
     "FROM success_patterns "
     "WHERE project_id = ? "
-    "ORDER BY confidence_score DESC, success_rate DESC "
+    "ORDER BY confidence_score DESC "
     "LIMIT 10"
 )
 

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -25,7 +25,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 25
+HIGHEST_QI_VERSION = 26
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -991,6 +991,59 @@ def _migrate_v25(conn: sqlite3.Connection) -> None:
             log('INFO', f'Migrated {tbl}: added tags column (LLM-tagger persist, v25)')
 
 
+def _migrate_v26(conn: sqlite3.Connection) -> None:
+    """V26: drop dead success_rate column from success_patterns (per-project store).
+
+    success_rate has always been 0.0 — no production path ever writes a non-zero
+    value. The effective sort is confidence_score DESC; success_rate was a dead
+    tiebreaker that added no ordering signal.
+
+    Uses ALTER TABLE DROP COLUMN (SQLite 3.35+). The idx_patterns_category index
+    referenced success_rate and must be dropped first, then recreated without it.
+
+    Reversible via _migrate_v26_down: re-adds the column with DEFAULT 0.0.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='success_patterns'"
+    ).fetchone():
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(success_patterns)").fetchall()}
+    if "success_rate" not in cols:
+        return  # already dropped — idempotent
+    conn.execute("DROP INDEX IF EXISTS idx_patterns_category")
+    conn.execute("ALTER TABLE success_patterns DROP COLUMN success_rate")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_patterns_category "
+        "ON success_patterns (category)"
+    )
+    log('INFO', 'Migrated success_patterns: dropped dead success_rate column (v26)')
+
+
+def _migrate_v26_down(conn: sqlite3.Connection) -> None:
+    """Down migration for V26: re-add success_rate REAL DEFAULT 0.0.
+
+    Restores the column so the schema is compatible with pre-v26 code.
+    Existing rows read 0.0 (the default). Also restores idx_patterns_category
+    with the original (category, success_rate DESC) definition.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='success_patterns'"
+    ).fetchone():
+        return
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(success_patterns)").fetchall()}
+    if "success_rate" in cols:
+        return  # already present — idempotent
+    conn.execute(
+        "ALTER TABLE success_patterns ADD COLUMN success_rate REAL DEFAULT 0.0"
+    )
+    conn.execute("DROP INDEX IF EXISTS idx_patterns_category")
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_patterns_category "
+        "ON success_patterns (category, success_rate DESC)"
+    )
+    log('INFO', 'Reversed V26: re-added success_rate column to success_patterns')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -1018,6 +1071,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     23: _migrate_v23,
     24: _migrate_v24,
     25: _migrate_v25,
+    26: _migrate_v26,
 }
 
 

--- a/tests/test_migrate_v26_drop_success_rate.py
+++ b/tests/test_migrate_v26_drop_success_rate.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+"""Tests for migration V26 — drop dead success_rate column from success_patterns.
+
+Covers:
+  - v26 up: success_rate column is dropped, idx_patterns_category recreated
+  - v26 down: success_rate column is re-added, idx_patterns_category restored
+  - round-trip: up then down restores the original column
+  - idempotency: running up twice or down twice is safe
+  - build_t0_state ORDER BY: queries work correctly without success_rate
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import quality_db_init as qdi  # noqa: E402
+import build_t0_state as bts   # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_v25_db(path: Path) -> sqlite3.Connection:
+    """Create a minimal success_patterns table at v25 schema (with success_rate)."""
+    conn = sqlite3.connect(str(path))
+    conn.isolation_level = None
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT,
+            category TEXT,
+            title TEXT,
+            description TEXT,
+            success_rate REAL DEFAULT 0.0,
+            usage_count INTEGER DEFAULT 0,
+            confidence_score REAL DEFAULT 0.5,
+            tags TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_patterns_category
+            ON success_patterns (category, success_rate DESC);
+        PRAGMA user_version = 25;
+    """)
+    conn.execute(
+        "INSERT INTO success_patterns "
+        "(pattern_type, category, title, description, success_rate, confidence_score) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("approach", "testing", "Pattern A", "Desc A", 0.0, 0.9),
+    )
+    conn.execute(
+        "INSERT INTO success_patterns "
+        "(pattern_type, category, title, description, success_rate, confidence_score) "
+        "VALUES (?, ?, ?, ?, ?, ?)",
+        ("approach", "testing", "Pattern B", "Desc B", 0.0, 0.7),
+    )
+    conn.commit()
+    return conn
+
+
+def _col_names(conn: sqlite3.Connection, table: str) -> set:
+    return {r[1] for r in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _index_sql(conn: sqlite3.Connection, name: str) -> str | None:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (name,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# Migration up
+# ---------------------------------------------------------------------------
+
+class TestMigrateV26Up:
+    def test_drops_success_rate_column(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        assert "success_rate" in _col_names(conn, "success_patterns")
+
+        qdi._migrate_v26(conn)
+
+        assert "success_rate" not in _col_names(conn, "success_patterns")
+        conn.close()
+
+    def test_preserves_other_columns(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+
+        qdi._migrate_v26(conn)
+
+        cols = _col_names(conn, "success_patterns")
+        for expected in ("id", "pattern_type", "category", "title", "description",
+                         "confidence_score", "usage_count"):
+            assert expected in cols, f"column {expected!r} was unexpectedly removed"
+        conn.close()
+
+    def test_preserves_row_data(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+
+        qdi._migrate_v26(conn)
+
+        rows = conn.execute(
+            "SELECT title, confidence_score FROM success_patterns ORDER BY confidence_score DESC"
+        ).fetchall()
+        assert len(rows) == 2
+        assert rows[0][0] == "Pattern A"
+        assert rows[1][0] == "Pattern B"
+        conn.close()
+
+    def test_recreates_idx_patterns_category_without_success_rate(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+
+        qdi._migrate_v26(conn)
+
+        sql = _index_sql(conn, "idx_patterns_category")
+        assert sql is not None, "idx_patterns_category was not recreated"
+        assert "success_rate" not in sql.lower()
+        conn.close()
+
+    def test_idempotent_when_column_already_absent(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        qdi._migrate_v26(conn)
+
+        # Running again must not raise
+        qdi._migrate_v26(conn)
+
+        assert "success_rate" not in _col_names(conn, "success_patterns")
+        conn.close()
+
+    def test_noop_when_table_absent(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.isolation_level = None
+        conn.execute("PRAGMA user_version = 25")
+
+        # Must not raise even when table doesn't exist
+        qdi._migrate_v26(conn)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Migration down
+# ---------------------------------------------------------------------------
+
+class TestMigrateV26Down:
+    def test_readds_success_rate_column(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        qdi._migrate_v26(conn)
+        assert "success_rate" not in _col_names(conn, "success_patterns")
+
+        qdi._migrate_v26_down(conn)
+
+        assert "success_rate" in _col_names(conn, "success_patterns")
+        conn.close()
+
+    def test_column_has_default_zero(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        qdi._migrate_v26(conn)
+        qdi._migrate_v26_down(conn)
+
+        # Existing rows must read 0.0 for success_rate
+        rows = conn.execute("SELECT success_rate FROM success_patterns").fetchall()
+        assert all(r[0] == 0.0 for r in rows), "restored rows should default to 0.0"
+        conn.close()
+
+    def test_restores_idx_patterns_category_with_success_rate(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        qdi._migrate_v26(conn)
+        qdi._migrate_v26_down(conn)
+
+        sql = _index_sql(conn, "idx_patterns_category")
+        assert sql is not None
+        assert "success_rate" in sql.lower()
+        conn.close()
+
+    def test_idempotent_when_column_already_present(
+        self, tmp_path: pytest.TempPathFactory
+    ) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+        # column is still present (v26 not applied yet)
+        assert "success_rate" in _col_names(conn, "success_patterns")
+
+        # Running down on a DB that still has the column must not raise
+        qdi._migrate_v26_down(conn)
+
+        assert "success_rate" in _col_names(conn, "success_patterns")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Round-trip
+# ---------------------------------------------------------------------------
+
+class TestMigrateV26RoundTrip:
+    def test_up_down_restores_column(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+
+        qdi._migrate_v26(conn)
+        assert "success_rate" not in _col_names(conn, "success_patterns")
+
+        qdi._migrate_v26_down(conn)
+        assert "success_rate" in _col_names(conn, "success_patterns")
+        conn.close()
+
+    def test_up_down_up_converges(self, tmp_path: pytest.TempPathFactory) -> None:
+        db_path = tmp_path / "qi.db"
+        conn = _make_v25_db(db_path)
+
+        qdi._migrate_v26(conn)
+        qdi._migrate_v26_down(conn)
+        qdi._migrate_v26(conn)
+
+        assert "success_rate" not in _col_names(conn, "success_patterns")
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# bootstrap_qi_db applies v26 automatically
+# ---------------------------------------------------------------------------
+
+class TestBootstrapAppliesV26:
+    def test_bootstrap_stamps_v26(self, tmp_path: pytest.TempPathFactory) -> None:
+        """A v25 DB bootstrapped with the current schema_file reaches user_version=26."""
+        db_path = tmp_path / "qi.db"
+        # Seed a minimal DB at v25
+        conn = _make_v25_db(db_path)
+        conn.close()
+
+        from schema_migration import get_user_version, apply_if_below
+
+        conn2 = sqlite3.connect(str(db_path))
+        conn2.isolation_level = None
+        apply_if_below(conn2, 26, qdi._migrate_v26)
+        v = get_user_version(conn2)
+        conn2.close()
+
+        assert v == 26
+        # Verify column is gone
+        conn3 = sqlite3.connect(str(db_path))
+        assert "success_rate" not in _col_names(conn3, "success_patterns")
+        conn3.close()
+
+
+# ---------------------------------------------------------------------------
+# build_t0_state ORDER BY without success_rate
+# ---------------------------------------------------------------------------
+
+class TestBuildT0StateOrderBy:
+    def test_intelligence_brief_sql_excludes_success_rate(self) -> None:
+        assert "success_rate" not in bts._INTELLIGENCE_BRIEF_SQL.lower()
+        assert "success_rate" not in bts._INTELLIGENCE_BRIEF_CENTRAL_SQL.lower()
+
+    def test_order_by_is_confidence_score_desc(self) -> None:
+        assert "order by confidence_score desc" in bts._INTELLIGENCE_BRIEF_SQL.lower()
+        assert "order by confidence_score desc" in bts._INTELLIGENCE_BRIEF_CENTRAL_SQL.lower()
+
+    def test_query_works_on_migrated_db(self, tmp_path: pytest.TempPathFactory) -> None:
+        """_collect_intelligence_brief_per_project returns results after v26 migration."""
+        db_path = tmp_path / "quality_intelligence.db"
+        conn = _make_v25_db(db_path)
+        qdi._migrate_v26(conn)
+        conn.close()
+
+        result = bts._collect_intelligence_brief_per_project("test-pid", tmp_path)
+
+        assert len(result) == 2
+        # Ordered by confidence_score DESC: Pattern A (0.9) before Pattern B (0.7)
+        assert result[0]["title"] == "Pattern A"
+        assert result[1]["title"] == "Pattern B"
+        assert "success_rate" not in result[0]
+
+    def test_query_works_on_legacy_db(self, tmp_path: pytest.TempPathFactory) -> None:
+        """_collect_intelligence_brief_per_project returns results from a pre-v26 DB."""
+        db_path = tmp_path / "quality_intelligence.db"
+        conn = _make_v25_db(db_path)
+        conn.close()
+
+        result = bts._collect_intelligence_brief_per_project("test-pid", tmp_path)
+
+        assert len(result) == 2
+        assert result[0]["title"] == "Pattern A"
+        # success_rate no longer selected even on legacy DB
+        assert "success_rate" not in result[0]


### PR DESCRIPTION
## Summary

D2 of self-improve-loop-v2. The intelligence data-flow map (implication 1) found `success_patterns.success_rate` is an always-0.0 dead tiebreaker; `build_t0_state`'s effective sort is already `confidence_score DESC`. Drops the column via reversible migration v26.

- `, success_rate DESC` tiebreaker removed from build_t0_state (confidence_score DESC alone).
- Base schema (fresh DBs) + incremental migration v26 (existing DBs) both drop the column, reversibly (down re-adds default 0.0). Per-project store (ADR-026), not central.
- Pre-existing project_id DEFAULT 'vnx-dev' non-conformance left untouched — deferred as an open item.

## Verification

664 passed; the 5 failures are PRE-EXISTING on main (migration-linter + init-migrate bootstrap — verified failing identically on main HEAD, unrelated to this change). New 310-line `test_migrate_v26_drop_success_rate.py` round-trips up+down.

## Provenance

Governed tmux-spawn lane (dispatch `D-selfimprove-d2-droprate`, database-engineer). Map + plan rev 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC