### PR TITLE
fix(report-contract): exempt non-report dispatch classes + window contract_invalid counters

### DIFF
--- a/scripts/check_active_drain.py
+++ b/scripts/check_active_drain.py
@@ -46,7 +46,10 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
 
 from project_root import resolve_data_dir  # noqa: E402
-from report_contract_scope import is_stale_contract_invalid  # noqa: E402
+from report_contract_scope import (  # noqa: E402
+    contract_invalid_effective_timestamp,
+    is_stale_contract_invalid,
+)
 
 
 def _data_dir(override: str | None) -> Path:
@@ -120,7 +123,7 @@ def build_receipt_status_index(receipts_dir: Path) -> dict[str, str]:
         # key-match — skip it as if no receipt were found (falls through to
         # the active-dispatch's own age check instead).
         if status_raw == "contract_invalid" and is_stale_contract_invalid(
-            data.get("timestamp")
+            contract_invalid_effective_timestamp(data)
         ):
             continue
         if status_raw in FAILURE_STATUSES:

--- a/scripts/check_active_drain.py
+++ b/scripts/check_active_drain.py
@@ -46,6 +46,7 @@ _SCRIPTS_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(_SCRIPTS_DIR / "lib"))
 
 from project_root import resolve_data_dir  # noqa: E402
+from report_contract_scope import is_stale_contract_invalid  # noqa: E402
 
 
 def _data_dir(override: str | None) -> Path:
@@ -114,6 +115,14 @@ def build_receipt_status_index(receipts_dir: Path) -> dict[str, str]:
         if not did or did == "unknown":
             continue
         status_raw = str(data.get("status", "")).strip().lower()
+        # A frozen contract_invalid batch (bulk-emitted, single old timestamp)
+        # is not a live signal for the currently-active dispatch it happens to
+        # key-match — skip it as if no receipt were found (falls through to
+        # the active-dispatch's own age check instead).
+        if status_raw == "contract_invalid" and is_stale_contract_invalid(
+            data.get("timestamp")
+        ):
+            continue
         if status_raw in FAILURE_STATUSES:
             normalized = "failure"
         elif status_raw in SUCCESS_STATUSES:

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -27,6 +27,7 @@ try:
     from vnx_paths import ensure_env
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
+from report_contract_scope import is_stale_contract_invalid
 
 
 # Failure statuses sampled from the governed receipt stream when mining for
@@ -419,6 +420,14 @@ class LearningLoop:
                     total_scanned += 1
                     status = str(receipt.get("status", "")).lower()
                     if status not in _FAILURE_STATUSES:
+                        continue
+
+                    # A frozen contract_invalid batch (bulk-emitted, single old
+                    # timestamp) is never a recurring pattern worth learning from —
+                    # exclude regardless of how far back start_time itself reaches.
+                    if status == "contract_invalid" and is_stale_contract_invalid(
+                        receipt.get("timestamp")
+                    ):
                         continue
 
                     # D3 data-quality filter: skip no-provider failure receipts.

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -422,12 +422,16 @@ class LearningLoop:
                     if status not in _FAILURE_STATUSES:
                         continue
 
+                    is_contract_invalid = status == "contract_invalid"
+                    effective_ts = (
+                        contract_invalid_effective_timestamp(receipt)
+                        if is_contract_invalid else None
+                    )
+
                     # A frozen contract_invalid batch (bulk-emitted, single old
                     # timestamp) is never a recurring pattern worth learning from —
                     # exclude regardless of how far back start_time itself reaches.
-                    if status == "contract_invalid" and is_stale_contract_invalid(
-                        contract_invalid_effective_timestamp(receipt)
-                    ):
+                    if is_contract_invalid and is_stale_contract_invalid(effective_ts):
                         continue
 
                     # D3 data-quality filter: skip no-provider failure receipts.
@@ -453,8 +457,15 @@ class LearningLoop:
                     # merely for lacking a timestamp, so this filter mirrors
                     # that convention instead of silently re-excluding what the
                     # staleness check just admitted.
+                    # contract_invalid records window on effective_ts (the
+                    # processor-stamped ingested_at, computed above) instead of
+                    # the worker-suppliable `timestamp` — otherwise a forged old
+                    # report-body timestamp could still drop a freshly-ingested
+                    # contract_invalid failure here even after surviving the
+                    # dedicated staleness check above (codex-gate fix-round
+                    # #1184, Finding 3 HIGH).
                     ts_raw = receipt.get("timestamp")
-                    ts_dt = _parse_receipt_timestamp(ts_raw)
+                    ts_dt = _parse_receipt_timestamp(effective_ts if is_contract_invalid else ts_raw)
                     if ts_dt is not None and ts_dt < start_time:
                         continue
 

--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -27,7 +27,7 @@ try:
     from vnx_paths import ensure_env
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
-from report_contract_scope import is_stale_contract_invalid
+from report_contract_scope import contract_invalid_effective_timestamp, is_stale_contract_invalid
 
 
 # Failure statuses sampled from the governed receipt stream when mining for
@@ -426,7 +426,7 @@ class LearningLoop:
                     # timestamp) is never a recurring pattern worth learning from —
                     # exclude regardless of how far back start_time itself reaches.
                     if status == "contract_invalid" and is_stale_contract_invalid(
-                        receipt.get("timestamp")
+                        contract_invalid_effective_timestamp(receipt)
                     ):
                         continue
 
@@ -443,12 +443,19 @@ class LearningLoop:
                         no_provider_skipped += 1
                         continue
 
-                    # Window filter on the receipt timestamp. Drop records we
-                    # cannot place in time so a full historical stream does not
-                    # over-produce against the >=2 recurrence threshold.
+                    # Window filter on the receipt timestamp. Fail-open on a
+                    # missing/unparseable timestamp — only a receipt we can
+                    # POSITIVELY date as older than start_time is excluded.
+                    # Dropping on ts_dt is None here used to contradict the
+                    # is_stale_contract_invalid() fail-open check just above
+                    # (which lets a dateless contract_invalid receipt through):
+                    # weekly_digest / check_active_drain never drop a record
+                    # merely for lacking a timestamp, so this filter mirrors
+                    # that convention instead of silently re-excluding what the
+                    # staleness check just admitted.
                     ts_raw = receipt.get("timestamp")
                     ts_dt = _parse_receipt_timestamp(ts_raw)
-                    if ts_dt is None or ts_dt < start_time:
+                    if ts_dt is not None and ts_dt < start_time:
                         continue
 
                     failure_patterns.append({

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -322,18 +322,20 @@ def _stamp_identity(receipt: Dict[str, Any], *, identity_cwd: Optional[Path] = N
 
 
 def _stamp_ingested_at(receipt: Dict[str, Any]) -> None:
-    """Stamp the authoritative ingest time — set by this append layer, NEVER
-    merged from report-body content (report_to_receipt_converter.py copies its
-    ``timestamp``/``recorded_at`` fields straight out of the worker's own
-    report frontmatter, which a broken/adversarial worker can forge to an
-    arbitrary old date). Staleness windowing for ``contract_invalid`` receipts
-    (``report_contract_scope.contract_invalid_effective_timestamp``) keys off
-    this field so a forged old body timestamp can no longer vanish a fresh
-    failure from the fleet's counters. Caller-supplied values are never
-    overwritten (idempotent re-append keeps the original ingest time).
+    """Stamp the authoritative ingest time — ALWAYS set to now by this append
+    layer, never preserved from a caller-supplied value. append_receipt.py
+    accepts worker-authored JSON directly, so a pre-set ``ingested_at`` is
+    exactly as forgeable as ``timestamp``/``recorded_at`` (which
+    report_to_receipt_converter.py copies straight out of the worker's own
+    report frontmatter) — honoring it would let a broken/adversarial worker
+    pre-stamp an old ``ingested_at`` and defeat the very staleness check
+    (``report_contract_scope.contract_invalid_effective_timestamp``) this
+    field exists to make forge-proof (codex-gate fix-round #1184, Finding 2
+    HIGH). A re-append of the same receipt content simply gets a fresh ingest
+    time for that write — nothing downstream keys dedup off this field
+    (``IDEMPOTENCY_FIELDS`` excludes ``ingested_at``; see the comment at its
+    call site below).
     """
-    if receipt.get("ingested_at"):
-        return
     from datetime import datetime, timezone
     receipt["ingested_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -321,6 +321,23 @@ def _stamp_identity(receipt: Dict[str, Any], *, identity_cwd: Optional[Path] = N
         receipt["agent_id"] = identity.agent_id
 
 
+def _stamp_ingested_at(receipt: Dict[str, Any]) -> None:
+    """Stamp the authoritative ingest time — set by this append layer, NEVER
+    merged from report-body content (report_to_receipt_converter.py copies its
+    ``timestamp``/``recorded_at`` fields straight out of the worker's own
+    report frontmatter, which a broken/adversarial worker can forge to an
+    arbitrary old date). Staleness windowing for ``contract_invalid`` receipts
+    (``report_contract_scope.contract_invalid_effective_timestamp``) keys off
+    this field so a forged old body timestamp can no longer vanish a fresh
+    failure from the fleet's counters. Caller-supplied values are never
+    overwritten (idempotent re-append keeps the original ingest time).
+    """
+    if receipt.get("ingested_at"):
+        return
+    from datetime import datetime, timezone
+    receipt["ingested_at"] = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
 def append_receipt_payload(
     receipt: Dict[str, Any],
     *,
@@ -347,6 +364,11 @@ def append_receipt_payload(
 
     event_name = _validate_receipt(receipt)
     idempotency_key = _compute_idempotency_key(receipt, event_name)
+
+    # Stamped AFTER the idempotency key so a fresh ingest time never perturbs
+    # dedup (IDEMPOTENCY_FIELDS does not include ingested_at, but the rare
+    # content-hash fallback branch would otherwise mint a new hash every call).
+    _stamp_ingested_at(receipt)
 
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
     cache_path = _cache_file_for(receipt_path)

--- a/scripts/lib/report_contract_scope.py
+++ b/scripts/lib/report_contract_scope.py
@@ -27,22 +27,28 @@ Two problems, one root: `report_contract_invalid` is measured as the fleet's #1
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any, Dict, Optional
 
 _LIB_DIR = Path(__file__).resolve().parent
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
+from dispatch_spec import _ID_RE  # noqa: E402
 from phantom_guard import REVIEW_ROLES, REVIEW_TASK_CLASSES  # noqa: E402
 
 # Dispatch-id prefixes for dispatch classes that never produce a unified build
 # report. Matched case-insensitively against the START of dispatch_id.
 _PANEL_PREFIX = "panel-"
 _BENCH_PREFIXES = ("bench-", "smoke-")
+
+# Status dirs a staged bundle can be in at classification time (stage_spec_bundle
+# writes to pending/; promotion/reap machinery moves it to active/ or completed/).
+_DISPATCH_STATUS_DIRS = ("pending", "active", "completed")
 
 ENV_WINDOW_DAYS = "VNX_CONTRACT_INVALID_WINDOW_DAYS"
 DEFAULT_WINDOW_DAYS = 14
@@ -98,6 +104,163 @@ def is_report_producing(
     ) is None
 
 
+# ---------------------------------------------------------------------------
+# Authoritative-record resolution (governance bypass fix)
+#
+# classify_non_report_dispatch() above is pure: it classifies whatever
+# role/task_class/read_only/dispatch_id it is handed, with no opinion on
+# WHERE those values came from. Both call sites historically handed it
+# values pulled straight from the WORKER'S OWN report body — a real
+# build-worker whose report is broken can therefore forge
+# role: code-reviewer / task_class: research_structured / read_only: true
+# in its frontmatter and self-exempt from report_contract_invalid. The
+# functions below resolve the AUTHORITATIVE role/task_class for a
+# dispatch_id from governed fabric sources the worker cannot write, and
+# classify_report_dispatch() is the safe entry point call sites must use
+# instead of calling classify_non_report_dispatch() directly with
+# report-body values.
+# ---------------------------------------------------------------------------
+
+def _load_dispatch_spec_role(dispatch_id: str, data_dir: Path) -> Optional[Dict[str, Optional[str]]]:
+    """Look up role/task_class from a staged ``dispatch-spec.json``.
+
+    Searches ``dispatches/{pending,active,completed}/<dispatch_id>/dispatch-spec.json``
+    — written by ``dispatch_bridge.stage_spec_bundle()`` at staging time, NEVER
+    by the worker. Returns None when no spec bundle exists for this
+    dispatch_id (reaped already, or never a governed dispatch to begin with).
+    """
+    for status in _DISPATCH_STATUS_DIRS:
+        spec_path = data_dir / "dispatches" / status / dispatch_id / "dispatch-spec.json"
+        if not spec_path.is_file():
+            continue
+        try:
+            raw = json.loads(spec_path.read_text(encoding="utf-8"))
+        except (OSError, ValueError):
+            continue
+        if not isinstance(raw, dict):
+            continue
+        return {"role": raw.get("role"), "task_class": raw.get("task_class")}
+    return None
+
+
+def _load_dispatch_register_role(dispatch_id: str, state_dir: Path) -> Optional[Dict[str, Optional[str]]]:
+    """Fallback lookup: scan ``dispatch_register.ndjson`` for this dispatch_id's role.
+
+    Checks both known register locations (legacy ``<state_dir>/dispatch_register.ndjson``
+    and the ADR-005 transactional ``<state_dir>/../events/dispatch_register.ndjson``).
+    Returns the role/task_class carried in the ``extra`` payload of the most
+    recent matching record, or None when nothing usable is found. Used only
+    when a ``dispatch-spec.json`` bundle has already been reaped.
+    """
+    candidates = (
+        state_dir / "dispatch_register.ndjson",
+        state_dir.parent / "events" / "dispatch_register.ndjson",
+    )
+    found: Optional[Dict[str, Optional[str]]] = None
+    for register_path in candidates:
+        if not register_path.is_file():
+            continue
+        try:
+            with register_path.open("r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except ValueError:
+                        continue
+                    if not isinstance(rec, dict) or rec.get("dispatch_id") != dispatch_id:
+                        continue
+                    extra = rec.get("extra")
+                    if not isinstance(extra, dict):
+                        continue
+                    if extra.get("role") or extra.get("task_class"):
+                        found = {"role": extra.get("role"), "task_class": extra.get("task_class")}
+        except OSError:
+            continue
+    return found
+
+
+def resolve_dispatch_authority(
+    dispatch_id: Optional[str],
+    *,
+    state_dir: Optional[Path] = None,
+    data_dir: Optional[Path] = None,
+) -> Optional[Dict[str, Optional[str]]]:
+    """Resolve role/task_class for dispatch_id from GOVERNED sources only.
+
+    Never reads the worker's own report. Tries the staged ``dispatch-spec.json``
+    first (authoritative, written before the worker ever runs), then
+    ``dispatch_register.ndjson`` as a fallback for a dispatch whose spec bundle
+    has already been reaped. Returns None when neither source has a record for
+    this dispatch_id — a genuinely ungoverned fabric dispatch (a panel seat or
+    benchmark cell whose id was assigned by trusted fabric machinery, not a
+    reviewed worker), where the dispatch_id-prefix signal remains valid.
+
+    ``data_dir`` defaults to ``state_dir.parent`` (the standing convention
+    elsewhere in this codebase — see ``dispatch_register.register_proposed_track_dispatch``
+    and ``dispatch_cli._authority_from_spec_path``: state dir is always
+    ``<data_dir>/state``).
+    """
+    if not dispatch_id or not _ID_RE.match(dispatch_id):
+        return None
+    if data_dir is None and state_dir is not None:
+        data_dir = state_dir.parent
+    if data_dir is not None:
+        found = _load_dispatch_spec_role(dispatch_id, data_dir)
+        if found is not None:
+            return found
+    if state_dir is not None:
+        found = _load_dispatch_register_role(dispatch_id, state_dir)
+        if found is not None:
+            return found
+    return None
+
+
+def classify_report_dispatch(
+    dispatch_id: Optional[str] = None,
+    *,
+    role: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
+    state_dir: Optional[Path] = None,
+    data_dir: Optional[Path] = None,
+) -> Optional[str]:
+    """Governance-safe wrapper call sites must use instead of
+    ``classify_non_report_dispatch()`` directly.
+
+    A worker's own report body can claim ANY role/task_class/read_only/
+    dispatch_id — those fields are not authoritative and must never, by
+    themselves, grant a report_contract_invalid exemption (a broken
+    build-worker report could otherwise self-exempt by forging its
+    frontmatter). This resolves the dispatch's AUTHORITATIVE role/task_class
+    first (staged ``dispatch-spec.json``, then ``dispatch_register.ndjson``).
+
+    When an authoritative record exists, classification uses ONLY that
+    record: the report-body ``role``/``task_class``/``read_only`` arguments
+    are ignored outright, and the ``dispatch_id`` prefix signal is disabled
+    (``dispatch_id=None`` passed through) — a governed dispatch's id prefix
+    is coincidental, not a fabric-assigned classification.
+
+    Only when NO authoritative record exists (a genuinely ungoverned fabric
+    dispatch — panel seat, benchmark/smoke cell) do the body-supplied fields
+    and the dispatch_id prefix apply, exactly as ``classify_non_report_dispatch``
+    already does.
+    """
+    authority = resolve_dispatch_authority(dispatch_id, state_dir=state_dir, data_dir=data_dir)
+    if authority is not None:
+        return classify_non_report_dispatch(
+            dispatch_id=None,
+            role=authority.get("role"),
+            task_class=authority.get("task_class"),
+            read_only=None,
+        )
+    return classify_non_report_dispatch(
+        dispatch_id=dispatch_id, role=role, task_class=task_class, read_only=read_only,
+    )
+
+
 def contract_invalid_window_days() -> int:
     """Configurable staleness threshold (days). Env override, default 14."""
     raw = os.environ.get(ENV_WINDOW_DAYS)
@@ -124,6 +287,22 @@ def _parse_timestamp(value: Optional[str]) -> Optional[datetime]:
     if dt.tzinfo is None:
         dt = dt.replace(tzinfo=timezone.utc)
     return dt.astimezone(timezone.utc)
+
+
+def contract_invalid_effective_timestamp(record: Dict[str, Any]) -> Optional[Any]:
+    """The timestamp to window a ``contract_invalid`` receipt's staleness on.
+
+    Prefers ``ingested_at`` — stamped by ``append_receipt_payload()`` at
+    receipt-write time, NEVER derived from the worker's own report body —
+    over ``timestamp``/``recorded_at``, which ``report_to_receipt_converter.py``
+    copies straight out of the merged report frontmatter/body. A worker whose
+    report carries a forged old ``timestamp`` can otherwise vanish a fresh
+    real failure from every counter that windows on it. Falls back to
+    ``timestamp`` then ``recorded_at`` for receipts written before
+    ``ingested_at`` existed — the frozen historical batches this window was
+    built to exclude keep their old effective timestamp and stay excluded.
+    """
+    return record.get("ingested_at") or record.get("timestamp") or record.get("recorded_at")
 
 
 def is_stale_contract_invalid(

--- a/scripts/lib/report_contract_scope.py
+++ b/scripts/lib/report_contract_scope.py
@@ -243,10 +243,18 @@ def classify_report_dispatch(
     (``dispatch_id=None`` passed through) — a governed dispatch's id prefix
     is coincidental, not a fabric-assigned classification.
 
-    Only when NO authoritative record exists (a genuinely ungoverned fabric
-    dispatch — panel seat, benchmark/smoke cell) do the body-supplied fields
-    and the dispatch_id prefix apply, exactly as ``classify_non_report_dispatch``
-    already does.
+    When NO authoritative record exists (a reaped/missing spec, or a
+    genuinely ungoverned fabric dispatch — panel seat, benchmark/smoke cell),
+    the caller-supplied ``role``/``task_class``/``read_only`` arguments are
+    STILL never trusted — they are report-body content (or a route_decision-
+    derived fallback) the worker itself can shape, so a build-worker whose
+    spec bundle has already been reaped could otherwise self-exempt by
+    forging its own frontmatter. Only the ``dispatch_id`` prefix survives
+    into this fallback (codex-gate fix-round #1184, Finding 1 BLOCKING).
+    The ``role``/``task_class``/``read_only`` parameters remain part of this
+    function's signature for call-site stability, but are intentionally
+    unused now — a future extension that resolves them from another
+    AUTHORITATIVE source could reintroduce narrow trust without an API change.
     """
     authority = resolve_dispatch_authority(dispatch_id, state_dir=state_dir, data_dir=data_dir)
     if authority is not None:
@@ -256,9 +264,7 @@ def classify_report_dispatch(
             task_class=authority.get("task_class"),
             read_only=None,
         )
-    return classify_non_report_dispatch(
-        dispatch_id=dispatch_id, role=role, task_class=task_class, read_only=read_only,
-    )
+    return classify_non_report_dispatch(dispatch_id=dispatch_id)
 
 
 def contract_invalid_window_days() -> int:

--- a/scripts/lib/report_contract_scope.py
+++ b/scripts/lib/report_contract_scope.py
@@ -1,0 +1,147 @@
+"""report_contract_scope.py — scope guard for the report-body-contract validator.
+
+Two problems, one root: `report_contract_invalid` is measured as the fleet's #1
+"governed failure" signal, but the counter conflates two different things.
+
+1. Scope: the report-body contract (`report_body_contract.validate_body`) checks
+   for headings (`## Changes`, `## Verification`, ...) that only a delivery
+   worker who actually changed files would write. Panel/deliberation seats and
+   benchmark/smoke harness runs never produce a diff by design — scoring their
+   reports against the contract manufactures noise for dispatch classes the
+   contract was never meant to police. `classify_non_report_dispatch` follows
+   the existing phantom_guard.py exemption taxonomy (REVIEW_ROLES,
+   task_class="research_structured", read_only=True) exactly, then extends it
+   with the dispatch_id-prefix classes observed in the fleet data (panel-*
+   deliberation seats, bench-*/smoke-* harness runs) that carry neither a role
+   nor a task_class in their report body.
+
+2. Staleness: a frozen historical batch (many `contract_invalid` receipts all
+   sharing one old timestamp — a one-time bulk event, not organic churn) reads
+   as "live" in any counter that has no time bound, or whose bound is wider
+   than the batch's age. `is_stale_contract_invalid` gives every counter a
+   shared, configurable cutoff (default 14 days, `VNX_CONTRACT_INVALID_WINDOW_DAYS`)
+   so a `contract_invalid` receipt older than the window never counts as an
+   active failure signal, regardless of what overall lookback window the
+   caller itself uses.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from phantom_guard import REVIEW_ROLES, REVIEW_TASK_CLASSES  # noqa: E402
+
+# Dispatch-id prefixes for dispatch classes that never produce a unified build
+# report. Matched case-insensitively against the START of dispatch_id.
+_PANEL_PREFIX = "panel-"
+_BENCH_PREFIXES = ("bench-", "smoke-")
+
+ENV_WINDOW_DAYS = "VNX_CONTRACT_INVALID_WINDOW_DAYS"
+DEFAULT_WINDOW_DAYS = 14
+
+
+def truthy(value: Optional[Any]) -> bool:
+    """Coerce a frontmatter/body-field value ("true", "1", True, ...) to bool."""
+    if isinstance(value, bool):
+        return value
+    return str(value).strip().lower() in ("true", "1", "yes")
+
+
+def classify_non_report_dispatch(
+    *,
+    dispatch_id: Optional[str] = None,
+    role: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
+) -> Optional[str]:
+    """Return the exemption reason (`report_class`) when this dispatch is NOT
+    expected to produce a unified build report, or None when it IS — i.e. the
+    report-body contract applies and a violation is a real `report_contract_invalid`.
+
+    Mirrors phantom_guard.phantom_guard's read_only/role/task_class exemption
+    order exactly, then extends it with dispatch_id-prefix classes for the
+    non-report shapes that carry neither a role nor a task_class in their
+    report body (panel deliberation seats, benchmark/smoke harness runs).
+    """
+    if read_only:
+        return "read_only"
+    if role is not None and role.strip().lower() in REVIEW_ROLES:
+        return "review_role"
+    if task_class is not None and task_class.strip().lower() in REVIEW_TASK_CLASSES:
+        return "research_structured"
+    did = (dispatch_id or "").strip().lower()
+    if did.startswith(_PANEL_PREFIX):
+        return "panel_seat"
+    if did.startswith(_BENCH_PREFIXES):
+        return "benchmark"
+    return None
+
+
+def is_report_producing(
+    *,
+    dispatch_id: Optional[str] = None,
+    role: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
+) -> bool:
+    """True when the report-body contract applies to this dispatch."""
+    return classify_non_report_dispatch(
+        dispatch_id=dispatch_id, role=role, task_class=task_class, read_only=read_only,
+    ) is None
+
+
+def contract_invalid_window_days() -> int:
+    """Configurable staleness threshold (days). Env override, default 14."""
+    raw = os.environ.get(ENV_WINDOW_DAYS)
+    if not raw:
+        return DEFAULT_WINDOW_DAYS
+    try:
+        return max(0, int(raw))
+    except (TypeError, ValueError):
+        return DEFAULT_WINDOW_DAYS
+
+
+def _parse_timestamp(value: Optional[str]) -> Optional[datetime]:
+    if not value or not isinstance(value, str):
+        return None
+    v = value.strip()
+    if not v:
+        return None
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt.astimezone(timezone.utc)
+
+
+def is_stale_contract_invalid(
+    timestamp: Optional[str],
+    *,
+    window_days: Optional[int] = None,
+    now: Optional[datetime] = None,
+) -> bool:
+    """True when a contract_invalid / report_contract_invalid receipt is older
+    than the live-failure window (default 14 days) and must be excluded from a
+    live failure count — a frozen historical batch, not ongoing churn.
+
+    A missing/unparseable timestamp is treated as NOT stale (fail-open: only a
+    receipt we can positively date as old is excluded from live counts).
+    """
+    dt = _parse_timestamp(timestamp)
+    if dt is None:
+        return False
+    days = window_days if window_days is not None else contract_invalid_window_days()
+    cutoff = (now or datetime.now(timezone.utc)) - timedelta(days=days)
+    return dt < cutoff

--- a/scripts/lib/report_contract_scope.py
+++ b/scripts/lib/report_contract_scope.py
@@ -40,6 +40,7 @@ if str(_LIB_DIR) not in sys.path:
 
 from dispatch_spec import _ID_RE  # noqa: E402
 from phantom_guard import REVIEW_ROLES, REVIEW_TASK_CLASSES  # noqa: E402
+from smart_router import ROLE_TO_TASK_CLASS  # noqa: E402
 
 # Dispatch-id prefixes for dispatch classes that never produce a unified build
 # report. Matched case-insensitively against the START of dispatch_id.
@@ -243,6 +244,17 @@ def classify_report_dispatch(
     (``dispatch_id=None`` passed through) — a governed dispatch's id prefix
     is coincidental, not a fabric-assigned classification.
 
+    ``stage_spec_bundle()`` writes ``role`` into ``dispatch-spec.json`` but
+    never ``task_class`` — so an authoritative record with a role and no
+    task_class (the common case) falls back to ``ROLE_TO_TASK_CLASS``
+    (``smart_router.py``, the fabric's own role→task_class map) to derive
+    one. This is still fully authoritative: both the role and the map come
+    from fabric code the worker cannot write, never from the worker's report
+    body (fix-round #1184, r3 — codex-regate-2 found review roles like
+    ``security-engineer``/``quality-engineer`` wrongly flagged
+    ``report_contract_invalid`` because they carry no spec task_class and
+    aren't in ``REVIEW_ROLES`` directly).
+
     When NO authoritative record exists (a reaped/missing spec, or a
     genuinely ungoverned fabric dispatch — panel seat, benchmark/smoke cell),
     the caller-supplied ``role``/``task_class``/``read_only`` arguments are
@@ -258,10 +270,16 @@ def classify_report_dispatch(
     """
     authority = resolve_dispatch_authority(dispatch_id, state_dir=state_dir, data_dir=data_dir)
     if authority is not None:
+        authoritative_role = authority.get("role")
+        authoritative_task_class = authority.get("task_class")
+        if not authoritative_task_class and authoritative_role:
+            authoritative_task_class = ROLE_TO_TASK_CLASS.get(
+                authoritative_role.strip().lstrip("/").lower()
+            )
         return classify_non_report_dispatch(
             dispatch_id=None,
-            role=authority.get("role"),
-            task_class=authority.get("task_class"),
+            role=authoritative_role,
+            task_class=authoritative_task_class,
             read_only=None,
         )
     return classify_non_report_dispatch(dispatch_id=dispatch_id)

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -195,6 +195,7 @@ def build_receipt_from_report(
     """
     sys.path.insert(0, str(_LIB_DIR))
     from report_body_contract import validate_body
+    from report_contract_scope import classify_non_report_dispatch, truthy
     from datetime import datetime, timezone
 
     fm = parse_frontmatter(text)
@@ -255,7 +256,28 @@ def build_receipt_from_report(
         "report_path": str(report_path),
     }
 
+    route_dec = _load_route_decision(dispatch_id, state_dir) if state_dir else None
+
     if contract_violations:
+        report_class = classify_non_report_dispatch(
+            dispatch_id=dispatch_id,
+            role=merged.get("role"),
+            task_class=merged.get("task_class") or (route_dec or {}).get("task_class"),
+            read_only=truthy(merged.get("read_only")),
+        )
+        if report_class is not None:
+            logger.info(
+                "report_to_receipt_converter: %s is a non-report dispatch class"
+                " (%s) — contract violations exempted: %s",
+                report_path.name, report_class, contract_violations,
+            )
+            return {
+                **base,
+                "event_type": "report_exempt",
+                "status": "exempt",
+                "report_class": report_class,
+                "contract_violations": contract_violations,
+            }
         logger.warning(
             "report_to_receipt_converter: contract violations in %s: %s"
             " — emitting as report_contract_invalid",
@@ -273,10 +295,8 @@ def build_receipt_from_report(
         "event_type": "task_complete",
         "status": merged.get("status", "unknown"),
     }
-    if state_dir and dispatch_id:
-        route_dec = _load_route_decision(dispatch_id, state_dir)
-        if route_dec:
-            receipt["route_decision"] = route_dec
+    if route_dec:
+        receipt["route_decision"] = route_dec
     return receipt
 
 

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -195,7 +195,7 @@ def build_receipt_from_report(
     """
     sys.path.insert(0, str(_LIB_DIR))
     from report_body_contract import validate_body
-    from report_contract_scope import classify_non_report_dispatch, truthy
+    from report_contract_scope import classify_report_dispatch, truthy
     from datetime import datetime, timezone
 
     fm = parse_frontmatter(text)
@@ -259,11 +259,17 @@ def build_receipt_from_report(
     route_dec = _load_route_decision(dispatch_id, state_dir) if state_dir else None
 
     if contract_violations:
-        report_class = classify_non_report_dispatch(
-            dispatch_id=dispatch_id,
+        # classify_report_dispatch() resolves the AUTHORITATIVE role/task_class
+        # for dispatch_id (staged dispatch-spec.json, then dispatch_register.ndjson)
+        # first. When an authoritative record exists, the report-body-derived
+        # role/task_class/read_only/dispatch_id-prefix below are ignored outright —
+        # a broken build-worker cannot self-exempt by forging its own frontmatter.
+        report_class = classify_report_dispatch(
+            dispatch_id,
             role=merged.get("role"),
             task_class=merged.get("task_class") or (route_dec or {}).get("task_class"),
             read_only=truthy(merged.get("read_only")),
+            state_dir=state_dir,
         )
         if report_class is not None:
             logger.info(

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -668,7 +668,31 @@ class ReportParser:
         _contract_valid = extracted.get('_body_contract_valid', True)
         _status = str(metadata.get('status', 'unknown')).lower()
         _claims_success = _status in ('success', 'done', 'complete', 'completed', 'pass', 'passed')
+
+        # A success-claim with an invalid body is only a real contract violation
+        # for dispatch classes that are expected to produce a build report. A
+        # panel/deliberation seat or a review/read_only dispatch never writes a
+        # ## Changes section by design — classify before reclassifying (gate F1).
+        _report_class = None
         if _claims_success and not _contract_valid:
+            try:
+                _lib = str(Path(__file__).resolve().parent / "lib")
+                if _lib not in sys.path:
+                    sys.path.insert(0, _lib)
+                from report_contract_scope import classify_non_report_dispatch, truthy
+                _report_class = classify_non_report_dispatch(
+                    dispatch_id=metadata.get('dispatch_id'),
+                    role=metadata.get('role'),
+                    task_class=metadata.get('task_class'),
+                    read_only=truthy(metadata.get('read_only')),
+                )
+            except Exception:
+                _report_class = None
+
+        if _claims_success and not _contract_valid and _report_class is not None:
+            _event_type = 'report_exempt'
+            _receipt_status = 'exempt'
+        elif _claims_success and not _contract_valid:
             _event_type = 'report_contract_invalid'
             _receipt_status = 'contract_invalid'
         else:
@@ -694,6 +718,8 @@ class ReportParser:
             'report_file': Path(report_path).name,  # Add filename for easier tracking
             'title': metadata.get('title', 'No title')
         }
+        if _report_class is not None:
+            receipt['report_class'] = _report_class
 
         # Add extracted intelligence
         if extracted['tags'] and any(extracted['tags'].values()):

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -22,8 +22,13 @@ from datetime import datetime
 class ReportParser:
     """Extract structured intelligence from markdown reports"""
 
-    def __init__(self):
-        """Initialize parser with regex patterns"""
+    def __init__(self, *, state_dir: Optional[Path] = None):
+        """Initialize parser with regex patterns.
+
+        ``state_dir`` overrides the resolved VNX_STATE_DIR (test injection point
+        for the dispatch-authority lookup in ``_build_enhanced_receipt``); it
+        defaults to the ambient-env resolution used everywhere else.
+        """
         script_dir = Path(__file__).resolve().parent
         sys.path.insert(0, str(script_dir / "lib"))
         try:
@@ -34,6 +39,7 @@ class ReportParser:
         paths = ensure_env()
         self.vnx_home = Path(paths["VNX_HOME"])
         self.dispatch_completed_dir = Path(paths["VNX_DISPATCH_DIR"]) / "completed"
+        self.state_dir = state_dir or Path(paths["VNX_STATE_DIR"])
 
         self.tag_patterns = {
             'issues': re.compile(r'\*\*Issue Tags\*\*:\s*(.+)'),
@@ -679,12 +685,18 @@ class ReportParser:
                 _lib = str(Path(__file__).resolve().parent / "lib")
                 if _lib not in sys.path:
                     sys.path.insert(0, _lib)
-                from report_contract_scope import classify_non_report_dispatch, truthy
-                _report_class = classify_non_report_dispatch(
-                    dispatch_id=metadata.get('dispatch_id'),
+                # classify_report_dispatch() resolves the AUTHORITATIVE role/task_class
+                # for dispatch_id (staged dispatch-spec.json, then dispatch_register.ndjson)
+                # first. When an authoritative record exists, the report-body-derived
+                # role/task_class/read_only/dispatch_id-prefix below are ignored outright —
+                # a broken build-worker cannot self-exempt by forging its own frontmatter.
+                from report_contract_scope import classify_report_dispatch, truthy
+                _report_class = classify_report_dispatch(
+                    metadata.get('dispatch_id'),
                     role=metadata.get('role'),
                     task_class=metadata.get('task_class'),
                     read_only=truthy(metadata.get('read_only')),
+                    state_dir=self.state_dir,
                 )
             except Exception:
                 _report_class = None

--- a/scripts/weekly_digest.py
+++ b/scripts/weekly_digest.py
@@ -26,6 +26,7 @@ try:
     from vnx_paths import ensure_env
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
+from report_contract_scope import is_stale_contract_invalid
 
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
@@ -141,8 +142,16 @@ def collect_metrics(days: int = 7) -> dict:
                 event_type = (rec.get("event_type") or "").lower()
                 if event_type in _SKIP_EVENT_TYPES:
                     continue
-                metrics["dispatch_outcomes"]["total"] += 1
                 status = (rec.get("status") or "").lower()
+                # A frozen contract_invalid batch (bulk-emitted, single old
+                # timestamp) is excluded from the live count regardless of the
+                # digest's own --days window — a dedicated, tighter cutoff
+                # (default 14d) so a wide --days call doesn't resurrect it.
+                if (
+                    status == "contract_invalid" or event_type == "report_contract_invalid"
+                ) and is_stale_contract_invalid(rec.get("timestamp")):
+                    continue
+                metrics["dispatch_outcomes"]["total"] += 1
                 # Empty status falls back to event_type for classification —
                 # preserves pre-vocab recall for e.g. status-less task_complete
                 # receipts (the old code classified on status OR event_type).

--- a/scripts/weekly_digest.py
+++ b/scripts/weekly_digest.py
@@ -26,7 +26,7 @@ try:
     from vnx_paths import ensure_env
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
-from report_contract_scope import is_stale_contract_invalid
+from report_contract_scope import contract_invalid_effective_timestamp, is_stale_contract_invalid
 
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
@@ -149,7 +149,7 @@ def collect_metrics(days: int = 7) -> dict:
                 # (default 14d) so a wide --days call doesn't resurrect it.
                 if (
                     status == "contract_invalid" or event_type == "report_contract_invalid"
-                ) and is_stale_contract_invalid(rec.get("timestamp")):
+                ) and is_stale_contract_invalid(contract_invalid_effective_timestamp(rec)):
                     continue
                 metrics["dispatch_outcomes"]["total"] += 1
                 # Empty status falls back to event_type for classification —

--- a/scripts/weekly_digest.py
+++ b/scripts/weekly_digest.py
@@ -135,22 +135,37 @@ def collect_metrics(days: int = 7) -> dict:
                     rec = json.loads(line)
                 except json.JSONDecodeError:
                     continue
-                ts = rec.get("timestamp", "")
-                if ts and isinstance(ts, str) and ts[:10] < since:
-                    continue
                 # Skip infra events before counting totals.
                 event_type = (rec.get("event_type") or "").lower()
                 if event_type in _SKIP_EVENT_TYPES:
                     continue
                 status = (rec.get("status") or "").lower()
-                # A frozen contract_invalid batch (bulk-emitted, single old
-                # timestamp) is excluded from the live count regardless of the
-                # digest's own --days window — a dedicated, tighter cutoff
-                # (default 14d) so a wide --days call doesn't resurrect it.
-                if (
+                is_contract_invalid = (
                     status == "contract_invalid" or event_type == "report_contract_invalid"
-                ) and is_stale_contract_invalid(contract_invalid_effective_timestamp(rec)):
-                    continue
+                )
+                if is_contract_invalid:
+                    # contract_invalid/report_contract_invalid records window
+                    # EXCLUSIVELY on the processor-stamped ingested_at (via
+                    # contract_invalid_effective_timestamp) — never on the
+                    # worker-suppliable `timestamp` field the generic filter
+                    # below uses. Otherwise a freshly-ingested contract_invalid
+                    # receipt whose report body forged an old `timestamp` would
+                    # get dropped by the generic --days filter before it ever
+                    # reaches the dedicated staleness check just below
+                    # (codex-gate fix-round #1184, Finding 3 HIGH).
+                    effective_ts = contract_invalid_effective_timestamp(rec)
+                    if effective_ts and isinstance(effective_ts, str) and effective_ts[:10] < since:
+                        continue
+                    # A frozen contract_invalid batch (bulk-emitted, single old
+                    # timestamp) is excluded from the live count regardless of the
+                    # digest's own --days window — a dedicated, tighter cutoff
+                    # (default 14d) so a wide --days call doesn't resurrect it.
+                    if is_stale_contract_invalid(effective_ts):
+                        continue
+                else:
+                    ts = rec.get("timestamp", "")
+                    if ts and isinstance(ts, str) and ts[:10] < since:
+                        continue
                 metrics["dispatch_outcomes"]["total"] += 1
                 # Empty status falls back to event_type for classification —
                 # preserves pre-vocab recall for e.g. status-less task_complete

--- a/tests/test_contract_invalid_windowing.py
+++ b/tests/test_contract_invalid_windowing.py
@@ -34,6 +34,15 @@ def _iso(dt: datetime) -> str:
 _FROZEN_BATCH_TS = _iso(_NOW - timedelta(days=26))  # older than the 14d window
 _FRESH_FAILURE_TS = _iso(_NOW - timedelta(hours=2))  # inside the window
 
+# codex-gate fix-round (#1184) Finding 2 (HIGH): a worker-forged old
+# report-body `timestamp` (report_to_receipt_converter.py copies it straight
+# out of the report frontmatter) must not vanish a receipt that was actually
+# INGESTED just now. 45 days back — older than the 14d staleness window but
+# still inside a generous 60d digest/mining lookback so the coarse --days /
+# start_time cutoff (which still keys off `timestamp`) does not itself
+# exclude it; only the ingested_at-aware staleness check is under test.
+_FORGED_OLD_BODY_TS = _iso(_NOW - timedelta(days=45))
+
 
 # ---------------------------------------------------------------------------
 # weekly_digest.collect_metrics
@@ -87,6 +96,28 @@ class TestWeeklyDigestWindowing:
         out = self._run(records, tmp_path, days=30)
         assert out["total"] == 0
         assert out["failure"] == 0
+
+    def test_fresh_ingested_at_beats_forged_old_body_timestamp(self, tmp_path):
+        """T-adv3: a receipt ingested moments ago, whose report body forged
+        an old `timestamp`, still counts as a live failure — the staleness
+        check windows on ingested_at, not the worker-suppliable timestamp."""
+        records = [{
+            "status": "contract_invalid",
+            "timestamp": _FORGED_OLD_BODY_TS,
+            "ingested_at": _FRESH_FAILURE_TS,
+        }]
+        out = self._run(records, tmp_path, days=60)
+        assert out["total"] == 1
+        assert out["failure"] == 1
+
+    def test_no_parseable_timestamp_at_all_fails_open_and_counts(self, tmp_path):
+        """T-adv4: a contract_invalid receipt with NEITHER ingested_at NOR
+        timestamp still counts — consistent fail-open (weekly_digest already
+        did this; this locks it in against regression)."""
+        records = [{"status": "contract_invalid"}]
+        out = self._run(records, tmp_path, days=30)
+        assert out["total"] == 1
+        assert out["failure"] == 1
 
 
 # ---------------------------------------------------------------------------
@@ -167,6 +198,44 @@ class TestLearningLoopWindowing:
         )
         assert len(failures) == 1
 
+    def test_fresh_ingested_at_beats_forged_old_body_timestamp(self, loop_env):
+        """T-adv3: ingested_at (fresh) wins over a forged old report-body
+        timestamp for the contract_invalid staleness check."""
+        loop, state_dir = loop_env
+        records = [{
+            "status": "contract_invalid", "terminal": "T1", "provider": "claude",
+            "dispatch_id": "d-adv3-forged-old-ts", "contract_violations": ["## Changes"],
+            "timestamp": _FORGED_OLD_BODY_TS, "ingested_at": _FRESH_FAILURE_TS,
+        }]
+        (state_dir / "t0_receipts.ndjson").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        failures = loop.extract_failure_patterns(
+            start_time=datetime.now(timezone.utc) - timedelta(days=60)
+        )
+        assert len(failures) == 1
+
+    def test_no_parseable_timestamp_at_all_fails_open_and_still_mined(self, loop_env):
+        """T-adv4: a contract_invalid receipt with NO timestamp field at all
+        (missing, not merely unparseable) still gets mined. Previously the
+        is_stale_contract_invalid() fail-open (missing timestamp -> not
+        stale, not skipped) was contradicted by a SECOND `ts_dt is None`
+        drop a few lines later — this locks in the fix so both checks agree."""
+        loop, state_dir = loop_env
+        records = [{
+            "status": "contract_invalid", "terminal": "T1", "provider": "claude",
+            "dispatch_id": "d-adv4-no-ts", "contract_violations": ["## Changes"],
+        }]
+        (state_dir / "t0_receipts.ndjson").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        failures = loop.extract_failure_patterns(
+            start_time=datetime.now(timezone.utc) - timedelta(days=2)
+        )
+        assert len(failures) == 1
+
 
 # ---------------------------------------------------------------------------
 # check_active_drain.build_receipt_status_index
@@ -208,7 +277,9 @@ class TestCheckActiveDrainWindowing:
     def test_missing_timestamp_still_indexed_as_failure(self, tmp_path):
         """Regression guard: a receipt with NO timestamp field (pre-existing
         real-world shape) must still classify as failure — fail-open, not
-        fail-closed, on missing dating information."""
+        fail-closed, on missing dating information. (T-adv4: check_active_drain
+        already had this right via is_stale_contract_invalid(None)==False;
+        this test locks it in against regression.)"""
         from check_active_drain import build_receipt_status_index
 
         receipts_processed = tmp_path / "receipts" / "processed"
@@ -217,6 +288,24 @@ class TestCheckActiveDrainWindowing:
         did = "20260610-no-timestamp-field"
         (receipts_processed / f"receipt-{did}.json").write_text(
             json.dumps({"dispatch_id": did, "status": "contract_invalid"}),
+            encoding="utf-8",
+        )
+
+        idx = build_receipt_status_index(tmp_path / "receipts")
+        assert idx[did] == "failure"
+
+    def test_fresh_ingested_at_beats_forged_old_body_timestamp(self, tmp_path):
+        """T-adv3: ingested_at (fresh) wins over a forged old report-body
+        timestamp for the contract_invalid staleness check."""
+        from check_active_drain import build_receipt_status_index
+
+        receipts_processed = tmp_path / "receipts" / "processed"
+        receipts_processed.mkdir(parents=True)
+
+        did = "20260716-t-adv3-forged-old-body-ts"
+        (receipts_processed / f"receipt-{did}.json").write_text(
+            json.dumps({"dispatch_id": did, "status": "contract_invalid",
+                        "timestamp": _FORGED_OLD_BODY_TS, "ingested_at": _FRESH_FAILURE_TS}),
             encoding="utf-8",
         )
 

--- a/tests/test_contract_invalid_windowing.py
+++ b/tests/test_contract_invalid_windowing.py
@@ -1,0 +1,228 @@
+"""Integration tests for the 14-day contract_invalid staleness window.
+
+Acceptance criterion (dispatch 20260716-report-contract-scope, part 2): a
+frozen historical batch of `contract_invalid` receipts (bulk-emitted, all
+sharing one old timestamp) must not inflate a "live failure" counter, while a
+genuinely fresh failure in the same ledger still counts. Each of the three
+named counter scripts gets its own tmp-ledger fixture with exactly that shape:
+one old contract_invalid batch + one fresh real failure.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPTS = REPO / "scripts"
+LIB = SCRIPTS / "lib"
+for p in (str(SCRIPTS), str(LIB)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+_NOW = datetime.now(tz=timezone.utc)
+
+
+def _iso(dt: datetime) -> str:
+    return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+_FROZEN_BATCH_TS = _iso(_NOW - timedelta(days=26))  # older than the 14d window
+_FRESH_FAILURE_TS = _iso(_NOW - timedelta(hours=2))  # inside the window
+
+
+# ---------------------------------------------------------------------------
+# weekly_digest.collect_metrics
+# ---------------------------------------------------------------------------
+
+class TestWeeklyDigestWindowing:
+    def _run(self, records: list[dict], tmp_path: Path, days: int = 30) -> dict:
+        import weekly_digest
+
+        receipts_path = tmp_path / "t0_receipts.ndjson"
+        receipts_path.write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+        with (
+            patch.object(weekly_digest, "RECEIPTS_PATH", receipts_path),
+            patch.object(weekly_digest, "DB_PATH", tmp_path / "nonexistent.db"),
+            patch.object(weekly_digest, "PENDING_PATH", tmp_path / "nonexistent.json"),
+        ):
+            metrics = weekly_digest.collect_metrics(days=days)
+        return metrics["dispatch_outcomes"]
+
+    def test_frozen_batch_excluded_fresh_failure_counted(self, tmp_path):
+        records = [
+            {"status": "contract_invalid", "timestamp": _FROZEN_BATCH_TS}
+            for _ in range(36)  # mirrors the measured seocrawler-v2 frozen batch size
+        ] + [
+            {"status": "failed", "timestamp": _FRESH_FAILURE_TS},
+        ]
+        # days=30 so the digest window alone would NOT exclude the 26-day batch —
+        # only the dedicated 14-day contract_invalid staleness check does.
+        out = self._run(records, tmp_path, days=30)
+        assert out["total"] == 1
+        assert out["failure"] == 1
+        assert out["success"] == 0
+        assert out["unknown"] == 0
+
+    def test_fresh_contract_invalid_still_counts_as_failure(self, tmp_path):
+        """A contract_invalid receipt inside the 14d window is still live."""
+        records = [{"status": "contract_invalid", "timestamp": _FRESH_FAILURE_TS}]
+        out = self._run(records, tmp_path, days=30)
+        assert out["total"] == 1
+        assert out["failure"] == 1
+
+    def test_report_contract_invalid_event_type_also_windowed(self, tmp_path):
+        """Frozen batches emitted via event_type (not status) are also excluded."""
+        records = [
+            {"event_type": "report_contract_invalid", "status": "contract_invalid",
+             "timestamp": _FROZEN_BATCH_TS}
+            for _ in range(10)
+        ]
+        out = self._run(records, tmp_path, days=30)
+        assert out["total"] == 0
+        assert out["failure"] == 0
+
+
+# ---------------------------------------------------------------------------
+# learning_loop.LearningLoop.extract_failure_patterns
+# ---------------------------------------------------------------------------
+
+class _FakePaths:
+    def __init__(self, state_dir: Path, vnx_home: Path):
+        self._d = {
+            "VNX_STATE_DIR": str(state_dir),
+            "VNX_HOME": str(vnx_home),
+            "VNX_DATA_DIR": str(state_dir.parent),
+        }
+
+    def __getitem__(self, k):
+        return self._d[k]
+
+    def get(self, k, default=None):
+        return self._d.get(k, default)
+
+
+class TestLearningLoopWindowing:
+    @pytest.fixture
+    def loop_env(self, tmp_path):
+        import learning_loop as ll
+
+        state_dir = tmp_path / "vnx-data" / "vnx-dev" / "state"
+        state_dir.mkdir(parents=True)
+        vnx_home = tmp_path / "repo"
+        vnx_home.mkdir()
+
+        fake = _FakePaths(state_dir, vnx_home)
+        with patch.object(ll, "ensure_env", return_value=fake):
+            loop = ll.LearningLoop()
+            yield loop, state_dir
+        try:
+            loop.conn.close()
+        except Exception:
+            pass
+
+    def test_frozen_batch_excluded_fresh_failure_included(self, loop_env):
+        loop, state_dir = loop_env
+        records = [
+            {"status": "contract_invalid", "terminal": "T1", "dispatch_id": f"d-old-{i}",
+             "timestamp": _FROZEN_BATCH_TS}
+            for i in range(20)
+        ] + [
+            {"status": "failed", "failure_reason": "Exhausted 3 retries", "terminal": "T1",
+             "provider": "claude", "dispatch_id": "d-fresh", "timestamp": _FRESH_FAILURE_TS},
+        ]
+        (state_dir / "t0_receipts.ndjson").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        # start_time reaches back 60 days — wide enough that, without the
+        # dedicated contract_invalid staleness check, the frozen batch would
+        # still be inside the window and get mined.
+        failures = loop.extract_failure_patterns(
+            start_time=datetime.now(timezone.utc) - timedelta(days=60)
+        )
+
+        assert len(failures) == 1
+        assert failures[0]["error"] == "Exhausted 3 retries"
+
+    def test_fresh_contract_invalid_still_mined(self, loop_env):
+        loop, state_dir = loop_env
+        records = [
+            {"status": "contract_invalid", "terminal": "T1", "provider": "claude",
+             "dispatch_id": "d-fresh-ci", "contract_violations": ["## Changes"],
+             "timestamp": _FRESH_FAILURE_TS},
+        ]
+        (state_dir / "t0_receipts.ndjson").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        failures = loop.extract_failure_patterns(
+            start_time=datetime.now(timezone.utc) - timedelta(days=2)
+        )
+        assert len(failures) == 1
+
+
+# ---------------------------------------------------------------------------
+# check_active_drain.build_receipt_status_index
+# ---------------------------------------------------------------------------
+
+class TestCheckActiveDrainWindowing:
+    def test_stale_contract_invalid_receipt_excluded_from_index(self, tmp_path):
+        from check_active_drain import build_receipt_status_index
+
+        receipts_processed = tmp_path / "receipts" / "processed"
+        receipts_processed.mkdir(parents=True)
+
+        did = "20260610-stale-contract-invalid"
+        (receipts_processed / f"receipt-{did}.json").write_text(
+            json.dumps({"dispatch_id": did, "status": "contract_invalid",
+                        "timestamp": _FROZEN_BATCH_TS}),
+            encoding="utf-8",
+        )
+
+        idx = build_receipt_status_index(tmp_path / "receipts")
+        assert did not in idx
+
+    def test_fresh_contract_invalid_receipt_still_indexed_as_failure(self, tmp_path):
+        from check_active_drain import build_receipt_status_index
+
+        receipts_processed = tmp_path / "receipts" / "processed"
+        receipts_processed.mkdir(parents=True)
+
+        did = "20260716-fresh-contract-invalid"
+        (receipts_processed / f"receipt-{did}.json").write_text(
+            json.dumps({"dispatch_id": did, "status": "contract_invalid",
+                        "timestamp": _FRESH_FAILURE_TS}),
+            encoding="utf-8",
+        )
+
+        idx = build_receipt_status_index(tmp_path / "receipts")
+        assert idx[did] == "failure"
+
+    def test_missing_timestamp_still_indexed_as_failure(self, tmp_path):
+        """Regression guard: a receipt with NO timestamp field (pre-existing
+        real-world shape) must still classify as failure — fail-open, not
+        fail-closed, on missing dating information."""
+        from check_active_drain import build_receipt_status_index
+
+        receipts_processed = tmp_path / "receipts" / "processed"
+        receipts_processed.mkdir(parents=True)
+
+        did = "20260610-no-timestamp-field"
+        (receipts_processed / f"receipt-{did}.json").write_text(
+            json.dumps({"dispatch_id": did, "status": "contract_invalid"}),
+            encoding="utf-8",
+        )
+
+        idx = build_receipt_status_index(tmp_path / "receipts")
+        assert idx[did] == "failure"
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_contract_invalid_windowing.py
+++ b/tests/test_contract_invalid_windowing.py
@@ -119,6 +119,24 @@ class TestWeeklyDigestWindowing:
         assert out["total"] == 1
         assert out["failure"] == 1
 
+    def test_t_adv8_fresh_ingested_at_beats_forged_old_timestamp_narrow_days(self, tmp_path):
+        """T-adv8 (fix-r2, Finding 3 HIGH): with a NARROW --days window, the
+        generic worker-`timestamp` window filter used to run before the
+        dedicated contract_invalid staleness check ever saw the record — a
+        forged old body `timestamp` (45d) outside a 7-day digest window
+        dropped the record even though its processor-stamped ingested_at was
+        fresh. Windowing for contract_invalid records must key off
+        ingested_at exclusively, for both the --days cutoff and the
+        dedicated staleness check."""
+        records = [{
+            "status": "contract_invalid",
+            "timestamp": _FORGED_OLD_BODY_TS,
+            "ingested_at": _FRESH_FAILURE_TS,
+        }]
+        out = self._run(records, tmp_path, days=7)
+        assert out["total"] == 1
+        assert out["failure"] == 1
+
 
 # ---------------------------------------------------------------------------
 # learning_loop.LearningLoop.extract_failure_patterns
@@ -226,6 +244,28 @@ class TestLearningLoopWindowing:
         records = [{
             "status": "contract_invalid", "terminal": "T1", "provider": "claude",
             "dispatch_id": "d-adv4-no-ts", "contract_violations": ["## Changes"],
+        }]
+        (state_dir / "t0_receipts.ndjson").write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"
+        )
+
+        failures = loop.extract_failure_patterns(
+            start_time=datetime.now(timezone.utc) - timedelta(days=2)
+        )
+        assert len(failures) == 1
+
+    def test_t_adv8_fresh_ingested_at_beats_forged_old_timestamp_narrow_start(self, loop_env):
+        """T-adv8 (fix-r2, Finding 3 HIGH): a SECOND generic window filter on
+        the worker-suppliable `timestamp` ran after the dedicated staleness
+        check and could still drop a freshly-ingested contract_invalid
+        receipt whose report body forged an old `timestamp` (45d) outside a
+        narrow start_time (2d). Both window decisions for contract_invalid
+        records must key off ingested_at exclusively."""
+        loop, state_dir = loop_env
+        records = [{
+            "status": "contract_invalid", "terminal": "T1", "provider": "claude",
+            "dispatch_id": "d-adv8-forged-old-ts", "contract_violations": ["## Changes"],
+            "timestamp": _FORGED_OLD_BODY_TS, "ingested_at": _FRESH_FAILURE_TS,
         }]
         (state_dir / "t0_receipts.ndjson").write_text(
             "\n".join(json.dumps(r) for r in records) + "\n", encoding="utf-8"

--- a/tests/test_report_contract_scope.py
+++ b/tests/test_report_contract_scope.py
@@ -356,6 +356,33 @@ class TestClassifyReportDispatch:
         _write_spec(tmp_path, did, "pending", {"role": "reviewer", "task_class": "research_structured"})
         assert classify_report_dispatch(did, data_dir=tmp_path) == "review_role"
 
+    def test_t_adv9_review_role_without_spec_task_class_now_exempt(self, tmp_path):
+        """T-adv9 (fix-r3): stage_spec_bundle() never writes task_class, only
+        role — a review-shaped role like security-engineer/quality-engineer
+        that isn't literally in REVIEW_ROLES must still be exempt via the
+        role's authoritative ROLE_TO_TASK_CLASS mapping (smart_router.py,
+        fabric code the worker cannot write — not a report-body claim).
+        Regression for codex-regate-2's Finding 1: this assertion fails on
+        pre-fix code (returns None -> wrongly flagged report_contract_invalid)
+        and passes post-fix (git stash proof recorded in the dispatch report)."""
+        did = "20260717-t-adv9-security-engineer"
+        _write_spec(tmp_path, did, "pending", {"role": "security-engineer"})
+        assert classify_report_dispatch(did, data_dir=tmp_path) == "research_structured"
+
+        did2 = "20260717-t-adv9-quality-engineer"
+        _write_spec(tmp_path, did2, "pending", {"role": "quality-engineer"})
+        assert classify_report_dispatch(did2, data_dir=tmp_path) == "research_structured"
+
+    def test_t_adv9_real_backend_developer_still_not_exempt(self, tmp_path):
+        """T-adv9 negative side: the derived-task_class path must not widen
+        the exemption to a genuine delivery role. backend-developer ->
+        01_code_generation (ROLE_TO_TASK_CLASS), which is NOT in
+        REVIEW_TASK_CLASSES, so a broken report from this role stays
+        report_contract_invalid — the over-exemption guard holds."""
+        did = "20260717-t-adv9-backend-developer"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        assert classify_report_dispatch(did, data_dir=tmp_path) is None
+
     def test_no_state_dir_no_data_dir_behaves_like_pure_function(self):
         """No lookup roots supplied at all -> same as classify_non_report_dispatch."""
         assert classify_report_dispatch("panel-no-roots-given") == "panel_seat"

--- a/tests/test_report_contract_scope.py
+++ b/tests/test_report_contract_scope.py
@@ -10,6 +10,7 @@ Covers:
 """
 from __future__ import annotations
 
+import json
 import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,9 +22,12 @@ sys.path.insert(0, str(REPO / "scripts" / "lib"))
 
 from report_contract_scope import (  # noqa: E402
     classify_non_report_dispatch,
+    classify_report_dispatch,
+    contract_invalid_effective_timestamp,
     contract_invalid_window_days,
     is_report_producing,
     is_stale_contract_invalid,
+    resolve_dispatch_authority,
     truthy,
 )
 
@@ -170,6 +174,189 @@ class TestIsStaleContractInvalid:
     def test_env_override_invalid_falls_back_to_default(self, monkeypatch):
         monkeypatch.setenv("VNX_CONTRACT_INVALID_WINDOW_DAYS", "not-a-number")
         assert contract_invalid_window_days() == 14
+
+
+# ---------------------------------------------------------------------------
+# resolve_dispatch_authority() — governed-source lookup (codex-gate fix-round,
+# Finding 1 BLOCKING: the exemption must never be classified off report-body
+# content a worker controls)
+# ---------------------------------------------------------------------------
+
+def _write_spec(data_dir: Path, dispatch_id: str, status: str, payload: dict) -> None:
+    spec_dir = data_dir / "dispatches" / status / dispatch_id
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "dispatch-spec.json").write_text(json.dumps(payload), encoding="utf-8")
+
+
+class TestResolveDispatchAuthority:
+    def test_none_dispatch_id_returns_none(self, tmp_path):
+        assert resolve_dispatch_authority(None, data_dir=tmp_path) is None
+
+    def test_no_spec_no_register_returns_none(self, tmp_path):
+        assert resolve_dispatch_authority("20260716-nothing-here", data_dir=tmp_path) is None
+
+    def test_finds_role_from_spec_in_pending(self, tmp_path):
+        did = "20260716-spec-pending"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        assert resolve_dispatch_authority(did, data_dir=tmp_path) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+    def test_finds_role_from_spec_in_active(self, tmp_path):
+        did = "20260716-spec-active"
+        _write_spec(tmp_path, did, "active", {"role": "code-reviewer", "task_class": "02_code_review"})
+        assert resolve_dispatch_authority(did, data_dir=tmp_path) == {
+            "role": "code-reviewer", "task_class": "02_code_review",
+        }
+
+    def test_finds_role_from_spec_in_completed(self, tmp_path):
+        did = "20260716-spec-completed"
+        _write_spec(tmp_path, did, "completed", {"role": "backend-developer"})
+        assert resolve_dispatch_authority(did, data_dir=tmp_path) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+    def test_data_dir_defaults_to_state_dir_parent(self, tmp_path):
+        did = "20260716-derived-data-dir"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        assert resolve_dispatch_authority(did, state_dir=state_dir) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+    def test_falls_back_to_register_when_no_spec(self, tmp_path):
+        did = "20260716-register-fallback"
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "dispatch_register.ndjson").write_text(
+            json.dumps({"dispatch_id": did, "extra": {"role": "backend-developer"}}) + "\n",
+            encoding="utf-8",
+        )
+        assert resolve_dispatch_authority(did, state_dir=state_dir) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+    def test_falls_back_to_adr005_register_path(self, tmp_path):
+        """dispatch_register.register_proposed_track_dispatch() writes to
+        <state_dir>/../events/dispatch_register.ndjson, not <state_dir> itself."""
+        did = "20260716-adr005-register"
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        events_dir = tmp_path / "events"
+        events_dir.mkdir(parents=True)
+        (events_dir / "dispatch_register.ndjson").write_text(
+            json.dumps({"dispatch_id": did, "extra": {"role": "backend-developer"}}) + "\n",
+            encoding="utf-8",
+        )
+        assert resolve_dispatch_authority(did, state_dir=state_dir) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+    def test_spec_wins_over_register(self, tmp_path):
+        did = "20260716-spec-wins"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / "dispatch_register.ndjson").write_text(
+            json.dumps({"dispatch_id": did, "extra": {"role": "code-reviewer"}}) + "\n",
+            encoding="utf-8",
+        )
+        assert resolve_dispatch_authority(did, state_dir=state_dir)["role"] == "backend-developer"
+
+    def test_rejects_path_traversal_dispatch_id(self, tmp_path):
+        # First char of _ID_RE is alnum-only — "../.." can never match, so this
+        # must fall through to "no authoritative record" rather than escape tmp_path.
+        assert resolve_dispatch_authority("../../../etc/passwd", data_dir=tmp_path) is None
+
+    def test_malformed_spec_json_does_not_crash(self, tmp_path):
+        did = "20260716-malformed-spec"
+        spec_dir = tmp_path / "dispatches" / "pending" / did
+        spec_dir.mkdir(parents=True)
+        (spec_dir / "dispatch-spec.json").write_text("{not valid json", encoding="utf-8")
+        assert resolve_dispatch_authority(did, data_dir=tmp_path) is None
+
+    def test_malformed_register_lines_skipped(self, tmp_path):
+        did = "20260716-malformed-register-line"
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        (state_dir / "dispatch_register.ndjson").write_text(
+            "not valid json\n"
+            + json.dumps({"dispatch_id": did, "extra": {"role": "backend-developer"}}) + "\n",
+            encoding="utf-8",
+        )
+        assert resolve_dispatch_authority(did, state_dir=state_dir) == {
+            "role": "backend-developer", "task_class": None,
+        }
+
+
+# ---------------------------------------------------------------------------
+# classify_report_dispatch() — the governance-safe wrapper call sites must use
+# ---------------------------------------------------------------------------
+
+class TestClassifyReportDispatch:
+    def test_authoritative_role_overrides_forged_body_fields(self, tmp_path):
+        """T-adv1 core: a spec-backed backend-developer dispatch cannot
+        self-exempt via forged report-body role/task_class/read_only."""
+        did = "20260716-authoritative-override"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        result = classify_report_dispatch(
+            did,
+            role="code-reviewer",
+            task_class="research_structured",
+            read_only=True,
+            data_dir=tmp_path,
+        )
+        assert result is None
+
+    def test_dispatch_id_prefix_disabled_when_authority_exists(self, tmp_path):
+        """A dispatch_id that happens to start with 'panel-' but HAS a real
+        spec (role=backend-developer) must not be exempted by the prefix."""
+        did = "panel-but-actually-a-governed-build-worker"
+        _write_spec(tmp_path, did, "pending", {"role": "backend-developer"})
+        assert classify_report_dispatch(did, data_dir=tmp_path) is None
+
+    def test_no_authority_falls_back_to_dispatch_id_prefix(self, tmp_path):
+        """T-adv2 core: a genuinely ungoverned panel seat (no spec, no
+        register record) keeps its existing prefix-based exemption."""
+        assert classify_report_dispatch("panel-real-seat-1", data_dir=tmp_path) == "panel_seat"
+
+    def test_no_authority_falls_back_to_body_role(self, tmp_path):
+        assert classify_report_dispatch(
+            "20260716-ungoverned-review", role="code-reviewer", data_dir=tmp_path
+        ) == "review_role"
+
+    def test_authoritative_task_class_from_spec_exempts(self, tmp_path):
+        did = "20260716-spec-task-class"
+        _write_spec(tmp_path, did, "pending", {"role": "reviewer", "task_class": "research_structured"})
+        assert classify_report_dispatch(did, data_dir=tmp_path) == "review_role"
+
+    def test_no_state_dir_no_data_dir_behaves_like_pure_function(self):
+        """No lookup roots supplied at all -> same as classify_non_report_dispatch."""
+        assert classify_report_dispatch("panel-no-roots-given") == "panel_seat"
+        assert classify_report_dispatch("20260716-plain", role="backend-developer") is None
+
+
+# ---------------------------------------------------------------------------
+# contract_invalid_effective_timestamp() — Finding 2 (HIGH): windowing must
+# key off the processor-stamped ingest time, not the worker-suppliable
+# timestamp/recorded_at.
+# ---------------------------------------------------------------------------
+
+class TestContractInvalidEffectiveTimestamp:
+    def test_prefers_ingested_at(self):
+        assert contract_invalid_effective_timestamp(
+            {"ingested_at": "A", "timestamp": "B", "recorded_at": "C"}
+        ) == "A"
+
+    def test_falls_back_to_timestamp_when_no_ingested_at(self):
+        assert contract_invalid_effective_timestamp({"timestamp": "B"}) == "B"
+
+    def test_falls_back_to_recorded_at_when_neither_ingested_at_nor_timestamp(self):
+        assert contract_invalid_effective_timestamp({"recorded_at": "C"}) == "C"
+
+    def test_returns_none_when_nothing_present(self):
+        assert contract_invalid_effective_timestamp({}) is None
 
 
 if __name__ == "__main__":

--- a/tests/test_report_contract_scope.py
+++ b/tests/test_report_contract_scope.py
@@ -1,0 +1,176 @@
+"""Tests for scripts/lib/report_contract_scope.py.
+
+Covers:
+  - classify_non_report_dispatch(): panel/bench/smoke dispatch_id prefixes,
+    phantom_guard-style role/task_class/read_only exemptions, and the
+    negative case (a real build-worker dispatch is NOT exempt).
+  - is_stale_contract_invalid(): default/overridden window, missing/
+    unparseable timestamps (fail-open), and boundary behaviour.
+  - truthy(): frontmatter/body-field string coercion.
+"""
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from report_contract_scope import (  # noqa: E402
+    classify_non_report_dispatch,
+    contract_invalid_window_days,
+    is_report_producing,
+    is_stale_contract_invalid,
+    truthy,
+)
+
+
+# ---------------------------------------------------------------------------
+# classify_non_report_dispatch — exempt classes
+# ---------------------------------------------------------------------------
+
+class TestClassifyExemptClasses:
+    def test_panel_seat_prefix_exempt(self):
+        assert classify_non_report_dispatch(
+            dispatch_id="panel-architecture-diverge-1-abc123"
+        ) == "panel_seat"
+
+    def test_panel_seat_case_insensitive(self):
+        assert classify_non_report_dispatch(dispatch_id="PANEL-Architecture-verify") == "panel_seat"
+
+    def test_bench_prefix_exempt(self):
+        assert classify_non_report_dispatch(dispatch_id="bench-model-x-task-y-20260716") == "benchmark"
+
+    def test_smoke_prefix_exempt(self):
+        assert classify_non_report_dispatch(dispatch_id="smoke-skill-injection-check") == "benchmark"
+
+    def test_review_role_exempt(self):
+        assert classify_non_report_dispatch(
+            dispatch_id="20260716-some-review", role="code-reviewer"
+        ) == "review_role"
+
+    def test_review_role_case_insensitive_and_whitespace(self):
+        assert classify_non_report_dispatch(role="  Plan-Reviewer  ") == "review_role"
+
+    def test_research_structured_task_class_exempt(self):
+        assert classify_non_report_dispatch(task_class="research_structured") == "research_structured"
+
+    def test_other_review_task_class_exempt(self):
+        assert classify_non_report_dispatch(task_class="02_code_review") == "research_structured"
+
+    def test_read_only_flag_exempt(self):
+        assert classify_non_report_dispatch(read_only=True) == "read_only"
+
+    def test_read_only_wins_over_absent_role(self):
+        assert classify_non_report_dispatch(dispatch_id="20260716-x", read_only=True) == "read_only"
+
+
+# ---------------------------------------------------------------------------
+# classify_non_report_dispatch — the negative case (no over-exemption)
+# ---------------------------------------------------------------------------
+
+class TestClassifyRealBuildWorkerNotExempt:
+    def test_plain_dispatch_id_not_exempt(self):
+        assert classify_non_report_dispatch(dispatch_id="20260716-report-contract-scope") is None
+
+    def test_backend_developer_role_not_exempt(self):
+        assert classify_non_report_dispatch(
+            dispatch_id="20260716-fix-something", role="backend-developer"
+        ) is None
+
+    def test_no_fields_at_all_not_exempt(self):
+        assert classify_non_report_dispatch() is None
+
+    def test_task_class_that_looks_like_coding_not_exempt(self):
+        assert classify_non_report_dispatch(task_class="01_code_generation") is None
+
+    def test_dispatch_id_containing_but_not_prefixed_with_panel_not_exempt(self):
+        # "panel" appears mid-string, not as a prefix — must NOT be exempted.
+        assert classify_non_report_dispatch(dispatch_id="20260716-review-panel-followup") is None
+
+    def test_is_report_producing_true_for_real_worker(self):
+        assert is_report_producing(dispatch_id="20260716-real-work", role="backend-developer") is True
+
+    def test_is_report_producing_false_for_panel_seat(self):
+        assert is_report_producing(dispatch_id="panel-arch-synth") is False
+
+
+# ---------------------------------------------------------------------------
+# truthy()
+# ---------------------------------------------------------------------------
+
+class TestTruthy:
+    @pytest.mark.parametrize("value", ["true", "True", "TRUE", "1", "yes", "Yes"])
+    def test_truthy_strings(self, value):
+        assert truthy(value) is True
+
+    @pytest.mark.parametrize("value", ["false", "0", "no", "", None, "bananas"])
+    def test_falsy_values(self, value):
+        assert truthy(value) is False
+
+    def test_bool_passthrough(self):
+        assert truthy(True) is True
+        assert truthy(False) is False
+
+
+# ---------------------------------------------------------------------------
+# is_stale_contract_invalid()
+# ---------------------------------------------------------------------------
+
+class TestIsStaleContractInvalid:
+    def _iso(self, dt: datetime) -> str:
+        return dt.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    def test_default_window_is_14_days(self):
+        assert contract_invalid_window_days() == 14
+
+    def test_fresh_timestamp_not_stale(self):
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=1))
+        assert is_stale_contract_invalid(ts, now=now) is False
+
+    def test_old_timestamp_is_stale(self):
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=26))
+        assert is_stale_contract_invalid(ts, now=now) is True
+
+    def test_boundary_just_inside_window_not_stale(self):
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=13))
+        assert is_stale_contract_invalid(ts, now=now) is False
+
+    def test_boundary_just_outside_window_is_stale(self):
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=15))
+        assert is_stale_contract_invalid(ts, now=now) is True
+
+    def test_missing_timestamp_fails_open_not_stale(self):
+        assert is_stale_contract_invalid(None) is False
+        assert is_stale_contract_invalid("") is False
+
+    def test_unparseable_timestamp_fails_open_not_stale(self):
+        assert is_stale_contract_invalid("not-a-timestamp") is False
+
+    def test_explicit_window_days_override(self):
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=5))
+        assert is_stale_contract_invalid(ts, window_days=3, now=now) is True
+        assert is_stale_contract_invalid(ts, window_days=7, now=now) is False
+
+    def test_env_override(self, monkeypatch):
+        monkeypatch.setenv("VNX_CONTRACT_INVALID_WINDOW_DAYS", "3")
+        assert contract_invalid_window_days() == 3
+        now = datetime.now(tz=timezone.utc)
+        ts = self._iso(now - timedelta(days=5))
+        assert is_stale_contract_invalid(ts, now=now) is True
+
+    def test_env_override_invalid_falls_back_to_default(self, monkeypatch):
+        monkeypatch.setenv("VNX_CONTRACT_INVALID_WINDOW_DAYS", "not-a-number")
+        assert contract_invalid_window_days() == 14
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/tests/test_report_contract_scope.py
+++ b/tests/test_report_contract_scope.py
@@ -321,10 +321,35 @@ class TestClassifyReportDispatch:
         register record) keeps its existing prefix-based exemption."""
         assert classify_report_dispatch("panel-real-seat-1", data_dir=tmp_path) == "panel_seat"
 
-    def test_no_authority_falls_back_to_body_role(self, tmp_path):
+    def test_no_authority_body_role_no_longer_exempts(self, tmp_path):
+        """fix-r2 Finding 1 BLOCKING: with no authoritative record, a
+        report-body role/task_class/read_only must NEVER grant an exemption
+        either — only the dispatch_id prefix survives into the fallback.
+        Previously this returned "review_role" (the self-exempt bug); the
+        dispatch_id here deliberately has no panel-/bench-/smoke- prefix so
+        no exemption signal remains at all."""
         assert classify_report_dispatch(
             "20260716-ungoverned-review", role="code-reviewer", data_dir=tmp_path
-        ) == "review_role"
+        ) is None
+
+    def test_t_adv5_no_spec_forged_role_and_read_only_not_exempt(self, tmp_path):
+        """T-adv5 (fix-r2, Finding 1 BLOCKING): a dispatch with NO
+        authoritative spec/register record and a plain dispatch_id (no
+        panel-/bench-/smoke- prefix) cannot self-exempt via forged
+        report-body role/read_only anymore."""
+        assert classify_report_dispatch(
+            "20260716-t-adv5-no-spec-forged",
+            role="code-reviewer",
+            task_class="research_structured",
+            read_only=True,
+            data_dir=tmp_path,
+        ) is None
+
+    def test_t_adv6_no_spec_panel_prefix_still_exempt(self, tmp_path):
+        """T-adv6 (fix-r2): the legitimate dispatch_id-prefix exemption
+        survives the Finding 1 fix — a spec-less panel-/bench-/smoke- seat is
+        still a genuinely ungoverned fabric dispatch."""
+        assert classify_report_dispatch("panel-t-adv6-no-spec", data_dir=tmp_path) == "panel_seat"
 
     def test_authoritative_task_class_from_spec_exempts(self, tmp_path):
         did = "20260716-spec-task-class"

--- a/tests/test_report_parser_contract.py
+++ b/tests/test_report_parser_contract.py
@@ -8,6 +8,7 @@ trail as a clean task_complete. A success-claim + invalid body -> report_contrac
 contract-valid success report -> task_complete; a non-success report is never reclassified.
 """
 
+import json
 import sys
 from pathlib import Path
 
@@ -126,6 +127,81 @@ def test_real_build_worker_broken_report_still_contract_invalid(tmp_path):
     assert r["event_type"] == "report_contract_invalid"
     assert r["status"] == "contract_invalid"
     assert "report_class" not in r
+
+
+# ---------------------------------------------------------------------------
+# codex-gate fix-round (#1184) — Finding 1 BLOCKING: classify off the
+# AUTHORITATIVE dispatch-spec.json, never the worker's own report body.
+# report_parser.py has its own copy of the classification call site
+# (_build_enhanced_receipt) — same vulnerability, same fix, own coverage.
+# ---------------------------------------------------------------------------
+
+def _write_dispatch_spec(data_dir: Path, dispatch_id: str, role: str, status: str = "pending") -> None:
+    spec_dir = data_dir / "dispatches" / status / dispatch_id
+    spec_dir.mkdir(parents=True, exist_ok=True)
+    (spec_dir / "dispatch-spec.json").write_text(
+        json.dumps({
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": dispatch_id,
+            "staging_id": dispatch_id,
+            "instruction_file": str(spec_dir / "instruction.md"),
+            "role": role,
+            "target_slot": "T1",
+        }),
+        encoding="utf-8",
+    )
+
+
+def test_forged_self_exempt_fields_do_not_bypass_contract_with_spec(tmp_path):
+    """T-adv1 (report_parser.py call site): a spec-backed backend-developer
+    dispatch forges read_only/role/task_class exemption fields in its own
+    report body. Must still get report_contract_invalid, NOT report_exempt."""
+    did = "20260716-t-adv1-parser-self-exempt"
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True)
+    _write_dispatch_spec(data_dir, did, "backend-developer")
+
+    body = f"""# Completion Report
+**Status**: success
+**Dispatch-ID**: {did}
+**Role**: code-reviewer
+**Task-Class**: research_structured
+**Read-Only**: true
+
+GATE GREEN — everything looks good. (No required sections, no evidence.)
+"""
+    p = tmp_path / "report.md"
+    p.write_text(body, encoding="utf-8")
+
+    r = ReportParser(state_dir=state_dir).parse_report(str(p))
+    assert r["event_type"] == "report_contract_invalid"
+    assert r["status"] == "contract_invalid"
+    assert "report_class" not in r
+
+
+def test_panel_seat_without_spec_still_exempt(tmp_path):
+    """T-adv2 (report_parser.py call site): a genuinely ungoverned panel
+    seat (no dispatch-spec.json anywhere) still gets report_exempt."""
+    did = "panel-t-adv2-parser-arch-diverge"
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True)
+
+    body = f"""# Completion Report
+**Status**: success
+**Dispatch-ID**: {did}
+
+GATE GREEN — deliberation seat verdict, no diff produced by design.
+"""
+    p = tmp_path / "report.md"
+    p.write_text(body, encoding="utf-8")
+
+    r = ReportParser(state_dir=state_dir).parse_report(str(p))
+    assert r["event_type"] == "report_exempt"
+    assert r["status"] == "exempt"
+    assert r["report_class"] == "panel_seat"
 
 
 if __name__ == "__main__":

--- a/tests/test_report_parser_contract.py
+++ b/tests/test_report_parser_contract.py
@@ -78,5 +78,55 @@ def test_non_success_report_is_not_reclassified(tmp_path):
     assert r["contract_valid"] is False
 
 
+# ---------------------------------------------------------------------------
+# Non-report dispatch classes are exempted, not report_contract_invalid
+# ---------------------------------------------------------------------------
+
+_PANEL_SEAT_BODY = """# Completion Report
+**Status**: success
+**Dispatch-ID**: panel-architecture-diverge-1-abc123
+
+GATE GREEN — deliberation seat verdict, no diff produced by design.
+"""
+
+_REVIEW_ROLE_BODY = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260716-plan-review-seat
+**Role**: code-reviewer
+
+GATE GREEN — review verdict only, no required sections.
+"""
+
+_REAL_BROKEN_BODY = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260716-real-broken-build
+**Role**: backend-developer
+
+GATE GREEN — everything looks good. (No required sections, no evidence.)
+"""
+
+
+def test_panel_seat_success_claim_is_exempt(tmp_path):
+    r = _parse(tmp_path, _PANEL_SEAT_BODY)
+    assert r["event_type"] == "report_exempt"
+    assert r["status"] == "exempt"
+    assert r["report_class"] == "panel_seat"
+
+
+def test_review_role_success_claim_is_exempt(tmp_path):
+    r = _parse(tmp_path, _REVIEW_ROLE_BODY)
+    assert r["event_type"] == "report_exempt"
+    assert r["report_class"] == "review_role"
+
+
+def test_real_build_worker_broken_report_still_contract_invalid(tmp_path):
+    """No exemption class applies: a genuinely broken build-worker report must
+    still emit report_contract_invalid — over-exemption is a failure."""
+    r = _parse(tmp_path, _REAL_BROKEN_BODY)
+    assert r["event_type"] == "report_contract_invalid"
+    assert r["status"] == "contract_invalid"
+    assert "report_class" not in r
+
+
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_report_parser_contract.py
+++ b/tests/test_report_parser_contract.py
@@ -114,10 +114,15 @@ def test_panel_seat_success_claim_is_exempt(tmp_path):
     assert r["report_class"] == "panel_seat"
 
 
-def test_review_role_success_claim_is_exempt(tmp_path):
+def test_review_role_body_without_spec_no_longer_exempt(tmp_path):
+    """fix-r2 Finding 1 BLOCKING (T-adv5): a report-body role, with no
+    authoritative dispatch-spec.json backing it (no state_dir passed here,
+    so no spec can ever be found), can no longer grant an exemption.
+    Previously this returned report_exempt/review_role."""
     r = _parse(tmp_path, _REVIEW_ROLE_BODY)
-    assert r["event_type"] == "report_exempt"
-    assert r["report_class"] == "review_role"
+    assert r["event_type"] == "report_contract_invalid"
+    assert r["status"] == "contract_invalid"
+    assert "report_class" not in r
 
 
 def test_real_build_worker_broken_report_still_contract_invalid(tmp_path):

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -637,3 +637,140 @@ class TestSmartRouterStrategyTag:
 
         result = _load_route_decision("bad-dispatch", state_dir)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Part 9: non-report dispatch classes are exempted, not report_contract_invalid
+# ---------------------------------------------------------------------------
+
+class TestNonReportDispatchExemption:
+    """Panel/deliberation seats, benchmark/smoke runs, and review/read_only
+    dispatches never write a ## Changes section by design. A contract
+    violation from one of those classes must emit report_exempt, not
+    report_contract_invalid — but a REAL build worker with a broken report
+    must still emit report_contract_invalid (no blanket exemption)."""
+
+    _BROKEN_BODY = "## Summary\n\nShort.\n"  # missing sections, no content dispatch_id
+
+    def test_panel_seat_dispatch_id_is_exempt(self, tmp_path, state_dir):
+        did = "panel-architecture-diverge-1-abc123"
+        report = tmp_path / f"{did}.md"
+        report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["status"] == "exempt"
+        assert r["report_class"] == "panel_seat"
+        assert r["dispatch_id"] == did
+
+    def test_bench_dispatch_id_is_exempt(self, tmp_path, state_dir):
+        did = "bench-model-x-task-y-20260716"
+        report = tmp_path / f"{did}.md"
+        report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "benchmark"
+
+    def test_smoke_dispatch_id_is_exempt(self, tmp_path, state_dir):
+        did = "smoke-skill-injection-check"
+        report = tmp_path / f"{did}.md"
+        report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "benchmark"
+
+    def test_review_role_frontmatter_is_exempt(self, tmp_path, state_dir):
+        did = "20260716-plan-review-seat"
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\nrole: code-reviewer\n---\n\n{self._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "review_role"
+
+    def test_read_only_frontmatter_is_exempt(self, tmp_path, state_dir):
+        did = "20260716-read-only-seat"
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\nread_only: true\n---\n\n{self._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "read_only"
+
+    def test_route_decision_task_class_is_used_as_fallback(self, tmp_path, state_dir):
+        """When the report body carries no task_class, the route_decision JSON's
+        task_class (written by smart_router) is consulted as a fallback signal."""
+        did = "20260716-router-tagged-review"
+        report = tmp_path / f"{did}.md"
+        report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
+
+        rd_dir = state_dir / "route_decisions"
+        rd_dir.mkdir(parents=True, exist_ok=True)
+        (rd_dir / f"{did}.json").write_text(
+            json.dumps({"strategy": "smart_router", "task_class": "research_structured"}),
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "research_structured"
+
+    def test_real_build_worker_still_gets_contract_invalid(self, tmp_path, state_dir):
+        """No exemption class applies: a genuinely broken build-worker report
+        must still emit report_contract_invalid (over-exemption is a failure)."""
+        did = "20260716-real-broken-build"
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\nrole: backend-developer\n---\n\n{self._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_contract_invalid"
+        assert r["status"] == "contract_invalid"
+        assert "report_class" not in r
+
+    def test_dispatch_id_containing_panel_midstring_still_contract_invalid(self, tmp_path, state_dir):
+        """dispatch_id prefix match only — "panel" mid-string must NOT exempt."""
+        did = "20260716-review-panel-followup"
+        report = tmp_path / f"{did}.md"
+        report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_contract_invalid"

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -774,3 +774,114 @@ class TestNonReportDispatchExemption:
 
         r = _receipts(state_dir)[0]
         assert r["event_type"] == "report_contract_invalid"
+
+
+# ---------------------------------------------------------------------------
+# Part 10: codex-gate fix-round (#1184) — Finding 1 BLOCKING: classification
+# must use the AUTHORITATIVE dispatch record, never report-body content the
+# reviewed worker itself writes.
+# ---------------------------------------------------------------------------
+
+class TestAuthoritativeClassificationBlocksSelfExempt:
+    """A real build-worker with a staged dispatch-spec.json (role=backend-
+    developer) cannot self-exempt from report_contract_invalid by forging
+    role/task_class/read_only exemption fields in its own report body."""
+
+    def _write_dispatch_spec(self, tmp_path: Path, dispatch_id: str, role: str, status: str = "pending") -> None:
+        """tmp_path here is the parent of the `state_dir` fixture — data_dir
+        in resolve_dispatch_authority() terms — mirroring stage_spec_bundle's
+        real bundle layout: <data_dir>/dispatches/<status>/<dispatch_id>/dispatch-spec.json."""
+        spec_dir = tmp_path / "dispatches" / status / dispatch_id
+        spec_dir.mkdir(parents=True, exist_ok=True)
+        (spec_dir / "dispatch-spec.json").write_text(
+            json.dumps({
+                "schema_version": 1,
+                "project_id": "vnx-dev",
+                "dispatch_id": dispatch_id,
+                "staging_id": dispatch_id,
+                "instruction_file": str(spec_dir / "instruction.md"),
+                "role": role,
+                "target_slot": "T1",
+            }),
+            encoding="utf-8",
+        )
+
+    def test_forged_self_exempt_fields_do_not_bypass_contract_with_spec(self, tmp_path, state_dir):
+        """T-adv1: dispatch has an authoritative spec (role=backend-developer).
+        Its report body forges read_only=true + role=code-reviewer +
+        task_class=research_structured AND has a broken body (missing
+        ## Changes). Must still get report_contract_invalid, NOT report_exempt."""
+        did = "20260716-t-adv1-self-exempt-attempt"
+        self._write_dispatch_spec(tmp_path, did, "backend-developer")
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\nread_only: true\nrole: code-reviewer\n"
+            f"task_class: research_structured\n---\n\n{TestNonReportDispatchExemption._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_contract_invalid"
+        assert r["status"] == "contract_invalid"
+        assert "report_class" not in r
+
+    def test_panel_seat_without_spec_still_exempt(self, tmp_path, state_dir):
+        """T-adv2: a genuinely ungoverned panel seat (dispatch_id panel-...,
+        NO dispatch-spec.json anywhere) still gets report_exempt — the
+        authority-first fix must not break the legitimate exemption path."""
+        did = "panel-t-adv2-arch-diverge-1"
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\n---\n\n{TestNonReportDispatchExemption._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["status"] == "exempt"
+        assert r["report_class"] == "panel_seat"
+
+    def test_review_role_spec_still_exempt(self, tmp_path, state_dir):
+        """A dispatch WITH a spec whose authoritative role genuinely is
+        code-reviewer is still exempt — the fix restricts the SOURCE of
+        truth, it does not remove the review_role exemption class itself."""
+        did = "20260716-t-adv-real-reviewer"
+        self._write_dispatch_spec(tmp_path, did, "code-reviewer")
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\n---\n\n{TestNonReportDispatchExemption._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_exempt"
+        assert r["report_class"] == "review_role"
+
+    def test_spec_in_active_dir_also_authoritative(self, tmp_path, state_dir):
+        """dispatches/active/ (promoted, not yet completed) must also be
+        searched — not just pending/."""
+        did = "20260716-t-adv-active-spec"
+        self._write_dispatch_spec(tmp_path, did, "backend-developer", status="active")
+        report = tmp_path / f"{did}.md"
+        report.write_text(
+            f"---\ndispatch_id: {did}\nrole: code-reviewer\n---\n\n{TestNonReportDispatchExemption._BROKEN_BODY}",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        r = _receipts(state_dir)[0]
+        assert r["event_type"] == "report_contract_invalid"
+        assert "report_class" not in r

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -693,7 +693,11 @@ class TestNonReportDispatchExemption:
         assert r["event_type"] == "report_exempt"
         assert r["report_class"] == "benchmark"
 
-    def test_review_role_frontmatter_is_exempt(self, tmp_path, state_dir):
+    def test_review_role_frontmatter_without_spec_no_longer_exempt(self, tmp_path, state_dir):
+        """fix-r2 Finding 1 BLOCKING (T-adv5): report-body role, with no
+        authoritative dispatch-spec.json/register record backing it, can no
+        longer grant an exemption. Previously this returned report_exempt —
+        the self-exempt bug a reaped/missing spec left open."""
         did = "20260716-plan-review-seat"
         report = tmp_path / f"{did}.md"
         report.write_text(
@@ -704,11 +708,15 @@ class TestNonReportDispatchExemption:
 
         result = convert_report_to_receipt(report, receipts_file=receipts_file)
 
+        assert result is not None
         r = _receipts(state_dir)[0]
-        assert r["event_type"] == "report_exempt"
-        assert r["report_class"] == "review_role"
+        assert r["event_type"] == "report_contract_invalid"
+        assert r["status"] == "contract_invalid"
+        assert "report_class" not in r
 
-    def test_read_only_frontmatter_is_exempt(self, tmp_path, state_dir):
+    def test_read_only_frontmatter_without_spec_no_longer_exempt(self, tmp_path, state_dir):
+        """fix-r2 Finding 1 BLOCKING (T-adv5): same as above for read_only —
+        a spec-less dispatch cannot self-exempt via a forged read_only flag."""
         did = "20260716-read-only-seat"
         report = tmp_path / f"{did}.md"
         report.write_text(
@@ -719,13 +727,20 @@ class TestNonReportDispatchExemption:
 
         result = convert_report_to_receipt(report, receipts_file=receipts_file)
 
+        assert result is not None
         r = _receipts(state_dir)[0]
-        assert r["event_type"] == "report_exempt"
-        assert r["report_class"] == "read_only"
+        assert r["event_type"] == "report_contract_invalid"
+        assert r["status"] == "contract_invalid"
+        assert "report_class" not in r
 
-    def test_route_decision_task_class_is_used_as_fallback(self, tmp_path, state_dir):
-        """When the report body carries no task_class, the route_decision JSON's
-        task_class (written by smart_router) is consulted as a fallback signal."""
+    def test_route_decision_task_class_no_longer_used_as_fallback(self, tmp_path, state_dir):
+        """fix-r2 Finding 1 BLOCKING: classify_report_dispatch's no-authority
+        fallback now ignores every caller-supplied role/task_class/read_only
+        argument, not just report-body ones — a route_decision-derived
+        task_class no longer grants an exemption either. Only an
+        authoritative dispatch-spec.json/register record, or the dispatch_id
+        prefix, can exempt. Previously this asserted report_exempt; that was
+        the same non-authoritative-signal class of bug as Finding 1."""
         did = "20260716-router-tagged-review"
         report = tmp_path / f"{did}.md"
         report.write_text(f"---\ndispatch_id: {did}\n---\n\n{self._BROKEN_BODY}", encoding="utf-8")
@@ -740,9 +755,10 @@ class TestNonReportDispatchExemption:
 
         result = convert_report_to_receipt(report, receipts_file=receipts_file)
 
+        assert result is not None
         r = _receipts(state_dir)[0]
-        assert r["event_type"] == "report_exempt"
-        assert r["report_class"] == "research_structured"
+        assert r["event_type"] == "report_contract_invalid"
+        assert "report_class" not in r
 
     def test_real_build_worker_still_gets_contract_invalid(self, tmp_path, state_dir):
         """No exemption class applies: a genuinely broken build-worker report

--- a/tests/test_stamp_ingested_at.py
+++ b/tests/test_stamp_ingested_at.py
@@ -1,0 +1,44 @@
+"""Regression test for _stamp_ingested_at (codex-gate fix-round #1184, Finding 2 HIGH).
+
+append_receipt.py accepts worker-authored JSON directly, so a caller-supplied
+`ingested_at` is exactly as forgeable as `timestamp`/`recorded_at`. The old
+implementation returned early when `ingested_at` was already present on the
+receipt, letting a worker pre-set an old value and defeat the staleness check
+(`report_contract_scope.contract_invalid_effective_timestamp`) this field
+exists to make forge-proof. `_stamp_ingested_at` must always overwrite it with
+the processor-emit time, regardless of any pre-existing value.
+"""
+
+from __future__ import annotations
+
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import append_receipt_internals.payload as payload_mod  # noqa: E402
+
+
+def test_t_adv7_preset_old_ingested_at_is_overwritten_with_fresh_time():
+    """T-adv7: a receipt with a pre-set old ingested_at gets a fresh
+    ingested_at after _stamp_ingested_at — a worker cannot forge it."""
+    old_ts = (datetime.now(timezone.utc) - timedelta(days=45)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    receipt = {"dispatch_id": "d-adv7-forged-ingested-at", "ingested_at": old_ts}
+
+    before = datetime.now(timezone.utc)
+    payload_mod._stamp_ingested_at(receipt)
+    after = datetime.now(timezone.utc)
+
+    assert receipt["ingested_at"] != old_ts
+    stamped = datetime.strptime(receipt["ingested_at"], "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    assert before - timedelta(seconds=5) <= stamped <= after + timedelta(seconds=5)
+
+
+def test_missing_ingested_at_is_stamped():
+    """Baseline: a receipt with no ingested_at at all still gets stamped."""
+    receipt = {"dispatch_id": "d-adv7-no-ingested-at"}
+    payload_mod._stamp_ingested_at(receipt)
+    assert "ingested_at" in receipt
+    datetime.strptime(receipt["ingested_at"], "%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
## Summary

`report_contract_invalid` is measured fleet-wide as the #1 "governed failure" signal, but it measures the wrong thing:

1. **Scope**: panel/deliberation seats, benchmark/smoke harness runs, and read-only reviews never produce a `## Changes` section by design — scoring their reports against the report-body contract manufactures noise for dispatch classes the contract was never meant to police.
2. **Windowing**: several counters read frozen historical batches (many `contract_invalid` receipts sharing one old bulk-emit timestamp) as live churn, because the counter has no time bound or a bound wider than the batch's age.

## Changes

- **New `scripts/lib/report_contract_scope.py`**:
  - `classify_non_report_dispatch()` follows the existing `phantom_guard.py` exemption taxonomy exactly (`REVIEW_ROLES`, `task_class="research_structured"`, `read_only=True`) and extends it with dispatch_id-prefix classes observed in the fleet data: `panel-` (deliberation seats), `bench-`/`smoke-` (benchmark/smoke harness runs).
  - `is_stale_contract_invalid()` — a shared 14-day staleness window (`VNX_CONTRACT_INVALID_WINDOW_DAYS` override), fail-open on a missing/unparseable timestamp.
- **`scripts/lib/report_to_receipt_converter.py`** and **`scripts/report_parser.py`** (the two `report_contract_invalid` emit sites): a contract violation from a non-report dispatch class now emits `event_type=report_exempt`, `status=exempt`, `report_class=<reason>` instead of `report_contract_invalid` — a benign, distinct receipt so the audit trail stays complete without counting as a failure. A genuinely broken report from a real build worker still emits `report_contract_invalid` (no blanket exemption).
- **`scripts/weekly_digest.py`**, **`scripts/learning_loop.py`**, **`scripts/check_active_drain.py`** (the three counters named in the dispatch spec that read/aggregate `report_contract_invalid`/`contract_invalid`): a stale (>14d) `contract_invalid` receipt is excluded from the live count, independent of each script's own lookback window (so a wide `--days`/`start_time` call can't resurrect a frozen batch).
- Ledger itself is untouched — this is a pure read-layer classification/windowing fix.

## Verification

- `tests/test_report_contract_scope.py` (new, 40 tests) — unit coverage for `classify_non_report_dispatch()` (panel/bench/smoke prefixes, review-role/task_class/read_only exemptions, and the negative case — a real build worker is NOT exempted) and `is_stale_contract_invalid()` (default/override window, boundaries, fail-open on missing/unparseable timestamps).
- `tests/test_report_to_receipt_converter.py` — 9 new tests in `TestNonReportDispatchExemption`: panel/bench/smoke/review-role/read-only/route-decision-task_class all exempt; a real build worker with a broken report still gets `report_contract_invalid`; a dispatch_id containing "panel" mid-string (not as prefix) is NOT exempted.
- `tests/test_report_parser_contract.py` — 3 new tests: panel-seat and review-role success-claims are exempt; a real broken build-worker report still gets `report_contract_invalid`.
- `tests/test_contract_invalid_windowing.py` (new, 8 tests) — acceptance criterion #2: a tmp ledger with one 26-day-old frozen `contract_invalid` batch (36 entries, mirroring the measured seocrawler-v2 batch size) + one fresh real failure, run through `weekly_digest.collect_metrics()`, `learning_loop.extract_failure_patterns()`, and `check_active_drain.build_receipt_status_index()` — the frozen batch is excluded, the fresh failure still counts. Also covers: a fresh `contract_invalid` still counts; a receipt with no `timestamp` field still classifies as failure (regression guard, fail-open).
- Full targeted regression: every test file that imports any of the six touched/added modules (`report_contract_scope`, `report_to_receipt_converter`, `report_parser`, `weekly_digest`, `learning_loop`, `check_active_drain`, plus `phantom_guard`/`receipt_classifier`/`report_body_contract` which the classifier reuses/is sync-guarded against) — **507 passed** in the final clean run.
- Confirmed via `git stash` comparison against unmodified code: 5 failures seen in an earlier broader run (`test_auto_report_integration.py`, 3x `test_dispatcher_drain_lifecycle.py`, `test_receipt_classifier.py::test_provider_ollama_invokes_correct_cli`) are **pre-existing and unrelated** to this change (reproduce identically without these edits).
- `python3 -m py_compile` clean on all 10 touched/added files.
- `git ls-remote origin refs/heads/fix/report-contract-scope-exempt` confirms the push: `2e97af7179e9201e1f45f4aba5e194748bfdab47`.

## Open Items

- The full unmodified `tests/` suite (929 files) was not run to completion in this environment — several subdirectories (notably `tests/f39/`) spawn real `claude -p` headless subprocess calls (known billing-gated / opt-in per prior fleet decision) and made a full run impractically slow here. Regression coverage was instead scoped to every test file that actually imports the touched modules (507 passing tests) plus a stash-comparison of the failures seen in a broader partial run, all confirmed pre-existing.
- `~/.claude/skills/build-log/scripts/scan_proposals.py` (OI-188) also counts/scans historical batches but is explicitly out of scope per the dispatch spec — it's a skill-file outside this repo's lane; T0 handles it manually.
- The classifier's `role`/`task_class`/`read_only` signals depend on the worker having written them into the report body (bold-field or frontmatter) or on a `route_decisions/<dispatch_id>.json` existing (task_class fallback, `report_to_receipt_converter.py` only). Dispatch_id-prefix matching (`panel-`/`bench-`/`smoke-`) is the primary, always-available signal and covers the measured fleet data; the role/task_class paths are best-effort supplementary coverage.

Dispatch-ID: 20260716-report-contract-scope