### PR TITLE
feat(intelligence): scout-effectiveness measurement harness (observational A/B on receipts)

### DIFF
--- a/scripts/lib/scout_effectiveness.py
+++ b/scripts/lib/scout_effectiveness.py
@@ -24,6 +24,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
 
+from atomic_io import atomic_write_json
+
 logger = logging.getLogger(__name__)
 
 RECEIPT_FILE = "t0_receipts.ndjson"
@@ -503,5 +505,7 @@ def report_to_dict(report: EffectivenessReport) -> Dict[str, Any]:
 
 def write_artifact(path: Path, report: EffectivenessReport) -> Path:
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(json.dumps(report_to_dict(report), indent=2) + "\n", encoding="utf-8")
+    # Atomic write (tmp + os.replace via atomic_io) so an interruption cannot
+    # truncate/corrupt a previously-written artifact (codex gate finding, PR #1072).
+    atomic_write_json(path, report_to_dict(report))
     return path

--- a/scripts/lib/scout_effectiveness.py
+++ b/scripts/lib/scout_effectiveness.py
@@ -1,0 +1,507 @@
+#!/usr/bin/env python3
+"""scout_effectiveness — measurement harness for the cheap-model scout pre-pass.
+
+Correlates governed dispatch receipts with scout sidecars / scout audit receipts
+to measure whether scout-enriched dispatches are cheaper/faster/more successful
+than non-enriched dispatches on the same corpus.
+
+Design notes:
+  - Read-only over receipts and sidecars; never mutates state.
+  - Sidecar existence is the scout-enriched flag (matches ``scout_prepass``).
+  - Reports are observational, not causal: dispatch selection is NOT randomized,
+    so confounders (task difficulty, role, model, etc.) may explain deltas.
+  - True rework attribution lives in ``quality_intelligence.db``
+    (``dispatch_metadata.parent_dispatch``). This harness uses receipt
+    ``status == "success"`` as an observational first-pass-yield proxy and
+    clearly labels it as such.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+RECEIPT_FILE = "t0_receipts.ndjson"
+SCOUT_RECEIPT_FILE = "scout_receipts.ndjson"
+SCOUT_SUBDIR = "scout"
+
+
+# ---------------------------------------------------------------------------
+# Data loading
+# ---------------------------------------------------------------------------
+
+def _safe_float(value: Any) -> Optional[float]:
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        value = value.strip()
+        if value == "":
+            return None
+        try:
+            return float(value)
+        except ValueError:
+            return None
+    return None
+
+
+def _safe_int(value: Any) -> Optional[int]:
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    if isinstance(value, float):
+        return int(value)
+    if isinstance(value, str):
+        value = value.strip().replace(",", "")
+        if value == "":
+            return None
+        try:
+            return int(float(value))
+        except ValueError:
+            return None
+    return None
+
+
+def _load_ndjson(path: Path) -> Tuple[List[Dict[str, Any]], int]:
+    """Load NDJSON lines. Returns (parsed_objects, invalid_line_count)."""
+    rows: List[Dict[str, Any]] = []
+    invalid = 0
+    if not path.is_file():
+        return rows, invalid
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+            if isinstance(parsed, dict):
+                rows.append(parsed)
+            else:
+                invalid += 1
+        except json.JSONDecodeError:
+            invalid += 1
+    return rows, invalid
+
+
+def load_receipts(state_dir: Path) -> Tuple[List[Dict[str, Any]], int]:
+    return _load_ndjson(Path(state_dir) / RECEIPT_FILE)
+
+
+def load_scout_receipts(state_dir: Path) -> Tuple[List[Dict[str, Any]], int]:
+    return _load_ndjson(Path(state_dir) / SCOUT_RECEIPT_FILE)
+
+
+def list_scout_sidecar_dispatch_ids(state_dir: Path) -> set[str]:
+    """Return dispatch_ids that have a scout sidecar on disk."""
+    scout_dir = Path(state_dir) / SCOUT_SUBDIR
+    if not scout_dir.is_dir():
+        return set()
+    ids: set[str] = set()
+    for path in scout_dir.iterdir():
+        if path.is_file() and path.suffix == ".json":
+            # The safe-id contract means path.stem is a valid dispatch_id.
+            ids.add(path.stem)
+    return ids
+
+
+# ---------------------------------------------------------------------------
+# Receipt extraction
+# ---------------------------------------------------------------------------
+
+def _extract_worker_tokens(receipt: Dict[str, Any]) -> Optional[int]:
+    """Sum input + output tokens from ``token_usage`` (governed shape)."""
+    token_usage = receipt.get("token_usage")
+    if not isinstance(token_usage, dict):
+        # Tolerate the flatter session keys used by some append paths.
+        token_usage = receipt
+    input_t = _safe_int(token_usage.get("input")) or _safe_int(token_usage.get("input_tokens"))
+    output_t = _safe_int(token_usage.get("output")) or _safe_int(token_usage.get("output_tokens"))
+    if input_t is None or output_t is None:
+        return None
+    return input_t + output_t
+
+
+def _extract_worker_cost(receipt: Dict[str, Any]) -> Optional[float]:
+    return _safe_float(receipt.get("cost_usd"))
+
+
+def _extract_duration(receipt: Dict[str, Any]) -> Optional[float]:
+    return _safe_float(receipt.get("duration_seconds"))
+
+
+def _is_success(receipt: Dict[str, Any]) -> Optional[bool]:
+    status = receipt.get("status")
+    if not status:
+        return None
+    return str(status).strip().lower() == "success"
+
+
+@dataclass(frozen=True)
+class DispatchRecord:
+    dispatch_id: str
+    provider: str
+    model: str
+    terminal_id: str
+    status: str
+    worker_tokens: Optional[int]
+    worker_cost_usd: Optional[float]
+    duration_seconds: Optional[float]
+    is_success: Optional[bool]
+    scout_enriched: bool
+    scout_cost_usd: float = 0.0
+
+
+def correlate_records(
+    receipts: Iterable[Dict[str, Any]],
+    scout_receipts: Iterable[Dict[str, Any]],
+    sidecar_ids: Iterable[str],
+) -> List[DispatchRecord]:
+    """Join worker receipts with scout audit receipts and sidecar flags."""
+    scout_cost_by_dispatch: Dict[str, float] = {}
+    for sr in scout_receipts:
+        if not isinstance(sr, dict):
+            continue
+        did = str(sr.get("dispatch_id") or "").strip()
+        if not did:
+            continue
+        scout_cost_by_dispatch[did] = scout_cost_by_dispatch.get(did, 0.0) + (
+            _safe_float(sr.get("cost_usd")) or 0.0
+        )
+
+    sidecar_set = set(sidecar_ids)
+
+    records: List[DispatchRecord] = []
+    for r in receipts:
+        if not isinstance(r, dict):
+            continue
+        did = str(r.get("dispatch_id") or "").strip()
+        if not did:
+            continue
+        enriched = did in sidecar_set or did in scout_cost_by_dispatch
+        records.append(
+            DispatchRecord(
+                dispatch_id=did,
+                provider=str(r.get("provider") or "unknown").strip(),
+                model=str(r.get("model") or "unknown").strip(),
+                terminal_id=str(r.get("terminal_id") or "unknown").strip(),
+                status=str(r.get("status") or "unknown").strip(),
+                worker_tokens=_extract_worker_tokens(r),
+                worker_cost_usd=_extract_worker_cost(r),
+                duration_seconds=_extract_duration(r),
+                is_success=_is_success(r),
+                scout_enriched=enriched,
+                scout_cost_usd=scout_cost_by_dispatch.get(did, 0.0) if enriched else 0.0,
+            )
+        )
+    return records
+
+
+# ---------------------------------------------------------------------------
+# Cohort statistics
+# ---------------------------------------------------------------------------
+
+def _mean(values: Sequence[float]) -> Optional[float]:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+def _rate(values: Sequence[bool]) -> Optional[float]:
+    if not values:
+        return None
+    return sum(values) / len(values)
+
+
+@dataclass
+class CohortStats:
+    count: int = 0
+    tokens_values: List[int] = field(default_factory=list)
+    cost_values: List[float] = field(default_factory=list)
+    duration_values: List[float] = field(default_factory=list)
+    success_values: List[bool] = field(default_factory=list)
+
+    @property
+    def mean_tokens(self) -> Optional[float]:
+        return _mean(self.tokens_values)
+
+    @property
+    def mean_cost_usd(self) -> Optional[float]:
+        return _mean(self.cost_values)
+
+    @property
+    def mean_duration_seconds(self) -> Optional[float]:
+        return _mean(self.duration_values)
+
+    @property
+    def success_rate(self) -> Optional[float]:
+        return _rate(self.success_values)
+
+    @property
+    def sum_cost_usd(self) -> float:
+        return sum(self.cost_values)
+
+    @property
+    def sum_tokens(self) -> int:
+        return sum(self.tokens_values)
+
+
+def build_cohort(records: Iterable[DispatchRecord]) -> CohortStats:
+    stats = CohortStats()
+    for rec in records:
+        stats.count += 1
+        if rec.worker_tokens is not None:
+            stats.tokens_values.append(rec.worker_tokens)
+        if rec.worker_cost_usd is not None:
+            stats.cost_values.append(rec.worker_cost_usd)
+        if rec.duration_seconds is not None:
+            stats.duration_values.append(rec.duration_seconds)
+        if rec.is_success is not None:
+            stats.success_values.append(rec.is_success)
+    return stats
+
+
+# ---------------------------------------------------------------------------
+# Effectiveness report
+# ---------------------------------------------------------------------------
+
+def _delta(enriched_val: Optional[float], non_val: Optional[float]) -> Optional[float]:
+    if enriched_val is None or non_val is None:
+        return None
+    return enriched_val - non_val
+
+
+def _pct_delta(delta: Optional[float], baseline: Optional[float]) -> Optional[float]:
+    if delta is None or baseline is None or baseline == 0:
+        return None
+    return (delta / baseline) * 100.0
+
+
+@dataclass
+class EffectivenessReport:
+    total_dispatches: int
+    enriched_count: int
+    non_enriched_count: int
+    enriched: CohortStats
+    non_enriched: CohortStats
+    total_scout_cost_usd: float
+    token_delta_per_dispatch: Optional[float]
+    token_delta_pct: Optional[float]
+    cost_delta_per_dispatch_usd: Optional[float]
+    cost_delta_pct: Optional[float]
+    duration_delta_seconds: Optional[float]
+    duration_delta_pct: Optional[float]
+    success_rate_delta: Optional[float]
+    success_rate_delta_pct_points: Optional[float]
+    estimated_worker_token_savings: Optional[float]
+    estimated_worker_cost_savings_usd: Optional[float]
+    net_usd: Optional[float]
+    verdict: str
+    warnings: List[str] = field(default_factory=list)
+    observational_note: str = (
+        "This is an OBSERVATIONAL comparison, not a causal A/B test. "
+        "Confounders (task difficulty, role, model, lane, instruction length) "
+        "are not controlled. A randomized shadow-A/B would be required for a "
+        "causal verdict on scout ROI."
+    )
+
+
+def compute_effectiveness(records: Sequence[DispatchRecord]) -> EffectivenessReport:
+    enriched = [r for r in records if r.scout_enriched]
+    non_enriched = [r for r in records if not r.scout_enriched]
+
+    enriched_stats = build_cohort(enriched)
+    non_stats = build_cohort(non_enriched)
+
+    total_scout_cost = sum(r.scout_cost_usd for r in enriched)
+
+    token_delta = _delta(enriched_stats.mean_tokens, non_stats.mean_tokens)
+    cost_delta = _delta(enriched_stats.mean_cost_usd, non_stats.mean_cost_usd)
+    duration_delta = _delta(enriched_stats.mean_duration_seconds, non_stats.mean_duration_seconds)
+    success_delta = _delta(enriched_stats.success_rate, non_stats.success_rate)
+
+    estimated_token_savings: Optional[float] = None
+    estimated_cost_savings: Optional[float] = None
+    net_usd: Optional[float] = None
+    verdict = "insufficient data"
+
+    warnings: List[str] = []
+
+    if enriched_stats.count == 0:
+        warnings.append("No scout-enriched dispatches found in corpus.")
+    if non_enriched.count == 0:
+        warnings.append("No non-enriched dispatches found in corpus.")
+
+    if enriched_stats.count and non_enriched.count:
+        if enriched_stats.mean_tokens is not None and non_stats.mean_tokens is not None:
+            # Negative delta means enriched uses fewer tokens -> savings.
+            estimated_token_savings = (non_stats.mean_tokens - enriched_stats.mean_tokens) * enriched_stats.count
+        if enriched_stats.mean_cost_usd is not None and non_stats.mean_cost_usd is not None:
+            estimated_cost_savings = (non_stats.mean_cost_usd - enriched_stats.mean_cost_usd) * enriched_stats.count
+        if estimated_cost_savings is not None:
+            net_usd = estimated_cost_savings - total_scout_cost
+            if net_usd > 0:
+                verdict = "scout pays for itself (observational)"
+            elif net_usd < 0:
+                verdict = "scout does not pay for itself (observational)"
+            else:
+                verdict = "scout breaks even (observational)"
+        else:
+            verdict = "cannot judge ROI: worker cost data missing"
+    else:
+        verdict = "cannot judge ROI: missing cohort"
+
+    return EffectivenessReport(
+        total_dispatches=len(records),
+        enriched_count=enriched_stats.count,
+        non_enriched_count=non_stats.count,
+        enriched=enriched_stats,
+        non_enriched=non_stats,
+        total_scout_cost_usd=total_scout_cost,
+        token_delta_per_dispatch=token_delta,
+        token_delta_pct=_pct_delta(token_delta, non_stats.mean_tokens),
+        cost_delta_per_dispatch_usd=cost_delta,
+        cost_delta_pct=_pct_delta(cost_delta, non_stats.mean_cost_usd),
+        duration_delta_seconds=duration_delta,
+        duration_delta_pct=_pct_delta(duration_delta, non_stats.mean_duration_seconds),
+        success_rate_delta=success_delta,
+        success_rate_delta_pct_points=success_delta,
+        estimated_worker_token_savings=estimated_token_savings,
+        estimated_worker_cost_savings_usd=estimated_cost_savings,
+        net_usd=net_usd,
+        verdict=verdict,
+        warnings=warnings,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Output formatting
+# ---------------------------------------------------------------------------
+
+def _fmt_optional(value: Optional[float], precision: int = 3, suffix: str = "") -> str:
+    if value is None:
+        return "n/a"
+    return f"{value:.{precision}f}{suffix}"
+
+
+def format_report(report: EffectivenessReport) -> str:
+    lines: List[str] = []
+    lines.append("=" * 72)
+    lines.append("Scout Effectiveness Measurement (observational)")
+    lines.append("=" * 72)
+    lines.append(f"Total dispatches analyzed: {report.total_dispatches}")
+    lines.append(f"  Scout-enriched:    {report.enriched_count}")
+    lines.append(f"  Non-enriched:      {report.non_enriched_count}")
+    lines.append("")
+    lines.append("Cohort means")
+    lines.append("-" * 72)
+    lines.append(
+        f"{'Metric':<36} {'Enriched':>14} {'Non-enriched':>14} {'Delta':>14}"
+    )
+    lines.append(
+        f"{'Worker tokens (input+output)':<36} "
+        f"{_fmt_optional(report.enriched.mean_tokens):>14} "
+        f"{_fmt_optional(report.non_enriched.mean_tokens):>14} "
+        f"{_fmt_optional(report.token_delta_per_dispatch):>14}"
+    )
+    lines.append(
+        f"{'Worker cost USD':<36} "
+        f"{_fmt_optional(report.enriched.mean_cost_usd, precision=6):>14} "
+        f"{_fmt_optional(report.non_enriched.mean_cost_usd, precision=6):>14} "
+        f"{_fmt_optional(report.cost_delta_per_dispatch_usd, precision=6):>14}"
+    )
+    lines.append(
+        f"{'Duration seconds':<36} "
+        f"{_fmt_optional(report.enriched.mean_duration_seconds):>14} "
+        f"{_fmt_optional(report.non_enriched.mean_duration_seconds):>14} "
+        f"{_fmt_optional(report.duration_delta_seconds):>14}"
+    )
+    lines.append(
+        f"{'Success rate (FPY proxy)':<36} "
+        f"{_fmt_optional(report.enriched.success_rate, precision=3):>14} "
+        f"{_fmt_optional(report.non_enriched.success_rate, precision=3):>14} "
+        f"{_fmt_optional(report.success_rate_delta, precision=3):>14}"
+    )
+    lines.append("")
+    lines.append("Economics")
+    lines.append("-" * 72)
+    lines.append(f"Total DeepSeek/scout cost:        ${_fmt_optional(report.total_scout_cost_usd, precision=6)}")
+    lines.append(
+        f"Estimated worker token savings:   {_fmt_optional(report.estimated_worker_token_savings)} tokens"
+    )
+    lines.append(
+        f"Estimated worker cost savings:    ${_fmt_optional(report.estimated_worker_cost_savings_usd, precision=6)}"
+    )
+    lines.append(f"Net USD (savings - scout cost):   ${_fmt_optional(report.net_usd, precision=6)}")
+    lines.append("")
+    lines.append(f"Verdict: {report.verdict}")
+    lines.append("")
+    if report.warnings:
+        lines.append("Warnings")
+        lines.append("-" * 72)
+        for w in report.warnings:
+            lines.append(f"  - {w}")
+        lines.append("")
+    lines.append("Notes")
+    lines.append("-" * 72)
+    lines.append(report.observational_note)
+    lines.append(
+        "True rework attribution requires quality_intelligence.db "
+        "(dispatch_metadata.parent_dispatch); receipt status is used here as a proxy."
+    )
+    return "\n".join(lines) + "\n"
+
+
+def report_to_dict(report: EffectivenessReport) -> Dict[str, Any]:
+    """Serialize the report to a plain JSON-serializable dict."""
+    return {
+        "total_dispatches": report.total_dispatches,
+        "enriched_count": report.enriched_count,
+        "non_enriched_count": report.non_enriched_count,
+        "enriched": {
+            "count": report.enriched.count,
+            "mean_tokens": report.enriched.mean_tokens,
+            "mean_cost_usd": report.enriched.mean_cost_usd,
+            "mean_duration_seconds": report.enriched.mean_duration_seconds,
+            "success_rate": report.enriched.success_rate,
+            "sum_tokens": report.enriched.sum_tokens,
+            "sum_cost_usd": report.enriched.sum_cost_usd,
+        },
+        "non_enriched": {
+            "count": report.non_enriched.count,
+            "mean_tokens": report.non_enriched.mean_tokens,
+            "mean_cost_usd": report.non_enriched.mean_cost_usd,
+            "mean_duration_seconds": report.non_enriched.mean_duration_seconds,
+            "success_rate": report.non_enriched.success_rate,
+            "sum_tokens": report.non_enriched.sum_tokens,
+            "sum_cost_usd": report.non_enriched.sum_cost_usd,
+        },
+        "total_scout_cost_usd": report.total_scout_cost_usd,
+        "token_delta_per_dispatch": report.token_delta_per_dispatch,
+        "token_delta_pct": report.token_delta_pct,
+        "cost_delta_per_dispatch_usd": report.cost_delta_per_dispatch_usd,
+        "cost_delta_pct": report.cost_delta_pct,
+        "duration_delta_seconds": report.duration_delta_seconds,
+        "duration_delta_pct": report.duration_delta_pct,
+        "success_rate_delta": report.success_rate_delta,
+        "estimated_worker_token_savings": report.estimated_worker_token_savings,
+        "estimated_worker_cost_savings_usd": report.estimated_worker_cost_savings_usd,
+        "net_usd": report.net_usd,
+        "verdict": report.verdict,
+        "warnings": report.warnings,
+        "observational_note": report.observational_note,
+    }
+
+
+def write_artifact(path: Path, report: EffectivenessReport) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(report_to_dict(report), indent=2) + "\n", encoding="utf-8")
+    return path

--- a/scripts/scout_effectiveness.py
+++ b/scripts/scout_effectiveness.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""CLI for the scout effectiveness measurement harness.
+
+Usage:
+    python3 scripts/scout_effectiveness.py [--state-dir PATH] [--output-json PATH]
+
+Resolves the state directory through VNX path helpers (``vnx_paths``), which
+honor ``VNX_STATE_DIR`` and fall back to the resolved project state directory
+(typically ``~/.vnx-data/<project_id>/state`` for existing central installs).
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIB_DIR = SCRIPT_DIR / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from scout_effectiveness import (  # noqa: E402
+    compute_effectiveness,
+    correlate_records,
+    format_report,
+    list_scout_sidecar_dispatch_ids,
+    load_receipts,
+    load_scout_receipts,
+    write_artifact,
+)
+
+try:
+    from vnx_paths import ensure_env  # noqa: E402
+except Exception as exc:  # pragma: no cover - bootstrap failure
+    raise SystemExit(f"Failed to load vnx_paths: {exc}") from exc
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_ARTIFACT_NAME = "scout_effectiveness.json"
+
+
+def _resolve_state_dir(cli_override: Optional[Path] = None) -> Path:
+    if cli_override is not None:
+        return cli_override.expanduser().resolve()
+    env_state = os.environ.get("VNX_STATE_DIR")
+    if env_state:
+        return Path(env_state).expanduser().resolve()
+    paths = ensure_env()
+    return Path(paths["VNX_STATE_DIR"]).expanduser().resolve()
+
+
+def _default_output_path(state_dir: Path) -> Path:
+    return state_dir / DEFAULT_ARTIFACT_NAME
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Measure scout effectiveness from existing VNX receipts and scout sidecars."
+    )
+    parser.add_argument(
+        "--state-dir",
+        type=Path,
+        default=None,
+        help="Override VNX state directory (default: resolved VNX_STATE_DIR).",
+    )
+    parser.add_argument(
+        "--output-json",
+        type=Path,
+        default=None,
+        help="Write JSON artifact to this path (default: <state-dir>/scout_effectiveness.json).",
+    )
+    parser.add_argument(
+        "--quiet",
+        action="store_true",
+        help="Suppress the CLI table; still writes the JSON artifact if requested.",
+    )
+    parser.add_argument(
+        "--no-json",
+        action="store_true",
+        help="Do not write the JSON artifact.",
+    )
+    parser.add_argument(
+        "--log-level",
+        default="WARNING",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"],
+        help="Logging level (default: WARNING).",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=getattr(logging, args.log_level), format="%(levelname)s: %(message)s")
+
+    state_dir = _resolve_state_dir(args.state_dir)
+    if not state_dir.is_dir():
+        print(f"[scout-effectiveness] State directory does not exist: {state_dir}", file=sys.stderr)
+        return 1
+
+    receipts, invalid_receipts = load_receipts(state_dir)
+    scout_receipts, invalid_scout = load_scout_receipts(state_dir)
+    sidecar_ids = list_scout_sidecar_dispatch_ids(state_dir)
+
+    records = correlate_records(receipts, scout_receipts, sidecar_ids)
+    report = compute_effectiveness(records)
+
+    if invalid_receipts:
+        report.warnings.append(f"Skipped {invalid_receipts} malformed t0_receipts lines.")
+    if invalid_scout:
+        report.warnings.append(f"Skipped {invalid_scout} malformed scout_receipts lines.")
+
+    if not receipts:
+        report.warnings.append(f"No receipts found at {state_dir / 't0_receipts.ndjson'}.")
+    if not scout_receipts and not sidecar_ids:
+        report.warnings.append(
+            "No scout receipts or sidecars found. "
+            "Either the scout has not run yet or it writes enrichment through a different path."
+        )
+
+    if not args.quiet:
+        print(format_report(report))
+
+    if not args.no_json:
+        output_path = args.output_json or _default_output_path(state_dir)
+        write_artifact(output_path, report)
+        if not args.quiet:
+            print(f"JSON artifact written: {output_path}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_scout_effectiveness.py
+++ b/tests/test_scout_effectiveness.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Tests for the scout effectiveness measurement harness.
+
+Dispatch-ID: 20260709-180848-scout-effectiveness-b
+
+Covers correlation math, cohort statistics, and the net verdict on a small
+fixture corpus. All state is written to temporary directories; no production
+receipts are touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import scout_effectiveness as se  # noqa: E402
+
+
+def _write_ndjson(path: Path, rows: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("\n".join(json.dumps(r, separators=(",", ":")) for r in rows) + "\n", encoding="utf-8")
+
+
+@pytest.fixture
+def fixture_corpus(tmp_path: Path):
+    """A tiny read-only corpus with 2 enriched and 2 non-enriched dispatches."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+
+    receipts = [
+        # Enriched dispatches: lower worker tokens/cost (scout is helping).
+        {
+            "dispatch_id": "20260709-100000-enriched-a",
+            "terminal_id": "T1",
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "status": "success",
+            "duration_seconds": 120.0,
+            "token_usage": {"input": 8000, "output": 2000},
+            "cost_usd": 0.120,
+        },
+        {
+            "dispatch_id": "20260709-100001-enriched-b",
+            "terminal_id": "T1",
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "status": "success",
+            "duration_seconds": 110.0,
+            "token_usage": {"input": 7000, "output": 1500},
+            "cost_usd": 0.105,
+        },
+        # Non-enriched dispatches: higher worker tokens/cost.
+        {
+            "dispatch_id": "20260709-100002-plain-a",
+            "terminal_id": "T1",
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "status": "success",
+            "duration_seconds": 180.0,
+            "token_usage": {"input": 12000, "output": 3000},
+            "cost_usd": 0.180,
+        },
+        {
+            "dispatch_id": "20260709-100003-plain-b",
+            "terminal_id": "T2",
+            "provider": "claude",
+            "model": "claude-sonnet-4-6",
+            "status": "failed",
+            "duration_seconds": 200.0,
+            "token_usage": {"input": 13000, "output": 3500},
+            "cost_usd": 0.200,
+        },
+    ]
+
+    scout_receipts = [
+        {
+            "event_type": "scout_prepass",
+            "dispatch_id": "20260709-100000-enriched-a",
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "cost_usd": 0.002,
+            "duration_seconds": 1.5,
+        },
+        {
+            "event_type": "scout_prepass",
+            "dispatch_id": "20260709-100001-enriched-b",
+            "provider": "deepseek",
+            "model": "deepseek-v4-flash",
+            "cost_usd": 0.0015,
+            "duration_seconds": 1.2,
+        },
+    ]
+
+    _write_ndjson(state_dir / "t0_receipts.ndjson", receipts)
+    _write_ndjson(state_dir / "scout_receipts.ndjson", scout_receipts)
+
+    # One sidecar to exercise the sidecar-discovery path; the other enriched
+    # dispatch is detected purely from scout_receipts.ndjson.
+    (state_dir / "scout").mkdir(parents=True)
+    (state_dir / "scout" / "20260709-100000-enriched-a.json").write_text(
+        json.dumps({"schema_version": 1, "dispatch_id": "20260709-100000-enriched-a"}),
+        encoding="utf-8",
+    )
+
+    return state_dir
+
+
+class TestCorrelation:
+    def test_sidecar_discovery(self, fixture_corpus):
+        ids = se.list_scout_sidecar_dispatch_ids(fixture_corpus)
+        assert ids == {"20260709-100000-enriched-a"}
+
+    def test_correlate_splits_enriched(self, fixture_corpus):
+        receipts, _ = se.load_receipts(fixture_corpus)
+        scout_receipts, _ = se.load_scout_receipts(fixture_corpus)
+        sidecar_ids = se.list_scout_sidecar_dispatch_ids(fixture_corpus)
+        records = se.correlate_records(receipts, scout_receipts, sidecar_ids)
+
+        enriched = [r for r in records if r.scout_enriched]
+        non_enriched = [r for r in records if not r.scout_enriched]
+
+        assert len(records) == 4
+        assert len(enriched) == 2
+        assert len(non_enriched) == 2
+        assert {r.dispatch_id for r in enriched} == {
+            "20260709-100000-enriched-a",
+            "20260709-100001-enriched-b",
+        }
+
+    def test_scout_cost_aggregation(self, fixture_corpus):
+        receipts, _ = se.load_receipts(fixture_corpus)
+        scout_receipts, _ = se.load_scout_receipts(fixture_corpus)
+        records = se.correlate_records(receipts, scout_receipts, set())
+        by_id = {r.dispatch_id: r for r in records}
+        assert by_id["20260709-100000-enriched-a"].scout_cost_usd == pytest.approx(0.002)
+        assert by_id["20260709-100001-enriched-b"].scout_cost_usd == pytest.approx(0.0015)
+        assert by_id["20260709-100002-plain-a"].scout_cost_usd == 0.0
+
+
+class TestCohortStats:
+    def test_means(self, fixture_corpus):
+        receipts, _ = se.load_receipts(fixture_corpus)
+        scout_receipts, _ = se.load_scout_receipts(fixture_corpus)
+        records = se.correlate_records(receipts, scout_receipts, set())
+        enriched = se.build_cohort(r for r in records if r.scout_enriched)
+        non_enriched = se.build_cohort(r for r in records if not r.scout_enriched)
+
+        assert enriched.mean_tokens == pytest.approx(9250.0)  # (10000 + 8500) / 2
+        assert non_enriched.mean_tokens == pytest.approx(15750.0)  # (15000 + 16500) / 2
+        assert enriched.mean_cost_usd == pytest.approx(0.1125)
+        assert non_enriched.mean_cost_usd == pytest.approx(0.19)
+        assert enriched.success_rate == pytest.approx(1.0)
+        assert non_enriched.success_rate == pytest.approx(0.5)
+
+
+class TestEffectivenessReport:
+    def test_net_verdict_positive(self, fixture_corpus):
+        receipts, _ = se.load_receipts(fixture_corpus)
+        scout_receipts, _ = se.load_scout_receipts(fixture_corpus)
+        records = se.correlate_records(receipts, scout_receipts, set())
+        report = se.compute_effectiveness(records)
+
+        assert report.total_dispatches == 4
+        assert report.enriched_count == 2
+        assert report.non_enriched_count == 2
+        assert report.total_scout_cost_usd == pytest.approx(0.0035)
+
+        # Non-enriched mean cost 0.19, enriched mean cost 0.1125 -> savings per
+        # enriched dispatch = 0.0775. Across 2 enriched dispatches = 0.155.
+        assert report.estimated_worker_cost_savings_usd == pytest.approx(0.155)
+        # Scout cost 0.0035 -> net positive.
+        assert report.net_usd == pytest.approx(0.1515)
+        assert report.verdict == "scout pays for itself (observational)"
+
+        # Token delta: enriched mean 9250, non-enriched mean 15750 -> delta -6500.
+        assert report.token_delta_per_dispatch == pytest.approx(-6500.0)
+        # Estimated token savings = 6500 * 2 = 13000.
+        assert report.estimated_worker_token_savings == pytest.approx(13000.0)
+
+    def test_report_serialization(self, fixture_corpus):
+        receipts, _ = se.load_receipts(fixture_corpus)
+        scout_receipts, _ = se.load_scout_receipts(fixture_corpus)
+        records = se.correlate_records(receipts, scout_receipts, set())
+        report = se.compute_effectiveness(records)
+        payload = se.report_to_dict(report)
+
+        assert payload["total_dispatches"] == 4
+        assert payload["enriched"]["count"] == 2
+        assert payload["non_enriched"]["count"] == 2
+        assert payload["net_usd"] == pytest.approx(0.1515)
+        assert "observational_note" in payload
+
+
+class TestEmptyCorpus:
+    def test_no_cohorts_warns(self, tmp_path: Path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _write_ndjson(state_dir / "t0_receipts.ndjson", [])
+        _write_ndjson(state_dir / "scout_receipts.ndjson", [])
+
+        receipts, _ = se.load_receipts(state_dir)
+        scout_receipts, _ = se.load_scout_receipts(state_dir)
+        records = se.correlate_records(receipts, scout_receipts, set())
+        report = se.compute_effectiveness(records)
+
+        assert report.enriched_count == 0
+        assert report.non_enriched_count == 0
+        assert report.verdict == "cannot judge ROI: missing cohort"
+
+
+class TestCli:
+    def _load_cli_main(self):
+        """Import the CLI script under a distinct module name."""
+        import importlib.util
+
+        cli_path = SCRIPTS_DIR / "scout_effectiveness.py"
+        spec = importlib.util.spec_from_file_location(
+            "scout_effectiveness_cli", cli_path
+        )
+        module = importlib.util.module_from_spec(spec)
+        sys.modules["scout_effectiveness_cli"] = module
+        spec.loader.exec_module(module)
+        return module.main
+
+    def test_cli_runs_and_writes_artifact(self, fixture_corpus, monkeypatch, capsys):
+        main = self._load_cli_main()
+        monkeypatch.setenv("VNX_STATE_DIR", str(fixture_corpus))
+        rc = main(["--state-dir", str(fixture_corpus)])
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "Scout Effectiveness Measurement" in captured.out
+        artifact = fixture_corpus / "scout_effectiveness.json"
+        assert artifact.is_file()
+        payload = json.loads(artifact.read_text(encoding="utf-8"))
+        assert payload["enriched_count"] == 2
+        assert payload["non_enriched_count"] == 2
+        assert payload["net_usd"] == pytest.approx(0.1515)
+
+    def test_cli_quiet_writes_json(self, fixture_corpus, monkeypatch, capsys):
+        main = self._load_cli_main()
+        monkeypatch.setenv("VNX_STATE_DIR", str(fixture_corpus))
+        rc = main(["--state-dir", str(fixture_corpus), "--quiet"])
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert captured.out == ""
+        assert (fixture_corpus / "scout_effectiveness.json").is_file()
+
+    def test_cli_no_json(self, fixture_corpus, monkeypatch, capsys):
+        main = self._load_cli_main()
+        monkeypatch.setenv("VNX_STATE_DIR", str(fixture_corpus))
+        rc = main(["--state-dir", str(fixture_corpus), "--no-json"])
+        captured = capsys.readouterr()
+
+        assert rc == 0
+        assert "Scout Effectiveness Measurement" in captured.out
+        assert not (fixture_corpus / "scout_effectiveness.json").exists()


### PR DESCRIPTION
## Summary
Adds a measurement harness that correlates scout-enriched vs non-enriched dispatches over the existing receipt corpus and reports the core metric (executor-model token savings) + rework/FPY/duration deltas + DeepSeek scout cost → a net verdict. Observational (not causal) — a randomized shadow-A/B is the follow-up. Built via the Kimi lane.

## Changes
- `scripts/lib/scout_effectiveness.py` (+507): correlation + metric library over receipts/sidecars, path-resolved via helpers.
- `scripts/scout_effectiveness.py` (+134): CLI (table + JSON artifact).
- `tests/test_scout_effectiveness.py` (+266): fixture corpus (enriched + non-enriched) asserting the math + net verdict.

## Open Items
Randomized shadow-A/B needed for a causal ROI verdict; this enables observational measurement only (honestly reported as such).

Track: scout-effectiveness · Dispatch: 20260709-180848-scout-effectiveness-b

🤖 Generated with [Claude Code](https://claude.com/claude-code)