### PR TITLE
fix(dispatch): fail-loud on empty provider-lane completion, never silent success

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -875,6 +875,14 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
         with serialize_lane(plan.serialization_class, dispatch_id=vspec.spec.dispatch_id):
             if plan.lane == "provider":
                 result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+                if result.status != "success":
+                    # Fail-loud: the door must never swallow a provider-lane failure into a
+                    # bare exit code — the caller (bin/vnx dispatch) prints nothing else.
+                    print(
+                        f"[dispatch_cli] provider lane {result.status}: "
+                        f"{result.error or '(no error captured)'}",
+                        file=sys.stderr,
+                    )
                 return result.returncode
             elif plan.lane == "claude_tmux_subscription":
                 return _execute_claude(

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -436,13 +436,29 @@ def _govern(
                 f"path={receipt_path} dispatch={spec.dispatch_id} (fail-closed)"
             )
 
-    logger.info(
-        "envelope._govern: dispatch=%s status=%s report=%s receipt=%s",
-        spec.dispatch_id,
-        adapter_result.status,
-        report_path,
-        receipt_path,
-    )
+    if adapter_result.status != "success":
+        # Fail-loud: a failure/timeout/empty-completion receipt must never be silent.
+        # dispatch_cli returns only an integer exit code for the provider lane, so this
+        # log line is often the only place the raw error surfaces — print it in full.
+        logger.error(
+            "envelope._govern: dispatch=%s provider=%s status=%s report=%s receipt=%s "
+            "completion_len=%d error=%s",
+            spec.dispatch_id,
+            spec.provider,
+            adapter_result.status,
+            report_path,
+            receipt_path,
+            len(adapter_result.completion_text or ""),
+            adapter_result.error or "(no error captured)",
+        )
+    else:
+        logger.info(
+            "envelope._govern: dispatch=%s status=%s report=%s receipt=%s",
+            spec.dispatch_id,
+            adapter_result.status,
+            report_path,
+            receipt_path,
+        )
     # P0.2: inline phantom-guard (provider lanes — the kimi/glm/deepseek text-only fabrication
     # vector). A delivery worker that reports success with no worktree/branch diff is rejected via
     # a corrective failed receipt. worktree_path is unavailable on EnvelopeSpec, so the guard derives
@@ -531,6 +547,42 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
 # ---------------------------------------------------------------------------
 
 
+def _fail_loud_on_empty_success(
+    status: str,
+    returncode: int,
+    completion_text: str,
+    provider_str: str,
+    raw_result: Any,
+) -> tuple:
+    """Refuse to report a "success" with a blank completion — surface it instead.
+
+    A provider spawn can return returncode=0 with an empty completion_text when
+    its own CLI/output-format changed underneath it (the exact silent-empty-
+    completion vector this guard exists to catch — see dispatch instruction
+    20260710-211102-envelope-provider-lane-empty-completion). Not every spawn_*
+    does its own empty-extraction check (kimi_spawn does; the harness/litellm/
+    codex/gemini spawns do not), so this backstop lives once, centrally, here —
+    the ONE place every provider-lane result passes through before GOVERN.
+
+    Returns (status, returncode, error) — unchanged unless status=="success"
+    and completion_text is blank, in which case status is downgraded to
+    "failure", returncode is forced non-zero, and error carries the raw spawn
+    result (repr'd) so the failure is diagnosable instead of a silent blank
+    report + receipt.
+    """
+    if status == "success" and not (completion_text or "").strip():
+        return (
+            "failure",
+            returncode or 1,
+            (
+                f"provider={provider_str} returned an empty completion with "
+                f"returncode={returncode} — refusing to report a silent empty "
+                f"success (raw spawn result: {raw_result!r})"
+            ),
+        )
+    return status, returncode, None
+
+
 def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
     """Map codex/kimi/gemini/litellm:* spawn result to _AdapterResult.
 
@@ -562,12 +614,17 @@ def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
             timed_out=True,
             event_writer_failures=ewf,
         )
+    completion_text = result.completion_text or ""
     status = "success" if result.returncode == 0 else "failure"
+    status, returncode, guard_error = _fail_loud_on_empty_success(
+        status, result.returncode, completion_text, provider_str, result
+    )
     return _AdapterResult(
-        returncode=result.returncode,
-        completion_text=(result.completion_text or ""),
+        returncode=returncode,
+        completion_text=completion_text,
         status=status,
         token_usage=token_usage,
+        error=guard_error,
         event_writer_failures=ewf,
     )
 
@@ -763,12 +820,17 @@ class ProviderAdapter:
                     status="success",
                     token_usage=token_usage,
                 )
+            _dh_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
+            status, _dh_rc, _dh_err = _fail_loud_on_empty_success(
+                status, result.returncode, _dh_text, pv.value, result
+            )
             return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
+                returncode=_dh_rc,
+                completion_text=_dh_text,
                 status=status,
                 token_usage=token_usage,
+                error=_dh_err,
             )
 
         # ---- glm-harness ---- (codex flip-PR F2: the door normalizes GLM -> glm-harness, so the
@@ -821,12 +883,17 @@ class ProviderAdapter:
                     status="success",
                     token_usage=token_usage,
                 )
+            _gh_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
+            status, _gh_rc, _gh_err = _fail_loud_on_empty_success(
+                status, result.returncode, _gh_text, pv.value, result
+            )
             return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
+                returncode=_gh_rc,
+                completion_text=_gh_text,
                 status=status,
                 token_usage=token_usage,
+                error=_gh_err,
             )
 
         # ---- local-gemma ----
@@ -862,12 +929,17 @@ class ProviderAdapter:
                     token_usage=token_usage,
                     timed_out=True,
                 )
+            _lg_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
+            status, _lg_rc, _lg_err = _fail_loud_on_empty_success(
+                status, result.returncode, _lg_text, pv.value, result
+            )
             return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
+                returncode=_lg_rc,
+                completion_text=_lg_text,
                 status=status,
                 token_usage=token_usage,
+                error=_lg_err,
             )
 
         # Provider.CLAUDE, Provider.AUTO, or any unexpected value — programming error

--- a/tests/test_dispatch_envelope_fail_loud.py
+++ b/tests/test_dispatch_envelope_fail_loud.py
@@ -1,0 +1,234 @@
+"""test_dispatch_envelope_fail_loud.py — Regression tests for dispatch #20260710-211102.
+
+Covers:
+1. The happy path: run_envelope_plan propagates a real (non-empty) provider
+   completion through PREPARE -> ROUTE -> EXECUTE -> GOVERN unchanged. This
+   pins the ProviderAdapter.run(plan, instruction, ...) call signature so a
+   future regression back to the single-positional adapter.run(spec) shape
+   (the shape run_envelope() uses for the codex/claude-subprocess lanes) is
+   caught immediately.
+2. The fail-loud guard: a provider spawn that returns returncode=0 with a
+   BLANK completion_text (the silent-empty-success vector — some spawn_*
+   functions, unlike kimi_spawn, do not self-check for empty extraction) must
+   be downgraded to status="failure" with a diagnosable error, never reported
+   as an empty "success".
+3. dispatch_cli surfaces the failure to stderr for the provider lane instead
+   of returning a bare exit code with no visible cause.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from dispatch_envelope import ProviderAdapter, run_envelope_plan
+from dispatch_internal import issue_permit
+from dispatch_plan import ExecutionPlan
+from dispatch_spec import Isolation, Provider
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_provider_plan(
+    tmp_path: Path,
+    *,
+    provider: Provider = Provider.KIMI,
+    model: str = "default",
+    dispatch_id: str = "test-fail-loud-dispatch",
+) -> ExecutionPlan:
+    instruction_file = tmp_path / f"instruction-{provider.value.replace(':', '-')}.md"
+    instruction_file.write_text("Reply with exactly the word OK.", encoding="utf-8")
+    sha256 = hashlib.sha256(
+        instruction_file.read_text(encoding="utf-8").encode("utf-8")
+    ).hexdigest()
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=provider,
+        model=model,
+        lane="provider",
+        adapter="provider",
+        target_id="T1",
+        billing="provider_metered",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="fail-loud-regression",
+        instruction_sha256=sha256,
+    )
+
+
+@dataclass
+class _FakeKimiResult:
+    """Minimal stand-in for KimiSpawnResult — same attribute surface consumed
+    by _map_generic_spawn_result / ProviderAdapter.run()."""
+
+    returncode: int = 0
+    completion_text: str = "OK"
+    events_written: int = 1
+    session_id: Optional[str] = None
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+
+# ---------------------------------------------------------------------------
+# Test 1: happy path — a real completion propagates through the full envelope
+# ---------------------------------------------------------------------------
+
+
+def test_run_envelope_plan_propagates_successful_kimi_completion(tmp_path):
+    """A provider plan whose spawn returns completion_text="OK", returncode=0
+    must come back out of run_envelope_plan as EnvelopeResult(status="success",
+    completion_text="OK") — this is the exact scenario dispatch
+    20260710-211102-envelope-provider-lane-empty-completion asked to pin down.
+    """
+    plan = _make_provider_plan(tmp_path, dispatch_id="test-kimi-happy-path")
+    permit = issue_permit(plan)
+
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir()
+    data_dir.mkdir()
+
+    fake_wt = tmp_path / "wt"
+    fake_wt.mkdir()
+
+    fake_result = _FakeKimiResult(returncode=0, completion_text="OK")
+
+    with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=fake_result), \
+         patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=fake_wt), \
+         patch("dispatch_worktree_isolation.remove_dispatch_worktree"):
+        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success", f"expected success, got {result.status} (error={result.error})"
+    assert result.returncode == 0
+    assert result.completion_text == "OK"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Test 2: fail-loud guard — returncode=0 + blank completion is never "success"
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "provider,spawn_target",
+    [
+        (Provider.KIMI, "provider_spawns.kimi_spawn.spawn_kimi"),
+        (Provider.CODEX, "provider_spawns.codex_spawn.spawn_codex"),
+        (Provider.GEMINI, "provider_spawns.gemini_spawn.spawn_gemini"),
+        (Provider.DEEPSEEK_HARNESS, "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness"),
+        (Provider.GLM_HARNESS, "provider_spawns.glm_harness_spawn.spawn_glm_harness"),
+    ],
+)
+def test_provider_adapter_empty_completion_is_fail_loud(
+    tmp_path, monkeypatch, provider, spawn_target
+):
+    """returncode=0 with a BLANK completion_text must downgrade to failure with
+    a diagnosable error — never a silent empty "success" (the exact vector
+    dispatch 20260710-211102 asked to close: "surface the raw spawn result +
+    a clear error, never a silent empty report + failure receipt").
+    """
+    monkeypatch.setattr(
+        "provider_dispatch._resolve_codex_model", lambda: "gpt-codex-test"
+    )
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.resolve_harness_model",
+        lambda m: "deepseek-v4-test",
+    )
+    monkeypatch.setattr(
+        "provider_spawns.glm_harness_spawn.resolve_harness_model",
+        lambda m: "glm-test",
+    )
+
+    empty_result = _FakeKimiResult(returncode=0, completion_text="", error=None)
+    monkeypatch.setattr(spawn_target, lambda *a, **k: empty_result)
+
+    plan = _make_provider_plan(tmp_path, provider=provider, model="default")
+    adapter = ProviderAdapter()
+
+    result = adapter.run(plan, "prompt")
+
+    assert result.status == "failure", (
+        f"{provider.value}: blank completion_text with returncode=0 must not "
+        f"report success (got status={result.status})"
+    )
+    assert result.completion_text == ""
+    assert result.error, f"{provider.value}: fail-loud guard must set a diagnosable error"
+    assert provider.value in result.error
+    assert "empty completion" in result.error
+
+
+def test_provider_adapter_nonempty_completion_still_succeeds(tmp_path, monkeypatch):
+    """Guard rail: the fail-loud guard must not false-positive on real output."""
+    real_result = _FakeKimiResult(returncode=0, completion_text="a real answer")
+    monkeypatch.setattr(
+        "provider_spawns.kimi_spawn.spawn_kimi", lambda *a, **k: real_result
+    )
+
+    plan = _make_provider_plan(tmp_path, provider=Provider.KIMI, model="default")
+    result = ProviderAdapter().run(plan, "prompt")
+
+    assert result.status == "success"
+    assert result.completion_text == "a real answer"
+    assert result.error is None
+
+
+# ---------------------------------------------------------------------------
+# Test 3: dispatch_cli surfaces the failure to stderr for the provider lane
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_cli_prints_provider_lane_error_on_failure(tmp_path, capsys):
+    """dispatch_cli.run_dispatch must not silently swallow a provider-lane
+    failure into a bare exit code — it must print the raw error to stderr so
+    the failure is visible to whoever ran `bin/vnx dispatch <id>`. Drives the
+    REAL run_dispatch() (only run_envelope_plan + the snapshot are mocked),
+    not a reimplementation of the print logic.
+    """
+    from test_dispatch_cli import _clean_snapshot, _make_spec_file  # noqa: PLC0415
+    from dispatch_cli import run_dispatch
+    from dispatch_envelope import EnvelopeResult
+
+    failing_result = EnvelopeResult(
+        status="failure",
+        returncode=1,
+        report_path=None,
+        receipt_path=None,
+        completion_text="",
+        error="provider=kimi returned an empty completion with returncode=0 — "
+              "refusing to report a silent empty success",
+    )
+
+    spec_file = _make_spec_file(tmp_path, provider="kimi", target_slot="T1")
+
+    with patch("dispatch_cli.build_runtime_snapshot", return_value=_clean_snapshot()), \
+         patch("dispatch_cli.run_envelope_plan", return_value=failing_result):
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "provider lane failure" in captured.err
+    assert "empty completion" in captured.err


### PR DESCRIPTION
## Summary
- Investigated the reported "kimi via the door returns empty completion + silent failure receipt in ~1s" bug.
- The hypothesized root cause (signature mismatch: `adapter.run(enriched_spec)` single positional vs `ProviderAdapter.run(plan, instruction, ...)`) does **not** exist on current `main`. `git blame` shows `run_envelope_plan` has always called `ProviderAdapter().run(plan, enriched_spec.instruction, cwd=wt_path)` correctly (2 positionals + cwd) since PR-3; the single-positional `adapter.run(spec)` call only exists in the unrelated legacy `run_envelope()` function used for the `codex`/`claude-subprocess` lanes (a different `_LANE_REGISTRY`), never for `provider`.
- A live end-to-end reproduction (real kimi CLI 1.46.0 + a real isolated git worktree, through the actual `run_envelope_plan` → `ProviderAdapter` → `_govern` pipeline) propagated a real completion correctly — that specific suspect is disconfirmed.
- What **is** a real, reproducible gap: `kimi_spawn.py` already self-checks for a blank `completion_text` on `returncode=0` and fails loud (`_finalize_kimi_result`'s "empty_extraction" check). `codex_spawn`, `gemini_spawn`, `litellm_spawn`, `deepseek_harness_spawn`, `glm_harness_spawn`, and `local_gemma_spawn` do **not** have an equivalent check — a `returncode=0` with an empty `completion_text` from any of those would have silently reported `status="success"` with a blank report, undetected.
- Also: `dispatch_cli.py`'s provider-lane branch discarded `EnvelopeResult.error`/`completion_text` entirely, returning only an integer exit code — so even a real failure had no visible cause to whoever ran `bin/vnx dispatch <id>`.

## Changes
- `scripts/lib/dispatch_envelope.py`:
  - New `_fail_loud_on_empty_success()` — a single, centralized guard: `status="success"` + blank `completion_text` is downgraded to `status="failure"` with a diagnosable error (`raw spawn result` repr'd), never a silent empty success. Applied at the one place every provider-lane result passes through (`_map_generic_spawn_result`, used by codex/kimi/gemini/litellm) plus the three inline blocks that don't go through it (deepseek-harness, glm-harness, local-gemma) — closing the gap symmetrically across every provider handler.
  - `_govern()` now logs at `ERROR` (with the full raw error + completion length) instead of `INFO` when `adapter_result.status != "success"` — failures are no longer buried at info level.
- `scripts/lib/dispatch_cli.py`: the provider-lane branch of `run_dispatch()` now prints `result.error` to stderr when `result.status != "success"`, instead of silently returning a bare exit code.
- `tests/test_dispatch_envelope_fail_loud.py` (new): 8 tests —
  1. Happy-path regression lock-in: `run_envelope_plan` propagates a real (`"OK"`) completion end-to-end — pins the correct `ProviderAdapter.run(plan, instruction, ...)` call shape.
  2. Parametrized across kimi/codex/gemini/deepseek-harness/glm-harness: `returncode=0` + blank `completion_text` → `status="failure"` with a diagnosable error (fails before the fix, passes after — verified by reverting the fix locally).
  3. Guard-rail: non-empty completion still reports success (no false positives).
  4. `dispatch_cli.run_dispatch` prints the provider-lane error to stderr on failure (drives the real function, not a reimplementation).

## Verification
- `python3 -m pytest tests/test_dispatch_envelope_fail_loud.py -v` → 8 passed.
- Reverted the fix locally (`git stash`) and re-ran the same file → 6 of 8 fail as expected (proves the tests exercise real regressions, not tautologies).
- `python3 -m pytest tests/test_dispatch_envelope_plan.py tests/test_dispatch_cli.py tests/test_dispatch_envelope.py tests/test_dispatch_envelope_fail_loud.py -q` → 133 passed, 6 pre-existing failures (confirmed identical with `git stash`, i.e. present on `main` before this change): 4 are an already-broken legacy claude-alias test group (`TestFlagGateClaude`, unrelated to provider lane), 2 (`test_run_envelope_plan_requires_permit`, `test_instruction_read_from_file`) only fail because this dev sandbox is itself a nested git worktree (`.git` is a file, not a directory), which breaks `create_dispatch_worktree`'s lock-dir path when it's not mocked — reproduces identically on `main`, unrelated to this fix, and won't occur in a normal (non-nested) checkout.
- Live-tested the real kimi CLI (1.46.0) through the unmodified and modified `run_envelope_plan`, with a real isolated `git worktree`, from the plain repo root — completion propagated correctly both times.
- `python3 -m py_compile scripts/lib/dispatch_envelope.py scripts/lib/dispatch_cli.py tests/test_dispatch_envelope_fail_loud.py` → OK.

## Open Items
- The specific *original* root cause behind the observed empty-completion incident (memory `kimi-empty-via-door-envelope-not-adapter`) was not reproduced despite a live end-to-end repro with the real kimi CLI. Recommend closing that memory's specific "signature mismatch" hypothesis as disconfirmed; if the symptom recurs, capture the raw `EnvelopeResult.error` (now surfaced both to stderr and to `logger.error`) from the actual failing run for a concrete repro.
- Found but did not fix (out of the stated scope: `dispatch_envelope.py` + adapter wiring, not `kimi_spawn.py`/`provider_dispatch.py`): `ProviderAdapter.run()`'s kimi branch does not apply `_kimi_resolve_cli_model_arg()` the way `_dispatch_kimi()` (provider_dispatch.py) does — an explicit non-default kimi model in a dispatch spec would reach the CLI unconverted. Low blast radius today (provider-lane specs rarely set an explicit kimi model), but worth a follow-up if operators start pinning kimi models through the door.
- `run_envelope_plan` never materializes `plan.dispatch_paths`/`seed_materialize` into the isolated worktree (only the claude tmux lane does today) — a provider-lane dispatch that names seed files gets an empty worktree. Unrelated to this bug; flagging as a separate gap.