### PR TITLE
fix(db): rotate quality_intelligence backups, keep last N (VNX_DB_BACKUP_KEEP=3)

### DIFF
--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -7,7 +7,9 @@ Purpose: Initialize SQLite Quality Intelligence Database from schema
 
 from __future__ import annotations  # PEP 563: lazy annotation evaluation — Python 3.9 compat
 
+import os
 import sqlite3
+import shutil
 import sys
 from pathlib import Path
 from datetime import datetime
@@ -74,6 +76,59 @@ def check_prerequisites() -> bool:
 
     return True
 
+_BACKUP_PREFIX = "quality_intelligence.db.backup_"
+
+
+def _parse_backup_keep(raw: str | None, default: int = 3) -> int:
+    """Return a sane keep count from VNX_DB_BACKUP_KEEP.
+
+    Falls back to ``default`` when the value is unset, invalid, or < 1.
+    Never returns 0 so we never delete the just-made backup.
+    """
+    if raw is None:
+        return default
+    try:
+        value = int(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+    return value if value >= 1 else default
+
+
+def _rotate_quality_db_backups(state_dir: Path, keep: int) -> None:
+    """Keep only the newest ``keep`` quality_intelligence.db.backup_* files.
+
+    Prunes the backup database files plus any matching ``-wal`` / ``-shm``
+    sidecars. Errors are logged but not raised: rotation is best-effort.
+    """
+    keep = _parse_backup_keep(str(keep) if keep is not None else None)
+
+    # Only consider the actual DB backups; sidecars are handled per-backup.
+    backups = [
+        p for p in state_dir.glob(f"{_BACKUP_PREFIX}*")
+        if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
+    ]
+    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+
+    kept = backups[:keep]
+    pruned = backups[keep:]
+
+    if not pruned:
+        log('INFO', f'No old quality_intelligence backups to prune (kept {len(kept)})')
+        return
+
+    for old in pruned:
+        try:
+            old.unlink(missing_ok=True)
+            for suffix in ("-wal", "-shm"):
+                sidecar = state_dir / f"{old.name}{suffix}"
+                sidecar.unlink(missing_ok=True)
+            log('INFO', f'Pruned old backup: {old.name}')
+        except Exception as e:
+            log('WARNING', f'Failed to prune {old.name}: {e}')
+
+    log('INFO', f'Kept {len(kept)} quality_intelligence backup(s): {", ".join(b.name for b in kept)}')
+
+
 def backup_existing_db() -> bool:
     """Backup existing database if it exists"""
     if not DB_PATH.exists():
@@ -87,8 +142,14 @@ def backup_existing_db() -> bool:
         log('INFO', f'Backing up existing database to: {backup_path}')
 
         # Copy file
-        import shutil
         shutil.copy2(DB_PATH, backup_path)
+
+        # Rotate older backups best-effort; never let cleanup abort the migration.
+        try:
+            keep = _parse_backup_keep(os.environ.get("VNX_DB_BACKUP_KEEP"))
+            _rotate_quality_db_backups(STATE_DIR, keep)
+        except Exception as e:
+            log('WARNING', f'Backup rotation failed (backup itself succeeded): {e}')
 
         log('SUCCESS', f'Database backed up successfully')
         return True

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -107,7 +107,13 @@ def _rotate_quality_db_backups(state_dir: Path, keep: int) -> None:
         p for p in state_dir.glob(f"{_BACKUP_PREFIX}*")
         if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
     ]
-    backups.sort(key=lambda p: p.stat().st_mtime, reverse=True)
+    # Sort by the backup timestamp encoded in the filename
+    # (quality_intelligence.db.backup_<YYYYMMDD_HHMMSS>), NOT by mtime:
+    # shutil.copy2 preserves the *source* DB's mtime, so every backup inherits
+    # the live DB's mtime rather than its own creation time. The filename
+    # timestamp is the true, monotonic backup time; the zero-padded
+    # YYYYMMDD_HHMMSS suffix sorts lexicographically in chronological order.
+    backups.sort(key=lambda p: p.name, reverse=True)
 
     kept = backups[:keep]
     pruned = backups[keep:]

--- a/tests/test_db_backup_rotation.py
+++ b/tests/test_db_backup_rotation.py
@@ -167,23 +167,32 @@ def test_backup_rotation_no_op_when_under_limit(tmp_path, monkeypatch):
         assert pb.exists()
 
 
-def test_rotate_helper_prunes_by_mtime_not_by_name_lexicography():
-    """Rotation uses mtime, not lexical filename order."""
+def test_rotate_helper_uses_filename_timestamp_not_mtime():
+    """Rotation ranks backups by the filename timestamp, not mtime.
+
+    shutil.copy2 preserves the *source* DB's mtime, so a newer backup can have
+    an OLDER mtime than an older one. Here the mtime order is deliberately the
+    inverse of the filename-timestamp order: the filename-newest backup
+    (2026-07-04) is given the OLDEST mtime, and the filename-oldest (2026-06-01)
+    the newest mtime. Correct rotation must keep the filename-newest; an
+    mtime-based sort would wrongly keep the stale one and could even delete the
+    just-created backup.
+    """
     state_dir = Path(__file__).resolve().parent / "_rotate_helper_tmp"
     state_dir.mkdir(exist_ok=True)
     try:
-        # Create backups with deliberately inverted lexical-vs-temporal order.
-        old_by_name = state_dir / "quality_intelligence.db.backup_99999999_999999"
-        new_by_name = state_dir / "quality_intelligence.db.backup_00000000_000000"
-        old_by_name.write_text("old")
-        new_by_name.write_text("new")
-        os.utime(old_by_name, (1_000_000_000, 1_000_000_000))
-        os.utime(new_by_name, (2_000_000_000, 2_000_000_000))
+        newest_by_name = state_dir / "quality_intelligence.db.backup_20260704_020001"
+        oldest_by_name = state_dir / "quality_intelligence.db.backup_20260601_020001"
+        newest_by_name.write_text("newest backup")
+        oldest_by_name.write_text("oldest backup")
+        # Inverted mtimes: filename-newest gets the OLDEST mtime.
+        os.utime(newest_by_name, (1_000_000_000, 1_000_000_000))
+        os.utime(oldest_by_name, (2_000_000_000, 2_000_000_000))
 
         qd._rotate_quality_db_backups(state_dir, keep=1)
 
-        assert not old_by_name.exists()
-        assert new_by_name.exists()
+        assert newest_by_name.exists(), "filename-newest backup must be kept"
+        assert not oldest_by_name.exists(), "filename-oldest backup must be pruned"
     finally:
         for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*"):
             p.unlink(missing_ok=True)

