### PR TITLE
fix(audit): exclude process_cleanup.py detector from raw-claude side-door scan

### DIFF
--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -121,6 +121,7 @@ _RAW_SCAN_EXCLUDE_SUBSTR = (
     "/__pycache__/",
     "/hooks/pretooluse_",           # guards that DETECT raw spawns (hold the pattern, do not spawn)
     "/dispatch_sidedoor_audit.py",  # this auditor (holds the patterns as source)
+    "/process_cleanup.py",          # process-hygiene scanner: holds claude -p/--print as DETECTION patterns to hunt forbidden spawns, never spawns (#1029)
 )
 
 # Audited delivery callers (PR-2). A scanned file outside this set is a NEW side door and

--- a/tests/test_dispatch_sidedoor_audit.py
+++ b/tests/test_dispatch_sidedoor_audit.py
@@ -57,6 +57,15 @@ def test_no_unaudited_raw_claude_spawns():
     )
 
 
+def test_process_cleanup_detector_is_not_flagged_as_raw_claude_spawn():
+    # Regression: process_cleanup.py holds claude -p/--print as DETECTION patterns for its
+    # process-hygiene scan (#1029); it never spawns claude and must not be flagged.
+    result = audit_mod.audit()
+    assert "scripts/lib/process_cleanup.py" not in result["raw_claude_unaudited"], (
+        "process_cleanup.py is a detector, not a spawner; it should be excluded from the raw scan"
+    )
+
+
 def test_scan_detects_known_raw_claude_spawns():
     found = audit_mod.scan_raw_claude_spawns()
     for caller in (


### PR DESCRIPTION
Dispatch-ID: 20260706-fix-sidedoor-audit-cleanup

process_cleanup.py holds claude -p/--print purely as DETECTION patterns for its process-hygiene scan (#1029). It never spawns claude, so exclude it from the raw-claude side-door audit to avoid a false-positive that blocks main.

## Changes
- Added `/process_cleanup.py` to `_RAW_SCAN_EXCLUDE_SUBSTR` in `scripts/lib/dispatch_sidedoor_audit.py`.
- Added regression test `test_process_cleanup_detector_is_not_flagged_as_raw_claude_spawn` in `tests/test_dispatch_sidedoor_audit.py`.

## Verification
- `python3 -m pytest tests/test_dispatch_sidedoor_audit.py -q` → 15 passed.
- `python3 -c ... audit() ...` → `raw_claude_unaudited: set()`.