### PR TITLE
fix(panel): pass real data_dir + synthesis provider-fallback (no unconsolidated report)

### DIFF
--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -194,7 +194,6 @@ def run_deliberation(
     digest = _digest(result.fan_out)
 
     # ── Stage 2: CONTRARIAN (one red-team seat — the strongest reasoner) ──────
-    contra_provider, contra_model = _pick(roster, prefer=("codex", "deepseek-harness", "claude"))
     contra_prompt = (
         f"You are the RED TEAM on a deliberation panel ({spec.description}).\n"
         f"QUESTION: {question}\n{ctx_block}\n"
@@ -203,11 +202,12 @@ def run_deliberation(
         "Name what everyone MISSED, steelman the dissent, and flag any claim stated as fact "
         "without evidence. Do not be agreeable. Terse, concrete."
     )
-    result.contrarian = _safe(dispatcher, contra_provider, contra_model, contra_prompt,
-                              f"panel-{mode}-contrarian-{uuid.uuid4().hex[:6]}")
+    result.contrarian = _first_ok(
+        dispatcher, _ordered_seats(roster, ("codex", "deepseek-harness", "claude")),
+        contra_prompt, f"panel-{mode}-contrarian",
+    )
 
     # ── Stage 3: VERIFY (adversarial factcheck of the top claims) ────────────
-    verify_provider, verify_model = _pick(roster, prefer=("codex", "kimi", "claude"))
     verify_prompt = (
         f"You are the VERIFY pass on a deliberation panel ({spec.description}).\n"
         f"QUESTION: {question}\n{ctx_block}\n"
@@ -216,11 +216,12 @@ def run_deliberation(
         f"{spec.verify_target}. Mark each: CONFIRMED / REFUTED / UNVERIFIABLE, with the specific "
         "evidence (file:line or source). Default to REFUTED/UNVERIFIABLE when evidence is thin."
     )
-    result.factcheck = _safe(dispatcher, verify_provider, verify_model, verify_prompt,
-                             f"panel-{mode}-verify-{uuid.uuid4().hex[:6]}")
+    result.factcheck = _first_ok(
+        dispatcher, _ordered_seats(roster, ("codex", "kimi", "claude")),
+        verify_prompt, f"panel-{mode}-verify",
+    )
 
     # ── Stage 4: SYNTHESIS (one cited report) ────────────────────────────────
-    synth_provider, synth_model = _pick(roster, prefer=("claude", "codex", "kimi"))
     synth_prompt = (
         f"You are the SYNTHESISER on a deliberation panel ({spec.description}).\n"
         f"QUESTION: {question}\n{ctx_block}\n"
@@ -230,26 +231,55 @@ def run_deliberation(
         "dissent), VERIFIED CLAIMS (ranked, with evidence), OPEN QUESTIONS. Dedupe. Cite "
         "file:line / sources. Do not invent agreement that isn't there."
     )
-    result.synthesis = _safe(dispatcher, synth_provider, synth_model, synth_prompt,
-                             f"panel-{mode}-synth-{uuid.uuid4().hex[:6]}")
+    result.synthesis = _first_ok(
+        dispatcher, _ordered_seats(roster, ("claude", "codex", "kimi")),
+        synth_prompt, f"panel-{mode}-synth",
+    )
 
     return result
 
 
-def _pick(roster: List[Tuple[str, str]], prefer: Tuple[str, ...]) -> Tuple[str, str]:
-    """Pick the first preferred provider present in the roster, else the first roster seat."""
+def _ordered_seats(
+    roster: List[Tuple[str, str]], prefer: Tuple[str, ...]
+) -> List[Tuple[str, str]]:
+    """Preferred seats present in the roster (in preference order), then the rest — so a
+    stage can fall back to the next provider when one fails."""
     have = {p: m for p, m in roster}
-    for p in prefer:
-        if p in have:
-            return p, have[p]
-    return roster[0]
+    seats = [(p, have[p]) for p in prefer if p in have]
+    seats += [(p, m) for p, m in roster if p not in prefer]
+    return seats or list(roster)
 
 
-def _safe(dispatcher: DispatcherFn, provider: str, model: str, prompt: str, did: str) -> str:
-    try:
-        return dispatcher(provider, model, prompt, did) or "[empty]"
-    except Exception as exc:  # noqa: BLE001 — a stage failure degrades the report, never crashes
-        return f"[dispatch error {provider}: {exc!r}]"
+def _pick(roster: List[Tuple[str, str]], prefer: Tuple[str, ...]) -> Tuple[str, str]:
+    """First preferred provider present in the roster, else the first roster seat."""
+    return _ordered_seats(roster, prefer)[0]
+
+
+def _is_error(text: str) -> bool:
+    t = (text or "").strip()
+    return (not t) or t.startswith("[dispatch error") or t == "[empty]"
+
+
+def _first_ok(
+    dispatcher: DispatcherFn,
+    seats: List[Tuple[str, str]],
+    prompt: str,
+    did_prefix: str,
+) -> str:
+    """Try each seat in order until one returns a real (non-error) report. This keeps the
+    critical sequential stages (contrarian / verify / synthesis) from collapsing the whole
+    panel when the first-choice provider is down (sales-copilot T0, 2026-07-10)."""
+    last = "[empty]"
+    for provider, model in seats:
+        try:
+            out = dispatcher(provider, model, prompt, f"{did_prefix}-{provider}-{uuid.uuid4().hex[:6]}")
+        except Exception as exc:  # noqa: BLE001
+            last = f"[dispatch error {provider}: {exc!r}]"
+            continue
+        if not _is_error(out):
+            return out
+        last = out or "[empty]"
+    return last
 
 
 __all__ = ["MODES", "DEFAULT_ROSTER", "ModeSpec", "DeliberationResult", "run_deliberation"]

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -51,7 +51,13 @@ def main(argv: "list[str] | None" = None) -> int:
             return 2
 
     from plan_gate_panel import _make_default_dispatcher  # noqa: PLC0415
-    dispatcher = _make_default_dispatcher(None, args.timeout)
+    # Pass a REAL data_dir: the claude/tmux lane writes each report to
+    # <data_dir>/unified_reports/<id>.md and _read_report falls back to that path. With
+    # data_dir=None the claude-lane reports (fan-out + synthesis) are written but never found
+    # → no cited synthesis (sales-copilot T0, 2026-07-10). unified_reports_dir().parent IS
+    # that data_dir, so the write-path and read-path agree.
+    data_dir = str(_resolve_reports_dir().parent)
+    dispatcher = _make_default_dispatcher(data_dir, args.timeout)
 
     print(f"[panel] mode={args.mode} — running 4-stage deliberation across the fleet ...", file=sys.stderr)
     result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context)

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -79,6 +79,17 @@ class TestDegradation:
         # the other seats + later stages still ran
         assert res.synthesis == "ok"
 
+    def test_synthesis_falls_back_when_first_seat_errors(self):
+        # synthesis prefers claude; make claude error and claude's error must NOT be the
+        # final synthesis — a later seat produces the real report (no unconsolidated report).
+        def flaky(provider, model, prompt, did):
+            if provider == "claude":
+                return "[dispatch error claude: boom]"
+            return f"ok-{provider}"
+        res = dp.run_deliberation("architecture", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
+        assert not res.synthesis.startswith("[dispatch error")
+        assert res.synthesis.startswith("ok-")  # a fallback seat produced it
+
 
 class TestModesAndReport:
     def test_unknown_mode_raises(self):


### PR DESCRIPTION
## Summary

sales-copilot T0 tested `/panel` (sweep) and got **NO cited synthesis** — the report was unconsolidated. This fixes the root cause + hardens the synthesis stage.

**Dispatch-ID:** manual-t0-panel-fix-20260710

## Root cause
`scripts/panel.py` passed `data_dir=None` to `_make_default_dispatcher`. The claude/tmux lane writes each report to `<data_dir>/unified_reports/<id>.md` and `_read_report` finds it via the base-fallback — but with `base=None` the claude-lane reports (fan-out + **synthesis**) were written but never found → no synthesis. The provider lane worked because it prints a `Report:` stderr line the tmux lane does not.

The `staging_validator: unstaged dispatch override` line sales-copilot saw is a **benign success-path WARNING** (`allow_unstaged=True` logs + returns OK), not the failure — a red herring.

## Changes
- `scripts/panel.py`: pass a real data_dir (`unified_reports().parent`) so the claude-lane write-path and read-path agree.
- `scripts/lib/deliberation_panel.py`: the sequential stages (contrarian/verify/synthesis) now try the preferred providers **in order** via `_first_ok()` until one returns a real report, instead of collapsing the whole panel when the first-choice provider is down. A dead glm-harness/claude seat degrades a stage, never the cited synthesis.

## Verification
- `tests/test_deliberation_panel.py` (10, fake dispatcher): added the synthesis-fallback case (first seat errors → a later seat produces the report). All green.

## Open Items
Redeploy to edge + notify sales-copilot T0 to re-test (I handle after merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7