### PR TITLE
fix(bench): match --retry-from DNF rows against their own dispatch_id (F5)

### DIFF
--- a/scripts/benchmark/field-tests/runners/run_field_tests.py
+++ b/scripts/benchmark/field-tests/runners/run_field_tests.py
@@ -196,26 +196,38 @@ def _load_dnf_cells_from_csv(
                 continue
 
             # Soft signal: report-missing for any cell with wallclock < 5s.
-            # Check filesystem for both report-naming conventions in both candidate dirs.
-            # KNOWN LIMITATION (F5, PR #831, deferred 1.0.1): the prefix match
-            # below has a per-cell timestamp suffix, so ANY historical report
-            # for this lane/task/rep counts as "present" — a short failed cell
-            # whose only report is from an earlier run is wrongly excluded from
-            # retry. Fix is to match the row's own dispatch_id; deferred.
+            # FIXED (F5, PR #831): match this row's OWN dispatch_id exactly
+            # (dispatch_id is a raw.csv column since the dispatch_id field
+            # landed on CellScore) instead of a bare (lane, task, rep) prefix.
+            # The prefix alone matches ANY historical report for that cell —
+            # including one left over from an earlier attempt with a
+            # different timestamp — which wrongly counted a genuinely-failed
+            # row as "report present" and excluded it from retry.
             if wall < 5.0:
-                prefix = f"bench-{row['lane_id']}-{row['task_id']}-r{row['replication']}-"
+                dispatch_id = (row.get("dispatch_id") or "").strip()
                 found = False
-                for d in REPORT_DIR_CANDIDATES:
-                    if not d.exists():
-                        continue
-                    for p in d.iterdir():
-                        if p.name.startswith(prefix) and (
-                            p.name.endswith(".md") or p.name.endswith("_report.md")
-                        ):
+                if dispatch_id:
+                    for d in REPORT_DIR_CANDIDATES:
+                        if (d / f"{dispatch_id}.md").exists() or (
+                            d / f"{dispatch_id}_report.md"
+                        ).exists():
                             found = True
                             break
-                    if found:
-                        break
+                else:
+                    # Legacy raw.csv predating the dispatch_id column: fall back
+                    # to the coarse prefix heuristic (may under-count DNFs).
+                    prefix = f"bench-{row['lane_id']}-{row['task_id']}-r{row['replication']}-"
+                    for d in REPORT_DIR_CANDIDATES:
+                        if not d.exists():
+                            continue
+                        for p in d.iterdir():
+                            if p.name.startswith(prefix) and (
+                                p.name.endswith(".md") or p.name.endswith("_report.md")
+                            ):
+                                found = True
+                                break
+                        if found:
+                            break
                 if not found:
                     dnf.add((row["lane_id"], row["task_id"], int(row["replication"])))
     return dnf
@@ -254,6 +266,7 @@ def _load_prior_scores(
                 judge_reasoning=row.get("judge_reasoning", ""),
                 cost_usd=float(row["cost_usd"]),
                 wallclock_seconds=float(row["wallclock_seconds"]),
+                dispatch_id=row.get("dispatch_id", ""),
             ))
     return prior
 

--- a/scripts/benchmark/field-tests/runners/scorer.py
+++ b/scripts/benchmark/field-tests/runners/scorer.py
@@ -47,6 +47,11 @@ class CellScore:
     input_tokens: int = 0
     output_tokens: int = 0
     tokens_per_second: float = 0.0   # output_tokens / wallclock (effective throughput)
+    # This row's own dispatch_id (bench-<lane>-<task>-r<rep>-<ts>). Lets
+    # --retry-from match a row against ITS OWN report file instead of any
+    # historical report for the same (lane, task, rep) — see F5 in
+    # run_field_tests._load_dnf_cells_from_csv. Empty for pre-fix raw.csv.
+    dispatch_id: str = ""
 
 
 def _load_verify_module(task_folder: Path):
@@ -316,6 +321,7 @@ def score_cell(
             judge_reasoning="skipped (dispatch failed)",
             cost_usd=0.0,
             wallclock_seconds=dispatch_result.wallclock_seconds,
+            dispatch_id=dispatch_result.dispatch_id,
         )
 
     # Verify in the checkout the worker actually wrote to. Headless/provider
@@ -380,4 +386,5 @@ def score_cell(
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         tokens_per_second=tokens_per_second,
+        dispatch_id=dispatch_result.dispatch_id,
     )

--- a/tests/test_bench_retry_stale_report_prefix.py
+++ b/tests/test_bench_retry_stale_report_prefix.py
@@ -1,0 +1,140 @@
+"""Regression test for run_field_tests._load_dnf_cells_from_csv stale-report matching.
+
+F5 (PR #831, deferred 1.0.1): the DNF soft-signal used to prefix-match report
+filenames on (lane_id, task_id, replication) only — `bench-{lane}-{task}-r{rep}-`.
+That prefix has no timestamp discriminator, so ANY historical report for that
+cell (e.g. left over from an earlier attempt in the same --max-retries loop, or
+from a completely different prior run) counted as "report present" for THIS
+row, even when the row's own dispatch never produced one. A genuinely-failed
+short-wallclock cell was then silently excluded from --retry-from and its bad
+score stayed in the consolidated output.
+
+Fix: CellScore/raw.csv now carries this row's own dispatch_id (bench-<lane>-
+<task>-r<rep>-<ts>), and the soft-signal check matches that exact dispatch_id's
+report file instead of the coarse prefix. Legacy raw.csv files without a
+dispatch_id column fall back to the old prefix heuristic.
+"""
+from __future__ import annotations
+
+import csv
+import sys
+from pathlib import Path
+
+sys.path.insert(
+    0,
+    str(Path(__file__).resolve().parents[1] / "scripts" / "benchmark" / "field-tests" / "runners"),
+)
+
+import lane_adapter  # noqa: E402
+import run_field_tests  # noqa: E402
+
+
+RAW_CSV_FIELDS = [
+    "lane_id", "task_id", "replication", "correctness", "completeness",
+    "cost_efficiency", "wallclock_efficiency", "code_quality", "composite",
+    "verify_evidence", "judge_reasoning", "cost_usd", "wallclock_seconds",
+    "input_tokens", "output_tokens", "tokens_per_second", "dispatch_id",
+]
+
+
+def _write_raw_csv(path: Path, rows: list[dict]) -> None:
+    with path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=RAW_CSV_FIELDS)
+        writer.writeheader()
+        for row in rows:
+            writer.writerow({k: row.get(k, "") for k in RAW_CSV_FIELDS})
+
+
+def _base_row(**overrides) -> dict:
+    row = {
+        "lane_id": "claude-sonnet-4-6",
+        "task_id": "01_yaml_config_refactor",
+        "replication": 1,
+        "correctness": 0.0,
+        "completeness": 0.0,
+        "cost_efficiency": 0.0,
+        "wallclock_efficiency": 0.0,
+        "code_quality": 0.0,
+        "composite": 0.0,
+        "verify_evidence": "",
+        "judge_reasoning": "",
+        "cost_usd": 0.0,
+        "wallclock_seconds": 2.0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "tokens_per_second": 0.0,
+        "dispatch_id": "",
+    }
+    row.update(overrides)
+    return row
+
+
+def test_stale_historical_report_no_longer_masks_a_real_dnf(tmp_path, monkeypatch):
+    """A short-wallclock row with NO report of its own must be flagged DNF,
+    even when an older report for the same (lane, task, rep) sits on disk."""
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir()
+    monkeypatch.setattr(lane_adapter, "REPORT_DIR_CANDIDATES", (reports_dir,))
+
+    # Stale report from an EARLIER attempt at the same (lane, task, rep) — a
+    # different timestamp, hence a different dispatch_id.
+    (reports_dir / "bench-claude-sonnet-4-6-01_yaml_config_refactor-r1-20260601-000000.md").write_text(
+        "stale earlier attempt", encoding="utf-8",
+    )
+
+    row = _base_row(
+        wallclock_seconds=2.0,
+        composite=0.0,
+        dispatch_id="bench-claude-sonnet-4-6-01_yaml_config_refactor-r1-20260602-000000",
+    )
+    csv_path = tmp_path / "raw.csv"
+    _write_raw_csv(csv_path, [row])
+
+    dnf = run_field_tests._load_dnf_cells_from_csv(csv_path)
+
+    assert ("claude-sonnet-4-6", "01_yaml_config_refactor", 1) in dnf
+
+
+def test_row_with_its_own_report_is_not_flagged_dnf(tmp_path, monkeypatch):
+    """A short-wallclock row whose OWN dispatch_id report exists must be
+    treated as healthy (not re-run)."""
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir()
+    monkeypatch.setattr(lane_adapter, "REPORT_DIR_CANDIDATES", (reports_dir,))
+
+    dispatch_id = "bench-claude-sonnet-4-6-01_yaml_config_refactor-r1-20260602-000000"
+    (reports_dir / f"{dispatch_id}.md").write_text("real report", encoding="utf-8")
+
+    row = _base_row(wallclock_seconds=2.0, composite=3.0, dispatch_id=dispatch_id)
+    csv_path = tmp_path / "raw.csv"
+    _write_raw_csv(csv_path, [row])
+
+    dnf = run_field_tests._load_dnf_cells_from_csv(csv_path)
+
+    assert ("claude-sonnet-4-6", "01_yaml_config_refactor", 1) not in dnf
+
+
+def test_legacy_csv_without_dispatch_id_column_falls_back_to_prefix(tmp_path, monkeypatch):
+    """Pre-fix raw.csv files have no dispatch_id column at all — the reader
+    must not crash and must preserve the old prefix-based behaviour."""
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir()
+    monkeypatch.setattr(lane_adapter, "REPORT_DIR_CANDIDATES", (reports_dir,))
+
+    (reports_dir / "bench-claude-sonnet-4-6-01_yaml_config_refactor-r1-20260601-000000.md").write_text(
+        "legacy report", encoding="utf-8",
+    )
+
+    legacy_fields = [f for f in RAW_CSV_FIELDS if f != "dispatch_id"]
+    row = _base_row(wallclock_seconds=2.0, composite=0.0)
+    csv_path = tmp_path / "raw.csv"
+    with csv_path.open("w", newline="", encoding="utf-8") as fh:
+        writer = csv.DictWriter(fh, fieldnames=legacy_fields)
+        writer.writeheader()
+        writer.writerow({k: row[k] for k in legacy_fields})
+
+    dnf = run_field_tests._load_dnf_cells_from_csv(csv_path)
+
+    # Old (imprecise) behaviour: any historical report matching the prefix
+    # counts as present, so this cell is NOT flagged DNF.
+    assert ("claude-sonnet-4-6", "01_yaml_config_refactor", 1) not in dnf


### PR DESCRIPTION
## Summary

Hardens one of the three bench-runner edge cases from track `oi-224-bench-runner-edges`: the stale-report prefix-match in `run_field_tests._load_dnf_cells_from_csv` (documented in-code as `F5, PR #831, deferred 1.0.1`).

`_load_dnf_cells_from_csv`'s report-presence soft-signal (used to decide which cells `--retry-from` re-runs) prefix-matched report filenames on `(lane_id, task_id, replication)` only — `bench-{lane}-{task}-r{rep}-`. That prefix has no timestamp discriminator, so **any** historical report for that cell — left over from an earlier retry attempt, or from a completely unrelated prior run — counted as "report present" for the current row. A genuinely-failed short-wallclock cell was then silently excluded from retry and its bad (near-zero) score stayed in the consolidated `raw.csv` output.

## Changes

- `scripts/benchmark/field-tests/runners/scorer.py`: `CellScore` gains a `dispatch_id: str = ""` field, populated from `dispatch_result.dispatch_id` at both construction sites in `score_cell()`. Since `raw.csv` is written via `asdict()`, this becomes a new column automatically.
- `scripts/benchmark/field-tests/runners/run_field_tests.py`:
  - `_load_dnf_cells_from_csv`: the soft-signal now checks for an exact report file matching **this row's own `dispatch_id`**, not a coarse prefix scan. Falls back to the old prefix heuristic when `dispatch_id` is absent (legacy `raw.csv` predating this fix).
  - `_load_prior_scores`: forwards `dispatch_id` when reconstructing `CellScore` rows for the healthy-prior-rows merge.
- `tests/test_bench_retry_stale_report_prefix.py` (new): regression coverage for the stale-match bug, the fixed exact-match behavior, and the legacy-CSV fallback.

## Verification

```
python3 -m pytest tests/test_bench_retry_stale_report_prefix.py -v
# 3 passed

python3 -m pytest tests/ -k "bench" -v
# 108 passed, 7 failed — all 7 failures confirmed pre-existing via `git stash` (models.yaml
# drift: HEADLESS_FORCED_MODELS emptied 2026-06-15, kimi-k2-6/glm-5-1 provider-string
# drift, task-folder count grown 9→13). None touch the changed code paths.

python3 -m py_compile scripts/benchmark/field-tests/runners/run_field_tests.py scripts/benchmark/field-tests/runners/scorer.py
# OK
```

Also manually verified `dispatch_id` round-trips through `write_raw_csv` → `csv.DictReader`.

## Open Items

The dispatch scoped three edge cases; this PR fixes the highest-risk one (F5). The other two, left for follow-up:

1. **Retry isolation under a headless shared checkout (F4)** — the `_run_with_retry` docstring in `run_field_tests.py` still documents this as an open "known limitation" (headless/provider lanes could leave the shared main checkout dirty across a retry, inflating scores). Investigation for this PR found the isolation architecture has since moved on: `dispatch_worktree_isolation.py` creates a fresh worktree keyed by the full (per-attempt, timestamped) `dispatch_id`, `benchmark_worker_isolation.materialize_benchmark_seed()` fail-loudly refuses to ever materialize into the shared main checkout (`.git`-is-dir discriminator), and `lane_adapter.dispatch()` runs a `_main_seed_status()` invariant check on the shared checkout both before and after every dispatch. Together these appear to close the original F5-adjacent risk architecturally, but the stale docstring should be verified end-to-end and updated (or the risk re-confirmed) in a dedicated follow-up rather than asserted here.
2. **Worktree-removal result handling (F8)** — in `run_field_tests.run_one_cell`'s `finally` block, a failed `git worktree remove --force` for a scoring worktree is printed to stderr but not surfaced as a structured result, so a leaked worktree is possible under repeated failures. Lower risk than F5 (resource/disk hygiene, not silent score corruption) — left untouched in this PR.