### PR TITLE
feat(intel): schedule operator-gated proposal tier + gate stale-pattern supersede [D3]

### DIFF
--- a/scripts/dispatcher_minimal.sh
+++ b/scripts/dispatcher_minimal.sh
@@ -603,6 +603,7 @@ process_dispatches() {
     _unified_supervisor_lease_sweep_tick
     _maybe_auto_seed_tracks
     _maybe_objective_reconcile
+    _maybe_learning_cycle
 
     for dispatch in "$PENDING_DIR"/*.md; do
         [ -f "$dispatch" ] || continue

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -8,6 +8,7 @@ Runs daily at 18:00 to analyze receipts and update pattern effectiveness.
 import hashlib
 import json
 import logging
+import os
 import sqlite3
 import time
 import sys
@@ -334,6 +335,11 @@ class LearningLoop:
         window, and projects each onto the failure dict consumed downstream by
         ``generate_prevention_rules`` / ``persist_to_intelligence_db``
         (keys: task / terminal / agent / error / timestamp).
+
+        Filter: receipts with a missing/empty provider AND a failure status are
+        skipped — these are the 9,052+ unknown:unknown receipts that carry no
+        usable provenance and would poison pattern proposals (D3 data-quality
+        guard). The post-filter corpus size is logged.
         """
         if not start_time:
             start_time = datetime.now(timezone.utc) - timedelta(hours=24)
@@ -344,6 +350,9 @@ class LearningLoop:
 
         if not self.receipts_path.exists():
             return failure_patterns
+
+        total_scanned = 0
+        no_provider_skipped = 0
 
         try:
             with open(self.receipts_path, "r", encoding="utf-8", errors="replace") as f:
@@ -356,8 +365,22 @@ class LearningLoop:
                     except json.JSONDecodeError:
                         continue
 
+                    total_scanned += 1
                     status = str(receipt.get("status", "")).lower()
                     if status not in _FAILURE_STATUSES:
+                        continue
+
+                    # D3 data-quality filter: skip no-provider failure receipts.
+                    # Targets receipts where 'provider' is explicitly set to a
+                    # none-sentinel ("none", "unknown", "null", ""), e.g. the 9,052+
+                    # unknown:unknown receipts. Receipts where the field is absent
+                    # entirely (e.g. contract_invalid from the receipt processor)
+                    # pass through — they carry usable governance provenance.
+                    raw_provider = receipt.get("provider")
+                    if raw_provider is not None and str(raw_provider).strip().lower() in (
+                        "", "none", "null", "unknown"
+                    ):
+                        no_provider_skipped += 1
                         continue
 
                     # Window filter on the receipt timestamp. Drop records we
@@ -379,6 +402,12 @@ class LearningLoop:
         except OSError as e:
             print(f"⚠️ Error reading receipt stream {self.receipts_path}: {e}")
 
+        post_filter = total_scanned - no_provider_skipped
+        print(
+            f"  Receipt corpus: {total_scanned} scanned, "
+            f"{no_provider_skipped} no-provider filtered → {post_filter} effective; "
+            f"{len(failure_patterns)} failures in window"
+        )
         return failure_patterns
 
     def _failure_error_message(self, receipt: Dict) -> str:
@@ -852,43 +881,122 @@ class LearningLoop:
         return hashlib.sha1(pattern_id.encode("utf-8")).hexdigest()
 
     def _supersede_stale_patterns(self) -> int:
-        """Set valid_until on low-confidence patterns older than 30 days (F54).
+        """Queue low-confidence stale patterns for operator-gated suppression (D3 G-L4 gate).
+
+        Candidates are written to pending_archival.json with action="supersede" and
+        status="pending". valid_until is NOT set automatically — operator approval is
+        required before any pattern is suppressed. This closes the G-L4 ungated bypass.
 
         Applies to:
-          - success_patterns (confidence_score < 0.3)
-          - prevention_rules  (confidence < 0.3)
+          - success_patterns (confidence_score < 0.3, older than 30 days)
+          - prevention_rules  (confidence < 0.3, older than 30 days)
         Antipatterns have no numeric confidence column and are skipped.
+
+        Off-switch: set VNX_LEARN_SUPERSEDE=0 to skip this step entirely.
         """
-        now = datetime.now().isoformat()
+        if os.environ.get("VNX_LEARN_SUPERSEDE", "1") == "0":
+            print("  VNX_LEARN_SUPERSEDE=0 — supersede step skipped")
+            return 0
+
         total = 0
         try:
-            cur = self.conn.execute(
-                "UPDATE success_patterns SET valid_until = ? "
-                "WHERE confidence_score < 0.3 "
-                "AND valid_from < datetime('now', '-30 days') "
-                "AND valid_until IS NULL",
-                (now,),
-            )
-            total += cur.rowcount
+            paths = ensure_env()
+            state_dir = Path(paths["VNX_STATE_DIR"]).expanduser().resolve()
+            pending_path = state_dir / "pending_archival.json"
 
-            cur = self.conn.execute(
-                "UPDATE prevention_rules SET valid_until = ? "
-                "WHERE confidence < 0.3 "
-                "AND valid_from < datetime('now', '-30 days') "
-                "AND valid_until IS NULL",
-                (now,),
-            )
-            total += cur.rowcount
+            existing: List[Dict] = []
+            if pending_path.exists():
+                try:
+                    data = json.loads(pending_path.read_text(encoding="utf-8"))
+                    existing = data.get("pending_archival", [])
+                except (json.JSONDecodeError, OSError):
+                    existing = []
 
-            self.conn.commit()
-            print(f"  Superseded {total} low-confidence patterns older than 30 days")
+            existing_keys = {
+                (str(e.get("pattern_id", "")), e.get("source_table", ""))
+                for e in existing
+            }
+            now = datetime.now().isoformat()
+            added = 0
+
+            # success_patterns candidates
+            try:
+                rows = self.conn.execute(
+                    "SELECT id, title, confidence_score FROM success_patterns "
+                    "WHERE confidence_score < 0.3 "
+                    "AND valid_from < datetime('now', '-30 days') "
+                    "AND valid_until IS NULL"
+                ).fetchall()
+                for row in rows:
+                    key = (str(row["id"]), "success_patterns")
+                    if key in existing_keys:
+                        continue
+                    existing.append({
+                        "pattern_id": str(row["id"]),
+                        "title": (row["title"] or "")[:120],
+                        "confidence": round(float(row["confidence_score"]), 4),
+                        "source_table": "success_patterns",
+                        "action": "supersede",
+                        "reason": "confidence_score < 0.3, older than 30 days",
+                        "queued_at": now,
+                        "status": "pending",
+                    })
+                    added += 1
+            except Exception as e:
+                log.debug("success_patterns supersede query failed: %s", e)
+
+            # prevention_rules candidates
+            try:
+                rows = self.conn.execute(
+                    "SELECT id, description AS title, confidence FROM prevention_rules "
+                    "WHERE confidence < 0.3 "
+                    "AND valid_from < datetime('now', '-30 days') "
+                    "AND valid_until IS NULL"
+                ).fetchall()
+                for row in rows:
+                    key = (str(row["id"]), "prevention_rules")
+                    if key in existing_keys:
+                        continue
+                    existing.append({
+                        "pattern_id": str(row["id"]),
+                        "title": (row["title"] or "")[:120],
+                        "confidence": round(float(row["confidence"]), 4),
+                        "source_table": "prevention_rules",
+                        "action": "supersede",
+                        "reason": "confidence < 0.3, older than 30 days",
+                        "queued_at": now,
+                        "status": "pending",
+                    })
+                    added += 1
+            except Exception as e:
+                log.debug("prevention_rules supersede query failed: %s", e)
+
+            total = added
+            if added:
+                pending_path.write_text(
+                    json.dumps({"pending_archival": existing}, indent=2, ensure_ascii=False),
+                    encoding="utf-8",
+                )
+                print(
+                    f"  Queued {added} stale-pattern supersede candidates for operator review"
+                    f" → {pending_path}"
+                )
+            else:
+                print("  No stale patterns qualified for supersede")
         except Exception as e:
-            print(f"❌ Error superseding stale patterns: {e}")
+            print(f"❌ Error queuing stale patterns for supersede: {e}")
         return total
 
-    def daily_learning_cycle(self):
-        """Run the complete daily learning cycle"""
-        print(f"\n🔄 Starting Daily Learning Cycle at {datetime.now().isoformat()}")
+    def daily_learning_cycle(self, from_history: bool = False):
+        """Run the complete daily learning cycle.
+
+        Args:
+            from_history: When True, mine the full receipt history (all-time window)
+                instead of the default 24-hour window. Use for the first run against
+                a historical trail (``vnx learning run --from-history``).
+        """
+        mode = "FULL HISTORY" if from_history else "DAILY (24h)"
+        print(f"\n🔄 Starting Learning Cycle [{mode}] at {datetime.now().isoformat()}")
         print("=" * 60)
 
         start_time = time.time()
@@ -910,7 +1018,11 @@ class LearningLoop:
 
         # 3. Extract and learn from failures
         print("\n🔍 Step 3: Learning from failures...")
-        failure_patterns = self.extract_failure_patterns()
+        failure_window = (
+            datetime(2000, 1, 1, tzinfo=timezone.utc) if from_history
+            else datetime.now(timezone.utc) - timedelta(hours=24)
+        )
+        failure_patterns = self.extract_failure_patterns(start_time=failure_window)
         new_rules = self.generate_prevention_rules(failure_patterns)
 
         if new_rules:
@@ -926,15 +1038,20 @@ class LearningLoop:
         self.save_pattern_metrics()
 
         # 5.5 Persist high-confidence patterns and failures to intelligence DB
+        # Off-switch: VNX_LEARN_PERSIST=0 skips the auto-persist of observations.
         print("\n🔗 Step 5.5: Bridging patterns to intelligence DB...")
-        self.persist_to_intelligence_db()
+        if os.environ.get("VNX_LEARN_PERSIST", "1") != "0":
+            self.persist_to_intelligence_db()
+        else:
+            print("  VNX_LEARN_PERSIST=0 — pattern persist skipped")
         self.ingest_approved_rules()
 
-        # 5.6 Supersede low-confidence stale patterns (F54 temporal lifecycle)
-        print("\n🗑️ Step 5.6: Superseding expired low-confidence patterns...")
+        # 5.6 Queue stale low-confidence patterns for operator-gated supersede (D3 G-L4).
+        # valid_until is NOT set here — operator must approve via pending_archival.json.
+        print("\n📋 Step 5.6: Queuing stale patterns for operator-gated supersede...")
         superseded = self._supersede_stale_patterns()
         if superseded:
-            print(f"  ✓ Superseded {superseded} stale patterns")
+            print(f"  ✓ {superseded} patterns queued for operator review")
 
         # 5.7 Close the feedback loop: sync pattern_usage stats back to
         # success_patterns.confidence_score so intelligence_selector reads
@@ -951,11 +1068,14 @@ class LearningLoop:
         print("\n📈 Step 6: Generating learning report...")
         report = self.generate_learning_report()
 
+        proposal_count = len(new_rules)
+        self.learning_stats["proposal_count"] = proposal_count
+
         elapsed = time.time() - start_time
         print(f"\n✅ Learning cycle completed in {elapsed:.2f} seconds")
         print(f"  • Patterns tracked: {len(self.pattern_metrics)}")
         print(f"  • Confidence adjustments: {self.learning_stats['confidence_adjustments']}")
-        print(f"  • New prevention rules: {len(new_rules)}")
+        print(f"  • Proposals (pending rules): {proposal_count}")
         print(f"  • Patterns archived: {self.learning_stats['patterns_archived']}")
         print("=" * 60)
 
@@ -987,20 +1107,23 @@ def main():
     """Run learning loop manually or check status"""
     import sys
 
+    from_history = "--from-history" in sys.argv
+    argv = [a for a in sys.argv[1:] if a != "--from-history"]
+
     loop = LearningLoop()
 
-    if len(sys.argv) > 1:
-        command = sys.argv[1]
+    if argv:
+        command = argv[0]
 
         if command == "run":
-            # Run full learning cycle
-            report = loop.daily_learning_cycle()
+            report = loop.daily_learning_cycle(from_history=from_history)
+            proposal_count = report.get("statistics", {}).get("proposal_count", 0)
+            print(f"\n📊 Proposals (pending rules): {proposal_count}")
             print("\n📊 Learning Summary:")
             print(json.dumps(report['statistics'], indent=2))
 
         elif command == "status":
-            # Show current status
-            print(f"📊 Pattern Metrics Status:")
+            print("📊 Pattern Metrics Status:")
             print(f"  Total patterns tracked: {len(loop.pattern_metrics)}")
 
             if loop.pattern_metrics:
@@ -1014,7 +1137,6 @@ def main():
                 print(f"  Recently used (7 days): {recently_used}")
 
         elif command == "test":
-            # Test pattern extraction
             print("Testing pattern extraction...")
             used = loop.extract_used_patterns(datetime.now(timezone.utc) - timedelta(hours=1))
             ignored = loop.extract_ignored_patterns(datetime.now(timezone.utc) - timedelta(hours=1))
@@ -1023,10 +1145,11 @@ def main():
 
         else:
             print(f"Unknown command: {command}")
-            print("Usage: learning_loop.py [run|status|test]")
+            print("Usage: learning_loop.py [run|status|test] [--from-history]")
     else:
         print("VNX Learning Loop v1.0")
         print("Commands: run, status, test")
+        print("Flags:    --from-history (mine full history instead of 24h window)")
 
 
 if __name__ == "__main__":

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -15,6 +15,8 @@
 #   VNX_SUPERVISOR_MODE            — "unified" enables ticks; default is "legacy" (no-op)
 #   VNX_RUNTIME_SUPERVISE_INTERVAL — seconds between supervise_all() calls; default 60
 #   VNX_LEASE_SWEEP_INTERVAL_SEC   — seconds between lease_sweep calls; default 30
+#   VNX_LEARNING_ENABLED           — "1" enables the daily learning cycle tick; default 0 (off)
+#   VNX_LEARNING_CYCLE_INTERVAL    — seconds between learning cycle runs; default 86400 (daily)
 
 # _maybe_runtime_supervise — throttled RuntimeSupervisor.supervise_all() tick (SUP-PR3).
 # Invokes scripts/lib/runtime_supervise.py at most once per
@@ -85,6 +87,32 @@ _maybe_objective_reconcile() {
         cmd+=(--apply)
     fi
     "${cmd[@]}" >> "$log_file" 2>&1 || true
+    echo "$now" > "$state_file"
+}
+
+# _maybe_learning_cycle — throttled daily learning cycle tick (D3).
+# Invokes scripts/learning_loop.py run at most once per VNX_LEARNING_CYCLE_INTERVAL
+# seconds when VNX_SUPERVISOR_MODE=unified AND VNX_LEARNING_ENABLED=1.
+# Default (unset) = no behaviour change (off by default, operator opt-in).
+# Logs to VNX_LOGS_DIR/learning_cycle.log.
+_maybe_learning_cycle() {
+    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
+    [[ "${VNX_LEARNING_ENABLED:-0}" == "1" ]] || return 0
+    local interval="${VNX_LEARNING_CYCLE_INTERVAL:-86400}"
+    local state_file="$STATE_DIR/.last_learning_cycle_ts"
+    local now last
+    now=$(date +%s)
+    last=0
+    if [[ -f "$state_file" ]]; then
+        last=$(cat "$state_file" 2>/dev/null || echo 0)
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    fi
+    if (( now - last < interval )); then
+        return 0
+    fi
+    local log_file="$VNX_LOGS_DIR/learning_cycle.log"
+    mkdir -p "$(dirname "$log_file")"
+    python3 "$VNX_DIR/scripts/learning_loop.py" run >> "$log_file" 2>&1 || true
     echo "$now" > "$state_file"
 }
 

--- a/tests/test_learning_d3_proposal.py
+++ b/tests/test_learning_d3_proposal.py
@@ -1,0 +1,425 @@
+#!/usr/bin/env python3
+"""D3 proposal-tier tests.
+
+Covers:
+  1. _supersede_stale_patterns routes to pending_archival.json (G-L4 gate — NOT auto-sets valid_until)
+  2. No-provider failure receipts are filtered before mining
+  3. Rule activation status remains "pending" (operator approval required)
+  4. Real-history run: ≥1 non-trivial proposal from actual t0_receipts.ndjson trail
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+def _bootstrap_schema(conn: sqlite3.Connection) -> None:
+    """Create minimal quality_intelligence.db schema for supersede tests.
+
+    Includes valid_from/valid_until columns added via migration in the real DB.
+    """
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT DEFAULT 'behavioral',
+            category TEXT,
+            title TEXT,
+            description TEXT,
+            pattern_data TEXT,
+            code_example TEXT,
+            prerequisites TEXT,
+            outcomes TEXT,
+            success_rate REAL DEFAULT 0.0,
+            usage_count INTEGER DEFAULT 0,
+            avg_completion_time REAL DEFAULT 0.0,
+            confidence_score REAL DEFAULT 0.5,
+            source_dispatch_ids TEXT,
+            source_receipts TEXT,
+            first_seen TEXT,
+            last_used TEXT,
+            valid_from DATETIME DEFAULT (datetime('now')),
+            valid_until DATETIME DEFAULT NULL,
+            tags TEXT DEFAULT '[]'
+        );
+        CREATE TABLE IF NOT EXISTS prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT,
+            rule_type TEXT,
+            description TEXT,
+            recommendation TEXT,
+            confidence REAL DEFAULT 0.5,
+            created_at TEXT,
+            triggered_count INTEGER DEFAULT 0,
+            last_triggered TEXT,
+            valid_from DATETIME DEFAULT (datetime('now')),
+            valid_until DATETIME DEFAULT NULL
+        );
+    """)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers / fixtures
+# ---------------------------------------------------------------------------
+
+def _now_iso(offset_hours: float = 0.0) -> str:
+    return (datetime.now(timezone.utc) + timedelta(hours=offset_hours)).isoformat()
+
+
+def _write_receipts(path: Path, receipts: list[dict]) -> None:
+    path.write_text(
+        "\n".join(json.dumps(r) for r in receipts) + "\n", encoding="utf-8"
+    )
+
+
+class _FakePaths:
+    def __init__(self, state_dir: Path, vnx_home: Path):
+        self._d = {
+            "VNX_STATE_DIR": str(state_dir),
+            "VNX_HOME": str(vnx_home),
+            "VNX_DATA_DIR": str(state_dir.parent),
+        }
+
+    def __getitem__(self, k):
+        return self._d[k]
+
+    def get(self, k, default=None):
+        return self._d.get(k, default)
+
+
+@pytest.fixture
+def loop_env(tmp_path):
+    """LearningLoop bound to a tmp state dir via patched ensure_env."""
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = _FakePaths(state_dir, vnx_home)
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# 1. _supersede_stale_patterns: routes to pending_archival.json, NOT valid_until
+# ---------------------------------------------------------------------------
+
+def _seed_success_pattern(loop, *, title="old-low-conf", confidence=0.1):
+    """Insert a stale, low-confidence success_pattern directly into the DB."""
+    old_date = (datetime.now() - timedelta(days=40)).isoformat()
+    loop.conn.execute(
+        """
+        INSERT OR REPLACE INTO success_patterns
+        (title, pattern_data, category, confidence_score, valid_from, valid_until,
+         source_dispatch_ids, usage_count, tags)
+        VALUES (?, ?, ?, ?, ?, NULL, '[]', 0, '[]')
+        """,
+        (title, json.dumps({"source": "learning_loop"}), "general", confidence, old_date),
+    )
+    loop.conn.commit()
+    return loop.conn.execute(
+        "SELECT id FROM success_patterns WHERE title = ?", (title,)
+    ).fetchone()["id"]
+
+
+def test_supersede_writes_pending_archival_not_valid_until(loop_env):
+    """_supersede_stale_patterns writes to pending_archival.json, never sets valid_until."""
+    loop, state_dir = loop_env
+    _bootstrap_schema(loop.conn)
+    pat_id = _seed_success_pattern(loop)
+
+    count = loop._supersede_stale_patterns()
+
+    # valid_until must NOT have been set
+    row = loop.conn.execute(
+        "SELECT valid_until FROM success_patterns WHERE id = ?", (pat_id,)
+    ).fetchone()
+    assert row is not None
+    assert row["valid_until"] is None, "valid_until must remain NULL — operator approval required"
+
+    # pending_archival.json must exist with the candidate
+    pending_path = state_dir / "pending_archival.json"
+    assert pending_path.exists(), "pending_archival.json must be written"
+
+    data = json.loads(pending_path.read_text(encoding="utf-8"))
+    archival = data.get("pending_archival", [])
+    assert len(archival) >= 1, "at least one candidate must be queued"
+
+    sp_candidates = [c for c in archival if c.get("source_table") == "success_patterns"]
+    assert sp_candidates, "success_patterns candidate missing from pending_archival.json"
+
+    c = sp_candidates[0]
+    assert c["action"] == "supersede"
+    assert c["status"] == "pending"
+    assert c["pattern_id"] == str(pat_id)
+
+
+def test_supersede_does_not_auto_apply_without_operator(loop_env):
+    """Running _supersede_stale_patterns multiple times is idempotent and never touches valid_until."""
+    loop, state_dir = loop_env
+    _bootstrap_schema(loop.conn)
+    pat_id = _seed_success_pattern(loop, title="stale-pat-2", confidence=0.05)
+
+    loop._supersede_stale_patterns()
+    loop._supersede_stale_patterns()  # second call — must not duplicate or auto-apply
+
+    row = loop.conn.execute(
+        "SELECT valid_until FROM success_patterns WHERE id = ?", (pat_id,)
+    ).fetchone()
+    assert row["valid_until"] is None
+
+    pending_path = state_dir / "pending_archival.json"
+    data = json.loads(pending_path.read_text(encoding="utf-8"))
+    sp_candidates = [
+        c for c in data.get("pending_archival", [])
+        if c.get("source_table") == "success_patterns" and c.get("pattern_id") == str(pat_id)
+    ]
+    assert len(sp_candidates) == 1, "second call must not duplicate the pending entry"
+
+
+def test_supersede_off_switch(loop_env, monkeypatch):
+    """VNX_LEARN_SUPERSEDE=0 skips the entire step."""
+    loop, state_dir = loop_env
+    _bootstrap_schema(loop.conn)
+    _seed_success_pattern(loop, title="off-switch-pat", confidence=0.05)
+
+    monkeypatch.setenv("VNX_LEARN_SUPERSEDE", "0")
+    count = loop._supersede_stale_patterns()
+    assert count == 0
+
+    pending_path = state_dir / "pending_archival.json"
+    assert not pending_path.exists(), "pending_archival.json must not be written when off"
+
+
+# ---------------------------------------------------------------------------
+# 2. No-provider failure receipts are filtered before mining
+# ---------------------------------------------------------------------------
+
+def test_no_provider_failure_receipts_filtered(loop_env, capsys):
+    """Failure receipts with explicitly-none provider are excluded from corpus.
+
+    Absent provider field (e.g. contract_invalid from the receipt processor)
+    passes through — only explicit none-sentinels are filtered.
+    """
+    loop, state_dir = loop_env
+    receipts = [
+        {   # INCLUDE: has real provider + failure
+            "status": "failed",
+            "provider": "claude",
+            "failure_reason": "Exhausted 3 retries",
+            "terminal": "T1",
+            "dispatch_id": "d-real",
+            "timestamp": _now_iso(-1),
+        },
+        {   # EXCLUDE: explicit provider="none" + failure (the 9,052 unknown:unknown receipts)
+            "status": "failed",
+            "provider": "none",
+            "sub_provider": "none",
+            "failure_reason": "some error",
+            "terminal": "T2",
+            "dispatch_id": "d-noprov1",
+            "timestamp": _now_iso(-1),
+        },
+        {   # EXCLUDE: explicit empty string provider + failure
+            "status": "failed",
+            "provider": "",
+            "failure_reason": "another error",
+            "terminal": "T3",
+            "dispatch_id": "d-noprov2",
+            "timestamp": _now_iso(-1),
+        },
+        {   # INCLUDE: absent provider field (e.g. contract_invalid from receipt processor)
+            "status": "error",
+            "failure_reason": "crash",
+            "terminal": "T4",
+            "dispatch_id": "d-noprov3",
+            "timestamp": _now_iso(-1),
+        },
+        {   # EXCLUDE: success receipts — already rejected by status filter (irrelevant)
+            "status": "done",
+            "provider": "none",
+            "terminal": "T1",
+            "dispatch_id": "d-ok",
+            "timestamp": _now_iso(-1),
+        },
+    ]
+    _write_receipts(state_dir / "t0_receipts.ndjson", receipts)
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+
+    # 2 pass: real provider + absent provider (governance receipt)
+    assert len(failures) == 2, (
+        "real-provider failure and absent-provider failure both pass; "
+        "only explicit none-sentinel providers are filtered"
+    )
+    agents = {f["agent"] for f in failures}
+    assert "claude" in agents, "real-provider failure must be included"
+
+    out, _ = capsys.readouterr()
+    assert "no-provider filtered" in out, "corpus size must be reported"
+
+
+def test_provider_unknown_filtered(loop_env):
+    """provider='unknown' is treated as no-provider and filtered out."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "provider": "unknown",
+                "failure_reason": "crash",
+                "terminal": "T1",
+                "dispatch_id": "d-unk",
+                "timestamp": _now_iso(-1),
+            }
+        ],
+    )
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+    assert failures == [], "provider='unknown' must be filtered"
+
+
+def test_corpus_size_reported(loop_env, capsys):
+    """extract_failure_patterns always reports post-filter corpus size."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "done",
+                "provider": "claude",
+                "terminal": "T1",
+                "dispatch_id": "d-ok",
+                "timestamp": _now_iso(-1),
+            }
+        ],
+    )
+    loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+    out, _ = capsys.readouterr()
+    assert "Receipt corpus:" in out
+    assert "scanned" in out
+    assert "filtered" in out
+
+
+# ---------------------------------------------------------------------------
+# 3. Rule activation status: pending (operator approval required)
+# ---------------------------------------------------------------------------
+
+def test_rule_activation_requires_operator_approval(loop_env):
+    """Rules queued by the learning loop always have status='pending' (G-L1)."""
+    loop, state_dir = loop_env
+    _write_receipts(
+        state_dir / "t0_receipts.ndjson",
+        [
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "provider": "claude",
+                "terminal": "T1",
+                "dispatch_id": "d-1",
+                "timestamp": _now_iso(-2),
+            },
+            {
+                "status": "failed",
+                "failure_reason": "Exhausted 3 retries",
+                "provider": "claude",
+                "terminal": "T1",
+                "dispatch_id": "d-2",
+                "timestamp": _now_iso(-1),
+            },
+        ],
+    )
+
+    failures = loop.extract_failure_patterns(
+        start_time=datetime.now(timezone.utc) - timedelta(days=2)
+    )
+    rules = loop.generate_prevention_rules(failures)
+    assert len(rules) >= 1
+    loop.update_terminal_constraints(rules)
+
+    pending_path = state_dir / "pending_rules.json"
+    assert pending_path.exists()
+    data = json.loads(pending_path.read_text(encoding="utf-8"))
+    pending = data.get("pending_rules", [])
+    assert len(pending) >= 1
+    assert all(r["status"] == "pending" for r in pending), "G-L1: no auto-activation"
+    # Confirm prevention_rules table has 0 rows (table may not exist in minimal test DB)
+    try:
+        table_rows = loop.conn.execute("SELECT COUNT(*) FROM prevention_rules").fetchone()[0]
+        assert table_rows == 0, "rules must not be inserted without operator approval"
+    except sqlite3.OperationalError:
+        pass  # table absent = no rows inserted, assertion already holds
+
+
+# ---------------------------------------------------------------------------
+# 4. Minimum-signal gate: ≥1 non-trivial proposal from real history
+# ---------------------------------------------------------------------------
+
+_REAL_RECEIPTS = Path(os.environ.get(
+    "VNX_STATE_DIR",
+    str(Path.home() / ".vnx-data" / "vnx-dev" / "state"),
+)) / "t0_receipts.ndjson"
+
+
+@pytest.mark.skipif(
+    not _REAL_RECEIPTS.exists(),
+    reason=f"real receipt trail not found at {_REAL_RECEIPTS}",
+)
+def test_real_history_produces_at_least_one_proposal():
+    """Full receipt history yields ≥1 recurring failure pattern proposal.
+
+    This is the minimum-signal gate (D3): a run against the actual governed
+    receipt stream must surface at least one non-trivial proposal (occurrence >= 2).
+    The no-provider-failure filter must be applied first.
+    """
+    from unittest.mock import patch as _patch
+
+    state_dir = _REAL_RECEIPTS.parent
+    vnx_home = state_dir.parent.parent  # best-effort
+
+    fake = _FakePaths(state_dir, vnx_home)
+    with _patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        try:
+            failures = loop.extract_failure_patterns(
+                start_time=datetime(2000, 1, 1, tzinfo=timezone.utc)
+            )
+            rules = loop.generate_prevention_rules(failures)
+        finally:
+            try:
+                loop.conn.close()
+            except Exception:
+                pass
+
+    assert len(rules) >= 1, (
+        f"Expected ≥1 proposal from {_REAL_RECEIPTS} "
+        f"(after no-provider filter); got {len(rules)}. "
+        "Receipt corpus may be too narrow — consider using --from-history."
+    )
+    # All proposals must be non-trivial (≥2 occurrences)
+    assert all(r.get("occurrence_count", 0) >= 2 for r in rules), (
+        "All proposals must have occurrence_count >= 2 (recurrence threshold)"
+    )

--- a/vnx_cli/commands/learning.py
+++ b/vnx_cli/commands/learning.py
@@ -1,0 +1,159 @@
+"""vnx learning — operator-gated proposal tier for the intelligence self-learning loop."""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+from vnx_cli import _engine
+_engine.ensure_engine_on_path()
+
+
+def _resolve_state_dir(project_dir: Path) -> Path:
+    """Return the canonical VNX state directory anchored on project_dir."""
+    return _engine.resolve_data_root(project_dir) / "state"
+
+
+def _cmd_run(args) -> int:
+    """Run the daily learning cycle and write pending proposals for operator review."""
+    project_dir = Path(getattr(args, "project_dir", "."))
+    from_history = getattr(args, "from_history", False)
+
+    # Validate project
+    if not (_engine.resolve_data_root(project_dir).exists()):
+        print("error: VNX project not initialized. Run `vnx init` first.", file=sys.stderr)
+        return 1
+
+    import learning_loop as ll  # type: ignore[import]
+    loop = ll.LearningLoop()
+    try:
+        report = loop.daily_learning_cycle(from_history=from_history)
+    finally:
+        try:
+            loop.conn.close()
+        except Exception:
+            pass
+
+    proposal_count = report.get("statistics", {}).get("proposal_count", 0)
+    print(f"\nProposals (pending rules): {proposal_count}")
+    print("\nSummary:")
+    print(json.dumps(report.get("statistics", {}), indent=2))
+    return 0
+
+
+def _cmd_status(args) -> int:
+    """Show pending proposals and archival candidates."""
+    project_dir = Path(getattr(args, "project_dir", "."))
+    state_dir = _resolve_state_dir(project_dir)
+
+    pending_rules_path = state_dir / "pending_rules.json"
+    pending_archival_path = state_dir / "pending_archival.json"
+
+    print("Learning loop status")
+    print("=" * 40)
+
+    # Pending rules
+    pending_rules = 0
+    approved_rules = 0
+    if pending_rules_path.exists():
+        try:
+            data = json.loads(pending_rules_path.read_text(encoding="utf-8"))
+            rules = data.get("pending_rules", [])
+            pending_rules = sum(1 for r in rules if r.get("status") == "pending")
+            approved_rules = sum(1 for r in rules if r.get("status") == "approved")
+        except (json.JSONDecodeError, OSError):
+            pass
+    print(f"  Pending rules (awaiting operator approval): {pending_rules}")
+    print(f"  Approved rules (ready for ingest):          {approved_rules}")
+
+    # Pending archival / supersede
+    pending_archival = 0
+    pending_supersede = 0
+    if pending_archival_path.exists():
+        try:
+            data = json.loads(pending_archival_path.read_text(encoding="utf-8"))
+            candidates = data.get("pending_archival", [])
+            for c in candidates:
+                if c.get("status") != "pending":
+                    continue
+                if c.get("action") == "supersede":
+                    pending_supersede += 1
+                else:
+                    pending_archival += 1
+        except (json.JSONDecodeError, OSError):
+            pass
+    print(f"  Pending archival candidates:                {pending_archival}")
+    print(f"  Pending supersede candidates (G-L4 gated): {pending_supersede}")
+    print()
+    print("To review proposals: vnx learning review")
+    return 0
+
+
+def _cmd_review(args) -> int:
+    """Show pending proposals for operator review."""
+    project_dir = Path(getattr(args, "project_dir", "."))
+    state_dir = _resolve_state_dir(project_dir)
+    mode = getattr(args, "mode", "all")
+
+    show_rules = mode in ("all", "rules")
+    show_archival = mode in ("all", "archival")
+
+    if show_rules:
+        pending_rules_path = state_dir / "pending_rules.json"
+        if not pending_rules_path.exists():
+            print("No pending_rules.json found. Run `vnx learning run` first.")
+        else:
+            try:
+                data = json.loads(pending_rules_path.read_text(encoding="utf-8"))
+                rules = [r for r in data.get("pending_rules", []) if r.get("status") == "pending"]
+                if not rules:
+                    print("No pending prevention rules.")
+                else:
+                    print(f"Pending prevention rules ({len(rules)}):")
+                    for r in rules:
+                        print(f"  [{r.get('id', '?')}] {r.get('pattern', '')[:80]}")
+                        print(f"    Prevention: {r.get('prevention', '')[:80]}")
+                        print(f"    Confidence: {r.get('confidence', '?')}  "
+                              f"Occurrences: {r.get('occurrence_count', '?')}")
+                        print()
+            except (json.JSONDecodeError, OSError) as exc:
+                print(f"error reading pending_rules.json: {exc}", file=sys.stderr)
+                return 1
+
+    if show_archival:
+        pending_archival_path = state_dir / "pending_archival.json"
+        if not pending_archival_path.exists():
+            print("No pending_archival.json found.")
+        else:
+            try:
+                data = json.loads(pending_archival_path.read_text(encoding="utf-8"))
+                candidates = [c for c in data.get("pending_archival", []) if c.get("status") == "pending"]
+                if not candidates:
+                    print("No pending archival/supersede candidates.")
+                else:
+                    print(f"Pending archival/supersede candidates ({len(candidates)}):")
+                    for c in candidates:
+                        action = c.get("action", "archive")
+                        print(f"  [{c.get('source_table', '?')}:{c.get('pattern_id', '?')}] "
+                              f"action={action}  conf={c.get('confidence', '?')}")
+                        print(f"    Title: {(c.get('title') or '')[:80]}")
+                        print(f"    Reason: {c.get('reason', '')}")
+                        print()
+            except (json.JSONDecodeError, OSError) as exc:
+                print(f"error reading pending_archival.json: {exc}", file=sys.stderr)
+                return 1
+
+    return 0
+
+
+def vnx_learning(args) -> int:
+    sub = getattr(args, "learning_subcommand", None)
+    dispatch = {
+        "run": _cmd_run,
+        "status": _cmd_status,
+        "review": _cmd_review,
+    }
+    if sub in dispatch:
+        return dispatch[sub](args)
+    print("Usage: vnx learning {run|status|review}")
+    return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -291,6 +291,48 @@ def _register_migrate_subparser(subparsers: argparse.Action) -> None:
     )
 
 
+def _register_learning_subparser(subparsers: argparse.Action) -> None:
+    learning_parser = subparsers.add_parser(
+        "learning",
+        help="operator-gated proposal tier for the intelligence self-learning loop",
+    )
+    learning_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory (default: current directory)",
+    )
+    learning_subs = learning_parser.add_subparsers(
+        dest="learning_subcommand", metavar="SUBCOMMAND"
+    )
+
+    lr_run = learning_subs.add_parser(
+        "run",
+        help="run the daily learning cycle and queue proposals for operator review",
+    )
+    lr_run.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_run.add_argument(
+        "--from-history",
+        dest="from_history",
+        action="store_true",
+        help="mine full receipt history (all-time window) instead of the default 24h window",
+    )
+
+    lr_status = learning_subs.add_parser("status", help="show pending proposal counts")
+    lr_status.add_argument("--project-dir", default=".", metavar="DIR")
+
+    lr_review = learning_subs.add_parser(
+        "review", help="show pending proposals for operator review"
+    )
+    lr_review.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_review.add_argument(
+        "--mode",
+        default="all",
+        choices=["all", "rules", "archival"],
+        help="which proposals to show: rules, archival, or all (default: all)",
+    )
+
+
 def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_parser = subparsers.add_parser(
         "dream",
@@ -364,6 +406,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.track import vnx_track
         sys.exit(vnx_track(args))
 
+    elif args.command == "learning":
+        from vnx_cli.commands.learning import vnx_learning
+        sys.exit(vnx_learning(args))
+
     elif args.command == "dream":
         from vnx_cli.commands.dream import vnx_dream
         sys.exit(vnx_dream(args))
@@ -396,6 +442,7 @@ def main() -> None:
     _register_update_subparser(subparsers)
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)
+    _register_learning_subparser(subparsers)
     _register_dream_subparser(subparsers)
     _register_migrate_subparser(subparsers)
 


### PR DESCRIPTION
## Summary

D3 of self-improve-loop-v2 — the headline: activate the operator-gated proposal tier, grounded in `claudedocs/2026-07-04-intelligence-dataflow-MAP.md`.

- `vnx learning {run,status,review}` CLI — run = daily_learning_cycle producing `pending_rules.json` / `pending_archival.json` for operator review (G-L1 enforced, never auto-activates); a supervisor tick `_maybe_learning_cycle` (unified mode, daily, off-switch `VNX_LEARNING_ENABLED`).
- **Closed the G-L4 ungated bypass** (map implication 3): `_supersede_stale_patterns` now routes through `pending_archival.json` so suppression needs operator approval — was silently auto-setting valid_until.
- Filters no-provider FAILURE receipts before mining (the real data-quality threat per the map; subprocess_completion was already ignored).
- Minimum-signal gate: a run reports the proposal count against real history.

## Verification

153 passed, 1 skipped (learning/supersede/proposal/archival suite; 8 new tests in `test_learning_d3_proposal.py`, independently re-run at the commit).

## Provenance

Governed tmux-spawn lane (dispatch `D-selfimprove-d3-proposal`, backend-developer). Map + plan rev 4. Depends on D1 (#1001, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC