### PR TITLE
feat(dispatch): track_id on spec + door validation + persist [TL-D1]

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -130,6 +130,7 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         skill=(raw.get("skill") or None),
         task_class=(raw.get("task_class") or None),
         pr_id=(raw.get("pr_id") or None),
+        track_id=(raw.get("track_id") or None),
         deadline_seconds=int(raw.get("deadline_seconds", 3600)),
         base_ref=str(raw.get("base_ref", "origin/main")),
         isolation=Isolation(raw.get("isolation", "worktree")),
@@ -319,6 +320,154 @@ def _check_staging_binding_verdict(
 
 
 # ---------------------------------------------------------------------------
+# TL-D1 — track_id door validation + persistence
+#
+# Structural link dispatch -> track, validated at the door (fail-closed on an
+# invalid/nonexistent/done track_id) and staged advisory->required on absence
+# via VNX_REQUIRE_DISPATCH_TRACK (mirrors the wiring_gate.py VNX_WIRING_GATE_REQUIRED
+# shadow/blocking staging pattern). Tracks live in the same runtime_coordination.db
+# as the dispatches table (schemas/migrations/0022_track_layer.sql).
+# ---------------------------------------------------------------------------
+
+_TRACKS_DB_FILENAME = "runtime_coordination.db"
+
+_NO_TRACK_ESCAPE_RE = _re.compile(r"^no-track:.+$")
+
+
+def _tracks_db_path(state_dir: Path) -> Path:
+    return state_dir / _TRACKS_DB_FILENAME
+
+
+def _has_col(conn, table: str, col: str) -> bool:
+    return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def _has_no_track_escape(tags: "tuple[str, ...]") -> bool:
+    return any(_NO_TRACK_ESCAPE_RE.match(t) for t in tags)
+
+
+def _lookup_track_phase(db_path: Path, track_id: str, project_id: str) -> Optional[str]:
+    """Return the track's phase for (track_id, project_id), or None if no such track.
+
+    Read-only URI connection: a missing DB file raises immediately rather than
+    silently creating an empty one. Caller degrades any exception to a WARN
+    verdict (fail-open on tracks-DB unavailability; never crash the door).
+    """
+    import sqlite3 as _sqlite3
+    conn = _sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    try:
+        row = conn.execute(
+            "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        return row[0] if row is not None else None
+    finally:
+        conn.close()
+
+
+def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optional[ConstraintVerdict]:
+    """Validate spec.track_id at the door.
+
+    - track_id present, references a nonexistent or already-done track -> blocking Reject
+      (the tag-vs-link mistake becomes impossible).
+    - track_id present, references a live track -> None (passes clean).
+    - tracks DB unavailable while checking a present track_id -> WARN, never crash.
+    - track_id absent -> staged advisory (VNX_REQUIRE_DISPATCH_TRACK OFF, default) WARN,
+      or required (ON) blocking Reject unless tags carries a 'no-track:<reason>' escape.
+    """
+    track_id = (spec.track_id or "").strip()
+    db_path = _tracks_db_path(state_dir)
+
+    if track_id:
+        try:
+            phase = _lookup_track_phase(db_path, track_id, spec.project_id)
+        except Exception as exc:
+            return ConstraintVerdict(
+                code="tracks-db-unavailable",
+                severity="warn",
+                message=(
+                    f"tracks DB unavailable ({exc}); cannot verify track_id={track_id!r}, "
+                    "degrading to warn"
+                ),
+            )
+        if phase is None:
+            return ConstraintVerdict(
+                code="bad-track-link",
+                severity="blocking",
+                message=(
+                    f"track_id={track_id!r} does not reference an existing track "
+                    f"for project_id={spec.project_id!r}"
+                ),
+            )
+        if phase == "done":
+            return ConstraintVerdict(
+                code="bad-track-link",
+                severity="blocking",
+                message=f"track_id={track_id!r} references a track already in phase='done'",
+            )
+        return None
+
+    import config_runtime
+    required = config_runtime.get_bool("VNX_REQUIRE_DISPATCH_TRACK")
+    if not required:
+        return ConstraintVerdict(
+            code="track_unlinked",
+            severity="warn",
+            message="dispatch has no track_id (VNX_REQUIRE_DISPATCH_TRACK is OFF; advisory-only)",
+        )
+    if _has_no_track_escape(spec.tags):
+        logger.info(
+            "[dispatch_cli] dispatch=%s: no-track escape applied (tags=%r)",
+            spec.dispatch_id, spec.tags,
+        )
+        return None
+    return ConstraintVerdict(
+        code="track-required",
+        severity="blocking",
+        message=(
+            "VNX_REQUIRE_DISPATCH_TRACK=1 requires a track_id; add a tags entry "
+            "'no-track:<reason>' to opt out for a genuinely exploratory dispatch"
+        ),
+    )
+
+
+def _persist_track_id(spec: DispatchSpec, *, state_dir: Path) -> None:
+    """Best-effort: attach spec.track_id to an EXISTING dispatches row (UPDATE-only).
+
+    Never INSERTs. The dispatches table (runtime_coordination.db) is read by the
+    worker-pool claim query, the runtime reconciler, and the runtime supervisor's
+    stuck/ghost-dispatch sweeps, all keyed off `state`. Fabricating a row for the
+    leaseless claude-tmux lane (which has no pre-existing tracker row) risks
+    tripping those sweeps. D2 treats an absent/None track_id as a no-op, so a
+    dispatch with no pre-existing row is a safe, anticipated case here, not a
+    partial failure. Adds the track_id column additively (_has_col-guarded) when
+    missing. Never raises.
+    """
+    track_id = (spec.track_id or "").strip()
+    if not track_id:
+        return
+    db_path = _tracks_db_path(state_dir)
+    if not db_path.exists():
+        return
+    import sqlite3 as _sqlite3
+    try:
+        conn = _sqlite3.connect(str(db_path), timeout=10.0)
+        try:
+            if not _has_col(conn, "dispatches", "track_id"):
+                conn.execute("ALTER TABLE dispatches ADD COLUMN track_id TEXT")
+                conn.commit()
+            conn.execute(
+                "UPDATE dispatches SET track_id = ? WHERE dispatch_id = ? AND project_id = ?",
+                (track_id, spec.dispatch_id, spec.project_id),
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("[dispatch_cli] track_id persist skipped: %s", exc)
+
+
+# ---------------------------------------------------------------------------
 # build_runtime_snapshot — all I/O lives here
 # ---------------------------------------------------------------------------
 
@@ -445,6 +594,12 @@ def build_runtime_snapshot(
         )
         if binding_verdict is not None:
             constraint_verdicts = constraint_verdicts + (binding_verdict,)
+
+    # TL-D1: track_id door validation (fail-closed on invalid/nonexistent/done;
+    # staged advisory->required WARN/Reject when absent).
+    track_verdict = _check_track_link_verdict(spec, state_dir=data_dir / "state")
+    if track_verdict is not None:
+        constraint_verdicts = constraint_verdicts + (track_verdict,)
 
     if is_claude_lane:
         target_health: dict[str, str] = {"ephemeral": "healthy"}
@@ -600,6 +755,13 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                 )
             except Exception as exc:
                 logger.debug("[dispatch_cli] scout pre-pass skipped: %s", exc)
+
+            # TL-D1: export the resolved track_id alongside VNX_CURRENT_DISPATCH_ID and
+            # persist it onto the dispatch tracker row so D2 can propagate it to
+            # track.pr_ref on merge. Best-effort — never blocks the door.
+            if vspec.spec.track_id:
+                os.environ["VNX_CURRENT_TRACK_ID"] = vspec.spec.track_id
+                _persist_track_id(vspec.spec, state_dir=state_dir)
 
         permit = issue_permit(plan)
         try:

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -79,6 +79,7 @@ class DispatchSpec:
     skill: Optional[str] = None
     task_class: Optional[str] = None
     pr_id: Optional[str] = None
+    track_id: Optional[str] = None  # structural link to a tracks-table row (TL-D1); validated at the door
     deadline_seconds: int = 3600
     base_ref: str = "origin/main"
     isolation: Isolation = Isolation.WORKTREE
@@ -271,6 +272,14 @@ def validate(
                 f"allow_headless is only valid for provider=claude, got provider={spec.provider.value!r}; "
                 "headless api-metered billing is a claude-only lane",
             )
+
+    # Rule 13 — track_id format (presence + format only; existence against the tracks
+    # DB is deferred to dispatch_cli's door validation, which has DB access — mirrors
+    # how role/skill existence is deferred to compile_plan per the module docstring)
+    if spec.track_id is not None:
+        _track_id = spec.track_id.strip()
+        if not _track_id or not _ID_RE.match(_track_id):
+            return Reject("bad-track-id", f"track_id {spec.track_id!r} does not match id regex")
 
     return ValidatedSpec(
         spec=spec,

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 import hashlib
 import json
 import os
+import sqlite3
 import subprocess
 import sys
 import textwrap
@@ -21,8 +22,12 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
 from dispatch_cli import (
+    _check_track_link_verdict,
     _execute_claude,
     _execute_claude_headless,
+    _has_col,
+    _persist_track_id,
+    _tracks_db_path,
     build_runtime_snapshot,
     fingerprint,
     load_spec,
@@ -1370,3 +1375,489 @@ class TestLoadSpecHeadlessReasonSanitization:
         spec_file.write_text(json.dumps(spec), encoding="utf-8")
         loaded = load_spec(spec_file)
         assert loaded.headless_reason is None
+
+
+# ---------------------------------------------------------------------------
+# TL-D1 — track_id: load_spec parsing
+# ---------------------------------------------------------------------------
+
+class TestLoadSpecTrackId:
+    def test_track_id_parsed(self, tmp_path):
+        spec_file = _make_spec_file(tmp_path, extra={"track_id": "track-linkage-enforcement"})
+        loaded = load_spec(spec_file)
+        assert loaded.track_id == "track-linkage-enforcement"
+
+    def test_track_id_absent_is_none(self, tmp_path):
+        spec_file = _make_spec_file(tmp_path)
+        loaded = load_spec(spec_file)
+        assert loaded.track_id is None
+
+    def test_track_id_empty_string_is_none(self, tmp_path):
+        spec_file = _make_spec_file(tmp_path, extra={"track_id": ""})
+        loaded = load_spec(spec_file)
+        assert loaded.track_id is None
+
+
+# ---------------------------------------------------------------------------
+# TL-D1 — track_id: tracks DB fixture helper
+# ---------------------------------------------------------------------------
+
+def _make_tracks_db(
+    state_dir: Path,
+    *,
+    tracks: "dict[str, str] | None" = None,
+    dispatches: "list[dict] | None" = None,
+    dispatches_has_track_id_col: bool = False,
+) -> Path:
+    """Build a minimal runtime_coordination.db with `tracks` (+ optionally `dispatches`).
+
+    tracks: {track_id: phase}. dispatches: list of {dispatch_id, project_id, state}.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE tracks (
+            track_id TEXT NOT NULL PRIMARY KEY,
+            phase TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+        )
+        """
+    )
+    for tid, phase in (tracks or {}).items():
+        conn.execute(
+            "INSERT INTO tracks (track_id, phase, project_id) VALUES (?, ?, 'vnx-dev')",
+            (tid, phase),
+        )
+    if dispatches is not None:
+        track_col = ", track_id TEXT" if dispatches_has_track_id_col else ""
+        conn.execute(
+            f"""
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'queued'{track_col},
+                UNIQUE(dispatch_id, project_id)
+            )
+            """
+        )
+        for row in dispatches:
+            conn.execute(
+                "INSERT INTO dispatches (dispatch_id, project_id, state) VALUES (?, ?, ?)",
+                (row["dispatch_id"], row.get("project_id", "vnx-dev"), row.get("state", "queued")),
+            )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# TL-D1 — _check_track_link_verdict unit tests
+# ---------------------------------------------------------------------------
+
+class TestCheckTrackLinkVerdict:
+    def test_valid_live_track_passes(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(state_dir, tracks={"my-track": "active"})
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        assert _check_track_link_verdict(spec, state_dir=state_dir) is None
+
+    def test_nonexistent_track_rejects(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(state_dir, tracks={"other-track": "active"})
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="does-not-exist",
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=state_dir)
+        assert verdict is not None
+        assert verdict.severity == "blocking"
+        assert verdict.code == "bad-track-link"
+
+    def test_done_track_rejects(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(state_dir, tracks={"finished-track": "done"})
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="finished-track",
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=state_dir)
+        assert verdict is not None
+        assert verdict.severity == "blocking"
+        assert verdict.code == "bad-track-link"
+
+    def test_wrong_project_id_treated_as_nonexistent(self, tmp_path):
+        """A track that exists but under a different project_id must not leak across tenants."""
+        state_dir = tmp_path / "state"
+        db_path = _make_tracks_db(state_dir, tracks={})
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO tracks (track_id, phase, project_id) VALUES ('shared-name', 'active', 'other-project')"
+        )
+        conn.commit()
+        conn.close()
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="shared-name",
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=state_dir)
+        assert verdict is not None
+        assert verdict.severity == "blocking"
+        assert verdict.code == "bad-track-link"
+
+    def test_missing_tracks_db_degrades_to_warn(self, tmp_path, monkeypatch):
+        """Never crash: a present track_id with no tracks DB at all -> WARN, not an exception."""
+        state_dir = tmp_path / "state-does-not-exist"
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=state_dir)
+        assert verdict is not None
+        assert verdict.severity == "warn"
+        assert verdict.code == "tracks-db-unavailable"
+
+    def test_absent_flag_off_warns(self, tmp_path, monkeypatch):
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda key: False)
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id=None,
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=tmp_path / "state")
+        assert verdict is not None
+        assert verdict.severity == "warn"
+        assert verdict.code == "track_unlinked"
+
+    def test_absent_flag_on_no_escape_rejects(self, tmp_path, monkeypatch):
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda key: True)
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id=None, tags=(),
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=tmp_path / "state")
+        assert verdict is not None
+        assert verdict.severity == "blocking"
+        assert verdict.code == "track-required"
+
+    def test_absent_flag_on_with_escape_passes(self, tmp_path, monkeypatch):
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda key: True)
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id=None,
+            tags=("no-track:exploratory spike",),
+        )
+        verdict = _check_track_link_verdict(spec, state_dir=tmp_path / "state")
+        assert verdict is None
+
+
+# ---------------------------------------------------------------------------
+# TL-D1 — _persist_track_id unit tests
+# ---------------------------------------------------------------------------
+
+class TestPersistTrackId:
+    def test_persists_onto_existing_row(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(
+            state_dir,
+            dispatches=[{"dispatch_id": "d1", "project_id": "vnx-dev", "state": "queued"}],
+        )
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        _persist_track_id(spec, state_dir=state_dir)
+
+        conn = sqlite3.connect(str(_tracks_db_path(state_dir)))
+        row = conn.execute(
+            "SELECT track_id, state FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+            ("d1", "vnx-dev"),
+        ).fetchone()
+        conn.close()
+        assert row is not None
+        assert row[0] == "my-track"
+        assert row[1] == "queued", "persistence must never mutate the state column"
+
+    def test_adds_track_id_column_when_missing(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(
+            state_dir,
+            dispatches=[{"dispatch_id": "d1"}],
+            dispatches_has_track_id_col=False,
+        )
+        conn = sqlite3.connect(str(_tracks_db_path(state_dir)))
+        assert not _has_col(conn, "dispatches", "track_id")
+        conn.close()
+
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        _persist_track_id(spec, state_dir=state_dir)
+
+        conn = sqlite3.connect(str(_tracks_db_path(state_dir)))
+        assert _has_col(conn, "dispatches", "track_id")
+        row = conn.execute("SELECT track_id FROM dispatches WHERE dispatch_id = 'd1'").fetchone()
+        conn.close()
+        assert row[0] == "my-track"
+
+    def test_noop_when_no_matching_row(self, tmp_path):
+        """UPDATE-only: no pre-existing dispatches row (the leaseless claude-tmux lane's
+        normal case today) must be a safe no-op, never an INSERT, never a raise."""
+        state_dir = tmp_path / "state"
+        _make_tracks_db(state_dir, dispatches=[])
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="ghost-dispatch", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        _persist_track_id(spec, state_dir=state_dir)  # must not raise
+
+        conn = sqlite3.connect(str(_tracks_db_path(state_dir)))
+        count = conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0]
+        conn.close()
+        assert count == 0, "must never INSERT a synthetic dispatches row"
+
+    def test_noop_when_track_id_absent(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _make_tracks_db(
+            state_dir,
+            dispatches=[{"dispatch_id": "d1", "project_id": "vnx-dev", "state": "queued"}],
+        )
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id=None,
+        )
+        _persist_track_id(spec, state_dir=state_dir)  # must not raise, must not touch the DB
+
+    def test_noop_when_db_missing(self, tmp_path):
+        """Never crash when the tracks DB file doesn't exist at all."""
+        state_dir = tmp_path / "state-does-not-exist"
+        spec = DispatchSpec(
+            schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+            instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+            gate="human-promoted", dispatch_paths=(), track_id="my-track",
+        )
+        _persist_track_id(spec, state_dir=state_dir)  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# TL-D1 — end-to-end run_dispatch tests
+# ---------------------------------------------------------------------------
+
+class TestTrackIdEndToEnd:
+    def test_valid_track_id_persists_and_proceeds(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "vnx-data"
+        state_dir = data_dir / "state"
+        staging_id = "20260706-staging-tl-d1"
+        bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+        bundle_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.delenv("VNX_CURRENT_TRACK_ID", raising=False)
+
+        _make_tracks_db(
+            state_dir,
+            tracks={"track-linkage-enforcement": "active"},
+            dispatches=[{"dispatch_id": "20260706-tl-e2e-valid", "project_id": "vnx-dev", "state": "queued"}],
+        )
+
+        instruction = bundle_dir / "instruction.md"
+        instruction.write_text("Do something useful.", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260706-tl-e2e-valid",
+            "staging_id": staging_id,
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "track_id": "track-linkage-enforcement",
+        }
+        spec_file = bundle_dir / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0
+        mock_execute.assert_called_once()
+        assert os.environ.get("VNX_CURRENT_TRACK_ID") == "track-linkage-enforcement"
+
+        conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = conn.execute(
+            "SELECT track_id FROM dispatches WHERE dispatch_id = ?", ("20260706-tl-e2e-valid",)
+        ).fetchone()
+        conn.close()
+        assert row[0] == "track-linkage-enforcement"
+
+    def test_nonexistent_track_id_rejects(self, tmp_path, monkeypatch, capsys):
+        data_dir = tmp_path / "vnx-data"
+        state_dir = data_dir / "state"
+        staging_id = "20260706-staging-tl-d1-bad"
+        bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+        bundle_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        _make_tracks_db(state_dir, tracks={"some-other-track": "active"})
+
+        instruction = bundle_dir / "instruction.md"
+        instruction.write_text("Do something useful.", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260706-tl-e2e-bad",
+            "staging_id": staging_id,
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "track_id": "does-not-exist",
+        }
+        spec_file = bundle_dir / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+        with patch("dispatch_cli._execute_claude") as mock_execute:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 1
+        mock_execute.assert_not_called()
+        err = capsys.readouterr().err
+        assert "bad-track-link" in err
+
+    def test_absent_track_id_default_off_warns_and_proceeds(self, tmp_path, monkeypatch, capsys):
+        """Flag OFF (default): an unlinked dispatch WARNs (visible in dry-run) but proceeds."""
+        data_dir = tmp_path / "vnx-data"
+        staging_id = "20260706-staging-tl-d1-unlinked"
+        bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+        bundle_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        instruction = bundle_dir / "instruction.md"
+        instruction.write_text("Do something useful.", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260706-tl-e2e-unlinked",
+            "staging_id": staging_id,
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+        }
+        spec_file = bundle_dir / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+        rc = run_dispatch(spec_file, dry_run=True)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "track_unlinked" in out
+
+    def test_absent_track_id_flag_on_rejects(self, tmp_path, monkeypatch, capsys):
+        data_dir = tmp_path / "vnx-data"
+        staging_id = "20260706-staging-tl-d1-required"
+        bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+        bundle_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        instruction = bundle_dir / "instruction.md"
+        instruction.write_text("Do something useful.", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260706-tl-e2e-required",
+            "staging_id": staging_id,
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+        }
+        spec_file = bundle_dir / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda key: True)
+
+        with patch("dispatch_cli._execute_claude") as mock_execute:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 1
+        mock_execute.assert_not_called()
+        err = capsys.readouterr().err
+        assert "track-required" in err
+
+    def test_absent_track_id_flag_on_with_escape_proceeds(self, tmp_path, monkeypatch):
+        data_dir = tmp_path / "vnx-data"
+        staging_id = "20260706-staging-tl-d1-escape"
+        bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+        bundle_dir.mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        instruction = bundle_dir / "instruction.md"
+        instruction.write_text("Do something useful.", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260706-tl-e2e-escape",
+            "staging_id": staging_id,
+            "instruction_file": str(instruction),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "human-promoted",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "isolation": "worktree",
+            "tags": ["no-track:exploratory spike"],
+        }
+        spec_file = bundle_dir / "dispatch-spec.json"
+        spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda key: True)
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0
+        mock_execute.assert_called_once()

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -493,3 +493,46 @@ class TestHeadlessNonClaudeProvider:
         spec = _valid_spec(ifile, allow_headless=False, headless_reason=None, provider=Provider.CODEX)
         result = _do_validate(spec, monkeypatch)
         assert isinstance(result, ValidatedSpec)
+
+
+# ---------------------------------------------------------------------------
+# Rule 13 — track_id format (TL-D1)
+# ---------------------------------------------------------------------------
+
+class TestRule13TrackId:
+    def test_default_none_passes(self, tmp_path, monkeypatch):
+        """track_id defaults to None → ValidatedSpec (rule only fires when set)."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert result.spec.track_id is None
+
+    def test_accepts_valid_track_id(self, tmp_path, monkeypatch):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, track_id="track-linkage-enforcement")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        assert result.spec.track_id == "track-linkage-enforcement"
+
+    @pytest.mark.parametrize("bad_track_id", [
+        "",
+        "   ",
+        "has spaces",
+        "!invalid",
+        "a" * 129,  # too long
+    ])
+    def test_rejects_bad_track_id(self, tmp_path, monkeypatch, bad_track_id):
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, track_id=bad_track_id)
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, Reject)
+        assert result.code == "bad-track-id"
+
+    def test_existence_against_tracks_db_is_not_checked_here(self, tmp_path, monkeypatch):
+        """validate() has no DB access — a well-formed but nonexistent track_id still
+        passes format validation; existence is a dispatch_cli door rule."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, track_id="totally-nonexistent-track")
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)


### PR DESCRIPTION
## Summary
- D1 of the `track-linkage-enforcement` arc (plan: `claudedocs/2026-07-05-track-linkage-enforcement-PLAN.md`). Adds an optional `track_id` field to `DispatchSpec`, validated for format only in `dispatch_spec.validate()` (Rule 13).
- `dispatch_cli.py`'s door (`build_runtime_snapshot`) validates `track_id` against the `tracks` table in `runtime_coordination.db`: a present `track_id` that references a nonexistent or already-`done` track is a fail-closed `Reject("bad-track-link")`. An absent `track_id` is staged advisory→required via `VNX_REQUIRE_DISPATCH_TRACK` (default OFF = WARN `track_unlinked`; ON = `Reject("track-required")` unless a `tags` entry `no-track:<reason>` is present).
- On a valid, linked dispatch: `VNX_CURRENT_TRACK_ID` is exported into the process env (flows to the provider lane via `os.environ.copy()`; the claude-tmux lane needs a small follow-up, see Open Items), and `track_id` is persisted onto the `dispatches` row (UPDATE-only, `_has_col`-guarded additive column) for D2 to read at merge time.

## Test plan
- [x] `python3 -m pytest tests/test_dispatch_spec.py tests/test_dispatch_cli.py -q` — 164 passed
- [x] `python3 -m pytest tests/test_dispatch_enforcement.py tests/test_dispatch_plan.py tests/test_dispatch_spec.py tests/test_dispatch_cli.py -q` — 267 passed (no regressions in dependent modules)
- [x] Dry-run against this dispatch's own (unlinked, tag-only) spec bundle prints a plan with the `track_unlinked` WARN, not a reject (flag OFF default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)