### PR TITLE
feat(adr-028): Phase 3 judge fast-path (default-off, conservative)

### DIFF
--- a/scripts/lib/decision_fast_path.py
+++ b/scripts/lib/decision_fast_path.py
@@ -1,0 +1,72 @@
+"""ADR-028 Phase 3 — decision judge fast-path.
+
+Gated behind ``VNX_DECISION_FAST_PATH=1`` (default OFF). When ON, a deterministic classifier
+short-circuits the TRIVIAL, unambiguous governance decisions (a clean receipt needs no
+action) so they never spend a judge/LLM call; everything with any nuance (failures,
+silences, escalations, unknown states) falls through to the normal backend (the judge, or
+the rule-based fallback). Rollback: unset the flag → every decision goes to the backend.
+
+Conservative by construction: the fast-path only handles the clearly-nothing-to-do case. It
+never decides a failure, an escalation, or an ambiguous state — those are exactly what the
+judge should weigh. So enabling it can only REMOVE obvious no-ops from the judge's load, never
+make a substantive call the judge would have made differently.
+"""
+
+from __future__ import annotations
+
+import math
+import os
+from typing import Any, Dict, Optional
+
+# Receipt statuses that are unambiguously "nothing to do".
+_CLEAN_STATUSES = frozenset({"ok", "done", "passed", "pass", "success", "succeeded", "complete", "completed"})
+
+
+def fast_path_enabled(env: Optional[dict] = None) -> bool:
+    """True iff VNX_DECISION_FAST_PATH=1. Default OFF (activation is the operator's knob)."""
+    env = os.environ if env is None else env
+    return env.get("VNX_DECISION_FAST_PATH") == "1"
+
+
+def classify(context: Dict[str, Any], question: str):
+    """Return a ``DecisionResult`` for a TRIVIAL, unambiguous decision, or ``None`` to route
+    to the judge/backend. Only the clearly-nothing-to-do case is handled here."""
+    from llm_decision_router import DecisionResult  # noqa: PLC0415 — avoid import cycle at module load
+
+    receipt = context.get("receipt")
+    if not isinstance(receipt, dict):
+        return None
+    status = str(receipt.get("status", "")).strip().lower()
+    if status not in _CLEAN_STATUSES:
+        return None
+
+    # Any pending signal → defer to the judge. Coerce the silence value ROBUSTLY (a numeric
+    # string like "1200" must still count). A value that is NOT a valid finite duration —
+    # bool (True/False coerce to 1.0/0.0), NaN, ±inf, or an unparseable string — is treated as
+    # a signal (defer), never as clean. The fast-path only fires when it is SURE nothing pends.
+    silence_raw = context.get("terminal_silence_seconds", 0)
+    if isinstance(silence_raw, bool):
+        silent = True  # a bool is not a valid duration → defer
+    else:
+        try:
+            s = float(silence_raw)
+            silent = (not math.isfinite(s)) or s > 900  # NaN/inf → invalid → defer
+        except (TypeError, ValueError):
+            silent = True  # cannot determine → not trivial → defer to the judge
+    escalated = any(
+        bool(context.get(k))
+        for k in ("escalate", "needs_review", "needs_human", "error", "failure", "incident")
+    )
+    if silent or escalated:
+        return None
+
+    return DecisionResult(
+        action="skip",
+        reasoning="fast-path: receipt clean, no pending signal — no action required",
+        confidence=1.0,
+        backend_used="fast-path",
+        latency_ms=0,
+    )
+
+
+__all__ = ["fast_path_enabled", "classify"]

--- a/scripts/lib/llm_decision_router.py
+++ b/scripts/lib/llm_decision_router.py
@@ -367,7 +367,25 @@ class DecisionRouter:
         Returns:
             DecisionResult with action, reasoning, confidence, backend_used, latency_ms.
         """
-        if self.backend == Backend.OLLAMA:
+        # ADR-028 Phase 3 fast-path (VNX_DECISION_FAST_PATH=1, default OFF): a deterministic
+        # classifier short-circuits TRIVIAL, unambiguous decisions (a clean receipt = no-op)
+        # so they never spend a judge/LLM call; non-trivial cases fall through to the backend.
+        # Fail-open: any error routes to the backend. Default OFF -> `fast` is always None ->
+        # the exact same backend branch runs and the decision is unchanged (the only added
+        # work is a swallowed flag check).
+        fast = None
+        try:
+            from decision_fast_path import fast_path_enabled, classify  # noqa: PLC0415
+
+            if fast_path_enabled():
+                fast = classify(context, question)
+        except Exception as exc:  # noqa: BLE001 — fast-path must never break the decision
+            logger.debug("decision fast-path skipped: %s", exc)
+            fast = None
+
+        if fast is not None:
+            result = fast
+        elif self.backend == Backend.OLLAMA:
             result = _decide_ollama(
                 context, question,
                 model=self.ollama_model,

--- a/tests/test_decision_fast_path.py
+++ b/tests/test_decision_fast_path.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""ADR-028 Phase 3 — decision judge fast-path. Verify the classifier only short-circuits
+TRIVIAL no-ops, and that DecisionRouter.decide() is behaviour-unchanged when the flag is off."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import decision_fast_path as fp  # noqa: E402
+from llm_decision_router import DecisionRouter  # noqa: E402
+
+
+class TestClassify:
+    def test_clean_receipt_is_trivial_skip(self):
+        res = fp.classify({"receipt": {"status": "ok"}}, "skip")
+        assert res is not None and res.action == "skip" and res.backend_used == "fast-path"
+
+    def test_failed_receipt_defers_to_judge(self):
+        assert fp.classify({"receipt": {"status": "failed"}}, "re_dispatch") is None
+
+    def test_clean_but_silent_defers_to_judge(self):
+        assert fp.classify(
+            {"receipt": {"status": "ok"}, "terminal_silence_seconds": 1200}, "skip"
+        ) is None
+
+    def test_clean_but_escalated_defers_to_judge(self):
+        assert fp.classify({"receipt": {"status": "ok"}, "needs_review": True}, "skip") is None
+
+    def test_no_receipt_defers_to_judge(self):
+        assert fp.classify({"terminal_silence_seconds": 10}, "skip") is None
+
+    def test_string_silence_is_coerced(self):
+        # codex gate: a numeric STRING silence must still count as a pending signal.
+        assert fp.classify(
+            {"receipt": {"status": "ok"}, "terminal_silence_seconds": "1200"}, "skip"
+        ) is None
+
+    def test_unparseable_silence_defers(self):
+        assert fp.classify(
+            {"receipt": {"status": "ok"}, "terminal_silence_seconds": "soon"}, "skip"
+        ) is None
+
+    def test_other_escalation_keys_defer(self):
+        for k in ("needs_human", "error", "failure", "incident"):
+            assert fp.classify({"receipt": {"status": "ok"}, k: True}, "skip") is None, k
+
+    def test_invalid_silence_values_defer(self):
+        # codex re-gate: bool / NaN / inf are not valid durations -> must defer, not skip.
+        for bad in (True, False, float("nan"), float("inf"), float("-inf"), "nan", "-inf"):
+            assert fp.classify(
+                {"receipt": {"status": "ok"}, "terminal_silence_seconds": bad}, "skip"
+            ) is None, bad
+
+    def test_valid_low_silence_still_trivial(self):
+        # a genuine small numeric silence is still a clean no-op.
+        res = fp.classify(
+            {"receipt": {"status": "ok"}, "terminal_silence_seconds": 12.5}, "skip"
+        )
+        assert res is not None and res.action == "skip"
+
+
+class TestFlagGate:
+    def test_default_off(self, monkeypatch):
+        monkeypatch.delenv("VNX_DECISION_FAST_PATH", raising=False)
+        assert fp.fast_path_enabled() is False
+
+    def test_on(self, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_FAST_PATH", "1")
+        assert fp.fast_path_enabled() is True
+
+
+class TestDecideWiring:
+    def test_flag_off_unchanged_behaviour(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_DECISION_FAST_PATH", raising=False)
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        # clean receipt -> rule-based says skip, but via the BACKEND (not fast-path).
+        result = router.decide({"receipt": {"status": "ok"}}, "skip")
+        assert result.action == "skip" and result.backend_used == "dry-run"
+
+    def test_flag_on_trivial_uses_fast_path(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_FAST_PATH", "1")
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        result = router.decide({"receipt": {"status": "ok"}}, "skip")
+        assert result.action == "skip" and result.backend_used == "fast-path"
+
+    def test_flag_on_nontrivial_falls_through_to_backend(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DECISION_FAST_PATH", "1")
+        router = DecisionRouter(data_dir=tmp_path, backend="dry-run")
+        # failed receipt is non-trivial -> fast-path returns None -> backend decides.
+        result = router.decide({"receipt": {"status": "failed"}}, "re_dispatch")
+        assert result.action == "re_dispatch" and result.backend_used == "dry-run"


### PR DESCRIPTION
## Summary

ADR-028 **Phase 3** — a deterministic fast-path classifier that short-circuits TRIVIAL, unambiguous decisions so they never spend a judge/LLM call; non-trivial cases fall through to the backend. Default OFF (`VNX_DECISION_FAST_PATH=1` to enable); rollback = unset the flag.

**Dispatch-ID:** manual-t0-adr028-phase3-20260710

## Changes
- **`scripts/lib/decision_fast_path.py`**: `classify()` returns a decision ONLY for the clearly-nothing-to-do case (clean receipt, no pending signal → `skip`); returns `None` (→ backend) for anything with nuance (failures, >15min silence, escalations, absent receipt).
- **`DecisionRouter.decide()`**: fast-path wired as the FIRST branch, fail-open. Default OFF → `fast` always None → **behaviour byte-for-byte unchanged**. The Phase-2 shadow still runs on the chosen result, so divergence data also covers fast-path decisions.

## Conservative by construction
The fast-path only removes obvious no-ops from the judge's load. It never decides a failure, an escalation, or an ambiguous state — those are exactly what the judge should weigh. Enabling it cannot make a substantive call the judge would have made differently.

## Verification
- `tests/test_decision_fast_path.py` (12): classify handles only trivial no-ops; **flag-off is behaviour-unchanged** (backend decides); flag-on routes trivial→fast-path, non-trivial→backend.
- 25 fast-path + shadow tests green.

## Open Items
Activation (`VNX_DECISION_FAST_PATH=1`) is the operator's knob. **Phase 4 (judge decisions binding / human-on-the-last-set)** is the real authority shift and is held for explicit operator go — not built here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7