### PR TITLE
fix(kimi): deep-fix #763 info-bug — role-gate content-block text + dedupe stale handler

### DIFF
--- a/scripts/lib/canonical_event.py
+++ b/scripts/lib/canonical_event.py
@@ -387,80 +387,19 @@ def _from_kimi_event(
     dispatch_id: str,
     terminal_id: str,
 ) -> CanonicalEvent:
-    """Map a raw Kimi CLI stream-json event dict to a CanonicalEvent (Tier-1)."""
-    def make(et: str, d: Dict[str, Any]) -> CanonicalEvent:
-        return CanonicalEvent(
-            dispatch_id=dispatch_id, terminal_id=terminal_id,
-            provider="kimi", event_type=et, data=d, observability_tier=1,
-        )
+    """Map a raw Kimi CLI stream-json event dict to a CanonicalEvent (Tier-1).
 
-    event_type = (raw.get("event_type") or raw.get("type") or "")
-
-    if event_type in ("assistant_text", "text"):
-        return make("text", {"text": str(raw.get("content", ""))})
-    if event_type == "tool_call":
-        return make("tool_use", {
-            "name": str(raw.get("name", "")),
-            "input": raw.get("input", {}),
-            "id": str(raw.get("id", "")),
-        })
-    if event_type == "tool_result":
-        return make("tool_result", {
-            "tool_use_id": str(raw.get("tool_call_id", "")),
-            "content": str(raw.get("output", "")),
-        })
-    if event_type == "usage_complete":
-        usage = raw.get("usage") or {}
-        token_count = {
-            "input_tokens": int((usage.get("prompt_tokens") or 0)),
-            "output_tokens": int((usage.get("completion_tokens") or 0)),
-            "cache_creation_tokens": 0,
-            "cache_read_tokens": 0,
-        }
-        return make("text", {"text": "", "token_count": token_count})
-    if event_type == "complete":
-        return make("complete", {})
-    if event_type == "error":
-        msg = raw.get("message") or raw.get("error") or ""
-        return make("error", {"message": str(msg) if msg else str(raw)[:200]})
-
-    # Kimi CLI Wire Protocol v1.26+ camelCase event types
-    if event_type == "TurnBegin":
-        return make("text", {"text": ""})
-
-    if event_type == "StepBegin":
-        return make("text", {"text": ""})
-
-    if event_type == "ContentPart":
-        return make("text", {"text": str(raw.get("content") or raw.get("text") or "")})
-
-    if event_type == "ThinkPart":
-        return make("thinking", {"text": str(raw.get("content") or raw.get("text") or "")})
-
-    if event_type == "TextPart":
-        return make("text", {"text": str(raw.get("text") or raw.get("content") or "")})
-
-    if event_type == "StatusUpdate":
-        tc_raw = raw.get("token_count") or raw.get("usage") or {}
-        token_count = {
-            "input_tokens": int(tc_raw.get("input_tokens") or tc_raw.get("prompt_tokens") or 0),
-            "output_tokens": int(tc_raw.get("output_tokens") or tc_raw.get("completion_tokens") or 0),
-            "cache_creation_tokens": int(tc_raw.get("cache_creation_tokens") or 0),
-            "cache_read_tokens": int(tc_raw.get("cache_read_tokens") or 0),
-        }
-        return make("text", {"text": "", "token_count": token_count})
-
-    if event_type == "TurnEnd":
-        return make("complete", {})
-
-    # Unknown event type — map to "info" (non-fatal passthrough).
-    # An unrecognized informational event must not flip the dispatch status to
-    # failure: returning "info" lets the consumer log it and move on without
-    # adding it to errors_captured or setting result.error.
-    return make("info", {
-        "raw_type": event_type,
-        "raw": str(raw)[:300],
-    })
+    Delegates to provider_spawns.kimi_spawn.normalize_kimi_event, the single
+    source of truth for Kimi event parsing. This function used to carry its
+    own full copy of the parsing logic; that copy silently missed the #763
+    1.44.0 content-block fix (no role/content[] handling, no quota/auth
+    detection) because nothing kept the two in sync. Delegating removes the
+    duplicate so a future kimi-cli format change only needs one fix, not two.
+    Import is deferred (not module-level) to avoid a circular import with
+    kimi_spawn.py, which imports CanonicalEvent from this module.
+    """
+    from provider_spawns.kimi_spawn import normalize_kimi_event
+    return normalize_kimi_event(raw, terminal_id, dispatch_id)
 
 
 def _from_ollama_event(

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -135,6 +135,9 @@ def normalize_kimi_event(raw: dict, terminal_id: str, dispatch_id: str) -> Canon
        "tool_calls": [...]}                 -> text (+ reasoning, tool_calls)
       {"role": "tool", "content": [{"type": "text", "text": "..."}],
        "tool_call_id": "..."}               -> tool_result
