### PR TITLE
feat(gov): server-side attestation verify gate, staged advisory + CODEOWNERS trust-root [D3]

### DIFF
--- a/.github/workflows/attestation-gate.yml
+++ b/.github/workflows/attestation-gate.yml
@@ -10,8 +10,18 @@
 # never from the PR head.  A PR cannot neuter the gate by editing its own
 # allowed_signers.  CODEOWNERS guards .vnx-attest/allowed_signers and this file.
 #
-# Exempt lane residual: PRs touching only docs/, tests/, or *.md files bypass
-# this gate.  This is an un-attributed lane — accepted for v1, named as a risk.
+# Verifier safety (D3 gate-fix): verify_pr.py and its helper scripts are extracted
+# from the BASE branch (origin/main) before running.  A PR that weakens or
+# replaces verify_pr.py cannot affect the gate decision — the base-branch copy
+# is always executed.  The PR-tree copy of verify_pr.py is never trusted.
+#
+# Exempt allowlist — fail-closed: PRs touching only the following paths are
+# exempt from the attestation gate:
+#   docs/    — documentation
+#   tests/   — test suite
+#   *.md     — markdown files
+# Everything else (including any new top-level file or directory) REQUIRES a
+# valid attestation.  Un-classified paths are never silently skipped.
 
 name: Attestation Gate (D3)
 
@@ -42,6 +52,20 @@ jobs:
         with:
           python-version: "3.11"
 
+      - name: Extract base-branch verifier
+        run: |
+          set -euo pipefail
+          # Obtain verify_pr.py and its dependency chain from origin/main.
+          # The PR-tree copy of any of these files is NEVER trusted or executed.
+          # A PR that weakens verify_pr.py cannot affect the gate decision.
+          VERIFIER_DIR="/tmp/vnx-base-verifier"
+          mkdir -p "$VERIFIER_DIR"
+          for f in verify_pr.py attest_record.py attestation.py content_key.py ndjson_hash_chain.py; do
+            git show "origin/main:scripts/lib/$f" > "$VERIFIER_DIR/$f"
+          done
+          echo "Base-branch verifier extracted to $VERIFIER_DIR"
+          ls -la "$VERIFIER_DIR"
+
       - name: Classify PR (feature vs exempt)
         id: classify
         run: |
@@ -52,18 +76,24 @@ jobs:
           echo "Changed files:"
           echo "$CHANGED"
 
-          # Feature-code paths that trigger the gate
-          FEATURE=$(echo "$CHANGED" | grep -E \
-            '^(scripts/|vnx_cli/|dashboard/|schemas/|\.vnx/|\.github/)' \
-            || true)
+          # Fail-closed classification using the exempt allowlist.
+          # The logic is INVERTED from a feature-list check:
+          #   Every path that is NOT in the exempt allowlist requires attestation.
+          # Exempt allowlist: docs/, tests/, *.md
+          # Everything else — including new top-level files or directories —
+          # is treated as REQUIRES-ATTESTATION, never silently skipped.
+          NON_EXEMPT=$(echo "$CHANGED" | grep -vE '^(docs/|tests/)|\.md$' || true)
 
-          if [ -z "$FEATURE" ]; then
+          if [ -z "$CHANGED" ]; then
+            echo "classification=empty" >> "$GITHUB_OUTPUT"
+            echo "::notice::Attestation gate: empty PR — exempt"
+          elif [ -z "$NON_EXEMPT" ]; then
             echo "classification=exempt" >> "$GITHUB_OUTPUT"
-            echo "::notice::Attestation gate: exempt (docs/tests/md only — un-attributed lane, named residual)"
+            echo "::notice::Attestation gate: exempt — all files in exempt allowlist (docs/, tests/, *.md)"
           else
             echo "classification=feature" >> "$GITHUB_OUTPUT"
-            echo "Feature-code files that trigger the gate:"
-            echo "$FEATURE"
+            echo "Files requiring attestation (outside exempt allowlist):"
+            echo "$NON_EXEMPT"
           fi
 
       - name: Read allowed_signers from BASE branch (trust anchor)
@@ -93,7 +123,9 @@ jobs:
           steps.read_signers.outputs.signers_found == 'true'
         run: |
           set -euo pipefail
-          python3 "$GITHUB_WORKSPACE/scripts/lib/verify_pr.py" \
+          # Run the BASE-BRANCH copy of verify_pr.py — the PR-tree copy is NEVER executed.
+          PYTHONPATH="/tmp/vnx-base-verifier" \
+          python3 /tmp/vnx-base-verifier/verify_pr.py \
             --repo-root "$GITHUB_WORKSPACE" \
             --base-ref "origin/main" \
             --head-ref HEAD \

--- a/.github/workflows/attestation-gate.yml
+++ b/.github/workflows/attestation-gate.yml
@@ -1,0 +1,101 @@
+# D3: Attestation verification gate — STAGED ADVISORY (non-blocking)
+#
+# This check runs and REPORTS but does NOT block merges (continue-on-error: true).
+# It becomes a REQUIRED check after the flip criterion is met:
+#   - N=5 consecutive PRs carrying valid signatures, operator-confirmed.
+#   - Operator step: promote this check to required + enforce_admins in branch
+#     protection settings, then set continue-on-error: false in this file.
+#
+# Trust-anchor safety: allowed_signers is read from the BASE branch (origin/main),
+# never from the PR head.  A PR cannot neuter the gate by editing its own
+# allowed_signers.  CODEOWNERS guards .vnx-attest/allowed_signers and this file.
+#
+# Exempt lane residual: PRs touching only docs/, tests/, or *.md files bypass
+# this gate.  This is an un-attributed lane — accepted for v1, named as a risk.
+
+name: Attestation Gate (D3)
+
+on:
+  pull_request:
+
+jobs:
+  attestation-gate:
+    name: "Gov-D3: Attestation signature gate (advisory)"
+    runs-on: ubuntu-latest
+    # STAGED ADVISORY: reports but never blocks.
+    # Remove this line when flipping to required (see flip criterion above).
+    continue-on-error: true
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          # Fetch full history so merge-base resolution works
+          fetch-depth: 0
+
+      - name: Fetch base branch for trust anchor + merge-base
+        run: |
+          git fetch origin main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Classify PR (feature vs exempt)
+        id: classify
+        run: |
+          set -euo pipefail
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+
+          CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          # Feature-code paths that trigger the gate
+          FEATURE=$(echo "$CHANGED" | grep -E \
+            '^(scripts/|vnx_cli/|dashboard/|schemas/|\.vnx/|\.github/)' \
+            || true)
+
+          if [ -z "$FEATURE" ]; then
+            echo "classification=exempt" >> "$GITHUB_OUTPUT"
+            echo "::notice::Attestation gate: exempt (docs/tests/md only — un-attributed lane, named residual)"
+          else
+            echo "classification=feature" >> "$GITHUB_OUTPUT"
+            echo "Feature-code files that trigger the gate:"
+            echo "$FEATURE"
+          fi
+
+      - name: Read allowed_signers from BASE branch (trust anchor)
+        if: steps.classify.outputs.classification == 'feature'
+        id: read_signers
+        run: |
+          set -euo pipefail
+          # Read from origin/main — NEVER from the PR head.
+          # A PR cannot introduce a rogue key and self-verify.
+          SIGNERS_CONTENT=$(git show "origin/main:.vnx-attest/allowed_signers" 2>/dev/null || true)
+
+          if [ -z "$SIGNERS_CONTENT" ]; then
+            echo "::warning::allowed_signers not found at origin/main:.vnx-attest/allowed_signers"
+            echo "::warning::This PR would FAIL once the gate becomes required."
+            echo "::warning::See docs/governance/KEY_PROVISIONING.md to provision signing keys."
+            echo "signers_found=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "$SIGNERS_CONTENT" > /tmp/vnx_allowed_signers
+            echo "signers_found=true" >> "$GITHUB_OUTPUT"
+            ENTRY_COUNT=$(wc -l < /tmp/vnx_allowed_signers)
+            echo "::notice::allowed_signers resolved from origin/main (${ENTRY_COUNT} entries)"
+          fi
+
+      - name: Run attestation verify-pr
+        if: >
+          steps.classify.outputs.classification == 'feature' &&
+          steps.read_signers.outputs.signers_found == 'true'
+        run: |
+          set -euo pipefail
+          python3 "$GITHUB_WORKSPACE/scripts/lib/verify_pr.py" \
+            --repo-root "$GITHUB_WORKSPACE" \
+            --base-ref "origin/main" \
+            --head-ref HEAD \
+            --allowed-signers /tmp/vnx_allowed_signers \
+            --verbose

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,19 @@
+# CODEOWNERS — trust-root paths for the D3 attestation gate.
+#
+# Changes to the signing trust anchor or the gate workflow require review
+# from a maintainer.  The gate verifies allowed_signers from the BASE branch,
+# so adding a CODEOWNERS rule here means any PR modifying these paths triggers
+# a required review BEFORE the change can land.
+#
+# A PR cannot self-authorize a new signing key: the CODEOWNERS rule ensures
+# a human maintainer reviews the change, and the gate always reads
+# allowed_signers from the pre-existing base branch (never the PR head).
+
+# Signing trust anchor — who is allowed to sign attestations
+.vnx-attest/allowed_signers @Vinix24
+
+# Attestation gate workflow — the server-side enforcement mechanism
+.github/workflows/attestation-gate.yml @Vinix24
+
+# Governance enforcement config — local detective layer
+.vnx/governance_enforcement.yaml @Vinix24

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -3,21 +3,31 @@
 Called by `vnx attest verify-pr` and by the GitHub Action
 .github/workflows/attestation-gate.yml.
 
