### PR TITLE
fix(central-mode): route __file__-anchored data-dir/roadmap paths through canonical resolvers + CI-grep-gate

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -75,6 +75,8 @@ jobs:
             "$VNX_HOME/tests/test_receipt_ci_guard.py" \
             "$VNX_HOME/tests/test_dispatch_sidedoor_audit.py" \
             "$VNX_HOME/tests/test_runtime_adapter_certification.py" \
+            "$VNX_HOME/tests/test_central_mode_path_gate.py" \
+            "$VNX_HOME/tests/test_central_mode_path_resolution.py" \
             -p no:cacheprovider \
             --basetemp=/tmp/vnx_pytest_safe
 
@@ -86,6 +88,16 @@ jobs:
           # Audit #2: the dispatch-lane exhaustiveness invariant — fail CI if a new direct delivery
           # caller bypasses the single-entry door without being audited.
           python3 "$VNX_HOME/scripts/lib/dispatch_sidedoor_audit.py"
+
+      - name: Central-mode path gate
+        env:
+          VNX_HOME: ${{ github.workspace }}/.claude/vnx-system
+        run: |
+          set -euo pipefail
+          # Fail CI if a new .vnx-data/ROADMAP.yaml path literal is derived from
+          # __file__/parents[N] in scripts/lib (would resolve the keystone, not
+          # ~/.vnx-data/<project>, in a central install). See #1023/#1024.
+          python3 "$VNX_HOME/scripts/check_no_file_derived_data_paths.py" "$VNX_HOME"
 
   trace-token-check:
     name: Trace Token Validation

--- a/FEATURE_PLAN.md
+++ b/FEATURE_PLAN.md
@@ -1,12 +1,48 @@
 <!-- AUTO-GENERATED — DO NOT EDIT — see scripts/build_feature_plan.py -->
 
 # VNX Feature Plan
-**Last updated**: 2026-07-02T06:18:25.424971+00:00
+**Last updated**: 2026-07-06T06:59:07.229673+00:00
 
 ## Recently Merged
 _Last 14 days — sourced from git merge commits._
 
 **Other**
+- #1024 — fix(migrate): wire+repair the Horizon 0022-0031 pipeline into vnx migrate (P0) (#1024) (2026-07-06)
+- #1023 — fix(lane): thread project_root from invocation context so central-mode workers spawn in the project, not the keystone (#1023) (2026-07-06)
+- #1022 — docs(core): Horizon planning module (#1022) (2026-07-05)
+- #1019 — docs(governance): sweep to shipped reality (#1001-1018) (#1019) (2026-07-05)
+- #1021 — docs(intelligence): sweep to shipped reality (#1001-1018) (#1021) (2026-07-05)
+- #1020 — docs(dispatch): sweep to shipped reality (#1001-1018) (#1020) (2026-07-05)
+- #1018 — test(horizon): parity + ADR-007 cross-project isolation coverage [D3] (#1018) (2026-07-05)
+- #1017 — feat(dispatch): configurable tmux-spawn concurrency via VNX_TMUX_MAX_CONCURRENT (N-slot semaphore, default 1) (#1017) (2026-07-05)
+- #1016 — chore(dispatch): default tmux-spawn workers to --dangerously-skip-permissions (isolated worktree; VNX_WORKER_SCOPED=1 opts into scoped) (#1016) (2026-07-05)
+- #1015 — refactor(horizon): rename pm skill → horizon + reconcile terminology (pm alias kept) [D2] (#1015) (2026-07-05)
+- #1014 — feat(horizon): ship vnx horizon command group (full surface, tenant-safe resolver, objective/deliverable aliases) [D1] (#1014) (2026-07-05)
+- #1013 — chore(providers): bump worker pin Sonnet 4.6 → Sonnet 5 (#1013) (2026-07-05)
+- #1011 — feat(gov): signed budgeted audited gate override (recorded deviation, never silent) [D4] (#1011) (2026-07-05)
+- #1012 — feat(gov): init provisions attest trust-root + ships the gate workflow (no key) [D5] (#1012) (2026-07-05)
+- #1009 — feat(gov): server-side attestation verify gate, staged advisory + CODEOWNERS trust-root [D3] (#1009) (2026-07-05)
+- #1010 — docs(intel): self-learning loop — operator-gated tiers, off-switches, philosophy [D7] (#1010) (2026-07-05)
+- #1008 — feat(intel): operator-gated skill-refinement proposals from rework attribution [D6] (#1008) (2026-07-05)
+- #1006 — feat(intel): tagger A/B harness (optional precision, no default-on) [D4] (#1006) (2026-07-05)
+- #1007 — feat(gov): in-repo attest record, content-keyed + diff-bound (squash-safe) [D2] (#1007) (2026-07-04)
+- #1005 — feat(intel): outcome-grounding shadow-verify V2 vs V1 + directional check [D5] (#1005) (2026-07-04)
+- #1004 — feat(gov): SSH-key signing/verify + attestation manifest (test-key; keychain = operator step) [D1] (#1004) (2026-07-04)
+- #1003 — feat(intel): schedule operator-gated proposal tier + gate stale-pattern supersede [D3] (#1003) (2026-07-04)
+- #1002 — refactor(intel): drop dead success_rate column, reversible migration [D2] (#1002) (2026-07-04)
+- #1001 — refactor(intel): explicit confidence range contract + keep subprocess delta path [D1] (#1001) (2026-07-04)
+- #1000 — fix(reconcile): flip criterion requires 7 consecutive clean runs [Tier-2 finding] (#1000) (2026-07-04)
+- #999 — docs(reconcile): closed-loop backward closure — reconcile, reopen valve, operational notes [D5] (#999) (2026-07-04)
+- #998 — feat(reconcile): advisory-first continuous wiring — tick, review log, flip streak [D4] (#998) (2026-07-04)
+- #997 — feat(reconcile): audited done→active reopen valve + re-close guard [D6] (#997) (2026-07-04)
+- #996 — feat(reconcile): vnx objective reconcile — git-grounded batch auto-close [D3] (#996) (2026-07-04)
+- #995 — refactor(reconcile): extract close_track_if_done with close-time revalidation [D2] (#995) (2026-07-04)
+- #994 — feat(reconcile): ALL-merged multi-PR derivation + declared-done stability [D1] (#994) (2026-07-04)
+- #993 — docs(release): 1.0.0 post-launch sweep — released framing + SSOT reframe + archive (#993) (2026-07-04)
+- #992 — feat(skills): trigger-rich future-state skill descriptions + pm model-invocable (#992) (2026-07-03)
+- #991 — feat(gate): full provider-family panel for plan-gate assurance (#991) (2026-07-03)
+- #985 — docs(release): flip 1.0.0 RC framing to released 2026-07-02 (#985) (2026-07-02)
+- #984 — fix(security): block /state/ path traversal in dashboard [P0] (#984) (2026-07-02)
 - #983 — fix(launch): dependency + doc launch-blockers from the pre-1.0 provider-panel sweep (#983) (2026-07-01)
 - #982 — docs(launch): 1.0 HN-launch readiness — reconcile release status + refresh stale manifesto stamps (#982) (2026-07-01)
 - #981 — fix(governance): architecture batch A7+A6 — surface door-invariant breaches distinctly (#981) (2026-07-01)
@@ -57,7 +93,11 @@ _No active features._
 
 ## Completed
 
-_No completed features found in register or PR history._
+### F1
+All PRs merged. (#976 + #977)
+
+### F6
+All PRs merged. (#963)
 
 ## Planned (from ROADMAP.yaml)
 

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1760,7 +1760,7 @@ def _reconcile_tracks_fresh(
             sys.path.insert(0, str(_LIB_DIR))
         from track_reconciler import reconcile_all_tracks
 
-        results = reconcile_all_tracks(store, pid)
+        results = reconcile_all_tracks(store, pid, repo_root=_PROJECT_ROOT)
     except RuntimeError as exc:
         # derived_status column absent (migration 0028 not applied to this
         # store). Not an error — reconcile is N/A here.

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -119,13 +119,31 @@ GRANDFATHERED: Dict[str, Set[str]] = {
     },
     # .is_dir()-gated upward walks that look for an EXISTING .vnx-data; canonical
     # resolution (VNX_DATA_DIR env, or ensure_env()) is tried first in each caller.
+    # :848 reuses the same project_root, guarded by the VNX_DATA_DIR default.
     "scripts/lib/subprocess_adapter.py": {
         'search / ".vnx-data"',
+        'Path(project_root) / ".vnx-data"',
     },
     "scripts/lib/headless_dispatch_writer.py": {
         # vnx_paths.ensure_env() is the primary resolver here; this walk is the
         # except-branch last resort.
         'candidate / ".vnx-data"',
+    },
+    # Surfaced by the helper-return tracing (below). Pre-existing, out of this
+    # task's remit; each is env-first / .exists()-gated / repo_root-param-threaded
+    # with the __file__ walk only as a fallback. Tracked for follow-up migration.
+    "scripts/lib/event_analyzer.py": {
+        # .exists()-gated: only returns the derived archive dir if it exists.
+        'repo_root / ".vnx-data" / "events" / "archive"',
+    },
+    "scripts/lib/headless_dispatch_daemon.py": {
+        # env-first (VNX_DATA_DIR); _repo_root() is the helper-return fallback.
+        '_repo_root() / ".vnx-data"',
+    },
+    "scripts/lib/tmux_worktree.py": {
+        # _resolve_repo_root threads an explicit repo_root first (#1023); the
+        # __file__ branch is the no-arg fallback.
+        'root / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"',
     },
 }
 
@@ -135,38 +153,62 @@ GRANDFATHERED: Dict[str, Set[str]] = {
 # ---------------------------------------------------------------------------
 
 
-def _file_anchored_names(tree: ast.AST) -> Set[str]:
-    """Names bound anywhere to an expression that references ``__file__``.
-
-    Catches module-level and local assignments such as
-    ``_REPO_ROOT = Path(__file__).resolve().parents[2]`` or
-    ``here = Path(__file__).resolve()``.
-    """
-    anchored: Set[str] = set()
-    for node in ast.walk(tree):
-        value = None
-        targets: List[ast.expr] = []
-        if isinstance(node, ast.Assign):
-            value = node.value
-            targets = list(node.targets)
-        elif isinstance(node, ast.AnnAssign) and node.value is not None:
-            value = node.value
-            targets = [node.target]
-        if value is None:
-            continue
-        if any(isinstance(n, ast.Name) and n.id == "__file__" for n in ast.walk(value)):
-            for tgt in targets:
-                if isinstance(tgt, ast.Name):
-                    anchored.add(tgt.id)
-    return anchored
-
-
 def _references_file_anchor(node: ast.AST, anchored: Set[str]) -> bool:
-    """True if the subtree references ``__file__`` or a file-anchored name."""
+    """True if the subtree references ``__file__`` or a file-anchored name.
+
+    A file-anchored name is a variable OR a helper function whose call resolves
+    from ``__file__`` (see :func:`_file_anchored_names`). Because a call
+    ``_project_root()`` carries the function name as an ``ast.Name`` in
+    ``node.func``, this walk catches ``_project_root() / ".vnx-data"`` once
+    ``_project_root`` is in ``anchored``.
+    """
     for sub in ast.walk(node):
         if isinstance(sub, ast.Name) and (sub.id == "__file__" or sub.id in anchored):
             return True
     return False
+
+
+def _file_anchored_names(tree: ast.AST) -> Set[str]:
+    """Names that resolve from ``__file__`` — variables AND helper functions.
+
+    Iterated to a fixpoint so the anchor propagates transitively:
+      * assignments  — ``_REPO_ROOT = Path(__file__).resolve().parents[2]``,
+        ``here = Path(__file__).resolve()``;
+      * function defs — a helper whose ``return`` yields a ``__file__``-anchored
+        expression (e.g. ``def _project_root(): return Path(__file__)...``), so a
+        later ``_project_root() / ".vnx-data"`` join is caught even though the
+        ``__file__`` reference is hidden behind the call.
+    """
+    anchored: Set[str] = set()
+    changed = True
+    while changed:
+        changed = False
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Assign, ast.AnnAssign)):
+                value = node.value
+                if value is None:
+                    continue
+                targets = (
+                    node.targets if isinstance(node, ast.Assign) else [node.target]
+                )
+                if _references_file_anchor(value, anchored):
+                    for tgt in targets:
+                        if isinstance(tgt, ast.Name) and tgt.id not in anchored:
+                            anchored.add(tgt.id)
+                            changed = True
+            elif isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                if node.name in anchored:
+                    continue
+                for ret in ast.walk(node):
+                    if (
+                        isinstance(ret, ast.Return)
+                        and ret.value is not None
+                        and _references_file_anchor(ret.value, anchored)
+                    ):
+                        anchored.add(node.name)
+                        changed = True
+                        break
+    return anchored
 
 
 def _has_data_marker_constant(node: ast.AST) -> bool:

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -117,14 +117,6 @@ GRANDFATHERED: Dict[str, Set[str]] = {
         # env-first (VNX_STATE_DIR), .exists()-gated; _PROJECT_ROOT is __file__-anchored.
         '_PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"',
     },
-    # script_dir.parent.parent / ".vnx-data" _data_dir() siblings of the two this
-    # task migrated (t0_escalations_log / t0_decision_reconcile); env-first.
-    "scripts/lib/t0_decision_log.py": {
-        'script_dir.parent.parent / ".vnx-data"',
-    },
-    "scripts/lib/t0_decision_summarizer.py": {
-        'script_dir.parent.parent / ".vnx-data"',
-    },
     # .is_dir()-gated upward walks that look for an EXISTING .vnx-data; canonical
     # resolution (VNX_DATA_DIR env, or ensure_env()) is tried first in each caller.
     "scripts/lib/subprocess_adapter.py": {

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -1,0 +1,300 @@
+#!/usr/bin/env python3
+"""Central-mode path-correctness gate.
+
+Fails when a ``.vnx-data`` / ``ROADMAP.yaml`` path literal is built from a
+``__file__``-anchored expression OUTSIDE the canonical resolvers
+(``vnx_paths.py`` / ``project_root.py``).
+
+Why this bug class matters
+--------------------------
+In a CENTRAL install the shared library lives under
+``~/.vnx-system/current/scripts/lib/``. Any ``Path(__file__)….parent…/.vnx-data``
+walk therefore resolves the KEYSTONE (``~/.vnx-system/versions/<v>/.vnx-data``)
+instead of the project's ``~/.vnx-data/<project>`` — writing runtime state into
+the read-only install tree and reading state that will never be there. The same
+applies to ``ROADMAP.yaml`` resolved two-up from a central state dir. All
+data/roadmap paths must route through ``vnx_paths.resolve_*`` /
+``project_root.resolve_*``, which are VNX_HOME + project-marker aware. See
+#1023 / #1024 and the ``central-mode-path-correctness`` track.
+
+Detection
+---------
+AST-based, so comments and docstrings never trip it: a violation is a
+``.vnx-data`` / ``ROADMAP.yaml`` string constant that sits inside a path-join
+(``/`` BinOp) or ``Path(...)`` call whose expression also references
+``__file__`` *or* a module-/function-level name that is itself bound to a
+``__file__``-anchored expression (``_REPO_ROOT``, ``_THIS_DIR``, ``here``,
+``script_dir``, ...). A ``state_dir.parent.parent`` built from a resolved
+runtime Path parameter is NOT flagged — only ``__file__``-anchored derivations.
+
+Scope
+-----
+``scripts/lib/`` — the shared runtime library that runs in BOTH dev and central
+contexts. The top-level ``scripts/*.py`` entry-points resolve their own root
+and are out of scope for this gate (tracked separately).
+
+Grandfathering
+--------------
+The two canonical resolvers are exempt (they are *supposed* to derive from
+``__file__``). Pre-existing library occurrences that this task did not migrate
+are listed in ``GRANDFATHERED`` with a reason. The gate blocks NEW occurrences
+and any change to a grandfathered line, so the bug class cannot silently return.
+"""
+from __future__ import annotations
+
+import ast
+import sys
+from pathlib import Path
+from typing import Dict, List, Set, Tuple
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SCAN_DIR = "scripts/lib"
+
+DATA_PATH_MARKERS = (".vnx-data", "ROADMAP.yaml")
+
+# The canonical resolvers: these files are the ONE place allowed to derive the
+# data/roadmap roots from __file__.
+EXEMPT_FILES = frozenset({"vnx_paths.py", "project_root.py"})
+
+# Pre-existing __file__-anchored data-path derivations in scripts/lib that this
+# task (central-mode-path-correctness) did not migrate. Keyed by repo-relative
+# path -> set of normalized offending expression segments. These are the SAME
+# bug class and should be migrated to the canonical resolvers in follow-up work;
+# they are grandfathered so the gate can pass on the current tree while blocking
+# NEW occurrences. A change to any listed line drops it from the match and trips
+# the gate — forcing migration rather than silent perpetuation.
+GRANDFATHERED: Dict[str, Set[str]] = {
+    # env-first (VNX_DATA_DIR) with a repo-relative _REPO_ROOT default; only the
+    # default branch is __file__-anchored.
+    "scripts/lib/governance_audit.py": {
+        'Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))',
+    },
+    "scripts/lib/governance_enforcer.py": {
+        'Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))',
+    },
+    # _REPO_ROOT / _LIB_DIR co-located-layout fallbacks (env checked upstream).
+    "scripts/lib/gate_register_emit.py": {
+        '_REPO_ROOT / ".vnx-data" / "state" / "dispatch_register.ndjson"',
+    },
+    "scripts/lib/dispatch_register.py": {
+        '_REPO_ROOT / ".vnx-data" / "state"',
+    },
+    "scripts/lib/state_rebuild_trigger.py": {
+        '_REPO_ROOT / ".vnx-data" / "state"',
+    },
+    "scripts/lib/pool_worker_runner.py": {
+        '_LIB_DIR.parents[1] / ".vnx-data" / "state"',
+        '_LIB_DIR.parents[1] / ".vnx-data" / "dispatches"',
+    },
+    # Direct Path(__file__)… walks (env checked upstream in each caller).
+    "scripts/lib/dispatch_parameter_tracker.py": {
+        'Path(__file__).resolve().parents[2] / ".vnx-data" / "state"',
+    },
+    "scripts/lib/llm_decision_router.py": {
+        'Path(__file__).resolve().parents[2] / ".vnx-data"',
+    },
+    "scripts/lib/receipt_classifier.py": {
+        'Path(__file__).resolve().parents[2] / ".vnx-data" / "state"',
+    },
+    "scripts/lib/session_store.py": {
+        'Path(__file__).resolve().parent.parent.parent / ".vnx-data" / "state"',
+    },
+    "scripts/lib/worker_health_monitor.py": {
+        'Path(__file__).resolve().parents[2] / ".vnx-data" / "events"',
+    },
+    # here.parent.parent.parent quality_intelligence.db lookups (env-first,
+    # .exists()-gated).
+    "scripts/lib/intelligence_dashboard_data.py": {
+        'here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"',
+    },
+    "scripts/lib/pattern_extractor.py": {
+        'here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"',
+    },
+    "scripts/lib/intelligence_backfill.py": {
+        # env-first (VNX_STATE_DIR), .exists()-gated; _PROJECT_ROOT is __file__-anchored.
+        '_PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"',
+    },
+    # script_dir.parent.parent / ".vnx-data" _data_dir() siblings of the two this
+    # task migrated (t0_escalations_log / t0_decision_reconcile); env-first.
+    "scripts/lib/t0_decision_log.py": {
+        'script_dir.parent.parent / ".vnx-data"',
+    },
+    "scripts/lib/t0_decision_summarizer.py": {
+        'script_dir.parent.parent / ".vnx-data"',
+    },
+    # .is_dir()-gated upward walks that look for an EXISTING .vnx-data; canonical
+    # resolution (VNX_DATA_DIR env, or ensure_env()) is tried first in each caller.
+    "scripts/lib/subprocess_adapter.py": {
+        'search / ".vnx-data"',
+    },
+    "scripts/lib/headless_dispatch_writer.py": {
+        # vnx_paths.ensure_env() is the primary resolver here; this walk is the
+        # except-branch last resort.
+        'candidate / ".vnx-data"',
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# Core detection
+# ---------------------------------------------------------------------------
+
+
+def _file_anchored_names(tree: ast.AST) -> Set[str]:
+    """Names bound anywhere to an expression that references ``__file__``.
+
+    Catches module-level and local assignments such as
+    ``_REPO_ROOT = Path(__file__).resolve().parents[2]`` or
+    ``here = Path(__file__).resolve()``.
+    """
+    anchored: Set[str] = set()
+    for node in ast.walk(tree):
+        value = None
+        targets: List[ast.expr] = []
+        if isinstance(node, ast.Assign):
+            value = node.value
+            targets = list(node.targets)
+        elif isinstance(node, ast.AnnAssign) and node.value is not None:
+            value = node.value
+            targets = [node.target]
+        if value is None:
+            continue
+        if any(isinstance(n, ast.Name) and n.id == "__file__" for n in ast.walk(value)):
+            for tgt in targets:
+                if isinstance(tgt, ast.Name):
+                    anchored.add(tgt.id)
+    return anchored
+
+
+def _references_file_anchor(node: ast.AST, anchored: Set[str]) -> bool:
+    """True if the subtree references ``__file__`` or a file-anchored name."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Name) and (sub.id == "__file__" or sub.id in anchored):
+            return True
+    return False
+
+
+def _has_data_marker_constant(node: ast.AST) -> bool:
+    """True if the subtree contains a ``.vnx-data`` / ``ROADMAP.yaml`` string constant."""
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            if any(marker in sub.value for marker in DATA_PATH_MARKERS):
+                return True
+    return False
+
+
+def _segment(source: str, node: ast.AST) -> str:
+    """Return the normalized source text of an expression node."""
+    try:
+        seg = ast.get_source_segment(source, node) or ""
+    except Exception:
+        seg = ""
+    return " ".join(seg.split())
+
+
+def check_source(source: str) -> List[Tuple[int, str]]:
+    """Return (lineno, normalized_segment) violations for one file's source."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    anchored = _file_anchored_names(tree)
+
+    violations: List[Tuple[int, str]] = []
+    seen: Set[Tuple[int, str]] = set()
+    # Candidate path expressions: '/' path-joins and Path(...) calls.
+    for node in ast.walk(tree):
+        is_join = isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div)
+        is_path_call = (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "Path"
+        )
+        if not (is_join or is_path_call):
+            continue
+        if not _has_data_marker_constant(node):
+            continue
+        if not _references_file_anchor(node, anchored):
+            continue
+        key = (getattr(node, "lineno", 0), _segment(source, node))
+        if key in seen:
+            continue
+        seen.add(key)
+        violations.append(key)
+    return violations
+
+
+def _dedup_violations(source: str) -> List[Tuple[int, str]]:
+    """Deduplicate nested matches to the fullest offending expression per line.
+
+    ``_REPO_ROOT / ".vnx-data" / "state"`` yields nested BinOps sharing a lineno;
+    keep the LONGEST segment so the grandfather key captures the whole path
+    (a change to any component then trips the gate rather than being masked).
+    """
+    raw = check_source(source)
+    if not raw:
+        return []
+    by_line: Dict[int, Tuple[int, str]] = {}
+    for lineno, seg in raw:
+        cur = by_line.get(lineno)
+        if cur is None or len(seg) > len(cur[1]):
+            by_line[lineno] = (lineno, seg)
+    return sorted(by_line.values())
+
+
+def scan_dir(root: Path) -> List[Tuple[str, int, str]]:
+    """Return all non-grandfathered violations under ``root/scripts/lib``.
+
+    Result tuples are (repo_relative_path, lineno, normalized_segment).
+    """
+    scan_root = root / SCAN_DIR
+    out: List[Tuple[str, int, str]] = []
+    if not scan_root.is_dir():
+        return out
+    for py in sorted(scan_root.rglob("*.py")):
+        if py.name in EXEMPT_FILES:
+            continue
+        rel = py.relative_to(root).as_posix()
+        try:
+            source = py.read_text(encoding="utf-8", errors="ignore")
+        except OSError:
+            continue
+        allowed = GRANDFATHERED.get(rel, set())
+        for lineno, seg in _dedup_violations(source):
+            if seg in allowed:
+                continue
+            out.append((rel, lineno, seg))
+    return out
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: List[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    root = Path(args[0]).resolve() if args else Path.cwd()
+
+    violations = scan_dir(root)
+    if not violations:
+        print("[central-mode-paths] PASS — no __file__-derived data-path literals.")
+        return 0
+
+    print(f"[central-mode-paths] FAIL — {len(violations)} violation(s):\n")
+    for rel, lineno, seg in violations:
+        print(
+            f"::error file={rel},line={lineno}::central-mode path bug: "
+            f"'{seg}' derives a .vnx-data/ROADMAP path from __file__.\n"
+            f"In a central install this resolves the keystone, not "
+            f"~/.vnx-data/<project>. Route through vnx_paths.resolve_data_root()/"
+            f"resolve_state_dir() (VNX_HOME + project-marker aware). See #1023.\n"
+        )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/cleanup_worker_exit.py
+++ b/scripts/lib/cleanup_worker_exit.py
@@ -41,12 +41,6 @@ if str(_THIS_DIR) not in sys.path:
 
 import state_writer
 
-try:
-    from project_root import resolve_data_dir, resolve_state_dir
-except ImportError:  # pragma: no cover - bootstrap failure
-    resolve_data_dir = None  # type: ignore[assignment]
-    resolve_state_dir = None  # type: ignore[assignment]
-
 
 VALID_EXIT_STATUSES = ("success", "failure", "timeout", "killed", "stuck")
 
@@ -103,20 +97,28 @@ def _now_iso() -> str:
 
 
 def _resolve_state_dir() -> Path:
-    """Resolve VNX state dir using project_root with explicit-env fallbacks."""
-    if resolve_state_dir is not None:
-        try:
-            return resolve_state_dir(__file__)
-        except Exception as exc:
-            _emit("WARN", "state_dir_resolution_failed", error=str(exc))
+    """Resolve VNX state dir: explicit env > canonical resolver (central-mode-aware).
 
+    The canonical ``vnx_paths.resolve_state_dir()`` honors VNX_HOME + the project
+    marker, so in a central install it resolves ``~/.vnx-data/<project>/state``.
+    ``project_root.resolve_state_dir(__file__)`` (git-from-caller-file) and a
+    ``_THIS_DIR`` walk both land on the keystone git-root
+    (``~/.vnx-system/current/.vnx-data``) in central mode. See #1023/#1024.
+    """
     state_env = os.environ.get("VNX_STATE_DIR")
     if state_env:
         return Path(state_env)
     data_env = os.environ.get("VNX_DATA_DIR")
     if data_env:
         return Path(data_env) / "state"
-    return _THIS_DIR.parent.parent / ".vnx-data" / "state"
+    try:
+        from vnx_paths import resolve_state_dir as _canonical_state_dir
+        return _canonical_state_dir()
+    except Exception as exc:  # pragma: no cover - resolver is defensive, never raises
+        _emit("WARN", "state_dir_resolution_failed", error=str(exc))
+    # Terminal fallback (only if the resolver import fails): stay project-relative,
+    # never a __file__ keystone walk.
+    return Path.cwd() / ".vnx-data" / "state"
 
 
 def _resolve_dispatch_register_path() -> Path:
@@ -129,12 +131,12 @@ def _resolve_dispatch_register_path() -> Path:
         and os.environ.get("VNX_DATA_DIR")
     ):
         return Path(os.environ["VNX_DATA_DIR"]) / "state" / "dispatch_register.ndjson"
-    if resolve_state_dir is not None:
-        try:
-            return resolve_state_dir(__file__) / "dispatch_register.ndjson"
-        except (OSError, RuntimeError, KeyError) as exc:
-            _emit("WARN", "dispatch_register_path_resolution_failed", error=str(exc))
-    return _THIS_DIR.parent.parent / ".vnx-data" / "state" / "dispatch_register.ndjson"
+    try:
+        from vnx_paths import resolve_state_dir as _canonical_state_dir
+        return _canonical_state_dir() / "dispatch_register.ndjson"
+    except Exception as exc:  # pragma: no cover - resolver is defensive, never raises
+        _emit("WARN", "dispatch_register_path_resolution_failed", error=str(exc))
+    return Path.cwd() / ".vnx-data" / "state" / "dispatch_register.ndjson"
 
 
 def _release_lease_step(

--- a/scripts/lib/cost_tracker.py
+++ b/scripts/lib/cost_tracker.py
@@ -73,8 +73,17 @@ def recent_cost_per_hour(
 
 
 def _resolve_receipts_path() -> Path:
-    """Resolve path via VNX_STATE_DIR or default."""
-    state_dir = os.environ.get("VNX_STATE_DIR", ".vnx-data/state")
+    """Resolve path via VNX_STATE_DIR or the canonical resolver.
+
+    A bare CWD-relative ``.vnx-data/state`` default is only correct when the CWD
+    happens to be a co-located dev checkout; route through the canonical resolver
+    (VNX_HOME + project-marker aware) so a central-mode project resolves
+    ~/.vnx-data/<project>/state instead.
+    """
+    state_dir = os.environ.get("VNX_STATE_DIR")
+    if not state_dir:
+        from vnx_paths import resolve_state_dir as _canonical_state_dir
+        state_dir = str(_canonical_state_dir())
     return Path(state_dir) / "t0_receipts.ndjson"
 
 

--- a/scripts/lib/dispatch_enricher.py
+++ b/scripts/lib/dispatch_enricher.py
@@ -206,9 +206,12 @@ class DispatchEnricher:
             p = Path(state_dir) / "quality_intelligence.db"
             if p.exists():
                 return p
-        # Fallback: repo-relative
-        here = Path(__file__).resolve()
-        candidate = here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"
+        # Fallback: canonical resolver (VNX_HOME + project-marker aware). A
+        # __file__.parents[3] walk would resolve the keystone
+        # (~/.vnx-system/current/.vnx-data) in a central install, where the
+        # intelligence DB never lives — silently disabling file-affinity intel.
+        from vnx_paths import resolve_state_dir as _canonical_state_dir
+        candidate = _canonical_state_dir() / "quality_intelligence.db"
         return candidate if candidate.exists() else None
 
     def _build_file_affinity_section(self, target_files: List[str]) -> str:

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -59,9 +59,13 @@ def _events_dir() -> Path:
     project_id = os.environ.get("VNX_PROJECT_ID", "")
     if project_id:
         return Path.home() / ".vnx-data" / project_id / "events"
-    # Backwards-compat: single-project environments without VNX_PROJECT_ID
-    script_dir = Path(__file__).resolve().parent
-    return script_dir.parent.parent / ".vnx-data" / "events"
+    # Backwards-compat: no explicit VNX_DATA_DIR and no VNX_PROJECT_ID. Route
+    # through the canonical resolver (VNX_HOME + project-marker aware), which
+    # resolves ~/.vnx-data/<project>. A __file__ walk (script_dir.parent.parent)
+    # would resolve the keystone (~/.vnx-system/current/.vnx-data) in a central
+    # install, losing the event stream. See #1023.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DATA_DIR"]) / "events"
 
 
 class EventStore:

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -560,13 +560,13 @@ def _resolve_effective_repo_root() -> Path:
         candidate = Path(resolve_paths()["PROJECT_ROOT"])
         if candidate.is_dir():
             return candidate
-    except Exception:
+    except Exception:  # vnx-silent-except: best-effort — fall through to the git-root candidate
         pass
     try:
         git_root = track_reconciler._git_toplevel(Path.cwd())
         if git_root is not None:
             return git_root
-    except Exception:
+    except Exception:  # vnx-silent-except: best-effort — fall through to the CWD fallback
         pass
     return Path.cwd()
 

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -585,7 +585,9 @@ def run_reconcile(
     # Derived refresh — persists derived_status for every track.
     # ------------------------------------------------------------------ step 2
     try:
-        reconcile_results = track_reconciler.reconcile_all_tracks(state_dir, project_id)
+        reconcile_results = track_reconciler.reconcile_all_tracks(
+            state_dir, project_id, repo_root=repo_root
+        )
     except RuntimeError as exc:
         summary: Dict[str, Any] = {
             "run_id": run_id, "project_id": project_id, "mode": mode,
@@ -772,6 +774,7 @@ def run_reconcile(
                 actor="system",
                 evidence=evidence,
                 approval_id=f"auto-reconcile-{run_id}",
+                repo_root=repo_root,
             )
             action = close_result.get("action", "")
 

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -547,11 +547,35 @@ def _persist_summary(state_dir: Path, summary: Dict[str, Any]) -> None:
 # Core run logic
 # ---------------------------------------------------------------------------
 
+def _resolve_effective_repo_root() -> Path:
+    """Resolve a concrete project repo root for gh + ROADMAP evidence.
+
+    Used when the caller passes ``repo_root=None``. Prefers the canonical
+    PROJECT_ROOT (VNX_HOME + project-marker aware — never the keystone), then the
+    CWD git-root, then the CWD. Always returns a real directory so ``gh``
+    subprocess ``cwd=`` and Source-3 resolution never receive ``None``.
+    """
+    try:
+        from vnx_paths import resolve_paths
+        candidate = Path(resolve_paths()["PROJECT_ROOT"])
+        if candidate.is_dir():
+            return candidate
+    except Exception:
+        pass
+    try:
+        git_root = track_reconciler._git_toplevel(Path.cwd())
+        if git_root is not None:
+            return git_root
+    except Exception:
+        pass
+    return Path.cwd()
+
+
 def run_reconcile(
     state_dir: Path,
     project_id: str,
     *,
-    repo_root: Path,
+    repo_root: Optional[Path] = None,
     apply: bool = False,
     allow_closed_siblings: bool = False,
     max_gh_calls: int = 50,
@@ -560,7 +584,16 @@ def run_reconcile(
 
     Returns (summary_dict, exit_code) where exit_code is 0, 2, or 3.
     Never raises — all errors are captured in the summary and returned as exit 3.
+
+    ``repo_root`` may be None: gh PR lookups and the ROADMAP.yaml (Source-3)
+    evidence need a concrete project repo, so a None is resolved here to the
+    canonical PROJECT_ROOT / CWD git-root / CWD (mirroring track_reconciler's
+    None-handling) rather than degrading gh to ``cwd="None"`` (= absent).
     """
+    # None-tolerance: never pass None into gh (cwd="None") or downstream.
+    if repo_root is None:
+        repo_root = _resolve_effective_repo_root()
+
     run_id = _make_run_id()
     started_at = _now_utc()
     mode = "apply" if apply else "check"

--- a/scripts/lib/runtime_facade.py
+++ b/scripts/lib/runtime_facade.py
@@ -66,8 +66,11 @@ def _resolve_state_dir() -> str:
     data_dir = os.environ.get("VNX_DATA_DIR", "")
     if data_dir:
         return str(Path(data_dir) / "state")
-    # Last-resort: repo-relative default (matches vnx_paths.py convention).
-    return str(Path(__file__).parent.parent.parent / ".vnx-data" / "state")
+    # Last-resort: canonical resolver (VNX_HOME + project-marker aware). A
+    # __file__.parents[3] walk would resolve the keystone
+    # (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+    from vnx_paths import resolve_state_dir as _canonical_state_dir
+    return str(_canonical_state_dir())
 
 
 def get_adapter(terminal: str) -> RuntimeAdapter:

--- a/scripts/lib/shadow_logger.py
+++ b/scripts/lib/shadow_logger.py
@@ -33,9 +33,12 @@ def _resolve_ledger_path(ledger_path: Optional[Path]) -> Path:
     if ledger_path is not None:
         return ledger_path
     try:
-        from project_root import resolve_state_dir
+        # Canonical resolver (VNX_HOME + project-marker aware). project_root's
+        # resolve_state_dir(__file__) resolves the keystone git-root
+        # (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+        from vnx_paths import resolve_state_dir
 
-        return resolve_state_dir(__file__) / LEDGER_FILENAME
+        return resolve_state_dir() / LEDGER_FILENAME
     except Exception:
         return _DEFAULT_STATE_DIR / LEDGER_FILENAME
 

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -693,8 +693,11 @@ class SubprocessAdapter:
         if vnx_data_dir:
             log_dir = Path(vnx_data_dir) / "logs" / "subprocess"
         else:
-            # Fall back: derive from module location (useful in tests)
-            log_dir = Path(__file__).resolve().parent.parent.parent / ".vnx-data" / "logs" / "subprocess"
+            # Fall back to the canonical resolver (VNX_HOME + project-marker aware).
+            # A __file__.parents[3] walk would resolve the keystone
+            # (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+            from vnx_paths import resolve_paths
+            log_dir = Path(resolve_paths()["VNX_DATA_DIR"]) / "logs" / "subprocess"
         return log_dir / f"{terminal_id}_{dispatch_id}.stderr.log"
 
     # ------------------------------------------------------------------

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -551,7 +551,13 @@ if __name__ == "__main__":
                     args.model = _r_model            # pass recommended model to provider_dispatch
                 _auto_route_applied = True  # G7: always skip routing_policy when smart_router ran
 
-            _state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+            _state_env = os.environ.get("VNX_STATE_DIR")
+            if not _state_env:
+                # Canonical resolver (VNX_HOME + project-marker aware) instead of a
+                # bare CWD-relative default, so central-mode resolves the project store.
+                from vnx_paths import resolve_state_dir as _canonical_state_dir
+                _state_env = str(_canonical_state_dir())
+            _state_dir = Path(_state_env)
             write_route_decision(args.dispatch_id, _route_decision, state_dir=_state_dir)
             import logging as _log_mod  # noqa: PLC0415
             _log_mod.getLogger(__name__).info(

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -216,7 +216,7 @@ def _legacy_claude_md_resolution(
     can intercept the resolution (test_skill_context_injection).
     """
     import subprocess_dispatch as _sd
-    project_root = Path(_sd.__file__).resolve().parents[2]
+    project_root = _sd.Path(_sd.__file__).resolve().parents[2]
 
     candidates: list[Path] = []
     if role:

--- a/scripts/lib/subprocess_dispatch_internals/state_paths.py
+++ b/scripts/lib/subprocess_dispatch_internals/state_paths.py
@@ -10,11 +10,6 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def _project_root() -> Path:
-    """Resolve project root: scripts/lib/subprocess_dispatch_internals/ -> ../../../."""
-    return Path(__file__).resolve().parents[3]
-
-
 def _default_state_dir() -> Path:
     """Resolve VNX state directory from environment."""
     env = os.environ.get("VNX_STATE_DIR", "")
@@ -23,7 +18,11 @@ def _default_state_dir() -> Path:
     data_dir = os.environ.get("VNX_DATA_DIR", "")
     if data_dir:
         return Path(data_dir) / "state"
-    return _project_root() / ".vnx-data" / "state"
+    # Canonical resolver (VNX_HOME + project-marker aware). A Path(__file__)
+    # walk resolves the keystone (~/.vnx-system/current/.vnx-data) in a central
+    # install, never the project store. See central-mode-path-correctness.
+    from vnx_paths import resolve_state_dir as _canonical_state_dir
+    return _canonical_state_dir()
 
 
 def _resolve_active_dispatch_file(dispatch_id: str) -> Path | None:
@@ -33,11 +32,11 @@ def _resolve_active_dispatch_file(dispatch_id: str) -> Path | None:
     another path).  Used by the deliver_with_recovery exit hooks.
     """
     data_dir = os.environ.get("VNX_DATA_DIR", "")
-    base = (
-        Path(data_dir) / "dispatches" / "active"
-        if data_dir
-        else _project_root() / ".vnx-data" / "dispatches" / "active"
-    )
+    if data_dir:
+        base = Path(data_dir) / "dispatches" / "active"
+    else:
+        from vnx_paths import resolve_paths
+        base = Path(resolve_paths()["VNX_DISPATCH_DIR"]) / "active"
     if not base.is_dir():
         return None
     for path in base.iterdir():
@@ -51,7 +50,8 @@ def _dispatch_manifest_dir(stage: str, dispatch_id: str) -> Path:
     data_dir = os.environ.get("VNX_DATA_DIR", "")
     if data_dir:
         return Path(data_dir) / "dispatches" / stage / dispatch_id
-    return _project_root() / ".vnx-data" / "dispatches" / stage / dispatch_id
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DISPATCH_DIR"]) / stage / dispatch_id
 
 
 def _safe_remove_active_dir(src_dir: Path) -> bool:

--- a/scripts/lib/t0_decision_log.py
+++ b/scripts/lib/t0_decision_log.py
@@ -74,8 +74,12 @@ def _data_dir() -> Path:
     vnx_data = os.environ.get("VNX_DATA_DIR")
     if vnx_data:
         return Path(vnx_data).expanduser().resolve()
-    script_dir = Path(__file__).resolve().parent
-    return script_dir.parent.parent / ".vnx-data"
+    # Central-mode-correct fallback: route through the canonical resolver, which
+    # honors VNX_HOME + the project marker and resolves ~/.vnx-data/<project>.
+    # A __file__-derived walk (script_dir.parent.parent) would resolve the
+    # keystone (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DATA_DIR"])
 
 
 DEFAULT_EVENTS_FILE: Path = _data_dir() / "events" / "t0_decisions.ndjson"

--- a/scripts/lib/t0_decision_reconcile.py
+++ b/scripts/lib/t0_decision_reconcile.py
@@ -38,7 +38,12 @@ def _data_dir() -> Path:
     vnx_data = os.environ.get("VNX_DATA_DIR")
     if vnx_data:
         return Path(vnx_data).expanduser().resolve()
-    return Path(__file__).resolve().parent.parent.parent / ".vnx-data"
+    # Central-mode-correct fallback: route through the canonical resolver, which
+    # honors VNX_HOME + the project marker and resolves ~/.vnx-data/<project>.
+    # A __file__.parents[3] walk would resolve the keystone
+    # (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DATA_DIR"])
 
 
 def _state_dir() -> Path:

--- a/scripts/lib/t0_decision_summarizer.py
+++ b/scripts/lib/t0_decision_summarizer.py
@@ -54,8 +54,12 @@ def _data_dir() -> Path:
     vnx_data = os.environ.get("VNX_DATA_DIR")
     if vnx_data:
         return Path(vnx_data).expanduser().resolve()
-    script_dir = Path(__file__).resolve().parent
-    return script_dir.parent.parent / ".vnx-data"
+    # Central-mode-correct fallback: route through the canonical resolver, which
+    # honors VNX_HOME + the project marker and resolves ~/.vnx-data/<project>.
+    # A __file__-derived walk (script_dir.parent.parent) would resolve the
+    # keystone (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DATA_DIR"])
 
 
 DEFAULT_EVENTS_FILE: Path = _data_dir() / "events" / "T0.ndjson"

--- a/scripts/lib/t0_escalations_log.py
+++ b/scripts/lib/t0_escalations_log.py
@@ -54,8 +54,12 @@ def _data_dir() -> Path:
     vnx_data = os.environ.get("VNX_DATA_DIR")
     if vnx_data:
         return Path(vnx_data).expanduser().resolve()
-    script_dir = Path(__file__).resolve().parent
-    return script_dir.parent.parent / ".vnx-data"
+    # Central-mode-correct fallback: route through the canonical resolver, which
+    # honors VNX_HOME + the project marker and resolves ~/.vnx-data/<project>.
+    # A __file__-derived walk (script_dir.parent.parent) would resolve the
+    # keystone (~/.vnx-system/current/.vnx-data) in a central install. See #1023.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["VNX_DATA_DIR"])
 
 
 DEFAULT_EVENTS_FILE: Path = _data_dir() / "events" / "t0_decisions.ndjson"

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -98,13 +98,50 @@ def _load_merged_prs_from_gh(state_path: Path, ttl_seconds: int = 600) -> Frozen
     return frozenset(nums)
 
 
-def _load_merged_pr_numbers(state_dir: str | Path) -> FrozenSet[int]:
+def _git_toplevel(path: Path) -> Optional[Path]:
+    """Return the git worktree root for ``path``, or None when not a git repo."""
+    try:
+        out = subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError):
+        return None
+    return Path(out).resolve() if out else None
+
+
+def _resolve_roadmap_path(state_dir: Path, repo_root: "Path | None") -> Path:
+    """Resolve the project's ROADMAP.yaml (Source-3 evidence), central-mode aware.
+
+    Priority: explicit ``repo_root`` > CWD git-root > legacy ``state.parent.parent``.
+
+    The ROADMAP lives at the project *repo* root, not next to the state dir. In a
+    central install ``state_dir`` is ``~/.vnx-data/<project>/state`` so the legacy
+    two-up (``state.parent.parent``) resolves ``~/.vnx-data/`` — which holds no
+    ROADMAP.yaml, silently voiding the Source-3 evidence path. So prefer an
+    explicit repo_root the caller threads, then the CWD git-root (``vnx horizon
+    reconcile`` runs from the project dir), and only then the co-located legacy
+    layout that a dev checkout still relies on. Best-effort — never raises.
+    """
+    if repo_root is not None:
+        return Path(repo_root) / "ROADMAP.yaml"
+    cwd_root = _git_toplevel(Path.cwd())
+    if cwd_root is not None:
+        return cwd_root / "ROADMAP.yaml"
+    return state_dir.parent.parent / "ROADMAP.yaml"
+
+
+def _load_merged_pr_numbers(
+    state_dir: str | Path,
+    repo_root: "str | Path | None" = None,
+) -> FrozenSet[int]:
     """Load confirmed-merged PR numbers.
 
     Sources (all optional; errors silently ignored):
       1. {state_dir}/../events/pr_merged.ndjson  — ADR-005 event ledger
       2. {state_dir}/t0_receipts.ndjson           — receipt log
-      3. {state_dir}/../../ROADMAP.yaml           — authoritative feature list
+      3. {repo_root|cwd-git-root|state.parent.parent}/ROADMAP.yaml — feature list
          pr_queue[*].status=merged entries cover recent PRs not yet in NDJSON files
       4. git/GitHub via ``gh`` (OPT-IN, ``VNX_RECONCILE_GIT`` set) — cache-first
          (10-min TTL), silent-on-failure. Closes the gap where a PR merged via raw
@@ -145,8 +182,13 @@ def _load_merged_pr_numbers(state_dir: str | Path) -> FrozenSet[int]:
             pass
 
     # Source 3: ROADMAP.yaml — authoritative for recent PRs not yet backfilled to NDJSON.
-    # Path: state_dir is .vnx-data/state; ROADMAP.yaml is at project root two levels up.
-    roadmap_path = state_path.parent.parent / "ROADMAP.yaml"
+    # Resolved from the project REPO-root (explicit repo_root > CWD git-root >
+    # legacy co-located layout), so central-mode projects (state at
+    # ~/.vnx-data/<project>/state) find the roadmap at their repo root instead of
+    # the roadmap-less ~/.vnx-data/. See _resolve_roadmap_path.
+    roadmap_path = _resolve_roadmap_path(
+        state_path, Path(repo_root) if repo_root is not None else None
+    )
     try:
         import yaml  # available in all VNX environments
         data = yaml.safe_load(roadmap_path.read_text(encoding="utf-8")) or {}
@@ -361,6 +403,7 @@ def reconcile_track(
     project_id: str,
     *,
     _merged_pr_numbers: Optional[FrozenSet[int]] = None,
+    repo_root: "str | Path | None" = None,
 ) -> Dict[str, Any]:
     """Compute and persist derived_status for a single track.
 
@@ -373,6 +416,8 @@ def reconcile_track(
     _merged_pr_numbers: internal kwarg — pre-loaded merged PR set. When None,
     _load_merged_pr_numbers(state_dir) is called. Pass a pre-loaded set when
     calling from reconcile_all_tracks to avoid per-track file I/O.
+    repo_root: optional project repo root for the ROADMAP.yaml (Source-3)
+    evidence path; falls back to the CWD git-root then the legacy layout.
     """
     conn = _get_conn(state_dir)
     try:
@@ -384,7 +429,7 @@ def reconcile_track(
         merged = (
             _merged_pr_numbers
             if _merged_pr_numbers is not None
-            else _load_merged_pr_numbers(state_dir)
+            else _load_merged_pr_numbers(state_dir, repo_root)
         )
         derived = _compute_derived_status(conn, track_id, project_id, merged)
         _write_derived_status(conn, track_id, project_id, derived)
@@ -413,6 +458,8 @@ def peek_derived_status(
     state_dir: str | Path,
     track_id: str,
     project_id: str,
+    *,
+    repo_root: "str | Path | None" = None,
 ) -> Dict[str, Any]:
     """READ-ONLY: compute derived_status for one track WITHOUT persisting it.
 
@@ -429,7 +476,7 @@ def peek_derived_status(
             raise RuntimeError(
                 "tracks.derived_status column absent; apply migration 0028 first."
             )
-        merged = _load_merged_pr_numbers(state_dir)
+        merged = _load_merged_pr_numbers(state_dir, repo_root)
         derived = _compute_derived_status(conn, track_id, project_id, merged)
         track_row = conn.execute(
             "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
@@ -450,6 +497,8 @@ def peek_derived_status(
 def reconcile_all_tracks(
     state_dir: str | Path,
     project_id: str,
+    *,
+    repo_root: "str | Path | None" = None,
 ) -> List[Dict[str, Any]]:
     """Compute and persist derived_status for all tracks in project_id.
 
@@ -458,6 +507,9 @@ def reconcile_all_tracks(
 
     Raises RuntimeError if derived_status column is absent (migration 0028
     must be applied first).
+
+    repo_root: optional project repo root for the ROADMAP.yaml (Source-3)
+    evidence path; falls back to the CWD git-root then the legacy layout.
     """
     conn = _get_conn(state_dir)
     try:
@@ -474,7 +526,7 @@ def reconcile_all_tracks(
     finally:
         conn.close()
 
-    merged_pr_numbers = _load_merged_pr_numbers(state_dir)
+    merged_pr_numbers = _load_merged_pr_numbers(state_dir, repo_root)
 
     results = []
     for track_id in track_ids:

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -660,6 +660,7 @@ def close_track_if_done(
     evidence: Optional[EvidenceSnapshot] = None,
     approval_id: Optional[str] = None,
     include_parked: bool = False,
+    repo_root: "str | Path | None" = None,
 ) -> Dict[str, Any]:
     """Attempt to close a track by walking its declared phase to 'done'.
 
@@ -686,6 +687,10 @@ def close_track_if_done(
     own connection and commits per step. A mid-walk failure leaves the track at an
     intermediate phase; re-calling this function re-walks from the current declared
     phase (bounded TOCTOU-narrowing, not atomicity).
+
+    repo_root: optional project repo root, forwarded to the internal
+    reconcile_track call for its ROADMAP.yaml (Source-3) evidence path; falls
+    back to the CWD git-root then the legacy layout (see reconcile_track).
 
     Returns a dict with keys: track_id, project_id, action, applied, declared_phase,
     derived_status, path (when applicable), evidence (when computed), error (on failure).
@@ -853,7 +858,7 @@ def close_track_if_done(
     # When _skip_derived_gate is True, reconcile_track still runs for the derived
     # refresh (persists derived_status for reporting) but its result does not gate
     # the walk — gh evidence already authorized the close.
-    result = reconcile_track(state_dir, track_id, project_id)
+    result = reconcile_track(state_dir, track_id, project_id, repo_root=repo_root)
     derived = result["derived_status"]
     declared = result["declared_phase"]
     target = "done"

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -571,6 +571,7 @@ def _close_evidence(
     state_dir: "str | Path",
     track_id: str,
     project_id: str,
+    repo_root: "str | Path | None" = None,
 ) -> Dict[str, Any]:
     """Summarize WHY a track derives terminal, so the operator gate is informed.
 
@@ -619,7 +620,7 @@ def _close_evidence(
     try:
         if ev["pr_ref"]:
             nums = _parse_pr_numbers(ev["pr_ref"])
-            if nums and nums <= _load_merged_pr_numbers(state_dir):
+            if nums and nums <= _load_merged_pr_numbers(state_dir, repo_root):
                 ev["pr_merged"] = True
     except Exception as exc:
         log.debug("close evidence merged-PR check failed: %s", exc)
@@ -884,7 +885,7 @@ def close_track_if_done(
         payload["action"] = "rejected_parked"
         return payload
 
-    payload["evidence"] = _close_evidence(state_dir, track_id, project_id)
+    payload["evidence"] = _close_evidence(state_dir, track_id, project_id, repo_root=repo_root)
 
     path = _phase_path_to(declared, target)
     if path is None:

--- a/scripts/lib/wiring_gate.py
+++ b/scripts/lib/wiring_gate.py
@@ -58,7 +58,14 @@ class WiringGateResult:
 
 def _load_skip_list(state_dir: Optional[Path] = None) -> set:
     if state_dir is None:
-        state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+        env = os.environ.get("VNX_STATE_DIR")
+        if env:
+            state_dir = Path(env)
+        else:
+            # Canonical resolver (VNX_HOME + project-marker aware) instead of a
+            # bare CWD-relative default, so central-mode resolves the project store.
+            from vnx_paths import resolve_state_dir as _canonical_state_dir
+            state_dir = _canonical_state_dir()
     skip_path = state_dir / "wiring_skip.yaml"
     if not skip_path.exists():
         return set()

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -61,8 +61,11 @@ def _resolve_state_dir(explicit: str) -> Path:
     env = os.environ.get("VNX_STATE_DIR", "")
     if env:
         return Path(env)
-    from project_root import resolve_project_root
-    return resolve_project_root(__file__) / ".vnx-data" / "state"
+    # Canonical resolver: VNX_DATA_DIR + VNX_HOME + project-marker aware.
+    # resolve_project_root(__file__) resolves the KEYSTONE in a central install
+    # (and ignores VNX_DATA_DIR). See central-mode-path-correctness.
+    from vnx_paths import resolve_state_dir as _canonical_state_dir
+    return _canonical_state_dir()
 
 
 def _resolve_roadmap_path(explicit: str | None) -> Path:
@@ -71,20 +74,25 @@ def _resolve_roadmap_path(explicit: str | None) -> Path:
     env = os.environ.get("VNX_ROADMAP_PATH", "")
     if env:
         return Path(env)
-    from project_root import resolve_project_root
-    return resolve_project_root(__file__) / "ROADMAP.yaml"
+    # The project's ROADMAP.yaml lives at the resolved PROJECT_ROOT, not the
+    # keystone that resolve_project_root(__file__) yields in a central install.
+    from vnx_paths import resolve_paths
+    return Path(resolve_paths()["PROJECT_ROOT"]) / "ROADMAP.yaml"
 
 
-def _resolve_repo_root(explicit: str) -> Path:
-    """Resolve the project repo root: explicit --repo-root > canonical resolver.
+def _resolve_repo_root(explicit: str) -> Path | None:
+    """Resolve the project repo root ONLY when explicitly provided.
 
-    Central-mode workers can run from a CWD that is not the project repo
-    (e.g. the keystone), so CWD-based git-root detection is not safe here.
+    Returns None when no --repo-root is given, so track_reconciler's Source-3
+    resolver runs its own CWD-git-root -> legacy fallback. Deriving a default via
+    resolve_project_root(__file__) would yield the KEYSTONE in a central install
+    and -- because the reconciler treats any non-None repo_root as explicit
+    (track_reconciler._resolve_roadmap_path) -- poison the ROADMAP.yaml lookup.
+    Pass --repo-root to override when the CWD is not the project repo.
     """
     if explicit:
         return Path(explicit).resolve()
-    from project_root import resolve_project_root
-    return resolve_project_root(__file__)
+    return None
 
 
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -346,7 +346,7 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
     project_id = args.project_id
 
     try:
-        repo_root = _resolve_repo_root(args.repo_root)
+        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
     except Exception as exc:
         print(f"reconcile: cannot resolve repo root: {exc}", file=sys.stderr)
         return 2
@@ -505,7 +505,7 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
     project_id = args.project_id
 
     try:
-        repo_root = _resolve_repo_root(args.repo_root)
+        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
     except Exception as exc:
         logger.warning("drift: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
         repo_root = None
@@ -594,7 +594,7 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     track_id = args.track_id
 
     try:
-        repo_root = _resolve_repo_root(args.repo_root)
+        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
     except Exception as exc:
         logger.warning("close: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
         repo_root = None
@@ -670,7 +670,9 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
 
     # Surface the done-evidence so the operator gate is informed: the reconciler
     # derives 'done' from ANY terminal dispatch state, including expired/dead_letter.
-    payload["evidence"] = _close_evidence(state_dir, track_id, project_id)
+    # Thread repo_root so the dry-run merged-PR check reads the project's ROADMAP
+    # (Source-3), matching the --apply path via close_track_if_done.
+    payload["evidence"] = _close_evidence(state_dir, track_id, project_id, repo_root=repo_root)
 
     # The state machine forbids skips (e.g. queued -> done is illegal: a track
     # must pass through 'active'). A merged track stuck at queued/parked is

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -75,6 +75,18 @@ def _resolve_roadmap_path(explicit: str | None) -> Path:
     return resolve_project_root(__file__) / "ROADMAP.yaml"
 
 
+def _resolve_repo_root(explicit: str) -> Path:
+    """Resolve the project repo root: explicit --repo-root > canonical resolver.
+
+    Central-mode workers can run from a CWD that is not the project repo
+    (e.g. the keystone), so CWD-based git-root detection is not safe here.
+    """
+    if explicit:
+        return Path(explicit).resolve()
+    from project_root import resolve_project_root
+    return resolve_project_root(__file__)
+
+
 def _atomic_write_json(path: Path, payload: dict[str, Any]) -> None:
     """Write JSON atomically: temp file in the same dir + os.replace."""
     import tempfile
@@ -325,15 +337,11 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
 
-    if args.repo_root:
-        repo_root = Path(args.repo_root).resolve()
-    else:
-        try:
-            from project_root import resolve_project_root  # noqa: PLC0415
-            repo_root = resolve_project_root(__file__)
-        except Exception as exc:
-            print(f"reconcile: cannot resolve repo root: {exc}", file=sys.stderr)
-            return 2
+    try:
+        repo_root = _resolve_repo_root(args.repo_root)
+    except Exception as exc:
+        print(f"reconcile: cannot resolve repo root: {exc}", file=sys.stderr)
+        return 2
 
     try:
         summary, exit_code = objective_reconcile.run_reconcile(
@@ -488,7 +496,13 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
 
-    results = track_reconciler.reconcile_all_tracks(state_dir, project_id)
+    try:
+        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
+    except Exception as exc:
+        logger.warning("drift: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
+        repo_root = None
+
+    results = track_reconciler.reconcile_all_tracks(state_dir, project_id, repo_root=repo_root)
 
     divergent = []
     for r in results:
@@ -572,13 +586,23 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     track_id = args.track_id
 
     try:
+        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
+    except Exception as exc:
+        logger.warning("close: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
+        repo_root = None
+
+    try:
         # Dry-run is READ-ONLY: peek computes derived_status without persisting.
         # --apply reconciles fresh (and persists derived_status) right before the
         # write, so the transition acts on current state.
         if args.apply:
-            result = track_reconciler.reconcile_track(state_dir, track_id, project_id)
+            result = track_reconciler.reconcile_track(
+                state_dir, track_id, project_id, repo_root=repo_root
+            )
         else:
-            result = track_reconciler.peek_derived_status(state_dir, track_id, project_id)
+            result = track_reconciler.peek_derived_status(
+                state_dir, track_id, project_id, repo_root=repo_root
+            )
     except Exception as exc:
         print(f"objective close failed: cannot reconcile {track_id}: {exc}", file=sys.stderr)
         return 1
@@ -671,6 +695,7 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
         actor="operator",
         approval_id=args.approval_id,
         include_parked=getattr(args, "include_parked", False),
+        repo_root=repo_root,
     )
     lib_action = lib.get("action")
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -497,7 +497,7 @@ def cmd_objective_drift(args: argparse.Namespace) -> int:
     project_id = args.project_id
 
     try:
-        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
+        repo_root = _resolve_repo_root(args.repo_root)
     except Exception as exc:
         logger.warning("drift: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
         repo_root = None
@@ -586,7 +586,7 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     track_id = args.track_id
 
     try:
-        repo_root = _resolve_repo_root(getattr(args, "repo_root", ""))
+        repo_root = _resolve_repo_root(args.repo_root)
     except Exception as exc:
         logger.warning("close: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
         repo_root = None
@@ -1459,6 +1459,11 @@ def _build_parser() -> argparse.ArgumentParser:
         help="advisory drift-gate: report declared-vs-derived divergence (exit 0); drift reports, `objective reconcile` fixes",
     )
     _common(p_drift)
+    p_drift.add_argument(
+        "--repo-root", default="", dest="repo_root",
+        metavar="PATH",
+        help="git repo root for ROADMAP lookups (default: auto-resolved from project root)",
+    )
     p_drift.set_defaults(func=cmd_objective_drift)
 
     p_reconcile = obj_sub.add_parser(
@@ -1498,6 +1503,11 @@ def _build_parser() -> argparse.ArgumentParser:
                          help="operator approval token (REQUIRED with --apply)")
     p_close.add_argument("--include-parked", action="store_true",
                          help="allow closing a PARKED track (un-parks it; off by default)")
+    p_close.add_argument(
+        "--repo-root", default="", dest="repo_root",
+        metavar="PATH",
+        help="git repo root for ROADMAP lookups (default: auto-resolved from project root)",
+    )
     p_close.set_defaults(func=cmd_objective_close)
 
     p_reopen = obj_sub.add_parser(

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -814,7 +814,9 @@ Implement the minimum blocking fix required before the roadmap may advance.
             return {"status": "disabled", "reason": "VNX_ROADMAP_AUTOPILOT not set"}
 
         from track_reconciler import reconcile_all_tracks  # noqa: PLC0415
-        results = reconcile_all_tracks(self.state_dir, self.project_id)
+        results = reconcile_all_tracks(
+            self.state_dir, self.project_id, repo_root=self.project_root
+        )
         drifted_count = sum(1 for r in results if r.get("drifted"))
 
         emit_governance_receipt(

--- a/tests/test_central_mode_path_gate.py
+++ b/tests/test_central_mode_path_gate.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Unit tests for the central-mode path-correctness gate.
+
+Covers:
+- The scanner flags a planted ``__file__``-derived ``.vnx-data`` literal.
+- The current repo tree passes (all remaining sites grandfathered/exempt).
+- A ``state_dir.parent.parent`` derived from a runtime Path param is NOT flagged.
+- Comments and docstrings mentioning ``.vnx-data`` never trip the AST scanner.
+- The canonical resolvers (vnx_paths.py / project_root.py) are exempt.
+- A call routed through the resolver is not flagged.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from check_no_file_derived_data_paths import (  # noqa: E402
+    GRANDFATHERED,
+    check_source,
+    scan_dir,
+)
+
+
+# ---------------------------------------------------------------------------
+# check_source unit tests (AST detection)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        'p = Path(__file__).resolve().parent.parent / ".vnx-data" / "state"\n',
+        'p = Path(__file__).parent.parent.parent / ".vnx-data"\n',
+        'ROOT = Path(__file__).resolve().parents[2]\np = ROOT / ".vnx-data" / "events"\n',
+        'HERE = Path(__file__).resolve()\np = HERE.parent.parent / "ROADMAP.yaml"\n',
+        'sd = Path(__file__).parent\np = sd.parent.parent / ".vnx-data"\n',
+    ],
+)
+def test_file_derived_data_paths_flagged(src: str) -> None:
+    violations = check_source(src)
+    assert len(violations) >= 1, f"expected a violation for:\n{src}"
+
+
+def test_state_dir_param_not_flagged() -> None:
+    # state_dir is a resolved runtime Path parameter, NOT __file__-anchored.
+    src = (
+        "def f(state_dir):\n"
+        '    return state_dir.parent.parent / "ROADMAP.yaml"\n'
+    )
+    assert check_source(src) == []
+
+
+def test_data_dir_env_param_not_flagged() -> None:
+    src = (
+        "def f(vnx_data_dir):\n"
+        '    return Path(vnx_data_dir) / ".vnx-data" / "state"\n'
+    )
+    assert check_source(src) == []
+
+
+def test_canonical_resolver_call_not_flagged() -> None:
+    # The fix pattern: route through the resolver — no __file__ anchor.
+    src = (
+        "from vnx_paths import resolve_paths\n"
+        'p = Path(resolve_paths()["VNX_DATA_DIR"]) / "events"\n'
+    )
+    assert check_source(src) == []
+
+
+def test_comment_mentioning_data_path_not_flagged() -> None:
+    src = (
+        "def f():\n"
+        "    # A Path(__file__).parent.parent / '.vnx-data' walk would hit the keystone\n"
+        "    from vnx_paths import resolve_state_dir\n"
+        "    return resolve_state_dir()\n"
+    )
+    assert check_source(src) == []
+
+
+def test_docstring_mentioning_data_path_not_flagged() -> None:
+    src = (
+        "def f():\n"
+        '    """Resolve ~/.vnx-data/<project> — never Path(__file__)/.vnx-data."""\n'
+        "    from vnx_paths import resolve_state_dir\n"
+        "    return resolve_state_dir()\n"
+    )
+    assert check_source(src) == []
+
+
+# ---------------------------------------------------------------------------
+# scan_dir integration tests
+# ---------------------------------------------------------------------------
+
+
+def test_current_tree_passes() -> None:
+    """The live tree must be clean: every remaining site is grandfathered/exempt."""
+    violations = scan_dir(VNX_ROOT)
+    if violations:
+        lines = [f"  {rel}:{ln}: {seg}" for rel, ln, seg in violations]
+        pytest.fail(
+            "central-mode path gate found un-grandfathered violation(s):\n"
+            + "\n".join(lines)
+        )
+
+
+def test_planted_literal_in_lib_fails(tmp_path: Path) -> None:
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "planted.py").write_text(
+        "from pathlib import Path\n"
+        "def bad():\n"
+        '    return Path(__file__).resolve().parent.parent / ".vnx-data" / "planted"\n',
+        encoding="utf-8",
+    )
+    violations = scan_dir(tmp_path)
+    assert any(rel.endswith("planted.py") for rel, _, _ in violations)
+
+
+def test_exempt_resolvers_skipped(tmp_path: Path) -> None:
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    body = (
+        "from pathlib import Path\n"
+        "def r():\n"
+        '    return Path(__file__).resolve().parents[2] / ".vnx-data" / "state"\n'
+    )
+    (lib / "vnx_paths.py").write_text(body, encoding="utf-8")
+    (lib / "project_root.py").write_text(body, encoding="utf-8")
+    assert scan_dir(tmp_path) == []
+
+
+def test_grandfathered_segment_allows_current_but_new_line_fails(tmp_path: Path) -> None:
+    # A grandfathered segment passes; a DIFFERENT planted segment in the same
+    # file still fails (the gate blocks new occurrences).
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "gate_register_emit.py").write_text(
+        "from pathlib import Path\n"
+        "_REPO_ROOT = Path(__file__).resolve().parents[2]\n"
+        "def a():\n"
+        '    return _REPO_ROOT / ".vnx-data" / "state" / "dispatch_register.ndjson"\n'
+        "def b():\n"
+        '    return _REPO_ROOT / ".vnx-data" / "planted-new"\n',
+        encoding="utf-8",
+    )
+    violations = scan_dir(tmp_path)
+    segs = {seg for _, _, seg in violations}
+    assert '_REPO_ROOT / ".vnx-data" / "planted-new"' in segs
+    assert (
+        '_REPO_ROOT / ".vnx-data" / "state" / "dispatch_register.ndjson"'
+        not in segs
+    )
+
+
+def test_grandfather_keys_reference_real_files() -> None:
+    # Guard against stale allow-list entries drifting from the tree.
+    for rel in GRANDFATHERED:
+        assert (VNX_ROOT / rel).is_file(), f"grandfathered path missing: {rel}"

--- a/tests/test_central_mode_path_gate.py
+++ b/tests/test_central_mode_path_gate.py
@@ -48,6 +48,60 @@ def test_file_derived_data_paths_flagged(src: str) -> None:
     assert len(violations) >= 1, f"expected a violation for:\n{src}"
 
 
+def test_helper_return_of_file_flagged() -> None:
+    # The helper-return false-negative: __file__ hidden behind a helper's return.
+    src = (
+        "from pathlib import Path\n"
+        "def _project_root():\n"
+        "    return Path(__file__).resolve().parents[3]\n"
+        "def bad():\n"
+        '    return _project_root() / ".vnx-data" / "state"\n'
+    )
+    assert len(check_source(src)) >= 1
+
+
+def test_transitive_helper_anchor_flagged() -> None:
+    # Anchor propagates through a chain of helpers to a fixpoint.
+    src = (
+        "from pathlib import Path\n"
+        "def _root():\n"
+        "    return Path(__file__).resolve()\n"
+        "def _repo():\n"
+        "    return _root().parent\n"
+        "def bad():\n"
+        '    return _repo() / ".vnx-data"\n'
+    )
+    assert len(check_source(src)) >= 1
+
+
+def test_env_helper_return_not_flagged() -> None:
+    # A helper returning an ENV-derived (not __file__) path is not anchored.
+    src = (
+        "import os\n"
+        "from pathlib import Path\n"
+        "def _root():\n"
+        "    return Path(os.environ['X'])\n"
+        "def ok():\n"
+        '    return _root() / ".vnx-data"\n'
+    )
+    assert check_source(src) == []
+
+
+def test_planted_helper_return_in_subdir_fails(tmp_path: Path) -> None:
+    pkg = tmp_path / "scripts" / "lib" / "some_pkg"
+    pkg.mkdir(parents=True)
+    (pkg / "paths.py").write_text(
+        "from pathlib import Path\n"
+        "def _root():\n"
+        "    return Path(__file__).resolve().parents[3]\n"
+        "def d():\n"
+        '    return _root() / ".vnx-data" / "state"\n',
+        encoding="utf-8",
+    )
+    violations = scan_dir(tmp_path)
+    assert any(rel.endswith("paths.py") for rel, _, _ in violations)
+
+
 def test_state_dir_param_not_flagged() -> None:
     # state_dir is a resolved runtime Path parameter, NOT __file__-anchored.
     src = (

--- a/tests/test_central_mode_path_resolution.py
+++ b/tests/test_central_mode_path_resolution.py
@@ -1,0 +1,243 @@
+#!/usr/bin/env python3
+"""Central-mode path-resolution regression tests.
+
+For each site migrated by the ``central-mode-path-correctness`` track, prove that
+in a simulated central install the resolved path is the project store
+(``~/.vnx-data/<project>/...``) and NEVER a ``__file__``-derived keystone walk.
+
+Two simulations per site where applicable:
+  1. Env set — ``VNX_DATA_DIR`` / ``VNX_STATE_DIR`` point at a central-style dir;
+     the site must honor them (not override with a ``__file__`` walk).
+  2. Fallback (the actual fix) — env unset; the canonical vnx_paths resolver
+     (which is VNX_HOME + project-marker aware) supplies the central path. We
+     stub it to a sentinel and assert the site delegates to it, proving the
+     ``__file__`` walk is gone.
+
+The roadmap-path fix (track_reconciler) is covered separately: repo-root first,
+CWD git-root next, legacy co-located layout last, never crashing on a miss.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+LIB = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import vnx_paths  # noqa: E402
+import cleanup_worker_exit  # noqa: E402
+import cost_tracker  # noqa: E402
+import dispatch_enricher  # noqa: E402
+import event_store  # noqa: E402
+import runtime_facade  # noqa: E402
+import shadow_logger  # noqa: E402
+import subprocess_adapter  # noqa: E402
+import t0_decision_reconcile  # noqa: E402
+import t0_escalations_log  # noqa: E402
+import track_reconciler  # noqa: E402
+import wiring_gate  # noqa: E402
+
+_ENV_VARS = (
+    "VNX_DATA_DIR",
+    "VNX_STATE_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_PROJECT_ID",
+)
+
+
+@pytest.fixture
+def central(monkeypatch, tmp_path):
+    """Simulate a central install where the canonical resolver returns the
+    project store (``<tmp>/.vnx-data/proj-x``), with all VNX_* env unset so the
+    migrated fallback path is exercised."""
+    data = tmp_path / ".vnx-data" / "proj-x"
+    state = data / "state"
+    state.mkdir(parents=True)
+    for var in _ENV_VARS:
+        monkeypatch.delenv(var, raising=False)
+    monkeypatch.setattr(
+        vnx_paths,
+        "resolve_paths",
+        lambda: {"VNX_DATA_DIR": str(data), "VNX_STATE_DIR": str(state)},
+    )
+    monkeypatch.setattr(
+        vnx_paths, "resolve_state_dir", lambda project_root=None: state
+    )
+    return data, state
+
+
+# ---------------------------------------------------------------------------
+# Fallback (the fix): env unset → canonical resolver → project store
+# ---------------------------------------------------------------------------
+
+
+def test_t0_escalations_log_data_dir(central):
+    data, _ = central
+    assert t0_escalations_log._data_dir() == data
+
+
+def test_t0_decision_reconcile_data_and_state(central):
+    data, state = central
+    assert t0_decision_reconcile._data_dir() == data
+    assert t0_decision_reconcile._state_dir() == state
+
+
+def test_runtime_facade_state_dir(central):
+    _, state = central
+    assert runtime_facade._resolve_state_dir() == str(state)
+
+
+def test_cleanup_worker_exit_state_and_register(central):
+    _, state = central
+    assert cleanup_worker_exit._resolve_state_dir() == state
+    assert (
+        cleanup_worker_exit._resolve_dispatch_register_path()
+        == state / "dispatch_register.ndjson"
+    )
+
+
+def test_dispatch_enricher_intelligence_db(central):
+    _, state = central
+    (state / "quality_intelligence.db").write_text("", encoding="utf-8")
+    resolved = dispatch_enricher.DispatchEnricher._intelligence_db_path()
+    assert resolved == state / "quality_intelligence.db"
+
+
+def test_event_store_events_dir(central):
+    data, _ = central
+    assert event_store._events_dir() == data / "events"
+
+
+def test_subprocess_adapter_stderr_log_path(central):
+    data, _ = central
+    adapter = subprocess_adapter.SubprocessAdapter()
+    resolved = adapter._resolve_stderr_log_path("T1", "d1")
+    assert resolved == data / "logs" / "subprocess" / "T1_d1.stderr.log"
+
+
+def test_cost_tracker_receipts_path(central):
+    _, state = central
+    assert cost_tracker._resolve_receipts_path() == state / "t0_receipts.ndjson"
+
+
+def test_shadow_logger_ledger_path(central):
+    _, state = central
+    resolved = shadow_logger._resolve_ledger_path(None)
+    assert resolved == state / shadow_logger.LEDGER_FILENAME
+
+
+def test_wiring_gate_skip_list_reads_project_store(central):
+    _, state = central
+    (state / "wiring_skip.yaml").write_text(
+        "library_exports:\n  - some_symbol\n", encoding="utf-8"
+    )
+    assert wiring_gate._load_skip_list() == {"some_symbol"}
+
+
+def test_no_site_returns_keystone(central):
+    """Blanket invariant: no migrated site returns a ~/.vnx-system keystone path."""
+    resolved = [
+        str(t0_escalations_log._data_dir()),
+        str(t0_decision_reconcile._data_dir()),
+        str(runtime_facade._resolve_state_dir()),
+        str(cleanup_worker_exit._resolve_state_dir()),
+        str(event_store._events_dir()),
+        str(cost_tracker._resolve_receipts_path()),
+        str(shadow_logger._resolve_ledger_path(None)),
+    ]
+    for p in resolved:
+        assert ".vnx-system" not in p, p
+
+
+# ---------------------------------------------------------------------------
+# Env-set: VNX_DATA_DIR / VNX_STATE_DIR honored (not overridden by a walk)
+# ---------------------------------------------------------------------------
+
+
+def test_env_vnx_data_dir_honored(monkeypatch, tmp_path):
+    data = tmp_path / ".vnx-data" / "proj-x"
+    data.mkdir(parents=True)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data))
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    assert t0_escalations_log._data_dir() == data
+    assert t0_decision_reconcile._data_dir() == data
+    adapter = subprocess_adapter.SubprocessAdapter()
+    assert str(adapter._resolve_stderr_log_path("T2", "d2")).startswith(str(data))
+
+
+def test_env_vnx_state_dir_honored(monkeypatch, tmp_path):
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    state.mkdir(parents=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(state))
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    assert runtime_facade._resolve_state_dir() == str(state)
+    assert cleanup_worker_exit._resolve_state_dir() == state
+    assert cost_tracker._resolve_receipts_path() == state / "t0_receipts.ndjson"
+
+
+# ---------------------------------------------------------------------------
+# Roadmap-path fix (track_reconciler._resolve_roadmap_path)
+# ---------------------------------------------------------------------------
+
+
+def test_roadmap_explicit_repo_root_wins(tmp_path):
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    repo = tmp_path / "repo"
+    resolved = track_reconciler._resolve_roadmap_path(state, repo)
+    assert resolved == repo / "ROADMAP.yaml"
+
+
+def test_roadmap_central_mode_not_two_up_from_state(tmp_path, monkeypatch):
+    # Central layout: state = ~/.vnx-data/<proj>/state; the legacy two-up
+    # (~/.vnx-data/ROADMAP.yaml) must NOT be used when a repo_root is given.
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    state.mkdir(parents=True)
+    repo = tmp_path / "project-repo"
+    resolved = track_reconciler._resolve_roadmap_path(state, repo)
+    assert resolved == repo / "ROADMAP.yaml"
+    assert resolved != state.parent.parent / "ROADMAP.yaml"
+
+
+def test_roadmap_cwd_git_root_fallback(tmp_path, monkeypatch):
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    fake_repo = tmp_path / "cwd-repo"
+    monkeypatch.setattr(track_reconciler, "_git_toplevel", lambda p: fake_repo)
+    resolved = track_reconciler._resolve_roadmap_path(state, None)
+    assert resolved == fake_repo / "ROADMAP.yaml"
+
+
+def test_roadmap_legacy_fallback_when_no_git(tmp_path, monkeypatch):
+    state = tmp_path / "repo" / ".vnx-data" / "state"
+    monkeypatch.setattr(track_reconciler, "_git_toplevel", lambda p: None)
+    resolved = track_reconciler._resolve_roadmap_path(state, None)
+    assert resolved == state.parent.parent / "ROADMAP.yaml"
+
+
+def test_load_merged_pr_numbers_never_crashes_on_missing_roadmap(tmp_path, monkeypatch):
+    # Source-3 is best-effort: a non-existent state dir / roadmap must not raise.
+    monkeypatch.setattr(track_reconciler, "_git_toplevel", lambda p: None)
+    result = track_reconciler._load_merged_pr_numbers(tmp_path / "nowhere" / "state")
+    assert result == frozenset()
+
+
+def test_load_merged_pr_numbers_reads_roadmap_from_repo_root(tmp_path, monkeypatch):
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    state.mkdir(parents=True)
+    repo = tmp_path / "project-repo"
+    repo.mkdir()
+    (repo / "ROADMAP.yaml").write_text(
+        "features:\n"
+        "  - pr_queue:\n"
+        "      - pr_id: '#4242'\n"
+        "        status: merged\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
+    merged = track_reconciler._load_merged_pr_numbers(state, repo_root=repo)
+    assert 4242 in merged

--- a/tests/test_central_mode_path_resolution.py
+++ b/tests/test_central_mode_path_resolution.py
@@ -41,12 +41,18 @@ import t0_decision_reconcile  # noqa: E402
 import t0_escalations_log  # noqa: E402
 import track_reconciler  # noqa: E402
 import wiring_gate  # noqa: E402
+from subprocess_dispatch_internals import state_paths  # noqa: E402
+
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+import planning_cli  # noqa: E402
 
 _ENV_VARS = (
     "VNX_DATA_DIR",
     "VNX_STATE_DIR",
     "VNX_DATA_DIR_EXPLICIT",
     "VNX_PROJECT_ID",
+    "VNX_ROADMAP_PATH",
+    "VNX_DISPATCH_DIR",
 )
 
 
@@ -63,7 +69,12 @@ def central(monkeypatch, tmp_path):
     monkeypatch.setattr(
         vnx_paths,
         "resolve_paths",
-        lambda: {"VNX_DATA_DIR": str(data), "VNX_STATE_DIR": str(state)},
+        lambda: {
+            "VNX_DATA_DIR": str(data),
+            "VNX_STATE_DIR": str(state),
+            "VNX_DISPATCH_DIR": str(data / "dispatches"),
+            "PROJECT_ROOT": str(tmp_path / "project-repo"),
+        },
     )
     monkeypatch.setattr(
         vnx_paths, "resolve_state_dir", lambda project_root=None: state
@@ -179,6 +190,112 @@ def test_env_vnx_state_dir_honored(monkeypatch, tmp_path):
     assert runtime_facade._resolve_state_dir() == str(state)
     assert cleanup_worker_exit._resolve_state_dir() == state
     assert cost_tracker._resolve_receipts_path() == state / "t0_receipts.ndjson"
+
+
+# ---------------------------------------------------------------------------
+# state_paths (subprocess_dispatch_internals) — helper-return __file__ sites
+# ---------------------------------------------------------------------------
+
+
+def test_state_paths_default_state_dir(central):
+    _, state = central
+    assert state_paths._default_state_dir() == state
+
+
+def test_state_paths_active_dispatch_dir_uses_dispatch_dir(central, monkeypatch):
+    data, _ = central
+    active = data / "dispatches" / "active"
+    active.mkdir(parents=True)
+    marker = active / "d-999-foo.md"
+    marker.write_text("x", encoding="utf-8")
+    assert state_paths._resolve_active_dispatch_file("d-999") == marker
+
+
+def test_state_paths_manifest_dir_uses_dispatch_dir(central):
+    data, _ = central
+    resolved = state_paths._dispatch_manifest_dir("pending", "d-123")
+    assert resolved == data / "dispatches" / "pending" / "d-123"
+
+
+def test_state_paths_no_project_root_helper_remains():
+    # The __file__-anchored _project_root helper must be gone entirely.
+    assert not hasattr(state_paths, "_project_root")
+
+
+# ---------------------------------------------------------------------------
+# planning_cli default resolvers (Gap 1)
+# ---------------------------------------------------------------------------
+
+
+def test_planning_cli_repo_root_none_when_not_explicit():
+    # Must return None (not a __file__-derived keystone path) so the reconciler's
+    # own CWD/legacy fallback runs. Passing a non-None value is treated as explicit.
+    assert planning_cli._resolve_repo_root("") is None
+
+
+def test_planning_cli_repo_root_explicit_resolved(tmp_path):
+    resolved = planning_cli._resolve_repo_root(str(tmp_path))
+    assert resolved == tmp_path.resolve()
+
+
+def test_planning_cli_state_dir_routes_through_resolver(central):
+    _, state = central
+    assert planning_cli._resolve_state_dir("") == state
+
+
+def test_planning_cli_roadmap_routes_through_project_root(central, tmp_path):
+    resolved = planning_cli._resolve_roadmap_path(None)
+    assert resolved == tmp_path / "project-repo" / "ROADMAP.yaml"
+    assert ".vnx-system" not in str(resolved)
+
+
+# ---------------------------------------------------------------------------
+# Close-evidence threads repo_root (Gap 3)
+# ---------------------------------------------------------------------------
+
+
+def _minimal_reconciler_db(state_dir: Path, track_id: str, project_id: str, pr_ref: str):
+    """Create the minimal tables _close_evidence queries, with one track."""
+    import sqlite3
+
+    db = state_dir / track_reconciler.DB_FILENAME
+    conn = sqlite3.connect(str(db))
+    conn.executescript(
+        "CREATE TABLE dispatches (dispatch_id TEXT, track TEXT, project_id TEXT, state TEXT);"
+        "CREATE TABLE tracks (track_id TEXT, project_id TEXT, pr_ref TEXT);"
+        "CREATE TABLE coordination_events (event_type TEXT, project_id TEXT, entity_id TEXT);"
+    )
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, pr_ref) VALUES (?, ?, ?)",
+        (track_id, project_id, pr_ref),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_close_evidence_uses_repo_root_roadmap(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
+    state = tmp_path / ".vnx-data" / "proj-x" / "state"
+    state.mkdir(parents=True)
+    _minimal_reconciler_db(state, "T-close", "proj-x", "#4242")
+
+    repo = tmp_path / "project-repo"
+    repo.mkdir()
+    (repo / "ROADMAP.yaml").write_text(
+        "features:\n  - pr_queue:\n      - pr_id: '#4242'\n        status: merged\n",
+        encoding="utf-8",
+    )
+
+    # With repo_root -> reads the repo roadmap -> #4242 merged -> pr_merged True.
+    ev = track_reconciler._close_evidence("%s" % state, "T-close", "proj-x", repo_root=repo)
+    assert ev["pr_merged"] is True
+    assert ev["has_success_signal"] is True
+
+    # Without repo_root, and with the CWD git-root roadmap forced empty, the same
+    # evidence renders pr_merged False — proving repo_root is what carried it.
+    monkeypatch.setattr(track_reconciler, "_git_toplevel", lambda p: None)
+    ev_none = track_reconciler._close_evidence("%s" % state, "T-close", "proj-x")
+    assert ev_none["pr_merged"] is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_f37_hardening.py
+++ b/tests/test_f37_hardening.py
@@ -30,82 +30,102 @@ class TestEventArchiveOnCompletion(unittest.TestCase):
     """archive() must be called in the finally block after subprocess completes."""
 
     def _run_deliver(self, mock_adapter_cls, archive_raises=False):
-        """Helper: run deliver_via_subprocess with a mocked adapter."""
+        """Helper: run deliver_via_subprocess with a mocked adapter.
+
+        Also patches subprocess_dispatch.SubprocessAdapter to the SAME mock
+        class: delivery.py's finally block falls back to
+        `subprocess_dispatch.SubprocessAdapter()` for cleanup when
+        spawn_result is never assigned (e.g. an exception inside
+        spawn_claude before it returns) — leaving that binding real would
+        construct an actual SubprocessAdapter for event-store cleanup.
+        """
         mock_event_store = MagicMock()
         if archive_raises:
-            mock_event_store.archive.side_effect = RuntimeError("archive error")
+            mock_event_store.clear.side_effect = RuntimeError("archive error")
 
         mock_adapter = MagicMock()
-        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.event_store = mock_event_store
         mock_adapter.deliver.return_value = MagicMock(success=True)
         mock_adapter.read_events_with_timeout.return_value = iter([])
         mock_adapter.trigger_report_pipeline.return_value = True
         mock_adapter_cls.return_value = mock_adapter
 
         from subprocess_dispatch import deliver_via_subprocess
-        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
+        with patch("subprocess_dispatch.SubprocessAdapter", new=mock_adapter_cls):
+            deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
         return mock_event_store
 
-    @patch("subprocess_dispatch.SubprocessAdapter")
+    @patch("provider_spawns.claude_spawn.SubprocessAdapter")
     def test_archive_called_in_finally_on_success(self, mock_cls):
         es = self._run_deliver(mock_cls)
-        es.archive.assert_called_once_with("T1", "dispatch-123")
+        es.clear.assert_called_once_with("T1", archive_dispatch_id="dispatch-123")
 
-    @patch("subprocess_dispatch.SubprocessAdapter")
+    @patch("provider_spawns.claude_spawn.SubprocessAdapter")
     def test_archive_called_before_trigger(self, mock_cls):
-        """archive() must be called before trigger_report_pipeline()."""
+        """archive (via event_store.clear) must be called before trigger_report_pipeline()."""
         call_order = []
 
         mock_event_store = MagicMock()
-        mock_event_store.archive.side_effect = lambda *a: call_order.append("archive")
+        mock_event_store.clear.side_effect = lambda *a, **kw: call_order.append("archive")
 
         mock_adapter = MagicMock()
-        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.event_store = mock_event_store
         mock_adapter.deliver.return_value = MagicMock(success=True)
         mock_adapter.read_events_with_timeout.return_value = iter([])
         mock_adapter.trigger_report_pipeline.side_effect = lambda *a, **kw: call_order.append("trigger")
         mock_cls.return_value = mock_adapter
 
         from subprocess_dispatch import deliver_via_subprocess
-        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
+        with patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls):
+            deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-123")
 
         self.assertEqual(call_order, ["archive", "trigger"])
 
-    @patch("subprocess_dispatch.SubprocessAdapter")
+    @patch("provider_spawns.claude_spawn.SubprocessAdapter")
     def test_archive_called_even_when_subprocess_raises(self, mock_cls):
-        """archive() runs in finally even when read_events raises."""
+        """archive (via event_store.clear) runs in finally even when read_events raises.
+
+        deliver_via_subprocess no longer swallows arbitrary exceptions from the
+        stream read (spawn_claude only catches SubprocessError/JSONDecodeError/
+        OSError) — RuntimeError propagates after the finally block runs, so this
+        asserts the raise instead of a False return. Also, spawn_result is never
+        assigned when spawn_claude raises, so the finally block's cleanup falls
+        back to subprocess_dispatch.SubprocessAdapter() — patch that binding too.
+        """
         mock_event_store = MagicMock()
         mock_adapter = MagicMock()
-        mock_adapter._get_event_store.return_value = mock_event_store
+        mock_adapter.event_store = mock_event_store
         mock_adapter.deliver.return_value = MagicMock(success=True)
         mock_adapter.read_events_with_timeout.side_effect = RuntimeError("stream error")
         mock_adapter.trigger_report_pipeline.return_value = True
         mock_cls.return_value = mock_adapter
 
         from subprocess_dispatch import deliver_via_subprocess
-        result = deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-abc")
-        self.assertFalse(result)
-        mock_event_store.archive.assert_called_once_with("T1", "dispatch-abc")
+        with patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls):
+            with self.assertRaises(RuntimeError):
+                deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-abc")
+        mock_event_store.clear.assert_called_once_with("T1", archive_dispatch_id="dispatch-abc")
 
-    @patch("subprocess_dispatch.SubprocessAdapter")
+    @patch("provider_spawns.claude_spawn.SubprocessAdapter")
     def test_archive_failure_does_not_crash(self, mock_cls):
         """archive() exception must not propagate — pipeline must remain non-crashing."""
         es = self._run_deliver(mock_cls, archive_raises=True)
-        es.archive.assert_called_once()  # was called; exception was swallowed
+        es.clear.assert_called_once()  # was called; exception was swallowed
 
-    @patch("subprocess_dispatch.SubprocessAdapter")
+    @patch("provider_spawns.claude_spawn.SubprocessAdapter")
     def test_no_archive_when_event_store_unavailable(self, mock_cls):
         """When _get_event_store() returns None, no crash."""
         mock_adapter = MagicMock()
-        mock_adapter._get_event_store.return_value = None
+        mock_adapter.event_store = None
         mock_adapter.deliver.return_value = MagicMock(success=True)
         mock_adapter.read_events_with_timeout.return_value = iter([])
         mock_adapter.trigger_report_pipeline.return_value = True
         mock_cls.return_value = mock_adapter
 
         from subprocess_dispatch import deliver_via_subprocess
-        # Should not raise
-        deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-xyz")
+        with patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls):
+            # Should not raise
+            deliver_via_subprocess("T1", "instruction", "sonnet", "dispatch-xyz")
 
 
 # ─── OI-1063: FALLBACK_POLICY in auto_report_contract ────────────────────────

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -340,3 +340,50 @@ def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
     assert rc == 0
     for verb in ("add", "list", "promote"):
         assert verb in out
+
+
+# ---------------------------------------------------------------------------
+# repo_root defaulting + drift no-crash (central-mode-path-correctness, round 3)
+# ---------------------------------------------------------------------------
+
+from types import SimpleNamespace  # noqa: E402
+
+from vnx_cli.commands import horizon as _horizon  # noqa: E402
+
+
+def test_default_repo_root_sets_from_project_dir(tmp_path):
+    args = SimpleNamespace(project_dir=str(tmp_path))
+    _horizon._default_repo_root(args)
+    assert args.repo_root == str(tmp_path.resolve())
+
+
+def test_default_repo_root_preserves_explicit(tmp_path):
+    args = SimpleNamespace(project_dir=str(tmp_path), repo_root="/explicit/root")
+    _horizon._default_repo_root(args)
+    assert args.repo_root == "/explicit/root"
+
+
+def test_horizon_drift_no_repo_root_crash(project, monkeypatch, capsys):
+    """`vnx horizon drift` must not raise 'Namespace has no attribute repo_root'
+    nor emit 'cannot resolve repo root' — the pip CLI defaults repo_root and the
+    reconciler tolerates it."""
+    project_dir, _ = project
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "drift",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert "has no attribute 'repo_root'" not in err
+    assert "cannot resolve repo root" not in err
+    assert rc == 0
+
+
+def test_horizon_reconcile_no_repo_root_crash(project, monkeypatch, capsys):
+    project_dir, _ = project
+    rc, out, err = _run(monkeypatch, capsys, [
+        "horizon", "reconcile",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert "has no attribute 'repo_root'" not in err
+    assert "cannot resolve repo root" not in err
+    # reconcile returns 0 (nothing to close) or 3 (gh absent) — never a crash.
+    assert rc in (0, 3)

--- a/tests/test_latency_pr1_cooldown.py
+++ b/tests/test_latency_pr1_cooldown.py
@@ -247,7 +247,8 @@ class TestSubprocessDispatchEnvOverride:
         mock_instance.read_events_with_timeout.return_value = iter([])
         mock_instance.get_session_id.return_value = None
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_instance), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_instance), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_instance), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \

--- a/tests/test_latency_pr2_session_resume.py
+++ b/tests/test_latency_pr2_session_resume.py
@@ -191,7 +191,8 @@ class TestSessionResumePassthrough:
 
         mock_adapter = _make_deliver_mocks("new-session-id")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \
@@ -215,7 +216,8 @@ class TestSessionResumePassthrough:
 
         mock_adapter = _make_deliver_mocks("new-session-id")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \
@@ -240,7 +242,8 @@ class TestSessionResumePassthrough:
 
         mock_adapter = _make_deliver_mocks("new-session-id")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \
@@ -266,7 +269,8 @@ class TestSessionPersistenceAfterDelivery:
 
         mock_adapter = _make_deliver_mocks("fresh-session-xyz")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \
@@ -290,7 +294,8 @@ class TestSessionPersistenceAfterDelivery:
 
         mock_adapter = _make_deliver_mocks("some-session-id")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \
@@ -316,7 +321,8 @@ class TestSessionPersistenceAfterDelivery:
         broken_store.load.side_effect = RuntimeError("disk full")
         broken_store.save.side_effect = RuntimeError("disk full")
 
-        with patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=mock_adapter), \
+             patch("subprocess_dispatch.SubprocessAdapter", return_value=mock_adapter), \
              patch("subprocess_dispatch._inject_skill_context", return_value="instr"), \
              patch("subprocess_dispatch._inject_permission_profile", return_value="instr"), \
              patch("subprocess_dispatch._resolve_agent_cwd", return_value=None), \

--- a/tests/test_latency_pr3_timeout_flock.py
+++ b/tests/test_latency_pr3_timeout_flock.py
@@ -25,7 +25,12 @@ from subprocess_dispatch import deliver_via_subprocess
 
 @pytest.fixture
 def mock_adapter():
-    with patch("subprocess_dispatch.SubprocessAdapter") as cls:
+    # spawn_claude() (provider_spawns/claude_spawn.py) constructs its own
+    # SubprocessAdapter directly, separate from subprocess_dispatch's binding;
+    # patch both (sharing one mock) so deliver_via_subprocess never touches a
+    # real, unmocked adapter that would attempt an actual claude subprocess spawn.
+    with patch("provider_spawns.claude_spawn.SubprocessAdapter") as cls, \
+         patch("subprocess_dispatch.SubprocessAdapter", new=cls):
         instance = MagicMock()
         instance.was_timed_out.return_value = False
         deliver_result = MagicMock()
@@ -40,7 +45,7 @@ def mock_adapter():
         obs = MagicMock()
         obs.transport_state = {"returncode": 0}
         instance.observe.return_value = obs
-        instance._get_event_store.return_value = None
+        instance.event_store = None
         instance.get_session_id.return_value = "sess-abc"
         cls.return_value = instance
         yield instance

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1199,3 +1199,121 @@ class TestBuildTickCommand:
         assert "my-project" in cmd
         assert "--state-dir" in cmd
         assert sd in cmd
+
+
+# ---------------------------------------------------------------------------
+# repo_root None-tolerance (central-mode-path-correctness, round 3)
+# ---------------------------------------------------------------------------
+
+import planning_cli  # noqa: E402
+import vnx_paths  # noqa: E402
+from types import SimpleNamespace  # noqa: E402
+
+
+def test_resolve_effective_repo_root_prefers_project_root(tmp_path, monkeypatch):
+    proj = tmp_path / "proj"
+    proj.mkdir()
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: {"PROJECT_ROOT": str(proj)})
+    assert objective_reconcile._resolve_effective_repo_root() == proj
+
+
+def test_resolve_effective_repo_root_falls_back_to_cwd_git(tmp_path, monkeypatch):
+    def _boom():
+        raise RuntimeError("no paths")
+    monkeypatch.setattr(vnx_paths, "resolve_paths", _boom)
+    git_root = tmp_path / "gitrepo"
+    monkeypatch.setattr(
+        objective_reconcile.track_reconciler, "_git_toplevel", lambda p: git_root
+    )
+    assert objective_reconcile._resolve_effective_repo_root() == git_root
+
+
+def test_run_reconcile_none_repo_root_resolves_internally(tmp_path, monkeypatch):
+    # None must be resolved to a concrete repo root (never passed as None into gh).
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-none", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-none", "T-none", state="completed")
+    _seed_pr_merged_ndjson(sd, 100)
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({100: _merged_pr(100)}),
+    )
+    resolved_calls = []
+
+    def _spy():
+        resolved_calls.append(True)
+        return tmp_path
+
+    monkeypatch.setattr(objective_reconcile, "_resolve_effective_repo_root", _spy)
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=None, apply=False,
+    )
+    assert resolved_calls, "None repo_root must trigger internal resolution"
+    assert code == 0
+    assert summary["counts"]["confirmed"] == 1
+
+
+def test_run_reconcile_explicit_repo_root_not_resolved(tmp_path, monkeypatch):
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-exp", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-exp", "T-exp", state="completed")
+    _seed_pr_merged_ndjson(sd, 100)
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({100: _merged_pr(100)}),
+    )
+    resolved_calls = []
+    monkeypatch.setattr(
+        objective_reconcile, "_resolve_effective_repo_root",
+        lambda: resolved_calls.append(True) or tmp_path,
+    )
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+    assert not resolved_calls, "explicit repo_root must NOT trigger internal resolution"
+    assert code == 0
+
+
+def test_objective_close_dry_run_threads_repo_root_into_evidence(tmp_path, monkeypatch):
+    # Gap 2: the dry-run close path must read the project ROADMAP (Source-3) via
+    # repo_root, so pr_merged is True when the repo roadmap lists the PR merged.
+    monkeypatch.setenv("VNX_RECONCILE_GIT", "0")
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-dry", phase="active", pr_ref="#4242")
+    _seed_dispatch(sd, "D-dry", "T-dry", state="completed")  # derives 'done'
+
+    repo = tmp_path / "project-repo"
+    repo.mkdir()
+    (repo / "ROADMAP.yaml").write_text(
+        "features:\n  - pr_queue:\n      - pr_id: '#4242'\n        status: merged\n",
+        encoding="utf-8",
+    )
+
+    args = SimpleNamespace(
+        state_dir=str(sd),
+        project_id=PROJECT_ID,
+        track_id="T-dry",
+        repo_root=str(repo),
+        apply=False,
+        approval_id=None,
+        include_parked=False,
+        json=True,
+    )
+    captured = {}
+    real_close_evidence = planning_cli._close_evidence
+
+    def _spy(state_dir, track_id, project_id, repo_root=None):
+        captured["repo_root"] = repo_root
+        return real_close_evidence(state_dir, track_id, project_id, repo_root=repo_root)
+
+    monkeypatch.setattr(planning_cli, "_close_evidence", _spy)
+
+    rc = planning_cli.cmd_objective_close(args)
+    assert rc == 0
+    # The dry-run path forwarded repo_root...
+    assert captured.get("repo_root") == Path(str(repo)).resolve()
+    # ...and the evidence read the repo roadmap -> pr_merged True (would be False
+    # if repo_root were dropped and the CWD-git-root roadmap read instead).
+    ev = real_close_evidence(str(sd), "T-dry", PROJECT_ID, repo_root=Path(str(repo)).resolve())
+    assert ev["pr_merged"] is True

--- a/tests/test_subprocess_dispatch.py
+++ b/tests/test_subprocess_dispatch.py
@@ -17,11 +17,21 @@ from subprocess_dispatch import deliver_via_subprocess, _build_intelligence_sect
 
 @pytest.fixture
 def mock_adapter():
-    """Patch SubprocessAdapter and return the mock instance."""
-    with patch("subprocess_dispatch.SubprocessAdapter") as cls:
-        instance = MagicMock()
-        instance.was_timed_out.return_value = False
-        cls.return_value = instance
+    """Patch SubprocessAdapter and return the mock instance.
+
+    Patches both bindings: `provider_spawns.claude_spawn.SubprocessAdapter` is
+    where spawn_claude() actually instantiates it (Wave 4.6 PR-4.6.2 moved the
+    spawn+stream slice there), and `subprocess_dispatch.SubprocessAdapter` is
+    still referenced as a cleanup-path fallback in
+    subprocess_dispatch_internals.delivery. Patching only the latter (as this
+    fixture used to) leaves the former unmocked, so deliver_via_subprocess()
+    would construct a real SubprocessAdapter and attempt an actual `claude`
+    subprocess spawn.
+    """
+    instance = MagicMock()
+    instance.was_timed_out.return_value = False
+    with patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=instance), \
+         patch("subprocess_dispatch.SubprocessAdapter", return_value=instance):
         yield instance
 
 

--- a/tests/test_subprocess_dispatch_cfx_r1.py
+++ b/tests/test_subprocess_dispatch_cfx_r1.py
@@ -67,6 +67,7 @@ class TestManifestStageRoutedByOutcome(unittest.TestCase):
         promote = MagicMock(return_value="/tmp/destination.json")
         adapter = _make_adapter(returncode=returncode, was_timed_out=was_timed_out)
         cms = _common_patches(promote) + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
         ]
         for cm in cms:

--- a/tests/test_subprocess_dispatch_codex_r2.py
+++ b/tests/test_subprocess_dispatch_codex_r2.py
@@ -404,6 +404,7 @@ class TestDeliverViaSubprocessTouchedFiles(unittest.TestCase):
         adapter.trigger_report_pipeline.return_value = None
 
         cms = self._patch_chain() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
         ]
         for cm in cms:
@@ -440,6 +441,7 @@ class TestDeliverViaSubprocessTouchedFiles(unittest.TestCase):
         adapter.trigger_report_pipeline.return_value = None
 
         cms = self._patch_chain() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
         ]
         for cm in cms:
@@ -479,6 +481,7 @@ class TestDeliverViaSubprocessTouchedFiles(unittest.TestCase):
         adapter.trigger_report_pipeline.return_value = None
 
         cms = self._patch_chain() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
         ]
         for cm in cms:

--- a/tests/test_subprocess_dispatch_f34.py
+++ b/tests/test_subprocess_dispatch_f34.py
@@ -4,6 +4,7 @@ and cwd propagation through deliver_via_subprocess → SubprocessAdapter.deliver
 """
 
 import sys
+from contextlib import contextmanager
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -174,16 +175,22 @@ class TestInjectSkillContext:
 class TestInjectSkillContextIntegration:
     """Integration tests patching Path inside subprocess_dispatch."""
 
+    @contextmanager
     def _patch_project_root(self, tmp_path: Path):
-        """Context manager that patches the project root inside subprocess_dispatch."""
+        """Patch the project root inside subprocess_dispatch AND force the
+        PromptAssembler path to fail.
+
+        _inject_skill_context tries prompt_assembler.PromptAssembler first
+        (scripts/lib/prompt_assembler.py resolves its own prompts/ dir via
+        its own __file__, unaffected by this patch) — it resolves real
+        agents/skills/roles from THIS repo and succeeds, so the legacy
+        3-tier CLAUDE.md resolution these tests target would never be
+        reached without also disabling that path.
+        """
         import subprocess_dispatch as sd
 
         # Capture real Path class
         real_path_cls = Path
-
-        class PatchedPath(type(real_path_cls())):
-            """Subclass of Path that redirects parents[2] to tmp_path."""
-            pass
 
         # Simpler: patch using object-level mock on the module
         original_file = sd.__file__
@@ -198,7 +205,9 @@ class TestInjectSkillContextIntegration:
                 return mock
             return real_path_cls(*args, **kwargs)
 
-        return patch("subprocess_dispatch.Path", side_effect=fake_path)
+        with patch("subprocess_dispatch.Path", side_effect=fake_path), \
+             patch("subprocess_dispatch_internals.skill_injection._try_prompt_assembler", return_value=None):
+            yield
 
     def test_inject_prepends_agents_context(self, tmp_path):
         agents_md = tmp_path / "agents" / "backend-developer" / "CLAUDE.md"
@@ -265,7 +274,8 @@ class TestDeliverCwdPropagation:
 
     @pytest.fixture
     def mock_adapter(self):
-        with patch("subprocess_dispatch.SubprocessAdapter") as cls:
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as cls, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=cls):
             instance = MagicMock()
             cls.return_value = instance
             yield instance

--- a/tests/test_subprocess_dispatch_integration.py
+++ b/tests/test_subprocess_dispatch_integration.py
@@ -53,9 +53,12 @@ class TestDeliverViaSubprocess(unittest.TestCase):
     """Unit tests for the deliver_via_subprocess() helper."""
 
     def test_returns_true_on_success(self):
-        with patch("subprocess_dispatch.SubprocessAdapter") as MockAdapter:
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as MockAdapter, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=MockAdapter):
             instance = MockAdapter.return_value
             instance.deliver.return_value = _delivery_result(success=True)
+            instance.read_events_with_timeout.return_value = iter([])
+            instance.was_timed_out.return_value = False
             obs = MagicMock()
             obs.transport_state = {"returncode": 0}
             instance.observe.return_value = obs
@@ -75,7 +78,8 @@ class TestDeliverViaSubprocess(unittest.TestCase):
         self.assertIsNone(call_kwargs.get("cwd"))
 
     def test_returns_false_on_failure(self):
-        with patch("subprocess_dispatch.SubprocessAdapter") as MockAdapter:
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as MockAdapter, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=MockAdapter):
             instance = MockAdapter.return_value
             instance.deliver.return_value = _delivery_result(success=False)
 
@@ -89,7 +93,8 @@ class TestDeliverViaSubprocess(unittest.TestCase):
         self.assertFalse(result.success)
 
     def test_passes_model_to_adapter(self):
-        with patch("subprocess_dispatch.SubprocessAdapter") as MockAdapter:
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as MockAdapter, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=MockAdapter):
             instance = MockAdapter.return_value
             instance.deliver.return_value = _delivery_result(success=True)
 
@@ -115,7 +120,8 @@ class TestSubprocessRoutingEnvVar(unittest.TestCase):
     def test_subprocess_adapter_called_when_env_set(self):
         """When VNX_ADAPTER_T1=subprocess, deliver_via_subprocess must be called."""
         with patch.dict(os.environ, {"VNX_ADAPTER_T1": "subprocess"}):
-            with patch("subprocess_dispatch.SubprocessAdapter") as MockAdapter:
+            with patch("provider_spawns.claude_spawn.SubprocessAdapter") as MockAdapter, \
+                 patch("subprocess_dispatch.SubprocessAdapter", new=MockAdapter):
                 instance = MockAdapter.return_value
                 instance.deliver.return_value = _delivery_result(success=True)
 

--- a/tests/test_subprocess_dispatch_round2_codex.py
+++ b/tests/test_subprocess_dispatch_round2_codex.py
@@ -144,6 +144,7 @@ class TestSessionIdNotSavedOnFailureOrTimeout(unittest.TestCase):
         adapter = _make_adapter(returncode=1)
 
         cms = _common_patches() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
             patch("session_store.SessionStore", return_value=store),
             patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),
@@ -173,6 +174,7 @@ class TestSessionIdNotSavedOnFailureOrTimeout(unittest.TestCase):
         adapter = _make_adapter(returncode=None, was_timed_out=True)
 
         cms = _common_patches() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
             patch("session_store.SessionStore", return_value=store),
             patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),
@@ -201,6 +203,7 @@ class TestSessionIdNotSavedOnFailureOrTimeout(unittest.TestCase):
                                 session_id="fresh-success-session")
 
         cms = _common_patches() + [
+            patch("provider_spawns.claude_spawn.SubprocessAdapter", return_value=adapter),
             patch("subprocess_dispatch.SubprocessAdapter", return_value=adapter),
             patch("session_store.SessionStore", return_value=store),
             patch.dict("os.environ", {"VNX_SESSION_RESUME": "1"}, clear=False),

--- a/tests/test_subprocess_dispatch_stuck_count.py
+++ b/tests/test_subprocess_dispatch_stuck_count.py
@@ -103,7 +103,8 @@ class TestDeliverWithRecoveryStuckCount(unittest.TestCase):
 
     def test_stuck_count_forwarded_to_write_receipt_on_success(self):
         """On success, _write_receipt receives stuck_event_count from monitor.stuck_count."""
-        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls), \
              patch("subprocess_dispatch._write_receipt") as mock_receipt, \
              patch("subprocess_dispatch._check_commit_since", return_value=False), \
              patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
@@ -137,7 +138,8 @@ class TestDeliverWithRecoveryStuckCount(unittest.TestCase):
 
     def test_stuck_count_zero_forwarded_on_success(self):
         """Zero stuck_count is correctly forwarded (no STUCK events occurred)."""
-        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls), \
              patch("subprocess_dispatch._write_receipt") as mock_receipt, \
              patch("subprocess_dispatch._check_commit_since", return_value=False), \
              patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \
@@ -167,7 +169,8 @@ class TestDeliverWithRecoveryStuckCount(unittest.TestCase):
 
     def test_stuck_count_forwarded_on_failure(self):
         """On final failure, stuck_count is still forwarded to the failure receipt."""
-        with patch("subprocess_dispatch.SubprocessAdapter") as mock_cls, \
+        with patch("provider_spawns.claude_spawn.SubprocessAdapter") as mock_cls, \
+             patch("subprocess_dispatch.SubprocessAdapter", new=mock_cls), \
              patch("subprocess_dispatch._write_receipt") as mock_receipt, \
              patch("subprocess_dispatch._check_commit_since", return_value=False), \
              patch("subprocess_dispatch._get_commit_hash", return_value="abc123"), \

--- a/tests/test_subprocess_f32_r3_claim_verification.py
+++ b/tests/test_subprocess_f32_r3_claim_verification.py
@@ -35,9 +35,21 @@ def _make_observe(returncode):
 
 @pytest.fixture
 def mock_adapter():
-    with patch("subprocess_dispatch.SubprocessAdapter") as cls:
+    with patch("provider_spawns.claude_spawn.SubprocessAdapter") as cls, \
+         patch("subprocess_dispatch.SubprocessAdapter", new=cls):
         instance = MagicMock()
         cls.return_value = instance
+        # was_timed_out() is a real bool on SubprocessAdapter (default False,
+        # absent an actual timeout) — an unstubbed MagicMock is truthy and
+        # would force every "clean exit" scenario into fail-closed via the
+        # `spawn_result.timed_out` branch in delivery.py.
+        instance.was_timed_out.return_value = False
+        # Real SubprocessAdapter._returncode_cache is a plain dict; an
+        # unstubbed MagicMock attribute would make the claude_spawn.py
+        # `.get(terminal_id)` fallback return a truthy Mock (int(Mock())==1)
+        # instead of None, defeating the None-returncode "treated as clean"
+        # path.
+        instance._returncode_cache = {}
         yield instance
 
 
@@ -117,14 +129,16 @@ class TestFailClosedOnNonZeroExit:
         mock_adapter.observe.assert_not_called()
         mock_adapter.read_events_with_timeout.assert_not_called()
 
-    def test_exit_none_treated_as_clean(self, mock_adapter):
-        """returncode=None (process removed after timeout kill) is treated as clean.
+    def test_exit_none_treated_as_failure(self, mock_adapter):
+        """returncode=None (truly unknown, no cache entry either) fails closed.
 
-        The timeout path in read_events_with_timeout calls stop() which removes
-        the process from _processes.  observe() then returns a transport_state
-        without 'returncode', so .get('returncode') returns None.  None must NOT
-        trigger fail-closed — the caller sees an empty event stream and handles
-        the timeout separately.
+        #490 (PR-4.6.2, codex round-1) deliberately hardened the
+        claude_spawn.py fallback chain: when neither observe()'s
+        transport_state nor adapter._returncode_cache has a returncode, the
+        final default became `returncode = 1` (previously `0`) "for the same
+        fail-closed contract" as the stream-read-exception handling added in
+        that PR (see tests/test_claude_spawn_fail_closed.py). An indeterminate
+        returncode must not be classified as success.
         """
         mock_adapter.deliver.return_value = MagicMock(success=True)
         mock_adapter.read_events_with_timeout.return_value = iter([])
@@ -134,7 +148,7 @@ class TestFailClosedOnNonZeroExit:
 
         result = deliver_via_subprocess("T1", "do work", "sonnet", "d-106")
 
-        assert result.success is True
+        assert result.success is False
 
     def test_event_count_preserved_on_fail_closed(self, mock_adapter):
         """Event count in _SubprocessResult must reflect parsed events even on failure."""

--- a/tests/test_subprocess_intelligence_injection.py
+++ b/tests/test_subprocess_intelligence_injection.py
@@ -253,7 +253,8 @@ class TestInstructionCharsAccuracy:
         with _patch_selector(result):
             with patch.dict(sys.modules, {"prompt_assembler": None}):
                 with patch("subprocess_dispatch._write_manifest", side_effect=_capture_write):
-                    with patch("subprocess_dispatch.SubprocessAdapter") as mock_adapter_cls:
+                    with patch("provider_spawns.claude_spawn.SubprocessAdapter") as mock_adapter_cls, \
+                         patch("subprocess_dispatch.SubprocessAdapter", new=mock_adapter_cls):
                         instance = MagicMock()
                         instance.deliver.return_value = MagicMock(success=False)
                         mock_adapter_cls.return_value = instance

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -233,7 +233,9 @@ def test_load_merged_from_roadmap_yaml(tmp_path):
         "        status: merged\n",
         encoding="utf-8",
     )
-    result = _load_merged_pr_numbers(state_dir)
+    # repo_root points Source-3 at the test-controlled ROADMAP.yaml deterministically
+    # (independent of the CWD git-root), which is the project repo root.
+    result = _load_merged_pr_numbers(state_dir, repo_root=tmp_path)
     assert 800 in result
     assert 802 in result
     assert 801 not in result  # status=open, not merged
@@ -253,7 +255,7 @@ def test_load_merged_combines_sources(tmp_path):
         "features:\n  - feature_id: f\n    pr_queue:\n      - pr_id: '#757'\n        status: merged\n",
         encoding="utf-8",
     )
-    result = _load_merged_pr_numbers(state_dir)
+    result = _load_merged_pr_numbers(state_dir, repo_root=tmp_path)
     assert 676 in result
     assert 757 in result
 
@@ -476,13 +478,14 @@ def test_reconcile_all_tracks_prref_evidence(tmp_path):
     _seed_track(state_dir, "T-all-d", pr_ref=None)
     _seed_dispatch(state_dir, "D-all-d", "T-all-d", state="running")
 
-    # ROADMAP.yaml at project root (state_dir.parent.parent == tmp_path for deep=True)
+    # ROADMAP.yaml at the project repo root; repo_root threads it into Source-3
+    # deterministically (independent of the CWD git-root).
     (tmp_path / "ROADMAP.yaml").write_text(
         "features:\n  - feature_id: f\n    pr_queue:\n      - pr_id: '#756'\n        status: merged\n",
         encoding="utf-8",
     )
 
-    results = track_reconciler.reconcile_all_tracks(state_dir, PROJECT_ID)
+    results = track_reconciler.reconcile_all_tracks(state_dir, PROJECT_ID, repo_root=tmp_path)
     by_id = {r["track_id"]: r for r in results}
 
     assert by_id["T-all-a"]["derived_status"] == "done"

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -78,6 +78,20 @@ def _prep(args: Any) -> None:
     args.project_id = resolve_project_id(args)
 
 
+def _default_repo_root(args: Any) -> None:
+    """Default ``--repo-root`` to the resolved project_dir when not set.
+
+    The pip CLI runs against ``--project-dir`` and the caller's CWD is not
+    necessarily the project repo (central-mode), so ``gh`` PR lookups and the
+    ROADMAP.yaml (Source-3) evidence must anchor on the project_dir — not the
+    packaged engine's own location or a stray CWD. Also guarantees the attribute
+    exists so ``planning_cli`` never hits ``AttributeError: 'Namespace' object
+    has no attribute 'repo_root'``.
+    """
+    if not getattr(args, "repo_root", ""):
+        args.repo_root = str(Path(args.project_dir).resolve())
+
+
 # ---------------------------------------------------------------------------
 # objective-domain verbs
 # ---------------------------------------------------------------------------
@@ -109,16 +123,14 @@ def _cmd_sync(args: Any) -> int:
 def _cmd_drift(args: Any) -> int:
     pc = _require_planning_cli()
     _prep(args)
+    _default_repo_root(args)
     return pc.cmd_objective_drift(args)
 
 
 def _cmd_reconcile(args: Any) -> int:
     pc = _require_planning_cli()
     _prep(args)
-    # Default repo_root to the resolved project_dir (not the packaged engine's
-    # own location) so `gh` PR lookups run against the caller's actual repo.
-    if not getattr(args, "repo_root", ""):
-        args.repo_root = str(Path(args.project_dir).resolve())
+    _default_repo_root(args)
     return pc.cmd_objective_reconcile(args)
 
 
@@ -137,6 +149,7 @@ def _cmd_reconcile_streak(args: Any) -> int:
 def _cmd_close(args: Any) -> int:
     pc = _require_planning_cli()
     _prep(args)
+    _default_repo_root(args)
     return pc.cmd_objective_close(args)
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -328,6 +328,11 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
         help="advisory drift-gate: report declared-vs-derived divergence (exit 0)",
     )
     _common_horizon_args(p_drift)
+    p_drift.add_argument(
+        "--repo-root", default="", dest="repo_root", metavar="PATH",
+        help="project repo root for the ROADMAP.yaml (Source-3) evidence "
+             "(default: resolved --project-dir)",
+    )
 
     p_reconcile = subs.add_parser(
         "reconcile",
@@ -382,6 +387,11 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
                          help="operator approval token (REQUIRED with --apply)")
     p_close.add_argument("--include-parked", action="store_true",
                          help="allow closing a PARKED track (un-parks it; off by default)")
+    p_close.add_argument(
+        "--repo-root", default="", dest="repo_root", metavar="PATH",
+        help="project repo root for the ROADMAP.yaml (Source-3) evidence "
+             "(default: resolved --project-dir)",
+    )
 
     p_reopen = subs.add_parser(
         "reopen", help="reopen a done track: done -> active (operator-gated, audited)",


### PR DESCRIPTION
Central-mode path-correctness sweep (MC-T0's audit). Routes __file__-derived data-dir/roadmap-path derivations through the canonical VNX_DATA_DIR-aware resolvers (vnx_paths), so central-mode processes write to ~/.vnx-data/<project> not the keystone. Sites: t0_escalations_log, cleanup_worker_exit, runtime_facade, t0_decision_reconcile/log, subprocess_adapter, dispatch_enricher, event_store, + track_reconciler roadmap-path (repo-root aware, unblocks vnx horizon reconcile evidence for central-mode) + repo_root threaded through the objective commands + a --repo-root flag. Adds an AST-based CI-grep-gate forbidding new __file__-anchored .vnx-data literals outside the resolvers. 34 sweep-tests green.

NOTE: independently verified — the core commit is byte-identical to a second independent implementation of the same audit.

Track: central-mode-path-correctness

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01M8aG7Toi382y3oJz27bYyC