### PR TITLE
fix(security): OI-222 SSRF hardening — CGNAT catch-all + DNS-rebind IP pinning

### DIFF
--- a/scripts/lib/url_policy.py
+++ b/scripts/lib/url_policy.py
@@ -11,7 +11,10 @@ Two-step validation:
      ``socket.getaddrinfo`` is range-checked. Catches a DNS record that
      points to RFC1918 / loopback / link-local / metadata space.
 
-The validator is policy-only: it never opens an HTTP connection.
+``URLPolicy`` itself is policy-only: it never opens an HTTP connection.
+Callers that need to fetch the validated URL should use
+:meth:`URLPolicy.validate_and_pin` + :func:`open_pinned_connection` (below)
+to avoid re-resolving the hostname after it has been vetted.
 
 Threats covered (SSRF taxonomy):
 - Private IPv4 (RFC1918), IPv4 loopback, link-local, unspecified, multicast
@@ -25,25 +28,29 @@ Threats covered (SSRF taxonomy):
 - CRLF / NUL injection in the raw URL string
 - Missing-host URLs: http:///path
 
-Known gaps (codex-gate PR #831, deferred to 1.0.1 SSRF-hardening OI):
-- F1: the final range check uses ``ip.is_private``, which does NOT reject
-  CGNAT (100.64.0.0/10) or other non-global-but-not-private ranges. A
-  stricter ``not ip.is_global`` check is the planned fix.
-- F2: DNS rebinding. This validator resolves and range-checks, then returns;
-  a later fetch re-resolves the hostname and could hit a rebound private IP.
-  Closing this requires the fetch path to pin the validated IP (connection-
-  level), which is the 1.0.1 wiring step — this module is policy-only and is
-  not yet wired into any production fetch path, so the gap has no live exposure.
+Fixed in OI-222 (1.0.1 SSRF-hardening):
+- F1: the final range check is ``not ip.is_global`` (was ``ip.is_private``,
+  which let CGNAT (100.64.0.0/10) and other non-global-but-not-private
+  ranges through).
+- F2: DNS-rebinding TOCTOU. ``validate_and_pin`` resolves + range-checks a
+  URL and returns a :class:`PinnedTarget` carrying the vetted IP; callers
+  connect to that IP directly (see :func:`open_pinned_connection`) instead
+  of letting the HTTP client re-resolve the hostname, which could by then
+  point somewhere unsafe.
 """
 
 from __future__ import annotations
 
+import http.client
 import ipaddress
 import socket
+from dataclasses import dataclass
 from typing import Iterable, Union
 from urllib.parse import urlparse
 
 IPAddress = Union[ipaddress.IPv4Address, ipaddress.IPv6Address]
+
+_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
 
 ALLOWED_SCHEMES: frozenset[str] = frozenset({"http", "https"})
 
@@ -69,13 +76,31 @@ class URLPolicyViolation(Exception):
     """Raised by :class:`URLPolicy` when a URL fails the SSRF policy.
 
     The ``reason`` attribute is a short, machine-friendly token identifying
-    why the URL was rejected (e.g. ``private_ip:10.0.0.5``).
+    why the URL was rejected (e.g. ``non_global_ip:10.0.0.5``).
     """
 
     def __init__(self, reason: str, url: str) -> None:
         super().__init__(f"{reason}: {url}")
         self.reason = reason
         self.url = url
+
+
+@dataclass(frozen=True)
+class PinnedTarget:
+    """Result of :meth:`URLPolicy.validate_and_pin`.
+
+    ``pinned_ip`` is the vetted address the caller MUST connect to (see
+    :func:`open_pinned_connection`). ``hostname`` is the original,
+    unresolved host — kept for the Host header and TLS SNI so the fetch
+    still looks like a normal request to ``hostname``, it just skips the
+    second DNS lookup that a rebind attack would exploit.
+    """
+
+    url: str
+    hostname: str
+    pinned_ip: str
+    port: int
+    scheme: str
 
 
 class URLPolicy:
@@ -100,6 +125,34 @@ class URLPolicy:
 
     def validate(self, url: str) -> None:
         """Validate ``url``; raise :class:`URLPolicyViolation` if unsafe."""
+        self._validate_impl(url)
+
+    def validate_and_pin(self, url: str) -> PinnedTarget:
+        """Validate ``url`` and pin it to the vetted IP.
+
+        Same checks as :meth:`validate`, but returns a :class:`PinnedTarget`
+        instead of ``None``. Use this instead of ``validate`` whenever the
+        caller is about to open a connection: fetching by ``pinned_ip``
+        (see :func:`open_pinned_connection`) closes the DNS-rebinding TOCTOU
+        window between this check and the actual HTTP request.
+        """
+        hostname, ip, port, scheme = self._validate_impl(url)
+        return PinnedTarget(
+            url=url,
+            hostname=hostname,
+            pinned_ip=str(ip),
+            port=port,
+            scheme=scheme,
+        )
+
+    def _validate_impl(self, url: str) -> tuple[str, IPAddress, int, str]:
+        """Shared validation core. Returns ``(hostname, ip, port, scheme)``.
+
+        For a hostname that resolves to multiple addresses, every address is
+        range-checked (any violation rejects the whole URL) and the first
+        resolved address is returned as the pin candidate, matching the
+        order ``getaddrinfo`` itself would try.
+        """
         if not isinstance(url, str) or not url:
             raise URLPolicyViolation("empty_url", str(url))
 
@@ -125,6 +178,7 @@ class URLPolicy:
             raise URLPolicyViolation("missing_host", url)
 
         hostname = hostname.lower()
+        port = parsed.port or _DEFAULT_PORTS.get(scheme, 0)
 
         if hostname in LOCALHOST_HOSTNAMES:
             raise URLPolicyViolation(
@@ -133,8 +187,9 @@ class URLPolicy:
 
         normalized = self._normalize_encoded_ipv4(hostname)
         if normalized is not None:
-            self._check_ip(ipaddress.ip_address(normalized), url)
-            return
+            ip = ipaddress.ip_address(normalized)
+            self._check_ip(ip, url)
+            return hostname, ip, port, scheme
 
         try:
             literal_ip = ipaddress.ip_address(hostname)
@@ -143,13 +198,14 @@ class URLPolicy:
 
         if literal_ip is not None:
             self._check_ip(literal_ip, url)
-            return
+            return hostname, literal_ip, port, scheme
 
         infos = socket.getaddrinfo(hostname, None)
 
         if not infos:
             raise URLPolicyViolation("dns_resolution_empty", url)
 
+        resolved_ips: list[IPAddress] = []
         for info in infos:
             addr = info[4][0]
             try:
@@ -159,11 +215,14 @@ class URLPolicy:
                     f"dns_returned_invalid_ip:{addr}", url
                 ) from exc
             self._check_ip(resolved_ip, url)
+            resolved_ips.append(resolved_ip)
+
+        return hostname, resolved_ips[0], port, scheme
 
     def _check_ip(self, ip: IPAddress, url: str) -> None:
         # Order matters: more specific labels fire before the catch-all
-        # ``is_private`` because Python classifies 0.0.0.0, link-local, and
-        # several reserved blocks as private as well.
+        # ``not ip.is_global`` because Python classifies 0.0.0.0, link-local,
+        # and several reserved blocks as non-global as well.
         ip_str = str(ip)
         if ip_str in METADATA_IPS:
             raise URLPolicyViolation(f"cloud_metadata_ip:{ip_str}", url)
@@ -177,8 +236,10 @@ class URLPolicy:
             raise URLPolicyViolation(f"multicast_ip:{ip_str}", url)
         if ip.is_reserved:
             raise URLPolicyViolation(f"reserved_ip:{ip_str}", url)
-        if ip.is_private:
-            raise URLPolicyViolation(f"private_ip:{ip_str}", url)
+        # Catch-all: rejects RFC1918 private space, CGNAT (100.64.0.0/10),
+        # and any other non-routable range not already named above.
+        if not ip.is_global:
+            raise URLPolicyViolation(f"non_global_ip:{ip_str}", url)
 
     @staticmethod
     def _normalize_encoded_ipv4(hostname: str) -> str | None:
@@ -211,3 +272,67 @@ class URLPolicy:
         if value < 0 or value > 0xFFFFFFFF:
             return None
         return str(ipaddress.IPv4Address(value))
+
+
+class _PinnedHTTPConnection(http.client.HTTPConnection):
+    """``HTTPConnection`` that connects to a fixed IP instead of resolving
+    ``host`` again. ``host`` is still used for the ``Host`` header."""
+
+    def __init__(self, pinned_ip: str, hostname: str, port: int, **kwargs) -> None:
+        super().__init__(hostname, port, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        self.sock = self._create_connection(
+            (self._pinned_ip, self.port), self.timeout, self.source_address
+        )
+        if self._tunnel_host:
+            self._tunnel()
+
+
+class _PinnedHTTPSConnection(http.client.HTTPSConnection):
+    """``HTTPSConnection`` that connects to a fixed IP instead of resolving
+    ``host`` again, then TLS-wraps using ``host`` for SNI and certificate
+    verification so the cert check still matches the original hostname."""
+
+    def __init__(self, pinned_ip: str, hostname: str, port: int, **kwargs) -> None:
+        super().__init__(hostname, port, **kwargs)
+        self._pinned_ip = pinned_ip
+
+    def connect(self) -> None:
+        sock = self._create_connection(
+            (self._pinned_ip, self.port), self.timeout, self.source_address
+        )
+        if self._tunnel_host:
+            self.sock = sock
+            self._tunnel()
+            sock = self.sock
+        server_hostname = self._tunnel_host if self._tunnel_host else self.host
+        self.sock = self._context.wrap_socket(sock, server_hostname=server_hostname)
+
+
+def open_pinned_connection(
+    target: PinnedTarget, timeout: float = 10.0
+) -> http.client.HTTPConnection:
+    """Open an HTTP(S) connection to ``target.pinned_ip``.
+
+    The ``Host`` header (and, for HTTPS, TLS SNI + certificate verification)
+    still uses ``target.hostname`` — the request looks identical to a normal
+    fetch of that hostname, it just skips the second DNS lookup a rebind
+    attack relies on. Callers must obtain ``target`` from
+    :meth:`URLPolicy.validate_and_pin`, not construct one by hand.
+
+    Usage::
+
+        target = URLPolicy().validate_and_pin(url)
+        conn = open_pinned_connection(target)
+        conn.request("GET", urlparse(target.url).path or "/")
+        resp = conn.getresponse()
+    """
+    if target.scheme == "https":
+        return _PinnedHTTPSConnection(
+            target.pinned_ip, target.hostname, target.port, timeout=timeout
+        )
+    return _PinnedHTTPConnection(
+        target.pinned_ip, target.hostname, target.port, timeout=timeout
+    )

--- a/tests/test_url_policy.py
+++ b/tests/test_url_policy.py
@@ -16,7 +16,11 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 
-from url_policy import URLPolicy, URLPolicyViolation
+from url_policy import (
+    URLPolicy,
+    URLPolicyViolation,
+    open_pinned_connection,
+)
 
 
 @pytest.fixture
@@ -48,7 +52,7 @@ def _fake_getaddrinfo(mapping: dict[str, list[str]]):
 def test_01_private_ipv4_rejected(policy: URLPolicy) -> None:
     with pytest.raises(URLPolicyViolation) as exc:
         policy.validate("http://10.0.0.5/admin")
-    assert "private_ip" in exc.value.reason
+    assert "non_global_ip" in exc.value.reason
     assert "10.0.0.5" in exc.value.reason
 
 
@@ -116,7 +120,7 @@ def test_07_dns_resolves_to_private_rejected(
     )
     with pytest.raises(URLPolicyViolation) as exc:
         policy.validate("https://sneaky.example.com/path")
-    assert "private_ip" in exc.value.reason
+    assert "non_global_ip" in exc.value.reason
     assert "10.20.30.40" in exc.value.reason
 
 
@@ -138,6 +142,150 @@ def test_10_userinfo_evasion_rejected(policy: URLPolicy) -> None:
         policy.validate("http://example.com@127.0.0.1/admin")
     assert "loopback_ip" in exc.value.reason
     assert "127.0.0.1" in exc.value.reason
+
+
+def test_11_cgnat_rejected(policy: URLPolicy) -> None:
+    """F1 — 100.64.0.0/10 (CGNAT) is not ``is_private`` but is non-global."""
+    for host in ("100.64.0.1", "100.127.255.255"):
+        with pytest.raises(URLPolicyViolation) as exc:
+            policy.validate(f"http://{host}/")
+        assert "non_global_ip" in exc.value.reason, host
+        assert host in exc.value.reason, host
+
+
+def test_11b_public_ip_still_passes_cgnat_fix(
+    policy: URLPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """F1 regression guard: a real public IP must still validate cleanly."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        _fake_getaddrinfo({"public.example.com": ["93.184.216.34"]}),
+    )
+    policy.validate("http://93.184.216.34/")
+    policy.validate("https://public.example.com/")
+
+
+# ---------------------------------------------------------------------------
+# F2 — DNS-rebinding TOCTOU (validate_and_pin)
+# ---------------------------------------------------------------------------
+
+
+def test_12_validate_and_pin_returns_vetted_ip(
+    policy: URLPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        _fake_getaddrinfo({"api.example.com": ["93.184.216.34"]}),
+    )
+    target = policy.validate_and_pin("https://api.example.com/v1")
+    assert target.hostname == "api.example.com"
+    assert target.pinned_ip == "93.184.216.34"
+    assert target.port == 443
+    assert target.scheme == "https"
+    assert target.url == "https://api.example.com/v1"
+
+
+def test_13_validate_and_pin_rejects_unsafe_target(
+    policy: URLPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        _fake_getaddrinfo({"sneaky.example.com": ["10.20.30.40"]}),
+    )
+    with pytest.raises(URLPolicyViolation):
+        policy.validate_and_pin("https://sneaky.example.com/")
+
+
+def test_14_pin_survives_dns_rebind(
+    policy: URLPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Simulates the classic TOCTOU: the resolver answers with a public IP
+    at validate-time, then flips to a private IP on the next lookup (as a
+    rebind attacker's authoritative DNS server would for a low-TTL record).
+    A caller connecting via the pinned target must still reach the public
+    IP that was actually vetted, never the rebound private one.
+    """
+    calls = {"n": 0}
+
+    def rebinding_resolver(host, *_args, **_kwargs):
+        calls["n"] += 1
+        addr = "93.184.216.34" if calls["n"] == 1 else "127.0.0.1"
+        return [(socket.AF_INET, socket.SOCK_STREAM, 0, "", (addr, 0))]
+
+    monkeypatch.setattr(socket, "getaddrinfo", rebinding_resolver)
+
+    target = policy.validate_and_pin("http://rebind.example.com/")
+    assert target.pinned_ip == "93.184.216.34"
+
+    # A later, independent resolution of the same host now returns the
+    # rebound private IP — proving the window exists...
+    second_lookup = socket.getaddrinfo("rebind.example.com", None)
+    assert second_lookup[0][4][0] == "127.0.0.1"
+
+    # ...but the pinned target is untouched: it never re-resolves.
+    assert target.pinned_ip == "93.184.216.34"
+
+    connect_calls = []
+
+    class _FakeSocket:
+        def __init__(self) -> None:
+            self.closed = False
+
+        def close(self) -> None:
+            self.closed = True
+
+    def fake_create_connection(address, *_args, **_kwargs):
+        connect_calls.append(address)
+        return _FakeSocket()
+
+    conn = open_pinned_connection(target, timeout=1.0)
+    monkeypatch.setattr(conn, "_create_connection", fake_create_connection)
+    conn.connect()
+
+    # The socket connects to the pinned IP, never to a fresh DNS answer —
+    # even though "rebind.example.com" now resolves to 127.0.0.1.
+    assert connect_calls == [("93.184.216.34", 80)]
+    assert conn.host == "rebind.example.com"
+
+
+def test_15_https_pin_connects_by_ip_but_verifies_original_hostname(
+    policy: URLPolicy, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """HTTPS pinning must dial the pinned IP while still presenting the
+    original hostname for TLS SNI + certificate verification — otherwise
+    the connection either fails cert validation or (worse) silently skips
+    it."""
+    monkeypatch.setattr(
+        socket,
+        "getaddrinfo",
+        _fake_getaddrinfo({"secure.example.com": ["93.184.216.34"]}),
+    )
+    target = policy.validate_and_pin("https://secure.example.com/")
+
+    connect_calls = []
+    wrap_calls = []
+
+    class _FakeSocket:
+        pass
+
+    def fake_create_connection(address, *_args, **_kwargs):
+        connect_calls.append(address)
+        return _FakeSocket()
+
+    def fake_wrap_socket(sock, server_hostname=None, **_kwargs):
+        wrap_calls.append(server_hostname)
+        return sock
+
+    conn = open_pinned_connection(target, timeout=1.0)
+    monkeypatch.setattr(conn, "_create_connection", fake_create_connection)
+    monkeypatch.setattr(conn._context, "wrap_socket", fake_wrap_socket)
+    conn.connect()
+
+    assert connect_calls == [("93.184.216.34", 443)]
+    assert wrap_calls == ["secure.example.com"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Closes the two confirmed SSRF gaps in `scripts/lib/url_policy.py` (sweep R8).

- **F1 — CGNAT bypass** (`url_policy.py:180`): the catch-all `if ip.is_private:` did not reject carrier-grade NAT (100.64.0.0/10). Replaced with `if not ip.is_global:` raising `non_global_ip:<ip>`. Specific earlier checks (unspecified/loopback/link_local/multicast/reserved/metadata) unchanged and still fire first for precise reasons; the new catch-all subsumes private + CGNAT + any other non-routable range.
- **F2 — DNS-rebinding TOCTOU**: added `PinnedTarget` + `URLPolicy.validate_and_pin(url)` and `open_pinned_connection(target)` (pinned-IP subclasses of HTTP/HTTPSConnection). The fetch dials the vetted IP directly instead of re-resolving; HTTPS still TLS-wraps with `server_hostname=hostname` so SNI + cert verification match the original host.

## Wiring
Grepped all outbound-HTTP call sites (`requests.*`, `urlopen`, `httpx`) — no production path fetches a user/config-influenced URL today (only fixed provider/API endpoints + a planted-vuln benchmark seed). Per the dispatch's explicit "do not invent one" instruction, no wiring was added; the new API is ready for a future doc-fetch enrichment.

## Verification
Full url_policy suite: 20 passed in 0.13s (incl. new `test_11_cgnat_rejected`, `test_14_pin_survives_dns_rebind`, `test_15_https_pin_connects_by_ip_but_verifies_original_hostname`).

Track: oi-222-ssrf-hardening · Dispatch: 20260709-074037-oi222-ssrf

🤖 Generated with [Claude Code](https://claude.com/claude-code)