### PR TITLE
feat(gov): in-repo attest record, content-keyed + diff-bound (squash-safe) [D2]

### DIFF
--- a/scripts/lib/attest_record.py
+++ b/scripts/lib/attest_record.py
@@ -1,0 +1,202 @@
+"""D2: In-repo attestation record, content-keyed and diff-bound.
+
+Each governed build commit writes a .vnx-attest/<content-key>.json record
+alongside the code change.  The record is:
+
+  - Content-keyed: keyed by SHA-256 of the merge-base→HEAD diff, so it
+    survives squash-merges and rebases that produce the same code delta.
+  - Diff-bound: the manifest embeds diff_hash, so a manifest for track A
+    cannot be silently reused for track B's code.
+  - Detached-signed: the manifest bytes are SSH-signed (D1's sign_manifest),
+    not just incidentally covered by git commit -S.
+
+The D3 server gate verifies: (a) a .vnx-attest/<content-key>.json exists for
+the PR's content-key; (b) manifest.diff_hash matches the PR's diff; (c) the
+signature is valid against allowed_signers.
+
+References:
+  - attestation.py: sign_manifest, verify_attestation, build_governed_manifest
+  - content_key.py: compute_diff_hash
+  - docs/governance/2026-07-04-governance-attribution-enforce-PLAN.md (D2)
+"""
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from pathlib import Path
+
+from attestation import (
+    build_governed_manifest,
+    sign_manifest,
+    verify_attestation,
+)
+from content_key import compute_diff_hash
+
+ATTEST_DIR = ".vnx-attest"
+
+
+@dataclass
+class AttestRecord:
+    """Written attestation record for a governed build commit."""
+    content_key: str
+    diff_hash: str
+    record_path: Path
+    manifest: dict
+    git_signed: bool
+
+
+def build_attest_manifest(
+    *,
+    dispatch_id: str,
+    deliverable_id: str,
+    track_id: str,
+    plan_gate_ref: str,
+    signer_identity: str,
+    timestamp: str,
+    diff_hash: str,
+) -> dict:
+    """Governed manifest extended with diff_hash for diff-binding.
+
+    The diff_hash field is covered by the signature, so a manifest cannot
+    be repurposed for a different diff without invalidating the signature.
+    """
+    manifest = build_governed_manifest(
+        dispatch_id=dispatch_id,
+        deliverable_id=deliverable_id,
+        track_id=track_id,
+        plan_gate_ref=plan_gate_ref,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+    )
+    manifest["diff_hash"] = diff_hash
+    return manifest
+
+
+def write_attest_record(
+    *,
+    dispatch_id: str,
+    deliverable_id: str,
+    track_id: str,
+    plan_gate_ref: str,
+    signer_identity: str,
+    timestamp: str,
+    key_path: "str | Path | None" = None,
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+) -> AttestRecord:
+    """Compute content-key, build + sign manifest, write .vnx-attest/<key>.json.
+
+    Does NOT stage or commit the file.  The caller (vnx attest write) stages
+    the file and commits with -S if a signing key is available.
+
+    Args:
+        dispatch_id: Dispatch-ID of the governed build.
+        deliverable_id: Deliverable being attested (e.g. "D2").
+        track_id: Track/objective ID.
+        plan_gate_ref: Plan-gate pass reference.
+        signer_identity: Signer identity matching an allowed_signers entry.
+        timestamp: ISO-8601 UTC timestamp (caller-supplied).
+        key_path: SSH private key path for detached signature.  None = unsigned.
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch ref for merge-base (default: origin/main).
+        head_ref: Branch tip (default: HEAD).
+
+    Returns:
+        AttestRecord with content_key, diff_hash, record_path, and manifest.
+
+    Raises:
+        RuntimeError: If git diff/merge-base operations fail.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+
+    diff_hash = compute_diff_hash(
+        repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+    )
+    content_key = diff_hash  # the content-key IS the diff hash
+
+    manifest = build_attest_manifest(
+        dispatch_id=dispatch_id,
+        deliverable_id=deliverable_id,
+        track_id=track_id,
+        plan_gate_ref=plan_gate_ref,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+        diff_hash=diff_hash,
+    )
+
+    if key_path is not None:
+        manifest = sign_manifest(manifest, key_path)
+
+    attest_dir = repo_root / ATTEST_DIR
+    attest_dir.mkdir(parents=True, exist_ok=True)
+    record_path = attest_dir / f"{content_key}.json"
+    record_path.write_text(
+        json.dumps(manifest, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    return AttestRecord(
+        content_key=content_key,
+        diff_hash=diff_hash,
+        record_path=record_path,
+        manifest=manifest,
+        git_signed=False,
+    )
+
+
+def verify_attest_record(
+    *,
+    allowed_signers: "str | Path",
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+) -> "tuple[bool, str]":
+    """Verify the attest record for the current branch.
+
+    Checks in order:
+    1. .vnx-attest/<computed-content-key>.json exists.
+    2. manifest.diff_hash matches the current branch diff (diff-binding).
+    3. The detached signature is valid against allowed_signers.
+
+    Args:
+        allowed_signers: Path to SSH allowed_signers file.
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch ref (default: origin/main).
+        head_ref: Branch tip (default: HEAD).
+
+    Returns:
+        (ok: bool, reason: str)
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+
+    try:
+        current_diff_hash = compute_diff_hash(
+            repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+        )
+    except RuntimeError as e:
+        return (False, f"diff computation failed: {e}")
+
+    record_path = repo_root / ATTEST_DIR / f"{current_diff_hash}.json"
+    if not record_path.exists():
+        return (False, f"no attest record for content-key {current_diff_hash[:12]}…")
+
+    try:
+        manifest = json.loads(record_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return (False, f"record unreadable: {e}")
+
+    # Diff-binding: the manifest must have been signed for THIS diff
+    record_diff_hash = manifest.get("diff_hash")
+    if record_diff_hash != current_diff_hash:
+        return (
+            False,
+            f"diff-binding mismatch: record.diff_hash={record_diff_hash!r} "
+            f"!= current={current_diff_hash!r}",
+        )
+
+    # Detached signature check
+    if not verify_attestation(manifest, allowed_signers):
+        return (False, "signature verification failed")
+
+    return (True, "ok")

--- a/scripts/lib/attest_record.py
+++ b/scripts/lib/attest_record.py
@@ -22,6 +22,7 @@ References:
 from __future__ import annotations
 
 import json
+import subprocess
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -200,3 +201,34 @@ def verify_attest_record(
         return (False, "signature verification failed")
 
     return (True, "ok")
+
+
+def read_allowed_signers_from_base(
+    repo_root: "str | Path",
+    base_ref: str = "origin/main",
+) -> "bytes | None":
+    """Read allowed_signers bytes from the BASE branch, never the PR working tree.
+
+    A PR-writable allowed_signers file cannot be trusted as a trust anchor — a
+    rogue key committed to .vnx-attest/allowed_signers would verify itself.
+    Reading from base_ref (e.g. origin/main) ensures only keys present BEFORE
+    the PR can be used for verification.
+
+    Tries .vnx-attest/allowed_signers then .vnx/allowed_signers at base_ref.
+    Returns raw bytes of the file, or None if not found in either location.
+
+    Note: CODEOWNERS protection of .vnx-attest/allowed_signers on the protected
+    branch is the server-side enforcement complement (wired in D3/D5).
+    """
+    repo_root = Path(repo_root)
+    for candidate in (
+        f"{ATTEST_DIR}/allowed_signers",
+        ".vnx/allowed_signers",
+    ):
+        result = subprocess.run(
+            ["git", "show", f"{base_ref}:{candidate}"],
+            cwd=str(repo_root), capture_output=True,
+        )
+        if result.returncode == 0 and result.stdout.strip():
+            return result.stdout
+    return None

--- a/scripts/lib/content_key.py
+++ b/scripts/lib/content_key.py
@@ -41,7 +41,14 @@ def _resolve_merge_base(base_ref: str, head_ref: str, cwd: Path) -> str:
 def _git_diff_bytes(from_ref: str, to_ref: str, cwd: Path) -> bytes:
     """Unified diff bytes excluding .vnx-attest/ for stable content-key hashing."""
     result = subprocess.run(
-        ["git", "diff", from_ref, to_ref, "--", ".", _ATTEST_EXCLUDE],
+        [
+            "git",
+            "-c", "diff.algorithm=myers",
+            "-c", "diff.noprefix=false",
+            "-c", "diff.mnemonicPrefix=false",
+            "-c", "core.textconv=false",
+            "diff", from_ref, to_ref, "--", ".", _ATTEST_EXCLUDE,
+        ],
         cwd=str(cwd), capture_output=True,
     )
     # exit 0 = no diff, 1 = diff found; anything else is an error

--- a/scripts/lib/content_key.py
+++ b/scripts/lib/content_key.py
@@ -1,0 +1,94 @@
+"""Content-key computation for squash-safe attestation (D2).
+
+The content-key is SHA-256 of the feature diff from merge-base to HEAD,
+excluding the .vnx-attest/ metadata directory so writing the attest record
+itself does not change the key.
+
+Squash-safety guarantee: squashing or rebasing commits without changing the
+final code delta produces the same content-key, because the key is derived
+from the resulting diff, not commit history.
+
+References:
+  - docs/governance/2026-07-04-governance-attribution-enforce-PLAN.md (D2)
+"""
+from __future__ import annotations
+
+import hashlib
+import subprocess
+from pathlib import Path
+
+_ATTEST_EXCLUDE = ":(exclude).vnx-attest/"
+
+
+def _resolve_merge_base(base_ref: str, head_ref: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", "merge-base", base_ref, head_ref],
+        cwd=str(cwd), capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git merge-base {base_ref!r} {head_ref!r} failed: "
+            f"{result.stderr.strip()}"
+        )
+    sha = result.stdout.strip()
+    if not sha:
+        raise RuntimeError(
+            f"git merge-base {base_ref!r} {head_ref!r} returned empty output"
+        )
+    return sha
+
+
+def _git_diff_bytes(from_ref: str, to_ref: str, cwd: Path) -> bytes:
+    """Unified diff bytes excluding .vnx-attest/ for stable content-key hashing."""
+    result = subprocess.run(
+        ["git", "diff", from_ref, to_ref, "--", ".", _ATTEST_EXCLUDE],
+        cwd=str(cwd), capture_output=True,
+    )
+    # exit 0 = no diff, 1 = diff found; anything else is an error
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git diff {from_ref} {to_ref} failed (exit {result.returncode}): "
+            f"{result.stderr.decode(errors='replace').strip()}"
+        )
+    return result.stdout
+
+
+def compute_diff_hash(
+    *,
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+) -> str:
+    """SHA-256 of the feature diff from merge-base to head_ref.
+
+    Excludes .vnx-attest/ so writing the attest record does not change the key.
+    Stable across squash-merges and rebases that produce the same code delta.
+
+    Args:
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch to merge-base against (default: origin/main).
+        head_ref: Branch tip to diff against (default: HEAD).
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+    merge_base = _resolve_merge_base(base_ref, head_ref, repo_root)
+    diff_bytes = _git_diff_bytes(merge_base, head_ref, repo_root)
+    return hashlib.sha256(diff_bytes).hexdigest()
+
+
+def compute_content_key(
+    *,
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+) -> str:
+    """Squash-safe content-key for the current branch.
+
+    The content-key is the diff hash — a SHA-256 of the feature diff from
+    merge-base to HEAD, excluding .vnx-attest/.
+
+    Args:
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch to merge-base against (default: origin/main).
+        head_ref: Branch tip (default: HEAD).
+    """
+    return compute_diff_hash(repo_root=repo_root, base_ref=base_ref, head_ref=head_ref)

--- a/tests/test_attest_d2.py
+++ b/tests/test_attest_d2.py
@@ -32,6 +32,7 @@ from attest_record import (
     build_attest_manifest,
     verify_attest_record,
     write_attest_record,
+    read_allowed_signers_from_base,
 )
 from attestation import build_governed_manifest, sign_manifest
 
@@ -504,3 +505,185 @@ class TestDiffBinding:
                 base_ref=base_sha,
             )
             assert ok, f"verify failed after committing attest record: {reason}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: allowed_signers trust anchor — base branch resolution
+# ---------------------------------------------------------------------------
+
+class TestAllowedSignersTrustAnchor:
+    """read_allowed_signers_from_base reads from the base ref, ignoring PR tree."""
+
+    def _base_with_allowed_signers(self, tmp: Path, pub_line: str) -> str:
+        """Init repo, add allowed_signers at base commit. Returns base SHA."""
+        _init_repo(tmp)
+        attest_dir = tmp / ATTEST_DIR
+        attest_dir.mkdir(parents=True, exist_ok=True)
+        (attest_dir / "allowed_signers").write_text(pub_line)
+        subprocess.run(["git", "add", ".vnx-attest/"], cwd=str(tmp), check=True, capture_output=True)
+        subprocess.run(["git", "commit", "-m", "add: allowed_signers"], cwd=str(tmp), check=True, capture_output=True)
+        return _head_sha(tmp)
+
+    def test_reads_from_base_ref_not_working_tree(self, ephemeral_key_dir):
+        """Working-tree mutation of allowed_signers does not affect base-ref resolution."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            identity = ephemeral_key_dir["identity"]
+            pub = ephemeral_key_dir["key_path"].with_suffix(".pub").read_text().strip()
+            base_sha = self._base_with_allowed_signers(repo, f"{identity} {pub}\n")
+
+            _add_file_commit(repo, "feature.py", "x = 1\n", "feat: feature")
+
+            # Overwrite working-tree allowed_signers with rogue content (uncommitted)
+            (repo / ATTEST_DIR / "allowed_signers").write_text("rogue@attacker rogue-key-blob\n")
+
+            content = read_allowed_signers_from_base(repo, base_sha)
+            assert content is not None, "Expected to find allowed_signers at base ref"
+            assert b"rogue" not in content, "Base-ref resolution must ignore working-tree mutation"
+            assert identity.encode() in content
+
+    def test_rogue_key_in_pr_tree_not_trusted(self, ephemeral_key_dir):
+        """Rogue key committed to PR tree cannot self-verify against base-branch signers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            identity = ephemeral_key_dir["identity"]
+            pub = ephemeral_key_dir["key_path"].with_suffix(".pub").read_text().strip()
+            base_sha = self._base_with_allowed_signers(repo, f"{identity} {pub}\n")
+
+            _add_file_commit(repo, "feature.py", "x = 1\n", "feat: feature")
+
+            # Generate a rogue key
+            with tempfile.TemporaryDirectory() as rogue_dir:
+                rogue_key = Path(rogue_dir) / "rogue"
+                subprocess.run(
+                    ["ssh-keygen", "-t", "ed25519", "-f", str(rogue_key), "-N", ""],
+                    check=True, capture_output=True,
+                )
+                rogue_pub = rogue_key.with_suffix(".pub").read_text().strip()
+                rogue_identity = "rogue@attacker"
+
+                # Sign an attest record with the rogue key
+                write_attest_record(
+                    dispatch_id="D-rogue",
+                    deliverable_id="D2",
+                    track_id="t",
+                    plan_gate_ref="r",
+                    signer_identity=rogue_identity,
+                    timestamp="2026-07-04T12:00:00Z",
+                    key_path=rogue_key,
+                    repo_root=repo,
+                    base_ref=base_sha,
+                )
+
+                # PR-tree: commit rogue key into allowed_signers
+                (repo / ATTEST_DIR / "allowed_signers").write_text(f"{rogue_identity} {rogue_pub}\n")
+                subprocess.run(["git", "add", ".vnx-attest/"], cwd=str(repo), check=True, capture_output=True)
+                subprocess.run(
+                    ["git", "commit", "-m", "attack: add rogue key"],
+                    cwd=str(repo), check=True, capture_output=True,
+                )
+
+                # Base-branch resolution returns ORIGINAL allowed_signers (no rogue key)
+                base_content = read_allowed_signers_from_base(repo, base_sha)
+                assert base_content is not None
+                assert b"rogue" not in base_content
+
+                # Verify against base-branch allowed_signers → must FAIL
+                tmp_as = Path(rogue_dir) / "base_as"
+                tmp_as.write_bytes(base_content)
+                ok, reason = verify_attest_record(
+                    allowed_signers=tmp_as,
+                    repo_root=repo,
+                    base_ref=base_sha,
+                )
+                assert not ok, "Rogue-signed record must not verify against base-branch signers"
+                assert "signature" in reason.lower()
+
+    def test_valid_key_in_base_branch_verifies(self, ephemeral_key_dir):
+        """Valid signature passes when allowed_signers is resolved from base branch."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = Path(tmpdir)
+            identity = ephemeral_key_dir["identity"]
+            pub = ephemeral_key_dir["key_path"].with_suffix(".pub").read_text().strip()
+            base_sha = self._base_with_allowed_signers(repo, f"{identity} {pub}\n")
+
+            _add_file_commit(repo, "feature.py", "x = 1\n", "feat: feature")
+
+            write_attest_record(
+                dispatch_id="D-base-verify",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=identity,
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            base_content = read_allowed_signers_from_base(repo, base_sha)
+            assert base_content is not None
+
+            with tempfile.TemporaryDirectory() as td:
+                tmp_as = Path(td) / "allowed_signers"
+                tmp_as.write_bytes(base_content)
+                ok, reason = verify_attest_record(
+                    allowed_signers=tmp_as,
+                    repo_root=repo,
+                    base_ref=base_sha,
+                )
+                assert ok, f"Valid key from base branch should pass verify: {reason}"
+
+
+# ---------------------------------------------------------------------------
+# Fix 2: diff-determinism — pinned git config
+# ---------------------------------------------------------------------------
+
+class TestDiffDeterminism:
+    """content-key is byte-identical regardless of local git diff config."""
+
+    def test_identical_under_patience_algorithm(self):
+        """Switching local diff.algorithm=patience does not change the content-key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "f.py", "def hello():\n    return 'world'\n", "feat: f")
+
+            key_default = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            subprocess.run(
+                ["git", "config", "diff.algorithm", "patience"],
+                cwd=str(repo), check=True, capture_output=True,
+            )
+            key_patience = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            subprocess.run(
+                ["git", "config", "--unset", "diff.algorithm"],
+                cwd=str(repo), capture_output=True,
+            )
+
+            assert key_default == key_patience, (
+                f"diff.algorithm=patience changed content-key: {key_default!r} != {key_patience!r}"
+            )
+
+    def test_identical_under_mnemonic_prefix(self):
+        """Enabling mnemonicPrefix does not change the content-key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "f.py", "x = 42\n", "feat: f")
+
+            key_before = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            subprocess.run(
+                ["git", "config", "diff.mnemonicPrefix", "true"],
+                cwd=str(repo), check=True, capture_output=True,
+            )
+            key_after = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            subprocess.run(
+                ["git", "config", "--unset", "diff.mnemonicPrefix"],
+                cwd=str(repo), capture_output=True,
+            )
+
+            assert key_before == key_after, (
+                f"mnemonicPrefix change affected content-key: {key_before!r} != {key_after!r}"
+            )

--- a/tests/test_attest_d2.py
+++ b/tests/test_attest_d2.py
@@ -1,0 +1,506 @@
+"""Tests for D2: content-key, attest_record, diff-binding.
+
+Test filter: pytest -k "attest or content_key or diff_bind"
+
+Covers:
+  - Content-key stable across simulated squash (same tree → same key)
+  - Content-key changes for different diffs
+  - Rebase (amend) re-derives the same key
+  - Writing .vnx-attest/ files excluded from content-key computation
+  - write_attest_record produces a valid JSON record
+  - Manifest contains diff_hash for diff-binding
+  - verify round-trip passes against test allowed_signers
+  - verify fails when no record exists
+  - verify fails when diff changes after writing record (diff-binding)
+  - verify fails with wrong allowed_signers
+  - Forged manifest (track A → track B slot) fails diff-binding check
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from content_key import compute_content_key, compute_diff_hash
+from attest_record import (
+    ATTEST_DIR,
+    AttestRecord,
+    build_attest_manifest,
+    verify_attest_record,
+    write_attest_record,
+)
+from attestation import build_governed_manifest, sign_manifest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def ephemeral_key_dir():
+    """Ephemeral ed25519 test key + allowed_signers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "testkey"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""],
+            check=True, capture_output=True,
+        )
+        pub = key_path.with_suffix(".pub").read_text().strip()
+        identity = "vnx-test@local"
+        allowed_signers = Path(tmpdir) / "allowed_signers"
+        allowed_signers.write_text(f"{identity} {pub}\n")
+        yield {
+            "key_path": key_path,
+            "identity": identity,
+            "allowed_signers": allowed_signers,
+        }
+
+
+def _init_repo(tmp: Path) -> Path:
+    """Init a git repo in tmp with a base commit (the merge-base)."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@vnx.local"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "VNX Test"], cwd=str(tmp), check=True, capture_output=True)
+    (tmp / "README.md").write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=str(tmp), check=True, capture_output=True)
+    return tmp
+
+
+def _add_file_commit(repo: Path, filename: str, content: str, msg: str) -> None:
+    (repo / filename).write_text(content)
+    subprocess.run(["git", "add", filename], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", msg], cwd=str(repo), check=True, capture_output=True)
+
+
+def _head_sha(repo: Path) -> str:
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True)
+    return r.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# content_key tests
+# ---------------------------------------------------------------------------
+
+class TestContentKey:
+    def test_content_key_stable_across_squash(self):
+        """Same code change → same content-key after squashing N commits to 1."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "feature.py", "print('hello')\n", "feat: step 1")
+            _add_file_commit(repo, "feature.py", "print('hello world')\n", "feat: step 2")
+            key_multi = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            # Simulate squash: reset to base, create one commit with the same final state
+            subprocess.run(["git", "reset", "--soft", base_sha], cwd=str(repo), check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "feat: squashed"], cwd=str(repo), check=True, capture_output=True)
+            key_squash = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            assert key_multi == key_squash, (
+                f"Squash changed content-key: {key_multi!r} != {key_squash!r}"
+            )
+
+    def test_content_key_rebase_same_key(self):
+        """Amending commit message (rebase-like) re-derives the same content-key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "rebase_test.py", "# rebase test\n", "feat: rebase test")
+            key_before = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            # Amend commit message — same tree, different commit SHA
+            subprocess.run(
+                ["git", "commit", "--amend", "-m", "feat: rebase test (amended)"],
+                cwd=str(repo), check=True, capture_output=True,
+            )
+            key_after = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            assert key_before == key_after, (
+                f"Amend changed content-key: {key_before!r} != {key_after!r}"
+            )
+
+    def test_content_key_differs_for_different_diffs(self):
+        """Different code changes produce different content-keys."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "track_a.py", "# track A\n", "feat: track A")
+            key_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            subprocess.run(["git", "reset", "--hard", base_sha], cwd=str(repo), check=True, capture_output=True)
+            _add_file_commit(repo, "track_b.py", "# track B\n", "feat: track B")
+            key_b = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            assert key_a != key_b
+
+    def test_content_key_excludes_attest_dir(self):
+        """Writing .vnx-attest/ files does not change the content-key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "myfeature.py", "x = 1\n", "feat: my feature")
+            key_before = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            # Commit an attest-dir file — should not affect the content-key
+            attest_dir = repo / ATTEST_DIR
+            attest_dir.mkdir(parents=True, exist_ok=True)
+            (attest_dir / "fake_record.json").write_text('{"attest": true}\n')
+            subprocess.run(["git", "add", ".vnx-attest/"], cwd=str(repo), check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "chore: attest record"], cwd=str(repo), check=True, capture_output=True)
+
+            key_after = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            assert key_before == key_after, (
+                f"Writing .vnx-attest/ changed content-key: {key_before!r} != {key_after!r}"
+            )
+
+    def test_compute_content_key_alias(self):
+        """compute_content_key is an alias for compute_diff_hash."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "f.py", "x=1\n", "feat: f")
+            assert compute_content_key(repo_root=repo, base_ref=base_sha) == \
+                   compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+
+# ---------------------------------------------------------------------------
+# attest_record — write tests
+# ---------------------------------------------------------------------------
+
+class TestWriteAttestRecord:
+    def test_write_creates_record_file(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-test-d2",
+                deliverable_id="D2",
+                track_id="governance-attribution-enforce",
+                plan_gate_ref="gate-pass-ref",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            assert isinstance(rec, AttestRecord)
+            assert rec.record_path.exists()
+            assert rec.record_path.parent.name == ATTEST_DIR
+            assert rec.record_path.name == f"{rec.content_key}.json"
+
+    def test_record_file_is_valid_json(self, ephemeral_key_dir):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-json-check",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            loaded = json.loads(rec.record_path.read_text())
+            assert loaded["diff_hash"] == rec.diff_hash
+            assert loaded["dispatch_id"] == "D-json-check"
+
+    def test_manifest_contains_diff_hash(self, ephemeral_key_dir):
+        """Manifest embeds diff_hash so signature covers the diff binding."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-diff-hash",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            assert rec.manifest.get("diff_hash") == rec.diff_hash
+            assert rec.manifest.get("diff_hash") == rec.content_key
+
+    def test_unsigned_record_without_key(self):
+        """key_path=None writes an unsigned record."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-unsigned",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="unsigned@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=None,
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            assert rec.record_path.exists()
+            assert "signature" not in rec.manifest
+
+    def test_content_key_is_diff_hash(self, ephemeral_key_dir):
+        """content_key == diff_hash (they are the same value)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-key-eq",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            assert rec.content_key == rec.diff_hash
+
+
+# ---------------------------------------------------------------------------
+# verify_attest_record tests
+# ---------------------------------------------------------------------------
+
+class TestVerifyAttestRecord:
+    def test_verify_round_trip_passes(self, ephemeral_key_dir):
+        """write then verify succeeds against the test allowed_signers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            write_attest_record(
+                dispatch_id="D-verify-rt",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            ok, reason = verify_attest_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert ok, f"verify failed: {reason}"
+            assert reason == "ok"
+
+    def test_verify_fails_when_no_record(self, ephemeral_key_dir):
+        """verify returns False gracefully when no attest record exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            ok, reason = verify_attest_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok
+            assert "no attest record" in reason
+
+    def test_verify_diff_binding_fails_after_diff_change(self, ephemeral_key_dir):
+        """Adding code after writing the record means the record no longer covers the diff."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "track_a.py", "# track A\n", "feat: track A")
+            write_attest_record(
+                dispatch_id="D-track-a",
+                deliverable_id="D1",
+                track_id="track-a",
+                plan_gate_ref="gate-a",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            # Change the diff — old record no longer binds to the new diff
+            _add_file_commit(repo, "extra.py", "# extra change\n", "feat: extra")
+
+            ok, reason = verify_attest_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok
+            # Either "no attest record" (new key has no file) is the correct failure
+            assert "no attest record" in reason or "diff-binding" in reason
+
+    def test_verify_fails_wrong_allowed_signers(self, ephemeral_key_dir):
+        """verify fails when the signer key is not in allowed_signers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            write_attest_record(
+                dispatch_id="D-wrong-signer",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            ok, reason = verify_attest_record(
+                allowed_signers=empty_as,
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok
+            assert "signature" in reason.lower() or "fail" in reason.lower()
+
+    def test_verify_unsigned_record_fails_sig_check(self):
+        """Unsigned record fails signature verification."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            write_attest_record(
+                dispatch_id="D-unsigned-verify",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity="unsigned@local",
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=None,
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            ok, reason = verify_attest_record(
+                allowed_signers=empty_as,
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok
+            assert "signature" in reason.lower()
+
+
+# ---------------------------------------------------------------------------
+# diff-binding specific tests
+# ---------------------------------------------------------------------------
+
+class TestDiffBinding:
+    def test_diff_bind_forged_manifest_fails(self, ephemeral_key_dir):
+        """Forging: placing track A manifest at track B's content-key slot fails verify."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            # Build and sign a manifest for track A's diff
+            _add_file_commit(repo, "feature_a.py", "a = 1\n", "feat: A")
+            key_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            m_a = build_governed_manifest(
+                dispatch_id="D-a",
+                deliverable_id="D1",
+                track_id="track-a",
+                plan_gate_ref="gate-a",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+            )
+            m_a["diff_hash"] = key_a
+            m_a_signed = sign_manifest(m_a, ephemeral_key_dir["key_path"])
+
+            # Extend the diff to simulate "track B" code landing on top
+            _add_file_commit(repo, "feature_b.py", "b = 2\n", "feat: B")
+            key_b = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            assert key_a != key_b, "Tracks A and B must produce different content-keys"
+
+            # Forge: write track A's manifest at track B's content-key slot
+            attest_dir = repo / ATTEST_DIR
+            attest_dir.mkdir(parents=True, exist_ok=True)
+            forged_path = attest_dir / f"{key_b}.json"
+            forged_path.write_text(json.dumps(m_a_signed, sort_keys=True, indent=2))
+
+            # Verify must fail: manifest.diff_hash (key_a) != current diff (key_b)
+            ok, reason = verify_attest_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok, "diff-binding should prevent reuse of track A manifest for track B"
+            assert "diff-binding" in reason
+
+    def test_diff_bind_record_survives_attest_commit(self, ephemeral_key_dir):
+        """The attest record commit itself does not break verify (attest excluded from key)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "code.py", "x = 1\n", "feat: code")
+
+            rec = write_attest_record(
+                dispatch_id="D-attest-commit",
+                deliverable_id="D2",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T00:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            # Commit the attest record itself
+            subprocess.run(["git", "add", ".vnx-attest/"], cwd=str(repo), check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "chore: attest record"], cwd=str(repo), check=True, capture_output=True)
+
+            # Verify should still pass: .vnx-attest/ excluded from key computation
+            ok, reason = verify_attest_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert ok, f"verify failed after committing attest record: {reason}"

--- a/vnx_cli/commands/attest.py
+++ b/vnx_cli/commands/attest.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
+import os
+import tempfile
 
 from vnx_cli import _engine
 
@@ -118,30 +120,51 @@ def vnx_attest_verify(args) -> int:
     allowed_signers_str = getattr(args, "allowed_signers", None)
     base_ref = getattr(args, "base_ref", "origin/main")
 
-    if not allowed_signers_str:
-        for candidate in (
-            repo_root / ".vnx-attest" / "allowed_signers",
-            repo_root / ".vnx" / "allowed_signers",
-        ):
-            if candidate.exists():
-                allowed_signers_str = str(candidate)
-                break
-
-    if not allowed_signers_str:
-        print(
-            "Error: --allowed-signers not supplied and no default found.",
-            file=sys.stderr,
-        )
-        return 1
-
     _engine.ensure_engine_on_path()
     import attest_record as _ar
 
-    ok, reason = _ar.verify_attest_record(
-        allowed_signers=allowed_signers_str,
-        repo_root=repo_root,
-        base_ref=base_ref,
-    )
+    is_override = bool(allowed_signers_str)
+    tmp_path = None
+
+    if is_override:
+        # Opt-in explicit override — warn: caller must ensure the path is protected
+        print(
+            f"  [warn] --allowed-signers override: {allowed_signers_str!r} "
+            "(skipping base-branch resolution; ensure this path is CODEOWNERS-protected)",
+            file=sys.stderr,
+        )
+    else:
+        # Default: read from base branch — NEVER from the PR working tree.
+        # A PR can write .vnx-attest/allowed_signers, so trusting the working-tree
+        # copy allows a rogue key to self-verify.
+        content = _ar.read_allowed_signers_from_base(repo_root, base_ref)
+        if content is not None:
+            fd, tmp_path = tempfile.mkstemp(suffix=".allowed_signers")
+            try:
+                os.write(fd, content)
+            finally:
+                os.close(fd)
+            allowed_signers_str = tmp_path
+        else:
+            print(
+                f"Error: allowed_signers not found in base branch {base_ref!r}. "
+                "Add .vnx-attest/allowed_signers at base branch, or pass --allowed-signers.",
+                file=sys.stderr,
+            )
+            return 1
+
+    try:
+        ok, reason = _ar.verify_attest_record(
+            allowed_signers=allowed_signers_str,
+            repo_root=repo_root,
+            base_ref=base_ref,
+        )
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
 
     if ok:
         print(f"  PASS: {reason}")

--- a/vnx_cli/commands/attest.py
+++ b/vnx_cli/commands/attest.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""vnx attest {write,verify} — in-repo attestation record (D2)."""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+from vnx_cli import _engine
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _git_add(path: Path, repo_root: Path) -> None:
+    subprocess.run(
+        ["git", "add", str(path.relative_to(repo_root))],
+        cwd=str(repo_root), check=True, capture_output=True,
+    )
+
+
+def _try_signed_commit(msg: str, repo_root: Path, key_path: Path) -> bool:
+    """Attempt `git commit -S` with the SSH key; return True on success."""
+    result = subprocess.run(
+        [
+            "git",
+            "-c", "gpg.format=ssh",
+            "-c", f"gpg.ssh.signingKey={key_path}",
+            "commit", "-S", "-m", msg,
+        ],
+        cwd=str(repo_root), capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+def _plain_commit(msg: str, repo_root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "commit", "-m", msg],
+        cwd=str(repo_root), capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        print(result.stderr, file=sys.stderr)
+    return result.returncode == 0
+
+
+def vnx_attest_write(args) -> int:
+    """Write an in-repo attest record for the current branch."""
+    repo_root = Path(getattr(args, "project_dir", ".")).resolve()
+    key_path_str = getattr(args, "key", None)
+    key_path = Path(key_path_str) if key_path_str else None
+
+    dispatch_id = args.dispatch_id
+    deliverable_id = args.deliverable
+    track_id = args.track
+    plan_gate_ref = getattr(args, "gate_ref", "no-gate-ref")
+    signer_identity = getattr(args, "signer", "vnx@local")
+    base_ref = getattr(args, "base_ref", "origin/main")
+    no_commit = getattr(args, "no_commit", False)
+
+    _engine.ensure_engine_on_path()
+    import attest_record as _ar
+
+    try:
+        rec = _ar.write_attest_record(
+            dispatch_id=dispatch_id,
+            deliverable_id=deliverable_id,
+            track_id=track_id,
+            plan_gate_ref=plan_gate_ref,
+            signer_identity=signer_identity,
+            timestamp=_utc_now(),
+            key_path=key_path,
+            repo_root=repo_root,
+            base_ref=base_ref,
+        )
+    except RuntimeError as e:
+        print(f"attest write failed: {e}", file=sys.stderr)
+        return 1
+
+    signed_str = (
+        "yes (detached SSH signature)" if rec.manifest.get("signature")
+        else "no (unsigned — advisory phase)"
+    )
+    print(f"  content-key: {rec.content_key}")
+    print(f"  record:      {rec.record_path}")
+    print(f"  signed:      {signed_str}")
+
+    if no_commit:
+        print("  committed:   skipped (--no-commit)")
+        return 0
+
+    try:
+        _git_add(rec.record_path, repo_root)
+    except subprocess.CalledProcessError as e:
+        print(f"  git add failed: {e}", file=sys.stderr)
+        return 1
+
+    commit_msg = f"chore(gov): attest record [{dispatch_id}]"
+    git_signed = False
+    if key_path and key_path.exists():
+        git_signed = _try_signed_commit(commit_msg, repo_root, key_path)
+
+    if not git_signed:
+        ok = _plain_commit(commit_msg, repo_root)
+        if not ok:
+            print("  Warning: git commit failed — record staged but not committed.", file=sys.stderr)
+            return 1
+
+    print(f"  committed:   {'SSH-signed' if git_signed else 'unsigned'}")
+    return 0
+
+
+def vnx_attest_verify(args) -> int:
+    """Verify the attest record for the current branch."""
+    repo_root = Path(getattr(args, "project_dir", ".")).resolve()
+    allowed_signers_str = getattr(args, "allowed_signers", None)
+    base_ref = getattr(args, "base_ref", "origin/main")
+
+    if not allowed_signers_str:
+        for candidate in (
+            repo_root / ".vnx-attest" / "allowed_signers",
+            repo_root / ".vnx" / "allowed_signers",
+        ):
+            if candidate.exists():
+                allowed_signers_str = str(candidate)
+                break
+
+    if not allowed_signers_str:
+        print(
+            "Error: --allowed-signers not supplied and no default found.",
+            file=sys.stderr,
+        )
+        return 1
+
+    _engine.ensure_engine_on_path()
+    import attest_record as _ar
+
+    ok, reason = _ar.verify_attest_record(
+        allowed_signers=allowed_signers_str,
+        repo_root=repo_root,
+        base_ref=base_ref,
+    )
+
+    if ok:
+        print(f"  PASS: {reason}")
+        return 0
+    else:
+        print(f"  FAIL: {reason}", file=sys.stderr)
+        return 1
+
+
+def vnx_attest(args) -> int:
+    subcommand = getattr(args, "attest_subcommand", None)
+    if subcommand == "write":
+        return vnx_attest_write(args)
+    elif subcommand == "verify":
+        return vnx_attest_verify(args)
+    else:
+        print("  Usage: vnx attest {write,verify}", file=sys.stderr)
+        return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -386,6 +386,42 @@ def _register_dream_subparser(subparsers: argparse.Action) -> None:
     )
 
 
+def _register_attest_subparser(subparsers: argparse.Action) -> None:
+    attest_parser = subparsers.add_parser(
+        "attest",
+        help="write and verify in-repo attestation records (governance D2)",
+    )
+    attest_subs = attest_parser.add_subparsers(dest="attest_subcommand", metavar="SUBCOMMAND")
+
+    aw = attest_subs.add_parser("write", help="write attest record for the current branch")
+    aw.add_argument("--dispatch-id", required=True, dest="dispatch_id", metavar="DISPATCH_ID",
+                    help="Dispatch-ID of the governed build")
+    aw.add_argument("--deliverable", required=True, metavar="DELIVERABLE",
+                    help="deliverable being attested (e.g. D2)")
+    aw.add_argument("--track", required=True, metavar="TRACK_ID",
+                    help="track/objective ID")
+    aw.add_argument("--gate-ref", dest="gate_ref", default="no-gate-ref", metavar="REF",
+                    help="plan-gate pass reference")
+    aw.add_argument("--signer", default="vnx@local", metavar="IDENTITY",
+                    help="signer identity (must match an allowed_signers entry)")
+    aw.add_argument("--key", default=None, metavar="KEY_PATH",
+                    help="SSH private key for detached signature (optional; unsigned if omitted)")
+    aw.add_argument("--base-ref", dest="base_ref", default="origin/main", metavar="REF",
+                    help="base branch for merge-base (default: origin/main)")
+    aw.add_argument("--no-commit", dest="no_commit", action="store_true",
+                    help="write the record file only; skip git add + commit")
+    aw.add_argument("--project-dir", default=".", metavar="DIR",
+                    help="repository root (default: current directory)")
+
+    av = attest_subs.add_parser("verify", help="verify a branch attest record")
+    av.add_argument("--allowed-signers", dest="allowed_signers", default=None, metavar="PATH",
+                    help="path to SSH allowed_signers file (auto-detected if omitted)")
+    av.add_argument("--base-ref", dest="base_ref", default="origin/main", metavar="REF",
+                    help="base branch for merge-base (default: origin/main)")
+    av.add_argument("--project-dir", default=".", metavar="DIR",
+                    help="repository root (default: current directory)")
+
+
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":
         from vnx_cli.commands.init_cmd import vnx_init
@@ -431,6 +467,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.migrate import vnx_migrate
         sys.exit(vnx_migrate(args))
 
+    elif args.command == "attest":
+        from vnx_cli.commands.attest import vnx_attest
+        sys.exit(vnx_attest(args))
+
     else:
         parser.print_help()
         sys.exit(0)
@@ -458,6 +498,7 @@ def main() -> None:
     _register_learning_subparser(subparsers)
     _register_dream_subparser(subparsers)
     _register_migrate_subparser(subparsers)
+    _register_attest_subparser(subparsers)
 
     args = parser.parse_args()
     _dispatch_command(args, parser)


### PR DESCRIPTION
## Summary

D2 of governance-attribution-enforce. The attestation now travels IN the repo so a server-side gate (D3, later) can verify it — grounded in the rev-4 plan's squash-safe + diff-bound corrections.

- Governed build commits write `.vnx-attest/<content-key>.json` — **content-keyed** (hash of the merge-base→HEAD tree/diff), NOT commit-sha, so it survives the repo's squash-merge; a rebase/force-push re-derives the same key.
- **Diff-bound**: the manifest signs the diff hash, so a manifest for track A cannot accompany track B's code.
- Detached-signed via D1's `sign_manifest`. `vnx attest {write,verify}` operator surface.
- Advisory only — nothing enforces yet (D3 is the server gate).

## Verification

17 attest_d2 tests pass (content-key stability across squash, diff-binding rejection, rebase re-derivation, verify round-trip). Independently re-run.

## Provenance

Governed tmux-spawn lane (dispatch `D-govenf-d2-travel`, security-engineer). Builds on D1 (#1004, merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC