### PR TITLE
fix(agent-resolver): fallback-aware agent availability readout

### DIFF
--- a/scripts/lib/agent_resolver.py
+++ b/scripts/lib/agent_resolver.py
@@ -78,6 +78,82 @@ def _resolve_agent_claude_md(
     return None
 
 
+@dataclass(frozen=True)
+class AvailableAgent:
+    """One agent discovered by ``list_available_agents()``, with provenance."""
+
+    name: str
+    source: str  # "project" | "engine" | "examples"
+    claude_md: Path
+
+
+def list_available_agents(
+    project_dir: Path | str,
+    engine_root: Path | str | None = None,
+) -> list[AvailableAgent]:
+    """Enumerate every agent resolvable across the full chain ``dispatch_agent`` walks.
+
+    Unions ``project_dir/agents``, ``project_dir/examples``,
+    ``engine_root/agents``, and ``engine_root/examples`` — the same dirs
+    ``_resolve_agent_claude_md`` checks, in the same precedence order. A
+    subdirectory only counts as an agent when ``_resolve_agent_claude_md``
+    would actually resolve it (i.e. it has a ``CLAUDE.md``), so this stays a
+    single source of truth with the resolver rather than a parallel
+    "looks like a dir" heuristic.
+
+    Dedups by name: on a clash the first tier in resolution order wins
+    (project agents > project examples > engine agents > engine examples),
+    so the listing matches what ``dispatch_agent`` would actually resolve
+    for that name. ``source`` reports which tier won: project-local
+    ``agents/`` is ``"project"``, engine ``agents/`` is ``"engine"``, and
+    either ``examples/`` tier is ``"examples"``.
+    """
+    project_dir = Path(project_dir)
+    engine_root = Path(engine_root) if engine_root is not None else None
+
+    tiers: list[Path] = [project_dir / "agents", project_dir / "examples"]
+    if engine_root is not None:
+        tiers.append(engine_root / "agents")
+        tiers.append(engine_root / "examples")
+
+    candidate_names: dict[str, None] = {}
+    for tier_dir in tiers:
+        if not tier_dir.is_dir():
+            continue
+        try:
+            entries = list(tier_dir.iterdir())
+        except OSError:
+            continue
+        for entry in entries:
+            if entry.is_dir() and _is_safe_agent_name(entry.name):
+                candidate_names.setdefault(entry.name, None)
+
+    project_agents_dir = project_dir / "agents"
+    project_examples_dir = project_dir / "examples"
+    engine_agents_dir = engine_root / "agents" if engine_root is not None else None
+    engine_examples_dir = engine_root / "examples" if engine_root is not None else None
+
+    found: list[AvailableAgent] = []
+    for name in sorted(candidate_names):
+        claude_md = _resolve_agent_claude_md(name, project_dir, engine_root)
+        if claude_md is None:
+            continue
+        tier_dir = claude_md.parent.parent
+        if tier_dir == project_agents_dir:
+            source = "project"
+        elif tier_dir == project_examples_dir:
+            source = "examples"
+        elif engine_agents_dir is not None and tier_dir == engine_agents_dir:
+            source = "engine"
+        elif engine_examples_dir is not None and tier_dir == engine_examples_dir:
+            source = "examples"
+        else:
+            source = "engine"
+        found.append(AvailableAgent(name=name, source=source, claude_md=claude_md))
+
+    return found
+
+
 def _coerce_str(value: Any) -> str | None:
     if value is None:
         return None

--- a/scripts/lib/agent_resolver.py
+++ b/scripts/lib/agent_resolver.py
@@ -8,6 +8,7 @@ schema into a typed, backward-compatible result.
 
 from __future__ import annotations
 
+import logging
 import os
 import re
 from dataclasses import dataclass, field
@@ -15,6 +16,8 @@ from pathlib import Path
 from typing import Any, Mapping
 
 import yaml
+
+logger = logging.getLogger(__name__)
 
 VNX_AGENT_FOLDERS_ENV = "VNX_AGENT_FOLDERS"
 
@@ -107,6 +110,12 @@ def list_available_agents(
     for that name. ``source`` reports which tier won: project-local
     ``agents/`` is ``"project"``, engine ``agents/`` is ``"engine"``, and
     either ``examples/`` tier is ``"examples"``.
+
+    A tier directory that does not exist is skipped quietly (nothing to
+    enumerate). A tier directory that exists but raises ``OSError`` on
+    read (e.g. a permissions failure) is logged as a WARNING via this
+    module's logger and skipped — the other tiers are still enumerated,
+    but the gap is never silently dropped.
     """
     project_dir = Path(project_dir)
     engine_root = Path(engine_root) if engine_root is not None else None
@@ -122,7 +131,12 @@ def list_available_agents(
             continue
         try:
             entries = list(tier_dir.iterdir())
-        except OSError:
+        except OSError as exc:
+            logger.warning(
+                "list_available_agents: unreadable tier %s — %s (skipping tier, other tiers still enumerated)",
+                tier_dir,
+                exc,
+            )
             continue
         for entry in entries:
             if entry.is_dir() and _is_safe_agent_name(entry.name):

--- a/tests/test_agent_resolver.py
+++ b/tests/test_agent_resolver.py
@@ -3,6 +3,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -227,6 +228,40 @@ class TestListAvailableAgents:
         (unsafe_dir / "CLAUDE.md").write_text("# hidden")
         agents = list_available_agents(project_dir)
         assert [a.name for a in agents] == ["valid-agent"]
+
+    def test_unreadable_tier_is_logged_not_silently_dropped(self, tmp_path, caplog):
+        """An OSError on one tier must be observable (logged), not silently swallowed.
+
+        Regression for a codex finding on PR #1156: `except OSError: continue`
+        with no logging meant doctor/status could silently under-count or
+        report zero agents on a permissions failure. The other (readable)
+        tiers must still be enumerated.
+
+        The unreadable tier is deliberately the *lowest*-precedence one
+        (engine examples/) so resolving the readable agent (found in the
+        highest-precedence project agents/ tier) never probes a path under
+        the unreadable dir — this isolates the enumeration-loop fix from the
+        unrelated, pre-existing gap where ``_resolve_agent_claude_md``'s bare
+        ``Path.exists()`` does not swallow ``PermissionError``.
+        """
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "readable-agent", rel="agents")
+        engine_root = tmp_path / "engine"
+        unreadable_dir = engine_root / "examples"
+        unreadable_dir.mkdir(parents=True)
+        unreadable_dir.chmod(0o000)
+
+        try:
+            with caplog.at_level(logging.WARNING, logger="agent_resolver"):
+                agents = list_available_agents(project_dir, engine_root=engine_root)
+        finally:
+            unreadable_dir.chmod(0o755)
+
+        assert [a.name for a in agents] == ["readable-agent"]
+        assert any(
+            "list_available_agents" in rec.message and str(unreadable_dir) in rec.message
+            for rec in caplog.records
+        )
 
 
 def test_resolve_agent_rejects_path_traversal(tmp_path):

--- a/tests/test_agent_resolver.py
+++ b/tests/test_agent_resolver.py
@@ -10,7 +10,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT / "scripts" / "lib") not in sys.path:
     sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
 
-from agent_resolver import agent_folders_enabled, resolve_agent
+from agent_resolver import agent_folders_enabled, list_available_agents, resolve_agent
 
 
 def _make_agent(base: Path, name: str, rel: str = "agents", config: str | None = None) -> Path:
@@ -143,6 +143,90 @@ class TestRobustness:
         agent_dir = _make_agent(tmp_path, "bad-yaml", config="not yaml: [")
         cfg = resolve_agent("bad-yaml", tmp_path)
         assert cfg is not None and cfg.claude_md == agent_dir / "CLAUDE.md" and cfg.provider == "claude"
+
+
+class TestListAvailableAgents:
+    def test_empty_everywhere_returns_empty_list(self, tmp_path):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        assert list_available_agents(project_dir) == []
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        assert list_available_agents(project_dir, engine_root=engine_root) == []
+
+    def test_project_only(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "local-agent")
+        agents = list_available_agents(project_dir)
+        assert [a.name for a in agents] == ["local-agent"]
+        assert agents[0].source == "project"
+
+    def test_engine_only_agents_fleet_wide(self, tmp_path):
+        """An engine-fleet-only project (no local agents/) still lists engine agents."""
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "backend-developer", rel="agents")
+        project_dir = tmp_path / "empty-project"
+        project_dir.mkdir()  # no local agents/ or examples/
+        agents = list_available_agents(project_dir, engine_root=engine_root)
+        assert [a.name for a in agents] == ["backend-developer"]
+        assert agents[0].source == "engine"
+
+    def test_examples_included_project_and_engine(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "demo-agent", rel="examples")
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "engine-demo", rel="examples")
+        agents = list_available_agents(project_dir, engine_root=engine_root)
+        names = {a.name: a.source for a in agents}
+        assert names == {"demo-agent": "examples", "engine-demo": "examples"}
+
+    def test_union_with_name_clash_project_wins(self, tmp_path):
+        project_dir = tmp_path / "project"
+        engine_root = tmp_path / "engine"
+        _make_agent(project_dir, "shared", rel="agents")
+        _make_agent(engine_root, "shared", rel="agents")
+        agents = list_available_agents(project_dir, engine_root=engine_root)
+        assert len(agents) == 1
+        assert agents[0].name == "shared"
+        assert agents[0].source == "project"
+        assert agents[0].claude_md == project_dir / "agents" / "shared" / "CLAUDE.md"
+
+    def test_union_across_all_four_tiers_dedup_and_count(self, tmp_path):
+        project_dir = tmp_path / "project"
+        engine_root = tmp_path / "engine"
+        _make_agent(project_dir, "proj-agent", rel="agents")
+        _make_agent(project_dir, "proj-example", rel="examples")
+        _make_agent(engine_root, "engine-agent", rel="agents")
+        _make_agent(engine_root, "engine-example", rel="examples")
+        # a clash between project examples and engine agents — project tier wins
+        _make_agent(project_dir, "clashed", rel="examples")
+        _make_agent(engine_root, "clashed", rel="agents")
+
+        agents = list_available_agents(project_dir, engine_root=engine_root)
+        by_name = {a.name: a.source for a in agents}
+        assert by_name == {
+            "proj-agent": "project",
+            "proj-example": "examples",
+            "engine-agent": "engine",
+            "engine-example": "examples",
+            "clashed": "examples",
+        }
+
+    def test_ignores_dirs_without_claude_md(self, tmp_path):
+        project_dir = tmp_path / "project"
+        agents_dir = project_dir / "agents"
+        agents_dir.mkdir(parents=True)
+        (agents_dir / "not-an-agent").mkdir()
+        assert list_available_agents(project_dir) == []
+
+    def test_rejects_unsafe_names(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "valid-agent")
+        unsafe_dir = project_dir / "agents" / ".hidden-agent"
+        unsafe_dir.mkdir(parents=True)
+        (unsafe_dir / "CLAUDE.md").write_text("# hidden")
+        agents = list_available_agents(project_dir)
+        assert [a.name for a in agents] == ["valid-agent"]
 
 
 def test_resolve_agent_rejects_path_traversal(tmp_path):

--- a/tests/test_vnx_cli.py
+++ b/tests/test_vnx_cli.py
@@ -177,10 +177,17 @@ def test_status_empty_project(tmp_path, capsys):
 
 
 def test_status_with_agents(tmp_path, capsys):
-    """Status lists agents from agents/ dir."""
+    """Status lists agents from agents/ dir.
+
+    A subdir only counts as a resolvable agent when it has a CLAUDE.md —
+    matching what dispatch_agent's resolver treats as a valid agent
+    (list_available_agents / _resolve_agent_claude_md), not any bare dir.
+    """
     vnx_init(_init_args(tmp_path))
     (tmp_path / "agents" / "T1").mkdir(parents=True)
+    (tmp_path / "agents" / "T1" / "CLAUDE.md").write_text("# T1\n")
     (tmp_path / "agents" / "T2").mkdir(parents=True)
+    (tmp_path / "agents" / "T2" / "CLAUDE.md").write_text("# T2\n")
 
     rc = vnx_status(_status_args(tmp_path))
 
@@ -194,6 +201,7 @@ def test_status_json_output(tmp_path):
     """Status --json returns valid JSON with expected structure."""
     vnx_init(_init_args(tmp_path))
     (tmp_path / "agents" / "T1").mkdir(parents=True)
+    (tmp_path / "agents" / "T1" / "CLAUDE.md").write_text("# T1\n")
 
     import io
     from contextlib import redirect_stdout

--- a/tests/unit/vnx_cli/commands/test_doctor.py
+++ b/tests/unit/vnx_cli/commands/test_doctor.py
@@ -1,12 +1,19 @@
 #!/usr/bin/env python3
-"""Unit tests for vnx_cli/commands/doctor.py hook-path probe."""
+"""Unit tests for vnx_cli/commands/doctor.py hook-path probe and agent enumeration."""
 
 import json
 from pathlib import Path
 
 import pytest
 
-from vnx_cli.commands.doctor import _check_hook_paths
+from vnx_cli.commands.doctor import PASS, WARN, _check_agents, _check_hook_paths
+
+
+def _make_agent(base: Path, name: str, rel: str = "agents") -> Path:
+    agent_dir = base / rel / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "CLAUDE.md").write_text(f"# {name}")
+    return agent_dir
 
 
 def _write_settings(project_dir: Path, settings: dict) -> Path:
@@ -141,3 +148,60 @@ class TestHookPathResolution:
         result = _check_hook_paths(project)
 
         assert result.status == "PASS"
+
+
+class TestCheckAgents:
+    """The `agents` check must count the FULL resolution chain, not just project-local."""
+
+    def test_project_local_only_passes(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "local-agent", rel="agents")
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        monkeypatch.setattr("vnx_cli.commands.doctor._engine.engine_root", lambda: engine_root)
+
+        result = _check_agents(project_dir)
+        assert result.status == PASS
+        assert "1 agent(s) resolvable" in result.detail
+        assert "project" in result.detail
+
+    def test_engine_fleet_only_project_no_false_zero(self, tmp_path, monkeypatch):
+        """Project-local agents/ empty, engine populated — must NOT WARN '0 agents'.
+
+        This is the exact defect from the dispatch: dispatch_agent resolves via
+        the full chain (project -> engine fallback), so the doctor readout must
+        agree instead of reporting an empty project-local dir as broken.
+        """
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "backend-developer", rel="agents")
+        monkeypatch.setattr("vnx_cli.commands.doctor._engine.engine_root", lambda: engine_root)
+
+        result = _check_agents(project_dir)
+        assert result.status == PASS
+        assert "1 agent(s) resolvable" in result.detail
+        assert "engine" in result.detail
+
+    def test_examples_tier_counted(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "project"
+        _make_agent(project_dir, "demo-agent", rel="examples")
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        monkeypatch.setattr("vnx_cli.commands.doctor._engine.engine_root", lambda: engine_root)
+
+        result = _check_agents(project_dir)
+        assert result.status == PASS
+        assert "1 agent(s) resolvable" in result.detail
+        assert "examples" in result.detail
+
+    def test_empty_everywhere_warns(self, tmp_path, monkeypatch):
+        project_dir = tmp_path / "project"
+        project_dir.mkdir()
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        monkeypatch.setattr("vnx_cli.commands.doctor._engine.engine_root", lambda: engine_root)
+
+        result = _check_agents(project_dir)
+        assert result.status == WARN
+        assert "no agents found" in result.detail.lower()

--- a/tests/unit/vnx_cli/commands/test_status.py
+++ b/tests/unit/vnx_cli/commands/test_status.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""Unit tests for vnx_cli/commands/status.py agent enumeration.
+
+`vnx status --json` must report the FULL agent resolution chain (project
+agents/, project examples/, engine agents/, engine examples/) — the same
+chain dispatch_agent walks — not just the project-local agents/ folder.
+"""
+
+import json
+from argparse import Namespace
+from io import StringIO
+from pathlib import Path
+from unittest.mock import patch
+
+from vnx_cli.commands.status import vnx_status
+
+
+def _make_agent(base: Path, name: str, rel: str = "agents") -> Path:
+    agent_dir = base / rel / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "CLAUDE.md").write_text(f"# {name}")
+    return agent_dir
+
+
+def _init_project(project_dir: Path) -> None:
+    (project_dir / ".vnx").mkdir(parents=True, exist_ok=True)
+
+
+def _run_status_json(project_dir: Path, engine_root: Path, data_root: Path) -> dict:
+    args = Namespace(json=True, tracks=False, project_id=None, project_dir=str(project_dir))
+    with patch("vnx_cli.commands.status._engine.resolve_data_root", return_value=data_root), \
+         patch("vnx_cli.commands.status._engine.engine_root", return_value=engine_root):
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            rc = vnx_status(args)
+    assert rc == 0
+    return json.loads(buf.getvalue())
+
+
+class TestAgentCountFullChain:
+    def test_project_local_only(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _init_project(project_dir)
+        _make_agent(project_dir, "local-agent")
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+
+        out = _run_status_json(project_dir, engine_root, data_root)
+        assert out["agent_count"] == 1
+        assert out["agents"] == ["local-agent"]
+
+    def test_engine_fleet_only_project_no_false_zero(self, tmp_path):
+        """Project-local agents/ absent, engine populated — agent_count must not be 0.
+
+        This is the exact defect from the dispatch: `vnx status --json` read
+        only project_dir/agents and reported agent_count: 0 for an
+        engine-fleet-only project even though dispatch_agent resolves fine
+        via the engine fallback.
+        """
+        project_dir = tmp_path / "project"
+        _init_project(project_dir)
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "backend-developer")
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+
+        out = _run_status_json(project_dir, engine_root, data_root)
+        assert out["agent_count"] == 1
+        assert out["agents"] == ["backend-developer"]
+
+    def test_union_project_and_engine(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _init_project(project_dir)
+        _make_agent(project_dir, "local-agent")
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "backend-developer")
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+
+        out = _run_status_json(project_dir, engine_root, data_root)
+        assert out["agent_count"] == 2
+        assert out["agents"] == ["backend-developer", "local-agent"]
+
+    def test_empty_everywhere(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _init_project(project_dir)
+        engine_root = tmp_path / "engine"
+        engine_root.mkdir()
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+
+        out = _run_status_json(project_dir, engine_root, data_root)
+        assert out["agent_count"] == 0
+        assert out["agents"] == []

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -89,29 +89,49 @@ def _check_directories(project_dir: Path, data_root: Path) -> list[Check]:
         else f"runtime data root missing ({data_root}) — run `vnx init`",
     ))
 
