### PR TITLE
fix(phantom-guard): diff pushed PR branch for fix-forward dispatches (no false-reject)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -29,6 +29,7 @@ from __future__ import annotations
 import hashlib
 import logging
 import os
+import subprocess
 import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -395,6 +396,61 @@ def _receipt_exists_for_dispatch(receipt_path: Path, dispatch_id: str) -> bool:
     return False
 
 
+def _resolve_fix_forward_diff(
+    spec: EnvelopeSpec,
+    own_diff: Optional[str],
+    *,
+    base_ref: str = "origin/main",
+    repo: Optional[Path] = None,
+) -> Optional[str]:
+    """Fall back to the PUSHED PR branch's diff when the dispatch's own worktree/branch diff
+    reads empty and the dispatch targets an EXISTING PR (``spec.pr_id`` set) — a fix-forward
+    dispatch.
+
+    A fix-forward dispatch pushes its commit onto that PR's branch (per its instruction), not
+    onto its own ``dispatch/<id>`` worktree branch — the own-worktree diff then reads empty even
+    though real work landed and was pushed. T0's rule is "verify the pushed branch, not the
+    report" (phantom_guard module docstring). ``spec.pr_id`` is the dispatch's existing-PR
+    identifier — already carried on EnvelopeSpec, populated from ``--pr-id`` — resolved to its
+    head branch via ``gh pr view``.
+
+    ``repo`` is the git checkout to resolve/fetch/diff against — the orchestrator's own repo
+    root (the ephemeral dispatch worktree is gone or going away by the time GOVERN runs), not
+    the worker's torn-down worktree. Defaults to ``project_root.resolve_project_root``.
+
+    No-op for a normal dispatch: a non-empty ``own_diff`` short-circuits before any gh/git call,
+    so the own-worktree diff stays the sole source there (unchanged behavior). Best-effort: any
+    resolution failure (no gh, bad pr_id, PR not pushed yet) falls back to ``own_diff``
+    unchanged — a genuinely empty dispatch (no own diff, no resolvable/non-empty pushed branch)
+    still reads empty here, so phantom_guard() still catches it.
+    """
+    if (own_diff or "").strip():
+        return own_diff
+    pr_id = (spec.pr_id or "").strip()
+    if not pr_id:
+        return own_diff
+    try:
+        from phantom_guard import compute_branch_diff, resolve_pr_head_branch  # noqa: PLC0415
+        if repo is None:
+            from project_root import resolve_project_root  # noqa: PLC0415
+            repo = resolve_project_root(__file__)
+        branch = resolve_pr_head_branch(pr_id, repo=repo)
+        if not branch:
+            return own_diff
+        subprocess.run(
+            ["git", "fetch", "origin", branch],
+            cwd=str(repo), capture_output=True, text=True, timeout=30, check=False,
+        )
+        pushed_diff = compute_branch_diff(f"origin/{branch}", base_ref=base_ref, repo=repo)
+    except Exception as exc:  # noqa: BLE001 — best-effort; never raise, never false-reject on a resolution error
+        logger.warning(
+            "envelope: fix-forward diff resolution failed dispatch=%s pr_id=%s: %s",
+            spec.dispatch_id, pr_id, exc,
+        )
+        return own_diff
+    return pushed_diff if pushed_diff.strip() else own_diff
+
+
 def _govern(
     spec: EnvelopeSpec,
     adapter_result: _AdapterResult,
@@ -402,6 +458,7 @@ def _govern(
     end_time: datetime,
     phantom_diff: Optional[str] = None,
     integrity: Optional[Any] = None,
+    base_ref: str = "origin/main",
 ) -> tuple:
     """Emit unified_report then dispatch receipt. Returns (report_path, receipt_path).
 
@@ -518,6 +575,10 @@ def _govern(
     try:
         from phantom_guard import record_phantom_if_any  # noqa: PLC0415
         _tok = adapter_result.token_usage or {}
+        # Fix-forward: an empty own-worktree/dispatch-branch diff is falsely read as phantom when
+        # the dispatch targets an existing PR (spec.pr_id) and pushed its commit onto THAT branch
+        # instead — resolve the pushed branch and use its diff when the own diff is empty.
+        _effective_diff = _resolve_fix_forward_diff(spec, phantom_diff, base_ref=base_ref)
         record_phantom_if_any(
             dispatch_id=spec.dispatch_id,
             role=spec.role,
@@ -525,7 +586,7 @@ def _govern(
             token_usage=(int(_tok.get("input", 0) or 0) + int(_tok.get("output", 0) or 0)) or None,
             worktree_path=None,
             base_sha=None,
-            worktree_diff=phantom_diff,  # F1: pre-captured before the worktree teardown
+            worktree_diff=_effective_diff,  # F1: pre-captured before the worktree teardown
             receipts_file=str(spec.state_dir / "t0_receipts.ndjson"),
             state_dir=spec.state_dir,
         )
@@ -1154,7 +1215,8 @@ def run_envelope_plan(
         remove_dispatch_worktree(plan.dispatch_id)
 
     report_path, receipt_path = _govern(
-        enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity
+        enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,
+        base_ref=plan.base_ref or "origin/main",
     )
 
     return EnvelopeResult(

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -10,6 +10,14 @@ it reads empty even for a real worktree worker (the known Layer-3 gap in provena
 info-severity, diffs the wrong tree, never fires). The caller computes the diff of the actual
 worktree / pushed branch and passes it in; T0's rule is "verify the pushed branch, not the report".
 
+A FIX-FORWARD dispatch (one that targets an existing PR via ``pr_id`` and pushes its commit onto
+that PR's branch instead of its own ``dispatch/<id>`` worktree branch) is the sharpest instance of
+this rule: its own-worktree diff reads empty even though the commit really landed. The pure
+decision function below does not special-case this — it is still "empty diff -> phantom" — the
+caller resolves the pushed branch (``resolve_pr_head_branch`` + ``compute_branch_diff``) and
+supplies THAT as ``worktree_diff`` when the own-worktree diff is empty (see
+``dispatch_envelope._resolve_fix_forward_diff``).
+
 token_usage is only CORROBORATING: providers that report it (codex/claude) spending >0 tokens proves
 an LLM ran; kimi-cli never reports tokens, so its absence/0 is not evidence of a phantom. Reviewers
 legitimately produce no diff, so REVIEW_ROLES are exempt.
@@ -126,6 +134,34 @@ def compute_branch_diff(
         ["git", "diff", f"{merge_base}..{head_ref}"],
         cwd=cwd, capture_output=True, text=True, check=True,
     ).stdout
+
+
+def resolve_pr_head_branch(
+    pr_id: str, *, repo: Optional[Path] = None, timeout: float = 10.0
+) -> Optional[str]:
+    """Resolve a PR number/id to its head branch name via ``gh pr view --json headRefName``.
+
+    Best-effort: returns None on ANY failure (gh unavailable, bad pr_id, no network, PR not
+    found, malformed JSON) — callers must treat None as 'unresolvable', NEVER as evidence of
+    anything (a resolution failure must never manufacture or suppress a phantom verdict).
+    """
+    pr_id = (pr_id or "").strip()
+    if not pr_id:
+        return None
+    cwd = str(repo) if repo else None
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "view", pr_id, "--json", "headRefName"],
+            cwd=cwd, capture_output=True, text=True, timeout=timeout, check=False,
+        )
+        if proc.returncode != 0:
+            return None
+        import json  # noqa: PLC0415
+        data = json.loads(proc.stdout)
+        branch = data.get("headRefName")
+        return branch.strip() if isinstance(branch, str) and branch.strip() else None
+    except (subprocess.TimeoutExpired, OSError, ValueError):
+        return None
 
 
 def compute_worktree_diff(worktree_path: Path, *, base_ref: str = "origin/main") -> str:

--- a/tests/test_phantom_guard_fix_forward.py
+++ b/tests/test_phantom_guard_fix_forward.py
@@ -1,0 +1,326 @@
+"""test_phantom_guard_fix_forward.py — fix-forward false-reject fix.
+
+A fix-forward dispatch pushes its commit onto an EXISTING PR branch (per its instruction)
+instead of its own dispatch/<id> worktree branch, so the own-worktree diff reads empty even
+though the commit really landed. Covers:
+
+1. phantom_guard.resolve_pr_head_branch — PR-id -> head-branch resolution via `gh pr view`,
+   isolated from real gh/network via a stubbed subprocess.run.
+2. dispatch_envelope._resolve_fix_forward_diff — the caller-side diff-source fix, unit-tested
+   with monkeypatched resolution + against a REAL local git repo (git fetch + git diff really
+   run) so the plumbing itself is proven, not just the branching logic.
+3. The three mandatory end-to-end scenarios via phantom_guard.phantom_guard(): fix-forward
+   passes, normal dispatch is unchanged, genuinely-empty still phantom.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+import phantom_guard as pg
+from dispatch_envelope import EnvelopeSpec, _resolve_fix_forward_diff
+
+
+# ---------------------------------------------------------------------------
+# resolve_pr_head_branch — gh CLI resolution, isolated from real gh/network
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _FakeProc:
+    returncode: int
+    stdout: str = ""
+
+
+def test_resolve_pr_head_branch_empty_pr_id_no_subprocess_call(monkeypatch):
+    def _boom(*a, **k):
+        raise AssertionError("subprocess.run must not be called for an empty pr_id")
+
+    monkeypatch.setattr(pg.subprocess, "run", _boom)
+    assert pg.resolve_pr_head_branch("") is None
+    assert pg.resolve_pr_head_branch(None) is None
+
+
+def test_resolve_pr_head_branch_success(monkeypatch):
+    monkeypatch.setattr(
+        pg.subprocess, "run",
+        lambda *a, **k: _FakeProc(0, '{"headRefName": "dispatch/20260710-existing-pr"}'),
+    )
+    assert pg.resolve_pr_head_branch("1161") == "dispatch/20260710-existing-pr"
+
+
+def test_resolve_pr_head_branch_gh_nonzero_exit_returns_none(monkeypatch):
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(1, ""))
+    assert pg.resolve_pr_head_branch("999999") is None
+
+
+def test_resolve_pr_head_branch_malformed_json_returns_none(monkeypatch):
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, "not json"))
+    assert pg.resolve_pr_head_branch("1161") is None
+
+
+def test_resolve_pr_head_branch_timeout_returns_none(monkeypatch):
+    def _raise_timeout(*a, **k):
+        raise subprocess.TimeoutExpired(cmd="gh", timeout=10)
+
+    monkeypatch.setattr(pg.subprocess, "run", _raise_timeout)
+    assert pg.resolve_pr_head_branch("1161") is None
+
+
+def test_resolve_pr_head_branch_gh_missing_returns_none(monkeypatch):
+    def _raise_oserror(*a, **k):
+        raise OSError("gh: command not found")
+
+    monkeypatch.setattr(pg.subprocess, "run", _raise_oserror)
+    assert pg.resolve_pr_head_branch("1161") is None
+
+
+def test_resolve_pr_head_branch_blank_headref_returns_none(monkeypatch):
+    monkeypatch.setattr(pg.subprocess, "run", lambda *a, **k: _FakeProc(0, '{"headRefName": ""}'))
+    assert pg.resolve_pr_head_branch("1161") is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_fix_forward_diff — pure branching, mocked resolution
+# ---------------------------------------------------------------------------
+
+
+def _spec(*, pr_id: Optional[str], tmp_path: Path) -> EnvelopeSpec:
+    return EnvelopeSpec(
+        dispatch_id="fixfwd-dispatch-001",
+        terminal_id="T1",
+        provider="claude",
+        model="sonnet",
+        instruction="fix forward onto the existing PR branch",
+        role="backend-developer",
+        pr_id=pr_id,
+        state_dir=tmp_path / "state",
+        data_dir=tmp_path / "data",
+    )
+
+
+def test_non_empty_own_diff_short_circuits_no_resolution_attempted(tmp_path, monkeypatch):
+    # Normal dispatch: a real own-worktree diff must be returned unchanged and must NEVER
+    # trigger a gh/git resolution call — pr_id being set must not matter here.
+    def _boom(*a, **k):
+        raise AssertionError("resolve_pr_head_branch must not be called when own_diff is non-empty")
+
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", _boom)
+    spec = _spec(pr_id="1161", tmp_path=tmp_path)
+    own_diff = "diff --git a/x b/x\n+hello\n"
+    assert _resolve_fix_forward_diff(spec, own_diff) == own_diff
+
+
+def test_empty_own_diff_no_pr_id_returns_unchanged_no_resolution(tmp_path, monkeypatch):
+    # No pr_id -> not a fix-forward candidate; empty own_diff passes through untouched.
+    def _boom(*a, **k):
+        raise AssertionError("resolve_pr_head_branch must not be called without pr_id")
+
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", _boom)
+    spec = _spec(pr_id=None, tmp_path=tmp_path)
+    assert _resolve_fix_forward_diff(spec, "") == ""
+    assert _resolve_fix_forward_diff(spec, None) is None
+
+
+def test_empty_own_diff_pr_id_set_resolution_fails_falls_back_to_own_diff(tmp_path, monkeypatch):
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: None)
+    spec = _spec(pr_id="1161", tmp_path=tmp_path)
+    assert _resolve_fix_forward_diff(spec, "") == ""
+
+
+def test_empty_own_diff_pr_id_set_branch_resolved_but_diff_empty_falls_back(tmp_path, monkeypatch):
+    # Branch resolves, but its diff against base is also empty (e.g. not pushed yet) — must
+    # still fall back to own_diff, not manufacture non-empty evidence.
+    # repo=tmp_path (not a real git checkout) so this stays isolated: the "git fetch" best-effort
+    # call harmlessly no-ops (check=False) and compute_branch_diff is stubbed directly, so no real
+    # git/subprocess plumbing — and critically, no monkeypatching of the shared subprocess module
+    # itself (that would also break project_root.py's own subprocess.check_output call, since
+    # `dispatch_envelope.subprocess` and `project_root.subprocess` are the SAME module object).
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "some-branch")
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "")
+    spec = _spec(pr_id="1161", tmp_path=tmp_path)
+    assert _resolve_fix_forward_diff(spec, "", repo=tmp_path) == ""
+
+
+def test_empty_own_diff_pr_id_set_pushed_diff_non_empty_wins(tmp_path, monkeypatch):
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "some-branch")
+    monkeypatch.setattr(pg, "compute_branch_diff", lambda *a, **k: "diff --git a/y b/y\n+fix\n")
+    spec = _spec(pr_id="1161", tmp_path=tmp_path)
+    result = _resolve_fix_forward_diff(spec, "", repo=tmp_path)
+    assert result == "diff --git a/y b/y\n+fix\n"
+
+
+def test_resolution_exception_never_raises_falls_back_to_own_diff(tmp_path, monkeypatch):
+    def _raise(*a, **k):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", _raise)
+    spec = _spec(pr_id="1161", tmp_path=tmp_path)
+    # must not raise
+    assert _resolve_fix_forward_diff(spec, "") == ""
+
+
+# ---------------------------------------------------------------------------
+# Real git repo fixture — proves the actual git plumbing (fetch + diff), not just branching
+# ---------------------------------------------------------------------------
+
+
+def _run_git(repo: Path, *args: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args], cwd=str(repo), capture_output=True, text=True, check=True,
+    )
+
+
+@pytest.fixture()
+def git_fixture(tmp_path: Path):
+    """A bare 'origin' remote + a working checkout, mirroring the real fabric shape: the
+    dispatch orchestrator's own repo checkout with a remote it fetches pushed branches from.
+    """
+    bare = tmp_path / "origin.git"
+    work = tmp_path / "work"
+    bare.mkdir()
+    _run_git(bare, "init", "--bare", "-b", "main")
+
+    work.mkdir()
+    _run_git(work, "init", "-b", "main")
+    _run_git(work, "config", "user.email", "test@example.com")
+    _run_git(work, "config", "user.name", "Test")
+    (work / "README.md").write_text("base\n", encoding="utf-8")
+    _run_git(work, "add", "README.md")
+    _run_git(work, "commit", "-m", "base commit")
+    _run_git(work, "remote", "add", "origin", str(bare))
+    _run_git(work, "push", "origin", "main")
+    return work
+
+
+def _push_branch_with_commit(work: Path, branch: str, filename: str) -> None:
+    """Simulate a worker pushing a fix-forward commit onto an existing PR branch."""
+    _run_git(work, "checkout", "-b", branch, "main")
+    (work / filename).write_text("fix-forward change\n", encoding="utf-8")
+    _run_git(work, "add", filename)
+    _run_git(work, "commit", "-m", f"fix-forward: {filename}")
+    _run_git(work, "push", "origin", branch)
+    _run_git(work, "checkout", "main")
+    _run_git(work, "branch", "-D", branch)  # own worktree no longer carries the branch locally
+
+
+def _push_branch_no_commit(work: Path, branch: str) -> None:
+    """Simulate an 'existing PR branch' with nothing new pushed onto it (still == main)."""
+    _run_git(work, "checkout", "-b", branch, "main")
+    _run_git(work, "push", "origin", branch)
+    _run_git(work, "checkout", "main")
+    _run_git(work, "branch", "-D", branch)
+
+
+def test_fix_forward_real_git_pushed_branch_diff_resolved(git_fixture, monkeypatch):
+    # own worktree has NOTHING (own_diff = ""); the fix-forward commit is only on origin's
+    # pre-existing PR branch. resolve_pr_head_branch is stubbed (no real gh call) to point at
+    # that real branch; git fetch + git diff run for REAL against the bare origin.
+    _push_branch_with_commit(git_fixture, "dispatch/original-pr-branch", "fix.txt")
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "dispatch/original-pr-branch")
+
+    spec = EnvelopeSpec(
+        dispatch_id="fixfwd-dispatch-002", terminal_id="T1", provider="claude", model="sonnet",
+        instruction="fix forward", role="backend-developer", pr_id="1161",
+        state_dir=git_fixture / "state", data_dir=git_fixture / "data",
+    )
+    result = _resolve_fix_forward_diff(spec, "", base_ref="main", repo=git_fixture)
+    assert result is not None and result.strip()
+    assert "fix.txt" in result
+
+
+def test_fix_forward_real_git_genuinely_empty_pushed_branch_falls_back(git_fixture, monkeypatch):
+    # the "existing PR branch" resolves but carries NO diff from base (nothing was pushed yet)
+    # -> falls back to own_diff (still empty here) so the caller still reads it as empty.
+    _push_branch_no_commit(git_fixture, "dispatch/stale-pr-branch")
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "dispatch/stale-pr-branch")
+
+    spec = EnvelopeSpec(
+        dispatch_id="fixfwd-dispatch-003", terminal_id="T1", provider="claude", model="sonnet",
+        instruction="fix forward", role="backend-developer", pr_id="1161",
+        state_dir=git_fixture / "state", data_dir=git_fixture / "data",
+    )
+    result = _resolve_fix_forward_diff(spec, "", base_ref="main", repo=git_fixture)
+    assert (result or "") == ""
+
+
+def test_fix_forward_real_git_unresolvable_branch_falls_back(git_fixture, monkeypatch):
+    # gh cannot resolve pr_id at all (deleted PR, bad id, no gh) -> ABSTAIN to own_diff, never
+    # raise, never fabricate a diff.
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: None)
+
+    spec = EnvelopeSpec(
+        dispatch_id="fixfwd-dispatch-004", terminal_id="T1", provider="claude", model="sonnet",
+        instruction="fix forward", role="backend-developer", pr_id="99999-does-not-exist",
+        state_dir=git_fixture / "state", data_dir=git_fixture / "data",
+    )
+    result = _resolve_fix_forward_diff(spec, "", base_ref="main", repo=git_fixture)
+    assert (result or "") == ""
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the three mandatory Verify scenarios, through phantom_guard() itself
+# ---------------------------------------------------------------------------
+
+
+def test_verify_fix_forward_dispatch_passes_not_phantom(git_fixture, monkeypatch):
+    """Fix-forward dispatch: own worktree empty but pushed branch carries a real commit ->
+    guard PASSES (not phantom)."""
+    _push_branch_with_commit(git_fixture, "dispatch/original-pr-branch", "fix.txt")
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "dispatch/original-pr-branch")
+
+    spec = EnvelopeSpec(
+        dispatch_id="fixfwd-e2e-pass", terminal_id="T1", provider="claude", model="sonnet",
+        instruction="fix forward", role="backend-developer", pr_id="1161",
+        state_dir=git_fixture / "state", data_dir=git_fixture / "data",
+    )
+    effective_diff = _resolve_fix_forward_diff(spec, "", base_ref="main", repo=git_fixture)
+    verdict = pg.phantom_guard(status="done", worktree_diff=effective_diff, token_usage=None,
+                               role="backend-developer")
+    assert not verdict.is_phantom
+
+
+def test_verify_normal_dispatch_non_empty_own_diff_unchanged(tmp_path):
+    """Normal dispatch with a non-empty own-worktree diff -> still passes (unchanged)."""
+    spec = _spec(pr_id=None, tmp_path=tmp_path)
+    own_diff = "diff --git a/x b/x\n+real work\n"
+    effective_diff = _resolve_fix_forward_diff(spec, own_diff)
+    assert effective_diff == own_diff
+    verdict = pg.phantom_guard(status="done", worktree_diff=effective_diff, token_usage=None,
+                               role="backend-developer")
+    assert not verdict.is_phantom
+
+
+def test_verify_genuinely_empty_case_still_phantom(git_fixture, monkeypatch):
+    """Genuinely empty case (no own-worktree diff AND no pushed-branch commit) -> still caught
+    as phantom."""
+    _push_branch_no_commit(git_fixture, "dispatch/stale-pr-branch")
+    monkeypatch.setattr(pg, "resolve_pr_head_branch", lambda pr_id, **k: "dispatch/stale-pr-branch")
+
+    spec = EnvelopeSpec(
+        dispatch_id="fixfwd-e2e-phantom", terminal_id="T1", provider="claude", model="sonnet",
+        instruction="fix forward", role="backend-developer", pr_id="1161",
+        state_dir=git_fixture / "state", data_dir=git_fixture / "data",
+    )
+    effective_diff = _resolve_fix_forward_diff(spec, "", base_ref="main", repo=git_fixture)
+    verdict = pg.phantom_guard(status="done", worktree_diff=effective_diff, token_usage=None,
+                               role="backend-developer")
+    assert verdict.is_phantom
+
+
+def test_verify_genuinely_empty_no_pr_id_still_phantom(tmp_path):
+    """No pr_id at all (not even a fix-forward candidate) + empty own diff -> still phantom."""
+    spec = _spec(pr_id=None, tmp_path=tmp_path)
+    effective_diff = _resolve_fix_forward_diff(spec, "")
+    verdict = pg.phantom_guard(status="done", worktree_diff=effective_diff, token_usage=None,
+                               role="backend-developer")
+    assert verdict.is_phantom


### PR DESCRIPTION
## Summary
A fix-forward dispatch pushes onto an EXISTING PR branch, leaving its own worktree empty — phantom_guard then false-rejected with "worktree diff EMPTY". The caller now diffs the pushed branch for fix-forward.

Track: `phantom-guard-fix-forward-false-reject` · Dispatch: `20260714-phantom-guard-fixforward`

## Changes
- `scripts/lib/dispatch_envelope.py`: new `_resolve_fix_forward_diff` — when own-worktree diff is empty AND the dispatch targets an existing PR (`spec.pr_id`), fall back to the pushed PR branch's diff (via `gh pr view`). Graceful fallback to own_diff on resolution failure.
- `scripts/lib/phantom_guard.py`: wired the fix-forward diff source.
- 326-line test file: fix-forward passes, normal dispatch unchanged, genuinely-empty still caught as phantom.

## Verification
New test suite green; core phantom rule intact.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)