### PR TITLE
feat(dispatch): make lane_safety.headless_block live + fail-closed (oi-223 + claude-headless-block)

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -31,7 +31,6 @@ owns lane selection (claude→tmux unless allow_headless). No Anthropic SDK impo
 from __future__ import annotations
 
 import hashlib
-import os
 import sys
 from pathlib import Path, PurePosixPath
 from typing import Optional
@@ -205,13 +204,19 @@ def bridge_dispatch(*, dry_run: bool = False, **stage_kwargs) -> int:
     error (e.g. unsafe dispatch_id, symlink escape) is surfaced as a clean 1 so a
     caller never falls back to a side-door delivery.
     """
-    if stage_kwargs.get("allow_headless") and os.environ.get("VNX_OVERRIDE_CLAUDE_HEADLESS") != "1":
-        print(
-            "[dispatch_bridge] REJECT [headless-blocked]: claude_headless lane blocked by default; "
-            "set VNX_OVERRIDE_CLAUDE_HEADLESS=1 to opt in",
-            file=sys.stderr,
-        )
-        return 1
+    if stage_kwargs.get("allow_headless"):
+        from routing_policy import is_claude_headless_blocked, load_lane_safety  # noqa: PLC0415
+        lane_safety = load_lane_safety()
+        if is_claude_headless_blocked(lane_safety):
+            override_env = (lane_safety.get("headless_block") or {}).get(
+                "override_env", "VNX_OVERRIDE_CLAUDE_HEADLESS"
+            )
+            print(
+                "[dispatch_bridge] REJECT [headless-blocked]: claude_headless lane blocked by default "
+                f"(lane_safety.headless_block, routing_policy.yaml); set {override_env}=1 to opt in",
+                file=sys.stderr,
+            )
+            return 1
     try:
         spec_file = stage_spec_bundle(**stage_kwargs)
     except (ValueError, OSError) as exc:

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -692,10 +692,19 @@ def _execute_claude_headless(
 
     Delegates all permit verification, TOCTOU check, and GOVERN to
     run_envelope_headless_plan — same security contract as the provider lane.
+
+    Fail-closed last gate before spawn: consults lane_safety.headless_block from
+    routing_policy.yaml (OI-223) instead of a hardcoded env check, so the yaml stays
+    the single source of truth for the block and its override var name.
     """
-    if os.environ.get("VNX_OVERRIDE_CLAUDE_HEADLESS") != "1":
+    from routing_policy import is_claude_headless_blocked, load_lane_safety  # noqa: PLC0415
+    lane_safety = load_lane_safety()
+    if is_claude_headless_blocked(lane_safety):
+        override_env = (lane_safety.get("headless_block") or {}).get(
+            "override_env", "VNX_OVERRIDE_CLAUDE_HEADLESS"
+        )
         raise PermissionError(
-            "claude_headless lane blocked by default; set VNX_OVERRIDE_CLAUDE_HEADLESS=1 to opt in"
+            f"claude_headless lane blocked by default; set {override_env}=1 to opt in"
         )
     result = run_envelope_headless_plan(plan, permit, state_dir=state_dir, data_dir=data_dir, role=role)
     return result.returncode

--- a/scripts/lib/providers/routing_policy.yaml
+++ b/scripts/lib/providers/routing_policy.yaml
@@ -45,12 +45,15 @@ rules:
 
 # Fallback chain when preferred lane fails (API down, rate-limited, etc)
 #
-# STATUS (2026-06-11, sweep H4 routing-conflict fix): this block is ADVISORY
-# only. No runner or dispatcher currently reads fallback_chain at runtime.
-# Entries document intended fallback behaviour; they do NOT trigger automatic
-# lane switching on their own. The kimi entry below reflects the corrected
-# kimi CLI lane — litellm:moonshot:* entries are kept for reference but
-# litellm:moonshot routing is blocked by kimi-via-cli-only (OI-223).
+# STATUS (2026-07-09, OI-223 lane_safety loader): still ADVISORY. decide_lane()
+# reads this block and resolves a chain onto RoutingDecision.fallback_chain, but
+# subprocess_dispatch._select_dispatch_path deliberately discards it for non-Claude
+# lanes ("This function never touches fallback_chain for non-Claude lanes") to avoid
+# silently rerouting a cheap-lane dispatch back onto Claude. No caller triggers
+# automatic lane switching on a failure. This is unrelated to the lane_safety block
+# below — OI-223 wired lane_safety.headless_block live, NOT fallback_chain. The kimi
+# entry below reflects the corrected kimi CLI lane — litellm:moonshot:* entries are
+# kept for reference but litellm:moonshot routing is blocked by kimi-via-cli-only.
 fallback_chain:
   "litellm:deepseek:*": ["kimi", "claude/sonnet-5"]
   "kimi": ["litellm:deepseek:deepseek-v4-pro", "claude/sonnet-5"]
@@ -58,27 +61,45 @@ fallback_chain:
   "claude/haiku-4-5": ["claude/sonnet-5"]
   # Sonnet and Opus have no fallback (they are the safety net)
 
-# Lane-safety rules — ADVISORY, NOT YET ENFORCED IN CODE.
+# Lane-safety rules.
 #
-# STATUS (2026-06-07, codex-gate PR #831 finding F6): these entries are
-# DECLARATIVE. No runner or dispatcher currently reads this block. They
-# document measured lane behaviour and the intended guard so the evidence
-# is findable, but they do NOT change routing on their own. Do not rely on
-# them as live guards.
-#
-# The ONE rule that IS live (force_headless) is enforced separately as a
-# hardcoded set in scripts/benchmark/field-tests/runners/lane_adapter.py
-# (HEADLESS_FORCED_MODELS) — kept in sync by hand, not read from here.
-#
-# Wiring a loader so the dispatcher reads these rules is tracked as a 1.0.1
-# open item (see PR #831 deferred-findings). Until then: advisory only,
-# every entry carries measured evidence but inert enforcement.
+# STATUS (2026-07-09, OI-223 lane_safety loader): the loader is now LIVE.
+# scripts/lib/routing_policy.load_lane_safety() parses this block and
+# is_claude_headless_blocked() reads `headless_block` below; both are
+# consulted at scripts/lib/dispatch_bridge.py (pre-stage reject) and
+# scripts/lib/dispatch_cli.py::_execute_claude_headless (the last gate
+# before spawn) instead of a hardcoded env-only check. Every OTHER entry in
+# this block (force_headless, claude_serial_under_load, codex_retry_once,
+# kimi_quota_fail_fast, tmux_spawn_max_runtime, haiku_receipt_nondeterminism)
+# remains DECLARATIVE — exposed by load_lane_safety() for tooling/tests, but
+# not read by any runtime gating decision. Do not rely on them as live guards.
 lane_safety:
+  # claude-headless-lane-block (OI-223 fold-in). LIVE as of this PR — see
+  # is_claude_headless_blocked() above. Refuses the claude_headless lane
+  # (`claude -p`, API-metered) by default; the tmux subscription lane stays
+  # the default for claude. Protects the production OAuth subscription
+  # post-2026-06-15 billing cutover (headless now bills API credits, not
+  # subscription quota). Set enabled: false here to lift the block yaml-side,
+  # or export the override_env var =1 to opt in per-dispatch.
+  headless_block:
+    enabled: true
+    override_env: "VNX_OVERRIDE_CLAUDE_HEADLESS"
+    reason: "claude -p (headless) is API-metered post-2026-06-15 cutover; the tmux subscription lane is the safe default for claude"
+
   # Anthropic Claude Code interactive-session hang (Issues #63390 + #64153).
   # Measured 2026-06-04/05: opus-4-8/4-7 + sonnet-5 hang for hours or exit
   # in 0.1s on complex content via the interactive tmux lane. The headless
   # `claude -p` path is unaffected. Force these models to the headless lane
   # until Anthropic ships a fix.
+  #
+  # SUPERSEDED (2026-06-15 empirical re-test, scripts/benchmark/field-tests/
+  # runners/lane_adapter.py HEADLESS_FORCED_MODELS): opus-4-8/4-7/sonnet-4-6
+  # completed trivial tasks cleanly on the tmux lane post-cutover; the hang did
+  # NOT reproduce, so that runner emptied its forced-model set. Left DECLARATIVE
+  # here (not wired into routing) deliberately: forcing these models onto
+  # headless would fight headless_block above and re-introduce the exact
+  # API-billing exposure OI-223 closes. Re-activate only via an explicit
+  # operator decision if the hang reproduces on a t3-complex (>1h) run.
   force_headless:
     models:
       - claude-opus-4-8

--- a/scripts/lib/routing_policy.py
+++ b/scripts/lib/routing_policy.py
@@ -53,6 +53,39 @@ def load_routing_policy(path: Path) -> dict:
     return data
 
 
+def load_lane_safety(policy_path: Optional[Path] = None) -> dict:
+    """Load the `lane_safety` block from routing_policy.yaml.
+
+    Returns the block as a plain dict (empty dict when the block is absent).
+    Raises the same errors as load_routing_policy on missing/malformed yaml.
+    """
+    if policy_path is None:
+        policy_path = _DEFAULT_POLICY_PATH
+    policy = load_routing_policy(policy_path)
+    lane_safety = policy.get("lane_safety") or {}
+    if not isinstance(lane_safety, dict):
+        raise ValueError(f"lane_safety block must be a mapping, got {type(lane_safety).__name__}")
+    return lane_safety
+
+
+def is_claude_headless_blocked(lane_safety: dict, env: Optional[Dict[str, str]] = None) -> bool:
+    """Return True when the claude_headless lane must be refused, per lane_safety + env.
+
+    Reads the `headless_block` rule (OI-223 claude-headless-lane-block fold-in) from the
+    loaded lane_safety block instead of a hardcoded env check, so routing_policy.yaml stays
+    the single source of truth. Fail-closed: a missing `headless_block` entry, or a missing
+    `enabled` key within it, still blocks. The override escape hatch is the env var named by
+    `headless_block.override_env` (default VNX_OVERRIDE_CLAUDE_HEADLESS) set to "1".
+    """
+    if env is None:
+        env = dict(os.environ)
+    block = lane_safety.get("headless_block") or {}
+    if not block.get("enabled", True):
+        return False
+    override_env = block.get("override_env") or "VNX_OVERRIDE_CLAUDE_HEADLESS"
+    return env.get(override_env) != "1"
+
+
 def decide_lane(
     task_class: str,
     complexity: str = "medium",

--- a/tests/test_dispatch_bridge_staging.py
+++ b/tests/test_dispatch_bridge_staging.py
@@ -107,3 +107,79 @@ def test_bridge_dispatch_rejects_unsafe_id_as_exit_1(tmp_path):
         target_slot="T1", project_id="p1", data_dir=tmp_path, dry_run=True,
     )
     assert rc == 1  # clean reject — never falls back to a side-door delivery
+
+
+# --- claude_headless lane_safety gate (OI-223): fail-closed by default, yaml-driven ---
+
+def test_bridge_headless_blocked_by_default_before_staging(tmp_path, monkeypatch, capsys):
+    """allow_headless=True without the override env var: REJECT before stage_spec_bundle
+    ever runs — no bundle is written, no side-door path is reachable."""
+    monkeypatch.delenv("VNX_OVERRIDE_CLAUDE_HEADLESS", raising=False)
+    reached_staging = []
+    monkeypatch.setattr(
+        dispatch_bridge, "stage_spec_bundle",
+        lambda **kw: reached_staging.append(kw),
+    )
+    rc = dispatch_bridge.bridge_dispatch(
+        instruction_text="x", dispatch_id=_GOOD_ID, role="dev",
+        target_slot="T1", project_id="p1", data_dir=tmp_path,
+        allow_headless=True, headless_reason="benchmark", dry_run=True,
+    )
+    assert rc == 1
+    assert reached_staging == []
+    err = capsys.readouterr().err
+    assert "headless-blocked" in err
+    assert "VNX_OVERRIDE_CLAUDE_HEADLESS" in err
+
+
+def test_bridge_headless_wrong_override_value_still_blocked(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_OVERRIDE_CLAUDE_HEADLESS", "true")  # only "1" opts in
+    reached_staging = []
+    monkeypatch.setattr(
+        dispatch_bridge, "stage_spec_bundle",
+        lambda **kw: reached_staging.append(kw),
+    )
+    rc = dispatch_bridge.bridge_dispatch(
+        instruction_text="x", dispatch_id=_GOOD_ID, role="dev",
+        target_slot="T1", project_id="p1", data_dir=tmp_path,
+        allow_headless=True, headless_reason="benchmark", dry_run=True,
+    )
+    assert rc == 1
+    assert reached_staging == []
+
+
+def test_bridge_headless_override_reaches_staging(tmp_path, monkeypatch):
+    """allow_headless=True + VNX_OVERRIDE_CLAUDE_HEADLESS=1: the gate is lifted and
+    execution proceeds into stage_spec_bundle (a real bundle gets written)."""
+    monkeypatch.setenv("VNX_OVERRIDE_CLAUDE_HEADLESS", "1")
+    import dispatch_cli
+    monkeypatch.setattr(dispatch_cli, "run_dispatch", lambda spec_file, dry_run=False: 0)
+
+    rc = dispatch_bridge.bridge_dispatch(
+        instruction_text="x", dispatch_id=_GOOD_ID, role="dev",
+        target_slot="T1", project_id="p1", data_dir=tmp_path,
+        allow_headless=True, headless_reason="benchmark", dry_run=True,
+    )
+
+    assert rc == 0
+    bundle = tmp_path / "dispatches" / "pending" / _GOOD_ID
+    payload = json.loads((bundle / "dispatch-spec.json").read_text(encoding="utf-8"))
+    assert payload["allow_headless"] is True
+
+
+def test_bridge_non_headless_dispatch_never_consults_the_gate(tmp_path, monkeypatch):
+    """allow_headless absent (default False): the claude tmux subscription lane is
+    unaffected — staging proceeds without the headless gate firing at all."""
+    monkeypatch.delenv("VNX_OVERRIDE_CLAUDE_HEADLESS", raising=False)
+    import dispatch_cli
+    monkeypatch.setattr(dispatch_cli, "run_dispatch", lambda spec_file, dry_run=False: 0)
+
+    rc = dispatch_bridge.bridge_dispatch(
+        instruction_text="x", dispatch_id=_GOOD_ID, role="dev",
+        target_slot="T1", project_id="p1", data_dir=tmp_path, dry_run=True,
+    )
+
+    assert rc == 0
+    bundle = tmp_path / "dispatches" / "pending" / _GOOD_ID
+    payload = json.loads((bundle / "dispatch-spec.json").read_text(encoding="utf-8"))
+    assert payload["allow_headless"] is False

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -16,7 +16,9 @@ from routing_policy import (
     _resolve_fallback_chain,
     _rule_matches,
     decide_lane,
+    is_claude_headless_blocked,
     lane_to_claude_model,
+    load_lane_safety,
     load_routing_policy,
 )
 
@@ -70,7 +72,7 @@ def test_non_mapping_yaml_raises(tmp_path: Path) -> None:
 
 def test_default_lane_unmatched() -> None:
     decision = decide_lane("unknown-task-class", complexity="medium", env=_env())
-    assert decision.lane == "claude/sonnet-4-6"
+    assert decision.lane == "claude/sonnet-5"
     assert decision.rule_name == "default"
 
 
@@ -87,19 +89,19 @@ def test_doc_update_routes_to_haiku() -> None:
 
 def test_refactor_medium_routes_to_sonnet() -> None:
     decision = decide_lane("refactor", complexity="medium", env=_env())
-    assert decision.lane == "claude/sonnet-4-6"
+    assert decision.lane == "claude/sonnet-5"
     assert decision.rule_name == "refactor-code-default"
 
 
 def test_refactor_high_routes_to_sonnet() -> None:
     decision = decide_lane("refactor", complexity="high", env=_env())
-    assert decision.lane == "claude/sonnet-4-6"
+    assert decision.lane == "claude/sonnet-5"
 
 
 def test_opt_in_deepseek_requires_flag() -> None:
     # Without opt-in flag: refactor + medium -> refactor-code-default (sonnet)
     without_flag = decide_lane("refactor", complexity="medium", env=_env())
-    assert without_flag.lane == "claude/sonnet-4-6"
+    assert without_flag.lane == "claude/sonnet-5"
     assert without_flag.rule_name == "refactor-code-default"
 
     # With opt-in flag: cost-optimized-code rule fires first because rules are ordered
@@ -115,7 +117,7 @@ def test_opt_in_deepseek_requires_flag() -> None:
     # So with the current yaml order, sonnet still wins even with the flag.
     # This is intentional: operators must move cost-optimized-code above refactor-code-default
     # in the yaml to activate it for refactor tasks.
-    assert with_flag.lane == "claude/sonnet-4-6"
+    assert with_flag.lane == "claude/sonnet-5"
 
     # Directly validate that _rule_matches respects opt_in_flag:
     cost_rule = {
@@ -158,8 +160,8 @@ def test_research_high_routes_to_opus() -> None:
 def test_fallback_chain_resolution_deepseek() -> None:
     decision = decide_lane("code-review", complexity="medium", env=_env())
     # review-analysis -> kimi (CLI lane)
-    # Its fallback chain: kimi -> [litellm:deepseek:deepseek-v4-pro, claude/sonnet-4-6]
-    assert "claude/sonnet-4-6" in decision.fallback_chain
+    # Its fallback chain: kimi -> [litellm:deepseek:deepseek-v4-pro, claude/sonnet-5]
+    assert "claude/sonnet-5" in decision.fallback_chain
 
 
 def test_fallback_chain_wildcard_deepseek() -> None:
@@ -167,7 +169,7 @@ def test_fallback_chain_wildcard_deepseek() -> None:
     policy = load_routing_policy(_POLICY_PATH)
     fallback_map = policy.get("fallback_chain", {})
     chain = _resolve_fallback_chain("litellm:deepseek:deepseek-v4-pro", fallback_map)
-    assert "claude/sonnet-4-6" in chain
+    assert "claude/sonnet-5" in chain
     assert len(chain) >= 2
 
 
@@ -175,14 +177,14 @@ def test_fallback_chain_haiku() -> None:
     policy = load_routing_policy(_POLICY_PATH)
     fallback_map = policy.get("fallback_chain", {})
     chain = _resolve_fallback_chain("claude/haiku-4-5", fallback_map)
-    assert chain == ["claude/sonnet-4-6"]
+    assert chain == ["claude/sonnet-5"]
 
 
 def test_fallback_chain_sonnet_empty() -> None:
     """Sonnet and Opus have no fallback — they are the safety net."""
     policy = load_routing_policy(_POLICY_PATH)
     fallback_map = policy.get("fallback_chain", {})
-    assert _resolve_fallback_chain("claude/sonnet-4-6", fallback_map) == []
+    assert _resolve_fallback_chain("claude/sonnet-5", fallback_map) == []
     assert _resolve_fallback_chain("claude/opus", fallback_map) == []
 
 
@@ -288,3 +290,77 @@ def test_policy_lanes_pass_constraint_preflight() -> None:
         + "\n".join(f"  - {v}" for v in violations_found)
         + "\n\nFix: update the lane in routing_policy.yaml to a non-blocked provider."
     )
+
+
+# ---------------------------------------------------------------------------
+# load_lane_safety / is_claude_headless_blocked — OI-223 lane_safety loader
+# ---------------------------------------------------------------------------
+
+
+def test_load_lane_safety_reads_production_yaml() -> None:
+    """lane_safety is actually loaded from the production routing_policy.yaml."""
+    lane_safety = load_lane_safety(_POLICY_PATH)
+    assert "headless_block" in lane_safety
+    assert "force_headless" in lane_safety
+
+
+def test_load_lane_safety_missing_block_returns_empty(tmp_path: Path) -> None:
+    policy_file = tmp_path / "routing_policy.yaml"
+    policy_file.write_text("version: 1\ndefault_lane: claude/sonnet-5\n")
+    assert load_lane_safety(policy_file) == {}
+
+
+def test_load_lane_safety_non_mapping_raises(tmp_path: Path) -> None:
+    policy_file = tmp_path / "routing_policy.yaml"
+    policy_file.write_text("version: 1\ndefault_lane: claude/sonnet-5\nlane_safety: [1, 2]\n")
+    with pytest.raises(ValueError, match="lane_safety block must be a mapping"):
+        load_lane_safety(policy_file)
+
+
+def test_production_headless_block_is_blocked_without_override() -> None:
+    lane_safety = load_lane_safety(_POLICY_PATH)
+    assert is_claude_headless_blocked(lane_safety, env={}) is True
+
+
+def test_production_headless_block_lifted_with_override() -> None:
+    lane_safety = load_lane_safety(_POLICY_PATH)
+    assert is_claude_headless_blocked(
+        lane_safety, env={"VNX_OVERRIDE_CLAUDE_HEADLESS": "1"}
+    ) is False
+
+
+def test_headless_block_wrong_override_value_still_blocked() -> None:
+    lane_safety = load_lane_safety(_POLICY_PATH)
+    assert is_claude_headless_blocked(
+        lane_safety, env={"VNX_OVERRIDE_CLAUDE_HEADLESS": "yes"}
+    ) is True
+
+
+def test_headless_blocked_missing_block_fails_closed() -> None:
+    """No `headless_block` entry at all -> still blocked (fail-closed default)."""
+    assert is_claude_headless_blocked({}, env={}) is True
+    assert is_claude_headless_blocked({}, env={"VNX_OVERRIDE_CLAUDE_HEADLESS": "1"}) is False
+
+
+def test_headless_blocked_disabled_via_yaml() -> None:
+    lane_safety = {"headless_block": {"enabled": False}}
+    assert is_claude_headless_blocked(lane_safety, env={}) is False
+
+
+def test_headless_blocked_custom_override_env_name() -> None:
+    lane_safety = {"headless_block": {"enabled": True, "override_env": "MY_CUSTOM_FLAG"}}
+    assert is_claude_headless_blocked(lane_safety, env={}) is True
+    assert is_claude_headless_blocked(lane_safety, env={"MY_CUSTOM_FLAG": "1"}) is False
+    # The default env var name is NOT the override when a custom name is configured.
+    assert is_claude_headless_blocked(
+        lane_safety, env={"VNX_OVERRIDE_CLAUDE_HEADLESS": "1"}
+    ) is True
+
+
+def test_headless_blocked_defaults_env_to_os_environ(monkeypatch: pytest.MonkeyPatch) -> None:
+    """env=None falls back to os.environ (real dispatcher call pattern)."""
+    lane_safety = {"headless_block": {"enabled": True}}
+    monkeypatch.delenv("VNX_OVERRIDE_CLAUDE_HEADLESS", raising=False)
+    assert is_claude_headless_blocked(lane_safety) is True
+    monkeypatch.setenv("VNX_OVERRIDE_CLAUDE_HEADLESS", "1")
+    assert is_claude_headless_blocked(lane_safety) is False


### PR DESCRIPTION
## Summary
Makes `routing_policy.yaml`'s `lane_safety.headless_block` rule LIVE via a typed loader, replacing the hardcoded `VNX_OVERRIDE_CLAUDE_HEADLESS` env-only check that was duplicated in two places. The claude_headless (API-metered) lane stays fail-closed by default; the escape hatch still works and is now yaml-configurable. Folds in `claude-headless-lane-block`.

## Changes
- `routing_policy.py` — `load_lane_safety()` + `is_claude_headless_blocked()` (fail-closed: missing block/key still blocks; reads override env name from yaml).
- `routing_policy.yaml` — added `lane_safety.headless_block` (live); refreshed lane_safety + fallback_chain STATUS comments; annotated `force_headless` as SUPERSEDED (left declarative — wiring it would fight the new guard).
- `dispatch_bridge.py` + `dispatch_cli.py::_execute_claude_headless` — consult the yaml loader instead of hardcoded env reads.
- `dispatch_plan.py::compile_plan` deliberately untouched (preserves its documented no-I/O purity invariant).
- Tests: +10 routing_policy, +4 bridge-staging; also fixed 7 pre-existing stale `claude/sonnet-4-6` assertions (stale since #1013, git-stash-verified pre-existing).

## Verification
`pytest test_routing_policy + test_dispatch_bridge_staging + test_dispatch_plan + test_dispatch_cli` → **233 passed**. kimi-via-cli-only consistency verified (review still routes to kimi CLI, no litellm:moonshot reintroduced). The multi-minute test slowness during the build was machine contention (concurrent dispatch-agent load), git-stash-verified as pre-existing, not this change.

## Open Items
None.

Track: oi-223-lane-safety-loader (+ claude-headless-lane-block) · Dispatch: 20260709-080058-oi223-lanesafety

🤖 Generated with [Claude Code](https://claude.com/claude-code)