### PR TITLE
fix(central-install): write install-mode marker on vnx update, doctor surfaces gap

### DIFF
--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -30,7 +30,7 @@ from typing import Dict, List, Optional, Tuple
 SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
-from vnx_paths import ensure_env
+from vnx_paths import ensure_env, _git_toplevel
 
 # ---------------------------------------------------------------------------
 # Result model
@@ -623,6 +623,22 @@ def check_path_hygiene(paths: Dict[str, str]) -> List[CheckResult]:
         return [CheckResult("hygiene", FAIL, "Path hygiene check failed")]
 
 
+def _looks_like_central_install_location(vnx_home: Path) -> bool:
+    """True when vnx_home sits under ~/.vnx-system/ — the central-install tree —
+    independent of whether the .vnx-install-mode marker is present there.
+
+    Distinguishes "should be a central install but lost/never got its marker"
+    from a legitimate standalone dev checkout: the latter is also frequently a
+    git-toplevel dir (so git-toplevel matching alone is not enough — see
+    check_contamination), but it never lives under ~/.vnx-system/.
+    """
+    try:
+        vnx_home.resolve().relative_to((Path.home() / ".vnx-system").resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
+
 def check_contamination(paths: Dict[str, str]) -> List[CheckResult]:
     """Warn (non-fatal) on pre-fix runtime state inside a central install.
 
@@ -640,6 +656,25 @@ def check_contamination(paths: Dict[str, str]) -> List[CheckResult]:
     except OSError:
         is_central = False
     if not is_central:
+        # A git-toplevel VNX_HOME under ~/.vnx-system/ with no (or an invalid)
+        # marker is a central install that has lost/never received its stamp —
+        # surface it instead of silently skipping (masking the condition this
+        # dispatch fixes). A plain git-toplevel match is not enough on its own:
+        # a standalone vnx-orchestration dev checkout is *also* its own git
+        # toplevel and legitimately carries no marker, so the location check
+        # is required to avoid flagging every ordinary dev checkout.
+        if _git_toplevel(vnx_home) == vnx_home and _looks_like_central_install_location(vnx_home):
+            if marker.is_file():
+                detail = (
+                    f"VNX_HOME is a git-toplevel central install with an "
+                    f"invalid .vnx-install-mode marker at {marker}"
+                )
+            else:
+                detail = (
+                    f"VNX_HOME is a git-toplevel central install missing its "
+                    f".vnx-install-mode marker at {marker}"
+                )
+            return [CheckResult("contamination", WARN, detail)]
         return []
 
     script = vnx_home / "scripts" / "vnx_contamination_check.sh"

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -3,6 +3,7 @@
 
 import io
 import json
+import subprocess
 import sys
 from argparse import Namespace
 from contextlib import redirect_stdout
@@ -15,6 +16,7 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 if str(REPO_ROOT) not in sys.path:
     sys.path.insert(0, str(REPO_ROOT))
 
+import vnx_cli.commands.update as update_module
 from vnx_cli.commands.update import (
     vnx_update,
     _resolve_root,
@@ -23,8 +25,34 @@ from vnx_cli.commands.update import (
     _prune_old_versions,
     _atomic_symlink_flip,
     _validate_version_name,
+    _fetch_version,
+    _write_install_marker,
+    _ensure_install_marker,
+    _git_toplevel,
+    INSTALL_MODE_MARKER,
+    INSTALL_MODE_VALUE,
     DEFAULT_KEEP_LAST,
 )
+
+
+def _git_repo(path: Path) -> Path:
+    """Init a minimal, committed git repo at ``path`` (no remote)."""
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True)
+    return path
+
+
+def _git_origin(tmp_path: Path) -> Path:
+    """A local git repo standing in for VNX_GIT_REMOTE (offline, deterministic)."""
+    origin = _git_repo(tmp_path / "origin")
+    (origin / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=origin, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "add readme"], cwd=origin, check=True)
+    subprocess.run(["git", "branch", "-M", "main"], cwd=origin, check=True)
+    return origin
 
 
 def _update_args(*, to_version=None, keep_last=DEFAULT_KEEP_LAST, dry_run=False, rollback=False):
@@ -391,3 +419,181 @@ def test_git_not_found_no_exception_raised(tmp_path, monkeypatch):
             pytest.fail("FileNotFoundError leaked out of vnx_update — must be caught internally")
 
     assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# central-install-mode-marker-missing: _git_toplevel / marker helpers
+# ---------------------------------------------------------------------------
+
+def test_git_toplevel_matches_repo_root(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    assert _git_toplevel(repo) == repo.resolve()
+
+
+def test_git_toplevel_none_for_non_repo(tmp_path):
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    assert _git_toplevel(plain) is None
+
+
+def test_write_install_marker_atomic(tmp_path):
+    version_dir = tmp_path / "v1"
+    version_dir.mkdir()
+    _write_install_marker(version_dir)
+    marker = version_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_ensure_install_marker_writes_when_git_toplevel(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    _ensure_install_marker(repo)
+    marker = repo / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_ensure_install_marker_noop_for_non_git_dir(tmp_path):
+    """Guard: never stamp a marker into a tree that isn't its own git toplevel
+    (e.g. a consumer project's own dev checkout) — matches
+    vnx_paths._is_central_install()'s git-toplevel==vnx_home condition."""
+    plain = tmp_path / "plain"
+    plain.mkdir()
+    _ensure_install_marker(plain)
+    assert not (plain / INSTALL_MODE_MARKER).exists()
+
+
+def test_ensure_install_marker_noop_for_none():
+    _ensure_install_marker(None)  # must not raise
+
+
+def test_ensure_install_marker_idempotent_when_already_valid(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    marker = repo / INSTALL_MODE_MARKER
+    marker.write_text("central\n", encoding="utf-8")
+    mtime_before = marker.stat().st_mtime_ns
+
+    _ensure_install_marker(repo)
+
+    assert marker.stat().st_mtime_ns == mtime_before
+
+
+def test_ensure_install_marker_overwrites_invalid_content(tmp_path):
+    repo = _git_repo(tmp_path / "repo")
+    marker = repo / INSTALL_MODE_MARKER
+    marker.write_text("embedded\n", encoding="utf-8")
+
+    _ensure_install_marker(repo)
+
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+# ---------------------------------------------------------------------------
+# central-install-mode-marker-missing: _fetch_version writes the marker
+# ---------------------------------------------------------------------------
+
+def test_fetch_version_clone_path_writes_marker(tmp_path, monkeypatch):
+    origin = _git_origin(tmp_path)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    root = tmp_path / "vnx-system"
+
+    target_dir = _fetch_version(root, "edge", dry_run=False)
+
+    marker = target_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_fetch_version_pull_path_backfills_missing_marker(tmp_path, monkeypatch):
+    """Reproduces the reported bug directly: a version dir fetched before this
+    fix (marker stripped/never written) must get it back on the next fetch —
+    the ``vnx update`` pull branch, not just the fresh-clone branch."""
+    origin = _git_origin(tmp_path)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    root = tmp_path / "vnx-system"
+
+    target_dir = _fetch_version(root, "edge", dry_run=False)
+    marker = target_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    marker.unlink()
+    assert not marker.is_file()
+
+    target_dir_again = _fetch_version(root, "edge", dry_run=False)
+
+    assert target_dir_again == target_dir
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_fetch_version_dry_run_writes_no_marker(tmp_path, monkeypatch):
+    origin = _git_origin(tmp_path)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    root = tmp_path / "vnx-system"
+
+    target_dir = _fetch_version(root, "edge", dry_run=True)
+
+    assert not (target_dir / INSTALL_MODE_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# central-install-mode-marker-missing: _atomic_symlink_flip self-heals target
+# ---------------------------------------------------------------------------
+
+def test_symlink_flip_backfills_marker_on_git_toplevel_target(tmp_path):
+    root = tmp_path / "install"
+    root.mkdir()
+    target_dir = _git_repo(root / "versions" / "v1.0.0")
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _atomic_symlink_flip(root, target_dir, dry_run=False, audit_log=audit_log)
+
+    marker = target_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_symlink_flip_skips_marker_on_non_git_target(tmp_path):
+    root = tmp_path / "install"
+    root.mkdir()
+    target_dir = root / "versions" / "v1.0.0"
+    target_dir.mkdir(parents=True)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _atomic_symlink_flip(root, target_dir, dry_run=False, audit_log=audit_log)
+
+    assert not (target_dir / INSTALL_MODE_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# central-install-mode-marker-missing: vnx_update repairs the active install
+# ---------------------------------------------------------------------------
+
+def test_vnx_update_repairs_active_marker_less_install(tmp_path, monkeypatch):
+    """The exact reported bug: `current` already points at a git-toplevel
+    version dir with no marker (fetched by a pre-fix `vnx update`). Any
+    subsequent `vnx update` invocation must repair it, even though the
+    requested target itself (here: re-fetching `edge`, which fails offline
+    with no configured remote) does not succeed."""
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    root = tmp_path
+    active = _git_repo(root / "versions" / "edge")
+    (root / "current").symlink_to(active)
+    marker = active / INSTALL_MODE_MARKER
+    assert not marker.is_file()
+
+    rc = vnx_update(_update_args(to_version="edge"))
+
+    assert rc == 1  # `git pull` fails: no remote configured on the local repo
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+
+
+def test_vnx_update_dry_run_does_not_repair_marker(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    root = tmp_path
+    active = _git_repo(root / "versions" / "edge")
+    (root / "current").symlink_to(active)
+
+    vnx_update(_update_args(to_version="edge", dry_run=True))
+
+    assert not (active / INSTALL_MODE_MARKER).exists()

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -445,9 +445,76 @@ def test_write_install_marker_atomic(tmp_path):
     assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
 
 
-def test_ensure_install_marker_writes_when_git_toplevel(tmp_path):
-    repo = _git_repo(tmp_path / "repo")
-    _ensure_install_marker(repo)
+# ---------------------------------------------------------------------------
+# ADR-005: marker write emits an NDJSON audit event
+# ---------------------------------------------------------------------------
+
+def test_write_install_marker_emits_audit_event(tmp_path):
+    version_dir = tmp_path / "v1"
+    version_dir.mkdir()
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _write_install_marker(version_dir, audit_log=audit_log)
+
+    assert audit_log.exists()
+    lines = audit_log.read_text().strip().splitlines()
+    assert len(lines) == 1
+    record = json.loads(lines[0])
+    assert record["event_type"] == "central_install_marker_written"
+    assert record["version_dir"] == str(version_dir)
+    assert "timestamp" in record and record["timestamp"]
+
+
+def test_fetch_version_emits_marker_audit_event(tmp_path, monkeypatch):
+    origin = _git_origin(tmp_path)
+    monkeypatch.setattr(update_module, "VNX_GIT_REMOTE", str(origin))
+    root = tmp_path / "vnx-system"
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    target_dir = _fetch_version(root, "edge", dry_run=False, audit_log=audit_log)
+
+    lines = audit_log.read_text().strip().splitlines()
+    events = [json.loads(line) for line in lines]
+    assert any(
+        e["event_type"] == "central_install_marker_written" and e["version_dir"] == str(target_dir)
+        for e in events
+    )
+
+
+def test_ensure_install_marker_repair_emits_audit_event(tmp_path):
+    root = tmp_path / "vnx-system"
+    repo = _git_repo(root / "versions" / "edge")
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _ensure_install_marker(root, repo, audit_log=audit_log)
+
+    lines = audit_log.read_text().strip().splitlines()
+    events = [json.loads(line) for line in lines]
+    assert any(
+        e["event_type"] == "central_install_marker_written" and e["version_dir"] == str(repo)
+        for e in events
+    )
+
+
+def test_ensure_install_marker_skip_emits_no_audit_event(tmp_path):
+    """The ownership guard's silent skip must not emit an event — nothing was
+    written, so there is nothing to audit."""
+    root = tmp_path / "vnx-system"
+    root.mkdir()
+    dev_checkout = _git_repo(tmp_path / "some-other-repo" / "vnx-orchestration")
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _ensure_install_marker(root, dev_checkout, audit_log=audit_log)
+
+    assert not audit_log.exists()
+
+
+def test_ensure_install_marker_writes_when_under_versions_and_git_toplevel(tmp_path):
+    root = tmp_path / "vnx-system"
+    repo = _git_repo(root / "versions" / "edge")
+
+    _ensure_install_marker(root, repo)
+
     marker = repo / INSTALL_MODE_MARKER
     assert marker.is_file()
     assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
@@ -456,34 +523,57 @@ def test_ensure_install_marker_writes_when_git_toplevel(tmp_path):
 def test_ensure_install_marker_noop_for_non_git_dir(tmp_path):
     """Guard: never stamp a marker into a tree that isn't its own git toplevel
     (e.g. a consumer project's own dev checkout) — matches
-    vnx_paths._is_central_install()'s git-toplevel==vnx_home condition."""
-    plain = tmp_path / "plain"
-    plain.mkdir()
-    _ensure_install_marker(plain)
+    vnx_paths._is_central_install()'s git-toplevel==vnx_home condition.
+    Placed under <root>/versions/ so this isolates the git-toplevel guard
+    specifically, independent of the ownership guard below."""
+    root = tmp_path / "vnx-system"
+    plain = root / "versions" / "plain"
+    plain.mkdir(parents=True)
+
+    _ensure_install_marker(root, plain)
+
     assert not (plain / INSTALL_MODE_MARKER).exists()
 
 
+def test_ensure_install_marker_noop_for_dev_checkout_not_under_versions(tmp_path):
+    """Fix (central-install-mode-marker-missing follow-up): a standalone dev
+    checkout is ALSO its own git toplevel — true of essentially any git repo —
+    so the git-toplevel check alone is not sufficient. Without the ownership
+    guard, a dev checkout that happens to resolve as the active `current` or a
+    flip/rollback target would get falsely stamped `.vnx-install-mode=central`,
+    the inverse of the mis-resolution class this marker exists to prevent."""
+    root = tmp_path / "vnx-system"
+    root.mkdir()
+    dev_checkout = _git_repo(tmp_path / "some-other-repo" / "vnx-orchestration")
+
+    _ensure_install_marker(root, dev_checkout)
+
+    assert not (dev_checkout / INSTALL_MODE_MARKER).exists()
+
+
 def test_ensure_install_marker_noop_for_none():
-    _ensure_install_marker(None)  # must not raise
+    _ensure_install_marker(Path("/tmp/unused-root"), None)  # must not raise
 
 
 def test_ensure_install_marker_idempotent_when_already_valid(tmp_path):
-    repo = _git_repo(tmp_path / "repo")
+    root = tmp_path / "vnx-system"
+    repo = _git_repo(root / "versions" / "edge")
     marker = repo / INSTALL_MODE_MARKER
     marker.write_text("central\n", encoding="utf-8")
     mtime_before = marker.stat().st_mtime_ns
 
-    _ensure_install_marker(repo)
+    _ensure_install_marker(root, repo)
 
     assert marker.stat().st_mtime_ns == mtime_before
 
 
 def test_ensure_install_marker_overwrites_invalid_content(tmp_path):
-    repo = _git_repo(tmp_path / "repo")
+    root = tmp_path / "vnx-system"
+    repo = _git_repo(root / "versions" / "edge")
     marker = repo / INSTALL_MODE_MARKER
     marker.write_text("embedded\n", encoding="utf-8")
 
-    _ensure_install_marker(repo)
+    _ensure_install_marker(root, repo)
 
     assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
 

--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -103,6 +103,7 @@ class TestCentralMode:
         central_scripts.mkdir(parents=True)
         version_file = central / "VERSION"
         version_file.write_text("1.0.0-rc2\n")
+        (central / ".vnx-install-mode").write_text("central\n")
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
@@ -117,6 +118,7 @@ class TestCentralMode:
         project = _make_project(tmp_path)
         central = tmp_path / "home" / ".vnx-system" / "current"
         (central / "scripts").mkdir(parents=True)
+        (central / ".vnx-install-mode").write_text("central\n")
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
@@ -159,6 +161,42 @@ class TestCentralMode:
             version_file.chmod(0o644)
 
         assert exit_code == 1
+
+    def test_central_mode_missing_marker_warns(self, tmp_path, monkeypatch):
+        """The active `current` resolves to a version dir with no
+        `.vnx-install-mode` marker (the bug this dispatch fixes: `vnx update`
+        never wrote one). The check must surface it, not silently PASS."""
+        project = _make_project(tmp_path)
+        version_dir = tmp_path / "home" / ".vnx-system" / "versions" / "edge"
+        (version_dir / "scripts").mkdir(parents=True)
+        version_file = version_dir / "VERSION"
+        version_file.write_text("edge\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(version_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == WARN
+        assert "mode: central" in result.detail
+        assert "pin: edge" in result.detail
+        assert "install-mode marker missing" in result.detail
+
+    def test_central_mode_invalid_marker_content_warns(self, tmp_path, monkeypatch):
+        project = _make_project(tmp_path)
+        version_dir = tmp_path / "home" / ".vnx-system" / "versions" / "edge"
+        (version_dir / "scripts").mkdir(parents=True)
+        (version_dir / ".vnx-install-mode").write_text("embedded\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(version_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == WARN
+        assert "install-mode marker invalid" in result.detail
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_wave4_contamination_check.py
+++ b/tests/test_wave4_contamination_check.py
@@ -175,5 +175,59 @@ def test_doctor_check_warns_on_contamination(tmp_path):
     assert any(".vnx-data" in d for d in results[0].details)
 
 
+# ── missing-marker parity (central-install-mode-marker-missing dispatch) ─────
+def _git_init(path: Path) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "--allow-empty", "-m", "init"], cwd=path, check=True)
+    return path.resolve()
+
+
+def test_doctor_check_warns_on_missing_marker_in_central_location(tmp_path, monkeypatch):
+    """A git-toplevel VNX_HOME living under ~/.vnx-system/ (the exact shape of a
+    `vnx update`-fetched version dir) but with no marker must WARN, not be
+    silently skipped as if it were a non-central layout."""
+    doctor = _load_doctor()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    version_dir = _git_init(tmp_path / "home" / ".vnx-system" / "versions" / "edge")
+    (version_dir / "scripts").mkdir(parents=True)
+
+    results = doctor.check_contamination({"VNX_HOME": str(version_dir)})
+
+    assert len(results) == 1
+    assert results[0].status == doctor.WARN
+    assert "missing" in results[0].message
+    assert ".vnx-install-mode" in results[0].message
+
+
+def test_doctor_check_warns_on_invalid_marker_content_in_central_location(tmp_path, monkeypatch):
+    doctor = _load_doctor()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    version_dir = _git_init(tmp_path / "home" / ".vnx-system" / "versions" / "edge")
+    (version_dir / "scripts").mkdir(parents=True)
+    (version_dir / ".vnx-install-mode").write_text("embedded\n", encoding="utf-8")
+
+    results = doctor.check_contamination({"VNX_HOME": str(version_dir)})
+
+    assert len(results) == 1
+    assert results[0].status == doctor.WARN
+    assert "invalid" in results[0].message
+
+
+def test_doctor_check_skips_dev_checkout_without_marker(tmp_path, monkeypatch):
+    """A standalone dev checkout is also its own git-toplevel and legitimately
+    carries no marker — it must stay silent (not under ~/.vnx-system/)."""
+    doctor = _load_doctor()
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+    checkout = _git_init(tmp_path / "dev-checkout")
+    (checkout / "scripts").mkdir(parents=True)
+
+    results = doctor.check_contamination({"VNX_HOME": str(checkout)})
+
+    assert results == []
+
+
 if __name__ == "__main__":  # pragma: no cover
     raise SystemExit(pytest.main([__file__, "-v"]))

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -135,6 +135,32 @@ def _resolve_central_pin(central_path: Path) -> str:
     return "unset"
 
 
+def _check_central_install_marker(central_path: Path) -> "str | None":
+    """Return a detail fragment if the resolved central version dir lacks a
+    valid `.vnx-install-mode=central` marker, else None.
+
+    ``central_path`` is the ``~/.vnx-system/current`` symlink; resolving it
+    gives the actual version dir (e.g. ``~/.vnx-system/versions/edge``) that
+    ``_is_central_install()`` in ``scripts/lib/vnx_paths.py`` inspects. A
+    missing/invalid marker there makes that resolver misread the install as a
+    standalone dev checkout and collapse PROJECT_ROOT onto the shared code tree.
+    """
+    try:
+        version_dir = central_path.resolve()
+    except OSError:
+        return "install-mode marker: cannot resolve version dir"
+    marker = version_dir / ".vnx-install-mode"
+    if not marker.is_file():
+        return f"install-mode marker missing at {marker}"
+    try:
+        content = marker.read_text(encoding="utf-8").strip()
+    except OSError as exc:
+        return f"install-mode marker unreadable ({exc})"
+    if content != "central":
+        return f"install-mode marker invalid (content={content!r}, expected 'central')"
+    return None
+
+
 def _check_install_mode(project_dir: Path) -> Check:
     """Detect embedded vs central VNX install mode and report the active pin."""
     embedded_path = project_dir / ".claude" / "vnx-system"
@@ -150,6 +176,13 @@ def _check_install_mode(project_dir: Path) -> Check:
                 name="install:mode",
                 status=WARN,
                 detail="mode: central, pin: error (cannot read version file — check permissions)",
+            )
+        marker_issue = _check_central_install_marker(central_path)
+        if marker_issue is not None:
+            return Check(
+                name="install:mode",
+                status=WARN,
+                detail=f"mode: central, pin: {pin}, {marker_issue}",
             )
         return Check(
             name="install:mode",

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -99,7 +99,9 @@ def _current_target(root: Path):
     return None
 
 
-def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
+def _fetch_version(
+    root: Path, target: str, dry_run: bool, audit_log: "Path | None" = None
+) -> Path:
     # Belt-and-suspenders: validate before every path join regardless of call site
     _validate_version_name(target)
 
@@ -133,7 +135,7 @@ def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
     # there makes CWD-based project_id resolution return `vnx-dev` for EVERY consumer
     # (the fleet-wide misroute/hard-reject class). Strip it after every fetch.
     _strip_tenant_marker(target_dir)
-    _write_install_marker(target_dir)
+    _write_install_marker(target_dir, audit_log=audit_log)
     return target_dir
 
 
@@ -163,26 +165,56 @@ def _git_toplevel(path: Path) -> "Path | None":
     return Path(output).expanduser().resolve()
 
 
-def _write_install_marker(version_dir: Path) -> None:
+def _write_install_marker(version_dir: Path, audit_log: "Path | None" = None) -> None:
     """Atomically write `.vnx-install-mode` = `central` into version_dir.
 
     Reuses the codebase's shared atomic-write helper (scripts/lib/atomic_io.py)
     instead of a bespoke tmp+os.replace implementation.
+
+    Emits a `central_install_marker_written` NDJSON audit event (ADR-005) —
+    this is an install-state mutation like the symlink flip and prune it
+    accompanies, and must leave the same kind of audit trace.
     """
     from vnx_cli import _engine
     _engine.ensure_engine_on_path()
     from atomic_io import atomic_write_text
 
     atomic_write_text(version_dir / INSTALL_MODE_MARKER, f"{INSTALL_MODE_VALUE}\n")
+    _emit_audit_event(
+        "central_install_marker_written",
+        {"version_dir": str(version_dir)},
+        audit_log=audit_log,
+    )
 
 
-def _ensure_install_marker(version_dir: "Path | None") -> None:
+def _is_under_versions(root: Path, version_dir: Path) -> bool:
+    """True when ``version_dir`` lives directly under ``<root>/versions/`` —
+    the central-install layout install-central.sh lays down
+    (``TARGET_DIR/versions/<version>/``).
+    """
+    try:
+        return version_dir.resolve().parent == (root / "versions").resolve()
+    except OSError:
+        return False
+
+
+def _ensure_install_marker(
+    root: Path, version_dir: "Path | None", audit_log: "Path | None" = None
+) -> None:
     """Self-heal: back-fill the marker on an already-installed, marker-less
     central version dir.
 
-    Guards on the same git-toplevel==version_dir condition
-    `vnx_paths._is_central_install()` uses, so a non-central tree (e.g. a
-    consumer project's own dev checkout) is never mistakenly stamped.
+    Guarded by two conditions:
+
+    1. Ownership: ``version_dir`` must live directly under ``<root>/versions/``
+       (the central-install layout). A standalone dev checkout that happens to
+       resolve as the active `current` target or a rollback/flip target is
+       NOT under ``versions/`` and must never be stamped — every git repo is
+       its own git-toplevel, so relying on that check alone would let a plain
+       dev checkout be mis-stamped `central`, the inverse of the bug this
+       marker exists to prevent.
+    2. Git-toplevel: mirrors the condition `vnx_paths._is_central_install()`
+       uses, kept as an additional guard on top of the ownership check above.
     """
     if version_dir is None or not version_dir.is_dir():
         return
@@ -192,9 +224,11 @@ def _ensure_install_marker(version_dir: "Path | None") -> None:
             return
     except OSError:
         return
+    if not _is_under_versions(root, version_dir):
+        return
     if _git_toplevel(version_dir) != version_dir:
         return
-    _write_install_marker(version_dir)
+    _write_install_marker(version_dir, audit_log=audit_log)
     print(f"Repaired missing install-mode marker: {marker}")
 
 
@@ -210,7 +244,7 @@ def _atomic_symlink_flip(
     # Self-heal: whatever becomes active must carry the marker, even when this
     # flip target was not freshly fetched (e.g. a --rollback to an older
     # version cloned before this fix shipped).
-    _ensure_install_marker(target_dir)
+    _ensure_install_marker(root, target_dir, audit_log=audit_log)
 
     from_version = _current_target(root)
     from_name = from_version.name if from_version else None
@@ -305,7 +339,7 @@ def vnx_update(args) -> int:
         # fetched before this fix shipped) may be active but marker-less. Heal
         # it on this and every subsequent `vnx update` invocation, regardless
         # of what --to/--rollback target is requested below.
-        _ensure_install_marker(_current_target(root))
+        _ensure_install_marker(root, _current_target(root))
 
     if rollback:
         return _do_rollback(root, dry_run=dry_run)

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -20,6 +20,13 @@ DEFAULT_KEEP_LAST = 3
 
 _VERSION_RE = re.compile(r"^(edge|latest|v?\d+\.\d+\.\d+(?:-[\w.]+)?)$")
 
+# Marker written into each central-install version dir. Mirrors
+# install-central.sh::write_install_marker (99-110). Without it,
+# _is_central_install() in vnx_paths.py misresolves a central install as a
+# standalone dev checkout and collapses PROJECT_ROOT onto the shared code tree.
+INSTALL_MODE_MARKER = ".vnx-install-mode"
+INSTALL_MODE_VALUE = "central"
+
 
 def _resolve_root() -> Path:
     env_root = os.environ.get("VNX_HOME_ROOT")
@@ -126,6 +133,7 @@ def _fetch_version(root: Path, target: str, dry_run: bool) -> Path:
     # there makes CWD-based project_id resolution return `vnx-dev` for EVERY consumer
     # (the fleet-wide misroute/hard-reject class). Strip it after every fetch.
     _strip_tenant_marker(target_dir)
+    _write_install_marker(target_dir)
     return target_dir
 
 
@@ -140,6 +148,56 @@ def _strip_tenant_marker(version_dir: Path) -> None:
         print(f"[warn] could not strip tenant marker {marker}: {exc}")
 
 
+def _git_toplevel(path: Path) -> "Path | None":
+    """Mirror of vnx_paths._git_toplevel — the git toplevel of ``path``, or None."""
+    try:
+        output = subprocess.check_output(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            stderr=subprocess.DEVNULL,
+            text=True,
+        ).strip()
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        return None
+    if not output:
+        return None
+    return Path(output).expanduser().resolve()
+
+
+def _write_install_marker(version_dir: Path) -> None:
+    """Atomically write `.vnx-install-mode` = `central` into version_dir.
+
+    Reuses the codebase's shared atomic-write helper (scripts/lib/atomic_io.py)
+    instead of a bespoke tmp+os.replace implementation.
+    """
+    from vnx_cli import _engine
+    _engine.ensure_engine_on_path()
+    from atomic_io import atomic_write_text
+
+    atomic_write_text(version_dir / INSTALL_MODE_MARKER, f"{INSTALL_MODE_VALUE}\n")
+
+
+def _ensure_install_marker(version_dir: "Path | None") -> None:
+    """Self-heal: back-fill the marker on an already-installed, marker-less
+    central version dir.
+
+    Guards on the same git-toplevel==version_dir condition
+    `vnx_paths._is_central_install()` uses, so a non-central tree (e.g. a
+    consumer project's own dev checkout) is never mistakenly stamped.
+    """
+    if version_dir is None or not version_dir.is_dir():
+        return
+    marker = version_dir / INSTALL_MODE_MARKER
+    try:
+        if marker.is_file() and marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE:
+            return
+    except OSError:
+        return
+    if _git_toplevel(version_dir) != version_dir:
+        return
+    _write_install_marker(version_dir)
+    print(f"Repaired missing install-mode marker: {marker}")
+
+
 def _atomic_symlink_flip(
     root: Path, target_dir: Path, dry_run: bool, audit_log: "Path | None" = None
 ) -> None:
@@ -148,6 +206,11 @@ def _atomic_symlink_flip(
     if dry_run:
         print(f"[dry-run] Would flip symlink: {current} -> {target_dir}")
         return
+
+    # Self-heal: whatever becomes active must carry the marker, even when this
+    # flip target was not freshly fetched (e.g. a --rollback to an older
+    # version cloned before this fix shipped).
+    _ensure_install_marker(target_dir)
 
     from_version = _current_target(root)
     from_name = from_version.name if from_version else None
@@ -237,6 +300,12 @@ def vnx_update(args) -> int:
 
     if dry_run:
         print(f"[dry-run] VNX_HOME_ROOT: {root}")
+    else:
+        # One-time repair: an already-installed central version (e.g. `edge`,
+        # fetched before this fix shipped) may be active but marker-less. Heal
+        # it on this and every subsequent `vnx update` invocation, regardless
+        # of what --to/--rollback target is requested below.
+        _ensure_install_marker(_current_target(root))
 
     if rollback:
         return _do_rollback(root, dry_run=dry_run)


### PR DESCRIPTION
## Summary

The central edge-install (`~/.vnx-system/versions/edge`) is missing the `.vnx-install-mode=central` marker because `vnx update` never wrote one — only `install-central.sh` did. Without it, `_is_central_install()` in `scripts/lib/vnx_paths.py` misreads a `vnx update`-fetched central install as a standalone dev checkout, collapsing `PROJECT_ROOT` onto the shared code tree (root cause behind `horizon-sync-roadmap-anchor`).

- `vnx_cli/commands/update.py::_fetch_version()` now writes `.vnx-install-mode=central` (atomic write via `scripts/lib/atomic_io.py`) after every clone/pull, mirroring `install-central.sh::write_install_marker`.
- Self-heal: `_atomic_symlink_flip()` and `vnx_update()` back-fill the marker onto any already-installed, git-toplevel central version dir missing one — guarded on the same git-toplevel==version_dir condition `vnx_paths._is_central_install()` uses, so a non-central tree (e.g. a consumer's own dev checkout) is never stamped. This heals the existing broken `edge` install on the next `vnx update` invocation, regardless of the requested `--to`/`--rollback` target.
- `vnx_cli/commands/doctor.py::_check_install_mode()` now resolves the active `current` symlink to its version dir and WARNs when the marker is missing or invalid, instead of only reporting the pin.
- `scripts/vnx_doctor.py::check_contamination()` gets parity: a git-toplevel `VNX_HOME` living under `~/.vnx-system/` with no/invalid marker now WARNs instead of being silently skipped (a plain git-toplevel check alone isn't enough — a standalone dev checkout is *also* its own git toplevel, so the `~/.vnx-system/` location is required to avoid false positives on ordinary dev checkouts).

## Changes

- `vnx_cli/commands/update.py`: added `INSTALL_MODE_MARKER`/`INSTALL_MODE_VALUE`, `_git_toplevel()`, `_write_install_marker()`, `_ensure_install_marker()`; wired into `_fetch_version()`, `_atomic_symlink_flip()`, and `vnx_update()`.
- `vnx_cli/commands/doctor.py`: added `_check_central_install_marker()`; `_check_install_mode()` now WARNs on a missing/invalid marker.
- `scripts/vnx_doctor.py`: added `_looks_like_central_install_location()`; `check_contamination()` now WARNs on a git-toplevel install under `~/.vnx-system/` with a missing/invalid marker instead of returning `[]`.
- `tests/test_vnx_cli_update.py`: new tests for `_git_toplevel`, `_write_install_marker`, `_ensure_install_marker`, `_fetch_version` marker writes (clone + pull/back-fill paths), `_atomic_symlink_flip` self-heal, and `vnx_update` end-to-end repair of an already-active marker-less install.
- `tests/test_vnx_doctor_strict.py`: existing central-mode tests updated to include a valid marker (so they represent a healthy install); added `test_central_mode_missing_marker_warns` and `test_central_mode_invalid_marker_content_warns`.
- `tests/test_wave4_contamination_check.py`: added tests for the new WARN (missing/invalid marker under `~/.vnx-system/`) and confirmed a standalone dev checkout (git-toplevel, but not under `~/.vnx-system/`) still stays silent.

## Verification

Ran the full relevant test modules:

```
python3 -m pytest tests/test_vnx_doctor_strict.py tests/test_wave4_contamination_check.py \
  tests/test_wave4_install_central_marker.py tests/test_wave4_central_install_e2e.py \
  tests/test_wave4_cmd_update.py tests/test_vnx_cli_update.py -q
```
→ 98 passed, 15 failed (all 14 `test_vnx_doctor_strict.py` failures + 1 `test_vnx_cli_update.py::test_dry_run_schema_warning_present` failure are pre-existing — confirmed identical on `git stash` against the unmodified tree before this change).

Also ran a broader keyword-filtered sweep (`update or doctor or install_central or contamination or vnx_paths or path_resolver`) across all of `tests/`: 399 passed, 5 failed, 1 skipped — same 5 pre-existing failures (test-isolation issues in unrelated modules, e.g. `test_intelligence_pipeline_e2e.py`, `test_learning_feature.py`, `test_serve_dashboard_api.py`) confirmed identical against the unmodified tree.

Syntax/import sanity: `ast.parse` on all 3 modified source files, plus direct imports of the new symbols from `vnx_cli.commands.update`, `vnx_cli.commands.doctor`, and a dynamic-load of `scripts/vnx_doctor.py` (matching how its own test suite loads it) — all clean.

## Open Items

None.

Dispatch-ID: 20260713-INSTALLMARKER