### PR TITLE
feat(fabric): vnx fabric-audit — phase-0 fabric hardening check [P0]

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -77,6 +77,7 @@ jobs:
             "$VNX_HOME/tests/test_runtime_adapter_certification.py" \
             "$VNX_HOME/tests/test_central_mode_path_gate.py" \
             "$VNX_HOME/tests/test_central_mode_path_resolution.py" \
+            "$VNX_HOME/tests/test_fabric_audit.py" \
             -p no:cacheprovider \
             --basetemp=/tmp/vnx_pytest_safe
 

--- a/bin/vnx
+++ b/bin/vnx
@@ -277,6 +277,7 @@ Commands:
   start --last           Start with last-used startup configuration
   stop               Stop VNX tmux session and orchestration processes
   doctor             Validate layout, dependencies, and path hygiene
+  fabric-audit       Audit the governance fabric: no shared-store fork, per-project ledgers, hash-chain integrity
   smoke              Run one-shot local receipt pipeline smoke test
   cost-report        Aggregate model usage + estimated cost from receipts
   package-check      Fail if runtime artifacts exist inside dist
@@ -2073,6 +2074,9 @@ main() {
       ;;
     doctor)
       cmd_doctor "$@"
+      ;;
+    fabric-audit)
+      python3 "$VNX_HOME/scripts/fabric_audit.py" "$@"
       ;;
     smoke)
       cmd_smoke "$@"

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -90,9 +90,17 @@ def _load_project_ids(registry_file: Path) -> list[tuple[str, str]]:
     else falls back to the registry name — so the audit still names the project.
     """
     out: list[tuple[str, str]] = []
+    if not registry_file.exists():
+        return out  # no registry is legitimate — nothing to enumerate
     try:
         data = json.loads(registry_file.read_text(encoding="utf-8"))
-    except Exception:
+    except (OSError, json.JSONDecodeError) as exc:
+        # A registry that EXISTS but is unreadable/malformed is a real fault:
+        # surface it instead of silently auditing zero projects.
+        print(
+            f"fabric-audit: WARNING — cannot read project registry {registry_file}: {exc}",
+            file=sys.stderr,
+        )
         return out
     for p in data.get("projects", []):
         path = p.get("path", "") or ""
@@ -100,12 +108,17 @@ def _load_project_ids(registry_file: Path) -> list[tuple[str, str]]:
         pid = name
         if path:
             id_file = Path(path) / ".vnx-project-id"
-            try:
-                first = id_file.read_text(encoding="utf-8").splitlines()[0].strip()
-                if first:
-                    pid = first
-            except Exception:
-                pass
+            if id_file.exists():
+                try:
+                    first = id_file.read_text(encoding="utf-8").splitlines()[0].strip()
+                    if first:
+                        pid = first
+                except (OSError, IndexError) as exc:
+                    print(
+                        f"fabric-audit: WARNING — cannot read {id_file}: {exc}; "
+                        f"falling back to registry name {name!r}",
+                        file=sys.stderr,
+                    )
         if pid:
             out.append((pid, path))
     return out

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -1,0 +1,283 @@
+#!/usr/bin/env python3
+"""fabric_audit.py — Phase-0 fabric hardening audit (ADR-028 §6 phase 0).
+
+Answers one question before a T0 session trusts the governance fabric:
+is the audit trail whole, per-project, and un-forked?
+
+Checks (each GREEN / RED / SKIP):
+
+  A. Legacy shared state at the data-home root.
+     A bare `<data_home>/state/` (a dir literally named "state", not a
+     project-id) holding *.db files is the split-brain signature: state that
+     should live under `<data_home>/<project-id>/state/` was written to a
+     shared, project-agnostic location instead. RED when found, with the
+     newest *.db mtime so an operator can tell a stale relic (safe to retire)
+     from a live writer (must be traced first).
+
+  B. Per-project stores are canonical.
+     Every registered project should own `<data_home>/<project-id>/state/`.
+     A project missing its central store is either unmigrated or resolving
+     somewhere else. RED when a registered project's central state is absent.
+
+  C. Receipt hash-chain integrity (ADR-023).
+     verify_chain() on each project's `state/t0_receipts.ndjson`. "unchained"
+     (chaining not yet enabled) is reported OK — ADR-023 is PARTIAL by design.
+     "verified" is GREEN; "broken" (tamper / partial chain) is RED.
+
+Exit 0 when no RED finding, 1 otherwise. `--json` for scripting.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+# Reuse the canonical chain verifier rather than reimplementing it.
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+try:
+    from ndjson_hash_chain import verify_chain  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    verify_chain = None  # type: ignore
+
+# Directory names at the data-home root that are shared/legacy by construction,
+# never a project-id. `state` holding *.db is the hard split-brain signal.
+SHARED_ROOT_DIRS = ("state", "events", "locks")
+
+# A bare shared store written within this many days is an ACTIVE fork (RED);
+# older than this it is a stale relic = cleanup debt (WARN, does not block).
+ACTIVE_FORK_STALE_DAYS = 7
+
+
+@dataclass
+class CheckResult:
+    key: str
+    title: str
+    status: str  # "GREEN" | "RED" | "SKIP"
+    detail: str
+    findings: list = field(default_factory=list)
+
+
+def _newest_db_mtime(directory: Path) -> Optional[float]:
+    """Newest mtime among *.db files directly in `directory` (non-recursive)."""
+    newest: Optional[float] = None
+    try:
+        for entry in directory.iterdir():
+            if entry.suffix == ".db" and entry.is_file():
+                m = entry.stat().st_mtime
+                if newest is None or m > newest:
+                    newest = m
+    except OSError:
+        return None
+    return newest
+
+
+def _fmt_ts(ts: Optional[float]) -> str:
+    if ts is None:
+        return "n/a"
+    import datetime
+
+    return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
+
+
+def _load_project_ids(registry_file: Path) -> list[tuple[str, str]]:
+    """Return [(project_id, project_path)] for registered projects.
+
+    project_id comes from `<path>/.vnx-project-id` (first line) when readable,
+    else falls back to the registry name — so the audit still names the project.
+    """
+    out: list[tuple[str, str]] = []
+    try:
+        data = json.loads(registry_file.read_text(encoding="utf-8"))
+    except Exception:
+        return out
+    for p in data.get("projects", []):
+        path = p.get("path", "") or ""
+        name = p.get("name") or p.get("id") or ""
+        pid = name
+        if path:
+            id_file = Path(path) / ".vnx-project-id"
+            try:
+                first = id_file.read_text(encoding="utf-8").splitlines()[0].strip()
+                if first:
+                    pid = first
+            except Exception:
+                pass
+        if pid:
+            out.append((pid, path))
+    return out
+
+
+def check_shared_root_state(data_home: Path) -> CheckResult:
+    findings = []
+    bare_state = data_home / "state"
+    if bare_state.is_dir():
+        newest = _newest_db_mtime(bare_state)
+        db_count = sum(1 for e in bare_state.iterdir() if e.suffix == ".db") if bare_state.exists() else 0
+        if db_count > 0:
+            findings.append({
+                "path": str(bare_state),
+                "db_count": db_count,
+                "newest_db_mtime": _fmt_ts(newest),
+            })
+    other_shared = []
+    for name in SHARED_ROOT_DIRS:
+        if name == "state":
+            continue
+        d = data_home / name
+        if d.is_dir() and any(d.iterdir()):
+            other_shared.append(name)
+    if findings:
+        import time
+
+        newest = _newest_db_mtime(bare_state)
+        age_days = (time.time() - newest) / 86400 if newest else None
+        active = age_days is not None and age_days < ACTIVE_FORK_STALE_DAYS
+        status = "RED" if active else "WARN"
+        kind = (
+            "ACTIVE fork — a live writer is still resolving to the shared store"
+            if active
+            else f"stale relic ({int(age_days)}d old) — cleanup debt, retire when convenient"
+        )
+        detail = (
+            f"legacy shared store {findings[0]['path']} "
+            f"({findings[0]['db_count']} *.db, newest write {findings[0]['newest_db_mtime']}) — {kind}; "
+            f"retire under <data_home>/<project-id>/state after confirming no live writer"
+        )
+        if other_shared:
+            detail += f"; also shared root dirs: {', '.join(other_shared)}"
+        return CheckResult("A", "Legacy shared state at data root", status, detail, findings)
+    if other_shared:
+        return CheckResult(
+            "A", "Legacy shared state at data root", "GREEN",
+            f"no bare state/*.db; shared root dirs present but empty-ish: {', '.join(other_shared)}",
+        )
+    return CheckResult("A", "Legacy shared state at data root", "GREEN", "no bare shared state store")
+
+
+def check_per_project_stores(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
+    if not projects:
+        return CheckResult("B", "Per-project stores canonical", "SKIP", "no registered projects")
+    missing = []
+    ok = 0
+    for pid, _path in projects:
+        state_dir = data_home / pid / "state"
+        if state_dir.is_dir():
+            ok += 1
+        else:
+            missing.append(pid)
+    if missing:
+        return CheckResult(
+            "B", "Per-project stores canonical", "RED",
+            f"{ok}/{len(projects)} projects have central state; missing: {', '.join(missing)}",
+            [{"missing_project": m} for m in missing],
+        )
+    return CheckResult(
+        "B", "Per-project stores canonical", "GREEN",
+        f"{ok}/{len(projects)} registered projects have <data_home>/<pid>/state",
+    )
+
+
+def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
+    if verify_chain is None:
+        return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "verify_chain unavailable")
+    if not projects:
+        return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "no registered projects")
+    broken = []
+    verified = 0
+    unchained = 0
+    checked = 0
+    for pid, _path in projects:
+        ledger = data_home / pid / "state" / "t0_receipts.ndjson"
+        if not ledger.exists():
+            continue
+        checked += 1
+        try:
+            is_valid, violations, status = verify_chain(ledger)
+        except Exception as exc:
+            broken.append({"project": pid, "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        if status == "verified":
+            verified += 1
+        elif status == "unchained":
+            unchained += 1
+        else:  # broken
+            broken.append({"project": pid, "violations": len(violations), "status": status})
+    if broken:
+        names = ", ".join(b["project"] for b in broken)
+        return CheckResult(
+            "C", "Receipt hash-chain integrity", "RED",
+            f"broken chain in: {names} (verified={verified}, unchained={unchained})",
+            broken,
+        )
+    if checked == 0:
+        return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "no t0_receipts.ndjson found")
+    return CheckResult(
+        "C", "Receipt hash-chain integrity", "GREEN",
+        f"{checked} ledgers ok (verified={verified}, unchained={unchained} — ADR-023 partial, not an error)",
+    )
+
+
+def run_audit(data_home: Path, registry_file: Path) -> list[CheckResult]:
+    projects = _load_project_ids(registry_file)
+    return [
+        check_shared_root_state(data_home),
+        check_per_project_stores(data_home, projects),
+        check_hash_chains(data_home, projects),
+    ]
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="VNX fabric-audit — phase-0 fabric hardening check")
+    parser.add_argument(
+        "--data-home",
+        default=os.environ.get("VNX_DATA_HOME") or str(Path.home() / ".vnx-data"),
+        help="Central data-home root (default: $VNX_DATA_HOME or ~/.vnx-data)",
+    )
+    parser.add_argument(
+        "--registry",
+        default=str(Path.home() / ".vnx" / "projects.json"),
+        help="Project registry JSON (default: ~/.vnx/projects.json)",
+    )
+    parser.add_argument("--json", action="store_true", help="Emit JSON")
+    args = parser.parse_args(argv)
+
+    data_home = Path(args.data_home).expanduser()
+    registry_file = Path(args.registry).expanduser()
+    results = run_audit(data_home, registry_file)
+
+    red = [r for r in results if r.status == "RED"]
+    warn = [r for r in results if r.status == "WARN"]
+    overall = "RED" if red else ("GREEN-WITH-WARN" if warn else "GREEN")
+
+    if args.json:
+        print(json.dumps({
+            "overall": overall,
+            "data_home": str(data_home),
+            "checks": [
+                {"key": r.key, "title": r.title, "status": r.status,
+                 "detail": r.detail, "findings": r.findings}
+                for r in results
+            ],
+        }, indent=2))
+    else:
+        print(f"VNX fabric-audit — data-home {data_home}")
+        for r in results:
+            dot = {"GREEN": "[ok]  ", "RED": "[RED] ", "WARN": "[warn]", "SKIP": "[--]  "}[r.status]
+            print(f"  {dot} [{r.key}] {r.title}: {r.detail}")
+        summary = f"OVERALL: {overall}"
+        if red:
+            summary += f" ({len(red)} blocking finding{'s' if len(red) != 1 else ''})"
+        elif warn:
+            summary += f" ({len(warn)} warning{'s' if len(warn) != 1 else ''} — non-blocking cleanup debt)"
+        print(summary)
+
+    # WARN is surfaced but does not block a T0 session; only RED fails.
+    return 1 if red else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
 import sys
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -46,6 +47,10 @@ except Exception:  # pragma: no cover - import guard
 # Directory names at the data-home root that are shared/legacy by construction,
 # never a project-id. `state` holding *.db is the hard split-brain signal.
 SHARED_ROOT_DIRS = ("state", "events", "locks")
+
+# A resolved project-id is used as a path component under <data_home>; reject
+# anything that could traverse or is otherwise not a plain id.
+SAFE_PROJECT_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]*$")
 
 # A bare shared store written within this many days is an ACTIVE fork (RED);
 # older than this it is a stale relic = cleanup debt (WARN, does not block).
@@ -83,25 +88,25 @@ def _fmt_ts(ts: Optional[float]) -> str:
     return datetime.datetime.fromtimestamp(ts).strftime("%Y-%m-%d %H:%M")
 
 
-def _load_project_ids(registry_file: Path) -> list[tuple[str, str]]:
-    """Return [(project_id, project_path)] for registered projects.
+def _load_project_ids(registry_file: Path) -> tuple[list[tuple[str, str]], Optional[str]]:
+    """Return ``([(project_id, project_path)], registry_error)``.
 
-    project_id comes from `<path>/.vnx-project-id` (first line) when readable,
-    else falls back to the registry name — so the audit still names the project.
+    ``registry_error`` is a message when the registry EXISTS but is unreadable
+    or malformed — the caller turns that into a RED finding so the audit never
+    reports clean while it was actually blind to the project set. A registry
+    that simply does not exist yields ``([], None)`` (legitimate).
+
+    project_id comes from ``<path>/.vnx-project-id`` (first line) when readable,
+    else falls back to the registry name. A resolved id that is not a safe path
+    component is skipped with a warning (traversal guard).
     """
     out: list[tuple[str, str]] = []
     if not registry_file.exists():
-        return out  # no registry is legitimate — nothing to enumerate
+        return out, None
     try:
         data = json.loads(registry_file.read_text(encoding="utf-8"))
     except (OSError, json.JSONDecodeError) as exc:
-        # A registry that EXISTS but is unreadable/malformed is a real fault:
-        # surface it instead of silently auditing zero projects.
-        print(
-            f"fabric-audit: WARNING — cannot read project registry {registry_file}: {exc}",
-            file=sys.stderr,
-        )
-        return out
+        return out, f"cannot read project registry {registry_file}: {exc}"
     for p in data.get("projects", []):
         path = p.get("path", "") or ""
         name = p.get("name") or p.get("id") or ""
@@ -119,9 +124,17 @@ def _load_project_ids(registry_file: Path) -> list[tuple[str, str]]:
                         f"falling back to registry name {name!r}",
                         file=sys.stderr,
                     )
-        if pid:
-            out.append((pid, path))
-    return out
+        if not pid:
+            continue
+        if "/" in pid or ".." in pid or not SAFE_PROJECT_ID.match(pid):
+            print(
+                f"fabric-audit: WARNING — skipping project with unsafe id {pid!r} "
+                f"(from {path or 'registry'}) — not used as a path component",
+                file=sys.stderr,
+            )
+            continue
+        out.append((pid, path))
+    return out, None
 
 
 def check_shared_root_state(data_home: Path) -> CheckResult:
@@ -171,7 +184,17 @@ def check_shared_root_state(data_home: Path) -> CheckResult:
     return CheckResult("A", "Legacy shared state at data root", "GREEN", "no bare shared state store")
 
 
-def check_per_project_stores(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
+def check_per_project_stores(
+    data_home: Path, projects: list[tuple[str, str]], registry_error: Optional[str] = None
+) -> CheckResult:
+    if registry_error:
+        # A registry we could not read must never read as clean — the audit
+        # was blind to the project set, so it cannot vouch for the stores.
+        return CheckResult(
+            "B", "Per-project stores canonical", "RED",
+            f"project registry unreadable — cannot verify per-project stores: {registry_error}",
+            [{"registry_error": registry_error}],
+        )
     if not projects:
         return CheckResult("B", "Per-project stores canonical", "SKIP", "no registered projects")
     missing = []
@@ -196,7 +219,12 @@ def check_per_project_stores(data_home: Path, projects: list[tuple[str, str]]) -
 
 def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
     if verify_chain is None:
-        return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "verify_chain unavailable")
+        # The integrity verifier failing to import is itself a problem — the
+        # audit cannot vouch for chain integrity, so surface it (not a silent SKIP).
+        return CheckResult(
+            "C", "Receipt hash-chain integrity", "WARN",
+            "integrity verifier (ndjson_hash_chain.verify_chain) could not be imported — chains NOT checked",
+        )
     if not projects:
         return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "no registered projects")
     broken = []
@@ -235,10 +263,10 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
 
 
 def run_audit(data_home: Path, registry_file: Path) -> list[CheckResult]:
-    projects = _load_project_ids(registry_file)
+    projects, registry_error = _load_project_ids(registry_file)
     return [
         check_shared_root_state(data_home),
-        check_per_project_stores(data_home, projects),
+        check_per_project_stores(data_home, projects, registry_error),
         check_hash_chains(data_home, projects),
     ]
 

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -61,7 +61,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "start", "stop", "restart", "jump", "ps", "cleanup",
     "new-worktree", "finish-worktree", "worktree-start", "worktree-stop",
     "worktree-refresh", "worktree-status", "merge-preflight",
-    "smoke", "package-check",
+    "smoke", "package-check", "fabric-audit",
     "dispatch", "gate", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",
     "pool", "permission",

--- a/tests/test_fabric_audit.py
+++ b/tests/test_fabric_audit.py
@@ -84,6 +84,37 @@ def test_no_projects_is_skip(tmp_path):
     assert r.status == "SKIP"
 
 
+def test_unreadable_registry_makes_check_b_red(tmp_path):
+    r = fa.check_per_project_stores(tmp_path, [], registry_error="cannot read registry: boom")
+    assert r.status == "RED"
+    assert "unreadable" in r.detail
+
+
+def test_malformed_registry_returns_error_not_silent_empty(tmp_path):
+    reg = tmp_path / "projects.json"
+    reg.write_text("{not valid json", encoding="utf-8")
+    projects, err = fa._load_project_ids(reg)
+    assert projects == []
+    assert err is not None  # surfaced, not silently swallowed
+
+
+def test_missing_registry_is_not_an_error(tmp_path):
+    projects, err = fa._load_project_ids(tmp_path / "does-not-exist.json")
+    assert projects == []
+    assert err is None
+
+
+def test_unsafe_project_id_is_skipped(tmp_path):
+    proj = tmp_path / "repo"
+    proj.mkdir()
+    (proj / ".vnx-project-id").write_text("../escape\n", encoding="utf-8")
+    reg = tmp_path / "projects.json"
+    reg.write_text(json.dumps({"projects": [{"name": "repo", "path": str(proj)}]}), encoding="utf-8")
+    projects, err = fa._load_project_ids(reg)
+    assert projects == []  # traversal id skipped
+    assert err is None
+
+
 # ── Check C: hash-chain integrity ───────────────────────────────────────────
 
 def test_unchained_ledger_is_green(tmp_path):
@@ -130,7 +161,8 @@ def test_run_audit_resolves_project_id_from_file(tmp_path):
     data_home.mkdir()
     reg = _registry(tmp_path, [("vnx-dev", "vnx-orchestration")])
     _mk_project(data_home, "vnx-dev")  # store keyed by the id, not the registry name
-    b = fa.check_per_project_stores(data_home, fa._load_project_ids(reg))
+    projects, err = fa._load_project_ids(reg)
+    b = fa.check_per_project_stores(data_home, projects, err)
     assert b.status == "GREEN"
 
 

--- a/tests/test_fabric_audit.py
+++ b/tests/test_fabric_audit.py
@@ -1,0 +1,147 @@
+"""Tests for scripts/fabric_audit.py — phase-0 fabric hardening audit (ADR-028)."""
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+
+import fabric_audit as fa  # noqa: E402
+
+
+def _mk_project(data_home: Path, pid: str) -> None:
+    (data_home / pid / "state").mkdir(parents=True, exist_ok=True)
+
+
+def _registry(tmp_path: Path, projects: list[tuple[str, str]]) -> Path:
+    """Write a registry JSON + .vnx-project-id per project; return registry path."""
+    entries = []
+    for pid, name in projects:
+        proj_root = tmp_path / "repos" / name
+        proj_root.mkdir(parents=True, exist_ok=True)
+        (proj_root / ".vnx-project-id").write_text(pid + "\n", encoding="utf-8")
+        entries.append({"name": name, "path": str(proj_root)})
+    reg = tmp_path / "projects.json"
+    reg.write_text(json.dumps({"projects": entries}), encoding="utf-8")
+    return reg
+
+
+# ── Check A: legacy shared state ────────────────────────────────────────────
+
+def test_no_bare_state_is_green(tmp_path):
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "GREEN"
+
+
+def test_active_bare_state_fork_is_red(tmp_path):
+    bare = tmp_path / "state"
+    bare.mkdir()
+    (bare / "runtime_coordination.db").write_bytes(b"x")  # fresh mtime = now
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "RED"
+    assert "ACTIVE fork" in r.detail
+
+
+def test_stale_bare_state_relic_is_warn(tmp_path):
+    bare = tmp_path / "state"
+    bare.mkdir()
+    db = bare / "quality_intelligence.db"
+    db.write_bytes(b"x")
+    old = time.time() - (fa.ACTIVE_FORK_STALE_DAYS + 10) * 86400
+    os.utime(db, (old, old))
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "WARN"
+    assert "stale relic" in r.detail
+
+
+def test_bare_state_without_db_is_green(tmp_path):
+    (tmp_path / "state").mkdir()  # empty dir, no *.db
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "GREEN"
+
+
+# ── Check B: per-project stores ─────────────────────────────────────────────
+
+def test_all_project_stores_present_is_green(tmp_path):
+    _mk_project(tmp_path, "vnx-dev")
+    _mk_project(tmp_path, "seo")
+    r = fa.check_per_project_stores(tmp_path, [("vnx-dev", ""), ("seo", "")])
+    assert r.status == "GREEN"
+
+
+def test_missing_project_store_is_red(tmp_path):
+    _mk_project(tmp_path, "vnx-dev")
+    r = fa.check_per_project_stores(tmp_path, [("vnx-dev", ""), ("ghost", "")])
+    assert r.status == "RED"
+    assert "ghost" in r.detail
+
+
+def test_no_projects_is_skip(tmp_path):
+    r = fa.check_per_project_stores(tmp_path, [])
+    assert r.status == "SKIP"
+
+
+# ── Check C: hash-chain integrity ───────────────────────────────────────────
+
+def test_unchained_ledger_is_green(tmp_path):
+    _mk_project(tmp_path, "vnx-dev")
+    ledger = tmp_path / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.write_text('{"a":1}\n{"a":2}\n', encoding="utf-8")  # no prev_hash = unchained
+    r = fa.check_hash_chains(tmp_path, [("vnx-dev", "")])
+    assert r.status == "GREEN"
+
+
+def test_partial_chain_ledger_is_red(tmp_path):
+    _mk_project(tmp_path, "vnx-dev")
+    ledger = tmp_path / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    # one entry chained, one not = partially chained = broken per verify_chain.
+    genesis = "0" * 64
+    ledger.write_text(
+        json.dumps({"a": 1, "prev_hash": genesis}) + "\n" + json.dumps({"a": 2}) + "\n",
+        encoding="utf-8",
+    )
+    r = fa.check_hash_chains(tmp_path, [("vnx-dev", "")])
+    assert r.status == "RED"
+
+
+def test_no_ledger_is_skip(tmp_path):
+    _mk_project(tmp_path, "vnx-dev")
+    r = fa.check_hash_chains(tmp_path, [("vnx-dev", "")])
+    assert r.status == "SKIP"
+
+
+# ── Integration: run_audit + project-id resolution ──────────────────────────
+
+def test_run_audit_clean_fabric_all_green(tmp_path):
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    reg = _registry(tmp_path, [("vnx-dev", "vnx-orchestration")])
+    _mk_project(data_home, "vnx-dev")
+    results = fa.run_audit(data_home, reg)
+    assert all(r.status in ("GREEN", "SKIP") for r in results)
+
+
+def test_run_audit_resolves_project_id_from_file(tmp_path):
+    """Registry name != project-id; the audit must resolve the id from .vnx-project-id."""
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    reg = _registry(tmp_path, [("vnx-dev", "vnx-orchestration")])
+    _mk_project(data_home, "vnx-dev")  # store keyed by the id, not the registry name
+    b = fa.check_per_project_stores(data_home, fa._load_project_ids(reg))
+    assert b.status == "GREEN"
+
+
+def test_main_json_exit_code_red(tmp_path, capsys):
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    bare = data_home / "state"
+    bare.mkdir()
+    (bare / "x.db").write_bytes(b"x")  # active fork
+    reg = _registry(tmp_path, [])
+    rc = fa.main(["--data-home", str(data_home), "--registry", str(reg), "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["overall"] == "RED"

--- a/vnx_cli/commands/fabric_audit.py
+++ b/vnx_cli/commands/fabric_audit.py
@@ -1,0 +1,23 @@
+#!/usr/bin/env python3
+"""vnx fabric-audit — phase-0 fabric hardening audit (ADR-028 §6 phase 0).
+
+Thin wrapper: the audit logic lives in ``scripts/fabric_audit.py`` (single
+source of truth, unit-tested). This puts the packaged engine on sys.path and
+delegates, so the packaged CLI and a bare ``python3 scripts/fabric_audit.py``
+run the identical checks.
+"""
+from vnx_cli import _engine
+
+
+def vnx_fabric_audit(args) -> int:
+    _engine.ensure_engine_on_path()
+    import fabric_audit  # noqa: E402 — resolved after ensure_engine_on_path()
+
+    argv: list[str] = []
+    if getattr(args, "data_home", None):
+        argv += ["--data-home", args.data_home]
+    if getattr(args, "registry", None):
+        argv += ["--registry", args.registry]
+    if getattr(args, "json", False):
+        argv.append("--json")
+    return fabric_audit.main(argv)

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -30,6 +30,30 @@ def _register_doctor_subparser(subparsers: argparse.Action) -> None:
     )
 
 
+def _register_fabric_audit_subparser(subparsers: argparse.Action) -> None:
+    fa_parser = subparsers.add_parser(
+        "fabric-audit",
+        help="audit the governance fabric: no shared-store fork, per-project ledgers, hash-chain integrity",
+    )
+    fa_parser.add_argument(
+        "--data-home",
+        default=None,
+        metavar="DIR",
+        help="central data-home root (default: $VNX_DATA_HOME or ~/.vnx-data)",
+    )
+    fa_parser.add_argument(
+        "--registry",
+        default=None,
+        metavar="FILE",
+        help="project registry JSON (default: ~/.vnx/projects.json)",
+    )
+    fa_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit results as JSON",
+    )
+
+
 def _register_version_subparser(subparsers: argparse.Action) -> None:
     version_parser = subparsers.add_parser(
         "version",
@@ -736,6 +760,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.doctor import vnx_doctor
         sys.exit(vnx_doctor(args))
 
+    elif args.command == "fabric-audit":
+        from vnx_cli.commands.fabric_audit import vnx_fabric_audit
+        sys.exit(vnx_fabric_audit(args))
+
     elif args.command == "status":
         from vnx_cli.commands.status import vnx_status
         sys.exit(vnx_status(args))
@@ -805,6 +833,7 @@ def main() -> None:
     subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
 
     _register_doctor_subparser(subparsers)
+    _register_fabric_audit_subparser(subparsers)
     _register_version_subparser(subparsers)
     _register_status_subparser(subparsers)
     _register_init_subparser(subparsers)


### PR DESCRIPTION
Horizon track: **fabric-hardening-phase0** (P0). Implements the `vnx fabric-audit` command from ADR-028 §6 phase 0.

## Summary
Surfaces the governance-fabric health that phase 0 requires green before a T0 session — turning "transparency without enforcement is inert" into an actionable check. Three checks, each GREEN / RED / WARN / SKIP:

- **A — Legacy shared state at data root:** a bare `<data_home>/state/` holding `*.db` is the split-brain signature (state that belongs under `<data_home>/<project-id>/state/` written to a shared location). Fresh write (<7d) = **RED** (active fork); stale = **WARN** (cleanup debt, non-blocking).
- **B — Per-project stores canonical:** every registered project owns its central state dir. Missing = RED.
- **C — Receipt hash-chain integrity** via `verify_chain()`: "unchained" is OK (ADR-023 partial by design); "broken" = RED.

## Changes
- `scripts/fabric_audit.py` (new) — logic, single source of truth, `--json`.
- `tests/test_fabric_audit.py` (new) — 13 tests; wired into Profile A CI.
- `vnx_cli/commands/fabric_audit.py` + `vnx_cli/main.py` — canonical Python CLI registration.
- `bin/vnx` — legacy bash surface registration (both delegate to the one module).

## Verification
- 13/13 unit tests pass locally.
- Live on this fleet: `GREEN-WITH-WARN` — the bare `~/.vnx-data/state` (10G, last real write Jun-20, 17d stale) is correctly flagged as retire-when-convenient cleanup debt, not an active fork.
- `vnx fabric-audit` + `vnx fabric-audit --json` verified via the canonical CLI.

## Open Items
The stale shared-store relic it flags (WARN) is the state-split-brain cleanup: retiring `~/.vnx-data/state` is parked for morning review (a stray open occurred at 19:26; retire after confirming no live writer). The audit makes that debt visible and non-blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)