### PR TITLE
fix(oi622-623-625): status PermissionError degrade + loud sqlite3.Error logging + guard-test snippet execution

### DIFF
--- a/scripts/lib/injection_effectiveness_probe.py
+++ b/scripts/lib/injection_effectiveness_probe.py
@@ -109,7 +109,8 @@ def _read_pattern_usage_totals(db_path: Path) -> Tuple[int, int]:
             ).fetchone()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("_read_pattern_usage_totals: query failed on %s: %s", db_path, exc)
         return 0, 0
     if row is None:
         return 0, 0
@@ -129,7 +130,8 @@ def _read_last_dream_cycle(db_path: Path) -> Optional[str]:
             ).fetchone()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("_read_last_dream_cycle: query failed on %s: %s", db_path, exc)
         return None
     if row is None:
         return None
@@ -305,7 +307,8 @@ def _read_reason_counts(db_path: Path) -> Dict[str, int]:
             ).fetchall()
         finally:
             conn.close()
-    except sqlite3.Error:
+    except sqlite3.Error as exc:
+        logger.warning("_read_reason_counts: query failed on %s: %s", db_path, exc)
         return {}
     return {str(reason): int(count) for reason, count in rows}
 

--- a/tests/test_injection_effectiveness_probe.py
+++ b/tests/test_injection_effectiveness_probe.py
@@ -263,6 +263,36 @@ def test_missing_pattern_usage_table_is_treated_as_no_data(tmp_path):
     assert result.detail["ignored_count"] == 0
 
 
+# --- OI-623: sqlite3.Error must be logged loudly, never suppressed silently ---
+
+def test_read_pattern_usage_totals_logs_on_sqlite_error(tmp_path, caplog):
+    from injection_effectiveness_probe import _read_pattern_usage_totals
+
+    db_path = tmp_path / "quality_intelligence.db"
+    sqlite3.connect(str(db_path)).close()  # exists, but no pattern_usage table
+
+    with caplog.at_level("WARNING", logger="injection_effectiveness_probe"):
+        result = _read_pattern_usage_totals(db_path)
+
+    assert result == (0, 0)
+    assert "_read_pattern_usage_totals" in caplog.text
+    assert "no such table" in caplog.text
+
+
+def test_read_last_dream_cycle_logs_on_sqlite_error(tmp_path, caplog):
+    from injection_effectiveness_probe import _read_last_dream_cycle
+
+    db_path = tmp_path / "quality_intelligence.db"
+    sqlite3.connect(str(db_path)).close()  # exists, but no dream_cycles table
+
+    with caplog.at_level("WARNING", logger="injection_effectiveness_probe"):
+        result = _read_last_dream_cycle(db_path)
+
+    assert result is None
+    assert "_read_last_dream_cycle" in caplog.text
+    assert "no such table" in caplog.text
+
+
 def test_corrupt_pending_rules_json_is_ignored_not_raised(tmp_path):
     _make_db(tmp_path, rows=[(80, 20)])
     (tmp_path / "pending_rules.json").write_text("{not valid json", encoding="utf-8")

--- a/tests/test_injection_reason_evaluator.py
+++ b/tests/test_injection_reason_evaluator.py
@@ -132,6 +132,19 @@ class TestBucketDistribution:
 
         assert distribution["total_ignored"] == 0
 
+    def test_missing_table_sqlite_error_is_logged_not_suppressed_silently(self, tmp_path, caplog):
+        # OI-623: the sqlite3.Error on this read path must be logged loudly,
+        # not returned as empty without a trace.
+        db_path = tmp_path / "quality_intelligence.db"
+        sqlite3.connect(str(db_path)).close()
+
+        with caplog.at_level("WARNING", logger="injection_effectiveness_probe"):
+            result = iep._read_reason_counts(db_path)
+
+        assert result == {}
+        assert "_read_reason_counts" in caplog.text
+        assert "no such table" in caplog.text
+
     def test_evaluator_never_writes_to_the_database_it_reads(self, tmp_path):
         rows = [(f"pat-{r}", 0, r) for r in NON_ADOPTION_REASONS]
         db_path = _make_outcome_db(tmp_path, rows)

