### PR TITLE
fix(classifier): robust JSON extraction + ollama via HTTP API

### DIFF
--- a/scripts/lib/classifier_providers/base.py
+++ b/scripts/lib/classifier_providers/base.py
@@ -57,39 +57,55 @@ class ClassifierProvider(ABC):
 _JSON_BLOCK_RE = re.compile(r"\{(?:[^{}]|(?:\{[^{}]*\}))*\}", re.DOTALL)
 
 
+def _loads_lenient(text: str) -> Optional[Dict[str, Any]]:
+    """json.loads returning a dict, with light repair for the JSON slip small models
+    make most: a trailing comma before ``}`` or ``]``. Conservative on purpose — it
+    never turns broken data into a plausible-but-wrong object, it only forgives a
+    stray comma. Returns None if no dict is recoverable."""
+    for candidate in (text, re.sub(r",(\s*[}\]])", r"\1", text)):
+        try:
+            obj = json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+        if isinstance(obj, dict):
+            return obj
+    return None
+
+
 def parse_json_block(text: str) -> Optional[Dict[str, Any]]:
     """Best-effort JSON extraction from arbitrary CLI text output.
 
-    Tries: full string parse → fenced ```json``` block → first balanced {...}.
+    Tries: full string parse → fenced ```json``` block → first balanced {...}, each
+    with a lenient trailing-comma repair. Crucially, when the OUTER object fails to
+    parse the scan does NOT silently fall through to an inner sub-object (that
+    returned e.g. a single ``{"ref","why"}`` item instead of the whole ranking) —
+    it stops, so a broken outer object reads as a miss, not as wrong data.
     Returns None if no parseable object is found.
     """
     if not text:
         return None
     stripped = text.strip()
-    try:
-        obj = json.loads(stripped)
-        if isinstance(obj, dict):
-            return obj
-    except (json.JSONDecodeError, ValueError):
-        pass
+    obj = _loads_lenient(stripped)
+    if obj is not None:
+        return obj
 
     # ```json ... ``` fenced block
     fence_match = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", stripped, re.DOTALL)
     if fence_match:
-        try:
-            obj = json.loads(fence_match.group(1))
-            if isinstance(obj, dict):
-                return obj
-        except (json.JSONDecodeError, ValueError):
-            pass
+        obj = _loads_lenient(fence_match.group(1))
+        if obj is not None:
+            return obj
 
-    # First balanced JSON object — depth scan to handle nested objects.
-    start = stripped.find("{")
-    while start != -1:
+    # Balanced TOP-LEVEL objects only. On a malformed outer object we advance PAST
+    # it (not into it), so the scan never returns an inner sub-object — e.g. a single
+    # {"ref","why"} item in place of the whole ranking when the outer JSON is broken.
+    i = stripped.find("{")
+    while i != -1:
         depth = 0
         in_str = False
         esc = False
-        for idx in range(start, len(stripped)):
+        end = -1
+        for idx in range(i, len(stripped)):
             ch = stripped[idx]
             if esc:
                 esc = False
@@ -97,7 +113,7 @@ def parse_json_block(text: str) -> Optional[Dict[str, Any]]:
             if ch == "\\":
                 esc = True
                 continue
-            if ch == '"' and not esc:
+            if ch == '"':
                 in_str = not in_str
                 continue
             if in_str:
@@ -107,14 +123,14 @@ def parse_json_block(text: str) -> Optional[Dict[str, Any]]:
             elif ch == "}":
                 depth -= 1
                 if depth == 0:
-                    candidate = stripped[start:idx + 1]
-                    try:
-                        obj = json.loads(candidate)
-                        if isinstance(obj, dict):
-                            return obj
-                    except (json.JSONDecodeError, ValueError):
-                        break
-        start = stripped.find("{", start + 1)
+                    end = idx
+                    break
+        if end == -1:
+            break  # no balanced close — nothing more to try
+        obj = _loads_lenient(stripped[i:end + 1])
+        if obj is not None:
+            return obj
+        i = stripped.find("{", end + 1)  # skip PAST this object, never into it
 
     return None
 

--- a/scripts/lib/classifier_providers/ollama_provider.py
+++ b/scripts/lib/classifier_providers/ollama_provider.py
@@ -1,11 +1,19 @@
-"""Local Ollama provider (subprocess only). Cost is $0 (local inference)."""
+"""Local Ollama provider (HTTP API). Cost is $0 (local inference).
+
+Calls the Ollama HTTP API (`/api/generate`, non-streaming, `format=json`) rather
+than `ollama run`. The interactive CLI writes TTY progress + line-wrap re-renders
+into a piped stdout that duplicate and corrupt the model's JSON; the HTTP API
+returns the completion verbatim in a clean envelope, so parsing is reliable.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 import shutil
-import subprocess
 import time
+import urllib.error
+import urllib.request
 from typing import Optional
 
 from .base import ClassifierProvider, ClassifierResult, parse_json_block
@@ -14,8 +22,15 @@ _DEFAULT_MODEL = "llama3.1:8b"
 _DEFAULT_TIMEOUT = 120
 
 
+def _api_host() -> str:
+    host = os.environ.get("OLLAMA_HOST", "http://localhost:11434").strip()
+    if not host.startswith("http"):
+        host = "http://" + host
+    return host.rstrip("/")
+
+
 class OllamaProvider(ClassifierProvider):
-    """Run classification via `ollama run <model>`."""
+    """Run classification via the local Ollama HTTP API."""
 
     name = "ollama"
 
@@ -35,50 +50,50 @@ class OllamaProvider(ClassifierProvider):
         return shutil.which("ollama") is not None
 
     def classify(self, prompt: str, _max_tokens: int = 1500) -> ClassifierResult:
-        cmd = ["ollama", "run", self.model]
+        url = _api_host() + "/api/generate"
+        # format=json constrains generation to a valid JSON object (no prose, no
+        # ```json fences), which is exactly the scout/tagger contract. temperature=0
+        # keeps the ranking deterministic across A/B runs.
+        body = json.dumps({
+            "model": self.model,
+            "prompt": prompt,
+            "stream": False,
+            "format": "json",
+            "options": {"temperature": 0},
+        }).encode("utf-8")
+        req = urllib.request.Request(
+            url, data=body, headers={"Content-Type": "application/json"}
+        )
         start = time.monotonic()
         try:
-            proc = subprocess.run(
-                cmd,
-                input=prompt,
-                capture_output=True,
-                text=True,
-                timeout=self.timeout_seconds,
-            )
-        except FileNotFoundError as exc:
+            with urllib.request.urlopen(req, timeout=self.timeout_seconds) as resp:
+                payload = json.loads(resp.read().decode("utf-8"))
+        except (urllib.error.URLError, TimeoutError) as exc:
             return ClassifierResult(
                 raw_response="",
                 parsed_json=None,
                 cost_usd=0.0,
                 latency_ms=int((time.monotonic() - start) * 1000),
                 provider=self.name,
-                error=f"ollama CLI not found: {exc}",
+                error=f"ollama API unreachable ({url}): {exc}",
             )
-        except subprocess.TimeoutExpired as exc:
+        except (ValueError, json.JSONDecodeError) as exc:
             return ClassifierResult(
                 raw_response="",
                 parsed_json=None,
                 cost_usd=0.0,
                 latency_ms=int((time.monotonic() - start) * 1000),
                 provider=self.name,
-                error=f"timeout after {self.timeout_seconds}s: {exc}",
+                error=f"ollama API returned non-JSON envelope: {exc}",
             )
         latency_ms = int((time.monotonic() - start) * 1000)
-        if proc.returncode != 0:
-            return ClassifierResult(
-                raw_response=proc.stdout or "",
-                parsed_json=None,
-                cost_usd=0.0,
-                latency_ms=latency_ms,
-                provider=self.name,
-                error=f"exit {proc.returncode}: {(proc.stderr or '').strip()[:500]}",
-            )
-        raw = proc.stdout or ""
+        raw = payload.get("response", "") or ""
         return ClassifierResult(
             raw_response=raw,
             parsed_json=parse_json_block(raw),
             cost_usd=0.0,
             latency_ms=latency_ms,
             provider=self.name,
+            error=payload.get("error"),
             extra={"model": self.model},
         )

--- a/tests/test_classifier_providers.py
+++ b/tests/test_classifier_providers.py
@@ -161,11 +161,28 @@ def test_haiku_provider_uses_correct_command():
 # ----------------------------------------------------------------------
 
 
+class _FakeResp:
+    """Minimal urlopen() context-manager stand-in returning a JSON envelope body."""
+
+    def __init__(self, body: str):
+        self._body = body.encode("utf-8")
+
+    def read(self) -> bytes:
+        return self._body
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
 def test_ollama_provider_parses_output():
+    # The HTTP API returns the model completion in a {"response": "..."} envelope.
     prov = OllamaProvider(model="llama3.1:8b")
     with patch(
-        "classifier_providers.ollama_provider.subprocess.run",
-        return_value=_make_completed('{"x": 1}'),
+        "classifier_providers.ollama_provider.urllib.request.urlopen",
+        return_value=_FakeResp(json.dumps({"response": '{"x": 1}'})),
     ):
         result = prov.classify("test")
     assert result.error is None
@@ -174,41 +191,69 @@ def test_ollama_provider_parses_output():
     assert result.provider == "ollama"
 
 
-def test_ollama_provider_uses_correct_command():
+def test_ollama_provider_uses_http_json_api():
     prov = OllamaProvider(model="llama3.1:8b")
     captured = {}
 
-    def fake_run(cmd, **kwargs):
-        captured["cmd"] = cmd
-        captured["kwargs"] = kwargs
-        return _make_completed('{}')
+    def fake_urlopen(req, **kwargs):
+        captured["url"] = req.full_url
+        captured["body"] = json.loads(req.data.decode("utf-8"))
+        return _FakeResp(json.dumps({"response": "{}"}))
 
-    with patch("classifier_providers.ollama_provider.subprocess.run", side_effect=fake_run):
+    with patch(
+        "classifier_providers.ollama_provider.urllib.request.urlopen",
+        side_effect=fake_urlopen,
+    ):
         prov.classify("hi")
-    assert captured["cmd"] == ["ollama", "run", "llama3.1:8b"]
-    assert captured["kwargs"]["input"] == "hi"
+    assert captured["url"].endswith("/api/generate")
+    assert captured["body"]["model"] == "llama3.1:8b"
+    assert captured["body"]["prompt"] == "hi"
+    assert captured["body"]["stream"] is False
+    assert captured["body"]["format"] == "json"
 
 
-def test_ollama_provider_handles_missing_cli():
+def test_ollama_provider_handles_api_unreachable():
+    import urllib.error
+
     prov = OllamaProvider()
     with patch(
-        "classifier_providers.ollama_provider.subprocess.run",
-        side_effect=FileNotFoundError("ollama"),
+        "classifier_providers.ollama_provider.urllib.request.urlopen",
+        side_effect=urllib.error.URLError("connection refused"),
     ):
         result = prov.classify("test")
     assert result.error is not None
-    assert "not found" in result.error
+    assert "unreachable" in result.error
 
 
-def test_ollama_provider_handles_nonzero_exit():
+def test_ollama_provider_surfaces_error_envelope():
     prov = OllamaProvider()
     with patch(
-        "classifier_providers.ollama_provider.subprocess.run",
-        return_value=_make_completed("", returncode=1, stderr="model missing"),
+        "classifier_providers.ollama_provider.urllib.request.urlopen",
+        return_value=_FakeResp(json.dumps({"response": "", "error": "model missing"})),
     ):
         result = prov.classify("test")
-    assert result.error is not None
-    assert "exit 1" in result.error
+    assert result.error == "model missing"
+
+
+# ----------------------------------------------------------------------
+# parse_json_block robustness
+# ----------------------------------------------------------------------
+
+
+def test_parse_json_block_repairs_trailing_comma():
+    assert parse_json_block('{"a": 1, "b": [1, 2,],}') == {"a": 1, "b": [1, 2]}
+
+
+def test_parse_json_block_extracts_object_amid_prose():
+    text = 'noise {"include": [{"ref": "a.py:1-2"}], "plan": "do it"} trailing'
+    assert parse_json_block(text) == {"include": [{"ref": "a.py:1-2"}], "plan": "do it"}
+
+
+def test_parse_json_block_does_not_return_inner_object_when_outer_broken():
+    # A malformed OUTER object must read as a miss, never fall through to a valid
+    # inner sub-object (the bug that returned {"ref","why"} instead of the ranking).
+    text = '{"include": [{"ref": "a.py:1-2", "why": "x"}], "bad": }'
+    assert parse_json_block(text) is None
 
 
 # ----------------------------------------------------------------------


### PR DESCRIPTION
## Summary
The shared classifier JSON extractor and the Ollama provider both silently mangled small/local-model output — the same class as the kimi/glm empty-extraction flake. Found while building a fair scout model A/B: gemma produced good JSON that was being corrupted before parsing.

## Changes
- **base.py** — lenient trailing-comma repair; the balanced-object scan now considers only TOP-LEVEL objects, so a malformed outer object reads as a miss instead of silently returning an inner `{"ref","why"}` sub-object.
- **ollama_provider.py** — call the local HTTP API (`/api/generate`, `stream=false`, `format=json`) instead of the interactive `ollama run` CLI, whose TTY escapes + line-wrap re-renders corrupted the JSON in a piped capture.
- Tests rewritten to the HTTP contract + added parse-robustness coverage.

## Verification
56 passed (test_classifier_providers.py + test_ollama_adapter.py). Live: gemma3:4b now returns clean rankings via the HTTP API (18s, $0).

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtKPxByKLvM86qg1KH1wWk