### PR TITLE
feat(objective): per-track lane_hint (governed/direct) for cold-start routing

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -54,6 +54,17 @@ import objective_reconcile  # noqa: E402
 _HORIZON_ORDER = ["now", "next", "later"]
 _HORIZON_LABEL = {"now": "NOW", "next": "NEXT", "later": "LATER", None: "UNSCHEDULED"}
 
+# lane_hint: a descriptive dispatch-routing hint carried on the track record
+# (e.g. "this track is meant to be dispatched governed vs direct") so a
+# cold-start T0 does not have to rediscover that judgment from a prior
+# session. Stored inside tracks.metadata_json rather than a dedicated column —
+# metadata_json is the existing extensibility slot for per-track attributes
+# that have not (yet) earned a first-class column (see
+# seed_tracks_from_roadmap.py's metadata.pr_queue). Descriptive only: it never
+# changes dispatch routing — the door still decides the lane.
+_VALID_LANE_HINTS = frozenset({"governed", "direct", "unset"})
+_LANE_HINT_DEFAULT = "unset"
+
 
 def _resolve_state_dir(explicit: str) -> Path:
     if explicit:
@@ -134,6 +145,68 @@ def _dependencies_for(state_dir: Path, track_id: str, project_id: str) -> list[s
 def _horizon_key(track: dict[str, Any]) -> Optional[str]:
     h = track.get("horizon")
     return h if h in _HORIZON_ORDER else None
+
+
+def _lane_hint_of(track: dict[str, Any]) -> str:
+    """Read the lane_hint carried in tracks.metadata_json.
+
+    Old records (no metadata_json, malformed JSON, or a JSON object missing
+    the key) all resolve to the default 'unset' — no migration, no error.
+    """
+    try:
+        meta = json.loads(track.get("metadata_json") or "{}")
+    except (TypeError, ValueError):
+        meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
+    value = meta.get("lane_hint")
+    return value if value in _VALID_LANE_HINTS else _LANE_HINT_DEFAULT
+
+
+def _metadata_json_with_lane_hint(existing_metadata_json: Optional[str], lane_hint: str) -> str:
+    """Return metadata_json with lane_hint set, preserving any other keys."""
+    try:
+        meta = json.loads(existing_metadata_json or "{}")
+    except (TypeError, ValueError):
+        meta = {}
+    if not isinstance(meta, dict):
+        meta = {}
+    meta["lane_hint"] = lane_hint
+    return json.dumps(meta, sort_keys=True)
+
+
+def _snapshot_lane_hints(state_dir: Path, project_id: str) -> dict[str, str]:
+    """{track_id: lane_hint} for every track with a non-default lane_hint set."""
+    return {
+        t["track_id"]: hint
+        for t in tracks_lib.list_tracks(state_dir, project_id)
+        if (hint := _lane_hint_of(t)) != _LANE_HINT_DEFAULT
+    }
+
+
+def _restore_lane_hints(state_dir: Path, project_id: str, snapshot: dict[str, str]) -> None:
+    """Re-apply lane_hint after `seeder.seed(apply=True)` runs.
+
+    The ROADMAP seeder (seed_tracks_from_roadmap.py) owns milestone/roadmap_status/
+    risk_class/pr_queue inside metadata_json and rebuilds that blob wholesale on
+    every authored-field change; it has no notion of lane_hint (a planning_cli-owned
+    extension of the same column), so syncing a track that also has other authored
+    drift would otherwise silently drop lane_hint back to 'unset'. Restoring it here
+    — the CLI layer that orchestrates the seeder call — keeps the seeder itself
+    unaware of lane_hint, at the cost of the sync report occasionally listing a
+    track as "updated" for a metadata-only round-trip even when no ROADMAP-authored
+    field actually changed.
+    """
+    for track_id, hint in snapshot.items():
+        track = tracks_lib.get_track(state_dir, track_id, project_id)
+        if track is None:
+            continue
+        if _lane_hint_of(track) == hint:
+            continue
+        new_metadata_json = _metadata_json_with_lane_hint(track.get("metadata_json"), hint)
+        tracks_lib.update_authored_fields(
+            state_dir, track_id, project_id, metadata_json=new_metadata_json,
+        )
 
 
 def cmd_objective_list(args: argparse.Namespace) -> int:
@@ -225,6 +298,7 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
         out = dict(track)
         out["depends_on"] = deps
         out["open_items"] = open_items
+        out["lane_hint"] = _lane_hint_of(track)
         print(json.dumps(out, indent=2, default=str))
         return 0
 
@@ -233,6 +307,7 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     print(f"  phase    : {track['phase']}")
     print(f"  horizon  : {track.get('horizon') or '(unscheduled)'}")
     print(f"  priority : {track.get('priority') or '-'}")
+    print(f"  lane_hint: {_lane_hint_of(track)}")
     print(f"  next_up  : {bool(track.get('next_up'))}")
     print(f"  pr_ref   : {track.get('pr_ref') or '-'}")
     print(f"  goal     : {track.get('goal_state') or '-'}")
@@ -263,7 +338,13 @@ def cmd_objective_sync(args: argparse.Namespace) -> int:
         return 1
 
     # Pure reuse: the seeder owns all projection logic. Dry-run writes nothing.
+    # Snapshot/restore lane_hint around the call: the seeder rebuilds
+    # metadata_json wholesale and has no notion of lane_hint (see
+    # _restore_lane_hints for why this lives here rather than in the seeder).
+    lane_hints_before = _snapshot_lane_hints(state_dir, project_id) if args.apply else {}
     report = seeder.seed(state_dir, roadmap_path, project_id, apply=args.apply)
+    if args.apply and lane_hints_before:
+        _restore_lane_hints(state_dir, project_id, lane_hints_before)
 
     if args.json:
         print(json.dumps(report, indent=2, default=str))
@@ -1472,6 +1553,8 @@ def cmd_objective_add(args: argparse.Namespace) -> int:
     promotes (see cmd_deliverable_promote).
     """
     state_dir = _resolve_state_dir(args.state_dir)
+    lane_hint = getattr(args, "lane_hint", None)
+    metadata_json = json.dumps({"lane_hint": lane_hint}) if lane_hint else None
     try:
         track = tracks_lib.create_track(
             state_dir,
@@ -1482,6 +1565,7 @@ def cmd_objective_add(args: argparse.Namespace) -> int:
             phase="queued",
             horizon=args.horizon,
             priority=args.priority,
+            metadata_json=metadata_json,
         )
     except Exception as exc:  # duplicate id, invalid horizon/priority, etc.
         print(f"objective add failed: {exc}", file=sys.stderr)
@@ -1500,6 +1584,42 @@ def cmd_objective_add(args: argparse.Namespace) -> int:
 
     gate_note = " — plan-gated (blocked until the plan panel passes)" if plan_gated else ""
     print(f"Added objective {tid} (phase=queued, horizon={args.horizon or 'unset'}){gate_note}")
+    return 0
+
+
+def cmd_objective_set_lane_hint(args: argparse.Namespace) -> int:
+    """Set the lane_hint (governed|direct|unset) on an existing track.
+
+    Descriptive only: this never changes dispatch routing — the door still
+    decides the lane. It exists so a cold-start T0 can read how a track is
+    MEANT to be dispatched without relying on judgment carried over from a
+    prior session. Writes via tracks_lib.update_authored_fields, the existing
+    single-writer path for track-authored fields.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"objective set-lane-hint: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    new_metadata_json = _metadata_json_with_lane_hint(track.get("metadata_json"), args.lane_hint)
+    try:
+        tracks_lib.update_authored_fields(
+            state_dir, track_id, project_id,
+            metadata_json=new_metadata_json,
+        )
+    except Exception as exc:
+        print(f"objective set-lane-hint failed: {exc}", file=sys.stderr)
+        return 1
+
+    print(f"Set lane_hint={args.lane_hint} on {track_id}")
     return 0
 
 
@@ -2143,7 +2263,20 @@ def _build_parser() -> argparse.ArgumentParser:
     p_add.add_argument("goal_state", help="what 'done' looks like for this track")
     p_add.add_argument("--horizon", choices=_HORIZON_ORDER, default=None)
     p_add.add_argument("--priority", default=None)
+    p_add.add_argument(
+        "--lane-hint", choices=sorted(_VALID_LANE_HINTS), default=None, dest="lane_hint",
+        help="descriptive dispatch-routing hint (governed|direct|unset); default unset",
+    )
     p_add.set_defaults(func=cmd_objective_add)
+
+    p_lane_hint = obj_sub.add_parser(
+        "set-lane-hint",
+        help="set the descriptive dispatch lane_hint (governed|direct|unset) on a track",
+    )
+    _common(p_lane_hint)
+    p_lane_hint.add_argument("track_id")
+    p_lane_hint.add_argument("lane_hint", choices=sorted(_VALID_LANE_HINTS))
+    p_lane_hint.set_defaults(func=cmd_objective_set_lane_hint)
 
     p_rec_review = obj_sub.add_parser(
         "reconcile-review",

--- a/tests/test_planning_cli_lane_hint.py
+++ b/tests/test_planning_cli_lane_hint.py
@@ -1,0 +1,349 @@
+"""tests/test_planning_cli_lane_hint.py — per-track `lane_hint` (governed|direct|unset).
+
+A track carries a descriptive lane_hint so a cold-start T0 knows how a track is
+MEANT to be dispatched without relying on judgment carried over from a prior
+session. Stored in tracks.metadata_json (the existing extensibility slot for
+per-track attributes — see seed_tracks_from_roadmap.py's metadata.pr_queue),
+not a dedicated column, so no migration is required and pre-existing tracks
+read back as 'unset' with no error.
+
+Verifies:
+- default 'unset' for a track created with no lane_hint
+- `objective add --lane-hint <value>` sets it at creation time
+- `objective set-lane-hint <id> <value>` sets/updates it on an existing track
+- it round-trips through `objective show` (text + --json)
+- a pre-existing track with no lane_hint key (or malformed metadata_json)
+  reads as 'unset' — no error, no migration break
+- an invalid value is rejected by argparse (small controlled set)
+- `objective sync --apply` (the ROADMAP seeder) does not silently wipe a
+  manually-set lane_hint, even when the seeder legitimately rewrites the rest
+  of metadata_json for an authored-field change
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+for p in (_LIB, _SCRIPTS):
+    if str(p) not in sys.path:
+        sys.path.insert(0, str(p))
+
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+import seed_tracks_from_roadmap as seeder  # noqa: E402
+import planning_cli  # noqa: E402
+
+
+def _bootstrap(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+        "state TEXT NOT NULL DEFAULT 'queued', terminal_id TEXT, track TEXT, "
+        "priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT, "
+        "attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "expires_after TEXT, metadata_json TEXT DEFAULT '{}', "
+        "UNIQUE(dispatch_id, project_id))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS coordination_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT, from_state TEXT, "
+        "to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT)"
+    )
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _add_args(state_dir: Path, **over) -> argparse.Namespace:
+    base = dict(
+        track_id="feat-lane-001", title="Lane hint track", goal_state="shipped",
+        horizon="now", priority=None, lane_hint=None,
+        project_id="vnx-dev", state_dir=str(state_dir), json=False,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def _show_json(state_dir: Path, track_id: str, project_id: str = "vnx-dev") -> dict:
+    import io
+    import contextlib
+
+    buf = io.StringIO()
+    with contextlib.redirect_stdout(buf):
+        rc = planning_cli.main([
+            "objective", "show", track_id,
+            "--project-id", project_id, "--state-dir", str(state_dir), "--json",
+        ])
+    assert rc == 0
+    return json.loads(buf.getvalue())
+
+
+# --- default / round-trip ---
+
+def test_new_track_defaults_to_unset(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    rc = planning_cli.cmd_objective_add(_add_args(state_dir))
+    assert rc == 0
+    data = _show_json(state_dir, "feat-lane-001")
+    assert data["lane_hint"] == "unset"
+
+
+def test_objective_add_sets_lane_hint(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    rc = planning_cli.cmd_objective_add(_add_args(state_dir, lane_hint="governed"))
+    assert rc == 0
+    data = _show_json(state_dir, "feat-lane-001")
+    assert data["lane_hint"] == "governed"
+    # round-trips through the store, not just the in-memory return value
+    track = tracks_lib.get_track(state_dir, "feat-lane-001", "vnx-dev")
+    assert json.loads(track["metadata_json"])["lane_hint"] == "governed"
+
+
+def test_set_lane_hint_command_round_trips(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    assert planning_cli.cmd_objective_add(_add_args(state_dir)) == 0
+
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-lane-001", "direct",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    assert "lane_hint=direct" in capsys.readouterr().out
+
+    data = _show_json(state_dir, "feat-lane-001")
+    assert data["lane_hint"] == "direct"
+
+
+def test_set_lane_hint_can_change_value(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    assert planning_cli.cmd_objective_add(_add_args(state_dir, lane_hint="governed")) == 0
+
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-lane-001", "direct",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    assert _show_json(state_dir, "feat-lane-001")["lane_hint"] == "direct"
+
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-lane-001", "unset",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    assert _show_json(state_dir, "feat-lane-001")["lane_hint"] == "unset"
+
+
+def test_set_lane_hint_preserves_other_metadata(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(
+        state_dir, "feat-lane-meta", "vnx-dev", "Meta track", "shipped",
+        metadata_json=json.dumps({"pr_queue": ["#42"]}),
+    )
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-lane-meta", "governed",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    track = tracks_lib.get_track(state_dir, "feat-lane-meta", "vnx-dev")
+    meta = json.loads(track["metadata_json"])
+    assert meta["lane_hint"] == "governed"
+    assert meta["pr_queue"] == ["#42"]
+
+
+def test_set_lane_hint_missing_track_fails_cleanly(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "does-not-exist", "governed",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 2
+    assert "track not found" in capsys.readouterr().err
+
+
+def test_invalid_lane_hint_value_rejected(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    assert planning_cli.cmd_objective_add(_add_args(state_dir)) == 0
+    with pytest.raises(SystemExit):
+        planning_cli.main([
+            "objective", "set-lane-hint", "feat-lane-001", "bogus",
+            "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+        ])
+
+
+# --- backward compatibility: pre-existing records with no lane_hint ---
+
+def test_track_without_metadata_key_reads_unset(tmp_path):
+    """A track whose metadata_json has no lane_hint key (e.g. seeded before this
+    feature existed) must read as 'unset', not raise."""
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(
+        state_dir, "feat-legacy", "vnx-dev", "Legacy track", "shipped",
+        metadata_json=json.dumps({"some_other_field": True}),
+    )
+    data = _show_json(state_dir, "feat-legacy")
+    assert data["lane_hint"] == "unset"
+
+
+def test_track_with_null_metadata_reads_unset(tmp_path):
+    """A row with metadata_json = NULL (older schema state) must not crash."""
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-null-meta", "vnx-dev", "Null meta", "shipped")
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET metadata_json = NULL WHERE track_id = ? AND project_id = ?",
+        ("feat-null-meta", "vnx-dev"),
+    )
+    conn.commit()
+    conn.close()
+    data = _show_json(state_dir, "feat-null-meta")
+    assert data["lane_hint"] == "unset"
+
+
+def test_track_with_malformed_metadata_reads_unset(tmp_path):
+    """A row with corrupt (non-JSON) metadata_json must not crash the read path."""
+    state_dir = _bootstrap(tmp_path)
+    tracks_lib.create_track(state_dir, "feat-bad-meta", "vnx-dev", "Bad meta", "shipped")
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET metadata_json = ? WHERE track_id = ? AND project_id = ?",
+        ("not-json{{", "feat-bad-meta", "vnx-dev"),
+    )
+    conn.commit()
+    conn.close()
+    data = _show_json(state_dir, "feat-bad-meta")
+    assert data["lane_hint"] == "unset"
+
+
+def test_show_text_output_includes_lane_hint_line(tmp_path, capsys):
+    state_dir = _bootstrap(tmp_path)
+    assert planning_cli.cmd_objective_add(_add_args(state_dir, lane_hint="direct")) == 0
+    rc = planning_cli.main([
+        "objective", "show", "feat-lane-001",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "lane_hint: direct" in out
+
+
+# --- objective sync (ROADMAP seeder) must not clobber a manually-set lane_hint ---
+
+_SAMPLE_ROADMAP = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: high
+    depends_on: []
+    milestone: "1.0"
+    status: planned
+"""
+
+_SAMPLE_ROADMAP_RISK_CHANGED = """
+roadmap_id: test-roadmap
+title: Test
+features:
+  - feature_id: feat-a
+    title: Feature A
+    risk_class: low
+    depends_on: []
+    milestone: "1.0"
+    status: planned
+"""
+
+
+def _sync_args(state_dir: Path, roadmap: Path, **over) -> argparse.Namespace:
+    base = dict(
+        state_dir=str(state_dir), roadmap=str(roadmap), project_id="vnx-dev",
+        json=False, apply=True,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+def test_sync_apply_preserves_lane_hint_when_nothing_else_changes(tmp_path):
+    state_dir = _bootstrap(tmp_path)
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(_SAMPLE_ROADMAP, encoding="utf-8")
+
+    assert seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)["summary"]["created"] == 1
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-a", "governed",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+
+    rc = planning_cli.cmd_objective_sync(_sync_args(state_dir, roadmap))
+    assert rc == 0
+    assert _lane_hint_via_get_track(state_dir, "feat-a") == "governed"
+
+
+def test_sync_apply_preserves_lane_hint_across_real_authored_change(tmp_path):
+    """lane_hint must survive a sync that legitimately rewrites metadata_json
+    for an unrelated ROADMAP-authored field (risk_class -> priority)."""
+    state_dir = _bootstrap(tmp_path)
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(_SAMPLE_ROADMAP, encoding="utf-8")
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+
+    rc = planning_cli.main([
+        "objective", "set-lane-hint", "feat-a", "direct",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+    assert rc == 0
+
+    roadmap.write_text(_SAMPLE_ROADMAP_RISK_CHANGED, encoding="utf-8")
+    rc = planning_cli.cmd_objective_sync(_sync_args(state_dir, roadmap))
+    assert rc == 0
+
+    track = tracks_lib.get_track(state_dir, "feat-a", "vnx-dev")
+    assert planning_cli._lane_hint_of(track) == "direct"
+    # confirm the risk_class-driven field actually changed underneath it
+    assert json.loads(track["metadata_json"])["risk_class"] == "low"
+
+
+def test_sync_check_mode_never_writes_lane_hint(tmp_path):
+    """CHECK mode (no --apply) must not touch the store at all."""
+    state_dir = _bootstrap(tmp_path)
+    roadmap = tmp_path / "ROADMAP.yaml"
+    roadmap.write_text(_SAMPLE_ROADMAP, encoding="utf-8")
+    seeder.seed(state_dir, roadmap, "vnx-dev", apply=True)
+    planning_cli.main([
+        "objective", "set-lane-hint", "feat-a", "governed",
+        "--project-id", "vnx-dev", "--state-dir", str(state_dir),
+    ])
+
+    rc = planning_cli.cmd_objective_sync(_sync_args(state_dir, roadmap, apply=False))
+    assert rc == 0
+    assert _lane_hint_via_get_track(state_dir, "feat-a") == "governed"
+
+
+def _lane_hint_via_get_track(state_dir: Path, track_id: str, project_id: str = "vnx-dev") -> str:
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    return planning_cli._lane_hint_of(track)


### PR DESCRIPTION
## Summary
Tracks now carry an optional `lane_hint` (governed | direct | unset) so a cold-start T0 knows how a track is meant to be dispatched without transferred judgment. Descriptive only — the door still decides the actual lane.

Track: `track-lane-risk-hint` · Dispatch: `20260714-track-lane-risk-hint`

## Changes
- `scripts/planning_cli.py`: `lane_hint` stored in `tracks.metadata_json` (backward-compatible — old tracks read as `unset`); shown in `objective show`; settable via the existing setter pattern.
- 349-line test.

## Verification
`pytest tests/test_planning_cli_lane_hint.py` green. Backward-compatible; no routing change.

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)