### PR TITLE
chore(slop): sync stale codex-default comments gpt-5.3-codex -> gpt-5.5

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -309,7 +309,7 @@ class GateRunner:
             cli_args = ["--model", model] + cli_args
         elif gate == "codex_gate":
             # Model selection: only override if explicitly requested via env/payload.
-            # Default path: let codex use ~/.codex/config.toml (currently gpt-5.3-codex).
+            # Default path: let codex use ~/.codex/config.toml (currently gpt-5.5).
             # 2026-04-19: gpt-5.2-codex deprecated via Codex CLI model-migration mapping;
             # ChatGPT-account auth rejects older explicit model flags, causing gate
             # failures with "model not supported when using Codex with a ChatGPT account".

--- a/scripts/lib/adapters/codex_adapter.py
+++ b/scripts/lib/adapters/codex_adapter.py
@@ -38,7 +38,7 @@ from vertex_ai_runner import collect_file_contents
 
 logger = logging.getLogger(__name__)
 
-# Model: empty string = use codex CLI config.toml default (currently gpt-5.3-codex).
+# Model: empty string = use codex CLI config.toml default (currently gpt-5.5).
 # 2026-04-19: gpt-5.2-codex deprecated via Codex CLI model-migration mapping;
 # ChatGPT-account auth rejects older explicit model flags.
 _DEFAULT_MODEL = ""


### PR DESCRIPTION
## Summary
Salvages the only unique work from the reaped `slop/doc-drift-pass` worktree (commit ec806a2c, Jun 23) — the one flagged in the 2026-07-11 handoff as "72M, 1226 unpushed local-only commits, decide if it's junk." Those 1226 commits are old merged-PR topology from when the branch was cut; the sole unique change is a cosmetic doc/comment sync. Applied fresh on current main.

## Changes
- `scripts/gate_runner.py:312` + `scripts/lib/adapters/codex_adapter.py:41`: the codex_gate default-path comment said `(currently gpt-5.3-codex)`; the live `~/.codex/config.toml` default is `gpt-5.5`. Comment-only, no behavior change.

The `COST_TRACKING_GUIDE.md` table half of the original commit is already superseded — current main's pricing table carries all four gpt-5.x-codex rows — so it is intentionally omitted.

## Verification
Comment-only diff (`git diff --stat`: 2 files, 2 lines). Confirmed codex default via `~/.codex/config.toml` -> `model = "gpt-5.5"`. Confirmed COST table already synced on main (`gpt-5.3/5.2/5.1/mini` rows present).

## Open Items
- The 72M `slop/doc-drift-pass` worktree can be removed once this merges — its meaningful content is preserved here. (Removal is destructive/local-only; awaiting operator OK per the handoff.)

Dispatch-ID: salvage-20260711-slop-codex-default-comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7