### PR TITLE
feat(gov): plan-gate-pass evidence — ADR-030 merge-gate primitive (bootstrap)

### DIFF
--- a/scripts/lib/plan_gate_evidence.py
+++ b/scripts/lib/plan_gate_evidence.py
@@ -1,0 +1,127 @@
+"""Plan-gate-pass evidence — the durable, tamper-evident record that a track's
+plan-first gate passed, plus its verification (ADR-030's merge-gate primitive).
+
+When a track's ``OI-PLAN`` plan-first gate is resolved (``plan-gate run`` PASS or
+``plan-gate attest``), emit a hash-chained ``plan_gate_pass`` record keyed by
+``track_id`` into ``.vnx-attest/plan-gates.ndjson``. Unlike the evidence-bound
+gate's diff-bound receipts, a plan-gate pass PREDATES the diff, so the record is
+TRACK-keyed, not content-keyed — the correct front link of the requirements-
+traceability chain (PRD → track → plan-gate-pass → dispatch → receipt → PR).
+
+The merge gate (``verify_pr``) then checks, for a PR's linked track, that a valid
+``plan_gate_pass`` record exists — advisory-first via ``VNX_PLAN_GATE_ENFORCE``
+(the same flag the dispatch door uses). Door gates the dispatch; merge gates the PR.
+
+Reuses the D1 attestation primitives (``sign_manifest`` / ``verify_attestation`` /
+``append_chained_entry``): a record signed when a key is available is tamper-PROOF;
+an unsigned record is still hash-chained (tamper-EVIDENT). Emission is best-effort
+and never raises — it must not break the plan-gate resolution it hangs off.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+_LEDGER = ".vnx-attest/plan-gates.ndjson"
+RECORD_TYPE = "plan_gate_pass"
+
+# verification states
+VERIFIED = "verified"          # a signed record exists AND its signature verifies
+PRESENT_UNSIGNED = "present"   # a hash-chained record exists but is unsigned/unverifiable
+ABSENT = "absent"              # no plan-gate-pass record for this track
+
+
+def _ledger_path(repo_root: "str | Path") -> Path:
+    return Path(repo_root) / _LEDGER
+
+
+def emit_plan_gate_pass(
+    *,
+    repo_root: "str | Path",
+    track_id: str,
+    project_id: str,
+    resolver: str,                 # "run" | "attest"
+    timestamp: str,
+    approval_id: Optional[str] = None,
+    reason: Optional[str] = None,
+    signer_identity: Optional[str] = None,
+    key_path: "str | Path | None" = None,
+) -> Optional[Dict[str, Any]]:
+    """Append a ``plan_gate_pass`` record for a track to the repo-committed ledger.
+
+    Signed when ``key_path`` + ``signer_identity`` are provided (tamper-proof);
+    otherwise appended unsigned but hash-chained (tamper-evident). Best-effort:
+    returns the appended record on success, ``None`` on any failure (never raises).
+    """
+    try:
+        from ndjson_hash_chain import append_chained_entry  # noqa: PLC0415
+
+        record: Dict[str, Any] = {
+            "type": RECORD_TYPE,
+            "track_id": track_id,
+            "project_id": project_id,
+            "resolver": resolver,
+            "resolved_at": timestamp,
+        }
+        if approval_id:
+            record["approval_id"] = approval_id
+        if reason:
+            record["reason"] = reason
+        if key_path and signer_identity:
+            from attestation import sign_manifest  # noqa: PLC0415
+            record["signer_identity"] = signer_identity
+            record = sign_manifest(record, key_path)
+
+        ledger = _ledger_path(repo_root)
+        ledger.parent.mkdir(parents=True, exist_ok=True)
+        append_chained_entry(ledger, record)
+        return record
+    except Exception:  # noqa: BLE001 — emission must never break the gate resolution
+        return None
+
+
+def verify_plan_gate_pass(
+    repo_root: "str | Path",
+    track_id: str,
+    project_id: str,
+    allowed_signers: "str | Path | None" = None,
+) -> Tuple[str, Optional[Dict[str, Any]]]:
+    """Return ``(state, record)`` for a track's plan-gate pass.
+
+    Walks the hash-chained ledger for the LATEST ``plan_gate_pass`` matching
+    ``(track_id, project_id)``. If ``allowed_signers`` is given and the record's
+    signature verifies → ``VERIFIED``; a present-but-unverifiable record →
+    ``PRESENT_UNSIGNED``; nothing → ``ABSENT``. Read-only; never raises.
+    """
+    ledger = _ledger_path(repo_root)
+    if not ledger.exists():
+        return (ABSENT, None)
+
+    latest: Optional[Dict[str, Any]] = None
+    try:
+        from ndjson_hash_chain import walk_chain  # noqa: PLC0415
+        for _i, entry, _h in walk_chain(ledger):
+            if not isinstance(entry, dict):
+                continue
+            if entry.get("type") != RECORD_TYPE:
+                continue
+            if entry.get("track_id") != track_id:
+                continue
+            if entry.get("project_id") not in (None, project_id):
+                continue
+            latest = entry  # last match wins — the most recent pass
+    except Exception:  # noqa: BLE001
+        return (ABSENT, None)
+
+    if latest is None:
+        return (ABSENT, None)
+
+    if allowed_signers is not None:
+        try:
+            from attestation import verify_attestation  # noqa: PLC0415
+            manifest = {k: v for k, v in latest.items() if k != "prev_hash"}
+            if verify_attestation(manifest, allowed_signers):
+                return (VERIFIED, latest)
+        except Exception:  # noqa: BLE001
+            pass
+    return (PRESENT_UNSIGNED, latest)

--- a/scripts/lib/plan_gate_evidence.py
+++ b/scripts/lib/plan_gate_evidence.py
@@ -122,6 +122,6 @@ def verify_plan_gate_pass(
             manifest = {k: v for k, v in latest.items() if k != "prev_hash"}
             if verify_attestation(manifest, allowed_signers):
                 return (VERIFIED, latest)
-        except Exception:  # noqa: BLE001
+        except Exception:  # vnx-silent-except: signature verify is best-effort; fall through to PRESENT
             pass
     return (PRESENT_UNSIGNED, latest)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1866,6 +1866,30 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
         {"reason": reason, "approval_id": approval_id, "track_id": track_id},
     )
 
+    # ADR-030 merge-gate primitive: a repo-committed, hash-chained plan_gate_pass
+    # record so the pass is verifiable at PR/merge time (the front link of the
+    # requirements-traceability chain). Best-effort, unsigned bootstrap — the
+    # runtime event above stays the authoritative audit; this never blocks attest.
+    try:
+        import subprocess as _sp  # noqa: PLC0415
+        import plan_gate_evidence  # noqa: PLC0415
+        _repo_root = getattr(args, "repo_root", None)
+        if not _repo_root:
+            try:
+                _repo_root = _sp.check_output(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    text=True, stderr=_sp.DEVNULL,
+                ).strip() or str(Path.cwd())
+            except Exception:  # noqa: BLE001
+                _repo_root = str(Path.cwd())
+        plan_gate_evidence.emit_plan_gate_pass(
+            repo_root=_repo_root, track_id=track_id, project_id=project_id,
+            resolver="attest", timestamp=_now_utc(),
+            approval_id=approval_id, reason=reason,
+        )
+    except Exception:  # noqa: BLE001 — evidence emission must never break attest
+        pass
+
     post = tracks_lib.get_track(state_dir, track_id, project_id)
     derived = post.get("derived_status") if isinstance(post, dict) else None
     payload["action"] = "attested"

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1887,7 +1887,7 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
             resolver="attest", timestamp=_now_utc(),
             approval_id=approval_id, reason=reason,
         )
-    except Exception:  # noqa: BLE001 — evidence emission must never break attest
+    except Exception:  # vnx-silent-except: evidence emission must never break attest
         pass
 
     post = tracks_lib.get_track(state_dir, track_id, project_id)

--- a/tests/test_plan_gate_evidence.py
+++ b/tests/test_plan_gate_evidence.py
@@ -1,0 +1,87 @@
+"""Tests for plan-gate-pass evidence (ADR-030 merge-gate primitive)."""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import plan_gate_evidence as pge  # noqa: E402
+
+
+def _emit(tmp, track="t", project="vnx-dev", resolver="attest", ts="2026-07-11T00:00:00Z", **kw):
+    return pge.emit_plan_gate_pass(
+        repo_root=tmp, track_id=track, project_id=project, resolver=resolver, timestamp=ts, **kw
+    )
+
+
+class TestEmit:
+    def test_emit_unsigned_creates_chained_ledger(self, tmp_path):
+        rec = _emit(tmp_path, approval_id="op-1", reason="already done")
+        assert rec is not None
+        ledger = tmp_path / ".vnx-attest" / "plan-gates.ndjson"
+        assert ledger.exists()
+        assert rec["type"] == "plan_gate_pass"
+        assert rec["track_id"] == "t"
+        assert rec["approval_id"] == "op-1"
+
+    def test_emit_is_best_effort_returns_none_on_failure(self, tmp_path, monkeypatch):
+        # A ledger path that cannot be created (parent is a file) → None, no raise.
+        bad = tmp_path / "afile"
+        bad.write_text("x")
+        rec = pge.emit_plan_gate_pass(
+            repo_root=bad, track_id="t", project_id="vnx-dev",
+            resolver="run", timestamp="2026-07-11T00:00:00Z",
+        )
+        assert rec is None
+
+
+class TestVerify:
+    def test_absent_when_no_ledger(self, tmp_path):
+        state, rec = pge.verify_plan_gate_pass(tmp_path, "t", "vnx-dev")
+        assert state == pge.ABSENT and rec is None
+
+    def test_present_unsigned_round_trip(self, tmp_path):
+        _emit(tmp_path)
+        state, rec = pge.verify_plan_gate_pass(tmp_path, "t", "vnx-dev")
+        assert state == pge.PRESENT_UNSIGNED
+        assert rec is not None and rec["track_id"] == "t"
+
+    def test_absent_for_other_track(self, tmp_path):
+        _emit(tmp_path, track="t")
+        state, _ = pge.verify_plan_gate_pass(tmp_path, "other", "vnx-dev")
+        assert state == pge.ABSENT
+
+    def test_tenant_isolation(self, tmp_path):
+        _emit(tmp_path, track="t", project="vnx-dev")
+        state, _ = pge.verify_plan_gate_pass(tmp_path, "t", "other-project")
+        assert state == pge.ABSENT
+
+    def test_latest_pass_wins(self, tmp_path):
+        _emit(tmp_path, ts="2026-07-11T00:00:00Z", reason="first")
+        _emit(tmp_path, ts="2026-07-11T09:00:00Z", reason="second")
+        state, rec = pge.verify_plan_gate_pass(tmp_path, "t", "vnx-dev")
+        assert state == pge.PRESENT_UNSIGNED
+        assert rec["reason"] == "second"
+
+    def test_verified_when_signature_checks(self, tmp_path, monkeypatch):
+        """With a key + a verifying signer, a record round-trips to VERIFIED."""
+        import attestation
+        monkeypatch.setattr(attestation, "sign_manifest",
+                            lambda m, k: {**m, "signature": "sig"})
+        monkeypatch.setattr(attestation, "verify_attestation", lambda m, s: True)
+        _emit(tmp_path, signer_identity="vincent", key_path="/fake/key")
+        state, rec = pge.verify_plan_gate_pass(tmp_path, "t", "vnx-dev", allowed_signers="/fake/signers")
+        assert state == pge.VERIFIED
+        assert rec["signer_identity"] == "vincent"
+
+    def test_signed_but_signature_fails_is_present(self, tmp_path, monkeypatch):
+        import attestation
+        monkeypatch.setattr(attestation, "sign_manifest",
+                            lambda m, k: {**m, "signature": "sig"})
+        monkeypatch.setattr(attestation, "verify_attestation", lambda m, s: False)
+        _emit(tmp_path, signer_identity="vincent", key_path="/fake/key")
+        state, _ = pge.verify_plan_gate_pass(tmp_path, "t", "vnx-dev", allowed_signers="/fake/signers")
+        assert state == pge.PRESENT_UNSIGNED


### PR DESCRIPTION
## Summary
The deferred second enforcement point of **ADR-030**. The dispatch door already gates the dispatch; this adds the primitive the **merge gate** needs: a repo-committed, hash-chained, tamper-evident record that a track's plan-first gate passed. Track-keyed (a plan-gate pass predates the diff, so it can't be diff-bound like the evidence-bound gate's receipts) — the **front link of the requirements-traceability chain** (PRD → track → plan-gate-pass → dispatch → receipt → PR).

Advisory-first bootstrap, matching the evidence-bound gate (#1080): ships the primitive + emission + tests; the CI/`verify_pr` wiring follows.

## Changes
- `scripts/lib/plan_gate_evidence.py` (new): `emit_plan_gate_pass` (signed if a key is available, else unsigned + hash-chained; best-effort, never raises) + `verify_plan_gate_pass` → `VERIFIED` / `PRESENT_UNSIGNED` / `ABSENT`. Reuses `sign_manifest` / `verify_attestation` / `append_chained_entry`.
- `scripts/planning_cli.py`: `cmd_plan_gate_attest` emits the record on a successful attest (best-effort; the runtime `plan_gate_attest` event stays the authoritative audit).
- `tests/test_plan_gate_evidence.py` (new): 9 tests (round-trip, latest-wins, tenant isolation, best-effort-on-failure, signed→VERIFIED, bad-signature→PRESENT).

## Verification
- `pytest tests/test_plan_gate_evidence.py` → 9 passed. `py_compile` OK. `.vnx-attest` is committable (same home as the evidence-bound gate's `governed.ndjson`).

## Open Items (the documented follow-up)
- Wire `verify_plan_gate_pass` into `verify_pr` / the CI attestation gate (advisory→required via `VNX_PLAN_GATE_ENFORCE`).
- Emit on the `plan-gate run` PASS path too (not just attest).
- Resolve the signing key so records are tamper-PROOF, not just tamper-evident.
- Operational: ensure the record reaches the PR branch (the `plan_ref` traceability track covers the linkage).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7