### PR TITLE
fix(door): central-store project_id authority = physical staged-bundle location

### DIFF
--- a/install-central.sh
+++ b/install-central.sh
@@ -109,6 +109,22 @@ write_install_marker() {
   mv -f "$tmp" "$marker"
 }
 
+# strip_tenant_marker — the installed engine tree must be TENANT-NEUTRAL. The repo
+# tracks its own `.vnx-project-id = vnx-dev`, which the clone drags into the shared
+# version dir. In central-install mode the door's CWD is this tree; a stray marker
+# there makes CWD-based project_id resolution return `vnx-dev` for EVERY consumer
+# (the fleet-wide misroute/hard-reject class). Remove it after clone.
+strip_tenant_marker() {
+  local version_dir="$1"
+  local marker="${version_dir}/.vnx-project-id"
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] strip stray tenant marker -> ${marker}"
+    return 0
+  fi
+  [ -f "$marker" ] && rm -f "$marker" && info "Stripped stray tenant marker: ${marker}"
+  return 0
+}
+
 # ---------------------------------------------------------------------------
 # check_prereqs — fail-fast on missing dependencies
 # ---------------------------------------------------------------------------
@@ -160,6 +176,7 @@ clone_version() {
     # Idempotent: ensure the marker exists even on a pre-existing version dir
     # (e.g. cloned before this installer learned to write it).
     write_install_marker "$version_dir"
+    strip_tenant_marker "$version_dir"
     return 0
   fi
 
@@ -182,6 +199,7 @@ clone_version() {
   fi
 
   write_install_marker "$version_dir"
+  strip_tenant_marker "$version_dir"
   success "Cloned ${VERSION} to ${version_dir}"
 }
 

--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -87,10 +87,16 @@ def _canonical_provider(raw: Optional[str]) -> Provider:
     return Provider(canonical)
 
 
-def _data_dir() -> Path:
-    """Resolve the data root EXACTLY as the door does (no divergence)."""
+def _data_dir(project_id: "Optional[str]" = None) -> Path:
+    """Resolve the data root EXACTLY as the door does (no divergence).
+
+    ``project_id`` (when given) is the authoritative tenant, so the bundle stages into
+    THAT project's central store instead of the ambient ``vnx-dev`` default. This keeps
+    the physical staging location coherent with the spec's declared ``project_id`` — the
+    invariant the door's ADR-007 guard now validates against.
+    """
     from dispatch_cli import _resolve_data_dir  # noqa: PLC0415
-    return _resolve_data_dir()
+    return _resolve_data_dir(project_id)
 
 
 def _project_id() -> str:
@@ -133,8 +139,16 @@ def stage_spec_bundle(
         )
     staging_id = dispatch_id
 
-    # 2. resolve the data root the SAME way the door does.
-    root = (data_dir or _data_dir()).resolve()
+    # 1b. resolve the effective tenant ONCE, up front, so the physical staging store and
+    # the spec's declared project_id are the SAME. Staging into the ambient _data_dir()
+    # (vnx-dev in a central install) while stamping the spec with the real project_id is
+    # exactly what caused the fleet-wide hard-reject: the door derives the tenant from the
+    # bundle's physical location, so a bundle staged into vnx-dev but declaring
+    # sales-copilot fails validation.
+    effective_project_id = project_id or _project_id()
+
+    # 2. resolve the data root the SAME way the door does — anchored on the tenant.
+    root = (data_dir or _data_dir(effective_project_id)).resolve()
     pending = root / "dispatches" / "pending"
 
     # 3. anchor the pending root BEFORE writing (defense-in-depth vs symlink escape).
@@ -164,7 +178,7 @@ def stage_spec_bundle(
     norm_reason = (headless_reason or "").strip() or None
     spec_payload = {
         "schema_version": 1,
-        "project_id": project_id or _project_id(),
+        "project_id": effective_project_id,
         "dispatch_id": dispatch_id,
         "staging_id": staging_id,
         "instruction_file": str(instruction_file.resolve()),

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -61,8 +61,14 @@ class _InvariantViolation(Exception):
 # Path resolution
 # ---------------------------------------------------------------------------
 
-def _resolve_data_dir() -> Path:
+def _resolve_data_dir(project_id: "str | None" = None) -> Path:
     """Resolve VNX data directory. Mirrors provider_dispatch._resolve_data_dir.
+
+    ``project_id`` (when given) is the authoritative tenant — used to derive the
+    central store ``~/.vnx-data/<project_id>`` so a caller that already knows the
+    target project (e.g. the staged-bundle authority in ``run_dispatch``) does not
+    fall back to the ambient ``VNX_PROJECT_ID``/``vnx-dev`` default.
+
 
     PR-4d trust boundary: the resolved data root is OPERATOR config, not attacker
     input. The threat model is our own agents, not an external adversary — and an
@@ -76,8 +82,8 @@ def _resolve_data_dir() -> Path:
     explicit_val = os.environ.get("VNX_DATA_DIR", "")
     if explicit_flag and explicit_val:
         return Path(explicit_val).resolve()
-    project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
-    return Path.home() / ".vnx-data" / project_id
+    pid = project_id or os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    return Path.home() / ".vnx-data" / pid
 
 
 def _resolve_project_id() -> str:
@@ -101,6 +107,36 @@ def _resolve_project_id() -> str:
 def _resolve_repo_root() -> Path:
     """scripts/lib/dispatch_cli.py -> repo root (parents[2])."""
     return Path(__file__).resolve().parents[2]
+
+
+def _authority_from_spec_path(spec_file: Path) -> "tuple[str | None, Path | None]":
+    """Derive (project_id, data_dir) from a staged bundle's PHYSICAL location.
+
+    Bundle layout (stage_spec_bundle): ``<data_dir>/dispatches/pending/<id>/dispatch-spec.json``.
+    The store the bundle physically lives in IS the dispatch's tenant authority — NOT the
+    ambient CWD. In a central install the door's CWD is the shared engine tree, whose stray
+    ``.vnx-project-id`` would mis-resolve every consumer to ``vnx-dev`` (misroute pre-#1091,
+    hard-reject post-#1091). Deriving from the bundle location fixes the whole class and keeps
+    the ADR-007 anti-redirect guard meaningful: a spec that declares a project_id different from
+    the store it was staged into still fails validation.
+
+    Returns ``(None, None)`` when ``spec_file`` is not under that layout (ad-hoc/test specs), so
+    the caller falls back to ambient resolution.
+    """
+    try:
+        p = Path(spec_file).resolve()
+        if p.name != "dispatch-spec.json":
+            return None, None
+        if p.parents[1].name != "pending" or p.parents[2].name != "dispatches":
+            return None, None
+        data_dir = p.parents[3]
+        from vnx_paths import project_id_from_state_dir  # noqa: PLC0415
+        pid = project_id_from_state_dir(data_dir / "state")
+        if not pid:
+            return None, None
+        return pid, data_dir
+    except Exception:  # noqa: BLE001 — resolution is best-effort; fall back to ambient
+        return None, None
 
 
 # ---------------------------------------------------------------------------
@@ -734,9 +770,47 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
     Returns 0 on success, 1 on any reject or execution failure.
     When dry_run=True, prints plan + permit fingerprint and spawns nothing.
     """
-    project_id = _resolve_project_id()
+    # Authority = where the bundle is PHYSICALLY staged, not ambient CWD/env. In a
+    # central install the door's CWD is the shared engine tree (its stray
+    # .vnx-project-id would mis-resolve every consumer to vnx-dev). Fall back to
+    # ambient resolution only when the spec isn't under the staged-bundle layout
+    # (ad-hoc/test specs).
+    derived_pid, derived_data_dir = _authority_from_spec_path(spec_file)
+
+    # ADR-007 independent-authority cross-check (codex gate PR #1093): when the OPERATOR
+    # explicitly pins the tenant / data root (VNX_PROJECT_ID / VNX_DATA_DIR_EXPLICIT), the
+    # staged-bundle authority MUST agree. This restores the anti-redirect guard whenever an
+    # independent authority exists — a bundle physically staged under a different project's
+    # store than the pinned one is a cross-project redirect and is rejected. Without an
+    # explicit pin (the common central-install case) the store's filesystem write-access is
+    # the trust boundary, per the PR-4d model ("resolved data root is OPERATOR config; the
+    # threat model is our own agents, not an external adversary").
+    if derived_pid:
+        env_pid = (os.environ.get("VNX_PROJECT_ID") or "").strip()
+        if env_pid and env_pid != derived_pid:
+            _emit_reject(Reject(
+                "project-mismatch",
+                f"staged-bundle project_id={derived_pid!r} != pinned VNX_PROJECT_ID={env_pid!r}; "
+                "caller cannot redirect state to another project",
+            ))
+            return 1
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+            explicit = (os.environ.get("VNX_DATA_DIR") or "").strip()
+            if (
+                explicit
+                and derived_data_dir is not None
+                and Path(explicit).resolve() != derived_data_dir.resolve()
+            ):
+                _emit_reject(Reject(
+                    "project-mismatch",
+                    f"staged-bundle data_dir={derived_data_dir} != pinned VNX_DATA_DIR={explicit}; "
+                    "refusing to write state outside the operator-pinned data root",
+                ))
+                return 1
+
+    project_id = derived_pid or _resolve_project_id()
     repo_root = _resolve_repo_root()
-    data_dir = _resolve_data_dir()
+    data_dir = derived_data_dir or _resolve_data_dir(derived_pid)
     state_dir = data_dir / "state"
 
     try:

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -10,7 +10,6 @@ ADR-007: not triggered here — no new table, pure in-process types only.
 from __future__ import annotations
 
 import hashlib
-import os
 import re
 from dataclasses import dataclass
 from enum import Enum
@@ -122,10 +121,6 @@ _BLOCKED_FIRST_COMPONENTS = frozenset({".git", ".vnx-data"})
 _VALID_TARGET_SLOTS = frozenset({"T0", "T1", "T2", "T3"})
 
 
-def _resolve_project_id() -> str:
-    return os.environ.get("VNX_PROJECT_ID", "vnx-dev")
-
-
 def _validate_dispatch_path(dp: DispatchPath) -> Optional[str]:
     """Return an error string if the DispatchPath is invalid, else None."""
     raw = str(dp.path)
@@ -174,12 +169,17 @@ def validate(
     if spec.schema_version != 1:
         return Reject("bad-schema", f"schema_version must be 1, got {spec.schema_version!r}")
 
-    # Rule 2 — project_id must match the caller's resolved project_id
-    resolved = _resolve_project_id()
-    if spec.project_id != resolved:
+    # Rule 2 — project_id must match the AUTHORITATIVE project_id the caller
+    # (run_dispatch) derived from the PHYSICAL staged-bundle store — never from
+    # ambient CWD/env. A bundle physically living in project X's store may not
+    # declare a different project_id (ADR-007 anti-redirect). The old code re-
+    # resolved from env with a hardcoded 'vnx-dev' default, which in a central
+    # install (CWD = shared engine tree with a stray .vnx-project-id) rejected
+    # every legitimate non-vnx-dev consumer dispatch as a "project-mismatch".
+    if spec.project_id != project_id:
         return Reject(
             "project-mismatch",
-            f"spec.project_id={spec.project_id!r} != resolved project_id={resolved!r}; "
+            f"spec.project_id={spec.project_id!r} != authoritative project_id={project_id!r}; "
             "caller cannot redirect state to another project",
         )
 

--- a/tests/test_dispatch_door_authority.py
+++ b/tests/test_dispatch_door_authority.py
@@ -1,0 +1,172 @@
+#!/usr/bin/env python3
+"""Regression tests for the central-store door-authority fix (2026-07-10).
+
+The fleet-wide hard-reject/misroute class had ONE root: the door re-resolved
+`project_id`/`data_dir` from ambient CWD/env (hardcoded `vnx-dev`) instead of from
+the PHYSICAL location the spec bundle was staged into. In a central install the door's
+CWD is the shared engine tree, whose stray `.vnx-project-id=vnx-dev` mis-resolved every
+non-vnx-dev consumer.
+
+These tests pin the coherent authority model:
+- `stage_spec_bundle` stages into the TARGET project's store (not ambient vnx-dev).
+- `_authority_from_spec_path` derives (project_id, data_dir) from that physical location.
+- Ambient `VNX_PROJECT_ID` must NEVER override the staged-bundle authority.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+for sub in ("scripts/lib", "scripts"):
+    p = str(REPO_ROOT / sub)
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import dispatch_bridge  # noqa: E402
+import dispatch_cli  # noqa: E402
+
+
+@pytest.fixture
+def fake_home(tmp_path, monkeypatch):
+    """Point Path.home() + the data-home at tmp, and clear data-dir overrides."""
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    return tmp_path
+
+
+class TestAuthorityFromSpecPath:
+    def test_derives_tenant_from_central_staged_bundle(self, fake_home, monkeypatch):
+        pid = "sales-copilot"
+        bundle = fake_home / ".vnx-data" / pid / "dispatches" / "pending" / "20260710-x-y"
+        bundle.mkdir(parents=True)
+        spec_file = bundle / "dispatch-spec.json"
+        spec_file.write_text("{}", encoding="utf-8")
+        # ambient env points at a DIFFERENT tenant — must be ignored.
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+        got_pid, got_data_dir = dispatch_cli._authority_from_spec_path(spec_file)
+        assert got_pid == pid
+        assert got_data_dir == fake_home / ".vnx-data" / pid
+
+    def test_returns_none_for_adhoc_spec_outside_layout(self, tmp_path):
+        spec_file = tmp_path / "dispatch-spec.json"
+        spec_file.write_text("{}", encoding="utf-8")
+        assert dispatch_cli._authority_from_spec_path(spec_file) == (None, None)
+
+    def test_returns_none_for_wrong_filename(self, fake_home):
+        bundle = fake_home / ".vnx-data" / "p" / "dispatches" / "pending" / "20260710-x-y"
+        bundle.mkdir(parents=True)
+        other = bundle / "instruction.md"
+        other.write_text("x", encoding="utf-8")
+        assert dispatch_cli._authority_from_spec_path(other) == (None, None)
+
+
+class TestStageBundleUsesTargetStore:
+    def test_bundle_stages_into_project_store_not_ambient(self, fake_home, monkeypatch):
+        # ambient env resolves vnx-dev; the passed project_id must win.
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        spec_file = dispatch_bridge.stage_spec_bundle(
+            instruction_text="do a thing",
+            dispatch_id="20260710-test-x",
+            role="backend-developer",
+            target_slot="T1",
+            project_id="sales-copilot",
+        )
+        parents = set(spec_file.parents)
+        assert fake_home / ".vnx-data" / "sales-copilot" in parents
+        assert fake_home / ".vnx-data" / "vnx-dev" not in parents
+
+    def test_staged_bundle_and_derived_authority_agree(self, fake_home, monkeypatch):
+        # End-to-end coherence: what stage_spec_bundle writes, the door re-derives.
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")  # stray/ambient
+        spec_file = dispatch_bridge.stage_spec_bundle(
+            instruction_text="do a thing",
+            dispatch_id="20260710-test-z",
+            role="backend-developer",
+            target_slot="T1",
+            project_id="mission-control",
+        )
+        got_pid, _ = dispatch_cli._authority_from_spec_path(spec_file)
+        assert got_pid == "mission-control"
+
+
+class TestEndToEndNoHardReject:
+    def test_consumer_dispatch_validates_without_env(self, fake_home, monkeypatch):
+        """The exact fleet-blocker: a sales-copilot dispatch with NO VNX_PROJECT_ID set,
+        while the ambient env would resolve vnx-dev, must pass validate (not project-mismatch).
+
+        Reproduces the door's resolve->load->validate chain end-to-end against a bundle
+        physically staged in the consumer's store."""
+        from dispatch_spec import Reject, ValidatedSpec  # noqa: PLC0415
+        from dispatch_cli import _authority_from_spec_path, _resolve_project_id, load_spec  # noqa: PLC0415
+        from dispatch_spec import validate  # noqa: PLC0415
+
+        # ambient env simulates the stray engine-tree resolution.
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        spec_file = dispatch_bridge.stage_spec_bundle(
+            instruction_text="ship a real feature end to end",
+            dispatch_id="20260710-sc-e2e",
+            role="backend-developer",
+            target_slot="T1",
+            project_id="sales-copilot",
+        )
+
+        # The door's authority chain (as in run_dispatch):
+        derived_pid, _ = _authority_from_spec_path(spec_file)
+        project_id = derived_pid or _resolve_project_id()
+        spec = load_spec(spec_file)
+        result = validate(spec, project_id=project_id, repo_root=REPO_ROOT)
+
+        assert not isinstance(result, Reject), getattr(result, "reason", result)
+        assert isinstance(result, ValidatedSpec)
+        assert project_id == "sales-copilot"  # authority came from the store, not env
+
+
+class TestOperatorPinCrossCheck:
+    """codex-gate PR #1093: an operator-pinned tenant/data-root must not be contradicted
+    by the staged-bundle authority (restores ADR-007 anti-redirect when a pin exists)."""
+
+    def test_run_dispatch_rejects_project_id_pin_mismatch(self, fake_home, monkeypatch, capsys):
+        from dispatch_cli import run_dispatch  # noqa: PLC0415
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        spec_file = dispatch_bridge.stage_spec_bundle(
+            instruction_text="x", dispatch_id="20260710-pin-a", role="backend-developer",
+            target_slot="T1", project_id="sales-copilot",
+        )
+        # operator pins a DIFFERENT project than the bundle physically lives in.
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        rc = run_dispatch(spec_file)
+        assert rc == 1
+        assert "pinned VNX_PROJECT_ID" in capsys.readouterr().err
+
+    def test_run_dispatch_rejects_explicit_data_dir_mismatch(self, fake_home, monkeypatch, capsys):
+        from dispatch_cli import run_dispatch  # noqa: PLC0415
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        spec_file = dispatch_bridge.stage_spec_bundle(
+            instruction_text="x", dispatch_id="20260710-pin-b", role="backend-developer",
+            target_slot="T1", project_id="sales-copilot",
+        )
+        # operator pins an explicit data root elsewhere than where the bundle lives.
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(fake_home / "elsewhere"))
+        rc = run_dispatch(spec_file)
+        assert rc == 1
+        assert "pinned VNX_DATA_DIR" in capsys.readouterr().err
+
+
+class TestResolveDataDirOverride:
+    def test_project_id_override_beats_env_default(self, fake_home, monkeypatch):
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        got = dispatch_cli._resolve_data_dir("seocrawler-v2")
+        assert got == fake_home / ".vnx-data" / "seocrawler-v2"
+
+    def test_explicit_data_dir_still_wins(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "explicit"))
+        got = dispatch_cli._resolve_data_dir("seocrawler-v2")
+        assert got == (tmp_path / "explicit").resolve()

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -110,11 +110,24 @@ class TestRule2ProjectMismatch:
     def test_rejects_wrong_project_id(self, tmp_path, monkeypatch):
         ifile = _write_instruction(tmp_path)
         spec = _valid_spec(ifile, project_id="other-project")
-        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
-        result = validate(spec, project_id="other-project", repo_root=Path("/fake"))
-        # validate() resolves from env, spec.project_id=other-project != env vnx-dev
+        # The authoritative project_id is what run_dispatch derives from the PHYSICAL
+        # staged-bundle store; a spec declaring a DIFFERENT project_id is an ADR-007
+        # cross-project redirect and must reject. Ambient env must NOT override the
+        # authority (that env-based re-resolve was the fleet-wide hard-reject bug).
+        monkeypatch.setenv("VNX_PROJECT_ID", "other-project")  # matches the spec, but is NOT authority
+        result = validate(spec, project_id="vnx-dev", repo_root=Path("/fake"))
         assert isinstance(result, Reject)
         assert result.code == "project-mismatch"
+
+    def test_validate_uses_authoritative_param_not_env(self, tmp_path, monkeypatch):
+        # Regression for the central-install hard-reject: a legitimate non-vnx-dev
+        # consumer dispatch (spec.project_id == authority) must VALIDATE even when the
+        # ambient env resolves to a different tenant (the stray engine-tree marker).
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, project_id="sales-copilot")
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")  # stray/ambient — must be ignored
+        result = validate(spec, project_id="sales-copilot", repo_root=Path("/fake"))
+        assert isinstance(result, ValidatedSpec)
 
     def test_accepts_matching_project_id(self, tmp_path, monkeypatch):
         ifile = _write_instruction(tmp_path)

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -120,7 +120,24 @@ def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
             check=True,
         )
 
+    # The installed engine tree must be TENANT-NEUTRAL. The repo tracks its own
+    # `.vnx-project-id = vnx-dev`, so a clone/pull drags that marker into the shared
+    # version dir. In central-install mode the door's CWD is this tree; a stray marker
+    # there makes CWD-based project_id resolution return `vnx-dev` for EVERY consumer
+    # (the fleet-wide misroute/hard-reject class). Strip it after every fetch.
+    _strip_tenant_marker(target_dir)
     return target_dir
+
+
+def _strip_tenant_marker(version_dir: Path) -> None:
+    """Remove `.vnx-project-id` from an installed engine version dir (tenant-neutral)."""
+    marker = version_dir / ".vnx-project-id"
+    try:
+        if marker.is_file():
+            marker.unlink()
+            print(f"Stripped stray tenant marker: {marker}")
+    except OSError as exc:
+        print(f"[warn] could not strip tenant marker {marker}: {exc}")
 
 
 def _atomic_symlink_flip(


### PR DESCRIPTION
## Summary

Closes the fleet-wide dispatch **hard-reject / misroute** class. After #1091, dispatching to any non-`vnx-dev` consumer (sales-copilot/mission-control/seocrawler) WITHOUT `VNX_PROJECT_ID` set fails with a hard `project-mismatch` reject.

Root cause (5-parallel-Kimi central-store review, unanimous): the door had **no single coherent authority** for `project_id`/`data_dir` — it re-resolved the tenant from ambient CWD/env (hardcoded `vnx-dev`). In a central install the door's CWD is the shared engine tree, whose **stray `.vnx-project-id=vnx-dev`** (a clone artifact) mis-resolved every consumer.

**Dispatch-ID:** manual-t0-door-authority-20260710

## Changes
The bundle's **physical staged location** is now the single authority:
- `dispatch_bridge.stage_spec_bundle` — stages into the target project's store (not ambient `vnx-dev`); spec's declared project_id and its physical store are always coherent.
- `dispatch_cli.run_dispatch` — derives `(project_id, data_dir)` from the staged spec path (`_authority_from_spec_path`); ambient CWD/env no longer overrides.
- `dispatch_cli._resolve_data_dir(project_id=…)` — explicit tenant beats the env default.
- `dispatch_spec.validate` — uses the authoritative param; deletes the local `_resolve_project_id()` + `vnx-dev` fallback. ADR-007 anti-redirect stays meaningful (a spec staged in store X may not declare project_id≠X).
- **Tier 2:** `install-central.sh` + `vnx_cli/commands/update.py` strip `.vnx-project-id` from the engine version dir after clone/pull (tenant-neutral tree); existing stray markers removed from the live install.

## Verification
- `tests/test_dispatch_door_authority.py` — **8 new**, incl. the exact no-env consumer-dispatch end-to-end that previously hard-rejected.
- `test_dispatch_spec` Rule-2 updated to the authoritative-param contract (old test asserted the buggy env re-resolve).
- **243 dispatch tests green** (spec/cli/bridge/sidedoor/door-flip/authority).
- 18 pre-existing `test_provider_dispatch_governance_integration` failures confirmed present on clean main (token_usage/cost harness issue) — unrelated, out of scope.

## Open Items
Follow-up tiers from the review (tracked separately): fail-closed `vnx-dev` sweep (~13 sites incl. `project_scope.current_project_id`), migration FK/integrity guard + re-enable W1 tenant-stamp, central-read cutover (`VNX_USE_CENTRAL_DB` opt-in), receipt-pipeline unification.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7