### PR TITLE
feat(orchestration): ADR-028 Phase 1 agent-folder fusion (config extension + resolver, backward-compatible)

### DIFF
--- a/docs/guides/AGENT_CREATION_GUIDE.md
+++ b/docs/guides/AGENT_CREATION_GUIDE.md
@@ -104,6 +104,45 @@ After completing the task, append a VNX unified report block:
 
 ---
 
+## Optional extended fields (ADR-028 Phase 1)
+
+`config.yaml` can also declare the agent's provider, model, permissions, and
+skills. These fields are **optional**; omitting them keeps the legacy behavior
+unchanged, so every existing agent continues to work.
+
+```yaml
+governance_profile: light
+provider: claude              # default: claude
+model: sonnet                 # default: falls back to CLI / VNX_MODEL default
+skills:
+  - backend-developer
+  - reviewer
+permissions:
+  allowed_tools: [Read, Write]
+  denied_tools: [Bash]
+  bash_allow_patterns: ["^git "]
+  bash_deny_patterns: ["rm -rf /"]
+isolation:
+  scope_type: business_folder
+  allowed_paths:
+    - "agents/<name>/"
+    - ".vnx-data/unified_reports/"
+  denied_paths:
+    - "scripts/"
+```
+
+- `provider` — target provider for provider-agnostic dispatch (default: `claude`).
+- `model` — model override for this agent; used only when the caller does not
+  pass an explicit `--model` (default: falls back to `sonnet`).
+- `skills` — list of skill names to inject into the agent context (default: `[]`).
+- `permissions` — role-scoped tool policy:
+  - `allowed_tools` / `denied_tools` — tool allow/deny lists.
+  - `bash_allow_patterns` / `bash_deny_patterns` — regex patterns for Bash
+    command filtering.
+
+The extended resolver is gated by `VNX_AGENT_FOLDERS` and defaults to **on**.
+Rollback to legacy behavior: `VNX_AGENT_FOLDERS=0`.
+
 ## Governance Profiles
 
 Profiles are defined in `.vnx/governance_profiles.yaml`. Three profiles ship by default:

--- a/scripts/lib/agent_resolver.py
+++ b/scripts/lib/agent_resolver.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Agent-folder resolver (ADR-028 Phase 1).
+
+Resolves an agent by name from the local ``agents/`` tree, project ``examples/``,
+or the packaged engine ``examples/`` fallback. Parses the extended ``config.yaml``
+schema into a typed, backward-compatible result.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Mapping
+
+import yaml
+
+VNX_AGENT_FOLDERS_ENV = "VNX_AGENT_FOLDERS"
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Typed view of an agent folder's config.yaml with safe defaults."""
+
+    name: str
+    claude_md: Path
+    provider: str = "claude"
+    model: str | None = None
+    governance_profile: str = "default"
+    default_instruction: str | None = None
+    isolation: dict[str, Any] = field(default_factory=dict)
+    permissions: dict[str, Any] = field(default_factory=dict)
+    skills: list[str] = field(default_factory=list)
+
+
+def agent_folders_enabled(env: Mapping[str, str] | None = None) -> bool:
+    """Return True unless ``VNX_AGENT_FOLDERS=0`` is set (default: ON)."""
+    env = env if env is not None else os.environ
+    return env.get(VNX_AGENT_FOLDERS_ENV, "1") != "0"
+
+
+def _resolve_agent_claude_md(
+    name: str,
+    project_dir: Path,
+    engine_root: Path | None = None,
+) -> Path | None:
+    """Find ``<name>/CLAUDE.md`` using project agents/, examples/, then engine examples/."""
+    candidates = [
+        project_dir / "agents" / name / "CLAUDE.md",
+        project_dir / "examples" / name / "CLAUDE.md",
+    ]
+    if engine_root is not None:
+        candidates.append(engine_root / "examples" / name / "CLAUDE.md")
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def _coerce_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.strip()
+        return value if value else None
+    return str(value).strip() or None
+
+
+def _coerce_str_list(value: Any) -> list[str]:
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value.strip()] if value.strip() else []
+    if isinstance(value, list):
+        return [str(item).strip() for item in value if str(item).strip()]
+    return []
+
+
+def _coerce_pattern_list(value: Any) -> list[str]:
+    """Preserve regex whitespace, unlike ``_coerce_str_list``."""
+    if value is None:
+        return []
+    if isinstance(value, str):
+        return [value]
+    if isinstance(value, list):
+        return [str(item) for item in value if str(item)]
+    return []
+
+
+def _normalize_permissions(raw: Any) -> dict[str, Any]:
+    """Return a permissions dict with predictable keys and list values."""
+    if not isinstance(raw, dict):
+        return {
+            "allowed_tools": [],
+            "denied_tools": [],
+            "bash_allow_patterns": [],
+            "bash_deny_patterns": [],
+        }
+    return {
+        "allowed_tools": _coerce_str_list(raw.get("allowed_tools")),
+        "denied_tools": _coerce_str_list(raw.get("denied_tools")),
+        "bash_allow_patterns": _coerce_pattern_list(raw.get("bash_allow_patterns")),
+        "bash_deny_patterns": _coerce_pattern_list(raw.get("bash_deny_patterns")),
+    }
+
+
+def resolve_agent(
+    name: str,
+    project_dir: Path | str,
+    engine_root: Path | str | None = None,
+) -> AgentConfig | None:
+    """Resolve an agent folder and parse its extended ``config.yaml``.
+
+    Returns ``None`` when no ``CLAUDE.md`` is found. Missing optional fields
+    resolve to safe defaults so old configs keep working.
+    """
+    project_dir = Path(project_dir)
+    engine_root = Path(engine_root) if engine_root is not None else None
+
+    claude_md = _resolve_agent_claude_md(name, project_dir, engine_root)
+    if claude_md is None:
+        return None
+
+    config_path = claude_md.parent / "config.yaml"
+    raw: dict[str, Any] = {}
+    try:
+        if config_path.is_file():
+            loaded = yaml.safe_load(config_path.read_text(encoding="utf-8"))
+            if isinstance(loaded, dict):
+                raw = loaded
+    except (OSError, yaml.YAMLError):
+        raw = {}
+
+    return AgentConfig(
+        name=name,
+        claude_md=claude_md,
+        provider=_coerce_str(raw.get("provider")) or "claude",
+        model=_coerce_str(raw.get("model")),
+        governance_profile=_coerce_str(raw.get("governance_profile")) or "default",
+        default_instruction=_coerce_str(raw.get("default_instruction")),
+        isolation=raw.get("isolation") if isinstance(raw.get("isolation"), dict) else {},
+        permissions=_normalize_permissions(raw.get("permissions")),
+        skills=_coerce_str_list(raw.get("skills")),
+    )

--- a/scripts/lib/agent_resolver.py
+++ b/scripts/lib/agent_resolver.py
@@ -9,6 +9,7 @@ schema into a typed, backward-compatible result.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Mapping
@@ -16,6 +17,15 @@ from typing import Any, Mapping
 import yaml
 
 VNX_AGENT_FOLDERS_ENV = "VNX_AGENT_FOLDERS"
+
+# Agent names are simple slugs; reject anything that could traverse the filesystem
+# (path separators, `..`, dots) before the name is ever joined into a path.
+_AGENT_NAME_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_-]*$")
+
+
+def _is_safe_agent_name(name: str) -> bool:
+    """True only for a slug-safe agent name — blocks path traversal (`../`, `/`, `..`)."""
+    return isinstance(name, str) and _AGENT_NAME_RE.match(name) is not None
 
 
 @dataclass(frozen=True)
@@ -45,6 +55,8 @@ def _resolve_agent_claude_md(
     engine_root: Path | None = None,
 ) -> Path | None:
     """Find ``<name>/CLAUDE.md`` using project agents/, examples/, then engine examples/."""
