### PR TITLE
fix(plan-gate-panel): scoped-spawn env + verdict-parser backward scan (opus seat NO-VERDICT)

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -203,47 +203,86 @@ def _parse_json_loose(body: str) -> Optional[Any]:
     return None
 
 
+def _iter_fence_bodies(report_text: str) -> List[str]:
+    """Return the body text of every ``vnx-plan-verdict`` fence, in document order.
+
+    Each fence's body is bounded by the START of the NEXT ``_OPEN_FENCE`` occurrence
+    (or end-of-text for the last fence) before the closing-``` search runs — so when a
+    report contains more than one fence, an earlier fence's body slice can never bleed
+    into a later fence (a naive ``rfind`` bound at end-of-text would pick up the LAST
+    fence's closing marker for every earlier fence too).
+    """
+    opens: List[int] = []
+    search_from = 0
+    while True:
+        idx = report_text.find(_OPEN_FENCE, search_from)
+        if idx == -1:
+            break
+        opens.append(idx)
+        search_from = idx + len(_OPEN_FENCE)
+    bodies = []
+    for i, idx in enumerate(opens):
+        bound = opens[i + 1] if i + 1 < len(opens) else len(report_text)
+        chunk = report_text[idx + len(_OPEN_FENCE):bound]
+        close_idx = chunk.rfind("```")
+        if close_idx != -1:
+            chunk = chunk[:close_idx]
+        bodies.append(chunk)
+    return bodies
+
+
 def parse_verdict(report_text: str) -> Dict[str, Any]:
-    """Extract the LAST ``vnx-plan-verdict`` block from a panelist report.
+    """Extract a ``vnx-plan-verdict`` block from a panelist report.
+
+    Scans every ``vnx-plan-verdict`` fence from LAST to FIRST and returns the first one
+    that parses into a valid verdict object. This matters when a panelist's final fence
+    is the ECHOED verdict-contract EXAMPLE (containing the non-JSON union
+    ``"verdict": "pass" | "revise" | "block"``) rather than its actual verdict: that
+    fence is unparseable by construction, so without scanning backward past it a real
+    verdict emitted earlier in the report would be lost to a spurious abstain.
 
     Tolerant of common near-miss formatting via ``_parse_json_loose`` — a trailing comma, prose
     bleeding in around the JSON object, or a nested ` ```json ` code fence wrapping the object —
     so a slightly-malformed body no longer forces a spurious abstain (the codex/glm verdict-JSON
-    flake). The exact ``vnx-plan-verdict`` fence label is still required verbatim: that is the
-    same marker ``_sanitize_doc`` neutralizes in untrusted plan-doc input, so this deliberately
-    does NOT fall back to a bare/relabeled ```json fence — doing so would reopen the verdict-
-    spoofing hole (kimi finding 4) via a doc that gets echoed into a panelist's own report.
+    flake). The exact ``vnx-plan-verdict`` fence label is still required verbatim for EVERY
+    candidate fence: that is the same marker ``_sanitize_doc`` neutralizes in untrusted plan-doc
+    input, so this deliberately never falls back to a bare/relabeled ```json fence — doing so
+    would reopen the verdict-spoofing hole (kimi finding 4) via a doc that gets echoed into a
+    panelist's own report.
 
-    Fail-safe by design: anything still unparseable after repair becomes ``revise`` with
+    Fail-safe by design: if NO fence parses into a valid verdict, the result is ``revise`` with
     ``parse_error=True`` so a missing/garbled verdict can never silently PASS.
     """
     empty = {"verdict": "revise", "blocking_findings": [], "rationale": "", "parse_error": True}
     if not report_text:
         return {**empty, "rationale": "empty report"}
-    idx = report_text.rfind(_OPEN_FENCE)
-    if idx == -1:
+    bodies = _iter_fence_bodies(report_text)
+    if not bodies:
         return {**empty, "rationale": "no verdict block found"}
-    body = report_text[idx + len(_OPEN_FENCE):]
-    close_idx = body.rfind("```")
-    if close_idx != -1:
-        body = body[:close_idx]
-    data = _parse_json_loose(body)
-    if data is None:
-        return {**empty, "rationale": "verdict block is not valid JSON"}
-    if not isinstance(data, dict):
-        return {**empty, "rationale": "verdict block is not a JSON object"}
-    verdict = str(data.get("verdict", "")).strip().lower()
-    if verdict not in _VALID_VERDICTS:
-        return {**empty, "rationale": f"unknown verdict {verdict!r}"}
-    findings = data.get("blocking_findings") or []
-    if not isinstance(findings, list):
-        findings = [str(findings)]
-    return {
-        "verdict": verdict,
-        "blocking_findings": [str(x) for x in findings],
-        "rationale": str(data.get("rationale", "")),
-        "parse_error": False,
-    }
+
+    last_reason = "verdict block is not valid JSON"
+    for body in reversed(bodies):
+        data = _parse_json_loose(body)
+        if data is None:
+            last_reason = "verdict block is not valid JSON"
+            continue
+        if not isinstance(data, dict):
+            last_reason = "verdict block is not a JSON object"
+            continue
+        verdict = str(data.get("verdict", "")).strip().lower()
+        if verdict not in _VALID_VERDICTS:
+            last_reason = f"unknown verdict {verdict!r}"
+            continue
+        findings = data.get("blocking_findings") or []
+        if not isinstance(findings, list):
+            findings = [str(findings)]
+        return {
+            "verdict": verdict,
+            "blocking_findings": [str(x) for x in findings],
+            "rationale": str(data.get("rationale", "")),
+            "parse_error": False,
+        }
+    return {**empty, "rationale": last_reason}
 
 
 @dataclass
