### PR TITLE
feat(config): add missing subsystem flags for governance, intelligence, and migration

### DIFF
--- a/dashboard/token-dashboard/app/operator/config/page.tsx
+++ b/dashboard/token-dashboard/app/operator/config/page.tsx
@@ -12,6 +12,16 @@ const CATEGORY_LABEL: Record<string, string> = {
   gate: 'Gates',
 };
 
+// Cockpit subsystem status (framework-status-audit-and-cockpit) — display metadata only.
+const STATUS_COLOR: Record<string, string> = {
+  LIVE: 'var(--color-success, #50fa7b)',
+  ACTIVATE: 'var(--color-accent, #f97316)',
+  SCOPE: 'var(--color-warning, #facc15)',
+  PARK: 'var(--color-muted)',
+  CUT: 'var(--color-danger, #ff5555)',
+  COCKPIT: 'var(--color-accent, #f97316)',
+};
+
 const PANEL = 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)';
 
 function isOn(row: ConfigEntryRow): boolean {
@@ -71,8 +81,26 @@ function ConfigRow({
               planned
             </span>
           )}
+          {row.status && (
+            <span
+              data-testid={`config-status-${row.key}`}
+              style={{
+                fontSize: 9,
+                fontWeight: 700,
+                color: STATUS_COLOR[row.status] ?? 'var(--color-muted)',
+                border: `1px solid ${STATUS_COLOR[row.status] ?? 'rgba(255,255,255,0.2)'}`,
+                borderRadius: 5,
+                padding: '1px 5px',
+              }}
+            >
+              {row.status}
+            </span>
+          )}
         </div>
-        <span style={{ fontSize: 11, color: 'var(--color-muted)', overflow: 'hidden', textOverflow: 'ellipsis' }}>{row.description}</span>
+        <span style={{ fontSize: 11, color: 'var(--color-muted)', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+          {row.description}
+          {row.subsystem ? ` · ${row.subsystem}` : ''}
+        </span>
       </div>
 
       <div style={{ flexShrink: 0 }}>

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -262,6 +262,8 @@ export interface ConfigEntryRow {
   writable_from_ui: boolean;
   requires_approval: boolean;
   planned: boolean;
+  subsystem?: string | null;
+  status?: string | null; // cockpit status: LIVE | PARK | CUT | ACTIVATE | SCOPE | COCKPIT
 }
 
 export interface ConfigEnvelope {

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -131,6 +131,49 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "Cross-project intelligence federation (NOT yet implemented).",
         writable=False, planned=True,
         subsystem="cross-project-federation", status="ACTIVATE"),
+
+    # framework-status-audit-and-cockpit PR-2: net-new subsystem flags, registered as display
+    # metadata only (§2.1 of the plan doc). No read-site consults these; registering them does not
+    # change any gate/enforcement decision. VNX_EVIDENCE_BOUND_GATE and VNX_PLAN_GATE_ENFORCE
+    # already existed before this PR (backfilled with subsystem/status in PR-1) and are NOT re-added.
+    "VNX_GOVERNANCE_ENFORCED": _e(
+        "VNX_GOVERNANCE_ENFORCED", "bool", "0", "gate",
+        "Governance-enforcement-stack master switch (display metadata only; no read-site wired).",
+        approval=True,
+        subsystem="governance-enforcement-stack", status="PARK"),
+    "VNX_LEARNING_LOOP_ENABLED": _e(
+        "VNX_LEARNING_LOOP_ENABLED", "bool", "0", "intelligence",
+        "Daily pattern learning / skill refinement / confidence-update loop.",
+        subsystem="intelligence-self-learning-loop", status="ACTIVATE"),
+    "VNX_DREAM_SCHEDULER_ENABLED": _e(
+        "VNX_DREAM_SCHEDULER_ENABLED", "bool", "0", "intelligence",
+        "Nightly memory consolidation + pending review dispatch.",
+        subsystem="dream-consolidation", status="ACTIVATE"),
+    "VNX_INJECTION_FEEDBACK_ENABLED": _e(
+        "VNX_INJECTION_FEEDBACK_ENABLED", "bool", "0", "intelligence",
+        "Instrument why intelligence injections are ignored before tuning generation.",
+        subsystem="injection-effectiveness-eval-loop", status="ACTIVATE"),
+    "VNX_PLAN_GATE_COMPLEX_ONLY": _e(
+        "VNX_PLAN_GATE_COMPLEX_ONLY", "bool", "0", "gate",
+        "Restrict the plan-gate panel to complex features (display metadata only; "
+        "the scope-skip read-site is deferred to review-floor-enforcer).",
+        subsystem="plan-gate-panel", status="SCOPE"),
+    "VNX_HASH_CHAIN_REQUIRED": _e(
+        "VNX_HASH_CHAIN_REQUIRED", "bool", "0", "gate",
+        "Tamper-evident NDJSON hash-chain requirement (display metadata only; no read-site wired).",
+        approval=True,
+        subsystem="receipt-hash-chain", status="PARK"),
+    "VNX_ATTESTATION_REQUIRED": _e(
+        "VNX_ATTESTATION_REQUIRED", "bool", "0", "gate",
+        "SSH-signed PR attestation requirement (display metadata only; no read-site wired).",
+        approval=True,
+        subsystem="signed-attestation", status="PARK"),
+    "VNX_MIGRATION_SYSTEM": _e(
+        "VNX_MIGRATION_SYSTEM", "enum", "manifest", "dispatch",
+        "Pinned selector recording which migration mechanism is active. Parked pending the "
+        "migration-consolidation-and-tenancy-cut trigger.",
+        writable=False,
+        subsystem="migration-mechanisms", status="PARK"),
 }
 
 # Flag-LESS subsystems from the cockpit ledger (docs/core/SUBSYSTEMS.md) — kernel/meta subsystems

--- a/tests/test_api_config.py
+++ b/tests/test_api_config.py
@@ -113,6 +113,22 @@ def test_get_config_inventory_shape(db):
     assert row["requires_approval"] is True
 
 
+def test_get_config_includes_pr2_subsystem_flags(db):
+    # framework-status-audit-and-cockpit PR-2: net-new display-metadata flags must surface here.
+    out, status = ac.operator_get_config({}, project_id=PID)
+    assert status == 200
+    keys = {row["key"] for row in out["config"]}
+    for key in (
+        "VNX_GOVERNANCE_ENFORCED", "VNX_LEARNING_LOOP_ENABLED", "VNX_DREAM_SCHEDULER_ENABLED",
+        "VNX_INJECTION_FEEDBACK_ENABLED", "VNX_PLAN_GATE_COMPLEX_ONLY", "VNX_HASH_CHAIN_REQUIRED",
+        "VNX_ATTESTATION_REQUIRED", "VNX_MIGRATION_SYSTEM",
+    ):
+        assert key in keys, f"{key} missing from /api/operator/config"
+    migration_row = next(r for r in out["config"] if r["key"] == "VNX_MIGRATION_SYSTEM")
+    assert migration_row["default"] == "manifest"
+    assert migration_row["writable_from_ui"] is False
+
+
 def test_get_config_reflects_db_value(db):
     # write via the DAO, then the inventory (through the wired resolver) must show it as non-default
     ac.operator_post_config_set(

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -168,5 +168,87 @@ def test_config_registry_subsystems_have_status_and_description():
         assert meta.get("description"), f"{name} is missing a description"
 
 
+# ---------------------------------------------------------------------------
+# PR-2: net-new subsystem flags (display metadata only)
+# ---------------------------------------------------------------------------
+
+PR2_NEW_FLAGS = (
+    "VNX_GOVERNANCE_ENFORCED",
+    "VNX_LEARNING_LOOP_ENABLED",
+    "VNX_DREAM_SCHEDULER_ENABLED",
+    "VNX_INJECTION_FEEDBACK_ENABLED",
+    "VNX_PLAN_GATE_COMPLEX_ONLY",
+    "VNX_HASH_CHAIN_REQUIRED",
+    "VNX_ATTESTATION_REQUIRED",
+    "VNX_MIGRATION_SYSTEM",
+)
+
+
+def test_pr2_new_flags_exist_default_off():
+    for key in PR2_NEW_FLAGS:
+        entry = cr.CONFIG_REGISTRY[key]
+        if key == "VNX_MIGRATION_SYSTEM":
+            assert entry.default == "manifest"
+            assert entry.type == "enum"
+        else:
+            assert entry.default == "0", f"{key} must default off"
+            assert entry.type == "bool"
+
+
+def test_pr2_approval_flags_require_approval():
+    for key in ("VNX_GOVERNANCE_ENFORCED", "VNX_HASH_CHAIN_REQUIRED", "VNX_ATTESTATION_REQUIRED"):
+        assert cr.CONFIG_REGISTRY[key].requires_approval is True
+
+
+def test_pr2_non_approval_flags_do_not_require_approval():
+    for key in (
+        "VNX_LEARNING_LOOP_ENABLED", "VNX_DREAM_SCHEDULER_ENABLED",
+        "VNX_INJECTION_FEEDBACK_ENABLED", "VNX_PLAN_GATE_COMPLEX_ONLY",
+    ):
+        assert cr.CONFIG_REGISTRY[key].requires_approval is False
+
+
+def test_pr2_migration_system_is_read_only():
+    entry = cr.CONFIG_REGISTRY["VNX_MIGRATION_SYSTEM"]
+    assert entry.writable_from_ui is False
+    assert entry.default == "manifest"
+
+
+def test_pr2_new_flags_have_correct_subsystem_and_status():
+    expected = {
+        "VNX_GOVERNANCE_ENFORCED": ("governance-enforcement-stack", "PARK"),
+        "VNX_LEARNING_LOOP_ENABLED": ("intelligence-self-learning-loop", "ACTIVATE"),
+        "VNX_DREAM_SCHEDULER_ENABLED": ("dream-consolidation", "ACTIVATE"),
+        "VNX_INJECTION_FEEDBACK_ENABLED": ("injection-effectiveness-eval-loop", "ACTIVATE"),
+        "VNX_PLAN_GATE_COMPLEX_ONLY": ("plan-gate-panel", "SCOPE"),
+        "VNX_HASH_CHAIN_REQUIRED": ("receipt-hash-chain", "PARK"),
+        "VNX_ATTESTATION_REQUIRED": ("signed-attestation", "PARK"),
+        "VNX_MIGRATION_SYSTEM": ("migration-mechanisms", "PARK"),
+    }
+    for key, (subsystem, status) in expected.items():
+        entry = cr.CONFIG_REGISTRY[key]
+        assert entry.subsystem == subsystem, key
+        assert entry.status == status, key
+
+
+def test_pr2_does_not_duplicate_already_registered_flags():
+    # VNX_EVIDENCE_BOUND_GATE and VNX_PLAN_GATE_ENFORCE predate PR-2 (PR-1 backfilled their
+    # subsystem/status). PR-2 must not re-register them or alter their existing metadata.
+    assert cr.CONFIG_REGISTRY["VNX_EVIDENCE_BOUND_GATE"].subsystem == "evidence-bound-gate"
+    assert cr.CONFIG_REGISTRY["VNX_EVIDENCE_BOUND_GATE"].status == "PARK"
+    assert cr.CONFIG_REGISTRY["VNX_PLAN_GATE_ENFORCE"].subsystem == "plan-gate-panel"
+    assert cr.CONFIG_REGISTRY["VNX_PLAN_GATE_ENFORCE"].status == "SCOPE"
+    for key in PR2_NEW_FLAGS:
+        assert key not in ("VNX_EVIDENCE_BOUND_GATE", "VNX_PLAN_GATE_ENFORCE")
+
+
+def test_pr2_registering_flags_does_not_change_effective_value_when_unset():
+    # Metadata-only guarantee (§2.1): registering a flag must not change what get()/get_bool()
+    # resolve to when nothing overrides it — no read-site behaviour change.
+    for key in PR2_NEW_FLAGS:
+        entry = cr.CONFIG_REGISTRY[key]
+        assert cr.get(key) == entry.default
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- Registers the 8 net-new PR-2 flags from `docs/core/framework-status-audit-and-cockpit_PRD.md` §PR-2 in `config_registry.CONFIG_REGISTRY` as **display metadata only**: `VNX_GOVERNANCE_ENFORCED`, `VNX_LEARNING_LOOP_ENABLED`, `VNX_DREAM_SCHEDULER_ENABLED`, `VNX_INJECTION_FEEDBACK_ENABLED`, `VNX_PLAN_GATE_COMPLEX_ONLY`, `VNX_HASH_CHAIN_REQUIRED`, `VNX_ATTESTATION_REQUIRED`, `VNX_MIGRATION_SYSTEM`.
- Does **not** re-register `VNX_EVIDENCE_BOUND_GATE` / `VNX_PLAN_GATE_ENFORCE` (already registered; PR-1 backfilled their subsystem/status).
- No read-site wiring — registering these flags does not change any gate/enforcement decision.
- Dashboard `operator/config` page now renders a cockpit status badge (LIVE/PARK/CUT/ACTIVATE/SCOPE/COCKPIT) and the subsystem name per row; `ConfigEntryRow` type gets optional `subsystem`/`status` fields.
- `dashboard/api_config.py` required no change — it passes `config_registry.all_effective()` through transparently.

## Changes
- `scripts/lib/config_registry.py` — 8 new `ConfigEntry` rows in `CONFIG_REGISTRY`, all default off (`VNX_MIGRATION_SYSTEM` is `enum` default `"manifest"`, `writable=False`). Approval required on `VNX_GOVERNANCE_ENFORCED`, `VNX_HASH_CHAIN_REQUIRED`, `VNX_ATTESTATION_REQUIRED`.
- `dashboard/token-dashboard/lib/types.ts` — added optional `subsystem`/`status` fields to `ConfigEntryRow`.
- `dashboard/token-dashboard/app/operator/config/page.tsx` — status badge + subsystem label per config row.
- `tests/test_config_registry.py` — new-flag existence/defaults, approval requirements, subsystem/status correctness, non-duplication of `VNX_EVIDENCE_BOUND_GATE`/`VNX_PLAN_GATE_ENFORCE`, and a metadata-only guarantee (`get()` returns the default when nothing overrides it).
- `tests/test_api_config.py` — asserts `/api/operator/config` returns all 8 new flags, with `VNX_MIGRATION_SYSTEM` read-only defaulting to `"manifest"`.

## Test plan
- [x] `python3 -m pytest tests/test_config_registry.py tests/test_api_config.py -v` — 40 passed
- [x] `python3 -m pytest tests/test_config_runtime.py tests/test_audit_correctness_fixes.py -q` (adjacent tests that iterate `CONFIG_REGISTRY`) — 29 passed
- [x] `npx jest __tests__/config-page.test.tsx` (dashboard/token-dashboard) — 7 passed
- [x] `npx tsc --noEmit` (dashboard/token-dashboard) — clean

## Open items
None — codex review gate was not run in this dispatch (per the dispatch's codex-unavailable note, file a codex-unavailable OI if the standard review gate can't run against this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)