--- a/tests/test_prompt_assembler.py
+++ b/tests/test_prompt_assembler.py
@@ -9,6 +9,9 @@ Tests the 3-layer user message architecture:
 
 from __future__ import annotations
 
+import os
+import re
+import subprocess
 import sys
 from pathlib import Path
 
@@ -139,12 +142,10 @@ def test_layer1_scratch_cleanup_is_noninteractive(assembler: PromptAssembler, ba
     assert "realpath" in layer1.lower(), (
         "guard must resolve the target to an absolute real path before deciding"
     )
-    for keyword in ("home", "tempdir", "tmpdir", "/tmp"):
-        assert keyword in layer1.lower(), f"guard must reference {keyword!r} in its scoping checks"
-    assert "refus" in layer1.lower(), (
-        "guard must refuse (raise/exit without deleting) on an unsafe target, "
-        "not silently proceed"
-    )
+    # NOTE: the actual refuse/allow predicates (home, tempdir, top-level dir,
+    # outside-roots) are exercised by really RUNNING the snippet, not by
+    # grepping for keywords here — see
+    # TestScratchCleanupGuardExecutes below (OI-625).
 
     # Sanity: the assembled prompt still includes L1 verbatim (regression guard
     # against a future refactor silently dropping Layer 1 from the pipe input).
@@ -154,6 +155,154 @@ def test_layer1_scratch_cleanup_is_noninteractive(assembler: PromptAssembler, ba
     )
     assert "shutil.rmtree" in prompt.context
     assert "realpath" in prompt.context.lower()
+
+
+# ---------------------------------------------------------------------------
+# TestScratchCleanupGuardExecutes (OI-625)
+# ---------------------------------------------------------------------------
+#
+# test_layer1_scratch_cleanup_is_noninteractive above only checked that the
+# guard's PROSE mentions the right keywords ("home", "tempdir", "refuse", ...).
+# That is a weak guarantee: the wording could stay intact while the actual
+# refuse/allow logic silently regresses (this is exactly the codex Round-2
+# finding on PR #1169 — an earlier version of this guard swapped a gated
+# `rm -rf` for an UNGUARDED `shutil.rmtree`, and a keyword-only test would
+# not have caught that). These tests extract the embedded `python3 -c "..."`
+# snippet out of base_worker.md's markdown fence and actually RUN it as a
+# subprocess against real target/home/tmpdir combinations, asserting the
+# observable refuse-vs-delete behavior rather than the wording.
+
+_GUARD_SNIPPET_RE = re.compile(r'python3 -c "\n(.*?)\n\s*"\n\s*```', re.DOTALL)
+
+
+def _extract_scratch_cleanup_guard(layer1: str) -> str:
+    """Pull the guard's python source out of base_worker.md's ```bash fence
+    and dedent it into runnable source (stripping the 2-space markdown-fence
+    indent). Fails loudly if the fence shape ever changes, rather than
+    silently no-op'ing the tests below."""
+    match = _GUARD_SNIPPET_RE.search(layer1)
+    assert match, "could not locate the `python3 -c \"...\"` guard snippet in base_worker.md"
+    lines = [
+        line[2:] if line.startswith("  ") else line
+        for line in match.group(1).splitlines()
+    ]
+    return "\n".join(lines)
+
+
+def _run_scratch_cleanup_guard(
+    snippet_source: str, target: Path, home: Path, tmpdir: Path
+) -> subprocess.CompletedProcess:
+    """Run the guard snippet as a real subprocess with `target` substituted
+    for the `<absolute-literal-path>` placeholder, and HOME/TMPDIR pointed at
+    isolated test directories so the guard's home/tempdir scoping checks
+    exercise controlled paths instead of the real developer machine."""
+    source = snippet_source.replace("<absolute-literal-path>", str(target))
+    env = dict(os.environ)
+    env["HOME"] = str(home)
+    env["TMPDIR"] = str(tmpdir)
+    return subprocess.run(
+        [sys.executable, "-c", source],
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=10,
+    )
+
+
+class TestScratchCleanupGuardExecutes:
+    """OI-625: run the extracted guard against the cases named in the OI —
+    /, a top-level dir, $HOME, a $HOME ancestor, and /var/tmp (outside the
+    recognized roots) must all REFUSE; a subdir under $TMPDIR must ALLOW
+    (i.e. actually delete). A future weakening of the guard predicates fails
+    one of these, not just the prose."""
+
+    @pytest.fixture()
+    def guard_source(self, assembler: PromptAssembler) -> str:
+        return _extract_scratch_cleanup_guard(assembler._load_base())
+
+    @pytest.fixture()
+    def scopes(self, tmp_path: Path) -> tuple[Path, Path]:
+        home = tmp_path / "fakehome"
+        home.mkdir()
+        scratch_root = tmp_path / "scratchroot"
+        scratch_root.mkdir()
+        return home, scratch_root
+
+    def test_refuses_filesystem_root(self, guard_source: str, scopes: tuple[Path, Path]) -> None:
+        home, scratch_root = scopes
+        result = _run_scratch_cleanup_guard(guard_source, Path("/"), home, scratch_root)
+        assert result.returncode != 0
+        assert "REFUSING" in result.stdout + result.stderr
+
+    def test_refuses_top_level_directory(self, guard_source: str, scopes: tuple[Path, Path]) -> None:
+        home, scratch_root = scopes
+        # Deliberately nonexistent — the guard must refuse before ever
+        # touching the filesystem, so a nonexistent target proves the refusal
+        # happens purely from the path shape (dirname == "/"), not from a
+        # missing-path short-circuit.
+        target = Path("/nonexistent-top-level-dir-oi625-guardtest")
+        result = _run_scratch_cleanup_guard(guard_source, target, home, scratch_root)
+        assert result.returncode != 0
+        assert "REFUSING" in result.stdout + result.stderr
+
+    def test_refuses_home(self, guard_source: str, scopes: tuple[Path, Path]) -> None:
+        home, scratch_root = scopes
+        result = _run_scratch_cleanup_guard(guard_source, home, home, scratch_root)
+        assert result.returncode != 0
+        assert "REFUSING" in result.stdout + result.stderr
+        assert home.is_dir(), "guard must never delete $HOME"
+
+    def test_refuses_home_ancestor(self, guard_source: str, tmp_path: Path) -> None:
+        home = tmp_path / "a" / "fakehome"
+        home.mkdir(parents=True)
+        scratch_root = tmp_path / "scratchroot"
+        scratch_root.mkdir()
+        ancestor = tmp_path / "a"
+        result = _run_scratch_cleanup_guard(guard_source, ancestor, home, scratch_root)
+        assert result.returncode != 0
+        assert "REFUSING" in result.stdout + result.stderr
+        assert home.is_dir(), "guard must never delete an ancestor of $HOME"
+
+    def test_refuses_var_tmp_outside_recognized_roots(
+        self, guard_source: str, scopes: tuple[Path, Path]
+    ) -> None:
+        home, scratch_root = scopes
+        # /var/tmp looks like scratch space but is NOT one of the recognized
+        # roots (tempfile.gettempdir()/$TMPDIR/'/tmp') — nonexistent leaf so a
+        # regressed guard can do no real damage even if it fails to refuse.
+        target = Path("/var/tmp") / f"vnx-oi625-guardtest-{os.getpid()}"
+        result = _run_scratch_cleanup_guard(guard_source, target, home, scratch_root)
+        assert result.returncode != 0
+        assert "REFUSING" in result.stdout + result.stderr
+        assert not target.exists()
+
+    def test_allows_subdir_under_tempdir(self, guard_source: str, scopes: tuple[Path, Path]) -> None:
+        home, scratch_root = scopes
+        victim = scratch_root / "to-delete"
+        victim.mkdir()
+        (victim / "marker.txt").write_text("x")
+        result = _run_scratch_cleanup_guard(guard_source, victim, home, scratch_root)
+        assert result.returncode == 0
+        assert "REFUSING" not in result.stdout + result.stderr
+        assert not victim.exists(), "guard must actually delete a legitimate scratch subdir"
+
+    def test_stripped_guard_would_have_failed_this_test(
+        self, scopes: tuple[Path, Path]
+    ) -> None:
+        """Proof this test class has teeth: a guard with the safety checks
+        stripped (the pre-#1169-class regression — unconditional
+        `shutil.rmtree(target, ignore_errors=True)`) silently deletes $HOME
+        instead of refusing. Guards against a future edit hollowing out the
+        real snippet's predicates while this test file goes unchanged."""
+        home, scratch_root = scopes
+        stripped_snippet = (
+            "import os, shutil, sys, tempfile\n"
+            "target = os.path.realpath('<absolute-literal-path>')\n"
+            "shutil.rmtree(target, ignore_errors=True)\n"
+        )
+        result = _run_scratch_cleanup_guard(stripped_snippet, home, home, scratch_root)
+        assert "REFUSING" not in result.stdout + result.stderr
+        assert not home.is_dir(), "sanity check: the stripped guard really does delete $HOME"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/vnx_cli/commands/test_status.py
+++ b/tests/unit/vnx_cli/commands/test_status.py
@@ -7,12 +7,17 @@ chain dispatch_agent walks — not just the project-local agents/ folder.
 """
 
 import json
+import os
 from argparse import Namespace
 from io import StringIO
 from pathlib import Path
 from unittest.mock import patch
 
+import pytest
+
 from vnx_cli.commands.status import vnx_status
+
+_CHMOD_UNRELIABLE = os.name != "posix" or (hasattr(os, "geteuid") and os.geteuid() == 0)
 
 
 def _make_agent(base: Path, name: str, rel: str = "agents") -> Path:
@@ -35,6 +40,17 @@ def _run_status_json(project_dir: Path, engine_root: Path, data_root: Path) -> d
             rc = vnx_status(args)
     assert rc == 0
     return json.loads(buf.getvalue())
+
+
+def _run_status_text(project_dir: Path, engine_root: Path, data_root: Path) -> str:
+    args = Namespace(json=False, tracks=False, project_id=None, project_dir=str(project_dir))
+    with patch("vnx_cli.commands.status._engine.resolve_data_root", return_value=data_root), \
+         patch("vnx_cli.commands.status._engine.engine_root", return_value=engine_root):
+        buf = StringIO()
+        with patch("sys.stdout", buf):
+            rc = vnx_status(args)
+    assert rc == 0
+    return buf.getvalue()
 
 
 class TestAgentCountFullChain:
@@ -94,3 +110,60 @@ class TestAgentCountFullChain:
         out = _run_status_json(project_dir, engine_root, data_root)
         assert out["agent_count"] == 0
         assert out["agents"] == []
+
+
+@pytest.mark.skipif(
+    _CHMOD_UNRELIABLE,
+    reason="chmod-based permission denial is not reliable as root or on non-POSIX platforms",
+)
+class TestAgentEnumerationPermissionError:
+    """OI-622: `vnx status` must not crash uncaught when a higher-precedence
+    agent tier directory is unreadable — it must degrade gracefully (the rest
+    of the status overview stays intact) and surface the reason explicitly,
+    never suppress it silently."""
+
+    def _make_blocked_project(self, tmp_path):
+        project_dir = tmp_path / "project"
+        _init_project(project_dir)
+        blocked_tier = project_dir / "agents"
+        blocked_tier.mkdir()
+        (blocked_tier / "blocked-agent").mkdir()
+        (blocked_tier / "blocked-agent" / "CLAUDE.md").write_text("# blocked")
+        engine_root = tmp_path / "engine"
+        _make_agent(engine_root, "backend-developer")
+        data_root = tmp_path / "data"
+        data_root.mkdir()
+        return project_dir, blocked_tier, engine_root, data_root
+
+    def test_json_degrades_with_reason(self, tmp_path):
+        project_dir, blocked_tier, engine_root, data_root = self._make_blocked_project(tmp_path)
+        os.chmod(blocked_tier, 0o000)
+        try:
+            out = _run_status_json(project_dir, engine_root, data_root)
+        finally:
+            os.chmod(blocked_tier, 0o755)
+
+        # Graceful degrade: agents section reports unavailable-with-reason,
+        # not a raised exception that takes down the whole readout.
+        assert out["agents"] == []
+        assert out["agent_count"] == 0
+        assert out["agents_status"] == "unavailable"
+        assert "Permission denied" in out["agents_error"]
+        # The rest of the status overview must still be present.
+        assert out["initialized"] is True
+        assert "active_dispatches" in out
+        assert "recent_completions" in out
+
+    def test_text_degrades_with_reason(self, tmp_path):
+        project_dir, blocked_tier, engine_root, data_root = self._make_blocked_project(tmp_path)
+        os.chmod(blocked_tier, 0o000)
+        try:
+            out = _run_status_text(project_dir, engine_root, data_root)
+        finally:
+            os.chmod(blocked_tier, 0o755)
+
+        assert "Agents            : unavailable" in out
+        assert "Permission denied" in out
+        # The rest of the status overview must still render.
+        assert "Active dispatches" in out
+        assert "Recent completions" in out

--- a/vnx_cli/commands/status.py
+++ b/vnx_cli/commands/status.py
@@ -2,10 +2,13 @@
 """vnx status — show current VNX project dispatch and agent status."""
 
 import json
+import logging
 import sqlite3
 from pathlib import Path
 
 from vnx_cli import _engine
+
+logger = logging.getLogger(__name__)
 
 
 def _resolve_project_id(args) -> str | None:
@@ -221,10 +224,22 @@ def vnx_status(args) -> int:
     # engine agents/, engine examples/), matching what dispatch_agent
     # actually resolves. A project-local-only read undercounted to 0 for
     # engine-fleet-only projects that dispatch fine.
+    #
+    # Mirrors doctor.py's _check_agents: an unreadable higher-precedence tier
+    # (e.g. a permissions-restricted project agents/ dir) can raise
+    # PermissionError out of list_available_agents even though a lower tier
+    # resolves fine (OI-622). Degrade gracefully instead of crashing the whole
+    # status readout — surface the reason, never suppress it silently.
     _engine.ensure_engine_on_path()
     from agent_resolver import list_available_agents
-    available_agents = list_available_agents(project_dir, engine_root=_engine.engine_root())
-    agent_names = sorted(a.name for a in available_agents)
+    agents_error: str | None = None
+    try:
+        available_agents = list_available_agents(project_dir, engine_root=_engine.engine_root())
+        agent_names = sorted(a.name for a in available_agents)
+    except Exception as exc:
+        logger.warning("vnx status: agent enumeration failed: %s", exc)
+        agent_names = []
+        agents_error = str(exc)
 
     if emit_json:
         output = {
@@ -235,6 +250,9 @@ def vnx_status(args) -> int:
             "agents": agent_names,
             "agent_count": len(agent_names),
         }
+        if agents_error is not None:
+            output["agents_status"] = "unavailable"
+            output["agents_error"] = agents_error
         if show_tracks:
             project_id = _resolve_project_id(args)
             if project_id:
@@ -277,12 +295,15 @@ def vnx_status(args) -> int:
         print(f"VNX status — {project_dir}")
         print()
         print(f"  Active dispatches : {active_count}")
-        print(f"  Agents            : {len(agent_names)}")
-        if agent_names:
-            for name in agent_names:
-                print(f"    - {name}")
+        if agents_error is not None:
+            print(f"  Agents            : unavailable ({agents_error})")
         else:
-            print("    (none — add subdirs to agents/)")
+            print(f"  Agents            : {len(agent_names)}")
+            if agent_names:
+                for name in agent_names:
+                    print(f"    - {name}")
+            else:
+                print("    (none — add subdirs to agents/)")
         print()
         if recent_completions:
             print("  Recent completions (last 5):")


### PR DESCRIPTION
## Summary

Closes three hygiene open items surfaced by prior codex gate rounds:

- **OI-622** — `vnx status` could raise an uncaught `PermissionError` when a higher-precedence agent tier directory was unreadable. `vnx_cli/commands/status.py` now wraps `list_available_agents()` in the same try/except pattern `doctor.py`'s `_check_agents` already uses: on failure it logs a warning, degrades `agents_status`/`agents_error` in JSON output (and an "unavailable (reason)" line in text output), and the rest of the status readout stays intact.
- **OI-623** — three `except sqlite3.Error:` blocks in `scripts/lib/injection_effectiveness_probe.py` (`_read_pattern_usage_totals`, `_read_last_dream_cycle`, `_read_reason_counts`) silently returned empty/`None` on a DB read failure. Each now logs `logger.warning(...)` naming the function and the underlying exception before returning the same safe fallback — matches this repo's established loud-degrade convention (e.g. `agent_resolver.py`'s unreadable-tier warning).
- **OI-625** — `test_layer1_scratch_cleanup_is_noninteractive` only asserted keyword presence (`home`, `tempdir`, `refuse`, ...) in the guard's prose, which would not have caught the pre-#1169-class regression (an unguarded `shutil.rmtree(..., ignore_errors=True)` with the right words still present). `tests/test_prompt_assembler.py` now extracts the actual `python3 -c "..."` guard snippet out of `base_worker.md`'s markdown fence and executes it as a real subprocess against six cases (`/`, a nonexistent top-level dir, `$HOME`, a `$HOME` ancestor, `/var/tmp` outside recognized roots, and a legitimate `$TMPDIR` subdir), asserting REFUSE-vs-ALLOW behavior. Includes a mutation-proof test (`test_stripped_guard_would_have_failed_this_test`) that runs a hollowed-out guard and confirms it *would* have deleted `$HOME` — proving this test class has teeth.

Original work by dispatch `20260716-oi622-623-625-hygiene`; that worker completed the implementation but was killed by the 3600s lane timeout before verify/PR/report. T0 salvaged the uncommitted working tree into `6a929473`. This finisher dispatch (`20260716-fin-hygiene`) verified the salvaged work against the OI specs, ran the full test suite, confirmed the lint gate, and opens this PR — no additional code changes were needed beyond the salvage commit.

## Changes

- `vnx_cli/commands/status.py` — try/except around agent enumeration, `agents_status`/`agents_error` JSON fields, text-mode degrade line (OI-622)
- `scripts/lib/injection_effectiveness_probe.py` — `logger.warning(...)` in all 3 `except sqlite3.Error:` handlers (OI-623)
- `tests/unit/vnx_cli/commands/test_status.py` — new `TestAgentEnumerationPermissionError` class (chmod-based, skipped on non-POSIX/root)
- `tests/test_injection_effectiveness_probe.py`, `tests/test_injection_reason_evaluator.py` — new `caplog`-based tests asserting the warning fires per handler
- `tests/test_prompt_assembler.py` — new `TestScratchCleanupGuardExecutes` class: extracts and subprocess-executes the guard snippet against 6 real cases + 1 mutation-proof case (OI-625)

## Verification

- `python3 -m pytest tests/test_prompt_assembler.py -q` → 31 passed
- `python3 -m pytest tests/test_injection_effectiveness_probe.py tests/test_injection_reason_evaluator.py -q` → 47 passed
- `python3 -m pytest tests/unit/vnx_cli/commands/test_status.py -v` → 6 passed (PermissionError tests confirmed to actually run, not skipped: `os.name=posix`, `euid=501`)
- `git diff <base>..HEAD --unified=0 -- '*.py' | grep '^+' | ... | python3 scripts/ci_lint_patterns.py --scan-stdin` → exit 0, no silent-except findings
- `bash scripts/local-ci.sh` → `adr-003-no-sdk` passes; `wheel-install` fails on an in-project-footprint assertion (12666 bytes ≥ 10KB) — confirmed **pre-existing** by running the identical gate against the parent commit (`1a4558de`, before this PR's changes) in an isolated worktree: same failure, same byte count. Unrelated to this PR's scope (no files in this diff touch `vnx init` scaffolding).
- Broad regression sweep (`pytest tests/ -k "status or injection or prompt_assembler"`) surfaced 16 failures in unrelated files (`test_gate_status_schema.py`, `test_cli_engine_bootstrap.py`, `test_wave7_fixes.py`, etc.) — spot-checked 2 against the parent commit in an isolated worktree and confirmed identical pre-existing failures, unrelated to this diff.

## Open Items

None — all three OIs (622, 623, 625) are covered with tests that fail without the fix and pass with it.

Dispatch-ID: 20260716-fin-hygiene

🤖 Generated with [Claude Code](https://claude.com/claude-code)