### PR TITLE
fix(gate): plan-gate-panel seat robustness (opus data_dir + codex/glm verdict repair)

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -66,6 +66,7 @@ DEFAULT_PANEL: List[Dict[str, str]] = [
 ]
 
 VERDICT_FENCE = "vnx-plan-verdict"
+_OPEN_FENCE = "```" + VERDICT_FENCE
 _VALID_VERDICTS = {"pass", "revise", "block"}
 
 # A dispatcher takes (provider, model_arg, instruction, dispatch_id) and returns the
@@ -163,22 +164,71 @@ def build_plan_review_instruction_fileref(
     )
 
 
+def _strip_trailing_commas(text: str) -> str:
+    """Remove a trailing comma immediately before a closing ``}``/``]`` (a recurring
+    codex/glm flake: ``{"a": 1,}``)."""
+    return re.sub(r",(\s*[}\]])", r"\1", text)
+
+
+def _extract_braced_object(text: str) -> Optional[str]:
+    """Slice from the first ``{`` to the last ``}`` in ``text``.
+
+    Strips prose bleed around the object (a panelist prefacing/trailing the JSON with
+    commentary) and, as a side effect, strips a nested ` ```json ` code fence wrapped around
+    the object too — the fence markers fall outside the first-``{``/last-``}`` window.
+    """
+    start, end = text.find("{"), text.rfind("}")
+    if start == -1 or end == -1 or end <= start:
+        return None
+    return text[start:end + 1]
+
+
+def _parse_json_loose(body: str) -> Optional[Any]:
+    """Best-effort repair of a near-miss verdict JSON body before giving up.
+
+    Tries, in order: the body as-is; the body with a braced-object extraction (drops prose
+    bleed and any nested ```json fence); each of those with trailing commas stripped. Returns
+    the parsed value, or ``None`` if nothing repairs into valid JSON.
+    """
+    candidates = [body.strip()]
+    braced = _extract_braced_object(body)
+    if braced is not None:
+        candidates.append(braced)
+    candidates.extend([_strip_trailing_commas(c) for c in list(candidates)])
+    for candidate in candidates:
+        try:
+            return json.loads(candidate)
+        except (json.JSONDecodeError, ValueError):
+            continue
+    return None
+
+
 def parse_verdict(report_text: str) -> Dict[str, Any]:
     """Extract the LAST ``vnx-plan-verdict`` block from a panelist report.
 
-    Fail-safe by design: anything unparseable becomes ``revise`` with
+    Tolerant of common near-miss formatting via ``_parse_json_loose`` — a trailing comma, prose
+    bleeding in around the JSON object, or a nested ` ```json ` code fence wrapping the object —
+    so a slightly-malformed body no longer forces a spurious abstain (the codex/glm verdict-JSON
+    flake). The exact ``vnx-plan-verdict`` fence label is still required verbatim: that is the
+    same marker ``_sanitize_doc`` neutralizes in untrusted plan-doc input, so this deliberately
+    does NOT fall back to a bare/relabeled ```json fence — doing so would reopen the verdict-
+    spoofing hole (kimi finding 4) via a doc that gets echoed into a panelist's own report.
+
+    Fail-safe by design: anything still unparseable after repair becomes ``revise`` with
     ``parse_error=True`` so a missing/garbled verdict can never silently PASS.
     """
     empty = {"verdict": "revise", "blocking_findings": [], "rationale": "", "parse_error": True}
     if not report_text:
         return {**empty, "rationale": "empty report"}
-    pattern = re.compile(r"```" + re.escape(VERDICT_FENCE) + r"\s*\n(.*?)```", re.DOTALL)
-    matches = pattern.findall(report_text)
-    if not matches:
+    idx = report_text.rfind(_OPEN_FENCE)
+    if idx == -1:
         return {**empty, "rationale": "no verdict block found"}
-    try:
-        data = json.loads(matches[-1].strip())
-    except (json.JSONDecodeError, ValueError):
+    body = report_text[idx + len(_OPEN_FENCE):]
+    close_idx = body.rfind("```")
+    if close_idx != -1:
+        body = body[:close_idx]
+    data = _parse_json_loose(body)
+    if data is None:
         return {**empty, "rationale": "verdict block is not valid JSON"}
     if not isinstance(data, dict):
         return {**empty, "rationale": "verdict block is not a JSON object"}
@@ -300,6 +350,31 @@ def _read_report(base: Optional[Path], dispatch_id: str, stderr: str) -> Optiona
     return None
 
 
+def _resolve_data_dir(data_dir: Optional[str]) -> Path:
+    """Resolve the data_dir the claude/tmux-lane report is written under and read back from.
+
+    A caller-supplied ``data_dir`` wins. When omitted, resolve via the SAME helper the
+    dispatch door itself uses (``project_root.resolve_data_dir``, invoked by
+    ``tmux_interactive_dispatch.py``'s ``_resolve_state_dir`` as
+    ``resolve_state_dir(caller_file=__file__).parent``) instead of degrading to ``None``.
+
+    A ``None`` base means ``_read_report``'s base-fallback path can never resolve the
+    claude/tmux-lane report: unlike ``provider_dispatch``, that lane prints no ``Report:``
+    stderr line, so the opus seat's authored report is never found -> NO-VERDICT rc=1
+    "staging_validator: unstaged dispatch override" (#1102 class bug).
+    """
+    if data_dir:
+        return Path(data_dir)
+    if str(HERE) not in sys.path:
+        sys.path.insert(0, str(HERE))
+    try:
+        from project_root import resolve_data_dir  # noqa: PLC0415
+        return resolve_data_dir(caller_file=__file__)
+    except Exception:
+        # Not a git repo and no VNX_CANONICAL_ROOT — last-resort fallback, same as before.
+        return Path(os.environ.get("VNX_DATA_DIR") or tempfile.gettempdir())
+
+
 def _make_default_dispatcher(
     data_dir: Optional[str], timeout_seconds: int,
 ) -> DispatcherFn:
