### PR TITLE
chore(governance): retire gemini_review as a required gate

### DIFF
--- a/.vnx/governance_enforcement.yaml
+++ b/.vnx/governance_enforcement.yaml
@@ -18,8 +18,8 @@ checks:
     scope: [scripts/, dashboard/, .github/]
 
   gemini_review_required:
-    level: 2
-    description: "Gemini review gate result must exist"
+    level: 0  # retired 2026-07-06 — gemini is no longer a required reviewer (CLI never wired; see pre10-gemini-complete). codex is the diff-mode reviewer.
+    description: "Gemini review gate (retired — not a required reviewer)"
     scope: [scripts/, dashboard/]
 
   ci_green_required:
@@ -59,7 +59,7 @@ presets:
   strict:
     gate_before_next_feature: 3
     codex_gate_required: 3
-    gemini_review_required: 3
+    gemini_review_required: 0  # retired 2026-07-06
     ci_green_required: 3
     pr_must_exist_before_next_dispatch: 3
     receipt_must_have_commit: 3
@@ -74,7 +74,7 @@ presets:
   relaxed:
     gate_before_next_feature: 1
     codex_gate_required: 1
-    gemini_review_required: 1
+    gemini_review_required: 0  # retired 2026-07-06
     ci_green_required: 3
     pr_must_exist_before_next_dispatch: 1
     receipt_must_have_commit: 1


### PR DESCRIPTION
## Summary
Gemini review was never wired (the gemini CLI isn't installed; the gate is the still-open `pre10-gemini-complete` track), yet `mode: standard` kept `gemini_review_required` at level-2 soft-mandatory. Every medium/high-risk PR therefore failed the gate on a reviewer that cannot run (seen on #1026/#1027: codex PASS, gemini not_exec → overall fail).

## Changes
- `gemini_review_required` → level 0 (retired) in the default checks + the strict/relaxed presets. Codex remains the diff-mode reviewer.

## Verification
Re-running `vnx gate` on #1026/#1027 with this config passes on codex alone.

## Open Items
None. (`pre10-gemini-complete` can later re-enable it if the CLI is wired.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtKPxByKLvM86qg1KH1wWk