### PR TITLE
docs(intelligence): sweep to shipped reality (#1001-1018)

### DIFF
--- a/docs/SCRIPTS_INDEX.md
+++ b/docs/SCRIPTS_INDEX.md
@@ -85,6 +85,8 @@ Primary intelligence/governance scripts:
 
 Related docs:
 
+- `docs/intelligence/SELF_LEARNING_LOOP.md`
+- `docs/intelligence/SCOUT_PREPASS.md`
 - `docs/intelligence/TAG_TAXONOMY.md`
 - `docs/intelligence/COST_TRACKING_GUIDE.md`
 - `docs/core/technical/INTELLIGENCE_SYSTEM.md`

--- a/docs/intelligence/SCOUT_PREPASS.md
+++ b/docs/intelligence/SCOUT_PREPASS.md
@@ -69,11 +69,14 @@ whole body in `try/except Exception` — "best-effort — NEVER raises" per its 
 |------|---------|------------|------|
 | `VNX_SCOUT_PREPASS` | `"0"` (off), category `intelligence` | `scout_prepass_enabled()` reads it through `config_runtime.get_bool()` — honours an operator dashboard/DB toggle, falls back to env, falls back to the registry default | `scripts/lib/config_registry.py:51-53`, `scripts/lib/scout_prepass.py:268-272` |
 
-**Current state for `vnx-dev`**: the registry default stays `"0"` — this is a per-project operator
-decision, not a code default change. The `project_config` DB row shows:
+**Current state for `vnx-dev`**: the registry default stays `"0"` — a per-project operator decision,
+not a code default change. The operator has flipped this flag ON for `vnx-dev` through the config
+control-plane (a `project_config` row with `config_value=1`). Runtime config is operator-flippable,
+so the live table is the source of truth rather than this doc:
 
 ```
-project_id=vnx-dev  config_key=VNX_SCOUT_PREPASS  config_value=1  updated_by=operator  updated_at=2026-07-05T14:47:57.660Z
+sqlite3 ~/.vnx-data/vnx-dev/state/runtime_coordination.db \
+  "SELECT config_key, config_value FROM project_config"
 ```
 
 A fresh `vnx init` project starts with scout OFF, exactly like every other intelligence flag in the
@@ -204,7 +207,7 @@ documented in [`TAG_TAXONOMY.md`](TAG_TAXONOMY.md).
 | `maybe_run_scout()` — opt-in, gated, never raises | `scripts/lib/scout_prepass.py:419-453` |
 | `scout_prepass_enabled()` reads `VNX_SCOUT_PREPASS` via `config_runtime` | `scripts/lib/scout_prepass.py:268-272` |
 | `VNX_SCOUT_PREPASS` registry default `"0"`, category `intelligence` | `scripts/lib/config_registry.py:51-53` |
-| Per-project operator override (`vnx-dev` = `1` since 2026-07-05) | `runtime_coordination.db: project_config` table |
+| Per-project operator override (operator-flippable; check the live table for current value) | `runtime_coordination.db: project_config` table |
 | `_scout_gate_ok()` — scope/lane/task_class gate | `scripts/lib/scout_prepass.py:285-304` |
 | `VNX_SCOUT_PROVIDER` / `VNX_SCOUT_MIN_PATHS` read via raw env (not `config_runtime`) | `scripts/lib/scout_prepass.py:275-282, 293` |
 | Provider allowlist — never a subscription lane | `scripts/lib/scout_prepass.py:265` |
@@ -224,5 +227,5 @@ documented in [`TAG_TAXONOMY.md`](TAG_TAXONOMY.md).
 
 ---
 
-*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017 drift-brief).*
+*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1018 drift-brief).*
 *Dispatch-ID: D-docs-intelligence*

