### PR TITLE
fix(lane): thread project_root from invocation context (central-mode workers spawn in the project, not the keystone)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -480,7 +480,10 @@ def _execute_claude(
     require_permit is the first action — un-evadable. P0-3: sha256 of the instruction
     file is re-verified immediately before delivery to detect TOCTOU swaps.
     """
-    from tmux_interactive_dispatch import TmuxInteractiveDispatch  # noqa: PLC0415
+    from tmux_interactive_dispatch import (  # noqa: PLC0415
+        TmuxInteractiveDispatch,
+        _resolve_invocation_project_root,
+    )
 
     require_permit(plan, permit)  # un-evadable gate — FIRST action, cannot be moved
 
@@ -502,7 +505,13 @@ def _execute_claude(
             f"(expected {plan.instruction_sha256[:12]}…, got {actual[:12]}…)"
         )
 
-    lane = TmuxInteractiveDispatch(state_dir)
+    # Thread the PROJECT repo root from the invocation context (VNX_PROJECT_ROOT /
+    # cwd-git), NOT the lane code's __file__: in central-install mode the code lives
+    # under the shared keystone, so the constructor's __file__ fallback would spawn
+    # the worker in the keystone instead of the operator's project.
+    lane = TmuxInteractiveDispatch(
+        state_dir, project_root=_resolve_invocation_project_root()
+    )
     result = lane.dispatch(
         instruction,
         plan.dispatch_id,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2272,6 +2272,45 @@ def _resolve_state_dir() -> Path:
     return resolve_state_dir(caller_file=__file__)
 
 
+def _resolve_invocation_project_root() -> Path:
+    """Resolve the PROJECT repo root from the INVOCATION CONTEXT, not the lane
+    code's on-disk location.
+
+    In central-install mode the lane code lives under
+    ``~/.vnx-system/current/scripts/lib/``, so ``Path(__file__).parents[2]``
+    resolves to the shared VNX keystone, NOT the operator's project. The worker
+    must be spawned in the project (``cwd`` / worktree ``repo_root``), so resolve
+    from the invocation context instead:
+
+      1. ``VNX_PROJECT_ROOT`` env var (exported by the central-install shim) when
+         it points at a real directory.
+      2. The invoking CWD's git top-level.
+      3. Last resort: the lane code's own repo root (``parents[2]``) — correct for
+         the embedded/dev-checkout layout where code and project coincide.
+
+    Deliberately does NOT pass ``caller_file=__file__`` to the shared resolver:
+    that would re-introduce the keystone bug via its physical-location candidate.
+    """
+    raw = os.environ.get("VNX_PROJECT_ROOT", "").strip()
+    if raw:
+        candidate = Path(raw).expanduser()
+        if candidate.is_dir():
+            return candidate.resolve()
+
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(Path.cwd()), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+        if out:
+            return Path(out).resolve()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        pass
+
+    return TmuxInteractiveDispatch._resolve_project_root()
+
+
 def main(argv: "list[str] | None" = None) -> int:
     import argparse
 
@@ -2335,7 +2374,9 @@ def main(argv: "list[str] | None" = None) -> int:
         getattr(args, "reason", None),
     )
 
-    lane = TmuxInteractiveDispatch(_resolve_state_dir())
+    lane = TmuxInteractiveDispatch(
+        _resolve_state_dir(), project_root=_resolve_invocation_project_root()
+    )
 
     result = lane.dispatch(
         args.instruction,

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -31,6 +31,7 @@ from tmux_interactive_dispatch import (
     TmuxResult,
     _assert_no_headless_flags,
     _default_launch_command,
+    _resolve_invocation_project_root,
     _resolve_state_dir,
     _sanitize_session_name,
     main,
@@ -1021,6 +1022,104 @@ class TestStateDirMatchesCanonical(unittest.TestCase):
             lane_path,
             f"MISMATCH: lane={lane_path!r} != canonical={canonical_path!r}",
         )
+
+
+class TestInvocationProjectRootResolution(unittest.TestCase):
+    """Central-mode guard: project_root must come from the INVOCATION context.
+
+    In central-install mode the lane code lives under the shared keystone
+    (~/.vnx-system/current/scripts/lib/), so Path(__file__).parents[2] is the
+    keystone, NOT the operator's project. The lane must resolve the project from
+    VNX_PROJECT_ROOT / cwd-git instead, or workers spawn in the wrong directory.
+    """
+
+    def setUp(self) -> None:
+        # Snapshot + neutralize env so each case controls its own inputs.
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("VNX_PROJECT_ROOT", "VNX_CANONICAL_ROOT")
+        }
+        os.environ.pop("VNX_PROJECT_ROOT", None)
+        os.environ.pop("VNX_CANONICAL_ROOT", None)
+        self._cwd = Path.cwd()
+
+    def tearDown(self) -> None:
+        os.chdir(self._cwd)
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    @staticmethod
+    def _keystone() -> Path:
+        # What the buggy __file__.parents[2] fallback would return.
+        return TmuxInteractiveDispatch._resolve_project_root()
+
+    def test_env_var_wins_when_dir(self):
+        """VNX_PROJECT_ROOT (central-install shim export) resolves to the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp).resolve()
+            os.environ["VNX_PROJECT_ROOT"] = str(project)
+
+            resolved = _resolve_invocation_project_root()
+
+            self.assertEqual(resolved, project)
+            self.assertNotEqual(
+                resolved,
+                self._keystone(),
+                "central-mode must not resolve to the keystone (__file__.parents[2])",
+            )
+
+    def test_env_var_ignored_when_not_a_dir(self):
+        """A stale/bogus VNX_PROJECT_ROOT (non-dir) is skipped, not trusted."""
+        with tempfile.TemporaryDirectory() as tmp:
+            missing = Path(tmp) / "does-not-exist"
+            os.environ["VNX_PROJECT_ROOT"] = str(missing)
+            # cwd is the vnx-orchestration repo (a git repo) during pytest, so
+            # candidate 2 (cwd-git) should carry the resolution.
+            resolved = _resolve_invocation_project_root()
+            self.assertTrue(resolved.is_dir())
+            self.assertNotEqual(resolved, missing)
+
+    def test_cwd_git_toplevel_used_when_no_env(self):
+        """With no env var, the invoking CWD's git top-level is the project."""
+        with tempfile.TemporaryDirectory() as tmp:
+            repo = Path(tmp).resolve()
+            subprocess.run(
+                ["git", "init", "-q"], cwd=repo, check=True,
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            nested = repo / "sub" / "dir"
+            nested.mkdir(parents=True)
+            os.chdir(nested)
+
+            resolved = _resolve_invocation_project_root()
+
+            # git top-level of the invocation cwd, not __file__.parents[2].
+            self.assertEqual(resolved, repo)
+            self.assertNotEqual(resolved, self._keystone())
+
+    def test_file_fallback_when_no_env_and_no_cwd_git(self):
+        """No env + a non-git cwd falls back to the lane code's own repo root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            non_git = Path(tmp).resolve()
+            os.chdir(non_git)
+
+            resolved = _resolve_invocation_project_root()
+
+            self.assertEqual(resolved, self._keystone())
+
+    def test_constructor_threads_resolved_root(self):
+        """The lane instance's _project_root reflects the invocation-context root."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp).resolve()
+            os.environ["VNX_PROJECT_ROOT"] = str(project)
+            with tempfile.TemporaryDirectory() as state:
+                lane = TmuxInteractiveDispatch(
+                    state, project_root=_resolve_invocation_project_root()
+                )
+                self.assertEqual(lane._project_root, project)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Central-mode bug (sales-copilot escalation, part of central-mode-path-correctness). The tmux lane + the door's in-process path derived project_root from `Path(__file__).parents[2]` → the keystone in central-mode, so workers spawned with cwd/repo_root = keystone not the project. New `_resolve_invocation_project_root()`: VNX_PROJECT_ROOT (already exported by the central shim) → CWD git-root → __file__ fallback. Fixes both main() + dispatch_cli._execute_claude(). 176+73 tests green (5 new).

Track: central-mode-path-correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC