### PR TITLE
feat(dashboard): subsystem cockpit tile on operator/observability page

### DIFF
--- a/dashboard/api_subsystems.py
+++ b/dashboard/api_subsystems.py
@@ -1,0 +1,130 @@
+"""Subsystem cockpit API (framework-status-audit-and-cockpit PR-4).
+
+  GET /api/operator/subsystems -> {project_id, subsystems: [...], queried_at}
+
+Rowset is the union of the two ``config_registry`` sources (mirrors ``vnx subsystems``, PR-3, but
+reads the registry directly rather than shelling out to the CLI):
+
+  (a) ``config_registry.CONFIG_REGISTRY`` — flag-backed subsystems. Several flags can share one
+      subsystem (e.g. every intelligence-tuning flag maps to ``intelligence-self-learning-loop``);
+      the LAST-inserted flag per subsystem is shown as that row's canonical ``flag`` (PR-2's net-new
+      master-switch flags are appended after the pre-existing tuning flags they group).
+  (b) ``config_registry.CONFIG_REGISTRY_SUBSYSTEMS`` — flag-less kernel subsystems (``phantom_guard``,
+      ``dispatch-plan``, ...). Disjoint from (a) by construction (config_registry.py docstring).
+
+HEALTH is read-only from ``health_beacon.all_beacons(data_dir)`` — the beacon root is
+``VNX_DATA_DIR`` (health_beacon writes/reads under ``VNX_DATA_DIR/health``), NOT ``VNX_STATE_DIR``.
+A subsystem with no beacon reports ``unknown`` — no probe framework exists yet (PR-5..7).
+
+Single-tenant: reads this dashboard's project (``CANONICAL_STATE_DIR``), same as ``api_config.py``.
+Fail-open: a missing/unavailable registry never raises past this module — the handler returns 503
+with an empty subsystem list rather than a 500.
+"""
+from __future__ import annotations
+
+import logging
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from api_health import _resolve_data_dir
+from api_operator import VNX_DIR, _op_dashboard_project_id
+
+_logger = logging.getLogger(__name__)
+
+_SUB_SCRIPTS_LIB = str(VNX_DIR / "scripts" / "lib")
+if _SUB_SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, _SUB_SCRIPTS_LIB)
+
+try:
+    import config_registry as _cr  # type: ignore[import]
+    _REGISTRY_AVAILABLE = True
+except Exception:
+    # Optional dependency: the registry module may be absent in a stripped install. Log so a real
+    # init error is visible (not silently mistaken for "no subsystems") but stay non-fatal.
+    _logger.warning("config_registry unavailable; subsystems API will report 503", exc_info=True)
+    _cr = None  # type: ignore[assignment]
+    _REGISTRY_AVAILABLE = False
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _canonical_flags(cr) -> Dict[str, str]:
+    """subsystem -> the one flag key shown as the row's canonical ``flag``.
+
+    CONFIG_REGISTRY is insertion-ordered; when several flags share a subsystem the LAST-inserted
+    one wins, matching ``vnx_cli/commands/subsystems.py``'s row-building convention.
+    """
+    canonical: Dict[str, str] = {}
+    for key, entry in cr.CONFIG_REGISTRY.items():
+        if entry.subsystem:
+            canonical[entry.subsystem] = key
+    return canonical
+
+
+def build_rows(cr, project_id: Optional[str]) -> List[Dict[str, Any]]:
+    """Rowset = (a) flag-less CONFIG_REGISTRY_SUBSYSTEMS union (b) flag-backed CONFIG_REGISTRY
+    (one canonical flag per subsystem). Health is attached separately by the caller."""
+    rows: List[Dict[str, Any]] = []
+
+    for subsystem, meta in cr.CONFIG_REGISTRY_SUBSYSTEMS.items():
+        status = meta.get("status", "COCKPIT")
+        rows.append({
+            "subsystem": subsystem,
+            "what": meta.get("description", ""),
+            "flag": None,
+            "status": status,
+            "effective_value": None,
+        })
+
+    for subsystem, flag_key in _canonical_flags(cr).items():
+        entry = cr.CONFIG_REGISTRY[flag_key]
+        rows.append({
+            "subsystem": subsystem,
+            "what": entry.description,
+            "flag": flag_key,
+            "status": entry.status or "COCKPIT",
+            "effective_value": cr.get(flag_key, project_id),
+        })
+
+    rows.sort(key=lambda r: r["subsystem"])
+    return rows
+
+
+def _attach_health(rows: List[Dict[str, Any]], data_dir: Path) -> None:
+    from health_beacon import all_beacons
+
+    beacons = all_beacons(data_dir)  # data_dir = VNX_DATA_DIR, not VNX_STATE_DIR
+    for row in rows:
+        beacon = beacons.get(row["subsystem"])
+        if beacon:
+            row["health"] = beacon.get("health", "unknown")
+            row["last_signal"] = beacon.get("last_run_iso", "")
+        else:
+            row["health"] = "unknown"
+            row["last_signal"] = ""
+
+
+def operator_get_subsystems(params: dict, *, project_id: "str | None" = None) -> "tuple[dict, int]":
+    """GET /api/operator/subsystems -- the live subsystem cockpit ledger (MAP + ON/OFF + HEALTH).
+
+    Returns (body, status): 200 on success; 503 when the registry is unavailable / errors (the body
+    carries a generic message -- the exception detail is logged server-side, never returned)."""
+    pid = project_id or _op_dashboard_project_id()
+    if not _REGISTRY_AVAILABLE:
+        return {"project_id": pid, "subsystems": [], "queried_at": _now(),
+                "error": "config registry unavailable"}, 503
+    try:
+        rows = build_rows(_cr, pid)
+        _attach_health(rows, _resolve_data_dir())
+    except Exception:
+        _logger.exception("subsystems inventory failed for project_id=%s", pid)
+        return {"project_id": pid, "subsystems": [], "queried_at": _now(),
+                "error": "subsystems inventory failed"}, 503
+    return {"project_id": pid, "subsystems": rows, "queried_at": _now()}, 200
+
+
+__all__ = ["operator_get_subsystems", "build_rows"]

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -175,6 +175,8 @@ from api_config import (  # noqa: E402
 
 from api_observability import operator_get_observability  # noqa: E402
 
+from api_subsystems import operator_get_subsystems  # noqa: E402
+
 from api_intelligence import (  # noqa: E402
     _intelligence_get_patterns,
     _intelligence_get_injections,
@@ -435,6 +437,11 @@ class DashboardHandler(SimpleHTTPRequestHandler):
 
         if path == "/api/operator/observability":
             result, status_int = operator_get_observability(params)
+            _json_response(self, HTTPStatus(status_int), result)
+            return
+
+        if path == "/api/operator/subsystems":
+            result, status_int = operator_get_subsystems(params)
             _json_response(self, HTTPStatus(status_int), result)
             return
 

--- a/dashboard/token-dashboard/__tests__/observability-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/observability-page.test.tsx
@@ -7,13 +7,14 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
-jest.mock('@/lib/hooks', () => ({ useObservability: jest.fn() }));
+jest.mock('@/lib/hooks', () => ({ useObservability: jest.fn(), useSubsystems: jest.fn() }));
 
-import { useObservability } from '@/lib/hooks';
+import { useObservability, useSubsystems } from '@/lib/hooks';
 import ObservabilityPage from '@/app/operator/observability/page';
-import type { ObservabilityEnvelope } from '@/lib/types';
+import type { ObservabilityEnvelope, SubsystemsEnvelope } from '@/lib/types';
 
 const mockUse = useObservability as jest.MockedFunction<typeof useObservability>;
+const mockUseSub = useSubsystems as jest.MockedFunction<typeof useSubsystems>;
 
 function envelope(over: Partial<ObservabilityEnvelope> = {}): ObservabilityEnvelope {
   return {
@@ -45,8 +46,20 @@ function envelope(over: Partial<ObservabilityEnvelope> = {}): ObservabilityEnvel
   };
 }
 
+function subsystemsEnvelope(): SubsystemsEnvelope {
+  return {
+    project_id: 'vnx-dev',
+    queried_at: '2026-07-12T10:00:00Z',
+    subsystems: [
+      { subsystem: 'governance-enforcement-stack', what: 'Receipt hash-chain + signed attestation + evidence-bound merge gate.', flag: 'VNX_GOVERNANCE_ENFORCED', status: 'PARK', effective_value: '0', health: 'unknown', last_signal: '' },
+      { subsystem: 'phantom_guard', what: 'Receipt deduplication and replay protection.', flag: null, status: 'LIVE', effective_value: null, health: 'ok', last_signal: '2026-07-12T09:00:00Z' },
+    ],
+  };
+}
+
 function renderWith(data: ObservabilityEnvelope | undefined, opts: { isLoading?: boolean; error?: Error } = {}) {
   mockUse.mockReturnValue({ data, isLoading: opts.isLoading ?? false, error: opts.error, mutate: jest.fn(), isValidating: false } as ReturnType<typeof useObservability>);
+  mockUseSub.mockReturnValue({ data: subsystemsEnvelope(), isLoading: false, error: undefined, mutate: jest.fn(), isValidating: false } as ReturnType<typeof useSubsystems>);
   return render(<ObservabilityPage />);
 }
 
@@ -69,6 +82,24 @@ describe('ObservabilityPage', () => {
     expect(screen.getByTestId('obs-rework-edge')).toHaveTextContent('debugger');
     expect(screen.getByTestId('obs-daemons')).toHaveTextContent('1 daemon');
     expect(screen.getByTestId('obs-cron-row')).toHaveTextContent('nightly_intelligence_pipeline');
+    // Subsystem cockpit tile (framework-status-audit-and-cockpit PR-4)
+    expect(screen.getByTestId('subsystem-cockpit-tile')).toBeInTheDocument();
+    expect(screen.getByTestId('subsystem-row-governance-enforcement-stack')).toHaveTextContent('governance-enforcement-stack');
+    expect(screen.getByTestId('subsystem-status-governance-enforcement-stack')).toHaveTextContent('PARK');
+    expect(screen.getByTestId('subsystem-health-governance-enforcement-stack')).toHaveTextContent('unknown');
+    expect(screen.getByTestId('subsystem-row-phantom_guard')).toHaveTextContent('phantom_guard');
+    expect(screen.getByTestId('subsystem-health-phantom_guard')).toHaveTextContent('ok');
+  });
+
+  test('subsystem cockpit tile shows its own loading/error state', () => {
+    mockUse.mockReturnValue({ data: envelope(), isLoading: false, error: undefined, mutate: jest.fn(), isValidating: false } as ReturnType<typeof useObservability>);
+    mockUseSub.mockReturnValue({ data: undefined, isLoading: true, error: undefined, mutate: jest.fn(), isValidating: false } as ReturnType<typeof useSubsystems>);
+    const { rerender } = render(<ObservabilityPage />);
+    expect(screen.getByTestId('subsystem-cockpit-loading')).toBeInTheDocument();
+
+    mockUseSub.mockReturnValue({ data: undefined, isLoading: false, error: new Error('x'), mutate: jest.fn(), isValidating: false } as ReturnType<typeof useSubsystems>);
+    rerender(<ObservabilityPage />);
+    expect(screen.getByTestId('subsystem-cockpit-error')).toBeInTheDocument();
   });
 
   test('shows degraded flag + empty states', () => {

--- a/dashboard/token-dashboard/app/operator/config/page.tsx
+++ b/dashboard/token-dashboard/app/operator/config/page.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import { useConfig, useConfigAudit } from '@/lib/hooks';
+import { mutate as globalMutate } from 'swr';
+import { useConfig, useConfigAudit, SUBSYSTEMS_SWR_KEY } from '@/lib/hooks';
 import { postConfigSet } from '@/lib/operator-api';
 import type { ConfigEntryRow, ConfigSetRequest } from '@/lib/types';
 
@@ -169,6 +170,8 @@ export default function ConfigPage() {
         setMsg({ kind: 'ok', text: `${row.key} → ${res.new_value}` });
         mutate();
         auditQuery.mutate();
+        // Revalidate the subsystem cockpit tile (a toggled flag's effective_value changed).
+        globalMutate(SUBSYSTEMS_SWR_KEY);
       } else {
         setMsg({ kind: 'err', text: res.message || 'change rejected' });
       }

--- a/dashboard/token-dashboard/app/operator/observability/page.tsx
+++ b/dashboard/token-dashboard/app/operator/observability/page.tsx
@@ -1,10 +1,75 @@
 'use client';
 
 import React from 'react';
-import { useObservability } from '@/lib/hooks';
-import type { ObservabilityEnvelope } from '@/lib/types';
+import { useObservability, useSubsystems } from '@/lib/hooks';
+import type { ObservabilityEnvelope, SubsystemRow } from '@/lib/types';
 
 const PANEL = 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)';
+
+// Cockpit subsystem status (framework-status-audit-and-cockpit) — mirrors /operator/config's palette.
+const SUBSYSTEM_STATUS_COLOR: Record<string, string> = {
+  LIVE: 'var(--color-success, #50fa7b)',
+  ACTIVATE: 'var(--color-accent, #f97316)',
+  SCOPE: 'var(--color-warning, #facc15)',
+  PARK: 'var(--color-muted)',
+  CUT: 'var(--color-danger, #ff5555)',
+  COCKPIT: 'var(--color-accent, #f97316)',
+};
+
+// Health vocabulary (health_beacon.py: ok | stale | fail | corrupt | unknown).
+const SUBSYSTEM_HEALTH_COLOR: Record<string, string> = {
+  ok: 'var(--color-success, #50fa7b)',
+  stale: 'var(--color-warning, #facc15)',
+  fail: 'var(--color-danger, #ff5555)',
+  corrupt: 'var(--color-danger, #ff5555)',
+  unknown: 'var(--color-muted)',
+};
+
+function SubsystemRowView({ row }: { row: SubsystemRow }) {
+  const statusColor = SUBSYSTEM_STATUS_COLOR[row.status] ?? 'var(--color-muted)';
+  const healthColor = SUBSYSTEM_HEALTH_COLOR[row.health] ?? SUBSYSTEM_HEALTH_COLOR.unknown;
+  return (
+    <div data-testid={`subsystem-row-${row.subsystem}`} style={_row}>
+      <span style={{ fontWeight: 700, minWidth: 220 }}>{row.subsystem}</span>
+      <span
+        data-testid={`subsystem-status-${row.subsystem}`}
+        style={{ fontSize: 10, fontWeight: 700, color: statusColor, border: `1px solid ${statusColor}`, borderRadius: 5, padding: '1px 7px' }}
+      >
+        {row.status}
+      </span>
+      <span
+        data-testid={`subsystem-health-${row.subsystem}`}
+        style={{ fontSize: 10, fontWeight: 700, color: healthColor, border: `1px solid ${healthColor}`, borderRadius: 5, padding: '1px 7px' }}
+      >
+        {row.health}
+      </span>
+      <code style={{ color: 'var(--color-muted)' }}>{row.flag ?? '—'}</code>
+      <span style={{ color: 'var(--color-muted)' }}>{row.effective_value ?? '—'}</span>
+    </div>
+  );
+}
+
+function SubsystemCockpitTile() {
+  const { data, isLoading, error } = useSubsystems();
+  return (
+    <section
+      data-testid="subsystem-cockpit-tile"
+      style={{ borderRadius: 10, padding: 14, background: PANEL, border: '1px solid rgba(255,255,255,0.08)', display: 'flex', flexDirection: 'column', gap: 8, gridColumn: '1 / -1' }}
+    >
+      <div style={{ display: 'flex', alignItems: 'baseline', gap: 8 }}>
+        <h2 style={{ fontSize: 13, fontWeight: 700, margin: 0, color: 'var(--color-foreground)' }}>Subsystem cockpit</h2>
+        {data && <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>({data.subsystems.length})</span>}
+      </div>
+      {isLoading && (
+        <div data-testid="subsystem-cockpit-loading" style={_muted}>Loading subsystems…</div>
+      )}
+      {!isLoading && (error || !data) && (
+        <div data-testid="subsystem-cockpit-error" style={{ fontSize: 11, color: 'var(--color-danger, #ff5555)' }}>Failed to load subsystem cockpit.</div>
+      )}
+      {data && data.subsystems.map((row) => <SubsystemRowView key={row.subsystem} row={row} />)}
+    </section>
+  );
+}
 
 function Section({ title, count, degraded, children }: {
   title: string; count?: number; degraded?: boolean; children: React.ReactNode;
@@ -59,6 +124,8 @@ function Body({ data }: { data: ObservabilityEnvelope }) {
       </div>
 
       <div style={{ display: 'grid', gridTemplateColumns: 'repeat(2, 1fr)', gap: 16, alignItems: 'start' }}>
+        <SubsystemCockpitTile />
+
         {/* Self-learning loop */}
         <Section title="Self-learning" count={sl.events.length} degraded={sl.degraded}>
           <div style={{ fontSize: 11, color: 'var(--color-muted)' }}>{sl.proposals} pending rule proposal(s)</div>

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -14,6 +14,7 @@ import {
   fetchConfig,
   fetchConfigAudit,
   fetchObservability,
+  fetchSubsystems,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -36,7 +37,7 @@ import type {
   ProjectsEnvelope, SessionEnvelope, TerminalsEnvelope,
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
   GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
-  ConfigEnvelope, ConfigAuditEnvelope, ObservabilityEnvelope,
+  ConfigEnvelope, ConfigAuditEnvelope, ObservabilityEnvelope, SubsystemsEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   LiveSessionsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
@@ -206,6 +207,19 @@ export function useObservability() {
   return useSWR<ObservabilityEnvelope>(
     'operator-observability',
     fetchObservability,
+    { refreshInterval: 20000, revalidateOnFocus: true, dedupingInterval: 8000 }
+  );
+}
+
+// SWR key for useSubsystems() — exported so other pages (e.g. /operator/config, after a
+// postConfigSet toggle) can call the global `mutate()` from 'swr' to revalidate the cockpit tile
+// without importing this hook.
+export const SUBSYSTEMS_SWR_KEY = 'operator-subsystems';
+
+export function useSubsystems() {
+  return useSWR<SubsystemsEnvelope>(
+    SUBSYSTEMS_SWR_KEY,
+    fetchSubsystems,
     { refreshInterval: 20000, revalidateOnFocus: true, dedupingInterval: 8000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -18,6 +18,7 @@ import type {
   ConfigSetResponse,
   ConfigAuditEnvelope,
   ObservabilityEnvelope,
+  SubsystemsEnvelope,
   LiveSessionsEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
@@ -148,6 +149,10 @@ export function fetchConfig(): Promise<ConfigEnvelope> {
 
 export function fetchObservability(): Promise<ObservabilityEnvelope> {
   return get(`${BASE}/observability`);
+}
+
+export function fetchSubsystems(): Promise<SubsystemsEnvelope> {
+  return get(`${BASE}/subsystems`);
 }
 
 export function fetchLiveSessions(): Promise<LiveSessionsEnvelope> {

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -395,6 +395,27 @@ export interface ReworkEdge {
   dispatched_at: string | null;
 }
 
+// ===== Subsystem Cockpit Types =====
+// Mirrors api_subsystems.py's rowset: config_registry (CONFIG_REGISTRY +
+// CONFIG_REGISTRY_SUBSYSTEMS) union'd with health_beacon health.
+
+export interface SubsystemRow {
+  subsystem: string;
+  what: string;
+  flag: string | null;
+  status: string; // LIVE | PARK | CUT | ACTIVATE | SCOPE | COCKPIT
+  effective_value: string | null;
+  health: string; // ok | stale | fail | corrupt | unknown
+  last_signal: string;
+}
+
+export interface SubsystemsEnvelope {
+  project_id: string;
+  subsystems: SubsystemRow[];
+  queried_at: string;
+  error?: string;
+}
+
 // ===== Kanban Board Types =====
 
 export interface KanbanCard {

--- a/tests/dashboard/test_api_subsystems.py
+++ b/tests/dashboard/test_api_subsystems.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for api_subsystems — the subsystem cockpit HTTP handler (framework-status-audit-and-cockpit
+PR-4).
+
+Covers GET /api/operator/subsystems: rowset shape (union of CONFIG_REGISTRY_SUBSYSTEMS + the
+canonical-flag-per-subsystem view of CONFIG_REGISTRY), health attachment from health_beacon
+(VNX_DATA_DIR root, not VNX_STATE_DIR), and the 503 fail-open path when the registry is unavailable.
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "dashboard"))
+
+import config_registry as cr  # noqa: E402
+import api_subsystems as api_sub  # noqa: E402
+from health_beacon import HealthBeacon  # noqa: E402
+
+PID = "vnx-dev"
+
+
+def test_build_rows_returns_at_least_10_subsystems():
+    rows = api_sub.build_rows(cr, PID)
+    assert len(rows) >= 10
+    subsystems = {r["subsystem"] for r in rows}
+    assert "governance-enforcement-stack" in subsystems
+    assert "phantom_guard" in subsystems  # flag-less kernel subsystem
+
+
+def test_build_rows_no_duplicate_subsystems():
+    rows = api_sub.build_rows(cr, PID)
+    subsystems = [r["subsystem"] for r in rows]
+    assert len(subsystems) == len(set(subsystems))
+
+
+def test_build_rows_flag_backed_row_has_effective_value():
+    rows = api_sub.build_rows(cr, PID)
+    governance = next(r for r in rows if r["subsystem"] == "governance-enforcement-stack")
+    assert governance["flag"] == "VNX_GOVERNANCE_ENFORCED"
+    assert governance["status"] == "PARK"
+    assert governance["effective_value"] == "0"  # default off
+
+
+def test_build_rows_flag_less_row_has_no_flag():
+    rows = api_sub.build_rows(cr, PID)
+    phantom = next(r for r in rows if r["subsystem"] == "phantom_guard")
+    assert phantom["flag"] is None
+    assert phantom["status"] == "LIVE"
+    assert phantom["effective_value"] is None
+
+
+def test_attach_health_unknown_when_no_beacon(tmp_path):
+    rows = [{"subsystem": "phantom_guard"}]
+    api_sub._attach_health(rows, tmp_path)
+    assert rows[0]["health"] == "unknown"
+    assert rows[0]["last_signal"] == ""
+
+
+def test_attach_health_reads_beacon(tmp_path):
+    beacon = HealthBeacon(tmp_path, "phantom_guard", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="ok", details={"signal": "zero duplicates"})
+    rows = [{"subsystem": "phantom_guard"}]
+    api_sub._attach_health(rows, tmp_path)
+    assert rows[0]["health"] == "ok"
+    assert rows[0]["last_signal"]
+
+
+def test_attach_health_fail_beacon(tmp_path):
+    beacon = HealthBeacon(tmp_path, "intelligence-self-learning-loop", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="fail", details={"signal": "98% ignore rate"})
+    rows = [{"subsystem": "intelligence-self-learning-loop"}]
+    api_sub._attach_health(rows, tmp_path)
+    assert rows[0]["health"] == "fail"
+
+
+def test_operator_get_subsystems_returns_200_with_health(monkeypatch, tmp_path):
+    beacon = HealthBeacon(tmp_path, "phantom_guard", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="ok")
+    monkeypatch.setattr(api_sub, "_resolve_data_dir", lambda: tmp_path)
+
+    body, status = api_sub.operator_get_subsystems({}, project_id=PID)
+
+    assert status == 200
+    assert body["project_id"] == PID
+    assert len(body["subsystems"]) >= 10
+    phantom = next(r for r in body["subsystems"] if r["subsystem"] == "phantom_guard")
+    assert phantom["health"] == "ok"
+    governance = next(r for r in body["subsystems"] if r["subsystem"] == "governance-enforcement-stack")
+    assert governance["health"] == "unknown"  # no beacon written for it
+
+
+def test_operator_get_subsystems_unavailable_returns_503(monkeypatch):
+    monkeypatch.setattr(api_sub, "_REGISTRY_AVAILABLE", False)
+    body, status = api_sub.operator_get_subsystems({}, project_id=PID)
+    assert status == 503
+    assert body["subsystems"] == []
+    assert "error" in body

--- a/tests/dashboard/test_page_subsystems.py
+++ b/tests/dashboard/test_page_subsystems.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Runs the React Testing Library coverage for the subsystem cockpit tile
+(framework-status-audit-and-cockpit PR-4).
+
+The actual assertions live in the Jest/RTL suite at
+``dashboard/token-dashboard/__tests__/observability-page.test.tsx`` (this repo's existing
+convention for `.tsx` component tests — see ``dashboard/token-dashboard/jest.config.js``'s
+``testMatch``). This module is a thin pytest wrapper so the cockpit tile's frontend coverage is
+collectible via plain ``pytest``, matching the other Python test entrypoints in this repo.
+
+Requires the token-dashboard Node toolchain (``npm ci`` run in ``dashboard/token-dashboard``) to
+execute the real assertions. When ``node_modules`` is not installed (e.g. a fresh worktree that
+has not run ``npm ci``), the test skips with an explicit reason instead of silently reporting a
+false pass -- run ``cd dashboard/token-dashboard && npm ci && npm test`` to exercise it directly.
+"""
+
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent.parent
+TOKEN_DASHBOARD = REPO / "dashboard" / "token-dashboard"
+TEST_FILE = "__tests__/observability-page.test.tsx"
+
+
+def _npm_toolchain_ready() -> bool:
+    if shutil.which("npx") is None:
+        return False
+    return (TOKEN_DASHBOARD / "node_modules" / ".bin" / "jest").exists()
+
+
+@pytest.mark.skipif(
+    not _npm_toolchain_ready(),
+    reason=(
+        "token-dashboard Node toolchain not installed (no node_modules/.bin/jest) -- "
+        "run `cd dashboard/token-dashboard && npm ci` first"
+    ),
+)
+def test_subsystem_cockpit_tile_rtl_suite_passes():
+    """The RTL suite in observability-page.test.tsx covers the subsystem cockpit tile: it renders
+    every subsystem row (incl. `governance-enforcement-stack`), status/health badges, and its own
+    loading/error states independent of the observability data hook."""
+    result = subprocess.run(
+        ["npx", "jest", TEST_FILE, "--silent"],
+        cwd=str(TOKEN_DASHBOARD),
+        capture_output=True,
+        text=True,
+        timeout=180,
+    )
+    assert result.returncode == 0, (
+        f"jest {TEST_FILE} failed (rc={result.returncode})\n"
+        f"stdout:\n{result.stdout}\nstderr:\n{result.stderr}"
+    )
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- PR-4 of `framework-status-audit-and-cockpit` (§PR-4). Adds a subsystem cockpit tile to the existing `/operator/observability` dashboard page — no new route.
- New `GET /api/operator/subsystems` reads the rowset directly from `config_registry` (`all_effective()` + `CONFIG_REGISTRY_SUBSYSTEMS`) and attaches read-only health from `health_beacon.all_beacons(VNX_DATA_DIR)`. Does not shell out to the `vnx subsystems` CLI.
- After a successful `postConfigSet` on `/operator/config`, the config page now calls SWR global `mutate()` on the subsystems key so the cockpit tile revalidates immediately (no page reload).

## Changes
- `dashboard/api_subsystems.py` (new) — `operator_get_subsystems()` handler + `build_rows()`/`_attach_health()`.
- `dashboard/serve_dashboard.py` — import + route `GET /api/operator/subsystems`.
- `dashboard/token-dashboard/lib/types.ts` — `SubsystemRow`, `SubsystemsEnvelope`.
- `dashboard/token-dashboard/lib/operator-api.ts` — `fetchSubsystems()`.
- `dashboard/token-dashboard/lib/hooks.ts` — `useSubsystems()` + exported `SUBSYSTEMS_SWR_KEY`.
- `dashboard/token-dashboard/app/operator/observability/page.tsx` — `SubsystemCockpitTile` section (status + health badges per subsystem, own loading/error state).
- `dashboard/token-dashboard/app/operator/config/page.tsx` — `mutate(SUBSYSTEMS_SWR_KEY)` after a successful flag toggle.
- `dashboard/token-dashboard/__tests__/observability-page.test.tsx` — extended to cover the cockpit tile (governance row, status/health badges, independent loading/error).
- `tests/dashboard/test_api_subsystems.py` (new) — API handler unit tests.
- `tests/dashboard/test_page_subsystems.py` (new) — pytest wrapper running the RTL suite via `npx jest` (skips honestly if the Node toolchain isn't installed).

Scope guard respected: no changes to `vnx subsystems` CLI, `config_registry` subsystem metadata, `docs/core/SUBSYSTEMS.md`, `scripts/check_subsystems_drift.py`, `scripts/commands/subsystems.sh`, or `vnx_cli/main.py`.

## Test plan
- [x] `python3 -m pytest tests/dashboard/test_api_subsystems.py tests/dashboard/test_page_subsystems.py -q` → 10 passed
- [x] `cd dashboard/token-dashboard && npx tsc --noEmit -p .` → clean (0 errors)
- [x] `npx jest __tests__/observability-page.test.tsx --silent` → 4 passed
- [x] `npx jest __tests__/config-page.test.tsx --silent` (regression check on the touched file) → 7 passed
- [x] Manual endpoint check: `operator_get_subsystems()` returns 200 with 26 subsystem rows incl. `governance-enforcement-stack`

🤖 Generated with [Claude Code](https://claude.com/claude-code)