### PR TITLE
feat(adr034-pr1): core chain-origin anchor library + ledger lock adoption

### DIFF
--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -1,0 +1,753 @@
+"""ADR-034: external git-committed chain-origin anchor.
+
+Anchors a hash-chain ledger's per-epoch fingerprint as a git-committed record
+in the governed project's OWN source repo (``governance/chain-origin.ndjson``),
+read back only from git-committed history — never the working-tree copy. This
+is what makes ``verify_chain`` fail CLOSED against a local actor who can strip
+and re-chain the ledger: the anchor lives outside the trust boundary the
+ledger itself is inside.
+
+Full design: docs/governance/decisions/ADR-034-external-chain-origin-anchor.md
+Three prior attempts (#1085, #1086, #1171) anchored the origin somewhere the
+same actor who edits the ledger can also edit; all three were HELD by codex
+review for that reason. This ADR moves the anchor's source of truth outside
+that boundary. Implement literally — do not redesign.
+
+``VNX_CHAIN_RECEIPTS`` stays default-OFF. Nothing in this module runs unless a
+caller explicitly invokes it; landing this file changes no runtime behavior.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys as _sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Literal
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in _sys.path:
+    _sys.path.insert(0, str(_LIB_DIR))
+
+from gh_pr_ensure import ensure_pr  # noqa: E402  (thin PR-creation helper, reused not reinvented)
+from ndjson_hash_chain import (  # noqa: E402
+    EPOCH_MARKER_TYPE,
+    _append_epoch_marker_locked,
+    _ledger_locked,
+    compute_entry_hash,
+    epoch_state,
+    walk_chain,
+)
+from ndjson_hash_chain import verify_chain as _base_verify_chain  # noqa: E402
+
+
+ANCHOR_REL_PATH = Path("governance/chain-origin.ndjson")  # NOT under docs/ — see ADR §3 placement note
+
+
+class BranchProtectionUnconfirmedError(RuntimeError):
+    """Raised by seal_and_commit_origin when branch protection isn't confirmed active.
+
+    ADR-034 §6 step 2b is a hard activation precondition, not best-effort: the
+    caller must independently confirm (``gh api
+    repos/:owner/:repo/branches/:branch/protection``) that the anchor-
+    immutability check is a required status check with enforce_admins on
+    BEFORE calling seal_and_commit_origin. That gh-api check itself is PR-2
+    scope (out of scope here) — this library only refuses to proceed without
+    an explicit caller-supplied confirmation.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Data types (ADR §7 lists field shapes, not concrete types — dataclasses
+# chosen here for a stable, typed, JSON-serializable contract)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class OriginFingerprint:
+    """An epoch's OPENING fingerprint — computed at its chain_epoch_start marker."""
+
+    epoch: int
+    origin_type: str
+    origin_hash: str
+    origin_line_number: int
+    entries_before_origin: int
+
+
+@dataclass(frozen=True)
+class ClosureFingerprint:
+    """An epoch's CLOSURE commitment — its last entry, at the moment the next epoch opens."""
+
+    epoch: int
+    closure_hash: str
+    closure_line_number: int
+    entries_in_epoch: int
+
+
+@dataclass(frozen=True)
+class AnchorRecord:
+    """One parsed line from the git-committed ``governance/chain-origin.ndjson``."""
+
+    key: str
+    ledger_identity: str
+    epoch: int
+    record_type: str  # "open" | "close"
+    origin_type: str | None = None
+    origin_hash: str | None = None
+    origin_line_number: int | None = None
+    entries_before_origin: int | None = None
+    closure_hash: str | None = None
+    closure_line_number: int | None = None
+    entries_in_epoch: int | None = None
+    sealed_at: str | None = None
+
+
+@dataclass(frozen=True)
+class AnchorProvenance:
+    """What was resolved and from where — populated even on a None/"corrupt" record
+    result, so a caller can always show what was checked (ADR §2 off-host cross-check)."""
+
+    ref: str
+    resolved: bool
+    anchor_commit_sha: str | None = None
+    remote_url: str | None = None
+    error: str | None = None
+
+
+@dataclass(frozen=True)
+class SealResult:
+    action: str  # "sealed" | "noop"
+    epoch: int
+    origin: OriginFingerprint | None
+    branch_name: str | None
+    pr_url: str | None
+    closed_epoch: int | None
+
+
+# ---------------------------------------------------------------------------
+# Keys (ADR §1, §7)
+# ---------------------------------------------------------------------------
+
+
+def ledger_identity(project_id: str, ledger_path: Path, project_data_dir: Path) -> str:
+    """Stable logical key: '{project_id}:{ledger_path relative to project_data_dir}'.
+
+    Never an absolute local filesystem path (ADR §1) — combined with an epoch
+    number to form the actual anchor-file key (anchor_key/closure_key).
+    """
+    rel = ledger_path.resolve().relative_to(project_data_dir.resolve())
+    return f"{project_id}:{rel.as_posix()}"
+
+
+def anchor_key(identity: str, epoch: int) -> str:
+    """'{identity}#{epoch}' — one committed record per SEALED EPOCH (ADR §1 R4 fix)."""
+    return f"{identity}#{epoch}"
+
+
+def closure_key(identity: str, epoch: int) -> str:
+    """'{anchor_key(identity, epoch)}:close' — the sibling key for epoch's CLOSURE
+    commitment (ADR §1 C6). A brand-new key distinct from anchor_key, so §3's
+    "only new keys may be appended" CI rule covers it with no change."""
+    return f"{anchor_key(identity, epoch)}:close"
+
+
+# ---------------------------------------------------------------------------
+# Pure fingerprint computation over the ledger tail (ADR §7)
+# ---------------------------------------------------------------------------
+
+
+def _find_epoch_marker_line(ledger_path: Path, epoch: int) -> tuple[int, dict]:
+    for line_no, entry, _hash in walk_chain(ledger_path):
+        if entry.get("type") == EPOCH_MARKER_TYPE and _coerce_epoch(entry) == epoch:
+            return line_no, entry
+    raise ValueError(f"no chain_epoch_start marker for epoch {epoch} in {ledger_path}")
+
+
+def _coerce_epoch(entry: dict) -> int | None:
+    try:
+        return int(entry.get("epoch", -1))
+    except (TypeError, ValueError):
+        return None
+
+
+def compute_epoch_fingerprint(ledger_path: Path, epoch: int) -> OriginFingerprint:
+    """Pure computation over the CURRENT tail of ledger_path for the given sealed
+    epoch. Caller must hold ledger_lock_path(ledger_path)'s flock when calling
+    this for a WRITE (seal_and_commit_origin) — a read-only verify call is a
+    best-effort snapshot, same as the existing unlocked verify_chain walk."""
+    marker_line, marker_entry = _find_epoch_marker_line(ledger_path, epoch)
+    origin_hash = compute_entry_hash(marker_entry)
+    entries_before = sum(1 for line_no, _e, _h in walk_chain(ledger_path) if line_no < marker_line)
+    return OriginFingerprint(
+        epoch=epoch,
+        origin_type=EPOCH_MARKER_TYPE,
+        origin_hash=origin_hash,
+        origin_line_number=marker_line,
+        entries_before_origin=entries_before,
+    )
+
+
+def compute_epoch_closure(
+    ledger_path: Path, epoch: int, *, next_epoch_marker_line: int
+) -> ClosureFingerprint:
+    """Pure computation of epoch's CLOSURE commitment (ADR §1 C6): the hash and
+    absolute line number of epoch's last entry — the line immediately before
+    next_epoch_marker_line — plus the entry count that fell within epoch.
+
+    A zero-entry epoch (force_new_epoch called with nothing appended since
+    the epoch opened — a legitimate "shrink the residual window" pattern,
+    ADR §1) has no entry of its own to close on; its closure fingerprint
+    degenerates to the epoch's OWN opening marker (closure_hash ==
+    origin_hash, closure_line_number == origin_line_number,
+    entries_in_epoch == 0), which is well-defined and still detects any
+    tamper of the marker itself.
+    """
+    marker_line, marker_entry = _find_epoch_marker_line(ledger_path, epoch)
+    last_line_no = marker_line
+    last_hash = compute_entry_hash(marker_entry)
+    count = 0
+    for line_no, _entry, hash_ in walk_chain(ledger_path):
+        if marker_line < line_no < next_epoch_marker_line:
+            count += 1
+            last_line_no = line_no
+            last_hash = hash_
+    return ClosureFingerprint(
+        epoch=epoch,
+        closure_hash=last_hash,
+        closure_line_number=last_line_no,
+        entries_in_epoch=count,
+    )
+
+
+def _observed_epochs(ledger_path: Path) -> list[tuple[int, int]]:
+    """Every (epoch, marker_line) observed in the ledger walk, sorted by line."""
+    epochs: list[tuple[int, int]] = []
+    for line_no, entry, _hash in walk_chain(ledger_path):
+        if entry.get("type") == EPOCH_MARKER_TYPE:
+            epoch = _coerce_epoch(entry)
+            if epoch is not None:
+                epochs.append((epoch, line_no))
+    epochs.sort(key=lambda pair: pair[1])
+    return epochs
+
+
+# ---------------------------------------------------------------------------
+# Git-committed-history reads (ADR §2, §3) — NEVER the working tree
+# ---------------------------------------------------------------------------
+
+
+def _git_run(project_root: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", "-C", str(project_root), *args],
+        capture_output=True,
+        text=True,
+        timeout=timeout,
+    )
+
+
+def _git_run_checked(project_root: Path, *args: str, timeout: int = 30) -> subprocess.CompletedProcess:
+    proc = _git_run(project_root, *args, timeout=timeout)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed in {project_root}: {(proc.stderr or '').strip()[:500]}"
+        )
+    return proc
+
+
+def _resolve_remote_name(ref: str) -> str:
+    return ref.split("/", 1)[0] if "/" in ref else "origin"
+
+
+def _resolve_anchor_content(
+    project_root: Path, ref: str, anchor_rel_path: Path
+) -> tuple[str | None, AnchorProvenance]:
+    """Fetch (best-effort) + resolve ref, then `git show ref:path` from git-committed
+    history only. Read order per ADR §2: live fetch first (strongest guarantee),
+    falling back to whatever ref already resolves to locally (last successful
+    fetch) if the fetch itself fails (network unavailable) — `git show` below
+    reads through git's object store either way, never the working tree.
+
+    Returns (content, provenance):
+      - content is the raw NDJSON text when ref resolves and the anchor file
+        exists at that ref (possibly zero anchor lines if brand new).
+      - content is None when ref resolves but the anchor file doesn't exist
+        YET at that ref — the legitimate "nothing sealed so far" case, NOT a
+        failure (provenance.resolved is still True).
+      - provenance.resolved is False only when ref itself cannot be resolved
+        at all (no network + no cached tracking ref, or project_root isn't a
+        git repo) — the fail-closed case (ADR §2 step 3: "can't check" is
+        never "assume fine").
+    """
+    remote = _resolve_remote_name(ref)
+    _git_run(project_root, "fetch", remote, timeout=20)  # best-effort; failure handled by rev-parse below
+
+    rev = _git_run(project_root, "rev-parse", ref)
+    if rev.returncode != 0:
+        return None, AnchorProvenance(
+            ref=ref, resolved=False, error=(rev.stderr or "").strip()[:300] or "ref did not resolve"
+        )
+
+    sha = rev.stdout.strip()
+    remote_url_proc = _git_run(project_root, "remote", "get-url", remote)
+    remote_url = remote_url_proc.stdout.strip() if remote_url_proc.returncode == 0 else None
+    provenance = AnchorProvenance(ref=ref, resolved=True, anchor_commit_sha=sha, remote_url=remote_url)
+
+    show = _git_run(project_root, "show", f"{ref}:{anchor_rel_path.as_posix()}")
+    if show.returncode != 0:
+        return None, provenance  # path doesn't exist at this ref yet — legitimate, not a fault
+    return show.stdout, provenance
+
+
+def _iter_anchor_lines(content: str):
+    for raw_line in content.splitlines():
+        line = raw_line.strip()
+        if not line:
+            continue
+        try:
+            parsed = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(parsed, dict):
+            yield parsed
+
+
+def _parse_anchor_line(raw: dict) -> AnchorRecord:
+    return AnchorRecord(
+        key=raw["key"],
+        ledger_identity=raw["ledger_identity"],
+        epoch=int(raw["epoch"]),
+        record_type=raw["record_type"],
+        origin_type=raw.get("origin_type"),
+        origin_hash=raw.get("origin_hash"),
+        origin_line_number=raw.get("origin_line_number"),
+        entries_before_origin=raw.get("entries_before_origin"),
+        closure_hash=raw.get("closure_hash"),
+        closure_line_number=raw.get("closure_line_number"),
+        entries_in_epoch=raw.get("entries_in_epoch"),
+        sealed_at=raw.get("sealed_at"),
+    )
+
+
+def read_git_anchor(
+    project_root: Path,
+    identity: str,
+    epoch: int,
+    *,
+    kind: Literal["open", "close"] = "open",
+    anchor_rel_path: Path = ANCHOR_REL_PATH,
+    ref: str = "origin/main",
+) -> tuple[AnchorRecord | Literal["corrupt"] | None, AnchorProvenance]:
+    """Resolves anchor_key(identity, epoch)'s record (kind="open") or
+    closure_key(identity, epoch)'s record (kind="close") from GIT-COMMITTED
+    content only (ADR §2). NEVER reads the working-tree file. Returns the
+    FIRST matching record in file order; "corrupt" if more than one record
+    matches the same key (dupes=broken, ADR §3 — identical rule for open and
+    close keys). None only when ref resolves cleanly with genuinely no record
+    for this key.
+    """
+    target_key = anchor_key(identity, epoch) if kind == "open" else closure_key(identity, epoch)
+    content, provenance = _resolve_anchor_content(project_root, ref, anchor_rel_path)
+    if not provenance.resolved or content is None:
+        return None, provenance
+
+    matches = [raw for raw in _iter_anchor_lines(content) if raw.get("key") == target_key]
+    if not matches:
+        return None, provenance
+    if len(matches) > 1:
+        return "corrupt", provenance
+    return _parse_anchor_line(matches[0]), provenance
+
+
+def read_git_anchors_for_identity(
+    project_root: Path,
+    identity: str,
+    *,
+    anchor_rel_path: Path = ANCHOR_REL_PATH,
+    ref: str = "origin/main",
+) -> tuple[list[AnchorRecord], AnchorProvenance]:
+    """Full-identity scan (ADR §2 C7): every record whose key matches
+    '{identity}#*' (open) or '{identity}#*:close' (closure), across ALL
+    epochs. Exists because read_git_anchor requires a known epoch, and the
+    reverse fail-closed rule needs to ask "does ANY anchor exist for this
+    identity" precisely when the ledger is missing/empty/reset and supplies
+    no epoch to look up. An empty list from a cleanly-resolved ref (check
+    provenance.resolved) means genuinely no anchor exists anywhere for this
+    identity — distinct from a resolution failure.
+    """
+    content, provenance = _resolve_anchor_content(project_root, ref, anchor_rel_path)
+    if not provenance.resolved or content is None:
+        return [], provenance
+
+    prefix = f"{identity}#"
+    records = [
+        _parse_anchor_line(raw) for raw in _iter_anchor_lines(content) if str(raw.get("key", "")).startswith(prefix)
+    ]
+    return records, provenance
+
+
+def _read_local_head_anchor(
+    project_root: Path, key: str, *, anchor_rel_path: Path = ANCHOR_REL_PATH
+) -> dict | None:
+    """Local-HEAD (not origin/main) lookup used ONLY for seal_and_commit_origin's
+    own idempotency check ("read from the actor's own current HEAD, pre-push" —
+    ADR §7). Never used by verify_chain/read_git_anchor, which must only trust
+    git-committed remote history."""
+    show = _git_run(project_root, "show", f"HEAD:{anchor_rel_path.as_posix()}")
+    if show.returncode != 0:
+        return None
+    for raw in _iter_anchor_lines(show.stdout):
+        if raw.get("key") == key:
+            return raw
+    return None
+
+
+def check_anchor_immutability(base_content: str, head_content: str) -> list[dict]:
+    """Pure diff-logic for ADR §3's write-side rule: any key present in BOTH
+    base and head whose content changed, or present in base but removed in
+    head, is a violation. Brand-new keys in head are allowed. This is the
+    LOGIC the PR-2 GitHub Actions check invokes (base branch vs PR head) — no
+    CI/workflow wiring lives in this module.
+    """
+    base_by_key = {raw["key"]: raw for raw in _iter_anchor_lines(base_content) if "key" in raw}
+    head_by_key = {raw["key"]: raw for raw in _iter_anchor_lines(head_content) if "key" in raw}
+
+    violations: list[dict] = []
+    for key, base_record in base_by_key.items():
+        if key not in head_by_key:
+            violations.append({"key": key, "violation": "removed"})
+        elif head_by_key[key] != base_record:
+            violations.append({"key": key, "violation": "modified"})
+    return violations
+
+
+# ---------------------------------------------------------------------------
+# Write side: seal_and_commit_origin (ADR §4, §7)
+# ---------------------------------------------------------------------------
+
+
+def _origin_record(identity: str, fp: OriginFingerprint, *, sealed_at: str) -> dict:
+    return {
+        "key": anchor_key(identity, fp.epoch),
+        "ledger_identity": identity,
+        "epoch": fp.epoch,
+        "record_type": "open",
+        "origin_type": fp.origin_type,
+        "origin_hash": fp.origin_hash,
+        "origin_line_number": fp.origin_line_number,
+        "entries_before_origin": fp.entries_before_origin,
+        "sealed_at": sealed_at,
+    }
+
+
+def _closure_record(identity: str, fp: ClosureFingerprint, *, sealed_at: str) -> dict:
+    return {
+        "key": closure_key(identity, fp.epoch),
+        "ledger_identity": identity,
+        "epoch": fp.epoch,
+        "record_type": "close",
+        "closure_hash": fp.closure_hash,
+        "closure_line_number": fp.closure_line_number,
+        "entries_in_epoch": fp.entries_in_epoch,
+        "sealed_at": sealed_at,
+    }
+
+
+def _pr_url_for(project_root: Path, pr_number: int) -> str | None:
+    proc = subprocess.run(
+        ["gh", "pr", "view", str(pr_number), "--json", "url", "--jq", ".url"],
+        capture_output=True,
+        text=True,
+        timeout=20,
+        cwd=str(project_root),
+    )
+    return proc.stdout.strip() if proc.returncode == 0 and proc.stdout.strip() else None
+
+
+def _commit_and_push_anchor(
+    project_root: Path,
+    base_branch: str,
+    records: list[dict],
+    *,
+    identity: str,
+    epoch: int,
+) -> tuple[str, str | None]:
+    """Thin commit-orchestration helper (dispatch scope: file-write + SealResult;
+    CI wiring is PR-2). Appends `records` to the working-tree copy of
+    governance/chain-origin.ndjson, commits on a fresh branch, pushes, and
+    best-effort opens a PR via the shared gh_pr_ensure helper (never raises on
+    PR-creation failure — see gh_pr_ensure.ensure_pr). Git add/commit/push
+    failures DO raise (RuntimeError via _git_run_checked): a half-sealed
+    ledger with no anchor commit must read as `broken` per verify_chain's
+    fail-closed contract, never silently swallowed (ADR §4).
+    """
+    anchor_path = project_root / ANCHOR_REL_PATH
+    anchor_path.parent.mkdir(parents=True, exist_ok=True)
+    with anchor_path.open("a", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+    safe_identity = identity.replace("/", "-").replace(":", "-").replace("#", "-")
+    branch_name = f"chain-origin-seal/{safe_identity}/epoch-{epoch}"
+
+    _git_run_checked(project_root, "checkout", "-B", branch_name)
+    _git_run_checked(project_root, "add", str(ANCHOR_REL_PATH))
+    _git_run_checked(
+        project_root, "commit", "-m", f"chore(chain-origin): seal epoch {epoch} for {identity}"
+    )
+    _git_run_checked(project_root, "push", "-u", "origin", branch_name)
+
+    pr_result = ensure_pr(
+        branch_name,
+        project_root,
+        title=f"chore(chain-origin): seal epoch {epoch} for {identity}",
+        body=(
+            "Automated ADR-034 chain-origin seal.\n\n"
+            f"- ledger_identity: `{identity}`\n"
+            f"- epoch: {epoch}\n"
+            f"- base branch: {base_branch}\n"
+        ),
+    )
+    pr_url = _pr_url_for(project_root, pr_result["pr_number"]) if pr_result.get("pr_number") is not None else None
+    return branch_name, pr_url
+
+
+def seal_and_commit_origin(
+    ledger_path: Path,
+    project_root: Path,
+    *,
+    project_id: str,
+    project_data_dir: Path,
+    branch: str = "main",
+    force_new_epoch: bool = False,
+    branch_protection_confirmed: bool = False,
+) -> SealResult:
+    """Operator/T0-governed entrypoint (ADR §7). Holds
+    ledger_lock_path(ledger_path)'s flock across the full
+    read-current-epoch -> compute -> anchor sequence.
+
+    REFUSES (raises BranchProtectionUnconfirmedError, no seal attempted) unless
+    the caller passes branch_protection_confirmed=True — ADR §6 step 2b's hard
+    activation precondition, verified independently by the caller (a future
+    gh-api branch-protection check, PR-2 scope) BEFORE calling this. This
+    library never performs that gh-api call itself.
+
+    Idempotent per epoch: an anchor_key(identity, epoch) already present in
+    the anchor file (read from the actor's own current HEAD, pre-push) is a
+    no-op for that epoch; a NEW epoch since the last seal, or a previously
+    marker-opened-but-never-anchored epoch (crash/push-failure recovery),
+    produces a new anchor record. force_new_epoch=True opens a new epoch (and
+    closes the prior one) even when chaining hasn't lapsed.
+    """
+    if not branch_protection_confirmed:
+        raise BranchProtectionUnconfirmedError(
+            f"seal_and_commit_origin refuses to seal {ledger_path} against branch "
+            f"{branch!r}: branch_protection_confirmed=False. ADR-034 §6 step 2b is a "
+            "hard activation precondition, not best-effort — the caller must "
+            "independently confirm (gh api repos/:owner/:repo/branches/:branch/"
+            "protection) that the anchor-immutability check is a required status "
+            "check with enforce_admins on before calling this. No commit or push "
+            "was attempted."
+        )
+
+    with _ledger_locked(ledger_path):
+        max_epoch, chaining_active = epoch_state(ledger_path)
+        opened_new_epoch = False
+        prior_epoch: int | None = None
+
+        # A new marked epoch is needed when chaining lapsed (existing ADR-029
+        # trigger), the caller forces it, OR max_epoch==0 — the ledger has
+        # NEVER had a chain_epoch_start marker, whether because it's empty or
+        # because it's a marker-less GENESIS chain ("verified", not
+        # "verified-segmented"). Epoch 0 has no marker to anchor by
+        # construction (ADR §1: "the immutable pre-adoption entries form
+        # epoch 0"), so max_epoch==0 can never itself be sealed/anchored —
+        # only a newly-opened epoch 1 can.
+        if force_new_epoch or not chaining_active or max_epoch == 0:
+            prior_epoch = max_epoch if max_epoch > 0 else None
+            new_epoch = max_epoch + 1
+            _append_epoch_marker_locked(ledger_path, new_epoch)
+            epoch = new_epoch
+            opened_new_epoch = True
+        else:
+            epoch = max_epoch
+
+        identity = ledger_identity(project_id, ledger_path, project_data_dir)
+        existing = _read_local_head_anchor(project_root, anchor_key(identity, epoch))
+        if existing is not None and not opened_new_epoch:
+            return SealResult(
+                action="noop", epoch=epoch, origin=None, branch_name=None, pr_url=None, closed_epoch=None
+            )
+
+        origin_fp = compute_epoch_fingerprint(ledger_path, epoch)
+        closure_fp: ClosureFingerprint | None = None
+        if prior_epoch is not None:
+            next_marker_line = sum(1 for _ in ledger_path.open("r", encoding="utf-8"))
+            closure_fp = compute_epoch_closure(ledger_path, prior_epoch, next_epoch_marker_line=next_marker_line)
+
+    # Git/commit/push below intentionally happens OUTSIDE the ledger lock — it
+    # touches project_root's git state, not the ledger file, and a slow push
+    # must not hold receipt appends hostage.
+    sealed_at = datetime.now(timezone.utc).isoformat()
+    records = [_origin_record(identity, origin_fp, sealed_at=sealed_at)]
+    if closure_fp is not None:
+        records.append(_closure_record(identity, closure_fp, sealed_at=sealed_at))
+
+    branch_name, pr_url = _commit_and_push_anchor(project_root, branch, records, identity=identity, epoch=epoch)
+
+    return SealResult(
+        action="sealed",
+        epoch=epoch,
+        origin=origin_fp,
+        branch_name=branch_name,
+        pr_url=pr_url,
+        closed_epoch=prior_epoch,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor-aware verify_chain (ADR §2, §7) — a NEW function, distinct from
+# ndjson_hash_chain.verify_chain (imported above as _base_verify_chain, which
+# stays byte-for-byte unchanged so its five existing callers keep working
+# unmodified; threading project_root through those call sites is the ADR §6
+# step-3 migration, gated on step 2b, and is explicitly PR-2+ scope).
+# ---------------------------------------------------------------------------
+
+
+def verify_chain(
+    path: Path,
+    *,
+    project_root: Path | None = None,
+    project_id: str | None = None,
+    project_data_dir: Path | None = None,
+    anchor_ref: str = "origin/main",
+) -> tuple[bool, list[dict], str, AnchorProvenance | None]:
+    """Existing ADR-029 epoch-aware walk (via ndjson_hash_chain.verify_chain),
+    PLUS the ADR-034 anchor-aware contract (§2):
+
+    - Forward (open): every chain_epoch_start marker observed requires a
+      matching git anchor for anchor_key(identity, epoch) — absence,
+      resolution failure, or "corrupt" (duplicate) all report "broken".
+    - Forward (closed): every epoch that has closed (a later epoch's marker
+      is present) requires a matching closure record whose closure_hash/
+      closure_line_number reproduce exactly what the walk observes. The
+      currently-open (latest) epoch is exempt.
+    - Reverse: resolved BEFORE the unchained/empty short-circuit via
+      read_git_anchors_for_identity — a missing/reset ledger with any
+      committed anchor for its identity is "broken", not "unchained".
+
+    Ledgers that never enabled chaining AND have no anchor anywhere are
+    unaffected. project_root/project_id/project_data_dir all missing on a
+    ledger the base walk shows as unchained is the "additive, read path
+    unchanged" case (ADR §6 step 1) — no anchor check is attempted, result
+    passes through unchanged. Missing identity params on a CHAINING-ENABLED
+    ledger is itself "broken" (cannot silently skip the anchor check).
+    """
+    base_ok, base_violations, base_status = _base_verify_chain(path)
+    saw_chain = base_status != "unchained"
+    identity_available = project_root is not None and project_id is not None and project_data_dir is not None
+
+    if not saw_chain:
+        if not identity_available:
+            return base_ok, list(base_violations), base_status, None
+
+        identity = ledger_identity(project_id, path, project_data_dir)  # type: ignore[arg-type]
+        anchors, provenance = read_git_anchors_for_identity(project_root, identity, ref=anchor_ref)  # type: ignore[arg-type]
+        if not provenance.resolved:
+            violations = list(base_violations) + [
+                {"note": "anchor resolution failed (fail-closed)", "error": provenance.error}
+            ]
+            return False, violations, "broken", provenance
+        if anchors:
+            violations = list(base_violations) + [
+                {
+                    "note": "git anchor exists for this ledger_identity but the ledger is missing/empty/unchained",
+                    "anchor_keys": [a.key for a in anchors],
+                }
+            ]
+            return False, violations, "broken", provenance
+        return base_ok, list(base_violations), base_status, provenance
+
+    if not identity_available:
+        violations = list(base_violations) + [
+            {"note": "project_root/project_id/project_data_dir required for a chaining-enabled ledger (ADR-034 §2)"}
+        ]
+        return False, violations, "broken", None
+
+    identity = ledger_identity(project_id, path, project_data_dir)  # type: ignore[arg-type]
+    epochs = _observed_epochs(path)
+    violations = list(base_violations)
+    last_provenance: AnchorProvenance | None = None
+    anchor_failed = False
+
+    for idx, (epoch, _marker_line) in enumerate(epochs):
+        record, provenance = read_git_anchor(project_root, identity, epoch, kind="open", ref=anchor_ref)  # type: ignore[arg-type]
+        last_provenance = provenance
+        if not provenance.resolved:
+            violations.append({"epoch": epoch, "note": "anchor resolution failed (fail-closed)", "error": provenance.error})
+            anchor_failed = True
+            continue
+        if record is None:
+            violations.append({"epoch": epoch, "note": "no git anchor for this epoch's chain_epoch_start marker"})
+            anchor_failed = True
+            continue
+        if record == "corrupt":
+            violations.append({"epoch": epoch, "note": "duplicate git anchor records for this epoch (corrupt)"})
+            anchor_failed = True
+            continue
+
+        observed = compute_epoch_fingerprint(path, epoch)
+        if (
+            record.origin_hash != observed.origin_hash
+            or record.origin_line_number != observed.origin_line_number
+            or record.entries_before_origin != observed.entries_before_origin
+        ):
+            violations.append(
+                {
+                    "epoch": epoch,
+                    "note": "epoch opening fingerprint mismatch (tamper)",
+                    "anchor_origin_hash": record.origin_hash,
+                    "observed_origin_hash": observed.origin_hash,
+                }
+            )
+            anchor_failed = True
+
+        is_closed = idx + 1 < len(epochs)
+        if not is_closed:
+            continue  # currently-open (latest) epoch: accepted residual, no closure expected
+
+        next_marker_line = epochs[idx + 1][1]
+        closure_record, cprovenance = read_git_anchor(project_root, identity, epoch, kind="close", ref=anchor_ref)  # type: ignore[arg-type]
+        last_provenance = cprovenance
+        if not cprovenance.resolved:
+            violations.append({"epoch": epoch, "note": "closure anchor resolution failed (fail-closed)", "error": cprovenance.error})
+            anchor_failed = True
+            continue
+        if closure_record is None:
+            violations.append({"epoch": epoch, "note": "no closure record for a CLOSED epoch"})
+            anchor_failed = True
+            continue
+        if closure_record == "corrupt":
+            violations.append({"epoch": epoch, "note": "duplicate closure records for this epoch (corrupt)"})
+            anchor_failed = True
+            continue
+
+        observed_closure = compute_epoch_closure(path, epoch, next_epoch_marker_line=next_marker_line)
+        if (
+            closure_record.closure_hash != observed_closure.closure_hash
+            or closure_record.closure_line_number != observed_closure.closure_line_number
+            or closure_record.entries_in_epoch != observed_closure.entries_in_epoch
+        ):
+            violations.append(
+                {
+                    "epoch": epoch,
+                    "note": "epoch closure fingerprint mismatch (tamper)",
+                    "anchor_closure_hash": closure_record.closure_hash,
+                    "observed_closure_hash": observed_closure.closure_hash,
+                }
+            )
+            anchor_failed = True
+
+    final_ok = base_ok and not anchor_failed
+    final_status = base_status if final_ok else "broken"
+    return final_ok, violations, final_status, last_provenance

--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -117,7 +117,7 @@ class AnchorProvenance:
 
 @dataclass(frozen=True)
 class SealResult:
-    action: str  # "sealed" | "noop"
+    action: str  # "sealed" | "noop" | "resumed"
     epoch: int
     origin: OriginFingerprint | None
     branch_name: str | None
@@ -259,6 +259,31 @@ def _resolve_remote_name(ref: str) -> str:
     return ref.split("/", 1)[0] if "/" in ref else "origin"
 
 
+def _qualify_remote_ref(project_root: Path, ref: str) -> str | None:
+    """Rewrite a `<remote>/<branch>` ref into its EXPLICIT `refs/remotes/<remote>/<branch>`
+    form so `git rev-parse`/`git show` can never resolve it against a
+    same-named LOCAL branch instead.
+
+    Per gitrevisions(7)'s disambiguation order, an unqualified `<refname>`
+    checks `refs/heads/<refname>` BEFORE `refs/remotes/<refname>` — a local
+    attacker who creates a branch literally named e.g. `origin/main` (git
+    allows slashes in branch names) gets it trusted over the real
+    remote-tracking ref unless callers qualify explicitly (Finding 5,
+    ADR-034 fix-r1).
+
+    Returns None when `ref` isn't a `<remote>/<branch>` shape against a
+    CONFIGURED remote — callers must fail closed in that case, never fall
+    back to the ambiguous short form.
+    """
+    remote, sep, branch = ref.partition("/")
+    if not sep or not remote or not branch:
+        return None
+    remote_check = _git_run(project_root, "remote", "get-url", remote)
+    if remote_check.returncode != 0:
+        return None
+    return f"refs/remotes/{remote}/{branch}"
+
+
 def _resolve_anchor_content(
     project_root: Path, ref: str, anchor_rel_path: Path
 ) -> tuple[str | None, AnchorProvenance]:
@@ -267,6 +292,13 @@ def _resolve_anchor_content(
     falling back to whatever ref already resolves to locally (last successful
     fetch) if the fetch itself fails (network unavailable) — `git show` below
     reads through git's object store either way, never the working tree.
+
+    `ref` is always resolved via its EXPLICIT `refs/remotes/<remote>/<branch>`
+    form (see `_qualify_remote_ref`) — never the bare `<remote>/<branch>`
+    shorthand, which a local branch of the same name could shadow (Finding 5).
+    A `ref` that isn't a resolvable `<remote>/<branch>` form against a
+    configured remote fails closed (`resolved=False`) rather than silently
+    falling back to the ambiguous form.
 
     Returns (content, provenance):
       - content is the raw NDJSON text when ref resolves and the anchor file
@@ -282,7 +314,15 @@ def _resolve_anchor_content(
     remote = _resolve_remote_name(ref)
     _git_run(project_root, "fetch", remote, timeout=20)  # best-effort; failure handled by rev-parse below
 
-    rev = _git_run(project_root, "rev-parse", ref)
+    qualified_ref = _qualify_remote_ref(project_root, ref)
+    if qualified_ref is None:
+        return None, AnchorProvenance(
+            ref=ref,
+            resolved=False,
+            error=f"ref {ref!r} is not a resolvable <remote>/<branch> form against a configured remote (fail-closed)",
+        )
+
+    rev = _git_run(project_root, "rev-parse", qualified_ref)
     if rev.returncode != 0:
         return None, AnchorProvenance(
             ref=ref, resolved=False, error=(rev.stderr or "").strip()[:300] or "ref did not resolve"
@@ -293,7 +333,7 @@ def _resolve_anchor_content(
     remote_url = remote_url_proc.stdout.strip() if remote_url_proc.returncode == 0 else None
     provenance = AnchorProvenance(ref=ref, resolved=True, anchor_commit_sha=sha, remote_url=remote_url)
 
-    show = _git_run(project_root, "show", f"{ref}:{anchor_rel_path.as_posix()}")
+    show = _git_run(project_root, "show", f"{qualified_ref}:{anchor_rel_path.as_posix()}")
     if show.returncode != 0:
         return None, provenance  # path doesn't exist at this ref yet — legitimate, not a fault
     return show.stdout, provenance
@@ -402,6 +442,31 @@ def _read_local_head_anchor(
     return None
 
 
+def _read_remote_base_anchor(
+    project_root: Path, branch: str, key: str, *, anchor_rel_path: Path = ANCHOR_REL_PATH
+) -> dict | None:
+    """Has `key` already landed on the REMOTE tracking ref for the seal's base
+    branch (``origin/<branch>``, post-fetch, resolved through the same
+    remote-ref qualification as ``read_git_anchor``)?
+
+    Distinguishes a TRUE noop (the anchor already reached origin — e.g. a
+    prior PR merged) from a partial-seal retry where a previous attempt
+    committed LOCALLY on its own seal branch but the ``git push`` itself
+    raised (Finding 3, ADR-034 fix-r1) — local HEAD alone can never answer
+    that question, since HEAD stays parked on the uncommitted seal branch
+    after a push failure. Same read discipline as read_git_anchor: fetch
+    best-effort, `git show` through git's object store, never the working
+    tree.
+    """
+    content, provenance = _resolve_anchor_content(project_root, f"origin/{branch}", anchor_rel_path)
+    if not provenance.resolved or content is None:
+        return None
+    for raw in _iter_anchor_lines(content):
+        if raw.get("key") == key:
+            return raw
+    return None
+
+
 def check_anchor_immutability(base_content: str, head_content: str) -> list[dict]:
     """Pure diff-logic for ADR §3's write-side rule: any key present in BOTH
     base and head whose content changed, or present in base but removed in
@@ -464,6 +529,15 @@ def _pr_url_for(project_root: Path, pr_number: int) -> str | None:
     return proc.stdout.strip() if proc.returncode == 0 and proc.stdout.strip() else None
 
 
+def _seal_branch_name(identity: str, epoch: int) -> str:
+    """Deterministic from (identity, epoch) alone — recomputed by both the
+    fresh-seal path and the partial-seal resume path (Finding 3) so a retry
+    in a NEW process can find the exact same local branch a prior attempt
+    committed to, with no state to persist between them."""
+    safe_identity = identity.replace("/", "-").replace(":", "-").replace("#", "-")
+    return f"chain-origin-seal/{safe_identity}/epoch-{epoch}"
+
+
 def _commit_and_push_anchor(
     project_root: Path,
     base_branch: str,
@@ -487,8 +561,7 @@ def _commit_and_push_anchor(
         for record in records:
             f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
 
-    safe_identity = identity.replace("/", "-").replace(":", "-").replace("#", "-")
-    branch_name = f"chain-origin-seal/{safe_identity}/epoch-{epoch}"
+    branch_name = _seal_branch_name(identity, epoch)
 
     _git_run_checked(project_root, "checkout", "-B", branch_name)
     _git_run_checked(project_root, "add", str(ANCHOR_REL_PATH))
@@ -510,6 +583,38 @@ def _commit_and_push_anchor(
     )
     pr_url = _pr_url_for(project_root, pr_result["pr_number"]) if pr_result.get("pr_number") is not None else None
     return branch_name, pr_url
+
+
+def _resume_partial_seal(project_root: Path, base_branch: str, identity: str, epoch: int) -> SealResult:
+    """Finding 3 fix (ADR-034 fix-r1): a prior seal attempt committed the
+    anchor record LOCALLY (on its deterministic seal branch, see
+    _seal_branch_name) but the ``git push`` itself raised before origin ever
+    saw it. Resume by re-pushing that SAME local branch/commit and
+    re-ensuring its PR — NEVER by calling _commit_and_push_anchor again,
+    which would re-append the record to the working-tree file and create a
+    SECOND commit (a duplicate record). The local branch ref is stable
+    across process restarts, so no state needs to be threaded through: just
+    recompute its name and push it.
+    """
+    branch_name = _seal_branch_name(identity, epoch)
+    _git_run_checked(project_root, "push", "-u", "origin", branch_name)
+
+    pr_result = ensure_pr(
+        branch_name,
+        project_root,
+        title=f"chore(chain-origin): seal epoch {epoch} for {identity}",
+        body=(
+            "Automated ADR-034 chain-origin seal (resumed after a prior push failure).\n\n"
+            f"- ledger_identity: `{identity}`\n"
+            f"- epoch: {epoch}\n"
+            f"- base branch: {base_branch}\n"
+        ),
+    )
+    pr_url = _pr_url_for(project_root, pr_result["pr_number"]) if pr_result.get("pr_number") is not None else None
+
+    return SealResult(
+        action="resumed", epoch=epoch, origin=None, branch_name=branch_name, pr_url=pr_url, closed_epoch=None
+    )
 
 
 def seal_and_commit_origin(
@@ -534,10 +639,18 @@ def seal_and_commit_origin(
 
     Idempotent per epoch: an anchor_key(identity, epoch) already present in
     the anchor file (read from the actor's own current HEAD, pre-push) is a
-    no-op for that epoch; a NEW epoch since the last seal, or a previously
-    marker-opened-but-never-anchored epoch (crash/push-failure recovery),
-    produces a new anchor record. force_new_epoch=True opens a new epoch (and
-    closes the prior one) even when chaining hasn't lapsed.
+    candidate no-op for that epoch — but the noop is only REAL when that
+    anchor has also reached origin's base branch (Finding 3, ADR-034
+    fix-r1). A commit that landed locally (on its own seal branch) but whose
+    `git push` itself raised leaves HEAD parked on that seal branch with the
+    anchor already committed; local-HEAD alone can't tell that apart from a
+    genuine prior success, so it's cross-checked against
+    ``origin/<branch>``. Local-only resumes the push (action="resumed") —
+    same branch, same commit, no new record appended. A NEW epoch since the
+    last seal, or a previously marker-opened-but-never-anchored epoch (crash
+    BEFORE any commit), produces a new anchor record (action="sealed").
+    force_new_epoch=True opens a new epoch (and closes the prior one) even
+    when chaining hasn't lapsed.
     """
     if not branch_protection_confirmed:
         raise BranchProtectionUnconfirmedError(
@@ -573,21 +686,34 @@ def seal_and_commit_origin(
             epoch = max_epoch
 
         identity = ledger_identity(project_id, ledger_path, project_data_dir)
-        existing = _read_local_head_anchor(project_root, anchor_key(identity, epoch))
-        if existing is not None and not opened_new_epoch:
-            return SealResult(
-                action="noop", epoch=epoch, origin=None, branch_name=None, pr_url=None, closed_epoch=None
-            )
+        local_existing = _read_local_head_anchor(project_root, anchor_key(identity, epoch))
+        needs_resume = False
+        if local_existing is not None and not opened_new_epoch:
+            remote_existing = _read_remote_base_anchor(project_root, branch, anchor_key(identity, epoch))
+            if remote_existing is not None:
+                return SealResult(
+                    action="noop", epoch=epoch, origin=None, branch_name=None, pr_url=None, closed_epoch=None
+                )
+            # Anchor committed locally (prior attempt's seal branch) but
+            # never reached origin — a partial-seal retry (Finding 3), not a
+            # genuine noop. Resume outside the lock below instead of
+            # re-appending/re-committing a duplicate record.
+            needs_resume = True
 
-        origin_fp = compute_epoch_fingerprint(ledger_path, epoch)
+        origin_fp: OriginFingerprint | None = None
         closure_fp: ClosureFingerprint | None = None
-        if prior_epoch is not None:
-            next_marker_line = sum(1 for _ in ledger_path.open("r", encoding="utf-8"))
-            closure_fp = compute_epoch_closure(ledger_path, prior_epoch, next_epoch_marker_line=next_marker_line)
+        if not needs_resume:
+            origin_fp = compute_epoch_fingerprint(ledger_path, epoch)
+            if prior_epoch is not None:
+                next_marker_line = sum(1 for _ in ledger_path.open("r", encoding="utf-8"))
+                closure_fp = compute_epoch_closure(ledger_path, prior_epoch, next_epoch_marker_line=next_marker_line)
 
     # Git/commit/push below intentionally happens OUTSIDE the ledger lock — it
     # touches project_root's git state, not the ledger file, and a slow push
     # must not hold receipt appends hostage.
+    if needs_resume:
+        return _resume_partial_seal(project_root, branch, identity, epoch)
+
     sealed_at = datetime.now(timezone.utc).isoformat()
     records = [_origin_record(identity, origin_fp, sealed_at=sealed_at)]
     if closure_fp is not None:
@@ -676,9 +802,66 @@ def verify_chain(
 
     identity = ledger_identity(project_id, path, project_data_dir)  # type: ignore[arg-type]
     epochs = _observed_epochs(path)
+    observed_epoch_numbers = {epoch for epoch, _marker_line in epochs}
+    max_observed_epoch = max(observed_epoch_numbers) if observed_epoch_numbers else None
     violations = list(base_violations)
     last_provenance: AnchorProvenance | None = None
     anchor_failed = False
+
+    # Reverse scan (Findings 1+2, ADR-034 fix-r1): MUST run unconditionally in
+    # the chained path, not only when the base walk reports "unchained". Two
+    # bypasses this closes:
+    #   (a) a markerless GENESIS rechain strips every chain_epoch_start
+    #       marker — _observed_epochs(path) is then [], so the per-epoch loop
+    #       below never runs and an existing origin anchor is never consulted;
+    #   (b) a rollback to an earlier epoch while origin holds a LATER epoch's
+    #       anchor — the earlier epoch still matches its own fingerprint and,
+    #       unqualified, would read as "the open latest epoch, no closure
+    #       required".
+    # Both require checking every anchor this identity has EVER had against
+    # what the CURRENT ledger tail actually still shows — not just the
+    # epochs the tail happens to observe right now.
+    anchors_for_identity, id_provenance = read_git_anchors_for_identity(project_root, identity, ref=anchor_ref)  # type: ignore[arg-type]
+    last_provenance = id_provenance
+    max_anchored_open_epoch: int | None = None
+    if not id_provenance.resolved:
+        violations.append({"note": "identity anchor scan failed (fail-closed)", "error": id_provenance.error})
+        anchor_failed = True
+    else:
+        open_anchor_epochs = {r.epoch for r in anchors_for_identity if r.record_type == "open"}
+        if open_anchor_epochs:
+            max_anchored_open_epoch = max(open_anchor_epochs)
+        if open_anchor_epochs and not observed_epoch_numbers:
+            violations.append(
+                {
+                    "note": "git anchors exist for this ledger_identity but the ledger shows no "
+                    "chain_epoch_start markers (markerless rechain)",
+                    "anchor_epochs": sorted(open_anchor_epochs),
+                }
+            )
+            anchor_failed = True
+        missing_anchored_epochs = open_anchor_epochs - observed_epoch_numbers
+        if missing_anchored_epochs:
+            violations.append(
+                {
+                    "note": "git anchor(s) exist for epoch(s) the ledger no longer observes",
+                    "missing_epochs": sorted(missing_anchored_epochs),
+                }
+            )
+            anchor_failed = True
+        if (
+            max_anchored_open_epoch is not None
+            and max_observed_epoch is not None
+            and max_anchored_open_epoch > max_observed_epoch
+        ):
+            violations.append(
+                {
+                    "note": "highest anchored epoch exceeds highest observed epoch (rollback)",
+                    "anchored_max_epoch": max_anchored_open_epoch,
+                    "observed_max_epoch": max_observed_epoch,
+                }
+            )
+            anchor_failed = True
 
     for idx, (epoch, _marker_line) in enumerate(epochs):
         record, provenance = read_git_anchor(project_root, identity, epoch, kind="open", ref=anchor_ref)  # type: ignore[arg-type]
@@ -712,9 +895,19 @@ def verify_chain(
             )
             anchor_failed = True
 
-        is_closed = idx + 1 < len(epochs)
-        if not is_closed:
-            continue  # currently-open (latest) epoch: accepted residual, no closure expected
+        if idx + 1 >= len(epochs):
+            # This is the last epoch the CURRENT ledger tail observes, so
+            # there's no local next-epoch marker to bound a closure
+            # computation against. That's only a legitimate "still open,
+            # no closure expected" exemption when this is ALSO truly the
+            # highest ANCHORED epoch (Finding 2's rollback-tightening) — a
+            # ledger rolled back to an earlier epoch while origin holds a
+            # LATER epoch's anchor must NOT read as "still open" just
+            # because it happens to be the local tail. The reverse scan
+            # above already flags that case broken (max_anchored_open_epoch
+            # > max_observed_epoch / missing anchored epoch), so there is
+            # nothing further to compute here either way.
+            continue
 
         next_marker_line = epochs[idx + 1][1]
         closure_record, cprovenance = read_git_anchor(project_root, identity, epoch, kind="close", ref=anchor_ref)  # type: ignore[arg-type]

--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -585,6 +585,41 @@ def _commit_and_push_anchor(
     return branch_name, pr_url
 
 
+def _missing_closure_fingerprints(
+    ledger_path: Path,
+    project_root: Path,
+    branch: str,
+    identity: str,
+    epochs: list[tuple[int, int]],
+) -> list[ClosureFingerprint]:
+    """Finding 2 fix (ADR-034 fix-r2): every epoch the CURRENT ledger tail
+    shows as CLOSED (a later epoch's marker exists) whose closure_key hasn't
+    yet landed on ``origin/<branch>`` — computed and returned regardless of
+    whether THIS seal call is the one that freshly opened the newer epoch.
+
+    Without this, a crash between appending a new epoch's marker (durable on
+    the ledger) and this call's own commit/push (never durable anywhere)
+    leaves epoch_state reporting the new epoch as already-current on retry —
+    ``opened_new_epoch=False``, ``prior_epoch=None`` — so a "only close what
+    I just opened" check would silently skip the prior epoch's closure
+    forever, and verify_chain would stay broken ("no closure record for a
+    CLOSED epoch") permanently. Idempotent per the same remote-check
+    discipline as ``seal_and_commit_origin``'s own noop check
+    (``_read_remote_base_anchor``): an epoch already closed on origin is
+    never recomputed/re-emitted. The currently-open (last) epoch is exempt —
+    there is nothing to close yet.
+    """
+    missing: list[ClosureFingerprint] = []
+    for idx, (epoch, _marker_line) in enumerate(epochs):
+        if idx + 1 >= len(epochs):
+            continue  # still open — no closure expected yet
+        if _read_remote_base_anchor(project_root, branch, closure_key(identity, epoch)) is not None:
+            continue  # already sealed by a prior (possibly different) seal call
+        next_marker_line = epochs[idx + 1][1]
+        missing.append(compute_epoch_closure(ledger_path, epoch, next_epoch_marker_line=next_marker_line))
+    return missing
+
+
 def _resume_partial_seal(project_root: Path, base_branch: str, identity: str, epoch: int) -> SealResult:
     """Finding 3 fix (ADR-034 fix-r1): a prior seal attempt committed the
     anchor record LOCALLY (on its deterministic seal branch, see
@@ -701,12 +736,17 @@ def seal_and_commit_origin(
             needs_resume = True
 
         origin_fp: OriginFingerprint | None = None
-        closure_fp: ClosureFingerprint | None = None
+        closure_fps: list[ClosureFingerprint] = []
         if not needs_resume:
             origin_fp = compute_epoch_fingerprint(ledger_path, epoch)
-            if prior_epoch is not None:
-                next_marker_line = sum(1 for _ in ledger_path.open("r", encoding="utf-8"))
-                closure_fp = compute_epoch_closure(ledger_path, prior_epoch, next_epoch_marker_line=next_marker_line)
+            # Backfill EVERY closed-but-unanchored epoch (Finding 2, ADR-034
+            # fix-r2) — not just `prior_epoch` (the epoch THIS call happens to
+            # have freshly closed). A prior crash between the marker-append
+            # and the commit/push can leave an older epoch's closure missing
+            # even when this call itself doesn't open a new epoch.
+            closure_fps = _missing_closure_fingerprints(
+                ledger_path, project_root, branch, identity, _observed_epochs(ledger_path)
+            )
 
     # Git/commit/push below intentionally happens OUTSIDE the ledger lock — it
     # touches project_root's git state, not the ledger file, and a slow push
@@ -716,7 +756,7 @@ def seal_and_commit_origin(
 
     sealed_at = datetime.now(timezone.utc).isoformat()
     records = [_origin_record(identity, origin_fp, sealed_at=sealed_at)]
-    if closure_fp is not None:
+    for closure_fp in closure_fps:
         records.append(_closure_record(identity, closure_fp, sealed_at=sealed_at))
 
     branch_name, pr_url = _commit_and_push_anchor(project_root, branch, records, identity=identity, epoch=epoch)
@@ -828,6 +868,22 @@ def verify_chain(
         violations.append({"note": "identity anchor scan failed (fail-closed)", "error": id_provenance.error})
         anchor_failed = True
     else:
+        if not anchors_for_identity:
+            # Finding 1 (ADR-034 fix-r2): a chaining-active ledger (saw_chain
+            # True — we're already inside that branch here) with ZERO anchors
+            # anywhere for its identity. The per-epoch loop below can't catch
+            # this on its own when epochs == [] (every chain_epoch_start
+            # marker stripped, a markerless GENESIS rechain) — it just never
+            # runs. A ledger with markers but genuinely no anchor yet is
+            # already caught per-epoch further down; this closes the
+            # markerless variant of the same gap so it fails identically.
+            violations.append(
+                {
+                    "note": "chaining-active ledger has no git anchor anywhere for this "
+                    "ledger_identity (unanchored or markerless chain)",
+                }
+            )
+            anchor_failed = True
         open_anchor_epochs = {r.epoch for r in anchors_for_identity if r.record_type == "open"}
         if open_anchor_epochs:
             max_anchored_open_epoch = max(open_anchor_epochs)

--- a/scripts/lib/ndjson_hash_chain.py
+++ b/scripts/lib/ndjson_hash_chain.py
@@ -14,8 +14,10 @@ not a replacement.
 """
 from __future__ import annotations
 
+import fcntl
 import hashlib
 import json
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Iterator
@@ -47,6 +49,42 @@ def compute_entry_hash(entry: dict) -> str:
     return hashlib.sha256(canonical_json(entry).encode("utf-8")).hexdigest()
 
 
+def ledger_lock_path(ledger_path: Path) -> Path:
+    """The ONE public lock primitive for a given ledger (ADR-034 §4).
+
+    Byte-identical to ``append_receipt_internals.idempotency._lock_file_for``'s
+    private path — the hot receipt-append path already locks here today via
+    that private helper, so the live lock file for ``state/t0_receipts.ndjson``
+    is unchanged and no migration is needed. This is now the single shared
+    source of truth: ``append_receipt_payload`` (via ``idempotency``, itself
+    unmodified by this ADR), ``append_chained_entry``, ``append_epoch_marker``,
+    and ``chain_origin_anchor.seal_and_commit_origin`` all take this SAME lock
+    around their critical sections — not independent locks on different paths
+    (the original ADR-034 draft's bug, corrected before implementation).
+    """
+    return ledger_path.parent / "append_receipt.lock"
+
+
+@contextmanager
+def _ledger_locked(ledger_path: Path) -> Iterator[None]:
+    """Hold ``ledger_lock_path(ledger_path)``'s flock for the wrapped block.
+
+    Not re-entrant: ``fcntl.flock`` excludes by open-file-description, not by
+    process, so a second ``open()`` + ``flock()`` of the same path from the
+    same process would block on itself. A caller that already holds this lock
+    (``seal_and_commit_origin``) must call the ``_locked`` suffixed internals
+    below directly instead of re-entering this context manager (ADR-034 §4).
+    """
+    lock_path = ledger_lock_path(ledger_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_handle:
+        fcntl.flock(lock_handle.fileno(), fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lock_handle.fileno(), fcntl.LOCK_UN)
+
+
 def append_chained_entry(
     path: Path,
     entry: dict,
@@ -65,6 +103,27 @@ def append_chained_entry(
     - 'correction': must include 'corrects_hash' field
     - 'redaction': must include 'redacts_hash' field; body should be opaque
     - 'tombstone': must include 'tombstones_hash' field
+
+    Holds ``ledger_lock_path(path)``'s flock around the read-tail + write
+    critical section (ADR-034 §4) — previously unlocked, which let a
+    concurrent writer race the tail-hash read.
+    """
+    with _ledger_locked(path):
+        return _append_chained_entry_locked(path, entry, event_type=event_type)
+
+
+def _append_chained_entry_locked(
+    path: Path,
+    entry: dict,
+    *,
+    event_type: str | None = None,
+) -> str:
+    """Body of ``append_chained_entry``, minus lock acquisition.
+
+    Caller MUST already hold ``ledger_lock_path(path)``'s flock. Exists so
+    ``seal_and_commit_origin`` (which holds the lock itself across a larger
+    critical section) can append without a second, self-deadlocking
+    ``flock()`` call on the same file from the same process.
     """
     if event_type == "backfill":
         prev_hash = GENESIS_HASH
@@ -133,6 +192,21 @@ def append_epoch_marker(path: Path, epoch: int) -> str:
 
     Append-only: never rewrites a historical line (ADR-005 preserved). Returns
     the marker entry's hash so the next appended receipt links to it.
+
+    Holds ``ledger_lock_path(path)``'s flock around the append (ADR-034 §4) —
+    previously unlocked.
+    """
+    with _ledger_locked(path):
+        return _append_epoch_marker_locked(path, epoch)
+
+
+def _append_epoch_marker_locked(path: Path, epoch: int) -> str:
+    """Body of ``append_epoch_marker``, minus lock acquisition.
+
+    Caller MUST already hold ``ledger_lock_path(path)``'s flock. Exists so
+    ``seal_and_commit_origin`` can open a new epoch inside its own
+    already-held critical section without a second, self-deadlocking
+    ``flock()`` call (ADR-034 §4).
     """
     marker = {
         "type": EPOCH_MARKER_TYPE,

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -459,6 +459,104 @@ def test_t20_rollback_to_earlier_epoch_with_later_anchor_is_broken(git_repo, tmp
     assert any("rollback" in str(v.get("note", "")) or "no longer observes" in str(v.get("note", "")) for v in violations)
 
 
+def test_t23_markerless_chaining_no_anchor_anywhere_is_broken(git_repo, tmp_path):
+    """ADR-034 fix-r2 Finding 1: a marker-less GENESIS chain (chained from
+    line 1 via prev_hash == GENESIS, no chain_epoch_start marker at all)
+    that has NEVER been sealed — zero anchors anywhere for its identity —
+    must fail closed as `broken`, not pass through as the legitimate
+    "verified" marker-less-chain case. _observed_epochs(path) is [] here
+    (no markers), so the per-epoch loop never runs; only a reverse "no
+    anchor anywhere for this chaining-active identity" check catches it."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 1})  # marker-less GENESIS chain, never sealed
+
+    ok, violations, status, prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert prov is not None and prov.resolved is True
+    assert any("no git anchor anywhere" in str(v.get("note", "")) for v in violations)
+
+    # No over-fire: sealing this SAME identity properly (real marker + real
+    # anchor) must still verify — the new check must not catch a
+    # legitimately-anchored chain.
+    ledger.write_text("")
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    ok2, _v2, status2, _p2 = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok2 is True and status2 == "verified-segmented"
+
+
+def test_t24_force_new_epoch_crash_before_commit_resume_backfills_prior_closure(
+    git_repo, tmp_path, monkeypatch
+):
+    """ADR-034 fix-r2 Finding 2: force_new_epoch appends the new epoch's
+    marker under the lock (durable — max_epoch advances) and computes epoch
+    1's closure, but crashes before `_commit_and_push_anchor` ever runs — no
+    commit, no push, nothing lands anywhere except the marker on the ledger.
+    On retry (a plain re-seal, not re-passing force_new_epoch), epoch_state
+    now reports the new epoch as already-current: opened_new_epoch=False,
+    prior_epoch=None. A naive "only close what I just opened" check would
+    never emit epoch 1's closure again — it would stay permanently
+    un-anchored and verify_chain permanently `broken` on "no closure record
+    for a CLOSED epoch"."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": "a"})
+    result1 = _seal(git_repo, ledger)
+    assert result1.action == "sealed" and result1.epoch == 1
+
+    real_commit = coa._commit_and_push_anchor
+
+    def crash_before_commit(*_args, **_kwargs):
+        raise RuntimeError("simulated crash before commit/push")
+
+    monkeypatch.setattr(coa, "_commit_and_push_anchor", crash_before_commit)
+    with pytest.raises(RuntimeError, match="simulated crash before commit/push"):
+        seal_and_commit_origin(
+            ledger,
+            git_repo,
+            project_id="vnx-dev",
+            project_data_dir=data_dir,
+            branch="main",
+            force_new_epoch=True,
+            branch_protection_confirmed=True,
+        )
+
+    # Precondition: the epoch-2 marker landed (inside the lock, durable on
+    # disk before the crash), but nothing was ever committed for it, and
+    # epoch 1's closure never reached origin either.
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    assert coa.epoch_state(ledger) == (2, True)
+    assert coa._read_local_head_anchor(git_repo, coa.anchor_key(identity, 2)) is None
+    assert coa._read_remote_base_anchor(git_repo, "main", coa.closure_key(identity, 1)) is None
+
+    ok_broken, _v, status_broken, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok_broken is False and status_broken == "broken"
+
+    monkeypatch.setattr(coa, "_commit_and_push_anchor", real_commit)
+    result2 = _seal(git_repo, ledger)  # plain retry — does NOT re-pass force_new_epoch
+    assert result2.action == "sealed"
+    assert result2.epoch == 2
+
+    closure1, prov = read_git_anchor(git_repo, identity, 1, kind="close")
+    assert prov.resolved is True
+    assert closure1 is not None and closure1 != "corrupt"
+
+    ok, _v2, status, _p2 = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is True and status == "verified-segmented"
+
+
 # ---------------------------------------------------------------------------
 # T6/T7: check_anchor_immutability pure diff logic (write-side rule; the
 # GitHub Actions wiring that invokes this in CI is PR-2 scope)

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -390,6 +390,75 @@ def test_t18_reverse_scan_finds_epoch2_only_anchor_no_epoch1(git_repo, tmp_path)
     assert status != "unchained"
 
 
+def test_t19_chained_markerless_rechain_with_existing_anchor_is_broken(git_repo, tmp_path):
+    """ADR-034 fix-r1 Finding 1+2 (a): stripping every chain_epoch_start
+    marker and re-chaining from GENESIS makes _observed_epochs(path) == [],
+    so the per-epoch loop never runs. Only the reverse identity-scan — which
+    must run unconditionally in the chained path, not only when base_status
+    == "unchained" — catches that this identity has a committed anchor the
+    ledger no longer shows any epoch for."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    baseline_ok, _v, baseline_status, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert baseline_ok and baseline_status == "verified-segmented"
+
+    # Attack: strip the ledger entirely and re-chain from GENESIS with no
+    # chain_epoch_start marker at all — the base walk sees a self-consistent
+    # marker-less "verified" chain (saw_chain True via base_status != "unchained").
+    ledger.write_text("")
+    append_chained_entry(ledger, {"seq": "re-chained-1"})
+
+    ok, violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert status != "unchained"
+    assert any("markerless" in str(v.get("note", "")) or "no longer observes" in str(v.get("note", "")) for v in violations)
+
+
+def test_t20_rollback_to_earlier_epoch_with_later_anchor_is_broken(git_repo, tmp_path):
+    """ADR-034 fix-r1 Finding 1+2 (b): rolling the ledger back to only epoch
+    1's original content (stripping epoch 2) while origin still holds the
+    epoch-2 open anchor + epoch-1 closure record. Epoch 1's own fingerprint
+    still matches and it's the LAST epoch the (rolled-back) ledger observes —
+    the bug this test guards against is treating that as "the open latest
+    epoch, no closure required" instead of checking it against the true
+    highest ANCHORED epoch (2)."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": "a"})
+    append_chained_entry(ledger, {"seq": "b"})
+    result1 = _seal(git_repo, ledger)
+    assert result1.action == "sealed" and result1.epoch == 1
+
+    original_epoch1_content = ledger.read_text()
+
+    result2 = _seal(git_repo, ledger, force_new_epoch=True)
+    assert result2.action == "sealed" and result2.epoch == 2 and result2.closed_epoch == 1
+
+    baseline_ok, _v, baseline_status, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert baseline_ok and baseline_status == "verified-segmented"
+
+    # Attack: roll the local ledger back to JUST epoch 1's original content.
+    ledger.write_text(original_epoch1_content)
+
+    ok, violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert any("rollback" in str(v.get("note", "")) or "no longer observes" in str(v.get("note", "")) for v in violations)
+
+
 # ---------------------------------------------------------------------------
 # T6/T7: check_anchor_immutability pure diff logic (write-side rule; the
 # GitHub Actions wiring that invokes this in CI is PR-2 scope)
@@ -502,6 +571,62 @@ def test_t10_partial_seal_is_broken_then_idempotent_retry(git_repo, tmp_path, mo
         ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
     )
     assert ok2 is True and status2 == "verified-segmented"
+
+
+def test_t21_partial_seal_push_failed_after_commit_resumes_not_noop(git_repo, tmp_path, monkeypatch):
+    """ADR-034 fix-r1 Finding 3: commit succeeds locally (checkout + add +
+    commit all real), then `git push` itself raises — HEAD stays parked on
+    the seal branch WITH the anchor commit. A naive retry that only checks
+    local HEAD would find the anchor already there and wrongly report
+    "noop", even though origin never received it and verify_chain would stay
+    broken forever. The retry must check origin, find nothing, and resume by
+    re-pushing the same local branch instead."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})  # marker-less genesis chain -> forces epoch-1 open
+
+    real_git_run_checked = coa._git_run_checked
+
+    def push_fails(project_root, *args, **kwargs):
+        if args and args[0] == "push":
+            raise RuntimeError("simulated push failure (network unreachable)")
+        return real_git_run_checked(project_root, *args, **kwargs)
+
+    monkeypatch.setattr(coa, "_git_run_checked", push_fails)
+    with pytest.raises(RuntimeError, match="simulated push failure"):
+        seal_and_commit_origin(
+            ledger,
+            git_repo,
+            project_id="vnx-dev",
+            project_data_dir=data_dir,
+            branch="main",
+            branch_protection_confirmed=True,
+        )
+
+    # Confirm the bug precondition: HEAD is on the seal branch, anchor
+    # committed locally, nothing on origin at all.
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    key = coa.anchor_key(identity, 1)
+    assert coa._read_local_head_anchor(git_repo, key) is not None
+    assert coa._read_remote_base_anchor(git_repo, "main", key) is None
+
+    monkeypatch.setattr(coa, "_git_run_checked", real_git_run_checked)
+    result = seal_and_commit_origin(
+        ledger,
+        git_repo,
+        project_id="vnx-dev",
+        project_data_dir=data_dir,
+        branch="main",
+        branch_protection_confirmed=True,
+    )
+    assert result.action != "noop"
+    assert result.branch_name is not None
+
+    # The resumed push actually landed the commit on origin's seal branch —
+    # no duplicate record was appended (still exactly one "open" record for
+    # this key).
+    rec, prov = read_git_anchor(git_repo, identity, 1, ref=f"origin/{result.branch_name}")
+    assert prov.resolved is True
+    assert rec is not None and rec != "corrupt"
 
 
 def test_t11_double_run_is_noop_new_epoch_produces_new_record(git_repo, tmp_path):
@@ -647,3 +772,52 @@ def test_read_git_anchors_for_identity_scopes_by_key_prefix(git_repo, tmp_path):
     assert prov.resolved is True
     assert len(anchors) == 1
     assert anchors[0].ledger_identity == identity
+
+
+def test_t22_local_branch_named_like_remote_ref_does_not_shadow_it(git_repo, tmp_path):
+    """ADR-034 fix-r1 Finding 5: git allows slashes in branch names, so a
+    local attacker can create a branch literally named `origin/main`. Per
+    gitrevisions(7)'s disambiguation order, an unqualified `git rev-parse
+    origin/main` resolves refs/heads/origin/main (the local shadow) BEFORE
+    refs/remotes/origin/main (the real remote-tracking ref) — a
+    committed-but-never-pushed forged anchor would otherwise get trusted
+    over the genuine remote content. The read path must qualify the ref
+    explicitly (refs/remotes/origin/main) and never fall back to the
+    ambiguous short form."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    real_rec, real_prov = read_git_anchor(git_repo, identity, 1)
+    assert real_prov.resolved is True
+    assert real_rec is not None and real_rec != "corrupt"
+
+    # Attacker: create a LOCAL branch literally named "origin/main", branched
+    # from the current (real) main, then commit FORGED anchor content on it
+    # -- never pushed anywhere. This branch is never merged/pushed; it just
+    # sits locally as a same-named shadow of the remote-tracking ref.
+    fake_fp = coa.OriginFingerprint(
+        epoch=1, origin_type="chain_epoch_start", origin_hash="f" * 64, origin_line_number=1, entries_before_origin=0
+    )
+    forged_record = coa._origin_record(identity, fake_fp, sealed_at="2026-01-01T00:00:00Z")
+    _run("git", "checkout", "-b", "origin/main", cwd=git_repo)
+    anchor_path = git_repo / coa.ANCHOR_REL_PATH
+    anchor_path.write_text(json.dumps(forged_record, sort_keys=True, separators=(",", ":")) + "\n")
+    _run("git", "add", str(coa.ANCHOR_REL_PATH), cwd=git_repo)
+    _run("git", "commit", "-m", "forged shadow branch content", cwd=git_repo)
+    _run("git", "checkout", "main", cwd=git_repo)
+
+    shadowed_rec, shadowed_prov = read_git_anchor(git_repo, identity, 1)
+    assert shadowed_prov.resolved is True  # the real remote-tracking ref still resolves
+    assert shadowed_rec is not None and shadowed_rec != "corrupt"
+    assert shadowed_rec.origin_hash == real_rec.origin_hash
+    assert shadowed_rec.origin_hash != "f" * 64  # NOT the forged shadow-branch content
+
+    # verify_chain must also read the genuine content, not the local shadow.
+    ok, _v, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is True and status == "verified-segmented"

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -1,0 +1,649 @@
+"""Tests for ADR-034 external chain-origin anchor (scripts/lib/chain_origin_anchor.py).
+
+Maps to docs/governance/decisions/ADR-034-external-chain-origin-anchor.md §7's
+required test list T1-T18 (T19 is not implemented here: the ADR itself frames
+it as "demonstrates the partial backstop, not a fix" — already covered by
+T13's mechanism — and needs no new CI wiring, which is PR-2 scope anyway).
+T6/T7 exercise check_anchor_immutability's pure diff LOGIC directly; the
+.github/workflows/ wiring that will invoke it in CI is explicitly PR-2 scope
+and is not created by this PR.
+
+Fixtures use a real local git repo with a local bare "origin" remote so
+fetch/show/push against origin/main work for real, without any network or
+GitHub access. `gh` (PR creation) is monkeypatched out — seal_and_commit_origin
+must never depend on `gh` being installed/authenticated for its core (file +
+commit + push) contract to be testable.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import chain_origin_anchor as coa  # noqa: E402
+from chain_origin_anchor import (  # noqa: E402
+    BranchProtectionUnconfirmedError,
+    anchor_key,
+    check_anchor_immutability,
+    closure_key,
+    compute_epoch_fingerprint,
+    ledger_identity,
+    read_git_anchor,
+    read_git_anchors_for_identity,
+    seal_and_commit_origin,
+    verify_chain,
+)
+from ndjson_hash_chain import (  # noqa: E402
+    GENESIS_HASH,
+    _ledger_locked,
+    append_chained_entry,
+    append_epoch_marker,
+    compute_entry_hash,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _run(*args: str, cwd: Path) -> str:
+    result = subprocess.run(list(args), cwd=str(cwd), capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git {args} failed in {cwd}: {result.stderr}")
+    return result.stdout
+
+
+@pytest.fixture
+def git_repo(tmp_path, monkeypatch):
+    """A working-tree repo with a local `origin` remote (a bare repo) so
+    fetch/show/push against origin/main work for real, with no network
+    access. `ensure_pr` is stubbed so seal_and_commit_origin never shells out
+    to `gh` (which has nothing real to talk to here)."""
+    bare = tmp_path / "origin.git"
+    _run("git", "init", "--bare", "-b", "main", str(bare), cwd=tmp_path)
+
+    work = tmp_path / "work"
+    _run("git", "init", "-b", "main", str(work), cwd=tmp_path)
+    _run("git", "config", "user.email", "test@example.com", cwd=work)
+    _run("git", "config", "user.name", "Test", cwd=work)
+    (work / "README.md").write_text("seed\n")
+    _run("git", "add", "README.md", cwd=work)
+    _run("git", "commit", "-m", "seed", cwd=work)
+    _run("git", "remote", "add", "origin", str(bare), cwd=work)
+    _run("git", "push", "-u", "origin", "main", cwd=work)
+
+    monkeypatch.setattr(
+        coa, "ensure_pr", lambda *a, **kw: {"pr_number": None, "created": False, "reason": "test-stub"}
+    )
+    return work
+
+
+def _merge_branch_to_main(work: Path, branch: str) -> None:
+    """Simulate a PR merge: merge `branch` into local main and push to origin."""
+    _run("git", "checkout", "main", cwd=work)
+    _run("git", "merge", "--no-ff", "-m", f"merge {branch}", branch, cwd=work)
+    _run("git", "push", "origin", "main", cwd=work)
+
+
+def _seal(work, ledger, *, project_id="vnx-dev", branch="main", force_new_epoch=False, confirmed=True):
+    data_dir = ledger.parent.parent
+    result = seal_and_commit_origin(
+        ledger,
+        work,
+        project_id=project_id,
+        project_data_dir=data_dir,
+        branch=branch,
+        force_new_epoch=force_new_epoch,
+        branch_protection_confirmed=confirmed,
+    )
+    if result.action == "sealed":
+        _merge_branch_to_main(work, result.branch_name)
+    return result
+
+
+def _write_raw_anchor_to_main(work: Path, records: list[dict]) -> None:
+    """Write anchor records DIRECTLY (bypassing seal_and_commit_origin) — used
+    to construct adversarial/forged states verify_chain must reject."""
+    anchor_path = work / coa.ANCHOR_REL_PATH
+    anchor_path.parent.mkdir(parents=True, exist_ok=True)
+    with anchor_path.open("a", encoding="utf-8") as f:
+        for r in records:
+            f.write(json.dumps(r, sort_keys=True, separators=(",", ":")) + "\n")
+    _run("git", "add", str(coa.ANCHOR_REL_PATH), cwd=work)
+    _run("git", "commit", "-m", "test: seed anchor", cwd=work)
+    _run("git", "push", "origin", "main", cwd=work)
+
+
+def _ledger_and_data_dir(tmp_path: Path, project_id: str = "vnx-dev") -> tuple[Path, Path]:
+    data_dir = tmp_path / ".vnx-data" / project_id
+    ledger = data_dir / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    return ledger, data_dir
+
+
+# ---------------------------------------------------------------------------
+# Key/identity primitives
+# ---------------------------------------------------------------------------
+
+
+def test_anchor_key_and_closure_key_format():
+    identity = "vnx-dev:state/t0_receipts.ndjson"
+    assert anchor_key(identity, 1) == "vnx-dev:state/t0_receipts.ndjson#1"
+    assert closure_key(identity, 1) == "vnx-dev:state/t0_receipts.ndjson#1:close"
+    assert closure_key(identity, 1) == f"{anchor_key(identity, 1)}:close"
+
+
+def test_ledger_identity_is_relative_not_absolute(tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    assert identity == "vnx-dev:state/t0_receipts.ndjson"
+    assert str(data_dir) not in identity
+    assert str(tmp_path) not in identity
+
+
+def test_compute_epoch_closure_zero_entries_degenerates_to_marker(tmp_path):
+    """force_new_epoch closing an epoch with nothing appended since it opened
+    (ADR §1's "shrink the residual window" pattern) must produce a
+    well-defined closure, not raise — the closure degenerates to the epoch's
+    own opening marker."""
+    ledger, _data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)  # line 1
+    append_epoch_marker(ledger, 2)  # line 2, immediately closes epoch 1 with nothing inside
+
+    fp = compute_epoch_fingerprint(ledger, 1)
+    closure = coa.compute_epoch_closure(ledger, 1, next_epoch_marker_line=2)
+    assert closure.entries_in_epoch == 0
+    assert closure.closure_hash == fp.origin_hash
+    assert closure.closure_line_number == fp.origin_line_number == 1
+
+
+def test_compute_epoch_fingerprint_and_closure(tmp_path):
+    ledger, _data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    append_chained_entry(ledger, {"seq": 2})
+    append_epoch_marker(ledger, 2)
+
+    fp = compute_epoch_fingerprint(ledger, 1)
+    assert fp.epoch == 1
+    assert fp.origin_line_number == 1
+    assert fp.entries_before_origin == 0
+
+    closure = coa.compute_epoch_closure(ledger, 1, next_epoch_marker_line=4)
+    assert closure.closure_line_number == 3
+    assert closure.entries_in_epoch == 2
+
+
+# ---------------------------------------------------------------------------
+# T1-T5, T8, T13, T15, T17, T18: verify_chain's anchor-aware contract
+# ---------------------------------------------------------------------------
+
+
+def test_t1_chaining_no_anchor_anywhere_is_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+
+    ok, violations, status, prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert prov is not None and prov.resolved is True
+
+
+def test_t2_working_tree_anchor_edit_is_ignored(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    baseline = verify_chain(ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir)
+    assert baseline[2] == "verified-segmented"
+
+    anchor_path = git_repo / coa.ANCHOR_REL_PATH
+    anchor_path.write_text("garbage not json\n")
+    edited = verify_chain(ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir)
+    assert edited[:3] == baseline[:3]
+
+    anchor_path.unlink()
+    deleted = verify_chain(ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir)
+    assert deleted[:3] == baseline[:3]
+
+
+def test_t3_no_project_root_on_chaining_ledger_is_broken(tmp_path):
+    ledger, _data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+
+    ok, violations, status, prov = verify_chain(ledger)
+    assert ok is False
+    assert status == "broken"
+    assert prov is None
+
+
+def test_t4_unchained_no_anchor_stays_unchained(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    with ledger.open("a") as f:
+        f.write(json.dumps({"seq": 0}) + "\n")
+
+    ok, violations, status, prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is True
+    assert status == "unchained"
+    assert prov is not None and prov.resolved is True
+
+
+def test_t5_duplicate_anchor_records_is_corrupt_then_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    fp = compute_epoch_fingerprint(ledger, 1)
+    record = coa._origin_record(identity, fp, sealed_at="2026-01-01T00:00:00Z")
+    _write_raw_anchor_to_main(git_repo, [record, record])  # forged duplicate
+
+    rec, _prov = read_git_anchor(git_repo, identity, 1)
+    assert rec == "corrupt"
+
+    ok, violations, status, prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+
+
+def test_t8_core_bypass_prefix_strip_and_rechain_is_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    append_chained_entry(ledger, {"seq": 2})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    baseline_ok, _v, baseline_status, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert baseline_ok and baseline_status == "verified-segmented"
+
+    # Attack: strip the ledger entirely, insert a fresh epoch-1 marker (same
+    # epoch number as the anchored one, but a DIFFERENT line/hash) and
+    # re-chain the remainder — the #1085/#1086/#1171 bypass.
+    ledger.write_text("")
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": "re-chained-1"})
+    append_chained_entry(ledger, {"seq": "re-chained-2"})
+
+    ok, violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert any("fingerprint mismatch" in str(v.get("note", "")) for v in violations)
+
+
+def test_t13_reverse_direction_ledger_deleted_anchor_remains_is_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+
+    ledger.unlink()
+    assert not ledger.exists()
+
+    ok, violations, status, prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert status != "unchained"
+    assert prov is not None and prov.resolved is True
+
+
+def test_t15_unanchored_new_epoch_is_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": 1})
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed" and result.epoch == 1
+
+    # Bypass: legitimately open + chain epoch 2, but never anchor it.
+    append_epoch_marker(ledger, 2)
+    append_chained_entry(ledger, {"seq": 2})
+
+    ok, violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert any(v.get("epoch") == 2 for v in violations)
+
+
+def test_t17_intra_epoch_rewrite_between_markers_is_broken(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_epoch_marker(ledger, 1)
+    append_chained_entry(ledger, {"seq": "a"})
+    append_chained_entry(ledger, {"seq": "b"})
+    result1 = _seal(git_repo, ledger)
+    assert result1.action == "sealed" and result1.epoch == 1
+
+    result2 = _seal(git_repo, ledger, force_new_epoch=True)
+    assert result2.action == "sealed" and result2.epoch == 2 and result2.closed_epoch == 1
+
+    baseline_ok, _v, baseline_status, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert baseline_ok and baseline_status == "verified-segmented"
+
+    # Attack: rewrite the two entries strictly BETWEEN epoch 1's marker and
+    # epoch 2's marker, preserving line count, recomputing prev_hash for the
+    # rewritten suffix, leaving BOTH markers themselves untouched. The base
+    # walk must see this as internally consistent — only the anchored
+    # closure fingerprint (computed on the ORIGINAL content) can catch it.
+    lines = ledger.read_text().splitlines()
+    marker_entry = json.loads(lines[0])
+    marker_hash = compute_entry_hash(marker_entry)
+    rewritten_a = {"seq": "REWRITTEN-a", "prev_hash": marker_hash}
+    rewritten_b = {"seq": "REWRITTEN-b", "prev_hash": compute_entry_hash(rewritten_a)}
+    lines[1] = json.dumps(rewritten_a)
+    lines[2] = json.dumps(rewritten_b)
+    ledger.write_text("\n".join(lines) + "\n")
+
+    ok, violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert any(v.get("epoch") == 1 and "closure" in str(v.get("note", "")) for v in violations)
+
+
+def test_t18_reverse_scan_finds_epoch2_only_anchor_no_epoch1(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    fake_fp = coa.OriginFingerprint(
+        epoch=2, origin_type="chain_epoch_start", origin_hash="f" * 64, origin_line_number=5, entries_before_origin=4
+    )
+    record = coa._origin_record(identity, fake_fp, sealed_at="2026-01-01T00:00:00Z")
+    _write_raw_anchor_to_main(git_repo, [record])
+
+    assert not ledger.exists()
+    anchors, prov = read_git_anchors_for_identity(git_repo, identity)
+    assert prov.resolved is True
+    assert len(anchors) == 1 and anchors[0].epoch == 2
+
+    ok, violations, status, _prov2 = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False
+    assert status == "broken"
+    assert status != "unchained"
+
+
+# ---------------------------------------------------------------------------
+# T6/T7: check_anchor_immutability pure diff logic (write-side rule; the
+# GitHub Actions wiring that invokes this in CI is PR-2 scope)
+# ---------------------------------------------------------------------------
+
+
+def test_t6_immutability_check_rejects_modified_existing_key():
+    base_record = {"key": "id#1", "ledger_identity": "id", "epoch": 1, "record_type": "open", "origin_hash": "aaa"}
+    head_record = {**base_record, "origin_hash": "FORGED"}
+    base = json.dumps(base_record, sort_keys=True) + "\n"
+    head = json.dumps(head_record, sort_keys=True) + "\n"
+
+    violations = check_anchor_immutability(base, head)
+    assert violations == [{"key": "id#1", "violation": "modified"}]
+
+
+def test_t6b_immutability_check_rejects_removed_key():
+    base_record = {"key": "id#1", "ledger_identity": "id", "epoch": 1, "record_type": "open"}
+    base = json.dumps(base_record, sort_keys=True) + "\n"
+
+    violations = check_anchor_immutability(base, "")
+    assert violations == [{"key": "id#1", "violation": "removed"}]
+
+
+def test_t7_immutability_check_accepts_new_key():
+    base_record = {"key": "id#1", "ledger_identity": "id", "epoch": 1, "record_type": "open"}
+    new_record = {"key": "id#2", "ledger_identity": "id", "epoch": 2, "record_type": "open"}
+    base = json.dumps(base_record, sort_keys=True) + "\n"
+    head = base + json.dumps(new_record, sort_keys=True) + "\n"
+
+    assert check_anchor_immutability(base, head) == []
+
+
+# ---------------------------------------------------------------------------
+# T9-T11, T16: seal_and_commit_origin
+# ---------------------------------------------------------------------------
+
+
+def test_t9_concurrent_append_blocks_while_lock_held(tmp_path):
+    """T9: a concurrent append while seal_and_commit_origin holds
+    ledger_lock_path's flock serializes rather than interleaving — same lock
+    file _ledger_locked and append_chained_entry both take."""
+    ledger, _data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})
+
+    lock_acquired = threading.Event()
+    release_lock = threading.Event()
+    order: list[str] = []
+
+    def hold_lock():
+        with _ledger_locked(ledger):
+            order.append("lock-acquired")
+            lock_acquired.set()
+            release_lock.wait(timeout=5)
+        order.append("lock-released")
+
+    holder = threading.Thread(target=hold_lock)
+    holder.start()
+    assert lock_acquired.wait(timeout=5)
+
+    def do_append():
+        append_chained_entry(ledger, {"seq": 1})
+        order.append("append-done")
+
+    appender = threading.Thread(target=do_append)
+    appender.start()
+    time.sleep(0.3)
+    assert "append-done" not in order  # still blocked behind the held lock
+
+    release_lock.set()
+    holder.join(timeout=5)
+    appender.join(timeout=5)
+    assert "append-done" in order
+    assert len(ledger.read_text().splitlines()) == 2
+
+
+def test_t10_partial_seal_is_broken_then_idempotent_retry(git_repo, tmp_path, monkeypatch):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})  # marker-less genesis chain -> forces epoch-1 open
+
+    real_commit = coa._commit_and_push_anchor
+
+    def failing_commit(*_args, **_kwargs):
+        raise RuntimeError("simulated push failure")
+
+    monkeypatch.setattr(coa, "_commit_and_push_anchor", failing_commit)
+    with pytest.raises(RuntimeError, match="simulated push failure"):
+        seal_and_commit_origin(
+            ledger,
+            git_repo,
+            project_id="vnx-dev",
+            project_data_dir=data_dir,
+            branch="main",
+            branch_protection_confirmed=True,
+        )
+
+    # Marker WAS appended (inside the lock, before the raise); no anchor was
+    # ever pushed -> verify_chain must report broken, not healthy.
+    ok, _v, status, _p = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is False and status == "broken"
+
+    monkeypatch.setattr(coa, "_commit_and_push_anchor", real_commit)
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+    assert result.epoch == 1
+
+    ok2, _v2, status2, _p2 = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok2 is True and status2 == "verified-segmented"
+
+
+def test_t11_double_run_is_noop_new_epoch_produces_new_record(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})
+
+    first = _seal(git_repo, ledger)
+    assert first.action == "sealed" and first.epoch == 1
+
+    second = _seal(git_repo, ledger)
+    assert second.action == "noop"
+
+    third = _seal(git_repo, ledger, force_new_epoch=True)
+    assert third.action == "sealed"
+    assert third.epoch == 2
+    assert third.closed_epoch == 1
+
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    rec1, _p1 = read_git_anchor(git_repo, identity, 1)
+    rec2, _p2 = read_git_anchor(git_repo, identity, 2)
+    closure1, _p3 = read_git_anchor(git_repo, identity, 1, kind="close")
+    assert rec1 is not None and rec1 != "corrupt"
+    assert rec2 is not None and rec2 != "corrupt"
+    assert closure1 is not None and closure1 != "corrupt"
+
+
+def test_t16_seal_refuses_without_branch_protection_confirmed(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})
+
+    log_before = _run("git", "log", "--oneline", "--all", cwd=git_repo)
+    anchor_path = git_repo / coa.ANCHOR_REL_PATH
+    assert not anchor_path.exists()
+
+    with pytest.raises(BranchProtectionUnconfirmedError):
+        seal_and_commit_origin(
+            ledger,
+            git_repo,
+            project_id="vnx-dev",
+            project_data_dir=data_dir,
+            branch="main",
+            branch_protection_confirmed=False,
+        )
+
+    assert not anchor_path.exists()
+    log_after = _run("git", "log", "--oneline", "--all", cwd=git_repo)
+    assert log_before == log_after
+    # Ledger itself is also untouched — no marker appended before the refusal.
+    assert len(ledger.read_text().splitlines()) == 1
+
+
+# ---------------------------------------------------------------------------
+# T12: existing behavior / read-path unchanged for callers that don't opt in
+# ---------------------------------------------------------------------------
+
+
+def test_t12_old_verify_chain_signature_and_behavior_unchanged(tmp_path):
+    """The EXISTING ndjson_hash_chain.verify_chain (used by all five
+    pre-ADR-034 call sites) still returns a plain 3-tuple and is byte-for-byte
+    unaffected by this module existing — ADR-034 §6 step 1: "additive,
+    verify_chain's read path unchanged"."""
+    from ndjson_hash_chain import verify_chain as old_verify_chain
+
+    p = tmp_path / "plain.ndjson"
+    for i in range(3):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i}) + "\n")
+
+    result = old_verify_chain(p)
+    assert len(result) == 3
+    ok, violations, status = result
+    assert ok is True and violations == [] and status == "unchained"
+
+
+def test_t12_new_verify_chain_without_identity_on_unchained_ledger_is_unaffected(tmp_path):
+    """Calling the NEW anchor-aware verify_chain with no project_root/id/
+    data_dir on a genuinely unchained ledger is the additive no-op path —
+    same result as the old function, plus a None provenance."""
+    p = tmp_path / "plain.ndjson"
+    for i in range(3):
+        with p.open("a") as f:
+            f.write(json.dumps({"seq": i}) + "\n")
+
+    ok, violations, status, prov = verify_chain(p)
+    assert ok is True and violations == [] and status == "unchained"
+    assert prov is None
+
+
+# ---------------------------------------------------------------------------
+# read_git_anchor / read_git_anchors_for_identity — direct unit coverage
+# ---------------------------------------------------------------------------
+
+
+def test_read_git_anchor_none_when_never_sealed(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+
+    rec, prov = read_git_anchor(git_repo, identity, 1)
+    assert rec is None
+    assert prov.resolved is True  # ref resolves fine; the anchor file just doesn't exist yet
+
+
+def test_read_git_anchor_fails_closed_when_ref_unresolvable(tmp_path):
+    not_a_repo = tmp_path / "not-a-repo"
+    not_a_repo.mkdir()
+
+    rec, prov = read_git_anchor(not_a_repo, "vnx-dev:state/t0_receipts.ndjson", 1)
+    assert rec is None
+    assert prov.resolved is False
+    assert prov.error is not None
+
+
+def test_anchor_provenance_carries_commit_sha_and_remote_url(git_repo, tmp_path):
+    """ADR §2 off-host cross-check: the resolved anchor commit SHA + remote
+    URL are always populated when the ref resolves, even with no record."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+
+    _rec, prov = read_git_anchor(git_repo, identity, 1)
+    assert prov.resolved is True
+    assert prov.anchor_commit_sha is not None and len(prov.anchor_commit_sha) == 40
+    assert prov.remote_url is not None
+
+
+def test_read_git_anchors_for_identity_scopes_by_key_prefix(git_repo, tmp_path):
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    other_identity = "vnx-dev:state/other_ledger.ndjson"
+
+    fp1 = coa.OriginFingerprint(
+        epoch=1, origin_type="chain_epoch_start", origin_hash="a" * 64, origin_line_number=1, entries_before_origin=0
+    )
+    fp_other = coa.OriginFingerprint(
+        epoch=1, origin_type="chain_epoch_start", origin_hash="b" * 64, origin_line_number=1, entries_before_origin=0
+    )
+    records = [
+        coa._origin_record(identity, fp1, sealed_at="2026-01-01T00:00:00Z"),
+        coa._origin_record(other_identity, fp_other, sealed_at="2026-01-01T00:00:00Z"),
+    ]
+    _write_raw_anchor_to_main(git_repo, records)
+
+    anchors, prov = read_git_anchors_for_identity(git_repo, identity)
+    assert prov.resolved is True
+    assert len(anchors) == 1
+    assert anchors[0].ledger_identity == identity

--- a/tests/test_ndjson_hash_chain.py
+++ b/tests/test_ndjson_hash_chain.py
@@ -384,3 +384,63 @@ def test_epoch_state_reports_max_epoch_and_active(tmp_path):
     append_epoch_marker(p, 1)
     max_epoch, active = epoch_state(p)
     assert max_epoch == 1 and active is True   # last entry is the marker -> chaining
+
+
+# ---------------------------------------------------------------------------
+# ADR-034: ledger_lock_path (T14) + lock adoption in append_chained_entry /
+# append_epoch_marker (the write-side primitives seal_and_commit_origin
+# shares — scripts/lib/chain_origin_anchor.py).
+# ---------------------------------------------------------------------------
+from ndjson_hash_chain import ledger_lock_path  # noqa: E402
+from append_receipt_internals.idempotency import _lock_file_for  # noqa: E402
+
+
+def test_t14_ledger_lock_path_matches_hot_path_lock_file(tmp_path):
+    """T14: seal_and_commit_origin and a concurrent append_receipt_payload call
+    target the SAME lock file. Assert identical resolved Path, not just "both
+    take some lock" — proves the original wrong-lock-target bug (ADR-034 §4,
+    R2/C2) can't silently regress. The hot path (append_receipt_internals/
+    idempotency.py) is NOT modified by this ADR; this only verifies the two
+    already agree."""
+    ledger_path = tmp_path / "state" / "t0_receipts.ndjson"
+    assert ledger_lock_path(ledger_path) == _lock_file_for(ledger_path)
+    assert ledger_lock_path(ledger_path).resolve() == _lock_file_for(ledger_path).resolve()
+
+
+def test_ledger_lock_path_is_append_receipt_lock_sibling(tmp_path):
+    p = tmp_path / "state" / "t0_receipts.ndjson"
+    assert ledger_lock_path(p) == p.parent / "append_receipt.lock"
+
+
+def test_append_chained_entry_still_works_under_new_lock(tmp_path):
+    """Regression: append_chained_entry's locked refactor must not change its
+    observable output (ADR-034 §4 adopts a lock but must not change behavior
+    with the flag off)."""
+    p = tmp_path / "chain.ndjson"
+    h1 = append_chained_entry(p, {"event": "first", "id": "e1"})
+    h2 = append_chained_entry(p, {"event": "second", "id": "e2"})
+    lines = p.read_text().splitlines()
+    assert json.loads(lines[0])["prev_hash"] == GENESIS_HASH
+    assert json.loads(lines[1])["prev_hash"] == h1
+    assert h1 != h2
+
+
+def test_append_epoch_marker_still_works_under_new_lock(tmp_path):
+    p = tmp_path / "chain.ndjson"
+    append_epoch_marker(p, 1)
+    max_epoch, active = epoch_state(p)
+    assert max_epoch == 1 and active is True
+    ok, violations, status = verify_chain(p)
+    assert ok is True and violations == [] and status == "verified-segmented"
+
+
+def test_ledger_lock_file_created_and_released(tmp_path):
+    """The lock file exists after an append and is not left locked (flock
+    released) — a second immediate append must not hang."""
+    p = tmp_path / "chain.ndjson"
+    append_chained_entry(p, {"seq": 0})
+    lock_path = ledger_lock_path(p)
+    assert lock_path.exists()
+    # A second append must complete promptly (lock released after the first).
+    append_chained_entry(p, {"seq": 1})
+    assert len(p.read_text().splitlines()) == 2


### PR DESCRIPTION
## Summary
Implements ADR-034 PR-1 (deliverable dlv-d2eac5fa32d1): the core anchor-library `scripts/lib/chain_origin_anchor.py` plus `ledger_lock_path()` adoption in `ndjson_hash_chain.py`. Implements the ADR §7 interface letterlijk: anchor/closure-keys en -records (§1), `compute_epoch_fingerprint`/`compute_epoch_closure`, de git-anchor scan-API (`read_git_anchor`, `read_git_anchors_for_identity`, `AnchorProvenance`), `seal_and_commit_origin` (+`SealResult`), en de `verify_chain`-uitbreiding met reverse-direction fail-CLOSED en per-epoch closure-verificatie (§2). `VNX_CHAIN_RECEIPTS` blijft OFF; geen default-gedragsverandering.

## Context
4e implementatiepoging op dit subsysteem (#1085/#1086/#1171 gekild door de codex-gate); dit is de eerste tegen het ADR-034-design dat 3 codex-rondes overleefde (#1172). Worker-sessie eindigde zonder report; werk gereviewd en gecommit door T0 (salvage-first).

## Verification
- `tests/test_chain_origin_anchor.py` + `tests/test_ndjson_hash_chain.py`: **58 passed** (T1-T13, T15-T18 in test_chain_origin_anchor; T14 lock-identiteit in test_ndjson_hash_chain: `test_t14_ledger_lock_path_matches_hot_path_lock_file`)
- Verwante suites (`test_acceptance_idempotency`, `test_chain_epoch_seal`, `test_chain_state_projection`, `test_receipt_hashchain`, `test_schema_idempotency`): **85 passed**
- Hot path (`append_receipt_internals/idempotency.py`) ongewijzigd; T14 assert lock-pad-identiteit.

## Afwijking van de spec
Size-budget zei 150-300 diff-regels code; dit zijn er ~830 (excl. tests). Het ADR §7-interface (10 functies + 6 dataclasses + fail-closed verificatie) past niet binnen dat budget; expliciet gerapporteerd i.p.v. stil scope te knippen.

## Out of scope (PR-2)
`.github/workflows/` anchor-immutability-check, fabric_audit.py-wiring, gh-api branch-protection-check, flag-flip.

Dispatch-ID: 20260716-adr034-impl-pr1

🤖 Generated with [Claude Code](https://claude.com/claude-code)