### PR TITLE
feat(doctor): flag dead/embedded-assumption hook + path references (central-mode-path-correctness)

### DIFF
--- a/tests/unit/vnx_cli/commands/test_doctor.py
+++ b/tests/unit/vnx_cli/commands/test_doctor.py
@@ -1,0 +1,143 @@
+#!/usr/bin/env python3
+"""Unit tests for vnx_cli/commands/doctor.py hook-path probe."""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from vnx_cli.commands.doctor import _check_hook_paths
+
+
+def _write_settings(project_dir: Path, settings: dict) -> Path:
+    settings_path = project_dir / ".claude" / "settings.json"
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(json.dumps(settings), encoding="utf-8")
+    return settings_path
+
+
+class TestHookPathResolution:
+    def test_live_and_dead_hook_paths(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+
+        hooks_dir = project / "scripts" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "live_hook.sh").write_text("#!/bin/bash\n")
+
+        settings = {
+            "hooks": {
+                "SessionStart": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": (
+                                    'bash -c \'exec bash "'
+                                    '$(git rev-parse --show-toplevel 2>/dev/null || echo .)'
+                                    '/scripts/hooks/live_hook.sh"\''
+                                ),
+                            }
+                        ],
+                    },
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": (
+                                    'bash -c \'exec bash "'
+                                    '$(git rev-parse --show-toplevel 2>/dev/null || echo .)'
+                                    '/scripts/hooks/dead_hook.sh"\''
+                                ),
+                            }
+                        ],
+                    },
+                ]
+            }
+        }
+        _write_settings(project, settings)
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "WARN"
+        assert "dead_hook.sh" in result.detail
+        assert "live_hook.sh" not in result.detail
+        assert "canonical .claude/vnx-system/hooks/" in result.detail
+
+    def test_missing_settings_is_clean(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "PASS"
+        assert "skipping" in result.detail
+
+    def test_malformed_settings_warns(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        settings_path = project / ".claude" / "settings.json"
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        settings_path.write_text("{not valid json", encoding="utf-8")
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "WARN"
+        assert "unparseable" in result.detail.lower()
+
+    def test_hardcoded_absolute_project_path_warns(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+
+        settings = {
+            "hooks": {
+                "PreToolUse": [
+                    {
+                        "matcher": "Bash",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": f"bash {project / 'scripts' / 'hooks' / 'gone.sh'}",
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        _write_settings(project, settings)
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "WARN"
+        assert "gone.sh" in result.detail
+        assert "hardcoded absolute" in result.detail.lower()
+
+    def test_all_paths_live_passes(self, tmp_path):
+        project = tmp_path / "project"
+        project.mkdir()
+        hooks_dir = project / "scripts" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "present.sh").write_text("#!/bin/bash\n")
+
+        settings = {
+            "hooks": {
+                "UserPromptSubmit": [
+                    {
+                        "matcher": "",
+                        "hooks": [
+                            {
+                                "type": "command",
+                                "command": 'bash -c \'exec bash "$ROOT/scripts/hooks/present.sh"\'',
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+        _write_settings(project, settings)
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "PASS"

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -4,6 +4,8 @@
 import json
 import logging
 import os
+import re
+import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -538,6 +540,131 @@ def _check_active_drain(data_root: Path) -> Check:
     )
 
 
+# Hook commands frequently embed relative or absolute script paths. These rot when
+# the install mode changes (embedded -> central) or when files move.
+_HOOK_PATH_RE = re.compile(
+    r"(?:^|(?<=[\s\"'=;]))(?:\$\w+|\$\([^)]*\))?"
+    r"[A-Za-z0-9_./-]*\.(?:sh|py)(?=[\s\"';|&<>(){}]|$)",
+    re.IGNORECASE,
+)
+
+
+def _strip_shell_prefix(raw: str) -> str:
+    """Remove a leading $(...) or $VAR from a path token so it can be resolved."""
+    raw = raw.strip()
+    if raw.startswith("$(") and ")/" in raw:
+        return raw.split(")/", 1)[1]
+    if raw.startswith("${") and "}/" in raw:
+        return raw.split("}/", 1)[1]
+    if raw.startswith("$") and "/" in raw:
+        return raw[raw.find("/") + 1:]
+    return raw
+
+
+def _extract_hook_paths(command: str) -> list[str]:
+    """Return candidate file paths referenced by a hook command string."""
+    candidates: list[str] = []
+    try:
+        tokens = shlex.split(command)
+    except ValueError:
+        tokens = [command]
+    for token in tokens:
+        for match in _HOOK_PATH_RE.finditer(token):
+            candidates.append(match.group(0))
+    return candidates
+
+
+def _check_hook_paths(project_dir: Path) -> Check:
+    """WARN for hook commands in .claude/settings.json that reference missing files."""
+    settings_path = project_dir / ".claude" / "settings.json"
+    if not settings_path.is_file():
+        return Check(
+            name="hooks:path-resolution",
+            status=PASS,
+            detail="no .claude/settings.json found; skipping hook path check",
+        )
+
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return Check(
+            name="hooks:path-resolution",
+            status=WARN,
+            detail=f".claude/settings.json is unparseable ({exc}); hook paths cannot be audited",
+        )
+
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return Check(
+            name="hooks:path-resolution",
+            status=PASS,
+            detail="no hooks section in .claude/settings.json",
+        )
+
+    project_root = project_dir.resolve()
+    dead_relative: list[str] = []
+    dead_absolute: list[str] = []
+
+    for event, matchers in hooks.items():
+        if not isinstance(matchers, list):
+            continue
+        for matcher in matchers:
+            if not isinstance(matcher, dict):
+                continue
+            for hook in matcher.get("hooks", []):
+                if not isinstance(hook, dict):
+                    continue
+                command = hook.get("command")
+                if not isinstance(command, str):
+                    continue
+                for raw in _extract_hook_paths(command):
+                    normalized = _strip_shell_prefix(raw)
+                    if not normalized or "/" not in normalized:
+                        continue
+                    if normalized.startswith("/"):
+                        abs_path = Path(normalized)
+                        try:
+                            in_project = abs_path.resolve().is_relative_to(project_root)
+                        except OSError:
+                            in_project = False
+                        if not in_project:
+                            continue
+                        if not abs_path.is_file():
+                            dead_absolute.append(normalized)
+                    else:
+                        target = project_root / normalized
+                        if not target.is_file():
+                            dead_relative.append(normalized)
+
+    if dead_relative or dead_absolute:
+        parts: list[str] = []
+        if dead_relative:
+            descriptions = "; ".join(
+                f"{p} (expected {project_root / p}; "
+                "use canonical .claude/vnx-system/hooks/ or vnx-install)"
+                for p in dead_relative
+            )
+            parts.append(f"referenced hook script(s) missing: {descriptions}")
+        if dead_absolute:
+            descriptions = "; ".join(
+                f"{p} (use canonical .claude/vnx-system/hooks/ or vnx-install, "
+                "not a hardcoded project-relative path)"
+                for p in dead_absolute
+            )
+            parts.append(f"hardcoded absolute project hook path(s) missing: {descriptions}")
+        return Check(
+            name="hooks:path-resolution",
+            status=WARN,
+            detail="; ".join(parts),
+        )
+
+    return Check(
+        name="hooks:path-resolution",
+        status=PASS,
+        detail="all referenced hook script paths resolve",
+    )
+
+
 def vnx_doctor(args) -> int:
     project_dir = Path(args.project_dir).resolve()
     emit_json = getattr(args, "json", False)
@@ -560,6 +687,7 @@ def vnx_doctor(args) -> int:
     checks.append(_check_overrides(project_dir))
     checks.extend(_check_worktree_orphans(project_dir))
     checks.append(_check_active_drain(data_root))
+    checks.append(_check_hook_paths(project_dir))
 
     passed = sum(1 for c in checks if c.status == PASS)
     warned = sum(1 for c in checks if c.status == WARN)


### PR DESCRIPTION
## Summary
Adds a WARN-level `vnx doctor` check that parses `.claude/settings.json` hooks and flags referenced script paths that do not resolve — the exact drift that silently broke a consumer repo (hooks pointed at non-existent `scripts/hooks/*.sh`, emitting "No such file" on every prompt). Also flags hardcoded absolute project paths assuming the old embedded layout. WARN, not FAIL. Built via the Kimi lane.

## Changes
- `vnx_cli/commands/doctor.py` (+128): new check parsing all hook events, extracting script paths (incl. `bash <path>` / inline `if…then <path>`), WARNing dead refs with an actionable message.
- `tests/unit/vnx_cli/commands/test_doctor.py` (+143): live+dead hook fixture, missing-settings.json no-crash.

Track: central-mode-path-correctness (doctor-check; the 2 concrete code bugs were already fixed) · Dispatch: 20260709-212328-centralmode-doctor

🤖 Generated with [Claude Code](https://claude.com/claude-code)