### PR TITLE
feat(t0): revive context rotation as T0-initiated, non-destructive control-plane (default OFF)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -106,6 +106,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null || echo .); mkdir -p \"$ROOT/.vnx-data/logs\" 2>/dev/null; python3 \"$ROOT/scripts/hooks/session_stop_rotation.py\" 2>>\"$ROOT/.vnx-data/logs/session_stop_rotation.err\"; exit 0'",
+            "timeout": 5000
+          }
+        ]
       }
     ]
   }

--- a/configs/context_rotation.yaml
+++ b/configs/context_rotation.yaml
@@ -1,0 +1,45 @@
+# VNX T0 context-rotation policy (default OFF).
+#
+# See docs/operations/CONTEXT_ROTATION.md for the full contract. This file is
+# the yaml half of RotationPolicy.load() (scripts/lib/context_rotation.py);
+# every field here can be overridden per-process by the matching
+# VNX_T0_ROTATION* env var (env always wins — see the doc for the table).
+#
+# Native Claude Code compaction remains the baseline. This policy only
+# controls the OPTIONAL T0-initiated handoff+respawn control-plane on top of
+# it; it never disables compaction.
+
+# Master switch. False (or absent) => checkpoint()/decide_rotation() are a
+# guaranteed no-op regardless of every other field below. Mirrors env
+# VNX_T0_ROTATION (set to "1" to enable).
+enabled: false
+
+# Only "governance_boundary" is implemented. Interactive T0 has no reliable
+# live context-percentage signal (verified round 1 of the design panel), so
+# there is no "pct" trigger mode — pct_ceiling below is a backstop on top of
+# the boundary trigger, not a trigger of its own.
+trigger: governance_boundary
+
+# Durable boundary COUNTER gate (not a timestamp/cooldown): a rotation is
+# only allowed once at least this many governance boundaries have passed
+# since the last CONFIRMED rotation. Persisted per-project per-terminal in
+# <central_data_dir>/state/rotation/<terminal>_durable.json.
+min_boundaries_between_rotations: 3
+
+# Optional safety-valve: when set, a rotation is allowed even if the boundary
+# counter hasn't cleared min_boundaries_between_rotations, provided the
+# caller-supplied context_pct is at/above this ceiling AND the call is still
+# at a governance boundary (rotation is never mid-action). Leave null to run
+# on the boundary counter alone (observability-only pct reporting).
+pct_ceiling: null
+
+# "tmux_new_session" | "off". Off means checkpoint() still writes the
+# handoff + advances debounce state on a decided rotation, but never spawns
+# a successor session — useful for dry-running the handoff pipeline. The
+# T0-initiated non-destructive tmux respawn only fires when this is
+# "tmux_new_session" AND enabled is true.
+respawn: off
+
+# Reserved for future handoff.md template variants. Only "default" exists
+# today (scripts/lib/context_rotation.write_t0_handoff).
+handoff_template: default

--- a/docs/operations/CONTEXT_ROTATION.md
+++ b/docs/operations/CONTEXT_ROTATION.md
@@ -1,0 +1,341 @@
+# T0 Context Rotation — Operator Guide
+
+> **Status: DEFAULT OFF.** Native Claude Code compaction (microcompaction +
+> auto-compaction at ~83% of the effective window) is the baseline and stays
+> the baseline. This control-plane is an *optional* add-on for a
+> **T0-initiated, non-destructive** handoff+respawn cycle on top of it — it
+> never replaces or disables compaction.
+>
+> Design authority: `claudedocs/plans/t0-context-rotation-revival.md` (rev 3),
+> ruled on by `claudedocs/2026-07-11-panel-t0-context-rotation-verdict.md`.
+> Not to be confused with the older **worker** (T1/T2/T3) rotation system
+> (`hooks/vnx_rotate.sh`, `docs/core/technical/CONTEXT_ROTATION_SYSTEM.md`),
+> which explicitly excludes T0 and uses a completely different mechanism
+> (`/clear` inside the SAME session, driven by a `PreToolUse` hook). This
+> document covers ONLY the T0 control-plane
+> (`scripts/lib/context_rotation.py`).
+
+---
+
+## Why this exists, and why it is not the worker system
+
+The worker rotation system fires `/clear` inside the same tmux pane — that
+works because a worker's job is a single bounded dispatch with a known
+skill/dispatch-id to resume. T0 is different: it is a long-running,
+open-ended orchestrator session with no single dispatch to hand back to, and
+a shell `Stop` hook **cannot launch a fresh interactive Claude session** —
+there is no hook-driven way to spawn T0's replacement. So the T0 respawn must
+be **T0-initiated**: the *running* T0 decides to rotate (at a governance
+boundary) and spawns its own successor, waiting for that successor to
+confirm it is alive before the original exits. If the successor never
+confirms, the rotation **aborts** and the original T0 keeps running — there
+is no window where zero T0 sessions exist.
+
+---
+
+## The moving parts
+
+| Piece | File | Role |
+|---|---|---|
+| `RotationPolicy` | `scripts/lib/context_rotation.py` | yaml + env policy surface |
+| `decide_rotation()` | same | pure decision function (no I/O) |
+| `checkpoint()` | same | the integration point T0 calls at a governance boundary |
+| `write_t0_handoff()` | same | writes the `handoff.md` contract |
+| `respawn()` | same | non-destructive `tmux new-session` + bounded readiness wait |
+| `handoff_reader.py` | `scripts/lib/handoff_reader.py` | parses `handoff.md` into a briefing |
+| `vnx handoff show` / `mark-ready` | `vnx_cli/commands/handoff.py` | CLI the successor runs to resume + ack |
+| `session_stop_rotation.py` | `scripts/hooks/session_stop_rotation.py` | Stop-hook **safety net only** — never spawns T0 |
+
+---
+
+## Policy surface
+
+`RotationPolicy.load()` reads `configs/context_rotation.yaml`, then applies
+env-var overrides (env always wins when the var is set):
+
+| Field | yaml key | env override | Default |
+|---|---|---|---|
+| enabled | `enabled` | `VNX_T0_ROTATION` (exactly `"1"` to enable) | `false` |
+| trigger | `trigger` | `VNX_T0_ROTATION_TRIGGER` | `governance_boundary` (only mode implemented) |
+| min_boundaries_between_rotations | `min_boundaries_between_rotations` | `VNX_T0_ROTATION_MIN_BOUNDARIES` | `3` |
+| pct_ceiling | `pct_ceiling` | `VNX_T0_ROTATION_PCT_CEILING` | `null` (off) |
+| respawn | `respawn` | `VNX_T0_ROTATION_RESPAWN` | `off` (`tmux_new_session` to actually spawn) |
+| handoff_template | `handoff_template` | — | `default` |
+
+**Two independent switches, both required for a real respawn:**
+`enabled=true` gates the whole control-plane (handoff writing, debounce
+bookkeeping, receipts). `respawn=tmux_new_session` additionally gates
+whether a decided rotation actually spawns a successor — with `respawn=off`
+(the shipped default even when `enabled` is flipped on), `checkpoint()` still
+writes the handoff/marker and advances debounce state on a decided rotation,
+which is useful for dry-running the pipeline without ever touching tmux.
+
+There is deliberately **no live context-percentage trigger** for interactive
+T0 (verified in round 1 of the design panel — no reliable signal exists).
+`pct_ceiling` is a *backstop*, not a trigger: when set, and the caller
+supplies `context_pct` at/above it, a rotation is allowed even before the
+boundary counter clears — but only ever at a genuine governance boundary
+(never mid-action).
+
+---
+
+## The decision: `decide_rotation()`
+
+Pure function, no I/O. Gate order:
+
+1. `policy.enabled` — false short-circuits everything.
+2. `mid_action` — a rotation is never decided mid-action.
+3. `at_governance_boundary` — must be true (the only implemented trigger).
+4. Durable **boundary-count** debounce: `boundaries_since_last_rotation >=
+   min_boundaries_between_rotations`, OR the `pct_ceiling` backstop fires.
+
+Note this is a **counter**, not a cooldown timer — `min_boundaries_between_
+rotations` counts governance boundaries crossed, not elapsed wall-clock time.
+
+---
+
+## The integration point: `checkpoint()`
+
+```python
+from context_rotation import checkpoint
+
+outcome = checkpoint(
+    at_governance_boundary=True,   # T0 calls this only at a real boundary
+    project_id=project_id,         # required — ADR-007, no silent default
+    context_pct=None,              # optional observability/backstop signal
+)
+```
+
+What it does, per call:
+
+1. Loads (or accepts an injected) `RotationPolicy`. If disabled, returns
+   immediately — **zero filesystem side effects**, not even the rotation
+   state directory gets created.
+2. Resolves project_id-scoped state via `resolve_central_data_dir(project_id)`
+   (`scripts/lib/vnx_paths.py`) — always `~/.vnx-data/<project_id>/...`,
+   regardless of dev-checkout vs central-install mode, so the respawned
+   successor (running from the same project root) resolves the exact same
+   paths.
+3. Checks the **request marker** (`<state>/rotation/<terminal>_request.json`)
+   for an `in_progress` entry younger than `request_ttl_seconds` (default
+   120s) — if found, the call is a duplicate and returns
+   `already_in_progress` without writing anything new. A marker older than
+   the TTL is treated as a crashed prior attempt and the call proceeds.
+4. Loads the **durable debounce counter** and calls `decide_rotation()`.
+   - Not rotating: increments the counter (if at a boundary) and returns.
+   - Rotating: writes the request marker (`status: in_progress`), then
+     `write_t0_handoff()`, then — only if `policy.respawn ==
+     "tmux_new_session"` — calls `respawn()`.
+5. **Debounce state (the counter reset to 0, `last_rotation_at` stamped) and
+   the `context_rotation_continuation` receipt only fire on a CONFIRMED
+   success** — respawn returning `success=True`, or immediately when
+   `respawn` policy is `"off"`. An **ABORTed** respawn:
+   - leaves the counter and `last_rotation_at` untouched, so the very next
+     boundary is eligible to retry;
+   - marks the request marker `status: aborted` (not blocking future
+     attempts);
+   - retains the handoff.md that was already written;
+   - logs loudly (`ERROR`) with the rotation_id and reason;
+   - does **not** emit the continuation receipt.
+
+---
+
+## Durable state layout (all under `resolve_central_data_dir(project_id)`)
+
+```
+~/.vnx-data/<project_id>/
+├── state/rotation/
+│   ├── T0_durable.json      # {"boundaries_since_last_rotation": int, "last_rotation_at": iso|null}
+│   ├── T0_request.json      # {"rotation_id", "status": in_progress|success|aborted, "created_at", ["reason"]}
+│   └── T0.ready             # written by the successor: {"rotation_id", "terminal", "marked_at"}
+└── rotation_handovers/T0/
+    └── handoff.md           # the resume contract (see below)
+```
+
+Every path is a function of `(project_id, terminal)` — a shared central
+install never collides two projects' rotation state (round-3 finding #8).
+
+---
+
+## The `handoff.md` contract
+
+Written by `write_t0_handoff()`, read by `handoff_reader.read_handoff()` /
+`vnx handoff show` — both sides must stay in lockstep on this shape:
+
+```markdown
+---
+context: t0-rotation
+project: <project_id>
+date: <ISO-8601 UTC>
+branch: <git branch, or "unknown">
+---
+
+# T0 Context Rotation Handoff
+
+## Waar we middenin zitten
+
+<short prose: uncommitted-changes summary + active NOW-horizon tracks>
+
+## State
+
+- Branch, uncommitted file list, last 5 commits
+- Horizon NOW / NEXT tracks (from `scripts/lib/tracks.list_tracks`)
+- Unresolved open items linked to those tracks
+
+## Next steps
+
+<unresolved open items, or the active NOW tracks, or a pointer to `vnx horizon list`>
+```
+
+**Fail-soft per source**: a git-command failure degrades to `branch:
+unknown` with empty commit/status lists; a horizon/open-items read failure
+(missing DB, schema mismatch) degrades to empty NOW/NEXT/open-items lists.
+Neither failure prevents the handoff from being written — `write_t0_handoff`
+always produces a complete, contract-shaped file.
+
+---
+
+## The respawn: non-destructive, with a readiness handshake
+
+`respawn()` does exactly this, and nothing else:
+
+1. `tmux new-session -d -s <session> -c <project_root>` — a fresh detached
+   session. **Never** touches the caller's own/current session.
+2. `tmux send-keys -l claude` + `Enter` — a bare, **interactive** `claude`
+   invocation. No `-p`, `--print`, or `--dangerously-skip-permissions`.
+3. A short boot delay, then `tmux send-keys -l "<resume prompt>"` + `Enter`
+   — the resume prompt is **typed text for the fresh Claude session's first
+   turn**, not a raw shell command. It instructs the successor to run:
+   ```
+   vnx handoff show --mark-ready --terminal T0 --rotation-id <id> --project-id <id>
+   ```
+4. Polls (bounded, default 60s) for `<state>/rotation/T0.ready` to appear
+   **with a matching `rotation_id`** (round-3 finding #6 — a stale `.ready`
+   from a previous rotation is rejected by content, not just presence).
+5. **On ready**: returns `success=True`. The caller (`checkpoint()`) then
+   marks the rotation confirmed; the old T0 is expected to exit shortly
+   after (outside this module's scope — the actual "exit" instruction is
+   part of T0's own boundary logic, not `context_rotation.py`).
+6. **On timeout**: `tmux kill-session -t <the-session-this-call-just-
+   spawned>` (round-3 finding #4 — reap the orphan so no duplicate T0
+   dangles), logs an `ERROR`-level ABORT, and returns `success=False`. The
+   caller's session is never touched.
+
+The `tmux_spawn_fn` / `tmux_kill_fn` parameters are injectable — production
+uses the real `subprocess`-based implementations; tests inject recording
+mocks (see `tests/test_context_rotation.py`), so no test ever spawns a real
+tmux session.
+
+### Why this does not collide with the raw-claude-spawn guard
+
+`scripts/hooks/pretooluse_block_raw_claude_spawn.sh` (via
+`pretooluse_spawn_detector.py`) hard-blocks `claude -p` / `--print` /
+`--dangerously-skip-permissions`, and its own header comment marks bare
+`claude` (no flags) as **"Always allowed... benign/interactive"**. Every
+subprocess call `respawn()` makes has `argv[0] == "tmux"` — `claude` only
+ever appears as a *later positional argument* to `tmux send-keys` (a single
+quoted string), never as the executable actually being invoked. The
+detector's hard-block classifies on `exe = basename(argv[0])`, so it
+structurally cannot match here (the same reasoning the detector itself
+applies to skip a lane `.py` name that shows up only as a `-c` code-string
+argument). In production this call also happens **inside an already-running
+Python process** (`checkpoint()`), not as a literal Bash-tool-call string
+Claude Code itself proposes — so the `PreToolUse` hook is not even in the
+invocation path. The guard-safe argv shape is defense-in-depth on top of
+that, and is asserted directly in `TestGuardSafeSpawnShape` /
+`TestRespawn.test_never_calls_a_destructive_or_kill_path_on_success`.
+
+---
+
+## The audit trail: `context_rotation_continuation`
+
+On a **confirmed** rotation, `checkpoint()` emits the same
+`context_rotation_continuation` event the worker rotation system
+(`hooks/vnx_rotate.sh`) already emits, so both producers feed the ONE read
+model (`scripts/lib/conversation_read_model.py`) that chains rotation events
+by `dispatch_id`:
+
+```json
+{
+  "event_type": "context_rotation_continuation",
+  "terminal": "T0",
+  "dispatch_id": "<rotation_id>",
+  "handover_path": "/path/to/handoff.md",
+  "skill": "t0-orchestrator",
+  "context_used_pct_at_rotation": 0,
+  "timestamp": "2026-07-12T12:00:00Z",
+  "project_id": "<project_id>",
+  "source": "context_rotation"
+}
+```
+
+No receipt is emitted on an aborted rotation — only a confirmed one is part
+of the audit chain.
+
+---
+
+## The `vnx handoff` CLI
+
+```
+vnx handoff show [--logdir DIR] [--terminal T0] [--mark-ready --rotation-id ID] [--project-id ID] [--project-dir DIR]
+vnx handoff mark-ready --rotation-id ID [--terminal T0] [--project-id ID] [--project-dir DIR]
+```
+
+- `show` prints the parsed briefing (`Waar we middenin zitten` / `State` /
+  `Next steps`). With no `--logdir`, it resolves the SAME project_id+terminal
+  -scoped path `checkpoint()` writes to, so a freshly-respawned T0 running
+  `vnx handoff show` from the project root finds the real handoff with zero
+  extra flags.
+- `mark-ready` (or `show --mark-ready --rotation-id ID`) writes the
+  rotation_id-stamped `.ready` signal the waiting `respawn()` call in the old
+  session is polling for.
+
+This is a **repo-level** contract — deliberately not the personal
+`/build-log wrap` + `/kickoff` skill chain. Those skills remain available for
+manual use; they are not part of this control-plane.
+
+---
+
+## The safety-net hook: `session_stop_rotation.py`
+
+Wired under `Stop` in `.claude/settings.json`, **NO-OP unless
+`VNX_T0_ROTATION=1`**. When enabled, it does exactly one thing: ensure
+`handoff.md` exists (by calling `write_t0_handoff()`) for the case where T0
+goes idle without ever having called `checkpoint()` — e.g. no boundary was
+reached that session, or rotation was toggled on mid-session. It makes **no
+claim to spawn a successor** — that is exclusively `checkpoint()` ->
+`respawn()`'s job. This preserves the "T0-initiated, never hook-initiated"
+invariant from the rev-3 decision (a shell `Stop` hook genuinely cannot
+launch an interactive Claude session).
+
+---
+
+## Enabling it
+
+1. Flip `enabled: true` in `configs/context_rotation.yaml`, or export
+   `VNX_T0_ROTATION=1` in the T0 session's environment.
+2. Decide whether you want the dry-run pipeline (`respawn: off` — handoff +
+   debounce bookkeeping only) or the real respawn (`respawn:
+   tmux_new_session`).
+3. Wire `checkpoint()` into T0's own governance-boundary logic (dispatch
+   completion, plan-gate resolution, etc.) — this module does not decide
+   *when* a boundary occurs; it only decides what to do once T0 says one has.
+4. Optionally set `VNX_T0_ROTATION_MIN_BOUNDARIES` / `_PCT_CEILING` to tune
+   the debounce for your session cadence.
+
+**Rollback**: unset `VNX_T0_ROTATION` (or leave `configs/context_rotation.yaml`
+at its shipped `enabled: false`). Zero code paths execute — this document
+describes an entirely additive, default-off feature. Native compaction keeps
+running exactly as it always has.
+
+---
+
+## What this explicitly does NOT do (out of scope)
+
+- No headless-T0 fork.
+- No change to native-compaction reliance between rotations — it is still
+  the thing that handles everything this control-plane doesn't.
+- No auto-enable / cross-project rollout.
+- No fully hands-off auto-respawn from a daemon with no T0 present — that
+  needs a governed interactive-session-spawn primitive and is explicitly
+  parked as a follow-up track (`t0-rotation-auto-spawn-primitive`).

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -17,6 +17,7 @@
 - Multi-model guide: `MULTI_MODEL_GUIDE.md`
 - Autonomous production guide: `AUTONOMOUS_PRODUCTION_GUIDE.md`
 - Transcript backup & archive: `TRANSCRIPT_BACKUP_ARCHIVE.md`
+- T0 context rotation (default OFF): `CONTEXT_ROTATION.md`
 
 > **Note**: `MONITORING_GUIDE.md` was retired. Runtime monitoring is now available
 > via the dashboard server (`dashboard/serve_dashboard.py`) at `/api/health`.

--- a/scripts/hooks/session_stop_rotation.py
+++ b/scripts/hooks/session_stop_rotation.py
@@ -10,6 +10,13 @@ spawn a successor T0 — the respawn is strictly T0-INITIATED
 (context_rotation.checkpoint() -> respawn()), never hook-initiated (rev-3
 plan §"Rev-3 decision", point 3).
 
+The Stop hook's settings.json matcher is empty ("") — it fires for EVERY
+session, T0 or worker. Since the handoff it writes is always the T0 one,
+this module verifies it IS a T0 session (env identity, falling back to the
+same cwd-based .claude/terminals/T{1,2,3} heuristic stop_report_hook.sh
+already uses to detect workers) before writing anything, so a stopping
+T1/T2/T3 can never clobber the T0 rotation handoff with worker state.
+
 Claude Code Stop hook contract: JSON on stdin ({session_id, transcript_path,
 cwd, ...}), JSON decision on stdout, exit 0 always (never block session
 stop).
@@ -19,12 +26,31 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import sys
 from pathlib import Path
 
 _LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
+
+# Matches .claude/terminals/T1, T2, or T3 anywhere in a cwd — mirrors the
+# case statement in scripts/hooks/stop_report_hook.sh's cwd-based terminal
+# detection. T0 has no such segment (it runs at the project root), so its
+# absence is the T0 signal.
+_WORKER_TERMINAL_CWD_RE = re.compile(r"(?:^|/)\.claude/terminals/(T[1-3])(?:/|$)")
+
+
+def _is_t0_session(cwd: str, env: dict) -> bool:
+    """Best-effort, in-script T0 identity check (portable — does not rely on
+    harness-level hook-matcher scoping). An explicit VNX_TERMINAL /
+    VNX_TERMINAL_ID env var wins when set; otherwise falls back to the cwd
+    heuristic. No T1/T2/T3 signal at all -> assume T0 (matches the existing
+    default: T0 runs at the project root, not under terminals/T{n})."""
+    terminal_env = env.get("VNX_TERMINAL") or env.get("VNX_TERMINAL_ID")
+    if terminal_env:
+        return terminal_env.strip().upper() == "T0"
+    return _WORKER_TERMINAL_CWD_RE.search((cwd or "").replace("\\", "/")) is None
 
 
 def main() -> int:
@@ -41,6 +67,11 @@ def main() -> int:
         payload = {}
 
     cwd = payload.get("cwd") or os.getcwd()
+
+    if not _is_t0_session(cwd, os.environ):
+        sys.stdout.write("{}\n")
+        return 0
+
     project_root = Path(cwd)
 
     try:

--- a/scripts/hooks/session_stop_rotation.py
+++ b/scripts/hooks/session_stop_rotation.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+"""Stop hook safety-net for T0 context rotation (DEFAULT OFF).
+
+NO-OP unless VNX_T0_ROTATION=1. When enabled, it ONLY ensures handoff.md
+exists at the project_id+terminal-scoped rotation dir — a safety net for the
+case where T0 goes idle (Stop fires) without ever calling
+scripts/lib/context_rotation.checkpoint() itself (e.g. no governance boundary
+was reached, or rotation was disabled mid-session). It makes NO claim to
+spawn a successor T0 — the respawn is strictly T0-INITIATED
+(context_rotation.checkpoint() -> respawn()), never hook-initiated (rev-3
+plan §"Rev-3 decision", point 3).
+
+Claude Code Stop hook contract: JSON on stdin ({session_id, transcript_path,
+cwd, ...}), JSON decision on stdout, exit 0 always (never block session
+stop).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+
+def main() -> int:
+    if os.environ.get("VNX_T0_ROTATION") != "1":
+        sys.stdout.write("{}\n")
+        return 0
+
+    try:
+        raw = sys.stdin.read()
+        payload = json.loads(raw) if raw.strip() else {}
+    except (json.JSONDecodeError, ValueError):
+        payload = {}
+    if not isinstance(payload, dict):
+        payload = {}
+
+    cwd = payload.get("cwd") or os.getcwd()
+    project_root = Path(cwd)
+
+    try:
+        from project_root import resolve_project_id
+        from context_rotation import write_t0_handoff, rotation_handoff_dir, DEFAULT_TERMINAL
+
+        project_id = resolve_project_id(str(project_root))
+        logdir = rotation_handoff_dir(project_id, DEFAULT_TERMINAL)
+        write_t0_handoff(logdir=logdir, project_root=project_root, project_id=project_id)
+    except Exception as exc:  # noqa: BLE001 - safety net must never block session stop
+        sys.stderr.write(f"session_stop_rotation: safety-net write failed: {exc}\n")
+
+    sys.stdout.write("{}\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/context_rotation.py
+++ b/scripts/lib/context_rotation.py
@@ -1,0 +1,773 @@
+#!/usr/bin/env python3
+"""T0 context-rotation control-plane (default OFF).
+
+Design authority: claudedocs/plans/t0-context-rotation-revival.md (rev 3).
+Full contract: docs/operations/CONTEXT_ROTATION.md.
+
+Native Claude Code compaction stays the baseline. This module is an OPTIONAL,
+T0-INITIATED, NON-DESTRUCTIVE control-plane on top of it:
+
+  - decide_rotation(): pure decision (enabled-gate, governance boundary,
+    durable boundary-count debounce, optional pct backstop, never mid-action).
+  - checkpoint(): the integration point a running T0 calls at a governance
+    boundary. Loads policy + durable state, decides, and on a decided
+    rotation writes a handoff.md + a request marker, then (if
+    policy.respawn == "tmux_new_session") calls respawn(). Debounce state
+    only advances after a CONFIRMED respawn success (or, when respawn is
+    "off", after the handoff/marker write itself succeeds) — an aborted
+    respawn leaves the counter untouched so the next boundary can retry.
+  - write_t0_handoff(): writes the repo handoff.md contract (frontmatter +
+    "Waar we middenin zitten" / "State" / "Next steps"), fail-soft per
+    source (git, horizon, open items each independently guarded).
+  - respawn(): NON-DESTRUCTIVE `tmux new-session -d` of a fresh, bare
+    interactive `claude` (never -p/--print/--dangerously-skip-permissions —
+    the exact form scripts/hooks/pretooluse_block_raw_claude_spawn.sh's own
+    header comment marks "Always allowed"; argv[0] is always `tmux`, never
+    `claude`, since `claude` only ever appears as a later positional/typed
+    argument, so pretooluse_spawn_detector.py's exe-basename classifier
+    never matches it as the executable being hard-blocked). Waits (bounded)
+    for a rotation_id-stamped `.ready` file from the successor; on timeout it
+    ABORTs — reaps the orphan tmux session it just created (never the
+    caller's own session), leaves the handoff/marker/durable state in place,
+    and logs loudly. The tmux call is injectable for tests.
+
+DEFAULT OFF: RotationPolicy.enabled is False unless configs/context_rotation.yaml
+sets `enabled: true` or the VNX_T0_ROTATION env var is exactly "1". With either
+absent, checkpoint()/decide_rotation() are a proven no-op (see
+tests/test_context_rotation.py).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import subprocess
+import sys
+import time
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+import yaml
+
+# Self-bootstrap: make this module importable both as `scripts.lib.context_rotation`
+# (namespace package from repo root, e.g. `python3 -c "import scripts.lib.context_rotation"`)
+# and via the test convention of prepending scripts/lib to sys.path directly. Either
+# way, this module's OWN sibling imports (vnx_paths, tracks, append_receipt) need
+# scripts/lib and scripts/ on sys.path — mirrors scripts/lib/vnx_paths.py's bootstrap.
+_LIB_DIR = Path(__file__).resolve().parent
+_SCRIPTS_DIR = _LIB_DIR.parent
+for _p in (str(_LIB_DIR), str(_SCRIPTS_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+from vnx_paths import resolve_central_data_dir  # noqa: E402
+
+log = logging.getLogger(__name__)
+
+DEFAULT_TERMINAL = "T0"
+HANDOFF_FILENAME = "handoff.md"
+_ROTATION_SUBDIR = ("rotation_handovers",)
+_STATE_SUBDIR = ("state", "rotation")
+_CONFIG_RELATIVE_PATH = Path("configs") / "context_rotation.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Path helpers (all project_id-scoped via resolve_central_data_dir — ADR-007 /
+# round-3 finding #8: shared central installs must never collide across
+# projects).
+# ---------------------------------------------------------------------------
+
+def rotation_state_dir(project_id: str) -> Path:
+    return resolve_central_data_dir(project_id).joinpath(*_STATE_SUBDIR)
+
+
+def rotation_handoff_dir(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    return resolve_central_data_dir(project_id).joinpath(*_ROTATION_SUBDIR, terminal)
+
+
+def durable_state_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    return rotation_state_dir(project_id) / f"{terminal}_durable.json"
+
+
+def request_marker_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    return rotation_state_dir(project_id) / f"{terminal}_request.json"
+
+
+def ready_signal_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    return rotation_state_dir(project_id) / f"{terminal}.ready"
+
+
+# ---------------------------------------------------------------------------
+# Small JSON/atomic-write helpers (Codex Defense Checklist: atomic writes on
+# canonical state — write <path>.tmp then os.replace).
+# ---------------------------------------------------------------------------
+
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.isoformat().replace("+00:00", "Z")
+
+
+def _write_json_atomic(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+    os.replace(tmp, path)
+
+
+def _load_json_safe(path: Path) -> Optional[Dict[str, Any]]:
+    if not path.is_file():
+        return None
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _seconds_since(iso_ts: str, now: datetime) -> float:
+    try:
+        parsed = datetime.fromisoformat(iso_ts.replace("Z", "+00:00"))
+    except (ValueError, AttributeError):
+        return float("inf")
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return (now - parsed).total_seconds()
+
+
+# ---------------------------------------------------------------------------
+# RotationPolicy
+# ---------------------------------------------------------------------------
+
+def _default_config_path() -> Path:
+    return _SCRIPTS_DIR.parent / _CONFIG_RELATIVE_PATH
+
+
+def _coerce_bool(value: Any) -> bool:
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes", "on")
+    return bool(value)
+
+
+@dataclass
+class RotationPolicy:
+    enabled: bool = False
+    trigger: str = "governance_boundary"
+    min_boundaries_between_rotations: int = 3
+    pct_ceiling: Optional[float] = None
+    respawn: str = "off"
+    handoff_template: str = "default"
+
+    @classmethod
+    def load(
+        cls,
+        *,
+        config_path: Optional[Path] = None,
+        env: Optional[Dict[str, str]] = None,
+    ) -> "RotationPolicy":
+        """Load policy from yaml (configs/context_rotation.yaml) + env overrides.
+
+        Env always wins when set. With no yaml file and no env vars, this
+        returns the dataclass defaults (enabled=False) — the DEFAULT-OFF
+        guarantee.
+        """
+        env = env if env is not None else os.environ
+        path = Path(config_path) if config_path is not None else _default_config_path()
+        data: Dict[str, Any] = {}
+        if path.is_file():
+            try:
+                loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+                if isinstance(loaded, dict):
+                    data = loaded
+            except (OSError, yaml.YAMLError) as exc:
+                log.warning("context_rotation: failed to load %s: %s", path, exc)
+
+        enabled = _coerce_bool(data.get("enabled", False))
+        if "VNX_T0_ROTATION" in env:
+            enabled = env.get("VNX_T0_ROTATION") == "1"
+
+        trigger = env.get("VNX_T0_ROTATION_TRIGGER") or data.get("trigger") or "governance_boundary"
+
+        min_boundaries_raw = env.get("VNX_T0_ROTATION_MIN_BOUNDARIES")
+        if min_boundaries_raw is not None:
+            min_boundaries = int(min_boundaries_raw)
+        else:
+            min_boundaries = int(data.get("min_boundaries_between_rotations", 3))
+
+        pct_ceiling_raw = env.get("VNX_T0_ROTATION_PCT_CEILING")
+        if pct_ceiling_raw is not None:
+            pct_ceiling: Optional[float] = float(pct_ceiling_raw)
+        else:
+            yaml_pct = data.get("pct_ceiling")
+            pct_ceiling = float(yaml_pct) if yaml_pct is not None else None
+
+        respawn = env.get("VNX_T0_ROTATION_RESPAWN") or data.get("respawn") or "off"
+        if respawn not in ("tmux_new_session", "off"):
+            log.warning("context_rotation: invalid respawn mode %r, defaulting to 'off'", respawn)
+            respawn = "off"
+
+        handoff_template = data.get("handoff_template", "default")
+
+        return cls(
+            enabled=enabled,
+            trigger=trigger,
+            min_boundaries_between_rotations=min_boundaries,
+            pct_ceiling=pct_ceiling,
+            respawn=respawn,
+            handoff_template=handoff_template,
+        )
+
+
+# ---------------------------------------------------------------------------
+# decide_rotation — pure
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RotationDecision:
+    should_rotate: bool
+    reason: str
+
+
+def decide_rotation(
+    *,
+    policy: RotationPolicy,
+    at_governance_boundary: bool,
+    boundaries_since_last_rotation: int,
+    context_pct: Optional[float] = None,
+    mid_action: bool = False,
+) -> RotationDecision:
+    """Pure decision function — no I/O, no side effects.
+
+    Gates, in order: enabled -> never mid-action -> must be at a governance
+    boundary -> durable boundary-count debounce (bypassable only by the
+    optional pct_ceiling backstop, which still requires being at a boundary).
+    """
+    if not policy.enabled:
+        return RotationDecision(False, "disabled")
+    if mid_action:
+        return RotationDecision(False, "mid_action")
+    if not at_governance_boundary:
+        return RotationDecision(False, "not_at_boundary")
+    if policy.trigger != "governance_boundary":
+        # Only governance_boundary is implemented (verified round 1: no
+        # reliable live-% signal for interactive T0).
+        return RotationDecision(False, f"unsupported_trigger:{policy.trigger}")
+
+    debounced = boundaries_since_last_rotation < policy.min_boundaries_between_rotations
+    pct_backstop = (
+        policy.pct_ceiling is not None
+        and context_pct is not None
+        and context_pct >= policy.pct_ceiling
+    )
+
+    if not debounced:
+        return RotationDecision(True, "boundary_debounce_cleared")
+    if pct_backstop:
+        return RotationDecision(True, "pct_ceiling_backstop")
+    return RotationDecision(False, "debounced")
+
+
+# ---------------------------------------------------------------------------
+# write_t0_handoff — REAL, project_id-scoped, fail-soft per source
+# ---------------------------------------------------------------------------
+
+def _git_snapshot(project_root: Path) -> Dict[str, Any]:
+    def _run(*args: str) -> str:
+        try:
+            return subprocess.check_output(
+                ["git", "-C", str(project_root), *args],
+                stderr=subprocess.DEVNULL,
+                text=True,
+                timeout=5,
+            ).strip()
+        except Exception:  # noqa: BLE001 - fail-soft, this is best-effort context
+            return ""
+
+    branch = _run("rev-parse", "--abbrev-ref", "HEAD") or "unknown"
+    status_out = _run("status", "--porcelain")
+    status_lines = [l for l in status_out.splitlines() if l.strip()] if status_out else []
+    log_out = _run("log", "--oneline", "-5")
+    commits = [l.strip() for l in log_out.splitlines() if l.strip()] if log_out else []
+    return {"branch": branch, "status_lines": status_lines, "commits": commits}
+
+
+def _horizon_snapshot(project_id: str) -> Dict[str, Any]:
+    """Best-effort NOW/NEXT tracks + their unresolved open items.
+
+    Fail-soft: any failure (missing DB, schema mismatch, import error)
+    returns an empty-but-well-formed snapshot rather than raising, so a
+    handoff is still written.
+    """
+    empty: Dict[str, Any] = {"now": [], "next": [], "open_items": [], "error": None}
+    try:
+        import tracks as _tracks  # scripts/lib/tracks.py
+    except Exception as exc:  # noqa: BLE001
+        log.warning("context_rotation: tracks module unavailable: %s", exc)
+        empty["error"] = str(exc)
+        return empty
+
+    state_dir = resolve_central_data_dir(project_id) / "state"
+    try:
+        rows = _tracks.list_tracks(state_dir, project_id)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("context_rotation: horizon read failed: %s", exc)
+        empty["error"] = str(exc)
+        return empty
+
+    now_tracks = [r for r in rows if r.get("horizon") == "now"]
+    next_tracks = [r for r in rows if r.get("horizon") == "next"]
+
+    open_items: List[Dict[str, Any]] = []
+    for row in now_tracks + next_tracks:
+        track_id = row.get("track_id")
+        if not track_id:
+            continue
+        try:
+            ois = _tracks.get_linked_open_items(state_dir, track_id, project_id)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("context_rotation: open-items read failed for %s: %s", track_id, exc)
+            continue
+        for oi in ois:
+            open_items.append({"track_id": track_id, **oi})
+
+    return {"now": now_tracks, "next": next_tracks, "open_items": open_items, "error": None}
+
+
+def write_t0_handoff(*, logdir: Path, project_root: Path, project_id: str) -> Path:
+    """Write the repo handoff.md contract to <logdir>/handoff.md.
+
+    Contract (docs/operations/CONTEXT_ROTATION.md): frontmatter (context,
+    project, date, branch) + `## Waar we middenin zitten` / `## State` /
+    `## Next steps`. Fail-soft per source — a git or horizon-read failure
+    degrades that section's content, it never prevents the handoff from
+    being written.
+    """
+    logdir = Path(logdir)
+    logdir.mkdir(parents=True, exist_ok=True)
+    project_root = Path(project_root)
+
+    try:
+        git = _git_snapshot(project_root)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("context_rotation: git snapshot failed: %s", exc)
+        git = {"branch": "unknown", "status_lines": [], "commits": []}
+
+    try:
+        horizon = _horizon_snapshot(project_id)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("context_rotation: horizon snapshot failed: %s", exc)
+        horizon = {"now": [], "next": [], "open_items": [], "error": str(exc)}
+
+    now_iso = _iso(_utc_now())
+    branch = git.get("branch") or "unknown"
+    status_lines = git.get("status_lines") or []
+    commits = git.get("commits") or []
+    now_tracks = horizon.get("now") or []
+    next_tracks = horizon.get("next") or []
+    open_items = horizon.get("open_items") or []
+
+    lines: List[str] = []
+    lines.append("---")
+    lines.append("context: t0-rotation")
+    lines.append(f"project: {project_id}")
+    lines.append(f"date: {now_iso}")
+    lines.append(f"branch: {branch}")
+    lines.append("---")
+    lines.append("")
+    lines.append("# T0 Context Rotation Handoff")
+    lines.append("")
+
+    lines.append("## Waar we middenin zitten")
+    lines.append("")
+    if status_lines:
+        lines.append(f"Uncommitted changes present ({len(status_lines)} file(s)) on branch `{branch}`.")
+    else:
+        lines.append(f"Working tree clean on branch `{branch}`.")
+    if now_tracks:
+        titles = ", ".join(
+            f"{t.get('track_id', '?')} ({t.get('title', '?')})" for t in now_tracks[:5]
+        )
+        lines.append(f"Active NOW-horizon tracks: {titles}.")
+    else:
+        lines.append("No tracks currently in the NOW horizon.")
+    if open_items:
+        lines.append(f"{len(open_items)} unresolved open item(s) linked to active tracks — see State below.")
+    lines.append("")
+
+    lines.append("## State")
+    lines.append("")
+    lines.append(f"- Branch: `{branch}`")
+    lines.append(f"- Uncommitted files: {len(status_lines)}")
+    for sl in status_lines[:20]:
+        lines.append(f"  - `{sl}`")
+    lines.append("- Last commits:")
+    for c in commits[:5]:
+        lines.append(f"  - {c}")
+    if not commits:
+        lines.append("  - (none available)")
+    lines.append(f"- Horizon NOW tracks: {len(now_tracks)}")
+    for t in now_tracks[:10]:
+        lines.append(f"  - `{t.get('track_id')}` — {t.get('title', '')} (phase={t.get('phase')})")
+    lines.append(f"- Horizon NEXT tracks: {len(next_tracks)}")
+    for t in next_tracks[:10]:
+        lines.append(f"  - `{t.get('track_id')}` — {t.get('title', '')} (phase={t.get('phase')})")
+    lines.append(f"- Unresolved open items: {len(open_items)}")
+    for oi in open_items[:15]:
+        lines.append(f"  - `{oi.get('track_id')}` / {oi.get('oi_id')} ({oi.get('link_type')})")
+    lines.append("")
+
+    lines.append("## Next steps")
+    lines.append("")
+    if open_items:
+        lines.append("Unresolved open items on active tracks:")
+        for oi in open_items[:10]:
+            lines.append(f"- `{oi.get('track_id')}` / {oi.get('oi_id')} ({oi.get('link_type')})")
+    elif now_tracks:
+        lines.append("Continue work on the active NOW-horizon tracks:")
+        for t in now_tracks[:10]:
+            lines.append(f"- `{t.get('track_id')}` — {t.get('title', '')}")
+    else:
+        lines.append("No pending horizon items detected. Run `vnx horizon list` to check for newly queued work.")
+    lines.append("")
+
+    handoff_path = logdir / HANDOFF_FILENAME
+    tmp = handoff_path.with_suffix(handoff_path.suffix + ".tmp")
+    tmp.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    os.replace(tmp, handoff_path)
+    return handoff_path
+
+
+# ---------------------------------------------------------------------------
+# respawn — NON-DESTRUCTIVE tmux new-session + bounded readiness wait
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RespawnResult:
+    success: bool
+    reason: str
+    session_name: Optional[str] = None
+    rotation_id: Optional[str] = None
+    waited_seconds: float = 0.0
+
+
+def _build_resume_prompt(*, terminal: str, rotation_id: str, project_id: str, handoff_path: Path) -> str:
+    return (
+        "Context rotation resume. Read the handoff, then run: "
+        f"vnx handoff show --mark-ready --terminal {terminal} "
+        f"--rotation-id {rotation_id} --project-id {project_id}\n"
+        f"(handoff: {handoff_path})"
+    )
+
+
+def _default_tmux_spawn(
+    session_name: str,
+    project_root: str,
+    resume_prompt: str,
+    *,
+    boot_delay_seconds: float = 3.0,
+) -> None:
+    """Spawn a fresh, bare interactive `claude` in a new detached tmux session.
+
+    Guard-safety (round-3 finding #5): every subprocess call here has argv[0]
+    == "tmux" — `claude` only ever appears as a later positional argument to
+    `tmux send-keys` (a single quoted string), never as the executable being
+    run in the outer command. scripts/hooks/pretooluse_spawn_detector.py's
+    _classify_argv() hard-blocks on `exe == "claude"` with a dangerous flag in
+    the SAME argv — that condition structurally never occurs here, and the
+    interactive `claude` invocation itself carries no -p/--print/
+    --dangerously-skip-permissions flag (the "Always allowed... claude
+    (benign/interactive)" case documented in that hook's own header comment).
+    In production this call happens inside an already-running python process
+    (not as a literal Bash-tool-call string the guard inspects), so the guard
+    is not even in the invocation path — this structure is defense-in-depth
+    on top of that.
+    """
+    subprocess.run(
+        ["tmux", "new-session", "-d", "-s", session_name, "-c", project_root],
+        check=True,
+        timeout=10,
+    )
+    subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", "claude"], check=True, timeout=10)
+    subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
+    if boot_delay_seconds > 0:
+        time.sleep(boot_delay_seconds)
+    subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", resume_prompt], check=True, timeout=10)
+    subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
+
+
+def _default_tmux_kill(session_name: str) -> None:
+    """Reap an orphan tmux session. Only ever called with a session_name this
+    module itself just created for a failed respawn attempt — never the
+    caller's own/current session (non-destructive guarantee)."""
+    subprocess.run(["tmux", "kill-session", "-t", session_name], check=False, timeout=10)
+
+
+def _check_ready(ready_path: Path, rotation_id: str) -> bool:
+    data = _load_json_safe(ready_path)
+    if not data:
+        return False
+    return data.get("rotation_id") == rotation_id
+
+
+def write_ready_signal(project_id: str, terminal: str, rotation_id: str) -> Path:
+    """Write the rotation_id-stamped `.ready` signal a waiting respawn() call
+    checks for. Called by the successor session (`vnx handoff mark-ready` /
+    `vnx handoff show --mark-ready`) once it has resumed — round-3 finding
+    #6: the rotation_id is what lets the waiter reject a stale `.ready` left
+    over from a previous rotation.
+    """
+    ready_path = ready_signal_path(project_id, terminal)
+    _write_json_atomic(ready_path, {
+        "rotation_id": rotation_id,
+        "terminal": terminal,
+        "marked_at": _iso(_utc_now()),
+    })
+    return ready_path
+
+
+def respawn(
+    *,
+    handoff_path: Path,
+    terminal: str,
+    project_id: str,
+    project_root: Path,
+    rotation_id: Optional[str] = None,
+    timeout_seconds: float = 60.0,
+    poll_interval_seconds: float = 0.5,
+    tmux_spawn_fn: Optional[Callable[[str, str, str], None]] = None,
+    tmux_kill_fn: Optional[Callable[[str], None]] = None,
+    sleep_fn: Callable[[float], None] = time.sleep,
+    time_fn: Callable[[], float] = time.monotonic,
+) -> RespawnResult:
+    """NON-DESTRUCTIVE respawn: tmux new-session -d a fresh T0, wait bounded
+    for its rotation_id-stamped `.ready` signal.
+
+    Never touches the caller's own session — no `vnx start`, no kill of an
+    existing session. On timeout, ABORTs: reaps the orphan session THIS call
+    spawned (round-3 finding #4) and returns success=False; the caller is
+    responsible for leaving all other state (handoff, durable counter) intact
+    so the next boundary can retry (round-3 finding #3).
+    """
+    spawn = tmux_spawn_fn or _default_tmux_spawn
+    kill = tmux_kill_fn or _default_tmux_kill
+    rotation_id = rotation_id or uuid.uuid4().hex[:12]
+
+    ready_path = ready_signal_path(project_id, terminal)
+    ready_path.parent.mkdir(parents=True, exist_ok=True)
+
+    session_name = f"vnx-t0-rotation-{terminal.lower()}-{rotation_id[:8]}"
+    resume_prompt = _build_resume_prompt(
+        terminal=terminal, rotation_id=rotation_id, project_id=project_id, handoff_path=handoff_path,
+    )
+
+    try:
+        spawn(session_name, str(project_root), resume_prompt)
+    except Exception as exc:  # noqa: BLE001
+        log.error("context_rotation: respawn spawn failed for %s: %s", session_name, exc)
+        return RespawnResult(success=False, reason=f"spawn_failed:{exc}", session_name=session_name, rotation_id=rotation_id)
+
+    start = time_fn()
+    while True:
+        if _check_ready(ready_path, rotation_id):
+            return RespawnResult(
+                success=True, reason="ready", session_name=session_name,
+                rotation_id=rotation_id, waited_seconds=time_fn() - start,
+            )
+        elapsed = time_fn() - start
+        if elapsed >= timeout_seconds:
+            log.error(
+                "context_rotation: ABORT — no ready signal for terminal=%s rotation_id=%s "
+                "within %.1fs; reaping orphan session %s (old session retained)",
+                terminal, rotation_id, timeout_seconds, session_name,
+            )
+            try:
+                kill(session_name)
+            except Exception as exc:  # noqa: BLE001
+                log.error("context_rotation: failed to reap orphan session %s: %s", session_name, exc)
+            return RespawnResult(
+                success=False, reason="timeout_no_ready", session_name=session_name,
+                rotation_id=rotation_id, waited_seconds=elapsed,
+            )
+        sleep_fn(poll_interval_seconds)
+
+
+# ---------------------------------------------------------------------------
+# checkpoint — THE integration point
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RotationOutcome:
+    rotated: bool
+    reason: str
+    handoff_path: Optional[Path] = None
+    marker_path: Optional[Path] = None
+    respawn_result: Optional[RespawnResult] = None
+    rotation_id: Optional[str] = None
+
+
+def _emit_continuation_receipt(
+    *, terminal: str, dispatch_id: str, handoff_path: str, context_pct: Optional[float], project_id: str,
+) -> None:
+    """Emit the EXISTING context_rotation_continuation event (round-3 finding
+    #1) that scripts/lib/conversation_read_model.py chains on by dispatch_id.
+    Same field shape as the legacy worker rotation emitter
+    (hooks/vnx_rotate.sh) so both producers feed one read model. Fail-soft:
+    a receipt-emission failure must never undo an already-successful
+    rotation, so this only logs loudly on failure.
+    """
+    receipt = {
+        "event_type": "context_rotation_continuation",
+        "terminal": terminal,
+        "dispatch_id": dispatch_id,
+        "handover_path": handoff_path,
+        "skill": "t0-orchestrator",
+        "context_used_pct_at_rotation": int(context_pct) if context_pct is not None else 0,
+        "timestamp": _iso(_utc_now()),
+        "project_id": project_id,
+        "source": "context_rotation",
+    }
+    try:
+        from append_receipt import append_receipt_payload
+        append_receipt_payload(receipt)
+    except Exception as exc:  # noqa: BLE001
+        log.error("context_rotation: failed to emit context_rotation_continuation receipt: %s", exc)
+
+
+def _load_durable(path: Path) -> Dict[str, Any]:
+    data = _load_json_safe(path)
+    if not isinstance(data, dict):
+        data = {}
+    data.setdefault("boundaries_since_last_rotation", 0)
+    data.setdefault("last_rotation_at", None)
+    return data
+
+
+def checkpoint(
+    *,
+    at_governance_boundary: bool = True,
+    project_id: str,
+    context_pct: Optional[float] = None,
+    terminal: str = DEFAULT_TERMINAL,
+    project_root: Optional[Path] = None,
+    policy: Optional[RotationPolicy] = None,
+    respawn_fn: Optional[Callable[..., RespawnResult]] = None,
+    now_fn: Callable[[], datetime] = _utc_now,
+    request_ttl_seconds: float = 120.0,
+) -> RotationOutcome:
+    """The integration point a running T0 calls at a governance boundary.
+
+    Loads policy + durable state (both project_id/terminal-scoped), decides
+    via decide_rotation(), and on a decided rotation writes handoff.md + a
+    request marker, then (if policy.respawn == "tmux_new_session") invokes
+    respawn(). The durable debounce counter only resets — and
+    context_rotation_continuation only fires — after a CONFIRMED success
+    (respawn ready, or immediately when respawn is "off"). An ABORTed respawn
+    leaves the counter untouched (round-3 finding #3) so a later boundary can
+    retry, and does not emit the continuation receipt (round-3 finding #1:
+    "on a successful rotate" only).
+
+    Idempotent: a request marker with status "in_progress" younger than
+    request_ttl_seconds short-circuits a duplicate call to a no-op instead of
+    writing a second handoff/marker or invoking respawn() twice.
+    """
+    policy = policy or RotationPolicy.load()
+    if not policy.enabled:
+        return RotationOutcome(rotated=False, reason="disabled")
+
+    resolved_project_root = Path(project_root) if project_root else Path.cwd()
+    state_dir = rotation_state_dir(project_id)
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    durable_path = durable_state_path(project_id, terminal)
+    durable = _load_durable(durable_path)
+
+    request_path = request_marker_path(project_id, terminal)
+    now = now_fn()
+    in_flight = _load_json_safe(request_path)
+    if in_flight and in_flight.get("status") == "in_progress":
+        created_at = in_flight.get("created_at")
+        if created_at and _seconds_since(created_at, now) < request_ttl_seconds:
+            return RotationOutcome(
+                rotated=False, reason="already_in_progress", rotation_id=in_flight.get("rotation_id"),
+            )
+        # Stale in_progress marker (a previous attempt crashed mid-flight
+        # without ever writing an outcome) — fall through and retry.
+
+    decision = decide_rotation(
+        policy=policy,
+        at_governance_boundary=at_governance_boundary,
+        boundaries_since_last_rotation=durable.get("boundaries_since_last_rotation", 0),
+        context_pct=context_pct,
+    )
+
+    if not decision.should_rotate:
+        if at_governance_boundary:
+            durable["boundaries_since_last_rotation"] = durable.get("boundaries_since_last_rotation", 0) + 1
+            _write_json_atomic(durable_path, durable)
+        return RotationOutcome(rotated=False, reason=decision.reason)
+
+    rotation_id = uuid.uuid4().hex[:12]
+    _write_json_atomic(request_path, {
+        "rotation_id": rotation_id, "status": "in_progress", "created_at": _iso(now),
+    })
+
+    handoff_dir = rotation_handoff_dir(project_id, terminal)
+    try:
+        handoff_path = write_t0_handoff(
+            logdir=handoff_dir, project_root=resolved_project_root, project_id=project_id,
+        )
+    except Exception as exc:  # noqa: BLE001
+        log.error("context_rotation: handoff write failed, aborting rotation: %s", exc)
+        _write_json_atomic(request_path, {
+            "rotation_id": rotation_id, "status": "aborted", "created_at": _iso(now),
+            "reason": f"handoff_write_failed:{exc}",
+        })
+        return RotationOutcome(rotated=False, reason="handoff_write_failed", rotation_id=rotation_id)
+
+    respawn_result: Optional[RespawnResult] = None
+    confirmed = True
+    if policy.respawn == "tmux_new_session":
+        respawn_impl = respawn_fn or respawn
+        respawn_result = respawn_impl(
+            handoff_path=handoff_path, terminal=terminal, project_id=project_id,
+            project_root=resolved_project_root, rotation_id=rotation_id,
+        )
+        confirmed = respawn_result.success
+
+    if confirmed:
+        durable["boundaries_since_last_rotation"] = 0
+        durable["last_rotation_at"] = _iso(now_fn())
+        _write_json_atomic(durable_path, durable)
+        _write_json_atomic(request_path, {
+            "rotation_id": rotation_id, "status": "success", "created_at": _iso(now),
+        })
+        _emit_continuation_receipt(
+            terminal=terminal, dispatch_id=rotation_id, handoff_path=str(handoff_path),
+            context_pct=context_pct, project_id=project_id,
+        )
+        return RotationOutcome(
+            rotated=True, reason=decision.reason, handoff_path=handoff_path,
+            marker_path=request_path, respawn_result=respawn_result, rotation_id=rotation_id,
+        )
+
+    abort_reason = respawn_result.reason if respawn_result else "unknown"
+    _write_json_atomic(request_path, {
+        "rotation_id": rotation_id, "status": "aborted", "created_at": _iso(now), "reason": abort_reason,
+    })
+    log.error(
+        "context_rotation: ABORT rotation_id=%s terminal=%s reason=%s — old session retained, "
+        "handoff kept at %s, debounce counter NOT reset (retry eligible next boundary)",
+        rotation_id, terminal, abort_reason, handoff_path,
+    )
+    return RotationOutcome(
+        rotated=False, reason=f"abort:{abort_reason}", handoff_path=handoff_path,
+        marker_path=request_path, respawn_result=respawn_result, rotation_id=rotation_id,
+    )

--- a/scripts/lib/context_rotation.py
+++ b/scripts/lib/context_rotation.py
@@ -42,6 +42,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 import time
@@ -74,11 +75,30 @@ _ROTATION_SUBDIR = ("rotation_handovers",)
 _STATE_SUBDIR = ("state", "rotation")
 _CONFIG_RELATIVE_PATH = Path("configs") / "context_rotation.yaml"
 
+# Terminal names flow into path components below (rotation_handoff_dir,
+# durable_state_path, request_marker_path, ready_signal_path). The CLI
+# `--terminal` flag (vnx handoff show/mark-ready) is untrusted input — a
+# value like "../../../../.ssh/x" would otherwise let a caller write files
+# outside the central data dir (path traversal). Only a bare identifier is
+# accepted; no separators, no "..".
+_TERMINAL_NAME_RE = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _validate_terminal(terminal: str) -> str:
+    """Reject any terminal value that isn't a safe, bare path component."""
+    if not isinstance(terminal, str) or not _TERMINAL_NAME_RE.match(terminal):
+        raise ValueError(
+            f"invalid terminal name {terminal!r}: must match {_TERMINAL_NAME_RE.pattern!r}"
+        )
+    return terminal
+
 
 # ---------------------------------------------------------------------------
 # Path helpers (all project_id-scoped via resolve_central_data_dir — ADR-007 /
 # round-3 finding #8: shared central installs must never collide across
-# projects).
+# projects). `terminal` is validated via _validate_terminal() in every helper
+# below — it is the single choke point untrusted --terminal input passes
+# through before becoming a path component.
 # ---------------------------------------------------------------------------
 
 def rotation_state_dir(project_id: str) -> Path:
@@ -86,18 +106,22 @@ def rotation_state_dir(project_id: str) -> Path:
 
 
 def rotation_handoff_dir(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    terminal = _validate_terminal(terminal)
     return resolve_central_data_dir(project_id).joinpath(*_ROTATION_SUBDIR, terminal)
 
 
 def durable_state_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    terminal = _validate_terminal(terminal)
     return rotation_state_dir(project_id) / f"{terminal}_durable.json"
 
 
 def request_marker_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    terminal = _validate_terminal(terminal)
     return rotation_state_dir(project_id) / f"{terminal}_request.json"
 
 
 def ready_signal_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+    terminal = _validate_terminal(terminal)
     return rotation_state_dir(project_id) / f"{terminal}.ready"
 
 
@@ -467,6 +491,19 @@ def _build_resume_prompt(*, terminal: str, rotation_id: str, project_id: str, ha
     )
 
 
+class SpawnPartialFailure(RuntimeError):
+    """Raised by a tmux_spawn_fn when the tmux session was already created
+    before a LATER step (send-keys, etc.) failed. Distinct from a spawn that
+    raises before anything was created — this tells respawn() the session
+    may exist and is worth reaping (round-3-follow-up finding: an exception
+    after `tmux new-session` succeeds must not leave an orphan session)."""
+
+    def __init__(self, session_name: str, cause: BaseException) -> None:
+        super().__init__(f"partial spawn failure for session {session_name!r}: {cause}")
+        self.session_name = session_name
+        self.cause = cause
+
+
 def _default_tmux_spawn(
     session_name: str,
     project_root: str,
@@ -489,18 +526,26 @@ def _default_tmux_spawn(
     (not as a literal Bash-tool-call string the guard inspects), so the guard
     is not even in the invocation path — this structure is defense-in-depth
     on top of that.
+
+    If `tmux new-session` itself fails, the session was never created and the
+    exception propagates as-is (nothing to reap). If any LATER step fails,
+    the session already exists — that failure is wrapped in
+    SpawnPartialFailure so respawn() knows to kill it before returning.
     """
     subprocess.run(
         ["tmux", "new-session", "-d", "-s", session_name, "-c", project_root],
         check=True,
         timeout=10,
     )
-    subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", "claude"], check=True, timeout=10)
-    subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
-    if boot_delay_seconds > 0:
-        time.sleep(boot_delay_seconds)
-    subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", resume_prompt], check=True, timeout=10)
-    subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
+    try:
+        subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", "claude"], check=True, timeout=10)
+        subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
+        if boot_delay_seconds > 0:
+            time.sleep(boot_delay_seconds)
+        subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", resume_prompt], check=True, timeout=10)
+        subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
+    except Exception as exc:  # noqa: BLE001 - re-raised wrapped, not swallowed
+        raise SpawnPartialFailure(session_name, exc) from exc
 
 
 def _default_tmux_kill(session_name: str) -> None:
@@ -554,7 +599,10 @@ def respawn(
     existing session. On timeout, ABORTs: reaps the orphan session THIS call
     spawned (round-3 finding #4) and returns success=False; the caller is
     responsible for leaving all other state (handoff, durable counter) intact
-    so the next boundary can retry (round-3 finding #3).
+    so the next boundary can retry (round-3 finding #3). A spawn that fails
+    AFTER the tmux session was already created (SpawnPartialFailure) is
+    reaped the same way — a raw spawn failure before anything existed is not
+    (there is nothing to reap).
     """
     spawn = tmux_spawn_fn or _default_tmux_spawn
     kill = tmux_kill_fn or _default_tmux_kill
@@ -570,6 +618,20 @@ def respawn(
 
     try:
         spawn(session_name, str(project_root), resume_prompt)
+    except SpawnPartialFailure as exc:
+        log.error(
+            "context_rotation: respawn spawn partially failed for %s (session may exist): %s "
+            "— reaping to avoid an orphan T0",
+            session_name, exc,
+        )
+        try:
+            kill(session_name)
+        except Exception as kill_exc:  # noqa: BLE001
+            log.error("context_rotation: failed to reap partially-spawned session %s: %s", session_name, kill_exc)
+        return RespawnResult(
+            success=False, reason=f"spawn_partial_failure:{exc.cause}",
+            session_name=session_name, rotation_id=rotation_id,
+        )
     except Exception as exc:  # noqa: BLE001
         log.error("context_rotation: respawn spawn failed for %s: %s", session_name, exc)
         return RespawnResult(success=False, reason=f"spawn_failed:{exc}", session_name=session_name, rotation_id=rotation_id)

--- a/scripts/lib/context_rotation.py
+++ b/scripts/lib/context_rotation.py
@@ -65,7 +65,7 @@ for _p in (str(_LIB_DIR), str(_SCRIPTS_DIR)):
     if _p not in sys.path:
         sys.path.insert(0, _p)
 
-from vnx_paths import resolve_central_data_dir  # noqa: E402
+from vnx_paths import resolve_central_data_dir, _resolve_state_root  # noqa: E402
 
 log = logging.getLogger(__name__)
 
@@ -94,35 +94,64 @@ def _validate_terminal(terminal: str) -> str:
 
 
 # ---------------------------------------------------------------------------
-# Path helpers (all project_id-scoped via resolve_central_data_dir — ADR-007 /
-# round-3 finding #8: shared central installs must never collide across
-# projects). `terminal` is validated via _validate_terminal() in every helper
-# below — it is the single choke point untrusted --terminal input passes
-# through before becoming a path component.
+# Path helpers (all project_id-scoped, resolved via the SAME canonical
+# resolver every other VNX surface uses — vnx_paths._resolve_state_root —
+# anchored on `project_root`. This deliberately does NOT hardcode
+# ~/.vnx-data/<project_id>: that central path is only used when this project
+# ALREADY resolves there (existing central install). For a project that
+# currently lives in project-local or XDG state, forcing the central path
+# would create ~/.vnx-data/<project_id> as a side effect of the FIRST
+# rotation call — after which vnx_paths' existence-gated central branch
+# would prefer that now-existing (but empty) dir over the project's real
+# store for every subsequent `vnx track`/`vnx horizon`/`status` call: a
+# state-store split-brain (ADR-026 / central-store class). `terminal` is
+# validated via _validate_terminal() in every helper below — it is the
+# single choke point untrusted --terminal input passes through before
+# becoming a path component.
 # ---------------------------------------------------------------------------
 
-def rotation_state_dir(project_id: str) -> Path:
-    return resolve_central_data_dir(project_id).joinpath(*_STATE_SUBDIR)
+def _project_data_root(project_id: str, project_root: Optional[Path] = None) -> Path:
+    """Resolve the data root THIS project already uses (central, project-local,
+    or XDG) — never forces ~/.vnx-data/<project_id> into existence when the
+    project doesn't already resolve there. `project_root` defaults to the
+    current working directory (matching checkpoint()'s own default) when not
+    supplied.
+    """
+    resolve_central_data_dir(project_id)  # validate project_id shape (ADR-007); raises ValueError on malformed input
+    root = Path(project_root) if project_root is not None else Path.cwd()
+    return _resolve_state_root(project_id, root)
 
 
-def rotation_handoff_dir(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+def rotation_state_dir(project_id: str, project_root: Optional[Path] = None) -> Path:
+    return _project_data_root(project_id, project_root).joinpath(*_STATE_SUBDIR)
+
+
+def rotation_handoff_dir(
+    project_id: str, terminal: str = DEFAULT_TERMINAL, project_root: Optional[Path] = None
+) -> Path:
     terminal = _validate_terminal(terminal)
-    return resolve_central_data_dir(project_id).joinpath(*_ROTATION_SUBDIR, terminal)
+    return _project_data_root(project_id, project_root).joinpath(*_ROTATION_SUBDIR, terminal)
 
 
-def durable_state_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+def durable_state_path(
+    project_id: str, terminal: str = DEFAULT_TERMINAL, project_root: Optional[Path] = None
+) -> Path:
     terminal = _validate_terminal(terminal)
-    return rotation_state_dir(project_id) / f"{terminal}_durable.json"
+    return rotation_state_dir(project_id, project_root) / f"{terminal}_durable.json"
 
 
-def request_marker_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+def request_marker_path(
+    project_id: str, terminal: str = DEFAULT_TERMINAL, project_root: Optional[Path] = None
+) -> Path:
     terminal = _validate_terminal(terminal)
-    return rotation_state_dir(project_id) / f"{terminal}_request.json"
+    return rotation_state_dir(project_id, project_root) / f"{terminal}_request.json"
 
 
-def ready_signal_path(project_id: str, terminal: str = DEFAULT_TERMINAL) -> Path:
+def ready_signal_path(
+    project_id: str, terminal: str = DEFAULT_TERMINAL, project_root: Optional[Path] = None
+) -> Path:
     terminal = _validate_terminal(terminal)
-    return rotation_state_dir(project_id) / f"{terminal}.ready"
+    return rotation_state_dir(project_id, project_root) / f"{terminal}.ready"
 
 
 # ---------------------------------------------------------------------------
@@ -323,7 +352,7 @@ def _git_snapshot(project_root: Path) -> Dict[str, Any]:
     return {"branch": branch, "status_lines": status_lines, "commits": commits}
 
 
-def _horizon_snapshot(project_id: str) -> Dict[str, Any]:
+def _horizon_snapshot(project_id: str, project_root: Optional[Path] = None) -> Dict[str, Any]:
     """Best-effort NOW/NEXT tracks + their unresolved open items.
 
     Fail-soft: any failure (missing DB, schema mismatch, import error)
@@ -338,7 +367,7 @@ def _horizon_snapshot(project_id: str) -> Dict[str, Any]:
         empty["error"] = str(exc)
         return empty
 
-    state_dir = resolve_central_data_dir(project_id) / "state"
+    state_dir = _project_data_root(project_id, project_root) / "state"
     try:
         rows = _tracks.list_tracks(state_dir, project_id)
     except Exception as exc:  # noqa: BLE001
@@ -385,7 +414,7 @@ def write_t0_handoff(*, logdir: Path, project_root: Path, project_id: str) -> Pa
         git = {"branch": "unknown", "status_lines": [], "commits": []}
 
     try:
-        horizon = _horizon_snapshot(project_id)
+        horizon = _horizon_snapshot(project_id, project_root)
     except Exception as exc:  # noqa: BLE001
         log.warning("context_rotation: horizon snapshot failed: %s", exc)
         horizon = {"now": [], "next": [], "open_items": [], "error": str(exc)}
@@ -562,14 +591,16 @@ def _check_ready(ready_path: Path, rotation_id: str) -> bool:
     return data.get("rotation_id") == rotation_id
 
 
-def write_ready_signal(project_id: str, terminal: str, rotation_id: str) -> Path:
+def write_ready_signal(
+    project_id: str, terminal: str, rotation_id: str, project_root: Optional[Path] = None
+) -> Path:
     """Write the rotation_id-stamped `.ready` signal a waiting respawn() call
     checks for. Called by the successor session (`vnx handoff mark-ready` /
     `vnx handoff show --mark-ready`) once it has resumed — round-3 finding
     #6: the rotation_id is what lets the waiter reject a stale `.ready` left
     over from a previous rotation.
     """
-    ready_path = ready_signal_path(project_id, terminal)
+    ready_path = ready_signal_path(project_id, terminal, project_root)
     _write_json_atomic(ready_path, {
         "rotation_id": rotation_id,
         "terminal": terminal,
@@ -608,7 +639,7 @@ def respawn(
     kill = tmux_kill_fn or _default_tmux_kill
     rotation_id = rotation_id or uuid.uuid4().hex[:12]
 
-    ready_path = ready_signal_path(project_id, terminal)
+    ready_path = ready_signal_path(project_id, terminal, project_root)
     ready_path.parent.mkdir(parents=True, exist_ok=True)
 
     session_name = f"vnx-t0-rotation-{terminal.lower()}-{rotation_id[:8]}"
@@ -745,13 +776,13 @@ def checkpoint(
         return RotationOutcome(rotated=False, reason="disabled")
 
     resolved_project_root = Path(project_root) if project_root else Path.cwd()
-    state_dir = rotation_state_dir(project_id)
+    state_dir = rotation_state_dir(project_id, resolved_project_root)
     state_dir.mkdir(parents=True, exist_ok=True)
 
-    durable_path = durable_state_path(project_id, terminal)
+    durable_path = durable_state_path(project_id, terminal, resolved_project_root)
     durable = _load_durable(durable_path)
 
-    request_path = request_marker_path(project_id, terminal)
+    request_path = request_marker_path(project_id, terminal, resolved_project_root)
     now = now_fn()
     in_flight = _load_json_safe(request_path)
     if in_flight and in_flight.get("status") == "in_progress":
@@ -781,7 +812,7 @@ def checkpoint(
         "rotation_id": rotation_id, "status": "in_progress", "created_at": _iso(now),
     })
 
-    handoff_dir = rotation_handoff_dir(project_id, terminal)
+    handoff_dir = rotation_handoff_dir(project_id, terminal, resolved_project_root)
     try:
         handoff_path = write_t0_handoff(
             logdir=handoff_dir, project_root=resolved_project_root, project_id=project_id,

--- a/scripts/lib/handoff_reader.py
+++ b/scripts/lib/handoff_reader.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Repo-level reader for the T0 context-rotation handoff.md contract.
+
+Parses the SAME shape scripts/lib/context_rotation.write_t0_handoff writes:
+frontmatter (context, project, date, branch) + `## Waar we middenin zitten` /
+`## State` / `## Next steps` sections. This is the "missing repo-level
+handoff reader" the rev-3 plan builds — `vnx handoff show` (vnx_cli/commands/
+handoff.py) is the CLI entry point a freshly-respawned T0 runs to resume.
+
+Full contract: docs/operations/CONTEXT_ROTATION.md.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Optional
+
+_FRONTMATTER_RE = re.compile(r"^---\n(.*?)\n---\n", re.DOTALL)
+_SECTION_RE = re.compile(r"^##\s+(.+?)\s*$", re.MULTILINE)
+
+
+@dataclass
+class HandoffBriefing:
+    context: str = ""
+    project: str = ""
+    date: str = ""
+    branch: str = ""
+    waar_we_middenin_zitten: str = ""
+    state: str = ""
+    next_steps: str = ""
+    raw: str = ""
+
+
+def _parse_frontmatter(text: str) -> Dict[str, str]:
+    match = _FRONTMATTER_RE.match(text)
+    if not match:
+        return {}
+    fields: Dict[str, str] = {}
+    for line in match.group(1).splitlines():
+        if ":" not in line:
+            continue
+        key, _, value = line.partition(":")
+        fields[key.strip()] = value.strip()
+    return fields
+
+
+def _parse_sections(text: str) -> Dict[str, str]:
+    body = _FRONTMATTER_RE.sub("", text, count=1)
+    matches = list(_SECTION_RE.finditer(body))
+    sections: Dict[str, str] = {}
+    for i, match in enumerate(matches):
+        title = match.group(1).strip()
+        start = match.end()
+        end = matches[i + 1].start() if i + 1 < len(matches) else len(body)
+        sections[title] = body[start:end].strip()
+    return sections
+
+
+def parse_handoff(text: str) -> HandoffBriefing:
+    """Parse raw handoff.md text into a HandoffBriefing. Never raises — a
+    malformed/partial document just yields empty fields."""
+    frontmatter = _parse_frontmatter(text)
+    sections = _parse_sections(text)
+    return HandoffBriefing(
+        context=frontmatter.get("context", ""),
+        project=frontmatter.get("project", ""),
+        date=frontmatter.get("date", ""),
+        branch=frontmatter.get("branch", ""),
+        waar_we_middenin_zitten=sections.get("Waar we middenin zitten", ""),
+        state=sections.get("State", ""),
+        next_steps=sections.get("Next steps", ""),
+        raw=text,
+    )
+
+
+def read_handoff(path: Path) -> Optional[HandoffBriefing]:
+    """Read + parse handoff.md at path. Returns None if missing/unreadable."""
+    resolved = Path(path)
+    if not resolved.is_file():
+        return None
+    try:
+        text = resolved.read_text(encoding="utf-8")
+    except OSError:
+        return None
+    return parse_handoff(text)
+
+
+def format_briefing(briefing: HandoffBriefing) -> str:
+    """Render a HandoffBriefing as the resume text `vnx handoff show` prints."""
+    lines = [
+        f"Context rotation resume — project={briefing.project} branch={briefing.branch} date={briefing.date}",
+        "",
+        "## Waar we middenin zitten",
+        briefing.waar_we_middenin_zitten or "(none recorded)",
+        "",
+        "## State",
+        briefing.state or "(none recorded)",
+        "",
+        "## Next steps",
+        briefing.next_steps or "(none recorded)",
+    ]
+    return "\n".join(lines)

--- a/tests/test_context_rotation.py
+++ b/tests/test_context_rotation.py
@@ -43,6 +43,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
 
 import context_rotation as cr  # noqa: E402
 import handoff_reader as hr  # noqa: E402
+import vnx_paths  # noqa: E402
 
 REPO_ROOT = Path(__file__).parent.parent
 HOOK_PATH = REPO_ROOT / "scripts" / "hooks" / "session_stop_rotation.py"
@@ -382,6 +383,101 @@ class TestCheckpoint:
 
 
 # ---------------------------------------------------------------------------
+# 3b. P1 regression: rotation must use the canonical data root, never
+# first-create a competing ~/.vnx-data/<project_id> central store.
+# ---------------------------------------------------------------------------
+
+class TestRotationUsesCanonicalDataRoot:
+    """A prior version hardcoded resolve_central_data_dir(project_id) in the
+    rotation path helpers. For a project that doesn't already have a central
+    ~/.vnx-data/<project_id> (i.e. it resolves to project-local or XDG
+    state), the FIRST checkpoint() call would nonetheless CREATE
+    ~/.vnx-data/<project_id> as a side effect (via state_dir.mkdir()) —
+    after which vnx_paths._resolve_state_root's existence-gated central
+    branch prefers that now-existing (but empty) dir over the project's
+    real store for every subsequent `vnx track`/`vnx horizon`/`status` call:
+    a state-store split-brain. checkpoint() must resolve (and only ever
+    write under) whatever store this project's project_root ALREADY
+    resolves to via the same canonical resolver the rest of VNX uses.
+    """
+
+    def test_checkpoint_never_creates_competing_central_dir(
+        self, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # Opt out of the autouse VNX_DATA_DIR_EXPLICIT override (see the
+        # comment in test_project_id_scoped_across_two_projects above) — this
+        # test exercises the default central/local/XDG resolution, which the
+        # explicit override would otherwise short-circuit.
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+        # The (separate, pre-existing) Phase-6-P3 receipt dual-write mirror
+        # legitimately writes a cross-project shadow copy of every appended
+        # receipt under resolve_central_data_dir(receipt["project_id"]) —
+        # that subsystem is out of scope here and NOT what this regression
+        # guards. Stub it out so this test only observes context_rotation's
+        # OWN rotation-file path resolution (durable/marker/handoff).
+        monkeypatch.setattr(cr, "_emit_continuation_receipt", lambda **kw: None)
+
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        project_id = "xdg-only-project"
+
+        central_dir = Path.home() / ".vnx-data" / project_id
+        assert not central_dir.exists()
+
+        expected_root = vnx_paths._resolve_state_root(project_id, repo)
+        # Sanity check on the fixture: with no existing central/local store,
+        # the canonical resolver itself lands on the XDG default, not central.
+        assert not str(expected_root).startswith(str(Path.home() / ".vnx-data"))
+
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
+        out = cr.checkpoint(project_id=project_id, policy=policy, project_root=str(repo))
+        assert out.rotated is True
+
+        # Rotation files landed under the SAME root the rest of VNX resolves
+        # to for this project — not a hardcoded central path.
+        assert str(out.handoff_path.resolve()).startswith(str(expected_root.resolve()))
+        assert str(out.marker_path.resolve()).startswith(str(expected_root.resolve()))
+
+        # The P1 bug: checkpoint() must NEVER create a competing
+        # ~/.vnx-data/<project_id> rotation/state tree as a side effect when
+        # the project doesn't already resolve there.
+        assert not central_dir.exists()
+
+        # The store the rest of VNX sees for this project is unchanged
+        # before/after the rotation call.
+        assert vnx_paths._resolve_state_root(project_id, repo) == expected_root
+
+    def test_horizon_snapshot_reads_from_the_same_resolved_root(
+        self, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """The handoff's horizon section must read tracks from the SAME
+        store checkpoint()/write_t0_handoff() resolves to — not a
+        hardcoded central dir the project never actually uses (the exact
+        failure mode described in the P1 finding: the handoff missed the
+        real NOW/NEXT tracks because it read from the wrong, freshly-created
+        empty central store)."""
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        project_id = "xdg-horizon-project"
+
+        resolved_root = vnx_paths._resolve_state_root(project_id, repo)
+        assert not resolved_root.exists()
+
+        logdir = tmp_path / "handoff_out"
+        handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=repo, project_id=project_id)
+
+        # write_t0_handoff must have looked for tracks under resolved_root
+        # (which it just created via mkdir-on-demand inside tracks setup, or
+        # left absent if tracks lazily no-ops) — never under a central dir
+        # this project doesn't use.
+        assert not (Path.home() / ".vnx-data" / project_id).exists()
+        assert handoff_path.is_file()
+
+
+# ---------------------------------------------------------------------------
 # 4. respawn()
 # ---------------------------------------------------------------------------
 
@@ -565,15 +661,15 @@ class TestTerminalValidation:
 
     @pytest.mark.parametrize("bad_terminal", TRAVERSAL_INPUTS)
     def test_traversal_never_escapes_central_dir(self, isolated_home: Path, bad_terminal: str) -> None:
-        central = cr.resolve_central_data_dir(PROJECT_ID)
+        base = cr._project_data_root(PROJECT_ID)
         for helper in self.PATH_HELPERS:
             try:
                 produced = helper(PROJECT_ID, bad_terminal)
             except ValueError:
                 continue  # rejected outright — cannot have escaped anything
             # If a helper somehow didn't raise, the produced path must still
-            # resolve inside the central dir.
-            assert str(produced.resolve()).startswith(str(central.resolve()))
+            # resolve inside the project's resolved data root.
+            assert str(produced.resolve()).startswith(str(base.resolve()))
 
     def test_checkpoint_rejects_malicious_terminal(self, isolated_home: Path) -> None:
         policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
@@ -585,10 +681,10 @@ class TestTerminalValidation:
 
     @pytest.mark.parametrize("good_terminal", ["T0", "T1", "T2", "T3", "my-term_1", "ABC123"])
     def test_valid_terminal_names_still_work(self, isolated_home: Path, good_terminal: str) -> None:
-        central = cr.resolve_central_data_dir(PROJECT_ID)
+        base = cr._project_data_root(PROJECT_ID)
         for helper in self.PATH_HELPERS:
             produced = helper(PROJECT_ID, good_terminal)
-            assert str(produced.resolve()).startswith(str(central.resolve()))
+            assert str(produced.resolve()).startswith(str(base.resolve()))
 
 
 # ---------------------------------------------------------------------------
@@ -615,7 +711,18 @@ class TestWriteT0Handoff:
         assert "## State" in text
         assert "## Next steps" in text
 
-    def test_project_id_scoped_across_two_projects(self, isolated_home: Path, tmp_path: Path) -> None:
+    def test_project_id_scoped_across_two_projects(
+        self, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        # The autouse _vnx_data_dir_isolation conftest fixture pins
+        # VNX_DATA_DIR_EXPLICIT=1 for every test (a safety net against ever
+        # touching the real ~/.vnx-data). That explicit override is, by
+        # design, project_id-independent (it collapses every project onto
+        # one operator-chosen dir) — this test needs the *default*, no
+        # override resolution to exercise project_id-scoping, so it opts
+        # out via the documented escape hatch.
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
         repo = tmp_path / "repo"
         _make_git_repo(repo)
 

--- a/tests/test_context_rotation.py
+++ b/tests/test_context_rotation.py
@@ -459,6 +459,41 @@ class TestRespawn:
         assert result.reason.startswith("spawn_failed")
         assert killed == []
 
+    def test_new_session_ok_then_send_keys_raises_reaps_partial_session(
+        self, isolated_home: Path,
+    ) -> None:
+        """Codex P2: `tmux new-session` succeeds but a later `send-keys`
+        raises. The session that WAS created must be reaped — not left as
+        an orphan/duplicate T0 — and the call must return a clean failure."""
+        killed: List[str] = []
+        calls: List[List[str]] = []
+
+        def flaky_run(cmd: List[str], *args: Any, **kwargs: Any) -> Any:
+            calls.append(list(cmd))
+            if cmd[:2] == ["tmux", "new-session"]:
+                return subprocess.CompletedProcess(cmd, 0)
+            if cmd[:2] == ["tmux", "send-keys"]:
+                raise subprocess.CalledProcessError(1, cmd)
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        import unittest.mock as mock
+        with mock.patch("context_rotation.subprocess.run", side_effect=flaky_run), \
+             mock.patch("context_rotation.time.sleep", lambda *_: None):
+            result = cr.respawn(
+                handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+                project_root=REPO_ROOT, rotation_id="rot-partial",
+                tmux_spawn_fn=cr._default_tmux_spawn,
+                tmux_kill_fn=lambda name: killed.append(name),
+                timeout_seconds=1, poll_interval_seconds=0.01,
+            )
+
+        assert result.success is False
+        assert result.reason.startswith("spawn_partial_failure")
+        # The session that new-session actually created is the ONE reaped —
+        # no orphan left behind, and no duplicate/zero T0.
+        assert killed == [result.session_name]
+        assert any(c[:2] == ["tmux", "new-session"] for c in calls)
+
     def test_never_calls_a_destructive_or_kill_path_on_success(self, isolated_home: Path) -> None:
         """Assert the whole respawn() call graph, when it succeeds, contains
         zero destructive verbs anywhere (no kill-session, no `vnx start`)."""
@@ -491,6 +526,69 @@ class TestRespawn:
         for cmd in calls:
             assert "kill-session" not in cmd
             assert not any("vnx" == c or c.endswith("/vnx") for c in cmd)
+
+
+# ---------------------------------------------------------------------------
+# 4b. Terminal-name path-traversal validation
+# ---------------------------------------------------------------------------
+
+class TestTerminalValidation:
+    """Codex P2: `--terminal` is untrusted CLI input and becomes a path
+    component in every terminal-scoped path helper. A value like
+    "../../../../.ssh/x" must never let a caller escape the central data
+    dir."""
+
+    TRAVERSAL_INPUTS = [
+        "../../../../.ssh/x",
+        "../evil",
+        "T0/../../etc",
+        "a/b",
+        "a\\b",
+        "..",
+        ".",
+        "",
+        "/etc/passwd",
+    ]
+
+    PATH_HELPERS = [
+        cr.rotation_handoff_dir,
+        cr.durable_state_path,
+        cr.request_marker_path,
+        cr.ready_signal_path,
+    ]
+
+    @pytest.mark.parametrize("bad_terminal", TRAVERSAL_INPUTS)
+    def test_path_helpers_reject_traversal(self, isolated_home: Path, bad_terminal: str) -> None:
+        for helper in self.PATH_HELPERS:
+            with pytest.raises(ValueError):
+                helper(PROJECT_ID, bad_terminal)
+
+    @pytest.mark.parametrize("bad_terminal", TRAVERSAL_INPUTS)
+    def test_traversal_never_escapes_central_dir(self, isolated_home: Path, bad_terminal: str) -> None:
+        central = cr.resolve_central_data_dir(PROJECT_ID)
+        for helper in self.PATH_HELPERS:
+            try:
+                produced = helper(PROJECT_ID, bad_terminal)
+            except ValueError:
+                continue  # rejected outright — cannot have escaped anything
+            # If a helper somehow didn't raise, the produced path must still
+            # resolve inside the central dir.
+            assert str(produced.resolve()).startswith(str(central.resolve()))
+
+    def test_checkpoint_rejects_malicious_terminal(self, isolated_home: Path) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
+        with pytest.raises(ValueError):
+            cr.checkpoint(
+                project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT),
+                terminal="../../../../.ssh/x",
+            )
+
+    @pytest.mark.parametrize("good_terminal", ["T0", "T1", "T2", "T3", "my-term_1", "ABC123"])
+    def test_valid_terminal_names_still_work(self, isolated_home: Path, good_terminal: str) -> None:
+        central = cr.resolve_central_data_dir(PROJECT_ID)
+        for helper in self.PATH_HELPERS:
+            produced = helper(PROJECT_ID, good_terminal)
+            assert str(produced.resolve()).startswith(str(central.resolve()))
 
 
 # ---------------------------------------------------------------------------
@@ -620,6 +718,71 @@ class TestSessionStopHook:
         (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
 
         env = {**__import__("os").environ, "HOME": str(isolated_home), "VNX_T0_ROTATION": "1"}
+
+        result = self._run_hook(repo, env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "{}"
+        assert cr.rotation_handoff_dir(PROJECT_ID, "T0").joinpath(cr.HANDOFF_FILENAME).is_file()
+
+    def _seed_t0_handoff_sentinel(self, tmp_path: Path) -> Path:
+        """Pre-existing T0 handoff (simulating a prior real rotation) that a
+        stopping worker's Stop hook must never clobber."""
+        handoff_dir = cr.rotation_handoff_dir(PROJECT_ID, "T0")
+        handoff_dir.mkdir(parents=True, exist_ok=True)
+        sentinel = handoff_dir / cr.HANDOFF_FILENAME
+        sentinel.write_text("SENTINEL-DO-NOT-OVERWRITE\n", encoding="utf-8")
+        return sentinel
+
+    def test_noop_for_non_t0_terminal_env(self, isolated_home: Path, tmp_path: Path) -> None:
+        """Codex P2: the empty-matcher Stop hook fires for every session.
+        A stopping T1 (VNX_TERMINAL=T1) must not write/overwrite the T0
+        handoff."""
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
+        sentinel = self._seed_t0_handoff_sentinel(tmp_path)
+
+        env = {
+            **__import__("os").environ, "HOME": str(isolated_home),
+            "VNX_T0_ROTATION": "1", "VNX_TERMINAL": "T1",
+        }
+
+        result = self._run_hook(repo, env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "{}"
+        assert sentinel.read_text(encoding="utf-8") == "SENTINEL-DO-NOT-OVERWRITE\n"
+
+    def test_noop_for_worker_terminal_cwd(self, isolated_home: Path, tmp_path: Path) -> None:
+        """Same as above but detected purely from cwd (no env var set) —
+        mirrors how a real T1/T2/T3 worker session's cwd looks."""
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
+        sentinel = self._seed_t0_handoff_sentinel(tmp_path)
+
+        worker_cwd = repo / ".claude" / "terminals" / "T2"
+        worker_cwd.mkdir(parents=True, exist_ok=True)
+
+        env = {**__import__("os").environ, "HOME": str(isolated_home), "VNX_T0_ROTATION": "1"}
+        env.pop("VNX_TERMINAL", None)
+        env.pop("VNX_TERMINAL_ID", None)
+
+        result = self._run_hook(worker_cwd, env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "{}"
+        assert sentinel.read_text(encoding="utf-8") == "SENTINEL-DO-NOT-OVERWRITE\n"
+
+    def test_t0_terminal_env_still_writes(self, isolated_home: Path, tmp_path: Path) -> None:
+        """Control case: an explicit VNX_TERMINAL=T0 must still write —
+        scoping must not turn into a blanket no-op."""
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
+
+        env = {
+            **__import__("os").environ, "HOME": str(isolated_home),
+            "VNX_T0_ROTATION": "1", "VNX_TERMINAL": "T0",
+        }
 
         result = self._run_hook(repo, env)
         assert result.returncode == 0

--- a/tests/test_context_rotation.py
+++ b/tests/test_context_rotation.py
@@ -1,0 +1,651 @@
+#!/usr/bin/env python3
+"""Tests for the T0 context-rotation control-plane (rev 3, default OFF).
+
+Design authority: claudedocs/plans/t0-context-rotation-revival.md.
+
+Covers:
+  1. RotationPolicy.load(): default-off (no yaml, no env); env overrides yaml;
+     explicit disabled policy wins regardless of env.
+  2. decide_rotation truth table, incl. durable boundary-count debounce
+     across simulated sessions (a fresh checkpoint() call re-reads the
+     durable JSON from disk each time — no in-memory session state).
+  3. checkpoint(): writes marker+handoff+durable-timestamp on a decided
+     rotation; is a strict no-op when disabled (zero filesystem side
+     effects); is idempotent against a duplicate in-flight call; debounce
+     persists across separate checkpoint() calls ("sessions"); an ABORTed
+     respawn does NOT advance the durable counter/timestamp and does NOT
+     emit the continuation receipt, but DOES allow a later retry.
+  4. respawn(): ready-signal -> success; no-ready-within-timeout -> ABORT
+     (retains handoff/marker, reaps ONLY the orphan session it created,
+     never a "kill"/"vnx start" of any existing/current session).
+  5. write_t0_handoff(): frontmatter + all three sections present,
+     project_id-scoped, fail-soft when git/horizon reads fail.
+  6. handoff_reader: round-trips a written handoff.md.
+  7. session_stop_rotation.py hook: no-op (and no handoff write) when
+     VNX_T0_ROTATION is unset; writes handoff.md when set.
+  8. Guard-safety: the default tmux spawn implementation's argv[0] is always
+     "tmux" — "claude" never appears as an invoked executable, only as a
+     literal send-keys payload with no flags.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).parent.parent / "scripts"))
+
+import context_rotation as cr  # noqa: E402
+import handoff_reader as hr  # noqa: E402
+
+REPO_ROOT = Path(__file__).parent.parent
+HOOK_PATH = REPO_ROOT / "scripts" / "hooks" / "session_stop_rotation.py"
+PROJECT_ID = "vnx-rotation-test"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def isolated_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Isolate resolve_central_data_dir()'s Path.home()-based resolution so
+    tests never touch the real ~/.vnx-data."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
+
+
+def _make_git_repo(path: Path, branch: str = "rotation-test-branch") -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    run = lambda *args: subprocess.run(  # noqa: E731
+        ["git", "-C", str(path), *args], check=True, capture_output=True, text=True,
+    )
+    run("init", "-q")
+    run("config", "user.email", "test@example.com")
+    run("config", "user.name", "Test")
+    run("checkout", "-q", "-b", branch)
+    (path / "README.md").write_text("hello\n", encoding="utf-8")
+    run("add", "README.md")
+    run("commit", "-q", "-m", "initial commit")
+    return None
+
+
+def _enabled_policy(**overrides: Any) -> cr.RotationPolicy:
+    base = dict(enabled=True, min_boundaries_between_rotations=0, respawn="off")
+    base.update(overrides)
+    return cr.RotationPolicy(**base)
+
+
+# ---------------------------------------------------------------------------
+# 1. RotationPolicy.load()
+# ---------------------------------------------------------------------------
+
+class TestRotationPolicyLoad:
+    def test_default_off_no_yaml_no_env(self, tmp_path: Path) -> None:
+        policy = cr.RotationPolicy.load(config_path=tmp_path / "missing.yaml", env={})
+        assert policy.enabled is False
+        assert policy.respawn == "off"
+        assert policy.trigger == "governance_boundary"
+
+    def test_shipped_config_is_disabled(self) -> None:
+        """The repo-committed configs/context_rotation.yaml must itself ship
+        with enabled: false — this is the actual file T0 loads in production."""
+        shipped = REPO_ROOT / "configs" / "context_rotation.yaml"
+        assert shipped.is_file()
+        policy = cr.RotationPolicy.load(config_path=shipped, env={})
+        assert policy.enabled is False
+
+    def test_env_var_enables(self, tmp_path: Path) -> None:
+        policy = cr.RotationPolicy.load(
+            config_path=tmp_path / "missing.yaml", env={"VNX_T0_ROTATION": "1"},
+        )
+        assert policy.enabled is True
+
+    def test_env_var_non_one_does_not_enable(self, tmp_path: Path) -> None:
+        policy = cr.RotationPolicy.load(
+            config_path=tmp_path / "missing.yaml", env={"VNX_T0_ROTATION": "true"},
+        )
+        assert policy.enabled is False
+
+    def test_yaml_enables_when_env_absent(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "context_rotation.yaml"
+        cfg.write_text("enabled: true\nmin_boundaries_between_rotations: 5\n", encoding="utf-8")
+        policy = cr.RotationPolicy.load(config_path=cfg, env={})
+        assert policy.enabled is True
+        assert policy.min_boundaries_between_rotations == 5
+
+    def test_env_overrides_yaml(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "context_rotation.yaml"
+        cfg.write_text("enabled: true\n", encoding="utf-8")
+        policy = cr.RotationPolicy.load(config_path=cfg, env={"VNX_T0_ROTATION": "0"})
+        assert policy.enabled is False
+
+    def test_invalid_respawn_mode_falls_back_to_off(self, tmp_path: Path) -> None:
+        cfg = tmp_path / "context_rotation.yaml"
+        cfg.write_text("respawn: something_destructive\n", encoding="utf-8")
+        policy = cr.RotationPolicy.load(config_path=cfg, env={})
+        assert policy.respawn == "off"
+
+
+# ---------------------------------------------------------------------------
+# 2. decide_rotation truth table
+# ---------------------------------------------------------------------------
+
+class TestDecideRotation:
+    def test_disabled_never_rotates(self) -> None:
+        policy = cr.RotationPolicy(enabled=False, min_boundaries_between_rotations=0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=99,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "disabled"
+
+    def test_mid_action_never_rotates(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=99, mid_action=True,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "mid_action"
+
+    def test_not_at_boundary_never_rotates(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=False, boundaries_since_last_rotation=99,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "not_at_boundary"
+
+    def test_debounced_below_min_boundaries(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=3)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=2,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "debounced"
+
+    def test_rotates_once_debounce_clears(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=3)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=3,
+        )
+        assert decision.should_rotate is True
+        assert decision.reason == "boundary_debounce_cleared"
+
+    def test_pct_ceiling_backstop_bypasses_debounce(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=10, pct_ceiling=80.0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=1, context_pct=85.0,
+        )
+        assert decision.should_rotate is True
+        assert decision.reason == "pct_ceiling_backstop"
+
+    def test_pct_below_ceiling_does_not_bypass_debounce(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=10, pct_ceiling=80.0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=True, boundaries_since_last_rotation=1, context_pct=50.0,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "debounced"
+
+    def test_pct_backstop_still_requires_boundary(self) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=10, pct_ceiling=80.0)
+        decision = cr.decide_rotation(
+            policy=policy, at_governance_boundary=False, boundaries_since_last_rotation=1, context_pct=99.0,
+        )
+        assert decision.should_rotate is False
+        assert decision.reason == "not_at_boundary"
+
+    def test_durable_debounce_across_simulated_sessions(self, isolated_home: Path) -> None:
+        """Each checkpoint() call re-reads durable state from disk — this is
+        what makes the debounce durable ACROSS separate 'sessions' (process
+        invocations), not just in-memory within one."""
+        policy = _enabled_policy(min_boundaries_between_rotations=3, respawn="off")
+
+        # "Session A": three boundary calls, none should rotate yet (0,1,2 < 3).
+        for expected_before in range(3):
+            durable = cr._load_durable(cr.durable_state_path(PROJECT_ID, "T0"))
+            assert durable["boundaries_since_last_rotation"] == expected_before
+            out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+            assert out.rotated is False
+
+        # "Session B" (a brand new checkpoint() call, simulating a fresh
+        # process): the durable counter now reads 3 from disk and rotates.
+        out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+        assert out.rotated is True
+
+        # "Session C": counter was reset to 0 on the confirmed rotation —
+        # immediately debounced again.
+        out2 = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+        assert out2.rotated is False
+        assert out2.reason == "debounced"
+
+
+# ---------------------------------------------------------------------------
+# 3. checkpoint()
+# ---------------------------------------------------------------------------
+
+class TestCheckpoint:
+    def test_disabled_is_zero_side_effect_noop(self, isolated_home: Path) -> None:
+        policy = cr.RotationPolicy(enabled=False)
+        out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+        assert out.rotated is False
+        assert out.reason == "disabled"
+        # Not even the rotation state directory should have been created.
+        assert not cr.rotation_state_dir(PROJECT_ID).exists()
+
+    def test_explicit_disabled_policy_wins_over_env(self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_T0_ROTATION", "1")
+        policy = cr.RotationPolicy(enabled=False)
+        out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+        assert out.rotated is False
+        assert out.reason == "disabled"
+        assert not cr.rotation_state_dir(PROJECT_ID).exists()
+
+    def test_rotation_writes_marker_handoff_and_durable_timestamp(self, isolated_home: Path) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
+        out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+
+        assert out.rotated is True
+        assert out.handoff_path is not None
+        assert out.handoff_path.is_file()
+        assert out.marker_path is not None
+
+        marker = json.loads(out.marker_path.read_text(encoding="utf-8"))
+        assert marker["status"] == "success"
+        assert marker["rotation_id"] == out.rotation_id
+
+        durable = cr._load_durable(cr.durable_state_path(PROJECT_ID, "T0"))
+        assert durable["boundaries_since_last_rotation"] == 0
+        assert durable["last_rotation_at"] is not None
+
+    def test_idempotent_duplicate_call_is_noop(self, isolated_home: Path) -> None:
+        """A duplicate checkpoint() call while a rotation is 'in_progress'
+        must not write a second handoff/marker. min_boundaries=0 isolates
+        this from the normal counter-debounce (which would also block a
+        second call, masking whether the marker itself is doing anything)."""
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
+
+        request_path = cr.request_marker_path(PROJECT_ID, "T0")
+        cr._write_json_atomic(request_path, {
+            "rotation_id": "already-running",
+            "status": "in_progress",
+            "created_at": cr._iso(cr._utc_now()),
+        })
+
+        out = cr.checkpoint(project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT))
+        assert out.rotated is False
+        assert out.reason == "already_in_progress"
+        assert out.rotation_id == "already-running"
+        # No handoff was written for this call.
+        assert not cr.rotation_handoff_dir(PROJECT_ID, "T0").joinpath(cr.HANDOFF_FILENAME).is_file()
+
+    def test_stale_in_progress_marker_allows_retry(self, isolated_home: Path) -> None:
+        """An in_progress marker older than request_ttl_seconds is treated as
+        a crashed attempt, not a live duplicate — the next call proceeds."""
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
+        request_path = cr.request_marker_path(PROJECT_ID, "T0")
+        cr._write_json_atomic(request_path, {
+            "rotation_id": "crashed-attempt",
+            "status": "in_progress",
+            "created_at": "2000-01-01T00:00:00Z",
+        })
+
+        out = cr.checkpoint(
+            project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT), request_ttl_seconds=1.0,
+        )
+        assert out.rotated is True
+        assert out.rotation_id != "crashed-attempt"
+
+    def test_aborted_respawn_does_not_advance_debounce_or_emit_receipt(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="tmux_new_session")
+
+        def fake_respawn(**kwargs: Any) -> cr.RespawnResult:
+            return cr.RespawnResult(success=False, reason="timeout_no_ready", rotation_id=kwargs["rotation_id"])
+
+        emitted: List[Dict[str, Any]] = []
+        monkeypatch.setattr(cr, "_emit_continuation_receipt", lambda **kw: emitted.append(kw))
+
+        out = cr.checkpoint(
+            project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT), respawn_fn=fake_respawn,
+        )
+
+        assert out.rotated is False
+        assert out.reason == "abort:timeout_no_ready"
+        assert emitted == []  # finding #1: receipt only fires on a successful rotate
+
+        durable = cr._load_durable(cr.durable_state_path(PROJECT_ID, "T0"))
+        assert durable["boundaries_since_last_rotation"] == 0  # never advanced past pre-attempt value
+        assert durable["last_rotation_at"] is None  # finding #3: not stamped on abort
+
+        marker = json.loads(cr.request_marker_path(PROJECT_ID, "T0").read_text(encoding="utf-8"))
+        assert marker["status"] == "aborted"
+
+        # Handoff is retained (not deleted) so the operator never loses state.
+        assert out.handoff_path.is_file()
+
+        # A later retry is not blocked by the aborted marker.
+        out2 = cr.checkpoint(
+            project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT), respawn_fn=fake_respawn,
+        )
+        assert out2.reason == "abort:timeout_no_ready"
+        assert out2.rotation_id != out.rotation_id
+
+    def test_successful_respawn_emits_continuation_receipt(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="tmux_new_session")
+
+        def fake_respawn(**kwargs: Any) -> cr.RespawnResult:
+            return cr.RespawnResult(success=True, reason="ready", rotation_id=kwargs["rotation_id"])
+
+        emitted: List[Dict[str, Any]] = []
+        monkeypatch.setattr(cr, "_emit_continuation_receipt", lambda **kw: emitted.append(kw))
+
+        out = cr.checkpoint(
+            project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT), respawn_fn=fake_respawn,
+        )
+        assert out.rotated is True
+        assert len(emitted) == 1
+        assert emitted[0]["terminal"] == "T0"
+        assert emitted[0]["dispatch_id"] == out.rotation_id
+        assert emitted[0]["project_id"] == PROJECT_ID
+
+    def test_handoff_write_failure_aborts_and_never_calls_respawn(
+        self, isolated_home: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="tmux_new_session")
+
+        def boom(**kwargs: Any) -> Path:
+            raise OSError("disk full")
+
+        monkeypatch.setattr(cr, "write_t0_handoff", boom)
+        respawn_calls: List[Any] = []
+
+        out = cr.checkpoint(
+            project_id=PROJECT_ID, policy=policy, project_root=str(REPO_ROOT),
+            respawn_fn=lambda **kw: respawn_calls.append(kw) or cr.RespawnResult(success=True, reason="ready"),
+        )
+        assert out.rotated is False
+        assert out.reason == "handoff_write_failed"
+        assert respawn_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 4. respawn()
+# ---------------------------------------------------------------------------
+
+class TestRespawn:
+    def test_ready_signal_yields_success(self, isolated_home: Path) -> None:
+        spawn_calls: List[Any] = []
+
+        def fake_spawn(session_name: str, project_root: str, resume_prompt: str) -> None:
+            spawn_calls.append(session_name)
+            cr.write_ready_signal(PROJECT_ID, "T0", "rot-ready")
+
+        result = cr.respawn(
+            handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+            project_root=REPO_ROOT, rotation_id="rot-ready", tmux_spawn_fn=fake_spawn,
+            timeout_seconds=5, poll_interval_seconds=0.01,
+        )
+        assert result.success is True
+        assert result.reason == "ready"
+        assert spawn_calls == [result.session_name]
+
+    def test_stale_ready_with_different_rotation_id_does_not_confirm(self, isolated_home: Path) -> None:
+        """Finding #6: a .ready left over from a PREVIOUS rotation must not
+        false-confirm a new one."""
+        cr.write_ready_signal(PROJECT_ID, "T0", "old-rotation")
+
+        killed: List[str] = []
+        result = cr.respawn(
+            handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+            project_root=REPO_ROOT, rotation_id="new-rotation",
+            tmux_spawn_fn=lambda *a: None, tmux_kill_fn=lambda name: killed.append(name),
+            timeout_seconds=0.05, poll_interval_seconds=0.01,
+        )
+        assert result.success is False
+        assert result.reason == "timeout_no_ready"
+        assert killed == [result.session_name]
+
+    def test_no_ready_within_timeout_aborts_and_reaps_only_orphan(
+        self, isolated_home: Path, caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        killed: List[str] = []
+        spawned: List[str] = []
+
+        def fake_spawn(session_name: str, project_root: str, resume_prompt: str) -> None:
+            spawned.append(session_name)  # never writes .ready
+
+        with caplog.at_level("ERROR"):
+            result = cr.respawn(
+                handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+                project_root=REPO_ROOT, rotation_id="rot-timeout", tmux_spawn_fn=fake_spawn,
+                tmux_kill_fn=lambda name: killed.append(name),
+                timeout_seconds=0.05, poll_interval_seconds=0.01,
+            )
+
+        assert result.success is False
+        assert result.reason == "timeout_no_ready"
+        # Non-destructive: the ONLY session reaped is the one THIS call spawned.
+        assert killed == spawned == [result.session_name]
+        assert "ABORT" in caplog.text
+
+    def test_spawn_failure_never_calls_kill(self, isolated_home: Path) -> None:
+        """A spawn that raises before any session exists must not attempt to
+        kill anything — there is nothing to reap."""
+        killed: List[str] = []
+
+        def failing_spawn(*args: Any) -> None:
+            raise RuntimeError("tmux not found")
+
+        result = cr.respawn(
+            handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+            project_root=REPO_ROOT, rotation_id="rot-spawnfail", tmux_spawn_fn=failing_spawn,
+            tmux_kill_fn=lambda name: killed.append(name),
+            timeout_seconds=1, poll_interval_seconds=0.01,
+        )
+        assert result.success is False
+        assert result.reason.startswith("spawn_failed")
+        assert killed == []
+
+    def test_never_calls_a_destructive_or_kill_path_on_success(self, isolated_home: Path) -> None:
+        """Assert the whole respawn() call graph, when it succeeds, contains
+        zero destructive verbs anywhere (no kill-session, no `vnx start`)."""
+        calls: List[List[str]] = []
+        real_run = subprocess.run
+
+        def recording_run(cmd: List[str], *args: Any, **kwargs: Any) -> Any:
+            calls.append(list(cmd))
+            if cmd[:2] == ["tmux", "new-session"]:
+                return real_run(["true"], check=True)
+            if cmd[:2] == ["tmux", "send-keys"]:
+                return real_run(["true"], check=True)
+            raise AssertionError(f"unexpected subprocess call: {cmd}")
+
+        import unittest.mock as mock
+        with mock.patch("context_rotation.subprocess.run", side_effect=recording_run), \
+             mock.patch("context_rotation.time.sleep", lambda *_: None):
+            def spawn_and_confirm(session_name: str, project_root: str, resume_prompt: str) -> None:
+                cr._default_tmux_spawn(session_name, project_root, resume_prompt, boot_delay_seconds=0)
+                cr.write_ready_signal(PROJECT_ID, "T0", "rot-real")
+
+            result = cr.respawn(
+                handoff_path=Path("handoff.md"), terminal="T0", project_id=PROJECT_ID,
+                project_root=REPO_ROOT, rotation_id="rot-real", tmux_spawn_fn=spawn_and_confirm,
+                timeout_seconds=2, poll_interval_seconds=0.01,
+            )
+
+        assert result.success is True
+        assert calls  # at least new-session + send-keys calls recorded
+        for cmd in calls:
+            assert "kill-session" not in cmd
+            assert not any("vnx" == c or c.endswith("/vnx") for c in cmd)
+
+
+# ---------------------------------------------------------------------------
+# 5. write_t0_handoff()
+# ---------------------------------------------------------------------------
+
+class TestWriteT0Handoff:
+    def test_contract_satisfied(self, isolated_home: Path, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_git_repo(repo, branch="my-feature-branch")
+
+        logdir = tmp_path / "handoff_out"
+        handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=repo, project_id=PROJECT_ID)
+
+        assert handoff_path == logdir / "handoff.md"
+        assert handoff_path.is_file()
+        text = handoff_path.read_text(encoding="utf-8")
+
+        assert text.startswith("---\n")
+        assert f"project: {PROJECT_ID}" in text
+        assert "branch: my-feature-branch" in text
+        assert "date:" in text
+        assert "## Waar we middenin zitten" in text
+        assert "## State" in text
+        assert "## Next steps" in text
+
+    def test_project_id_scoped_across_two_projects(self, isolated_home: Path, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+
+        dir_a = cr.rotation_handoff_dir("project-a", "T0")
+        dir_b = cr.rotation_handoff_dir("project-b", "T0")
+        assert dir_a != dir_b
+
+        path_a = cr.write_t0_handoff(logdir=dir_a, project_root=repo, project_id="project-a")
+        path_b = cr.write_t0_handoff(logdir=dir_b, project_root=repo, project_id="project-b")
+        assert path_a != path_b
+        assert "project: project-a" in path_a.read_text(encoding="utf-8")
+        assert "project: project-b" in path_b.read_text(encoding="utf-8")
+
+    def test_fail_soft_on_non_git_directory(self, isolated_home: Path, tmp_path: Path) -> None:
+        non_git = tmp_path / "not_a_repo"
+        non_git.mkdir()
+        logdir = tmp_path / "handoff_out"
+
+        handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=non_git, project_id=PROJECT_ID)
+        assert handoff_path.is_file()
+        text = handoff_path.read_text(encoding="utf-8")
+        assert "branch: unknown" in text
+        assert "## Next steps" in text  # still fully written despite no git
+
+    def test_fail_soft_on_missing_tracks_db(self, isolated_home: Path, tmp_path: Path) -> None:
+        """No DB has been created for this project_id yet — the horizon
+        section must degrade gracefully, not raise."""
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        logdir = tmp_path / "handoff_out"
+
+        handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=repo, project_id="brand-new-project")
+        assert handoff_path.is_file()
+        assert "Horizon NOW tracks: 0" in handoff_path.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 6. handoff_reader
+# ---------------------------------------------------------------------------
+
+class TestHandoffReader:
+    def test_round_trip(self, isolated_home: Path, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_git_repo(repo, branch="round-trip-branch")
+        logdir = tmp_path / "handoff_out"
+
+        handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=repo, project_id=PROJECT_ID)
+        briefing = hr.read_handoff(handoff_path)
+
+        assert briefing is not None
+        assert briefing.project == PROJECT_ID
+        assert briefing.branch == "round-trip-branch"
+        assert briefing.context == "t0-rotation"
+        assert "Working tree clean" in briefing.waar_we_middenin_zitten
+        assert "round-trip-branch" in briefing.state
+        assert briefing.next_steps  # non-empty
+
+    def test_missing_file_returns_none(self, tmp_path: Path) -> None:
+        assert hr.read_handoff(tmp_path / "nope.md") is None
+
+    def test_format_briefing_includes_all_sections(self) -> None:
+        briefing = hr.HandoffBriefing(
+            context="t0-rotation", project="p", date="d", branch="b",
+            waar_we_middenin_zitten="wip text", state="state text", next_steps="next text",
+        )
+        rendered = hr.format_briefing(briefing)
+        assert "wip text" in rendered
+        assert "state text" in rendered
+        assert "next text" in rendered
+
+
+# ---------------------------------------------------------------------------
+# 7. session_stop_rotation.py hook
+# ---------------------------------------------------------------------------
+
+class TestSessionStopHook:
+    def _run_hook(self, cwd: Path, env: Dict[str, str]) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            [sys.executable, str(HOOK_PATH)],
+            input=json.dumps({"cwd": str(cwd), "session_id": "test-session"}),
+            capture_output=True, text=True, cwd=str(cwd), env=env, timeout=15,
+        )
+
+    def test_noop_when_flag_unset(self, isolated_home: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
+
+        env = {**__import__("os").environ, "HOME": str(isolated_home)}
+        env.pop("VNX_T0_ROTATION", None)
+
+        result = self._run_hook(repo, env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "{}"
+        assert not cr.rotation_handoff_dir(PROJECT_ID, "T0").joinpath(cr.HANDOFF_FILENAME).is_file()
+
+    def test_writes_handoff_when_flag_set(self, isolated_home: Path, tmp_path: Path) -> None:
+        repo = tmp_path / "repo"
+        _make_git_repo(repo)
+        (repo / ".vnx-project-id").write_text(f"{PROJECT_ID}\n", encoding="utf-8")
+
+        env = {**__import__("os").environ, "HOME": str(isolated_home), "VNX_T0_ROTATION": "1"}
+
+        result = self._run_hook(repo, env)
+        assert result.returncode == 0
+        assert result.stdout.strip() == "{}"
+        assert cr.rotation_handoff_dir(PROJECT_ID, "T0").joinpath(cr.HANDOFF_FILENAME).is_file()
+
+
+# ---------------------------------------------------------------------------
+# 8. Guard-safety: argv[0] is always "tmux", never "claude"
+# ---------------------------------------------------------------------------
+
+class TestGuardSafeSpawnShape:
+    def test_default_tmux_spawn_never_invokes_claude_as_executable(self) -> None:
+        calls: List[List[str]] = []
+
+        import unittest.mock as mock
+        with mock.patch("context_rotation.subprocess.run") as run_mock, \
+             mock.patch("context_rotation.time.sleep", lambda *_: None):
+            run_mock.side_effect = lambda cmd, **kw: calls.append(list(cmd))
+            cr._default_tmux_spawn("vnx-t0-rotation-t0-abc123", "/tmp/repo", "resume prompt text", boot_delay_seconds=0)
+
+        assert calls, "expected at least one subprocess.run call"
+        for cmd in calls:
+            assert cmd[0] == "tmux", f"argv[0] must always be tmux, got: {cmd}"
+            # "claude" (when present) is a literal send-keys payload, never argv[0].
+            assert cmd[0] != "claude"
+        dangerous_flags = {"-p", "--print", "--dangerously-skip-permissions"}
+        for cmd in calls:
+            assert not (dangerous_flags & set(cmd)), f"dangerous flag present in {cmd}"

--- a/tests/test_runtime_adapter_certification.py
+++ b/tests/test_runtime_adapter_certification.py
@@ -242,8 +242,11 @@ class TestDirectCouplingFreeze:
         # (operator-approved): the leaseless tmux-spawn lane is now first-class,
         # so the door/spawn/governance modules below legitimately couple to tmux.
         # The set guards against NEW, unexpected coupling outside this lane.
+        # context_rotation.py — T0-initiated non-destructive rotation respawn
+        # (default-OFF); first-class tmux use, added 2026-07-12.
         known_preexisting = {
             "cleanup_worker_exit.py",
+            "context_rotation.py",
             "dashboard_actions.py",
             "dispatch_govern.py",
             "dispatch_prepare.py",
@@ -268,8 +271,11 @@ class TestDirectCouplingFreeze:
         """Direct-tmux-coupling file set must not grow beyond the approved baseline."""
         # Refreshed 2026-06-27 (operator-approved) — see the note in
         # test_no_direct_tmux_subprocess_in_protected_modules. Kept in sync with it.
+        # context_rotation.py — T0-initiated non-destructive rotation respawn
+        # (default-OFF); first-class tmux use, added 2026-07-12.
         known_files = {
             "cleanup_worker_exit.py",
+            "context_rotation.py",
             "dashboard_actions.py",
             "dispatch_govern.py",
             "dispatch_prepare.py",

--- a/tests/test_vnx_cli_handoff_argparse.py
+++ b/tests/test_vnx_cli_handoff_argparse.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Regression test for the `vnx handoff` argparse duplicate-dest bug.
+
+Background: `handoff_parser` (the `vnx handoff` level) and its `show`/
+`mark-ready` sub-subparsers both declare `--project-dir`/`--project-id`
+with the same dest. argparse's SubParsersAction parses each subcommand into
+a FRESH namespace and then copies every attribute from it back onto the
+parent namespace — including untouched defaults — which silently clobbered
+an explicit `--project-id`/`--project-dir` given at the parent position
+(`vnx handoff --project-id foo show`) back to the subparser's own default
+(None / "."). Fixed via `default=argparse.SUPPRESS` on the subparser copies
+so an unset flag never overwrites a value already resolved by the parent.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from vnx_cli import main as vnx_main  # noqa: E402
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(prog="vnx")
+    subparsers = parser.add_subparsers(dest="command")
+    vnx_main._register_handoff_subparser(subparsers)
+    return parser
+
+
+class TestHandoffProjectIdNotClobbered:
+    def test_project_id_at_parent_position_is_honored_by_show(self) -> None:
+        """`vnx handoff --project-id foo show` must resolve project_id=foo,
+        not fall back to the show-subparser's own None default."""
+        args = _build_parser().parse_args(["handoff", "--project-id", "foo", "show"])
+        assert getattr(args, "project_id", None) == "foo"
+
+    def test_project_id_at_sub_position_is_still_honored_by_show(self) -> None:
+        """The reverse order must also work — an explicit flag on the
+        subcommand itself is honored regardless of position."""
+        args = _build_parser().parse_args(["handoff", "show", "--project-id", "foo"])
+        assert getattr(args, "project_id", None) == "foo"
+
+    def test_project_dir_at_parent_position_is_honored_by_show(self) -> None:
+        args = _build_parser().parse_args(["handoff", "--project-dir", "/x", "show"])
+        assert getattr(args, "project_dir", None) == "/x"
+
+    def test_no_project_id_anywhere_falls_back_to_none(self) -> None:
+        """Absence of the flag at either level must still resolve to the
+        documented auto-resolution fallback (None), not raise."""
+        args = _build_parser().parse_args(["handoff", "show"])
+        assert getattr(args, "project_id", None) is None
+        assert getattr(args, "project_dir", None) == "."
+
+    def test_project_id_at_parent_position_is_honored_by_mark_ready(self) -> None:
+        args = _build_parser().parse_args(
+            ["handoff", "--project-id", "foo", "mark-ready", "--rotation-id", "rid"]
+        )
+        assert getattr(args, "project_id", None) == "foo"
+        assert args.rotation_id == "rid"
+
+    def test_project_id_at_sub_position_is_still_honored_by_mark_ready(self) -> None:
+        args = _build_parser().parse_args(
+            ["handoff", "mark-ready", "--rotation-id", "rid", "--project-id", "foo"]
+        )
+        assert getattr(args, "project_id", None) == "foo"

--- a/tests/test_vnx_cli_handoff_show.py
+++ b/tests/test_vnx_cli_handoff_show.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+"""P3 regression: `vnx handoff show --logdir <path>` must not require a
+resolvable project_id.
+
+Background: `_show()` used to call `_resolve_project_id(args)` BEFORE
+checking `args.logdir`, so inspecting an explicit/archived handoff.md
+(possibly outside any VNX project) failed with an auto-resolution error even
+though no project_id is needed to read a handoff by explicit path. The fix
+defers `_resolve_project_id()` until it's actually needed: the DEFAULT
+logdir fallback, or `--mark-ready` (which needs project_id to write the
+.ready signal).
+"""
+
+from __future__ import annotations
+
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from vnx_cli.commands import handoff as handoff_mod  # noqa: E402
+
+_HANDOFF_MD = """---
+context: t0-rotation
+project: some-project
+date: 2026-07-12T00:00:00Z
+branch: main
+---
+
+# T0 Context Rotation Handoff
+
+## Waar we middenin zitten
+
+Working tree clean on branch `main`.
+
+## State
+
+- Branch: `main`
+
+## Next steps
+
+No pending horizon items detected.
+"""
+
+
+def _args(**overrides: object) -> types.SimpleNamespace:
+    base = dict(logdir=None, terminal="T0", mark_ready=False, rotation_id=None, project_id=None, project_dir=".")
+    base.update(overrides)
+    return types.SimpleNamespace(**base)
+
+
+def _unresolvable_project_id(_args: object) -> str:
+    """Stand-in for the real `_resolve_project_id`, which calls
+    `sys.exit(2)` when auto-resolution fails (no --project-id, no
+    resolvable project). Raising SystemExit here reproduces that failure
+    deterministically regardless of the ambient test environment's own
+    project markers."""
+    raise SystemExit(2)
+
+
+class TestShowWithExplicitLogdirDefersProjectId:
+    def test_succeeds_without_a_resolvable_project_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        handoff_dir = tmp_path / "archived_handoff"
+        handoff_dir.mkdir()
+        (handoff_dir / "handoff.md").write_text(_HANDOFF_MD, encoding="utf-8")
+
+        monkeypatch.setattr(handoff_mod, "_resolve_project_id", _unresolvable_project_id)
+
+        result = handoff_mod._show(_args(logdir=str(handoff_dir)))
+        assert result == 0
+
+    def test_never_calls_resolve_project_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        handoff_dir = tmp_path / "archived_handoff"
+        handoff_dir.mkdir()
+        (handoff_dir / "handoff.md").write_text(_HANDOFF_MD, encoding="utf-8")
+
+        calls: list[object] = []
+        monkeypatch.setattr(
+            handoff_mod, "_resolve_project_id", lambda a: calls.append(a) or "should-not-happen",
+        )
+
+        result = handoff_mod._show(_args(logdir=str(handoff_dir)))
+        assert result == 0
+        assert calls == []
+
+
+class TestShowStillResolvesProjectIdWhenNeeded:
+    """The deferral must not turn into an outright removal — the default
+    (no --logdir) path and --mark-ready still need project_id."""
+
+    def test_no_logdir_still_resolves_project_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        calls: list[object] = []
+
+        def _fake_resolve(a: object) -> str:
+            calls.append(a)
+            return "fallback-project"
+
+        monkeypatch.setattr(handoff_mod, "_resolve_project_id", _fake_resolve)
+        monkeypatch.setattr(handoff_mod, "_resolve_logdir", lambda a, pid: tmp_path / "nope")
+
+        result = handoff_mod._show(_args(logdir=None))
+        assert result == 1  # no handoff.md at the fake logdir — but project_id WAS resolved
+        assert len(calls) == 1
+
+    def test_mark_ready_with_explicit_logdir_still_resolves_project_id(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        handoff_dir = tmp_path / "archived_handoff"
+        handoff_dir.mkdir()
+        (handoff_dir / "handoff.md").write_text(_HANDOFF_MD, encoding="utf-8")
+
+        calls: list[object] = []
+
+        def _fake_resolve(a: object) -> str:
+            calls.append(a)
+            return "fallback-project"
+
+        monkeypatch.setattr(handoff_mod, "_resolve_project_id", _fake_resolve)
+        monkeypatch.setattr(handoff_mod, "_mark_ready", lambda a, pid: (calls.append(pid), 0)[1])
+
+        result = handoff_mod._show(_args(logdir=str(handoff_dir), mark_ready=True))
+        assert result == 0
+        assert len(calls) == 2  # once for _resolve_project_id, once recording the pid passed to _mark_ready
+        assert calls[1] == "fallback-project"

--- a/vnx_cli/commands/handoff.py
+++ b/vnx_cli/commands/handoff.py
@@ -48,7 +48,8 @@ def _resolve_logdir(args: Any, project_id: str) -> Path:
     _engine.ensure_engine_on_path()
     from context_rotation import rotation_handoff_dir
     terminal = getattr(args, "terminal", "T0") or "T0"
-    return rotation_handoff_dir(project_id, terminal)
+    project_root = Path(getattr(args, "project_dir", ".")).resolve()
+    return rotation_handoff_dir(project_id, terminal, project_root)
 
 
 def _mark_ready(args: Any, project_id: str) -> int:
@@ -57,18 +58,27 @@ def _mark_ready(args: Any, project_id: str) -> int:
         print("Error: --rotation-id is required to mark ready", file=sys.stderr)
         return 2
     terminal = getattr(args, "terminal", "T0") or "T0"
+    project_root = Path(getattr(args, "project_dir", ".")).resolve()
 
     _engine.ensure_engine_on_path()
     from context_rotation import write_ready_signal
 
-    ready_path = write_ready_signal(project_id, terminal, rotation_id)
+    ready_path = write_ready_signal(project_id, terminal, rotation_id, project_root=project_root)
     print(f"ready: terminal={terminal} rotation_id={rotation_id} -> {ready_path}")
     return 0
 
 
 def _show(args: Any) -> int:
-    project_id = _resolve_project_id(args)
-    logdir = _resolve_logdir(args, project_id)
+    logdir_arg = getattr(args, "logdir", None)
+    mark_ready = getattr(args, "mark_ready", False)
+
+    # Defer project-id resolution: an explicit --logdir needs no project
+    # context to read a handoff.md (it may point outside any VNX project
+    # entirely, e.g. an archived handoff). Only resolve when falling back to
+    # the default project_id+terminal-scoped logdir, or when --mark-ready
+    # needs a project_id afterwards.
+    project_id = _resolve_project_id(args) if (not logdir_arg or mark_ready) else None
+    logdir = Path(logdir_arg) if logdir_arg else _resolve_logdir(args, project_id)
 
     _engine.ensure_engine_on_path()
     from handoff_reader import read_handoff, format_briefing
@@ -81,7 +91,7 @@ def _show(args: Any) -> int:
 
     print(format_briefing(briefing))
 
-    if getattr(args, "mark_ready", False):
+    if mark_ready:
         return _mark_ready(args, project_id)
     return 0
 

--- a/vnx_cli/commands/handoff.py
+++ b/vnx_cli/commands/handoff.py
@@ -1,0 +1,97 @@
+#!/usr/bin/env python3
+"""vnx handoff — repo-level reader for the T0 context-rotation handoff.
+
+Two verbs:
+  vnx handoff show [--logdir DIR] [--terminal T0] [--mark-ready --rotation-id ID]
+      Prints the resume briefing parsed from <logdir>/handoff.md. This is
+      what a freshly-respawned T0 runs first (scripts/lib/context_rotation.
+      respawn() preloads exactly this instruction into the successor's tmux
+      pane) — NOT the personal /kickoff skill; this is the repo-level
+      contract (docs/operations/CONTEXT_ROTATION.md).
+  vnx handoff mark-ready --rotation-id ID [--terminal T0]
+      Writes the rotation_id-stamped `.ready` signal the old T0's respawn()
+      call is waiting on (round-3 finding #6: the waiter validates the
+      rotation_id, so a stale `.ready` from a previous rotation can never
+      false-confirm a new one).
+
+--logdir defaults to the SAME project_id+terminal-scoped path
+context_rotation.checkpoint() writes to, so `vnx handoff show` with no flags
+finds the handoff a real rotation produced.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any
+
+from vnx_cli import _engine
+
+
+def _resolve_project_id(args: Any) -> str:
+    pid = getattr(args, "project_id", None)
+    if pid:
+        return pid
+    _engine.ensure_engine_on_path()
+    from project_root import resolve_project_id as _resolve
+    try:
+        return _resolve(getattr(args, "project_dir", "."))
+    except RuntimeError as exc:
+        print(f"Error: --project-id not supplied and auto-resolution failed: {exc}", file=sys.stderr)
+        sys.exit(2)
+
+
+def _resolve_logdir(args: Any, project_id: str) -> Path:
+    logdir = getattr(args, "logdir", None)
+    if logdir:
+        return Path(logdir)
+    _engine.ensure_engine_on_path()
+    from context_rotation import rotation_handoff_dir
+    terminal = getattr(args, "terminal", "T0") or "T0"
+    return rotation_handoff_dir(project_id, terminal)
+
+
+def _mark_ready(args: Any, project_id: str) -> int:
+    rotation_id = getattr(args, "rotation_id", None)
+    if not rotation_id:
+        print("Error: --rotation-id is required to mark ready", file=sys.stderr)
+        return 2
+    terminal = getattr(args, "terminal", "T0") or "T0"
+
+    _engine.ensure_engine_on_path()
+    from context_rotation import write_ready_signal
+
+    ready_path = write_ready_signal(project_id, terminal, rotation_id)
+    print(f"ready: terminal={terminal} rotation_id={rotation_id} -> {ready_path}")
+    return 0
+
+
+def _show(args: Any) -> int:
+    project_id = _resolve_project_id(args)
+    logdir = _resolve_logdir(args, project_id)
+
+    _engine.ensure_engine_on_path()
+    from handoff_reader import read_handoff, format_briefing
+
+    handoff_path = logdir / "handoff.md"
+    briefing = read_handoff(handoff_path)
+    if briefing is None:
+        print(f"No handoff found at {handoff_path}", file=sys.stderr)
+        return 1
+
+    print(format_briefing(briefing))
+
+    if getattr(args, "mark_ready", False):
+        return _mark_ready(args, project_id)
+    return 0
+
+
+def vnx_handoff(args: Any) -> int:
+    sub = getattr(args, "handoff_subcommand", None)
+    if sub in (None, "show"):
+        return _show(args)
+    if sub == "mark-ready":
+        project_id = _resolve_project_id(args)
+        return _mark_ready(args, project_id)
+    print(f"Unknown handoff subcommand: {sub}", file=sys.stderr)
+    return 2

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -629,14 +629,24 @@ def _register_handoff_subparser(subparsers: argparse.Action) -> None:
         help="also write the .ready signal after printing (requires --rotation-id)",
     )
     show_parser.add_argument("--rotation-id", default=None, metavar="ROTATION_ID")
-    show_parser.add_argument("--project-dir", default=".", metavar="DIR")
-    show_parser.add_argument("--project-id", default=None, metavar="PROJECT_ID")
+    # SUPPRESS (not "." / None): the subparsers action parses each subcommand
+    # into a FRESH namespace and then copies every attribute from it back
+    # onto the parent namespace — including untouched defaults. Without
+    # SUPPRESS, that copy silently clobbers a --project-dir/--project-id
+    # already set at the parent `handoff` level (e.g. `vnx handoff
+    # --project-id foo show`) back to this subparser's own default. SUPPRESS
+    # means "don't set this attribute at all unless the user passed it here",
+    # so an unset flag on the subcommand never overwrites a value the parent
+    # already resolved.
+    show_parser.add_argument("--project-dir", default=argparse.SUPPRESS, metavar="DIR")
+    show_parser.add_argument("--project-id", default=argparse.SUPPRESS, metavar="PROJECT_ID")
 
     mark_ready_parser = handoff_subs.add_parser("mark-ready", help="write the rotation_id-stamped .ready signal")
     mark_ready_parser.add_argument("--rotation-id", required=True, metavar="ROTATION_ID")
     mark_ready_parser.add_argument("--terminal", default="T0", metavar="TERMINAL")
-    mark_ready_parser.add_argument("--project-dir", default=".", metavar="DIR")
-    mark_ready_parser.add_argument("--project-id", default=None, metavar="PROJECT_ID")
+    # See the show_parser comment above — same duplicate-dest clobber risk.
+    mark_ready_parser.add_argument("--project-dir", default=argparse.SUPPRESS, metavar="DIR")
+    mark_ready_parser.add_argument("--project-id", default=argparse.SUPPRESS, metavar="PROJECT_ID")
 
 
 def _register_migrate_subparser(subparsers: argparse.Action) -> None:

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -600,6 +600,45 @@ def _register_deliverable_subparser(subparsers: argparse.Action) -> None:
     _register_deliverable_verbs(deliverable_subs)
 
 
+def _register_handoff_subparser(subparsers: argparse.Action) -> None:
+    handoff_parser = subparsers.add_parser(
+        "handoff",
+        help="read/ack the T0 context-rotation handoff (show/mark-ready)",
+    )
+    handoff_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    handoff_parser.add_argument(
+        "--project-id",
+        default=None,
+        metavar="PROJECT_ID",
+        help="project_id (default: resolved from VNX_PROJECT_ID / .vnx-project-id / git remote)",
+    )
+    handoff_subs = handoff_parser.add_subparsers(dest="handoff_subcommand", metavar="SUBCOMMAND")
+
+    show_parser = handoff_subs.add_parser("show", help="print the resume briefing parsed from handoff.md")
+    show_parser.add_argument(
+        "--logdir",
+        default=None,
+        metavar="DIR",
+        help="directory containing handoff.md (default: the project_id+terminal-scoped rotation dir)",
+    )
+    show_parser.add_argument("--terminal", default="T0", metavar="TERMINAL")
+    show_parser.add_argument(
+        "--mark-ready",
+        action="store_true",
+        dest="mark_ready",
+        help="also write the .ready signal after printing (requires --rotation-id)",
+    )
+    show_parser.add_argument("--rotation-id", default=None, metavar="ROTATION_ID")
+    show_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    show_parser.add_argument("--project-id", default=None, metavar="PROJECT_ID")
+
+    mark_ready_parser = handoff_subs.add_parser("mark-ready", help="write the rotation_id-stamped .ready signal")
+    mark_ready_parser.add_argument("--rotation-id", required=True, metavar="ROTATION_ID")
+    mark_ready_parser.add_argument("--terminal", default="T0", metavar="TERMINAL")
+    mark_ready_parser.add_argument("--project-dir", default=".", metavar="DIR")
+    mark_ready_parser.add_argument("--project-id", default=None, metavar="PROJECT_ID")
+
+
 def _register_migrate_subparser(subparsers: argparse.Action) -> None:
     migrate_parser = subparsers.add_parser(
         "migrate",
@@ -915,6 +954,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.track import vnx_track
         sys.exit(vnx_track(args))
 
+    elif args.command == "handoff":
+        from vnx_cli.commands.handoff import vnx_handoff
+        sys.exit(vnx_handoff(args))
+
     elif args.command == "learning":
         from vnx_cli.commands.learning import vnx_learning
         sys.exit(vnx_learning(args))
@@ -970,6 +1013,7 @@ def main() -> None:
     _register_update_subparser(subparsers)
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)
+    _register_handoff_subparser(subparsers)
     _register_learning_subparser(subparsers)
     _register_dream_subparser(subparsers)
     _register_migrate_subparser(subparsers)


### PR DESCRIPTION
## Summary
- Builds rev-3 of `claudedocs/plans/t0-context-rotation-revival.md` (ruled by `claudedocs/2026-07-11-panel-t0-context-rotation-verdict.md`): a default-OFF, **T0-initiated, non-destructive** handoff+respawn control-plane on top of native Claude Code compaction (which stays the baseline).
- `scripts/lib/context_rotation.py`: `RotationPolicy` (yaml `configs/context_rotation.yaml` + env, default `enabled: false`), pure `decide_rotation()` (enabled-gate, governance-boundary trigger, durable **boundary-count** debounce, optional `pct_ceiling` backstop, never mid-action), `checkpoint()` (the integration point — writes handoff + request marker, advances debounce/emits the audit receipt **only on confirmed success**), `write_t0_handoff()` (real, project_id-scoped, fail-soft per source), `respawn()` (non-destructive `tmux new-session -d` of a bare interactive `claude`, bounded wait for a rotation_id-stamped `.ready`, ABORT reaps only the orphan it spawned).
- Repo-level handoff reader: `scripts/lib/handoff_reader.py` + `vnx handoff show` / `vnx handoff mark-ready`, wired into the same `vnx_cli/main.py` subparser registry as every other `vnx` subcommand.
- `scripts/hooks/session_stop_rotation.py` + `.claude/settings.json` `Stop` wiring — NO-OP unless `VNX_T0_ROTATION=1`; when enabled it only ensures `handoff.md` exists (safety net, never spawns T0 — a shell hook structurally cannot launch an interactive session).
- `docs/operations/CONTEXT_ROTATION.md` — full contract, including why this does not collide with `pretooluse_block_raw_claude_spawn.sh` (every subprocess call has `argv[0] == "tmux"`; `claude` only ever appears as a later positional/typed argument, never as the invoked executable).

## Round-3 panel findings addressed
1. `checkpoint()` emits the *existing* `context_rotation_continuation` receipt (same shape `hooks/vnx_rotate.sh` already emits) that `conversation_read_model.py` chains on — only on a confirmed rotation.
2. Durable debounce is a **boundary counter** (`boundaries_since_last_rotation`), not a timestamp/cooldown.
3. Debounce state (counter reset + `last_rotation_at`) only advances **after confirmed respawn success**; an ABORT leaves it untouched so the next boundary can retry.
4. ABORT reaps the orphan tmux session it just spawned (`tmux kill-session`) — never the caller's own session.
5. Guard-safety documented + tested: the spawn's `argv[0]` is always `tmux`; `claude` never appears as an invoked executable with a dangerous flag.
6. The `.ready` signal carries `rotation_id`; the waiter validates it before treating it as confirmed (a stale `.ready` from a prior rotation cannot false-confirm).
7. `vnx handoff show|mark-ready` registered in the same `vnx_cli/main.py` `_dispatch_command` / subparser registry every other `vnx` subcommand uses.
8. All durable state, the `.ready` signal, and the handoff dir are project_id-scoped via `resolve_central_data_dir()`.

## Test plan
- [x] `python3 -m pytest tests/test_context_rotation.py -q` — 39 passed (policy load, decide_rotation truth table incl. durable debounce across simulated sessions, checkpoint incl. idempotency/abort/success paths, respawn incl. ready/timeout/orphan-reap/non-destructive assertions, write_t0_handoff contract + fail-soft, handoff_reader round-trip, Stop-hook no-op vs enabled, guard-safe spawn shape).
- [x] `python3 -c "import scripts.lib.context_rotation"` — OK.
- [x] `vnx handoff show --help` smoke test — verified via `python3 -m vnx_cli.main handoff show --help` (the installed `vnx` binary on this machine is a separate editable install pointing elsewhere, per fleet-wide `VNX_HOME` sharing — this worktree's `vnx_cli` module is what was exercised).
- [x] `python3 -m py_compile` on all new/edited Python files.
- Default-OFF proven in tests both ways: env unset + no yaml → no-op; explicit `RotationPolicy(enabled=False)` wins over `VNX_T0_ROTATION=1` env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)