### PR TITLE
feat(horizon): ship vnx horizon command group (full surface, tenant-safe resolver, aliases) [D1]

### DIFF
--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -1,0 +1,342 @@
+"""tests/test_horizon_cli.py — `vnx horizon` pip-CLI command group (D1).
+
+Verifies D1 of claudedocs/2026-07-05-horizon-planning-module-PLAN.md:
+
+- `vnx horizon` wraps the existing planning_cli engine — no new logic.
+- State resolves via the CENTRAL data root (`_engine.resolve_data_root`,
+  matching `vnx track`/`vnx status`) — NOT `planning_cli._resolve_state_dir`'s
+  repo-local degraded `<git-root>/.vnx-data/state` path.
+- `--project-id` is required/resolved explicitly (ADR-007): a missing
+  --project-id in an unresolvable context is rejected, never silently
+  defaulted to 'vnx-dev'.
+- `vnx objective` and `vnx deliverable` are full aliases of the same handler
+  functions as `vnx horizon` / `vnx horizon deliverable`.
+- `vnx horizon --help` lists the full subcommand surface.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = REPO_ROOT / "scripts" / "lib"
+_SCRIPTS = REPO_ROOT / "scripts"
+_MIGRATIONS = REPO_ROOT / "schemas" / "migrations"
+for _p in (str(REPO_ROOT), str(_LIB), str(_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import schema_migration  # noqa: E402
+
+from vnx_cli import _engine  # noqa: E402
+from vnx_cli.main import main as vnx_main  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _bootstrap_store(state_dir: Path) -> None:
+    """Pre-migrate a runtime_coordination.db far enough for the planning
+    surface (tracks/deliverables/plan-gate): 22 (track layer), 24 (tenant
+    scoping), 27 (horizon + deliverables view), 28 (derived_status)."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+        "state TEXT NOT NULL DEFAULT 'queued', terminal_id TEXT, track TEXT, "
+        "priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT, "
+        "attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "expires_after TEXT, metadata_json TEXT DEFAULT '{}', "
+        "UNIQUE(dispatch_id, project_id))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS coordination_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT, from_state TEXT, "
+        "to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT)"
+    )
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    # Preflight normally owned by migrate_future_system.py: 0027's deliverables
+    # VIEW selects dispatches.output_ref/output_kind, which the minimal
+    # dispatches table above doesn't carry yet.
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.commit()
+    for version, filename in [
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def isolated_env(monkeypatch):
+    """Strip ambient VNX_* env so resolution is deterministic per-test."""
+    for key in (
+        "VNX_DATA_HOME", "VNX_DATA_DIR", "VNX_DATA_DIR_EXPLICIT",
+        "VNX_PROJECT_ID", "VNX_STATE_DIR", "VNX_CANONICAL_ROOT", "PROJECT_ROOT",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+@pytest.fixture()
+def project(tmp_path, isolated_env, monkeypatch):
+    """An isolated, non-git project dir + a pre-migrated CENTRAL store wired
+    via VNX_DATA_DIR_EXPLICIT (the highest-precedence override) — deliberately
+    decoupled from --project-id resolution so store-location assertions and
+    project-id assertions can be tested independently."""
+    project_dir = tmp_path / "proj"
+    project_dir.mkdir()
+    data_root = tmp_path / "central-data"
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+    state_dir = data_root / "state"
+    _bootstrap_store(state_dir)
+    # Pin CWD to the isolated (non-git) project dir so project_id auto-resolution
+    # (which also consults CWD) never accidentally picks up this repo's own
+    # git remote / any ancestor .vnx-project-id marker.
+    monkeypatch.chdir(project_dir)
+    return project_dir, state_dir
+
+
+def _run(monkeypatch, capsys, argv):
+    monkeypatch.setattr(sys, "argv", ["vnx", *argv])
+    with pytest.raises(SystemExit) as exc:
+        vnx_main()
+    out = capsys.readouterr()
+    return exc.value.code, out.out, out.err
+
+
+# ---------------------------------------------------------------------------
+# add / list round trip + central store resolution
+# ---------------------------------------------------------------------------
+
+def test_horizon_add_list_round_trip(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "feat-h1", "Feature H1", "shipped",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "list", "--project-id", "horizon-test",
+        "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    data = json.loads(out)
+    assert {d["track_id"] for d in data} == {"feat-h1"}
+
+
+def test_horizon_resolves_central_store_not_repo_local(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+
+    expected_state_dir = _engine.resolve_data_root(project_dir) / "state"
+    assert expected_state_dir == state_dir
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "feat-h2", "Feature H2", "shipped",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    # The track landed in the pre-migrated CENTRAL store, not a repo-local
+    # `<project_dir>/.vnx-data/state` (which was never created) or this
+    # checkout's own `.vnx-data/state` (planning_cli's degraded default).
+    assert not (project_dir / ".vnx-data").exists()
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    try:
+        row = conn.execute(
+            "SELECT track_id FROM tracks WHERE track_id = ? AND project_id = ?",
+            ("feat-h2", "horizon-test"),
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+
+
+# ---------------------------------------------------------------------------
+# project-id resolution (ADR-007) — never a silent 'vnx-dev' fallback
+# ---------------------------------------------------------------------------
+
+def test_horizon_missing_project_id_is_rejected_not_defaulted(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "list", "--project-dir", str(project_dir),
+    ])
+    assert rc == 2
+    assert "vnx-dev" not in err
+    assert "project-id" in err or "project_id" in err
+
+    # No 'vnx-dev' row was ever created/queried against the store.
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    try:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM tracks WHERE project_id = 'vnx-dev'"
+        ).fetchone()[0]
+    finally:
+        conn.close()
+    assert count == 0
+
+
+def test_horizon_resolves_project_id_from_marker_when_unambiguous(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+    (project_dir / ".vnx-project-id").write_text("marker-proj\n", encoding="utf-8")
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "feat-marker", "Marker Feature", "shipped",
+        "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    try:
+        row = conn.execute(
+            "SELECT project_id FROM tracks WHERE track_id = 'feat-marker'"
+        ).fetchone()
+    finally:
+        conn.close()
+    assert row is not None
+    assert row[0] == "marker-proj"
+
+
+# ---------------------------------------------------------------------------
+# objective / deliverable aliases hit the SAME handlers as horizon
+# ---------------------------------------------------------------------------
+
+def test_objective_alias_reads_same_store_as_horizon(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "feat-alias1", "Alias via horizon", "shipped",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "objective", "list", "--project-id", "horizon-test",
+        "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    assert "feat-alias1" in {d["track_id"] for d in json.loads(out)}
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "objective", "add", "feat-alias2", "Alias via objective", "shipped",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "list", "--project-id", "horizon-test",
+        "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    ids = {d["track_id"] for d in json.loads(out)}
+    assert {"feat-alias1", "feat-alias2"} <= ids
+
+
+def test_deliverable_alias_reads_same_store_as_horizon_deliverable(project, monkeypatch, capsys):
+    project_dir, state_dir = project
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "feat-dlv", "Deliverable host", "shipped",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "deliverable", "add", "--objective", "feat-dlv", "--output-kind", "doc",
+        "--title", "via top-level alias",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "deliverable", "list", "--objective", "feat-dlv",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    records = json.loads(out)
+    assert any(r.get("track") == "feat-dlv" for r in records)
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "deliverable", "add", "--objective", "feat-dlv", "--output-kind", "post",
+        "--title", "via nested horizon",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "deliverable", "list", "--objective", "feat-dlv",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    records = json.loads(out)
+    assert len(records) == 2
+
+
+# ---------------------------------------------------------------------------
+# --help lists the full surface
+# ---------------------------------------------------------------------------
+
+def test_horizon_help_lists_full_surface(monkeypatch, capsys):
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "--help"])
+    assert rc == 0
+    for verb in (
+        "add", "list", "show", "sync", "drift", "reconcile",
+        "reconcile-review", "reconcile-streak", "close", "reopen",
+        "deliverable", "plan-gate",
+    ):
+        assert verb in out, f"missing verb in `vnx horizon --help`: {verb}"
+
+
+def test_horizon_deliverable_and_plan_gate_help_list_full_surface(monkeypatch, capsys):
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "deliverable", "--help"])
+    assert rc == 0
+    for verb in ("add", "list", "promote"):
+        assert verb in out
+
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "plan-gate", "--help"])
+    assert rc == 0
+    for verb in ("seed", "run", "status"):
+        assert verb in out
+
+
+def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
+    rc, out, _ = _run(monkeypatch, capsys, ["objective", "--help"])
+    assert rc == 0
+    for verb in (
+        "add", "list", "show", "sync", "drift", "reconcile",
+        "reconcile-review", "reconcile-streak", "close", "reopen",
+    ):
+        assert verb in out
+    # objective is the OBJECTIVE-domain alias only — deliverable/plan-gate stay
+    # on their own top-level surfaces, matching bin/vnx's existing split.
+    assert "deliverable" not in out
+    assert "plan-gate" not in out
+
+    rc, out, _ = _run(monkeypatch, capsys, ["deliverable", "--help"])
+    assert rc == 0
+    for verb in ("add", "list", "promote"):
+        assert verb in out

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""vnx horizon — the planning-layer command group (Horizon).
+
+Wraps the existing planning engine (``scripts/planning_cli.py`` cmd_* functions
++ ``objective_reconcile``) with the pip CLI's tenant-safe resolvers. No new
+planning logic lives here — every verb below is a thin delegate.
+
+Backward-compat aliases: ``vnx objective <verb>`` and ``vnx deliverable
+<verb>`` dispatch to the SAME handler functions as ``vnx horizon <verb>`` /
+``vnx horizon deliverable <verb>`` (parity with ``bin/vnx``'s top-level
+``objective``/``deliverable`` commands, which shell out to the same
+``scripts/planning_cli.py``). One implementation, three entry names.
+
+State-dir resolution (critical): ``planning_cli._resolve_state_dir`` resolves
+the REPO-LOCAL ``<git-root>/.vnx-data/state`` — the degraded path. This module
+NEVER calls it. Instead every verb resolves the CENTRAL data root via
+``_engine.resolve_data_root`` (the same resolver ``vnx track``/``vnx status``
+use) and passes the result as ``args.state_dir``, which the delegated cmd_*
+functions treat as an explicit override.
+
+Project-id resolution (ADR-007): ``--project-id`` defaults to None at the
+argparse layer (never ``'vnx-dev'``). When omitted, it is resolved from
+``VNX_PROJECT_ID`` / a ``.vnx-project-id`` marker / the git remote (see
+``project_root.resolve_project_id``); if none of those are unambiguous, the
+command refuses with exit code 2 instead of silently defaulting.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+from vnx_cli import _engine
+
+
+def resolve_state_dir(project_dir: str | Path) -> Path:
+    """Central data root for planning state — matches ``vnx track``/``vnx status``.
+
+    NOT ``planning_cli._resolve_state_dir`` (that resolves the repo-local
+    ``.vnx-data/state`` degraded path).
+    """
+    return _engine.resolve_data_root(Path(project_dir).resolve()) / "state"
+
+
+def resolve_project_id(args: Any) -> str:
+    """Resolve ``--project-id``: explicit > env/marker/git-remote > hard refusal.
+
+    Never falls back to ``'vnx-dev'`` silently (ADR-007).
+    """
+    pid = getattr(args, "project_id", None)
+    if pid:
+        return pid
+
+    _engine.ensure_engine_on_path()
+    from project_root import resolve_project_id as _resolve
+
+    try:
+        return _resolve(getattr(args, "project_dir", "."))
+    except RuntimeError as exc:
+        print(
+            f"  Error: --project-id not supplied and auto-resolution failed: {exc}",
+            file=sys.stderr,
+        )
+        sys.exit(2)
+
+
+def _require_planning_cli():
+    _engine.ensure_engine_on_path()
+    import planning_cli
+
+    return planning_cli
+
+
+def _prep(args: Any) -> None:
+    """Bind the tenant-safe state_dir + resolved project_id onto args, in place."""
+    args.state_dir = str(resolve_state_dir(args.project_dir))
+    args.project_id = resolve_project_id(args)
+
+
+# ---------------------------------------------------------------------------
+# objective-domain verbs
+# ---------------------------------------------------------------------------
+
+def _cmd_add(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_add(args)
+
+
+def _cmd_list(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_list(args)
+
+
+def _cmd_show(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_show(args)
+
+
+def _cmd_sync(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_sync(args)
+
+
+def _cmd_drift(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_drift(args)
+
+
+def _cmd_reconcile(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    # Default repo_root to the resolved project_dir (not the packaged engine's
+    # own location) so `gh` PR lookups run against the caller's actual repo.
+    if not getattr(args, "repo_root", ""):
+        args.repo_root = str(Path(args.project_dir).resolve())
+    return pc.cmd_objective_reconcile(args)
+
+
+def _cmd_reconcile_review(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_reconcile_review(args)
+
+
+def _cmd_reconcile_streak(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_reconcile_streak(args)
+
+
+def _cmd_close(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_close(args)
+
+
+def _cmd_reopen(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_reopen(args)
+
+
+_VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
+    "add": _cmd_add,
+    "list": _cmd_list,
+    "show": _cmd_show,
+    "sync": _cmd_sync,
+    "drift": _cmd_drift,
+    "reconcile": _cmd_reconcile,
+    "reconcile-review": _cmd_reconcile_review,
+    "reconcile-streak": _cmd_reconcile_streak,
+    "close": _cmd_close,
+    "reopen": _cmd_reopen,
+}
+
+
+# ---------------------------------------------------------------------------
+# deliverable-domain verbs
+# ---------------------------------------------------------------------------
+
+def _cmd_deliverable_add(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_deliverable_add(args)
+
+
+def _cmd_deliverable_list(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_deliverable_list(args)
+
+
+def _cmd_deliverable_promote(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_deliverable_promote(args)
+
+
+_DELIVERABLE_DISPATCH: dict[str, Callable[[Any], int]] = {
+    "add": _cmd_deliverable_add,
+    "list": _cmd_deliverable_list,
+    "promote": _cmd_deliverable_promote,
+}
+
+
+# ---------------------------------------------------------------------------
+# plan-gate-domain verbs
+# ---------------------------------------------------------------------------
+
+def _cmd_plan_gate_seed(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_seed(args)
+
+
+def _cmd_plan_gate_run(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_run(args)
+
+
+def _cmd_plan_gate_status(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_status(args)
+
+
+_PLAN_GATE_DISPATCH: dict[str, Callable[[Any], int]] = {
+    "seed": _cmd_plan_gate_seed,
+    "run": _cmd_plan_gate_run,
+    "status": _cmd_plan_gate_status,
+}
+
+
+# ---------------------------------------------------------------------------
+# entry points (wired from vnx_cli/main.py)
+# ---------------------------------------------------------------------------
+
+def _dispatch_deliverable(args: Any) -> int:
+    sub = getattr(args, "deliverable_verb", None)
+    fn = _DELIVERABLE_DISPATCH.get(sub)
+    if fn is None:
+        print(
+            "  vnx horizon deliverable: missing subcommand. "
+            "See `vnx horizon deliverable --help`",
+            file=sys.stderr,
+        )
+        return 1
+    return fn(args)
+
+
+def _dispatch_plan_gate(args: Any) -> int:
+    sub = getattr(args, "plan_gate_verb", None)
+    fn = _PLAN_GATE_DISPATCH.get(sub)
+    if fn is None:
+        print(
+            "  vnx horizon plan-gate: missing subcommand. "
+            "See `vnx horizon plan-gate --help`",
+            file=sys.stderr,
+        )
+        return 1
+    return fn(args)
+
+
+def vnx_horizon(args: Any) -> int:
+    """Entry point for ``vnx horizon`` — the full surface (objective verbs +
+    nested ``deliverable``/``plan-gate`` groups)."""
+    verb = getattr(args, "horizon_verb", None)
+    if verb == "deliverable":
+        return _dispatch_deliverable(args)
+    if verb == "plan-gate":
+        return _dispatch_plan_gate(args)
+    fn = _VERB_DISPATCH.get(verb)
+    if fn is None:
+        print("  vnx horizon: missing subcommand. See `vnx horizon --help`", file=sys.stderr)
+        return 1
+    return fn(args)
+
+
+def vnx_objective(args: Any) -> int:
+    """Entry point for the top-level ``vnx objective`` alias.
+
+    Same verbs, same handler functions as ``vnx horizon`` (excluding the
+    nested ``deliverable``/``plan-gate`` groups, which are their own
+    top-level surfaces — see ``vnx_deliverable`` — per ``bin/vnx`` parity).
+    """
+    verb = getattr(args, "objective_verb", None)
+    fn = _VERB_DISPATCH.get(verb)
+    if fn is None:
+        print("  vnx objective: missing subcommand. See `vnx objective --help`", file=sys.stderr)
+        return 1
+    return fn(args)
+
+
+def vnx_deliverable(args: Any) -> int:
+    """Entry point for the top-level ``vnx deliverable`` alias.
+
+    Same handler functions as ``vnx horizon deliverable``.
+    """
+    sub = getattr(args, "deliverable_verb", None)
+    fn = _DELIVERABLE_DISPATCH.get(sub)
+    if fn is None:
+        print("  vnx deliverable: missing subcommand. See `vnx deliverable --help`", file=sys.stderr)
+        return 1
+    return fn(args)

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -278,6 +278,212 @@ def _register_track_subparser(subparsers: argparse.Action) -> None:
     toic_parser.add_argument("--project-dir", default=".", metavar="DIR")
 
 
+_HORIZON_CHOICES = ("now", "next", "later")
+_PHASE_CHOICES = ("queued", "active", "parked", "done")
+_OUTPUT_KIND_CHOICES = ("pr", "post", "deal", "doc")
+
+
+def _common_horizon_args(p: argparse.ArgumentParser) -> None:
+    p.add_argument(
+        "--project-id",
+        default=None,
+        metavar="PROJECT_ID",
+        help="project_id (default: resolved from VNX_PROJECT_ID / .vnx-project-id / "
+             "git remote; never silently 'vnx-dev' — ADR-007)",
+    )
+    p.add_argument("--project-dir", default=".", metavar="DIR")
+    p.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+
+
+def _register_objective_verbs(subs: argparse.Action) -> None:
+    """Register the objective-domain verbs shared by `vnx horizon` and the
+    `vnx objective` backward-compat alias — same flags, same handlers."""
+    p_add = subs.add_parser("add", help="add an ad-hoc objective/track (no ROADMAP edit)")
+    _common_horizon_args(p_add)
+    p_add.add_argument("track_id", metavar="TRACK_ID")
+    p_add.add_argument("title", metavar="TITLE")
+    p_add.add_argument("goal_state", metavar="GOAL_STATE", help="what 'done' looks like")
+    p_add.add_argument("--horizon", choices=_HORIZON_CHOICES, default=None)
+    p_add.add_argument("--priority", default=None)
+
+    p_list = subs.add_parser("list", help="list objectives grouped by horizon")
+    _common_horizon_args(p_list)
+    p_list.add_argument("--horizon", choices=_HORIZON_CHOICES, default=None)
+    p_list.add_argument("--phase", choices=_PHASE_CHOICES, default=None)
+
+    p_show = subs.add_parser("show", help="show one objective")
+    _common_horizon_args(p_show)
+    p_show.add_argument("track_id", metavar="TRACK_ID")
+
+    p_sync = subs.add_parser(
+        "sync", help="re-project ROADMAP.yaml -> tracks (CHECK by default; --apply to write)"
+    )
+    _common_horizon_args(p_sync)
+    p_sync.add_argument("--apply", action="store_true",
+                        help="apply the idempotent projection (default: dry-run check)")
+    p_sync.add_argument("--roadmap", default=None, help="path to ROADMAP.yaml (default: project root)")
+
+    p_drift = subs.add_parser(
+        "drift",
+        help="advisory drift-gate: report declared-vs-derived divergence (exit 0)",
+    )
+    _common_horizon_args(p_drift)
+
+    p_reconcile = subs.add_parser(
+        "reconcile",
+        help="batch git-grounded auto-close: verify PR merge state via gh and close done tracks",
+    )
+    _common_horizon_args(p_reconcile)
+    p_reconcile.add_argument(
+        "--apply", action="store_true",
+        help="close CONFIRMED tracks (default: check only — no phase writes)",
+    )
+    p_reconcile.add_argument(
+        "--allow-closed-siblings", action="store_true", dest="allow_closed_siblings",
+        help="CONFIRMED if >=1 PR merged even when siblings are CLOSED-unmerged",
+    )
+    p_reconcile.add_argument(
+        "--max-gh-calls", type=int, default=50, dest="max_gh_calls", metavar="N",
+        help="cap live gh pr view calls per run (default 50; excess -> deferred)",
+    )
+    p_reconcile.add_argument(
+        "--repo-root", default="", dest="repo_root", metavar="PATH",
+        help="git repo root for gh calls (default: resolved --project-dir)",
+    )
+
+    p_rec_review = subs.add_parser(
+        "reconcile-review",
+        help="record an operator review of a reconcile run (ok or false-candidate)",
+    )
+    _common_horizon_args(p_rec_review)
+    p_rec_review.add_argument("run_id", help="run_id from reconcile_history.ndjson")
+    p_rec_review.add_argument("--reviewer", required=True, help="reviewer name or id")
+    p_rec_review.add_argument(
+        "--verdict", required=True, choices=["ok", "false-candidate"],
+        help="ok = candidate is correct; false-candidate = reconcile over-nominated this track",
+    )
+    p_rec_review.add_argument("--note", default="", help="optional review note")
+
+    p_rec_streak = subs.add_parser(
+        "reconcile-streak",
+        help="compute the consecutive clean-run streak for the VNX_AUTO_CLOSE flip decision",
+    )
+    _common_horizon_args(p_rec_streak)
+
+    p_close = subs.add_parser(
+        "close",
+        help="close-the-loop: advance declared phase to a terminal derived_status (human-gated)",
+    )
+    _common_horizon_args(p_close)
+    p_close.add_argument("track_id")
+    p_close.add_argument("--apply", action="store_true",
+                         help="write the transition (default: dry-run check)")
+    p_close.add_argument("--approval-id", default="",
+                         help="operator approval token (REQUIRED with --apply)")
+    p_close.add_argument("--include-parked", action="store_true",
+                         help="allow closing a PARKED track (un-parks it; off by default)")
+
+    p_reopen = subs.add_parser(
+        "reopen", help="reopen a done track: done -> active (operator-gated, audited)",
+    )
+    _common_horizon_args(p_reopen)
+    p_reopen.add_argument("track_id")
+    p_reopen.add_argument("--approval-id", default="", dest="approval_id",
+                          help="operator approval token (REQUIRED)")
+    p_reopen.add_argument("--reason", default="",
+                          help="reason for reopening (REQUIRED)")
+
+
+def _register_deliverable_verbs(subs: argparse.Action) -> None:
+    """Register the deliverable-domain verbs shared by `vnx horizon deliverable`
+    and the top-level `vnx deliverable` backward-compat alias."""
+    p_dadd = subs.add_parser("add", help="plan a deliverable (proposed dispatch)")
+    _common_horizon_args(p_dadd)
+    p_dadd.add_argument("--objective", required=True, metavar="TRACK_ID",
+                        help="track/objective this deliverable belongs to")
+    p_dadd.add_argument("--output-kind", required=True, choices=_OUTPUT_KIND_CHOICES,
+                        metavar="KIND", dest="output_kind")
+    p_dadd.add_argument("--title", required=True)
+
+    p_dlist = subs.add_parser("list", help="list deliverables grouped by objective")
+    _common_horizon_args(p_dlist)
+    p_dlist.add_argument("--objective", default=None, metavar="TRACK_ID")
+
+    p_dpromote = subs.add_parser(
+        "promote", help="human gate: promote deliverable from proposed -> ready",
+    )
+    _common_horizon_args(p_dpromote)
+    p_dpromote.add_argument("dispatch_id")
+
+
+def _register_plan_gate_verbs(subs: argparse.Action) -> None:
+    """Register the plan-gate-domain verbs under `vnx horizon plan-gate`."""
+    p_pseed = subs.add_parser(
+        "seed", help="seed the OI-PLAN blocker (track stays blocked until the gate passes)",
+    )
+    _common_horizon_args(p_pseed)
+    p_pseed.add_argument("track_id")
+
+    p_prun = subs.add_parser(
+        "run", help="run the panel over a plan doc; on PASS, resolve the blocker",
+    )
+    _common_horizon_args(p_prun)
+    p_prun.add_argument("track_id")
+    p_prun.add_argument("--doc", required=True, help="path to the plan doc under review")
+
+    p_pstat = subs.add_parser(
+        "status", help="show a track's plan-gate state + derived_status",
+    )
+    _common_horizon_args(p_pstat)
+    p_pstat.add_argument("track_id")
+
+
+def _register_horizon_subparser(subparsers: argparse.Action) -> None:
+    horizon_parser = subparsers.add_parser(
+        "horizon",
+        help="planning layer: objectives, deliverables, plan-gate (aliases: objective, deliverable)",
+    )
+    horizon_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    horizon_subs = horizon_parser.add_subparsers(dest="horizon_verb", metavar="VERB")
+    _register_objective_verbs(horizon_subs)
+
+    dlv_parser = horizon_subs.add_parser(
+        "deliverable", help="deliverable plane (proposed dispatches)"
+    )
+    dlv_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    dlv_subs = dlv_parser.add_subparsers(dest="deliverable_verb", metavar="VERB")
+    _register_deliverable_verbs(dlv_subs)
+
+    pg_parser = horizon_subs.add_parser(
+        "plan-gate", help="plan-first gate: a multi-model panel reviews a plan before any build"
+    )
+    pg_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    pg_subs = pg_parser.add_subparsers(dest="plan_gate_verb", metavar="VERB")
+    _register_plan_gate_verbs(pg_subs)
+
+
+def _register_objective_subparser(subparsers: argparse.Action) -> None:
+    """Backward-compat alias: `vnx objective <verb>` — same verbs/handlers as
+    `vnx horizon <verb>` (bin/vnx parity)."""
+    objective_parser = subparsers.add_parser(
+        "objective", help="alias for `vnx horizon` (backward compat)",
+    )
+    objective_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    objective_subs = objective_parser.add_subparsers(dest="objective_verb", metavar="VERB")
+    _register_objective_verbs(objective_subs)
+
+
+def _register_deliverable_subparser(subparsers: argparse.Action) -> None:
+    """Backward-compat alias: `vnx deliverable <verb>` — same handlers as
+    `vnx horizon deliverable` (bin/vnx parity)."""
+    deliverable_parser = subparsers.add_parser(
+        "deliverable", help="alias for `vnx horizon deliverable` (backward compat)",
+    )
+    deliverable_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    deliverable_subs = deliverable_parser.add_subparsers(dest="deliverable_verb", metavar="VERB")
+    _register_deliverable_verbs(deliverable_subs)
+
+
 def _register_migrate_subparser(subparsers: argparse.Action) -> None:
     migrate_parser = subparsers.add_parser(
         "migrate",
@@ -560,6 +766,18 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.attest import vnx_attest
         sys.exit(vnx_attest(args))
 
+    elif args.command == "horizon":
+        from vnx_cli.commands.horizon import vnx_horizon
+        sys.exit(vnx_horizon(args))
+
+    elif args.command == "objective":
+        from vnx_cli.commands.horizon import vnx_objective
+        sys.exit(vnx_objective(args))
+
+    elif args.command == "deliverable":
+        from vnx_cli.commands.horizon import vnx_deliverable
+        sys.exit(vnx_deliverable(args))
+
     else:
         parser.print_help()
         sys.exit(0)
@@ -588,6 +806,9 @@ def main() -> None:
     _register_dream_subparser(subparsers)
     _register_migrate_subparser(subparsers)
     _register_attest_subparser(subparsers)
+    _register_horizon_subparser(subparsers)
+    _register_objective_subparser(subparsers)
+    _register_deliverable_subparser(subparsers)
 
     args = parser.parse_args()
     _dispatch_command(args, parser)


### PR DESCRIPTION
## Summary

D1 of horizon-planning-module (plan operator-accepted @ cap). Ships the planning module as `vnx horizon` in the pip CLI — the convenience + drift-guard surface over the existing engine.

- `vnx_cli/commands/horizon.py`: the `horizon` command group delegating 100% to `planning_cli` cmd_* (no new logic), full surface (add/list/show/sync/close/reopen/drift/reconcile/reconcile-review/reconcile-streak/plan-gate/deliverable).
- **State-dir via `_engine.resolve_data_root`** (the pip CLI's CENTRAL store), NOT `planning_cli._resolve_state_dir` (repo-local degraded) — the round-1 panel finding, fixed. Prevents the second-divergent-roadmap drift.
- **Aliases**: `vnx objective` + `vnx deliverable` share the SAME handlers (`_register_objective_verbs`), full surface, no subset.
- ADR-007: `--project-id` required/resolved, never silent `vnx-dev`.

## Verification

test_horizon_cli.py green (round-trip, resolver==central store, project-id, aliases, --help). Independently re-run.

## Provenance

Governed tmux-spawn lane (dispatch `D-horizon-d1-cli-r2`, Sonnet 5). Plan rev @ cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC