### PR TITLE
feat(intel): tagger A/B harness (optional precision, no default-on) [D4]

### DIFF
--- a/scripts/lib/vnx_tagger.py
+++ b/scripts/lib/vnx_tagger.py
@@ -100,16 +100,33 @@ def llm_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:
 
     Honours VNX_TAGGER_ENABLED (opt-in) and VNX_TAGGER_PROVIDER (model-agnostic).
     """
-    if not is_enabled() or not (text or paths):
-        return []
+    tags, _ = _llm_tags_with_cost(text, paths, enabled_override=False)
+    return tags
+
+
+def _llm_tags_with_cost(
+    text: str,
+    paths: Optional[List[str]] = None,
+    enabled_override: bool = False,
+) -> "tuple[List[str], float]":
+    """Like llm_tags but returns (tags, cost_usd). For A/B measurement use.
+
+    enabled_override=True bypasses VNX_TAGGER_ENABLED so the caller can run the
+    LLM arm regardless of the env flag (the A/B harness controls the flag itself).
+    Fail-silent: any error returns ([], 0.0).
+    """
+    if not enabled_override and not is_enabled():
+        return [], 0.0
+    if not (text or paths):
+        return [], 0.0
     try:
         from classifier_providers import get_provider
         provider = get_provider(get_tagger_provider_name())
         if not provider.is_available():
-            return []
+            return [], 0.0
         result = provider.classify(_build_prompt(text or "", paths), _max_tokens=200)
         if result.error:
-            return []
+            return [], 0.0
         data = result.parsed_json
         if data is None and result.raw_response:
             try:
@@ -117,11 +134,12 @@ def llm_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:
             except (json.JSONDecodeError, TypeError):
                 data = None
         if not isinstance(data, dict):
-            return []
-        return validate_tags(list(data.get("tags", []))[: _MAX_TAGS * 2])
+            return [], 0.0
+        tags = validate_tags(list(data.get("tags", []))[: _MAX_TAGS * 2])
+        cost = float(getattr(result, "cost_usd", None) or 0.0)
+        return tags, cost
     except Exception:
-        # Fail-silent: callers fall back to the deterministic floor.
-        return []
+        return [], 0.0
 
 
 def enrich_tags(text: str, paths: Optional[List[str]] = None) -> List[str]:

--- a/tests/test_tagger_ab.py
+++ b/tests/test_tagger_ab.py
@@ -1,0 +1,460 @@
+"""Tests for the tagger A/B harness (D4 — tagger as optional precision).
+
+Covers:
+- selector _relevance_score works with tagger OFF (no hard dependency on LLM tags)
+- derive_tags is the sole tag source when tagger disabled
+- _sample_patterns: DB missing, table missing, normal case
+- _run_ab_comparison: both arms, provider-unavailable case, rescue rate
+- _cmd_tagger_ab: no-DB path, seeded-sample with mocked LLM
+- Decision criterion thresholds in the report output
+- VNX_TAGGER_ENABLED default is OFF (no accidental default-on flip)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import List
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO))
+
+
+# ---------------------------------------------------------------------------
+# Selector works without the tagger (no hard dependency)
+# ---------------------------------------------------------------------------
+
+def test_relevance_score_positive_without_tagger(monkeypatch):
+    """_relevance_score returns > 0 via derive_tags when VNX_TAGGER_ENABLED is unset."""
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+
+    from intelligence_selector import _relevance_score
+
+    class _Item:
+        title = "fix dispatch lane bug"
+        content = ""
+        confidence = 0.8
+        scope_tags = None  # no stored tags — tagger was never on
+        item_class = "proven_pattern"
+        last_seen = None
+
+    query_scope = ["dispatch", "fix_bug"]
+    score = _relevance_score(_Item(), query_scope)
+
+    # derive_tags("fix dispatch lane bug") finds ["dispatch", "fix_bug"] → overlap 2
+    # score = 0.8 * (1 + 2) * 1.0 * 1.2 = 2.88
+    assert score > 0
+    assert score > 0.8  # overlap must have factored in (score > confidence baseline)
+
+
+def test_relevance_score_equals_derive_tags_score_when_tagger_disabled(monkeypatch):
+    """With tagger disabled, _relevance_score is identical to using only derive_tags."""
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+
+    from intelligence_selector import _relevance_score, _CLASS_WEIGHT, _recency_decay
+    from vnx_tag_vocabulary import derive_tags
+
+    class _Item:
+        title = "receipt audit ndjson provenance"
+        content = ""
+        confidence = 0.7
+        scope_tags = None
+        item_class = "proven_pattern"
+        last_seen = None
+
+    query_scope = ["receipts_audit", "fix_bug"]
+
+    det_tags = set(derive_tags(f"{_Item.title} {_Item.content}"))
+    expected_overlap = len(det_tags & set(query_scope))
+    weight = _CLASS_WEIGHT.get("proven_pattern", 1.0)
+    recency = _recency_decay(None)
+    expected_score = 0.7 * (1.0 + expected_overlap) * recency * weight
+
+    actual = _relevance_score(_Item(), query_scope)
+    assert abs(actual - expected_score) < 0.001
+
+
+def test_stored_scope_tags_add_on_top_of_derive_tags(monkeypatch):
+    """Items with stored scope_tags (from tagger persist) get higher overlap than
+    those with only derive_tags, proving stored tags complement the deterministic floor."""
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+
+    from intelligence_selector import _relevance_score
+
+    class _ItemNoStored:
+        title = "wire the integration hook"
+        content = ""
+        confidence = 0.6
+        scope_tags = None
+        item_class = "proven_pattern"
+        last_seen = None
+
+    class _ItemWithStored:
+        title = "wire the integration hook"
+        content = ""
+        confidence = 0.6
+        scope_tags = ["providers_routing", "wire_integration"]  # stored from tagger
+        item_class = "proven_pattern"
+        last_seen = None
+
+    query_scope = ["providers_routing", "wire_integration", "intelligence"]
+    score_without = _relevance_score(_ItemNoStored(), query_scope)
+    score_with = _relevance_score(_ItemWithStored(), query_scope)
+
+    # With stored tags, overlap is higher → score must be higher
+    assert score_with >= score_without
+
+
+# ---------------------------------------------------------------------------
+# derive_tags no-dependency check (VNX_TAGGER_ENABLED default is OFF)
+# ---------------------------------------------------------------------------
+
+def test_tagger_enabled_default_is_off():
+    """VNX_TAGGER_ENABLED must default to disabled — no silent default-on flip."""
+    env_backup = os.environ.pop("VNX_TAGGER_ENABLED", None)
+    try:
+        import vnx_tagger
+        assert vnx_tagger.is_enabled() is False
+    finally:
+        if env_backup is not None:
+            os.environ["VNX_TAGGER_ENABLED"] = env_backup
+
+
+def test_derive_tags_path_active_when_tagger_off(monkeypatch):
+    """Selector uses derive_tags and returns non-empty tags even when tagger is disabled."""
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+
+    from vnx_tag_vocabulary import derive_tags
+    tags = derive_tags("dispatch lane bug fix")
+    assert "dispatch" in tags
+    assert "fix_bug" in tags
+
+
+# ---------------------------------------------------------------------------
+# _sample_patterns
+# ---------------------------------------------------------------------------
+
+def test_sample_patterns_missing_db(tmp_path):
+    from vnx_cli.commands.learning import _sample_patterns
+    result = _sample_patterns(tmp_path / "nonexistent.db", n=10)
+    assert result == []
+
+
+def test_sample_patterns_missing_table(tmp_path):
+    db = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE other (id INTEGER PRIMARY KEY)")
+    conn.commit(); conn.close()
+
+    from vnx_cli.commands.learning import _sample_patterns
+    result = _sample_patterns(db, n=10)
+    assert result == []
+
+
+def test_sample_patterns_returns_seeded_sample(tmp_path):
+    db = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "CREATE TABLE success_patterns "
+        "(id INTEGER PRIMARY KEY, title TEXT, description TEXT, tags TEXT)"
+    )
+    for i in range(30):
+        conn.execute(
+            "INSERT INTO success_patterns(id,title,description) VALUES (?,?,?)",
+            (i + 1, f"pattern {i}", f"desc {i}"),
+        )
+    conn.commit(); conn.close()
+
+    from vnx_cli.commands.learning import _sample_patterns
+
+    # Returns at most n patterns
+    result = _sample_patterns(db, n=10, seed=42)
+    assert len(result) == 10
+
+    # Deterministic: same seed → same order
+    result2 = _sample_patterns(db, n=10, seed=42)
+    assert [r["id"] for r in result] == [r["id"] for r in result2]
+
+    # Different seed → different (possibly) order
+    result3 = _sample_patterns(db, n=10, seed=99)
+    # (May coincidentally match if tiny sample; just assert no crash + right size)
+    assert len(result3) == 10
+
+
+def test_sample_patterns_fewer_than_n_available(tmp_path):
+    db = tmp_path / "qi.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("CREATE TABLE success_patterns (id INTEGER PRIMARY KEY, title TEXT)")
+    conn.execute("INSERT INTO success_patterns(id,title) VALUES (1,'only one')")
+    conn.commit(); conn.close()
+
+    from vnx_cli.commands.learning import _sample_patterns
+    result = _sample_patterns(db, n=20, seed=42)
+    assert len(result) == 1
+
+
+# ---------------------------------------------------------------------------
+# _run_ab_comparison
+# ---------------------------------------------------------------------------
+
+_FAKE_PATTERNS = [
+    {"id": 1, "title": "fix dispatch lane regression", "description": "", "stored_tags": ""},
+    {"id": 2, "title": "intelligence selector inject", "description": "", "stored_tags": ""},
+    {"id": 3, "title": "governance gate phantom receipt", "description": "", "stored_tags": ""},
+    {"id": 4, "title": "no matching keywords here xyz", "description": "", "stored_tags": ""},
+]
+
+
+def test_run_ab_comparison_provider_unavailable(monkeypatch):
+    """When provider is unavailable, LLM arm returns empty tags and zero cost."""
+    from vnx_cli.commands.learning import _run_ab_comparison
+
+    result = _run_ab_comparison(_FAKE_PATTERNS, provider_available=False)
+
+    assert result["n_sampled"] == 4
+    assert result["provider_available"] is False
+    assert result["total_cost_usd"] == 0.0
+    assert result["cost_per_pattern_usd"] == 0.0
+    assert result["rescued"] == 0  # no LLM → no new tags
+    # WITH == WITHOUT when provider unavailable
+    assert result["avg_overlap_with"] == result["avg_overlap_without"]
+
+
+def test_run_ab_comparison_llm_adds_new_tags(monkeypatch):
+    """When LLM arm adds new tags, rescue_rate and overlap improve."""
+    import vnx_tagger as _tagger
+
+    # Mock: LLM adds "harden" for all patterns
+    monkeypatch.setattr(
+        _tagger, "_llm_tags_with_cost",
+        lambda text, paths=None, enabled_override=False: (["harden"], 0.00005),
+    )
+
+    from vnx_cli.commands.learning import _run_ab_comparison
+
+    patterns = [
+        {"id": 1, "title": "guard boundary harden edge", "description": "", "stored_tags": ""},
+        {"id": 2, "title": "no keywords", "description": "", "stored_tags": ""},
+    ]
+
+    result = _run_ab_comparison(patterns, provider_available=True)
+
+    assert result["provider_available"] is True
+    assert result["total_cost_usd"] == pytest.approx(0.0001, abs=1e-8)  # 2 × 0.00005
+    # "harden" is in _AB_QUERY_SCOPES (governance_gates + harden), so at least
+    # one scope gains overlap when "harden" is added.
+    assert result["avg_overlap_with"] >= result["avg_overlap_without"]
+
+
+def test_run_ab_comparison_rescue_rate(monkeypatch):
+    """rescue_rate is the fraction of patterns where LLM added at least one new tag."""
+    import vnx_tagger as _tagger
+
+    call_count = [0]
+
+    def _mock_llm(text, paths=None, enabled_override=False):
+        call_count[0] += 1
+        # Add a new tag only for the first pattern
+        if call_count[0] == 1:
+            return ["harden"], 0.00005
+        return [], 0.0
+
+    monkeypatch.setattr(_tagger, "_llm_tags_with_cost", _mock_llm)
+
+    from vnx_cli.commands.learning import _run_ab_comparison
+
+    patterns = [
+        {"id": 1, "title": "simple text no det keywords", "description": "", "stored_tags": ""},
+        {"id": 2, "title": "also plain text", "description": "", "stored_tags": ""},
+    ]
+
+    result = _run_ab_comparison(patterns, provider_available=True)
+
+    assert result["rescued"] == 1
+    assert result["rescue_rate"] == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# _cmd_tagger_ab integration
+# ---------------------------------------------------------------------------
+
+def test_cmd_tagger_ab_no_db(tmp_path, capsys):
+    """_cmd_tagger_ab exits 1 with a helpful message when QI DB is absent."""
+    import vnx_paths
+
+    # Point the data root at a temp dir that has a state/ subdirectory but no DB
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+
+    with patch("vnx_cli._engine.resolve_data_root", return_value=tmp_path):
+        args = argparse.Namespace(project_dir=".", sample=5, seed=42)
+        from vnx_cli.commands.learning import _cmd_tagger_ab
+        rc = _cmd_tagger_ab(args)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "no patterns" in captured.err or "quality_intelligence" in captured.err
+
+
+def _make_qi_db(path: Path) -> None:
+    conn = sqlite3.connect(str(path))
+    conn.execute(
+        "CREATE TABLE success_patterns "
+        "(id INTEGER PRIMARY KEY, title TEXT, description TEXT, tags TEXT)"
+    )
+    for i in range(10):
+        conn.execute(
+            "INSERT INTO success_patterns(id,title,description) VALUES (?,?,?)",
+            (i + 1, f"fix dispatch lane pattern {i}", f"desc {i}"),
+        )
+    conn.commit()
+    conn.close()
+
+
+def test_cmd_tagger_ab_provider_unavailable(tmp_path, capsys, monkeypatch):
+    """_cmd_tagger_ab exits 0 and prints the WITHOUT arm when provider is unavailable."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    _make_qi_db(state_dir / "quality_intelligence.db")
+
+    import vnx_tagger as _tagger
+    monkeypatch.setattr(_tagger, "get_tagger_provider_name", lambda: "deepseek")
+
+    # Make provider unavailable
+    from classifier_providers.base import ClassifierResult
+    class _FakeProv:
+        def is_available(self): return False
+
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: _FakeProv())
+
+    with patch("vnx_cli._engine.resolve_data_root", return_value=tmp_path):
+        args = argparse.Namespace(project_dir=".", sample=5, seed=42)
+        from vnx_cli.commands.learning import _cmd_tagger_ab
+        rc = _cmd_tagger_ab(args)
+
+    assert rc == 0
+    captured = capsys.readouterr()
+    # Should note provider unavailability
+    assert "not available" in captured.err or "unavailable" in captured.err.lower()
+    # Output should contain the report header
+    assert "A/B" in captured.out or "tagger" in captured.out.lower()
+
+
+def test_cmd_tagger_ab_with_mocked_llm(tmp_path, capsys, monkeypatch):
+    """_cmd_tagger_ab exits 0 and prints precision-lift + cost when LLM arm works."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    _make_qi_db(state_dir / "quality_intelligence.db")
+
+    import vnx_tagger as _tagger
+    monkeypatch.setattr(_tagger, "get_tagger_provider_name", lambda: "deepseek")
+
+    # Provider available
+    class _FakeProv:
+        def is_available(self): return True
+
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: _FakeProv())
+
+    # LLM adds "harden" with a small cost
+    monkeypatch.setattr(
+        _tagger, "_llm_tags_with_cost",
+        lambda text, paths=None, enabled_override=False: (["harden"], 0.0001),
+    )
+
+    with patch("vnx_cli._engine.resolve_data_root", return_value=tmp_path):
+        args = argparse.Namespace(project_dir=".", sample=5, seed=42)
+        from vnx_cli.commands.learning import _cmd_tagger_ab
+        rc = _cmd_tagger_ab(args)
+
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "A/B" in out or "overlap" in out.lower()
+    assert "rescue" in out.lower()
+    assert "cost" in out.lower()
+    # Decision criterion must appear
+    assert "ENABLE" in out or "HOLD OFF" in out
+
+
+def test_cmd_tagger_ab_decision_criterion_appears(tmp_path, capsys, monkeypatch):
+    """Report always prints the default-on decision criterion regardless of verdict."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    _make_qi_db(state_dir / "quality_intelligence.db")
+
+    import vnx_tagger as _tagger
+    monkeypatch.setattr(_tagger, "get_tagger_provider_name", lambda: "deepseek")
+
+    class _FakeProv:
+        def is_available(self): return True
+
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: _FakeProv())
+
+    # Zero cost + zero new tags → HOLD OFF
+    monkeypatch.setattr(
+        _tagger, "_llm_tags_with_cost",
+        lambda text, paths=None, enabled_override=False: ([], 0.0),
+    )
+
+    with patch("vnx_cli._engine.resolve_data_root", return_value=tmp_path):
+        args = argparse.Namespace(project_dir=".", sample=5, seed=42)
+        from vnx_cli.commands.learning import _cmd_tagger_ab
+        _cmd_tagger_ab(args)
+
+    out = capsys.readouterr().out
+    assert "20%" in out or "0.001" in out  # thresholds are printed
+
+
+def test_tagger_enabled_flag_not_set_by_ab(tmp_path, monkeypatch):
+    """tagger-ab must NOT set VNX_TAGGER_ENABLED=1 as a side effect."""
+    monkeypatch.delenv("VNX_TAGGER_ENABLED", raising=False)
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    _make_qi_db(state_dir / "quality_intelligence.db")
+
+    import vnx_tagger as _tagger
+    monkeypatch.setattr(_tagger, "get_tagger_provider_name", lambda: "deepseek")
+
+    class _FakeProv:
+        def is_available(self): return True
+
+    monkeypatch.setattr("classifier_providers.get_provider", lambda name=None: _FakeProv())
+    monkeypatch.setattr(
+        _tagger, "_llm_tags_with_cost",
+        lambda text, paths=None, enabled_override=False: (["harden"], 0.0001),
+    )
+
+    with patch("vnx_cli._engine.resolve_data_root", return_value=tmp_path):
+        args = argparse.Namespace(project_dir=".", sample=5, seed=42)
+        from vnx_cli.commands.learning import _cmd_tagger_ab
+        _cmd_tagger_ab(args)
+
+    # VNX_TAGGER_ENABLED must still be absent after the command
+    assert os.environ.get("VNX_TAGGER_ENABLED") is None
+
+
+# ---------------------------------------------------------------------------
+# tag_overlap helper
+# ---------------------------------------------------------------------------
+
+def test_tag_overlap_empty():
+    from vnx_cli.commands.learning import _tag_overlap
+    assert _tag_overlap(set(), ["dispatch", "fix_bug"]) == 0
+
+
+def test_tag_overlap_partial():
+    from vnx_cli.commands.learning import _tag_overlap
+    assert _tag_overlap({"dispatch", "harden"}, ["dispatch", "fix_bug"]) == 1
+
+
+def test_tag_overlap_full():
+    from vnx_cli.commands.learning import _tag_overlap
+    assert _tag_overlap({"dispatch", "fix_bug"}, ["dispatch", "fix_bug"]) == 2

--- a/vnx_cli/commands/learning.py
+++ b/vnx_cli/commands/learning.py
@@ -2,11 +2,26 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 import sys
 from pathlib import Path
+from typing import List, Optional, Tuple
 
 from vnx_cli import _engine
 _engine.ensure_engine_on_path()
+
+# Representative query scopes for the A/B tag-overlap simulation.
+# Each tuple is a plausible set of scope tags a dispatch might carry.
+_AB_QUERY_SCOPES: List[List[str]] = [
+    ["dispatch", "fix_bug"],
+    ["intelligence", "implement_feature"],
+    ["governance_gates", "harden"],
+    ["receipts_audit", "review_audit"],
+    ["schema_migrations", "migrate_schema"],
+    ["providers_routing", "wire_integration"],
+    ["learning_loop", "implement_feature"],
+    ["tests_harness", "add_test"],
+]
 
 
 def _resolve_state_dir(project_dir: Path) -> Path:
@@ -146,14 +161,254 @@ def _cmd_review(args) -> int:
     return 0
 
 
+def _sample_patterns(db_path: Path, n: int, seed: int = 42) -> List[dict]:
+    """Return up to n patterns from success_patterns, deterministically seeded.
+
+    Falls back to an empty list when the DB does not exist or lacks the table.
+    Read-only: no writes, no schema changes.
+    """
+    if not db_path.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(db_path))
+        conn.row_factory = sqlite3.Row
+    except sqlite3.Error:
+        return []
+    try:
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(success_patterns)").fetchall()}
+    except sqlite3.Error:
+        conn.close()
+        return []
+    if "title" not in cols:
+        conn.close()
+        return []
+    desc_col = "COALESCE(description,'')" if "description" in cols else "''"
+    tags_col = "COALESCE(tags,'')" if "tags" in cols else "''"
+    try:
+        rows = conn.execute(
+            f"SELECT id, title, {desc_col} AS description, {tags_col} AS stored_tags"
+            " FROM success_patterns"
+            " ORDER BY id DESC"
+            f" LIMIT ?",
+            (max(n * 4, n),),  # over-fetch; we seed-shuffle below
+        ).fetchall()
+    except sqlite3.Error:
+        conn.close()
+        return []
+    conn.close()
+
+    import random as _random
+    rng = _random.Random(seed)
+    shuffled = list(rows)
+    rng.shuffle(shuffled)
+    return [{"id": r["id"], "title": r["title"] or "", "description": r["description"] or "",
+             "stored_tags": r["stored_tags"] or ""} for r in shuffled[:n]]
+
+
+def _tag_overlap(item_tags: set, query_scope: List[str]) -> int:
+    return len(item_tags & set(query_scope))
+
+
+def _run_ab_comparison(
+    patterns: List[dict],
+    provider_available: bool,
+) -> dict:
+    """Core A/B logic — pure, no I/O, injectable for tests.
+
+    For each pattern:
+    - WITHOUT arm: derive_tags(title + description)
+    - WITH arm: _llm_tags_with_cost(title + description, enabled_override=True)
+      (returns ([], 0.0) when provider is unavailable)
+
+    Returns a result dict with per-pattern data and aggregate metrics.
+    """
+    from vnx_tag_vocabulary import derive_tags
+    import vnx_tagger as _tagger
+
+    per_pattern = []
+    total_cost = 0.0
+    rescued = 0  # patterns where LLM added at least 1 new tag
+
+    for pat in patterns:
+        text = f"{pat['title']} {pat['description']}".strip()
+        without_tags = set(derive_tags(text))
+
+        if provider_available:
+            llm_new, cost = _tagger._llm_tags_with_cost(text, enabled_override=True)
+        else:
+            llm_new, cost = [], 0.0
+
+        with_tags = without_tags | set(llm_new)
+        new_tags = set(llm_new) - without_tags
+
+        # Precision = mean tag_overlap across the representative query scopes
+        overlap_without = sum(_tag_overlap(without_tags, q) for q in _AB_QUERY_SCOPES)
+        overlap_with = sum(_tag_overlap(with_tags, q) for q in _AB_QUERY_SCOPES)
+
+        if new_tags:
+            rescued += 1
+        total_cost += cost
+        per_pattern.append({
+            "id": pat["id"],
+            "title": pat["title"][:60],
+            "without_tags": sorted(without_tags),
+            "new_llm_tags": sorted(new_tags),
+            "overlap_without": overlap_without,
+            "overlap_with": overlap_with,
+            "cost_usd": cost,
+        })
+
+    n = len(patterns)
+    rescue_rate = rescued / n if n else 0.0
+    avg_overlap_without = sum(p["overlap_without"] for p in per_pattern) / n if n else 0.0
+    avg_overlap_with = sum(p["overlap_with"] for p in per_pattern) / n if n else 0.0
+
+    return {
+        "n_sampled": n,
+        "provider_available": provider_available,
+        "rescue_rate": rescue_rate,
+        "rescued": rescued,
+        "avg_overlap_without": avg_overlap_without,
+        "avg_overlap_with": avg_overlap_with,
+        "total_cost_usd": total_cost,
+        "cost_per_pattern_usd": total_cost / n if n else 0.0,
+        "per_pattern": per_pattern,
+    }
+
+
+def _cmd_tagger_ab(args) -> int:
+    """Run a read-only A/B comparison: tagger ON vs OFF on a small pattern sample.
+
+    Measures:
+    - rescue_rate: fraction of patterns where LLM added tags the deterministic
+      derive_tags() missed
+    - precision lift: average tag-overlap improvement across representative query
+      scopes (proxy for selection probability improvement)
+    - cost: tokens / USD per pattern for the LLM arm
+
+    Does NOT modify the database or set VNX_TAGGER_ENABLED.
+
+    Decision criterion for default-on: enable VNX_TAGGER_ENABLED once the operator
+    observes rescue_rate >= 0.20 AND cost_per_pattern <= 0.001 USD from a live run.
+    """
+    project_dir = Path(getattr(args, "project_dir", "."))
+    sample_n = int(getattr(args, "sample", 20))
+    seed = int(getattr(args, "seed", 42))
+
+    state_dir = _resolve_state_dir(project_dir)
+    db_path = state_dir / "quality_intelligence.db"
+
+    patterns = _sample_patterns(db_path, n=sample_n, seed=seed)
+    if not patterns:
+        print("tagger-ab: no patterns found in success_patterns table.", file=sys.stderr)
+        print(f"  (DB path checked: {db_path})", file=sys.stderr)
+        print("  Run `vnx learning run` first to populate the intelligence store.", file=sys.stderr)
+        return 1
+
+    # Check provider availability WITHOUT making an LLM call
+    provider_available = False
+    try:
+        import vnx_tagger as _tagger
+        from classifier_providers import get_provider
+        prov = get_provider(_tagger.get_tagger_provider_name())
+        provider_available = prov.is_available()
+    except Exception:
+        provider_available = False
+
+    if not provider_available:
+        print(
+            "tagger-ab: LLM provider not available (check DEEPSEEK_API_KEY or "
+            f"VNX_TAGGER_PROVIDER={_tagger.get_tagger_provider_name()!r}).",
+            file=sys.stderr,
+        )
+        print("  Running WITHOUT arm only (deterministic derive_tags).", file=sys.stderr)
+
+    result = _run_ab_comparison(patterns, provider_available=provider_available)
+
+    _print_ab_report(result)
+    return 0
+
+
+def _print_ab_report(result: dict) -> None:
+    n = result["n_sampled"]
+    rescued = result["rescued"]
+    rescue_rate = result["rescue_rate"]
+    avg_without = result["avg_overlap_without"]
+    avg_with = result["avg_overlap_with"]
+    total_cost = result["total_cost_usd"]
+    cost_per = result["cost_per_pattern_usd"]
+    provider_ok = result["provider_available"]
+
+    print()
+    print("=" * 60)
+    print("Tagger A/B — tag-overlap precision comparison")
+    print("=" * 60)
+    print(f"  Sample size        : {n} patterns")
+    print(f"  LLM arm available  : {'yes' if provider_ok else 'no (deterministic only)'}")
+    print()
+
+    print("WITHOUT tagger (derive_tags only):")
+    print(f"  Avg tag-overlap / query scope : {avg_without:.2f}")
+    print()
+
+    if provider_ok:
+        lift = avg_with - avg_without
+        lift_pct = (lift / avg_without * 100) if avg_without > 0 else 0.0
+        print("WITH tagger (derive_tags + LLM):")
+        print(f"  Avg tag-overlap / query scope : {avg_with:.2f}")
+        print(f"  Overlap lift                  : +{lift:.2f} ({lift_pct:+.1f}%)")
+        print(f"  Rescue rate                   : {rescued}/{n} ({rescue_rate:.0%})")
+        print()
+        print("Cost (LLM arm):")
+        print(f"  Total                         : ${total_cost:.6f}")
+        print(f"  Per pattern                   : ${cost_per:.6f}")
+        print()
+
+        # Decision criterion
+        RESCUE_THRESHOLD = 0.20
+        COST_CEILING = 0.001  # USD per pattern
+        meets_rescue = rescue_rate >= RESCUE_THRESHOLD
+        meets_cost = cost_per <= COST_CEILING
+        verdict = "ENABLE" if (meets_rescue and meets_cost) else "HOLD OFF"
+        print("Decision criterion (default-on threshold):")
+        print(f"  rescue_rate >= 20%     : {'PASS' if meets_rescue else 'FAIL'} ({rescue_rate:.0%})")
+        print(f"  cost_per_pattern <= $0.001 : {'PASS' if meets_cost else 'FAIL'} (${cost_per:.6f})")
+        print()
+        print(f"  => {verdict}: set VNX_TAGGER_ENABLED=1 to enable default-on tagging.")
+        if verdict == "HOLD OFF":
+            print("     Investigate: rescue_rate too low → LLM adds few tags the deterministic")
+            print("     floor misses, OR cost too high → switch to a cheaper provider.")
+    else:
+        print("(LLM arm skipped — set DEEPSEEK_API_KEY and re-run to measure cost + lift)")
+        print()
+        print("Decision criterion (default-on threshold):")
+        print("  Measure rescue_rate >= 20% AND cost_per_pattern <= $0.001 USD from a live run.")
+        print("  Do NOT set VNX_TAGGER_ENABLED=1 without seeing those numbers.")
+
+    print()
+
+    # Per-pattern detail (only the top rescued patterns)
+    rescued_patterns = [p for p in result["per_pattern"] if p["new_llm_tags"]]
+    if rescued_patterns:
+        print(f"Rescued patterns ({len(rescued_patterns)} of {n}):")
+        for p in rescued_patterns[:5]:
+            print(f"  [{p['id']}] {p['title']}")
+            print(f"       det: {p['without_tags']}")
+            print(f"       llm: {p['new_llm_tags']}")
+        if len(rescued_patterns) > 5:
+            print(f"  ... and {len(rescued_patterns) - 5} more")
+    print("=" * 60)
+
+
 def vnx_learning(args) -> int:
     sub = getattr(args, "learning_subcommand", None)
     dispatch = {
         "run": _cmd_run,
         "status": _cmd_status,
         "review": _cmd_review,
+        "tagger-ab": _cmd_tagger_ab,
     }
     if sub in dispatch:
         return dispatch[sub](args)
-    print("Usage: vnx learning {run|status|review}")
+    print("Usage: vnx learning {run|status|review|tagger-ab}")
     return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -332,6 +332,30 @@ def _register_learning_subparser(subparsers: argparse.Action) -> None:
         help="which proposals to show: rules, archival, or all (default: all)",
     )
 
+    lr_ab = learning_subs.add_parser(
+        "tagger-ab",
+        help=(
+            "read-only A/B: tag-overlap precision WITH tagger (LLM) vs WITHOUT "
+            "(deterministic derive_tags). Reports rescue-rate + cost. "
+            "Does NOT set VNX_TAGGER_ENABLED."
+        ),
+    )
+    lr_ab.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_ab.add_argument(
+        "--sample",
+        type=int,
+        default=20,
+        metavar="N",
+        help="number of patterns to sample (default: 20; keep small — each makes one LLM call)",
+    )
+    lr_ab.add_argument(
+        "--seed",
+        type=int,
+        default=42,
+        metavar="SEED",
+        help="random seed for deterministic sampling (default: 42)",
+    )
+
 
 def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_parser = subparsers.add_parser(


### PR DESCRIPTION
## Summary

D4 of self-improve-loop-v2. Per the map (implication 6): the tagger is OPTIONAL precision (the selector works via deterministic `derive_tags()` regardless), so this ships an A/B harness, NOT a default-on.

- `vnx learning tagger-ab`: runs the selector's tag-overlap WITH the LLM tagger vs WITHOUT (deterministic only) on a seeded sample; reports precision-lift + tagger cost (`_llm_tags_with_cost`).
- `VNX_TAGGER_ENABLED` stays OFF by default — no default-on flip; the operator decides from the A/B (precision-lift vs cost ceiling, documented).
- The selector works with the tagger OFF (tested — no hard dependency).

## Verification

20 new tests pass (`test_tagger_ab.py`, independently re-run).

## Provenance

Governed tmux-spawn lane (dispatch `D-selfimprove-d4-tagger`). Map + plan rev 4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC