### PR TITLE
feat(adr-028): Phase 2 decision-judge SHADOW mode (safety valve, default-off)

### DIFF
--- a/scripts/decision_shadow_report.py
+++ b/scripts/decision_shadow_report.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Report the decision-judge SHADOW divergence (ADR-028 Phase 2).
+
+Prints how often the shadow judge agreed with T0's actual decision — the data that
+justifies (or blocks) turning on Phases 3-4. Reads the per-project central store by
+default; pass --state-dir to target another.
+
+    python3 scripts/decision_shadow_report.py [--state-dir DIR] [--limit N]
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from decision_shadow import DIVERGENCE_LEDGER, divergence_summary  # noqa: E402
+
+
+def _recent(state_dir: Path, limit: int) -> list[dict]:
+    path = state_dir / DIVERGENCE_LEDGER
+    rows: list[dict] = []
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rows.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+    except OSError:
+        return []
+    return rows[-limit:]
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description="ADR-028 Phase 2 shadow divergence report")
+    parser.add_argument("--state-dir", default=None, help="central state dir (default: resolved)")
+    parser.add_argument("--limit", type=int, default=10, help="recent divergences to show")
+    args = parser.parse_args(argv)
+
+    if args.state_dir is not None:
+        state_dir = Path(args.state_dir)
+    else:
+        from vnx_paths import resolve_state_dir  # noqa: PLC0415
+        state_dir = resolve_state_dir()
+
+    summary = divergence_summary(state_dir=state_dir)
+    print(f"VNX decision-judge SHADOW divergence — {state_dir}")
+    if summary["total"] == 0:
+        print("  no divergence records yet (shadow off, or no decisions logged).")
+        return 0
+
+    rate = summary["agree_rate"]
+    print(f"  decisions compared : {summary['total']}")
+    print(f"  judge agreed       : {summary['agree']}")
+    print(f"  judge diverged     : {summary['disagree']}")
+    print(f"  agreement rate     : {rate:.1%}" if rate is not None else "  agreement rate     : n/a")
+
+    recent = [r for r in _recent(state_dir, args.limit) if r.get("agree") is False]
+    if recent:
+        print(f"\n  recent divergences (judge != T0), last {len(recent)}:")
+        for r in recent:
+            print(
+                f"    {r.get('decision_id','?')}: T0={r.get('actual_action')!r} "
+                f"judge={r.get('advisory_action')!r} (conf {r.get('advisory_confidence')})"
+            )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/decision_shadow.py
+++ b/scripts/lib/decision_shadow.py
@@ -1,0 +1,187 @@
+"""ADR-028 Phase 2 — decision-judge SHADOW mode (the safety valve).
+
+Gated behind ``VNX_DECISION_JUDGE_SHADOW=1`` (default OFF). When ON, a judge produces an
+ADVISORY decision at each governance decision point; it is written to a SEPARATE
+``decision_advisory.ndjson`` ledger that T0 READS BUT NEVER ACTS ON — T0 decides itself. A
+comparator then logs where the judge and the human (T0) diverge to
+``decision_divergence.ndjson``. This validates the judge against the human at ZERO risk
+before any decision authority shifts (that shift is Phases 3-4, separately operator-gated).
+
+Zero-risk guarantees:
+- Default OFF; every function is a no-op when the flag is unset.
+- Advisories + divergences live in their OWN ledgers, NOT the governed ``t0_receipts.ndjson``,
+  so nothing downstream (receipt processor, gates) is affected by shadow output.
+- The comparator only LOGS; it never changes a decision.
+- Every entry point is fail-open: a shadow error MUST NOT break T0's real decision.
+
+Rollback: unset the flag; the advisory ledgers are inert observability.
+
+The judge is pluggable (``judge`` param). The default is the deterministic rule-based
+decision (no LLM, zero cost); the real ephemeral LLM judge (Phase 3+) injects its own.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+_LIB = Path(__file__).resolve().parent
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+ADVISORY_LEDGER = "decision_advisory.ndjson"
+DIVERGENCE_LEDGER = "decision_divergence.ndjson"
+_FLAG = "VNX_DECISION_JUDGE_SHADOW"
+
+
+def shadow_enabled(env: Optional[dict] = None) -> bool:
+    """True iff VNX_DECISION_JUDGE_SHADOW=1. Default OFF (the safety valve is opt-in)."""
+    env = os.environ if env is None else env
+    return env.get(_FLAG) == "1"
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _state_dir(state_dir: "str | Path | None") -> Path:
+    if state_dir is not None:
+        return Path(state_dir)
+    from vnx_paths import resolve_state_dir  # noqa: PLC0415
+    return resolve_state_dir()
+
+
+def _default_judge(context: Dict[str, Any], question: str):
+    """Deterministic rule-based judge (no LLM, no cost). The real ephemeral LLM judge is
+    injected via the ``judge`` param; this keeps shadow mode zero-cost by default."""
+    from llm_decision_router import _rule_based_decision  # noqa: PLC0415
+    return _rule_based_decision(context, question)
+
+
+def _atomic_append(path: Path, record: Dict[str, Any], lock_name: str) -> None:
+    """fcntl-locked atomic NDJSON append (same contract as append_receipt/shadow_logger)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    sentinel = path.parent / lock_name
+    with sentinel.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            fh.write(json.dumps(record, separators=(",", ":"), sort_keys=False) + "\n")
+
+
+def _advisory_dict(result: Any) -> Dict[str, Any]:
+    if hasattr(result, "to_dict"):
+        return result.to_dict()
+    if isinstance(result, dict):
+        return result
+    return {"action": getattr(result, "action", None)}
+
+
+def record_advisory(
+    decision_id: str,
+    context: Dict[str, Any],
+    question: str,
+    *,
+    judge: Optional[Callable[[Dict[str, Any], str], Any]] = None,
+    state_dir: "str | Path | None" = None,
+    ts: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """When shadow is ON, run the judge and append a ``decision_advisory`` entry. T0 must
+    READ BUT NOT ACT on it. Returns the advisory dict (action/reasoning/confidence/…), or
+    None when shadow is OFF or on any error (fail-open — never breaks the real path)."""
+    if not shadow_enabled():
+        return None
+    try:
+        result = (judge or _default_judge)(context, question)
+        advisory = _advisory_dict(result)
+        record = {
+            "event": "decision_advisory",
+            "decision_id": decision_id,
+            "question": question,
+            "advisory": advisory,
+            "ts": ts or _now_iso(),
+            "note": "SHADOW advisory — T0 does not act on this (ADR-028 Phase 2)",
+        }
+        _atomic_append(_state_dir(state_dir) / ADVISORY_LEDGER, record, ADVISORY_LEDGER + ".lock")
+        return advisory
+    except Exception:  # noqa: BLE001 — shadow must never break the real decision path
+        return None
+
+
+def compare_and_log(
+    decision_id: str,
+    actual_action: Optional[str],
+    advisory: Optional[Dict[str, Any]],
+    *,
+    state_dir: "str | Path | None" = None,
+    ts: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    """Comparator: log whether T0's actual decision agrees with the judge's advisory, to
+    ``decision_divergence.ndjson``. Logs ONLY — never changes a decision. No-op when shadow
+    is OFF or ``advisory`` is None. Returns the divergence record, or None (fail-open)."""
+    if not shadow_enabled() or advisory is None:
+        return None
+    try:
+        advisory_action = (
+            advisory.get("action") if isinstance(advisory, dict)
+            else getattr(advisory, "action", None)
+        )
+        record = {
+            "event": "decision_divergence",
+            "decision_id": decision_id,
+            "actual_action": actual_action,
+            "advisory_action": advisory_action,
+            "agree": actual_action == advisory_action,
+            "advisory_confidence": (
+                advisory.get("confidence") if isinstance(advisory, dict) else None
+            ),
+            "ts": ts or _now_iso(),
+        }
+        _atomic_append(
+            _state_dir(state_dir) / DIVERGENCE_LEDGER, record, DIVERGENCE_LEDGER + ".lock"
+        )
+        return record
+    except Exception:  # noqa: BLE001 — comparator is observational; never break the caller
+        return None
+
+
+def divergence_summary(state_dir: "str | Path | None" = None) -> Dict[str, Any]:
+    """Read the divergence ledger and return {total, agree, disagree, agree_rate}. This is
+    the data that justifies (or blocks) turning on Phases 3-4. Empty/absent ledger -> zeros."""
+    path = _state_dir(state_dir) / DIVERGENCE_LEDGER
+    total = agree = 0
+    try:
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            total += 1
+            if rec.get("agree") is True:
+                agree += 1
+    except OSError:
+        pass
+    return {
+        "total": total,
+        "agree": agree,
+        "disagree": total - agree,
+        "agree_rate": (agree / total) if total else None,
+    }
+
+
+__all__ = [
+    "ADVISORY_LEDGER",
+    "DIVERGENCE_LEDGER",
+    "shadow_enabled",
+    "record_advisory",
+    "compare_and_log",
+    "divergence_summary",
+]

--- a/tests/test_decision_shadow.py
+++ b/tests/test_decision_shadow.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/decision_shadow.py — ADR-028 Phase 2 decision-judge SHADOW mode.
+
+Zero-risk contract: default OFF (no-op), separate ledgers (never t0_receipts.ndjson),
+comparator logs only, fail-open."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import decision_shadow as ds  # noqa: E402
+
+
+CTX_FAILED = {"receipt": {"status": "failed"}}
+Q = "advance or retry this dispatch?"
+
+
+class TestFlagGate:
+    def test_default_off_is_noop(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_DECISION_JUDGE_SHADOW", raising=False)
+        assert ds.shadow_enabled() is False
+        assert ds.record_advisory("d1", CTX_FAILED, Q, state_dir=tmp_path) is None
+        # nothing written
+        assert not (tmp_path / ds.ADVISORY_LEDGER).exists()
+
+    def test_enabled_flag(self, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        assert ds.shadow_enabled() is True
+
+
+class TestRecordAdvisory:
+    def test_writes_advisory_ledger_when_on(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        advisory = ds.record_advisory("d1", CTX_FAILED, Q, state_dir=tmp_path)
+        assert advisory is not None and advisory["action"] == "re_dispatch"
+        led = tmp_path / ds.ADVISORY_LEDGER
+        assert led.exists() and "decision_advisory" in led.read_text(encoding="utf-8")
+
+    def test_does_not_touch_governed_receipt_ledger(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        ds.record_advisory("d1", CTX_FAILED, Q, state_dir=tmp_path)
+        # ISOLATION: shadow output must never land in the governed audit trail.
+        assert not (tmp_path / "t0_receipts.ndjson").exists()
+
+    def test_custom_judge_injected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+
+        class _J:
+            def to_dict(self):
+                return {"action": "custom", "confidence": 0.5}
+
+        advisory = ds.record_advisory(
+            "d1", {}, Q, judge=lambda c, q: _J(), state_dir=tmp_path
+        )
+        assert advisory["action"] == "custom"
+
+    def test_fail_open_on_broken_judge(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+
+        def _boom(context, question):
+            raise ValueError("judge exploded")
+
+        # must NOT raise into the real decision path
+        assert ds.record_advisory("d1", {}, Q, judge=_boom, state_dir=tmp_path) is None
+
+
+class TestComparator:
+    def test_agree_and_disagree(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        advisory = {"action": "re_dispatch", "confidence": 0.8}
+        agree = ds.compare_and_log("d1", "re_dispatch", advisory, state_dir=tmp_path)
+        disagree = ds.compare_and_log("d2", "skip", advisory, state_dir=tmp_path)
+        assert agree["agree"] is True
+        assert disagree["agree"] is False
+        assert (tmp_path / ds.DIVERGENCE_LEDGER).exists()
+
+    def test_noop_when_advisory_none(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        assert ds.compare_and_log("d1", "skip", None, state_dir=tmp_path) is None
+
+    def test_noop_when_shadow_off(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_DECISION_JUDGE_SHADOW", raising=False)
+        assert ds.compare_and_log("d1", "skip", {"action": "skip"}, state_dir=tmp_path) is None
+
+
+class TestDivergenceSummary:
+    def test_summary_counts_and_rate(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        adv = {"action": "re_dispatch", "confidence": 0.8}
+        ds.compare_and_log("d1", "re_dispatch", adv, state_dir=tmp_path)  # agree
+        ds.compare_and_log("d2", "re_dispatch", adv, state_dir=tmp_path)  # agree
+        ds.compare_and_log("d3", "skip", adv, state_dir=tmp_path)          # disagree
+        summary = ds.divergence_summary(state_dir=tmp_path)
+        assert summary == {"total": 3, "agree": 2, "disagree": 1, "agree_rate": pytest.approx(2 / 3)}
+
+    def test_summary_empty_ledger(self, tmp_path):
+        summary = ds.divergence_summary(state_dir=tmp_path)
+        assert summary == {"total": 0, "agree": 0, "disagree": 0, "agree_rate": None}


### PR DESCRIPTION
## Summary

ADR-028 **Phase 2** — the zero-risk safety valve that validates an LLM judge against the human (T0) before any decision authority shifts (Phases 3-4 remain separately operator-gated). Authorized by operator ("bouw Phase 2").

**Dispatch-ID:** manual-t0-adr028-phase2-20260710

## Changes (purely additive — touches NO existing decision code)
- **`scripts/lib/decision_shadow.py`**:
  - `shadow_enabled()` — gate on `VNX_DECISION_JUDGE_SHADOW=1` (**default OFF**).
  - `record_advisory()` — runs a pluggable judge (default = deterministic rule-based, zero LLM cost), appends a `decision_advisory` entry T0 **reads but never acts on**.
  - `compare_and_log()` — comparator: logs whether T0's actual decision agreed with the advisory to `decision_divergence.ndjson`. **Logs only; never changes a decision.**
  - `divergence_summary()` — `{total, agree, disagree, agree_rate}` (the data that justifies/blocks Phases 3-4).
- **`scripts/decision_shadow_report.py`** — `python3 scripts/decision_shadow_report.py` prints the agreement rate + recent divergences.

## Zero-risk by construction
- Default OFF; every function is a no-op when the flag is unset.
- Advisories + divergences live in their **own ledgers**, NOT the governed `t0_receipts.ndjson` — nothing downstream (receipt processor, gates) is affected.
- Every entry point is **fail-open**: a shadow error never breaks T0's real decision.
- Rollback: unset the flag. **Activation + wiring at T0's decision points is your knob** (the Phase-2→3 transition), per the ADR ratification.

## Verification
- `tests/test_decision_shadow.py` (11): flag gate, **ledger isolation** (never touches `t0_receipts.ndjson`), custom-judge injection, **fail-open on a broken judge**, comparator agree/disagree, summary counts/rate.

## Open Items
Activation (setting the flag + wiring the calls into T0's decision points) is the operator go for Phase 2→3. Phases 3-4 (authority shift) remain operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7