### PR TITLE
fix(plan-gate): restore 5/5 panel seats — opus data_dir + robust verdict parse

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -163,25 +163,133 @@ def build_plan_review_instruction_fileref(
     )
 
 
-def parse_verdict(report_text: str) -> Dict[str, Any]:
-    """Extract the LAST ``vnx-plan-verdict`` block from a panelist report.
+_CONTRACT_FENCE_RE = re.compile(r"```" + re.escape(VERDICT_FENCE) + r"\s*\n(.*?)```", re.DOTALL)
+# Any code fence (```json ...```, ``` ...```, ```JSON5 ...```) — the degraded-recovery channel
+# for a panelist that wrapped its verdict in the wrong fence (the codex/glm verdict-JSON flake).
+_CODE_FENCE_RE = re.compile(r"```[A-Za-z0-9_.+-]*[ \t]*\r?\n(.*?)```", re.DOTALL)
 
-    Fail-safe by design: anything unparseable becomes ``revise`` with
-    ``parse_error=True`` so a missing/garbled verdict can never silently PASS.
-    """
-    empty = {"verdict": "revise", "blocking_findings": [], "rationale": "", "parse_error": True}
-    if not report_text:
-        return {**empty, "rationale": "empty report"}
-    pattern = re.compile(r"```" + re.escape(VERDICT_FENCE) + r"\s*\n(.*?)```", re.DOTALL)
-    matches = pattern.findall(report_text)
-    if not matches:
-        return {**empty, "rationale": "no verdict block found"}
+
+def _loads_json(candidate: str) -> Any:
+    """``json.loads`` with ONE conservative repair pass (strip trailing commas before a
+    closing brace/bracket — the single most common LLM JSON tic). Returns the parsed value
+    or ``None`` when it still will not parse. The repair only removes a dangling comma; it can
+    never quote an unquoted key or invent a value, so genuine garbage (``{verdict: pass,,,}``)
+    stays garbage and still abstains."""
     try:
-        data = json.loads(matches[-1].strip())
+        return json.loads(candidate)
     except (json.JSONDecodeError, ValueError):
-        return {**empty, "rationale": "verdict block is not valid JSON"}
-    if not isinstance(data, dict):
-        return {**empty, "rationale": "verdict block is not a JSON object"}
+        pass
+    repaired = re.sub(r",\s*([}\]])", r"\1", candidate)
+    if repaired != candidate:
+        try:
+            return json.loads(repaired)
+        except (json.JSONDecodeError, ValueError):
+            return None
+    return None
+
+
+def _find_balanced_objects(text: str) -> List[str]:
+    """Every balanced ``{...}`` substring in ``text``, in order of appearance.
+
+    String- and escape-aware, so braces inside JSON string values do not skew the depth
+    count. Used to recover a verdict object embedded in prose or wrapped in a non-contract
+    code fence — the ``glm``/``codex`` case where the model emits the right JSON but not the
+    exact ``vnx-plan-verdict`` fence."""
+    out: List[str] = []
+    i, n = 0, len(text)
+    while i < n:
+        if text[i] != "{":
+            i += 1
+            continue
+        depth, in_str, esc, j = 0, False, False, i
+        while j < n:
+            c = text[j]
+            if in_str:
+                if esc:
+                    esc = False
+                elif c == "\\":
+                    esc = True
+                elif c == '"':
+                    in_str = False
+            elif c == '"':
+                in_str = True
+            elif c == "{":
+                depth += 1
+            elif c == "}":
+                depth -= 1
+                if depth == 0:
+                    out.append(text[i:j + 1])
+                    break
+            j += 1
+        i = j + 1 if j < n else n
+    return out
+
+
+def _verdict_obj_in(chunk: str) -> Optional[Dict[str, Any]]:
+    """The verdict OBJECT (a dict carrying a ``verdict`` key) inside ``chunk``, whether the
+    chunk is clean JSON, JSON wrapped in prose, or JSON in a nested code fence. ``None`` if
+    the chunk carries no such object. Validity of the verdict VALUE is checked by the caller."""
+    chunk = chunk.strip()
+    if not chunk:
+        return None
+    data = _loads_json(chunk)
+    if isinstance(data, dict) and "verdict" in data:
+        return data
+    for block in reversed(_CODE_FENCE_RE.findall(chunk)):
+        data = _loads_json(block.strip())
+        if isinstance(data, dict) and "verdict" in data:
+            return data
+    for cand in reversed(_find_balanced_objects(chunk)):
+        data = _loads_json(cand)
+        if isinstance(data, dict) and "verdict" in data:
+            return data
+    return None
+
+
+def _locate_verdict_object(report_text: str) -> Optional[Dict[str, Any]]:
+    """Locate the panelist's verdict object across three channels, most-trusted first.
+
+    1. CONTRACT — the ``vnx-plan-verdict`` fence. When present it is AUTHORITATIVE and its
+       LAST occurrence is the only one consulted (a doc's own fence is neutralized upstream by
+       ``_sanitize_doc``, so this channel cannot be spoofed). If that fence carries no JSON
+       object at all we abstain rather than fall through — the same fail-safe as before.
+    2. CODE-FENCE — only when NO contract fence exists: a verdict wrapped in a ```json
+       block (the codex/glm flake). Last valid object wins.
+    3. PROSE — last resort: a balanced JSON object with a ``verdict`` key sitting in prose.
+
+    Returns a dict that has a ``verdict`` key (its VALUE may still be invalid — the caller
+    validates), or ``None`` when no verdict object can be recovered anywhere."""
+    contract = _CONTRACT_FENCE_RE.findall(report_text)
+    if contract:
+        return _verdict_obj_in(contract[-1])
+    for block in reversed(_CODE_FENCE_RE.findall(report_text)):
+        obj = _verdict_obj_in(block)
+        if obj is not None:
+            return obj
+    for cand in reversed(_find_balanced_objects(report_text)):
+        data = _loads_json(cand)
+        if isinstance(data, dict) and "verdict" in data:
+            return data
+    return None
+
+
+def parse_verdict(report_text: str) -> Dict[str, Any]:
+    """Extract the panelist's ``vnx-plan-verdict`` from a report.
+
+    Robust by design (2026-07-11): the contract fence is honoured first, but a verdict wrapped
+    in a ```json fence or embedded in prose is still recovered instead of abstaining — the
+    codex/glm verdict-JSON flake that dropped those seats to non-scoring. See
+    ``_locate_verdict_object`` for the channel precedence.
+
+    Fail-safe is preserved: a genuinely empty or garbage output (no recoverable verdict object,
+    or an object whose ``verdict`` value is not pass/revise/block) becomes ``revise`` with
+    ``parse_error=True`` so a missing/garbled verdict can never silently PASS."""
+    empty = {"verdict": "revise", "blocking_findings": [], "rationale": "", "parse_error": True}
+    if not report_text or not report_text.strip():
+        return {**empty, "rationale": "empty report"}
+    data = _locate_verdict_object(report_text)
+    if data is None:
+        return {**empty, "rationale": "no verdict block found"}
     verdict = str(data.get("verdict", "")).strip().lower()
     if verdict not in _VALID_VERDICTS:
         return {**empty, "rationale": f"unknown verdict {verdict!r}"}
@@ -300,6 +408,22 @@ def _read_report(base: Optional[Path], dispatch_id: str, stderr: str) -> Optiona
     return None
 
 
+def _resolve_data_dir() -> str:
+    """Resolve a real VNX data_dir for the claude/tmux lane's report round-trip.
+
+    The claude lane writes its verdict report to ``<data_dir>/unified_reports/<id>.md`` but,
+    unlike ``provider_dispatch``, prints NO ``Report:`` stderr line, so ``_read_report`` can
+    only find it through the ``base`` fallback. When ``base`` is None the opus seat's report is
+    written but never read back -> NO-VERDICT (rc1) — the #1102-class failure that drops opus
+    from the panel. Resolving a real data_dir here keeps the write-path and read-path in
+    agreement for EVERY caller (mirrors panel.py's ``_resolve_reports_dir().parent``, #1102)."""
+    try:
+        from vnx_paths import resolve_state_dir  # noqa: PLC0415
+        return str(resolve_state_dir().parent)
+    except Exception:
+        return str(Path(os.environ.get("VNX_DATA_DIR") or (HERE.parent.parent / ".vnx-data")))
+
+
 def _make_default_dispatcher(
     data_dir: Optional[str], timeout_seconds: int,
 ) -> DispatcherFn:
