### PR TITLE
feat(tmux-lane): fail loud on empty extraction before govern() reports done

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -720,6 +720,83 @@ class TmuxInteractiveDispatch:
             return None
         return {"input": inp, "output": out, "cache_read": 0}
 
+    def _fail_loud_on_empty_extraction(
+        self,
+        *,
+        dispatch_id: str,
+        receipt: "dict | None",
+        role: "str | None",
+        worktree_path: "Path | None",
+        base_sha: "str | None",
+        pane_tokens: "dict | None" = None,
+    ) -> "dict | None":
+        """Reject a worker's self-reported completion BEFORE govern() synthesizes a
+        report from it, when the worktree shows no evidence of work.
+
+        The tmux-lane twin of dispatch_envelope._fail_loud_on_empty_success — that
+        guard catches an empty PROVIDER completion at EXECUTE time, before GOVERN
+        ever sees it. Until this hook, the tmux lane's equivalent check
+        (phantom_guard) ran only INSIDE govern(), AFTER the unified report was
+        already synthesized and emitted with status="done" — the correction landed
+        as a second, later receipt (audit-honest, per phantom_guard's design), but
+        the report FILE itself kept claiming success. Running the identical
+        rejection here, before _govern_report(), means the report synthesized from
+        this receipt already reflects "failed" — no "done" report is ever emitted
+        for an empty extraction (dispatch 20260711-164747-provider-hardening).
+
+        Delegates to phantom_guard.record_phantom_if_any for BOTH the decision and
+        the corrective-receipt append (the same ndjson-visible signal the govern()
+        -time backstop produces), so the two chokepoints share one implementation
+        and never diverge. By the time govern()'s own post-hoc check runs, the
+        receipt it sees already carries status="failed" — its guard_at_govern
+        short-circuits on the non-completion status, so no second corrective
+        receipt is appended.
+
+        Never raises: on any internal error the receipt is returned unchanged
+        (fail-open, matching the guard's own abstain contract).
+        """
+        if receipt is None:
+            return receipt
+        try:
+            from phantom_guard import record_phantom_if_any  # noqa: PLC0415
+            _tok = pane_tokens or {}
+            verdict = record_phantom_if_any(
+                dispatch_id=dispatch_id,
+                role=role,
+                status=receipt.get("status"),
+                token_usage=(
+                    int(_tok.get("input", 0) or 0) + int(_tok.get("output", 0) or 0)
+                ) or None,
+                worktree_path=worktree_path,
+                base_sha=base_sha,
+                receipts_file=str(self._receipts_file),
+                state_dir=self._state_dir,
+            )
+        except Exception as exc:  # noqa: BLE001 — never block a real completion on a guard error
+            logger.error(
+                "interactive: fail-loud-on-empty-extraction guard errored dispatch=%s: %s",
+                dispatch_id, exc,
+            )
+            return receipt
+        if not verdict.is_phantom:
+            return receipt
+        logger.warning(
+            "interactive: fail-loud-on-empty-extraction REJECTED dispatch=%s — %s",
+            dispatch_id, verdict.reason,
+        )
+        self._emit_event(
+            "interactive_empty_extraction",
+            dispatch_id=dispatch_id,
+            label=str(receipt.get("terminal") or receipt.get("terminal_id") or ""),
+            reason=verdict.reason,
+            metadata={"original_status": receipt.get("status")},
+        )
+        downgraded = dict(receipt)
+        downgraded["status"] = "failed"
+        downgraded["phantom_rejected"] = True
+        downgraded["phantom_reason"] = verdict.reason
+        return downgraded
+
     def _build_completion_protocol(
         self, dispatch_id: str, label: str, model: str = "unknown", *, integrity=None
     ) -> str:
@@ -2275,14 +2352,24 @@ class TmuxInteractiveDispatch:
                 reason=f"receipt status={receipt.get('status')}",
                 metadata={"session": session, "status": receipt.get("status")},
             )
+            # Best-effort token usage parsed from the pane TUI counter (no usage API on
+            # the subscription lane) — used as a frontmatter fallback AND as
+            # corroborating detail for the fail-loud check below.
+            _pane_tokens = self._parse_token_usage_from_log(_raw_log[0])
+            # P0.3: fail loud on an empty extraction BEFORE trusting the worker's own
+            # "done" claim — see _fail_loud_on_empty_extraction docstring.
+            receipt = self._fail_loud_on_empty_extraction(
+                dispatch_id=dispatch_id,
+                receipt=receipt,
+                role=role,
+                worktree_path=worktree_handle.path if worktree_handle else None,
+                base_sha=worktree_handle.base_sha if worktree_handle else None,
+                pane_tokens=_pane_tokens,
+            )
             worker_succeeded = receipt is not None and receipt.get("status") not in (
                 "failed",
                 "blocked",
             )
-            # Best-effort token usage parsed from the pane TUI counter (no usage API on
-            # the subscription lane) — used only as a frontmatter fallback when the
-            # worker receipt carries none.
-            _pane_tokens = self._parse_token_usage_from_log(_raw_log[0])
             emitted_report = self._govern_report(
                 dispatch_id=dispatch_id,
                 terminal_id=label,

--- a/tests/test_tmux_fail_loud_empty_extraction.py
+++ b/tests/test_tmux_fail_loud_empty_extraction.py
@@ -1,0 +1,304 @@
+"""test_tmux_fail_loud_empty_extraction.py — dispatch 20260711-164747-provider-hardening.
+
+Covers TmuxInteractiveDispatch._fail_loud_on_empty_extraction: the tmux-lane twin of
+dispatch_envelope._fail_loud_on_empty_success (tests/test_dispatch_envelope_fail_loud.py).
+That guard catches an empty PROVIDER completion at EXECUTE time, before GOVERN. This one
+catches an empty WORKER extraction (a self-reported "done" receipt backed by no worktree
+diff) at the equivalent point in the tmux lane — BEFORE _govern_report() ever synthesizes
+a report from it — so an empty extraction never produces a "done" report/receipt in the
+first place, instead of only being corrected after the fact by the govern()-time
+phantom_guard backstop.
+
+Two layers:
+  1. Unit tests directly on _fail_loud_on_empty_extraction, mocking
+     phantom_guard.record_phantom_if_any (the decision + corrective-append is already
+     covered by test_phantom_guard.py / test_phantom_guard_inline.py — these tests isolate
+     the NEW wiring: does an empty extraction downgrade the receipt, emit an audit event,
+     and never raise; does a real extraction pass through unchanged).
+  2. End-to-end tests driving the real dispatch() loop (tmux mocked via FakeTmux, phantom
+     decision mocked via phantom_guard.record_phantom_if_any) to prove the wiring actually
+     changes the dispatch OUTCOME — result.success, result.receipt["status"], and
+     result.failure_reason — not just the isolated method's return value.
+"""
+from __future__ import annotations
+
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from runtime_coordination import get_connection, get_events, init_schema  # noqa: E402
+from tmux_interactive_dispatch import TmuxInteractiveDispatch  # noqa: E402
+from tmux_worktree import ReapResult, WorktreeHandle  # noqa: E402
+import phantom_guard as pg  # noqa: E402
+
+from test_tmux_interactive_dispatch import FakeTmux  # noqa: E402
+
+
+class _BaseCase(unittest.TestCase):
+    DISPATCH_ID = "20260711-failloud-test"
+
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.state_dir = Path(self._tmp.name)
+        init_schema(self.state_dir)
+        self.receipts_file = self.state_dir / "t0_receipts.ndjson"
+
+    def _make_lane(self, fake: FakeTmux) -> TmuxInteractiveDispatch:
+        return TmuxInteractiveDispatch(
+            self.state_dir,
+            runner=fake,
+            receipts_file=self.receipts_file,
+            project_root=self.state_dir,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 1: unit tests on _fail_loud_on_empty_extraction directly
+# ---------------------------------------------------------------------------
+
+
+class TestFailLoudOnEmptyExtractionUnit(_BaseCase):
+    def test_none_receipt_passthrough_no_guard_call(self):
+        """No receipt (deadline/timeout path) -> returned as-is; guard never invoked."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        with patch("phantom_guard.record_phantom_if_any") as mock_guard:
+            result = lane._fail_loud_on_empty_extraction(
+                dispatch_id=self.DISPATCH_ID,
+                receipt=None,
+                role="backend-developer",
+                worktree_path=None,
+                base_sha=None,
+            )
+        self.assertIsNone(result)
+        mock_guard.assert_not_called()
+
+    def test_empty_extraction_downgrades_receipt_to_failed(self):
+        """A phantom verdict must downgrade status to 'failed' and carry the reason —
+        this is the "empty -> loud-fail" case the dispatch asked for."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        receipt = {"status": "done", "dispatch_id": self.DISPATCH_ID, "terminal": "ephemeral"}
+
+        with patch(
+            "phantom_guard.record_phantom_if_any",
+            return_value=pg.PhantomVerdict(True, "PHANTOM: empty extraction, no diff"),
+        ) as mock_guard:
+            result = lane._fail_loud_on_empty_extraction(
+                dispatch_id=self.DISPATCH_ID,
+                receipt=receipt,
+                role="backend-developer",
+                worktree_path=self.state_dir / "wt",
+                base_sha="deadbeef",
+                pane_tokens={"input": 0, "output": 231, "cache_read": 0},
+            )
+
+        mock_guard.assert_called_once()
+        call_kwargs = mock_guard.call_args.kwargs
+        self.assertEqual(call_kwargs["dispatch_id"], self.DISPATCH_ID)
+        self.assertEqual(call_kwargs["status"], "done")
+        self.assertEqual(call_kwargs["token_usage"], 231)
+        self.assertEqual(call_kwargs["receipts_file"], str(self.receipts_file))
+        self.assertEqual(call_kwargs["state_dir"], self.state_dir)
+
+        self.assertEqual(result["status"], "failed")
+        self.assertTrue(result["phantom_rejected"])
+        self.assertIn("empty extraction", result["phantom_reason"])
+        # original receipt object must not be mutated in place (caller may reuse it)
+        self.assertEqual(receipt["status"], "done")
+
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        event_types = {e["event_type"] for e in events}
+        self.assertIn("interactive_empty_extraction", event_types)
+
+    def test_nonempty_extraction_passes_through_unchanged(self):
+        """A non-phantom verdict (real work present) -> receipt returned unchanged —
+        the "non-empty -> pass" case the dispatch asked for."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        receipt = {"status": "done", "dispatch_id": self.DISPATCH_ID}
+
+        with patch(
+            "phantom_guard.record_phantom_if_any",
+            return_value=pg.PhantomVerdict(False, "non-empty worktree diff — work is present"),
+        ):
+            result = lane._fail_loud_on_empty_extraction(
+                dispatch_id=self.DISPATCH_ID,
+                receipt=receipt,
+                role="backend-developer",
+                worktree_path=self.state_dir / "wt",
+                base_sha="deadbeef",
+            )
+
+        self.assertEqual(result["status"], "done")
+        self.assertNotIn("phantom_rejected", result)
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        event_types = {e["event_type"] for e in events}
+        self.assertNotIn("interactive_empty_extraction", event_types)
+
+    def test_review_role_never_downgraded(self):
+        """A review role's completion is exempt (phantom_guard's own rule, delegated
+        through unchanged) — record_phantom_if_any handles this; verify it still
+        propagates a non-phantom verdict correctly for a reviewer receipt."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        receipt = {"status": "done", "dispatch_id": self.DISPATCH_ID}
+
+        with patch(
+            "phantom_guard.record_phantom_if_any",
+            return_value=pg.PhantomVerdict(False, "review role — a verdict, not a diff"),
+        ) as mock_guard:
+            result = lane._fail_loud_on_empty_extraction(
+                dispatch_id=self.DISPATCH_ID,
+                receipt=receipt,
+                role="plan-reviewer",
+                worktree_path=None,
+                base_sha=None,
+            )
+        self.assertEqual(mock_guard.call_args.kwargs["role"], "plan-reviewer")
+        self.assertEqual(result["status"], "done")
+
+    def test_guard_error_is_non_fatal_receipt_passthrough(self):
+        """A guard-internal exception must never block a real completion — the receipt
+        is returned unchanged, matching the guard's own fail-open/abstain contract."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        receipt = {"status": "done", "dispatch_id": self.DISPATCH_ID}
+
+        with patch(
+            "phantom_guard.record_phantom_if_any",
+            side_effect=RuntimeError("db locked"),
+        ):
+            result = lane._fail_loud_on_empty_extraction(
+                dispatch_id=self.DISPATCH_ID,
+                receipt=receipt,
+                role="backend-developer",
+                worktree_path=self.state_dir / "wt",
+                base_sha="deadbeef",
+            )
+        self.assertEqual(result["status"], "done")
+
+
+# ---------------------------------------------------------------------------
+# Layer 2: end-to-end through dispatch()
+# ---------------------------------------------------------------------------
+
+
+class _WorktreeCase(_BaseCase):
+    def _make_handle(self) -> WorktreeHandle:
+        wt_path = self.state_dir / "worktrees" / f"dispatch-{self.DISPATCH_ID}"
+        wt_path.mkdir(parents=True, exist_ok=True)
+        return WorktreeHandle(
+            path=wt_path,
+            branch=f"dispatch/{self.DISPATCH_ID}",
+            base_sha="deadbeef" * 5,
+            base_ref="origin/main",
+            dispatch_id=self.DISPATCH_ID,
+        )
+
+    def _fast_dispatch(self, lane: TmuxInteractiveDispatch, **overrides):
+        import os
+
+        kwargs = dict(
+            role="backend-developer",
+            model="sonnet",
+            deadline_seconds=5.0,
+            poll_interval=0.01,
+            warmup_timeout=0.5,
+            warmup_poll_interval=0.01,
+            isolated_worktree=True,
+        )
+        kwargs.update(overrides)
+        _env = {
+            "VNX_TMUX_PASTE_SETTLE_SECONDS": "0",
+            "VNX_TMUX_SUBMIT_RETRY_DELAY": "0",
+            "VNX_TMUX_SUBMIT_VERIFY_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_POLL": "0.02",
+        }
+        with patch.dict(os.environ, _env):
+            return lane.dispatch("Do the thing.", self.DISPATCH_ID, **kwargs)
+
+
+class TestEndToEndEmptyExtractionFailsLoud(_WorktreeCase):
+    def test_worker_done_with_empty_extraction_fails_the_dispatch(self):
+        """A worker self-reports 'done' but the phantom decision says empty extraction:
+        dispatch() must return success=False, receipt status downgraded to 'failed',
+        and the failure surfaced in failure_reason — never a silent 'done' outcome."""
+        handle = self._make_handle()
+        fake = FakeTmux(
+            receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID, receipt_status="done"
+        )
+        lane = self._make_lane(fake)
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle), \
+             patch("tmux_interactive_dispatch.classify", return_value="clean"), \
+             patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)), \
+             patch(
+                 "phantom_guard.record_phantom_if_any",
+                 return_value=pg.PhantomVerdict(
+                     True, "PHANTOM: status='done' claims completion but the worktree diff is EMPTY"
+                 ),
+             ):
+            result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success, "empty extraction must not report success")
+        self.assertIsNotNone(result.receipt)
+        self.assertEqual(result.receipt["status"], "failed")
+        self.assertTrue(result.receipt.get("phantom_rejected"))
+        self.assertIn("worker_status: failed", result.failure_reason)
+
+    def test_worker_done_with_real_extraction_still_succeeds(self):
+        """Guard rail: a real (non-empty) extraction must not be false-flagged —
+        dispatch() proceeds to success exactly as before this change."""
+        handle = self._make_handle()
+        fake = FakeTmux(
+            receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID, receipt_status="done"
+        )
+        lane = self._make_lane(fake)
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle), \
+             patch("tmux_interactive_dispatch.classify", return_value="clean"), \
+             patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)), \
+             patch(
+                 "phantom_guard.record_phantom_if_any",
+                 return_value=pg.PhantomVerdict(False, "non-empty worktree diff — work is present"),
+             ):
+            result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
+        self.assertEqual(result.receipt["status"], "done")
+        self.assertNotIn("phantom_rejected", result.receipt)
+
+    def test_unresolvable_worktree_abstains_real_phantom_guard(self):
+        """No mocking of phantom_guard at all — the REAL guard runs against a
+        WorktreeHandle pointing at a plain (non-git) directory, which
+        compute_worktree_diff cannot diff. It must ABSTAIN (never false-reject),
+        preserving the pre-existing dispatch outcome for every test/caller that
+        does not set up a real git worktree."""
+        handle = self._make_handle()  # plain mkdir, not a git repo
+        fake = FakeTmux(
+            receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID, receipt_status="done"
+        )
+        lane = self._make_lane(fake)
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle), \
+             patch("tmux_interactive_dispatch.classify", return_value="clean"), \
+             patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)):
+            result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
+        self.assertEqual(result.receipt["status"], "done")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- The tmux-spawn lane's phantom check (`phantom_guard`) previously ran only INSIDE `govern()`, after a "done" unified report was already synthesized and emitted — the correction landed as a second, later corrective receipt, but the report file itself kept claiming success.
- Adds `TmuxInteractiveDispatch._fail_loud_on_empty_extraction`, called right after the worker's completion receipt is observed and BEFORE `_govern_report()` synthesizes anything. It delegates to `phantom_guard.record_phantom_if_any` (same decision + ndjson-visible corrective-receipt append the govern()-time backstop already uses), so both chokepoints share one implementation and can never diverge.
- When the extraction is empty (worker self-reports `done` but the worktree diff is empty), the receipt is downgraded to `status="failed"` before the report is emitted — no "done" report/receipt is ever produced for an empty extraction. This is the tmux-lane twin of the provider lane's existing `dispatch_envelope._fail_loud_on_empty_success`.
- Review roles, the `VNX_OVERRIDE_PHANTOM_GUARD=1` escape hatch, and the abstain-on-unresolvable-diff behavior are all inherited unchanged from `phantom_guard`.

## Changes
- `scripts/lib/tmux_interactive_dispatch.py`: new `_fail_loud_on_empty_extraction` method; wired into `dispatch()` right after the worker receipt is observed, before `_govern_report()`.
- `tests/test_tmux_fail_loud_empty_extraction.py`: new test file — unit tests on the method directly (empty→loud-fail, non-empty→pass, review-role passthrough, guard-error fail-open) plus end-to-end `dispatch()` tests proving the wiring changes the actual outcome (`result.success`, `result.receipt["status"]`, `result.failure_reason`), including a regression test that the real (unmocked) guard abstains safely on a non-git worktree.

## Verification
```
python3 -m pytest tests/test_tmux_fail_loud_empty_extraction.py tests/test_tmux_interactive_dispatch.py tests/test_tmux_interactive_dispatch_metadata.py tests/test_phantom_guard.py tests/test_phantom_guard_inline.py tests/test_dispatch_envelope_fail_loud.py tests/test_dispatch_govern.py -q
```
→ 265 passed.

Pre-existing unrelated failures confirmed via `git stash` (same 22 failures on unmodified `main`, `MagicMock is not JSON serializable` in `test_tmux_adapter.py` / `test_provider_dispatch_governance_integration.py` fixtures) — untouched by this change.

## Test plan
- [x] New unit tests for `_fail_loud_on_empty_extraction` (empty → downgraded to failed + event emitted; non-empty → unchanged; review role passthrough; guard error → fail-open passthrough)
- [x] End-to-end `dispatch()` tests: empty extraction → `success=False`, `receipt["status"]=="failed"`; real extraction → unchanged success path; unmocked guard on non-git worktree → abstains (no regression for existing worktree tests)
- [x] Full related suite green (265 passed), no regressions vs. pre-existing failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)