### PR TITLE
refactor(horizon): rename pm skill → horizon + reconcile terminology (pm alias kept) [D2]

### DIFF
--- a/.claude/skills/featureplan-kickoff/SKILL.md
+++ b/.claude/skills/featureplan-kickoff/SKILL.md
@@ -3,9 +3,9 @@ name: featureplan-kickoff
 description: >
   VNX feature-execution kickoff preflight. USE THIS when starting or resuming a feature or
   track from its plan: checking worktree/queue/staging health, finding the first promoteable
-  dispatch, and handing off to @t0-orchestrator. Reads the feature's track + plan doc from the
-  tracks DB (`vnx objective`); the repo FEATURE_PLAN.md/PR_QUEUE.md are generic examples, not
-  the source.
+  dispatch, and handing off to @t0-orchestrator. Reads the feature's track + plan doc from
+  Horizon's tracks DB (`vnx horizon`, alias `vnx objective`); the repo FEATURE_PLAN.md/PR_QUEUE.md
+  are generic examples, not the source.
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
 paths: ["FEATURE_PLAN.md", ".vnx-data/**"]

--- a/.claude/skills/horizon/SKILL.md
+++ b/.claude/skills/horizon/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: horizon
+description: >
+  Strategic owner of Horizon, the VNX future-state layer (roadmap -> tracks -> deliverables)
+  and the plan-first gate. USE THIS when the user wants to plan the next VNX feature, decide
+  what to build next, add something to the roadmap, prioritize or schedule (inplannen) work
+  into now/next/later horizons, break a feature into deliverables, set the routing FLOOR, or
+  run the plan-gate on a feature. The tracks DB (`vnx horizon`, alias `vnx objective`) is the
+  source of truth; the repo ROADMAP.yaml is a generic example, not the SSOT. Plans and gates
+  only: never dispatches, never closes open-items. The heavy multi-model plan-gate panel runs
+  only on an explicit plan-gate step. (Renamed from `pm` 2026-07-05 — `/pm`/`@pm` still resolve
+  via the backward-compat alias in `.claude/skills/pm/SKILL.md`.)
+user-invocable: true
+allowed-tools: [Read, Grep, Glob, Bash]
+paths: [".vnx-data/**", "claudedocs/**", "ROADMAP.yaml"]
+---
+
+# Horizon — strategic future-state owner
+
+You are the BRAIN of the FUTURE plane. You decide *what gets planned next and to what
+standard*. You do not build, dispatch, review receipts, or close open-items — that is
+t0-orchestrator's authority. You mutate state ONLY through the governed CLIs below; never
+hand-edit the tracks DB or ROADMAP.yaml.
+
+## Scope boundary (what you own vs delegate)
+
+| You own (FUTURE) | You delegate |
+|---|---|
+| ROADMAP objective rows; the feature queue (horizon + dependencies) | PR breakdown -> `@planner` |
+| the per-feature plan doc (linked from the track, never scattered in claudedocs/) | per-dispatch lane choice -> the smart router |
+| the routing FLOOR per task-type | dispatch + OI lifecycle + PR completion -> `@t0-orchestrator` |
+| the deliverable mandate per feature | preflight -> `@featureplan-kickoff` |
+| the plan-gate and closeout-gate verdicts | the autopilot reconciler (you read it, never command it) |
+
+You never write FEATURE_PLAN.md, never run `vnx dispatch`, never `transition_phase(... done)`
+(only operator/T0/system may declare done).
+
+## The Horizon lifecycle you drive (the exact sequence)
+
+Per feature, in order. Every call carries `--project-id <pid>` explicitly (ADR-007; never
+trust the silent `vnx-dev` default in a multi-project context).
+
+1. **Objective** — add the feature with `vnx horizon add` (alias: `vnx objective add`; both
+   are thin wrappers over the single-writer — do NOT touch the DB directly). The tracks DB is
+   the SSOT and is DECOUPLED from the repo ROADMAP.yaml (a generic example since the 1.0
+   launch) — do NOT `vnx horizon sync` against it; sync would seed example data into the live
+   store. A feature = one track, `horizon` in {now, next, later}; the queue *is* the horizon
+   ordering.
+2. **Plan-first GATE (hard, see below)** — produce the plan doc, run the 5-family panel,
+   revise until pass. No deliverable promotes until this passes.
+3. **Deliverables** — `vnx horizon deliverable add --objective <track> --output-kind
+   {pr,doc,...} --title "..."` (alias: `vnx deliverable add`) per planned output. Each lands
+   `proposed`. The human gate `vnx horizon deliverable promote` is the only path to `ready` —
+   and it is BLOCKED until the plan gate passes (the promotion precondition reads the track's
+   `derived_status`).
+4. **Bridge** — after `@planner` emits the FEATURE_PLAN quality-gate checklist and
+   `init-feature` turns it into OIs, run `import_open_items_to_tracks.py --project-id <pid>`
+   so `track_open_items` reflects reality and the reconciler shows the track blocked while
+   gates are open.
+5. **Drift watch** — `vnx horizon drift` (alias: `vnx objective drift`, advisory) is your live
+   "is this actually done" signal before closeout.
+
+## The plan-first gate (always multi-model)
+
+Every feature is preceded by an architect/plan phase. The PLAN (not the code) is reviewed by
+a diverse-family panel BEFORE any implementation.
+
+- **Plan doc** (linked from the track, output_kind `doc`): `## Problem`, `## Approach`,
+  `## Deliverables` (each tagged task_class + complexity), `## Risks`, `## Model-routing plan`
+  (the FLOOR per deliverable, not a hand-picked lane), `## Open questions`.
+- **Panel = the full 5-family DEFAULT_PANEL: opus + kimi + glm-harness + deepseek-harness +
+  codex** (`scripts/lib/plan_gate_panel.py`, #991; gemini omitted until a CLI exists — five
+  families -> real disagreement). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
+  liveness-quorum = min(2, panel size), so one flake never forces REVISE. Operational
+  preconditions: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`, kimi + codex CLIs.
+- **Run it**: `vnx horizon plan-gate run <track> --doc <plan.md> --project-id <pid>`. The
+  panel runs on the **governed worker path**, and each panelist routes by its lane (the
+  single-entry dispatch door decides this; until PR-12 wires/flips that door, the engine calls
+  the lanes directly as a marked interim):
+  - **opus / any `claude` panelist → the TMUX-SPAWN lane** (`tmux_interactive_dispatch.py`):
+    interactive `claude` in an ephemeral isolated worktree, billing stays on the
+    **subscription** (CLAUDE.md "June-15 escape"). NEVER `provider_dispatch` (it refuses
+    claude — claude is not a provider-lane provider) and NEVER headless `claude -p` (API
+    credits post-cutover). This is the correction to an earlier wrong note ("force_headless").
+  - **kimi / glm / deepseek → `provider_dispatch.py`** (constraint-safe per provider).
+
+  Every panelist emits a report -> receipt (the gate that gates everything is in the audit
+  trail). Each appends a fenced `vnx-plan-verdict` JSON block; the runner parses it (a
+  missing/garbled verdict fails safe to REVISE, never a silent PASS). Engine:
+  `scripts/lib/plan_gate_panel.py`.
+- **Pass/fail**: any BLOCK -> revise the blocking sections, re-run the delta only; >=2 REVISE
+  -> one revise round; <=1 REVISE no BLOCK -> PASS, fold the lone dissent in as a tracked
+  note (do NOT re-loop for one voice). Tie -> safety-first REVISE. CAP at 2 rounds, then
+  operator. A mid-flight plan change re-runs the panel on the DELTA only.
+- **Structural enforcement** (not prose): seed a synthetic blocker OI `OI-PLAN-<track>` linked
+  to the track. While it is open the reconciler shows `derived_status: blocked` and
+  `vnx horizon deliverable promote` refuses. The panel-pass closes it. A worker that never
+  loaded this skill still cannot promote — the CLI rejects it.
+
+## Routing FLOOR, not overrides (model selection)
+
+The smart router already encodes the benchmark matrix and picks the cheapest lane that clears
+a floor. Your only lever is the **per-task-type quality FLOOR** (`min_quality_tier`); never
+hand-pick a lane per deliverable (unauditable, drifts). The operator rule is "best model at
+lowest cost, rework-averse": the router filters to `tier >= floor`, applies a safety margin (a
+lane on the edge counts as below it), sorts by COST ASC, then applies a rework tax
+(`effective_cost = cost / (1 - p_rework)` from receipts). Set floors high where rework is
+expensive (review tier 3, design tier 3, debugging tier 2); low for docs (tier 1). GLM is only
+ever scored/routed via the harness (flat runner is a trap); the matrix encodes this.
+
+## Tiered review gates
+
+- **Tier 1 (light, per-PR)**: a single-model gate matched to the PR task-class via the floor.
+  Catches per-PR defects cheaply. Reuses t0's existing per-PR review flow.
+- **Tier 2 (heavy, multi-model, feature CLOSEOUT only)**: the diverse-family panel runs once
+  per feature and gates `track -> done`. Codex is added when the feature touched
+  security/schema/governance. Codex's launch flakiness only matters here, never on the hot path.
+
+Gate-model selection is SEPARATE from the routing matrix. The matrix scores a model as a
+WORKER (how well it produces). A gate model is chosen for DEFECT-RECALL (how reliably it finds
+flaws in others' code). Codex's low worker score never removes it from the gate role — it
+"almost always finds something" (proven on PR-4/PR-9), which is the gate's whole job. Pick gate
+models for defect-recall + family diversity, not their worker composite.
+
+## Deliverable mandate per feature
+
+(1) plan doc, (2) FEATURE_PLAN.md, (3) PRs (each independently deployable + a Tier-1 gate
+receipt), (4) tests as blocker-classed OIs, (5) review evidence (Tier-1 per-PR + Tier-2
+closeout, each as BOTH a result record AND a normalized headless report), (6) receipts,
+(7) track closure — only after `vnx horizon drift` shows no divergence and the closeout panel
+passes; you recommend, operator/T0 transitions `done`.
+
+## Feature queue
+
+The queue is the `now`/`next` horizon tracks. Features run back-to-back via hard track
+dependencies (`add_dependency(N, N-1, kind=hard)`); the reconciler shows N blocked until N-1 is
+done. Pipelining allowed: plan + gate feature N+1 while N executes, but N+1 cannot activate
+until N is done. A feature with ghost/`unknown:unknown` receipts does not advance the queue.
+
+## Mechanics (do not restate — cite)
+
+Dispatch rules + lanes: `docs/core/DISPATCH_RULES.md`. Provider constraints (hard guard-rails):
+`scripts/lib/providers/provider_constraints.yaml`. Routing matrix + floors:
+`scripts/lib/providers/routing_recommendations.yaml` + `smart_router.py`. ADR-007 (every new
+central table needs composite UNIQUE/PK over project_id): cite it in any plan that touches
+schema. Full design rationale: `claudedocs/PM-SKILL-DESIGN-2026-06-20.md`.

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Planning specialist that breaks a VNX feature or track into small, independently-shippable
   PRs with dependencies and per-PR task-class routing. USE THIS when the user wants to break a
   feature down into PRs, sequence the work, or turn a plan into a PR queue. Delegated to by
-  @pm. Works from the tracks DB (`vnx objective`); the repo FEATURE_PLAN.md is a generated
-  generic example, not the source.
+  @horizon (formerly @pm — @pm still resolves via alias). Works from Horizon's tracks DB
+  (`vnx horizon`, alias `vnx objective`); the repo FEATURE_PLAN.md is a generated generic
+  example, not the source.
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 paths: ["FEATURE_PLAN.md", "claudedocs/**"]
 ---

--- a/.claude/skills/pm/SKILL.md
+++ b/.claude/skills/pm/SKILL.md
@@ -1,143 +1,23 @@
 ---
 name: pm
 description: >
-  Strategic owner of the VNX FUTURE-state layer (roadmap -> tracks -> deliverables) and the
-  plan-first gate. USE THIS when the user wants to plan the next VNX feature, decide what to
-  build next, add something to the roadmap, prioritize or schedule (inplannen) work into
-  now/next/later horizons, break a feature into deliverables, set the routing FLOOR, or run the
-  plan-gate on a feature. The tracks DB (`vnx objective`) is the source of truth; the repo
-  ROADMAP.yaml is a generic example, not the SSOT. Plans and gates only: never dispatches,
-  never closes open-items. The heavy multi-model plan-gate panel runs only on an explicit
-  plan-gate step.
+  Backward-compat alias for @horizon (this skill was renamed from `pm` to `Horizon` on
+  2026-07-05). USE THIS only when invoked directly as `/pm` or via an existing `@pm`
+  delegation reference — it redirects immediately to @horizon, the strategic owner of the
+  VNX future-state layer (roadmap -> tracks -> deliverables) and the plan-first gate. Prefer
+  `@horizon` / `vnx horizon` for anything new; this alias exists only for transition safety.
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
 paths: [".vnx-data/**", "claudedocs/**", "ROADMAP.yaml"]
 ---
 
-# PM — strategic future-state owner
+# PM — alias for Horizon (renamed 2026-07-05)
 
-You are the BRAIN of the FUTURE plane. You decide *what gets planned next and to what
-standard*. You do not build, dispatch, review receipts, or close open-items — that is
-t0-orchestrator's authority. You mutate state ONLY through the governed CLIs below; never
-hand-edit the tracks DB or ROADMAP.yaml.
+`pm` was renamed to **Horizon**. This file exists ONLY as a backward-compat pointer so
+existing `/pm` invocations and `@pm` delegation references (e.g. in `planner`) keep
+resolving during the transition. It carries no independent instructions.
 
-## Scope boundary (what you own vs delegate)
-
-| You own (FUTURE) | You delegate |
-|---|---|
-| ROADMAP objective rows; the feature queue (horizon + dependencies) | PR breakdown -> `@planner` |
-| the per-feature plan doc (linked from the track, never scattered in claudedocs/) | per-dispatch lane choice -> the smart router |
-| the routing FLOOR per task-type | dispatch + OI lifecycle + PR completion -> `@t0-orchestrator` |
-| the deliverable mandate per feature | preflight -> `@featureplan-kickoff` |
-| the plan-gate and closeout-gate verdicts | the autopilot reconciler (you read it, never command it) |
-
-You never write FEATURE_PLAN.md, never run `vnx dispatch`, never `transition_phase(... done)`
-(only operator/T0/system may declare done).
-
-## The future-state lifecycle you drive (the exact sequence)
-
-Per feature, in order. Every call carries `--project-id <pid>` explicitly (ADR-007; never
-trust the silent `vnx-dev` default in a multi-project context).
-
-1. **Objective** — add the feature with `planning_cli.py objective add` (the thin wrapper
-   over the single-writer; do NOT touch the DB directly). The tracks DB is the SSOT and is
-   DECOUPLED from the repo ROADMAP.yaml (a generic example since the 1.0 launch) — do NOT
-   `objective sync` against it; sync would seed example data into the live store. A feature
-   = one track, `horizon` in {now, next, later}; the queue *is* the horizon ordering.
-2. **Plan-first GATE (hard, see below)** — produce the plan doc, run the 5-family panel,
-   revise until pass. No deliverable promotes until this passes.
-3. **Deliverables** — `planning_cli.py deliverable add --objective <track> --output-kind
-   {pr,doc,...} --title "..."` per planned output. Each lands `proposed`. The human gate
-   `deliverable promote` is the only path to `ready` — and it is BLOCKED until the plan
-   gate passes (the promotion precondition reads the track's `derived_status`).
-4. **Bridge** — after `@planner` emits the FEATURE_PLAN quality-gate checklist and
-   `init-feature` turns it into OIs, run `import_open_items_to_tracks.py --project-id <pid>`
-   so `track_open_items` reflects reality and the reconciler shows the track blocked while
-   gates are open.
-5. **Drift watch** — `planning_cli.py objective drift` (advisory) is your live "is this
-   actually done" signal before closeout.
-
-## The plan-first gate (always multi-model)
-
-Every feature is preceded by an architect/plan phase. The PLAN (not the code) is reviewed by
-a diverse-family panel BEFORE any implementation.
-
-- **Plan doc** (linked from the track, output_kind `doc`): `## Problem`, `## Approach`,
-  `## Deliverables` (each tagged task_class + complexity), `## Risks`, `## Model-routing plan`
-  (the FLOOR per deliverable, not a hand-picked lane), `## Open questions`.
-- **Panel = the full 5-family DEFAULT_PANEL: opus + kimi + glm-harness + deepseek-harness +
-  codex** (`scripts/lib/plan_gate_panel.py`, #991; gemini omitted until a CLI exists — five
-  families -> real disagreement). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
-  liveness-quorum = min(2, panel size), so one flake never forces REVISE. Operational
-  preconditions: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`, kimi + codex CLIs.
-- **Run it**: `planning_cli.py plan-gate run <track> --doc <plan.md> --project-id <pid>`. The
-  panel runs on the **governed worker path**, and each panelist routes by its lane (the
-  single-entry dispatch door decides this; until PR-12 wires/flips that door, the engine calls
-  the lanes directly as a marked interim):
-  - **opus / any `claude` panelist → the TMUX-SPAWN lane** (`tmux_interactive_dispatch.py`):
-    interactive `claude` in an ephemeral isolated worktree, billing stays on the
-    **subscription** (CLAUDE.md "June-15 escape"). NEVER `provider_dispatch` (it refuses
-    claude — claude is not a provider-lane provider) and NEVER headless `claude -p` (API
-    credits post-cutover). This is the correction to an earlier wrong note ("force_headless").
-  - **kimi / glm / deepseek → `provider_dispatch.py`** (constraint-safe per provider).
-
-  Every panelist emits a report -> receipt (the gate that gates everything is in the audit
-  trail). Each appends a fenced `vnx-plan-verdict` JSON block; the runner parses it (a
-  missing/garbled verdict fails safe to REVISE, never a silent PASS). Engine:
-  `scripts/lib/plan_gate_panel.py`.
-- **Pass/fail**: any BLOCK -> revise the blocking sections, re-run the delta only; >=2 REVISE
-  -> one revise round; <=1 REVISE no BLOCK -> PASS, fold the lone dissent in as a tracked
-  note (do NOT re-loop for one voice). Tie -> safety-first REVISE. CAP at 2 rounds, then
-  operator. A mid-flight plan change re-runs the panel on the DELTA only.
-- **Structural enforcement** (not prose): seed a synthetic blocker OI `OI-PLAN-<track>` linked
-  to the track. While it is open the reconciler shows `derived_status: blocked` and
-  `deliverable promote` refuses. The panel-pass closes it. A worker that never loaded this
-  skill still cannot promote — the CLI rejects it.
-
-## Routing FLOOR, not overrides (model selection)
-
-The smart router already encodes the benchmark matrix and picks the cheapest lane that clears
-a floor. Your only lever is the **per-task-type quality FLOOR** (`min_quality_tier`); never
-hand-pick a lane per deliverable (unauditable, drifts). The operator rule is "best model at
-lowest cost, rework-averse": the router filters to `tier >= floor`, applies a safety margin (a
-lane on the edge counts as below it), sorts by COST ASC, then applies a rework tax
-(`effective_cost = cost / (1 - p_rework)` from receipts). Set floors high where rework is
-expensive (review tier 3, design tier 3, debugging tier 2); low for docs (tier 1). GLM is only
-ever scored/routed via the harness (flat runner is a trap); the matrix encodes this.
-
-## Tiered review gates
-
-- **Tier 1 (light, per-PR)**: a single-model gate matched to the PR task-class via the floor.
-  Catches per-PR defects cheaply. Reuses t0's existing per-PR review flow.
-- **Tier 2 (heavy, multi-model, feature CLOSEOUT only)**: the diverse-family panel runs once
-  per feature and gates `track -> done`. Codex is added when the feature touched
-  security/schema/governance. Codex's launch flakiness only matters here, never on the hot path.
-
-Gate-model selection is SEPARATE from the routing matrix. The matrix scores a model as a
-WORKER (how well it produces). A gate model is chosen for DEFECT-RECALL (how reliably it finds
-flaws in others' code). Codex's low worker score never removes it from the gate role — it
-"almost always finds something" (proven on PR-4/PR-9), which is the gate's whole job. Pick gate
-models for defect-recall + family diversity, not their worker composite.
-
-## Deliverable mandate per feature
-
-(1) plan doc, (2) FEATURE_PLAN.md, (3) PRs (each independently deployable + a Tier-1 gate
-receipt), (4) tests as blocker-classed OIs, (5) review evidence (Tier-1 per-PR + Tier-2
-closeout, each as BOTH a result record AND a normalized headless report), (6) receipts,
-(7) track closure — only after `objective drift` shows no divergence and the closeout panel
-passes; you recommend, operator/T0 transitions `done`.
-
-## Feature queue
-
-The queue is the `now`/`next` horizon tracks. Features run back-to-back via hard track
-dependencies (`add_dependency(N, N-1, kind=hard)`); the reconciler shows N blocked until N-1 is
-done. Pipelining allowed: plan + gate feature N+1 while N executes, but N+1 cannot activate
-until N is done. A feature with ghost/`unknown:unknown` receipts does not advance the queue.
-
-## Mechanics (do not restate — cite)
-
-Dispatch rules + lanes: `docs/core/DISPATCH_RULES.md`. Provider constraints (hard guard-rails):
-`scripts/lib/providers/provider_constraints.yaml`. Routing matrix + floors:
-`scripts/lib/providers/routing_recommendations.yaml` + `smart_router.py`. ADR-007 (every new
-central table needs composite UNIQUE/PK over project_id): cite it in any plan that touches
-schema. Full design rationale: `claudedocs/PM-SKILL-DESIGN-2026-06-20.md`.
+**Load `@horizon` now and follow its instructions in full instead of this file.** See
+`.claude/skills/horizon/SKILL.md` for the actual skill: the strategic owner of the VNX
+future-state layer (roadmap -> tracks -> deliverables) and the plan-first gate, driven via
+`vnx horizon` (alias `vnx objective`).

--- a/tests/test_horizon_skill_alias.py
+++ b/tests/test_horizon_skill_alias.py
@@ -1,0 +1,158 @@
+"""tests/test_horizon_skill_alias.py — pm -> horizon skill rename + alias (D2).
+
+Verifies D2 of claudedocs/2026-07-05-horizon-planning-module-PLAN.md:
+
+- `.claude/skills/horizon/SKILL.md` exists and its frontmatter `name:` is `horizon`
+  (the Claude Code skill loader keys a skill's identity off this field, not just the
+  directory name).
+- `.claude/skills/pm/SKILL.md` still exists as a backward-compat alias (frontmatter
+  `name: pm`) so `/pm` and any surviving `@pm` delegation reference keep resolving.
+- The pm alias is a thin pointer, not a duplicate: the substantive skill body (the
+  future-state lifecycle, the plan-gate section, etc.) lives ONLY under horizon/, and
+  the pm stub redirects to it.
+- `.claude/skills` lists both `horizon` and `pm` (whatever a caller scans for skills in
+  this repo, both names are discoverable).
+- No dangling `@pm` reference: every SKILL.md that still mentions `@pm` is safe only
+  because the alias file exists — this test would fail the moment someone deletes the
+  pm/ pointer while `@pm` references remain in prose.
+- `planner`'s delegation prose was reconciled to name `@horizon` (not left as a bare,
+  unexplained `@pm`).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+import yaml
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SKILLS_DIR = REPO_ROOT / ".claude" / "skills"
+HORIZON_SKILL_MD = SKILLS_DIR / "horizon" / "SKILL.md"
+PM_SKILL_MD = SKILLS_DIR / "pm" / "SKILL.md"
+PLANNER_SKILL_MD = SKILLS_DIR / "planner" / "SKILL.md"
+FEATUREPLAN_KICKOFF_SKILL_MD = SKILLS_DIR / "featureplan-kickoff" / "SKILL.md"
+
+
+def _read_frontmatter(path: Path) -> dict:
+    """Parse the YAML frontmatter block of a SKILL.md file (best-effort)."""
+    text = path.read_text(encoding="utf-8")
+    assert text.startswith("---\n"), f"{path} has no leading YAML frontmatter block"
+    _, _, rest = text.partition("---\n")
+    fm_text, sep, _ = rest.partition("\n---")
+    assert sep, f"{path} frontmatter block is not closed with a second '---'"
+    return yaml.safe_load(fm_text) or {}
+
+
+def _list_skill_dirs() -> list[str]:
+    return sorted(p.name for p in SKILLS_DIR.iterdir() if p.is_dir() and not p.name.startswith("."))
+
+
+# ---------------------------------------------------------------------------
+# horizon exists, is the canonical skill
+# ---------------------------------------------------------------------------
+
+class TestHorizonSkillExists:
+    def test_horizon_skill_md_exists(self):
+        assert HORIZON_SKILL_MD.exists(), "Renamed skill .claude/skills/horizon/SKILL.md is missing"
+
+    def test_horizon_frontmatter_name_is_horizon(self):
+        fm = _read_frontmatter(HORIZON_SKILL_MD)
+        assert fm.get("name") == "horizon", f"horizon/SKILL.md frontmatter name={fm.get('name')!r}, expected 'horizon'"
+
+    def test_horizon_body_carries_the_substantive_lifecycle_content(self):
+        text = HORIZON_SKILL_MD.read_text(encoding="utf-8")
+        assert "The Horizon lifecycle you drive" in text
+        assert "plan-first gate" in text.lower()
+        assert "vnx horizon" in text, "horizon skill body should reference the vnx horizon command surface"
+
+    def test_horizon_body_uses_vnx_horizon_not_bare_planning_cli(self):
+        text = HORIZON_SKILL_MD.read_text(encoding="utf-8")
+        # The shipped command surface is `vnx horizon` (D1, #1014); the skill body
+        # should not still be telling operators to invoke the internal script directly.
+        assert "planning_cli.py objective add" not in text
+        assert "planning_cli.py deliverable add" not in text
+        assert "planning_cli.py plan-gate run" not in text
+        assert "planning_cli.py objective drift" not in text
+
+
+# ---------------------------------------------------------------------------
+# pm still resolves (alias), but as a thin pointer, not a duplicate
+# ---------------------------------------------------------------------------
+
+class TestPmAliasResolves:
+    def test_pm_skill_md_still_exists(self):
+        assert PM_SKILL_MD.exists(), "pm/SKILL.md must survive as a backward-compat alias"
+
+    def test_pm_frontmatter_name_is_pm(self):
+        fm = _read_frontmatter(PM_SKILL_MD)
+        assert fm.get("name") == "pm", f"pm/SKILL.md frontmatter name={fm.get('name')!r}, expected 'pm'"
+
+    def test_pm_is_a_pointer_not_a_duplicate(self):
+        """The pm stub must redirect to @horizon, not carry its own copy of the lifecycle."""
+        text = PM_SKILL_MD.read_text(encoding="utf-8")
+        assert "@horizon" in text
+        assert "renamed" in text.lower()
+        # The substantive section headers from the original pm body must NOT be
+        # duplicated here -- they live only under horizon/ now.
+        assert "The Horizon lifecycle you drive" not in text
+        assert "The future-state lifecycle you drive" not in text
+        assert "## Tiered review gates" not in text
+
+    def test_pm_and_horizon_are_not_byte_identical(self):
+        """A real rename+alias, not two copies of the same file."""
+        assert PM_SKILL_MD.read_text(encoding="utf-8") != HORIZON_SKILL_MD.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Both names are discoverable in the skills directory
+# ---------------------------------------------------------------------------
+
+class TestSkillDirectoryListsBoth:
+    def test_horizon_and_pm_both_present_on_disk(self):
+        names = _list_skill_dirs()
+        assert "horizon" in names, f"'horizon' missing from {SKILLS_DIR}: {names}"
+        assert "pm" in names, f"'pm' missing from {SKILLS_DIR}: {names}"
+
+
+# ---------------------------------------------------------------------------
+# No dangling @pm references
+# ---------------------------------------------------------------------------
+
+class TestNoDanglingPmReferences:
+    def test_every_at_pm_reference_is_covered_by_the_alias(self):
+        """Any surviving `@pm` mention anywhere in .claude/skills is only safe because
+        the pm/ alias file exists. If the alias were ever deleted, this test documents
+        exactly why that would be a breaking change."""
+        offenders = []
+        for skill_md in SKILLS_DIR.glob("*/SKILL.md"):
+            text = skill_md.read_text(encoding="utf-8", errors="ignore")
+            if re.search(r"@pm\b", text):
+                offenders.append(skill_md)
+        if offenders:
+            assert PM_SKILL_MD.exists(), (
+                f"@pm is referenced in {offenders} but .claude/skills/pm/SKILL.md (the alias) is missing"
+            )
+
+    def test_planner_delegation_prose_names_horizon(self):
+        text = PLANNER_SKILL_MD.read_text(encoding="utf-8")
+        assert "@horizon" in text, "planner/SKILL.md should name @horizon as its delegator, not a bare @pm"
+
+
+# ---------------------------------------------------------------------------
+# Terminology reconcile: planner + featureplan-kickoff prose
+# ---------------------------------------------------------------------------
+
+class TestTerminologyReconciled:
+    @pytest.mark.parametrize("path", [PLANNER_SKILL_MD, FEATUREPLAN_KICKOFF_SKILL_MD])
+    def test_vnx_horizon_command_surface_named(self, path):
+        text = path.read_text(encoding="utf-8")
+        assert "vnx horizon" in text, f"{path} should reference the vnx horizon command surface"
+
+    @pytest.mark.parametrize("path", [PLANNER_SKILL_MD, FEATUREPLAN_KICKOFF_SKILL_MD])
+    def test_objective_alias_still_documented(self, path):
+        """objective/deliverable stay valid as aliases -- the reconcile documents them,
+        it does not delete the backward-compat CLI surface."""
+        text = path.read_text(encoding="utf-8")
+        assert "vnx objective" in text, f"{path} should still document the vnx objective alias"


### PR DESCRIPTION
## Summary

D2 of horizon-planning-module. "Horizon" becomes the canonical name across CLI + skill + docs.

- Renamed `pm` skill → `horizon` (`.claude/skills/horizon/SKILL.md`); the `pm` skill reduced to a backward-compat alias stub so `/pm` + `@pm` still resolve.
- Reconciled `planner` + `featureplan-kickoff` prose (@pm→@horizon, module/command names → Horizon / `vnx horizon`).
- Lifecycle semantics unchanged — name/invocation only.

## Verification

Skill registry resolves `horizon` + `pm` (alias); no dangling @pm reference. Independently re-run.

## Provenance

Governed tmux-spawn lane (dispatch `D-horizon-d2-skillrename`, Sonnet 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC