### PR TITLE
fix(billing): per-provider billing classification + phantom_guard kimi non-token signal [TL-ppb]

### DIFF
--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -23,6 +23,7 @@ from dispatch_spec import (
     Reject,
     ValidatedSpec,
 )
+from providers.billing_lanes import is_subscription_lane
 
 
 # ---------------------------------------------------------------------------
@@ -171,6 +172,10 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     if is_claude_headless:
         billing = "api_metered"
     elif is_claude_lane:
+        billing = "subscription"
+    elif is_subscription_lane(provider.value):
+        # kimi/glm-harness/deepseek-harness are OAuth/own-key harness lanes for this
+        # account, not per-token metered against the shared cost budget (billing_lanes.py).
         billing = "subscription"
     else:
         billing = "provider_metered"

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -18,9 +18,20 @@ Decision rule (a delivery worker is a phantom when):
     role NOT in REVIEW_ROLES
     AND status claims completion (done/success)
     AND the worktree diff is empty
+    AND no non-token evidence was accepted (see below)
 token_usage is corroborating DETAIL only — token>0 does NOT exempt (it means an LLM thought, not
 that a deliverable was produced; a delivery task that changed nothing is a phantom even if tokens
 were spent). Reviews are exempt; a legitimate no-op delivery uses VNX_OVERRIDE_PHANTOM_GUARD.
+
+Provider-aware non-token evidence (TOKEN_BLIND_PROVIDERS): kimi's CLI does not reliably surface a
+token count, and a real kimi push can still read as an empty diff if the diff is captured after the
+dispatch branch already merged into base (base..head reads empty once head is an ancestor of base).
+Requiring token_usage>0 as the ONLY escape hatch would make every such push a false phantom. So for
+a provider in TOKEN_BLIND_PROVIDERS, an explicit non-token evidence reference (a commit sha, branch
+name, or PR id/ref proving the dispatch produced output) is accepted in place of a non-empty diff.
+This does NOT weaken the guard for the genuine phantom case: no diff AND no evidence reference is
+still rejected, and non-token-blind providers (claude, codex, ...) get no such escape hatch — their
+empty-diff receipts are phantoms regardless of token_usage, exactly as before.
 """
 from __future__ import annotations
 
@@ -38,6 +49,14 @@ REVIEW_ROLES = frozenset({"plan-reviewer", "code-reviewer", "security-reviewer",
 
 # Receipt status values that assert the work completed.
 COMPLETION_STATUSES = frozenset({"done", "success", "complete", "completed"})
+
+# Providers whose CLI does not reliably surface a token count (kimi-cli emits no
+# token_count event on a normal run). For these, token_usage==0/None must never be
+# read as "no work happened" — see the non-token evidence path in phantom_guard().
+# Extend here only when a provider's lane is MEASURED to have the same reporting gap;
+# providers that do report tokens (claude, codex, glm-harness/deepseek-harness via the
+# claude-CLI harness) get no such escape hatch.
+TOKEN_BLIND_PROVIDERS = frozenset({"kimi"})
 
 
 @dataclass(frozen=True)
@@ -59,15 +78,27 @@ def phantom_guard(
     worktree_diff: Optional[str],
     token_usage: Optional[int] = None,
     role: Optional[str] = None,
+    provider: Optional[str] = None,
+    non_token_evidence: Optional[str] = None,
 ) -> PhantomVerdict:
     """Pure decision. See module docstring for the rule. worktree_diff is the REAL diff of the
-    worker's worktree/branch (caller-computed), NOT the receipt's main-repo provenance."""
+    worker's worktree/branch (caller-computed), NOT the receipt's main-repo provenance.
+
+    ``provider`` + ``non_token_evidence`` are the TOKEN_BLIND_PROVIDERS escape hatch: when the
+    diff itself is empty, a token-blind provider (kimi at minimum) may still pass a non-token
+    evidence reference (commit sha / branch / PR id) proving the dispatch produced output.
+    """
     if role is not None and role.strip().lower() in REVIEW_ROLES:
         return _ok(f"review role {role!r} — a verdict, not a diff, is expected")
     if (status or "").strip().lower() not in COMPLETION_STATUSES:
         return _ok(f"status {status!r} is not a completion claim — nothing to falsify")
     if (worktree_diff or "").strip():
         return _ok("non-empty worktree diff — work is present")
+    if (provider or "").strip().lower() in TOKEN_BLIND_PROVIDERS and (non_token_evidence or "").strip():
+        return _ok(
+            f"token-blind provider {provider!r} — accepted non-token evidence {non_token_evidence!r} "
+            f"in place of token_usage/diff"
+        )
     # Empty diff on a delivery completion claim = PHANTOM, REGARDLESS of token_usage. token>0
     # means an LLM thought/read, NOT that a deliverable was produced — a delivery task that
     # changed nothing is a phantom even if tokens were spent (the earlier token>0 short-circuit
@@ -141,6 +172,11 @@ def guard_receipt(
     explicit ``worktree_diff`` > ``worktree_path`` (compute_worktree_diff) > ``head_ref``
     (compute_branch_diff). If none is given, the diff is treated as empty (caller asserted no
     out-of-band evidence) — the strictest reading.
+
+    ``provider`` and the non-token evidence reference are read straight off the receipt
+    (``receipt["provider"]``, ``receipt["pr_id"]``/``pr_ref``/``commit_sha``/``branch``) so a
+    token-blind provider's receipt (kimi at minimum) is not false-rejected purely because
+    ``token_usage`` is 0/absent — see TOKEN_BLIND_PROVIDERS in the module docstring.
     """
     if worktree_diff is None:
         if worktree_path is not None:
@@ -154,6 +190,8 @@ def guard_receipt(
         worktree_diff=worktree_diff,
         token_usage=_extract_token_usage(receipt),
         role=receipt.get("role") or receipt.get("agent"),
+        provider=receipt.get("provider"),
+        non_token_evidence=_extract_non_token_evidence(receipt),
     )
 
 
@@ -166,6 +204,8 @@ def guard_at_govern(
     worktree_path: Optional[Path] = None,
     base_sha: Optional[str] = None,
     worktree_diff: Optional[str] = None,
+    provider: Optional[str] = None,
+    non_token_evidence: Optional[str] = None,
 ) -> PhantomVerdict:
     """Inline govern-time phantom check for BOTH lanes (claude tmux via dispatch_govern.govern,
     providers via dispatch_envelope._govern — the kimi/glm/deepseek fabrication vector).
@@ -178,6 +218,10 @@ def guard_at_govern(
          GovernSpec — not torn down until after govern),
       2. else the dispatch's own branch ``dispatch/<sanitized id>`` (still-present isolated branch),
       3. else ABSTAIN — return ok (an unresolvable/torn-down ref must never read as "empty diff").
+
+    ``provider`` + ``non_token_evidence`` forward to ``phantom_guard()``'s TOKEN_BLIND_PROVIDERS
+    escape hatch (kimi at minimum): when the resolved diff is still empty, a caller-supplied
+    non-token evidence reference (commit sha / branch / PR id) is accepted in its place.
 
     Honors ``VNX_OVERRIDE_PHANTOM_GUARD=1`` (operator escape for a legitimate no-op delivery). This
     function performs NO receipt I/O — the caller appends the corrective ``failed`` receipt on a
@@ -200,7 +244,10 @@ def guard_at_govern(
                 diff = compute_branch_diff(branch, base_ref=base)
         except Exception as exc:  # CalledProcessError / missing ref / reaped worktree
             return _ok(f"phantom-guard ABSTAINED — worker diff unresolvable ({type(exc).__name__})")
-    return phantom_guard(status=status, worktree_diff=diff, token_usage=token_usage, role=role)
+    return phantom_guard(
+        status=status, worktree_diff=diff, token_usage=token_usage, role=role,
+        provider=provider, non_token_evidence=non_token_evidence,
+    )
 
 
 def record_phantom_if_any(
@@ -213,6 +260,8 @@ def record_phantom_if_any(
     base_sha: Optional[str] = None,
     worktree_diff: Optional[str] = None,
     receipts_file: Optional[str] = None,
+    provider: Optional[str] = None,
+    non_token_evidence: Optional[str] = None,
 ) -> PhantomVerdict:
     """``guard_at_govern`` + on a phantom verdict, append a corrective ``failed`` completion receipt.
 
@@ -227,6 +276,7 @@ def record_phantom_if_any(
     verdict = guard_at_govern(
         dispatch_id=dispatch_id, role=role, status=status, token_usage=token_usage,
         worktree_path=worktree_path, base_sha=base_sha, worktree_diff=worktree_diff,
+        provider=provider, non_token_evidence=non_token_evidence,
     )
     if verdict.is_phantom and receipts_file:
         try:
@@ -311,6 +361,23 @@ def _extract_token_usage(receipt: Mapping[str, Any]) -> Optional[int]:
     return None
 
 
+# Receipt keys checked, in order, for a non-token evidence reference (commit sha, branch
+# name, or PR id/ref). First truthy, non-placeholder value wins.
+_NON_TOKEN_EVIDENCE_KEYS = ("pr_id", "pr_ref", "commit_sha", "branch")
+
+
+def _extract_non_token_evidence(receipt: Mapping[str, Any]) -> Optional[str]:
+    """Best-effort non-token evidence reference from a receipt; None when absent."""
+    for key in _NON_TOKEN_EVIDENCE_KEYS:
+        value = receipt.get(key)
+        if value is None:
+            continue
+        text = str(value).strip()
+        if text and text.lower() != "none":
+            return text
+    return None
+
+
 def main(argv: Optional[list] = None) -> int:
     import argparse
     import json
@@ -321,6 +388,8 @@ def main(argv: Optional[list] = None) -> int:
     p.add_argument("--status", help="Receipt status (when not passing --receipt-json).")
     p.add_argument("--role", default=None)
     p.add_argument("--token-usage", type=int, default=None)
+    p.add_argument("--provider", default=None, help="Dispatch provider (e.g. kimi) — enables the TOKEN_BLIND_PROVIDERS evidence path.")
+    p.add_argument("--non-token-evidence", default=None, help="Commit sha / branch / PR id proving the dispatch produced output.")
     src = p.add_mutually_exclusive_group()
     src.add_argument("--worktree", help="Path to the worker's worktree (diff it vs --base).")
     src.add_argument("--branch", help="Pushed branch ref to diff vs --base.")
@@ -344,6 +413,7 @@ def main(argv: Optional[list] = None) -> int:
         verdict = phantom_guard(
             status=args.status, worktree_diff=diff,
             token_usage=args.token_usage, role=args.role,
+            provider=args.provider, non_token_evidence=args.non_token_evidence,
         )
 
     print(verdict.reason, file=sys.stderr)

--- a/scripts/lib/providers/billing_lanes.py
+++ b/scripts/lib/providers/billing_lanes.py
@@ -1,0 +1,40 @@
+"""billing_lanes.py — canonical billing classification for provider lanes.
+
+SSOT for which provider lanes bill as subscription/OAuth-key (no per-token
+metered cost lands against this account) vs genuinely API-metered lanes.
+Consumed by dispatch_plan.py's D2 billing rule so cost-tracking and the
+per-provider quota cap see the real lane instead of a blanket
+"everything non-claude is metered" label.
+
+Each entry ties back to a provider_constraints.yaml guard-rail so the
+classification and the routing constraint never drift apart:
+  - "kimi": kimi-via-cli-only — CLI OAuth login (`kimi login`), no per-token
+    billing surfaces to this account.
+  - "glm-harness" / "litellm:zai": glm-via-harness-only — GLM runs via the
+    claude-CLI harness -> local litellm proxy -> OpenRouter on an
+    already-provisioned key; litellm:zai is the alias a legacy caller may
+    still present before the door normalizes it to glm-harness.
+  - "deepseek-harness": deepseek-harness-subscription-blocked — runs via the
+    claude-CLI harness with an own DeepSeek API key + hardening, never the
+    production Anthropic OAuth subscription.
+
+Genuinely per-token-metered lanes (codex, gemini, litellm:deepseek,
+litellm:moonshot, local-gemma) are deliberately absent — they classify as
+"provider_metered" by omission.
+"""
+from __future__ import annotations
+
+# Provider.value strings (see dispatch_spec.Provider) whose lane is
+# subscription/OAuth-key billed rather than genuinely per-token API-metered
+# on this account.
+SUBSCRIPTION_LANE_PROVIDERS: frozenset[str] = frozenset({
+    "kimi",
+    "litellm:zai",
+    "glm-harness",
+    "deepseek-harness",
+})
+
+
+def is_subscription_lane(provider_value: str) -> bool:
+    """True if *provider_value* (a Provider.value string) bills as subscription/OAuth-key."""
+    return provider_value in SUBSCRIPTION_LANE_PROVIDERS

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -181,6 +181,56 @@ class TestProviderLaneParallel:
 
 
 # ---------------------------------------------------------------------------
+# test_billing_classification — per-provider-billing-phantom PR
+# ---------------------------------------------------------------------------
+
+class TestBillingClassification:
+    """kimi/glm-harness/litellm:zai/deepseek-harness are OAuth/own-key harness
+    lanes for this account, not per-token metered — billing_lanes.py SSOT."""
+
+    @pytest.mark.parametrize(
+        "provider",
+        [Provider.KIMI, Provider.LITELLM_ZAI, Provider.GLM_HARNESS, Provider.DEEPSEEK_HARNESS],
+    )
+    def test_subscription_lane_providers_classify_as_subscription(
+        self, provider: Provider, tmp_path: Path
+    ) -> None:
+        vspec = _make_vspec(provider=provider, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.billing == "subscription", (
+            f"expected subscription billing for {provider.value}, got {plan.billing!r}"
+        )
+
+    def test_claude_lane_stays_subscription(self, tmp_path: Path) -> None:
+        vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.billing == "subscription"
+
+    @pytest.mark.parametrize(
+        "provider",
+        [Provider.CODEX, Provider.GEMINI, Provider.LITELLM_DEEPSEEK, Provider.LITELLM_MOONSHOT],
+    )
+    def test_genuinely_metered_providers_stay_provider_metered(
+        self, provider: Provider, tmp_path: Path
+    ) -> None:
+        vspec = _make_vspec(provider=provider, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.billing == "provider_metered", (
+            f"expected provider_metered billing for {provider.value}, got {plan.billing!r}"
+        )
+
+    def test_headless_claude_stays_api_metered(self, tmp_path: Path) -> None:
+        """Headless claude (allow_headless=True) is the one genuinely metered claude lane."""
+        vspec = _make_vspec_headless(tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.billing == "api_metered"
+
+
+# ---------------------------------------------------------------------------
 # test_staging_gate
 # ---------------------------------------------------------------------------
 

--- a/tests/test_phantom_guard.py
+++ b/tests/test_phantom_guard.py
@@ -65,3 +65,72 @@ def test_unmeasured_tokens_mapping_is_none():
     assert pg._extract_token_usage({"token_usage": {"input": 0, "output": 0}}) is None
     assert pg._extract_token_usage({"token_usage": 42}) == 42
     assert pg._extract_token_usage({}) is None
+
+
+# ---------------------------------------------------------------------------
+# TOKEN_BLIND_PROVIDERS — per-provider-billing-phantom PR
+# ---------------------------------------------------------------------------
+
+def test_kimi_zero_tokens_with_evidence_is_not_phantom():
+    # kimi-cli reports token_usage=0 on a real push; a non-token evidence reference
+    # (commit/PR) must stand in for the (still empty, e.g. post-merge) diff.
+    v = pg.phantom_guard(
+        status="done", worktree_diff="", token_usage=0, role="backend-developer",
+        provider="kimi", non_token_evidence="pr#1234",
+    )
+    assert not v.is_phantom
+    assert "kimi" in v.reason
+
+
+def test_kimi_zero_tokens_no_evidence_is_still_phantom():
+    # the genuine phantom case: kimi, no diff, no evidence at all — still rejected.
+    v = pg.phantom_guard(
+        status="done", worktree_diff="", token_usage=0, role="backend-developer",
+        provider="kimi", non_token_evidence=None,
+    )
+    assert v.is_phantom
+
+
+def test_non_kimi_provider_with_evidence_is_still_phantom():
+    # the evidence escape hatch is provider-scoped: a token-reporting provider (claude)
+    # gets no such exemption — empty diff is still a phantom regardless of "evidence".
+    v = pg.phantom_guard(
+        status="done", worktree_diff="", token_usage=0, role="backend-developer",
+        provider="claude", non_token_evidence="pr#1234",
+    )
+    assert v.is_phantom
+
+
+def test_kimi_with_real_diff_and_no_evidence_is_not_phantom_as_before():
+    # non-empty diff still short-circuits before the evidence check is ever consulted.
+    v = pg.phantom_guard(
+        status="done", worktree_diff="diff --git a/x b/x\n+y\n", token_usage=0,
+        role="backend-developer", provider="kimi", non_token_evidence=None,
+    )
+    assert not v.is_phantom
+
+
+def test_guard_receipt_kimi_pr_id_evidence_not_phantom():
+    receipt = {
+        "status": "done", "role": "backend-developer", "provider": "kimi",
+        "token_usage": 0, "pr_id": "1234",
+    }
+    v = pg.guard_receipt(receipt, worktree_diff="")
+    assert not v.is_phantom
+
+
+def test_guard_receipt_kimi_no_evidence_is_phantom():
+    receipt = {
+        "status": "done", "role": "backend-developer", "provider": "kimi",
+        "token_usage": 0,
+    }
+    v = pg.guard_receipt(receipt, worktree_diff="")
+    assert v.is_phantom
+
+
+def test_extract_non_token_evidence_checks_known_keys_in_order():
+    assert pg._extract_non_token_evidence({"pr_id": "42"}) == "42"
+    assert pg._extract_non_token_evidence({"pr_id": "none", "commit_sha": "abc123"}) == "abc123"
+    assert pg._extract_non_token_evidence({"branch": "dispatch/foo"}) == "dispatch/foo"
+    assert pg._extract_non_token_evidence({}) is None
+    assert pg._extract_non_token_evidence({"pr_id": None, "commit_sha": ""}) is None


### PR DESCRIPTION
Horizon track: **per-provider-billing-phantom** (P2). Addresses the dispatch-lane billing-label gap.

## Summary
`dispatch_plan` labelled everything-not-claude as `provider_metered`, but kimi / glm-harness / deepseek-harness are subscription/OAuth lanes. That drives cost-drift and ignores the quota cap. Separately, `phantom_guard` keyed on a token signal that kimi does not always emit, so legitimate kimi gate-receipts risked being flagged as phantom.

## Changes
- `scripts/lib/providers/billing_lanes.py` (new): per-provider billing-lane classification (subscription vs metered), single source of truth.
- `scripts/lib/dispatch_plan.py`: consume the classifier instead of the not-claude heuristic.
- `scripts/lib/phantom_guard.py`: accept kimi's non-token completion signal so real gate-receipts are not falsely flagged.

## Verification
Local CI + codex-gate on merge. Tests: `tests/test_dispatch_plan.py` (+50), `tests/test_phantom_guard.py` (+69).

🤖 Generated with [Claude Code](https://claude.com/claude-code)