### PR TITLE
fix(migrate): wire+repair the Horizon 0022-0031 pipeline into vnx migrate (P0)

### DIFF
--- a/schemas/migrations/0031_runtime_tenant_fk_repair.sql
+++ b/schemas/migrations/0031_runtime_tenant_fk_repair.sql
@@ -10,6 +10,13 @@
 -- this static DDL atomically, and checks foreign_key_check + integrity_check
 -- before commit. The lease-token partial UNIQUE remains intentionally global
 -- because it is an incarnation token, not a tenant natural key.
+--
+-- TENANT PLACEHOLDER (ADR-007, D3): the ``'vnx-dev'`` literals below (the four
+-- project_id column DEFAULTs and the four row-copy INSERT...SELECT projections)
+-- are AT-REST PLACEHOLDERS ONLY. apply_migration_v31 renders this file through
+-- _render_static_0031_sql_with_pid(), substituting the DB-path-anchored,
+-- fail-closed-RESOLVED project_id before execution, so a non-vnx-dev store is
+-- never stamped 'vnx-dev'. Do NOT read these literals as a hardcoded tenant.
 
 PRAGMA foreign_keys = OFF;
 

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -29,6 +29,23 @@ VALID_HORIZONS = frozenset({"now", "next", "later"})
 class InvalidHorizonError(ValueError):
     pass
 
+
+class HorizonColumnMissingError(RuntimeError):
+    """Raised when a horizon is requested but tracks.horizon does not exist.
+
+    Fail-closed (D5): a store predating migration 0027 lacks the horizon column.
+    The old behaviour silently DROPPED the requested horizon on create (and the
+    UPDATE path raised an opaque OperationalError), so `horizon add --horizon now`
+    appeared to succeed while the schedule was ignored. We now refuse loudly and
+    point the operator at `vnx migrate` instead of accepting a value we cannot store.
+    """
+    pass
+
+
+def _tracks_has_horizon(conn: sqlite3.Connection) -> bool:
+    """True when the tracks table carries the horizon column (migration 0027)."""
+    return any(row[1] == "horizon" for row in conn.execute("PRAGMA table_info('tracks')"))
+
 ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "queued":  frozenset({"active", "parked"}),
     "active":  frozenset({"done", "parked"}),
@@ -211,14 +228,23 @@ def create_track(
         )
 
     now = _now_utc()
-    _emit_track_event(state_dir, "track_created", track_id, project_id, "system", {"title": title})
     conn = _get_conn(state_dir)
     try:
         # horizon (migration 0027) is optional: only reference the column when it
         # exists, so the DAL stays compatible with pre-0027 (v24-era) databases.
-        has_horizon = any(
-            row[1] == "horizon" for row in conn.execute("PRAGMA table_info('tracks')")
-        )
+        # D5 fail-closed: if a horizon was REQUESTED but the column is absent, refuse
+        # loudly rather than silently drop it (the pre-fix silent no-op that hid the
+        # stuck-store gap). A pre-0027 store that requests NO horizon still works.
+        # Checked BEFORE the audit event so a refused create emits no track_created.
+        has_horizon = _tracks_has_horizon(conn)
+        if horizon is not None and not has_horizon:
+            raise HorizonColumnMissingError(
+                f"Cannot set horizon={horizon!r} on track {track_id!r}: the tracks "
+                "table has no 'horizon' column (store predates migration 0027). "
+                "Run `vnx migrate` to add the Horizon schema, then retry."
+            )
+        _emit_track_event(
+            state_dir, "track_created", track_id, project_id, "system", {"title": title})
         if has_horizon:
             conn.execute(
                 """
@@ -316,6 +342,17 @@ def update_authored_fields(
         ).fetchone()
         if not row:
             raise TrackNotFoundError(f"Track not found: ({track_id!r}, {project_id!r})")
+
+        # D5 fail-closed: refuse a horizon write when the column is absent (pre-0027
+        # store) rather than crashing with an opaque "no such column: horizon". The
+        # unconditional `updates["horizon"] = horizon` above would otherwise reach the
+        # UPDATE and raise sqlite3.OperationalError. Checked before the audit event.
+        if "horizon" in updates and not _tracks_has_horizon(conn):
+            raise HorizonColumnMissingError(
+                f"Cannot set horizon={updates['horizon']!r} on track {track_id!r}: the "
+                "tracks table has no 'horizon' column (store predates migration 0027). "
+                "Run `vnx migrate` to add the Horizon schema, then retry."
+            )
 
         if updates:
             _emit_track_event(

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -167,6 +167,13 @@ _IDENT_PATTERN = r'"[^"]+"|`[^`]+`|\[[^\]]+\]|[A-Za-z_][A-Za-z0-9_]*'
 _IDENT_RE = re.compile(_IDENT_PATTERN)
 _CONSTRAINT_KW = ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT")
 
+#: Safe tenant-slug grammar (codex injection fix). A resolved project_id gets inlined
+#: into DDL DEFAULTs / row-copy where a bind param can't reach, so it must be a slug
+#: with no quote/semicolon/paren/whitespace. Bounded length caps abuse. Matches every
+#: legitimate VNX id (`^[a-z][a-z0-9-]{1,31}$` and `vnx-<hex>`), rejects hostile input
+#: like `x'); DROP TABLE tracks;--`.
+_SAFE_PROJECT_ID_RE = re.compile(r"^[a-z0-9][a-z0-9._-]{0,63}$")
+
 
 def _mask_quoted_sql(sql: str) -> str:
     """Mask quoted content AND SQL comments while preserving length.
@@ -434,7 +441,20 @@ def _resolve_validated_project_id(db_path) -> str:
             "No silent 'vnx-dev' default (R3.1). See docs/governance/decisions/"
             "ADR-007-multitenant-project-id-stamping.md"
         )
-    return distinct.pop()
+    resolved = distinct.pop()
+    # Charset validation (codex injection fix): the resolved tenant is inlined into
+    # DDL DEFAULTs / index names / row-copy where a bind parameter cannot reach, so a
+    # marker or env value carrying a quote/semicolon/paren/space could inject SQL. A
+    # legitimate VNX project_id is a slug; reject anything outside the safe grammar
+    # BEFORE it is used anywhere. This is the last line of defense — _sql_quote_literal
+    # and bound parameters still apply at the use-sites.
+    if not _SAFE_PROJECT_ID_RE.match(resolved):
+        raise RuntimeError(
+            f"ADR-007 fail-closed: resolved project_id {resolved!r} is not a valid "
+            f"tenant slug (must match {_SAFE_PROJECT_ID_RE.pattern}). Refusing to use "
+            "an unsafe/injectable identity."
+        )
+    return resolved
 
 
 def _sql_quote_literal(value: str) -> str:
@@ -2586,20 +2606,24 @@ def _copy_rows_into_v31_staging(
     collision — never silent data loss.
     """
     src_col_list = ", ".join(f'"{c}"' for c in base_copy_cols)
+    # resolved_pid is passed as a BOUND PARAMETER (codex injection fix) — never
+    # string-interpolated into the SQL, even though _resolve_validated_project_id
+    # already charset-validates it (defense in depth).
     if has_pid:
         # project_id column exists: copy it, filling NULL/'' with resolved_pid.
         dst_col_list = ", ".join(f'"{c}"' for c in base_copy_cols + ["project_id"])
         pid_expr = (
             "CASE WHEN \"project_id\" IS NULL OR \"project_id\" = '' "
-            f"THEN '{resolved_pid}' ELSE \"project_id\" END"
+            "THEN ? ELSE \"project_id\" END"
         )
         select_sql = f'SELECT {src_col_list}, {pid_expr} FROM "{table}"'
     else:
         # project_id column absent: add it set to resolved_pid for all rows.
         dst_col_list = src_col_list + ', "project_id"'
-        select_sql = f"SELECT {src_col_list}, '{resolved_pid}' FROM \"{table}\""
+        select_sql = f'SELECT {src_col_list}, ? FROM "{table}"'
     try:
-        conn.execute(f'INSERT INTO "{staging}" ({dst_col_list}) {select_sql}')
+        conn.execute(
+            f'INSERT INTO "{staging}" ({dst_col_list}) {select_sql}', (resolved_pid,))
     except sqlite3.IntegrityError as exc:
         raise RuntimeError(
             f"0031 adaptive row-copy composite-key collision in '{table}': {exc}. "
@@ -2884,6 +2908,52 @@ def _run_adaptive_v31_repair(
     _verify_foreign_keys_restored(conn, original_fk)
 
 
+_CREATE_INDEX_NAME_RE = re.compile(
+    r'(?is)^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?("?)([A-Za-z0-9_]+)\1')
+
+
+def _canonical_runtime_index_defs() -> dict[str, set[str]]:
+    """Map index name → {acceptable normalized CREATE INDEX definitions}, over the
+    legacy (_RUNTIME_V30_LEGACY_INDEX_SQL) and v31 (_V31_TABLE_INDEXES) canonical sets.
+    An index of a canonical name whose definition matches none of these has drifted."""
+    acc: dict[str, set[str]] = {}
+    for sqls in _V31_TABLE_INDEXES.values():
+        for sql in sqls:
+            m = _CREATE_INDEX_NAME_RE.match(sql)
+            if m:
+                acc.setdefault(m.group(2), set()).add(_normalize_create_index_sql(sql))
+    for by_name in _RUNTIME_V30_LEGACY_INDEX_SQL.values():
+        for name, sql in by_name.items():
+            acc.setdefault(name, set()).add(_normalize_create_index_sql(sql))
+    return acc
+
+
+def _assert_no_conflicting_runtime_index_redefinition(conn: sqlite3.Connection) -> None:
+    """Refuse (do NOT silently coerce/drop) a runtime index that REUSES a canonical
+    index name with a DIFFERENT definition (codex safety fix). The adaptive rebuild
+    recreates indexes from the authoritative v31 set, so a same-name index carrying
+    different semantics (e.g. a rogue UNIQUE(idx_lease_state) on other columns) would
+    be silently replaced — a real, possibly load-bearing constraint change. A drifted
+    canonical-named index whose normalized definition matches neither the legacy nor
+    the v31 canonical def aborts the migration for operator review. Custom-named
+    (non-canonical) indexes are out of scope here."""
+    acc = _canonical_runtime_index_defs()
+    present = {r[0] for r in conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table'")}
+    for table in _RUNTIME_V31_TABLES:
+        if table not in present:
+            continue
+        for name, sql in conn.execute(
+            "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=? "
+            "AND sql IS NOT NULL", (table,)).fetchall():
+            if name in acc and _normalize_create_index_sql(sql) not in acc[name]:
+                raise RuntimeError(
+                    f"0031 refuses to proceed: index {name!r} on {table!r} definition "
+                    f"differs from every canonical/legacy runtime definition "
+                    f"(found {sql!r}). Refusing to silently coerce or drop conflicting "
+                    "index semantics — resolve the index manually first.")
+
+
 def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
     migration_path = _MIGRATIONS / "0031_runtime_tenant_fk_repair.sql"
     if not migration_path.exists():
@@ -2906,6 +2976,11 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         print("  [stamp] runtime tenant/FK repair already complete; user_version → 31")
         _run_runtime_v31_transaction(conn, ("PRAGMA user_version = 31",))
         return
+
+    # Refuse conflicting canonical-named index redefinitions BEFORE choosing a repair
+    # path — this RuntimeError must propagate (it is NOT the "mixed shape" signal that
+    # the try/except below converts into the adaptive path).
+    _assert_no_conflicting_runtime_index_redefinition(conn)
 
     # Adaptive branch (W1B spec): when the cluster is NEITHER v31-complete (above)
     # NOR clean-v30-legacy, run the adaptive FK-repair (mixed state, e.g. seocrawler-v2

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -2967,6 +2967,14 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         raise RuntimeError(
             f"0031 requires user_version=30 after the prior numbered walk; got {current_version}.")
 
+    # Refuse conflicting canonical-named index redefinitions FIRST — before the
+    # v31-complete / tables-absent fast paths (codex round-2 fast-path-bypass fix). The
+    # manifest's v31-complete check compares key columns/unique/partial only, NOT
+    # ASC/DESC direction or collation, so a same-name index that differs ONLY in
+    # direction/collation would slip through the fast path and be silently accepted.
+    # The guard skips absent tables, so it is a no-op on the tables-absent path.
+    _assert_no_conflicting_runtime_index_redefinition(conn)
+
     if _runtime_v31_tables_absent(conn):
         print("  [skip] migration 0031 runtime tables absent; user_version → 31")
         conn.execute("PRAGMA user_version = 31")
@@ -2976,11 +2984,6 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         print("  [stamp] runtime tenant/FK repair already complete; user_version → 31")
         _run_runtime_v31_transaction(conn, ("PRAGMA user_version = 31",))
         return
-
-    # Refuse conflicting canonical-named index redefinitions BEFORE choosing a repair
-    # path — this RuntimeError must propagate (it is NOT the "mixed shape" signal that
-    # the try/except below converts into the adaptive path).
-    _assert_no_conflicting_runtime_index_redefinition(conn)
 
     # Adaptive branch (W1B spec): when the cluster is NEITHER v31-complete (above)
     # NOR clean-v30-legacy, run the adaptive FK-repair (mixed state, e.g. seocrawler-v2

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -169,26 +169,57 @@ _CONSTRAINT_KW = ("PRIMARY", "UNIQUE", "CHECK", "FOREIGN", "CONSTRAINT")
 
 
 def _mask_quoted_sql(sql: str) -> str:
-    """Mask quoted content while preserving length and quote delimiters.
+    """Mask quoted content AND SQL comments while preserving length.
 
     Handles SQL strings plus double-quoted, backtick-quoted, and bracket-quoted
-    identifiers, including doubled closing delimiters. This is intentionally a
-    bounded scanner for the existing CREATE TABLE/INDEX helpers, not a SQL parser.
+    identifiers (including doubled closing delimiters), and additionally masks
+    ``-- line`` comments and ``/* block */`` comments before any paren-balance,
+    comma-split, or keyword scan runs against the masked copy. A ``)`` / ``(`` /
+    ``,`` living inside a comment (or a doubled string delimiter) must never
+    perturb `_matching_paren`, `_split_columns_and_constraints`, or the inline
+    keyword scans — sqlite_master stores CREATE TABLE/INDEX text verbatim, so a
+    legacy schema carrying a comment with an unbalanced paren was raising
+    "unbalanced parentheses in SQL" (B.1). Comment bytes (delimiters included)
+    become the mask byte; string/identifier quote delimiters are preserved so the
+    downstream scanners still see the token boundaries. Length is preserved
+    exactly (`zip(body, masked)` in `_split_columns_and_constraints` depends on
+    it). This is a bounded scanner for the CREATE TABLE/INDEX helpers, not a full
+    SQL parser.
     """
-    out, i = list(sql), 0
-    while i < len(sql):
-        opener = sql[i]
-        if opener not in ("'", '"', "`", "["):
+    out, i, n = list(sql), 0, len(sql)
+    while i < n:
+        ch = sql[i]
+        nxt = sql[i + 1] if i + 1 < n else ""
+        # -- line comment: mask through (but not including) the newline. A `--`
+        # inside a string is consumed by the quote inner-loop below, never here.
+        if ch == "-" and nxt == "-":
+            while i < n and sql[i] != "\n":
+                out[i] = "\x00"
+                i += 1
+            continue
+        # /* block comment */: mask through the closing delimiter, inclusive.
+        if ch == "/" and nxt == "*":
+            out[i] = out[i + 1] = "\x00"
+            i += 2
+            while i < n:
+                if sql[i] == "*" and i + 1 < n and sql[i + 1] == "/":
+                    out[i] = out[i + 1] = "\x00"
+                    i += 2
+                    break
+                out[i] = "\x00"
+                i += 1
+            continue
+        if ch not in ("'", '"', "`", "["):
             i += 1
             continue
-        closer = "]" if opener == "[" else opener
+        closer = "]" if ch == "[" else ch
         i += 1
-        while i < len(sql):
+        while i < n:
             if sql[i] != closer:
                 out[i] = "\x00"
                 i += 1
                 continue
-            if i + 1 < len(sql) and sql[i + 1] == closer:
+            if i + 1 < n and sql[i + 1] == closer:
                 out[i] = out[i + 1] = "\x00"
                 i += 2
                 continue
@@ -404,6 +435,35 @@ def _resolve_validated_project_id(db_path) -> str:
             "ADR-007-multitenant-project-id-stamping.md"
         )
     return distinct.pop()
