### PR TITLE
feat(cli): add vnx subsystems command rendering live SSOT

### DIFF
--- a/.github/workflows/subsystems-drift.yml
+++ b/.github/workflows/subsystems-drift.yml
@@ -1,0 +1,23 @@
+name: Subsystems Ledger Drift Check
+
+on:
+  push:
+    branches: ["main", "baseline/**"]
+  pull_request:
+
+jobs:
+  subsystems-drift:
+    name: docs/core/SUBSYSTEMS.md matches the live registry
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Check ledger drift (deterministic columns only)
+        run: make subsystems-check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+.PHONY: subsystems-check
+
+# Diff docs/core/SUBSYSTEMS.md's deterministic columns (subsystem/what/flag/status)
+# against the live `vnx subsystems --md` generator. The dynamic `health` column is
+# excluded (framework-status-audit-and-cockpit PR-3). Wired into
+# .github/workflows/subsystems-drift.yml.
+subsystems-check:
+	python3 scripts/check_subsystems_drift.py

--- a/bin/vnx
+++ b/bin/vnx
@@ -343,6 +343,8 @@ Process commands (visibility and control):
   status --dispatches  Just dispatch queue
   status --gates       Just gate results
   status --json        Machine-readable JSON output
+  subsystems [--json|--md] [--probe]
+                     Render the subsystem cockpit SSOT (MAP + ON/OFF + HEALTH)
   ps [--json]        Show PID, parent PID, uptime, and health for VNX processes
   cleanup [--dry-run]  Remove orphan PIDs and stale locks
   restart <process>  Restart a managed VNX process
@@ -2416,6 +2418,9 @@ main() {
       ;;
     status)
       cmd_status "$@"
+      ;;
+    subsystems)
+      cmd_subsystems "$@"
       ;;
     ps)
       python3 "$VNX_HOME/scripts/vnx_process_ux.py" ps "$@"

--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -1,6 +1,6 @@
 # VNX Subsystem Status Ledger
 
-This document is the single source of truth for which VNX subsystems are live, parked, cut, or scoped. **Bootstrap note (PR-1):** the table below is a hand-seeded initial snapshot; the `health` column is a seed, not yet a probe reading. Once `vnx subsystems --md` (PR-3) and the effectiveness probes (PR-5–7) land, the ledger is regenerated from `scripts/lib/config_registry.py` plus health probes and the CI drift-check (`.github/workflows/subsystems-drift.yml`, PR-3) forbids hand-edits. Until then, treat `health` values as seeds.
+This document is the single source of truth for which VNX subsystems are live, parked, cut, or scoped. **Generated (PR-3):** the deterministic columns (subsystem/what/flag/status) are regenerated from `scripts/lib/config_registry.py` via `vnx subsystems --md`; `.github/workflows/subsystems-drift.yml` fails CI if this file drifts from that output. The `health` column is dynamic — it comes from a live health beacon when a probe has run (PR-5–7), else falls back to the last-committed value here. Hand-edits to the deterministic columns will be reverted by the next `vnx subsystems --md` run; hand-edits to `health` are fine until a probe takes over that row.
 
 | subsystem | what | flag | status | health |
 |-----------|------|------|--------|--------|
@@ -11,9 +11,13 @@ This document is the single source of truth for which VNX subsystems are live, p
 | zero-llm-injection | No prompt injection via environment or receipts; strict input boundaries. | — | LIVE | works — red-team tests pass |
 | dispatch-plan | Single-entry dispatch door, dispatch-plan reconciliation. | — | LIVE | works — dispatch tests pass |
 | test-suite | Pytest + integration coverage for kernel and cockpit. | — | LIVE | works — CI green |
+| cheap-recon-scout | Cheap-model scout recon pre-pass in the dispatch door (fail-open). | `VNX_SCOUT_PREPASS` | LIVE | unknown — no probe yet |
+| horizon-planning | Autonomous roadmap auto-next loading (starts work unattended). | `VNX_ROADMAP_AUTOPILOT` | LIVE | unknown — no probe yet |
+| headless-dispatch-routing | Headless dispatch routing mode selector. | `VNX_HEADLESS_ROUTING` | LIVE | unknown — no probe yet |
+| central-db-routing | Central-DB read mode for the runtime coordination store (per-project vs central vs shadow). | `VNX_USE_CENTRAL_DB` | LIVE | unknown — no probe yet |
 | migration-mechanisms | Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation PARKed pending inventory-lock. | `VNX_MIGRATION_SYSTEM` | PARK-with-trigger | degraded — 42 SQL files + 6 appliers; consolidation PARKed pending inventory-lock (`scripts/lib/migration_inventory.py`, PR-8) |
-| within-db-tenancy | Composite `(project_id, id)` keys inside per-project DBs. Removal PARKed pending per-table central-DB safety proof. | — | PARK-with-trigger | degraded — keys present; drop deferred (central-store/dual-write/ADR-026 interaction) |
-| docs-bloat | Comparisons, stale archive, marketing docs inflating `docs/` count. | — | CUT | degraded — ~288 markdown files, large `_archive/` |
+| within-db-tenancy | Composite (project_id, id) keys inside per-project DBs. Removal PARKed pending per-table central-DB safety proof. | — | PARK-with-trigger | degraded — keys present; drop deferred (central-store/dual-write/ADR-026 interaction) |
+| docs-bloat | Comparisons, stale archive, marketing docs inflating docs/ count. | — | CUT | degraded — ~288 markdown files, large `_archive/` |
 | governance-enforcement-stack | Receipt hash-chain + signed attestation + evidence-bound merge gate. SURFACED here; enforcement wiring deferred. | `VNX_GOVERNANCE_ENFORCED` | PARK-with-trigger | produces-crap — 15,577 receipts, 0 `prev_hash` |
 | receipt-hash-chain | Tamper-evident NDJSON hash-chain (ADR-029). | `VNX_HASH_CHAIN_REQUIRED` | PARK-with-trigger | produces-crap — unchained receipts |
 | signed-attestation | SSH-signed PR attestation manifests (ADR-027). | `VNX_ATTESTATION_REQUIRED` | PARK-with-trigger | produces-crap — 0 signed attestations in active use |
