### PR TITLE
fix(t0-startup-import): make t0-orchestrator skill body reach T0 despite disable-model-invocation

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -73,6 +73,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/hooks/sessionstart.sh\"'",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/.claude/skills/featureplan-kickoff/SKILL.md
+++ b/.claude/skills/featureplan-kickoff/SKILL.md
@@ -46,7 +46,9 @@ You are not responsible for:
 3. Use CLI and state verification; do not guess queue or dispatch state.
 4. Do not promote more than one new dispatch during kickoff.
 5. If kickoff preconditions are contradictory or unsafe, stop and report `WAIT` or `ESCALATE`.
-6. When kickoff succeeds, explicitly tell the operator or T0 to load `@t0-orchestrator` next.
+6. When kickoff succeeds, explicitly tell the operator or T0 to resume per role-orchestrator.md's
+   Mandatory Startup (SessionStart-hook-injected playbook, or `@t0-orchestrator` via the Skill
+   tool if that heading is absent).
 
 ## 2.1 Feature Plan Field Conventions
 
@@ -194,7 +196,7 @@ Return a concise kickoff summary containing:
 
 Then explicitly hand off:
 
-`Kickoff complete. Load @t0-orchestrator and continue normal orchestration from the current queue state.`
+`Kickoff complete. Resume orchestration per role-orchestrator.md's Mandatory Startup (SessionStart-hook-injected playbook, or invoke @t0-orchestrator via the Skill tool if that heading is absent) and continue from the current queue state.`
 
 ## 5. Failure Modes
 

--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -11,9 +11,18 @@
 @role-orchestrator.md
 
 <!--
-  Skill body imported passively because the skill is intentionally not
-  model-invocable (A-4, disable-model-invocation: true). Content-in-context
-  replaces the old `load @t0-orchestrator` Skill-tool call.
+  t0-orchestrator's SKILL.md body is intentionally NOT `@`-imported here.
+  It's not model-invocable (A-4, disable-model-invocation: true), so an
+  import used to sit on this line as a passive delivery path — but a
+  `@`-import of a file outside this directory tree (.claude/skills/... is a
+  sibling, not a descendant, of .claude/terminals/T0/) is classified by
+  Claude Code as an "external CLAUDE.md file import" and blocks session
+  start on an interactive trust prompt. A fresh autonomous T0 spawn has no
+  human to answer that prompt and just hangs (F1, 2026-07-16 live smoke
+  test). The playbook body now reaches T0 via the SessionStart hook instead
+  (`hooks/sessionstart.sh`, deployed fleet-wide as
+  `.claude/hooks/sessionstart.sh` by `vnx init`/`bootstrap_hooks`), which
+  injects it as additionalContext before the first prompt — no import, no
+  Skill-tool call, no prompt. See role-orchestrator.md's "Mandatory Startup".
 -->
 
-@../../skills/t0-orchestrator/SKILL.md

--- a/.claude/terminals/T0/CLAUDE.md
+++ b/.claude/terminals/T0/CLAUDE.md
@@ -9,3 +9,11 @@
 -->
 
 @role-orchestrator.md
+
+<!--
+  Skill body imported passively because the skill is intentionally not
+  model-invocable (A-4, disable-model-invocation: true). Content-in-context
+  replaces the old `load @t0-orchestrator` Skill-tool call.
+-->
+
+@../../skills/t0-orchestrator/SKILL.md

--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -5,8 +5,15 @@ You are the BRAIN, not the HANDS.
 
 ## Mandatory Startup
 
-Before any orchestration action, load `@t0-orchestrator`.
-Do not run orchestration from memory; follow the skill workflow.
+The `t0-orchestrator` skill playbook governs all orchestration decisions — never orchestrate
+from memory. Its content reaches your context one of two ways, in order:
+
+1. **In context already** — your terminal `CLAUDE.md` imports the playbook body directly
+   (`@../../skills/t0-orchestrator/SKILL.md`). If you can see a `# T0 Orchestrator` heading
+   above, this is already satisfied; proceed.
+2. **Not in context** — invoke `@t0-orchestrator` via the Skill tool. If that call returns
+   `Unknown skill` or the skill is not model-invocable, STOP: do not orchestrate from memory.
+   Report role↔skill drift and run `bash scripts/commands/t0_role_audit.sh` to confirm.
 
 ### Autonomous Execution
 
@@ -69,7 +76,7 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 
 ## Crash Recovery (on-demand only)
 
-Follow the full procedure in `@t0-orchestrator` §7 (Startup / recovery / runbooks), which points to `docs/core/DISPATCH_RULES.md` §10.
+Follow the full procedure in the t0-orchestrator playbook §7 (Startup / recovery / runbooks), which points to `docs/core/DISPATCH_RULES.md` §10.
 Quick reference: validate schema → repair stale leases → reconcile queue → check orphaned dispatches → check incidents.
 
 ## Role-File Load Check (fleet drift)

--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -6,14 +6,19 @@ You are the BRAIN, not the HANDS.
 ## Mandatory Startup
 
 The `t0-orchestrator` skill playbook governs all orchestration decisions — never orchestrate
-from memory. Its content reaches your context one of two ways, in order:
+from memory. Its content reaches your context one of two ways:
 
-1. **In context already** — your terminal `CLAUDE.md` imports the playbook body directly
-   (`@../../skills/t0-orchestrator/SKILL.md`). If you can see a `# T0 Orchestrator` heading
-   above, this is already satisfied; proceed.
-2. **Not in context** — invoke `@t0-orchestrator` via the Skill tool. If that call returns
-   `Unknown skill` or the skill is not model-invocable, STOP: do not orchestrate from memory.
-   Report role↔skill drift and run `bash scripts/commands/t0_role_audit.sh` to confirm.
+1. **SessionStart hook injection (primary)** — the project's SessionStart hook
+   (`hooks/sessionstart.sh`, deployed fleet-wide as `.claude/hooks/sessionstart.sh` by
+   `vnx init`/`bootstrap_hooks`) reads `.claude/skills/t0-orchestrator/SKILL.md` and injects its
+   body as `additionalContext` for T0 sessions before you see the first prompt — no `@`-import,
+   no Skill-tool call, no interactive trust prompt. If you can see a `# T0 Orchestrator` heading
+   anywhere in this loaded context, this is already satisfied; proceed.
+2. **Skill-tool invocation (fallback)** — if that heading is absent (e.g. this project's
+   SessionStart hook hasn't been synced/wired yet), invoke `@t0-orchestrator` via the Skill
+   tool. If that call returns `Unknown skill` or the skill is not model-invocable, STOP: do not
+   orchestrate from memory. Report role↔skill drift and run
+   `bash scripts/commands/t0_role_audit.sh` to confirm.
 
 ### Autonomous Execution
 

--- a/bin/vnx
+++ b/bin/vnx
@@ -1499,11 +1499,17 @@ cmd_role_sync() {
   # Warn (do not block) when the shipped role's Mandatory Startup step has
   # neither an in-context path nor an invocable fallback for the
   # t0-orchestrator skill in the TARGET project: CLAUDE.md doesn't import its
-  # SKILL.md, and SKILL.md is either missing or carries
-  # `disable-model-invocation: true`. Grep-level only — the full
-  # IMPORT-MISSING / SKILL-UNLOADABLE check lives in
+  # SKILL.md, its SessionStart hook doesn't inject it either, and SKILL.md is
+  # either missing or carries `disable-model-invocation: true`. Grep-level
+  # only — the full IMPORT-MISSING / SKILL-UNLOADABLE check lives in
   # scripts/commands/t0_role_audit.sh --static (F1: this exact gap left
   # t0-orchestrator unloadable in this repo's own fabric source for ~7 weeks).
+  #
+  # The awk frontmatter check is anchored on the key's own line-start (no
+  # leading whitespace — real top-level frontmatter keys never have any) and
+  # skips comment lines: unanchored, a `description:` field merely MENTIONING
+  # the string `disable-model-invocation: true` false-positived here too
+  # (finding 3, codex, 2026-07-16 — same bug as t0_role_audit.sh's check).
   local t0_skill_md="$target_root/.claude/skills/t0-orchestrator/SKILL.md"
   local t0_skill_imported=0
   if [ -f "$project_t0_dir/CLAUDE.md" ] && grep -q "skills/t0-orchestrator/SKILL.md" "$project_t0_dir/CLAUDE.md" 2>/dev/null; then
@@ -1513,11 +1519,24 @@ cmd_role_sync() {
     local t0_skill_invocable=1
     if [ ! -f "$t0_skill_md" ]; then
       t0_skill_invocable=0
-    elif awk '/^---[ \t]*$/{n++; if(n==2) exit} n==1 && /disable-model-invocation:[ \t]*true/{f=1} END{exit(f?0:1)}' "$t0_skill_md" 2>/dev/null; then
+    elif awk '
+      /^---[ \t]*$/{n++; if(n==2) exit}
+      n==1 && /^[ \t]*#/{next}
+      n==1 && /^disable-model-invocation:[ \t]*true([ \t]|$)/{f=1}
+      END{exit(f?0:1)}
+    ' "$t0_skill_md" 2>/dev/null; then
       t0_skill_invocable=0
     fi
-    if [ "$t0_skill_invocable" -eq 0 ]; then
-      log "[role-sync] NOTE: $target_root does not import the t0-orchestrator skill body into $project_t0_dir/CLAUDE.md, and its SKILL.md is missing or not model-invocable."
+    local t0_skill_hook_injected=0
+    local hook_candidate
+    for hook_candidate in "$target_root/.claude/hooks/sessionstart.sh" "$target_root/hooks/sessionstart.sh"; do
+      if [ -f "$hook_candidate" ] && grep -q "skills/t0-orchestrator/SKILL.md" "$hook_candidate" 2>/dev/null; then
+        t0_skill_hook_injected=1
+        break
+      fi
+    done
+    if [ "$t0_skill_invocable" -eq 0 ] && [ "$t0_skill_hook_injected" -eq 0 ]; then
+      log "[role-sync] NOTE: $target_root does not import the t0-orchestrator skill body into $project_t0_dir/CLAUDE.md (nor does its SessionStart hook inject it), and its SKILL.md is missing or not model-invocable."
       log "[role-sync]       Run 'bash scripts/commands/t0_role_audit.sh --static $target_root' for detail; the shipped role's Mandatory Startup step will stall on Skill-tool invocation."
     fi
   fi

--- a/bin/vnx
+++ b/bin/vnx
@@ -1539,29 +1539,43 @@ cmd_role_sync() {
     # duplicated here deliberately — this command does not source
     # t0_role_audit.sh.
     local t0_skill_hook_injected=0
-    local hook_candidate hook_settings hook_base
+    local hook_candidate hook_settings hook_needle
     for hook_candidate in "$target_root/.claude/hooks/sessionstart.sh" "$target_root/hooks/sessionstart.sh"; do
+      # A wired hook whose TEXT references the skill path is not proof the
+      # skill actually exists -- gate on SKILL.md's own existence first, same
+      # as the static audit already does (finding 4, 2026-07-16 r4).
+      [ -f "$t0_skill_md" ] || break
       [ -f "$hook_candidate" ] || continue
       grep -q "skills/t0-orchestrator/SKILL.md" "$hook_candidate" 2>/dev/null || continue
-      hook_base="$(basename "$hook_candidate")"
+      # Basename alone is too loose -- an unrelated script that merely SHARES
+      # the name "sessionstart.sh" at a different path would false-match.
+      # Use the last two path segments instead (finding 2, 2026-07-16 r4).
+      hook_needle="$(basename "$(dirname "$hook_candidate")")/$(basename "$hook_candidate")"
       hook_settings="$target_root/.claude/settings.json"
       [ -f "$hook_settings" ] || hook_settings="$target_root/templates/settings_vnx_keys.json.tmpl"
-      if [ -f "$hook_settings" ] && awk -v needle="$hook_base" '
+      # The line that first matches "SessionStart": is itself scanned for the
+      # needle too (via scan()) -- a minified single-line settings.json
+      # otherwise false-negatives (finding 3, 2026-07-16 r4).
+      if [ -f "$hook_settings" ] && awk -v needle="$hook_needle" '
+        function scan(line,    idx) {
+          idx = index(line, "#")
+          if (idx > 0) line = substr(line, 1, idx - 1)
+          if (index(line, needle) > 0) { found = 1 }
+        }
         !in_block && /"SessionStart"[ \t]*:/ {
           in_block = 1
           o = gsub(/\[/, "[")
           c = gsub(/\]/, "]")
           depth = o - c
+          scan($0)
+          if (depth <= 0) { in_block = 0 }
           next
         }
         in_block {
-          line = $0
           o = gsub(/\[/, "[")
           c = gsub(/\]/, "]")
           depth += (o - c)
-          idx = index(line, "#")
-          if (idx > 0) line = substr(line, 1, idx - 1)
-          if (index(line, needle) > 0) { found = 1 }
+          scan($0)
           if (depth <= 0) { in_block = 0 }
         }
         END { exit(found ? 0 : 1) }

--- a/bin/vnx
+++ b/bin/vnx
@@ -1527,16 +1527,51 @@ cmd_role_sync() {
     ' "$t0_skill_md" 2>/dev/null; then
       t0_skill_invocable=0
     fi
+    # A hook script existing and correctly referencing the skill is not
+    # proof it actually runs — Claude Code only fires hooks registered in
+    # .claude/settings.json's "hooks.SessionStart" array. Without also
+    # checking that wiring, this NOTE stayed silent on exactly the gap
+    # finding 1 (codex round 2, 2026-07-16) found in this repo's own fabric
+    # source: hooks/sessionstart.sh correctly injects the skill body, but
+    # .claude/settings.json's SessionStart config never calls it. Same
+    # bracket-depth-tracked awk scan as t0_role_audit.sh's
+    # _t0_static_settings_json_wires_hook (see that file for full comments);
+    # duplicated here deliberately — this command does not source
+    # t0_role_audit.sh.
     local t0_skill_hook_injected=0
-    local hook_candidate
+    local hook_candidate hook_settings hook_base
     for hook_candidate in "$target_root/.claude/hooks/sessionstart.sh" "$target_root/hooks/sessionstart.sh"; do
-      if [ -f "$hook_candidate" ] && grep -q "skills/t0-orchestrator/SKILL.md" "$hook_candidate" 2>/dev/null; then
+      [ -f "$hook_candidate" ] || continue
+      grep -q "skills/t0-orchestrator/SKILL.md" "$hook_candidate" 2>/dev/null || continue
+      hook_base="$(basename "$hook_candidate")"
+      hook_settings="$target_root/.claude/settings.json"
+      [ -f "$hook_settings" ] || hook_settings="$target_root/templates/settings_vnx_keys.json.tmpl"
+      if [ -f "$hook_settings" ] && awk -v needle="$hook_base" '
+        !in_block && /"SessionStart"[ \t]*:/ {
+          in_block = 1
+          o = gsub(/\[/, "[")
+          c = gsub(/\]/, "]")
+          depth = o - c
+          next
+        }
+        in_block {
+          line = $0
+          o = gsub(/\[/, "[")
+          c = gsub(/\]/, "]")
+          depth += (o - c)
+          idx = index(line, "#")
+          if (idx > 0) line = substr(line, 1, idx - 1)
+          if (index(line, needle) > 0) { found = 1 }
+          if (depth <= 0) { in_block = 0 }
+        }
+        END { exit(found ? 0 : 1) }
+      ' "$hook_settings" 2>/dev/null; then
         t0_skill_hook_injected=1
         break
       fi
     done
     if [ "$t0_skill_invocable" -eq 0 ] && [ "$t0_skill_hook_injected" -eq 0 ]; then
-      log "[role-sync] NOTE: $target_root does not import the t0-orchestrator skill body into $project_t0_dir/CLAUDE.md (nor does its SessionStart hook inject it), and its SKILL.md is missing or not model-invocable."
+      log "[role-sync] NOTE: $target_root does not import the t0-orchestrator skill body into $project_t0_dir/CLAUDE.md, and its SKILL.md is missing or not model-invocable. Its SessionStart hook script either doesn't inject the skill, or isn't actually wired into .claude/settings.json's SessionStart config."
       log "[role-sync]       Run 'bash scripts/commands/t0_role_audit.sh --static $target_root' for detail; the shipped role's Mandatory Startup step will stall on Skill-tool invocation."
     fi
   fi

--- a/bin/vnx
+++ b/bin/vnx
@@ -1496,6 +1496,32 @@ cmd_role_sync() {
     log "[role-sync]       Convert it to a thin '@role-orchestrator.md' + project-context to activate this."
   fi
 
+  # Warn (do not block) when the shipped role's Mandatory Startup step has
+  # neither an in-context path nor an invocable fallback for the
+  # t0-orchestrator skill in the TARGET project: CLAUDE.md doesn't import its
+  # SKILL.md, and SKILL.md is either missing or carries
+  # `disable-model-invocation: true`. Grep-level only — the full
+  # IMPORT-MISSING / SKILL-UNLOADABLE check lives in
+  # scripts/commands/t0_role_audit.sh --static (F1: this exact gap left
+  # t0-orchestrator unloadable in this repo's own fabric source for ~7 weeks).
+  local t0_skill_md="$target_root/.claude/skills/t0-orchestrator/SKILL.md"
+  local t0_skill_imported=0
+  if [ -f "$project_t0_dir/CLAUDE.md" ] && grep -q "skills/t0-orchestrator/SKILL.md" "$project_t0_dir/CLAUDE.md" 2>/dev/null; then
+    t0_skill_imported=1
+  fi
+  if [ "$t0_skill_imported" -eq 0 ]; then
+    local t0_skill_invocable=1
+    if [ ! -f "$t0_skill_md" ]; then
+      t0_skill_invocable=0
+    elif awk '/^---[ \t]*$/{n++; if(n==2) exit} n==1 && /disable-model-invocation:[ \t]*true/{f=1} END{exit(f?0:1)}' "$t0_skill_md" 2>/dev/null; then
+      t0_skill_invocable=0
+    fi
+    if [ "$t0_skill_invocable" -eq 0 ]; then
+      log "[role-sync] NOTE: $target_root does not import the t0-orchestrator skill body into $project_t0_dir/CLAUDE.md, and its SKILL.md is missing or not model-invocable."
+      log "[role-sync]       Run 'bash scripts/commands/t0_role_audit.sh --static $target_root' for detail; the shipped role's Mandatory Startup step will stall on Skill-tool invocation."
+    fi
+  fi
+
   # Provider-agnostic (anti-lock-in): mirror the canonical role into a marked
   # block in AGENTS.md (Codex) and GEMINI.md (Gemini/Kimi), sitting alongside
   # role-orchestrator.md in the T0 dir. Reuses the same insert-or-replace

--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -53,14 +53,16 @@ if [ -n "${CLAUDE_TRACK:-}" ]; then
   TRACK="$CLAUDE_TRACK"
 fi
 
-# ── Resolve project name from directory structure ────────────────────
+# ── Resolve project root from directory structure ────────────────────
 # Walk up from terminal dir to find project root
 PROJECT_NAME=""
+PROJECT_ROOT=""
 CURRENT_DIR="$PWD"
 for _ in 1 2 3 4 5; do
   PARENT="$(dirname "$CURRENT_DIR")"
   if [ -f "$PARENT/.vnx/config.yml" ] || [ -d "$PARENT/.vnx" ]; then
     PROJECT_NAME="$(basename "$PARENT")"
+    PROJECT_ROOT="$PARENT"
     break
   fi
   CURRENT_DIR="$PARENT"
@@ -114,6 +116,27 @@ case "$TERMINAL" in
       fi
     fi
 
+    # ── T0 Orchestrator playbook body (in-context injection) ────────────
+    # t0-orchestrator is intentionally not model-invocable
+    # (disable-model-invocation: true, A-4 hardening), so its content has to
+    # reach T0 some other way. A CLAUDE.md `@`-import of the skill body
+    # works for a git-tracked project file but trips Claude Code's
+    # external-CLAUDE.md-import trust prompt on a fresh autonomous spawn (F1,
+    # 2026-07-16 live smoke test) — nobody is there to answer that prompt, so
+    # the session just hangs. Reading the body here instead and returning it
+    # as hook additionalContext reaches the same content without any import
+    # or Skill-tool call, and without ever triggering that prompt. Fail-soft:
+    # an absent SKILL.md just means an unchanged (shorter) context, not a
+    # hook error — and each hook run recomputes this fresh from disk, so
+    # nothing accumulates across repeated SessionStart fires (/clear, etc).
+    T0_SKILL_BODY=""
+    if [ -n "$PROJECT_ROOT" ]; then
+      _T0_SKILL_MD="$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md"
+      if [ -f "$_T0_SKILL_MD" ]; then
+        T0_SKILL_BODY="$(cat "$_T0_SKILL_MD" 2>/dev/null || true)"
+      fi
+    fi
+
     ADDITIONAL_CONTEXT="T0 Master Orchestrator Active${PROJECT_NAME:+ — $PROJECT_NAME}
 Available skills: @t0-orchestrator @architect @planner
 Use /t0-orchestrator for orchestration decisions and receipt processing
@@ -123,7 +146,10 @@ $(echo -e "${T0_TERMINAL_STATES:-No terminal state data}")
 ${T0_OPEN_ITEMS:-No open items data}
 
 CRITICAL: After every completion receipt, check quality advisory + open items before proceeding.
-Skills must NOT use @ prefix in Role field. Check .vnx/skills/skills.yaml for valid skills."
+Skills must NOT use @ prefix in Role field. Check .vnx/skills/skills.yaml for valid skills.${T0_SKILL_BODY:+
+
+---
+$T0_SKILL_BODY}"
     ;;
 
   T1)

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -55,12 +55,36 @@ _t0_static_resolve_import() {
 # Naive frontmatter check: does the FIRST `---`...`---` block contain the
 # literal line `disable-model-invocation: true`? This is deliberately not a
 # YAML parser — it must never grow into one.
+#
+# Anchored on the key's own line-start (no leading whitespace — real
+# top-level frontmatter keys never have any) and skips comment lines. Without
+# the anchor, a `description:` field or comment that merely MENTIONS the
+# string `disable-model-invocation: true` (e.g. documenting the flag) false-
+# positived as SKILL-UNLOADABLE (finding 3, codex, 2026-07-16).
 _t0_static_frontmatter_disables_invocation() {
   awk '
     /^---[ \t]*$/ { n++; if (n == 2) exit }
-    n == 1 && /disable-model-invocation:[ \t]*true/ { found = 1 }
+    n == 1 && /^[ \t]*#/ { next }
+    n == 1 && /^disable-model-invocation:[ \t]*true([ \t]|$)/ { found = 1 }
     END { exit(found ? 0 : 1) }
   ' "$1"
+}
+
+# Does this project's SessionStart hook (the Claude-Code-only mechanism —
+# see hooks/sessionstart.sh and role-orchestrator.md's "Mandatory Startup")
+# inject a given skill's SKILL.md body into T0 context? Checked by literal
+# path reference, not execution — deliberately static, matching this
+# script's "never grow into a real parser/interpreter" discipline. Checks
+# the deployed consumer copy first, then the fabric-source template (the
+# shape this very repo's own checkout has, since it never runs `vnx init`
+# on itself).
+_t0_static_hook_injects_skill() {
+  local root="$1" skill_name="$2" hook
+  for hook in "$root/.claude/hooks/sessionstart.sh" "$root/hooks/sessionstart.sh"; do
+    [ -f "$hook" ] || continue
+    grep -q "skills/$skill_name/SKILL.md" "$hook" 2>/dev/null && return 0
+  done
+  return 1
 }
 
 # Static role<->skill invocability check for one project root. Prints one
@@ -72,9 +96,17 @@ _t0_static_frontmatter_disables_invocation() {
 #                        not exist.
 #   SKILL-UNLOADABLE  — a backtick-quoted `@<skill>` reference in
 #                        role-orchestrator.md names a skill that is neither
-#                        in-context (imported by CLAUDE.md) nor
-#                        model-invocable (SKILL.md missing, or present with
-#                        `disable-model-invocation: true` and not imported).
+#                        in-context (imported by CLAUDE.md, or injected by the
+#                        SessionStart hook) nor model-invocable (SKILL.md
+#                        missing, or present with `disable-model-invocation:
+#                        true` and not otherwise in-context).
+#   PLAYBOOK-MECHANISM-GAP — AGENTS.md/GEMINI.md (the codex/gemini T0
+#                        surfaces `vnx role sync` mirrors the role into) carry
+#                        the role text, but neither provider has a
+#                        SessionStart-hook equivalent to deliver the
+#                        playbook body in-context there. A tracked, reported
+#                        gap (finding 2, codex, 2026-07-16) — not silently
+#                        clean, but not required to block on today.
 _t0_static_check() {
   local root="$1"
   local t0_dir="$root/.claude/terminals/T0"
@@ -121,12 +153,32 @@ _t0_static_check() {
         *"|$skill_md_real"*) continue ;;  # in-context via CLAUDE.md import; invocability irrelevant
       esac
 
+      if _t0_static_hook_injects_skill "$root" "$skill_name"; then
+        continue  # in-context via SessionStart hook injection; invocability irrelevant
+      fi
+
       if _t0_static_frontmatter_disables_invocation "$skill_md"; then
-        echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' — not imported by CLAUDE.md and disable-model-invocation: true in $skill_md"
+        echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' — not imported by CLAUDE.md, not hook-injected, and disable-model-invocation: true in $skill_md"
         findings=$((findings + 1))
       fi
     done < <(grep -oE '`@[a-zA-Z0-9_-]+`' "$role_md" 2>/dev/null | tr -d '`@' | sort -u)
   fi
+
+  # Tri-file surfaces: `vnx role sync --apply` mirrors the SAME Mandatory
+  # Startup role text into AGENTS.md (codex) and GEMINI.md (gemini), marked
+  # by <!-- VNX:BEGIN T0-ROLE --> ... <!-- VNX:END T0-ROLE -->. A project can
+  # audit clean on CLAUDE.md while its codex/gemini T0 surface carries a
+  # "Mandatory Startup" step with no working delivery mechanism at all —
+  # Claude Code's SessionStart-hook injection has no codex/gemini equivalent
+  # yet. Report it rather than staying silent (finding 2); closing the gap
+  # itself is tracked separately, not enforced here.
+  local provider_file
+  for provider_file in "$t0_dir/AGENTS.md" "$t0_dir/GEMINI.md"; do
+    [ -f "$provider_file" ] || continue
+    grep -q '<!-- VNX:BEGIN T0-ROLE -->' "$provider_file" 2>/dev/null || continue
+    echo "PLAYBOOK-MECHANISM-GAP: $provider_file carries the T0 role but has no SessionStart-hook equivalent to deliver the t0-orchestrator playbook body in-context on this surface (tracked open item, not currently blocking)"
+    findings=$((findings + 1))
+  done
 
   [ "$findings" -eq 0 ]
 }

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -105,22 +105,31 @@ _t0_static_hook_file_references_skill() {
 _t0_static_settings_json_wires_hook() {
   local settings_file="$1" needle="$2"
   [ -f "$settings_file" ] || return 1
+  # The line that first matches "SessionStart": is itself scanned for the
+  # needle too (via the shared scan() helper) -- a minified single-line
+  # settings.json puts the whole SessionStart array (key, brackets, and hook
+  # command) on that one line, and skipping it produced a false negative
+  # (finding 3, 2026-07-16 r4).
   awk -v needle="$needle" '
+    function scan(line,    idx) {
+      idx = index(line, "#")
+      if (idx > 0) line = substr(line, 1, idx - 1)
+      if (index(line, needle) > 0) { found = 1 }
+    }
     !in_block && /"SessionStart"[ \t]*:/ {
       in_block = 1
       o = gsub(/\[/, "[")
       c = gsub(/\]/, "]")
       depth = o - c
+      scan($0)
+      if (depth <= 0) { in_block = 0 }
       next
     }
     in_block {
-      line = $0
       o = gsub(/\[/, "[")
       c = gsub(/\]/, "]")
       depth += (o - c)
-      idx = index(line, "#")
-      if (idx > 0) line = substr(line, 1, idx - 1)
-      if (index(line, needle) > 0) { found = 1 }
+      scan($0)
       if (depth <= 0) { in_block = 0 }
     }
     END { exit(found ? 0 : 1) }
@@ -141,16 +150,20 @@ _t0_static_settings_json_wires_hook() {
 # so a not-yet-live consumer project isn't reported unloadable purely for
 # not having generated its settings.json yet.
 _t0_static_settings_wires_hook() {
-  local root="$1" hook="$2" hook_base settings
-  hook_base="$(basename "$hook")"
+  local root="$1" hook="$2" hook_needle settings
+  # Basename alone is too loose -- an unrelated script that merely SHARES the
+  # name "sessionstart.sh" at a different path would false-match. Use the
+  # last two path segments (dir/file, e.g. "hooks/sessionstart.sh") instead,
+  # so only a reference to the actual hook counts (finding 2, 2026-07-16 r4).
+  hook_needle="$(basename "$(dirname "$hook")")/$(basename "$hook")"
   settings="$root/.claude/settings.json"
   if [ -f "$settings" ]; then
-    _t0_static_settings_json_wires_hook "$settings" "$hook_base"
+    _t0_static_settings_json_wires_hook "$settings" "$hook_needle"
     return $?
   fi
   settings="$root/templates/settings_vnx_keys.json.tmpl"
   [ -f "$settings" ] || return 1
-  _t0_static_settings_json_wires_hook "$settings" "$hook_base"
+  _t0_static_settings_json_wires_hook "$settings" "$hook_needle"
 }
 
 # Full in-context check: a SessionStart hook script references the skill's

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -70,21 +70,97 @@ _t0_static_frontmatter_disables_invocation() {
   ' "$1"
 }
 
-# Does this project's SessionStart hook (the Claude-Code-only mechanism —
-# see hooks/sessionstart.sh and role-orchestrator.md's "Mandatory Startup")
-# inject a given skill's SKILL.md body into T0 context? Checked by literal
-# path reference, not execution — deliberately static, matching this
-# script's "never grow into a real parser/interpreter" discipline. Checks
-# the deployed consumer copy first, then the fabric-source template (the
-# shape this very repo's own checkout has, since it never runs `vnx init`
-# on itself).
-_t0_static_hook_injects_skill() {
+# Does a SessionStart hook script on disk (deployed consumer copy checked
+# first, then the fabric-source template — the shape this very repo's own
+# checkout has, since it never runs `vnx init` on itself) contain a literal
+# reference to a given skill's SKILL.md path? Checked by grep, not
+# execution — deliberately static, matching this script's "never grow into
+# a real parser/interpreter" discipline. Prints the matched hook's path on
+# stdout when found (so the caller can pass it straight to
+# _t0_static_settings_wires_hook without re-deriving it).
+#
+# File-content only — this does NOT prove Claude Code actually runs the
+# hook. See _t0_static_hook_injects_skill for the full check.
+_t0_static_hook_file_references_skill() {
   local root="$1" skill_name="$2" hook
   for hook in "$root/.claude/hooks/sessionstart.sh" "$root/hooks/sessionstart.sh"; do
     [ -f "$hook" ] || continue
-    grep -q "skills/$skill_name/SKILL.md" "$hook" 2>/dev/null && return 0
+    if grep -q "skills/$skill_name/SKILL.md" "$hook" 2>/dev/null; then
+      printf '%s' "$hook"
+      return 0
+    fi
   done
   return 1
+}
+
+# Does <settings_file>'s "hooks.SessionStart" array actually reference
+# $needle (a hook script's basename)? Bracket-depth tracked rather than
+# indentation-anchored, so reformatted JSON doesn't break the block
+# boundary: depth increments on every `[` and decrements on every `]` from
+# the "SessionStart" key's own line onward, and the scan stops the instant
+# depth returns to (or below) zero — i.e. the line that closes the
+# SessionStart array itself. A reference is ignored when it appears only
+# after an unescaped `#` in the command string — a shell comment, not an
+# active invocation (a commented-out hook wire does not count as wired).
+_t0_static_settings_json_wires_hook() {
+  local settings_file="$1" needle="$2"
+  [ -f "$settings_file" ] || return 1
+  awk -v needle="$needle" '
+    !in_block && /"SessionStart"[ \t]*:/ {
+      in_block = 1
+      o = gsub(/\[/, "[")
+      c = gsub(/\]/, "]")
+      depth = o - c
+      next
+    }
+    in_block {
+      line = $0
+      o = gsub(/\[/, "[")
+      c = gsub(/\]/, "]")
+      depth += (o - c)
+      idx = index(line, "#")
+      if (idx > 0) line = substr(line, 1, idx - 1)
+      if (index(line, needle) > 0) { found = 1 }
+      if (depth <= 0) { in_block = 0 }
+    }
+    END { exit(found ? 0 : 1) }
+  ' "$settings_file" 2>/dev/null
+}
+
+# Does this project actually invoke $hook (a SessionStart hook script path
+# already confirmed on disk by the caller) from its SessionStart config?
+# Checks the deployed .claude/settings.json first — the real, live config
+# that decides what Claude Code runs for THIS project, so a hook file's
+# content is never trusted as a proxy for "and it runs" once a settings.json
+# exists (a hook script existing is not proof it fires: finding 1, codex
+# round 2, 2026-07-16 — this repo's own hooks/sessionstart.sh correctly
+# injects the skill body, but .claude/settings.json's SessionStart config
+# never calls it). Only when no .claude/settings.json exists at all (a
+# project that hasn't run `vnx init`/`vnx regen-settings` yet) does this fall
+# back to the settings TEMPLATE that ships the wiring to future consumers,
+# so a not-yet-live consumer project isn't reported unloadable purely for
+# not having generated its settings.json yet.
+_t0_static_settings_wires_hook() {
+  local root="$1" hook="$2" hook_base settings
+  hook_base="$(basename "$hook")"
+  settings="$root/.claude/settings.json"
+  if [ -f "$settings" ]; then
+    _t0_static_settings_json_wires_hook "$settings" "$hook_base"
+    return $?
+  fi
+  settings="$root/templates/settings_vnx_keys.json.tmpl"
+  [ -f "$settings" ] || return 1
+  _t0_static_settings_json_wires_hook "$settings" "$hook_base"
+}
+
+# Full in-context check: a SessionStart hook script references the skill's
+# SKILL.md path AND this project's settings actually wire that hook up to
+# run. Both halves are required — see _t0_static_hook_file_references_skill
+# and _t0_static_settings_wires_hook for what each half checks.
+_t0_static_hook_injects_skill() {
+  local root="$1" skill_name="$2" hook
+  hook="$(_t0_static_hook_file_references_skill "$root" "$skill_name")" || return 1
+  _t0_static_settings_wires_hook "$root" "$hook"
 }
 
 # Static role<->skill invocability check for one project root. Prints one
@@ -100,6 +176,17 @@ _t0_static_hook_injects_skill() {
 #                        SessionStart hook) nor model-invocable (SKILL.md
 #                        missing, or present with `disable-model-invocation:
 #                        true` and not otherwise in-context).
+#   HOOK-NOT-WIRED    — a SessionStart hook script exists and its content
+#                        correctly references the skill's SKILL.md path, but
+#                        nothing in .claude/settings.json's (or the settings
+#                        template's) "hooks.SessionStart" config actually
+#                        invokes that hook script — so its body never runs
+#                        and never reaches T0 context, even though the hook
+#                        FILE itself looks correct (finding 1, codex round 2,
+#                        2026-07-16: a hook file existing was previously
+#                        accepted as sufficient proof of in-context delivery,
+#                        without checking whether Claude Code is actually
+#                        configured to run it).
 #   PLAYBOOK-MECHANISM-GAP — AGENTS.md/GEMINI.md (the codex/gemini T0
 #                        surfaces `vnx role sync` mirrors the role into) carry
 #                        the role text, but neither provider has a
@@ -158,7 +245,11 @@ _t0_static_check() {
       fi
 
       if _t0_static_frontmatter_disables_invocation "$skill_md"; then
-        echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' — not imported by CLAUDE.md, not hook-injected, and disable-model-invocation: true in $skill_md"
+        if _t0_static_hook_file_references_skill "$root" "$skill_name" >/dev/null; then
+          echo "HOOK-NOT-WIRED: role-orchestrator.md references '@$skill_name' — a SessionStart hook script correctly references $skill_md, but no active (uncommented) reference to that hook exists in the SessionStart config of .claude/settings.json (or, absent that file, the settings template) — disable-model-invocation: true in $skill_md means the Skill-tool fallback is blocked too, so the playbook body never reaches T0 context"
+        else
+          echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' — not imported by CLAUDE.md, not hook-injected, and disable-model-invocation: true in $skill_md"
+        fi
         findings=$((findings + 1))
       fi
     done < <(grep -oE '`@[a-zA-Z0-9_-]+`' "$role_md" 2>/dev/null | tr -d '`@' | sort -u)

--- a/scripts/commands/t0_role_audit.sh
+++ b/scripts/commands/t0_role_audit.sh
@@ -14,13 +14,122 @@
 # This makes that drift observable: it reports, per project/terminal,
 # whether the running T0 would load its role file right now.
 #
-# Usage: bash scripts/commands/t0_role_audit.sh
+# Also audits a SECOND, independent drift class: role<->skill invocability.
+# role-orchestrator.md presupposes that certain skills are loadable (either
+# in-context via a CLAUDE.md `@`-import, or model-invocable via the Skill
+# tool). Nothing previously cross-checked that presupposition against skill
+# frontmatter (`disable-model-invocation: true`) or import targets actually
+# existing on disk — that gap is exactly how F1 (t0-orchestrator unloadable
+# in the fabric source) went undetected for ~7 weeks. `--static` runs this
+# check standalone; the default live-session audit below also runs it
+# automatically for every project it discovers.
+#
+# Usage:
+#   bash scripts/commands/t0_role_audit.sh                    # live-session audit (unchanged)
+#   bash scripts/commands/t0_role_audit.sh --static [ROOT]     # role<->skill invocability only
+#                                                                # ROOT defaults to cwd's git root
 #
 # Standalone by design — this must also audit OTHER registered VNX projects,
 # not just the one it happens to be invoked from, so it does not depend on
 # bin/vnx's command loader (PROJECT_ROOT/VNX_HOME/log/err are not assumed).
 
 set -uo pipefail
+
+# Absolute path to this script itself, so the registry sub-pass (a Python
+# heredoc, see below) can re-invoke `--static` per registered project without
+# guessing where it lives.
+_T0_AUDIT_SELF="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)/$(basename "${BASH_SOURCE[0]}")"
+
+# Resolve an `@`-import target relative to the file that contains it.
+# $1 = raw path text after the leading `@` on an import line
+# $2 = directory of the importing file
+_t0_static_resolve_import() {
+  local raw="$1" base_dir="$2"
+  case "$raw" in
+    '~'*) printf '%s' "${raw/#\~/$HOME}" ;;
+    /*)   printf '%s' "$raw" ;;
+    *)    printf '%s' "$base_dir/$raw" ;;
+  esac
+}
+
+# Naive frontmatter check: does the FIRST `---`...`---` block contain the
+# literal line `disable-model-invocation: true`? This is deliberately not a
+# YAML parser — it must never grow into one.
+_t0_static_frontmatter_disables_invocation() {
+  awk '
+    /^---[ \t]*$/ { n++; if (n == 2) exit }
+    n == 1 && /disable-model-invocation:[ \t]*true/ { found = 1 }
+    END { exit(found ? 0 : 1) }
+  ' "$1"
+}
+
+# Static role<->skill invocability check for one project root. Prints one
+# finding per line (IMPORT-MISSING / SKILL-UNLOADABLE) to stdout; returns 0
+# when clean, 1 when any finding was printed.
+#
+#   IMPORT-MISSING    — an `@`-import line in the T0 CLAUDE.md or
+#                        role-orchestrator.md resolves to a file that does
+#                        not exist.
+#   SKILL-UNLOADABLE  — a backtick-quoted `@<skill>` reference in
+#                        role-orchestrator.md names a skill that is neither
+#                        in-context (imported by CLAUDE.md) nor
+#                        model-invocable (SKILL.md missing, or present with
+#                        `disable-model-invocation: true` and not imported).
+_t0_static_check() {
+  local root="$1"
+  local t0_dir="$root/.claude/terminals/T0"
+  local claude_md="$t0_dir/CLAUDE.md"
+  local role_md="$t0_dir/role-orchestrator.md"
+  local findings=0
+  local imported_targets=""
+
+  local f dir line raw resolved
+  for f in "$claude_md" "$role_md"; do
+    [ -f "$f" ] || continue
+    dir="$(dirname "$f")"
+    while IFS= read -r line; do
+      [ -z "$line" ] && continue
+      raw="${line#@}"
+      resolved="$(_t0_static_resolve_import "$raw" "$dir")"
+      if [ ! -f "$resolved" ]; then
+        echo "IMPORT-MISSING: $f imports '@$raw' -> $resolved (does not exist)"
+        findings=$((findings + 1))
+      else
+        # Normalize (the raw concatenation may still contain `../`) so an
+        # import target and a skill's canonical SKILL.md path compare equal
+        # whenever they name the same file on disk.
+        imported_targets="$imported_targets|$(realpath "$resolved" 2>/dev/null || printf '%s' "$resolved")"
+      fi
+    done < <(grep -h '^@' "$f" 2>/dev/null)
+  done
+
+  if [ -f "$role_md" ]; then
+    local skill_name skill_md
+    while IFS= read -r skill_name; do
+      [ -z "$skill_name" ] && continue
+      skill_md="$root/.claude/skills/$skill_name/SKILL.md"
+
+      if [ ! -f "$skill_md" ]; then
+        echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' but $skill_md does not exist"
+        findings=$((findings + 1))
+        continue
+      fi
+
+      local skill_md_real
+      skill_md_real="$(realpath "$skill_md" 2>/dev/null || printf '%s' "$skill_md")"
+      case "$imported_targets" in
+        *"|$skill_md_real"*) continue ;;  # in-context via CLAUDE.md import; invocability irrelevant
+      esac
+
+      if _t0_static_frontmatter_disables_invocation "$skill_md"; then
+        echo "SKILL-UNLOADABLE: role-orchestrator.md references '@$skill_name' — not imported by CLAUDE.md and disable-model-invocation: true in $skill_md"
+        findings=$((findings + 1))
+      fi
+    done < <(grep -oE '`@[a-zA-Z0-9_-]+`' "$role_md" 2>/dev/null | tr -d '`@' | sort -u)
+  fi
+
+  [ "$findings" -eq 0 ]
+}
 
 # All descendant PIDs of $1 (the FULL process tree, not just direct children).
 # BFS over pgrep -P; process trees are acyclic so this always terminates.
@@ -62,6 +171,21 @@ _t0_audit_row() {
 }
 
 main() {
+  if [ "${1:-}" = "--static" ]; then
+    local static_root="${2:-}"
+    if [ -z "$static_root" ]; then
+      static_root="$(git rev-parse --show-toplevel 2>/dev/null)" || static_root="$(pwd)"
+    fi
+    local static_output
+    static_output="$(_t0_static_check "$static_root")"
+    if [ -z "$static_output" ]; then
+      echo "(clean — no role<->skill invocability drift found in $static_root)"
+      return 0
+    fi
+    printf '%s\n' "$static_output"
+    return 1
+  fi
+
   if ! command -v tmux >/dev/null 2>&1; then
     echo "tmux not found — cannot audit live sessions." >&2
     exit 1
@@ -111,6 +235,13 @@ main() {
     _t0_audit_active_cli "$pane_pid" && cli="running"
 
     _t0_audit_row "$(basename "$project_root")" "T0" "$loaded" "$cli" "$pane_path"
+
+    local static_output_live
+    static_output_live="$(_t0_static_check "$project_root")"
+    if [ -n "$static_output_live" ]; then
+      echo "  [static] role<->skill invocability drift:"
+      printf '%s\n' "$static_output_live" | sed 's/^/    /'
+    fi
   done < <(tmux list-panes -a -F '#{pane_id} #{pane_pid} #{pane_current_path}' 2>/dev/null)
 
   if [ "$found_any" -eq 0 ]; then
@@ -122,10 +253,10 @@ main() {
   # instead of silently disappearing from the report.
   local registry="$HOME/.vnx/projects.json"
   if [ -f "$registry" ] && command -v python3 >/dev/null 2>&1; then
-    python3 - "$registry" "$seen_roots" <<'PYEOF'
-import json, os, sys
+    python3 - "$registry" "$seen_roots" "$_T0_AUDIT_SELF" <<'PYEOF'
+import json, os, subprocess, sys
 
-registry_file, seen_raw = sys.argv[1], sys.argv[2]
+registry_file, seen_raw, audit_self = sys.argv[1], sys.argv[2], sys.argv[3]
 seen = set(seen_raw.split())
 
 try:
@@ -149,6 +280,14 @@ for p in data.get("projects", []):
     if os.path.isfile(role_file):
         print("{:<22} {:<6} {:<9} {:<9} {:<55}".format(
             os.path.basename(root), "T0", "n/a", "(not running)", root))
+        static_proc = subprocess.run(
+            ["bash", audit_self, "--static", root],
+            capture_output=True, text=True,
+        )
+        if static_proc.returncode != 0 and static_proc.stdout.strip():
+            print("  [static] role<->skill invocability drift:")
+            for line in static_proc.stdout.strip().splitlines():
+                print(f"    {line}")
 PYEOF
   fi
 }

--- a/templates/init/default/claude_md.j2
+++ b/templates/init/default/claude_md.j2
@@ -21,4 +21,5 @@ This project uses **VNX Glass Box Governance** for multi-agent orchestration.
 1. `vnx doctor` — validate setup
 2. Edit `.claude/terminals/T0/CLAUDE.md` for your project context
 3. `vnx track new <id> --project-id {{ project_id }} --title "..." --goal "..."`
-4. Start T0 terminal: load `@t0-orchestrator`
+4. Start T0 terminal — the SessionStart hook auto-loads the `t0-orchestrator` playbook; if that
+   heading is absent, invoke `@t0-orchestrator` via the Skill tool instead

--- a/templates/init/default/terminals/T0_claude_md.j2
+++ b/templates/init/default/terminals/T0_claude_md.j2
@@ -13,7 +13,15 @@ T0 outputs: dispatch instructions, manager blocks, gate/closure decisions, light
 **NEVER**: author `claudedocs/*` reports, conduct multi-step research, or self-dispatch.
 
 ## Startup
-Load `@t0-orchestrator` before any orchestration action.
+The `t0-orchestrator` skill playbook governs every orchestration decision — never orchestrate
+from memory. It reaches your context one of two ways:
+1. **SessionStart hook injection (primary)** — `.claude/hooks/sessionstart.sh` (deployed by
+   `vnx init`/`bootstrap_hooks`) reads `.claude/skills/t0-orchestrator/SKILL.md` and injects its
+   body before your first prompt. A `# T0 Orchestrator` heading in this context means it's
+   already loaded — proceed.
+2. **Skill-tool invocation (fallback)** — if that heading is absent, invoke `@t0-orchestrator`
+   via the Skill tool. If it returns `Unknown skill` or is not model-invocable, STOP: do not
+   orchestrate from memory. Run `bash scripts/commands/t0_role_audit.sh` to confirm the drift.
 
 ## Quick Commands
 ```bash

--- a/templates/terminals/T0.md
+++ b/templates/terminals/T0.md
@@ -5,8 +5,20 @@ You are the BRAIN, not the HANDS.
 
 ## Mandatory Startup
 
-Before any orchestration action, load `@t0-orchestrator`.
-Do not run orchestration from memory; follow the skill workflow.
+The `t0-orchestrator` skill playbook governs all orchestration decisions — never orchestrate
+from memory. Its content reaches your context one of two ways:
+
+1. **SessionStart hook injection (primary)** — the project's SessionStart hook
+   (`.claude/hooks/sessionstart.sh`, deployed by `vnx init`/`bootstrap_hooks`) reads
+   `.claude/skills/t0-orchestrator/SKILL.md` and injects its body as `additionalContext` for T0
+   sessions before you see the first prompt — no `@`-import, no Skill-tool call, no interactive
+   trust prompt. If you can see a `# T0 Orchestrator` heading anywhere in this loaded context,
+   this is already satisfied; proceed.
+2. **Skill-tool invocation (fallback)** — if that heading is absent (e.g. this project's
+   SessionStart hook hasn't been synced/wired yet), invoke `@t0-orchestrator` via the Skill
+   tool. If that call returns `Unknown skill` or the skill is not model-invocable, STOP: do not
+   orchestrate from memory. Report role<->skill drift and run
+   `bash scripts/commands/t0_role_audit.sh` to confirm.
 
 ## Runtime Policy
 

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -427,6 +427,24 @@ class TestT0OrchestratorInvocabilityNote:
         assert r.returncode == 0, r.stderr
         assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
 
+    def test_warns_when_skill_md_missing_even_if_hook_wired_and_references_it(self, tmp_path):
+        """Finding 4 (2026-07-16 r4): a wired hook whose TEXT references the
+        skill's SKILL.md path is not proof that file actually exists — no
+        SKILL.md at all here (the sales-copilot case), yet the hook-injection
+        check only grepped hook text and never confirmed SKILL.md existed on
+        disk, so the NOTE stayed silent instead of warning like the static
+        audit's SKILL-UNLOADABLE already does for this exact case."""
+        project = _make_project(tmp_path)
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+        _wire_sessionstart_hook(project, ".claude/hooks/sessionstart.sh")
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
+
 
 # ---------------------------------------------------------------------------
 # Finding 3 (codex, 2026-07-16): the awk frontmatter check matched

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -78,6 +78,32 @@ def _backups(t0_dir: Path, basename: str):
     return sorted(t0_dir.glob(f"{basename}.bak.*"))
 
 
+def _wire_sessionstart_hook(project: Path, hook_relpath: str):
+    """Write a minimal .claude/settings.json that actually registers
+    `hook_relpath` (e.g. ".claude/hooks/sessionstart.sh") in the
+    SessionStart hooks config — the piece a hook FILE existing does not by
+    itself prove (finding 1, codex round 2, 2026-07-16)."""
+    settings_dir = project / ".claude"
+    settings_dir.mkdir(parents=True, exist_ok=True)
+    (settings_dir / "settings.json").write_text(
+        '{\n'
+        '  "hooks": {\n'
+        '    "SessionStart": [\n'
+        '      {\n'
+        '        "matcher": "*",\n'
+        '        "hooks": [\n'
+        '          {\n'
+        '            "type": "command",\n'
+        f'            "command": "bash /abs/project/root/{hook_relpath}"\n'
+        '          }\n'
+        '        ]\n'
+        '      }\n'
+        '    ]\n'
+        '  }\n'
+        '}\n'
+    )
+
+
 # ---------------------------------------------------------------------------
 # --dry-run default / --apply writes
 # ---------------------------------------------------------------------------
@@ -309,7 +335,33 @@ class TestT0OrchestratorInvocabilityNote:
     def test_silent_when_target_has_hook_injection_for_skill(self, tmp_path):
         """Finding 0 mechanism change: the playbook body now reaches T0 via
         the SessionStart hook, not a CLAUDE.md `@`-import — the NOTE-check
-        must recognize that as satisfying the condition too."""
+        must recognize that as satisfying the condition too. This also
+        requires (finding 1, codex round 2, 2026-07-16) that the hook is
+        actually wired into .claude/settings.json's SessionStart config —
+        a hook file existing and referencing the skill is not enough by
+        itself."""
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\ndisable-model-invocation: true\n---\n\nplaybook body\n"
+        )
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+        _wire_sessionstart_hook(project, ".claude/hooks/sessionstart.sh")
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+    def test_warns_when_hook_present_and_referencing_skill_but_settings_do_not_wire_it(self, tmp_path):
+        """Finding 1 (codex round 2, 2026-07-16): a hook script existing and
+        correctly referencing the skill is not proof Claude Code runs it —
+        this repo's own fabric-source hooks/sessionstart.sh does exactly
+        this and its .claude/settings.json never calls it. No settings.json
+        at all (and no settings template) here, mirroring that gap."""
         project = _make_project(tmp_path)
         skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
         skill_dir.mkdir(parents=True)
@@ -323,7 +375,43 @@ class TestT0OrchestratorInvocabilityNote:
         )
         r = _run_bash("--project-dir", str(project), cwd=tmp_path)
         assert r.returncode == 0, r.stderr
-        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+        assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
+
+    def test_warns_when_settings_json_reference_to_hook_is_commented_out(self, tmp_path):
+        """A commented-out reference to the hook path inside the command
+        string must not count as wired."""
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\ndisable-model-invocation: true\n---\n\nplaybook body\n"
+        )
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+        settings_dir = project / ".claude"
+        (settings_dir / "settings.json").write_text(
+            '{\n'
+            '  "hooks": {\n'
+            '    "SessionStart": [\n'
+            '      {\n'
+            '        "matcher": "*",\n'
+            '        "hooks": [\n'
+            '          {\n'
+            '            "type": "command",\n'
+            '            "command": "bash -c \'# exec bash .claude/hooks/sessionstart.sh\'"\n'
+            '          }\n'
+            '        ]\n'
+            '      }\n'
+            '    ]\n'
+            '  }\n'
+            '}\n'
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
 
     def test_warns_when_hook_present_but_not_referencing_the_skill(self, tmp_path):
         project = _make_project(tmp_path)

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -270,6 +270,44 @@ class TestConsumerRepoResolution:
 
 
 # ---------------------------------------------------------------------------
+# t0-orchestrator invocability NOTE (F1 prevention): the shipped role's
+# Mandatory Startup step needs the skill EITHER in-context (CLAUDE.md import)
+# OR model-invocable (SKILL.md without disable-model-invocation: true). Role
+# sync warns, never blocks, when a target project has neither.
+# ---------------------------------------------------------------------------
+
+class TestT0OrchestratorInvocabilityNote:
+    def test_warns_when_target_has_neither_import_nor_invocable_skill(self, tmp_path):
+        project = _make_project(tmp_path)
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        out = r.stdout + r.stderr
+        assert "does not import the t0-orchestrator skill body" in out
+        assert "t0_role_audit.sh --static" in out
+
+    def test_silent_when_target_imports_the_skill_body(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text(
+            "@role-orchestrator.md\n@../../skills/t0-orchestrator/SKILL.md\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+    def test_silent_when_target_skill_is_model_invocable(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\n---\n\nplaybook body\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+
+# ---------------------------------------------------------------------------
 # VNX_HOME guard still refuses in-place (central install only)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_role_sync.py
+++ b/tests/test_role_sync.py
@@ -306,6 +306,84 @@ class TestT0OrchestratorInvocabilityNote:
         assert r.returncode == 0, r.stderr
         assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
 
+    def test_silent_when_target_has_hook_injection_for_skill(self, tmp_path):
+        """Finding 0 mechanism change: the playbook body now reaches T0 via
+        the SessionStart hook, not a CLAUDE.md `@`-import — the NOTE-check
+        must recognize that as satisfying the condition too."""
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\ndisable-model-invocation: true\n---\n\nplaybook body\n"
+        )
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+    def test_warns_when_hook_present_but_not_referencing_the_skill(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\ndisable-model-invocation: true\n---\n\nplaybook body\n"
+        )
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text("#!/usr/bin/env bash\necho '{}'\n")
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Finding 3 (codex, 2026-07-16): the awk frontmatter check matched
+# `disable-model-invocation: true` anywhere in the frontmatter block
+# (comments, description text) instead of anchoring on the real key.
+# ---------------------------------------------------------------------------
+
+class TestFrontmatterAnchorIgnoresMentionsAndComments:
+    def test_silent_when_description_merely_mentions_the_disable_string(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\n"
+            'description: "Docs note: disable-model-invocation: true is an example flag."\n'
+            "---\n\nplaybook body\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+    def test_silent_when_disable_line_is_commented_out(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\n"
+            "# disable-model-invocation: true  (left as documentation)\n"
+            "---\n\nplaybook body\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" not in (r.stdout + r.stderr)
+
+    def test_still_warns_on_a_real_disable_key(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(
+            "---\nname: t0-orchestrator\ndescription: test\ndisable-model-invocation: true\n---\n\nplaybook body\n"
+        )
+        r = _run_bash("--project-dir", str(project), cwd=tmp_path)
+        assert r.returncode == 0, r.stderr
+        assert "does not import the t0-orchestrator skill body" in (r.stdout + r.stderr)
+
 
 # ---------------------------------------------------------------------------
 # VNX_HOME guard still refuses in-place (central install only)

--- a/tests/test_sessionstart_hook.py
+++ b/tests/test_sessionstart_hook.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Tests for `hooks/sessionstart.sh` — the fleet-wide SessionStart hook.
+
+Dispatch-ID: 20260716-ff-1174-startup-import
+
+Finding 0 (live smoke test, 2026-07-16): T0's Mandatory Startup step used to
+reach the (intentionally non-model-invocable) t0-orchestrator SKILL.md body
+via a CLAUDE.md `@`-import. That import resolves outside the T0 terminal
+directory, and Claude Code classifies it as an "external CLAUDE.md file
+import" — a fresh autonomous T0 spawn hits an interactive trust prompt with
+nobody to answer it, and hangs.
+
+The fix moves the delivery into this hook instead: for a T0 session, it reads
+`.claude/skills/t0-orchestrator/SKILL.md` and returns its body as
+`additionalContext`, before the model ever sees a prompt — no import, no
+Skill-tool call, so no trust prompt is possible. This is deployed fleet-wide
+via `vnx init`/`bootstrap_hooks` (`.claude/hooks/sessionstart.sh`), so the fix
+lands everywhere that syncs, with no per-project hand-config.
+
+Isolation: every test builds a throwaway tmp_path project and invokes the
+hook as a subprocess with a faked `cwd`; nothing here touches this repo's own
+`.claude/` state.
+"""
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "hooks" / "sessionstart.sh"
+
+SKILL_BODY = """\
+---
+name: t0-orchestrator
+description: test skill
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: [Read]
+---
+
+# T0 Orchestrator
+
+You are the orchestration authority for VNX. UNIQUE-PLAYBOOK-MARKER-4f8e1c.
+"""
+
+
+def _make_project(tmp_path: Path, name: str = "project") -> Path:
+    root = tmp_path / name
+    (root / ".vnx").mkdir(parents=True)
+    for term in ("T0", "T1", "T2", "T3"):
+        (root / ".claude" / "terminals" / term).mkdir(parents=True)
+    return root
+
+
+def _run_hook(cwd: Path):
+    r = subprocess.run(
+        ["bash", str(HOOK)],
+        capture_output=True, text=True, cwd=str(cwd),
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    return json.loads(r.stdout)
+
+
+class TestT0SkillBodyInjection:
+    def test_injects_skill_body_when_present(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "UNIQUE-PLAYBOOK-MARKER-4f8e1c" in ctx
+        assert "T0 Master Orchestrator Active" in ctx
+
+    def test_fail_soft_when_skill_missing(self, tmp_path):
+        """No `.claude/skills/t0-orchestrator/SKILL.md` at all — the hook
+        must still succeed and return valid JSON, just without the body."""
+        project = _make_project(tmp_path)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "T0 Master Orchestrator Active" in ctx
+        assert "UNIQUE-PLAYBOOK-MARKER-4f8e1c" not in ctx
+
+    def test_output_is_reasonably_sized(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        # Sanity bound, not a real product limit: catches an accidental
+        # infinite-growth bug (e.g. self-referential injection) long before
+        # it could approach any real hook-output ceiling.
+        assert len(ctx.encode("utf-8")) < 100_000
+
+    def test_idempotent_across_repeated_invocations(self, tmp_path):
+        """Each SessionStart fire (a fresh session, a `/clear`, ...) must
+        recompute the same output from disk — nothing accumulates."""
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+
+        t0_dir = project / ".claude" / "terminals" / "T0"
+        first = _run_hook(t0_dir)
+        second = _run_hook(t0_dir)
+        assert first == second
+
+
+class TestOtherTerminalsUnaffected:
+    def test_t1_terminal_has_no_skill_body_injection(self, tmp_path):
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T1")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "T1 Worker (Track A) Active" in ctx
+        assert "UNIQUE-PLAYBOOK-MARKER-4f8e1c" not in ctx
+
+
+class TestNonVnxDirectory:
+    def test_exits_silently_outside_a_terminal_directory(self, tmp_path):
+        r = subprocess.run(
+            ["bash", str(HOOK)],
+            capture_output=True, text=True, cwd=str(tmp_path),
+        )
+        assert r.returncode == 0
+        assert r.stdout.strip() == "{}"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_t0_role_audit_static.py
+++ b/tests/test_t0_role_audit_static.py
@@ -34,14 +34,30 @@ run `vnx regen-settings` yet). A hook-file-only match without settings wiring
 now reports the new HOOK-NOT-WIRED finding instead of the generic
 SKILL-UNLOADABLE.
 
-Isolation: every test targets a throwaway tmp_path project; a regression
-guard asserts the repo's own `.claude/terminals/T0/` audits honestly — it
-currently reports HOOK-NOT-WIRED, since wiring `.claude/settings.json` is an
-explicitly-authorized separate operator action, not part of this fix. That
-guard must flip to clean (not be re-loosened) once the operator makes that
-edit — never edited by these tests.
+Fix-forward round 4 (20260716-ff-1174-r4): the repo self-audit regression
+guard below asserted a FIXED expected outcome (HOOK-NOT-WIRED) that was true
+only until the operator wired `.claude/settings.json` — once that landed
+(commit 67f0bf91), the guard itself started failing on the branch that fixed
+the gap it exists to catch. It is now state-aware: it independently
+JSON-parses `.claude/settings.json` (not via the script under test) to
+determine whether the hook is actually wired, then asserts whichever outcome
+that state implies — clean/exit 0 when wired, HOOK-NOT-WIRED/exit!=0 when
+not. Both directions stay fixture-tested above regardless of this repo's own
+state; this guard only checks the self-audit stays consistent with reality.
+
+Also this round: finding 2 (basename-only hook matching let an unrelated
+script sharing the name "sessionstart.sh" at a different path false-match —
+fixed to compare the dir/file path suffix instead) and finding 3 (a minified
+single-line settings.json skipped the very line carrying both the
+"SessionStart" key and the hook command, false-negativing HOOK-NOT-WIRED —
+fixed to scan that line too).
+
+Isolation: every test targets a throwaway tmp_path project except the
+self-audit guard, which deliberately targets this repo's own
+`.claude/terminals/T0/` — never edited by these tests.
 """
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -462,6 +478,54 @@ class TestSkillHookInjected:
         assert r.returncode == 0, r.stdout + r.stderr
         assert "clean" in (r.stdout + r.stderr).lower()
 
+    def test_settings_reference_to_differently_located_same_basename_script_reports_not_wired(self, tmp_path):
+        """Finding 2 (2026-07-16 r4): matching only the hook's BASENAME let
+        an unrelated script that merely SHARES the name "sessionstart.sh" at
+        a different path count as wiring the real hook. The needle must
+        include the directory component (hooks/sessionstart.sh), not just
+        the basename."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        settings_dir = project / ".claude"
+        (settings_dir / "settings.json").write_text(
+            '{\n'
+            '  "hooks": {\n'
+            '    "SessionStart": [\n'
+            '      {\n'
+            '        "matcher": "*",\n'
+            '        "hooks": [\n'
+            '          {\n'
+            '            "type": "command",\n'
+            '            "command": "bash scripts/unrelated-tool/sessionstart.sh"\n'
+            '          }\n'
+            '        ]\n'
+            '      }\n'
+            '    ]\n'
+            '  }\n'
+            '}\n'
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "HOOK-NOT-WIRED" in r.stdout
+
+    def test_minified_single_line_settings_json_wires_hook(self, tmp_path):
+        """Finding 3 (2026-07-16 r4): the awk scan skipped the very line
+        that matched "SessionStart": before checking it for the needle — a
+        minified single-line settings.json puts key, brackets, and hook
+        command all on that one line, so it was never found."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        settings_dir = project / ".claude"
+        (settings_dir / "settings.json").write_text(
+            '{"hooks":{"SessionStart":[{"matcher":"*","hooks":[{"type":"command",'
+            '"command":"bash .claude/hooks/sessionstart.sh"}]}]}}\n'
+        )
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
 
 class TestTriFilePlaybookMechanismGap:
     """Finding 2 (codex): `vnx role sync` mirrors the same Mandatory Startup
@@ -537,23 +601,48 @@ class TestDefaultRootIsGitRoot:
         assert r.returncode == 0, r.stdout + r.stderr
 
 
+def _repo_sessionstart_hook_is_wired() -> bool:
+    """Independent (JSON-parse, not the awk logic under test) check of
+    whether this repo's own .claude/settings.json actively references
+    hooks/sessionstart.sh in its SessionStart config — decides which
+    assertion direction the regression guard below expects, rather than the
+    guard hardcoding one fixed outcome that goes stale the moment an
+    operator edits settings.json (finding 1 self-test staleness, 2026-07-16
+    r4: commit 67f0bf91 wired the hook and this guard's old fixed
+    HOOK-NOT-WIRED assertion started failing on its own branch)."""
+    settings_file = REPO / ".claude" / "settings.json"
+    if not settings_file.is_file():
+        return False
+    try:
+        data = json.loads(settings_file.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    for entry in data.get("hooks", {}).get("SessionStart", []):
+        for hook in entry.get("hooks", []):
+            if "hooks/sessionstart.sh" in hook.get("command", ""):
+                return True
+    return False
+
+
 class TestRepoSelfAudit:
-    def test_vnx_repo_itself_reports_the_honest_hook_not_wired_gap(self):
-        """Finding 1 (codex round 2, 2026-07-16): this repo's own
-        hooks/sessionstart.sh correctly injects the t0-orchestrator skill
-        body, but .claude/settings.json's SessionStart config does not
-        invoke that hook — that line is intentionally left for a separate,
-        explicitly-authorized operator action (an operator-config change,
-        not something this fix-forward makes on its own). Until that
-        settings.json edit lands, `--static` must report this gap honestly
-        rather than claim clean — this regression guard asserts the honest
-        state, and must flip back to clean (not be re-loosened) once the
-        operator wires the hook. Never edited by these tests."""
+    def test_vnx_repo_itself_matches_its_actual_hook_wiring_state(self):
+        """State-aware regression guard: whichever way this repo's own
+        .claude/settings.json currently wires (or doesn't wire)
+        hooks/sessionstart.sh, `--static` must report the matching outcome —
+        clean/exit 0 once wired, HOOK-NOT-WIRED/exit!=0 while it isn't. Both
+        directions stay independently fixture-tested above (TestSkillHookInjected);
+        this guard only checks the self-audit stays consistent with the real
+        state of this repo's own settings.json — never edited by these
+        tests."""
         r = _run_static(REPO)
-        assert r.returncode != 0, r.stdout + r.stderr
         out = r.stdout + r.stderr
-        assert "HOOK-NOT-WIRED" in out
-        assert "t0-orchestrator" in out
+        if _repo_sessionstart_hook_is_wired():
+            assert r.returncode == 0, out
+            assert "HOOK-NOT-WIRED" not in out
+        else:
+            assert r.returncode != 0, out
+            assert "HOOK-NOT-WIRED" in out
+            assert "t0-orchestrator" in out
 
 
 if __name__ == "__main__":

--- a/tests/test_t0_role_audit_static.py
+++ b/tests/test_t0_role_audit_static.py
@@ -21,9 +21,25 @@ finding, since codex/gemini have no hook equivalent); (3) the frontmatter
 and skips comments, so a `description:` field merely mentioning that string
 no longer false-positives as SKILL-UNLOADABLE.
 
+Fix-forward round 3 (20260716-ff-1174-r3): codex round 2 found that
+`_t0_static_hook_injects_skill` accepted a hook FILE's content as sufficient
+proof of in-context delivery without checking whether Claude Code is actually
+configured to run that hook at all (finding 1) — exactly the gap in this
+repo's own fabric source: `hooks/sessionstart.sh` correctly injects the skill
+body, but `.claude/settings.json`'s SessionStart config never calls it. The
+check now also requires an active (uncommented) reference to the hook script
+in the SessionStart config of `.claude/settings.json` (or, absent that file,
+the settings template — a consumer-check fallback for projects that haven't
+run `vnx regen-settings` yet). A hook-file-only match without settings wiring
+now reports the new HOOK-NOT-WIRED finding instead of the generic
+SKILL-UNLOADABLE.
+
 Isolation: every test targets a throwaway tmp_path project; a regression
-guard asserts the repo's own `.claude/terminals/T0/` audits clean after the
-F1 fix (it must never need editing by these tests).
+guard asserts the repo's own `.claude/terminals/T0/` audits honestly — it
+currently reports HOOK-NOT-WIRED, since wiring `.claude/settings.json` is an
+explicitly-authorized separate operator action, not part of this fix. That
+guard must flip to clean (not be re-loosened) once the operator makes that
+edit — never edited by these tests.
 """
 
 import subprocess
@@ -106,6 +122,37 @@ def _make_project(tmp_path: Path, name: str = "project") -> Path:
     t0 = root / ".claude" / "terminals" / "T0"
     t0.mkdir(parents=True)
     return root
+
+
+def _wire_sessionstart_hook(project: Path, hook_relpath: str, settings_path: Path = None):
+    """Write a minimal settings.json (default: project/.claude/settings.json)
+    that actually registers `hook_relpath` (e.g. ".claude/hooks/sessionstart.sh"
+    or "hooks/sessionstart.sh") in the SessionStart hooks config — the piece a
+    hook FILE existing does not by itself prove (finding 1, codex round 2,
+    2026-07-16)."""
+    if settings_path is None:
+        settings_dir = project / ".claude"
+        settings_dir.mkdir(parents=True, exist_ok=True)
+        settings_path = settings_dir / "settings.json"
+    else:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+    settings_path.write_text(
+        '{\n'
+        '  "hooks": {\n'
+        '    "SessionStart": [\n'
+        '      {\n'
+        '        "matcher": "*",\n'
+        '        "hooks": [\n'
+        '          {\n'
+        '            "type": "command",\n'
+        f'            "command": "bash /abs/project/root/{hook_relpath}"\n'
+        '          }\n'
+        '        ]\n'
+        '      }\n'
+        '    ]\n'
+        '  }\n'
+        '}\n'
+    )
 
 
 class TestHealthyProject:
@@ -261,10 +308,13 @@ class TestSkillHookInjected:
     """Finding 0 mechanism change: the t0-orchestrator playbook body now
     reaches T0 via the SessionStart hook, not a CLAUDE.md `@`-import. The
     hook-detection path must satisfy the in-context condition the same way
-    an import used to."""
+    an import used to — but ONLY when the hook is both referencing the
+    skill AND actually wired into SessionStart config (finding 1, codex
+    round 2, 2026-07-16): a hook file existing was previously accepted as
+    sufficient proof on its own, without checking whether Claude Code is
+    configured to run it at all."""
 
-    def test_disabled_skill_hook_injected_by_deployed_copy_is_clean(self, tmp_path):
-        project = _make_project(tmp_path)
+    def _write_hook(self, project: Path, hooks_dir_name: str):
         t0 = project / ".claude" / "terminals" / "T0"
         (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
         (t0 / "role-orchestrator.md").write_text(
@@ -274,11 +324,16 @@ class TestSkillHookInjected:
         skill_dir.mkdir(parents=True)
         (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
 
-        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir = project / hooks_dir_name
         hooks_dir.mkdir(parents=True)
         (hooks_dir / "sessionstart.sh").write_text(
             "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
         )
+
+    def test_disabled_skill_hook_injected_by_deployed_copy_is_clean(self, tmp_path):
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        _wire_sessionstart_hook(project, ".claude/hooks/sessionstart.sh")
 
         r = _run_static(project)
         assert r.returncode == 0, r.stdout + r.stderr
@@ -286,22 +341,11 @@ class TestSkillHookInjected:
 
     def test_disabled_skill_hook_injected_by_fabric_source_template_is_clean(self, tmp_path):
         """Mirrors this repo's own shape: no `.claude/hooks/` deployed copy,
-        only the fabric-source `hooks/sessionstart.sh` template."""
+        only the fabric-source `hooks/sessionstart.sh` template — WIRED into
+        .claude/settings.json's SessionStart config."""
         project = _make_project(tmp_path)
-        t0 = project / ".claude" / "terminals" / "T0"
-        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
-        (t0 / "role-orchestrator.md").write_text(
-            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
-        )
-        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
-
-        hooks_dir = project / "hooks"
-        hooks_dir.mkdir(parents=True)
-        (hooks_dir / "sessionstart.sh").write_text(
-            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
-        )
+        self._write_hook(project, "hooks")
+        _wire_sessionstart_hook(project, "hooks/sessionstart.sh")
 
         r = _run_static(project)
         assert r.returncode == 0, r.stdout + r.stderr
@@ -323,10 +367,100 @@ class TestSkillHookInjected:
         hooks_dir = project / ".claude" / "hooks"
         hooks_dir.mkdir(parents=True)
         (hooks_dir / "sessionstart.sh").write_text("#!/usr/bin/env bash\necho '{}'\n")
+        _wire_sessionstart_hook(project, ".claude/hooks/sessionstart.sh")
 
         r = _run_static(project)
         assert r.returncode != 0
         assert "SKILL-UNLOADABLE" in r.stdout
+
+    def test_hook_references_skill_but_settings_do_not_wire_it_reports_hook_not_wired(self, tmp_path):
+        """The exact gap finding 1 found in this repo's own fabric source:
+        hooks/sessionstart.sh correctly injects the skill body, but no
+        .claude/settings.json (nor a settings template) exists to actually
+        invoke it. A hook file being present and correctly written is not
+        proof Claude Code runs it — this must report a finding, not clean."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, "hooks")
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "HOOK-NOT-WIRED" in r.stdout
+        assert "t0-orchestrator" in r.stdout
+
+    def test_deployed_hook_references_skill_but_settings_json_omits_it_reports_hook_not_wired(self, tmp_path):
+        """Same gap, deployed-consumer shape: .claude/hooks/sessionstart.sh
+        references the skill, but .claude/settings.json exists and simply
+        never wires it into SessionStart (e.g. only unrelated hooks are
+        registered there, mirroring this repo's real settings.json)."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        settings_dir = project / ".claude"
+        (settings_dir / "settings.json").write_text(
+            '{\n'
+            '  "hooks": {\n'
+            '    "SessionStart": [\n'
+            '      {\n'
+            '        "matcher": "",\n'
+            '        "hooks": [\n'
+            '          {\n'
+            '            "type": "command",\n'
+            '            "command": "bash -c \'exec bash scripts/hooks/unrelated.sh\'"\n'
+            '          }\n'
+            '        ]\n'
+            '      }\n'
+            '    ]\n'
+            '  }\n'
+            '}\n'
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "HOOK-NOT-WIRED" in r.stdout
+
+    def test_commented_out_settings_reference_to_hook_does_not_count_as_wired(self, tmp_path):
+        """A `#`-commented shell reference to the hook path inside the
+        command string must not be treated as an active invocation."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        settings_dir = project / ".claude"
+        (settings_dir / "settings.json").write_text(
+            '{\n'
+            '  "hooks": {\n'
+            '    "SessionStart": [\n'
+            '      {\n'
+            '        "matcher": "*",\n'
+            '        "hooks": [\n'
+            '          {\n'
+            '            "type": "command",\n'
+            '            "command": "bash -c \'# exec bash .claude/hooks/sessionstart.sh\'"\n'
+            '          }\n'
+            '        ]\n'
+            '      }\n'
+            '    ]\n'
+            '  }\n'
+            '}\n'
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "HOOK-NOT-WIRED" in r.stdout
+
+    def test_settings_template_wires_hook_when_no_deployed_settings_json_is_clean(self, tmp_path):
+        """Consumer-check fallback: a project that hasn't run `vnx init`/
+        `vnx regen-settings` yet has no .claude/settings.json at all — the
+        settings TEMPLATE it will get is accepted as evidence instead, so it
+        isn't reported unloadable purely for not having generated its
+        settings.json yet."""
+        project = _make_project(tmp_path)
+        self._write_hook(project, ".claude/hooks")
+        _wire_sessionstart_hook(
+            project, ".claude/hooks/sessionstart.sh",
+            settings_path=project / "templates" / "settings_vnx_keys.json.tmpl",
+        )
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
 
 
 class TestTriFilePlaybookMechanismGap:
@@ -404,12 +538,22 @@ class TestDefaultRootIsGitRoot:
 
 
 class TestRepoSelfAudit:
-    def test_vnx_repo_itself_passes_static_audit(self):
-        """Regression guard: after the F1 fix, this repo's own T0 role must
-        audit clean — never edited by these tests."""
+    def test_vnx_repo_itself_reports_the_honest_hook_not_wired_gap(self):
+        """Finding 1 (codex round 2, 2026-07-16): this repo's own
+        hooks/sessionstart.sh correctly injects the t0-orchestrator skill
+        body, but .claude/settings.json's SessionStart config does not
+        invoke that hook — that line is intentionally left for a separate,
+        explicitly-authorized operator action (an operator-config change,
+        not something this fix-forward makes on its own). Until that
+        settings.json edit lands, `--static` must report this gap honestly
+        rather than claim clean — this regression guard asserts the honest
+        state, and must flip back to clean (not be re-loosened) once the
+        operator wires the hook. Never edited by these tests."""
         r = _run_static(REPO)
-        assert r.returncode == 0, r.stdout + r.stderr
-        assert "clean" in (r.stdout + r.stderr).lower()
+        assert r.returncode != 0, r.stdout + r.stderr
+        out = r.stdout + r.stderr
+        assert "HOOK-NOT-WIRED" in out
+        assert "t0-orchestrator" in out
 
 
 if __name__ == "__main__":

--- a/tests/test_t0_role_audit_static.py
+++ b/tests/test_t0_role_audit_static.py
@@ -1,0 +1,188 @@
+#!/usr/bin/env python3
+"""Tests for `t0_role_audit.sh --static` — role<->skill invocability audit.
+
+Dispatch-ID: 20260716-f1-t0-startup-import
+
+F1 root cause: role-orchestrator.md presupposed `t0-orchestrator` was
+model-loadable via the Skill tool, but its frontmatter carried
+`disable-model-invocation: true` (set by commit 3e2592f9, A-4 hardening) —
+nothing cross-checked the two, so the drift went undetected for ~7 weeks.
+`--static` makes that class of drift observable and CI-assertable.
+
+Isolation: every test targets a throwaway tmp_path project; a regression
+guard asserts the repo's own `.claude/terminals/T0/` audits clean after the
+F1 fix (it must never need editing by these tests).
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+AUDIT_SCRIPT = REPO / "scripts" / "commands" / "t0_role_audit.sh"
+
+SKILL_DISABLED_FRONTMATTER = """\
+---
+name: t0-orchestrator
+description: test skill
+user-invocable: true
+disable-model-invocation: true
+allowed-tools: [Read]
+---
+
+# T0 Orchestrator
+
+playbook body
+"""
+
+SKILL_INVOCABLE_FRONTMATTER = """\
+---
+name: t0-orchestrator
+description: test skill
+allowed-tools: [Read]
+---
+
+# T0 Orchestrator
+
+playbook body
+"""
+
+
+def _run_static(root: Path):
+    return subprocess.run(
+        ["bash", str(AUDIT_SCRIPT), "--static", str(root)],
+        capture_output=True, text=True,
+    )
+
+
+def _make_project(tmp_path: Path, name: str = "project") -> Path:
+    root = tmp_path / name
+    t0 = root / ".claude" / "terminals" / "T0"
+    t0.mkdir(parents=True)
+    return root
+
+
+class TestHealthyProject:
+    def test_import_present_and_resolves_exits_clean(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text("# T0\n\nNo skill references here.\n")
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
+
+class TestImportMissing:
+    def test_missing_import_target_reports_import_missing(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n@does-not-exist.md\n")
+        (t0 / "role-orchestrator.md").write_text("# T0\n\nNo skill references here.\n")
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "IMPORT-MISSING" in r.stdout
+        assert "does-not-exist.md" in r.stdout
+
+
+class TestSkillUnloadable:
+    def test_disabled_skill_not_imported_reports_skill_unloadable(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "SKILL-UNLOADABLE" in r.stdout
+        assert "t0-orchestrator" in r.stdout
+
+    def test_missing_skill_file_entirely_reports_skill_unloadable(self, tmp_path):
+        """The sales-copilot case: role text references a skill that has no
+        SKILL.md at all in this project."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "SKILL-UNLOADABLE" in r.stdout
+        assert "does not exist" in r.stdout
+
+    def test_disabled_skill_but_invocable_variant_is_clean(self, tmp_path):
+        """A skill without disable-model-invocation is a real Skill-tool call
+        target — no finding, even without a CLAUDE.md import."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_INVOCABLE_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+
+
+class TestSkillImportedIntoContext:
+    def test_disabled_skill_imported_by_claude_md_is_clean(self, tmp_path):
+        """Mirrors the actual F1 fix: a disabled skill referenced in
+        role-orchestrator.md is fine when its SKILL.md is `@`-imported
+        (in-context) by the T0 CLAUDE.md — invocability becomes irrelevant."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text(
+            "@role-orchestrator.md\n@../../skills/t0-orchestrator/SKILL.md\n"
+        )
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
+
+class TestDefaultRootIsGitRoot:
+    def test_no_project_root_arg_defaults_to_cwd_git_root(self, tmp_path):
+        project = _make_project(tmp_path)
+        subprocess.run(["git", "init", "-q"], cwd=str(project), check=True)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text("# T0\n\nNo skill references here.\n")
+
+        r = subprocess.run(
+            ["bash", str(AUDIT_SCRIPT), "--static"],
+            capture_output=True, text=True, cwd=str(project),
+        )
+        assert r.returncode == 0, r.stdout + r.stderr
+
+
+class TestRepoSelfAudit:
+    def test_vnx_repo_itself_passes_static_audit(self):
+        """Regression guard: after the F1 fix, this repo's own T0 role must
+        audit clean — never edited by these tests."""
+        r = _run_static(REPO)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_t0_role_audit_static.py
+++ b/tests/test_t0_role_audit_static.py
@@ -1,13 +1,25 @@
 #!/usr/bin/env python3
 """Tests for `t0_role_audit.sh --static` — role<->skill invocability audit.
 
-Dispatch-ID: 20260716-f1-t0-startup-import
+Dispatch-ID: 20260716-f1-t0-startup-import / 20260716-ff-1174-startup-import
 
 F1 root cause: role-orchestrator.md presupposed `t0-orchestrator` was
 model-loadable via the Skill tool, but its frontmatter carried
 `disable-model-invocation: true` (set by commit 3e2592f9, A-4 hardening) —
 nothing cross-checked the two, so the drift went undetected for ~7 weeks.
 `--static` makes that class of drift observable and CI-assertable.
+
+Fix-forward (20260716-ff-1174): the F1 fix's own CLAUDE.md `@`-import of the
+skill body turned out to trip Claude Code's external-CLAUDE.md-import trust
+prompt on a fresh autonomous spawn (live smoke test) — replaced with
+SessionStart-hook injection (`hooks/sessionstart.sh`). This file's coverage
+grew three ways: (1) hook-injection now satisfies the in-context check the
+same way a CLAUDE.md import used to; (2) AGENTS.md/GEMINI.md tri-file
+surfaces are audited too (PLAYBOOK-MECHANISM-GAP, a reported-not-silent
+finding, since codex/gemini have no hook equivalent); (3) the frontmatter
+`disable-model-invocation: true` grep is anchored to the key's own line-start
+and skips comments, so a `description:` field merely mentioning that string
+no longer false-positives as SKILL-UNLOADABLE.
 
 Isolation: every test targets a throwaway tmp_path project; a regression
 guard asserts the repo's own `.claude/terminals/T0/` audits clean after the
@@ -41,6 +53,38 @@ SKILL_INVOCABLE_FRONTMATTER = """\
 ---
 name: t0-orchestrator
 description: test skill
+allowed-tools: [Read]
+---
+
+# T0 Orchestrator
+
+playbook body
+"""
+
+# Finding 3 (codex, 2026-07-16): the frontmatter grep matched
+# `disable-model-invocation: true` ANYWHERE in the frontmatter block,
+# including inside a description or a comment — these two fixtures name the
+# literal string without setting the real key, and must NOT be treated as
+# disabled.
+SKILL_DESCRIPTION_MENTIONS_STRING_FRONTMATTER = """\
+---
+name: t0-orchestrator
+description: "Docs note: disable-model-invocation: true is an example flag, not set here."
+user-invocable: true
+allowed-tools: [Read]
+---
+
+# T0 Orchestrator
+
+playbook body
+"""
+
+SKILL_COMMENTED_OUT_DISABLE_FRONTMATTER = """\
+---
+name: t0-orchestrator
+description: test skill
+# disable-model-invocation: true  (left here as documentation, not active)
+user-invocable: true
 allowed-tools: [Read]
 ---
 
@@ -158,6 +202,190 @@ class TestSkillImportedIntoContext:
         r = _run_static(project)
         assert r.returncode == 0, r.stdout + r.stderr
         assert "clean" in (r.stdout + r.stderr).lower()
+
+
+class TestFrontmatterAnchorIgnoresMentionsAndComments:
+    """Finding 3 (codex): unanchored grep false-positived SKILL-UNLOADABLE
+    when the literal string `disable-model-invocation: true` appeared inside
+    a description or a comment rather than as the real key."""
+
+    def test_description_mentioning_the_string_is_not_treated_as_disabled(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DESCRIPTION_MENTIONS_STRING_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "SKILL-UNLOADABLE" not in r.stdout
+
+    def test_commented_out_disable_line_is_not_treated_as_disabled(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_COMMENTED_OUT_DISABLE_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "SKILL-UNLOADABLE" not in r.stdout
+
+    def test_real_disable_key_still_detected(self, tmp_path):
+        """Regression guard: the anchor fix must not blind the check to a
+        genuinely disabled skill."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "SKILL-UNLOADABLE" in r.stdout
+
+
+class TestSkillHookInjected:
+    """Finding 0 mechanism change: the t0-orchestrator playbook body now
+    reaches T0 via the SessionStart hook, not a CLAUDE.md `@`-import. The
+    hook-detection path must satisfy the in-context condition the same way
+    an import used to."""
+
+    def test_disabled_skill_hook_injected_by_deployed_copy_is_clean(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
+    def test_disabled_skill_hook_injected_by_fabric_source_template_is_clean(self, tmp_path):
+        """Mirrors this repo's own shape: no `.claude/hooks/` deployed copy,
+        only the fabric-source `hooks/sessionstart.sh` template."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        hooks_dir = project / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text(
+            "#!/usr/bin/env bash\ncat \"$PROJECT_ROOT/.claude/skills/t0-orchestrator/SKILL.md\"\n"
+        )
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "clean" in (r.stdout + r.stderr).lower()
+
+    def test_hook_present_but_not_referencing_the_skill_still_reports_unloadable(self, tmp_path):
+        """A hook file existing is not enough — it must actually reference
+        this skill's SKILL.md path."""
+        project = _make_project(tmp_path)
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text(
+            "# T0\n\nBefore anything, invoke `@t0-orchestrator` via the Skill tool.\n"
+        )
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_DISABLED_FRONTMATTER)
+
+        hooks_dir = project / ".claude" / "hooks"
+        hooks_dir.mkdir(parents=True)
+        (hooks_dir / "sessionstart.sh").write_text("#!/usr/bin/env bash\necho '{}'\n")
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "SKILL-UNLOADABLE" in r.stdout
+
+
+class TestTriFilePlaybookMechanismGap:
+    """Finding 2 (codex): `vnx role sync` mirrors the same Mandatory Startup
+    role text into AGENTS.md/GEMINI.md, but Claude Code's SessionStart-hook
+    injection has no codex/gemini equivalent — the audit must report that
+    gap instead of auditing clean on CLAUDE.md alone."""
+
+    ROLE_MARKER_BEGIN = "<!-- VNX:BEGIN T0-ROLE -->"
+    ROLE_MARKER_END = "<!-- VNX:END T0-ROLE -->"
+
+    def _healthy_claude_side(self, project: Path):
+        t0 = project / ".claude" / "terminals" / "T0"
+        (t0 / "CLAUDE.md").write_text("@role-orchestrator.md\n")
+        (t0 / "role-orchestrator.md").write_text("# T0\n\nNo skill references here.\n")
+        return t0
+
+    def test_agents_md_with_role_marker_reports_gap(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = self._healthy_claude_side(project)
+        (t0 / "AGENTS.md").write_text(
+            f"{self.ROLE_MARKER_BEGIN}\n# T0 - VNX Master Orchestrator\n{self.ROLE_MARKER_END}\n"
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "PLAYBOOK-MECHANISM-GAP" in r.stdout
+        assert "AGENTS.md" in r.stdout
+
+    def test_gemini_md_with_role_marker_reports_gap(self, tmp_path):
+        project = _make_project(tmp_path)
+        t0 = self._healthy_claude_side(project)
+        (t0 / "GEMINI.md").write_text(
+            f"{self.ROLE_MARKER_BEGIN}\n# T0 - VNX Master Orchestrator\n{self.ROLE_MARKER_END}\n"
+        )
+
+        r = _run_static(project)
+        assert r.returncode != 0
+        assert "PLAYBOOK-MECHANISM-GAP" in r.stdout
+        assert "GEMINI.md" in r.stdout
+
+    def test_agents_md_without_role_marker_is_not_flagged(self, tmp_path):
+        """A hand-authored AGENTS.md that hasn't been synced with `vnx role
+        sync` yet carries no marker — nothing to report."""
+        project = _make_project(tmp_path)
+        t0 = self._healthy_claude_side(project)
+        (t0 / "AGENTS.md").write_text("# Project Codex notes\n\nSome custom guidance.\n")
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "PLAYBOOK-MECHANISM-GAP" not in r.stdout
+
+    def test_no_provider_files_is_not_flagged(self, tmp_path):
+        project = _make_project(tmp_path)
+        self._healthy_claude_side(project)
+
+        r = _run_static(project)
+        assert r.returncode == 0, r.stdout + r.stderr
+        assert "PLAYBOOK-MECHANISM-GAP" not in r.stdout
 
 
 class TestDefaultRootIsGitRoot:


### PR DESCRIPTION
## Summary

**F1** (`claudedocs/t0-toolcall-audit-20260715/SYNTHESIS.md`): `role-orchestrator.md`'s Mandatory Startup told T0 to `load @t0-orchestrator` via the Skill tool, but commit `3e2592f9` (A-4 skill frontmatter hardening, 2026-05-29) set `disable-model-invocation: true` on that skill — `Unknown skill: t0-orchestrator`, 4/4 measured attempts, ~7 weeks live in the fabric source itself. Fix (a) only, per dispatch: passive content-in-context import. Fix (b) (flipping the flag back) is explicitly out of scope — forbidden by the dispatch, not attempted.

## Changes

1. **`.claude/terminals/T0/CLAUDE.md`** — passively `@`-imports the skill body directly (`@../../skills/t0-orchestrator/SKILL.md`), so the playbook reaches T0's context at session start without any Skill-tool call.
2. **`.claude/terminals/T0/role-orchestrator.md`** — both dead-instruction occurrences rewritten conditional:
   - Mandatory Startup: in-context → proceed; not-in-context → invoke `@t0-orchestrator`; invocation fails → STOP and flag drift.
   - Crash Recovery: references "the t0-orchestrator playbook §7" instead of implying a load action.
   - This works in both fleet states — vnx (post-fix, in-context) and MC/SEO today (no import yet, but skill still model-invocable there).
3. **`scripts/commands/t0_role_audit.sh`** — new `--static [project_root]` mode (default: git root of cwd), detecting two finding classes:
   - `IMPORT-MISSING` — an `@`-import in T0's CLAUDE.md/role-orchestrator.md resolves to a file that doesn't exist.
   - `SKILL-UNLOADABLE` — a backtick `@<skill>` reference in role-orchestrator.md names a skill that's neither in-context (CLAUDE.md import) nor model-invocable (missing SKILL.md, or `disable-model-invocation: true` and not imported).
   Also runs automatically per project discovered by the existing live-tmux and registry flows, so drift surfaces without a separate invocation. Standalone (no `bin/vnx` dependency), naive frontmatter grep only (no YAML parser).
4. **`bin/vnx` `cmd_role_sync`** — new NOTE-level warning (never blocking) when a target project has neither the CLAUDE.md import nor a model-invocable t0-orchestrator skill. Reuses the same grep-level detection rule; does not duplicate the audit script's function. `vnx_cli/commands/role.py` needed no change — it delegates wholesale to `bin/vnx`, so the NOTE surfaces on both CLIs by construction.
5. **Tests** — `tests/test_t0_role_audit_static.py` (new, 8 cases: healthy/clean, IMPORT-MISSING, SKILL-UNLOADABLE not-imported, SKILL-UNLOADABLE missing-entirely (sales-copilot case), invocable-variant-clean, imported-into-context-clean, default-root-is-git-root, and a regression guard that this repo itself passes `--static`) + 3 new cases in `tests/test_role_sync.py` for the `cmd_role_sync` NOTE.

## Verification

- `bash -n bin/vnx` and `bash -n scripts/commands/t0_role_audit.sh` — both pass.
- `python3 -m pytest tests/test_role_sync.py tests/test_t0_role_audit_static.py -v` — **29/29 passed**.
- `bash scripts/commands/t0_role_audit.sh --static "$(pwd)"` on this worktree post-fix — `(clean — no role<->skill invocability drift found)`, exit 0.
- `grep -n "load \`@t0-orchestrator\`" .claude/terminals/T0/role-orchestrator.md` — empty (acceptance criterion 2).
- Ran the same live-session audit against the real fleet (`~/Development/vnx-orchestration` main checkout, sales-copilot, MC, SEOcrawler_v2) — correctly flagged the **still-broken** main checkout (`disable-model-invocation: true`, not imported) and the sales-copilot **missing-skill-entirely** case, exactly matching the dispatch's known facts. Confirms the detector works against real, not just synthetic, drift.
- `python3 -m pytest tests/ --collect-only -q` — 17268 tests collected, no import errors introduced.
- `SKIP_WHEEL=1 bash scripts/local-ci.sh` — passes. Full `scripts/local-ci.sh` (with the wheel-install gate) fails on an unrelated pre-existing footprint assertion (`in-project footprint 12666 bytes >= 10 KB`) — reproduced identically on unmodified `main` at this commit via `git stash` (see Open Items). GitHub Actions "VNX CI" is green on the last 3 main commits including current HEAD, so this is a local-environment-only issue, not a regression from this PR.
- Path resolution for the new `../../` import verified via `ls .claude/terminals/T0/../../skills/t0-orchestrator/SKILL.md` (resolves) both before and after the edit.

**Smoke test not performed as literally specified** (spawn a throwaway interactive `claude` session, cwd `.claude/terminals/T0`, confirm playbook content in context): this worker's permission profile denies `WebSearch`/`WebFetch`, and the fleet's hard rule forbids headless `claude -p` for Claude/Opus/Sonnet (`docs/core/DISPATCH_RULES.md` — tmux-spawn lane only). Neither tool was available to drive or verify a live nested session from this headless dispatch. Verified instead via: (1) static path resolution, (2) the identical `@`-import mechanism already provably working in this exact session's own system prompt (`@~/.claude/profile.md`, `@role-orchestrator.md`) per Claude Code's documented import semantics (relative-to-file resolution, recursive). Flagged as a residual gap in Open Items — a human or an interactive session should do the literal live smoke test before or shortly after merge.

## Open Items

- **Live interactive smoke test not performed** (see Verification) — needs a human-driven or tmux-spawn-lane interactive session in `.claude/terminals/T0` to literally confirm the playbook heading appears in context pre-any-Skill-call. Static + mechanism-level evidence is strong but this is the one acceptance-criterion-1 check not done exactly as specified.
- **`architect` skill investigation** (dispatch item 4, report-only, no flags changed):
  - Two independent copies exist: `skills/architect/SKILL.md` (fabric source, no `disable-model-invocation`) vs `.claude/skills/architect/SKILL.md` (this repo's self-hosted install, has the flag — added by 3e2592f9, source copy untouched by that commit).
  - No literal "load `@architect`" imperative found anywhere (roles, docs, scripts) analogous to t0-orchestrator's — `fpc_certification_checks.py:685`'s `skill_name="architect"` is dispatch-routing metadata, not a Skill-tool call; the many `**Skill**: @architect` fields in dispatch-spec docs/tests are worker-routing metadata (subprocess/tmux lane injects that terminal's own skill context, unaffected by this flag).
  - **Residual risk found**: `hooks/sessionstart.sh:118` injects `"Available skills: @t0-orchestrator @architect @planner"` into T0's session context. `architect` carries `disable-model-invocation: true`; `planner` (listed right next to it) does not. This ambiguous phrasing could nudge an autonomous T0 into the same "Unknown skill" failure mode as F1, for `architect` specifically. Verdict: flag itself isn't proven wrong, but the sessionstart hook line is a related, unaddressed risk — worth its own follow-up dispatch (distinguish model-invocable from operator-only in that context string, or drop `@architect` from the autonomous-facing list).
- **`control-centre` skill investigation** (report-only, no flags changed): flag is correct. Per ADR-017, Control Centre is an operator-launched interactive session (`user-invocable: true`); `docs/operations/CONTROL_CENTRE.md` and `control_centre_cli.py` confirm all operations are driven by an operator running the CLI directly, never by a model autonomously invoking the Skill tool. No dead instruction found.
- **Fleet rollout follow-up** (explicitly out of scope for this PR): MC, SEOcrawler, sales-copilot still lack the CLAUDE.md skill-body import. `bin/vnx role sync`'s new NOTE will surface this per-project on next sync; sales-copilot additionally needs the `t0-orchestrator` skill file installed at all (currently missing entirely, per dispatch's known facts and reconfirmed by the live audit run in Verification).
- **`scripts/local-ci.sh` wheel-install gate**: pre-existing local-only failure (`in-project footprint 12666 bytes >= 10 KB`), reproduces on unmodified main, unrelated to this diff. GitHub Actions CI is green. Not fixed here — out of scope for F1.

Dispatch-ID: 20260716-f1-t0-startup-import