### PR TITLE
fix(providers): reconcile GLM constraint text to GLM-5.2 (SSOT)

### DIFF
--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -89,9 +89,10 @@ constraints:
       provider: zai
       via: direct
     reason: >-
-      Native Zhipu integration is deferred. Wave 7 PR-7.3 routes GLM-5.1
-      through OpenRouter; direct Zhipu API calls bypass the cost-tracking
-      pipeline and the fallback chain configured in routing_policy.yaml.
+      Native Zhipu integration is deferred. Wave 7 PR-7.3 routes GLM (GLM-5.2
+      current, GLM-5.1 available) through OpenRouter; direct Zhipu API calls
+      bypass the cost-tracking pipeline and the fallback chain configured in
+      routing_policy.yaml.
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false
@@ -102,10 +103,10 @@ constraints:
       provider: zai
       model: [glm-4.5, glm-4.6]
     reason: >-
-      GLM-4.5 and GLM-4.6 are legacy and superseded by GLM-5.1 (verified
-      2026-05-10, project_kimi_glm_integration_paths.md). The provider
-      will retire the legacy snapshots; new dispatches must use the
-      glm-5.1-default model key.
+      GLM-4.5 and GLM-4.6 are legacy and superseded by the GLM-5.x line
+      (verified 2026-05-10, project_kimi_glm_integration_paths.md). The
+      provider will retire the legacy snapshots; new dispatches use a
+      current GLM-5.x key (glm-5.2 preferred, glm-5.1 available).
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false


### PR DESCRIPTION
## Summary
Reconciles the GLM version named in `provider_constraints.yaml` reason-text with the README provider table shipped in #1058. Text-only, no behavior change.

## Changes
- `zai-via-openrouter-only` reason: "routes GLM-5.1" → "routes GLM (GLM-5.2 current, GLM-5.1 available)".
- `deprecated-glm-models` reason: "superseded by GLM-5.1 … must use the glm-5.1-default key" → "superseded by the GLM-5.x line … use a current GLM-5.x key (glm-5.2 preferred, glm-5.1 available)".

## Verification
- verify-before-build: the wave7 registry **already** ships `glm-5.2` (`openrouter/z-ai/glm-5.2`, 2026-06-16) and `deepseek-v4-pro/flash`; tests + the plan-gate panel already use glm-5.2. Only the constraint prose was stale.
- YAML parses (`yaml.safe_load`). No functional/routing key changed.

## Open Items
- The **fleet-wide GLM-5.2 default routing flip** (WP8) is intentionally NOT in this PR: it changes dispatch routing (blast radius) and deserves a considered change, not a doc-reconcile. Flagged for a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY