### PR TITLE
fix(phantom-guard): exempt read-only reviews keyed by task_class or read_only flag

### DIFF
--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -12,10 +12,16 @@ worktree / pushed branch and passes it in; T0's rule is "verify the pushed branc
 
 token_usage is only CORROBORATING: providers that report it (codex/claude) spending >0 tokens proves
 an LLM ran; kimi-cli never reports tokens, so its absence/0 is not evidence of a phantom. Reviewers
-legitimately produce no diff, so REVIEW_ROLES are exempt.
+legitimately produce no diff, so REVIEW_ROLES are exempt — and since not every review dispatch is
+routed by a recognized `role` string (some are keyed by `task_class`, e.g. task_class="review" /
+"code-review"), the same exemption applies via REVIEW_TASK_CLASSES, and a caller can assert it
+directly with an explicit `read_only=True` flag (e.g. a receipt/manifest field) when neither role
+nor task_class is a reliable signal.
 
 Decision rule (a delivery worker is a phantom when):
-    role NOT in REVIEW_ROLES
+    read_only is not truthy
+    AND role NOT in REVIEW_ROLES
+    AND task_class NOT in REVIEW_TASK_CLASSES
     AND status claims completion (done/success)
     AND the worktree diff is empty
 token_usage is corroborating DETAIL only — token>0 does NOT exempt (it means an LLM thought, not
@@ -35,6 +41,17 @@ _LOG = logging.getLogger(__name__)
 # SSOT for review roles — kept in sync with the kimi-routing predicate (item C). A reviewer's
 # job is a verdict, not a diff, so it is never a phantom for "no changes".
 REVIEW_ROLES = frozenset({"plan-reviewer", "code-reviewer", "security-reviewer", "reviewer"})
+
+# Same exemption, keyed on task_class for dispatches routed/labeled by class rather than by a
+# REVIEW_ROLES role string (the "02_code_review"-style receipts.task_class convention used
+# elsewhere in the fabric — see evidence_bound_gate._task_class_for_manifest and the
+# task_class="review" receipts in outcome_signals). A genuine read-only review keyed only by
+# task_class was previously falling through to the delivery phantom check on an empty diff.
+REVIEW_TASK_CLASSES = frozenset({
+    "review", "code-review", "code_review",
+    "plan-review", "plan_review",
+    "security-review", "security_review",
+})
 
 # Receipt status values that assert the work completed.
 COMPLETION_STATUSES = frozenset({"done", "success", "complete", "completed"})
@@ -59,11 +76,17 @@ def phantom_guard(
     worktree_diff: Optional[str],
     token_usage: Optional[int] = None,
     role: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
 ) -> PhantomVerdict:
     """Pure decision. See module docstring for the rule. worktree_diff is the REAL diff of the
     worker's worktree/branch (caller-computed), NOT the receipt's main-repo provenance."""
+    if read_only:
+        return _ok("read_only=True — a verdict, not a diff, is expected")
     if role is not None and role.strip().lower() in REVIEW_ROLES:
         return _ok(f"review role {role!r} — a verdict, not a diff, is expected")
+    if task_class is not None and task_class.strip().lower() in REVIEW_TASK_CLASSES:
+        return _ok(f"review task_class {task_class!r} — a verdict, not a diff, is expected")
     if (status or "").strip().lower() not in COMPLETION_STATUSES:
         return _ok(f"status {status!r} is not a completion claim — nothing to falsify")
     if (worktree_diff or "").strip():
@@ -154,6 +177,8 @@ def guard_receipt(
         worktree_diff=worktree_diff,
         token_usage=_extract_token_usage(receipt),
         role=receipt.get("role") or receipt.get("agent"),
+        task_class=receipt.get("task_class"),
+        read_only=bool(receipt.get("read_only")),
     )
 
 
@@ -166,6 +191,8 @@ def guard_at_govern(
     worktree_path: Optional[Path] = None,
     base_sha: Optional[str] = None,
     worktree_diff: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
 ) -> PhantomVerdict:
     """Inline govern-time phantom check for BOTH lanes (claude tmux via dispatch_govern.govern,
     providers via dispatch_envelope._govern — the kimi/glm/deepseek fabrication vector).
@@ -200,7 +227,10 @@ def guard_at_govern(
                 diff = compute_branch_diff(branch, base_ref=base)
         except Exception as exc:  # CalledProcessError / missing ref / reaped worktree
             return _ok(f"phantom-guard ABSTAINED — worker diff unresolvable ({type(exc).__name__})")
-    return phantom_guard(status=status, worktree_diff=diff, token_usage=token_usage, role=role)
+    return phantom_guard(
+        status=status, worktree_diff=diff, token_usage=token_usage, role=role,
+        task_class=task_class, read_only=read_only,
+    )
 
 
 def record_phantom_if_any(
@@ -214,6 +244,8 @@ def record_phantom_if_any(
     worktree_diff: Optional[str] = None,
     receipts_file: Optional[str] = None,
     state_dir: Optional[Path] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
 ) -> PhantomVerdict:
     """``guard_at_govern`` + on a phantom verdict, append a corrective ``failed`` completion receipt.
 
@@ -233,6 +265,7 @@ def record_phantom_if_any(
     verdict = guard_at_govern(
         dispatch_id=dispatch_id, role=role, status=status, token_usage=token_usage,
         worktree_path=worktree_path, base_sha=base_sha, worktree_diff=worktree_diff,
+        task_class=task_class, read_only=read_only,
     )
     if verdict.is_phantom and state_dir:
         try:
@@ -338,6 +371,8 @@ def main(argv: Optional[list] = None) -> int:
     p.add_argument("--receipt-json", help="Receipt as a JSON string (or use --status/--role).")
     p.add_argument("--status", help="Receipt status (when not passing --receipt-json).")
     p.add_argument("--role", default=None)
+    p.add_argument("--task-class", default=None)
+    p.add_argument("--read-only", action="store_true")
     p.add_argument("--token-usage", type=int, default=None)
     src = p.add_mutually_exclusive_group()
     src.add_argument("--worktree", help="Path to the worker's worktree (diff it vs --base).")
@@ -362,6 +397,7 @@ def main(argv: Optional[list] = None) -> int:
         verdict = phantom_guard(
             status=args.status, worktree_diff=diff,
             token_usage=args.token_usage, role=args.role,
+            task_class=args.task_class, read_only=args.read_only,
         )
 
     print(verdict.reason, file=sys.stderr)

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -12,11 +12,13 @@ worktree / pushed branch and passes it in; T0's rule is "verify the pushed branc
 
 token_usage is only CORROBORATING: providers that report it (codex/claude) spending >0 tokens proves
 an LLM ran; kimi-cli never reports tokens, so its absence/0 is not evidence of a phantom. Reviewers
-legitimately produce no diff, so REVIEW_ROLES are exempt — and since not every review dispatch is
-routed by a recognized `role` string (some are keyed by `task_class`, e.g. task_class="review" /
-"code-review"), the same exemption applies via REVIEW_TASK_CLASSES, and a caller can assert it
-directly with an explicit `read_only=True` flag (e.g. a receipt/manifest field) when neither role
-nor task_class is a reliable signal.
+legitimately produce no diff, so REVIEW_ROLES are exempt.
+
+A read-only review can also arrive WITHOUT a REVIEW_ROLES-matching ``role`` string — e.g. a dispatch
+routed through ``task_class="research_structured"`` (the fabric's review/analysis bucket, see
+dispatch_router.py ROLE_TO_TASK_CLASS) or one that carries an explicit ``read_only=True`` flag on the
+dispatch spec. Both are exempt the same way a REVIEW_ROLES role is: a verdict with real tokens and an
+empty diff is expected, not evidence of fabrication.
 
 Decision rule (a delivery worker is a phantom when):
     read_only is not truthy
@@ -42,15 +44,16 @@ _LOG = logging.getLogger(__name__)
 # job is a verdict, not a diff, so it is never a phantom for "no changes".
 REVIEW_ROLES = frozenset({"plan-reviewer", "code-reviewer", "security-reviewer", "reviewer"})
 
-# Same exemption, keyed on task_class for dispatches routed/labeled by class rather than by a
-# REVIEW_ROLES role string (the "02_code_review"-style receipts.task_class convention used
-# elsewhere in the fabric — see evidence_bound_gate._task_class_for_manifest and the
-# task_class="review" receipts in outcome_signals). A genuine read-only review keyed only by
-# task_class was previously falling through to the delivery phantom check on an empty diff.
+# SSOT for review/analysis task_class values — a second key onto the same exemption for callers
+# that route by task_class rather than a REVIEW_ROLES-matching role string. "research_structured"
+# is the fabric's canonical bucket for reviewer/architect/planner/security-engineer/data-analyst
+# work (dispatch_router.py ROLE_TO_TASK_CLASS); "02_code_review" is smart_router.py's cost-routing
+# classifier bucket for review/audit/lint instructions. "review"/"analysis"/"code_review" are plain
+# literal fallbacks for callers that tag task_class without going through either taxonomy. The
+# hyphenated variants ("code-review"/"plan-review") were dropped: they are not emitted by any real
+# dispatch path (only ever a docstring example), so they widened the exemption for nothing.
 REVIEW_TASK_CLASSES = frozenset({
-    "review", "code-review", "code_review",
-    "plan-review", "plan_review",
-    "security-review", "security_review",
+    "research_structured", "02_code_review", "code_review", "review", "analysis",
 })
 
 # Receipt status values that assert the work completed.

--- a/tests/test_phantom_guard.py
+++ b/tests/test_phantom_guard.py
@@ -65,3 +65,59 @@ def test_unmeasured_tokens_mapping_is_none():
     assert pg._extract_token_usage({"token_usage": {"input": 0, "output": 0}}) is None
     assert pg._extract_token_usage({"token_usage": 42}) == 42
     assert pg._extract_token_usage({}) is None
+
+
+def test_review_task_class_is_never_phantom():
+    # a review keyed by task_class (not a REVIEW_ROLES role string) with real tokens spent and an
+    # empty diff — the genuine read-only review case this PR fixes.
+    v = pg.phantom_guard(status="done", worktree_diff="", token_usage=987,
+                         role="backend-developer", task_class="review")
+    assert not v.is_phantom
+    assert "task_class" in v.reason
+
+
+def test_review_task_class_variants_are_exempt():
+    for tc in ("code-review", "code_review", "plan-review", "plan_review",
+               "security-review", "security_review", "REVIEW", " review "):
+        v = pg.phantom_guard(status="done", worktree_diff="", token_usage=None,
+                             role="backend-developer", task_class=tc)
+        assert not v.is_phantom, f"task_class={tc!r} should be exempt"
+
+
+def test_unrelated_task_class_is_still_phantom():
+    v = pg.phantom_guard(status="done", worktree_diff="", token_usage=None,
+                         role="backend-developer", task_class="implementation")
+    assert v.is_phantom
+
+
+def test_read_only_flag_is_never_phantom():
+    # explicit read_only=True exempts regardless of role/task_class — the escape hatch for a
+    # review dispatch that isn't captured by either known-role or known-task_class matching.
+    v = pg.phantom_guard(status="done", worktree_diff="", token_usage=555,
+                         role="backend-developer", task_class=None, read_only=True)
+    assert not v.is_phantom
+    assert "read_only" in v.reason
+
+
+def test_read_only_false_does_not_exempt():
+    v = pg.phantom_guard(status="done", worktree_diff="", token_usage=None,
+                         role="backend-developer", read_only=False)
+    assert v.is_phantom
+
+
+def test_guard_receipt_extracts_task_class_and_read_only():
+    # task_class-keyed review: real tokens, empty diff, delivery-shaped role -> not phantom
+    receipt = {"status": "done", "role": "backend-developer", "task_class": "review",
+               "token_usage": {"input": 100, "output": 50}}
+    v = pg.guard_receipt(receipt, worktree_diff="")
+    assert not v.is_phantom
+
+    # read_only flag on the receipt itself, no recognized role/task_class
+    receipt2 = {"status": "done", "role": "backend-developer", "read_only": True}
+    v2 = pg.guard_receipt(receipt2, worktree_diff="")
+    assert not v2.is_phantom
+
+    # neither signal present, empty diff, delivery role -> still phantom
+    receipt3 = {"status": "done", "role": "backend-developer"}
+    v3 = pg.guard_receipt(receipt3, worktree_diff="")
+    assert v3.is_phantom

--- a/tests/test_phantom_guard.py
+++ b/tests/test_phantom_guard.py
@@ -77,11 +77,22 @@ def test_review_task_class_is_never_phantom():
 
 
 def test_review_task_class_variants_are_exempt():
-    for tc in ("code-review", "code_review", "plan-review", "plan_review",
-               "security-review", "security_review", "REVIEW", " review "):
+    # The real fabric review/analysis task_class buckets (dispatch_router.py ROLE_TO_TASK_CLASS +
+    # smart_router.py), plus case/whitespace-normalized forms.
+    for tc in ("research_structured", "02_code_review", "code_review", "review", "analysis",
+               "REVIEW", " review "):
         v = pg.phantom_guard(status="done", worktree_diff="", token_usage=None,
                              role="backend-developer", task_class=tc)
         assert not v.is_phantom, f"task_class={tc!r} should be exempt"
+
+
+def test_hyphenated_task_class_is_not_exempt():
+    # Hyphenated variants were never emitted by any real dispatch path (only a docstring example),
+    # so they are NOT in the exemption set — an empty-diff delivery claiming one is still a phantom.
+    for tc in ("code-review", "plan-review", "security-review"):
+        v = pg.phantom_guard(status="done", worktree_diff="", token_usage=None,
+                             role="backend-developer", task_class=tc)
+        assert v.is_phantom, f"task_class={tc!r} is not a real review bucket and must not exempt"
 
 
 def test_unrelated_task_class_is_still_phantom():

--- a/tests/test_phantom_guard_inline.py
+++ b/tests/test_phantom_guard_inline.py
@@ -59,6 +59,39 @@ def test_precaptured_worktree_diff_bypasses_resolution():
     assert not v2.is_phantom
 
 
+def test_guard_at_govern_exempts_review_task_class_with_precaptured_empty_diff():
+    # a read-only review keyed by task_class (not a REVIEW_ROLES role string), real tokens spent,
+    # empty pre-captured diff -> must not be phantom-rejected.
+    v = pg.guard_at_govern(dispatch_id="d1", role="backend-developer", status="done",
+                           token_usage=987, worktree_diff="", task_class="review")
+    assert not v.is_phantom
+
+
+def test_guard_at_govern_exempts_read_only_flag_with_precaptured_empty_diff():
+    v = pg.guard_at_govern(dispatch_id="d1", role="backend-developer", status="done",
+                           token_usage=987, worktree_diff="", read_only=True)
+    assert not v.is_phantom
+
+
+def test_record_phantom_threads_task_class_and_read_only(monkeypatch, tmp_path):
+    # record_phantom_if_any must forward task_class/read_only to guard_at_govern so the receipt
+    # entry point exempts a genuine empty-diff review the same way the pure decision does.
+    captured = {}
+
+    def _fake_guard_at_govern(**kw):
+        captured.update(kw)
+        return pg.PhantomVerdict(False, "ok")
+
+    monkeypatch.setattr(pg, "guard_at_govern", _fake_guard_at_govern)
+    v = pg.record_phantom_if_any(dispatch_id="d1", role="backend-developer", status="done",
+                                 token_usage=987, worktree_diff="",
+                                 receipts_file=str(tmp_path / "r.ndjson"),
+                                 task_class="review", read_only=None)
+    assert not v.is_phantom
+    assert captured["task_class"] == "review"
+    assert captured["read_only"] is None
+
+
 def test_dedup_phantom_rejected_wins_over_worker_done():
     import dispatch_govern as dg
     worker = {"dispatch_id": "d1", "status": "done", "timestamp": "2026-06-23T10:00:00Z"}


### PR DESCRIPTION
## Summary
- Read-only reviews (empty diff, real tokens) were phantom-rejected whenever the dispatch was keyed by `task_class` (e.g. `task_class="review"`) rather than by a recognized `REVIEW_ROLES` role string.
- Adds a `REVIEW_TASK_CLASSES` exemption (mirrors `REVIEW_ROLES`) plus an explicit `read_only` flag, threaded through `phantom_guard()`, `guard_receipt()`, `guard_at_govern()`, `record_phantom_if_any()`, and the CLI.
- `guard_receipt()` now also pulls `task_class`/`read_only` straight off the receipt dict, so no caller wiring is required for receipt-based callers.

## Test plan
- [x] `python3 -m pytest -q -k phantom` — 30 passed
- [x] `python3 -c "import ast; ast.parse(open('scripts/lib/phantom_guard.py').read())"` — syntax OK

🤖 Generated with [Claude Code](https://claude.com/claude-code)