### PR TITLE
fix(dispatch-agent): honor requested provider lane, close raw-model coercion gap

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -662,6 +662,44 @@ def build_runtime_snapshot(
             message=f"Constraint registry unavailable — fail-closed: {exc}",
         ),)
 
+    # Defense-in-depth (dispatch-agent-lane-coercion, OI-LANECOERCE): a worker-model pin
+    # (workers-sonnet-pinned) replaces spec.model with effective_model BEFORE the check above
+    # ever runs, so a cross-provider requested model (e.g. --model kimi resolved onto the claude
+    # lane) is invisible to the kimi-via-cli-only guard by the time it inspects effective_model
+    # ("claude-sonnet-5"). Re-run the check against the RAW requested model too, so the pin can
+    # never mask a mismatched provider. Only BLOCKING verdicts are folded in — warn-only pin
+    # noise (e.g. --model opus pinned to sonnet) is already reported once via D4's own warning.
+    raw_model = spec.model
+    if raw_model and raw_model != effective_model:
+        try:
+            raw_violations = _constraint_check(
+                provider=provider_value,
+                sub_provider=sub_provider,
+                model=raw_model,
+                terminal_id=spec.target_slot,
+                role=spec.role,
+                via=via,
+                env=os.environ,
+                check_registry=False,
+            )
+        except Exception as exc:
+            raw_violations = []
+            constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
+                code="registry-unavailable",
+                severity="blocking",
+                message=f"Constraint registry unavailable (raw-model guard) — fail-closed: {exc}",
+            ),)
+        existing_codes = {v.code for v in constraint_verdicts}
+        for v in raw_violations:
+            if v.severity == "blocking" and v.code not in existing_codes:
+                constraint_verdicts = constraint_verdicts + (ConstraintVerdict(
+                    code=v.code,
+                    severity=v.severity,
+                    message=f"[raw-model guard] {v.message}",
+                    override_applied=v.override_applied,
+                ),)
+                existing_codes.add(v.code)
+
     # P0-2: anchor the pending root BEFORE trusting any bundle path. A symlinked
     # dispatches/pending that escapes the data root cannot host a promoted bundle
     # (fail-closed) — checked unconditionally so it holds even if existence is faked.

--- a/tests/test_dispatch_agent_lane_coercion.py
+++ b/tests/test_dispatch_agent_lane_coercion.py
@@ -1,0 +1,249 @@
+#!/usr/bin/env python3
+"""Tests for dispatch-agent-lane-coercion (20260713-LANECOERCE).
+
+`vnx dispatch-agent --model kimi` used to discard the requested model's provider
+entirely: deliver_via_door() was never passed a `provider=` kwarg, so it always
+defaulted to "claude" — a kimi request silently spawned a claude-subscription
+worker with no error, bypassing the kimi-via-cli-only constraint and misclassifying
+billing.
+
+Covers:
+  1. _infer_provider_for_model: model -> provider inference (unit-level).
+  2. vnx_dispatch_agent: --model kimi resolves provider="kimi" and is threaded
+     through to deliver_via_door (plan-level assertion, no real worker spawned).
+  3. vnx_dispatch_agent: --model opus/sonnet still resolves provider="claude"
+     (no regression for the legitimate claude lane).
+  4. vnx_dispatch_agent: an unresolvable --model hard-errors BEFORE dispatch
+     instead of silently coercing to claude.
+  5. vnx_dispatch_agent: agent_config["provider"] is honored when no explicit
+     --model is given (the previously-discarded config field).
+  6. vnx_dispatch_agent: when the single-entry door is disabled (legacy lane),
+     a non-claude provider hard-errors instead of falling through to the
+     claude-only legacy `deliver_with_recovery` path.
+"""
+
+from __future__ import annotations
+
+import sys
+from argparse import Namespace
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+SCRIPTS_LIB = REPO_ROOT / "scripts" / "lib"
+if str(SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_LIB))
+
+from vnx_cli.commands.dispatch_agent import _infer_provider_for_model, vnx_dispatch_agent
+
+
+# ---------------------------------------------------------------------------
+# 1. _infer_provider_for_model — unit tests
+# ---------------------------------------------------------------------------
+
+class TestInferProviderForModel:
+    @pytest.mark.parametrize(
+        "model,expected",
+        [
+            ("kimi", "kimi"),
+            ("kimi-k2-6", "kimi"),
+            ("kimi-k2-0905-default", "kimi"),
+            ("KIMI", "kimi"),
+            ("sonnet", "claude"),
+            ("opus", "claude"),
+            ("haiku", "claude"),
+            ("claude-sonnet-5", "claude"),
+            ("codex", "codex"),
+            ("gpt-5.5", "codex"),
+            ("gemini", "gemini"),
+            ("gemini-2.5-pro", "gemini"),
+            ("glm-5.1", "glm-harness"),
+            ("glm-5.2", "glm-harness"),
+            ("zai", "glm-harness"),
+            ("deepseek-harness", "deepseek-harness"),
+            ("deepseek-v4-pro", "deepseek-harness"),
+            ("local-gemma", "local-gemma"),
+            ("gemma-4b-local", "local-gemma"),
+            ("", "claude"),
+            (None, "claude"),
+        ],
+    )
+    def test_known_models_map_to_expected_provider(self, model, expected):
+        assert _infer_provider_for_model(model) == expected
+
+    def test_unknown_model_raises_value_error(self):
+        with pytest.raises(ValueError, match="does not map to any honorable provider"):
+            _infer_provider_for_model("totally-unknown-xyz-999")
+
+
+# ---------------------------------------------------------------------------
+# Shared dispatch harness
+# ---------------------------------------------------------------------------
+
+def _make_agent(
+    base: Path,
+    name: str = "hello-world",
+    *,
+    default_instruction: str = "Say hi",
+    provider: str | None = None,
+    model: str | None = None,
+) -> Path:
+    agent_dir = base / "examples" / name
+    agent_dir.mkdir(parents=True)
+    (agent_dir / "CLAUDE.md").write_text(f"# {name} agent")
+    lines = ["governance_profile: minimal", f'default_instruction: "{default_instruction}"']
+    if provider:
+        lines.append(f"provider: {provider}")
+    if model:
+        lines.append(f"model: {model}")
+    (agent_dir / "config.yaml").write_text("\n".join(lines) + "\n")
+    return agent_dir
+
+
+def _run_dispatch_capturing_door_kwargs(
+    tmp_path: Path,
+    *,
+    model: str | None,
+    agent_provider: str | None = None,
+    agent_model: str | None = None,
+    legacy: bool = False,
+    monkeypatch=None,
+):
+    """Invoke vnx_dispatch_agent with the REAL dispatch_bridge/dispatch_spec modules
+    (needed for real provider inference), but with deliver_via_door replaced so no
+    worker is ever staged/spawned — a plan-level assertion on the kwargs it receives."""
+    _make_agent(tmp_path, provider=agent_provider, model=agent_model)
+    if legacy and monkeypatch is not None:
+        monkeypatch.setenv("VNX_DISPATCH_LEGACY", "1")
+
+    captured = {}
+
+    def fake_door(legacy_fn, **kwargs):
+        captured.update(kwargs)
+        return True
+
+    import dispatch_bridge  # real module, scripts/lib already on sys.path
+
+    from vnx_cli import _engine
+    with patch.object(_engine, "engine_root", return_value=tmp_path), \
+         patch.object(dispatch_bridge, "deliver_via_door", side_effect=fake_door):
+        args = Namespace(agent="hello-world", instruction=None, model=model, project_dir=str(tmp_path))
+        rc = vnx_dispatch_agent(args)
+
+    return rc, captured
+
+
+# ---------------------------------------------------------------------------
+# 2. --model kimi routes to provider="kimi"
+# ---------------------------------------------------------------------------
+
+class TestKimiModelRoutesToKimiProvider:
+    def test_explicit_kimi_model_resolves_kimi_provider(self, tmp_path):
+        rc, captured = _run_dispatch_capturing_door_kwargs(tmp_path, model="kimi")
+
+        assert rc == 0
+        assert captured.get("provider") == "kimi", (
+            "requested --model kimi must resolve provider='kimi', not silently default to claude"
+        )
+        assert captured.get("model") == "kimi"
+
+    def test_kimi_variant_model_resolves_kimi_provider(self, tmp_path):
+        rc, captured = _run_dispatch_capturing_door_kwargs(tmp_path, model="kimi-k2-6")
+
+        assert rc == 0
+        assert captured.get("provider") == "kimi"
+
+
+# ---------------------------------------------------------------------------
+# 3. --model opus/sonnet still routes to provider="claude" (no regression)
+# ---------------------------------------------------------------------------
+
+class TestClaudeModelsStillRouteToClaudeProvider:
+    @pytest.mark.parametrize("model", ["opus", "sonnet", "haiku"])
+    def test_claude_tier_model_resolves_claude_provider(self, tmp_path, model):
+        rc, captured = _run_dispatch_capturing_door_kwargs(tmp_path, model=model)
+
+        assert rc == 0
+        assert captured.get("provider") == "claude"
+        assert captured.get("model") == model
+
+    def test_no_explicit_model_defaults_to_claude(self, tmp_path):
+        """No --model, no agent_config model/provider -> legacy default sonnet on claude."""
+        rc, captured = _run_dispatch_capturing_door_kwargs(tmp_path, model=None)
+
+        assert rc == 0
+        assert captured.get("provider") == "claude"
+        assert captured.get("model") == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# 4. Unresolvable model hard-errors instead of silently coercing to claude
+# ---------------------------------------------------------------------------
+
+class TestUnresolvableModelHardErrors:
+    def test_unknown_model_hard_errors_before_dispatch(self, tmp_path, capsys):
+        rc, captured = _run_dispatch_capturing_door_kwargs(tmp_path, model="totally-unknown-xyz-999")
+
+        assert rc == 1
+        assert captured == {}, "deliver_via_door must never be called for an unresolvable model"
+        err = capsys.readouterr().err
+        assert "does not map to any honorable provider" in err
+
+
+# ---------------------------------------------------------------------------
+# 5. agent_config["provider"] is honored when no explicit --model is given
+# ---------------------------------------------------------------------------
+
+class TestAgentConfigProviderHonored:
+    def test_agent_configured_provider_used_without_explicit_model(self, tmp_path):
+        """The agent declares provider: codex with no matching model — previously this
+        field was resolved (agent_resolver) but then discarded outright."""
+        rc, captured = _run_dispatch_capturing_door_kwargs(
+            tmp_path, model=None, agent_provider="codex",
+        )
+
+        assert rc == 0
+        assert captured.get("provider") == "codex"
+
+    def test_explicit_model_override_wins_over_agent_config_provider(self, tmp_path):
+        """An explicit --model kimi must win even if the agent's own config.yaml
+        declares a different provider — the user's request is authoritative."""
+        rc, captured = _run_dispatch_capturing_door_kwargs(
+            tmp_path, model="kimi", agent_provider="claude",
+        )
+
+        assert rc == 0
+        assert captured.get("provider") == "kimi"
+
+
+# ---------------------------------------------------------------------------
+# 6. Legacy (door-disabled) lane hard-errors for a non-claude provider
+# ---------------------------------------------------------------------------
+
+class TestLegacyLaneGuardsNonClaudeProvider:
+    def test_kimi_model_hard_errors_when_door_disabled(self, tmp_path, monkeypatch, capsys):
+        """VNX_DISPATCH_LEGACY=1 routes deliver_via_door() straight to the claude-only
+        legacy deliver_with_recovery() callable, which cannot honor a kimi request —
+        must hard-error rather than silently spawning a claude worker."""
+        rc, captured = _run_dispatch_capturing_door_kwargs(
+            tmp_path, model="kimi", legacy=True, monkeypatch=monkeypatch,
+        )
+
+        assert rc == 1
+        assert captured == {}, "deliver_via_door must never be reached on the legacy-lane guard"
+        err = capsys.readouterr().err
+        assert "legacy dispatch lane only drives the claude CLI" in err
+
+    def test_claude_model_still_works_when_door_disabled(self, tmp_path, monkeypatch):
+        """No regression: a genuine claude model must still work on the legacy lane."""
+        rc, captured = _run_dispatch_capturing_door_kwargs(
+            tmp_path, model="sonnet", legacy=True, monkeypatch=monkeypatch,
+        )
+
+        assert rc == 0
+        assert captured.get("provider") == "claude"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1026,6 +1026,20 @@ def test_forbid_route_kimi_is_blocking_in_constraint_engine():
     assert kimi_v.severity == "blocking"
 
 
+def test_kimi_model_under_claude_provider_is_blocking_in_constraint_engine():
+    """dispatch-agent-lane-coercion (20260713-LANECOERCE): the hardcoded kimi-model-substring
+    guard (constraint_enforcer.py ~502-507) is distinct from the litellm:moonshot forbid_route
+    rule above — it must flag ANY non-kimi provider carrying a kimi-branded model string, which
+    is exactly the raw (pre-pin) shape a --model kimi request has under provider=claude."""
+    violations = ConstraintEnforcer().check_constraints(
+        provider="claude",
+        model="kimi",
+    )
+    kimi_v = next((v for v in violations if v.code == "kimi-via-cli-only"), None)
+    assert kimi_v is not None, "Expected kimi-via-cli-only violation for provider=claude, model=kimi"
+    assert kimi_v.severity == "blocking"
+
+
 def test_forbid_route_deprecated_glm_is_blocking_in_constraint_engine():
     """PR-4e: deprecated-glm-models forbid_route must remain BLOCKING severity."""
     violations = ConstraintEnforcer().check_constraints(
@@ -1071,6 +1085,90 @@ def test_forbid_route_blocking_verdict_rejects_dispatch(tmp_path):
 
     assert rc == 1, "Blocking forbid_route verdict must cause a Reject"
     mock_exec.assert_not_called()
+
+
+def test_raw_kimi_model_rejected_despite_workers_sonnet_pin(tmp_path, monkeypatch, capsys):
+    """dispatch-agent-lane-coercion (20260713-LANECOERCE), defense-in-depth: a REAL staged spec
+    with provider=claude, model=kimi, target_slot=T1 must be REJECTED by build_runtime_snapshot's
+    raw-model guard, not silently pinned to claude-sonnet-5 (workers-sonnet-pinned) before the
+    kimi-via-cli-only check ever inspects the requested model. Uses the real constraint engine
+    end-to-end (no snapshot mocking) so the fix is exercised exactly as dispatch_cli runs it."""
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260713-staging-kimi-coercion"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    inst = bundle_dir / "instruction.md"
+    inst.write_text("# Kimi-labelled dispatch\n\nDo something useful.\n", encoding="utf-8")
+    spec_dict = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260713-test-kimi-coercion",
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "model": "kimi",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+    with patch("dispatch_cli._execute_claude") as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 1, "provider=claude + model=kimi must be rejected, not silently pinned to sonnet"
+    mock_execute.assert_not_called()
+    err = capsys.readouterr().err
+    assert "kimi-via-cli-only" in err
+
+
+def test_raw_opus_model_pin_override_still_proceeds(tmp_path, monkeypatch):
+    """Regression: --model opus pinned to sonnet (workers-sonnet-pinned, a WARN-only verdict)
+    must still PROCEED. The new raw-model guard only rejects a genuine cross-provider model
+    (e.g. kimi); it must not turn every ordinary pin-override into a hard reject."""
+    data_dir = tmp_path / "vnx-data"
+    staging_id = "20260713-staging-opus-pin"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    inst = bundle_dir / "instruction.md"
+    inst.write_text("# Opus-requested dispatch\n\nDo something useful.\n", encoding="utf-8")
+    spec_dict = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": "20260713-test-opus-pin",
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T1",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "model": "opus",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0, "requested opus pinned to sonnet for T1 must still proceed (warn only)"
+    mock_execute.assert_called_once()
+    plan_arg = mock_execute.call_args[0][0]
+    assert plan_arg.model == "claude-sonnet-5"
 
 
 # ---------------------------------------------------------------------------

--- a/vnx_cli/commands/dispatch_agent.py
+++ b/vnx_cli/commands/dispatch_agent.py
@@ -48,6 +48,64 @@ def _read_default_instruction(config_path: Path) -> str | None:
     return None
 
 
+def _infer_provider_for_model(model: str) -> str:
+    """Derive the honoring provider for a requested ``--model`` string.
+
+    Reuses dispatch_bridge._canonical_provider for exact provider-name matches
+    (covers the reported case, ``--model kimi`` -> Provider.KIMI) and falls
+    back to the same provider-signature substring convention the
+    kimi-via-cli-only guard (constraint_enforcer.py) already applies to model
+    strings, for provider-specific model ids that aren't themselves a bare
+    provider name (kimi-k2-6, glm-5.1, deepseek-v4-pro, gemini-2.5-pro, ...).
+
+    Raises ValueError when no provider can be honored, so the caller can
+    hard-error before dispatch instead of letting the provider silently
+    default to "claude" (the dispatch-agent-lane-coercion bug).
+    """
+    from dispatch_bridge import _canonical_provider  # type: ignore[import]  # noqa: PLC0415
+    from dispatch_spec import Provider  # type: ignore[import]  # noqa: PLC0415
+
+    normalized = (model or "").strip().lower()
+    if not normalized:
+        return Provider.CLAUDE.value
+
+    # Exact provider-name match (kimi, codex, gemini, claude, glm, zai,
+    # deepseek-harness, glm-harness, local-gemma, auto, ...).
+    try:
+        return _canonical_provider(normalized).value
+    except ValueError:
+        pass
+
+    # Bare claude model tiers/aliases are not provider names themselves.
+    if normalized in {"sonnet", "opus", "haiku"} or normalized.startswith(
+        ("claude-", "opus-", "sonnet-", "haiku-")
+    ):
+        return Provider.CLAUDE.value
+
+    # Provider-specific model-id substrings — the same convention the
+    # kimi-via-cli-only guard already uses ("kimi" in model_norm).
+    for needle, provider in (
+        ("kimi", Provider.KIMI),
+        ("glm", Provider.GLM_HARNESS),
+        ("zai", Provider.GLM_HARNESS),
+        ("deepseek", Provider.DEEPSEEK_HARNESS),
+        ("gemini", Provider.GEMINI),
+        ("gemma", Provider.LOCAL_GEMMA),
+        ("gpt", Provider.CODEX),
+        ("codex", Provider.CODEX),
+    ):
+        if needle in normalized:
+            return provider.value
+
+    raise ValueError(
+        f"--model {model!r} does not map to any honorable provider lane. "
+        "Use a claude model (sonnet/opus/haiku), a kimi model (kimi*), a glm "
+        "model (glm*/zai*), a deepseek model (deepseek*), a gemini model "
+        "(gemini*), or pass a provider name directly "
+        "(claude/codex/gemini/kimi/glm-harness/deepseek-harness/local-gemma)."
+    )
+
+
 def _resolve_agent_config(
     agent: str,
     agent_claude_md: Path,
@@ -84,6 +142,7 @@ def vnx_dispatch_agent(args) -> int:
     agent = args.agent
     instruction = getattr(args, "instruction", None)
     model = getattr(args, "model", None)
+    explicit_model = model  # user's raw --model override, if any (captured before defaulting)
     project_dir = Path(getattr(args, "project_dir", ".")).resolve()
 
     # Validate agent CLAUDE.md exists
@@ -126,12 +185,39 @@ def vnx_dispatch_agent(args) -> int:
         else:
             model = "sonnet"
 
+    # Resolve provider (root cause of dispatch-agent-lane-coercion, 20260713-LANECOERCE):
+    # --model kimi previously discarded agent_config["provider"] entirely and deliver_via_door
+    # silently defaulted provider="claude", spawning a claude-subscription worker for a kimi
+    # request with no error and no honored kimi-via-cli-only routing.
+    #   1. An explicit --model override always wins — the user's choice must be honored via the
+    #      matching provider, not silently re-routed to whatever the agent's config declares.
+    #   2. Otherwise trust the agent's own agent_config["provider"] when set (it may legitimately
+    #      declare a provider without also pinning a specific model).
+    #   3. Otherwise infer from the resolved (possibly default "sonnet") model.
+    # A model that maps to no honorable provider hard-errors BEFORE dispatch instead of silently
+    # coercing to claude.
+    if explicit_model:
+        try:
+            provider = _infer_provider_for_model(explicit_model)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+    elif agent_config is not None and agent_config.get("provider"):
+        provider = str(agent_config["provider"])
+    else:
+        try:
+            provider = _infer_provider_for_model(model)
+        except ValueError as exc:
+            print(f"Error: {exc}", file=sys.stderr)
+            return 1
+
     # Generate a dispatch ID
     dispatch_id = f"D-{uuid.uuid4().hex[:8]}"
 
     try:
         from subprocess_dispatch import deliver_with_recovery  # type: ignore[import]
         from dispatch_bridge import deliver_via_door  # type: ignore[import]
+        from dispatch_flags import single_entry_enabled  # type: ignore[import]
     except ImportError as exc:
         print(
             f"Error: could not import subprocess_dispatch: {exc}\n"
@@ -140,9 +226,26 @@ def vnx_dispatch_agent(args) -> int:
         )
         return 1
 
+    # The legacy fallback lane (deliver_with_recovery / subprocess_dispatch) only ever drives the
+    # `claude` CLI — it has no concept of provider. When the single-entry door is disabled
+    # (VNX_DISPATCH_LEGACY=1 / VNX_SINGLE_ENTRY_DISPATCH=0) it would silently spawn a claude
+    # worker for a non-claude provider instead of honoring it, reintroducing the exact
+    # dispatch-agent-lane-coercion bug this fix closes on the door path. Hard-error instead.
+    if provider != "claude" and not single_entry_enabled():
+        print(
+            f"Error: --model {model!r} resolves to provider {provider!r}, but the single-entry "
+            "dispatch door is disabled (VNX_DISPATCH_LEGACY=1 / VNX_SINGLE_ENTRY_DISPATCH=0). "
+            "The legacy dispatch lane only drives the claude CLI and cannot honor a non-claude "
+            "provider. Unset VNX_DISPATCH_LEGACY / VNX_SINGLE_ENTRY_DISPATCH to use the door, "
+            "or request a claude model.",
+            file=sys.stderr,
+        )
+        return 1
+
     # Preflight (audit high #6): the default lane drives an installed, authenticated `claude` CLI as
-    # a subprocess. A missing binary otherwise surfaces only as a bare "status: failed".
-    if shutil.which("claude") is None:
+    # a subprocess. A missing binary otherwise surfaces only as a bare "status: failed". Scoped to
+    # the claude lane — a kimi/codex/gemini/glm dispatch has no dependency on the `claude` binary.
+    if provider == "claude" and shutil.which("claude") is None:
         print(
             "Warning: 'claude' CLI not found on PATH. The default dispatch lane drives an installed, "
             "authenticated `claude` CLI as a subprocess.\n"
@@ -176,6 +279,7 @@ def vnx_dispatch_agent(args) -> int:
         dispatch_id=dispatch_id,
         target_slot="T1",
         role=agent,
+        provider=provider,
         model=model,
         project_id=project_id,
     )


### PR DESCRIPTION
## Summary
- `vnx dispatch-agent --model kimi` in a pip consumer silently coerced to `claude-sonnet-5` on the claude tmux subscription lane: `deliver_via_door()` was never passed a `provider=` kwarg and always defaulted to `"claude"`, bypassing `kimi-via-cli-only` and misclassifying billing.
- Root cause: `vnx_cli/commands/dispatch_agent.py::vnx_dispatch_agent` resolved `agent_config["provider"]` (line 77) but discarded it, and never derived a provider from `--model`.
- Defense-in-depth gap: `dispatch_cli.py::build_runtime_snapshot` ran the `kimi-via-cli-only` constraint check against the **pinned** `effective_model` (`claude-sonnet-5`), not the raw requested model (`kimi`) — so `workers-sonnet-pinned` silently masked the guard.

## Changes
- `vnx_cli/commands/dispatch_agent.py`: added `_infer_provider_for_model()` (reuses `dispatch_bridge._canonical_provider` + the same kimi-via-cli-only model-substring convention already used in `constraint_enforcer.py`). Provider resolution priority: explicit `--model` override → `agent_config["provider"]` → inferred from the resolved model. Threads `provider=` into `deliver_via_door`. An unresolvable model hard-errors before dispatch instead of defaulting to claude. Also hard-errors if a non-claude provider is requested while the single-entry door is disabled (`VNX_DISPATCH_LEGACY=1`), since the legacy fallback lane only drives the `claude` CLI. Scoped the "claude CLI not found" preflight warning to the claude lane.
- `scripts/lib/dispatch_cli.py`: `build_runtime_snapshot` now re-runs the constraint check against the **raw** requested model (`spec.model`) in addition to the pinned `effective_model`, folding in only `blocking` verdicts (so ordinary warn-only pin overrides like `opus`→`sonnet` are unaffected). Closes the gap where a worker-model pin could mask a cross-provider requested model.

## Test plan
- [x] `pytest tests/test_dispatch_agent_lane_coercion.py -v` — 33 new tests (provider inference unit tests + `vnx_dispatch_agent` integration tests for kimi routing, claude regression, hard-error on unknown model, agent_config provider honored, legacy-lane guard).
- [x] `pytest tests/test_dispatch_cli.py -v` — 97 passed, incl. 2 new end-to-end raw-model-guard tests + 1 new constraint-engine test.
- [x] `pytest tests/test_dispatch_agent_default_instruction.py tests/test_dispatch_agent_preflight.py tests/test_constraint_enforcer.py tests/test_constraint_enforcer_kimi_valid.py tests/test_dispatch_plan.py tests/test_dispatch_enforcement.py -v` — 194 passed, 1 skipped, 3 pre-existing failures verified unrelated via baseline (`git stash`) diff.
- [x] `pytest tests/test_dispatch_bridge_staging.py tests/test_dispatch_flags.py tests/test_dispatch_spec.py tests/test_dispatch_lane_routing.py tests/test_agent_dispatch.py tests/test_classifier_providers.py tests/test_pr10_provider_string_canon.py tests/test_smart_router_multiprovider.py tests/test_provider_dispatch_kimi.py tests/test_dispatch_door_authority.py tests/test_dispatch_sidedoor_audit.py -q` — 227 passed.
- [x] `pytest tests/ --collect-only -q` — 17058 tests collected, no import-time errors introduced.

🤖 Generated with [Claude Code](https://claude.com/claude-code)