### PR TITLE
feat(bench): lane-calibration field-test for smart-router routing

### DIFF
--- a/scripts/benchmark/field-tests/README.md
+++ b/scripts/benchmark/field-tests/README.md
@@ -31,6 +31,30 @@ python3 scripts/benchmark/field-tests/runners/skill_smoke.py --lane kimi-k2-6
 ```
 The smoke dispatches a neutral review assignment (never says "security") with a planted SQL injection, hardcoded credential, and off-by-one. PASS = the worker surfaces the security vocabulary AND a planted vuln (presence-based, not strict ordering — see the module docstring); the skill's mandatory activation line is reported as extra evidence. It is a dev smoke, not a governed gate. Last verified 2026-06-07: 5/5 reachable lanes PASS (kimi blocked on quota) — see ADR-022 Validation.
 
+## Lane calibration (routing field-test)
+
+Separate from the model-quality matrix above: `runners/lane_calibration.py` checks
+whether the production smart router (`providers.smart_router.cost_tier` +
+`.tier_routing`) picks the RIGHT lane for a set of realistic field-tests tasks —
+not whether a model does the work well, but whether the dispatch would even be
+routed to an appropriately-sized lane (tier-zero local model vs. tier-high opus)
+before any tokens are spent.
+
+```bash
+python3 scripts/benchmark/field-tests/runners/lane_calibration.py            # table, exit 1 on mismatch
+python3 scripts/benchmark/field-tests/runners/lane_calibration.py --json     # machine-readable
+pytest tests/test_lane_calibration_field_test.py -v                          # pytest wrapper
+```
+
+Self-contained: it feeds each case's real `instruction.md` + `target_loc` through
+`classify_dispatch()` / `resolve_tier_route()` directly — no subprocess dispatch,
+no network call, no model spawn, no external credits. Expected outcomes are
+documented per-case in `lane_calibration.yaml`, captured against the classifier's
+actual current behavior (a regression fixture, not an aspirational spec) — some
+cases carry a `note:` flagging a known keyword-heuristic miscalibration (e.g.
+"refactor" in a task title over-triggering the arch-keyword tier-high path) that
+is out of scope for this field-test to fix.
+
 ## What this measures
 
 For each (lane, task, replication) cell:

--- a/scripts/benchmark/field-tests/lane_calibration.yaml
+++ b/scripts/benchmark/field-tests/lane_calibration.yaml
@@ -1,0 +1,85 @@
+# lane_calibration.yaml — documented expected outcome for the lane-calibration field-test
+#
+# Each case feeds a REAL field-tests task (its actual instruction.md text + the
+# target_loc from tasks.yaml) through the production smart-router pipeline
+# (providers.smart_router.cost_tier.classify_dispatch -> tier_routing.resolve_tier_route)
+# and asserts the tier/provider/lane it selects. This is a regression fixture, not
+# an aspirational spec: expected_* values are the classifier's ACTUAL current
+# output on this corpus, captured 2026-07-11 against smart_router as of #1121.
+#
+# n_files is the count of files listed under the task's "## Files you may
+# create/modify" heading in instruction.md (required files only; optional
+# extras excluded) - hand-counted once per task, not re-derived at runtime.
+#
+# A run of runners/lane_calibration.py that diverges from this table means the
+# router's routing behavior drifted for these realistic tasks - update the
+# table deliberately after confirming the new behavior is intended.
+
+version: 1
+
+cases:
+  - task_id: "01_yaml_config_refactor"
+    tier: t1_trivial
+    n_files: 2
+    expected_tier: tier-high
+    expected_provider: claude
+    expected_lane: tmux_interactive
+    note: >
+      Known miscalibration: single-file 60-LOC config refactor gets tier-high
+      because the instruction text contains the word "refactor", which matches
+      the arch-keyword pattern intended for architectural rewrites. Flagged as
+      a follow-up (keyword over-triggers on task-title vocabulary), not fixed
+      by this field-test.
+
+  - task_id: "02_rls_policy"
+    tier: t1_trivial
+    n_files: 1
+    expected_tier: tier-mid
+    expected_provider: claude
+    expected_lane: tmux_interactive
+    note: >
+      Known miscalibration: this is a Postgres Row Level Security policy
+      (security-sensitive by construction) but the instruction never spells
+      out "security"/"auth"/etc. literally - only "RLS" - so the security
+      keyword filter misses it. Falls through to the schema/migration keyword
+      match (tier-mid) instead of tier-high.
+
+  - task_id: "03_dotenv_script"
+    tier: t1_trivial
+    n_files: 1
+    expected_tier: tier-zero
+    expected_provider: local-gemma
+    expected_lane: mlx
+
+  - task_id: "04_scorer_task"
+    tier: t2_medium
+    n_files: 5
+    expected_tier: tier-high
+    expected_provider: claude
+    expected_lane: tmux_interactive
+
+  - task_id: "05_extractor_subclass"
+    tier: t2_medium
+    n_files: 3
+    expected_tier: tier-mid
+    expected_provider: claude
+    expected_lane: tmux_interactive
+
+  - task_id: "06_flaky_mock_fix"
+    tier: t2_medium
+    n_files: 1
+    expected_tier: tier-mid
+    expected_provider: claude
+    expected_lane: tmux_interactive
+    note: >
+      Known miscalibration: single-file 80-LOC mock fix gets tier-mid because
+      the instruction describes a chained `.table().select()...` mock API and
+      "table" matches the schema keyword list (intended for database-schema
+      work, not a Supabase mock method name).
+
+  - task_id: "08_ssrf_async_fetch"
+    tier: t3_complex
+    n_files: 2
+    expected_tier: tier-high
+    expected_provider: claude
+    expected_lane: tmux_interactive

--- a/scripts/benchmark/field-tests/runners/lane_calibration.py
+++ b/scripts/benchmark/field-tests/runners/lane_calibration.py
@@ -1,0 +1,133 @@
+"""lane_calibration.py — field-test: does the smart router pick the right lane
+for realistic field-tests tasks?
+
+Feeds each case's REAL instruction.md text + target_loc (from tasks.yaml)
+through the production routing pipeline:
+
+    providers.smart_router.cost_tier.classify_dispatch(...) -> tier
+    providers.smart_router.tier_routing.resolve_tier_route(tier) -> provider/lane
+
+and compares the result against the documented expected outcome in
+lane_calibration.yaml. No subprocess dispatch, no network call, no model
+spawn — pure classifier logic, so this runs in well under a second and never
+touches external credits.
+
+A mismatch means routing behavior drifted for one of these realistic tasks
+since the calibration table was captured — investigate before updating the
+table (see lane_calibration.yaml header for what "known miscalibration"
+notes mean vs. genuine drift).
+
+Usage:
+    python3 lane_calibration.py            # human-readable table, exit 1 on mismatch
+    python3 lane_calibration.py --json     # machine-readable result list
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import yaml
+
+HERE = Path(__file__).resolve().parent
+FIELD_TESTS = HERE.parent
+REPO_ROOT = FIELD_TESTS.parents[2]
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+from providers.smart_router.cost_tier import classify_dispatch  # noqa: E402
+from providers.smart_router.tier_routing import resolve_tier_route  # noqa: E402
+
+
+@dataclass
+class CalibrationResult:
+    task_id: str
+    passed: bool
+    expected_tier: str
+    actual_tier: str
+    expected_provider: str
+    actual_provider: str
+    expected_lane: str
+    actual_lane: str
+    note: Optional[str] = None
+
+
+def load_tasks_by_id(field_tests_dir: Path = FIELD_TESTS) -> dict:
+    cfg = yaml.safe_load((field_tests_dir / "tasks.yaml").read_text(encoding="utf-8"))
+    return {t["id"]: t for t in cfg["tasks"]}
+
+
+def load_calibration_cases(field_tests_dir: Path = FIELD_TESTS) -> list[dict]:
+    cfg = yaml.safe_load(
+        (field_tests_dir / "lane_calibration.yaml").read_text(encoding="utf-8")
+    )
+    return cfg["cases"]
+
+
+def run_case(case: dict, tasks_by_id: dict, field_tests_dir: Path = FIELD_TESTS) -> CalibrationResult:
+    task = tasks_by_id[case["task_id"]]
+    instruction = (field_tests_dir / task["folder"] / "instruction.md").read_text(
+        encoding="utf-8"
+    )
+    file_paths = [None] * case["n_files"]
+    loc_estimate = task["target_loc"]
+
+    actual_tier = classify_dispatch({"instruction": instruction}, file_paths, loc_estimate)
+    route = resolve_tier_route(actual_tier, env={})
+
+    passed = (
+        actual_tier == case["expected_tier"]
+        and route.provider == case["expected_provider"]
+        and route.lane == case["expected_lane"]
+    )
+    return CalibrationResult(
+        task_id=case["task_id"],
+        passed=passed,
+        expected_tier=case["expected_tier"],
+        actual_tier=actual_tier,
+        expected_provider=case["expected_provider"],
+        actual_provider=route.provider,
+        expected_lane=case["expected_lane"],
+        actual_lane=route.lane,
+        note=case.get("note"),
+    )
+
+
+def run_all(field_tests_dir: Path = FIELD_TESTS) -> list[CalibrationResult]:
+    tasks_by_id = load_tasks_by_id(field_tests_dir)
+    cases = load_calibration_cases(field_tests_dir)
+    return [run_case(c, tasks_by_id, field_tests_dir) for c in cases]
+
+
+def _print_table(results: list[CalibrationResult]) -> None:
+    for r in results:
+        status = "PASS" if r.passed else "FAIL"
+        print(f"[{status}] {r.task_id}")
+        print(f"       tier:     expected={r.expected_tier:<10} actual={r.actual_tier}")
+        print(f"       provider: expected={r.expected_provider:<10} actual={r.actual_provider}")
+        print(f"       lane:     expected={r.expected_lane:<16} actual={r.actual_lane}")
+        if r.note:
+            print(f"       note: {r.note.strip()}")
+    n_pass = sum(1 for r in results if r.passed)
+    print(f"\n{n_pass}/{len(results)} lane-calibration cases passed")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--json", action="store_true", help="emit JSON instead of a table")
+    args = parser.parse_args()
+
+    results = run_all()
+
+    if args.json:
+        print(json.dumps([r.__dict__ for r in results], indent=2))
+    else:
+        _print_table(results)
+
+    return 0 if all(r.passed for r in results) else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_lane_calibration_field_test.py
+++ b/tests/test_lane_calibration_field_test.py
@@ -1,0 +1,91 @@
+"""Tests for the lane-calibration field-test (scripts/benchmark/field-tests).
+
+This is the pytest wrapper around
+scripts/benchmark/field-tests/runners/lane_calibration.py — the realistic-bench
+field-test that feeds real field-tests task instructions through the
+production smart-router (classify_dispatch -> resolve_tier_route) and checks
+the result against the documented expected outcome in lane_calibration.yaml.
+
+Covers: every case in the calibration table matches (regression guard against
+routing drift), the runner's CLI exit code, and that a genuine mismatch is
+actually detected (the fixture-comparison logic isn't a no-op).
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+RUNNER_DIR = REPO_ROOT / "scripts" / "benchmark" / "field-tests" / "runners"
+RUNNER_SCRIPT = RUNNER_DIR / "lane_calibration.py"
+
+sys.path.insert(0, str(RUNNER_DIR))
+import lane_calibration as lc  # noqa: E402
+
+
+def test_calibration_yaml_and_tasks_yaml_are_consistent():
+    tasks_by_id = lc.load_tasks_by_id()
+    cases = lc.load_calibration_cases()
+    assert cases, "lane_calibration.yaml has no cases"
+    for case in cases:
+        assert case["task_id"] in tasks_by_id, (
+            f"{case['task_id']} in lane_calibration.yaml has no matching "
+            "entry in tasks.yaml"
+        )
+
+
+@pytest.mark.parametrize(
+    "case",
+    lc.load_calibration_cases(),
+    ids=lambda c: c["task_id"],
+)
+def test_case_matches_documented_expected_outcome(case):
+    tasks_by_id = lc.load_tasks_by_id()
+    result = lc.run_case(case, tasks_by_id)
+    assert result.passed, (
+        f"{result.task_id}: expected tier={result.expected_tier} "
+        f"provider={result.expected_provider} lane={result.expected_lane}, "
+        f"got tier={result.actual_tier} provider={result.actual_provider} "
+        f"lane={result.actual_lane}"
+    )
+
+
+def test_run_all_returns_one_result_per_case():
+    results = lc.run_all()
+    cases = lc.load_calibration_cases()
+    assert len(results) == len(cases)
+    assert all(r.passed for r in results)
+
+
+def test_mismatch_is_actually_detected():
+    """Guard against the comparison silently always passing."""
+    tasks_by_id = lc.load_tasks_by_id()
+    case = dict(lc.load_calibration_cases()[0])
+    case["expected_tier"] = "tier-does-not-exist"
+    result = lc.run_case(case, tasks_by_id)
+    assert result.passed is False
+
+
+def test_cli_runs_clean_and_exits_zero():
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER_SCRIPT)],
+        capture_output=True, text=True, check=False, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    assert "cases passed" in proc.stdout
+
+
+def test_cli_json_output_is_valid():
+    import json
+
+    proc = subprocess.run(
+        [sys.executable, str(RUNNER_SCRIPT), "--json"],
+        capture_output=True, text=True, check=False, cwd=REPO_ROOT,
+    )
+    assert proc.returncode == 0, proc.stdout + proc.stderr
+    payload = json.loads(proc.stdout)
+    assert isinstance(payload, list) and payload
+    assert all(row["passed"] for row in payload)


### PR DESCRIPTION
## Summary
- Adds `scripts/benchmark/field-tests/runners/lane_calibration.py` — a new realistic-bench field-test (companion to the existing model-quality matrix) that checks whether the production smart router (`providers.smart_router.cost_tier.classify_dispatch` + `.tier_routing.resolve_tier_route`) picks the right tier/provider/lane for realistic tasks *before* any tokens are spent.
- Each case feeds the REAL `instruction.md` text + `target_loc` of an existing field-tests task (01, 02, 03, 04, 05, 06, 08) through the actual classifier — no subprocess dispatch, no network call, no model spawn, no external credits.
- `lane_calibration.yaml` documents the expected outcome per case, captured against the classifier's actual current behavior (a regression fixture).
- Surfaces (documents, does not fix — out of scope here) three keyword-heuristic miscalibrations found by running real task text through the classifier:
  - `01_yaml_config_refactor`: the word "refactor" in the task title triggers the arch-keyword pattern → tier-high for a 60-LOC single-concern config change.
  - `02_rls_policy`: a Postgres Row Level Security migration isn't recognized as security-sensitive because "security"/"auth" never appear literally, only "RLS" → falls through to tier-mid via the schema/migration keyword instead of tier-high.
  - `06_flaky_mock_fix`: a Supabase mock's `.table()` chained call matches the "table" schema keyword (meant for real database-schema work) → tier-mid instead of tier-low.
- README updated with a "Lane calibration" section.

## Test plan
- [x] `python3 scripts/benchmark/field-tests/runners/lane_calibration.py` — 7/7 cases pass, exit 0
- [x] `python3 scripts/benchmark/field-tests/runners/lane_calibration.py --json` — valid JSON, exit 0
- [x] `pytest tests/test_lane_calibration_field_test.py -v` — 12 passed
- [x] `pytest tests/ -q -k "smart_router or smart_lanes or lane_calibration or cost_tier or tier_routing"` — 235 passed, 3 pre-existing failures confirmed unrelated (identical failures reproduce on main without this change, via `git stash` comparison)
- [x] `pytest tests/ -q --collect-only` — 16673 tests collected cleanly (16661 baseline + 12 new), no collection errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)