### PR TITLE
fix(tenant-stamping): W1 child-FK-widening + pool_config dedupe (W1 stays disabled)

### DIFF
--- a/scripts/lib/tenant_stamping.py
+++ b/scripts/lib/tenant_stamping.py
@@ -489,15 +489,29 @@ def _rebuild_table_phase1(
     conn: sqlite3.Connection,
     table: str,
     non_composite_uniques: list[dict],
-) -> None:
+    widened_keys: set[tuple[str, str]] | None = None,
+) -> list[tuple[str, str]]:
     """Rebuild ``table`` to add project_id to each non-composite UNIQUE/PK.
 
     Phase 1 keeps project_id NULLABLE — we only widen the uniqueness key.
     Uses the copy-and-rename pattern (SQLite cannot ALTER CONSTRAINT).
 
+    When ``widened_keys`` is provided, any single-column FK on this table that
+    references a parent key recorded in ``widened_keys`` is widened to a
+    composite FK including project_id.  This keeps child tables consistent
+    with parents whose UNIQUE/PK was widened to (old_col, project_id).
+
     FK-off must already be active on this connection (caller's responsibility).
+
+    Returns the list of (table, old_col) parent keys that were widened to
+    composite by this rebuild.
     """
+    if widened_keys is None:
+        widened_keys = set()
+
     cols = _get_table_columns(conn, table)
+    widened_here: list[tuple[str, str]] = []
+    has_project_id = any(c["name"] == "project_id" for c in cols)
     col_defs = []
     pk_cols = [c for c in cols if c["pk"] > 0]
     pk_col_names = {c["name"] for c in pk_cols}
@@ -560,6 +574,9 @@ def _rebuild_table_phase1(
             extra_pk_cols = [c["name"] for c in pk_col_list]
             composite_pk = ", ".join(_safe_ident(n) for n in extra_pk_cols + ["project_id"])
             col_defs.append(f"  PRIMARY KEY ({composite_pk})")
+            # Record the widened single-column PK so child FKs can follow.
+            if len(pk_col_list) == 1:
+                widened_here.append((table, pk_col_list[0]["name"]))
         else:
             existing_pk = ", ".join(_safe_ident(c["name"]) for c in pk_col_list)
             col_defs.append(f"  PRIMARY KEY ({existing_pk})")
@@ -583,6 +600,10 @@ def _rebuild_table_phase1(
         existing_cols = uidx["cols"]
         if "project_id" not in existing_cols:
             extended = existing_cols + ["project_id"]
+            # Record single-column declared UNIQUEs that were widened so child
+            # FKs referencing the old key can be widened to match.
+            if len(existing_cols) == 1:
+                widened_here.append((table, existing_cols[0]))
         else:
             extended = existing_cols  # already composite — re-emit verbatim
         uc_list = ", ".join(_safe_ident(c) for c in extended)
@@ -597,13 +618,32 @@ def _rebuild_table_phase1(
             fk_by_id[fk_id] = []
         fk_by_id[fk_id].append(row)
     for fk_id, fk_group in sorted(fk_by_id.items()):
-        from_cols = ", ".join(_safe_ident(r[3]) for r in sorted(fk_group, key=lambda r: r[1]))
         ref_table = fk_group[0][2]
-        to_cols = ", ".join(_safe_ident(r[4]) for r in sorted(fk_group, key=lambda r: r[1]))
+        old_from_cols = [r[3] for r in sorted(fk_group, key=lambda r: r[1])]
+        old_to_cols = [r[4] for r in sorted(fk_group, key=lambda r: r[1])]
         on_update = fk_group[0][5]
         on_delete = fk_group[0][6]
+
+        # Widen this child FK if it references a parent key that Phase 1 has
+        # widened to a composite (old_col, project_id).  The parent key was
+        # single-column before widening; we mirror that by appending project_id
+        # to both the child FK columns and the referenced parent columns.
+        if (
+            len(old_to_cols) == 1
+            and (ref_table, old_to_cols[0]) in widened_keys
+            and "project_id" not in old_from_cols
+            and has_project_id
+        ):
+            new_from_cols = old_from_cols + ["project_id"]
+            new_to_cols = old_to_cols + ["project_id"]
+        else:
+            new_from_cols = old_from_cols
+            new_to_cols = old_to_cols
+
+        from_cols_sql = ", ".join(_safe_ident(c) for c in new_from_cols)
+        to_cols_sql = ", ".join(_safe_ident(c) for c in new_to_cols)
         col_defs.append(
-            f"  FOREIGN KEY ({from_cols}) REFERENCES {_safe_ident(ref_table)} ({to_cols})"
+            f"  FOREIGN KEY ({from_cols_sql}) REFERENCES {_safe_ident(ref_table)} ({to_cols_sql})"
             f" ON UPDATE {on_update} ON DELETE {on_delete}"
         )
 
@@ -683,6 +723,8 @@ def _rebuild_table_phase1(
     for _, idx_sql in secondary_indexes:
         conn.execute(idx_sql)
 
+    return widened_here
+
 
 def run_phase1_ddl(
     conn: sqlite3.Connection,
@@ -695,10 +737,15 @@ def run_phase1_ddl(
     ``tables`` must already be in topological (parent-before-child) order.
     Returns the list of tables that were actually rebuilt.
 
+    Child FKs that reference a widened single-column parent key are discovered
+    and rebuilt automatically, so foreign_key_check passes after Phase 1 even
+    when a parent UNIQUE/PK becomes composite (e.g. recommendations ->
+    recommendation_outcomes).
+
     This function manages its own FK-off + BEGIN EXCLUSIVE transaction.
     """
-    rebuilt: list[str] = []
-    tables_needing_rebuild: list[tuple[str, list[dict]]] = []
+    need_rebuild: set[str] = set()
+    table_non_composite: dict[str, list[dict]] = {}
 
     for table in tables:
         non_composite = _get_unique_indexes(conn, table)
@@ -723,9 +770,10 @@ def run_phase1_ddl(
             and not (len(pk_cols) == 1 and pk_cols[0]["type"].upper() == "INTEGER")
         )
         if non_composite_declared or pk_lacks_pid:
-            tables_needing_rebuild.append((table, non_composite))
+            need_rebuild.add(table)
+            table_non_composite[table] = non_composite
 
-    if not tables_needing_rebuild:
+    if not need_rebuild:
         return []
 
     original_fk = conn.execute("PRAGMA foreign_keys").fetchone()[0]
@@ -735,9 +783,47 @@ def run_phase1_ddl(
         conn.execute("PRAGMA foreign_keys=OFF")
         conn.execute("BEGIN EXCLUSIVE")
         try:
-            for table, non_composite in tables_needing_rebuild:
-                _rebuild_table_phase1(conn, table, non_composite)
-                rebuilt.append(table)
+            rebuilt: list[str] = []
+            rebuilt_set: set[str] = set()
+            widened_keys: set[tuple[str, str]] = set()
+
+            # Iteratively rebuild tables and discover child FKs that must also be
+            # widened.  Each loop processes all tables in topological order; newly
+            # discovered children are handled in subsequent loops, which also covers
+            # chained FK dependencies.
+            changed = True
+            while changed:
+                changed = False
+                for table in tables:
+                    if table not in need_rebuild or table in rebuilt_set:
+                        continue
+                    non_composite = table_non_composite.get(table, _get_unique_indexes(conn, table))
+                    new_widened = _rebuild_table_phase1(
+                        conn, table, non_composite, widened_keys=widened_keys
+                    )
+                    rebuilt.append(table)
+                    rebuilt_set.add(table)
+                    for key in new_widened:
+                        if key not in widened_keys:
+                            widened_keys.add(key)
+                            changed = True
+
+                # After rebuilding everything currently queued, scan for child tables
+                # whose FKs still reference the old single-column parent key.
+                for table in tables:
+                    if table in rebuilt_set:
+                        continue
+                    fk_rows = conn.execute(
+                        f"PRAGMA foreign_key_list({_safe_ident(table)[1:-1]})"
+                    ).fetchall()
+                    for row in fk_rows:
+                        ref_table = row[2]
+                        to_col = row[4]
+                        if (ref_table, to_col) in widened_keys:
+                            need_rebuild.add(table)
+                            changed = True
+                            break
+
             # B3(a) fix: run integrity checks before committing Phase 1 DDL.
             # A rebuild that silently damages the schema is caught here and
             # rolled back, never committed.

--- a/tests/test_migrate_pool_seed.py
+++ b/tests/test_migrate_pool_seed.py
@@ -374,3 +374,66 @@ class TestResolverAlignment:
         finally:
             conn.close()
         assert len(rows) == 1, "runtime_schema_version table must exist after bootstrap"
+
+
+    def test_pool_config_no_duplicate_after_vnx_dev_seed(self, tmp_path, monkeypatch):
+        """Migration 0020's ('vnx-dev','default') row is upgraded, not duplicated.
+
+        The bootstrap path applies migration 0020 (which seeds 'vnx-dev') and then
+        calls _seed_default_pool_config with the CLI-derived project_id.  The seed
+        must UPDATE the legacy row instead of INSERTing a second one, so a later
+        W1 Phase-2 vnx-dev->pid restamp cannot collide on UNIQUE(project_id, pool_id).
+        """
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(data_root, project_id="myproject")
+
+        import sqlite3
+        db = data_root / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        try:
+            for tbl in ("pool_config", "worker_pools"):
+                rows = conn.execute(
+                    f"SELECT project_id FROM {tbl} WHERE pool_id = 'default'"
+                ).fetchall()
+                assert len(rows) == 1, (
+                    f"{tbl} must have exactly one default row; got {rows}"
+                )
+                assert rows[0][0] == "myproject", (
+                    f"{tbl} default row must be 'myproject'; got {rows[0][0]!r}"
+                )
+        finally:
+            conn.close()
+
+    def test_pool_config_seed_idempotent_across_vnx_dev_upgrade(self, tmp_path, monkeypatch):
+        """Re-running bootstrap after the vnx-dev->myproject upgrade is a no-op."""
+        data_root = tmp_path / "data"
+        project_dir = tmp_path / "myproject"
+        project_dir.mkdir()
+
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_root))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        from vnx_cli.commands.init_cmd import _bootstrap_runtime_dbs
+        _bootstrap_runtime_dbs(data_root, project_id="myproject")
+        _bootstrap_runtime_dbs(data_root, project_id="myproject")
+
+        import sqlite3
+        db = data_root / "state" / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        try:
+            for tbl in ("pool_config", "worker_pools"):
+                count = conn.execute(
+                    f"SELECT COUNT(*) FROM {tbl} WHERE pool_id = 'default'"
+                ).fetchone()[0]
+                assert count == 1, (
+                    f"Idempotent bootstrap must not duplicate {tbl} default row; got {count}"
+                )
+        finally:
+            conn.close()

--- a/tests/test_w1_tenant_stamping.py
+++ b/tests/test_w1_tenant_stamping.py
@@ -144,6 +144,139 @@ def _make_parent_child_tables(conn: sqlite3.Connection) -> None:
     conn.commit()
 
 
+def _make_recommendation_like_tables(conn: sqlite3.Connection) -> None:
+    """Create parent UNIQUE(recommendation_id) + child FK (the reported W1 bug)."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS recommendations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            recommendation_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            title TEXT NOT NULL,
+            UNIQUE (recommendation_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS recommendation_outcomes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            recommendation_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            metric_name TEXT NOT NULL,
+            FOREIGN KEY (recommendation_id) REFERENCES recommendations(recommendation_id)
+        )
+    """)
+    conn.commit()
+
+
+def _make_legacy_store(conn: sqlite3.Connection) -> None:
+    """Fixture legacy store for full W1 3-phase run.
+
+    Mixes tables whose single-column UNIQUE/PK must be widened with already-
+    composite keys (pool_config), plus a child FK that references a widened
+    parent key.
+    """
+    conn.execute("PRAGMA foreign_keys = OFF")
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            UNIQUE (dispatch_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS terminal_leases (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            terminal_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'idle',
+            UNIQUE (terminal_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS worker_states (
+            terminal_id TEXT NOT NULL,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'initializing',
+            state_entered_at TEXT NOT NULL,
+            PRIMARY KEY (terminal_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS pool_config (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            pool_id TEXT NOT NULL DEFAULT 'default',
+            min_workers INTEGER NOT NULL DEFAULT 1,
+            max_workers INTEGER NOT NULL DEFAULT 6,
+            target_workers INTEGER NOT NULL DEFAULT 3,
+            role_mix_json TEXT NOT NULL DEFAULT '["backend-developer"]',
+            provider_mix_json TEXT NOT NULL DEFAULT '["claude"]',
+            scale_policy TEXT NOT NULL DEFAULT 'queue_depth_v1',
+            cooldown_seconds INTEGER NOT NULL DEFAULT 120,
+            UNIQUE (project_id, pool_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS worker_pools (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            pool_id TEXT NOT NULL DEFAULT 'default',
+            state TEXT NOT NULL DEFAULT 'idle',
+            current_size INTEGER NOT NULL DEFAULT 0,
+            target_size INTEGER NOT NULL DEFAULT 0,
+            UNIQUE (project_id, pool_id),
+            FOREIGN KEY (project_id, pool_id) REFERENCES pool_config(project_id, pool_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS recommendations (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            recommendation_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            title TEXT NOT NULL,
+            UNIQUE (recommendation_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS recommendation_outcomes (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            recommendation_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            metric_name TEXT NOT NULL,
+            FOREIGN KEY (recommendation_id) REFERENCES recommendations(recommendation_id)
+        )
+    """)
+    conn.commit()
+
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id) VALUES ('d1', 'vnx-dev')"
+    )
+    conn.execute(
+        "INSERT INTO terminal_leases (terminal_id, project_id) VALUES ('T1', 'vnx-dev')"
+    )
+    conn.execute(
+        "INSERT INTO worker_states (terminal_id, dispatch_id, project_id, state_entered_at) "
+        "VALUES ('T1', 'd1', 'vnx-dev', '2024-01-01T00:00:00Z')"
+    )
+    conn.execute(
+        "INSERT INTO pool_config (project_id, pool_id) VALUES ('vnx-dev', 'default')"
+    )
+    conn.execute(
+        "INSERT INTO worker_pools (project_id, pool_id) VALUES ('vnx-dev', 'default')"
+    )
+    conn.execute(
+        "INSERT INTO recommendations (recommendation_id, title, project_id) "
+        "VALUES ('rec1', 'title', 'vnx-dev')"
+    )
+    conn.execute(
+        "INSERT INTO recommendation_outcomes (recommendation_id, metric_name, project_id) "
+        "VALUES ('rec1', 'm', 'vnx-dev')"
+    )
+    conn.commit()
+
+
 def _db(tmp_path: Path, name: str = "test.db") -> Path:
     p = tmp_path / name
     return p
@@ -1378,15 +1511,13 @@ class TestB2SingleColTextPK:
         assert "project_id" in pk_cols, "project_id must be in the composite PK"
         assert project_id_val == "new-tenant"
 
-    def test_fk_to_text_pk_catches_damage_and_restores_original(self, tmp_path: Path) -> None:
-        """B3 spec: FK-to-single-col-PK → Phase 1 integrity check catches damage + restores ORIGINAL.
+    def test_fk_to_text_pk_is_widened_with_parent(self, tmp_path: Path) -> None:
+        """A child FK to a single-col TEXT PK is widened when the parent PK becomes composite.
 
-        When a parent table has TEXT PRIMARY KEY and a child FK references that single-col key,
-        Phase 1 rebuilds the parent to a composite PK (code, project_id). The child's FK
-        (cat_code) REFERENCES categories(code) now has a "foreign key mismatch" because 'code'
-        is no longer the full PK. The B3(a) integrity check fires before COMMIT and forces
-        ROLLBACK, and the B3(b) pre-migration restore brings the DB back to the original state
-        (before Phase 1 DDL ran). This is the exact scenario the spec describes.
+        Previously this caused a foreign key mismatch and Phase 1 would roll back.
+        The W1 fix automatically widens the child FK to (cat_code, project_id) so it
+        references the parent's new composite PK (code, project_id).  The full 3-phase
+        migration succeeds, all rows are preserved, and foreign_key_check is clean.
         """
         db = _db(tmp_path)
         conn = _open(db)
@@ -1410,31 +1541,38 @@ class TestB2SingleColTextPK:
         conn.execute("INSERT INTO categories (code, label) VALUES ('A', 'Alpha')")
         conn.execute("INSERT INTO items (cat_code, project_id) VALUES ('A', 'vnx-dev')")
         conn.commit()
-
-        # Capture the original schema before migration.
-        cat_pk_before = [r[1] for r in conn.execute("PRAGMA table_info(categories)").fetchall() if r[5] > 0]
-        item_count_before = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
         conn.close()
 
-        # Phase 1 rebuild of 'categories' makes the child FK a mismatch.
-        # B3(a): foreign_key_check detects this and forces ROLLBACK before COMMIT.
-        # B3(b): the pre-migration restore brings the DB back to original state.
-        with pytest.raises(RuntimeError, match="(?i)(foreign key mismatch|Phase 1.*failed)"):
-            ts.run_three_phase_migration_on_db(db, "tenant-x", db_label="TEST")
+        # Full migration should now succeed because the child FK is widened automatically.
+        result = ts.run_three_phase_migration_on_db(db, "tenant-x", db_label="TEST")
+        assert result["ok"] is True
 
-        # The DB must be restored to its pre-migration state (B3(b)).
         conn = sqlite3.connect(str(db))
-        cat_pk_after = [r[1] for r in conn.execute("PRAGMA table_info(categories)").fetchall() if r[5] > 0]
-        item_count_after = conn.execute("SELECT COUNT(*) FROM items").fetchone()[0]
-        conn.close()
+        try:
+            fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+            assert not fk_violations, f"foreign_key_check violations: {fk_violations}"
 
-        # Schema must be back to original (Phase 1 DDL rolled back).
-        assert cat_pk_after == cat_pk_before, (
-            f"Schema not restored after Phase 1 failure. "
-            f"Before: {cat_pk_before}, After: {cat_pk_after}"
-        )
-        # Data must be intact.
-        assert item_count_after == item_count_before
+            # Parent PK is composite.
+            cat_pk = [r[1] for r in conn.execute("PRAGMA table_info(categories)").fetchall() if r[5] > 0]
+            assert "code" in cat_pk and "project_id" in cat_pk
+
+            # Child FK is now composite (cat_code, project_id) -> (code, project_id).
+            fks = conn.execute("PRAGMA foreign_key_list(items)").fetchall()
+            child_fk_cols = [(row[3], row[4]) for row in fks if row[2] == "categories"]
+            assert ("cat_code", "code") in child_fk_cols
+            assert ("project_id", "project_id") in child_fk_cols
+
+            # Data preserved and restamped.
+            assert conn.execute("SELECT COUNT(*) FROM categories").fetchone()[0] == 1
+            assert conn.execute("SELECT COUNT(*) FROM items").fetchone()[0] == 1
+            assert conn.execute(
+                "SELECT project_id FROM categories WHERE code='A'"
+            ).fetchone()[0] == "tenant-x"
+            assert conn.execute(
+                "SELECT project_id FROM items WHERE cat_code='A'"
+            ).fetchone()[0] == "tenant-x"
+        finally:
+            conn.close()
 
 
 # ===========================================================================
@@ -2588,3 +2726,96 @@ class TestFtsShadowExclusion:
         ic = conn.execute("PRAGMA integrity_check").fetchall()
         assert ic == [("ok",)], f"integrity_check failed: {ic}"
         conn.close()
+
+
+# ===========================================================================
+# 24. Child-FK widening when parent UNIQUE/PK becomes composite
+# ===========================================================================
+
+class TestChildFkwidening:
+    """W1 fix: child FKs that referenced a single-column parent key are widened."""
+
+    def test_phase1_widens_child_fk_when_parent_unique_becomes_composite(
+        self, tmp_path: Path
+    ) -> None:
+        """recommendations UNIQUE(recommendation_id) widens; child FK follows."""
+        db = _db(tmp_path)
+        conn = _open(db)
+        _make_recommendation_like_tables(conn)
+        conn.execute(
+            "INSERT INTO recommendations (recommendation_id, title, project_id) "
+            "VALUES ('rec1', 'title', 'vnx-dev')"
+        )
+        conn.execute(
+            "INSERT INTO recommendation_outcomes (recommendation_id, metric_name, project_id) "
+            "VALUES ('rec1', 'm', 'vnx-dev')"
+        )
+        conn.commit()
+        conn.close()
+
+        result = ts.run_three_phase_migration_on_db(db, "myproject", db_label="TEST")
+        assert result["ok"] is True
+
+        conn = sqlite3.connect(str(db))
+        try:
+            fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+            assert not fk_violations, f"FK violations: {fk_violations}"
+
+            rec_rows = conn.execute("SELECT COUNT(*) FROM recommendations").fetchone()[0]
+            out_rows = conn.execute("SELECT COUNT(*) FROM recommendation_outcomes").fetchone()[0]
+            assert rec_rows == 1, f"recommendations lost rows: {rec_rows}"
+            assert out_rows == 1, f"recommendation_outcomes lost rows: {out_rows}"
+
+            # Child FK is now composite (recommendation_id, project_id).
+            fks = conn.execute("PRAGMA foreign_key_list(recommendation_outcomes)").fetchall()
+            child_fk_cols = [(row[3], row[4]) for row in fks if row[2] == "recommendations"]
+            assert ("recommendation_id", "recommendation_id") in child_fk_cols
+            assert ("project_id", "project_id") in child_fk_cols
+        finally:
+            conn.close()
+
+
+# ===========================================================================
+# 25. Full W1 3-phase run on a synthetic legacy fixture store
+# ===========================================================================
+
+class TestFullW1Fixture:
+    """Run all 3 W1 phases on a synthetic legacy store and verify a clean result."""
+
+    def test_full_three_phase_on_legacy_fixture(self, tmp_path: Path) -> None:
+        """Legacy fixture with mixed widened/already-composite keys + child FKs."""
+        db = _db(tmp_path)
+        conn = _open(db)
+        _make_legacy_store(conn)
+        conn.close()
+
+        result = ts.run_three_phase_migration_on_db(db, "myproject", db_label="TEST")
+        assert result["ok"] is True
+
+        conn = sqlite3.connect(str(db))
+        try:
+            fk_violations = conn.execute("PRAGMA foreign_key_check").fetchall()
+            assert not fk_violations, f"FK violations after full W1: {fk_violations}"
+
+            tables = [
+                "dispatches",
+                "terminal_leases",
+                "worker_states",
+                "pool_config",
+                "worker_pools",
+                "recommendations",
+                "recommendation_outcomes",
+            ]
+            for tbl in tables:
+                count = conn.execute(f"SELECT COUNT(*) FROM {tbl}").fetchone()[0]
+                assert count > 0, f"{tbl} unexpectedly has zero rows"
+                vals = {r[0] for r in conn.execute(f"SELECT DISTINCT project_id FROM {tbl}").fetchall()}
+                assert vals == {"myproject"}, f"{tbl} has wrong project_ids: {vals}"
+
+            for tbl in tables:
+                cols = {r[1]: r for r in conn.execute(f"PRAGMA table_info({tbl})").fetchall()}
+                assert cols["project_id"][3] == 1, (
+                    f"{tbl}.project_id must be NOT NULL after Phase 3"
+                )
+        finally:
+            conn.close()

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -342,36 +342,74 @@ def _emit_bootstrap_event(data_root: Path, status: str, error: str = "") -> None
 def _seed_default_pool_config(db_path: Path, project_id: str) -> None:
     """Seed default pool_config + worker_pools rows for project_id. Idempotent.
 
-    ADR-007: UNIQUE(project_id, pool_id) is the natural guard; INSERT OR IGNORE
-    is safe to re-run on every migrate call without duplicating the row.
-    pool_config must be inserted before worker_pools (FK dependency).
+    ADR-007: UNIQUE(project_id, pool_id) is the natural guard.  Migration 0020
+    seeds a ('vnx-dev', 'default') row; this function upgrades that legacy row
+    to ``project_id`` instead of inserting a second row.  This prevents the W1
+    Phase-2 vnx-dev->pid restamp from colliding on the composite UNIQUE.
+
+    pool_config must be updated/inserted before worker_pools (FK dependency).
     """
     import sqlite3 as _sqlite3
     conn = _sqlite3.connect(str(db_path), timeout=10.0)
     try:
         conn.execute("PRAGMA journal_mode = WAL")
-        conn.execute("PRAGMA foreign_keys = ON")
-        conn.execute(
-            """
-            INSERT OR IGNORE INTO pool_config
-                (project_id, pool_id, min_workers, max_workers, target_workers,
-                 role_mix_json, provider_mix_json, scale_policy, cooldown_seconds)
-            VALUES (?, 'default', 0, 4, 1,
-                    '["backend-developer"]',
-                    '["claude"]',
-                    'queue_depth_v1', 120)
-            """,
-            (project_id,),
-        )
-        conn.execute(
-            """
-            INSERT OR IGNORE INTO worker_pools
-                (project_id, pool_id, state, current_size, target_size)
-            VALUES (?, 'default', 'idle', 0, 0)
-            """,
-            (project_id,),
-        )
+        # FKs are suspended during the seed upgrade: migration 0020 creates a
+        # (pool_config='vnx-dev', worker_pools='vnx-dev') pair linked by FK.  When
+        # we upgrade both rows to project_id we must avoid a transient FK violation
+        # between the two UPDATEs.  The final state is consistent, so re-enabling
+        # FKs after COMMIT is safe.
+        conn.execute("PRAGMA foreign_keys = OFF")
+
+        # pool_config: ensure exactly one default row for project_id.
+        existing = conn.execute(
+            "SELECT project_id FROM pool_config WHERE pool_id = ?",
+            ("default",),
+        ).fetchone()
+        if existing is None:
+            conn.execute(
+                """
+                INSERT INTO pool_config
+                    (project_id, pool_id, min_workers, max_workers, target_workers,
+                     role_mix_json, provider_mix_json, scale_policy, cooldown_seconds)
+                VALUES (?, 'default', 0, 4, 1,
+                        '["backend-developer"]',
+                        '["claude"]',
+                        'queue_depth_v1', 120)
+                """,
+                (project_id,),
+            )
+        elif existing[0] == "vnx-dev" and project_id != "vnx-dev":
+            conn.execute(
+                "UPDATE pool_config SET project_id = ? WHERE pool_id = ? AND project_id = ?",
+                (project_id, "default", "vnx-dev"),
+            )
+        # else: already seeded for project_id (or vnx-dev -> vnx-dev); leave untouched.
+
+        # worker_pools: mirror the same idempotent upgrade so the FK target and
+        # the runtime state row stay one-to-one with pool_config.
+        existing_wp = conn.execute(
+            "SELECT project_id FROM worker_pools WHERE pool_id = ?",
+            ("default",),
+        ).fetchone()
+        if existing_wp is None:
+            conn.execute(
+                """
+                INSERT INTO worker_pools
+                    (project_id, pool_id, state, current_size, target_size)
+                VALUES (?, 'default', 'idle', 0, 0)
+                """,
+                (project_id,),
+            )
+        elif existing_wp[0] == "vnx-dev" and project_id != "vnx-dev":
+            conn.execute(
+                "UPDATE worker_pools SET project_id = ? WHERE pool_id = ? AND project_id = ?",
+                (project_id, "default", "vnx-dev"),
+            )
+
         conn.commit()
+        # Re-enable FK enforcement now the consistent (project_id, default) pair
+        # is in place.
+        conn.execute("PRAGMA foreign_keys = ON")
     finally:
         conn.close()
 


### PR DESCRIPTION
## Summary
Fixes the two bugs that disabled W1 tenant-stamping (`vnx migrate` runs `run_tenant_stamp=False`): (1) `_rebuild_table_phase1` now widens child FKs that reference a parent key when that key is widened to a composite (via `PRAGMA foreign_key_list`), so `foreign_key_check` passes; (2) `pool_config` seed is deduped/idempotent so `_bootstrap_runtime_dbs` and migration 0020 no longer collide on the UNIQUE. **W1 stays DISABLED in `vnx migrate`** — this makes W1 CORRECT so the operator can re-enable it later (with a backup); it does NOT re-enable it (re-enabling runs destructive table-rebuilds = a separate operator step).

## Changes
- `scripts/lib/tenant_stamping.py` (+108): `widened_keys` threading + child-FK-widening in the Phase-1 rebuild. Data-preserving (widens constraints, copies rows).
- `vnx_cli/commands/init_cmd.py` (+86): idempotent pool_config seed (no double-seed collision).
- Tests (+352): FK-widening → foreign_key_check clean + all rows retained; pool_config no collision; full W1 3-phase run on a fixture legacy store completes.

## Verification
89 tests pass. `migrate.py` untouched → W1 remains disabled. Non-destructive (no DROP/DELETE in the rebuild).

## Open Items
- Re-enable W1 in `vnx migrate` (flip `run_tenant_stamp=True`) is an operator follow-up — it runs table-rebuilds, so do it with a store backup.

Track: w1-tenant-stamping-fk-widening-fix · Dispatch: 20260710-075100-w1fix-fkwiden

🤖 Generated with [Claude Code](https://claude.com/claude-code)