### PR TITLE
feat(security): feature-flagged worker-permission enforcement (default-OFF, both lanes)

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -31,6 +31,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
+# ADR-012 worker-permission enforcement flag (default OFF). Imported defensively.
+try:
+    from worker_permissions import worker_permission_enforcement_enabled
+except Exception:  # pragma: no cover - sibling import is available in-tree
+    def worker_permission_enforcement_enabled() -> bool:  # type: ignore[misc]
+        return os.environ.get("VNX_ENFORCE_WORKER_PERMISSIONS", "0").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+
 logger = logging.getLogger(__name__)
 
 # scripts/ dir resolved from this file's location (scripts/lib/dispatch_govern.py → scripts/).
@@ -138,6 +147,9 @@ def ensure_receipt(
         "model": spec.model or "unknown",
         "lane": lane,
     }
+    # ADR-012 worker-permission enforcement audit marker (only when flag ON).
+    if worker_permission_enforcement_enabled():
+        synthesized_receipt["worker_permission_enforcement"] = "enforced"
     if report_path is not None:
         synthesized_receipt["report_path"] = str(report_path)
 

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -64,6 +64,7 @@ def emit_dispatch_receipt(
     state_dir: Path,
     report_path: Optional[str] = None,
     events_path: Optional[str] = None,
+    permission_enforcement: Optional[str] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson. fcntl.flock for concurrent safety.
 
@@ -78,6 +79,11 @@ def emit_dispatch_receipt(
     dispatch lane produces no event stream (tmux, claude subprocess) or when the
     archive step was skipped.  Turns dispatch→stream linkage from convention
     (matching dispatch_id in the filename) into an explicit data pointer.
+
+    ``permission_enforcement``: when provided (e.g. "enforced"), stamps the
+    receipt with the ADR-012 worker-permission enforcement mode. Only set when
+    ``VNX_ENFORCE_WORKER_PERMISSIONS`` is active so flag-off receipts remain
+    byte-identical to the pre-feature shape.
 
     Raises:
         ValueError: provider field doesn't match required pattern
@@ -106,6 +112,8 @@ def emit_dispatch_receipt(
         "timestamp": now_ts,
         "recorded_at": recorded_ts,
     }
+    if permission_enforcement:
+        receipt["permission_enforcement"] = permission_enforcement
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -32,6 +32,24 @@ logger = logging.getLogger(__name__)
 
 _EX_USAGE = 64  # sysexits.h EX_USAGE
 
+# ADR-012 worker-permission enforcement flag (default OFF). Imported defensively
+# so provider_dispatch remains importable even if worker_permissions is missing.
+try:
+    from worker_permissions import (
+        worker_permission_enforcement_enabled,
+        worker_scoped_enabled,
+    )
+except Exception:  # pragma: no cover - sibling import is available in-tree
+    def worker_permission_enforcement_enabled() -> bool:  # type: ignore[misc]
+        return os.environ.get("VNX_ENFORCE_WORKER_PERMISSIONS", "0").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+
+    def worker_scoped_enabled() -> bool:  # type: ignore[misc]
+        return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
+            "1", "true", "yes", "on",
+        )
+
 # Providers whose spawn handlers exist.
 _IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini", "kimi", "litellm", "deepseek-harness", "glm-harness", "local-gemma"}
 
@@ -559,6 +577,9 @@ def _emit_governance(
                 state_dir=state_dir,
                 report_path=str(report_path),
                 events_path=events_path,
+                permission_enforcement=(
+                    "enforced" if worker_permission_enforcement_enabled() else None
+                ),
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break
@@ -886,6 +907,12 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
 
     start_time = datetime.now(timezone.utc)
     try:
+        # ADR-012: benchmark worker permission mode follows the feature flag.
+        # Default OFF keeps the historical skip-permissions posture; ON opts into
+        # role-scoped --allowedTools/--permission-mode via subprocess_adapter.
+        skip_permissions = not (
+            worker_permission_enforcement_enabled() or worker_scoped_enabled()
+        )
         result = spawn_claude(
             prompt=instruction,
             model=args.model,
@@ -893,7 +920,7 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             cwd=worker_cwd,
             role=role,
-            skip_permissions=True,  # benchmark: no human to answer tool-permission prompts
+            skip_permissions=skip_permissions,
             event_writer=event_store.append if event_store is not None else None,
             total_deadline=total_deadline,
             requires_mcp=getattr(args, "requires_mcp", False),

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -54,12 +54,14 @@ try:
     from worker_permissions import (
         build_claude_scope_args,
         resolve_worker_profile,
+        worker_permission_enforcement_enabled,
         worker_scoped_enabled,
     )
 except Exception:  # pragma: no cover - sibling import is available in-tree
     build_claude_scope_args = None
     resolve_worker_profile = None
     worker_scoped_enabled = None
+    worker_permission_enforcement_enabled = None
 
 _LEGACY_SKIP_FLAG = "--dangerously-skip-permissions"
 # Inline fallback used only if worker_permissions cannot be imported — still
@@ -75,17 +77,24 @@ _FALLBACK_SCOPE_ARGS = [
 def _build_worker_scope_args(role: Optional[str], requires_mcp: bool = False) -> List[str]:
     """Return the capability-scoping argv head for a headless ``claude`` spawn.
 
-    Default (``VNX_WORKER_SCOPED`` unset or falsey): the blanket
-    ``--dangerously-skip-permissions`` flag. Set ``VNX_WORKER_SCOPED=1`` (a
-    truthy value) to opt into ``--permission-mode acceptEdits`` + empty
+    Default (``VNX_ENFORCE_WORKER_PERMISSIONS`` and ``VNX_WORKER_SCOPED`` both
+    unset/falsey): the blanket ``--dangerously-skip-permissions`` flag, preserving
+    historical behavior. Set ``VNX_ENFORCE_WORKER_PERMISSIONS=1`` (or the legacy
+    ``VNX_WORKER_SCOPED=1``) to opt into ``--permission-mode acceptEdits`` + empty
     ambient MCP + the role's tool allow-list instead.
 
     ``requires_mcp``: when True, the ``--strict-mcp-config --mcp-config {}`` pair
     is forwarded to ``build_claude_scope_args`` so the dispatch retains its normal
     ambient MCP config instead of being force-emptied. Only takes effect in the
-    scoped (``VNX_WORKER_SCOPED=1``) posture — the blanket default ignores it.
+    scoped posture — the blanket default ignores it.
     """
-    if worker_scoped_enabled is not None and not worker_scoped_enabled():
+    # New enforcement flag OR legacy scoped flag opts into scoped args.
+    # If worker_permissions is unavailable, fall through to the scoped fallback
+    # below (fail-closed — never silently re-open skip-permissions).
+    scoped = False
+    if worker_scoped_enabled is not None and worker_permission_enforcement_enabled is not None:
+        scoped = worker_scoped_enabled() or worker_permission_enforcement_enabled()
+    if not scoped:
         return [_LEGACY_SKIP_FLAG]
     if resolve_worker_profile is not None and build_claude_scope_args is not None:
         try:

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -89,11 +89,18 @@ def _build_worker_scope_args(role: Optional[str], requires_mcp: bool = False) ->
     scoped posture — the blanket default ignores it.
     """
     # New enforcement flag OR legacy scoped flag opts into scoped args.
-    # If worker_permissions is unavailable, fall through to the scoped fallback
-    # below (fail-closed — never silently re-open skip-permissions).
     scoped = False
     if worker_scoped_enabled is not None and worker_permission_enforcement_enabled is not None:
         scoped = worker_scoped_enabled() or worker_permission_enforcement_enabled()
+    else:
+        # worker_permissions import failed: read the flags DIRECTLY so an enforcement
+        # request still fails CLOSED into the scoped fallback below, never silently
+        # re-opening --dangerously-skip-permissions.
+        _falsey = ("", "0", "false", "False", "no", "off")
+        scoped = (
+            os.environ.get("VNX_ENFORCE_WORKER_PERMISSIONS", "") not in _falsey
+            or os.environ.get("VNX_WORKER_SCOPED", "") not in _falsey
+        )
     if not scoped:
         return [_LEGACY_SKIP_FLAG]
     if resolve_worker_profile is not None and build_claude_scope_args is not None:

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -45,13 +45,14 @@ from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, class
 # by default (tmux-spawn workers run in an isolated per-dispatch worktree, so
 # the scoped allow-list only stalls autonomous builds on prompts for
 # un-allow-listed ops). Scoped (empty ambient MCP + acceptEdits + role
-# allow-list) is opt-in via VNX_WORKER_SCOPED=1. Imported defensively; if
-# unavailable the detached branch keeps a minimal inline fallback with the
-# same default.
+# allow-list) is opt-in via VNX_ENFORCE_WORKER_PERMISSIONS=1 (ADR-012) or the
+# legacy VNX_WORKER_SCOPED=1. Imported defensively; if unavailable the detached
+# branch keeps a minimal inline fallback with the same default.
 try:
     from worker_permissions import (  # noqa: E402
         EMPTY_MCP_CONFIG,
         worker_scoped_enabled,
+        worker_permission_enforcement_enabled,
         build_claude_scope_args as _wp_build_claude_scope_args,
         resolve_worker_profile as _wp_resolve_worker_profile,
     )
@@ -62,6 +63,14 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
 
     def worker_scoped_enabled() -> bool:  # type: ignore[misc]
         return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
+            "1",
+            "true",
+            "yes",
+            "on",
+        )
+
+    def worker_permission_enforcement_enabled() -> bool:  # type: ignore[misc]
+        return os.environ.get("VNX_ENFORCE_WORKER_PERMISSIONS", "0").strip().lower() in (
             "1",
             "true",
             "yes",
@@ -259,9 +268,10 @@ def _default_launch_command(
         # Detached/autonomous run (no TTY to answer prompts). Default: the
         # blanket skip-permissions flag — the spawn runs in an isolated
         # per-dispatch worktree, so scoping only stalls autonomous builds on
-        # prompts for un-allow-listed ops. VNX_WORKER_SCOPED=1 opts into the
-        # scoped posture (role allow-list + optional empty-MCP) instead.
-        if worker_scoped_enabled():
+        # prompts for un-allow-listed ops. VNX_ENFORCE_WORKER_PERMISSIONS=1
+        # (or legacy VNX_WORKER_SCOPED=1) opts into the scoped posture
+        # (role allow-list + optional empty-MCP) instead.
+        if worker_scoped_enabled() or worker_permission_enforcement_enabled():
             profile = _wp_resolve_worker_profile(role)
             scope_args = _wp_build_claude_scope_args(
                 profile,
@@ -718,6 +728,10 @@ class TmuxInteractiveDispatch:
                 "model": model,
                 "lane": "tmux_interactive",
             }
+            # Audit marker for the ADR-012 worker-permission enforcement mode.
+            # Only emitted when the flag is ON so flag-off receipts are byte-identical.
+            if worker_permission_enforcement_enabled():
+                receipt_dict["permission_enforcement"] = "enforced"
             json_str = json.dumps(receipt_dict)
             # Escape inner double-quotes for the shell double-quoted argument.
             escaped = json_str.replace('"', '\\"')
@@ -1613,15 +1627,19 @@ class TmuxInteractiveDispatch:
         # every non-scoped path — attached, blanket skip-permissions, or
         # VNX_WORKER_SCOPED unset/falsey — so an unscoped working-tree-only
         # worker can never silently reach git commit/push.
-        if working_tree_only and not (skip_permissions and worker_scoped_enabled()):
+        if working_tree_only and not (
+            skip_permissions
+            and (worker_scoped_enabled() or worker_permission_enforcement_enabled())
+        ):
             return InteractiveDispatchResult(
                 success=False,
                 dispatch_id=dispatch_id,
                 failure_reason=(
                     "working_tree_only requires a scoped detached spawn "
-                    "(skip_permissions + explicit VNX_WORKER_SCOPED=1; scoped is "
-                    "opt-in now that blanket skip-permissions is the default); "
-                    "refusing unscoped dispatch where the commit/push deny would not bind"
+                    "(skip_permissions + explicit VNX_ENFORCE_WORKER_PERMISSIONS=1 "
+                    "or VNX_WORKER_SCOPED=1; scoped is opt-in now that blanket "
+                    "skip-permissions is the default); refusing unscoped dispatch "
+                    "where the commit/push deny would not bind"
                 ),
             )
 

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -156,6 +156,25 @@ def worker_scoped_enabled() -> bool:
     )
 
 
+def worker_permission_enforcement_enabled() -> bool:
+    """Whether role-scoped worker permission enforcement is active (default OFF).
+
+    This is the ADR-012 enforcement flag: when ON, detached workers launch with
+    role-derived ``--allowedTools`` / ``--disallowedTools`` /
+    ``--permission-mode`` instead of the blanket
+    ``--dangerously-skip-permissions``. Default OFF preserves the historical
+    skip-permissions behavior exactly.
+
+    Truthy values: ``1``, ``true``, ``yes``, ``on``.
+    """
+    return os.environ.get("VNX_ENFORCE_WORKER_PERMISSIONS", "0").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+        "on",
+    )
+
+
 def default_code_worker_profile() -> PermissionProfile:
     """Functional least-privilege profile for a headless code worker.
 

--- a/tests/test_worker_permission_enforcement_flag.py
+++ b/tests/test_worker_permission_enforcement_flag.py
@@ -1,0 +1,312 @@
+"""ADR-012 worker-permission enforcement feature flag — default-OFF safety tests.
+
+Covers both launch lanes:
+  * tmux interactive lane (_default_launch_command)
+  * provider/headless lane (subprocess_adapter._build_worker_scope_args)
+
+Verifies:
+  - Flag OFF/absent → byte-for-byte current behavior (--dangerously-skip-permissions).
+  - Flag ON → role-scoped --allowedTools / --permission-mode and no skip flag.
+  - Unknown role falls back to the functional code-worker profile.
+  - Receipt marker is only emitted when the flag is ON.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from tmux_interactive_dispatch import _default_launch_command
+from worker_permissions import (
+    build_claude_scope_args,
+    default_code_worker_profile,
+    worker_permission_enforcement_enabled,
+)
+
+# Import subprocess_adapter helpers separately so we can patch env without
+# reloading the whole module.
+from subprocess_adapter import _build_worker_scope_args
+
+
+def _set_enforcement(enforce: bool):
+    """Patch environment helpers consistently across modules."""
+    val = "1" if enforce else "0"
+    env = {"VNX_ENFORCE_WORKER_PERMISSIONS": val, "VNX_WORKER_SCOPED": "0"}
+    return patch.dict(os.environ, env, clear=False)
+
+
+def _extract_receipt_from_protocol(protocol: str) -> dict:
+    """Parse the receipt JSON from the done/failed bash block."""
+    blocks = re.findall(r"```bash\n(.+?)\n```", protocol, re.DOTALL)
+    assert blocks, "No bash blocks found in protocol"
+    for block in blocks:
+        for line in block.splitlines():
+            if "--receipt" in line:
+                m = re.search(r'--receipt\s+"((?:[^"\\]|\\.)*)"', line)
+                if m:
+                    raw = (
+                        m.group(1)
+                        .replace('\\"', '"')
+                        .replace("$_VNX_TS", "2099-01-01T00:00:00Z")
+                    )
+                    return json.loads(raw)
+    raise AssertionError("Could not find receipt in protocol")
+
+
+# ---------------------------------------------------------------------------
+# worker_permission_enforcement_enabled()
+# ---------------------------------------------------------------------------
+
+class TestWorkerPermissionEnforcementEnabled:
+    def test_default_off(self):
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_ENFORCE_WORKER_PERMISSIONS", None)
+            assert worker_permission_enforcement_enabled() is False
+
+    @pytest.mark.parametrize("truthy", ["1", "true", "True", "yes", "on"])
+    def test_truthy_values(self, truthy):
+        with patch.dict(os.environ, {"VNX_ENFORCE_WORKER_PERMISSIONS": truthy}, clear=False):
+            assert worker_permission_enforcement_enabled() is True
+
+    @pytest.mark.parametrize("falsy", ["0", "false", "no", "off", ""])
+    def test_falsy_values(self, falsy):
+        with patch.dict(os.environ, {"VNX_ENFORCE_WORKER_PERMISSIONS": falsy}, clear=False):
+            assert worker_permission_enforcement_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Provider/headless lane: subprocess_adapter._build_worker_scope_args
+# ---------------------------------------------------------------------------
+
+class TestProviderLaneScopeArgs:
+    def test_flag_off_uses_legacy_skip_flag(self):
+        with _set_enforcement(False):
+            args = _build_worker_scope_args("backend-developer")
+
+        assert args == ["--dangerously-skip-permissions"]
+        assert "--allowedTools" not in args
+        assert "--permission-mode" not in args
+
+    def test_flag_on_uses_role_scoped_args(self):
+        with _set_enforcement(True):
+            args = _build_worker_scope_args("backend-developer")
+
+        assert "--dangerously-skip-permissions" not in args
+        assert "--permission-mode" in args
+        assert "--allowedTools" in args
+        assert "Read" in args[args.index("--allowedTools") + 1]
+
+    def test_flag_on_with_requires_mcp_omits_empty_mcp(self):
+        with _set_enforcement(True):
+            args = _build_worker_scope_args("backend-developer", requires_mcp=True)
+
+        assert "--dangerously-skip-permissions" not in args
+        assert "--permission-mode" in args
+        assert "--allowedTools" in args
+        assert "--strict-mcp-config" not in args
+        assert "--mcp-config" not in args
+
+    def test_flag_on_unknown_role_falls_back_to_code_worker(self):
+        with _set_enforcement(True):
+            args = _build_worker_scope_args("nonexistent-role-xyz")
+
+        assert "--dangerously-skip-permissions" not in args
+        assert "--permission-mode" in args
+        assert "--allowedTools" in args
+        # Fallback code-worker profile denies WebSearch/WebFetch
+        assert "WebSearch" in args[args.index("--disallowedTools") + 1]
+
+
+# ---------------------------------------------------------------------------
+# Tmux interactive lane: _default_launch_command
+# ---------------------------------------------------------------------------
+
+class TestTmuxLaneLaunchCommand:
+    def test_flag_off_uses_legacy_skip_flag(self):
+        with _set_enforcement(False):
+            cmd = _default_launch_command("sonnet", skip_permissions=True, role="backend-developer")
+
+        assert "--dangerously-skip-permissions" in cmd
+        assert "--allowedTools" not in cmd
+        assert "--permission-mode" not in cmd
+
+    def test_flag_on_uses_role_scoped_args(self):
+        with _set_enforcement(True):
+            cmd = _default_launch_command("sonnet", skip_permissions=True, role="backend-developer")
+
+        assert "--dangerously-skip-permissions" not in cmd
+        assert "--permission-mode" in cmd
+        assert "--allowedTools" in cmd
+        assert "WebSearch" in cmd  # denied_tools from backend-developer profile
+
+    def test_flag_on_unknown_role_falls_back_to_code_worker(self):
+        with _set_enforcement(True):
+            cmd = _default_launch_command("sonnet", skip_permissions=True, role="unknown-role")
+
+        assert "--dangerously-skip-permissions" not in cmd
+        assert "--permission-mode" in cmd
+        assert "--allowedTools" in cmd
+        # Fallback denies WebSearch/WebFetch
+        assert "WebSearch" in cmd
+
+    def test_flag_off_args_are_byte_identical_to_legacy(self):
+        """Default-OFF must produce the exact same launch line as before the feature."""
+        with _set_enforcement(False):
+            cmd = _default_launch_command("sonnet", skip_permissions=True, role="backend-developer")
+
+        expected = (
+            "source ~/.zshrc 2>/dev/null; claude --model sonnet --dangerously-skip-permissions"
+        )
+        assert cmd == expected
+
+
+# ---------------------------------------------------------------------------
+# Provider dispatch benchmark wrapper
+# ---------------------------------------------------------------------------
+
+class TestProviderDispatchBenchmarkWrapper:
+    def _run_benchmark(self, enforce: bool) -> MagicMock:
+        import provider_dispatch
+
+        with _set_enforcement(enforce):
+            with patch("provider_dispatch._prepare_provider_workdir") as mock_prep:
+                mock_prep.return_value = (None, Path("/tmp"))
+                with patch(
+                    "provider_spawns.claude_spawn.spawn_claude"
+                ) as mock_spawn:
+                    mock_spawn.return_value = MagicMock(
+                        error=None, timed_out=False, returncode=0
+                    )
+                    with patch("provider_dispatch._emit_governance"):
+                        with patch("provider_dispatch._finish_provider_worktree"):
+                            args = MagicMock()
+                            args.role = "backend-developer"
+                            args.model = "sonnet"
+                            args.dispatch_id = "disp-001"
+                            args.terminal_id = "T1"
+                            args.instruction = "noop"
+                            args.max_retries = 3
+                            args.no_auto_commit = False
+                            args.gate = ""
+                            args.dispatch_paths = ""
+                            args.pr_id = None
+                            provider_dispatch._dispatch_claude_benchmark(args)
+        return mock_spawn
+
+    def test_benchmark_passes_skip_permissions_when_flag_off(self):
+        mock_spawn = self._run_benchmark(enforce=False)
+        call_kwargs = mock_spawn.call_args.kwargs
+        assert call_kwargs["skip_permissions"] is True
+
+    def test_benchmark_passes_scoped_when_flag_on(self):
+        mock_spawn = self._run_benchmark(enforce=True)
+        call_kwargs = mock_spawn.call_args.kwargs
+        assert call_kwargs["skip_permissions"] is False
+
+
+# ---------------------------------------------------------------------------
+# Receipt marker
+# ---------------------------------------------------------------------------
+
+class TestReceiptMarker:
+    def test_emit_dispatch_receipt_has_marker_when_flag_on(self, tmp_path: Path):
+        from governance_emit import emit_dispatch_receipt
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        with _set_enforcement(True):
+            path = emit_dispatch_receipt(
+                dispatch_id="disp-marker",
+                terminal_id="T1",
+                provider="claude",
+                model="sonnet",
+                pr_id=None,
+                status="success",
+                completion_pct=100,
+                risk=0.0,
+                findings=[],
+                duration_seconds=1.0,
+                token_usage={"input": 0, "output": 0, "cache_hit": 0},
+                cost_usd=0.0,
+                state_dir=state_dir,
+                permission_enforcement="enforced",
+            )
+
+        lines = path.read_text().strip().splitlines()
+        receipt = json.loads(lines[-1])
+        assert receipt["permission_enforcement"] == "enforced"
+
+    def test_emit_dispatch_receipt_omits_marker_when_not_provided(self, tmp_path: Path):
+        from governance_emit import emit_dispatch_receipt
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        path = emit_dispatch_receipt(
+            dispatch_id="disp-no-marker",
+            terminal_id="T1",
+            provider="claude",
+            model="sonnet",
+            pr_id=None,
+            status="success",
+            completion_pct=100,
+            risk=0.0,
+            findings=[],
+            duration_seconds=1.0,
+            token_usage={"input": 0, "output": 0, "cache_hit": 0},
+            cost_usd=0.0,
+            state_dir=state_dir,
+        )
+
+        lines = path.read_text().strip().splitlines()
+        receipt = json.loads(lines[-1])
+        assert "permission_enforcement" not in receipt
+
+    def test_tmux_completion_protocol_includes_marker_when_flag_on(self):
+        from tmux_interactive_dispatch import TmuxInteractiveDispatch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            lane = TmuxInteractiveDispatch(state_dir, project_root=state_dir)
+            with _set_enforcement(True):
+                protocol = lane._build_completion_protocol("disp-003", "T1", model="sonnet")
+
+            receipt = _extract_receipt_from_protocol(protocol)
+            assert receipt["permission_enforcement"] == "enforced"
+
+    def test_tmux_completion_protocol_omits_marker_when_flag_off(self):
+        from tmux_interactive_dispatch import TmuxInteractiveDispatch
+
+        with tempfile.TemporaryDirectory() as tmp:
+            state_dir = Path(tmp)
+            lane = TmuxInteractiveDispatch(state_dir, project_root=state_dir)
+            with _set_enforcement(False):
+                protocol = lane._build_completion_protocol("disp-004", "T1", model="sonnet")
+
+            receipt = _extract_receipt_from_protocol(protocol)
+            assert "permission_enforcement" not in receipt
+
+
+# ---------------------------------------------------------------------------
+# build_claude_scope_args integration
+# ---------------------------------------------------------------------------
+
+class TestBuildClaudeScopeArgs:
+    def test_backend_profile_generates_expected_args(self):
+        profile = default_code_worker_profile()
+        args = build_claude_scope_args(profile)
+
+        assert args[0:2] == ["--permission-mode", "acceptEdits"]
+        assert "--allowedTools" in args
+        assert "Read" in args[args.index("--allowedTools") + 1]
+        assert "--disallowedTools" in args
+        assert "WebSearch" in args[args.index("--disallowedTools") + 1]


### PR DESCRIPTION
## Summary
Ships the ADR-012 worker-permission enforcement capability behind a default-OFF flag `VNX_ENFORCE_WORKER_PERMISSIONS`. Flag OFF (default) → both lanes launch byte-identically to today (`--dangerously-skip-permissions`). Flag ON → role-scoped `--allowedTools`/`--disallowedTools`/`--permission-mode` via the existing `worker_permissions.py`/`capability_profiles.py` infra, with a `permission_enforcement: enforced` receipt marker. Safe to merge dormant; enabling it fleet-wide is a deliberate operator flip.

## Changes
Wired the flag into both lanes (`tmux_interactive_dispatch._default_launch_command`, `subprocess_adapter._build_worker_scope_args`, `provider_dispatch`), plus receipt-marker plumbing (`governance_emit`, `dispatch_govern` — avoided the existing `permission_enforcement` field collision). +312-line test suite.

## Verification
26 tests pass, incl. **byte-identical legacy launch args** with flag OFF (both lanes), flag-ON scoped args, unknown-role fallback, receipt markers. Verified default-off preserves current behavior exactly.

Track: worker-permission-enforce-all-lanes · Dispatch: 20260709-221003-workerperm-flagged

🤖 Generated with [Claude Code](https://claude.com/claude-code)