### PR TITLE
fix(fabric): packaged backend-developer agent + consumer-door note (unblocks pip-consumer dispatch)

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -62,6 +62,7 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 **Worker dispatch policy:**
 
 - All dispatches go through the single-entry door `vnx dispatch <pending-id>`, which decides the lane. Calling a lane script directly is a side door (rollback only: `VNX_DISPATCH_LEGACY=1`).
+- Source vs. consumer: the door above (`bin/vnx dispatch <id>`) is the fabric source repo's form. In a pip-installed consumer repo (no `bin/`), the equivalent governed door is `vnx dispatch-agent --agent <name>` (it routes through the same `deliver_via_door` bridge); `vnx pool` replaces `bin/vnx pool`.
 - Provider→lane (hard): `claude`/Opus/Sonnet route via the tmux-spawn lane (`scripts/lib/tmux_interactive_dispatch.py`, interactive, subscription-preserving) — NEVER `provider_dispatch`, NEVER `claude -p`. `kimi`/`glm`/`deepseek` route via `provider_dispatch.py`.
 - Default model: sonnet. For complex reasoning: `--model opus` with `VNX_OVERRIDE_WORKERS_SONNET_PINNED=1`.
 - No Claude Code subagents (Task tool). Full decision rule: `docs/core/DISPATCH_RULES.md`.

--- a/examples/backend-developer/CLAUDE.md
+++ b/examples/backend-developer/CLAUDE.md
@@ -1,0 +1,33 @@
+# Backend Developer Agent
+
+You are a generic backend-developer worker for a single governed VNX dispatch.
+
+## Role
+
+Implement one small, independently-deployable change to a backend codebase: a
+bug fix, a feature, or a test addition, as directed by the dispatch
+instruction. Follow the target repo's own `CLAUDE.md` for local conventions —
+this file only describes the worker's role and report obligations.
+
+## Input
+
+A dispatch instruction describing the change to make.
+
+## Output
+
+- Working code that satisfies the instruction, with tests added or updated
+  and passing.
+- A branch named `dispatch/<dispatch-id>`, pushed to origin — never commit
+  directly to `main`.
+- A completion report at `$VNX_DATA_DIR/unified_reports/<dispatch-id>.md`
+  with the exact headings `## Summary`, `## Changes`, `## Verification`,
+  `## Open Items`.
+
+## Constraints
+
+- No TODO comments, mock objects, placeholder data, or partial features —
+  finish what you start.
+- Run the project's existing test suite before committing; report the exact
+  commands and pass/fail counts in the completion report.
+- Follow the target repo's established patterns and conventions.
+- No Anthropic SDK imports, no direct calls to api.anthropic.com — CLI-only.

--- a/examples/backend-developer/config.yaml
+++ b/examples/backend-developer/config.yaml
@@ -1,0 +1,8 @@
+governance_profile: minimal
+description: "Generic backend-developer worker for a single governed dispatch"
+default_instruction: "Implement the change described in the dispatch instruction: make the code change, add or update tests, and commit."
+isolation:
+  scope_type: example
+  allowed_paths:
+    - "examples/backend-developer/"
+    - ".vnx-data/unified_reports/"

--- a/tests/test_dispatch_agent_default_instruction.py
+++ b/tests/test_dispatch_agent_default_instruction.py
@@ -201,6 +201,25 @@ def test_hello_world_resolves_without_project_dir():
     assert result.name == "CLAUDE.md"
 
 
+def test_backend_developer_config_has_default_instruction():
+    """examples/backend-developer/config.yaml must have default_instruction."""
+    config_path = REPO_ROOT / "examples" / "backend-developer" / "config.yaml"
+    assert config_path.is_file(), "examples/backend-developer/config.yaml missing"
+    instruction = _read_default_instruction(config_path)
+    assert instruction, "default_instruction must be non-empty in backend-developer config.yaml"
+
+
+def test_backend_developer_resolves_without_project_dir():
+    """backend-developer resolves from engine root even in an empty project dir,
+    same packaged-examples fallback consumer repos (MC/SEO/sales-copilot) rely on
+    since they ship no local agents/ dir."""
+    with tempfile.TemporaryDirectory() as tmp:
+        empty = Path(tmp)
+        result = _resolve_agent_path(empty, "backend-developer")
+    assert result is not None, "backend-developer not found via engine root fallback"
+    assert result.name == "CLAUDE.md"
+
+
 # ---------------------------------------------------------------------------
 # 7. pyproject.toml declares examples/ in package-data
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Unblocks the governed dispatch door for pip-installed consumer repos (mission-control, seocrawler-v2, sales-copilot). Ships a packaged `backend-developer` example agent so `vnx dispatch-agent --agent backend-developer` resolves everywhere (previously only `hello-world` shipped), and adds one additive note to the canonical role clarifying the source-repo (`bin/vnx dispatch`) vs pip-consumer (`vnx dispatch-agent`) door split. Directly resolves the Mission Control dispatch blocker reported cross-T0.

## Changes
- `examples/backend-developer/CLAUDE.md` (new) — minimal generic worker role, mirrors `hello-world`.
- `examples/backend-developer/config.yaml` (new) — sensible `default_instruction` so the agent resolves + fires without an explicit `--instruction`.
- `tests/test_dispatch_agent_default_instruction.py` — 2 tests: config has default_instruction; `_resolve_agent_path` finds `backend-developer` from packaged-examples fallback (resolve-only).
- `.claude/terminals/T0/role-orchestrator.md` — one additive bullet: source door = `bin/vnx dispatch`; pip-consumer door = `vnx dispatch-agent` (same `deliver_via_door` bridge); `vnx pool` replaces `bin/vnx pool`. No lines deleted. `vnx role sync` intentionally NOT run (propagation is a deliberate per-repo step).

`examples/**/*` already in pyproject package-data — ships automatically, no pyproject change.

## Verification
`pytest tests/test_dispatch_agent_default_instruction.py -k "not TestDispatchAgentDefaultInstruction"` → 15 passed (incl. both new tests). Diff scoped to exactly 4 files.

## Follow-ups (pre-existing, not introduced)
- Flake in `TestDispatchAgentDefaultInstruction::test_uses_default_instruction_when_none_given` (mocks `subprocess_dispatch` but not `dispatch_bridge.deliver_via_door` → real door runs, phantom_guard rejects empty diff). Same flake the audit-dx worker independently found.
- The dual-CLI (`vnx dispatch` vs `vnx dispatch-agent`) reconcile remains a separate plan-gated decision.

Track: t0-role-load-drift · Dispatch: 20260709-080633-fabricdoor-consumer

🤖 Generated with [Claude Code](https://claude.com/claude-code)