+      {"role": "user"|"system"|other, "content": [...]}  -> info (non-fatal;
+       NEVER extracted as answer text — guards against an echoed prompt/
+       transcript turn being concatenated into completion_text)
 
     Below: legacy ``event_type`` shapes, retained for backward compatibility.
 
@@ -190,23 +193,42 @@ def normalize_kimi_event(raw: dict, terminal_id: str, dispatch_id: str) -> Canon
     role = raw.get("role")
     content = raw.get("content")
     if not event_type and isinstance(content, list) and isinstance(role, str):
-        text, reasoning = _extract_content_blocks(content)
         if role == "tool":
+            text, reasoning = _extract_content_blocks(content)
             return make("tool_result", {
                 "tool_use_id": str(raw.get("tool_call_id", "")),
                 "content": text or reasoning,
             })
-        # assistant (and any other agent role): the answer text is the payload;
-        # reasoning + tool_calls ride along for observability but never become
-        # completion text. Intermediate tool-call turns legitimately carry an
-        # empty text block — only the final assistant message contributes text.
-        data: Dict[str, Any] = {"text": text}
-        if reasoning:
-            data["reasoning"] = reasoning
-        tool_calls = raw.get("tool_calls")
-        if tool_calls:
-            data["tool_calls"] = tool_calls
-        return make("text", data)
+        if role == "assistant":
+            # The answer text is the payload; reasoning + tool_calls ride along
+            # for observability but never become completion text. Intermediate
+            # tool-call turns legitimately carry an empty text block — only the
+            # final assistant message contributes text.
+            text, reasoning = _extract_content_blocks(content)
+            data: Dict[str, Any] = {"text": text}
+            if reasoning:
+                data["reasoning"] = reasoning
+            tool_calls = raw.get("tool_calls")
+            if tool_calls:
+                data["tool_calls"] = tool_calls
+            return make("text", data)
+        # Any other role (e.g. "user" — an echoed prompt/transcript turn, or
+        # "system") must NEVER be extracted as answer text. Deep-fix for the
+        # #763 info-bug follow-up: the original content-block detection keyed
+        # only on "isinstance(role, str)" and treated every non-"tool" role as
+        # assistant output, so a CLI that echoes the user's own turn back into
+        # the stream (common for transcript/session-resume modes) would have
+        # its prompt silently concatenated into completion_text. Route to
+        # "info" instead: non-fatal, does not corrupt completion_text, and
+        # still counts toward saw_stream_output so fail-loud still fires if no
+        # real assistant text ever arrives.
+        logger.debug(
+            "kimi_spawn: content-block role=%r is not assistant/tool — mapping to info", role
+        )
+        return make("info", {
+            "raw_type": f"role:{role}",
+            "raw": str(raw)[:300],
+        })
 
     if event_type in ("assistant_text", "text"):
         return make("text", {"text": str(raw.get("content", ""))})

--- a/tests/test_canonical_event.py
+++ b/tests/test_canonical_event.py
@@ -254,3 +254,77 @@ class TestFromLegacy:
         assert ev.observability_tier == 2
         assert ev.dispatch_id == ""
         assert ev.terminal_id == ""
+
+
+# ---------------------------------------------------------------------------
+# MAJOR-2 regression — kimi-deepfix-major2
+#
+# canonical_event.py used to carry its own full copy of Kimi event parsing
+# (_from_kimi_event) that never received the #763 1.44.0 content-block fix:
+# no role/content[] handling, no quota/auth detection. Any caller reaching
+# kimi events through CanonicalEvent.from_provider_event("kimi", ...) instead
+# of provider_spawns.kimi_spawn.normalize_kimi_event() directly would hit the
+# original info-bug (1.44.0 content-block messages silently mapped to "info",
+# losing all answer text) even after #763 shipped. _from_kimi_event now
+# delegates to normalize_kimi_event as the single source of truth; these
+# tests lock that in so the two entry points can never drift apart again.
+# ---------------------------------------------------------------------------
+
+class TestFromProviderEventKimiDelegatesToNormalizeKimiEvent:
+    def test_144_content_block_extracts_text_via_from_provider_event(self):
+        raw = {
+            "role": "assistant",
+            "content": [
+                {"type": "think", "think": "reasoning"},
+                {"type": "text", "text": "the answer"},
+            ],
+        }
+        ev = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert ev.event_type == "text"
+        assert ev.data["text"] == "the answer"
+        assert ev.provider == "kimi"
+
+    def test_144_tool_role_maps_to_tool_result_via_from_provider_event(self):
+        raw = {
+            "role": "tool",
+            "content": [{"type": "text", "text": "tool output"}],
+            "tool_call_id": "tc-1",
+        }
+        ev = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert ev.event_type == "tool_result"
+        assert ev.data["content"] == "tool output"
+
+    def test_echoed_user_role_not_extracted_as_text_via_from_provider_event(self):
+        """The role-gate deep-fix must apply through this entry point too."""
+        raw = {"role": "user", "content": [{"type": "text", "text": "echoed prompt"}]}
+        ev = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert ev.event_type == "info"
+        assert "text" not in ev.data
+
+    def test_quota_error_detected_via_from_provider_event(self):
+        raw = {"status": 403, "message": "quota exceeded"}
+        ev = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert ev.event_type == "error"
+        assert ev.data["reason"] == "quota_or_auth"
+
+    def test_legacy_event_type_still_works_via_from_provider_event(self):
+        raw = {"event_type": "assistant_text", "content": "legacy string"}
+        ev = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert ev.event_type == "text"
+        assert ev.data["text"] == "legacy string"
+
+    def test_matches_normalize_kimi_event_directly(self):
+        """Same raw event through both entry points must produce identical data."""
+        import sys as _sys
+        from pathlib import Path as _Path
+
+        lib_dir = str(_Path(__file__).resolve().parent.parent / "scripts" / "lib")
+        if lib_dir not in _sys.path:
+            _sys.path.insert(0, lib_dir)
+        from provider_spawns.kimi_spawn import normalize_kimi_event
+
+        raw = {"role": "assistant", "content": [{"type": "text", "text": "parity check"}]}
+        direct = normalize_kimi_event(raw, "T1", "d-001")
+        via_dispatch = CanonicalEvent.from_provider_event("kimi", raw, "d-001", "T1")
+        assert direct.event_type == via_dispatch.event_type
+        assert direct.data == via_dispatch.data

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -256,6 +256,148 @@ class TestNormalizeKimiEvent(unittest.TestCase):
         self.assertEqual(event.observability_tier, 1)
 
 
+# ---------------------------------------------------------------------------
+# MAJOR-2 regression suite — kimi-deepfix-major2
+#
+# #763 fixed the immediate fail-loud gap (unknown event_type -> "info" ->
+# silently-empty completion_text reported as success). These tests cover the
+# deeper content-block edge cases #763 did not: a role != "assistant"/"tool"
+# content-block message (e.g. an echoed "user" turn) must never be extracted
+# as answer text, and malformed content[] entries must degrade gracefully
+# instead of crashing or corrupting completion_text.
+# ---------------------------------------------------------------------------
+
+class TestKimiDeepfixMajor2ContentBlockRoleGate(unittest.TestCase):
+    """Unit-level: normalize_kimi_event must gate text extraction on role=='assistant'.
+
+    Bug: the pre-fix content-block branch treated ANY string role that wasn't
+    "tool" as an assistant turn ("assistant (and any other agent role)"), so a
+    kimi-cli stream that echoes the user's own prompt back as a
+    {"role": "user", "content": [...]} line — common in transcript/session-
+    resume output — would have that echoed prompt silently concatenated into
+    completion_text alongside (or instead of) the real answer.
+    """
+
+    def test_user_role_content_block_is_not_extracted_as_text(self):
+        raw = {
+            "role": "user",
+            "content": [{"type": "text", "text": "please review this PR"}],
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "info")
+        self.assertNotIn("text", event.data)
+
+    def test_system_role_content_block_is_not_extracted_as_text(self):
+        raw = {
+            "role": "system",
+            "content": [{"type": "text", "text": "you are a helpful assistant"}],
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "info")
+        self.assertNotIn("text", event.data)
+
+    def test_unrecognized_role_content_block_maps_to_info_not_text(self):
+        raw = {"role": "developer", "content": [{"type": "text", "text": "hint"}]}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "info")
+
+    def test_assistant_role_still_extracts_text(self):
+        """Control: the fix must not regress the actual assistant path."""
+        raw = {"role": "assistant", "content": [{"type": "text", "text": "the answer"}]}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "text")
+        self.assertEqual(event.data["text"], "the answer")
+
+    def test_tool_role_still_maps_to_tool_result(self):
+        """Control: the fix must not regress the tool-role path."""
+        raw = {
+            "role": "tool",
+            "content": [{"type": "text", "text": "tool output"}],
+            "tool_call_id": "tc-1",
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "tool_result")
+        self.assertEqual(event.data["content"], "tool output")
+
+    # --- defensive reads on malformed content-block shapes -----------------
+
+    def test_content_none_on_assistant_message_does_not_crash_or_fabricate_text(self):
+        raw = {"role": "assistant", "content": None}
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        # Falls through to the unknown-event-type fallback: non-fatal, no
+        # crash, and critically no fabricated text.
+        self.assertEqual(event.event_type, "info")
+
+    def test_content_list_with_non_dict_entries_ignored_not_crashed(self):
+        raw = {
+            "role": "assistant",
+            "content": ["a bare string block", 42, None, {"type": "text", "text": "real answer"}],
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.event_type, "text")
+        self.assertEqual(event.data["text"], "real answer")
+
+    def test_content_block_missing_type_key_ignored(self):
+        raw = {
+            "role": "assistant",
+            "content": [{"text": "no type field"}, {"type": "text", "text": "kept"}],
+        }
+        event = normalize_kimi_event(raw, "T1", "dispatch-01")
+        self.assertEqual(event.data["text"], "kept")
+
+
+class TestKimiDeepfixMajor2EndToEnd(unittest.TestCase):
+    """Integration-level: an echoed user turn in the stream must never leak into
+    completion_text, even when it arrives alongside a real assistant answer.
+    """
+
+    def _run_with_events(self, events: list, returncode: int = 0) -> KimiSpawnResult:
+        data = b"".join((json.dumps(e) + "\n").encode() for e in events)
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            try:
+                os.write(write_fd, data)
+            finally:
+                os.close(write_fd)
+
+        writer_thread = threading.Thread(target=_writer, daemon=True)
+        writer_thread.start()
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = returncode
+        fake_proc.poll.return_value = returncode
+        fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=returncode)
+        fake_proc.kill = MagicMock()
+
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi("prompt", dispatch_id="d1", terminal_id="T1")
+        finally:
+            writer_thread.join(timeout=5)
+        return result
+
+    def test_echoed_user_turn_does_not_leak_into_completion_text(self):
+        events = [
+            {"role": "user", "content": [{"type": "text", "text": "please review this PR"}]},
+            {
+                "role": "assistant",
+                "content": [
+                    {"type": "think", "think": "reviewing now"},
+                    {"type": "text", "text": "VERDICT: approve"},
+                ],
+            },
+        ]
+        result = self._run_with_events(events, returncode=0)
+        self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.completion_text, "VERDICT: approve")
+        self.assertNotIn("please review this PR", result.completion_text)
+
+
 class TestSpawnKimiSubprocess(unittest.TestCase):
     def test_returns_127_when_cli_missing(self):
         with patch("subprocess.Popen", side_effect=FileNotFoundError("kimi not found")):


### PR DESCRIPTION
## Summary

Deep-fix for the kimi #763 info-bug, per the `kimi-deepfix-major2` track (1.0.1 roadmap item). #763 fixed the immediate fail-loud gap for the kimi-cli 1.44.0 content-block stream-json format; this PR closes two content-block edge cases it left uncovered, both instances of the same "info-bug" class (an unhandled shape silently mapped to `"info"` instead of being handled correctly or failing loud):

1. **Role-gate bug** in `normalize_kimi_event()` (`kimi_spawn.py`): the content-block branch treated *any* string `role` other than `"tool"` as an assistant turn. A kimi-cli stream that echoes the user's own turn back as `{"role": "user", "content": [...]}` (common in transcript/session-resume output) would have that echoed prompt silently concatenated into `completion_text`. Text extraction is now gated strictly on `role == "assistant"`; any other role maps to `"info"` (non-fatal, never corrupts `completion_text`, still counts toward `saw_stream_output` so fail-loud still fires correctly).

2. **Stale duplicate handler** in `canonical_event.py`: `_from_kimi_event()` carried its own full copy of Kimi event parsing that never received the #763 1.44.0 content-block fix at all — no `role`/`content[]` handling, no quota/auth detection. Any caller reaching kimi events through `CanonicalEvent.from_provider_event("kimi", ...)` instead of `provider_spawns.kimi_spawn.normalize_kimi_event()` directly would still hit the *original* pre-#763 bug. Now delegates to `normalize_kimi_event` as the single source of truth (deferred import to dodge the circular dependency), removing ~85 lines of duplicated logic that could drift again.

## Changes

- `scripts/lib/provider_spawns/kimi_spawn.py` — restrict content-block text extraction to `role == "assistant"`; route `"user"`/`"system"`/other roles to `"info"`.
- `scripts/lib/canonical_event.py` — `_from_kimi_event()` now delegates to `provider_spawns.kimi_spawn.normalize_kimi_event()` instead of maintaining a parallel copy.
- `tests/test_kimi_spawn.py` — MAJOR-2 regression suite: role-gate unit tests, defensive malformed-content-block tests (`content=None`, non-dict entries, missing `"type"` key), end-to-end `spawn_kimi()` test proving an echoed user turn never leaks into `completion_text`.
- `tests/test_canonical_event.py` — delegation-parity suite proving `from_provider_event("kimi", ...)` and `normalize_kimi_event()` can no longer drift apart (role-gate applies through both entry points, quota detection, legacy event_type shapes, byte-identical output on the same raw event).

All new tests run at unit/mock level — no live kimi call required (the kimi lane may be down at runtime per the dispatch instruction).

## Verification

```
python3 -m pytest tests/test_kimi_spawn.py tests/test_kimi_spawn_camelcase.py tests/test_kimi_wrapper.py \
  tests/test_gate_kimi_ff849_fixes.py tests/test_canonical_event.py tests/test_canonical_event_shape_conformance.py \
  tests/test_provider_dispatch_kimi.py tests/test_wave7_kimi_smoke.py tests/test_provider_spawn_frontmatter.py \
  tests/test_constraint_enforcer_kimi_valid.py -q
# 293 passed in 2.02s
```

Full repo suite (`pytest tests/ -q --ignore=tests/f39`) run in background; the only pre-existing failure found (`tests/f39/test_replay_level1.py::test_level1_scenario[receipt_with_stale_terminal_lease]`) was confirmed present on `main` before this change too (unrelated — invokes a live `claude -p` replay, known-flaky per prior audit) and is excluded from this PR's scope.

## Open Items

None — smallest coherent slice of the track. Deferred (per ROADMAP.yaml `provider-hardening`, 1.1): generalizing fail-loud + CI-canary + version-pin across all providers, and any speculative handling of content-block shapes not confirmed by a real kimi-cli capture (e.g. Anthropic-native `tool_use` blocks nested inside `content[]` — the current 1.44.0 capture puts tool calls in a separate top-level `tool_calls` field, per the original #763 capture).

🤖 Generated with [Claude Code](https://claude.com/claude-code)