### PR TITLE
feat(fabric): blocking gate findings become track_open_items

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -459,6 +459,7 @@ def _govern(
             base_sha=None,
             worktree_diff=phantom_diff,  # F1: pre-captured before the worktree teardown
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
+            state_dir=spec.state_dir,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error(

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -280,6 +280,7 @@ def govern(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome:
             worktree_path=spec.worktree_path,
             base_sha=spec.base_sha,
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
+            state_dir=spec.state_dir,
         )
     except Exception as exc:  # noqa: BLE001
         logger.error("govern: phantom-guard check failed (non-fatal) dispatch=%s: %s", dispatch_id, exc)

--- a/scripts/lib/gate_findings_bridge.py
+++ b/scripts/lib/gate_findings_bridge.py
@@ -1,0 +1,219 @@
+#!/usr/bin/env python3
+"""gate_findings_bridge.py — blocking gate verdicts -> first-class fabric open-items.
+
+The gap this closes (proof-case: ppb #1039): a BLOCKING gate verdict (pre_merge_gate
+HOLD, phantom_guard reject, quality_advisory severity="blocking") used to live only in
+a gate-result file or a worker report. Nobody scanning `vnx horizon show <track>` or the
+kickoff/human-gate surface would see it without reading the PR. This module makes a
+blocking verdict a `track_open_items` row (link_type="blocks") the moment the gate fires,
+and closes it the moment a later clean run on the SAME dispatch supersedes it.
+
+Single writer (D1, STATE_FABRIC.md): every ``track_open_items`` mutation goes THROUGH
+``tracks.link_open_item`` / ``tracks.unlink_open_item`` — this module owns no SQL of its
+own against that table. It only reads ``dispatches`` (read-only) to resolve the track a
+gate's dispatch_id points to, mirroring ``scripts/import_open_items_to_tracks.py``.
+
+ADR-005 (D3 semantics, mirrored from the OI bridge): the DB mutation and its commit are
+the authoritative act. The ``track_oi_linked``/``track_oi_closed`` ledger event is
+deferred and emitted ONLY AFTER that commit succeeds — at-most-once, non-fatal on
+failure (logged, never rolled back; the reconciler can re-derive from the committed row).
+
+ADR-007 (tenant scoping): project_id is resolved FROM the dispatch's own row in
+``dispatches`` — never defaulted to ``vnx-dev``. A dispatch with no row, no track_id, or
+no project_id is, from this module's perspective, UNLINKED: it degrades quietly (a single
+log line) and creates nothing. An unlinked gate finding is not a fabric open-item, and
+that is an accepted, intentional no-op (per the dispatch contract), not an error.
+
+Both entry points are best-effort and NEVER raise: a gate's own PASS/HOLD decision must
+never be affected by a finding-emit failure (this module is observability bolted onto an
+already-made decision, not part of the decision itself).
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from pathlib import Path
+from typing import Optional
+
+import tracks
+
+_LOG = logging.getLogger(__name__)
+
+DB_FILENAME = "runtime_coordination.db"
+
+# The gate finding is idempotent by construction: the SAME (gate_name, dispatch_id) pair
+# always derives the SAME oi_id, and tracks.link_open_item upserts on the
+# (track_id, oi_id, link_type) primary key — a re-run never duplicates the row.
+_LINK_TYPE = "blocks"
+_LINK_SOURCE = "manual"
+
+
+def _oi_id(gate_name: str, dispatch_id: str) -> str:
+    return f"gate:{gate_name}:{dispatch_id}"
+
+
+def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    return any(row[1] == col for row in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def _resolve_dispatch_track(
+    state_dir: str | Path, dispatch_id: str
+) -> Optional[tuple[str, str]]:
+    """Resolve (track_id, project_id) for ``dispatch_id``, or None to degrade quietly.
+
+    Fail-closed on tenancy (ADR-007): a dispatch row missing ``project_id`` (or
+    ``track_id``) is treated as unresolvable, NEVER defaulted to 'vnx-dev'. Any DB
+    error (locked/absent/malformed) also resolves to None — a gate must never crash
+    because the fabric-linking read failed.
+    """
+    if not dispatch_id or not dispatch_id.strip():
+        return None
+    db_path = Path(state_dir) / DB_FILENAME
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    except sqlite3.Error:
+        return None
+    try:
+        if not _has_col(conn, "dispatches", "track_id") or not _has_col(
+            conn, "dispatches", "project_id"
+        ):
+            return None
+        row = conn.execute(
+            "SELECT track_id, project_id FROM dispatches WHERE dispatch_id = ?",
+            (dispatch_id,),
+        ).fetchone()
+        if not row or not row[0] or not row[1]:
+            return None
+        return (row[0], row[1])
+    except sqlite3.Error:
+        return None
+    finally:
+        conn.close()
+
+
+def record_gate_finding(
+    state_dir: str | Path,
+    *,
+    dispatch_id: str,
+    gate_name: str,
+    summary: str,
+    pr_ref: Optional[str] = None,
+) -> bool:
+    """Best-effort: upsert a ``blocks`` open-item for a BLOCKING gate verdict.
+
+    No-op (returns False, logged) when the dispatch has no linked track — an
+    unlinked gate finding is intentionally not a fabric open-item. Never raises.
+    """
+    resolved = _resolve_dispatch_track(state_dir, dispatch_id)
+    if resolved is None:
+        _LOG.info(
+            "gate_findings_bridge: dispatch=%s gate=%s has no linked track — "
+            "degrading quietly (no fabric open-item created)",
+            dispatch_id, gate_name,
+        )
+        return False
+    track_id, project_id = resolved
+    oi_id = _oi_id(gate_name, dispatch_id)
+    db_path = Path(state_dir) / DB_FILENAME
+    events: list = []
+    conn: Optional[sqlite3.Connection] = None
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        conn.execute("BEGIN IMMEDIATE")
+        tracks.link_open_item(
+            state_dir, track_id, project_id, oi_id, _LINK_TYPE, _LINK_SOURCE,
+            conn=conn, event_sink=events,
+            details={"gate_name": gate_name, "dispatch_id": dispatch_id,
+                     "summary": summary, "pr_ref": pr_ref},
+        )
+        conn.commit()
+    except Exception as exc:  # noqa: BLE001 — never break the caller's gate decision
+        if conn is not None:
+            conn.rollback()
+        _LOG.warning(
+            "gate_findings_bridge: record failed dispatch=%s track=%s gate=%s: %s",
+            dispatch_id, track_id, gate_name, exc,
+        )
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+    _emit_deferred(state_dir, events)
+    _LOG.warning(
+        "gate_findings_bridge: RECORDED blocking finding track=%s project=%s gate=%s "
+        "dispatch=%s pr_ref=%s: %s",
+        track_id, project_id, gate_name, dispatch_id, pr_ref, summary,
+    )
+    return True
+
+
+def resolve_gate_finding(
+    state_dir: str | Path,
+    *,
+    dispatch_id: str,
+    gate_name: str,
+    reason: str = "gate clean run",
+) -> bool:
+    """Best-effort: close a previously-recorded ``blocks`` finding on a clean gate run.
+
+    No-op (returns False) when the dispatch is unlinked, migration 0030 is absent, or
+    no ACTIVE finding is on record for (gate_name, dispatch_id) — closing nothing is
+    the expected common case (most clean runs never had a finding to begin with).
+    Never raises.
+    """
+    resolved = _resolve_dispatch_track(state_dir, dispatch_id)
+    if resolved is None:
+        return False
+    track_id, project_id = resolved
+    oi_id = _oi_id(gate_name, dispatch_id)
+    db_path = Path(state_dir) / DB_FILENAME
+    events: list = []
+    conn: Optional[sqlite3.Connection] = None
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        if not _has_col(conn, "track_open_items", "resolved_at"):
+            return False  # pre-0030 store: nothing this module can resolve
+        active = conn.execute(
+            "SELECT 1 FROM track_open_items WHERE track_id = ? AND project_id = ? "
+            "AND oi_id = ? AND link_type = ? AND resolved_at IS NULL",
+            (track_id, project_id, oi_id, _LINK_TYPE),
+        ).fetchone()
+        if not active:
+            return False
+        conn.execute("BEGIN IMMEDIATE")
+        tracks.unlink_open_item(
+            state_dir, track_id, project_id, oi_id, _LINK_TYPE,
+            reason=reason, actor="system", conn=conn, event_sink=events,
+        )
+        conn.commit()
+    except Exception as exc:  # noqa: BLE001 — never break the caller's gate decision
+        if conn is not None:
+            conn.rollback()
+        _LOG.warning(
+            "gate_findings_bridge: resolve failed dispatch=%s track=%s gate=%s: %s",
+            dispatch_id, track_id, gate_name, exc,
+        )
+        return False
+    finally:
+        if conn is not None:
+            conn.close()
+    _emit_deferred(state_dir, events)
+    _LOG.info(
+        "gate_findings_bridge: RESOLVED finding track=%s gate=%s dispatch=%s: %s",
+        track_id, gate_name, dispatch_id, reason,
+    )
+    return True
+
+
+def _emit_deferred(state_dir: str | Path, events: list) -> None:
+    """Emit deferred ADR-005 events AFTER the commit (D3) — logged, non-fatal on failure."""
+    for spec in events:
+        try:
+            tracks._emit_track_event(state_dir, *spec)
+        except Exception as exc:  # noqa: BLE001 — post-commit best-effort, never fatal
+            _LOG.warning("gate_findings_bridge: post-commit ledger emit failed: %s", exc)

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -213,6 +213,7 @@ def record_phantom_if_any(
     base_sha: Optional[str] = None,
     worktree_diff: Optional[str] = None,
     receipts_file: Optional[str] = None,
+    state_dir: Optional[Path] = None,
 ) -> PhantomVerdict:
     """``guard_at_govern`` + on a phantom verdict, append a corrective ``failed`` completion receipt.
 
@@ -223,11 +224,28 @@ def record_phantom_if_any(
     worker's ``done`` win). So the dispatch resolves FAILED while the worker's original ``done``
     receipt is PRESERVED (the contradiction is recorded, not overwritten — audit-honest, the ISAE
     lens). Never raises: a corrective-append failure is logged, not propagated.
+
+    A phantom verdict also, best-effort, records a `blocks` fabric open-item on the
+    dispatch's linked track (via gate_findings_bridge) when ``state_dir`` is supplied —
+    the ppb #1039 gap: a blocking finding must surface on the track, not only the
+    receipt. Degrades quietly on an unlinked dispatch; never fatal to the guard itself.
     """
     verdict = guard_at_govern(
         dispatch_id=dispatch_id, role=role, status=status, token_usage=token_usage,
         worktree_path=worktree_path, base_sha=base_sha, worktree_diff=worktree_diff,
     )
+    if verdict.is_phantom and state_dir:
+        try:
+            from gate_findings_bridge import record_gate_finding  # noqa: PLC0415
+            record_gate_finding(
+                state_dir, dispatch_id=dispatch_id, gate_name="phantom_guard",
+                summary=verdict.reason,
+            )
+        except Exception as exc:  # noqa: BLE001 — never break the guard on a fabric-link failure
+            _LOG.warning(
+                "phantom_guard: gate_findings_bridge record failed dispatch=%s: %s",
+                dispatch_id, exc,
+            )
     if verdict.is_phantom and receipts_file:
         try:
             import os  # noqa: PLC0415

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -565,6 +565,7 @@ def link_open_item(
     *,
     conn: Optional[sqlite3.Connection] = None,
     event_sink: Optional[list] = None,
+    details: Optional[dict] = None,
 ) -> None:
     """Upsert an active track↔open-item link (INSERT OR REPLACE; reopen-safe).
 
@@ -577,6 +578,12 @@ def link_open_item(
 
     Without ``conn`` (owns=True, standalone) the function self-manages its
     connection, emits the event in-line, and commits — unchanged behaviour.
+
+    ``details`` merges extra keys (e.g. a gate finding's summary/pr_ref) into the
+    ``track_oi_linked`` ledger event on top of the always-present ``oi_id``/
+    ``link_type``. ``track_open_items`` itself carries no free-text column (by
+    design — ``oi_id`` is a pointer), so richer context lives in the Past-layer
+    event, not the Current-layer row.
     """
     valid_link_types = frozenset({"blocks", "warns", "related"})
     valid_link_sources = frozenset({"file_path", "mention", "manual"})
@@ -604,9 +611,12 @@ def link_open_item(
             """,
             (track_id, project_id, oi_id, link_type, link_source, _now_utc()),
         )
+        event_details = {"oi_id": oi_id, "link_type": link_type}
+        if details:
+            event_details.update(details)
         _emit_or_defer(
             event_sink, state_dir, "track_oi_linked", track_id, project_id,
-            "system", {"oi_id": oi_id, "link_type": link_type},
+            "system", event_details,
         )
         if owns:
             _conn.commit()

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -203,10 +203,12 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
         return 1
 
     deps = _dependencies_for(state_dir, args.track_id, project_id)
+    open_items = tracks_lib.get_linked_open_items(state_dir, args.track_id, project_id)
 
     if args.json:
         out = dict(track)
         out["depends_on"] = deps
+        out["open_items"] = open_items
         print(json.dumps(out, indent=2, default=str))
         return 0
 
@@ -219,6 +221,12 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     print(f"  pr_ref   : {track.get('pr_ref') or '-'}")
     print(f"  goal     : {track.get('goal_state') or '-'}")
     print(f"  depends  : {', '.join(deps) if deps else '(none)'}")
+    if open_items:
+        print("  open items (unresolved):")
+        for oi in open_items:
+            print(f"    - [{oi['link_type']}] {oi['oi_id']}  (linked {oi.get('linked_at', '?')})")
+    else:
+        print("  open items : (none)")
     print()
     return 0
 

--- a/scripts/pre_merge_gate.py
+++ b/scripts/pre_merge_gate.py
@@ -24,10 +24,13 @@ from __future__ import annotations
 import argparse
 import datetime as dt
 import json
+import logging
 import subprocess
 import sys
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+
+_LOG = logging.getLogger(__name__)
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
@@ -42,6 +45,7 @@ from quality_advisory import (
     get_changed_files,
 )
 from cqs_calculator import calculate_cqs
+from gate_findings_bridge import record_gate_finding, resolve_gate_finding
 
 # CQS threshold: dispatches below this score get a HOLD
 CQS_THRESHOLD = 50.0
@@ -645,6 +649,23 @@ def _find_dispatch_for_pr(pr_id: str, dispatch_dir: Path) -> Optional[Path]:
     return candidates[0]
 
 
+def _resolve_dispatch_id_for_pr(pr_id: str, dispatch_dir: Path) -> Optional[str]:
+    """Best-effort dispatch_id for a PR, via its dispatch file's 'Dispatch-ID:' footer.
+
+    Reuses the same dispatch-file lookup as the contract/artifact checks. Returns None
+    (never raises) when no dispatch file is found or it carries no Dispatch-ID footer —
+    the fabric-linking bridge treats that as an unlinked gate (quiet no-op).
+    """
+    dispatch_file = _find_dispatch_for_pr(pr_id, dispatch_dir)
+    if dispatch_file is None:
+        return None
+    try:
+        dispatch_id = parse_contract_from_file(dispatch_file).dispatch_id
+    except OSError:
+        return None
+    return dispatch_id or None
+
+
 def _is_artifact_path(path: str) -> bool:
     """Check if a path refers to a PDF or XLSX artifact."""
     lower = path.lower()
@@ -740,6 +761,45 @@ def _get_net_line_deletion(project_root: Path) -> Optional[int]:
 # Gate orchestrator
 # ---------------------------------------------------------------------------
 
+def _sync_fabric_finding(
+    pr_id: str,
+    dispatch_dir: Path,
+    state_dir: Path,
+    verdict: str,
+    hold_checks: List[Dict[str, Any]],
+) -> None:
+    """Best-effort: mirror the overall gate verdict onto the dispatch's track.
+
+    HOLD records a single `blocks` open-item (gate_name="pre_merge_gate") carrying every
+    HOLD check's detail — this also covers quality_advisory's severity="blocking" path,
+    since a quality-advisory HOLD already surfaces as one of ``hold_checks``. GO resolves
+    a previously-recorded finding (a fixed-and-repushed PR going green). Never raises and
+    never changes ``verdict`` — a finding-emit failure is observability only, logged and
+    swallowed by record_gate_finding/resolve_gate_finding themselves.
+    """
+    dispatch_id = _resolve_dispatch_id_for_pr(pr_id, dispatch_dir)
+    if not dispatch_id:
+        return
+    try:
+        if verdict == "HOLD":
+            summary = "; ".join(f"{c['check']}: {c.get('detail', '')}" for c in hold_checks)
+            record_gate_finding(
+                state_dir, dispatch_id=dispatch_id, gate_name="pre_merge_gate",
+                summary=summary, pr_ref=pr_id,
+            )
+        else:
+            resolve_gate_finding(
+                state_dir, dispatch_id=dispatch_id, gate_name="pre_merge_gate",
+                reason="pre_merge_gate clean run",
+            )
+    except Exception as exc:  # noqa: BLE001 — defense in depth: the bridge is already
+        # non-raising by design, but the gate's verdict must survive even a regression
+        # in that contract.
+        _LOG.warning(
+            "pre_merge_gate: fabric finding sync failed dispatch=%s: %s", dispatch_id, exc,
+        )
+
+
 def run_gate_checks(
     pr_id: str,
     project_root: Path,
@@ -768,6 +828,8 @@ def run_gate_checks(
 
     hold_checks = [c for c in checks if c.get("status") == "HOLD"]
     verdict = "HOLD" if hold_checks else "GO"
+
+    _sync_fabric_finding(pr_id, dispatch_dir, state_dir, verdict, hold_checks)
 
     return {
         "pr_id": pr_id,

--- a/tests/test_gate_findings_bridge.py
+++ b/tests/test_gate_findings_bridge.py
@@ -1,0 +1,277 @@
+"""tests/test_gate_findings_bridge.py — blocking gate verdict -> fabric open-item.
+
+Covers the dispatch contract for 20260708-gate-findings-fabric:
+  1. linked dispatch + BLOCKING gate -> a `blocks` track_open_item, idempotent on rerun.
+  2. unlinked dispatch (no track_id / no project_id) -> quiet no-op, no orphaned row.
+  3. a subsequent clean gate run resolves the finding (tracks.unlink_open_item semantics).
+  4. tenant scoping: a dispatch in project B never links a track in project A.
+  5. the ADR-005 ledger event carries gate_name/summary/pr_ref (Past-layer detail).
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+import gate_findings_bridge as bridge  # noqa: E402
+
+PROJECT_A = "test-proj-a"
+PROJECT_B = "test-proj-b"
+
+
+def _build_db(tmp_path: Path) -> Path:
+    """State_dir with the track layer (0022-0030) + a dispatches.track_id column.
+
+    Mirrors dispatch_cli._persist_track_id: track_id is an additive ALTER TABLE, not
+    part of the original dispatches schema.
+    """
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+
+    # track_id is an ADDITIVE column (dispatch_cli._persist_track_id), not part of any
+    # migration's base schema — added here exactly as production adds it lazily.
+    conn.execute("ALTER TABLE dispatches ADD COLUMN track_id TEXT")
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _insert_dispatch(
+    state_dir: Path, dispatch_id: str, project_id: str, track_id: str | None
+) -> None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, track_id) VALUES (?, ?, ?)",
+        (dispatch_id, project_id, track_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.fixture()
+def state_dir(tmp_path):
+    return _build_db(tmp_path)
+
+
+def _oi_rows(state_dir: Path, track_id: str, project_id: str) -> list[dict]:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.row_factory = sqlite3.Row
+    rows = conn.execute(
+        "SELECT * FROM track_open_items WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchall()
+    conn.close()
+    return [dict(r) for r in rows]
+
+
+class TestRecordGateFinding:
+    def test_linked_dispatch_creates_blocking_open_item(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-1", PROJECT_A, "T1", "G1", phase="active")
+        _insert_dispatch(state_dir, "d-1", PROJECT_A, "feat-1")
+
+        ok = bridge.record_gate_finding(
+            state_dir, dispatch_id="d-1", gate_name="pre_merge_gate",
+            summary="pr_size: too large", pr_ref="PR-6",
+        )
+        assert ok is True
+
+        rows = _oi_rows(state_dir, "feat-1", PROJECT_A)
+        assert len(rows) == 1
+        assert rows[0]["oi_id"] == "gate:pre_merge_gate:d-1"
+        assert rows[0]["link_type"] == "blocks"
+        assert rows[0]["resolved_at"] is None
+
+    def test_rerun_is_idempotent_no_duplicate(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-2", PROJECT_A, "T2", "G2", phase="active")
+        _insert_dispatch(state_dir, "d-2", PROJECT_A, "feat-2")
+
+        for _ in range(3):
+            bridge.record_gate_finding(
+                state_dir, dispatch_id="d-2", gate_name="phantom_guard",
+                summary="phantom rejected",
+            )
+
+        rows = _oi_rows(state_dir, "feat-2", PROJECT_A)
+        assert len(rows) == 1  # upsert on (track_id, oi_id, link_type) PK — never duplicates
+
+    def test_different_gate_names_are_distinct_findings(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-3", PROJECT_A, "T3", "G3", phase="active")
+        _insert_dispatch(state_dir, "d-3", PROJECT_A, "feat-3")
+
+        bridge.record_gate_finding(state_dir, dispatch_id="d-3", gate_name="pre_merge_gate", summary="s1")
+        bridge.record_gate_finding(state_dir, dispatch_id="d-3", gate_name="phantom_guard", summary="s2")
+
+        rows = _oi_rows(state_dir, "feat-3", PROJECT_A)
+        assert {r["oi_id"] for r in rows} == {
+            "gate:pre_merge_gate:d-3", "gate:phantom_guard:d-3",
+        }
+
+    def test_unlinked_dispatch_missing_row_is_noop(self, state_dir):
+        """No dispatches row at all for this dispatch_id — degrade quietly."""
+        ok = bridge.record_gate_finding(
+            state_dir, dispatch_id="no-such-dispatch", gate_name="pre_merge_gate", summary="x",
+        )
+        assert ok is False
+
+    def test_unlinked_dispatch_null_track_id_is_noop(self, state_dir):
+        """A dispatch row exists but track_id is NULL (never linked to a track)."""
+        _insert_dispatch(state_dir, "d-4", PROJECT_A, None)
+        ok = bridge.record_gate_finding(
+            state_dir, dispatch_id="d-4", gate_name="pre_merge_gate", summary="x",
+        )
+        assert ok is False
+        # No orphaned open-item under any track for this project.
+        db = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        n = conn.execute(
+            "SELECT COUNT(*) FROM track_open_items WHERE oi_id LIKE 'gate:%d-4%'"
+        ).fetchone()[0]
+        conn.close()
+        assert n == 0
+
+    def test_missing_project_id_column_fails_closed_not_vnx_dev(self, tmp_path):
+        """ADR-007: a dispatches table without project_id must never default to 'vnx-dev'.
+
+        Uses a standalone minimal DB (no track layer needed — resolution must fail
+        before ever reaching tracks/track_open_items).
+        """
+        state_dir = tmp_path / "bare_state"
+        state_dir.mkdir(parents=True)
+        db = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("CREATE TABLE dispatches (dispatch_id TEXT, track_id TEXT)")
+        conn.execute("INSERT INTO dispatches (dispatch_id, track_id) VALUES ('d-5', 'feat-x')")
+        conn.commit()
+        conn.close()
+
+        ok = bridge.record_gate_finding(
+            state_dir, dispatch_id="d-5", gate_name="pre_merge_gate", summary="x",
+        )
+        assert ok is False
+
+    def test_tenant_scoping_same_track_id_different_project(self, state_dir):
+        """Two projects can legally reuse the same track_id string; a finding for project B
+        must never land on project A's track row."""
+        tracks_lib.create_track(state_dir, "shared-id", PROJECT_A, "TA", "GA", phase="active")
+        tracks_lib.create_track(state_dir, "shared-id", PROJECT_B, "TB", "GB", phase="active")
+        _insert_dispatch(state_dir, "d-6", PROJECT_B, "shared-id")
+
+        bridge.record_gate_finding(
+            state_dir, dispatch_id="d-6", gate_name="pre_merge_gate", summary="x",
+        )
+
+        assert _oi_rows(state_dir, "shared-id", PROJECT_B) != []
+        assert _oi_rows(state_dir, "shared-id", PROJECT_A) == []
+
+    def test_ledger_event_carries_gate_details(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-7", PROJECT_A, "T7", "G7", phase="active")
+        _insert_dispatch(state_dir, "d-7", PROJECT_A, "feat-7")
+
+        bridge.record_gate_finding(
+            state_dir, dispatch_id="d-7", gate_name="pre_merge_gate",
+            summary="net_deletion: mass delete", pr_ref="PR-42",
+        )
+
+        events_file = state_dir.parent / "events" / "track_events.ndjson"
+        events = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
+        linked = [e for e in events if e.get("event_type") == "track_oi_linked" and e.get("track_id") == "feat-7"]
+        assert len(linked) == 1
+        details = linked[0]["details"]
+        assert details["gate_name"] == "pre_merge_gate"
+        assert details["dispatch_id"] == "d-7"
+        assert details["pr_ref"] == "PR-42"
+        assert "net_deletion" in details["summary"]
+
+
+class TestResolveGateFinding:
+    def test_resolve_closes_active_finding(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-8", PROJECT_A, "T8", "G8", phase="active")
+        _insert_dispatch(state_dir, "d-8", PROJECT_A, "feat-8")
+        bridge.record_gate_finding(state_dir, dispatch_id="d-8", gate_name="pre_merge_gate", summary="x")
+
+        ok = bridge.resolve_gate_finding(
+            state_dir, dispatch_id="d-8", gate_name="pre_merge_gate", reason="clean rerun",
+        )
+        assert ok is True
+
+        rows = _oi_rows(state_dir, "feat-8", PROJECT_A)
+        assert len(rows) == 1
+        assert rows[0]["resolved_at"] is not None
+        assert rows[0]["resolution_reason"] == "clean rerun"
+
+        # Excluded from the active-only view (no stale finding lingers).
+        active = tracks_lib.get_linked_open_items(state_dir, "feat-8", PROJECT_A)
+        assert active == []
+
+    def test_resolve_noop_when_no_prior_finding(self, state_dir):
+        tracks_lib.create_track(state_dir, "feat-9", PROJECT_A, "T9", "G9", phase="active")
+        _insert_dispatch(state_dir, "d-9", PROJECT_A, "feat-9")
+
+        ok = bridge.resolve_gate_finding(
+            state_dir, dispatch_id="d-9", gate_name="pre_merge_gate",
+        )
+        assert ok is False
+
+    def test_resolve_noop_when_dispatch_unlinked(self, state_dir):
+        ok = bridge.resolve_gate_finding(
+            state_dir, dispatch_id="no-such-dispatch", gate_name="pre_merge_gate",
+        )
+        assert ok is False
+
+    def test_resolve_is_idempotent(self, state_dir):
+        """Resolving twice never raises — the second call finds no active row."""
+        tracks_lib.create_track(state_dir, "feat-10", PROJECT_A, "T10", "G10", phase="active")
+        _insert_dispatch(state_dir, "d-10", PROJECT_A, "feat-10")
+        bridge.record_gate_finding(state_dir, dispatch_id="d-10", gate_name="pre_merge_gate", summary="x")
+
+        first = bridge.resolve_gate_finding(state_dir, dispatch_id="d-10", gate_name="pre_merge_gate")
+        second = bridge.resolve_gate_finding(state_dir, dispatch_id="d-10", gate_name="pre_merge_gate")
+        assert first is True
+        assert second is False

--- a/tests/test_phantom_guard_inline.py
+++ b/tests/test_phantom_guard_inline.py
@@ -94,3 +94,56 @@ def test_record_phantom_append_failure_is_non_fatal(monkeypatch, tmp_path):
     v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
                                  receipts_file=str(tmp_path / "r.ndjson"))
     assert v.is_phantom  # verdict still returned, no exception escaped
+
+
+def test_record_phantom_calls_gate_findings_bridge(monkeypatch, tmp_path):
+    """A phantom verdict, given state_dir, records a fabric finding (the ppb #1039 gap)."""
+    monkeypatch.setattr(pg, "guard_at_govern",
+                        lambda **kw: pg.PhantomVerdict(True, "PHANTOM: test reason"))
+    import append_receipt
+    monkeypatch.setattr(append_receipt, "append_receipt_payload", lambda *a, **k: None)
+    import gate_findings_bridge
+    captured = {}
+    monkeypatch.setattr(
+        gate_findings_bridge, "record_gate_finding",
+        lambda state_dir, **kw: captured.update(state_dir=state_dir, kw=kw) or True,
+    )
+    pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+                             receipts_file=str(tmp_path / "r.ndjson"), state_dir=tmp_path)
+    assert captured["state_dir"] == tmp_path
+    assert captured["kw"]["dispatch_id"] == "d1"
+    assert captured["kw"]["gate_name"] == "phantom_guard"
+
+
+def test_record_phantom_bridge_failure_is_non_fatal(monkeypatch, tmp_path):
+    monkeypatch.setattr(pg, "guard_at_govern",
+                        lambda **kw: pg.PhantomVerdict(True, "PHANTOM: test reason"))
+    import append_receipt
+    monkeypatch.setattr(append_receipt, "append_receipt_payload", lambda *a, **k: None)
+    import gate_findings_bridge
+
+    def _boom(*a, **k):
+        raise RuntimeError("db locked")
+
+    monkeypatch.setattr(gate_findings_bridge, "record_gate_finding", _boom)
+    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+                                 receipts_file=str(tmp_path / "r.ndjson"), state_dir=tmp_path)
+    assert v.is_phantom  # verdict unaffected by a bridge failure
+
+
+def test_record_phantom_no_bridge_call_without_state_dir(monkeypatch, tmp_path):
+    """state_dir omitted (older/unaware caller) -> the bridge is never touched."""
+    monkeypatch.setattr(pg, "guard_at_govern",
+                        lambda **kw: pg.PhantomVerdict(True, "PHANTOM: test reason"))
+    import append_receipt
+    monkeypatch.setattr(append_receipt, "append_receipt_payload", lambda *a, **k: None)
+    import gate_findings_bridge
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        gate_findings_bridge, "record_gate_finding",
+        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
+    )
+    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+                                 receipts_file=str(tmp_path / "r.ndjson"))
+    assert v.is_phantom
+    assert calls["n"] == 0

--- a/tests/test_planning_cli_objective.py
+++ b/tests/test_planning_cli_objective.py
@@ -29,6 +29,7 @@ for p in (_LIB, _SCRIPTS):
 import schema_migration
 import seed_tracks_from_roadmap as seeder
 import planning_cli
+import tracks as tracks_lib
 
 
 SAMPLE_ROADMAP = """
@@ -170,3 +171,42 @@ def test_objective_show_missing_returns_nonzero(seeded_state, capsys):
         "--state-dir", str(seeded_state),
     ])
     assert rc == 1
+
+
+def test_objective_show_no_open_items(seeded_state, capsys):
+    rc = planning_cli.main([
+        "objective", "show", "feat-a", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "open items : (none)" in out
+
+
+def test_objective_show_lists_open_blocking_finding(seeded_state, capsys):
+    """A gate-recorded `blocks` open-item must surface here without any PR read."""
+    tracks_lib.link_open_item(
+        seeded_state, "feat-a", "vnx-dev", "gate:pre_merge_gate:d-1", "blocks", "manual",
+    )
+    rc = planning_cli.main([
+        "objective", "show", "feat-a", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "open items (unresolved):" in out
+    assert "[blocks] gate:pre_merge_gate:d-1" in out
+
+
+def test_objective_show_json_includes_open_items(seeded_state, capsys):
+    tracks_lib.link_open_item(
+        seeded_state, "feat-a", "vnx-dev", "gate:pre_merge_gate:d-1", "blocks", "manual",
+    )
+    rc = planning_cli.main([
+        "objective", "show", "feat-a", "--project-id", "vnx-dev",
+        "--state-dir", str(seeded_state), "--json",
+    ])
+    assert rc == 0
+    data = json.loads(capsys.readouterr().out)
+    assert len(data["open_items"]) == 1
+    assert data["open_items"][0]["oi_id"] == "gate:pre_merge_gate:d-1"

--- a/tests/test_pre_merge_gate.py
+++ b/tests/test_pre_merge_gate.py
@@ -18,6 +18,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 sys.path.insert(0, str(SCRIPT_DIR))
 
+import pre_merge_gate
 from pre_merge_gate import (
     check_open_items,
     check_cqs,
@@ -33,6 +34,7 @@ from pre_merge_gate import (
     store_gate_result,
     format_human_readable,
     _find_dispatch_for_pr,
+    _resolve_dispatch_id_for_pr,
     _is_artifact_path,
     CQS_THRESHOLD,
     DELETION_FILE_WARN,
@@ -491,6 +493,106 @@ class TestHelpers:
     def test_find_dispatch_for_pr_not_found(self, dispatch_dir):
         found = _find_dispatch_for_pr("PR-99", dispatch_dir)
         assert found is None
+
+    def test_resolve_dispatch_id_for_pr(self, dispatch_dir):
+        content = "# Dispatch\n\n**PR**: PR-6\nDispatch-ID: gate-findings-fabric-test\n"
+        (dispatch_dir / "active" / "d.md").write_text(content)
+        assert _resolve_dispatch_id_for_pr("PR-6", dispatch_dir) == "gate-findings-fabric-test"
+
+    def test_resolve_dispatch_id_for_pr_no_dispatch_file(self, dispatch_dir):
+        assert _resolve_dispatch_id_for_pr("PR-99", dispatch_dir) is None
+
+
+# ---------------------------------------------------------------------------
+# Gate -> fabric wiring (gate_findings_bridge)
+# ---------------------------------------------------------------------------
+
+class TestFabricFindingWiring:
+    """run_gate_checks must call the bridge best-effort, keyed on the resolved
+    dispatch_id, without ever changing its own verdict."""
+
+    def test_hold_records_finding_when_dispatch_resolved(
+        self, state_dir, dispatch_dir, tmp_path, monkeypatch
+    ):
+        (dispatch_dir / "active" / "d.md").write_text(
+            "# Dispatch\n\n**PR**: PR-6\nDispatch-ID: d-hold\n"
+        )
+        oi = {"schema_version": "1.0", "items": [
+            {"id": "OI-001", "status": "open", "severity": "blocker", "title": "x", "pr_id": "PR-6"},
+        ]}
+        (state_dir / "open_items.json").write_text(json.dumps(oi))
+
+        captured = {}
+        monkeypatch.setattr(
+            pre_merge_gate, "record_gate_finding",
+            lambda state_dir, **kw: captured.update(kw) or True,
+        )
+        result = run_gate_checks(
+            pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True,
+        )
+        assert result["verdict"] == "HOLD"
+        assert captured["dispatch_id"] == "d-hold"
+        assert captured["gate_name"] == "pre_merge_gate"
+        assert captured["pr_ref"] == "PR-6"
+        assert "open_items" in captured["summary"]
+
+    def test_go_resolves_finding_when_dispatch_resolved(
+        self, state_dir, dispatch_dir, tmp_path, monkeypatch
+    ):
+        (dispatch_dir / "active" / "d.md").write_text(
+            "# Dispatch\n\n**PR**: PR-6\nDispatch-ID: d-go\n"
+        )
+        captured = {}
+        monkeypatch.setattr(
+            pre_merge_gate, "resolve_gate_finding",
+            lambda state_dir, **kw: captured.update(kw) or True,
+        )
+        result = run_gate_checks(
+            pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True,
+        )
+        assert result["verdict"] == "GO"
+        assert captured["dispatch_id"] == "d-go"
+        assert captured["gate_name"] == "pre_merge_gate"
+
+    def test_no_dispatch_file_skips_bridge_entirely(
+        self, state_dir, dispatch_dir, tmp_path, monkeypatch
+    ):
+        """No dispatch file for this PR -> unresolved dispatch_id -> bridge never called."""
+        calls = {"n": 0}
+        monkeypatch.setattr(
+            pre_merge_gate, "record_gate_finding",
+            lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
+        )
+        monkeypatch.setattr(
+            pre_merge_gate, "resolve_gate_finding",
+            lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
+        )
+        run_gate_checks(
+            pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True,
+        )
+        assert calls["n"] == 0
+
+    def test_bridge_failure_never_changes_verdict(
+        self, state_dir, dispatch_dir, tmp_path, monkeypatch
+    ):
+        """Defense in depth: even if the (already best-effort) bridge itself regressed and
+        raised, run_gate_checks must still return its verdict rather than crash."""
+        (dispatch_dir / "active" / "d.md").write_text(
+            "# Dispatch\n\n**PR**: PR-6\nDispatch-ID: d-boom\n"
+        )
+
+        def _boom(*a, **k):
+            raise RuntimeError("db locked")
+
+        monkeypatch.setattr(pre_merge_gate, "resolve_gate_finding", _boom)
+        result = run_gate_checks(
+            pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True,
+        )
+        assert result["verdict"] == "GO"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes the gap proven by ppb #1039: a BLOCKING gate finding lived only in a report, so it needed a manual handoff to carry it. Now a blocking gate (pre_merge_gate HOLD, phantom_guard reject) emits a track-linked `blocks` open-item via the single-writer `tracks.py` primitives, so open blocking-findings surface in `vnx horizon`/kickoff without reading the PR.

Track: kickoff-gate-findings-to-fabric (P1). Governed dispatch `20260708-gate-findings-fabric` (tmux-subscription lane).

## Changes
- `scripts/lib/gate_findings_bridge.py` (new) — the bridge.
- Wired into `scripts/lib/phantom_guard.py`, `scripts/pre_merge_gate.py`, `scripts/lib/dispatch_envelope.py`, `scripts/lib/dispatch_govern.py`, `scripts/lib/tracks.py`, `scripts/planning_cli.py`.
- Tests: gate_findings_bridge, phantom_guard_inline, pre_merge_gate, planning_cli_objective (+472 test lines).

## Verification
CI + codex-gate on this PR (governance-core: touches phantom_guard + pre_merge_gate). Idempotency, linked→open-item, unlinked→no-op, tenant scoping covered per the instruction DoD.

## Open Items
Post-merge: `vnx horizon link-pr kickoff-gate-findings-to-fabric <pr>`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY