### PR TITLE
feat(t0-state): surface proposed deliverables as a human-gate queue at kickoff

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -538,6 +538,67 @@ def _build_tracks_from_db(state_dir: Path, project_id: str) -> Dict[str, Any]:
 
 
 # ---------------------------------------------------------------------------
+# Human gate queue — proposed deliverables awaiting operator promote (ADR-007)
+# ---------------------------------------------------------------------------
+#
+# `vnx deliverable add` writes a `dispatches` row with state='proposed'; it
+# stays un-promoted and NOT dispatchable until `vnx deliverable promote` moves
+# it to 'ready' (see planning_cli.py cmd_deliverable_add/cmd_deliverable_promote).
+# Today that row is invisible until an operator thinks to run
+# `vnx deliverable list`. This reader surfaces it at kickoff instead. Only
+# columns present since the v1 base schema are selected (dispatch_id, track,
+# metadata_json, created_at, project_id) so the query never trips on
+# later-migration-only columns (e.g. output_kind/output_ref) on a store that
+# hasn't run the out-of-band migration yet.
+
+_HUMAN_GATE_QUEUE_SQL = (
+    "SELECT dispatch_id, track, metadata_json, created_at "
+    "FROM dispatches WHERE project_id = ? AND state = 'proposed' "
+    "ORDER BY created_at ASC"
+)
+
+
+def _build_human_gate_queue(state_dir: Path, project_id: str) -> List[Dict[str, Any]]:
+    """Proposed deliverables/dispatches waiting on an operator promote decision.
+
+    Read-only and additive: never mutates state, never promotes. Degrades to
+    an empty list (never raises) on unavailable identity, a missing/premigration
+    DB, or a locked/malformed DB — this is advisory surfacing, not a gate, so a
+    degraded read must not block SessionStart.
+    """
+    pid = (project_id or "").strip()
+    if not pid:
+        return []
+
+    db_path = state_dir / "runtime_coordination.db"
+    if not db_path.exists():
+        return []
+
+    try:
+        rows = _query_canonical_scoped(db_path, _HUMAN_GATE_QUEUE_SQL, pid)
+    except (sqlite3.OperationalError, sqlite3.DatabaseError) as exc:
+        log.debug(
+            "human_gate_queue query failed (%s): %s", _classify_db_error(exc), exc
+        )
+        return []
+
+    queue: List[Dict[str, Any]] = []
+    for row in rows:
+        try:
+            meta = json.loads(row.get("metadata_json") or "{}")
+        except (TypeError, ValueError):
+            meta = {}
+        title = meta.get("title") if isinstance(meta, dict) else None
+        queue.append({
+            "id": row.get("dispatch_id"),
+            "title": title,
+            "track": row.get("track"),
+            "created_at": row.get("created_at"),
+        })
+    return queue
+
+
+# ---------------------------------------------------------------------------
 # Feature state — register-canonical aggregation with FEATURE_PLAN.md fallback
 # ---------------------------------------------------------------------------
 
