### PR TITLE
feat(durability): fsync the receipt append + torn-tail read guard (post10-durability-fsync)

### DIFF
--- a/scripts/lib/digest/io.py
+++ b/scripts/lib/digest/io.py
@@ -7,11 +7,11 @@ Public surface:
 
 from __future__ import annotations
 
-import json
 import logging
 from pathlib import Path
 
 from atomic_io import atomic_write_text
+from ndjson_io import read_ndjson
 
 logger = logging.getLogger(__name__)
 
@@ -22,24 +22,11 @@ def write_digest_output(content: str, output_path: Path) -> None:
 
 
 def read_state_ndjson(path: Path) -> list[dict]:
-    """Read NDJSON file line by line, skipping malformed lines.
+    """Read NDJSON file line by line, tolerating a torn tail and malformed lines.
 
-    Returns [] when the file does not exist (FileNotFoundError).
-    Skips and debug-logs each line that fails json.JSONDecodeError.
-    No other exceptions caught — OSError (e.g. permission denied) propagates.
+    Returns [] when the file does not exist. Delegates to the shared
+    :func:`ndjson_io.read_ndjson` guard so a partial final line left by a crash
+    mid-append is skipped instead of breaking the reader. OSError (other than a
+    missing file) propagates.
     """
-    try:
-        text = path.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        return []
-
-    records: list[dict] = []
-    for line in text.splitlines():
-        line = line.strip()
-        if not line:
-            continue
-        try:
-            records.append(json.loads(line))
-        except json.JSONDecodeError:
-            logger.debug("digest.io: skipping malformed NDJSON line in %s", path)
-    return records
+    return read_ndjson(path)

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -19,9 +19,18 @@ import json
 import logging
 import os
 import re
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+# Ensure the sibling scripts/lib modules resolve even when a caller imports
+# governance_emit by path without scripts/lib already on sys.path.
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from ndjson_io import fsync_fileno
 
 logger = logging.getLogger(__name__)
 
@@ -108,6 +117,11 @@ def emit_dispatch_receipt(
             try:
                 fh.write(line)
                 fh.flush()
+                # Durability: force the appended record to stable storage before
+                # the lock releases, so a crash after this point cannot lose the
+                # receipt. Best-effort — a filesystem that rejects fsync degrades
+                # with a warning rather than failing the write (never raises).
+                fsync_fileno(fh, context=f"dispatch={dispatch_id}")
             finally:
                 fcntl.flock(fh, fcntl.LOCK_UN)
     except OSError as exc:

--- a/scripts/lib/ndjson_io.py
+++ b/scripts/lib/ndjson_io.py
@@ -1,0 +1,106 @@
+"""ndjson_io.py — durable NDJSON append fsync + torn-tail-safe read.
+
+Two primitives shared by the governance audit trail (``t0_receipts.ndjson`` and
+its sibling gate/event NDJSON streams):
+
+  fsync_fileno(fh)      Best-effort ``os.fsync`` of an open append handle so the
+                        record is on disk before the ``fcntl.flock`` releases.
+                        Degrades gracefully (logged warning, returns False) on a
+                        filesystem that rejects fsync — never raises, so it can
+                        sit inside an existing write error-contract untouched.
+
+  iter_ndjson(path)     Iterate parsed records, skipping a torn/partial final
+  read_ndjson(path)     line left by a crash mid-append instead of raising. A
+                        partial last record must never break the reader.
+
+Posix-only paths (the audit trail is written with ``fcntl.flock`` on posix);
+``os.fsync`` is available on every platform this repo targets.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Iterator, List, Union
+
+logger = logging.getLogger(__name__)
+
+PathLike = Union[str, "os.PathLike[str]", Path]
+
+
+def fsync_fileno(fh: Any, *, context: str = "") -> bool:
+    """Best-effort ``os.fsync`` of an open file handle.
+
+    Durability step for a locked NDJSON append: flushes the OS page cache to
+    stable storage so an appended record survives a crash before the append
+    lock is released. On a filesystem that does not support fsync (rare — some
+    network/overlay mounts raise ``OSError``) the failure is logged and
+    swallowed so it never escalates past the caller's existing error contract.
+
+    Returns True when the sync succeeded, False when it degraded.
+    """
+    try:
+        os.fsync(fh.fileno())
+        return True
+    except (OSError, ValueError) as exc:
+        logger.warning(
+            "ndjson_io: fsync failed%s (durability degraded, record kept): %s",
+            f" for {context}" if context else "",
+            exc,
+        )
+        return False
+
+
+def iter_ndjson(path: PathLike) -> Iterator[Any]:
+    """Yield parsed JSON records from an NDJSON file, tolerating a torn tail.
+
+    A crash mid-append can leave the file's final record partial (truncated
+    JSON, or missing its trailing newline). That torn tail is skipped instead
+    of raising, so a reader is never broken by an incomplete last line. Blank
+    lines are skipped. A malformed line that is NOT the final record is genuine
+    mid-file corruption: it is skipped with a WARNING (the reader stays alive
+    and the anomaly is surfaced) rather than silently accepted. A missing file
+    yields nothing.
+    """
+    p = Path(path)
+    try:
+        text = p.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        return
+    if not text:
+        return
+
+    lines = text.splitlines()
+
+    # Index of the final non-blank line. A crash mid-append leaves its partial
+    # record here, so this is the only line permitted to be unparseable.
+    last_content_idx = -1
+    for i in range(len(lines) - 1, -1, -1):
+        if lines[i].strip():
+            last_content_idx = i
+            break
+
+    for idx, raw in enumerate(lines):
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            yield json.loads(line)
+        except json.JSONDecodeError:
+            if idx == last_content_idx:
+                # Torn tail — expected after a crash mid-append. Skip quietly.
+                logger.debug("ndjson_io: skipping torn tail line in %s", p)
+            else:
+                logger.warning(
+                    "ndjson_io: skipping malformed NDJSON line %d in %s", idx + 1, p
+                )
+
+
+def read_ndjson(path: PathLike) -> List[Any]:
+    """Eager list form of :func:`iter_ndjson` (torn-tail-safe)."""
+    return list(iter_ndjson(path))
+
+
+__all__ = ["fsync_fileno", "iter_ndjson", "read_ndjson"]

--- a/scripts/lib/runtime_core.py
+++ b/scripts/lib/runtime_core.py
@@ -33,6 +33,7 @@ from typing import Any, Dict, List, Optional
 
 from dispatch_broker import BrokerError, DispatchBroker, load_broker
 from lease_manager import LeaseManager
+from ndjson_io import read_ndjson
 from runtime_coordination import DuplicateTransitionError, InvalidTransitionError, init_schema, get_connection, release_all_leases
 from failure_classifier import classify_failure
 from runtime_state_reconciler import ZOMBIE_LEASE, RuntimeStateReconciler
@@ -636,15 +637,17 @@ class RuntimeCore:
             receipts_path = state_path / "t0_receipts.ndjson"
             if not receipts_path.exists():
                 return {"ok": True, "reason": "receipts_file_not_found"}
-            lines = [l.strip() for l in receipts_path.read_text(encoding="utf-8").splitlines() if l.strip()]
-            if not lines:
+            # Torn-tail-safe read: a crash mid-append can leave a partial last
+            # line — skip it rather than fail the linkage check on it.
+            records = read_ndjson(receipts_path)
+            if not records:
                 return {"ok": True, "reason": "no_receipts_yet"}
-            last = json.loads(lines[-1])
+            last = records[-1]
             has_dispatch_id = (
                 "dispatch_id" in last or "dispatch-id" in last
                 or "dispatch_id" in last.get("metadata", {})
             )
-            return {"ok": True, "has_dispatch_id": has_dispatch_id, "receipt_count": len(lines)}
+            return {"ok": True, "has_dispatch_id": has_dispatch_id, "receipt_count": len(records)}
         except Exception as exc:
             return {"ok": False, "error": str(exc)}
 

--- a/tests/test_governance_emit.py
+++ b/tests/test_governance_emit.py
@@ -256,6 +256,47 @@ def test_provider_validation_raises_before_write(tmp_state):
 
 
 # ---------------------------------------------------------------------------
+# Durability (fsync) tests
+# ---------------------------------------------------------------------------
+
+def test_emit_is_durable_and_fsyncs_the_append(tmp_state, monkeypatch):
+    """The append is fsync'd before the lock releases, and the record is on disk."""
+    import governance_emit as ge
+
+    contexts = []
+    real_fsync = ge.fsync_fileno
+
+    def spy(fh, **kwargs):
+        contexts.append(kwargs.get("context"))
+        return real_fsync(fh, **kwargs)
+
+    monkeypatch.setattr(ge, "fsync_fileno", spy)
+
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+
+    assert contexts, "emit must fsync the receipt append for durability"
+    assert any("test-dispatch-001" in (c or "") for c in contexts)
+
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["dispatch_id"] == "test-dispatch-001"
+
+
+def test_emit_survives_fsync_failure(tmp_state, monkeypatch):
+    """An fsync failure (fs without fsync support) must degrade, not break the write."""
+    import ndjson_io
+
+    def boom(_fd):
+        raise OSError("fsync not supported on this filesystem")
+
+    monkeypatch.setattr(ndjson_io.os, "fsync", boom)
+
+    path = emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    assert path.exists()
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["dispatch_id"] == "test-dispatch-001"
+
+
+# ---------------------------------------------------------------------------
 # Unified report tests
 # ---------------------------------------------------------------------------
 

--- a/tests/test_ndjson_io.py
+++ b/tests/test_ndjson_io.py
@@ -1,0 +1,133 @@
+"""test_ndjson_io.py — shared NDJSON durability (fsync) + torn-tail read guard.
+
+Covers scripts/lib/ndjson_io.py:
+  - read_ndjson / iter_ndjson skip a torn/partial final line from a crash
+    mid-append instead of raising, and read every complete record otherwise.
+  - fsync_fileno is best-effort: it syncs a healthy handle and degrades to a
+    logged warning (returns False, never raises) when the fs rejects fsync.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import ndjson_io
+from ndjson_io import fsync_fileno, iter_ndjson, read_ndjson
+
+
+# ---------------------------------------------------------------------------
+# read guard
+# ---------------------------------------------------------------------------
+
+def test_normal_multiline_reads_all_records(tmp_path):
+    path = tmp_path / "t0_receipts.ndjson"
+    records = [{"dispatch_id": f"d-{i}", "status": "success"} for i in range(3)]
+    path.write_text(
+        "".join(json.dumps(r, separators=(",", ":")) + "\n" for r in records),
+        encoding="utf-8",
+    )
+    assert read_ndjson(path) == records
+
+
+def test_torn_tail_truncated_json_is_skipped(tmp_path):
+    """A crash mid-append leaves a partial final line — read the complete ones only."""
+    path = tmp_path / "t0_receipts.ndjson"
+    good = [{"dispatch_id": "d-0"}, {"dispatch_id": "d-1"}]
+    path.write_text(
+        json.dumps(good[0], separators=(",", ":")) + "\n"
+        + json.dumps(good[1], separators=(",", ":")) + "\n"
+        # torn tail: writer crashed after part of the record, before the newline
+        + '{"dispatch_id": "d-2", "par',
+        encoding="utf-8",
+    )
+    out = read_ndjson(path)  # must not raise
+    assert out == good
+
+
+def test_torn_tail_missing_newline_but_valid_json_is_read(tmp_path):
+    """A complete final record without a trailing newline still parses and is kept."""
+    path = tmp_path / "t0_receipts.ndjson"
+    path.write_text(
+        json.dumps({"dispatch_id": "d-0"}, separators=(",", ":")) + "\n"
+        + json.dumps({"dispatch_id": "d-1"}, separators=(",", ":")),  # no trailing \n
+        encoding="utf-8",
+    )
+    assert read_ndjson(path) == [{"dispatch_id": "d-0"}, {"dispatch_id": "d-1"}]
+
+
+def test_midfile_malformed_line_is_skipped_with_warning(tmp_path, caplog):
+    """Genuine mid-file corruption is skipped (loud) — reader still returns the good records."""
+    path = tmp_path / "t0_receipts.ndjson"
+    path.write_text(
+        json.dumps({"dispatch_id": "d-0"}, separators=(",", ":")) + "\n"
+        + "{not valid json\n"
+        + json.dumps({"dispatch_id": "d-2"}, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    with caplog.at_level(logging.WARNING, logger="ndjson_io"):
+        out = read_ndjson(path)
+    assert out == [{"dispatch_id": "d-0"}, {"dispatch_id": "d-2"}]
+    assert any("malformed" in r.message.lower() for r in caplog.records)
+
+
+def test_blank_lines_are_skipped(tmp_path):
+    path = tmp_path / "t0_receipts.ndjson"
+    path.write_text(
+        json.dumps({"dispatch_id": "d-0"}, separators=(",", ":")) + "\n"
+        + "\n   \n"
+        + json.dumps({"dispatch_id": "d-1"}, separators=(",", ":")) + "\n",
+        encoding="utf-8",
+    )
+    assert read_ndjson(path) == [{"dispatch_id": "d-0"}, {"dispatch_id": "d-1"}]
+
+
+def test_missing_file_yields_nothing(tmp_path):
+    assert read_ndjson(tmp_path / "does-not-exist.ndjson") == []
+
+
+def test_empty_file_yields_nothing(tmp_path):
+    path = tmp_path / "empty.ndjson"
+    path.write_text("", encoding="utf-8")
+    assert read_ndjson(path) == []
+
+
+def test_iter_ndjson_is_lazy(tmp_path):
+    path = tmp_path / "t0_receipts.ndjson"
+    path.write_text(json.dumps({"dispatch_id": "d-0"}) + "\n", encoding="utf-8")
+    it = iter_ndjson(path)
+    assert iter(it) is it  # a generator/iterator, not a materialized list
+
+
+# ---------------------------------------------------------------------------
+# fsync helper
+# ---------------------------------------------------------------------------
+
+def test_fsync_fileno_syncs_healthy_handle(tmp_path):
+    path = tmp_path / "durable.ndjson"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write("line\n")
+        fh.flush()
+        assert fsync_fileno(fh) is True
+
+
+def test_fsync_fileno_degrades_on_oserror(tmp_path, monkeypatch, caplog):
+    """A filesystem that rejects fsync must degrade to a warning, never raise."""
+    def boom(_fd):
+        raise OSError("fsync not supported on this filesystem")
+
+    monkeypatch.setattr(ndjson_io.os, "fsync", boom)
+    path = tmp_path / "durable.ndjson"
+    with open(path, "a", encoding="utf-8") as fh:
+        fh.write("line\n")
+        fh.flush()
+        with caplog.at_level(logging.WARNING, logger="ndjson_io"):
+            result = fsync_fileno(fh, context="dispatch=x")  # must not raise
+    assert result is False
+    assert any("fsync failed" in r.message.lower() for r in caplog.records)


### PR DESCRIPTION
## Summary
The NDJSON audit trail was appended with flock+flush but no fsync (a crash after flush could lose the last receipt), and readers did `json.loads(lines[-1])` which raises on a torn final line from a crash mid-append. Adds durability + a torn-tail read guard.

## Changes
- `scripts/lib/ndjson_io.py` (new) — `fsync_fileno` (best-effort, degrades to a logged warning, never raises) + `iter_ndjson`/`read_ndjson` (skip a torn/partial FINAL line; a malformed non-final line is skipped loudly).
- `governance_emit.py` — fsync inside the flock before release.
- `runtime_core.py` + `digest/io.py` — read the last receipt via the shared guard instead of raw last-line parse.
- Tests: `test_ndjson_io.py` (new) + durability tests in `test_governance_emit.py`.

## Verification
Directly-touched suites: `pytest tests/test_ndjson_io.py tests/test_governance_emit.py tests/test_governance_emit_schema.py tests/digest tests/test_runtime_cutover.py -q` → 108 passed. Schema + flock protocol unchanged. (The 20 failures under a broad `-k` filter were verified PRE-EXISTING on the base tree — codex/subprocess/f39/env-sensitive, unrelated.)

## Open Items
None. Other append sites (append_receipt_internals, provider_dispatch, state_writer which already fsyncs) left untouched per small-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QtKPxByKLvM86qg1KH1wWk