### PR TITLE
feat(dashboard): live-sessions observability tile (session-observability Part A)

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -11,6 +11,7 @@ import contextlib
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import threading
@@ -40,6 +41,11 @@ DB_PATH = CANONICAL_STATE_DIR / "quality_intelligence.db"
 GATE_CONFIG_PATH = VNX_DIR / "configs" / "governance_gates.yaml"
 TERMINAL_TRACK_MAP = {"T1": "A", "T2": "B", "T3": "C"}
 VALID_TERMINALS = frozenset({"T0", "T1", "T2", "T3"})
+
+_UTC = timezone.utc
+
+# Pane current_command values that indicate an idle shell (not actively running a tool).
+_IDLE_SHELL_COMMANDS = frozenset({"bash", "zsh", "sh", "-bash", "-zsh", "-sh"})
 
 _gate_config_lock = threading.Lock()
 
@@ -673,6 +679,177 @@ def _operator_get_terminal(terminal_id: str) -> dict:
         return envelope.to_dict()
     except Exception as exc:
         return {"view": "TerminalView", "degraded": True, "degraded_reasons": [str(exc)], "data": {"terminal_id": terminal_id}}
+
+
+def _session_name_to_project(session_name: str) -> "str | None":
+    """Best-effort project name from a tmux session name."""
+    if session_name.startswith("vnx-"):
+        return session_name[4:] or None
+    if session_name.startswith("t0-"):
+        return "system"
+    return session_name
+
+
+def _parse_iso_or_none(value: "str | None") -> "datetime | None":
+    """Parse an ISO-8601 timestamp; return None on any failure."""
+    if not value:
+        return None
+    try:
+        ts = value.replace("Z", "+00:00")
+        return datetime.fromisoformat(ts)
+    except Exception:
+        return None
+
+
+def _list_tmux_sessions(now: datetime) -> "tuple[list[dict], list[str]]":
+    """Return (sessions, degraded_reasons) from tmux list-sessions/list-panes.
+
+    If tmux is absent or its commands fail, returns ([], []) — never raises.
+    """
+    if shutil.which("tmux") is None:
+        return [], []
+
+    sessions_result = subprocess.run(
+        ["tmux", "list-sessions", "-F", "#{session_name}\t#{session_activity}"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    if sessions_result.returncode != 0:
+        return [], []
+
+    # Collect per-session pane commands in one tmux call so busy/idle is cheap.
+    pane_commands: dict[str, list[str]] = defaultdict(list)
+    panes_result = subprocess.run(
+        ["tmux", "list-panes", "-a", "-F", "#{session_name}\t#{pane_current_command}"],
+        capture_output=True,
+        text=True,
+        timeout=5,
+    )
+    if panes_result.returncode == 0:
+        for line in panes_result.stdout.splitlines():
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                pane_commands[parts[0]].append(parts[1])
+
+    sessions: list[dict] = []
+    for line in sessions_result.stdout.splitlines():
+        parts = line.split("\t", 1)
+        if len(parts) != 2:
+            continue
+        name, activity_str = parts
+        try:
+            activity_epoch = int(activity_str)
+        except ValueError:
+            continue
+        last_activity_dt = datetime.fromtimestamp(activity_epoch, tz=_UTC)
+        last_activity = last_activity_dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+        age_seconds = max(0, int((now - last_activity_dt).total_seconds()))
+        commands = pane_commands.get(name, [])
+        status = "busy" if any(cmd not in _IDLE_SHELL_COMMANDS for cmd in commands) else "idle"
+        sessions.append({
+            "name": name,
+            "project": _session_name_to_project(name),
+            "status": status,
+            "last_activity": last_activity,
+            "age_seconds": age_seconds,
+        })
+
+    return sessions, []
+
+
+def _load_session_store_entries() -> "dict[str, dict]":
+    """Read persisted per-terminal session entries without mutating state."""
+    try:
+        from session_store import SessionStore
+        return SessionStore().all_entries()
+    except Exception:
+        return {}
+
+
+def _operator_get_sessions() -> dict:
+    """GET /api/operator/sessions -- read-only live session observability tile.
+
+    Composes tmux session liveness (name, project, idle/busy, activity age) with
+    the persistent session-store state (provider session_id, last dispatch_id).
+    No control actions are exposed here; Part B restart panel is out of scope.
+    """
+    now = datetime.now(_UTC)
+    degraded = False
+    degraded_reasons: list[str] = []
+    sessions_by_name: dict[str, dict] = {}
+
+    try:
+        tmux_sessions, tmux_reasons = _list_tmux_sessions(now)
+        degraded_reasons.extend(tmux_reasons)
+    except Exception as exc:
+        tmux_sessions = []
+        degraded = True
+        degraded_reasons.append(f"tmux enumeration failed: {exc}")
+
+    for s in tmux_sessions:
+        sessions_by_name[s["name"]] = {
+            "name": s["name"],
+            "project": s["project"],
+            "status": s["status"],
+            "last_activity": s["last_activity"],
+            "age_seconds": s["age_seconds"],
+            "session_id": None,
+            "dispatch_id": None,
+            "remote_control_url": None,
+        }
+
+    try:
+        store_entries = _load_session_store_entries()
+    except Exception as exc:
+        store_entries = {}
+        degraded = True
+        degraded_reasons.append(f"session store read failed: {exc}")
+
+    for terminal_id, entry in store_entries.items():
+        name = terminal_id
+        session_id = entry.get("session_id") or None
+        dispatch_id = entry.get("dispatch_id") or None
+        updated_at = entry.get("updated_at")
+        updated_dt = _parse_iso_or_none(updated_at)
+
+        if name in sessions_by_name:
+            existing = sessions_by_name[name]
+            existing["session_id"] = existing["session_id"] or session_id
+            existing["dispatch_id"] = existing["dispatch_id"] or dispatch_id
+            # The session-store update time can be more recent than tmux activity;
+            # surface the freshest timestamp we have.
+            if updated_dt is not None:
+                existing_dt = _parse_iso_or_none(existing.get("last_activity"))
+                if existing_dt is None or updated_dt > existing_dt:
+                    existing["last_activity"] = updated_at
+                    existing["age_seconds"] = max(0, int((now - updated_dt).total_seconds()))
+        else:
+            last_activity = updated_at if updated_dt is not None else None
+            age_seconds = max(0, int((now - updated_dt).total_seconds())) if updated_dt is not None else None
+            sessions_by_name[name] = {
+                "name": name,
+                "project": _session_name_to_project(name),
+                "status": "idle",
+                "last_activity": last_activity,
+                "age_seconds": age_seconds,
+                "session_id": session_id,
+                "dispatch_id": dispatch_id,
+                "remote_control_url": None,
+            }
+
+    data = sorted(
+        sessions_by_name.values(),
+        key=lambda s: ((s["project"] or ""), s["name"]),
+    )
+
+    return {
+        "view": "live-sessions",
+        "queried_at": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "degraded": degraded,
+        "degraded_reasons": degraded_reasons,
+        "data": data,
+    }
 
 
 def _operator_get_open_items(params: dict) -> dict:

--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -707,7 +707,7 @@ def _list_tmux_sessions(now: datetime) -> "tuple[list[dict], list[str]]":
     If tmux is absent or its commands fail, returns ([], []) — never raises.
     """
     if shutil.which("tmux") is None:
-        return [], []
+        return [], ["tmux binary not found on PATH"]
 
     sessions_result = subprocess.run(
         ["tmux", "list-sessions", "-F", "#{session_name}\t#{session_activity}"],
@@ -716,7 +716,9 @@ def _list_tmux_sessions(now: datetime) -> "tuple[list[dict], list[str]]":
         timeout=5,
     )
     if sessions_result.returncode != 0:
-        return [], []
+        reason = f"tmux list-sessions failed (rc={sessions_result.returncode})"
+        _logger.warning("session observability: %s", reason)
+        return [], [reason]
 
     # Collect per-session pane commands in one tmux call so busy/idle is cheap.
     pane_commands: dict[str, list[str]] = defaultdict(list)
@@ -763,7 +765,8 @@ def _load_session_store_entries() -> "dict[str, dict]":
     try:
         from session_store import SessionStore
         return SessionStore().all_entries()
-    except Exception:
+    except Exception as exc:
+        _logger.warning("session observability: session_store read failed, returning no persisted entries: %s", exc)
         return {}
 
 

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -132,6 +132,7 @@ from api_operator import (  # noqa: E402
     _operator_get_open_items,
     _operator_get_open_items_aggregate,
     _operator_get_projects,
+    _operator_get_sessions,
     _operator_get_report_content,
     _operator_get_reports,
     _operator_get_session,
@@ -372,6 +373,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
         if path.startswith("/api/operator/terminal/"):
             tid = path[len("/api/operator/terminal/"):]
             _json_response(self, HTTPStatus.OK, _operator_get_terminal(tid))
+            return
+
+        if path == "/api/operator/sessions":
+            _json_response(self, HTTPStatus.OK, _operator_get_sessions())
             return
 
         if path == "/api/operator/open-items/aggregate":

--- a/dashboard/token-dashboard/app/operator/sessions/page.tsx
+++ b/dashboard/token-dashboard/app/operator/sessions/page.tsx
@@ -1,0 +1,165 @@
+'use client';
+
+import { useLiveSessions } from '@/lib/hooks';
+import type { LiveSession } from '@/lib/types';
+import { Activity } from 'lucide-react';
+
+function formatAge(seconds: number | null): string {
+  if (seconds === null || seconds < 0) return '—';
+  if (seconds < 60) return `${seconds}s`;
+  if (seconds < 3600) return `${Math.floor(seconds / 60)}m`;
+  if (seconds < 86400) return `${Math.floor(seconds / 3600)}h`;
+  return `${Math.floor(seconds / 86400)}d`;
+}
+
+function StatusBadge({ status }: { status: LiveSession['status'] }) {
+  const color = status === 'busy' ? '#facc15' : 'var(--color-muted)';
+  return (
+    <span
+      style={{
+        fontSize: 11,
+        fontWeight: 700,
+        textTransform: 'uppercase',
+        color,
+        border: `1px solid ${color}`,
+        borderRadius: 5,
+        padding: '2px 7px',
+      }}
+    >
+      {status}
+    </span>
+  );
+}
+
+function SessionRow({ session }: { session: LiveSession }) {
+  return (
+    <div
+      data-testid={`session-row-${session.name}`}
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 16,
+        padding: '12px 14px',
+        borderBottom: '1px solid rgba(255,255,255,0.06)',
+        fontSize: 12,
+      }}
+    >
+      <div style={{ minWidth: 180, flex: 1 }}>
+        <div style={{ fontWeight: 600, color: 'var(--color-foreground)' }}>{session.name}</div>
+        {session.project && (
+          <div style={{ color: 'var(--color-muted)', fontSize: 11 }}>{session.project}</div>
+        )}
+      </div>
+      <div style={{ minWidth: 70 }}>
+        <StatusBadge status={session.status} />
+      </div>
+      <div style={{ minWidth: 160, color: 'var(--color-muted)' }}>
+        {session.last_activity ? new Date(session.last_activity).toLocaleString() : '—'}
+      </div>
+      <div style={{ minWidth: 70, color: 'var(--color-muted)' }}>{formatAge(session.age_seconds)}</div>
+      {session.remote_control_url && (
+        <a
+          href={session.remote_control_url}
+          target="_blank"
+          rel="noreferrer"
+          style={{ color: 'var(--color-accent)', textDecoration: 'none' }}
+        >
+          remote
+        </a>
+      )}
+    </div>
+  );
+}
+
+export default function LiveSessionsPage() {
+  const { data, error, isLoading } = useLiveSessions();
+  const sessions = data?.data ?? [];
+
+  return (
+    <div data-testid="live-sessions-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 12 }}>
+        <Activity size={18} style={{ color: 'var(--color-accent)' }} />
+        <h1 style={{ fontSize: 18, fontWeight: 700, margin: 0 }}>Live Sessions</h1>
+        <span style={{ fontSize: 12, color: 'var(--color-muted)' }}>read-only observability</span>
+      </div>
+
+      {data?.degraded && (
+        <div
+          data-testid="live-sessions-degraded"
+          style={{
+            padding: '10px 14px',
+            borderRadius: 8,
+            background: 'rgba(250, 204, 21, 0.08)',
+            border: '1px solid rgba(250, 204, 21, 0.3)',
+            color: '#facc15',
+            fontSize: 12,
+          }}
+        >
+          Degraded: {data.degraded_reasons?.join('; ')}
+        </div>
+      )}
+
+      {isLoading && (
+        <div data-testid="live-sessions-loading" style={{ color: 'var(--color-muted)', padding: '20px 0' }}>
+          Loading live sessions…
+        </div>
+      )}
+
+      {!isLoading && error && (
+        <div data-testid="live-sessions-error" style={{ color: 'var(--color-danger, #ff5555)', padding: '20px 0' }}>
+          Failed to load live sessions.
+        </div>
+      )}
+
+      {!isLoading && !error && sessions.length === 0 && (
+        <div
+          data-testid="live-sessions-empty"
+          style={{
+            padding: '32px 20px',
+            textAlign: 'center',
+            color: 'var(--color-muted)',
+            fontSize: 13,
+            background: 'rgba(255,255,255,0.02)',
+            borderRadius: 12,
+            border: '1px dashed rgba(255,255,255,0.08)',
+          }}
+        >
+          No live tmux sessions found.
+        </div>
+      )}
+
+      {!isLoading && !error && sessions.length > 0 && (
+        <div
+          style={{
+            borderRadius: 12,
+            background: 'rgba(255,255,255,0.03)',
+            border: '1px solid rgba(255,255,255,0.08)',
+            overflow: 'hidden',
+          }}
+        >
+          <div
+            style={{
+              display: 'flex',
+              alignItems: 'center',
+              gap: 16,
+              padding: '10px 14px',
+              borderBottom: '1px solid rgba(255,255,255,0.08)',
+              fontSize: 11,
+              fontWeight: 700,
+              color: 'var(--color-muted)',
+              textTransform: 'uppercase',
+            }}
+          >
+            <div style={{ minWidth: 180, flex: 1 }}>Session / Project</div>
+            <div style={{ minWidth: 70 }}>Status</div>
+            <div style={{ minWidth: 160 }}>Last Activity</div>
+            <div style={{ minWidth: 70 }}>Age</div>
+          </div>
+          {sessions.map(session => (
+            <SessionRow key={session.name} session={session} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/dashboard/token-dashboard/components/sidebar.tsx
+++ b/dashboard/token-dashboard/components/sidebar.tsx
@@ -18,6 +18,7 @@ const OPERATOR_NAV = [
   { href: '/operator/intelligence', label: 'Intelligence', icon: Brain },
   { href: '/operator/dispatches', label: 'Dispatches', icon: ClipboardList },
   { href: '/operator/improvements', label: 'Improvements', icon: Lightbulb },
+  { href: '/operator/sessions', label: 'Live Sessions', icon: Activity },
   { href: '/operator/reports', label: 'Reports', icon: FileText },
   { href: '/operator/health', label: 'System Health', icon: HeartPulse },
   { href: '/agent-stream', label: 'Agent Stream', icon: Activity },

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -17,6 +17,7 @@ import {
   fetchReports,
   fetchReportContent,
   fetchAgents,
+  fetchLiveSessions,
   fetchIntelligencePatterns,
   fetchIntelligenceInjections,
   fetchIntelligenceClassifications,
@@ -37,6 +38,7 @@ import type {
   GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
   ConfigEnvelope, ConfigAuditEnvelope, ObservabilityEnvelope,
   ReportsEnvelope, AgentsEnvelope,
+  LiveSessionsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
   ProposalsResponse, ConfidenceTrendsResponse, WeeklyDigest,
   LearningProposalsResponse,
@@ -244,6 +246,14 @@ export function useAgents() {
     'operator-agents',
     fetchAgents,
     { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 20000 }
+  );
+}
+
+export function useLiveSessions() {
+  return useSWR<LiveSessionsEnvelope>(
+    'operator-live-sessions',
+    fetchLiveSessions,
+    { refreshInterval: 15000, revalidateOnFocus: true, dedupingInterval: 8000 }
   );
 }
 

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -18,6 +18,7 @@ import type {
   ConfigSetResponse,
   ConfigAuditEnvelope,
   ObservabilityEnvelope,
+  LiveSessionsEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
   PatternsResponse,
@@ -147,6 +148,10 @@ export function fetchConfig(): Promise<ConfigEnvelope> {
 
 export function fetchObservability(): Promise<ObservabilityEnvelope> {
   return get(`${BASE}/observability`);
+}
+
+export function fetchLiveSessions(): Promise<LiveSessionsEnvelope> {
+  return get(`${BASE}/sessions`);
 }
 
 export function postConfigSet(req: ConfigSetRequest): Promise<ConfigSetResponse> {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -152,6 +152,19 @@ export interface FreshnessEnvelope<T = unknown> {
 export interface ProjectsEnvelope extends FreshnessEnvelope<ProjectEntry[]> {}
 export interface SessionEnvelope extends FreshnessEnvelope<SessionData> {}
 export interface TerminalsEnvelope extends FreshnessEnvelope<TerminalEntry[]> {}
+
+export interface LiveSession {
+  name: string;
+  project: string | null;
+  status: 'idle' | 'busy';
+  last_activity: string | null;
+  age_seconds: number | null;
+  session_id: string | null;
+  dispatch_id: string | null;
+  remote_control_url: string | null;
+}
+
+export interface LiveSessionsEnvelope extends FreshnessEnvelope<LiveSession[]> {}
 export interface TerminalEnvelope extends FreshnessEnvelope<TerminalEntry> {}
 export interface OpenItemsEnvelope extends FreshnessEnvelope<{ items: OpenItem[]; summary: OpenItemSummary }> {}
 export interface AggregateOpenItemsEnvelope extends FreshnessEnvelope<{

--- a/scripts/lib/session_store.py
+++ b/scripts/lib/session_store.py
@@ -199,3 +199,22 @@ class SessionStore:
         except Exception as exc:
             logger.debug("SessionStore.all_sessions: %s", exc)
             return {}
+
+    def all_entries(self) -> Dict[str, Dict[str, Any]]:
+        """Return full terminal entries for read-only consumers.
+
+        Mirrors ``all_sessions`` but preserves ``dispatch_id`` and
+        ``updated_at`` so dashboards can show last-mutated timestamps without
+        re-parsing the raw file.
+        """
+        try:
+            data = self._read_raw()
+            terminals = data.get("terminals", {})
+            result: Dict[str, Dict[str, Any]] = {}
+            for tid, entry in terminals.items():
+                if isinstance(entry, dict) and entry.get("session_id"):
+                    result[tid] = dict(entry)
+            return result
+        except Exception as exc:
+            logger.debug("SessionStore.all_entries: %s", exc)
+            return {}

--- a/tests/test_serve_dashboard_api.py
+++ b/tests/test_serve_dashboard_api.py
@@ -552,3 +552,93 @@ class TestSignalStore:
         assert len(lines) == 2
         for line in lines:
             json.loads(line)  # each line must be valid JSON
+
+
+# ---------------------------------------------------------------------------
+# /api/operator/sessions
+# ---------------------------------------------------------------------------
+
+class TestOperatorSessions:
+    """Live sessions read-model composes tmux state with session-store state."""
+
+    def test_tmux_absent_returns_empty_session_list(self) -> None:
+        with patch.object(ao.shutil, "which", return_value=None):
+            result = sd._operator_get_sessions()
+        assert isinstance(result, dict)
+        assert result["view"] == "live-sessions"
+        assert result["data"] == []
+        assert result["degraded"] is False
+
+    def test_composes_tmux_and_session_store(self) -> None:
+        tmux_sessions = [
+            {
+                "name": "vnx-demo",
+                "project": "demo",
+                "status": "idle",
+                "last_activity": "2026-07-09T20:00:00Z",
+                "age_seconds": 3600,
+            },
+            {
+                "name": "t0-probe",
+                "project": "system",
+                "status": "busy",
+                "last_activity": "2026-07-09T20:30:00Z",
+                "age_seconds": 1800,
+            },
+        ]
+        store_entries = {
+            "vnx-demo": {
+                "session_id": "sess-123",
+                "dispatch_id": "disp-456",
+                "updated_at": "2026-07-09T21:00:00Z",
+            },
+            "orphan-terminal": {
+                "session_id": "sess-789",
+                "dispatch_id": "disp-000",
+                "updated_at": "2026-07-09T19:00:00Z",
+            },
+        }
+
+        with (
+            patch.object(ao, "_list_tmux_sessions", return_value=(tmux_sessions, [])),
+            patch.object(ao, "_load_session_store_entries", return_value=store_entries),
+        ):
+            result = sd._operator_get_sessions()
+
+        assert result["degraded"] is False
+        sessions = result["data"]
+        assert len(sessions) == 3
+
+        names = [s["name"] for s in sessions]
+        assert names == ["vnx-demo", "orphan-terminal", "t0-probe"]
+
+        demo = next(s for s in sessions if s["name"] == "vnx-demo")
+        assert demo["project"] == "demo"
+        assert demo["status"] == "idle"
+        assert demo["session_id"] == "sess-123"
+        assert demo["dispatch_id"] == "disp-456"
+        # session-store updated_at is fresher than tmux activity, so it wins
+        assert demo["last_activity"] == "2026-07-09T21:00:00Z"
+        assert isinstance(demo["age_seconds"], int)
+
+        probe = next(s for s in sessions if s["name"] == "t0-probe")
+        assert probe["project"] == "system"
+        assert probe["status"] == "busy"
+        assert probe["session_id"] is None
+        assert probe["dispatch_id"] is None
+
+        orphan = next(s for s in sessions if s["name"] == "orphan-terminal")
+        assert orphan["project"] == "orphan-terminal"
+        assert orphan["status"] == "idle"
+        assert orphan["session_id"] == "sess-789"
+
+    def test_degraded_on_session_store_read_failure(self) -> None:
+        with (
+            patch.object(ao, "_list_tmux_sessions", return_value=([], [])),
+            patch.object(ao, "_load_session_store_entries", side_effect=RuntimeError("locked")),
+        ):
+            result = sd._operator_get_sessions()
+
+        assert result["degraded"] is True
+        assert any("session store" in reason.lower() for reason in result["degraded_reasons"])
+        assert result["data"] == []


### PR DESCRIPTION
## Summary
Adds a read-only operator view of live sessions (tmux + session-store): name/project, idle|busy, last-activity, age. New `operator/sessions` page + data API, mirroring the learning-proposals tile pattern. Part B (deterministic restart control panel) is out of scope → follow-up. Built via the Kimi lane.

## Changes
- `dashboard/token-dashboard/app/operator/sessions/page.tsx` (+165) + sidebar entry: live/auto-refresh session list.
- `dashboard/token-dashboard/lib/{hooks,operator-api,types}.ts`: SWR hook + fetch + types.
- `scripts/lib/session_store.py` (+19): session-list surface for the API.
- `tests/test_serve_dashboard_api.py` (+90): fixture tmux + session-store → normalized list.

Read-only; no restart/kill actions. Branch forked pre-#1073/#1074 — verified additions-only vs merge-base.

Track: session-observability-and-deterministic-restart (Part A) · Dispatch: 20260709-213505-sessobs-tile

🤖 Generated with [Claude Code](https://claude.com/claude-code)