### PR TITLE
fix(plan-gate): hints emit `vnx horizon plan-gate`, not the non-existent `vnx plan-gate`

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -470,7 +470,7 @@ def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optiona
                 # DB race between the phase read and here; already fail-open above.
                 pg_state = _pge.UNSUPPORTED
             if pg_state == _pge.UNRESOLVED:
-                run_cmd = f"vnx plan-gate run {track_id} --doc <plan-doc>"
+                run_cmd = f"vnx horizon plan-gate run {track_id} --doc <plan-doc>"
                 if mode == "required" and not _pge.override_active():
                     return ConstraintVerdict(
                         code="plan-gate-unresolved",
@@ -478,7 +478,7 @@ def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optiona
                         message=(
                             f"track_id={track_id!r} has not passed its plan-first gate "
                             f"(OI-PLAN-{track_id} unresolved). Plan before work: run "
-                            f"`{run_cmd}` (or `vnx plan-gate attest {track_id}`), or "
+                            f"`{run_cmd}` (or `vnx horizon plan-gate attest {track_id}`), or "
                             f"operator-override with VNX_OVERRIDE_PLAN_GATE=1."
                         ),
                     )

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -485,8 +485,8 @@ def format_blocking_hint(detail: Optional[Dict[str, Any]]) -> str:
             lines.append(
                 f"blocked by open-item {oi_id}{suffix} -- this is the plan-first "
                 f"gate; resolve with EITHER: re-run the panel: "
-                f"vnx plan-gate run {plan_track} --doc <plan-doc>  OR operator "
-                f'override: vnx plan-gate attest {plan_track} --reason '
+                f"vnx horizon plan-gate run {plan_track} --doc <plan-doc>  OR operator "
+                f'override: vnx horizon plan-gate attest {plan_track} --reason '
                 f'"<why this is already done>" --approval-id <token>'
             )
         else:

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1849,7 +1849,7 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
         if args.json:
             print(json.dumps(payload, indent=2, default=str))
         else:
-            print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+            print(f"\nvnx horizon plan-gate attest — {track_id} (project '{project_id}')\n")
             print(
                 "  no unresolved plan blocker found (gate not seeded, or already "
                 "passed). No change made.\n"
@@ -1876,7 +1876,7 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
         if args.json:
             print(json.dumps(payload, indent=2, default=str))
         else:
-            print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+            print(f"\nvnx horizon plan-gate attest — {track_id} (project '{project_id}')\n")
             print(f"  attested: {reason} (approval={approval_id})")
             print(
                 f"  plan blocker resolved={resolved}, but track {track_id} is STILL "
@@ -1888,7 +1888,7 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
     if args.json:
         print(json.dumps(payload, indent=2, default=str))
     else:
-        print(f"\nvnx plan-gate attest — {track_id} (project '{project_id}')\n")
+        print(f"\nvnx horizon plan-gate attest — {track_id} (project '{project_id}')\n")
         print(f"  attested: {reason} (approval={approval_id})")
         print(f"  plan gate cleared. derived_status={derived}.\n")
     return 0


### PR DESCRIPTION
## Summary
MC T0 (consumer) reported that `vnx objective close` blocks on the OI-PLAN gate and its hint says to run `vnx plan-gate run/attest` — but that command does not exist (`invalid choice: plan-gate`); the verbs are nested under `vnx horizon plan-gate` (no top-level alias). The `vnx_cli` runtime was already correct (MC hit an older engine); this fixes the remaining **scripts surface** that the reconcile tick, SessionStart hooks, and the dispatch door use — including the ADR-030 door enforcement message introduced earlier today, which carried the same bug.

## Changes
- `scripts/lib/track_reconciler.py`: `format_blocking_hint` → `vnx horizon plan-gate run/attest`.
- `scripts/lib/dispatch_cli.py`: door enforcement message → `vnx horizon plan-gate run/attest`.
- `scripts/planning_cli.py`: attest command headers (cosmetic) → `vnx horizon plan-gate attest`.

## Verification
- `grep -rn "vnx plan-gate" scripts/ vnx_cli/ | grep -v "vnx horizon plan-gate"` → clean.
- `py_compile` OK. Confirmed `vnx objective close` (runtime) already emits the correct nested command.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7