### PR TITLE
feat(adr-028): activate Phase 2 shadow — wire DecisionRouter.decide to the judge

### DIFF
--- a/scripts/lib/llm_decision_router.py
+++ b/scripts/lib/llm_decision_router.py
@@ -384,7 +384,45 @@ class DecisionRouter:
         except Exception as exc:
             logger.warning("Failed to log decision: %s", exc)
 
+        # ADR-028 Phase 2 shadow (VNX_DECISION_JUDGE_SHADOW=1, default OFF): a judge writes an
+        # ADVISORY decision T0 does NOT act on, and a comparator logs divergence vs `result`.
+        # Fail-open — never affects the returned decision. `result` above is authoritative.
+        try:
+            from decision_shadow import (  # noqa: PLC0415
+                shadow_enabled,
+                record_advisory,
+                compare_and_log,
+            )
+
+            if shadow_enabled():
+                did = str(
+                    context.get("dispatch_id")
+                    or context.get("decision_id")
+                    or f"{question}:{result.backend_used}"
+                )
+                sd = self.data_dir / "state"
+                advisory = record_advisory(
+                    did, context, question, judge=self._shadow_judge(), state_dir=sd
+                )
+                compare_and_log(did, result.action, advisory, state_dir=sd)
+        except Exception as exc:  # noqa: BLE001 — shadow must never break the real decision
+            logger.debug("decision shadow skipped: %s", exc)
+
         return result
+
+    def _shadow_judge(self):
+        """Judge callable for Phase-2 shadow — a DISTINCT second opinion from this router's
+        own backend. Defaults to the deterministic rule-based decision (zero cost); set
+        ``VNX_DECISION_JUDGE_BACKEND=ollama|claude-cli`` to shadow an LLM judge. Calls the
+        backend function DIRECTLY (never ``decide()``) so shadow can't recurse into itself."""
+        backend = os.environ.get("VNX_DECISION_JUDGE_BACKEND")
+        if backend == "ollama":
+            return lambda ctx, q: _decide_ollama(
+                ctx, q, model=self.ollama_model, host=self.ollama_host, timeout=self.timeout
+            )
+        if backend == "claude-cli":
+            return lambda ctx, q: _decide_claude_cli(ctx, q, timeout=self.timeout)
+        return _rule_based_decision
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_decision_router_shadow_wiring.py
+++ b/tests/test_decision_router_shadow_wiring.py
@@ -1,0 +1,56 @@
+#!/usr/bin/env python3
+"""ADR-028 Phase 2 — verify DecisionRouter.decide() is wired to the shadow (fail-open,
+flag-gated) and that the shadow NEVER affects the authoritative decision."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+from llm_decision_router import DecisionRouter  # noqa: E402
+import decision_shadow as ds  # noqa: E402
+
+CTX_FAILED = {"receipt": {"status": "failed"}}  # rule-based -> re_dispatch
+
+
+class TestDecideShadowWiring:
+    def test_shadow_off_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_DECISION_JUDGE_SHADOW", raising=False)
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        result = router.decide(CTX_FAILED, "re_dispatch")
+        assert result.action == "re_dispatch"
+        assert not (tmp_path / "state" / ds.ADVISORY_LEDGER).exists()
+        assert not (tmp_path / "state" / ds.DIVERGENCE_LEDGER).exists()
+
+    def test_shadow_on_writes_ledgers_and_result_unaffected(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        result = router.decide(CTX_FAILED, "re_dispatch")
+        # authoritative decision is unchanged by the shadow
+        assert result.action == "re_dispatch"
+        sd = tmp_path / "state"
+        assert (sd / ds.ADVISORY_LEDGER).exists()
+        assert (sd / ds.DIVERGENCE_LEDGER).exists()
+        # rule-based shadow judge agrees with the rule-based router on this context
+        summary = ds.divergence_summary(state_dir=sd)
+        assert summary["total"] == 1 and summary["agree"] == 1
+
+    def test_shadow_never_touches_governed_receipts(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        router.decide(CTX_FAILED, "re_dispatch")
+        assert not (tmp_path / "state" / "t0_receipts.ndjson").exists()
+
+    def test_broken_shadow_judge_does_not_break_decide(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_JUDGE_SHADOW", "1")
+        # point the shadow judge at a backend that will fail to import/execute cleanly;
+        # decide() must still return the authoritative rule-based decision.
+        monkeypatch.setenv("VNX_DECISION_JUDGE_BACKEND", "ollama")
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        result = router.decide(CTX_FAILED, "re_dispatch")
+        assert result.action == "re_dispatch"  # unaffected, fail-open


### PR DESCRIPTION
## Summary

"Zet shadow aan": wires the Phase 2 shadow module (#1096) into the canonical decision point (`DecisionRouter.decide`), so the safety valve actually collects divergence data. Default OFF (`VNX_DECISION_JUDGE_SHADOW=1` to enable).

**Dispatch-ID:** manual-t0-phase2-wiring-20260710

## Changes
- `DecisionRouter.decide()`: after computing the authoritative `result`, if shadow is on, a judge writes an ADVISORY decision T0 does NOT act on + a comparator logs divergence vs `result`. Fail-open (any error swallowed at debug); `result` returned unchanged.
- `DecisionRouter._shadow_judge()`: a DISTINCT backend from the router's own (default rule-based, zero cost; `VNX_DECISION_JUDGE_BACKEND=ollama|claude-cli` to shadow an LLM judge). Calls the backend function directly — never `decide()` — so shadow can't recurse.
- Ledgers land in the router's `state/` dir (`decision_advisory.ndjson` / `decision_divergence.ndjson`), never `t0_receipts.ndjson`.

## Verification
- `tests/test_decision_router_shadow_wiring.py` (4): flag-off writes nothing; flag-on writes both ledgers + **result unaffected**; never touches `t0_receipts.ndjson`; **broken shadow judge doesn't break decide()**.
- 33 other router/shadow tests green. (1 pre-existing `test_ollama_successful_response` failure is an unrelated ollama-mock issue, confirmed on clean main.)

## Open Items
Inspect divergence with `python3 scripts/decision_shadow_report.py`. Phases 3-4 (fast-path, binding) remain operator-gated and should wait for shadow divergence data.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7