### PR TITLE
feat(hooks): SessionStart auto-close tick (git-grounded, trust-gated)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -46,6 +46,16 @@
     ],
     "SessionStart": [
       {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/session_reconcile_autoclose.sh\"'",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
         "matcher": "terminals/T0",
         "hooks": [
           {

--- a/scripts/hooks/session_reconcile_autoclose.sh
+++ b/scripts/hooks/session_reconcile_autoclose.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# VNX SessionStart auto-close tick
+#
+# Fires on Claude Code's SessionStart hook for the interactive T0/operator
+# session. Runs `objective reconcile` so tracks whose PRs merged since the last
+# session close automatically, keeping the horizon in sync with git reality
+# without a long-running supervisor.
+#
+# WHY a session hook and not a cron/launchd agent: `gh` auth is keyring-backed
+# on this fleet (no GH_TOKEN), so a headless launchd context cannot authenticate
+# the `gh pr view` calls reconcile depends on — every PR would come back
+# `unverified` and nothing would close. The interactive session HAS keychain
+# access, so this is the reliable context. Session-start is also the moment a
+# synced horizon matters most (kickoff).
+#
+# SAFETY — self-disabling trust gate: only runs `--apply` (writes phase) when
+# `reconcile-streak` reports flip_criterion_met=true. If that trust is ever lost
+# (a false-candidate review resets the streak) it silently drops back to CHECK
+# mode (advisory, zero writes). reconcile itself only closes tracks whose linked
+# PRs are verified MERGED on GitHub.
+#
+# Scoped to the interactive session: fires ONLY when VNX_DISPATCH_ID is UNSET.
+# A tmux-spawn worker (VNX_DISPATCH_ID set) drains stdin and exits 0 — no-op.
+#
+# Detached (nohup + background) so it never blocks session start. Always exit 0.
+
+# Drain the hook's stdin JSON so the caller never blocks.
+cat >/dev/null 2>&1 || true
+
+# ── Guard: skip tmux-spawn workers; only the interactive session ticks ───────
+if [ -n "${VNX_DISPATCH_ID:-}" ]; then
+    exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+CLI="$ROOT/scripts/planning_cli.py"
+LOG_DIR="$ROOT/.vnx-data/logs"
+LOG="$LOG_DIR/objective_reconcile.log"
+
+# No CLI, nothing to do.
+[ -f "$CLI" ] || exit 0
+mkdir -p "$LOG_DIR" 2>/dev/null || true
+
+# Run the whole tick detached so session start never waits on gh network calls.
+(
+    # Resolve project_id the same way the CLI does (git remote / .vnx-project-id),
+    # falling back to the reconcile default. Empty is fine — the CLI resolves it.
+    PID="${VNX_PROJECT_ID:-}"
+    PID_ARGS=()
+    [ -n "$PID" ] && PID_ARGS=(--project-id "$PID")
+
+    # Decide apply vs check from the trust gate.
+    MODE="check"
+    if python3 "$CLI" objective reconcile-streak "${PID_ARGS[@]}" --json 2>/dev/null \
+        | python3 -c 'import sys,json;
+d=json.load(sys.stdin);
+sys.exit(0 if d.get("flip_criterion_met") else 1)' 2>/dev/null; then
+        MODE="apply"
+    fi
+
+    STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+    echo "[$STAMP] session-reconcile tick: mode=$MODE" >>"$LOG" 2>&1
+
+    if [ "$MODE" = "apply" ]; then
+        python3 "$CLI" objective reconcile "${PID_ARGS[@]}" --apply --repo-root "$ROOT" >>"$LOG" 2>&1
+    else
+        python3 "$CLI" objective reconcile "${PID_ARGS[@]}" --repo-root "$ROOT" >>"$LOG" 2>&1
+    fi
+) </dev/null >/dev/null 2>&1 &
+
+exit 0


### PR DESCRIPTION
## Summary
Runs `objective reconcile` at interactive session start so tracks whose PRs merged since last close auto-close, keeping the horizon in sync with git reality without a long-running supervisor. Item 2 of the top-10 (recurring auto-close), operator-approved.

Why a session hook, not launchd/cron: `gh` auth is keyring-backed on this fleet (no GH_TOKEN), so a headless context cannot authenticate the `gh pr view` calls reconcile needs. The interactive session has keychain access; session-start is also when a synced horizon matters most.

## Changes
- `scripts/hooks/session_reconcile_autoclose.sh` (new) — trust-gated, detached, always exit 0.
- `.claude/settings.json` — wires the hook into SessionStart.

## Verification
Both guards verified locally: interactive session → fires in apply-mode (flip_criterion_met=true) and logs; a tmux-spawn worker (VNX_DISPATCH_ID set) no-ops. Self-disabling to CHECK mode if the reconcile-streak trust is ever lost.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY