### PR TITLE
feat(supervisor): auto-close ON by default in the reconcile tick

### DIFF
--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -55,12 +55,15 @@ _maybe_auto_seed_tracks() {
         >> "$log_file" 2>&1 || true
 }
 
-# _maybe_objective_reconcile — throttled advisory-first git-grounded reconcile tick (D4).
+# _maybe_objective_reconcile — throttled git-grounded reconcile tick (D4).
 # Invokes `objective reconcile` at most once per VNX_OBJECTIVE_RECONCILE_INTERVAL seconds
-# when VNX_SUPERVISOR_MODE=unified. Default CHECK mode only; --apply added when
-# VNX_AUTO_CLOSE=1 (operator must set this after `objective reconcile-streak` confirms the
-# flip criterion). Best-effort (|| true); logged to objective_reconcile.log.
-# Default (unset/legacy) = no behaviour change.
+# when VNX_SUPERVISOR_MODE=unified. Auto-close is ON BY DEFAULT (operator directive
+# 2026-07-10, matching the SessionStart hook): --apply is added unless the operator opts
+# out with VNX_AUTO_CLOSE=0 → advisory CHECK (zero writes). reconcile only closes tracks
+# whose linked PRs are verified MERGED and whose blockers are resolved, so applying by
+# default keeps the horizon in sync with git reality; the streak is still computed for
+# observability but no longer gates the flip. Best-effort (|| true); logged to
+# objective_reconcile.log. Default (unset/legacy VNX_SUPERVISOR_MODE) = no behaviour change.
 _maybe_objective_reconcile() {
     [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
     local interval="${VNX_OBJECTIVE_RECONCILE_INTERVAL:-900}"
@@ -83,7 +86,7 @@ _maybe_objective_reconcile() {
         --project-id "$VNX_PROJECT_ID"
         --state-dir "$STATE_DIR"
     )
-    if [[ "${VNX_AUTO_CLOSE:-0}" == "1" ]]; then
+    if [[ "${VNX_AUTO_CLOSE:-1}" != "0" ]]; then
         cmd+=(--apply)
     fi
     "${cmd[@]}" >> "$log_file" 2>&1 || true


### PR DESCRIPTION
## Summary

Aligns the supervisor's `_maybe_objective_reconcile` tick with the SessionStart hook: **auto-close is now ON by default** (`VNX_AUTO_CLOSE` defaults to `1`; opt out with `VNX_AUTO_CLOSE=0`). The supervisor tick still defaulted to `0` while `session_reconcile_autoclose.sh` was flipped to ON on 2026-07-10 (operator directive; streak no longer gates the flip). Two ticks, one policy now.

**Safety unchanged:** reconcile's `--apply` closes ONLY tracks whose linked PRs are verified MERGED *and* whose blockers are resolved. `close_track_if_done` revalidates for unresolved `link_type='blocks'` open-items at close-time and returns `stale_candidate` (zero writes) when any remain — so a plan-first-gate-blocked track is never closed by this default.

## Changes
- `scripts/lib/dispatcher_supervisor_ticks.sh`: `${VNX_AUTO_CLOSE:-0} == 1` → `${VNX_AUTO_CLOSE:-1} != 0`; comment updated to the 2026-07-10 directive.

## Verification
- `bash -n scripts/lib/dispatcher_supervisor_ticks.sh` (syntax).
- Behaviour: unset/`1` → `--apply` appended; `0` → CHECK-only. Matches `session_reconcile_autoclose.sh:57`.

## Open Items
- This makes the flag consistent but does NOT retroactively unstick the 13 currently-confirmed tracks: each has an unresolved `OI-PLAN` plan-first-gate blocker, so reconcile correctly refuses to close them regardless of the flag. That drift is addressed separately (evidence-bound-gate close-wiring).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7