### PR TITLE
feat(regression-attribution): git-bisect primitive to name the commit that broke a check (PR-1)

### DIFF
--- a/scripts/lib/regression_attribution.py
+++ b/scripts/lib/regression_attribution.py
@@ -1,0 +1,275 @@
+#!/usr/bin/env python3
+"""Regression attribution primitive — name the commit that broke a check.
+
+Given a shell command that currently fails (``bad_ref``, default ``HEAD``)
+but is known to have passed at some earlier point (``good_ref``), this finds
+the exact commit that introduced the failure via ``git bisect`` and reports
+its author, date, subject, and changed files.
+
+This is the CORE PRIMITIVE only (track: regression-attribution-canary,
+PR-1). No scheduler, no open-item wiring, no notifications — those are
+later PRs. `attribute_regression()` is pure and testable: point it at any
+git repo, get back an `AttributionResult`.
+
+Mechanism: `git bisect` (via `git bisect run`), not a reimplementation.
+
+Safety:
+  - Refuses to run against a dirty working tree (raises DirtyWorkingTreeError)
+    so uncommitted work can never be lost or silently checked out over.
+  - Always restores the original HEAD/branch in a `finally` block, even on
+    exceptions raised from inside the bisect run.
+
+BILLING SAFETY: No Anthropic SDK. No LLM calls. Pure git/subprocess.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+STATUS_ATTRIBUTED = "attributed"
+STATUS_INCONCLUSIVE = "inconclusive"
+
+_FIRST_BAD_RE = re.compile(r"\b([0-9a-f]{7,40}) is the first bad commit\b")
+_DIFFSTAT_LINE_RE = re.compile(r"^\s*(.+?)\s+\|\s+\d+")
+
+
+class RegressionAttributionError(RuntimeError):
+    """Raised when git/bisect fails in a way attribution cannot recover from."""
+
+
+class DirtyWorkingTreeError(RegressionAttributionError):
+    """Raised when the target working tree has uncommitted changes.
+
+    Attribution must checkout arbitrary refs during bisection; running
+    against a dirty tree risks losing uncommitted work, so it is refused
+    outright rather than stashed automatically.
+    """
+
+
+@dataclass
+class AttributionResult:
+    """Result of an `attribute_regression()` call."""
+
+    status: str  # "attributed" | "inconclusive"
+    check_cmd: str
+    good_ref: str
+    bad_ref: str
+    good_sha: Optional[str] = None
+    bad_sha: Optional[str] = None
+    reason: Optional[str] = None
+    commit_sha: Optional[str] = None
+    author: Optional[str] = None
+    author_email: Optional[str] = None
+    date: Optional[str] = None
+    subject: Optional[str] = None
+    changed_files: List[str] = field(default_factory=list)
+    stat_summary: Optional[str] = None
+
+    @property
+    def is_attributed(self) -> bool:
+        return self.status == STATUS_ATTRIBUTED
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "status": self.status,
+            "check_cmd": self.check_cmd,
+            "good_ref": self.good_ref,
+            "bad_ref": self.bad_ref,
+            "good_sha": self.good_sha,
+            "bad_sha": self.bad_sha,
+            "reason": self.reason,
+            "commit_sha": self.commit_sha,
+            "author": self.author,
+            "author_email": self.author_email,
+            "date": self.date,
+            "subject": self.subject,
+            "changed_files": self.changed_files,
+            "stat_summary": self.stat_summary,
+        }
+
+
+# ---------------------------------------------------------------------------
+# git plumbing helpers
+# ---------------------------------------------------------------------------
+
+def _git(root: Path, *args: str, check: bool = True) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", *args],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+    )
+    if check and result.returncode != 0:
+        raise RegressionAttributionError(
+            f"git {' '.join(args)} failed (exit {result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    return result
+
+
+def _rev_parse(root: Path, ref: str) -> str:
+    return _git(root, "rev-parse", ref).stdout.strip()
+
+
+def _current_ref(root: Path) -> str:
+    """Return the branch name if HEAD is on one, else the detached commit sha."""
+    result = _git(root, "symbolic-ref", "--short", "-q", "HEAD", check=False)
+    if result.returncode == 0 and result.stdout.strip():
+        return result.stdout.strip()
+    return _rev_parse(root, "HEAD")
+
+
+def _checkout(root: Path, ref: str) -> None:
+    _git(root, "checkout", "--quiet", ref)
+
+
+def _require_clean_worktree(root: Path) -> None:
+    result = _git(root, "status", "--porcelain")
+    if result.stdout.strip():
+        raise DirtyWorkingTreeError(
+            f"refusing to run regression attribution on a dirty working tree "
+            f"at {root} — commit or stash your changes first"
+        )
+
+
+def _run_check(root: Path, check_cmd: str) -> bool:
+    result = subprocess.run(
+        ["bash", "-c", check_cmd],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+    )
+    return result.returncode == 0
+
+
+def _run_bisect(root: Path, check_cmd: str, good_sha: str, bad_sha: str) -> str:
+    """Run `git bisect` between good_sha (passes) and bad_sha (fails).
+
+    Returns the full sha of the first commit at which check_cmd fails.
+    Assumes bisect state is clean on entry; caller is responsible for
+    `git bisect reset` in a finally block.
+    """
+    _git(root, "bisect", "start", bad_sha, good_sha)
+
+    run_result = subprocess.run(
+        ["git", "bisect", "run", "bash", "-c", check_cmd],
+        cwd=str(root),
+        capture_output=True,
+        text=True,
+    )
+    output = f"{run_result.stdout}\n{run_result.stderr}"
+    match = _FIRST_BAD_RE.search(output)
+    if not match:
+        raise RegressionAttributionError(
+            f"git bisect run did not converge to a single commit:\n{output.strip()}"
+        )
+    return _rev_parse(root, match.group(1))
+
+
+def _commit_details(root: Path, sha: str) -> Dict[str, Any]:
+    log_fmt = "%H%x1f%an%x1f%ae%x1f%aI%x1f%s"
+    log_out = _git(root, "log", "-1", f"--format={log_fmt}", sha).stdout.strip()
+    full_sha, author, author_email, date, subject = log_out.split("\x1f", 4)
+
+    stat_out = _git(root, "show", "--stat", "--format=", sha).stdout
+
+    changed_files: List[str] = []
+    for line in stat_out.splitlines():
+        stat_match = _DIFFSTAT_LINE_RE.match(line)
+        if stat_match:
+            changed_files.append(stat_match.group(1).strip())
+
+    return {
+        "commit_sha": full_sha,
+        "author": author,
+        "author_email": author_email,
+        "date": date,
+        "subject": subject,
+        "changed_files": changed_files,
+        "stat_summary": stat_out.strip(),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Public primitive
+# ---------------------------------------------------------------------------
+
+def attribute_regression(
+    check_cmd: str,
+    good_ref: str,
+    bad_ref: str = "HEAD",
+    repo_root: "str | Path | None" = None,
+) -> AttributionResult:
+    """Find the commit that made `check_cmd` start failing.
+
+    Args:
+        check_cmd: shell command run via `bash -c`; exit 0 = pass, nonzero = fail.
+        good_ref: a ref known to pass check_cmd.
+        bad_ref: a ref known to fail check_cmd (default: HEAD).
+        repo_root: git repo to operate in (default: cwd).
+
+    Returns:
+        AttributionResult with status "attributed" (commit found) or
+        "inconclusive" (bad_ref already passes, or good_ref already fails —
+        not a regression in this range; no bisect is run in either case).
+
+    Raises:
+        DirtyWorkingTreeError: working tree has uncommitted changes.
+        RegressionAttributionError: git/bisect failed unexpectedly.
+    """
+    root = Path(repo_root).resolve() if repo_root is not None else Path.cwd().resolve()
+    _require_clean_worktree(root)
+
+    good_sha = _rev_parse(root, good_ref)
+    bad_sha = _rev_parse(root, bad_ref)
+    original_ref = _current_ref(root)
+
+    try:
+        _checkout(root, bad_sha)
+        if _run_check(root, check_cmd):
+            return AttributionResult(
+                status=STATUS_INCONCLUSIVE,
+                check_cmd=check_cmd,
+                good_ref=good_ref,
+                bad_ref=bad_ref,
+                good_sha=good_sha,
+                bad_sha=bad_sha,
+                reason=(
+                    f"check_cmd passed at bad_ref ({bad_ref} = {bad_sha[:12]}); "
+                    "nothing to attribute"
+                ),
+            )
+
+        _checkout(root, good_sha)
+        if not _run_check(root, check_cmd):
+            return AttributionResult(
+                status=STATUS_INCONCLUSIVE,
+                check_cmd=check_cmd,
+                good_ref=good_ref,
+                bad_ref=bad_ref,
+                good_sha=good_sha,
+                bad_sha=bad_sha,
+                reason=(
+                    f"check_cmd also failed at good_ref ({good_ref} = {good_sha[:12]}); "
+                    "not a regression in this range"
+                ),
+            )
+
+        commit_sha = _run_bisect(root, check_cmd, good_sha, bad_sha)
+        details = _commit_details(root, commit_sha)
+        return AttributionResult(
+            status=STATUS_ATTRIBUTED,
+            check_cmd=check_cmd,
+            good_ref=good_ref,
+            bad_ref=bad_ref,
+            good_sha=good_sha,
+            bad_sha=bad_sha,
+            **details,
+        )
+    finally:
+        _git(root, "bisect", "reset", check=False)
+        _git(root, "checkout", "--quiet", original_ref, check=False)

--- a/scripts/regression_attribution.py
+++ b/scripts/regression_attribution.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""CLI for the regression attribution primitive.
+
+Given a check command that fails at `bad_ref` (default HEAD) but is known
+to have passed at `good_ref`, finds and prints the introducing commit via
+`git bisect`.
+
+Usage:
+    python3 scripts/regression_attribution.py --check "pytest tests/foo.py" --good v1.2.0
+    python3 scripts/regression_attribution.py --check "./scripts/check.sh" --good abc123 --bad HEAD
+    python3 scripts/regression_attribution.py --check "make lint" --good main~50 --json
+
+This is a thin argument-parsing wrapper only; all logic lives in
+scripts/lib/regression_attribution.py so it stays independently testable.
+
+BILLING SAFETY: No Anthropic SDK. No LLM calls.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIB_DIR = SCRIPT_DIR / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+from regression_attribution import (  # noqa: E402
+    AttributionResult,
+    RegressionAttributionError,
+    attribute_regression,
+)
+
+EXIT_ATTRIBUTED = 0
+EXIT_INCONCLUSIVE = 1
+EXIT_ERROR = 2
+
+
+def _print_human(result: AttributionResult) -> None:
+    good_label = f"{result.good_ref} ({(result.good_sha or '')[:12]})"
+    bad_label = f"{result.bad_ref} ({(result.bad_sha or '')[:12]})"
+    print(f"check:   {result.check_cmd}")
+    print(f"range:   {good_label} (good) -> {bad_label} (bad)")
+    print(f"status:  {result.status}")
+    if result.status == "attributed":
+        print(f"commit:  {result.commit_sha}")
+        print(f"author:  {result.author} <{result.author_email}>")
+        print(f"date:    {result.date}")
+        print(f"subject: {result.subject}")
+        print("files:")
+        for changed_file in result.changed_files:
+            print(f"  - {changed_file}")
+    else:
+        print(f"reason:  {result.reason}")
+
+
+def main(argv: "list[str] | None" = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--check", required=True, dest="check_cmd",
+        help="shell command to run at each candidate commit (exit 0 = pass, nonzero = fail)",
+    )
+    parser.add_argument(
+        "--good", required=True, dest="good_ref",
+        help="ref known to pass --check",
+    )
+    parser.add_argument(
+        "--bad", default="HEAD", dest="bad_ref",
+        help="ref known to fail --check (default: HEAD)",
+    )
+    parser.add_argument(
+        "--repo-root", default=None, dest="repo_root",
+        help="git repo to operate in (default: current directory)",
+    )
+    parser.add_argument("--json", action="store_true", help="emit structured JSON output")
+    args = parser.parse_args(argv)
+
+    try:
+        result = attribute_regression(
+            check_cmd=args.check_cmd,
+            good_ref=args.good_ref,
+            bad_ref=args.bad_ref,
+            repo_root=args.repo_root,
+        )
+    except RegressionAttributionError as exc:
+        if args.json:
+            print(json.dumps({"status": "error", "reason": str(exc)}))
+        else:
+            print(f"regression_attribution: {exc}", file=sys.stderr)
+        return EXIT_ERROR
+
+    if args.json:
+        print(json.dumps(result.to_dict(), indent=2))
+    else:
+        _print_human(result)
+
+    return EXIT_ATTRIBUTED if result.status == "attributed" else EXIT_INCONCLUSIVE
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_regression_attribution.py
+++ b/tests/test_regression_attribution.py
@@ -1,0 +1,212 @@
+"""Tests for the regression-attribution primitive (track: regression-attribution-canary, PR-1).
+
+Builds a tiny throwaway git fixture repo per test and exercises the real
+`git bisect` mechanism end-to-end — no mocking of git subprocess calls.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+LIB_DIR = REPO_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(LIB_DIR))
+
+from regression_attribution import (  # noqa: E402
+    AttributionResult,
+    DirtyWorkingTreeError,
+    attribute_regression,
+)
+
+
+def _git(root: Path, *args: str) -> subprocess.CompletedProcess:
+    result = subprocess.run(
+        ["git", *args], cwd=str(root), capture_output=True, text=True,
+    )
+    assert result.returncode == 0, f"git {' '.join(args)} failed: {result.stderr}"
+    return result
+
+
+def _commit(root: Path, message: str) -> str:
+    _git(root, "add", "-A")
+    _git(root, "commit", "--quiet", "-m", message)
+    return _git(root, "rev-parse", "HEAD").stdout.strip()
+
+
+def _head_sha(root: Path) -> str:
+    return subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=str(root), capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _head_branch(root: Path) -> str:
+    return subprocess.run(
+        ["git", "symbolic-ref", "--short", "HEAD"],
+        cwd=str(root), capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+
+def _bisect_in_progress(root: Path) -> bool:
+    result = subprocess.run(
+        ["git", "bisect", "log"], cwd=str(root), capture_output=True, text=True,
+    )
+    return result.returncode == 0
+
+
+@pytest.fixture()
+def fixture_repo(tmp_path):
+    """A tiny repo: good commit -> unrelated commit -> BREAKING commit -> unrelated commit (HEAD)."""
+    root = tmp_path / "fixture-repo"
+    root.mkdir()
+    _git(root, "init", "--quiet")
+    _git(root, "config", "user.name", "VNX Test")
+    _git(root, "config", "user.email", "vnx-test@example.invalid")
+    _git(root, "config", "commit.gpgsign", "false")
+
+    (root / "check.sh").write_text("#!/bin/bash\nexit 0\n")
+    (root / "README.md").write_text("v1\n")
+    commit1 = _commit(root, "commit1: initial passing check")
+
+    (root / "README.md").write_text("v2\n")
+    commit2 = _commit(root, "commit2: unrelated doc change")
+
+    (root / "check.sh").write_text("#!/bin/bash\nexit 1\n")
+    commit3 = _commit(root, "commit3: BREAKS check.sh")
+
+    (root / "README.md").write_text("v3\n")
+    commit4 = _commit(root, "commit4: unrelated change after break")
+
+    return {
+        "root": root,
+        "commit1": commit1,
+        "commit2": commit2,
+        "commit3": commit3,
+        "commit4": commit4,
+    }
+
+
+class TestAttributesExactBreakingCommit:
+    def test_names_exact_breaking_commit_and_files(self, fixture_repo):
+        root = fixture_repo["root"]
+        result = attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=fixture_repo["commit2"],
+            bad_ref="HEAD",
+            repo_root=root,
+        )
+        assert isinstance(result, AttributionResult)
+        assert result.status == "attributed"
+        assert result.commit_sha == fixture_repo["commit3"]
+        assert result.author == "VNX Test"
+        assert result.subject == "commit3: BREAKS check.sh"
+        assert result.changed_files == ["check.sh"]
+        assert result.check_cmd == "bash check.sh"
+        assert result.good_sha == fixture_repo["commit2"]
+        assert result.bad_sha == fixture_repo["commit4"]
+
+
+class TestNotARegressionGuard:
+    def test_check_fails_at_good_ref_is_inconclusive_and_skips_bisect(self, fixture_repo):
+        root = fixture_repo["root"]
+        # good_ref points at a commit where the check ALSO fails (commit3) —
+        # not a regression within (commit3, HEAD].
+        result = attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=fixture_repo["commit3"],
+            bad_ref="HEAD",
+            repo_root=root,
+        )
+        assert result.status == "inconclusive"
+        assert "also failed at good_ref" in result.reason
+        assert result.commit_sha is None
+        assert result.changed_files == []
+        assert not _bisect_in_progress(root)
+
+    def test_check_passes_at_bad_ref_is_inconclusive_and_skips_bisect(self, fixture_repo):
+        root = fixture_repo["root"]
+        # bad_ref points at commit2, where the check still passes -> nothing to attribute.
+        result = attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=fixture_repo["commit1"],
+            bad_ref=fixture_repo["commit2"],
+            repo_root=root,
+        )
+        assert result.status == "inconclusive"
+        assert "nothing to attribute" in result.reason
+        assert result.commit_sha is None
+        assert not _bisect_in_progress(root)
+
+
+class TestHeadRestoration:
+    def test_restores_original_branch_and_sha_after_attribution(self, fixture_repo):
+        root = fixture_repo["root"]
+        original_branch = _head_branch(root)
+        original_sha = _head_sha(root)
+        assert original_sha == fixture_repo["commit4"]
+
+        attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=fixture_repo["commit2"],
+            bad_ref="HEAD",
+            repo_root=root,
+        )
+
+        assert _head_branch(root) == original_branch
+        assert _head_sha(root) == original_sha
+        assert not _bisect_in_progress(root)
+
+    def test_restores_original_ref_even_on_inconclusive_path(self, fixture_repo):
+        root = fixture_repo["root"]
+        original_branch = _head_branch(root)
+        original_sha = _head_sha(root)
+
+        attribute_regression(
+            check_cmd="bash check.sh",
+            good_ref=fixture_repo["commit3"],
+            bad_ref="HEAD",
+            repo_root=root,
+        )
+
+        assert _head_branch(root) == original_branch
+        assert _head_sha(root) == original_sha
+
+
+class TestDirtyWorkingTreeRefused:
+    def test_refuses_dirty_working_tree(self, fixture_repo):
+        root = fixture_repo["root"]
+        (root / "README.md").write_text("uncommitted change\n")
+
+        with pytest.raises(DirtyWorkingTreeError):
+            attribute_regression(
+                check_cmd="bash check.sh",
+                good_ref=fixture_repo["commit2"],
+                bad_ref="HEAD",
+                repo_root=root,
+            )
+
+        # Guard must fire before any checkout — the dirty change and HEAD
+        # position are untouched.
+        status = subprocess.run(
+            ["git", "status", "--porcelain"], cwd=str(root), capture_output=True, text=True, check=True,
+        ).stdout
+        assert "README.md" in status
+        assert _head_sha(root) == fixture_repo["commit4"]
+        assert not _bisect_in_progress(root)
+
+    def test_refuses_dirty_tree_with_untracked_file(self, fixture_repo):
+        root = fixture_repo["root"]
+        (root / "untracked.txt").write_text("new file\n")
+
+        with pytest.raises(DirtyWorkingTreeError):
+            attribute_regression(
+                check_cmd="bash check.sh",
+                good_ref=fixture_repo["commit2"],
+                bad_ref="HEAD",
+                repo_root=root,
+            )
+
+        assert (root / "untracked.txt").exists()


### PR DESCRIPTION
## Summary
PR-1 of the regression-attribution canary: the core primitive. Given a check that newly fails, `git bisect` names the exact commit + author + files that introduced it. (Daily scheduler + open-item wiring are later PRs.)

Track: `regression-attribution-canary` · Dispatch: `20260714-regression-attribution-primitive`

## Changes
- New `scripts/lib/regression_attribution.py`: `attribute_regression(check_cmd, good_ref, bad_ref)` — confirms fail@bad/pass@good (else inconclusive, no bisect), runs `git bisect run`, returns introducing commit sha/author/date/subject/files. Refuses dirty tree; restores HEAD (bisect reset) in finally.
- New `scripts/regression_attribution.py` CLI (`--check --good --bad --json`).
- Tests: fixture-repo bisect names the breaking commit; not-a-regression guard; HEAD restored; dirty-tree refused.

## Verification
`pytest tests/test_regression_attribution.py` green. New files only; nothing wired into scheduler/cron yet.

## Open Items
None. PR-2: daily rotating check + open-item + notification wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)