### PR TITLE
fix(fabric,ci): fabric-audit -wal/-shm awareness + repo-local state-pin gate + apt-flake

### DIFF
--- a/.github/workflows/public-ci.yml
+++ b/.github/workflows/public-ci.yml
@@ -16,6 +16,9 @@ jobs:
 
       - name: Install ripgrep
         run: |
+          # Strip the flaky packages.microsoft.com (azure-cli) apt source that intermittently
+          # breaks apt-get update on ubuntu-latest with a NOSPLIT/hash-sum mismatch.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y ripgrep
 

--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Install ripgrep
         run: |
+          # Strip the flaky packages.microsoft.com (azure-cli) apt source that intermittently
+          # breaks apt-get update on ubuntu-latest with a NOSPLIT/hash-sum mismatch.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y ripgrep
 
@@ -274,6 +277,9 @@ jobs:
 
       - name: Install ripgrep
         run: |
+          # Strip the flaky packages.microsoft.com (azure-cli) apt source that intermittently
+          # breaks apt-get update on ubuntu-latest with a NOSPLIT/hash-sum mismatch.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources 2>/dev/null || true
           sudo apt-get update
           sudo apt-get install -y ripgrep
 
@@ -415,3 +421,44 @@ jobs:
         run: |
           set -euo pipefail
           bash "$GITHUB_WORKSPACE/scripts/ci/pip_install_smoke.sh"
+
+  state-pin-gate:
+    name: Repo-local state-pin gate (#1043 footgun)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install ripgrep
+        run: |
+          # Strip the flaky packages.microsoft.com (azure-cli) apt source that intermittently
+          # breaks apt-get update on ubuntu-latest with a NOSPLIT/hash-sum mismatch.
+          sudo rm -f /etc/apt/sources.list.d/microsoft*.list /etc/apt/sources.list.d/*microsoft*.sources 2>/dev/null || true
+          sudo apt-get update
+          sudo apt-get install -y ripgrep
+
+      - name: Ban repo-local VNX_STATE_DIR pins
+        run: |
+          set -euo pipefail
+          # #1043 footgun: pinning VNX_STATE_DIR to a repo-local .vnx-data path breaks
+          # central-mode resolution and forks the audit trail. The pre-existing "Legacy
+          # path gate" only scans scripts/; the footgun actually lived in the T0 role,
+          # templates, skills and docs. Ban the relative pin across every shipped surface.
+          # tests/ legitimately point VNX_STATE_DIR at tmp dirs; daily-log/ only narrates it.
+          matches=$(rg -n "VNX_STATE_DIR[[:space:]]*=[[:space:]]*[\"']?\.{0,2}/?\.vnx-data" . \
+            --glob "!**/tests/**" \
+            --glob "!**/daily-log/**" \
+            --glob "!**/archive*/**" \
+            --glob "!**/.git/**" \
+            --glob "!**/.vnx-data/**" \
+            --glob "!**/*.DEPRECATED" \
+            || true)
+          if [ -n "$matches" ]; then
+            echo "$matches"
+            echo ""
+            echo "Repo-local VNX_STATE_DIR pin detected (#1043 footgun)."
+            echo "Resolve state via VNX_DATA_DIR / vnx_paths — never pin a repo-local .vnx-data path."
+            exit 1
+          fi
+          echo "[ok] no repo-local VNX_STATE_DIR pins in shipped surfaces"

--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -446,14 +446,22 @@ jobs:
           # path gate" only scans scripts/; the footgun actually lived in the T0 role,
           # templates, skills and docs. Ban the relative pin across every shipped surface.
           # tests/ legitimately point VNX_STATE_DIR at tmp dirs; daily-log/ only narrates it.
+          # rg exits 0 (matches), 1 (no matches), 2+ (error). Distinguish them: a bare `|| true`
+          # would mask an rg error (bad regex, unreadable tree) as a clean pass.
+          set +e
           matches=$(rg -n "VNX_STATE_DIR[[:space:]]*=[[:space:]]*[\"']?\.{0,2}/?\.vnx-data" . \
             --glob "!**/tests/**" \
             --glob "!**/daily-log/**" \
             --glob "!**/archive*/**" \
             --glob "!**/.git/**" \
             --glob "!**/.vnx-data/**" \
-            --glob "!**/*.DEPRECATED" \
-            || true)
+            --glob "!**/*.DEPRECATED")
+          rc=$?
+          set -e
+          if [ "$rc" -gt 1 ]; then
+            echo "ripgrep errored (exit $rc) — failing the gate instead of masking it as a pass"
+            exit "$rc"
+          fi
           if [ -n "$matches" ]; then
             echo "$matches"
             echo ""

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -12,7 +12,11 @@ Checks (each GREEN / RED / SKIP):
      should live under `<data_home>/<project-id>/state/` was written to a
      shared, project-agnostic location instead. RED when found, with the
      newest *.db mtime so an operator can tell a stale relic (safe to retire)
-     from a live writer (must be traced first).
+     from a live writer (must be traced first). The active/stale decision also
+     weighs `.db-wal`/`.db-shm` sidecar mtimes: a fresh sidecar on an old .db
+     means a connection opened the store recently (uncheckpointed), so it is
+     treated as a possible live writer (RED, verify with `lsof`) rather than a
+     safe stale relic.
 
   B. Per-project stores are canonical.
      Every registered project should own `<data_home>/<project-id>/state/`.
@@ -72,6 +76,29 @@ def _newest_db_mtime(directory: Path) -> Optional[float]:
     try:
         for entry in directory.iterdir():
             if entry.suffix == ".db" and entry.is_file():
+                m = entry.stat().st_mtime
+                if newest is None or m > newest:
+                    newest = m
+    except OSError:
+        return None
+    return newest
+
+
+def _newest_sidecar_mtime(directory: Path) -> Optional[float]:
+    """Newest mtime among SQLite sidecar files (``*.db-wal`` / ``*.db-shm``) directly
+    in ``directory``.
+
+    A fresh sidecar means a connection opened the store recently even when the
+    ``.db`` mtime (its last checkpoint) stayed old. Check A used to read only
+    ``.db`` mtimes, so a Jun-20 ``.db`` with a same-day ``.db-wal`` reported as a
+    safe 17-day stale relic while a connection had in fact just touched it. mtime
+    alone cannot tell a leftover sidecar from a live handle, so a recent sidecar
+    must escalate the finding (verify with ``lsof`` before retiring).
+    """
+    newest: Optional[float] = None
+    try:
+        for entry in directory.iterdir():
+            if entry.is_file() and (entry.name.endswith(".db-wal") or entry.name.endswith(".db-shm")):
                 m = entry.stat().st_mtime
                 if newest is None or m > newest:
                     newest = m
@@ -159,15 +186,29 @@ def check_shared_root_state(data_home: Path) -> CheckResult:
     if findings:
         import time
 
-        newest = _newest_db_mtime(bare_state)
-        age_days = (time.time() - newest) / 86400 if newest else None
+        newest_db = _newest_db_mtime(bare_state)
+        newest_sidecar = _newest_sidecar_mtime(bare_state)
+        findings[0]["newest_sidecar_mtime"] = _fmt_ts(newest_sidecar)
+        # A recent -wal/-shm touch means a connection opened the store recently even
+        # when the .db was never checkpointed (its mtime stays old). Drive the
+        # active/stale decision off the newest of the two so an old .db can never
+        # read as a safe stale relic while a sidecar was just written.
+        activity = max((m for m in (newest_db, newest_sidecar) if m is not None), default=None)
+        age_days = (time.time() - activity) / 86400 if activity else None
         active = age_days is not None and age_days < ACTIVE_FORK_STALE_DAYS
         status = "RED" if active else "WARN"
-        kind = (
-            "ACTIVE fork — a live writer is still resolving to the shared store"
-            if active
-            else f"stale relic ({int(age_days)}d old) — cleanup debt, retire when convenient"
+        sidecar_recent = newest_sidecar is not None and (
+            newest_db is None or newest_sidecar > newest_db
         )
+        if active:
+            kind = "ACTIVE fork — a live writer may still be resolving to the shared store"
+            if sidecar_recent:
+                kind += (
+                    f" (a -wal/-shm connection touched it at {_fmt_ts(newest_sidecar)}, "
+                    f"newer than the last .db checkpoint — verify with `lsof` before retiring)"
+                )
+        else:
+            kind = f"stale relic ({int(age_days)}d old) — cleanup debt, retire when convenient"
         detail = (
             f"legacy shared store {findings[0]['path']} "
             f"({findings[0]['db_count']} *.db, newest write {findings[0]['newest_db_mtime']}) — {kind}; "

--- a/tests/test_fabric_audit.py
+++ b/tests/test_fabric_audit.py
@@ -63,6 +63,36 @@ def test_bare_state_without_db_is_green(tmp_path):
     assert r.status == "GREEN"
 
 
+def test_recent_wal_on_stale_db_is_red(tmp_path):
+    """A stale .db (old mtime) with a FRESH -wal sidecar is a possible live writer,
+    not a safe stale relic — the split-brain false-clean this guards against
+    (Jun-20 .db, same-day .db-wal read as 17d stale before this fix)."""
+    bare = tmp_path / "state"
+    bare.mkdir()
+    db = bare / "runtime_coordination.db"
+    db.write_bytes(b"x")
+    old = time.time() - (fa.ACTIVE_FORK_STALE_DAYS + 10) * 86400
+    os.utime(db, (old, old))
+    (bare / "runtime_coordination.db-wal").write_bytes(b"")  # fresh mtime = now
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "RED"
+    assert "lsof" in r.detail
+
+
+def test_stale_db_with_stale_wal_stays_warn(tmp_path):
+    """Old .db + old sidecar is still just cleanup debt — no false RED."""
+    bare = tmp_path / "state"
+    bare.mkdir()
+    old = time.time() - (fa.ACTIVE_FORK_STALE_DAYS + 10) * 86400
+    for name in ("runtime_coordination.db", "runtime_coordination.db-wal"):
+        f = bare / name
+        f.write_bytes(b"")
+        os.utime(f, (old, old))
+    r = fa.check_shared_root_state(tmp_path)
+    assert r.status == "WARN"
+    assert "stale relic" in r.detail
+
+
 # ── Check B: per-project stores ─────────────────────────────────────────────
 
 def test_all_project_stores_present_is_green(tmp_path):


### PR DESCRIPTION
## Summary
Three phase-0 fabric/CI hardening fixes from the autonomous horizon run.

1. **fabric-audit `-wal`/`-shm` awareness** (correctness bug in #1045). Check A read only `.db` mtimes, so a Jun-20 `.db` with a same-day `.db-wal` reported as a safe 17-day stale relic while a connection had just opened the store. mtime alone can't distinguish a leftover sidecar from a live handle, so a fresh `.db-wal`/`.db-shm` now drives the active/stale decision and escalates to **RED** with a "verify with `lsof` before retiring" note. This was proven empirically this session: the audit gave a false-clean signal during the store-retirement.

2. **Repo-local state-pin gate** (durability guard for #1043). The pre-existing "Legacy path gate" only scans `scripts/`, but the `VNX_STATE_DIR=.vnx-data` footgun lived in the T0 role, templates, skills and docs. A new standalone `state-pin-gate` job bans the repo-local relative pin across every shipped surface. `tests/` (legit tmp dirs) and `daily-log/` (narration) are excluded.

3. **CI apt-flake fix.** Strip the flaky `packages.microsoft.com` (azure-cli) apt source before `apt-get update` in all three ripgrep-install steps — it broke the install ~4x/night with a NOSPLIT/hash-sum mismatch.

## Changes
- `scripts/fabric_audit.py` — `_newest_sidecar_mtime()` helper; check A weighs sidecar mtimes, RED-with-lsof-note on a fresh sidecar over an old `.db`; docstring updated.
- `tests/test_fabric_audit.py` — 2 new tests (recent-wal-on-stale-db → RED; stale-db+stale-wal → WARN).
- `.github/workflows/vnx-ci.yml` — new `state-pin-gate` job; apt-flake strip in 2 ripgrep steps.
- `.github/workflows/public-ci.yml` — apt-flake strip.

## Verification
- `pytest tests/test_fabric_audit.py` → 19 passed (17 existing + 2 new).
- Both workflow files parse as valid YAML.
- Lint regex validated locally: clean on current tree, catches a planted `VNX_STATE_DIR=.vnx-data/state`.

## Open Items
None.

Dispatch-ID: 20260708-fabric-ci-hardening

🤖 Generated with [Claude Code](https://claude.com/claude-code)