@@ -397,6 +436,15 @@ def _make_default_dispatcher(
         _tmp_doc_path: Optional[str] = None
         try:
             if provider in _CLAUDE_PROVIDERS:
+                # Scoped-spawn fix (2026-07-14): --working-tree-only's commit/push deny
+                # only binds in the scoped detached spawn; tmux_interactive_dispatch.dispatch()
+                # fails CLOSED otherwise (its D2.2 scoping precondition), refusing the dispatch
+                # before any report is written -> silent NO-VERDICT for this seat. Opt this
+                # subprocess's env into the scoped posture so the --working-tree-only flag this
+                # lane already passes is actually honored. Provider (kimi/glm/deepseek) lanes
+                # below are untouched — this only applies to the claude/tmux branch.
+                env["VNX_WORKER_SCOPED"] = "1"
+
                 # BUG-2 FIX (file-ref): the instruction already has the full plan doc inlined
                 # by run_panel's build_plan_review_instruction call. For the claude/tmux lane
                 # we replace it with a compact file-ref instruction so the ~50k-char body never
@@ -468,9 +516,13 @@ def _make_default_dispatcher(
             )
             report = _read_report(base, dispatch_id, proc.stderr)
             if report is None:
+                # tmux_interactive_dispatch's CLI prints the InteractiveDispatchResult (incl.
+                # the actionable `failure_reason`) as JSON to STDOUT, not stderr -- surfacing
+                # only stderr here previously masked the real cause (e.g. the D2.2 scoping
+                # refusal) behind an unrelated last-stderr-line red herring.
                 raise RuntimeError(
                     f"no report for {dispatch_id} (rc={proc.returncode}): "
-                    f"{(proc.stderr or '')[-400:]}"
+                    f"stdout: {(proc.stdout or '')[-800:]} | stderr: {(proc.stderr or '')[-400:]}"
                 )
             return report
         finally:

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -142,6 +142,43 @@ def test_parse_verdict_genuinely_absent_block_still_failsafe_revise():
     assert out["parse_error"] is True
 
 
+def test_parse_verdict_echoed_contract_example_as_last_fence_falls_back_to_earlier_real_verdict():
+    # A panelist's LAST fence is the echoed verdict-CONTRACT EXAMPLE (the literal union
+    # "pass" | "revise" | "block", not valid JSON) rather than its actual verdict. An
+    # earlier fence in the same report holds the real verdict. The scan must walk
+    # backward past the unparseable echoed fence and recover the earlier real one --
+    # not abstain despite a real verdict having been emitted.
+    real = _report('{"verdict": "pass", "blocking_findings": [], "rationale": "solid plan"}')
+    echoed_contract = (
+        "\n\nFor reference, the contract says:\n\n"
+        f"```{pgp.VERDICT_FENCE}\n"
+        "{\n"
+        '  "verdict": "pass" | "revise" | "block",\n'
+        '  "blocking_findings": ["short concrete issue", "..."],\n'
+        '  "rationale": "one or two sentences"\n'
+        "}\n"
+        "```\n"
+    )
+    out = pgp.parse_verdict(real + echoed_contract)
+    assert out["verdict"] == "pass"
+    assert out["parse_error"] is False
+    assert out["rationale"] == "solid plan"
+
+
+def test_parse_verdict_all_fences_unparseable_still_failsafe_revise():
+    # If EVERY fence (not just the last) fails to parse into a valid verdict, the
+    # fail-safe still applies -- there is no earlier real verdict to fall back to.
+    text = (
+        f"```{pgp.VERDICT_FENCE}\nnot json at all\n```\n"
+        f"```{pgp.VERDICT_FENCE}\n"
+        '{"verdict": "pass" | "revise" | "block"}\n'
+        "```\n"
+    )
+    out = pgp.parse_verdict(text)
+    assert out["verdict"] == "revise"
+    assert out["parse_error"] is True
+
+
 # --------------------------------------------------------------------------
 # apply_panel_rule
 # --------------------------------------------------------------------------
@@ -842,6 +879,141 @@ def test_claude_lane_dispatcher_writes_temp_file_and_cleans_up(tmp_path):
     # The temp file must have been cleaned up after the subprocess returned.
     for p in seen_tmp_paths:
         assert not os.path.exists(p), f"temp doc file not cleaned up: {p}"
+
+
+# --------------------------------------------------------------------------
+# scoped-spawn fix (2026-07-14): tmux_interactive_dispatch.dispatch()'s D2.2 scoping
+# precondition (tmux_interactive_dispatch.py, "D2.2 scoping precondition" -- fail-closed:
+# a working_tree_only dispatch is refused unless the env carries VNX_WORKER_SCOPED=1 or
+# VNX_ENFORCE_WORKER_PERMISSIONS=1) is deterministic and already has direct test coverage
+# in tests/test_working_tree_only.py (test_default_env_working_tree_only_is_rejected /
+# test_scoped_opt_in_working_tree_only_is_accepted_by_precondition) -- not duplicated here.
+# What's new in THIS module: the claude/tmux-lane subprocess env plan_gate_panel builds
+# must actually set the flag so that precondition is satisfied instead of tripping it.
+# --------------------------------------------------------------------------
+
+def test_claude_lane_dispatcher_sets_scoped_spawn_env(tmp_path, monkeypatch):
+    """The claude/tmux-lane subprocess env must carry VNX_WORKER_SCOPED=1.
+
+    Without it, tmux_interactive_dispatch.dispatch()'s D2.2 scoping precondition
+    refuses every --working-tree-only dispatch this lane sends (working_tree_only
+    requires a scoped detached spawn) before any report is written -- the opus/claude
+    seat's silent NO-VERDICT root cause. The base env must NOT already carry the flag,
+    so a pass here proves the dispatcher sets it rather than an ambient leak.
+    """
+    monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    seen_envs: list = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_envs.append(kwargs.get("env"))
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    import plan_gate_panel as _pgp
+    import unittest.mock as mock
+
+    authored_report = _make_report_with_fence("pass")
+    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(_pgp, "_read_report", return_value=authored_report):
+            pgp.run_panel(
+                doc,
+                track_id="feat-scoped",
+                project_id="p1",
+                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+                data_dir=str(tmp_path),
+            )
+
+    assert len(seen_envs) == 1
+    assert seen_envs[0] is not None
+    assert seen_envs[0].get("VNX_WORKER_SCOPED") == "1", (
+        "claude/tmux-lane subprocess env must set VNX_WORKER_SCOPED=1 so the "
+        "--working-tree-only D2.2 fail-closed precondition is satisfied"
+    )
+
+
+def test_provider_lane_dispatcher_does_not_set_scoped_spawn_env(tmp_path, monkeypatch):
+    """The scoped-spawn env fix is claude/tmux-lane-only.
+
+    kimi/glm/deepseek route through provider_dispatch.py, which has no
+    --working-tree-only concept; their subprocess env must be left untouched.
+    """
+    monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    seen_envs: list = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_envs.append(kwargs.get("env"))
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    import plan_gate_panel as _pgp
+    import unittest.mock as mock
+
+    authored_report = _make_report_with_fence("pass")
+    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(_pgp, "_read_report", return_value=authored_report):
+            pgp.run_panel(
+                doc,
+                track_id="feat-provider-scope",
+                project_id="p1",
+                panel=[{"label": "kimi", "provider": "kimi", "model_arg": "kimi-k2-7-code"}],
+                data_dir=str(tmp_path),
+            )
+
+    assert len(seen_envs) == 1
+    assert seen_envs[0] is not None
+    assert "VNX_WORKER_SCOPED" not in seen_envs[0]
+
+
+def test_claude_lane_no_report_error_surfaces_stdout_failure_reason(tmp_path):
+    """The 'no report' RuntimeError must include proc.stdout, not just stderr.
+
+    tmux_interactive_dispatch's CLI prints the InteractiveDispatchResult (incl. the
+    actionable failure_reason, e.g. the D2.2 scoping refusal) as JSON to STDOUT. The
+    previous stderr-only message masked the real cause behind an unrelated red herring
+    (a stray 'staging_validator: unstaged dispatch override' stderr line) for a full day.
+    """
+    import json
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        import subprocess as _sp
+        stdout = json.dumps({
+            "success": False,
+            "dispatch_id": "whatever",
+            "failure_reason": "working_tree_only requires a scoped detached spawn",
+        })
+        return _sp.CompletedProcess(
+            cmd, returncode=1, stdout=stdout,
+            stderr="staging_validator: unstaged dispatch override",
+        )
+
+    import plan_gate_panel as _pgp
+    import unittest.mock as mock
+
+    with mock.patch.object(_pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(_pgp, "_read_report", return_value=None):
+            out = pgp.run_panel(
+                doc,
+                track_id="feat-diag",
+                project_id="p1",
+                panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+                data_dir=str(tmp_path),
+            )
+
+    opus = next(p for p in out["panelists"] if p["label"] == "opus")
+    assert opus["dispatched"] is False
+    assert "working_tree_only requires a scoped detached spawn" in opus["error"], (
+        "the real failure_reason (printed to stdout by tmux_interactive_dispatch's CLI) "
+        "must be surfaced, not swallowed behind a stderr-only error message"
+    )
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
Fixes the two confirmed root causes of the plan-gate panel's opus/claude seat NO-VERDICT at duration ~0.0, which degraded the panel to REVISE fleet-wide.

Track: `plan-gate-panel-scoped-spawn-fix`
Dispatch: `20260714-plangate-scoped-spawn-fix`

## Fix A — scoped spawn + diagnosability (`scripts/lib/plan_gate_panel.py`)
- `_dispatch` claude branch now sets `env["VNX_WORKER_SCOPED"] = "1"` before `subprocess.run`, so `--working-tree-only` binds and `tmux_interactive_dispatch.py`'s fail-closed D2.2 precondition (1755-1774) accepts the scoped spawn instead of refusing it. Provider (kimi/glm/deepseek) branch untouched.
- "No report" error now includes `proc.stdout[-800:]` (the real `failure_reason`, previously discarded) alongside `proc.stderr[-400:]`.

## Fix B — verdict parser skips echoed contract example (`scripts/lib/plan_gate_panel.py`)
- New `_iter_fence_bodies()` slices per-fence bodies; `parse_verdict()` scans `vnx-plan-verdict` fences last-to-first and returns the first that parses into a valid verdict. Fail-safe (`revise` + `parse_error=True`) only if none parse. Verdict-spoofing guard preserved (exact fence label still required; no bare ```json fallback).

## Verification
- `pytest tests/test_plan_gate_panel.py` → 64 passed (was 61; +3 net incl. 5 new tests covering both fixes + scope boundary).
- Cross-module: `test_plan_gate_panel.py test_working_tree_only.py test_worker_permission_enforcement_flag.py` → 99 passed. `tmux_interactive_dispatch.py` untouched; its D2.2 refusal coverage unchanged.
- Root cause confirmed against live code (plan_gate_panel.py:396/449/470-474; tmux_interactive_dispatch.py:1755-1776).

## Open Items
- Live opus-seat "after" confirmation (a real panel spawn showing the opus seat now scores) was deferred by the headless worker to avoid a nested tmux spawn from inside its own worker session. T0 runs this directly as the final acceptance check before merge.
- No global default flipped; scope held to `plan_gate_panel.py` + `tests/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)