### PR TITLE
feat(dispatch): configurable tmux-spawn concurrency via VNX_TMUX_MAX_CONCURRENT (N-slot semaphore)

### DIFF
--- a/scripts/lib/dispatch_serialization.py
+++ b/scripts/lib/dispatch_serialization.py
@@ -1,7 +1,17 @@
-"""dispatch_serialization.py — Claude subscription serial lock (PR-6).
+"""dispatch_serialization.py — Claude subscription N-slot serial lock (PR-6 + tmux-concurrency-config).
 
 serialize_lane(serialization_class) context manager: serializes the claude-tmux
-lane (one at a time per account); provider + headless lanes pass None -> no-op.
+lane to at most N concurrent holders per account; provider + headless lanes
+pass None -> no-op.
+
+The serial lock protects the Claude SUBSCRIPTION, not a resource. Running
+multiple subscription-authenticated `claude` processes concurrently risks
+rate-limits and (per prior-incident precedent) account action. Default
+concurrency is 1 (fully serial, the historically-safe behavior). An operator
+who accepts that trade-off may opt in to more headroom via
+VNX_TMUX_MAX_CONCURRENT — e.g. =3 to run three tmux-spawn workers at once.
+This is an explicit, informed opt-in: raising it is the operator's call, not
+a default the code should creep towards.
 
 Lock is account-level: $VNX_LOCK_DIR or ~/.vnx-data/locks — shared across all
 projects and worktrees that use the same Claude subscription.
@@ -18,7 +28,7 @@ import os
 import time
 from contextlib import contextmanager
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional
 
 try:
     import fcntl
@@ -56,8 +66,49 @@ def _timeout_seconds() -> float:
         return 0.0
 
 
