### PR TITLE
fix(oi654): receipt-delivery submit-verify + dedupe + digest + VNX_RECEIPT_T0_PUSH kill-switch

### DIFF
--- a/scripts/lib/receipt_processor/rp_delivery.sh
+++ b/scripts/lib/receipt_processor/rp_delivery.sh
@@ -6,9 +6,60 @@
 #           extract_receipt_fields() from rp_extract.sh,
 #           get_pane_id_smart() from pane_manager,
 #           _rf_* fields, $RECEIPTS_PENDING_DIR, $RECEIPTS_PROCESSED_DIR
+# Env flags (OI-654): VNX_RECEIPT_T0_PUSH=1 (default) pushes to the T0 tmux
+#           pane; 0 suppresses the push (ndjson append + outbox still happen).
+#           VNX_RECEIPT_DIGEST_THRESHOLD=5 (default) collapses a pending stack
+#           bigger than this into one digest paste instead of N individual ones.
+
+# Verify a paste actually submitted rather than sitting in T0's input line
+# (e.g. Enter landed while T0 was mid-turn or in a modal and got absorbed as
+# a no-op). Captures the pane and checks whether the LAST line (the live
+# input row) is still non-empty after the double-Enter sequence.
+# Fails OPEN on a capture-pane error (empty dump): this is an additive
+# vangnet, not a new way for delivery to block when tmux itself misbehaves.
+# Returns 0 verified / 1 not-verified (caller must not mark processed).
+_rpd_verify_submit() {
+    local t0_pane="$1"
+    local log_label="$2"
+
+    local pane_dump last_line
+    pane_dump=$(tmux capture-pane -t "$t0_pane" -p 2>/dev/null)
+    last_line=$(printf '%s\n' "$pane_dump" | tail -n 1)
+    # Trim leading/trailing whitespace so a blank-but-padded prompt line counts as empty.
+    last_line="${last_line#"${last_line%%[![:space:]]*}"}"
+    last_line="${last_line%"${last_line##*[![:space:]]}"}"
+
+    if [ -n "$last_line" ]; then
+        log "WARN" "Submit-verify failed for $log_label: input line not empty after Enter (pane: $t0_pane)"
+        return 1
+    fi
+    return 0
+}
+
+# Shared paste + double-Enter + submit-verify sequence.
+# Returns 0 if the paste was delivered AND verified submitted, 1 otherwise.
+_rpd_paste_and_verify() {
+    local t0_pane="$1"
+    local message="$2"
+    local log_label="$3"
+
+    echo "$message" | tmux load-buffer -
+    if ! tmux paste-buffer -t "$t0_pane" 2>/dev/null; then
+        log "ERROR" "Failed to paste to T0 pane $t0_pane ($log_label)"
+        return 1
+    fi
+
+    sleep 1
+    tmux send-keys -t "$t0_pane" Enter
+    sleep 0.3
+    tmux send-keys -t "$t0_pane" Enter
+    sleep 0.3
+
+    _rpd_verify_submit "$t0_pane" "$log_label"
+}
 
 # Section F (inner): Build enriched receipt message and paste to T0 tmux pane.
-# Returns 0 on success, 1 if pane unreachable or paste failed.
+# Returns 0 on success, 1 if pane unreachable, paste failed, or submit-verify failed.
 # Reads _rf_* variables set by extract_receipt_fields().
 _deliver_receipt_to_t0_pane() {
     local receipt_json="$1"
@@ -27,6 +78,15 @@ _deliver_receipt_to_t0_pane() {
             return 0
             ;;
     esac
+
+    # Push-switch (OI-654): T0's polling on report-files instead of pane pushes
+    # doesn't need the paste. Suppress it entirely — ndjson append already
+    # happened upstream in append_and_track_receipt(), so the audit trail is
+    # intact; only the tmux side-channel notification is skipped.
+    if [ "${VNX_RECEIPT_T0_PUSH:-1}" = "0" ]; then
+        log "INFO" "delivery_mode=suppressed dispatch_id=$dispatch_id (VNX_RECEIPT_T0_PUSH=0)"
+        return 0
+    fi
 
     local t0_pane
     t0_pane=$(get_pane_id_smart "T0" 2>/dev/null)
@@ -48,18 +108,44 @@ _deliver_receipt_to_t0_pane() {
 
     local receipt_msg="/t0-orchestrator 📨 RECEIPT:${terminal}:${footer_status} | ID: ${dispatch_id} | Next: ${next_action}${quality_line}${state_line}${git_line}
 Report: ${report_path}"
-    echo "$receipt_msg" | tmux load-buffer -
-    if ! tmux paste-buffer -t "$t0_pane" 2>/dev/null; then
-        log "ERROR" "Failed to paste receipt to T0 pane $t0_pane"
+
+    if ! _rpd_paste_and_verify "$t0_pane" "$receipt_msg" "$dispatch_id"; then
+        log "WARN" "Receipt not verified delivered, leaving pending: $dispatch_id"
         return 1
     fi
 
-    sleep 1
-    tmux send-keys -t "$t0_pane" Enter
-    sleep 0.3
-    tmux send-keys -t "$t0_pane" Enter
-
     log "INFO" "Receipt delivered to T0 (pane: $t0_pane)"
+    return 0
+}
+
+# Deliver a digest paste covering a whole stack of pending receipts, instead of
+# pasting each one individually. Same push-switch + submit-verify discipline
+# as _deliver_receipt_to_t0_pane. Returns 0 verified-delivered / 1 otherwise.
+_rpd_deliver_digest() {
+    local count="$1"
+    local oldest_dispatch_id="$2"
+
+    if [ "${VNX_RECEIPT_T0_PUSH:-1}" = "0" ]; then
+        log "INFO" "delivery_mode=suppressed digest count=$count (VNX_RECEIPT_T0_PUSH=0)"
+        return 0
+    fi
+
+    local t0_pane
+    t0_pane=$(get_pane_id_smart "T0" 2>/dev/null)
+    if [ -z "$t0_pane" ]; then
+        log "ERROR" "Could not find T0 pane for digest delivery"
+        return 1
+    fi
+
+    local digest_msg="/t0-orchestrator 📨 RECEIPT-DIGEST: ${count} receipts pending, oudste: ${oldest_dispatch_id}, zie t0_receipts.ndjson"
+
+    if ! _rpd_paste_and_verify "$t0_pane" "$digest_msg" "digest:${oldest_dispatch_id}"; then
+        log "WARN" "Digest not verified delivered, leaving $count receipt(s) pending"
+        return 1
+    fi
+
+    log "INFO" "Digest delivered to T0 (pane: $t0_pane, count=$count)"
+    return 0
 }
 
 # Section F: Outbox wrapper — write-first, then deliver.
@@ -87,26 +173,117 @@ send_receipt_to_t0() {
 }
 
 # Retry poller: attempt delivery of all receipts still in pending/.
+# Dedupes by dispatch_id (OI-654): a dispatch_id with multiple stacked pending
+# files gets exactly ONE delivery attempt per sweep, and all its files move
+# together on success/stay together on failure — a repeatedly-failing pane
+# does not stack N identical notifications.
+# When the resulting number of distinct pending dispatches exceeds
+# VNX_RECEIPT_DIGEST_THRESHOLD (default 5), one digest message replaces the
+# individual pastes entirely.
 # Called periodically from _poll_new_reports() and once on startup.
 _retry_pending_receipts() {
+    local digest_threshold="${VNX_RECEIPT_DIGEST_THRESHOLD:-5}"
+
     local pending_files=()
     while IFS= read -r -d '' f; do
         pending_files+=("$f")
     done < <(find "$RECEIPTS_PENDING_DIR" -name "*.json" -type f -print0 2>/dev/null)
 
-    [ ${#pending_files[@]} -eq 0 ] && return 0
+    local total=${#pending_files[@]}
+    [ "$total" -eq 0 ] && return 0
 
-    log "INFO" "Retrying ${#pending_files[@]} pending receipt(s)..."
+    # Per-file dispatch_id lookup (parallel array, same index as pending_files).
+    local file_dispatch_ids=()
+    local f dispatch_id
     for f in "${pending_files[@]}"; do
-        local receipt_json
-        receipt_json=$(cat "$f")
-        local terminal
+        dispatch_id=$(jq -r '.dispatch_id // empty' "$f" 2>/dev/null)
+        [ -z "$dispatch_id" ] && dispatch_id="no-id"
+        file_dispatch_ids+=("$dispatch_id")
+    done
+
+    # Unique dispatch_ids in first-seen order (dedupe key list). Deliberately
+    # avoids associative arrays / negative array indices — bash 3.2 (macOS
+    # default /bin/bash) supports neither.
+    local unique_ids=()
+    local id already u
+    for id in "${file_dispatch_ids[@]}"; do
+        already=0
+        # bash 3.2 (macOS default) treats "${arr[@]}" as unbound under `set -u`
+        # when arr has zero elements — the "${arr[@]+...}" guard avoids that.
+        for u in "${unique_ids[@]+"${unique_ids[@]}"}"; do
+            [ "$u" = "$id" ] && { already=1; break; }
+        done
+        [ "$already" -eq 0 ] && unique_ids+=("$id")
+    done
+
+    local group_count=${#unique_ids[@]}
+    if [ "$group_count" -lt "$total" ]; then
+        log "INFO" "Deduped $total pending receipt(s) into $group_count unique dispatch(es)"
+    fi
+
+    # Digest mode: too many distinct pending dispatches to paste individually.
+    if [ "$group_count" -gt "$digest_threshold" ]; then
+        local oldest_idx=0 oldest_mtime cur_mtime i
+        oldest_mtime=$(stat -f%m "${pending_files[0]}" 2>/dev/null || stat -c%Y "${pending_files[0]}" 2>/dev/null || echo 0)
+        for ((i = 1; i < total; i++)); do
+            cur_mtime=$(stat -f%m "${pending_files[$i]}" 2>/dev/null || stat -c%Y "${pending_files[$i]}" 2>/dev/null || echo 0)
+            if [ "$cur_mtime" -lt "$oldest_mtime" ]; then
+                oldest_mtime=$cur_mtime
+                oldest_idx=$i
+            fi
+        done
+        local oldest_dispatch_id="${file_dispatch_ids[$oldest_idx]}"
+
+        log "INFO" "Pending stack ($group_count dispatches, $total files) exceeds digest threshold ($digest_threshold); sending 1 digest"
+        if _rpd_deliver_digest "$total" "$oldest_dispatch_id"; then
+            for f in "${pending_files[@]}"; do
+                mv "$f" "$RECEIPTS_PROCESSED_DIR/$(basename "$f")"
+            done
+            log "INFO" "Digest delivered covering $total pending receipt(s)"
+        else
+            log "WARN" "Digest delivery unverified; $total receipt(s) remain pending"
+        fi
+        return 0
+    fi
+
+    log "INFO" "Retrying $total pending receipt(s) across $group_count dispatch(es)..."
+
+    local gi
+    for ((gi = 0; gi < group_count; gi++)); do
+        id="${unique_ids[$gi]}"
+        local group_indices=()
+        local fidx
+        for ((fidx = 0; fidx < total; fidx++)); do
+            [ "${file_dispatch_ids[$fidx]}" = "$id" ] && group_indices+=("$fidx")
+        done
+
+        # Representative = most recently written file in the group.
+        local rep_idx="${group_indices[0]}"
+        local gj rep_mtime cur_mtime2
+        rep_mtime=$(stat -f%m "${pending_files[$rep_idx]}" 2>/dev/null || stat -c%Y "${pending_files[$rep_idx]}" 2>/dev/null || echo 0)
+        for gj in "${group_indices[@]}"; do
+            cur_mtime2=$(stat -f%m "${pending_files[$gj]}" 2>/dev/null || stat -c%Y "${pending_files[$gj]}" 2>/dev/null || echo 0)
+            if [ "$cur_mtime2" -ge "$rep_mtime" ]; then
+                rep_mtime=$cur_mtime2
+                rep_idx=$gj
+            fi
+        done
+
+        local receipt_json terminal
+        receipt_json=$(cat "${pending_files[$rep_idx]}")
         terminal=$(echo "$receipt_json" | jq -r '.terminal // "unknown"' 2>/dev/null)
         # Re-extract _rf_* fields so _deliver_receipt_to_t0_pane() has the right context
         extract_receipt_fields "$receipt_json" 2>/dev/null || true
+
+        if [ "${#group_indices[@]}" -gt 1 ]; then
+            log "INFO" "Deduped ${#group_indices[@]} pending receipts for dispatch_id=$id into 1 delivery"
+        fi
+
         if _deliver_receipt_to_t0_pane "$receipt_json" "$terminal"; then
-            mv "$f" "$RECEIPTS_PROCESSED_DIR/$(basename "$f")"
-            log "INFO" "Pending receipt delivered: $(basename "$f")"
+            for gj in "${group_indices[@]}"; do
+                mv "${pending_files[$gj]}" "$RECEIPTS_PROCESSED_DIR/$(basename "${pending_files[$gj]}")"
+            done
+            log "INFO" "Pending receipt delivered: $(basename "${pending_files[$rep_idx]}")"
         fi
     done
 }

--- a/scripts/lib/receipt_processor/rp_delivery.sh
+++ b/scripts/lib/receipt_processor/rp_delivery.sh
@@ -10,6 +10,10 @@
 #           pane; 0 suppresses the push (ndjson append + outbox still happen).
 #           VNX_RECEIPT_DIGEST_THRESHOLD=5 (default) collapses a pending stack
 #           bigger than this into one digest paste instead of N individual ones.
+#           VNX_RECEIPT_VERIFY_MAX_RETRIES=3 (default) caps how many failed
+#           submit-verify sweeps a pending item/digest-group tolerates before
+#           it is force-processed (delivery_mode=unverified_after_N) instead
+#           of retried forever. Requires jq on PATH (fail-fast if absent).
 
 # Verify a paste actually submitted rather than sitting in T0's input line
 # (e.g. Enter landed while T0 was mid-turn or in a modal and got absorbed as
@@ -43,16 +47,28 @@ _rpd_paste_and_verify() {
     local message="$2"
     local log_label="$3"
 
-    echo "$message" | tmux load-buffer -
+    # finding 1a: check every tmux call's exit code. A failed load-buffer or
+    # send-keys means the paste never happened (or Enter never landed) — the
+    # item must stay pending, not fall through to submit-verify on a no-op.
+    if ! echo "$message" | tmux load-buffer - 2>/dev/null; then
+        log "ERROR" "Failed to load-buffer for T0 pane $t0_pane ($log_label)"
+        return 1
+    fi
     if ! tmux paste-buffer -t "$t0_pane" 2>/dev/null; then
         log "ERROR" "Failed to paste to T0 pane $t0_pane ($log_label)"
         return 1
     fi
 
     sleep 1
-    tmux send-keys -t "$t0_pane" Enter
+    if ! tmux send-keys -t "$t0_pane" Enter 2>/dev/null; then
+        log "ERROR" "Failed to send Enter (1st) to T0 pane $t0_pane ($log_label)"
+        return 1
+    fi
     sleep 0.3
-    tmux send-keys -t "$t0_pane" Enter
+    if ! tmux send-keys -t "$t0_pane" Enter 2>/dev/null; then
+        log "ERROR" "Failed to send Enter (2nd) to T0 pane $t0_pane ($log_label)"
+        return 1
+    fi
     sleep 0.3
 
     _rpd_verify_submit "$t0_pane" "$log_label"
@@ -118,12 +134,39 @@ Report: ${report_path}"
     return 0
 }
 
+# finding 3 (readability improvement, not an audit-trail change — see NOTE
+# above the digest branch in _retry_pending_receipts): builds a comma-joined
+# list of up to 10 dispatch_ids for the digest message, so T0 sees WHICH
+# dispatches are behind the count instead of only a bare number + the oldest
+# one. Caps at 10 + "…" so the message can't balloon for a very large stack —
+# t0_receipts.ndjson remains the full inventory for anyone who needs it.
+_rpd_build_id_list() {
+    local max=10
+    local n=$#
+    local limit=$n
+    [ "$limit" -gt "$max" ] && limit=$max
+
+    local list="" i=0 item
+    for item in "$@"; do
+        i=$((i + 1))
+        [ "$i" -gt "$limit" ] && break
+        if [ -n "$list" ]; then
+            list="${list},${item}"
+        else
+            list="$item"
+        fi
+    done
+    [ "$n" -gt "$max" ] && list="${list}…"
+    printf '%s' "$list"
+}
+
 # Deliver a digest paste covering a whole stack of pending receipts, instead of
 # pasting each one individually. Same push-switch + submit-verify discipline
 # as _deliver_receipt_to_t0_pane. Returns 0 verified-delivered / 1 otherwise.
 _rpd_deliver_digest() {
     local count="$1"
     local oldest_dispatch_id="$2"
+    local id_list="$3"
 
     if [ "${VNX_RECEIPT_T0_PUSH:-1}" = "0" ]; then
         log "INFO" "delivery_mode=suppressed digest count=$count (VNX_RECEIPT_T0_PUSH=0)"
@@ -137,7 +180,7 @@ _rpd_deliver_digest() {
         return 1
     fi
 
-    local digest_msg="/t0-orchestrator 📨 RECEIPT-DIGEST: ${count} receipts pending, oudste: ${oldest_dispatch_id}, zie t0_receipts.ndjson"
+    local digest_msg="/t0-orchestrator 📨 RECEIPT-DIGEST: ${count} receipts pending, oudste: ${oldest_dispatch_id}, IDs: ${id_list}, zie t0_receipts.ndjson"
 
     if ! _rpd_paste_and_verify "$t0_pane" "$digest_msg" "digest:${oldest_dispatch_id}"; then
         log "WARN" "Digest not verified delivered, leaving $count receipt(s) pending"
@@ -146,6 +189,49 @@ _rpd_deliver_digest() {
 
     log "INFO" "Digest delivered to T0 (pane: $t0_pane, count=$count)"
     return 0
+}
+
+# finding 4 vlucht-route: force-move a set of pending files straight to
+# processed/ without another delivery attempt. t0_receipts.ndjson already has
+# every one of these receipts (written upstream in append_and_track_receipt())
+# — retrying a submit-verify that fails forever is more harmful than accepting
+# one possibly-missed live paste. Shared by both the individual-group path and
+# the digest path so the cap behaves identically in both (codex checklist:
+# same fix to all handlers).
+_rpd_force_process() {
+    local max_retries="$1" label="$2" fail_count="$3"
+    shift 3
+    local f
+    for f in "$@"; do
+        mv "$f" "$RECEIPTS_PROCESSED_DIR/$(basename "$f")"
+    done
+    log "WARN" "delivery_mode=unverified_after_${max_retries} ${label} force-processed $# item(s) after ${fail_count} failed verify sweep(s)"
+}
+
+# finding 4: fail-count sidecar stored as a field inside the pending JSON
+# receipt itself (rather than the filename) so it survives dedupe grouping
+# and doesn't require renaming files mid-sweep. Defaults to 0 for files
+# predating this fix or on any parse error.
+_rpd_get_fail_count() {
+    local count
+    count=$(jq -r '._verify_fail_count // 0' "$1" 2>/dev/null)
+    [ -z "$count" ] && count=0
+    printf '%s' "$count"
+}
+
+# finding 4: atomic increment (codex checklist — never rewrite canonical state
+# in place). Writes to a tmp file in the same dir, then renames over the
+# original; a crash mid-write must not corrupt a pending receipt the next
+# sweep still needs to read.
+_rpd_increment_fail_count() {
+    local file="$1"
+    local tmp="${file}.tmp.$$"
+    if jq '._verify_fail_count = ((._verify_fail_count // 0) + 1)' "$file" > "$tmp" 2>/dev/null; then
+        mv "$tmp" "$file"
+    else
+        rm -f "$tmp"
+        log "WARN" "Failed to increment verify-fail count for $(basename "$file")"
+    fi
 }
 
 # Section F: Outbox wrapper — write-first, then deliver.
@@ -177,12 +263,39 @@ send_receipt_to_t0() {
 # files gets exactly ONE delivery attempt per sweep, and all its files move
 # together on success/stay together on failure — a repeatedly-failing pane
 # does not stack N identical notifications.
+#
+# NOTE (finding 2 — dedupe is a delivery-channel decision, not an audit-trail
+# one): collapsing N pending files for the same dispatch_id into ONE tmux
+# paste only reduces how many times T0's pane is interrupted. Every one of
+# those N payloads was already durably persisted before dedupe ever runs
+# (send_receipt_to_t0() writes to $RECEIPTS_PENDING_DIR before any delivery
+# attempt), and a successful delivery here moves EVERY file in the group —
+# not just the representative — to $RECEIPTS_PROCESSED_DIR. The full history
+# of older same-id payloads and their individual details survives intact in
+# t0_receipts.ndjson and receipts/processed/; this function only ever decides
+# notification cadence, never what the audit trail retains.
+#
 # When the resulting number of distinct pending dispatches exceeds
 # VNX_RECEIPT_DIGEST_THRESHOLD (default 5), one digest message replaces the
-# individual pastes entirely.
+# individual pastes entirely (see NOTE on finding 3 at the digest branch).
+#
+# finding 4: a pending item/group whose submit-verify has failed
+# VNX_RECEIPT_VERIFY_MAX_RETRIES (default 3) times in a row is force-processed
+# instead of retried forever — see _rpd_force_process().
+#
+# finding 5: jq is required (dispatch_id lookup, dedupe key extraction,
+# fail-count sidecar). Its absence must fail loud, not silently collapse
+# every file to dispatch_id="no-id" or move files without delivery.
+#
 # Called periodically from _poll_new_reports() and once on startup.
 _retry_pending_receipts() {
+    if ! command -v jq >/dev/null 2>&1; then
+        log "ERROR" "jq not found on PATH - cannot process pending receipts (dedupe/digest/retry-cap all require jq); leaving pending files untouched"
+        return 1
+    fi
+
     local digest_threshold="${VNX_RECEIPT_DIGEST_THRESHOLD:-5}"
+    local max_retries="${VNX_RECEIPT_VERIFY_MAX_RETRIES:-3}"
 
     local pending_files=()
     while IFS= read -r -d '' f; do
@@ -222,6 +335,15 @@ _retry_pending_receipts() {
     fi
 
     # Digest mode: too many distinct pending dispatches to paste individually.
+    #
+    # NOTE (finding 3 — digest is a delivery-channel decision, not an
+    # audit-trail one): collapsing the whole pending stack into one digest
+    # paste only affects the tmux-side notification. Every individual receipt
+    # behind it is already in t0_receipts.ndjson and moves intact to
+    # receipts/processed/ on delivery — the digest message now names up to
+    # ~10 dispatch_ids (_rpd_build_id_list) so T0 gets more than a bare
+    # count+oldest, but this is a cheap readability improvement, not a full
+    # inventory; the ndjson stays the source of truth.
     if [ "$group_count" -gt "$digest_threshold" ]; then
         local oldest_idx=0 oldest_mtime cur_mtime i
         oldest_mtime=$(stat -f%m "${pending_files[0]}" 2>/dev/null || stat -c%Y "${pending_files[0]}" 2>/dev/null || echo 0)
@@ -234,14 +356,33 @@ _retry_pending_receipts() {
         done
         local oldest_dispatch_id="${file_dispatch_ids[$oldest_idx]}"
 
+        # finding 4 vlucht-route (digest path): if this entire pending stack
+        # has already failed verify max_retries times, force-process the lot
+        # instead of attempting yet another digest paste.
+        local digest_fail_count=0 df_idx df_fc
+        for ((df_idx = 0; df_idx < total; df_idx++)); do
+            df_fc=$(_rpd_get_fail_count "${pending_files[$df_idx]}")
+            [ "$df_fc" -gt "$digest_fail_count" ] && digest_fail_count=$df_fc
+        done
+        if [ "$digest_fail_count" -ge "$max_retries" ]; then
+            _rpd_force_process "$max_retries" "digest" "$digest_fail_count" "${pending_files[@]}"
+            return 0
+        fi
+
+        local id_list
+        id_list=$(_rpd_build_id_list "${unique_ids[@]}")
+
         log "INFO" "Pending stack ($group_count dispatches, $total files) exceeds digest threshold ($digest_threshold); sending 1 digest"
-        if _rpd_deliver_digest "$total" "$oldest_dispatch_id"; then
+        if _rpd_deliver_digest "$total" "$oldest_dispatch_id" "$id_list"; then
             for f in "${pending_files[@]}"; do
                 mv "$f" "$RECEIPTS_PROCESSED_DIR/$(basename "$f")"
             done
             log "INFO" "Digest delivered covering $total pending receipt(s)"
         else
-            log "WARN" "Digest delivery unverified; $total receipt(s) remain pending"
+            for f in "${pending_files[@]}"; do
+                _rpd_increment_fail_count "$f"
+            done
+            log "WARN" "Digest delivery unverified; $total receipt(s) remain pending (fail count now $((digest_fail_count + 1))/$max_retries)"
         fi
         return 0
     fi
@@ -269,6 +410,23 @@ _retry_pending_receipts() {
             fi
         done
 
+        # finding 4 vlucht-route: if this dispatch_id's group has already
+        # failed submit-verify max_retries times, force-process it instead of
+        # attempting another paste this sweep.
+        local group_fail_count=0 gf_fc
+        for gj in "${group_indices[@]}"; do
+            gf_fc=$(_rpd_get_fail_count "${pending_files[$gj]}")
+            [ "$gf_fc" -gt "$group_fail_count" ] && group_fail_count=$gf_fc
+        done
+        if [ "$group_fail_count" -ge "$max_retries" ]; then
+            local group_files=()
+            for gj in "${group_indices[@]}"; do
+                group_files+=("${pending_files[$gj]}")
+            done
+            _rpd_force_process "$max_retries" "dispatch_id=$id" "$group_fail_count" "${group_files[@]}"
+            continue
+        fi
+
         local receipt_json terminal
         receipt_json=$(cat "${pending_files[$rep_idx]}")
         terminal=$(echo "$receipt_json" | jq -r '.terminal // "unknown"' 2>/dev/null)
@@ -284,6 +442,11 @@ _retry_pending_receipts() {
                 mv "${pending_files[$gj]}" "$RECEIPTS_PROCESSED_DIR/$(basename "${pending_files[$gj]}")"
             done
             log "INFO" "Pending receipt delivered: $(basename "${pending_files[$rep_idx]}")"
+        else
+            for gj in "${group_indices[@]}"; do
+                _rpd_increment_fail_count "${pending_files[$gj]}"
+            done
+            log "WARN" "Verify-fail count incremented for dispatch_id=$id (now $((group_fail_count + 1))/$max_retries)"
         fi
     done
 }

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -59,6 +59,15 @@ PID_FILE="$VNX_PIDS_DIR/receipt_processor.pid"
 RECEIPTS_PENDING_DIR="${VNX_DATA_DIR}/receipts/pending"
 RECEIPTS_PROCESSED_DIR="${VNX_DATA_DIR}/receipts/processed"
 RECEIPT_RETRY_INTERVAL="${VNX_RECEIPT_RETRY_INTERVAL:-10}"  # seconds between pending retry sweeps
+# VNX_RECEIPT_T0_PUSH=1 (default) pushes each receipt to the T0 tmux pane via
+# paste-buffer; 0 suppresses the push entirely — ndjson append + outbox
+# processing still happen (audit trail intact), only the pane notification is
+# skipped. For T0's that poll report-files instead of consuming pane pushes.
+# Read directly (no indirection var) by rp_delivery.sh at delivery time.
+# VNX_RECEIPT_DIGEST_THRESHOLD=5 (default) — once more than this many distinct
+# dispatch_ids are stacked in receipts/pending/, the retry sweep sends ONE
+# digest paste instead of N individual ones. Read directly by
+# rp_delivery.sh's _retry_pending_receipts(). (OI-654)
 
 # Cross-platform SHA-256 helper (Linux: sha256sum, macOS: shasum -a 256)
 _SHA256_FALLBACK_WARN=""

--- a/tests/test_rp_delivery_gates.sh
+++ b/tests/test_rp_delivery_gates.sh
@@ -1,0 +1,247 @@
+#!/usr/bin/env bash
+# Tests for rp_delivery.sh (OI-654: submit-verify + dedupe + digest + push-switch)
+#
+# Coverage:
+#   - Baseline: default env (push=1, unset) still pastes + verifies + processes (no regression)
+#   - Submit-verify: empty input line after Enter -> verified -> pending file moves to processed
+#   - Submit-verify: non-empty input line after Enter -> NOT verified -> stays pending, WARN logged
+#   - Dedupe: 3 pending files, same dispatch_id -> exactly 1 paste-buffer call, all 3 processed
+#   - Digest: pending dispatches over threshold -> exactly 1 digest paste, all processed
+#   - Push-switch: VNX_RECEIPT_T0_PUSH=0 -> zero tmux calls, item still moves to processed (suppressed)
+#
+# Mirrors the function-override tmux mock pattern from tests/test_input_mode_guard.sh.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Test harness ---
+PASS_COUNT=0
+FAIL_COUNT=0
+
+pass() { echo "PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    if [ "$expected" = "$actual" ]; then pass "$msg"; else fail "$msg" "expected='$expected' actual='$actual'"; fi
+}
+
+assert_file_contains() {
+    local file="$1" pattern="$2" msg="$3"
+    if grep -q "$pattern" "$file" 2>/dev/null; then pass "$msg"; else fail "$msg" "pattern '$pattern' not found in $file"; fi
+}
+
+# --- Sandbox dirs ---
+TMP_ROOT=$(mktemp -d)
+STATE_DIR="$TMP_ROOT/state"
+RECEIPTS_PENDING_DIR="$TMP_ROOT/receipts/pending"
+RECEIPTS_PROCESSED_DIR="$TMP_ROOT/receipts/processed"
+PROCESSING_LOG="$TMP_ROOT/processing.log"
+mkdir -p "$STATE_DIR" "$RECEIPTS_PENDING_DIR" "$RECEIPTS_PROCESSED_DIR"
+touch "$PROCESSING_LOG"
+
+MOCK_CALL_LOG="$TMP_ROOT/mock_calls"
+MOCK_LOADED_BUFFER="$TMP_ROOT/mock_loaded_buffer"
+MOCK_PASTE_FAIL_FLAG="$TMP_ROOT/mock_paste_fail"
+MOCK_CAPTURE_RESPONSE_FILE="$TMP_ROOT/mock_capture_response"
+touch "$MOCK_CALL_LOG" "$MOCK_CAPTURE_RESPONSE_FILE"
+
+reset_mocks() {
+    rm -f "$MOCK_CALL_LOG" "$MOCK_LOADED_BUFFER" "$MOCK_PASTE_FAIL_FLAG"
+    : > "$MOCK_CAPTURE_RESPONSE_FILE"
+    touch "$MOCK_CALL_LOG"
+    rm -rf "${RECEIPTS_PENDING_DIR:?}"/* "${RECEIPTS_PROCESSED_DIR:?}"/* 2>/dev/null
+    unset VNX_RECEIPT_T0_PUSH VNX_RECEIPT_DIGEST_THRESHOLD
+}
+
+# capture-pane's "last line" response for the next verify call. Empty = submit
+# verified (input line clear); non-empty = submit NOT verified (residual text).
+set_capture_response() { printf '%s' "$1" > "$MOCK_CAPTURE_RESPONSE_FILE"; }
+
+write_pending() {
+    local filename="$1" dispatch_id="$2"
+    cat > "$RECEIPTS_PENDING_DIR/$filename" <<JSON
+{"dispatch_id":"$dispatch_id","terminal":"T1","status":"success","event_type":"task_complete","timestamp":"2026-07-16T10:00:00Z","report_path":"/tmp/r.md"}
+JSON
+    # Deterministic mtime ordering for "oldest" assertions (BSD+GNU touch -t compatible).
+    touch -t "20260101000${filename: -6:1}" "$RECEIPTS_PENDING_DIR/$filename" 2>/dev/null || true
+}
+
+count_files() { find "$1" -type f 2>/dev/null | wc -l | tr -d ' '; }
+
+# --- Minimal stubs required by rp_delivery.sh outside the full daemon ---
+sleep()  { return 0; }
+get_pane_id_smart() { echo "test:0.0"; }
+
+# tmux mock: file-based state so changes survive $() subshells
+tmux() {
+    local subcmd="$1"
+    echo "$subcmd" >> "$MOCK_CALL_LOG"
+    case "$subcmd" in
+        load-buffer)
+            cat > "$MOCK_LOADED_BUFFER"
+            return 0
+            ;;
+        paste-buffer)
+            [ -f "$MOCK_PASTE_FAIL_FLAG" ] && return 1
+            return 0
+            ;;
+        send-keys)
+            return 0
+            ;;
+        capture-pane)
+            cat "$MOCK_CAPTURE_RESPONSE_FILE" 2>/dev/null
+            return 0
+            ;;
+        *)
+            return 0
+            ;;
+    esac
+}
+
+# Source the real libraries under test
+source "$PROJECT_ROOT/scripts/lib/receipt_processor/rp_logging.sh"
+source "$PROJECT_ROOT/scripts/lib/receipt_processor/rp_extract.sh"
+source "$PROJECT_ROOT/scripts/lib/receipt_processor/rp_delivery.sh"
+
+# ===========================================================================
+# Test 0: Baseline — default env (VNX_RECEIPT_T0_PUSH unset) still delivers
+# ===========================================================================
+reset_mocks
+write_pending "d-000-1.json" "d-000"
+set_capture_response ""   # empty input line -> verified
+_retry_pending_receipts
+
+assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T0: baseline (push unset) sends exactly 1 paste-buffer"
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T0: baseline pending item moved to processed"
+assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T0: baseline pending dir empty after delivery"
+
+# ===========================================================================
+# Test 1: Submit-verify success — empty input line -> processed
+# ===========================================================================
+reset_mocks
+write_pending "d-101-1.json" "d-101"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T1: verified-empty input line -> item moved to processed"
+assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T1: verified-empty input line -> pending dir empty"
+
+# ===========================================================================
+# Test 2: Submit-verify failure — non-empty input line -> stays pending
+# ===========================================================================
+reset_mocks
+write_pending "d-102-1.json" "d-102"
+set_capture_response "Report: /tmp/r.md"   # residual receipt text still in input line
+_retry_pending_receipts
+
+assert_eq "0" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T2: unverified (non-empty input line) -> nothing moved to processed"
+assert_eq "1" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T2: unverified (non-empty input line) -> item stays pending"
+assert_file_contains "$PROCESSING_LOG" "Submit-verify failed" \
+    "T2: WARN logged for unverified submit"
+
+# ===========================================================================
+# Test 3: Dedupe — 3 pending files, same dispatch_id -> 1 delivery
+# ===========================================================================
+reset_mocks
+write_pending "d-dup-1.json" "d-dup"
+write_pending "d-dup-2.json" "d-dup"
+write_pending "d-dup-3.json" "d-dup"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T3: 3 pending items with the same dispatch_id -> exactly 1 paste-buffer"
+assert_eq "3" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T3: all 3 duplicate pending files moved to processed together"
+assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T3: pending dir empty after deduped delivery"
+assert_file_contains "$PROCESSING_LOG" "Deduped 3 pending receipts for dispatch_id=d-dup" \
+    "T3: dedupe logged"
+
+# ===========================================================================
+# Test 4: Digest — 6 distinct pending dispatches (> default threshold 5) -> 1 digest
+# ===========================================================================
+reset_mocks
+write_pending "d-digest-1.json" "d-digest-1"
+write_pending "d-digest-2.json" "d-digest-2"
+write_pending "d-digest-3.json" "d-digest-3"
+write_pending "d-digest-4.json" "d-digest-4"
+write_pending "d-digest-5.json" "d-digest-5"
+write_pending "d-digest-6.json" "d-digest-6"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T4: 6 distinct pending dispatches -> exactly 1 digest paste"
+assert_eq "6" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T4: all 6 pending files moved to processed after digest delivery"
+assert_file_contains "$MOCK_LOADED_BUFFER" "RECEIPT-DIGEST: 6 receipts pending" \
+    "T4: digest message states the correct count"
+assert_file_contains "$MOCK_LOADED_BUFFER" "oudste: d-digest-1" \
+    "T4: digest message names the oldest dispatch_id"
+
+# ===========================================================================
+# Test 4b: Digest threshold is configurable via VNX_RECEIPT_DIGEST_THRESHOLD
+# ===========================================================================
+reset_mocks
+export VNX_RECEIPT_DIGEST_THRESHOLD=1
+write_pending "d-cfg-1.json" "d-cfg-1"
+write_pending "d-cfg-2.json" "d-cfg-2"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_file_contains "$MOCK_LOADED_BUFFER" "RECEIPT-DIGEST" \
+    "T4b: lowered threshold (1) triggers digest for just 2 dispatches"
+unset VNX_RECEIPT_DIGEST_THRESHOLD
+
+# ===========================================================================
+# Test 5: Push-switch — VNX_RECEIPT_T0_PUSH=0 -> zero tmux calls, still processed
+# ===========================================================================
+reset_mocks
+export VNX_RECEIPT_T0_PUSH=0
+receipt_json='{"dispatch_id":"d-push-off","terminal":"T2","status":"success","event_type":"task_complete","timestamp":"2026-07-16T10:00:00Z","report_path":"/tmp/r.md"}'
+extract_receipt_fields "$receipt_json"
+send_receipt_to_t0 "$receipt_json" "T2"
+
+assert_eq "0" "$(wc -l < "$MOCK_CALL_LOG" | tr -d ' ')" \
+    "T5: VNX_RECEIPT_T0_PUSH=0 makes zero tmux calls"
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T5: item still moves to processed when push is suppressed"
+assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T5: pending dir empty after suppressed delivery"
+assert_file_contains "$PROCESSING_LOG" "delivery_mode=suppressed dispatch_id=d-push-off" \
+    "T5: suppressed delivery_mode logged"
+unset VNX_RECEIPT_T0_PUSH
+
+# ===========================================================================
+# Test 6: Push-switch default (unset) behaves exactly like push=1 (no surprise)
+# ===========================================================================
+reset_mocks
+receipt_json='{"dispatch_id":"d-push-default","terminal":"T2","status":"success","event_type":"task_complete","timestamp":"2026-07-16T10:00:00Z","report_path":"/tmp/r.md"}'
+extract_receipt_fields "$receipt_json"
+set_capture_response ""
+send_receipt_to_t0 "$receipt_json" "T2"
+
+assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T6: default (VNX_RECEIPT_T0_PUSH unset) still pastes — no behavior change"
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T6: default push delivers and processes normally"
+
+# --- Cleanup ---
+rm -rf "$TMP_ROOT"
+
+# --- Summary ---
+echo ""
+echo "=== rp_delivery test results: $PASS_COUNT passed, $FAIL_COUNT failed ==="
+
+[ "$FAIL_COUNT" -eq 0 ] || exit 1

--- a/tests/test_rp_delivery_gates.sh
+++ b/tests/test_rp_delivery_gates.sh
@@ -45,15 +45,16 @@ touch "$PROCESSING_LOG"
 MOCK_CALL_LOG="$TMP_ROOT/mock_calls"
 MOCK_LOADED_BUFFER="$TMP_ROOT/mock_loaded_buffer"
 MOCK_PASTE_FAIL_FLAG="$TMP_ROOT/mock_paste_fail"
+MOCK_LOADBUFFER_FAIL_FLAG="$TMP_ROOT/mock_loadbuffer_fail"
 MOCK_CAPTURE_RESPONSE_FILE="$TMP_ROOT/mock_capture_response"
 touch "$MOCK_CALL_LOG" "$MOCK_CAPTURE_RESPONSE_FILE"
 
 reset_mocks() {
-    rm -f "$MOCK_CALL_LOG" "$MOCK_LOADED_BUFFER" "$MOCK_PASTE_FAIL_FLAG"
+    rm -f "$MOCK_CALL_LOG" "$MOCK_LOADED_BUFFER" "$MOCK_PASTE_FAIL_FLAG" "$MOCK_LOADBUFFER_FAIL_FLAG"
     : > "$MOCK_CAPTURE_RESPONSE_FILE"
     touch "$MOCK_CALL_LOG"
     rm -rf "${RECEIPTS_PENDING_DIR:?}"/* "${RECEIPTS_PROCESSED_DIR:?}"/* 2>/dev/null
-    unset VNX_RECEIPT_T0_PUSH VNX_RECEIPT_DIGEST_THRESHOLD
+    unset VNX_RECEIPT_T0_PUSH VNX_RECEIPT_DIGEST_THRESHOLD VNX_RECEIPT_VERIFY_MAX_RETRIES
 }
 
 # capture-pane's "last line" response for the next verify call. Empty = submit
@@ -81,6 +82,10 @@ tmux() {
     echo "$subcmd" >> "$MOCK_CALL_LOG"
     case "$subcmd" in
         load-buffer)
+            if [ -f "$MOCK_LOADBUFFER_FAIL_FLAG" ]; then
+                cat > /dev/null
+                return 1
+            fi
             cat > "$MOCK_LOADED_BUFFER"
             return 0
             ;;
@@ -236,6 +241,102 @@ assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
     "T6: default (VNX_RECEIPT_T0_PUSH unset) still pastes — no behavior change"
 assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
     "T6: default push delivers and processes normally"
+
+# ===========================================================================
+# Test 7 (finding 4): verify-fail cap -> force-processed after N retries,
+# no (N+1)th paste attempted
+# ===========================================================================
+reset_mocks
+write_pending "d-cap-1.json" "d-cap"
+set_capture_response "Report: /tmp/r.md"   # always unverified
+
+_retry_pending_receipts
+_retry_pending_receipts
+_retry_pending_receipts
+assert_eq "3" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T7: 3 failed sweeps -> exactly 3 paste-buffer attempts"
+assert_eq "0" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T7: still pending after 3 failed sweeps (at cap, not yet over)"
+
+_retry_pending_receipts   # 4th sweep: cap reached -> force-process, no paste
+assert_eq "3" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T7: 4th sweep does not attempt another paste (cap already hit)"
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T7: 4th sweep force-processes the item"
+assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T7: pending dir empty after force-process"
+assert_file_contains "$PROCESSING_LOG" "unverified_after_3" \
+    "T7: force-process WARN logged with retry count"
+
+# ===========================================================================
+# Test 8 (finding 5): jq absent on PATH -> fail loud, zero processed-moves
+# ===========================================================================
+reset_mocks
+write_pending "d-nojq-1.json" "d-nojq"
+set_capture_response ""
+# PATH-stub containing only what log() needs (date, tee) so the fail-loud
+# error path can still write to $PROCESSING_LOG — everything else PATH would
+# normally resolve (jq included) is deliberately absent.
+NOJQ_BIN_DIR="$TMP_ROOT/nojq_bin"
+mkdir -p "$NOJQ_BIN_DIR"
+ln -sf "$(command -v date)" "$NOJQ_BIN_DIR/date"
+ln -sf "$(command -v tee)" "$NOJQ_BIN_DIR/tee"
+ORIG_PATH="$PATH"
+PATH="$NOJQ_BIN_DIR"
+_retry_pending_receipts
+RETRY_RC=$?
+PATH="$ORIG_PATH"
+
+assert_eq "1" "$RETRY_RC" \
+    "T8: jq absent -> _retry_pending_receipts returns failure"
+assert_eq "0" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T8: jq absent -> zero processed-moves"
+assert_eq "1" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T8: jq absent -> pending file untouched"
+assert_file_contains "$PROCESSING_LOG" "jq not found" \
+    "T8: jq-absence error logged"
+
+# ===========================================================================
+# Test 9 (finding 1a): load-buffer failure -> paste sequence aborts,
+# item stays pending
+# ===========================================================================
+reset_mocks
+write_pending "d-lb-1.json" "d-lb"
+touch "$MOCK_LOADBUFFER_FAIL_FLAG"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_eq "0" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T9: load-buffer failure -> paste-buffer never attempted"
+assert_eq "0" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T9: load-buffer failure -> nothing moved to processed"
+assert_eq "1" "$(count_files "$RECEIPTS_PENDING_DIR")" \
+    "T9: load-buffer failure -> item stays pending"
+assert_file_contains "$PROCESSING_LOG" "Failed to load-buffer" \
+    "T9: load-buffer failure logged"
+rm -f "$MOCK_LOADBUFFER_FAIL_FLAG"
+
+# ===========================================================================
+# Test 10 (finding 3): digest message includes the dispatch_id list
+# ===========================================================================
+reset_mocks
+write_pending "d-idlist-1.json" "d-idlist-1"
+write_pending "d-idlist-2.json" "d-idlist-2"
+write_pending "d-idlist-3.json" "d-idlist-3"
+write_pending "d-idlist-4.json" "d-idlist-4"
+write_pending "d-idlist-5.json" "d-idlist-5"
+write_pending "d-idlist-6.json" "d-idlist-6"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_file_contains "$MOCK_LOADED_BUFFER" "IDs:" \
+    "T10: digest message has an IDs: section"
+IDLIST_ALL_PRESENT=1
+for n in 1 2 3 4 5 6; do
+    grep -q "d-idlist-$n" "$MOCK_LOADED_BUFFER" || IDLIST_ALL_PRESENT=0
+done
+assert_eq "1" "$IDLIST_ALL_PRESENT" \
+    "T10: digest message lists all 6 pending dispatch_ids (under the 10-id cap)"
 
 # --- Cleanup ---
 rm -rf "$TMP_ROOT"


### PR DESCRIPTION
Closes OI-654. Worker completed and committed (e97fd7aa) but skipped push+PR; T0 salvage-pushed.

- Submit-verify after paste+double-Enter (capture-pane last-line check); unverified stays in outbox pending for retry
- Retry-sweep dedupes pending by dispatch_id (bash-3.2-safe)
- Digest message when >VNX_RECEIPT_DIGEST_THRESHOLD (default 5) distinct pending
- VNX_RECEIPT_T0_PUSH=0 suppresses tmux push entirely (audit-append intact, delivery_mode=suppressed)
- 23 new bash-mock tests (tests/test_rp_delivery_gates.sh); defaults unchanged

Report: unified_reports/20260716-oi654-receipt-delivery.md
Dispatch-ID: 20260716-oi654-receipt-delivery

🤖 Generated with [Claude Code](https://claude.com/claude-code)