### PR TITLE
feat(gov): enforce plan-first gate at the dispatch door (ADR-030, advisory-first)

### DIFF
--- a/docs/governance/decisions/ADR-030-plan-first-gate-enforcement.md
+++ b/docs/governance/decisions/ADR-030-plan-first-gate-enforcement.md
@@ -1,0 +1,55 @@
+# ADR-030 — Plan-first-gate enforcement: defense-in-depth at the dispatch door and the merge gate
+
+**Status:** Accepted (advisory-first rollout; operator flips each point to `required` once observed clean)
+**Date:** 2026-07-11
+**Decided by:** Operator (Vincent van Deth), in an interactive session. Design grounded in the current `dispatch_cli._check_track_link_verdict` (TL-D1 door validation), `planning_cli._seed_plan_blocker`/`_resolve_plan_blocker`, and `track_reconciler.close_track_if_done` close-time revalidation.
+**Resolves / Cross-refs:** Complements ADR-027 (signed attestation = provenance) and the evidence-bound merge gate (#1080, evidence = completion). Uses the same advisory→required staging as `evidence_bound_gate.py` and the `VNX_REQUIRE_DISPATCH_TRACK` shadow/blocking pattern. Extends the TL-D1 track-linkage layer.
+
+## Context
+
+The plan-first gate seeds a synthetic `OI-PLAN-<track>` blocker on a track at creation (`planning_cli._seed_plan_blocker`) so the track is "born plan-gated". It is meant to force *planning before work*: a plan doc reviewed by the plan-gate panel (`vnx plan-gate run`) or an operator attestation (`vnx plan-gate attest`) resolves the blocker.
+
+The gate was **toothless everywhere it mattered**. The `OI-PLAN` blocker was consulted at exactly one place — `close_track_if_done`'s close-time revalidation, which refuses to move a track to `done` while any `blocks` open-item is unresolved. It was **never** consulted by:
+
+- the **dispatch door** (`dispatch_cli._check_track_link_verdict` validated `track_id` presence/existence/`done` but not the plan gate), nor
+- the **merge gate** (`verify_pr.py` / the CI attestation gate checked provenance + evidence, not the track's plan gate).
+
+The only other "enforcement" was prose in the T0 orchestrator skill instructing the model to run the plan gate first — which interactive and autonomous work skips.
+
+The measured consequence: on 2026-07-11, **13 of 13** reconcile-confirmed tracks (PRs verified MERGED) were stuck `queued`/`blocked`, each with exactly one unresolved blocker — its `OI-PLAN` plan-first gate. Every one had been built and merged **without its plan gate ever passing**. Auto-close (`VNX_AUTO_CLOSE=1`, streak ungated) correctly refused to close them (`close_track_if_done` returns `stale_candidate` on an unresolved blocker), so the drift surfaced as a pile of done-but-unclosable tracks. That backlog is the *symptom*; the missing dispatch-time and merge-time enforcement is the *disease*.
+
+## Decision
+
+Enforce the plan-first gate at **both** chokepoints — defense in depth — sharing one read-only check, and roll it out **advisory-first**.
+
+### 1. Shared check — `scripts/lib/plan_gate_enforcement.py`
+
+A dependency-free (stdlib + sqlite) module both points call:
+
+- `plan_gate_state(db_path, track_id, project_id)` → `passed` | `unresolved` | `unsupported`. Read-only URI connection; a missing DB raises (callers degrade to WARN, never crash). `unsupported` when the schema lacks `track_open_items.resolved_at` — the same predicate `planning_cli._plan_gate_supported` guards SEED with, so a DB that could never *clear* a blocker is never *enforced against*. Only the `OI-PLAN-<track>` blocker counts (other `blocks` open-items are the closure gate's concern).
+- `enforce_mode()` → `off` | `advisory` | `required`, from `VNX_PLAN_GATE_ENFORCE` (default `advisory`; unknown value fails safe to `off`).
+- `override_active()` → `VNX_OVERRIDE_PLAN_GATE` truthy. The caller records `override_applied` so the deviation is audited, never silent (ADR-027 discipline).
+
+### 2. Dispatch door
+
+`_check_track_link_verdict`: a `track_id` that references a **live** track (already handled: nonexistent/`done` → blocking) now also checks the plan gate. `unresolved` →
+
+- `required` without override → **blocking** `ConstraintVerdict(code="plan-gate-unresolved")`; the message names `vnx plan-gate run <track> --doc <plan-doc>`, `vnx plan-gate attest <track>`, and the `VNX_OVERRIDE_PLAN_GATE=1` escape.
+- `advisory`, or `required` + override → **warn** (`override_applied` set when overridden). `passed`/`unsupported`/`off` → clean.
+
+This catches every governed, track-linked dispatch at the single-entry door.
+
+### 3. Merge gate
+
+`verify_pr.py` applies the same check for a PR whose linked track's plan gate is `unresolved`: advisory logs the gap; required blocks. This catches work that reaches a PR without a governed dispatch (the universal chokepoint, since `main` is PR-protected).
+
+## Rollout
+
+`VNX_PLAN_GATE_ENFORCE` defaults to `advisory`: both points surface the violation (WARN / logged gap) without blocking. The operator flips to `required` per point once the advisory signal is observed clean fleet-wide — mirroring the evidence-bound-gate D3 and `VNX_REQUIRE_DISPATCH_TRACK` stagings. `VNX_OVERRIDE_PLAN_GATE=1` is the audited operator escape for a genuinely-planned exception.
+
+The existing backlog of 13 done-but-plan-gateless tracks is **not** retroactively legitimized by this ADR — those still need an operator attest (`vnx plan-gate attest`) or a retroactive panel run to close. Enforcement stops *new* build-before-plan; it does not rewrite history.
+
+## Consequences
+
+- **Positive:** "plan before work" becomes structural, not advisory prose. Build-before-plan is caught at dispatch and at merge. One shared truth, no duplicated SQL. Advisory-first means zero surprise breakage; the operator owns the flip to `required`.
+- **Negative / watch:** advisory-mode adds a read-only query + a WARN per track-linked dispatch/PR whose gate is open — expected noise until the backlog is cleared. `required` mode can block legitimate work when a plan gate genuinely wasn't run; the override + the panel/attest paths are the release valves. Interactive operator work that opens a PR without a track link is not covered by the door (the operator is the human gate there); the merge gate covers it only when the PR declares its track.

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -455,6 +455,45 @@ def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optiona
                 severity="blocking",
                 message=f"track_id={track_id!r} references a track already in phase='done'",
             )
+
+        # Plan-first-gate enforcement (advisory-first). A live track whose OI-PLAN
+        # plan-first gate is unresolved must not be dispatched: building before
+        # planning is exactly what the gate exists to prevent, yet the gate used to
+        # bind only closure bookkeeping. Shared read-only check lives in
+        # plan_gate_enforcement so the merge gate applies the same rule.
+        import plan_gate_enforcement as _pge  # noqa: PLC0415
+        mode = _pge.enforce_mode()
+        if mode != "off":
+            try:
+                pg_state = _pge.plan_gate_state(db_path, track_id, spec.project_id)
+            except Exception:
+                # DB race between the phase read and here; already fail-open above.
+                pg_state = _pge.UNSUPPORTED
+            if pg_state == _pge.UNRESOLVED:
+                run_cmd = f"vnx plan-gate run {track_id} --doc <plan-doc>"
+                if mode == "required" and not _pge.override_active():
+                    return ConstraintVerdict(
+                        code="plan-gate-unresolved",
+                        severity="blocking",
+                        message=(
+                            f"track_id={track_id!r} has not passed its plan-first gate "
+                            f"(OI-PLAN-{track_id} unresolved). Plan before work: run "
+                            f"`{run_cmd}` (or `vnx plan-gate attest {track_id}`), or "
+                            f"operator-override with VNX_OVERRIDE_PLAN_GATE=1."
+                        ),
+                    )
+                overridden = mode == "required" and _pge.override_active()
+                return ConstraintVerdict(
+                    code="plan-gate-unresolved",
+                    severity="warn",
+                    message=(
+                        f"track_id={track_id!r} plan-first gate unresolved "
+                        f"(VNX_PLAN_GATE_ENFORCE={mode}"
+                        + (", operator override applied" if overridden else "")
+                        + f"); advisory. Run `{run_cmd}` before dispatching."
+                    ),
+                    override_applied=overridden,
+                )
         return None
 
     import config_runtime

--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -1,0 +1,108 @@
+"""Plan-first-gate enforcement (defense-in-depth, advisory-first).
+
+The plan-first gate seeds a synthetic ``OI-PLAN-<track>`` blocker on a track so it
+is "born plan-gated" (``planning_cli._seed_plan_blocker``). Until now that blocker
+only gated CLOSURE bookkeeping — ``track_reconciler.close_track_if_done`` revalidates
+it at close-time — but never the WORK: neither the dispatch door nor the merge gate
+consulted it, so a track could be dispatched and its PR merged without the plan gate
+ever passing (build-before-plan). Both enforcement points call the read-only check
+here so the rule lives in exactly one place.
+
+Flag ``VNX_PLAN_GATE_ENFORCE`` (off | advisory | required), default ``advisory``:
+  - ``off``      : no check (an unknown value also fails safe to off).
+  - ``advisory`` : check + surface a WARN, never block (default; mirrors the
+                   evidence-bound-gate D3 rollout in ``evidence_bound_gate.py``).
+  - ``required`` : block when the plan gate is unresolved.
+
+Operator override ``VNX_OVERRIDE_PLAN_GATE=1`` forces a pass in ``required`` mode; the
+caller records ``override_applied`` so the deviation stays in the audit trail (never
+silent) — the same discipline as the ADR-027 signed gate-override.
+
+This module is deliberately dependency-free (stdlib + sqlite only): the door
+constructs a ``ConstraintVerdict`` from the state, the merge gate constructs its own
+gate-shaped result, but both share this one truth.
+"""
+from __future__ import annotations
+
+import os
+import sqlite3
+from pathlib import Path
+
+PLAN_OI_PREFIX = "OI-PLAN-"
+
+# plan-gate state discriminators
+PASSED = "passed"            # no unresolved OI-PLAN blocker (gate passed, or never seeded)
+UNRESOLVED = "unresolved"    # an OI-PLAN-<track> 'blocks' row with resolved_at IS NULL
+UNSUPPORTED = "unsupported"  # schema predates the resolvable-blocker columns; cannot enforce
+
+_ENFORCE_MODES = {"off", "advisory", "required"}
+_TRUTHY = {"1", "true", "yes", "on"}
+
+
+def plan_blocker_oi(track_id: str) -> str:
+    """The synthetic open-item id for a track's plan-first gate."""
+    return f"{PLAN_OI_PREFIX}{track_id}"
+
+
+def enforce_mode() -> str:
+    """Resolve ``VNX_PLAN_GATE_ENFORCE`` to off/advisory/required (default advisory).
+
+    An unknown value fails safe to ``off`` — enforcement never turns on by accident.
+    """
+    raw = (os.environ.get("VNX_PLAN_GATE_ENFORCE") or "advisory").strip().lower()
+    return raw if raw in _ENFORCE_MODES else "off"
+
+
+def override_active() -> bool:
+    """True when the operator set ``VNX_OVERRIDE_PLAN_GATE`` to an affirmative value."""
+    return (os.environ.get("VNX_OVERRIDE_PLAN_GATE") or "").strip().lower() in _TRUTHY
+
+
+def _has_table(conn: sqlite3.Connection, name: str) -> bool:
+    return (
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name=? LIMIT 1",
+            (name,),
+        ).fetchone()
+        is not None
+    )
+
+
+def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})"))
+
+
+def plan_gate_state(db_path: "str | Path", track_id: str, project_id: str) -> str:
+    """Return ``PASSED`` / ``UNRESOLVED`` / ``UNSUPPORTED`` for a track's plan-first gate.
+
+    Read-only URI connection: a missing DB file raises immediately rather than
+    silently creating an empty one (callers degrade any exception to a WARN — never
+    crash the door). ``UNSUPPORTED`` when the schema lacks ``track_open_items`` or its
+    ``resolved_at`` column — the same predicate ``planning_cli._plan_gate_supported``
+    guards SEED with, so a DB that could never CLEAR a blocker is never enforced against.
+
+    Only the ``OI-PLAN-<track>`` blocker counts here; other unresolved ``blocks``
+    open-items are the closure gate's concern, not the plan-first gate's.
+    """
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    try:
+        if not (_has_table(conn, "track_open_items") and _has_col(conn, "track_open_items", "resolved_at")):
+            return UNSUPPORTED
+        oi = plan_blocker_oi(track_id)
+        if _has_col(conn, "track_open_items", "project_id"):
+            row = conn.execute(
+                "SELECT 1 FROM track_open_items "
+                "WHERE track_id=? AND project_id=? AND oi_id=? "
+                "AND link_type='blocks' AND resolved_at IS NULL LIMIT 1",
+                (track_id, project_id, oi),
+            ).fetchone()
+        else:  # pre-0024 DB: no tenant column
+            row = conn.execute(
+                "SELECT 1 FROM track_open_items "
+                "WHERE track_id=? AND oi_id=? AND link_type='blocks' "
+                "AND resolved_at IS NULL LIMIT 1",
+                (track_id, oi),
+            ).fetchone()
+        return UNRESOLVED if row is not None else PASSED
+    finally:
+        conn.close()

--- a/tests/test_plan_gate_enforcement.py
+++ b/tests/test_plan_gate_enforcement.py
@@ -1,0 +1,184 @@
+"""Tests for plan-first-gate enforcement (defense-in-depth, advisory-first).
+
+Covers the shared read-only check (plan_gate_enforcement) and its wiring into the
+dispatch door (_check_track_link_verdict). Merge-gate wiring is tested separately.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import plan_gate_enforcement as pge  # noqa: E402
+from dispatch_cli import _check_track_link_verdict  # noqa: E402
+from dispatch_spec import DispatchSpec  # noqa: E402
+
+
+def _make_db(
+    state_dir: Path,
+    *,
+    tracks: "dict[str, str]",
+    plan_blockers: "dict[str, bool] | None" = None,
+    with_open_items: bool = True,
+) -> Path:
+    """Build a runtime_coordination.db with `tracks` and (optionally) `track_open_items`.
+
+    tracks: {track_id: phase}. plan_blockers: {track_id: resolved?} — seeds an
+    OI-PLAN-<track> 'blocks' row; resolved=True stamps resolved_at, False leaves it NULL.
+    with_open_items=False omits the table entirely (schema-unsupported case).
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE tracks (track_id TEXT PRIMARY KEY, phase TEXT NOT NULL, "
+        "project_id TEXT NOT NULL DEFAULT 'vnx-dev', derived_status TEXT)"
+    )
+    for tid, phase in tracks.items():
+        conn.execute(
+            "INSERT INTO tracks (track_id, phase, project_id) VALUES (?, ?, 'vnx-dev')",
+            (tid, phase),
+        )
+    if with_open_items:
+        conn.execute(
+            "CREATE TABLE track_open_items ("
+            "track_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+            "oi_id TEXT NOT NULL, link_type TEXT NOT NULL, link_source TEXT, "
+            "resolved_at TEXT, PRIMARY KEY (track_id, project_id, oi_id, link_type))"
+        )
+        for tid, resolved in (plan_blockers or {}).items():
+            conn.execute(
+                "INSERT INTO track_open_items "
+                "(track_id, project_id, oi_id, link_type, link_source, resolved_at) "
+                "VALUES (?, 'vnx-dev', ?, 'blocks', 'manual', ?)",
+                (tid, pge.plan_blocker_oi(tid), "2026-07-11T00:00:00Z" if resolved else None),
+            )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _spec(track_id: str) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1, project_id="vnx-dev", dispatch_id="d1", staging_id="s1",
+        instruction_file=Path("/fake"), role="backend-developer", target_slot="T1",
+        gate="human-promoted", dispatch_paths=(), track_id=track_id,
+    )
+
+
+# --------------------------------------------------------------------------- mode
+class TestEnforceMode:
+    def test_default_is_advisory(self, monkeypatch):
+        monkeypatch.delenv("VNX_PLAN_GATE_ENFORCE", raising=False)
+        assert pge.enforce_mode() == "advisory"
+
+    @pytest.mark.parametrize("val,expected", [
+        ("off", "off"), ("advisory", "advisory"), ("required", "required"),
+        ("REQUIRED", "required"), (" advisory ", "advisory"),
+        ("garbage", "off"), ("", "advisory"),
+    ])
+    def test_resolution(self, monkeypatch, val, expected):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", val)
+        assert pge.enforce_mode() == expected
+
+    @pytest.mark.parametrize("val,expected", [
+        ("1", True), ("true", True), ("YES", True), ("on", True),
+        ("0", False), ("", False), ("no", False),
+    ])
+    def test_override_active(self, monkeypatch, val, expected):
+        monkeypatch.setenv("VNX_OVERRIDE_PLAN_GATE", val)
+        assert pge.override_active() is expected
+
+
+# --------------------------------------------------------------------- plan_gate_state
+class TestPlanGateState:
+    def test_passed_when_no_blocker(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={})
+        assert pge.plan_gate_state(db, "t", "vnx-dev") == pge.PASSED
+
+    def test_passed_when_blocker_resolved(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": True})
+        assert pge.plan_gate_state(db, "t", "vnx-dev") == pge.PASSED
+
+    def test_unresolved_when_blocker_open(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": False})
+        assert pge.plan_gate_state(db, "t", "vnx-dev") == pge.UNRESOLVED
+
+    def test_unsupported_when_no_open_items_table(self, tmp_path):
+        db = _make_db(tmp_path, tracks={"t": "active"}, with_open_items=False)
+        assert pge.plan_gate_state(db, "t", "vnx-dev") == pge.UNSUPPORTED
+
+    def test_tenant_isolation(self, tmp_path):
+        """A blocker under a different project_id does not gate this tenant's track."""
+        db = _make_db(tmp_path, tracks={"t": "active"}, plan_blockers={"t": False})
+        assert pge.plan_gate_state(db, "t", "other-project") == pge.PASSED
+
+    def test_missing_db_raises(self, tmp_path):
+        with pytest.raises(sqlite3.OperationalError):
+            pge.plan_gate_state(tmp_path / "nope.db", "t", "vnx-dev")
+
+
+# --------------------------------------------------------------------- door wiring
+class TestDoorEnforcement:
+    def test_advisory_unresolved_warns_not_blocks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "advisory")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, plan_blockers={"t": False})
+        v = _check_track_link_verdict(_spec("t"), state_dir=state)
+        assert v is not None
+        assert v.code == "plan-gate-unresolved"
+        assert v.severity == "warn"
+
+    def test_required_unresolved_blocks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "required")
+        monkeypatch.delenv("VNX_OVERRIDE_PLAN_GATE", raising=False)
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, plan_blockers={"t": False})
+        v = _check_track_link_verdict(_spec("t"), state_dir=state)
+        assert v is not None
+        assert v.code == "plan-gate-unresolved"
+        assert v.severity == "blocking"
+
+    def test_required_override_warns_not_blocks(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "required")
+        monkeypatch.setenv("VNX_OVERRIDE_PLAN_GATE", "1")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, plan_blockers={"t": False})
+        v = _check_track_link_verdict(_spec("t"), state_dir=state)
+        assert v is not None
+        assert v.severity == "warn"
+        assert v.override_applied is True
+
+    def test_required_passed_gate_is_clean(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "required")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, plan_blockers={"t": True})
+        assert _check_track_link_verdict(_spec("t"), state_dir=state) is None
+
+    def test_off_skips_check(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "off")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, plan_blockers={"t": False})
+        assert _check_track_link_verdict(_spec("t"), state_dir=state) is None
+
+    def test_unsupported_schema_is_clean(self, tmp_path, monkeypatch):
+        """A live track in a DB without track_open_items still passes clean (no false block)."""
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "required")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "active"}, with_open_items=False)
+        assert _check_track_link_verdict(_spec("t"), state_dir=state) is None
+
+    def test_done_track_still_rejects_before_plan_check(self, tmp_path, monkeypatch):
+        """A done track is rejected on the pre-existing bad-track-link path, not plan-gate."""
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "required")
+        state = tmp_path / "state"
+        _make_db(state, tracks={"t": "done"}, plan_blockers={"t": False})
+        v = _check_track_link_verdict(_spec("t"), state_dir=state)
+        assert v is not None
+        assert v.code == "bad-track-link"


### PR DESCRIPTION
## Summary

The plan-first gate (`OI-PLAN-<track>` blocker) was **toothless everywhere it mattered**: it was consulted only at close-time (`close_track_if_done` revalidation), never at the dispatch door or the merge gate. So a track could be built and merged with its plan gate never passing — build-before-plan. Measured on 2026-07-11: **13/13** reconcile-confirmed tracks (PRs verified MERGED) stuck with exactly one unresolved blocker — their `OI-PLAN` plan-first gate. That backlog is the symptom; the missing enforcement is the disease.

This is **ADR-030** — enforce at both the dispatch door and the merge gate, advisory-first. This PR does the **shared check + the door**; the merge gate follows in a companion PR.

## Changes
- `scripts/lib/plan_gate_enforcement.py` (new): dependency-free shared check. `plan_gate_state()` → `passed`/`unresolved`/`unsupported` (read-only; `unsupported` when the schema can't clear a blocker, mirroring `_plan_gate_supported`). `enforce_mode()` (`VNX_PLAN_GATE_ENFORCE`, default `advisory`, unknown→`off`). `override_active()` (`VNX_OVERRIDE_PLAN_GATE`).
- `scripts/lib/dispatch_cli.py`: `_check_track_link_verdict` — a live track whose plan gate is `unresolved` yields a **blocking** verdict in `required` (unless override → warn + `override_applied`), a **warn** in `advisory`; `passed`/`unsupported`/`off` stay clean.
- `docs/governance/decisions/ADR-030-plan-first-gate-enforcement.md` (new).
- `tests/test_plan_gate_enforcement.py` (new): 28 tests.

## Verification
- `pytest tests/test_plan_gate_enforcement.py` → **28 passed**.
- `pytest tests/test_dispatch_cli.py` → **94 passed** (no regression; the existing "live track passes clean" tests use a DB without `track_open_items` → `unsupported` → clean).
- `py_compile` on both changed modules → OK.
- Advisory default proven: unresolved gate → warn, never blocks. Required blocks; override downgrades to warn and records `override_applied=True`.

## Open Items
- Merge-gate enforcement (`verify_pr.py`) — companion PR.
- Does NOT retroactively legitimize the 13 stuck tracks: those still need an operator `vnx plan-gate attest` or a retroactive panel run to close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7