### PR TITLE
feat(gov): signed budgeted audited gate override (recorded deviation, never silent) [D4]

### DIFF
--- a/scripts/lib/attest_override.py
+++ b/scripts/lib/attest_override.py
@@ -1,0 +1,311 @@
+"""D4: Signed, budgeted, audited gate override.
+
+An operator can bypass the server-gate for a specific PR/diff WITH a signed
+override manifest — reason (required, non-empty), content-key (diff-bound),
+operator signature (reusing D1 sign_manifest), and a budget decrement.
+
+This is NOT a blanket skip.  An override is itself a signed attestation of
+type "override".  The ISO/ISAE principle: zero UNRECORDED deviations, but a
+RECORDED+SIGNED override is allowed.
+
+Override budget: N overrides per rolling 30-day window, configurable via
+VNX_ATTEST_OVERRIDE_BUDGET (default: 5).  The count is derived from the
+append-only NDJSON trail, never a mutable counter.
+
+Override record:  .vnx-attest/override-<content-key>.json
+Override trail:   .vnx-attest/override-trail.ndjson  (hash-chained, append-only)
+
+Security invariants:
+  - The override is diff-bound: content_key ties it to exactly one diff.
+  - Signer-pinned: verified against base-branch allowed_signers, not PR-tree.
+  - A PR cannot forge its own override: the signer must be in allowed_signers
+    at the base branch before the PR was opened.
+  - Budget is append-only: the trail cannot be truncated to recover budget
+    without operator-visible forensic evidence.
+
+References:
+  - attestation.py: sign_manifest, verify_attestation, SCHEMA_VERSION
+  - attest_record.py: ATTEST_DIR
+  - content_key.py: compute_diff_hash
+  - ndjson_hash_chain.py: append_chained_entry
+  - docs/governance/2026-07-04-governance-attribution-enforce-PLAN.md (D4)
+"""
+from __future__ import annotations
+
+import json
+import os
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+
+from attestation import (
+    SCHEMA_VERSION,
+    sign_manifest,
+    verify_attestation,
+)
+from attest_record import ATTEST_DIR
+from content_key import compute_diff_hash
+from ndjson_hash_chain import append_chained_entry
+
+ATTESTATION_OVERRIDE = "override"
+
+OVERRIDE_TRAIL_FILE = "override-trail.ndjson"
+OVERRIDE_RECORD_PREFIX = "override-"
+
+DEFAULT_OVERRIDE_BUDGET = 5
+OVERRIDE_WINDOW_DAYS = 30
+
+
+@dataclass
+class OverrideRecord:
+    """Written override record for a gate deviation."""
+    content_key: str
+    diff_hash: str
+    record_path: Path
+    trail_path: Path
+    manifest: dict
+
+
+def get_override_budget() -> int:
+    """Return the per-window override budget from VNX_ATTEST_OVERRIDE_BUDGET (default: 5)."""
+    raw = os.environ.get("VNX_ATTEST_OVERRIDE_BUDGET", "").strip()
+    if raw.isdigit():
+        return int(raw)
+    return DEFAULT_OVERRIDE_BUDGET
+
+
+def build_override_manifest(
+    *,
+    content_key: str,
+    reason: str,
+    dispatch_id: str,
+    signer_identity: str,
+    timestamp: str,
+) -> dict:
+    """Build an override manifest dict (without signature field).
+
+    Args:
+        content_key: Diff hash (content-key) this override applies to.
+        reason: Non-empty human-readable justification.
+        dispatch_id: Dispatch-ID or override slug for traceability.
+        signer_identity: Signer identity matching an allowed_signers entry.
+        timestamp: ISO-8601 UTC timestamp (caller-supplied).
+
+    Raises:
+        ValueError: If reason is empty or whitespace-only.
+    """
+    if not reason or not reason.strip():
+        raise ValueError("override reason must be non-empty")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "attestation_type": ATTESTATION_OVERRIDE,
+        "content_key": content_key,
+        "diff_hash": content_key,
+        "reason": reason.strip(),
+        "dispatch_id": dispatch_id,
+        "signer_identity": signer_identity,
+        "timestamp": timestamp,
+    }
+
+
+def count_overrides_in_window(
+    trail_path: "str | Path",
+    window_days: int = OVERRIDE_WINDOW_DAYS,
+    _now_ts: "str | None" = None,
+) -> int:
+    """Count override entries in the NDJSON trail within the rolling window.
+
+    Derived from the append-only trail — not a mutable counter.
+    An entry counts if its timestamp is within window_days of now.
+
+    Args:
+        trail_path: Path to override-trail.ndjson.
+        window_days: Rolling window in days (default: 30).
+        _now_ts: ISO-8601 UTC 'now' — injected by tests; production omits.
+
+    Returns:
+        Count of valid override entries within the window.
+    """
+    trail_path = Path(trail_path)
+    if not trail_path.exists():
+        return 0
+
+    if _now_ts is not None:
+        now = datetime.fromisoformat(_now_ts.replace("Z", "+00:00"))
+    else:
+        now = datetime.now(timezone.utc)
+
+    window_seconds = window_days * 86400
+    count = 0
+    try:
+        lines = trail_path.read_text(encoding="utf-8").splitlines()
+    except OSError:
+        return 0
+
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            entry = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if entry.get("attestation_type") != ATTESTATION_OVERRIDE:
+            continue
+        ts_str = entry.get("timestamp", "")
+        if not ts_str:
+            continue
+        try:
+            ts = datetime.fromisoformat(ts_str.replace("Z", "+00:00"))
+        except ValueError:
+            continue
+        if (now - ts).total_seconds() <= window_seconds:
+            count += 1
+
+    return count
+
+
+def write_override_record(
+    *,
+    content_key: str,
+    reason: str,
+    dispatch_id: str,
+    signer_identity: str,
+    timestamp: str,
+    key_path: "str | Path",
+    repo_root: "str | Path | None" = None,
+) -> OverrideRecord:
+    """Build, sign, and persist an override record + trail entry.
+
+    Writes:
+      .vnx-attest/override-<content_key>.json  — signed override record
+      .vnx-attest/override-trail.ndjson         — append-only audit trail
+
+    The caller MUST check count_overrides_in_window against get_override_budget()
+    BEFORE calling this function.  This function does NOT enforce the budget.
+
+    Args:
+        content_key: The diff hash this override applies to.
+        reason: Non-empty justification (validated in build_override_manifest).
+        dispatch_id: Dispatch-ID or override slug.
+        signer_identity: Signer identity matching allowed_signers.
+        timestamp: ISO-8601 UTC timestamp.
+        key_path: SSH private key path for signing.
+        repo_root: Repository root.  Defaults to cwd.
+
+    Raises:
+        ValueError: If reason is empty.
+        RuntimeError: If ssh-keygen signing fails.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+    attest_dir = repo_root / ATTEST_DIR
+    attest_dir.mkdir(parents=True, exist_ok=True)
+
+    manifest = build_override_manifest(
+        content_key=content_key,
+        reason=reason,
+        dispatch_id=dispatch_id,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+    )
+    signed = sign_manifest(manifest, key_path)
+
+    # Write the record file (content-key-addressed)
+    record_path = attest_dir / f"{OVERRIDE_RECORD_PREFIX}{content_key}.json"
+    record_path.write_text(
+        json.dumps(signed, sort_keys=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+    # Append to the hash-chained audit trail (append-only)
+    trail_path = attest_dir / OVERRIDE_TRAIL_FILE
+    append_chained_entry(trail_path, signed)
+
+    return OverrideRecord(
+        content_key=content_key,
+        diff_hash=content_key,
+        record_path=record_path,
+        trail_path=trail_path,
+        manifest=signed,
+    )
+
+
+def verify_override_record(
+    *,
+    allowed_signers: "str | Path",
+    repo_root: "str | Path | None" = None,
+    base_ref: str = "origin/main",
+    head_ref: str = "HEAD",
+) -> "tuple[bool, str, dict | None]":
+    """Verify the override record for the current branch.
+
+    Checks in order:
+    1. Compute current diff's content-key.
+    2. .vnx-attest/override-<content-key>.json exists.
+    3. manifest.content_key matches current content-key (diff-binding).
+    4. attestation_type is "override".
+    5. manifest.reason is non-empty.
+    6. Signature is valid against base-branch allowed_signers.
+
+    Args:
+        allowed_signers: Path to SSH allowed_signers file (base-branch copy).
+        repo_root: Repository root.  Defaults to cwd.
+        base_ref: Base branch for merge-base (default: origin/main).
+        head_ref: Branch tip to verify (default: HEAD).
+
+    Returns:
+        (ok: bool, reason_str: str, manifest: dict | None)
+        manifest is the parsed override manifest on success, None on failure.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+
+    try:
+        current_content_key = compute_diff_hash(
+            repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+        )
+    except RuntimeError as e:
+        return (False, f"diff computation failed: {e}", None)
+
+    record_path = repo_root / ATTEST_DIR / f"{OVERRIDE_RECORD_PREFIX}{current_content_key}.json"
+    if not record_path.exists():
+        return (
+            False,
+            f"no override record for content-key {current_content_key[:12]}…",
+            None,
+        )
+
+    try:
+        manifest = json.loads(record_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError) as e:
+        return (False, f"override record unreadable: {e}", None)
+
+    # Diff-binding: the override must be for THIS exact diff
+    record_key = manifest.get("content_key") or manifest.get("diff_hash")
+    if record_key != current_content_key:
+        return (
+            False,
+            f"diff-binding mismatch: override.content_key={record_key!r} "
+            f"!= current={current_content_key!r}",
+            None,
+        )
+
+    # attestation_type guard
+    if manifest.get("attestation_type") != ATTESTATION_OVERRIDE:
+        return (
+            False,
+            f"record is not an override "
+            f"(attestation_type={manifest.get('attestation_type')!r})",
+            None,
+        )
+
+    # Reason must be non-empty
+    reason_val = manifest.get("reason", "")
+    if not reason_val or not reason_val.strip():
+        return (False, "override manifest has empty reason", None)
+
+    # Signature must be valid against base-branch allowed_signers
+    # (signer-pinned: PR-tree cannot supply its own trust anchor)
+    if not verify_attestation(manifest, allowed_signers):
+        return (False, "override signature verification failed", None)
+
+    return (True, "ok", manifest)

