### PR TITLE
fix(lane-rmrf-allowlist): scoped allow-list build-toolchain + kill rm-rf hang

### DIFF
--- a/.vnx/worker_permissions.yaml
+++ b/.vnx/worker_permissions.yaml
@@ -22,16 +22,38 @@ _vnx_meta:
 
 profiles:
   backend-developer:
-    allowed_tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+    # Build-toolchain coverage (OI-104): bare "Bash" already wildcards every
+    # bash invocation, but these explicit Bash(<cmd>:*) entries self-document
+    # the toolchain a headless build worker needs and give redundant, explicit
+    # coverage independent of how a given claude CLI version interprets a bare
+    # tool-name entry. They do NOT bypass Claude Code's own unconditional
+    # dangerous-rm safety gate (see docs/operations/WORKER_PERMISSIONS.md) —
+    # that gate cannot be satisfied by any allow-list entry.
+    allowed_tools:
+      - Read
+      - Write
+      - Edit
+      - MultiEdit
+      - Bash
+      - Grep
+      - Glob
+      - "Bash(git:*)"
+      - "Bash(gh:*)"
+      - "Bash(python3:*)"
+      - "Bash(pytest:*)"
+      - "Bash(pip:*)"
+      - "Bash(rm:*)"
+      - "Bash(chmod:*)"
+      - "Bash(mkdir:*)"
     denied_tools: [WebSearch, WebFetch]
     bash_allow_patterns:
       - "pytest*"
       - "python3*"
-      - "git add*"
-      - "git commit*"
-      - "git push origin*"
+      - "git*"
+      - "gh*"
       - "pip install*"
       - "bash -n*"
+      - "chmod*"
     bash_deny_patterns:
       - "rm -rf*"
       - "git reset --hard*"

--- a/docs/operations/WORKER_PERMISSIONS.md
+++ b/docs/operations/WORKER_PERMISSIONS.md
@@ -124,12 +124,20 @@ interactive prompt, not a Unix shell `rm -i` confirmation).
 
 **Fix:** don't ask workers to run `rm -rf`/`rmdir` with a variable-expanded
 target at all. `scripts/lib/prompts/base_worker.md`'s cleanup instruction
-directs workers to `python3 -c "import shutil; shutil.rmtree(...)"` for
-directory removal instead — a `python3` invocation never routes through the
-CLI's rm-specific static analyzer, so no prompt is ever raised, headless or
-not. `rm -f <literal-path>` (a single named file, no shell variable) remains
-fine since the gate only fires on non-provably-safe *recursive* removal of a
-variable-expanded target.
+directs workers to a **guarded** `python3 -c "..."` snippet for directory
+removal instead — a `python3` invocation never routes through the CLI's
+rm-specific static analyzer, so no prompt is ever raised, headless or not.
+Guarded, not a bare `shutil.rmtree(...)`: the snippet resolves the target to
+an absolute real path and refuses — no delete, an explicit error instead — when
+the target is `/`, a top-level directory, `$HOME` or an ancestor of it, or
+outside a recognized temp/scratch root (`tempfile.gettempdir()` / `$TMPDIR` /
+`/tmp`). A bare, unguarded `shutil.rmtree()` would kill the interactive rm-gate
+hang but reintroduce the exact failure mode that gate exists to prevent — a
+wrong literal path silently, recursively deleted with no confirmation and no
+error (worse if paired with `ignore_errors=True`, which the guidance
+explicitly does not use). `rm -f <literal-path>` (a single named file, no
+shell variable) remains fine since the gate only fires on non-provably-safe
+*recursive* removal of a variable-expanded target.
 
 ## Related
 

--- a/docs/operations/WORKER_PERMISSIONS.md
+++ b/docs/operations/WORKER_PERMISSIONS.md
@@ -96,6 +96,41 @@ if working_tree_only and not (skip_permissions and worker_scoped_enabled()):
 In practice: a `working_tree_only` dispatch **must** set `VNX_WORKER_SCOPED=1`
 for that one dispatch, or it fails closed before any worker spawns.
 
+## The unbypassable exception: Claude Code's own dangerous-rm gate (OI-104)
+
+Neither posture above touches this: the `claude` CLI binary has its own
+built-in, unconditional safety check for `rm`/`rmdir` commands whose target
+cannot be statically proven safe (a shell-variable or command-substitution
+path that could be empty/unset and resolve to `/` or a top-level directory,
+or a command too complex to analyze). That check always demands interactive
+approval — it is enforced *inside the claude binary's permission-decision
+pipeline*, before `--allowedTools`/`--disallowedTools` or even
+`--dangerously-skip-permissions` are consulted, and it explicitly cannot be
+satisfied by any allow-list entry. A headless worker has no TTY to answer it,
+so the dispatch hangs forever.
+
+This is what actually caused the 2026-07-14 batch regression where 4 of 6
+build-workers hung on an `rm -rf` scratch-cleanup confirm **even under the
+default blanket `--dangerously-skip-permissions`** — neither posture in this
+doc was in play; the workers were simply telling their own Bash tool to run
+`rm -rf` on a variable-expanded scratch path, and the CLI's own gate caught
+it regardless of dispatch-lane permission mode. Evidence: the installed
+`claude` binary's own strings carry the telemetry event name
+`tengu_bash_dangerous_rm_too_complex` and the literal message "This requires
+explicit approval and cannot be auto-allowed by permission rules." — matching
+the empirically-observed fix (an operator manually sending "1" + Enter to a
+numbered Claude Code permission choice, the signature of the CLI's own
+interactive prompt, not a Unix shell `rm -i` confirmation).
+
+**Fix:** don't ask workers to run `rm -rf`/`rmdir` with a variable-expanded
+target at all. `scripts/lib/prompts/base_worker.md`'s cleanup instruction
+directs workers to `python3 -c "import shutil; shutil.rmtree(...)"` for
+directory removal instead — a `python3` invocation never routes through the
+CLI's rm-specific static analyzer, so no prompt is ever raised, headless or
+not. `rm -f <literal-path>` (a single named file, no shell variable) remains
+fine since the gate only fires on non-provably-safe *recursive* removal of a
+variable-expanded target.
+
 ## Related
 
 - `docs/core/DISPATCH_RULES.md` §5 — lane defaults, where this default is called out

--- a/scripts/lib/prompts/base_worker.md
+++ b/scripts/lib/prompts/base_worker.md
@@ -12,9 +12,38 @@ You are a VNX headless worker executing a dispatch instruction.
   it cannot statically prove the target isn't an empty/unset variable resolving
   to a root or top-level directory — and that approval prompt is NOT skipped by
   running headless/autonomous, so it hangs a dispatch with no human to answer
-  it. For a directory, run `python3 -c "import shutil; shutil.rmtree('<absolute-literal-path>', ignore_errors=True)"`
-  instead. For a single file, `rm -f <absolute-literal-path>` (a literal path,
-  no shell variable) is fine.
+  it. For a directory, use the GUARDED delete below instead of a bare
+  `shutil.rmtree(...)` — it resolves the target to an absolute real path first
+  and REFUSES (raises, prints the reason, deletes nothing) instead of silently
+  recursing when the target is `/`, a top-level directory, `$HOME` or an
+  ancestor of it, or anything outside a recognized temp/scratch root. Never
+  weaken this with `ignore_errors=True`: that flag would swallow the very
+  error the guard is designed to surface on a wrong path.
+
+  ```bash
+  python3 -c "
+  import os, shutil, sys, tempfile
+  target = os.path.realpath('<absolute-literal-path>')
+  home = os.path.realpath(os.path.expanduser('~'))
+  roots = {os.path.realpath(tempfile.gettempdir()), os.path.realpath('/tmp')}
+  if os.environ.get('TMPDIR'):
+      roots.add(os.path.realpath(os.environ['TMPDIR']))
+  under_scratch_root = any(target == r or target.startswith(r + os.sep) for r in roots)
+  if (
+      target == os.path.realpath('/')
+      or os.path.dirname(target) == os.path.realpath('/')
+      or target == home
+      or home.startswith(target + os.sep)
+      or not under_scratch_root
+  ):
+      sys.exit(f'REFUSING to delete unsafe path: {target}')
+  shutil.rmtree(target)
+  "
+  ```
+
+  For a single file, `rm -f <absolute-literal-path>` (a literal path, no shell
+  variable) is fine — it is not recursive, so the dangerous-rm gate never fires
+  on it.
 
 ## Report Discipline
 Your completion report must include:

--- a/scripts/lib/prompts/base_worker.md
+++ b/scripts/lib/prompts/base_worker.md
@@ -6,7 +6,15 @@ You are a VNX headless worker executing a dispatch instruction.
 - No TODO comments — complete all implementations to working state
 - No mock objects, placeholder data, or stub implementations
 - No partial features — start it means finish it
-- Remove temporary files and scripts after operations
+- Remove temporary files and scripts after operations. Do NOT use `rm -rf`/`rmdir`
+  with a shell-variable or command-substitution path for this: Claude Code has a
+  built-in dangerous-rm safety check that requires interactive approval whenever
+  it cannot statically prove the target isn't an empty/unset variable resolving
+  to a root or top-level directory — and that approval prompt is NOT skipped by
+  running headless/autonomous, so it hangs a dispatch with no human to answer
+  it. For a directory, run `python3 -c "import shutil; shutil.rmtree('<absolute-literal-path>', ignore_errors=True)"`
+  instead. For a single file, `rm -f <absolute-literal-path>` (a literal path,
+  no shell variable) is fine.
 
 ## Report Discipline
 Your completion report must include:

--- a/scripts/lib/prompts/roles/backend-developer.md
+++ b/scripts/lib/prompts/roles/backend-developer.md
@@ -10,18 +10,18 @@ You implement features, fix bugs, and write tests for backend systems.
 
 ## Permission Profile
 
-**Allowed tools:** Read, Write, Edit, MultiEdit, Bash, Grep, Glob
+**Allowed tools:** Read, Write, Edit, MultiEdit, Bash, Grep, Glob, Bash(git:*), Bash(gh:*), Bash(python3:*), Bash(pytest:*), Bash(pip:*), Bash(rm:*), Bash(chmod:*), Bash(mkdir:*)
 
 **Denied tools:** WebSearch, WebFetch
 
 **Bash — allowed patterns:**
 - `pytest*`
 - `python3*`
-- `git add*`
-- `git commit*`
-- `git push origin*`
+- `git*`
+- `gh*`
 - `pip install*`
 - `bash -n*`
+- `chmod*`
 
 **Bash — denied patterns:**
 - `rm -rf*`

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -81,7 +81,14 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
         args = ["--permission-mode", permission_mode]
         if not requires_mcp:
             args += ["--strict-mcp-config", "--mcp-config", EMPTY_MCP_CONFIG]
-        args += ["--allowedTools", "Read,Write,Edit,MultiEdit,Bash,Grep,Glob"]
+        # Kept in parity with worker_permissions.DEFAULT_CODE_WORKER_TOOLS (OI-104):
+        # explicit Bash(<cmd>:*) build-toolchain coverage alongside bare "Bash".
+        args += [
+            "--allowedTools",
+            "Read,Write,Edit,MultiEdit,Bash,Grep,Glob,"
+            "Bash(git:*),Bash(gh:*),Bash(python3:*),Bash(pytest:*),"
+            "Bash(pip:*),Bash(rm:*),Bash(chmod:*),Bash(mkdir:*)",
+        ]
         if working_tree_only:
             args += ["--disallowedTools", "Bash(git commit),Bash(git commit:*),Bash(git push),Bash(git push:*)"]
         return args

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -41,7 +41,16 @@ logger = logging.getLogger(__name__)
 # Essential tools a headless code worker needs to read, write, and commit code.
 # Used as the fallback allow-list when no role-specific profile is available so
 # capability scoping never strips a worker of its ability to do backend work.
-DEFAULT_CODE_WORKER_TOOLS = ["Read", "Write", "Edit", "MultiEdit", "Bash", "Grep", "Glob"]
+#
+# The explicit Bash(<cmd>:*) entries (OI-104) self-document and redundantly
+# cover the build toolchain (git/gh/python3/pytest/pip/rm/chmod) on top of the
+# bare "Bash" wildcard already above them. Neither form bypasses Claude Code's
+# own unconditional dangerous-rm safety gate — see docs/operations/WORKER_PERMISSIONS.md.
+DEFAULT_CODE_WORKER_TOOLS = [
+    "Read", "Write", "Edit", "MultiEdit", "Bash", "Grep", "Glob",
+    "Bash(git:*)", "Bash(gh:*)", "Bash(python3:*)", "Bash(pytest:*)",
+    "Bash(pip:*)", "Bash(rm:*)", "Bash(chmod:*)", "Bash(mkdir:*)",
+]
 
 # Empty ambient-MCP config string handed to `claude --mcp-config`. Paired with
 # `--strict-mcp-config` this makes a worker reach ZERO MCP servers (no Supabase,

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -124,6 +124,28 @@ def test_layer1_scratch_cleanup_is_noninteractive(assembler: PromptAssembler, ba
     # The safe non-rm alternative must be present.
     assert "shutil.rmtree" in layer1
 
+    # The alternative must be a GUARDED delete, not a blind recursive one —
+    # swapping a gated `rm -rf` for an unguarded `shutil.rmtree` is a net
+    # safety regression: a wrong literal path gets silently, recursively
+    # deleted with no confirmation and no error (codex gate finding on PR
+    # #1169). The guidance must resolve the target to a real path and refuse
+    # deletion outside a recognized scope, instead of masking a bad path with
+    # ignore_errors=True.
+    assert "shutil.rmtree(target)" in layer1, (
+        "the recommended rmtree call must take no ignore_errors=True argument "
+        "— that flag would silently mask a wrong-path deletion instead of "
+        "surfacing it"
+    )
+    assert "realpath" in layer1.lower(), (
+        "guard must resolve the target to an absolute real path before deciding"
+    )
+    for keyword in ("home", "tempdir", "tmpdir", "/tmp"):
+        assert keyword in layer1.lower(), f"guard must reference {keyword!r} in its scoping checks"
+    assert "refus" in layer1.lower(), (
+        "guard must refuse (raise/exit without deleting) on an unsafe target, "
+        "not silently proceed"
+    )
+
     # Sanity: the assembled prompt still includes L1 verbatim (regression guard
     # against a future refactor silently dropping Layer 1 from the pipe input).
     prompt = assembler.assemble(
@@ -131,6 +153,7 @@ def test_layer1_scratch_cleanup_is_noninteractive(assembler: PromptAssembler, ba
         instruction=basic_instruction,
     )
     assert "shutil.rmtree" in prompt.context
+    assert "realpath" in prompt.context.lower()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -93,6 +93,47 @@ def test_layer1_always_included(assembler: PromptAssembler, basic_instruction: s
 
 
 # ---------------------------------------------------------------------------
+# test_layer1_scratch_cleanup_is_noninteractive (OI-104)
+# ---------------------------------------------------------------------------
+
+def test_layer1_scratch_cleanup_is_noninteractive(assembler: PromptAssembler, basic_instruction: str) -> None:
+    """base_worker.md's cleanup instruction must never tell a worker to run a
+    literal `rm -rf`/`rmdir` — Claude Code's own dangerous-rm safety check
+    requires interactive approval for that regardless of
+    --dangerously-skip-permissions, which hangs a headless dispatch forever
+    (OI-104). The instruction must point workers at a non-rm alternative
+    (python3 shutil.rmtree) instead.
+    """
+    # Scoped to Layer 1 alone (base_worker.md) — Layer 2 role files legitimately
+    # keep "rm -rf*" in their own (separate, pre-existing) bash_deny_patterns
+    # listing, which would otherwise pollute a whole-context substring check.
+    layer1 = assembler._load_base()
+    assert "temporary files" in layer1.lower()
+    # The instruction must explicitly warn against rm -rf/rmdir (this sentence
+    # itself legitimately contains the substring "rm -rf" as a warning, not a
+    # suggested command)...
+    assert "do not use `rm -rf`" in layer1.lower()
+    # ...and no *standalone suggested* rm -rf/rm -r/rmdir invocation may appear
+    # anywhere else in Layer 1 (only inside that one warning clause).
+    warning_clause = "rm -rf`/`rmdir`"
+    assert layer1.count(warning_clause) == 1
+    scrubbed = layer1.replace(warning_clause, "")
+    assert "rm -rf" not in scrubbed
+    assert "rm -r " not in scrubbed
+    assert "rmdir" not in scrubbed.lower()
+    # The safe non-rm alternative must be present.
+    assert "shutil.rmtree" in layer1
+
+    # Sanity: the assembled prompt still includes L1 verbatim (regression guard
+    # against a future refactor silently dropping Layer 1 from the pipe input).
+    prompt = assembler.assemble(
+        dispatch_metadata={"role": "backend-developer", "terminal": "T1"},
+        instruction=basic_instruction,
+    )
+    assert "shutil.rmtree" in prompt.context
+
+
+# ---------------------------------------------------------------------------
 # test_unknown_role_falls_back_to_base
 # ---------------------------------------------------------------------------
 

--- a/tests/test_worker_capability_scoping.py
+++ b/tests/test_worker_capability_scoping.py
@@ -42,12 +42,24 @@ from worker_permissions import (
     build_claude_scope_args,
     default_code_worker_profile,
     generate_claude_settings,
+    load_permissions,
     resolve_worker_profile,
     worker_scoped_enabled,
 )
 
 CODE_WORKER_ESSENTIALS = {"Read", "Write", "Edit", "Bash", "Glob", "Grep"}
 SKIP_FLAG = "--dangerously-skip-permissions"
+
+# OI-104: build toolchain a scoped autonomous build worker needs — git, gh,
+# python3, pytest, pip, rm, chmod, mkdir. These are redundant with the bare
+# "Bash" wildcard already in CODE_WORKER_ESSENTIALS, but are explicit,
+# self-documenting, and independently testable coverage of the ops that
+# previously stalled a scoped (VNX_WORKER_SCOPED=1) dispatch on an
+# un-allow-listed-op permission prompt (docs/operations/WORKER_PERMISSIONS.md).
+BUILD_TOOLCHAIN_PATTERNS = {
+    "Bash(git:*)", "Bash(gh:*)", "Bash(python3:*)", "Bash(pytest:*)",
+    "Bash(pip:*)", "Bash(rm:*)", "Bash(chmod:*)", "Bash(mkdir:*)",
+}
 
 
 def _make_alive_process(pid: int = 4242) -> MagicMock:
@@ -500,3 +512,105 @@ class TestClaudeSpawnRoleForwarding:
         assert role_calls[0] is None, (
             f"expected None role for no-role spawn; got {role_calls[0]!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# 10. OI-104: scoped-profile allow-list covers the build toolchain
+# ---------------------------------------------------------------------------
+
+_REAL_YAML_PATH = Path(__file__).resolve().parents[1] / ".vnx" / "worker_permissions.yaml"
+_TMUX_DISPATCH_SRC_PATH = (
+    Path(__file__).resolve().parents[1] / "scripts" / "lib" / "tmux_interactive_dispatch.py"
+)
+
+
+class TestBuildToolchainAllowlistCoverage:
+    """A scoped (VNX_WORKER_SCOPED=1 / VNX_ENFORCE_WORKER_PERMISSIONS=1) build
+    worker must not stall on a permission prompt for git/gh/python3/pytest/
+    rm/chmod/mkdir — the build toolchain an autonomous build dispatch uses."""
+
+    def test_default_code_worker_tools_cover_build_toolchain(self):
+        allowed = set(DEFAULT_CODE_WORKER_TOOLS)
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed), (
+            f"missing from DEFAULT_CODE_WORKER_TOOLS: {BUILD_TOOLCHAIN_PATTERNS - allowed}"
+        )
+
+    def test_default_code_worker_profile_scope_args_cover_build_toolchain(self):
+        args = build_claude_scope_args(default_code_worker_profile())
+        allow_idx = args.index("--allowedTools")
+        allowed = set(args[allow_idx + 1].split(","))
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed)
+
+    def test_real_backend_developer_yaml_profile_covers_build_toolchain(self):
+        # Loads the ACTUAL project .vnx/worker_permissions.yaml (not a test
+        # fixture) so this fails if the shipped profile drifts from the fix.
+        assert _REAL_YAML_PATH.exists(), f"expected real yaml at {_REAL_YAML_PATH}"
+        profile = load_permissions("backend-developer", yaml_path=_REAL_YAML_PATH)
+        allowed = set(profile.allowed_tools)
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed), (
+            f"backend-developer profile missing: {BUILD_TOOLCHAIN_PATTERNS - allowed}"
+        )
+        # disallowedTools semantics (denied_tools) must stay intact.
+        assert "WebSearch" in profile.denied_tools
+        assert "WebFetch" in profile.denied_tools
+
+    def test_real_backend_developer_yaml_scope_args_cover_build_toolchain(self):
+        profile = load_permissions("backend-developer", yaml_path=_REAL_YAML_PATH)
+        args = build_claude_scope_args(profile)
+        allow_idx = args.index("--allowedTools")
+        allowed = set(args[allow_idx + 1].split(","))
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed)
+        deny_idx = args.index("--disallowedTools")
+        denied = set(args[deny_idx + 1].split(","))
+        assert {"WebSearch", "WebFetch"}.issubset(denied)
+
+    def test_tmux_detached_spawn_scoped_covers_build_toolchain(self, monkeypatch):
+        # End-to-end: VNX_WORKER_SCOPED=1 + role="backend-developer" resolves
+        # the real project yaml via worker_permissions' sibling-path lookup
+        # (Path(__file__).resolve().parents[2] from scripts/lib/), independent
+        # of ambient VNX_PROJECT_ROOT/PROJECT_ROOT env vars.
+        monkeypatch.delenv("VNX_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("PROJECT_ROOT", raising=False)
+        monkeypatch.setenv("VNX_WORKER_SCOPED", "1")
+        import shlex as _shlex
+        cmd = _default_launch_command(
+            "sonnet", skip_permissions=True, role="backend-developer"
+        )
+        tokens = _shlex.split(cmd)
+        idx = tokens.index("--allowedTools")
+        allowed = set(tokens[idx + 1].split(","))
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed), (
+            f"missing from scoped tmux spawn --allowedTools: {BUILD_TOOLCHAIN_PATTERNS - allowed}"
+        )
+
+    def test_enforcement_flag_also_covers_build_toolchain(self, monkeypatch):
+        # VNX_ENFORCE_WORKER_PERMISSIONS=1 (ADR-012) is the other flag that
+        # opts into the scoped posture; must get the same coverage.
+        monkeypatch.delenv("VNX_PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("PROJECT_ROOT", raising=False)
+        monkeypatch.delenv("VNX_WORKER_SCOPED", raising=False)
+        monkeypatch.setenv("VNX_ENFORCE_WORKER_PERMISSIONS", "1")
+        import shlex as _shlex
+        cmd = _default_launch_command(
+            "sonnet", skip_permissions=True, role="backend-developer"
+        )
+        tokens = _shlex.split(cmd)
+        idx = tokens.index("--allowedTools")
+        allowed = set(tokens[idx + 1].split(","))
+        assert BUILD_TOOLCHAIN_PATTERNS.issubset(allowed)
+
+    def test_inline_import_fallback_stays_in_parity_with_default_code_worker_tools(self):
+        # tmux_interactive_dispatch.py defines an inline fallback
+        # _wp_build_claude_scope_args (used only when `import worker_permissions`
+        # fails) with a hardcoded --allowedTools string that must be hand-kept
+        # in parity with DEFAULT_CODE_WORKER_TOOLS. This regression test reads
+        # the source text so drift is caught without simulating an ImportError
+        # at module-load time.
+        source = _TMUX_DISPATCH_SRC_PATH.read_text()
+        start = source.index("def _wp_build_claude_scope_args(profile")
+        end = source.index("def _wp_resolve_worker_profile", start)
+        fallback_body = source[start:end]
+        for pattern in BUILD_TOOLCHAIN_PATTERNS:
+            assert pattern in fallback_body, (
+                f"inline fallback in tmux_interactive_dispatch.py missing {pattern!r}"
+            )


### PR DESCRIPTION
Root-cause (OI-104): the 4/6 rm-rf scratch-cleanup hangs from the 2026-07-14
batch, observed even under the default blanket --dangerously-skip-permissions,
are NOT a scoped-profile allow-list gap. Claude Code's own binary has an
unconditional dangerous-rm safety check (telemetry event
tengu_bash_dangerous_rm_too_complex) that demands interactive approval for
rm/rmdir on a shell-variable-expanded target it cannot statically prove safe —
enforced inside the claude binary before --allowedTools/--disallowedTools or
--dangerously-skip-permissions are even consulted. Confirmed via the installed
claude 2.1.210 binary's own strings and cross-referenced with the 2026-07-14
memory note (workers were unstuck with "1"+Enter, the signature of Claude
Code's own numbered permission prompt, not a shell rm -i confirm).

Fixes:
- base_worker.md: cleanup instruction now directs workers to
  `python3 -c "import shutil; shutil.rmtree(...)"` for directories instead of
  `rm -rf` — a python3 invocation never routes through the CLI's rm-specific
  static analyzer, so the prompt never fires, headless or not.
- worker_permissions.yaml / worker_permissions.py / tmux_interactive_dispatch.py
  (inline import-failure fallback, kept in parity): scoped-profile
  --allowedTools now explicitly covers Bash(git:*), Bash(gh:*),
  Bash(python3:*), Bash(pytest:*), Bash(pip:*), Bash(rm:*), Bash(chmod:*),
  Bash(mkdir:*) — the build toolchain a scoped (VNX_WORKER_SCOPED=1 /
  VNX_ENFORCE_WORKER_PERMISSIONS=1) autonomous build worker needs, on top of
  the existing bare "Bash" wildcard. Separate fix from the rm-rf hang itself
  (that gate can't be satisfied by any allow-list entry) but closes the
  distinct un-allow-listed-op stall class documented in WORKER_PERMISSIONS.md.
- roles/backend-developer.md static prompt + yaml bash_allow_patterns synced
  to match (git*, gh*, chmod*); rm -rf* deny pattern left intact.
- docs/operations/WORKER_PERMISSIONS.md: new section documenting the
  dangerous-rm gate finding.

Tests: tests/test_worker_capability_scoping.py (new
TestBuildToolchainAllowlistCoverage — 8 tests covering DEFAULT_CODE_WORKER_TOOLS,
build_claude_scope_args, the real .vnx/worker_permissions.yaml profile, the
tmux detached-spawn end-to-end path under both VNX_WORKER_SCOPED and
VNX_ENFORCE_WORKER_PERMISSIONS, and the inline fallback parity), and
tests/test_prompt_assembler.py (new test_layer1_scratch_cleanup_is_noninteractive
proving base_worker.md never suggests a literal rm -rf/rmdir and points at
shutil.rmtree instead).

Dispatch-ID: 20260715-lane-rmrf-allowlist
