### PR TITLE
feat(health): add effectiveness probe registry and base class

### DIFF
--- a/scripts/lib/effectiveness_probe.py
+++ b/scripts/lib/effectiveness_probe.py
@@ -1,0 +1,129 @@
+"""effectiveness_probe — read-only "does it produce crap?" probe framework.
+
+The cockpit (docs/core/SUBSYSTEMS.md) needs a HEALTH signal per subsystem that is
+measured, not guessed. This module is the framework every concrete probe (PR-6's
+injection-effectiveness probe, PR-7's governance/plan-gate/migration probes) plugs
+into: a small ABC (``EffectivenessProbe``), a result shape (``ProbeResult``), a
+subsystem -> probe-class registry (``EFFECTIVENESS_PROBES``), and the vocabulary
+translation into ``health_beacon``'s status strings (``PROBE_TO_BEACON``).
+
+ADR-007 scope: probes are read-only over existing stores and write only file-based
+beacons under ``<state_dir>/health/`` via ``health_beacon.py`` (see
+subsystem_health.py). They create no new central-DB table, so the ADR-007
+composite-``project_id``-key requirement does not attach to this module.
+
+A tampered/broken hash-chain maps to beacon ``fail``, NOT ``corrupt``:
+``health_beacon.py`` derives ``corrupt`` only from unreadable JSON, and
+``all_beacons()`` has no ``status == "corrupt"`` branch — routing a probe's tamper
+signal there would silently fall through to the staleness/ok branch. A probe that
+detects tampering must classify as ``produces_crap`` (-> beacon ``fail``) and record
+``"tamper"`` in its raw detail; ``corrupt`` stays owned by the beacon layer.
+"""
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Any, Callable, Dict, Type
+
+# The only status values a probe may report. A total vocabulary — every concrete
+# probe's health() must return exactly one of these for every possible input.
+PROBE_STATUSES = frozenset(("ok", "degraded", "produces_crap", "unknown"))
+
+
+@dataclass(frozen=True)
+class ProbeResult:
+    """The outcome of running one probe: a classification, a one-line summary,
+    and the raw signal that produced them (for the beacon `details` payload)."""
+
+    status: str
+    signal: str
+    detail: Dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.status not in PROBE_STATUSES:
+            raise ValueError(
+                f"invalid ProbeResult.status {self.status!r}; must be one of "
+                f"{sorted(PROBE_STATUSES)}"
+            )
+
+
+class EffectivenessProbe(abc.ABC):
+    """Base class for a read-only subsystem effectiveness probe.
+
+    Subclasses implement three total functions:
+
+    - ``probe()``       -- gather raw, read-only signal. No side effects, no writes.
+    - ``signal(raw)``   -- render the raw signal as a one-line human summary.
+    - ``health(raw)``   -- classify the raw signal into one of ``PROBE_STATUSES``.
+
+    ``run()`` is the concrete orchestrator: it calls the three in order and
+    returns a ``ProbeResult``. Callers (``subsystem_health.aggregate()``) use
+    ``run()``, not the individual hooks, so every probe is exercised the same way.
+    """
+
+    subsystem: str = ""
+
+    @abc.abstractmethod
+    def probe(self) -> Dict[str, Any]:
+        """Gather raw signal for this subsystem. Read-only; no side effects."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def signal(self, raw: Dict[str, Any]) -> str:
+        """One-line human-readable summary of ``raw``."""
+        raise NotImplementedError
+
+    @abc.abstractmethod
+    def health(self, raw: Dict[str, Any]) -> str:
+        """Classify ``raw`` into one of ``PROBE_STATUSES``. Total function of ``raw``."""
+        raise NotImplementedError
+
+    def run(self) -> ProbeResult:
+        """Run probe() -> health()/signal() -> ProbeResult, in that fixed order."""
+        raw = self.probe()
+        return ProbeResult(status=self.health(raw), signal=self.signal(raw), detail=raw)
+
+
+# subsystem name -> probe class. Concrete probes register themselves here, either
+# via direct assignment or the ``register_probe`` decorator below. Empty until
+# PR-6/PR-7 register the injection-effectiveness and governance/plan-gate/migration
+# probes; a subsystem with no entry here reports `unknown` (see subsystem_health.py).
+EFFECTIVENESS_PROBES: Dict[str, Type["EffectivenessProbe"]] = {}
+
+
+def register_probe(subsystem: str) -> Callable[[Type["EffectivenessProbe"]], Type["EffectivenessProbe"]]:
+    """Class decorator: register a concrete probe under ``subsystem``.
+
+    Usage::
+
+        @register_probe("intelligence-self-learning-loop")
+        class InjectionEffectivenessProbe(EffectivenessProbe):
+            ...
+    """
+
+    def _decorate(cls: Type["EffectivenessProbe"]) -> Type["EffectivenessProbe"]:
+        EFFECTIVENESS_PROBES[subsystem] = cls
+        return cls
+
+    return _decorate
+
+
+# Probe status vocabulary -> health_beacon.py status string. Deliberately partial:
+# "unknown" has NO entry — a subsystem with no registered probe gets no beacon
+# written at all (see subsystem_health.aggregate()); it is reported as `unknown`
+# with signal "no probe registered" in the aggregator's return value only.
+PROBE_TO_BEACON: Dict[str, str] = {
+    "ok": "ok",
+    "degraded": "stale",
+    "produces_crap": "fail",
+}
+
+
+__all__ = [
+    "PROBE_STATUSES",
+    "ProbeResult",
+    "EffectivenessProbe",
+    "EFFECTIVENESS_PROBES",
+    "register_probe",
+    "PROBE_TO_BEACON",
+]

--- a/scripts/lib/subsystem_health.py
+++ b/scripts/lib/subsystem_health.py
@@ -1,0 +1,86 @@
+"""subsystem_health — runs every registered effectiveness probe and emits a
+HealthBeacon per subsystem (framework-status-audit-and-cockpit PR-5).
+
+This module SUPPLIES the aggregator behind PR-3's guarded ``vnx subsystems
+--probe`` import: PR-3 owns ``scripts/lib/subsystems.py`` (the CLI) and imports
+this module at call time; this module does not import or edit PR-3's CLI, so the
+two PRs are parallel siblings with no cross-file edit and no added DAG dependency.
+Before PR-3 lands, nothing in the CLI surface changes.
+
+ADR-007 scope: ``aggregate()`` is read-only over ``config_registry`` and each
+probe's own read-only signal sources. Its only write is the beacon file under
+``<state_dir>/health/<subsystem>.json`` via ``health_beacon.HealthBeacon``
+(itself a read-only-safe atomic file write, not a DB table). No new central-DB
+table is created, so the ADR-007 composite-``project_id``-key requirement does
+not attach.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import config_registry  # noqa: E402  (after the scripts/lib path guard above)
+import project_root  # noqa: E402
+from effectiveness_probe import (  # noqa: E402
+    EFFECTIVENESS_PROBES,
+    PROBE_TO_BEACON,
+    ProbeResult,
+)
+from health_beacon import HealthBeacon  # noqa: E402
+
+
+def known_subsystems() -> List[str]:
+    """Every cockpit subsystem name: flag-backed entries from ``CONFIG_REGISTRY``,
+    flag-less entries from ``CONFIG_REGISTRY_SUBSYSTEMS``, and any subsystem with a
+    registered probe but no registry entry yet. Deduped and sorted."""
+    names = {
+        entry.subsystem
+        for entry in config_registry.CONFIG_REGISTRY.values()
+        if entry.subsystem
+    }
+    names |= set(config_registry.CONFIG_REGISTRY_SUBSYSTEMS.keys())
+    names |= set(EFFECTIVENESS_PROBES.keys())
+    return sorted(names)
+
+
+def aggregate(
+    state_dir: Optional[Path] = None,
+    subsystems: Optional[Iterable[str]] = None,
+) -> Dict[str, Dict[str, Any]]:
+    """Run every registered probe over ``subsystems`` (default: every known
+    cockpit subsystem), write a beacon for each probed result, and return a dict
+    keyed by subsystem name -> ``{"status", "signal", "detail"}``.
+
+    A subsystem with no entry in ``EFFECTIVENESS_PROBES`` reports
+    ``status="unknown"``, ``signal="no probe registered"`` and gets NO beacon
+    written (there is nothing measured to persist).
+    """
+    if state_dir is None:
+        state_dir = project_root.resolve_data_dir(__file__)
+    state_dir = Path(state_dir)
+
+    target = sorted(subsystems) if subsystems is not None else known_subsystems()
+
+    results: Dict[str, Dict[str, Any]] = {}
+    for name in target:
+        probe_cls = EFFECTIVENESS_PROBES.get(name)
+        if probe_cls is None:
+            result = ProbeResult(status="unknown", signal="no probe registered", detail={})
+        else:
+            result = probe_cls().run()
+
+        results[name] = {"status": result.status, "signal": result.signal, "detail": result.detail}
+
+        beacon_status = PROBE_TO_BEACON.get(result.status)
+        if beacon_status is not None:
+            HealthBeacon(state_dir, name).heartbeat(status=beacon_status, details=result.detail)
+
+    return results
+
+
+__all__ = ["known_subsystems", "aggregate"]

--- a/tests/test_effectiveness_probe.py
+++ b/tests/test_effectiveness_probe.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/lib/effectiveness_probe.py — the base probe framework
+(framework-status-audit-and-cockpit PR-5).
+
+Dispatch-ID: 20260712-183939-cockpit-pr5
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from effectiveness_probe import (  # noqa: E402
+    EFFECTIVENESS_PROBES,
+    PROBE_STATUSES,
+    PROBE_TO_BEACON,
+    EffectivenessProbe,
+    ProbeResult,
+    register_probe,
+)
+
+
+class _DummyProbe(EffectivenessProbe):
+    subsystem = "dummy-subsystem"
+
+    def probe(self):
+        return {"used": 3, "ignored": 1}
+
+    def signal(self, raw):
+        return f"used={raw['used']} ignored={raw['ignored']}"
+
+    def health(self, raw):
+        return "ok" if raw["ignored"] < raw["used"] else "produces_crap"
+
+
+def test_dummy_probe_run_returns_probe_result_with_expected_shape():
+    result = _DummyProbe().run()
+
+    assert isinstance(result, ProbeResult)
+    assert result.status == "ok"
+    assert result.signal == "used=3 ignored=1"
+    assert result.detail == {"used": 3, "ignored": 1}
+
+
+def test_probe_result_rejects_status_outside_vocabulary():
+    with pytest.raises(ValueError):
+        ProbeResult(status="bogus", signal="x", detail={})
+
+
+def test_probe_result_accepts_every_vocabulary_status():
+    for status in PROBE_STATUSES:
+        result = ProbeResult(status=status, signal="s", detail={})
+        assert result.status == status
+
+
+def test_abstract_base_cannot_be_instantiated_directly():
+    with pytest.raises(TypeError):
+        EffectivenessProbe()  # type: ignore[abstract]
+
+
+def test_register_probe_decorator_populates_registry():
+    EFFECTIVENESS_PROBES.pop("dummy-subsystem", None)
+    try:
+        @register_probe("dummy-subsystem")
+        class _RegisteredProbe(EffectivenessProbe):
+            subsystem = "dummy-subsystem"
+
+            def probe(self):
+                return {}
+
+            def signal(self, raw):
+                return "registered"
+
+            def health(self, raw):
+                return "ok"
+
+        assert EFFECTIVENESS_PROBES["dummy-subsystem"] is _RegisteredProbe
+    finally:
+        EFFECTIVENESS_PROBES.pop("dummy-subsystem", None)
+
+
+def test_probe_to_beacon_mapping_matches_prd_contract():
+    assert PROBE_TO_BEACON["ok"] == "ok"
+    assert PROBE_TO_BEACON["degraded"] == "stale"
+    assert PROBE_TO_BEACON["produces_crap"] == "fail"
+    # "unknown" is deliberately absent: no probe registered -> no beacon written.
+    assert "unknown" not in PROBE_TO_BEACON
+
+
+def test_tampered_signal_classifies_as_produces_crap_not_a_beacon_corrupt_bypass():
+    """A tampered/broken hash-chain must map to beacon `fail`, never `corrupt`
+    (health_beacon.py reserves `corrupt` for unreadable JSON — see module docstring)."""
+
+    class _TamperProbe(EffectivenessProbe):
+        subsystem = "receipt-hash-chain"
+
+        def probe(self):
+            return {"chain_status": "broken", "tamper": True}
+
+        def signal(self, raw):
+            return "hash-chain broken: tamper detected"
+
+        def health(self, raw):
+            return "produces_crap" if raw.get("tamper") else "ok"
+
+    result = _TamperProbe().run()
+
+    assert result.status == "produces_crap"
+    assert result.detail["tamper"] is True
+    assert PROBE_TO_BEACON[result.status] == "fail"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_subsystem_health.py
+++ b/tests/test_subsystem_health.py
@@ -1,0 +1,119 @@
+"""Tests for scripts/lib/subsystem_health.py — the probe aggregator
+(framework-status-audit-and-cockpit PR-5).
+
+Dispatch-ID: 20260712-183939-cockpit-pr5
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import subsystem_health  # noqa: E402
+from effectiveness_probe import EFFECTIVENESS_PROBES, EffectivenessProbe  # noqa: E402
+
+
+class _OkProbe(EffectivenessProbe):
+    subsystem = "probe-ok-subsystem"
+
+    def probe(self):
+        return {"signal": "fine"}
+
+    def signal(self, raw):
+        return "all good"
+
+    def health(self, raw):
+        return "ok"
+
+
+class _CrapProbe(EffectivenessProbe):
+    subsystem = "probe-crap-subsystem"
+
+    def probe(self):
+        return {"tamper": True}
+
+    def signal(self, raw):
+        return "broken chain"
+
+    def health(self, raw):
+        return "produces_crap"
+
+
+def test_aggregate_runs_registered_probes_and_reports_unknown_for_the_rest(monkeypatch, tmp_path):
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-ok-subsystem", _OkProbe)
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-crap-subsystem", _CrapProbe)
+
+    results = subsystem_health.aggregate(
+        state_dir=tmp_path,
+        subsystems=["probe-ok-subsystem", "probe-crap-subsystem", "no-probe-subsystem"],
+    )
+
+    assert results["probe-ok-subsystem"]["status"] == "ok"
+    assert results["probe-crap-subsystem"]["status"] == "produces_crap"
+    assert results["probe-crap-subsystem"]["detail"]["tamper"] is True
+    assert results["no-probe-subsystem"]["status"] == "unknown"
+    assert results["no-probe-subsystem"]["signal"] == "no probe registered"
+
+
+def test_aggregate_emits_beacons_under_health_dir_for_probed_subsystems(monkeypatch, tmp_path):
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-ok-subsystem", _OkProbe)
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-crap-subsystem", _CrapProbe)
+
+    subsystem_health.aggregate(
+        state_dir=tmp_path,
+        subsystems=["probe-ok-subsystem", "probe-crap-subsystem"],
+    )
+
+    ok_beacon = tmp_path / "health" / "probe-ok-subsystem.json"
+    crap_beacon = tmp_path / "health" / "probe-crap-subsystem.json"
+    assert ok_beacon.exists()
+    assert crap_beacon.exists()
+
+    ok_payload = json.loads(ok_beacon.read_text(encoding="utf-8"))
+    crap_payload = json.loads(crap_beacon.read_text(encoding="utf-8"))
+    assert ok_payload["status"] == "ok"
+    # produces_crap -> beacon "fail", never "corrupt" (see effectiveness_probe.py docstring).
+    assert crap_payload["status"] == "fail"
+    assert crap_payload["details"]["tamper"] is True
+
+
+def test_aggregate_writes_no_beacon_for_unknown_status(tmp_path):
+    subsystem_health.aggregate(state_dir=tmp_path, subsystems=["no-probe-subsystem"])
+
+    beacon_path = tmp_path / "health" / "no-probe-subsystem.json"
+    assert not beacon_path.exists()
+
+
+def test_known_subsystems_includes_registry_and_probe_names(monkeypatch):
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-ok-subsystem", _OkProbe)
+
+    names = subsystem_health.known_subsystems()
+
+    # Flag-backed (config_registry.CONFIG_REGISTRY) and flag-less
+    # (CONFIG_REGISTRY_SUBSYSTEMS) entries are both present.
+    assert "governance-enforcement-stack" in names
+    assert "phantom_guard" in names
+    # A subsystem with only a registered probe (no registry entry) is present too.
+    assert "probe-ok-subsystem" in names
+    assert names == sorted(set(names))
+
+
+def test_aggregate_default_subsystems_covers_the_known_universe(monkeypatch, tmp_path):
+    monkeypatch.setitem(EFFECTIVENESS_PROBES, "probe-ok-subsystem", _OkProbe)
+
+    results = subsystem_health.aggregate(state_dir=tmp_path)
+
+    assert results["probe-ok-subsystem"]["status"] == "ok"
+    assert results["governance-enforcement-stack"]["status"] == "unknown"
+    assert results["governance-enforcement-stack"]["signal"] == "no probe registered"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

Implements PR-5 of `framework-status-audit-and-cockpit`: the effectiveness probe framework + aggregator. See `docs/core/framework-status-audit-and-cockpit_PRD.md` §PR-5.

- `scripts/lib/effectiveness_probe.py` — `EffectivenessProbe` ABC (`probe()`/`signal()`/`health()`, orchestrated by a concrete `run()`), `ProbeResult` dataclass (`status ∈ {ok, degraded, produces_crap, unknown}`), `EFFECTIVENESS_PROBES` subsystem→class registry (+ `register_probe` decorator), `PROBE_TO_BEACON` vocabulary translation.
- `scripts/lib/subsystem_health.py` — `aggregate()` runs every registered probe (default: every known cockpit subsystem, pulled from `config_registry`), writes a `HealthBeacon` per probed result under `<state_dir>/health/`, and reports `unknown`/`"no probe registered"` (no beacon write) for subsystems with no probe.

**Key rule enforced:** a tampered/broken hash-chain classifies `produces_crap` → beacon `fail`, never `corrupt` (`health_beacon.py` reserves `corrupt` for unreadable JSON; `all_beacons()` has no `status=='corrupt'` branch). Covered by a dedicated test.

This PR supplies the module behind PR-3's guarded `vnx subsystems --probe` import — it does not touch PR-3's `subsystems.py` (parallel sibling PRs, no cross-file edit, no added DAG dependency).

**pr_type:** `feat` · **review floor (advisory):** codex + kimi

## Changes

- `scripts/lib/effectiveness_probe.py` (new, 129 LOC)
- `scripts/lib/subsystem_health.py` (new, 86 LOC)
- `tests/test_effectiveness_probe.py` (new)
- `tests/test_subsystem_health.py` (new)

215 LOC of source (within the ≤300 budget). No existing files modified.

## Verification

- `python3 -m pytest tests/test_effectiveness_probe.py tests/test_subsystem_health.py -v` → **12 passed**
- `python3 -c "import py_compile; py_compile.compile('scripts/lib/effectiveness_probe.py', doraise=True); py_compile.compile('scripts/lib/subsystem_health.py', doraise=True)"` → OK
- Manual smoke: imported `subsystem_health` standalone and ran `known_subsystems()` — returns 20 subsystems sourced from `config_registry.CONFIG_REGISTRY` + `CONFIG_REGISTRY_SUBSYSTEMS`.

ADR-007: probes are read-only over existing stores; the only write is the file-based `HealthBeacon`, no new central-DB table — composite-`project_id` requirement does not attach.

## Open Items

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)