### PR TITLE
feat(gov): evidence-bound merge gate — advisory-default (D3 bootstrap)

### DIFF
--- a/.github/workflows/attestation-gate.yml
+++ b/.github/workflows/attestation-gate.yml
@@ -60,8 +60,18 @@ jobs:
           # A PR that weakens verify_pr.py cannot affect the gate decision.
           VERIFIER_DIR="/tmp/vnx-base-verifier"
           mkdir -p "$VERIFIER_DIR"
-          for f in verify_pr.py attest_record.py attestation.py content_key.py ndjson_hash_chain.py; do
-            git show "origin/main:scripts/lib/$f" > "$VERIFIER_DIR/$f"
+          for f in verify_pr.py attest_record.py attestation.py content_key.py ndjson_hash_chain.py evidence_bound_gate.py; do
+            if git show "origin/main:scripts/lib/$f" > "$VERIFIER_DIR/$f" 2>/dev/null; then
+              echo "Extracted $f from origin/main"
+            elif [ "$f" = "evidence_bound_gate.py" ]; then
+              # Bootstrap: the evidence-bound gate module lands in origin/main only after
+              # this PR.  Old base-branch verifiers do not import it, so a missing copy is
+              # safe during the advisory rollout window.
+              echo "Skipping $f — not yet present in origin/main (bootstrap)"
+            else
+              echo "Required verifier $f missing from origin/main" >&2
+              exit 1
+            fi
           done
           echo "Base-branch verifier extracted to $VERIFIER_DIR"
           ls -la "$VERIFIER_DIR"

--- a/scripts/lib/attest_record.py
+++ b/scripts/lib/attest_record.py
@@ -55,6 +55,7 @@ def build_attest_manifest(
     signer_identity: str,
     timestamp: str,
     diff_hash: str,
+    task_class: "str | None" = None,
 ) -> dict:
     """Governed manifest extended with diff_hash for diff-binding.
 
@@ -68,6 +69,7 @@ def build_attest_manifest(
         plan_gate_ref=plan_gate_ref,
         signer_identity=signer_identity,
         timestamp=timestamp,
+        task_class=task_class,
     )
     manifest["diff_hash"] = diff_hash
     return manifest
@@ -85,6 +87,7 @@ def write_attest_record(
     repo_root: "str | Path | None" = None,
     base_ref: str = "origin/main",
     head_ref: str = "HEAD",
+    task_class: "str | None" = None,
 ) -> AttestRecord:
     """Compute content-key, build + sign manifest, write .vnx-attest/<key>.json.
 
@@ -124,6 +127,7 @@ def write_attest_record(
         signer_identity=signer_identity,
         timestamp=timestamp,
         diff_hash=diff_hash,
+        task_class=task_class,
     )
 
     if key_path is not None:

--- a/scripts/lib/attestation.py
+++ b/scripts/lib/attestation.py
@@ -71,6 +71,7 @@ def build_governed_manifest(
     plan_gate_ref: str,
     signer_identity: str,
     timestamp: str,
+    task_class: Optional[str] = None,
 ) -> dict:
     """Build a governed attestation manifest dict (without chain/signature fields).
 
@@ -81,8 +82,10 @@ def build_governed_manifest(
         plan_gate_ref: Reference to the plan-gate pass (e.g. PASS commit or receipt hash).
         signer_identity: The signer identity string matching an allowed_signers entry.
         timestamp: ISO-8601 UTC timestamp (caller supplies — no Date.now in scripts).
+        task_class: Optional task class (e.g. "implementation" or "closeout") used by
+            the evidence-bound gate to decide the required evidence set.
     """
-    return {
+    manifest: dict = {
         "schema_version": SCHEMA_VERSION,
         "attestation_type": ATTESTATION_GOVERNED,
         "dispatch_id": dispatch_id,
@@ -92,6 +95,9 @@ def build_governed_manifest(
         "signer_identity": signer_identity,
         "timestamp": timestamp,
     }
+    if task_class is not None:
+        manifest["task_class"] = task_class
+    return manifest
 
 
 def build_adhoc_manifest(
@@ -240,6 +246,7 @@ def emit_governed_attestation(
     timestamp: str,
     key_path: "str | Path",
     repo_root: "str | Path | None" = None,
+    task_class: Optional[str] = None,
 ) -> AttestationRecord:
     """Build, sign, hash-chain, and persist a governed attestation.
 
@@ -268,6 +275,7 @@ def emit_governed_attestation(
         plan_gate_ref=plan_gate_ref,
         signer_identity=signer_identity,
         timestamp=timestamp,
+        task_class=task_class,
     )
     signed = sign_manifest(manifest, key_path)
     chain_hash = append_chained_entry(ledger_path, signed)

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -78,6 +78,11 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
     "VNX_WIRING_GATE_REQUIRED": _e(
         "VNX_WIRING_GATE_REQUIRED", "bool", "0", "gate",
         "Require the wiring gate.", approval=True),
+    "VNX_EVIDENCE_BOUND_GATE": _e(
+        "VNX_EVIDENCE_BOUND_GATE", "enum", "advisory", "gate",
+        "Evidence-bound merge gate mode: off | advisory | required. "
+        "Advisory logs missing/invalid evidence but never blocks; required enforces evidence before merge. "
+        "Default is advisory for D3 bootstrap.", approval=True),
     "VNX_USE_CENTRAL_DB": _e(
         "VNX_USE_CENTRAL_DB", "enum", "", "dispatch",
         "Central-DB read mode (''=per-project | '1'=central | 'shadow'). Process-start routing — "

--- a/scripts/lib/evidence_bound_gate.py
+++ b/scripts/lib/evidence_bound_gate.py
@@ -1,0 +1,212 @@
+"""Evidence-bound merge gate (D3 bootstrap).
+
+Advisory-by-default verification that a PR's attestation is backed by the
+required evidence, each receipt signed and diff-bound to the same content-key.
+
+Evidence is stored as signed governed attestations in the existing
+``.vnx-attest/governed.ndjson`` hash-chain (the same ledger used by D1
+``emit_governed_attestation``).  Each evidence entry is a normal governed
+manifest extended with ``content_key`` and ``evidence_type`` so it can be
+located, signature-verified with ``verify_attestation``, and bound to the PR
+diff via ``content_key.compute_diff_hash``.
+
+Flag: ``VNX_EVIDENCE_BOUND_GATE`` (off | advisory | required).
+  - off:      no evidence check, provenance-only gate behaviour unchanged.
+  - advisory: verify evidence, log missing/invalid, but never block (default).
+  - required: block the merge-gate when required evidence is missing/invalid.
+
+References:
+  - attestation.py: build_governed_manifest, sign_manifest, verify_attestation
+  - content_key.py: compute_diff_hash
+  - ndjson_hash_chain.py: verify_chain, walk_chain, append_chained_entry
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from attestation import build_governed_manifest, sign_manifest, verify_attestation
+from content_key import compute_diff_hash
+from ndjson_hash_chain import append_chained_entry, verify_chain, walk_chain
+
+# Ledger shared with D1 governed attestations.
+_EVIDENCE_LEDGER = ".vnx-attest/governed.ndjson"
+
+# Evidence type discriminators stored in governed manifest entries.
+EVIDENCE_TEST_PASS = "test_pass"
+EVIDENCE_TIER1_GATE_PASS = "tier1_gate_pass"
+EVIDENCE_TIER2_PANEL_PASS = "tier2_panel_pass"
+
+# Required evidence set per task class.
+_REQUIRED_EVIDENCE: Dict[str, List[str]] = {
+    "implementation": [EVIDENCE_TEST_PASS, EVIDENCE_TIER1_GATE_PASS],
+    "closeout": [
+        EVIDENCE_TEST_PASS,
+        EVIDENCE_TIER1_GATE_PASS,
+        EVIDENCE_TIER2_PANEL_PASS,
+    ],
+}
+
+
+def gate_state() -> str:
+    """Resolve ``VNX_EVIDENCE_BOUND_GATE`` to one of off/advisory/required.
+
+    Defaults to ``advisory`` so the D3 bootstrap never blocks merges.
+    Unknown values fall back to ``off`` (fail-safe disable).
+    """
+    raw = (os.environ.get("VNX_EVIDENCE_BOUND_GATE") or "advisory").lower().strip()
+    if raw in {"off", "advisory", "required"}:
+        return raw
+    return "off"
+
+
+def _task_class_for_manifest(manifest: Dict[str, Any]) -> str:
+    """Determine the task class used for evidence requirements.
+
+    Explicit ``task_class`` field wins, then ``tags`` containing ``closeout``,
+    then a ``deliverable_id`` ending in ``-closeout``.  Everything else is
+    treated as ``implementation`` so the default requirement set is minimal.
+    """
+    tc = manifest.get("task_class")
+    if tc in _REQUIRED_EVIDENCE:
+        return str(tc)
+
+    tags = manifest.get("tags") or []
+    if isinstance(tags, (list, tuple, set)) and "closeout" in tags:
+        return "closeout"
+
+    deliverable = manifest.get("deliverable_id")
+    if isinstance(deliverable, str) and deliverable.endswith("-closeout"):
+        return "closeout"
+
+    return "implementation"
+
+
+def required_evidence_for(manifest: Dict[str, Any]) -> List[str]:
+    """Return the ordered list of required evidence types for ``manifest``."""
+    return list(_REQUIRED_EVIDENCE.get(_task_class_for_manifest(manifest), []))
+
+
+def emit_evidence_attestation(
+    *,
+    evidence_type: str,
+    content_key: str,
+    dispatch_id: str,
+    track_id: str,
+    signer_identity: str,
+    timestamp: str,
+    key_path: "str | Path",
+    repo_root: "str | Path | None" = None,
+) -> Dict[str, Any]:
+    """Sign and append an evidence receipt to the governed hash-chain.
+
+    Reuses ``build_governed_manifest`` + ``sign_manifest`` + ``append_chained_entry``
+    so the receipt format is the existing D1 governed attestation with only
+    additive ``content_key`` / ``evidence_type`` fields.
+    """
+    repo_root = Path(repo_root) if repo_root else Path.cwd()
+    ledger_path = repo_root / _EVIDENCE_LEDGER
+
+    manifest = build_governed_manifest(
+        dispatch_id=dispatch_id,
+        deliverable_id=evidence_type,
+        track_id=track_id,
+        plan_gate_ref=content_key,
+        signer_identity=signer_identity,
+        timestamp=timestamp,
+    )
+    manifest["content_key"] = content_key
+    manifest["evidence_type"] = evidence_type
+
+    signed = sign_manifest(manifest, key_path)
+    append_chained_entry(ledger_path, signed)
+    return signed
+
+
+def verify_evidence_bound(
+    *,
+    repo_root: "str | Path",
+    base_ref: str,
+    head_ref: str,
+    allowed_signers: "str | Path",
+    manifest: Dict[str, Any],
+    verbose: bool = False,
+) -> Tuple[bool, str, List[str]]:
+    """Verify the required evidence set for a PR attestation.
+
+    Returns ``(ok, status, details)``:
+      - ok: True if every required evidence type is present, validly signed,
+        and bound to the current diff.
+      - status: short human-readable summary.
+      - details: list of per-item advisory messages (missing/invalid evidence).
+
+    Required evidence is derived from ``manifest`` via ``required_evidence_for``.
+    """
+    repo_root = Path(repo_root)
+    ledger_path = repo_root / _EVIDENCE_LEDGER
+    required = required_evidence_for(manifest)
+
+    if not required:
+        return (True, "no required evidence for task class", [])
+
+    try:
+        current_key = compute_diff_hash(
+            repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+        )
+    except RuntimeError as exc:
+        detail = f"diff computation failed: {exc}"
+        return (False, detail, [detail])
+
+    details: List[str] = []
+
+    # Chain-integrity check: a tampered evidence ledger is itself a violation.
+    if ledger_path.exists():
+        chain_ok, violations, chain_status = verify_chain(ledger_path)
+        if not chain_ok:
+            detail = (
+                f"evidence ledger chain broken: "
+                f"{violations[0] if violations else 'unknown'}"
+            )
+            return (False, detail, [detail])
+    else:
+        detail = f"evidence ledger missing; required: {', '.join(required)}"
+        return (False, detail, [detail])
+
+    if chain_status == "unchained":
+        # Chaining was never enabled (VNX_CHAIN_RECEIPTS off).  The ledger may
+        # still contain evidence entries, but we cannot assert chain integrity.
+        # Continue with per-entry signature verification.
+        if verbose:
+            details.append("evidence ledger is unchained; verifying signatures only")
+
+    found: Dict[str, List[Dict[str, Any]]] = {et: [] for et in required}
+    invalid: List[str] = []
+
+    for line_no, entry, _entry_hash in walk_chain(ledger_path):
+        if not isinstance(entry, dict):
+            continue
+        et = entry.get("evidence_type")
+        if et not in required:
+            continue
+        if entry.get("content_key") != current_key:
+            continue
+
+        # Verify the detached SSH signature against base-branch allowed_signers.
+        # Drop the chain pointer so verify_attestation computes canonical bytes.
+        verification_manifest = {k: v for k, v in entry.items() if k != "prev_hash"}
+        if verify_attestation(verification_manifest, allowed_signers):
+            found[et].append(entry)
+        else:
+            invalid.append(
+                f"{et} evidence at line {line_no} has an invalid signature"
+            )
+
+    missing = [et for et in required if not found[et]]
+    if missing:
+        details.append(f"missing evidence: {', '.join(missing)}")
+    details.extend(invalid)
+
+    ok = not missing and not invalid
+    status = "ok" if ok else "; ".join(details)
+    return (ok, status, details)

--- a/scripts/lib/verify_pr.py
+++ b/scripts/lib/verify_pr.py
@@ -38,11 +38,14 @@ References:
 """
 from __future__ import annotations
 
+import json
 import os
 import subprocess
 import sys
 import tempfile
 from pathlib import Path
+
+import evidence_bound_gate
 
 # Exempt allowlist — paths exempt from attestation.
 # MUST stay in sync with the bash classify step in attestation-gate.yml.
@@ -333,6 +336,61 @@ def verify_pr(
                 pass
 
     if ok:
+        # Evidence-bound gate (D3 bootstrap): advisory by default, never weakens
+        # the provenance-only pass above.  Reuses D1/D2 signing and the hash-chain.
+        state = evidence_bound_gate.gate_state()
+        if state != "off":
+            try:
+                from content_key import compute_diff_hash
+
+                content_key = compute_diff_hash(
+                    repo_root=repo_root, base_ref=base_ref, head_ref=head_ref
+                )
+                record_path = repo_root / ".vnx-attest" / f"{content_key}.json"
+                manifest = json.loads(
+                    record_path.read_text(encoding="utf-8")
+                )
+                ev_ok, ev_status, ev_details = (
+                    evidence_bound_gate.verify_evidence_bound(
+                        repo_root=repo_root,
+                        base_ref=base_ref,
+                        head_ref=head_ref,
+                        allowed_signers=allowed_signers_path,
+                        manifest=manifest,
+                        verbose=verbose,
+                    )
+                )
+                if not ev_ok:
+                    if state == "required":
+                        return (
+                            1,
+                            f"FAIL: evidence-bound gate required — {ev_status}",
+                        )
+                    # Advisory mode: make the gap visible but allow the merge.
+                    for detail in ev_details:
+                        print(
+                            f"[evidence-bound advisory] {detail}",
+                            file=sys.stderr,
+                        )
+                    if verbose:
+                        print(
+                            f"[evidence-bound advisory] status={ev_status}",
+                            file=sys.stderr,
+                        )
+            except Exception as exc:
+                # Any internal evidence-check failure is surfaced as an advisory
+                # only — the provenance gate must not crash because of a
+                # bootstrap instrumentation problem.
+                if state == "required":
+                    return (
+                        1,
+                        f"FAIL: evidence-bound gate required — internal error: {exc}",
+                    )
+                print(
+                    f"[evidence-bound advisory] internal error: {exc}",
+                    file=sys.stderr,
+                )
+
         return (0, "PASS: attestation valid")
 
     if ov_ok and ov_manifest is not None:

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -40,6 +40,13 @@ def test_gate_flags_default_off_matching_code():
     assert cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"].default == "0"
 
 
+def test_evidence_bound_gate_default_advisory_and_requires_approval():
+    entry = cr.CONFIG_REGISTRY["VNX_EVIDENCE_BOUND_GATE"]
+    assert entry.default == "advisory"
+    assert entry.type == "enum"
+    assert entry.requires_approval is True
+
+
 def test_feature_toggles_default_off_and_provider_deepseek():
     assert cr.CONFIG_REGISTRY["VNX_SCOUT_PREPASS"].default == "0"
     assert cr.CONFIG_REGISTRY["VNX_TAGGER_ENABLED"].default == "0"
@@ -49,6 +56,8 @@ def test_feature_toggles_default_off_and_provider_deepseek():
 
 def test_gate_and_autopilot_require_approval():
     assert cr.CONFIG_REGISTRY["VNX_CI_GATE_REQUIRED"].requires_approval is True
+    assert cr.CONFIG_REGISTRY["VNX_WIRING_GATE_REQUIRED"].requires_approval is True
+    assert cr.CONFIG_REGISTRY["VNX_EVIDENCE_BOUND_GATE"].requires_approval is True
     assert cr.CONFIG_REGISTRY["VNX_ROADMAP_AUTOPILOT"].requires_approval is True
     # fail-safe intelligence toggles do not require approval
     assert cr.CONFIG_REGISTRY["VNX_SCOUT_PREPASS"].requires_approval is False

--- a/tests/test_verify_pr.py
+++ b/tests/test_verify_pr.py
@@ -26,6 +26,12 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib
 from verify_pr import classify_pr, verify_pr, _is_feature_file, _is_exempt_file
 from attest_record import ATTEST_DIR, write_attest_record
 from content_key import compute_diff_hash
+from evidence_bound_gate import (
+    emit_evidence_attestation,
+    EVIDENCE_TEST_PASS,
+    EVIDENCE_TIER1_GATE_PASS,
+    EVIDENCE_TIER2_PANEL_PASS,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -411,3 +417,266 @@ class TestPRTreeAllowedSignersIgnored:
                 f"Rogue self-authorization should fail but got exit_code={exit_code}: {message}"
             )
             assert "FAIL" in message
+
+
+# ---------------------------------------------------------------------------
+# Integration tests: evidence-bound gate (D3 bootstrap)
+# ---------------------------------------------------------------------------
+
+def _write_evidence(repo: Path, content_key: str, evidence_type: str, key_dir: dict, track_id: str = "evidence-bound") -> None:
+    """Append a signed, diff-bound evidence entry to .vnx-attest/governed.ndjson."""
+    emit_evidence_attestation(
+        evidence_type=evidence_type,
+        content_key=content_key,
+        dispatch_id=f"D-ev-{evidence_type}",
+        track_id=track_id,
+        signer_identity=key_dir["identity"],
+        timestamp="2026-07-09T12:00:00Z",
+        key_path=key_dir["key_path"],
+        repo_root=repo,
+    )
+
+
+def _setup_feature_branch_with_attest(
+    tmpdir: str,
+    ephemeral_key_dir: dict,
+    *,
+    task_class: "str | None" = None,
+) -> tuple[Path, str, str]:
+    """Create a repo with a feature commit and a signed attestation record.
+
+    Returns (repo, base_sha, content_key).
+    """
+    repo = _init_repo(Path(tmpdir))
+    base_sha = _head_sha(repo)
+
+    _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: feature")
+    content_key = compute_diff_hash(repo_root=repo, base_ref=base_sha, head_ref="HEAD")
+
+    write_attest_record(
+        dispatch_id="D-evidence-bound",
+        deliverable_id="D3",
+        track_id="evidence-bound-gate",
+        plan_gate_ref="gate-ref",
+        signer_identity=ephemeral_key_dir["identity"],
+        timestamp="2026-07-09T12:00:00Z",
+        key_path=ephemeral_key_dir["key_path"],
+        repo_root=repo,
+        base_ref=base_sha,
+        task_class=task_class,
+    )
+    return repo, base_sha, content_key
+
+
+class TestEvidenceBoundGate:
+    """VNX_EVIDENCE_BOUND_GATE off/advisory/required bootstrap behaviour."""
+
+    def test_required_mode_blocks_missing_evidence(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "required")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, _content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Expected FAIL (required missing evidence) but got {exit_code}: {message}"
+            assert "evidence-bound gate required" in message.lower()
+            assert "test_pass" in message.lower() or "tier1_gate_pass" in message.lower()
+
+    def test_advisory_mode_allows_missing_evidence_with_log(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "advisory")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, _content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            captured = capsys.readouterr()
+            assert exit_code == 0, f"Expected PASS/advisory but got {exit_code}: {message}"
+            assert "PASS" in message
+            assert "[evidence-bound advisory]" in captured.err
+            assert "test_pass" in captured.err.lower() or "tier1_gate_pass" in captured.err.lower()
+
+    def test_default_advisory_allows_missing_evidence(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        """With no env set, the gate defaults to advisory and never blocks."""
+        monkeypatch.delenv("VNX_EVIDENCE_BOUND_GATE", raising=False)
+        monkeypatch.delenv("VNX_OVERRIDE_EVIDENCE_BOUND_GATE", raising=False)
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, _content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            captured = capsys.readouterr()
+            assert exit_code == 0, f"Expected default-advisory PASS but got {exit_code}: {message}"
+            assert "[evidence-bound advisory]" in captured.err
+
+    def test_off_mode_skips_evidence_check(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "off")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, _content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            captured = capsys.readouterr()
+            assert exit_code == 0, f"Expected PASS but got {exit_code}: {message}"
+            assert "evidence-bound advisory" not in captured.err.lower()
+
+    def test_required_mode_passes_with_valid_evidence(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "required")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+            _write_evidence(repo, content_key, EVIDENCE_TEST_PASS, ephemeral_key_dir)
+            _write_evidence(repo, content_key, EVIDENCE_TIER1_GATE_PASS, ephemeral_key_dir)
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 0, f"Expected PASS with evidence but got {exit_code}: {message}"
+            assert "PASS" in message
+            assert "evidence-bound gate required" not in message.lower()
+
+    def test_closeout_requires_tier2_panel_evidence(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "required")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="closeout"
+            )
+            _write_evidence(repo, content_key, EVIDENCE_TEST_PASS, ephemeral_key_dir)
+            _write_evidence(repo, content_key, EVIDENCE_TIER1_GATE_PASS, ephemeral_key_dir)
+
+            # Missing Tier-2 panel evidence should block closeout.
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            captured = capsys.readouterr()
+            assert exit_code == 1, f"Expected FAIL (missing panel evidence) but got {exit_code}: {message}"
+            assert "tier2_panel_pass" in captured.err or "tier2_panel_pass" in message
+
+            # Add the panel evidence and verify the gate now passes.
+            _write_evidence(repo, content_key, EVIDENCE_TIER2_PANEL_PASS, ephemeral_key_dir)
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 0, f"Expected PASS after panel evidence but got {exit_code}: {message}"
+
+    def test_stale_wrong_diff_evidence_does_not_satisfy_bound(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        """A test receipt from an older green run must not cover a new diff."""
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "required")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo = _init_repo(Path(tmpdir))
+            base_sha = _head_sha(repo)
+
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 1\n", "feat: v1")
+            old_content_key = compute_diff_hash(
+                repo_root=repo, base_ref=base_sha, head_ref="HEAD"
+            )
+            # Evidence bound to the OLD diff.
+            _write_evidence(repo, old_content_key, EVIDENCE_TEST_PASS, ephemeral_key_dir)
+            _write_evidence(repo, old_content_key, EVIDENCE_TIER1_GATE_PASS, ephemeral_key_dir)
+
+            # Add more feature code — the diff (and content-key) changes.
+            _add_file_commit(repo, "scripts/lib/feature.py", "x = 2\n", "feat: v2")
+
+            # Attest the NEW diff.
+            write_attest_record(
+                dispatch_id="D-evidence-bound-stale",
+                deliverable_id="D3",
+                track_id="evidence-bound-gate",
+                plan_gate_ref="gate-ref",
+                signer_identity=ephemeral_key_dir["identity"],
+                timestamp="2026-07-09T12:00:00Z",
+                key_path=ephemeral_key_dir["key_path"],
+                repo_root=repo,
+                base_ref=base_sha,
+                task_class="implementation",
+            )
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Expected FAIL (stale evidence) but got {exit_code}: {message}"
+            assert "evidence-bound gate required" in message.lower()
+            assert "missing evidence" in message.lower()
+
+    def test_invalid_signature_evidence_is_rejected(
+        self, ephemeral_key_dir, monkeypatch, capsys,
+    ):
+        monkeypatch.setenv("VNX_EVIDENCE_BOUND_GATE", "required")
+        with tempfile.TemporaryDirectory() as tmpdir:
+            repo, base_sha, content_key = _setup_feature_branch_with_attest(
+                tmpdir, ephemeral_key_dir, task_class="implementation"
+            )
+            # Evidence signed with the legitimate key is accepted.
+            _write_evidence(repo, content_key, EVIDENCE_TEST_PASS, ephemeral_key_dir)
+            _write_evidence(repo, content_key, EVIDENCE_TIER1_GATE_PASS, ephemeral_key_dir)
+
+            # Corrupt the Tier-1 evidence signature.
+            ledger = repo / ".vnx-attest" / "governed.ndjson"
+            lines = ledger.read_text(encoding="utf-8").splitlines()
+            for i, line in enumerate(lines):
+                entry = json.loads(line)
+                if entry.get("evidence_type") == EVIDENCE_TIER1_GATE_PASS:
+                    entry["signature"] = entry["signature"][:-8] + "deadbeef"
+                    lines[i] = json.dumps(entry)
+                    break
+            ledger.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+            exit_code, message = verify_pr(
+                repo_root=repo,
+                base_ref=base_sha,
+                head_ref="HEAD",
+                allowed_signers_override=ephemeral_key_dir["allowed_signers"],
+            )
+            assert exit_code == 1, f"Expected FAIL (invalid evidence signature) but got {exit_code}: {message}"
+            assert "evidence-bound gate required" in message.lower()
+            assert "invalid signature" in message.lower()


### PR DESCRIPTION
## Summary
Closes the provenance-vs-completion gap: the signed-attestation gate proves WHO/WHAT (provenance) but not that required evidence (test-receipt + Tier-1 gate + closeout Tier-2-panel) is PRESENT + VALID + SIGNED + diff-bound. This gate verifies that. **Advisory by default** (`VNX_EVIDENCE_BOUND_GATE` defaults to `advisory`: logs gaps, NEVER blocks); operator flips to `required` to enforce. Reuses the existing D1-D5 signing / hash-chain / attestation primitives — no new crypto. Built via the Kimi lane.

## Changes
- `scripts/lib/evidence_bound_gate.py` (+212): the evidence check (present + valid-signed + diff-bound via content-key), required-evidence set per task-class.
- `scripts/lib/verify_pr.py` (+58): wired as an additive, flag-gated verification (provenance-only path unchanged when advisory/off).
- `attestation.py` / `attest_record.py` / `config_registry.py`: flag config + integration.
- `.github/workflows/attestation-gate.yml`: bootstrap-safe verifier extraction (the new module isn't on origin/main until this PR merges → graceful skip during advisory rollout; NOT a blocking gate).

## Verification
52 tests pass. Advisory-default proven (missing evidence → allow + log); required-mode blocks; a stale wrong-diff receipt does NOT satisfy the diff-bound check.

Track: evidence-bound-gate · Dispatch: 20260709-224955-evidence-bound

🤖 Generated with [Claude Code](https://claude.com/claude-code)