+
+
+def _sql_quote_literal(value: str) -> str:
+    """Return *value* as a safely single-quoted SQL string literal (R3.1/ADR-007).
+
+    Used to inline a fail-closed-RESOLVED project_id into DDL where a bind
+    parameter is impossible (a CREATE TABLE column DEFAULT, or the static-file
+    row-copy substitution). Single quotes are doubled. Callers pass only an
+    already-validated project_id (`^[a-z][a-z0-9-]{1,31}$`), so this is defense in
+    depth, never the primary guard. NEVER used to inline the 'vnx-dev' sentinel.
+    """
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _render_static_0031_sql_with_pid(sql: str, project_id: str) -> str:
+    """Substitute the tenant placeholder in the static 0031 DDL with the RESOLVED
+    project_id (D3, ADR-007 damage-causer fix).
+
+    `schemas/migrations/0031_runtime_tenant_fk_repair.sql` uses ``'vnx-dev'`` at
+    rest as a placeholder for BOTH the column DEFAULT and the four row-copy
+    ``INSERT ... SELECT`` literals. Applying that verbatim on a non-vnx-dev store
+    (e.g. sales-copilot) would stamp every rebuilt runtime row with the wrong
+    tenant — corruption. The clean-v30-legacy path therefore renders the file with
+    the DB-path-anchored, fail-closed-resolved tenant identity before executing
+    it. `project_id` is never the sentinel: it comes from
+    `_resolve_validated_project_id`. Idempotent for a store whose real tenant IS
+    'vnx-dev' (the substitution is then a no-op replacement of like-for-like).
+    """
+    return sql.replace("'vnx-dev'", _sql_quote_literal(project_id))
 
 
 def _validate_existing_project_id_or_abort(conn: sqlite3.Connection,
@@ -2213,7 +2273,7 @@ CREATE TABLE {staging} (
     id              INTEGER PRIMARY KEY AUTOINCREMENT,
     attempt_id      TEXT    NOT NULL,
     dispatch_id     TEXT    NOT NULL,
-    project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+    project_id      TEXT    NOT NULL DEFAULT {pid},
     attempt_number  INTEGER NOT NULL DEFAULT 1,
     terminal_id     TEXT    NOT NULL,
     state           TEXT    NOT NULL DEFAULT 'pending',
@@ -2230,7 +2290,7 @@ CREATE TABLE {staging} (
     id                      INTEGER PRIMARY KEY AUTOINCREMENT,
     run_id                  TEXT    NOT NULL,
     dispatch_id             TEXT    NOT NULL,
-    project_id              TEXT    NOT NULL DEFAULT 'vnx-dev',
+    project_id              TEXT    NOT NULL DEFAULT {pid},
     attempt_id              TEXT    NOT NULL,
     target_id               TEXT    NOT NULL,
     target_type             TEXT    NOT NULL,
@@ -2261,7 +2321,7 @@ CREATE TABLE {staging} (
 CREATE TABLE {staging} (
     id                  INTEGER PRIMARY KEY AUTOINCREMENT,
     terminal_id         TEXT    NOT NULL,
-    project_id          TEXT    NOT NULL DEFAULT 'vnx-dev',
+    project_id          TEXT    NOT NULL DEFAULT {pid},
     state               TEXT    NOT NULL DEFAULT 'idle',
     dispatch_id         TEXT,
     generation          INTEGER NOT NULL DEFAULT 1,
@@ -2279,7 +2339,7 @@ CREATE TABLE {staging} (
     "worker_states": """\
 CREATE TABLE {staging} (
     terminal_id      TEXT    NOT NULL,
-    project_id       TEXT    NOT NULL DEFAULT 'vnx-dev',
+    project_id       TEXT    NOT NULL DEFAULT {pid},
     dispatch_id      TEXT    NOT NULL,
     state            TEXT    NOT NULL DEFAULT 'initializing',
     last_output_at   TEXT,
@@ -2579,9 +2639,14 @@ def _adaptive_rebuild_table(
         f'SELECT COUNT(*) FROM "{table}"'
     ).fetchone()[0]
 
-    # Build + populate the staging table
+    # Build + populate the staging table. The project_id column DEFAULT is the
+    # RESOLVED tenant (D3), never the 'vnx-dev' sentinel — inlined because a
+    # CREATE TABLE DEFAULT cannot be a bind parameter. Row values are still set
+    # explicitly by _copy_rows_into_v31_staging; the DEFAULT only governs any
+    # future INSERT that omits project_id, and must not be a wrong tenant.
     conn.execute(f'DROP TABLE IF EXISTS "{staging}"')
-    conn.execute(ddl_template.format(staging=f'"{staging}"'))
+    conn.execute(ddl_template.format(
+        staging=f'"{staging}"', pid=_sql_quote_literal(resolved_pid)))
 
     _copy_rows_into_v31_staging(conn, table, staging, base_copy_cols, resolved_pid, has_pid)
 
@@ -2843,9 +2908,9 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         return
 
     # Adaptive branch (W1B spec): when the cluster is NEITHER v31-complete (above)
-    # NOR clean-v30-legacy (the guard below would refuse), run the adaptive FK-repair.
-    # This handles the "mixed" state where runtime tables already carry an out-of-band
-    # project_id but FKs are not yet composite (e.g. seocrawler-v2 at v30).
+    # NOR clean-v30-legacy, run the adaptive FK-repair (mixed state, e.g. seocrawler-v2
+    # / sales-copilot at v30). Otherwise apply the static 0031 DDL. Both resolve the
+    # tenant identity and stamp the RESOLVED project_id, never the 'vnx-dev' sentinel.
     try:
         _assert_runtime_v30_legacy_shape(conn)
         is_legacy_clean = True
@@ -2853,31 +2918,48 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         is_legacy_clean = False
 
     if not is_legacy_clean:
-        # Mixed/contaminated store — run the adaptive repair path.
-        # Resolve the DB path from the connection (PRAGMA database_list row 0, col 2).
-        db_file = conn.execute("PRAGMA database_list").fetchone()[2]
-        if not db_file:
-            raise RuntimeError(
-                "0031 adaptive: cannot resolve project_id — connection has no database file "
-                "(in-memory or unnamed). Pass a real DB path."
-            )
-        resolved_pid = _resolve_validated_project_id(db_file)
-        print(
-            f"  [adapt] 0031 mixed store detected (project_id already present but FKs not composite). "
-            f"Running adaptive FK-repair for pid='{resolved_pid}' ..."
-        )
-        # D1: foreign-tenant pre-flight (tables that have project_id)
-        _adaptive_foreign_tenant_preflight(conn, list(_ADAPTIVE_RUNTIME_TABLES), resolved_pid)
-        # D1: orphan pre-flight (conservative — abort on any orphans)
-        _adaptive_orphan_preflight(conn)
-        # D2–D5 + stamp user_version=31 in one FK-off BEGIN IMMEDIATE transaction
-        _run_adaptive_v31_repair(conn, resolved_pid)
-        print(f"  [ok]    adaptive repair complete; user_version → {schema_migration.get_user_version(conn)}")
-        return
+        _apply_adaptive_0031(conn)
+    else:
+        _apply_static_0031(conn, migration_path)
 
-    # Clean v30-legacy shape — use the static 0031 DDL path (original behavior).
-    sql = migration_path.read_text(encoding="utf-8")
-    print("  [apply] migration 0031_runtime_tenant_fk_repair.sql ...")
+
+def _resolve_0031_pid_from_conn(conn: sqlite3.Connection, label: str) -> str:
+    """Resolve+validate the tenant identity for 0031 from the connection's DB file."""
+    db_file = conn.execute("PRAGMA database_list").fetchone()[2]
+    if not db_file:
+        raise RuntimeError(
+            f"0031 {label}: cannot resolve project_id — connection has no database "
+            "file (in-memory or unnamed). Pass a real DB path.")
+    return _resolve_validated_project_id(db_file)
+
+
+def _apply_adaptive_0031(conn: sqlite3.Connection) -> None:
+    """Mixed/contaminated store — adaptive FK-repair with the RESOLVED project_id."""
+    resolved_pid = _resolve_0031_pid_from_conn(conn, "adaptive")
+    print(
+        f"  [adapt] 0031 mixed store detected (project_id already present but FKs not "
+        f"composite). Running adaptive FK-repair for pid='{resolved_pid}' ...")
+    # D1: foreign-tenant + orphan pre-flights (fail-closed) before any mutation.
+    _adaptive_foreign_tenant_preflight(conn, list(_ADAPTIVE_RUNTIME_TABLES), resolved_pid)
+    _adaptive_orphan_preflight(conn)
+    # D2–D5 + stamp user_version=31 in one FK-off BEGIN IMMEDIATE transaction.
+    _run_adaptive_v31_repair(conn, resolved_pid)
+    print(f"  [ok]    adaptive repair complete; user_version → "
+          f"{schema_migration.get_user_version(conn)}")
+
+
+def _apply_static_0031(conn: sqlite3.Connection, migration_path: Path) -> None:
+    """Clean v30-legacy shape — static 0031 DDL, tenant-stamped with the RESOLVED
+    project_id (D3). The file's 'vnx-dev' placeholders (column DEFAULT + the four
+    row-copy INSERT...SELECT literals) are substituted for the DB-path-anchored,
+    fail-closed tenant identity before execution so a non-vnx-dev store is never
+    corrupted. The FK-off-before-BEGIN-IMMEDIATE envelope lives in
+    _run_runtime_v31_transaction (the in-file `PRAGMA foreign_keys=OFF` is a no-op
+    inside the open transaction — D6)."""
+    resolved_pid = _resolve_0031_pid_from_conn(conn, "static")
+    sql = _render_static_0031_sql_with_pid(
+        migration_path.read_text(encoding="utf-8"), resolved_pid)
+    print(f"  [apply] migration 0031_runtime_tenant_fk_repair.sql (tenant={resolved_pid!r}) ...")
     _run_runtime_v31_transaction(
         conn,
         schema_migration._split_sql_statements(sql),
@@ -2890,11 +2972,42 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
 # Main
 # ---------------------------------------------------------------------------
 
+#: The numbered-walk preflight hooks, as (version, fn) — the single source for both
+#: the import-time registrations above and the defensive re-assert in _run_pipeline.
+_PREFLIGHT_SPECS = (
+    (22, _assert_dispatches_schema_intact),
+    (24, _assert_tracks_v22_intact),
+    (27, _ensure_dispatches_output_columns),
+    (27, _assert_tracks_v24_intact),
+    (28, _assert_tracks_v27_intact),
+    (29, _assert_tracks_v28_intact),
+    (30, _assert_tracks_v29_intact),
+)
+
+
+def _register_preflights() -> None:
+    """(Re)register the numbered-walk preflight hooks idempotently.
+
+    The hooks are registered at import, but a caller/test may have cleared
+    schema_migration._PREFLIGHT_HOOKS (bootstrap-isolation fixtures do this to keep
+    the v22 pre-hook from firing during a fresh bootstrap). The future-system walk
+    DEPENDS on them — notably v27's _ensure_dispatches_output_columns, which adds
+    dispatches.output_ref before the 0027 deliverables view (else: "no such column:
+    output_ref"). run() re-asserts them defensively, registering each only when
+    absent so import-time registration is never duplicated. The v22 pre-hook stays a
+    no-op here because run() executes AFTER the bootstrap has already reached ≥ v22
+    (0022 is then a user_version skip that never invokes its preflight)."""
+    for version, fn in _PREFLIGHT_SPECS:
+        if fn not in schema_migration._PREFLIGHT_HOOKS.get(version, []):
+            schema_migration.register_preflight(version, fn)
+
+
 def _run_numbered_walk(conn: sqlite3.Connection, project_root: Path) -> None:
     """Step C of run(): apply the numbered migrations 0022 → 0031 in order, each
     idempotent via user_version, committing after each. Preflights (steps 3-12) are
     manifest-backed (schema_manifest). See the module docstring for the full ordering.
     """
+    _register_preflights()  # defensive: the walk depends on these hooks (v27 output_ref)
     apply_migration(conn, project_root)       # 0022 — track tables; dispatches w/o track FK
     conn.commit()
     apply_migration_v24(conn, project_root)   # 0024 — composite (track_id, project_id) PK/FK
@@ -2978,21 +3091,81 @@ def _run_w1_coupled_migration(rc_db_path: Path) -> None:
         print("  [W1] No tenant-stamping changes needed (RC + QI already clean).")
 
 
-def run(project_root: Path | None = None) -> None:
-    """Apply future-system migrations through 0031.
+def backup_store_vacuum_into(db_path: Path) -> Path:
+    """D6 data-safety: consistent pre-migration backup via ``VACUUM INTO``.
+
+    The store runs in WAL mode, so a plain file copy can miss committed data
+    still in the -wal (not a valid safety proof). ``VACUUM INTO`` writes a single
+    self-consistent snapshot file using a short-lived read connection (no
+    migration lock held). Writes ``<db>.premigrate-<UTC>.bak`` beside the store
+    and returns it. Raises if the snapshot is not produced — a store is never
+    migrated without a provable backup. The rebuild is NOT purely additive
+    (0022/0024/0031 rebuild tables), so this backup is the abort-and-restore path.
+    """
+    ts = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+    backup_path = db_path.with_name(f"{db_path.name}.premigrate-{ts}.bak")
+    if backup_path.exists():
+        backup_path = db_path.with_name(
+            f"{db_path.name}.premigrate-{ts}-{os.getpid()}.bak")
+    src = sqlite3.connect(str(db_path), timeout=30.0)
+    try:
+        src.execute("VACUUM INTO ?", (str(backup_path),))
+    finally:
+        src.close()
+    if not backup_path.exists():
+        raise RuntimeError(
+            f"pre-migration VACUUM INTO backup was not created at {backup_path}; "
+            "refusing to migrate without a provable backup (D6).")
+    print(f"  [backup] pre-migration snapshot → {backup_path}")
+    return backup_path
+
+
+def run(
+    project_root: Path | None = None,
+    *,
+    data_dir: Path | None = None,
+    tenant_stamp_fatal: bool = True,
+    run_tenant_stamp: bool = True,
+    backup: bool = False,
+) -> None:
+    """Apply future-system migrations through 0031 (+ optional W1 tenant-stamping).
 
     DB path resolution (mirrors dispatch_cli.py:69-74):
+    - Explicit ``data_dir`` argument wins (D4 threading trap): the CLI has already
+      resolved the canonical data root, so it threads the EXACT directory here
+      instead of letting the runner re-derive ``<project_root>/.vnx-data``.
     - VNX_DATA_DIR_EXPLICIT=1 + VNX_DATA_DIR set: use the explicit data dir's
       state directory (allows targeting a central per-project store for migrations).
-    - Fallback: the project-local state directory under project_root (no central data dir).
+    - Fallback: the project-local state directory under project_root.
+
+    ``run_tenant_stamp`` (D-W1): when True (default, direct/strict callers) the W1
+    3-phase tenant-stamping runs after the schema walk. The ``vnx migrate`` CLI passes
+    FALSE: W1 is DISABLED there because it is currently broken for the store shapes
+    vnx migrate targets — a normally-bootstrapped store carries BOTH a ('vnx-dev',
+    'default') pool_config row (migration 0020 seed) and a (<pid>, 'default') row
+    (init bootstrap seed), so Phase 2's 'vnx-dev'→<pid> restamp always collides on
+    pool_config's UNIQUE(project_id, pool_id); legacy stores additionally trip a
+    child-FK-widening gap (recommendation_outcomes → recommendations). W1 self-restores
+    on failure, so it achieves nothing but heavy checkpoint churn here. The SCHEMA fix
+    (tracks.horizon, the actual gap) is delivered by the walk regardless. Re-enable W1
+    once the tenant_stamping follow-up ships. ``tenant_stamp_fatal`` governs whether a
+    W1 failure aborts (True) or downgrades to a WARNING after the committed walk (False)
+    — only consulted when ``run_tenant_stamp`` is True.
+
+    ``backup`` (D6): when True, take a ``VACUUM INTO`` snapshot of the store before
+    any mutation.
     """
     _project_root_provided = project_root is not None
     if project_root is None:
         project_root = resolve_project_root(__file__)
     _pytest_db_isolation_guard(project_root)
 
-    data_dir = _resolve_data_dir(project_root, project_root_provided=_project_root_provided)
-    state_dir = data_dir / "state"
+    if data_dir is not None:
+        resolved_data_dir = Path(data_dir).resolve()
+    else:
+        resolved_data_dir = _resolve_data_dir(
+            project_root, project_root_provided=_project_root_provided)
+    state_dir = resolved_data_dir / "state"
     state_dir.mkdir(parents=True, exist_ok=True)
     db_path = state_dir / "runtime_coordination.db"
 
@@ -3004,40 +3177,50 @@ def run(project_root: Path | None = None) -> None:
 
     print(f"\nVNX migrate_future_system — db: {db_path}")
 
+    if backup:
+        backup_store_vacuum_into(db_path)
+
+    _run_pipeline(db_path, project_root,
+                  tenant_stamp_fatal=tenant_stamp_fatal,
+                  run_tenant_stamp=run_tenant_stamp)
+
+
+def _run_pipeline(
+    db_path: Path, project_root: Path, *,
+    tenant_stamp_fatal: bool, run_tenant_stamp: bool = True,
+) -> None:
+    """Steps A–E of run(): ADR-007 repair → version reconcile → 0022→0031 walk →
+    convergence guard → W1 tenant-stamping. Extracted from run() so each stays within
+    the 70-line function-size gate; behaviour is identical."""
     conn = sqlite3.connect(str(db_path), timeout=30.0)
     conn.execute("PRAGMA journal_mode = WAL")
     conn.execute("PRAGMA foreign_keys = ON")
-
     try:
-        # (A) ADR-007 pre-migration repair (R1/R2.2/R3.1): convert any single-column
-        # dispatch_id uniqueness into composite UNIQUE(dispatch_id, project_id).
-        # No-op when already composite; resolves the tenant only when needed.
+        # (A) ADR-007 pre-migration repair: convert any single-column dispatch_id
+        # uniqueness into composite UNIQUE(dispatch_id, project_id). No-op when already
+        # composite; resolves the tenant only when needed.
         _run_adr007_dispatches_repair(conn, db_path)
-
-        # (B) Numbered version reconciliation (R2.1/R2.2): validate the claimed
-        # user_version against the invariant manifest; a DB that LIES about its
-        # version is downgraded to its true version so the walk re-applies what the
-        # downgrade exposed. Runs AFTER the repair, BEFORE the numbered walk (PRD §6).
+        # (B) Numbered version reconciliation: a DB that LIES about its user_version is
+        # downgraded to its true version so the walk re-applies what the downgrade
+        # exposed. Runs AFTER the repair, BEFORE the numbered walk (PRD §6).
         _run_version_reconciliation(conn, db_path)
-
         if schema_migration.get_user_version(conn) < 22:
             _assert_dispatches_schema_intact(conn)
-
-        # (C) Numbered migration walk: 0022 → 0031 (each idempotent via user_version).
+        # (C) Numbered migration walk 0022 → 0031 (each idempotent via user_version).
         _run_numbered_walk(conn, project_root)
-
-        # (D) Oscillation guard (R2.1): the terminal version's manifest MUST hold;
-        # a downgrade+re-walk that did not converge aborts here rather than looping.
+        # (D) Oscillation guard: the terminal version's manifest MUST hold or abort.
         _assert_manifest_converged(conn)
-
-        # (E) W1 tenant-stamping (1.0-blocker): close conn first (the 3-phase
-        # runner opens its own — avoids WAL conflicts), then run the COUPLED
-        # two-DB orchestrator so BOTH RC and QI migrate (QI path resolved inside).
+        # (E) W1 tenant-stamping: close conn first (the 3-phase runner opens its own,
+        # avoiding WAL conflicts). The walk (C) + convergence (D) are already COMMITTED
+        # per-step, so a non-fatal W1 failure keeps the converged terminal schema. The
+        # vnx migrate CLI disables W1 (run_tenant_stamp=False) — see run()'s docstring.
         conn.close()
         conn = None
-        _run_w1_coupled_migration(db_path)
+        if run_tenant_stamp:
+            _run_w1_step(db_path, tenant_stamp_fatal=tenant_stamp_fatal)
+        else:
+            print("  [W1][skip] tenant-stamping disabled by caller (schema-only migrate).")
         print("\n  Migration complete. Schema at user_version (RC verified by manifest converge).\n")
-
     except Exception:
         if conn is not None:
             try:
@@ -3048,6 +3231,24 @@ def run(project_root: Path | None = None) -> None:
     finally:
         if conn is not None:
             conn.close()
+
+
+def _run_w1_step(db_path: Path, *, tenant_stamp_fatal: bool) -> None:
+    """Run W1 coupled tenant-stamping. On a non-fatal failure (the vnx migrate CLI)
+    W1 self-checkpoints + restores its own partial work, so the converged terminal
+    schema (tracks.horizon) is preserved and the operator is warned (D-W1)."""
+    try:
+        _run_w1_coupled_migration(db_path)
+    except Exception as w1_exc:
+        if tenant_stamp_fatal:
+            raise
+        print(
+            "\n  [W1][WARN] deep tenant-stamping did not converge and was rolled back "
+            f"to its pre-W1 checkpoint: {w1_exc}\n"
+            "  The schema migration (through 0031, tracks.horizon) DID land and is "
+            "committed. Any residual legacy ('vnx-dev'/NULL) tenant rows in runtime/"
+            "intelligence tables remain unstamped — re-run once the tenant-stamping "
+            "follow-up ships. No data was lost.\n")
 
 
 if __name__ == "__main__":

--- a/scripts/migrate_future_system.py
+++ b/scripts/migrate_future_system.py
@@ -2912,10 +2912,24 @@ _CREATE_INDEX_NAME_RE = re.compile(
     r'(?is)^\s*CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?("?)([A-Za-z0-9_]+)\1')
 
 
+#: worker_pool_membership canonical indexes (0020 legacy == v31 adaptive rebuild).
+#: WPM has no entry in _V31_TABLE_INDEXES — the adaptive WPM rebuild
+#: (_adaptive_rebuild_worker_pool_membership) creates these inline — so they are
+#: enumerated here for the conflict guard, which iterates WPM (it is in
+#: _RUNTIME_V31_TABLES). Without this a same-name partial-WHERE drift on
+#: idx_pool_membership_active would go undetected (codex round-3 gap 2).
+_WPM_CANONICAL_INDEXES = (
+    "CREATE UNIQUE INDEX idx_pool_membership_active "
+    "ON worker_pool_membership(terminal_id, project_id) WHERE released_at IS NULL",
+    "CREATE INDEX idx_pool_membership_pool ON worker_pool_membership(project_id, pool_id)",
+)
+
+
 def _canonical_runtime_index_defs() -> dict[str, set[str]]:
     """Map index name → {acceptable normalized CREATE INDEX definitions}, over the
-    legacy (_RUNTIME_V30_LEGACY_INDEX_SQL) and v31 (_V31_TABLE_INDEXES) canonical sets.
-    An index of a canonical name whose definition matches none of these has drifted."""
+    legacy (_RUNTIME_V30_LEGACY_INDEX_SQL), v31 (_V31_TABLE_INDEXES), and
+    worker_pool_membership (_WPM_CANONICAL_INDEXES) canonical sets. An index of a
+    canonical name whose definition matches none of these has drifted."""
     acc: dict[str, set[str]] = {}
     for sqls in _V31_TABLE_INDEXES.values():
         for sql in sqls:
@@ -2925,6 +2939,10 @@ def _canonical_runtime_index_defs() -> dict[str, set[str]]:
     for by_name in _RUNTIME_V30_LEGACY_INDEX_SQL.values():
         for name, sql in by_name.items():
             acc.setdefault(name, set()).add(_normalize_create_index_sql(sql))
+    for sql in _WPM_CANONICAL_INDEXES:
+        m = _CREATE_INDEX_NAME_RE.match(sql)
+        if m:
+            acc.setdefault(m.group(2), set()).add(_normalize_create_index_sql(sql))
     return acc
 
 
@@ -2960,20 +2978,22 @@ def apply_migration_v31(conn: sqlite3.Connection, project_root: Path) -> None:
         raise FileNotFoundError(f"Migration not found: {migration_path}")
 
     current_version = schema_migration.get_user_version(conn)
+
+    # Refuse conflicting canonical-named index redefinitions FIRST — before EVERY
+    # early return, including the already-v31 fast-return (codex round-3) and the
+    # v31-complete / tables-absent fast paths (codex round-2). Neither the
+    # user_version >= 31 check nor the manifest's v31-complete check compares ASC/DESC
+    # direction or collation, so a same-name index that differs ONLY in
+    # direction/collation would otherwise slip through silently. The guard skips absent
+    # tables, so it is a no-op on the tables-absent / fresh paths.
+    _assert_no_conflicting_runtime_index_redefinition(conn)
+
     if current_version >= 31:
         print(f"  [skip] migration 0031 already applied (user_version={current_version})")
         return
     if current_version != 30:
         raise RuntimeError(
             f"0031 requires user_version=30 after the prior numbered walk; got {current_version}.")
-
-    # Refuse conflicting canonical-named index redefinitions FIRST — before the
-    # v31-complete / tables-absent fast paths (codex round-2 fast-path-bypass fix). The
-    # manifest's v31-complete check compares key columns/unique/partial only, NOT
-    # ASC/DESC direction or collation, so a same-name index that differs ONLY in
-    # direction/collation would slip through the fast path and be silently accepted.
-    # The guard skips absent tables, so it is a no-op on the tables-absent path.
-    _assert_no_conflicting_runtime_index_redefinition(conn)
 
     if _runtime_v31_tables_absent(conn):
         print("  [skip] migration 0031 runtime tables absent; user_version → 31")

--- a/tests/test_horizon_schema_migration_fix.py
+++ b/tests/test_horizon_schema_migration_fix.py
@@ -431,10 +431,11 @@ class TestTenantReconciliation:
         with pytest.raises(RuntimeError, match="split-tenant"):
             _reconcile_tenant_or_fail(data_root, "cliproj")
 
-    def test_vnx_migrate_refuses_split_tenant_end_to_end(self, tmp_path: Path,
-                                                         monkeypatch: pytest.MonkeyPatch) -> None:
-        """The wired vnx migrate returns non-zero (does not migrate) on a marker/CLI
-        tenant mismatch."""
+    def test_vnx_migrate_refuses_split_tenant_leaves_store_untouched(
+            self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The reconcile is the FIRST gate (before bootstrap): a marker/CLI mismatch
+        returns rc 1 with ZERO rows created or seeded — no DB, no pool_config, and the
+        marker is not overwritten (codex round-2 ordering fix)."""
         import argparse
         from vnx_cli.commands.migrate import vnx_migrate
         project_dir = tmp_path / "myproject"
@@ -446,6 +447,11 @@ class TestTenantReconciliation:
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
         rc = vnx_migrate(argparse.Namespace(project_dir=str(project_dir)))
         assert rc == 1
+        # Bootstrap never ran → no store, no seed. Marker unchanged.
+        assert not (xdg / "state" / "runtime_coordination.db").exists(), (
+            "refused split-tenant store must have NO runtime_coordination.db (bootstrap "
+            "must not have run/seeded)")
+        assert (xdg / ".vnx-project-id").read_text(encoding="utf-8").strip() == "otherproj"
 
 
 class TestResolvedPidValidation:
@@ -465,6 +471,39 @@ class TestResolvedPidValidation:
         db = tmp_path / "state" / "runtime_coordination.db"
         db.parent.mkdir(parents=True)
         assert mfs._resolve_validated_project_id(db) == "sales-copilot"
+
+    def test_normalize_index_distinguishes_direction_collation_partial(self) -> None:
+        """Proof (codex round-2): _normalize_create_index_sql already distinguishes
+        ASC/DESC, COLLATE, and partial WHERE — so the guard compares full semantics,
+        not just name+columns. No change needed to the normalizer itself."""
+        n = mfs._normalize_create_index_sql
+        assert n("CREATE INDEX ix ON t(a, b DESC)") != n("CREATE INDEX ix ON t(a, b ASC)")
+        assert n("CREATE INDEX ix ON t(a COLLATE NOCASE)") != n("CREATE INDEX ix ON t(a COLLATE BINARY)")
+        assert n("CREATE INDEX ix ON t(a) WHERE x='running'") != n("CREATE INDEX ix ON t(a)")
+
+    def test_v31_complete_store_asc_vs_desc_index_aborts(self, tmp_path: Path,
+                                                         monkeypatch: pytest.MonkeyPatch) -> None:
+        """Fast-path-bypass fix: a v31-COMPLETE store carrying a same-name index that
+        differs only in ASC-vs-canonical-DESC is REFUSED, not silently accepted via the
+        v31-complete fast path (the manifest ignores index direction)."""
+        pid = "fastpath-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, run_tenant_stamp=False)  # → v31
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP INDEX idx_headless_run_state")
+        conn.execute(
+            "CREATE INDEX idx_headless_run_state ON headless_runs(state, started_at ASC)")
+        conn.execute("PRAGMA user_version = 30")
+        conn.commit()
+        # The store still looks v31-complete to the manifest (direction is not checked),
+        # so without the fix the fast path would stamp v31 and accept the drift.
+        assert mfs._runtime_v31_complete(conn) is True
+        conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(RuntimeError, match="idx_headless_run_state.*differs"):
+            mfs.apply_migration_v31(conn, data_root)
+        conn.close()
 
     def test_hostile_pid_via_pipeline_leaves_store_intact(self, tmp_path: Path,
                                                           monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_horizon_schema_migration_fix.py
+++ b/tests/test_horizon_schema_migration_fix.py
@@ -400,6 +400,96 @@ class TestD6Safety:
 
 
 # ===========================================================================
+# codex diff-gate fixes — tenant reconciliation + resolved-pid validation
+# ===========================================================================
+
+class TestTenantReconciliation:
+    """Fix 1: vnx migrate must refuse a split-tenant store rather than stamp one
+    tenant while seeding another."""
+
+    def test_mismatched_marker_vs_cli_pid_refuses(self, tmp_path: Path) -> None:
+        from vnx_cli.commands.migrate import _reconcile_tenant_or_fail
+        data_root = tmp_path / ".vnx-data" / "myproject"
+        data_root.mkdir(parents=True)
+        (data_root / ".vnx-project-id").write_text("otherproj\n", encoding="utf-8")
+        with pytest.raises(RuntimeError, match="split-tenant"):
+            _reconcile_tenant_or_fail(data_root, "myproject")
+
+    def test_agreeing_marker_passes(self, tmp_path: Path) -> None:
+        from vnx_cli.commands.migrate import _reconcile_tenant_or_fail
+        data_root = tmp_path / ".vnx-data" / "myproject"
+        data_root.mkdir(parents=True)
+        (data_root / ".vnx-project-id").write_text("myproject\n", encoding="utf-8")
+        _reconcile_tenant_or_fail(data_root, "myproject")  # must not raise
+
+    def test_env_pid_mismatch_refuses(self, tmp_path: Path,
+                                      monkeypatch: pytest.MonkeyPatch) -> None:
+        from vnx_cli.commands.migrate import _reconcile_tenant_or_fail
+        monkeypatch.setenv("VNX_PROJECT_ID", "envproj")
+        data_root = tmp_path / "xdg"
+        data_root.mkdir()
+        with pytest.raises(RuntimeError, match="split-tenant"):
+            _reconcile_tenant_or_fail(data_root, "cliproj")
+
+    def test_vnx_migrate_refuses_split_tenant_end_to_end(self, tmp_path: Path,
+                                                         monkeypatch: pytest.MonkeyPatch) -> None:
+        """The wired vnx migrate returns non-zero (does not migrate) on a marker/CLI
+        tenant mismatch."""
+        import argparse
+        from vnx_cli.commands.migrate import vnx_migrate
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+        xdg = tmp_path / "xdg"
+        xdg.mkdir()
+        (xdg / ".vnx-project-id").write_text("otherproj\n", encoding="utf-8")
+        monkeypatch.setenv("VNX_DATA_DIR", str(xdg))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        rc = vnx_migrate(argparse.Namespace(project_dir=str(project_dir)))
+        assert rc == 1
+
+
+class TestResolvedPidValidation:
+    """Fix 2: the resolved project_id is charset-validated and never raw-interpolated."""
+
+    def test_hostile_pid_rejected_not_executed(self, tmp_path: Path,
+                                               monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_PROJECT_ID", "x'); DROP TABLE tracks;--")
+        db = tmp_path / "state" / "runtime_coordination.db"
+        db.parent.mkdir(parents=True)
+        with pytest.raises(RuntimeError, match="not a valid tenant slug"):
+            mfs._resolve_validated_project_id(db)
+
+    def test_valid_slug_accepted(self, tmp_path: Path,
+                                 monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_PROJECT_ID", "sales-copilot")
+        db = tmp_path / "state" / "runtime_coordination.db"
+        db.parent.mkdir(parents=True)
+        assert mfs._resolve_validated_project_id(db) == "sales-copilot"
+
+    def test_hostile_pid_via_pipeline_leaves_store_intact(self, tmp_path: Path,
+                                                          monkeypatch: pytest.MonkeyPatch) -> None:
+        """A hostile marker on a store that needs the adaptive 0031 repair aborts the
+        migration WITHOUT executing the injected SQL (tracks table survives)."""
+        pid = "inject-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        # Overwrite the data-path-anchored identity with a hostile marker so the
+        # resolver picks it up and must reject it.
+        (data_root / ".vnx-project-id").write_text(
+            "x'); DROP TABLE tracks;--\n", encoding="utf-8")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        with pytest.raises(RuntimeError):
+            mfs.run(data_dir=data_root, run_tenant_stamp=False)
+        c = sqlite3.connect(str(db_path))
+        try:
+            assert c.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' AND name='tracks'"
+            ).fetchone() is not None, "tracks table must survive — injection not executed"
+        finally:
+            c.close()
+
+
+# ===========================================================================
 # D5 — fail-closed horizon guards in the tracks DAL
 # ===========================================================================
 

--- a/tests/test_horizon_schema_migration_fix.py
+++ b/tests/test_horizon_schema_migration_fix.py
@@ -505,6 +505,49 @@ class TestResolvedPidValidation:
             mfs.apply_migration_v31(conn, data_root)
         conn.close()
 
+    def test_v31_store_index_drift_aborts_through_run(self, tmp_path: Path,
+                                                     monkeypatch: pytest.MonkeyPatch) -> None:
+        """codex round-3 gap 1: an already-v31 store carrying a same-name ASC-vs-DESC
+        drift aborts through mfs.run() (the walk's apply_migration_v31 runs the guard
+        BEFORE the user_version >= 31 early-return; the manifest ignores direction so
+        version reconciliation does not downgrade it away)."""
+        pid = "run-drift-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, run_tenant_stamp=False)  # → v31
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP INDEX idx_headless_run_state")
+        conn.execute(
+            "CREATE INDEX idx_headless_run_state ON headless_runs(state, started_at ASC)")
+        conn.commit()
+        conn.close()
+        assert _uv(db_path) == 31  # store stays v31 — the >= 31 fast-return would apply
+        with pytest.raises(RuntimeError, match="idx_headless_run_state.*differs"):
+            mfs.run(data_dir=data_root, run_tenant_stamp=False)
+
+    def test_wpm_partial_where_drift_aborts(self, tmp_path: Path,
+                                           monkeypatch: pytest.MonkeyPatch) -> None:
+        """codex round-3 gap 2: a same-name partial-WHERE drift on
+        idx_pool_membership_active (worker_pool_membership) is detected/aborted like the
+        other runtime tables — its canonical defs are now in the guard's set."""
+        pid = "wpm-drift-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, run_tenant_stamp=False)  # → v31; WPM canonical indexes
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("DROP INDEX idx_pool_membership_active")
+        conn.execute(
+            "CREATE UNIQUE INDEX idx_pool_membership_active "
+            "ON worker_pool_membership(terminal_id, project_id) WHERE released_at IS NOT NULL")
+        conn.commit()
+        conn.execute("PRAGMA foreign_keys = ON")
+        # Guard runs before the >= 31 early-return, so it fires at user_version 31 too.
+        with pytest.raises(RuntimeError, match="idx_pool_membership_active.*differs"):
+            mfs.apply_migration_v31(conn, data_root)
+        conn.close()
+
     def test_hostile_pid_via_pipeline_leaves_store_intact(self, tmp_path: Path,
                                                           monkeypatch: pytest.MonkeyPatch) -> None:
         """A hostile marker on a store that needs the adaptive 0031 repair aborts the

--- a/tests/test_horizon_schema_migration_fix.py
+++ b/tests/test_horizon_schema_migration_fix.py
@@ -1,0 +1,481 @@
+"""Tests for the Horizon schema-migration fix (track: horizon-schema-migration-fix).
+
+Covers the D1–D6 deliverables:
+
+  D1  parser comment-masking so a schema comment carrying ')' / '(' / ',' no longer
+      raises "unbalanced parentheses in SQL".
+  D2  runtime child tables reference the composite parent key after 0031
+      (foreign_key_check empty).
+  D3  0031 stamps the RESOLVED project_id, never the hardcoded 'vnx-dev' sentinel,
+      on a NON-vnx-dev store — plus a leak assertion on tracks.
+  D4  the WHOLE future-system pipeline (0027→0031 + Horizon) runs, so a pre-27 store
+      gains tracks.horizon; idempotent re-run.
+  D5  tracks.create_track / update_authored_fields fail closed when a horizon is
+      requested but the column is absent.
+  D6  VACUUM INTO backup before migrating; crash between DROP and RENAME leaves a
+      recoverable store; lying-version fixtures reconcile; FK enforcement is off
+      during the rebuild.
+
+Dispatch-ID: D-horizon-schema-migration-fix
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+for _p in (str(ROOT), str(ROOT / "scripts"), str(ROOT / "scripts" / "lib")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import migrate_future_system as mfs  # noqa: E402
+import tracks as tracks_dal  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+def _bootstrap_store(data_root: Path) -> Path:
+    """Bootstrap a fresh runtime store (v1→v26) under ``data_root/state`` and return
+    the runtime_coordination.db path. Mirrors _bootstrap_runtime_dbs' RC chain.
+
+    Importing migrate_future_system (module-level) registers the future-system
+    preflight hooks (v22, v24, …) whose contract assumes the future-system walk
+    (dispatches already composite). The bootstrap's auto_apply(0022) rebuilds
+    dispatches from solo→composite and would trip that preflight. Production is
+    unaffected — vnx migrate imports mfs only AFTER the bootstrap — so we clear
+    and restore the preflight registry around the bootstrap chain to mirror it.
+    """
+    import schema_migration  # type: ignore
+
+    state_dir = data_root / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    saved_hooks = {k: list(v) for k, v in schema_migration._PREFLIGHT_HOOKS.items()}
+    schema_migration._PREFLIGHT_HOOKS.clear()
+    try:
+        from coordination_db import init_schema, db_path_from_state_dir  # type: ignore
+        init_schema(state_dir)
+        db_path = db_path_from_state_dir(state_dir)
+        from project_id_migration import run_runtime_coordination_migration  # type: ignore
+        run_runtime_coordination_migration(db_path)
+        from migrations.auto_apply import auto_apply  # type: ignore
+        auto_apply(db_path)
+    finally:
+        schema_migration._PREFLIGHT_HOOKS.clear()
+        schema_migration._PREFLIGHT_HOOKS.update(saved_hooks)
+    return db_path
+
+
+def _central_data_root(tmp_path: Path, pid: str) -> Path:
+    """A data root shaped ``<tmp>/.vnx-data/<pid>`` so _project_id_from_db_path()
+    fail-closed-resolves *pid* from the DB path (no env var needed)."""
+    return tmp_path / ".vnx-data" / pid
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Keep the pytest DB-isolation guard satisfied and never leak a stray
+    VNX_PROJECT_ID into the fail-closed resolver (each test's store resolves its
+    tenant from its own DB path)."""
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "guard-tmp"))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+
+def _uv(db_path: Path) -> int:
+    c = sqlite3.connect(str(db_path))
+    try:
+        return c.execute("PRAGMA user_version").fetchone()[0]
+    finally:
+        c.close()
+
+
+def _has_horizon(db_path: Path) -> bool:
+    c = sqlite3.connect(str(db_path))
+    try:
+        return any(r[1] == "horizon" for r in c.execute("PRAGMA table_info('tracks')"))
+    finally:
+        c.close()
+
+
+# ===========================================================================
+# D1 — parser comment masking
+# ===========================================================================
+
+class TestD1ParserCommentMasking:
+    def test_block_comment_paren_does_not_unbalance(self) -> None:
+        sql = "CREATE TABLE t (a INT /* note ) ( */, b INT)"
+        op = sql.index("(")
+        cp = mfs._matching_paren(sql, op)
+        assert sql[op + 1:cp] == "a INT /* note ) ( */, b INT"
+
+    def test_line_comment_paren_does_not_unbalance(self) -> None:
+        sql = "CREATE UNIQUE INDEX ix ON dispatches(dispatch_id) -- trailing ) ( (\n"
+        op = sql.index("(")
+        assert sql[op + 1:mfs._matching_paren(sql, op)] == "dispatch_id"
+
+    def test_comment_comma_not_split_as_column(self) -> None:
+        items = mfs._split_columns_and_constraints(
+            "a INT /* x, y */, b TEXT DEFAULT 'p,q'")
+        assert items == ["a INT /* x, y */", "b TEXT DEFAULT 'p,q'"]
+
+    def test_mask_preserves_length(self) -> None:
+        sql = "x /* a ) */ -- b (\n y '('"
+        assert len(mfs._mask_quoted_sql(sql)) == len(sql)
+
+
+# ===========================================================================
+# D3 — resolved tenant stamp, never 'vnx-dev' on a non-vnx-dev store
+# ===========================================================================
+
+class TestD3ResolvedTenantStamp:
+    def test_render_static_0031_substitutes_resolved_pid(self) -> None:
+        rendered = mfs._render_static_0031_sql_with_pid(
+            "INSERT INTO x SELECT 'vnx-dev'; project_id TEXT DEFAULT 'vnx-dev'",
+            "sales-copilot")
+        assert "'vnx-dev'" not in rendered
+        assert rendered.count("'sales-copilot'") == 2
+
+    def test_render_escapes_single_quotes(self) -> None:
+        # Defense in depth — a validated pid never carries a quote, but the
+        # substitution must not enable SQL breakage if one ever slipped through.
+        assert mfs._sql_quote_literal("a'b") == "'a''b'"
+
+    def test_no_vnx_dev_leak_on_non_vnx_dev_store(self, tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+        pid = "salescopilot-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        # Seed a track + a runtime lease row stamped with the correct tenant, plus a
+        # legacy 'vnx-dev' lease row that Phase 2 (W1) restamps.
+        c = sqlite3.connect(str(db_path))
+        c.execute("INSERT INTO tracks (track_id, project_id, title, goal_state, phase) "
+                  "VALUES ('t-1', ?, 'T', 'g', 'queued')", (pid,))
+        c.commit()
+        c.close()
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        c = sqlite3.connect(str(db_path))
+        try:
+            # Leak assertion (coordinator R2): a non-vnx-dev fixture must hold NO
+            # 'vnx-dev' project_id in tracks after migration.
+            assert c.execute("SELECT DISTINCT project_id FROM tracks").fetchall() == [(pid,)]
+            assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            c.close()
+
+    def test_runtime_child_fks_are_composite(self, tmp_path: Path,
+                                             monkeypatch: pytest.MonkeyPatch) -> None:
+        """D2: after 0031 every runtime child references the composite parent key."""
+        pid = "fkshape-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        c = sqlite3.connect(str(db_path))
+        try:
+            assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+            for table, expect in (
+                ("headless_runs", {"dispatch_id", "project_id"}),
+                ("dispatch_attempts", {"dispatch_id", "project_id"}),
+                ("worker_states", {"terminal_id", "project_id"}),
+            ):
+                fks = c.execute(f"PRAGMA foreign_key_list('{table}')").fetchall()
+                # every FK 'from' side must include project_id (composite)
+                by_id: dict[int, set[str]] = {}
+                for r in fks:
+                    by_id.setdefault(r[0], set()).add(r[3])
+                assert any(expect.issubset(cols) for cols in by_id.values()), (
+                    f"{table} FKs not composite: {by_id}")
+        finally:
+            c.close()
+
+
+# ===========================================================================
+# D4 — pre-27 store gains tracks.horizon; idempotent
+# ===========================================================================
+
+class TestD4WholePipeline:
+    def test_pre27_store_migrates_to_horizon(self, tmp_path: Path,
+                                             monkeypatch: pytest.MonkeyPatch) -> None:
+        pid = "pre27-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        assert _uv(db_path) < 27
+        assert not _has_horizon(db_path)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        assert _uv(db_path) == 31
+        assert _has_horizon(db_path)
+
+    def test_schema_only_run_skips_w1_but_delivers_horizon(self, tmp_path: Path,
+                                                           monkeypatch: pytest.MonkeyPatch) -> None:
+        """run_tenant_stamp=False (the vnx migrate CLI contract) delivers tracks.horizon
+        and the composite runtime FKs WITHOUT running the (currently-broken) W1 pass."""
+        pid = "schemaonly-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, run_tenant_stamp=False, backup=True)
+        assert _uv(db_path) == 31
+        assert _has_horizon(db_path)
+        c = sqlite3.connect(str(db_path))
+        try:
+            assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            c.close()
+
+    def test_idempotent_rerun(self, tmp_path: Path,
+                              monkeypatch: pytest.MonkeyPatch) -> None:
+        pid = "idem-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)  # re-run: no-op
+        assert _uv(db_path) == 31
+        assert _has_horizon(db_path)
+        c = sqlite3.connect(str(db_path))
+        try:
+            assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            c.close()
+
+
+# ===========================================================================
+# D6 — backup, lying-version reconcile, crash recovery, FK-off behaviour
+# ===========================================================================
+
+class TestD6Safety:
+    def test_vacuum_into_backup_created_and_valid(self, tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+        pid = "backup-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True, backup=True)
+        backups = list((data_root / "state").glob("runtime_coordination.db.premigrate-*.bak"))
+        assert backups, "no VACUUM INTO backup was created"
+        # The backup must be a self-consistent readable SQLite DB.
+        b = sqlite3.connect(str(backups[0]))
+        try:
+            assert b.execute("PRAGMA integrity_check").fetchone() == ("ok",)
+        finally:
+            b.close()
+
+    def test_lying_version_downgraded_and_horizon_added(self, tmp_path: Path,
+                                                        monkeypatch: pytest.MonkeyPatch) -> None:
+        """A store that CLAIMS a version past 0027 but physically lacks tracks.horizon
+        is reconciled (downgraded) and the walk re-adds horizon."""
+        pid = "lying-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        assert not _has_horizon(db_path)
+        c = sqlite3.connect(str(db_path))
+        c.execute("PRAGMA user_version = 28")  # lie: claim past 0027
+        c.commit()
+        c.close()
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        assert _uv(db_path) == 31
+        assert _has_horizon(db_path)
+
+    def test_duplicate_column_rerun_is_noop(self, tmp_path: Path,
+                                            monkeypatch: pytest.MonkeyPatch) -> None:
+        """Re-running after a converged migration is a clean no-op (no duplicate-column
+        error from re-applying 0027's ADD COLUMN)."""
+        pid = "dup-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        # A second run must not raise "duplicate column name: horizon".
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        assert _has_horizon(db_path)
+
+    def test_crash_between_drop_and_rename_is_recoverable(self, tmp_path: Path,
+                                                          monkeypatch: pytest.MonkeyPatch) -> None:
+        """A crash between DROP headless_runs and RENAME staging→headless_runs must
+        roll the whole 0031 rebuild back (headless_runs intact, version unchanged),
+        and a retry must then succeed."""
+        pid = "crash-proj"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        # Walk to v30 first so the crash isolates the 0031 rebuild step.
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+
+        # Drive the numbered walk up to (but not including) 0031 via the public
+        # apply_migration_* chain on a normal connection.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys = ON")
+        mfs._run_adr007_dispatches_repair(conn, db_path)
+        mfs._run_version_reconciliation(conn, db_path)
+        for fn in (mfs.apply_migration, mfs.apply_migration_v24, mfs.apply_migration_v27,
+                   mfs.apply_migration_v28, mfs.apply_migration_v29, mfs.apply_migration_v30):
+            fn(conn, data_root)
+            conn.commit()
+        assert mfs.schema_migration.get_user_version(conn) == 30
+        pre_rows = conn.execute("SELECT COUNT(*) FROM headless_runs").fetchone()[0]
+        conn.close()
+
+        # Reconnect through a factory that raises exactly on the headless_runs RENAME.
+        class _RenameCrash(sqlite3.Connection):
+            def execute(self, sql, *args, **kwargs):  # type: ignore[override]
+                if isinstance(sql, str) and 'RENAME TO "headless_runs"' in sql:
+                    raise RuntimeError("simulated crash between DROP and RENAME")
+                return super().execute(sql, *args, **kwargs)
+
+        crash_conn = sqlite3.connect(str(db_path), factory=_RenameCrash)
+        crash_conn.execute("PRAGMA foreign_keys = ON")
+        with pytest.raises(RuntimeError, match="simulated crash"):
+            mfs.apply_migration_v31(crash_conn, data_root)
+        crash_conn.close()
+
+        # Store must be intact: version still 30, headless_runs present with rows.
+        assert _uv(db_path) == 30
+        check = sqlite3.connect(str(db_path))
+        try:
+            assert check.execute(
+                "SELECT COUNT(*) FROM headless_runs").fetchone()[0] == pre_rows
+        finally:
+            check.close()
+
+        # Retry succeeds cleanly.
+        retry = sqlite3.connect(str(db_path))
+        retry.execute("PRAGMA foreign_keys = ON")
+        mfs.apply_migration_v31(retry, data_root)
+        retry.commit()
+        assert mfs.schema_migration.get_user_version(retry) == 31
+        assert retry.execute("PRAGMA foreign_key_check").fetchall() == []
+        retry.close()
+
+    def test_fk_enforcement_off_during_rebuild(self, tmp_path: Path,
+                                               monkeypatch: pytest.MonkeyPatch) -> None:
+        """The 0031 rebuild must run with FK enforcement OFF (set before the
+        transaction — the in-SQL PRAGMA is a no-op inside it). A child table carrying
+        a GHOST FK to a dropped parent (a real post-0022-rebuild artifact) would make
+        the DROP fail if FK enforcement were on; the rebuild succeeding proves it is
+        off, and foreign_key_check is empty afterwards."""
+        pid = "fkoff-test"
+        data_root = _central_data_root(tmp_path, pid)
+        db_path = _bootstrap_store(data_root)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+
+        # Inject a ghost FK: rebuild dispatch_attempts to REFERENCE a non-existent
+        # 'dispatches_pre_v22' (mirrors the sales-copilot legacy artifact).
+        conn = sqlite3.connect(str(db_path))
+        conn.execute("PRAGMA foreign_keys = OFF")
+        conn.executescript(
+            """
+            ALTER TABLE dispatch_attempts RENAME TO dispatch_attempts_old;
+            CREATE TABLE dispatch_attempts (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                attempt_id TEXT NOT NULL UNIQUE,
+                dispatch_id TEXT NOT NULL REFERENCES "dispatches_pre_v22" (dispatch_id),
+                attempt_number INTEGER NOT NULL DEFAULT 1,
+                terminal_id TEXT NOT NULL,
+                state TEXT NOT NULL DEFAULT 'pending',
+                started_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+                ended_at TEXT, failure_reason TEXT, metadata_json TEXT DEFAULT '{}',
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+            );
+            DROP TABLE dispatch_attempts_old;
+            """
+        )
+        conn.commit()
+        conn.close()
+
+        mfs.run(data_dir=data_root, tenant_stamp_fatal=True)
+        assert _uv(db_path) == 31
+        c = sqlite3.connect(str(db_path))
+        try:
+            assert c.execute("PRAGMA foreign_key_check").fetchall() == []
+        finally:
+            c.close()
+
+
+# ===========================================================================
+# D5 — fail-closed horizon guards in the tracks DAL
+# ===========================================================================
+
+_TRACKS_V22_DDL = """
+CREATE TABLE tracks (
+    track_id TEXT NOT NULL PRIMARY KEY,
+    title TEXT NOT NULL,
+    goal_state TEXT NOT NULL,
+    phase TEXT NOT NULL DEFAULT 'queued',
+    next_up INTEGER NOT NULL DEFAULT 0,
+    sort_order INTEGER NOT NULL DEFAULT 0,
+    priority TEXT,
+    requires_operator_promotion INTEGER NOT NULL DEFAULT 1,
+    instruction_template TEXT,
+    context_composer_rules TEXT,
+    pr_ref TEXT,
+    trigger_condition TEXT,
+    project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    phase_changed_at TEXT,
+    completed_at TEXT,
+    metadata_json TEXT DEFAULT '{}'
+);
+"""
+
+
+def _make_pre27_tracks_store(tmp_path: Path, *, with_horizon: bool) -> Path:
+    """A minimal store with a tracks table, optionally carrying the horizon column."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (tmp_path / "events").mkdir(parents=True, exist_ok=True)
+    db = state_dir / tracks_dal.DB_FILENAME
+    conn = sqlite3.connect(str(db))
+    conn.executescript(_TRACKS_V22_DDL)
+    if with_horizon:
+        conn.execute("ALTER TABLE tracks ADD COLUMN horizon TEXT")
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+class TestD5FailClosedHorizon:
+    def test_create_track_with_horizon_pre27_raises(self, tmp_path: Path) -> None:
+        state_dir = _make_pre27_tracks_store(tmp_path, with_horizon=False)
+        with pytest.raises(tracks_dal.HorizonColumnMissingError, match="run `vnx migrate`|migration 0027"):
+            tracks_dal.create_track(
+                state_dir, "t-1", "proj-x", "Title", "goal", horizon="now")
+        # No spurious track_created row (guard runs before insert).
+        c = sqlite3.connect(str(state_dir / tracks_dal.DB_FILENAME))
+        try:
+            assert c.execute("SELECT COUNT(*) FROM tracks").fetchone()[0] == 0
+        finally:
+            c.close()
+
+    def test_create_track_without_horizon_pre27_ok(self, tmp_path: Path) -> None:
+        state_dir = _make_pre27_tracks_store(tmp_path, with_horizon=False)
+        row = tracks_dal.create_track(
+            state_dir, "t-1", "proj-x", "Title", "goal", horizon=None)
+        assert row["track_id"] == "t-1"
+
+    def test_create_track_with_horizon_post27_ok(self, tmp_path: Path) -> None:
+        state_dir = _make_pre27_tracks_store(tmp_path, with_horizon=True)
+        row = tracks_dal.create_track(
+            state_dir, "t-1", "proj-x", "Title", "goal", horizon="now")
+        assert row["horizon"] == "now"
+
+    def test_update_authored_horizon_pre27_raises(self, tmp_path: Path) -> None:
+        state_dir = _make_pre27_tracks_store(tmp_path, with_horizon=False)
+        tracks_dal.create_track(state_dir, "t-1", "proj-x", "Title", "goal", horizon=None)
+        with pytest.raises(tracks_dal.HorizonColumnMissingError):
+            tracks_dal.update_authored_fields(
+                state_dir, "t-1", "proj-x", horizon="next")
+
+    def test_update_authored_non_horizon_pre27_ok(self, tmp_path: Path) -> None:
+        state_dir = _make_pre27_tracks_store(tmp_path, with_horizon=False)
+        tracks_dal.create_track(state_dir, "t-1", "proj-x", "Title", "goal", horizon=None)
+        row = tracks_dal.update_authored_fields(
+            state_dir, "t-1", "proj-x", title="New Title")
+        assert row["title"] == "New Title"

--- a/tests/test_migration_0031_runtime_fk.py
+++ b/tests/test_migration_0031_runtime_fk.py
@@ -155,7 +155,10 @@ _TRACK_CHAIN = (
 
 def _build_v30_db(tmp_path: Path) -> tuple[Path, sqlite3.Connection]:
     project_root = tmp_path / "project"
-    state_dir = project_root / ".vnx-data" / "state"
+    # Anchor the store under .vnx-data/<pid>/state so the static 0031 path can
+    # fail-closed-resolve the tenant identity ('vnx-dev' here) from the DB path
+    # (D3: the row-copy is stamped with the RESOLVED pid, not a hardcoded literal).
+    state_dir = project_root / ".vnx-data" / "vnx-dev" / "state"
     state_dir.mkdir(parents=True)
     conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
     conn.execute("PRAGMA foreign_keys=OFF")

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -15,11 +15,110 @@ Use when:
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 
 from vnx_cli import _engine
 from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+
+
+def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
+    """Drive the WHOLE future-system pipeline against the store at *data_root* (D4).
+
+    The bootstrap chain above only reaches the numbered runners with a paired
+    ``apply_NNNN.py`` (≤ v26). The Horizon schema (tracks.horizon, deliverables
+    view) plus the ADR-007 dispatches repair, version reconciliation, the 0027→0031
+    walk, and W1 tenant-stamping live in ``migrate_future_system.run()``, which was
+    NEVER wired into ``vnx migrate`` — leaving pre-Horizon stores missing
+    ``tracks.horizon`` (Bug A). This threads the EXACT canonical data root the CLI
+    already resolved (the runner would otherwise re-derive
+    ``<project_root>/.vnx-data`` — the D4 threading trap) and takes a VACUUM INTO
+    backup first. A W1 tenant-stamping failure is non-fatal here: the schema walk is
+    committed before W1 runs, so the store keeps ``tracks.horizon`` and the operator
+    is warned rather than losing the Horizon schema.
+    """
+    _engine.ensure_engine_on_path()
+    scripts_dir = _engine.engine_root() / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+
+    import migrate_future_system  # type: ignore
+
+    # Anchor the tenant on disk (not via a global env mutation that would leak across
+    # a fleet sweep or a shared test process): write the canonical .vnx-project-id
+    # marker in the data root when absent, so the fail-closed resolver in the runner
+    # resolves THIS store's project_id even for a non-central (XDG/local) layout the
+    # DB-path anchor can't cover. Never overwrites an existing marker.
+    marker = data_root / ".vnx-project-id"
+    if not marker.exists():
+        try:
+            marker.write_text(project_id + "\n", encoding="utf-8")
+        except OSError:
+            pass  # advisory — central stores still resolve via the DB-path anchor
+
+    # data_dir is threaded explicitly (D4 threading trap); no env mutation needed.
+    # run_tenant_stamp=False: W1 tenant-stamping is disabled for vnx migrate because it
+    # is currently broken for the stores this targets (pool_config UNIQUE collision on
+    # every bootstrapped store + a legacy recommendation_outcomes child-FK gap) and
+    # would only churn the store on a self-restoring failure. The schema fix that adds
+    # tracks.horizon (the actual gap) is delivered by the walk regardless. See run().
+    migrate_future_system.run(
+        data_dir=data_root,
+        tenant_stamp_fatal=False,
+        run_tenant_stamp=False,
+        backup=True,
+    )
+
+
+def _iter_central_project_stores() -> list[tuple[Path, str]]:
+    """Return ``[(data_root, project_id)]`` for every central per-project store.
+
+    A central store lives at ``<data_home>/<project_id>/state/runtime_coordination.db``
+    where <data_home> is ``$VNX_DATA_HOME`` or ``~/.vnx-data``. Only directory names
+    matching the project-id grammar (``^[a-z][a-z0-9-]{1,31}$``) are considered, so a
+    stray non-store dir cannot be swept and no path-traversal name is honoured.
+    """
+    import re as _re
+
+    pid_re = _re.compile(r"^[a-z][a-z0-9-]{1,31}$")
+    data_home = Path(os.environ.get("VNX_DATA_HOME") or (Path.home() / ".vnx-data"))
+    if not data_home.is_dir():
+        return []
+    stores: list[tuple[Path, str]] = []
+    for child in sorted(data_home.iterdir()):
+        if not child.is_dir() or not pid_re.match(child.name):
+            continue
+        if (child / "state" / "runtime_coordination.db").exists():
+            stores.append((child, child.name))
+    return stores
+
+
+def migrate_all_central_stores() -> int:
+    """Fleet-sync: run the future-system pipeline on every central store (D4).
+
+    Invoked after ``vnx update`` flips the engine version so no per-project store is
+    left half-migrated behind a newer engine. Best-effort per store: a failure on one
+    store is logged and the sweep continues (never aborts the whole fleet). Each store
+    gets a VACUUM INTO backup and non-fatal W1. Returns the count that migrated cleanly.
+    """
+    stores = _iter_central_project_stores()
+    if not stores:
+        print("  no central per-project stores found — nothing to migrate.")
+        return 0
+    ok = 0
+    for data_root, project_id in stores:
+        print(f"\n[fleet-migrate] {project_id} — {data_root}")
+        try:
+            _run_future_system_pipeline(data_root, project_id)
+            ok += 1
+        except Exception as exc:
+            print(
+                f"  [fleet-migrate][WARN] {project_id}: migration failed: {exc}",
+                file=sys.stderr,
+            )
+    print(f"\n[fleet-migrate] {ok}/{len(stores)} central stores migrated cleanly.")
+    return ok
 
 
 def vnx_migrate(args) -> int:
@@ -43,6 +142,14 @@ def vnx_migrate(args) -> int:
         _bootstrap_runtime_dbs(data_root, project_id=project_id)
     except Exception as exc:
         print(f"\n  error: migration failed: {exc}", file=sys.stderr)
+        return 1
+
+    # D4: drive the future-system pipeline (0027→0031 + Horizon + W1) so
+    # tracks.horizon actually lands. Without this, vnx migrate stops at v26.
+    try:
+        _run_future_system_pipeline(data_root, project_id)
+    except Exception as exc:
+        print(f"\n  error: future-system migration failed: {exc}", file=sys.stderr)
         return 1
 
     print()

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -16,11 +16,55 @@ Use when:
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 
 from vnx_cli import _engine
 from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+
+#: Central store layout ``.../.vnx-data/<pid>/`` — anchors the tenant on the data path.
+_DATA_PATH_PID_RE = re.compile(r"(?:^|/)\.vnx-data/([a-z0-9][a-z0-9._-]{0,63})/?$")
+
+
+def _read_marker_pid(data_root: Path) -> "str | None":
+    """First non-empty line of ``data_root/.vnx-project-id`` (the tenant marker)."""
+    marker = data_root / ".vnx-project-id"
+    if not marker.is_file():
+        return None
+    try:
+        first = marker.read_text(encoding="utf-8").splitlines()[0].strip()
+    except (OSError, IndexError):
+        return None
+    return first or None
+
+
+def _reconcile_tenant_or_fail(data_root: Path, project_id: str) -> None:
+    """FAIL-CLOSED tenant reconciliation before migrating (codex split-tenant fix).
+
+    The CLI seeds pool_config with the CLI-derived ``project_id`` while the runner's
+    fail-closed resolver stamps rows from the ``.vnx-project-id`` marker / VNX_PROJECT_ID
+    / data-path anchor. If those DISAGREE, the store would be split-tenant (codex saw
+    terminal_leases stamped 'otherproj' while pool_config was seeded 'myproject'). We
+    refuse when any present source disagrees with the CLI-derived id rather than
+    silently stamping one and seeding another.
+    """
+    sources = {
+        "cli-derived": project_id,
+        "marker": _read_marker_pid(data_root),
+        "env:VNX_PROJECT_ID": (os.environ.get("VNX_PROJECT_ID") or "").strip() or None,
+    }
+    m = _DATA_PATH_PID_RE.search(str(data_root).rstrip("/"))
+    if m:
+        sources["data-path"] = m.group(1)
+    present = {k: v for k, v in sources.items() if v}
+    if len(set(present.values())) > 1:
+        detail = ", ".join(f"{k}={v!r}" for k, v in present.items())
+        raise RuntimeError(
+            "refusing to migrate a split-tenant store: the tenant sources disagree "
+            f"({detail}). Resolve .vnx-project-id / VNX_PROJECT_ID / the data-path so "
+            "they all name one project before migrating (ADR-007 fail-closed)."
+        )
 
 
 def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
@@ -45,11 +89,15 @@ def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
 
     import migrate_future_system  # type: ignore
 
+    # FAIL-CLOSED first: refuse to migrate if the CLI-derived tenant disagrees with an
+    # existing marker / VNX_PROJECT_ID / the data-path anchor (no split-tenant store).
+    _reconcile_tenant_or_fail(data_root, project_id)
+
     # Anchor the tenant on disk (not via a global env mutation that would leak across
     # a fleet sweep or a shared test process): write the canonical .vnx-project-id
     # marker in the data root when absent, so the fail-closed resolver in the runner
     # resolves THIS store's project_id even for a non-central (XDG/local) layout the
-    # DB-path anchor can't cover. Never overwrites an existing marker.
+    # DB-path anchor can't cover. Never overwrites an existing marker (reconciled above).
     marker = data_root / ".vnx-project-id"
     if not marker.exists():
         try:

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -184,6 +184,16 @@ def vnx_migrate(args) -> int:
     # Derive project_id so the bootstrap seeds the correct pool_config row.
     project_id = _engine.derive_project_id(project_dir)
 
+    # FAIL-CLOSED FIRST GATE (codex round-2 ordering fix): reconcile the tenant BEFORE
+    # bootstrap so a split-tenant store is refused with ZERO rows created or seeded —
+    # bootstrap seeds pool_config with the CLI-derived id, which must never happen on a
+    # store whose marker/env/data-path names a different tenant.
+    try:
+        _reconcile_tenant_or_fail(data_root, project_id)
+    except Exception as exc:
+        print(f"\n  error: {exc}", file=sys.stderr)
+        return 1
+
     print(f"Migrating VNX runtime databases at: {data_root}")
 
     try:

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -250,7 +250,19 @@ def vnx_update(args) -> int:
 
     if dry_run:
         print(f"[dry-run] Update to '{target}' would succeed.")
-    else:
-        print(f"VNX updated to '{target}'.")
+        print("[dry-run] Would migrate all central per-project stores to the new schema.")
+        return 0
+
+    print(f"VNX updated to '{target}'.")
+
+    # D4 fleet-sync: after flipping the engine version, migrate every central
+    # per-project store so none is left half-migrated behind the newer engine.
+    # Best-effort — a per-store failure is logged, never aborts the update.
+    try:
+        print("\nMigrating central per-project stores to the new schema ...")
+        from vnx_cli.commands.migrate import migrate_all_central_stores
+        migrate_all_central_stores()
+    except Exception as exc:
+        print(f"  warning: fleet store migration sweep failed: {exc}", file=sys.stderr)
 
     return 0


### PR DESCRIPTION
P0 — sales-copilot escalation. Pre-Horizon stores (sales-copilot @v26) miss `tracks.horizon`; the pipeline was unwired + broken. Fixes: parser (`_mask_quoted_sql` masks block/line comments), composite FK shape, **0031's hardcoded 'vnx-dev' in both `_V31_TABLE_DDL` + the static SQL** (ADR-007 — would have corrupted sales-copilot), `vnx migrate`+`update` drive the whole pipeline (exact data_root threading), has_horizon fail-closed in the write-path, WAL-safe VACUUM INTO backup + crash-tests. Verified against a read-only snapshot of the real sales-copilot store. 21 new tests green; ~480 regression suite: only pre-existing base-HEAD failures.

DEVIATION (reported): W1 tenant-stamping disabled in `vnx migrate` (`run_tenant_stamp=False`) — W1 is genuinely broken (pool_config double-seed collision + child-FK-widening gap); ships schema-only (the actual gap) + a follow-up track for W1.

Track: horizon-schema-migration-fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC