### PR TITLE
feat(gov): SSH-key signing/verify + attestation manifest (test-key; keychain = operator step) [D1]

### DIFF
--- a/docs/governance/KEY_PROVISIONING.md
+++ b/docs/governance/KEY_PROVISIONING.md
@@ -1,0 +1,141 @@
+# Operator Key Provisioning — VNX Signing Authority
+
+This document describes the one-time operator step to provision a VNX signing key.
+This is executed by the operator (Vincent), not by any worker or automated process.
+
+## Prerequisites
+
+- macOS with Secure Enclave (Touch ID) present, OR a machine-scoped key is acceptable
+- `ssh-keygen` (ships with macOS)
+- Git ≥ 2.34 (SSH signing support)
+
+---
+
+## Step 1 — Generate the signing key
+
+**Option A — Secure Enclave key (Touch ID; strongest, non-exportable):**
+
+```bash
+ssh-keygen -t ed25519-sk -O resident -O application=ssh:vnx-sign \
+  -C "vnx-signing-key@$(hostname -s)" \
+  -f ~/.ssh/vnx_sign_ed25519_sk
+```
+
+The private key material never leaves the Secure Enclave.  Touch ID confirms each signing operation.
+
+**Option B — Machine key (simpler; key is exportable):**
+
+```bash
+ssh-keygen -t ed25519 -C "vnx-signing-key@$(hostname -s)" \
+  -f ~/.ssh/vnx_sign_ed25519
+```
+
+Set file permissions: `chmod 600 ~/.ssh/vnx_sign_ed25519`.
+
+> **Honest residual:** a machine key (Option B) is exportable.  If the worker process can read
+> `~/.ssh/vnx_sign_ed25519`, the guarantee degrades from preventive to detective.  Option A
+> eliminates that residual — the Secure Enclave private key is hardware-bound to this machine
+> and requires Touch ID confirmation.
+
+---
+
+## Step 2 — Register the public key in `allowed_signers`
+
+```bash
+# In the repo root:
+echo "vnx-operator@$(hostname -s) $(cat ~/.ssh/vnx_sign_ed25519.pub)" \
+  >> allowed_signers
+```
+
+Or for the SK key:
+
+```bash
+echo "vnx-operator@$(hostname -s) $(cat ~/.ssh/vnx_sign_ed25519_sk.pub)" \
+  >> allowed_signers
+```
+
+Commit `allowed_signers` to the repository.  It is a trust-root path — any change
+to it must be signed by a pre-existing trusted key and reviewed (see `CODEOWNERS`).
+
+---
+
+## Step 3 — Configure Git to use SSH signing
+
+```bash
+git config --global gpg.format ssh
+git config --global user.signingkey ~/.ssh/vnx_sign_ed25519     # or _sk variant
+git config --global gpg.ssh.allowedSignersFile "$(pwd)/allowed_signers"
+git config --global commit.gpgsign true
+```
+
+Verify the configuration:
+
+```bash
+git config --global gpg.format       # → ssh
+git config --global user.signingkey  # → path to your key
+```
+
+---
+
+## Step 4 — Test sign + verify
+
+```bash
+# Create a test file and sign it
+echo "vnx test" > /tmp/vnx_test_sign.txt
+ssh-keygen -Y sign -f ~/.ssh/vnx_sign_ed25519 -n "vnx-attestation" /tmp/vnx_test_sign.txt
+
+# Verify the signature
+ssh-keygen -Y verify \
+  -f "$(pwd)/allowed_signers" \
+  -I "vnx-operator@$(hostname -s)" \
+  -n "vnx-attestation" \
+  -s /tmp/vnx_test_sign.txt.sig \
+  < /tmp/vnx_test_sign.txt
+```
+
+Expected output: `Good "vnx-attestation" signature for vnx-operator@<hostname> with ED25519 key ...`
+
+---
+
+## Step 5 — Set the key path for the attestation module
+
+Pass the key path when calling `emit_governed_attestation`:
+
+```python
+from scripts.lib.attestation import emit_governed_attestation
+
+rec = emit_governed_attestation(
+    dispatch_id="D-my-feature",
+    deliverable_id="D1",
+    track_id="my-track",
+    plan_gate_ref="plan-gate-pass-ref",
+    signer_identity="vnx-operator@mymachine",
+    timestamp="2026-07-04T12:00:00Z",
+    key_path="~/.ssh/vnx_sign_ed25519",   # ← operator-provided
+    repo_root=".",
+)
+```
+
+The attestation module **never provisions, stores, or looks up keys**.
+Key custody is entirely the operator's responsibility.
+
+---
+
+## Key rotation and revocation
+
+- To revoke a key: remove its line from `allowed_signers` (base-branch side).
+  Past attestations in `.vnx-attest/governed.ndjson` remain valid via the
+  receipt chain timestamp — they were signed when the key was trusted.
+- To rotate: add the new key line to `allowed_signers`, generate new key,
+  update `user.signingkey` in git config.  Sign the `allowed_signers` change
+  with a **pre-existing** trusted key (the new key cannot self-authorize).
+- Validity windows: add a comment next to each key noting its active-from date
+  so an auditor can match attestation timestamps against key validity.
+
+---
+
+## Single-machine residual
+
+This setup binds the signing trust to this machine.  A remote signing service
+(where the door process signs and the worker never holds the key) would
+eliminate this residual.  That hardening path is named as a future slice.

--- a/scripts/lib/attestation.py
+++ b/scripts/lib/attestation.py
@@ -1,0 +1,335 @@
+"""VNX signing authority and attestation manifest (D1).
+
+Emits a signed attestation for a governed action: lineage (Dispatch-ID,
+deliverable_id, track_id, plan-gate-pass ref) hash-chained via
+ndjson_hash_chain, signed with a caller-supplied SSH key.
+
+The signing key is ALWAYS passed in — never provisioned here.  Keychain
+provisioning is an operator step; see docs/governance/KEY_PROVISIONING.md.
+
+SSH signing namespace: "vnx-attestation"
+Attestation ledger: .vnx-attest/governed.ndjson  (governed)
+                    .vnx-attest/adhoc.ndjson      (ad-hoc)
+
+References:
+  - ndjson_hash_chain.py: hash-chain primitive
+  - trace_token_validator.py: Dispatch-ID format
+  - docs/governance/2026-07-04-governance-attribution-enforce-PLAN.md
+"""
+from __future__ import annotations
+
+import base64
+import hashlib
+import json
+import os
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from ndjson_hash_chain import append_chained_entry, compute_entry_hash
+
+# SSH signing namespace — must match verify calls.
+_SSH_NAMESPACE = "vnx-attestation"
+
+SCHEMA_VERSION = "1"
+
+ATTESTATION_GOVERNED = "governed"
+ATTESTATION_ADHOC = "ad-hoc"
+
+
+# ---------------------------------------------------------------------------
+# Manifest helpers
+# ---------------------------------------------------------------------------
+
+def manifest_canonical_bytes(manifest: dict) -> bytes:
+    """Return canonical UTF-8 bytes for signing/verification.
+
+    Excludes 'signature' and 'prev_hash': prev_hash is a chain-pointer, not
+    semantic content; signature is what this function feeds INTO the sign step.
+    """
+    excluded = {"signature", "prev_hash"}
+    filtered = {k: v for k, v in manifest.items() if k not in excluded}
+    return json.dumps(filtered, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+
+def manifest_content_hash(manifest: dict) -> str:
+    """SHA-256 of canonical bytes (excludes signature and prev_hash)."""
+    return hashlib.sha256(manifest_canonical_bytes(manifest)).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Manifest builders
+# ---------------------------------------------------------------------------
+
+def build_governed_manifest(
+    *,
+    dispatch_id: str,
+    deliverable_id: str,
+    track_id: str,
+    plan_gate_ref: str,
+    signer_identity: str,
+    timestamp: str,
+) -> dict:
+    """Build a governed attestation manifest dict (without chain/signature fields).
+
+    Args:
+        dispatch_id: Dispatch-ID of the governed build.
+        deliverable_id: Deliverable being attested (e.g. "D1").
+        track_id: Track/objective ID (e.g. "governance-attribution-enforce").
+        plan_gate_ref: Reference to the plan-gate pass (e.g. PASS commit or receipt hash).
+        signer_identity: The signer identity string matching an allowed_signers entry.
+        timestamp: ISO-8601 UTC timestamp (caller supplies — no Date.now in scripts).
+    """
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "attestation_type": ATTESTATION_GOVERNED,
+        "dispatch_id": dispatch_id,
+        "deliverable_id": deliverable_id,
+        "track_id": track_id,
+        "plan_gate_ref": plan_gate_ref,
+        "signer_identity": signer_identity,
+        "timestamp": timestamp,
+    }
+
+
+def build_adhoc_manifest(
+    *,
+    dispatch_id: str,
+    signer_identity: str,
+    timestamp: str,
+    note: str = "",
+) -> dict:
+    """Build an ad-hoc low-attestation manifest.
+
+    Ad-hoc actions NEVER receive a governed signature.  The attestation_type
+    field is "ad-hoc" so they are always distinguishable from governed actions.
+    Lineage fields (deliverable_id, track_id, plan_gate_ref) are absent.
+
+    Args:
+        dispatch_id: Dispatch-ID of the ad-hoc action (or "ad-hoc:<slug>").
+        signer_identity: The signer identity string.
+        timestamp: ISO-8601 UTC timestamp.
+        note: Optional free-text note describing the ad-hoc action.
+    """
+    manifest: dict = {
+        "schema_version": SCHEMA_VERSION,
+        "attestation_type": ATTESTATION_ADHOC,
+        "dispatch_id": dispatch_id,
+        "signer_identity": signer_identity,
+        "timestamp": timestamp,
+    }
+    if note:
+        manifest["note"] = note
+    return manifest
+
+
+# ---------------------------------------------------------------------------
+# SSH sign / verify
+# ---------------------------------------------------------------------------
+
+def sign_manifest(manifest: dict, key_path: "str | Path") -> dict:
+    """Sign a manifest with a caller-supplied SSH key.
+
+    Returns the manifest dict with a "signature" field added (base64-encoded
+    raw SSH .sig bytes).  The canonical bytes that are signed exclude the
+    "signature" and "prev_hash" fields so the signature is stable across
+    chain positions.
+
+    Args:
+        manifest: Manifest dict WITHOUT a signature field.
+        key_path: Path to the SSH private key file (ed25519 or equivalent).
+                  The caller is responsible for key custody; this function
+                  never provisions, stores, or looks up keys.
+
+    Raises:
+        RuntimeError: If ssh-keygen signing fails.
+    """
+    key_path = Path(key_path)
+    canonical = manifest_canonical_bytes(manifest)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        data_file = tmp / "manifest.bin"
+        data_file.write_bytes(canonical)
+
+        result = subprocess.run(
+            ["ssh-keygen", "-Y", "sign", "-f", str(key_path),
+             "-n", _SSH_NAMESPACE, str(data_file)],
+            capture_output=True,
+        )
+        if result.returncode != 0:
+            stderr = result.stderr.decode("utf-8", errors="replace").strip()
+            raise RuntimeError(f"ssh-keygen signing failed: {stderr}")
+
+        sig_file = data_file.with_suffix(".bin.sig")
+        if not sig_file.exists():
+            raise RuntimeError("ssh-keygen did not produce a .sig file")
+
+        sig_bytes = sig_file.read_bytes()
+
+    signed = dict(manifest)
+    signed["signature"] = base64.b64encode(sig_bytes).decode("ascii")
+    return signed
+
+
+def verify_attestation(manifest: dict, allowed_signers: "str | Path") -> bool:
+    """Verify a detached SSH signature embedded in a manifest dict.
+
+    Args:
+        manifest: Manifest dict containing a "signature" field (base64 SSH .sig)
+                  and a "signer_identity" field matching an allowed_signers entry.
+        allowed_signers: Path to an SSH allowed_signers file.
+                         Format: "<identity> <keytype> <base64-pubkey>"
+
+    Returns:
+        True if the signature is valid for the manifest's canonical bytes
+        and the signer is in allowed_signers.  False on any verification
+        failure (bad sig, unknown signer, missing fields).
+    """
+    sig_b64 = manifest.get("signature")
+    identity = manifest.get("signer_identity")
+    if not sig_b64 or not identity:
+        return False
+
+    try:
+        sig_bytes = base64.b64decode(sig_b64)
+    except Exception:
+        return False
+
+    canonical = manifest_canonical_bytes(manifest)
+    allowed_signers = Path(allowed_signers)
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        sig_file = tmp / "manifest.sig"
+        sig_file.write_bytes(sig_bytes)
+
+        result = subprocess.run(
+            ["ssh-keygen", "-Y", "verify",
+             "-f", str(allowed_signers),
+             "-I", identity,
+             "-n", _SSH_NAMESPACE,
+             "-s", str(sig_file)],
+            input=canonical,
+            capture_output=True,
+        )
+        return result.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# High-level emit
+# ---------------------------------------------------------------------------
+
+@dataclass
+class AttestationRecord:
+    """Fully signed and hash-chained attestation record."""
+    manifest: dict
+    chain_hash: str
+    ledger_path: Path
+
+
+def emit_governed_attestation(
+    *,
+    dispatch_id: str,
+    deliverable_id: str,
+    track_id: str,
+    plan_gate_ref: str,
+    signer_identity: str,
+    timestamp: str,
+    key_path: "str | Path",
+    repo_root: "str | Path | None" = None,
+) -> AttestationRecord:
+    """Build, sign, hash-chain, and persist a governed attestation.
+
+    Writes to <repo_root>/.vnx-attest/governed.ndjson.
+
+    Args:
+        dispatch_id: Dispatch-ID of the governed build.
+        deliverable_id: Deliverable being attested.
+        track_id: Track/objective ID.
+        plan_gate_ref: Plan-gate pass reference.
+        signer_identity: Signer identity (matches allowed_signers).
+        timestamp: ISO-8601 UTC timestamp.
+        key_path: SSH private key path (caller-supplied; never provisioned here).
+        repo_root: Repository root.  Defaults to cwd.
+
+    Returns:
+        AttestationRecord with the signed manifest, its chain hash, and ledger path.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+    ledger_path = repo_root / ".vnx-attest" / "governed.ndjson"
+
+    manifest = build_governed_manifest(
+        dispatch_id=dispatch_id,
+        deliverable_id=deliverable_id,
+        track_id=track_id,
+        plan_gate_ref=plan_gate_ref,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+    )
+    signed = sign_manifest(manifest, key_path)
+    chain_hash = append_chained_entry(ledger_path, signed)
+
+    return AttestationRecord(
+        manifest=signed,
+        chain_hash=chain_hash,
+        ledger_path=ledger_path,
+    )
+
+
+def emit_adhoc_attestation(
+    *,
+    dispatch_id: str,
+    signer_identity: str,
+    timestamp: str,
+    note: str = "",
+    repo_root: "str | Path | None" = None,
+) -> AttestationRecord:
+    """Build and hash-chain an ad-hoc low-attestation manifest.
+
+    Ad-hoc attestations are NOT signed (no key required).  They are
+    distinguishable from governed attestations by attestation_type="ad-hoc"
+    and the absence of lineage fields and a signature.
+
+    Args:
+        dispatch_id: Dispatch-ID or ad-hoc slug.
+        signer_identity: Identity string for audit trail labelling.
+        timestamp: ISO-8601 UTC timestamp.
+        note: Optional description of the ad-hoc action.
+        repo_root: Repository root.  Defaults to cwd.
+
+    Returns:
+        AttestationRecord (no signature field; chain_hash reflects the entry).
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+    ledger_path = repo_root / ".vnx-attest" / "adhoc.ndjson"
+
+    manifest = build_adhoc_manifest(
+        dispatch_id=dispatch_id,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+        note=note,
+    )
+    chain_hash = append_chained_entry(ledger_path, manifest)
+
+    return AttestationRecord(
+        manifest=manifest,
+        chain_hash=chain_hash,
+        ledger_path=ledger_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+def is_governed(manifest: dict) -> bool:
+    """Return True if the manifest is a governed attestation."""
+    return manifest.get("attestation_type") == ATTESTATION_GOVERNED
+
+
+def is_adhoc(manifest: dict) -> bool:
+    """Return True if the manifest is an ad-hoc attestation."""
+    return manifest.get("attestation_type") == ATTESTATION_ADHOC

--- a/tests/test_attestation.py
+++ b/tests/test_attestation.py
@@ -1,0 +1,408 @@
+"""Tests for scripts/lib/attestation.py (D1 — signing authority + manifest).
+
+Covers:
+  - Governed manifest build and field completeness
+  - Ad-hoc manifest build and distinguishability from governed
+  - Sign + verify round-trip using an ephemeral ed25519 test key
+  - Hash-chain linking (prev_hash integrity across two entries)
+  - Bad/corrupted signature fails verify_attestation
+  - Missing signature/identity fields fail verify gracefully
+  - emit_governed_attestation writes to .vnx-attest/governed.ndjson
+  - emit_adhoc_attestation writes to .vnx-attest/adhoc.ndjson (no signature)
+  - canonical bytes are stable (excludes signature + prev_hash)
+"""
+
+import base64
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from attestation import (
+    ATTESTATION_ADHOC,
+    ATTESTATION_GOVERNED,
+    AttestationRecord,
+    build_adhoc_manifest,
+    build_governed_manifest,
+    emit_adhoc_attestation,
+    emit_governed_attestation,
+    is_adhoc,
+    is_governed,
+    manifest_canonical_bytes,
+    manifest_content_hash,
+    sign_manifest,
+    verify_attestation,
+)
+from ndjson_hash_chain import compute_entry_hash, verify_chain
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def ephemeral_key_dir():
+    """Generate a non-interactive ed25519 test key in a temp dir (no keychain)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "testkey"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""],
+            check=True, capture_output=True,
+        )
+        pub = key_path.with_suffix(".pub").read_text().strip()
+        # allowed_signers format: <identity> <keytype> <base64-pubkey>
+        identity = "vnx-test@local"
+        allowed_signers = Path(tmpdir) / "allowed_signers"
+        allowed_signers.write_text(f"{identity} {pub}\n")
+        yield {
+            "key_path": key_path,
+            "identity": identity,
+            "allowed_signers": allowed_signers,
+            "tmpdir": Path(tmpdir),
+        }
+
+
+@pytest.fixture
+def governed_manifest():
+    return build_governed_manifest(
+        dispatch_id="D-test-d1",
+        deliverable_id="D1",
+        track_id="governance-attribution-enforce",
+        plan_gate_ref="gate-pass-ref-abc123",
+        signer_identity="vnx-test@local",
+        timestamp="2026-07-04T12:00:00Z",
+    )
+
+
+@pytest.fixture
+def adhoc_manifest():
+    return build_adhoc_manifest(
+        dispatch_id="ad-hoc:explore-branch",
+        signer_identity="vnx-test@local",
+        timestamp="2026-07-04T12:00:00Z",
+        note="exploratory run, not for merge",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Manifest builders
+# ---------------------------------------------------------------------------
+
+class TestBuildGovernedManifest:
+    def test_required_fields_present(self, governed_manifest):
+        m = governed_manifest
+        assert m["schema_version"] == "1"
+        assert m["attestation_type"] == ATTESTATION_GOVERNED
+        assert m["dispatch_id"] == "D-test-d1"
+        assert m["deliverable_id"] == "D1"
+        assert m["track_id"] == "governance-attribution-enforce"
+        assert m["plan_gate_ref"] == "gate-pass-ref-abc123"
+        assert m["signer_identity"] == "vnx-test@local"
+        assert m["timestamp"] == "2026-07-04T12:00:00Z"
+
+    def test_no_signature_in_unisigned(self, governed_manifest):
+        assert "signature" not in governed_manifest
+
+    def test_is_governed(self, governed_manifest):
+        assert is_governed(governed_manifest)
+        assert not is_adhoc(governed_manifest)
+
+
+class TestBuildAdhocManifest:
+    def test_required_fields(self, adhoc_manifest):
+        m = adhoc_manifest
+        assert m["schema_version"] == "1"
+        assert m["attestation_type"] == ATTESTATION_ADHOC
+        assert m["dispatch_id"] == "ad-hoc:explore-branch"
+        assert m["signer_identity"] == "vnx-test@local"
+        assert m["note"] == "exploratory run, not for merge"
+
+    def test_no_lineage_fields(self, adhoc_manifest):
+        m = adhoc_manifest
+        assert "deliverable_id" not in m
+        assert "track_id" not in m
+        assert "plan_gate_ref" not in m
+
+    def test_no_signature(self, adhoc_manifest):
+        assert "signature" not in adhoc_manifest
+
+    def test_is_adhoc(self, adhoc_manifest):
+        assert is_adhoc(adhoc_manifest)
+        assert not is_governed(adhoc_manifest)
+
+    def test_note_omitted_when_empty(self):
+        m = build_adhoc_manifest(
+            dispatch_id="ad-hoc:x",
+            signer_identity="id@local",
+            timestamp="2026-07-04T00:00:00Z",
+        )
+        assert "note" not in m
+
+
+# ---------------------------------------------------------------------------
+# Canonical bytes stability
+# ---------------------------------------------------------------------------
+
+class TestCanonicalBytes:
+    def test_excludes_signature_field(self, governed_manifest):
+        signed = dict(governed_manifest)
+        signed["signature"] = "fakesig=="
+        assert manifest_canonical_bytes(governed_manifest) == manifest_canonical_bytes(signed)
+
+    def test_excludes_prev_hash_field(self, governed_manifest):
+        chained = dict(governed_manifest)
+        chained["prev_hash"] = "0" * 64
+        assert manifest_canonical_bytes(governed_manifest) == manifest_canonical_bytes(chained)
+
+    def test_content_hash_stable(self, governed_manifest):
+        h1 = manifest_content_hash(governed_manifest)
+        h2 = manifest_content_hash(governed_manifest)
+        assert h1 == h2
+        assert len(h1) == 64
+
+    def test_content_hash_changes_on_field_change(self, governed_manifest):
+        modified = dict(governed_manifest)
+        modified["deliverable_id"] = "D2"
+        assert manifest_content_hash(governed_manifest) != manifest_content_hash(modified)
+
+
+# ---------------------------------------------------------------------------
+# Sign + verify round-trip
+# ---------------------------------------------------------------------------
+
+class TestSignAndVerify:
+    def test_sign_adds_signature_field(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        assert "signature" in signed
+        # Should be valid base64
+        decoded = base64.b64decode(signed["signature"])
+        assert len(decoded) > 0
+
+    def test_sign_preserves_other_fields(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        for key in governed_manifest:
+            assert signed[key] == governed_manifest[key]
+
+    def test_verify_round_trip_passes(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        result = verify_attestation(signed, ephemeral_key_dir["allowed_signers"])
+        assert result is True
+
+    def test_verify_bad_signature_fails(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        # Corrupt the signature
+        corrupted = dict(signed)
+        corrupted["signature"] = base64.b64encode(b"not-a-real-sig").decode("ascii")
+        result = verify_attestation(corrupted, ephemeral_key_dir["allowed_signers"])
+        assert result is False
+
+    def test_verify_tampered_manifest_fails(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        # Tamper with a field after signing — canonical bytes will differ
+        tampered = dict(signed)
+        tampered["deliverable_id"] = "D99"
+        result = verify_attestation(tampered, ephemeral_key_dir["allowed_signers"])
+        assert result is False
+
+    def test_verify_missing_signature_field_returns_false(self, governed_manifest, ephemeral_key_dir):
+        result = verify_attestation(governed_manifest, ephemeral_key_dir["allowed_signers"])
+        assert result is False
+
+    def test_verify_missing_identity_returns_false(self, governed_manifest, ephemeral_key_dir):
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        no_identity = dict(signed)
+        del no_identity["signer_identity"]
+        result = verify_attestation(no_identity, ephemeral_key_dir["allowed_signers"])
+        assert result is False
+
+    def test_verify_wrong_allowed_signers(self, governed_manifest, ephemeral_key_dir):
+        """A signature valid for one key fails against empty/wrong allowed_signers."""
+        signed = sign_manifest(governed_manifest, ephemeral_key_dir["key_path"])
+        with tempfile.NamedTemporaryFile(mode="w", suffix=".as", delete=False) as f:
+            # Empty allowed_signers — no keys trusted
+            empty_as = Path(f.name)
+        try:
+            result = verify_attestation(signed, empty_as)
+            assert result is False
+        finally:
+            empty_as.unlink(missing_ok=True)
+
+
+# ---------------------------------------------------------------------------
+# Hash-chain linking
+# ---------------------------------------------------------------------------
+
+class TestHashChainLinking:
+    def test_two_governed_entries_chain_correctly(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo_root = Path(tmpdir)
+
+            rec1 = emit_governed_attestation(
+                dispatch_id="D-chain-test-1",
+                deliverable_id="D1",
+                track_id="some-track",
+                plan_gate_ref="ref-a",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo_root,
+            )
+            rec2 = emit_governed_attestation(
+                dispatch_id="D-chain-test-2",
+                deliverable_id="D2",
+                track_id="some-track",
+                plan_gate_ref="ref-b",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T11:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo_root,
+            )
+
+            ledger = rec1.ledger_path
+            is_valid, violations, status = verify_chain(ledger)
+            assert is_valid, f"Chain broken: {violations}"
+            assert status == "verified"
+
+            # The second entry's prev_hash = first entry's content hash
+            lines = [json.loads(l) for l in ledger.read_text().splitlines() if l.strip()]
+            assert len(lines) == 2
+            expected_prev = compute_entry_hash(lines[0])
+            assert lines[1]["prev_hash"] == expected_prev
+
+    def test_chain_hash_in_record_matches_ledger(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_governed_attestation(
+                dispatch_id="D-hash-check",
+                deliverable_id="D1",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=Path(tmpdir),
+            )
+            ledger_entry = json.loads(rec.ledger_path.read_text().strip())
+            assert compute_entry_hash(ledger_entry) == rec.chain_hash
+
+
+# ---------------------------------------------------------------------------
+# emit_governed_attestation / emit_adhoc_attestation
+# ---------------------------------------------------------------------------
+
+class TestEmitGovernedAttestation:
+    def test_returns_attestation_record(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_governed_attestation(
+                dispatch_id="D-emit-gov",
+                deliverable_id="D1",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=Path(tmpdir),
+            )
+            assert isinstance(rec, AttestationRecord)
+            assert rec.ledger_path.name == "governed.ndjson"
+
+    def test_ledger_entry_verifiable(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_governed_attestation(
+                dispatch_id="D-emit-verif",
+                deliverable_id="D1",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=Path(tmpdir),
+            )
+            entry = json.loads(rec.ledger_path.read_text().strip())
+            assert verify_attestation(entry, ephemeral_key_dir["allowed_signers"])
+
+    def test_attestation_type_is_governed(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_governed_attestation(
+                dispatch_id="D-type-check",
+                deliverable_id="D1",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=Path(tmpdir),
+            )
+            assert rec.manifest["attestation_type"] == ATTESTATION_GOVERNED
+
+
+class TestEmitAdhocAttestation:
+    def test_returns_attestation_record(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_adhoc_attestation(
+                dispatch_id="ad-hoc:explore",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                repo_root=Path(tmpdir),
+            )
+            assert isinstance(rec, AttestationRecord)
+            assert rec.ledger_path.name == "adhoc.ndjson"
+
+    def test_no_signature_in_adhoc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_adhoc_attestation(
+                dispatch_id="ad-hoc:explore",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                repo_root=Path(tmpdir),
+            )
+            assert "signature" not in rec.manifest
+
+    def test_attestation_type_is_adhoc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_adhoc_attestation(
+                dispatch_id="ad-hoc:explore",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                repo_root=Path(tmpdir),
+            )
+            assert rec.manifest["attestation_type"] == ATTESTATION_ADHOC
+
+    def test_adhoc_not_verifiable_as_governed(self, ephemeral_key_dir):
+        """Ad-hoc manifests have no signature, so verify_attestation returns False."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            rec = emit_adhoc_attestation(
+                dispatch_id="ad-hoc:explore",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                repo_root=Path(tmpdir),
+            )
+            result = verify_attestation(rec.manifest, ephemeral_key_dir["allowed_signers"])
+            assert result is False
+
+    def test_adhoc_is_distinguishable_from_governed(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            adhoc = emit_adhoc_attestation(
+                dispatch_id="ad-hoc:x",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                repo_root=Path(tmpdir),
+            )
+            gov = emit_governed_attestation(
+                dispatch_id="D-gov-x",
+                deliverable_id="D1",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="vnx-test@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=Path(tmpdir),
+            )
+            assert is_adhoc(adhoc.manifest)
+            assert not is_governed(adhoc.manifest)
+            assert is_governed(gov.manifest)
+            assert not is_adhoc(gov.manifest)


### PR DESCRIPTION
## Summary

D1 of governance-attribution-enforce (operator-accepted plan rev 4) — the signing foundation for the server-side signed-attestation model. Grounded in the D0 audit (`claudedocs/2026-07-04-govenf-d0-audit.md`).

- `scripts/lib/attestation.py`: emits a signed attestation for a governed action — lineage (Dispatch-ID, deliverable_id, track_id, plan-gate-pass ref) hash-chained via `ndjson_hash_chain`, signed with a caller-supplied SSH key. `verify_attestation` checks a detached signature over the manifest's canonical bytes against `allowed_signers`.
- Ad-hoc actions get a distinct `attestation_type=ad-hoc`, never a governed signature.
- **The signing key is always passed IN — no keychain/provisioning in code.** The v1 build timed out because macOS Keychain provisioning needs interactive Touch ID (a headless worker can't). `docs/governance/KEY_PROVISIONING.md` documents the one-time OPERATOR step (Vincent runs it with Touch ID).
- Advisory only — nothing enforces yet (D3 is the server gate, later PR).

## Verification

30 attestation tests pass with an ephemeral test key (sign/verify round-trip, tamper detection, hash-chain linking, ad-hoc/governed distinguishability). The 3 `governance_digest_runner` failures are PRE-EXISTING on main (verified), unrelated.

## Operator follow-up

After merge, provision the real signing key: see `docs/governance/KEY_PROVISIONING.md` (needs your Touch ID). This is the one step a headless agent cannot do.

## Provenance

Governed tmux-spawn lane (dispatch `D-govenf-d1-signing-v2`, security-engineer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC