### PR TITLE
feat(panel): multi-provider deliberation panel skill (/panel <mode>)

### DIFF
--- a/.claude/skills/panel/SKILL.md
+++ b/.claude/skills/panel/SKILL.md
@@ -1,0 +1,53 @@
+---
+name: panel
+description: Multi-provider deliberation panel for COMPLEX, multi-view questions — architecture, strategy, market research, and codebase sweeps. Runs a 4-stage deliberation across the provider fleet (diverge → contrarian red-team → adversarial verify → cited synthesis), the same multi-perspective rigour the plan-gate already applies to plan reviews, generalised to arbitrary questions. Use when one model's answer isn't enough and you want convergence THROUGH disagreement + verification, not a single opinion.
+allowed-tools: [Read, Grep, Glob, Bash]
+---
+
+# /panel — multi-provider deliberation
+
+For hard questions where you want several strong models to genuinely deliberate, not just answer in parallel. Each stage builds on the last, so the panel converges *through* disagreement and verification instead of averaging opinions.
+
+## When to use
+
+- **architecture** — a feature/system design where the tradeoffs are non-obvious.
+- **strategy** — a business/product call that rests on assumptions worth stress-testing.
+- **research** — market/competitive questions where claims need refuting.
+- **sweep** — a codebase audit (security / correctness / dead-code / refactor).
+
+Reach for it when a single model's answer would be a guess, and you'd otherwise open five terminals yourself.
+
+## How it works (4 stages)
+
+1. **Diverge** — every fleet provider (codex / kimi / claude / glm-5.2 / deepseek-harness) analyses the SAME question through a DIFFERENT mode-specific lens.
+2. **Contrarian** — one designated seat red-teams the emerging consensus: what did everyone miss, which "this is fine" is wrong.
+3. **Verify** — the top claims are adversarially checked (against the CODE for sweeps — real `file:line`; against SOURCES for research — try to refute).
+4. **Synthesis** — one cited report: consensus + surviving dissent + verified/refuted claims, ranked and deduped.
+
+## Run it
+
+```bash
+python3 scripts/panel.py <mode> "<question>" [--context-file FILE] [--timeout 900] [--out FILE]
+```
+
+Examples:
+
+```bash
+# architecture decision, grounded on a design doc
+python3 scripts/panel.py architecture "Should the judge run per-receipt or batched?" --context-file docs/adr-028.md
+
+# code sweep grounded on a diff or file list
+git diff origin/main > /tmp/d.diff
+python3 scripts/panel.py sweep "Review this change for security + correctness" --context-file /tmp/d.diff
+
+# market research
+python3 scripts/panel.py research "Is there an underserved MKB market for local-LLM invoice processing?"
+```
+
+The cited report lands in `unified_reports/panel-<mode>-<id>.md` and prints to stdout.
+
+## Notes
+
+- Governed lane: each panelist dispatches through the review lane and emits a receipt. Respects the provider constraints (kimi-via-cli-only, glm via OpenRouter/harness, deepseek-harness with its own key + hardening, no-anthropic-sdk) — the dispatcher routes each provider correctly.
+- A dead/absent provider (e.g. deepseek without its key) degrades the panel gracefully; it never blocks the run.
+- The panel is the fabric's general multi-view tool. It complements the **plan-gate panel** (which is scoped to plan reviews) and the **t0-orchestrator** skill (which owns orchestration decisions). Implementation: `scripts/lib/deliberation_panel.py`.

--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -1,0 +1,255 @@
+"""Multi-provider deliberation panel — a fabric capability for COMPLEX, multi-view questions.
+
+`vnx panel <mode> "<question>"`. Unlike a flat fan-out, each stage builds on the previous, so
+the panel actually deliberates instead of just polling:
+
+  1. DIVERGE   — every provider gets the SAME question through a DIFFERENT mode-specific lens.
+  2. CONTRARIAN — one designated seat red-teams the emerging consensus: what is everyone missing?
+  3. VERIFY    — the top claims are adversarially checked (against the CODE for sweeps, against
+                 SOURCES for research) — the /deep-research adversarial-verify pattern.
+  4. SYNTHESIS — one cited report: consensus + surviving dissent + verified/refuted claims,
+                 ranked and deduped, with file:line / source references.
+
+Generalises `plan_gate_panel` (plan-review) to arbitrary questions and reuses its governed
+review-lane dispatcher. Respects the provider constraints (kimi-via-cli-only, zai-via-
+openrouter-only, deepseek-harness own-key, no-anthropic-sdk) — the dispatcher routes each
+provider string through its correct lane.
+"""
+
+from __future__ import annotations
+
+import concurrent.futures as _cf
+import uuid
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+# A dispatcher runs one panelist and returns its report text.
+DispatcherFn = Callable[[str, str, str, str], str]
+
+# Default panel roster (provider, model). Each entry routes through its own governed lane.
+# deepseek-harness is optional (needs its own key + hardening) — degrades gracefully if absent.
+DEFAULT_ROSTER: List[Tuple[str, str]] = [
+    ("codex", "gpt-5.5"),
+    ("kimi", "kimi-k2-7-code"),
+    ("claude", "sonnet"),
+    ("glm-harness", "glm-5.2"),
+    ("deepseek-harness", "deepseek-reasoner"),
+]
+
+
+@dataclass
+class ModeSpec:
+    key: str
+    description: str
+    lenses: List[str]          # one angle per roster slot (cycled if fewer than roster)
+    contrarian_focus: str      # what the red-team seat should attack
+    verify_target: str         # "the code (cite file:line)" | "the sources (try to refute)"
+    synth_goal: str            # what the final report must deliver
+
+
+MODES: Dict[str, ModeSpec] = {
+    "sweep": ModeSpec(
+        key="sweep",
+        description="codebase sweep — security / correctness / dead-code / refactor",
+        lenses=[
+            "security vulnerabilities and unsafe patterns",
+            "correctness bugs and edge cases",
+            "dead / unreachable code and unused surface",
+            "refactor + simplification opportunities",
+            "performance and resource hotspots",
+        ],
+        contrarian_focus="the panel's severity ranking and any 'this is fine' conclusions — "
+                         "which flagged issue is actually a non-issue, and which UNflagged area is the real risk",
+        verify_target="the code — read each cited file:line and confirm it actually supports the claim",
+        synth_goal="a ranked, deduped findings list (severity, file:line, one-line why), "
+                   "consensus vs contested, and the single highest-leverage fix",
+    ),
+    "research": ModeSpec(
+        key="research",
+        description="market / competitive research",
+        lenses=[
+            "market size, segments and demand signals",
+            "the competitive landscape and incumbents",
+            "trends, timing and second-order effects",
+            "risks, headwinds and failure modes",
+            "the underserved opportunity / wedge",
+        ],
+        contrarian_focus="the optimistic consensus — the strongest case that this market/thesis is wrong or already lost",
+        verify_target="the sources — try to REFUTE each top claim; mark unsupported assertions",
+        synth_goal="a cited briefing: verified findings, the contrarian's surviving objections, "
+                   "confidence per claim, and the 3 decisions this should inform",
+    ),
+    "architecture": ModeSpec(
+        key="architecture",
+        description="feature / system architecture design + tradeoffs",
+        lenses=[
+            "the clean design and its data model",
+            "implementation feasibility and effort",
+            "operational reality (failure modes, rollback, observability)",
+            "alternative approaches that were not proposed",
+            "long-term maintainability and coupling",
+        ],
+        contrarian_focus="the emerging design — where it will break under load / over time, and the simpler alternative it dismisses",
+        verify_target="the codebase — confirm each feasibility/effort claim against the actual code (cite file:line)",
+        synth_goal="a decision doc: recommended design, the tradeoffs, the surviving objections, "
+                   "the rejected alternatives + why, and the phased rollout with rollback",
+    ),
+    "strategy": ModeSpec(
+        key="strategy",
+        description="business / product strategy",
+        lenses=[
+            "the opportunity and upside",
+            "execution path and required resources",
+            "risk, downside and what could kill it",
+            "the market / customer reality",
+            "sequencing and what to do first",
+        ],
+        contrarian_focus="the strategy's core assumption — what has to be TRUE for it to work, and why that might not hold",
+        verify_target="the sources / stated facts — flag any assumption presented as fact",
+        synth_goal="a one-page strategy call: the recommendation, the bet it rests on, the "
+                   "surviving risks, and the first concrete move",
+    ),
+}
+
+
+@dataclass
+class DeliberationResult:
+    mode: str
+    question: str
+    fan_out: List[Dict[str, str]] = field(default_factory=list)  # {provider, lens, text}
+    contrarian: str = ""
+    factcheck: str = ""
+    synthesis: str = ""
+
+    def to_report(self) -> str:
+        lines = [
+            f"# Deliberation panel — {self.mode}",
+            f"\n**Question:** {self.question}\n",
+            "## Synthesis (cited)\n",
+            self.synthesis or "_(no synthesis)_",
+            "\n---\n## Contrarian / red-team\n",
+            self.contrarian or "_(none)_",
+            "\n---\n## Verification pass\n",
+            self.factcheck or "_(none)_",
+            "\n---\n## Divergent views (fan-out)\n",
+        ]
+        for fo in self.fan_out:
+            lines.append(f"\n### {fo['provider']} — lens: {fo['lens']}\n")
+            lines.append(fo["text"] or "_(empty)_")
+        return "\n".join(lines)
+
+
+def _digest(fan_out: List[Dict[str, str]], limit: int = 1500) -> str:
+    """Compact digest of the fan-out for the contrarian/verify/synthesis stages."""
+    parts = []
+    for fo in fan_out:
+        text = (fo.get("text") or "").strip()
+        parts.append(f"[{fo['provider']} / {fo['lens']}]\n{text[:limit]}")
+    return "\n\n".join(parts)
+
+
+def run_deliberation(
+    mode: str,
+    question: str,
+    *,
+    dispatcher: DispatcherFn,
+    roster: Optional[List[Tuple[str, str]]] = None,
+    context: str = "",
+    max_workers: int = 5,
+) -> DeliberationResult:
+    """Run the 4-stage deliberation. ``dispatcher(provider, model, prompt, dispatch_id)`` runs
+    one panelist and returns its report text (governed lane). ``context`` is optional extra
+    grounding (a diff, a file list, a brief) injected into every stage."""
+    spec = MODES.get(mode)
+    if spec is None:
+        raise ValueError(f"unknown mode {mode!r}; choose one of {sorted(MODES)}")
+    roster = roster or DEFAULT_ROSTER
+    ctx_block = f"\n\n## Shared context\n{context}\n" if context else ""
+    result = DeliberationResult(mode=mode, question=question)
+
+    # ── Stage 1: DIVERGE (parallel fan-out) ──────────────────────────────────
+    def _one(idx: int, provider: str, model: str) -> Dict[str, str]:
+        lens = spec.lenses[idx % len(spec.lenses)]
+        prompt = (
+            f"You are one seat on a deliberation panel ({spec.description}).\n"
+            f"QUESTION: {question}\n{ctx_block}\n"
+            f"YOUR LENS: {lens}.\n"
+            "Analyse the question ONLY through your lens. Be concrete and cite evidence "
+            "(file:line for code, a named source for research). Give your strongest findings, "
+            "then one thing you are UNSURE about. Terse."
+        )
+        try:
+            text = dispatcher(provider, model, prompt, f"panel-{mode}-diverge-{idx}-{uuid.uuid4().hex[:6]}")
+        except Exception as exc:  # noqa: BLE001 — a dead provider degrades the panel, never kills it
+            text = f"[dispatch error: {exc!r}]"
+        return {"provider": provider, "lens": lens, "text": text or "[empty]"}
+
+    with _cf.ThreadPoolExecutor(max_workers=max_workers) as ex:
+        futures = [ex.submit(_one, i, p, m) for i, (p, m) in enumerate(roster)]
+        result.fan_out = [f.result() for f in _cf.as_completed(futures)]
+    # stable order by roster
+    order = {p: i for i, (p, _) in enumerate(roster)}
+    result.fan_out.sort(key=lambda fo: order.get(fo["provider"], 99))
+
+    digest = _digest(result.fan_out)
+
+    # ── Stage 2: CONTRARIAN (one red-team seat — the strongest reasoner) ──────
+    contra_provider, contra_model = _pick(roster, prefer=("codex", "deepseek-harness", "claude"))
+    contra_prompt = (
+        f"You are the RED TEAM on a deliberation panel ({spec.description}).\n"
+        f"QUESTION: {question}\n{ctx_block}\n"
+        f"The panel said:\n{digest}\n\n"
+        f"Attack the emerging consensus. Focus on: {spec.contrarian_focus}. "
+        "Name what everyone MISSED, steelman the dissent, and flag any claim stated as fact "
+        "without evidence. Do not be agreeable. Terse, concrete."
+    )
+    result.contrarian = _safe(dispatcher, contra_provider, contra_model, contra_prompt,
+                              f"panel-{mode}-contrarian-{uuid.uuid4().hex[:6]}")
+
+    # ── Stage 3: VERIFY (adversarial factcheck of the top claims) ────────────
+    verify_provider, verify_model = _pick(roster, prefer=("codex", "kimi", "claude"))
+    verify_prompt = (
+        f"You are the VERIFY pass on a deliberation panel ({spec.description}).\n"
+        f"QUESTION: {question}\n{ctx_block}\n"
+        f"Panel findings:\n{digest}\n\nRed-team:\n{result.contrarian[:1500]}\n\n"
+        f"Take the TOP 5 concrete claims across the above and adversarially verify each against "
+        f"{spec.verify_target}. Mark each: CONFIRMED / REFUTED / UNVERIFIABLE, with the specific "
+        "evidence (file:line or source). Default to REFUTED/UNVERIFIABLE when evidence is thin."
+    )
+    result.factcheck = _safe(dispatcher, verify_provider, verify_model, verify_prompt,
+                             f"panel-{mode}-verify-{uuid.uuid4().hex[:6]}")
+
+    # ── Stage 4: SYNTHESIS (one cited report) ────────────────────────────────
+    synth_provider, synth_model = _pick(roster, prefer=("claude", "codex", "kimi"))
+    synth_prompt = (
+        f"You are the SYNTHESISER on a deliberation panel ({spec.description}).\n"
+        f"QUESTION: {question}\n{ctx_block}\n"
+        f"Divergent views:\n{digest}\n\nRed-team:\n{result.contrarian[:1500]}\n\n"
+        f"Verification:\n{result.factcheck[:1500]}\n\n"
+        f"Produce {spec.synth_goal}. Structure: CONSENSUS (verified), CONTESTED (surviving "
+        "dissent), VERIFIED CLAIMS (ranked, with evidence), OPEN QUESTIONS. Dedupe. Cite "
+        "file:line / sources. Do not invent agreement that isn't there."
+    )
+    result.synthesis = _safe(dispatcher, synth_provider, synth_model, synth_prompt,
+                             f"panel-{mode}-synth-{uuid.uuid4().hex[:6]}")
+
+    return result
+
+
+def _pick(roster: List[Tuple[str, str]], prefer: Tuple[str, ...]) -> Tuple[str, str]:
+    """Pick the first preferred provider present in the roster, else the first roster seat."""
+    have = {p: m for p, m in roster}
+    for p in prefer:
+        if p in have:
+            return p, have[p]
+    return roster[0]
+
+
+def _safe(dispatcher: DispatcherFn, provider: str, model: str, prompt: str, did: str) -> str:
+    try:
+        return dispatcher(provider, model, prompt, did) or "[empty]"
+    except Exception as exc:  # noqa: BLE001 — a stage failure degrades the report, never crashes
+        return f"[dispatch error {provider}: {exc!r}]"
+
+
+__all__ = ["MODES", "DEFAULT_ROSTER", "ModeSpec", "DeliberationResult", "run_deliberation"]

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -1,0 +1,72 @@
+#!/usr/bin/env python3
+"""`vnx panel` runner — multi-provider deliberation panel for complex, multi-view questions.
+
+    python3 scripts/panel.py <mode> "<question>" [--context-file F] [--timeout S] [--out F]
+
+Modes: sweep | research | architecture | strategy. Runs the 4-stage deliberation
+(diverge → contrarian → verify → synthesis) via the governed review-lane dispatcher, then
+writes the cited report to unified_reports/ (and prints it).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+import uuid
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from deliberation_panel import MODES, run_deliberation  # noqa: E402
+
+
+def _resolve_reports_dir() -> Path:
+    try:
+        from vnx_paths import resolve_state_dir  # noqa: PLC0415
+        base = resolve_state_dir().parent
+    except Exception:
+        base = Path(__file__).resolve().parents[1] / ".vnx-data"
+    d = base / "unified_reports"
+    d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description="VNX multi-provider deliberation panel")
+    parser.add_argument("mode", choices=sorted(MODES), help="deliberation mode")
+    parser.add_argument("question", help="the question / target for the panel")
+    parser.add_argument("--context-file", default=None, help="file whose contents ground every stage")
+    parser.add_argument("--timeout", type=int, default=900, help="per-panelist timeout seconds")
+    parser.add_argument("--out", default=None, help="write the report here (default: unified_reports/)")
+    args = parser.parse_args(argv)
+
+    context = ""
+    if args.context_file:
+        try:
+            context = Path(args.context_file).read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"panel: cannot read --context-file: {exc}", file=sys.stderr)
+            return 2
+
+    from plan_gate_panel import _make_default_dispatcher  # noqa: PLC0415
+    dispatcher = _make_default_dispatcher(None, args.timeout)
+
+    print(f"[panel] mode={args.mode} — running 4-stage deliberation across the fleet ...", file=sys.stderr)
+    result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context)
+    report = result.to_report()
+
+    out = Path(args.out) if args.out else (_resolve_reports_dir() / f"panel-{args.mode}-{uuid.uuid4().hex[:8]}.md")
+    try:
+        out.write_text(report, encoding="utf-8")
+        print(f"[panel] report -> {out}", file=sys.stderr)
+    except OSError as exc:
+        print(f"panel: could not write report: {exc}", file=sys.stderr)
+
+    print(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/deliberation_panel.py — the 4-stage multi-provider deliberation.
+Uses a FAKE dispatcher (records calls) so no live provider is hit."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = str(REPO_ROOT / "scripts" / "lib")
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import deliberation_panel as dp  # noqa: E402
+
+
+class _Recorder:
+    """Fake dispatcher: returns a tagged stub and records every (provider, prompt, did)."""
+    def __init__(self):
+        self.calls = []
+
+    def __call__(self, provider, model, prompt, did):
+        self.calls.append({"provider": provider, "prompt": prompt, "did": did})
+        return f"<<{provider}:{did.split('-')[2] if did.count('-') >= 2 else did}>>"
+
+    def stage_prompts(self, stage: str):
+        return [c["prompt"] for c in self.calls if f"-{stage}-" in c["did"]]
+
+
+ROSTER = [("codex", "gpt-5.5"), ("kimi", "k2"), ("claude", "sonnet")]
+
+
+class TestFourStageFlow:
+    def test_runs_all_four_stages(self):
+        rec = _Recorder()
+        res = dp.run_deliberation("sweep", "audit src/", dispatcher=rec, roster=ROSTER, max_workers=3)
+        # stage 1: one fan-out per roster seat
+        assert len(res.fan_out) == 3
+        assert {fo["provider"] for fo in res.fan_out} == {"codex", "kimi", "claude"}
+        # stages 2-4 produced text
+        assert res.contrarian and res.factcheck and res.synthesis
+        # exactly 3 + 1 + 1 + 1 dispatches
+        assert len(rec.calls) == 6
+
+    def test_stage_prompts_carry_lens_and_prior_context(self):
+        rec = _Recorder()
+        dp.run_deliberation("sweep", "audit src/", dispatcher=rec, roster=ROSTER, max_workers=3)
+        # fan-out prompts mention the lens keyword "lens"
+        assert all("LENS" in p for p in rec.stage_prompts("diverge"))
+        # contrarian prompt embeds the fan-out digest (provider tags appear)
+        contra = rec.stage_prompts("contrarian")[0]
+        assert "The panel said" in contra
+        # verify prompt embeds the contrarian output
+        verify = rec.stage_prompts("verify")[0]
+        assert "Red-team" in verify
+        # synthesis embeds verification
+        synth = rec.stage_prompts("synth")[0]
+        assert "Verification" in synth and "Divergent views" in synth
+
+    def test_context_injected_into_every_stage(self):
+        rec = _Recorder()
+        dp.run_deliberation("architecture", "design X", dispatcher=rec, roster=ROSTER,
+                            context="MARKER-CTX-123", max_workers=3)
+        assert all("MARKER-CTX-123" in c["prompt"] for c in rec.calls)
+
+
+class TestDegradation:
+    def test_one_dead_provider_does_not_kill_panel(self):
+        def flaky(provider, model, prompt, did):
+            if provider == "kimi":
+                raise RuntimeError("kimi down")
+            return "ok"
+        res = dp.run_deliberation("sweep", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
+        kimi = next(fo for fo in res.fan_out if fo["provider"] == "kimi")
+        assert "dispatch error" in kimi["text"]
+        # the other seats + later stages still ran
+        assert res.synthesis == "ok"
+
+
+class TestModesAndReport:
+    def test_unknown_mode_raises(self):
+        with pytest.raises(ValueError):
+            dp.run_deliberation("nonsense", "q", dispatcher=_Recorder(), roster=ROSTER)
+
+    def test_all_modes_have_specs(self):
+        for m in ("sweep", "research", "architecture", "strategy"):
+            spec = dp.MODES[m]
+            assert spec.lenses and spec.contrarian_focus and spec.verify_target and spec.synth_goal
+
+    def test_report_has_all_sections(self):
+        rec = _Recorder()
+        res = dp.run_deliberation("strategy", "should we?", dispatcher=rec, roster=ROSTER, max_workers=3)
+        report = res.to_report()
+        for section in ("Synthesis", "Contrarian", "Verification", "Divergent views"):
+            assert section in report
+
+
+class TestPick:
+    def test_prefers_present_provider(self):
+        assert dp._pick(ROSTER, prefer=("deepseek-harness", "claude"))[0] == "claude"
+
+    def test_falls_back_to_first_seat(self):
+        assert dp._pick(ROSTER, prefer=("nope",))[0] == "codex"


### PR DESCRIPTION
## Summary

A reusable **multi-provider deliberation panel** for COMPLEX, multi-view questions — the multi-perspective rigour the plan-gate already applies to plan reviews, generalised to arbitrary questions. Built upstream so it distributes fleet-wide. Requested by sales-copilot T0 on Vincent's behalf.

**Dispatch-ID:** manual-t0-deliberation-panel-20260710

## Design — 4 stages that build on each other (not a flat fan-out)
1. **Diverge** — every fleet provider (codex/kimi/claude/glm-5.2/deepseek-harness) analyses the SAME question through a DIFFERENT mode-specific lens.
2. **Contrarian** — one designated seat red-teams the emerging consensus (what did everyone miss).
3. **Verify** — the top claims adversarially checked (against the CODE for sweeps — real `file:line`; against SOURCES for research — try to refute), `/deep-research` style.
4. **Synthesis** — one cited report: consensus + surviving dissent + verified/refuted, ranked + deduped.

Modes: `sweep` (security/correctness/dead-code/refactor), `research` (market/competitive), `architecture` (design + tradeoffs), `strategy`.

## Changes
- `scripts/lib/deliberation_panel.py` — dispatcher-injectable orchestration; production uses `plan_gate_panel._make_default_dispatcher` (governed review lane, emits a receipt). Parallel fan-out; a dead/absent provider degrades gracefully. Respects provider constraints (kimi-via-cli-only, glm via harness, deepseek-harness own-key, no-anthropic-sdk).
- `scripts/panel.py` — `python3 scripts/panel.py <mode> "<question>" [--context-file F]`; writes cited report to `unified_reports/`.
- `.claude/skills/panel/SKILL.md` — the `/panel` skill (fleet-wide via skill sync).

## Verification
- `tests/test_deliberation_panel.py` (9, fake dispatcher — no live provider): all 4 stages run; stage prompts carry the lens + prior-stage context; context injected everywhere; a dead provider degrades not crashes; unknown mode raises; report has all sections.

## Open Items
Fleet distribution via edge + skill sync (I handle after merge). Live end-to-end test from sales-copilot is theirs to run once synced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7