### PR TITLE
fix(tenant-stamp): dedup dual-seed legacy rows, re-enable W1 in vnx migrate

### DIFF
--- a/scripts/lib/tenant_stamping.py
+++ b/scripts/lib/tenant_stamping.py
@@ -882,6 +882,72 @@ def _resolve_legacy_guard(
                 )
 
 
+def _unique_keys_including_pid(conn: sqlite3.Connection, table: str) -> list[list[str]]:
+    """Natural-key column lists for every UNIQUE index/PK on ``table`` that includes
+    ``project_id`` (any origin — declared UNIQUE, composite PK auto-index, or standalone
+    UNIQUE index). Each returned list is the key columns OTHER than project_id, i.e. the
+    natural key a legacy row and a pid row can collide on during the Phase-2 restamp.
+    Expression indexes (index_info column name is NULL) are skipped."""
+    keys: list[list[str]] = []
+    seen: set[tuple] = set()
+    for idx in conn.execute(f"PRAGMA index_list({_safe_ident(table)[1:-1]})").fetchall():
+        if not idx[2]:  # not unique
+            continue
+        # Skip PARTIAL unique indexes (index_list col 4 = 'partial'): they only enforce
+        # uniqueness on rows matching their WHERE predicate, so a (pid, key) row need not
+        # collide with a legacy (vnx-dev, key) row — deduping on one risks a false positive.
+        if len(idx) > 4 and idx[4]:
+            continue
+        cols = [
+            r[2]
+            for r in conn.execute(
+                f"PRAGMA index_info({_safe_ident(idx[1])[1:-1]})"
+            ).fetchall()
+        ]
+        if any(c is None for c in cols) or "project_id" not in cols:
+            continue
+        other = tuple(c for c in cols if c != "project_id")
+        if other and other not in seen:
+            seen.add(other)
+            keys.append(list(other))
+    return keys
+
+
+def _dedup_legacy_collisions(conn: sqlite3.Connection, table: str, pid: str) -> int:
+    """Delete legacy (NULL/''/'vnx-dev') rows whose Phase-2 restamp target ``(pid, key)``
+    ALREADY exists — the pid row is authoritative; the legacy row is a stale mis-tenanted
+    duplicate (the normally-bootstrapped-store dual-seed: e.g. a ``('vnx-dev','default')``
+    and a ``(<pid>,'default')`` pool_config/execution_targets row). Without this the
+    ``'vnx-dev'``→``<pid>`` restamp trips the composite ``UNIQUE(project_id, …)`` constraint
+    and W1 aborts (the reason ``vnx migrate`` shipped ``run_tenant_stamp=False``).
+
+    Runs inside the caller's ``foreign_keys=OFF`` Phase-2 transaction; any child rows that
+    referenced the deleted legacy parent repoint to the surviving pid parent via their own
+    restamp, so ``foreign_key_check`` passes at COMMIT. No-op for a vnx-dev store (no
+    restamp happens there). Returns rows deleted."""
+    if pid == "vnx-dev":
+        return 0
+    t = _safe_ident(table)
+    deleted = 0
+    for key_cols in _unique_keys_including_pid(conn, table):
+        # Use `=` (NOT `IS`): a SQLite UNIQUE collision requires every key column non-NULL
+        # AND equal — two NULLs do NOT collide (SQLite allows duplicate NULLs in a UNIQUE
+        # index). `keep.col = t.col` is NULL/false when either side is NULL, so a legacy row
+        # with a NULL key column is left for the restamp instead of being wrongly deleted.
+        pred = " AND ".join(
+            f"keep.{_safe_ident(c)} = {t}.{_safe_ident(c)}" for c in key_cols
+        )
+        cur = conn.execute(
+            f"DELETE FROM {t} "
+            f"WHERE ({t}.project_id IS NULL OR {t}.project_id IN ('vnx-dev', '')) "
+            f"AND EXISTS (SELECT 1 FROM {t} AS keep "
+            f"WHERE keep.project_id = ? AND {pred})",
+            (pid,),
+        )
+        deleted += cur.rowcount
+    return deleted
+
+
 def _restamp_table(conn: sqlite3.Connection, table: str, pid: str) -> int:
     """Re-stamp legacy project_id values in ``table`` to ``pid``.
 
@@ -934,6 +1000,9 @@ def run_phase2_restamp(
         conn.execute("BEGIN EXCLUSIVE")
         try:
             for table in tables:
+                # Dedup the dual-seed legacy duplicates BEFORE restamping so the
+                # 'vnx-dev'->pid UPDATE cannot trip the composite UNIQUE(project_id, …).
+                _dedup_legacy_collisions(conn, table, pid)
                 n = _restamp_table(conn, table, pid)
                 updated[table] = n
 

--- a/tests/test_w1_dedup_collision.py
+++ b/tests/test_w1_dedup_collision.py
@@ -1,0 +1,118 @@
+#!/usr/bin/env python3
+"""Regression tests for the W1 dual-seed collision fix (tenant_stamping._dedup_legacy_collisions,
+2026-07-10). A normally-bootstrapped non-vnx-dev store carries BOTH a legacy ('vnx-dev', key) row
+and an authoritative (<pid>, key) row on a composite UNIQUE(project_id, key). Phase 2's
+'vnx-dev'->pid restamp trips that UNIQUE — the reason `vnx migrate` shipped run_tenant_stamp=False.
+The dedup drops the stale legacy duplicate (pid row is authoritative) before the restamp."""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+from tenant_stamping import (  # noqa: E402
+    _dedup_legacy_collisions,
+    _unique_keys_including_pid,
+    run_phase2_restamp,
+)
+
+
+def _conn_with_dual_seed() -> sqlite3.Connection:
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(
+        """
+        CREATE TABLE execution_targets (
+            project_id TEXT,
+            target_id  TEXT,
+            data       TEXT,
+            UNIQUE(project_id, target_id)
+        );
+        -- authoritative pid rows + stale vnx-dev duplicates on the SAME target_id
+        INSERT INTO execution_targets VALUES ('sales-copilot','T1','keep');
+        INSERT INTO execution_targets VALUES ('vnx-dev','T1','stale');
+        INSERT INTO execution_targets VALUES ('sales-copilot','T2','keep');
+        INSERT INTO execution_targets VALUES ('vnx-dev','T2','stale');
+        -- a vnx-dev-ONLY row with no pid twin: must NOT be deduped (it gets restamped instead)
+        INSERT INTO execution_targets VALUES ('vnx-dev','T9','unique-legacy');
+        """
+    )
+    conn.commit()
+    return conn
+
+
+class TestUniqueKeysIncludingPid:
+    def test_finds_composite_unique_natural_key(self):
+        conn = _conn_with_dual_seed()
+        keys = _unique_keys_including_pid(conn, "execution_targets")
+        assert ["target_id"] in keys
+
+
+class TestDedupLegacyCollisions:
+    def test_drops_only_colliding_legacy_rows(self):
+        conn = _conn_with_dual_seed()
+        deleted = _dedup_legacy_collisions(conn, "execution_targets", "sales-copilot")
+        assert deleted == 2  # ('vnx-dev','T1') + ('vnx-dev','T2'); NOT the T9 orphan
+        rows = set(conn.execute("SELECT project_id, target_id FROM execution_targets").fetchall())
+        assert ("sales-copilot", "T1") in rows and ("sales-copilot", "T2") in rows
+        assert ("vnx-dev", "T1") not in rows and ("vnx-dev", "T2") not in rows
+        assert ("vnx-dev", "T9") in rows  # no pid twin -> preserved for the restamp
+
+    def test_noop_for_vnx_dev_store(self):
+        conn = _conn_with_dual_seed()
+        assert _dedup_legacy_collisions(conn, "execution_targets", "vnx-dev") == 0
+
+    def test_null_key_not_deduped(self):
+        # SQLite allows duplicate NULLs in a UNIQUE index, so a legacy row with a NULL
+        # natural key does NOT collide with a pid row — it must be left for the restamp,
+        # not deleted. (codex gate: `IS` would wrongly treat NULLs as equal.)
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            """
+            CREATE TABLE t (project_id TEXT, k TEXT, UNIQUE(project_id, k));
+            INSERT INTO t VALUES ('sales-copilot', NULL);
+            INSERT INTO t VALUES ('vnx-dev', NULL);
+            """
+        )
+        conn.commit()
+        assert _dedup_legacy_collisions(conn, "t", "sales-copilot") == 0
+
+    def test_partial_unique_index_skipped(self):
+        # A partial UNIQUE index only enforces uniqueness on rows matching its predicate,
+        # so it must not drive a dedup (codex gate: false-positive risk).
+        conn = sqlite3.connect(":memory:")
+        conn.executescript(
+            """
+            CREATE TABLE t (project_id TEXT, k TEXT, active INT);
+            CREATE UNIQUE INDEX ux ON t(project_id, k) WHERE active = 1;
+            INSERT INTO t VALUES ('sales-copilot', 'K', 0);
+            INSERT INTO t VALUES ('vnx-dev', 'K', 0);
+            """
+        )
+        conn.commit()
+        assert _unique_keys_including_pid(conn, "t") == []
+        assert _dedup_legacy_collisions(conn, "t", "sales-copilot") == 0
+
+
+class TestPhase2RestampWithDualSeed:
+    def test_restamp_succeeds_and_repoints(self):
+        conn = _conn_with_dual_seed()
+        # Before the fix this raised "UNIQUE constraint failed: execution_targets".
+        run_phase2_restamp(conn, ["execution_targets"], "sales-copilot", db_label="test")
+        rows = sorted(conn.execute("SELECT project_id, target_id FROM execution_targets").fetchall())
+        # dual-seed collapsed to the authoritative pid rows; the orphan legacy row restamped.
+        assert rows == [
+            ("sales-copilot", "T1"),
+            ("sales-copilot", "T2"),
+            ("sales-copilot", "T9"),
+        ]
+        # no leftover legacy tenants
+        legacy = conn.execute(
+            "SELECT COUNT(*) FROM execution_targets WHERE project_id IN ('vnx-dev','') OR project_id IS NULL"
+        ).fetchone()[0]
+        assert legacy == 0

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -120,15 +120,19 @@ def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
             pass  # advisory — central stores still resolve via the DB-path anchor
 
     # data_dir is threaded explicitly (D4 threading trap); no env mutation needed.
-    # run_tenant_stamp=False: W1 tenant-stamping is disabled for vnx migrate because it
-    # is currently broken for the stores this targets (pool_config UNIQUE collision on
-    # every bootstrapped store + a legacy recommendation_outcomes child-FK gap) and
-    # would only churn the store on a self-restoring failure. The schema fix that adds
-    # tracks.horizon (the actual gap) is delivered by the walk regardless. See run().
+    # run_tenant_stamp=True (RE-ENABLED 2026-07-10): W1 tenant-stamping was disabled because
+    # a normally-bootstrapped non-vnx-dev store carries a legacy ('vnx-dev', key) row AND an
+    # authoritative (<pid>, key) row on a composite UNIQUE(project_id, key) (e.g.
+    # execution_targets, pool_config), so Phase 2's 'vnx-dev'->pid restamp tripped the UNIQUE.
+    # tenant_stamping._dedup_legacy_collisions now drops the stale legacy duplicate (the pid
+    # row wins; children repoint via their own restamp) BEFORE the restamp. Verified on copies
+    # of all 4 live central stores: W1 succeeds, foreign_key_check clean, only stale dual-seed
+    # duplicates removed (no legitimate-data loss). tenant_stamp_fatal=False keeps a W1 failure
+    # non-fatal (WARNING after the committed schema walk) as belt-and-suspenders.
     migrate_future_system.run(
         data_dir=data_root,
         tenant_stamp_fatal=False,
-        run_tenant_stamp=False,
+        run_tenant_stamp=True,
         backup=True,
     )
 


### PR DESCRIPTION
## Summary

Re-enables W1 tenant-stamping in `vnx migrate` (the operator-gated half of Tier F / task #30), authorized explicitly for a **review-before-merge** PR. W1 was shipped disabled (`run_tenant_stamp=False`) because it broke on normally-bootstrapped non-vnx-dev stores.

**Dispatch-ID:** manual-t0-w1-reenable-20260710

## Root cause (empirical — dry-run on copies of all 4 live central stores)
A normally-bootstrapped non-vnx-dev store carries BOTH a legacy `('vnx-dev', key)` row and an authoritative `(<pid>, key)` row on a composite `UNIQUE(project_id, key)`. sales-copilot's `execution_targets` had `('vnx-dev', interactive_tmux_claude_T1..T3)` twins of its `(sales-copilot, …)` rows + a `('vnx-dev','default')`/`(<pid>,'default')` pool_config dual-seed. Phase 2's `'vnx-dev'`→pid restamp trips the UNIQUE → W1 self-restores from checkpoint → churn, no progress.

## Changes
- **`tenant_stamping.py`**: `_dedup_legacy_collisions` + `_unique_keys_including_pid` drop each stale legacy duplicate whose restamp-target `(pid, key)` already exists, BEFORE the Phase-2 restamp. The pid row is authoritative; children repoint to the surviving pid parent via their own restamp (FK-clean at COMMIT). Generic over any UNIQUE/PK including project_id. No-op for a vnx-dev store.
- **`vnx_cli/commands/migrate.py`**: `run_tenant_stamp=True` (kept `tenant_stamp_fatal=False` — a W1 failure downgrades to WARNING, never aborts the migration).

## Verification (dry-run on copies — no live store touched)
| store | W1 | FK-check | rows exec/pool/tracks | vnx-dev leftover |
|---|---|---|---|---|
| sales-copilot | ✅ (was ❌ UNIQUE) | 0 | 6/2/17 → **3/1/17** | 0 |
| mission-control | ✅ | 0 | 3/1/47 unchanged | 0 |
| seocrawler-v2 | ✅ | 0 | 3/1/26 unchanged | 0 |
| vnx-dev | ✅ | 0 | 3/1/156 unchanged | 0 |

Confirmed every deleted `vnx-dev` row had an exact pid twin on the natural key (0 vnx-dev-only rows) — dedup, not data loss.

- `tests/test_w1_dedup_collision.py` (4): reproduce the collision + assert an orphan-legacy row (no pid twin) is **preserved** (restamped, not deleted).
- 125 W1/tenant-stamping tests green.

## Open Items
Review-before-merge (operator-gated per your go). Remaining Tier F polish (kill `DEFAULT 'vnx-dev'` in schemas, extend composite UNIQUE to coordination_events/incident_log/intelligence_injections) stays in #30.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7