### PR TITLE
fix(t0-rotation): pin respawned successor to Opus (t0-opus-only)

### DIFF
--- a/scripts/lib/context_rotation.py
+++ b/scripts/lib/context_rotation.py
@@ -19,8 +19,9 @@ T0-INITIATED, NON-DESTRUCTIVE control-plane on top of it:
   - write_t0_handoff(): writes the repo handoff.md contract (frontmatter +
     "Waar we middenin zitten" / "State" / "Next steps"), fail-soft per
     source (git, horizon, open items each independently guarded).
-  - respawn(): NON-DESTRUCTIVE `tmux new-session -d` of a fresh, bare
-    interactive `claude` (never -p/--print/--dangerously-skip-permissions —
+  - respawn(): NON-DESTRUCTIVE `tmux new-session -d` of a fresh, Opus-pinned
+    (`--model opus`, per t0-opus-only) interactive `claude` (never
+    -p/--print/--dangerously-skip-permissions —
     the exact form scripts/hooks/pretooluse_block_raw_claude_spawn.sh's own
     header comment marks "Always allowed"; argv[0] is always `tmux`, never
     `claude`, since `claude` only ever appears as a later positional/typed
@@ -74,6 +75,11 @@ HANDOFF_FILENAME = "handoff.md"
 _ROTATION_SUBDIR = ("rotation_handovers",)
 _STATE_SUBDIR = ("state", "rotation")
 _CONFIG_RELATIVE_PATH = Path("configs") / "context_rotation.yaml"
+
+# t0-opus-only (~/.claude/rules/provider-constraints.md): T0 must always run
+# Opus, no Sonnet/Fable downgrade. A bare `claude` inherits the operator's
+# default model, so the respawned successor must pin it explicitly.
+_SUCCESSOR_MODEL = "opus"
 
 # Terminal names flow into path components below (rotation_handoff_dir,
 # durable_state_path, request_marker_path, ready_signal_path). The CLI
@@ -546,7 +552,9 @@ def _default_tmux_spawn(
     *,
     boot_delay_seconds: float = 3.0,
 ) -> None:
-    """Spawn a fresh, bare interactive `claude` in a new detached tmux session.
+    """Spawn a fresh, Opus-pinned interactive `claude` in a new detached tmux
+    session (t0-opus-only: the successor must never inherit the operator's
+    default model — see `_SUCCESSOR_MODEL`).
 
     The session's cwd is `<project_root>/.claude/terminals/T0`, NOT
     project_root itself (OI-619 finding #1): Claude Code's memory-file
@@ -585,7 +593,11 @@ def _default_tmux_spawn(
         timeout=10,
     )
     try:
-        subprocess.run(["tmux", "send-keys", "-t", session_name, "-l", "claude"], check=True, timeout=10)
+        subprocess.run(
+            ["tmux", "send-keys", "-t", session_name, "-l", f"claude --model {_SUCCESSOR_MODEL}"],
+            check=True,
+            timeout=10,
+        )
         subprocess.run(["tmux", "send-keys", "-t", session_name, "Enter"], check=True, timeout=10)
         if boot_delay_seconds > 0:
             time.sleep(boot_delay_seconds)

--- a/tests/test_context_rotation.py
+++ b/tests/test_context_rotation.py
@@ -25,7 +25,8 @@ Covers:
      VNX_T0_ROTATION is unset; writes handoff.md when set.
   8. Guard-safety: the default tmux spawn implementation's argv[0] is always
      "tmux" — "claude" never appears as an invoked executable, only as a
-     literal send-keys payload with no flags.
+     literal send-keys payload (Opus-pinned via `--model opus`, no dangerous
+     flags).
 """
 
 from __future__ import annotations
@@ -974,6 +975,27 @@ class TestGuardSafeSpawnShape:
         dangerous_flags = {"-p", "--print", "--dangerously-skip-permissions"}
         for cmd in calls:
             assert not (dangerous_flags & set(cmd)), f"dangerous flag present in {cmd}"
+
+    def test_default_tmux_spawn_pins_successor_to_opus(self) -> None:
+        """t0-opus-only (~/.claude/rules/provider-constraints.md): the
+        respawned successor must never inherit the operator's default model.
+        A bare `claude` send-keys payload silently boots on whatever model is
+        configured as default (verified live: booted as Fable 5, not Opus) —
+        the launch string must explicitly pin `--model opus`."""
+        calls: List[List[str]] = []
+
+        import unittest.mock as mock
+        with mock.patch("context_rotation.subprocess.run") as run_mock, \
+             mock.patch("context_rotation.time.sleep", lambda *_: None):
+            run_mock.side_effect = lambda cmd, **kw: calls.append(list(cmd))
+            cr._default_tmux_spawn("vnx-t0-rotation-t0-abc123", "/tmp/repo", "resume prompt text", boot_delay_seconds=0)
+
+        send_keys_calls = [c for c in calls if c[:2] == ["tmux", "send-keys"]]
+        launch_calls = [c for c in send_keys_calls if "claude" in " ".join(c)]
+        assert len(launch_calls) == 1, f"expected exactly one claude launch payload, got: {send_keys_calls}"
+        launch_payload = launch_calls[0][-1]
+        assert launch_payload == "claude --model opus"
+        assert cr._SUCCESSOR_MODEL == "opus"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- The T0 context-rotation respawn spawns the successor by typing a bare `claude` into a fresh detached tmux session (`scripts/lib/context_rotation.py`, `_default_tmux_spawn`).
- A bare `claude` inherits the operator's default model — verified live, the successor booted as Fable 5, not Opus. This silently violates the `t0-opus-only` provider constraint (T0 must run Opus, no downgrade).
- Fix: the send-keys launch string now pins `--model opus`, built from a new module-level `_SUCCESSOR_MODEL = "opus"` constant with a comment citing `t0-opus-only`.

## Test plan
- [x] `python3 -m pytest tests/test_context_rotation.py -k "TestGuardSafeSpawnShape or TestRespawnT0Workdir or spawn"` — 15 passed
- [x] `python3 -m pytest tests/test_context_rotation.py` (full suite) — 78 passed
- [x] Added `test_default_tmux_spawn_pins_successor_to_opus` asserting the launch payload is exactly `claude --model opus`, so a future edit that drops the pin fails CI
- [x] Confirmed `RotationPolicy.enabled` default (`False`) and the rest of `_default_tmux_spawn` (T0-workdir cwd, resume-prompt send-keys, Enter-as-separate-keystroke) are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)