### PR TITLE
feat(horizon): hide done tracks from list by default (--all to show)

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -144,6 +144,16 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
     if args.horizon:
         tracks = [t for t in tracks if _horizon_key(t) == args.horizon]
 
+    # Actionable-by-default: hide done tracks unless --all or an explicit
+    # --phase done. Done work stays in its band and the receipt ledger; the
+    # default view should surface only what still needs a human, so a
+    # reconciled-but-unarchived track no longer reads as live drift.
+    hidden_done = 0
+    if not getattr(args, "all", False) and args.phase is None:
+        before = len(tracks)
+        tracks = [t for t in tracks if t["phase"] != "done"]
+        hidden_done = before - len(tracks)
+
     if args.json:
         out = [
             {
@@ -163,8 +173,12 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
         return 0
 
     if not tracks:
-        print(f"No objectives found for project '{project_id}'.")
-        print("Seed from ROADMAP: python3 scripts/seed_tracks_from_roadmap.py --apply")
+        if hidden_done:
+            print(f"No open objectives for project '{project_id}' "
+                  f"({hidden_done} done hidden — --all to show).")
+        else:
+            print(f"No objectives found for project '{project_id}'.")
+            print("Seed from ROADMAP: python3 scripts/seed_tracks_from_roadmap.py --apply")
         return 0
 
     # Group by horizon band.
@@ -191,6 +205,8 @@ def cmd_objective_list(args: argparse.Namespace) -> int:
                 f"{t.get('priority') or '-':<3} {t['title']}{pr_str}{dep_str}"
             )
         print()
+    if hidden_done:
+        print(f"({hidden_done} done hidden — --all or --phase done to show)\n")
     return 0
 
 
@@ -1894,6 +1910,8 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_list)
     p_list.add_argument("--horizon", choices=_HORIZON_ORDER, default=None)
     p_list.add_argument("--phase", choices=sorted(tracks_lib.VALID_PHASES), default=None)
+    p_list.add_argument("--all", action="store_true",
+                        help="include done tracks (hidden by default)")
     p_list.set_defaults(func=cmd_objective_list)
 
     p_show = obj_sub.add_parser("show", help="show one objective")

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -148,6 +148,44 @@ def test_horizon_add_list_round_trip(project, monkeypatch, capsys):
     assert {d["track_id"] for d in data} == {"feat-h1"}
 
 
+def test_horizon_list_hides_done_by_default(project, monkeypatch, capsys):
+    """Actionable-by-default: `horizon list` hides done tracks (they stay in
+    their band + the receipt ledger); --all and --phase done surface them
+    explicitly. Keeps a reconciled-but-unarchived track from reading as drift."""
+    project_dir, state_dir = project
+    pid = "horizon-test"
+
+    for tid in ("feat-open", "feat-shipped"):
+        rc, _, err = _run(monkeypatch, capsys, [
+            "horizon", "add", tid, f"Title {tid}", "shipped",
+            "--project-id", pid, "--project-dir", str(project_dir),
+        ])
+        assert rc == 0, err
+
+    # `add` always creates phase=queued; mark one done directly.
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    try:
+        conn.execute(
+            "UPDATE tracks SET phase = 'done' WHERE track_id = ? AND project_id = ?",
+            ("feat-shipped", pid),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    def _ids(extra):
+        rc, out, err = _run(monkeypatch, capsys, [
+            "horizon", "list", "--project-id", pid,
+            "--project-dir", str(project_dir), "--json", *extra,
+        ])
+        assert rc == 0, err
+        return {d["track_id"] for d in json.loads(out)}
+
+    assert _ids([]) == {"feat-open"}                                  # default: done hidden
+    assert _ids(["--all"]) == {"feat-open", "feat-shipped"}           # --all: both
+    assert _ids(["--phase", "done"]) == {"feat-shipped"}              # explicit done
+
+
 def test_horizon_resolves_central_store_not_repo_local(project, monkeypatch, capsys):
     project_dir, state_dir = project
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -369,6 +369,8 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     _common_horizon_args(p_list)
     p_list.add_argument("--horizon", choices=_HORIZON_CHOICES, default=None)
     p_list.add_argument("--phase", choices=_PHASE_CHOICES, default=None)
+    p_list.add_argument("--all", action="store_true",
+                        help="include done tracks (hidden by default)")
 
     p_show = subs.add_parser("show", help="show one objective")
     _common_horizon_args(p_show)


### PR DESCRIPTION
## Summary
Directly fixes the "why do closed items still show as drift" question: `vnx horizon list` rendered done tracks inline in their band, so 13 reconciled-but-archived-pending done tracks read as live drift in the NOW view — even though the git-grounded reconcile had already correctly set them to `done`. This is a display default, not a status problem.

## Changes
- `cmd_objective_list` (`scripts/planning_cli.py`): hide `phase=done` by default unless `--all` or an explicit `--phase done`, with a `(N done hidden — --all to show)` hint. Done work stays in its band + the receipt ledger; nothing is closed or moved.
- `--all` flag added to both CLI parsers: `vnx horizon list` (pip `vnx_cli/main.py`) and `vnx objective list` (`bin/vnx` → `scripts/planning_cli.py`).
- New parity test `test_horizon_list_hides_done_by_default`.

## Verification
- Manual, both CLIs: NOW default `32 → 19` visible (13 done hidden); `--all` shows all 32; `--phase done` shows the 13. pip `vnx` and `bin/vnx objective` parity confirmed.
- `pytest tests/test_horizon_cli.py` green incl. the new test.
- Note: `tests/test_horizon_parity.py` has 10 failures, but they are **pre-existing on clean main** (verified by stashing this diff) — a separate verb-parity drift (`objective` alias missing `link-pr`/`close`/`attest` in help), not introduced here.

## Open Items
- Pre-existing `test_horizon_parity.py` verb-drift flagged separately.
- The other half of drift-prevention (periodic auto-close tick, so the reconcile fires intra-session in long-lived T0s, not only at SessionStart) is a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY