### PR TITLE
feat(bootstrap): thin the injected CLAUDE snippet to a pointer (WP1)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,38 +1,24 @@
 <!-- VNX:BEGIN BOOTSTRAP -->
-## VNX Governance System
+## VNX Governance
 
-This project uses **VNX Glass Box Governance** for multi-agent orchestration.
+This repository is governed by **VNX Glass Box Governance**: multi-agent orchestration with a human gate at every step and an append-only NDJSON receipt per dispatch.
 
-### How It Works
-VNX coordinates work across 4 terminals (T0-T3) with human gates at every step:
-- **T0** (Orchestrator): Plans work, creates dispatches, reviews results. Does NOT write code.
-- **T1** (Track A): Primary implementation — components, pages, features.
-- **T2** (Track B): Testing, integration, validation.
-- **T3** (Track C): Code review, security, performance analysis.
+The mechanism is not duplicated here. How the fabric works — the single-entry dispatch door and its lanes, review gates, the horizon planning layer, state resolution, and the report contract — lives in one canonical place so it can never drift out of a project file:
 
-### Key Paths
-- `.vnx/` — VNX system (skills, scripts, templates, docs). Do not modify.
-- `.vnx-data/` — Runtime state (dispatches, receipts, logs). Do not commit.
-- `.claude/terminals/T0-T3/CLAUDE.md` — Terminal-specific instructions.
-- `.claude/skills/` — Agent skills (copied from the shipped template at init; after init this is the source of truth — edit skills here directly).
+- **How the fabric works:** the canonical orchestrator role, `.claude/terminals/T0/role-orchestrator.md`, kept in sync fleet-wide by `vnx role sync`.
+- **Runbooks + gotchas:** the `fabric-reference` skill.
+- **Dispatch mechanics (lanes, provider routing, failure modes):** `docs/core/DISPATCH_RULES.md`.
 
-### Workflow
-1. T0 creates a dispatch in `.vnx-data/dispatches/pending/`
-2. Human promotes dispatch (approval gate)
-3. Workers (T1/T2/T3) execute their assigned tracks
-4. Interactive workers write reports to `$VNX_DATA_DIR/unified_reports/`
-5. Headless review gates write normalized reports to `$VNX_DATA_DIR/unified_reports/headless/` and structured results to `.vnx-data/state/review_gates/results/`
-6. Receipt processor generates NDJSON audit trail
-7. T0 reviews receipts, review-gate evidence, and closure state before advancing quality gates
+Everything above this block describes *this project*. Everything the fabric does lives in the canonical role — never copy fabric mechanism back into this file, or the copy drifts the moment the fabric changes.
+<!-- VNX:END BOOTSTRAP -->
 
-### Rules
-- Every change goes through a dispatch. No cowboy commits.
-- PRs are small (150-300 lines) and independently deployable.
-- `.vnx-data/` is runtime state — never commit it.
-- Read your terminal's CLAUDE.md for role-specific instructions.
-- Required headless review gates are not complete until both the result record and the normalized headless report exist.
+<!-- The sections below live here because this repo IS the fabric. In a consumer
+     project they do NOT belong in CLAUDE.md: the report contract reaches workers
+     operationally via build_directive() at dispatch time, and lane detail lives in
+     the canonical role + docs/core/DISPATCH_RULES.md. They stay outside the bootstrap
+     block so `vnx role sync` / re-init never propagates them into consumer files. -->
 
-### Mandatory Report Contract
+## Mandatory Report Contract
 
 **Every agent and worker MUST write a unified report on completing any task.**
 
@@ -56,7 +42,7 @@ Your report MUST contain these exact headings (aliases accepted):
 
 `## Summary` must be at least 50 non-whitespace characters. `## Open Items` may contain "None" explicitly. Include your dispatch ID as a plain-text or bold field (e.g. `Dispatch-ID: 20260601-213416-myfeature`). Full contract: `scripts/lib/report_body_contract.py`.
 
-### Dispatch lanes
+## Dispatch lanes
 
 Two lanes ship on main; T0 picks per task. Full decision rule, provider strings, concurrency, and failure modes live in **`docs/core/DISPATCH_RULES.md`** (tmux-spawn lane detail: `docs/operations/TMUX_SPAWN_LANE.md`).
 
@@ -66,7 +52,6 @@ Two lanes ship on main; T0 picks per task. Full decision rule, provider strings,
 **Provider→lane rule (hard).** `claude`/Opus/Sonnet panelists and workers route via the **tmux-spawn lane** (subscription, June-15 escape) — NEVER `provider_dispatch` (it refuses claude: claude is not a provider-lane provider) and NEVER headless `claude -p` (API credits post-cutover). `kimi`/`glm`(litellm:zai)/`deepseek` route via `provider_dispatch.py`. Everything dispatches through the **single-entry door** (`vnx dispatch`), which decides the lane; calling a lane script directly is a side door (PR-12 consolidates the remaining ones, incl. the plan-gate panel). The plan-first gate (`plan_gate_panel.py`) honors this split.
 
 For full documentation: `docs/`
-<!-- VNX:END BOOTSTRAP -->
 
 <important if="working on schemas/migrations">
 ADR-007 binding: every new central-DB table requires composite UNIQUE/PK over project_id.

--- a/templates/snippets/CLAUDE_SNIPPET.md
+++ b/templates/snippets/CLAUDE_SNIPPET.md
@@ -1,65 +1,11 @@
-## VNX Governance System
+## VNX Governance
 
-This project uses **VNX Glass Box Governance** for multi-agent orchestration.
+This repository is governed by **VNX Glass Box Governance**: multi-agent orchestration with a human gate at every step and an append-only NDJSON receipt per dispatch.
 
-### How It Works
-VNX coordinates work across 4 terminals (T0-T3) with human gates at every step:
-- **T0** (Orchestrator): Plans work, creates dispatches, reviews results. Does NOT write code.
-- **T1** (Track A): Primary implementation — components, pages, features.
-- **T2** (Track B): Testing, integration, validation.
-- **T3** (Track C): Code review, security, performance analysis.
+The mechanism is not duplicated here. How the fabric works — the single-entry dispatch door and its lanes, review gates, the horizon planning layer, state resolution, and the report contract — lives in one canonical place so it can never drift out of a project file:
 
-### Key Paths
-- `.vnx/` — VNX system (skills, scripts, templates, docs). Do not modify.
-- `.vnx-data/` — Runtime state (dispatches, receipts, logs). Do not commit.
-- `.claude/terminals/T0-T3/CLAUDE.md` — Terminal-specific instructions.
-- `.claude/skills/` — Agent skills (copied from the shipped template at init; after init this is the source of truth — edit skills here directly).
+- **How the fabric works:** the canonical orchestrator role, `.claude/terminals/T0/role-orchestrator.md`, kept in sync fleet-wide by `vnx role sync`.
+- **Runbooks + gotchas:** the `fabric-reference` skill.
+- **Dispatch mechanics (lanes, provider routing, failure modes):** `docs/core/DISPATCH_RULES.md`.
 
-### Workflow
-1. T0 creates a dispatch in `.vnx-data/dispatches/pending/`
-2. Human promotes dispatch (approval gate)
-3. Workers (T1/T2/T3) execute their assigned tracks
-4. Interactive workers write reports to `$VNX_DATA_DIR/unified_reports/`
-5. Headless review gates write normalized reports to `$VNX_DATA_DIR/unified_reports/headless/` and structured results to `.vnx-data/state/review_gates/results/`
-6. Receipt processor generates NDJSON audit trail
-7. T0 reviews receipts, review-gate evidence, and closure state before advancing quality gates
-
-### Rules
-- Every change goes through a dispatch. No cowboy commits.
-- PRs are small (150-300 lines) and independently deployable.
-- `.vnx-data/` is runtime state — never commit it.
-- Read your terminal's CLAUDE.md for role-specific instructions.
-- Required headless review gates are not complete until both the result record and the normalized headless report exist.
-
-### Mandatory Report Contract
-
-**Every agent and worker MUST write a unified report on completing any task.**
-
-This is how work enters the governed audit trail:
-```
-report on disk → receipt processor → t0_receipts.ndjson
-```
-
-Without a report, your work has no receipt and is invisible to governance.
-
-Write to: `$VNX_DATA_DIR/unified_reports/<dispatch-id>.md`
-
-Your report MUST contain these exact headings (aliases accepted):
-
-| Required | Accepted aliases |
-|---|---|
-| `## Summary` | — |
-| `## Changes` | `## Files Modified`, `## Work Completed` |
-| `## Verification` | `## Test Results`, `## Evidence`, `## Tests` |
-| `## Open Items` | — |
-
-`## Summary` must be at least 50 non-whitespace characters. `## Open Items` may contain "None" explicitly. Include your dispatch ID as a plain-text or bold field (e.g. `Dispatch-ID: 20260601-213416-myfeature`). Full contract: `scripts/lib/report_body_contract.py`.
-
-### Dispatch lanes
-
-Two lanes ship on main; T0 picks per task. Full decision rule, provider strings, concurrency, and failure modes live in **`docs/core/DISPATCH_RULES.md`** (tmux-spawn lane detail: `docs/operations/TMUX_SPAWN_LANE.md`).
-
-- **`scripts/lib/tmux_interactive_dispatch.py`** (default) — leaseless ephemeral, isolated worktree per dispatch, drives an interactive `claude` worker on the subscription. Use for parallel/independent feature work.
-- **`scripts/lib/subprocess_dispatch.py`** — terminal-pinned (Wave 5 smart-context, lease, triple-gate). Opt in per terminal with `VNX_ADAPTER_T{n}=subprocess`. Use for single-worker PRs that benefit from prior-round findings, or work expected to run >30 min. **No Anthropic SDK** — only `subprocess.Popen(["claude", ...])`.
-
-For full documentation: `.vnx/docs/`
+Everything above this block describes *this project*. Everything the fabric does lives in the canonical role — never copy fabric mechanism back into this file, or the copy drifts the moment the fabric changes.


### PR DESCRIPTION
## Summary
The WP1 fix, done at the source. The VNX bootstrap block — injected verbatim into every consumer's `CLAUDE.md` between the `VNX:BEGIN/END` markers — duplicated the full fabric mechanism into repos that don't own it. That's the drift source (a consumer carried a stale batch-dispatch copy the canon had dropped). Thinning the shared snippet fixes it fleet-wide from one place, not per-repo.

## Changes
- `templates/snippets/CLAUDE_SNIPPET.md` → a thin pointer: this repo is governed; how the fabric works lives in the canonical role (`.claude/terminals/T0/role-orchestrator.md`, synced by `vnx role sync`), the `fabric-reference` skill, and `docs/core/DISPATCH_RULES.md`. ~65 lines → ~12.
- This repo's own `CLAUDE.md`: bootstrap block regenerated to match the thin snippet; the report contract + dispatch-lane detail **moved out of the block** into hand-authored sections (this repo IS the fabric, so it keeps them — but outside the block so they never propagate to consumers).

## Verification
- `pytest tests/test_t0_skill_slim.py` — 9/9 green (enforces block == snippet, DISPATCH_RULES referenced, no verbose lane prose, report contract + `@~/.claude/vnx-local.md` retained).
- `tests/test_vnx_marked_blocks_lib.sh` — PASS.
- Consumer safety: `vnx_init.py` does an idempotent marker-replace, so re-running init/bootstrap updates each consumer's block in place with zero project-content loss (the markers bound exactly what changes). The report contract still reaches workers operationally via `build_directive()` at dispatch time.

## Open Items
- **Propagation:** re-run the bootstrap/patch-agent-files on sc / MC / SEO to thin their CLAUDE.md blocks (safe follow-up — marker-bounded).
- **Pre-existing (not this PR):** `test_init_migrate_bootstrap.py::...test_pool_default_db_path_honors_vnx_data_dir` fails on clean main too (test-ordering/env-leak: it picks up another test's tmpdir) — unrelated to this change; flagged for a separate fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011jv26QirCEyTADHu4DrVCY