### PR TITLE
feat(injection-eval): reason-aware evaluator + measure-only tuning proposals [PR-B]

### DIFF
--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -1147,12 +1147,34 @@ class LearningLoop:
         except Exception as e:
             print(f"❌ Error reconciling confidence: {e}")
 
+        # 5.8 Reason-aware injection-effectiveness evaluator (injection-effectiveness-eval-loop
+        # PR-B): measure-only tuning proposals from the pattern_injection_outcome reason
+        # distribution. Gated behind its OWN opt-in flags (VNX_INJECTION_WHY_ENABLED AND
+        # VNX_INJECTION_FEEDBACK_ENABLED — the latter already required =1 to have reached this
+        # point via evaluate_activation_gate). No new flag; never auto-applies a tuning change
+        # (G-L1) — proposals land in pending_injection_tuning.json for operator review only.
+        print("\n🔬 Step 5.8: Reason-aware injection tuning proposals...")
+        reason_result = {"ran": False, "proposals_written": 0, "proposals_generated": 0}
+        try:
+            from injection_effectiveness_probe import run_reason_evaluator_and_propose
+            reason_result = run_reason_evaluator_and_propose(state_dir=self.db_path.parent)
+            if reason_result["ran"]:
+                print(
+                    f"  ✓ {reason_result['proposals_written']} new tuning proposal(s) queued "
+                    f"({reason_result['proposals_generated']} generated this run)"
+                )
+            else:
+                print("  Injection-tuning flags off — reason evaluator skipped")
+        except Exception as e:
+            print(f"❌ Error running reason evaluator: {e}")
+
         # 6. Generate report
         print("\n📈 Step 6: Generating learning report...")
         report = self.generate_learning_report()
 
         proposal_count = len(new_rules)
         self.learning_stats["proposal_count"] = proposal_count
+        self.learning_stats["injection_tuning_proposals"] = reason_result.get("proposals_written", 0)
 
         elapsed = time.time() - start_time
         print(f"\n✅ Learning cycle completed in {elapsed:.2f} seconds")

--- a/scripts/lib/injection_effectiveness_probe.py
+++ b/scripts/lib/injection_effectiveness_probe.py
@@ -45,7 +45,10 @@ a flag; the queue they write to is inert until an operator acts on it (G-L1).
 """
 from __future__ import annotations
 
+import fcntl
+import hashlib
 import json
+import logging
 import os
 import sqlite3
 import sys
@@ -60,6 +63,8 @@ if _LIB not in sys.path:
 import config_registry  # noqa: E402
 import project_root  # noqa: E402
 from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
+
+logger = logging.getLogger(__name__)
 
 # r >= this -> produces_crap (owns the 0.90 endpoint).
 PRODUCES_CRAP_THRESHOLD = 0.90
@@ -423,6 +428,101 @@ def generate_tuning_proposals(
     return proposals
 
 
+def _quarantine_corrupt_queue(path: Path, reason: str) -> None:
+    """Preserve an unreadable/corrupt proposal-queue file instead of letting
+    ``write_tuning_proposals`` silently overwrite it.
+
+    Logs a WARNING naming the path and the read/parse error — this codebase's
+    established convention for surfacing a corrupt-state-file instead of
+    silently dropping it (mirrors ``scripts/lib/agent_resolver.py``'s
+    unreadable-tier WARNING) — then renames the corrupt file aside to a
+    UTC-timestamped ``.corrupt.<ts>`` sibling so an operator can inspect or
+    recover any pending proposals it held. Best-effort: if the rename itself
+    fails (e.g. permissions), the WARNING still fires — the corruption is
+    never silent even when the file cannot be relocated.
+    """
+    logger.warning(
+        "write_tuning_proposals: existing queue %s is unreadable/corrupt (%s) — "
+        "quarantining before rewrite; any pending proposals it held are preserved "
+        "in the quarantined copy for operator review, not merged forward",
+        path,
+        reason,
+    )
+    quarantine_path = path.with_name(
+        f"{path.name}.corrupt.{_now_utc().strftime('%Y%m%dT%H%M%SZ')}"
+    )
+    try:
+        os.replace(str(path), str(quarantine_path))
+    except OSError as exc:
+        logger.warning(
+            "write_tuning_proposals: failed to quarantine corrupt queue %s to %s (%s) — left in place",
+            path,
+            quarantine_path,
+            exc,
+        )
+
+
+def _tuning_proposals_events_path() -> Path:
+    """Resolve ``.vnx-data/events/pending_injection_tuning.ndjson``.
+
+    Same resolver + ``events/`` subdirectory convention as
+    ``scripts/lib/provider_costs.py``'s ``_resolve_costs_path()`` and
+    ``scripts/gather_intelligence.py``'s ``_pattern_injection_outcome_events_path()``.
+    """
+    data_dir = project_root.resolve_data_dir(__file__)
+    return data_dir / "events" / "pending_injection_tuning.ndjson"
+
+
+def _emit_tuning_proposals_written_event(
+    *,
+    output_path: Path,
+    proposals_added: int,
+    proposals_total: int,
+    generated_at: str,
+) -> None:
+    """ADR-005 audit event for the ``pending_injection_tuning.json`` write.
+
+    Mirrors ``scripts/lib/provider_costs.py``'s ``emit_provider_cost()``
+    convention (fcntl-locked NDJSON append, sha256 idempotency key,
+    project_id stamp per ADR-007) and ``scripts/gather_intelligence.py``'s
+    sibling ``_emit_injection_outcome_event()``. Raises on write failure — no
+    silent except, matching that convention.
+
+    Reached only from ``write_tuning_proposals``, which in production is only
+    invoked by ``run_reason_evaluator_and_propose`` after the
+    ``VNX_INJECTION_WHY_ENABLED`` + ``VNX_INJECTION_FEEDBACK_ENABLED`` gate —
+    default (flags off) behavior is unchanged, since ``write_tuning_proposals``
+    is never reached when either flag is off.
+    """
+    project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    timestamp = _now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+    record_id = hashlib.sha256(
+        f"{project_id}:{output_path}:{generated_at}:{proposals_added}:{proposals_total}".encode(
+            "utf-8"
+        )
+    ).hexdigest()[:32]
+    event = {
+        "record_id": record_id,
+        "event_type": "injection_tuning_proposals_written",
+        "project_id": project_id,
+        "path": str(output_path),
+        "proposals_added": proposals_added,
+        "proposals_total": proposals_total,
+        "generated_at": generated_at,
+        "timestamp": timestamp,
+    }
+    path = _tuning_proposals_events_path()
+    path.parent.mkdir(parents=True, exist_ok=True)
+    line = json.dumps(event, separators=(",", ":")) + "\n"
+    with path.open("a", encoding="utf-8") as fh:
+        fcntl.flock(fh, fcntl.LOCK_EX)
+        try:
+            fh.write(line)
+            fh.flush()
+        finally:
+            fcntl.flock(fh, fcntl.LOCK_UN)
+
+
 def write_tuning_proposals(
     proposals: List[Dict[str, Any]],
     output_path: "Path | str",
@@ -435,6 +535,15 @@ def write_tuning_proposals(
     status edit (e.g. approved/rejected) on an already-queued proposal survives
     a later evaluator run instead of being silently reset to "pending". Returns
     the number of NEWLY added proposals (0 if every id already existed).
+
+    A missing ``output_path`` (normal first run) starts ``existing`` at ``[]``
+    quietly. An ``output_path`` that EXISTS but is unreadable/corrupt (bad
+    JSON, I/O error, or a parseable-but-non-object top level) is NEVER
+    silently discarded — it is quarantined (see ``_quarantine_corrupt_queue``)
+    and a WARNING is logged before the fresh queue is written.
+
+    Emits an ADR-005 NDJSON audit event (``_emit_tuning_proposals_written_event``)
+    after the ``os.replace`` that persists the queue.
     """
     output_path = Path(output_path)
     if generated_at is None:
@@ -442,12 +551,17 @@ def write_tuning_proposals(
 
     existing: List[Dict[str, Any]] = []
     if output_path.exists():
+        data: Any = None
         try:
             data = json.loads(output_path.read_text(encoding="utf-8"))
-            if isinstance(data, dict):
-                existing = [e for e in data.get("proposals", []) if isinstance(e, dict)]
-        except (json.JSONDecodeError, OSError):
-            existing = []
+        except (json.JSONDecodeError, OSError) as exc:
+            _quarantine_corrupt_queue(output_path, str(exc))
+        if isinstance(data, dict):
+            existing = [e for e in data.get("proposals", []) if isinstance(e, dict)]
+        elif data is not None:
+            _quarantine_corrupt_queue(
+                output_path, f"top-level JSON is {type(data).__name__}, expected an object"
+            )
 
     existing_ids = {e.get("id") for e in existing}
     merged = list(existing)
@@ -461,6 +575,14 @@ def write_tuning_proposals(
     tmp = output_path.with_suffix(output_path.suffix + ".tmp")
     tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
     os.replace(str(tmp), str(output_path))
+
+    _emit_tuning_proposals_written_event(
+        output_path=output_path,
+        proposals_added=added,
+        proposals_total=len(merged),
+        generated_at=generated_at,
+    )
+
     return added
 
 

--- a/scripts/lib/injection_effectiveness_probe.py
+++ b/scripts/lib/injection_effectiveness_probe.py
@@ -32,20 +32,32 @@ in ``signal()``/``detail`` only — it never changes the classification.
 
 This probe MEASURES only. It never flips ``VNX_LEARNING_LOOP_ENABLED`` or
 ``VNX_INJECTION_FEEDBACK_ENABLED`` and never writes to any table it reads.
+
+PR-B (injection-effectiveness-eval-loop) adds a sibling, reason-aware layer in
+this same module: ``InjectionReasonEvaluator`` reads the ``reason`` column
+PR-A's WHY-instrumentation writes to ``pattern_injection_outcome`` and buckets
+it into generation/ranking/presentation failure stages, and
+``generate_tuning_proposals``/``write_tuning_proposals`` turn that into
+measure-only, operator-gated tuning proposals (reusing the pending_rules.json/
+pending_skill_refinements.json convention — see scripts/lib/skill_refinement.py).
+Both stay read-only over pattern_injection_outcome/pattern_usage and never flip
+a flag; the queue they write to is inert until an operator acts on it (G-L1).
 """
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 _LIB = str(Path(__file__).resolve().parent)
 if _LIB not in sys.path:
     sys.path.insert(0, _LIB)
 
+import config_registry  # noqa: E402
 import project_root  # noqa: E402
 from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
 
@@ -228,9 +240,284 @@ class InjectionEffectivenessProbe(EffectivenessProbe):
         return ", ".join(bits)
 
 
+# ---------------------------------------------------------------------------
+# Reason-aware evaluator (injection-effectiveness-eval-loop PR-B).
+#
+# PR-A's VNX_INJECTION_WHY_ENABLED instrumentation persists a per-offer
+# used/ignored-REASON row (pattern_injection_outcome). InjectionEffectivenessProbe
+# above is reason-BLIND: it only sums used/ignored totals. This sibling evaluator
+# reads that table's ``reason`` column and maps each of the six deterministic
+# reasons (gather_intelligence.NON_ADOPTION_REASONS) to the failure stage it
+# implicates, so an operator can see whether the loop's problem is upstream
+# (generation), mid-stream (ranking), or delivery-time (presentation):
+#
+#   irrelevant-to-task, low-signal, already-known, stale  -> generation
+#   wrong-file-affinity                                    -> ranking
+#   bad-timing                                              -> presentation
+#
+# Read-only, like InjectionEffectivenessProbe: evaluate() only SELECTs from
+# pattern_injection_outcome, never writes to it or any other table. Proposal
+# generation/writing (below) targets a NEW JSON proposal queue only — it never
+# touches outcome/usage tables or flips a flag (G-L1).
+#
+# NOT registered in EFFECTIVENESS_PROBES: that registry holds one probe per
+# cockpit subsystem, already owned by InjectionEffectivenessProbe under
+# "intelligence-self-learning-loop". This evaluator is a diagnostic breakdown,
+# not a health classification, so it stays a plain sibling class rather than
+# an EffectivenessProbe subclass (registering it there would silently replace
+# the existing registration for the same subsystem key).
+# ---------------------------------------------------------------------------
+
+# reason -> failure bucket. Keys mirror gather_intelligence.NON_ADOPTION_REASONS,
+# kept as a literal here (rather than importing gather_intelligence, which would
+# pull its full intelligence-gatherer dependency chain into this lightweight,
+# hot-ish probe module) — tests/test_injection_reason_evaluator.py asserts this
+# set stays in sync with that module's tuple.
+REASON_TO_BUCKET: Dict[str, str] = {
+    "irrelevant-to-task": "generation",
+    "low-signal": "generation",
+    "already-known": "generation",
+    "stale": "generation",
+    "wrong-file-affinity": "ranking",
+    "bad-timing": "presentation",
+}
+BUCKETS: Tuple[str, ...] = ("generation", "ranking", "presentation")
+
+
+def _read_reason_counts(db_path: Path) -> Dict[str, int]:
+    """Per-reason counts of ignored (``used = 0``) ``pattern_injection_outcome`` rows.
+
+    Read-only; a missing DB/table/column returns ``{}`` rather than raising — an
+    evaluator must never crash the daily learning cycle it is wired into."""
+    if not db_path.exists():
+        return {}
+    try:
+        conn = sqlite3.connect(str(db_path))
+        try:
+            rows = conn.execute(
+                "SELECT reason, COUNT(*) FROM pattern_injection_outcome "
+                "WHERE used = 0 AND reason IS NOT NULL GROUP BY reason"
+            ).fetchall()
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        return {}
+    return {str(reason): int(count) for reason, count in rows}
+
+
+def _bucket_distribution(reason_counts: Dict[str, int]) -> Dict[str, Any]:
+    """Map reason counts to bucket counts/proportions.
+
+    Unrecognized reasons are dropped rather than raising, so a future reason
+    vocabulary change degrades gracefully instead of crashing the evaluator.
+    """
+    bucket_counts = {b: 0 for b in BUCKETS}
+    for reason, count in reason_counts.items():
+        bucket = REASON_TO_BUCKET.get(reason)
+        if bucket is not None:
+            bucket_counts[bucket] += count
+
+    total = sum(bucket_counts.values())
+    bucket_proportions = {
+        b: (bucket_counts[b] / total if total > 0 else 0.0) for b in BUCKETS
+    }
+    return {
+        "reason_counts": dict(reason_counts),
+        "bucket_counts": bucket_counts,
+        "bucket_proportions": bucket_proportions,
+        "total_ignored": total,
+    }
+
+
+class InjectionReasonEvaluator:
+    """Reads ``pattern_injection_outcome.reason`` and reports the generation/
+    ranking/presentation failure-bucket distribution. Read-only end to end;
+    never writes to any table it reads."""
+
+    def __init__(self, state_dir: Optional[Path] = None) -> None:
+        self.state_dir = (
+            Path(state_dir) if state_dir is not None else project_root.resolve_state_dir(__file__)
+        )
+
+    def evaluate(self) -> Dict[str, Any]:
+        db_path = self.state_dir / "quality_intelligence.db"
+        reason_counts = _read_reason_counts(db_path)
+        return _bucket_distribution(reason_counts)
+
+
+# ---------------------------------------------------------------------------
+# Measure-only tuning proposals (operator-gated; G-L1: never auto-applied).
+#
+# Reuses the pending_rules.json / pending_skill_refinements.json convention
+# (see scripts/lib/skill_refinement.py's write_proposals): atomic tmp+os.replace
+# write, status="pending", a SEPARATE operator-approved step (not built by this
+# PR) applies any resulting tuning change. This layer never flips a flag, never
+# down-ranks a pattern, and never writes to pattern_usage/pattern_injection_outcome
+# — the proposal JSON file is the entire side effect.
+# ---------------------------------------------------------------------------
+
+_BUCKET_TITLES: Dict[str, str] = {
+    "generation": "down-rank pattern generation",
+    "ranking": "fix file-affinity ranking",
+    "presentation": "fix injection timing/presentation",
+}
+_BUCKET_RECOMMENDATIONS: Dict[str, str] = {
+    "generation": (
+        "These offers were ignored for reasons the injection GENERATOR controls — the "
+        "pattern should not have been generated/offered at all. Consider down-ranking or "
+        "suppressing the responsible pattern-type(s)/tag(s) before they are offered again."
+    ),
+    "ranking": (
+        "These offers were ignored because they were offered against the wrong file "
+        "context. Consider tightening the file-affinity signal the RANKING step uses to "
+        "select which dispatch a pattern is offered to."
+    ),
+    "presentation": (
+        "These offers were ignored because they arrived after the relevant edit window "
+        "had already closed. Consider offering earlier in the dispatch lifecycle, or "
+        "suppressing PRESENTATION of a pattern once its window has passed."
+    ),
+}
+
+
+def _bucket_proposal(
+    bucket: str, distribution: Dict[str, Any], generated_at: str
+) -> Optional[Dict[str, Any]]:
+    count = distribution["bucket_counts"].get(bucket, 0)
+    if count <= 0:
+        return None
+    reasons = {
+        reason: n
+        for reason, n in distribution["reason_counts"].items()
+        if REASON_TO_BUCKET.get(reason) == bucket and n > 0
+    }
+    reason_list = "/".join(sorted(reasons))
+    return {
+        "id": f"injtune-{bucket}-{generated_at[:10].replace('-', '')}",
+        "bucket": bucket,
+        "count": count,
+        "proportion": distribution["bucket_proportions"].get(bucket, 0.0),
+        "reasons": reasons,
+        "title": f"{_BUCKET_TITLES[bucket]}: {count} offer(s) ignored-as-{reason_list}",
+        "recommendation": _BUCKET_RECOMMENDATIONS[bucket],
+        "status": "pending",
+        "generated_at": generated_at,
+    }
+
+
+def generate_tuning_proposals(
+    distribution: Dict[str, Any], generated_at: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Turn a bucket distribution into 0-3 measure-only tuning proposals (one per
+    bucket with ignored offers, in generation/ranking/presentation order).
+
+    Pure function: no I/O, no side effects, does not mutate ``distribution``.
+    """
+    if generated_at is None:
+        generated_at = _now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+    proposals = []
+    for bucket in BUCKETS:
+        proposal = _bucket_proposal(bucket, distribution, generated_at)
+        if proposal is not None:
+            proposals.append(proposal)
+    return proposals
+
+
+def write_tuning_proposals(
+    proposals: List[Dict[str, Any]],
+    output_path: "Path | str",
+    generated_at: Optional[str] = None,
+) -> int:
+    """Atomically write/merge proposals into ``pending_injection_tuning.json``
+    (tmp + os.replace, mirroring skill_refinement.write_proposals).
+
+    Merges with any existing queue, deduplicating by ``id`` so an operator's
+    status edit (e.g. approved/rejected) on an already-queued proposal survives
+    a later evaluator run instead of being silently reset to "pending". Returns
+    the number of NEWLY added proposals (0 if every id already existed).
+    """
+    output_path = Path(output_path)
+    if generated_at is None:
+        generated_at = _now_utc().strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    existing: List[Dict[str, Any]] = []
+    if output_path.exists():
+        try:
+            data = json.loads(output_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                existing = [e for e in data.get("proposals", []) if isinstance(e, dict)]
+        except (json.JSONDecodeError, OSError):
+            existing = []
+
+    existing_ids = {e.get("id") for e in existing}
+    merged = list(existing)
+    added = 0
+    for proposal in proposals:
+        if proposal.get("id") not in existing_ids:
+            merged.append(proposal)
+            added += 1
+
+    payload = {"generated_at": generated_at, "proposals": merged}
+    tmp = output_path.with_suffix(output_path.suffix + ".tmp")
+    tmp.write_text(json.dumps(payload, indent=2, ensure_ascii=False), encoding="utf-8")
+    os.replace(str(tmp), str(output_path))
+    return added
+
+
+def _reason_tuning_enabled() -> bool:
+    """Both of the loop's existing opt-in flags must be on — this introduces no
+    new flag. Resolved via ``config_registry.get_bool`` (operator-override +
+    per-project-DB + env precedence) rather than a raw ``os.environ`` read, so
+    an operator's UI/override toggle is honored the same way it is for every
+    other config_registry-backed flag."""
+    return config_registry.get_bool("VNX_INJECTION_WHY_ENABLED") and config_registry.get_bool(
+        "VNX_INJECTION_FEEDBACK_ENABLED"
+    )
+
+
+def run_reason_evaluator_and_propose(state_dir: Optional[Path] = None) -> Dict[str, Any]:
+    """Gate-checked entry point wiring the evaluator + proposal writer together.
+
+    With ``VNX_INJECTION_WHY_ENABLED`` and ``VNX_INJECTION_FEEDBACK_ENABLED`` not
+    BOTH on: a no-op — the evaluator is never invoked, no file is read or
+    written, byte-for-byte current behavior. Returns ``{"ran": False, ...}``.
+
+    When both are on: runs ``InjectionReasonEvaluator.evaluate()``, generates
+    proposals, and (if any) writes them to ``pending_injection_tuning.json``.
+    Never mutates ``pattern_injection_outcome``/``pattern_usage`` or any flag —
+    matches the base probe's "MEASURES only" contract.
+    """
+    if not _reason_tuning_enabled():
+        return {"ran": False, "reason": "flags_off", "proposals_written": 0, "distribution": None}
+
+    resolved_state_dir = (
+        Path(state_dir) if state_dir is not None else project_root.resolve_state_dir(__file__)
+    )
+    evaluator = InjectionReasonEvaluator(state_dir=resolved_state_dir)
+    distribution = evaluator.evaluate()
+    proposals = generate_tuning_proposals(distribution)
+    added = 0
+    if proposals:
+        added = write_tuning_proposals(
+            proposals, resolved_state_dir / "pending_injection_tuning.json"
+        )
+    return {
+        "ran": True,
+        "distribution": distribution,
+        "proposals_generated": len(proposals),
+        "proposals_written": added,
+    }
+
+
 __all__ = [
     "InjectionEffectivenessProbe",
     "PRODUCES_CRAP_THRESHOLD",
     "DEGRADED_THRESHOLD",
     "STALL_THRESHOLD_DAYS",
+    "REASON_TO_BUCKET",
+    "BUCKETS",
+    "InjectionReasonEvaluator",
+    "generate_tuning_proposals",
+    "write_tuning_proposals",
+    "run_reason_evaluator_and_propose",
 ]

--- a/tests/test_injection_reason_evaluator.py
+++ b/tests/test_injection_reason_evaluator.py
@@ -1,0 +1,396 @@
+"""Tests for the reason-aware injection-effectiveness evaluator + measure-only
+tuning proposals (dispatch: injection-effectiveness-eval-loop PR-B).
+
+Covers:
+1. Bucket mapping: pattern_injection_outcome.reason -> generation/ranking/
+   presentation counts + proportions, across all six reasons.
+2. Proposal generation: generation-heavy / ranking-heavy / presentation-heavy
+   distributions each emit the expected proposal shape; mixed distributions
+   emit one proposal per non-zero bucket.
+3. Proposal persistence: atomic write to the operator-gated
+   pending_injection_tuning.json queue; id-dedup preserves an operator's
+   status edit across re-runs.
+4. Gate: VNX_INJECTION_WHY_ENABLED + VNX_INJECTION_FEEDBACK_ENABLED must BOTH
+   be on, or run_reason_evaluator_and_propose is a byte-for-byte no-op.
+5. Never mutates outcome/usage tables or flags.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+for _p in (_SCRIPTS_DIR, _LIB_DIR):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+from effectiveness_probe import EFFECTIVENESS_PROBES  # noqa: E402
+import injection_effectiveness_probe as iep  # noqa: E402
+from injection_effectiveness_probe import (  # noqa: E402
+    BUCKETS,
+    REASON_TO_BUCKET,
+    InjectionReasonEvaluator,
+    generate_tuning_proposals,
+    run_reason_evaluator_and_propose,
+    write_tuning_proposals,
+)
+from gather_intelligence import NON_ADOPTION_REASONS  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_outcome_db(tmp_path: Path, rows) -> Path:
+    """rows: iterable of (pattern_id, used, reason) tuples."""
+    db_path = tmp_path / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            """
+            CREATE TABLE pattern_injection_outcome (
+                id          INTEGER PRIMARY KEY,
+                dispatch_id TEXT    NOT NULL,
+                pattern_id  TEXT    NOT NULL,
+                pattern_hash TEXT,
+                used        INTEGER NOT NULL DEFAULT 0,
+                reason      TEXT,
+                evidence    TEXT,
+                project_id  TEXT    NOT NULL DEFAULT 'vnx-dev',
+                created_at  TEXT    NOT NULL
+            )
+            """
+        )
+        for i, (pattern_id, used, reason) in enumerate(rows):
+            conn.execute(
+                "INSERT INTO pattern_injection_outcome "
+                "(dispatch_id, pattern_id, used, reason, project_id, created_at) "
+                "VALUES (?, ?, ?, ?, 'vnx-dev', '2026-07-13T00:00:00Z')",
+                (f"d-{i}", pattern_id, used, reason),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+# ---------------------------------------------------------------------------
+# 1. Bucket mapping
+# ---------------------------------------------------------------------------
+
+class TestReasonToBucketDriftGuard:
+    def test_reason_to_bucket_covers_exactly_the_six_non_adoption_reasons(self):
+        assert set(REASON_TO_BUCKET) == set(NON_ADOPTION_REASONS)
+
+    def test_every_bucket_value_is_one_of_the_three_buckets(self):
+        assert set(REASON_TO_BUCKET.values()) <= set(BUCKETS)
+        assert set(REASON_TO_BUCKET.values()) == set(BUCKETS)
+
+
+class TestBucketDistribution:
+    def test_all_six_reasons_map_to_correct_buckets_with_counts_and_proportions(self, tmp_path):
+        rows = [(f"pat-{r}", 0, r) for r in NON_ADOPTION_REASONS]
+        _make_outcome_db(tmp_path, rows)
+
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        assert distribution["bucket_counts"] == {"generation": 4, "ranking": 1, "presentation": 1}
+        assert distribution["total_ignored"] == 6
+        assert distribution["bucket_proportions"]["generation"] == pytest.approx(4 / 6)
+        assert distribution["bucket_proportions"]["ranking"] == pytest.approx(1 / 6)
+        assert distribution["bucket_proportions"]["presentation"] == pytest.approx(1 / 6)
+        assert distribution["reason_counts"] == {r: 1 for r in NON_ADOPTION_REASONS}
+
+    def test_used_rows_are_excluded_from_the_distribution(self, tmp_path):
+        rows = [("pat-used", 1, None), ("pat-ignored", 0, "wrong-file-affinity")]
+        _make_outcome_db(tmp_path, rows)
+
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        assert distribution["total_ignored"] == 1
+        assert distribution["bucket_counts"] == {"generation": 0, "ranking": 1, "presentation": 0}
+
+    def test_no_db_at_all_returns_zeroed_distribution_not_a_crash(self, tmp_path):
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        assert distribution["total_ignored"] == 0
+        assert distribution["bucket_counts"] == {"generation": 0, "ranking": 0, "presentation": 0}
+        assert distribution["bucket_proportions"] == {"generation": 0.0, "ranking": 0.0, "presentation": 0.0}
+
+    def test_missing_pattern_injection_outcome_table_is_treated_as_no_data(self, tmp_path):
+        db_path = tmp_path / "quality_intelligence.db"
+        sqlite3.connect(str(db_path)).close()
+
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        assert distribution["total_ignored"] == 0
+
+    def test_evaluator_never_writes_to_the_database_it_reads(self, tmp_path):
+        rows = [(f"pat-{r}", 0, r) for r in NON_ADOPTION_REASONS]
+        db_path = _make_outcome_db(tmp_path, rows)
+        before = db_path.read_bytes()
+
+        InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        assert db_path.read_bytes() == before
+
+    def test_evaluator_not_registered_as_a_cockpit_effectiveness_probe(self):
+        """The evaluator is a diagnostic breakdown, not a health probe — it must
+        not clobber InjectionEffectivenessProbe's registration for the same
+        subsystem key."""
+        assert InjectionReasonEvaluator not in EFFECTIVENESS_PROBES.values()
+        assert EFFECTIVENESS_PROBES["intelligence-self-learning-loop"].__name__ == (
+            "InjectionEffectivenessProbe"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Proposal generation — pure function of a distribution
+# ---------------------------------------------------------------------------
+
+_GENERATED_AT = "2026-07-13T12:00:00Z"
+
+
+class TestProposalShapes:
+    def test_generation_heavy_distribution_emits_only_a_generation_proposal(self, tmp_path):
+        rows = [("p1", 0, "irrelevant-to-task"), ("p2", 0, "low-signal"), ("p3", 0, "low-signal")]
+        _make_outcome_db(tmp_path, rows)
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        proposals = generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert len(proposals) == 1
+        proposal = proposals[0]
+        assert proposal["bucket"] == "generation"
+        assert proposal["count"] == 3
+        assert "down-rank" in proposal["title"]
+        assert proposal["reasons"] == {"irrelevant-to-task": 1, "low-signal": 2}
+        assert proposal["status"] == "pending"
+
+    def test_ranking_heavy_distribution_emits_only_a_ranking_proposal(self, tmp_path):
+        rows = [("p1", 0, "wrong-file-affinity"), ("p2", 0, "wrong-file-affinity")]
+        _make_outcome_db(tmp_path, rows)
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        proposals = generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert len(proposals) == 1
+        proposal = proposals[0]
+        assert proposal["bucket"] == "ranking"
+        assert proposal["count"] == 2
+        assert "file-affinity ranking" in proposal["title"]
+        assert proposal["reasons"] == {"wrong-file-affinity": 2}
+
+    def test_presentation_heavy_distribution_emits_only_a_presentation_proposal(self, tmp_path):
+        rows = [("p1", 0, "bad-timing")]
+        _make_outcome_db(tmp_path, rows)
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        proposals = generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert len(proposals) == 1
+        proposal = proposals[0]
+        assert proposal["bucket"] == "presentation"
+        assert proposal["count"] == 1
+        assert "timing" in proposal["title"]
+        assert proposal["reasons"] == {"bad-timing": 1}
+
+    def test_mixed_distribution_emits_one_proposal_per_nonzero_bucket_in_order(self, tmp_path):
+        rows = [
+            ("p1", 0, "stale"),
+            ("p2", 0, "wrong-file-affinity"),
+            ("p3", 0, "bad-timing"),
+        ]
+        _make_outcome_db(tmp_path, rows)
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        proposals = generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert [p["bucket"] for p in proposals] == ["generation", "ranking", "presentation"]
+
+    def test_empty_distribution_emits_no_proposals(self, tmp_path):
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        proposals = generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert proposals == []
+
+    def test_generate_tuning_proposals_is_pure_no_files_written(self, tmp_path, monkeypatch):
+        monkeypatch.chdir(tmp_path)
+        rows = [("p1", 0, "bad-timing")]
+        _make_outcome_db(tmp_path, rows)
+        distribution = InjectionReasonEvaluator(state_dir=tmp_path).evaluate()
+
+        generate_tuning_proposals(distribution, generated_at=_GENERATED_AT)
+
+        assert not (tmp_path / "pending_injection_tuning.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 3. Proposal persistence — operator-gated surface
+# ---------------------------------------------------------------------------
+
+class TestWriteTuningProposals:
+    def test_writes_atomically_to_the_operator_gated_queue(self, tmp_path):
+        proposals = [{
+            "id": "injtune-ranking-20260713",
+            "bucket": "ranking",
+            "count": 2,
+            "status": "pending",
+            "generated_at": _GENERATED_AT,
+        }]
+        out = tmp_path / "pending_injection_tuning.json"
+
+        added = write_tuning_proposals(proposals, out, generated_at=_GENERATED_AT)
+
+        assert added == 1
+        assert out.exists()
+        assert not out.with_suffix(out.suffix + ".tmp").exists()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["proposals"][0]["status"] == "pending"
+        assert data["proposals"][0]["id"] == "injtune-ranking-20260713"
+
+    def test_dedup_by_id_preserves_operator_status_edit(self, tmp_path):
+        out = tmp_path / "pending_injection_tuning.json"
+        proposal = {
+            "id": "injtune-generation-20260713",
+            "bucket": "generation",
+            "count": 5,
+            "status": "pending",
+            "generated_at": _GENERATED_AT,
+        }
+        write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        # Operator approves it out-of-band.
+        data = json.loads(out.read_text(encoding="utf-8"))
+        data["proposals"][0]["status"] = "approved"
+        out.write_text(json.dumps(data), encoding="utf-8")
+
+        # Evaluator re-runs the same day and regenerates the identical proposal.
+        added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        assert added == 0
+        data_after = json.loads(out.read_text(encoding="utf-8"))
+        assert len(data_after["proposals"]) == 1
+        assert data_after["proposals"][0]["status"] == "approved"
+
+    def test_corrupt_existing_queue_is_replaced_not_raised(self, tmp_path):
+        out = tmp_path / "pending_injection_tuning.json"
+        out.write_text("{not valid json", encoding="utf-8")
+        proposal = {"id": "injtune-ranking-20260713", "bucket": "ranking", "status": "pending"}
+
+        added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        assert added == 1
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert len(data["proposals"]) == 1
+
+
+# ---------------------------------------------------------------------------
+# 4. Gate — both opt-in flags required; no new flag introduced
+# ---------------------------------------------------------------------------
+
+class TestGate:
+    def test_both_flags_off_is_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_INJECTION_WHY_ENABLED", raising=False)
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+        rows = [("p1", 0, "bad-timing")]
+        _make_outcome_db(tmp_path, rows)
+
+        result = run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert result == {"ran": False, "reason": "flags_off", "proposals_written": 0, "distribution": None}
+        assert not (tmp_path / "pending_injection_tuning.json").exists()
+
+    def test_only_why_flag_on_is_still_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_INJECTION_WHY_ENABLED", "1")
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+        rows = [("p1", 0, "bad-timing")]
+        _make_outcome_db(tmp_path, rows)
+
+        result = run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert result["ran"] is False
+        assert not (tmp_path / "pending_injection_tuning.json").exists()
+
+    def test_only_feedback_flag_on_is_still_a_noop(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_INJECTION_WHY_ENABLED", raising=False)
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+        rows = [("p1", 0, "bad-timing")]
+        _make_outcome_db(tmp_path, rows)
+
+        result = run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert result["ran"] is False
+        assert not (tmp_path / "pending_injection_tuning.json").exists()
+
+    def test_flags_off_never_touches_the_filesystem_evaluator(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("VNX_INJECTION_WHY_ENABLED", raising=False)
+        monkeypatch.delenv("VNX_INJECTION_FEEDBACK_ENABLED", raising=False)
+        calls = []
+        monkeypatch.setattr(
+            iep, "InjectionReasonEvaluator",
+            lambda **kw: calls.append(kw) or InjectionReasonEvaluator(**kw),
+        )
+
+        run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert calls == []
+
+    def test_both_flags_on_runs_and_writes_proposals(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_INJECTION_WHY_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+        rows = [("p1", 0, "wrong-file-affinity"), ("p2", 0, "wrong-file-affinity")]
+        _make_outcome_db(tmp_path, rows)
+
+        result = run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert result["ran"] is True
+        assert result["proposals_written"] == 1
+        assert result["distribution"]["bucket_counts"]["ranking"] == 2
+
+        out = tmp_path / "pending_injection_tuning.json"
+        assert out.exists()
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert data["proposals"][0]["bucket"] == "ranking"
+
+    def test_both_flags_on_but_no_ignored_rows_writes_nothing(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_INJECTION_WHY_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+
+        result = run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert result["ran"] is True
+        assert result["proposals_written"] == 0
+        assert not (tmp_path / "pending_injection_tuning.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 5. Never mutates outcome/usage tables or flags
+# ---------------------------------------------------------------------------
+
+class TestNeverMutatesStateItReads:
+    def test_run_never_mutates_the_outcome_db_or_leaves_flags_changed(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_INJECTION_WHY_ENABLED", "1")
+        monkeypatch.setenv("VNX_INJECTION_FEEDBACK_ENABLED", "1")
+        rows = [(f"pat-{r}", 0, r) for r in NON_ADOPTION_REASONS]
+        db_path = _make_outcome_db(tmp_path, rows)
+        before = db_path.read_bytes()
+
+        run_reason_evaluator_and_propose(state_dir=tmp_path)
+
+        assert db_path.read_bytes() == before
+        assert os.environ.get("VNX_INJECTION_WHY_ENABLED") == "1"
+        assert os.environ.get("VNX_INJECTION_FEEDBACK_ENABLED") == "1"
+        assert os.environ.get("VNX_LEARNING_LOOP_ENABLED", "0") == "0"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_injection_reason_evaluator.py
+++ b/tests/test_injection_reason_evaluator.py
@@ -281,16 +281,88 @@ class TestWriteTuningProposals:
         assert len(data_after["proposals"]) == 1
         assert data_after["proposals"][0]["status"] == "approved"
 
-    def test_corrupt_existing_queue_is_replaced_not_raised(self, tmp_path):
+    def test_corrupt_existing_queue_is_quarantined_not_silently_replaced(self, tmp_path, caplog):
         out = tmp_path / "pending_injection_tuning.json"
-        out.write_text("{not valid json", encoding="utf-8")
+        corrupt_bytes = "{not valid json"
+        out.write_text(corrupt_bytes, encoding="utf-8")
+        proposal = {"id": "injtune-ranking-20260713", "bucket": "ranking", "status": "pending"}
+
+        with caplog.at_level("WARNING"):
+            added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        # The write still proceeds (the loop must not seize up on a corrupt
+        # queue) but the fresh file only ever holds the newly generated
+        # proposal — nothing "recovered" from the corrupt bytes.
+        assert added == 1
+        data = json.loads(out.read_text(encoding="utf-8"))
+        assert len(data["proposals"]) == 1
+
+        # The corrupt original is preserved for operator inspection, not lost.
+        quarantined = list(tmp_path.glob("pending_injection_tuning.json.corrupt.*"))
+        assert len(quarantined) == 1
+        assert quarantined[0].read_text(encoding="utf-8") == corrupt_bytes
+
+        assert any(
+            "unreadable/corrupt" in record.message and str(out) in record.message
+            for record in caplog.records
+        )
+
+    def test_non_object_existing_queue_is_quarantined_not_silently_dropped(self, tmp_path, caplog):
+        out = tmp_path / "pending_injection_tuning.json"
+        out.write_text("[]", encoding="utf-8")
+        proposal = {"id": "injtune-ranking-20260713", "bucket": "ranking", "status": "pending"}
+
+        with caplog.at_level("WARNING"):
+            added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        assert added == 1
+        quarantined = list(tmp_path.glob("pending_injection_tuning.json.corrupt.*"))
+        assert len(quarantined) == 1
+        assert any("unreadable/corrupt" in record.message for record in caplog.records)
+
+    def test_first_run_no_existing_file_is_quiet(self, tmp_path, caplog):
+        out = tmp_path / "pending_injection_tuning.json"
+        proposal = {"id": "injtune-ranking-20260713", "bucket": "ranking", "status": "pending"}
+
+        with caplog.at_level("WARNING"):
+            added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
+
+        assert added == 1
+        assert not list(tmp_path.glob("*.corrupt.*"))
+        assert caplog.records == []
+
+    def test_write_emits_adr005_audit_event(self, tmp_path, monkeypatch):
+        events_path = tmp_path / "events" / "pending_injection_tuning.ndjson"
+        monkeypatch.setattr(iep, "_tuning_proposals_events_path", lambda: events_path)
+        out = tmp_path / "pending_injection_tuning.json"
         proposal = {"id": "injtune-ranking-20260713", "bucket": "ranking", "status": "pending"}
 
         added = write_tuning_proposals([proposal], out, generated_at=_GENERATED_AT)
 
         assert added == 1
-        data = json.loads(out.read_text(encoding="utf-8"))
-        assert len(data["proposals"]) == 1
+        assert events_path.exists()
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 1
+        event = json.loads(lines[0])
+        assert event["event_type"] == "injection_tuning_proposals_written"
+        assert event["path"] == str(out)
+        assert event["proposals_added"] == 1
+        assert event["proposals_total"] == 1
+        assert event["generated_at"] == _GENERATED_AT
+        assert "record_id" in event and "project_id" in event and "timestamp" in event
+
+    def test_write_emits_one_audit_event_per_call(self, tmp_path, monkeypatch):
+        events_path = tmp_path / "events" / "pending_injection_tuning.ndjson"
+        monkeypatch.setattr(iep, "_tuning_proposals_events_path", lambda: events_path)
+        out = tmp_path / "pending_injection_tuning.json"
+        proposal_a = {"id": "injtune-ranking-a", "bucket": "ranking", "status": "pending"}
+        proposal_b = {"id": "injtune-ranking-b", "bucket": "ranking", "status": "pending"}
+
+        write_tuning_proposals([proposal_a], out, generated_at=_GENERATED_AT)
+        write_tuning_proposals([proposal_b], out, generated_at=_GENERATED_AT)
+
+        lines = events_path.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
PR-B of injection-effectiveness-eval-loop (P1), completing the meta-loop. A reason-aware evaluator reads PR-A's `pattern_injection_outcome.reason`, buckets the six non-adoption reasons into generation / ranking / presentation failure stages, and emits **measure-only** tuning proposals to a new operator-gated queue `pending_injection_tuning.json`.

- Extends `InjectionEffectivenessProbe` (read-only over the tables it reads) with the reason distribution + bucket mapping.
- Wired into the learning-loop read-path; gated behind the existing `VNX_INJECTION_WHY_ENABLED` + `VNX_INJECTION_FEEDBACK_ENABLED` flags. No new flag, no default flipped, nothing auto-applied (G-L1 honored).
- Proposals follow the atomic-write + `status: pending` + id-dedup convention.

## Verification
292 injection/probe/self-learning tests passed. Full test module: `tests/test_injection_reason_evaluator.py` (+396). Report: `20260713-INJECTEVAL.md`.

Dispatch-ID: 20260713-INJECTEVAL

## Open Items
- `pending_injection_tuning.json` has no list/approve/reject CLI/dashboard consumer yet (same state as pending_archival.json before its consumer) — follow-up. Applying an approved proposal (actual down-rank / ranking-fix) is deliberately NOT built (operator-gated).
- Optional `(used, reason)` index skipped (migration-registry out of scope); existing dispatch_id/pattern_id indexes adequate at current volume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)