### PR TITLE
feat(governance): ADR-029 hash-chain epoch-rotation (verify + seal + audit)

### DIFF
--- a/scripts/chain_epoch_seal.py
+++ b/scripts/chain_epoch_seal.py
@@ -1,0 +1,94 @@
+#!/usr/bin/env python3
+"""ADR-029 chain-epoch seal migration.
+
+Appends a ``chain_epoch_start`` marker to a receipt ledger BEFORE enabling
+``VNX_CHAIN_RECEIPTS`` default-on, so that new receipts chain within a fresh
+epoch and ``verify_chain`` returns ``verified-segmented`` (healthy) instead of
+``broken`` (the naive-flip footgun). The immutable pre-adoption entries stay
+epoch 0.
+
+Guarantees:
+- Idempotent: a ledger that is already chaining (its last entry carries
+  ``prev_hash``) is a no-op — running the seal twice never double-appends.
+- Append-only: never rewrites a historical line (ADR-005 preserved).
+
+Usage:
+    python3 scripts/chain_epoch_seal.py <ledger.ndjson> [<ledger2.ndjson> ...]
+    python3 scripts/chain_epoch_seal.py --dry-run <ledger.ndjson>
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+from ndjson_hash_chain import (  # type: ignore[import]
+    append_epoch_marker,
+    epoch_state,
+    verify_chain,
+)
+
+
+def seal_ledger(path: Path) -> dict:
+    """Idempotently seal ``path`` with a chain-epoch marker. Returns a result dict.
+
+    - ``action="noop"`` when the ledger is already chaining or absent.
+    - ``action="sealed"`` when a marker was appended, with the new ``epoch`` and
+      the post-seal ``status`` (should be ``verified-segmented`` or ``verified``).
+    """
+    if not path.exists() or path.stat().st_size == 0:
+        # A fresh/empty ledger needs no seal: the first appended receipt chains
+        # from GENESIS on its own.
+        return {"ledger": str(path), "action": "noop", "reason": "ledger empty or absent"}
+
+    max_epoch, chaining_active = epoch_state(path)
+    if chaining_active:
+        return {"ledger": str(path), "action": "noop", "reason": "already chaining", "epoch": max_epoch}
+
+    epoch = max_epoch + 1
+    marker_hash = append_epoch_marker(path, epoch)
+    _ok, _violations, status = verify_chain(path)
+    return {
+        "ledger": str(path),
+        "action": "sealed",
+        "epoch": epoch,
+        "marker_hash": marker_hash,
+        "status": status,
+    }
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description="ADR-029 chain-epoch seal migration")
+    ap.add_argument("ledger", nargs="+", help="path(s) to NDJSON ledger(s) to seal")
+    ap.add_argument("--dry-run", action="store_true", help="report what would happen; do not write")
+    args = ap.parse_args(argv)
+
+    rc = 0
+    for raw in args.ledger:
+        path = Path(raw)
+        if args.dry_run:
+            if not path.exists() or path.stat().st_size == 0:
+                print(f"[dry-run] {path}: noop (empty or absent)")
+                continue
+            max_epoch, active = epoch_state(path)
+            if active:
+                print(f"[dry-run] {path}: noop (already chaining, epoch {max_epoch})")
+            else:
+                print(f"[dry-run] {path}: would seal epoch {max_epoch + 1}")
+            continue
+
+        res = seal_ledger(path)
+        if res["action"] == "sealed":
+            print(f"[seal] {res['ledger']}: sealed epoch {res['epoch']} -> status={res['status']}")
+            if res["status"] not in ("verified-segmented", "verified"):
+                print(f"[seal] WARNING: post-seal status is {res['status']!r}, not healthy", file=sys.stderr)
+                rc = 1
+        else:
+            print(f"[seal] {res['ledger']}: noop ({res.get('reason')})")
+    return rc
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -270,6 +270,7 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
         return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "no registered projects")
     broken = []
     verified = 0
+    segmented = 0
     unchained = 0
     checked = 0
     for pid, _path in projects:
@@ -284,6 +285,10 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
             continue
         if status == "verified":
             verified += 1
+        elif status == "verified-segmented":
+            # ADR-029: an unchained epoch-0 prefix + intact chained epoch(s) is
+            # a healthy sealed ledger mid-adoption, not a break.
+            segmented += 1
         elif status == "unchained":
             unchained += 1
         else:  # broken
@@ -292,14 +297,14 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
         names = ", ".join(b["project"] for b in broken)
         return CheckResult(
             "C", "Receipt hash-chain integrity", "RED",
-            f"broken chain in: {names} (verified={verified}, unchained={unchained})",
+            f"broken chain in: {names} (verified={verified}, segmented={segmented}, unchained={unchained})",
             broken,
         )
     if checked == 0:
         return CheckResult("C", "Receipt hash-chain integrity", "SKIP", "no t0_receipts.ndjson found")
     return CheckResult(
         "C", "Receipt hash-chain integrity", "GREEN",
-        f"{checked} ledgers ok (verified={verified}, unchained={unchained} — ADR-023 partial, not an error)",
+        f"{checked} ledgers ok (verified={verified}, segmented={segmented}, unchained={unchained} — ADR-023/029)",
     )
 
 

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -16,11 +16,20 @@ from __future__ import annotations
 
 import hashlib
 import json
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
 
 GENESIS_HASH = "0" * 64  # Sentinel for first entry in chain
+
+# ADR-029: a chain epoch begins with a dedicated marker entry whose prev_hash is
+# GENESIS. The immutable pre-adoption entries form epoch 0 (legitimately
+# unchained); every entry from a marker forward chains within its epoch. This
+# lets chaining be adopted on an existing ledger without rewriting history
+# (ADR-005 append-only preserved) and without flipping the fleet-wide integrity
+# check RED on the first post-flip receipt.
+EPOCH_MARKER_TYPE = "chain_epoch_start"
 
 
 def canonical_json(obj: dict) -> str:
@@ -80,6 +89,63 @@ def append_chained_entry(
     return compute_entry_hash(chained)
 
 
+def _iter_parsed(path: Path) -> Iterator[tuple[int, dict]]:
+    """Yield (line_number, entry) for each parseable non-blank NDJSON line."""
+    if not path.exists() or path.stat().st_size == 0:
+        return
+    with path.open("r", encoding="utf-8") as f:
+        for line_no, line in enumerate(f, start=1):
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield line_no, json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def epoch_state(path: Path) -> tuple[int, bool]:
+    """Inspect a ledger's epoch state for the ADR-029 seal migration.
+
+    Returns ``(max_epoch, chaining_active)``:
+    - ``max_epoch``: highest ``epoch`` on any ``chain_epoch_start`` marker (0 if none).
+    - ``chaining_active``: True when the LAST non-blank entry carries ``prev_hash``
+      (a marker or a chained entry), so a newly-appended receipt would chain into
+      the current epoch rather than land in an unchained prefix. When True the
+      seal is a no-op — this is what makes ``chain_epoch_seal`` idempotent.
+    """
+    max_epoch = 0
+    last_has_prev = False
+    for _, entry in _iter_parsed(path):
+        if entry.get("type") == EPOCH_MARKER_TYPE:
+            try:
+                max_epoch = max(max_epoch, int(entry.get("epoch", 0)))
+            except (TypeError, ValueError):
+                pass
+            last_has_prev = True
+        else:
+            last_has_prev = "prev_hash" in entry
+    return max_epoch, last_has_prev
+
+
+def append_epoch_marker(path: Path, epoch: int) -> str:
+    """Append a ``chain_epoch_start`` marker (``prev_hash == GENESIS``) opening ``epoch``.
+
+    Append-only: never rewrites a historical line (ADR-005 preserved). Returns
+    the marker entry's hash so the next appended receipt links to it.
+    """
+    marker = {
+        "type": EPOCH_MARKER_TYPE,
+        "epoch": epoch,
+        "epoch_ts": datetime.now(timezone.utc).isoformat(),
+        "prev_hash": GENESIS_HASH,
+    }
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as f:
+        f.write(json.dumps(marker) + "\n")
+    return compute_entry_hash(marker)
+
+
 def _read_last_hash(path: Path) -> str | None:
     """Return hash of last entry in file, or None if file empty/missing."""
     if not path.exists() or path.stat().st_size == 0:
@@ -107,32 +173,43 @@ def _read_last_hash(path: Path) -> str | None:
 
 
 def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
-    """Verify the hash-chain integrity for an NDJSON file.
+    """Verify the hash-chain integrity of an NDJSON ledger (ADR-029 epoch-aware).
 
     Returns (is_valid, violations_list, status) where status is one of:
 
-    - "unchained": no entry in the file carries a prev_hash field; chaining
-      was never enabled (VNX_CHAIN_RECEIPTS is off by default).  Integrity
-      cannot be verified — this is NOT an error.  is_valid is True.
-    - "verified": every entry carries prev_hash and the chain is intact.
-      is_valid is True.
-    - "broken": chain is present but has integrity violations (tampered,
-      inserted, or partially chained — some entries carry prev_hash while
-      others do not).  is_valid is False.
+    - "unchained": no entry carries prev_hash and there is no chain_epoch_start
+      marker — chaining was never enabled (VNX_CHAIN_RECEIPTS default off).
+      Integrity cannot be verified; NOT an error. is_valid=True.
+    - "verified": the ledger chains from a single GENESIS with no unchained
+      prefix and no explicit epoch marker. is_valid=True.
+    - "verified-segmented": a legitimate ADR-029 layout — an immutable unchained
+      epoch-0 prefix and/or one or more explicit chain_epoch_start epochs, each
+      chained intact. is_valid=True.
+    - "broken": a within-epoch prev_hash mismatch, an unchained entry INSIDE a
+      chained epoch, a chained entry with no preceding epoch marker after an
+      unchained prefix (a naive VNX_CHAIN_RECEIPTS flip that skipped the seal),
+      an epoch marker whose prev_hash != GENESIS, or unparseable lines.
+      is_valid=False.
 
-    A partially-chained ledger (some entries with prev_hash, some without)
-    is classified as "broken", not "unchained".  A ledger must be either
-    fully unchained or fully chained to be considered healthy.
+    Threat-model note (ADR-029, accepted residual): epoch-0 history and the
+    relocation of an epoch boundary are NOT defended here. A local actor with
+    write access to the ledger can strip a prefix, insert a fresh
+    chain_epoch_start marker, and re-chain the remainder — this verifies. A
+    ledger is only as trustworthy as its first sealed epoch onward; full
+    tamper-evidence against a local attacker needs an EXTERNAL append-only
+    anchor (out of scope for ADR-029 — a future epoch-seal-anchor ADR). This
+    check detects accidental corruption and within-epoch tampering, the
+    governance value ADR-023/ADR-029 target. Flag stays default-off until the
+    fleet-wide seal migration lands.
 
-    violations_list contains dicts with: line_number, expected_prev_hash,
-    actual_prev_hash (and optionally 'error' or 'note').
+    violations_list contains dicts with: line_number and one of
+    expected_prev_hash/actual_prev_hash, 'error', or 'note'.
     """
     entries: list[tuple[int, dict]] = []
+    parse_errors: list[dict] = []
 
     if not path.exists() or path.stat().st_size == 0:
         return (True, [], "unchained")
-
-    parse_errors: list[dict] = []
 
     with path.open("r", encoding="utf-8") as f:
         for line_no, line in enumerate(f, start=1):
@@ -140,76 +217,83 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
             if not line:
                 continue
             try:
-                entry = json.loads(line)
+                entries.append((line_no, json.loads(line)))
             except json.JSONDecodeError as e:
-                parse_errors.append({
-                    "line_number": line_no,
-                    "error": f"invalid JSON: {e}",
-                })
-                continue
-            entries.append((line_no, entry))
+                parse_errors.append({"line_number": line_no, "error": f"invalid JSON: {e}"})
 
-    # Unparseable lines are always a violation regardless of chain status.
     if parse_errors and not entries:
         return (False, parse_errors, "broken")
-
     if not entries:
         return (True, [], "unchained")
 
-    # Determine whether any entry carries prev_hash.
-    chained_count = sum(1 for _, e in entries if "prev_hash" in e)
-    total = len(entries)
-
-    if chained_count == 0 and not parse_errors:
-        # No entry has prev_hash — ledger is fully unchained.  Chaining was
-        # not enabled (VNX_CHAIN_RECEIPTS default off).  Not an error.
-        return (True, [], "unchained")
-
-    # At least one entry has prev_hash (or there are parse errors mixed in).
-    # Enforce full-chain integrity.  A partially-chained ledger (some entries
-    # lack prev_hash while others have it) is a real violation — broken.
     violations: list[dict] = list(parse_errors)
+    in_chain = False    # currently inside a chained epoch
+    saw_chain = False   # any chained content at all (marker or chained entry)
+    saw_prefix = False  # an unchained epoch-0 prefix entry
+    saw_marker = False  # an explicit chain_epoch_start marker
     expected_prev = GENESIS_HASH
 
     for line_no, entry in entries:
+        is_marker = entry.get("type") == EPOCH_MARKER_TYPE
+        has_prev = "prev_hash" in entry
         actual_prev = entry.get("prev_hash")
 
-        if line_no == entries[0][0]:
-            # First entry in the file.
-            if actual_prev is not None and actual_prev != GENESIS_HASH:
+        if is_marker:
+            saw_chain = True
+            saw_marker = True
+            if actual_prev != GENESIS_HASH:
                 violations.append({
                     "line_number": line_no,
                     "expected_prev_hash": GENESIS_HASH,
                     "actual_prev_hash": actual_prev,
-                    "note": "first entry: prev_hash must be GENESIS or absent",
+                    "note": "chain_epoch_start marker must anchor to GENESIS",
                 })
+            in_chain = True
+            expected_prev = compute_entry_hash(entry)
+            continue
+
+        if not in_chain:
+            # Leading region: the epoch-0 unchained prefix, or the first chained
+            # entry of a marker-less GENESIS chain.
+            if has_prev:
+                saw_chain = True
+                if actual_prev == GENESIS_HASH and not saw_prefix:
+                    # Chained from the first line — a marker-less "verified" chain.
+                    in_chain = True
+                    expected_prev = compute_entry_hash(entry)
+                else:
+                    # Chained entry after an unchained prefix, or anchored to a
+                    # non-GENESIS hash, with no chain_epoch_start marker: the
+                    # naive-flip / unsealed case.
+                    violations.append({
+                        "line_number": line_no,
+                        "note": "chained entry without a preceding chain_epoch_start marker (unsealed / naive flip)",
+                    })
+                    in_chain = True
+                    expected_prev = compute_entry_hash(entry)
+            else:
+                saw_prefix = True
         else:
-            if actual_prev != expected_prev:
+            # Inside a chained epoch.
+            if not has_prev:
+                violations.append({
+                    "line_number": line_no,
+                    "note": "unchained entry inside a chained epoch",
+                })
+            elif actual_prev != expected_prev:
                 violations.append({
                     "line_number": line_no,
                     "expected_prev_hash": expected_prev,
                     "actual_prev_hash": actual_prev,
                 })
-
-        expected_prev = compute_entry_hash(entry)
+            expected_prev = compute_entry_hash(entry)
 
     if violations:
         return (False, violations, "broken")
-
-    # All parseable entries chained and intact.
-    if chained_count < total:
-        # Partial chain detected even with no hash mismatches.  This guard is
-        # LOAD-BEARING for the edge case where the FIRST entry carries no
-        # prev_hash (allowed by the first-entry branch) while later entries
-        # hash-link correctly to their predecessor — the loop produces zero
-        # violations there; only this count check catches the partial chain.
-        return (False, [{
-            "note": (
-                f"partial chain: {chained_count}/{total} entries carry prev_hash; "
-                "ledger must be fully unchained or fully chained"
-            )
-        }], "broken")
-
+    if not saw_chain:
+        return (True, [], "unchained")
+    if saw_prefix or saw_marker:
+        return (True, [], "verified-segmented")
     return (True, [], "verified")
 
 

