### PR TITLE
docs(role): codify the file-layout master-rule in the canonical role

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -79,6 +79,10 @@ If you are reading this file, your role loaded correctly — Claude Code found i
 bash scripts/commands/t0_role_audit.sh
 ```
 
+## File-Layout Discipline (master-rule)
+
+Project files describe the project; the fabric describes itself. A repo's `CLAUDE.md` and `project-context.md` cover ONLY that repo — its stack, domain, and local conventions. HOW the fabric works (dispatch lanes, gates, horizon, state resolution, receipts) lives ONLY here, in this canonical role, and propagates via `vnx role sync`. Never copy fabric mechanism into a project file: a duplicated copy drifts the moment the fabric changes (proven — a consumer carried a stale batch-dispatch pattern the canon had already dropped). When a project file explains the fabric, strip that part and let the role carry it.
+
 ## Runtime Policy
 
 - T0 runtime is Claude Opus only.


### PR DESCRIPTION
## Summary
Codifies the WP1 principle in the canonical T0 role: project files describe the project; the fabric describes itself. This is the governance rule behind the whole fabric-hygiene initiative.

## Changes
- New "File-Layout Discipline (master-rule)" section in `.claude/terminals/T0/role-orchestrator.md`: a repo's `CLAUDE.md`/`project-context.md` cover only that repo; fabric mechanism (dispatch, gates, horizon, state, receipts) lives only in the canonical role and propagates via `vnx role sync`. Duplicated fabric mechanism drifts.

## Verification
- Text-only addition to the canonical role. Kept tight (~1 paragraph) to respect the T0-context-trim goal.
- Note: this changes the canonical role, so after merge the fleet is momentarily out of byte-parity until `vnx role sync --apply` propagates it to the consumer repos — an expected, intended propagation, not drift.

## Open Items
- The actual consumer root-CLAUDE.md strip (sc 18 / MC 21 / SEO 6 fabric-mechanism hits) stays **human-gated**: the prior content-migration pilot lost 54 lines of project content, so per-section judgment is required. This PR codifies the rule; it does not blind-strip.
- Run `vnx role sync --apply` after merge to propagate to the fleet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY