### PR TITLE
docs(fabric-reference): salvage known-issues runbook notes from #1105

### DIFF
--- a/.claude/skills/fabric-reference/SKILL.md
+++ b/.claude/skills/fabric-reference/SKILL.md
@@ -86,6 +86,11 @@ vnx horizon plan-gate ...           # multi-model panel reviews a plan before an
 - **`vnx start --help` runs start:** it spawns the daemon set (footgun); SIGKILL the supervisor root if triggered.
 - **Central-mode paths:** embedded-layout path assumptions can break central-mode resolution (fleet burn-in) — resolve via the helpers, never hardcode `.vnx-data/` literals.
 
+### Known issues (tracked, active)
+
+- **An empty provider completion is usually a TRANSIENT lane issue, not a structural door bug:** if `bin/vnx dispatch <id>` for a provider lane (kimi/glm/deepseek) lands an empty completion, check the lane's health FIRST — kimi OAuth/quota, glm proxy on `:4141` — not the envelope. The door's provider path works end-to-end; a blank completion is now downgraded to a loud `failure` (embedding the raw spawn result) for ALL provider spawns as of #1107, and the door surfaces `EnvelopeResult.error` instead of a bare exit code, so the real cause is visible.
+- **The plan-gate panel can score on fewer than 5 seats (`plan-gate-panel-seat-robustness`):** in `plan_gate_panel.py` (NOT the `/panel` skill) the **opus seat NO-VERDICTs reliably** on a `data_dir=None` report-resolution miss (#1102 class: `staging_validator: unstaged dispatch override`), and the codex + glm seats can **intermittently** abstain on unparseable verdict JSON (codex abstained in one round, scored the next). A verdict may rest on as few as 2 seats (kimi + deepseek) or as many as 4 — **confirm the real scoring-seat count in the log before trusting a plan-gate PASS/REVISE**.
+
 ## Where the source of truth lives
 
 - Dispatch mechanics, lanes, failure modes: `docs/core/DISPATCH_RULES.md`


### PR DESCRIPTION
## Summary
Salvages the one non-superseded piece of #1105 (cut 1.2.0). #1105 conflicted on main because VERSION is already `1.2.0`, the CHANGELOG carries `[1.2.0]`, and the README "what's new" section is newer on main than #1105's take. The only content NOT already on main was the fabric-reference **Known issues (tracked, active)** runbook section.

## Changes
- `.claude/skills/fabric-reference/SKILL.md`: add two tracked known-issues notes — (1) an empty provider completion is usually a transient lane issue (kimi OAuth/glm proxy), not a door bug, fail-loud as of #1107; (2) the plan-gate panel can score on fewer than 5 seats (opus NO-VERDICTs reliably, codex/glm abstain intermittently) — confirm the real seat count before trusting a verdict.
- **Corrected vs #1105:** the note's "2/5 seats" was stale — a 2026-07-11 re-gate scored 4/5; reworded to the intermittent range.

## Verification
Doc-only. Section confirmed absent from main before salvage; VERSION=1.2.0 + CHANGELOG `[1.2.0]` already live.

## Open Items
- #1105 closed as superseded.

Dispatch-ID: salvage-20260711-fabric-reference-known-issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EfK4VyrYKevnVaJr5kMoN7