### PR TITLE
feat(reconcile): name the blocking OI + oi-close hint on blocked derivation [TL-D5]

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -371,6 +371,118 @@ def _compute_derived_status(
     return "queued"
 
 
+def _blocking_detail(
+    conn: sqlite3.Connection,
+    track_id: str,
+    project_id: str,
+) -> Dict[str, Any]:
+    """Identify WHY a track derives 'blocked' (read-only; writes nothing).
+
+    Mirrors the step-1 (blocker open-item) / step-2 (dependency) query shapes
+    in _compute_derived_status exactly, but returns the blocking ids (and a
+    label, when the OI table happens to carry one) instead of a LIMIT-1
+    existence probe — so the caller can NAME the blocker instead of merely
+    detecting it. Reuses the same pre-0030 / project_id-column fallbacks.
+
+    Returns {"blocking_ois": [...], "blocking_deps": [...]}; both empty when
+    neither check currently blocks (i.e. when called for a non-blocked track).
+    """
+    has_project_id_col = _has_col(conn, "track_open_items", "project_id")
+    has_resolved_at_col = _has_col(conn, "track_open_items", "resolved_at")
+    label_col = next(
+        (c for c in ("title", "text") if _has_col(conn, "track_open_items", c)), None
+    )
+    select_cols = "oi_id" + (f", {label_col}" if label_col else "")
+
+    if has_project_id_col and has_resolved_at_col:
+        rows = conn.execute(
+            f"""
+            SELECT {select_cols} FROM track_open_items
+            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
+              AND resolved_at IS NULL
+            ORDER BY oi_id ASC
+            """,
+            (track_id, project_id),
+        ).fetchall()
+    elif has_project_id_col:
+        rows = conn.execute(
+            f"""
+            SELECT {select_cols} FROM track_open_items
+            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
+            ORDER BY oi_id ASC
+            """,
+            (track_id, project_id),
+        ).fetchall()
+    else:
+        rows = conn.execute(
+            f"""
+            SELECT {select_cols} FROM track_open_items
+            WHERE track_id = ? AND link_type = 'blocks'
+            ORDER BY oi_id ASC
+            """,
+            (track_id,),
+        ).fetchall()
+
+    blocking_ois: List[Dict[str, Any]] = []
+    for row in rows:
+        entry: Dict[str, Any] = {"oi_id": row["oi_id"]}
+        if label_col:
+            entry["label"] = row[label_col]
+        blocking_ois.append(entry)
+
+    dep_rows = conn.execute(
+        """
+        SELECT td.to_track_id, t.phase
+        FROM track_dependencies td
+        JOIN tracks t
+          ON t.track_id = td.to_track_id AND t.project_id = td.to_project_id
+        WHERE td.from_track_id = ? AND td.from_project_id = ?
+        """,
+        (track_id, project_id),
+    ).fetchall()
+    blocking_deps = [
+        {"track_id": row["to_track_id"], "phase": row["phase"]}
+        for row in dep_rows
+        if row["phase"] != "done"
+    ]
+
+    return {"blocking_ois": blocking_ois, "blocking_deps": blocking_deps}
+
+
+def format_blocking_hint(detail: Optional[Dict[str, Any]]) -> str:
+    """Render an operator-facing hint naming each blocker + its exact resolving
+    command — "transparantie zonder actie is inert": the surface must point at
+    the action, not just restate the fact of being blocked.
+
+    Blocker-OI resolution stays HUMAN-GATED: this only formats the command; it
+    never runs it and never clears the open-item itself.
+
+    Returns "" when detail is None/empty or names no blockers.
+    """
+    if not detail:
+        return ""
+    blocking_ois = detail.get("blocking_ois") or []
+    blocking_deps = detail.get("blocking_deps") or []
+    if not blocking_ois and not blocking_deps:
+        return ""
+
+    lines: List[str] = []
+    for oi in blocking_ois:
+        oi_id = oi.get("oi_id")
+        label = oi.get("label")
+        suffix = f" ({label})" if label else ""
+        lines.append(
+            f"blocked by open-item {oi_id}{suffix} -- resolve: "
+            f'vnx track oi-close {oi_id} --reason "<why this no longer blocks>"'
+        )
+    for dep in blocking_deps:
+        lines.append(
+            f"blocked by dependency {dep.get('track_id')} "
+            f"-- not done (phase={dep.get('phase')})"
+        )
+    return "\n".join(lines)
+
+
 def _write_derived_status(
     conn: sqlite3.Connection,
     track_id: str,
@@ -443,13 +555,16 @@ def reconcile_track(
 
         _log_drift(track_id, project_id, declared, derived)
 
-        return {
+        result: Dict[str, Any] = {
             "track_id": track_id,
             "project_id": project_id,
             "derived_status": derived,
             "declared_phase": declared,
             "drifted": declared != derived,
         }
+        if derived == "blocked":
+            result["blocking_detail"] = _blocking_detail(conn, track_id, project_id)
+        return result
     finally:
         conn.close()
 
@@ -483,13 +598,16 @@ def peek_derived_status(
             (track_id, project_id),
         ).fetchone()
         declared = track_row["phase"] if track_row else None
-        return {
+        result: Dict[str, Any] = {
             "track_id": track_id,
             "project_id": project_id,
             "derived_status": derived,
             "declared_phase": declared,
             "drifted": declared != derived,
         }
+        if derived == "blocked":
+            result["blocking_detail"] = _blocking_detail(conn, track_id, project_id)
+        return result
     finally:
         conn.close()
 
@@ -539,6 +657,10 @@ def reconcile_all_tracks(
             "reconciled track=%s derived=%s declared=%s drift=%s",
             track_id, result["derived_status"], result["declared_phase"], result["drifted"],
         )
+        if result["derived_status"] == "blocked":
+            hint = format_blocking_hint(result.get("blocking_detail"))
+            if hint:
+                log.info("track_blocked: track=%s project=%s\n%s", track_id, project_id, hint)
 
     log.info(
         "track_reconciler: project=%s tracks=%d drifted=%d",

--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -480,6 +480,100 @@ def test_0028_down_removes_derived_status(tmp_path):
     assert row == ("t-down", "queued")
 
 
+def test_blocking_detail_names_blocker_oi(tmp_path):
+    """blocking_detail.blocking_ois names the unresolved blocker OI; the hint
+    carries the exact oi-close command to resolve it."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-hint-oi")
+    _seed_dispatch(state_dir, "D-hint-oi-1", "T-hint-oi", state="completed")
+    _seed_pr_merged_event(state_dir, "D-hint-oi-1")
+    tracks_lib.link_open_item(state_dir, "T-hint-oi", PROJECT_ID, "OI-777", "blocks", "manual")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-hint-oi", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+    detail = result["blocking_detail"]
+    assert detail["blocking_ois"] == [{"oi_id": "OI-777"}]
+    assert detail["blocking_deps"] == []
+
+    hint = track_reconciler.format_blocking_hint(detail)
+    assert "OI-777" in hint
+    assert "vnx track oi-close OI-777" in hint
+
+
+def test_blocking_detail_names_dependency(tmp_path):
+    """blocking_detail.blocking_deps names the not-done dependency track."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-hint-dep-parent", phase="queued")
+    _seed_track(state_dir, "T-hint-dep-child")
+    tracks_lib.add_dependency(
+        state_dir,
+        "T-hint-dep-child", PROJECT_ID,
+        "T-hint-dep-parent", PROJECT_ID,
+        kind="hard", derivation_source="manual",
+    )
+    _seed_dispatch(state_dir, "D-hint-dep-1", "T-hint-dep-child", state="completed")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-hint-dep-child", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+    detail = result["blocking_detail"]
+    assert detail["blocking_ois"] == []
+    assert detail["blocking_deps"] == [{"track_id": "T-hint-dep-parent", "phase": "queued"}]
+
+    hint = track_reconciler.format_blocking_hint(detail)
+    assert "T-hint-dep-parent" in hint
+    assert "not done" in hint
+
+
+def test_no_blocking_detail_when_not_blocked(tmp_path):
+    """A non-blocked track carries no blocking_detail key; its hint is empty."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-hint-clean")
+    _seed_dispatch(state_dir, "D-hint-clean-1", "T-hint-clean", state="completed")
+    _seed_pr_merged_event(state_dir, "D-hint-clean-1")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-hint-clean", PROJECT_ID)
+    assert result["derived_status"] != "blocked"
+    assert "blocking_detail" not in result
+    assert track_reconciler.format_blocking_hint(result.get("blocking_detail")) == ""
+
+
+def test_blocking_detail_works_pre_0030_without_resolved_at(tmp_path):
+    """No resolved_at column (pre-migration-0030 DB) — the presence-only
+    fallback still NAMES the blocker OI, not just detects it."""
+    state_dir = _build_db(tmp_path)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    cols = [r[1] for r in conn.execute("PRAGMA table_info(track_open_items)")]
+    conn.close()
+    assert "resolved_at" not in cols  # _build_db never applies migration 0030
+
+    _seed_track(state_dir, "T-hint-pre0030")
+    _seed_dispatch(state_dir, "D-hint-pre0030-1", "T-hint-pre0030", state="completed")
+    tracks_lib.link_open_item(state_dir, "T-hint-pre0030", PROJECT_ID, "OI-888", "blocks", "manual")
+
+    result = track_reconciler.reconcile_track(state_dir, "T-hint-pre0030", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+    assert result["blocking_detail"]["blocking_ois"] == [{"oi_id": "OI-888"}]
+
+
+def test_format_blocking_hint_none_and_empty():
+    """format_blocking_hint tolerates None and an empty dict — both '' """
+    assert track_reconciler.format_blocking_hint(None) == ""
+    assert track_reconciler.format_blocking_hint({}) == ""
+
+
+def test_peek_derived_status_carries_blocking_detail(tmp_path):
+    """peek_derived_status (read-only preview) also carries blocking_detail."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-hint-peek")
+    _seed_dispatch(state_dir, "D-hint-peek-1", "T-hint-peek", state="completed")
+    tracks_lib.link_open_item(state_dir, "T-hint-peek", PROJECT_ID, "OI-555", "blocks", "manual")
+
+    result = track_reconciler.peek_derived_status(state_dir, "T-hint-peek", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+    assert result["blocking_detail"]["blocking_ois"] == [{"oi_id": "OI-555"}]
+
+
 def test_0028_down_preserves_track_dependencies(tmp_path):
     """Down migration must not break FK-referenced data."""
     conn, _ = _base_v27_db(tmp_path)


### PR DESCRIPTION
## Summary
- `_compute_derived_status` (`track_reconciler.py`) returns `blocked` from an unresolved `link_type='blocks'` open-item or a not-done dependency, *before* any pr_ref/PR evidence is read. A track can therefore be genuinely merged-and-live yet derive `blocked` purely because a stale blocker-OI was never resolved — proven live on MC's `calendar-booking-wj03`.
- Today the operator only sees `derived=blocked` and has to guess which open-item to clear. This PR surfaces WHICH blocker, and the exact command to resolve it. "Transparantie zonder actie is inert."

## Changes
- `scripts/lib/track_reconciler.py`:
  - `_blocking_detail(conn, track_id, project_id) -> dict` — read-only helper mirroring the step-1 (blocker OI)/step-2 (dependency) query shapes already in `_compute_derived_status`, but returning the ids (+ label, if the OI table ever carries a `title`/`text` column) instead of a LIMIT-1 existence probe. Reuses the existing pre-0030/project_id-column fallbacks.
  - `format_blocking_hint(detail: dict | None) -> str` — public renderer that names each blocker OI with its `vnx track oi-close <oi_id> --reason "..."` command, and each not-done dependency track. Returns `""` for `None`/empty/non-blocking detail.
  - `reconcile_track()` and `peek_derived_status()` now add `result["blocking_detail"]` only when `derived == "blocked"`; all existing keys are unchanged (backward-compatible).
  - `reconcile_all_tracks()` logs the hint (`log.info`) for each blocked track so `vnx objective reconcile` surfaces it.
- `tests/test_track_reconciler.py`: 6 new tests covering blocker-OI naming, dependency naming, non-blocked tracks (no key / empty hint), the pre-0030 (no `resolved_at`) fallback, `format_blocking_hint(None)`/`({})`, and `peek_derived_status` parity.

Pure reporting change — no state write anywhere in the new code paths. Blocker-OI resolution stays human-gated: this only surfaces the blocker + the resolving command, it never clears it (Vincent-decision 2026-07-06).

## Test plan
- [x] `python3 -m pytest tests/test_track_reconciler.py -q` — 23 passed
- [x] `python3 -m pytest tests/test_planning_cli_objective_add.py tests/test_objective_reconcile.py tests/test_planning_cli_objective.py -q` — 62 passed (downstream consumers of `reconcile_track`/`reconcile_all_tracks` unaffected by the additive key)

🤖 Generated with [Claude Code](https://claude.com/claude-code)