### PR TITLE
fix(cli): wire plan-gate attest into canonical vnx horizon surface

### DIFF
--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -224,10 +224,17 @@ def _cmd_plan_gate_status(args: Any) -> int:
     return pc.cmd_plan_gate_status(args)
 
 
+def _cmd_plan_gate_attest(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_attest(args)
+
+
 _PLAN_GATE_DISPATCH: dict[str, Callable[[Any], int]] = {
     "seed": _cmd_plan_gate_seed,
     "run": _cmd_plan_gate_run,
     "status": _cmd_plan_gate_status,
+    "attest": _cmd_plan_gate_attest,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -471,6 +471,17 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     _common_horizon_args(p_pstat)
     p_pstat.add_argument("track_id")
 
+    p_patt = subs.add_parser(
+        "attest",
+        help="operator escape-hatch: attest the plan gate as passed without re-running the panel",
+    )
+    _common_horizon_args(p_patt)
+    p_patt.add_argument("track_id")
+    p_patt.add_argument("--reason", default=None,
+                        help="operator attestation reason (REQUIRED)")
+    p_patt.add_argument("--approval-id", dest="approval_id", default=None,
+                        help="operator approval token (REQUIRED)")
+
 
 def _register_horizon_subparser(subparsers: argparse.Action) -> None:
     horizon_parser = subparsers.add_parser(


### PR DESCRIPTION
Follow-up to PR #1038 (brc). The `plan-gate attest` escape-hatch shipped in `planning_cli.py` but was unreachable via the canonical `vnx horizon plan-gate` CLI (which registered only seed/run/status) — `vnx horizon plan-gate attest` failed with argparse "invalid choice".

## Changes
- `vnx_cli/main.py`: register the `attest` subparser under `vnx horizon plan-gate` (track_id + --reason + --approval-id).
- `vnx_cli/commands/horizon.py`: `_cmd_plan_gate_attest` dispatch, delegating to `planning_cli.cmd_plan_gate_attest` (single source of truth), added to `_PLAN_GATE_DISPATCH`.

## Verification
`vnx horizon plan-gate attest <track>` now reaches planning_cli's "--reason and --approval-id are both required" validation. `--help` lists attest. Local CI + codex-gate on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)