### PR TITLE
feat(health): add effectiveness probes for governance stack, plan-gate, and migration

### DIFF
--- a/scripts/lib/governance_effectiveness_probe.py
+++ b/scripts/lib/governance_effectiveness_probe.py
@@ -1,0 +1,95 @@
+"""governance_effectiveness_probe — read-only health probe for the
+governance-enforcement-stack (framework-status-audit-and-cockpit PR-7).
+
+Reads the REAL hash-chained attestation ledger, ``.vnx-attest/plan-gates.ndjson``
+(``.vnx-attest/governed.ndjson`` does NOT exist — kimi finding, verified against
+the tree) and verifies its integrity via ``ndjson_hash_chain.verify_chain()``.
+
+Vocabulary (glm/deepseek finding): an ``unchained`` ledger (no entry carries
+``prev_hash``) is the EXPECTED PARK state — hash-chaining is off by default
+(``VNX_HASH_CHAIN_REQUIRED`` default "0") — and reports ``ok``, not
+``produces_crap``. Only a ``broken`` chain (a ``prev_hash`` present but failing
+verification — tamper) reports ``produces_crap`` (beacon ``fail``, with
+``tamper: True`` in the detail); ``corrupt`` stays owned by the beacon layer for
+unreadable JSON (see ``effectiveness_probe.py`` module docstring).
+
+Known detection limitation: this probe inherits ``verify_chain``'s open #1086
+prefix-strip weakness — it cannot detect a prefix-strip forgery until #1086's
+origin-pinning lands. Recorded verbatim in every result's ``detail``.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import project_root  # noqa: E402
+from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
+from ndjson_hash_chain import verify_chain, walk_chain  # noqa: E402
+
+LEDGER_RELPATH = ".vnx-attest/plan-gates.ndjson"
+
+DETECTION_LIMITATION = (
+    "inherits verify_chain's open #1086 prefix-strip weakness: cannot detect a "
+    "prefix-strip forgery until #1086's origin-pinning lands"
+)
+
+
+@register_probe("governance-enforcement-stack")
+class GovernanceEffectivenessProbe(EffectivenessProbe):
+    """Read-only over ``.vnx-attest/plan-gates.ndjson``. No new central-DB table
+    (ADR-007 scope statement, PR-5)."""
+
+    subsystem = "governance-enforcement-stack"
+
+    def __init__(self, repo_root: Optional[Path] = None) -> None:
+        self._repo_root = Path(repo_root) if repo_root else project_root.resolve_project_root(__file__)
+
+    def _ledger_path(self) -> Path:
+        return self._repo_root / LEDGER_RELPATH
+
+    def probe(self) -> Dict[str, Any]:
+        path = self._ledger_path()
+        if not path.exists():
+            return {
+                "ledger_exists": False,
+                "entry_count": 0,
+                "chain_status": "unchained",
+                "chain_valid": True,
+                "violation_count": 0,
+                "detection_limitation": DETECTION_LIMITATION,
+            }
+        entry_count = sum(1 for _ in walk_chain(path))
+        is_valid, violations, status = verify_chain(path)
+        return {
+            "ledger_exists": True,
+            "entry_count": entry_count,
+            "chain_status": status,
+            "chain_valid": is_valid,
+            "violation_count": len(violations),
+            "tamper": status == "broken",
+            "detection_limitation": DETECTION_LIMITATION,
+        }
+
+    def signal(self, raw: Dict[str, Any]) -> str:
+        if not raw["ledger_exists"] or raw["entry_count"] == 0:
+            return "no plan-gates.ndjson attestations yet"
+        base = f"{raw['entry_count']} attestation(s); chain={raw['chain_status']}"
+        if raw["chain_status"] == "broken":
+            return f"{base} — TAMPER: {raw['violation_count']} violation(s)"
+        return base
+
+    def health(self, raw: Dict[str, Any]) -> str:
+        if not raw["ledger_exists"] or raw["entry_count"] == 0:
+            return "unknown"
+        if raw["chain_status"] == "broken":
+            return "produces_crap"
+        # "unchained" (expected PARK state), "verified", "verified-segmented" all ok.
+        return "ok"
+
+
+__all__ = ["GovernanceEffectivenessProbe", "LEDGER_RELPATH", "DETECTION_LIMITATION"]

--- a/scripts/lib/migration_effectiveness_probe.py
+++ b/scripts/lib/migration_effectiveness_probe.py
@@ -1,0 +1,107 @@
+"""migration_effectiveness_probe — read-only health probe for the
+migration-mechanisms subsystem (framework-status-audit-and-cockpit PR-7).
+
+Reads the declarative invariant manifest (``schema_manifest.py``, PR-A2) and
+compares it against the actual runtime coordination DB's claimed
+``PRAGMA user_version``: does the DB's claimed version match a real manifest
+entry, does that entry's invariants fully hold, and how far behind the
+terminal (highest known) manifest version is it.
+
+This mirrors what ``schema_manifest.reconcile_user_version()`` already checks
+at migration-walk time, but read-only and outside that write path: a probe run
+never mutates ``user_version`` or any table (ADR-007 scope statement, PR-5 —
+no new central-DB table, no write beyond the beacon).
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import project_root  # noqa: E402
+import schema_manifest  # noqa: E402
+from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
+
+COORDINATION_DB_FILENAME = "runtime_coordination.db"
+
+
+@register_probe("migration-mechanisms")
+class MigrationEffectivenessProbe(EffectivenessProbe):
+    """Read-only over the runtime coordination DB's ``PRAGMA user_version`` vs
+    ``schema_manifest.SCHEMA_MANIFEST``. No new central-DB table (ADR-007 scope
+    statement, PR-5)."""
+
+    subsystem = "migration-mechanisms"
+
+    def __init__(self, state_dir: Optional[Path] = None) -> None:
+        self._state_dir = Path(state_dir) if state_dir else project_root.resolve_state_dir(__file__)
+
+    def _db_path(self) -> Path:
+        return self._state_dir / COORDINATION_DB_FILENAME
+
+    def probe(self) -> Dict[str, Any]:
+        path = self._db_path()
+        if not path.exists():
+            return {"db_exists": False}
+
+        conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True, timeout=10.0)
+        try:
+            claimed = conn.execute("PRAGMA user_version").fetchone()[0]
+            terminal = schema_manifest.TERMINAL_VERSION
+            candidates = [v for v in schema_manifest.SCHEMA_MANIFEST if v <= claimed]
+            effective = max(candidates) if candidates else None
+            if effective is None:
+                return {
+                    "db_exists": True,
+                    "claimed_version": claimed,
+                    "terminal_version": terminal,
+                    "effective_version": None,
+                    "violation_count": 0,
+                    "violations_sample": [],
+                }
+            violations = schema_manifest.validate_db_at_version(conn, effective)
+            return {
+                "db_exists": True,
+                "claimed_version": claimed,
+                "terminal_version": terminal,
+                "effective_version": effective,
+                "violation_count": len(violations),
+                "violations_sample": list(violations[:3]),
+            }
+        finally:
+            conn.close()
+
+    def signal(self, raw: Dict[str, Any]) -> str:
+        if not raw["db_exists"]:
+            return "no runtime coordination DB yet"
+        if raw["effective_version"] is None:
+            return f"user_version={raw['claimed_version']} predates the manifest floor (v{schema_manifest.MIN_VERSION})"
+        if raw["violation_count"]:
+            return (
+                f"user_version={raw['claimed_version']} FAILS its v{raw['effective_version']} "
+                f"invariant manifest ({raw['violation_count']} violation(s))"
+            )
+        lag = raw["terminal_version"] - raw["claimed_version"]
+        if lag > 0:
+            return (
+                f"user_version={raw['claimed_version']} valid, {lag} version(s) behind "
+                f"terminal v{raw['terminal_version']}"
+            )
+        return f"user_version={raw['claimed_version']} matches terminal v{raw['terminal_version']}, manifest holds"
+
+    def health(self, raw: Dict[str, Any]) -> str:
+        if not raw["db_exists"] or raw["effective_version"] is None:
+            return "unknown"
+        if raw["violation_count"] > 0:
+            return "produces_crap"
+        if raw["claimed_version"] < raw["terminal_version"]:
+            return "degraded"
+        return "ok"
+
+
+__all__ = ["MigrationEffectivenessProbe", "COORDINATION_DB_FILENAME"]

