### PR TITLE
fix(lane-autopr-followups): OI-626 + OI-627 — autopr_rejected mirror + dispatch-id/staging-id guard

### DIFF
--- a/scripts/lib/staging_validator.py
+++ b/scripts/lib/staging_validator.py
@@ -90,9 +90,18 @@ def validate_staging_path(
         # PATH TRAVERSAL FIX — validate format before any path join
         if not _DISPATCH_ID_RE.match(sid):
             _reject("staging-pending-flow violated: invalid dispatch_id format")
-        if dispatch_id is not None and dispatch_id.strip() != sid:
+        # OI-627 follow-up: compare the RAW dispatch_id (no .strip()) against sid.
+        # Both entry-points (subprocess_dispatch.py, tmux_interactive_dispatch.py)
+        # thread the raw, unstripped args.dispatch_id into every downstream use
+        # (worktree/branch name, VNX_CURRENT_DISPATCH_ID env var, commit trailer).
+        # Stripping only for this comparison let a caller pass e.g. "real-id "
+        # (trailing whitespace) and slip past the guard while downstream code
+        # still executed under the differing raw value — reopening the exact
+        # provenance break this guard exists to close. Comparing raw-to-raw
+        # means guard-pass implies byte-for-byte identity with what runs next.
+        if dispatch_id is not None and dispatch_id != sid:
             _reject(
-                f"staging-pending-flow violated: --dispatch-id {dispatch_id.strip()!r} "
+                f"staging-pending-flow violated: --dispatch-id {dispatch_id!r} "
                 f"does not match --from-staging-id {sid!r} — the executed dispatch "
                 "(worktree, worker env, commit provenance trailer) must run under the "
                 "same id that was staged"

--- a/scripts/lib/staging_validator.py
+++ b/scripts/lib/staging_validator.py
@@ -53,6 +53,7 @@ def validate_staging_path(
     reason: Optional[str],
     *,
     data_dir: Optional[Path] = None,
+    dispatch_id: Optional[str] = None,
 ) -> None:
     """Enforce the staging→pending→promote dispatch gate.
 
@@ -64,6 +65,15 @@ def validate_staging_path(
         allow_unstaged:  Explicit bypass (requires non-empty reason for audit trail).
         reason:          Audit reason string — required with allow_unstaged.
         data_dir:        VNX data root (auto-resolved via project_root when None).
+        dispatch_id:     The --dispatch-id the caller is about to actually execute
+            with (OI-627). Only the staging *id* was previously checked for
+            existence — the lane then spawns the worker, worktree, and
+            provenance trailer (VNX_CURRENT_DISPATCH_ID) under a separately
+            supplied --dispatch-id with no cross-check, so a caller passing
+            mismatched values silently commits under the wrong id and breaks
+            the dispatch->commit provenance chain. When both are given they
+            must match exactly. Optional (defaults to None = no check) so
+            existing callers/tests that don't pass it are unaffected.
     """
     if allow_unstaged:
         if not reason or not reason.strip():
@@ -80,6 +90,13 @@ def validate_staging_path(
         # PATH TRAVERSAL FIX — validate format before any path join
         if not _DISPATCH_ID_RE.match(sid):
             _reject("staging-pending-flow violated: invalid dispatch_id format")
+        if dispatch_id is not None and dispatch_id.strip() != sid:
+            _reject(
+                f"staging-pending-flow violated: --dispatch-id {dispatch_id.strip()!r} "
+                f"does not match --from-staging-id {sid!r} — the executed dispatch "
+                "(worktree, worker env, commit provenance trailer) must run under the "
+                "same id that was staged"
+            )
         _data = _resolve_data_dir(data_dir)
         dispatches = _data / "dispatches"
         if _exists_in_dir(dispatches / "pending", sid) or _exists_in_dir(

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -519,11 +519,15 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # ADR-006: staging→pending→promote gate — must pass before any dispatch work.
+    # OI-627: dispatch_id=args.dispatch_id cross-checks the id actually executed
+    # against the staged id — a caller cannot stage under the real id and then
+    # run (and stamp the commit trailer) under a different one.
     from staging_validator import validate_staging_path as _validate_staging  # noqa: PLC0415
     _validate_staging(
         getattr(args, "from_staging_id", None),
         getattr(args, "allow_unstaged", False),
         getattr(args, "reason", None),
+        dispatch_id=args.dispatch_id,
     )
 
     # Wave-5 ADR injection opt-out: set env var before instruction assembly (INT-2)

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2657,11 +2657,15 @@ def main(argv: "list[str] | None" = None) -> int:
     args = parser.parse_args(argv)
 
     # ADR-006: staging→pending→promote gate — must pass before any dispatch work.
+    # OI-627: dispatch_id=args.dispatch_id cross-checks the id actually executed
+    # against the staged id — a caller cannot stage under the real id and then
+    # run (and stamp the commit trailer) under a different one.
     from staging_validator import validate_staging_path as _validate_staging  # noqa: PLC0415
     _validate_staging(
         getattr(args, "from_staging_id", None),
         getattr(args, "allow_unstaged", False),
         getattr(args, "reason", None),
+        dispatch_id=args.dispatch_id,
     )
 
     lane = TmuxInteractiveDispatch(

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -166,8 +166,13 @@ sys.path.insert(0, str(Path(scripts_dir) / 'lib'))
 from vnx_paths import ensure_env
 p = ensure_env()
 # G2: if a phantom-guard corrective receipt already rejected this dispatch,
-# downgrade the persisted outcome_status to failed. Fail-open: any read error
-# leaves the original status untouched.
+# downgrade the persisted outcome_status to failed. OI-626: mirrors
+# dispatch_govern.dedup_completion_receipts' Tier-0 override, which honors an
+# autopr_rejected receipt (pr_enforcement.py: branch pushed but no PR found/
+# created) the same way it honors phantom_rejected — without this mirror the
+# shell-processed intelligence-DB outcome_status disagreed with the python-lane
+# receipt resolution for a rejected auto-PR. Fail-open: any read error leaves
+# the original status untouched.
 ledger = Path(p['VNX_STATE_DIR']) / 't0_receipts.ndjson'
 try:
     if ledger.exists():
@@ -182,7 +187,9 @@ try:
                     continue
                 if not isinstance(r, dict):
                     continue
-                if r.get('dispatch_id') == dispatch_id and r.get('phantom_rejected') is True:
+                if r.get('dispatch_id') == dispatch_id and (
+                    r.get('phantom_rejected') is True or r.get('autopr_rejected') is True
+                ):
                     status = 'failed'
                     break
 except Exception:

--- a/tests/dispatch/test_staging_enforcement.py
+++ b/tests/dispatch/test_staging_enforcement.py
@@ -127,6 +127,89 @@ class TestStagingEnforcement:
 
 
 # ---------------------------------------------------------------------------
+# OI-627 — --dispatch-id must match --from-staging-id
+#
+# Prior to this fix, validate_staging_path only checked that --from-staging-id
+# existed in pending/staging — it never cross-checked that the id the lane
+# actually executes (args.dispatch_id, which becomes the worktree/branch name,
+# the VNX_CURRENT_DISPATCH_ID env var, and ultimately the "Dispatch-ID:" git
+# commit trailer via the prepare-commit-msg hook) was the SAME id. A caller
+# could stage a spec bundle under the real governed id and then fire the lane
+# with an unrelated --dispatch-id, producing a real PR whose commit trailer
+# carries the wrong id and breaks dispatch->commit provenance (observed in
+# production: PR #1171 committed under the real dispatch
+# '20260715-hashchain-anchor' but the commit trailer read
+# 'Dispatch-ID: dispatch-fwd-02').
+# ---------------------------------------------------------------------------
+
+class TestDispatchIdMatchesStagingId:
+
+    def test_accepts_matching_dispatch_id_and_staging_id(self, tmp_path: Path) -> None:
+        """A fix-forward-style invocation where --dispatch-id == --from-staging-id passes."""
+        _make_pending_dispatch(tmp_path, "20260715-hashchain-anchor")
+        validate_staging_path(
+            "20260715-hashchain-anchor",
+            False,
+            None,
+            data_dir=tmp_path,
+            dispatch_id="20260715-hashchain-anchor",
+        )
+
+    def test_rejects_mismatched_dispatch_id(self, tmp_path: Path, capsys) -> None:
+        """A fix-forward-style invocation with a different --dispatch-id is rejected loudly."""
+        _make_pending_dispatch(tmp_path, "20260715-hashchain-anchor")
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "20260715-hashchain-anchor",
+                False,
+                None,
+                data_dir=tmp_path,
+                dispatch_id="dispatch-fwd-02",
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+        assert "dispatch-fwd-02" in captured.err
+        assert "20260715-hashchain-anchor" in captured.err
+
+    def test_mismatch_rejected_before_existence_check(self, tmp_path: Path, capsys) -> None:
+        """The id-match check fires even when the staged bundle doesn't exist yet —
+        a mismatched --dispatch-id is a caller bug regardless of staging state."""
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "20260715-hashchain-anchor",
+                False,
+                None,
+                data_dir=tmp_path,
+                dispatch_id="dispatch-fwd-02",
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "does not match" in captured.err
+
+    def test_dispatch_id_none_skips_check_backward_compat(self, tmp_path: Path) -> None:
+        """Callers that don't pass dispatch_id= (legacy call sites, other tests) are unaffected."""
+        _make_pending_dispatch(tmp_path, "20260601-test-dispatch")
+        validate_staging_path(
+            "20260601-test-dispatch",
+            False,
+            None,
+            data_dir=tmp_path,
+        )
+
+    def test_allow_unstaged_bypass_ignores_dispatch_id_mismatch(self, tmp_path: Path) -> None:
+        """--allow-unstaged is an explicit, audited bypass — it short-circuits before the
+        staging-id path entirely, so a dispatch_id mismatch is moot there."""
+        validate_staging_path(
+            None,
+            True,
+            "emergency hotfix",
+            data_dir=tmp_path,
+            dispatch_id="anything-goes-here",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Wiring checks — validate that both CLI entry-points declare the new args
 # ---------------------------------------------------------------------------
 
@@ -153,6 +236,10 @@ class TestArgWiring:
         assert "--allow-unstaged" in src
         assert "--reason" in src
         assert "validate_staging_path" in src
+        assert "dispatch_id=args.dispatch_id" in src, (
+            "OI-627: subprocess_dispatch must thread args.dispatch_id into "
+            "validate_staging_path so a mismatched --dispatch-id is rejected"
+        )
 
     def test_tmux_interactive_dispatch_declares_staging_args(self) -> None:
         """tmux_interactive_dispatch main() parser must accept --from-staging-id etc."""
@@ -164,6 +251,10 @@ class TestArgWiring:
         assert "--allow-unstaged" in src
         assert "--reason" in src
         assert "validate_staging_path" in src
+        assert "dispatch_id=args.dispatch_id" in src, (
+            "OI-627: tmux_interactive_dispatch must thread args.dispatch_id into "
+            "validate_staging_path so a mismatched --dispatch-id is rejected"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/dispatch/test_staging_enforcement.py
+++ b/tests/dispatch/test_staging_enforcement.py
@@ -208,6 +208,57 @@ class TestDispatchIdMatchesStagingId:
             dispatch_id="anything-goes-here",
         )
 
+    def test_rejects_dispatch_id_with_trailing_whitespace(self, tmp_path: Path, capsys) -> None:
+        """Codex finding: the guard used to compare dispatch_id.strip() against sid while
+        both entry-points (subprocess_dispatch.py, tmux_interactive_dispatch.py) go on to
+        use the RAW, unstripped args.dispatch_id for the worktree/branch name, the
+        VNX_CURRENT_DISPATCH_ID env var, and the commit trailer. A caller passing
+        --from-staging-id 'real-id' --dispatch-id 'real-id ' (trailing space) used to
+        slip past the guard while downstream code ran under a byte-different id — the
+        exact provenance break the guard exists to close. It must now be rejected."""
+        _make_pending_dispatch(tmp_path, "real-id")
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "real-id",
+                False,
+                None,
+                data_dir=tmp_path,
+                dispatch_id="real-id ",
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+        assert "does not match" in captured.err
+
+    def test_rejects_dispatch_id_with_leading_whitespace(self, tmp_path: Path, capsys) -> None:
+        """Same gap, leading-whitespace variant — guard must reject, not silently strip."""
+        _make_pending_dispatch(tmp_path, "real-id")
+        with pytest.raises(SystemExit) as exc_info:
+            validate_staging_path(
+                "real-id",
+                False,
+                None,
+                data_dir=tmp_path,
+                dispatch_id=" real-id",
+            )
+        assert exc_info.value.code == 1
+        captured = capsys.readouterr()
+        assert "staging-pending-flow violated" in captured.err
+
+    def test_accepts_dispatch_id_with_whitespace_when_staging_id_matches_raw(
+        self, tmp_path: Path
+    ) -> None:
+        """Sanity check: raw-to-raw comparison still passes when both sides carry the
+        identical (untrimmed) value — the guard rejects DIVERGENCE, not whitespace itself."""
+        _make_pending_dispatch(tmp_path, "real-id")
+        validate_staging_path(
+            "real-id",
+            False,
+            None,
+            data_dir=tmp_path,
+            dispatch_id="real-id",
+        )
+
 
 # ---------------------------------------------------------------------------
 # Wiring checks — validate that both CLI entry-points declare the new args

--- a/tests/test_receipt_processor_autopr_rejected_mirror.py
+++ b/tests/test_receipt_processor_autopr_rejected_mirror.py
@@ -1,0 +1,282 @@
+"""Tests for OI-626: receipt_processor.sh must mirror the autopr_rejected
+outcome_status downgrade the python lanes already apply.
+
+dispatch_govern.dedup_completion_receipts' Tier-0 override treats an
+autopr_rejected corrective receipt (pr_enforcement.py: branch pushed but no PR
+found/created) the same way it treats a phantom_rejected one — final,
+overriding the worker's own claim. receipt_processor.sh:185's inline python
+snippet (_psr_update_dispatch_outcome) previously only checked
+phantom_rejected when downgrading the persisted quality_intelligence.db
+outcome_status, so an autopr-rejected dispatch stayed 'done' in the shell-
+processed intelligence DB while dedup_completion_receipts resolved it as
+rejected — an inconsistent audit trail across the two paths.
+
+Exercises the REAL _psr_update_dispatch_outcome by sourcing receipt_processor.sh
+in _RP_LIB_MODE=1 (same pattern as test_receipt_processor_bootstrap.py), not a
+reimplementation of its logic.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import subprocess
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+RP_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+from dispatch_govern import dedup_completion_receipts  # noqa: E402
+
+
+def _init_dispatch_metadata_db(db_path: Path, dispatch_id: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL,
+            terminal TEXT NOT NULL,
+            track TEXT NOT NULL,
+            outcome_status TEXT,
+            outcome_report_path TEXT,
+            completed_at TEXT
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO dispatch_metadata (dispatch_id, project_id, terminal, track, outcome_status) "
+        "VALUES (?, 'vnx-dev', 'T1', 'A', NULL)",
+        (dispatch_id,),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _read_outcome_status(db_path: Path, dispatch_id: str) -> "str | None":
+    conn = sqlite3.connect(str(db_path))
+    row = conn.execute(
+        "SELECT outcome_status FROM dispatch_metadata WHERE dispatch_id = ?",
+        (dispatch_id,),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+def _run_update_dispatch_outcome(
+    dispatch_id: str,
+    status: str,
+    receipts: "list[dict] | None" = None,
+    event_type: str = "task_complete",
+) -> "tuple[int, str, str | None]":
+    """Source the real receipt_processor.sh and invoke _psr_update_dispatch_outcome.
+
+    Returns (returncode, stderr, final_outcome_status_from_db).
+    """
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        state = tmp / "state"
+        data_dir = tmp / "data"
+        unified = tmp / "unified"
+        headless = tmp / "headless"
+        pids = tmp / "pids"
+        locks = tmp / "locks"
+        for d in (state, data_dir, unified, headless, pids, locks):
+            d.mkdir(parents=True)
+
+        db_path = state / "quality_intelligence.db"
+        _init_dispatch_metadata_db(db_path, dispatch_id)
+
+        if receipts:
+            ledger = state / "t0_receipts.ndjson"
+            with ledger.open("w", encoding="utf-8") as f:
+                for r in receipts:
+                    f.write(json.dumps(r) + "\n")
+
+        timestamp = "2026-07-16T12:00:00Z"
+
+        bash_cmd = f"""
+set -e
+export _RP_LIB_MODE=1
+export VNX_DATA_DIR="{data_dir}"
+export VNX_DATA_DIR_EXPLICIT=1
+export VNX_STATE_DIR="{state}"
+export VNX_PIDS_DIR="{pids}"
+export VNX_LOCKS_DIR="{locks}"
+export VNX_REPORTS_DIR="{unified}"
+export VNX_HEADLESS_REPORTS_DIR="{headless}"
+source "{RP_SCRIPT}" || {{ echo "FATAL: source {RP_SCRIPT} failed" >&2; exit 1; }}
+
+_psr_update_dispatch_outcome "{dispatch_id}" "{event_type}" "{status}" "" "{timestamp}"
+"""
+        result = subprocess.run(["bash", "-c", bash_cmd], capture_output=True, text=True)
+        final_status = _read_outcome_status(db_path, dispatch_id)
+        return result.returncode, result.stderr, final_status
+
+
+# ---------------------------------------------------------------------------
+# receipt_processor.sh shell-lane behavior
+# ---------------------------------------------------------------------------
+
+def test_autopr_rejected_receipt_downgrades_outcome_to_failed():
+    """A worker-claimed 'done' status must be downgraded to 'failed' in the
+    intelligence DB when a corrective autopr_rejected receipt exists for the
+    same dispatch — mirroring the python-lane Tier-0 override."""
+    dispatch_id = "20260716-autopr-rejected-test"
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id,
+        "done",
+        receipts=[
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": dispatch_id,
+                "status": "failed",
+                "autopr_rejected": True,
+                "autopr_reason": "gh pr create failed for branch dispatch/20260716-autopr-rejected-test",
+                "source": "pr_enforcement",
+                "timestamp": "2026-07-16T11:59:00Z",
+            }
+        ],
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "failed", (
+        f"Expected outcome_status downgraded to 'failed' via autopr_rejected mirror, "
+        f"got {final_status!r}. stderr:\n{stderr}"
+    )
+
+
+def test_phantom_rejected_receipt_still_downgrades_outcome_to_failed():
+    """Regression guard: the pre-existing phantom_rejected mirror must keep working
+    after extending the condition to also cover autopr_rejected."""
+    dispatch_id = "20260716-phantom-rejected-test"
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id,
+        "done",
+        receipts=[
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": dispatch_id,
+                "status": "failed",
+                "phantom_rejected": True,
+                "source": "phantom_guard",
+                "timestamp": "2026-07-16T11:59:00Z",
+            }
+        ],
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "failed"
+
+
+def test_no_corrective_receipt_keeps_worker_claimed_status():
+    """No phantom_rejected / autopr_rejected receipt on the ledger for this
+    dispatch → the worker-claimed status is persisted as-is."""
+    dispatch_id = "20260716-no-override-test"
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id,
+        "done",
+        receipts=[
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": dispatch_id,
+                "status": "done",
+                "source": "tmux_interactive",
+                "timestamp": "2026-07-16T11:59:00Z",
+            }
+        ],
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "done"
+
+
+def test_autopr_rejected_false_does_not_trigger_downgrade():
+    """An explicit autopr_rejected=False on an unrelated receipt must not
+    trigger the override (only autopr_rejected is True counts)."""
+    dispatch_id = "20260716-autopr-false-test"
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id,
+        "done",
+        receipts=[
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": dispatch_id,
+                "status": "done",
+                "autopr_rejected": False,
+                "source": "tmux_interactive",
+                "timestamp": "2026-07-16T11:59:00Z",
+            }
+        ],
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "done"
+
+
+def test_other_dispatch_autopr_rejection_does_not_leak():
+    """An autopr_rejected receipt for a DIFFERENT dispatch_id must not affect
+    this one (dispatch_id scoping)."""
+    dispatch_id = "20260716-scoped-test"
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id,
+        "done",
+        receipts=[
+            {
+                "event_type": "subprocess_completion",
+                "dispatch_id": "some-other-dispatch",
+                "status": "failed",
+                "autopr_rejected": True,
+                "source": "pr_enforcement",
+                "timestamp": "2026-07-16T11:59:00Z",
+            }
+        ],
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "done"
+
+
+# ---------------------------------------------------------------------------
+# Parity — the shell lane and the python lane (dispatch_govern) must classify
+# the exact same autopr_rejected receipt set identically.
+# ---------------------------------------------------------------------------
+
+def test_shell_and_python_lane_agree_on_autopr_rejected_classification():
+    """Same receipt set fed to both the shell processor's outcome-downgrade
+    check and dispatch_govern.dedup_completion_receipts (the python lane) must
+    agree that the dispatch is rejected/failed, not done."""
+    dispatch_id = "20260716-parity-test"
+    receipts = [
+        {
+            "event_type": "subprocess_completion",
+            "dispatch_id": dispatch_id,
+            "status": "done",
+            "source": "tmux_interactive",
+            "timestamp": "2026-07-16T11:58:00Z",
+        },
+        {
+            "event_type": "subprocess_completion",
+            "dispatch_id": dispatch_id,
+            "status": "failed",
+            "autopr_rejected": True,
+            "source": "pr_enforcement",
+            "timestamp": "2026-07-16T11:59:00Z",
+        },
+    ]
+
+    # Python lane
+    preferred = dedup_completion_receipts(
+        [r for r in receipts if r["dispatch_id"] == dispatch_id]
+    )
+    assert preferred is not None
+    assert preferred["status"] == "failed", "python lane must resolve as failed"
+
+    # Shell lane
+    rc, stderr, final_status = _run_update_dispatch_outcome(
+        dispatch_id, "done", receipts=receipts,
+    )
+    assert rc == 0, f"_psr_update_dispatch_outcome failed rc={rc}:\n{stderr}"
+    assert final_status == "failed", "shell lane must resolve as failed to match the python lane"
+    assert final_status == preferred["status"], (
+        f"shell lane ({final_status!r}) and python lane ({preferred['status']!r}) "
+        "must classify the same autopr_rejected receipt identically"
+    )


### PR DESCRIPTION
## Summary

Two follow-up fixes on the #1170 (lane-autopr-enforce) lane/receipt surface, closing OI-626 and OI-627.

**OI-626 — receipt_processor.sh missing autopr_rejected mirror.** `dispatch_govern.dedup_completion_receipts`'s Tier-0 override treats an `autopr_rejected` corrective receipt (from `pr_enforcement.py`: branch pushed but no PR found/created) as final, the same way it treats `phantom_rejected`. `receipt_processor.sh`'s inline outcome-downgrade check (`_psr_update_dispatch_outcome`) only checked `phantom_rejected`, so the shell-processed `quality_intelligence.db` `outcome_status` disagreed with the python-lane's receipt resolution for a rejected auto-PR. Extended the condition to match.

**OI-627 — auto-PR trailer carries the wrong Dispatch-ID on fix-forward paths.** `validate_staging_path()` (ADR-006 staging gate) checked that `--from-staging-id` existed under `pending/`/`staging/`, but never cross-checked it against the separately-supplied `--dispatch-id` the lane actually executes with — the id that becomes the worktree/branch name, the `VNX_CURRENT_DISPATCH_ID` env var in the worker's tmux pane, and ultimately the `Dispatch-ID:` commit trailer via the `prepare-commit-msg` hook. A caller could stage a spec under the real governed id and then fire the lane with an unrelated `--dispatch-id`, silently breaking the dispatch→commit provenance chain — this is exactly what happened in production: PR #1171 committed and pushed correctly, but its trailer read `Dispatch-ID: dispatch-fwd-02` instead of the real `20260715-hashchain-anchor`. Added a hard mismatch check, wired into both the tmux-spawn and subprocess lanes.

## Changes

- `scripts/receipt_processor.sh` — `_psr_update_dispatch_outcome`'s ledger-scan condition now checks `phantom_rejected is True or autopr_rejected is True` (was `phantom_rejected` only).
- `scripts/lib/staging_validator.py` — `validate_staging_path()` gains an optional keyword-only `dispatch_id` param; when both `from_staging_id` and `dispatch_id` are given and they differ, rejects with `staging-pending-flow violated: --dispatch-id ... does not match --from-staging-id ...`. Backward compatible (defaults to `None` = no check).
- `scripts/lib/tmux_interactive_dispatch.py` — `main()` now passes `dispatch_id=args.dispatch_id` into `validate_staging_path`.
- `scripts/lib/subprocess_dispatch.py` — same wiring for the subprocess lane (Codex Defense Checklist: same fix to all handlers).
- `tests/test_receipt_processor_autopr_rejected_mirror.py` (new) — sources the real `receipt_processor.sh` in `_RP_LIB_MODE=1` and exercises `_psr_update_dispatch_outcome` directly against a `t0_receipts.ndjson` fixture + a `quality_intelligence.db` fixture; includes a parity test asserting the shell lane and `dispatch_govern.dedup_completion_receipts` (python lane) classify the same `autopr_rejected` receipt identically.
- `tests/dispatch/test_staging_enforcement.py` — new `TestDispatchIdMatchesStagingId` class (match/mismatch/backward-compat/bypass cases) plus wiring assertions that both CLI entry-points thread `dispatch_id=args.dispatch_id`.

## Verification

- `bash -n scripts/receipt_processor.sh` → OK
- `python3 -c "import ast; ast.parse(...)"` on all three modified `.py` files → OK
- `python3 -m pytest tests/test_receipt_processor_autopr_rejected_mirror.py tests/dispatch/test_staging_enforcement.py -v` → **25 passed**
- Regression proof: `git stash` on the production fixes, re-ran the same two test files → the two autopr-mirror tests fail as expected (`assert 'done' == 'failed'`, `assert 'done' == 'failed'`), the 4 unrelated ones still pass; `git stash pop` restored the fix and all 25 pass again.
- `python3 -m pytest tests/ -k "staging or dispatch_govern or tmux_interactive or subprocess_dispatch or receipt_processor or pr_enforcement" -q` → 478 passed, 23 failed. Diffed each failing test against the pre-change baseline (`git stash` the 4 production files, re-run): all 23 fail identically on baseline (`test_dashboard_kanban_certification.py`, `test_provider_dispatch_governance_integration.py`, `test_subprocess_dispatch_identity.py::test_deliver_without_extra_env_inherits_default`, `test_subprocess_dispatch_worktree_isolation.py::test_repo_root_no_override`, `test_tmux_interactive_dispatch.py::test_completion_protocol_absolute_path` + `test_worker_receipt_carries_provider_model_lane`) — pre-existing, unrelated to this change.
- `python3 -m pytest tests/ -k "pr_enforcement or gh_pr_ensure" -q` → 30 passed (untouched by this PR, confirms no regression on the adjacent auto-PR mechanism).
- Known pre-existing red (out of scope, per dispatch note): OI-624 doctor-smoke `.claude/skills/skills.yaml` regression — not touched here.

## Test plan

- [x] `_psr_update_dispatch_outcome` downgrades `outcome_status` to `failed` when an `autopr_rejected` receipt exists for the dispatch (and still does for `phantom_rejected`; and does NOT for unrelated/other-dispatch/false receipts)
- [x] Shell lane and python lane (`dedup_completion_receipts`) agree on the same receipt set
- [x] `validate_staging_path(dispatch_id=...)` rejects a mismatched `--dispatch-id`/`--from-staging-id` pair, accepts a matching pair, and is a no-op when `dispatch_id` isn't passed (backward compat)
- [x] Both CLI entry-points (tmux + subprocess) wire `dispatch_id=args.dispatch_id` into the validator

🤖 Generated with [Claude Code](https://claude.com/claude-code)