### PR TITLE
test(fsr-b): add builder-layer regression test for _resolve_tracks_store guard

### DIFF
--- a/tests/test_fsr_b_tenant_guard.py
+++ b/tests/test_fsr_b_tenant_guard.py
@@ -222,6 +222,27 @@ def test_reader_absent_db_is_healthy_empty(
 
 
 # ---------------------------------------------------------------------------
+# Builder-layer guard: _resolve_tracks_store must never escape to the real
+# central store during a pinned-isolation test run (audit #13 regression).
+# ---------------------------------------------------------------------------
+
+def test_resolve_tracks_store_stays_on_tmp_store_under_pinned_isolation(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """With the isolation guard applied, _resolve_tracks_store must resolve to
+    the tmp state_dir, not silently fall through to resolve_central_data_dir
+    and read the real production ~/.vnx-data/<project>/state (audit #13 — the
+    canary otherwise reads production tracks instead of the seeded tmp DB).
+    """
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    _make_v24_db(state_dir)
+
+    resolved = bts._resolve_tracks_store(state_dir, _TENANT_A)
+
+    assert resolved == state_dir
+
+
+# ---------------------------------------------------------------------------
 # Through build_t0_state: wiring + output flag (acceptance a & b)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_fsr_b_tenant_guard.py
+++ b/tests/test_fsr_b_tenant_guard.py
@@ -226,20 +226,40 @@ def test_reader_absent_db_is_healthy_empty(
 # central store during a pinned-isolation test run (audit #13 regression).
 # ---------------------------------------------------------------------------
 
-def test_resolve_tracks_store_stays_on_tmp_store_under_pinned_isolation(
+def test_resolve_tracks_store_escape_is_neutralized_by_pinned_isolation(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    """With the isolation guard applied, _resolve_tracks_store must resolve to
-    the tmp state_dir, not silently fall through to resolve_central_data_dir
-    and read the real production ~/.vnx-data/<project>/state (audit #13 — the
-    canary otherwise reads production tracks instead of the seeded tmp DB).
+    """audit #13: prove BOTH halves so the test can actually fail.
+
+    ``_resolve_tracks_store`` returns the central store only when
+    ``resolve_central_data_dir`` is not None AND that store has a
+    ``runtime_coordination.db``. A test that just calls ``_pin_isolation``
+    (which sets ``resolve_central_data_dir`` to None) is a tautology — it passes
+    regardless of the guard. So first demonstrate a *live* escape path against a
+    fake central store, then assert the pinned isolation neutralizes it.
     """
-    state_dir = _pin_isolation(tmp_path, monkeypatch)
-    _make_v24_db(state_dir)
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
 
-    resolved = bts._resolve_tracks_store(state_dir, _TENANT_A)
+    # A fake central store WITH a runtime_coordination.db — the escape target.
+    fake_central = tmp_path / "central"
+    fake_central_state = fake_central / "state"
+    fake_central_state.mkdir(parents=True)
+    (fake_central_state / "runtime_coordination.db").write_text("")
 
-    assert resolved == state_dir
+    # 1) Escape path is REAL: when central resolves to a populated store,
+    #    _resolve_tracks_store prefers it over state_dir. If this ever stops
+    #    holding, the guard-half below would pass vacuously — hence assert it.
+    monkeypatch.setattr(
+        bts, "resolve_central_data_dir", lambda pid: fake_central, raising=False
+    )
+    assert bts._resolve_tracks_store(state_dir, _TENANT_A) == fake_central_state
+
+    # 2) Pinned isolation NEUTRALIZES the escape: _pin_isolation sets
+    #    resolve_central_data_dir to None, so the resolver stays on the tmp
+    #    state_dir even though a populated central store exists on disk.
+    pinned_state = _pin_isolation(tmp_path, monkeypatch)
+    assert bts._resolve_tracks_store(pinned_state, _TENANT_A) == pinned_state
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Audit finding at `tests/test_fsr_b_tenant_guard.py:225-244` claimed `_resolve_tracks_store` calls `resolve_central_data_dir('vnx-dev')` and reads the real production store, bypassing the monkeypatched `VNX_DATA_DIR`.

Investigation found this was **already fixed** on `main` by commit `9e91bd447` (2026-06-27, PR #960): `_pin_isolation` (line 60) already does `monkeypatch.setattr(bts, "resolve_central_data_dir", None, raising=False)`, which every test in the file uses before calling `build_t0_state()`. Since `_resolve_tracks_store` looks up `resolve_central_data_dir` as a bare module-global in `build_t0_state.py`, the monkeypatch on the `bts` module object is picked up at call time — confirmed by reading `scripts/build_t0_state.py:1692-1709`.

A builder-layer resolver test for `_resolve_tracks_store` also already exists (`tests/test_build_t0_state_freshness.py::test_reconcile_resolves_central_store_not_ambient`), but it only covers the positive case (central store correctly resolved when mocked). This PR adds the missing negative/guard case **co-located in the tenant-guard test file**, directly asserting `_resolve_tracks_store` stays on the tmp `state_dir` under the pinned-isolation guard used throughout this file — closing the specific gap the audit flagged, without duplicating unrelated fix work.

No behavioral/production code changed — only test additions.

## Test plan
- [x] `python3 -m pytest tests/test_fsr_b_tenant_guard.py -q` → 10 passed (9 pre-existing + 1 new)
- [x] `python3 -m pytest tests/test_build_t0_state_freshness.py -q` → 7 passed (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)