### PR TITLE
feat(intel): outcome-grounding shadow-verify V2 vs V1 + directional check [D5]

### DIFF
--- a/scripts/lib/intelligence_persist.py
+++ b/scripts/lib/intelligence_persist.py
@@ -568,3 +568,193 @@ def _append_to_json_list(existing_json: Optional[str], new_item: str) -> str:
     if new_item and new_item not in items:
         items.append(new_item)
     return json.dumps(items[-20:])  # keep last 20
+
+
+# ---------------------------------------------------------------------------
+# Shadow / divergence comparison (D5)
+# ---------------------------------------------------------------------------
+
+def _projected_conf(
+    found: bool,
+    current_conf: float,
+    cur_succ: int,
+    cur_fail: int,
+    is_success: bool,
+) -> float:
+    """Shadow helper: projected confidence after one outcome — no DB write.
+
+    When ``found`` is False the pattern is not matched by this path, so the
+    confidence is left unchanged.  When True, the beta-posterior is recomputed
+    with the incremented counter.
+    """
+    if not found:
+        return current_conf
+    from confidence_reconcile import beta_score
+    new_s = cur_succ + (1 if is_success else 0)
+    new_f = cur_fail + (0 if is_success else 1)
+    return round(beta_score(new_s, new_f), 6)
+
+
+def shadow_grounding_compare(
+    db_path: Path,
+    dispatches: List[Dict[str, Any]],
+) -> Dict[str, Any]:
+    """Read-only V1 vs V2 confidence divergence report.
+
+    For each entry in ``dispatches`` (list of
+    ``{'dispatch_id': str, 'status': 'success'|'failure'}``), resolves which
+    patterns V1 (``source_dispatch_ids LIKE``) and V2
+    (``dispatch_pattern_offered`` junction) would update, then computes the
+    projected beta-score each path would produce — WITHOUT writing anything.
+
+    ``VNX_OUTCOME_GROUNDING_V2`` is intentionally ignored: shadow mode always
+    evaluates both paths in parallel so the report is flag-independent.
+
+    Returns::
+
+        {
+          'dispatches': [
+            {
+              'dispatch_id': str,
+              'status': str,
+              'v1_pattern_ids': [int, ...],
+              'v2_pattern_ids': [int, ...],
+              'v1_only':   [int, ...],   # matched by V1, not V2
+              'v2_only':   [int, ...],   # matched by V2, not V1
+              'agreement': [int, ...],   # matched by both
+              'pattern_details': {
+                  sp_id: {
+                      'title': str,
+                      'current_conf': float,
+                      'v1_new_conf': float,  # current_conf when not matched
+                      'v2_new_conf': float,
+                      'in_v1': bool,
+                      'in_v2': bool,
+                  }
+              },
+              'has_divergence': bool,
+            },
+            ...
+          ],
+          'summary': {
+              'total_dispatches': int,
+              'diverged_dispatches': int,
+              'v2_only_grounded': int,
+              'v1_only_grounded': int,
+              'junction_available': bool,
+          },
+        }
+    """
+    if not db_path.exists():
+        return {
+            "dispatches": [],
+            "summary": {
+                "total_dispatches": 0,
+                "diverged_dispatches": 0,
+                "v2_only_grounded": 0,
+                "v1_only_grounded": 0,
+                "junction_available": False,
+            },
+        }
+
+    from confidence_reconcile import SUCCESS_PATTERN_PREFIX
+
+    conn = sqlite3.connect(str(db_path), timeout=10.0)
+    conn.row_factory = sqlite3.Row
+    try:
+        project_id = current_project_id()
+        sp_has_project = _has_column(conn, "success_patterns", "project_id")
+        junction_available = _has_table(conn, "dispatch_pattern_offered")
+        pu_table_exists = _has_table(conn, "pattern_usage")
+
+        dispatch_results: List[Dict[str, Any]] = []
+        total_v2_only = 0
+        total_v1_only = 0
+        diverged = 0
+
+        for entry in dispatches:
+            dispatch_id = (entry.get("dispatch_id") or "").strip()
+            status = (entry.get("status") or "").lower()
+            is_success = status == "success"
+
+            v1_rows = _legacy_source_id_rows(conn, dispatch_id, project_id, sp_has_project)
+            v1_by_id = {int(row["id"]): row for row in v1_rows}
+            v1_ids = set(v1_by_id)
+
+            if junction_available:
+                v2_rows = _junction_grounded_rows(conn, dispatch_id, project_id, sp_has_project)
+            else:
+                v2_rows = []
+            v2_by_id = {int(row["id"]): row for row in v2_rows}
+            v2_ids = set(v2_by_id)
+
+            all_ids = v1_ids | v2_ids
+            v1_only = sorted(v1_ids - v2_ids)
+            v2_only = sorted(v2_ids - v1_ids)
+            agreement = sorted(v1_ids & v2_ids)
+            has_divergence = bool(v1_only or v2_only)
+
+            if has_divergence:
+                diverged += 1
+            total_v2_only += len(v2_only)
+            total_v1_only += len(v1_only)
+
+            pattern_details: Dict[int, Dict[str, Any]] = {}
+            for sp_id in all_ids:
+                source_row = v1_by_id.get(sp_id) or v2_by_id.get(sp_id)
+                current_conf = float(source_row["confidence_score"] or 0.0) if source_row else 0.0
+                title = str(source_row["title"] or f"pattern_{sp_id}")[:120] if source_row else f"pattern_{sp_id}"
+
+                cur_succ = 0
+                cur_fail = 0
+                if pu_table_exists:
+                    pid = f"{SUCCESS_PATTERN_PREFIX}{sp_id}"
+                    try:
+                        pu_row = conn.execute(
+                            "SELECT success_count, failure_count FROM pattern_usage "
+                            "WHERE pattern_id = ?",
+                            (pid,),
+                        ).fetchone()
+                        if pu_row:
+                            cur_succ = int(pu_row["success_count"] or 0)
+                            cur_fail = int(pu_row["failure_count"] or 0)
+                    except sqlite3.OperationalError:
+                        pass
+
+                pattern_details[sp_id] = {
+                    "title": title,
+                    "current_conf": current_conf,
+                    "v1_new_conf": _projected_conf(
+                        sp_id in v1_ids, current_conf, cur_succ, cur_fail, is_success
+                    ),
+                    "v2_new_conf": _projected_conf(
+                        sp_id in v2_ids, current_conf, cur_succ, cur_fail, is_success
+                    ),
+                    "in_v1": sp_id in v1_ids,
+                    "in_v2": sp_id in v2_ids,
+                }
+
+            dispatch_results.append({
+                "dispatch_id": dispatch_id,
+                "status": status,
+                "v1_pattern_ids": sorted(v1_ids),
+                "v2_pattern_ids": sorted(v2_ids),
+                "v1_only": v1_only,
+                "v2_only": v2_only,
+                "agreement": agreement,
+                "pattern_details": pattern_details,
+                "has_divergence": has_divergence,
+            })
+
+        return {
+            "dispatches": dispatch_results,
+            "summary": {
+                "total_dispatches": len(dispatches),
+                "diverged_dispatches": diverged,
+                "v2_only_grounded": total_v2_only,
+                "v1_only_grounded": total_v1_only,
+                "junction_available": junction_available,
+            },
+        }
+    finally:
+        conn.close()

