### PR TITLE
feat(role): provider-agnostic role sync + fix dual-CLI gap + project resolution

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -8,11 +8,16 @@ You are the BRAIN, not the HANDS.
 Before any orchestration action, load `@t0-orchestrator`.
 Do not run orchestration from memory; follow the skill workflow.
 
-For the next 4-feature hardening lane, operate in full autonomous mode:
-- no routine user checkpoints
-- no pause requests unless a true chain-breaking blocker prevents safe continuation
-- after each feature: close -> merge -> verify merge -> create next branch/worktree from post-merge `main`
-- do not end the chain with unresolved chain-created open items
+### Autonomous Execution
+
+When operating in autonomous mode (no routine user checkpoints), follow this discipline:
+- No pause requests unless a true chain-breaking blocker prevents safe continuation.
+- After each feature: close -> merge -> verify merge -> create next branch/worktree from post-merge `main`.
+- Do not end the chain with unresolved chain-created open items.
+- Review every receipt critically; close open items only after your own verification, then promote only the next eligible dispatch.
+- Maximize safe parallelism only where dependencies explicitly allow it.
+- Keep working until the queue truly blocks or the active objective is completed.
+- Do not ask the user to continue unless there is a real strategic blocker or destructive-risk choice.
 
 ## Startup State
 
@@ -79,8 +84,10 @@ bash scripts/commands/t0_role_audit.sh
 - T0 runtime is Claude Opus only.
 - `T1` and `T2` are manually Sonnet-pinned; do not assume runtime `/model` switching works.
 - `T3` is a Claude review/certification terminal and must be treated as modal-sensitive after `/clear`.
-- Tri-file support (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) applies to worker terminals.
-- T0 orchestration uses `CLAUDE.md` only.
+- Tri-file support (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) is fleet-wide, including T0 (deliberate,
+  as of the provider-agnostic role sync): an orchestrator session may run under Claude
+  (`CLAUDE.md` -> `@role-orchestrator.md`), Codex (`AGENTS.md`), or Kimi/Gemini (`GEMINI.md`).
+  `vnx role sync --apply` keeps all three carrying the same canonical role.
 
 ## Permissions and Hard Guardrails
 
@@ -106,6 +113,22 @@ bash scripts/commands/t0_role_audit.sh
 7. Dispatch one block at a time and keep queue state consistent.
 8. Request required headless review gates and verify their report + receipt evidence before closure.
 
+### Deliverable Review Standard
+
+Review every worker deliverable critically. Weak evidence is not acceptable. For every material
+receipt, verify at minimum:
+- claimed file changes exist
+- claimed behavior exists in code
+- relevant old failure patterns are absent or explicitly bounded
+- relevant tests pass on the integrated branch head
+- retained evidence exists where required
+
+If a deliverable is not good enough: reject or hold the receipt, reopen or create open items, send
+the work back to the relevant terminal — do not soften or bypass the gate.
+
+Developers do NOT certify their own work: T1/T2 implement, T3 certifies, T0 is the sole authority
+for acceptance and queue advancement.
+
 ## Core Decision Rules
 
 1. risk ≤ 0.3 + success + work pending → DISPATCH (no deep verification needed).
@@ -117,6 +140,43 @@ bash scripts/commands/t0_role_audit.sh
 7. If the review stack requires Gemini or Codex evidence, do not complete until both a gate result and a normalized headless report exist.
 8. `queued` review-gate state is only request state, not completion evidence.
 9. A required gate with empty `contract_hash` or empty `report_path` is incomplete evidence and blocks closure.
+
+## Dispatch Promotion Rule
+
+No staged dispatch may be promoted merely because a receipt exists. Promote from staging only
+after checking:
+- dependency eligibility
+- queue state
+- open-item state
+- claimed file changes
+- claimed behavior in code
+- required tests and retained evidence for that deliverable
+
+If the previous deliverable is not truly accepted, the next one does not start.
+
+## Promote vs Manager-Block Rule
+
+When T0 promotes a staged dispatch, the project's dispatch delivery mechanism automatically
+delivers it to the target terminal. T0 must NOT also issue a Manager Block for the same
+dispatch — doing so causes a duplicate delivery.
+
+Manager Blocks are only for situations outside the staged dispatch system:
+- ad-hoc follow-up instructions
+- new issues or decisions not covered by an existing dispatch
+- re-dispatch after rejection with modified instructions
+
+Normal queue flow: promote -> wait for receipt -> review -> promote next. No Manager Block needed.
+
+## Completion Rule
+
+The active objective is only complete when:
+- all queued deliverables are accepted
+- all blocker/warn open items are closed or explicitly deferred with rationale
+- retained evidence matches the required gates
+- the final verdict names an exact release candidate SHA
+- rollout boundaries are explicit
+- docs, queue, and verdict speak the same truth
+- any required soak/verification window has a final verdict, where the plan requires one
 
 ## Headless Review Enforcement
 
@@ -147,11 +207,23 @@ RATIONALE: `gh pr checks` lists individual job names but the workflow as a whole
 
 ## Doubt Escalation Policy
 
-When uncertain, use this order:
+Ask the user as little as possible. When uncertain, use this order:
 
 1. Request a second review (another terminal/person) for the same deliverable.
 2. Present clear options and tradeoffs to the user and ask for decision.
 3. Do not dispatch or close critical items until ambiguity is resolved.
+
+Only escalate to the user when:
+- there is a real strategic decision that cannot be derived from local truth
+- there is a destructive or irreversible action that is not clearly authorized (e.g. production
+  migrations, committing secrets, force-push)
+- the objective's truth is contradictory and cannot be reconciled locally
+- rollout risk is materially unclear and cannot be bounded from evidence
+
+Do NOT ask the user for:
+- permission to continue to the next dispatch
+- informal go-aheads after normal receipt review
+- trivial queue advancement decisions
 
 ## Stale Lease Cleanup (Required Before First Dispatch)
 

--- a/bin/vnx
+++ b/bin/vnx
@@ -1380,28 +1380,80 @@ HELP
   fi
 }
 
+# Returns 0 if upserting the marked block described by $2-$4 into $1 would be
+# a no-op (already current), 1 otherwise. Runs the real vnx_upsert_marked_block
+# against a scratch copy, so callers get an exact answer without touching the
+# real target file — shared by role-sync's dry-run reporting and its
+# backup-only-on-real-change guard in --apply mode.
+_role_sync_block_current() {
+  local target_file="$1" snippet_file="$2" marker_begin="$3" marker_end="$4"
+  local scratch probe_result
+  scratch="$(mktemp)"
+  if [ -f "$target_file" ]; then
+    cp "$target_file" "$scratch"
+  else
+    rm -f "$scratch"
+  fi
+  if vnx_upsert_marked_block "$scratch" "$snippet_file" "$marker_begin" "$marker_end"; then
+    probe_result=0
+  else
+    probe_result=$?
+  fi
+  rm -f "$scratch"
+  [ "$probe_result" -eq 0 ]
+}
+
 # cmd_role_sync — idempotent refresh of a project's CANONICAL orchestrator role
-# (.claude/terminals/T0/role-orchestrator.md) from the installed VNX. This is the
-# fleet-canonicalization companion to skills sync: the role file is byte-identical
-# across the whole fleet, while each project's terminals/T0/CLAUDE.md stays local
-# (a thin `@role-orchestrator.md` import + project-specific context — the only
-# sanctioned per-project deviation, NEVER touched here).
-# Safe by design: timestamped backup before any overwrite, dry-run preview is the
-# DEFAULT, and the project CLAUDE.md is left untouched (project context preserved).
+# (.claude/terminals/T0/role-orchestrator.md) from the installed VNX, and
+# provider-agnostic mirrors of it (marked block in AGENTS.md / GEMINI.md,
+# alongside role-orchestrator.md in the T0 dir) so an orchestrator session
+# running under Codex or Kimi/Gemini gets the SAME canonical role as Claude.
+# This is the fleet-canonicalization companion to skills sync: the role is
+# byte-identical across the whole fleet, while each project's
+# terminals/T0/CLAUDE.md stays local (a thin `@role-orchestrator.md` import +
+# project-specific context — the only sanctioned per-project deviation, NEVER
+# touched here).
+# Safe by design: timestamped backup before any overwrite, dry-run preview is
+# the DEFAULT, and the project CLAUDE.md is left untouched.
+#
+# Target resolution: independent of the ambient $PROJECT_ROOT. A standalone
+# dev checkout of vnx-orchestration always resolves its own $PROJECT_ROOT to
+# $VNX_HOME (runtime/bootstrap stays local to the checkout) — correct for
+# every other command, but wrong here, since role sync's whole job is to
+# target a *different*, consumer repo. Resolves fresh from cwd's git root (or
+# --project-dir) every invocation instead.
 cmd_role_sync() {
-  _guard_not_vnx_home "$PROJECT_ROOT" || return 1
   local apply=0
+  local project_dir_arg=""
   while [ "$#" -gt 0 ]; do
     case "$1" in
       --apply)   apply=1; shift ;;
       --dry-run) apply=0; shift ;;
-      -h|--help) echo "Usage: vnx role sync [--apply|--dry-run]"; return 0 ;;
+      --project-dir)
+        [ "$#" -ge 2 ] || { err "[role-sync] --project-dir requires a value"; return 1; }
+        project_dir_arg="$2"; shift 2 ;;
+      -h|--help)
+        echo "Usage: vnx role sync [--apply|--dry-run] [--project-dir DIR]"
+        return 0
+        ;;
       *) err "[role-sync] unknown argument: $1"; return 1 ;;
     esac
   done
 
+  local target_root
+  if [ -n "$project_dir_arg" ]; then
+    target_root="$(cd "$project_dir_arg" 2>/dev/null && pwd)" || {
+      err "[role-sync] --project-dir not found: $project_dir_arg"; return 1
+    }
+  else
+    target_root="$(git -C "$(pwd)" rev-parse --show-toplevel 2>/dev/null)" || target_root=""
+    [ -n "$target_root" ] || target_root="$(pwd)"
+  fi
+
+  _guard_not_vnx_home "$target_root" || return 1
+
   local shipped_role="$VNX_HOME/.claude/terminals/T0/role-orchestrator.md"
-  local project_t0_dir="$PROJECT_ROOT/.claude/terminals/T0"
+  local project_t0_dir="$target_root/.claude/terminals/T0"
   local project_role="$project_t0_dir/role-orchestrator.md"
 
   if [ ! -f "$shipped_role" ]; then
@@ -1412,15 +1464,16 @@ cmd_role_sync() {
     return 1
   fi
 
+  local role_current=0
   if [ -f "$project_role" ] && cmp -s "$shipped_role" "$project_role"; then
-    log "[role-sync] canonical role already current with $VNX_HOME (no changes)"
-    return 0
-  fi
-
-  log "[role-sync] canonical role differs from project (or is absent) — would update:"
-  log "  $project_role"
-  if [ -f "$project_role" ]; then
-    diff -u "$project_role" "$shipped_role" 2>/dev/null | head -40 || true
+    role_current=1
+    log "[role-sync] role-orchestrator.md already current with $VNX_HOME (no changes)"
+  else
+    log "[role-sync] canonical role differs from project (or is absent) — would update:"
+    log "  $project_role"
+    if [ -f "$project_role" ]; then
+      diff -u "$project_role" "$shipped_role" 2>/dev/null | head -40 || true
+    fi
   fi
 
   # Warn (do not block) when the project CLAUDE.md is still a monolith and does
@@ -1431,35 +1484,92 @@ cmd_role_sync() {
     log "[role-sync]       Convert it to a thin '@role-orchestrator.md' + project-context to activate this."
   fi
 
+  # Provider-agnostic (anti-lock-in): mirror the canonical role into a marked
+  # block in AGENTS.md (Codex) and GEMINI.md (Gemini/Kimi), sitting alongside
+  # role-orchestrator.md in the T0 dir. Reuses the same insert-or-replace
+  # marked-block helper as `patch-agent-files` (vnx_upsert_marked_block), with
+  # its own marker pair so it never collides with the project-root bootstrap
+  # block those commands manage.
+  local role_marker_begin="<!-- VNX:BEGIN T0-ROLE -->"
+  local role_marker_end="<!-- VNX:END T0-ROLE -->"
+  local changed_files=()
+  local provider_file base
+
+  for provider_file in "$project_t0_dir/AGENTS.md" "$project_t0_dir/GEMINI.md"; do
+    base="$(basename "$provider_file")"
+
+    if _role_sync_block_current "$provider_file" "$shipped_role" "$role_marker_begin" "$role_marker_end"; then
+      log "[role-sync] $base already current (no changes)"
+      continue
+    fi
+
+    if [ "$apply" -eq 0 ]; then
+      log "[role-sync] would sync canonical role block -> $provider_file"
+      continue
+    fi
+
+    if [ -f "$provider_file" ]; then
+      local ts backup
+      ts="$(date +%Y%m%d-%H%M%S)"
+      backup="$provider_file.bak.$ts"
+      if ! cp "$provider_file" "$backup"; then
+        err "[role-sync] backup failed for $provider_file; aborting"; return 1
+      fi
+      log "[role-sync] backed up $base -> $backup"
+    fi
+
+    local result
+    if vnx_upsert_marked_block "$provider_file" "$shipped_role" "$role_marker_begin" "$role_marker_end"; then
+      result=0
+    else
+      result=$?
+    fi
+    case "$result" in
+      0) log "[role-sync] $base already current (no changes)" ;;
+      1) log "[role-sync] created $provider_file"; changed_files+=("$base") ;;
+      2) log "[role-sync] updated $provider_file"; changed_files+=("$base") ;;
+      *) err "[role-sync] failed to update $provider_file"; return 1 ;;
+    esac
+  done
+
   if [ "$apply" -eq 0 ]; then
     log "[role-sync] dry-run (default). Re-run with --apply to update (a backup is made first)."
     return 0
   fi
 
-  if [ -f "$project_role" ]; then
-    local ts backup
-    ts="$(date +%Y%m%d-%H%M%S)"
-    backup="$project_role.bak.$ts"
-    if ! cp "$project_role" "$backup"; then
-      err "[role-sync] backup failed; aborting (no changes made)"; return 1
+  if [ "$role_current" -eq 0 ]; then
+    if [ -f "$project_role" ]; then
+      local ts backup
+      ts="$(date +%Y%m%d-%H%M%S)"
+      backup="$project_role.bak.$ts"
+      if ! cp "$project_role" "$backup"; then
+        err "[role-sync] backup failed; aborting (no changes made)"; return 1
+      fi
+      log "[role-sync] backed up current role -> $backup"
     fi
-    log "[role-sync] backed up current role -> $backup"
+
+    # Atomic replace: write a same-directory temp file, then rename over the target.
+    # A rename on the same filesystem is atomic, so a T0 reader never sees a
+    # truncated/partial role file even if this is interrupted mid-write.
+    local tmp
+    tmp="$(mktemp "$project_t0_dir/.role-orchestrator.XXXXXX")" || {
+      err "[role-sync] could not create temp file in $project_t0_dir; aborting"; return 1
+    }
+    if ! cp "$shipped_role" "$tmp"; then
+      rm -f "$tmp"; err "[role-sync] copy to temp failed; aborting (no changes made)"; return 1
+    fi
+    if ! mv -f "$tmp" "$project_role"; then
+      rm -f "$tmp"; err "[role-sync] atomic replace failed; aborting (backup preserved)"; return 1
+    fi
+    log "[role-sync] refreshed role-orchestrator.md from $VNX_HOME (project CLAUDE.md untouched)"
+    changed_files+=("role-orchestrator.md")
   fi
 
-  # Atomic replace: write a same-directory temp file, then rename over the target.
-  # A rename on the same filesystem is atomic, so a T0 reader never sees a
-  # truncated/partial role file even if this is interrupted mid-write.
-  local tmp
-  tmp="$(mktemp "$project_t0_dir/.role-orchestrator.XXXXXX")" || {
-    err "[role-sync] could not create temp file in $project_t0_dir; aborting"; return 1
-  }
-  if ! cp "$shipped_role" "$tmp"; then
-    rm -f "$tmp"; err "[role-sync] copy to temp failed; aborting (no changes made)"; return 1
+  if [ "${#changed_files[@]}" -gt 0 ]; then
+    log "[role-sync] changed: ${changed_files[*]}"
+  else
+    log "[role-sync] no changes (already current)"
   fi
-  if ! mv -f "$tmp" "$project_role"; then
-    rm -f "$tmp"; err "[role-sync] atomic replace failed; aborting (backup preserved)"; return 1
-  fi
-  log "[role-sync] refreshed role-orchestrator.md from $VNX_HOME (project CLAUDE.md untouched)"
   log "[role-sync] done. Verify a T0 launch loads it: bash scripts/commands/t0_role_audit.sh"
 }
 
@@ -1474,11 +1584,17 @@ cmd_role() {
 Usage: vnx role <command>
 
 Commands:
-  sync [--apply|--dry-run]   Refresh .claude/terminals/T0/role-orchestrator.md (the
-                             canonical, fleet-identical orchestrator role) from the
-                             installed VNX, with a timestamped backup. The project
-                             terminals/T0/CLAUDE.md (thin import + project context) is
-                             left untouched. Default is --dry-run (preview).
+  sync [--apply|--dry-run] [--project-dir DIR]
+                             Refresh the canonical, fleet-identical T0 orchestrator
+                             role in the target repo's .claude/terminals/T0/: Claude's
+                             role-orchestrator.md (imported by CLAUDE.md), plus a
+                             marked canonical-role block in AGENTS.md (Codex) and
+                             GEMINI.md (Gemini/Kimi) — same role, any provider. Target
+                             repo defaults to the current directory's git root;
+                             override with --project-dir. Timestamped backup before
+                             any overwrite. The project terminals/T0/CLAUDE.md (thin
+                             import + project context) is left untouched. Default is
+                             --dry-run (preview).
 HELP
   else
     err "[role] unknown subcommand: $sub (try 'vnx role --help')"

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Tests for `vnx role sync` — provider-agnostic fleet-wide T0 role sync.
+
+Dispatch-ID: 20260708-090921-rolesync-provider-agnostic
+
+Covers the two blocking bugs fixed here and the new provider-agnostic feature:
+  - Bug 1 (dual-CLI gap): `role sync` now exists on both the bash `bin/vnx` and
+    the Python `vnx_cli` entry points, and both must agree.
+  - Bug 2 (project resolution): `cmd_role_sync` no longer trusts the ambient
+    $PROJECT_ROOT (which a standalone dev checkout of vnx-orchestration always
+    collapses onto $VNX_HOME) — it resolves the target repo fresh from cwd's
+    git root (or an explicit --project-dir) on every invocation.
+  - Feature: --apply also mirrors the canonical role into a marked block in
+    AGENTS.md (Codex) and GEMINI.md (Gemini/Kimi), alongside role-orchestrator.md,
+    so a Codex/Kimi orchestrator session gets the same role as Claude.
+
+Isolation: every test targets a throwaway tmp_path project via --project-dir or
+an isolated cwd; a regression guard asserts the repo's own
+.claude/terminals/T0/ is never touched.
+"""
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+VNX = REPO / "bin" / "vnx"
+SHIPPED_ROLE = REPO / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+ROLE_MARKER_BEGIN = "<!-- VNX:BEGIN T0-ROLE -->"
+ROLE_MARKER_END = "<!-- VNX:END T0-ROLE -->"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _run_bash(*args: str, cwd: Path, env: dict = None):
+    run_env = dict(os.environ)
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        ["bash", str(VNX), "role", "sync", *args],
+        capture_output=True, text=True, cwd=str(cwd), env=run_env,
+    )
+
+
+def _run_python(*args: str, cwd: Path, env: dict = None):
+    run_env = dict(os.environ)
+    run_env["PYTHONPATH"] = str(REPO) + os.pathsep + run_env.get("PYTHONPATH", "")
+    if env:
+        run_env.update(env)
+    return subprocess.run(
+        [sys.executable, "-m", "vnx_cli.main", "role", "sync", *args],
+        capture_output=True, text=True, cwd=str(cwd), env=run_env,
+    )
+
+
+def _init_git(path: Path):
+    subprocess.run(["git", "init", "-q"], cwd=str(path), check=True)
+    subprocess.run(["git", "config", "user.email", "test@test.local"], cwd=str(path), check=True)
+    subprocess.run(["git", "config", "user.name", "test"], cwd=str(path), check=True)
+
+
+def _make_project(tmp_path: Path, name: str = "project") -> Path:
+    """A bare project with a T0 terminal dir + a thin CLAUDE.md import, no role yet."""
+    root = tmp_path / name
+    t0 = root / ".claude" / "terminals" / "T0"
+    t0.mkdir(parents=True)
+    (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+    return root
+
+
+def _backups(t0_dir: Path, basename: str):
+    return sorted(t0_dir.glob(f"{basename}.bak.*"))
+
+
+# ---------------------------------------------------------------------------
+# --dry-run default / --apply writes
+# ---------------------------------------------------------------------------
+
+class TestDryRunDefault:
+    def test_dry_run_is_default_and_writes_nothing(self, tmp_path):
+        project = _make_project(tmp_path)
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "dry-run" in (r.stdout + r.stderr)
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert not (t0 / "role-orchestrator.md").exists()
+        assert not (t0 / "AGENTS.md").exists()
+        assert not (t0 / "GEMINI.md").exists()
+
+    def test_explicit_dry_run_flag_writes_nothing(self, tmp_path):
+        project = _make_project(tmp_path)
+        r = _run_bash("--dry-run", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert not (t0 / "role-orchestrator.md").exists()
+
+    def test_apply_writes_all_three_provider_surfaces(self, tmp_path):
+        project = _make_project(tmp_path)
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert (t0 / "role-orchestrator.md").read_text() == SHIPPED_ROLE.read_text()
+        for provider_file in ("AGENTS.md", "GEMINI.md"):
+            content = (t0 / provider_file).read_text()
+            assert ROLE_MARKER_BEGIN in content
+            assert ROLE_MARKER_END in content
+            assert "T0 - VNX Master Orchestrator" in content
+        # CLAUDE.md (the thin import) must never be touched by role sync.
+        assert (t0 / "CLAUDE.md").read_text() == "@role-orchestrator.md\n"
+
+
+# ---------------------------------------------------------------------------
+# Tri-file write: AGENTS.md + GEMINI.md get the marked role block, idempotent
+# ---------------------------------------------------------------------------
+
+class TestTriFileWrite:
+    def test_marked_block_contains_full_canonical_role(self, tmp_path):
+        project = _make_project(tmp_path)
+        _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        agents = (t0 / "AGENTS.md").read_text()
+        start = agents.index(ROLE_MARKER_BEGIN) + len(ROLE_MARKER_BEGIN) + 1
+        end = agents.index(ROLE_MARKER_END)
+        block_body = agents[start:end]
+        assert block_body.strip() == SHIPPED_ROLE.read_text().strip()
+
+    def test_idempotent_on_reapply_no_new_backups_no_content_change(self, tmp_path):
+        project = _make_project(tmp_path)
+        _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        agents_before = (t0 / "AGENTS.md").read_text()
+        gemini_before = (t0 / "GEMINI.md").read_text()
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "already current" in (r.stdout + r.stderr).lower()
+        assert (t0 / "AGENTS.md").read_text() == agents_before
+        assert (t0 / "GEMINI.md").read_text() == gemini_before
+        assert _backups(t0, "AGENTS.md") == []
+        assert _backups(t0, "GEMINI.md") == []
+        assert _backups(t0, "role-orchestrator.md") == []
+
+    def test_preserves_content_outside_marker_block(self, tmp_path):
+        """A hand-written AGENTS.md may carry other project instructions —
+        role sync must only touch its own marked block."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "AGENTS.md").write_text("# Project Codex notes\n\nSome custom guidance.\n")
+        _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        content = (t0 / "AGENTS.md").read_text()
+        assert "# Project Codex notes" in content
+        assert "Some custom guidance." in content
+        assert ROLE_MARKER_BEGIN in content
+
+
+# ---------------------------------------------------------------------------
+# Backup-first + atomic replace
+# ---------------------------------------------------------------------------
+
+class TestBackupAndAtomicReplace:
+    def test_backup_made_before_role_overwrite_and_holds_old_content(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "role-orchestrator.md").write_text("OUTDATED ROLE CONTENT\n")
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+
+        backups = _backups(t0, "role-orchestrator.md")
+        assert len(backups) == 1
+        assert backups[0].read_text() == "OUTDATED ROLE CONTENT\n"
+        assert (t0 / "role-orchestrator.md").read_text() == SHIPPED_ROLE.read_text()
+
+    def test_provider_file_backup_made_only_on_real_drift(self, tmp_path):
+        project = _make_project(tmp_path)
+        _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+
+        # Corrupt the block body (not just append after it) to force real drift.
+        agents = (t0 / "AGENTS.md").read_text()
+        corrupted = agents.replace("T0 - VNX Master Orchestrator", "CORRUPTED TITLE")
+        (t0 / "AGENTS.md").write_text(corrupted)
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        backups = _backups(t0, "AGENTS.md")
+        assert len(backups) == 1
+        assert "CORRUPTED TITLE" in backups[0].read_text()
+        assert "CORRUPTED TITLE" not in (t0 / "AGENTS.md").read_text()
+
+    def test_no_temp_files_left_behind(self, tmp_path):
+        project = _make_project(tmp_path)
+        _run_bash("--apply", "--project-dir", str(project), cwd=tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        leftover = [p for p in t0.iterdir() if p.name.startswith(".role-orchestrator.")]
+        assert leftover == []
+
+
+# ---------------------------------------------------------------------------
+# Consumer-repo resolution (Bug 2): targets cwd's repo, not VNX_HOME
+# ---------------------------------------------------------------------------
+
+class TestConsumerRepoResolution:
+    def test_resolves_git_root_from_a_subdirectory_no_project_dir_flag(self, tmp_path):
+        """The core Bug-2 regression: invoking with no --project-dir from a
+        sub-directory of a consumer repo must resolve the repo's git ROOT, not
+        the sub-directory and not VNX_HOME."""
+        project = _make_project(tmp_path, "consumer")
+        _init_git(project)
+        subdir = project / "some" / "nested" / "dir"
+        subdir.mkdir(parents=True)
+
+        r = _run_bash("--apply", cwd=subdir)
+        assert r.returncode == 0, r.stderr
+
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert (t0 / "role-orchestrator.md").read_text() == SHIPPED_ROLE.read_text()
+        # Must not have been written into the subdirectory itself.
+        assert not (subdir / ".claude").exists()
+
+    def test_absolute_path_invocation_from_consumer_repo_never_touches_vnx_home(self, tmp_path):
+        """Reproduces the exact reported bug: `bash <vnx-checkout>/bin/vnx role
+        sync` invoked by absolute path from within a consumer repo must target
+        the consumer repo, never VNX_HOME (this repo's own checkout)."""
+        project = _make_project(tmp_path, "consumer")
+        _init_git(project)
+
+        before = subprocess.run(
+            ["git", "status", "--short", ".claude/terminals/T0/"],
+            capture_output=True, text=True, cwd=str(REPO),
+        ).stdout
+
+        r = _run_bash("--apply", cwd=project)
+        assert r.returncode == 0, r.stderr
+
+        after = subprocess.run(
+            ["git", "status", "--short", ".claude/terminals/T0/"],
+            capture_output=True, text=True, cwd=str(REPO),
+        ).stdout
+        assert before == after, "role sync must never write into VNX_HOME's own checkout"
+        assert not list(REPO.glob(".claude/terminals/T0/*.bak.*")), "no backup leak into VNX_HOME"
+
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert (t0 / "role-orchestrator.md").exists()
+
+    def test_project_dir_flag_overrides_cwd(self, tmp_path):
+        project = _make_project(tmp_path, "consumer")
+        unrelated_cwd = tmp_path / "elsewhere"
+        unrelated_cwd.mkdir()
+
+        r = _run_bash("--apply", "--project-dir", str(project), cwd=unrelated_cwd)
+        assert r.returncode == 0, r.stderr
+
+        t0 = project / ".claude" / "terminals" / "T0"
+        assert (t0 / "role-orchestrator.md").exists()
+        assert not (unrelated_cwd / ".claude").exists()
+
+    def test_missing_project_t0_dir_errors(self, tmp_path):
+        empty = tmp_path / "empty"
+        empty.mkdir()
+        r = _run_bash("--project-dir", str(empty), cwd=tmp_path)
+        assert r.returncode != 0
+        assert "bootstrap-terminals" in (r.stdout + r.stderr)
+
+
+# ---------------------------------------------------------------------------
+# VNX_HOME guard still refuses in-place (central install only)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def fake_central_vnx_home(tmp_path):
+    """A minimal, self-contained central-install VNX_HOME: real copies (not
+    symlinks — vnx_paths.sh resolves via `pwd -P`, which would follow a symlink
+    straight back to the real repo) of just what cmd_role_sync needs, marked
+    with .vnx-install-mode=central so `_guard_not_vnx_home` engages. Deliberately
+    omits scripts/lib/vnx_paths.sh so bin/vnx's inline fallback resolver (which
+    mirrors the same central-install detection) is exercised instead.
+    """
+    home = tmp_path / "fake-vnx-home"
+    (home / "bin").mkdir(parents=True)
+    (home / "scripts" / "lib").mkdir(parents=True)
+    (home / ".claude" / "terminals" / "T0").mkdir(parents=True)
+
+    (home / "bin" / "vnx").write_text(VNX.read_text())
+    (home / "bin" / "vnx").chmod(0o755)
+    (home / "scripts" / "lib" / "vnx_marked_blocks.sh").write_text(
+        (REPO / "scripts" / "lib" / "vnx_marked_blocks.sh").read_text()
+    )
+    (home / ".claude" / "terminals" / "T0" / "role-orchestrator.md").write_text(
+        SHIPPED_ROLE.read_text()
+    )
+    (home / ".vnx-install-mode").write_text("central\n")
+    # VNX_HOME must be its own git repo root for the central-install branch of
+    # the resolver to engage at all (mirrors a real central install, which is
+    # a git clone per scripts/lib update.py) — otherwise the resolver falls
+    # through to a different branch entirely and VNX_CANONICAL_ROOT collapses
+    # onto VNX_HOME regardless of cwd, a resolver quirk unrelated to role sync.
+    _init_git(home)
+    return home
+
+
+class TestVnxHomeGuard:
+    def test_refuses_when_target_equals_vnx_home(self, fake_central_vnx_home, tmp_path):
+        neutral_cwd = tmp_path / "neutral"
+        neutral_cwd.mkdir()
+        r = subprocess.run(
+            ["bash", str(fake_central_vnx_home / "bin" / "vnx"), "role", "sync",
+             "--apply", "--project-dir", str(fake_central_vnx_home)],
+            capture_output=True, text=True, cwd=str(neutral_cwd),
+        )
+        assert r.returncode != 0
+        assert "immutable central install" in (r.stdout + r.stderr)
+        assert not (fake_central_vnx_home / ".claude" / "terminals" / "T0" / "AGENTS.md").exists()
+
+    def test_allows_a_different_target_under_the_same_central_install(self, fake_central_vnx_home, tmp_path):
+        consumer = _make_project(tmp_path, "consumer")
+        r = subprocess.run(
+            ["bash", str(fake_central_vnx_home / "bin" / "vnx"), "role", "sync",
+             "--apply", "--project-dir", str(consumer)],
+            capture_output=True, text=True, cwd=str(tmp_path),
+        )
+        assert r.returncode == 0, r.stderr
+        assert (consumer / ".claude" / "terminals" / "T0" / "role-orchestrator.md").exists()
+
+
+# ---------------------------------------------------------------------------
+# Dual-CLI parity: bash and Python (vnx_cli) produce the same result
+# ---------------------------------------------------------------------------
+
+class TestDualCliParity:
+    def test_python_cli_delegates_and_agrees_with_bash(self, tmp_path):
+        bash_project = _make_project(tmp_path, "bash_target")
+        python_project = _make_project(tmp_path, "python_target")
+
+        r_bash = _run_bash("--apply", "--project-dir", str(bash_project), cwd=tmp_path)
+        assert r_bash.returncode == 0, r_bash.stderr
+
+        r_python = _run_python("--apply", "--project-dir", str(python_project), cwd=tmp_path)
+        assert r_python.returncode == 0, r_python.stderr
+
+        bash_t0 = bash_project / ".claude" / "terminals" / "T0"
+        python_t0 = python_project / ".claude" / "terminals" / "T0"
+        for name in ("role-orchestrator.md", "AGENTS.md", "GEMINI.md"):
+            assert (bash_t0 / name).read_text() == (python_t0 / name).read_text(), (
+                f"{name} diverged between bash bin/vnx and python vnx_cli"
+            )
+
+    def test_python_cli_dry_run_default_matches_bash(self, tmp_path):
+        bash_project = _make_project(tmp_path, "bash_target")
+        python_project = _make_project(tmp_path, "python_target")
+
+        r_bash = _run_bash("--project-dir", str(bash_project), cwd=tmp_path)
+        r_python = _run_python("--project-dir", str(python_project), cwd=tmp_path)
+
+        assert r_bash.returncode == 0 and r_python.returncode == 0
+        assert "dry-run" in (r_bash.stdout + r_bash.stderr)
+        assert "dry-run" in (r_python.stdout + r_python.stderr)
+        assert not (bash_project / ".claude" / "terminals" / "T0" / "role-orchestrator.md").exists()
+        assert not (python_project / ".claude" / "terminals" / "T0" / "role-orchestrator.md").exists()
+
+    def test_python_cli_errors_gracefully_without_a_vnx_home(self, tmp_path, monkeypatch):
+        """If bin/vnx cannot be found from the resolved engine root, the Python
+        CLI must fail loud with a clear message, never silently no-op."""
+        project = _make_project(tmp_path, "consumer")
+        fake_engine_root = tmp_path / "no-bin-here"
+        fake_engine_root.mkdir()
+
+        env = dict(os.environ)
+        env["PYTHONPATH"] = str(REPO) + os.pathsep + env.get("PYTHONPATH", "")
+        script = (
+            "import sys; from unittest.mock import patch; "
+            "from vnx_cli import _engine; "
+            f"patch.object(_engine, 'engine_root', return_value=__import__('pathlib').Path({str(fake_engine_root)!r})).start(); "
+            "from vnx_cli.main import main; "
+            f"sys.argv = ['vnx', 'role', 'sync', '--project-dir', {str(project)!r}]; "
+            "main()"
+        )
+        r = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True, text=True, cwd=str(tmp_path), env=env,
+        )
+        assert r.returncode != 0
+        assert "not found" in (r.stdout + r.stderr).lower()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/vnx_cli/commands/role.py
+++ b/vnx_cli/commands/role.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""vnx role — Python entrypoint for the fleet-wide canonical T0 role sync.
+
+Delegates to bin/vnx's bash implementation (`cmd_role_sync`) instead of
+reimplementing the marked-block merge logic a second time: a single
+implementation shared by both CLI surfaces guarantees dual-CLI parity by
+construction rather than by ongoing maintenance discipline. Same precedent as
+`patch_agent_files` in scripts/vnx_init.py, which shells out to
+`bin/vnx patch-agent-files`.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+from vnx_cli import _engine
+
+
+def vnx_role(args) -> int:
+    """Dispatch `vnx role <subcommand>`."""
+    sub = getattr(args, "role_subcommand", None)
+    if sub is None:
+        print("Usage: vnx role sync [--apply|--dry-run] [--project-dir DIR]", file=sys.stderr)
+        return 1
+    if sub == "sync":
+        return _vnx_role_sync(args)
+    print(f"ERROR: [role] unknown subcommand: {sub!r} (try 'vnx role sync')", file=sys.stderr)
+    return 1
+
+
+def _vnx_role_sync(args) -> int:
+    """`vnx role sync` — refresh the canonical T0 role in the target repo.
+
+    Resolves the bash implementation from the SAME engine tree this Python CLI
+    was loaded from (`_engine.engine_root()`), so the shipped canonical role
+    (`.claude/terminals/T0/role-orchestrator.md`) that bash's `$VNX_HOME`
+    resolves to is exactly the tree backing this command.
+    """
+    engine_root = _engine.engine_root()
+    vnx_bin = engine_root / "bin" / "vnx"
+    if not vnx_bin.exists():
+        print(
+            f"ERROR: [role-sync] bash implementation not found: {vnx_bin}\n"
+            "  'vnx role sync' requires a full VNX checkout (bin/vnx present) — "
+            "not available from this install.",
+            file=sys.stderr,
+        )
+        return 1
+
+    cmd = [str(vnx_bin), "role", "sync"]
+
+    # Default "." means "let bash resolve the target from cwd's git root" —
+    # the Bug-2 fix. An explicit --project-dir is a deliberate override, passed
+    # straight through (resolved to an absolute path so it survives regardless
+    # of the subprocess's cwd).
+    project_dir = getattr(args, "project_dir", ".") or "."
+    if project_dir != ".":
+        cmd.extend(["--project-dir", str(Path(project_dir).resolve())])
+
+    cmd.append("--apply" if getattr(args, "apply", False) else "--dry-run")
+
+    result = subprocess.run(cmd)
+    return result.returncode

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -153,6 +153,41 @@ def _register_pool_subparser(subparsers: argparse.Action) -> None:
     )
 
 
+def _register_role_subparser(subparsers: argparse.Action) -> None:
+    role_parser = subparsers.add_parser(
+        "role",
+        help="sync the canonical, fleet-wide T0 orchestrator role (Claude/Codex/Kimi)",
+    )
+    role_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="target repo directory (default: current directory's git root)",
+    )
+    role_subs = role_parser.add_subparsers(dest="role_subcommand", metavar="SUBCOMMAND")
+
+    rs_parser = role_subs.add_parser(
+        "sync",
+        help="refresh role-orchestrator.md + AGENTS.md/GEMINI.md role block from canonical VNX",
+    )
+    rs_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="target repo directory (default: current directory's git root)",
+    )
+    rs_apply_group = rs_parser.add_mutually_exclusive_group()
+    rs_apply_group.add_argument(
+        "--apply", action="store_true", dest="apply",
+        help="write changes, with a timestamped backup first (default: dry-run preview)",
+    )
+    rs_apply_group.add_argument(
+        "--dry-run", action="store_false", dest="apply",
+        help="preview only, no writes (default)",
+    )
+    rs_parser.set_defaults(apply=False)
+
+
 def _register_update_subparser(subparsers: argparse.Action) -> None:
     update_parser = subparsers.add_parser(
         "update",
@@ -787,6 +822,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.pool import main as pool_main
         sys.exit(pool_main(argv=getattr(args, "pool_args", None) or None))
 
+    elif args.command == "role":
+        from vnx_cli.commands.role import vnx_role
+        sys.exit(vnx_role(args))
+
     elif args.command == "version":
         from vnx_cli.commands.version import vnx_version
         sys.exit(vnx_version(args))
@@ -849,6 +888,7 @@ def main() -> None:
     _register_status_subparser(subparsers)
     _register_init_subparser(subparsers)
     _register_pool_subparser(subparsers)
+    _register_role_subparser(subparsers)
     _register_update_subparser(subparsers)
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)


### PR DESCRIPTION
## Summary

`vnx role sync` (#1056) was effectively non-functional fleet-wide. This PR fixes both blocking bugs, adds the provider-agnostic feature, and promotes the shared generic T0 policy into canon.

- **Bug 1 (dual-CLI gap):** `role sync` existed only in bash `bin/vnx`; the globally-installed Python `vnx_cli` had no `role` command at all (`invalid choice: 'role'`).
- **Bug 2 (project resolution):** `cmd_role_sync` used the ambient `$PROJECT_ROOT`, which a standalone dev checkout of vnx-orchestration always collapses onto `$VNX_HOME` — so running `role sync` by absolute path from a consumer repo silently compared the canonical role against itself and reported "already current" while the consumer repo had no role file at all.
- **Feature (provider-agnostic):** `--apply` now also mirrors the canonical role into a marked block in `AGENTS.md` (Codex) and `GEMINI.md` (Gemini/Kimi), alongside `role-orchestrator.md`, so an orchestrator run under any provider gets the same role.
- **Canon promotion:** folds six generic T0 policies every fleet repo had reinvented (Deliverable Review Standard, Doubt/User Escalation, Autonomous Execution discipline, Dispatch Promotion Rule, Promote vs Manager-Block Rule, Completion Rule) into the canonical role, genericized (no repo-specific paths). Updates the tri-file policy line: T0 may now run under Claude/Codex/Kimi, not Claude-only.

## Changes

- `bin/vnx`: `cmd_role_sync` resolves its target fresh from cwd's git root (or `--project-dir`) every invocation, independent of ambient `$PROJECT_ROOT`. `_guard_not_vnx_home` still refuses a central-install target. New `_role_sync_block_current` helper probes a scratch copy so dry-run reporting and the apply-mode backup-only-on-real-change guard share one code path (no backup spam on idempotent re-runs). Provider-file sync reuses `vnx_upsert_marked_block` with a new `<!-- VNX:BEGIN/END T0-ROLE -->` marker pair.
- `vnx_cli/commands/role.py` (new) + `vnx_cli/main.py`: registers `vnx role sync` on the Python CLI, delegating to `bin/vnx`'s bash implementation (same precedent as `patch_agent_files` in `scripts/vnx_init.py`) — one implementation, guaranteed parity instead of a second hand-maintained copy.
- `.claude/terminals/T0/role-orchestrator.md`: policy line update + the six promoted sections, folded into existing sections where they overlapped (Core Responsibilities, Doubt Escalation Policy, Mandatory Startup) and added as new sections where they didn't (Dispatch Promotion Rule, Promote vs Manager-Block Rule, Completion Rule).
- `tests/test_role_sync.py` (new, 18 tests): consumer-repo resolution (incl. the exact reported Bug-2 regression — absolute-path invocation from a consumer repo must never touch VNX_HOME), VNX_HOME guard (refuses central-install self-target, allows a different target under the same central install), dual-CLI parity, tri-file write + idempotency + block-content preservation, backup-first + atomic replace, dry-run default / `--apply` writes.
- Re-synced the fleet: seocrawler-v2, sales-copilot, mission-control now have a byte-identical `role-orchestrator.md` and newly-created `AGENTS.md`/`GEMINI.md` carrying the marked role block. `CLAUDE.md`/`project-context.md` in all three left untouched (confirmed via mtime + git status before/after).

## Test plan

- [x] `pytest tests/test_role_sync.py tests/test_vnx_cli.py tests/test_cli_init.py tests/test_skills_sync.py -q` — 55 passed
- [x] `bash -n bin/vnx` — syntax OK
- [x] `bash tests/test_vnx_marked_blocks_lib.sh` — PASS
- [x] Manual smoke test: dry-run/apply/re-apply/drift-detection against a scratch consumer repo (bash + Python surfaces)
- [x] Live re-sync against the 3 fleet repos, byte-identical role confirmed, marked blocks confirmed, CLAUDE.md/project-context.md confirmed untouched (mtime unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)