@@ -21,9 +25,10 @@ This document is the single source of truth for which VNX subsystems are live, p
 | intelligence-self-learning-loop | Daily pattern learning, skill refinements, confidence updates. | `VNX_LEARNING_LOOP_ENABLED` | ACTIVATE-and-measure | produces-crap — 98% injection ignore rate, 0 dream cycles |
 | dream-consolidation | Nightly memory consolidation + pending review dispatch. | `VNX_DREAM_SCHEDULER_ENABLED` | ACTIVATE-and-measure | unknown — no cycles run |
 | injection-effectiveness-eval-loop | Instrument WHY patterns are ignored before tuning generation. | `VNX_INJECTION_FEEDBACK_ENABLED` | ACTIVATE-and-measure | unknown — probe not built yet |
+| cross-project-federation | Cross-project intelligence federation (not yet implemented). | `VNX_USE_FEDERATION` | ACTIVATE-and-measure | unknown — no probe yet |
 | plan-gate-panel | 5-model deliberation panel for plan-first enforcement. | `VNX_PLAN_GATE_ENFORCE` | SCOPE | works — panel runs, verdicts recorded |
 | plan-gate-task-class-scope | Restrict panel to complex features; skip trivial tracks. Enforcement deferred to review-floor-enforcer. | `VNX_PLAN_GATE_COMPLEX_ONLY` | SCOPE | unknown — read-site deferred |
-| subsystem-cockpit | SUBSYSTEMS.md + config_registry + `vnx subsystems` + dashboard tile. | — | COCKPIT | degraded — SSOT exists, probes partial |
+| subsystem-cockpit | SUBSYSTEMS.md + config_registry + vnx subsystems + dashboard tile. | — | COCKPIT | degraded — SSOT exists, probes partial |
 | effectiveness-probe-framework | Generic "does it produce crap?" probes per subsystem. | — | COCKPIT | unknown — framework not built yet |
 
 **Legend:**

--- a/scripts/check_subsystems_drift.py
+++ b/scripts/check_subsystems_drift.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""CI check: docs/core/SUBSYSTEMS.md deterministic columns match the live
+cockpit generator (framework-status-audit-and-cockpit PR-3).
+
+Diffs the DETERMINISTIC columns only — subsystem / what / flag / status.
+The `health` column is intentionally excluded: it is dynamic (live beacon or
+seed fallback) and would trip on every probe run, forcing a ledger recommit
+for no reason. Wired via `make subsystems-check` and
+`.github/workflows/subsystems-drift.yml`.
+
+Exit codes: 0 = in sync, 1 = drift detected, 2 = internal error.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+for sub in (_REPO_ROOT / "scripts", _REPO_ROOT / "scripts" / "lib"):
+    s = str(sub)
+    if s not in sys.path:
+        sys.path.insert(0, s)
+
+sys.path.insert(0, str(_REPO_ROOT))
+
+LEDGER_PATH = _REPO_ROOT / "docs" / "core" / "SUBSYSTEMS.md"
+
+
+def _deterministic_rows(md_text: str) -> list[tuple[str, str, str, str]]:
+    """Parse (subsystem, what, flag, status) tuples out of a ledger table,
+    dropping the dynamic `health` column."""
+    rows = []
+    for line in md_text.splitlines():
+        line = line.strip()
+        if not line.startswith("|") or not line.endswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != 5:
+            continue
+        subsystem, what, flag, status, _health = cells
+        if subsystem in ("subsystem", "") or set(subsystem) <= {"-"}:
+            continue
+        rows.append((subsystem, what, flag, status))
+    return rows
+
+
+def main() -> int:
+    try:
+        from vnx_cli.commands.subsystems import build_rows, _render_md
+    except ImportError as exc:
+        print(f"internal error: cannot import subsystems generator: {exc}", file=sys.stderr)
+        return 2
+
+    try:
+        committed_text = LEDGER_PATH.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"internal error: cannot read {LEDGER_PATH}: {exc}", file=sys.stderr)
+        return 2
+
+    rows = build_rows()
+    for row in rows:
+        row["health"] = ""  # dynamic column — excluded from the drift comparison
+    generated_rows = _deterministic_rows(_render_md(rows))
+    committed_rows = _deterministic_rows(committed_text)
+
+    if generated_rows == committed_rows:
+        print(f"OK — {LEDGER_PATH} deterministic columns match the live registry "
+              f"({len(generated_rows)} subsystems).")
+        return 0
+
+    print("DRIFT — docs/core/SUBSYSTEMS.md deterministic columns (subsystem/what/flag/status) "
+          "do not match `vnx subsystems --md`. Regenerate with:\n"
+          "  python3 -m vnx_cli.main subsystems --md   # then splice the table back in\n",
+          file=sys.stderr)
+
+    generated_map = {r[0]: r for r in generated_rows}
+    committed_map = {r[0]: r for r in committed_rows}
+
+    for subsystem in sorted(set(generated_map) | set(committed_map)):
+        gen = generated_map.get(subsystem)
+        com = committed_map.get(subsystem)
+        if gen != com:
+            print(f"  {subsystem}:", file=sys.stderr)
+            print(f"    generated: {gen}", file=sys.stderr)
+            print(f"    committed: {com}", file=sys.stderr)
+
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/commands/subsystems.sh
+++ b/scripts/commands/subsystems.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+# VNX Command: subsystems
+# Thin wrapper around the pip-CLI `vnx subsystems` command (framework-status-
+# audit-and-cockpit PR-3) — repo-local dual-CLI parity.
+
+cmd_subsystems() {
+  PYTHONPATH="$VNX_HOME:$VNX_HOME/scripts/lib:${PYTHONPATH:-}" \
+    python3 -m vnx_cli.main subsystems "$@"
+}

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -157,7 +157,11 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "VNX_PLAN_GATE_COMPLEX_ONLY", "bool", "0", "gate",
         "Restrict the plan-gate panel to complex features (display metadata only; "
         "the scope-skip read-site is deferred to review-floor-enforcer).",
-        subsystem="plan-gate-panel", status="SCOPE"),
+        # subsystem matches the docs/core/SUBSYSTEMS.md seed row
+        # "plan-gate-task-class-scope" (framework-status-audit-and-cockpit PR-3
+        # fix) — distinct from "plan-gate-panel" (VNX_PLAN_GATE_ENFORCE), so the
+        # cockpit generator has exactly one canonical flag per ledger row.
+        subsystem="plan-gate-task-class-scope", status="SCOPE"),
     "VNX_HASH_CHAIN_REQUIRED": _e(
         "VNX_HASH_CHAIN_REQUIRED", "bool", "0", "gate",
         "Tamper-evident NDJSON hash-chain requirement (display metadata only; no read-site wired).",

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -61,7 +61,7 @@ TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "start", "stop", "restart", "jump", "ps", "cleanup",
     "new-worktree", "finish-worktree", "worktree-start", "worktree-stop",
     "worktree-refresh", "worktree-status", "merge-preflight",
-    "smoke", "package-check", "fabric-audit",
+    "smoke", "package-check", "fabric-audit", "subsystems",
     "dispatch", "gate", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",
     "pool", "permission",

--- a/tests/scripts/test_subsystems_sh.py
+++ b/tests/scripts/test_subsystems_sh.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Tests for scripts/commands/subsystems.sh + its bin/vnx wiring
+(framework-status-audit-and-cockpit PR-3 — dual-CLI parity).
+
+Invokes the real `bin/vnx subsystems` entrypoint via subprocess (not a
+reimplementation) so a broken wrapper or a missing `bin/vnx` case branch
+fails this test.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+BIN_VNX = REPO_ROOT / "bin" / "vnx"
+
+
+def test_bash_wrapper_invokes_python_cli_and_returns_zero():
+    result = subprocess.run(
+        [str(BIN_VNX), "subsystems", "--json"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "subsystems" in payload
+    assert len(payload["subsystems"]) >= 20
+
+
+def test_bash_wrapper_md_flag_emits_ledger_table():
+    result = subprocess.run(
+        [str(BIN_VNX), "subsystems", "--md"],
+        cwd=str(REPO_ROOT),
+        capture_output=True,
+        text=True,
+        timeout=60,
+    )
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.startswith("| subsystem | what | flag | status | health |")
+
+
+def test_commands_file_defines_cmd_subsystems():
+    sh_path = REPO_ROOT / "scripts" / "commands" / "subsystems.sh"
+    assert sh_path.is_file()
+    text = sh_path.read_text(encoding="utf-8")
+    assert "cmd_subsystems()" in text
+
+    # bash -n syntax check — matches the worker's "every modified .sh file
+    # must pass syntax check" rule.
+    check = subprocess.run(["bash", "-n", str(sh_path)], capture_output=True, text=True)
+    assert check.returncode == 0, check.stderr
+
+
+def test_bin_vnx_wires_subsystems_command():
+    text = BIN_VNX.read_text(encoding="utf-8")
+    assert "subsystems)" in text
+    assert "cmd_subsystems" in text

--- a/tests/test_config_registry.py
+++ b/tests/test_config_registry.py
@@ -220,7 +220,12 @@ def test_pr2_new_flags_have_correct_subsystem_and_status():
         "VNX_LEARNING_LOOP_ENABLED": ("intelligence-self-learning-loop", "ACTIVATE"),
         "VNX_DREAM_SCHEDULER_ENABLED": ("dream-consolidation", "ACTIVATE"),
         "VNX_INJECTION_FEEDBACK_ENABLED": ("injection-effectiveness-eval-loop", "ACTIVATE"),
-        "VNX_PLAN_GATE_COMPLEX_ONLY": ("plan-gate-panel", "SCOPE"),
+        # "plan-gate-task-class-scope" — matches the docs/core/SUBSYSTEMS.md
+        # seed row (§5 of the PRD), distinct from "plan-gate-panel"
+        # (VNX_PLAN_GATE_ENFORCE) below. Fixed in
+        # framework-status-audit-and-cockpit PR-3 so the cockpit generator has
+        # exactly one canonical flag per ledger row.
+        "VNX_PLAN_GATE_COMPLEX_ONLY": ("plan-gate-task-class-scope", "SCOPE"),
         "VNX_HASH_CHAIN_REQUIRED": ("receipt-hash-chain", "PARK"),
         "VNX_ATTESTATION_REQUIRED": ("signed-attestation", "PARK"),
         "VNX_MIGRATION_SYSTEM": ("migration-mechanisms", "PARK"),

--- a/tests/vnx_cli/test_subsystems.py
+++ b/tests/vnx_cli/test_subsystems.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Tests for vnx_cli/commands/subsystems.py (framework-status-audit-and-cockpit PR-3).
+
+Covers: --json shape (subsystems + health keys), the --md round-trip against the
+committed docs/core/SUBSYSTEMS.md deterministic columns, the --probe guarded
+import of scripts/lib/subsystem_health.py (PR-5) — both the module-absent
+fallback and the live-aggregator-result path — and the regression guard that
+all_beacons() is always called with a resolved Path (never argless).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from argparse import Namespace
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.subsystems import (  # noqa: E402
+    build_rows,
+    _render_md,
+    _parse_seed_health,
+    vnx_subsystems,
+)
+from vnx_cli import _engine  # noqa: E402
+
+
+def _args(project_dir, *, json_flag=False, md=False, probe=False, project_id=None):
+    return Namespace(
+        project_dir=str(project_dir),
+        json=json_flag,
+        md=md,
+        probe=probe,
+        project_id=project_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# --json shape
+# ---------------------------------------------------------------------------
+
+def test_json_output_contains_expected_subsystems_and_health(tmp_path, capsys):
+    rc = vnx_subsystems(_args(tmp_path, json_flag=True))
+    assert rc == 0
+
+    payload = json.loads(capsys.readouterr().out)
+    assert "subsystems" in payload
+    rows = payload["subsystems"]
+    assert len(rows) >= 20
+
+    names = {r["subsystem"] for r in rows}
+    for expected in (
+        "provider-routing",
+        "phantom_guard",
+        "intelligence-self-learning-loop",
+        "governance-enforcement-stack",
+        "plan-gate-panel",
+        "plan-gate-task-class-scope",
+    ):
+        assert expected in names, f"missing subsystem row: {expected}"
+
+    for row in rows:
+        assert "health" in row
+        assert row["health"]  # never empty — beacon, seed, or "unknown"
+
+    # flag-backed row carries its registry effective value ...
+    migration = next(r for r in rows if r["subsystem"] == "migration-mechanisms")
+    assert migration["flag"] == "VNX_MIGRATION_SYSTEM"
+    assert migration["effective_value"] == "manifest"
+
+    # ... a flag-less (union-source-b) row carries neither
+    phantom = next(r for r in rows if r["subsystem"] == "phantom_guard")
+    assert phantom["flag"] is None
+    assert phantom["effective_value"] is None
+
+
+# ---------------------------------------------------------------------------
+# --md round-trip against the committed ledger (deterministic columns only)
+# ---------------------------------------------------------------------------
+
+def test_md_deterministic_columns_match_committed_ledger():
+    # Reuses the same parser make subsystems-check runs in CI, so this test and
+    # the drift-check can never silently diverge on what "deterministic" means.
+    sys.path.insert(0, str(REPO_ROOT / "scripts"))
+    from check_subsystems_drift import _deterministic_rows
+
+    engine_root = _engine.engine_root()
+    committed = (engine_root / "docs" / "core" / "SUBSYSTEMS.md").read_text(encoding="utf-8")
+
+    rows = build_rows()
+    for row in rows:
+        row["health"] = ""  # dynamic column excluded from the round-trip check
+    generated = _render_md(rows)
+
+    assert _deterministic_rows(generated) == _deterministic_rows(committed)
+
+
+def test_md_health_falls_back_to_committed_seed_when_no_beacon(tmp_path, capsys):
+    # tests/conftest.py points VNX_DATA_DIR at an empty per-session tmp dir, so
+    # no beacon exists for any subsystem here — every row must fall back to the
+    # seed value parsed out of the committed ledger.
+    vnx_subsystems(_args(tmp_path, md=True))
+    out = capsys.readouterr().out
+
+    engine_root = _engine.engine_root()
+    seed_health = _parse_seed_health(engine_root)
+
+    for subsystem, expected_health in seed_health.items():
+        line = next((l for l in out.splitlines() if l.startswith(f"| {subsystem} |")), None)
+        assert line is not None, f"missing row for {subsystem}"
+        assert line.rstrip("|").rsplit("|", 1)[-1].strip() == expected_health
+
+
+# ---------------------------------------------------------------------------
+# --probe: guarded import of scripts/lib/subsystem_health.py (PR-5's owned
+# module). PR-3 must behave correctly whether PR-5 has merged yet or not, so
+# the guarded-import fallback is exercised directly via monkeypatch rather
+# than depending on ambient module presence in the test environment.
+# ---------------------------------------------------------------------------
+
+def test_probe_falls_back_to_unknown_when_aggregator_module_absent(tmp_path, monkeypatch, capsys):
+    import vnx_cli.commands.subsystems as subsystems_mod
+
+    monkeypatch.setattr(subsystems_mod, "_run_registered_probes", lambda data_dir: None)
+
+    rc = vnx_subsystems(_args(tmp_path, json_flag=True, probe=True))
+    assert rc == 0
+
+    rows = json.loads(capsys.readouterr().out)["subsystems"]
+    assert rows, "expected at least one subsystem row"
+    for row in rows:
+        assert row["health"] == "unknown"
+        assert row["last_signal"] == "no probe registered"
+
+
+def test_probe_uses_live_aggregator_result_when_present(tmp_path, monkeypatch, capsys):
+    import vnx_cli.commands.subsystems as subsystems_mod
+
+    fake_results = {
+        "provider-routing": {"status": "ok", "signal": "measured live", "detail": {}},
+    }
+    monkeypatch.setattr(subsystems_mod, "_run_registered_probes", lambda data_dir: fake_results)
+
+    rc = vnx_subsystems(_args(tmp_path, json_flag=True, probe=True))
+    assert rc == 0
+
+    rows = json.loads(capsys.readouterr().out)["subsystems"]
+    provider = next(r for r in rows if r["subsystem"] == "provider-routing")
+    assert provider["health"] == "ok — measured live"
+    assert provider["last_signal"] == "measured live"
+
+    # any subsystem the fake aggregator didn't cover still degrades cleanly
+    other = next(r for r in rows if r["subsystem"] == "phantom_guard")
+    assert other["health"] == "unknown"
+    assert other["last_signal"] == "no probe registered"
+
+
+def test_probe_guarded_import_matches_current_subsystem_health_contract(tmp_path):
+    """Regression guard: if scripts/lib/subsystem_health.py (PR-5) is present,
+    _run_registered_probes must call its real aggregate() signature without
+    raising — proves the guarded import isn't silently swallowing a real
+    TypeError from an API drift between PR-3 and PR-5."""
+    import vnx_cli.commands.subsystems as subsystems_mod
+
+    _engine.ensure_engine_on_path()
+    try:
+        import subsystem_health  # noqa: F401
+    except ImportError:
+        pytest.skip("scripts/lib/subsystem_health.py (PR-5) not present yet")
+
+    result = subsystems_mod._run_registered_probes(tmp_path)
+    assert isinstance(result, dict)
+    assert "__error__" not in result
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: all_beacons() must never be called argless
+# ---------------------------------------------------------------------------
+
+def test_all_beacons_called_with_resolved_data_dir(tmp_path, monkeypatch, capsys):
+    _engine.ensure_engine_on_path()
+    import health_beacon
+
+    calls = []
+    real_all_beacons = health_beacon.all_beacons
+
+    def _spy(state_dir):
+        calls.append(state_dir)
+        return real_all_beacons(state_dir)
+
+    monkeypatch.setattr(health_beacon, "all_beacons", _spy)
+
+    vnx_subsystems(_args(tmp_path, json_flag=True))
+    capsys.readouterr()
+
+    assert len(calls) == 1
+    assert isinstance(calls[0], Path)
+    assert calls[0].name == ".vnx-data" or str(calls[0])  # a real resolved path, not None

--- a/vnx_cli/commands/subsystems.py
+++ b/vnx_cli/commands/subsystems.py
@@ -1,0 +1,328 @@
+#!/usr/bin/env python3
+"""vnx subsystems — render the live subsystem cockpit SSOT (MAP + ON/OFF + HEALTH).
+
+Rowset is the union of three sources (framework-status-audit-and-cockpit PR-3):
+  (a) ``config_registry.CONFIG_REGISTRY`` + ``all_effective()`` — flag-backed
+      subsystems. Several flags can share one subsystem (e.g. every
+      intelligence-tuning flag maps to ``intelligence-self-learning-loop``);
+      ``_ROW_ORDER`` below pins exactly one canonical flag per subsystem row
+      (the master on/off switch), matching ``docs/core/SUBSYSTEMS.md``.
+  (b) ``config_registry.CONFIG_REGISTRY_SUBSYSTEMS`` — flag-less kernel
+      subsystems (``phantom_guard``, ``dispatch-plan``, ...).
+  (c) ``health_beacon.all_beacons(data_dir)`` — live HEALTH only. The beacon
+      root is ``VNX_DATA_DIR`` (health_beacon writes/reads under
+      ``VNX_DATA_DIR/health``), NOT ``VNX_STATE_DIR``.
+
+``--md`` emits the exact ``docs/core/SUBSYSTEMS.md`` ledger table. The
+deterministic columns (subsystem/what/flag/status) are always regenerated from
+the registry; ``.github/workflows/subsystems-drift.yml`` diffs exactly those
+columns against the committed file — the dynamic ``health`` column is excluded
+so a live probe never forces a ledger recommit. Before a beacon exists for a
+subsystem, health falls back to the value committed in the seed table (parsed
+from the file itself), so the round-trip is byte-identical before PR-5..7 land.
+
+``--probe`` is this PR's owned flag surface (PR-5 supplies the aggregator, via
+a guarded import, with no edit back to this file). A subsystem with no probe
+registered in ``EFFECTIVENESS_PROBES`` reports ``unknown`` / ``"no probe
+registered"``; if the aggregator module itself is absent, every row does.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from vnx_cli import _engine
+
+_engine.ensure_engine_on_path()
+
+# Long-form ledger status text (docs/core/SUBSYSTEMS.md legend) vs the short
+# registry code (config_registry.ALLOWED_STATUSES). Pure display mapping —
+# no runtime behaviour hinges on it.
+_STATUS_DISPLAY: Dict[str, str] = {
+    "LIVE": "LIVE",
+    "PARK": "PARK-with-trigger",
+    "CUT": "CUT",
+    "ACTIVATE": "ACTIVATE-and-measure",
+    "SCOPE": "SCOPE",
+    "COCKPIT": "COCKPIT",
+}
+
+# Subsystem-level "what" narrative for flag-backed CONFIG_REGISTRY subsystems.
+# ConfigEntry.description is per-FLAG (e.g. VNX_MIGRATION_SYSTEM's own text);
+# the ledger's "what" column is per-SUBSYSTEM. Text is verbatim from the PR-1
+# seed for the 10 subsystems that already had a ledger row; the 5 new ones
+# (registered pre-PR-1 but never added to the hand-seeded ledger) get concise
+# text authored here.
+SUBSYSTEM_DESCRIPTIONS: Dict[str, str] = {
+    "migration-mechanisms": (
+        "Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation "
+        "PARKed pending inventory-lock."
+    ),
+    "governance-enforcement-stack": (
+        "Receipt hash-chain + signed attestation + evidence-bound merge gate. "
+        "SURFACED here; enforcement wiring deferred."
+    ),
+    "receipt-hash-chain": "Tamper-evident NDJSON hash-chain (ADR-029).",
+    "signed-attestation": "SSH-signed PR attestation manifests (ADR-027).",
+    "evidence-bound-gate": "D3 evidence-bound merge gate.",
+    "intelligence-self-learning-loop": (
+        "Daily pattern learning, skill refinements, confidence updates."
+    ),
+    "dream-consolidation": "Nightly memory consolidation + pending review dispatch.",
+    "injection-effectiveness-eval-loop": (
+        "Instrument WHY patterns are ignored before tuning generation."
+    ),
+    "plan-gate-panel": "5-model deliberation panel for plan-first enforcement.",
+    "plan-gate-task-class-scope": (
+        "Restrict panel to complex features; skip trivial tracks. Enforcement "
+        "deferred to review-floor-enforcer."
+    ),
+    "cheap-recon-scout": "Cheap-model scout recon pre-pass in the dispatch door (fail-open).",
+    "horizon-planning": "Autonomous roadmap auto-next loading (starts work unattended).",
+    "headless-dispatch-routing": "Headless dispatch routing mode selector.",
+    "central-db-routing": (
+        "Central-DB read mode for the runtime coordination store "
+        "(per-project vs central vs shadow)."
+    ),
+    "cross-project-federation": "Cross-project intelligence federation (not yet implemented).",
+}
+
+# Ledger row order (framework-status-audit-and-cockpit PR-3). Grouped by
+# status, matching docs/core/SUBSYSTEMS.md. A subsystem discovered in the
+# registry but absent here is a build error (see _order_key) — the ledger
+# stays a deliberately curated MAP, not an alphabetical dump.
+_ROW_ORDER: List[str] = [
+    # LIVE
+    "provider-routing",
+    "git-grounded-reconcile",
+    "phantom_guard",
+    "tmux-operational-scar",
+    "zero-llm-injection",
+    "dispatch-plan",
+    "test-suite",
+    "cheap-recon-scout",
+    "horizon-planning",
+    "headless-dispatch-routing",
+    "central-db-routing",
+    # PARK-with-trigger / CUT
+    "migration-mechanisms",
+    "within-db-tenancy",
+    "docs-bloat",
+    "governance-enforcement-stack",
+    "receipt-hash-chain",
+    "signed-attestation",
+    "evidence-bound-gate",
+    # ACTIVATE-and-measure
+    "intelligence-self-learning-loop",
+    "dream-consolidation",
+    "injection-effectiveness-eval-loop",
+    "cross-project-federation",
+    # SCOPE
+    "plan-gate-panel",
+    "plan-gate-task-class-scope",
+    # COCKPIT
+    "subsystem-cockpit",
+    "effectiveness-probe-framework",
+]
+
+
+def _order_key(subsystem: str) -> int:
+    try:
+        return _ROW_ORDER.index(subsystem)
+    except ValueError:
+        raise ValueError(
+            f"subsystem {subsystem!r} discovered in config_registry but not "
+            "listed in vnx_cli/commands/subsystems.py:_ROW_ORDER — add it to "
+            "the cockpit ledger order (and SUBSYSTEM_DESCRIPTIONS if it has a "
+            "flag) before it can render."
+        ) from None
+
+
+def _canonical_flags(cr) -> Dict[str, str]:
+    """subsystem -> the one flag key shown as the ledger row's ``flag``.
+
+    CONFIG_REGISTRY is insertion-ordered; when several flags share a
+    subsystem the LAST-inserted one wins (PR-2's net-new master-switch flags
+    are appended after the pre-existing tuning flags they group).
+    """
+    canonical: Dict[str, str] = {}
+    for key, entry in cr.CONFIG_REGISTRY.items():
+        if entry.subsystem:
+            canonical[entry.subsystem] = key
+    return canonical
+
+
+def build_rows(project_id: Optional[str] = None) -> List[Dict[str, Any]]:
+    """Rowset = (a) CONFIG_REGISTRY (canonical flag per subsystem) union (b)
+    CONFIG_REGISTRY_SUBSYSTEMS (flag-less). Health is NOT populated here —
+    see _attach_health."""
+    import config_registry as cr
+
+    rows: List[Dict[str, Any]] = []
+
+    for subsystem, meta in cr.CONFIG_REGISTRY_SUBSYSTEMS.items():
+        status = meta.get("status", "COCKPIT")
+        rows.append({
+            "subsystem": subsystem,
+            "what": meta.get("description", ""),
+            "flag": None,
+            "status": status,
+            "status_display": _STATUS_DISPLAY.get(status, status),
+            "effective_value": None,
+            "provenance": "config_registry_subsystems",
+        })
+
+    for subsystem, flag_key in _canonical_flags(cr).items():
+        entry = cr.CONFIG_REGISTRY[flag_key]
+        status = entry.status or "COCKPIT"
+        rows.append({
+            "subsystem": subsystem,
+            "what": SUBSYSTEM_DESCRIPTIONS.get(subsystem, entry.description),
+            "flag": flag_key,
+            "status": status,
+            "status_display": _STATUS_DISPLAY.get(status, status),
+            "effective_value": cr.get(flag_key, project_id),
+            "provenance": "config_registry",
+        })
+
+    rows.sort(key=lambda r: _order_key(r["subsystem"]))
+    return rows
+
+
+def _parse_seed_health(engine_root: Path) -> Dict[str, str]:
+    """Parse the health cell out of the committed docs/core/SUBSYSTEMS.md
+    ledger table — the fallback used until a live beacon exists for a
+    subsystem (PR-5..7). Returns {} if the file is missing/unparseable."""
+    path = engine_root / "docs" / "core" / "SUBSYSTEMS.md"
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError:
+        return {}
+
+    out: Dict[str, str] = {}
+    for line in text.splitlines():
+        line = line.strip()
+        if not line.startswith("|") or not line.endswith("|"):
+            continue
+        cells = [c.strip() for c in line.strip("|").split("|")]
+        if len(cells) != 5:
+            continue
+        subsystem, _what, _flag, _status, health = cells
+        if subsystem in ("subsystem", "") or set(subsystem) <= {"-"}:
+            continue
+        out[subsystem] = health
+    return out
+
+
+def _run_registered_probes(data_dir: Path) -> Optional[Dict[str, Any]]:
+    """Guarded import of scripts/lib/subsystem_health.py (PR-5). Returns None
+    when the module does not exist yet — the caller then reports 'unknown' /
+    'no probe registered' for every subsystem. PR-3 owns this flag surface;
+    PR-5 supplies the module with no edit back to this file.
+
+    Beacons are written under the same resolved ``data_dir`` (VNX_DATA_DIR)
+    this CLI already uses for reading them, rather than letting the
+    aggregator re-resolve it independently."""
+    try:
+        from subsystem_health import aggregate  # type: ignore[import-not-found]
+    except ImportError:
+        return None
+    try:
+        return aggregate(state_dir=data_dir)
+    except Exception as exc:  # probe internals are owned by PR-5+; never crash the CLI
+        return {"__error__": str(exc)}
+
+
+def _attach_health(
+    rows: List[Dict[str, Any]],
+    data_dir: Path,
+    seed_health: Dict[str, str],
+    use_probe: bool,
+) -> None:
+    from health_beacon import all_beacons
+
+    if use_probe:
+        probe_results = _run_registered_probes(data_dir)
+        for row in rows:
+            result = probe_results.get(row["subsystem"]) if probe_results else None
+            if isinstance(result, dict) and "status" in result:
+                status = result.get("status", "unknown")
+                signal = result.get("signal", "")
+                row["health"] = f"{status} — {signal}" if signal else status
+                row["last_signal"] = signal
+            else:
+                row["health"] = "unknown"
+                row["last_signal"] = "no probe registered"
+        return
+
+    beacons = all_beacons(data_dir)  # data_dir = VNX_DATA_DIR, not VNX_STATE_DIR
+    for row in rows:
+        subsystem = row["subsystem"]
+        beacon = beacons.get(subsystem)
+        if beacon:
+            health = beacon.get("health", "unknown")
+            detail = beacon.get("details") or {}
+            signal = detail.get("signal") or beacon.get("status", "")
+            row["health"] = f"{health} — {signal}" if signal else health
+            row["last_signal"] = beacon.get("last_run_iso", "")
+        else:
+            row["health"] = seed_health.get(subsystem, "unknown — no probe yet")
+            row["last_signal"] = ""
+
+
+def _escape_cell(text: str) -> str:
+    """Escape literal ``|`` so free-text cells never fracture the GFM table."""
+    return text.replace("|", "\\|")
+
+
+def _render_md(rows: List[Dict[str, Any]]) -> str:
+    lines = ["| subsystem | what | flag | status | health |",
+             "|-----------|------|------|--------|--------|"]
+    for row in rows:
+        flag = f"`{row['flag']}`" if row["flag"] else "—"
+        lines.append(
+            f"| {row['subsystem']} | {_escape_cell(row['what'])} | {flag} | "
+            f"{row['status_display']} | {_escape_cell(row['health'])} |"
+        )
+    return "\n".join(lines)
+
+
+def _render_table(rows: List[Dict[str, Any]]) -> str:
+    header = f"  {'SUBSYSTEM':<34} {'STATUS':<10} {'FLAG':<26} {'EFFECTIVE':<10} {'HEALTH'}"
+    lines = [header, "  " + "-" * len(header.strip())]
+    for row in rows:
+        flag = row["flag"] or "—"
+        effective = row["effective_value"] if row["effective_value"] is not None else "—"
+        health = (row.get("health") or "unknown")[:60]
+        lines.append(
+            f"  {row['subsystem']:<34} {row['status']:<10} {flag:<26} "
+            f"{str(effective):<10} {health}"
+        )
+    return "\n".join(lines)
+
+
+def vnx_subsystems(args) -> int:
+    project_id = getattr(args, "project_id", None)
+    project_dir = Path(getattr(args, "project_dir", ".")).resolve()
+    emit_json = getattr(args, "json", False)
+    emit_md = getattr(args, "md", False)
+    use_probe = getattr(args, "probe", False)
+
+    engine_root = _engine.engine_root()
+    data_dir = _engine.resolve_data_root(project_dir)
+
+    rows = build_rows(project_id)
+    seed_health = _parse_seed_health(engine_root)
+    _attach_health(rows, data_dir, seed_health, use_probe)
+
+    if emit_md:
+        print(_render_md(rows))
+        return 0
+
+    if emit_json:
+        print(json.dumps({"project_id": project_id, "subsystems": rows}, indent=2))
+        return 0
+
+    print(_render_table(rows))
+    return 0

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -96,6 +96,40 @@ def _register_status_subparser(subparsers: argparse.Action) -> None:
     )
 
 
+def _register_subsystems_subparser(subparsers: argparse.Action) -> None:
+    subsystems_parser = subparsers.add_parser(
+        "subsystems",
+        help="render the live subsystem cockpit SSOT (MAP + ON/OFF + HEALTH)",
+    )
+    subsystems_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit results as JSON",
+    )
+    subsystems_parser.add_argument(
+        "--md",
+        action="store_true",
+        help="emit the docs/core/SUBSYSTEMS.md ledger table verbatim",
+    )
+    subsystems_parser.add_argument(
+        "--probe",
+        action="store_true",
+        help="run registered effectiveness probes for live health (unknown for unregistered subsystems)",
+    )
+    subsystems_parser.add_argument(
+        "--project-id",
+        default=None,
+        metavar="PROJECT_ID",
+        help="project_id to resolve flag values for (default: registry default / env)",
+    )
+    subsystems_parser.add_argument(
+        "--project-dir",
+        default=".",
+        metavar="DIR",
+        help="project directory to resolve the data root from (default: current directory)",
+    )
+
+
 def _register_init_subparser(subparsers: argparse.Action) -> None:
     init_parser = subparsers.add_parser(
         "init",
@@ -853,6 +887,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.status import vnx_status
         sys.exit(vnx_status(args))
 
+    elif args.command == "subsystems":
+        from vnx_cli.commands.subsystems import vnx_subsystems
+        sys.exit(vnx_subsystems(args))
+
     elif args.command == "dispatch-agent":
         from vnx_cli.commands.dispatch_agent import vnx_dispatch_agent
         sys.exit(vnx_dispatch_agent(args))
@@ -925,6 +963,7 @@ def main() -> None:
     _register_fabric_audit_subparser(subparsers)
     _register_version_subparser(subparsers)
     _register_status_subparser(subparsers)
+    _register_subsystems_subparser(subparsers)
     _register_init_subparser(subparsers)
     _register_pool_subparser(subparsers)
     _register_role_subparser(subparsers)


### PR DESCRIPTION
## Summary
Implements PR-3 of `framework-status-audit-and-cockpit` (see `docs/core/framework-status-audit-and-cockpit_PRD.md` §PR-3): `vnx subsystems [--json] [--md] [--probe] [--project-id] [--project-dir]`.

- Rowset = union of `config_registry.CONFIG_REGISTRY` (flag-backed, one canonical flag per subsystem via last-insertion-wins) and `config_registry.CONFIG_REGISTRY_SUBSYSTEMS` (flag-less kernel subsystems).
- Health = live beacon (`health_beacon.all_beacons(VNX_DATA_DIR)`, resolved via `_engine.resolve_data_root` — never argless) → committed-seed fallback (parsed from `docs/core/SUBSYSTEMS.md` itself) → `unknown`.
- `--md` emits the exact ledger table; `.github/workflows/subsystems-drift.yml` + `make subsystems-check` diff the deterministic columns (subsystem/what/flag/status) against the committed file in CI, excluding the dynamic `health` column.
- `--probe` is this PR's owned flag surface: a guarded import of `scripts/lib/subsystem_health.aggregate()` (PR-5, already merged) — no edit back to this file, per the documented parallel-DAG-sibling contract with PR-5.
- Registered in `vnx_cli/main.py`; `scripts/commands/subsystems.sh` + a `bin/vnx` case give repo-local dual-CLI parity.

### Notable fixes made along the way
- `docs/core/SUBSYSTEMS.md` is now **regenerated via the CLI itself** (verified byte-identical round-trip) and gained 5 rows that existed in `config_registry` but were missing from the PR-1 hand-seed: `cheap-recon-scout`, `horizon-planning`, `headless-dispatch-routing`, `central-db-routing`, `cross-project-federation`.
- Fixed a pre-existing subsystem-mapping bug in `scripts/lib/config_registry.py`: `VNX_PLAN_GATE_COMPLEX_ONLY` was tagged `subsystem="plan-gate-panel"`, colliding with `VNX_PLAN_GATE_ENFORCE` and diverging from the PRD's own `"plan-gate-task-class-scope"` seed row. Corrected so the cockpit generator has exactly one canonical flag per ledger row; `tests/test_config_registry.py` updated to match (pure display metadata — no runtime behavior change).
- Rebased onto `origin/main` mid-dispatch to pick up PR-5/PR-6/PR-8 (merged concurrently) and integrated `subsystem_health.aggregate()`'s real signature.

## Changes
- `vnx_cli/commands/subsystems.py` (new) — the CLI implementation.
- `vnx_cli/main.py` — subparser registration + dispatch branch.
- `scripts/commands/subsystems.sh` (new) + `bin/vnx` — bash wrapper + wiring.
- `scripts/check_subsystems_drift.py` (new) + `Makefile` (new, `subsystems-check` target) + `.github/workflows/subsystems-drift.yml` (new).
- `docs/core/SUBSYSTEMS.md` — regenerated deterministic columns + 5 new rows; migration-mechanisms health text preserved from PR-8.
- `scripts/lib/config_registry.py` — 1-line subsystem fix (see above).
- `tests/vnx_cli/test_subsystems.py` (new), `tests/scripts/test_subsystems_sh.py` (new), `tests/test_config_registry.py` (updated for the fix).

## Verification
- `python3 -m pytest tests/vnx_cli/test_subsystems.py tests/scripts/test_subsystems_sh.py tests/test_config_registry.py tests/test_subsystems_md_exists.py tests/test_api_config.py tests/test_effectiveness_probe.py tests/test_subsystem_health.py tests/test_injection_effectiveness_probe.py tests/test_migration_inventory.py tests/test_migration_inventory_classification.py tests/test_migration_inventory_completeness.py -q` → **96 passed**
- `make subsystems-check` → OK, 26 subsystems, deterministic columns match
- `bash -n bin/vnx && bash -n scripts/commands/subsystems.sh` → both pass
- Manually verified `vnx subsystems`, `--json`, `--md`, `--probe` (both via `python3 -m vnx_cli.main` and `./bin/vnx`)
- Did NOT run the full repo test suite (deadline discipline — targeted tests only; full suite runs in CI)

## Open Items
None — codex review gate not yet run (rate-limit note per dispatch instructions applies if hit); kimi/gemini review requested per standard flow.