### PR TITLE
feat(dispatch): wire subprocess lane onto shared dispatch_govern.govern()

### DIFF
--- a/docs/core/PROVIDER_LANES.md
+++ b/docs/core/PROVIDER_LANES.md
@@ -140,11 +140,28 @@ report body is what the worker actually wrote. `govern()` always runs as a
 backstop: if the worker did not produce a usable report, it emits an honest
 minimal body marked `contract_status="synthesized"` rather than leaving a gap.
 
+**claude-subprocess lane: `govern()` wiring is opt-in (`VNX_SHARED_GOVERN=1`,
+default off).** `dispatch_govern.py`'s own module docstring names both the tmux
+and subprocess lanes as intended callers, but only tmux was wired end to end.
+Behind the flag, `deliver_with_recovery` routes both the success and the
+budget-exhausted-failure path through the same `govern()` used by tmux — including
+git-diff synthesis (`base_sha` = the pre-dispatch commit SHA) and schema-complete
+frontmatter — instead of the legacy stub-only `_ensure_unified_report` (success) or
+no report at all (final failure). `govern()`'s authored-report lookup also checks
+the legacy subprocess worker filename (`<dispatch_id>_report.md`, from
+`receipt_writer._ensure_unified_report`'s docstring convention) as a fallback
+alongside the canonical `<dispatch_id>.md`. Receipt writing (`_write_receipt`) is
+unchanged in both flag states. Flag default is off pending a burn-in period;
+flipping it on is a follow-up, not part of this slice.
+
 **provider_dispatch lanes (codex, gemini, kimi, deepseek-harness, litellm): the
 report is synthesized.** These lanes do not author a report. `_emit_governance`
 builds the unified report from the captured `completion_text` of the spawn
 result. The report body is a synthesis of what the process printed, not a
-document the worker chose to write.
+document the worker chose to write. This lane (and the `claude_headless` lane
+in `dispatch_envelope.py`, which still has its own local `_prepare()`/`_govern()`
+rather than the shared `dispatch_prepare`/`dispatch_govern` modules) remain
+un-migrated — tracked as follow-up slices of the same Option B parity work.
 
 **The known gap.** An analysis-only dispatch on a provider_dispatch lane (review,
 audit, no commit) can yield an empty report body. The synthesized report is

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -362,6 +362,12 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     dispatch_id = spec.dispatch_id
     reports_dir = Path(spec.data_dir) / "unified_reports"
     worker_report_path = reports_dir / f"{dispatch_id}.md"
+    # Legacy subprocess-lane worker convention (receipt_writer._ensure_unified_report)
+    # instructs workers to write "<dispatch_id>_report.md" — a naming divergence from
+    # the "<dispatch_id>.md" convention govern() and the tmux lane use. Checked as a
+    # fallback so authored-report detection works for the subprocess lane too, without
+    # requiring every existing worker template to be renamed in this same PR.
+    legacy_report_path = reports_dir / f"{dispatch_id}_report.md"
 
     # Determine enforcement mode: tmux=shadow, subprocess=enforce (when flag on).
     contract_validate = os.environ.get("VNX_CONTRACT_VALIDATE", "shadow").strip().lower()
@@ -371,9 +377,13 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     body: Optional[str] = None
     contract_status = "synthesized"
 
-    if worker_report_path.exists():
+    candidate_path = (
+        worker_report_path if worker_report_path.exists()
+        else (legacy_report_path if legacy_report_path.exists() else None)
+    )
+    if candidate_path is not None:
         try:
-            candidate = worker_report_path.read_text(encoding="utf-8")
+            candidate = candidate_path.read_text(encoding="utf-8")
             # plan-reviewer role: the worker writes a free-form review that ends with
             # a vnx-plan-verdict fence.  It intentionally lacks ## Changes / ## Verification
             # / ## Open Items — applying standard contract validation would always fail and

--- a/scripts/lib/subprocess_dispatch_internals/recovery.py
+++ b/scripts/lib/subprocess_dispatch_internals/recovery.py
@@ -7,6 +7,7 @@ that ``unittest.mock.patch("subprocess_dispatch.X")`` intercepts the call.
 from __future__ import annotations
 
 import logging
+import os
 import sys
 import time
 from datetime import datetime, timezone
@@ -18,6 +19,90 @@ from subprocess_dispatch_internals.runtime_overrides import apply_runtime_overri
 from provider_dispatch import _extract_token_usage, _compute_cost
 
 logger = logging.getLogger(__name__)
+
+
+def _shared_govern_enabled() -> bool:
+    """VNX_SHARED_GOVERN gate for the subprocess lane (default off — safe ship).
+
+    dispatch_govern.py's own docstring names tmux AND subprocess as its intended
+    callers; the tmux lane already routes through govern() unconditionally. This
+    flag lets the subprocess lane opt in the same way VNX_SHARED_PREPARE gated its
+    PREPARE-side adoption before tmux made it unconditional.
+    """
+    return os.environ.get("VNX_SHARED_GOVERN", "0").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _govern_report(
+    *,
+    dispatch_id: str,
+    terminal_id: str,
+    instruction: str,
+    status: str,
+    dispatch_start_ts: str,
+    pre_sha: str,
+    model: "str | None",
+    role: "str | None",
+    pr_id: "str | None",
+    token_usage: "dict | None",
+    cost_usd: "float | None",
+) -> None:
+    """Emit the unified report via the shared dispatch_govern.govern() step.
+
+    Mirrors the tmux lane's GOVERN wiring. govern() checks unified_reports/ for a
+    worker-authored report (including the legacy "<id>_report.md" subprocess-lane
+    filename) and falls back to a git-diff synthesis (base_sha=pre_sha) with
+    schema-complete frontmatter and contract validation — a strict upgrade over the
+    prior stub-only ``_ensure_unified_report`` (success path) / no report at all
+    (failure path).
+
+    Receipt writing is untouched: ``_write_receipt`` still runs unconditionally
+    after this call. Passing a non-None ``GovernRaw.receipt`` makes govern()'s
+    ``ensure_receipt`` fallback a no-op, so there is no double-receipt-append.
+
+    govern() is documented to never raise; only the import is defended here.
+    """
+    import subprocess_dispatch as _sd
+    try:
+        from dispatch_govern import GovernRaw, GovernSpec, govern  # noqa: PLC0415
+    except ImportError as exc:
+        logger.error(
+            "deliver_with_recovery: dispatch_govern import failed for dispatch=%s: %s",
+            dispatch_id, exc,
+        )
+        return
+
+    state_dir = _sd._default_state_dir()
+    repo_cwd = Path(__file__).resolve().parents[3]
+    try:
+        started = datetime.fromisoformat(dispatch_start_ts)
+        duration_seconds = (datetime.now(timezone.utc) - started).total_seconds()
+    except ValueError:
+        duration_seconds = 0.0
+
+    spec = GovernSpec(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        instruction=instruction,
+        data_dir=state_dir.parent,
+        state_dir=state_dir,
+        pr_id=pr_id,
+        base_sha=pre_sha,
+        worktree_path=repo_cwd,
+        model=model,
+        role=role,
+    )
+    raw = GovernRaw(
+        receipt={
+            "status": status,
+            "model": model,
+            "token_usage": token_usage,
+            "cost_usd": cost_usd,
+        },
+        duration_seconds=duration_seconds,
+    )
+    govern(spec, raw, lane="subprocess")
 
 
 
@@ -143,6 +228,8 @@ def _handle_success(
     model: "str | None" = None,
     pr_id: "str | None" = None,
     mandate_id: "str | None" = None,
+    instruction: str = "",
+    role: "str | None" = None,
 ) -> None:
     """Run the success branch: write receipt, feedback, outcome capture, cleanup."""
     import subprocess_dispatch as _sd
@@ -183,7 +270,15 @@ def _handle_success(
         project_id=_cost_pid,
     )
 
-    _sd._ensure_unified_report(dispatch_id, terminal_id, "done")
+    if _shared_govern_enabled():
+        _govern_report(
+            dispatch_id=dispatch_id, terminal_id=terminal_id, instruction=instruction,
+            status="done", dispatch_start_ts=dispatch_start_ts, pre_sha=pre_sha,
+            model=model, role=role, pr_id=pr_id,
+            token_usage=token_usage, cost_usd=cost_usd,
+        )
+    else:
+        _sd._ensure_unified_report(dispatch_id, terminal_id, "done")
     _sd._write_receipt(
         dispatch_id, terminal_id, "done",
         event_count=sub_result.event_count,
@@ -243,6 +338,8 @@ def _handle_final_failure(
     lease_generation: "int | None",
     model: "str | None" = None,
     pr_id: "str | None" = None,
+    instruction: str = "",
+    role: "str | None" = None,
 ) -> None:
     """Run the budget-exhausted failure branch: stash, receipt, decay, cleanup."""
     import subprocess_dispatch as _sd
@@ -255,6 +352,17 @@ def _handle_final_failure(
             manifest_paths=manifest_paths,
         )
     token_usage, cost_usd = _resolve_token_usage_and_cost(dispatch_id, sub_result, model)
+    if _shared_govern_enabled():
+        # Genuinely new coverage: pre-wiring, the subprocess lane emitted no unified
+        # report at all on the budget-exhausted failure path (only _write_receipt ran).
+        # govern() gives failed dispatches the same honest synthesized body the tmux
+        # lane always produces, instead of an audit-trail gap.
+        _govern_report(
+            dispatch_id=dispatch_id, terminal_id=terminal_id, instruction=instruction,
+            status="failed", dispatch_start_ts=dispatch_start_ts, pre_sha=pre_sha,
+            model=model, role=role, pr_id=pr_id,
+            token_usage=token_usage, cost_usd=cost_usd,
+        )
     _sd._write_receipt(
         dispatch_id, terminal_id, "failed",
         event_count=sub_result.event_count,
@@ -398,6 +506,8 @@ def _backoff_or_fail(
     lease_generation: "int | None",
     model: "str | None" = None,
     pr_id: "str | None" = None,
+    instruction: str = "",
+    role: "str | None" = None,
 ) -> None:
     """Sleep with exponential backoff, or run the final-failure branch when exhausted."""
     if attempt < max_retries:
@@ -421,6 +531,8 @@ def _backoff_or_fail(
             lease_generation=lease_generation,
             model=model,
             pr_id=pr_id,
+            instruction=instruction,
+            role=role,
         )
 
 
@@ -493,6 +605,8 @@ def deliver_with_recovery(
                 model=model,
                 pr_id=pr_id,
                 mandate_id=mandate_id,
+                instruction=instruction,
+                role=role,
             )
             return True
         _backoff_or_fail(
@@ -506,6 +620,8 @@ def deliver_with_recovery(
             lease_generation=lease_generation,
             model=model,
             pr_id=pr_id,
+            instruction=instruction,
+            role=role,
         )
 
     return False

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -102,6 +102,57 @@ def test_govern_authored_uses_worker_report(tmp_data, tmp_state, monkeypatch):
     assert outcome.report_path is not None
 
 
+def test_govern_authored_finds_legacy_report_suffix_filename(tmp_data, tmp_state, monkeypatch):
+    """A worker report at the legacy "<id>_report.md" filename (subprocess-lane
+    convention, receipt_writer._ensure_unified_report) is detected as authored
+    even though govern()'s primary lookup is "<id>.md" (tmux-lane convention).
+    """
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    legacy_report_file = reports_dir / "test-govern-001_report.md"
+    legacy_report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="subprocess")
+
+    assert outcome.contract_status == "authored"
+    # The canonical "<id>.md" path is what govern() writes/stamps to, regardless
+    # of which filename the authored candidate was read from.
+    canonical_path = reports_dir / "test-govern-001.md"
+    assert outcome.report_path == canonical_path
+    content = canonical_path.read_text(encoding="utf-8")
+    assert content.startswith("---\n")
+    assert "Implemented the feature correctly" in content
+
+
+def test_govern_prefers_canonical_filename_over_legacy(tmp_data, tmp_state, monkeypatch):
+    """When both "<id>.md" and "<id>_report.md" exist, the canonical name wins."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    canonical_body = _valid_body().replace(
+        "Implemented the feature correctly", "CANONICAL body marker"
+    )
+    (reports_dir / "test-govern-001.md").write_text(canonical_body, encoding="utf-8")
+    legacy_body = _valid_body().replace(
+        "Implemented the feature correctly", "LEGACY body marker"
+    )
+    (reports_dir / "test-govern-001_report.md").write_text(legacy_body, encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="subprocess")
+
+    assert outcome.contract_status == "authored"
+    content = outcome.report_path.read_text(encoding="utf-8")
+    assert "CANONICAL body marker" in content
+    assert "LEGACY body marker" not in content
+
+
 def test_govern_authored_stamps_frontmatter_on_worker_report(tmp_data, tmp_state, monkeypatch):
     """After govern(), a frontmatter-less worker report has a YAML frontmatter block stamped."""
     monkeypatch.setenv("VNX_SHARED_GOVERN", "1")

--- a/tests/test_subprocess_dispatch_govern.py
+++ b/tests/test_subprocess_dispatch_govern.py
@@ -1,0 +1,213 @@
+#!/usr/bin/env python3
+"""Tests for the subprocess lane's VNX_SHARED_GOVERN wiring onto dispatch_govern.govern().
+
+dispatch_govern.py's own module docstring names tmux AND subprocess as its intended
+callers, but only the tmux lane called govern() — the subprocess lane still used the
+legacy stub-writer (_ensure_unified_report) on success and emitted no report at all on
+a budget-exhausted failure. This closes that gap behind VNX_SHARED_GOVERN (default off).
+
+Verifies that:
+  - VNX_SHARED_GOVERN unset/0 (default): behavior is unchanged — _ensure_unified_report
+    runs on success, dispatch_govern.govern() is never called, and no report is emitted
+    on final failure (matching pre-existing behavior).
+  - VNX_SHARED_GOVERN=1: govern() runs instead of _ensure_unified_report on success, and
+    also runs on final failure (new coverage) — both with lane="subprocess".
+  - _write_receipt is called exactly once in every case, unaffected by the flag.
+"""
+
+import os
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+
+import subprocess_dispatch  # noqa: E402
+from subprocess_dispatch_internals.delivery_runtime import _SubprocessResult  # noqa: E402
+from subprocess_dispatch_internals.recovery import (  # noqa: E402
+    _handle_final_failure,
+    _handle_success,
+)
+
+
+def _success_result(**overrides) -> _SubprocessResult:
+    defaults = dict(
+        success=True,
+        session_id="sess-govern-test",
+        event_count=3,
+        manifest_path="/active/dispatch/manifest.json",
+        touched_files=frozenset(),
+    )
+    defaults.update(overrides)
+    return _SubprocessResult(**defaults)
+
+
+class _HandleSuccessTestBase(unittest.TestCase):
+    """Shared patch scaffolding for _handle_success — mirrors test_subprocess_dispatch_stuck_count.py."""
+
+    def _run_handle_success(self, **kwargs):
+        monitor = MagicMock()
+        monitor.stuck_count = 0
+        monitor.mark_completed = MagicMock()
+
+        with patch.object(subprocess_dispatch, "_get_commit_hash", return_value="abc123"), \
+             patch.object(subprocess_dispatch, "_check_commit_since", return_value=False), \
+             patch.object(subprocess_dispatch, "_write_receipt") as mock_receipt, \
+             patch.object(subprocess_dispatch, "_ensure_unified_report") as mock_stub, \
+             patch.object(subprocess_dispatch, "_update_pattern_confidence", return_value=0), \
+             patch.object(subprocess_dispatch, "_capture_dispatch_outcome"), \
+             patch.object(subprocess_dispatch, "cleanup_worker_exit"), \
+             patch("dispatch_govern.govern") as mock_dg_govern:
+            _handle_success(
+                dispatch_id="dispatch-govern-success",
+                terminal_id="T1",
+                attempt=0,
+                sub_result=_success_result(),
+                monitor=monitor,
+                auto_commit=False,
+                gate="",
+                pre_dispatch_dirty=frozenset(),
+                manifest_paths=None,
+                commit_hash_before="abc123",
+                dispatch_start_ts="2026-07-11T00:00:00+00:00",
+                pre_sha="abc123",
+                lease_generation=None,
+                model="sonnet",
+                pr_id=None,
+                mandate_id=None,
+                instruction="Do the thing.",
+                role="backend-developer",
+                **kwargs,
+            )
+        return mock_receipt, mock_stub, mock_dg_govern
+
+
+class TestHandleSuccessSharedGovernOff(_HandleSuccessTestBase):
+    def test_default_off_uses_legacy_stub_writer(self):
+        os.environ.pop("VNX_SHARED_GOVERN", None)
+        mock_receipt, mock_stub, mock_dg_govern = self._run_handle_success()
+
+        mock_stub.assert_called_once_with("dispatch-govern-success", "T1", "done")
+        mock_dg_govern.assert_not_called()
+        mock_receipt.assert_called_once()
+
+    def test_explicit_off_uses_legacy_stub_writer(self):
+        os.environ["VNX_SHARED_GOVERN"] = "0"
+        try:
+            mock_receipt, mock_stub, mock_dg_govern = self._run_handle_success()
+        finally:
+            os.environ.pop("VNX_SHARED_GOVERN", None)
+
+        mock_stub.assert_called_once()
+        mock_dg_govern.assert_not_called()
+        mock_receipt.assert_called_once()
+
+
+class TestHandleSuccessSharedGovernOn(_HandleSuccessTestBase):
+    def test_on_calls_govern_instead_of_stub(self):
+        os.environ["VNX_SHARED_GOVERN"] = "1"
+        try:
+            mock_receipt, mock_stub, mock_dg_govern = self._run_handle_success()
+        finally:
+            os.environ.pop("VNX_SHARED_GOVERN", None)
+
+        mock_stub.assert_not_called()
+        mock_dg_govern.assert_called_once()
+        _, kwargs = mock_dg_govern.call_args
+        # govern(spec, raw, lane=...) — inspect positional + kwarg lane.
+        args = mock_dg_govern.call_args.args
+        spec = args[0]
+        raw = args[1]
+        lane = mock_dg_govern.call_args.kwargs.get("lane") or args[2]
+
+        self.assertEqual(lane, "subprocess")
+        self.assertEqual(spec.dispatch_id, "dispatch-govern-success")
+        self.assertEqual(spec.terminal_id, "T1")
+        self.assertEqual(spec.instruction, "Do the thing.")
+        self.assertEqual(spec.base_sha, "abc123")
+        self.assertEqual(spec.model, "sonnet")
+        self.assertEqual(spec.role, "backend-developer")
+        self.assertEqual(raw.receipt.get("status"), "done")
+        # Receipt writing is untouched by the flag.
+        mock_receipt.assert_called_once()
+
+
+class _HandleFinalFailureTestBase(unittest.TestCase):
+    def _run_handle_final_failure(self, **kwargs):
+        monitor = MagicMock()
+        monitor.stuck_count = 0
+        monitor.mark_completed = MagicMock()
+
+        failed_result = _SubprocessResult(
+            success=False,
+            session_id=None,
+            event_count=1,
+            manifest_path="/active/dispatch/manifest.json",
+            touched_files=frozenset(),
+        )
+
+        with patch.object(subprocess_dispatch, "_write_receipt") as mock_receipt, \
+             patch.object(subprocess_dispatch, "_auto_stash_changes", return_value=False), \
+             patch.object(subprocess_dispatch, "_update_pattern_confidence", return_value=0), \
+             patch.object(subprocess_dispatch, "_capture_dispatch_outcome"), \
+             patch.object(subprocess_dispatch, "_promote_manifest"), \
+             patch.object(subprocess_dispatch, "cleanup_worker_exit"), \
+             patch("dispatch_govern.govern") as mock_dg_govern:
+            _handle_final_failure(
+                dispatch_id="dispatch-govern-failure",
+                terminal_id="T1",
+                attempt=2,
+                sub_result=failed_result,
+                monitor=monitor,
+                auto_commit=False,
+                pre_dispatch_dirty=frozenset(),
+                manifest_paths=None,
+                commit_hash_before="abc123",
+                dispatch_start_ts="2026-07-11T00:00:00+00:00",
+                pre_sha="abc123",
+                max_retries=2,
+                lease_generation=None,
+                model="sonnet",
+                pr_id=None,
+                instruction="Do the thing.",
+                role="backend-developer",
+                **kwargs,
+            )
+        return mock_receipt, mock_dg_govern
+
+
+class TestHandleFinalFailureSharedGovern(_HandleFinalFailureTestBase):
+    def test_default_off_emits_no_report_at_all(self):
+        """Pre-existing behavior: on final failure, no report emission — only the receipt."""
+        os.environ.pop("VNX_SHARED_GOVERN", None)
+        mock_receipt, mock_dg_govern = self._run_handle_final_failure()
+
+        mock_dg_govern.assert_not_called()
+        mock_receipt.assert_called_once()
+
+    def test_on_calls_govern_with_failed_status(self):
+        """New coverage: VNX_SHARED_GOVERN=1 gives failed subprocess dispatches an
+        honest governed report, matching the tmux lane's always-govern behavior."""
+        os.environ["VNX_SHARED_GOVERN"] = "1"
+        try:
+            mock_receipt, mock_dg_govern = self._run_handle_final_failure()
+        finally:
+            os.environ.pop("VNX_SHARED_GOVERN", None)
+
+        mock_dg_govern.assert_called_once()
+        args = mock_dg_govern.call_args.args
+        spec, raw = args[0], args[1]
+        lane = mock_dg_govern.call_args.kwargs.get("lane") or args[2]
+
+        self.assertEqual(lane, "subprocess")
+        self.assertEqual(spec.dispatch_id, "dispatch-govern-failure")
+        self.assertEqual(raw.receipt.get("status"), "failed")
+        # Receipt writing is untouched by the flag.
+        mock_receipt.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- First slice of "Option B parity" (uniform prepare()/govern() across all lanes). `dispatch_govern.py`'s own docstring names tmux **and** subprocess as intended callers, but only tmux was wired end to end — this PR closes that gap for the subprocess lane, behind a default-off flag.
- `VNX_SHARED_GOVERN=1` routes `deliver_with_recovery`'s success and budget-exhausted-failure paths through the same `govern()` the tmux lane already uses (git-diff synthesis, schema-complete frontmatter, contract validation) instead of the legacy stub-only `_ensure_unified_report` (success) or no report at all (final failure).
- `govern()`'s authored-report lookup now also checks the legacy subprocess worker filename (`<id>_report.md`) as a fallback alongside the canonical `<id>.md`, so authored-report detection actually activates for this lane instead of always falling through to synthesis.
- Receipt writing (`_write_receipt`) is untouched in both flag states — this PR only changes report-body quality, not the receipt schema.

## Scope
Smallest coherent seam per dispatch instructions — does **not** touch:
- `claude_headless` lane (`dispatch_envelope.run_envelope_headless_plan`) — still uses envelope's own local `_prepare()`/`_govern()`.
- provider_dispatch lanes (codex/kimi/gemini/deepseek-harness/litellm via `run_envelope_plan`) — same local envelope prepare/govern, shared across 7 providers; report-writing divergence documented in `docs/core/PROVIDER_LANES.md`.

These are listed as follow-up slices in the updated docs section.

## Test plan
- [x] `pytest tests/test_dispatch_govern.py tests/test_subprocess_dispatch_govern.py tests/test_tmux_interactive_dispatch.py tests/test_dispatch_prepare.py -q` → 266 passed
- [x] `pytest tests/test_subprocess_dispatch*.py tests/test_dispatcher_drain_lifecycle.py -q` → 132 passed, 5 pre-existing failures unrelated to this change (verified identical on `main`)
- [x] New tests cover: flag off (unchanged legacy behavior, regression guard), flag on (govern() called with lane="subprocess", correct `GovernSpec`/`GovernRaw` field wiring), and the legacy-filename authored-report fallback in `dispatch_govern.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)