### PR TITLE
chore(migrations): lock the full migration-surface inventory (evidence for the parked consolidation track)

### DIFF
--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -11,7 +11,7 @@ This document is the single source of truth for which VNX subsystems are live, p
 | zero-llm-injection | No prompt injection via environment or receipts; strict input boundaries. | — | LIVE | works — red-team tests pass |
 | dispatch-plan | Single-entry dispatch door, dispatch-plan reconciliation. | — | LIVE | works — dispatch tests pass |
 | test-suite | Pytest + integration coverage for kernel and cockpit. | — | LIVE | works — CI green |
-| migration-mechanisms | Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation PARKed pending inventory-lock. | `VNX_MIGRATION_SYSTEM` | PARK-with-trigger | degraded — 42 SQL files + 6 appliers; collapse deferred to a verified track |
+| migration-mechanisms | Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation PARKed pending inventory-lock. | `VNX_MIGRATION_SYSTEM` | PARK-with-trigger | degraded — 42 SQL files + 6 appliers; consolidation PARKed pending inventory-lock (`scripts/lib/migration_inventory.py`, PR-8) |
 | within-db-tenancy | Composite `(project_id, id)` keys inside per-project DBs. Removal PARKed pending per-table central-DB safety proof. | — | PARK-with-trigger | degraded — keys present; drop deferred (central-store/dual-write/ADR-026 interaction) |
 | docs-bloat | Comparisons, stale archive, marketing docs inflating `docs/` count. | — | CUT | degraded — ~288 markdown files, large `_archive/` |
 | governance-enforcement-stack | Receipt hash-chain + signed attestation + evidence-bound merge gate. SURFACED here; enforcement wiring deferred. | `VNX_GOVERNANCE_ENFORCED` | PARK-with-trigger | produces-crap — 15,577 receipts, 0 `prev_hash` |

--- a/scripts/lib/migration_inventory.py
+++ b/scripts/lib/migration_inventory.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""migration_inventory.py — read-only inventory lock over the VNX migration surface (PR-8).
+
+Evidence artifact for the parked `migration-consolidation-and-tenancy-cut` track
+(docs/core/framework-status-audit-and-cockpit_PRD.md §PR-8). This module DELETES
+or DEPRECATES nothing — it only enumerates the six migration surfaces (SQL files,
+Python appliers, the manifest reconciler, the schema-migration helpers, the ADR-007
+tenancy stamper, and the CLI entrypoint), classifies every touched table as
+central-DB (shared) vs per-project, and exposes `verify_complete()` as a read-only
+fs<->git completeness oracle.
+
+Table classification (ADR-007): every table below lives in one of the three
+central VNX state DBs (quality_intelligence.db, runtime_coordination.db,
+dispatch_tracker.db) that schemas/migrations/*.sql exclusively evolves — see
+docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md, which binds
+"every new central-DB table MUST be project_id-stamped at design time". Verified
+against the tree 2026-07-12: every CREATE TABLE in this surface carries
+`project_id TEXT NOT NULL DEFAULT 'vnx-dev'`. There is currently no per-project-only
+table in this surface; a future migration that adds one and is not added to
+CENTRAL_DB_TABLES fails verify_complete() loudly instead of silently reading
+"unknown".
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+try:
+    from project_root import resolve_project_root
+except ImportError:  # pragma: no cover - direct execution without scripts/lib on sys.path
+    import sys
+
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    from project_root import resolve_project_root
+
+
+CENTRAL_DB_TABLES: Dict[str, bool] = {
+    name: True
+    for name in (
+        "antipatterns", "central_install_events", "central_install_pins",
+        "code_snippets", "confidence_events", "coordination_events",
+        "cross_project_recommendations", "dispatch_attempts", "dispatch_metadata",
+        "dispatch_pattern_offered", "dispatch_quality_context", "dispatches",
+        "dream_cycles", "dream_pattern_archives", "escalation_log",
+        "execution_targets", "global_patterns", "governance_metrics",
+        "headless_runs", "improvement_suggestions", "inbound_inbox",
+        "incident_log", "intelligence_injections", "nightly_digests",
+        "pattern_usage", "pool_config", "prevention_rules", "quality_alerts",
+        "quality_system_metrics", "quality_trends", "recommendation_outcomes",
+        "recommendations", "report_findings", "retry_budgets", "retry_state",
+        "runtime_schema_version", "scan_history", "schema_version",
+        "session_analytics", "snippet_metadata", "sqlite_sequence",
+        "success_patterns", "tag_combinations", "terminal_leases",
+        "track_dependencies", "track_open_items", "track_phase_history",
+        "tracks", "vnx_code_quality", "worker_pool_membership",
+        "worker_pools", "worker_states",
+    )
+}
+
+# Files whose only executable statements do not mechanically resolve to a table
+# name via the statement parser below (a documentation-only migration whose SQL
+# is fully commented out; a DROP-INDEX-only down-migration whose index names
+# encode the table by naming convention, not a parseable `ON <table>` clause).
+# Hand-verified against the file text 2026-07-12.
+_MANUAL_TABLE_OVERRIDES: Dict[str, Tuple[str, ...]] = {
+    "0016_rebuild_fts5.sql": ("code_snippets",),
+    "2026_05_task_subclass_down.sql": ("success_patterns", "antipatterns"),
+}
+
+_COMMENT_RE = re.compile(r"--.*?$", re.MULTILINE)
+_STMT_TABLE_RE = re.compile(
+    r"^\s*(?:"
+    r"CREATE\s+(?:TEMP(?:ORARY)?\s+)?(?:VIRTUAL\s+)?TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?P<t1>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|ALTER\s+TABLE\s+(?P<t2>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?P<t3>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|CREATE\s+(?:UNIQUE\s+)?INDEX\s+(?:IF\s+NOT\s+EXISTS\s+)?[A-Za-z_][A-Za-z0-9_]*\s+ON\s+(?P<t4>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|UPDATE\s+(?P<t5>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|DELETE\s+FROM\s+(?P<t6>[A-Za-z_][A-Za-z0-9_]*)"
+    r"|INSERT\s+(?:OR\s+(?:IGNORE|REPLACE)\s+)?INTO\s+(?P<t7>[A-Za-z_][A-Za-z0-9_]*)"
+    r")",
+    re.IGNORECASE,
+)
+# Collapses migration-internal rebuild artifacts (dispatches_v10, tracks_pre_v24,
+# dispatch_attempts_new, tracks_pre_0027_down, ...) to the logical table name.
+_SUFFIX_RE = re.compile(r"_(?:v\d+|new|pre_v\d+(?:_down)?|pre_\d+_down)$")
+
+
+def _canonical_table(raw: str) -> str:
+    name = raw
+    prev = None
+    while prev != name:
+        prev = name
+        name = _SUFFIX_RE.sub("", name)
+    return name
+
+
+def tables_touched_in_sql(text: str, filename: str = "") -> Tuple[str, ...]:
+    """Canonical table names one migration file touches.
+
+    Parses statement-by-statement (line comments stripped, split on ';') so a
+    free-text comment mentioning "CREATE TABLE" never produces a false-positive
+    table name — only text at the START of an executable statement matches.
+    """
+    stripped = _COMMENT_RE.sub("", text)
+    found: List[str] = []
+    for stmt in stripped.split(";"):
+        m = _STMT_TABLE_RE.match(stmt.strip())
+        if m:
+            raw = next(v for v in m.groupdict().values() if v)
+            found.append(_canonical_table(raw))
+    if not found and filename in _MANUAL_TABLE_OVERRIDES:
+        found = list(_MANUAL_TABLE_OVERRIDES[filename])
+    seen: set = set()
+    ordered: List[str] = []
+    for t in found:
+        if t not in seen:
+            seen.add(t)
+            ordered.append(t)
+    return tuple(ordered)
+
+
+@dataclass(frozen=True)
+class TableTouch:
+    table: str
+    central_db: Optional[bool]  # None == unclassified ("unknown")
+
+
+@dataclass(frozen=True)
+class MigrationSurface:
+    surface_id: int
+    name: str
+    paths: Tuple[str, ...]
+    file_count: int
+    tables_touched: Tuple[TableTouch, ...]
+    # Surface 1 only: per-file table breakdown, for the completeness oracle.
+    per_file_tables: Tuple[Tuple[str, Tuple[str, ...]], ...] = ()
+
+
+def _sql_files(root: Path) -> List[Path]:
+    return sorted((root / "schemas" / "migrations").glob("*.sql"))
+
+
+def _applier_files(root: Path) -> List[Path]:
+    return sorted((root / "scripts" / "lib" / "migrations").glob("apply_*.py"))
+
+
+def _rel(root: Path, path: Path) -> str:
+    return str(path.relative_to(root))
+
+
+def build_inventory(root: Optional[Path] = None) -> Tuple[MigrationSurface, ...]:
+    """Enumerate all six migration surfaces, read-only, rooted at *root*.
+
+    *root* defaults to the repo root (git-resolved) but is a real parameter so
+    callers — including the completeness oracle's negative test — can point it
+    at an isolated temp directory instead of the real repo.
+    """
+    root = (root or resolve_project_root(__file__)).resolve()
+
+    sql_files = _sql_files(root)
+    per_file_tables: List[Tuple[str, Tuple[str, ...]]] = []
+    distinct_tables: Dict[str, Optional[bool]] = {}
+    for f in sql_files:
+        touched = tables_touched_in_sql(f.read_text(encoding="utf-8"), f.name)
+        per_file_tables.append((f.name, touched))
+        for t in touched:
+            distinct_tables[t] = CENTRAL_DB_TABLES.get(t)
+
+    applier_files = _applier_files(root)
+
+    return (
+        MigrationSurface(
+            surface_id=1,
+            name="sql-migrations",
+            paths=tuple(_rel(root, p) for p in sql_files),
+            file_count=len(sql_files),
+            tables_touched=tuple(
+                TableTouch(t, c) for t, c in sorted(distinct_tables.items())
+            ),
+            per_file_tables=tuple(per_file_tables),
+        ),
+        MigrationSurface(
+            surface_id=2,
+            name="python-appliers",
+            paths=tuple(_rel(root, p) for p in applier_files),
+            file_count=len(applier_files),
+            tables_touched=(),
+        ),
+        MigrationSurface(
+            surface_id=3,
+            name="schema-manifest",
+            paths=(_rel(root, root / "scripts" / "lib" / "schema_manifest.py"),),
+            file_count=1,
+            tables_touched=(),
+        ),
+        MigrationSurface(
+            surface_id=4,
+            name="schema-migration-helpers",
+            paths=(
+                _rel(root, root / "scripts" / "lib" / "schema_migration.py"),
+                _rel(root, root / "scripts" / "lib" / "migrations" / "auto_apply.py"),
+            ),
+            file_count=2,
+            tables_touched=(),
+        ),
+        MigrationSurface(
+            surface_id=5,
+            name="project-id-migration",
+            paths=(_rel(root, root / "scripts" / "lib" / "project_id_migration.py"),),
+            file_count=1,
+            tables_touched=(),
+        ),
+        MigrationSurface(
+            surface_id=6,
+            name="migrate-cli",
+            paths=(_rel(root, root / "vnx_cli" / "commands" / "migrate.py"),),
+            file_count=1,
+            tables_touched=(),
+        ),
+    )
+
+
+@dataclass(frozen=True)
+class CompletenessResult:
+    ok: bool
+    violations: Tuple[str, ...]
+
+
+def verify_complete(root: Optional[Path] = None) -> CompletenessResult:
+    """Read-only completeness oracle over ONE shared migrations root.
+
+    1. The fs-glob enumeration of ``<root>/schemas/migrations/*.sql`` must equal
+       ``git ls-files`` for the same glob, over the SAME root: a file on disk but
+       untracked, or tracked but missing on disk, is itself a FAIL.
+    2. Every ``scripts/lib/migrations/apply_*.py`` on disk must be represented in
+       the applier surface (surface 2).
+    3. Every SQL file enumerated in surface 1 must resolve to >=1 touched table,
+       and every touched table must carry a non-unknown ``central_db`` value.
+    """
+    root = (root or resolve_project_root(__file__)).resolve()
+    violations: List[str] = []
+
+    migrations_dir = root / "schemas" / "migrations"
+    fs_sql = {p.name for p in migrations_dir.glob("*.sql")} if migrations_dir.is_dir() else set()
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "ls-files", "schemas/migrations/*.sql"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        git_sql = {Path(line).name for line in proc.stdout.splitlines() if line.strip()}
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError) as exc:
+        violations.append(f"git ls-files failed: {exc}")
+        git_sql = set()
+
+    only_on_disk = fs_sql - git_sql
+    only_in_git = git_sql - fs_sql
+    if only_on_disk:
+        violations.append(f"untracked on disk (not in git): {sorted(only_on_disk)}")
+    if only_in_git:
+        violations.append(f"tracked in git but missing on disk: {sorted(only_in_git)}")
+
+    surfaces = build_inventory(root)
+    sql_surface, applier_surface = surfaces[0], surfaces[1]
+
+    applier_names_on_disk = {p.name for p in _applier_files(root)}
+    applier_names_in_surface = {Path(p).name for p in applier_surface.paths}
+    missing_appliers = applier_names_on_disk - applier_names_in_surface
+    if missing_appliers:
+        violations.append(f"applier(s) on disk but not in surface 2: {sorted(missing_appliers)}")
+
+    classification = {tt.table: tt.central_db for tt in sql_surface.tables_touched}
+    for fname, tables in sql_surface.per_file_tables:
+        if not tables:
+            violations.append(f"{fname}: resolved to 0 touched tables")
+            continue
+        for t in tables:
+            if classification.get(t) is None:
+                violations.append(f"{fname}: table {t!r} has unknown central_db classification")
+
+    return CompletenessResult(ok=not violations, violations=tuple(violations))
+
+
+if __name__ == "__main__":  # pragma: no cover - manual inspection entrypoint
+    for surface in build_inventory():
+        print(f"[{surface.surface_id}] {surface.name}: {surface.file_count} file(s)")
+        for p in surface.paths[:3]:
+            print(f"    {p}")
+        if surface.file_count > 3:
+            print(f"    ... +{surface.file_count - 3} more")
+    result = verify_complete()
+    print(f"verify_complete: ok={result.ok}")
+    for v in result.violations:
+        print(f"  - {v}")

--- a/tests/test_migration_inventory.py
+++ b/tests/test_migration_inventory.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""Tests for migration_inventory — the six-surface migration inventory-lock (PR-8).
+
+Dispatch-ID: 20260712-183939-cockpit-pr8
+
+Read-only cataloguing only: these tests assert enumeration counts and shape, not
+that anything is removed or migrated.
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import migration_inventory as mi  # noqa: E402
+
+
+def test_six_surfaces_present():
+    surfaces = mi.build_inventory(REPO)
+    assert [s.surface_id for s in surfaces] == [1, 2, 3, 4, 5, 6]
+    names = {s.name for s in surfaces}
+    assert names == {
+        "sql-migrations",
+        "python-appliers",
+        "schema-manifest",
+        "schema-migration-helpers",
+        "project-id-migration",
+        "migrate-cli",
+    }
+
+
+def test_sql_surface_has_at_least_42_files():
+    surfaces = mi.build_inventory(REPO)
+    sql_surface = surfaces[0]
+    assert sql_surface.file_count >= 42
+    assert len(sql_surface.paths) == sql_surface.file_count
+    assert all(p.endswith(".sql") for p in sql_surface.paths)
+
+
+def test_applier_surface_has_six_runners():
+    surfaces = mi.build_inventory(REPO)
+    applier_surface = surfaces[1]
+    assert applier_surface.file_count == 6
+    names = {Path(p).stem for p in applier_surface.paths}
+    assert names == {
+        "apply_0017", "apply_0019", "apply_0020",
+        "apply_0022", "apply_0024", "apply_0026",
+    }
+
+
+def test_single_file_surfaces_point_at_real_paths():
+    surfaces = mi.build_inventory(REPO)
+    for surface in surfaces[2:]:
+        assert surface.file_count == len(surface.paths)
+        for p in surface.paths:
+            assert (REPO / p).is_file(), f"{p} missing on disk for surface {surface.name}"
+
+
+def test_no_file_is_deleted_or_modified_by_import():
+    # This module is read-only cataloguing: importing/building the inventory
+    # must not touch the working tree.
+    import subprocess
+
+    before = subprocess.run(
+        ["git", "-C", str(REPO), "status", "--porcelain", "schemas/migrations"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    mi.build_inventory(REPO)
+    after = subprocess.run(
+        ["git", "-C", str(REPO), "status", "--porcelain", "schemas/migrations"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert before == after

--- a/tests/test_migration_inventory_classification.py
+++ b/tests/test_migration_inventory_classification.py
@@ -1,0 +1,47 @@
+#!/usr/bin/env python3
+"""Tests for migration_inventory table classification (central_db vs per-project).
+
+Dispatch-ID: 20260712-183939-cockpit-pr8
+
+ADR-007 grounding: every table touched by schemas/migrations/*.sql lives in one
+of the three central VNX state DBs, so every touched table must classify as a
+real bool — never `unknown` (None).
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import migration_inventory as mi  # noqa: E402
+
+
+def test_every_touched_table_has_a_classification():
+    surfaces = mi.build_inventory(REPO)
+    sql_surface = surfaces[0]
+    assert sql_surface.tables_touched, "expected at least one touched table"
+    unknown = [tt.table for tt in sql_surface.tables_touched if tt.central_db is None]
+    assert unknown == [], f"tables with no central_db classification: {unknown}"
+
+
+def test_every_touched_table_is_central_db_true():
+    # Verified 2026-07-12: the entire schemas/migrations/ surface exclusively
+    # evolves the three central stores (quality_intelligence.db,
+    # runtime_coordination.db, dispatch_tracker.db) per ADR-007. There is
+    # currently no per-project-only table in this surface.
+    surfaces = mi.build_inventory(REPO)
+    sql_surface = surfaces[0]
+    non_central = [tt.table for tt in sql_surface.tables_touched if tt.central_db is not True]
+    assert non_central == []
+
+
+def test_every_sql_file_resolves_to_at_least_one_table():
+    surfaces = mi.build_inventory(REPO)
+    sql_surface = surfaces[0]
+    empty_files = [fname for fname, tables in sql_surface.per_file_tables if not tables]
+    assert empty_files == [], f"SQL files with zero resolved tables: {empty_files}"
+
+
+def test_classification_lookup_returns_none_for_unclassified_table():
+    assert mi.CENTRAL_DB_TABLES.get("some_future_unclassified_table") is None

--- a/tests/test_migration_inventory_completeness.py
+++ b/tests/test_migration_inventory_completeness.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+"""Tests for migration_inventory.verify_complete() — the fs<->git completeness oracle.
+
+Dispatch-ID: 20260712-183939-cockpit-pr8
+
+The oracle compares the filesystem-glob enumeration of `<root>/schemas/migrations/*.sql`
+against `git ls-files` for the SAME root. Both universes must be rooted at the same
+migrations dir, or the comparison is meaningless (codex finding). The negative case
+runs against a MONKEYPATCHED TEMP root — never the real repo dir — so it can safely
+mutate the working tree (add an untracked file) without polluting this checkout.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import migration_inventory as mi  # noqa: E402
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(["git", "-C", str(root), *args], check=True, capture_output=True, text=True)
+
+
+def _seed_temp_repo(root: Path) -> None:
+    (root / "schemas" / "migrations").mkdir(parents=True)
+    (root / "schemas" / "migrations" / "0001_seed.sql").write_text(
+        "CREATE TABLE dispatches (id INTEGER PRIMARY KEY, project_id TEXT NOT NULL);\n"
+    )
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "test@example.com")
+    _git(root, "config", "user.name", "test")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "seed")
+
+
+def test_verify_complete_passes_on_the_real_tree():
+    result = mi.verify_complete(REPO)
+    assert result.ok, result.violations
+    assert result.violations == ()
+
+
+def test_verify_complete_fails_on_untracked_sql_in_a_monkeypatched_temp_root(tmp_path, monkeypatch):
+    _seed_temp_repo(tmp_path)
+
+    # Baseline: fs and git agree over this shared temp root.
+    baseline = mi.verify_complete(tmp_path)
+    assert baseline.ok, baseline.violations
+
+    # Introduce a disk<->git divergence: a SQL file on disk that was never
+    # `git add`-ed. This must never touch the real repo — the migrations root
+    # is monkeypatched to the temp dir for the whole call chain, including the
+    # root=None default-resolution path.
+    (tmp_path / "schemas" / "migrations" / "0002_untracked.sql").write_text(
+        "CREATE TABLE terminal_leases (id INTEGER PRIMARY KEY, project_id TEXT NOT NULL);\n"
+    )
+
+    monkeypatch.setattr(mi, "resolve_project_root", lambda *_a, **_kw: tmp_path)
+
+    result = mi.verify_complete()
+    assert not result.ok
+    assert any("0002_untracked.sql" in v for v in result.violations)
+
+    # The real repo's migrations dir must be untouched by the negative case.
+    real_status = subprocess.run(
+        ["git", "-C", str(REPO), "status", "--porcelain", "schemas/migrations"],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    assert real_status == ""
+
+
+def test_verify_complete_fails_when_tracked_file_missing_from_disk(tmp_path):
+    _seed_temp_repo(tmp_path)
+    (tmp_path / "schemas" / "migrations" / "0001_seed.sql").unlink()
+
+    result = mi.verify_complete(tmp_path)
+    assert not result.ok
+    assert any("0001_seed.sql" in v for v in result.violations)


### PR DESCRIPTION
## Summary
- PR-8 of `framework-status-audit-and-cockpit` (§PR-8, LOC scope ≈220). Read-only migration-surface inventory-lock. **Deletes/deprecates nothing** — the consolidation + ADR-007-tenancy CUT stay PARKed to `migration-consolidation-and-tenancy-cut`; this PR produces the locked inventory that is that track's un-park trigger.
- `pr_type: chore`, `task_class: coding_interactive` (staging). Review floor (advisory): codex diff-mode.

## Changes
- **`scripts/lib/migration_inventory.py`** (new): enumerates all 6 migration surfaces:
  1. `schemas/migrations/*.sql` — 42 files
  2. `scripts/lib/migrations/apply_00NN.py` — the 6 per-version python appliers (0017/0019/0020/0022/0024/0026)
  3. `scripts/lib/schema_manifest.py`
  4. `scripts/lib/schema_migration.py` + `scripts/lib/migrations/auto_apply.py`
  5. `scripts/lib/project_id_migration.py`
  6. `vnx_cli/commands/migrate.py`
  - Parses each SQL file statement-by-statement (comments stripped, split on `;`) to extract touched tables, so a comment mentioning "CREATE TABLE" can never produce a false-positive.
  - Classifies every touched table `central_db: bool` per ADR-007 (52 distinct tables — verified against the tree 2026-07-12: every `CREATE TABLE` in this surface carries `project_id TEXT NOT NULL DEFAULT 'vnx-dev'`, so all 52 are `central_db=True`; the map is closed-world — an unclassified future table reads `None`/unknown rather than silently passing).
  - `verify_complete()` — the completeness oracle, with the migrations root as a parameter:
    1. fs-glob of `<root>/schemas/migrations/*.sql` must equal `git ls-files` for the **same** root — untracked-on-disk or tracked-but-missing is a FAIL.
    2. every `apply_*.py` on disk must appear in the applier surface.
    3. every enumerated SQL file must resolve to ≥1 touched table, and every touched table must have a non-unknown classification.
- **`docs/core/SUBSYSTEMS.md`**: `migration-mechanisms` health row now points at the new inventory-lock module.
- **Tests** (`tests/test_migration_inventory*.py`, 3 files, 12 tests): surface-shape assertions, classification-completeness assertions, and the fs↔git oracle — including the negative case, which runs against a **monkeypatched temp root** (never the real repo dir) so the untracked-file mutation can never pollute this checkout.

## Verification
- `python3 -m pytest tests/test_migration_inventory.py tests/test_migration_inventory_classification.py tests/test_migration_inventory_completeness.py -v` → **12 passed**
- `python3 -m ruff check scripts/lib/migration_inventory.py tests/test_migration_inventory*.py` → all checks passed
- Manual run: `python3 scripts/lib/migration_inventory.py` → all 6 surfaces enumerate with real paths (42 SQL / 6 appliers / 4 single-file surfaces), `verify_complete: ok=True`
- `git diff --stat` confirms no file outside the stated scope was touched; `docs/core/SUBSYSTEMS.md` diff is 1 line changed.

## Open Items
None.

Dispatch-ID: 20260712-183939-cockpit-pr8