### PR TITLE
feat(dashboard): surface self-learning proposals on operator/improvements (pending-proposals-surfacing)

### DIFF
--- a/dashboard/api_intelligence.py
+++ b/dashboard/api_intelligence.py
@@ -488,6 +488,116 @@ def _scripts_dir() -> Path:
     return Path(__file__).resolve().parent.parent / "scripts"
 
 
+# ---------------------------------------------------------------------------
+# Self-learning proposal sources (operator-gated, read-only)
+# ---------------------------------------------------------------------------
+
+def _load_json_state(path: Path) -> dict:
+    """Best-effort read of a JSON state file; return empty dict on any error."""
+    if not path.exists():
+        return {}
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError, TypeError):
+        return {}
+
+
+def _read_skill_refinement_proposals(state_dir: Path) -> list[dict]:
+    """Return pending skill-refinement proposals from pending_skill_refinements.json."""
+    data = _load_json_state(state_dir / "pending_skill_refinements.json")
+    proposals: list[dict] = []
+    for p in data.get("proposals", []):
+        if p.get("status") != "pending":
+            continue
+        proposals.append({
+            "id": p.get("id"),
+            "type": "skill_refinement",
+            "target": p.get("skill_path", p.get("role", "")),
+            "summary": p.get("rationale", ""),
+            "rationale": p.get("rationale", ""),
+            "confidence": float(p.get("rework_rate", 0)) if p.get("rework_rate") is not None else 0.0,
+            "created_at": p.get("generated_at", ""),
+            "meta": {
+                "role": p.get("role", ""),
+                "rework_rate": p.get("rework_rate"),
+                "reworked_count": p.get("reworked_count"),
+                "total_dispatches": p.get("total_dispatches"),
+                "diff_lines": len((p.get("diff") or "").splitlines()),
+            },
+        })
+    return proposals
+
+
+def _read_pending_rules(state_dir: Path) -> list[dict]:
+    """Return pending prevention-rule proposals from pending_rules.json."""
+    data = _load_json_state(state_dir / "pending_rules.json")
+    proposals: list[dict] = []
+    for r in data.get("pending_rules", []):
+        if r.get("status") != "pending":
+            continue
+        proposals.append({
+            "id": r.get("id"),
+            "type": "rule",
+            "target": r.get("terminal_constraint", "any"),
+            "summary": r.get("pattern", ""),
+            "rationale": r.get("prevention", ""),
+            "confidence": float(r.get("confidence", 0)) if r.get("confidence") is not None else 0.0,
+            "created_at": r.get("created_at", ""),
+            "meta": {
+                "occurrence_count": r.get("occurrence_count"),
+            },
+        })
+    return proposals
+
+
+def _read_archival_candidates(state_dir: Path) -> list[dict]:
+    """Return pending archival / supersede candidates from pending_archival.json."""
+    data = _load_json_state(state_dir / "pending_archival.json")
+    proposals: list[dict] = []
+    for c in data.get("pending_archival", []):
+        if c.get("status") != "pending":
+            continue
+        action = c.get("action") or "archive"
+        proposals.append({
+            "id": c.get("pattern_id"),
+            "type": "archival",
+            "target": c.get("title", ""),
+            "summary": c.get("reason", ""),
+            "rationale": f"{action}: {c.get('reason', '')}".strip(),
+            "confidence": float(c.get("confidence", 0)) if c.get("confidence") is not None else 0.0,
+            "created_at": c.get("queued_at", ""),
+            "meta": {
+                "action": action,
+                "source_table": c.get("source_table", ""),
+                "last_used": c.get("last_used"),
+            },
+        })
+    return proposals
+
+
+def _intelligence_get_learning_proposals(params: dict) -> dict:
+    """Return all pending operator-gated self-learning proposals.
+
+    Sources:
+      - pending_skill_refinements.json (skill-refine)
+      - pending_rules.json (learning run)
+      - pending_archival.json (learning run)
+    """
+    state_dir = _state_dir()
+    proposals: list[dict] = []
+    try:
+        proposals.extend(_read_skill_refinement_proposals(state_dir))
+        proposals.extend(_read_pending_rules(state_dir))
+        proposals.extend(_read_archival_candidates(state_dir))
+    except Exception as exc:  # vnx-silent-except: best-effort enrichment
+        _logger.debug("failed to read self-learning proposals: %s", exc)
+
+    # Stable ordering: newest first; fall back to type then target.
+    proposals.sort(key=lambda p: (p.get("created_at") or "", p.get("type", ""), p.get("target", "")), reverse=True)
+    return {"proposals": proposals}
+
+
 def _load_pending_edits() -> dict:
     path = _state_dir() / "pending_edits.json"
     if not path.exists():

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -181,6 +181,7 @@ from api_intelligence import (  # noqa: E402
     _intelligence_get_dispatch_outcomes,
     _intelligence_get_transcript,
     _intelligence_get_proposals,
+    _intelligence_get_learning_proposals,
     _intelligence_accept_proposal,
     _intelligence_reject_proposal,
     _intelligence_apply_proposals,
@@ -500,6 +501,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/intelligence/proposals":
             _json_response(self, HTTPStatus.OK, _intelligence_get_proposals(params))
+            return
+
+        if path == "/api/intelligence/learning-proposals":
+            _json_response(self, HTTPStatus.OK, _intelligence_get_learning_proposals(params))
             return
 
         if path == "/api/intelligence/confidence-trends":

--- a/dashboard/token-dashboard/__tests__/learning-proposals-section.test.tsx
+++ b/dashboard/token-dashboard/__tests__/learning-proposals-section.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Tests for the self-learning proposals section on app/operator/improvements/page.tsx.
+ */
+
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+jest.mock('@/lib/hooks', () => ({
+  useLearningProposals: jest.fn(),
+  useProposals: jest.fn(),
+  useConfidenceTrends: jest.fn(),
+  useWeeklyDigest: jest.fn(),
+}));
+
+import { useLearningProposals, useProposals, useConfidenceTrends, useWeeklyDigest } from '@/lib/hooks';
+import ImprovementsPage from '@/app/operator/improvements/page';
+import type { LearningProposalsResponse, ProposalsResponse, ConfidenceTrendsResponse } from '@/lib/types';
+
+const mockUseLearning = useLearningProposals as jest.MockedFunction<typeof useLearningProposals>;
+const mockUseProposals = useProposals as jest.MockedFunction<typeof useProposals>;
+const mockUseTrends = useConfidenceTrends as jest.MockedFunction<typeof useConfidenceTrends>;
+const mockUseDigest = useWeeklyDigest as jest.MockedFunction<typeof useWeeklyDigest>;
+
+function learningEnvelope(proposals: LearningProposalsResponse['proposals'] = []): LearningProposalsResponse {
+  return { proposals };
+}
+
+function emptyProposals(): ProposalsResponse {
+  return { proposals: [] };
+}
+
+function emptyTrends(): ConfidenceTrendsResponse {
+  return { trends: [] };
+}
+
+function renderWith(
+  learning: LearningProposalsResponse | undefined,
+  opts: { isLoading?: boolean; error?: Error } = {}
+) {
+  mockUseLearning.mockReturnValue({
+    data: learning,
+    isLoading: opts.isLoading ?? false,
+    error: opts.error,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useLearningProposals>);
+  mockUseProposals.mockReturnValue({
+    data: emptyProposals(),
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useProposals>);
+  mockUseTrends.mockReturnValue({
+    data: emptyTrends(),
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useConfidenceTrends>);
+  mockUseDigest.mockReturnValue({
+    data: undefined,
+    isLoading: false,
+    error: undefined,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useWeeklyDigest>);
+  return render(<ImprovementsPage />);
+}
+
+describe('LearningProposalsSection', () => {
+  test('renders empty state when no proposals', () => {
+    renderWith(learningEnvelope());
+    expect(screen.getAllByText(/Self-Learning Proposals/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/No pending self-learning proposals/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('renders skill refinement, rule, and archival proposals', () => {
+    renderWith(learningEnvelope([
+      {
+        id: 'skillref-debugger-20260709',
+        type: 'skill_refinement',
+        target: '.claude/skills/debugger/SKILL.md',
+        summary: 'Rework rate is high.',
+        rationale: 'Add rework checklist.',
+        confidence: 0.45,
+        created_at: '2026-07-09T10:00:00Z',
+      },
+      {
+        id: 'rule-abc',
+        type: 'rule',
+        target: 'T1',
+        summary: 'Agent not found error.',
+        rationale: 'Validate agent exists.',
+        confidence: 0.6,
+        created_at: '2026-07-09T09:00:00Z',
+      },
+      {
+        id: 'pattern-1',
+        type: 'archival',
+        target: 'Old auth helper',
+        summary: 'Unused for 30+ days.',
+        rationale: 'archive: Unused for 30+ days.',
+        confidence: 0.15,
+        created_at: '2026-07-09T08:00:00Z',
+      },
+    ]));
+
+    expect(screen.getByText('.claude/skills/debugger/SKILL.md')).toBeInTheDocument();
+    expect(screen.getByText('Skill refinement')).toBeInTheDocument();
+    expect(screen.getByText('T1')).toBeInTheDocument();
+    expect(screen.getByText('Prevention rule')).toBeInTheDocument();
+    expect(screen.getByText('Old auth helper')).toBeInTheDocument();
+    expect(screen.getByText('Archival / supersede')).toBeInTheDocument();
+    expect(screen.getAllByText(/vnx learning skill-review/i).length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText(/vnx learning review/i).length).toBeGreaterThanOrEqual(1);
+  });
+
+  test('renders loading state', () => {
+    const { container } = renderWith(undefined, { isLoading: true });
+    expect(container.querySelector('.animate-spin')).toBeInTheDocument();
+  });
+
+  test('renders error state', () => {
+    renderWith(undefined, { error: new Error('boom') });
+    expect(screen.getAllByText(/Failed to load self-learning proposals/i).length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/dashboard/token-dashboard/app/operator/improvements/page.tsx
+++ b/dashboard/token-dashboard/app/operator/improvements/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { RefreshCw, Lightbulb, TrendingUp, BookOpen, CheckCircle2, XCircle, Play } from 'lucide-react';
+import { RefreshCw, Lightbulb, TrendingUp, BookOpen, CheckCircle2, XCircle, Play, GraduationCap, Shield, Archive } from 'lucide-react';
 import {
   LineChart,
   Line,
@@ -12,9 +12,9 @@ import {
   Legend,
   ResponsiveContainer,
 } from 'recharts';
-import { useProposals, useConfidenceTrends, useWeeklyDigest } from '@/lib/hooks';
+import { useProposals, useConfidenceTrends, useWeeklyDigest, useLearningProposals } from '@/lib/hooks';
 import { acceptProposal, rejectProposal, applyProposals, generateWeeklyDigest } from '@/lib/operator-api';
-import type { Proposal, WeeklyDigest } from '@/lib/types';
+import type { Proposal, LearningProposal, WeeklyDigest } from '@/lib/types';
 
 // ---- Helpers ----
 
@@ -24,6 +24,12 @@ const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string
   prompt: { bg: 'rgba(107, 138, 230, 0.08)', border: 'rgba(107, 138, 230, 0.22)', text: '#6B8AE6' },
   workflow: { bg: 'rgba(249, 115, 22, 0.08)', border: 'rgba(249, 115, 22, 0.22)', text: '#f97316' },
   default: { bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.1)', text: 'var(--color-muted)' },
+};
+
+const LEARNING_TYPE_META: Record<string, { icon: typeof Lightbulb; label: string; color: string }> = {
+  skill_refinement: { icon: GraduationCap, label: 'Skill refinement', color: '#6B8AE6' },
+  rule: { icon: Shield, label: 'Prevention rule', color: '#50fa7b' },
+  archival: { icon: Archive, label: 'Archival / supersede', color: '#ff6b6b' },
 };
 
 function categoryStyle(cat: string) {
@@ -180,6 +186,76 @@ function ProposalCard({
               </button>
             </div>
           )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---- Learning Proposals Section (self-learning loop) ----
+
+function LearningProposalCard({ proposal }: { proposal: LearningProposal }) {
+  const meta = LEARNING_TYPE_META[proposal.type] ?? { icon: Lightbulb, label: proposal.type, color: 'var(--color-muted)' };
+  const Icon = meta.icon;
+
+  return (
+    <div style={{ padding: '14px 16px', borderRadius: 10, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)', display: 'flex', flexDirection: 'column', gap: 10 }}>
+      <div className="flex items-start justify-between gap-2">
+        <div className="flex items-center gap-2" style={{ flex: 1 }}>
+          <Icon size={14} style={{ color: meta.color, flexShrink: 0 }} />
+          <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-foreground)', lineHeight: 1.45 }}>
+            {proposal.target}
+          </span>
+        </div>
+        <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 5, background: 'rgba(255,255,255,0.05)', border: '1px solid rgba(255,255,255,0.1)', color: meta.color, flexShrink: 0 }}>
+          {meta.label}
+        </span>
+      </div>
+
+      <p style={{ fontSize: 12, color: 'var(--color-muted)', lineHeight: 1.5 }}>
+        {proposal.summary || proposal.rationale}
+      </p>
+
+      <div>
+        <div className="flex items-center justify-between" style={{ marginBottom: 2 }}>
+          <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>
+            conf <strong style={{ color: meta.color }}>{(proposal.confidence * 100).toFixed(0)}%</strong>
+          </span>
+          <span style={{ fontSize: 10, color: 'var(--color-muted)' }}>
+            {proposal.created_at ? new Date(proposal.created_at).toLocaleString() : '—'}
+          </span>
+        </div>
+        <ConfidenceBar value={proposal.confidence} />
+      </div>
+
+      <div className="flex gap-2" style={{ marginTop: 2 }}>
+        <span style={{ fontSize: 10, color: 'var(--color-muted)', border: '1px solid rgba(255,255,255,0.08)', borderRadius: 5, padding: '2px 6px' }}>
+          Review via <code>vnx learning {proposal.type === 'skill_refinement' ? 'skill-review' : 'review'}</code>
+        </span>
+      </div>
+    </div>
+  );
+}
+
+function LearningProposalsSection() {
+  const { data, error, isLoading } = useLearningProposals();
+  const proposals = data?.proposals ?? [];
+
+  return (
+    <div style={{ padding: '20px 24px', borderRadius: 14, background: 'rgba(255,255,255,0.03)', border: '1px solid rgba(255,255,255,0.08)', marginBottom: 24 }}>
+      <SectionHeader icon={GraduationCap} title="Self-Learning Proposals" count={proposals.length} />
+
+      {isLoading && <LoadingSpinner />}
+      {error && <EmptyState label="Failed to load self-learning proposals" />}
+      {!isLoading && !error && proposals.length === 0 && (
+        <EmptyState label="No pending self-learning proposals — run `vnx learning run` or `vnx learning skill-refine` to generate them" />
+      )}
+
+      {proposals.length > 0 && (
+        <div style={{ display: 'flex', flexDirection: 'column', gap: 10 }}>
+          {proposals.map(p => (
+            <LearningProposalCard key={`${p.type}-${p.id}`} proposal={p} />
+          ))}
         </div>
       )}
     </div>
@@ -432,6 +508,7 @@ export default function ImprovementsPage() {
         </p>
       </div>
 
+      <LearningProposalsSection />
       <ProposalsSection />
       <ConfidenceTrendsSection />
       <WeeklyDigestSection />

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -22,6 +22,7 @@ import {
   fetchIntelligenceClassifications,
   fetchIntelligenceDispatchOutcomes,
   fetchProposals,
+  fetchLearningProposals,
   fetchConfidenceTrends,
   fetchWeeklyDigest,
   fetchDispatches,
@@ -38,6 +39,7 @@ import type {
   ReportsEnvelope, AgentsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
+  LearningProposalsResponse,
   DispatchesResponse, DispatchDetailResponse, DispatchEventsResponse, DispatchResultResponse,
 } from './types';
 
@@ -285,6 +287,14 @@ export function useProposals() {
   return useSWR<ProposalsResponse>(
     'intelligence-proposals',
     () => fetchProposals(),
+    { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
+  );
+}
+
+export function useLearningProposals() {
+  return useSWR<LearningProposalsResponse>(
+    'intelligence-learning-proposals',
+    () => fetchLearningProposals(),
     { refreshInterval: 30000, revalidateOnFocus: true, dedupingInterval: 10000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -28,6 +28,7 @@ import type {
   ConfidenceTrendsResponse,
   WeeklyDigest,
   ProposalActionResponse,
+  LearningProposalsResponse,
   DispatchesResponse,
   DispatchDetailResponse,
   DispatchEventsResponse,
@@ -206,6 +207,10 @@ export function fetchIntelligenceDispatchOutcomes(limit = 200): Promise<Dispatch
 
 export function fetchProposals(): Promise<ProposalsResponse> {
   return get('/api/intelligence/proposals');
+}
+
+export function fetchLearningProposals(): Promise<LearningProposalsResponse> {
+  return get('/api/intelligence/learning-proposals');
 }
 
 export function acceptProposal(id: number): Promise<ProposalActionResponse> {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -654,6 +654,21 @@ export interface ProposalActionResponse {
   error?: string;
 }
 
+export interface LearningProposal {
+  id: string;
+  type: 'skill_refinement' | 'rule' | 'archival';
+  target: string;
+  summary: string;
+  rationale: string;
+  confidence: number;
+  created_at: string;
+  meta?: Record<string, unknown>;
+}
+
+export interface LearningProposalsResponse {
+  proposals: LearningProposal[];
+}
+
 // ===== Dispatch Viewer Types =====
 
 export type DispatchStage = 'staging' | 'pending' | 'active' | 'review' | 'done' | 'rejected';

--- a/tests/test_learning_proposals_api.py
+++ b/tests/test_learning_proposals_api.py
@@ -1,0 +1,212 @@
+"""Tests for the self-learning proposals read API.
+
+GET /api/intelligence/learning-proposals surfaces operator-gated proposals from:
+  - state/pending_skill_refinements.json
+  - state/pending_rules.json
+  - state/pending_archival.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+import api_intelligence
+
+
+def _mock_sd(tmp_path: Path):
+    """Return a mock serve_dashboard namespace with state paths under tmp_path."""
+    import types
+
+    sd = types.SimpleNamespace()
+    sd.DB_PATH = tmp_path / "quality_intelligence.db"
+    sd.REPORTS_DIR = tmp_path / "unified_reports"
+    sd.RECEIPTS_PATH = tmp_path / "t0_receipts.ndjson"
+    return sd
+
+
+def _write_skill_refinements(tmp_path: Path, proposals: list[dict]) -> Path:
+    path = tmp_path / "pending_skill_refinements.json"
+    path.write_text(
+        json.dumps(
+            {"generated_at": "2026-07-09T10:00:00Z", "threshold": 0.3, "proposals": proposals},
+            indent=2,
+            ensure_ascii=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_pending_rules(tmp_path: Path, rules: list[dict]) -> Path:
+    path = tmp_path / "pending_rules.json"
+    path.write_text(
+        json.dumps({"pending_rules": rules}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _write_pending_archival(tmp_path: Path, candidates: list[dict]) -> Path:
+    path = tmp_path / "pending_archival.json"
+    path.write_text(
+        json.dumps({"pending_archival": candidates}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestLearningProposalsReadApi:
+    def test_empty_state_returns_empty_list(self, tmp_path):
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert result == {"proposals": []}
+
+    def test_returns_skill_refinement_proposals(self, tmp_path):
+        _write_skill_refinements(tmp_path, [
+            {
+                "id": "skillref-debugger-20260709",
+                "role": "debugger",
+                "skill_path": ".claude/skills/debugger/SKILL.md",
+                "rework_rate": 0.45,
+                "reworked_count": 5,
+                "total_dispatches": 11,
+                "diff": "--- a/.claude/skills/debugger/SKILL.md\n+++ b/.claude/skills/debugger/SKILL.md\n@@ -1 +1 @@\n",
+                "rationale": "Role 'debugger' has a rework rate of 45%.",
+                "operator_test": "1. Review the diff.",
+                "status": "pending",
+                "generated_at": "2026-07-09T10:00:00Z",
+            }
+        ])
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert len(result["proposals"]) == 1
+        prop = result["proposals"][0]
+        assert prop["id"] == "skillref-debugger-20260709"
+        assert prop["type"] == "skill_refinement"
+        assert prop["target"] == ".claude/skills/debugger/SKILL.md"
+        assert prop["summary"] == "Role 'debugger' has a rework rate of 45%."
+        assert prop["confidence"] == 0.45
+        assert prop["created_at"] == "2026-07-09T10:00:00Z"
+        assert prop["meta"]["role"] == "debugger"
+
+    def test_returns_pending_rules(self, tmp_path):
+        _write_pending_rules(tmp_path, [
+            {
+                "id": "rule-abc123",
+                "created_at": "2026-07-09T09:00:00Z",
+                "source": "learning_loop",
+                "rule_type": "failure_prevention",
+                "pattern": "Error pattern: agent not found",
+                "terminal_constraint": "T1",
+                "prevention": "Validate agent exists before dispatch.",
+                "confidence": 0.6,
+                "occurrence_count": 3,
+                "status": "pending",
+            }
+        ])
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert len(result["proposals"]) == 1
+        prop = result["proposals"][0]
+        assert prop["id"] == "rule-abc123"
+        assert prop["type"] == "rule"
+        assert prop["target"] == "T1"
+        assert prop["summary"] == "Error pattern: agent not found"
+        assert prop["rationale"] == "Validate agent exists before dispatch."
+        assert prop["confidence"] == 0.6
+        assert prop["created_at"] == "2026-07-09T09:00:00Z"
+
+    def test_returns_archival_candidates(self, tmp_path):
+        _write_pending_archival(tmp_path, [
+            {
+                "pattern_id": "pattern-1",
+                "title": "Old auth helper",
+                "last_used": "2026-06-01T00:00:00Z",
+                "confidence": 0.15,
+                "used_count": 0,
+                "ignored_count": 5,
+                "reason": "Unused for 30+ days with confidence < 0.3",
+                "queued_at": "2026-07-09T08:00:00Z",
+                "status": "pending",
+            },
+            {
+                "pattern_id": "pattern-2",
+                "title": "Stale success pattern",
+                "confidence": 0.2,
+                "source_table": "success_patterns",
+                "action": "supersede",
+                "reason": "confidence_score < 0.3, older than 30 days",
+                "queued_at": "2026-07-09T08:30:00Z",
+                "status": "pending",
+            },
+        ])
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert len(result["proposals"]) == 2
+        # Newest first per created_at ordering
+        supersede, archive = result["proposals"]
+        assert archive["type"] == "archival"
+        assert archive["target"] == "Old auth helper"
+        assert archive["meta"]["action"] == "archive"
+        assert supersede["type"] == "archival"
+        assert supersede["target"] == "Stale success pattern"
+        assert supersede["meta"]["action"] == "supersede"
+        assert supersede["rationale"] == "supersede: confidence_score < 0.3, older than 30 days"
+
+    def test_non_pending_status_is_filtered(self, tmp_path):
+        _write_pending_rules(tmp_path, [
+            {
+                "id": "rule-approved",
+                "created_at": "2026-07-09T09:00:00Z",
+                "pattern": "approved pattern",
+                "prevention": "prevention text",
+                "confidence": 0.6,
+                "status": "approved",
+            },
+            {
+                "id": "rule-pending",
+                "created_at": "2026-07-09T09:00:00Z",
+                "pattern": "pending pattern",
+                "prevention": "prevention text",
+                "confidence": 0.6,
+                "status": "pending",
+            },
+        ])
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert len(result["proposals"]) == 1
+        assert result["proposals"][0]["id"] == "rule-pending"
+
+    def test_missing_files_are_tolerant(self, tmp_path):
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert result == {"proposals": []}
+
+    def test_malformed_json_returns_empty(self, tmp_path):
+        (tmp_path / "pending_rules.json").write_text("not json", encoding="utf-8")
+        sd = _mock_sd(tmp_path)
+        with patch.object(api_intelligence, "_sd", return_value=sd):
+            result = api_intelligence._intelligence_get_learning_proposals({})
+
+        assert result == {"proposals": []}


### PR DESCRIPTION
## Summary
Surfaces the self-learning loop's operator-gated proposals on the dashboard (previously CLI-only via `vnx learning`). New read-only API `/api/intelligence/learning-proposals` normalizes `pending_skill_refinements.json` + `pending_rules.json` + `pending_archival.json`, and the `operator/improvements` page renders them as a tile. Read-only (no auto-activation — operator-gated per the self-learning contract). Built via the Kimi lane.

## Changes
- `dashboard/api_intelligence.py` (+110) + `dashboard/serve_dashboard.py`: `_intelligence_get_learning_proposals()` + `GET /api/intelligence/learning-proposals`, normalized shape (id/type/target/summary/rationale/confidence/created_at/meta).
- `dashboard/token-dashboard/`: `types.ts` (LearningProposal), `operator-api.ts` (fetch), `hooks.ts` (useLearningProposals SWR), `app/operator/improvements/page.tsx` (LearningProposalsSection tile, read-only).
- Tests: `tests/test_learning_proposals_api.py` (+212) + a TSX section test.

In-conversation pop-up = out of scope (needs hook wiring) — follow-up.

Track: pending-proposals-surfacing · Dispatch: 20260709-180848-proposals-surface-c

🤖 Generated with [Claude Code](https://claude.com/claude-code)