### PR TITLE
feat(dispatch): persist final prompt + input=output injection integrity check

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -321,6 +321,50 @@ def _prepare(spec: EnvelopeSpec) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Final-prompt integrity (input-side audit closure)
+# ---------------------------------------------------------------------------
+
+
+def _record_integrity(
+    spec: EnvelopeSpec,
+    enriched_instruction: str,
+    raw_instruction: str,
+    *,
+    bundle_dir: Optional[Path] = None,
+):
+    """Persist the enriched final prompt + verify raw+injections reconstruct it.
+
+    Returns a FinalPromptIntegrity (stamped onto the receipt by _govern) or None
+    when the integrity module is unavailable / persistence failed. The strict
+    (fail-closed) reconstruction raise propagates; every other error is swallowed so
+    the audit-closure step can never itself break a dispatch.
+    """
+    try:
+        from final_prompt_integrity import record_final_prompt_integrity  # noqa: PLC0415
+        from final_prompt_integrity import InjectionReconstructError  # noqa: PLC0415
+    except ImportError:
+        return None
+    try:
+        return record_final_prompt_integrity(
+            dispatch_id=spec.dispatch_id,
+            final_prompt=enriched_instruction,
+            raw_instruction=raw_instruction,
+            data_dir=spec.data_dir,
+            state_dir=spec.state_dir,
+            bundle_dir=bundle_dir,
+        )
+    except InjectionReconstructError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — audit closure must never break a dispatch
+        logger.error(
+            "envelope: final-prompt integrity failed (non-fatal) dispatch=%s: %s",
+            spec.dispatch_id,
+            exc,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
 # GOVERN
 # ---------------------------------------------------------------------------
 
@@ -357,6 +401,7 @@ def _govern(
     start_time: datetime,
     end_time: datetime,
     phantom_diff: Optional[str] = None,
+    integrity: Optional[Any] = None,
 ) -> tuple:
     """Emit unified_report then dispatch receipt. Returns (report_path, receipt_path).
 
@@ -419,6 +464,13 @@ def _govern(
                 cost_usd=None,
                 state_dir=spec.state_dir,
                 report_path=str(report_path) if report_path else None,
+                final_prompt_path=getattr(integrity, "final_prompt_path", None),
+                final_prompt_sha256=getattr(integrity, "final_prompt_sha256", None),
+                injection_reconstructs=(
+                    getattr(integrity, "injection_reconstructs", None)
+                    if integrity is not None
+                    else None
+                ),
             )
         except Exception as exc:
             raise EnvelopeGovernError(
@@ -523,13 +575,18 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         data_dir=spec.data_dir,
     )
 
+    # INTEGRITY — persist the enriched final prompt + verify raw+injections reconstruct it
+    integrity = _record_integrity(enriched_spec, enriched_instruction, spec.instruction)
+
     # EXECUTE
     start_time = datetime.now(timezone.utc)
     adapter_result = adapter.run(enriched_spec)
     end_time = datetime.now(timezone.utc)
 
     # GOVERN (fail-closed on receipt)
-    report_path, receipt_path = _govern(enriched_spec, adapter_result, start_time, end_time)
+    report_path, receipt_path = _govern(
+        enriched_spec, adapter_result, start_time, end_time, integrity=integrity
+    )
 
     returncode = 0 if adapter_result.status == "success" else 1
     return EnvelopeResult(
@@ -1036,6 +1093,14 @@ def run_envelope_plan(
         data_dir=spec.data_dir,
     )
 
+    # INTEGRITY — the bundle dir is the pending/<id>/ that hosts instruction.md.
+    integrity = _record_integrity(
+        enriched_spec,
+        enriched_instruction,
+        instruction,
+        bundle_dir=Path(plan.instruction_file).parent,
+    )
+
     from dispatch_worktree_isolation import (  # noqa: PLC0415
         create_dispatch_worktree,
         remove_dispatch_worktree,
@@ -1057,7 +1122,9 @@ def run_envelope_plan(
             error=_isolation_error,
         )
         _fail_start = _fail_end = datetime.now(timezone.utc)
-        report_path, receipt_path = _govern(enriched_spec, _fail_result, _fail_start, _fail_end)
+        report_path, receipt_path = _govern(
+            enriched_spec, _fail_result, _fail_start, _fail_end, integrity=integrity
+        )
         return EnvelopeResult(
             status="failure",
             returncode=1,
@@ -1086,7 +1153,9 @@ def run_envelope_plan(
     finally:
         remove_dispatch_worktree(plan.dispatch_id)
 
-    report_path, receipt_path = _govern(enriched_spec, result, start, end, phantom_diff=_phantom_diff)
+    report_path, receipt_path = _govern(
+        enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity
+    )
 
     return EnvelopeResult(
         status=result.status,
@@ -1182,11 +1251,19 @@ def run_envelope_headless_plan(
         data_dir=spec.data_dir,
     )
 
+    # INTEGRITY — persist the enriched final prompt + verify reconstruction
+    integrity = _record_integrity(
+        enriched_spec,
+        enriched_instruction,
+        instruction,
+        bundle_dir=Path(plan.instruction_file).parent,
+    )
+
     start = datetime.now(timezone.utc)
     result = ClaudeSubprocessAdapter().run(enriched_spec)
     end = datetime.now(timezone.utc)
 
-    report_path, receipt_path = _govern(enriched_spec, result, start, end)
+    report_path, receipt_path = _govern(enriched_spec, result, start, end, integrity=integrity)
 
     return EnvelopeResult(
         status=result.status,

--- a/scripts/lib/final_prompt_integrity.py
+++ b/scripts/lib/final_prompt_integrity.py
@@ -1,0 +1,354 @@
+"""final_prompt_integrity.py — persist the assembled FINAL dispatch prompt and
+verify that the raw instruction + intelligence injections reconstruct it.
+
+This closes the input-side of the audit chain (authored → injected → delivered →
+response → report → receipt). Before this module, neither dispatch lane persisted
+the exact enriched body the model actually saw:
+
+  * tmux-interactive: ``_assemble_context`` builds the enriched body and pastes it
+    into the pane — nothing persisted.
+  * provider/envelope: ``_prepare`` builds the enriched instruction — the receipt
+    records only the RAW ``instruction``, not the enriched body.
+
+What is written:
+
+  * ``dispatches/pending/<id>/final_prompt.md`` — the assembled enriched body.
+  * ``final_prompt_sha256`` + ``final_prompt_path`` added to ``dispatch-spec.json``
+    (alongside the existing ``instruction_sha256``). ``load_spec`` reads known keys
+    by name, so the extra keys are inert to the door.
+  * ``final_prompt_path`` / ``final_prompt_sha256`` / ``injection_reconstructs`` on
+    the dispatch receipt.
+
+The integrity check is CONTAINMENT and tolerant by construction: the raw instruction
+bytes must appear in the final body, and every item recorded in
+``intelligence_injections.items_json`` must appear in it too (whitespace-normalized
+substring). Deterministic lane wrappers (permission preamble, report-contract
+directive, completion protocol, scope guard, trailer sentinel) are ADDITIONS layered
+on top of the enriched body — they never remove information, so containment is
+insensitive to them. They are enumerated in ``DEFAULT_WRAPPER_MARKERS`` so a future
+exact-reconstruction mode can account for them.
+
+Fail-loud contract: when containment fails, ``injection_reconstructs`` lands False on
+the receipt AND an ERROR is logged (never silent). ``VNX_INJECTION_RECONSTRUCT_STRICT=1``
+escalates to a raised ``InjectionReconstructError`` (fail-closed), per the track's
+advisory-first-then-fail-closed rollout.
+
+No Anthropic SDK. Pure stdlib + the coordination-DB reader.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import re
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import List, Optional
+
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from atomic_io import atomic_write_json, atomic_write_text  # noqa: E402
+
+logger = logging.getLogger(__name__)
+
+# Deterministic lane wrappers layered ON TOP of the enriched body. Registered (not
+# gating) so a future exact-reconstruction mode can subtract them before diffing.
+DEFAULT_WRAPPER_MARKERS: tuple[str, ...] = (
+    "## Completion Protocol",            # tmux completion-protocol footer
+    "## Scope Guard",                    # tmux scope-note
+    "## Role",                           # legacy role header (fallback path)
+    "## Worker Preamble",                # legacy no-role preamble
+    "## Report Contract",                # report-body-contract directive heading
+    "<!-- VNX-END-OF-INSTRUCTION -->",   # trailer sentinel
+)
+
+_ENV_STRICT = "VNX_INJECTION_RECONSTRUCT_STRICT"
+
+_WS_RE = re.compile(r"\s+")
+
+
+class InjectionReconstructError(RuntimeError):
+    """Raised when reconstruction fails AND strict/fail-closed mode is enabled."""
+
+
+@dataclass(frozen=True)
+class ReconstructResult:
+    """Outcome of the containment check."""
+
+    reconstructs: bool
+    items_checked: int
+    missing: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class FinalPromptIntegrity:
+    """Everything a lane needs to stamp the spec + receipt after assembly."""
+
+    final_prompt_path: Optional[str]
+    final_prompt_sha256: str
+    injection_reconstructs: bool
+    items_checked: int
+    missing: tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Primitives
+# ---------------------------------------------------------------------------
+
+def compute_sha256(text: str) -> str:
+    """sha256 hexdigest of *text* encoded as UTF-8."""
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _normalize_ws(text: str) -> str:
+    """Collapse every whitespace run to a single space and strip the ends.
+
+    Injection rendering interleaves newlines/indentation that the raw item content
+    does not carry (and vice versa); normalizing both sides makes the substring
+    containment check robust to that formatting without loosening what it proves.
+    """
+    return _WS_RE.sub(" ", text).strip()
+
+
+def strip_known_wrappers(text: str, markers: "tuple[str, ...]" = DEFAULT_WRAPPER_MARKERS) -> str:
+    """Return *text* with the deterministic wrapper sections elided.
+
+    Best-effort helper for callers that want the enriched-body-only view (the
+    containment check itself does not need it — it tolerates the wrappers). Only the
+    trailer sentinel and everything after the FIRST wrapper heading are removed, in
+    marker order of appearance, so the enriched prefix is preserved.
+    """
+    cut = len(text)
+    for marker in markers:
+        idx = text.find(marker)
+        if idx != -1:
+            cut = min(cut, idx)
+    return text[:cut].rstrip()
+
+
+# ---------------------------------------------------------------------------
+# Injection items
+# ---------------------------------------------------------------------------
+
+def load_injection_items(state_dir: "str | Path", dispatch_id: str) -> List[dict]:
+    """Load the ``items_json`` recorded for *dispatch_id* at ``dispatch_create``.
+
+    Reads the coordination DB (``runtime_coordination.db``). Returns the parsed list
+    of item dicts, or ``[]`` when the DB/table/row is absent or unparseable (the
+    check then trivially holds with ``items_checked=0`` — an honest "nothing to
+    verify", never a false failure). Best-effort: never raises.
+    """
+    try:
+        from coordination_db import db_path_from_state_dir  # noqa: PLC0415
+    except ImportError:
+        return []
+    db_path = db_path_from_state_dir(state_dir)
+    if not Path(db_path).exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(db_path), timeout=10.0)
+        conn.row_factory = sqlite3.Row
+        try:
+            rows = conn.execute(
+                "SELECT items_json, injection_point FROM intelligence_injections "
+                "WHERE dispatch_id = ? ORDER BY injected_at DESC",
+                (dispatch_id,),
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        logger.debug("final_prompt_integrity: injection read failed dispatch=%s: %s", dispatch_id, exc)
+        return []
+
+    if not rows:
+        return []
+    # Prefer the dispatch_create injection (the one that enriched the prompt);
+    # fall back to the most-recent row of any point.
+    chosen = None
+    for row in rows:
+        if (row["injection_point"] or "") == "dispatch_create":
+            chosen = row
+            break
+    if chosen is None:
+        chosen = rows[0]
+    try:
+        items = json.loads(chosen["items_json"] or "[]")
+    except (json.JSONDecodeError, TypeError):
+        return []
+    return [it for it in items if isinstance(it, dict)]
+
+
+# ---------------------------------------------------------------------------
+# Reconstruction check
+# ---------------------------------------------------------------------------
+
+def _item_label(item: dict) -> str:
+    return str(item.get("item_id") or item.get("item_class") or "item")
+
+
+def verify_injection_reconstructs(
+    final_prompt: str,
+    raw_instruction: str,
+    injection_items: List[dict],
+    *,
+    dispatch_id: str = "",
+    strict: Optional[bool] = None,
+) -> ReconstructResult:
+    """Assert raw instruction + each injection item survive into *final_prompt*.
+
+    Containment (tolerant): the whitespace-normalized raw instruction, and the
+    whitespace-normalized ``content`` of every injection item, must each be a
+    substring of the normalized final body. ``items_json`` stores a PREFIX of the
+    item content (``to_dict`` caps it), and a prefix of verbatim-rendered content is
+    always a substring — so a passing item genuinely reached the model, and a
+    corrupted/dropped item genuinely fails.
+
+    On failure: logs an ERROR with the missing pieces (fail-loud) and returns
+    ``reconstructs=False``. When *strict* (or ``VNX_INJECTION_RECONSTRUCT_STRICT=1``)
+    is set, raises ``InjectionReconstructError`` (fail-closed).
+    """
+    norm_final = _normalize_ws(final_prompt)
+    missing: List[str] = []
+
+    raw_norm = _normalize_ws(raw_instruction)
+    if raw_norm and raw_norm not in norm_final:
+        missing.append("raw-instruction")
+
+    checked = 0
+    for item in injection_items:
+        content = (item.get("content") or "").strip()
+        if not content:
+            continue
+        checked += 1
+        if _normalize_ws(content) not in norm_final:
+            missing.append(_item_label(item))
+
+    reconstructs = not missing
+    if not reconstructs:
+        logger.error(
+            "final_prompt_integrity: injection reconstruction FAILED dispatch=%s "
+            "missing=%s (raw+%d items checked against %d-char final body) — the "
+            "delivered prompt does not contain the governed raw instruction and/or "
+            "recorded injection items; audit chain broken at the input side",
+            dispatch_id or "(unknown)",
+            missing,
+            checked,
+            len(final_prompt),
+        )
+
+    _strict = strict
+    if _strict is None:
+        _strict = os.environ.get(_ENV_STRICT, "0").strip().lower() in ("1", "true", "yes", "on")
+    if not reconstructs and _strict:
+        raise InjectionReconstructError(
+            f"final_prompt_integrity: reconstruction failed dispatch={dispatch_id or '(unknown)'} "
+            f"missing={missing} (fail-closed via {_ENV_STRICT})"
+        )
+    return ReconstructResult(reconstructs=reconstructs, items_checked=checked, missing=tuple(missing))
+
+
+# ---------------------------------------------------------------------------
+# Persistence
+# ---------------------------------------------------------------------------
+
+def persist_final_prompt(
+    bundle_dir: "str | Path",
+    final_prompt: str,
+    *,
+    update_spec: bool = True,
+) -> "tuple[Optional[Path], str]":
+    """Write ``final_prompt.md`` into *bundle_dir* and pin its sha in the spec.
+
+    Returns ``(final_prompt_path, final_prompt_sha256)``. The sha is ALWAYS computed
+    and returned (it is the receipt-carried fact); ``final_prompt_path`` is None only
+    when the file could not be written (logged, non-fatal). When *update_spec* and a
+    sibling ``dispatch-spec.json`` exists, ``final_prompt_sha256`` +
+    ``final_prompt_path`` are merged into it atomically.
+    """
+    sha = compute_sha256(final_prompt)
+    bundle = Path(bundle_dir)
+    final_path: Optional[Path] = None
+    try:
+        bundle.mkdir(parents=True, exist_ok=True)
+        final_path = bundle / "final_prompt.md"
+        atomic_write_text(final_path, final_prompt)
+    except OSError as exc:
+        logger.error(
+            "final_prompt_integrity: could not persist final_prompt.md in %s: %s "
+            "(sha still recorded on the receipt)",
+            bundle,
+            exc,
+        )
+        return None, sha
+
+    if update_spec:
+        spec_file = bundle / "dispatch-spec.json"
+        if spec_file.exists():
+            try:
+                data = json.loads(spec_file.read_text(encoding="utf-8"))
+                data["final_prompt_sha256"] = sha
+                data["final_prompt_path"] = str(final_path.resolve())
+                atomic_write_json(spec_file, data)
+            except (OSError, json.JSONDecodeError) as exc:
+                logger.warning(
+                    "final_prompt_integrity: could not stamp final_prompt_sha256 into %s: %s",
+                    spec_file,
+                    exc,
+                )
+    return final_path, sha
+
+
+# ---------------------------------------------------------------------------
+# Lane entry point
+# ---------------------------------------------------------------------------
+
+def _default_bundle_dir(data_dir: "str | Path", dispatch_id: str) -> Path:
+    return Path(data_dir) / "dispatches" / "pending" / dispatch_id
+
+
+def record_final_prompt_integrity(
+    *,
+    dispatch_id: str,
+    final_prompt: str,
+    raw_instruction: str,
+    data_dir: "str | Path",
+    state_dir: "str | Path",
+    bundle_dir: "Optional[str | Path]" = None,
+    strict: Optional[bool] = None,
+) -> FinalPromptIntegrity:
+    """Persist the final prompt, then verify raw + injections reconstruct it.
+
+    One call for both lanes:
+      1. write ``final_prompt.md`` + stamp ``final_prompt_sha256`` in the spec,
+      2. load the recorded injection items,
+      3. run the containment check (fail-loud; fail-closed under strict).
+
+    Returns a ``FinalPromptIntegrity`` the lane stamps onto its receipt. Persistence
+    is best-effort (a missing bundle never blocks a dispatch); the reconstruction
+    check's strict-mode raise propagates so an opted-in operator gets fail-closed.
+    """
+    if bundle_dir is None:
+        bundle_dir = _default_bundle_dir(data_dir, dispatch_id)
+
+    final_path, sha = persist_final_prompt(bundle_dir, final_prompt)
+    items = load_injection_items(state_dir, dispatch_id)
+    recon = verify_injection_reconstructs(
+        final_prompt,
+        raw_instruction,
+        items,
+        dispatch_id=dispatch_id,
+        strict=strict,
+    )
+    return FinalPromptIntegrity(
+        final_prompt_path=str(final_path) if final_path else None,
+        final_prompt_sha256=sha,
+        injection_reconstructs=recon.reconstructs,
+        items_checked=recon.items_checked,
+        missing=recon.missing,
+    )

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -66,6 +66,9 @@ def emit_dispatch_receipt(
     events_path: Optional[str] = None,
     permission_enforcement: Optional[str] = None,
     mandate_id: Optional[str] = None,
+    final_prompt_path: Optional[str] = None,
+    final_prompt_sha256: Optional[str] = None,
+    injection_reconstructs: Optional[bool] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson. fcntl.flock for concurrent safety.
 
@@ -85,6 +88,14 @@ def emit_dispatch_receipt(
     receipt with the ADR-012 worker-permission enforcement mode. Only set when
     ``VNX_ENFORCE_WORKER_PERMISSIONS`` is active so flag-off receipts remain
     byte-identical to the pre-feature shape.
+
+    ``final_prompt_path`` / ``final_prompt_sha256`` / ``injection_reconstructs``:
+    the input-side audit pointer (final_prompt_integrity). ``final_prompt_path``
+    points at the persisted assembled prompt, ``final_prompt_sha256`` pins its
+    bytes, and ``injection_reconstructs`` records whether the raw instruction +
+    recorded intelligence injections literally reconstruct that body. Each is only
+    stamped when provided so lanes that do not yet compute integrity keep a
+    byte-identical receipt shape.
 
     Raises:
         ValueError: provider field doesn't match required pattern
@@ -117,6 +128,12 @@ def emit_dispatch_receipt(
         receipt["permission_enforcement"] = permission_enforcement
     if mandate_id:
         receipt["mandate_id"] = mandate_id
+    if final_prompt_path is not None:
+        receipt["final_prompt_path"] = final_prompt_path
+    if final_prompt_sha256 is not None:
+        receipt["final_prompt_sha256"] = final_prompt_sha256
+    if injection_reconstructs is not None:
+        receipt["injection_reconstructs"] = injection_reconstructs
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -497,6 +497,51 @@ class TmuxInteractiveDispatch:
         import report_body_contract as _rbc  # noqa: PLC0415
         return body + "\n\n" + _rbc.build_directive(dispatch_id or "", pr_id=pr_id)
 
+    def _record_final_prompt_integrity(
+        self,
+        *,
+        dispatch_id: str,
+        final_prompt: str,
+        raw_instruction: str,
+    ):
+        """Persist the assembled final prompt + verify raw+injections reconstruct it.
+
+        ``final_prompt`` is the enriched body (skill + intelligence + instruction +
+        report-contract directive) BEFORE this lane's deterministic delivery wrappers
+        (completion protocol, scope guard, trailer). The integrity fields are baked
+        into the worker's completion-protocol receipt so the audit chain closes at the
+        input side.
+
+        Best-effort: the strict (fail-closed) reconstruction raise propagates so an
+        opted-in operator gets fail-closed delivery; every other error is swallowed so
+        the audit-closure step can never itself break a dispatch. Returns the
+        FinalPromptIntegrity or None.
+        """
+        try:
+            from final_prompt_integrity import (  # noqa: PLC0415
+                InjectionReconstructError,
+                record_final_prompt_integrity,
+            )
+        except ImportError:
+            return None
+        try:
+            return record_final_prompt_integrity(
+                dispatch_id=dispatch_id,
+                final_prompt=final_prompt,
+                raw_instruction=raw_instruction,
+                data_dir=self._state_dir.parent,
+                state_dir=self._state_dir,
+            )
+        except InjectionReconstructError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — audit closure must never break a dispatch
+            logger.error(
+                "interactive: final-prompt integrity failed (non-fatal) dispatch=%s: %s",
+                dispatch_id,
+                exc,
+            )
+            return None
+
     def _stamp_dispatch_metadata(
         self,
         dispatch_id: str,
@@ -676,7 +721,7 @@ class TmuxInteractiveDispatch:
         return {"input": inp, "output": out, "cache_read": 0}
 
     def _build_completion_protocol(
-        self, dispatch_id: str, label: str, model: str = "unknown"
+        self, dispatch_id: str, label: str, model: str = "unknown", *, integrity=None
     ) -> str:
         """Footer instructing the worker to emit a clean receipt directly.
 
@@ -732,6 +777,16 @@ class TmuxInteractiveDispatch:
             # Only emitted when the flag is ON so flag-off receipts are byte-identical.
             if worker_permission_enforcement_enabled():
                 receipt_dict["permission_enforcement"] = "enforced"
+            # Input-side audit closure (final_prompt_integrity). Only baked in when
+            # integrity was computed so the receipt shape stays byte-identical
+            # otherwise. The worker echoes these back verbatim in its receipt.
+            if integrity is not None:
+                if getattr(integrity, "final_prompt_path", None) is not None:
+                    receipt_dict["final_prompt_path"] = integrity.final_prompt_path
+                receipt_dict["final_prompt_sha256"] = integrity.final_prompt_sha256
+                receipt_dict["injection_reconstructs"] = bool(
+                    integrity.injection_reconstructs
+                )
             json_str = json.dumps(receipt_dict)
             # Escape inner double-quotes for the shell double-quoted argument.
             escaped = json_str.replace('"', '\\"')
@@ -2011,6 +2066,16 @@ class TmuxInteractiveDispatch:
                 instruction=instruction,
                 dispatch_paths=dispatch_paths,
             )
+            # 6b. Input-side audit closure: persist the enriched final prompt (the
+            # body BEFORE the lane's deterministic delivery wrappers) + verify the
+            # raw instruction and recorded intelligence injections reconstruct it.
+            # The result is baked into the worker's completion-protocol receipt.
+            _integrity = self._record_final_prompt_integrity(
+                dispatch_id=dispatch_id,
+                final_prompt=_context_body,
+                raw_instruction=instruction,
+            )
+
             if os.environ.get("VNX_BENCH_EQUAL_CONTEXT") == "1":
                 body = _context_body
             elif os.environ.get("VNX_SHARED_PREPARE", "0").strip().lower() in (
@@ -2024,7 +2089,9 @@ class TmuxInteractiveDispatch:
                     _TRAILER = "<!-- VNX-END-OF-INSTRUCTION -->"
                 body = (
                     _context_body
-                    + self._build_completion_protocol(dispatch_id, label, model=model)
+                    + self._build_completion_protocol(
+                        dispatch_id, label, model=model, integrity=_integrity
+                    )
                     + f"\n\n{_TRAILER}\n"
                 )
             else:
@@ -2032,7 +2099,9 @@ class TmuxInteractiveDispatch:
                 body = (
                     _context_body
                     + self._scope_note(dispatch_paths)
-                    + self._build_completion_protocol(dispatch_id, label, model=model)
+                    + self._build_completion_protocol(
+                        dispatch_id, label, model=model, integrity=_integrity
+                    )
                 )
 
             # 7. Deliver instruction

--- a/tests/test_final_prompt_integrity.py
+++ b/tests/test_final_prompt_integrity.py
@@ -1,0 +1,401 @@
+"""test_final_prompt_integrity.py — the input-side audit-closure regression suite.
+
+Track: final-dispatch-persist-integrity (P1). Proves:
+
+  1. The enriched final prompt is persisted (``final_prompt.md``) and its sha is
+     pinned into ``dispatch-spec.json`` + matches the bytes on disk.
+  2. Reconstruction SUCCEEDS for a real case: the raw instruction bytes and every
+     recorded intelligence-injection item literally survive into the final body.
+  3. A deliberately CORRUPTED / dropped injection makes ``injection_reconstructs``
+     False and fails LOUD (ERROR log; strict mode raises).
+  4. ``emit_dispatch_receipt`` carries the three integrity fields, and the envelope
+     provider lane stamps ``injection_reconstructs`` onto its receipt end-to-end.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import sqlite3
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Optional
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import final_prompt_integrity as fpi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _item(content: str, *, item_class: str = "proven_pattern", title: str = "T", item_id: str = "i1") -> dict:
+    return {"item_id": item_id, "item_class": item_class, "title": title, "content": content}
+
+
+def _render_final(raw: str, items: list) -> str:
+    """A stand-in for the enriched body: intelligence section (rendered) + raw."""
+    parts = ["## Relevant Intelligence (from past dispatches)", ""]
+    for it in items:
+        parts.append(f"- **{it['title']}**: {it['content']}")
+    parts.append("\n---\n")
+    parts.append(raw)
+    return "\n".join(parts)
+
+
+def _write_injection_row(state_dir: Path, dispatch_id: str, items: list, *, injection_point: str = "dispatch_create") -> None:
+    """Insert one intelligence_injections row (minimal table) the loader can read."""
+    db = state_dir / "runtime_coordination.db"
+    db.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db))
+    try:
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS intelligence_injections ("
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT, "
+            "injection_point TEXT, items_json TEXT, injected_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO intelligence_injections (dispatch_id, injection_point, items_json, injected_at) "
+            "VALUES (?, ?, ?, ?)",
+            (dispatch_id, injection_point, json.dumps(items), "2026-07-11T00:00:00Z"),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 1. Pure reconstruction check
+# ---------------------------------------------------------------------------
+
+def test_verify_reconstructs_true_for_raw_and_items():
+    raw = "Implement the widget loader and return exactly OK."
+    items = [_item("Always guard against a null store handle", item_id="ap1", item_class="failure_prevention")]
+    final = _render_final(raw, items)
+
+    res = fpi.verify_injection_reconstructs(final, raw, items, dispatch_id="d-ok")
+
+    assert res.reconstructs is True
+    assert res.items_checked == 1
+    assert res.missing == ()
+
+
+def test_verify_true_is_whitespace_tolerant():
+    raw = "line one\n  line two\tline three"
+    items = [_item("multi\nline\ncontent here")]
+    # final collapses/reflows whitespace differently — containment must still hold.
+    final = "PREAMBLE  multi line content here MIDDLE line one line two   line three END"
+
+    res = fpi.verify_injection_reconstructs(final, raw, items)
+    assert res.reconstructs is True
+
+
+def test_verify_true_when_item_content_is_a_prefix():
+    # items_json stores content[:cap] (a prefix). A prefix of verbatim-rendered
+    # content is still a substring, so it must reconstruct.
+    raw = "do the thing"
+    full = "the quick brown fox jumps over the lazy dog"
+    stored_prefix = full[:20]  # "the quick brown fox "
+    final = _render_final(raw, [_item(full)])
+    res = fpi.verify_injection_reconstructs(final, raw, [_item(stored_prefix)])
+    assert res.reconstructs is True
+
+
+def test_verify_false_when_item_dropped_fails_loud(caplog):
+    raw = "raw instruction body"
+    good = _item("this proven pattern actually reached the model", item_id="sp-good")
+    dropped = _item("THIS INJECTION NEVER MADE IT INTO THE PROMPT", item_id="sp-dropped")
+    # final contains raw + the good item, but NOT the dropped item's content.
+    final = _render_final(raw, [good])
+
+    with caplog.at_level(logging.ERROR, logger="final_prompt_integrity"):
+        res = fpi.verify_injection_reconstructs(final, raw, [good, dropped], dispatch_id="d-drop")
+
+    assert res.reconstructs is False
+    assert "sp-dropped" in res.missing
+    assert "sp-good" not in res.missing
+    # fail-loud: an ERROR was logged naming the dispatch.
+    assert any("reconstruction FAILED" in r.message and "d-drop" in r.getMessage() for r in caplog.records)
+
+
+def test_verify_false_when_raw_missing():
+    raw = "the raw instruction that was silently swapped out"
+    final = "## Intelligence\n\n- something else entirely\n"
+    res = fpi.verify_injection_reconstructs(final, raw, [])
+    assert res.reconstructs is False
+    assert "raw-instruction" in res.missing
+
+
+def test_verify_strict_raises_fail_closed():
+    raw = "raw body"
+    final = "nothing matching here"
+    with pytest.raises(fpi.InjectionReconstructError):
+        fpi.verify_injection_reconstructs(final, raw, [], strict=True)
+
+
+def test_verify_strict_env_toggle(monkeypatch):
+    monkeypatch.setenv("VNX_INJECTION_RECONSTRUCT_STRICT", "1")
+    with pytest.raises(fpi.InjectionReconstructError):
+        fpi.verify_injection_reconstructs("no match", "raw", [])
+
+
+# ---------------------------------------------------------------------------
+# 2. Persistence
+# ---------------------------------------------------------------------------
+
+def test_persist_writes_final_prompt_and_stamps_spec(tmp_path):
+    bundle = tmp_path / "dispatches" / "pending" / "d-1"
+    bundle.mkdir(parents=True)
+    (bundle / "dispatch-spec.json").write_text(
+        json.dumps({"schema_version": 1, "dispatch_id": "d-1", "instruction_sha256": "abc"}),
+        encoding="utf-8",
+    )
+    final_prompt = "## enriched body\n\nthe full assembled prompt"
+
+    path, sha = fpi.persist_final_prompt(bundle, final_prompt)
+
+    assert path is not None and path.name == "final_prompt.md"
+    assert path.read_text(encoding="utf-8") == final_prompt
+    # sha matches the persisted bytes.
+    assert sha == hashlib.sha256(final_prompt.encode("utf-8")).hexdigest()
+    # spec now carries the pointer + hash, keeping instruction_sha256 intact.
+    spec = json.loads((bundle / "dispatch-spec.json").read_text(encoding="utf-8"))
+    assert spec["final_prompt_sha256"] == sha
+    assert spec["final_prompt_path"].endswith("final_prompt.md")
+    assert spec["instruction_sha256"] == "abc"
+
+
+def test_persist_returns_sha_even_without_spec(tmp_path):
+    bundle = tmp_path / "bundle"
+    path, sha = fpi.persist_final_prompt(bundle, "body only")
+    assert path is not None
+    assert sha == hashlib.sha256(b"body only").hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# 3. Injection loader
+# ---------------------------------------------------------------------------
+
+def test_load_injection_items_reads_coord_db(tmp_path):
+    items = [_item("recorded content A"), _item("recorded content B", item_id="i2")]
+    _write_injection_row(tmp_path, "d-load", items)
+    loaded = fpi.load_injection_items(tmp_path, "d-load")
+    assert [it["content"] for it in loaded] == ["recorded content A", "recorded content B"]
+
+
+def test_load_injection_items_absent_db_is_empty(tmp_path):
+    assert fpi.load_injection_items(tmp_path, "nope") == []
+
+
+def test_load_injection_items_prefers_dispatch_create(tmp_path):
+    _write_injection_row(tmp_path, "d-p", [_item("other point", item_id="x")], injection_point="closeout")
+    _write_injection_row(tmp_path, "d-p", [_item("create point", item_id="y")], injection_point="dispatch_create")
+    loaded = fpi.load_injection_items(tmp_path, "d-p")
+    assert [it["item_id"] for it in loaded] == ["y"]
+
+
+# ---------------------------------------------------------------------------
+# 4. End-to-end record_final_prompt_integrity
+# ---------------------------------------------------------------------------
+
+def test_record_integrity_end_to_end_pass(tmp_path):
+    dispatch_id = "d-e2e-ok"
+    raw = "Build the loader. Return OK."
+    items = [_item("proven: reuse the existing store handle", item_id="sp1")]
+    _write_injection_row(tmp_path, dispatch_id, items)
+    final_prompt = _render_final(raw, items)
+
+    result = fpi.record_final_prompt_integrity(
+        dispatch_id=dispatch_id,
+        final_prompt=final_prompt,
+        raw_instruction=raw,
+        data_dir=tmp_path,
+        state_dir=tmp_path,
+    )
+
+    assert result.injection_reconstructs is True
+    assert result.items_checked == 1
+    # final_prompt.md was written into the derived pending bundle, sha matches.
+    persisted = Path(result.final_prompt_path)
+    assert persisted.read_text(encoding="utf-8") == final_prompt
+    assert result.final_prompt_sha256 == hashlib.sha256(final_prompt.encode("utf-8")).hexdigest()
+
+
+def test_record_integrity_end_to_end_corrupted_fails_loud(tmp_path, caplog):
+    """The regression this track exists to catch: a recorded injection that does
+    NOT survive into the delivered prompt must flip injection_reconstructs False."""
+    dispatch_id = "d-e2e-bad"
+    raw = "Build the loader. Return OK."
+    recorded = [_item("this recorded pattern was DROPPED from the prompt", item_id="sp-x")]
+    _write_injection_row(tmp_path, dispatch_id, recorded)
+    # The delivered final prompt omits the recorded item entirely.
+    final_prompt = _render_final(raw, [])
+
+    with caplog.at_level(logging.ERROR, logger="final_prompt_integrity"):
+        result = fpi.record_final_prompt_integrity(
+            dispatch_id=dispatch_id,
+            final_prompt=final_prompt,
+            raw_instruction=raw,
+            data_dir=tmp_path,
+            state_dir=tmp_path,
+        )
+
+    assert result.injection_reconstructs is False
+    assert "sp-x" in result.missing
+    assert any("reconstruction FAILED" in r.message for r in caplog.records)
+    # Even on failure the prompt is still persisted + hashed (audit evidence).
+    assert Path(result.final_prompt_path).exists()
+    assert result.final_prompt_sha256
+
+
+# ---------------------------------------------------------------------------
+# 5. Receipt carriage
+# ---------------------------------------------------------------------------
+
+def test_emit_dispatch_receipt_carries_integrity_fields(tmp_path):
+    from governance_emit import emit_dispatch_receipt  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="d-receipt",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=1.0,
+        token_usage={"input": 1, "output": 1},
+        cost_usd=None,
+        state_dir=state_dir,
+        final_prompt_path="/x/final_prompt.md",
+        final_prompt_sha256="deadbeef",
+        injection_reconstructs=False,
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text(encoding="utf-8").strip().splitlines()[-1]
+    receipt = json.loads(line)
+    assert receipt["final_prompt_path"] == "/x/final_prompt.md"
+    assert receipt["final_prompt_sha256"] == "deadbeef"
+    assert receipt["injection_reconstructs"] is False
+
+
+def test_emit_dispatch_receipt_omits_integrity_when_unset(tmp_path):
+    from governance_emit import emit_dispatch_receipt  # noqa: PLC0415
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="d-plain",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=1.0,
+        token_usage={},
+        cost_usd=None,
+        state_dir=state_dir,
+    )
+    receipt = json.loads((state_dir / "t0_receipts.ndjson").read_text(encoding="utf-8").strip())
+    assert "injection_reconstructs" not in receipt
+    assert "final_prompt_sha256" not in receipt
+
+
+# ---------------------------------------------------------------------------
+# 6. Envelope provider-lane integration (end-to-end receipt stamping)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeSpawnResult:
+    returncode: int = 0
+    completion_text: str = "OK"
+    events_written: int = 1
+    session_id: Optional[str] = None
+    timed_out: bool = False
+    stopped_early: bool = False
+    token_usage: Optional[Dict[str, Any]] = None
+    error: Optional[str] = None
+    event_writer_failures: int = 0
+
+
+def _make_provider_plan(tmp_path: Path, dispatch_id: str):
+    from dispatch_plan import ExecutionPlan
+    from dispatch_spec import Isolation, Provider
+
+    bundle = tmp_path / "dispatches" / "pending" / dispatch_id
+    bundle.mkdir(parents=True)
+    instruction_file = bundle / "instruction.md"
+    instruction_file.write_text("Reply with exactly the word OK.", encoding="utf-8")
+    sha = hashlib.sha256(instruction_file.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    return ExecutionPlan(
+        dispatch_id=dispatch_id,
+        project_id="vnx-dev",
+        provider=Provider.KIMI,
+        model="default",
+        lane="provider",
+        adapter="provider",
+        target_id="T1",
+        billing="provider_metered",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="integrity-integration",
+        instruction_sha256=sha,
+    )
+
+
+def test_run_envelope_plan_stamps_injection_reconstructs(tmp_path):
+    """The real-case integration: run_envelope_plan persists final_prompt.md and
+    stamps injection_reconstructs onto the receipt (regression guard for the wiring)."""
+    from dispatch_envelope import run_envelope_plan
+    from dispatch_internal import issue_permit
+
+    dispatch_id = "d-env-integ"
+    plan = _make_provider_plan(tmp_path, dispatch_id)
+    permit = issue_permit(plan)
+
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path
+    state_dir.mkdir()
+
+    fake_wt = tmp_path / "wt"
+    fake_wt.mkdir()
+
+    with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=_FakeSpawnResult()), \
+         patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=fake_wt), \
+         patch("dispatch_worktree_isolation.remove_dispatch_worktree"):
+        result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+    assert result.status == "success", f"error={result.error}"
+
+    # final_prompt.md persisted into the bundle, spec stamped with the sha.
+    bundle = tmp_path / "dispatches" / "pending" / dispatch_id
+    assert (bundle / "final_prompt.md").exists()
+
+    # the receipt carries the integrity fields (raw ⊆ enriched, 0 items → True).
+    receipt = json.loads((state_dir / "t0_receipts.ndjson").read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert "injection_reconstructs" in receipt, (
+        "regression: run_envelope_plan did not stamp injection_reconstructs onto the receipt"
+    )
+    assert receipt["injection_reconstructs"] is True
+    assert receipt["final_prompt_sha256"]


### PR DESCRIPTION
## Summary

Closes the input-side of the audit chain (authored → injected → delivered → response → report → receipt) for track `final-dispatch-persist-integrity` (P1). Before this PR, neither dispatch lane persisted the exact enriched body the model actually saw: the tmux lane assembled the body and pasted it to the pane; the provider/envelope lane recorded only the RAW instruction on the receipt, not the enriched body. The delivered prompt was therefore not reconstructable from the governed store, and the learning/skill-refinement loop was blind to the orchestration signal.

Both governed door lanes now persist the assembled FINAL prompt as `final_prompt.md` plus `final_prompt_sha256` in `dispatch-spec.json`, carry a receipt pointer, and — at delivery — assert that the raw instruction bytes plus every `intelligence_injections.items_json` item literally reconstruct the final body. An `injection_reconstructs` boolean lands in the receipt and fails LOUD on mismatch.

## Changes

- **`scripts/lib/final_prompt_integrity.py`** (new): the shared core.
  - `persist_final_prompt` — writes `dispatches/pending/<id>/final_prompt.md` and pins `final_prompt_sha256` + `final_prompt_path` into `dispatch-spec.json` (`load_spec` reads known keys by name, so the extra keys are inert to the door).
  - `verify_injection_reconstructs` — containment check: the whitespace-normalized raw instruction and each recorded injection item's `content` must be a substring of the final body. `items_json` stores a prefix of content (`to_dict` caps it), and a prefix of verbatim-rendered content is always a substring — so a passing item genuinely reached the model, and a corrupted/dropped one genuinely fails.
  - Fail-loud: `injection_reconstructs=False` + an ERROR log; `VNX_INJECTION_RECONSTRUCT_STRICT=1` escalates to a raised `InjectionReconstructError` (fail-closed), per the track's advisory-first-then-fail-closed rollout.
  - Deterministic lane wrappers (permission preamble, report-contract directive, completion protocol, scope guard, trailer sentinel) are additions layered on top of the enriched body — containment tolerates them by construction; they are enumerated in `DEFAULT_WRAPPER_MARKERS` for a future exact-reconstruction mode.
- **`scripts/lib/tmux_interactive_dispatch.py`**: persist `_context_body` (the enriched body before delivery wrappers) via `_record_final_prompt_integrity`, and bake `final_prompt_path`/`final_prompt_sha256`/`injection_reconstructs` into the worker's completion-protocol receipt.
- **`scripts/lib/dispatch_envelope.py`**: persist the enriched instruction in `run_envelope_plan`, `run_envelope_headless_plan`, and `run_envelope`; `_govern` stamps the fields onto the receipt.
- **`scripts/lib/governance_emit.py`**: `emit_dispatch_receipt` gains optional `final_prompt_path` / `final_prompt_sha256` / `injection_reconstructs` (only set when provided → byte-identical receipt otherwise, mirroring the `permission_enforcement` pattern).

**ADR-007:** no new central table (persist-to-file + existing receipt/spec fields), so the composite-UNIQUE/PK-over-`project_id` requirement is not triggered.

## Verification

- `tests/test_final_prompt_integrity.py` (17 tests, all pass): persist + sha match; reconstruction succeeds for a real case (raw + items); whitespace tolerance; content-prefix tolerance; a dropped/corrupted injection flips `injection_reconstructs` False + fails loud (ERROR log); `strict` raises; env-toggle strict; injection loader reads the coord DB (prefers `dispatch_create`); end-to-end pass + corrupted; `emit_dispatch_receipt` carries the fields and omits them when unset; `run_envelope_plan` stamps `injection_reconstructs` end-to-end.
- **Revert experiment (proves the tests catch the real regression):**
  - Disabling the item-containment check (`if False and …`) fails exactly `test_verify_false_when_item_dropped_fails_loud` and `test_record_integrity_end_to_end_corrupted_fails_loud` (2 failed, 15 passed); restored → 17 passed.
  - Removing `integrity=integrity` from the envelope `_govern` call fails `test_run_envelope_plan_stamps_injection_reconstructs` with the exact regression message ("did not stamp injection_reconstructs onto the receipt"); restored → passes.
- Regression sweep (modules I edited): `test_tmux_interactive_dispatch.py`, `test_tmux_interactive_dispatch_metadata.py`, `test_governance_emit.py`, `test_governance_emit_schema.py`, `test_final_prompt_integrity.py` → 246 passed. `test_dispatch_cli.py`, `test_dispatch_door_authority.py`, `test_dispatch_bridge_staging.py` → 122 passed.
- Pre-existing failures confirmed NOT introduced by this PR (identical failure set with my lib edits stashed): `test_dispatch_envelope*.py` 6 failures (nested-worktree sandbox `.git/worktrees` not-a-directory + mock-based flag-gate tests); `test_tmux_adapter*.py` 4 failures (unrelated `tmux_adapter.py`: missing `tmux_adapter_cli`, `shutdown(graceful=)` signature).
- `py_compile` clean on all changed modules; no-anthropic-sdk (ADR-003) gate clean — no SDK import anywhere.

## Open Items

- **Terminal-pinned `subprocess_dispatch.py` lane (deferred):** the opt-in Wave-5 `VNX_ADAPTER_T{n}=subprocess` path has its own `deliver_with_recovery` + `emit_dispatch_receipt`/`emit_unified_report` and does not route through the envelope, so it is not yet integrity-wired. All three default governed door lanes (claude_tmux_subscription, provider envelope, claude_headless) ARE wired. Wiring the pinned lane is a follow-up (the shared module makes it a one-call addition).
- **Advisory-first by default (per plan open-question 2):** on mismatch the fabric flags + loud-logs but does not block; `VNX_INJECTION_RECONSTRUCT_STRICT=1` opts into fail-closed. Flip the default to fail-closed once the wrapper allowlist is observed stable in the field.
- **Retention (per plan open-question 1):** `final_prompt.md` is kept alongside the bundle; a rotation/archival policy matching the events-ring archive is not implemented (the permanent hash lives in the receipt regardless).
- **Tier-1/Tier-2 review (deliverable 7):** the governance review gates run in the dispatch/merge flow, out of scope for the code PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7