### PR TITLE
feat(hashchain-anchor): pin chain origin to close ADR-029 prefix-strip bypass

### DIFF
--- a/docs/governance/decisions/ADR-033-epoch-seal-anchor.md
+++ b/docs/governance/decisions/ADR-033-epoch-seal-anchor.md
@@ -1,0 +1,132 @@
+# ADR-033 — Hash-chain origin anchor: closing the prefix-strip / re-seal bypass
+
+**Status:** Accepted (hardening, no behavior flip)
+**Date:** 2026-07-15
+**Decided by:** Worker dispatch `20260715-hashchain-anchor`, track `post10-hashchain-default-on` (deliverable `dlv-d2eac5fa32d1`). This is the "future epoch-seal-anchor ADR" that `ndjson_hash_chain.verify_chain`'s threat-model note (ADR-029) already referenced.
+**Resolves / Cross-refs:** Extends ADR-023 (receipt hash-chain, default-off), ADR-029 (epoch rotation, the accepted residual this ADR closes), ADR-005 (append-only NDJSON ledger — the anchor store follows the same shape). Supersedes the design explored in PR #1086 (HELD, DB-backed origin store) and the finding it traces to, PR #1085 (closed).
+
+## Context
+
+ADR-029 made hash-chain adoption safe to flip on without a fleet-wide RED by introducing `chain_epoch_start` epoch markers: an unchained epoch-0 prefix (pre-adoption history) followed by one or more explicitly-sealed, chained epochs verifies as `verified-segmented` — healthy.
+
+ADR-029's own "Threat-model note" documented an accepted residual, verbatim in the `verify_chain` docstring:
+
+> A local actor with write access to the ledger can strip a prefix, insert a fresh `chain_epoch_start` marker, and re-chain the remainder — this verifies.
+
+Concretely: `verify_chain` has no memory of *where* a ledger's trustworthy chain is supposed to begin. It only checks that whatever `chain_epoch_start` marker it finds anchors to `GENESIS_HASH` and that everything after it chains correctly. Any GENESIS-rooted marker satisfies that — including one an attacker planted after deleting the real history. A truncate-and-reseal (delete the true epoch-0 prefix and the true first marker, keep only later entries, re-chain them under a brand-new marker) is indistinguishable from a legitimate seal. This is exactly the finding that HELD PR #1085 (closed) and its would-be fix, PR #1086 (HELD through four `codex_gate` rounds).
+
+### Why PR #1086's approach didn't land
+
+PR #1086 pinned the origin in `runtime_coordination.db` (a "trusted" SQLite store) rather than a sidecar file, reasoning that a sidecar an attacker could rewrite defeats the point. Four gate rounds found, in order:
+
+1. **Mutable origin.** `INSERT OR REPLACE INTO vnx_chain_origin` let an attacker strip the prefix, append a new first-chained entry, and have `_record_chain_origin` silently overwrite the pin with their own.
+2. **Non-atomic append + anchor.** The ledger write and the origin-store write are two different storage engines (file vs. SQLite) — no shared transaction. A crash between them could leave a chained entry with no pinned origin.
+3. **Fail-open on store errors.** `except sqlite3.OperationalError: return None` treated *any* DB error (locked, corrupt, not just "no such table") as "no origin recorded" — which downgrades straight to unauthenticated verification. An attacker who can induce an `OperationalError` defeats the pin without touching a single hash.
+4. **No ADR-005 audit event** for the origin mutation — a trust anchor with no audit trail of its own is itself a gap.
+
+The conclusion on record (PR #1086, round 4): *"iterative patching will not resolve this... tamper-evident chaining needs a holistic security design."* That holistic design is this ADR.
+
+Note the original PR #1085 finding actually offered **both** options — "a trusted sidecar **or** the coordination DB" — so a sidecar file was never rejected on principle; PR #1086 simply chose the DB, and that specific implementation accumulated the four defects above. This ADR chooses the sidecar and shows why, done carefully, it avoids all four.
+
+## Decision
+
+Pin the chain origin in a **sibling, append-only NDJSON anchor file** next to the ledger it protects (`scripts/lib/chain_origin_anchor.py`), written **only** by the one-time `chain_epoch_seal.seal_ledger` migration — never on the hot per-receipt append path. `ndjson_hash_chain.verify_chain` enforces the anchor when one exists; with no anchor present, verification is byte-for-byte identical to pre-ADR-033 behavior.
+
+### 1. Anchor record
+
+For a ledger at `<dir>/<name>.ndjson`, the anchor lives at `<dir>/<name>.ndjson.origin_anchor.ndjson` — a plain NDJSON file, one record per ledger it has ever anchored (in practice: at most one, this ledger only):
+
+```json
+{
+  "ledger_identity": "/abs/path/to/t0_receipts.ndjson",
+  "origin_type": "epoch_marker",
+  "origin_hash": "<sha256 of the earliest chain_epoch_start marker's canonical JSON>",
+  "origin_line_number": 4,
+  "origin_epoch": 1,
+  "entries_before_origin": 3,
+  "sealed_at": "2026-07-15T12:00:00+00:00"
+}
+```
+
+`origin_type` is `"epoch_marker"` (the ledger's earliest `chain_epoch_start` marker — the normal case, produced by `chain_epoch_seal`) or `"genesis_entry"` (a marker-less ledger chained directly from GENESIS at line 1 — the `verify_chain` `"verified"` status, reachable if chaining is ever enabled on a fresh ledger without going through the seal script).
+
+### 2. Write-once, by construction
+
+`write_origin_anchor_if_absent(ledger_path, origin)` opens the anchor file `a+` and takes an exclusive `flock` for the entire read-check-then-append: it scans existing records for this ledger's identity; if one exists, it returns that record **unchanged** — the caller's `origin` argument is discarded, even if it differs. There is no UPDATE/REPLACE code path at all, so PR #1086 defect #1 (mutable origin) has no equivalent here to regress into.
+
+### 3. No per-append atomicity problem to solve
+
+The anchor is written by `chain_epoch_seal.seal_ledger`, a one-time (idempotent) migration — not paired with every receipt append the way PR #1086's design was. This sidesteps defect #2 structurally rather than by careful sequencing: if `seal_ledger` crashes between appending the marker and writing the anchor, the ledger is left with a valid, unanchored marker; re-running `seal_ledger` (already required to be idempotent by ADR-029) sees `chaining_active=True`, takes the no-op action branch, and completes the anchor write. No recovery/reconciliation design is needed beyond "the seal script is already idempotent and always tries to anchor."
+
+### 4. Fail CLOSED on anchor-store errors
+
+`read_origin_anchor` distinguishes "no anchor file, or an anchor file with no record for this ledger and nothing unparseable in it" (→ `None`, legitimately never sealed) from "the anchor file exists and contains at least one line that fails to parse, with no valid record found for this ledger" (→ `{"_corrupt": True}`). `verify_chain` treats the latter as `broken` immediately. There is no `except: return None` anywhere in the read path that could turn a real error into a silent pass — this directly closes PR #1086 defect #3.
+
+### 5. The anchor file is its own audit trail
+
+Per ADR-005, the anchor file is itself append-only NDJSON with a `sealed_at` timestamp — `tail -f`-able, `git diff`-able, no separate event stream needed. This closes PR #1086's advisory finding #4 (no audit event for the origin mutation) as a side effect of the storage choice, not a bolt-on.
+
+### 6. `verify_chain` enforcement
+
+`verify_chain` (`scripts/lib/ndjson_hash_chain.py`) now:
+
+1. Runs the existing ADR-029 epoch-aware walk unchanged (factored out as `_verify_chain_unanchored`).
+2. Looks up the ledger's anchor. **No anchor → returns the unanchored result verbatim** (identical `(is_valid, violations, status)` tuple as before this ADR).
+3. With an anchor present:
+   - Corrupt anchor → `broken`.
+   - Unanchored ledger status is already `broken` → unchanged.
+   - Unanchored ledger status is `unchained` (all chain activity gone even though an anchor was previously recorded) → `broken` — history was erased outright.
+   - Otherwise (`verified` / `verified-segmented`), re-derives the ledger's **current** origin — its earliest `chain_epoch_start` marker, or its first entry for a marker-less genesis chain — and compares `origin_hash` **and** `origin_line_number` against the pinned anchor. A mismatch on either (moved boundary, stripped prefix content, wrong marker) → `broken`, with a violation note naming the anchor mismatch.
+
+Pinning **both** the hash and the line number matters: ADR-005 append-only guarantees nothing is ever removed *before* the true origin in legitimate operation, so the origin's line number is exactly as immutable as its content. An attacker who deletes an early prefix line without touching the marker's own bytes changes nothing about the marker's hash but does shift its line number — caught by the position check even when the content check alone would not catch it.
+
+### 7. Flag stays default-off
+
+`VNX_CHAIN_RECEIPTS` is not touched by this change. This is a precondition for eventually flipping it, not the flip itself. The append path (`append_chained_entry`, `append_epoch_marker`) is unmodified; only `verify_chain` (read path) and `chain_epoch_seal.seal_ledger` (the one-time migration, which now also calls the new `seal_chain_origin`) change.
+
+## Threat model
+
+**Closed by this ADR:** a local actor with write access to the ledger who strips an early prefix (including a legitimately-sealed epoch marker) and re-chains the remainder under a fresh GENESIS-rooted marker. Once a ledger has been sealed (and therefore anchored), this now verifies `broken`, not `verified-segmented`.
+
+**Not closed (explicitly out of scope, same residual ADR-029 already accepted):** a root-equivalent attacker who edits **both** the ledger and its sibling anchor file in the same operation. A locally-stored anchor — whether a sidecar file (this ADR) or a DB row (PR #1086's attempt) — is exactly as defeatable by an attacker who controls both stores; neither approach changes that fact, which is why PR #1086's round-4 conclusion listed "external append-only / signed anchor" as a separate, later scope item. Full defense against a local root attacker requires an anchor that lives outside the machine the attacker controls (a remote append-only log, a signed/timestamped external attestation) — deferred.
+
+**Also not covered:** legitimate flag-flapping mid-ledger-life (chaining enabled, then disabled, then re-enabled) still produces a real `broken` finding for the unchained gap in between, by the pre-existing ADR-029 state machine — this ADR does not change that, and it is a correct result (an integrity gap genuinely exists there), not a false positive introduced by the anchor.
+
+## Consequences
+
+### Accepted
+
+- `verify_chain` gains an opt-in-by-construction hardening: it only activates once a ledger has been sealed via `chain_epoch_seal.seal_ledger` (or anything else that calls the new `seal_chain_origin`). Ledgers that have never been sealed are completely unaffected — same `unchained`/`verified`/`verified-segmented`/`broken` behavior as before.
+- All existing `verify_chain` callers (`fabric_audit.py` check C, `scripts/lib/evidence_bound_gate.py`, `scripts/lib/attest_override.py`, `scripts/lib/governance_effectiveness_probe.py`, `scripts/audit_chain.py`) get this protection automatically once their target ledger is sealed, with no call-site changes — the enforcement lives in the shared `verify_chain` entry point precisely so there is nothing to forget to wire up per caller.
+- PR #1086 should be closed in favor of this design once this lands (left to the operator/T0 to action — not done by this dispatch).
+
+### Rejected
+
+- Rewriting the anchor on every re-seal / new epoch. The anchor pins the ledger's **earliest** trustworthy point, not its latest; a legitimate second or third epoch marker must never move it (covered by test: a later, legitimately-chained epoch leaves the original anchor byte-identical).
+- Coupling the anchor write to the hot per-receipt append path (what PR #1086 did). Decoupling it — anchor only at seal time — is what removes the atomicity problem structurally instead of requiring a recovery/reconciliation protocol.
+- An external/remote/signed anchor in this pass. Real, but a materially larger scope (network dependency, signing key management) than "close the local truncate-and-reseal bypass" — tracked as a future item, not silently dropped.
+
+## Test plan
+
+`tests/test_chain_origin_anchor.py`:
+
+- The bypass is closed: seal a ledger, pin its anchor, truncate-and-reseal it (strip the true prefix + true marker, re-chain the same tail bodies under a fresh GENESIS marker) → `broken` (fails against pre-ADR-033 `verify_chain`, passes after).
+- A moved epoch boundary (one prefix line removed; the marker's own bytes are untouched but its line number shifts) → `broken`, caught by the line-number pin even though the hash alone would not catch it.
+- Legitimate seal + matching anchor → stays `verified-segmented`.
+- A legitimate second epoch (no unchained gap) leaves the original anchor untouched and the ledger stays healthy.
+- A marker-less genesis chain (`verified`) anchors to its first entry; the same truncate-and-reanchor attack on it is also caught.
+- No anchor present → `verify_chain` output is identical, entry-for-entry, to the pre-anchor `_verify_chain_unanchored` core (regression guard for the default/no-anchor path), across both a healthy and a tampered ledger.
+- First-seal bootstrap writes the anchor exactly once; a second `seal_ledger` call is a no-op — the anchor file's bytes do not change.
+- `write_origin_anchor_if_absent` called directly with two different origins for the same ledger: the second call is discarded, first one wins, file has exactly one record (append-only, write-once as a primitive, independent of the seal script).
+- A corrupt anchor file fails closed (`broken`), never silently treated as "no anchor".
+- An anchor pinned on a ledger later wiped back to fully unchained → `broken` (history erased, not read as "chaining never enabled").
+- `seal_chain_origin` is a no-op on an unchained, empty, or absent ledger (nothing to anchor yet).
+
+## See also
+
+- ADR-023 — Receipt hash-chain (experimental opt-in)
+- ADR-029 — Epoch rotation (the accepted residual this ADR closes)
+- ADR-005 — Append-only NDJSON ledger (the anchor file follows the same append-only shape)
+- PR #1085 (closed) — original prefix-strip finding
+- PR #1086 (HELD) — DB-backed origin-pin attempt; four gate rounds' findings directly shaped this design
+- `scripts/lib/chain_origin_anchor.py`, `scripts/lib/ndjson_hash_chain.py` (`verify_chain`, `seal_chain_origin`, `_compute_current_origin`), `scripts/chain_epoch_seal.py`

--- a/scripts/chain_epoch_seal.py
+++ b/scripts/chain_epoch_seal.py
@@ -27,6 +27,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
 from ndjson_hash_chain import (  # type: ignore[import]
     append_epoch_marker,
     epoch_state,
+    seal_chain_origin,
     verify_chain,
 )
 
@@ -37,6 +38,11 @@ def seal_ledger(path: Path) -> dict:
     - ``action="noop"`` when the ledger is already chaining or absent.
     - ``action="sealed"`` when a marker was appended, with the new ``epoch`` and
       the post-seal ``status`` (should be ``verified-segmented`` or ``verified``).
+
+    ADR-033: also pins the ledger's chain-origin anchor (idempotent — a no-op
+    once an anchor exists). This only happens on the FIRST seal; a later
+    re-seal (opening epoch 2+) leaves the original anchor untouched, since the
+    origin is the ledger's earliest chained point, not its latest.
     """
     if not path.exists() or path.stat().st_size == 0:
         # A fresh/empty ledger needs no seal: the first appended receipt chains
@@ -45,11 +51,13 @@ def seal_ledger(path: Path) -> dict:
 
     max_epoch, chaining_active = epoch_state(path)
     if chaining_active:
+        seal_chain_origin(path)
         return {"ledger": str(path), "action": "noop", "reason": "already chaining", "epoch": max_epoch}
 
     epoch = max_epoch + 1
     marker_hash = append_epoch_marker(path, epoch)
     _ok, _violations, status = verify_chain(path)
+    seal_chain_origin(path)
     return {
         "ledger": str(path),
         "action": "sealed",

--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -1,0 +1,139 @@
+"""chain_origin_anchor.py — sibling append-only store pinning a ledger's chain origin.
+
+Closes the ``verify_chain`` prefix-strip bypass documented in ADR-029's
+threat-model note (see ADR-033): a local actor with ledger write access can
+strip an early prefix, insert a fresh ``chain_epoch_start`` marker
+(``prev_hash=GENESIS``), and re-chain the remainder — this verifies as
+``verified-segmented`` because ``verify_chain`` has no memory of where the
+chain was supposed to begin. This module gives it that memory.
+
+Design note (chosen after PR #1086's DB-backed origin store — recorded in
+``runtime_coordination.db`` — was HELD through four codex_gate rounds: mutable
+origin via ``INSERT OR REPLACE``, then a non-atomic ledger-write/origin-write
+pair, then fail-open on store errors): pin the origin in a SIBLING APPEND-ONLY
+NDJSON file next to the ledger, written only by the one-time
+``chain_epoch_seal`` migration — never on the hot receipt-append path.
+- **Write-once** is a plain "does a record already exist" check made under an
+  exclusive flock; there is no UPDATE/REPLACE surface to make mutable.
+- There is no per-append atomicity problem to solve, because the anchor write
+  happens out-of-band from receipt appends rather than paired with every one.
+  A seal that crashes between the marker append and the anchor write is
+  self-healing: ``chain_epoch_seal.seal_ledger`` is idempotent, so re-running
+  it completes the anchor write without re-marking the ledger.
+- The anchor file is itself an ADR-005-shaped append-only NDJSON record, so it
+  carries its own audit trail (``sealed_at``) without a separate event.
+- Reads fail CLOSED: a corrupt/unparseable anchor file is reported as such,
+  never silently treated as "no anchor" (which would fail open).
+
+Explicitly out of scope (see ADR-033): a root attacker who edits BOTH the
+ledger and its sibling anchor file defeats this scheme. Full defense against
+that needs an external/remote append-only anchor — deferred, same accepted
+residual as ADR-029.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+ANCHOR_SUFFIX = ".origin_anchor.ndjson"
+
+# Sentinel returned by read_origin_anchor when the anchor file exists but no
+# line for this ledger parses cleanly — fail CLOSED, never "no anchor".
+CORRUPT = {"_corrupt": True}
+
+
+def anchor_path(ledger_path: Path) -> Path:
+    """Sibling append-only anchor file for ``ledger_path``."""
+    return ledger_path.with_name(ledger_path.name + ANCHOR_SUFFIX)
+
+
+def _ledger_identity(ledger_path: Path) -> str:
+    return str(ledger_path.resolve())
+
+
+def read_origin_anchor(ledger_path: Path) -> dict | None:
+    """Return the pinned origin record for ``ledger_path``, or ``None`` if
+    the ledger has never been sealed (no anchor file, or an anchor file with
+    no record for this ledger and nothing unparseable in it either).
+
+    Fails CLOSED on corruption: if the anchor file exists and contains at
+    least one unparseable line but no valid record for this ledger, returns
+    ``{"_corrupt": True}`` rather than silently treating it as "no anchor".
+    """
+    anchor_file = anchor_path(ledger_path)
+    if not anchor_file.exists() or anchor_file.stat().st_size == 0:
+        return None
+
+    identity = _ledger_identity(ledger_path)
+    record: dict | None = None
+    saw_unparseable = False
+    with anchor_file.open("r", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_SH)
+        try:
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    saw_unparseable = True
+                    continue
+                if obj.get("ledger_identity") == identity:
+                    record = obj
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)
+
+    if record is None and saw_unparseable:
+        return dict(CORRUPT)
+    return record
+
+
+def write_origin_anchor_if_absent(ledger_path: Path, origin: dict) -> dict:
+    """Idempotently pin ``origin`` for ``ledger_path``.
+
+    Write-once: the read-check-then-append critical section runs under an
+    exclusive flock, so a second (or concurrent) call for the same ledger
+    returns the EXISTING record untouched — the anchor, once written, is
+    immutable, never overwritten with ``origin``.
+
+    ``origin`` must contain ``origin_type``, ``origin_hash``,
+    ``origin_line_number``, and ``origin_epoch``.
+    """
+    anchor_file = anchor_path(ledger_path)
+    anchor_file.parent.mkdir(parents=True, exist_ok=True)
+    identity = _ledger_identity(ledger_path)
+
+    with open(anchor_file, "a+", encoding="utf-8") as f:
+        fcntl.flock(f.fileno(), fcntl.LOCK_EX)
+        try:
+            f.seek(0)
+            for line in f:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    obj = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if obj.get("ledger_identity") == identity:
+                    return obj
+
+            record = {
+                "ledger_identity": identity,
+                "origin_type": origin["origin_type"],
+                "origin_hash": origin["origin_hash"],
+                "origin_line_number": origin["origin_line_number"],
+                "origin_epoch": origin["origin_epoch"],
+                "entries_before_origin": origin["origin_line_number"] - 1,
+                "sealed_at": datetime.now(timezone.utc).isoformat(),
+            }
+            f.write(json.dumps(record, sort_keys=True) + "\n")
+            f.flush()
+            os.fsync(f.fileno())
+            return record
+        finally:
+            fcntl.flock(f.fileno(), fcntl.LOCK_UN)

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
 
+import chain_origin_anchor
 
 GENESIS_HASH = "0" * 64  # Sentinel for first entry in chain
 
@@ -173,7 +174,8 @@ def _read_last_hash(path: Path) -> str | None:
 
 
 def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
-    """Verify the hash-chain integrity of an NDJSON ledger (ADR-029 epoch-aware).
+    """Verify the hash-chain integrity of an NDJSON ledger (ADR-029 epoch-aware,
+    ADR-033 origin-anchored).
 
     Returns (is_valid, violations_list, status) where status is one of:
 
@@ -188,22 +190,139 @@ def verify_chain(path: Path) -> tuple[bool, list[dict], str]:
     - "broken": a within-epoch prev_hash mismatch, an unchained entry INSIDE a
       chained epoch, a chained entry with no preceding epoch marker after an
       unchained prefix (a naive VNX_CHAIN_RECEIPTS flip that skipped the seal),
-      an epoch marker whose prev_hash != GENESIS, or unparseable lines.
-      is_valid=False.
+      an epoch marker whose prev_hash != GENESIS, unparseable lines, OR (new,
+      ADR-033) a mismatch against a pinned chain-origin anchor.
 
-    Threat-model note (ADR-029, accepted residual): epoch-0 history and the
-    relocation of an epoch boundary are NOT defended here. A local actor with
-    write access to the ledger can strip a prefix, insert a fresh
-    chain_epoch_start marker, and re-chain the remainder — this verifies. A
-    ledger is only as trustworthy as its first sealed epoch onward; full
-    tamper-evidence against a local attacker needs an EXTERNAL append-only
-    anchor (out of scope for ADR-029 — a future epoch-seal-anchor ADR). This
-    check detects accidental corruption and within-epoch tampering, the
-    governance value ADR-023/ADR-029 target. Flag stays default-off until the
-    fleet-wide seal migration lands.
+    Threat-model note (ADR-029 residual, CLOSED by ADR-033 when an anchor is
+    present): epoch-0 history and the relocation of an epoch boundary are only
+    defended once a chain-origin anchor has been recorded for this ledger (see
+    `chain_origin_anchor.py`, written by `chain_epoch_seal.seal_ledger`). When
+    an anchor exists, this function additionally re-derives the ledger's
+    CURRENT origin (its earliest chain_epoch_start marker, or its first entry
+    for a marker-less genesis chain) and compares it against the pinned
+    anchor; a stripped-and-resealed prefix, a moved epoch boundary, or a
+    first-entry that no longer matches the pinned origin all return "broken".
+    With NO anchor present, this function is byte-for-byte identical to the
+    pre-ADR-033 behavior: a local actor with write access to the ledger can
+    still strip a prefix, insert a fresh chain_epoch_start marker, and
+    re-chain the remainder undetected. Sealing a ledger (which also anchors
+    it) is what turns this protection on. Even with an anchor, a root
+    attacker who edits BOTH the ledger and its sibling anchor file defeats
+    the scheme — full tamper-evidence against that needs an EXTERNAL
+    append-only anchor (out of scope for ADR-033, same accepted residual as
+    ADR-029).
 
     violations_list contains dicts with: line_number and one of
     expected_prev_hash/actual_prev_hash, 'error', or 'note'.
+    """
+    ok, violations, status = _verify_chain_unanchored(path)
+
+    anchor = chain_origin_anchor.read_origin_anchor(path)
+    if anchor is None:
+        return ok, violations, status
+
+    if anchor.get("_corrupt"):
+        return (
+            False,
+            violations + [{
+                "note": "chain-origin anchor file is present but corrupt/unparseable — failing closed",
+            }],
+            "broken",
+        )
+
+    if status == "broken":
+        return ok, violations, status
+
+    if status == "unchained":
+        return (
+            False,
+            violations + [{
+                "note": "chain-origin anchor is pinned but the ledger now shows no chain activity — history erased",
+                "expected_origin_hash": anchor.get("origin_hash"),
+                "expected_origin_line_number": anchor.get("origin_line_number"),
+            }],
+            "broken",
+        )
+
+    current_origin = _compute_current_origin(path, status)
+    if current_origin is None or (
+        current_origin["origin_hash"] != anchor.get("origin_hash")
+        or current_origin["origin_line_number"] != anchor.get("origin_line_number")
+    ):
+        return (
+            False,
+            violations + [{
+                "note": "chain-origin anchor mismatch — ledger prefix was stripped and re-chained (truncate-and-reseal)",
+                "expected_origin_hash": anchor.get("origin_hash"),
+                "actual_origin_hash": (current_origin or {}).get("origin_hash"),
+                "expected_origin_line_number": anchor.get("origin_line_number"),
+                "actual_origin_line_number": (current_origin or {}).get("origin_line_number"),
+            }],
+            "broken",
+        )
+
+    return ok, violations, status
+
+
+def _compute_current_origin(path: Path, status: str) -> dict | None:
+    """Return the ledger's CURRENT chain-origin fingerprint given its already-
+    computed `status`, or None if the ledger has no anchorable origin.
+
+    - "verified-segmented": origin is the EARLIEST chain_epoch_start marker
+      (verify_chain only reaches this status without violations when a marker
+      is present — see the state-machine note in verify_chain).
+    - "verified": origin is the first entry (marker-less genesis chain, no
+      unchained prefix, chained from line 1).
+    - anything else: no origin to compute.
+    """
+    if status not in ("verified", "verified-segmented"):
+        return None
+    for line_no, entry in _iter_parsed(path):
+        is_marker = entry.get("type") == EPOCH_MARKER_TYPE
+        has_prev = "prev_hash" in entry
+        if status == "verified-segmented":
+            if is_marker:
+                try:
+                    epoch = int(entry.get("epoch", 0))
+                except (TypeError, ValueError):
+                    epoch = 0
+                return {
+                    "origin_type": "epoch_marker",
+                    "origin_hash": compute_entry_hash(entry),
+                    "origin_line_number": line_no,
+                    "origin_epoch": epoch,
+                }
+        elif has_prev:
+            return {
+                "origin_type": "genesis_entry",
+                "origin_hash": compute_entry_hash(entry),
+                "origin_line_number": line_no,
+                "origin_epoch": 0,
+            }
+    return None
+
+
+def seal_chain_origin(path: Path) -> dict | None:
+    """Idempotently pin the ledger's current chain origin to its sibling
+    anchor store (see `chain_origin_anchor.py`).
+
+    Returns the anchor record (existing or newly-written), or None if the
+    ledger has no chain activity yet (status "unchained" or "broken" —
+    nothing trustworthy to anchor).
+    """
+    _ok, _violations, status = _verify_chain_unanchored(path)
+    origin = _compute_current_origin(path, status)
+    if origin is None:
+        return None
+    return chain_origin_anchor.write_origin_anchor_if_absent(path, origin)
+
+
+def _verify_chain_unanchored(path: Path) -> tuple[bool, list[dict], str]:
+    """ADR-029 epoch-aware chain verification, with NO chain-origin anchor
+    check. See `verify_chain` (the public, anchor-aware entry point) for the
+    full state-machine description; this is its core walk, factored out so
+    `_compute_current_origin` and `seal_chain_origin` can reuse it without
+    recursing through the anchor overlay.
     """
     entries: list[tuple[int, dict]] = []
     parse_errors: list[dict] = []

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -1,0 +1,330 @@
+"""Tests for the ADR-033 chain-origin anchor (scripts/lib/chain_origin_anchor.py)
+and its wiring into ndjson_hash_chain.verify_chain / chain_epoch_seal.seal_ledger.
+
+Covers the DoD from the hashchain-anchor dispatch:
+  - the documented ADR-029 prefix-strip-and-reseal bypass is now `broken`
+  - a legitimately sealed ledger with a matching anchor still verifies
+  - no anchor present -> identical result to the pre-ADR-033 verifier
+  - first-seal bootstrap writes the anchor exactly once; a second seal is a
+    no-op (idempotent, append-only)
+  - fail-closed behavior on a corrupt anchor file
+  - a moved epoch boundary (line number shifts, content unchanged) is caught
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import chain_origin_anchor  # noqa: E402
+from ndjson_hash_chain import (  # noqa: E402
+    append_chained_entry,
+    append_epoch_marker,
+    compute_entry_hash,
+    seal_chain_origin,
+    verify_chain,
+    _verify_chain_unanchored,
+)
+
+# Load scripts/chain_epoch_seal.py (not importable as a package name).
+_spec = importlib.util.spec_from_file_location(
+    "chain_epoch_seal", REPO / "scripts" / "chain_epoch_seal.py"
+)
+seal_mod = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(seal_mod)  # type: ignore[union-attr]
+seal_ledger = seal_mod.seal_ledger
+
+
+def _write_unchained(path: Path, n: int, start: int = 0) -> None:
+    for i in range(start, start + n):
+        with path.open("a") as f:
+            f.write(json.dumps({"seq": i, "old": True}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# The bypass is closed
+# ---------------------------------------------------------------------------
+
+
+def test_bypass_closed_truncate_and_reseal_is_broken(tmp_path):
+    """Build a sealed ledger, record its anchor, then truncate-and-reseal it:
+    strip the original unchained prefix + original epoch marker, keep only the
+    tail chained entries' bodies, and re-chain them under a FRESH GENESIS-
+    rooted marker. This is exactly the ADR-029 threat-model bypass: before
+    ADR-033, `verify_chain` returns `verified-segmented` (valid) for this.
+    After the anchor, it must return `broken`.
+    """
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 3)                    # epoch-0 unchained prefix (lines 1-3)
+    res = seal_ledger(p)                      # seals epoch 1 (line 4) + pins the anchor
+    assert res["action"] == "sealed"
+    append_chained_entry(p, {"seq": 3, "payload": "legit-a"})   # line 5
+    append_chained_entry(p, {"seq": 4, "payload": "legit-b"})   # line 6
+
+    ok, _v, status = verify_chain(p)
+    assert ok is True and status == "verified-segmented"       # sanity: legit ledger passes
+
+    anchor = chain_origin_anchor.read_origin_anchor(p)
+    assert anchor is not None
+    assert anchor["origin_line_number"] == 4
+    assert anchor["origin_type"] == "epoch_marker"
+
+    # --- Attack: strip lines 1-4 (prefix + original marker), keep the tail
+    # entries' bodies, re-chain them from a brand-new GENESIS-rooted marker.
+    tail_bodies = []
+    for line in p.read_text().splitlines()[4:]:
+        body = json.loads(line)
+        body.pop("prev_hash", None)
+        tail_bodies.append(body)
+
+    p.write_text("")  # truncate the ledger
+    append_epoch_marker(p, 1)                 # fresh marker, prev_hash=GENESIS, now at line 1
+    for body in tail_bodies:
+        append_chained_entry(p, body)
+
+    ok2, violations2, status2 = verify_chain(p)
+    assert ok2 is False
+    assert status2 == "broken"
+    assert any("anchor" in str(v.get("note", "")) for v in violations2)
+
+
+def test_moved_epoch_boundary_same_content_is_broken(tmp_path):
+    """A subtler variant: the attacker removes exactly ONE prefix line before
+    the original marker. The marker's own content (and hence hash) is
+    byte-identical, but it now lives at a different line number. The pinned
+    anchor must catch the shifted boundary even though the hash matches.
+    """
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 3)
+    seal_ledger(p)  # marker at line 4, anchor pinned there
+    append_chained_entry(p, {"seq": 3})
+
+    anchor = chain_origin_anchor.read_origin_anchor(p)
+    assert anchor["origin_line_number"] == 4
+
+    lines = p.read_text().splitlines()
+    # Drop the first unchained prefix line (index 0) only; marker + tail intact.
+    new_lines = lines[1:]
+    p.write_text("\n".join(new_lines) + "\n")
+
+    # The marker line itself is untouched content-wise, but it's now line 3.
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert any("anchor" in str(v.get("note", "")) for v in violations)
+
+
+# ---------------------------------------------------------------------------
+# Legitimate seal + matching anchor stays healthy
+# ---------------------------------------------------------------------------
+
+
+def test_legitimate_seal_with_matching_anchor_is_verified_segmented(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 2)
+    seal_ledger(p)
+    append_chained_entry(p, {"seq": 2})
+    append_chained_entry(p, {"seq": 3})
+
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert violations == []
+    assert status == "verified-segmented"
+
+
+def test_legitimate_second_epoch_keeps_original_anchor_and_still_verifies(tmp_path):
+    """A second, immediately-chained epoch (no unchained gap in between) must
+    NOT move the pinned anchor — it stays pinned to the very first sealed
+    origin — and the ledger stays healthy."""
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 1)
+    seal_ledger(p)                              # epoch 1, anchor pinned at its marker (line 2)
+    append_chained_entry(p, {"seq": 1})
+    anchor_after_first_seal = chain_origin_anchor.read_origin_anchor(p)
+    assert anchor_after_first_seal["origin_line_number"] == 2
+
+    append_epoch_marker(p, 2)                    # epoch 2 opens immediately, no gap
+    append_chained_entry(p, {"seq": 2})
+
+    seal_chain_origin(p)                          # idempotent — must stay a no-op
+    anchor_after_second_epoch = chain_origin_anchor.read_origin_anchor(p)
+    assert anchor_after_second_epoch == anchor_after_first_seal   # untouched
+
+    ok, violations, status = verify_chain(p)
+    assert ok is True
+    assert violations == []
+    assert status == "verified-segmented"
+
+
+def test_marker_less_genesis_chain_anchors_first_entry(tmp_path):
+    """A ledger chained directly from GENESIS with no epoch marker at all
+    ('verified') anchors to its first entry, not a marker."""
+    p = tmp_path / "ledger.ndjson"
+    append_chained_entry(p, {"seq": 0})
+    append_chained_entry(p, {"seq": 1})
+
+    anchor = seal_chain_origin(p)
+    assert anchor is not None
+    assert anchor["origin_type"] == "genesis_entry"
+    assert anchor["origin_line_number"] == 1
+
+    ok, _v, status = verify_chain(p)
+    assert ok is True and status == "verified"
+
+    # Tamper: strip the first entry's prev_hash-bearing status by removing it
+    # and re-anchoring the remainder from a fresh GENESIS link.
+    lines = p.read_text().splitlines()
+    second = json.loads(lines[1])
+    second_body = {k: v for k, v in second.items() if k != "prev_hash"}
+    p.write_text("")
+    append_chained_entry(p, second_body)  # now chains from GENESIS at line 1 again
+
+    ok2, violations2, status2 = verify_chain(p)
+    assert ok2 is False
+    assert status2 == "broken"
+    assert any("anchor" in str(v.get("note", "")) for v in violations2)
+
+
+# ---------------------------------------------------------------------------
+# No anchor present -> byte-for-byte unchanged (regression guard)
+# ---------------------------------------------------------------------------
+
+
+def test_no_anchor_present_matches_unanchored_verifier(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 2)
+    append_epoch_marker(p, 1)
+    append_chained_entry(p, {"seq": 2})
+    append_chained_entry(p, {"seq": 3})
+
+    assert chain_origin_anchor.read_origin_anchor(p) is None  # never sealed via seal_ledger
+
+    anchored = verify_chain(p)
+    unanchored = _verify_chain_unanchored(p)
+    assert anchored == unanchored
+
+
+def test_no_anchor_present_tampered_ledger_still_broken_same_as_before(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    append_chained_entry(p, {"seq": 0})
+    append_chained_entry(p, {"seq": 1})
+    append_chained_entry(p, {"seq": 2})
+    lines = p.read_text().splitlines()
+    tampered = json.loads(lines[1])
+    tampered["seq"] = 99
+    lines[1] = json.dumps(tampered)
+    p.write_text("\n".join(lines) + "\n")
+
+    assert chain_origin_anchor.read_origin_anchor(p) is None
+    assert verify_chain(p) == _verify_chain_unanchored(p)
+    ok, _v, status = verify_chain(p)
+    assert ok is False and status == "broken"
+
+
+# ---------------------------------------------------------------------------
+# First-seal bootstrap writes the anchor exactly once; idempotent, append-only
+# ---------------------------------------------------------------------------
+
+
+def test_first_seal_writes_anchor_once_second_seal_is_noop(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 2)
+
+    first = seal_ledger(p)
+    assert first["action"] == "sealed"
+    anchor_file = chain_origin_anchor.anchor_path(p)
+    assert anchor_file.exists()
+    lines_after_first = anchor_file.read_text().splitlines()
+    assert len(lines_after_first) == 1
+
+    second = seal_ledger(p)
+    assert second["action"] == "noop"
+    lines_after_second = anchor_file.read_text().splitlines()
+    assert lines_after_second == lines_after_first  # nothing appended, byte-identical
+
+
+def test_write_origin_anchor_if_absent_is_truly_write_once(tmp_path):
+    """Direct unit test on the anchor primitive: a second call with a
+    DIFFERENT origin for the same ledger must NOT overwrite the first."""
+    p = tmp_path / "ledger.ndjson"
+    origin_a = {"origin_type": "epoch_marker", "origin_hash": "a" * 64, "origin_line_number": 4, "origin_epoch": 1}
+    origin_b = {"origin_type": "epoch_marker", "origin_hash": "b" * 64, "origin_line_number": 9, "origin_epoch": 2}
+
+    first = chain_origin_anchor.write_origin_anchor_if_absent(p, origin_a)
+    assert first["origin_hash"] == "a" * 64
+
+    second = chain_origin_anchor.write_origin_anchor_if_absent(p, origin_b)
+    assert second["origin_hash"] == "a" * 64  # unchanged — origin_b never wins
+
+    anchor_file = chain_origin_anchor.anchor_path(p)
+    lines = anchor_file.read_text().splitlines()
+    assert len(lines) == 1  # exactly one record ever, append-only
+
+
+def test_anchor_path_is_sibling_file(tmp_path):
+    p = tmp_path / "state" / "t0_receipts.ndjson"
+    anchor_file = chain_origin_anchor.anchor_path(p)
+    assert anchor_file.parent == p.parent
+    assert anchor_file.name == "t0_receipts.ndjson.origin_anchor.ndjson"
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed behavior
+# ---------------------------------------------------------------------------
+
+
+def test_corrupt_anchor_file_fails_closed(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 2)
+    seal_ledger(p)
+    append_chained_entry(p, {"seq": 2})
+
+    ok, _v, status = verify_chain(p)
+    assert ok is True and status == "verified-segmented"  # sane before corruption
+
+    anchor_file = chain_origin_anchor.anchor_path(p)
+    anchor_file.write_text("{not valid json at all\n")
+
+    assert chain_origin_anchor.read_origin_anchor(p) == {"_corrupt": True}
+
+    ok2, violations2, status2 = verify_chain(p)
+    assert ok2 is False
+    assert status2 == "broken"
+    assert any("corrupt" in str(v.get("note", "")) for v in violations2)
+
+
+def test_anchor_pinned_but_ledger_erased_to_unchained_is_broken(tmp_path):
+    """If the entire ledger is wiped back to a plain unchained state while an
+    anchor from a prior seal still exists, that is history erasure and must
+    be reported broken, not silently accepted as 'chaining not yet enabled'."""
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 2)
+    seal_ledger(p)
+    append_chained_entry(p, {"seq": 2})
+
+    assert chain_origin_anchor.read_origin_anchor(p) is not None
+
+    p.write_text(json.dumps({"seq": 0, "wiped": True}) + "\n")  # plain, no prev_hash anywhere
+
+    ok, violations, status = verify_chain(p)
+    assert ok is False
+    assert status == "broken"
+    assert any("anchor" in str(v.get("note", "")) for v in violations)
+
+
+def test_seal_chain_origin_noop_on_unchained_ledger(tmp_path):
+    p = tmp_path / "ledger.ndjson"
+    _write_unchained(p, 3)  # no marker, no chaining at all yet
+    assert seal_chain_origin(p) is None
+    assert chain_origin_anchor.read_origin_anchor(p) is None
+
+
+def test_seal_chain_origin_noop_on_empty_or_absent_ledger(tmp_path):
+    p = tmp_path / "absent.ndjson"
+    assert seal_chain_origin(p) is None
+    p.touch()
+    assert seal_chain_origin(p) is None


### PR DESCRIPTION
## Summary
- Adds `scripts/lib/chain_origin_anchor.py`: a sibling append-only NDJSON anchor file, written once at seal time by `chain_epoch_seal.seal_ledger`, that pins a ledger's earliest `chain_epoch_start` marker (or first genesis entry).
- `verify_chain` now enforces the pinned origin when one exists: a truncate-and-reseal or a moved epoch boundary now verifies `broken` instead of `verified-segmented`. With no anchor present, behavior is byte-for-byte identical to pre-ADR-033.
- Closes the ADR-029 accepted-residual prefix-strip bypass (the finding that HELD PR #1085/#1086). Supersedes PR #1086's DB-backed approach — see ADR-033 for why (four `codex_gate` rounds of defects: mutable origin, non-atomic write, fail-open on error, no audit trail).
- `VNX_CHAIN_RECEIPTS` stays default-off — this hardens `verify_chain`'s read path ahead of a future flip, no behavior flip in this PR.

## Test plan
- [x] `pytest tests/test_chain_origin_anchor.py -v` — 14/14 passed (bypass-closed, moved-boundary, legit-seal, second-epoch-stability, genesis-anchor, no-anchor-regression, write-once idempotency, fail-closed-on-corruption, erased-ledger-detection)
- [x] `pytest tests/test_chain_origin_anchor.py tests/test_ndjson_hash_chain.py tests/test_chain_epoch_seal.py tests/test_governance_effectiveness_probe.py tests/test_fabric_audit.py tests/test_attest_override.py tests/test_receipt_hashchain.py tests/test_plan_gate_effectiveness_probe.py tests/test_attestation.py` — 144/144 passed (all `verify_chain` callers, no regressions)
- [x] `python3 -m py_compile` on all three changed/added modules

🤖 Generated with [Claude Code](https://claude.com/claude-code)