### PR TITLE
feat(quality): whole-repo standing file-size advisory (monolith backlog)

### DIFF
--- a/scripts/lib/quality_advisory.py
+++ b/scripts/lib/quality_advisory.py
@@ -739,3 +739,121 @@ def generate_quality_advisory(
     advisory.t0_recommendation = make_t0_decision(all_checks, risk_score)
 
     return advisory
+
+
+# Directories that are never source code for the whole-repo advisory scan.
+_BACKLOG_SKIP_DIRS = {
+    ".git",
+    "__pycache__",
+    ".venv",
+    "venv",
+    "node_modules",
+    ".vnx-data",
+    "dist",
+    "build",
+    ".tox",
+    ".pytest_cache",
+    ".mypy_cache",
+    ".egg-info",
+    ".claude",
+}
+
+
+def build_whole_repo_file_size_backlog(
+    repo_root: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Scan the entire repository for the file-size refactor backlog.
+
+    Unlike the diff-scoped blocking gate, this pass is purely ADVISORY. It walks
+    every source file under ``repo_root`` and returns every file that exceeds the
+    language warning threshold, sorted worst-first. Files over the blocking
+    threshold are flagged as ``blocking`` unless they are on the size allowlist
+    (then ``allowlisted`` with the grandfather reason) or are test files (then
+    ``warning`` with ``is_test_file`` set). Nothing in this function fails or
+    raises a gate hold.
+
+    Args:
+        repo_root: Repository root to scan. Defaults to the current working
+            directory.
+
+    Returns:
+        A dict describing the backlog, including ``backlog`` (list of entries),
+        counts, thresholds, and metadata.
+    """
+    if repo_root is None:
+        repo_root = Path.cwd()
+    repo_root = repo_root.resolve()
+
+    backlog: List[Dict[str, Any]] = []
+
+    for path in repo_root.rglob("*"):
+        if not path.is_file() or path.is_symlink():
+            continue
+        if path.suffix not in (".py", ".sh") and not path.name.endswith(".bash"):
+            continue
+        rel_parts = path.relative_to(repo_root).parts
+        if any(part in _BACKLOG_SKIP_DIRS for part in rel_parts):
+            continue
+
+        try:
+            lines = path.read_text(encoding="utf-8").splitlines()
+        except (OSError, UnicodeDecodeError):
+            continue
+
+        line_count = len(lines)
+        if path.suffix == ".py":
+            warning_threshold = FILE_SIZE_WARNING_PYTHON
+            blocking_threshold = FILE_SIZE_BLOCKING_PYTHON
+        else:
+            warning_threshold = FILE_SIZE_WARNING_SHELL
+            blocking_threshold = FILE_SIZE_BLOCKING_SHELL
+
+        if line_count <= warning_threshold:
+            continue
+
+        rel = path.relative_to(repo_root)
+        allow_reason = _file_size_allowlist_reason(path)
+        test_file = _is_test_file(path)
+
+        entry: Dict[str, Any] = {
+            "file": str(path),
+            "repo_relative": str(rel),
+            "line_count": line_count,
+            "warning_threshold": warning_threshold,
+            "blocking_threshold": blocking_threshold,
+            "status": "warning",
+            "severity": "warning",
+        }
+        if test_file:
+            entry["is_test_file"] = True
+
+        if line_count > blocking_threshold:
+            if allow_reason is not None:
+                entry["status"] = "allowlisted"
+                entry["allowlist_reason"] = allow_reason
+            elif test_file:
+                entry["status"] = "warning"
+            else:
+                entry["status"] = "blocking"
+                entry["severity"] = "blocking"
+
+        backlog.append(entry)
+
+    backlog.sort(key=lambda e: (-e["line_count"], e["repo_relative"]))
+
+    return {
+        "version": "1.0",
+        "generated_at": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+        "repo_root": str(repo_root),
+        "warning_threshold_python": FILE_SIZE_WARNING_PYTHON,
+        "blocking_threshold_python": FILE_SIZE_BLOCKING_PYTHON,
+        "warning_threshold_shell": FILE_SIZE_WARNING_SHELL,
+        "blocking_threshold_shell": FILE_SIZE_BLOCKING_SHELL,
+        "allowlisted_count": sum(1 for e in backlog if e["status"] == "allowlisted"),
+        "blocking_count": sum(1 for e in backlog if e["status"] == "blocking"),
+        "warning_count": sum(
+            1 for e in backlog if e["status"] not in ("allowlisted", "blocking")
+        ),
+        "total_backlog": len(backlog),
+        "backlog": backlog,
+    }

--- a/scripts/quality_advisory_scan.py
+++ b/scripts/quality_advisory_scan.py
@@ -1,0 +1,66 @@
+#!/usr/bin/env python3
+"""Whole-repo quality advisory backlog scanner.
+
+Advisory-only companion to the diff-scoped BLOCKING file-size gate in
+``scripts/lib/quality_advisory.py``. Walks the whole repository tree and writes
+a JSON backlog of every source file that exceeds the warning threshold. The
+output is written atomically and the script always exits 0 — it produces a
+backlog, it never fails a gate.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from atomic_io import atomic_write_json
+from project_root import resolve_data_dir, resolve_project_root
+from quality_advisory import build_whole_repo_file_size_backlog
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate a whole-repo file-size advisory backlog (advisory only; "
+            "never blocks CI or gates)."
+        )
+    )
+    parser.add_argument(
+        "--repo-root",
+        type=Path,
+        default=None,
+        help="Repository root to scan (default: git-resolved project root).",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=None,
+        help=(
+            "Output JSON path (default: "
+            "$VNX_DATA_DIR/quality_advisory_backlog.json)."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    repo_root = args.repo_root or resolve_project_root(__file__)
+    output_path = args.output or (
+        resolve_data_dir(__file__) / "quality_advisory_backlog.json"
+    )
+
+    backlog = build_whole_repo_file_size_backlog(repo_root)
+    atomic_write_json(output_path, backlog)
+
+    print(
+        f"quality_advisory_scan: wrote {backlog['total_backlog']} backlog item(s) "
+        f"({backlog['blocking_count']} blocking, {backlog['allowlisted_count']} "
+        f"allowlisted, {backlog['warning_count']} warning) to {output_path}"
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_quality_advisory_pipeline.py
+++ b/tests/test_quality_advisory_pipeline.py
@@ -14,6 +14,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 import quality_advisory as quality_advisory_module
 from quality_advisory import (
     QualityCheck,
+    build_whole_repo_file_size_backlog,
     check_file_size,
     check_function_sizes,
     calculate_risk_score,
@@ -454,6 +455,73 @@ class TestQualityAdvisoryGeneration:
         assert all(w.severity == "warning" for w in warnings)
         assert all(w.level == "warn" for w in warnings)
         assert all(w["code"] == "tool_unavailable" for w in warnings)
+
+
+class TestWholeRepoFileSizeBacklog:
+    """Test the whole-repo advisory backlog pass."""
+
+    def test_backlog_lists_oversized_allowlisted_and_skips_small(self, tmp_path):
+        """Whole-repo pass surfaces warning + allowlisted files and skips under-threshold files."""
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        lib = scripts / "lib"
+        lib.mkdir(parents=True)
+
+        big = scripts / "too_big.py"
+        big.write_text("\n" * 600)  # over python warning (500), under blocking (1200)
+
+        allowed = lib / "provider_dispatch.py"
+        allowed.write_text("\n" * 1300)  # over blocking, allowlisted
+
+        small = scripts / "small.py"
+        small.write_text("\n" * 100)  # under warning
+
+        backlog = build_whole_repo_file_size_backlog(tmp_path)
+
+        files = {e["repo_relative"] for e in backlog["backlog"]}
+        assert "scripts/too_big.py" in files
+        assert "scripts/lib/provider_dispatch.py" in files
+        assert "scripts/small.py" not in files
+
+        by_rel = {e["repo_relative"]: e for e in backlog["backlog"]}
+        assert by_rel["scripts/too_big.py"]["status"] == "warning"
+        assert by_rel["scripts/lib/provider_dispatch.py"]["status"] == "allowlisted"
+        assert "allowlist_reason" in by_rel["scripts/lib/provider_dispatch.py"]
+        assert "grandfathered monolith" in by_rel["scripts/lib/provider_dispatch.py"]["allowlist_reason"]
+
+        # Sorted worst-first
+        counts = [e["line_count"] for e in backlog["backlog"]]
+        assert counts == sorted(counts, reverse=True)
+
+        assert backlog["total_backlog"] == 2
+        assert backlog["warning_count"] == 1
+        assert backlog["allowlisted_count"] == 1
+        assert backlog["blocking_count"] == 0
+
+    def test_backlog_flags_non_allowlisted_blocking_monolith(self, tmp_path):
+        """A file over the hard ceiling that is NOT allowlisted is flagged blocking."""
+        f = tmp_path / "new_monolith.py"
+        f.write_text("\n" * 1300)
+
+        backlog = build_whole_repo_file_size_backlog(tmp_path)
+
+        assert backlog["total_backlog"] == 1
+        entry = backlog["backlog"][0]
+        assert entry["status"] == "blocking"
+        assert entry["severity"] == "blocking"
+        assert entry["line_count"] == 1300
+
+    def test_backlog_skips_ignored_directories(self, tmp_path):
+        """Files in skipped directories (e.g. __pycache__) do not pollute the backlog."""
+        cache = tmp_path / "__pycache__"
+        cache.mkdir()
+        (cache / "big.pyc").write_bytes(b"x" * 10000)  # irrelevant binary
+        scripts = tmp_path / "scripts"
+        scripts.mkdir()
+        (scripts / "small.py").write_text("\n" * 100)
+
+        backlog = build_whole_repo_file_size_backlog(tmp_path)
+        assert backlog["total_backlog"] == 0
 
 
 class TestTerminalSnapshot:


### PR DESCRIPTION
## Summary
Adds a whole-repo advisory pass surfacing the standing monolith backlog (files over the warning/blocking thresholds), complementing the existing diff-scoped BLOCKING gate. Advisory only — nothing fails on it. Built via the Kimi lane. Reuses thresholds+allowlist from `quality_advisory.py` (single source); artifact written atomically.

## Changes
- `scripts/lib/quality_advisory.py` (+118): whole-repo scan producing the backlog (worst-first, allowlisted monoliths marked with reason, not new violations).
- `scripts/quality_advisory_scan.py` (+66): CLI emitting the backlog + an atomic JSON artifact (atomic_io).
- `tests/test_quality_advisory_pipeline.py` (+68): over-threshold + allowlisted-monolith fixture assertions.

Diff-stat vs current main may show unrelated deletions — branch forked pre-#1073; verified against merge-base, real change is additions-only (no doctor.py touch).

Track: quality-advisory-code-health (whole-repo advisory; the BLOCKING ceiling was already shipped) · Dispatch: 20260709-213236-qualadv-wholerepo

🤖 Generated with [Claude Code](https://claude.com/claude-code)