--- a/scripts/lib/plan_gate_effectiveness_probe.py
+++ b/scripts/lib/plan_gate_effectiveness_probe.py
@@ -1,0 +1,144 @@
+"""plan_gate_effectiveness_probe — read-only health probe for the
+plan-gate-panel subsystem (framework-status-audit-and-cockpit PR-7).
+
+Two REAL, persisted signal sources (kimi finding — name the source):
+
+1. ``.vnx-attest/plan-gates.ndjson`` — the same panel attestation ledger the
+   governance probe verifies, read here for its ``resolver`` field. Per-panelist
+   pass/revise/block counts are NOT persisted anywhere (only the final resolved
+   ``plan_gate_pass`` record survives — see ``plan_gate_panel.run_panel`` /
+   ``planning_cli.py``); ``resolver`` is the only durable proxy for whether a
+   track's plan gate converged organically via the panel run (``"run"``) or
+   needed a manual operator override (``"attest"`` — ``planning_cli.py``'s
+   ``plan-gate attest`` command, the escape hatch for a panel that did not
+   converge on its own).
+2. The ``OI-PLAN-<track>`` blocker rows in ``track_open_items`` (the runtime
+   coordination DB), under ``VNX_DATA_DIR`` — the same table
+   ``plan_gate_enforcement.plan_gate_state()`` reads per-track, queried here
+   in aggregate across every track.
+
+Health is `ok` when gates resolve without a stuck backlog and organic panel
+convergence is not swamped by manual overrides; `degraded` when a blocker has
+sat open past the staleness window, or every resolved gate on record required a
+manual attest (the panel itself never converged unassisted) — both read as
+"panel verdicts disagree" in the PRD's vocabulary.
+
+Deliberately NOT checked (kimi finding): whether complex tracks skip the panel
+(``VNX_PLAN_GATE_COMPLEX_ONLY``) — the scope-skip read-site does not exist yet
+(deferred to ``review-floor-enforcer``), so there is no signal to probe.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LIB = str(Path(__file__).resolve().parent)
+if _LIB not in sys.path:
+    sys.path.insert(0, _LIB)
+
+import project_root  # noqa: E402
+from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
+from ndjson_hash_chain import walk_chain  # noqa: E402
+
+LEDGER_RELPATH = ".vnx-attest/plan-gates.ndjson"
+COORDINATION_DB_FILENAME = "runtime_coordination.db"
+STALE_DAYS = 7
+_PLAN_OI_PREFIX = "OI-PLAN-"
+
+
+def _has_table(conn: sqlite3.Connection, name: str) -> bool:
+    return conn.execute(
+        "SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (name,)
+    ).fetchone() is not None
+
+
+def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
+    return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})"))
+
+
+@register_probe("plan-gate-panel")
+class PlanGateEffectivenessProbe(EffectivenessProbe):
+    """Read-only over ``.vnx-attest/plan-gates.ndjson`` and ``track_open_items``.
+    No new central-DB table (ADR-007 scope statement, PR-5)."""
+
+    subsystem = "plan-gate-panel"
+
+    def __init__(self, repo_root: Optional[Path] = None, state_dir: Optional[Path] = None) -> None:
+        self._repo_root = Path(repo_root) if repo_root else project_root.resolve_project_root(__file__)
+        self._state_dir = Path(state_dir) if state_dir else project_root.resolve_state_dir(__file__)
+
+    def _ledger_path(self) -> Path:
+        return self._repo_root / LEDGER_RELPATH
+
+    def _db_path(self) -> Path:
+        return self._state_dir / COORDINATION_DB_FILENAME
+
+    def probe(self) -> Dict[str, Any]:
+        ledger_total = 0
+        ledger_attest_count = 0
+        ledger_path = self._ledger_path()
+        if ledger_path.exists():
+            for _line_no, entry, _hash in walk_chain(ledger_path):
+                if not isinstance(entry, dict) or entry.get("type") != "plan_gate_pass":
+                    continue
+                ledger_total += 1
+                if entry.get("resolver") == "attest":
+                    ledger_attest_count += 1
+
+        oi_plan_unresolved = 0
+        oi_plan_stale_unresolved = 0
+        oi_plan_resolved = 0
+        db_path = self._db_path()
+        if db_path.exists():
+            conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+            try:
+                if _has_table(conn, "track_open_items") and _has_col(conn, "track_open_items", "resolved_at"):
+                    cutoff = (datetime.now(timezone.utc) - timedelta(days=STALE_DAYS)).isoformat()
+                    rows = conn.execute(
+                        "SELECT linked_at, resolved_at FROM track_open_items "
+                        "WHERE oi_id LIKE ? AND link_type='blocks'",
+                        (f"{_PLAN_OI_PREFIX}%",),
+                    ).fetchall()
+                    for linked_at, resolved_at in rows:
+                        if resolved_at:
+                            oi_plan_resolved += 1
+                        else:
+                            oi_plan_unresolved += 1
+                            if linked_at and str(linked_at) < cutoff:
+                                oi_plan_stale_unresolved += 1
+            finally:
+                conn.close()
+
+        return {
+            "ledger_total": ledger_total,
+            "ledger_attest_count": ledger_attest_count,
+            "oi_plan_unresolved": oi_plan_unresolved,
+            "oi_plan_stale_unresolved": oi_plan_stale_unresolved,
+            "oi_plan_resolved": oi_plan_resolved,
+        }
+
+    def signal(self, raw: Dict[str, Any]) -> str:
+        if not any(raw.values()):
+            return "no plan-gate activity yet (no ledger records, no OI-PLAN blockers)"
+        return (
+            f"{raw['ledger_total']} plan-gate-pass record(s) "
+            f"({raw['ledger_attest_count']} via manual attest); "
+            f"{raw['oi_plan_unresolved']} unresolved OI-PLAN blocker(s) "
+            f"({raw['oi_plan_stale_unresolved']} stale >{STALE_DAYS}d), "
+            f"{raw['oi_plan_resolved']} resolved"
+        )
+
+    def health(self, raw: Dict[str, Any]) -> str:
+        if not any(raw.values()):
+            return "unknown"
+        if raw["oi_plan_stale_unresolved"] > 0:
+            return "degraded"
+        if raw["ledger_total"] > 0 and raw["ledger_attest_count"] == raw["ledger_total"] and raw["oi_plan_resolved"] > 0:
+            return "degraded"
+        return "ok"
+
+
+__all__ = ["PlanGateEffectivenessProbe", "LEDGER_RELPATH", "COORDINATION_DB_FILENAME", "STALE_DAYS"]

--- a/scripts/lib/subsystem_health.py
+++ b/scripts/lib/subsystem_health.py
@@ -33,6 +33,14 @@ from effectiveness_probe import (  # noqa: E402
 )
 from health_beacon import HealthBeacon  # noqa: E402
 
+# Concrete probes self-register into EFFECTIVENESS_PROBES via `@register_probe`
+# at import time (PR-7). Importing them here means aggregate() sees every
+# registered probe regardless of which entrypoint (CLI, test, dashboard)
+# triggers the first import of this module.
+import governance_effectiveness_probe  # noqa: E402,F401
+import migration_effectiveness_probe  # noqa: E402,F401
+import plan_gate_effectiveness_probe  # noqa: E402,F401
+
 
 def known_subsystems() -> List[str]:
     """Every cockpit subsystem name: flag-backed entries from ``CONFIG_REGISTRY``,

