### PR TITLE
feat(intelligence): build injection-effectiveness probe before activating learning loop

### DIFF
--- a/scripts/lib/injection_effectiveness_probe.py
+++ b/scripts/lib/injection_effectiveness_probe.py
@@ -1,0 +1,236 @@
+"""injection_effectiveness_probe — read-only effectiveness probe for the
+intelligence self-learning loop (framework-status-audit-and-cockpit PR-6).
+
+The loop must not be activated blind: before ``VNX_LEARNING_LOOP_ENABLED`` /
+``VNX_INJECTION_FEEDBACK_ENABLED`` can gate anything real (PR-17), this probe
+measures whether pattern injections are actually being used.
+
+Signal sources (all PERSISTED, verified to exist):
+  - the persisted ``pattern_usage`` table in ``quality_intelligence.db``
+    (``used_count`` / ``ignored_count`` columns) — NOT the in-memory
+    ``PatternUsageMetric`` object from ``scripts/learning_loop.py``, which is
+    per-process and empty in a probe run.
+  - ``pending_rules.json`` / ``pending_skill_refinements.json`` under the
+    state directory — the operator-gated proposal queues.
+  - the ``dream_cycles`` table (also in ``quality_intelligence.db``) for the
+    most recent consolidation cycle timestamp.
+
+There is no "injection outcome receipts" source — that artifact does not
+exist. ``ignore_rate`` is computed from the ``pattern_usage`` used/ignored
+totals alone.
+
+Health is a TOTAL function of ``r`` (ignore_rate) plus the proposal-queue
+staleness signal, checked top-down, first match wins:
+  - ``unknown``: no data (zero used AND zero ignored).
+  - ``produces_crap``: ``r >= 0.90``.
+  - ``degraded``: ``0.50 <= r < 0.90``, OR the oldest pending proposal has sat
+    unresolved for more than 7 days.
+  - ``ok``: ``r < 0.50`` and the proposal queue is not stalled.
+Every ``r`` matches exactly one branch; the 0.90/0.50 endpoints are owned by
+``produces_crap``/``degraded`` respectively. The human-readable reason lives
+in ``signal()``/``detail`` only — it never changes the classification.
+
+This probe MEASURES only. It never flips ``VNX_LEARNING_LOOP_ENABLED`` or
+``VNX_INJECTION_FEEDBACK_ENABLED`` and never writes to any table it reads.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import project_root  # noqa: E402
+from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
+
+# r >= this -> produces_crap (owns the 0.90 endpoint).
+PRODUCES_CRAP_THRESHOLD = 0.90
+# r >= this (and < PRODUCES_CRAP_THRESHOLD) -> degraded (owns the 0.50 endpoint).
+DEGRADED_THRESHOLD = 0.50
+# A pending proposal older than this many days marks the queue "stalled".
+STALL_THRESHOLD_DAYS = 7.0
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(value: Optional[str]) -> Optional[datetime]:
+    """Best-effort ISO-8601 parse. Returns None (never raises) on bad input."""
+    if not value or not isinstance(value, str):
+        return None
+    raw = value.strip()
+    if raw.endswith("Z"):
+        raw = raw[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(raw)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def _read_pattern_usage_totals(db_path: Path) -> Tuple[int, int]:
+    """Sum ``used_count``/``ignored_count`` over the persisted ``pattern_usage``
+    table. Read-only; a missing DB/table/column returns ``(0, 0)`` rather than
+    raising — a probe must never crash the aggregator."""
+    if not db_path.exists():
+        return 0, 0
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT COALESCE(SUM(used_count), 0), COALESCE(SUM(ignored_count), 0) "
+                "FROM pattern_usage"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return 0, 0
+    if row is None:
+        return 0, 0
+    return int(row[0] or 0), int(row[1] or 0)
+
+
+def _read_last_dream_cycle(db_path: Path) -> Optional[str]:
+    """Most recent ``dream_cycles.started_at`` (ISO string), read-only.
+    None if the DB/table is absent or empty."""
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT started_at FROM dream_cycles ORDER BY started_at DESC LIMIT 1"
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return None
+    if row is None:
+        return None
+    return row[0]
+
+
+def _pending_from_json(path: Path, list_key: str, ts_key: str) -> Tuple[int, Optional[datetime]]:
+    """Count ``status == "pending"`` entries in a proposal-queue JSON file and
+    return the oldest such entry's timestamp (None if unparseable/absent)."""
+    if not path.exists():
+        return 0, None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return 0, None
+    if not isinstance(data, dict):
+        return 0, None
+
+    count = 0
+    oldest: Optional[datetime] = None
+    for entry in data.get(list_key, []):
+        if not isinstance(entry, dict) or entry.get("status") != "pending":
+            continue
+        count += 1
+        ts = _parse_iso(entry.get(ts_key))
+        if ts is not None and (oldest is None or ts < oldest):
+            oldest = ts
+    return count, oldest
+
+
+def _read_pending_proposals(state_dir: Path) -> Tuple[int, Optional[float]]:
+    """Combine ``pending_rules.json`` + ``pending_skill_refinements.json``:
+    returns ``(pending_count, oldest_pending_age_days)``. The age is None when
+    there are no pending entries with a parseable timestamp."""
+    rules_count, rules_oldest = _pending_from_json(
+        state_dir / "pending_rules.json", "pending_rules", "created_at"
+    )
+    refinements_count, refinements_oldest = _pending_from_json(
+        state_dir / "pending_skill_refinements.json", "proposals", "generated_at"
+    )
+
+    pending_count = rules_count + refinements_count
+    candidates = [ts for ts in (rules_oldest, refinements_oldest) if ts is not None]
+    if not candidates:
+        return pending_count, None
+
+    oldest = min(candidates)
+    age_days = (_now_utc() - oldest).total_seconds() / 86400.0
+    return pending_count, age_days
+
+
+@register_probe("intelligence-self-learning-loop")
+class InjectionEffectivenessProbe(EffectivenessProbe):
+    """Measures whether the intelligence self-learning loop's pattern
+    injections are used or ignored, and whether its operator-gated proposal
+    queue is flowing. Read-only end to end; never activates the loop."""
+
+    subsystem = "intelligence-self-learning-loop"
+
+    def __init__(self, state_dir: Optional[Path] = None) -> None:
+        self.state_dir = (
+            Path(state_dir) if state_dir is not None else project_root.resolve_state_dir(__file__)
+        )
+
+    def probe(self) -> Dict[str, Any]:
+        db_path = self.state_dir / "quality_intelligence.db"
+        used_count, ignored_count = _read_pattern_usage_totals(db_path)
+        pending_proposals, oldest_pending_age_days = _read_pending_proposals(self.state_dir)
+        last_dream_cycle_iso = _read_last_dream_cycle(db_path)
+
+        total = used_count + ignored_count
+        ignore_rate = (ignored_count / total) if total > 0 else None
+
+        return {
+            "used_count": used_count,
+            "ignored_count": ignored_count,
+            "ignore_rate": ignore_rate,
+            "pending_proposals": pending_proposals,
+            "oldest_pending_age_days": oldest_pending_age_days,
+            "last_dream_cycle_iso": last_dream_cycle_iso,
+        }
+
+    def health(self, raw: Dict[str, Any]) -> str:
+        ignore_rate = raw.get("ignore_rate")
+        if ignore_rate is None:
+            return "unknown"
+        if ignore_rate >= PRODUCES_CRAP_THRESHOLD:
+            return "produces_crap"
+
+        age_days = raw.get("oldest_pending_age_days")
+        stalled = (
+            raw.get("pending_proposals", 0) > 0
+            and age_days is not None
+            and age_days > STALL_THRESHOLD_DAYS
+        )
+        if ignore_rate >= DEGRADED_THRESHOLD or stalled:
+            return "degraded"
+        return "ok"
+
+    def signal(self, raw: Dict[str, Any]) -> str:
+        ignore_rate = raw.get("ignore_rate")
+        if ignore_rate is None:
+            return "no injection usage data yet (0 used, 0 ignored)"
+
+        bits = [f"ignore_rate={ignore_rate:.0%}", f"used={raw['used_count']}", f"ignored={raw['ignored_count']}"]
+        pending = raw.get("pending_proposals", 0)
+        if pending:
+            age_days = raw.get("oldest_pending_age_days")
+            if age_days is not None and age_days > STALL_THRESHOLD_DAYS:
+                bits.append(f"{pending} pending proposal(s), oldest stalled {age_days:.1f}d")
+            else:
+                bits.append(f"{pending} pending proposal(s) flowing")
+        return ", ".join(bits)
+
+
+__all__ = [
+    "InjectionEffectivenessProbe",
+    "PRODUCES_CRAP_THRESHOLD",
+    "DEGRADED_THRESHOLD",
+    "STALL_THRESHOLD_DAYS",
+]

--- a/tests/test_injection_effectiveness_probe.py
+++ b/tests/test_injection_effectiveness_probe.py
@@ -1,0 +1,296 @@
+"""Tests for scripts/lib/injection_effectiveness_probe.py — the intelligence
+self-learning-loop effectiveness probe (framework-status-audit-and-cockpit PR-6).
+
+Dispatch-ID: 20260712-185055-cockpit-pr6
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from effectiveness_probe import EFFECTIVENESS_PROBES  # noqa: E402
+from injection_effectiveness_probe import (  # noqa: E402
+    DEGRADED_THRESHOLD,
+    PRODUCES_CRAP_THRESHOLD,
+    STALL_THRESHOLD_DAYS,
+    InjectionEffectivenessProbe,
+)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _make_db(tmp_path: Path, rows=(), dream_cycles=()) -> Path:
+    """Create a quality_intelligence.db with a pattern_usage table (matching the
+    schema learning_loop.py creates) and a dream_cycles table (matching
+    schemas/migrations/0025_dream_consolidation.sql), pre-populated with rows."""
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE pattern_usage (
+                pattern_id TEXT PRIMARY KEY,
+                pattern_title TEXT NOT NULL,
+                pattern_hash TEXT NOT NULL,
+                used_count INTEGER DEFAULT 0,
+                ignored_count INTEGER DEFAULT 0,
+                success_count INTEGER DEFAULT 0,
+                failure_count INTEGER DEFAULT 0,
+                last_used TIMESTAMP,
+                last_offered TIMESTAMP,
+                confidence REAL DEFAULT 1.0,
+                created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+            """
+        )
+        for i, (used, ignored) in enumerate(rows):
+            conn.execute(
+                "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+                "used_count, ignored_count) VALUES (?, ?, ?, ?, ?)",
+                (f"pat-{i}", f"Pattern {i}", f"hash-{i}", used, ignored),
+            )
+        conn.execute(
+            """
+            CREATE TABLE dream_cycles (
+                cycle_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                started_at TEXT NOT NULL,
+                status TEXT NOT NULL DEFAULT 'pending',
+                PRIMARY KEY (cycle_id, project_id)
+            )
+            """
+        )
+        for i, started_at in enumerate(dream_cycles):
+            conn.execute(
+                "INSERT INTO dream_cycles (cycle_id, started_at) VALUES (?, ?)",
+                (f"cycle-{i}", started_at),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _write_pending_rules(state_dir: Path, entries) -> None:
+    (state_dir / "pending_rules.json").write_text(
+        json.dumps({"pending_rules": entries}), encoding="utf-8"
+    )
+
+
+def _write_pending_refinements(state_dir: Path, entries) -> None:
+    (state_dir / "pending_skill_refinements.json").write_text(
+        json.dumps({"generated_at": _iso(datetime.now(timezone.utc)), "proposals": entries}),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# health() classification — total function of ignore_rate + stall signal
+# ---------------------------------------------------------------------------
+
+
+def test_no_data_reports_unknown(tmp_path):
+    _make_db(tmp_path, rows=())
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.status == "unknown"
+    assert result.detail["ignore_rate"] is None
+    assert result.detail["used_count"] == 0
+    assert result.detail["ignored_count"] == 0
+
+
+def test_no_db_at_all_reports_unknown(tmp_path):
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.status == "unknown"
+
+
+def test_high_ignore_rate_reports_produces_crap(tmp_path):
+    _make_db(tmp_path, rows=[(2, 98)])  # ignore_rate = 0.98
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.status == "produces_crap"
+    assert result.detail["ignore_rate"] == pytest.approx(0.98)
+
+
+def test_ignore_rate_exactly_at_produces_crap_threshold_is_produces_crap(tmp_path):
+    _make_db(tmp_path, rows=[(10, 90)])  # ignore_rate = 0.90 exactly
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.detail["ignore_rate"] == pytest.approx(PRODUCES_CRAP_THRESHOLD)
+    assert result.status == "produces_crap"
+
+
+def test_mid_ignore_rate_reports_degraded(tmp_path):
+    _make_db(tmp_path, rows=[(40, 60)])  # ignore_rate = 0.60
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.status == "degraded"
+
+
+def test_ignore_rate_exactly_at_degraded_threshold_is_degraded(tmp_path):
+    _make_db(tmp_path, rows=[(50, 50)])  # ignore_rate = 0.50 exactly
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.detail["ignore_rate"] == pytest.approx(DEGRADED_THRESHOLD)
+    assert result.status == "degraded"
+
+
+def test_balanced_low_ignore_rate_reports_ok(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])  # ignore_rate = 0.20
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+
+    result = probe.run()
+
+    assert result.status == "ok"
+    assert result.detail["ignore_rate"] == pytest.approx(0.20)
+
+
+def test_low_ignore_rate_but_stalled_proposals_reports_degraded(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])  # ignore_rate = 0.20, would be ok alone
+    stale_ts = _iso(datetime.now(timezone.utc) - timedelta(days=STALL_THRESHOLD_DAYS + 1))
+    _write_pending_rules(
+        tmp_path,
+        [{"id": "r1", "status": "pending", "created_at": stale_ts, "pattern": "x", "prevention": "y"}],
+    )
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "degraded"
+    assert result.detail["pending_proposals"] == 1
+    assert result.detail["oldest_pending_age_days"] > STALL_THRESHOLD_DAYS
+
+
+def test_low_ignore_rate_with_fresh_pending_proposals_reports_ok(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])  # ignore_rate = 0.20
+    fresh_ts = _iso(datetime.now(timezone.utc) - timedelta(days=1))
+    _write_pending_rules(
+        tmp_path,
+        [{"id": "r1", "status": "pending", "created_at": fresh_ts, "pattern": "x", "prevention": "y"}],
+    )
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "ok"
+    assert result.detail["pending_proposals"] == 1
+
+
+def test_non_pending_proposals_are_not_counted_or_stalling(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])
+    stale_ts = _iso(datetime.now(timezone.utc) - timedelta(days=STALL_THRESHOLD_DAYS + 5))
+    _write_pending_rules(
+        tmp_path,
+        [{"id": "r1", "status": "ingested", "created_at": stale_ts, "pattern": "x", "prevention": "y"}],
+    )
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "ok"
+    assert result.detail["pending_proposals"] == 0
+
+
+def test_skill_refinement_proposals_also_count_toward_pending_and_staleness(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])
+    stale_ts = _iso(datetime.now(timezone.utc) - timedelta(days=STALL_THRESHOLD_DAYS + 3))
+    _write_pending_refinements(
+        tmp_path,
+        [{"id": "skillref-1", "status": "pending", "generated_at": stale_ts, "role": "backend"}],
+    )
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "degraded"
+    assert result.detail["pending_proposals"] == 1
+
+
+# ---------------------------------------------------------------------------
+# beacon detail contract
+# ---------------------------------------------------------------------------
+
+
+def test_beacon_detail_contains_required_keys(tmp_path):
+    started_at = _iso(datetime.now(timezone.utc))
+    _make_db(tmp_path, rows=[(80, 20)], dream_cycles=[started_at])
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    for key in ("ignore_rate", "used_count", "ignored_count", "pending_proposals", "last_dream_cycle_iso"):
+        assert key in result.detail
+    assert result.detail["last_dream_cycle_iso"] == started_at
+
+
+def test_missing_pattern_usage_table_is_treated_as_no_data(tmp_path):
+    # A DB file exists but never had pattern_usage created (e.g. fresh install).
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.close()
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "unknown"
+    assert result.detail["used_count"] == 0
+    assert result.detail["ignored_count"] == 0
+
+
+def test_corrupt_pending_rules_json_is_ignored_not_raised(tmp_path):
+    _make_db(tmp_path, rows=[(80, 20)])
+    (tmp_path / "pending_rules.json").write_text("{not valid json", encoding="utf-8")
+
+    probe = InjectionEffectivenessProbe(state_dir=tmp_path)
+    result = probe.run()
+
+    assert result.status == "ok"
+    assert result.detail["pending_proposals"] == 0
+
+
+# ---------------------------------------------------------------------------
+# measurement only — no activation side effects
+# ---------------------------------------------------------------------------
+
+
+def test_probe_never_writes_to_the_database_it_reads(tmp_path):
+    db_path = _make_db(tmp_path, rows=[(5, 95)])
+    before = db_path.read_bytes()
+
+    InjectionEffectivenessProbe(state_dir=tmp_path).run()
+
+    assert db_path.read_bytes() == before
+
+
+def test_probe_is_registered_under_intelligence_self_learning_loop():
+    assert EFFECTIVENESS_PROBES["intelligence-self-learning-loop"] is InjectionEffectivenessProbe
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_subsystem_health.py
+++ b/tests/test_subsystem_health.py
@@ -115,5 +115,33 @@ def test_aggregate_default_subsystems_covers_the_known_universe(monkeypatch, tmp
     assert results["governance-enforcement-stack"]["signal"] == "no probe registered"
 
 
+def test_injection_effectiveness_probe_is_registered_under_intelligence_self_learning_loop():
+    """PR-6: importing the concrete probe module registers it (decorator side
+    effect); the aggregator must pick it up under the real subsystem name
+    instead of reporting `unknown`."""
+    import injection_effectiveness_probe  # noqa: F401  (registers via decorator)
+
+    assert "intelligence-self-learning-loop" in EFFECTIVENESS_PROBES
+    assert (
+        EFFECTIVENESS_PROBES["intelligence-self-learning-loop"]
+        is injection_effectiveness_probe.InjectionEffectivenessProbe
+    )
+
+
+def test_aggregate_runs_injection_effectiveness_probe_end_to_end(tmp_path):
+    """No pattern_usage data yet in a fresh state dir -> unknown, not a crash,
+    and the aggregator writes no beacon for it (unknown has no PROBE_TO_BEACON
+    entry)."""
+    import injection_effectiveness_probe  # noqa: F401  (registers via decorator)
+
+    results = subsystem_health.aggregate(
+        state_dir=tmp_path, subsystems=["intelligence-self-learning-loop"]
+    )
+
+    assert results["intelligence-self-learning-loop"]["status"] == "unknown"
+    beacon_path = tmp_path / "health" / "intelligence-self-learning-loop.json"
+    assert not beacon_path.exists()
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
Implements PR-6 of the `framework-status-audit-and-cockpit` track (§PR-6): a read-only `EffectivenessProbe` for the `intelligence-self-learning-loop` subsystem. This is the measurement gate PR-17 will later consult before the dormant learning loop can activate — it does not touch activation itself.

## Changes
- `scripts/lib/injection_effectiveness_probe.py` (new): `InjectionEffectivenessProbe`, registered via `@register_probe("intelligence-self-learning-loop")`.
  - Reads the **persisted** `pattern_usage` table in `quality_intelligence.db` (`used_count`/`ignored_count` totals) — not the in-memory `PatternUsageMetric` from `scripts/learning_loop.py`.
  - Reads `pending_rules.json` + `pending_skill_refinements.json` under the state dir for pending-proposal count and staleness (oldest `status == "pending"` entry's age).
  - Reads `dream_cycles.started_at` (most recent) for `last_dream_cycle_iso`.
  - No "injection outcome receipts" source — that artifact doesn't exist; `ignore_rate` comes from `pattern_usage` alone.
  - `health()` is a total function of `ignore_rate`, checked top-down: `unknown` (no data) → `produces_crap` (`r ≥ 0.90`) → `degraded` (`0.50 ≤ r < 0.90` OR proposal queue stalled >7d) → `ok`. Endpoints 0.90/0.50 owned by `produces_crap`/`degraded` respectively.
  - Beacon `detail` carries `ignore_rate`, `used_count`, `ignored_count`, `pending_proposals`, `last_dream_cycle_iso` (plus `oldest_pending_age_days`).
  - Purely read-only: never writes to `pattern_usage`/`dream_cycles`, never flips `VNX_LEARNING_LOOP_ENABLED` or `VNX_INJECTION_FEEDBACK_ENABLED`.
- `tests/test_injection_effectiveness_probe.py` (new): 17 tests covering the `unknown`/`produces_crap`/`degraded`/`ok` boundary cases (including exact-threshold edges at 0.90/0.50), stalled-vs-flowing proposal queues, non-pending entries excluded, missing table / corrupt JSON handled without raising, no-write guarantee, and registry membership.
- `tests/test_subsystem_health.py` (extended): 2 tests asserting the probe registers under `intelligence-self-learning-loop` and that `subsystem_health.aggregate()` runs it end-to-end.

## Verification
- `python3 -m pytest tests/test_injection_effectiveness_probe.py tests/test_subsystem_health.py tests/test_effectiveness_probe.py -v` → **30 passed**.
- `python3 -m py_compile scripts/lib/injection_effectiveness_probe.py tests/test_injection_effectiveness_probe.py tests/test_subsystem_health.py` → OK.
- Only ran the tests directly touched by this PR, per dispatch deadline discipline (no full-suite run in this worktree).

## Open Items
None.