### PR TITLE
fix(health): register injection-effectiveness probe in the aggregator

### DIFF
--- a/scripts/lib/subsystem_health.py
+++ b/scripts/lib/subsystem_health.py
@@ -38,6 +38,7 @@ from health_beacon import HealthBeacon  # noqa: E402
 # registered probe regardless of which entrypoint (CLI, test, dashboard)
 # triggers the first import of this module.
 import governance_effectiveness_probe  # noqa: E402,F401
+import injection_effectiveness_probe  # noqa: E402,F401
 import migration_effectiveness_probe  # noqa: E402,F401
 import plan_gate_effectiveness_probe  # noqa: E402,F401
 


### PR DESCRIPTION
`subsystem_health.py` imported governance/migration/plan-gate probes but not `injection_effectiveness_probe` (PR-6), so `vnx subsystems --probe` showed intelligence-self-learning-loop as 'no probe registered'. Adds the missing import — all four probes now surface. Completes PR-6's cockpit integration. Verified: EFFECTIVENESS_PROBES now includes intelligence-self-learning-loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)