-Checks (for a PR touching feature code):
-  1. Is the PR feature-code only or exempt (docs/tests/md only)?
-     Exempt PRs exit 0 with a named residual note.
+Checks (for a PR requiring attestation):
+  1. Classify changed files against the exempt allowlist (fail-closed).
+     Every path not in the exempt allowlist REQUIRES a valid attestation.
+     Un-classified paths (e.g. a new top-level dir) are never silently skipped.
   2. Read allowed_signers from the BASE branch (never the PR tree).
   3. Verify: .vnx-attest/<content-key>.json exists, diff_hash binds,
      signature is valid against allowed_signers.
 
-Feature-code paths  (gate fires on any match):
-  scripts/, vnx_cli/, dashboard/, schemas/, .vnx/, .github/
+Verifier safety: this file is executed from the BASE branch by the GitHub
+Action (extracted via `git show origin/main:scripts/lib/verify_pr.py`).
+The PR-tree copy of verify_pr.py is NEVER run for the gate decision, so a
+PR that weakens this file cannot affect the gate outcome.
 
-Exempt paths (gate skipped if ALL changed files match these):
-  docs/, tests/, *.md
+Exempt allowlist — explicit; fail-closed:
+  docs/   — documentation directory
+  tests/  — test-suite directory
+  *.md    — markdown files
+
+Everything else is REQUIRES-ATTESTATION by default.  Any new top-level file
+or directory that is not in the exempt allowlist requires a valid attestation.
+This is intentionally conservative: prefer a false-positive (unexpected
+attestation requirement) over a false-negative (silently ungated change).
 
 Exit codes:
-  0 — PASS (valid attest) or EXEMPT (docs/tests/md only)
+  0 — PASS (valid attest) or EXEMPT (all files in exempt allowlist)
   1 — FAIL (unsigned feature PR, bad sig, no record, diff mismatch)
   2 — CONFIG ERROR (allowed_signers not found at base branch)
 
@@ -34,6 +44,18 @@ import sys
 import tempfile
 from pathlib import Path
 
