### PR TITLE
fix(audit): security batch — scrub Anthropic credentials from litellm/harness subprocess env (S1,S2,S3)

### DIFF
--- a/scripts/lib/adapters/_litellm_agentic_runner.py
+++ b/scripts/lib/adapters/_litellm_agentic_runner.py
@@ -36,7 +36,15 @@ Exit codes:
   2 — other error (import failure, service unavailable, bad input, etc.)
 
 SECURITY: all tool paths resolve INSIDE cwd; traversal escapes are refused.
-run_command executes in cwd with a bounded timeout.
+run_command executes in cwd with a bounded timeout. run_command is intentionally
+shell=True with NO command allowlist/sandbox (audit S1) — restricting it would
+defeat the tool's purpose (running arbitrary tests/build commands). Its blast
+radius is bounded two ways instead: it runs inside an isolated worker cwd, and
+its own process env is credential-scrubbed by the spawn layer (litellm_spawn.py
+_scrubbed_env, audit S2) — an external/untrusted model driving this loop cannot
+read the Anthropic account's own API key or OAuth token through run_command,
+even though the shell itself remains unrestricted. A full command sandbox
+(seccomp/container) is a larger architecture change tracked separately.
 
 BILLING SAFETY: No Anthropic SDK imports. Uses the litellm library only.
 """

--- a/scripts/lib/provider_spawns/deepseek_harness_spawn.py
+++ b/scripts/lib/provider_spawns/deepseek_harness_spawn.py
@@ -67,10 +67,14 @@ MCP_OFF_CONFIG = '{"mcpServers":{}}'
 # Environment variable that holds the operator's own DeepSeek API key.
 DEEPSEEK_API_KEY_ENV = "DEEPSEEK_API_KEY"
 
-# Keys that must be absent from the final child env — specifically the production
-# Anthropic API key which would authenticate against api.anthropic.com and risk
-# account ban (constraint: deepseek-harness-subscription-blocked).
-_HARNESS_SCRUB_KEYS: frozenset = frozenset({"ANTHROPIC_API_KEY"})
+# Keys that must be absent from the final child env — the production Anthropic API key
+# AND the cached OAuth session token, either of which would authenticate the redirected
+# CLI against api.anthropic.com and risk account ban (constraint:
+# deepseek-harness-subscription-blocked). CLAUDE_CODE_OAUTH_TOKEN is scrubbed alongside
+# ANTHROPIC_API_KEY (audit S3) — an inherited OAuth token sitting next to the key-auth
+# ANTHROPIC_AUTH_TOKEN override is exactly the ambiguity the measured-safe key-auth
+# recipe is meant to eliminate.
+_HARNESS_SCRUB_KEYS: frozenset = frozenset({"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"})
 
 
 def resolve_harness_model(model: Optional[str] = None) -> str:

--- a/scripts/lib/provider_spawns/glm_harness_spawn.py
+++ b/scripts/lib/provider_spawns/glm_harness_spawn.py
@@ -43,7 +43,10 @@ DEFAULT_GLM_PROXY_URL = "http://localhost:4141"
 DEFAULT_GLM_PROXY_KEY = "sk-glm-harness-local"
 DEFAULT_GLM_HARNESS_MODEL = "glm-5.2"
 MCP_OFF_CONFIG = '{"mcpServers":{}}'
-_HARNESS_SCRUB_KEYS: frozenset = frozenset({"ANTHROPIC_API_KEY"})
+# CLAUDE_CODE_OAUTH_TOKEN scrubbed alongside ANTHROPIC_API_KEY (audit S3) — mirrors
+# deepseek_harness_spawn's _HARNESS_SCRUB_KEYS: an inherited OAuth token must not survive
+# into this redirected CLI either.
+_HARNESS_SCRUB_KEYS: frozenset = frozenset({"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"})
 
 
 def resolve_harness_model(model: Optional[str] = None) -> str:

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -13,6 +13,11 @@ Callers handle: lease/manifest/receipt/event-archive/retry.
 BILLING SAFETY: only subprocess.Popen([sys.executable, "-u", runner_path]) is
 invoked. No Anthropic SDK, no direct API calls. LiteLLM is isolated to
 _litellm_runner.py subprocess.
+
+CREDENTIAL SAFETY (audit S2): every Popen env for these subprocesses is built via
+_scrubbed_env(), which strips ANTHROPIC_API_KEY and CLAUDE_CODE_OAUTH_TOKEN after
+merging the parent env — an external/untrusted model driven through the agentic
+runner's run_command tool cannot read the Anthropic account's own credentials.
 """
 
 from __future__ import annotations
@@ -40,6 +45,24 @@ logger = logging.getLogger(__name__)
 _RUNNER_PATH = Path(__file__).resolve().parents[1] / "adapters" / "_litellm_runner.py"
 
 _TIER_STREAMING = 1
+
+# Audit S2: these lanes exclusively drive non-Anthropic models (DeepSeek, OpenRouter, GLM,
+# etc. via litellm) in a subprocess the external model itself can direct — the one-shot
+# runner via completion(), the agentic runner via its run_command tool (shell=True, no
+# allowlist; audit S1). Full os.environ inheritance would hand the Anthropic account's own
+# credentials to that subprocess, readable/exfiltratable by an external/untrusted model
+# through run_command. Neither key is ever needed by a litellm-routed child, so both are
+# scrubbed from every Popen env unconditionally (not caller-optional — there is no legitimate
+# case where a litellm child needs them).
+_CREDENTIAL_SCRUB_KEYS = ("ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN")
+
+
+def _scrubbed_env(extra_env: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Merge extra_env over the parent env, then strip Anthropic-account credentials."""
+    env = {**os.environ, **(extra_env or {})}
+    for _key in _CREDENTIAL_SCRUB_KEYS:
+        env.pop(_key, None)
+    return env
 
 
 # ---------------------------------------------------------------------------
@@ -216,7 +239,7 @@ def _start_litellm_subprocess(
     All subprocess-boundary errors convert to structured results; none are re-raised.
     """
     cmd = _build_litellm_cmd(runner_path)
-    env = {**os.environ, **(extra_env or {})}
+    env = _scrubbed_env(extra_env)
     cwd_str = str(cwd) if cwd is not None else None
 
     try:
@@ -560,7 +583,7 @@ def spawn_litellm_agentic(
     # (We can't reuse _start_litellm_subprocess: it pre-writes AND closes stdin, which
     # makes a later communicate() raise "flush of closed file".)
     cmd = _build_litellm_cmd(_runner)
-    env = {**os.environ, **(extra_env or {})}
+    env = _scrubbed_env(extra_env)
     try:
         proc = subprocess.Popen(
             cmd, stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,

--- a/tests/test_deepseek_harness_spawn.py
+++ b/tests/test_deepseek_harness_spawn.py
@@ -69,6 +69,12 @@ class TestHarnessHelpers:
         # Must NOT smuggle in an anthropic api key or OAuth marker.
         assert "ANTHROPIC_API_KEY" not in env
 
+    def test_harness_scrub_keys_cover_both_credential_forms(self):
+        """Audit S3: the scrub set must cover both the API key AND the OAuth session
+        token — an inherited CLAUDE_CODE_OAUTH_TOKEN would otherwise sit next to the
+        key-auth ANTHROPIC_AUTH_TOKEN override and reintroduce auth ambiguity."""
+        assert dh._HARNESS_SCRUB_KEYS == frozenset({"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"})
+
     def test_mcp_fully_off_cli_args(self):
         # --mcp-config is variadic; JSON value first, boolean terminator last so
         # the positional prompt is not slurped into the config list.
@@ -330,6 +336,55 @@ class TestFinalPopenEnvScrub:
             "ANTHROPIC_AUTH_TOKEN (DeepSeek own key) must be present"
         )
         assert env.get("ANTHROPIC_BASE_URL") == DEEPSEEK_ANTHROPIC_BASE_URL
+
+    def test_claude_code_oauth_token_absent_from_final_popen_env(self):
+        """Audit S3: a cached CLAUDE_CODE_OAUTH_TOKEN must not survive into the
+        redirected CLI either — only ANTHROPIC_API_KEY was scrubbed before this fix."""
+        import subprocess_adapter as sa
+
+        captured = {}
+
+        class _FakeProc:
+            pid = 9999
+            returncode = 0
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                return 0
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            proc = _FakeProc()
+            proc.stdout = MagicMock()
+            proc.stderr = MagicMock()
+            return proc
+
+        def _empty_events(self_adapter, terminal_id, **kw):
+            return iter([])
+
+        with patch.dict(
+            "os.environ",
+            {"CLAUDE_CODE_OAUTH_TOKEN": "oauth-real-production-session-token", "DEEPSEEK_API_KEY": _FAKE_KEY},
+        ), patch.object(sa.subprocess, "Popen", _fake_popen), \
+                patch("subprocess_adapter.os.setsid", lambda: None), \
+                patch.object(sa.SubprocessAdapter, "read_events_with_timeout", _empty_events):
+            spawn_deepseek_harness(
+                prompt="Reply OK.",
+                model=None,
+                dispatch_id="d-scrub-oauth-test",
+                terminal_id="T1",
+                api_key=_FAKE_KEY,
+            )
+
+        env = captured.get("env")
+        assert env is not None
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env, (
+            "CLAUDE_CODE_OAUTH_TOKEN must be scrubbed from the final Popen env "
+            "(present in os.environ but must not reach the DeepSeek child process)"
+        )
+        assert env.get("ANTHROPIC_AUTH_TOKEN") == _FAKE_KEY
 
 
 if __name__ == "__main__":

--- a/tests/test_glm_harness_spawn_credential_scrub.py
+++ b/tests/test_glm_harness_spawn_credential_scrub.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""test_glm_harness_spawn_credential_scrub.py — audit S3 regression.
+
+glm_harness_spawn.py mirrors deepseek_harness_spawn.py's account-safety contract (claude
+CLI redirected to a local litellm→OpenRouter proxy via key-auth env). It shared the same
+gap: _HARNESS_SCRUB_KEYS scrubbed ANTHROPIC_API_KEY but not CLAUDE_CODE_OAUTH_TOKEN, so a
+cached OAuth session token could survive into the redirected CLI. See
+test_deepseek_harness_spawn.py for the sibling coverage.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns import glm_harness_spawn as gh  # noqa: E402
+from provider_spawns.glm_harness_spawn import spawn_glm_harness  # noqa: E402
+
+
+class TestHarnessScrubKeys:
+    def test_scrub_keys_cover_both_credential_forms(self):
+        assert gh._HARNESS_SCRUB_KEYS == frozenset({"ANTHROPIC_API_KEY", "CLAUDE_CODE_OAUTH_TOKEN"})
+
+
+class TestFinalPopenEnvScrub:
+    """Verify both credential forms are absent from the final child env reaching the OS process."""
+
+    def _run_spawn(self, env_overrides: dict) -> dict:
+        import subprocess_adapter as sa
+
+        captured = {}
+
+        class _FakeProc:
+            pid = 9999
+            returncode = 0
+
+            def poll(self):
+                return 0
+
+            def wait(self, timeout=None):
+                return 0
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            proc = _FakeProc()
+            proc.stdout = MagicMock()
+            proc.stderr = MagicMock()
+            return proc
+
+        def _empty_events(self_adapter, terminal_id, **kw):
+            return iter([])
+
+        with patch.dict("os.environ", env_overrides), \
+                patch.object(gh, "_proxy_reachable", lambda url, timeout=3.0: True), \
+                patch.object(sa.subprocess, "Popen", _fake_popen), \
+                patch("subprocess_adapter.os.setsid", lambda: None), \
+                patch.object(sa.SubprocessAdapter, "read_events_with_timeout", _empty_events):
+            spawn_glm_harness(
+                prompt="Reply OK.",
+                model=None,
+                dispatch_id="d-glm-scrub-test",
+                terminal_id="T1",
+            )
+        return captured.get("env")
+
+    def test_anthropic_api_key_absent_from_final_popen_env(self):
+        env = self._run_spawn({"ANTHROPIC_API_KEY": "sk-ant-real-production-key"})
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert env.get("ANTHROPIC_AUTH_TOKEN") == gh._proxy_key()
+
+    def test_claude_code_oauth_token_absent_from_final_popen_env(self):
+        env = self._run_spawn({"CLAUDE_CODE_OAUTH_TOKEN": "oauth-real-production-session-token"})
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env.get("ANTHROPIC_AUTH_TOKEN") == gh._proxy_key()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_litellm_spawn_credential_scrub.py
+++ b/tests/test_litellm_spawn_credential_scrub.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""test_litellm_spawn_credential_scrub.py — audit S1/S2 regression.
+
+litellm_spawn.py drives external, non-Anthropic models (DeepSeek/OpenRouter/GLM) in a
+subprocess the model itself can direct via the agentic runner's run_command tool
+(shell=True, no allowlist — audit S1). Full os.environ inheritance would hand that
+subprocess the Anthropic account's own credentials, readable/exfiltratable by an
+external model. Covers both Popen sites:
+
+  - _start_litellm_subprocess (the one-shot spawn_litellm() path)
+  - spawn_litellm_agentic() (the agentic tool-use loop)
+
+and the shared _scrubbed_env() helper both sites now use.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+
+from provider_spawns import litellm_spawn as ls  # noqa: E402
+
+_LEAKED_ANTHROPIC_KEY = "sk-ant-real-production-key"
+_LEAKED_OAUTH_TOKEN = "oauth-real-production-session-token"
+
+
+def _leaked_credentials_env() -> dict:
+    return {
+        "ANTHROPIC_API_KEY": _LEAKED_ANTHROPIC_KEY,
+        "CLAUDE_CODE_OAUTH_TOKEN": _LEAKED_OAUTH_TOKEN,
+        "PATH": "/usr/bin",  # a benign var must survive the scrub
+    }
+
+
+class TestScrubbedEnvHelper:
+    def test_strips_both_credential_keys(self):
+        with patch.dict("os.environ", _leaked_credentials_env(), clear=True):
+            env = ls._scrubbed_env(None)
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["PATH"] == "/usr/bin"
+
+    def test_extra_env_cannot_reintroduce_credentials(self):
+        """A caller-supplied extra_env carrying either key must still be scrubbed."""
+        with patch.dict("os.environ", {}, clear=True):
+            env = ls._scrubbed_env({
+                "ANTHROPIC_API_KEY": _LEAKED_ANTHROPIC_KEY,
+                "CLAUDE_CODE_OAUTH_TOKEN": _LEAKED_OAUTH_TOKEN,
+                "DEEPSEEK_API_KEY": "sk-deepseek-own-key",
+            })
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+        assert env["DEEPSEEK_API_KEY"] == "sk-deepseek-own-key"
+
+
+class TestOneShotSpawnPopenEnv:
+    """spawn_litellm()'s underlying Popen call must never receive Anthropic credentials."""
+
+    def test_final_popen_env_excludes_anthropic_credentials(self):
+        captured = {}
+
+        class _FakeProc:
+            returncode = 0
+            stdin = MagicMock()
+            stdout = MagicMock()
+            stderr = MagicMock()
+
+            def wait(self, timeout=None):
+                return 0
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _FakeProc()
+
+        with patch.dict("os.environ", _leaked_credentials_env(), clear=True), \
+                patch("provider_spawns.litellm_spawn.subprocess.Popen", _fake_popen):
+            ls._start_litellm_subprocess(
+                runner_path="/fake/runner.py",
+                payload_json="{}",
+                extra_env=None,
+                cwd=None,
+            )
+
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+
+class TestAgenticSpawnPopenEnv:
+    """spawn_litellm_agentic()'s Popen call must never receive Anthropic credentials.
+
+    This is the higher-stakes site: the spawned runner gives the external model a
+    run_command tool that inherits this exact env (audit S1 + S2 combined).
+    """
+
+    def test_final_popen_env_excludes_anthropic_credentials(self):
+        captured = {}
+
+        class _FakeProc:
+            returncode = 0
+
+            def communicate(self, input=None, timeout=None):
+                return b"", b""
+
+            def wait(self, timeout=None):
+                return 0
+
+            def kill(self):
+                pass
+
+        def _fake_popen(cmd, **kwargs):
+            captured["env"] = kwargs.get("env")
+            return _FakeProc()
+
+        with patch.dict("os.environ", _leaked_credentials_env(), clear=True), \
+                patch("provider_spawns.litellm_spawn.subprocess.Popen", _fake_popen):
+            ls.spawn_litellm_agentic(
+                prompt="test",
+                model="anthropic/claude-sonnet-4-6",
+                dispatch_id="d-scrub-agentic",
+                terminal_id="T1",
+                cwd=".",
+            )
+
+        env = captured.get("env")
+        assert env is not None, "Popen must receive an explicit env dict"
+        assert "ANTHROPIC_API_KEY" not in env
+        assert "CLAUDE_CODE_OAUTH_TOKEN" not in env
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Remediates the security cluster (S1, S2, S3) from the 2026-06-27 repo audit's medium-severity backlog. These three findings share one root cause: subprocesses that drive external, non-Anthropic models (DeepSeek/OpenRouter/GLM via litellm, or the redirected `claude` CLI harnesses) inherited the full parent environment, including the Anthropic account's own `ANTHROPIC_API_KEY` and `CLAUDE_CODE_OAUTH_TOKEN`.

- **S2** — `litellm_spawn.py`'s two `Popen` sites (`_start_litellm_subprocess` for the one-shot lane, `spawn_litellm_agentic` for the agentic tool-use loop) built `env = {**os.environ, **(extra_env or {})}` with no scrubbing. The agentic runner gives the model a `run_command` tool (`shell=True`, no allowlist — **S1**), so a compromised or adversarially-prompted external model could read and exfiltrate the Anthropic credentials from its own process env.
- **S1** — `_litellm_agentic_runner.py`'s `run_command` tool has no command allowlist/sandbox by design (it must run arbitrary tests/build commands to be useful). A full sandbox is a larger architecture change, out of scope here. The credential-exfiltration path — the most severe practical consequence of S1 — is closed transitively by the S2 fix, since `run_command` inherits the runner process's own (now-scrubbed) env. This is documented explicitly in the module docstring rather than silently left open.
- **S3** — `deepseek_harness_spawn.py` and `glm_harness_spawn.py` (both redirect the `claude` CLI to a non-Anthropic endpoint via key-auth) each defined `_HARNESS_SCRUB_KEYS = frozenset({"ANTHROPIC_API_KEY"})`, missing `CLAUDE_CODE_OAUTH_TOKEN`. An inherited cached OAuth token sitting alongside the key-auth `ANTHROPIC_AUTH_TOKEN` override reintroduces exactly the auth ambiguity the measured-safe key-auth recipe (documented in both files) exists to eliminate. Both scrub sets now cover both credential forms.

## Changes

- `scripts/lib/provider_spawns/litellm_spawn.py` — new `_scrubbed_env()` helper (strips `ANTHROPIC_API_KEY` + `CLAUDE_CODE_OAUTH_TOKEN` unconditionally after merging `extra_env`), applied at both `Popen` call sites. Docstring updated.
- `scripts/lib/provider_spawns/deepseek_harness_spawn.py` — `_HARNESS_SCRUB_KEYS` extended to include `CLAUDE_CODE_OAUTH_TOKEN`.
- `scripts/lib/provider_spawns/glm_harness_spawn.py` — same fix applied (audit only called out the deepseek file; grepped for the sibling handler per the "same fix to all handlers" convention and found the identical gap).
- `scripts/lib/adapters/_litellm_agentic_runner.py` — docstring documents the S1 risk acceptance and how S2's fix bounds its blast radius.
- Tests: `tests/test_litellm_spawn_credential_scrub.py` (new), `tests/test_glm_harness_spawn_credential_scrub.py` (new), `tests/test_deepseek_harness_spawn.py` (extended) — assert the final `Popen` env excludes both credential keys even when present in `os.environ`, and that a caller-supplied `extra_env` cannot reintroduce them.

## Verification

```
python3 -m pytest tests/test_litellm_spawn_credential_scrub.py tests/test_glm_harness_spawn_credential_scrub.py \
  tests/test_deepseek_harness_spawn.py tests/test_litellm_spawn_byte_identity.py \
  tests/test_litellm_spawn_fail_closed.py tests/test_glm_harness_normalization.py -q
# 58 passed in 1.36s
```

`ruff check` on all changed files: clean (one pre-existing unrelated `F401` in `litellm_spawn.py` predates this change, not introduced by it).

`tests/test_litellm_agentic_runner.py::test_full_loop_writes_file_and_completes` fails on `main` before this PR too (confirmed via `git stash`) — pre-existing, unrelated to this change, not touched here.

## Test plan
- [x] New/extended tests pass locally
- [x] No regression in adjacent litellm/harness/spawn test suites
- [x] `ruff check` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)