@@ -1828,6 +1889,7 @@ def build_t0_state(
     queues = _build_queues(dispatch_dir, state_dir)
     tracks = _build_tracks(state_dir)
     canonical_tracks = _build_tracks_from_db(tracks_store, project_id)  # R3.2/ADR-007: tenant-scoped (central SSOT)
+    human_gate_queue = _build_human_gate_queue(tracks_store, project_id)  # proposed deliverables awaiting operator promote
     pr_progress = _build_pr_progress(dispatch_dir, state_dir)
     feature_state = _build_feature_state(state_dir=state_dir)
     open_items = _collect_open_items(project_id, state_dir)
@@ -1856,6 +1918,7 @@ def build_t0_state(
         "tracks": tracks,
         "track_freshness": track_freshness,
         "canonical_tracks": canonical_tracks,
+        "human_gate_queue": human_gate_queue,
         "pr_progress": pr_progress,
         "feature_state": feature_state,
         "open_items": open_items,

--- a/tests/test_human_gate_queue.py
+++ b/tests/test_human_gate_queue.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for the human_gate_queue surfacing in build_t0_state.py.
+
+Track `kickoff-human-gate-queue`: deliverables/proposals in state=proposed are
+un-promoted and NOT dispatchable until an operator runs `vnx deliverable
+promote`. They were invisible at kickoff. `_build_human_gate_queue` and the
+`human_gate_queue` key in `build_t0_state()`'s output surface them so the
+operator sees the human-gate queue on startup.
+
+Read-only, additive: this only surfaces the queue and must never touch the
+deliverable/promote flow itself.
+
+Discipline: temp-DB ONLY. Every test pins VNX_DATA_DIR_EXPLICIT=1 + a tmp
+VNX_DATA_DIR, and blocks the central-store fallback so the builder resolves
+the tmp store rather than a live ~/.vnx-data/<project>/state.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_SCRIPTS_DIR = _REPO_ROOT / "scripts"
+_LIB_DIR = _SCRIPTS_DIR / "lib"
+
+for _p in (str(_SCRIPTS_DIR), str(_LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import build_t0_state as bts  # noqa: E402
+
+_PROJECT_ID = "vnx-dev"
+
+
+# ---------------------------------------------------------------------------
+# Isolation + fixtures
+# ---------------------------------------------------------------------------
+
+def _pin_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Pin VNX_DATA_DIR_EXPLICIT=1 + a tmp VNX_DATA_DIR; return the state dir."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    # Block the central-store fallback so the builder resolves the tmp store,
+    # not the live ~/.vnx-data/<project>/state.
+    monkeypatch.setattr(bts, "resolve_central_data_dir", None, raising=False)
+    return state_dir
+
+
+def _make_dispatches_db(state_dir: Path) -> Path:
+    """Minimal runtime_coordination.db with just the dispatches table."""
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2',
+            pr_ref TEXT, gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0,
+            bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _insert_dispatch(
+    db_path: Path,
+    *,
+    dispatch_id: str,
+    project_id: str,
+    state: str,
+    track: str | None = None,
+    title: str | None = None,
+    created_at: str = "2026-07-14T09:00:00.000000Z",
+) -> None:
+    metadata = json.dumps({"title": title, "deliverable": True}) if title else "{}"
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO dispatches "
+            "(dispatch_id, project_id, state, track, metadata_json, created_at, updated_at) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?)",
+            (dispatch_id, project_id, state, track, metadata, created_at, created_at),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Direct reader: _build_human_gate_queue
+# ---------------------------------------------------------------------------
+
+def test_reader_lists_proposed_deliverable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path,
+        dispatch_id="dlv-bead16844a0a",
+        project_id=_PROJECT_ID,
+        state="proposed",
+        track="kickoff-human-gate-queue",
+        title="Ship the human gate queue",
+    )
+
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+
+    assert len(queue) == 1
+    item = queue[0]
+    assert item["id"] == "dlv-bead16844a0a"
+    assert item["title"] == "Ship the human gate queue"
+    assert item["track"] == "kickoff-human-gate-queue"
+    assert item["created_at"] == "2026-07-14T09:00:00.000000Z"
+
+
+def test_reader_excludes_non_proposed_states(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path, dispatch_id="dlv-ready-1", project_id=_PROJECT_ID,
+        state="ready", track="t", title="Already promoted",
+    )
+    _insert_dispatch(
+        db_path, dispatch_id="d-queued-1", project_id=_PROJECT_ID,
+        state="queued", track="t", title=None,
+    )
+
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+    assert queue == []
+
+
+def test_reader_scopes_to_project_id(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path, dispatch_id="dlv-a", project_id="tenant-a",
+        state="proposed", track="t", title="Tenant A deliverable",
+    )
+    _insert_dispatch(
+        db_path, dispatch_id="dlv-b", project_id="tenant-b",
+        state="proposed", track="t", title="Tenant B deliverable",
+    )
+
+    queue_a = bts._build_human_gate_queue(state_dir, "tenant-a")
+    assert {item["id"] for item in queue_a} == {"dlv-a"}
+
+    queue_b = bts._build_human_gate_queue(state_dir, "tenant-b")
+    assert {item["id"] for item in queue_b} == {"dlv-b"}
+
+
+def test_reader_no_proposed_items_is_empty_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    _make_dispatches_db(state_dir)  # empty table, no rows at all
+
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+    assert queue == []
+
+
+def test_reader_absent_db_is_empty_list_no_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    # No runtime_coordination.db created at all.
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+    assert queue == []
+
+
+def test_reader_premigration_db_is_empty_list_no_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A DB without the dispatches table degrades to [], not an exception."""
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = state_dir / "runtime_coordination.db"
+    sqlite3.connect(str(db_path)).close()  # empty DB, no dispatches table
+
+    queue = bts._build_human_gate_queue(state_dir, _PROJECT_ID)
+    assert queue == []
+
+
+@pytest.mark.parametrize("bad_pid", ["", "   ", None])
+def test_reader_unavailable_identity_is_empty_list(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, bad_pid
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path, dispatch_id="dlv-x", project_id=_PROJECT_ID,
+        state="proposed", track="t", title="x",
+    )
+
+    queue = bts._build_human_gate_queue(state_dir, bad_pid)
+    assert queue == []
+
+
+# ---------------------------------------------------------------------------
+# Through build_t0_state: wiring + additive key
+# ---------------------------------------------------------------------------
+
+def test_build_t0_state_surfaces_proposed_deliverable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    db_path = _make_dispatches_db(state_dir)
+    _insert_dispatch(
+        db_path,
+        dispatch_id="dlv-bead16844a0a",
+        project_id=_PROJECT_ID,
+        state="proposed",
+        track="kickoff-human-gate-queue",
+        title="Ship the human gate queue",
+    )
+    # Marker resolves project identity to _PROJECT_ID (ancestor of state_dir).
+    (tmp_path / ".vnx-project-id").write_text(_PROJECT_ID + "\n", encoding="utf-8")
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+
+    state = bts.build_t0_state(state_dir, dispatch_dir)
+
+    assert "human_gate_queue" in state
+    ids = {item["id"] for item in state["human_gate_queue"]}
+    assert "dlv-bead16844a0a" in ids
+    item = next(i for i in state["human_gate_queue"] if i["id"] == "dlv-bead16844a0a")
+    assert item["title"] == "Ship the human gate queue"
+    assert item["track"] == "kickoff-human-gate-queue"
+
+
+def test_build_t0_state_empty_human_gate_queue_no_error(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    _make_dispatches_db(state_dir)  # no proposed rows
+    (tmp_path / ".vnx-project-id").write_text(_PROJECT_ID + "\n", encoding="utf-8")
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+
+    state = bts.build_t0_state(state_dir, dispatch_dir)
+
+    assert state["human_gate_queue"] == []
+
+
+def test_build_t0_state_preserves_existing_keys(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Additive-only: human_gate_queue must not disturb canonical_tracks/etc."""
+    state_dir = _pin_isolation(tmp_path, monkeypatch)
+    _make_dispatches_db(state_dir)
+    (tmp_path / ".vnx-project-id").write_text(_PROJECT_ID + "\n", encoding="utf-8")
+    dispatch_dir = tmp_path / "dispatches"
+    dispatch_dir.mkdir()
+
+    state = bts.build_t0_state(state_dir, dispatch_dir)
+
+    assert "canonical_tracks" in state
+    assert "tracks" in state
+    assert "human_gate_queue" in state


### PR DESCRIPTION
## Summary
Proposed deliverables (state=proposed) are un-promoted and invisible at kickoff — one sat unseen. `build_t0_state` now surfaces them as a `human_gate_queue` so the operator sees what's waiting on a promote decision.

Track: `kickoff-human-gate-queue` · Dispatch: `20260714-kickoff-human-gate-queue`

## Changes
- `scripts/build_t0_state.py`: new `human_gate_queue` section listing proposed deliverables (id, title, track, created_at) from the central per-project store. Read-only, additive key; empty list when none.
- 285-line test.

## Verification
`pytest tests/test_human_gate_queue.py` green. Additive; existing state keys unchanged.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)