### PR TITLE
feat(dashboard): surface effectiveness-probe signals on health and intelligence pages

### DIFF
--- a/dashboard/api_health.py
+++ b/dashboard/api_health.py
@@ -2,14 +2,18 @@
 
 Exposes :func:`_operator_get_health` which serves
 ``GET /api/operator/health`` — JSON of every component beacon under
-``$VNX_DATA_DIR/health/``, plus a roll-up summary.
+``$VNX_DATA_DIR/health/``, plus a roll-up summary and a per-subsystem
+effectiveness summary (framework-status-audit-and-cockpit PR-18).
 """
 from __future__ import annotations
 
+import logging
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+_logger = logging.getLogger(__name__)
 
 # Make scripts/lib importable so we can reuse health_beacon helpers.
 _DASHBOARD_DIR = Path(__file__).resolve().parent
@@ -17,7 +21,7 @@ _SCRIPTS_LIB = _DASHBOARD_DIR.parent / "scripts" / "lib"
 if str(_SCRIPTS_LIB) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_LIB))
 
-from health_beacon import beacon_summary  # noqa: E402
+from health_beacon import all_beacons, beacon_summary  # noqa: E402
 
 
 def _resolve_data_dir() -> Path:
@@ -28,8 +32,54 @@ def _resolve_data_dir() -> Path:
     return state_dir.parent
 
 
+def _subsystem_effectiveness_summary(data_dir: Path) -> List[Dict[str, Any]]:
+    """Every known cockpit subsystem (PR-1..8/17 registry) joined against its
+    beacon-derived health. Read-only: reads ``config_registry``/probe registries
+    for subsystem NAMES and ``health_beacon.all_beacons()`` for their last-written
+    status — it never runs a probe (that stays owned by ``vnx subsystems --probe``,
+    PR-3/PR-5). A subsystem with no beacon on disk (never probed, or its probe
+    itself reported ``unknown``) is reported ``health="unknown"`` so the health
+    page can prompt the operator to add/improve a probe (PR-18 acceptance
+    criterion), rather than silently omitting the card.
+    """
+    try:
+        import subsystem_health  # noqa: PLC0415
+    except Exception as exc:
+        _logger.warning("subsystem_health unavailable; effectiveness summary empty: %s", exc)
+        return []
+
+    try:
+        names = subsystem_health.known_subsystems()
+    except Exception:
+        _logger.exception("known_subsystems() failed")
+        return []
+
+    beacons = all_beacons(data_dir)
+    rows: List[Dict[str, Any]] = []
+    for name in names:
+        beacon = beacons.get(name)
+        if beacon:
+            rows.append({
+                "subsystem": name,
+                "health": beacon.get("health", "unknown"),
+                "status": beacon.get("status", ""),
+                "last_signal": beacon.get("last_run_iso", ""),
+                "detail": beacon.get("details") or {},
+            })
+        else:
+            rows.append({
+                "subsystem": name,
+                "health": "unknown",
+                "status": "unknown",
+                "last_signal": "",
+                "detail": {},
+            })
+    return rows
+
+
 def _operator_get_health() -> Dict[str, Any]:
-    """GET /api/operator/health — beacon dump with classification."""
+    """GET /api/operator/health — beacon dump with classification, plus the
+    per-subsystem effectiveness summary (PR-18)."""
     now = datetime.now(timezone.utc).isoformat()
     data_dir = _resolve_data_dir()
     try:
@@ -40,6 +90,7 @@ def _operator_get_health() -> Dict[str, Any]:
             "overall": summary["overall"],
             "counts": summary["counts"],
             "beacons": summary["beacons"],
+            "subsystems": _subsystem_effectiveness_summary(data_dir),
         }
     except Exception as exc:
         return {
@@ -48,6 +99,7 @@ def _operator_get_health() -> Dict[str, Any]:
             "overall": "fail",
             "counts": {"ok": 0, "stale": 0, "fail": 0, "corrupt": 0},
             "beacons": {},
+            "subsystems": [],
             "error": str(exc),
         }
 

--- a/dashboard/serve_dashboard.py
+++ b/dashboard/serve_dashboard.py
@@ -538,6 +538,12 @@ class DashboardHandler(SimpleHTTPRequestHandler):
             _json_response(self, HTTPStatus.OK, _intelligence_get_effectiveness_probe())
             return
 
+        # PR-18: point-in-time dashboard gauge (same read-only probe signal as
+        # the PR-17 gate-signal route above, exposed under /api/operator/*).
+        if path == "/api/operator/intelligence/effectiveness":
+            _json_response(self, HTTPStatus.OK, _intelligence_get_effectiveness_probe())
+            return
+
         if path == "/api/intelligence/behavioral":
             payload, status_int = _intelligence_get_behavioral_summary()
             _json_response(self, HTTPStatus(status_int), payload)

--- a/dashboard/token-dashboard/__tests__/health-page.test.tsx
+++ b/dashboard/token-dashboard/__tests__/health-page.test.tsx
@@ -4,6 +4,7 @@
  * - Renders overall status + score + per-component status badges
  * - Loading + error states render
  * - Unknown status strings never throw (fall back to muted)
+ * - Subsystem effectiveness cards (PR-18) render independently via useHealthBeacons()
  */
 
 import React from 'react';
@@ -12,13 +13,15 @@ import '@testing-library/jest-dom';
 
 jest.mock('@/lib/hooks', () => ({
   useSystemHealth: jest.fn(),
+  useHealthBeacons: jest.fn(),
 }));
 
-import { useSystemHealth } from '@/lib/hooks';
+import { useSystemHealth, useHealthBeacons } from '@/lib/hooks';
 import SystemHealthPage from '@/app/operator/health/page';
-import type { SystemHealthEnvelope } from '@/lib/types';
+import type { SystemHealthEnvelope, HealthBeaconEnvelope } from '@/lib/types';
 
 const mockUseSystemHealth = useSystemHealth as jest.MockedFunction<typeof useSystemHealth>;
+const mockUseHealthBeacons = useHealthBeacons as jest.MockedFunction<typeof useHealthBeacons>;
 
 function envelope(overrides: Partial<SystemHealthEnvelope> = {}): SystemHealthEnvelope {
   return {
@@ -33,7 +36,27 @@ function envelope(overrides: Partial<SystemHealthEnvelope> = {}): SystemHealthEn
   };
 }
 
-function renderWith(data: SystemHealthEnvelope | undefined, opts: { isLoading?: boolean; error?: Error } = {}) {
+function beaconEnvelope(overrides: Partial<HealthBeaconEnvelope> = {}): HealthBeaconEnvelope {
+  return {
+    queried_at: '2026-06-27T15:00:00Z',
+    data_dir: '/tmp/.vnx-data',
+    overall: 'ok',
+    counts: { ok: 1, stale: 0, fail: 0, corrupt: 0 },
+    beacons: {},
+    subsystems: [
+      { subsystem: 'phantom_guard', health: 'ok', status: 'ok', last_signal: '2026-06-27T15:00:00Z', detail: {} },
+      { subsystem: 'governance-enforcement-stack', health: 'unknown', status: 'unknown', last_signal: '', detail: {} },
+    ],
+    ...overrides,
+  };
+}
+
+function renderWith(
+  data: SystemHealthEnvelope | undefined,
+  opts: { isLoading?: boolean; error?: Error } = {},
+  beaconData: HealthBeaconEnvelope | undefined = beaconEnvelope(),
+  beaconOpts: { isLoading?: boolean; error?: Error } = {},
+) {
   mockUseSystemHealth.mockReturnValue({
     data,
     isLoading: opts.isLoading ?? false,
@@ -41,6 +64,13 @@ function renderWith(data: SystemHealthEnvelope | undefined, opts: { isLoading?: 
     mutate: jest.fn(),
     isValidating: false,
   } as ReturnType<typeof useSystemHealth>);
+  mockUseHealthBeacons.mockReturnValue({
+    data: beaconData,
+    isLoading: beaconOpts.isLoading ?? false,
+    error: beaconOpts.error,
+    mutate: jest.fn(),
+    isValidating: false,
+  } as ReturnType<typeof useHealthBeacons>);
   return render(<SystemHealthPage />);
 }
 
@@ -72,5 +102,23 @@ describe('SystemHealthPage', () => {
   test('empty components renders placeholder', () => {
     renderWith(envelope({ components: {} }));
     expect(screen.getByTestId('health-empty')).toBeInTheDocument();
+  });
+
+  test('renders subsystem effectiveness cards with health badges', () => {
+    renderWith(envelope());
+    expect(screen.getByTestId('subsystems-grid')).toBeInTheDocument();
+    expect(screen.getByTestId('subsystem-card-phantom_guard')).toBeInTheDocument();
+    expect(screen.getByTestId('subsystem-health-phantom_guard')).toHaveTextContent('ok');
+    expect(screen.getByTestId('subsystem-health-governance-enforcement-stack')).toHaveTextContent('unknown');
+  });
+
+  test('subsystems loading state renders independently of system health data', () => {
+    renderWith(envelope(), {}, undefined, { isLoading: true });
+    expect(screen.getByTestId('subsystems-loading')).toBeInTheDocument();
+  });
+
+  test('subsystems empty state renders placeholder', () => {
+    renderWith(envelope(), {}, beaconEnvelope({ subsystems: [] }));
+    expect(screen.getByTestId('subsystems-empty')).toBeInTheDocument();
   });
 });

--- a/dashboard/token-dashboard/app/operator/health/page.tsx
+++ b/dashboard/token-dashboard/app/operator/health/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
-import { useSystemHealth } from '@/lib/hooks';
-import type { SystemHealthComponent } from '@/lib/types';
+import { useSystemHealth, useHealthBeacons } from '@/lib/hooks';
+import type { SystemHealthComponent, SubsystemEffectivenessRow } from '@/lib/types';
 
 // Status → color. Unknown statuses fall back to muted (never throws on a new status string).
 function statusColor(status: string): string {
@@ -10,6 +10,18 @@ function statusColor(status: string): string {
     case 'degraded': return 'var(--color-warning, #facc15)';
     case 'dead': return 'var(--color-danger, #ff5555)';
     default: return 'var(--color-muted, rgba(244,244,249,0.5))';
+  }
+}
+
+// Beacon health vocabulary (ok | stale | fail | corrupt | unknown) differs from the
+// system-health vocabulary above — kept as a separate mapping rather than overloading it.
+function beaconHealthColor(health: string): string {
+  switch (health) {
+    case 'ok': return 'var(--color-success, #50fa7b)';
+    case 'stale': return 'var(--color-warning, #facc15)';
+    case 'fail':
+    case 'corrupt': return 'var(--color-danger, #ff5555)';
+    default: return 'var(--color-muted, rgba(244,244,249,0.5))'; // unknown
   }
 }
 
@@ -58,8 +70,66 @@ function ComponentCard({ name, comp }: { name: string; comp: SystemHealthCompone
   );
 }
 
+function SubsystemCard({ row }: { row: SubsystemEffectivenessRow }) {
+  const isUnknown = row.health === 'unknown';
+  const detailKeys = Object.keys(row.detail ?? {});
+  return (
+    <div
+      data-testid={`subsystem-card-${row.subsystem}`}
+      style={{
+        borderRadius: 10,
+        padding: '12px 14px',
+        background: 'linear-gradient(135deg, rgba(10,20,48,0.9) 0%, rgba(10,20,48,0.7) 100%)',
+        border: `1px solid ${isUnknown ? 'rgba(255,255,255,0.08)' : `${beaconHealthColor(row.health)}33`}`,
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <div style={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', gap: 8 }}>
+        <span style={{ fontSize: 12, fontWeight: 700, color: 'var(--color-foreground)' }}>{row.subsystem}</span>
+        <span
+          data-testid={`subsystem-health-${row.subsystem}`}
+          style={{
+            fontSize: 10,
+            fontWeight: 700,
+            letterSpacing: '0.04em',
+            padding: '2px 8px',
+            borderRadius: 6,
+            color: beaconHealthColor(row.health),
+            border: `1px solid ${beaconHealthColor(row.health)}`,
+          }}
+        >
+          {row.health}
+        </span>
+      </div>
+      {isUnknown ? (
+        <span style={{ fontSize: 10, color: 'var(--color-muted)' }}>
+          No probe registered — add or improve an effectiveness probe to measure this subsystem.
+        </span>
+      ) : (
+        <>
+          {row.last_signal && (
+            <span style={{ fontSize: 10, color: 'rgba(255,255,255,0.3)' }}>last signal {row.last_signal}</span>
+          )}
+          {detailKeys.length > 0 && (
+            <div style={{ display: 'flex', flexDirection: 'column', gap: 2 }}>
+              {detailKeys.slice(0, 6).map((k) => (
+                <span key={k} style={{ fontSize: 10, color: 'var(--color-muted)' }}>
+                  {k}: {String(row.detail[k])}
+                </span>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
 export default function SystemHealthPage() {
   const { data, isLoading, error } = useSystemHealth();
+  const { data: beaconData, isLoading: subsystemsLoading, error: subsystemsError } = useHealthBeacons();
 
   if (isLoading) {
     return <div data-testid="health-loading" style={{ padding: 24, color: 'var(--color-muted)' }}>Loading system health…</div>;
@@ -71,6 +141,7 @@ export default function SystemHealthPage() {
   const components = data.components ?? {};
   const names = Object.keys(components).sort();
   const scorePct = Math.round((data.health_score ?? 0) * 100);
+  const subsystems = beaconData?.subsystems ?? [];
 
   return (
     <div data-testid="health-page" style={{ padding: 24, display: 'flex', flexDirection: 'column', gap: 16 }}>
@@ -102,6 +173,27 @@ export default function SystemHealthPage() {
           ))}
         </div>
       )}
+
+      <div style={{ marginTop: 16, display: 'flex', flexDirection: 'column', gap: 12 }}>
+        <h2 style={{ fontSize: 15, fontWeight: 700, margin: 0 }}>Subsystem Effectiveness</h2>
+
+        {subsystemsLoading ? (
+          <div data-testid="subsystems-loading" style={{ color: 'var(--color-muted)' }}>Loading subsystem effectiveness…</div>
+        ) : subsystemsError ? (
+          <div data-testid="subsystems-error" style={{ color: 'var(--color-danger, #ff5555)' }}>Failed to load subsystem effectiveness.</div>
+        ) : subsystems.length === 0 ? (
+          <div data-testid="subsystems-empty" style={{ color: 'var(--color-muted)' }}>No subsystems reported.</div>
+        ) : (
+          <div
+            data-testid="subsystems-grid"
+            style={{ display: 'grid', gridTemplateColumns: 'repeat(auto-fill, minmax(240px, 1fr))', gap: 12 }}
+          >
+            {subsystems.map((row) => (
+              <SubsystemCard key={row.subsystem} row={row} />
+            ))}
+          </div>
+        )}
+      </div>
     </div>
   );
 }

--- a/dashboard/token-dashboard/app/operator/intelligence/page.tsx
+++ b/dashboard/token-dashboard/app/operator/intelligence/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { RefreshCw, Brain, CheckCircle2, AlertTriangle, Zap, Activity } from 'lucide-react';
+import { RefreshCw, Brain, CheckCircle2, AlertTriangle, Zap, Activity, Gauge } from 'lucide-react';
 import {
   BarChart,
   Bar,
@@ -21,6 +21,7 @@ import {
   useIntelligenceInjections,
   useIntelligenceClassifications,
   useIntelligenceDispatchOutcomes,
+  useIntelligenceEffectiveness,
 } from '@/lib/hooks';
 import type { SuccessPattern, Antipattern, DispatchOutcome, ClassificationRecord } from '@/lib/types';
 
@@ -61,6 +62,65 @@ function LoadingSpinner() {
   return (
     <div className="flex items-center justify-center py-12">
       <div className="animate-spin w-6 h-6 border-2 rounded-full" style={{ borderColor: 'var(--color-card-border)', borderTopColor: 'var(--color-accent)' }} />
+    </div>
+  );
+}
+
+// Probe status vocabulary (ok | degraded | produces_crap | unknown) — the same
+// gate signal that decides whether the self-learning loop activates (PR-17).
+const PROBE_HEALTH_COLORS: Record<string, string> = {
+  ok: '#50fa7b',
+  degraded: '#facc15',
+  produces_crap: '#ff6b6b',
+  unknown: '#6B6B6B',
+};
+
+function probeHealthColor(status: string): string {
+  return PROBE_HEALTH_COLORS[status] ?? PROBE_HEALTH_COLORS.unknown;
+}
+
+function EffectivenessGauge({
+  probeHealth,
+  ignoreRate,
+  pendingProposals,
+  signal,
+}: {
+  probeHealth: string;
+  ignoreRate: number | null;
+  pendingProposals: number;
+  signal: string;
+}) {
+  const color = probeHealthColor(probeHealth);
+  const pct = ignoreRate === null ? null : Math.round(Math.min(1, Math.max(0, ignoreRate)) * 100);
+  return (
+    <div
+      data-testid="effectiveness-gauge"
+      style={{ padding: '16px 20px', borderRadius: 12, background: 'rgba(255,255,255,0.02)', border: `1px solid ${color}33`, display: 'flex', alignItems: 'center', gap: 28, flexWrap: 'wrap' }}
+    >
+      <div>
+        <p style={{ fontSize: 11, color: 'var(--color-muted)', marginBottom: 4 }}>Probe health</p>
+        <span
+          data-testid="effectiveness-probe-health"
+          style={{ fontSize: 12, fontWeight: 700, letterSpacing: '0.04em', padding: '2px 10px', borderRadius: 6, color, border: `1px solid ${color}` }}
+        >
+          {probeHealth}
+        </span>
+      </div>
+      <div>
+        <p style={{ fontSize: 11, color: 'var(--color-muted)', marginBottom: 4 }}>Ignore rate (point-in-time)</p>
+        <span data-testid="effectiveness-ignore-rate" style={{ fontSize: 20, fontWeight: 700, color }}>
+          {pct === null ? 'no data' : `${pct}%`}
+        </span>
+      </div>
+      <div>
+        <p style={{ fontSize: 11, color: 'var(--color-muted)', marginBottom: 4 }}>Pending proposals</p>
+        <span data-testid="effectiveness-pending-proposals" style={{ fontSize: 20, fontWeight: 700, color: 'var(--color-foreground)' }}>
+          {pendingProposals}
+        </span>
+      </div>
+      {signal && (
+        <span style={{ fontSize: 11, color: 'var(--color-muted)', flexBasis: '100%' }}>{signal}</span>
+      )}
     </div>
   );
 }
@@ -226,12 +286,14 @@ export default function IntelligencePage() {
   const { data: injectionsData, isLoading: injectionsLoading, mutate: mutateInjections } = useIntelligenceInjections();
   const { data: classificationsData, isLoading: classLoading, mutate: mutateClass } = useIntelligenceClassifications();
   const { data: outcomesData, isLoading: outcomesLoading, mutate: mutateOutcomes } = useIntelligenceDispatchOutcomes();
+  const { data: effectivenessData, isLoading: effectivenessLoading, mutate: mutateEffectiveness } = useIntelligenceEffectiveness();
 
   function handleRefresh() {
     mutatePatterns();
     mutateInjections();
     mutateClass();
     mutateOutcomes();
+    mutateEffectiveness();
   }
 
   const successPatterns = patternsData?.success_patterns ?? [];
@@ -268,6 +330,23 @@ export default function IntelligencePage() {
           <RefreshCw size={13} />
           Refresh
         </button>
+      </div>
+
+      {/* === Section 0: Injection-Effectiveness (point-in-time, PR-18) === */}
+      <div style={{ marginBottom: 40 }}>
+        <SectionHeader icon={Gauge} title="Injection Effectiveness" />
+        {effectivenessLoading ? (
+          <LoadingSpinner />
+        ) : !effectivenessData ? (
+          <EmptyState label="Effectiveness probe unavailable." />
+        ) : (
+          <EffectivenessGauge
+            probeHealth={effectivenessData.probe_health}
+            ignoreRate={effectivenessData.ignore_rate}
+            pendingProposals={effectivenessData.pending_proposals}
+            signal={effectivenessData.signal}
+          />
+        )}
       </div>
 
       {/* === Section 1: Pattern Overview === */}

--- a/dashboard/token-dashboard/lib/hooks.ts
+++ b/dashboard/token-dashboard/lib/hooks.ts
@@ -15,6 +15,7 @@ import {
   fetchConfigAudit,
   fetchObservability,
   fetchSubsystems,
+  fetchHealthBeacons,
   fetchReports,
   fetchReportContent,
   fetchAgents,
@@ -23,6 +24,7 @@ import {
   fetchIntelligenceInjections,
   fetchIntelligenceClassifications,
   fetchIntelligenceDispatchOutcomes,
+  fetchIntelligenceEffectiveness,
   fetchProposals,
   fetchLearningProposals,
   fetchConfidenceTrends,
@@ -38,6 +40,7 @@ import type {
   OpenItemsEnvelope, AggregateOpenItemsEnvelope, KanbanEnvelope,
   GateConfigResponse, GovernanceDigestEnvelope, SystemHealthEnvelope, PlanningEnvelope,
   ConfigEnvelope, ConfigAuditEnvelope, ObservabilityEnvelope, SubsystemsEnvelope,
+  HealthBeaconEnvelope, EffectivenessProbeEnvelope,
   ReportsEnvelope, AgentsEnvelope,
   LiveSessionsEnvelope,
   PatternsResponse, InjectionsResponse, ClassificationsResponse, DispatchOutcomesResponse,
@@ -224,6 +227,17 @@ export function useSubsystems() {
   );
 }
 
+// Per-subsystem effectiveness summary backing the health page's subsystem
+// cards (PR-18) — beacon-derived health for every known cockpit subsystem,
+// including those with no probe yet (reported "unknown").
+export function useHealthBeacons() {
+  return useSWR<HealthBeaconEnvelope>(
+    'operator-health-beacons',
+    fetchHealthBeacons,
+    { refreshInterval: 20000, revalidateOnFocus: true, dedupingInterval: 8000 }
+  );
+}
+
 export function useConfigAudit(key?: string) {
   return useSWR<ConfigAuditEnvelope>(
     key ? `operator-config-audit:${key}` : 'operator-config-audit',
@@ -301,6 +315,16 @@ export function useIntelligenceDispatchOutcomes() {
   return useSWR<DispatchOutcomesResponse>(
     'intelligence-dispatch-outcomes',
     () => fetchIntelligenceDispatchOutcomes(),
+    { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 20000 }
+  );
+}
+
+// Point-in-time injection-effectiveness gauge (PR-18) — current ignore_rate +
+// pending_proposals from the latest beacon. Not a time-series.
+export function useIntelligenceEffectiveness() {
+  return useSWR<EffectivenessProbeEnvelope>(
+    'intelligence-effectiveness',
+    () => fetchIntelligenceEffectiveness(),
     { refreshInterval: 60000, revalidateOnFocus: true, dedupingInterval: 20000 }
   );
 }

--- a/dashboard/token-dashboard/lib/operator-api.ts
+++ b/dashboard/token-dashboard/lib/operator-api.ts
@@ -19,6 +19,8 @@ import type {
   ConfigAuditEnvelope,
   ObservabilityEnvelope,
   SubsystemsEnvelope,
+  HealthBeaconEnvelope,
+  EffectivenessProbeEnvelope,
   LiveSessionsEnvelope,
   ReportsEnvelope,
   AgentsEnvelope,
@@ -155,6 +157,10 @@ export function fetchSubsystems(): Promise<SubsystemsEnvelope> {
   return get(`${BASE}/subsystems`);
 }
 
+export function fetchHealthBeacons(): Promise<HealthBeaconEnvelope> {
+  return get(`${BASE}/health`);
+}
+
 export function fetchLiveSessions(): Promise<LiveSessionsEnvelope> {
   return get(`${BASE}/sessions`);
 }
@@ -211,6 +217,12 @@ export function fetchIntelligenceClassifications(limit = 100): Promise<Classific
 
 export function fetchIntelligenceDispatchOutcomes(limit = 200): Promise<DispatchOutcomesResponse> {
   return get('/api/intelligence/dispatch-outcomes', { limit: String(limit) });
+}
+
+// Point-in-time injection-effectiveness gauge (PR-18) — current ignore_rate +
+// pending_proposals from the latest beacon. Not a time-series.
+export function fetchIntelligenceEffectiveness(): Promise<EffectivenessProbeEnvelope> {
+  return get('/api/operator/intelligence/effectiveness');
 }
 
 // ===== Self-Improvement API =====

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -416,6 +416,41 @@ export interface SubsystemsEnvelope {
   error?: string;
 }
 
+// ===== Subsystem Effectiveness (Health page, PR-18) =====
+// Mirrors api_health.py's _subsystem_effectiveness_summary(): every known
+// cockpit subsystem joined against its beacon-derived health, defaulting to
+// "unknown" when no probe has ever written a beacon for it.
+
+export interface SubsystemEffectivenessRow {
+  subsystem: string;
+  health: string; // ok | stale | fail | corrupt | unknown
+  status: string;
+  last_signal: string;
+  detail: Record<string, unknown>;
+}
+
+export interface HealthBeaconEnvelope {
+  queried_at: string;
+  data_dir: string;
+  overall: string; // ok | stale | fail
+  counts: Record<string, number>;
+  beacons: Record<string, unknown>;
+  subsystems: SubsystemEffectivenessRow[];
+  error?: string;
+}
+
+// ===== Intelligence Effectiveness Gauge (PR-18) =====
+// Point-in-time signal from the injection-effectiveness probe (PR-6): the same
+// probe that gates the self-learning loop's activation (PR-17). No time-series —
+// no ignore_rate history store exists yet.
+
+export interface EffectivenessProbeEnvelope {
+  probe_health: string; // ok | degraded | produces_crap | unknown
+  ignore_rate: number | null;
+  pending_proposals: number;
+  signal: string;
+}
+
 // ===== Kanban Board Types =====
 
 export interface KanbanCard {

--- a/tests/dashboard/test_api_health_subsystems.py
+++ b/tests/dashboard/test_api_health_subsystems.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""Tests for api_health's subsystem effectiveness summary (framework-status-audit-and-cockpit
+PR-18).
+
+Covers GET /api/operator/health's new "subsystems" field: every known cockpit subsystem
+(config_registry + effectiveness-probe registry, via subsystem_health.known_subsystems()) joined
+against health_beacon.all_beacons(), defaulting an unprobed subsystem to health="unknown" rather
+than omitting it -- the health page needs every subsystem to appear so "unknown" can prompt the
+operator to add/improve a probe (PR-18 acceptance criterion). Read-only: the summary never runs a
+probe itself (that stays owned by `vnx subsystems --probe`, PR-3/PR-5).
+"""
+
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "dashboard"))
+
+import api_health  # noqa: E402
+from health_beacon import HealthBeacon  # noqa: E402
+
+
+def test_subsystem_effectiveness_summary_at_least_10_subsystems(tmp_path):
+    rows = api_health._subsystem_effectiveness_summary(tmp_path)
+    assert len(rows) >= 10
+    subsystems = {r["subsystem"] for r in rows}
+    assert "governance-enforcement-stack" in subsystems
+    assert "phantom_guard" in subsystems  # flag-less kernel subsystem
+
+
+def test_subsystem_effectiveness_summary_no_duplicates(tmp_path):
+    rows = api_health._subsystem_effectiveness_summary(tmp_path)
+    names = [r["subsystem"] for r in rows]
+    assert len(names) == len(set(names))
+
+
+def test_subsystem_effectiveness_summary_unknown_when_no_beacon(tmp_path):
+    rows = api_health._subsystem_effectiveness_summary(tmp_path)
+    governance = next(r for r in rows if r["subsystem"] == "governance-enforcement-stack")
+    assert governance["health"] == "unknown"
+    assert governance["status"] == "unknown"
+    assert governance["last_signal"] == ""
+    assert governance["detail"] == {}
+
+
+def test_subsystem_effectiveness_summary_reads_ok_beacon(tmp_path):
+    beacon = HealthBeacon(tmp_path, "phantom_guard", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="ok", details={"duplicates": 0})
+
+    rows = api_health._subsystem_effectiveness_summary(tmp_path)
+
+    phantom = next(r for r in rows if r["subsystem"] == "phantom_guard")
+    assert phantom["health"] == "ok"
+    assert phantom["status"] == "ok"
+    assert phantom["last_signal"]
+    assert phantom["detail"] == {"duplicates": 0}
+
+
+def test_subsystem_effectiveness_summary_fail_beacon(tmp_path):
+    beacon = HealthBeacon(tmp_path, "intelligence-self-learning-loop", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="fail", details={"ignore_rate": 0.98})
+
+    rows = api_health._subsystem_effectiveness_summary(tmp_path)
+
+    loop = next(r for r in rows if r["subsystem"] == "intelligence-self-learning-loop")
+    assert loop["health"] == "fail"
+
+
+def test_operator_get_health_includes_subsystems(monkeypatch, tmp_path):
+    beacon = HealthBeacon(tmp_path, "phantom_guard", expected_interval_seconds=None)
+    beacon.heartbeat_strict(status="ok")
+    monkeypatch.setattr(api_health, "_resolve_data_dir", lambda: tmp_path)
+
+    body = api_health._operator_get_health()
+
+    assert "subsystems" in body
+    assert len(body["subsystems"]) >= 10
+    phantom = next(r for r in body["subsystems"] if r["subsystem"] == "phantom_guard")
+    assert phantom["health"] == "ok"
+    # Existing beacon-summary fields stay intact -- no regression for PR-1..8/17 consumers.
+    assert "overall" in body
+    assert "counts" in body
+    assert "beacons" in body
+
+
+def test_operator_get_health_error_path_reports_empty_subsystems(monkeypatch, tmp_path):
+    def _boom(_data_dir):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(api_health, "_resolve_data_dir", lambda: tmp_path)
+    monkeypatch.setattr(api_health, "beacon_summary", _boom)
+
+    body = api_health._operator_get_health()
+
+    assert body["overall"] == "fail"
+    assert body["subsystems"] == []
+    assert "error" in body
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/dashboard/test_intelligence_effectiveness.py
+++ b/tests/dashboard/test_intelligence_effectiveness.py
@@ -1,0 +1,99 @@
+#!/usr/bin/env python3
+"""Tests for the injection-effectiveness dashboard gauge endpoint
+(framework-status-audit-and-cockpit PR-18): GET /api/operator/intelligence/effectiveness.
+
+Covers api_intelligence._intelligence_get_effectiveness_probe(): the point-in-time ignore_rate +
+pending_proposals signal read from the same probe (PR-6, injection_effectiveness_probe.py) that
+gates the self-learning loop's activation (PR-17). This is a point-in-time gauge, NOT a
+time-series -- no ignore_rate history store exists (deepseek finding, PRD PR-18 scope). PR-17
+already covers the probe/handler's classification logic in depth
+(tests/test_api_intelligence_effectiveness_probe.py); this suite focuses on the PR-18-specific
+route wiring and the shape the dashboard gauge depends on.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+REPO = Path(__file__).resolve().parent.parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+sys.path.insert(0, str(REPO / "dashboard"))
+
+import serve_dashboard as sd  # noqa: E402
+import api_intelligence as api_intel  # noqa: E402
+
+
+def _make_qi_db(db_path: Path, used: int, ignored: int) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE pattern_usage (used_count INTEGER, ignored_count INTEGER)")
+    conn.execute(
+        "INSERT INTO pattern_usage (used_count, ignored_count) VALUES (?, ?)", (used, ignored)
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_effectiveness_endpoint_returns_expected_shape():
+    with patch.object(sd, "DB_PATH", Path("/nonexistent/quality_intelligence.db")):
+        result = api_intel._intelligence_get_effectiveness_probe()
+
+    assert set(result.keys()) == {"probe_health", "ignore_rate", "pending_proposals", "signal"}
+    assert isinstance(result["signal"], str) and result["signal"]
+
+
+def test_effectiveness_endpoint_unknown_when_no_data(tmp_path):
+    with patch.object(sd, "DB_PATH", tmp_path / "quality_intelligence.db"):
+        result = api_intel._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "unknown"
+    assert result["ignore_rate"] is None
+    assert result["pending_proposals"] == 0
+
+
+def test_effectiveness_endpoint_ok_health(tmp_path):
+    db_path = tmp_path / "quality_intelligence.db"
+    _make_qi_db(db_path, used=90, ignored=10)  # ignore_rate = 0.10 -> ok
+
+    with patch.object(sd, "DB_PATH", db_path):
+        result = api_intel._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "ok"
+    assert result["ignore_rate"] == 0.10
+
+
+def test_effectiveness_endpoint_produces_crap_health(tmp_path):
+    db_path = tmp_path / "quality_intelligence.db"
+    _make_qi_db(db_path, used=5, ignored=95)  # ignore_rate = 0.95 -> produces_crap
+
+    with patch.object(sd, "DB_PATH", db_path):
+        result = api_intel._intelligence_get_effectiveness_probe()
+
+    assert result["probe_health"] == "produces_crap"
+    assert result["ignore_rate"] == 0.95
+
+
+def test_effectiveness_endpoint_counts_pending_proposals(tmp_path):
+    db_path = tmp_path / "quality_intelligence.db"
+    _make_qi_db(db_path, used=90, ignored=10)
+    (tmp_path / "pending_rules.json").write_text(
+        '{"pending_rules": [{"status": "pending", "created_at": "2026-07-10T00:00:00Z"}]}',
+        encoding="utf-8",
+    )
+
+    with patch.object(sd, "DB_PATH", db_path):
+        result = api_intel._intelligence_get_effectiveness_probe()
+
+    assert result["pending_proposals"] == 1
+
+
+def test_route_is_wired_in_serve_dashboard():
+    """GET /api/operator/intelligence/effectiveness must be registered as a route
+    (PR-18 scope item) on top of PR-17's /api/intelligence/effectiveness-probe gate signal."""
+    source = (REPO / "dashboard" / "serve_dashboard.py").read_text(encoding="utf-8")
+    assert '"/api/operator/intelligence/effectiveness"' in source
+
+
+if __name__ == "__main__":
+    import pytest
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary
- Extends `dashboard/api_health.py`'s `_operator_get_health()` with a `subsystems` field: every known cockpit subsystem (`subsystem_health.known_subsystems()`) joined against `health_beacon.all_beacons()`, defaulting unprobed subsystems to `health="unknown"` instead of omitting them.
- Wires `GET /api/operator/intelligence/effectiveness` in `serve_dashboard.py`, reusing PR-17's existing `_intelligence_get_effectiveness_probe()` handler (same read-only injection-effectiveness signal that gates the self-learning loop).
- `app/operator/health/page.tsx`: adds a "Subsystem Effectiveness" section rendering a card per subsystem with a beacon-derived health badge; `unknown` cards prompt the operator to add/improve a probe.
- `app/operator/intelligence/page.tsx`: adds a point-in-time "Injection Effectiveness" gauge (probe health, ignore_rate, pending_proposals, signal) — explicitly NOT a time-series, since no ignore_rate history store exists (PRD PR-18 descope).
- New SWR hooks `useHealthBeacons()` / `useIntelligenceEffectiveness()` + fetch functions, following existing conventions.
- Updated `health-page.test.tsx` to mock the new `useHealthBeacons()` hook (existing test would otherwise break) and added coverage for the new subsystem cards.

## Test plan
- [x] `python3 -m pytest tests/dashboard/test_api_health_subsystems.py tests/dashboard/test_intelligence_effectiveness.py -q` — 13 passed
- [x] `python3 -m pytest tests/test_api_intelligence_effectiveness_probe.py tests/dashboard/test_api_subsystems.py -q` — 13 passed (no regression on PR-17/PR-4 tests)
- [x] `cd dashboard/token-dashboard && npx tsc --noEmit -p .` — zero errors in all 5 touched source files (pre-existing baseline noise in `__tests__/*` and `e2e/*` from missing `@types/jest`/`@playwright/test` typings is unrelated to this change and present on `main` too)

🤖 Generated with [Claude Code](https://claude.com/claude-code)