--- a/docs/intelligence/SCOUT_PREPASS.md
+++ b/docs/intelligence/SCOUT_PREPASS.md
@@ -1,0 +1,228 @@
+# Scout Pre-Pass — Cheap-Model Recon Before the Permit
+
+**Status**: Live, opt-in (`VNX_SCOUT_PREPASS`). Enabled for project `vnx-dev` via the operator
+config DB since 2026-07-05.
+**Ground-truth source**: `scripts/lib/scout_prepass.py` (453 lines) + `scripts/lib/dispatch_cli.py`
+(door wiring) + `scripts/lib/intelligence_sources/scout_sketch.py` (consumer).
+
+---
+
+## What it does
+
+Before a dispatch's permit is issued, a cheap key-auth model ranks the deterministic code-anchor
+candidates for that dispatch into `INCLUDE` / `MAYBE` / `EXCLUDE` verdicts plus a short plan
+sketch. The verdicts are written to a per-dispatch sidecar file. The intelligence selector then
+renders that sidecar as a ranked, pointer-only grounding block injected into the worker's context —
+instead of (or alongside) the raw deterministic anchor list.
+
+This is a **re-ranker over grep-of-5 style deterministic candidates**, not a free-form search: the
+scout model can only rank refs that `code_anchor_finder` already surfaced (anti-hallucination —
+see [Anti-hallucination](#anti-hallucination-snap-to-candidates) below). It never reads or rewrites
+the instruction file, so the permit / `instruction_sha256` TOCTOU contract is untouched.
+
+## Why a sidecar, not an instruction edit
+
+The sidecar is a **separate file keyed by dispatch_id** — `<state_dir>/scout/<dispatch_id>.json`.
+It never mutates the instruction the permit was issued against. Reading it is best-effort and
+fail-open: a missing or malformed sidecar returns `None` and the worker falls back to the
+deterministic `code_anchor` injection it would have gotten anyway.
+
+`scripts/lib/scout_prepass.py:1-33` (module docstring) states the design contract explicitly.
+
+## Producer — wired in the door, before the permit
+
+`scripts/lib/dispatch_cli.py:575-593`, inside `run_dispatch`: after `compile_plan()` succeeds and
+before `issue_permit()`, `maybe_run_scout()` runs (skipped on `dry_run`). It is wrapped in a bare
+`try/except` at the call site — a scout failure can never block the door.
+
+```python
+# scripts/lib/dispatch_cli.py:581-593
+if not dry_run:
+    try:
+        from scout_prepass import maybe_run_scout
+        maybe_run_scout(
+            dispatch_id=plan.dispatch_id,
+            instruction_text=vspec.instruction_text,
+            dispatch_paths=[dp.path for dp in vspec.spec.dispatch_paths],
+            state_dir=state_dir,
+            task_class=getattr(vspec.spec, "task_class", None),
+            lane=plan.lane,
+        )
+    except Exception as exc:
+        logger.debug("[dispatch_cli] scout pre-pass skipped: %s", exc)
+```
+
+`maybe_run_scout()` itself (`scout_prepass.py:419-453`) is the single entry point and wraps its
+whole body in `try/except Exception` — "best-effort — NEVER raises" per its docstring. Internally it:
+
+1. Checks `scout_prepass_enabled()` — bails immediately if off.
+2. Checks `_scout_gate_ok()` — scope/lane/task_class gate (below).
+3. Computes `_candidate_refs()` from `code_anchor_finder.fetch_code_anchors()` — bails if empty.
+4. Resolves `_scout_provider_name()` and builds a bounded prompt (`_build_scout_prompt`).
+5. Calls the model via `_invoke_scout_model()` (the key-auth classifier harness).
+6. Assembles + snaps the verdicts to real candidates (`_assemble_sidecar` → `_snap_refs`).
+7. Writes the sidecar atomically (`write_scout_sidecar` — tmp file + `os.replace`).
+
+## Enable flag
+
+| Flag | Default | Resolution | Code |
+|------|---------|------------|------|
+| `VNX_SCOUT_PREPASS` | `"0"` (off), category `intelligence` | `scout_prepass_enabled()` reads it through `config_runtime.get_bool()` — honours an operator dashboard/DB toggle, falls back to env, falls back to the registry default | `scripts/lib/config_registry.py:51-53`, `scripts/lib/scout_prepass.py:268-272` |
+
+**Current state for `vnx-dev`**: the registry default stays `"0"` — this is a per-project operator
+decision, not a code default change. The `project_config` DB row shows:
+
+```
+project_id=vnx-dev  config_key=VNX_SCOUT_PREPASS  config_value=1  updated_by=operator  updated_at=2026-07-05T14:47:57.660Z
+```
+
+A fresh `vnx init` project starts with scout OFF, exactly like every other intelligence flag in the
+registry. Flip it per-project the same way (dashboard config page, or `VNX_SCOUT_PREPASS=1` env for
+a quick local trial).
+
+## Scope/lane gate — `_scout_gate_ok()`
+
+`scripts/lib/scout_prepass.py:285-304`. Even with the flag on, the scout skips:
+
+- Dispatches touching fewer than `VNX_SCOUT_MIN_PATHS` paths (env, default `2` — `_DEFAULT_MIN_PATHS`, `scout_prepass.py:255`).
+- Instructions shorter than 40 characters (`_MIN_INSTRUCTION_CHARS`, `scout_prepass.py:256`).
+- `task_class` in `{docs_synthesis, channel_response, ops_watchdog}` — `_SKIP_TASK_CLASSES` (`scout_prepass.py:258`): no source to rank.
+- `lane == "claude_headless"` — `_SKIP_LANES` (`scout_prepass.py:261`): the rare API-metered opt-in path; the scout never spends a call there.
+
+**Note**: `VNX_SCOUT_PROVIDER` (`_scout_provider_name`, `scout_prepass.py:275-282`) and
+`VNX_SCOUT_MIN_PATHS` (`scout_prepass.py:293`) are read via plain `os.environ.get`, **not** through
+`config_runtime` — only the top-level enable flag is dashboard-flippable today. Flipping the
+dashboard toggle does not change the provider or the path threshold; those still require an env
+var. This split is intentional (infra-level tuning vs. an operator feature switch) but is worth
+knowing if a dashboard flip doesn't change behavior the way you expect.
+
+## Provider allowlist — never a subscription lane
+
+`_ALLOWED_SCOUT_PROVIDERS = frozenset({"deepseek", "ollama", "gemini", "codex"})`
+(`scout_prepass.py:265`). `_scout_provider_name()` default-denies anything outside this set
+(including `haiku`, a subscription lane) and falls back to `deepseek`. This mirrors a hard
+constraint stated directly in the module comments: the scout must NEVER run on a claude/subscription
+lane, only a cheap key-auth classifier lane (`scout_prepass.py:248-253, 259-265`).
+
+## Anti-hallucination: snap-to-candidates
+
+The model receives an exact list of candidate refs and is told "Only use refs from the candidate
+list" (`_build_scout_prompt`, `scout_prepass.py:317-336`). On the way back, `_snap_refs()`
+(`scout_prepass.py:361-382`) discards any verdict whose `ref` is not literally one of the candidate
+strings passed in. A model that invents a file:line range gets silently dropped, not injected.
+
+## Path-containment contract
+
+`_SAFE_DISPATCH_ID = re.compile(r"^[A-Za-z0-9._-]+$")` (`scout_prepass.py:55`) — a kimi-gate finding
+during the original build. A `dispatch_id` becomes a filesystem path segment
+(`<state_dir>/scout/<dispatch_id>.json`), so it is validated before ever touching the filesystem:
+no separators, no `..`, no absolute-path markers. `scout_sidecar_path()` (`scout_prepass.py:82-88`)
+raises `ValueError` on a hostile id; every read-path caller catches this and fails open
+(`read_scout_sidecar`, `scout_prepass.py:99-104`).
+
+## Sidecar schema (v1)
+
+```json
+{
+  "schema_version": 1,
+  "dispatch_id": "<id>",
+  "generated_at": "<ISO8601>",
+  "provider": "deepseek",
+  "model": "deepseek-v4-flash",
+  "include": [{"ref": "scripts/lib/foo.py:10-20", "why": "..."}],
+  "maybe":   [{"ref": "scripts/lib/foo.py:50-60", "why": "..."}],
+  "exclude": [{"ref": "...", "why": "..."}],
+  "tests":   ["tests/test_foo.py"],
+  "docs":    ["docs/foo.md"],
+  "plan_sketch": "one or two line sketch"
+}
+```
+
+(`scout_prepass.py:19-32`). The consumer rejects a sidecar whose `schema_version` doesn't match or
+whose embedded `dispatch_id` doesn't match the one requested (`read_scout_sidecar`,
+`scout_prepass.py:119-129`) — defense against a stale or misplaced file being misread as this
+dispatch's context.
+
+Defensive caps on write and read (both sides apply the same bounds, `scout_prepass.py:76-79`):
+`_MAX_REFS_PER_BUCKET = 8`, `_MAX_AUX_ITEMS = 5`, `_MAX_WHY_CHARS = 120`, `_MAX_PLAN_CHARS = 300`.
+
+## Consumer — `scout_sketch` intelligence source
+
+`scripts/lib/intelligence_sources/scout_sketch.py:21-58` — `build_scout_sketch_item()` reads the
+sidecar for the current dispatch via `read_scout_sidecar()`, renders it with
+`format_scout_sketch()` (bounded to `SCOUT_SKETCH_MAX_CHARS = 1200`, `scout_prepass.py:73`,
+pointer-only — file:line ranges, never code bodies), and returns an `IntelligenceItem` with
+`confidence=1.0` (model-curated recon over deterministic candidates) and `evidence_count` equal to
+the number of ranked pointers (`sidecar_evidence_count`, `scout_prepass.py:181-184`).
+
+`EXCLUDE` verdicts are intentionally never rendered — they only shrink the `INCLUDE` set and would
+add noise a worker shouldn't anchor on (`format_scout_sketch`, `scout_prepass.py:190-192`).
+
+### Selection weight
+
+Registered in `intelligence_selector.py`'s direct-injection source table as the **last** class
+(`_DIRECT_SOURCES`, `intelligence_selector.py:75-86`) — its eviction order is the longest, so it
+survives a budget squeeze over the other direct classes while still being droppable as a last
+resort. Under `VNX_INTEL_RANK_THEN_BUDGET` (see below), its composite-score class weight is
+**1.45** — above `proven_pattern` (1.2) and `prior_round_finding` (1.4), below `failure_prevention`
+(1.5) (`_CLASS_WEIGHT`, `intelligence_selector.py:94-105`).
+
+---
+
+## Rank-then-budget (a related, separately-gated build step)
+
+Scout injection interacts with a second opt-in flag: `VNX_INTEL_RANK_THEN_BUDGET` (default `"0"`,
+`config_registry.py:60-62`). When off (the class-priority default), items are dropped by fixed
+class order until the budget fits. When on, `intelligence_selector._relevance_score()`
+(`intelligence_selector.py:131-146`) replaces that with a composite-score knapsack:
+
+```
+score = confidence * (1 + tag_overlap) * recency_decay * class_weight
+```
+
+- `tag_overlap` — the item's own `scope_tags` plus tags derived on-the-fly from
+  `vnx_tag_vocabulary.derive_tags()` over its title+content, intersected with the query scope
+  (`intelligence_selector.py:138-143`).
+- `recency_decay` — 30-day half-life, floored at `0.3` (`_recency_decay`,
+  `intelligence_selector.py:114-128`): `max(0.3, 0.5 ** (age_days / 30.0))`.
+- `class_weight` — the `_CLASS_WEIGHT` table above.
+- `_RESERVED_CLASSES = frozenset({"failure_prevention"})` (`intelligence_selector.py:106`) gets
+  first claim on the budget regardless of score, so a cheap high-scoring anchor can never evict a
+  critical failure-prevention rule.
+
+Both flags are independent: scout can inject its sketch under the legacy class-priority eviction
+too. Rank-then-budget just changes *which* items survive a tight budget, using the tag vocabulary
+documented in [`TAG_TAXONOMY.md`](TAG_TAXONOMY.md).
+
+---
+
+## Claim-to-code map
+
+| Claim | File:line |
+|-------|-----------|
+| Scout producer wired in the door, before permit issuance, fail-open | `scripts/lib/dispatch_cli.py:575-593` |
+| `maybe_run_scout()` — opt-in, gated, never raises | `scripts/lib/scout_prepass.py:419-453` |
+| `scout_prepass_enabled()` reads `VNX_SCOUT_PREPASS` via `config_runtime` | `scripts/lib/scout_prepass.py:268-272` |
+| `VNX_SCOUT_PREPASS` registry default `"0"`, category `intelligence` | `scripts/lib/config_registry.py:51-53` |
+| Per-project operator override (`vnx-dev` = `1` since 2026-07-05) | `runtime_coordination.db: project_config` table |
+| `_scout_gate_ok()` — scope/lane/task_class gate | `scripts/lib/scout_prepass.py:285-304` |
+| `VNX_SCOUT_PROVIDER` / `VNX_SCOUT_MIN_PATHS` read via raw env (not `config_runtime`) | `scripts/lib/scout_prepass.py:275-282, 293` |
+| Provider allowlist — never a subscription lane | `scripts/lib/scout_prepass.py:265` |
+| Anti-hallucination snap-to-candidates | `scripts/lib/scout_prepass.py:361-382` |
+| Path-containment `_SAFE_DISPATCH_ID` (kimi-gate finding) | `scripts/lib/scout_prepass.py:43-55` |
+| Sidecar schema v1 | `scripts/lib/scout_prepass.py:19-32` |
+| Schema/dispatch-id mismatch rejected on read | `scripts/lib/scout_prepass.py:119-129` |
+| Sidecar defensive caps | `scripts/lib/scout_prepass.py:73-79` |
+| Consumer renders sketch, confidence 1.0, pointer-only | `scripts/lib/intelligence_sources/scout_sketch.py:21-58` |
+| EXCLUDE verdicts never rendered | `scripts/lib/scout_prepass.py:190-192` |
+| `scout_sketch` in direct-injection source table (last, longest eviction order) | `scripts/lib/intelligence_selector.py:75-86` |
+| `scout_sketch` class-weight 1.45 | `scripts/lib/intelligence_selector.py:94-105` |
+| `VNX_INTEL_RANK_THEN_BUDGET` default `"0"` | `scripts/lib/config_registry.py:60-62` |
+| Composite relevance score formula | `scripts/lib/intelligence_selector.py:131-146` |
+| 30-day half-life recency decay, floor 0.3 | `scripts/lib/intelligence_selector.py:114-128` |
+| `_RESERVED_CLASSES = {"failure_prevention"}` | `scripts/lib/intelligence_selector.py:106` |
+
+---
+
+*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017 drift-brief).*
+*Dispatch-ID: D-docs-intelligence*

--- a/docs/intelligence/SCOUT_PREPASS.md
+++ b/docs/intelligence/SCOUT_PREPASS.md
@@ -158,7 +158,8 @@ pointer-only — file:line ranges, never code bodies), and returns an `Intellige
 `confidence=1.0` (model-curated recon over deterministic candidates) and `evidence_count` equal to
 the number of ranked pointers (`sidecar_evidence_count`, `scout_prepass.py:181-184`).
 
-`EXCLUDE` verdicts are intentionally never rendered — they only shrink the `INCLUDE` set and would
+`EXCLUDE` verdicts are intentionally never rendered — they are simply omitted from the sketch
+(nothing removes an `INCLUDE` pointer for also appearing in `EXCLUDE`), since rendering them would
 add noise a worker shouldn't anchor on (`format_scout_sketch`, `scout_prepass.py:190-192`).
 
 ### Selection weight

--- a/docs/intelligence/SELF_LEARNING_LOOP.md
+++ b/docs/intelligence/SELF_LEARNING_LOOP.md
@@ -1,7 +1,7 @@
 # VNX Self-Learning Loop — Operator-Gated Intelligence
 
 **Status**: Active (D1–D6 shipped on main, 2026-07-04). Verified against code again 2026-07-05
-(PRs #1001–#1017 drift-sweep).
+(PRs #1001–#1018 drift-sweep).
 **Related doc**: [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md) covers the scout pre-pass and rank-then-budget
 selection in depth — this doc summarizes rank-then-budget below and defers detail there.
 **Ground truth**: the code modules cited throughout this doc (`scripts/learning_loop.py`,
@@ -257,13 +257,15 @@ These default ON, not off — they are off-switches for sub-steps of the learnin
 ### Current per-project state — `vnx-dev`
 
 The registry defaults above never change (a fresh `vnx init` project starts with every intelligence
-flag OFF). This project's `runtime_coordination.db: project_config` table currently overrides two of
-them, set by the operator through the config control-plane:
+flag OFF). Through the config control-plane the operator has flipped two of them ON for this project
+— `VNX_SCOUT_PREPASS` and `VNX_TAGGER_ENABLED` (both `config_value=1` in
+`runtime_coordination.db: project_config`). Runtime config is operator-flippable, so read the live
+table for the authoritative current state rather than a snapshot here:
 
-| Flag | Value | Updated |
-|------|-------|---------|
-| `VNX_SCOUT_PREPASS` | `1` | 2026-07-05T14:47:57Z |
-| `VNX_TAGGER_ENABLED` | `1` | 2026-07-05T15:35:56Z |
+```
+sqlite3 ~/.vnx-data/vnx-dev/state/runtime_coordination.db \
+  "SELECT config_key, config_value FROM project_config"
+```
 
 The tagger flip followed a `vnx learning tagger-ab` run that observed a 100% rescue rate at
 ~$0.0005/pattern (DeepSeek-Flash) — comfortably past the `rescue_rate >= 20% AND
@@ -407,5 +409,5 @@ Value grows as governed builds resume. The proposal tier is not a no-op even aga
 
 ---
 
-*Doc written 2026-07-05 for D7; updated 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017).*
+*Doc written 2026-07-05 for D7; updated 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1018).*
 *Dispatch-ID: D-docs-intelligence (update); originally D-selfimprove-d7-docs.*

--- a/docs/intelligence/SELF_LEARNING_LOOP.md
+++ b/docs/intelligence/SELF_LEARNING_LOOP.md
@@ -1,7 +1,12 @@
 # VNX Self-Learning Loop — Operator-Gated Intelligence
 
