### PR TITLE
test(dx): regression coverage for worker-CLI preflight + doctor probe (audit #6/#7/#8)

### DIFF
--- a/tests/test_dispatch_agent_preflight.py
+++ b/tests/test_dispatch_agent_preflight.py
@@ -1,0 +1,98 @@
+#!/usr/bin/env python3
+"""Tests for dispatch-agent claude-CLI preflight (audit-dx-dispatch-preflight).
+
+Covers:
+  1. Missing `claude` CLI on PATH -> preflight warning printed to stderr (non-Claude lanes
+     remain valid, so this is a warning, not a hard block).
+  2. Present `claude` CLI -> no preflight warning.
+  3. Failed door result -> actionable `vnx doctor` hint printed, exit code 1.
+  4. Successful door result -> no failure hint, exit code 0.
+
+VNX_DISPATCH_LEGACY=1 is set so deliver_via_door takes the `legacy()` branch (the mocked
+deliver_with_recovery) instead of routing through the real single-entry door's bridge_dispatch,
+which would attempt to stage and spawn a real dispatch.
+"""
+
+from __future__ import annotations
+
+import shutil
+import sys
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+_REAL_WHICH = shutil.which
+
+
+def _make_agent(base: Path, name: str = "hello-world", default_instruction: str = "Say hi") -> Path:
+    agent_dir = base / "examples" / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "CLAUDE.md").write_text(f"# {name} agent")
+    (agent_dir / "config.yaml").write_text(
+        f'governance_profile: minimal\ndefault_instruction: "{default_instruction}"\n'
+    )
+    return agent_dir
+
+
+def _run_dispatch(tmp_path: Path, monkeypatch, *, claude_present: bool, door_success: bool) -> int:
+    """Invoke vnx_dispatch_agent with the door forced to the legacy (mocked) lane."""
+    _make_agent(tmp_path)
+    monkeypatch.setenv("VNX_DISPATCH_LEGACY", "1")
+
+    def fake_which(tool):
+        if tool == "claude":
+            return "/usr/local/bin/claude" if claude_present else None
+        return _REAL_WHICH(tool)
+
+    from vnx_cli import _engine
+    with patch.object(_engine, "engine_root", return_value=tmp_path), \
+         patch("vnx_cli.commands.dispatch_agent._engine.ensure_engine_on_path"), \
+         patch("shutil.which", side_effect=fake_which), \
+         patch.dict(
+             "sys.modules",
+             {"subprocess_dispatch": MagicMock(deliver_with_recovery=lambda **kw: door_success)},
+         ):
+        from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
+        args = Namespace(agent="hello-world", instruction=None, model="sonnet", project_dir=str(tmp_path))
+        rc = vnx_dispatch_agent(args)
+    return rc
+
+
+class TestClaudePreflightWarning:
+    def test_missing_claude_prints_warning(self, tmp_path, monkeypatch, capsys):
+        rc = _run_dispatch(tmp_path, monkeypatch, claude_present=False, door_success=True)
+
+        captured = capsys.readouterr()
+        assert "'claude' CLI not found" in captured.err
+        assert "vnx doctor" in captured.err
+        assert rc == 0
+
+    def test_present_claude_no_warning(self, tmp_path, monkeypatch, capsys):
+        rc = _run_dispatch(tmp_path, monkeypatch, claude_present=True, door_success=True)
+
+        captured = capsys.readouterr()
+        assert "not found on PATH" not in captured.err
+        assert rc == 0
+
+
+class TestFailedDispatchHint:
+    def test_failed_dispatch_prints_actionable_hint_and_nonzero_exit(self, tmp_path, monkeypatch, capsys):
+        rc = _run_dispatch(tmp_path, monkeypatch, claude_present=False, door_success=False)
+
+        captured = capsys.readouterr()
+        assert rc == 1
+        assert "status      : failed" in captured.out
+        assert "vnx doctor" in captured.err
+        assert "Dispatch failed" in captured.err
+
+    def test_successful_dispatch_has_no_failure_hint(self, tmp_path, monkeypatch, capsys):
+        rc = _run_dispatch(tmp_path, monkeypatch, claude_present=True, door_success=True)
+
+        captured = capsys.readouterr()
+        assert rc == 0
+        assert "status      : done" in captured.out
+        assert "Dispatch failed" not in captured.err

--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -4,6 +4,7 @@
 import argparse
 import sqlite3
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -15,6 +16,7 @@ from vnx_cli.commands.doctor import (
     _check_overrides,
     _check_schema_versions,
     _check_skill_coverage,
+    _check_tools,
     vnx_doctor,
 )
 
@@ -291,6 +293,61 @@ class TestSchemaVersions:
         coord_check = next(r for r in results if "runtime_coordination" in r.name)
         assert coord_check.status == PASS
         assert "12" in coord_check.detail
+
+
+# ---------------------------------------------------------------------------
+# Test: worker-CLI probe (audit-dx-doctor-worker-cli, audit high #7)
+# ---------------------------------------------------------------------------
+
+class TestWorkerCliProbe:
+    def test_no_worker_cli_warns(self):
+        """No claude/codex/gemini/kimi on PATH -> tool:worker-cli is WARN, not FAIL."""
+        worker_clis = {"claude", "codex", "gemini", "kimi"}
+
+        def fake_which(tool):
+            if tool in worker_clis:
+                return None
+            return "/usr/bin/" + tool
+
+        with patch("shutil.which", side_effect=fake_which):
+            results = _check_tools()
+
+        worker_check = next(r for r in results if r.name == "tool:worker-cli")
+        assert worker_check.status == WARN
+        assert "no worker CLI" in worker_check.detail
+        assert "dispatch-agent" in worker_check.detail
+
+    def test_claude_present_passes(self):
+        """claude on PATH (even with other worker CLIs absent) -> tool:worker-cli PASS."""
+        def fake_which(tool):
+            if tool == "claude":
+                return "/usr/local/bin/claude"
+            if tool in ("codex", "gemini", "kimi"):
+                return None
+            return "/usr/bin/" + tool
+
+        with patch("shutil.which", side_effect=fake_which):
+            results = _check_tools()
+
+        worker_check = next(r for r in results if r.name == "tool:worker-cli")
+        assert worker_check.status == PASS
+        assert "claude" in worker_check.detail
+
+    def test_missing_worker_cli_does_not_fail_doctor(self, tmp_path, monkeypatch):
+        """A missing worker CLI is a WARN, so it must not push non-strict `vnx doctor` to exit 1."""
+        project = _make_project(tmp_path)
+        _make_coordination_db(project / ".vnx-data" / "state", schema_version=10)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        def fake_which(tool):
+            if tool in ("claude", "codex", "gemini", "kimi"):
+                return None
+            return "/usr/bin/" + tool
+
+        with patch("shutil.which", side_effect=fake_which):
+            exit_code = vnx_doctor(_make_args(str(project), strict=False))
+
+        assert exit_code == 0
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Verify-before-build outcome: the three targeted tracks (`audit-dx-dispatch-preflight`,
`audit-dx-doctor-worker-cli`, `audit-dx-prerequisites-docs`) were **already shipped in PR #958**
(`d498f6b1`, 2026-06-27). The tracks table still showed them `queued` (stale state), so this
dispatch ran against stale track state, not current code. No production change was needed or made.

What was genuinely missing: regression tests for that shipped behavior. This PR adds them (tests-only, ~155 lines).

## Changes
- `tests/test_dispatch_agent_preflight.py` (new, 4 tests): missing-claude warns to stderr, present-claude no warning, failed-door-result prints the `vnx doctor` hint (exit 1), success has no hint (exit 0). Uses `VNX_DISPATCH_LEGACY=1` to take the mocked legacy branch.
- `tests/test_vnx_doctor_strict.py`: `TestWorkerCliProbe` (3 tests) — no-worker-CLI WARNs, `claude`-present PASSes, missing worker CLI does not force non-strict doctor to non-zero.

Confirmed already-shipped: `dispatch_agent.py:91-98` (which-precheck) + `:124-130` (doctor hint); `doctor.py:55-67` (`tool:worker-cli` WARN probe); `README.md:93-99` (Prerequisites).

## Verification
`test_dispatch_agent_preflight.py`: 4 passed. The 7 new tests pass; git-stash-verified the delta is exactly these 7 (13→20 passed, 14 pre-existing failures unchanged).

## Follow-ups (pre-existing, NOT introduced here)
- 14 pre-existing failures in `test_vnx_doctor_strict.py` (env leakage in `TestEmbeddedMode`; `data_root` vs `project_dir` signature drift in Schema/Skill/Drain helpers).
- Pre-existing hang in `test_dispatch_agent_default_instruction.py` under door default-on routing (mocks the legacy fn, not `deliver_via_door`).

Tracks closed against #958 (their real closer), not this PR.
Dispatch: 20260709-080317-auditdx-workercli

🤖 Generated with [Claude Code](https://claude.com/claude-code)