--- a/tests/test_db_backup_rotation.py
+++ b/tests/test_db_backup_rotation.py
@@ -1,0 +1,190 @@
+"""Tests for quality_intelligence.db backup rotation (VNX_DB_BACKUP_KEEP)."""
+
+from __future__ import annotations
+
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+_LIB = _SCRIPTS / "lib"
+for _p in (_SCRIPTS, _LIB):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+os.environ.setdefault("VNX_HOME", str(Path(__file__).resolve().parent.parent))
+os.environ.setdefault("VNX_DATA_DIR", str(Path(__file__).resolve().parent.parent / ".vnx-data"))
+os.environ.setdefault("VNX_STATE_DIR", str(Path(__file__).resolve().parent.parent / ".vnx-data/state"))
+
+import quality_db_init as qd
+
+
+def _make_backups(state_dir: Path, count: int) -> list[Path]:
+    """Create ``count`` backup files with strictly increasing mtimes."""
+    backups: list[Path] = []
+    base_time = 1_000_000_000  # fixed epoch baseline avoids filesystem noise
+    for i in range(count):
+        ts = f"20260710_{i:06d}"
+        bp = state_dir / f"quality_intelligence.db.backup_{ts}"
+        bp.write_text(f"backup {i}")
+        os.utime(bp, (base_time + i, base_time + i))
+        backups.append(bp)
+    return backups
+
+
+def test_backup_rotation_keeps_last_n(tmp_path, monkeypatch):
+    """backup_existing_db prunes older backups, keeps VNX_DB_BACKUP_KEEP newest."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    db_path = state_dir / "quality_intelligence.db"
+    db_path.write_text("live db")
+
+    premigrate = state_dir / "quality_intelligence.db.pre-migrate-xyz"
+    premigrate.write_text("pre-migrate copy")
+
+    unrelated = state_dir / "unrelated_file.txt"
+    unrelated.write_text("leave me alone")
+
+    # 6 pre-existing backups (keep=3 means 3 will survive after the new backup is added).
+    pre_backups = _make_backups(state_dir, 6)
+    # Attach sidecars to every other backup so we can verify sidecar pruning.
+    for i, bp in enumerate(pre_backups):
+        if i % 2 == 0:
+            (state_dir / f"{bp.name}-wal").write_text("wal")
+            (state_dir / f"{bp.name}-shm").write_text("shm")
+
+    monkeypatch.setattr(qd, "STATE_DIR", state_dir)
+    monkeypatch.setattr(qd, "DB_PATH", db_path)
+    monkeypatch.setenv("VNX_DB_BACKUP_KEEP", "3")
+
+    assert qd.backup_existing_db() is True
+
+    db_backups = sorted(
+        (
+            p for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*")
+            if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
+        ),
+        key=lambda p: p.stat().st_mtime,
+    )
+
+    # 3 newest remain: the just-created backup plus the 2 newest pre-existing ones.
+    assert len(db_backups) == 3
+    kept_names = {p.name for p in db_backups}
+    assert pre_backups[-2].name in kept_names
+    assert pre_backups[-1].name in kept_names
+
+    # Oldest 4 pre-existing backups and their sidecars were pruned.
+    for old in pre_backups[:-2]:
+        assert not old.exists()
+        assert not (state_dir / f"{old.name}-wal").exists()
+        assert not (state_dir / f"{old.name}-shm").exists()
+
+    # Sidecars of the kept pre-existing backups survive.
+    for kept in pre_backups[-2:]:
+        if (state_dir / f"{kept.name}-wal").exists() or (state_dir / f"{kept.name}-shm").exists():
+            assert (state_dir / f"{kept.name}-wal").exists()
+            assert (state_dir / f"{kept.name}-shm").exists()
+
+    # Live DB, pre-migrate copy, and unrelated files are untouched.
+    assert db_path.read_text() == "live db"
+    assert premigrate.read_text() == "pre-migrate copy"
+    assert unrelated.read_text() == "leave me alone"
+
+
+def test_backup_rotation_invalid_env_falls_back_to_three(tmp_path, monkeypatch):
+    """Invalid VNX_DB_BACKUP_KEEP falls back to keep=3."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    db_path = state_dir / "quality_intelligence.db"
+    db_path.write_text("live db")
+
+    pre_backups = _make_backups(state_dir, 5)
+
+    monkeypatch.setattr(qd, "STATE_DIR", state_dir)
+    monkeypatch.setattr(qd, "DB_PATH", db_path)
+    monkeypatch.setenv("VNX_DB_BACKUP_KEEP", "not-a-number")
+
+    assert qd.backup_existing_db() is True
+
+    db_backups = [
+        p for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*")
+        if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
+    ]
+    assert len(db_backups) == 3
+
+
+def test_backup_rotation_zero_env_falls_back_to_three(tmp_path, monkeypatch):
+    """VNX_DB_BACKUP_KEEP=0 falls back to keep=3 and does not delete everything."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    db_path = state_dir / "quality_intelligence.db"
+    db_path.write_text("live db")
+
+    pre_backups = _make_backups(state_dir, 5)
+
+    monkeypatch.setattr(qd, "STATE_DIR", state_dir)
+    monkeypatch.setattr(qd, "DB_PATH", db_path)
+    monkeypatch.setenv("VNX_DB_BACKUP_KEEP", "0")
+
+    assert qd.backup_existing_db() is True
+
+    db_backups = [
+        p for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*")
+        if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
+    ]
+    assert len(db_backups) == 3
+
+
+def test_backup_rotation_no_op_when_under_limit(tmp_path, monkeypatch):
+    """Nothing is pruned when the number of backups is already <= keep."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    db_path = state_dir / "quality_intelligence.db"
+    db_path.write_text("live db")
+
+    pre_backups = _make_backups(state_dir, 2)
+
+    monkeypatch.setattr(qd, "STATE_DIR", state_dir)
+    monkeypatch.setattr(qd, "DB_PATH", db_path)
+    monkeypatch.setenv("VNX_DB_BACKUP_KEEP", "3")
+
+    assert qd.backup_existing_db() is True
+
+    db_backups = [
+        p for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*")
+        if not (p.name.endswith("-wal") or p.name.endswith("-shm"))
+    ]
+    # 2 pre-existing + 1 newly created = 3, all kept.
+    assert len(db_backups) == 3
+    for pb in pre_backups:
+        assert pb.exists()
+
+
+def test_rotate_helper_prunes_by_mtime_not_by_name_lexicography():
+    """Rotation uses mtime, not lexical filename order."""
+    state_dir = Path(__file__).resolve().parent / "_rotate_helper_tmp"
+    state_dir.mkdir(exist_ok=True)
+    try:
+        # Create backups with deliberately inverted lexical-vs-temporal order.
+        old_by_name = state_dir / "quality_intelligence.db.backup_99999999_999999"
+        new_by_name = state_dir / "quality_intelligence.db.backup_00000000_000000"
+        old_by_name.write_text("old")
+        new_by_name.write_text("new")
+        os.utime(old_by_name, (1_000_000_000, 1_000_000_000))
+        os.utime(new_by_name, (2_000_000_000, 2_000_000_000))
+
+        qd._rotate_quality_db_backups(state_dir, keep=1)
+
+        assert not old_by_name.exists()
+        assert new_by_name.exists()
+    finally:
+        for p in state_dir.glob(f"{qd._BACKUP_PREFIX}*"):
+            p.unlink(missing_ok=True)
+        state_dir.rmdir()


### PR DESCRIPTION
## Summary
`backup_existing_db()` copied the live DB before each migration but never pruned old backups — on the seocrawler-v2 store this accumulated ~18GB of stale 1.6GB daily backups (22GB store, 1.6GB real data). This adds keep-last-N rotation so backups can no longer grow unbounded. Default N=3, override via `VNX_DB_BACKUP_KEEP`.

## Changes
- `scripts/quality_db_init.py`: `_parse_backup_keep()` (env, default 3, safe fallback) + `_rotate_quality_db_backups()` (keep newest N `quality_intelligence.db.backup_*` + their `-wal`/`-shm` sidecars, delete the rest); called after a successful backup, wrapped defensively so rotation failure never aborts the migration. Live DB, `.pre-migrate-*`, and unrelated files are never touched.
- `tests/test_db_backup_rotation.py`: keep-last-N with a pre-migrate decoy + unrelated file left intact; invalid-env → fallback to 3.

## Verification
`pytest tests/test_db_backup_rotation.py` green. Backup CREATION path unchanged; only post-backup cleanup added.

## Open Items
- Rotation sorts by mtime; filenames also carry the backup timestamp — a filename-timestamp sort would be marginally more robust if two backups ever share an mtime. Noted for review.