### PR TITLE
fix(dispatch): project_id resolves from target project, not hardcoded vnx-dev (cross-project state contamination)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -81,7 +81,21 @@ def _resolve_data_dir() -> Path:
 
 
 def _resolve_project_id() -> str:
-    return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    """Authoritative project_id for the door's ADR-007 guard.
+
+    Delegates to the canonical resolver: VNX_PROJECT_ID env, then the nearest
+    ``.vnx-project-id`` marker walking up from CWD. The old ``return
+    os.environ.get("VNX_PROJECT_ID", "vnx-dev")`` HARDCODED ``vnx-dev`` as the
+    fallback, so EVERY consumer dispatch that did not export VNX_PROJECT_ID
+    resolved to ``vnx-dev`` — the guard then either mis-routed the entire
+    governance state (receipt, report, spec, events, log) into the vnx-dev store
+    or rejected the correct project_id as a "cross-project redirect". This hit
+    every consumer (sales-copilot, mission-control, seocrawler). Resolving from
+    the marker fixes the fleet; an unresolvable project fails closed (raises)
+    rather than silently landing in vnx-dev.
+    """
+    from project_root import resolve_project_id  # noqa: PLC0415
+    return resolve_project_id()
 
 
 def _resolve_repo_root() -> Path:

--- a/tests/test_dispatch_agent_default_instruction.py
+++ b/tests/test_dispatch_agent_default_instruction.py
@@ -158,6 +158,34 @@ class TestDispatchAgentDefaultInstruction:
         captured = capsys.readouterr()
         assert "--instruction" in captured.err
 
+    def test_derives_project_id_from_project_dir_and_passes_to_door(self, tmp_path):
+        """The dispatch project_id must come from the TARGET --project-dir's
+        .vnx-project-id and be threaded to the door — NOT resolved from the
+        engine/cwd. Without it a consumer dispatch mis-routes its entire
+        governance state into the wrong store (sales-copilot -> vnx-dev)."""
+        self._make_agent(tmp_path, "greeter", "Say hi")
+        (tmp_path / ".vnx-project-id").write_text("my-target\n")
+
+        captured = {}
+
+        def fake_door(legacy, **kwargs):
+            captured.update(kwargs)
+            return True
+
+        from vnx_cli import _engine
+        with patch.object(_engine, "engine_root", return_value=tmp_path), \
+             patch("vnx_cli.commands.dispatch_agent._engine.ensure_engine_on_path"), \
+             patch.dict("sys.modules", {
+                 "subprocess_dispatch": MagicMock(deliver_with_recovery=lambda **k: True),
+                 "dispatch_bridge": MagicMock(deliver_via_door=fake_door),
+             }):
+            from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
+            args = Namespace(agent="greeter", instruction="build it", model="sonnet", project_dir=str(tmp_path))
+            rc = vnx_dispatch_agent(args)
+
+        assert rc == 0
+        assert captured.get("project_id") == "my-target"
+
     def test_explicit_instruction_overrides_default(self, tmp_path):
         """Explicit --instruction takes precedence over default_instruction."""
         self._make_agent(tmp_path, "hello-world", "Default instruction")

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -151,7 +151,15 @@ def vnx_dispatch_agent(args) -> int:
             file=sys.stderr,
         )
 
-    print(f"Dispatching to agent '{agent}' (dispatch_id={dispatch_id}) ...")
+    # Derive the project_id from the TARGET project (--project-dir), not the
+    # CLI/engine cwd. Without this the door falls back to _resolve_project_id()
+    # which reads the engine location (vnx-dev), so a consumer dispatch lands its
+    # entire governance state — receipt, report, spec, events, log — in the WRONG
+    # store (cross-project audit contamination; sales-copilot -> vnx-dev). The
+    # door accepts project_id and prefers it when the caller knows it.
+    project_id = _engine.derive_project_id(project_dir)
+
+    print(f"Dispatching to agent '{agent}' (dispatch_id={dispatch_id}, project_id={project_id}) ...")
 
     # Route through the single-entry door (gated by VNX_SINGLE_ENTRY_DISPATCH / VNX_DISPATCH_LEGACY);
     # the legacy subprocess lane runs only when the door is off. codex flip-PR F3: the shipped
@@ -169,6 +177,7 @@ def vnx_dispatch_agent(args) -> int:
         target_slot="T1",
         role=agent,
         model=model,
+        project_id=project_id,
     )
 
     status = "done" if success else "failed"


### PR DESCRIPTION
## Summary
Every consumer dispatch without `VNX_PROJECT_ID` set landed its entire governance state (receipt, report, spec, events, log) in `~/.vnx-data/vnx-dev/` instead of its own store — cross-project audit contamination reported by the sales-copilot T0 (smoke `D-dfa88607`, OI-126 H2 central fallback on every fire; Jul-5 sales-copilot receipts already tagged `project_id=vnx-dev`). Hits all consumers.

## Root cause
`dispatch_cli._resolve_project_id()` (the door's ADR-007 authoritative resolver) was `return os.environ.get("VNX_PROJECT_ID", "vnx-dev")` — a hardcoded `vnx-dev` fallback. And `vnx dispatch-agent` resolved `--project-dir` for agent lookup but never passed the derived project_id to `deliver_via_door`, so the door used that resolver.

## Changes
- `scripts/lib/dispatch_cli.py`: `_resolve_project_id()` delegates to `project_root.resolve_project_id()` (VNX_PROJECT_ID -> nearest `.vnx-project-id` marker from CWD; fail-closed if unresolvable).
- `vnx_cli/commands/dispatch_agent.py`: derive `project_id` from `--project-dir` via `_engine.derive_project_id` and thread it to `deliver_via_door`.
- test: dispatch_agent threads the target project_id to the door.

## Verification
109 dispatch_cli + project_root + agent tests pass. `_resolve_project_id()` from a marker'd CWD returns that project (not vnx-dev).

## Open Items
- After merge + `vnx update --to edge`, consumers resolve their own project_id. Mis-landed sales-copilot state in `~/.vnx-data/vnx-dev/` needs reconciliation back (separate, in progress).