### PR TITLE
feat(planning): plan-gate attest CLI + OI-type-aware blocking hint [TL-brc]

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -449,10 +449,19 @@ def _blocking_detail(
     return {"blocking_ois": blocking_ois, "blocking_deps": blocking_deps}
 
 
+_PLAN_OI_PREFIX = "OI-PLAN-"
+
+
 def format_blocking_hint(detail: Optional[Dict[str, Any]]) -> str:
     """Render an operator-facing hint naming each blocker + its exact resolving
     command — "transparantie zonder actie is inert": the surface must point at
     the action, not just restate the fact of being blocked.
+
+    OI-type-aware: a synthetic ``OI-PLAN-<track>`` blocker (the plan-first gate)
+    resolves through the plan-gate CLI, NOT the generic open-item path — the
+    track_id is derived from the oi_id itself. Any other (generic) blocking
+    open-item has no dedicated CLI resolver today; the hint says so explicitly
+    and names the real underlying mechanism instead of a dead command.
 
     Blocker-OI resolution stays HUMAN-GATED: this only formats the command; it
     never runs it and never clears the open-item itself.
@@ -468,13 +477,26 @@ def format_blocking_hint(detail: Optional[Dict[str, Any]]) -> str:
 
     lines: List[str] = []
     for oi in blocking_ois:
-        oi_id = oi.get("oi_id")
+        oi_id = oi.get("oi_id") or ""
         label = oi.get("label")
         suffix = f" ({label})" if label else ""
-        lines.append(
-            f"blocked by open-item {oi_id}{suffix} -- resolve: "
-            f'vnx track oi-close {oi_id} --reason "<why this no longer blocks>"'
-        )
+        if oi_id.startswith(_PLAN_OI_PREFIX):
+            plan_track = oi_id[len(_PLAN_OI_PREFIX):]
+            lines.append(
+                f"blocked by open-item {oi_id}{suffix} -- this is the plan-first "
+                f"gate; resolve with EITHER: re-run the panel: "
+                f"vnx plan-gate run {plan_track} --doc <plan-doc>  OR operator "
+                f'override: vnx plan-gate attest {plan_track} --reason '
+                f'"<why this is already done>" --approval-id <token>'
+            )
+        else:
+            lines.append(
+                f"blocked by open-item {oi_id}{suffix} -- no CLI resolver exists "
+                f"today; clear via tracks.unlink_open_item(state_dir, track_id, "
+                f"project_id, {oi_id!r}, 'blocks', reason=\"<why this no longer "
+                f"blocks>\") in scripts/lib/tracks.py (sets resolved_at "
+                f"non-destructively; the row is never deleted)"
+            )
     for dep in blocking_deps:
         lines.append(
             f"blocked by dependency {dep.get('track_id')} "

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1767,6 +1767,109 @@ def cmd_plan_gate_status(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
+    """Operator escape-hatch: attest a track's plan gate as passed WITHOUT re-running
+    the panel (mirrors `_close_with_attest`'s design for the sibling ops-track case).
+
+    For the class of bug the track-linkage arc fixes: work already shipped, merged,
+    and CI-green via an ad-hoc dispatch BEFORE the plan-gate ran. Re-running a
+    pre-work plan panel against already-merged work is category-wrong; this is the
+    human-gated override.
+
+    Human-gated: --reason AND --approval-id are BOTH required. On success, resolves
+    the OI-PLAN-<track_id> blocker via `_resolve_plan_blocker` (which also
+    reconciles the track) and emits a `plan_gate_attest` audit event. Never claims a
+    clear that didn't happen: a track with no unresolved plan blocker (not seeded,
+    or already passed) is reported honestly and exits non-zero; a track still
+    blocked by another blocker/dependency after resolving is reported plainly
+    (mirrors the honesty in `cmd_plan_gate_run`).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    reason = (getattr(args, "reason", None) or "").strip()
+    approval_id = (getattr(args, "approval_id", None) or "").strip()
+    if not reason or not approval_id:
+        print(
+            "plan-gate attest: --reason and --approval-id are both required "
+            "(the operator's gate token). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"plan-gate attest: track not found: {track_id!r} (project {project_id!r}). "
+            "No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    payload: dict[str, Any] = {
+        "track_id": track_id,
+        "project_id": project_id,
+        "action": None,
+        "applied": False,
+    }
+
+    try:
+        resolved = _resolve_plan_blocker(state_dir, track_id, project_id)
+    except Exception as exc:
+        print(f"plan-gate attest: unexpected error resolving blocker: {exc}", file=sys.stderr)
+        return 1
+
+    if not resolved:
+        payload["action"] = "noop_not_blocked"
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+            print(
+                "  no unresolved plan blocker found (gate not seeded, or already "
+                "passed). No change made.\n"
+            )
+        return 1
+
+    # Audit the operator attestation (reason + approval_id + track_id).
+    tracks_lib._emit_track_event(
+        state_dir,
+        "plan_gate_attest",
+        track_id,
+        project_id,
+        "operator",
+        {"reason": reason, "approval_id": approval_id, "track_id": track_id},
+    )
+
+    post = tracks_lib.get_track(state_dir, track_id, project_id)
+    derived = post.get("derived_status") if isinstance(post, dict) else None
+    payload["action"] = "attested"
+    payload["applied"] = True
+    payload["derived_status"] = derived
+
+    if derived == "blocked":
+        if args.json:
+            print(json.dumps(payload, indent=2, default=str))
+        else:
+            print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+            print(f"  attested: {reason} (approval={approval_id})")
+            print(
+                f"  plan blocker resolved={resolved}, but track {track_id} is STILL "
+                "blocked (another blocker or hard dependency remains). Clear the "
+                "remaining blocker first.\n"
+            )
+        return 2
+
+    if args.json:
+        print(json.dumps(payload, indent=2, default=str))
+    else:
+        print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+        print(f"  attested: {reason} (approval={approval_id})")
+        print(f"  plan gate cleared. derived_status={derived}.\n")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vnx", description="VNX planning read surface")
     sub = parser.add_subparsers(dest="domain", required=True)
@@ -1980,6 +2083,19 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_pstat)
     p_pstat.add_argument("track_id")
     p_pstat.set_defaults(func=cmd_plan_gate_status)
+
+    p_pattest = pg_sub.add_parser(
+        "attest",
+        help="operator escape-hatch: attest the plan gate as passed without re-running the panel",
+    )
+    _common(p_pattest)
+    p_pattest.add_argument("track_id")
+    p_pattest.add_argument("--reason", default="", help="operator attestation reason (REQUIRED)")
+    p_pattest.add_argument(
+        "--approval-id", default="", dest="approval_id",
+        help="operator approval token (REQUIRED)",
+    )
+    p_pattest.set_defaults(func=cmd_plan_gate_attest)
 
     return parser
 

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -99,6 +99,55 @@ def _phase(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> str:
     return row[0] if row else ""
 
 
+def _build_db_plan_gate(tmp_path: Path) -> Path:
+    """Same as `_build_db` but with migration 0030 applied (track_open_items
+    .resolved_at / .resolution_reason) — required for the plan-gate blocker
+    seed/resolve lifecycle (`_plan_gate_supported`)."""
+    state_dir = _build_db(tmp_path)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    schema_migration.apply_script_if_below(
+        conn, 30, (_MIGRATIONS / "0030_track_oi_resolved_at.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _plan_oi_resolved_at(state_dir: Path, track_id: str, project_id: str = PROJECT_ID):
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT resolved_at FROM track_open_items "
+        "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+        (track_id, project_id, f"OI-PLAN-{track_id}"),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _derived_status(state_dir: Path, track_id: str, project_id: str = PROJECT_ID):
+    t = tracks_lib.get_track(state_dir, track_id, project_id)
+    return t.get("derived_status") if t else None
+
+
+def _plan_attest_args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    reason: str = "",
+    approval_id: str = "",
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        reason=reason,
+        approval_id=approval_id,
+        json=json,
+    )
+
+
 def _history_count(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> int:
     conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
     n = conn.execute(
@@ -284,3 +333,87 @@ def test_close_blocked_renders_blocking_dependency_hint(tmp_path, capsys):
     assert "blocked" in out
     assert "blocked by dependency dep" in out
     assert "not done (phase=queued)" in out
+
+
+# ---------------------------------------------------------------------------
+# plan-gate attest
+# ---------------------------------------------------------------------------
+
+def test_plan_gate_attest_resolves_blocker_and_writes_audit(tmp_path):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="shipped", phase="queued")
+    assert planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID) is True
+    assert _derived_status(sd, "T") == "blocked"
+
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="already shipped+merged pre-gate", approval_id="APR-1")
+    )
+    assert rc == 0
+    assert _plan_oi_resolved_at(sd, "T") is not None
+    assert _derived_status(sd, "T") != "blocked"
+
+    events = _track_events(sd, "T", "plan_gate_attest")
+    assert len(events) == 1
+    details = events[0]["details"]
+    assert details["reason"] == "already shipped+merged pre-gate"
+    assert details["approval_id"] == "APR-1"
+    assert details["track_id"] == "T"
+
+
+def test_plan_gate_attest_requires_reason_and_approval_id(tmp_path):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+
+    rc_no_reason = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="", approval_id="APR-1")
+    )
+    assert rc_no_reason == 2
+    assert _plan_oi_resolved_at(sd, "T") is None
+
+    rc_no_approval = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="shipped", approval_id="")
+    )
+    assert rc_no_approval == 2
+    assert _plan_oi_resolved_at(sd, "T") is None
+    assert _track_events(sd, "T", "plan_gate_attest") == []
+
+
+def test_plan_gate_attest_no_blocker_reports_honestly(tmp_path, capsys):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    # No _seed_plan_blocker call: nothing to resolve.
+
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="shipped", approval_id="APR-1")
+    )
+    assert rc == 1
+    assert _track_events(sd, "T", "plan_gate_attest") == []
+    assert "no unresolved plan blocker" in capsys.readouterr().out
+
+
+def test_plan_gate_attest_track_not_found(tmp_path):
+    sd = _build_db_plan_gate(tmp_path)
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "missing", reason="x", approval_id="y")
+    )
+    assert rc == 1
+
+
+def test_plan_gate_attest_still_blocked_reports_plainly(tmp_path, capsys):
+    """Resolving the plan blocker clears IT, but a hard dependency still blocks —
+    attest must report that plainly, not claim a full unblock."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    tracks_lib.create_track(sd, "dep", PROJECT_ID, title="dep", goal_state="y", phase="queued")
+    tracks_lib.add_dependency(sd, "T", PROJECT_ID, "dep", PROJECT_ID, kind="hard", derivation_source="manual")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="shipped", approval_id="APR-1")
+    )
+    assert rc == 2
+    assert _plan_oi_resolved_at(sd, "T") is not None  # the plan blocker itself WAS resolved
+    assert _derived_status(sd, "T") == "blocked"  # but still blocked by the dependency
+    assert len(_track_events(sd, "T", "plan_gate_attest")) == 1
+    assert "STILL" in capsys.readouterr().out

--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -481,8 +481,9 @@ def test_0028_down_removes_derived_status(tmp_path):
 
 
 def test_blocking_detail_names_blocker_oi(tmp_path):
-    """blocking_detail.blocking_ois names the unresolved blocker OI; the hint
-    carries the exact oi-close command to resolve it."""
+    """blocking_detail.blocking_ois names the unresolved blocker OI; a generic
+    (non-plan) blocker has no CLI resolver today, so the hint says so honestly
+    and points at the real underlying mechanism instead of a dead command."""
     state_dir = _build_db(tmp_path)
     _seed_track(state_dir, "T-hint-oi")
     _seed_dispatch(state_dir, "D-hint-oi-1", "T-hint-oi", state="completed")
@@ -497,7 +498,32 @@ def test_blocking_detail_names_blocker_oi(tmp_path):
 
     hint = track_reconciler.format_blocking_hint(detail)
     assert "OI-777" in hint
-    assert "vnx track oi-close OI-777" in hint
+    assert "no CLI resolver exists" in hint
+    assert "tracks.unlink_open_item" in hint
+    assert "vnx track oi-close" not in hint
+
+
+def test_blocking_detail_plan_oi_yields_plan_gate_hint(tmp_path):
+    """An OI-PLAN-<track> blocker (the plan-first gate) yields a plan-gate
+    run|attest hint — never the dead `oi-close` command — and derives the
+    track id from the oi_id itself."""
+    state_dir = _build_db(tmp_path)
+    _seed_track(state_dir, "T-hint-plan")
+    _seed_dispatch(state_dir, "D-hint-plan-1", "T-hint-plan", state="completed")
+    tracks_lib.link_open_item(
+        state_dir, "T-hint-plan", PROJECT_ID, "OI-PLAN-T-hint-plan", "blocks", "manual"
+    )
+
+    result = track_reconciler.reconcile_track(state_dir, "T-hint-plan", PROJECT_ID)
+    assert result["derived_status"] == "blocked"
+    detail = result["blocking_detail"]
+    assert detail["blocking_ois"] == [{"oi_id": "OI-PLAN-T-hint-plan"}]
+
+    hint = track_reconciler.format_blocking_hint(detail)
+    assert "vnx plan-gate run T-hint-plan --doc" in hint
+    assert "vnx plan-gate attest T-hint-plan --reason" in hint
+    assert "--approval-id" in hint
+    assert "vnx track oi-close" not in hint
 
 
 def test_blocking_detail_names_dependency(tmp_path):


### PR DESCRIPTION
Horizon track: **blocker-resolution-completeness** (P1).

## Summary
`_close_with_attest` gave ops-tracks a human-gated escape hatch for no-PR-evidence closure, but the plan-gate had none: a track whose work shipped+merged+CI-green via an ad-hoc dispatch BEFORE the gate ran could only clear its `OI-PLAN-<track>` blocker by re-running a pre-work plan panel, which is category-wrong and REVISEs on plan-doc-completeness grounds.

## Changes
- `vnx plan-gate attest <track> --reason --approval-id` mirrors the `close --attest` design: both flags required, resolves the blocker via existing `_resolve_plan_blocker`, audits a `plan_gate_attest` event, honest exit when not blocked or still blocked by another dependency.
- `format_blocking_hint` is now OI-type-aware: `OI-PLAN-*` points at the attest escape hatch; a generic `track_open_items` blocker names the real mechanism (`tracks.unlink_open_item`) instead of the dead `vnx track oi-close` command.

## Verification
Local CI + codex-gate on merge (overnight governed run). Tests: `tests/test_planning_cli.py` (+133), `tests/test_track_reconciler.py` (+32).

🤖 Generated with [Claude Code](https://claude.com/claude-code)