### PR TITLE
fix(cli): vnx version reads resolved-engine VERSION (stop the 1.0.0 lie)

### DIFF
--- a/tests/test_vnx_cli_version.py
+++ b/tests/test_vnx_cli_version.py
@@ -44,6 +44,31 @@ def test_read_version_file_matches_repo_version():
         assert _read_version_file() == expected
 
 
+def test_read_version_file_prefers_engine_version_over_dist_info(tmp_path, monkeypatch):
+    """The RESOLVED engine's VERSION wins over stale pip dist-info metadata.
+
+    Reproduces the 'vnx version lies' bug: the editable finder points at a
+    version dir (e.g. versions/edge=1.1.0) whose VERSION differs from the
+    dist-info name (...-1.0.0). vnx version must report the engine's VERSION.
+    """
+    import vnx_cli._engine as _engine
+    fake_engine = tmp_path / "engine"
+    fake_engine.mkdir()
+    (fake_engine / "VERSION").write_text("9.9.9\n")
+    monkeypatch.setattr(_engine, "engine_root", lambda: fake_engine)
+    assert _read_version_file() == "9.9.9"
+
+
+def test_read_version_file_falls_back_when_no_version_file(tmp_path, monkeypatch):
+    """No VERSION file in the engine -> fall back to package __version__."""
+    import vnx_cli._engine as _engine
+    from vnx_cli import __version__
+    empty = tmp_path / "no_version"
+    empty.mkdir()
+    monkeypatch.setattr(_engine, "engine_root", lambda: empty)
+    assert _read_version_file() == __version__
+
+
 # ---------------------------------------------------------------------------
 # _read_pin
 # ---------------------------------------------------------------------------

--- a/vnx_cli/commands/version.py
+++ b/vnx_cli/commands/version.py
@@ -9,8 +9,21 @@ from pathlib import Path
 
 
 def _read_version_file() -> str:
-    # Single source of truth: vnx_cli.__version__ (package metadata in an
-    # installed wheel, root VERSION file in a dev checkout).
+    # Read the version from the RESOLVED engine's VERSION file, not the pip
+    # dist-info metadata. The editable finder can map ``vnx_cli`` to a version
+    # dir whose name differs from the dist-info (e.g. finder -> versions/edge
+    # =1.1.0 while the dist-info is still ...-1.0.0); the metadata then lies.
+    # The engine's VERSION file is authoritative for the code that actually
+    # loads. Fall back to package metadata only if VERSION is unreadable.
+    try:
+        from vnx_cli import _engine
+        version_file = _engine.engine_root() / "VERSION"
+        if version_file.is_file():
+            v = version_file.read_text(encoding="utf-8").strip()
+            if v:
+                return v
+    except Exception:
+        pass
     from vnx_cli import __version__
     return __version__
 


### PR DESCRIPTION
## Summary
`vnx version` printed the stale pip dist-info (1.0.0) instead of the code that actually loads (edge=1.1.0 via the editable finder), causing consumer T0 sessions to misdiagnose "I'm on old code". `_read_version_file` now reads the resolved engine's `VERSION` file (`engine_root()/VERSION`), falling back to `vnx_cli.__version__` only if absent.

## Changes
- `vnx_cli/commands/version.py`: `_read_version_file` reads `engine_root()/VERSION` first.
- `tests/test_vnx_cli_version.py`: +2 tests (engine VERSION wins over dist-info; fallback when VERSION absent). Existing repo-version test still green.

## Verification
`pytest tests/test_vnx_cli_version.py` -> 15 passed. `_read_version_file()` now returns 1.1.0 in the edge checkout.

## Open Items
None