-**Status**: Active (D1–D6 shipped on main, 2026-07-04)
-**Ground-truth source**: `claudedocs/2026-07-04-intelligence-dataflow-MAP.md`
+**Status**: Active (D1–D6 shipped on main, 2026-07-04). Verified against code again 2026-07-05
+(PRs #1001–#1017 drift-sweep).
+**Related doc**: [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md) covers the scout pre-pass and rank-then-budget
+selection in depth — this doc summarizes rank-then-budget below and defers detail there.
+**Ground truth**: the code modules cited throughout this doc (`scripts/learning_loop.py`,
+`scripts/lib/confidence_reconcile.py`, `scripts/lib/vnx_tagger.py`, `scripts/lib/skill_refinement.py`,
+`scripts/lib/rework_attribution.py`, `scripts/lib/intelligence_persist.py`).
 
 ---
 
@@ -72,6 +77,38 @@ Safety contracts (`skill_refinement.py:1–15`):
 - Proposals target ONLY `.claude/skills/` (project-editable per CLAUDE.md), NEVER `.vnx/skills/` (shipped template).
 - Application is a separate operator-approved step.
 
+#### The rework→skill-refine chain (D6, #1008)
+
+Two modules, two slices, one loop:
+
+1. **Slice 1 — `rework_attribution.py`** (read-only attribution engine, unlocked by the commit
+   provenance chain, #969): for each git commit carrying a `Dispatch-ID:` trace token,
+   `_changed_regions()` finds the pre-image lines that commit replaced, then `_blame_origin_counts()`
+   blames those lines against the commit's parent. Whichever earlier token-commit introduced the
+   replaced lines is the dominant origin, persisted (fill-once) into the existing but previously
+   dormant `dispatch_metadata.parent_dispatch` column (`compute_rework_edges`,
+   `scripts/lib/rework_attribution.py:137-181`). `success_by_role()` computes per-role first-pass
+   success **excluding benchmark/headless runs** (`_GOVERNED_PREDICATE`,
+   `scripts/lib/rework_attribution.py:187-213`) — the field-test track carries ~99% of
+   role-stamped rows and would otherwise dominate the rate. `rework_by_origin_role()`
+   (`scripts/lib/rework_attribution.py:228-242`) self-joins `dispatch_metadata` on
+   `parent_dispatch` to count how often each origin role's work was later reworked.
+2. **Slice 2 — `skill_refinement.py`**: `compute_rework_rates()` joins those two queries into
+   `{role: {total, reworked, rework_rate}}` (`scripts/lib/skill_refinement.py:37-68`);
+   `find_rework_prone_roles()` filters to `rework_rate > REWORK_THRESHOLD` (`= 0.3`,
+   `scripts/lib/skill_refinement.py:27, 71-79`). For each prone role, `resolve_skill_path()`
+   locates `.claude/skills/<role>/SKILL.md` (never `.vnx/skills/`,
+   `scripts/lib/skill_refinement.py:82-89`) and `generate_proposal()` inserts a
+   `## Rework Attribution Signal` section (with a rework-reduction checklist) before the
+   `## Skill Activation Announcement` heading, producing a unified diff
+   (`scripts/lib/skill_refinement.py:92-222`). Idempotency guard: if the attribution heading
+   already exists in the skill file, no duplicate proposal is generated
+   (`scripts/lib/skill_refinement.py:185-186`).
+
+The edge only accrues forward from #969 — only commits stamped with a trace token (governed lanes)
+carry the link, so `parent_dispatch` fills in over time as governed dispatches land. No new table:
+this is ADR-007-free, a self-join over an existing dormant column.
+
 ### `vnx learning skill-review`
 
 Prints pending skill refinements, optionally showing the full unified diff (`--show-diff`). No writes.
@@ -127,10 +164,18 @@ vnx learning skill-refine
 Operator: vnx learning skill-review --show-diff
   → review diff + rationale + operator-test note
 
-Operator: vnx learning skill-refine --apply  (or manual patch application)
-  → applies diff to .claude/skills/<role>/SKILL.md
+Operator: manually apply the diff to .claude/skills/<role>/SKILL.md
   → NEVER touches .vnx/skills/
 ```
+
+**Note on `--apply`**: the generated proposal text and CLI help strings (`skill_refinement.py:119,
+215`, `vnx_cli/commands/learning.py:468, 527`) describe `vnx learning skill-refine --apply` as the
+activation step. **This flag does not exist.** `vnx_cli/main.py:578-592` registers only
+`--project-dir` and `--threshold` for the `skill-refine` subcommand — there is no `apply_*` function
+in `skill_refinement.py` either (only `generate_*`/`write_proposals`). Until `--apply` is
+implemented, activation is **manual only**: apply the unified diff from
+`pending_skill_refinements.json` to the target `.claude/skills/<role>/SKILL.md` yourself (e.g.
+`git apply` or a manual patch), then verify the section landed correctly.
 
 ---
 
@@ -146,6 +191,49 @@ Prior to D3, `_supersede_stale_patterns()` wrote `valid_until` directly, silentl
 
 ---
 
+## Rank-Then-Budget Selection (opt-in)
+
+`VNX_INTEL_RANK_THEN_BUDGET` (default `"0"`, `config_registry.py:60-62`) replaces the legacy
+class-priority eviction in `intelligence_selector.py` with a composite-score knapsack:
+`score = confidence * (1 + tag_overlap) * recency_decay * class_weight`
+(`intelligence_selector.py:131-146`). `tag_overlap` is computed against
+`vnx_tag_vocabulary.derive_tags()` (the same closed vocabulary the tagger validates against — see
+[`TAG_TAXONOMY.md`](TAG_TAXONOMY.md)); `recency_decay` is a 30-day half-life floored at `0.3`
+(`intelligence_selector.py:114-128`); `_RESERVED_CLASSES = {"failure_prevention"}`
+(`intelligence_selector.py:106`) always gets first claim on the budget so a cheap high-scoring
+anchor can never evict a critical failure-prevention rule. Full detail, including the
+`scout_sketch` class weight of `1.45`, is in [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md#rank-then-budget-a-related-separately-gated-build-step).
+
+Default OFF — the legacy class-priority path stays the default until operator-enabled per project.
+
+## Tagging Events Audit Trail
+
+Every time the tagger successfully tags a pattern (`enrich_pattern_tags`,
+`scripts/lib/vnx_tagger.py:157-240`), it writes an audit row to a `tagging_events` table in the
+same `quality_intelligence.db` the tagger already writes to (`_TAGGING_EVENTS_SCHEMA`,
+`scripts/lib/vnx_tagger.py:52-65`):
+
+```sql
+CREATE TABLE IF NOT EXISTS tagging_events (
+    id            INTEGER PRIMARY KEY AUTOINCREMENT,
+    project_id    TEXT NOT NULL DEFAULT 'vnx-dev',
+    table_name    TEXT NOT NULL,
+    pattern_id    INTEGER NOT NULL,
+    pattern_title TEXT,
+    tags_json     TEXT NOT NULL,
+    provider      TEXT,
+    tagged_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    UNIQUE (project_id, table_name, pattern_id, tagged_at)
+);
+```
+
+One row per pattern the tagger actually enriches (non-empty tag result only — a pattern the LLM
+couldn't tag doesn't generate a row). ADR-007-compliant: `UNIQUE` is composite over `project_id`.
+This is the audit trail behind the dashboard's tagging-observability panel (#966): "what did the
+tagging agent do, and with which model." It is distinct from the A/B harness below — the A/B
+harness is a read-only diagnostic that never writes to the DB; `tagging_events` is the persistent
+record of live, persist-time tagging once `VNX_TAGGER_ENABLED=1`.
+
 ## Off-Switches and Opt-In Flags
 
 All intelligence flags default OFF (feature-dark until explicitly enabled). Precedence: `VNX_OVERRIDE_<BARE>` env → `project_config` DB → `VNX_<BARE>` env → registry default. Registry source: `scripts/lib/config_registry.py`.
@@ -155,7 +243,9 @@ All intelligence flags default OFF (feature-dark until explicitly enabled). Prec
 | `VNX_LEARNING_ENABLED` | `0` (off) | Supervisor tick that invokes the daily learning cycle automatically. Requires `VNX_SUPERVISOR_MODE=unified`. When unset, the cycle only runs when explicitly invoked via `vnx learning run`. | `scripts/lib/dispatcher_supervisor_ticks.sh:100` |
 | `VNX_LEARN_PERSIST` | `1` (on) | Step 5.5 of the daily cycle — persists high-confidence used patterns and recurring failures to `success_patterns`/`antipatterns`. Set to `0` to run the cycle without writing to the intelligence DB (observation-only mode). | `scripts/learning_loop.py:1043` |
 | `VNX_LEARN_SUPERSEDE` | `1` (on) | Step 5.6 — queues stale low-confidence patterns to `pending_archival.json`. Set to `0` to skip the supersede-candidate scan entirely. | `scripts/learning_loop.py:897` |
-| `VNX_TAGGER_ENABLED` | `0` (off) | LLM tagger enrichment at persist-time. When on, enriches `success_patterns.tags` and `antipatterns.tags` with closed-vocabulary tags via the configured provider (default: DeepSeek-Flash). The selector works without it via deterministic `derive_tags()`. | `scripts/lib/vnx_tagger.py:43`, `config_registry.py:54` |
+| `VNX_SCOUT_PREPASS` | `0` (off) | Cheap-model scout recon pre-pass in the door, before the permit (see [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md)). Fail-open. | `scripts/lib/scout_prepass.py:268-272`, `config_registry.py:51` |
+| `VNX_INTEL_RANK_THEN_BUDGET` | `0` (off) | Replaces class-priority intelligence eviction with a composite-score knapsack (confidence × tag-overlap × recency × class-weight). | `scripts/lib/intelligence_selector.py:109-146`, `config_registry.py:60` |
+| `VNX_TAGGER_ENABLED` | `0` (off) | LLM tagger enrichment at persist-time. When on, enriches `success_patterns.tags` and `antipatterns.tags` with closed-vocabulary tags via the configured provider (default: DeepSeek-Flash), and writes a `tagging_events` audit row per enrichment. The selector works without it via deterministic `derive_tags()`. | `scripts/lib/vnx_tagger.py:43`, `config_registry.py:54` |
 | `VNX_TAGGER_PROVIDER` | `"deepseek"` | Provider for the LLM tagger. Model-agnostic. | `scripts/lib/config_registry.py:57` |
 | `VNX_HAIKU_CLASSIFY` | `0` (off) | LLM-based receipt classification (Haiku) at report ingestion time. When off, rule-based classification is used. | `scripts/lib/report_classifier.py:244`, `config_registry.py:66` |
 | `VNX_OUTCOME_GROUNDING_V2` | `0` (off) | Junction-grounded confidence updates. When on, `update_confidence_from_outcome()` links receipts to patterns via `dispatch_pattern_offered` (exact match, no cap). When off, uses the legacy substring join on `source_dispatch_ids` (capped at 20 entries). | `scripts/lib/intelligence_persist.py:56`, `config_registry.py:63` |
@@ -164,6 +254,22 @@ All intelligence flags default OFF (feature-dark until explicitly enabled). Prec
 
 These default ON, not off — they are off-switches for sub-steps of the learning cycle, not opt-in gates. Setting either to `0` makes the cycle run in a reduced mode (observation without DB writes). They are documented here because they provide surgical rollback if a step causes unexpected behavior.
 
+### Current per-project state — `vnx-dev`
+
+The registry defaults above never change (a fresh `vnx init` project starts with every intelligence
+flag OFF). This project's `runtime_coordination.db: project_config` table currently overrides two of
+them, set by the operator through the config control-plane:
+
+| Flag | Value | Updated |
+|------|-------|---------|
+| `VNX_SCOUT_PREPASS` | `1` | 2026-07-05T14:47:57Z |
+| `VNX_TAGGER_ENABLED` | `1` | 2026-07-05T15:35:56Z |
+
+The tagger flip followed a `vnx learning tagger-ab` run that observed a 100% rescue rate at
+~$0.0005/pattern (DeepSeek-Flash) — comfortably past the `rescue_rate >= 20% AND
+cost_per_pattern <= $0.001` decision criterion below. This is a per-project operator decision, not a
+code change; `VNX_INTEL_RANK_THEN_BUDGET` and `VNX_OUTCOME_GROUNDING_V2` remain OFF for this project.
+
 ---
 
 ## Confidence Authority
@@ -171,9 +277,60 @@ These default ON, not off — they are off-switches for sub-steps of the learnin
 The selector reads `success_patterns.confidence_score`. The authoritative writer is `confidence_reconcile.reconcile_pattern_confidence()` (Beta-Laplace from `pattern_usage.success_count/failure_count`). It fires in two places:
 
 - Step 5.7 of the daily cycle (`learning_loop.py:1061`).
-- At every proven-pattern query via `maybe_reconcile()` (TTL=300 s safety-net, `confidence_reconcile.py:162`).
+- At every proven-pattern query via `maybe_reconcile()` (TTL=300 s safety-net, `confidence_reconcile.py:183–220`).
 
 The internal accumulator `pattern_usage.confidence` can exceed 1.0 (learning loop boosts to 2.0 cap). The reconcile clamps to 1.0 on write to `confidence_score`. Do not read `pattern_usage.confidence` as a selector-ready score.
+
+### Range contract (D1, #1001)
+
+`reconcile_pattern_confidence()` asserts the invariant at its single write boundary before every
+`UPDATE`:
+
+```python
+# scripts/lib/confidence_reconcile.py:164-167
+assert 0.0 <= new_score <= 1.0, (
+    f"confidence_score out of range before write: "
+    f"{new_score!r} for sp_id={sp_id}"
+)
+```
+
+`beta_score()` (`confidence_reconcile.py:76-83`) and `_recency_decay()`
+(`confidence_reconcile.py:48-56`) always compose to `[0.0, 1.0]`, and the legacy
+`_aggregate_for_pattern()` fallback clamps explicitly (`confidence_reconcile.py:118-122`) — so the
+assert is a tripwire for a future writer that breaks the invariant, not a normal-path check.
+
+### Subprocess-lane fixed-delta path
+
+The Beta-Laplace reconcile above only fires from receipt-driven events
+(`update_confidence_from_outcome` listens exclusively for `task_complete`/`task_failed`). Dispatches
+routed through the **subprocess lane** that complete without emitting one of those events (a
+`subprocess_completion` receipt instead) never trigger it. For those, a separate fixed-delta path is
+the **only** confidence update they receive:
+
+```python
+# scripts/lib/subprocess_dispatch_internals/pattern_confidence.py:187-236
+# success: confidence_score = MIN(confidence_score + 0.05, 1.0)
+# failure: confidence_score = MAX(confidence_score - 0.10, 0.0)
+```
+
+`_update_pattern_confidence()` (`pattern_confidence.py:104-159`) looks up patterns offered to the
+dispatch (`dispatch_pattern_offered`, falling back to `pattern_usage.dispatch_id` for older DBs) and
+applies the delta by title match. It deliberately does **not** touch
+`pattern_usage.used_count`/`success_count`/`failure_count` — those columns are reserved for
+confirmed-usage signals from the Beta-Laplace path, so the two update mechanisms never double-count
+the same evidence. Do not retire this path until a receipt-level grounding path exists for
+`subprocess_completion` events (`pattern_confidence.py:129-136`).
+
+### Schema note (D2, #1002)
+
+`success_patterns.success_rate` was dropped (`_migrate_v26`, reversible via `_migrate_v26_down`,
+`scripts/quality_db_init.py:994-1044`) — the column had always been `0.0` in production; no path
+ever wrote a non-zero value. `confidence_score DESC` was already the sole effective sort before the
+drop (`_INTELLIGENCE_BRIEF_SQL`, `scripts/build_t0_state.py:1009-1014`); the column no longer
+physically exists in `schemas/quality_intelligence.sql`. (Unrelated: `build_t0_state.py` also reads
+a `success_rate` key elsewhere, at line 1093 — that one comes from
+`DispatchParameterTracker.stats()` in `dispatch_tracker.db`, a different table entirely, and is
+untouched by this migration.)
 
 ---
 
@@ -184,6 +341,10 @@ Enable `VNX_TAGGER_ENABLED=1` only after running `vnx learning tagger-ab` and ob
 - `cost_per_pattern_usd <= 0.001` (DeepSeek-Flash tier)
 
 Without these numbers from a live run, do not flip the default. The A/B command is read-only and never modifies the DB or sets the flag.
+
+For `vnx-dev`, a live run cleared both thresholds (100% rescue, ~$0.0005/pattern), so the operator
+flipped `VNX_TAGGER_ENABLED=1` via the config DB (see [above](#current-per-project-state--vnx-dev)).
+This is a per-project decision — a fresh project starts back at OFF and needs its own A/B run.
 
 ---
 
@@ -225,14 +386,26 @@ Value grows as governed builds resume. The proposal tier is not a no-op even aga
 | `VNX_LEARNING_ENABLED` supervisor gate | `scripts/lib/dispatcher_supervisor_ticks.sh:100` |
 | Tagger A/B read-only guard | `vnx_cli/commands/learning.py:303` |
 | Grounding shadow read-only | `vnx_cli/commands/learning.py:531–615` |
-| Skill refinement targets .claude/skills/ only | `scripts/lib/skill_refinement.py:1–15` |
+| Skill refinement targets .claude/skills/ only | `scripts/lib/skill_refinement.py:82–89` |
 | Skill refinement never mutates directly | `scripts/lib/skill_refinement.py:1–15` |
-| Beta-Laplace authority | `scripts/lib/confidence_reconcile.py:151` |
-| maybe_reconcile safety-net (TTL=300s) | `scripts/lib/confidence_reconcile.py:162` |
+| `--apply` CLI flag does NOT exist (doc/help text claim it; code doesn't) | `vnx_cli/main.py:578–592` (missing); refs in `vnx_cli/commands/learning.py:468, 527`, `skill_refinement.py:119, 215` |
+| REWORK_THRESHOLD = 0.3 | `scripts/lib/skill_refinement.py:27` |
+| Rework attribution: git-churn blame → origin dispatch | `scripts/lib/rework_attribution.py:137–181` |
+| Rework-prone role filter | `scripts/lib/skill_refinement.py:71–79` |
+| Beta-Laplace authority | `scripts/lib/confidence_reconcile.py:76–83, 127–180` |
+| maybe_reconcile safety-net (TTL=300s) | `scripts/lib/confidence_reconcile.py:183–220` |
 | pattern_usage.confidence cap 2.0 | `scripts/learning_loop.py:283–297` |
-| confidence_score clamped ≤1.0 at write | `scripts/lib/confidence_reconcile.py:151` |
+| confidence_score range assert at write boundary | `scripts/lib/confidence_reconcile.py:164–167` |
+| Subprocess-lane fixed-delta path (+0.05/-0.10) | `scripts/lib/subprocess_dispatch_internals/pattern_confidence.py:104–159, 187–236` |
+| D2: success_rate column dropped (reversible) | `scripts/quality_db_init.py:994–1044` |
+| `VNX_SCOUT_PREPASS` default "0" | `scripts/lib/config_registry.py:51–53` |
+| Scout pre-pass producer + consumer | see [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md) claim-to-code map |
+| `VNX_INTEL_RANK_THEN_BUDGET` default "0" | `scripts/lib/config_registry.py:60–62` |
+| Composite relevance score | `scripts/lib/intelligence_selector.py:131–146` |
+| `tagging_events` audit table | `scripts/lib/vnx_tagger.py:52–65` |
+| Tagger closed-vocab floor + snap-to-vocab | `scripts/lib/vnx_tag_vocabulary.py:72–95` |
 
 ---
 
-*Doc written 2026-07-05 for D7. Verified against shipped code (D1–D6 on main).*
-*Dispatch-ID: D-selfimprove-d7-docs*
+*Doc written 2026-07-05 for D7; updated 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017).*
+*Dispatch-ID: D-docs-intelligence (update); originally D-selfimprove-d7-docs.*

--- a/docs/intelligence/TAG_TAXONOMY.md
+++ b/docs/intelligence/TAG_TAXONOMY.md
@@ -1,208 +1,135 @@
-# VNX Tag Taxonomy v2.0
-**Last Updated**: 2026-03-28
-**Owner**: T-MANAGER
+# VNX Tag Taxonomy
 
-**Status**: Active
-**Date**: 2026-03-28
-**Purpose**: Standardized tag vocabulary for tag intelligence system
+**Last Updated**: 2026-07-05 (refreshed for the docs-intelligence sweep, PRs #1001–#1017)
 
-## Overview
+**There are two separate, still-live tag systems in this codebase.** They serve different
+consumers and do not share a vocabulary. This doc covers both, in order of which is now the SSOT
+for the governed dispatch pipeline.
 
-The VNX Tag Taxonomy provides a standardized vocabulary for tagging issues, patterns, and prevention rules. This ensures consistency across the orchestration system and enables intelligent pattern matching.
+---
 
-## Tag Categories
+## 1. VNX closed vocabulary — SSOT for selector matching + the LLM tagger
 
-### Phase Tags
-Indicate which development phase the issue occurred in.
+**Module**: `scripts/lib/vnx_tag_vocabulary.py` (95 lines).
+**Consumers**: `intelligence_selector.py`'s rank-then-budget scoring (opt-in
+`VNX_INTEL_RANK_THEN_BUDGET`), `vnx_tagger.py`'s LLM tagger (opt-in `VNX_TAGGER_ENABLED`), and
+`scripts/lib/scout_prepass.py` indirectly via the tag-overlap score. Full pipeline detail:
+[`SELF_LEARNING_LOOP.md`](SELF_LEARNING_LOOP.md) and [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md).
 
-| Tag | Description | Example Usage |
-|-----|-------------|---------------|
-| `design-phase` | Planning, architecture, design decisions | Design flaw, missing requirement |
-| `implementation-phase` | Coding, development, feature creation | Bug during coding, implementation error |
-| `testing-phase` | QA, validation, test execution | Test failure, validation issue |
-| `production-phase` | Deployment, release, live operations | Production bug, deployment failure |
+This is a **closed, faceted taxonomy** purpose-built for the VNX Orchestration codebase (not
+SEOcrawler) — three flat, independent facets used to match injected intelligence to a dispatch by
+intent + subsystem, not just file-path overlap.
 
-**Aliases**: design, planning, architecture → `design-phase`
+### Facets
 
-### Component Tags
-Identify which system component is affected.
+| Facet | Purpose | Tag count | Code |
+|-------|---------|-----------|------|
+| **Domain** | The subsystem the work touches | 12 | `vnx_tag_vocabulary.py:23-36` |
+| **Intent** | What the work is | 10 | `vnx_tag_vocabulary.py:39-50` |
+| **Component** | Cross-cutting concern | 8 | `vnx_tag_vocabulary.py:53-62` |
 
-| Tag | Description | Example Usage |
-|-----|-------------|---------------|
-| `crawler-component` | Web crawling, scraping, page analysis | Crawler timeout, parsing error |
-| `storage-component` | Database, persistence, data storage | Storage failure, query timeout |
-| `api-component` | API endpoints, controllers, routing | API error, endpoint failure |
+**Domain tags**: `dispatch`, `intelligence`, `receipts_audit`, `governance_gates`,
+`providers_routing`, `schema_migrations`, `tenant_project_id`, `tests_harness`, `docs`,
+`dashboard_ui`, `benchmark`, `learning_loop`.
 
-**Aliases**: crawler, scraping, web → `crawler-component`
+**Intent tags**: `fix_bug`, `implement_feature`, `refactor`, `add_test`, `harden`, `migrate_schema`,
+`wire_integration`, `review_audit`, `document`, `investigate_rootcause`.
 
-### Issue Tags
-Classify the type of problem encountered.
+**Component tags**: `fail_closed`, `idempotency`, `concurrency_lease`, `project_id_stamping`,
+`cli_subprocess`, `ndjson_contract`, `fts5`, `provider_constraint`.
 
-| Tag | Description | Example Usage |
-|-----|-------------|---------------|
-| `validation-error` | Data validation, input checks, schema violations | Invalid input, schema mismatch |
-| `performance-issue` | Slow operations, optimization needs | Slow query, timeout |
-| `memory-problem` | Memory leaks, OOM, resource exhaustion | Memory leak, high RAM usage |
-| `race-condition` | Concurrency issues, threading problems | Race condition, deadlock |
+Each facet maps tags to keyword lists (`_DOMAIN_KEYWORDS`, `_INTENT_KEYWORDS`,
+`_COMPONENT_KEYWORDS`, `vnx_tag_vocabulary.py:23-62`). `VNX_TAG_VOCABULARY` is the union of all
+three (`vnx_tag_vocabulary.py:66-69`) — the single closed set every tag, deterministic or LLM, must
+belong to.
 
-**Aliases**: validation-error, invalid-data → `validation-error`
-
-### Severity Tags
-Indicate priority and impact level.
-
-| Tag | Description | Example Usage |
-|-----|-------------|---------------|
-| `critical-blocker` | Blocks progress, must fix immediately | Production down, data loss |
-| `high-priority` | Important but not blocking | Major bug, significant impact |
-| `medium-impact` | Moderate importance | Minor bug, enhancement needed |
-
-**Aliases**: critical, blocker, urgent → `critical-blocker`
-
-### Action Tags
-Suggest required actions or solutions.
-
-| Tag | Description | Example Usage |
-|-----|-------------|---------------|
-| `needs-refactor` | Code needs restructuring | Technical debt, code smell |
-| `needs-validation` | Missing validation layer | Add input checks, schema validation |
-| `needs-retry-logic` | Requires resilience patterns | Add retry, circuit breaker |
-
-**Aliases**: refactor, technical-debt → `needs-refactor`
-
-## Tag Normalization Rules
-
-The Tag Intelligence Engine automatically normalizes tags to the standard taxonomy:
+### Deterministic floor — `derive_tags()`
 
 ```python
-# Examples of normalization
-"design" → "design-phase"
-"memory leak" → "memory-problem"
-"API" → "api-component"
-"critical" → "critical-blocker"
+# vnx_tag_vocabulary.py:72-86
+def derive_tags(text, paths=None) -> List[str]:
+    """Keyword/path scan only — no LLM. Deduplicated, facet-ordered."""
 ```
 
-### Normalization Process
-1. Convert to lowercase
-2. Strip whitespace
-3. Map aliases to canonical tags
-4. Remove duplicates
-5. Sort alphabetically
+A pure keyword/path substring scan, no LLM call, always available. This is the floor every dispatch
+gets regardless of whether the LLM tagger is enabled — the selector's `rank_then_budget` tag-overlap
+score (`intelligence_selector.py:131-146`) calls this on-the-fly against an item's title+content
+even when no tags were ever persisted to the DB.
 
-## Tag Combination Examples
+### LLM enrichment layer — `vnx_tagger.py`
 
-### Common Patterns
+Opt-in (`VNX_TAGGER_ENABLED=1`, default off), model-agnostic (`VNX_TAGGER_PROVIDER`, default
+`deepseek`). `enrich_tags()` (`vnx_tagger.py:145-154`) always starts from `derive_tags()` and only
+*adds* LLM-suggested tags on top — the LLM never replaces the deterministic floor.
 
-**Example 1: Design Phase Validation**
-```yaml
-tags: [design-phase, api-component, validation-error, needs-validation]
-interpretation: API design missing input validation
-recommendation: Add input validation design early in planning
-```
-
-**Example 2: Implementation Memory Issue**
-```yaml
-tags: [implementation-phase, crawler-component, memory-problem, high-priority]
-interpretation: Crawler memory leak during development
-recommendation: Implement memory profiling during development
-```
-
-**Example 3: Production Race Condition**
-```yaml
-tags: [production-phase, storage-component, race-condition, critical-blocker]
-interpretation: Critical database concurrency issue in production
-recommendation: Add transaction isolation, implement row-level locking
-```
-
-## Prevention Rule Generation
-
-When a tag combination appears **2+ times**, the system generates a prevention rule.
-
-### Pairwise & Triple Subsets (v2.0)
-
-Tag combinations are decomposed into **pairwise and triple** subsets before storage and matching. Previously, full n-tuples of 8-12 tags produced nearly unique combinations that never matched. Now:
-
-```
-Input: ["implementation-phase", "sse-streaming", "memory-problem", "high-priority"]
-Output subsets:
-  Pairs:   (implementation-phase, sse-streaming), (implementation-phase, memory-problem), ...
-  Triples: (implementation-phase, sse-streaming, memory-problem), ...
-```
-
-This enables actual pattern detection — pairs like `(sse-streaming, memory-problem)` recur across multiple dispatches and generate meaningful prevention rules.
-
-**Hierarchical matching**: If a pair matches, the system checks whether any triple containing those tags also matches, providing more specific recommendations when available.
-
-### Rule Components
-- **Tag Combination**: Sorted pairwise or triple tuple of normalized tags
-- **Rule Type**: Classified based on tag content (critical-prevention, validation-check, etc.)
-- **Description**: Human-readable pattern description
-- **Recommendation**: Actionable steps to prevent recurrence
-- **Confidence**: 0.0-1.0 based on occurrence count (max at 10 occurrences)
-- **Status**: Rules are queued in `pending_rules.json` for operator review (G-L1: never auto-activated)
-
-### Rule Types
-| Type | Triggered By | Purpose |
-|------|--------------|---------|
-| `critical-prevention` | Contains `critical-blocker` | Prevent critical failures |
-| `validation-check` | Contains `validation-error` | Add validation layers |
-| `performance-optimization` | Contains `performance-issue` | Optimize operations |
-| `memory-management` | Contains `memory-problem` | Prevent memory issues |
-| `concurrency-control` | Contains `race-condition` | Handle concurrency safely |
-| `general-prevention` | Other combinations | General pattern prevention |
-
-## Usage Examples
-
-### CLI Analysis
-```bash
-# Analyze tag combination
-python3 tag_intelligence.py analyze validation-error api-component \
-  --phase implementation --terminal T1 --outcome failure
-
-# Query prevention rules
-python3 tag_intelligence.py rules --min-confidence 0.7
-
-# Get statistics
-python3 tag_intelligence.py stats
-```
-
-### Python API
-```python
-from tag_intelligence import TagIntelligenceEngine
-
-engine = TagIntelligenceEngine()
-
-# Analyze tags
-result = engine.analyze_multi_tag_patterns(
-    tags=["memory", "crawler", "critical"],
-    phase="production-phase",
-    terminal="T1",
-    outcome="failure"
-)
-
-# Query prevention rules
-rules = engine.query_prevention_rules(
-    tags=["validation-error"],
-    min_confidence=0.5
-)
-```
-
-## Integration with Intelligence System
-
-The Tag Intelligence Engine integrates with `gather_intelligence.py`:
+**Snap-to-vocab validation** — the load-bearing safety property:
 
 ```python
-# In gather_for_dispatch()
-quality_context = {
-    "tags_analyzed": True,
-    "tag_combination": normalized_tags,
-    "prevention_rules_available": len(rules) > 0,
-    "prevention_rule_count": len(rules)
-}
+# vnx_tag_vocabulary.py:89-95
+def validate_tags(tags) -> List[str]:
+    """Keep only tags that are in the closed vocabulary."""
+    return [t for t in (tags or []) if t in VNX_TAG_VOCABULARY]
 ```
 
-## Database Schema
+The LLM prompt (`_build_prompt`, `vnx_tagger.py:78-95`) lists the exact closed vocabulary and
+instructs "choosing ONLY from the closed vocabulary. Do not invent tags." The response is then
+passed through `validate_tags()` (`vnx_tagger.py:138`) regardless — an off-vocabulary hallucination
+from the model can never enter the matching layer. Max 6 tags per pattern (`_MAX_TAGS`,
+`vnx_tagger.py:46`).
 
-### tag_combinations Table
+`enrich_pattern_tags()` (`vnx_tagger.py:157-240`) is the persist-time entry point: it tags
+untagged rows in `success_patterns`/`antipatterns` (JSON `tags` column) and writes one audit row per
+successful tagging to a `tagging_events` table (`vnx_tagger.py:52-65`) — see
+[`SELF_LEARNING_LOOP.md`#tagging-events-audit-trail](SELF_LEARNING_LOOP.md#tagging-events-audit-trail).
+Called from `intelligence_daemon.GovernanceDigestRunner.run_once()` after signal persistence
+(`scripts/intelligence_daemon.py:236-247`).
+
+### Decision criterion + current state
+
+Enable `VNX_TAGGER_ENABLED=1` per-project only after `vnx learning tagger-ab` shows
+`rescue_rate >= 20%` and `cost_per_pattern_usd <= $0.001`
+(`vnx_cli/commands/learning.py:382-386`). For `vnx-dev` this ran 100% rescue at ~$0.0005/pattern and
+was flipped on 2026-07-05 — see [`SELF_LEARNING_LOOP.md`](SELF_LEARNING_LOOP.md#current-per-project-state--vnx-dev)
+for the live flag state.
+
+---
+
+## 2. Legacy taxonomy — `tag_intelligence.py` (SEOcrawler-flavored, still live)
+
+**Module**: `scripts/tag_intelligence.py`.
+**Consumers**: `scripts/gather_intelligence.py`, `scripts/lib/intelligence_hygiene.py`,
+`scripts/intelligence_daemon.py` (via `TagIntelligenceEngine`) — the interactive/skill-invoked
+intelligence-gathering path (`.claude/skills/*/scripts/intelligence.sh`,
+`scripts/userpromptsubmit_worker_intelligence_inject.sh`), separate from the governed-dispatch
+`IntelligenceSelector` pipeline above.
+
+This is an **older, unrelated vocabulary** originally written for SEOcrawler-style work
+(`crawler-component`, `storage-component`, `api-component`) and is **not** the vocabulary the
+selector's rank-then-budget scoring or the LLM tagger validate against. It is still live code, not
+dead — do not delete it — but it is a parallel system, not a predecessor that `vnx_tag_vocabulary.py`
+replaced.
+
+### Facets (five, not three)
+
+| Category | Purpose |
+|----------|---------|
+| Phase | `design-phase`, `implementation-phase`, `testing-phase`, `production-phase` |
+| Component | `crawler-component`, `storage-component`, `api-component` |
+| Issue | `validation-error`, `performance-issue`, `memory-problem`, `race-condition` |
+| Severity | `critical-blocker`, `high-priority`, `medium-impact` |
+| Action | `needs-refactor`, `needs-validation`, `needs-retry-logic` |
+
+### Prevention rule generation
+
+`TagIntelligenceEngine` decomposes tag combinations into **pairwise and triple subsets** before
+storage/matching (v2.0, 2026-03-28) — full n-tuples of 8-12 tags produced nearly-unique combinations
+that never matched, so this was narrowed to pairs/triples. A combination generates a prevention rule
+after **2+ occurrences**; rules land in `pending_rules.json` for operator review (G-L1: never
+auto-activated) — the same governance principle as the newer `learning_loop.py` pipeline, but a
+separate code path and a separate `prevention_rules` write site.
+
+### Schema
+
 ```sql
 CREATE TABLE tag_combinations (
     id INTEGER PRIMARY KEY,
@@ -216,49 +143,25 @@ CREATE TABLE tag_combinations (
 )
 ```
 
-### prevention_rules Table
-```sql
-CREATE TABLE prevention_rules (
-    id INTEGER PRIMARY KEY,
-    tag_combination TEXT NOT NULL,
-    rule_type TEXT NOT NULL,
-    description TEXT NOT NULL,
-    recommendation TEXT NOT NULL,
-    confidence REAL DEFAULT 0.0,
-    created_at TEXT NOT NULL,
-    triggered_count INTEGER DEFAULT 0,
-    last_triggered TEXT
-)
+### CLI / API
+
+```bash
+python3 scripts/tag_intelligence.py analyze validation-error api-component \
+  --phase implementation --terminal T1 --outcome failure
+python3 scripts/tag_intelligence.py rules --min-confidence 0.7
+python3 scripts/tag_intelligence.py stats
 ```
 
-## Tag Evolution Guidelines
+```python
+from tag_intelligence import TagIntelligenceEngine
+engine = TagIntelligenceEngine()
+result = engine.analyze_multi_tag_patterns(tags=["memory", "crawler", "critical"], ...)
+```
 
-### Adding New Tags
-1. Verify tag doesn't exist (check all aliases)
-2. Assign to appropriate category
-3. Add normalization rule to `normalize_tags()`
-4. Update this documentation
-5. Run tests to verify normalization
+### Recommendation Manager
 
-### Retiring Tags
-1. Mark as deprecated in this doc
-2. Add migration rule to normalization
-3. Update existing database entries
-4. Keep normalization for backwards compatibility
+`RecommendationManager` (also in `scripts/tag_intelligence.py`) manages structured recommendations:
 
-## Best Practices
-
-1. **Be Specific**: Use combination of phase + component + issue for clarity
-2. **Avoid Redundancy**: Don't use multiple severity tags
-3. **Action-Oriented**: Include action tags when clear solution exists
-4. **Consistent Phrasing**: Use verb-noun format for action tags
-5. **Minimal Set**: Use 2-4 tags per issue for optimal pattern matching
-
-## Recommendation Manager
-
-The `RecommendationManager` (in `tag_intelligence.py`) manages structured recommendations derived from tag patterns:
-
-### Recommendation Schema
 ```json
 {
   "type": "claude_md_patch|prevention_rule|routing_hint",
@@ -266,22 +169,43 @@ The `RecommendationManager` (in `tag_intelligence.py`) manages structured recomm
   "symptom": "detected_issue",
   "evidence_ids": ["dispatch_1", "receipt_2", "OI-042"],
   "confidence": 0.75,
-  "created_at": "2026-03-28T14:00:00Z",
-  "id": "sha1_hash_12chars",
   "status": "pending|superseded|accepted"
 }
 ```
 
-### Governance Rules
-- **G-L1**: Prevention rules are never auto-activated — queued in `pending_rules.json`
-- **G-L2**: Evidence trail required — `ValueError` if `evidence_ids` is empty
-- **G-L8**: Maximum 5 active pending recommendations. Excess supersedes lowest-confidence
-- Stale pending edits (>7 days) are automatically flagged for operator review
-- Duplicate recommendations for the same `target + symptom` are merged or superseded
+Governance rules: **G-L1** (never auto-activated), **G-L2** (evidence trail required —
+`ValueError` on empty `evidence_ids`), **G-L8** (max 5 active pending recommendations, excess
+supersedes lowest-confidence). Stale pending edits (>7 days) are flagged for operator review;
+duplicate `target + symptom` recommendations are merged or superseded.
+
+---
+
+## Which one should new code use?
+
+If you are extending the **governed dispatch pipeline** (intelligence selector, tagger,
+scout pre-pass, rank-then-budget) — use `vnx_tag_vocabulary.py`. It is the closed vocabulary those
+subsystems validate against, and adding tags there requires updating the keyword dicts in that
+module (Section 1).
+
+If you are extending the **skill-invoked gather_intelligence.py path** (interactive
+`intelligence.sh` scripts, `TagIntelligenceEngine.analyze_multi_tag_patterns`) — use the legacy
+taxonomy in `tag_intelligence.py` (Section 2). Do not attempt to merge the two vocabularies without
+a design decision on the consumer side; they are read by different code and a merge would need
+migration for both `tag_combinations` and the closed-vocab keyword tables.
+
+---
 
 ## References
 
-- Tag Intelligence Engine: `scripts/tag_intelligence.py`
-- Recommendation Manager: `scripts/tag_intelligence.py` (RecommendationManager class)
-- Tests: `tests/test_tag_intelligence.py`
-- Integration: `scripts/gather_intelligence.py`
+- Closed vocabulary SSOT: `scripts/lib/vnx_tag_vocabulary.py`
+- LLM tagger: `scripts/lib/vnx_tagger.py`
+- Legacy engine: `scripts/tag_intelligence.py`
+- Legacy integration: `scripts/gather_intelligence.py`
+- Selector + rank-then-budget: `scripts/lib/intelligence_selector.py`, [`SELF_LEARNING_LOOP.md`](SELF_LEARNING_LOOP.md)
+- Scout pre-pass: [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md)
+- Legacy tests: `tests/test_tag_intelligence.py`
+
+---
+
+*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017 drift-brief).*
+*Dispatch-ID: D-docs-intelligence*

--- a/docs/intelligence/TAG_TAXONOMY.md
+++ b/docs/intelligence/TAG_TAXONOMY.md
@@ -1,6 +1,6 @@
 # VNX Tag Taxonomy
 
-**Last Updated**: 2026-07-05 (refreshed for the docs-intelligence sweep, PRs #1001–#1017)
+**Last Updated**: 2026-07-05 (refreshed for the docs-intelligence sweep, PRs #1001–#1018)
 
 **There are two separate, still-live tag systems in this codebase.** They serve different
 consumers and do not share a vocabulary. This doc covers both, in order of which is now the SSOT
@@ -207,5 +207,5 @@ migration for both `tag_combinations` and the closed-vocab keyword tables.
 
 ---
 
-*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1017 drift-brief).*
+*Doc written 2026-07-05 for the docs-intelligence sweep (PRs #1001–#1018 drift-brief).*
 *Dispatch-ID: D-docs-intelligence*

--- a/docs/intelligence/TAG_TAXONOMY.md
+++ b/docs/intelligence/TAG_TAXONOMY.md
@@ -12,8 +12,8 @@ for the governed dispatch pipeline.
 
 **Module**: `scripts/lib/vnx_tag_vocabulary.py` (95 lines).
 **Consumers**: `intelligence_selector.py`'s rank-then-budget scoring (opt-in
-`VNX_INTEL_RANK_THEN_BUDGET`), `vnx_tagger.py`'s LLM tagger (opt-in `VNX_TAGGER_ENABLED`), and
-`scripts/lib/scout_prepass.py` indirectly via the tag-overlap score. Full pipeline detail:
+`VNX_INTEL_RANK_THEN_BUDGET`) — which calls `derive_tags` to compute the tag-overlap score — and
+`vnx_tagger.py`'s LLM tagger (opt-in `VNX_TAGGER_ENABLED`). Full pipeline detail:
 [`SELF_LEARNING_LOOP.md`](SELF_LEARNING_LOOP.md) and [`SCOUT_PREPASS.md`](SCOUT_PREPASS.md).
 
 This is a **closed, faceted taxonomy** purpose-built for the VNX Orchestration codebase (not


### PR DESCRIPTION
Docs sweep for the intelligence domain, grounded in the provider-panel drift-brief + verified vs current code. Part of docs-drift-archive-sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC