### PR TITLE
fix(dashboard): light-theme contrast sweep for badge/status palettes

### DIFF
--- a/dashboard/token-dashboard/app/conversations/page.tsx
+++ b/dashboard/token-dashboard/app/conversations/page.tsx
@@ -137,13 +137,14 @@ function SessionDetailPanel({
   onClose: () => void;
   onViewTranscript: () => void;
 }) {
+  // Literal hex (not CSS vars) — feeds the `${color}NN` alpha-suffix trick below.
   const terminalColors: Record<string, string> = {
-    T0: '#6B8AE6',
-    T1: '#50fa7b',
-    T2: '#facc15',
-    T3: '#9B6BE6',
+    T0: '#1d4ed8',
+    T1: '#15803d',
+    T2: '#b45309',
+    T3: '#6d28d9',
   };
-  const color = session.terminal ? terminalColors[session.terminal] ?? '#6B6B6B' : '#6B6B6B';
+  const color = session.terminal ? terminalColors[session.terminal] ?? '#4a5a7a' : '#4a5a7a';
 
   return (
     <div>
@@ -218,7 +219,7 @@ function SessionDetailPanel({
           borderRadius: 8,
           background: 'rgba(107,138,230,0.1)',
           border: '1px solid rgba(107,138,230,0.3)',
-          color: '#6B8AE6',
+          color: 'var(--color-info)',
           fontSize: 13,
           fontWeight: 500,
           cursor: 'pointer',

--- a/dashboard/token-dashboard/app/globals.css
+++ b/dashboard/token-dashboard/app/globals.css
@@ -10,15 +10,18 @@
   --color-primary:      #0a2463;
   --color-accent:       #2e86c1;
   --color-accent-soft:  #e5f6ff;
-  --color-accent-gold:  #f39c12;
+  --color-accent-gold:  #b45309;
   --color-foreground:   #0a2463;
   --color-muted:        #4a5a7a;
   --color-text-faint:   #8a96ad;
   --color-border:       #e1e8f0;
   --color-border-strong:#c8d4e5;
-  --color-success:      #27ae60;
-  --color-warning:      #f39c12;
+  --color-success:      #15803d;
+  --color-warning:      #b45309;
   --color-error:        #c0392b;
+  --color-danger:       var(--color-error);
+  --color-info:         #1d4ed8;
+  --color-track-c:      #6d28d9;
 
   --color-chart-t-manager: #f39c12;
   --color-chart-t0:        #0a2463;

--- a/dashboard/token-dashboard/app/operator/governance/page.tsx
+++ b/dashboard/token-dashboard/app/operator/governance/page.tsx
@@ -289,12 +289,13 @@ function RecurrenceTable({
 
 // ---- Recommendation card ----
 
+// Literal hex (not CSS vars) — these feed the `${catColor}NN` alpha-suffix trick below.
 const CATEGORY_COLORS: Record<string, string> = {
-  operational_defect: '#ff6b6b',
-  prompt_config_tuning: '#6B8AE6',
-  governance_health: '#50fa7b',
-  process: '#facc15',
-  default: 'var(--color-muted)',
+  operational_defect: '#c0392b',
+  prompt_config_tuning: '#1d4ed8',
+  governance_health: '#15803d',
+  process: '#b45309',
+  default: '#4a5a7a',
 };
 
 function categoryColor(cat: string): string {
@@ -347,7 +348,7 @@ function RecommendationCard({ rec }: { rec: DigestRecommendation }) {
               borderRadius: 5,
               background: 'rgba(107, 138, 230, 0.12)',
               border: '1px solid rgba(107, 138, 230, 0.3)',
-              color: '#6B8AE6',
+              color: 'var(--color-info)',
               display: 'flex',
               alignItems: 'center',
               gap: 4,

--- a/dashboard/token-dashboard/app/operator/improvements/page.tsx
+++ b/dashboard/token-dashboard/app/operator/improvements/page.tsx
@@ -19,17 +19,17 @@ import type { Proposal, LearningProposal, WeeklyDigest } from '@/lib/types';
 // ---- Helpers ----
 
 const CATEGORY_COLORS: Record<string, { bg: string; border: string; text: string }> = {
-  pattern: { bg: 'rgba(80, 250, 123, 0.08)', border: 'rgba(80, 250, 123, 0.22)', text: '#50fa7b' },
-  antipattern: { bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.22)', text: '#ff6b6b' },
-  prompt: { bg: 'rgba(107, 138, 230, 0.08)', border: 'rgba(107, 138, 230, 0.22)', text: '#6B8AE6' },
-  workflow: { bg: 'rgba(249, 115, 22, 0.08)', border: 'rgba(249, 115, 22, 0.22)', text: '#f97316' },
+  pattern: { bg: 'rgba(80, 250, 123, 0.08)', border: 'rgba(80, 250, 123, 0.22)', text: 'var(--color-success)' },
+  antipattern: { bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.22)', text: 'var(--color-error)' },
+  prompt: { bg: 'rgba(107, 138, 230, 0.08)', border: 'rgba(107, 138, 230, 0.22)', text: 'var(--color-info)' },
+  workflow: { bg: 'rgba(249, 115, 22, 0.08)', border: 'rgba(249, 115, 22, 0.22)', text: '#c2410c' },
   default: { bg: 'rgba(255,255,255,0.04)', border: 'rgba(255,255,255,0.1)', text: 'var(--color-muted)' },
 };
 
 const LEARNING_TYPE_META: Record<string, { icon: typeof Lightbulb; label: string; color: string }> = {
-  skill_refinement: { icon: GraduationCap, label: 'Skill refinement', color: '#6B8AE6' },
-  rule: { icon: Shield, label: 'Prevention rule', color: '#50fa7b' },
-  archival: { icon: Archive, label: 'Archival / supersede', color: '#ff6b6b' },
+  skill_refinement: { icon: GraduationCap, label: 'Skill refinement', color: 'var(--color-info)' },
+  rule: { icon: Shield, label: 'Prevention rule', color: 'var(--color-success)' },
+  archival: { icon: Archive, label: 'Archival / supersede', color: 'var(--color-error)' },
 };
 
 function categoryStyle(cat: string) {
@@ -137,7 +137,7 @@ function ProposalCard({
             conf <strong style={{ color: style.text }}>{(proposal.confidence * 100).toFixed(0)}%</strong>
           </span>
           {!isPending && (
-            <span style={{ fontSize: 10, fontWeight: 600, color: proposal.status === 'accepted' ? '#50fa7b' : '#ff6b6b' }}>
+            <span style={{ fontSize: 10, fontWeight: 600, color: proposal.status === 'accepted' ? 'var(--color-success)' : 'var(--color-error)' }}>
               {proposal.status.toUpperCase()}
             </span>
           )}
@@ -152,7 +152,7 @@ function ProposalCard({
               onClick={handleAccept}
               disabled={busy}
               className="flex items-center gap-1"
-              style={{ padding: '5px 12px', borderRadius: 6, background: 'rgba(80,250,123,0.15)', border: '1px solid rgba(80,250,123,0.35)', color: '#50fa7b', fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+              style={{ padding: '5px 12px', borderRadius: 6, background: 'rgba(80,250,123,0.15)', border: '1px solid rgba(80,250,123,0.35)', color: 'var(--color-success)', fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
             >
               <CheckCircle2 size={12} />
               Accept
@@ -161,7 +161,7 @@ function ProposalCard({
               onClick={handleReject}
               disabled={busy}
               className="flex items-center gap-1"
-              style={{ padding: '5px 12px', borderRadius: 6, background: 'rgba(255,107,107,0.12)', border: '1px solid rgba(255,107,107,0.3)', color: '#ff6b6b', fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
+              style={{ padding: '5px 12px', borderRadius: 6, background: 'rgba(255,107,107,0.12)', border: '1px solid rgba(255,107,107,0.3)', color: 'var(--color-error)', fontSize: 12, fontWeight: 600, cursor: busy ? 'not-allowed' : 'pointer', opacity: busy ? 0.6 : 1 }}
             >
               <XCircle size={12} />
               {rejectOpen ? 'Confirm Reject' : 'Reject'}
@@ -305,7 +305,7 @@ function ProposalsSection() {
             onClick={handleApplyAll}
             disabled={applying}
             className="flex items-center gap-1"
-            style={{ padding: '6px 14px', borderRadius: 7, background: 'rgba(80,250,123,0.12)', border: '1px solid rgba(80,250,123,0.3)', color: '#50fa7b', fontSize: 12, fontWeight: 600, cursor: applying ? 'not-allowed' : 'pointer', opacity: applying ? 0.6 : 1 }}
+            style={{ padding: '6px 14px', borderRadius: 7, background: 'rgba(80,250,123,0.12)', border: '1px solid rgba(80,250,123,0.3)', color: 'var(--color-success)', fontSize: 12, fontWeight: 600, cursor: applying ? 'not-allowed' : 'pointer', opacity: applying ? 0.6 : 1 }}
           >
             <Play size={12} />
             Apply All Accepted ({accepted.length})
@@ -314,7 +314,7 @@ function ProposalsSection() {
       </div>
 
       {applyMsg && (
-        <div style={{ marginBottom: 12, padding: '8px 12px', borderRadius: 8, background: applyMsg.startsWith('Error') ? 'rgba(255,107,107,0.1)' : 'rgba(80,250,123,0.1)', border: `1px solid ${applyMsg.startsWith('Error') ? 'rgba(255,107,107,0.25)' : 'rgba(80,250,123,0.25)'}`, fontSize: 12, color: applyMsg.startsWith('Error') ? '#ff6b6b' : '#50fa7b' }}>
+        <div style={{ marginBottom: 12, padding: '8px 12px', borderRadius: 8, background: applyMsg.startsWith('Error') ? 'rgba(255,107,107,0.1)' : 'rgba(80,250,123,0.1)', border: `1px solid ${applyMsg.startsWith('Error') ? 'rgba(255,107,107,0.25)' : 'rgba(80,250,123,0.25)'}`, fontSize: 12, color: applyMsg.startsWith('Error') ? 'var(--color-error)' : 'var(--color-success)' }}>
           {applyMsg}
         </div>
       )}
@@ -424,7 +424,7 @@ function WeeklyDigestSection() {
           onClick={handleGenerate}
           disabled={generating}
           className="flex items-center gap-1"
-          style={{ padding: '6px 14px', borderRadius: 7, background: 'rgba(107,138,230,0.12)', border: '1px solid rgba(107,138,230,0.3)', color: '#6B8AE6', fontSize: 12, fontWeight: 600, cursor: generating ? 'not-allowed' : 'pointer', opacity: generating ? 0.6 : 1 }}
+          style={{ padding: '6px 14px', borderRadius: 7, background: 'rgba(107,138,230,0.12)', border: '1px solid rgba(107,138,230,0.3)', color: 'var(--color-info)', fontSize: 12, fontWeight: 600, cursor: generating ? 'not-allowed' : 'pointer', opacity: generating ? 0.6 : 1 }}
         >
           <RefreshCw size={12} className={generating ? 'animate-spin' : ''} />
           {generating ? 'Generating…' : 'Generate Now'}
@@ -432,7 +432,7 @@ function WeeklyDigestSection() {
       </div>
 
       {genError && (
-        <div style={{ marginBottom: 12, padding: '8px 12px', borderRadius: 8, background: 'rgba(255,107,107,0.1)', border: '1px solid rgba(255,107,107,0.25)', fontSize: 12, color: '#ff6b6b' }}>
+        <div style={{ marginBottom: 12, padding: '8px 12px', borderRadius: 8, background: 'rgba(255,107,107,0.1)', border: '1px solid rgba(255,107,107,0.25)', fontSize: 12, color: 'var(--color-error)' }}>
           {genError}
         </div>
       )}

--- a/dashboard/token-dashboard/app/operator/intelligence/page.tsx
+++ b/dashboard/token-dashboard/app/operator/intelligence/page.tsx
@@ -27,19 +27,20 @@ import type { SuccessPattern, Antipattern, DispatchOutcome, ClassificationRecord
 
 // ---- Helpers ----
 
+// Literal hex (not CSS vars) — these feed the `${color}NN` alpha-suffix trick below.
 const SEVERITY_COLORS: Record<string, string> = {
-  critical: '#ff6b6b',
-  high: '#f97316',
-  medium: '#facc15',
-  low: '#6B8AE6',
+  critical: '#c0392b',
+  high: '#c2410c',
+  medium: '#b45309',
+  low: '#1d4ed8',
 };
 
 const PIE_PALETTE = ['#6B8AE6', '#50fa7b', '#facc15', '#f97316', '#9B6BE6', '#ff6b6b', '#8be9fd'];
 
 const TRACK_COLORS: Record<string, string> = {
-  A: '#50fa7b',
-  B: '#facc15',
-  C: '#9B6BE6',
+  A: 'var(--color-success)',
+  B: 'var(--color-warning)',
+  C: 'var(--color-track-c)',
 };
 
 function SectionHeader({ icon: Icon, title, count }: { icon: React.ElementType; title: string; count?: number }) {
@@ -69,10 +70,10 @@ function LoadingSpinner() {
 // Probe status vocabulary (ok | degraded | produces_crap | unknown) — the same
 // gate signal that decides whether the self-learning loop activates (PR-17).
 const PROBE_HEALTH_COLORS: Record<string, string> = {
-  ok: '#50fa7b',
-  degraded: '#facc15',
-  produces_crap: '#ff6b6b',
-  unknown: '#6B6B6B',
+  ok: '#15803d',
+  degraded: '#b45309',
+  produces_crap: '#c0392b',
+  unknown: '#4a5a7a',
 };
 
 function probeHealthColor(status: string): string {
@@ -150,14 +151,14 @@ function SuccessPatternCard({ pattern }: { pattern: SuccessPattern }) {
     <div style={{ padding: '14px 16px', borderRadius: 10, background: 'rgba(80, 250, 123, 0.06)', border: '1px solid rgba(80, 250, 123, 0.18)' }}>
       <div className="flex items-start justify-between gap-2">
         <span style={{ fontSize: 13, fontWeight: 600, color: 'var(--color-foreground)', lineHeight: 1.4 }}>{pattern.title}</span>
-        <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 5, background: 'rgba(80, 250, 123, 0.12)', border: '1px solid rgba(80, 250, 123, 0.25)', color: '#50fa7b', flexShrink: 0 }}>
+        <span style={{ fontSize: 10, fontWeight: 700, padding: '2px 7px', borderRadius: 5, background: 'rgba(80, 250, 123, 0.12)', border: '1px solid rgba(80, 250, 123, 0.25)', color: 'var(--color-success)', flexShrink: 0 }}>
           {pattern.category || 'general'}
         </span>
       </div>
       <ConfidenceBar value={pattern.confidence} />
       <div className="flex items-center gap-3" style={{ marginTop: 8 }}>
         <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>
-          conf <strong style={{ color: '#50fa7b' }}>{(pattern.confidence * 100).toFixed(0)}%</strong>
+          conf <strong style={{ color: 'var(--color-success)' }}>{(pattern.confidence * 100).toFixed(0)}%</strong>
         </span>
         <span style={{ fontSize: 11, color: 'var(--color-muted)' }}>
           used <strong style={{ color: 'var(--color-foreground)' }}>{pattern.used_count}</strong>×
@@ -361,8 +362,8 @@ export default function IntelligencePage() {
             {/* Success Patterns */}
             <div>
               <div className="flex items-center gap-2" style={{ marginBottom: 12 }}>
-                <CheckCircle2 size={13} style={{ color: '#50fa7b' }} />
-                <span style={{ fontSize: 12, fontWeight: 600, color: '#50fa7b' }}>
+                <CheckCircle2 size={13} style={{ color: 'var(--color-success)' }} />
+                <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-success)' }}>
                   Success Patterns ({successPatterns.length})
                 </span>
               </div>
@@ -377,8 +378,8 @@ export default function IntelligencePage() {
             {/* Antipatterns */}
             <div>
               <div className="flex items-center gap-2" style={{ marginBottom: 12 }}>
-                <AlertTriangle size={13} style={{ color: '#ff6b6b' }} />
-                <span style={{ fontSize: 12, fontWeight: 600, color: '#ff6b6b' }}>
+                <AlertTriangle size={13} style={{ color: 'var(--color-error)' }} />
+                <span style={{ fontSize: 12, fontWeight: 600, color: 'var(--color-error)' }}>
                   Antipatterns ({antipatterns.length})
                 </span>
               </div>
@@ -489,11 +490,11 @@ export default function IntelligencePage() {
                 <div className="flex items-center gap-8" style={{ marginLeft: 'auto' }}>
                   <span style={{ fontSize: 11 }}>
                     <span style={{ color: 'var(--color-muted)' }}>injected </span>
-                    <strong style={{ color: '#50fa7b' }}>{ev.items_injected}</strong>
+                    <strong style={{ color: 'var(--color-success)' }}>{ev.items_injected}</strong>
                   </span>
                   <span style={{ fontSize: 11 }}>
                     <span style={{ color: 'var(--color-muted)' }}>suppressed </span>
-                    <strong style={{ color: '#facc15' }}>{ev.items_suppressed}</strong>
+                    <strong style={{ color: 'var(--color-warning)' }}>{ev.items_suppressed}</strong>
                   </span>
                 </div>
               </div>
@@ -524,7 +525,7 @@ export default function IntelligencePage() {
               ) : (
                 <div style={{ display: 'flex', flexDirection: 'column', gap: 12 }}>
                   {trackSuccessRates.map(({ track, rate, total }) => {
-                    const color = TRACK_COLORS[track] ?? '#6B8AE6';
+                    const color = TRACK_COLORS[track] ?? 'var(--color-info)';
                     return (
                       <div key={track}>
                         <div className="flex items-center justify-between" style={{ marginBottom: 4 }}>

--- a/dashboard/token-dashboard/app/operator/kanban/page.tsx
+++ b/dashboard/token-dashboard/app/operator/kanban/page.tsx
@@ -14,17 +14,17 @@ const TRACK_COLORS: Record<string, { bg: string; border: string; text: string }>
   A: {
     bg: 'rgba(80, 250, 123, 0.12)',
     border: 'rgba(80, 250, 123, 0.4)',
-    text: '#50fa7b',
+    text: 'var(--color-success)',
   },
   B: {
     bg: 'rgba(250, 204, 21, 0.12)',
     border: 'rgba(250, 204, 21, 0.4)',
-    text: '#facc15',
+    text: 'var(--color-warning)',
   },
   C: {
     bg: 'rgba(155, 107, 230, 0.12)',
     border: 'rgba(155, 107, 230, 0.4)',
-    text: '#9B6BE6',
+    text: 'var(--color-track-c)',
   },
 };
 
@@ -171,7 +171,7 @@ function DispatchCard({ card }: { card: KanbanCard }) {
               borderRadius: 5,
               background: 'rgba(107,138,230,0.12)',
               border: '1px solid rgba(107,138,230,0.25)',
-              color: '#6B8AE6',
+              color: 'var(--color-info)',
             }}
           >
             {card.terminal}
@@ -224,7 +224,7 @@ function DispatchCard({ card }: { card: KanbanCard }) {
             <span
               data-testid="card-scout"
               title="Scout-verrijkt: deze dispatch heeft een scout pre-pass sidecar"
-              style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-info, #6ca8ff)' }}
+              style={{ fontSize: 10, fontWeight: 600, color: 'var(--color-info)' }}
             >
               🔍 scout
             </span>
@@ -463,7 +463,7 @@ function KanbanContent() {
                 fontWeight: projectFilter === p.name ? 600 : 400,
                 background: projectFilter === p.name ? 'rgba(107, 138, 230, 0.15)' : 'rgba(255,255,255,0.04)',
                 border: `1px solid ${projectFilter === p.name ? 'rgba(107, 138, 230, 0.4)' : 'rgba(255,255,255,0.08)'}`,
-                color: projectFilter === p.name ? '#6B8AE6' : 'var(--color-muted)',
+                color: projectFilter === p.name ? 'var(--color-info)' : 'var(--color-muted)',
                 cursor: 'pointer',
               }}
             >

--- a/dashboard/token-dashboard/app/operator/planning/page.tsx
+++ b/dashboard/token-dashboard/app/operator/planning/page.tsx
@@ -15,7 +15,7 @@ function phaseColor(phase: string): string {
     case 'done': return 'var(--color-success, #50fa7b)';
     case 'active': case 'in_progress': return 'var(--color-accent, #f97316)';
     case 'blocked': case 'failed': return 'var(--color-danger, #ff5555)';
-    case 'queued': case 'proposed': return 'rgba(108,168,255,0.85)';
+    case 'queued': case 'proposed': return 'var(--color-info)';
     default: return 'var(--color-muted, rgba(244,244,249,0.5))';
   }
 }

--- a/dashboard/token-dashboard/app/operator/reports/page.tsx
+++ b/dashboard/token-dashboard/app/operator/reports/page.tsx
@@ -9,20 +9,20 @@ import BreadcrumbNav from '@/components/operator/breadcrumb-nav';
 import type { Report } from '@/lib/types';
 
 const TRACK_COLORS: Record<string, { color: string; bg: string; border: string }> = {
-  A: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
-  B: { color: '#facc15', bg: 'rgba(250, 204, 21, 0.1)', border: 'rgba(250, 204, 21, 0.3)' },
-  C: { color: '#9B6BE6', bg: 'rgba(155, 107, 230, 0.1)', border: 'rgba(155, 107, 230, 0.3)' },
+  A: { color: 'var(--color-success)', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
+  B: { color: 'var(--color-warning)', bg: 'rgba(250, 204, 21, 0.1)', border: 'rgba(250, 204, 21, 0.3)' },
+  C: { color: 'var(--color-track-c)', bg: 'rgba(155, 107, 230, 0.1)', border: 'rgba(155, 107, 230, 0.3)' },
 };
 
 const STATUS_COLORS: Record<string, { color: string; bg: string; border: string }> = {
-  success: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.08)', border: 'rgba(80, 250, 123, 0.25)' },
-  failure: { color: '#ff6b6b', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
-  failed:  { color: '#ff6b6b', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
+  success: { color: 'var(--color-success)', bg: 'rgba(80, 250, 123, 0.08)', border: 'rgba(80, 250, 123, 0.25)' },
+  failure: { color: 'var(--color-error)', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
+  failed:  { color: 'var(--color-error)', bg: 'rgba(255, 107, 107, 0.08)', border: 'rgba(255, 107, 107, 0.25)' },
 };
 
 function TrackBadge({ track }: { track: string | null | undefined }) {
   const safeTrack = (track || 'UNKNOWN').toUpperCase();
-  const cfg = TRACK_COLORS[safeTrack] ?? { color: '#6B6B6B', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
+  const cfg = TRACK_COLORS[safeTrack] ?? { color: 'var(--color-muted)', bg: 'rgba(107,107,107,0.1)', border: 'rgba(107,107,107,0.3)' };
   return (
     <span
       style={{
@@ -271,7 +271,7 @@ function ReportRow({ report }: { report: Report }) {
                 alignItems: 'center',
                 gap: 5,
                 fontSize: 11,
-                color: '#6B8AE6',
+                color: 'var(--color-info)',
                 textDecoration: 'none',
                 padding: '3px 10px',
                 borderRadius: 6,

--- a/dashboard/token-dashboard/app/operator/sessions/page.tsx
+++ b/dashboard/token-dashboard/app/operator/sessions/page.tsx
@@ -13,7 +13,7 @@ function formatAge(seconds: number | null): string {
 }
 
 function StatusBadge({ status }: { status: LiveSession['status'] }) {
-  const color = status === 'busy' ? '#facc15' : 'var(--color-muted)';
+  const color = status === 'busy' ? 'var(--color-warning)' : 'var(--color-muted)';
   return (
     <span
       style={{
@@ -91,7 +91,7 @@ export default function LiveSessionsPage() {
             borderRadius: 8,
             background: 'rgba(250, 204, 21, 0.08)',
             border: '1px solid rgba(250, 204, 21, 0.3)',
-            color: '#facc15',
+            color: 'var(--color-warning)',
             fontSize: 12,
           }}
         >

--- a/dashboard/token-dashboard/app/usage/page.tsx
+++ b/dashboard/token-dashboard/app/usage/page.tsx
@@ -382,7 +382,7 @@ export default function UsagePage() {
             {Array.from(modelCosts.entries())
               .sort(([a], [b]) => a.localeCompare(b))
               .map(([model, cost]) => {
-                const color = model === 'claude-opus' ? '#f97316' : '#6B8AE6';
+                const color = model === 'claude-opus' ? '#c2410c' : '#1d4ed8';
                 const pricing = PRICING[model as ModelKey];
                 return (
                   <CostCard
@@ -479,16 +479,16 @@ export default function UsagePage() {
                             {row.terminal}
                           </span>
                         </td>
-                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: '#ff6b6b', textAlign: 'right' }}>
+                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: 'var(--color-error)', textAlign: 'right' }}>
                           {formatTokens(row.input)}
                         </td>
-                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: '#f97316', textAlign: 'right' }}>
+                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: '#c2410c', textAlign: 'right' }}>
                           {formatTokens(row.cacheCreation)}
                         </td>
-                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: '#6B8AE6', textAlign: 'right' }}>
+                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: 'var(--color-info)', textAlign: 'right' }}>
                           {formatTokens(row.cacheRead)}
                         </td>
-                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: '#50fa7b', textAlign: 'right' }}>
+                        <td className="font-mono text-xs" style={{ padding: '10px 16px', color: 'var(--color-success)', textAlign: 'right' }}>
                           {formatTokens(row.output)}
                         </td>
                         <td className="font-mono text-xs" style={{ padding: '10px 16px', color: 'var(--color-foreground)', textAlign: 'right' }}>
@@ -515,16 +515,16 @@ export default function UsagePage() {
                     >
                       Total
                     </td>
-                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: '#ff6b6b', textAlign: 'right' }}>
+                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: 'var(--color-error)', textAlign: 'right' }}>
                       {formatTokens(totals.input)}
                     </td>
-                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: '#f97316', textAlign: 'right' }}>
+                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: '#c2410c', textAlign: 'right' }}>
                       {formatTokens(totals.cacheCreation)}
                     </td>
-                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: '#6B8AE6', textAlign: 'right' }}>
+                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: 'var(--color-info)', textAlign: 'right' }}>
                       {formatTokens(totals.cacheRead)}
                     </td>
-                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: '#50fa7b', textAlign: 'right' }}>
+                    <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: 'var(--color-success)', textAlign: 'right' }}>
                       {formatTokens(totals.output)}
                     </td>
                     <td className="font-mono text-xs font-bold" style={{ padding: '12px 16px', color: 'var(--color-foreground)', textAlign: 'right' }}>

--- a/dashboard/token-dashboard/components/operator/agent-selector.tsx
+++ b/dashboard/token-dashboard/components/operator/agent-selector.tsx
@@ -4,15 +4,16 @@ import { useAgents } from '@/lib/hooks';
 import type { Agent } from '@/lib/types';
 
 const ADAPTER_COLORS: Record<string, { color: string; bg: string; border: string }> = {
-  subprocess: { color: '#50fa7b', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
-  tmux:       { color: '#6B8AE6', bg: 'rgba(107, 138, 230, 0.1)', border: 'rgba(107, 138, 230, 0.3)' },
+  subprocess: { color: 'var(--color-success)', bg: 'rgba(80, 250, 123, 0.1)', border: 'rgba(80, 250, 123, 0.3)' },
+  tmux:       { color: 'var(--color-info)', bg: 'rgba(107, 138, 230, 0.1)', border: 'rgba(107, 138, 230, 0.3)' },
 };
 
+// Literal hex (not CSS vars) — feeds the `${termColor}NN` alpha-suffix trick below.
 const TERMINAL_COLORS: Record<string, string> = {
-  T0: '#6B8AE6',
-  T1: '#50fa7b',
-  T2: '#facc15',
-  T3: '#9B6BE6',
+  T0: '#1d4ed8',
+  T1: '#15803d',
+  T2: '#b45309',
+  T3: '#6d28d9',
 };
 
 interface AgentSelectorProps {
@@ -27,7 +28,7 @@ function AgentPill({ agent, isSelected, onClick }: {
   isSelected: boolean;
   onClick: () => void;
 }) {
-  const termColor = TERMINAL_COLORS[agent.terminal] ?? '#6B6B6B';
+  const termColor = TERMINAL_COLORS[agent.terminal] ?? '#4a5a7a';
   const adapterCfg = ADAPTER_COLORS[agent.adapter] ?? ADAPTER_COLORS.tmux;
 
   return (

--- a/dashboard/token-dashboard/lib/types.ts
+++ b/dashboard/token-dashboard/lib/types.ts
@@ -34,18 +34,18 @@ export interface SessionDetail {
 export type GroupBy = 'day' | 'week' | 'month';
 
 export const TERMINAL_COLORS: Record<string, string> = {
-  'T-MANAGER': '#f39c12',
+  'T-MANAGER': '#b45309',
   'T0': '#0a2463',
   'T1': '#2e86c1',
-  'T2': '#27ae60',
-  'T3': '#6B8AE6',
-  'unknown': '#8a96ad',
+  'T2': '#15803d',
+  'T3': '#1d4ed8',
+  'unknown': '#4a5a7a',
 };
 
 export const MODEL_COLORS: Record<string, string> = {
   'claude-opus': '#0a2463',
   'claude-sonnet': '#2e86c1',
-  'unknown': '#8a96ad',
+  'unknown': '#4a5a7a',
 };
 
 export type SortOrder = 'DESC' | 'ASC';


### PR DESCRIPTION
## Summary

The #1148 light-theme migration left several badge/status/chip color paths on bare bright hex values (dracula-era `#50fa7b`/`#facc15`/`#9B6BE6`/`#ff6b6b`/`#6B8AE6`) that fail WCAG AA on the new light card backgrounds. Root-caused it to two systemic bugs rather than patching each hex individually:

1. **`--color-danger` and `--color-info` were never defined** in `globals.css`, but referenced everywhere via `var(--color-danger, #ff5555)` / `var(--color-info, #6ca8ff)` fallback syntax — every call site silently resolved to the dark-theme fallback hex regardless of "theme" (this app has no dark theme anymore, just one light theme). Defined both properly.
2. **`--color-success` (#27ae60) and `--color-warning` (#f39c12)** were already migrated off the dracula palette in the original light-theme work, but still fail AA as text (2.87:1 / 2.19:1 against white). Darkened to `#15803d` / `#b45309` (~5:1 both), which fixes every existing `var(--color-success/warning)` consumer with zero code changes.

Added `--color-track-c` (#6d28d9) for the recurring Track-C/T3 purple identity color duplicated across 5 files, and fixed the same contrast class in the shared `lib/types.ts` `TERMINAL_COLORS`/`MODEL_COLORS` (imported by 11 files app-wide).

Several call sites concatenate their color into a `${color}NN` alpha-suffix string (icon-background tints, boxShadow glows) — that breaks with a `var()` reference, so those specific spots keep literal hex matching the new token values instead.

## Changes

- `app/globals.css` — darkened `--color-success`/`--color-warning`/`--color-accent-gold`; added `--color-danger` (alias of `--color-error`), `--color-info`, `--color-track-c`
- `lib/types.ts` — fixed `TERMINAL_COLORS`/`MODEL_COLORS` T2/T3/T-MANAGER/unknown contrast (shared by terminals, tokens, conversation-timeline, terminal-filter, charts, transcript-viewer, terminal-status-card)
- `app/operator/{intelligence,kanban,reports,governance,sessions,planning}/page.tsx`, `app/{conversations,usage}/page.tsx`, `app/operator/improvements/page.tsx`, `components/operator/agent-selector.tsx` — swapped bare bright-hex badge/status text to CSS var tokens (or accessible literal hex where the alpha-suffix trick requires a real hex string)
- `app/operator/{config,health,observability,planning,sessions}/page.tsx` — no direct edits needed; already used `var(--color-success/warning/danger, ...)` and now resolve correctly since the vars are defined

Chart/pie data-viz fills, `--color-accent` (used 60+ places as primary nav-brand color), and `--color-text-faint` (deliberately de-emphasized secondary text) were left untouched — out of scope for a badge/status contrast sweep.

## Verification

Computed WCAG contrast ratios for every changed token against both light backgrounds in use (`#ffffff` card, `#f4f7fb` sidebar/hover):

| Token | Old (white) | New (white) | New (sidebar) |
|---|---|---|---|
| `--color-success` | 2.87:1 ❌ | 5.02:1 ✅ | 4.67:1 ✅ |
| `--color-warning` / `--color-accent-gold` | 2.19:1 ❌ | 5.02:1 ✅ | 4.67:1 ✅ |
| `--color-danger` (was undefined→#ff5555) | 3.14:1 ❌ | 5.44:1 ✅ | 5.06:1 ✅ |
| `--color-info` (was undefined→#6ca8ff/#6B8AE6) | 3.28:1 ❌ | 6.70:1 ✅ | 6.24:1 ✅ |
| `--color-track-c` (was #9B6BE6) | 3.72:1 ❌ | 7.10:1 ✅ | 6.61:1 ✅ |
| orange (workflow/high-sev/cache-write, was #f97316) | 2.80:1 ❌ | 5.18:1 ✅ | 4.82:1 ✅ |
| `--color-error` (unchanged, already passed) | 5.44:1 ✅ | — | 5.06:1 ✅ |

All now clear the 4.5:1 AA threshold for normal-size badge text (10-12px), on both backgrounds.

- `npm run build` — compiles + typechecks cleanly, all 23 routes generate.
- Visual spot-check via dev server (backend API unavailable in this sandbox, so no live dispatch/session data): the shared `terminal-filter.tsx` pill badges (importing the fixed `lib/types.ts` palette) render with clearly legible T2/T3/T-MANAGER text; the config page's error banner renders in properly-dark, legible red instead of the old washed-out `#ff5555`.
- No dark-theme regression check applicable — this dashboard has no dark theme (`prefers-color-scheme`/`data-theme` grep returns nothing; single hardcoded light theme in `globals.css`), so that part of the dispatch's verification checklist doesn't apply here.

## Test plan

- [x] `npm run build` succeeds
- [x] Contrast ratios computed for every changed color against both card backgrounds
- [x] Visual spot-check of terminal-filter badges + config error banner in dev server
- [ ] Live visual check of kanban/intelligence/reports Track badges with real dispatch data (backend API not running in this environment — recommend a human spot-check once merged)

## Open items (follow-up, out of scope here)

1. **Two more operator pages were never light-theme migrated at all**: `app/operator/intelligence/page.tsx` and `app/operator/improvements/page.tsx` predate/postdate the #1148 migration's file list and still use dark-theme card backgrounds/borders/chart-tooltip fills (`rgba(255,255,255,0.02-0.08)`, `#0c1638` tooltip backgrounds paired with dark-navy tooltip text). I fixed the badge/status text in both, but the surrounding chrome needs its own light-theme migration pass (same shape as #1148, applied to these 2 files).
2. **At least 3 incompatible Track/Terminal color conventions coexist**: `lib/types.ts`'s canonical T0-T3 (navy/blue/green/lightblue), the duplicated-5x dracula-style A/B/C and T0-T3 (green/yellow/purple) fixed in this PR, and a third one in `components/operator/dispatch-list.tsx` (`trackColor`: A=cyan `#22d3ee`, B=purple `#a855f7`, C=orange `#f97316`) plus more bare bright-hex badge text in `app/operator/page.tsx`, `app/operator/open-items/page.tsx`, `components/kpi-cards.tsx`, `components/transcript-viewer.tsx`, `components/operator/dispatch-stage-badge.tsx`, `components/operator/project-card.tsx`, `components/operator/event-timeline.tsx` — same bug class, different files, not touched here to keep this PR to the dispatch's named scope. Worth a dedicated design-system consolidation dispatch.
3. **`--color-accent` (#2e86c1, 3.97:1) and the shared `TERMINAL_COLORS.T1`/`MODEL_COLORS['claude-sonnet']`** (same hex) sit just under the 4.5:1 AA bar when used as small badge text — left alone since `--color-accent` is the primary nav-brand color used 60+ places; fixing it is a brand-color decision, not a mechanical badge swap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)