### PR TITLE
docs(applications): coding + finance application docs

### DIFF
--- a/docs/applications/README.md
+++ b/docs/applications/README.md
@@ -1,0 +1,14 @@
+# Applications
+
+VNX is a governance layer for AI agents: every unit of work is authorized, reviewed by a human, and recorded as an append-only receipt. The mechanism is domain-agnostic. What makes it useful for coding agents — a tamper-evident trail of who did what, a gate before anything ships, and measurable process quality — is exactly what regulated domains have always demanded.
+
+This folder documents where that governance layer fits.
+
+| Application | What it covers |
+|---|---|
+| [Coding agents](coding-agents.md) | The proven, in-production application: governing multi-agent software work end to end. |
+| [Finance & compliance](finance.md) | The same ledger discipline applied to finance processes — the origin the model was built from. |
+
+The core primitive is the same everywhere: a **dispatch** (one authorized unit of work) produces a **receipt** (one append-only ledger line), and nothing advances without a **human gate**. The two documents above show what that looks like in two very different domains.
+
+For the underlying mechanics, see [`docs/core/11_RECEIPT_FORMAT.md`](../core/11_RECEIPT_FORMAT.md) (the receipt/ledger spec) and [`docs/core/00_VNX_ARCHITECTURE.md`](../core/00_VNX_ARCHITECTURE.md).

--- a/docs/applications/coding-agents.md
+++ b/docs/applications/coding-agents.md
@@ -1,0 +1,34 @@
+# Coding agents
+
+The application VNX was built for: governing multi-agent software development so that every change is authorized, reviewed, and recorded — instead of trusting a black box.
+
+## What it does
+
+When an AI agent writes code, three questions usually go unanswered: what exactly did it do, who approved it, and was it any good? VNX answers all three by construction. Every piece of work runs as a **dispatch**, produces an append-only **receipt**, and passes a **human gate** before it ships. The result is a complete, tamper-evident audit trail of every agent action, plus process-quality metrics you can actually track.
+
+## How it works
+
+The unit of work is a dispatch: one scoped task, sent through a single entry door that decides how it runs.
+
+1. **Authorize.** A dispatch is staged and only becomes runnable after a human promotes it. No agent starts work on its own.
+2. **Isolate and build.** A worker agent runs in its own git worktree, on its own branch. It never touches the main line directly.
+3. **Review — adversarial, not self-certifying.** The change goes through review gates: an independent model reviews the diff to *refute* it (find the bug, the security hole, the missed edge case), and deterministic CI runs the full test suite. Developers do not certify their own work.
+4. **Human gate.** Nothing merges without a person authorizing the merge, and only when the gate and CI are green. This is the last set of hands, always human.
+5. **Record — and link.** On completion, an append-only receipt is written to an NDJSON ledger: the task, the outcome, the evidence, the timing. Receipts are never edited — only appended. Crucially, the receipt links the exact **instruction** (the dispatch that was sent) to its **output** (the result, the log stream) and to the **commit** it produced. The chain runs both ways: from any receipt you can recover the instruction that caused it and the code change it produced, and from any commit you can find the receipt and the instruction behind it.
+
+State lives per project, so one project's ledger can never bleed into another's.
+
+Because instruction, outcome, and resulting change are linked — not just logged side by side — the whole run is **replayable as a picture, not only as scattered details.** You can reconstruct not just "what line changed" but "which instruction, judged how, produced which change, approved by whom." That is the difference between a log and a ledger.
+
+## Why it is useful
+
+- **A real audit trail.** Every agent action is a ledger line you can read back months later: what ran, who approved it, whether it passed the gate. Delete-and-pretend is not possible — the ledger only grows.
+- **Bugs caught before they ship.** The adversarial review gate repeatedly catches issues the builder's own tests miss — fail-open security bypasses, off-by-one boundaries, wrong assumptions — because the reviewer's job is to break the change, not confirm it.
+- **Process quality you can measure.** Because every dispatch is recorded, you get statistical-process-control metrics on the work itself: First-Pass Yield (how often work passes clean the first time) and rework rate (how often it comes back). Governance stops being a feeling and becomes a number.
+- **Human in the loop where it counts.** The machine proposes and builds; a person decides. The gate is not a rubber stamp — a red gate or a red CI blocks the merge, no exceptions.
+
+## In practice
+
+VNX has run this way in production across roughly 900 sessions, producing on the order of 8,000 governed receipts (13,000+ including benchmark runs), with an 87% token reduction in the dispatch path versus a naive approach. It is open source: [github.com/Vinix24/vnx-orchestration](https://github.com/Vinix24/vnx-orchestration).
+
+The point is not the numbers. The point is that a black box became a glass box: you can see, review, and audit every step an AI agent takes — and the next domain that needs exactly that discipline is [finance](finance.md).

--- a/docs/applications/finance.md
+++ b/docs/applications/finance.md
@@ -1,0 +1,43 @@
+# Finance & compliance
+
+The governance model in this repository was not designed for code first. It was designed by someone who spent a decade in finance — ISO, ISAE, audit trails, segregation of duties — and then applied that discipline to AI agents. This document runs the mapping in the other direction: how the same ledger discipline applies to finance processes.
+
+If you come from finance, none of the ideas below are new. You have run controlled, auditable processes your whole career. What is new is that an AI agent can now run inside those same controls, instead of beside them as an unaccountable black box.
+
+## The mapping
+
+Every primitive in the framework has a direct finance equivalent.
+
+| Framework primitive | Finance equivalent |
+|---|---|
+| Receipt per dispatch | Journal entry per transaction |
+| Append-only NDJSON ledger | Immutable general ledger — you append, you never overwrite |
+| Human gate / review gate | Four-eyes principle / segregation of duties |
+| First-Pass Yield + rework rate | Statistical process control on the process itself |
+| Hash-chained receipts | Tamper-evidence — a changed record breaks the chain |
+| Dispatch → review → human merge | Authorization flow with recorded approval |
+| Instruction ↔ output ↔ change, linked | Source document ↔ posted entry ↔ reported figure — full two-way traceability |
+| Per-project state | Entity/ledger separation |
+
+This is not an analogy stretched to fit. The append-only receipt *is* a journal entry. The reason it maps cleanly is that it was taken from finance in the first place.
+
+## How you would apply it
+
+Take any finance process you would consider handing partly to an AI agent — invoice processing, reconciliation, drafting journal entries, expense checks, first-line control testing. Instead of letting the model act and hoping, you run it inside the same four controls the framework already enforces:
+
+1. **Every action becomes a journal entry.** The agent reads an invoice, proposes a booking, flags an exception — each step writes a receipt: what it did, on what input, with what confidence, when, and under whose authority. Nothing the agent does is off the record.
+2. **The ledger is append-only and tamper-evident.** Corrections are new entries, never edits. The receipts are hash-chained, so any attempt to rewrite history breaks the chain and is detectable. This is the audit-trail integrity an external auditor asks for.
+3. **A human authorizes the last set.** The agent proposes; a person approves the entry that actually posts. Four-eyes is built in, not bolted on — and the approval itself is recorded as part of the trail.
+4. **You measure the process, not just the output.** First-Pass Yield tells you how often the agent's work is right the first time; rework rate tells you how often it comes back. You are running SPC on an AI-driven finance process, exactly as you would on any controlled process.
+
+And because the instruction is linked to its output and to the resulting entry, the process is **replayable, not just inspectable.** You can take any reported figure and walk it all the way back — to the posting, to the agent's action, to the exact instruction and the input it ran on — and walk it forward again. That two-way reconstruction is precisely what an audit walkthrough is: not a sample of details, but the whole picture, re-derivable on demand.
+
+The result is an AI-assisted finance workflow that an auditor can read end to end: every decision, every approval, every correction, in an immutable ledger — mapping naturally onto ISAE 3402 / internal-control language.
+
+## Why it matters
+
+The usual objection to AI in finance is not capability. It is accountability: you cannot audit a black box, and finance does not run on trust-me. That is the gap this closes. The same mechanism that makes AI coding work auditable — see [coding agents](coding-agents.md) — makes AI-driven finance processes as auditable as your general ledger.
+
+## Scope
+
+This is a conceptual document: how the discipline maps, and how you would apply it. It describes the governance model (open source at [github.com/Vinix24/vnx-orchestration](https://github.com/Vinix24/vnx-orchestration)), not a packaged finance product. If you want to explore what this would look like for a specific finance process, that mapping is the natural starting point — take one process, run it through the four controls above, and see what the ledger tells you.


### PR DESCRIPTION
## Summary
- Adds `docs/applications/` with three verbatim-authored docs: `README.md` (index), `coding-agents.md`, and `finance.md`
- Maps VNX's glass-box governance primitives (dispatch, receipt, human gate) onto two domains: the proven coding-agent application and the finance/compliance origin the ledger discipline was drawn from
- Pure documentation addition — no code, no runtime state changes

## Test plan
- [x] Confirmed byte-for-byte match between staged `/tmp/*.txt` sources and the committed `.md` files (`diff` clean on all three)
- [x] Confirmed all three files are non-empty
- [x] Confirmed relative links resolve: README ↔ coding-agents.md ↔ finance.md (same folder), and `../core/11_RECEIPT_FORMAT.md` / `../core/00_VNX_ARCHITECTURE.md` (both exist)
- [x] Confirmed no unrelated files touched (`git status` staged only the three new files)

Dispatch-ID: 20260713-085536-docs-applications

🤖 Generated with [Claude Code](https://claude.com/claude-code)