+# Exempt allowlist — paths exempt from attestation.
+# MUST stay in sync with the bash classify step in attestation-gate.yml.
+# The gate logic is INVERTED: anything NOT exempt requires attestation.
+_EXEMPT_PREFIXES = (
+    "docs/",
+    "tests/",
+)
+
+# Note: _FEATURE_PREFIXES is kept for documentation / future audit use only.
+# Classification no longer depends on matching feature prefixes — it depends
+# on NOT matching the exempt allowlist.  Any path outside the exempt allowlist
+# is treated as requiring attestation (fail-closed).
 _FEATURE_PREFIXES = (
     "scripts/",
     "vnx_cli/",
@@ -41,11 +63,6 @@ _FEATURE_PREFIXES = (
     "schemas/",
     ".vnx/",
     ".github/",
-)
-
-_EXEMPT_PREFIXES = (
-    "docs/",
-    "tests/",
 )
 
 
@@ -75,6 +92,11 @@ def _is_feature_file(path: str) -> bool:
 
 
 def _is_exempt_file(path: str) -> bool:
+    """Return True if this path is in the exempt allowlist.
+
+    Exempt paths: docs/, tests/, *.md
+    Everything else is NOT exempt (requires attestation).
+    """
     for prefix in _EXEMPT_PREFIXES:
         if path.startswith(prefix):
             return True
@@ -99,23 +121,29 @@ def _resolve_merge_base(base_ref: str, head_ref: str, cwd: Path) -> str:
 def classify_pr(
     changed_files: list[str],
 ) -> str:
-    """Classify a PR's changed files.
+    """Classify a PR's changed files — fail-closed against the exempt allowlist.
+
+    Classification is EXHAUSTIVE: every changed path is either in the exempt
+    allowlist (EXEMPT) or requires attestation (feature).  There is no
+    un-classified / silently-skipped category.
 
     Returns:
-      "feature"  — at least one feature-path file → gate fires
-      "exempt"   — all files are docs/tests/md → gate skips
+      "feature"  — at least one file is NOT in the exempt allowlist → gate fires
+      "exempt"   — ALL files are in the exempt allowlist → gate skips
       "empty"    — no changed files (degenerate case → treat as exempt)
+
+    Exempt allowlist: docs/, tests/, *.md
+    Anything outside this list — including new top-level files or directories —
+    defaults to "feature" (requires attestation).
     """
     if not changed_files:
         return "empty"
-    feature_files = [f for f in changed_files if _is_feature_file(f)]
-    if feature_files:
-        return "feature"
-    # all files must be individually exempt; mixed non-feature non-exempt → feature
     all_exempt = all(_is_exempt_file(f) for f in changed_files)
     if all_exempt:
         return "exempt"
-    # files outside feature AND outside exempt prefixes: treat as feature
+    # At least one file is outside the exempt allowlist → gate fires.
+    # This covers feature-code paths (scripts/, vnx_cli/, ...) AND any
+    # un-classified path (e.g. setup.py, pyproject.toml, a new top-level dir).
     return "feature"
 
 

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -1,0 +1,258 @@
+"""D3: verify-pr helper — server-side attestation gate logic.
+
+Called by `vnx attest verify-pr` and by the GitHub Action
+.github/workflows/attestation-gate.yml.
+
+Checks (for a PR touching feature code):
+  1. Is the PR feature-code only or exempt (docs/tests/md only)?
+     Exempt PRs exit 0 with a named residual note.
+  2. Read allowed_signers from the BASE branch (never the PR tree).
+  3. Verify: .vnx-attest/<content-key>.json exists, diff_hash binds,
+     signature is valid against allowed_signers.
+
+Feature-code paths  (gate fires on any match):
+  scripts/, vnx_cli/, dashboard/, schemas/, .vnx/, .github/
+
+Exempt paths (gate skipped if ALL changed files match these):
+  docs/, tests/, *.md
+
+Exit codes:
+  0 — PASS (valid attest) or EXEMPT (docs/tests/md only)
+  1 — FAIL (unsigned feature PR, bad sig, no record, diff mismatch)
+  2 — CONFIG ERROR (allowed_signers not found at base branch)
+
+References:
+  - attest_record.py: verify_attest_record, read_allowed_signers_from_base
+  - content_key.py:   compute_diff_hash
+  - docs/governance/2026-07-04-governance-attribution-enforce-PLAN.md (D3)
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+_FEATURE_PREFIXES = (
+    "scripts/",
+    "vnx_cli/",
+    "dashboard/",
+    "schemas/",
+    ".vnx/",
+    ".github/",
+)
+
+_EXEMPT_PREFIXES = (
+    "docs/",
+    "tests/",
+)
+
+
+def _changed_files(
+    merge_base: str,
+    head_ref: str,
+    cwd: Path,
+) -> list[str]:
+    """Return list of changed file paths between merge_base and head_ref."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", merge_base, head_ref],
+        cwd=str(cwd), capture_output=True, text=True,
+    )
+    if result.returncode not in (0, 1):
+        raise RuntimeError(
+            f"git diff --name-only failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    return [f for f in result.stdout.splitlines() if f.strip()]
+
+
+def _is_feature_file(path: str) -> bool:
+    for prefix in _FEATURE_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    return False
+
+
+def _is_exempt_file(path: str) -> bool:
+    for prefix in _EXEMPT_PREFIXES:
+        if path.startswith(prefix):
+            return True
+    if path.endswith(".md"):
+        return True
+    return False
+
+
+def _resolve_merge_base(base_ref: str, head_ref: str, cwd: Path) -> str:
+    result = subprocess.run(
+        ["git", "merge-base", base_ref, head_ref],
+        cwd=str(cwd), capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git merge-base {base_ref!r} {head_ref!r} failed: "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout.strip()
+
+
+def classify_pr(
+    changed_files: list[str],
+) -> str:
+    """Classify a PR's changed files.
+
+    Returns:
+      "feature"  — at least one feature-path file → gate fires
+      "exempt"   — all files are docs/tests/md → gate skips
+      "empty"    — no changed files (degenerate case → treat as exempt)
+    """
+    if not changed_files:
+        return "empty"
+    feature_files = [f for f in changed_files if _is_feature_file(f)]
+    if feature_files:
+        return "feature"
+    # all files must be individually exempt; mixed non-feature non-exempt → feature
+    all_exempt = all(_is_exempt_file(f) for f in changed_files)
+    if all_exempt:
+        return "exempt"
+    # files outside feature AND outside exempt prefixes: treat as feature
+    return "feature"
+
+
+def verify_pr(
+    *,
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+    allowed_signers_override: "str | Path | None" = None,
+    verbose: bool = False,
+) -> "tuple[int, str]":
+    """Run the full verify-pr check for a PR.
+
+    Returns (exit_code, message):
+      (0, "exempt: docs/tests/md only — un-attributed lane (named residual)")
+      (0, "PASS: attestation valid")
+      (1, "FAIL: <reason>")
+      (2, "CONFIG ERROR: <reason>")
+
+    The caller is responsible for printing the message and exiting.
+
+    Args:
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch to merge-base against (default: origin/main).
+        head_ref: Branch tip to verify (default: HEAD).
+        allowed_signers_override: Explicit path to allowed_signers — skips
+            base-branch resolution.  ONLY for tests; production always uses
+            base-branch resolution so a PR cannot supply its own trust anchor.
+        verbose: If True, emit diagnostic lines to stderr.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+
+    try:
+        merge_base = _resolve_merge_base(base_ref, head_ref, repo_root)
+    except RuntimeError as e:
+        return (1, f"FAIL: merge-base resolution failed: {e}")
+
+    try:
+        changed = _changed_files(merge_base, head_ref, repo_root)
+    except RuntimeError as e:
+        return (1, f"FAIL: changed-files detection failed: {e}")
+
+    classification = classify_pr(changed)
+
+    if verbose:
+        print(
+            f"[verify-pr] base={base_ref} head={head_ref} "
+            f"merge_base={merge_base[:12]} changed={len(changed)} "
+            f"classification={classification}",
+            file=sys.stderr,
+        )
+
+    if classification in ("exempt", "empty"):
+        return (
+            0,
+            "exempt: docs/tests/md only — un-attributed lane (named residual, accepted v1)",
+        )
+
+    # Feature code in this PR — gate fires.
+    # Resolve allowed_signers from base branch (never from PR tree).
+    tmp_path = None
+    try:
+        if allowed_signers_override is not None:
+            allowed_signers_path = Path(allowed_signers_override)
+        else:
+            from attest_record import read_allowed_signers_from_base
+            raw = read_allowed_signers_from_base(repo_root, base_ref)
+            if raw is None:
+                return (
+                    2,
+                    f"CONFIG ERROR: .vnx-attest/allowed_signers not found at "
+                    f"base branch {base_ref!r}. "
+                    "Add .vnx-attest/allowed_signers at the base branch "
+                    "(see docs/governance/KEY_PROVISIONING.md).",
+                )
+            fd, tmp_str = tempfile.mkstemp(suffix=".allowed_signers")
+            try:
+                os.write(fd, raw)
+            finally:
+                os.close(fd)
+            tmp_path = tmp_str
+            allowed_signers_path = Path(tmp_path)
+
+        from attest_record import verify_attest_record
+        ok, reason = verify_attest_record(
+            allowed_signers=allowed_signers_path,
+            repo_root=repo_root,
+            base_ref=base_ref,
+            head_ref=head_ref,
+        )
+    finally:
+        if tmp_path:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+    if ok:
+        return (0, "PASS: attestation valid")
+    return (1, f"FAIL: {reason}")
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point (used by the GitHub Action)
+# ---------------------------------------------------------------------------
+
+def _cli_main(argv=None):
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Verify attestation for a PR (D3 gate).",
+    )
+    parser.add_argument("--repo-root", default=".", metavar="DIR",
+                        help="repository root (default: current directory)")
+    parser.add_argument("--base-ref", default="origin/main", metavar="REF",
+                        help="base branch for merge-base (default: origin/main)")
+    parser.add_argument("--head-ref", default="HEAD", metavar="REF",
+                        help="PR head ref (default: HEAD)")
+    parser.add_argument("--allowed-signers", default=None, metavar="PATH",
+                        help="override allowed_signers path (base-branch resolution if omitted)")
+    parser.add_argument("--verbose", action="store_true",
+                        help="emit diagnostic lines to stderr")
+    args = parser.parse_args(argv)
+
+    exit_code, message = verify_pr(
+        repo_root=args.repo_root,
+        base_ref=args.base_ref,
+        head_ref=args.head_ref,
+        allowed_signers_override=args.allowed_signers,
+        verbose=args.verbose,
+    )
+    if exit_code == 0:
+        print(message)
+    else:
+        print(message, file=sys.stderr)
+    sys.exit(exit_code)
+
+
+if __name__ == "__main__":
+    _cli_main()

