### PR TITLE
fix(auto-seed): anchor roadmap on project-root or refuse (defuse apply=True landmine)

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1192,11 +1192,90 @@ def cmd_objective_reopen(args: argparse.Namespace) -> int:
     return 0
 
 
+class _RoadmapAnchorRefused(Exception):
+    """Raised when the auto-seed roadmap cannot be unambiguously anchored to
+    the current project. Caught by maybe_auto_seed(), which refuses to seed
+    rather than run seed(apply=True) against an unanchored ROADMAP.yaml."""
+
+
+def _looks_like_shipped_example_roadmap(data: Any) -> bool:
+    """True when parsed ROADMAP YAML content is the shipped illustrative
+    template (`launch_state.status: example`) rather than a project's own
+    authored roadmap. See ROADMAP.yaml's own header: "This shipped file is an
+    ILLUSTRATIVE EXAMPLE of the roadmap format."
+    """
+    if not isinstance(data, dict):
+        return False
+    launch_state = data.get("launch_state")
+    return isinstance(launch_state, dict) and launch_state.get("status") == "example"
+
+
+def _resolve_anchored_roadmap_path(
+    explicit: str | None,
+    env: dict,
+    project_root: str | Path | None = None,
+) -> Path:
+    """Resolve ROADMAP.yaml for the auto-seed hook, anchored on PROJECT ROOT.
+
+    Precedence: explicit path > VNX_ROADMAP_PATH env override > a default
+    anchored on the resolved project root. Callers of an explicit path/env
+    override are trusted (same contract as `_resolve_roadmap_path`) and are
+    not passed through the anchor checks below.
+
+    The default branch resolves the project root via the standard resolver
+    (`project_root.resolve_project_root`, CWD-git-root based -- deliberately
+    NOT passed `planning_cli.py`'s own `__file__`, since in a central install
+    that file lives inside the shared VNX_HOME git clone and git-resolving
+    from there would collapse the root onto the keystone code tree instead of
+    the project actually being seeded). Raises _RoadmapAnchorRefused when:
+      - the project root cannot be resolved unambiguously (not a git repo,
+        no VNX_CANONICAL_ROOT fallback);
+      - the resulting roadmap path would fall outside the resolved project
+        root; or
+      - the roadmap content matches the shipped illustrative template.
+    """
+    if explicit:
+        return Path(explicit)
+
+    env_override = env.get("VNX_ROADMAP_PATH", "")
+    if env_override:
+        return Path(env_override)
+
+    if project_root is not None:
+        root = Path(project_root).resolve()
+    else:
+        from project_root import resolve_project_root
+        try:
+            root = resolve_project_root()
+        except RuntimeError as exc:
+            raise _RoadmapAnchorRefused(f"cannot resolve project root: {exc}") from exc
+
+    candidate = (root / "ROADMAP.yaml").resolve()
+    if not candidate.is_relative_to(root):
+        raise _RoadmapAnchorRefused(
+            f"resolved roadmap path escapes project root {root}: {candidate}"
+        )
+
+    if candidate.exists():
+        import yaml
+        try:
+            data = yaml.safe_load(candidate.read_text(encoding="utf-8")) or {}
+        except (OSError, yaml.YAMLError):
+            data = {}
+        if _looks_like_shipped_example_roadmap(data):
+            raise _RoadmapAnchorRefused(
+                f"resolved roadmap is the shipped illustrative example template: {candidate}"
+            )
+
+    return candidate
+
+
 def maybe_auto_seed(
     state_dir: str | Path | None = None,
     roadmap_path: str | Path | None = None,
     project_id: Optional[str] = None,
     env: Optional[dict] = None,
+    project_root: str | Path | None = None,
 ) -> dict[str, Any]:
     """Flag-gated prelude hook: idempotent `objective sync --apply` when opted in.
 
@@ -1204,15 +1283,28 @@ def maybe_auto_seed(
     (VNX_AUTO_SEED_TRACKS unset/!=1) is a no-op. When set, projects ROADMAP onto
     tracks idempotently. NEVER writes ROADMAP.yaml; NEVER promotes deliverables.
 
-    Returns a result dict: {"skipped": True, ...} when disabled, else
-    {"skipped": False, "summary": {...}}.
+    The roadmap is resolved anchored on the project root (see
+    `_resolve_anchored_roadmap_path`); when that anchor is ambiguous or would
+    resolve to the shipped example template, the hook REFUSES to seed instead
+    of running `seed(apply=True)` against the wrong roadmap.
+
+    Returns a result dict: {"skipped": True, ...} when disabled or refused,
+    else {"skipped": False, "summary": {...}}.
     """
     env = env if env is not None else os.environ
     if env.get("VNX_AUTO_SEED_TRACKS", "") != "1":
         return {"skipped": True, "reason": "VNX_AUTO_SEED_TRACKS not set"}
 
     s_dir = _resolve_state_dir(str(state_dir) if state_dir else env.get("VNX_STATE_DIR", ""))
-    r_path = _resolve_roadmap_path(str(roadmap_path) if roadmap_path else None)
+    try:
+        r_path = _resolve_anchored_roadmap_path(
+            str(roadmap_path) if roadmap_path else None, env, project_root=project_root,
+        )
+    except _RoadmapAnchorRefused as exc:
+        reason = f"refusing to seed: {exc}"
+        logger.warning("maybe_auto_seed: %s", reason)
+        return {"skipped": True, "reason": reason}
+
     pid = project_id or env.get("VNX_PROJECT_ID", "vnx-dev")
 
     if not Path(r_path).exists():

--- a/tests/test_planning_turnon.py
+++ b/tests/test_planning_turnon.py
@@ -219,6 +219,152 @@ def test_auto_seed_enabled_calls_seeder_with_apply_true(empty_state, monkeypatch
 
 
 # ---------------------------------------------------------------------------
+# Part 2b — auto-seed roadmap anchoring (the apply=True landmine)
+# ---------------------------------------------------------------------------
+
+def _seed_spy(monkeypatch, calls):
+    def _spy(s_dir, r_path, project_id, *, apply=False):
+        calls.append({"apply": apply, "project_id": project_id, "r_path": str(r_path)})
+        return {"summary": {"created": 0, "updated": 0, "unchanged": 0,
+                            "phase_drift": 0, "orphan": 0}}
+    monkeypatch.setattr(planning_cli.seeder, "seed", _spy)
+
+
+def test_auto_seed_reaches_apply_when_anchored_on_explicit_project_root(tmp_path):
+    """Correctly-anchored: an explicit project_root pointing at a real,
+    project-authored ROADMAP.yaml still reaches the seed/apply path."""
+    project_root = tmp_path / "my-project"
+    project_root.mkdir()
+    (project_root / "ROADMAP.yaml").write_text(SAMPLE_ROADMAP, encoding="utf-8")
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+
+    result = planning_cli.maybe_auto_seed(
+        state_dir=state_dir, project_id="vnx-dev",
+        env={"VNX_AUTO_SEED_TRACKS": "1"}, project_root=project_root,
+    )
+    assert result["skipped"] is False
+    assert result["summary"]["created"] == 3
+    seeded = {t["track_id"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    assert seeded == {"feat-a", "feat-b", "feat-c"}
+
+
+def test_auto_seed_refuses_when_project_root_unresolvable(tmp_path, monkeypatch, caplog):
+    """Unanchored: no explicit roadmap/project_root, CWD is not a git repo, and
+    no VNX_CANONICAL_ROOT fallback -- the hook must refuse rather than guess,
+    and must never call seed(apply=True)."""
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+    cwd = tmp_path / "not-a-repo"
+    cwd.mkdir()
+    monkeypatch.chdir(cwd)
+    monkeypatch.delenv("VNX_CANONICAL_ROOT", raising=False)
+
+    calls: list[dict] = []
+    _seed_spy(monkeypatch, calls)
+
+    with caplog.at_level("WARNING"):
+        result = planning_cli.maybe_auto_seed(
+            state_dir=state_dir, project_id="vnx-dev",
+            env={"VNX_AUTO_SEED_TRACKS": "1"},
+        )
+
+    assert result["skipped"] is True
+    assert "cannot resolve project root" in result["reason"]
+    assert calls == []  # seed(apply=True) never invoked
+    assert any("refusing to seed" in rec.message for rec in caplog.records)
+
+
+def test_auto_seed_refuses_on_shipped_example_template(tmp_path, monkeypatch, caplog):
+    """Unanchored: the resolved ROADMAP.yaml is the shipped illustrative
+    example template (launch_state.status: example) -- refuse instead of
+    projecting example-feature onto the tracks DB."""
+    project_root = tmp_path / "central-keystone"
+    project_root.mkdir()
+    (project_root / "ROADMAP.yaml").write_text(
+        "roadmap_id: vnx-roadmap\n"
+        "title: VNX Roadmap (example)\n"
+        "launch_state:\n"
+        "  status: example\n"
+        "features:\n"
+        "  - feature_id: example-feature\n"
+        "    title: Example feature\n"
+        "    status: planned\n",
+        encoding="utf-8",
+    )
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+
+    calls: list[dict] = []
+    _seed_spy(monkeypatch, calls)
+
+    with caplog.at_level("WARNING"):
+        result = planning_cli.maybe_auto_seed(
+            state_dir=state_dir, project_id="vnx-dev",
+            env={"VNX_AUTO_SEED_TRACKS": "1"}, project_root=project_root,
+        )
+
+    assert result["skipped"] is True
+    assert "shipped illustrative example template" in result["reason"]
+    assert calls == []
+    assert any("refusing to seed" in rec.message for rec in caplog.records)
+
+
+def test_auto_seed_refuses_when_roadmap_symlink_escapes_project_root(tmp_path, monkeypatch, caplog):
+    """Unanchored: ROADMAP.yaml inside the resolved project root is a symlink
+    that escapes to a file outside the project -- refuse rather than seed off
+    a roadmap that isn't really the project's own."""
+    outside = tmp_path / "outside" / "ROADMAP.yaml"
+    outside.parent.mkdir()
+    outside.write_text(SAMPLE_ROADMAP, encoding="utf-8")
+
+    project_root = tmp_path / "my-project"
+    project_root.mkdir()
+    (project_root / "ROADMAP.yaml").symlink_to(outside)
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+
+    calls: list[dict] = []
+    _seed_spy(monkeypatch, calls)
+
+    with caplog.at_level("WARNING"):
+        result = planning_cli.maybe_auto_seed(
+            state_dir=state_dir, project_id="vnx-dev",
+            env={"VNX_AUTO_SEED_TRACKS": "1"}, project_root=project_root,
+        )
+
+    assert result["skipped"] is True
+    assert "escapes project root" in result["reason"]
+    assert calls == []
+    assert any("refusing to seed" in rec.message for rec in caplog.records)
+
+
+def test_auto_seed_anchors_via_cwd_git_root_when_no_explicit_project_root(tmp_path, monkeypatch):
+    """Correctly-anchored default path: no explicit roadmap_path/project_root
+    is given, so the hook resolves the project root from CWD's git top-level
+    (the standard project_root.resolve_project_root() resolver) and reaches
+    the seed/apply path against that project's own ROADMAP.yaml."""
+    import subprocess
+
+    project_root = tmp_path / "git-project"
+    project_root.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=project_root, check=True)
+    (project_root / "ROADMAP.yaml").write_text(SAMPLE_ROADMAP, encoding="utf-8")
+    state_dir = tmp_path / "state"
+    _init_schema(state_dir)
+    monkeypatch.chdir(project_root)
+
+    result = planning_cli.maybe_auto_seed(
+        state_dir=state_dir, project_id="vnx-dev",
+        env={"VNX_AUTO_SEED_TRACKS": "1"},
+    )
+    assert result["skipped"] is False
+    assert result["summary"]["created"] == 3
+    seeded = {t["track_id"] for t in tracks_lib.list_tracks(state_dir, "vnx-dev")}
+    assert seeded == {"feat-a", "feat-b", "feat-c"}
+
+
+# ---------------------------------------------------------------------------
 # Part 3 — advisory drift-gate
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
The `VNX_AUTO_SEED_TRACKS` prelude-hook resolved the roadmap without a project anchor and ran `seed(apply=True)` — enabling the flag without threading the roadmap could project the wrong/edge-template roadmap onto the tracks-DB. Now it anchors on project-root or refuses.

Track: `auto-seed-prelude-roadmap-anchor` · Dispatch: `20260714-autoseed-roadmap-anchor`

## Changes
- `scripts/planning_cli.py`: `maybe_auto_seed()` anchors roadmap resolution on the resolved project root (`project_root.resolve_project_root`); on ambiguous/unanchored resolution it REFUSES (logs reason) instead of `seed(apply=True)`. Default-off and behavior-preserving when correctly anchored.
- Tests: anchored → seeds; ambiguous/unanchored → refuses, no apply.

## Verification
`pytest tests/test_planning_turnon.py` green.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)