### PR TITLE
feat(horizon): link-pr + close --attest escape-hatch CLIs [TL-D3]

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -34,7 +34,7 @@ import os
 import sqlite3
 import sys
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
 
@@ -572,6 +572,326 @@ _close_evidence = track_reconciler._close_evidence
 _phase_path_to = track_reconciler._phase_path_to
 
 
+def _normalize_pr_ref(raw: str) -> Optional[str]:
+    """Parse '#756', '756', or 'PR-42' -> '#756'. Returns None on failure."""
+    try:
+        n = int(str(raw).strip().lstrip("#").strip())
+    except (TypeError, ValueError):
+        return None
+    return f"#{n}"
+
+
+def _merge_pr_refs(existing: Optional[str], incoming: list[str]) -> tuple[Optional[str], list[str], list[str]]:
+    """Merge new PR refs into an existing comma-separated pr_ref.
+
+    Returns (new_pr_ref, added_refs, already_present_refs). Preserves order and
+    deduplicates by PR number.
+    """
+    seen: set[int] = set()
+    merged: list[str] = []
+
+    def _add(raw: str) -> tuple[Optional[str], bool]:
+        norm = _normalize_pr_ref(raw)
+        if norm is None:
+            return None, False
+        n = int(norm.lstrip("#"))
+        if n in seen:
+            return norm, False
+        seen.add(n)
+        merged.append(norm)
+        return norm, True
+
+    # Existing first (preserve order).
+    for tok in str(existing or "").split(","):
+        _add(tok)
+
+    added: list[str] = []
+    already: list[str] = []
+    for raw in incoming:
+        # Accept comma-separated or repeated args.
+        for tok in str(raw).split(","):
+            tok = tok.strip()
+            if not tok:
+                continue
+            norm, is_new = _add(tok)
+            if norm is None:
+                continue
+            (added if is_new else already).append(norm)
+
+    new_ref = ",".join(merged) if merged else None
+    return new_ref, added, already
+
+
+def cmd_objective_link_pr(args: argparse.Namespace) -> int:
+    """Manually link PR ref(s) to a track (retroactive/override; audited).
+
+    Accepts comma-separated or repeated PR arguments. Normalizes each to #NNN,
+    deduplicates against the track's existing pr_ref, and preserves order.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"objective link-pr: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    existing = track.get("pr_ref")
+    new_ref, added, already = _merge_pr_refs(existing, list(args.pr))
+
+    if new_ref is None:
+        print(
+            f"objective link-pr: no valid PR refs provided for {track_id!r}. "
+            "No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if new_ref == (existing or ""):
+        if args.json:
+            print(json.dumps({
+                "track_id": track_id,
+                "project_id": project_id,
+                "pr_ref": new_ref,
+                "added": added,
+                "already_present": already,
+                "action": "noop_no_change",
+                "applied": False,
+            }, indent=2, default=str))
+        else:
+            print(f"\nvnx objective link-pr — {track_id} (project '{project_id}')")
+            print(f"  pr_ref: {new_ref}")
+            print(f"  all provided PR refs already present; no change made.\n")
+        return 0
+
+    # ADR-007: write is scoped to (track_id, project_id).
+    conn = _db_conn(state_dir)
+    try:
+        conn.execute(
+            "UPDATE tracks SET pr_ref = ? WHERE track_id = ? AND project_id = ?",
+            (new_ref, track_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # ADR-005 audit event: specific operator action.
+    tracks_lib._emit_track_event(
+        state_dir,
+        "track_pr_linked",
+        track_id,
+        project_id,
+        "operator",
+        {"added": added, "already_present": already, "pr_ref": new_ref},
+    )
+
+    if args.json:
+        print(json.dumps({
+            "track_id": track_id,
+            "project_id": project_id,
+            "pr_ref": new_ref,
+            "added": added,
+            "already_present": already,
+            "action": "linked",
+            "applied": True,
+        }, indent=2, default=str))
+    else:
+        print(f"\nvnx objective link-pr — {track_id} (project '{project_id}')")
+        print(f"  pr_ref: {new_ref}")
+        if added:
+            print(f"  + added: {', '.join(added)}")
+        if already:
+            print(f"  = already present: {', '.join(already)}")
+        print()
+    return 0
+
+
+def _close_with_attest(
+    args: argparse.Namespace,
+    state_dir: Path,
+    track_id: str,
+    project_id: str,
+    reason: str,
+    repo_root: Optional[str | Path],
+) -> int:
+    """Attested close path for ops-tracks with no PR evidence.
+
+    Human-gated: --attest REQUIRES --apply AND --approval-id. Sets
+    tracks.pr_ref = 'ops-attest:<YYYY-MM-DD>', emits an audit event, then walks
+    the track's declared phase to 'done' through tracks.transition_phase (the
+    single-writer). This is an explicit operator override; it does NOT resolve
+    blocker open-items.
+    """
+    if not args.apply:
+        print(
+            "objective close --attest: --apply is required to write an attestation. "
+            "No change made.",
+            file=sys.stderr,
+        )
+        return 2
+    approval_id = (args.approval_id or "").strip()
+    if not approval_id:
+        print(
+            "objective close --attest: --approval-id is required (the operator's gate token). "
+            "No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"objective close --attest: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    declared = track["phase"]
+    target = "done"
+    payload: dict[str, Any] = {
+        "track_id": track_id,
+        "project_id": project_id,
+        "declared_phase": declared,
+        "action": None,
+        "applied": False,
+    }
+
+    if declared == target:
+        payload["action"] = "noop_already_closed"
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(f"  already closed (phase={declared}).\n")
+        return 0
+
+    # Respect the same deliberate stop-signal as the evidence-grounded path.
+    if declared == "parked" and not getattr(args, "include_parked", False):
+        payload["action"] = "rejected_parked"
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(
+                "  track is PARKED (a deliberate stop). Pass --include-parked to close "
+                "it anyway, or un-park it first. No change made.\n"
+            )
+        return 2
+
+    path = _phase_path_to(declared, target)
+    if path is None:
+        payload["action"] = "rejected_no_path"
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(
+                f"  ERROR: no legal transition path {declared} -> {target} "
+                f"(ALLOWED_TRANSITIONS). No change made.\n"
+            )
+        return 2
+    payload["path"] = [declared, *path]
+
+    # Stamp the explicit attestation on the track.
+    attest_ref = f"ops-attest:{date.today().isoformat()}"
+    conn = _db_conn(state_dir)
+    try:
+        conn.execute(
+            "UPDATE tracks SET pr_ref = ? WHERE track_id = ? AND project_id = ?",
+            (attest_ref, track_id, project_id),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    # Audit the operator attestation (reason + approval_id).
+    tracks_lib._emit_track_event(
+        state_dir,
+        "track_ops_attest",
+        track_id,
+        project_id,
+        "operator",
+        {"reason": reason, "approval_id": approval_id, "pr_ref": attest_ref},
+    )
+
+    # Walk the legal phase path via the single-writer.
+    cur = declared
+    try:
+        for step in path:
+            tracks_lib.transition_phase(
+                state_dir, track_id, project_id, step,
+                actor="operator",
+                reason=f"close-the-loop attested ({declared}->{target}): {reason}",
+                approval_id=approval_id,
+            )
+            cur = step
+    except tracks_lib.TrackNotFoundError as exc:
+        payload["declared_phase"] = cur
+        payload["action"] = "rejected_not_found"
+        payload["error"] = str(exc)
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(f"  ERROR: {exc}\n")
+        return 2
+    except tracks_lib.InvalidTransitionError as exc:
+        payload["declared_phase"] = cur
+        payload["action"] = "rejected_walk_failed"
+        payload["error"] = str(exc)
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(
+                f"  ERROR: transition failed at '{cur}': {exc}. "
+                f"Track left at '{cur}'.\n"
+            )
+        return 2
+    except Exception as exc:
+        payload["declared_phase"] = cur
+        payload["action"] = "rejected_walk_failed"
+        payload["error"] = f"{type(exc).__name__}: {exc}"
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+            print(
+                f"  ERROR: transition failed at '{cur}': {exc}. "
+                f"Track left at '{cur}'.\n"
+            )
+        return 2
+
+    # Best-effort refresh of derived_status now that phase is 'done'.
+    try:
+        track_reconciler.reconcile_track(state_dir, track_id, project_id, repo_root=repo_root)
+    except Exception:
+        logger.warning("close --attest: derived refresh failed after transition", exc_info=True)
+
+    payload["action"] = "closed"
+    payload["applied"] = True
+    payload["declared_phase"] = target
+    payload["pr_ref"] = attest_ref
+
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+        print(f"  attested: {reason}")
+        print(f"  pr_ref set: {attest_ref}")
+        print(
+            f"  closed: {' -> '.join([declared, *path])} "
+            f"(actor=operator, approval={approval_id}).\n"
+        )
+    return 0
+
+
 def cmd_objective_close(args: argparse.Namespace) -> int:
     """Close-the-loop: resolve phase_drift by advancing a track's DECLARED phase
     to its derived_status when the work is genuinely done (PR merged).
@@ -588,6 +908,11 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
       - The write goes through tracks.transition_phase (the single-writer): it
         enforces ALLOWED_TRANSITIONS, stamps completed_at, and records a
         track_phase_history row + event with the approval_id (full audit trail).
+
+    --attest <reason> is the escape hatch for ops-tracks with no PR evidence
+    (e.g. a fleet-sync or docs-sweep). It still requires --apply + --approval-id,
+    writes tracks.pr_ref = 'ops-attest:<date>', emits an audit event, then walks
+    the phase to 'done'. It does NOT resolve blocker open-items.
     """
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
@@ -598,6 +923,10 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     except Exception as exc:
         logger.warning("close: cannot resolve repo root, ROADMAP source-3 disabled: %s", exc)
         repo_root = None
+
+    attest_reason = getattr(args, "attest", None)
+    if attest_reason is not None:
+        return _close_with_attest(args, state_dir, track_id, project_id, attest_reason, repo_root)
 
     try:
         # Dry-run is READ-ONLY: peek computes derived_status without persisting.
@@ -648,6 +977,13 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
                           "(no completed dispatch, no merged PR) — likely all-failed. "
                           "Confirm this is really done before --apply.")
             print(f"  {message}\n")
+            # Surface D5's blocker hint when close is blocked (guarded: no crash
+            # until D5 lands format_blocking_hint + blocking_detail).
+            if action == "noop_not_terminal" and derived == "blocked":
+                _fmt = getattr(track_reconciler, "format_blocking_hint", None)
+                detail = result.get("blocking_detail") if isinstance(result, dict) else None
+                if _fmt and detail:
+                    print(_fmt(detail))
         return rc
 
     if derived != target:
@@ -1435,7 +1771,7 @@ def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vnx", description="VNX planning read surface")
     sub = parser.add_subparsers(dest="domain", required=True)
 
-    obj = sub.add_parser("objective", help="strategic-layer objectives (tracks)")
+    obj = sub.add_parser("objective", aliases=["horizon"], help="strategic-layer objectives (tracks)")
     obj_sub = obj.add_subparsers(dest="action", required=True)
 
     def _common(p: argparse.ArgumentParser) -> None:
@@ -1518,7 +1854,23 @@ def _build_parser() -> argparse.ArgumentParser:
         metavar="PATH",
         help="git repo root for ROADMAP lookups (default: auto-resolved from project root)",
     )
+    p_close.add_argument(
+        "--attest", default=None, metavar="REASON",
+        help="operator attestation for ops-tracks with no PR evidence (requires --apply --approval-id)",
+    )
     p_close.set_defaults(func=cmd_objective_close)
+
+    p_link_pr = obj_sub.add_parser(
+        "link-pr",
+        help="manually link PR ref(s) to a track (retroactive/override; audited)",
+    )
+    _common(p_link_pr)
+    p_link_pr.add_argument("track_id")
+    p_link_pr.add_argument(
+        "pr", nargs="+",
+        help="PR reference(s) as #NNN or NNN; comma-separated or repeated",
+    )
+    p_link_pr.set_defaults(func=cmd_objective_link_pr)
 
     p_reopen = obj_sub.add_parser(
         "reopen",

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -265,9 +265,9 @@ def test_close_without_attest_still_refuses_non_terminal(tmp_path, capsys):
 # D5 blocker hint (guarded)
 # ---------------------------------------------------------------------------
 
-def test_close_blocked_calls_hint_renderer_guarded_no_crash(tmp_path, capsys):
-    """When derived_status is blocked, the guarded hint call must not crash
-    even though format_blocking_hint does not exist yet (D5)."""
+def test_close_blocked_renders_blocking_dependency_hint(tmp_path, capsys):
+    """When derived_status is blocked, the guarded hint call renders the
+    blocker hint now that format_blocking_hint exists (D5)."""
     sd = _build_db(tmp_path)
     tracks_lib.create_track(sd, "blocked", PROJECT_ID, title="x", goal_state="y", phase="queued")
     tracks_lib.create_track(sd, "dep", PROJECT_ID, title="dep", goal_state="y", phase="queued")
@@ -282,5 +282,5 @@ def test_close_blocked_calls_hint_renderer_guarded_no_crash(tmp_path, capsys):
     assert rc == 0
     out = capsys.readouterr().out
     assert "blocked" in out
-    # No crash means the test passes; format_blocking_hint is absent so no extra output.
-    assert not hasattr(track_reconciler, "format_blocking_hint")
+    assert "blocked by dependency dep" in out
+    assert "not done (phase=queued)" in out

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -1,0 +1,286 @@
+"""tests/test_planning_cli.py — D3 escape-hatch CLIs: link-pr + close --attest.
+
+Self-contained synthetic-DB tests for:
+- `vnx objective link-pr <track> <pr>[,<pr>...]`
+- `vnx objective close <track> --attest "<reason>" --apply --approval-id <id>`
+- guarded D5 blocker-hint surface in the normal close path.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import planning_cli  # noqa: E402
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-proj"
+
+
+def _build_db(tmp_path: Path) -> Path:
+    """Create a minimal modern tracks DB (migrations 22/24/27/28)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL, project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
+    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for ver, fname in ((27, "0027_planning_horizon_and_deliverable_view.sql"),
+                       (28, "0028_tracks_derived_status.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _pr_ref(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> str:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchone()
+    conn.close()
+    return (row[0] or "") if row else ""
+
+
+def _phase(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> str:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else ""
+
+
+def _history_count(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> int:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    n = conn.execute(
+        "SELECT count(*) FROM track_phase_history WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchone()[0]
+    conn.close()
+    return n
+
+
+def _track_events(state_dir: Path, track_id: str, event_type: str) -> list[dict]:
+    """Read ADR-005 track audit events for a specific track + type."""
+    path = state_dir.parent / "events" / "track_events.ndjson"
+    if not path.exists():
+        return []
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        rec = json.loads(line)
+        if rec.get("track_id") == track_id and rec.get("event_type") == event_type:
+            out.append(rec)
+    return out
+
+
+def _link_pr_args(
+    state_dir: Path,
+    track_id: str,
+    *prs: str,
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        pr=list(prs),
+        json=json,
+    )
+
+
+def _close_args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    apply: bool = False,
+    approval_id: str = "",
+    attest: str | None = None,
+    include_parked: bool = False,
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        apply=apply,
+        approval_id=approval_id,
+        attest=attest,
+        include_parked=include_parked,
+        json=json,
+        repo_root="",
+    )
+
+
+# ---------------------------------------------------------------------------
+# link-pr
+# ---------------------------------------------------------------------------
+
+def test_link_pr_adds_and_dedupes_preserves_existing(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="#100"
+    )
+    rc = planning_cli.cmd_objective_link_pr(_link_pr_args(sd, "T", "#397,#398", "#100"))
+    assert rc == 0
+    assert _pr_ref(sd, "T") == "#100,#397,#398"
+
+
+def test_link_pr_on_missing_track_is_clean_error(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    rc = planning_cli.cmd_objective_link_pr(_link_pr_args(sd, "missing", "#1"))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not found" in (captured.out + captured.err)
+
+
+def test_link_pr_writes_audit_event(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_link_pr(_link_pr_args(sd, "T", "#397,#398"))
+    assert rc == 0
+    events = _track_events(sd, "T", "track_pr_linked")
+    assert len(events) == 1
+    details = events[0]["details"]
+    assert details["added"] == ["#397", "#398"]
+    assert details["pr_ref"] == "#397,#398"
+
+
+def test_link_pr_wrong_project_id_does_not_write(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_link_pr(
+        _link_pr_args(sd, "T", "#1", project_id="other-proj")
+    )
+    assert rc == 1
+    assert _pr_ref(sd, "T", PROJECT_ID) == ""
+
+
+# ---------------------------------------------------------------------------
+# close --attest
+# ---------------------------------------------------------------------------
+
+def test_close_attest_advances_ops_track_and_writes_audit(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "ops", PROJECT_ID, title="fleet sync", goal_state="done", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "ops", apply=True, approval_id="APR-OPS", attest="fleet-sync")
+    )
+    assert rc == 0
+    assert _phase(sd, "ops") == "done"
+    assert _pr_ref(sd, "ops").startswith("ops-attest:")
+    assert _history_count(sd, "ops") == 2  # queued -> active -> done
+
+    events = _track_events(sd, "ops", "track_ops_attest")
+    assert len(events) == 1
+    details = events[0]["details"]
+    assert details["reason"] == "fleet-sync"
+    assert details["approval_id"] == "APR-OPS"
+    assert details["pr_ref"].startswith("ops-attest:")
+
+
+def test_close_attest_without_apply_or_approval_is_rejected(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "ops", PROJECT_ID, title="x", goal_state="y", phase="queued")
+
+    rc_no_apply = planning_cli.cmd_objective_close(
+        _close_args(sd, "ops", apply=False, approval_id="X", attest="reason")
+    )
+    assert rc_no_apply == 2
+    assert _phase(sd, "ops") == "queued"
+
+    rc_no_approval = planning_cli.cmd_objective_close(
+        _close_args(sd, "ops", apply=True, approval_id="", attest="reason")
+    )
+    assert rc_no_approval == 2
+    assert _phase(sd, "ops") == "queued"
+    assert _pr_ref(sd, "ops") == ""
+
+
+def test_close_without_attest_still_refuses_non_terminal(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "T", apply=True, approval_id="X")
+    )
+    assert rc == 0
+    assert "not terminal" in capsys.readouterr().out
+    assert _phase(sd, "T") == "queued"
+
+
+# ---------------------------------------------------------------------------
+# D5 blocker hint (guarded)
+# ---------------------------------------------------------------------------
+
+def test_close_blocked_calls_hint_renderer_guarded_no_crash(tmp_path, capsys):
+    """When derived_status is blocked, the guarded hint call must not crash
+    even though format_blocking_hint does not exist yet (D5)."""
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "blocked", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    tracks_lib.create_track(sd, "dep", PROJECT_ID, title="dep", goal_state="y", phase="queued")
+    tracks_lib.add_dependency(
+        sd, "blocked", PROJECT_ID, "dep", PROJECT_ID, "hard", "manual"
+    )
+    # Reconcile so derived_status reflects the blocker.
+    import track_reconciler  # noqa: E402
+    track_reconciler.reconcile_track(sd, "blocked", PROJECT_ID)
+
+    rc = planning_cli.cmd_objective_close(_close_args(sd, "blocked"))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "blocked" in out
+    # No crash means the test passes; format_blocking_hint is absent so no extra output.
+    assert not hasattr(track_reconciler, "format_blocking_hint")


### PR DESCRIPTION
Dispatch-ID: 20260706-tl-d3-horizon-clis

D3 of the track-linkage-enforcement arc turns the two manual DB-poke moves from this session into audited, ADR-007-scoped CLIs.

## What's new
- `vnx horizon link-pr <track> <pr>[,<pr>...]`: retroactively link PR refs to a track's pr_ref (deduped, existing preserved, project_id-scoped). Audited via track_events.ndjson.
- `vnx horizon close <track> --attest "<reason>" --apply --approval-id <id>`: operator attestation path for ops-tracks with no PR evidence. Writes tracks.pr_ref = ops-attest:<date>, emits an audit event, then walks phase to done via tracks.transition_phase. Still human-gated.
- Guarded D5 blocker-hint surface on blocked closes (getattr-gated; no crash until D5 lands).
- Added `horizon` as an alias for the `objective` subparser.

## Verification
- `python3 -m pytest tests/test_planning_cli.py -q`  → 8 passed
- `python3 -m pytest tests/test_objective_close.py tests/test_planning_cli_objective.py tests/test_planning_cli_objective_add.py -q`  → 27 passed

## Scope
Only `scripts/planning_cli.py` and `tests/test_planning_cli.py` were changed.
