### PR TITLE
fix(governance): hardened hash-chain primitive with origin-pinning (supersedes #1085 verify)

### DIFF
--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -23,6 +23,21 @@ Security note (origin pinning, PR #1085 fix):
 - When no origin record exists the verifier falls back to strict mode: a chained
   ledger must start at line 1 with a GENESIS-anchored entry and every entry must
   carry `prev_hash`.
+- The origin record is WRITE-ONCE (`ON CONFLICT DO NOTHING`): once pinned it can
+  never be overwritten, so an attacker cannot re-record a forged origin after
+  stripping the prefix (PR #1086 fix).
+
+Threat model + residual limit (honest scope):
+- This detects ACCIDENTAL corruption and NAIVE tampering (prefix strip/delete +
+  re-anchor, forged-origin overwrite) against a ledger whose trusted origin row
+  is intact.
+- It does NOT fully defend a local attacker who both DELETES the origin row from
+  `runtime_coordination.db` AND re-chains the entire remaining ledger from a new
+  GENESIS: strict-mode then accepts the re-chained file. True tamper-EVIDENCE
+  against a local attacker with write access to both the ledger and the origin
+  store requires an EXTERNAL append-only / signed anchor (periodic head-hash
+  seal), tracked as ADR-029 (`chain_epoch_seal`), out of scope for this fix.
+  The flag stays default-off (`VNX_RECEIPT_HASH_CHAIN`) until that anchor lands.
 """
 from __future__ import annotations
 
@@ -82,11 +97,20 @@ def _record_chain_origin(
     origin_db.parent.mkdir(parents=True, exist_ok=True)
     with sqlite3.connect(str(origin_db)) as conn:
         _init_origin_store(conn)
+        # WRITE-ONCE: the chain origin is immutable history — the first chained
+        # entry of a ledger. INSERT OR REPLACE would let a later append overwrite
+        # the pinned origin, which defeats the pin (an attacker could strip the
+        # prefix, append a new "first" chained entry, and re-record the origin).
+        # ON CONFLICT DO NOTHING keeps the first-recorded origin forever; a
+        # re-record attempt is silently ignored so verify_chain still checks the
+        # ledger against the ORIGINAL origin. A genuine new epoch uses a new
+        # ledger file (new path = new row), so this never blocks legitimate use.
         conn.execute(
             f"""
-            INSERT OR REPLACE INTO {_ORIGIN_TABLE}
+            INSERT INTO {_ORIGIN_TABLE}
                 (ledger_path, line_number, entry_hash, recorded_at)
             VALUES (?, ?, ?, ?)
+            ON CONFLICT(ledger_path) DO NOTHING
             """,
             (
                 str(ledger_path.resolve()),
@@ -103,14 +127,21 @@ def _read_chain_origin(origin_db: Path, ledger_path: Path) -> dict | None:
     if not origin_db.exists():
         return None
     with sqlite3.connect(str(origin_db)) as conn:
-        cur = conn.execute(
-            f"""
-            SELECT line_number, entry_hash FROM {_ORIGIN_TABLE}
-            WHERE ledger_path = ?
-            """,
-            (str(ledger_path.resolve()),),
-        )
-        row = cur.fetchone()
+        try:
+            cur = conn.execute(
+                f"""
+                SELECT line_number, entry_hash FROM {_ORIGIN_TABLE}
+                WHERE ledger_path = ?
+                """,
+                (str(ledger_path.resolve()),),
+            )
+            row = cur.fetchone()
+        except sqlite3.OperationalError:
+            # The origin table has never been created in this coordination DB
+            # (e.g. a pre-existing runtime_coordination.db that predates chaining,
+            # or no ledger has recorded an origin yet). Treat as "no origin
+            # recorded" -> verify_chain uses strict mode; never crash the verify.
+            return None
         if row is None:
             return None
         return {"line_number": row[0], "entry_hash": row[1]}

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -11,16 +11,31 @@ Event-type conventions per session-handoff:
 
 Per ADR-005: NDJSON-first principle preserved. Hash-chain is ADDITIVE metadata,
 not a replacement.
+
+Security note (origin pinning, PR #1085 fix):
+- The first chained entry in a ledger is the chain origin. Its file line number
+  and canonical hash are recorded in the project's trusted
+  `runtime_coordination.db` when chaining is first adopted.
+- `verify_chain` reads that record and rejects any ledger whose observed chain
+  origin is later than (or different from) the recorded origin. This closes the
+  prefix-strip / prefix-deletion + re-anchor bypass where an attacker removes
+  entries from the start of the ledger and rewinds the chain to GENESIS_HASH.
+- When no origin record exists the verifier falls back to strict mode: a chained
+  ledger must start at line 1 with a GENESIS-anchored entry and every entry must
+  carry `prev_hash`.
 """
 from __future__ import annotations
 
 import hashlib
 import json
+import sqlite3
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
 
 GENESIS_HASH = "0" * 64  # Sentinel for first entry in chain
+_ORIGIN_TABLE = "vnx_chain_origin"
 
 
 def canonical_json(obj: dict) -> str:
@@ -38,6 +53,86 @@ def compute_entry_hash(entry: dict) -> str:
     return hashlib.sha256(canonical_json(entry).encode("utf-8")).hexdigest()
 
 
+def _origin_store_path(ledger_path: Path) -> Path:
+    """Trusted SQLite store for the chain origin of this ledger."""
+    return ledger_path.parent / "runtime_coordination.db"
+
+
+def _init_origin_store(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"""
+        CREATE TABLE IF NOT EXISTS {_ORIGIN_TABLE} (
+            ledger_path TEXT PRIMARY KEY,
+            line_number INTEGER NOT NULL,
+            entry_hash TEXT NOT NULL,
+            recorded_at TEXT NOT NULL
+        )
+        """
+    )
+    conn.commit()
+
+
+def _record_chain_origin(
+    origin_db: Path,
+    ledger_path: Path,
+    line_number: int,
+    entry_hash: str,
+) -> None:
+    """Persist the chain origin for a ledger in the trusted SQLite store."""
+    origin_db.parent.mkdir(parents=True, exist_ok=True)
+    with sqlite3.connect(str(origin_db)) as conn:
+        _init_origin_store(conn)
+        conn.execute(
+            f"""
+            INSERT OR REPLACE INTO {_ORIGIN_TABLE}
+                (ledger_path, line_number, entry_hash, recorded_at)
+            VALUES (?, ?, ?, ?)
+            """,
+            (
+                str(ledger_path.resolve()),
+                line_number,
+                entry_hash,
+                datetime.now(timezone.utc).isoformat(),
+            ),
+        )
+        conn.commit()
+
+
+def _read_chain_origin(origin_db: Path, ledger_path: Path) -> dict | None:
+    """Return the recorded origin for a ledger, or None if not recorded."""
+    if not origin_db.exists():
+        return None
+    with sqlite3.connect(str(origin_db)) as conn:
+        cur = conn.execute(
+            f"""
+            SELECT line_number, entry_hash FROM {_ORIGIN_TABLE}
+            WHERE ledger_path = ?
+            """,
+            (str(ledger_path.resolve()),),
+        )
+        row = cur.fetchone()
+        if row is None:
+            return None
+        return {"line_number": row[0], "entry_hash": row[1]}
+
+
+def _has_chained_entries(path: Path) -> bool:
+    """True if the ledger already contains at least one entry with prev_hash."""
+    if not path.exists() or path.stat().st_size == 0:
+        return False
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                if "prev_hash" in json.loads(line):
+                    return True
+            except json.JSONDecodeError:
+                continue
+    return False
+
+
 def append_chained_entry(
     path: Path,
     entry: dict,
@@ -48,7 +143,10 @@ def append_chained_entry(
 
     Returns the hash of the newly-appended entry.
 
-    If file is empty/missing: uses GENESIS_HASH as prev_hash.
+    If the ledger has no chained entries yet (empty, missing, or only plain
+    NDJSON lines), the new entry becomes the chain origin: its prev_hash is
+    GENESIS_HASH and its line number + canonical hash are recorded in the
+    project's trusted origin store (`runtime_coordination.db`).
 
     Event-type conventions:
     - None: regular entry (default)
@@ -57,10 +155,15 @@ def append_chained_entry(
     - 'redaction': must include 'redacts_hash' field; body should be opaque
     - 'tombstone': must include 'tombstones_hash' field
     """
+    already_chained = _has_chained_entries(path)
+
     if event_type == "backfill":
         prev_hash = GENESIS_HASH
+    elif already_chained:
+        prev_hash = _read_last_hash(path)
     else:
-        prev_hash = _read_last_hash(path) or GENESIS_HASH
+        # First chained entry in this ledger — starts a new epoch at GENESIS.
+        prev_hash = GENESIS_HASH
 
     chained = {**entry, "prev_hash": prev_hash}
     if event_type:
@@ -74,10 +177,22 @@ def append_chained_entry(
         raise ValueError("tombstone event requires 'tombstones_hash' field")
 
     path.parent.mkdir(parents=True, exist_ok=True)
+
+    # Determine the line number this entry will occupy after append.
+    next_line = 1
+    if path.exists():
+        with path.open("r", encoding="utf-8") as f:
+            next_line = sum(1 for _ in f) + 1
+
     with path.open("a", encoding="utf-8") as f:
         f.write(json.dumps(chained) + "\n")
 
-    return compute_entry_hash(chained)
+    new_hash = compute_entry_hash(chained)
+
+    if not already_chained:
+        _record_chain_origin(_origin_store_path(path), path, next_line, new_hash)
+
+    return new_hash
 
 
 def _read_last_hash(path: Path) -> str | None:
@@ -114,15 +229,23 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
     - "unchained": no entry in the file carries a prev_hash field; chaining
       was never enabled (VNX_CHAIN_RECEIPTS is off by default).  Integrity
       cannot be verified — this is NOT an error.  is_valid is True.
-    - "verified": every entry carries prev_hash and the chain is intact.
-      is_valid is True.
+    - "verified": the chain from the recorded origin onward is intact.
+      is_valid is True.  A ledger with an unchained prefix before the recorded
+      origin is also reported "verified" (segmented ledger / mid-ledger
+      adoption).
     - "broken": chain is present but has integrity violations (tampered,
-      inserted, or partially chained — some entries carry prev_hash while
-      others do not).  is_valid is False.
+      inserted, partially chained, or the observed origin differs from the
+      recorded origin).  is_valid is False.
 
-    A partially-chained ledger (some entries with prev_hash, some without)
-    is classified as "broken", not "unchained".  A ledger must be either
-    fully unchained or fully chained to be considered healthy.
+    When a chain origin has been recorded in the trusted origin store
+    (`runtime_coordination.db`) the verifier tolerates an unchained prefix
+    before that origin, but the entry at the recorded origin line MUST match
+    the recorded hash and anchor to GENESIS_HASH.  Every entry after the
+    origin MUST carry prev_hash == expected_prev_hash.
+
+    When no origin record exists the verifier uses strict mode: a chained
+    ledger must start at line 1 with a GENESIS-anchored entry and every entry
+    must carry prev_hash.
 
     violations_list contains dicts with: line_number, expected_prev_hash,
     actual_prev_hash (and optionally 'error' or 'note').
@@ -166,11 +289,110 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
         return (True, [], "unchained")
 
     # At least one entry has prev_hash (or there are parse errors mixed in).
-    # Enforce full-chain integrity.  A partially-chained ledger (some entries
-    # lack prev_hash while others have it) is a real violation — broken.
     violations: list[dict] = list(parse_errors)
-    expected_prev = GENESIS_HASH
+    origin = _read_chain_origin(_origin_store_path(path), path)
 
+    if origin is not None:
+        # Origin-aware mode: tolerate an unchained prefix before the recorded
+        # origin, but pin the origin itself and verify the suffix.
+        _verify_with_origin(path, entries, origin, violations)
+    else:
+        # Strict mode: no unchained prefix allowed for a chained ledger.
+        _verify_strict(entries, chained_count, total, violations)
+
+    if violations:
+        return (False, violations, "broken")
+
+    return (True, [], "verified")
+
+
+def _verify_with_origin(
+    path: Path,
+    entries: list[tuple[int, dict]],
+    origin: dict,
+    violations: list[dict],
+) -> None:
+    """Verify entries from the recorded origin onward.
+
+    Mutates ``violations`` in place. Entries before the recorded origin are
+    tolerated as a legitimate unchained prefix.
+    """
+    origin_line = origin["line_number"]
+    origin_hash = origin["entry_hash"]
+
+    origin_entry = None
+    for line_no, entry in entries:
+        if line_no == origin_line:
+            origin_entry = entry
+            break
+
+    if origin_entry is None:
+        violations.append({
+            "line_number": origin_line,
+            "note": "recorded chain origin line not found in ledger (prefix stripped?)",
+        })
+        return
+
+    if origin_entry.get("prev_hash") != GENESIS_HASH:
+        violations.append({
+            "line_number": origin_line,
+            "expected_prev_hash": GENESIS_HASH,
+            "actual_prev_hash": origin_entry.get("prev_hash"),
+            "note": "recorded chain origin must anchor to GENESIS_HASH",
+        })
+
+    actual_hash = compute_entry_hash(origin_entry)
+    if actual_hash != origin_hash:
+        violations.append({
+            "line_number": origin_line,
+            "expected_entry_hash": origin_hash,
+            "actual_entry_hash": actual_hash,
+            "note": "recorded chain origin hash mismatch (prefix re-anchored?)",
+        })
+
+    expected_prev = GENESIS_HASH
+    found_origin = False
+    for line_no, entry in entries:
+        if line_no < origin_line:
+            continue
+        if line_no == origin_line:
+            found_origin = True
+            expected_prev = compute_entry_hash(entry)
+            continue
+        if not found_origin:
+            continue
+        actual_prev = entry.get("prev_hash")
+        if actual_prev != expected_prev:
+            violations.append({
+                "line_number": line_no,
+                "expected_prev_hash": expected_prev,
+                "actual_prev_hash": actual_prev,
+            })
+        expected_prev = compute_entry_hash(entry)
+
+
+def _verify_strict(
+    entries: list[tuple[int, dict]],
+    chained_count: int,
+    total: int,
+    violations: list[dict],
+) -> None:
+    """Strict verification for ledgers with no recorded origin.
+
+    A chained ledger must start at line 1 with a GENESIS-anchored entry and
+    every entry must carry prev_hash.
+    """
+    if chained_count > 0:
+        first_line_no, first_entry = entries[0]
+        if first_entry.get("prev_hash") != GENESIS_HASH:
+            violations.append({
+                "line_number": first_line_no,
+                "expected_prev_hash": GENESIS_HASH,
+                "actual_prev_hash": first_entry.get("prev_hash"),
+                "note": "chained ledger must start with GENESIS-anchored entry (origin not recorded)",
+            })
+
+    expected_prev = GENESIS_HASH
     for line_no, entry in entries:
         actual_prev = entry.get("prev_hash")
 
@@ -193,24 +415,18 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
 
         expected_prev = compute_entry_hash(entry)
 
-    if violations:
-        return (False, violations, "broken")
-
-    # All parseable entries chained and intact.
     if chained_count < total:
         # Partial chain detected even with no hash mismatches.  This guard is
         # LOAD-BEARING for the edge case where the FIRST entry carries no
         # prev_hash (allowed by the first-entry branch) while later entries
         # hash-link correctly to their predecessor — the loop produces zero
         # violations there; only this count check catches the partial chain.
-        return (False, [{
+        violations.append({
             "note": (
                 f"partial chain: {chained_count}/{total} entries carry prev_hash; "
                 "ledger must be fully unchained or fully chained"
             )
-        }], "broken")
-
-    return (True, [], "verified")
+        })
 
 
 def walk_chain(path: Path) -> Iterator[tuple[int, dict, str]]:

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -19,6 +19,8 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
+import sqlite3
+
 from ndjson_hash_chain import (
     GENESIS_HASH,
     append_chained_entry,
@@ -26,6 +28,9 @@ from ndjson_hash_chain import (
     compute_entry_hash,
     verify_chain,
     walk_chain,
+    _origin_store_path,
+    _read_chain_origin,
+    _record_chain_origin,
 )
 
 
@@ -403,3 +408,48 @@ def test_verify_chain_mid_ledger_adoption_is_verified(tmp_path):
     assert ok is True
     assert status == "verified"
     assert violations == []
+
+
+# ---------------------------------------------------------------------------
+# Origin-store hardening (PR #1086 fix: write-once anchor + missing-table)
+# ---------------------------------------------------------------------------
+def test_origin_is_write_once_forged_rerecord_ignored(tmp_path):
+    """A recorded chain origin is immutable: a later re-record is ignored.
+
+    Closes the mutable-origin bypass — an attacker who strips the prefix and
+    appends a new 'first' chained entry must NOT be able to overwrite the pinned
+    origin. The first-recorded origin wins forever.
+    """
+    p = tmp_path / "ledger.ndjson"
+    for i in range(4):
+        append_chained_entry(p, {"seq": i})
+    origin_db = _origin_store_path(p)
+    original = _read_chain_origin(origin_db, p)
+    assert original is not None
+
+    # Attacker tries to move the pinned origin forward with a forged hash.
+    _record_chain_origin(origin_db, p, line_number=3, entry_hash="deadbeef" * 8)
+
+    after = _read_chain_origin(origin_db, p)
+    assert after == original, "origin must be write-once (forged re-record ignored)"
+
+
+def test_missing_origin_table_falls_back_to_strict_no_crash(tmp_path):
+    """A coordination DB without the origin table must not crash verify_chain.
+
+    Pre-existing runtime_coordination.db files predate the origin table; the
+    verifier must treat a missing table as 'no origin recorded' and fall back to
+    strict mode instead of raising sqlite3.OperationalError.
+    """
+    p = tmp_path / "ledger.ndjson"
+    for i in range(3):
+        append_chained_entry(p, {"seq": i})
+    origin_db = _origin_store_path(p)
+    # Simulate a coordination DB that exists but has no origin table.
+    with sqlite3.connect(str(origin_db)) as conn:
+        conn.execute("DROP TABLE IF EXISTS vnx_chain_origin")
+        conn.commit()
+
+    # Must not raise; a genesis-anchored full chain passes strict mode.
+    ok, violations, status = verify_chain(p)
+    assert ok is True, f"strict fallback should verify a genesis chain: {status} {violations}"

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -312,3 +312,94 @@ def test_verify_chain_missing_file_is_unchained(tmp_path):
     assert ok is True
     assert violations == []
     assert status == "unchained"
+
+
+# ---------------------------------------------------------------------------
+# Origin pinning: prefix-strip / prefix-deletion attack regression
+# ---------------------------------------------------------------------------
+
+
+def test_verify_chain_prefix_deletion_reanchor_attack_is_broken(tmp_path):
+    """PR #1085 bypass regression: attacker deletes a prefix and re-anchors.
+
+    A fully-chained ledger pins its origin at line 1. An attacker holding a
+    valid ledger can delete the first k+1 entries and rewrite the new first
+    entry to use GENESIS_HASH; the suffix still links correctly because
+    canonical_json excludes prev_hash. Without origin pinning this verifies
+    as "verified"; with pinning the recorded origin hash no longer matches
+    the observed first chained entry and the ledger is "broken".
+    """
+    p = tmp_path / "attack.ndjson"
+    for i in range(5):
+        append_chained_entry(p, {"seq": i, "event": "dispatch", "id": f"e{i}"})
+
+    # Sanity: intact chain verifies.
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert status == "verified"
+
+    lines = p.read_text().splitlines()
+    # Delete the prefix entries 0 and 1.
+    del lines[0:2]
+    # Re-anchor the new first entry (originally entry 2) to GENESIS_HASH.
+    reanchored = json.loads(lines[0])
+    reanchored["prev_hash"] = GENESIS_HASH
+    lines[0] = json.dumps(reanchored)
+    p.write_text("\n".join(lines) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert any("origin" in str(v).lower() for v in violations)
+
+
+def test_verify_chain_stripped_prefix_with_reanchor_is_broken(tmp_path):
+    """Variant: prev_hash is stripped from a prefix but the lines remain.
+
+    The recorded origin is at line 1. Stripping prev_hash from entries 0..k
+    moves the observed switch point to line k+2. verify_chain detects the
+    origin line mismatch.
+    """
+    p = tmp_path / "strip-attack.ndjson"
+    for i in range(5):
+        append_chained_entry(p, {"seq": i, "event": "dispatch", "id": f"e{i}"})
+
+    lines = p.read_text().splitlines()
+    # Strip prev_hash from entries 0 and 1.
+    for i in range(2):
+        stripped = json.loads(lines[i])
+        stripped.pop("prev_hash", None)
+        lines[i] = json.dumps(stripped)
+    # Re-anchor entry 2 (now the switch point) to GENESIS.
+    reanchored = json.loads(lines[2])
+    reanchored["prev_hash"] = GENESIS_HASH
+    lines[2] = json.dumps(reanchored)
+    p.write_text("\n".join(lines) + "\n")
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert any("origin" in str(v).lower() for v in violations)
+
+
+def test_verify_chain_mid_ledger_adoption_is_verified(tmp_path):
+    """Approach B preserves genuine mid-ledger adoption.
+
+    A legacy unchained prefix (chaining never adopted before line N) is valid
+    when the chain origin was recorded at the adoption point: entries before
+    the origin are tolerated, entries from the origin onward must chain.
+    """
+    p = tmp_path / "mid-adopt.ndjson"
+    # Legacy unchained prefix.
+    for i in range(3):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i, "event": "legacy"}) + "\n")
+
+    # First chained entry starts a new epoch.
+    append_chained_entry(p, {"seq": 3, "event": "dispatch"})
+    append_chained_entry(p, {"seq": 4, "event": "dispatch"})
+
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert status == "verified"
+    assert violations == []


### PR DESCRIPTION
## Summary
Ships the hash-chain NDJSON primitive (`scripts/lib/ndjson_hash_chain.py`) with the **origin-pinning fix** that closes the `verify_chain` prefix-strip bypass codex flagged on #1085. The chain origin (first-chained line number + canonical hash) is recorded in the trusted `runtime_coordination.db`; `verify_chain` rejects any ledger whose observed switch point is later than or differs from the recorded origin, so a stripped/deleted prefix + re-anchor is detected as `broken`. Approach B (per the review): a sidecar file an attacker could rewrite is not used.

Self-contained: touches only the primitive + its tests. The `emit_dispatch_receipt` wiring is a separate follow-up on top of this hardened signature (append_chained_entry no longer takes `prev_hash`; it derives + pins it internally).

## Changes
- `scripts/lib/ndjson_hash_chain.py`: trusted origin store in `runtime_coordination.db`; `append_chained_entry` records origin on first chained entry (incl. mid-ledger adoption); `verify_chain` pins the origin, strict fallback when no origin record exists.
- `tests/test_ndjson_hash_chain.py`: +3 tests incl. the codex attack repro (`prefix deletion + re-anchor` → `broken`), stripped-prefix repro, and genuine mid-ledger-adoption still `verified`.

## Verification
`pytest tests/test_ndjson_hash_chain.py` → 23 passed. Flag stays default-off (`VNX_RECEIPT_HASH_CHAIN`).

## Open Items
- Follow-up PR: wire `emit_dispatch_receipt` to the hardened `append_chained_entry` (drop the old `prev_hash` arg). Tracked.
- `base_ref` was not honored by the dispatch door (worker branched from main despite base_ref set) — separate fabric bug to track.