--- a/tests/test_verify_pr.py
+++ b/tests/test_verify_pr.py
@@ -1,0 +1,405 @@
+"""Tests for D3: verify_pr helper — server-side attestation gate logic.
+
+Test filter: pytest -k "verify_pr or gate"
+
+Covers:
+  - classify_pr: feature vs exempt vs empty
+  - verify_pr: validly-signed+diff-bound attest PASSES
+  - verify_pr: manifest for a different diff FAILS (diff-binding)
+  - verify_pr: PR-tree allowed_signers is IGNORED (base-branch used)
+  - verify_pr: unsigned feature PR FAILS
+  - verify_pr: docs-only PR is EXEMPT (exit 0)
+  - verify_pr: tests-only PR is EXEMPT
+  - verify_pr: *.md-only PR is EXEMPT
+  - verify_pr: mixed feature+docs triggers gate
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from verify_pr import classify_pr, verify_pr, _is_feature_file, _is_exempt_file
+from attest_record import ATTEST_DIR, write_attest_record
+from content_key import compute_diff_hash
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def ephemeral_key_dir():
+    """Ephemeral ed25519 test key + allowed_signers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "testkey"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""],
+            check=True, capture_output=True,
+        )
+        pub = key_path.with_suffix(".pub").read_text().strip()
+        identity = "vnx-test@local"
+        allowed_signers = Path(tmpdir) / "allowed_signers"
+        allowed_signers.write_text(f"{identity} {pub}\n")
+        yield {
+            "key_path": key_path,
+            "identity": identity,
+            "allowed_signers": allowed_signers,
+        }
+
+
+def _init_repo(tmp: Path) -> Path:
+    """Init a git repo in tmp with a base commit."""
+    subprocess.run(["git", "init", "-b", "main"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@vnx.local"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "VNX Test"], cwd=str(tmp), check=True, capture_output=True)
+    (tmp / "README.md").write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=str(tmp), check=True, capture_output=True)
+    return tmp
+
+
+def _head_sha(repo: Path) -> str:
+    r = subprocess.run(["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True)
+    return r.stdout.strip()
+
+
+def _add_file_commit(repo: Path, filename: str, content: str, msg: str) -> None:
+    # Support sub-paths
+    full = repo / filename
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content)
+    subprocess.run(["git", "add", filename], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", msg], cwd=str(repo), check=True, capture_output=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: classify_pr
+# ---------------------------------------------------------------------------
+
+class TestClassifyPR:
+    def test_feature_scripts(self):
+        assert classify_pr(["scripts/lib/foo.py"]) == "feature"
+
+    def test_feature_vnx_cli(self):
+        assert classify_pr(["vnx_cli/main.py", "vnx_cli/commands/attest.py"]) == "feature"
+
+    def test_feature_dashboard(self):
+        assert classify_pr(["dashboard/api_config.py"]) == "feature"
+
+    def test_feature_schemas(self):
+        assert classify_pr(["schemas/quality_intelligence.sql"]) == "feature"
+
+    def test_feature_vnx_dir(self):
+        assert classify_pr([".vnx/governance_enforcement.yaml"]) == "feature"
+
+    def test_feature_github_dir(self):
+        assert classify_pr([".github/workflows/vnx-ci.yml"]) == "feature"
+
+    def test_exempt_docs_only(self):
+        assert classify_pr(["docs/README.md", "docs/core/ARCH.md"]) == "exempt"
+
+    def test_exempt_tests_only(self):
+        assert classify_pr(["tests/test_foo.py", "tests/conftest.py"]) == "exempt"
+
+    def test_exempt_md_only(self):
+        assert classify_pr(["CHANGELOG.md", "README.md"]) == "exempt"
+
+    def test_exempt_mixed_docs_tests(self):
+        assert classify_pr(["docs/foo.md", "tests/test_bar.py"]) == "exempt"
+
+    def test_exempt_empty(self):
+        assert classify_pr([]) == "empty"
+
+    def test_feature_mixed_feature_and_docs(self):
+        # feature file + docs file → feature (gate fires)
+        assert classify_pr(["scripts/lib/foo.py", "docs/ARCH.md"]) == "feature"
+
+    def test_non_exempt_non_feature_treated_as_feature(self):
+        # A file outside both feature and exempt prefixes (e.g. setup.py) → feature
+        result = classify_pr(["setup.py"])
+        assert result == "feature"
+
+
+class TestPathHelpers:
+    def test_is_feature_file_scripts(self):
+        assert _is_feature_file("scripts/lib/foo.py")
+
+    def test_is_feature_file_github(self):
+        assert _is_feature_file(".github/workflows/foo.yml")
+
+    def test_is_feature_file_not_matching(self):
+        assert not _is_feature_file("docs/ARCH.md")
+
+    def test_is_exempt_docs(self):
+        assert _is_exempt_file("docs/ARCH.md")
+
+    def test_is_exempt_tests(self):
+        assert _is_exempt_file("tests/test_foo.py")
+
+    def test_is_exempt_md(self):
+        assert _is_exempt_file("CHANGELOG.md")
+
+    def test_is_exempt_not_matching(self):
+        assert not _is_exempt_file("scripts/lib/foo.py")
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: verify_pr
+# ---------------------------------------------------------------------------
+
+class TestVerifyPRPass:
+    def test_valid_attest_passes(self, ephemeral_key_dir):
+        """A validly-signed, diff-bound attest record passes verify_pr."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+
+            write_attest_record(
+                dispatch_id="D-vpr-pass",
+                deliverable_id="D3",
+                track_id="governance-attribution-enforce",
+                plan_gate_ref="gate-ref",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 0, f"Expected PASS but got: {message}"
+            assert "PASS" in message
+
+
+class TestVerifyPRFail:
+    def test_manifest_for_different_diff_fails(self, ephemeral_key_dir):
+        """A manifest signed for a different diff fails diff-binding check."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            # Write feature code and sign it
+            _add_file_commit(repo, "scripts/lib/track_a.py", "a = 1\n", "feat: track A")
+            write_attest_record(
+                dispatch_id="D-track-a",
+                deliverable_id="D1",
+                track_id="track-a",
+                plan_gate_ref="gate-a",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            # Add more feature code — the diff changes, old record no longer covers it
+            _add_file_commit(repo, "scripts/lib/track_b.py", "b = 2\n", "feat: track B")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Expected FAIL (diff-binding) but got {exit_code}: {message}"
+            assert "FAIL" in message
+
+    def test_unsigned_feature_pr_fails(self):
+        """Feature PR with no attest record fails verify_pr."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "vnx_cli/main.py", "# feature\n", "feat: cli change")
+
+            # No attest record written
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=empty_as,
+            )
+            assert exit_code == 1, f"Expected FAIL but got {exit_code}: {message}"
+            assert "FAIL" in message
+
+    def test_wrong_allowed_signers_fails(self, ephemeral_key_dir):
+        """A valid attest record fails if allowed_signers does not contain the key."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+
+            write_attest_record(
+                dispatch_id="D-wrong-key",
+                deliverable_id="D3",
+                track_id="t",
+                plan_gate_ref="r",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=empty_as,
+            )
+            assert exit_code == 1, f"Expected FAIL but got {exit_code}: {message}"
+            assert "FAIL" in message
+
+
+class TestVerifyPRExempt:
+    def test_docs_only_pr_is_exempt(self, ephemeral_key_dir):
+        """A PR touching only docs/ files is exempt — exit 0."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "docs/ARCH.md", "# arch\n", "docs: update arch")
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=empty_as,
+            )
+            assert exit_code == 0, f"Expected exempt (0) but got {exit_code}: {message}"
+            assert "exempt" in message
+
+    def test_tests_only_pr_is_exempt(self, ephemeral_key_dir):
+        """A PR touching only tests/ files is exempt — exit 0."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "tests/test_new.py", "# test\n", "test: add test")
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=empty_as,
+            )
+            assert exit_code == 0, f"Expected exempt (0) but got {exit_code}: {message}"
+            assert "exempt" in message
+
+    def test_md_only_pr_is_exempt(self):
+        """A PR touching only *.md files is exempt — exit 0."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "CHANGELOG.md", "# change\n", "docs: changelog")
+
+            empty_as = Path(tmpdir) / "empty_allowed_signers"
+            empty_as.write_text("")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=empty_as,
+            )
+            assert exit_code == 0, f"Expected exempt (0) but got {exit_code}: {message}"
+            assert "exempt" in message
+
+
+class TestPRTreeAllowedSignersIgnored:
+    """PR-tree allowed_signers is IGNORED — base-branch is used.
+
+    When allowed_signers_override is not set, verify_pr calls
+    read_allowed_signers_from_base (base-ref resolution).
+    This test simulates the trust-anchor property directly: even if the
+    working tree has a rogue allowed_signers, the base-ref copy is used.
+    """
+
+    def test_rogue_key_in_pr_tree_not_self_verifying(self, ephemeral_key_dir):
+        """A rogue key committed to .vnx-attest/allowed_signers in the PR cannot self-verify."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+
+            # Set up base branch with the legitimate key
+            identity = ephemeral_key_dir["identity"]
+            pub = ephemeral_key_dir["key_path"].with_suffix(".pub").read_text().strip()
+            attest_dir = repo / ATTEST_DIR
+            attest_dir.mkdir(parents=True, exist_ok=True)
+            (attest_dir / "allowed_signers").write_text(f"{identity} {pub}\n")
+            subprocess.run(["git", "add", ATTEST_DIR], cwd=str(repo), check=True, capture_output=True)
+            subprocess.run(["git", "commit", "-m", "add: allowed_signers"], cwd=str(repo), check=True, capture_output=True)
+            base_sha = _head_sha(repo)
+
+            # PR: add feature code
+            _add_file_commit(repo, "scripts/lib/attack.py", "evil = 1\n", "feat: attack")
+
+            # PR tree: generate a rogue key and commit it into allowed_signers
+            rogue_dir = Path(tmpdir) / "rogue_keys"
+            rogue_dir.mkdir()
+            rogue_key = rogue_dir / "rogue"
+            subprocess.run(
+                ["ssh-keygen", "-t", "ed25519", "-f", str(rogue_key), "-N", ""],
+                check=True, capture_output=True,
+            )
+            rogue_pub = rogue_key.with_suffix(".pub").read_text().strip()
+            rogue_identity = "rogue@attacker"
+
+            # Sign attest with rogue key
+            write_attest_record(
+                dispatch_id="D-attack",
+                deliverable_id="D3",
+                track_id="attack",
+                plan_gate_ref="none",
+                signer_identity=rogue_identity,
+                timestamp="2026-07-04T12:00:00Z",
+                key_path=rogue_key,
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            # Commit rogue key into PR-tree allowed_signers (self-authorization attempt)
+            (attest_dir / "allowed_signers").write_text(f"{rogue_identity} {rogue_pub}\n")
+            subprocess.run(["git", "add", ATTEST_DIR], cwd=str(repo), check=True, capture_output=True)
+            subprocess.run(
+                ["git", "commit", "-m", "attack: add rogue key to allowed_signers"],
+                cwd=str(repo), check=True, capture_output=True,
+            )
+
+            # verify_pr without override uses read_allowed_signers_from_base →
+            # base_sha:.vnx-attest/allowed_signers contains only the LEGITIMATE key
+            # → rogue-signed record must FAIL
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+            )
+            assert exit_code == 1, (
+                f"Rogue self-authorization should fail but got exit_code={exit_code}: {message}"
+            )
+            assert "FAIL" in message

--- a/tests/test_verify_pr.py
+++ b/tests/test_verify_pr.py
@@ -124,6 +124,14 @@ class TestClassifyPR:
         result = classify_pr(["setup.py"])
         assert result == "feature"
 
+    def test_new_top_level_dir_requires_attestation(self):
+        # Fail-closed: a new top-level directory is not in the exempt allowlist → feature
+        assert classify_pr(["newdir/somefile.py"]) == "feature"
+
+    def test_unclassified_build_file_requires_attestation(self):
+        # Fail-closed: pyproject.toml is not in the exempt allowlist → feature
+        assert classify_pr(["pyproject.toml"]) == "feature"
+
 
 class TestPathHelpers:
     def test_is_feature_file_scripts(self):

--- a/vnx_cli/commands/attest.py
+++ b/vnx_cli/commands/attest.py
@@ -180,6 +180,37 @@ def vnx_attest(args) -> int:
         return vnx_attest_write(args)
     elif subcommand == "verify":
         return vnx_attest_verify(args)
+    elif subcommand == "verify-pr":
+        return vnx_attest_verify_pr(args)
     else:
-        print("  Usage: vnx attest {write,verify}", file=sys.stderr)
+        print("  Usage: vnx attest {write,verify,verify-pr}", file=sys.stderr)
         return 1
+
+
+def vnx_attest_verify_pr(args) -> int:
+    """Verify attestation for a PR — used by the D3 GitHub Action gate."""
+    repo_root = Path(getattr(args, "project_dir", ".")).resolve()
+    base_ref = getattr(args, "base_ref", "origin/main")
+    head_ref = getattr(args, "head_ref", "HEAD")
+    allowed_signers_override = getattr(args, "allowed_signers", None)
+    verbose = getattr(args, "verbose", False)
+
+    _engine.ensure_engine_on_path()
+    import verify_pr as _vpr
+
+    exit_code, message = _vpr.verify_pr(
+        repo_root=repo_root,
+        base_ref=base_ref,
+        head_ref=head_ref,
+        allowed_signers_override=allowed_signers_override or None,
+        verbose=verbose,
+    )
+
+    if exit_code == 0:
+        print(f"  {message}")
+    elif exit_code == 2:
+        print(f"  {message}", file=sys.stderr)
+    else:
+        print(f"  {message}", file=sys.stderr)
+
+    return exit_code

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -445,6 +445,21 @@ def _register_attest_subparser(subparsers: argparse.Action) -> None:
     av.add_argument("--project-dir", default=".", metavar="DIR",
                     help="repository root (default: current directory)")
 
+    avp = attest_subs.add_parser(
+        "verify-pr",
+        help="verify attestation for a PR (D3 gate — used by GitHub Action)",
+    )
+    avp.add_argument("--base-ref", dest="base_ref", default="origin/main", metavar="REF",
+                     help="base branch for merge-base (default: origin/main)")
+    avp.add_argument("--head-ref", dest="head_ref", default="HEAD", metavar="REF",
+                     help="PR head ref to verify (default: HEAD)")
+    avp.add_argument("--allowed-signers", dest="allowed_signers", default=None, metavar="PATH",
+                     help="override allowed_signers path (default: resolved from base branch)")
+    avp.add_argument("--verbose", action="store_true",
+                     help="emit diagnostic lines to stderr")
+    avp.add_argument("--project-dir", default=".", metavar="DIR",
+                     help="repository root (default: current directory)")
+
 
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":


### PR DESCRIPTION
## Summary

D3 of governance-attribution-enforce — THE hard gate (but advisory first). The un-bypassable server-side point that verifies the signed attestation at the permanence boundary (PR merge).

- `.github/workflows/attestation-gate.yml`: for feature-code PRs, verifies (a) the .vnx-attest manifest is validly signed (detached, canonical, allowed_signers pinned to the BASE branch — never the PR tree), (b) the manifest binds to this PR's merge-base→head diff (content-key, D2). Does NOT check plan-gate-pass (signer-attested — CI has no store access, honest).
- **STAGED ADVISORY** (`continue-on-error`): runs + reports, does NOT block yet. Flip criterion documented (N consecutive signed PRs, operator-confirmed) before required + enforce_admins.
- **CODEOWNERS** protects the trust-root paths (allowed_signers, the workflow) so a PR cannot neuter the gate.
- Exempt-path residual (tests/docs) named.

## Verification

28 new verify_pr tests + 80 total (D1/D2/D3) pass: diff-binding rejection, rogue-key-in-PR-tree blocked (base-branch used), unsigned feature PR fails, docs-only exempt. Independently re-run.

## Operator follow-up

The gate is ADVISORY until you provision the keychain signing key (`docs/governance/KEY_PROVISIONING.md`) and flip it to required. Until then it reports without blocking.

## Provenance

Governed tmux-spawn lane (dispatch `D-govenf-d3-servergate`, security-engineer). Builds on D1 (#1004) + D2 (#1007).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC