### PR TITLE
feat(gov): register VNX_PLAN_GATE_ENFORCE in the config registry (enables audited flip)

### DIFF
--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -83,6 +83,12 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "Evidence-bound merge gate mode: off | advisory | required. "
         "Advisory logs missing/invalid evidence but never blocks; required enforces evidence before merge. "
         "Default is advisory for D3 bootstrap.", approval=True),
+    "VNX_PLAN_GATE_ENFORCE": _e(
+        "VNX_PLAN_GATE_ENFORCE", "enum", "advisory", "gate",
+        "Plan-first-gate enforcement mode: off | advisory | required (ADR-030). "
+        "Advisory warns when a track-linked dispatch has an unresolved plan gate; required blocks it. "
+        "The process env var overrides this; operator override VNX_OVERRIDE_PLAN_GATE=1. Default advisory.",
+        approval=True),
     "VNX_USE_CENTRAL_DB": _e(
         "VNX_USE_CENTRAL_DB", "enum", "", "dispatch",
         "Central-DB read mode (''=per-project | '1'=central | 'shadow'). Process-start routing — "

--- a/tests/test_plan_gate_enforcement.py
+++ b/tests/test_plan_gate_enforcement.py
@@ -119,6 +119,19 @@ class TestEnforceMode:
         monkeypatch.setattr(config_runtime, "get", _boom)
         assert pge.enforce_mode() == "advisory"
 
+    def test_flag_registered_in_config_registry(self):
+        """The flag must be a registered, writable, approval-gated enum so the audited
+        set_config path (project_config) can flip it — otherwise config_runtime.get can
+        never see an operator flip."""
+        import config_registry
+        entry = config_registry.CONFIG_REGISTRY.get("VNX_PLAN_GATE_ENFORCE")
+        assert entry is not None, "VNX_PLAN_GATE_ENFORCE not registered"
+        assert entry.type == "enum"
+        assert entry.default == "advisory"
+        assert entry.category == "gate"
+        assert entry.writable_from_ui is True
+        assert entry.requires_approval is True
+
 
 # --------------------------------------------------------------------- plan_gate_state
 class TestPlanGateState:


### PR DESCRIPTION
## Summary
Closes the gap in #1115: `enforce_mode()` reads the config plane, but `VNX_PLAN_GATE_ENFORCE` was never registered, so the audited `set_config` path rejected it ("unknown config key"). Registers it as an approval-gated `enum` (off|advisory|required, default advisory, category `gate`), mirroring `VNX_EVIDENCE_BOUND_GATE`. The advisory→required flip is now a first-class, audited, revertible operator control.

## Changes
- `scripts/lib/config_registry.py`: register `VNX_PLAN_GATE_ENFORCE`.
- `tests/test_plan_gate_enforcement.py`: +1 test (registered, enum, gate, writable, approval-gated).

## Verification
- `pytest tests/test_plan_gate_enforcement.py` → 32 passed. `py_compile` OK.

## Open Items
None. (Flipping vnx-dev to `required` is a follow-up operator action via `set_config` with an approval-id.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7