### PR TITLE
fix(state): remove repo-local VNX_STATE_DIR pin from T0 role/template/skill/docs [fase 0]

### DIFF
--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -158,13 +158,15 @@ When uncertain, use this order:
 Before the first promote of any new feature chain, check all target terminals for stale leases in runtime_coordination.db. The dispatcher fails closed on expired-but-uncleaned leases.
 
 ```bash
-export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+# VNX paths (VNX_STATE_DIR / VNX_DATA_DIR / VNX_DISPATCH_DIR) resolve centrally
+# via the vnx runtime — do NOT hardcode .vnx-data/ literals here. A repo-local
+# pin forks state from the central store (~/.vnx-data/<project>) = split-brain.
 # Check each terminal
 for T in T1 T2 T3; do
   python3 scripts/runtime_core_cli.py check-terminal --terminal $T --dispatch-id <new-dispatch-id>
 done
 # If any shows lease_expired_not_cleaned, find generation and release:
-sqlite3 .vnx-data/state/runtime_coordination.db "SELECT * FROM terminal_leases WHERE terminal_id='<T>';"
+sqlite3 "$VNX_STATE_DIR/runtime_coordination.db" "SELECT * FROM terminal_leases WHERE terminal_id='<T>';"
 python3 scripts/runtime_core_cli.py release-on-failure --terminal <T> --dispatch-id <old-dispatch> --generation <gen> --reason "stale_lease_cleanup"
 ```
 

--- a/docs/operations/TMUX_SPAWN_LANE.md
+++ b/docs/operations/TMUX_SPAWN_LANE.md
@@ -20,7 +20,9 @@ This lane runs Claude workers on the **subscription** (interactive `claude`, nev
 ## Canonical command
 
 ```bash
-export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+# VNX paths (VNX_STATE_DIR / VNX_DATA_DIR / VNX_DISPATCH_DIR) resolve centrally
+# via the vnx runtime — do NOT hardcode .vnx-data/ literals here. A repo-local
+# pin forks state from the central store (~/.vnx-data/<project>) = split-brain.
 
 python3 scripts/lib/tmux_interactive_dispatch.py \
   --dispatch-id "$(date +%Y%m%d-%H%M%S)-<slug>" \

--- a/scripts/build_decisions_digest.py
+++ b/scripts/build_decisions_digest.py
@@ -3,11 +3,13 @@
 1.0 scope: progress-only path. D3-D5 collectors wired in 1.0.1.
 
 Usage:
-  VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data python3 scripts/build_decisions_digest.py
+  python3 scripts/build_decisions_digest.py
 
 Env vars:
-  VNX_STATE_DIR  — state directory (default: .vnx-data/state)
-  VNX_DATA_DIR   — data root directory (default: .vnx-data)
+  VNX_STATE_DIR  — state directory (default: resolved centrally via vnx_paths →
+                   ~/.vnx-data/<project>/state; do not pin repo-local)
+  VNX_DATA_DIR   — data root directory (default: resolved centrally via vnx_paths →
+                   ~/.vnx-data/<project>)
 """
 
 from __future__ import annotations

--- a/skills/t0-orchestrator/SKILL.md
+++ b/skills/t0-orchestrator/SKILL.md
@@ -442,7 +442,9 @@ For any feature work (code edit + PR + tests), dispatches to T1/T2/T3 MUST go vi
 #### Canonical dispatch command
 
 ```bash
-export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+# VNX paths (VNX_STATE_DIR / VNX_DATA_DIR / VNX_DISPATCH_DIR) resolve centrally
+# via the vnx runtime — do NOT hardcode .vnx-data/ literals here. A repo-local
+# pin forks state from the central store (~/.vnx-data/<project>) = split-brain.
 
 python3 scripts/lib/subprocess_dispatch.py \
   --terminal-id T1 \

--- a/templates/terminals/T0.md
+++ b/templates/terminals/T0.md
@@ -40,7 +40,9 @@ For any feature work (code edit + PR + tests), dispatches to T1/T2/T3 MUST go vi
 ### Canonical dispatch command
 
 ```bash
-export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches
+# VNX paths (VNX_STATE_DIR / VNX_DATA_DIR / VNX_DISPATCH_DIR) resolve centrally
+# via the vnx runtime — do NOT hardcode .vnx-data/ literals here. A repo-local
+# pin forks state from the central store (~/.vnx-data/<project>) = split-brain.
 
 python3 $VNX_HOME/scripts/lib/subprocess_dispatch.py \
   --terminal-id T1 \


### PR DESCRIPTION
Horizon track: **fabric-hardening-phase0** (P0). Correctness bug — state split-brain source.

## Summary
The `export VNX_STATE_DIR=.vnx-data/state VNX_DATA_DIR=.vnx-data VNX_DISPATCH_DIR=.vnx-data/dispatches` preamble in the T0 role file, its shipped template, the t0-orchestrator skill, the tmux-spawn-lane doc, and the decisions-digest usage string pinned state to a repo-local relative path. In a central-mode install the canonical dirs live under `~/.vnx-data/<project>/`; a repo-local pin silently overrides central resolution and forks the audit trail = **state split-brain**.

## Changes
- Removed the hardcoded repo-local export from 5 locations, replaced with a comment explaining central resolution (so it isn't re-added).
- Role-file lease-check snippet now reads `$VNX_STATE_DIR/runtime_coordination.db` instead of the `.vnx-data/state/` literal.
- `vnx` already resolves these dirs centrally when unset (`bin/vnx:120`, `vnx_paths.py:381`), so removal lets the canonical resolution stand in both the vnx-managed shell and a bare shell.

## Verification
- `git grep` confirms no repo-local `VNX_STATE_DIR=.vnx-data/state` remains in tracked non-worktree files.
- Verified sourcing `vnx_paths.sh` with env unset resolves `VNX_STATE_DIR=~/.vnx-data/vnx-dev/state` (central).
- Local CI + codex-gate on merge.

## Open Items
Durable guard: the footgun survived because the CI legacy-path-gate only scans `scripts/`. Extending it to cover role/template/skill/docs is folded into the fabric-audit work (same P0 track).

🤖 Generated with [Claude Code](https://claude.com/claude-code)