### PR TITLE
fix(plan-gate): bounded single retry of a flaked panelist before abstain [TL-quorum]

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -50,10 +50,11 @@ _CLAUDE_PROVIDERS = {"claude"}
 # Full diverse-family assurance panel: (label, provider string, model_arg).
 # One panelist per provider family (Anthropic / Moonshot / Zhipu / DeepSeek / OpenAI) so a
 # plan is reviewed from five independent vantage points before any code is written.
-# NOTE: with the current fail-safe rule, a panelist that emits no verdict (a down proxy or an
-# uninstalled CLI) forces an unconditional REVISE. Keep every provider here runnable, and see
-# the `panel-quorum-fix` track for the retry/quorum/abstain rule that makes a large panel
-# robust to a single flake. glm-harness requires the local litellm proxy on :4141.
+# NOTE: a panelist that flakes (a down proxy, an uninstalled CLI, or an unparseable verdict) is
+# RETRIED once (VNX_PANEL_RETRY, see run_panel) and, if it still yields no readable verdict,
+# ABSTAINS as a non-scoring lane instead of vetoing — so a single down lane no longer forces a
+# REVISE (apply_panel_rule's liveness quorum). Keep every provider here runnable anyway; the
+# retry only rescues transient flakes. glm-harness requires the local litellm proxy on :4141.
 DEFAULT_PANEL: List[Dict[str, str]] = [
     {"label": "opus", "provider": "claude", "model_arg": "opus"},
     {"label": "kimi", "provider": "kimi", "model_arg": "kimi-k2-7-code"},
@@ -415,6 +416,49 @@ def _make_default_dispatcher(
     return _dispatch
 
 
+def _panel_retry_count() -> int:
+    """Extra attempts for a flaked panelist (``VNX_PANEL_RETRY``, default 1, clamped >= 0).
+
+    A panelist whose verdict is unparseable (parse_error) or that failed to dispatch is a
+    transient-flake suspect (the codex verdict-JSON flake, the glm parse flake). It is retried
+    up to this many times before it falls through to the abstain/non-scoring path — recovering
+    the flake without letting one down lane force a REVISE. A malformed value falls back to 1.
+    """
+    raw = os.environ.get("VNX_PANEL_RETRY", "").strip()
+    if not raw:
+        return 1
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return 1
+
+
+def _dispatch_one(
+    dispatcher: DispatcherFn, member: Dict[str, str], instruction: str, dispatch_id: str,
+) -> PanelistResult:
+    """Dispatch ONE panelist once and parse its verdict into a ``PanelistResult``.
+
+    Best-effort and non-raising: a dispatch / report-read failure returns a non-scoring result
+    (``dispatched=False``, ``error`` set); a returned report whose verdict block does not parse
+    returns ``parse_error=True``. Both outcomes are RETRYABLE by ``run_panel`` before they fall
+    through to the abstain path — a retry that itself errors just degrades to the same abstain.
+    """
+    try:
+        report_text = dispatcher(member["provider"], member["model_arg"], instruction, dispatch_id)
+    except Exception as exc:  # dispatch / report-read failure -> no verdict
+        return PanelistResult(
+            label=member["label"], provider=member["provider"],
+            dispatched=False, error=str(exc), report_path=dispatch_id,
+        )
+    parsed = parse_verdict(report_text)
+    return PanelistResult(
+        label=member["label"], provider=member["provider"],
+        verdict=parsed["verdict"], blocking_findings=parsed["blocking_findings"],
+        rationale=parsed["rationale"], parse_error=parsed["parse_error"],
+        dispatched=True, report_path=dispatch_id,
+    )
+
+
 def run_panel(
     doc_path: str | Path,
     *,
@@ -436,24 +480,22 @@ def run_panel(
     doc_text = Path(doc_path).read_text(encoding="utf-8")
     instruction = build_plan_review_instruction(doc_text, track_id)
 
+    retries = _panel_retry_count()
+
     results: List[PanelistResult] = []
     for member in panel:
-        did = f"plan-gate-{track_id}-{member['label']}-{uuid.uuid4().hex[:8]}"
-        try:
-            report_text = dispatcher(member["provider"], member["model_arg"], instruction, did)
-        except Exception as exc:  # dispatch / report-read failure -> no verdict
-            results.append(PanelistResult(
-                label=member["label"], provider=member["provider"],
-                dispatched=False, error=str(exc), report_path=did,
-            ))
-            continue
-        parsed = parse_verdict(report_text)
-        results.append(PanelistResult(
-            label=member["label"], provider=member["provider"],
-            verdict=parsed["verdict"], blocking_findings=parsed["blocking_findings"],
-            rationale=parsed["rationale"], parse_error=parsed["parse_error"],
-            dispatched=True, report_path=did,
-        ))
+        # One dispatch, plus up to `retries` retries when the lane flakes (a dispatch failure
+        # or an unparseable verdict). The first SCORING verdict wins and short-circuits; if a
+        # retry also flakes we keep its (still non-scoring) result, which then abstains via
+        # apply_panel_rule. Never more than `retries` extra attempts — each is a fresh governed
+        # dispatch id so the retry lands its own report -> receipt.
+        result: PanelistResult
+        for _ in range(retries + 1):
+            did = f"plan-gate-{track_id}-{member['label']}-{uuid.uuid4().hex[:8]}"
+            result = _dispatch_one(dispatcher, member, instruction, did)
+            if result.dispatched and not result.parse_error:
+                break  # readable verdict — no retry needed
+        results.append(result)
 
     summary = apply_panel_rule(results)
     return {

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -154,14 +154,12 @@ def _fake_dispatcher(verdict_by_provider):
 def test_run_panel_all_pass(tmp_path):
     doc = tmp_path / "plan.md"
     doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
-    disp = _fake_dispatcher({
-        "claude": '{"verdict": "pass"}',
-        "kimi": '{"verdict": "pass"}',
-        "glm-harness": '{"verdict": "pass"}',
-    })
+    # every default-panel provider passes -> PASS across the full family panel (panel grew to
+    # five families in #991, so map every default provider rather than a hard-coded three).
+    disp = _fake_dispatcher({m["provider"]: '{"verdict": "pass"}' for m in pgp.DEFAULT_PANEL})
     out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=disp)
     assert out["decision"] == "PASS"
-    assert len(out["panelists"]) == 3
+    assert len(out["panelists"]) == len(pgp.DEFAULT_PANEL)
 
 
 def test_run_panel_one_block_revises(tmp_path):
@@ -192,6 +190,159 @@ def test_run_panel_dispatch_exception_is_no_verdict(tmp_path):
     assert kimi["dispatched"] is False
     assert "kimi cli not installed" in kimi["error"]
     assert "non-scoring (abstained): kimi" in out["summary"]["rationale"]
+
+
+# --------------------------------------------------------------------------
+# panel-quorum-fix: bounded single retry of a flaked panelist (VNX_PANEL_RETRY)
+# in front of the (already-shipped) abstain/quorum rule.
+# --------------------------------------------------------------------------
+
+def test_panel_retry_count_default_is_one(monkeypatch):
+    monkeypatch.delenv("VNX_PANEL_RETRY", raising=False)
+    assert pgp._panel_retry_count() == 1
+
+
+def test_panel_retry_count_honors_env(monkeypatch):
+    monkeypatch.setenv("VNX_PANEL_RETRY", "3")
+    assert pgp._panel_retry_count() == 3
+    monkeypatch.setenv("VNX_PANEL_RETRY", "0")
+    assert pgp._panel_retry_count() == 0
+
+
+def test_panel_retry_count_malformed_falls_back_to_one(monkeypatch):
+    monkeypatch.setenv("VNX_PANEL_RETRY", "not-a-number")
+    assert pgp._panel_retry_count() == 1
+    monkeypatch.setenv("VNX_PANEL_RETRY", "-4")  # clamped to >= 0
+    assert pgp._panel_retry_count() == 0
+
+
+def test_run_panel_first_flake_then_success_recovers(tmp_path, monkeypatch):
+    # A panelist that flakes once (no verdict fence) then succeeds must recover to a SCORING
+    # verdict via the single retry — the codex verdict-JSON / glm parse flake case.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls = {"kimi": 0}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        if provider == "kimi":
+            calls["kimi"] += 1
+            if calls["kimi"] == 1:
+                return "# review\n\nno verdict fence emitted this time\n"  # first attempt flakes
+            return _report('{"verdict": "pass"}')  # retry succeeds
+        return _report('{"verdict": "pass"}')
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert calls["kimi"] == 2  # one dispatch + one retry
+    kimi = next(p for p in out["panelists"] if p["label"] == "kimi")
+    assert kimi["parse_error"] is False  # retry recovered a readable verdict
+    assert kimi["verdict"] == "pass"
+    assert out["decision"] == "PASS"
+
+
+def test_run_panel_first_dispatch_error_then_success_recovers(tmp_path, monkeypatch):
+    # A dispatch that raises on the first attempt (down proxy) then succeeds must also recover.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls = {"glm-harness": 0}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        if provider == "glm-harness":
+            calls["glm-harness"] += 1
+            if calls["glm-harness"] == 1:
+                raise RuntimeError("litellm proxy on :4141 not up yet")
+            return _report('{"verdict": "pass"}')
+        return _report('{"verdict": "pass"}')
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert calls["glm-harness"] == 2
+    glm = next(p for p in out["panelists"] if p["provider"] == "glm-harness")
+    assert glm["dispatched"] is True
+    assert glm["parse_error"] is False
+    assert out["decision"] == "PASS"
+
+
+def test_run_panel_persistent_flake_still_abstains(tmp_path, monkeypatch):
+    # A lane that flakes on every attempt exhausts the retry budget and abstains (non-scoring);
+    # the two readable PASS voices still meet quorum -> PASS. The retry must not raise.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls = {"glm-harness": 0}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        if provider == "glm-harness":
+            calls["glm-harness"] += 1
+            return "# review\n\nstill no verdict fence\n"  # flakes every attempt
+        return _report('{"verdict": "pass"}')
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert calls["glm-harness"] == 2  # initial + one retry, then it gives up
+    glm = next(p for p in out["panelists"] if p["provider"] == "glm-harness")
+    assert glm["parse_error"] is True
+    assert glm["verdict"] != "pass"  # a flaked lane is never counted as a pass
+    assert out["decision"] == "PASS"
+    assert "non-scoring (abstained): glm-5.2-harness" in out["summary"]["rationale"]
+
+
+def test_run_panel_retry_count_is_honored_and_bounded(tmp_path, monkeypatch):
+    # VNX_PANEL_RETRY=2 -> at most 1 initial + 2 retries = 3 attempts, never more.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "2")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls = {"kimi": 0}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        if provider == "kimi":
+            calls["kimi"] += 1
+            raise RuntimeError("kimi cli down")  # dispatch failure every attempt
+        return _report('{"verdict": "pass"}')
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert calls["kimi"] == 3  # bounded by the configured budget
+    kimi = next(p for p in out["panelists"] if p["label"] == "kimi")
+    assert kimi["dispatched"] is False
+    assert out["decision"] == "PASS"  # two readable PASS voices meet quorum
+
+
+def test_run_panel_retry_zero_disables_retry(tmp_path, monkeypatch):
+    # VNX_PANEL_RETRY=0 -> exactly one attempt per panelist, no retry.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "0")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls = {"kimi": 0}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        if provider == "kimi":
+            calls["kimi"] += 1
+            return "# review\n\nno verdict fence\n"  # would-be retryable flake
+        return _report('{"verdict": "pass"}')
+
+    pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert calls["kimi"] == 1  # retry disabled -> single attempt
+
+
+def test_run_panel_success_first_try_does_not_retry(tmp_path, monkeypatch):
+    # A clean first-try verdict must NOT trigger a retry even with a generous budget.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "3")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    calls: dict = {}
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        calls[provider] = calls.get(provider, 0) + 1
+        return _report('{"verdict": "pass"}')
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert out["decision"] == "PASS"
+    assert all(n == 1 for n in calls.values())  # every lane dispatched exactly once
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
Horizon track: **post10-panel-quorum-fix** (P1). Directly mitigates the glm/codex verdict-JSON flake that forces spurious REVISE.

## Summary
A single panelist emitting unparseable JSON (glm's known empty-flake, codex's empty verdict) forced the whole plan-gate to REVISE. This adds a bounded single retry of a flaked panelist, then abstains that seat rather than counting it as a REVISE vote — so one flake no longer blocks a legitimate PASS.

## Changes
- `scripts/lib/plan_gate_panel.py`: bounded single retry on parse-failure, then abstain + quorum over the remaining valid votes.

## Verification
Local CI + codex-gate on merge. Tests: `tests/test_plan_gate_panel.py` (+163).

🤖 Generated with [Claude Code](https://claude.com/claude-code)