--- a/tests/test_grounding_shadow.py
+++ b/tests/test_grounding_shadow.py
@@ -1,0 +1,369 @@
+#!/usr/bin/env python3
+"""Tests for outcome-grounding shadow mode: V1 vs V2 divergence report.
+
+Dispatch-ID: D-selfimprove-d5-grounding
+
+Named fixture: ``receipt_trail_gap_5x3``
+
+Corpus design:
+- 5 patterns total
+- Patterns 1-3: offered to FAILED dispatches; source_dispatch_ids=[] (the receipt-trail gap)
+- Patterns 4-5: offered to SUCCESSFUL dispatches; source_dispatch_ids=[dispatch_id]
+
+V1 (legacy substring join) cannot ground patterns 1-3 for their failed dispatches
+because the source_dispatch_ids list is empty — the LIKE match fails on "[]".
+V2 (junction) finds them via dispatch_pattern_offered and correctly decays confidence.
+
+Acceptance check (deterministic, no judge):
+  For each failure dispatch, v2_new_conf < current_conf AND v1_new_conf == current_conf.
+  The V2 projected confidence is strictly lower than V1 for the 3 failure patterns.
+"""
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from intelligence_persist import shadow_grounding_compare, update_confidence_from_outcome  # noqa: E402
+
+# ---------------------------------------------------------------------------
+# Fixture name — the named corpus referenced in the acceptance check
+# ---------------------------------------------------------------------------
+
+FIXTURE_NAME = "receipt_trail_gap_5x3"
+
+# ---------------------------------------------------------------------------
+# Schema / helpers (self-contained; no cross-test imports)
+# ---------------------------------------------------------------------------
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS success_patterns (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    pattern_type TEXT NOT NULL,
+    category TEXT NOT NULL,
+    title TEXT NOT NULL,
+    description TEXT NOT NULL,
+    pattern_data TEXT NOT NULL,
+    confidence_score REAL DEFAULT 0.0,
+    usage_count INTEGER DEFAULT 0,
+    source_dispatch_ids TEXT,
+    first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
+    last_used DATETIME
+);
+
+CREATE TABLE IF NOT EXISTS pattern_usage (
+    pattern_id TEXT PRIMARY KEY,
+    pattern_title TEXT NOT NULL,
+    pattern_hash TEXT NOT NULL,
+    used_count INTEGER DEFAULT 0,
+    ignored_count INTEGER DEFAULT 0,
+    success_count INTEGER DEFAULT 0,
+    failure_count INTEGER DEFAULT 0,
+    last_used TIMESTAMP,
+    last_offered TIMESTAMP,
+    confidence REAL DEFAULT 1.0,
+    created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+    updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE IF NOT EXISTS confidence_events (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    dispatch_id TEXT NOT NULL,
+    terminal TEXT,
+    outcome TEXT NOT NULL,
+    patterns_boosted INTEGER DEFAULT 0,
+    patterns_decayed INTEGER DEFAULT 0,
+    confidence_change REAL NOT NULL,
+    occurred_at TEXT NOT NULL,
+    grounding_source TEXT
+);
+
+CREATE TABLE IF NOT EXISTS dispatch_pattern_offered (
+    dispatch_id   TEXT NOT NULL,
+    pattern_id    TEXT NOT NULL,
+    pattern_title TEXT NOT NULL,
+    offered_at    TEXT NOT NULL,
+    PRIMARY KEY (dispatch_id, pattern_id)
+);
+"""
+
+
+def _make_db(tmp_path: Path) -> Path:
+    db = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db))
+    conn.executescript(_SCHEMA)
+    conn.commit()
+    conn.close()
+    return db
+
+
+def _insert_pattern(db: Path, *, source_dispatch_ids, confidence: float = 0.5, title: str = "Test pattern") -> int:
+    conn = sqlite3.connect(str(db))
+    src = json.dumps(source_dispatch_ids) if source_dispatch_ids is not None else None
+    cur = conn.execute(
+        "INSERT INTO success_patterns "
+        "(pattern_type, category, title, description, pattern_data, "
+        " confidence_score, usage_count, source_dispatch_ids) "
+        "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+        ("approach", "governance", title, "desc", "{}", confidence, 1, src),
+    )
+    row_id = cur.lastrowid
+    conn.commit()
+    conn.close()
+    return row_id
+
+
+def _offer(db: Path, dispatch_id: str, pattern_id: str, title: str = "Test pattern") -> None:
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO dispatch_pattern_offered "
+        "(dispatch_id, pattern_id, pattern_title, offered_at) "
+        "VALUES (?, ?, ?, ?)",
+        (dispatch_id, pattern_id, title, "2026-07-04T00:00:00+00:00"),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _confidence(db: Path, sp_id: int) -> float:
+    conn = sqlite3.connect(str(db))
+    row = conn.execute(
+        "SELECT confidence_score FROM success_patterns WHERE id = ?", (sp_id,)
+    ).fetchone()
+    conn.close()
+    return float(row[0])
+
+
+# ---------------------------------------------------------------------------
+# Named fixture builder: receipt_trail_gap_5x3
+# ---------------------------------------------------------------------------
+
+_FAILURE_DISPATCHES = ["D-shadow-F1", "D-shadow-F2", "D-shadow-F3"]
+_SUCCESS_DISPATCHES = ["D-shadow-S1", "D-shadow-S2"]
+
+
+def _build_fixture_db(tmp_path: Path):
+    """Build the ``receipt_trail_gap_5x3`` corpus.
+
+    Returns (db_path, dispatches_list) where dispatches_list has the 5 entries
+    in the order [F1, F2, F3, S1, S2].
+    """
+    db = _make_db(tmp_path)
+
+    # Patterns 1-3: offered to failed dispatches; source_dispatch_ids intentionally EMPTY
+    sp_ids_failure = []
+    for i, did in enumerate(_FAILURE_DISPATCHES, start=1):
+        sp_id = _insert_pattern(db, source_dispatch_ids=[], confidence=0.5, title=f"Failure pattern {i}")
+        _offer(db, did, f"intel_sp_{sp_id}", title=f"Failure pattern {i}")
+        sp_ids_failure.append(sp_id)
+
+    # Patterns 4-5: offered to successful dispatches; source_dispatch_ids populated
+    sp_ids_success = []
+    for i, did in enumerate(_SUCCESS_DISPATCHES, start=1):
+        sp_id = _insert_pattern(db, source_dispatch_ids=[did], confidence=0.5, title=f"Success pattern {i}")
+        _offer(db, did, f"intel_sp_{sp_id}", title=f"Success pattern {i}")
+        sp_ids_success.append(sp_id)
+
+    dispatches = (
+        [{"dispatch_id": d, "status": "failure"} for d in _FAILURE_DISPATCHES]
+        + [{"dispatch_id": d, "status": "success"} for d in _SUCCESS_DISPATCHES]
+    )
+    return db, dispatches, sp_ids_failure, sp_ids_success
+
+
+# ---------------------------------------------------------------------------
+# Acceptance check: receipt_trail_gap_5x3 — directional difference assertion
+# ---------------------------------------------------------------------------
+
+def test_receipt_trail_gap_5x3_directional_check(tmp_path, monkeypatch):
+    """Fixture receipt_trail_gap_5x3: V2 shows lower confidence for failure patterns.
+
+    This is the deterministic scripted acceptance check for D5.  No judge;
+    the assertions are numeric comparisons on projected confidence values.
+    """
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+    db, dispatches, sp_ids_failure, sp_ids_success = _build_fixture_db(tmp_path)
+
+    report = shadow_grounding_compare(db, dispatches)
+    summary = report["summary"]
+
+    assert summary["junction_available"], "junction table must exist in fixture"
+    assert summary["total_dispatches"] == 5
+
+    failure_entries = [e for e in report["dispatches"] if e["status"] == "failure"]
+    success_entries = [e for e in report["dispatches"] if e["status"] == "success"]
+    assert len(failure_entries) == 3
+    assert len(success_entries) == 2
+
+    # Core directional check: for each failure dispatch
+    for entry in failure_entries:
+        assert entry["has_divergence"], (
+            f"fixture {FIXTURE_NAME}: expected divergence for {entry['dispatch_id']}"
+        )
+        assert not entry["v1_only"], (
+            f"{entry['dispatch_id']}: V1 must not find patterns with empty source_dispatch_ids"
+        )
+        assert entry["v2_only"], (
+            f"{entry['dispatch_id']}: V2 must find the pattern via junction"
+        )
+
+        for sp_id in entry["v2_only"]:
+            detail = entry["pattern_details"][sp_id]
+            # V2 correctly decays the confidence because the dispatch failed
+            assert detail["v2_new_conf"] < detail["current_conf"], (
+                f"fixture {FIXTURE_NAME}: V2 must decay for failure "
+                f"(sp_id={sp_id}, v2={detail['v2_new_conf']}, current={detail['current_conf']})"
+            )
+            # V1 is blind to this failure (empty source_dispatch_ids = no LIKE match)
+            assert detail["v1_new_conf"] == detail["current_conf"], (
+                f"fixture {FIXTURE_NAME}: V1 must leave confidence unchanged "
+                f"(sp_id={sp_id}, v1={detail['v1_new_conf']}, current={detail['current_conf']})"
+            )
+            # The key directional assertion: V2 < V1
+            assert detail["v2_new_conf"] < detail["v1_new_conf"], (
+                f"fixture {FIXTURE_NAME}: V2 must be strictly lower than V1 for failure patterns "
+                f"(sp_id={sp_id}, v2={detail['v2_new_conf']}, v1={detail['v1_new_conf']})"
+            )
+
+    # Summary aggregates
+    assert summary["diverged_dispatches"] == 3
+    assert summary["v2_only_grounded"] == 3
+    assert summary["v1_only_grounded"] == 0
+
+    # Success dispatches: both paths agree (source_dispatch_ids is populated)
+    for entry in success_entries:
+        assert not entry["v1_only"], (
+            f"fixture {FIXTURE_NAME}: no V1-only for success dispatch {entry['dispatch_id']}"
+        )
+        assert not entry["v2_only"], (
+            f"fixture {FIXTURE_NAME}: no V2-only for success dispatch {entry['dispatch_id']}"
+        )
+        for sp_id in entry["agreement"]:
+            detail = entry["pattern_details"][sp_id]
+            assert detail["v1_new_conf"] == detail["v2_new_conf"], (
+                f"fixture {FIXTURE_NAME}: V1 and V2 must agree for success dispatch "
+                f"(sp_id={sp_id})"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Guard: shadow must not change the live default or write to DB
+# ---------------------------------------------------------------------------
+
+def test_shadow_does_not_mutate_db(tmp_path, monkeypatch):
+    """shadow_grounding_compare must not alter any confidence_score rows."""
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+    db, dispatches, sp_ids_failure, _ = _build_fixture_db(tmp_path)
+
+    before = {sp_id: _confidence(db, sp_id) for sp_id in sp_ids_failure}
+    shadow_grounding_compare(db, dispatches)
+    after = {sp_id: _confidence(db, sp_id) for sp_id in sp_ids_failure}
+
+    assert before == after, "shadow_grounding_compare must not write to success_patterns"
+
+
+def test_shadow_does_not_change_env_flag(tmp_path, monkeypatch):
+    """Calling shadow_grounding_compare must not set VNX_OUTCOME_GROUNDING_V2."""
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+    db, dispatches, _, _ = _build_fixture_db(tmp_path)
+
+    shadow_grounding_compare(db, dispatches)
+
+    assert os.environ.get("VNX_OUTCOME_GROUNDING_V2") is None, (
+        "shadow_grounding_compare must not set VNX_OUTCOME_GROUNDING_V2"
+    )
+
+
+# ---------------------------------------------------------------------------
+# V1 default preservation: flag unset → live update_confidence_from_outcome
+# does NOT ground via junction (receipt-trail gap stays open until V2 is flipped)
+# ---------------------------------------------------------------------------
+
+def test_v1_default_preserved_for_failure_with_empty_source_ids(tmp_path, monkeypatch):
+    """V1 default: live update_confidence_from_outcome does not decay via junction."""
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+    db, dispatches, sp_ids_failure, _ = _build_fixture_db(tmp_path)
+
+    failure_dispatch = dispatches[0]  # D-shadow-F1, status='failure'
+    result = update_confidence_from_outcome(
+        db, failure_dispatch["dispatch_id"], "T1", "failure"
+    )
+
+    # V1 flag off → LIKE on "[]" finds nothing → 0 grounded
+    assert result == {"boosted": 0, "decayed": 0}, (
+        "V1 default must not decay patterns with empty source_dispatch_ids"
+    )
+    # Confidence unchanged
+    assert _confidence(db, sp_ids_failure[0]) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# Shadow with no junction table — falls back gracefully
+# ---------------------------------------------------------------------------
+
+def test_shadow_no_junction_reports_unavailable(tmp_path, monkeypatch):
+    """When dispatch_pattern_offered is absent, shadow reports junction_available=False."""
+    monkeypatch.delenv("VNX_OUTCOME_GROUNDING_V2", raising=False)
+
+    db = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db))
+    # Schema without the junction table
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            pattern_type TEXT NOT NULL,
+            category TEXT NOT NULL,
+            title TEXT NOT NULL,
+            description TEXT NOT NULL,
+            pattern_data TEXT NOT NULL,
+            confidence_score REAL DEFAULT 0.5,
+            usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT,
+            first_seen DATETIME DEFAULT CURRENT_TIMESTAMP,
+            last_used DATETIME
+        );
+        CREATE TABLE IF NOT EXISTS pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TIMESTAMP,
+            confidence REAL DEFAULT 1.0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+    dispatches = [{"dispatch_id": "D-test", "status": "failure"}]
+    report = shadow_grounding_compare(db, dispatches)
+
+    assert not report["summary"]["junction_available"]
+    assert report["summary"]["total_dispatches"] == 1
+    assert report["summary"]["v2_only_grounded"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Shadow with nonexistent DB — returns empty report, no exception
+# ---------------------------------------------------------------------------
+
+def test_shadow_missing_db(tmp_path):
+    """shadow_grounding_compare returns an empty report when DB does not exist."""
+    db = tmp_path / "missing.db"
+    dispatches = [{"dispatch_id": "D-x", "status": "failure"}]
+    report = shadow_grounding_compare(db, dispatches)
+
+    assert report["summary"]["total_dispatches"] == 0
+    assert report["dispatches"] == []

--- a/vnx_cli/commands/learning.py
+++ b/vnx_cli/commands/learning.py
@@ -146,14 +146,102 @@ def _cmd_review(args) -> int:
     return 0
 
 
+def _cmd_grounding_shadow(args) -> int:
+    """Compare V1 (substring-join) vs V2 (junction) grounding — read-only, no DB writes."""
+    import sqlite3 as _sqlite3
+    project_dir = Path(getattr(args, "project_dir", "."))
+    limit = int(getattr(args, "limit", 50))
+
+    state_dir = _resolve_state_dir(project_dir)
+    db_path = state_dir / "quality_intelligence.db"
+
+    if not db_path.exists():
+        print(f"error: quality_intelligence.db not found at {db_path}", file=sys.stderr)
+        print("Run `vnx init` to initialise the project first.", file=sys.stderr)
+        return 1
+
+    try:
+        conn = _sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = _sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT dispatch_id, outcome_status FROM dispatch_metadata "
+                "WHERE outcome_status IN ('success', 'failure') "
+                "ORDER BY dispatched_at DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+        except _sqlite3.OperationalError:
+            rows = []
+        finally:
+            conn.close()
+    except Exception as exc:
+        print(f"error: could not read dispatch_metadata: {exc}", file=sys.stderr)
+        return 1
+
+    if not rows:
+        print("No completed dispatches found in dispatch_metadata.")
+        print("Run some dispatches first to populate outcome data.")
+        return 0
+
+    dispatches = [
+        {"dispatch_id": r["dispatch_id"], "status": r["outcome_status"]}
+        for r in rows
+    ]
+
+    import intelligence_persist as _ip  # type: ignore[import]
+    report = _ip.shadow_grounding_compare(db_path, dispatches)
+
+    summary = report["summary"]
+    print("\nVNX Learning — Outcome Grounding Shadow (V1 vs V2)")
+    print("=" * 52)
+    print(f"Dispatches analysed : {summary['total_dispatches']}")
+    print(f"Junction available  : {'yes' if summary['junction_available'] else 'no'}")
+
+    if not summary["junction_available"]:
+        print()
+        print("No dispatch_pattern_offered junction table found.")
+        print("V2 grounding requires the junction — run `vnx migrate` to create it.")
+        return 0
+
+    diverged_entries = [e for e in report["dispatches"] if e["has_divergence"]]
+    if diverged_entries:
+        print()
+        for entry in diverged_entries:
+            n_v2_only = len(entry["v2_only"])
+            n_v1_only = len(entry["v1_only"])
+            tag = f"[{entry['status']}]"
+            print(f"  {entry['dispatch_id']} {tag}")
+            if n_v2_only:
+                print(f"    V2-only grounded (V1 missed): {n_v2_only} pattern(s)")
+            if n_v1_only:
+                print(f"    V1-only grounded (V2 skips) : {n_v1_only} pattern(s)")
+
+    print()
+    print("Divergence summary:")
+    print(f"  Diverged dispatches             : {summary['diverged_dispatches']}/{summary['total_dispatches']}")
+    print(f"  Patterns V2 grounds / V1 misses : {summary['v2_only_grounded']}")
+    print(f"  Patterns V1 grounds / V2 skips  : {summary['v1_only_grounded']}")
+
+    if summary["diverged_dispatches"] == 0:
+        print("\nNo divergence — V1 and V2 agree on all dispatches.")
+    else:
+        print()
+        print("To flip the default to V2 once shadow validates on real data:")
+        print("  Set VNX_OUTCOME_GROUNDING_V2=1 in your environment, or")
+        print("  flip the config toggle in the dashboard (requires operator approval).")
+
+    return 0
+
+
 def vnx_learning(args) -> int:
     sub = getattr(args, "learning_subcommand", None)
     dispatch = {
         "run": _cmd_run,
         "status": _cmd_status,
         "review": _cmd_review,
+        "grounding-shadow": _cmd_grounding_shadow,
     }
     if sub in dispatch:
         return dispatch[sub](args)
-    print("Usage: vnx learning {run|status|review}")
+    print("Usage: vnx learning {run|status|review|grounding-shadow}")
     return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -332,6 +332,19 @@ def _register_learning_subparser(subparsers: argparse.Action) -> None:
         help="which proposals to show: rules, archival, or all (default: all)",
     )
 
+    lr_gs = learning_subs.add_parser(
+        "grounding-shadow",
+        help="compare V1 (substring-join) vs V2 (junction) confidence grounding — read-only",
+    )
+    lr_gs.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_gs.add_argument(
+        "--limit",
+        type=int,
+        default=50,
+        metavar="N",
+        help="max recent dispatches to analyse (default: 50)",
+    )
+
 
 def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_parser = subparsers.add_parser(


### PR DESCRIPTION
## Summary

D5 of self-improve-loop-v2. The junction path is already wired behind `VNX_OUTCOME_GROUNDING_V2` (map implication 5, corrected from rev-1's inverted assumption), so this ships the DIAGNOSTIC, not a rebuild.

- Read-only SHADOW mode: computes both V1 (legacy substring join) and V2 (junction) confidence deltas WITHOUT writing the DB or flipping the live default.
- Named fixture `receipt_trail_gap_5x3`: proves V2 correctly decays confidence for the 3 failure patterns V1 is blind to (empty source_dispatch_ids but a junction row). Deterministic directional check, not a judge.
- `VNX_OUTCOME_GROUNDING_V2` stays OFF by default — the operator validates on real data via the shadow, then flips as a follow-up. Documented.

## Verification

grounding-shadow tests pass (14 related per the report). The 3 `test_subprocess_dispatch_cfx_r1` failures are PRE-EXISTING on main, unrelated.

## Provenance

Governed tmux-spawn lane (dispatch `D-selfimprove-d5-grounding`). Map + plan rev 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC