### PR TITLE
chore(dispatch): default tmux-spawn workers to --dangerously-skip-permissions (isolated worktree)

### DIFF
--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -75,14 +75,15 @@ _FALLBACK_SCOPE_ARGS = [
 def _build_worker_scope_args(role: Optional[str], requires_mcp: bool = False) -> List[str]:
     """Return the capability-scoping argv head for a headless ``claude`` spawn.
 
-    Default (``VNX_WORKER_SCOPED`` unset or truthy): drop the blanket
-    ``--dangerously-skip-permissions`` for ``--permission-mode acceptEdits`` +
-    empty ambient MCP + the role's tool allow-list. Set ``VNX_WORKER_SCOPED=0``
-    to restore the legacy skip-permissions posture (emergency rollback only).
+    Default (``VNX_WORKER_SCOPED`` unset or falsey): the blanket
+    ``--dangerously-skip-permissions`` flag. Set ``VNX_WORKER_SCOPED=1`` (a
+    truthy value) to opt into ``--permission-mode acceptEdits`` + empty
+    ambient MCP + the role's tool allow-list instead.
 
     ``requires_mcp``: when True, the ``--strict-mcp-config --mcp-config {}`` pair
     is forwarded to ``build_claude_scope_args`` so the dispatch retains its normal
-    ambient MCP config instead of being force-emptied.
+    ambient MCP config instead of being force-emptied. Only takes effect in the
+    scoped (``VNX_WORKER_SCOPED=1``) posture — the blanket default ignores it.
     """
     if worker_scoped_enabled is not None and not worker_scoped_enabled():
         return [_LEGACY_SKIP_FLAG]

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -41,10 +41,13 @@ logger = logging.getLogger(__name__)
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
 
 # Capability scoping (interim, per WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4/§5):
-# detached ephemeral spawns drop --dangerously-skip-permissions for an empty
-# ambient MCP + acceptEdits posture + role allow-list. Imported defensively;
-# if unavailable the detached branch keeps a minimal scoped fallback (never
-# --dangerously-skip-permissions, but without the role-specific allow-list).
+# detached ephemeral spawns run under the blanket --dangerously-skip-permissions
+# by default (tmux-spawn workers run in an isolated per-dispatch worktree, so
+# the scoped allow-list only stalls autonomous builds on prompts for
+# un-allow-listed ops). Scoped (empty ambient MCP + acceptEdits + role
+# allow-list) is opt-in via VNX_WORKER_SCOPED=1. Imported defensively; if
+# unavailable the detached branch keeps a minimal inline fallback with the
+# same default.
 try:
     from worker_permissions import (  # noqa: E402
         EMPTY_MCP_CONFIG,
@@ -58,11 +61,11 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
     _WP_AVAILABLE = False
 
     def worker_scoped_enabled() -> bool:  # type: ignore[misc]
-        return os.environ.get("VNX_WORKER_SCOPED", "1").strip().lower() not in (
-            "0",
-            "false",
-            "no",
-            "off",
+        return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
         )
 
     def _wp_build_claude_scope_args(profile, *, permission_mode="acceptEdits", requires_mcp=False, working_tree_only=False):  # type: ignore[misc]
@@ -253,10 +256,11 @@ def _default_launch_command(
         extra_flags = " ".join(safe_tokens)
     flags = ""
     if skip_permissions:
-        # Detached/autonomous run (no TTY to answer prompts). Default: scope the
-        # spawn — role allow-list + optional empty-MCP — instead of the blanket
-        # skip-permissions blast radius. VNX_WORKER_SCOPED=0 restores the legacy
-        # flag for emergency rollback.
+        # Detached/autonomous run (no TTY to answer prompts). Default: the
+        # blanket skip-permissions flag — the spawn runs in an isolated
+        # per-dispatch worktree, so scoping only stalls autonomous builds on
+        # prompts for un-allow-listed ops. VNX_WORKER_SCOPED=1 opts into the
+        # scoped posture (role allow-list + optional empty-MCP) instead.
         if worker_scoped_enabled():
             profile = _wp_resolve_worker_profile(role)
             scope_args = _wp_build_claude_scope_args(
@@ -1604,17 +1608,20 @@ class TmuxInteractiveDispatch:
 
         # D2.2 scoping precondition (fail-closed): a working-tree-only dispatch's
         # commit/push deny only binds in the scoped detached spawn (the path where
-        # _wp_build_claude_scope_args is invoked). Reject every other path —
-        # attached, --dangerously-skip-permissions, or VNX_WORKER_SCOPED=0 — so an
-        # unscoped working-tree-only worker can never silently reach git commit/push.
+        # _wp_build_claude_scope_args is invoked). Since the blanket
+        # --dangerously-skip-permissions is now the tmux-spawn default, reject
+        # every non-scoped path — attached, blanket skip-permissions, or
+        # VNX_WORKER_SCOPED unset/falsey — so an unscoped working-tree-only
+        # worker can never silently reach git commit/push.
         if working_tree_only and not (skip_permissions and worker_scoped_enabled()):
             return InteractiveDispatchResult(
                 success=False,
                 dispatch_id=dispatch_id,
                 failure_reason=(
                     "working_tree_only requires a scoped detached spawn "
-                    "(skip_permissions + VNX_WORKER_SCOPED!=0); refusing unscoped "
-                    "dispatch where the commit/push deny would not bind"
+                    "(skip_permissions + explicit VNX_WORKER_SCOPED=1; scoped is "
+                    "opt-in now that blanket skip-permissions is the default); "
+                    "refusing unscoped dispatch where the commit/push deny would not bind"
                 ),
             )
 

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -138,18 +138,21 @@ def generate_claude_settings(profile: PermissionProfile) -> dict:
 
 
 def worker_scoped_enabled() -> bool:
-    """Whether headless workers spawn with scoped capabilities (default ON).
+    """Whether headless workers spawn with scoped capabilities (default OFF).
 
-    Returns True unless ``VNX_WORKER_SCOPED`` is explicitly set to a falsey value
-    (``0`` / ``false`` / ``no`` / ``off``). The falsey setting restores the legacy
-    ``--dangerously-skip-permissions`` posture — emergency rollback only, since it
-    re-opens the full ambient-MCP blast radius.
+    Tmux-spawn workers run in an isolated per-dispatch worktree, so the scoped
+    allow-list only stalls autonomous builds on prompts for un-allow-listed ops
+    (skills/ writes, mkdir, rm) without adding real blast-radius protection.
+    Returns False (blanket ``--dangerously-skip-permissions``) unless
+    ``VNX_WORKER_SCOPED`` is explicitly set to a truthy value (``1`` / ``true`` /
+    ``yes`` / ``on``), which opts back into the scoped posture (role allow-list +
+    empty ambient MCP).
     """
-    return os.environ.get("VNX_WORKER_SCOPED", "1").strip().lower() not in (
-        "0",
-        "false",
-        "no",
-        "off",
+    return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
     )
 
 

--- a/tests/test_worker_capability_scoping.py
+++ b/tests/test_worker_capability_scoping.py
@@ -1,17 +1,23 @@
 #!/usr/bin/env python3
-"""Tests for the INTERIM worker capability-scoping fix.
+"""Tests for worker capability scoping.
 
-Per WORKER-CAPABILITY-SCOPING-DESIGN.md §5: ephemeral workers must spawn WITHOUT
-``--dangerously-skip-permissions`` and WITHOUT ambient MCP, while remaining fully
-functional code workers (Read/Write/Edit/Bash/Glob/Grep + git).
+Per operator decision (2026-07-05): tmux-spawn workers run in an isolated
+per-dispatch worktree, so the scoped allow-list only stalls autonomous builds
+on prompts for un-allow-listed ops. The default is now the blanket
+``--dangerously-skip-permissions``; the scoped posture (WITHOUT
+``--dangerously-skip-permissions`` and WITHOUT ambient MCP, while remaining a
+fully functional code worker: Read/Write/Edit/Bash/Glob/Grep + git) is opt-in
+via ``VNX_WORKER_SCOPED=1``.
 
 Covers:
   1. generate_claude_settings(default_profile) yields the code-worker allow-list
   2. build_claude_scope_args() — empty MCP, acceptEdits, allow/deny lists, no skip flag
-  3. SubprocessAdapter.deliver() spawn argv: empty MCP, no skip-permissions
+  3. SubprocessAdapter.deliver() spawn argv: blanket skip-permissions by default,
+     scoped (empty MCP, no skip-permissions) opt-in via VNX_WORKER_SCOPED=1
   4. resolve_worker_profile() fallback for unknown / empty roles
-  5. VNX_WORKER_SCOPED=0 feature flag restores the legacy skip-permissions posture
-  6. tmux _default_launch_command() detached spawn is scoped (no skip flag by default)
+  5. VNX_WORKER_SCOPED=1 feature flag opts into the scoped posture
+  6. tmux _default_launch_command() detached spawn is blanket by default (skip
+     flag present); VNX_WORKER_SCOPED=1 opts into the scoped posture
   7. negative-path: empty profile yields a still-valid scope argv
 """
 
@@ -158,7 +164,7 @@ class TestResolveWorkerProfile:
 # ---------------------------------------------------------------------------
 
 class TestDeliverSpawnArgv:
-    def test_argv_has_empty_mcp_and_no_skip_permissions(self):
+    def test_argv_has_skip_permissions_by_default(self):
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
@@ -167,12 +173,11 @@ class TestDeliverSpawnArgv:
 
         assert cmd[0] == "claude"
         assert "-p" in cmd
-        assert SKIP_FLAG not in cmd, "skip-permissions must be gone for the default worker"
-        assert "--strict-mcp-config" in cmd
-        idx = cmd.index("--mcp-config")
-        assert json.loads(cmd[idx + 1]) == {"mcpServers": {}}
+        assert SKIP_FLAG in cmd, "blanket skip-permissions is the default worker posture"
+        assert "--strict-mcp-config" not in cmd
 
-    def test_argv_keeps_functional_code_worker_tools(self):
+    def test_argv_keeps_functional_code_worker_tools_when_scoped(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
@@ -182,11 +187,14 @@ class TestDeliverSpawnArgv:
         allowed = set(cmd[allow_idx + 1].split(","))
         assert CODE_WORKER_ESSENTIALS.issubset(allowed)
 
-    def test_instruction_precedes_variadic_scope_flags(self):
+    def test_instruction_precedes_variadic_scope_flags_when_scoped(self, monkeypatch):
         # Regression: --allowedTools / --disallowedTools are variadic (<tools...>).
         # If the instruction is appended AFTER them it is swallowed as a tool value,
         # leaving claude --print with no prompt -> "Input must be provided" -> exit 1.
-        # The prompt must therefore come BEFORE the scope flags.
+        # The prompt must therefore come BEFORE the scope flags. Only relevant in
+        # the scoped posture (VNX_WORKER_SCOPED=1) — the blanket default has no
+        # variadic scope flags to be swallowed by.
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
@@ -201,15 +209,15 @@ class TestDeliverSpawnArgv:
         if "--disallowedTools" in cmd:
             assert instr_idx < cmd.index("--disallowedTools")
 
-    def test_feature_flag_off_restores_skip_permissions(self, monkeypatch):
-        monkeypatch.setenv("VNX_WORKER_SCOPED", "0")
+    def test_feature_flag_on_enables_scoping(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
             adapter.deliver("T1", "dispatch-cap-4", instruction="do work")
         cmd = mock_popen.call_args[0][0]
-        assert SKIP_FLAG in cmd
-        assert "--strict-mcp-config" not in cmd
+        assert SKIP_FLAG not in cmd
+        assert "--strict-mcp-config" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -217,12 +225,12 @@ class TestDeliverSpawnArgv:
 # ---------------------------------------------------------------------------
 
 class TestTmuxDetachedSpawn:
-    def test_detached_default_is_scoped(self):
+    def test_detached_default_is_blanket(self):
         cmd = _default_launch_command("sonnet", skip_permissions=True)
-        assert SKIP_FLAG not in cmd
-        assert "--strict-mcp-config" in cmd
-        assert "--permission-mode acceptEdits" in cmd
-        assert '{"mcpServers":{}}' in cmd
+        assert SKIP_FLAG in cmd
+        assert "--strict-mcp-config" not in cmd
+        assert "--permission-mode acceptEdits" not in cmd
+        assert '{"mcpServers":{}}' not in cmd
 
     def test_attached_run_unchanged(self):
         cmd = _default_launch_command("sonnet", skip_permissions=False)
@@ -230,11 +238,11 @@ class TestTmuxDetachedSpawn:
         assert "--strict-mcp-config" not in cmd
         assert cmd == "source ~/.zshrc 2>/dev/null; claude --model sonnet"
 
-    def test_detached_flag_off_restores_skip(self, monkeypatch):
-        monkeypatch.setenv("VNX_WORKER_SCOPED", "0")
+    def test_detached_flag_on_enables_scoping(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         cmd = _default_launch_command("sonnet", skip_permissions=True)
-        assert SKIP_FLAG in cmd
-        assert "--strict-mcp-config" not in cmd
+        assert SKIP_FLAG not in cmd
+        assert "--strict-mcp-config" in cmd
 
 
 # ---------------------------------------------------------------------------
@@ -242,9 +250,9 @@ class TestTmuxDetachedSpawn:
 # ---------------------------------------------------------------------------
 
 class TestWorkerScopedEnabled:
-    def test_default_on(self, monkeypatch):
+    def test_default_off(self, monkeypatch):
         monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
-        assert worker_scoped_enabled() is True
+        assert worker_scoped_enabled() is False
 
     @pytest.mark.parametrize("val", ["0", "false", "no", "off", "OFF", "False"])
     def test_falsey_values_disable(self, monkeypatch, val):
@@ -262,14 +270,22 @@ class TestWorkerScopedEnabled:
 # ---------------------------------------------------------------------------
 
 class TestTmuxDetachedNoStall:
-    """Detached worker gets --allowedTools so it can proceed without TTY prompts."""
+    """Detached worker gets the blanket skip flag by default so it can proceed
+    without TTY prompts; VNX_WORKER_SCOPED=1 opts into --allowedTools instead."""
 
-    def test_detached_spawn_has_allowed_tools(self):
+    def test_detached_spawn_has_skip_permissions_by_default(self):
+        cmd = _default_launch_command("sonnet", skip_permissions=True)
+        assert SKIP_FLAG in cmd
+        assert "--allowedTools" not in cmd
+
+    def test_detached_spawn_scoped_has_allowed_tools(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         cmd = _default_launch_command("sonnet", skip_permissions=True)
         assert "--allowedTools" in cmd
         assert SKIP_FLAG not in cmd
 
-    def test_detached_spawn_allowed_tools_cover_code_essentials(self):
+    def test_detached_spawn_scoped_allowed_tools_cover_code_essentials(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         import shlex as _shlex
         cmd = _default_launch_command("sonnet", skip_permissions=True)
         tokens = _shlex.split(cmd)
@@ -278,10 +294,6 @@ class TestTmuxDetachedNoStall:
         assert CODE_WORKER_ESSENTIALS.issubset(allowed), (
             f"essentials missing from --allowedTools: {CODE_WORKER_ESSENTIALS - allowed}"
         )
-
-    def test_detached_spawn_no_dangerously_skip_permissions(self):
-        cmd = _default_launch_command("sonnet", skip_permissions=True)
-        assert SKIP_FLAG not in cmd
 
     def test_attached_spawn_no_allowed_tools_injected(self):
         # Attached (human-in-loop) sessions are unchanged; no allowedTools injected.
@@ -313,7 +325,10 @@ class TestRequiresMcpScoping:
         assert "--permission-mode" in args
         assert "--allowedTools" in args
 
-    def test_adapter_deliver_requires_mcp_false_empties_mcp(self):
+    def test_adapter_deliver_requires_mcp_false_empties_mcp(self, monkeypatch):
+        # requires_mcp threading only applies in the scoped posture — the blanket
+        # default ignores requires_mcp entirely (no MCP args either way).
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:
@@ -323,7 +338,8 @@ class TestRequiresMcpScoping:
         idx = cmd.index("--mcp-config")
         assert json.loads(cmd[idx + 1]) == {"mcpServers": {}}
 
-    def test_adapter_deliver_requires_mcp_true_keeps_mcp(self):
+    def test_adapter_deliver_requires_mcp_true_keeps_mcp(self, monkeypatch):
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         adapter = SubprocessAdapter()
         proc = _make_alive_process()
         with patch("subprocess.Popen", return_value=proc) as mock_popen:

--- a/tests/test_working_tree_only.py
+++ b/tests/test_working_tree_only.py
@@ -4,10 +4,14 @@ Two layers:
   - the SLOT: build_claude_scope_args / _default_launch_command emit a
     `--disallowedTools Bash(git commit...)/Bash(git push...)` deny when
     working_tree_only=True (the commit/push deny binds at the tool-permission
-    layer, not just the instruction preamble).
+    layer, not just the instruction preamble). This only binds in the scoped
+    posture (VNX_WORKER_SCOPED=1) since the blanket default carries no
+    allow/deny lists at all.
   - the SCOPING PRECONDITION (fail-closed): TmuxInteractiveDispatch.dispatch
-    rejects a working_tree_only dispatch on any unscoped path (attached, or
-    VNX_WORKER_SCOPED=0) where the deny would not bind.
+    rejects a working_tree_only dispatch on any unscoped path (attached, the
+    blanket default with VNX_WORKER_SCOPED unset, or explicit
+    VNX_WORKER_SCOPED=0) where the deny would not bind. Only an explicit
+    VNX_WORKER_SCOPED=1 satisfies the precondition.
 """
 
 from __future__ import annotations
@@ -60,7 +64,11 @@ class TestGitDenySlot:
         assert "git push" not in joined
         assert "git commit" not in joined
 
-    def test_launch_command_includes_git_deny(self):
+    def test_launch_command_includes_git_deny(self, monkeypatch):
+        # The git-commit/push deny only binds in the scoped posture (it rides on
+        # --disallowedTools inside build_claude_scope_args); the blanket default
+        # ignores working_tree_only entirely, so opt into scoping explicitly.
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
         cmd = tid._default_launch_command(
             "sonnet", skip_permissions=True, working_tree_only=True
         )
@@ -88,8 +96,9 @@ class TestScopingPrecondition:
         assert "working_tree_only" in (result.failure_reason or "")
 
     def test_unscoped_env_working_tree_only_is_rejected(self, tmp_path, monkeypatch):
-        # Detached but VNX_WORKER_SCOPED=0 -> legacy --dangerously-skip-permissions,
-        # no scope args -> the deny would not bind -> reject.
+        # Detached but VNX_WORKER_SCOPED=0 (explicit-off, same posture as the
+        # default) -> blanket --dangerously-skip-permissions, no scope args ->
+        # the deny would not bind -> reject.
         monkeypatch.setenv("VNX_WORKER_SCOPED", "0")
         lane = _lane(tmp_path)
         result = lane.dispatch(
@@ -97,6 +106,32 @@ class TestScopingPrecondition:
         )
         assert result.success is False
         assert "working_tree_only" in (result.failure_reason or "")
+
+    def test_default_env_working_tree_only_is_rejected(self, tmp_path, monkeypatch):
+        # Detached with VNX_WORKER_SCOPED unset -> the new blanket-by-default
+        # posture -> no scope args -> the deny would not bind -> reject. Only an
+        # explicit VNX_WORKER_SCOPED=1 satisfies the precondition.
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        lane = _lane(tmp_path)
+        result = lane.dispatch(
+            "noop", "wt-default-unscoped", working_tree_only=True, skip_permissions=True,
+        )
+        assert result.success is False
+        assert "working_tree_only" in (result.failure_reason or "")
+
+    def test_scoped_opt_in_working_tree_only_is_accepted_by_precondition(
+        self, tmp_path, monkeypatch
+    ):
+        # Detached with VNX_WORKER_SCOPED=1 satisfies the precondition (the
+        # scoping check itself passes; dispatch may still fail later for other
+        # reasons such as the stub runner/tmux plumbing — the precondition
+        # message must simply not be the failure reason).
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
+        lane = _lane(tmp_path)
+        result = lane.dispatch(
+            "noop", "wt-scoped", working_tree_only=True, skip_permissions=True,
+        )
+        assert "working_tree_only requires" not in (result.failure_reason or "")
 
     def test_non_working_tree_only_attached_is_not_rejected_by_precondition(self, tmp_path):
         # A normal attached dispatch must NOT be rejected by the wt-only precondition.


### PR DESCRIPTION
Operator decision (Vincent, 2026-07-05): tmux-spawn workers run in an isolated per-dispatch worktree, so the scoped allow-list only stalled autonomous builds on prompts (skills/, mkdir, rm). Flip worker_scoped_enabled() default to blanket; VNX_WORKER_SCOPED=1 opts back into scoped (required for working_tree_only). Both defns + the 2 test files updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC