### PR TITLE
feat(openrouter-arbitrary): proxy-gated OpenAI-compat lane skeleton

### DIFF
--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -34,8 +34,10 @@ from ndjson_io import fsync_fileno
 
 logger = logging.getLogger(__name__)
 
+# The third (model-alias) segment allows "/" — the openrouter-arbitrary lane passes
+# raw OpenRouter "vendor/model" paths as the alias (e.g. litellm:openrouter:openai/gpt-4o-mini).
 _PROVIDER_RE = re.compile(
-    r"^(claude|codex|gemini|kimi|deepseek-harness|glm-harness|litellm(:[a-z][a-z0-9_-]*(:[a-z][a-z0-9_.-]*)?)?|local-gemma)$"
+    r"^(claude|codex|gemini|kimi|deepseek-harness|glm-harness|litellm(:[a-z][a-z0-9_-]*(:[a-z][a-z0-9_./-]*)?)?|local-gemma)$"
 )
 
 
@@ -44,7 +46,7 @@ def _validate_provider(provider: str) -> None:
     if not _PROVIDER_RE.match(provider or ""):
         raise ValueError(
             f"Invalid provider {provider!r}. "
-            "Must match ^(claude|codex|gemini|kimi|deepseek-harness|glm-harness|litellm(:[a-z][a-z0-9_-]*(:[a-z][a-z0-9_.-]*)?)?|local-gemma)$"
+            "Must match ^(claude|codex|gemini|kimi|deepseek-harness|glm-harness|litellm(:[a-z][a-z0-9_-]*(:[a-z][a-z0-9_./-]*)?)?|local-gemma)$"
         )
 
 

--- a/scripts/lib/provider_costs.py
+++ b/scripts/lib/provider_costs.py
@@ -64,6 +64,9 @@ _PROVIDER_RATES: dict[tuple[str, str], tuple[float, float, bool]] = {
     ("litellm:moonshot", "kimi-k2-0905-preview"):  (0.0, 0.0,  True),
     ("litellm:zai", "glm-5.1-default"):        (0.07,  0.14,  False),
     ("litellm:ollama", "llama3"):              (0.0,   0.0,   True),
+    # openrouter-arbitrary lane (PR-1 skeleton) — the one proven model
+    # (openrouter/openai/gpt-4o-mini); OpenRouter pass-through pricing.
+    ("litellm:openrouter", "gpt-4o-mini"):     (0.15,  0.60,  False),
 }
 
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -64,6 +64,10 @@ _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "zai": "openrouter/z-ai/glm-5",
     "ollama": "ollama/llama3",
     "anthropic": "anthropic/claude-sonnet-4-6",
+    # openrouter-arbitrary lane (PR-1 skeleton): the ONE OpenAI-compat model this
+    # slice proves out end-to-end. Any other OpenRouter model path can be dispatched
+    # via --provider litellm:openrouter:<vendor>/<model> — see _resolve_openrouter_model.
+    "openrouter": "openrouter/openai/gpt-4o-mini",
 }
 
 # Env vars required per sub-provider (fast-fail before subprocess spawn)
@@ -71,6 +75,7 @@ _SUB_PROVIDER_KEY_REQS: dict = {
     "deepseek": "DEEPSEEK_API_KEY",
     "moonshot": "MOONSHOT_API_KEY",
     "zai": "OPENROUTER_API_KEY",
+    "openrouter": "OPENROUTER_API_KEY",
 }
 
 # GLM model names that are LEGACY — rejected on zai dispatch (PR-7.3)
@@ -81,6 +86,7 @@ _SUB_PROVIDER_DEFAULT_ALIAS: dict = {
     "deepseek": "deepseek-v4-pro",
     "moonshot": "kimi-k2-0905-default",
     "zai": "glm-5.1-default",
+    "openrouter": "gpt-4o-mini-default",
 }
 
 
@@ -716,6 +722,11 @@ def _constraint_registry_check_enabled(args: argparse.Namespace, provider: str) 
     if not (provider.startswith("litellm:") or provider == "litellm"):
         return True
     base_sub, model_alias = _litellm_parts(provider)
+    if base_sub == "openrouter":
+        # Arbitrary-model lane by design — not curated against the wave7 provider
+        # registry (see _resolve_openrouter_model). OPENROUTER_API_KEY
+        # (_SUB_PROVIDER_KEY_REQS) is the real pre-flight gate for this lane.
+        return False
     if os.environ.get("VNX_LITELLM_MODEL", "") or model_alias:
         return True
     if getattr(args, "model", None) and args.model != "sonnet":
@@ -839,7 +850,9 @@ def _build_parser() -> argparse.ArgumentParser:
         help=(
             "Provider to use for dispatch. "
             "Accepted values: claude, codex, gemini, kimi, litellm:<model>. "
-            "Example: --provider claude, --provider kimi, --provider litellm:deepseek-v4-pro"
+            "Example: --provider claude, --provider kimi, --provider litellm:deepseek-v4-pro, "
+            "--provider litellm:openrouter (proxy-gated OpenAI-compat lane; optional "
+            "arbitrary model via litellm:openrouter:<vendor>/<model>, requires OPENROUTER_API_KEY)"
         ),
     )
     # Forward all existing subprocess_dispatch.py flags verbatim.
@@ -1384,6 +1397,26 @@ def _resolve_zai_model(model_alias: "str | None" = None) -> str:
     return next(iter(cfg.models.values())).litellm_name
 
 
+def _resolve_openrouter_model(model_alias: "str | None" = None) -> str:
+    """Resolve the litellm model path for the openrouter-arbitrary lane.
+
+    Unlike deepseek/moonshot/zai, this sub-provider is deliberately NOT curated
+    against the wave7 provider registry — that is the "arbitrary" in
+    openrouter-arbitrary. ``model_alias`` (from ``--provider
+    litellm:openrouter:<alias>``) is treated as a raw OpenRouter model path and
+    passed straight through, prefixed with "openrouter/" when the caller omitted
+    it. The one sentinel alias ``_SUB_PROVIDER_DEFAULT_ALIAS["openrouter"]``
+    (and an absent alias) resolve to the single model this skeleton PR proves out
+    end-to-end (_LITELLM_SUB_PROVIDER_DEFAULTS["openrouter"]).
+    """
+    alias = (model_alias or "").strip()
+    if not alias or alias == _SUB_PROVIDER_DEFAULT_ALIAS["openrouter"]:
+        return _LITELLM_SUB_PROVIDER_DEFAULTS["openrouter"]
+    if alias.startswith("openrouter/"):
+        return alias
+    return f"openrouter/{alias}"
+
+
 def _dispatch_litellm(args: argparse.Namespace) -> int:
     """Route to spawn_litellm for litellm-provider dispatches (PR-4.6.5).
 
@@ -1432,6 +1465,8 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         if model_alias:
             _validate_zai_model_not_legacy(model_alias)
         model = env_model or _resolve_zai_model(model_alias)
+    elif base_sub == "openrouter":
+        model = env_model or _resolve_openrouter_model(model_alias)
     elif env_model:
         model = env_model
     elif base_sub and base_sub in _LITELLM_SUB_PROVIDER_DEFAULTS:

--- a/scripts/lib/providers/behavior_contracts.py
+++ b/scripts/lib/providers/behavior_contracts.py
@@ -114,6 +114,21 @@ CONTRACTS: Dict[str, BehaviorContract] = {
         max_context_tokens=200_000,
         max_output_tokens=8192,
     ),
+    "litellm:openrouter:gpt-4o-mini-default": BehaviorContract(
+        # openrouter-arbitrary lane (PR-1 skeleton): the one OpenAI-compat model
+        # proven end-to-end. Any other model routed via
+        # --provider litellm:openrouter:<vendor>/<model> proceeds uncontracted
+        # (no KeyError — see provider_dispatch._dispatch_litellm).
+        provider="litellm",
+        sub_provider="openrouter",
+        supports_streaming=True,
+        supports_tool_calls=True,
+        tool_call_shape="openai_tools",
+        cache_control_supported=False,
+        audit_shape="canonical_event",
+        max_context_tokens=128_000,
+        max_output_tokens=16_384,
+    ),
     "litellm:zai:glm-5.1-default": BehaviorContract(
         provider="litellm",
         sub_provider="zai",

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -56,9 +56,13 @@ class TestAllKnownLanesHaveContracts:
         assert missing == [], f"Lanes in routing_policy.yaml missing contracts: {missing}"
 
     def test_ten_contracts_registered(self):
-        """Registry has exactly 10 contracts (all current lanes)."""
-        assert len(CONTRACTS) == 10, (
-            f"Expected 10 contracts, got {len(CONTRACTS)}. "
+        """Registry has exactly 11 contracts (all current lanes).
+
+        Bumped from 10 -> 11 for the openrouter-arbitrary lane skeleton
+        (litellm:openrouter:gpt-4o-mini-default — the one proven model).
+        """
+        assert len(CONTRACTS) == 11, (
+            f"Expected 11 contracts, got {len(CONTRACTS)}. "
             f"Keys: {sorted(CONTRACTS.keys())}"
         )
 

--- a/tests/test_provider_dispatch_openrouter_arbitrary.py
+++ b/tests/test_provider_dispatch_openrouter_arbitrary.py
@@ -1,0 +1,280 @@
+#!/usr/bin/env python3
+"""test_provider_dispatch_openrouter_arbitrary.py — openrouter-arbitrary lane skeleton.
+
+Track: openrouter-arbitrary (OpenRouter-arbitrary / OpenAI-compat proxy-gated lane
+class). This PR is the minimal seam: --provider litellm:openrouter[:<vendor>/<model>]
+routed through the existing litellm dispatch machinery, proving out ONE OpenAI-compat
+model (openai/gpt-4o-mini via OpenRouter) end-to-end.
+
+Covers:
+- registration: openrouter is a fast-fail key-req'd, defaulted litellm sub-provider
+- _resolve_openrouter_model: sentinel/absent alias -> the one proven model;
+  any other alias is raw OpenRouter pass-through (the "arbitrary" part)
+- _build_lane_key: default alias vs. arbitrary alias
+- behavior contract: the one proven model has a registered contract (openai_tools);
+  an arbitrary model proceeds uncontracted (no KeyError)
+- _dispatch_litellm fast-fails (EX_USAGE) without OPENROUTER_API_KEY
+- _dispatch_litellm resolves model + lane correctly for bare and aliased provider
+  strings and passes them through to spawn_litellm
+- constraint pre-flight: NOT registry-curated (arbitrary by design), via=openrouter
+  clears cleanly, no blocking violation
+- cost rate table resolves real pricing for the one proven model
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import provider_dispatch as pd  # noqa: E402
+from provider_dispatch import _build_lane_key, _resolve_openrouter_model  # noqa: E402
+from providers.behavior_contracts import get_contract  # noqa: E402
+from provider_spawns.litellm_spawn import LiteLLMSpawnResult  # noqa: E402
+
+_FAKE_KEY = "sk-or-test-key-1234567890abcd"
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+class TestRegistration:
+    def test_openrouter_requires_openrouter_api_key(self):
+        assert pd._SUB_PROVIDER_KEY_REQS["openrouter"] == "OPENROUTER_API_KEY"
+
+    def test_openrouter_has_a_default_model(self):
+        assert pd._LITELLM_SUB_PROVIDER_DEFAULTS["openrouter"] == "openrouter/openai/gpt-4o-mini"
+
+    def test_openrouter_default_alias_is_registered(self):
+        assert pd._SUB_PROVIDER_DEFAULT_ALIAS["openrouter"] == "gpt-4o-mini-default"
+
+
+# ---------------------------------------------------------------------------
+# _resolve_openrouter_model — arbitrary pass-through
+# ---------------------------------------------------------------------------
+
+class TestResolveOpenrouterModel:
+    def test_no_alias_resolves_to_proven_default(self):
+        assert _resolve_openrouter_model(None) == "openrouter/openai/gpt-4o-mini"
+
+    def test_blank_alias_resolves_to_proven_default(self):
+        assert _resolve_openrouter_model("  ") == "openrouter/openai/gpt-4o-mini"
+
+    def test_sentinel_default_alias_resolves_to_proven_default(self):
+        assert _resolve_openrouter_model("gpt-4o-mini-default") == "openrouter/openai/gpt-4o-mini"
+
+    def test_arbitrary_alias_is_prefixed_with_openrouter(self):
+        assert (
+            _resolve_openrouter_model("anthropic/claude-3-haiku")
+            == "openrouter/anthropic/claude-3-haiku"
+        )
+
+    def test_already_prefixed_alias_is_not_double_prefixed(self):
+        assert (
+            _resolve_openrouter_model("openrouter/anthropic/claude-3-haiku")
+            == "openrouter/anthropic/claude-3-haiku"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _build_lane_key
+# ---------------------------------------------------------------------------
+
+class TestBuildLaneKey:
+    def test_default_alias(self):
+        assert _build_lane_key("openrouter", None) == "litellm:openrouter:gpt-4o-mini-default"
+
+    def test_arbitrary_alias(self):
+        assert (
+            _build_lane_key("openrouter", "anthropic/claude-3-haiku")
+            == "litellm:openrouter:anthropic/claude-3-haiku"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Behavior contract: proven model is contracted, arbitrary models are not
+# ---------------------------------------------------------------------------
+
+class TestBehaviorContract:
+    def test_proven_default_has_openai_tools_contract(self):
+        contract = get_contract("litellm:openrouter:gpt-4o-mini-default")
+        assert contract.tool_call_shape == "openai_tools"
+        assert contract.provider == "litellm"
+        assert contract.sub_provider == "openrouter"
+
+    def test_arbitrary_model_has_no_contract(self):
+        with pytest.raises(KeyError):
+            get_contract("litellm:openrouter:some/unregistered-model")
+
+
+# ---------------------------------------------------------------------------
+# Constraint pre-flight
+# ---------------------------------------------------------------------------
+
+class TestConstraintPreflight:
+    def _args(self, provider="litellm:openrouter", model="sonnet"):
+        ns = MagicMock()
+        ns.provider = provider
+        ns.model = model
+        ns.terminal_id = "T1"
+        ns.role = "backend-developer"
+        return ns
+
+    def test_registry_check_disabled_bare(self):
+        assert pd._constraint_registry_check_enabled(self._args(), "litellm:openrouter") is False
+
+    def test_registry_check_disabled_with_alias(self):
+        provider = "litellm:openrouter:anthropic/claude-3-haiku"
+        assert pd._constraint_registry_check_enabled(self._args(provider), provider) is False
+
+    def test_constraint_model_bare_resolves_to_default(self):
+        model = pd._constraint_model_for_provider(self._args(), "litellm:openrouter")
+        assert model == "openrouter/openai/gpt-4o-mini"
+
+    def test_constraint_model_with_alias_returns_alias(self):
+        provider = "litellm:openrouter:anthropic/claude-3-haiku"
+        model = pd._constraint_model_for_provider(self._args(provider), provider)
+        assert model == "anthropic/claude-3-haiku"
+
+    def test_check_constraints_does_not_raise_for_openrouter(self):
+        """The lane is arbitrary-by-design — no forbid_route entry should block it."""
+        args = self._args()
+        args.instruction = "Reply OK."
+        args.dispatch_id = "test-openrouter-preflight"
+        with patch.dict("os.environ", {"OPENROUTER_API_KEY": _FAKE_KEY}):
+            violations = pd._check_constraints(args, "litellm:openrouter")
+        blocking = [v for v in violations if v.severity == "blocking"]
+        assert blocking == []
+
+
+# ---------------------------------------------------------------------------
+# _dispatch_litellm — fast-fail + routing
+# ---------------------------------------------------------------------------
+
+class TestDispatchLitellmFastFail:
+    def test_missing_openrouter_key_returns_ex_usage(self):
+        argv = [
+            "--provider", "litellm:openrouter",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-openrouter-nokey",
+            "--instruction", "echo hello",
+        ]
+        with patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("OPENROUTER_API_KEY", None)
+            rc = pd.main(argv)
+        assert rc == pd._EX_USAGE
+
+
+class TestDispatchLitellmRouting:
+    def test_bare_provider_resolves_default_model_and_lane(self):
+        captured_kwargs: dict = {}
+
+        def fake_spawn(**kwargs):
+            captured_kwargs.update(kwargs)
+            return LiteLLMSpawnResult(
+                returncode=0, completion_text="ok", events_written=1,
+                session_id=None, timed_out=False,
+            )
+
+        argv = [
+            "--provider", "litellm:openrouter",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-openrouter-bare",
+            "--instruction", "echo hello",
+        ]
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", fake_spawn), \
+                patch.dict("os.environ", {"OPENROUTER_API_KEY": _FAKE_KEY}):
+            rc = pd.main(argv)
+
+        assert rc == 0
+        assert captured_kwargs["model"] == "openrouter/openai/gpt-4o-mini"
+        assert captured_kwargs["lane"] == "litellm:openrouter:gpt-4o-mini-default"
+        assert captured_kwargs["tool_call_shape"] == "openai_tools"
+        assert captured_kwargs["sub_provider"] == "openrouter"
+
+    def test_arbitrary_alias_resolves_raw_passthrough_model(self):
+        """Proves the 'arbitrary' part: any OpenRouter model path can be dispatched
+        without a code change, at the cost of running uncontracted (no KeyError)."""
+        captured_kwargs: dict = {}
+
+        def fake_spawn(**kwargs):
+            captured_kwargs.update(kwargs)
+            return LiteLLMSpawnResult(
+                returncode=0, completion_text="ok", events_written=1,
+                session_id=None, timed_out=False,
+            )
+
+        argv = [
+            "--provider", "litellm:openrouter:anthropic/claude-3-haiku",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-openrouter-arbitrary",
+            "--instruction", "echo hello",
+        ]
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", fake_spawn), \
+                patch.dict("os.environ", {"OPENROUTER_API_KEY": _FAKE_KEY}):
+            rc = pd.main(argv)
+
+        assert rc == 0
+        assert captured_kwargs["model"] == "openrouter/anthropic/claude-3-haiku"
+        assert captured_kwargs["lane"] == "litellm:openrouter:anthropic/claude-3-haiku"
+        assert captured_kwargs["tool_call_shape"] is None  # uncontracted, not an error
+
+    def test_env_model_override_wins_over_alias(self):
+        captured_kwargs: dict = {}
+
+        def fake_spawn(**kwargs):
+            captured_kwargs.update(kwargs)
+            return LiteLLMSpawnResult(
+                returncode=0, completion_text="ok", events_written=1,
+                session_id=None, timed_out=False,
+            )
+
+        argv = [
+            "--provider", "litellm:openrouter:anthropic/claude-3-haiku",
+            "--terminal-id", "T1",
+            "--dispatch-id", "test-openrouter-envoverride",
+            "--instruction", "echo hello",
+        ]
+
+        with patch("provider_spawns.litellm_spawn.spawn_litellm", fake_spawn), \
+                patch.dict("os.environ", {
+                    "OPENROUTER_API_KEY": _FAKE_KEY,
+                    "VNX_LITELLM_MODEL": "openrouter/google/gemini-2.5-flash",
+                }):
+            rc = pd.main(argv)
+
+        assert rc == 0
+        assert captured_kwargs["model"] == "openrouter/google/gemini-2.5-flash"
+
+
+# ---------------------------------------------------------------------------
+# Cost rate table — the one proven model resolves real pricing
+# ---------------------------------------------------------------------------
+
+class TestCostResolution:
+    def test_proven_default_resolves_pricing(self):
+        from provider_costs import resolve_cost_usd
+
+        cost = resolve_cost_usd(
+            "litellm:openrouter", "openrouter/openai/gpt-4o-mini",
+            input_tokens=1_000_000, output_tokens=1_000_000,
+        )
+        assert cost == pytest.approx(0.75)
+
+    def test_compute_cost_end_to_end_via_rate_table_fallback(self):
+        """_compute_cost falls back to the rate table when the wave7 registry has
+        no 'openrouter' section (by design — this lane is not registry-curated)."""
+        cost = pd._compute_cost(
+            "litellm:openrouter", "openrouter/openai/gpt-4o-mini",
+            {"input": 1_000_000, "output": 1_000_000},
+        )
+        assert cost == pytest.approx(0.75)


### PR DESCRIPTION
## Summary
- Minimal skeleton for the OpenRouter-arbitrary / OpenAI-compat proxy-gated lane class, per dispatch `20260711-164747-openrouter-arbitrary`.
- Routes ONE OpenAI-compat model (`openai/gpt-4o-mini` via OpenRouter) end-to-end through the existing `litellm` sub-provider machinery in `provider_dispatch.py` (`--provider litellm:openrouter`).
- The seam is generic: any other OpenRouter model path can be dispatched via `--provider litellm:openrouter:<vendor>/<model>` today, without further code changes (raw pass-through, uncontracted/best-effort cost). Only ONE model is registered with a behavior contract + cost pricing in this PR, per dispatch scope.

## Changes
- `scripts/lib/provider_dispatch.py`: registers `openrouter` as a litellm sub-provider (`_LITELLM_SUB_PROVIDER_DEFAULTS`, `_SUB_PROVIDER_KEY_REQS` → `OPENROUTER_API_KEY` fast-fail, `_SUB_PROVIDER_DEFAULT_ALIAS`); adds `_resolve_openrouter_model()` (sentinel/absent alias → the one proven model, any other alias → raw `openrouter/<alias>` pass-through); wires the `_dispatch_litellm` model-resolution branch; exempts `openrouter` from wave7-registry curation in `_constraint_registry_check_enabled` (this lane is arbitrary by design, not registry-bounded); updates `--provider` help text.
- `scripts/lib/providers/behavior_contracts.py`: adds `litellm:openrouter:gpt-4o-mini-default` contract (`openai_tools` shape).
- `scripts/lib/provider_costs.py`: adds a rate-table entry for the proven model (`$0.15`/`$0.60` per Mtok).
- `scripts/lib/governance_emit.py`: widens `_PROVIDER_RE` to allow `/` in the model-alias segment of the provider string — required so `litellm:openrouter:<vendor>/<model>` receipts pass validation (was previously rejected, caught by a new test in this PR).
- `tests/test_provider_dispatch_openrouter_arbitrary.py` (new, 23 tests): registration, model resolution (default + arbitrary pass-through), lane-key construction, contract lookup, constraint pre-flight (registry exemption + no blocking violations), `OPENROUTER_API_KEY` fast-fail, end-to-end `main()` routing (bare provider, arbitrary alias, `VNX_LITELLM_MODEL` env override), and cost resolution.
- `tests/test_behavior_contracts.py`: bumps the exact-contract-count assertion 10 → 11 (intentional, mirrors the pattern used for every prior lane addition).

## Verification
- `python3 -m pytest tests/test_provider_dispatch_openrouter_arbitrary.py -v` → 23 passed.
- `python3 -m pytest tests/test_provider_dispatch_openrouter_arbitrary.py tests/test_governance_emit.py tests/test_behavior_contracts.py tests/test_provider_costs.py tests/test_cost_table.py tests/test_provider_dispatch_entry.py tests/test_provider_dispatch_contract_integration.py tests/test_constraint_enforcer.py -q` → 195 passed, 2 pre-existing failures (`test_routing_policy_lanes_covered`, `TestWorkersSonnetPinned::test_t2_with_sonnet_allowed`) confirmed unrelated by diffing against a clean checkout of `main`.
- Broader sweep (`provider_dispatch*`, `litellm*`, `governance_emit*`, `wave7_*smoke`, `dispatch_envelope*`, `observability_linkage`, `pool_manager_real_spawn`, `behavior_contracts`) → 339 passed, 21 pre-existing failures, all independently reproduced on a clean `main` checkout (same failure set, same messages) — zero regressions attributable to this change.
- No shell files touched (`bash -n` not applicable).

## Test plan
- [x] Unit tests for `_resolve_openrouter_model` (default/sentinel/arbitrary alias, prefix idempotency)
- [x] `_build_lane_key` for default vs. arbitrary alias
- [x] Behavior contract present for the proven model; absent (KeyError) for arbitrary models
- [x] Constraint pre-flight: registry check disabled for `openrouter`, no blocking violations
- [x] `OPENROUTER_API_KEY` fast-fail returns `EX_USAGE`
- [x] End-to-end `main()` routing for bare provider, arbitrary alias, and `VNX_LITELLM_MODEL` override
- [x] Cost rate-table resolution for the proven model

## Open Items
- Only ONE model (`openai/gpt-4o-mini`) has a registered behavior contract + cost pricing, per dispatch scope ("do NOT add many providers... just build the seam + prove it with one model"). Other OpenRouter models work via raw pass-through but run uncontracted and with `cost_usd=None`.
- NOT wired into the structured staging door (`dispatch_spec.Provider` closed enum, `dispatch_cli.py`, `dispatch_bridge.py`, `routing_policy.yaml`) — intentionally out of scope per the dispatch instruction ("do NOT wire it into routing_policy broadly"). The lane is reachable today only via direct `provider_dispatch.py --provider litellm:openrouter[...]` invocation, not via `vnx dispatch`'s governed staging flow. A follow-up track would add the `Provider.LITELLM_OPENROUTER` enum member + door wiring once the lane has proven itself.
- No live OpenRouter API call was exercised (no network credentials in this environment) — verification is at the seam/unit level (spawn is mocked); an operator with `OPENROUTER_API_KEY` should do one live smoke dispatch before relying on this in production.
- **Operational note, unrelated to this diff's content but discovered while working this dispatch:** `git stash` is unsafe in this multi-worktree setup — `refs/stash` is shared across ALL worktrees of this repo (confirmed via `git rev-parse --git-common-dir`), and with several sibling dispatch worktrees active concurrently, my own `git stash`/`git stash pop` collided with another worker's stash mid-session. I recovered by re-applying my own edits from memory (verified via diff — byte-identical to the pre-incident version) and left the other worker's files (`scripts/lib/dispatch_govern.py`, `scripts/lib/subprocess_dispatch_internals/recovery.py`, `tests/test_dispatch_govern.py`) untouched and uncommitted in this worktree so as not to destroy their work; I also backed them up to `/private/tmp/claude-501/.../scratchpad/foreign-worker-backup/` as a safety net. Recommend never using `git stash` for before/after test comparisons in shared-repo worktrees — use `git worktree` or a throwaway branch instead.