### PR TITLE
fix(vnx-init): per-skill refresh in bootstrap_skills (mixed-dir safe, no freeze/clobber)

### DIFF
--- a/scripts/vnx_init.py
+++ b/scripts/vnx_init.py
@@ -32,6 +32,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 from vnx_paths import ensure_env
+from vnx_skills import is_opted_out, iter_skill_dirs
 
 # ---------------------------------------------------------------------------
 # Result model
@@ -198,8 +199,57 @@ def write_config(paths: Dict[str, str]) -> StepResult:
 # Step: bootstrap skills
 # ---------------------------------------------------------------------------
 
+def _refresh_canon_skills(canon_dirs: List[Path], target: Path) -> "tuple[int, int]":
+    """Refresh each canon skill into target/<name>/ in place.
+
+    ``target`` (.claude/skills and its codex/gemini mirrors) is a MIXED dir:
+    shipped canon skills co-exist with project-authored skills (ADR
+    2026-07-14 skills-in-consumers-ssot §11). Only directory names present in
+    ``canon_dirs`` are touched; anything else under target is project-authored
+    and is left byte-for-byte untouched. A target skill dir carrying the
+    ``.vnx-skip-sync`` marker is preserved even when its name matches canon,
+    so a consumer can pin a local customization of a canon skill.
+
+    Returns (canon_refreshed_count, project_preserved_count).
+    """
+    if target.is_symlink():
+        target.unlink()
+
+    target.mkdir(parents=True, exist_ok=True)
+    use_rsync = shutil.which("rsync") is not None
+
+    canon_names = {skill_dir.name for skill_dir in canon_dirs}
+    refreshed = 0
+    for skill_dir in canon_dirs:
+        dest = target / skill_dir.name
+        if dest.exists() and is_opted_out(dest):
+            continue
+        if use_rsync:
+            subprocess.run(["rsync", "-a", f"{skill_dir}/", f"{dest}/"],
+                           check=True, capture_output=True)
+        else:
+            if dest.exists():
+                shutil.rmtree(dest)
+            shutil.copytree(str(skill_dir), str(dest))
+        refreshed += 1
+
+    preserved = sum(
+        1 for child in target.iterdir()
+        if child.is_dir() and child.name not in canon_names
+    )
+
+    return refreshed, preserved
+
+
 def bootstrap_skills(paths: Dict[str, str]) -> StepResult:
-    """Copy shipped skills to .claude/skills/ (and multi-provider dirs)."""
+    """Refresh shipped canon skills into .claude/skills/ (and multi-provider dirs).
+
+    Per-skill refresh, not dir-level copy-once: each shipped skill under
+    VNX_HOME/skills is re-synced into the target by name every run, so a
+    consumer's canon skills can never freeze/drift from fabric canon. Skill
+    dirs whose name isn't in the shipped set are project-authored and are
+    never touched.
+    """
     project_root = Path(paths["PROJECT_ROOT"])
     vnx_home = Path(paths["VNX_HOME"])
     shipped = vnx_home / "skills"
@@ -208,21 +258,15 @@ def bootstrap_skills(paths: Dict[str, str]) -> StepResult:
     if not shipped.is_dir():
         return StepResult("skills", FAIL, f"Missing shipped skills: {shipped}")
 
-    # Remove stale symlink
-    if target.is_symlink():
-        target.unlink()
-    elif target.is_dir():
-        return StepResult("skills", SKIP, "Keeping existing skills dir")
+    canon_dirs = list(iter_skill_dirs(shipped))
+    if not canon_dirs:
+        return StepResult("skills", FAIL, f"No canon skill directories found under: {shipped}")
 
-    target.parent.mkdir(parents=True, exist_ok=True)
-
-    if shutil.which("rsync"):
-        subprocess.run(["rsync", "-a", f"{shipped}/", f"{target}/"],
-                       check=True, capture_output=True)
-    else:
-        shutil.copytree(str(shipped), str(target), dirs_exist_ok=True)
-
-    details = []
+    refreshed, preserved = _refresh_canon_skills(canon_dirs, target)
+    details = [
+        f".claude/skills: refreshed {refreshed} canon skill(s), "
+        f"preserved {preserved} project skill(s)"
+    ]
 
     # Multi-provider sync
     for cli, skill_dir in [
@@ -230,15 +274,14 @@ def bootstrap_skills(paths: Dict[str, str]) -> StepResult:
         ("gemini", project_root / ".gemini" / "skills"),
     ]:
         if shutil.which(cli):
-            skill_dir.mkdir(parents=True, exist_ok=True)
-            if shutil.which("rsync"):
-                subprocess.run(["rsync", "-a", f"{shipped}/", f"{skill_dir}/"],
-                               check=True, capture_output=True)
-            else:
-                shutil.copytree(str(shipped), str(skill_dir), dirs_exist_ok=True)
-            details.append(f"Synced to {cli}: {skill_dir}")
+            r, p = _refresh_canon_skills(canon_dirs, skill_dir)
+            details.append(
+                f"Synced to {cli} ({skill_dir}): refreshed {r} canon skill(s), "
+                f"preserved {p} project skill(s)"
+            )
 
-    return StepResult("skills", PASS, f"Copied to {target}", details)
+    return StepResult("skills", PASS,
+                      f"Refreshed {refreshed} canon skill(s) in {target}", details)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_vnx_init.py
+++ b/tests/test_vnx_init.py
@@ -47,8 +47,8 @@ def vnx_env(tmp_path):
 
     # Create VNX_HOME structure
     (vnx_home / "skills").mkdir()
-    (vnx_home / "skills" / "skills.yaml").write_text("skills: []\n")
-    (vnx_home / "skills" / "test-skill.md").write_text("# Test skill\n")
+    (vnx_home / "skills" / "test-skill").mkdir()
+    (vnx_home / "skills" / "test-skill" / "SKILL.md").write_text("# Test skill\n")
     (vnx_home / "templates" / "terminals").mkdir(parents=True)
     for tid in ["T0", "T1", "T2", "T3"]:
         (vnx_home / "templates" / "terminals" / f"{tid}.md").write_text(f"# {tid}\n")
@@ -164,14 +164,48 @@ class TestBootstrapSkills:
 
         skills_dir = Path(vnx_env["PROJECT_ROOT"]) / ".claude" / "skills"
         assert skills_dir.is_dir()
-        assert (skills_dir / "skills.yaml").exists()
-        assert (skills_dir / "test-skill.md").exists()
+        assert (skills_dir / "test-skill" / "SKILL.md").exists()
 
-    def test_skips_existing_dir(self, vnx_env):
+    def test_refreshes_stale_canon_skill_and_preserves_project_skill(self, vnx_env):
+        """Pre-existing target dir: canon skill refreshes, project skill is untouched."""
         skills_dir = Path(vnx_env["PROJECT_ROOT"]) / ".claude" / "skills"
         skills_dir.mkdir(parents=True)
+
+        # Stale canon skill: shares a name with the shipped skill but drifted content.
+        stale = skills_dir / "test-skill"
+        stale.mkdir()
+        (stale / "SKILL.md").write_text("# STALE drifted content\n")
+
+        # Project-authored skill: name not present in the shipped canon set.
+        project_skill = skills_dir / "my-project-skill"
+        project_skill.mkdir()
+        (project_skill / "SKILL.md").write_text("# My project skill\n")
+        (project_skill / "notes.txt").write_text("keep me\n")
+
         result = bootstrap_skills(vnx_env)
-        assert result.status == SKIP
+        assert result.status == PASS
+
+        shipped_content = (Path(vnx_env["VNX_HOME"]) / "skills" / "test-skill" / "SKILL.md").read_text()
+        refreshed_content = (skills_dir / "test-skill" / "SKILL.md").read_text()
+        assert refreshed_content == shipped_content
+        assert "STALE" not in refreshed_content
+
+        assert (project_skill / "SKILL.md").read_text() == "# My project skill\n"
+        assert (project_skill / "notes.txt").read_text() == "keep me\n"
+
+    def test_honors_skip_sync_marker_on_target(self, vnx_env):
+        """A target skill carrying .vnx-skip-sync is never overwritten, even on a canon name."""
+        skills_dir = Path(vnx_env["PROJECT_ROOT"]) / ".claude" / "skills"
+        skills_dir.mkdir(parents=True)
+
+        pinned = skills_dir / "test-skill"
+        pinned.mkdir()
+        (pinned / "SKILL.md").write_text("# Locally pinned, do not sync\n")
+        (pinned / ".vnx-skip-sync").write_text("")
+
+        result = bootstrap_skills(vnx_env)
+        assert result.status == PASS
+        assert (pinned / "SKILL.md").read_text() == "# Locally pinned, do not sync\n"
 
     def test_removes_stale_symlink(self, vnx_env):
         skills_dir = Path(vnx_env["PROJECT_ROOT"]) / ".claude" / "skills"
@@ -180,6 +214,7 @@ class TestBootstrapSkills:
         result = bootstrap_skills(vnx_env)
         assert result.status == PASS
         assert not skills_dir.is_symlink()
+        assert (skills_dir / "test-skill" / "SKILL.md").exists()
 
     def test_fails_on_missing_shipped(self, vnx_env):
         import shutil
@@ -207,7 +242,7 @@ class TestBootstrapSkills:
         result = bootstrap_skills(wt_paths)
 
         assert result.status == PASS
-        assert (worktree_root / ".claude" / "skills" / "skills.yaml").exists()
+        assert (worktree_root / ".claude" / "skills" / "test-skill" / "SKILL.md").exists()
         assert not (canonical_root / ".claude" / "skills").exists()
 
 
@@ -309,7 +344,7 @@ class TestRunInit:
         # Verify key artifacts exist
         project_root = Path(vnx_env["PROJECT_ROOT"])
         assert (project_root / ".vnx" / "config.yml").exists()
-        assert (project_root / ".claude" / "skills" / "skills.yaml").exists()
+        assert (project_root / ".claude" / "skills" / "test-skill" / "SKILL.md").exists()
         assert (project_root / ".claude" / "terminals" / "T0" / "CLAUDE.md").exists()
         assert Path(vnx_env["VNX_STATE_DIR"]).is_dir()
 


### PR DESCRIPTION
## Summary
Fixes the skip-if-exists freeze in `bootstrap_skills` (the SEOcrawler drift cause). `.claude/skills` is a MIXED loaded dir (canon + project skills), so canon skills now refresh per-skill while project skills are preserved.

Track: `skills-consumer-install-artifact` · Dispatch: `20260714-skills-perskill-refresh`

## Changes
- `scripts/vnx_init.py::bootstrap_skills`: per-skill refresh via `vnx_skills.iter_skill_dirs` — canon skills overwritten in place, project skills (not in shipped canon) preserved byte-for-byte, `.vnx-skip-sync` honored. No more dir-level skip-if-exists or wholesale clobber. Returns (canon_refreshed, project_preserved).
- Tests: mixed-dir preserve, `.vnx-skip-sync`, first-run full materialize.

## Verification
`pytest tests/test_vnx_init.py` green. Implements ADR-032 §11 (mixed-dir per-skill rule).

## Open Items
None. Follow-up (separate PR): A/B/C manifest gitignore generation + verify terminals/hooks for the same mixing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)