### PR TITLE
feat(migrate): advisory pre-flight FK/integrity check before each store migration

### DIFF
--- a/scripts/lib/store_integrity.py
+++ b/scripts/lib/store_integrity.py
@@ -1,0 +1,114 @@
+"""Advisory pre-migration integrity check for a central store.
+
+Runs ``PRAGMA foreign_key_check`` + ``PRAGMA integrity_check`` on a store's
+``runtime_coordination.db`` BEFORE a migration mutates it, so dangling FK edges
+(the mission-control 22-dangling ``track_dependencies`` class, 2026-07-10) surface as a
+clear report instead of a cryptic mid-migration constraint failure.
+
+**Advisory by default** — reports violations and continues; the migration runner already
+prunes/repairs many of them. Set ``VNX_MIGRATE_STRICT_FK=1`` to abort a store's migration
+before it mutates (the fleet sweep then skips that one store and continues). Read-only:
+opens the DB in ``mode=ro`` and never writes.
+
+This is the low-risk half of Tier F migration hardening (central-store review 2026-07-10,
+task #30). The W1 tenant-stamp re-enable is the operator-gated half and lives elsewhere.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import List, NamedTuple, Optional
+
+
+class StoreIntegrityError(RuntimeError):
+    """Raised by ``preflight_or_report`` only when VNX_MIGRATE_STRICT_FK=1 and the store
+    has FK/integrity violations."""
+
+
+class IntegrityReport(NamedTuple):
+    db_path: Path
+    fk_violations: List[tuple]      # rows from PRAGMA foreign_key_check
+    integrity_errors: List[str]     # PRAGMA integrity_check rows other than "ok"
+    ok: bool
+
+
+def check_store_integrity(db_path: "str | Path") -> IntegrityReport:
+    """Read-only FK + integrity check. A missing/unreadable DB reports ``ok`` (nothing to
+    check) rather than raising — the migration itself handles a truly broken file."""
+    path = Path(db_path)
+    if not path.is_file():
+        return IntegrityReport(path, [], [], True)
+    try:
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+    except sqlite3.Error:
+        return IntegrityReport(path, [], [], True)
+    try:
+        fk = list(conn.execute("PRAGMA foreign_key_check").fetchall())
+        integ = [str(r[0]) for r in conn.execute("PRAGMA integrity_check").fetchall()]
+    except sqlite3.Error:
+        return IntegrityReport(path, [], [], True)
+    finally:
+        conn.close()
+    integ_errors = [r for r in integ if r != "ok"]
+    return IntegrityReport(path, fk, integ_errors, not fk and not integ_errors)
+
+
+def strict_fk_enabled(env: Optional[dict] = None) -> bool:
+    env = os.environ if env is None else env
+    return env.get("VNX_MIGRATE_STRICT_FK") == "1"
+
+
+def preflight_or_report(
+    db_path: "str | Path",
+    *,
+    label: str = "",
+    out=None,
+) -> IntegrityReport:
+    """Run the advisory pre-flight. Prints a report on violations. Raises
+    ``StoreIntegrityError`` ONLY when ``VNX_MIGRATE_STRICT_FK=1``; otherwise advisory."""
+    stream = out or sys.stderr
+    report = check_store_integrity(db_path)
+    if report.ok:
+        return report
+
+    tag = f"[integrity]{(' ' + label) if label else ''}"
+    if report.fk_violations:
+        print(
+            f"  {tag} {len(report.fk_violations)} dangling FK row(s) in {report.db_path.name}:",
+            file=stream,
+        )
+        for row in report.fk_violations[:20]:
+            tbl = row[0] if len(row) > 0 else "?"
+            rowid = row[1] if len(row) > 1 else "?"
+            parent = row[2] if len(row) > 2 else "?"
+            fkid = row[3] if len(row) > 3 else "?"
+            print(f"    {tbl} rowid={rowid} -> missing parent {parent} (fk#{fkid})", file=stream)
+        if len(report.fk_violations) > 20:
+            print(f"    … +{len(report.fk_violations) - 20} more", file=stream)
+    for err in report.integrity_errors[:10]:
+        print(f"  {tag} integrity: {err}", file=stream)
+
+    if strict_fk_enabled():
+        raise StoreIntegrityError(
+            f"{report.db_path}: {len(report.fk_violations)} FK + "
+            f"{len(report.integrity_errors)} integrity violation(s) "
+            "(VNX_MIGRATE_STRICT_FK=1 — aborting this store before it mutates)"
+        )
+    print(
+        f"  {tag} advisory only — continuing; set VNX_MIGRATE_STRICT_FK=1 to abort a "
+        "violating store before it mutates.",
+        file=stream,
+    )
+    return report
+
+
+__all__ = [
+    "IntegrityReport",
+    "StoreIntegrityError",
+    "check_store_integrity",
+    "preflight_or_report",
+    "strict_fk_enabled",
+]

--- a/tests/test_store_integrity.py
+++ b/tests/test_store_integrity.py
@@ -1,0 +1,114 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/store_integrity.py — the advisory pre-migration FK/integrity
+check (Tier F, task #30). Reproduces the mission-control dangling-FK class in a fixture."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+from store_integrity import (  # noqa: E402
+    StoreIntegrityError,
+    check_store_integrity,
+    preflight_or_report,
+    strict_fk_enabled,
+)
+
+
+def _make_clean_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    conn.executescript(
+        """
+        CREATE TABLE tracks (track_id TEXT PRIMARY KEY);
+        CREATE TABLE deps (
+            id INTEGER PRIMARY KEY,
+            from_track TEXT REFERENCES tracks(track_id)
+        );
+        INSERT INTO tracks VALUES ('t1');
+        INSERT INTO deps (from_track) VALUES ('t1');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+def _make_dangling_fk_db(path: Path) -> None:
+    conn = sqlite3.connect(path)
+    # FK enforcement OFF so we can plant a dangling edge (the mission-control class).
+    conn.executescript(
+        """
+        PRAGMA foreign_keys=OFF;
+        CREATE TABLE tracks (track_id TEXT PRIMARY KEY);
+        CREATE TABLE deps (
+            id INTEGER PRIMARY KEY,
+            from_track TEXT REFERENCES tracks(track_id)
+        );
+        INSERT INTO tracks VALUES ('t1');
+        INSERT INTO deps (from_track) VALUES ('ghost-track');
+        """
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestCheckStoreIntegrity:
+    def test_clean_db_is_ok(self, tmp_path):
+        db = tmp_path / "runtime_coordination.db"
+        _make_clean_db(db)
+        report = check_store_integrity(db)
+        assert report.ok
+        assert report.fk_violations == []
+        assert report.integrity_errors == []
+
+    def test_dangling_fk_detected(self, tmp_path):
+        db = tmp_path / "runtime_coordination.db"
+        _make_dangling_fk_db(db)
+        report = check_store_integrity(db)
+        assert not report.ok
+        assert len(report.fk_violations) == 1
+        assert any("deps" in str(v[0]) for v in report.fk_violations)
+
+    def test_missing_db_reports_ok(self, tmp_path):
+        report = check_store_integrity(tmp_path / "nope.db")
+        assert report.ok
+
+
+class TestPreflightAdvisoryVsStrict:
+    def test_advisory_does_not_raise_on_violation(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.delenv("VNX_MIGRATE_STRICT_FK", raising=False)
+        db = tmp_path / "runtime_coordination.db"
+        _make_dangling_fk_db(db)
+        report = preflight_or_report(db, label="mission-control")
+        assert not report.ok
+        err = capsys.readouterr().err
+        assert "dangling FK" in err
+        assert "advisory only" in err
+
+    def test_strict_raises_on_violation(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_MIGRATE_STRICT_FK", "1")
+        db = tmp_path / "runtime_coordination.db"
+        _make_dangling_fk_db(db)
+        with pytest.raises(StoreIntegrityError):
+            preflight_or_report(db, label="mission-control")
+
+    def test_clean_db_silent_and_no_raise_even_in_strict(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setenv("VNX_MIGRATE_STRICT_FK", "1")
+        db = tmp_path / "runtime_coordination.db"
+        _make_clean_db(db)
+        report = preflight_or_report(db)
+        assert report.ok
+        assert capsys.readouterr().err == ""
+
+
+def test_strict_fk_enabled_flag():
+    assert strict_fk_enabled({"VNX_MIGRATE_STRICT_FK": "1"}) is True
+    assert strict_fk_enabled({"VNX_MIGRATE_STRICT_FK": "0"}) is False
+    assert strict_fk_enabled({}) is False

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -93,6 +93,20 @@ def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
     # existing marker / VNX_PROJECT_ID / the data-path anchor (no split-tenant store).
     _reconcile_tenant_or_fail(data_root, project_id)
 
+    # Advisory pre-flight integrity check (Tier F, task #30): surface dangling FK edges
+    # (the mission-control 22-dangling track_dependencies class) as a clear report BEFORE
+    # the migration mutates, instead of a cryptic mid-migration constraint failure. Placed
+    # right after the tenant gate and before ANY write (marker or DB), so strict mode aborts
+    # before the store is touched at all. Advisory by default; VNX_MIGRATE_STRICT_FK=1 aborts
+    # a violating store (the fleet sweep then skips it and continues). Fail-open: never block
+    # a migration on the check itself.
+    try:
+        from store_integrity import preflight_or_report  # noqa: PLC0415
+
+        preflight_or_report(data_root / "state" / "runtime_coordination.db", label=project_id)
+    except ImportError:
+        pass  # advisory tooling absent — never blocks the migration
+
     # Anchor the tenant on disk (not via a global env mutation that would leak across
     # a fleet sweep or a shared test process): write the canonical .vnx-project-id
     # marker in the data root when absent, so the fail-closed resolver in the runner


### PR DESCRIPTION
## Summary

The mission-control fleet migration failed on **22 dangling `track_dependencies` FK rows** (2026-07-10) with a cryptic mid-migration error and no pre-warning. This adds the low-risk half of Tier F migration hardening (central-store review task #30): an advisory pre-flight integrity check.

**Dispatch-ID:** manual-t0-migrate-integrity-20260710

## Changes
- **New `scripts/lib/store_integrity.py`** — read-only `PRAGMA foreign_key_check` + `integrity_check` on `runtime_coordination.db`, run BEFORE `migrate_future_system.run()` mutates. Reports dangling FK edges (table/rowid/missing-parent) and continues. `VNX_MIGRATE_STRICT_FK=1` aborts a violating store before it mutates (fleet sweep skips it, continues).
- **`vnx_cli/commands/migrate.py`** — wired fail-open into the per-store pipeline (import error never blocks a migration).

Low-risk by construction: mutates nothing, advisory by default, so it cannot newly-block a fleet migration. The **operator-gated** half of Tier F (re-enable W1 tenant-stamp — currently disabled because broken for normally-bootstrapped stores) stays task #30, awaiting explicit operator steer.

## Verification
- `tests/test_store_integrity.py` — 7 tests: reproduce the dangling-FK class in a fixture, advisory-vs-strict, missing-DB → ok.
- Verified live: all 4 central stores (vnx-dev/mission-control/sales-copilot/seocrawler-v2) report clean (0 FK, 0 integrity).

## Open Items
Operator-gated Tier F remainder (W1 tenant-stamp re-enable) tracked as #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7