### PR TITLE
fix(dispatch): kimi=subscription, local-gemma=local in billing classifier

### DIFF
--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -167,11 +167,18 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         adapter = "provider"
     fired.append("D1")
 
-    # D2 — billing
+    # D2 — billing. Provider lanes are metered by default, with two exceptions:
+    # kimi runs on a flat CLI-OAuth subscription (kimi-via-cli-only), and
+    # local-gemma runs on-device with no API cost. Labeling both as
+    # provider_metered overstated cost and hid their real quota model.
     if is_claude_headless:
         billing = "api_metered"
     elif is_claude_lane:
         billing = "subscription"
+    elif provider == Provider.KIMI:
+        billing = "subscription"
+    elif provider == Provider.LOCAL_GEMMA:
+        billing = "local"
     else:
         billing = "provider_metered"
     fired.append("D2")

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -179,6 +179,33 @@ class TestProviderLaneParallel:
         assert plan.serialization_class is None
         assert plan.billing == "provider_metered"
 
+    def test_kimi_is_subscription_not_metered(self, tmp_path: Path) -> None:
+        # kimi runs on a flat CLI-OAuth subscription (kimi-via-cli-only), not
+        # per-token API billing; it must not be labeled provider_metered.
+        vspec = _make_vspec(provider=Provider.KIMI, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.lane == "provider"
+        assert plan.billing == "subscription"
+
+    def test_local_gemma_is_local_not_metered(self, tmp_path: Path) -> None:
+        # local-gemma runs on-device with no API cost.
+        vspec = _make_vspec(provider=Provider.LOCAL_GEMMA, target_slot="T1", tmp_path=tmp_path)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.billing == "local"
+
+    def test_metered_providers_stay_metered(self, tmp_path: Path) -> None:
+        # glm-harness (OpenRouter) and deepseek-harness (own key) are genuinely
+        # metered — the kimi/local exceptions must not leak to them.
+        for prov in (Provider.GLM_HARNESS, Provider.DEEPSEEK_HARNESS, Provider.GEMINI):
+            plan = compile_plan(
+                _make_vspec(provider=prov, target_slot="T1", tmp_path=tmp_path),
+                _healthy_snapshot(),
+            )
+            assert isinstance(plan, ExecutionPlan), prov
+            assert plan.billing == "provider_metered", prov
+
 
 # ---------------------------------------------------------------------------
 # test_staging_gate


### PR DESCRIPTION
## Summary
Fixes the dispatch-lane billing-label gap: D2 labeled every non-claude lane `provider_metered`, which overstated cost and hid the real quota model for two lanes.

## Changes
- `dispatch_plan.py` D2: `kimi` → `subscription` (flat CLI-OAuth, `kimi-via-cli-only`), `local-gemma` → `local` (on-device, no API cost). Genuinely metered lanes (codex, gemini, glm-harness/OpenRouter, deepseek-harness/own-key) stay `provider_metered`.
- 3 new tests: kimi=subscription, local-gemma=local, metered-providers-stay-metered.

## Verification
- `pytest tests/test_dispatch_plan.py` — 89 passed.
- `billing` is a label field (only surfaced in `dispatch_cli` output); no downstream logic branches on it, so the added values are safe.
- Billing model confirmed by the operator: kimi is subscription.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY