### PR TITLE
fix(central-mode): sweep embedded-layout path assumptions, extend doctor check

### DIFF
--- a/scripts/build_decisions_digest.py
+++ b/scripts/build_decisions_digest.py
@@ -32,6 +32,33 @@ from digest.renderer import render_minimal_digest
 logger = logging.getLogger(__name__)
 
 
+def _canonical_paths() -> dict | None:
+    """Resolve VNX_STATE_DIR/VNX_DATA_DIR via canonical vnx_paths (central-mode aware)."""
+    try:
+        from vnx_paths import resolve_paths
+        return resolve_paths()
+    except Exception:
+        return None
+
+
+def _default_state_dir() -> Path:
+    env = os.environ.get("VNX_STATE_DIR")
+    if env:
+        return Path(env)
+    # A bare ".vnx-data/state" default resolves relative to CWD, ignoring the
+    # central ~/.vnx-data/<project>/state location. See #1023.
+    canonical = _canonical_paths()
+    return Path(canonical["VNX_STATE_DIR"]) if canonical else Path(".vnx-data/state")
+
+
+def _default_data_dir() -> Path:
+    env = os.environ.get("VNX_DATA_DIR")
+    if env:
+        return Path(env)
+    canonical = _canonical_paths()
+    return Path(canonical["VNX_DATA_DIR"]) if canonical else Path(".vnx-data")
+
+
 def render_decisions_digest(
     state_dir: Path | None = None,
     data_dir: Path | None = None,
@@ -42,9 +69,9 @@ def render_decisions_digest(
     to a non-directory path (sanity guard only; missing files are tolerated).
     """
     if state_dir is None:
-        state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
+        state_dir = _default_state_dir()
     if data_dir is None:
-        data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+        data_dir = _default_data_dir()
 
     progress = collect_progress(state_dir=state_dir, data_dir=data_dir)
     return render_minimal_digest(progress=progress, manual_decisions=None)
@@ -58,8 +85,8 @@ def main() -> int:
     """
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-    state_dir = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state"))
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", ".vnx-data"))
+    state_dir = _default_state_dir()
+    data_dir = _default_data_dir()
 
     content = render_decisions_digest(state_dir=state_dir, data_dir=data_dir)
     output_path = state_dir / "decisions_digest.md"

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -36,9 +36,13 @@ and are out of scope for this gate (tracked separately).
 Grandfathering
 --------------
 The two canonical resolvers are exempt (they are *supposed* to derive from
-``__file__``). Pre-existing library occurrences that this task did not migrate
-are listed in ``GRANDFATHERED`` with a reason. The gate blocks NEW occurrences
-and any change to a grandfathered line, so the bug class cannot silently return.
+``__file__``). Every occurrence listed in ``GRANDFATHERED`` has been migrated
+(central-mode-path-correctness track, centralmode-embedded-sweep dispatch) to
+try the canonical ``vnx_paths.resolve_paths()`` resolver FIRST; the listed
+``__file__``-anchored expression is what remains as a defensive last-resort
+fallback for the rare case where the canonical resolver itself is unavailable
+(e.g. import failure). The gate blocks NEW occurrences and any change to a
+grandfathered line, so the bug class cannot silently return.
 """
 from __future__ import annotations
 
@@ -67,13 +71,14 @@ EXEMPT_FILES = frozenset({"vnx_paths.py", "project_root.py"})
 # NEW occurrences. A change to any listed line drops it from the match and trips
 # the gate — forcing migration rather than silent perpetuation.
 GRANDFATHERED: Dict[str, Set[str]] = {
-    # env-first (VNX_DATA_DIR) with a repo-relative _REPO_ROOT default; only the
-    # default branch is __file__-anchored.
+    # central-mode-embedded-sweep (2026-07-13): migrated to try vnx_paths.resolve_paths()
+    # first; _REPO_ROOT / ".vnx-data" now only fires in the except-Exception
+    # last-resort branch (mirrors the dispatch_register.py pattern below).
     "scripts/lib/governance_audit.py": {
-        'Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))',
+        '_REPO_ROOT / ".vnx-data"',
     },
     "scripts/lib/governance_enforcer.py": {
-        'Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))',
+        '_REPO_ROOT / ".vnx-data"',
     },
     # _REPO_ROOT / _LIB_DIR co-located-layout fallbacks (env checked upstream).
     "scripts/lib/gate_register_emit.py": {
@@ -145,6 +150,16 @@ GRANDFATHERED: Dict[str, Set[str]] = {
         # __file__ branch is the no-arg fallback.
         'root / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"',
     },
+    # centralmode-embedded-sweep (2026-07-13): the marker constant lives in a
+    # module-level _DEFAULT_RELATIVE_PATH, so this join evaded detection until
+    # _marker_named_constants() was added. Migrated to try vnx_paths.resolve_paths()
+    # first; the git-root walk now only fires in the except-Exception last resort.
+    "scripts/lib/strategy/roadmap.py": {
+        'root / _DEFAULT_RELATIVE_PATH',
+    },
+    "scripts/lib/strategy/decisions.py": {
+        'root / _DEFAULT_RELATIVE_PATH',
+    },
 }
 
 
@@ -211,12 +226,60 @@ def _file_anchored_names(tree: ast.AST) -> Set[str]:
     return anchored
 
 
-def _has_data_marker_constant(node: ast.AST) -> bool:
-    """True if the subtree contains a ``.vnx-data`` / ``ROADMAP.yaml`` string constant."""
+def _has_marker_constant_literal(node: ast.AST) -> bool:
+    """True if the subtree contains a literal ``.vnx-data`` / ``ROADMAP.yaml`` string constant."""
     for sub in ast.walk(node):
         if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
             if any(marker in sub.value for marker in DATA_PATH_MARKERS):
                 return True
+    return False
+
+
+def _marker_named_constants(tree: ast.AST) -> Set[str]:
+    """MODULE-LEVEL names whose assigned value is a marker string literal.
+
+    Catches the indirection where the ``.vnx-data``/``ROADMAP.yaml`` literal lives
+    in its own module constant (e.g. ``_DEFAULT_RELATIVE_PATH = Path(".vnx-data/x.yaml")``)
+    and a LATER expression joins it against a ``__file__``-anchored root
+    (``root / _DEFAULT_RELATIVE_PATH``) — the join node itself carries no inline
+    string constant, so without this the marker is invisible to
+    :func:`_has_data_marker_constant`.
+
+    Deliberately restricted to assignments that are DIRECT children of the
+    module body (not nested in a function). A function-local name like
+    ``state_dir`` is routinely reassigned per-branch with unrelated values
+    across a file; treating it as globally marker-tainted the moment ANY branch
+    assigns it a marker literal produces false positives on every other,
+    unrelated use of that same name. A module-level ``_UPPER_SNAKE``-style
+    constant is assigned once and never rebound, so tainting it is precise.
+    """
+    names: Set[str] = set()
+    if not isinstance(tree, ast.Module):
+        return names
+    for node in tree.body:
+        if isinstance(node, (ast.Assign, ast.AnnAssign)):
+            value = node.value
+            if value is None or not _has_marker_constant_literal(value):
+                continue
+            targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+            for tgt in targets:
+                if isinstance(tgt, ast.Name):
+                    names.add(tgt.id)
+    return names
+
+
+def _has_data_marker_constant(node: ast.AST, marker_names: Set[str]) -> bool:
+    """True if the subtree contains a ``.vnx-data``/``ROADMAP.yaml`` marker.
+
+    Either a literal string constant, or a reference to a name previously bound
+    to one (see :func:`_marker_named_constants`).
+    """
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Constant) and isinstance(sub.value, str):
+            if any(marker in sub.value for marker in DATA_PATH_MARKERS):
+                return True
+        if isinstance(sub, ast.Name) and sub.id in marker_names:
+            return True
     return False
 
 
@@ -236,6 +299,7 @@ def check_source(source: str) -> List[Tuple[int, str]]:
     except SyntaxError:
         return []
     anchored = _file_anchored_names(tree)
+    marker_names = _marker_named_constants(tree)
 
     violations: List[Tuple[int, str]] = []
     seen: Set[Tuple[int, str]] = set()
@@ -249,7 +313,7 @@ def check_source(source: str) -> List[Tuple[int, str]]:
         )
         if not (is_join or is_path_call):
             continue
-        if not _has_data_marker_constant(node):
+        if not _has_data_marker_constant(node, marker_names):
             continue
         if not _references_file_anchor(node, anchored):
             continue

--- a/scripts/f39/gate_locks.py
+++ b/scripts/f39/gate_locks.py
@@ -24,10 +24,32 @@ from __future__ import annotations
 
 import json
 import os
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
-LOCK_DIR = Path(os.environ.get("VNX_STATE_DIR", ".vnx-data/state")) / "gate_locks"
+
+def _resolve_state_dir() -> Path:
+    """Resolve VNX_STATE_DIR via canonical vnx_paths, falling back to CWD-relative.
+
+    A bare ``.vnx-data/state`` default resolves relative to CWD, which is only
+    correct when CWD happens to be the project root with a legacy project-local
+    layout; it ignores the central ``~/.vnx-data/<project>/state`` location.
+    """
+    env = os.environ.get("VNX_STATE_DIR")
+    if env:
+        return Path(env)
+    try:
+        repo_root = str(Path(__file__).resolve().parents[2] / "scripts" / "lib")
+        if repo_root not in sys.path:
+            sys.path.insert(0, repo_root)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_STATE_DIR"])
+    except Exception:
+        return Path(".vnx-data/state")
+
+
+LOCK_DIR = _resolve_state_dir() / "gate_locks"
 
 
 def create_lock(pr_id: str, gate_name: str) -> Path:

--- a/scripts/lib/event_analyzer.py
+++ b/scripts/lib/event_analyzer.py
@@ -396,9 +396,21 @@ def get_summary(behaviors: list[DispatchBehavior]) -> dict:
 # ---------------------------------------------------------------------------
 
 def _default_archive_dir() -> Path:
-    """Locate .vnx-data/events/archive relative to repo root."""
+    """Locate the events archive dir via canonical vnx_paths (central-mode aware)."""
     here = Path(__file__).resolve().parent
-    # scripts/lib -> scripts -> repo root
+    try:
+        lib_dir = str(here)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        candidate = Path(resolve_paths()["VNX_DATA_DIR"]) / "events" / "archive"
+        if candidate.exists():
+            return candidate
+    except Exception:
+        pass
+    # scripts/lib -> scripts -> repo root — a raw __file__ two-up walk resolves
+    # the KEYSTONE (not the project's ~/.vnx-data/<project>) in a central
+    # install. Kept only as a last-resort fallback. See #1023.
     repo_root = here.parent.parent
     candidate = repo_root / ".vnx-data" / "events" / "archive"
     if candidate.exists():

--- a/scripts/lib/event_analyzer.py
+++ b/scripts/lib/event_analyzer.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 import re
 import sys
 from collections import Counter, defaultdict
@@ -407,7 +408,10 @@ def _default_archive_dir() -> Path:
         if candidate.exists():
             return candidate
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     # scripts/lib -> scripts -> repo root — a raw __file__ two-up walk resolves
     # the KEYSTONE (not the project's ~/.vnx-data/<project>) in a central
     # install. Kept only as a last-resort fallback. See #1023.

--- a/scripts/lib/governance_audit.py
+++ b/scripts/lib/governance_audit.py
@@ -27,6 +27,7 @@ import hashlib
 import json
 import logging
 import os
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
@@ -40,14 +41,31 @@ _REPO_ROOT = Path(__file__).resolve().parents[2]
 _legacy_warned: bool = False
 
 
+def _data_dir() -> Path:
+    """Resolve VNX_DATA_DIR via canonical vnx_paths, falling back to repo-relative.
+
+    A raw ``_REPO_ROOT / ".vnx-data"`` default resolves the KEYSTONE (not the
+    project's ``~/.vnx-data/<project>``) in a central install. See #1023.
+    """
+    env = os.environ.get("VNX_DATA_DIR")
+    if env:
+        return Path(env)
+    try:
+        lib_dir = str(_REPO_ROOT / "scripts" / "lib")
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception:
+        return _REPO_ROOT / ".vnx-data"
+
+
 def _audit_path() -> Path:
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
-    return data_dir / "state" / "governance_audit.ndjson"
+    return _data_dir() / "state" / "governance_audit.ndjson"
 
 
 def _legacy_audit_path() -> Path:
-    data_dir = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
-    return data_dir / "events" / "governance_audit.ndjson"
+    return _data_dir() / "events" / "governance_audit.ndjson"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/governance_enforcer.py
+++ b/scripts/lib/governance_enforcer.py
@@ -46,7 +46,28 @@ except ImportError:  # pragma: no cover — audit module optional at import time
 _SCRIPT_DIR = Path(__file__).resolve().parent
 _REPO_ROOT = _SCRIPT_DIR.parent.parent
 _VNX_DIR = _REPO_ROOT / ".vnx"
-_VNX_DATA_DIR = Path(os.environ.get("VNX_DATA_DIR", str(_REPO_ROOT / ".vnx-data")))
+
+
+def _resolve_vnx_data_dir() -> Path:
+    """Resolve VNX_DATA_DIR via canonical vnx_paths, falling back to repo-relative.
+
+    A raw ``_REPO_ROOT / ".vnx-data"`` default resolves the KEYSTONE (not the
+    project's ``~/.vnx-data/<project>``) in a central install. See #1023.
+    """
+    env = os.environ.get("VNX_DATA_DIR")
+    if env:
+        return Path(env)
+    try:
+        lib_dir = str(_SCRIPT_DIR)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception:
+        return _REPO_ROOT / ".vnx-data"
+
+
+_VNX_DATA_DIR = _resolve_vnx_data_dir()
 
 DEFAULT_CONFIG_PATH = _VNX_DIR / "governance_enforcement.yaml"
 GATE_RESULTS_DIR = _VNX_DATA_DIR / "state" / "review_gates" / "results"

--- a/scripts/lib/headless_dispatch_daemon.py
+++ b/scripts/lib/headless_dispatch_daemon.py
@@ -39,10 +39,27 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
+def _canonical_data_dir() -> Optional[Path]:
+    """Resolve VNX_DATA_DIR via the canonical vnx_paths resolver (central-mode aware)."""
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception:
+        return None
+
+
 def _default_data_dir() -> Path:
     env = os.environ.get("VNX_DATA_DIR", "")
     if env:
         return Path(env)
+    # A raw _repo_root() walk resolves the KEYSTONE (not the project's
+    # ~/.vnx-data/<project>) in a central install. See #1023.
+    canonical = _canonical_data_dir()
+    if canonical is not None:
+        return canonical
     return _repo_root() / ".vnx-data"
 
 

--- a/scripts/lib/headless_dispatch_writer.py
+++ b/scripts/lib/headless_dispatch_writer.py
@@ -64,7 +64,22 @@ def _dispatch_dir() -> Path:
 
 
 def _skills_dir() -> Path:
-    """Resolve the .claude/skills/ directory."""
+    """Resolve the project's skills directory via canonical vnx_paths.
+
+    A raw __file__ upward walk for ``.claude/skills`` resolves relative to the
+    KEYSTONE (not the project root) in a central install. See #1023.
+    """
+    lib_dir = Path(__file__).resolve().parent
+    if str(lib_dir) not in sys.path:
+        sys.path.insert(0, str(lib_dir))
+    try:
+        from vnx_paths import ensure_env
+        skills = Path(ensure_env()["VNX_SKILLS_DIR"])
+        if skills.is_dir():
+            return skills
+    except Exception:
+        pass
+    # Last-resort fallback: walk up from this file looking for .claude/skills.
     candidate = Path(__file__).resolve()
     for _ in range(6):
         candidate = candidate.parent

--- a/scripts/lib/headless_dispatch_writer.py
+++ b/scripts/lib/headless_dispatch_writer.py
@@ -20,6 +20,7 @@ Design invariants:
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from dataclasses import dataclass, field
@@ -78,7 +79,10 @@ def _skills_dir() -> Path:
         if skills.is_dir():
             return skills
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     # Last-resort fallback: walk up from this file looking for .claude/skills.
     candidate = Path(__file__).resolve()
     for _ in range(6):

--- a/scripts/lib/intelligence_backfill.py
+++ b/scripts/lib/intelligence_backfill.py
@@ -142,7 +142,10 @@ def _default_db_path() -> Optional[Path]:
         if candidate.exists():
             return candidate
     except Exception:
-        pass
+        logger.debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
     if candidate.exists():
         return candidate

--- a/scripts/lib/intelligence_backfill.py
+++ b/scripts/lib/intelligence_backfill.py
@@ -128,12 +128,21 @@ def run_backfill(db_path: Path, *, dry_run: bool = False) -> Dict[str, Dict[str,
 
 
 def _default_db_path() -> Optional[Path]:
-    """Resolve default quality_intelligence.db via VNX_STATE_DIR or project root."""
+    """Resolve default quality_intelligence.db via VNX_STATE_DIR or canonical vnx_paths."""
     state_dir_env = os.environ.get("VNX_STATE_DIR")
     if state_dir_env:
         candidate = Path(state_dir_env) / "quality_intelligence.db"
         if candidate.exists():
             return candidate
+    # _PROJECT_ROOT / ".vnx-data" is repo-local; a central install's DB lives at
+    # ~/.vnx-data/<project>/state instead. Try the canonical resolver first.
+    try:
+        from vnx_paths import resolve_paths
+        candidate = Path(resolve_paths()["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        if candidate.exists():
+            return candidate
+    except Exception:
+        pass
     candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
     if candidate.exists():
         return candidate

--- a/scripts/lib/intelligence_dashboard_data.py
+++ b/scripts/lib/intelligence_dashboard_data.py
@@ -12,6 +12,7 @@ Usage (as library):
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -37,7 +38,10 @@ def _db_path() -> Path | None:
         if candidate.exists():
             return candidate
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     # Last-resort fallback: repo-relative
     here = Path(__file__).resolve()
     candidate = here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"

--- a/scripts/lib/intelligence_dashboard_data.py
+++ b/scripts/lib/intelligence_dashboard_data.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import json
 import os
 import sqlite3
+import sys
 from pathlib import Path
 from typing import Any
 
@@ -25,7 +26,19 @@ def _db_path() -> Path | None:
         p = Path(state_dir) / "quality_intelligence.db"
         if p.exists():
             return p
-    # Fallback: repo-relative
+    # Canonical resolver: a raw __file__ two-up walk resolves the KEYSTONE
+    # (not the project's ~/.vnx-data/<project>) in a central install. See #1023.
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        candidate = Path(resolve_paths()["VNX_STATE_DIR"]) / "quality_intelligence.db"
+        if candidate.exists():
+            return candidate
+    except Exception:
+        pass
+    # Last-resort fallback: repo-relative
     here = Path(__file__).resolve()
     candidate = here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"
     return candidate if candidate.exists() else None

--- a/scripts/lib/llm_decision_router.py
+++ b/scripts/lib/llm_decision_router.py
@@ -451,7 +451,16 @@ def _default_data_dir() -> Path:
     env = os.environ.get("VNX_DATA_DIR", "")
     if env:
         return Path(env)
-    return Path(__file__).resolve().parents[2] / ".vnx-data"
+    # A raw __file__.parents[2] walk resolves the KEYSTONE (not the project's
+    # ~/.vnx-data/<project>) in a central install. See #1023.
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception:
+        return Path(__file__).resolve().parents[2] / ".vnx-data"
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/pattern_extractor.py
+++ b/scripts/lib/pattern_extractor.py
@@ -40,8 +40,17 @@ def _default_db_path() -> Path:
     state_dir = os.environ.get("VNX_STATE_DIR", "")
     if state_dir:
         return Path(state_dir) / "quality_intelligence.db"
-    here = Path(__file__).resolve()
-    return here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"
+    # Canonical resolver: a raw __file__ two-up walk resolves the KEYSTONE
+    # (not the project's ~/.vnx-data/<project>) in a central install. See #1023.
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_STATE_DIR"]) / "quality_intelligence.db"
+    except Exception:
+        here = Path(__file__).resolve()
+        return here.parent.parent.parent / ".vnx-data" / "state" / "quality_intelligence.db"
 
 
 def _open_db(db_path: Path) -> sqlite3.Connection:

--- a/scripts/lib/pool_worker_runner.py
+++ b/scripts/lib/pool_worker_runner.py
@@ -51,6 +51,15 @@ def _validate_dispatch_id(dispatch_id: str, dispatch_dir: Path) -> Path:
     return Path(resolved)
 
 
+def _canonical_data_dir() -> Optional[Path]:
+    """Resolve VNX_DATA_DIR via the canonical vnx_paths resolver (central-mode aware)."""
+    try:
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception:
+        return None
+
+
 def _resolve_state_dir() -> Path:
     # Treat empty-string env vars as unset (VNX_STATE_DIR='' must fall through to VNX_DATA_DIR)
     vnx_state = os.environ.get("VNX_STATE_DIR") or ""
@@ -59,12 +68,22 @@ def _resolve_state_dir() -> Path:
         return Path(vnx_state)
     if vnx_data:
         return Path(vnx_data) / "state"
+    # A raw _LIB_DIR.parents[1] walk resolves the KEYSTONE (not the project's
+    # ~/.vnx-data/<project>) in a central install. See #1023.
+    canonical = _canonical_data_dir()
+    if canonical is not None:
+        return canonical / "state"
     return _LIB_DIR.parents[1] / ".vnx-data" / "state"
 
 
 def _resolve_dispatch_dir() -> Path:
     data = os.environ.get("VNX_DATA_DIR")
-    return Path(data) / "dispatches" if data else _LIB_DIR.parents[1] / ".vnx-data" / "dispatches"
+    if data:
+        return Path(data) / "dispatches"
+    canonical = _canonical_data_dir()
+    if canonical is not None:
+        return canonical / "dispatches"
+    return _LIB_DIR.parents[1] / ".vnx-data" / "dispatches"
 
 
 def _deliver_claude(terminal_id: str, dispatch_id: str, instruction: str,

--- a/scripts/lib/receipt_classifier.py
+++ b/scripts/lib/receipt_classifier.py
@@ -111,7 +111,16 @@ def state_dir() -> Path:
     raw = os.environ.get(ENV_STATE_DIR)
     if raw:
         return Path(raw)
-    return Path(__file__).resolve().parents[2] / ".vnx-data" / "state"
+    # A raw __file__.parents[2] walk resolves the KEYSTONE (not the project's
+    # ~/.vnx-data/<project>) in a central install. See #1023.
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_STATE_DIR"])
+    except Exception:
+        return Path(__file__).resolve().parents[2] / ".vnx-data" / "state"
 
 
 def should_classify(receipt: Dict[str, Any], mode: Optional[str] = None) -> bool:

--- a/scripts/lib/session_store.py
+++ b/scripts/lib/session_store.py
@@ -18,6 +18,7 @@ import fcntl
 import json
 import logging
 import os
+import sys
 import tempfile
 from datetime import datetime, timezone
 from pathlib import Path
@@ -34,14 +35,23 @@ def _now_iso() -> str:
 
 
 def _default_state_dir() -> Path:
-    """Resolve VNX state dir from environment, falling back to project-relative path."""
+    """Resolve VNX state dir from environment, falling back to vnx_paths (central-mode aware)."""
     env = os.environ.get("VNX_STATE_DIR", "")
     if env:
         return Path(env)
     data_dir = os.environ.get("VNX_DATA_DIR", "")
     if data_dir:
         return Path(data_dir) / "state"
-    return Path(__file__).resolve().parent.parent.parent / ".vnx-data" / "state"
+    # A raw __file__ two-up walk resolves the KEYSTONE (not the project's
+    # ~/.vnx-data/<project>) in a central install. See #1023.
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_STATE_DIR"])
+    except Exception:
+        return Path(__file__).resolve().parent.parent.parent / ".vnx-data" / "state"
 
 
 class SessionStore:

--- a/scripts/lib/strategy/decisions.py
+++ b/scripts/lib/strategy/decisions.py
@@ -20,6 +20,7 @@ import json
 import os
 import re
 import subprocess
+import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from pathlib import Path
@@ -31,6 +32,8 @@ _DECISION_ID_RE = re.compile(
     r"^(OD|TD)-(?P<year>\d{4})-(?P<month>\d{2})-(?P<day>\d{2})-(?P<seq>\d{3})$"
 )
 _DEFAULT_RELATIVE_PATH = Path(".vnx-data/strategy/decisions.ndjson")
+# Same suffix, relative to VNX_DATA_DIR (which already IS the ".vnx-data" dir).
+_DATA_DIR_RELATIVE_PATH = _DEFAULT_RELATIVE_PATH.relative_to(".vnx-data")
 
 REQUIRED_FIELDS: tuple[str, ...] = ("decision_id", "scope", "ts", "rationale")
 
@@ -71,6 +74,22 @@ def _git_root_from(start: Path) -> Path | None:
 
 
 def _default_path() -> Path:
+    """Resolve the default decisions.ndjson path via canonical vnx_paths.
+
+    A ``_git_root_from(here)``-first walk (``here`` anchored on ``__file__``)
+    resolves the KEYSTONE's git root — not the project's — in a central
+    install. Try the canonical resolver first; keep the git-root walk only as
+    a last-resort fallback. See #1023.
+    """
+    try:
+        here = Path(__file__).resolve().parent
+        lib_dir = str(here.parent)  # scripts/lib/strategy -> scripts/lib
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"]) / _DATA_DIR_RELATIVE_PATH
+    except Exception:
+        pass
     here = Path(__file__).resolve().parent
     root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
     if root is None:

--- a/scripts/lib/strategy/decisions.py
+++ b/scripts/lib/strategy/decisions.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import fcntl
 import json
+import logging
 import os
 import re
 import subprocess
@@ -89,7 +90,10 @@ def _default_path() -> Path:
         from vnx_paths import resolve_paths
         return Path(resolve_paths()["VNX_DATA_DIR"]) / _DATA_DIR_RELATIVE_PATH
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     here = Path(__file__).resolve().parent
     root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
     if root is None:

--- a/scripts/lib/strategy/roadmap.py
+++ b/scripts/lib/strategy/roadmap.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 import os
 import re
 import subprocess
+import sys
 from dataclasses import asdict, dataclass, field, replace
 from pathlib import Path
 from typing import Any
@@ -30,6 +31,8 @@ DECISION_STATUSES = ("open", "closed")
 _DECISION_ID_RE = re.compile(r"^(od|td)_\d+$")
 
 _DEFAULT_RELATIVE_PATH = Path(".vnx-data/strategy/roadmap.yaml")
+# Same suffix, relative to VNX_DATA_DIR (which already IS the ".vnx-data" dir).
+_DATA_DIR_RELATIVE_PATH = _DEFAULT_RELATIVE_PATH.relative_to(".vnx-data")
 
 
 class RoadmapValidationError(ValueError):
@@ -127,7 +130,22 @@ def _git_root_from(start: Path) -> Path | None:
 
 
 def _default_path() -> Path:
-    """Resolve the default roadmap.yaml path against the project root."""
+    """Resolve the default roadmap.yaml path via canonical vnx_paths.
+
+    A ``_git_root_from(here)``-first walk (``here`` anchored on ``__file__``)
+    resolves the KEYSTONE's git root — not the project's — in a central
+    install. Try the canonical resolver first; keep the git-root walk only as
+    a last-resort fallback. See #1023.
+    """
+    try:
+        here = Path(__file__).resolve().parent
+        lib_dir = str(here.parent)  # scripts/lib/strategy -> scripts/lib
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"]) / _DATA_DIR_RELATIVE_PATH
+    except Exception:
+        pass
     here = Path(__file__).resolve().parent
     root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
     if root is None:

--- a/scripts/lib/strategy/roadmap.py
+++ b/scripts/lib/strategy/roadmap.py
@@ -11,6 +11,7 @@ emitted with a stable layout.
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import subprocess
@@ -145,7 +146,10 @@ def _default_path() -> Path:
         from vnx_paths import resolve_paths
         return Path(resolve_paths()["VNX_DATA_DIR"]) / _DATA_DIR_RELATIVE_PATH
     except Exception:
-        pass
+        logging.getLogger(__name__).debug(
+            "vnx_paths canonical resolver unavailable; using __file__ last-resort path fallback",
+            exc_info=True,
+        )
     here = Path(__file__).resolve().parent
     root = _git_root_from(here) or _git_root_from(Path.cwd().resolve())
     if root is None:

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -22,6 +22,7 @@ import os
 import select
 import signal
 import subprocess
+import sys
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -846,13 +847,22 @@ class SubprocessAdapter:
             if vnx_data_env:
                 project_root = str(Path(vnx_data_env).parent)
             else:
-                # Walk up from this file to find .vnx-data
-                search = Path(__file__).resolve()
-                for _ in range(6):
-                    search = search.parent
-                    if (search / ".vnx-data").is_dir():
-                        project_root = str(search)
-                        break
+                # A raw __file__ upward walk for an EXISTING .vnx-data resolves
+                # the KEYSTONE (not the project root) in a central install if the
+                # keystone happens to contain a stray .vnx-data/. See #1023.
+                try:
+                    lib_dir = str(Path(__file__).resolve().parent)
+                    if lib_dir not in sys.path:
+                        sys.path.insert(0, lib_dir)
+                    from vnx_paths import resolve_paths
+                    project_root = resolve_paths()["PROJECT_ROOT"]
+                except Exception:
+                    search = Path(__file__).resolve()
+                    for _ in range(6):
+                        search = search.parent
+                        if (search / ".vnx-data").is_dir():
+                            project_root = str(search)
+                            break
 
         if project_root is None:
             logger.warning(

--- a/scripts/lib/worker_health_monitor.py
+++ b/scripts/lib/worker_health_monitor.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import sys
 import threading
 import time
 from dataclasses import dataclass, field
@@ -72,6 +73,18 @@ class WorkerHealth:
         }
 
 
+def _resolve_central_events_dir() -> Path:
+    """Resolve the events dir via canonical vnx_paths (central-mode aware)."""
+    try:
+        lib_dir = str(Path(__file__).resolve().parent)
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return Path(resolve_paths()["VNX_DATA_DIR"]) / "events"
+    except Exception:
+        return Path(__file__).resolve().parents[2] / ".vnx-data" / "events"
+
+
 class WorkerHealthMonitor:
     """Real-time health tracking for a single headless worker dispatch."""
 
@@ -106,9 +119,9 @@ class WorkerHealthMonitor:
             if data_dir:
                 self._events_dir = Path(data_dir) / "events"
             else:
-                self._events_dir = (
-                    Path(__file__).resolve().parents[2] / ".vnx-data" / "events"
-                )
+                # A raw __file__.parents[2] walk resolves the KEYSTONE (not the
+                # project's ~/.vnx-data/<project>) in a central install. See #1023.
+                self._events_dir = _resolve_central_events_dir()
 
         # Start background writer thread
         self._stop_event = threading.Event()

--- a/scripts/shadow_report.py
+++ b/scripts/shadow_report.py
@@ -32,9 +32,12 @@ def _resolve_ledger_path(explicit: str | None = None) -> Path:
     if explicit:
         return Path(explicit)
     try:
-        from project_root import resolve_state_dir
+        # Canonical resolver (VNX_HOME + project-marker aware, central-mode
+        # aware). project_root.resolve_state_dir(__file__) is git-root-only and
+        # resolves the keystone git root in a central install. See #1023.
+        from vnx_paths import resolve_state_dir
 
-        return resolve_state_dir(__file__) / LEDGER_FILENAME
+        return resolve_state_dir() / LEDGER_FILENAME
     except Exception:
         return Path(".vnx-data/state") / LEDGER_FILENAME
 

--- a/scripts/t0_lifecycle_cli.py
+++ b/scripts/t0_lifecycle_cli.py
@@ -41,17 +41,37 @@ from aggregator.t0_lifecycle import (
 )
 
 
+def _canonical_paths() -> dict | None:
+    """Resolve VNX_STATE_DIR/VNX_DATA_DIR via canonical vnx_paths (central-mode aware)."""
+    try:
+        lib_dir = str(_SCRIPTS_DIR / "lib")
+        if lib_dir not in sys.path:
+            sys.path.insert(0, lib_dir)
+        from vnx_paths import resolve_paths
+        return resolve_paths()
+    except Exception:
+        return None
+
+
 def _resolve_paths(args: argparse.Namespace) -> tuple[Path, Path]:
+    canonical = _canonical_paths()
+
     if args.coord_db:
         coord_db = Path(args.coord_db).resolve()
     else:
-        state_dir = os.environ.get("VNX_STATE_DIR") or ".vnx-data/state"
+        state_dir = os.environ.get("VNX_STATE_DIR")
+        if not state_dir:
+            # A bare ".vnx-data/state" default resolves relative to CWD, ignoring
+            # the central ~/.vnx-data/<project>/state location. See #1023.
+            state_dir = canonical["VNX_STATE_DIR"] if canonical else ".vnx-data/state"
         coord_db = Path(state_dir).resolve() / "runtime_coordination.db"
 
     if args.vnx_data_dir:
         vnx_data = Path(args.vnx_data_dir).resolve()
     else:
-        vnx_data_env = os.environ.get("VNX_DATA_DIR") or ".vnx-data"
+        vnx_data_env = os.environ.get("VNX_DATA_DIR")
+        if not vnx_data_env:
+            vnx_data_env = canonical["VNX_DATA_DIR"] if canonical else ".vnx-data"
         vnx_data = Path(vnx_data_env).resolve()
 
     return coord_db, vnx_data

--- a/scripts/vnx_settings_merge.py
+++ b/scripts/vnx_settings_merge.py
@@ -60,8 +60,14 @@ def load_template(vnx_home: str, project_root: str) -> dict:
     with open(template_path, "r") as f:
         raw = f.read()
 
-    # Substitute template variables
-    rendered = raw.replace("{{PROJECT_ROOT}}", project_root)
+    # Substitute template variables. VNX_HOME is where the shared scripts/
+    # tree actually lives (embedded: a hidden dir under the project's .claude/,
+    # central: the shared per-machine install, dev checkout: the repo itself)
+    # — distinct from PROJECT_ROOT, which only equals VNX_HOME in the
+    # dev-checkout case. A hook command that hardcodes {{PROJECT_ROOT}}/scripts/... breaks in
+    # embedded and central installs. See #1023.
+    rendered = raw.replace("{{VNX_HOME}}", vnx_home)
+    rendered = rendered.replace("{{PROJECT_ROOT}}", project_root)
 
     try:
         return json.loads(rendered)

--- a/templates/settings_vnx_keys.json.tmpl
+++ b/templates/settings_vnx_keys.json.tmpl
@@ -61,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash {{PROJECT_ROOT}}/scripts/hooks/pretooluse_block_raw_claude_spawn.sh",
+            "command": "bash {{VNX_HOME}}/scripts/hooks/pretooluse_block_raw_claude_spawn.sh",
             "timeout": 5000
           }
         ]
@@ -85,7 +85,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "if [[ \"$PWD\" == */T0 ]]; then {{PROJECT_ROOT}}/scripts/userpromptsubmit_intelligence_inject.sh; elif [[ \"$PWD\" == */T1 ]] || [[ \"$PWD\" == */T2 ]] || [[ \"$PWD\" == */T3 ]]; then {{PROJECT_ROOT}}/scripts/userpromptsubmit_worker_intelligence_inject.sh; else echo '{\"decision\": \"allow\"}'; fi",
+            "command": "if [[ \"$PWD\" == */T0 ]]; then {{VNX_HOME}}/scripts/userpromptsubmit_intelligence_inject.sh; elif [[ \"$PWD\" == */T1 ]] || [[ \"$PWD\" == */T2 ]] || [[ \"$PWD\" == */T3 ]]; then {{VNX_HOME}}/scripts/userpromptsubmit_worker_intelligence_inject.sh; else echo '{\"decision\": \"allow\"}'; fi",
             "timeout": 8000
           }
         ]

--- a/tests/test_pool_worker_runner.py
+++ b/tests/test_pool_worker_runner.py
@@ -220,11 +220,27 @@ class TestStateDirResolution(unittest.TestCase):
             result = _resolve_state_dir()
         self.assertEqual(result, Path("/tmp/mystate"))
 
-    def test_both_absent_returns_default(self):
+    def test_both_absent_uses_canonical_resolver(self):
+        """No env vars set -> resolves via vnx_paths.resolve_paths(), not a repo-relative guess.
+
+        A raw _LIB_DIR.parents[1] / ".vnx-data" / "state" default would resolve the
+        KEYSTONE (not the project's ~/.vnx-data/<project>) in a central install. See #1023.
+        """
         stripped = {k: v for k, v in os.environ.items()
                     if k not in ("VNX_STATE_DIR", "VNX_DATA_DIR")}
         with patch.dict(os.environ, stripped, clear=True):
-            result = _resolve_state_dir()
+            with patch("pool_worker_runner._canonical_data_dir",
+                        return_value=Path("/tmp/canonical-project/.vnx-data")):
+                result = _resolve_state_dir()
+        self.assertEqual(result, Path("/tmp/canonical-project/.vnx-data") / "state")
+
+    def test_both_absent_falls_back_when_canonical_resolver_unavailable(self):
+        """Canonical resolver import/call failure -> last-resort repo-relative fallback."""
+        stripped = {k: v for k, v in os.environ.items()
+                    if k not in ("VNX_STATE_DIR", "VNX_DATA_DIR")}
+        with patch.dict(os.environ, stripped, clear=True):
+            with patch("pool_worker_runner._canonical_data_dir", return_value=None):
+                result = _resolve_state_dir()
         self.assertTrue(str(result).endswith(os.path.join(".vnx-data", "state")))
 
 

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -665,6 +665,63 @@ def _check_hook_paths(project_dir: Path) -> Check:
     )
 
 
+def _check_embedded_path_assumptions() -> Check:
+    """WARN when scripts/lib contains __file__-anchored .vnx-data/ROADMAP.yaml derivations.
+
+    Central-mode-path-correctness (#1023/#1024): a bare ``Path(__file__)….parent…``
+    walk that builds a ``.vnx-data``/``ROADMAP.yaml`` path resolves the KEYSTONE
+    (``~/.vnx-system/versions/<v>/.vnx-data``) instead of the project's
+    ``~/.vnx-data/<project>`` in a central install. Delegates to the AST-based
+    ``scripts/check_no_file_derived_data_paths.py`` detector — which carries a
+    grandfathered allowlist for already-migrated last-resort fallbacks and traces
+    module-level marker constants (e.g. ``_DEFAULT_RELATIVE_PATH = Path(".vnx-data/x")``
+    joined against a file-anchored root elsewhere) — so this stays advisory-accurate
+    with no false positives on doc literals or intentional defensive fallbacks.
+
+    Scans the resolved engine root (VNX_HOME-equivalent: the central symlink
+    target, the embedded project copy, or the dev checkout), NOT project_dir —
+    ``scripts/lib`` is framework code, not project code, and only exists inside
+    the engine tree.
+    """
+    try:
+        engine_root = _engine.ensure_engine_on_path()
+        import check_no_file_derived_data_paths as _checker
+    except Exception as exc:
+        return Check(
+            name="paths:embedded-assumptions",
+            status=WARN,
+            detail=f"could not load central-mode path checker: {exc}",
+        )
+
+    try:
+        violations = _checker.scan_dir(engine_root)
+    except Exception as exc:
+        return Check(
+            name="paths:embedded-assumptions",
+            status=WARN,
+            detail=f"central-mode path checker failed: {exc}",
+        )
+
+    if violations:
+        shown = "; ".join(f"{rel}:{lineno} ({seg})" for rel, lineno, seg in violations[:5])
+        more = f" (+{len(violations) - 5} more)" if len(violations) > 5 else ""
+        return Check(
+            name="paths:embedded-assumptions",
+            status=WARN,
+            detail=(
+                f"{len(violations)} __file__-anchored .vnx-data/ROADMAP.yaml path "
+                f"derivation(s) in scripts/lib — resolves the keystone, not the "
+                f"project, in a central install. Route through vnx_paths.resolve_paths() "
+                f"instead: {shown}{more}"
+            ),
+        )
+    return Check(
+        name="paths:embedded-assumptions",
+        status=PASS,
+        detail="no __file__-anchored .vnx-data/ROADMAP.yaml path derivations in scripts/lib",
+    )
+
+
 def vnx_doctor(args) -> int:
     project_dir = Path(args.project_dir).resolve()
     emit_json = getattr(args, "json", False)
@@ -688,6 +745,7 @@ def vnx_doctor(args) -> int:
     checks.extend(_check_worktree_orphans(project_dir))
     checks.append(_check_active_drain(data_root))
     checks.append(_check_hook_paths(project_dir))
+    checks.append(_check_embedded_path_assumptions())
 
     passed = sum(1 for c in checks if c.status == PASS)
     warned = sum(1 for c in checks if c.status == WARN)


### PR DESCRIPTION
## Summary
- Broad sweep for the `central-mode-path-correctness` track. Finds and fixes remaining embedded/co-located-layout path assumptions so central-mode projects resolve state correctly, and extends `vnx doctor` so the class stays caught.
- Migrates all 16 `GRANDFATHERED` entries in `scripts/check_no_file_derived_data_paths.py` — the "prior WIP" the track referenced — to try `vnx_paths.resolve_paths()` first; the `__file__`-anchored expression now only fires as a defensive last resort.
- Strengthens the AST checker itself: adds module-level marker-constant tracing so `root / _DEFAULT_RELATIVE_PATH`-style indirection (found live in `strategy/roadmap.py` and `strategy/decisions.py`) is no longer invisible to the gate.
- Fixes 7 bare `.vnx-data/...` CWD-relative literal fallbacks with zero canonical-resolver attempt (`t0_lifecycle_cli.py`, `build_decisions_digest.py`, `shadow_report.py`, `f39/gate_locks.py`).
- Fixes `templates/settings_vnx_keys.json.tmpl`: 3 hook commands were hardcoded relative to `{{PROJECT_ROOT}}` instead of `{{VNX_HOME}}` — wrong for every install mode except a dev checkout where the two happen to coincide. `vnx_settings_merge.py` never substituted `{{VNX_HOME}}` at all.
- Fixes `headless_dispatch_writer.py::_skills_dir()` — walked up from `__file__` instead of using `vnx_paths`' `VNX_SKILLS_DIR` resolution (class 5).
- Extends `vnx doctor` with a new `paths:embedded-assumptions` WARN-level check that delegates to the AST checker against the resolved engine root, so regressions in this class are caught going forward.

## Changes
**Migrated to canonical-resolver-first (class 3, `__file__`-anchored):**
- `scripts/lib/governance_audit.py`, `governance_enforcer.py`, `pool_worker_runner.py`, `llm_decision_router.py`, `receipt_classifier.py`, `session_store.py`, `worker_health_monitor.py`, `intelligence_dashboard_data.py`, `pattern_extractor.py`, `intelligence_backfill.py`, `event_analyzer.py`, `headless_dispatch_daemon.py`, `subprocess_adapter.py` (`trigger_report_pipeline`)

**Fixed indirect marker-constant evasion of the AST gate (class 3):**
- `scripts/lib/strategy/roadmap.py`, `scripts/lib/strategy/decisions.py`

**Fixed bare CWD-relative literal fallbacks (class 1):**
- `scripts/t0_lifecycle_cli.py`, `scripts/build_decisions_digest.py`, `scripts/shadow_report.py`, `scripts/f39/gate_locks.py`

**Fixed hardcoded hook paths (class 4):**
- `templates/settings_vnx_keys.json.tmpl`, `scripts/vnx_settings_merge.py`

**Fixed skills-path assumption (class 5):**
- `scripts/lib/headless_dispatch_writer.py::_skills_dir()`

**Strengthened the detector + doctor:**
- `scripts/check_no_file_derived_data_paths.py` — module-level marker-constant tracing, GRANDFATHERED dict reconciled to post-migration segment text
- `vnx_cli/commands/doctor.py` — new `paths:embedded-assumptions` check

**Test fix:**
- `tests/test_pool_worker_runner.py` — `test_both_absent_returns_default` asserted the OLD buggy CWD-relative fallback; replaced with a canonical-resolver-first test plus a negative-path test for when the resolver is unavailable.

## Test plan
- [x] `python3 scripts/check_no_file_derived_data_paths.py .` → PASS (0 violations)
- [x] Confirmed the strengthened checker catches the pre-fix bug: replayed against `git show HEAD:scripts/lib/strategy/roadmap.py` / `decisions.py` → both correctly flagged
- [x] `PYTHONPATH=. python3 -m vnx_cli.main doctor --project-dir .` → 19 passed, 0 warned, 0 failed (new `paths:embedded-assumptions` check PASSes)
- [x] `bash bin/vnx doctor` → 37 passed, 7 warnings (pre-existing dev-checkout warnings only), 0 failed
- [x] Simulated CI's "Legacy path gate" ripgrep pattern locally against `scripts/` → no matches
- [x] `tests/test_central_mode_path_gate.py` + `tests/test_central_mode_path_resolution.py` → 47 passed
- [x] `tests/test_vnx_doctor_template_scan.py` → 6 passed (a stray comment of mine initially tripped `vnx_doctor.sh`'s forbidden-path grep; reworded)
- [x] Targeted regression sweep across every touched module's test file — see report for full list; only `test_pool_worker_runner.py` needed a genuine update (asserted the old buggy behavior), everything else passes unchanged
- [x] Confirmed a handful of failures encountered along the way are pre-existing and unrelated (byte-identical failure on `git stash`'d baseline): `test_llm_decision_router.py::test_ollama_successful_response`, `test_receipt_classifier.py::test_provider_ollama_invokes_correct_cli`, `test_strategy_roadmap[_real_file].py` committed-roadmap tests, `test_project_status_hook.py` (2), `test_headless_dispatch_daemon_wave5.py::TestDeliverFallbackPathPropagatesPrId` (2), `test_subprocess_adapter_pr3.py::test_extracted_from_first_init_only`, and 14 in `test_vnx_doctor_strict.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)