--- a/tests/test_governance_effectiveness_probe.py
+++ b/tests/test_governance_effectiveness_probe.py
@@ -1,0 +1,101 @@
+"""Tests for scripts/lib/governance_effectiveness_probe.py
+(framework-status-audit-and-cockpit PR-7).
+
+Dispatch-ID: 20260712-185712-cockpit-pr7
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from effectiveness_probe import EFFECTIVENESS_PROBES  # noqa: E402
+from governance_effectiveness_probe import (  # noqa: E402
+    GovernanceEffectivenessProbe,
+)
+from ndjson_hash_chain import append_chained_entry  # noqa: E402
+
+
+def _ledger_path(repo_root: Path) -> Path:
+    return repo_root / ".vnx-attest" / "plan-gates.ndjson"
+
+
+def test_registered_under_governance_enforcement_stack():
+    assert EFFECTIVENESS_PROBES["governance-enforcement-stack"] is GovernanceEffectivenessProbe
+
+
+def test_unknown_when_ledger_absent(tmp_path):
+    result = GovernanceEffectivenessProbe(repo_root=tmp_path).run()
+
+    assert result.status == "unknown"
+    assert result.detail["ledger_exists"] is False
+    assert "detection_limitation" in result.detail
+
+
+def test_unchained_ledger_is_ok_not_produces_crap(tmp_path):
+    """An unchained ledger (no prev_hash) is the expected PARK state, not a failure."""
+    ledger = _ledger_path(tmp_path)
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(json.dumps({"type": "plan_gate_pass", "track_id": "t1"}) + "\n")
+
+    result = GovernanceEffectivenessProbe(repo_root=tmp_path).run()
+
+    assert result.status == "ok"
+    assert result.detail["chain_status"] == "unchained"
+    assert result.detail["entry_count"] == 1
+
+
+def test_verified_chain_is_ok(tmp_path):
+    ledger = _ledger_path(tmp_path)
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t1", "resolver": "attest"})
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t2", "resolver": "attest"})
+
+    result = GovernanceEffectivenessProbe(repo_root=tmp_path).run()
+
+    assert result.status == "ok"
+    assert result.detail["chain_status"] in ("verified", "verified-segmented")
+    assert result.detail["entry_count"] == 2
+
+
+def test_broken_chain_is_produces_crap_with_tamper_detail_not_corrupt(tmp_path):
+    """A tampered chain (prev_hash present but wrong) maps to produces_crap (beacon
+    `fail`), never `corrupt` — that vocabulary is reserved for unreadable JSON."""
+    ledger = _ledger_path(tmp_path)
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t1", "resolver": "attest"})
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t2", "resolver": "attest"})
+
+    lines = ledger.read_text(encoding="utf-8").splitlines()
+    tampered = json.loads(lines[-1])
+    tampered["prev_hash"] = "f" * 64
+    lines[-1] = json.dumps(tampered)
+    ledger.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    result = GovernanceEffectivenessProbe(repo_root=tmp_path).run()
+
+    assert result.status == "produces_crap"
+    assert result.detail["chain_status"] == "broken"
+    assert result.detail["tamper"] is True
+    assert "TAMPER" in result.signal
+
+
+def test_detection_limitation_caveat_always_present(tmp_path):
+    result = GovernanceEffectivenessProbe(repo_root=tmp_path).run()
+    assert "#1086" in result.detail["detection_limitation"]
+
+
+def test_default_construction_resolves_real_repo_root_without_crashing():
+    """The zero-arg constructor path is what subsystem_health.aggregate() actually
+    calls (probe_cls()); it must resolve a real repo_root and never raise."""
+    result = GovernanceEffectivenessProbe().run()
+    assert result.status in {"ok", "degraded", "produces_crap", "unknown"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_migration_effectiveness_probe.py
+++ b/tests/test_migration_effectiveness_probe.py
@@ -1,0 +1,156 @@
+"""Tests for scripts/lib/migration_effectiveness_probe.py
+(framework-status-audit-and-cockpit PR-7).
+
+Builds GENUINE migration-walked DBs via ``migrate_future_system`` (the same
+builder pattern as ``tests/test_fsr_version_reconciliation.py``) rather than
+hand-rolling schema fixtures, so the probe is exercised against the real
+migration surface, not a guess at its shape.
+
+Dispatch-ID: 20260712-185712-cockpit-pr7
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS = _REPO_ROOT / "scripts"
+_LIB = _SCRIPTS / "lib"
+for _p in (_LIB, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import migrate_future_system as mfs  # noqa: E402
+import schema_migration  # noqa: E402
+from effectiveness_probe import EFFECTIVENESS_PROBES  # noqa: E402
+from migration_effectiveness_probe import (  # noqa: E402
+    COORDINATION_DB_FILENAME,
+    MigrationEffectivenessProbe,
+)
+
+_V21_DISPATCHES = """
+CREATE TABLE dispatches (
+    id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+    project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+    terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT,
+    attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+    created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+    expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+    UNIQUE(dispatch_id, project_id)
+)
+"""
+
+_APPLY_CHAIN = (
+    (22, "apply_migration"), (24, "apply_migration_v24"), (27, "apply_migration_v27"),
+    (28, "apply_migration_v28"), (29, "apply_migration_v29"), (30, "apply_migration_v30"),
+    (31, "apply_migration_v31"),
+)
+
+
+def _make_project(tmp_path: Path) -> Path:
+    proj = tmp_path / "project"
+    state = proj / ".vnx-data" / "state"
+    state.mkdir(parents=True)
+    db = state / COORDINATION_DB_FILENAME
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.executescript(_V21_DISPATCHES)
+    conn.commit()
+    conn.close()
+    return proj
+
+
+def _state_dir(proj: Path) -> Path:
+    return proj / ".vnx-data" / "state"
+
+
+def _build_db_at(tmp_path: Path, target: int) -> Path:
+    proj = _make_project(tmp_path)
+    db = _state_dir(proj) / COORDINATION_DB_FILENAME
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    for ver, fname in _APPLY_CHAIN:
+        if ver > target:
+            break
+        getattr(mfs, fname)(conn, proj)
+        conn.commit()
+    assert schema_migration.get_user_version(conn) == target
+    conn.close()
+    return proj
+
+
+def test_registered_under_migration_mechanisms():
+    assert EFFECTIVENESS_PROBES["migration-mechanisms"] is MigrationEffectivenessProbe
+
+
+def test_unknown_when_db_absent(tmp_path):
+    result = MigrationEffectivenessProbe(state_dir=tmp_path / "state").run()
+    assert result.status == "unknown"
+    assert result.detail["db_exists"] is False
+
+
+def test_unknown_when_claimed_version_predates_manifest_floor(tmp_path):
+    """A user_version of 0 (no migration ever walked) has no applicable manifest
+    entry to validate against — nothing to measure, not a failure."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    conn = sqlite3.connect(str(state_dir / COORDINATION_DB_FILENAME))
+    conn.execute("CREATE TABLE placeholder (x INTEGER)")
+    conn.commit()
+    conn.close()
+
+    result = MigrationEffectivenessProbe(state_dir=state_dir).run()
+
+    assert result.status == "unknown"
+    assert result.detail["effective_version"] is None
+
+
+def test_genuine_terminal_version_db_is_ok(tmp_path):
+    proj = _build_db_at(tmp_path, 31)
+
+    result = MigrationEffectivenessProbe(state_dir=_state_dir(proj)).run()
+
+    assert result.status == "ok"
+    assert result.detail["claimed_version"] == 31
+    assert result.detail["violation_count"] == 0
+
+
+def test_genuine_earlier_version_db_is_degraded_not_produces_crap(tmp_path):
+    """A DB honestly at an earlier, internally-consistent version is behind, not
+    broken — the manifest holds for its claimed (lower) version."""
+    proj = _build_db_at(tmp_path, 27)
+
+    result = MigrationEffectivenessProbe(state_dir=_state_dir(proj)).run()
+
+    assert result.status == "degraded"
+    assert result.detail["claimed_version"] == 27
+    assert result.detail["violation_count"] == 0
+
+
+def test_lying_user_version_is_produces_crap(tmp_path):
+    """A DB physically at v27 that claims v31 fails the v31 invariant manifest —
+    genuine drift/corruption, not a lag."""
+    proj = _build_db_at(tmp_path, 27)
+    db = _state_dir(proj) / COORDINATION_DB_FILENAME
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA user_version = 31")
+    conn.commit()
+    conn.close()
+
+    result = MigrationEffectivenessProbe(state_dir=_state_dir(proj)).run()
+
+    assert result.status == "produces_crap"
+    assert result.detail["violation_count"] > 0
+
+
+def test_default_construction_resolves_real_state_dir_without_crashing():
+    result = MigrationEffectivenessProbe().run()
+    assert result.status in {"ok", "degraded", "produces_crap", "unknown"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_plan_gate_effectiveness_probe.py
+++ b/tests/test_plan_gate_effectiveness_probe.py
@@ -1,0 +1,121 @@
+"""Tests for scripts/lib/plan_gate_effectiveness_probe.py
+(framework-status-audit-and-cockpit PR-7).
+
+Dispatch-ID: 20260712-185712-cockpit-pr7
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB_DIR = _REPO_ROOT / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from effectiveness_probe import EFFECTIVENESS_PROBES  # noqa: E402
+from ndjson_hash_chain import append_chained_entry  # noqa: E402
+from plan_gate_effectiveness_probe import (  # noqa: E402
+    COORDINATION_DB_FILENAME,
+    PlanGateEffectivenessProbe,
+)
+
+
+def _ledger_path(repo_root: Path) -> Path:
+    return repo_root / ".vnx-attest" / "plan-gates.ndjson"
+
+
+def _make_db(state_dir: Path, rows) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / COORDINATION_DB_FILENAME))
+    conn.execute(
+        "CREATE TABLE track_open_items (track_id TEXT, project_id TEXT, oi_id TEXT, "
+        "link_type TEXT, linked_at TEXT, resolved_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO track_open_items "
+        "(track_id, project_id, oi_id, link_type, linked_at, resolved_at) VALUES (?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_registered_under_plan_gate_panel():
+    assert EFFECTIVENESS_PROBES["plan-gate-panel"] is PlanGateEffectivenessProbe
+
+
+def test_unknown_when_nothing_exists(tmp_path):
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+    assert result.status == "unknown"
+
+
+def test_fresh_unresolved_blocker_alone_is_ok_not_degraded(tmp_path):
+    """A newly-seeded OI-PLAN blocker is expected transient state (every track is
+    'born plan-gated') — not, by itself, a sign of trouble."""
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [("t1", "p", "OI-PLAN-t1", "blocks", now, None)])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "ok"
+    assert result.detail["oi_plan_unresolved"] == 1
+    assert result.detail["oi_plan_stale_unresolved"] == 0
+
+
+def test_stale_unresolved_blocker_is_degraded(tmp_path):
+    state_dir = tmp_path / "state"
+    old = (datetime.now(timezone.utc) - timedelta(days=30)).isoformat()
+    _make_db(state_dir, [("t1", "p", "OI-PLAN-t1", "blocks", old, None)])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "degraded"
+    assert result.detail["oi_plan_stale_unresolved"] == 1
+
+
+def test_all_manual_attest_resolutions_is_degraded(tmp_path):
+    """Every ledger record needing a manual operator override — never an organic
+    panel convergence — reads as the panel not converging on its own."""
+    ledger = _ledger_path(tmp_path)
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t1", "resolver": "attest"})
+
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [("t1", "p", "OI-PLAN-t1", "blocks", now, now)])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "degraded"
+    assert result.detail["ledger_attest_count"] == result.detail["ledger_total"] == 1
+
+
+def test_mixed_resolver_with_no_stale_backlog_is_ok(tmp_path):
+    ledger = _ledger_path(tmp_path)
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t1", "resolver": "run"})
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t2", "resolver": "attest"})
+
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [
+        ("t1", "p", "OI-PLAN-t1", "blocks", now, now),
+        ("t2", "p", "OI-PLAN-t2", "blocks", now, now),
+    ])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "ok"
+
+
+def test_default_construction_resolves_real_paths_without_crashing():
+    result = PlanGateEffectivenessProbe().run()
+    assert result.status in {"ok", "degraded", "produces_crap", "unknown"}
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_subsystem_health.py
+++ b/tests/test_subsystem_health.py
@@ -111,8 +111,25 @@ def test_aggregate_default_subsystems_covers_the_known_universe(monkeypatch, tmp
     results = subsystem_health.aggregate(state_dir=tmp_path)
 
     assert results["probe-ok-subsystem"]["status"] == "ok"
-    assert results["governance-enforcement-stack"]["status"] == "unknown"
-    assert results["governance-enforcement-stack"]["signal"] == "no probe registered"
+    # "docs-bloat" carries no probe by PRD design (PR-11 is pure docs cleanup, no
+    # code/health surface) — it stays the "no probe registered" exemplar even
+    # after PR-7 registers real probes for governance/plan-gate/migration.
+    assert results["docs-bloat"]["status"] == "unknown"
+    assert results["docs-bloat"]["signal"] == "no probe registered"
+
+
+def test_aggregate_wires_governance_plan_gate_and_migration_probes(tmp_path):
+    """PR-7 acceptance criteria: ``vnx subsystems --probe`` (which calls
+    aggregate()) returns real health — not 'no probe registered' — for all
+    three subsystems, using each probe's default (real repo/state) resolution."""
+    results = subsystem_health.aggregate(
+        state_dir=tmp_path,
+        subsystems=["governance-enforcement-stack", "plan-gate-panel", "migration-mechanisms"],
+    )
+
+    for name in ("governance-enforcement-stack", "plan-gate-panel", "migration-mechanisms"):
+        assert results[name]["signal"] != "no probe registered"
+        assert results[name]["status"] in {"ok", "degraded", "produces_crap", "unknown"}
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Implements PR-7 of the `framework-status-audit-and-cockpit` track (see `docs/core/framework-status-audit-and-cockpit_PRD.md` §PR-7): three read-only `EffectivenessProbe` implementations wired into `EFFECTIVENESS_PROBES`.

- **`governance_effectiveness_probe.py`** — reads the REAL `.vnx-attest/plan-gates.ndjson` ledger (`.vnx-attest/governed.ndjson` does not exist) and verifies its hash chain via `ndjson_hash_chain.verify_chain()`. An `unchained` ledger (no `prev_hash`) is the expected PARK state → `ok`, **not** `produces_crap`. Only a `broken` chain (a `prev_hash` present but verification fails — tamper) is `produces_crap` (beacon `fail`, `tamper: True` in detail; `corrupt` stays owned by the beacon layer for unreadable JSON). Every result records the open #1086 prefix-strip detection limitation.
- **`plan_gate_effectiveness_probe.py`** — reads the same ledger's `resolver` field (only proxy available: per-panelist pass/revise/block counts are never persisted) plus aggregate `OI-PLAN-<track>` blocker state from `track_open_items` under `VNX_DATA_DIR`. `degraded` when a blocker has sat open >7 days, or every resolved gate on record required a manual `attest` override (panel never converged unassisted). Deliberately does **not** check the complex-tracks-skip (`VNX_PLAN_GATE_COMPLEX_ONLY`) — that read-site doesn't exist yet (deferred to `review-floor-enforcer`).
- **`migration_effectiveness_probe.py`** — compares the runtime coordination DB's claimed `PRAGMA user_version` against `schema_manifest.py`'s invariant manifest. `degraded` when honestly behind the terminal version (manifest holds for the claimed version); `produces_crap` when the claimed version fails its own manifest (drift/corruption, e.g. a lying `user_version`).

`subsystem_health.py` now imports all three concrete probe modules so `aggregate()` sees them regardless of which entrypoint triggers the first import (CLI, test, dashboard).

## Changes

- `scripts/lib/governance_effectiveness_probe.py` (new)
- `scripts/lib/plan_gate_effectiveness_probe.py` (new)
- `scripts/lib/migration_effectiveness_probe.py` (new)
- `scripts/lib/subsystem_health.py` — import the 3 concrete probe modules to trigger `@register_probe` registration
- `tests/test_governance_effectiveness_probe.py` (new)
- `tests/test_plan_gate_effectiveness_probe.py` (new)
- `tests/test_migration_effectiveness_probe.py` (new)
- `tests/test_subsystem_health.py` — updated the one PR-5 assertion that relied on `governance-enforcement-stack` being probe-less (swapped to `docs-bloat`, which has no probe by PRD design — pure docs cleanup, no health surface); added an integration test confirming all three subsystems now return real health via `aggregate()`

## Verification

Ran targeted tests only (not the full suite — deadline discipline):

```
python3 -m pytest tests/test_governance_effectiveness_probe.py tests/test_plan_gate_effectiveness_probe.py tests/test_migration_effectiveness_probe.py tests/test_subsystem_health.py tests/test_effectiveness_probe.py tests/test_fsr_version_reconciliation.py tests/test_config_registry.py -q
```
→ **79 passed**

- `test_migration_effectiveness_probe.py` builds GENUINE migration-walked DBs via `migrate_future_system.apply_migration*` (same builder pattern as `tests/test_fsr_version_reconciliation.py`), not hand-rolled schema fixtures, and covers: no DB → `unknown`; pre-manifest-floor `user_version` → `unknown`; genuine v31 → `ok`; genuine v27 (honestly behind) → `degraded`; a lying `user_version` (physically v27, claims v31) → `produces_crap`.
- `test_governance_effectiveness_probe.py` covers: no ledger → `unknown`; unchained ledger → `ok` (not `produces_crap`); verified/verified-segmented chain → `ok`; a tampered chain (mismatched `prev_hash`) → `produces_crap` with `tamper: True` in detail (never `corrupt`).
- `test_plan_gate_effectiveness_probe.py` covers: nothing yet → `unknown`; a fresh (non-stale) unresolved OI-PLAN blocker alone → `ok` (not degraded — every track is "born plan-gated", so a recent open blocker is expected transient state); a stale (>7d) unresolved blocker → `degraded`; every ledger record needing manual `attest` → `degraded`; a mix including a non-`attest` resolver with no stale backlog → `ok`.
- Each probe's zero-arg constructor (the path `subsystem_health.aggregate()` actually calls) is exercised directly against the real repo/state dirs to confirm it never crashes.
- `bash -n` not applicable (no shell files touched). `python3 -m py_compile` clean on all touched files.

Did **not** run the full repo test suite (per dispatch deadline discipline — a prior worker was killed running the full suite including the slow f39 billing-landmine test).

## Open Items

None — all three probes are implemented, registered, and tested per §PR-7's scope. A codex re-audit was not run in this session (not flagged unavailable either; simply out of scope for this targeted dispatch) — if the codex gate is exercised in review and flags anything, address in a follow-up.