### PR TITLE
fix(horizon): anchor `objective sync` roadmap on --project-dir, not the central template

### DIFF
--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -425,3 +425,68 @@ def test_horizon_reconcile_no_repo_root_crash(project, monkeypatch, capsys):
     assert "cannot resolve repo root" not in err
     # reconcile returns 0 (nothing to close) or 3 (gh absent) — never a crash.
     assert rc in (0, 3)
+
+
+# ---------------------------------------------------------------------------
+# roadmap anchoring on --project-dir (sync must not read the central template)
+# ---------------------------------------------------------------------------
+
+def test_default_roadmap_sets_from_project_dir(tmp_path):
+    args = SimpleNamespace(project_dir=str(tmp_path), roadmap=None)
+    _horizon._default_roadmap(args)
+    assert args.roadmap == str((tmp_path / "ROADMAP.yaml").resolve())
+
+
+def test_default_roadmap_preserves_explicit_flag(tmp_path):
+    args = SimpleNamespace(project_dir=str(tmp_path), roadmap="/explicit/ROADMAP.yaml")
+    _horizon._default_roadmap(args)
+    assert args.roadmap == "/explicit/ROADMAP.yaml"
+
+
+def test_default_roadmap_honors_env_override(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_ROADMAP_PATH", "/env/ROADMAP.yaml")
+    args = SimpleNamespace(project_dir=str(tmp_path), roadmap=None)
+    _horizon._default_roadmap(args)
+    # env override wins; the wrapper leaves roadmap unset so planning_cli's
+    # _resolve_roadmap_path picks up VNX_ROADMAP_PATH itself.
+    assert args.roadmap is None
+
+
+def test_horizon_sync_reads_project_roadmap_not_central_template(project, monkeypatch, capsys):
+    """`vnx objective sync` must project the PROJECT's ROADMAP.yaml, not the
+    central install's illustrative template. The bug: without anchoring on
+    --project-dir, _resolve_roadmap_path fell through to resolve_paths()
+    ["PROJECT_ROOT"], which collapses onto ~/.vnx-system/versions/<v> in a
+    marker-less central install — creating a phantom `example-feature` and
+    orphaning every real track."""
+    project_dir, state_dir = project
+    pid = "horizon-test"
+
+    # Seed one real track into the central store.
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "add", "real-track", "Real Track", "shipped",
+        "--project-id", pid, "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    # Author a project-local ROADMAP.yaml containing exactly that track.
+    (project_dir / "ROADMAP.yaml").write_text(
+        "features:\n"
+        "  - feature_id: real-track\n"
+        "    title: Real Track\n"
+        "    status: shipped\n",
+        encoding="utf-8",
+    )
+
+    rc, out, err = _run(monkeypatch, capsys, [
+        "objective", "sync",
+        "--project-id", pid, "--project-dir", str(project_dir), "--json",
+    ])
+    assert rc == 0, err
+    report = json.loads(out)
+    s = report["summary"]
+    # The real track is recognised (not orphaned) and no phantom example-feature
+    # is created — proof the project roadmap was read, not the central template.
+    assert "example-feature" not in report.get("created", [])
+    assert s["orphan"] == 0, report
+    assert "real-track" not in report.get("orphan", [])

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -27,6 +27,7 @@ command refuses with exit code 2 instead of silently defaulting.
 
 from __future__ import annotations
 
+import os
 import sys
 from pathlib import Path
 from typing import Any, Callable
@@ -92,6 +93,28 @@ def _default_repo_root(args: Any) -> None:
         args.repo_root = str(Path(args.project_dir).resolve())
 
 
+def _default_roadmap(args: Any) -> None:
+    """Default ``--roadmap`` to the project_dir-anchored ROADMAP.yaml when unset.
+
+    The sibling of ``_default_repo_root`` for the one verb that reads the ROADMAP
+    directly (``sync``). Without it, ``planning_cli._resolve_roadmap_path`` falls
+    through to ``resolve_paths()["PROJECT_ROOT"]``, which collapses onto the
+    central install's OWN code tree (``~/.vnx-system/versions/<v>``) when the
+    ``.vnx-install-mode`` marker is absent — so a consumer project's sync reads
+    the shipped illustrative ``ROADMAP.yaml`` template (one ``example-feature``),
+    tries to create it, and flags every real track as an orphan.
+
+    The pip CLI always knows the project via ``--project-dir``; anchor on it, the
+    same way ``resolve_state_dir`` anchors the store. An explicit ``--roadmap`` or
+    a ``VNX_ROADMAP_PATH`` override still wins (precedence: flag > env > project).
+    """
+    if getattr(args, "roadmap", None):
+        return
+    if os.environ.get("VNX_ROADMAP_PATH"):
+        return
+    args.roadmap = str(Path(args.project_dir).resolve() / "ROADMAP.yaml")
+
+
 # ---------------------------------------------------------------------------
 # objective-domain verbs
 # ---------------------------------------------------------------------------
@@ -117,6 +140,7 @@ def _cmd_show(args: Any) -> int:
 def _cmd_sync(args: Any) -> int:
     pc = _require_planning_cli()
     _prep(args)
+    _default_roadmap(args)
     return pc.cmd_objective_sync(args)
 
 


### PR DESCRIPTION
## Problem

MC T0 escalated: `vnx objective/horizon sync` in a consumer project reads the **wrong** ROADMAP.yaml. It was the one objective verb that read the roadmap without anchoring on `--project-dir`, falling through to `planning_cli._resolve_roadmap_path -> resolve_paths()["PROJECT_ROOT"]`. In a central install without the `.vnx-install-mode` marker, that collapses onto the install's own code tree (`~/.vnx-system/versions/<v>`), so the consumer's sync projects the shipped illustrative template (one `example-feature`) and flags every real track as an orphan.

## Reproduction (read-only dry-run, no writes)

| | roadmap | created | orphan |
|---|---|---|---|
| **before** | `.../edge/ROADMAP.yaml` | 1 (example-feature) | **53** (all real tracks) |
| **after** | `.../mission-control/ROADMAP.yaml` | 0 | 8 (real) + 7 phase-drift |

## Fix

Mirrors the existing `_default_repo_root` pattern: a `_default_roadmap(args)` helper defaults `--roadmap` to `<project-dir>/ROADMAP.yaml` when unset, called in `_cmd_sync`. Explicit `--roadmap` and `VNX_ROADMAP_PATH` still win (precedence: flag > env > project). No change to the shared `resolve_paths()` (broader blast radius, other callers).

Concrete instance of the `central-mode-path-correctness` class: that track claimed this "gefixt in track-linkage D0", but the earlier fix covered only `track_reconciler` (reconcile/close), not the objective-sync codepath.

## Tests

- 4 new tests in `test_horizon_cli.py` (unit: sets-from-project-dir / preserves-explicit / honors-env; integration: sync reads project roadmap). `pytest tests/test_horizon_cli.py` → 18 passed.
- The 12 `test_horizon_parity.py` / `test_planning_cli_objective.py` failures are pre-existing (`link-pr` verb drift), unrelated.

## Follow-ups (tracked, not in this PR)

- `central-install-mode-marker-missing` — the deeper root cause (missing `.vnx-install-mode` marker).
- `auto-seed-prelude-roadmap-anchor` — `planning_cli.py:1215` shares the flaw but runs `apply=True`.

Dispatch-ID: 20260710-222217-horizon-sync-roadmap-path-A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7