+    if not _is_safe_agent_name(name):
+        return None
     candidates = [
         project_dir / "agents" / name / "CLAUDE.md",
         project_dir / "examples" / name / "CLAUDE.md",

--- a/tests/test_agent_resolver.py
+++ b/tests/test_agent_resolver.py
@@ -124,3 +124,17 @@ class TestRobustness:
         agent_dir = _make_agent(tmp_path, "bad-yaml", config="not yaml: [")
         cfg = resolve_agent("bad-yaml", tmp_path)
         assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md" and cfg.provider == "claude"
+
+
+def test_resolve_agent_rejects_path_traversal(tmp_path):
+    """A traversal agent name must never resolve to a path outside the agent dirs."""
+    import agent_resolver as ar
+    # Plant a CLAUDE.md two levels up to prove traversal can't reach it.
+    (tmp_path / "CLAUDE.md").write_text("outside", encoding="utf-8")
+    proj = tmp_path / "proj"
+    (proj / "agents").mkdir(parents=True)
+    for bad in ["../../CLAUDE-dir", "..", "a/b", "../../../etc", "foo/../bar"]:
+        assert ar._resolve_agent_claude_md(bad, proj) is None
+        assert ar.resolve_agent(bad, proj) is None
+    assert ar._is_safe_agent_name("backend-developer") is True
+    assert ar._is_safe_agent_name("../x") is False

--- a/tests/test_agent_resolver.py
+++ b/tests/test_agent_resolver.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/agent_resolver.py (ADR-028 Phase 1)."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT / "scripts" / "lib") not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from agent_resolver import agent_folders_enabled, resolve_agent
+
+
+def _make_agent(base: Path, name: str, rel: str = "agents", config: str | None = None) -> Path:
+    agent_dir = base / rel / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "CLAUDE.md").write_text(f"# {name}")
+    if config is not None:
+        (agent_dir / "config.yaml").write_text(config)
+    return agent_dir
+
+
+class TestResolveAgentPrecedence:
+    def test_finds_agent_in_project_agents(self, tmp_path):
+        agent_dir = _make_agent(tmp_path, "local-agent")
+        cfg = resolve_agent("local-agent", tmp_path)
+        assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md"
+
+    def test_finds_agent_in_project_examples(self, tmp_path):
+        agent_dir = _make_agent(tmp_path, "demo-agent", rel="examples")
+        cfg = resolve_agent("demo-agent", tmp_path)
+        assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md"
+
+    def test_falls_back_to_engine_root_examples(self, tmp_path):
+        engine_root = tmp_path / "engine"
+        agent_dir = _make_agent(engine_root, "packaged-agent", rel="examples")
+        project_dir = tmp_path / "empty-project"
+        project_dir.mkdir()
+        cfg = resolve_agent("packaged-agent", project_dir, engine_root=engine_root)
+        assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md"
+
+    def test_project_beats_engine_root(self, tmp_path):
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "shared", rel="examples", config="provider: engine\n")
+        local_dir = _make_agent(tmp_path, "shared", rel="agents", config="provider: local\n")
+        cfg = resolve_agent("shared", tmp_path, engine_root=engine_root)
+        assert cfg is not None and cfg.claude_md == local_dir / "CLAUDE.md" and cfg.provider == "local"
+
+    def test_unknown_agent_returns_none(self, tmp_path):
+        assert resolve_agent("does-not-exist", tmp_path) is None
+
+
+class TestBackwardCompatibleDefaults:
+    def test_minimal_config_resolves_defaults(self, tmp_path):
+        _make_agent(tmp_path, "minimal", config="governance_profile: minimal\ndefault_instruction: Hello\n")
+        cfg = resolve_agent("minimal", tmp_path)
+        assert cfg is not None
+        assert cfg.provider == "claude" and cfg.model is None
+        assert cfg.governance_profile == "minimal" and cfg.default_instruction == "Hello"
+        assert cfg.isolation == {}
+        assert cfg.skills == []
+        assert cfg.permissions == {
+            "allowed_tools": [],
+            "denied_tools": [],
+            "bash_allow_patterns": [],
+            "bash_deny_patterns": [],
+        }
+
+    def test_missing_config_yaml_uses_defaults(self, tmp_path):
+        _make_agent(tmp_path, "no-config", config=None)
+        cfg = resolve_agent("no-config", tmp_path)
+        assert cfg is not None and cfg.provider == "claude" and cfg.model is None
+
+
+class TestExtendedConfigParsing:
+    def test_resolves_provider_and_model(self, tmp_path):
+        _make_agent(tmp_path, "kimi-agent", config="provider: kimi\nmodel: k2\n")
+        cfg = resolve_agent("kimi-agent", tmp_path)
+        assert cfg is not None and cfg.provider == "kimi" and cfg.model == "k2"
+
+    def test_resolves_permissions(self, tmp_path):
+        _make_agent(
+            tmp_path,
+            "guarded",
+            config=(
+                "permissions:\n"
+                "  allowed_tools: [Read, Write]\n"
+                "  denied_tools: [Bash]\n"
+                "  bash_allow_patterns: ['^git ']\n"
+                "  bash_deny_patterns: ['rm -rf']\n"
+            ),
+        )
+        cfg = resolve_agent("guarded", tmp_path)
+        assert cfg is not None
+        assert cfg.permissions["allowed_tools"] == ["Read", "Write"]
+        assert cfg.permissions["denied_tools"] == ["Bash"]
+        assert cfg.permissions["bash_allow_patterns"] == ["^git "]
+        assert cfg.permissions["bash_deny_patterns"] == ["rm -rf"]
+
+    def test_resolves_skills(self, tmp_path):
+        _make_agent(tmp_path, "skilled", config="skills:\n  - backend-developer\n  - reviewer\n")
+        cfg = resolve_agent("skilled", tmp_path)
+        assert cfg is not None and cfg.skills == ["backend-developer", "reviewer"]
+
+    def test_isolation_preserved(self, tmp_path):
+        _make_agent(tmp_path, "isolated", config="isolation:\n  scope_type: business_folder\n")
+        cfg = resolve_agent("isolated", tmp_path)
+        assert cfg is not None and cfg.isolation["scope_type"] == "business_folder"
+
+
+class TestFeatureFlag:
+    def test_defaults_to_enabled(self):
+        assert agent_folders_enabled({}) is True
+        assert agent_folders_enabled({"VNX_AGENT_FOLDERS": "1"}) is True
+
+    def test_zero_disables(self):
+        assert agent_folders_enabled({"VNX_AGENT_FOLDERS": "0"}) is False
+
+
+class TestRobustness:
+    def test_malformed_yaml_falls_back_to_defaults(self, tmp_path):
+        agent_dir = _make_agent(tmp_path, "bad-yaml", config="not yaml: [")
+        cfg = resolve_agent("bad-yaml", tmp_path)
+        assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md" and cfg.provider == "claude"

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -39,10 +39,42 @@ def _read_default_instruction(config_path: Path) -> str | None:
     return None
 
 
+def _resolve_agent_config(
+    agent: str,
+    agent_claude_md: Path,
+    project_dir: Path,
+) -> tuple[dict[str, object] | None, bool]:
+    """Load extended agent config when VNX_AGENT_FOLDERS is enabled.
+
+    Returns (agent_config, enabled). On import or parse errors, falls back to
+    legacy behavior (config=None) so a broken resolver never blocks dispatch.
+    """
+    try:
+        from agent_resolver import agent_folders_enabled, resolve_agent
+    except ImportError:
+        return None, False
+
+    if not agent_folders_enabled():
+        return None, False
+
+    agent_config = resolve_agent(
+        agent,
+        project_dir=project_dir,
+        engine_root=_engine.engine_root(),
+    )
+    if agent_config is None or agent_config.claude_md != agent_claude_md:
+        return None, True
+    return {
+        "provider": agent_config.provider,
+        "model": agent_config.model,
+        "default_instruction": agent_config.default_instruction,
+    }, True
+
+
 def vnx_dispatch_agent(args) -> int:
     agent = args.agent
     instruction = getattr(args, "instruction", None)
-    model = getattr(args, "model", "sonnet")
+    model = getattr(args, "model", None)
     project_dir = Path(getattr(args, "project_dir", ".")).resolve()
 
     # Validate agent CLAUDE.md exists
@@ -55,10 +87,20 @@ def vnx_dispatch_agent(args) -> int:
         )
         return 1
 
-    # Resolve instruction: explicit arg > default_instruction in config.yaml
+    # Add the packaged engine to sys.path so subprocess_dispatch is importable
+    # for both editable checkouts and pip-installed wheels. Also required so
+    # scripts/lib/agent_resolver.py can be imported in the pip package layout.
+    _engine.ensure_engine_on_path()
+
+    agent_config, agent_folders_on = _resolve_agent_config(agent, agent_claude_md, project_dir)
+
+    # Resolve instruction: explicit arg > config default_instruction > legacy scan
     if not instruction:
-        config_path = agent_claude_md.parent / "config.yaml"
-        instruction = _read_default_instruction(config_path)
+        if agent_config is not None:
+            instruction = agent_config.get("default_instruction")  # type: ignore[assignment]
+        if not instruction:
+            config_path = agent_claude_md.parent / "config.yaml"
+            instruction = _read_default_instruction(config_path)
 
     if not instruction:
         print(
@@ -68,12 +110,15 @@ def vnx_dispatch_agent(args) -> int:
         )
         return 1
 
+    # Resolve model: explicit arg > config model > legacy default sonnet
+    if not model:
+        if agent_config is not None and agent_config.get("model"):
+            model = agent_config["model"]  # type: ignore[assignment]
+        else:
+            model = "sonnet"
+
     # Generate a dispatch ID
     dispatch_id = f"D-{uuid.uuid4().hex[:8]}"
-
-    # Add the packaged engine to sys.path so subprocess_dispatch is importable
-    # for both editable checkouts and pip-installed wheels.
-    _engine.ensure_engine_on_path()
 
     try:
         from subprocess_dispatch import deliver_with_recovery  # type: ignore[import]

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -238,9 +238,9 @@ def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
     )
     dispatch_parser.add_argument(
         "--model",
-        default="sonnet",
+        default=None,
         metavar="MODEL",
-        help="model to use (default: sonnet)",
+        help="model to use (default: sonnet, or the agent's config.yaml model when VNX_AGENT_FOLDERS is enabled)",
     )
     dispatch_parser.add_argument(
         "--project-dir",


### PR DESCRIPTION
## Summary
ADR-028 Phase 1: extends agent `config.yaml` with optional `provider`/`model`/`permissions`/`skills`, adds `scripts/lib/agent_resolver.py`, and wires the resolver into `vnx dispatch-agent` — fully backward-compatible. Existing agents (hello-world, backend-developer, …) resolve to the same defaults. Rollback via `VNX_AGENT_FOLDERS=0`.

## Changes
- `scripts/lib/agent_resolver.py` (+144): resolves an agent (local `agents/` or packaged `examples/` fallback), parsing the extended config into a typed result with defaults.
- `vnx_cli/commands/dispatch_agent.py` (+61) + `main.py`: consult the resolver for provider/model when present, fall back to today's behavior otherwise.
- `docs/guides/AGENT_CREATION_GUIDE.md`: documents the new optional fields.

## Verification
29 tests pass (agent_resolver + dispatch-agent resolution). Minimal config → defaults; extended config → resolved fields; existing dispatch-agent tests unchanged.

Track: agent-folder-fusion-phase1 · Dispatch: 20260709-221122-agentfolder-p1

🤖 Generated with [Claude Code](https://claude.com/claude-code)