-    agents_dir = project_dir / "agents"
-    if agents_dir.is_dir():
-        agent_dirs = [d for d in agents_dir.iterdir() if d.is_dir()]
-        if agent_dirs:
-            results.append(Check(
-                name="agents",
-                status=PASS,
-                detail=f"{len(agent_dirs)} agent dir(s) found",
-            ))
-        else:
-            results.append(Check(
-                name="agents",
-                status=WARN,
-                detail="agents/ exists but contains no subdirectories",
-            ))
-    else:
-        results.append(Check(
-            name="agents",
-            status=WARN,
-            detail="agents/ directory not found",
-        ))
+    results.append(_check_agents(project_dir))
 
     return results
+
+
+def _check_agents(project_dir: Path) -> Check:
+    """Count agents across the FULL resolution chain ``dispatch_agent`` uses.
+
+    A project-local ``agents/`` folder is only one tier of the chain
+    ``_resolve_agent_claude_md`` walks (project agents/, project examples/,
+    engine agents/, engine examples/). Reading only the project-local dir
+    made doctor WARN "agents/ directory not found" for engine-fleet-only
+    projects that dispatch perfectly fine — WARN only when the full chain
+    yields zero agents.
+    """
+    try:
+        _engine.ensure_engine_on_path()
+        from agent_resolver import list_available_agents
+        agents = list_available_agents(project_dir, engine_root=_engine.engine_root())
+    except Exception as exc:
+        logger.warning("doctor: agent enumeration failed: %s", exc)
+        return Check(
+            name="agents",
+            status=WARN,
+            detail=f"could not enumerate agents: {exc}",
+        )
+
+    if not agents:
+        return Check(
+            name="agents",
+            status=WARN,
+            detail="no agents found in project agents/, project examples/, engine agents/, or engine examples/",
+        )
+
+    by_source: dict[str, int] = {}
+    for agent in agents:
+        by_source[agent.source] = by_source.get(agent.source, 0) + 1
+    breakdown = ", ".join(f"{count} {source}" for source, count in sorted(by_source.items()))
+    return Check(
+        name="agents",
+        status=PASS,
+        detail=f"{len(agents)} agent(s) resolvable ({breakdown})",
+    )
 
 
 def _resolve_central_pin(central_path: Path) -> str:

--- a/vnx_cli/commands/status.py
+++ b/vnx_cli/commands/status.py
@@ -217,13 +217,14 @@ def vnx_status(args) -> int:
 
     recent_completions = [f.name for f in completed_files]
 
-    # Agents
-    agents_dir = project_dir / "agents"
-    agent_names: list[str] = []
-    if agents_dir.is_dir():
-        agent_names = sorted(
-            d.name for d in agents_dir.iterdir() if d.is_dir()
-        )
+    # Agents — full resolution chain (project agents/, project examples/,
+    # engine agents/, engine examples/), matching what dispatch_agent
+    # actually resolves. A project-local-only read undercounted to 0 for
+    # engine-fleet-only projects that dispatch fine.
+    _engine.ensure_engine_on_path()
+    from agent_resolver import list_available_agents
+    available_agents = list_available_agents(project_dir, engine_root=_engine.engine_root())
+    agent_names = sorted(a.name for a in available_agents)
 
     if emit_json:
         output = {


### PR DESCRIPTION
## Summary
- `doctor` and `vnx status --json` read only the project-local `agents/` folder for counting/listing, while `dispatch_agent` resolves via the full chain (project `agents/` -> project `examples/` -> engine `agents/` -> engine `examples/`). Dispatch works fine on an engine-fleet-only project; the availability readout misreported 0, making Mission Control / sales-copilot show "no agents available".
- Added `list_available_agents(project_dir, engine_root=None)` to `scripts/lib/agent_resolver.py` — a full-chain enumeration helper built on the existing `_resolve_agent_claude_md` resolver, so validity ("has a resolvable CLAUDE.md") and precedence (project wins on a name clash) stay a single source of truth with `dispatch_agent`'s own resolution.
- Wired `vnx_cli/commands/doctor.py`'s `agents` check and `vnx_cli/commands/status.py`'s `agent_count`/`agents` to the new helper. `doctor` now WARNs only when the FULL chain yields zero agents, not just the project-local dir.
- Left `dashboard/api_operator.py`'s `_operator_get_agents` (`/api/operator/agents`) untouched — verified it's a hardcoded T0-T3 terminal-slot mapping, a different concept from a dispatchable-agents enumeration, not the mirror of this bug.

## Test plan
- [x] `pytest tests/test_agent_resolver.py -v` — 25 passed (7 new `TestListAvailableAgents` cases: project-only, engine-only fleet-wide, examples inclusion, name-clash dedup, 4-tier union, unsafe-name rejection, empty-everywhere)
- [x] `pytest tests/unit/vnx_cli/commands/test_doctor.py -v` — 9 passed (4 new `TestCheckAgents` cases incl. the exact engine-fleet-only-project no-false-zero regression)
- [x] `pytest tests/unit/vnx_cli/commands/test_status.py -v` — 4 passed (new file; engine-fleet-only-project no-false-zero for `vnx status --json`)
- [x] `pytest tests/test_vnx_cli.py -v` — 14 passed (2 pre-existing tests updated: bare dirs no longer count as agents without a CLAUDE.md, matching the DoD's "only count resolvable agent dirs" requirement)
- [x] Dogfooded against this repo: `vnx doctor` reports `11 agent(s) resolvable (1 examples, 10 project)`; `vnx status --json` reports matching `agent_count`/`agents`

🤖 Generated with [Claude Code](https://claude.com/claude-code)