### PR TITLE
feat(gov): plan-gate enforce mode honors the config plane (persisted flip)

### DIFF
--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -47,9 +47,21 @@ def plan_blocker_oi(track_id: str) -> str:
 def enforce_mode() -> str:
     """Resolve ``VNX_PLAN_GATE_ENFORCE`` to off/advisory/required (default advisory).
 
-    An unknown value fails safe to ``off`` — enforcement never turns on by accident.
+    Precedence: the process env var (an explicit per-session override) wins; then the
+    persisted config-plane value (``project_config`` via ``config_runtime`` — the same
+    surface ``/operator/config`` flips, audited + revertible); then the ``advisory``
+    default. An unknown value fails safe to ``off`` — enforcement never turns on by
+    accident. The config lookup is best-effort (fail-soft): a missing store leaves the
+    env/default behaviour unchanged.
     """
-    raw = (os.environ.get("VNX_PLAN_GATE_ENFORCE") or "advisory").strip().lower()
+    raw = os.environ.get("VNX_PLAN_GATE_ENFORCE")
+    if not raw:
+        try:
+            import config_runtime  # noqa: PLC0415
+            raw = config_runtime.get("VNX_PLAN_GATE_ENFORCE")
+        except Exception:
+            raw = None
+    raw = (raw or "advisory").strip().lower()
     return raw if raw in _ENFORCE_MODES else "off"
 
 

--- a/tests/test_plan_gate_enforcement.py
+++ b/tests/test_plan_gate_enforcement.py
@@ -95,6 +95,30 @@ class TestEnforceMode:
         monkeypatch.setenv("VNX_OVERRIDE_PLAN_GATE", val)
         assert pge.override_active() is expected
 
+    def test_config_plane_honored_when_env_unset(self, monkeypatch):
+        """A persisted project_config value flips the mode when the env var is unset."""
+        monkeypatch.delenv("VNX_PLAN_GATE_ENFORCE", raising=False)
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get",
+                            lambda k: "required" if k == "VNX_PLAN_GATE_ENFORCE" else None)
+        assert pge.enforce_mode() == "required"
+
+    def test_env_overrides_config_plane(self, monkeypatch):
+        """The process env var wins over the persisted config value."""
+        monkeypatch.setenv("VNX_PLAN_GATE_ENFORCE", "off")
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get", lambda k: "required")
+        assert pge.enforce_mode() == "off"
+
+    def test_config_lookup_failure_falls_back_to_advisory(self, monkeypatch):
+        """A raising config layer must not break enforce_mode (fail-soft → advisory)."""
+        monkeypatch.delenv("VNX_PLAN_GATE_ENFORCE", raising=False)
+        import config_runtime
+        def _boom(k):
+            raise RuntimeError("no store")
+        monkeypatch.setattr(config_runtime, "get", _boom)
+        assert pge.enforce_mode() == "advisory"
+
 
 # --------------------------------------------------------------------- plan_gate_state
 class TestPlanGateState:


### PR DESCRIPTION
## Summary

Makes the advisory→required flip a first-class, persisted operator control. `enforce_mode()` read only the process env var; it now resolves: env var (per-session override) > `project_config` via `config_runtime` (the audited `/operator/config` surface, persisted + revertible) > `advisory` default. Best-effort/fail-soft: a missing store leaves env/default behaviour unchanged. Consistent with the existing config-plane flags.

## Changes
- `scripts/lib/plan_gate_enforcement.py`: `enforce_mode()` consults the config plane when the env var is unset.
- `tests/test_plan_gate_enforcement.py`: +3 tests (config honored when env unset; env overrides config; config failure → advisory fail-soft).

## Verification
- `pytest tests/test_plan_gate_enforcement.py` → 31 passed (28 + 3). `py_compile` OK.

## Open Items
- Enacting `required` fleet-wide is a separate operator action after deploy; instantly revertible to `advisory`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7