### PR TITLE
feat(bench): generalize harness — bring-your-own-tasks/models, seeds-decoupled (OI-225)

### DIFF
--- a/scripts/benchmark/judge_quality.py
+++ b/scripts/benchmark/judge_quality.py
@@ -8,6 +8,7 @@ For each result file in results/:
 
 Usage:
     python3 scripts/benchmark/judge_quality.py [--results-dir PATH] [--model opus]
+    python3 scripts/benchmark/judge_quality.py --tasks-dir /path/to/my/prompts  # bring-your-own-tasks
 """
 
 from __future__ import annotations
@@ -15,6 +16,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -141,12 +143,19 @@ def judge_result_file(result_path: Path, prompts_dir: Path, model: str, timeout:
 def main() -> int:
     parser = argparse.ArgumentParser(description="Judge benchmark responses via Claude Opus")
     parser.add_argument("--results-dir", default=None, help="Path to results directory")
+    parser.add_argument(
+        "--tasks-dir",
+        default=os.environ.get("VNX_BENCH_TASKS_DIR", ""),
+        help="Directory of *.txt task prompts to look up original task text (bring-your-own-tasks). "
+             "Default: bundled scripts/benchmark/prompts/",
+    )
     parser.add_argument("--model", default="opus", help="Claude model to use as judge")
     parser.add_argument("--timeout", type=int, default=120, help="Per-call timeout in seconds")
     parser.add_argument("--skip-judged", action="store_true", help="Skip files already containing judge_scores")
     args = parser.parse_args()
 
     results_dir = Path(args.results_dir) if args.results_dir else RESULTS_DIR
+    prompts_dir = Path(args.tasks_dir) if args.tasks_dir else PROMPTS_DIR
     if not results_dir.exists():
         print(f"Results directory not found: {results_dir}")
         return 1
@@ -168,7 +177,7 @@ def main() -> int:
 
         print(f"  [{i}/{len(result_files)}] {path.name}...")
         try:
-            score = judge_result_file(path, PROMPTS_DIR, args.model, args.timeout)
+            score = judge_result_file(path, prompts_dir, args.model, args.timeout)
             q = score["quality_score"]
             c = "correct" if score["correctness"] else "incorrect"
             comp = score["completeness_score"]

--- a/scripts/benchmark/run_benchmark.py
+++ b/scripts/benchmark/run_benchmark.py
@@ -5,6 +5,13 @@ Usage:
     python3 scripts/benchmark/run_benchmark.py [--models MODEL_IDS] [--tasks TASK_IDS] [--output PATH]
     python3 scripts/benchmark/run_benchmark.py --dry-run
 
+Bring-your-own-tasks / bring-your-own-models (decoupled from the bundled seeds):
+    python3 scripts/benchmark/run_benchmark.py --tasks-dir /path/to/my/prompts --models-file /path/to/my/models.yaml --dry-run
+    VNX_BENCH_TASKS_DIR=/path/to/my/prompts VNX_BENCH_MODELS_FILE=/path/to/my/models.yaml python3 scripts/benchmark/run_benchmark.py --dry-run
+
+--tasks-dir/--models-file (or their VNX_BENCH_TASKS_DIR/VNX_BENCH_MODELS_FILE env equivalents) default to
+the repo-bundled scripts/benchmark/prompts/ and models.yaml when unset, so existing invocations are unchanged.
+
 For each (model, task):
   - Dispatch via provider_dispatch.py
   - Wait for completion
@@ -179,10 +186,20 @@ def _filter_tasks(tasks: List[Dict], selector: str) -> List[Dict]:
 
 
 def main() -> int:
-    parser = argparse.ArgumentParser(description="VNX benchmark runner — 9 models x 7 tasks")
+    parser = argparse.ArgumentParser(description="VNX benchmark runner — N models x M tasks")
     parser.add_argument("--models", default="all", help="Comma-separated model IDs or 'all'")
     parser.add_argument("--tasks", default="all", help="Comma-separated task IDs or 'all'")
     parser.add_argument("--output", default=None, help="Override output directory")
+    parser.add_argument(
+        "--tasks-dir",
+        default=os.environ.get("VNX_BENCH_TASKS_DIR", ""),
+        help="Directory of *.txt task prompts (bring-your-own-tasks). Default: bundled scripts/benchmark/prompts/",
+    )
+    parser.add_argument(
+        "--models-file",
+        default=os.environ.get("VNX_BENCH_MODELS_FILE", ""),
+        help="Path to a models.yaml (bring-your-own model roster). Default: bundled scripts/benchmark/models.yaml",
+    )
     parser.add_argument("--terminal-id", default="BENCH", help="Terminal ID for governance state (default: BENCH)")
     parser.add_argument("--dry-run", action="store_true", help="List dispatches without executing")
     parser.add_argument("--run", action="store_true", help="Actually execute benchmarks")
@@ -196,8 +213,11 @@ def main() -> int:
     output_dir = Path(args.output) if args.output else RESULTS_DIR
     output_dir.mkdir(parents=True, exist_ok=True)
 
-    models = _filter_models(load_models(), args.models)
-    tasks = _filter_tasks(load_tasks(), args.tasks)
+    tasks_dir = Path(args.tasks_dir) if args.tasks_dir else None
+    models_file = Path(args.models_file) if args.models_file else None
+
+    models = _filter_models(load_models(models_file), args.models)
+    tasks = _filter_tasks(load_tasks(tasks_dir), args.tasks)
 
     total = len(models) * len(tasks)
     print(f"Benchmark plan: {len(models)} models x {len(tasks)} tasks = {total} dispatches")

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -426,8 +426,11 @@ def test_glm_uses_zai_provider():
     models = run_benchmark.load_models()
     glm = next((m for m in models if m["id"] == "glm-5-1"), None)
     assert glm is not None, "glm-5-1 not found in models.yaml"
-    assert glm["provider"] == "litellm:zai", f"Expected litellm:zai, got {glm['provider']}"
-    assert glm["model_arg"] == "glm-5", f"Expected glm-5, got {glm['model_arg']}"
+    # glm-5-1 was corrected in models.yaml to map to the REAL GLM-5.1 (litellm:zai:glm-5.1 /
+    # model_arg glm-5.1), not the base glm-5 alias. The zai sub-provider prefix is what satisfies
+    # zai-via-openrouter-only; the :glm-5.1 suffix selects the real model.
+    assert glm["provider"].startswith("litellm:zai"), f"Expected litellm:zai*, got {glm['provider']}"
+    assert glm["model_arg"] == "glm-5.1", f"Expected glm-5.1, got {glm['model_arg']}"
 
 
 # ---------------------------------------------------------------------------
@@ -469,3 +472,115 @@ def test_analyze_warns_on_unreadable_file(tmp_path: Path, capsys):
 
     assert len(records) == 1
     assert "WARNING" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# OI-225: --tasks-dir / --models-file CLI + VNX_BENCH_* env fallback
+# (bring-your-own-tasks generalization seam — decouples the runner from the
+# bundled repo-specific prompts/models.yaml without packaging the harness)
+# ---------------------------------------------------------------------------
+
+def test_dry_run_uses_custom_tasks_dir_and_models_file(
+    tmp_prompts: Path, tmp_models_yaml: Path, monkeypatch, capsys,
+):
+    monkeypatch.setattr(sys, "argv", [
+        "run_benchmark.py", "--dry-run",
+        "--tasks-dir", str(tmp_prompts),
+        "--models-file", str(tmp_models_yaml),
+    ])
+    rc = run_benchmark.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "claude-sonnet-4-6 x 01_alpha" in out
+    assert "deepseek-v4-pro x 02_beta" in out
+    # bundled repo seeds must not leak in when a custom source is given
+    assert "01_code_generation" not in out
+    assert "claude-opus-4-8" not in out
+
+
+def test_dry_run_env_var_fallback_for_tasks_and_models(
+    tmp_prompts: Path, tmp_models_yaml: Path, monkeypatch, capsys,
+):
+    monkeypatch.setenv("VNX_BENCH_TASKS_DIR", str(tmp_prompts))
+    monkeypatch.setenv("VNX_BENCH_MODELS_FILE", str(tmp_models_yaml))
+    monkeypatch.setattr(sys, "argv", ["run_benchmark.py", "--dry-run"])
+
+    rc = run_benchmark.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "claude-sonnet-4-6 x 01_alpha" in out
+
+
+def test_dry_run_cli_flag_overrides_env_var(
+    tmp_prompts: Path, tmp_models_yaml: Path, tmp_path: Path, monkeypatch, capsys,
+):
+    # A second, distinct task source set via env — the explicit CLI flag must win.
+    other_prompts = tmp_path / "other_prompts"
+    other_prompts.mkdir()
+    (other_prompts / "99_gamma.txt").write_text("Do task gamma.")
+
+    monkeypatch.setenv("VNX_BENCH_TASKS_DIR", str(other_prompts))
+    monkeypatch.setattr(sys, "argv", [
+        "run_benchmark.py", "--dry-run",
+        "--tasks-dir", str(tmp_prompts),
+        "--models-file", str(tmp_models_yaml),
+    ])
+
+    rc = run_benchmark.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert "01_alpha" in out
+    assert "99_gamma" not in out
+
+
+def test_dry_run_defaults_to_bundled_seeds_when_unset(monkeypatch, capsys):
+    monkeypatch.delenv("VNX_BENCH_TASKS_DIR", raising=False)
+    monkeypatch.delenv("VNX_BENCH_MODELS_FILE", raising=False)
+    monkeypatch.setattr(sys, "argv", ["run_benchmark.py", "--dry-run"])
+
+    rc = run_benchmark.main()
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # bundled prompt/model still reachable when no override is given (backward-compat)
+    assert "01_code_generation" in out
+    assert "claude-opus-4-8" in out
+
+
+def test_judge_quality_tasks_dir_cli_overrides_bundled_prompts(
+    tmp_path: Path, monkeypatch,
+):
+    custom_prompts = tmp_path / "prompts"
+    custom_prompts.mkdir()
+    (custom_prompts / "01_alpha.txt").write_text("Custom bring-your-own task alpha.")
+
+    results_dir = tmp_path / "results"
+    results_dir.mkdir()
+    record = {
+        "model_id": "claude-sonnet-4-6",
+        "task_id": "01_alpha",
+        "response": "some response",
+    }
+    (results_dir / "claude-sonnet-4-6__01_alpha.json").write_text(json.dumps(record))
+
+    captured_prompts = []
+
+    def fake_call_judge(prompt, model, timeout):
+        captured_prompts.append(prompt)
+        return '{"quality_score": 5, "correctness": true, "completeness_score": 5, "notable_issues": ""}'
+
+    monkeypatch.setattr(sys, "argv", [
+        "judge_quality.py",
+        "--results-dir", str(results_dir),
+        "--tasks-dir", str(custom_prompts),
+    ])
+
+    with patch.object(judge_quality, "_call_judge", side_effect=fake_call_judge):
+        rc = judge_quality.main()
+
+    assert rc == 0
+    assert len(captured_prompts) == 1
+    assert "Custom bring-your-own task alpha." in captured_prompts[0]


### PR DESCRIPTION
## Summary
Salvages the reaped **OI-225** worker's output into a governed PR. The worker stalled on an interactive prompt before it could commit; its complete diff landed uncommitted in the main working tree (the "3 benchmark files with unclear provenance" flagged in the 2026-07-11 handoff). Verified complete against the track DoD and re-run green — strictly better than re-dispatching from scratch.

Generalizes the benchmark harness into a shippable, seeds-free feature: bring-your-own-tasks and bring-your-own-models, decoupled from the repo-bundled seeds.

## Changes
- `scripts/benchmark/run_benchmark.py`: `--tasks-dir` / `--models-file` flags + `VNX_BENCH_TASKS_DIR` / `VNX_BENCH_MODELS_FILE` env fallbacks. Both default to the bundled `prompts/` + `models.yaml`, so existing invocations are unchanged. argparse description generalized to "N models x M tasks".
- `scripts/benchmark/judge_quality.py`: `--tasks-dir` / `VNX_BENCH_TASKS_DIR` to resolve original task text from an arbitrary prompts dir.
- `tests/test_benchmark_suite.py`: 5 new tests covering custom dir, env-var fallback, CLI-over-env precedence, bundled-default fallback, and judge-side task-dir override.
- **Drive-by fix (same file):** `test_glm_uses_zai_provider` asserted a stale mapping. `models.yaml` corrected `glm-5-1` to the REAL GLM-5.1 (`litellm:zai:glm-5.1` / `model_arg glm-5.1`); the test still expected base `glm-5`. Updated to `startswith("litellm:zai")` (preserves the `zai-via-openrouter-only` intent) + `glm-5.1`.

## Verification
`python3 -m pytest tests/test_benchmark_suite.py -q` -> **31 passed** (was 30 passed / 1 pre-existing failure).

Backward-compat confirmed: unset flags/env fall through to bundled seeds.

## Open Items
- Track linkage: this PR closes `oi-225-bench-harness-generalize` on merge (auto-close).
- The stale-test fix is orthogonal to OI-225 but bundled to keep the benchmark suite green; called out above for reviewer awareness.

Dispatch-ID: salvage-20260711-oi225-bench-harness-generalize

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7