+def _max_concurrent() -> int:
+    """N-slot concurrency limit for the claude-tmux lane.
+
+    VNX_TMUX_MAX_CONCURRENT, clamped to >= 1. Missing, unparseable, zero, or
+    negative values fall back to 1 -- the subscription-safe default. Only a
+    valid positive integer opts into more than one concurrent slot.
+    """
+    raw = os.environ.get("VNX_TMUX_MAX_CONCURRENT", "1")
+    try:
+        n = int(raw)
+    except (ValueError, TypeError):
+        return 1
+    return n if n >= 1 else 1
+
+
 def _iso_now() -> str:
     return datetime.datetime.now(datetime.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# Slot path helpers
+# ---------------------------------------------------------------------------
+
+def _slot_lock_paths(lock_dir: Path, serialization_class: str, n: int) -> List[Path]:
+    """N per-slot lock file paths: <lock_dir>/<class>-slot-<0..n-1>.lock."""
+    return [lock_dir / f"{serialization_class}-slot-{i}.lock" for i in range(n)]
+
+
+def _slot_glob_pattern(serialization_class: str) -> str:
+    return f"{serialization_class}-slot-*.lock"
+
+
+def _describe_holder(lock_path: Path) -> str:
+    try:
+        raw = lock_path.read_text(encoding="utf-8")
+        holder = json.loads(raw)
+        return (
+            f"{lock_path.name}: pid={holder.get('pid')}, "
+            f"dispatch_id={holder.get('dispatch_id')!r}, "
+            f"since={holder.get('timestamp')}"
+        )
+    except Exception:
+        return f"{lock_path.name}: unknown holder (lock file unreadable)"
 
 
 # ---------------------------------------------------------------------------
@@ -67,15 +118,32 @@ def _iso_now() -> str:
 _POLL_INTERVAL = 0.2  # seconds between LOCK_NB retries
 
 
-def _acquire_with_warn(
-    fd: int,
-    lock_path: Path,
-    dispatch_id: Optional[str],
-) -> None:
-    """Acquire LOCK_EX on fd with wait-warn and optional hard timeout.
+def _try_acquire_any_slot(fds: List[int]) -> Optional[int]:
+    """Try each slot fd non-blocking in turn; return the index of the first
+    slot successfully locked, or None if all slots are currently held.
 
-    Polls with LOCK_NB so we can emit a warning after warn_seconds and enforce
-    an optional hard ceiling without relying on SIGALRM (thread-unsafe).
+    Any OSError whose errno is NOT a contention errno (e.g. EBADF) is a real
+    fd error and is re-raised immediately rather than treated as "busy".
+    """
+    for idx, fd in enumerate(fds):
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            return idx
+        except OSError as exc:
+            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES):
+                raise
+    return None
+
+
+def _acquire_any_slot_with_warn(
+    fds: List[int],
+    lock_paths: List[Path],
+    serialization_class: str,
+    dispatch_id: Optional[str],
+) -> int:
+    """Acquire the first free slot among fds, with wait-warn and optional
+    hard timeout. Polls ALL slots each interval (not just slot 0) so whichever
+    holder releases first is grabbed immediately.
     """
     warn_secs = _warn_seconds()
     timeout_secs = _timeout_seconds()
@@ -83,33 +151,20 @@ def _acquire_with_warn(
     warned = False
 
     while True:
-        try:
-            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
-            return  # acquired
-        except OSError as exc:
-            # Only contention errnos mean "still locked — keep polling".
-            # Any other errno (e.g. EBADF) is a real fd error; re-raise immediately.
-            if exc.errno not in (errno.EWOULDBLOCK, errno.EAGAIN, errno.EACCES):
-                raise
+        idx = _try_acquire_any_slot(fds)
+        if idx is not None:
+            return idx
 
         elapsed = time.monotonic() - start
 
         if not warned and elapsed >= warn_secs:
-            try:
-                raw = lock_path.read_text(encoding="utf-8")
-                holder = json.loads(raw)
-                holder_info = (
-                    f"pid={holder.get('pid')}, "
-                    f"dispatch_id={holder.get('dispatch_id')!r}, "
-                    f"since={holder.get('timestamp')}"
-                )
-            except Exception:
-                holder_info = "unknown holder (lock file unreadable)"
+            holder_info = "; ".join(_describe_holder(p) for p in lock_paths)
             logger.warning(
-                "[dispatch_serialization] WAITING for %s serial lock "
-                "— held by %s (%.0fs elapsed) — still waiting; "
+                "[dispatch_serialization] WAITING for a free %s slot "
+                "(all %d busy) — %s (%.0fs elapsed) — still waiting; "
                 "use --force-release-lock to clear a stale lock",
-                lock_path.name,
+                serialization_class,
+                len(fds),
                 holder_info,
                 elapsed,
             )
@@ -117,8 +172,9 @@ def _acquire_with_warn(
 
         if timeout_secs > 0 and elapsed >= timeout_secs:
             raise TimeoutError(
-                f"claude-tmux serial lock not acquired within {timeout_secs:.0f}s "
-                f"(elapsed {elapsed:.0f}s); "
+                f"{serialization_class} serial lock: no free slot within "
+                f"{timeout_secs:.0f}s (elapsed {elapsed:.0f}s, "
+                f"{len(fds)} slot(s) all busy); "
                 f"use --force-release-lock to clear a stale lock"
             )
 
@@ -135,16 +191,19 @@ def serialize_lane(
     *,
     dispatch_id: Optional[str] = None,
 ):
-    """Serialize execution for the given serialization_class.
+    """Serialize execution for the given serialization_class across N slots.
 
     None -> no-op: yield immediately, touch nothing (providers + headless).
-    "claude-tmux" -> acquire exclusive flock on <lock_dir>/claude-tmux.lock
-    and hold it through the entire with-body (execution + receipt/GOVERN).
-    Lock is released unconditionally in finally, including on exception.
-    flock auto-releases on process death; no manual stale-lock cleanup needed.
+    "claude-tmux" -> acquire the first free slot among N exclusive flocks on
+    <lock_dir>/claude-tmux-slot-{0..N-1}.lock (N = VNX_TMUX_MAX_CONCURRENT,
+    default 1) and hold it through the entire with-body (execution +
+    receipt/GOVERN). The acquired slot is released unconditionally in
+    finally, including on exception. flock auto-releases on process death;
+    no manual stale-lock cleanup needed.
 
-    Note: flock is NOT reentrant in the same process for the same inode. A nested
-    serialize_lane("claude-tmux") within the same process self-deadlocks. This is
+    Note: flock is NOT reentrant in the same process for the same inode. A
+    nested serialize_lane("claude-tmux") within the same process can self
+    -deadlock once all N slots are exhausted by the outer call(s). This is
     intentional for VNX's separate-process dispatch model — do not nest.
 
     Note: advisory flock() over NFS may not serialize across all client/kernel
@@ -164,12 +223,18 @@ def serialize_lane(
     lock_dir = _lock_dir()
     lock_dir.mkdir(parents=True, exist_ok=True)
     lock_dir.chmod(0o700)  # account-level lock dir must not be other-user writable
-    lock_path = lock_dir / f"{serialization_class}.lock"
 
-    fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+    n = _max_concurrent()
+    lock_paths = _slot_lock_paths(lock_dir, serialization_class, n)
+
+    fds: List[int] = []
     try:
-        os.fchmod(fd, 0o600)  # tighten existing file if it had lax permissions
-        _acquire_with_warn(fd, lock_path, dispatch_id)
+        for lock_path in lock_paths:
+            fd = os.open(str(lock_path), os.O_RDWR | os.O_CREAT, 0o600)
+            os.fchmod(fd, 0o600)  # tighten existing file if it had lax permissions
+            fds.append(fd)
+
+        idx = _acquire_any_slot_with_warn(fds, lock_paths, serialization_class, dispatch_id)
 
         # Write holder metadata for diagnostics + wait-warn + force-release.
         # Written AFTER acquiring so only the true current holder is recorded.
@@ -178,61 +243,69 @@ def serialize_lane(
             "dispatch_id": dispatch_id,
             "timestamp": _iso_now(),
         }
-        os.ftruncate(fd, 0)
-        os.lseek(fd, 0, os.SEEK_SET)
-        os.write(fd, json.dumps(metadata).encode("utf-8"))
+        os.ftruncate(fds[idx], 0)
+        os.lseek(fds[idx], 0, os.SEEK_SET)
+        os.write(fds[idx], json.dumps(metadata).encode("utf-8"))
 
         try:
             yield
         finally:
-            fcntl.flock(fd, fcntl.LOCK_UN)
+            fcntl.flock(fds[idx], fcntl.LOCK_UN)
     finally:
-        os.close(fd)
+        for fd in fds:
+            os.close(fd)
 
 
 def force_release(serialization_class: str = "claude-tmux") -> None:
-    """Operator escape: print holder metadata and remove the lock file.
+    """Operator escape: print holder metadata and remove ALL slot lock files
+    for this class (glob <lock_dir>/<class>-slot-*.lock).
 
-    Checks whether the holder process is still alive BEFORE removing:
-    - If ALIVE: prints a LOUD double-run warning and proceeds with removal.
+    Every matching slot file is inspected independently. For each:
+    - If holder ALIVE: prints a LOUD double-run warning and proceeds with removal.
       A new acquire on a fresh inode can then run concurrently with the
       original holder — true parallel double-run. Only use when the holder
       is genuinely hung and not making progress.
-    - If DEAD: notes the holder is gone (flock auto-released) and removal is safe.
+    - If holder DEAD: notes the holder is gone (flock auto-released) and removal is safe.
     - If pid unreadable: removes without liveness check.
 
-    Does NOT kill the holder process. After removal, a new acquire succeeds immediately.
+    Does NOT kill any holder process. After removal, new acquires succeed immediately.
 
-    WARNING: force-releasing a LIVE holder allows two claude-tmux dispatches to run
+    WARNING: force-releasing a LIVE holder allows another claude-tmux dispatch to run
     concurrently (double-run). The flock on the old (now-unlinked) inode remains held
     by the original process while a new dispatch acquires a lock on a fresh inode.
     """
     lock_dir = _lock_dir()
-    lock_path = lock_dir / f"{serialization_class}.lock"
+    pattern = _slot_glob_pattern(serialization_class)
+    slot_paths = sorted(lock_dir.glob(pattern))
 
-    if not lock_path.exists():
-        print(f"[force-release] No lock file found: {lock_path}")
+    if not slot_paths:
+        print(f"[force-release] No lock files found matching: {lock_dir / pattern}")
         print("[force-release] No stale lock to clear.")
         return
 
+    for lock_path in slot_paths:
+        _force_release_one(lock_path)
+
+
+def _force_release_one(lock_path: Path) -> None:
     holder_pid = None
     try:
         raw = lock_path.read_text(encoding="utf-8")
         holder = json.loads(raw)
         holder_pid = holder.get("pid")
-        print(f"[force-release] Prior holder metadata: {holder}")
+        print(f"[force-release] Prior holder metadata ({lock_path.name}): {holder}")
         print(f"[force-release]   pid          = {holder.get('pid')}")
         print(f"[force-release]   dispatch_id  = {holder.get('dispatch_id')}")
         print(f"[force-release]   timestamp    = {holder.get('timestamp')}")
     except Exception as exc:
-        print(f"[force-release] Could not read holder metadata: {exc}")
+        print(f"[force-release] Could not read holder metadata ({lock_path.name}): {exc}")
 
     if holder_pid is not None:
         try:
             os.kill(holder_pid, 0)
             # No exception -> process is alive
             print(
-                f"WARNING: holder pid {holder_pid} is STILL ALIVE. "
+                f"WARNING: holder pid {holder_pid} ({lock_path.name}) is STILL ALIVE. "
                 "Force-releasing now will let a SECOND claude-tmux dispatch run "
                 "in PARALLEL with it (double-run). Only do this if that process "
                 "is hung/not-progressing."
@@ -242,10 +315,10 @@ def force_release(serialization_class: str = "claude-tmux") -> None:
         except PermissionError:
             # Process exists but belongs to another user
             print(
-                f"WARNING: holder pid {holder_pid} is STILL ALIVE (owned by another user). "
-                "Force-releasing now will let a SECOND claude-tmux dispatch run "
-                "in PARALLEL with it (double-run). Only do this if that process "
-                "is hung/not-progressing."
+                f"WARNING: holder pid {holder_pid} ({lock_path.name}) is STILL ALIVE "
+                "(owned by another user). Force-releasing now will let a SECOND "
+                "claude-tmux dispatch run in PARALLEL with it (double-run). Only do "
+                "this if that process is hung/not-progressing."
             )
 
     lock_path.unlink(missing_ok=True)

--- a/tests/test_dispatch_serialization.py
+++ b/tests/test_dispatch_serialization.py
@@ -59,6 +59,91 @@ def test_parallel_claude_serializes(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# test_three_slots_concurrent_fourth_blocks
+# ---------------------------------------------------------------------------
+
+def test_three_slots_concurrent_fourth_blocks(tmp_path, monkeypatch):
+    """VNX_TMUX_MAX_CONCURRENT=3: three concurrent holders run simultaneously;
+    a fourth waiter blocks until one of the three releases."""
+    monkeypatch.setenv("VNX_LOCK_DIR", str(tmp_path / "locks"))
+    monkeypatch.setenv("VNX_TMUX_MAX_CONCURRENT", "3")
+
+    concurrent_count = 0
+    max_concurrent_seen = 0
+    count_lock = threading.Lock()
+    release_gate = threading.Event()  # holds the first 3 workers inside the body
+    fourth_entered = threading.Event()
+    errors = []
+
+    def holder_worker(idx):
+        nonlocal concurrent_count, max_concurrent_seen
+        try:
+            with serialize_lane("claude-tmux", dispatch_id=f"holder-{idx}"):
+                with count_lock:
+                    concurrent_count += 1
+                    max_concurrent_seen = max(max_concurrent_seen, concurrent_count)
+                release_gate.wait(timeout=5)
+                with count_lock:
+                    concurrent_count -= 1
+        except Exception as exc:
+            errors.append((f"holder-{idx}", exc))
+
+    def fourth_worker():
+        try:
+            with serialize_lane("claude-tmux", dispatch_id="fourth"):
+                fourth_entered.set()
+        except Exception as exc:
+            errors.append(("fourth", exc))
+
+    holders = [threading.Thread(target=holder_worker, args=(i,)) for i in range(3)]
+    for t in holders:
+        t.start()
+
+    # Wait until all three holders are confirmed inside the body.
+    deadline = time.monotonic() + 5
+    while time.monotonic() < deadline and concurrent_count < 3:
+        time.sleep(0.02)
+    assert concurrent_count == 3, "three holders did not all acquire concurrently"
+
+    fourth = threading.Thread(target=fourth_worker)
+    fourth.start()
+    # Fourth must NOT enter while all 3 slots are held.
+    assert not fourth_entered.wait(timeout=0.3), "fourth acquired before a slot freed"
+
+    release_gate.set()  # let the three holders release
+    for t in holders:
+        t.join(timeout=5)
+    fourth.join(timeout=5)
+
+    assert not errors, f"unexpected errors: {errors}"
+    assert max_concurrent_seen == 3, f"expected 3 concurrent holders, saw {max_concurrent_seen}"
+    assert fourth_entered.is_set(), "fourth waiter never acquired after a slot freed"
+
+
+# ---------------------------------------------------------------------------
+# test_max_concurrent clamping + defaults
+# ---------------------------------------------------------------------------
+
+def test_max_concurrent_defaults_to_one(monkeypatch):
+    """No VNX_TMUX_MAX_CONCURRENT set -> default concurrency is 1 (subscription-safe)."""
+    monkeypatch.delenv("VNX_TMUX_MAX_CONCURRENT", raising=False)
+    assert _ds_mod._max_concurrent() == 1
+
+
+def test_max_concurrent_accepts_valid_positive_value(monkeypatch):
+    """A valid positive integer is used verbatim."""
+    monkeypatch.setenv("VNX_TMUX_MAX_CONCURRENT", "3")
+    assert _ds_mod._max_concurrent() == 3
+
+
+@pytest.mark.parametrize("raw_value", ["0", "-1", "-100", "x", ""])
+def test_max_concurrent_clamps_bad_values(raw_value, monkeypatch):
+    """0, negative, or unparseable VNX_TMUX_MAX_CONCURRENT falls back to 1."""
+    monkeypatch.setenv("VNX_TMUX_MAX_CONCURRENT", raw_value)
+    assert _ds_mod._max_concurrent() == 1
+
+
+# ---------------------------------------------------------------------------
 # test_provider_lanes_stay_parallel
 # ---------------------------------------------------------------------------
 
@@ -171,7 +256,7 @@ def test_force_release(tmp_path, monkeypatch, capsys):
 
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_dir / "claude-tmux.lock"
+    lock_file = lock_dir / "claude-tmux-slot-0.lock"
 
     # Write a stale lock file — simulates a prior holder whose process exited
     # without releasing (or whose pid no longer exists).
@@ -219,11 +304,11 @@ def test_lock_dir_is_account_level(tmp_path, monkeypatch):
 
     with serialize_lane("claude-tmux", dispatch_id="dir-scope-test"):
         # Lock file must be in VNX_LOCK_DIR
-        assert (account_lock_dir / "claude-tmux.lock").exists(), (
+        assert (account_lock_dir / "claude-tmux-slot-0.lock").exists(), (
             "lock file not created in VNX_LOCK_DIR"
         )
         # Lock file must NOT be in VNX_DATA_DIR
-        assert not (project_data_dir / "claude-tmux.lock").exists(), (
+        assert not (project_data_dir / "claude-tmux-slot-0.lock").exists(), (
             "lock file incorrectly created in project VNX_DATA_DIR"
         )
 
@@ -247,7 +332,7 @@ def test_force_release_warns_on_live_holder(tmp_path, monkeypatch, capsys):
 
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_dir / "claude-tmux.lock"
+    lock_file = lock_dir / "claude-tmux-slot-0.lock"
 
     # Current pid is guaranteed alive
     live_meta = {
@@ -277,7 +362,7 @@ def test_force_release_dead_holder_no_warning(tmp_path, monkeypatch, capsys):
 
     lock_dir = tmp_path / "locks"
     lock_dir.mkdir(parents=True, exist_ok=True)
-    lock_file = lock_dir / "claude-tmux.lock"
+    lock_file = lock_dir / "claude-tmux-slot-0.lock"
 
     dead_meta = {
         "pid": 999999,  # safely outside any realistic PID range on macOS/Linux


### PR DESCRIPTION
Operator request (Vincent, 2026-07-05): make concurrent tmux-spawn subscription-claude workers configurable. Replaces the single exclusive claude-tmux lock with an N-slot counting semaphore; N=VNX_TMUX_MAX_CONCURRENT (default 1, subscription-safe). Protects the subscription (concurrent claudes risk rate-limits); N>1 is an operator opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC