### PR TITLE
feat(fabric): VNX_DATA_DIR_GUARD startup guard — warn-default (fabric-hardening Phase-0)

### DIFF
--- a/scripts/lib/data_dir_guard.py
+++ b/scripts/lib/data_dir_guard.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""VNX data-dir / project_id consistency guard (ADR-028 Phase-0).
+
+Advisory by default: warns when the resolved VNX_DATA_DIR does not belong to
+the project identified by ``.vnx-project-id`` / ``VNX_PROJECT_ID``.  When
+``VNX_DATA_DIR_GUARD=enforce`` the same check aborts startup.
+
+This is intentionally separate from path resolution so it can be imported and
+called at the natural startup point (``vnx_paths.resolve_paths()``) without
+duplicating path logic.
+"""
+from __future__ import annotations
+
+import os
+import warnings
+from pathlib import Path
+from typing import Optional
+
+from project_root import resolve_central_data_dir, resolve_project_id
+from vnx_ids import PROJECT_ID_RE
+
+
+class VNXDataDirMismatchWarning(UserWarning):
+    """Emitted when the resolved data-dir does not match the resolved project_id."""
+
+
+def _guard_mode() -> str:
+    raw = os.environ.get("VNX_DATA_DIR_GUARD", "warn").lower().strip()
+    if raw in ("off", "warn", "enforce"):
+        return raw
+    return "warn"
+
+
+def _expected_central_dir(project_id: str) -> Path:
+    return resolve_central_data_dir(project_id).resolve()
+
+
+def _is_under_central_dir(resolved: Path, expected: Path) -> bool:
+    if resolved == expected:
+        return True
+    expected_prefix = str(expected) + os.sep
+    return str(resolved).startswith(expected_prefix)
+
+
+def check_data_dir_project_id_guard(
+    data_dir: str | Path,
+    project_id: Optional[str] = None,
+) -> None:
+    """Check that ``data_dir`` belongs to ``project_id``'s central data directory.
+
+    Behavior is controlled by ``VNX_DATA_DIR_GUARD``:
+      * ``off``    — no check.
+      * ``warn``   — emit a ``VNXDataDirMismatchWarning`` on mismatch (default).
+      * ``enforce`` — raise ``RuntimeError`` on mismatch.
+
+    If ``project_id`` is not supplied it is resolved from the environment / marker
+    file via ``project_root.resolve_project_id()``.  A missing or invalid
+    project_id is treated as "cannot verify" and the guard skips silently rather
+    than fabricating a false mismatch.
+
+    Args:
+        data_dir: The resolved VNX_DATA_DIR to check.
+        project_id: Optional explicit project_id.  When omitted the ambient
+                    project_id is resolved.
+
+    Raises:
+        RuntimeError: In ``enforce`` mode when the data-dir is not under the
+                      expected central directory for the resolved project_id.
+    """
+    mode = _guard_mode()
+    if mode == "off":
+        return
+
+    resolved = Path(data_dir).expanduser().resolve()
+
+    pid = project_id
+    if pid is None:
+        try:
+            pid = resolve_project_id()
+        except RuntimeError:
+            return
+    pid = pid.strip()
+    if not pid or not PROJECT_ID_RE.match(pid):
+        return
+
+    expected = _expected_central_dir(pid)
+    if _is_under_central_dir(resolved, expected):
+        return
+
+    msg = (
+        f"VNX data-dir mismatch: resolved data-dir {resolved} does not belong to "
+        f"project {pid!r} (expected central dir {expected}). "
+        "Running with the wrong data directory can write receipts/state into "
+        "another project's store or a stray repo-local tree. "
+        "Fix: ensure VNX_PROJECT_ID matches the intended project, add a "
+        ".vnx-project-id marker in the project root, or stop pinning a "
+        "repo-local VNX_DATA_DIR / VNX_STATE_DIR. "
+        "Set VNX_DATA_DIR_GUARD=enforce to abort on this condition, "
+        "or =off to silence this warning."
+    )
+
+    if mode == "enforce":
+        raise RuntimeError(msg)
+
+    warnings.warn(VNXDataDirMismatchWarning(msg), stacklevel=2)

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -24,6 +24,8 @@ if _lib not in _sys.path:
 # Single source of truth — do not redefine; import from vnx_ids.
 from vnx_ids import PROJECT_ID_RE as _PROJECT_ID_RE
 
+import data_dir_guard
+
 log = logging.getLogger(__name__)
 
 
@@ -349,7 +351,9 @@ def resolve_data_root(project_root) -> Path:
     """
     project_root = Path(project_root).expanduser().resolve()
     pid = _resolve_state_project_id(project_root)
-    return _resolve_state_root(pid, project_root)
+    data_dir = _resolve_state_root(pid, project_root)
+    data_dir_guard.check_data_dir_project_id_guard(data_dir, pid)
+    return data_dir
 
 
 def resolve_paths() -> Dict[str, str]:
@@ -372,6 +376,7 @@ def resolve_paths() -> Dict[str, str]:
         )
     _state_project_id = _resolve_state_project_id(project_root)
     vnx_data_dir = _resolve_state_root(_state_project_id, project_root)
+    data_dir_guard.check_data_dir_project_id_guard(vnx_data_dir, _state_project_id)
 
     paths = {
         "VNX_HOME": str(vnx_home),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,9 @@ import pytest
 _CONFTEST_ISOLATION_TMP = tempfile.mkdtemp(prefix="vnx_conftest_")
 os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
 os.environ["VNX_DATA_DIR"] = _CONFTEST_ISOLATION_TMP
+# Keep the new data-dir guard from emitting warnings during normal tests.
+# Tests that exercise the guard override this explicitly.
+os.environ.setdefault("VNX_DATA_DIR_GUARD", "off")
 
 # Make scripts/lib importable for all tests
 _LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"

--- a/tests/test_data_dir_guard.py
+++ b/tests/test_data_dir_guard.py
@@ -1,0 +1,214 @@
+"""Tests for the VNX data-dir / project_id guard (ADR-028 Phase-0).
+
+The guard is ``warn`` by default in production but ``off`` by default in the
+shared ``conftest.py`` so the existing suite does not drown in mismatch warnings
+for its temp-data isolation.  These tests override the flag explicitly.
+"""
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pytest
+
+import data_dir_guard
+import vnx_paths
+from data_dir_guard import VNXDataDirMismatchWarning, check_data_dir_project_id_guard
+
+
+def _fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` to a temp directory for the test."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def _clean_data_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove env vars that would interfere with explicit data-dir resolution."""
+    for key in (
+        "VNX_DATA_DIR",
+        "VNX_DATA_DIR_EXPLICIT",
+        "VNX_DATA_HOME",
+        "XDG_DATA_HOME",
+        "VNX_STATE_DIR",
+        "VNX_PROJECT_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestGuardDirect:
+    def test_off_mode_is_silent_on_mismatch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        home = _fake_home(tmp_path, monkeypatch)
+        wrong = tmp_path / "other-project" / ".vnx-data"
+        wrong.mkdir(parents=True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            check_data_dir_project_id_guard(wrong, "myproj")
+
+        assert len(caught) == 0
+
+    def test_warn_mode_emits_warning_on_mismatch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        home = _fake_home(tmp_path, monkeypatch)
+        wrong = tmp_path / "other-project" / ".vnx-data"
+        wrong.mkdir(parents=True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            check_data_dir_project_id_guard(wrong, "myproj")
+
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, VNXDataDirMismatchWarning)
+        msg = str(caught[0].message)
+        assert "myproj" in msg
+        assert str(wrong.resolve()) in msg
+        assert "expected central dir" in msg
+
+    def test_warn_mode_does_not_abort(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        wrong = tmp_path / "wrong"
+        wrong.mkdir()
+        # Must not raise.
+        check_data_dir_project_id_guard(wrong, "myproj")
+
+    def test_enforce_mode_raises_on_mismatch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        home = _fake_home(tmp_path, monkeypatch)
+        wrong = tmp_path / "other-project" / ".vnx-data"
+        wrong.mkdir(parents=True)
+
+        with pytest.raises(RuntimeError, match="VNX data-dir mismatch"):
+            check_data_dir_project_id_guard(wrong, "myproj")
+
+    @pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+    def test_matching_central_dir_is_silent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", mode)
+        home = _fake_home(tmp_path, monkeypatch)
+        central = home / ".vnx-data" / "myproj"
+        central.mkdir(parents=True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            check_data_dir_project_id_guard(central, "myproj")
+            check_data_dir_project_id_guard(central / "state", "myproj")
+
+        assert len(caught) == 0
+
+    def test_enforce_mode_missing_project_id_skips(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """No marker / env project_id must not be treated as a mismatch."""
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.chdir(tmp_path)  # no .vnx-project-id here
+        wrong = tmp_path / "wrong"
+        wrong.mkdir()
+
+        # Should skip, not raise.
+        check_data_dir_project_id_guard(wrong, None)
+
+    def test_invalid_project_id_skips(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        wrong = tmp_path / "wrong"
+        wrong.mkdir()
+
+        check_data_dir_project_id_guard(wrong, "Bad_ID_123")
+
+    def test_default_mode_is_warn(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        # conftest sets this to off; deleting it reverts to production default.
+        monkeypatch.delenv("VNX_DATA_DIR_GUARD", raising=False)
+        home = _fake_home(tmp_path, monkeypatch)
+        wrong = tmp_path / "other" / ".vnx-data"
+        wrong.mkdir(parents=True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            check_data_dir_project_id_guard(wrong, "myproj")
+
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, VNXDataDirMismatchWarning)
+
+
+class TestGuardViaVnxPaths:
+    def test_resolve_data_root_matching_central_no_warning(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        _clean_data_env(monkeypatch)
+        home = _fake_home(tmp_path, monkeypatch)
+        project_root = tmp_path / "myproj"
+        project_root.mkdir()
+        (project_root / ".vnx-project-id").write_text("myproj\n")
+        central = home / ".vnx-data" / "myproj"
+        central.mkdir(parents=True)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = vnx_paths.resolve_data_root(project_root)
+
+        assert result == central.resolve()
+        assert len(caught) == 0
+
+    def test_resolve_paths_mismatch_warns_but_does_not_abort(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        _clean_data_env(monkeypatch)
+        home = _fake_home(tmp_path, monkeypatch)
+        central = home / ".vnx-data" / "myproj"
+        central.mkdir(parents=True)
+        wrong = tmp_path / "wrong-data"
+        wrong.mkdir()
+
+        monkeypatch.setenv("VNX_PROJECT_ID", "myproj")
+        monkeypatch.setenv("VNX_DATA_DIR", str(wrong))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            paths = vnx_paths.resolve_paths()
+
+        assert paths["VNX_DATA_DIR"] == str(wrong.resolve())
+        assert len(caught) == 1
+        assert issubclass(caught[0].category, VNXDataDirMismatchWarning)
+
+    def test_resolve_paths_enforce_aborts_on_mismatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        _clean_data_env(monkeypatch)
+        home = _fake_home(tmp_path, monkeypatch)
+        central = home / ".vnx-data" / "myproj"
+        central.mkdir(parents=True)
+        wrong = tmp_path / "wrong-data"
+        wrong.mkdir()
+
+        monkeypatch.setenv("VNX_PROJECT_ID", "myproj")
+        monkeypatch.setenv("VNX_DATA_DIR", str(wrong))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with pytest.raises(RuntimeError, match="VNX data-dir mismatch"):
+            vnx_paths.resolve_paths()
+
+    def test_resolve_paths_off_silent_on_mismatch(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        _clean_data_env(monkeypatch)
+        home = _fake_home(tmp_path, monkeypatch)
+        central = home / ".vnx-data" / "myproj"
+        central.mkdir(parents=True)
+        wrong = tmp_path / "wrong-data"
+        wrong.mkdir()
+
+        monkeypatch.setenv("VNX_PROJECT_ID", "myproj")
+        monkeypatch.setenv("VNX_DATA_DIR", str(wrong))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            paths = vnx_paths.resolve_paths()
+
+        assert paths["VNX_DATA_DIR"] == str(wrong.resolve())
+        assert len(caught) == 0


### PR DESCRIPTION
## Summary
Adds a data-dir/project_id mismatch guard (fabric-hardening Phase-0): warns (default) or aborts (enforce) when the resolved `VNX_DATA_DIR` does not belong to the project's `.vnx-project-id` — the exact split-brain class behind OI-894 / the central-mode drift. `VNX_DATA_DIR_GUARD` has 3 modes, **default `warn`** (advisory→required bootstrap): a mismatch logs an actionable warning but NEVER aborts by default. `enforce` raises; `off` disables. Reuses the existing resolvers; does NOT touch the dual-write paths (that's the separate P5 architectural decision).

## Changes
- `scripts/lib/data_dir_guard.py` (+105): `check_data_dir_project_id_guard(data_dir, project_id)` with 3 modes.
- `scripts/lib/vnx_paths.py` (+7): calls the guard at the data-dir resolution points (warn-default, so resolution is unaffected).
- Tests (+214): matching dir → no warn/abort (all modes); mismatch → warn logs / enforce raises / off silent; missing `.vnx-project-id` handled gracefully.

## Verification
14 tests pass. Default `warn` proven (no abort); path resolution unchanged in default mode.

Track: fabric-hardening-phase0 (data-dir guard part) · Dispatch: 20260710-081438-datadir-guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)