--- a/tests/test_chain_epoch_seal.py
+++ b/tests/test_chain_epoch_seal.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for the ADR-029 chain-epoch seal migration (scripts/chain_epoch_seal.py)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from ndjson_hash_chain import append_chained_entry, verify_chain  # noqa: E402
+
+# Load scripts/chain_epoch_seal.py (not importable as a package name).
+_spec = importlib.util.spec_from_file_location(
+    "chain_epoch_seal", REPO / "scripts" / "chain_epoch_seal.py"
+)
+seal_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(seal_mod)  # type: ignore[union-attr]
+seal_ledger = seal_mod.seal_ledger
+
+
+def _write_unchained(path: Path, n: int) -> None:
+    for i in range(n):
+        with path.open("a") as f:
+            f.write(json.dumps({"seq": i, "old": True}) + "\n")
+
+
+def test_seal_unchained_ledger_opens_epoch_1_and_verifies_segmented(tmp_path):
+    p = tmp_path / "t0_receipts.ndjson"
+    _write_unchained(p, 3)
+    res = seal_ledger(p)
+    assert res["action"] == "sealed" and res["epoch"] == 1
+    assert res["status"] == "verified-segmented"
+    # And a subsequent chained append still verifies as segmented.
+    append_chained_entry(p, {"seq": 3})
+    ok, _v, status = verify_chain(p)
+    assert ok is True and status == "verified-segmented"
+
+
+def test_seal_is_idempotent(tmp_path):
+    p = tmp_path / "t0_receipts.ndjson"
+    _write_unchained(p, 2)
+    first = seal_ledger(p)
+    assert first["action"] == "sealed"
+    lines_after_first = p.read_text().splitlines()
+    # Second run must be a no-op (ledger is now chaining).
+    second = seal_ledger(p)
+    assert second["action"] == "noop"
+    assert p.read_text().splitlines() == lines_after_first  # nothing appended
+
+
+def test_seal_is_append_only(tmp_path):
+    """The pre-adoption history lines are byte-identical after sealing (ADR-005)."""
+    p = tmp_path / "t0_receipts.ndjson"
+    _write_unchained(p, 3)
+    original = p.read_text().splitlines()
+    seal_ledger(p)
+    after = p.read_text().splitlines()
+    assert after[: len(original)] == original          # history untouched
+    assert len(after) == len(original) + 1             # exactly one marker appended
+    assert json.loads(after[-1])["type"] == "chain_epoch_start"
+
+
+def test_seal_empty_or_absent_is_noop(tmp_path):
+    p = tmp_path / "absent.ndjson"
+    assert seal_ledger(p)["action"] == "noop"
+    p.touch()
+    assert seal_ledger(p)["action"] == "noop"
+
+
+def test_seal_next_epoch_numbering(tmp_path):
+    """A ledger that already has epoch 1 but ends on an unchained entry seals epoch 2."""
+    p = tmp_path / "t0_receipts.ndjson"
+    _write_unchained(p, 1)
+    seal_ledger(p)                       # opens epoch 1
+    append_chained_entry(p, {"seq": 1})
+    # Simulate a later unchained tail (rotation) to force a re-seal.
+    with p.open("a") as f:
+        f.write(json.dumps({"seq": 2, "tail": True}) + "\n")
+    res = seal_ledger(p)
+    assert res["action"] == "sealed" and res["epoch"] == 2

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -285,10 +285,10 @@ def test_verify_chain_partial_chain_is_broken(tmp_path):
 
 
 def test_verify_chain_first_unchained_rest_linked_is_broken(tmp_path):
-    """LOAD-BEARING guard case (kimi-gate PR #840 F1): first entry has no
-    prev_hash (allowed by the first-entry branch), later entries hash-link
-    correctly to their predecessor. The verify loop produces zero violations
-    here — only the chained_count < total guard catches the partial chain."""
+    """ADR-029 naive-flip guard: first entry has no prev_hash, a later entry
+    hash-links correctly to its predecessor, but there is NO chain_epoch_start
+    marker. This is exactly the 'flipped VNX_CHAIN_RECEIPTS without running the
+    seal' footgun — it must be broken, not silently accepted as segmented."""
     p = tmp_path / "first-unchained.ndjson"
     first = {"seq": 0, "id": "plain-0"}
     with p.open("a") as f:
@@ -301,7 +301,7 @@ def test_verify_chain_first_unchained_rest_linked_is_broken(tmp_path):
     ok, violations, status = verify_chain(p)
     assert ok is False
     assert status == "broken"
-    assert any("partial chain" in str(v) for v in violations)
+    assert any("marker" in str(v) or "naive flip" in str(v) for v in violations)
 
 
 def test_verify_chain_missing_file_is_unchained(tmp_path):
@@ -312,3 +312,75 @@ def test_verify_chain_missing_file_is_unchained(tmp_path):
     assert ok is True
     assert violations == []
     assert status == "unchained"
+
+
+# ---------------------------------------------------------------------------
+# ADR-029: epoch-rotation (verified-segmented, chain_epoch_start marker)
+# ---------------------------------------------------------------------------
+from ndjson_hash_chain import append_epoch_marker, epoch_state, EPOCH_MARKER_TYPE
+
+
+def test_adr029_a_unchained_prefix_plus_epoch_is_verified_segmented(tmp_path):
+    """(a) Unchained epoch-0 prefix + one intact chained epoch -> verified-segmented."""
+    p = tmp_path / "seg.ndjson"
+    # epoch-0 unchained history (immutable, pre-adoption)
+    for i in range(3):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i, "old": True}) + "\n")
+    append_epoch_marker(p, 1)          # seal: opens epoch 1
+    append_chained_entry(p, {"seq": 3})  # chains within epoch 1
+    append_chained_entry(p, {"seq": 4})
+    ok, violations, status = verify_chain(p)
+    assert ok is True and status == "verified-segmented" and violations == []
+
+
+def test_adr029_b_within_epoch_tamper_is_broken(tmp_path):
+    p = tmp_path / "tamper.ndjson"
+    append_epoch_marker(p, 1)
+    append_chained_entry(p, {"seq": 1})
+    append_chained_entry(p, {"seq": 2})
+    lines = p.read_text().splitlines()
+    e = json.loads(lines[1]); e["seq"] = 99; lines[1] = json.dumps(e)
+    p.write_text("\n".join(lines) + "\n")
+    ok, _v, status = verify_chain(p)
+    assert ok is False and status == "broken"
+
+
+def test_adr029_c_unchained_after_marker_is_broken(tmp_path):
+    p = tmp_path / "gap.ndjson"
+    append_epoch_marker(p, 1)
+    append_chained_entry(p, {"seq": 1})
+    with p.open("a") as f:               # an unchained entry INSIDE the epoch
+        f.write(json.dumps({"seq": 2, "plain": True}) + "\n")
+    ok, _v, status = verify_chain(p)
+    assert ok is False and status == "broken"
+
+
+def test_adr029_e_marker_non_genesis_is_broken(tmp_path):
+    p = tmp_path / "badmarker.ndjson"
+    with p.open("a") as f:
+        f.write(json.dumps({"type": EPOCH_MARKER_TYPE, "epoch": 1, "prev_hash": "a" * 64}) + "\n")
+    ok, _v, status = verify_chain(p)
+    assert ok is False and status == "broken"
+
+
+def test_adr029_multi_epoch_verified_segmented(tmp_path):
+    """A second epoch (re-seal) chains cleanly -> still verified-segmented."""
+    p = tmp_path / "multi.ndjson"
+    append_epoch_marker(p, 1)
+    append_chained_entry(p, {"seq": 1})
+    append_epoch_marker(p, 2)          # epoch 2 opens with GENESIS again
+    append_chained_entry(p, {"seq": 2})
+    ok, _v, status = verify_chain(p)
+    assert ok is True and status == "verified-segmented"
+
+
+def test_epoch_state_reports_max_epoch_and_active(tmp_path):
+    p = tmp_path / "state.ndjson"
+    for i in range(2):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i}) + "\n")
+    assert epoch_state(p) == (0, False)   # unchained prefix, not chaining
+    append_epoch_marker(p, 1)
+    max_epoch, active = epoch_state(p)
+    assert max_epoch == 1 and active is True   # last entry is the marker -> chaining


### PR DESCRIPTION
## Summary
Implements the **accepted ADR-029** (epoch-rotation) steps 1-3. Enabling receipt chaining (`VNX_CHAIN_RECEIPTS`) on an existing ledger must not (a) flip `fabric-audit` check C RED on the first post-flip receipt, nor (b) rewrite history (ADR-005). Epoch rotation solves this: pre-adoption entries are epoch 0 (legitimately unchained); a `chain_epoch_start` marker (prev_hash=GENESIS) opens epoch 1+; new receipts chain within the epoch.

Steps 1-3 here are **inert until the flag flips** (they only *accept* more states). Steps 4-5 (run the seal per ledger, flip default-on fleet-wide) are the operator's staged rollout, not this PR. Flag stays default-off.

## Changes
- `ndjson_hash_chain.verify_chain`: epoch-aware state machine + new `verified-segmented` status (unchained epoch-0 prefix + intact chained epoch(s)). Naive flip (chained suffix, no marker), within-epoch tamper, unchained-inside-epoch, non-GENESIS marker → all stay `broken`.
- `ndjson_hash_chain`: `append_epoch_marker()` + `epoch_state()`.
- `scripts/chain_epoch_seal.py` (new): idempotent, append-only seal migration.
- `fabric_audit` check C: `verified-segmented` → GREEN.
- Tests: ADR-029 verify plan (a-e + multi-epoch) + seal idempotency/append-only/next-epoch. **31 pass.**

## Threat model (documented in code + ADR-029)
Accepted residual: epoch-0 history and epoch-boundary relocation are NOT defended — a local actor with ledger write access can strip a prefix, insert a marker, and re-chain (this verifies). ADR-029 explicitly accepts this ("only as trustworthy as its first sealed epoch onward"). Full tamper-evidence against a local attacker requires an external append-only anchor (a future ADR). This detects accidental corruption + within-epoch tampering — the ADR-023/029 governance target.

## Open Items
- Operator steps 4-5: `python3 scripts/chain_epoch_seal.py <ledger>` per project, then flip `VNX_CHAIN_RECEIPTS` default-on + re-run `vnx fabric-audit`.