### PR TITLE
feat(intelligence): activate learning loop only when effectiveness probe is healthy

### DIFF
--- a/dashboard/api_intelligence.py
+++ b/dashboard/api_intelligence.py
@@ -1103,6 +1103,38 @@ def _intelligence_get_learning_summary() -> tuple[dict, int]:
 
 
 # ---------------------------------------------------------------------------
+# /api/intelligence/effectiveness-probe — PR-17 gate signal exposure
+# ---------------------------------------------------------------------------
+
+
+def _intelligence_get_effectiveness_probe() -> dict:
+    """Expose the injection-effectiveness probe (PR-6) signal for the dashboard —
+    the SAME probe that gates the learning loop's activation (PR-17). Read-only:
+    this never reads or flips VNX_LEARNING_LOOP_ENABLED / VNX_INJECTION_FEEDBACK_ENABLED.
+    """
+    sd = _sd()
+    state_dir = sd.DB_PATH.parent
+    try:
+        from injection_effectiveness_probe import InjectionEffectivenessProbe
+
+        result = InjectionEffectivenessProbe(state_dir=state_dir).run()
+    except Exception as e:
+        _logger.debug("injection-effectiveness probe unavailable: %s", e)
+        return {
+            "probe_health": "unknown",
+            "ignore_rate": None,
+            "pending_proposals": 0,
+            "signal": "probe unavailable",
+        }
+    return {
+        "probe_health": result.status,
+        "ignore_rate": result.detail.get("ignore_rate"),
+        "pending_proposals": result.detail.get("pending_proposals", 0),
+        "signal": result.signal,
+    }
+
+
+# ---------------------------------------------------------------------------
 # /api/governance/* — Governance audit trail endpoints
 # ---------------------------------------------------------------------------
 

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -190,6 +190,7 @@ from api_intelligence import (  # noqa: E402
     _intelligence_get_weekly_digest,
     _intelligence_generate_weekly_digest,
     _intelligence_get_learning_summary,
+    _intelligence_get_effectiveness_probe,
     _governance_get_enforcement,
     _governance_get_overrides,
     _governance_get_audit,
@@ -524,6 +525,10 @@ class DashboardHandler(SimpleHTTPRequestHandler):
         if path == "/api/intelligence/learning-summary":
             payload, status_int = _intelligence_get_learning_summary()
             _json_response(self, HTTPStatus(status_int), payload)
+            return
+
+        if path == "/api/intelligence/effectiveness-probe":
+            _json_response(self, HTTPStatus.OK, _intelligence_get_effectiveness_probe())
             return
 
         if path == "/api/intelligence/behavioral":

--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -51,6 +51,22 @@ def _resolve_data_root(data_root: "Path | None") -> Path:
     return Path(_vnx_paths.resolve_paths()["VNX_DATA_DIR"])
 
 
+def _injection_probe_health(state_dir: Path) -> str:
+    """Run the injection-effectiveness probe (PR-6) and return its health status.
+
+    This is the PR-17 activation gate for the dream-cycle executor: read-only,
+    never raises — a probe/import failure degrades to ``"unknown"`` (gated,
+    same as a genuinely unhealthy probe) rather than crashing the cycle.
+    """
+    try:
+        from injection_effectiveness_probe import InjectionEffectivenessProbe
+
+        return InjectionEffectivenessProbe(state_dir=state_dir).run().status
+    except Exception as exc:
+        print(f"dream run: injection-effectiveness probe unavailable ({exc}) -> unknown", flush=True)
+        return "unknown"
+
+
 def _check_receipt_completeness(
     data_root: Path, max_age_hours: int = 48
 ) -> tuple[bool, str]:
@@ -219,6 +235,49 @@ def run_dream_cycle(
     # ADR-007: must NOT use resolve_project_root(__file__)/.vnx-data — that path
     # is the VNX source repo and breaks on central installs.
     _data_root = _resolve_data_root(data_root)
+
+    # PR-17 activation gate: VNX_DREAM_SCHEDULER_ENABLED is the arm-switch, the
+    # injection-effectiveness probe (PR-6) health is the gate. scheduler.py only
+    # installs the LaunchAgent/crontab — it never runs the cycle — so the gate
+    # lives here to hold for both the scheduled and manual (`vnx dream run`) paths.
+    if os.environ.get("VNX_DREAM_SCHEDULER_ENABLED", "0") != "1":
+        _emit_dream_event(
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "reason": "scheduler_disabled",
+                "detail": "VNX_DREAM_SCHEDULER_ENABLED=0",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+            _data_root,
+        )
+        return {
+            "status": "skipped",
+            "cycle_id": cycle_id,
+            "reason": "scheduler_disabled",
+            "detail": "VNX_DREAM_SCHEDULER_ENABLED=0",
+        }
+
+    probe_health = _injection_probe_health(db_path.parent)
+    if probe_health != "ok":
+        _emit_dream_event(
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": cycle_id,
+                "project_id": project_id,
+                "reason": "probe_not_ok",
+                "detail": f"injection-effectiveness probe health={probe_health}",
+                "timestamp": datetime.now(timezone.utc).isoformat(),
+            },
+            _data_root,
+        )
+        return {
+            "status": "skipped",
+            "cycle_id": cycle_id,
+            "reason": "probe_not_ok",
+            "probe_health": probe_health,
+        }
 
     # GAP-7: receipt-completeness preflight — skip cycle on empty/stale data
     complete, detail = _check_receipt_completeness(_data_root)

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -14,7 +14,7 @@ import time
 import sys
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional
 from dataclasses import dataclass
 from collections import defaultdict
 import re
@@ -69,6 +69,57 @@ def _parse_receipt_timestamp(value) -> Optional[datetime]:
             return _to_aware_utc(datetime.fromisoformat(raw[:10]))
         except ValueError:
             return None
+
+
+class LearningLoopMisconfigured(RuntimeError):
+    """Raised when VNX_LEARNING_LOOP_ENABLED=1 but VNX_INJECTION_FEEDBACK_ENABLED=0.
+
+    The injection-effectiveness probe (PR-6) is the thing that gates the loop;
+    arming the loop without the probe that gates it is a hard misconfiguration,
+    not a degraded-but-tolerable state (framework-status-audit-and-cockpit PR-17).
+    """
+
+
+def evaluate_activation_gate(state_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """The PR-17 activation gate: four explicit, non-overlapping paths.
+
+    1. ``VNX_LEARNING_LOOP_ENABLED=0`` (default)            -> dormant no-op.
+    2. ``=1`` and ``VNX_INJECTION_FEEDBACK_ENABLED=0``        -> raises
+       ``LearningLoopMisconfigured`` (cannot activate learning without the
+       effectiveness probe that gates it).
+    3. Both enabled, probe health is anything other than ``"ok"`` (``unknown``,
+       ``degraded``, ``produces_crap``)                       -> degraded, no
+       pattern updates. ``degraded`` is deliberately gated here alongside
+       ``unknown``/``produces_crap`` — it is NOT healthy enough to activate.
+    4. Both enabled and probe health ``"ok"``                 -> run.
+
+    The activation gate is the probe health, not a flag: the two env flags are
+    only the arm-switch: they decide whether the probe is even consulted.
+
+    Returns ``{"action": "dormant"|"degraded"|"run", "probe_health": str|None,
+    "detail": str}``.
+    """
+    learning_enabled = os.environ.get("VNX_LEARNING_LOOP_ENABLED", "0") == "1"
+    feedback_enabled = os.environ.get("VNX_INJECTION_FEEDBACK_ENABLED", "0") == "1"
+
+    if not learning_enabled:
+        return {"action": "dormant", "probe_health": None, "detail": "VNX_LEARNING_LOOP_ENABLED=0"}
+
+    if not feedback_enabled:
+        raise LearningLoopMisconfigured(
+            "VNX_LEARNING_LOOP_ENABLED=1 requires VNX_INJECTION_FEEDBACK_ENABLED=1 — "
+            "the injection-effectiveness probe (PR-6) gates the learning loop; "
+            "cannot activate learning without it."
+        )
+
+    from injection_effectiveness_probe import InjectionEffectivenessProbe
+
+    result = InjectionEffectivenessProbe(state_dir=state_dir).run()
+
+    if result.status != "ok":
+        return {"action": "degraded", "probe_health": result.status, "detail": result.signal}
+
+    return {"action": "run", "probe_health": result.status, "detail": result.signal}
 
 
 @dataclass
@@ -995,6 +1046,38 @@ class LearningLoop:
                 instead of the default 24-hour window. Use for the first run against
                 a historical trail (``vnx learning run --from-history``).
         """
+        gate = evaluate_activation_gate(state_dir=self.db_path.parent)
+
+        if gate["action"] == "dormant":
+            print("💤 Learning loop dormant (VNX_LEARNING_LOOP_ENABLED=0) — no-op, no beacon")
+            return {"status": "dormant", "gate": gate, "statistics": {}}
+
+        if gate["action"] == "degraded":
+            print(
+                f"⛔ Learning loop gated: probe health={gate['probe_health']!r} "
+                f"({gate['detail']}) — skipping pattern updates"
+            )
+            try:
+                from health_beacon import HealthBeacon
+                from vnx_paths import ensure_env as _hb_ensure_env
+                _hb_paths = _hb_ensure_env()
+                HealthBeacon(
+                    Path(_hb_paths["VNX_DATA_DIR"]),
+                    "learning_loop",
+                    expected_interval_seconds=86400,
+                ).heartbeat(
+                    status="degraded",
+                    details={"probe_health": gate["probe_health"], "reason": gate["detail"]},
+                )
+            except (ImportError, OSError, KeyError) as e:
+                log.debug("HealthBeacon degraded heartbeat skipped: %s", e)
+            return {
+                "status": "degraded",
+                "probe_health": gate["probe_health"],
+                "gate": gate,
+                "statistics": {},
+            }
+
         mode = "FULL HISTORY" if from_history else "DAILY (24h)"
         print(f"\n🔄 Starting Learning Cycle [{mode}] at {datetime.now().isoformat()}")
         print("=" * 60)

--- a/tests/test_api_intelligence_effectiveness_probe.py
+++ b/tests/test_api_intelligence_effectiveness_probe.py
@@ -1,0 +1,90 @@
+"""Tests for /api/intelligence/effectiveness-probe (framework-status-audit-and-cockpit PR-17).
+
+Exposes the injection-effectiveness probe (PR-6) signal — the same probe that
+gates the learning loop's activation — for dashboard display. Read-only.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(_ROOT / "dashboard"))
+sys.path.insert(0, str(_ROOT / "scripts" / "lib"))
+
+import api_intelligence
+
+
+def _mock_sd(db_path: Path):
+    sd = types.SimpleNamespace()
+    sd.DB_PATH = db_path
+    return sd
+
+
+def _make_db_with_usage(tmp_path: Path, used: int, ignored: int) -> Path:
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE pattern_usage (pattern_id TEXT PRIMARY KEY, "
+        "pattern_title TEXT, pattern_hash TEXT, used_count INTEGER DEFAULT 0, "
+        "ignored_count INTEGER DEFAULT 0)"
+    )
+    conn.execute(
+        "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+        "used_count, ignored_count) VALUES ('p1', 'P', 'h', ?, ?)",
+        (used, ignored),
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_no_data_reports_unknown(tmp_path):
+    db_path = tmp_path / "quality_intelligence.db"  # never created -> no data
+    sd = _mock_sd(db_path)
+
+    with patch.object(api_intelligence, "_sd", return_value=sd):
+        result = api_intelligence._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "unknown"
+    assert result["ignore_rate"] is None
+    assert result["pending_proposals"] == 0
+    assert isinstance(result["signal"], str)
+
+
+def test_healthy_signal_reports_ok_with_ignore_rate(tmp_path):
+    db_path = _make_db_with_usage(tmp_path, used=95, ignored=5)
+    sd = _mock_sd(db_path)
+
+    with patch.object(api_intelligence, "_sd", return_value=sd):
+        result = api_intelligence._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "ok"
+    assert result["ignore_rate"] == 0.05
+
+
+def test_high_ignore_rate_reports_produces_crap(tmp_path):
+    db_path = _make_db_with_usage(tmp_path, used=2, ignored=98)
+    sd = _mock_sd(db_path)
+
+    with patch.object(api_intelligence, "_sd", return_value=sd):
+        result = api_intelligence._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "produces_crap"
+    assert result["ignore_rate"] == 0.98
+
+
+def test_probe_import_failure_degrades_to_unknown_not_500(tmp_path):
+    """A broken probe import must never crash the dashboard endpoint."""
+    db_path = tmp_path / "quality_intelligence.db"
+    sd = _mock_sd(db_path)
+
+    with patch.object(api_intelligence, "_sd", return_value=sd), \
+         patch.dict(sys.modules, {"injection_effectiveness_probe": None}):
+        result = api_intelligence._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "unknown"
+    assert result["pending_proposals"] == 0

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -8,6 +8,9 @@ Coverage:
 - test_run_dream_cycle_happy_path: full cycle with mocked kimi
 - GAP-7 receipt-completeness preflight: stale/empty → skip with warning event
 - TestCentralDataRootRespected: file I/O uses data_root param, not source-repo .vnx-data
+- TestActivationGate: PR-17 gate — VNX_DREAM_SCHEDULER_ENABLED + injection-effectiveness
+  probe health (PR-6) must both pass before the executor runs; scheduler.py is not
+  involved (it only installs the LaunchAgent/crontab)
 """
 from __future__ import annotations
 
@@ -27,6 +30,21 @@ sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(REPO_ROOT / "scripts" / "dream"))
 
 import consolidator
+
+# Captured before the autouse fixture below monkeypatches consolidator._injection_probe_health,
+# so the real-probe-integration tests in TestActivationGate can exercise the genuine function.
+_REAL_INJECTION_PROBE_HEALTH = consolidator._injection_probe_health
+
+
+@pytest.fixture(autouse=True)
+def _dream_activation_gate_open(monkeypatch):
+    """PR-17 added an activation gate that defaults closed. Open it for every test
+    in this file so the consolidation-mechanics tests keep exercising the same code
+    paths they did before the gate existed. The gate's own closed-state behavior is
+    covered by TestActivationGate below (which overrides these as needed).
+    """
+    monkeypatch.setenv("VNX_DREAM_SCHEDULER_ENABLED", "1")
+    monkeypatch.setattr(consolidator, "_injection_probe_health", lambda state_dir: "ok")
 
 
 # ---------------------------------------------------------------------------
@@ -781,3 +799,135 @@ class TestCentralDataRootRespected:
         explicit = tmp_path / "my-override"
         result = consolidator._resolve_data_root(explicit)
         assert result == explicit
+
+
+class TestActivationGate:
+    """PR-17: VNX_DREAM_SCHEDULER_ENABLED (arm-switch) + injection-effectiveness
+    probe health (PR-6, gate) must both pass before the executor runs a cycle.
+    scheduler.py never enters this path — it only installs the LaunchAgent/crontab.
+    """
+
+    def test_scheduler_disabled_skips_without_kimi(self, tmp_path, monkeypatch):
+        """VNX_DREAM_SCHEDULER_ENABLED unset (default 0) -> skip, kimi never invoked."""
+        monkeypatch.delenv("VNX_DREAM_SCHEDULER_ENABLED", raising=False)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with patch("consolidator._dispatch_kimi_consolidation") as mock_kimi:
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "scheduler_disabled"
+        mock_kimi.assert_not_called()
+
+    def test_scheduler_disabled_emits_skipped_event(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_DREAM_SCHEDULER_ENABLED", raising=False)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
+
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
+        events = [json.loads(line) for line in event_files[0].read_text().strip().splitlines()]
+        assert any(
+            e["event_type"] == "dream_cycle_skipped" and e["reason"] == "scheduler_disabled"
+            for e in events
+        )
+
+    @pytest.mark.parametrize("probe_health", ["unknown", "degraded", "produces_crap"])
+    def test_probe_not_ok_skips_without_kimi(self, tmp_path, monkeypatch, probe_health):
+        """Scheduler armed but probe health != 'ok' -> skip, kimi never invoked.
+
+        Covers all three non-'ok' probe states — only a clean 'ok' may activate.
+        """
+        monkeypatch.setenv("VNX_DREAM_SCHEDULER_ENABLED", "1")
+        monkeypatch.setattr(consolidator, "_injection_probe_health", lambda state_dir: probe_health)
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with patch("consolidator._dispatch_kimi_consolidation") as mock_kimi:
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
+
+        assert result["status"] == "skipped"
+        assert result["reason"] == "probe_not_ok"
+        assert result["probe_health"] == probe_health
+        mock_kimi.assert_not_called()
+
+    def test_probe_not_ok_emits_skipped_event(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_DREAM_SCHEDULER_ENABLED", "1")
+        monkeypatch.setattr(consolidator, "_injection_probe_health", lambda state_dir: "degraded")
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
+
+        event_files = list((data_root / "events" / "dream").glob("*.ndjson"))
+        events = [json.loads(line) for line in event_files[0].read_text().strip().splitlines()]
+        assert any(
+            e["event_type"] == "dream_cycle_skipped" and e["reason"] == "probe_not_ok"
+            for e in events
+        )
+
+    def test_probe_ok_proceeds_past_gate(self, tmp_path, monkeypatch):
+        """Scheduler armed + probe 'ok' -> gate passes, cycle proceeds to kimi."""
+        monkeypatch.setenv("VNX_DREAM_SCHEDULER_ENABLED", "1")
+        monkeypatch.setattr(consolidator, "_injection_probe_health", lambda state_dir: "ok")
+        db_path, data_root = _make_db_with_receipts(tmp_path, with_patterns=True)
+
+        with patch(
+            "consolidator._dispatch_kimi_consolidation", return_value=_FAKE_CONSOLIDATION
+        ) as mock_kimi:
+            result = consolidator.run_dream_cycle("vnx-dev", db_path, data_root=data_root)
+
+        mock_kimi.assert_called_once()
+        assert result.get("reason") not in ("scheduler_disabled", "probe_not_ok")
+
+    def test_injection_probe_health_reads_real_probe(self, tmp_path):
+        """_injection_probe_health wires the real PR-6 probe end-to-end (not mocked):
+        a pattern_usage table with a low ignore_rate reports 'ok'."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE pattern_usage (
+                pattern_id TEXT PRIMARY KEY,
+                pattern_title TEXT NOT NULL,
+                pattern_hash TEXT NOT NULL,
+                used_count INTEGER DEFAULT 0,
+                ignored_count INTEGER DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "used_count, ignored_count) VALUES ('p1', 'Pattern 1', 'hash1', 95, 5)"
+        )
+        conn.commit()
+        conn.close()
+
+        assert _REAL_INJECTION_PROBE_HEALTH(state_dir) == "ok"
+
+    def test_injection_probe_health_reads_real_probe_unhealthy(self, tmp_path):
+        """A pattern_usage table with a high ignore_rate reports 'produces_crap',
+        not 'ok' — proving the real probe integration is wired, not stubbed."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE pattern_usage (
+                pattern_id TEXT PRIMARY KEY,
+                pattern_title TEXT NOT NULL,
+                pattern_hash TEXT NOT NULL,
+                used_count INTEGER DEFAULT 0,
+                ignored_count INTEGER DEFAULT 0
+            )
+            """
+        )
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "used_count, ignored_count) VALUES ('p1', 'Pattern 1', 'hash1', 2, 98)"
+        )
+        conn.commit()
+        conn.close()
+
+        assert _REAL_INJECTION_PROBE_HEALTH(state_dir) == "produces_crap"

--- a/tests/test_learning_loop_crap_signal.py
+++ b/tests/test_learning_loop_crap_signal.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""tests/test_learning_loop_crap_signal.py — PR-17 gate path 3: probe 'produces_crap'.
+
+framework-status-audit-and-cockpit PR-17: when the injection-effectiveness probe
+(PR-6) reports produces_crap (ignore_rate >= 0.90), the learning loop must exit
+early with a degraded beacon and perform NO pattern updates.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+@pytest.fixture
+def loop_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = {
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(vnx_home),
+        "VNX_DATA_DIR": str(state_dir.parent),
+    }
+    monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+    monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        loop.conn.commit()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+def _seed_pattern_usage(state_dir: Path, used: int, ignored: int) -> None:
+    db_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+        "used_count, ignored_count) VALUES ('p1', 'Pattern 1', 'hash1', ?, ?)",
+        (used, ignored),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_produces_crap_skips_pattern_updates(loop_env):
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=2, ignored=98)  # ignore_rate=0.98
+
+    with patch.object(loop, "update_confidence_scores") as mock_update, \
+         patch("health_beacon.HealthBeacon"):
+        report = loop.daily_learning_cycle()
+
+    assert report["status"] == "degraded"
+    assert report["probe_health"] == "produces_crap"
+    mock_update.assert_not_called()
+
+
+def test_produces_crap_writes_degraded_beacon(loop_env):
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=1, ignored=99)  # ignore_rate=0.99
+
+    with patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+        mock_beacon = MagicMock()
+        mock_beacon_cls.return_value = mock_beacon
+        loop.daily_learning_cycle()
+
+    mock_beacon.heartbeat.assert_called_once()
+    kwargs = mock_beacon.heartbeat.call_args.kwargs
+    assert kwargs["status"] == "degraded"
+    assert kwargs["details"]["probe_health"] == "produces_crap"
+
+
+def test_produces_crap_at_exact_threshold(loop_env):
+    """ignore_rate exactly 0.90 owns the produces_crap endpoint (PR-6 contract)."""
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=10, ignored=90)  # ignore_rate = 0.90
+
+    with patch("health_beacon.HealthBeacon"):
+        report = loop.daily_learning_cycle()
+
+    assert report["probe_health"] == "produces_crap"
+
+
+def test_produces_crap_does_not_reach_downstream_pipeline(loop_env):
+    """Gated cycles must not persist/archive/supersede either — not just skip
+    confidence scoring."""
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=2, ignored=98)
+
+    with patch.object(loop, "persist_to_intelligence_db") as mock_persist, \
+         patch.object(loop, "archive_unused_patterns") as mock_archive, \
+         patch("health_beacon.HealthBeacon"):
+        loop.daily_learning_cycle()
+
+    mock_persist.assert_not_called()
+    mock_archive.assert_not_called()

--- a/tests/test_learning_loop_degraded_no_activate.py
+++ b/tests/test_learning_loop_degraded_no_activate.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""tests/test_learning_loop_degraded_no_activate.py — PR-17 safety-gap regression guard.
+
+Codex finding (framework-status-audit-and-cockpit v4 gate): a 'degraded' probe
+signal (50-90% ignore rate) must NOT activate the learning loop. Only a clean
+'ok' may run the cycle — 'degraded' is gated exactly like 'unknown'/
+'produces_crap', it is NOT treated as "good enough to feed generation".
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+@pytest.fixture
+def loop_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = {
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(vnx_home),
+        "VNX_DATA_DIR": str(state_dir.parent),
+    }
+    monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+    monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        loop.conn.commit()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+def _seed_pattern_usage(state_dir: Path, used: int, ignored: int, pattern_id: str = "p1") -> None:
+    db_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+        "used_count, ignored_count) VALUES (?, ?, ?, ?, ?)",
+        (pattern_id, f"Pattern {pattern_id}", f"hash-{pattern_id}", used, ignored),
+    )
+    conn.commit()
+    conn.close()
+
+
+@pytest.mark.parametrize(
+    "used,ignored",
+    [
+        (50, 50),  # ignore_rate = 0.50 -- exact lower bound, owned by degraded
+        (25, 75),  # ignore_rate = 0.75 -- mid-range
+        (11, 89),  # ignore_rate = 0.89 -- just under the produces_crap threshold
+    ],
+)
+def test_degraded_probe_does_not_activate_loop(loop_env, used, ignored):
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=used, ignored=ignored)
+
+    with patch.object(loop, "update_confidence_scores") as mock_update, \
+         patch("health_beacon.HealthBeacon"):
+        report = loop.daily_learning_cycle()
+
+    assert report["status"] == "degraded"
+    assert report["probe_health"] == "degraded"
+    mock_update.assert_not_called()
+
+
+def test_degraded_writes_degraded_beacon_not_ok(loop_env):
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=25, ignored=75)
+
+    with patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+        mock_beacon = MagicMock()
+        mock_beacon_cls.return_value = mock_beacon
+        loop.daily_learning_cycle()
+
+    kwargs = mock_beacon.heartbeat.call_args.kwargs
+    assert kwargs["status"] == "degraded"
+    assert kwargs["status"] != "ok"
+
+
+def test_degraded_does_not_reach_downstream_pipeline(loop_env):
+    """Extra guard: the entire downstream pipeline (persist, archive) must not
+    run when gated by 'degraded' — not just confidence scoring."""
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=25, ignored=75)
+
+    with patch.object(loop, "persist_to_intelligence_db") as mock_persist, \
+         patch.object(loop, "archive_unused_patterns") as mock_archive, \
+         patch("health_beacon.HealthBeacon"):
+        loop.daily_learning_cycle()
+
+    mock_persist.assert_not_called()
+    mock_archive.assert_not_called()
+
+
+def test_only_ok_activates_not_degraded(loop_env):
+    """Direct contrast within one test: degraded skips, ok runs — pins the
+    boundary so a future change can't quietly widen 'ok' to include degraded."""
+    loop, state_dir = loop_env
+    _seed_pattern_usage(state_dir, used=25, ignored=75)  # degraded
+
+    with patch.object(loop, "update_confidence_scores") as mock_update, \
+         patch("health_beacon.HealthBeacon"):
+        degraded_report = loop.daily_learning_cycle()
+
+    assert degraded_report["status"] == "degraded"
+    mock_update.assert_not_called()
+
+    # Flip to a healthy signal by adding a large batch of used-not-ignored
+    # activity under a second pattern_id — ignore_rate (summed across all rows)
+    # drops well under the degraded threshold.
+    _seed_pattern_usage(state_dir, used=9000, ignored=0, pattern_id="p2")
+
+    with patch.object(loop, "update_confidence_scores") as mock_update_ok, \
+         patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+        mock_beacon = MagicMock()
+        mock_beacon_cls.return_value = mock_beacon
+        ok_report = loop.daily_learning_cycle()
+
+    assert ok_report.get("status") not in ("dormant", "degraded")
+    mock_update_ok.assert_called()
+    assert mock_beacon.heartbeat.call_args.kwargs["status"] == "ok"

--- a/tests/test_learning_loop_gate.py
+++ b/tests/test_learning_loop_gate.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""tests/test_learning_loop_gate.py — PR-17 activation gate
+(framework-status-audit-and-cockpit).
+
+Covers the two flag-driven paths of the four-path gate in scripts/learning_loop.py:
+  1. VNX_LEARNING_LOOP_ENABLED=0 (default)                         -> dormant no-op.
+  2. VNX_LEARNING_LOOP_ENABLED=1, VNX_INJECTION_FEEDBACK_ENABLED=0  -> hard error.
+  4. Both enabled, probe health "ok"                                -> cycle runs.
+
+Probe-health-gated path 3 (unknown/degraded/produces_crap) has its own dedicated
+test files: test_learning_loop_unknown_probe.py, test_learning_loop_crap_signal.py,
+test_learning_loop_degraded_no_activate.py.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+@pytest.fixture
+def loop_env(tmp_path):
+    """LearningLoop bound to a tmp state dir via patched ensure_env."""
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = {
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(vnx_home),
+        "VNX_DATA_DIR": str(state_dir.parent),
+    }
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        loop.conn.commit()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+def _seed_pattern_usage(state_dir: Path, used: int, ignored: int) -> None:
+    """Insert a pattern_usage row via a fresh connection, mirroring how the
+    injection-effectiveness probe (opening its own read connection) sees it."""
+    db_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+        "used_count, ignored_count) VALUES ('p1', 'Pattern 1', 'hash1', ?, ?)",
+        (used, ignored),
+    )
+    conn.commit()
+    conn.close()
+
+
+class TestPathOneDormant:
+    def test_dormant_by_default_no_error(self, loop_env, monkeypatch):
+        loop, _ = loop_env
+        monkeypatch.delenv("VNX_LEARNING_LOOP_ENABLED", raising=False)
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+
+        report = loop.daily_learning_cycle()
+
+        assert report["status"] == "dormant"
+        assert report["gate"]["action"] == "dormant"
+        assert report["gate"]["probe_health"] is None
+
+    def test_dormant_explicit_zero_no_error(self, loop_env, monkeypatch):
+        loop, _ = loop_env
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "0")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+
+        report = loop.daily_learning_cycle()
+
+        assert report["status"] == "dormant"
+
+    def test_dormant_writes_no_beacon(self, loop_env, monkeypatch):
+        """Path 1 is explicitly 'not an error, no beacon' (PRD acceptance criteria)."""
+        loop, _ = loop_env
+        monkeypatch.delenv("VNX_LEARNING_LOOP_ENABLED", raising=False)
+
+        with patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+            loop.daily_learning_cycle()
+
+        mock_beacon_cls.assert_not_called()
+
+
+class TestPathTwoHardError:
+    def test_enabled_without_feedback_flag_raises(self, loop_env, monkeypatch):
+        loop, _ = loop_env
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+
+        with pytest.raises(ll.LearningLoopMisconfigured):
+            loop.daily_learning_cycle()
+
+    def test_enabled_with_feedback_explicit_zero_raises(self, loop_env, monkeypatch):
+        loop, _ = loop_env
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "0")
+
+        with pytest.raises(ll.LearningLoopMisconfigured):
+            loop.daily_learning_cycle()
+
+
+class TestPathFourRun:
+    def test_both_enabled_ok_probe_runs_cycle(self, loop_env, monkeypatch):
+        loop, state_dir = loop_env
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+        _seed_pattern_usage(state_dir, used=95, ignored=5)  # ignore_rate=0.05 -> ok
+
+        with patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+            mock_beacon = MagicMock()
+            mock_beacon_cls.return_value = mock_beacon
+            report = loop.daily_learning_cycle()
+
+        assert report.get("status") not in ("dormant", "degraded")
+        assert report.get("learning_cycle") == "daily"
+        mock_beacon.heartbeat.assert_called_once()
+        assert mock_beacon.heartbeat.call_args.kwargs["status"] == "ok"
+
+
+class TestEvaluateActivationGateDirect:
+    """Unit-level coverage of evaluate_activation_gate() without a full LearningLoop."""
+
+    def test_dormant_when_learning_disabled(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_LEARNING_LOOP_ENABLED", raising=False)
+        gate = ll.evaluate_activation_gate(state_dir=tmp_path)
+        assert gate == {
+            "action": "dormant",
+            "probe_health": None,
+            "detail": "VNX_LEARNING_LOOP_ENABLED=0",
+        }
+
+    def test_raises_when_enabled_without_feedback(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+        with pytest.raises(ll.LearningLoopMisconfigured):
+            ll.evaluate_activation_gate(state_dir=tmp_path)
+
+    def test_run_when_both_enabled_and_probe_ok(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+        db_path = tmp_path / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE pattern_usage (pattern_id TEXT PRIMARY KEY, "
+            "pattern_title TEXT, pattern_hash TEXT, used_count INTEGER DEFAULT 0, "
+            "ignored_count INTEGER DEFAULT 0)"
+        )
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "used_count, ignored_count) VALUES ('p1', 'P', 'h', 95, 5)"
+        )
+        conn.commit()
+        conn.close()
+
+        gate = ll.evaluate_activation_gate(state_dir=tmp_path)
+
+        assert gate["action"] == "run"
+        assert gate["probe_health"] == "ok"

--- a/tests/test_learning_loop_unknown_probe.py
+++ b/tests/test_learning_loop_unknown_probe.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python3
+"""tests/test_learning_loop_unknown_probe.py — PR-17 gate path 3: probe 'unknown'.
+
+framework-status-audit-and-cockpit PR-17: with no pattern-usage signal yet
+(0 used, 0 ignored), the injection-effectiveness probe (PR-6) reports 'unknown'
+(no baseline). The gate must NOT activate blind — 'unknown' is gated exactly
+like 'degraded'/'produces_crap', not treated as a free pass.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+
+import learning_loop as ll  # noqa: E402
+
+
+@pytest.fixture
+def loop_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+    state_dir.mkdir(parents=True)
+    vnx_home = tmp_path / "repo"
+    vnx_home.mkdir()
+
+    fake = {
+        "VNX_STATE_DIR": str(state_dir),
+        "VNX_HOME": str(vnx_home),
+        "VNX_DATA_DIR": str(state_dir.parent),
+    }
+    monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+    monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+    with patch.object(ll, "ensure_env", return_value=fake):
+        loop = ll.LearningLoop()
+        loop.conn.commit()
+        yield loop, state_dir
+    try:
+        loop.conn.close()
+    except Exception:
+        pass
+
+
+def test_unknown_probe_no_data_skips_pattern_updates(loop_env):
+    """No pattern_usage rows seeded at all -> probe reports 'unknown'."""
+    loop, _ = loop_env
+
+    with patch.object(loop, "update_confidence_scores") as mock_update, \
+         patch("health_beacon.HealthBeacon"):
+        report = loop.daily_learning_cycle()
+
+    assert report["status"] == "degraded"
+    assert report["probe_health"] == "unknown"
+    mock_update.assert_not_called()
+
+
+def test_unknown_probe_writes_degraded_beacon(loop_env):
+    loop, _ = loop_env
+
+    with patch("health_beacon.HealthBeacon") as mock_beacon_cls:
+        mock_beacon = MagicMock()
+        mock_beacon_cls.return_value = mock_beacon
+        loop.daily_learning_cycle()
+
+    mock_beacon.heartbeat.assert_called_once()
+    kwargs = mock_beacon.heartbeat.call_args.kwargs
+    assert kwargs["status"] == "degraded"
+    assert kwargs["details"]["probe_health"] == "unknown"
+
+
+def test_unknown_probe_no_db_file_also_gates(tmp_path, monkeypatch):
+    """A missing quality_intelligence.db entirely (fresh install) also reports
+    'unknown', not a crash — the gate stays closed rather than erroring out."""
+    monkeypatch.setenv("VNX_LEARNING_LOOP_ENABLED", "1")
+    monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+
+    gate = ll.evaluate_activation_gate(state_dir=tmp_path / "does-not-exist")
+
+    assert gate["action"] == "degraded"
+    assert gate["probe_health"] == "unknown"


### PR DESCRIPTION
## Summary
- Implements the PR-17 activation gate from `docs/core/framework-status-audit-and-cockpit_PRD.md` §PR-17.
- The **activation gate is the injection-effectiveness probe health** (PR-6), not a flag. The two env flags (`VNX_LEARNING_LOOP_ENABLED`, `VNX_INJECTION_FEEDBACK_ENABLED`) are only the arm-switch.
- `scripts/learning_loop.py`: `evaluate_activation_gate()` + wiring into `LearningLoop.daily_learning_cycle()` implements the four non-overlapping paths:
  1. `LEARNING_LOOP_ENABLED=0` (default) → dormant no-op, no beacon.
  2. `=1` + `INJECTION_FEEDBACK_ENABLED=0` → hard error (`LearningLoopMisconfigured`).
  3. Both on, probe health `unknown`/`degraded`/`produces_crap` → exit early, degraded beacon, **no pattern updates**. `degraded` is deliberately gated alongside the other two (codex safety-gap finding: degraded must NOT activate).
  4. Both on, probe health `ok` → cycle runs.
- `scripts/dream/consolidator.py:run_dream_cycle()` gets the same-shaped gate: `VNX_DREAM_SCHEDULER_ENABLED` + the same PR-6 probe (`_injection_probe_health`). The gate lives in the executor, not `scheduler.py` (which only installs the LaunchAgent/crontab), so it holds for both the scheduled and manual (`vnx dream run`) paths.
- `dashboard/api_intelligence.py` + `serve_dashboard.py`: new read-only `/api/intelligence/effectiveness-probe` endpoint exposing `probe_health`, `ignore_rate`, `pending_proposals`, `signal`.

## Changes
- `scripts/learning_loop.py` — `LearningLoopMisconfigured` exception + `evaluate_activation_gate()`; gate wired into the top of `daily_learning_cycle()` (shared by every caller: CLI, `vnx_cli/commands/learning.py`, `intelligence_daemon.py`).
- `scripts/dream/consolidator.py` — `_injection_probe_health()` helper + gate at the top of `run_dream_cycle()`, before the existing GAP-7 receipt-completeness preflight.
- `dashboard/api_intelligence.py` — `_intelligence_get_effectiveness_probe()`.
- `dashboard/serve_dashboard.py` — routes `/api/intelligence/effectiveness-probe`.
- `tests/test_dream_consolidator.py` — autouse fixture opens the new gate for the existing 45 consolidation-mechanics tests (mocked probe + `VNX_DREAM_SCHEDULER_ENABLED=1`); new `TestActivationGate` class covers the closed-gate states plus two tests wired to the real PR-6 probe (not mocked).
- New test files: `tests/test_learning_loop_gate.py`, `tests/test_learning_loop_crap_signal.py`, `tests/test_learning_loop_unknown_probe.py`, `tests/test_learning_loop_degraded_no_activate.py` (the explicit safety-gap regression guard named in the dispatch), `tests/test_api_intelligence_effectiveness_probe.py`.

## Test plan
- [x] `pytest tests/test_learning_loop_gate.py tests/test_learning_loop_crap_signal.py tests/test_learning_loop_unknown_probe.py tests/test_learning_loop_degraded_no_activate.py -v` — 22 passed
- [x] `pytest tests/test_dream_consolidator.py -v` — 45 passed (existing 36 + 9 new gate tests)
- [x] `pytest tests/test_api_intelligence_effectiveness_probe.py -v` — 4 passed
- [x] Regression check on pre-existing learning_loop suites: `test_learning_loop_tz.py`, `test_learning_d3_proposal.py`, `test_learning_loop_proposal_tier.py`, `test_learning_loop_exception_handling.py`, `test_learning_loop_certification.py` — 63 passed
- [x] Regression check: `test_dream_scheduler.py`, `test_dream_cli.py` — 33 passed
- [x] `python3 -m ast` syntax check on all 4 modified source files

🤖 Generated with [Claude Code](https://claude.com/claude-code)