@@ -315,7 +439,12 @@ def _make_default_dispatcher(
                            (bills API credits post-cutover).
       kimi/glm/deepseek -> provider_dispatch (constraint-safe per provider).
     """
-    base = Path(data_dir) if data_dir else None
+    # A REAL base is required for the claude/tmux lane: it writes its report to
+    # <base>/unified_reports/<id>.md and _read_report reads it back from exactly there (the tmux
+    # lane prints no `Report:` line to key off). With base=None the opus seat's report is written
+    # but never found -> NO-VERDICT (rc1). Resolve a real data_dir so no caller can pass None and
+    # silently drop the claude seat — the #1102-class fix, now guaranteed at the module level.
+    base = Path(data_dir) if data_dir else Path(_resolve_data_dir())
 
     def _dispatch(provider: str, model_arg: str, instruction: str, dispatch_id: str) -> str:
         env = dict(os.environ)
@@ -329,17 +458,9 @@ def _make_default_dispatcher(
                 #
                 # We write the original inline instruction to a temp file so the worker can
                 # read the plan + rubric + verdict contract from a stable on-disk path.
-                # The expected report path is derived from data_dir so the file-ref instruction
-                # can tell the worker exactly where to write its verdict report.
-                report_path_str: str
-                if base is not None:
-                    report_path_str = str(base / "unified_reports" / f"{dispatch_id}.md")
-                else:
-                    # Fallback: derive from VNX_DATA_DIR or a tmp path
-                    report_path_str = str(
-                        Path(os.environ.get("VNX_DATA_DIR", tempfile.gettempdir()))
-                        / "unified_reports" / f"{dispatch_id}.md"
-                    )
+                # The expected report path is derived from `base` (a real data_dir, resolved
+                # above) so the write-path here and _read_report's read-path always agree.
+                report_path_str = str(base / "unified_reports" / f"{dispatch_id}.md")
 
                 # Write the full inline instruction (plan + rubric + contract) to a temp file.
                 # The worker reads this file; the short file-ref instruction points to it.

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -912,3 +912,150 @@ def test_govern_spec_role_plan_reviewer_fenceless_report_becomes_synthesized(tmp
     assert pgp.parse_verdict(result_body)["parse_error"] is True, (
         "synthesized body unexpectedly contains a parseable verdict fence"
     )
+
+
+# --------------------------------------------------------------------------
+# seat-robustness (2026-07-11): parse_verdict recovers a verdict wrapped in a
+# ```json fence or embedded in prose (the codex/glm verdict-JSON flake that made
+# those seats abstain), while genuine garbage still abstains.
+# --------------------------------------------------------------------------
+
+def test_parse_verdict_json_code_fence_scores():
+    # codex/glm flake: the verdict lands in a ```json fence, NOT the vnx-plan-verdict fence.
+    text = (
+        "# Plan Review\n\nLooks mostly sound.\n\n"
+        '```json\n{"verdict": "pass", "blocking_findings": [], "rationale": "ok"}\n```\n'
+    )
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+
+
+def test_parse_verdict_bare_json_in_prose_scores():
+    # No fence at all — the verdict object sits inline in prose.
+    text = 'My verdict is {"verdict": "revise", "blocking_findings": ["thin risks"]} — fix that.\n'
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "revise"
+    assert out["parse_error"] is False
+    assert out["blocking_findings"] == ["thin risks"]
+
+
+def test_parse_verdict_contract_fence_with_prose_wrapper_scores():
+    # The contract fence exists but the model wrapped the JSON in prose inside it.
+    text = (
+        f"```{pgp.VERDICT_FENCE}\n"
+        'Here is my verdict:\n{"verdict": "block", "rationale": "unsafe"}\nthanks\n'
+        "```\n"
+    )
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "block"
+    assert out["parse_error"] is False
+
+
+def test_parse_verdict_trailing_comma_is_repaired():
+    # A single dangling comma (the most common LLM JSON tic) is repaired, not abstained.
+    text = _report('{"verdict": "pass", "blocking_findings": [],}')
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+
+
+def test_parse_verdict_braces_in_string_do_not_break_extraction():
+    # Braces inside a JSON string value must not skew the balanced-object scan.
+    text = 'note {"rationale": "use {placeholder} here", "verdict": "pass"} done\n'
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+
+
+def test_parse_verdict_true_garbage_still_abstains():
+    # Prose with no JSON object at all -> abstain (fail-safe preserved).
+    out = pgp.parse_verdict("# review\n\nThe plan is fine, ship it. No structured verdict.\n")
+    assert out["verdict"] == "revise"
+    assert out["parse_error"] is True
+
+
+def test_parse_verdict_unquoted_key_garbage_still_abstains():
+    # Unquoted keys/values are NOT recoverable by the conservative repair -> abstain.
+    # This guard keeps the robustness from becoming a phantom-pass hole.
+    for blob in ("{verdict: pass,,,}", "{'verdict': 'pass'}", "{verdict pass}"):
+        out = pgp.parse_verdict(f"```json\n{blob}\n```\n")
+        assert out["parse_error"] is True, f"garbage recovered as a verdict: {blob!r}"
+
+
+def test_parse_verdict_prose_object_without_verdict_key_abstains():
+    # A balanced JSON object with NO verdict key must not be mistaken for a verdict.
+    out = pgp.parse_verdict('some notes {"note": "looks ok", "score": 5} end\n')
+    assert out["parse_error"] is True
+
+
+def test_parse_verdict_contract_fence_wins_over_stray_json_fence():
+    # Anti-spoof: when the authoritative contract fence is present, a stray ```json block
+    # (e.g. echoed from the plan doc) does NOT override it.
+    text = (
+        '```json\n{"verdict": "pass"}\n```\n\n'
+        f"```{pgp.VERDICT_FENCE}\n" + '{"verdict": "block", "rationale": "real"}\n```\n'
+    )
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "block", "stray ```json overrode the contract fence"
+    assert out["parse_error"] is False
+
+
+# --------------------------------------------------------------------------
+# seat-robustness (2026-07-11): the opus/claude seat must SCORE even when
+# run_panel is called with data_dir=None (the #1102-class NO-VERDICT root cause).
+# --------------------------------------------------------------------------
+
+def test_resolve_data_dir_falls_back_to_env(monkeypatch):
+    # When vnx_paths is unavailable, _resolve_data_dir honours VNX_DATA_DIR — never returns
+    # an empty/None value the claude lane could not write to.
+    monkeypatch.setenv("VNX_DATA_DIR", "/tmp/vnx-data-test-xyz")
+    monkeypatch.setitem(sys.modules, "vnx_paths", None)  # force the ImportError fallback
+    assert pgp._resolve_data_dir() == "/tmp/vnx-data-test-xyz"
+
+
+def test_opus_seat_scores_when_data_dir_none(tmp_path, monkeypatch):
+    """The opus/claude seat must SCORE when run_panel is called with data_dir=None.
+
+    The claude/tmux lane prints no `Report:` stderr line, so _read_report can only find the
+    worker's report through the resolved data_dir base. Pre-fix, data_dir=None left base=None
+    and the opus report was written but never read -> NO-VERDICT (rc1), dropping opus from the
+    panel. This proves _make_default_dispatcher now resolves a real data_dir so the seat scores.
+    """
+    import subprocess as _sp
+    import unittest.mock as mock
+
+    # Resolve to a controlled tmp data_dir (mirrors what vnx_paths gives in production).
+    monkeypatch.setattr(pgp, "_resolve_data_dir", lambda: str(tmp_path))
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        # Simulate the claude/tmux worker: write the verdict report to
+        # <data_dir>/unified_reports/<dispatch_id>.md and print NOTHING to stderr — the tmux
+        # lane, unlike provider_dispatch, emits no `Report:` line for _read_report to key off.
+        did = cmd[cmd.index("--dispatch-id") + 1]
+        rp = tmp_path / "unified_reports" / f"{did}.md"
+        rp.parent.mkdir(parents=True, exist_ok=True)
+        rp.write_text(
+            f"# Plan Review\n\n```{pgp.VERDICT_FENCE}\n"
+            '{"verdict": "pass", "blocking_findings": [], "rationale": "ok"}\n```\n',
+            encoding="utf-8",
+        )
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        out = pgp.run_panel(
+            doc,
+            track_id="feat-opus-null-dd",
+            project_id="p1",
+            panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+            data_dir=None,  # <-- the bug trigger
+        )
+
+    opus = next(p for p in out["panelists"] if p["label"] == "opus")
+    assert opus["dispatched"] is True, "opus seat did not score with data_dir=None (NO-VERDICT)"
+    assert opus["parse_error"] is False
+    assert opus["verdict"] == "pass"
+    assert out["decision"] == "PASS"


### PR DESCRIPTION
## Summary

The 5-family plan-gate panel (`scripts/lib/plan_gate_panel.py`, NOT the `/panel` skill) had degraded to ~2/5 scoring seats: only kimi + deepseek scored, while opus dropped to NO-VERDICT and codex/glm abstained on non-clean JSON. This restores all five seats by fixing the two independent root causes.

## Changes

**(a) Opus seat data_dir resolution (#1102-class).** The claude/tmux lane writes its verdict report to `<data_dir>/unified_reports/<id>.md` but — unlike `provider_dispatch` — prints no `Report:` stderr line, so `_read_report` can only find it via the `base` fallback. With `data_dir=None`, `base` was None and the opus report was written but never read back → NO-VERDICT (rc1). New `_resolve_data_dir()` helper resolves a real data_dir (mirroring `panel.py`'s `_resolve_reports_dir().parent` from #1102); `_make_default_dispatcher` uses it so no caller can pass None and silently drop the claude seat. The now-redundant `report_path_str` fallback branch is removed since `base` is always a real path.

**(b) Robust verdict-JSON parse.** `parse_verdict` (was `plan_gate_panel.py:166`) now recovers a verdict wrapped in a ` ```json ` fence or embedded in prose — the codex/glm verdict-JSON flake that made those seats abstain — via three channels, most-trusted first:
1. CONTRACT — the `vnx-plan-verdict` fence; authoritative, last occurrence, precedence unchanged so the anti-spoof property (`_sanitize_doc`) holds.
2. CODE-FENCE — only when no contract fence exists: a verdict in a generic ` ```json ` block.
3. PROSE — last resort: a balanced JSON object (string/escape-aware scan) carrying a `verdict` key.

Plus one conservative repair pass (strip a single trailing comma). Verdict semantics are NOT weakened: unquoted-key/garbage output, objects without a `verdict` key, and objects whose `verdict` value isn't pass/revise/block all still abstain (`parse_error=True`) — robustness never becomes a phantom-pass hole.

Files:
- `scripts/lib/plan_gate_panel.py` — new `_loads_json`, `_find_balanced_objects`, `_verdict_obj_in`, `_locate_verdict_object`, `_resolve_data_dir`; rewritten `parse_verdict`; `_make_default_dispatcher` base resolution.
- `tests/test_plan_gate_panel.py` — +11 tests.

## Verification

- `python3 -m pytest tests/test_plan_gate_panel*.py -q` → **61 passed** (50 existing + 11 new).
- `python3 -m pytest tests/test_plan_gate_enforcement.py -q` → 28 passed (adjacent, no regression).
- `python3 -m py_compile scripts/lib/plan_gate_panel.py scripts/panel.py scripts/kimi_gate.py` → clean.
- **Revert experiment:** `git stash push scripts/lib/plan_gate_panel.py` (keep the new tests), re-run → **7 of the new tests FAIL** against the pre-fix source (opus-seat-with-None-data_dir, fenced-json, json-in-prose, prose-wrapper-in-contract-fence, trailing-comma, braces-in-string, env-fallback); `git stash pop` → all 61 pass again. The 4 "still-abstains" guard tests pass both before and after (they assert preserved fail-safe behavior), as designed.

New tests cover: opus seat scores with `data_dir=None`; `_resolve_data_dir` env fallback; `parse_verdict` recovers fenced-json / json-in-prose / prose-wrapped-contract-fence / trailing-comma / braces-in-string; and still abstains on unquoted-key garbage / no-verdict-key object / true prose garbage; contract-fence-wins anti-spoof guard.

## Open Items

None. This is a self-contained fix to `plan_gate_panel.py`; the broader PR-12 single-entry-door consolidation of the lane scripts is unchanged and out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7