### PR TITLE
feat(lane-autopr-enforce): tmux-spawn build workers auto-create their own PR

### DIFF
--- a/scripts/lib/auto_gate_trigger.py
+++ b/scripts/lib/auto_gate_trigger.py
@@ -97,61 +97,6 @@ def _get_current_branch() -> str:
         return ""
 
 
-def _find_open_pr(branch: str) -> Optional[int]:
-    """Return open PR number for branch, or None if not found."""
-    if not branch:
-        return None
-    try:
-        proc = subprocess.run(
-            ["gh", "pr", "list", "--head", branch, "--json", "number,state"],
-            capture_output=True, text=True, timeout=20,
-            cwd=str(_REPO_ROOT),
-        )
-        if proc.returncode != 0:
-            logger.debug("gh pr list failed: %s", proc.stderr.strip()[:200])
-            return None
-        prs = json.loads(proc.stdout)
-        open_prs = [p for p in prs if p.get("state", "").upper() == "OPEN"]
-        return open_prs[0]["number"] if open_prs else None
-    except Exception as exc:
-        logger.debug("_find_open_pr failed: %s", exc)
-        return None
-
-
-def _create_pr(feature_id: str, branch: str) -> Optional[int]:
-    """Create a GitHub PR for branch; return PR number or None on failure."""
-    title = f"feat({feature_id.lower()}): auto-created by VNX governance trigger"
-    body = (
-        f"Auto-created by VNX auto_gate_trigger when all PRs for {feature_id} "
-        "were detected as committed.\n\n"
-        "This PR was opened automatically to satisfy the `pr_must_exist_before_next_dispatch` "
-        "governance check. Please update the title and description before merging."
-    )
-    try:
-        proc = subprocess.run(
-            ["gh", "pr", "create",
-             "--title", title,
-             "--body", body,
-             "--head", branch,
-             "--draft"],
-            capture_output=True, text=True, timeout=60,
-            cwd=str(_REPO_ROOT),
-        )
-        if proc.returncode != 0:
-            logger.warning("gh pr create failed: %s", proc.stderr.strip()[:400])
-            return None
-        # gh pr create outputs PR URL; parse the number from the last path segment
-        url = proc.stdout.strip()
-        m = re.search(r"/pull/(\d+)", url)
-        if m:
-            return int(m.group(1))
-        logger.warning("Could not parse PR number from gh output: %s", url[:200])
-        return None
-    except Exception as exc:
-        logger.warning("_create_pr exception: %s", exc)
-        return None
-
-
 def _trigger_gate(pr_number: int, branch: str, gate_name: str) -> bool:
     """Invoke review_gate_manager request-and-execute for a single gate.
 
@@ -259,24 +204,38 @@ def trigger_gates_if_feature_complete(
         feature_id, feature_state.completed_prs, feature_state.total_prs,
     )
 
-    # 4. Find or create GitHub PR
+    # 4. Find or create GitHub PR (shared implementation — see gh_pr_ensure.py)
     branch = _get_current_branch()
-    pr_number = _find_open_pr(branch)
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+    from gh_pr_ensure import ensure_pr  # noqa: PLC0415
+
+    pr_result = ensure_pr(
+        branch,
+        _REPO_ROOT,
+        title=f"feat({feature_id.lower()}): auto-created by VNX governance trigger",
+        body=(
+            f"Auto-created by VNX auto_gate_trigger when all PRs for {feature_id} "
+            "were detected as committed.\n\n"
+            "This PR was opened automatically to satisfy the `pr_must_exist_before_next_dispatch` "
+            "governance check. Please update the title and description before merging."
+        ),
+        draft=True,
+    )
+    pr_number = pr_result["pr_number"]
+    if pr_result.get("created"):
+        logger.info("No open PR found for branch '%s' — created PR #%s", branch, pr_number)
 
     if pr_number is None:
-        logger.info("No open PR found for branch '%s' — creating one", branch)
-        pr_number = _create_pr(feature_id, branch)
-        if pr_number is None:
-            reason = f"Failed to create GitHub PR for branch '{branch}'"
-            logger.warning("auto_gate_trigger: %s", reason)
-            _log_auto_gate_event(data_dir, {
-                "timestamp": _now_utc(),
-                "feature_id": feature_id,
-                "branch": branch,
-                "triggered": False,
-                "reason": reason,
-            })
-            return {"triggered": False, "reason": reason, "pr_number": None, "gates": []}
+        reason = pr_result.get("reason") or f"Failed to create GitHub PR for branch '{branch}'"
+        logger.warning("auto_gate_trigger: %s", reason)
+        _log_auto_gate_event(data_dir, {
+            "timestamp": _now_utc(),
+            "feature_id": feature_id,
+            "branch": branch,
+            "triggered": False,
+            "reason": reason,
+        })
+        return {"triggered": False, "reason": reason, "pr_number": None, "gates": []}
 
     logger.info("Using PR #%d for gate triggers", pr_number)
 

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -76,13 +76,15 @@ def dedup_completion_receipts(receipts: list) -> "dict | None":
     if len(receipts) == 1:
         return receipts[0]
 
-    # Tier 0 (phantom override): a govern-time phantom rejection is FINAL — it overrides the
-    # worker's own claim regardless of authored/synthesized status or a same-second timestamp tie
-    # (codex P0.2 F4). The worker's original receipt stays on the ledger; this only decides which
-    # one is authoritative for gate evaluation.
-    phantom = [r for r in receipts if r.get("phantom_rejected")]
-    if phantom:
-        return max(phantom, key=lambda r: str(r.get("timestamp") or ""))
+    # Tier 0 (govern-time override): a phantom rejection OR an autopr rejection
+    # (pr_enforcement.py: the branch was pushed but no PR could be found/created) is
+    # FINAL — it overrides the worker's own claim regardless of authored/synthesized
+    # status or a same-second timestamp tie (codex P0.2 F4). The worker's original
+    # receipt stays on the ledger; this only decides which one is authoritative for
+    # gate evaluation.
+    override = [r for r in receipts if r.get("phantom_rejected") or r.get("autopr_rejected")]
+    if override:
+        return max(override, key=lambda r: str(r.get("timestamp") or ""))
 
     # Tier 1: authoritative status outranks unknown
     authoritative = [r for r in receipts if _receipt_authority(r)]

--- a/scripts/lib/gh_pr_ensure.py
+++ b/scripts/lib/gh_pr_ensure.py
@@ -1,0 +1,130 @@
+"""gh_pr_ensure.py — single shared implementation of "find or create a GitHub PR
+for a branch", used by every lane that needs an idempotent auto-PR guarantee.
+
+Two call sites need this:
+  - auto_gate_trigger.py: opens a PR once a multi-PR feature's checkboxes are
+    all committed, so the review-gate stack has something to attach to.
+  - pr_enforcement.py (tmux-spawn build-dispatch completion path): opens a PR
+    for a worker that committed + pushed its dispatch branch but never ran
+    `gh pr create` itself, so T0 does not have to salvage it by hand.
+
+Both call sites must share exactly one `gh pr create` invocation — two independent
+implementations drift (different flags, different idempotency checks) and that
+drift is how duplicate PRs happen.
+
+BILLING SAFETY: No Anthropic SDK. CLI-only (git/gh via subprocess).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import subprocess
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def find_open_pr(branch: str, repo_root: Path, *, timeout: int = 20) -> Optional[int]:
+    """Return the open PR number for *branch*, or None if none exists / lookup failed.
+
+    Never raises: a `gh` failure (auth, network, rate limit) is treated as "unknown",
+    not "no PR exists" — callers must not use None here to justify creating a
+    duplicate without a corroborating create-side idempotency check of their own.
+    """
+    if not branch:
+        return None
+    try:
+        proc = subprocess.run(
+            ["gh", "pr", "list", "--head", branch, "--json", "number,state"],
+            capture_output=True, text=True, timeout=timeout,
+            cwd=str(repo_root),
+        )
+        if proc.returncode != 0:
+            logger.debug("gh pr list failed for %s: %s", branch, (proc.stderr or "").strip()[:200])
+            return None
+        prs = json.loads(proc.stdout)
+        open_prs = [p for p in prs if (p.get("state") or "").upper() == "OPEN"]
+        return open_prs[0]["number"] if open_prs else None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("find_open_pr failed for %s: %s", branch, exc)
+        return None
+
+
+def create_pr(
+    branch: str,
+    repo_root: Path,
+    *,
+    title: str,
+    body: str,
+    draft: bool = False,
+    timeout: int = 60,
+) -> Optional[int]:
+    """Create a GitHub PR for *branch*; return the PR number, or None on failure.
+
+    Never raises: `gh` unavailability / auth / network errors are reported via the
+    None return, not propagated — a transient GitHub outage must not crash a
+    dispatch lane.
+    """
+    cmd = ["gh", "pr", "create", "--title", title, "--body", body, "--head", branch]
+    if draft:
+        cmd.append("--draft")
+    try:
+        proc = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout,
+            cwd=str(repo_root),
+        )
+        if proc.returncode != 0:
+            logger.warning("gh pr create failed for %s: %s", branch, (proc.stderr or "").strip()[:400])
+            return None
+        url = proc.stdout.strip()
+        m = re.search(r"/pull/(\d+)", url)
+        if m:
+            return int(m.group(1))
+        logger.warning("Could not parse PR number from gh output for %s: %s", branch, url[:200])
+        return None
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("create_pr exception for %s: %s", branch, exc)
+        return None
+
+
+def ensure_pr(
+    branch: str,
+    repo_root: Path,
+    *,
+    title: str,
+    body: str,
+    draft: bool = False,
+) -> Dict[str, Any]:
+    """Idempotently ensure an open PR exists for *branch*.
+
+    Re-checks for an open PR immediately before creating one and again treats a
+    "gh pr create" failure that reports the PR already exists as success (a race
+    between the initial lookup and the create call), so concurrent callers never
+    produce two PRs for the same branch.
+
+    Returns {"pr_number": int|None, "created": bool, "reason": str|None}.
+    "reason" is populated only when pr_number is None (a genuine failure).
+    """
+    pr_number = find_open_pr(branch, repo_root)
+    if pr_number is not None:
+        return {"pr_number": pr_number, "created": False, "reason": None}
+
+    pr_number = create_pr(branch, repo_root, title=title, body=body, draft=draft)
+    if pr_number is not None:
+        return {"pr_number": pr_number, "created": True, "reason": None}
+
+    # create_pr failed — re-check once for a PR that appeared concurrently (a
+    # racing caller, or `gh pr create` itself failing only because one already
+    # exists) before reporting a genuine failure.
+    pr_number = find_open_pr(branch, repo_root)
+    if pr_number is not None:
+        return {"pr_number": pr_number, "created": False, "reason": None}
+
+    return {
+        "pr_number": None,
+        "created": False,
+        "reason": f"gh pr create failed for branch {branch!r} (no open PR found on retry)",
+    }

--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -1,0 +1,138 @@
+"""pr_enforcement.py — enforce that a build worker's pushed dispatch branch has an
+open PR, in the tmux-spawn build-dispatch completion path.
+
+Problem: a build worker commits and pushes its `dispatch/<id>` branch to origin but
+frequently never runs `gh pr create`. The dispatch then "completes" with a branch
+sitting on origin and no PR, and T0 has to salvage it by hand every time
+(`gh pr create --head dispatch/<id>`).
+
+This module is the enforcement chokepoint the tmux lane calls right before it
+governs the dispatch (see tmux_interactive_dispatch.TmuxInteractiveDispatch's
+teardown flow). It reuses gh_pr_ensure (the one shared gh-pr-create implementation
+— auto_gate_trigger.py uses the same module) so there is exactly one `gh pr create`
+invocation in the codebase, never two independently-drifting ones.
+
+Enforcement, not best-effort: when the branch was pushed and PR creation fails, this
+is recorded as a receipt-visible failure — a corrective 'failed' completion receipt
+is appended to the ndjson ledger, mirroring phantom_guard's tier-0 override pattern
+(dispatch_govern.dedup_completion_receipts honors ``autopr_rejected`` the same way
+it honors ``phantom_rejected``) — so a dispatch that pushed real work but never got
+a PR does NOT silently resolve as 'done'.
+
+Out of scope: a branch that was never pushed (worktree_state != "pushed") has
+nothing to enforce here — an empty/uncommitted worktree is phantom_guard's problem,
+not this module's.
+
+BILLING SAFETY: No Anthropic SDK. CLI-only (gh/git via subprocess, through
+gh_pr_ensure).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger(__name__)
+
+# append_receipt.py lives in scripts/, not scripts/lib — mirrors
+# dispatch_govern.ensure_receipt / phantom_guard.record_phantom_if_any.
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
+
+
+@dataclass(frozen=True)
+class PrEnforcementResult:
+    """Outcome of enforce_pr_exists().
+
+    applicable=False: the branch was never pushed — nothing to enforce, ok=True.
+    applicable=True, ok=True: a PR exists (found or just created).
+    applicable=True, ok=False: the branch was pushed but no PR could be found or
+        created — a corrective receipt has already been appended.
+    """
+    applicable: bool
+    ok: bool
+    pr_number: Optional[int] = None
+    created: bool = False
+    reason: Optional[str] = None
+
+
+def enforce_pr_exists(
+    *,
+    dispatch_id: str,
+    branch: str,
+    worktree_state: str,
+    repo_root: Path,
+    receipts_file: "str | Path",
+    pr_title: str,
+    pr_body: str,
+) -> PrEnforcementResult:
+    """Ensure *branch* has an open PR when it was pushed to origin.
+
+    ``worktree_state`` is the tmux_worktree.classify() verdict
+    ("clean"/"committed"/"pushed"/"dirty"). Only "pushed" is in scope.
+
+    Never raises: a gh_pr_ensure exception is treated as a creation failure (still
+    enforced — reported via PrEnforcementResult.ok=False + corrective receipt), not
+    propagated, so a transient GitHub/network error never crashes the dispatch lane.
+    """
+    if worktree_state != "pushed":
+        return PrEnforcementResult(
+            applicable=False, ok=True,
+            reason=f"worktree_state={worktree_state!r} — nothing pushed to open a PR for",
+        )
+
+    try:
+        from gh_pr_ensure import ensure_pr  # noqa: PLC0415
+        result = ensure_pr(branch, repo_root, title=pr_title, body=pr_body, draft=False)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("pr_enforcement: ensure_pr raised for %s: %s", branch, exc)
+        result = {"pr_number": None, "created": False, "reason": f"ensure_pr exception: {exc}"}
+
+    pr_number = result.get("pr_number")
+    if pr_number is not None:
+        return PrEnforcementResult(
+            applicable=True, ok=True,
+            pr_number=pr_number, created=bool(result.get("created")),
+        )
+
+    reason = result.get("reason") or f"gh pr create failed for branch {branch!r}"
+    logger.warning(
+        "pr_enforcement: REJECTED dispatch=%s branch=%s — %s", dispatch_id, branch, reason,
+    )
+    _record_corrective_receipt(
+        dispatch_id=dispatch_id, branch=branch, reason=reason, receipts_file=receipts_file,
+    )
+    return PrEnforcementResult(applicable=True, ok=False, reason=reason)
+
+
+def _record_corrective_receipt(
+    *, dispatch_id: str, branch: str, reason: str, receipts_file: "str | Path",
+) -> None:
+    """Append a corrective 'failed' completion receipt — the loud, receipt-visible
+    signal that a pushed-but-PR-less dispatch is incomplete. Never raises."""
+    try:
+        if _SCRIPTS_DIR not in sys.path:
+            sys.path.insert(0, _SCRIPTS_DIR)
+        from append_receipt import append_receipt_payload  # noqa: PLC0415
+        append_receipt_payload(
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": dispatch_id,
+                "status": "failed",
+                "autopr_rejected": True,
+                "autopr_reason": reason,
+                "branch": branch,
+                "source": "pr_enforcement",
+                "synthesized": False,
+                "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            },
+            receipts_file=str(receipts_file),
+            cache_window_seconds=0,
+        )
+    except Exception as exc:  # noqa: BLE001 — a corrective-append failure must never break the lane
+        logger.warning(
+            "pr_enforcement: corrective receipt append failed dispatch=%s: %s", dispatch_id, exc,
+        )

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -804,6 +804,76 @@ class TmuxInteractiveDispatch:
         downgraded["phantom_reason"] = verdict.reason
         return downgraded
 
+    def _enforce_pr_exists(
+        self,
+        *,
+        dispatch_id: str,
+        label: str,
+        worktree_handle: "WorktreeHandle",
+        worktree_state: str,
+    ) -> "PrEnforcementResult":
+        """Lane-context adapter over pr_enforcement.enforce_pr_exists (lane-fix B).
+
+        ``worktree_state`` is the caller's already-computed classify(worktree_handle)
+        verdict — passed in rather than reclassified here so classify() runs exactly
+        once per dispatch (its result is memoized into _wt_classification and reused
+        by _teardown's reap() call).
+
+        When the branch was pushed to origin, ensures an open PR exists — creating
+        one via gh_pr_ensure when it does not. Emits an audit event either way; a
+        creation failure is ALSO recorded as a receipt-visible corrective receipt by
+        pr_enforcement itself.
+
+        Never raises: mirrors the fail-open contract of the phantom-guard hook —
+        an internal error here must not crash a real, successful dispatch.
+        """
+        try:
+            from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
+
+            result = enforce_pr_exists(
+                dispatch_id=dispatch_id,
+                branch=worktree_handle.branch,
+                worktree_state=worktree_state,
+                repo_root=self._project_root,
+                receipts_file=self._receipts_file,
+                pr_title=f"dispatch({dispatch_id}): auto-created by VNX tmux-spawn lane",
+                pr_body=(
+                    f"Auto-created by VNX tmux-spawn build-dispatch completion "
+                    f"(dispatch `{dispatch_id}`) — the worker pushed this branch "
+                    "but did not open a PR itself. Please review before merging."
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001 — never block a real completion on this guard
+            logger.error(
+                "interactive: PR-enforcement guard errored dispatch=%s: %s", dispatch_id, exc,
+            )
+            from pr_enforcement import PrEnforcementResult  # noqa: PLC0415
+            return PrEnforcementResult(applicable=False, ok=True, reason=f"guard error: {exc}")
+
+        if not result.applicable:
+            return result
+
+        if result.ok:
+            self._emit_event(
+                "interactive_autopr",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason="created" if result.created else "already_existed",
+                metadata={"pr_number": result.pr_number, "created": result.created},
+            )
+        else:
+            logger.warning(
+                "interactive: PR-enforcement REJECTED dispatch=%s — %s",
+                dispatch_id, result.reason,
+            )
+            self._emit_event(
+                "interactive_autopr_failed",
+                dispatch_id=dispatch_id,
+                label=label,
+                reason=result.reason,
+            )
+        return result
+
     def _build_completion_protocol(
         self, dispatch_id: str, label: str, model: str = "unknown", *, integrity=None
     ) -> str:
@@ -1805,6 +1875,11 @@ class TmuxInteractiveDispatch:
         # never spawns a tmux session with an uncontrolled cwd.
         worktree_handle: "WorktreeHandle | None" = None
         _wt_state: "list[str | None]" = [None]
+        # Set by the pre-govern auto-PR-enforcement check (success path only) so
+        # _teardown's classify() call is memoized rather than re-run — classify()
+        # is read-only/idempotent but callers (e.g. tests) assert it runs exactly
+        # once per dispatch.
+        _wt_classification: "list[str | None]" = [None]
         _raw_log: "list[Path | None]" = [None]
         # Worker-permission relay handle (flag-gated); stopped in _teardown.
         _relay_handle: "list[object | None]" = [None]
@@ -1904,7 +1979,11 @@ class TmuxInteractiveDispatch:
                     logger.debug("interactive: teardown normalizer dispatch=%s: %s", dispatch_id, exc)
             if worktree_handle is not None:
                 try:
-                    cls = classify(worktree_handle)
+                    cls = (
+                        _wt_classification[0]
+                        if _wt_classification[0] is not None
+                        else classify(worktree_handle)
+                    )
                     reap_result = reap(worktree_handle, cls)
                     _wt_state[0] = cls
                     self._emit_event(
@@ -2377,6 +2456,27 @@ class TmuxInteractiveDispatch:
                 "failed",
                 "blocked",
             )
+            # Auto-PR enforcement: a build worker that committed+pushed its dispatch
+            # branch but never ran `gh pr create` leaves T0 to salvage the PR by hand
+            # every time (lane-fix B). Runs BEFORE govern() so a creation failure is
+            # reflected in the governed report and InteractiveDispatchResult.success —
+            # never a silent "done" with a branch stranded on origin.
+            _autopr_failure_reason: "str | None" = None
+            if worker_succeeded and worktree_handle is not None:
+                _wt_classification[0] = classify(worktree_handle)
+                autopr_result = self._enforce_pr_exists(
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    worktree_handle=worktree_handle,
+                    worktree_state=_wt_classification[0],
+                )
+                if not autopr_result.ok:
+                    worker_succeeded = False
+                    _autopr_failure_reason = autopr_result.reason
+                    receipt = dict(receipt)
+                    receipt["status"] = "failed"
+                    receipt["autopr_rejected"] = True
+                    receipt["autopr_reason"] = autopr_result.reason
             emitted_report = self._govern_report(
                 dispatch_id=dispatch_id,
                 terminal_id=label,
@@ -2389,6 +2489,11 @@ class TmuxInteractiveDispatch:
                 token_usage=_pane_tokens,
                 role=role,
                 session_id=session_uuid,
+                **(
+                    {"failure_reason": f"pushed_branch_no_pr: {_autopr_failure_reason}"}
+                    if _autopr_failure_reason
+                    else {}
+                ),
             )
             # A governed-completion path (worker OK) with no linked report is an
             # audit-trail gap — do not report success with an unlinked report.
@@ -2412,7 +2517,11 @@ class TmuxInteractiveDispatch:
                     None if success else (
                         "unified_report_emit_failed"
                         if worker_succeeded
-                        else f"worker_status: {receipt.get('status')}"
+                        else (
+                            f"pushed_branch_no_pr: {_autopr_failure_reason}"
+                            if _autopr_failure_reason
+                            else f"worker_status: {receipt.get('status')}"
+                        )
                     )
                 ),
                 duration_seconds=time.monotonic() - start_time,

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -782,6 +782,35 @@ def test_dedup_multiple_done_authored_picks_newest():
     assert result is r2
 
 
+def test_dedup_autopr_rejected_wins_over_worker_done():
+    """pr_enforcement's corrective receipt (autopr_rejected) is a Tier-0 override,
+    same as phantom_rejected — a same-second timestamp tie must not let the
+    worker's own 'done' win."""
+    worker = {"dispatch_id": "d1", "status": "done", "timestamp": "2026-07-15T10:00:00Z"}
+    corrective = {
+        "dispatch_id": "d1", "status": "failed", "autopr_rejected": True,
+        "timestamp": "2026-07-15T10:00:00Z",
+    }
+    assert dedup_completion_receipts([worker, corrective])["status"] == "failed"
+    assert dedup_completion_receipts([corrective, worker])["status"] == "failed"
+
+
+def test_dedup_autopr_and_phantom_override_together():
+    """Either override marker alone is sufficient — both land in Tier 0."""
+    phantom = {
+        "dispatch_id": "d1", "status": "failed", "phantom_rejected": True,
+        "timestamp": "2026-07-15T09:00:00Z",
+    }
+    autopr = {
+        "dispatch_id": "d1", "status": "failed", "autopr_rejected": True,
+        "timestamp": "2026-07-15T10:00:00Z",
+    }
+    worker = {"dispatch_id": "d1", "status": "done", "timestamp": "2026-07-15T11:00:00Z"}
+    # worker is newest by timestamp but must still lose to the Tier-0 pool.
+    result = dedup_completion_receipts([worker, phantom, autopr])
+    assert result is autopr, "newest Tier-0 override (autopr) must win over a newer worker 'done'"
+
+
 # ---------------------------------------------------------------------------
 # ensure_receipt — uniform stamp: provider/sub_provider/model/lane
 # ---------------------------------------------------------------------------

--- a/tests/test_gh_pr_ensure.py
+++ b/tests/test_gh_pr_ensure.py
@@ -1,0 +1,156 @@
+"""Tests for gh_pr_ensure.py — shared find/create-PR helper.
+
+All `gh` invocations are mocked at the subprocess.run boundary; nothing here
+touches GitHub.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import gh_pr_ensure as ghe
+
+
+def _completed(returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(args=[], returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+# ---------------------------------------------------------------------------
+# find_open_pr
+# ---------------------------------------------------------------------------
+
+def test_find_open_pr_returns_number_when_open_pr_exists(tmp_path):
+    payload = '[{"number": 42, "state": "OPEN"}]'
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout=payload)) as mock_run:
+        result = ghe.find_open_pr("dispatch/x", tmp_path)
+    assert result == 42
+    args = mock_run.call_args.args[0]
+    assert args[:3] == ["gh", "pr", "list"]
+    assert "--head" in args and "dispatch/x" in args
+
+
+def test_find_open_pr_returns_none_when_no_pr(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout="[]")):
+        assert ghe.find_open_pr("dispatch/x", tmp_path) is None
+
+
+def test_find_open_pr_ignores_closed_prs(tmp_path):
+    payload = '[{"number": 7, "state": "CLOSED"}, {"number": 8, "state": "MERGED"}]'
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout=payload)):
+        assert ghe.find_open_pr("dispatch/x", tmp_path) is None
+
+
+def test_find_open_pr_none_on_gh_failure(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(returncode=1, stderr="boom")):
+        assert ghe.find_open_pr("dispatch/x", tmp_path) is None
+
+
+def test_find_open_pr_none_on_empty_branch(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run") as mock_run:
+        assert ghe.find_open_pr("", tmp_path) is None
+    mock_run.assert_not_called()
+
+
+def test_find_open_pr_none_on_exception(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", side_effect=OSError("gh not found")):
+        assert ghe.find_open_pr("dispatch/x", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# create_pr
+# ---------------------------------------------------------------------------
+
+def test_create_pr_parses_number_from_url(tmp_path):
+    url = "https://github.com/org/repo/pull/99\n"
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout=url)) as mock_run:
+        result = ghe.create_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert result == 99
+    args = mock_run.call_args.args[0]
+    assert args[:3] == ["gh", "pr", "create"]
+    assert "--draft" not in args
+
+
+def test_create_pr_passes_draft_flag(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout="https://x/pull/1")) as mock_run:
+        ghe.create_pr("dispatch/x", tmp_path, title="t", body="b", draft=True)
+    args = mock_run.call_args.args[0]
+    assert "--draft" in args
+
+
+def test_create_pr_none_on_gh_failure(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(returncode=1, stderr="no access")):
+        assert ghe.create_pr("dispatch/x", tmp_path, title="t", body="b") is None
+
+
+def test_create_pr_none_on_unparseable_output(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", return_value=_completed(stdout="not a url")):
+        assert ghe.create_pr("dispatch/x", tmp_path, title="t", body="b") is None
+
+
+def test_create_pr_none_on_exception(tmp_path):
+    with patch("gh_pr_ensure.subprocess.run", side_effect=OSError("gh not found")):
+        assert ghe.create_pr("dispatch/x", tmp_path, title="t", body="b") is None
+
+
+# ---------------------------------------------------------------------------
+# ensure_pr — scenarios (a) push+no-PR creates exactly one, (b) idempotent
+# re-run, (c) existing-PR no-op
+# ---------------------------------------------------------------------------
+
+def test_ensure_pr_creates_when_none_exists(tmp_path):
+    """(a) A branch with no open PR gets exactly one PR created."""
+    with patch("gh_pr_ensure.find_open_pr", return_value=None) as mock_find:
+        with patch("gh_pr_ensure.create_pr", return_value=55) as mock_create:
+            result = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert result == {"pr_number": 55, "created": True, "reason": None}
+    mock_find.assert_called_once()
+    mock_create.assert_called_once()
+
+
+def test_ensure_pr_is_idempotent_on_rerun(tmp_path):
+    """(b) Re-running ensure_pr after a PR was created is a no-op — still one PR."""
+    with patch("gh_pr_ensure.find_open_pr", return_value=None) as mock_find:
+        with patch("gh_pr_ensure.create_pr", return_value=55) as mock_create:
+            first = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert first["pr_number"] == 55
+    assert first["created"] is True
+
+    # Second call: the branch now HAS an open PR — find_open_pr returns it,
+    # create_pr must never be invoked again.
+    with patch("gh_pr_ensure.find_open_pr", return_value=55) as mock_find2:
+        with patch("gh_pr_ensure.create_pr") as mock_create2:
+            second = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert second == {"pr_number": 55, "created": False, "reason": None}
+    mock_create2.assert_not_called()
+
+
+def test_ensure_pr_noop_when_pr_already_exists(tmp_path):
+    """(c) An existing-PR branch is a pure no-op — no create call at all."""
+    with patch("gh_pr_ensure.find_open_pr", return_value=17) as mock_find:
+        with patch("gh_pr_ensure.create_pr") as mock_create:
+            result = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert result == {"pr_number": 17, "created": False, "reason": None}
+    mock_find.assert_called_once()
+    mock_create.assert_not_called()
+
+
+def test_ensure_pr_reports_failure_reason_when_create_fails(tmp_path):
+    """create_pr failing (and no PR appears on retry-check) surfaces a reason."""
+    with patch("gh_pr_ensure.find_open_pr", return_value=None):
+        with patch("gh_pr_ensure.create_pr", return_value=None):
+            result = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert result["pr_number"] is None
+    assert result["created"] is False
+    assert "dispatch/x" in result["reason"]
+
+
+def test_ensure_pr_recovers_from_create_race(tmp_path):
+    """create_pr fails but a concurrent caller's PR is now visible — treated as success."""
+    with patch("gh_pr_ensure.find_open_pr", side_effect=[None, 88]):
+        with patch("gh_pr_ensure.create_pr", return_value=None):
+            result = ghe.ensure_pr("dispatch/x", tmp_path, title="t", body="b")
+    assert result == {"pr_number": 88, "created": False, "reason": None}

--- a/tests/test_governance_audit_stamping.py
+++ b/tests/test_governance_audit_stamping.py
@@ -231,6 +231,7 @@ def test_auto_gate_trigger_passes_dispatch_id_to_log_gate_result(tmp_path, monke
     _set_data_dir(tmp_path, monkeypatch)
 
     import auto_gate_trigger
+    import gh_pr_ensure
 
     recorded_calls: list[dict] = []
 
@@ -250,7 +251,10 @@ def test_auto_gate_trigger_passes_dispatch_id_to_log_gate_result(tmp_path, monke
         patch.object(auto_gate_trigger, "_extract_feature_id_from_plan", return_value="F51"),
         patch.object(auto_gate_trigger, "_load_required_gates", return_value=["codex_gate"]),
         patch.object(auto_gate_trigger, "_get_current_branch", return_value="feat/f51"),
-        patch.object(auto_gate_trigger, "_find_open_pr", return_value=261),
+        patch.object(
+            gh_pr_ensure, "ensure_pr",
+            return_value={"pr_number": 261, "created": False, "reason": None},
+        ),
         patch.object(auto_gate_trigger, "_trigger_gate", return_value=True),
         patch.object(auto_gate_trigger, "_log_auto_gate_event", return_value=None),
     ):

--- a/tests/test_pr_enforcement.py
+++ b/tests/test_pr_enforcement.py
@@ -1,0 +1,232 @@
+"""Tests for pr_enforcement.py — the tmux-spawn build-dispatch auto-PR enforcement
+chokepoint. gh_pr_ensure and append_receipt are mocked; nothing here touches
+GitHub or a real git repo.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import pr_enforcement as pe
+
+
+def _kwargs(**overrides):
+    base = dict(
+        dispatch_id="d1",
+        branch="dispatch/d1",
+        worktree_state="pushed",
+        repo_root=Path("/repo"),
+        receipts_file="/tmp/does-not-matter.ndjson",
+        pr_title="t",
+        pr_body="b",
+    )
+    base.update(overrides)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Out-of-scope worktree states — no gh call at all
+# ---------------------------------------------------------------------------
+
+def test_not_applicable_when_not_pushed(monkeypatch):
+    called = {"n": 0}
+
+    def _boom(*a, **kw):
+        called["n"] += 1
+        raise AssertionError("gh_pr_ensure must not be imported/called")
+
+    import gh_pr_ensure
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _boom)
+
+    for state in ("clean", "committed", "dirty"):
+        result = pe.enforce_pr_exists(**_kwargs(worktree_state=state))
+        assert result.applicable is False
+        assert result.ok is True
+        assert result.pr_number is None
+    assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# (a) pushed + no PR -> creates exactly one
+# ---------------------------------------------------------------------------
+
+def test_pushed_no_pr_creates_one(monkeypatch):
+    import gh_pr_ensure
+    captured = {}
+
+    def _fake_ensure_pr(branch, repo_root, *, title, body, draft=False):
+        captured.update(branch=branch, repo_root=repo_root, title=title, body=body, draft=draft)
+        return {"pr_number": 101, "created": True, "reason": None}
+
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _fake_ensure_pr)
+
+    result = pe.enforce_pr_exists(**_kwargs())
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pr_number == 101
+    assert result.created is True
+    assert captured["branch"] == "dispatch/d1"
+    assert captured["draft"] is False
+
+
+# ---------------------------------------------------------------------------
+# (b) re-running the enforcement path is idempotent — still one PR, no re-create
+# ---------------------------------------------------------------------------
+
+def test_rerun_is_idempotent(monkeypatch):
+    import gh_pr_ensure
+
+    calls = {"n": 0}
+
+    def _fake_ensure_pr(branch, repo_root, *, title, body, draft=False):
+        calls["n"] += 1
+        # ensure_pr itself is idempotent (tested in test_gh_pr_ensure.py); simulate
+        # its post-creation no-op behavior on the second call.
+        if calls["n"] == 1:
+            return {"pr_number": 101, "created": True, "reason": None}
+        return {"pr_number": 101, "created": False, "reason": None}
+
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _fake_ensure_pr)
+
+    first = pe.enforce_pr_exists(**_kwargs())
+    second = pe.enforce_pr_exists(**_kwargs())
+
+    assert first.pr_number == 101 and first.created is True
+    assert second.pr_number == 101 and second.created is False
+    assert calls["n"] == 2  # enforce_pr_exists was invoked twice, but only 1 PR ever exists
+
+
+# ---------------------------------------------------------------------------
+# (c) existing-PR branch -> pure no-op
+# ---------------------------------------------------------------------------
+
+def test_existing_pr_is_noop(monkeypatch):
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 55, "created": False, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs())
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pr_number == 55
+    assert result.created is False
+
+
+# ---------------------------------------------------------------------------
+# Enforcement: creation failure is a LOUD, receipt-visible failure
+# ---------------------------------------------------------------------------
+
+def test_creation_failure_appends_corrective_receipt(monkeypatch, tmp_path):
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": None, "created": False, "reason": "gh auth expired"},
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload, kw=kw),
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(receipts_file=str(tmp_path / "r.ndjson")))
+
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.pr_number is None
+    assert result.reason == "gh auth expired"
+
+    payload = captured["payload"]
+    assert payload["status"] == "failed"
+    assert payload["autopr_rejected"] is True
+    assert payload["autopr_reason"] == "gh auth expired"
+    assert payload["dispatch_id"] == "d1"
+    assert payload["branch"] == "dispatch/d1"
+    # event_type must be one the watchers honor (ACTIONABLE_EVENTS), mirrors phantom_guard
+    assert payload["event_type"] == "subprocess_completion"
+    assert payload["synthesized"] is False  # else dedup Tier-2 would drop it
+    assert payload["timestamp"].endswith("Z")
+
+
+def test_creation_failure_default_reason_when_ensure_pr_omits_one(monkeypatch, tmp_path):
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": None, "created": False, "reason": None},
+    )
+    import append_receipt
+    monkeypatch.setattr(append_receipt, "append_receipt_payload", lambda *a, **k: None)
+
+    result = pe.enforce_pr_exists(**_kwargs())
+
+    assert result.ok is False
+    assert "dispatch/d1" in result.reason
+
+
+def test_ensure_pr_exception_is_treated_as_failure_not_raised(monkeypatch, tmp_path):
+    import gh_pr_ensure
+
+    def _boom(*a, **kw):
+        raise RuntimeError("network exploded")
+
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _boom)
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(receipts_file=str(tmp_path / "r.ndjson")))
+
+    assert result.ok is False
+    assert "network exploded" in result.reason
+    assert captured["payload"]["autopr_rejected"] is True
+
+
+def test_corrective_receipt_append_failure_is_non_fatal(monkeypatch, tmp_path):
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": None, "created": False, "reason": "boom"},
+    )
+    import append_receipt
+
+    def _boom(*a, **kw):
+        raise RuntimeError("append exploded")
+
+    monkeypatch.setattr(append_receipt, "append_receipt_payload", _boom)
+
+    # Must not raise even though the corrective append itself fails.
+    result = pe.enforce_pr_exists(**_kwargs())
+    assert result.ok is False
+    assert result.reason == "boom"
+
+
+def test_success_path_never_touches_append_receipt(monkeypatch):
+    """A found/created PR must NOT append any corrective receipt."""
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 9, "created": True, "reason": None},
+    )
+    import append_receipt
+    calls = {"n": 0}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda *a, **k: calls.__setitem__("n", calls["n"] + 1),
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs())
+
+    assert result.ok is True
+    assert calls["n"] == 0

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -37,6 +37,7 @@ from tmux_interactive_dispatch import (
     main,
 )
 from tmux_worktree import ReapResult, WorktreeAllocateError, WorktreeHandle
+from pr_enforcement import PrEnforcementResult
 
 
 class FakeTmux:
@@ -1260,6 +1261,108 @@ class TestWorktreeTeardownLifecycle(_WorktreeTestCase):
             "interactive_teardown_preserved must be emitted for dirty worktree",
         )
         self.assertEqual(result.worktree_state, "dirty")
+
+
+# ---------------------------------------------------------------------------
+# lane-worker-autopr-enforce: auto-PR enforcement wiring
+# ---------------------------------------------------------------------------
+
+class TestAutoPrEnforcement(_WorktreeTestCase):
+    """dispatch() wires pr_enforcement.enforce_pr_exists into the success path."""
+
+    def test_pushed_worktree_triggers_pr_enforcement(self):
+        """A worker that pushed its branch runs PR enforcement; success on PR found/created."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock(
+            return_value=PrEnforcementResult(applicable=True, ok=True, pr_number=5, created=True)
+        )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed") as mock_classify:
+                with patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)):
+                    with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+                        result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertTrue(result.success)
+        mock_enforce.assert_called_once()
+        call_kwargs = mock_enforce.call_args.kwargs
+        self.assertEqual(call_kwargs["dispatch_id"], self.DISPATCH_ID)
+        self.assertEqual(call_kwargs["branch"], handle.branch)
+        self.assertEqual(call_kwargs["worktree_state"], "pushed")
+        # classify() must be called exactly once (memoized, reused by teardown's reap()).
+        mock_classify.assert_called_once_with(handle)
+        self.assertEqual(result.worktree_state, "pushed")
+
+    def test_non_pushed_worktree_skips_pr_enforcement(self):
+        """A clean/committed/dirty worktree has nothing to PR — the real enforcement path
+        runs (not mocked, to prove the end-to-end short-circuit) but never reaches gh."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_ensure_pr = MagicMock()
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="clean"):
+                with patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)):
+                    with patch("gh_pr_ensure.ensure_pr", mock_ensure_pr):
+                        result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertTrue(result.success)
+        mock_ensure_pr.assert_not_called()
+
+    def test_pr_enforcement_failure_fails_dispatch(self):
+        """A pushed branch that never gets a PR fails the dispatch loudly — no phantom success."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock(
+            return_value=PrEnforcementResult(applicable=True, ok=False, reason="gh auth expired")
+        )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed"):
+                with patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)):
+                    with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+                        result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertFalse(result.success)
+        self.assertIn("pushed_branch_no_pr", result.failure_reason)
+        self.assertIn("gh auth expired", result.failure_reason)
+        self.assertEqual(result.receipt.get("status"), "failed")
+        self.assertTrue(result.receipt.get("autopr_rejected"))
+        self.assertEqual(result.receipt.get("autopr_reason"), "gh auth expired")
+
+    def test_pr_enforcement_skipped_when_worker_already_failed(self):
+        """A worker that self-reported failure is never PR-enforced (nothing to enforce)."""
+        handle = self._make_handle()
+        fake = FakeTmux(
+            receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID, receipt_status="failed",
+        )
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock()
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="pushed"):
+                with patch("tmux_interactive_dispatch.reap", return_value=ReapResult(removed=True)):
+                    with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+                        result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertFalse(result.success)
+        mock_enforce.assert_not_called()
+
+    def test_pr_enforcement_skipped_without_worktree(self):
+        """isolated_worktree=False (no worktree_handle) never invokes PR enforcement."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock()
+
+        with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+            result = self._fast_dispatch(lane, isolated_worktree=False)
+
+        self.assertTrue(result.success)
+        mock_enforce.assert_not_called()
 
 
 class TestWorktreeCliFlags(unittest.TestCase):


### PR DESCRIPTION
The tmux-spawn build-dispatch lane let workers commit+push their branch
without ever running gh pr create, forcing T0 to salvage every dispatch by
hand (6/6 observed in a recent batch). Wires an idempotent auto-PR check into
the completion path: a pushed-but-PR-less branch gets one PR opened via a new
shared gh_pr_ensure helper (also adopted by auto_gate_trigger.py, replacing
its own duplicate gh invocation). A PR-creation failure is enforced, not
best-effort — it downgrades the dispatch to failed and appends a corrective
receipt (dedup_completion_receipts now honors autopr_rejected as a Tier-0
override, same as phantom_rejected) so a stranded branch never resolves as a
silent "done".

Dispatch-ID: 20260715-lane-autopr-enforce

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