--- a/scripts/lib/attest_override.py
+++ b/scripts/lib/attest_override.py
@@ -149,6 +149,13 @@ def count_overrides_in_window(
         raise ValueError(
             f"override trail chain integrity failed ({trail_path}): {chain_err}"
         )
+    # A non-empty "unchained" trail = the hash-chain was stripped (production
+    # always writes via append_chained_entry). Refuse to trust it — otherwise an
+    # attacker replaces the chained ledger with raw rows to dodge the chain check.
+    if chain_err == "unchained" and trail_path.read_text(encoding="utf-8").strip():
+        raise ValueError(
+            f"override trail is unchained (hash-chain stripped): {trail_path}"
+        )
 
     if _now_ts is not None:
         now = datetime.fromisoformat(_now_ts.replace("Z", "+00:00"))

--- a/scripts/lib/attest_override.py
+++ b/scripts/lib/attest_override.py
@@ -45,7 +45,7 @@ from attestation import (
 )
 from attest_record import ATTEST_DIR
 from content_key import compute_diff_hash
-from ndjson_hash_chain import append_chained_entry
+from ndjson_hash_chain import append_chained_entry, verify_chain, walk_chain
 
 ATTESTATION_OVERRIDE = "override"
 
@@ -111,24 +111,44 @@ def build_override_manifest(
 def count_overrides_in_window(
     trail_path: "str | Path",
     window_days: int = OVERRIDE_WINDOW_DAYS,
+    allowed_signers: "str | Path | None" = None,
     _now_ts: "str | None" = None,
 ) -> int:
-    """Count override entries in the NDJSON trail within the rolling window.
+    """Count VALID override entries in the NDJSON trail within the rolling window.
 
-    Derived from the append-only trail — not a mutable counter.
-    An entry counts if its timestamp is within window_days of now.
+    Derived from the append-only trail — not a mutable counter. An entry only
+    counts toward the budget when it is (a) part of an intact hash-chain and,
+    when ``allowed_signers`` is given, (b) carries a valid detached signature.
+    A forged, unsigned, or chain-tampered entry MUST NOT count toward — nor be
+    able to deflate — the budget.
 
     Args:
         trail_path: Path to override-trail.ndjson.
         window_days: Rolling window in days (default: 30).
+        allowed_signers: allowed_signers file used to verify each entry's
+            signature. When None the signature is NOT checked — callers that
+            enforce a budget (the gate, write_override_record) MUST pass a
+            base-branch-pinned allowed_signers so a rogue key cannot self-authorize.
         _now_ts: ISO-8601 UTC 'now' — injected by tests; production omits.
 
     Returns:
         Count of valid override entries within the window.
+
+    Raises:
+        ValueError: If the trail's hash-chain integrity check fails (tamper) —
+            a tampered budget ledger must never be silently trusted.
     """
     trail_path = Path(trail_path)
     if not trail_path.exists():
         return 0
+
+    # Chain integrity first: a tampered/spliced trail must never be trusted for
+    # budgeting (an attacker could delete their own override rows to free budget).
+    chain_ok, _violations, chain_err = verify_chain(trail_path)
+    if not chain_ok:
+        raise ValueError(
+            f"override trail chain integrity failed ({trail_path}): {chain_err}"
+        )
 
     if _now_ts is not None:
         now = datetime.fromisoformat(_now_ts.replace("Z", "+00:00"))
@@ -137,21 +157,17 @@ def count_overrides_in_window(
 
     window_seconds = window_days * 86400
     count = 0
-    try:
-        lines = trail_path.read_text(encoding="utf-8").splitlines()
-    except OSError:
-        return 0
-
-    for line in lines:
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            entry = json.loads(line)
-        except json.JSONDecodeError:
+    for _idx, entry, _entry_hash in walk_chain(trail_path):
+        if not isinstance(entry, dict):
             continue
         if entry.get("attestation_type") != ATTESTATION_OVERRIDE:
             continue
+        # Signature must be valid. Strip the chain pointer (prev_hash) added by
+        # append_chained_entry to reconstruct the exact signed manifest.
+        if allowed_signers is not None:
+            manifest = {k: v for k, v in entry.items() if k != "prev_hash"}
+            if not verify_attestation(manifest, allowed_signers):
+                continue
         ts_str = entry.get("timestamp", "")
         if not ts_str:
             continue
@@ -174,6 +190,8 @@ def write_override_record(
     timestamp: str,
     key_path: "str | Path",
     repo_root: "str | Path | None" = None,
+    allowed_signers: "str | Path | None" = None,
+    _now_ts: "str | None" = None,
 ) -> OverrideRecord:
     """Build, sign, and persist an override record + trail entry.
 
@@ -181,8 +199,11 @@ def write_override_record(
       .vnx-attest/override-<content_key>.json  — signed override record
       .vnx-attest/override-trail.ndjson         — append-only audit trail
 
-    The caller MUST check count_overrides_in_window against get_override_budget()
-    BEFORE calling this function.  This function does NOT enforce the budget.
+    Enforces the rolling budget itself (defense in depth): it re-derives the
+    used count from the (chain-verified, signature-checked) trail and REFUSES to
+    write when the budget is exhausted, even if a caller skipped its own check.
+    Pass ``allowed_signers`` (base-branch-pinned) so the budget count verifies
+    signatures; without it the count cannot reject a forged trail entry.
 
     Args:
         content_key: The diff hash this override applies to.
@@ -200,6 +221,20 @@ def write_override_record(
     repo_root = Path(repo_root) if repo_root else Path.cwd()
     attest_dir = repo_root / ATTEST_DIR
     attest_dir.mkdir(parents=True, exist_ok=True)
+
+    # Defense in depth: enforce the rolling budget here too, re-derived from the
+    # chain-verified, signature-checked trail. A caller that forgot to check (or
+    # a race between check and write) must still not exceed the budget.
+    trail_path = attest_dir / OVERRIDE_TRAIL_FILE
+    budget = get_override_budget()
+    used = count_overrides_in_window(
+        trail_path, allowed_signers=allowed_signers, _now_ts=_now_ts
+    )
+    if used >= budget:
+        raise RuntimeError(
+            f"override budget exhausted ({used}/{budget} used in the last "
+            f"{OVERRIDE_WINDOW_DAYS} days); refusing to write override record"
+        )
 
     manifest = build_override_manifest(
         content_key=content_key,

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -209,6 +209,7 @@ def verify_pr(
     reason = "unknown"
     ov_ok = False
     ov_manifest = None
+    _ov_detail = ""
     try:
         if allowed_signers_override is not None:
             allowed_signers_path = Path(allowed_signers_override)
@@ -251,6 +252,51 @@ def verify_pr(
                 base_ref=base_ref,
                 head_ref=head_ref,
             )
+            # Gate-side budget enforcement (round-2 finding 3) + anti-reset
+            # (finding 1): a validly-signed override still FAILS the gate if it
+            # exceeds the rolling budget, and the PR trail must append-only EXTEND
+            # the base-branch trail — deleting rows to free budget is rejected.
+            if ov_ok and ov_manifest is not None:
+                from attest_override import (
+                    ATTEST_DIR as _AO_DIR,
+                    OVERRIDE_TRAIL_FILE as _AO_TRAIL,
+                    count_overrides_in_window,
+                    get_override_budget,
+                )
+                _pr_trail = repo_root / _AO_DIR / _AO_TRAIL
+                _pr_lines = (
+                    _pr_trail.read_text(encoding="utf-8").splitlines()
+                    if _pr_trail.exists() else []
+                )
+                _base = subprocess.run(
+                    ["git", "show", f"{base_ref}:{_AO_DIR}/{_AO_TRAIL}"],
+                    cwd=str(repo_root), capture_output=True,
+                )
+                if _base.returncode == 0:
+                    _base_lines = _base.stdout.decode(
+                        "utf-8", "replace"
+                    ).splitlines()
+                    if _pr_lines[: len(_base_lines)] != _base_lines:
+                        ov_ok = False
+                        _ov_detail = (
+                            "override trail does not append-only extend the base "
+                            "branch (budget-reset attempt)"
+                        )
+                if ov_ok:
+                    try:
+                        _used = count_overrides_in_window(
+                            _pr_trail, allowed_signers=allowed_signers_path
+                        )
+                    except ValueError as _e:
+                        ov_ok = False
+                        _ov_detail = str(_e)
+                    else:
+                        _budget = get_override_budget()
+                        if _used > _budget:
+                            ov_ok = False
+                            _ov_detail = (
+                                f"override budget exhausted ({_used}/{_budget})"
+                            )
     finally:
         if tmp_path:
             try:
@@ -270,6 +316,11 @@ def verify_pr(
             f"override: RECORDED deviation — signed by {signer!r} "
             f"for {ck_short}\u2026 | reason: {ov_reason!r}",
         )
+
+    # An override was attempted (signed) but rejected by the budget / anti-reset
+    # / chain checks \u2014 never a silent pass, never falls back to the generic FAIL.
+    if ov_manifest is not None:
+        return (1, f"override REJECTED: {_ov_detail}")
 
     return (1, f"FAIL: {reason}")
 

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -282,6 +282,34 @@ def verify_pr(
                             "override trail does not append-only extend the base "
                             "branch (budget-reset attempt)"
                         )
+                # Trail-membership (round-3 finding): the override RECORD file
+                # alone is not enough — a matching, validly-signed entry MUST exist
+                # in the append-only trail, else the audit ledger / rolling budget
+                # was bypassed by keeping the record but deleting the trail row.
+                if ov_ok:
+                    from attest_override import ATTESTATION_OVERRIDE as _AO_TYPE
+                    from attestation import verify_attestation as _verify
+                    from ndjson_hash_chain import walk_chain as _walk
+                    _ck = ov_manifest.get("content_key")
+                    _in_trail = False
+                    if _pr_trail.exists():
+                        for _i, _e, _h in _walk(_pr_trail):
+                            if not isinstance(_e, dict):
+                                continue
+                            if _e.get("attestation_type") != _AO_TYPE:
+                                continue
+                            if _e.get("content_key") != _ck:
+                                continue
+                            _m = {k: v for k, v in _e.items() if k != "prev_hash"}
+                            if _verify(_m, allowed_signers_path):
+                                _in_trail = True
+                                break
+                    if not _in_trail:
+                        ov_ok = False
+                        _ov_detail = (
+                            "override record is not recorded in the append-only "
+                            "trail (audit-ledger bypass)"
+                        )
                 if ov_ok:
                     try:
                         _used = count_overrides_in_window(

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -205,6 +205,10 @@ def verify_pr(
     # Feature code in this PR — gate fires.
     # Resolve allowed_signers from base branch (never from PR tree).
     tmp_path = None
+    ok = False
+    reason = "unknown"
+    ov_ok = False
+    ov_manifest = None
     try:
         if allowed_signers_override is not None:
             allowed_signers_path = Path(allowed_signers_override)
@@ -234,6 +238,19 @@ def verify_pr(
             base_ref=base_ref,
             head_ref=head_ref,
         )
+
+        if not ok:
+            # Regular attestation failed — check for a valid signed override.
+            # An override is diff-bound and signer-pinned to base-branch
+            # allowed_signers.  It is NEVER a silent pass: the verdict is
+            # "override" and the deviation is permanently recorded in the trail.
+            from attest_override import verify_override_record
+            ov_ok, _ov_detail, ov_manifest = verify_override_record(
+                allowed_signers=allowed_signers_path,
+                repo_root=repo_root,
+                base_ref=base_ref,
+                head_ref=head_ref,
+            )
     finally:
         if tmp_path:
             try:
@@ -243,6 +260,17 @@ def verify_pr(
 
     if ok:
         return (0, "PASS: attestation valid")
+
+    if ov_ok and ov_manifest is not None:
+        signer = ov_manifest.get("signer_identity", "unknown")
+        ck_short = ov_manifest.get("content_key", "?")[:12]
+        ov_reason = ov_manifest.get("reason", "")
+        return (
+            0,
+            f"override: RECORDED deviation — signed by {signer!r} "
+            f"for {ck_short}\u2026 | reason: {ov_reason!r}",
+        )
+
     return (1, f"FAIL: {reason}")
 
 

--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -454,19 +454,58 @@ class TestBudgetEnforcement:
         """Overrides older than the window do not count against the budget."""
         with tempfile.TemporaryDirectory() as tmpdir:
             trail = Path(tmpdir) / "trail.ndjson"
-            # Write 10 entries older than 30 days
+            # Write 10 hash-chained entries older than 30 days
             now_ts = "2026-07-05T12:00:00Z"
             for i in range(10):
-                entry = {
+                append_chained_entry(trail, {
                     "attestation_type": ATTESTATION_OVERRIDE,
                     "timestamp": "2026-05-01T10:00:00Z",
                     "content_key": f"old{i}",
-                }
-                with trail.open("a") as f:
-                    f.write(json.dumps(entry) + "\n")
+                })
 
             count = count_overrides_in_window(trail, _now_ts=now_ts)
             assert count == 0, "Old overrides must not count against the budget"
+
+    def test_count_rejects_unchained_trail(self, tmp_path):
+        """A non-empty trail with the hash-chain stripped must raise (finding 2)."""
+        trail = tmp_path / "trail.ndjson"
+        # Raw rows, no prev_hash — a stripped/forged ledger.
+        with trail.open("a") as f:
+            f.write(json.dumps({
+                "attestation_type": ATTESTATION_OVERRIDE,
+                "timestamp": "2026-07-04T10:00:00Z",
+            }) + "\n")
+        with pytest.raises(ValueError):
+            count_overrides_in_window(trail, _now_ts="2026-07-05T12:00:00Z")
+
+    def test_write_override_record_refuses_when_exhausted(self, ephemeral_key_dir, monkeypatch):
+        """write_override_record enforces the budget itself (finding 4)."""
+        monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "1")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            from content_key import compute_diff_hash
+
+            _add_file_commit(repo, "scripts/lib/a.py", "a = 1\n", "feat: a")
+            ck_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            write_override_record(
+                content_key=ck_a, reason="first", dispatch_id="D-1",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"], repo_root=repo,
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+            )
+            # Budget is 1; a second write must be refused by write_override_record.
+            _add_file_commit(repo, "scripts/lib/b.py", "b = 2\n", "feat: b")
+            ck_b = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            with pytest.raises(RuntimeError, match="budget exhausted"):
+                write_override_record(
+                    content_key=ck_b, reason="second", dispatch_id="D-2",
+                    signer_identity=ephemeral_key_dir["identity"],
+                    timestamp="2026-07-05T11:00:00Z",
+                    key_path=ephemeral_key_dir["key_path"], repo_root=repo,
+                    allowed_signers=ephemeral_key_dir["allowed_signers"],
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -613,3 +652,39 @@ class TestVerifyPRWithOverride:
             )
             assert exit_code == 1
             assert "FAIL" in message
+
+    def test_override_past_budget_rejected_by_gate(self, ephemeral_key_dir, monkeypatch):
+        """A validly-signed override past the rolling budget is REJECTED by the gate (finding 3)."""
+        from attest_override import build_override_manifest
+        from attestation import sign_manifest
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            from content_key import compute_diff_hash
+
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat")
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            # A valid override for the CURRENT diff.
+            write_override_record(
+                content_key=ck, reason="current", dispatch_id="D-cur",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T11:00:00Z",
+                key_path=ephemeral_key_dir["key_path"], repo_root=repo,
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+            )
+            # A second, older, validly-signed override in the trail → window count = 2.
+            trail = repo / ATTEST_DIR / OVERRIDE_TRAIL_FILE
+            m2 = build_override_manifest(
+                content_key="other-key", reason="older override",
+                dispatch_id="D-old", signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T09:00:00Z",
+            )
+            append_chained_entry(trail, sign_manifest(m2, ephemeral_key_dir["key_path"]))
+            # Budget of 1 — the gate must reject even a validly-signed override.
+            monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "1")
+            exit_code, message = verify_pr(
+                repo_root=repo, base_ref=base_sha, head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Override past budget must be rejected, got: {message}"
+            assert "budget" in message.lower() and "REJECT" in message

--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -40,6 +40,7 @@ from attest_override import (
 )
 from verify_pr import verify_pr
 from attest_record import write_attest_record
+from ndjson_hash_chain import append_chained_entry
 
 
 # ---------------------------------------------------------------------------
@@ -171,60 +172,56 @@ class TestCountOverridesInWindow:
     def test_counts_recent_overrides(self, tmp_path):
         trail = tmp_path / "trail.ndjson"
         now = "2026-07-05T12:00:00Z"
-        # Three recent override entries
+        # Three recent override entries, hash-chained (as production writes them).
         for i in range(3):
-            entry = {
+            append_chained_entry(trail, {
                 "attestation_type": ATTESTATION_OVERRIDE,
                 "timestamp": "2026-07-04T10:00:00Z",
                 "content_key": f"key{i}",
-            }
-            with trail.open("a") as f:
-                f.write(json.dumps(entry) + "\n")
+            })
         assert count_overrides_in_window(trail, _now_ts=now) == 3
 
     def test_excludes_old_overrides(self, tmp_path):
         trail = tmp_path / "trail.ndjson"
         now = "2026-07-05T12:00:00Z"
-        # Entry older than 30 days
-        old_entry = {
+        append_chained_entry(trail, {
             "attestation_type": ATTESTATION_OVERRIDE,
-            "timestamp": "2026-05-01T10:00:00Z",
+            "timestamp": "2026-05-01T10:00:00Z",  # older than 30 days
             "content_key": "old",
-        }
-        # Entry within 30 days
-        recent_entry = {
+        })
+        append_chained_entry(trail, {
             "attestation_type": ATTESTATION_OVERRIDE,
-            "timestamp": "2026-07-04T10:00:00Z",
+            "timestamp": "2026-07-04T10:00:00Z",  # within 30 days
             "content_key": "recent",
-        }
-        with trail.open("a") as f:
-            f.write(json.dumps(old_entry) + "\n")
-            f.write(json.dumps(recent_entry) + "\n")
+        })
         assert count_overrides_in_window(trail, _now_ts=now) == 1
 
     def test_excludes_non_override_entries(self, tmp_path):
         trail = tmp_path / "trail.ndjson"
         now = "2026-07-05T12:00:00Z"
-        entries = [
+        for e in [
             {"attestation_type": "governed", "timestamp": "2026-07-04T10:00:00Z"},
             {"attestation_type": ATTESTATION_OVERRIDE, "timestamp": "2026-07-04T10:00:00Z"},
             {"attestation_type": "ad-hoc", "timestamp": "2026-07-04T10:00:00Z"},
-        ]
-        with trail.open("a") as f:
-            for e in entries:
-                f.write(json.dumps(e) + "\n")
+        ]:
+            append_chained_entry(trail, e)
         assert count_overrides_in_window(trail, _now_ts=now) == 1
 
-    def test_ignores_invalid_json_lines(self, tmp_path):
+    def test_tampered_trail_raises(self, tmp_path):
+        """A spliced/tampered budget ledger must raise, never silently under-count."""
         trail = tmp_path / "trail.ndjson"
-        now = "2026-07-05T12:00:00Z"
-        with trail.open("a") as f:
-            f.write("not-json\n")
-            f.write(json.dumps({
-                "attestation_type": ATTESTATION_OVERRIDE,
-                "timestamp": "2026-07-04T10:00:00Z",
-            }) + "\n")
-        assert count_overrides_in_window(trail, _now_ts=now) == 1
+        for ts in ("2026-07-04T10:00:00Z", "2026-07-04T11:00:00Z"):
+            append_chained_entry(trail, {
+                "attestation_type": ATTESTATION_OVERRIDE, "timestamp": ts,
+            })
+        # Tamper with the first entry's body without recomputing the chain hash.
+        lines = trail.read_text().splitlines()
+        first = json.loads(lines[0])
+        first["content_key"] = "TAMPERED"
+        lines[0] = json.dumps(first)
+        trail.write_text("\n".join(lines) + "\n")
+        with pytest.raises(ValueError):
+            count_overrides_in_window(trail, _now_ts="2026-07-05T12:00:00Z")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -1,0 +1,618 @@
+"""Tests for D4: signed, budgeted, audited gate override.
+
+Test filter: pytest -k "override or attest or verify_pr"
+
+Covers:
+  - A signed override for the exact diff verifies as 'override' (not 'pass')
+  - An override for a different diff FAILS (diff-binding)
+  - Budget-exhausted refuses write_override_record callers
+  - count_overrides_in_window derived from the trail, not a mutable counter
+  - Unsigned / rogue-key override FAILS signature check
+  - Empty reason rejected at build time (ValueError)
+  - verify_pr: valid override returns (0, ...) with "override" in message
+  - verify_pr: override for wrong diff → FAIL (not override)
+  - verify_pr: regular PASS still works after the override code path is added
+"""
+import json
+import subprocess
+import sys
+import tempfile
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from attest_override import (
+    ATTEST_DIR,
+    ATTESTATION_OVERRIDE,
+    DEFAULT_OVERRIDE_BUDGET,
+    OVERRIDE_RECORD_PREFIX,
+    OVERRIDE_TRAIL_FILE,
+    OVERRIDE_WINDOW_DAYS,
+    OverrideRecord,
+    build_override_manifest,
+    count_overrides_in_window,
+    get_override_budget,
+    verify_override_record,
+    write_override_record,
+)
+from verify_pr import verify_pr
+from attest_record import write_attest_record
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(scope="session")
+def ephemeral_key_dir():
+    """Ephemeral ed25519 test key + allowed_signers."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "testkey"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""],
+            check=True, capture_output=True,
+        )
+        pub = key_path.with_suffix(".pub").read_text().strip()
+        identity = "vnx-override-test@local"
+        allowed_signers = Path(tmpdir) / "allowed_signers"
+        allowed_signers.write_text(f"{identity} {pub}\n")
+        yield {
+            "key_path": key_path,
+            "identity": identity,
+            "allowed_signers": allowed_signers,
+        }
+
+
+@pytest.fixture(scope="session")
+def rogue_key_dir():
+    """A second ed25519 key NOT in allowed_signers (used for forgery tests)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        key_path = Path(tmpdir) / "roguekey"
+        subprocess.run(
+            ["ssh-keygen", "-t", "ed25519", "-f", str(key_path), "-N", ""],
+            check=True, capture_output=True,
+        )
+        yield {"key_path": key_path, "identity": "rogue@attacker"}
+
+
+def _init_repo(tmp: Path) -> Path:
+    subprocess.run(["git", "init", "-b", "main"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@vnx.local"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "VNX Test"], cwd=str(tmp), check=True, capture_output=True)
+    (tmp / "README.md").write_text("base\n")
+    subprocess.run(["git", "add", "README.md"], cwd=str(tmp), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "base"], cwd=str(tmp), check=True, capture_output=True)
+    return tmp
+
+
+def _head_sha(repo: Path) -> str:
+    r = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(repo), capture_output=True, text=True, check=True
+    )
+    return r.stdout.strip()
+
+
+def _add_file_commit(repo: Path, filename: str, content: str, msg: str) -> None:
+    full = repo / filename
+    full.parent.mkdir(parents=True, exist_ok=True)
+    full.write_text(content)
+    subprocess.run(["git", "add", filename], cwd=str(repo), check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", msg], cwd=str(repo), check=True, capture_output=True)
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: build_override_manifest
+# ---------------------------------------------------------------------------
+
+class TestBuildOverrideManifest:
+    def test_required_fields(self):
+        m = build_override_manifest(
+            content_key="abc123",
+            reason="emergency hotfix for prod outage",
+            dispatch_id="D-hotfix",
+            signer_identity="vnx@local",
+            timestamp="2026-07-05T10:00:00Z",
+        )
+        assert m["schema_version"] == "1"
+        assert m["attestation_type"] == ATTESTATION_OVERRIDE
+        assert m["content_key"] == "abc123"
+        assert m["diff_hash"] == "abc123"
+        assert m["reason"] == "emergency hotfix for prod outage"
+        assert m["dispatch_id"] == "D-hotfix"
+        assert m["signer_identity"] == "vnx@local"
+        assert m["timestamp"] == "2026-07-05T10:00:00Z"
+
+    def test_empty_reason_raises(self):
+        with pytest.raises(ValueError, match="reason must be non-empty"):
+            build_override_manifest(
+                content_key="abc",
+                reason="",
+                dispatch_id="x",
+                signer_identity="y",
+                timestamp="2026-07-05T10:00:00Z",
+            )
+
+    def test_whitespace_only_reason_raises(self):
+        with pytest.raises(ValueError):
+            build_override_manifest(
+                content_key="abc",
+                reason="   ",
+                dispatch_id="x",
+                signer_identity="y",
+                timestamp="2026-07-05T10:00:00Z",
+            )
+
+    def test_reason_is_stripped(self):
+        m = build_override_manifest(
+            content_key="abc",
+            reason="  reason with spaces  ",
+            dispatch_id="x",
+            signer_identity="y",
+            timestamp="2026-07-05T10:00:00Z",
+        )
+        assert m["reason"] == "reason with spaces"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: count_overrides_in_window
+# ---------------------------------------------------------------------------
+
+class TestCountOverridesInWindow:
+    def test_empty_trail_returns_zero(self, tmp_path):
+        trail = tmp_path / "override-trail.ndjson"
+        assert count_overrides_in_window(trail) == 0
+
+    def test_missing_trail_returns_zero(self, tmp_path):
+        assert count_overrides_in_window(tmp_path / "nonexistent.ndjson") == 0
+
+    def test_counts_recent_overrides(self, tmp_path):
+        trail = tmp_path / "trail.ndjson"
+        now = "2026-07-05T12:00:00Z"
+        # Three recent override entries
+        for i in range(3):
+            entry = {
+                "attestation_type": ATTESTATION_OVERRIDE,
+                "timestamp": "2026-07-04T10:00:00Z",
+                "content_key": f"key{i}",
+            }
+            with trail.open("a") as f:
+                f.write(json.dumps(entry) + "\n")
+        assert count_overrides_in_window(trail, _now_ts=now) == 3
+
+    def test_excludes_old_overrides(self, tmp_path):
+        trail = tmp_path / "trail.ndjson"
+        now = "2026-07-05T12:00:00Z"
+        # Entry older than 30 days
+        old_entry = {
+            "attestation_type": ATTESTATION_OVERRIDE,
+            "timestamp": "2026-05-01T10:00:00Z",
+            "content_key": "old",
+        }
+        # Entry within 30 days
+        recent_entry = {
+            "attestation_type": ATTESTATION_OVERRIDE,
+            "timestamp": "2026-07-04T10:00:00Z",
+            "content_key": "recent",
+        }
+        with trail.open("a") as f:
+            f.write(json.dumps(old_entry) + "\n")
+            f.write(json.dumps(recent_entry) + "\n")
+        assert count_overrides_in_window(trail, _now_ts=now) == 1
+
+    def test_excludes_non_override_entries(self, tmp_path):
+        trail = tmp_path / "trail.ndjson"
+        now = "2026-07-05T12:00:00Z"
+        entries = [
+            {"attestation_type": "governed", "timestamp": "2026-07-04T10:00:00Z"},
+            {"attestation_type": ATTESTATION_OVERRIDE, "timestamp": "2026-07-04T10:00:00Z"},
+            {"attestation_type": "ad-hoc", "timestamp": "2026-07-04T10:00:00Z"},
+        ]
+        with trail.open("a") as f:
+            for e in entries:
+                f.write(json.dumps(e) + "\n")
+        assert count_overrides_in_window(trail, _now_ts=now) == 1
+
+    def test_ignores_invalid_json_lines(self, tmp_path):
+        trail = tmp_path / "trail.ndjson"
+        now = "2026-07-05T12:00:00Z"
+        with trail.open("a") as f:
+            f.write("not-json\n")
+            f.write(json.dumps({
+                "attestation_type": ATTESTATION_OVERRIDE,
+                "timestamp": "2026-07-04T10:00:00Z",
+            }) + "\n")
+        assert count_overrides_in_window(trail, _now_ts=now) == 1
+
+
+# ---------------------------------------------------------------------------
+# Unit tests: get_override_budget
+# ---------------------------------------------------------------------------
+
+class TestGetOverrideBudget:
+    def test_default(self, monkeypatch):
+        monkeypatch.delenv("VNX_ATTEST_OVERRIDE_BUDGET", raising=False)
+        assert get_override_budget() == DEFAULT_OVERRIDE_BUDGET
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "10")
+        assert get_override_budget() == 10
+
+    def test_invalid_env_falls_back(self, monkeypatch):
+        monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "abc")
+        assert get_override_budget() == DEFAULT_OVERRIDE_BUDGET
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: write_override_record + verify_override_record
+# ---------------------------------------------------------------------------
+
+class TestWriteAndVerifyOverride:
+    def test_roundtrip_exact_diff_passes(self, ephemeral_key_dir):
+        """A signed override for the exact diff verifies as 'override'."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+
+            from content_key import compute_diff_hash
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            rec = write_override_record(
+                content_key=ck,
+                reason="approved by architect — prod incident",
+                dispatch_id="D-override-test",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            assert rec.record_path.exists()
+            assert rec.trail_path.exists()
+            assert rec.manifest["attestation_type"] == ATTESTATION_OVERRIDE
+
+            ok, reason, manifest = verify_override_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert ok, f"Expected OK but got: {reason}"
+            assert manifest is not None
+            assert manifest["attestation_type"] == ATTESTATION_OVERRIDE
+            assert manifest["content_key"] == ck
+
+    def test_override_for_different_diff_fails(self, ephemeral_key_dir):
+        """An override signed for diff A does not verify for diff B."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            # Write feature A and sign override for it
+            _add_file_commit(repo, "scripts/lib/feature_a.py", "a = 1\n", "feat: A")
+            from content_key import compute_diff_hash
+            ck_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            write_override_record(
+                content_key=ck_a,
+                reason="override for diff A",
+                dispatch_id="D-override-a",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            # Now add more code — diff changes
+            _add_file_commit(repo, "scripts/lib/feature_b.py", "b = 2\n", "feat: B")
+
+            ok, reason, manifest = verify_override_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok, "Override for wrong diff should FAIL"
+            assert manifest is None
+
+    def test_rogue_key_override_fails(self, ephemeral_key_dir, rogue_key_dir):
+        """An override signed with an unknown key fails signature check."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+
+            from content_key import compute_diff_hash
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            # Sign with rogue key (not in allowed_signers)
+            write_override_record(
+                content_key=ck,
+                reason="unauthorized override attempt",
+                dispatch_id="D-rogue",
+                signer_identity=rogue_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=rogue_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            ok, reason, manifest = verify_override_record(
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+            assert not ok, f"Rogue-key override should FAIL but got ok=True"
+            assert manifest is None
+
+    def test_trail_is_appended(self, ephemeral_key_dir):
+        """Each write_override_record appends one entry to the trail."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/f.py", "x = 1\n", "feat")
+            from content_key import compute_diff_hash
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            trail = repo / ATTEST_DIR / OVERRIDE_TRAIL_FILE
+            assert not trail.exists()
+
+            write_override_record(
+                content_key=ck,
+                reason="test trail append",
+                dispatch_id="D-trail",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            assert trail.exists()
+            lines = [l for l in trail.read_text().splitlines() if l.strip()]
+            assert len(lines) == 1
+            entry = json.loads(lines[0])
+            assert entry["attestation_type"] == ATTESTATION_OVERRIDE
+
+    def test_record_count_derived_from_trail(self, ephemeral_key_dir):
+        """Override count comes from the trail; count is accurate after two writes."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            # First override — diff A
+            _add_file_commit(repo, "scripts/lib/a.py", "a = 1\n", "feat: a")
+            from content_key import compute_diff_hash
+            ck_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            trail = repo / ATTEST_DIR / OVERRIDE_TRAIL_FILE
+
+            write_override_record(
+                content_key=ck_a,
+                reason="first override",
+                dispatch_id="D-1",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            count1 = count_overrides_in_window(trail, _now_ts="2026-07-05T12:00:00Z")
+            assert count1 == 1
+
+            # Second override — diff B (different content_key, same trail)
+            _add_file_commit(repo, "scripts/lib/b.py", "b = 2\n", "feat: b")
+            ck_b = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            write_override_record(
+                content_key=ck_b,
+                reason="second override",
+                dispatch_id="D-2",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-04T11:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            count2 = count_overrides_in_window(trail, _now_ts="2026-07-05T12:00:00Z")
+            assert count2 == 2
+
+
+# ---------------------------------------------------------------------------
+# Budget enforcement tests (check before write — caller responsibility)
+# ---------------------------------------------------------------------------
+
+class TestBudgetEnforcement:
+    def test_budget_count_exhausted_scenario(self, ephemeral_key_dir, monkeypatch):
+        """Budget logic: used >= budget should block the caller from writing."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            trail = repo / ATTEST_DIR / OVERRIDE_TRAIL_FILE
+
+            # Force budget to 2 for this test
+            monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "2")
+
+            from content_key import compute_diff_hash
+
+            now_ts = "2026-07-05T12:00:00Z"
+
+            # Write two overrides to fill the budget
+            for i in range(2):
+                _add_file_commit(repo, f"scripts/lib/feat{i}.py", f"x={i}\n", f"feat: {i}")
+                ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+                write_override_record(
+                    content_key=ck,
+                    reason=f"override {i}",
+                    dispatch_id=f"D-budget-{i}",
+                    signer_identity=ephemeral_key_dir["identity"],
+                    timestamp="2026-07-04T10:00:00Z",
+                    key_path=ephemeral_key_dir["key_path"],
+                    repo_root=repo,
+                )
+
+            budget = get_override_budget()
+            used = count_overrides_in_window(trail, _now_ts=now_ts)
+            assert used >= budget, "Budget should be exhausted"
+
+    def test_old_overrides_do_not_count(self, ephemeral_key_dir):
+        """Overrides older than the window do not count against the budget."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            trail = Path(tmpdir) / "trail.ndjson"
+            # Write 10 entries older than 30 days
+            now_ts = "2026-07-05T12:00:00Z"
+            for i in range(10):
+                entry = {
+                    "attestation_type": ATTESTATION_OVERRIDE,
+                    "timestamp": "2026-05-01T10:00:00Z",
+                    "content_key": f"old{i}",
+                }
+                with trail.open("a") as f:
+                    f.write(json.dumps(entry) + "\n")
+
+            count = count_overrides_in_window(trail, _now_ts=now_ts)
+            assert count == 0, "Old overrides must not count against the budget"
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: verify_pr with override
+# ---------------------------------------------------------------------------
+
+class TestVerifyPRWithOverride:
+    def test_valid_override_returns_override_verdict(self, ephemeral_key_dir):
+        """verify_pr returns (0, ...'override'...) when a valid override exists."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+
+            from content_key import compute_diff_hash
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            write_override_record(
+                content_key=ck,
+                reason="prod incident — SLA breach imminent",
+                dispatch_id="D-vpr-override",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 0, f"Expected override PASS but got: {message}"
+            assert "override" in message.lower(), (
+                f"Message should say 'override', got: {message!r}"
+            )
+            assert "PASS" not in message, (
+                f"Override verdict must not say 'PASS' (must be distinct): {message!r}"
+            )
+
+    def test_override_for_wrong_diff_fails(self, ephemeral_key_dir):
+        """verify_pr fails when the override was signed for a different diff."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            # Sign override for diff A
+            _add_file_commit(repo, "scripts/lib/a.py", "a = 1\n", "feat: a")
+            from content_key import compute_diff_hash
+            ck_a = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            write_override_record(
+                content_key=ck_a,
+                reason="override for diff A only",
+                dispatch_id="D-wrong-diff",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            # Extend the branch — diff changes
+            _add_file_commit(repo, "scripts/lib/b.py", "b = 2\n", "feat: b")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Expected FAIL (wrong diff) but got {exit_code}: {message}"
+            assert "FAIL" in message
+
+    def test_rogue_key_override_fails_in_verify_pr(self, ephemeral_key_dir, rogue_key_dir):
+        """verify_pr rejects an override signed by a key not in allowed_signers."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/attack.py", "evil = 1\n", "feat: attack")
+
+            from content_key import compute_diff_hash
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+
+            # Sign with rogue key
+            write_override_record(
+                content_key=ck,
+                reason="unauthorized override",
+                dispatch_id="D-rogue",
+                signer_identity=rogue_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=rogue_key_dir["key_path"],
+                repo_root=repo,
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Rogue override should FAIL, got {exit_code}: {message}"
+
+    def test_regular_pass_still_works(self, ephemeral_key_dir):
+        """The regular PASS path still works after the override code path was added."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat")
+
+            write_attest_record(
+                dispatch_id="D-regular-pass",
+                deliverable_id="D4",
+                track_id="governance-attribution-enforce",
+                plan_gate_ref="gate-ref",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 0, f"Regular PASS should still work, got: {message}"
+            assert "PASS" in message
+            assert "override" not in message.lower()
+
+    def test_no_attest_no_override_fails(self, ephemeral_key_dir):
+        """A feature PR with neither attest nor override FAILS."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            _add_file_commit(repo, "vnx_cli/main.py", "# code\n", "feat: code")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1
+            assert "FAIL" in message

--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -688,3 +688,29 @@ class TestVerifyPRWithOverride:
             )
             assert exit_code == 1, f"Override past budget must be rejected, got: {message}"
             assert "budget" in message.lower() and "REJECT" in message
+
+    def test_override_record_without_trail_entry_rejected(self, ephemeral_key_dir):
+        """A record file present without a matching trail entry is rejected (round-3: audit-ledger bypass)."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+            from content_key import compute_diff_hash
+
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat")
+            ck = compute_diff_hash(repo_root=repo, base_ref=base_sha)
+            write_override_record(
+                content_key=ck, reason="incident", dispatch_id="D-x",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-05T10:00:00Z",
+                key_path=ephemeral_key_dir["key_path"], repo_root=repo,
+                allowed_signers=ephemeral_key_dir["allowed_signers"],
+            )
+            # Attack: keep the signed record file but delete the trail row that
+            # records the deviation, to dodge the budget/audit ledger.
+            (repo / ATTEST_DIR / OVERRIDE_TRAIL_FILE).unlink()
+            exit_code, message = verify_pr(
+                repo_root=repo, base_ref=base_sha, head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Override without a trail entry must be rejected: {message}"
+            assert "trail" in message.lower() and "REJECT" in message

--- a/vnx_cli/commands/attest.py
+++ b/vnx_cli/commands/attest.py
@@ -182,8 +182,10 @@ def vnx_attest(args) -> int:
         return vnx_attest_verify(args)
     elif subcommand == "verify-pr":
         return vnx_attest_verify_pr(args)
+    elif subcommand == "override":
+        return vnx_attest_override(args)
     else:
-        print("  Usage: vnx attest {write,verify,verify-pr}", file=sys.stderr)
+        print("  Usage: vnx attest {write,verify,verify-pr,override}", file=sys.stderr)
         return 1
 
 
@@ -214,3 +216,116 @@ def vnx_attest_verify_pr(args) -> int:
         print(f"  {message}", file=sys.stderr)
 
     return exit_code
+
+def vnx_attest_override(args) -> int:
+    """Record a signed, budgeted gate override for the current branch (D4).
+
+    Writes:
+      .vnx-attest/override-<content-key>.json  — signed override record
+      .vnx-attest/override-trail.ndjson         — append-only audit trail
+
+    The override is diff-bound (content-keyed) and signer-pinned to
+    base-branch allowed_signers.  Budget is enforced per rolling 30-day window
+    via the append-only trail.
+    """
+    repo_root = Path(getattr(args, "project_dir", ".")).resolve()
+    key_path_str = getattr(args, "key", None)
+    if not key_path_str:
+        print("  Error: --key is required for override", file=sys.stderr)
+        return 1
+    key_path = Path(key_path_str)
+    if not key_path.exists():
+        print(f"  Error: key not found: {key_path}", file=sys.stderr)
+        return 1
+
+    reason = getattr(args, "reason", "")
+    if not reason or not reason.strip():
+        print("  Error: --reason is required and must be non-empty", file=sys.stderr)
+        return 1
+
+    dispatch_id = getattr(args, "dispatch_id", "override")
+    signer_identity = getattr(args, "signer", "vnx@local")
+    base_ref = getattr(args, "base_ref", "origin/main")
+    head_ref = getattr(args, "head_ref", "HEAD")
+    no_commit = getattr(args, "no_commit", False)
+
+    _engine.ensure_engine_on_path()
+    import attest_override as _ao
+    import content_key as _ck
+
+    # Compute content-key for this branch
+    try:
+        ck = _ck.compute_diff_hash(
+            repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+        )
+    except RuntimeError as e:
+        print(f"  Error computing content-key: {e}", file=sys.stderr)
+        return 1
+
+    # Budget check — derived from append-only trail, not a mutable counter
+    budget = _ao.get_override_budget()
+    trail_path = repo_root / _ao.ATTEST_DIR / _ao.OVERRIDE_TRAIL_FILE
+    used = _ao.count_overrides_in_window(trail_path)
+    if used >= budget:
+        print(
+            f"  REFUSED: override budget exhausted "
+            f"({used}/{budget} used in the last {_ao.OVERRIDE_WINDOW_DAYS} days). "
+            "Wait for the window to roll or raise VNX_ATTEST_OVERRIDE_BUDGET.",
+            file=sys.stderr,
+        )
+        return 1
+
+    # Write override record + trail entry
+    try:
+        rec = _ao.write_override_record(
+            content_key=ck,
+            reason=reason,
+            dispatch_id=dispatch_id,
+            signer_identity=signer_identity,
+            timestamp=_utc_now(),
+            key_path=key_path,
+            repo_root=repo_root,
+        )
+    except (ValueError, RuntimeError) as e:
+        print(f"  override write failed: {e}", file=sys.stderr)
+        return 1
+
+    remaining_after = budget - (used + 1)
+    print(f"  content-key:   {rec.content_key[:12]}\u2026")
+    print(f"  record:        {rec.record_path}")
+    print(f"  trail:         {rec.trail_path}")
+    print(f"  reason:        {rec.manifest['reason']!r}")
+    print(
+        f"  budget:        {used + 1}/{budget} used in last {_ao.OVERRIDE_WINDOW_DAYS} days "
+        f"({remaining_after} remaining)"
+    )
+    print(f"  ** OVERRIDE RECORDED — this deviation is permanent in the audit trail **")
+
+    if no_commit:
+        print("  committed:     skipped (--no-commit)")
+        return 0
+
+    try:
+        _git_add(rec.record_path, repo_root)
+        _git_add(rec.trail_path, repo_root)
+    except subprocess.CalledProcessError as e:
+        print(f"  git add failed: {e}", file=sys.stderr)
+        return 1
+
+    reason_short = reason.strip()[:60]
+    commit_msg = f"chore(gov): attest override [{dispatch_id}] — {reason_short}"
+    git_signed = False
+    if key_path.exists():
+        git_signed = _try_signed_commit(commit_msg, repo_root, key_path)
+
+    if not git_signed:
+        ok = _plain_commit(commit_msg, repo_root)
+        if not ok:
+            print(
+                "  Warning: git commit failed — records staged but not committed.",
+                file=sys.stderr,
+            )
+            return 1
+
+    print(f"  committed:     {'SSH-signed' if git_signed else 'unsigned'}")
+    return 0

--- a/vnx_cli/commands/attest.py
+++ b/vnx_cli/commands/attest.py
@@ -251,44 +251,83 @@ def vnx_attest_override(args) -> int:
 
     _engine.ensure_engine_on_path()
     import attest_override as _ao
+    import attest_record as _ar
     import content_key as _ck
 
-    # Compute content-key for this branch
-    try:
-        ck = _ck.compute_diff_hash(
-            repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
-        )
-    except RuntimeError as e:
-        print(f"  Error computing content-key: {e}", file=sys.stderr)
-        return 1
+    # Resolve allowed_signers from the BASE branch (never the PR working tree) so
+    # the budget count verifies each trail entry's signature against a protected
+    # key set — a rogue key added in the PR cannot self-authorize or deflate the
+    # budget. An explicit --allowed-signers is an opt-in, CODEOWNERS-trust override.
+    allowed_signers_str = getattr(args, "allowed_signers", None)
+    _as_tmp = None
+    if not allowed_signers_str:
+        content = _ar.read_allowed_signers_from_base(repo_root, base_ref)
+        if content is None:
+            print(
+                f"  REFUSED: allowed_signers not found in base branch {base_ref!r}. "
+                "Add .vnx-attest/allowed_signers at base, or pass --allowed-signers.",
+                file=sys.stderr,
+            )
+            return 1
+        fd, _as_tmp = tempfile.mkstemp(suffix=".allowed_signers")
+        try:
+            os.write(fd, content)
+        finally:
+            os.close(fd)
+        allowed_signers_str = _as_tmp
 
-    # Budget check — derived from append-only trail, not a mutable counter
-    budget = _ao.get_override_budget()
-    trail_path = repo_root / _ao.ATTEST_DIR / _ao.OVERRIDE_TRAIL_FILE
-    used = _ao.count_overrides_in_window(trail_path)
-    if used >= budget:
-        print(
-            f"  REFUSED: override budget exhausted "
-            f"({used}/{budget} used in the last {_ao.OVERRIDE_WINDOW_DAYS} days). "
-            "Wait for the window to roll or raise VNX_ATTEST_OVERRIDE_BUDGET.",
-            file=sys.stderr,
-        )
-        return 1
-
-    # Write override record + trail entry
     try:
-        rec = _ao.write_override_record(
-            content_key=ck,
-            reason=reason,
-            dispatch_id=dispatch_id,
-            signer_identity=signer_identity,
-            timestamp=_utc_now(),
-            key_path=key_path,
-            repo_root=repo_root,
-        )
-    except (ValueError, RuntimeError) as e:
-        print(f"  override write failed: {e}", file=sys.stderr)
-        return 1
+        # Compute content-key for this branch
+        try:
+            ck = _ck.compute_diff_hash(
+                repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+            )
+        except RuntimeError as e:
+            print(f"  Error computing content-key: {e}", file=sys.stderr)
+            return 1
+
+        # Budget check BEFORE accepting — derived from the append-only trail with
+        # chain-integrity + signature verification (a forged entry cannot count).
+        budget = _ao.get_override_budget()
+        trail_path = repo_root / _ao.ATTEST_DIR / _ao.OVERRIDE_TRAIL_FILE
+        try:
+            used = _ao.count_overrides_in_window(
+                trail_path, allowed_signers=allowed_signers_str
+            )
+        except ValueError as e:
+            print(f"  REFUSED: {e}", file=sys.stderr)
+            return 1
+        if used >= budget:
+            print(
+                f"  REFUSED: override budget exhausted "
+                f"({used}/{budget} used in the last {_ao.OVERRIDE_WINDOW_DAYS} days). "
+                "Wait for the window to roll or raise VNX_ATTEST_OVERRIDE_BUDGET.",
+                file=sys.stderr,
+            )
+            return 1
+
+        # Write override record + trail entry (write_override_record re-checks the
+        # budget itself as defense in depth).
+        try:
+            rec = _ao.write_override_record(
+                content_key=ck,
+                reason=reason,
+                dispatch_id=dispatch_id,
+                signer_identity=signer_identity,
+                timestamp=_utc_now(),
+                key_path=key_path,
+                repo_root=repo_root,
+                allowed_signers=allowed_signers_str,
+            )
+        except (ValueError, RuntimeError) as e:
+            print(f"  override write failed: {e}", file=sys.stderr)
+            return 1
+    finally:
+        if _as_tmp:
+            try:
+                os.unlink(_as_tmp)
+            except OSError:
+                pass
 
     remaining_after = budget - (used + 1)
     print(f"  content-key:   {rec.content_key[:12]}\u2026")

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -488,6 +488,28 @@ def _register_attest_subparser(subparsers: argparse.Action) -> None:
     avp.add_argument("--project-dir", default=".", metavar="DIR",
                      help="repository root (default: current directory)")
 
+    # D4: signed, budgeted, audited gate override
+    aov = attest_subs.add_parser(
+        "override",
+        help="record a signed, budgeted gate override (D4 — recorded deviation, never silent)",
+    )
+    aov.add_argument("--reason", required=True, metavar="REASON",
+                     help="non-empty justification (permanent audit record)")
+    aov.add_argument("--key", required=True, metavar="KEY_PATH",
+                     help="SSH private key for signing (must match an allowed_signers entry)")
+    aov.add_argument("--signer", default="vnx@local", metavar="IDENTITY",
+                     help="signer identity (must match an allowed_signers entry at base branch)")
+    aov.add_argument("--dispatch-id", dest="dispatch_id", default="override", metavar="ID",
+                     help="dispatch ID or override slug for traceability")
+    aov.add_argument("--base-ref", dest="base_ref", default="origin/main", metavar="REF",
+                     help="base branch for merge-base (default: origin/main)")
+    aov.add_argument("--head-ref", dest="head_ref", default="HEAD", metavar="REF",
+                     help="PR head ref (default: HEAD)")
+    aov.add_argument("--no-commit", dest="no_commit", action="store_true",
+                     help="write record files only; skip git add + commit")
+    aov.add_argument("--project-dir", default=".", metavar="DIR",
+                     help="repository root (default: current directory)")
+
 
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":


### PR DESCRIPTION
## Summary

D4 of governance-attribution-enforce. The ISO/ISAE principle made operational: zero UNRECORDED deviations, but a RECORDED+SIGNED override is allowed.

- `vnx attest override`: an operator bypasses the server-gate for a specific PR/diff ONLY via a signed override attestation (reason required, diff-bound content-key, budget-decremented, operator-signed via D1).
- **Budget**: N per rolling window (config), derived from the append-only audit trail; exhausted → refuses.
- verify_pr recognizes a valid signed override for the exact content-key as verdict `override` — **never a silent pass**, always recorded prominently.
- Diff-bound + signer-pinned to base-branch allowed_signers — a PR cannot forge its own override.

## Verification

618-line test module passes (signed override for exact diff = override; different diff fails; budget-exhausted refuses; rogue-key fails; count derived from trail). Independently re-run.

## Provenance

Governed tmux-spawn lane (dispatch `D-govenf-d4-override`, security-engineer). Builds on D1/D2/D3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC