### PR TITLE
fix(start): robust T0 role-load self-heal + fleet drift audit [TL-trd]

### DIFF
--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -66,6 +66,14 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 Follow the full procedure in `@t0-orchestrator` §7 (Startup / recovery / runbooks), which points to `docs/core/DISPATCH_RULES.md` §10.
 Quick reference: validate schema → repair stale leases → reconcile queue → check orphaned dispatches → check incidents.
 
+## Role-File Load Check (fleet drift)
+
+If you are reading this file, your role loaded correctly — Claude Code found it by walking up from cwd, which only happens when cwd is (under) `.claude/terminals/T0`. If a tmux restart, `tmux-resurrect`/`continuum` auto-restore, or manual re-attach ever drops cwd back to the project root, a T0 session silently loses this entire file with no error — it just runs the generic project `CLAUDE.md` instead. `vnx start` self-heals this on the next launch for genuinely stale sessions; it cannot touch a session with a live CLI already running (by design — it will not kill your session). To check the whole fleet for this drift without disturbing any running session:
+
+```bash
+bash scripts/commands/t0_role_audit.sh
+```
+
 ## Runtime Policy
 
 - T0 runtime is Claude Opus only.

--- a/scripts/commands/start.sh
+++ b/scripts/commands/start.sh
@@ -7,7 +7,6 @@
 # _update_last_used, _detect_worktree_context, cmd_intelligence_export, etc.)
 # are available when this runs.
 
-
 # Detect whether a tmux pane has an active CLI (claude/codex/gemini/node) in
 # its process tree. Checked via `ps`, not tmux's `#{pane_current_command}`:
 # a running claude process can report its own version string (e.g. "2.1.201")

--- a/scripts/commands/start.sh
+++ b/scripts/commands/start.sh
@@ -7,6 +7,26 @@
 # _update_last_used, _detect_worktree_context, cmd_intelligence_export, etc.)
 # are available when this runs.
 
+
+# Detect whether a tmux pane has an active CLI (claude/codex/gemini/node) in
+# its process tree. Checked via `ps`, not tmux's `#{pane_current_command}`:
+# a running claude process can report its own version string (e.g. "2.1.201")
+# there instead of the literal binary name, which makes pane_current_command
+# an unreliable liveness signal and causes a genuinely-running T0 to be
+# misdetected as a stale/idle session.
+_vnx_pane_active_cli() {
+  local pane_pid="$1" pid comm
+  [ -z "$pane_pid" ] && return 1
+  for pid in "$pane_pid" $(pgrep -P "$pane_pid" 2>/dev/null); do
+    comm="$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')"
+    comm="${comm##*/}"
+    case "$comm" in
+      claude|codex|gemini|node) return 0 ;;
+    esac
+  done
+  return 1
+}
+
 cmd_start() {
   local session_name="vnx-$(basename "$PROJECT_ROOT")"
   local terms_dir="$PROJECT_ROOT/.claude/terminals"
@@ -188,8 +208,11 @@ cmd_start() {
   # contain idle shells (no active Claude/Codex/Gemini process).
   if tmux has-session -t "$session_name" 2>/dev/null; then
     local active_cli_count=0
-    active_cli_count="$(tmux list-panes -t "$session_name" -F '#{pane_current_command}' 2>/dev/null \
-      | awk '$1=="node" || $1=="claude" || $1=="codex" || $1=="gemini" {c++} END {print c+0}')"
+    local _acc_pane_pid
+    while IFS= read -r _acc_pane_pid; do
+      [ -z "$_acc_pane_pid" ] && continue
+      _vnx_pane_active_cli "$_acc_pane_pid" && active_cli_count=$((active_cli_count + 1))
+    done < <(tmux list-panes -t "$session_name" -F '#{pane_pid}' 2>/dev/null)
 
     # If a profile was explicitly selected, kill the existing session and restart
     # fresh so the chosen T0 provider is actually applied.
@@ -207,8 +230,18 @@ cmd_start() {
       # Without this, re-heal creates duplicate supervisors/receipt_processors.
       vnx_kill_all_orchestration "$scripts_dir" "$log_dir" "session_reheal"
 
+      # T0-only layout guarantees exactly one persistent pane per session.
+      # Do NOT filter by cwd here: if the pane's cwd has already drifted away
+      # from $terms_dir/T0 (the exact condition this re-heal path exists to
+      # fix), a cwd-based filter matches nothing, the cd+relaunch below is
+      # silently skipped, and the drift becomes permanent — every future
+      # `vnx start` reports "re-heal complete" without ever sending a single
+      # keystroke. Exclude only the transient queue-popup window
+      # (queue_popup_watcher.sh: "VNX-Queue"), which self-destructs after use
+      # and can briefly coexist as a second window in this session.
       local T0
-      T0="$(tmux list-panes -t "$session_name" -F '#{pane_id} #{pane_current_path}' 2>/dev/null | awk -v p="$terms_dir/T0" '$2==p {print $1; exit}')"
+      T0="$(tmux list-panes -t "$session_name" -F '#{window_name} #{pane_id}' 2>/dev/null \
+        | awk '$1!="VNX-Queue" {print $2; exit}')"
 
       local node_path=""
       node_path="$(_resolve_node_path 2>/dev/null)" || node_path=""

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -1,0 +1,129 @@
+#!/usr/bin/env bash
+# VNX fleet audit: does each project's live (or registered) T0 session
+# actually load its role file (.claude/terminals/T0/CLAUDE.md)?
+#
+# Claude Code discovers CLAUDE.md by walking UP from cwd, merging every
+# CLAUDE.md found in ancestor directories. .claude/terminals/T0/CLAUDE.md is a
+# DESCENDANT of the project root, not an ancestor of it — so a T0 claude
+# process only picks it up when its cwd is exactly <project_root>/.claude/
+# terminals/T0. Any launch path that starts claude at the project root
+# instead (a stale tmux-resurrect/continuum respawn, a manual re-attach, a
+# launcher bug) silently drops the orchestrator role file — no error, no
+# warning, T0 just runs without its playbook.
+#
+# This makes that drift observable: it reports, per project/terminal,
+# whether the running T0 would load its role file right now.
+#
+# Usage: bash scripts/commands/t0_role_audit.sh
+#
+# Standalone by design — this must also audit OTHER registered VNX projects,
+# not just the one it happens to be invoked from, so it does not depend on
+# bin/vnx's command loader (PROJECT_ROOT/VNX_HOME/log/err are not assumed).
+
+set -uo pipefail
+
+# Detect whether a tmux pane has an active CLI (claude/codex/gemini/node) in
+# its process tree. Checked via `ps`, not tmux's `#{pane_current_command}`:
+# a running claude process can report its own version string (e.g. "2.1.201")
+# there instead of the literal binary name.
+_t0_audit_active_cli() {
+  local pane_pid="$1" pid comm
+  [ -z "$pane_pid" ] && return 1
+  for pid in "$pane_pid" $(pgrep -P "$pane_pid" 2>/dev/null); do
+    comm="$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')"
+    comm="${comm##*/}"
+    case "$comm" in
+      claude|codex|gemini|node) return 0 ;;
+    esac
+  done
+  return 1
+}
+
+_t0_audit_row() {
+  printf '%-22s %-6s %-9s %-9s %-55s\n' "$1" "$2" "$3" "$4" "$5"
+}
+
+main() {
+  if ! command -v tmux >/dev/null 2>&1; then
+    echo "tmux not found — cannot audit live sessions." >&2
+    exit 1
+  fi
+
+  _t0_audit_row "PROJECT" "TERM" "LOADED?" "CLI" "CWD"
+  _t0_audit_row "-------" "----" "-------" "---" "---"
+
+  local found_any=0
+  local seen_roots=""
+
+  while IFS=' ' read -r pane_id pane_path pane_pid; do
+    [ -z "$pane_id" ] && continue
+
+    # Skip per-dispatch worker worktrees (tmux_interactive_dispatch.py checks
+    # out one worktree per dispatch under .vnx-data/worktrees/). Those panes
+    # run a worker (T1/T2/T3-style implementation task), never a T0
+    # orchestrator, even though the checkout also happens to contain a
+    # .claude/terminals/T0/CLAUDE.md file inherited from the repo tree.
+    case "$pane_path" in
+      */.vnx-data/worktrees/*) continue ;;
+    esac
+
+    local project_root="" loaded=""
+    if [ "${pane_path%/.claude/terminals/T0}" != "$pane_path" ]; then
+      # cwd is exactly <root>/.claude/terminals/T0 — role file loads.
+      project_root="${pane_path%/.claude/terminals/T0}"
+      loaded="yes"
+    elif [ -f "$pane_path/.claude/terminals/T0/CLAUDE.md" ]; then
+      # cwd is a project root that HAS a T0 role file, but this pane is not
+      # inside it — the generic project CLAUDE.md loads instead.
+      project_root="$pane_path"
+      loaded="no"
+    else
+      continue  # Not a VNX T0-governed pane — skip (e.g. a plain client session).
+    fi
+
+    found_any=1
+    case " $seen_roots " in
+      *" $project_root "*) ;;
+      *) seen_roots="$seen_roots $project_root" ;;
+    esac
+
+    local cli="(idle)"
+    _t0_audit_active_cli "$pane_pid" && cli="running"
+
+    _t0_audit_row "$(basename "$project_root")" "T0" "$loaded" "$cli" "$pane_path"
+  done < <(tmux list-panes -a -F '#{pane_id} #{pane_current_path} #{pane_pid}' 2>/dev/null)
+
+  if [ "$found_any" -eq 0 ]; then
+    echo "(no live T0 sessions found)"
+  fi
+
+  # Cross-reference the project registry (~/.vnx/projects.json) so projects
+  # with a configured T0 role file but no live tmux session are still listed,
+  # instead of silently disappearing from the report.
+  local registry="$HOME/.vnx/projects.json"
+  if [ -f "$registry" ] && command -v python3 >/dev/null 2>&1; then
+    python3 - "$registry" "$seen_roots" <<'PYEOF'
+import json, os, sys
+
+registry_file, seen_raw = sys.argv[1], sys.argv[2]
+seen = set(seen_raw.split())
+
+try:
+    with open(registry_file) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+
+for p in data.get("projects", []):
+    root = p.get("path", "")
+    if not root or root in seen:
+        continue
+    role_file = os.path.join(root, ".claude", "terminals", "T0", "CLAUDE.md")
+    if os.path.isfile(role_file):
+        print("{:<22} {:<6} {:<9} {:<9} {:<55}".format(
+            os.path.basename(root), "T0", "n/a", "(not running)", root))
+PYEOF
+  fi
+}
+
+main "$@"

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -22,14 +22,32 @@
 
 set -uo pipefail
 
+# All descendant PIDs of $1 (the FULL process tree, not just direct children).
+# BFS over pgrep -P; process trees are acyclic so this always terminates.
+_t0_audit_descendants() {
+  local queue="$1" next child kids acc=""
+  while [ -n "$queue" ]; do
+    next=""
+    for child in $queue; do
+      kids="$(pgrep -P "$child" 2>/dev/null)"
+      [ -z "$kids" ] && continue
+      acc="$acc $kids"
+      next="$next $kids"
+    done
+    queue="$next"
+  done
+  printf '%s' "$acc"
+}
+
 # Detect whether a tmux pane has an active CLI (claude/codex/gemini/node) in
 # its process tree. Checked via `ps`, not tmux's `#{pane_current_command}`:
 # a running claude process can report its own version string (e.g. "2.1.201")
-# there instead of the literal binary name.
+# there instead of the literal binary name. Walks the whole descendant tree so
+# a CLI launched under an intermediate shell/wrapper is still detected.
 _t0_audit_active_cli() {
   local pane_pid="$1" pid comm
   [ -z "$pane_pid" ] && return 1
-  for pid in "$pane_pid" $(pgrep -P "$pane_pid" 2>/dev/null); do
+  for pid in "$pane_pid" $(_t0_audit_descendants "$pane_pid"); do
     comm="$(ps -o comm= -p "$pid" 2>/dev/null | tr -d ' ')"
     comm="${comm##*/}"
     case "$comm" in
@@ -55,7 +73,9 @@ main() {
   local found_any=0
   local seen_roots=""
 
-  while IFS=' ' read -r pane_id pane_path pane_pid; do
+  # pane_current_path is read LAST so an embedded space in the cwd is absorbed
+  # into pane_path by read's remainder rule, instead of shifting into pane_pid.
+  while IFS=' ' read -r pane_id pane_pid pane_path; do
     [ -z "$pane_id" ] && continue
 
     # Skip per-dispatch worker worktrees (tmux_interactive_dispatch.py checks
@@ -91,7 +111,7 @@ main() {
     _t0_audit_active_cli "$pane_pid" && cli="running"
 
     _t0_audit_row "$(basename "$project_root")" "T0" "$loaded" "$cli" "$pane_path"
-  done < <(tmux list-panes -a -F '#{pane_id} #{pane_current_path} #{pane_pid}' 2>/dev/null)
+  done < <(tmux list-panes -a -F '#{pane_id} #{pane_pid} #{pane_current_path}' 2>/dev/null)
 
   if [ "$found_any" -eq 0 ]; then
     echo "(no live T0 sessions found)"
@@ -111,8 +131,15 @@ seen = set(seen_raw.split())
 try:
     with open(registry_file) as f:
         data = json.load(f)
-except Exception:
-    sys.exit(0)
+except Exception as exc:
+    # Fail loud: a registry that exists but cannot be read/parsed is a real
+    # error — swallowing it as exit 0 would report a clean audit while the
+    # not-running-projects cross-reference was silently skipped.
+    print(
+        f"warning: could not read/parse T0 project registry {registry_file}: {exc}",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 for p in data.get("projects", []):
     root = p.get("path", "")


### PR DESCRIPTION
Horizon track: **t0-role-load-drift** (P1).

## Summary
`cmd_start`'s stale-session re-heal located the T0 pane by matching its cwd against `$terms_dir/T0` exactly. Once a pane's cwd drifts (tmux-continuum/resurrect respawns a bare `claude` on server restart, no cd/env), the filter matches nothing, the cd+relaunch is silently skipped, and `vnx start` reports "re-heal complete" without sending a keystroke — making the drift permanent. Compounding: the CLI-liveness check read `#{pane_current_command}`, which a live claude can report as its version string, misclassifying a healthy T0 as stale.

## Changes
- Pane discovery grabs the session's sole persistent pane (excluding the transient VNX-Queue popup) instead of filtering by cwd.
- CLI-liveness checked via `ps` against the pane's process tree instead of tmux's unreliable `pane_current_command`.
- `scripts/commands/t0_role_audit.sh` (new): per project, reports whether the T0 session's cwd would actually load `.claude/terminals/T0/CLAUDE.md`. Confirmed live: all four fleet projects run at project root, role file NOT loaded.

## Verification
Local CI + codex-gate on merge. `.claude/terminals/T0/CLAUDE.md` (+8), `scripts/commands/start.sh` (+38), `scripts/commands/t0_role_audit.sh` (+129).

🤖 Generated with [Claude Code](https://claude.com/claude-code)