@@ -315,7 +390,7 @@ def _make_default_dispatcher(
                            (bills API credits post-cutover).
       kimi/glm/deepseek -> provider_dispatch (constraint-safe per provider).
     """
-    base = Path(data_dir) if data_dir else None
+    base = _resolve_data_dir(data_dir)
 
     def _dispatch(provider: str, model_arg: str, instruction: str, dispatch_id: str) -> str:
         env = dict(os.environ)
@@ -329,17 +404,10 @@ def _make_default_dispatcher(
                 #
                 # We write the original inline instruction to a temp file so the worker can
                 # read the plan + rubric + verdict contract from a stable on-disk path.
-                # The expected report path is derived from data_dir so the file-ref instruction
-                # can tell the worker exactly where to write its verdict report.
-                report_path_str: str
-                if base is not None:
-                    report_path_str = str(base / "unified_reports" / f"{dispatch_id}.md")
-                else:
-                    # Fallback: derive from VNX_DATA_DIR or a tmp path
-                    report_path_str = str(
-                        Path(os.environ.get("VNX_DATA_DIR", tempfile.gettempdir()))
-                        / "unified_reports" / f"{dispatch_id}.md"
-                    )
+                # The expected report path is derived from data_dir (resolved above, never
+                # None) so the file-ref instruction's write path and _read_report's read path
+                # agree.
+                report_path_str = str(base / "unified_reports" / f"{dispatch_id}.md")
 
                 # Write the full inline instruction (plan + rubric + contract) to a temp file.
                 # The worker reads this file; the short file-ref instruction points to it.

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -80,6 +80,69 @@ def test_parse_verdict_empty_report():
 
 
 # --------------------------------------------------------------------------
+# parse_verdict tolerant repair pass (seat-robustness: codex + glm verdict-JSON flake).
+# A slightly-malformed body must still parse; a genuinely absent block must still
+# fail safe to revise (never a silent PASS).
+# --------------------------------------------------------------------------
+
+def test_parse_verdict_trailing_comma_is_repaired():
+    body = (
+        '{\n  "verdict": "pass",\n  "blocking_findings": [],\n  "rationale": "ok",\n}'
+    )
+    out = pgp.parse_verdict(_report(body))
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+    assert out["rationale"] == "ok"
+
+
+def test_parse_verdict_prose_wrapped_json_is_repaired():
+    body = (
+        "Here is my verdict, see below:\n"
+        '{"verdict": "revise", "blocking_findings": ["needs rollback"], "rationale": "gap"}\n'
+        "Thanks for reading."
+    )
+    out = pgp.parse_verdict(_report(body))
+    assert out["verdict"] == "revise"
+    assert out["blocking_findings"] == ["needs rollback"]
+    assert out["parse_error"] is False
+
+
+def test_parse_verdict_nested_json_fenced_block_is_repaired():
+    # A panelist that nests a standard ```json fence INSIDE the required
+    # ```vnx-plan-verdict fence (a common LLM habit) must still parse. The outer
+    # fence label is still required verbatim -- this is not a fallback to a bare
+    # ```json fence, which would reopen the verdict-spoofing hole.
+    text = (
+        "# review\n\nsome prose\n\n"
+        f"```{pgp.VERDICT_FENCE}\n"
+        "```json\n"
+        '{"verdict": "pass", "blocking_findings": [], "rationale": "nested fence ok"}\n'
+        "```\n"
+        "```\n"
+    )
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+    assert out["rationale"] == "nested fence ok"
+
+
+def test_parse_verdict_bare_json_fence_without_label_does_not_count():
+    # A bare ```json fence with NO ```vnx-plan-verdict label anywhere must still fail
+    # safe -- accepting it would let an untrusted plan doc spoof a verdict via a
+    # generic ```json block that gets echoed into a panelist's report.
+    text = '# review\n\n```json\n{"verdict": "pass"}\n```\n'
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "revise"
+    assert out["parse_error"] is True
+
+
+def test_parse_verdict_genuinely_absent_block_still_failsafe_revise():
+    out = pgp.parse_verdict("# review\n\nLGTM, ship it, no fence emitted.\n")
+    assert out["verdict"] == "revise"
+    assert out["parse_error"] is True
+
+
+# --------------------------------------------------------------------------
 # apply_panel_rule
 # --------------------------------------------------------------------------
 
@@ -912,3 +975,75 @@ def test_govern_spec_role_plan_reviewer_fenceless_report_becomes_synthesized(tmp
     assert pgp.parse_verdict(result_body)["parse_error"] is True, (
         "synthesized body unexpectedly contains a parseable verdict fence"
     )
+
+
+# --------------------------------------------------------------------------
+# seat-robustness (#1102 class): _resolve_data_dir must never degrade to None so
+# the opus/claude-lane report path can always be located by _read_report.
+# --------------------------------------------------------------------------
+
+def test_resolve_data_dir_honors_explicit_value(tmp_path):
+    assert pgp._resolve_data_dir(str(tmp_path)) == tmp_path
+
+
+def test_resolve_data_dir_none_resolves_to_real_path_not_none():
+    # With no caller-supplied data_dir, the resolver must fall back to the SAME helper the
+    # dispatch door uses (project_root.resolve_data_dir) rather than returning None -- a
+    # None base is exactly what broke the opus seat's report lookup (#1102 class bug).
+    resolved = pgp._resolve_data_dir(None)
+    assert resolved is not None
+    assert isinstance(resolved, Path)
+    assert resolved.is_absolute()
+
+
+def test_resolve_data_dir_none_matches_project_root_helper():
+    import sys
+    _lib = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+    if _lib not in sys.path:
+        sys.path.insert(0, _lib)
+    from project_root import resolve_data_dir
+
+    assert pgp._resolve_data_dir(None) == resolve_data_dir(caller_file=pgp.__file__)
+
+
+def _completed_process():
+    import subprocess as _sp
+    return _sp.CompletedProcess([], returncode=0, stdout="", stderr="")
+
+
+def test_claude_lane_report_path_uses_resolved_data_dir_when_none(tmp_path, monkeypatch):
+    # Regression for the opus-seat NO-VERDICT bug: when run_panel is called with no
+    # data_dir, the claude/tmux lane's report path (and the read-back base) must still
+    # resolve to a real directory, not None -- _read_report(None, ...) can never find the
+    # worker-authored report when the tmux lane prints no `Report:` stderr line.
+    import unittest.mock as mock
+    import plan_gate_panel as _pgp
+
+    fake_base = tmp_path / "resolved-data-dir"
+    monkeypatch.setattr(_pgp, "_resolve_data_dir", lambda data_dir: fake_base)
+
+    authored_report = _make_report_with_fence("pass")
+    seen_bases = []
+
+    def _fake_read_report(base, dispatch_id, stderr):
+        seen_bases.append(base)
+        return authored_report
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    with mock.patch.object(_pgp.subprocess, "run") as mock_run:
+        mock_run.return_value = _completed_process()
+        with mock.patch.object(_pgp, "_read_report", side_effect=_fake_read_report):
+            out = pgp.run_panel(
+                doc,
+                track_id="feat-nodatadir",
+                project_id="p1",
+                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+                # data_dir intentionally omitted -> None
+            )
+
+    assert out["decision"] == "PASS"
+    assert len(seen_bases) == 1
+    assert seen_bases[0] == fake_base
+    assert seen_bases[0] is not None


### PR DESCRIPTION
## Summary
- Fixes two independent bugs that degraded the 5-family plan-gate panel (`scripts/lib/plan_gate_panel.py`) to 2/5 scoring seats.
- **opus/claude-lane data_dir resolution (#1102 class):** `_make_default_dispatcher` degraded to `base=None` whenever `data_dir` was omitted, so `_read_report`'s base-fallback path could never resolve the tmux-lane report (that lane prints no `Report:` stderr line, unlike `provider_dispatch`) -> NO-VERDICT rc=1 ("staging_validator: unstaged dispatch override"). New `_resolve_data_dir()` resolves via the same helper the dispatch door itself uses (`project_root.resolve_data_dir`) instead of degrading to `None`.
- **codex/glm seats abstaining on unparseable verdict JSON:** `parse_verdict` now runs a repair pass (`_parse_json_loose`) before giving up — strips trailing commas, strips prose bleed around the JSON object, and tolerates a nested ` ```json ` fence wrapped inside the required ` ```vnx-plan-verdict ` fence. The exact fence label is still required verbatim (no fallback to a bare/relabeled ` ```json ` fence), so the verdict-spoofing guard (`_sanitize_doc`, kimi finding 4) is unweakened. A genuinely absent or still-unparseable block still fails safe to `revise`.

## Test plan
- [x] `python3 -m pytest tests/test_plan_gate_panel.py -q` — 59 passed (9 new: 5 tolerant-parse cases, 4 data_dir-resolution cases)
- [x] `python3 -m pytest tests/test_runtime_adapter_certification.py tests/test_dispatch_sidedoor_audit.py tests/test_glm_harness_normalization.py tests/test_deliberation_panel.py -q` — 65 passed (no regressions in dependent modules)

🤖 Generated with [Claude Code](https://claude.com/claude-code)