### PR TITLE
feat(adr034-pr2): anchor-immutability CI, branch-protection check, fabric_audit wiring, seal-idempotency fix

### DIFF
--- a/.github/workflows/anchor-immutability-check.yml
+++ b/.github/workflows/anchor-immutability-check.yml
@@ -11,10 +11,32 @@
 # in scripts/lib/chain_origin_anchor.py is the pure diff logic this check
 # invokes.
 #
-# Trust-anchor safety (reuses attestation-gate.yml's base-branch-trust
-# pattern): the CHECKING CODE itself (chain_origin_anchor.py + its import
-# chain) is extracted from origin/main, never the PR tree — a PR that
-# weakened check_anchor_immutability cannot affect its own gate decision.
+# Trust-anchor safety, TWO layers (ADR-034 fix-r1, Finding 1):
+#
+#  1. Trigger is `pull_request_target`, NOT `pull_request`. GitHub always
+#     evaluates a `pull_request_target` workflow using the JOB DEFINITION
+#     committed on the base branch — never the PR's own copy of this YAML.
+#     Under the old `pull_request` trigger, a PR could rewrite this very
+#     file into a no-op job with the SAME required-check name (and tamper
+#     governance/chain-origin.ndjson in the same diff) and its own
+#     neutered workflow version is what would run — the check would
+#     "pass" while immutability was violated. `pull_request_target`
+#     closes that: the steps below are always the trusted, base-branch
+#     version, regardless of what the PR's tree contains.
+#
+#  2. Classic `pull_request_target` footgun avoidance: this job NEVER
+#     checks out the PR head into the working tree, and NEVER executes
+#     anything from PR-authored content. The default checkout (no `ref:`
+#     override) resolves to the BASE branch tip. The PR head commit is
+#     fetched as a bare git object and read ONLY via `git show <sha>:path`
+#     / `git diff` — i.e. raw blob bytes fed as DATA into
+#     check_anchor_immutability's pure JSON-line parser, never as code.
+#     The checking code itself (chain_origin_anchor.py + its import chain)
+#     is likewise extracted from origin/main, mirroring
+#     attestation-gate.yml's base-branch-trust pattern.
+#
+# `permissions: contents: read` scopes the token down to the minimum this
+# read-only check needs — this job never writes back to the repo.
 #
 # This job always runs on every PR (no path filter at the workflow level) so
 # it always reports a status — required-status-check semantics need a
@@ -32,7 +54,10 @@
 name: Anchor Immutability Check
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
 
 jobs:
   anchor-immutability:
@@ -40,13 +65,12 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Checkout PR head
+      - name: Checkout base branch (trusted — PR code is NEVER checked out or executed)
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
 
-      - name: Fetch base branch for trust anchor + diff
+      - name: Fetch origin/main (trust anchor + diff base)
         run: git fetch origin main
 
       - name: Setup Python
@@ -54,13 +78,22 @@ jobs:
         with:
           python-version: "3.11"
 
-      - name: Classify PR (touches governance/chain-origin.ndjson?)
-        id: classify
+      - name: Fetch PR head commit (bare object only — never checked out, never executed)
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
-          MERGE_BASE=$(git merge-base origin/main HEAD)
+          git fetch --no-tags origin "$HEAD_SHA"
 
-          CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+      - name: Classify PR (touches governance/chain-origin.ndjson?)
+        id: classify
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+          MERGE_BASE=$(git merge-base origin/main "$HEAD_SHA")
+
+          CHANGED=$(git diff --name-only "$MERGE_BASE" "$HEAD_SHA")
           echo "Changed files:"
           echo "$CHANGED"
 
@@ -89,12 +122,16 @@ jobs:
 
       - name: Extract base + head content of governance/chain-origin.ndjson
         if: steps.classify.outputs.classification == 'touched'
+        env:
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
         run: |
           set -euo pipefail
           # A missing base-side file (this PR's epoch is the ledger's
           # first-ever seal) is a legitimate empty-base case, not a failure.
+          # Both reads are raw blob content via `git show` — DATA, never
+          # checked out into a working tree and never executed.
           git show "origin/main:governance/chain-origin.ndjson" > /tmp/anchor_base.ndjson 2>/dev/null || : > /tmp/anchor_base.ndjson
-          git show "HEAD:governance/chain-origin.ndjson" > /tmp/anchor_head.ndjson
+          git show "$HEAD_SHA:governance/chain-origin.ndjson" > /tmp/anchor_head.ndjson
 
       - name: Run check_anchor_immutability (base-branch code, base vs head content)
         if: steps.classify.outputs.classification == 'touched'

--- a/.github/workflows/anchor-immutability-check.yml
+++ b/.github/workflows/anchor-immutability-check.yml
@@ -1,0 +1,126 @@
+# ADR-034 §3: Anchor immutability check — REQUIRED from commit one, NOT
+# continue-on-error (unlike attestation-gate.yml's staged-advisory rollout —
+# ADR §3 "C4" fix: an advisory-only write-side check is equivalent to no
+# write-side defense at all for this ADR's threat model).
+#
+# Diffs governance/chain-origin.ndjson between the PR's base (origin/main)
+# and head: any line whose {ledger_identity}#{epoch} (or ":close") key
+# already existed in the base-branch copy but changed content, or was
+# removed, fails the check. Only brand-new keys (an epoch's first-ever seal,
+# or its later closure record) may be appended — check_anchor_immutability()
+# in scripts/lib/chain_origin_anchor.py is the pure diff logic this check
+# invokes.
+#
+# Trust-anchor safety (reuses attestation-gate.yml's base-branch-trust
+# pattern): the CHECKING CODE itself (chain_origin_anchor.py + its import
+# chain) is extracted from origin/main, never the PR tree — a PR that
+# weakened check_anchor_immutability cannot affect its own gate decision.
+#
+# This job always runs on every PR (no path filter at the workflow level) so
+# it always reports a status — required-status-check semantics need a
+# consistent report, not a workflow that sometimes doesn't trigger at all.
+# Internally, the "classify" step exits early with a pass when
+# governance/chain-origin.ndjson isn't in this PR's diff at all — the
+# dispatch's "runs only when the file is in the diff" is the CHECK LOGIC's
+# scope, not the workflow trigger's.
+#
+# job name below MUST byte-match ANCHOR_IMMUTABILITY_CHECK_NAME in
+# scripts/lib/chain_origin_anchor.py — that constant is what
+# check_branch_protection() (ADR §6 step 2b) looks for in a repo's
+# required_status_checks.
+
+name: Anchor Immutability Check
+
+on:
+  pull_request:
+
+jobs:
+  anchor-immutability:
+    name: "Anchor Immutability Check"
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          fetch-depth: 0
+
+      - name: Fetch base branch for trust anchor + diff
+        run: git fetch origin main
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Classify PR (touches governance/chain-origin.ndjson?)
+        id: classify
+        run: |
+          set -euo pipefail
+          MERGE_BASE=$(git merge-base origin/main HEAD)
+
+          CHANGED=$(git diff --name-only "$MERGE_BASE" HEAD)
+          echo "Changed files:"
+          echo "$CHANGED"
+
+          if echo "$CHANGED" | grep -qx 'governance/chain-origin.ndjson'; then
+            echo "classification=touched" >> "$GITHUB_OUTPUT"
+            echo "::notice::Anchor Immutability Check: governance/chain-origin.ndjson is in this PR's diff — checking"
+          else
+            echo "classification=untouched" >> "$GITHUB_OUTPUT"
+            echo "::notice::Anchor Immutability Check: governance/chain-origin.ndjson not in this PR's diff — exempt"
+          fi
+
+      - name: Extract base-branch checker code (never trust the PR-tree copy)
+        if: steps.classify.outputs.classification == 'touched'
+        run: |
+          set -euo pipefail
+          # A PR that weakens check_anchor_immutability (or its imports)
+          # cannot affect its own gate decision — only the origin/main copy
+          # of the checking code is ever executed here.
+          VERIFIER_DIR="/tmp/vnx-anchor-verifier"
+          mkdir -p "$VERIFIER_DIR"
+          for f in chain_origin_anchor.py gh_pr_ensure.py ndjson_hash_chain.py; do
+            git show "origin/main:scripts/lib/$f" > "$VERIFIER_DIR/$f"
+            echo "Extracted $f from origin/main"
+          done
+          ls -la "$VERIFIER_DIR"
+
+      - name: Extract base + head content of governance/chain-origin.ndjson
+        if: steps.classify.outputs.classification == 'touched'
+        run: |
+          set -euo pipefail
+          # A missing base-side file (this PR's epoch is the ledger's
+          # first-ever seal) is a legitimate empty-base case, not a failure.
+          git show "origin/main:governance/chain-origin.ndjson" > /tmp/anchor_base.ndjson 2>/dev/null || : > /tmp/anchor_base.ndjson
+          git show "HEAD:governance/chain-origin.ndjson" > /tmp/anchor_head.ndjson
+
+      - name: Run check_anchor_immutability (base-branch code, base vs head content)
+        if: steps.classify.outputs.classification == 'touched'
+        run: |
+          set -euo pipefail
+          PYTHONPATH="/tmp/vnx-anchor-verifier" python3 - <<'PY'
+          import sys
+
+          sys.path.insert(0, "/tmp/vnx-anchor-verifier")
+          from chain_origin_anchor import check_anchor_immutability
+
+          with open("/tmp/anchor_base.ndjson", encoding="utf-8") as f:
+              base_content = f.read()
+          with open("/tmp/anchor_head.ndjson", encoding="utf-8") as f:
+              head_content = f.read()
+
+          violations = check_anchor_immutability(base_content, head_content)
+          if violations:
+              print("::error::governance/chain-origin.ndjson anchor-immutability violations found:")
+              for v in violations:
+                  print(f"::error::  key={v['key']!r} violation={v['violation']!r}")
+              print(
+                  f"::error::{len(violations)} existing anchor key(s) modified or removed — "
+                  "only brand-new keys may be appended (ADR-034 §3)."
+              )
+              sys.exit(1)
+
+          print("Anchor Immutability Check: PASS — no existing key modified or removed.")
+          PY

--- a/scripts/chain_branch_protection_check.py
+++ b/scripts/chain_branch_protection_check.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+"""CLI path for ADR-034 §6 step 2b's branch-protection activation precondition.
+
+A seal orchestration script runs this BEFORE calling
+``chain_origin_anchor.seal_and_commit_origin`` and only passes
+``branch_protection_confirmed=True`` when this exits 0. This is the caller-side
+verification that check is meant to defend: ``seal_and_commit_origin`` itself
+never shells out to `gh` — it only trusts an explicit caller-supplied
+confirmation.
+
+Usage:
+    python3 scripts/chain_branch_protection_check.py [--project-root PATH] [--branch main] [--json]
+
+Exit 0 when confirmed (required check present, enforce_admins on, force-pushes
+blocked); exit 1 otherwise — fail-closed, same as ``verify_chain``'s "can't
+check is never assume fine" contract.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+from chain_origin_anchor import (  # type: ignore[import]  # noqa: E402
+    ANCHOR_IMMUTABILITY_CHECK_NAME,
+    check_branch_protection,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    ap = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--project-root", default=".", type=Path, help="repo root (default: cwd)")
+    ap.add_argument("--branch", default="main", help="branch to check (default: main)")
+    ap.add_argument(
+        "--check-name",
+        default=ANCHOR_IMMUTABILITY_CHECK_NAME,
+        help="required-status-check name to look for (default: the anchor-immutability check's job name)",
+    )
+    ap.add_argument(
+        "--owner-repo",
+        default=None,
+        help="explicit 'owner/repo' (default: resolved from the project's 'origin' remote)",
+    )
+    ap.add_argument("--json", action="store_true", help="emit JSON instead of a human-readable line")
+    args = ap.parse_args(argv)
+
+    status = check_branch_protection(
+        args.project_root.resolve(),
+        args.branch,
+        required_check_name=args.check_name,
+        owner_repo=args.owner_repo,
+    )
+
+    if args.json:
+        print(json.dumps(status.__dict__, indent=2))
+    else:
+        verdict = "CONFIRMED" if status.confirmed else "NOT CONFIRMED"
+        print(
+            f"[{verdict}] {status.owner_repo or '?'}@{status.branch}: "
+            f"required_check={status.required_check_present} "
+            f"enforce_admins={status.enforce_admins} "
+            f"force_pushes_blocked={status.force_pushes_blocked}"
+        )
+        if status.reason:
+            print(f"  reason: {status.reason}")
+
+    return 0 if status.confirmed else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -28,6 +28,19 @@ Checks (each GREEN / RED / SKIP):
      (chaining not yet enabled) is reported OK — ADR-023 is PARTIAL by design.
      "verified" is GREEN; "broken" (tamper / partial chain) is RED.
 
+  D. Chain-origin anchor provenance (ADR-034).
+     The anchor-aware verify_chain() (scripts/lib/chain_origin_anchor.py) on
+     each project's `state/t0_receipts.ndjson`, run against that project's OWN
+     repo (the registry's `path`) as `project_root`. Additive to check C, not
+     a replacement — ADR-034 §6 step 3 (flipping check C's OWN verify_chain
+     call to the anchor-aware, fail-closed contract) is a separate, later
+     migration gated on step 2b's per-project branch-protection precondition.
+     This section surfaces AnchorProvenance (ref, anchor_commit_sha,
+     remote_url) for every checked ledger and goes RED on "broken" — which
+     includes the reverse-direction case (a git anchor exists for a ledger
+     that is now missing/empty/unchained), catching a deleted-then-reset
+     ledger that check C alone would still read as a clean "unchained".
+
 Exit 0 when no RED finding, 1 otherwise. `--json` for scripting.
 """
 from __future__ import annotations
@@ -47,6 +60,10 @@ try:
     from ndjson_hash_chain import verify_chain  # type: ignore
 except Exception:  # pragma: no cover - import guard
     verify_chain = None  # type: ignore
+try:
+    from chain_origin_anchor import verify_chain as anchor_verify_chain  # type: ignore
+except Exception:  # pragma: no cover - import guard
+    anchor_verify_chain = None  # type: ignore
 
 # Directory names at the data-home root that are shared/legacy by construction,
 # never a project-id. `state` holding *.db is the hard split-brain signal.
@@ -308,12 +325,86 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
     )
 
 
+def check_anchor_provenance(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
+    if anchor_verify_chain is None:
+        # Same convention as check C: a verifier that fails to import must
+        # not read as a silent SKIP — the audit cannot vouch for anchor
+        # provenance, so surface it.
+        return CheckResult(
+            "D", "Chain-origin anchor provenance (ADR-034)", "WARN",
+            "anchor verifier (chain_origin_anchor.verify_chain) could not be imported — anchors NOT checked",
+        )
+    if not projects:
+        return CheckResult("D", "Chain-origin anchor provenance (ADR-034)", "SKIP", "no registered projects")
+
+    findings = []
+    broken_projects = []
+    verified = 0
+    unchained = 0
+    checked = 0
+    for pid, path in projects:
+        ledger = data_home / pid / "state" / "t0_receipts.ndjson"
+        if not ledger.exists():
+            continue
+        project_root = Path(path) if path else None
+        if project_root is None or not project_root.is_dir():
+            # No resolvable repo for this project — nothing to anchor-check
+            # against (verify_chain requires project_root, ADR §2).
+            continue
+        checked += 1
+        try:
+            _is_valid, violations, status, provenance = anchor_verify_chain(
+                ledger,
+                project_root=project_root,
+                project_id=pid,
+                project_data_dir=data_home / pid,
+            )
+        except Exception as exc:
+            broken_projects.append(pid)
+            findings.append({"project": pid, "status": "error", "error": f"{type(exc).__name__}: {exc}"})
+            continue
+        finding = {
+            "project": pid,
+            "status": status,
+            "anchor_ref": provenance.ref if provenance else None,
+            "anchor_commit_sha": provenance.anchor_commit_sha if provenance else None,
+            "remote_url": provenance.remote_url if provenance else None,
+        }
+        if status in ("verified", "verified-segmented"):
+            verified += 1
+        elif status == "unchained":
+            unchained += 1
+        else:  # broken
+            broken_projects.append(pid)
+            finding["violations"] = len(violations)
+        findings.append(finding)
+
+    if broken_projects:
+        names = ", ".join(broken_projects)
+        return CheckResult(
+            "D", "Chain-origin anchor provenance (ADR-034)", "RED",
+            f"broken anchor verification in: {names} (verified={verified}, unchained={unchained})",
+            findings,
+        )
+    if checked == 0:
+        return CheckResult(
+            "D", "Chain-origin anchor provenance (ADR-034)", "SKIP",
+            "no t0_receipts.ndjson found with a resolvable project repo",
+        )
+    return CheckResult(
+        "D", "Chain-origin anchor provenance (ADR-034)", "GREEN",
+        f"{checked} ledgers ok (verified={verified}, unchained={unchained} — ADR-034)",
+        findings,
+    )
+
+
 def run_audit(data_home: Path, registry_file: Path) -> list[CheckResult]:
     projects, registry_error = _load_project_ids(registry_file)
     return [
         check_shared_root_state(data_home),
         check_per_project_stores(data_home, projects, registry_error),
         check_hash_chains(data_home, projects),
+        check_anchor_provenance(data_home, projects),
     ]
 
 

--- a/scripts/fabric_audit.py
+++ b/scripts/fabric_audit.py
@@ -327,11 +327,15 @@ def check_hash_chains(data_home: Path, projects: list[tuple[str, str]]) -> Check
 
 def check_anchor_provenance(data_home: Path, projects: list[tuple[str, str]]) -> CheckResult:
     if anchor_verify_chain is None:
-        # Same convention as check C: a verifier that fails to import must
-        # not read as a silent SKIP — the audit cannot vouch for anchor
-        # provenance, so surface it.
+        # Finding 4 (ADR-034 fix-r1): RED, not WARN. WARN is non-blocking
+        # (main() only fails on a RED finding) — an anchor verifier that
+        # can't even import means the anchor-provenance audit did NOT run at
+        # all, which must never let the overall audit exit 0. Unlike check
+        # C's underlying chain-integrity verifier (a long-standing, always-
+        # available import), this is the anchor check's OWN verifier — its
+        # absence is exactly the failure this specific check exists to catch.
         return CheckResult(
-            "D", "Chain-origin anchor provenance (ADR-034)", "WARN",
+            "D", "Chain-origin anchor provenance (ADR-034)", "RED",
             "anchor verifier (chain_origin_anchor.verify_chain) could not be imported — anchors NOT checked",
         )
     if not projects:
@@ -344,13 +348,26 @@ def check_anchor_provenance(data_home: Path, projects: list[tuple[str, str]]) ->
     checked = 0
     for pid, path in projects:
         ledger = data_home / pid / "state" / "t0_receipts.ndjson"
-        if not ledger.exists():
-            continue
         project_root = Path(path) if path else None
-        if project_root is None or not project_root.is_dir():
-            # No resolvable repo for this project — nothing to anchor-check
-            # against (verify_chain requires project_root, ADR §2).
+        if project_root is None or not project_root.is_dir() or not (project_root / ".git").exists():
+            # No resolvable GIT repo for this project — nothing to
+            # anchor-check against (verify_chain requires a real git
+            # checkout, ADR §2). Checking for `.git` specifically (not just
+            # "is a directory") matters now that a missing ledger file no
+            # longer short-circuits this loop (Finding 3 below) — a
+            # registered project path that exists but was never actually
+            # cloned/initialized as a git repo must still SKIP, not fail
+            # anchor resolution and read as broken/RED.
             continue
+        # Finding 3 (ADR-034 fix-r1): do NOT skip on a missing ledger file
+        # here. A project whose t0_receipts.ndjson was deleted/reset but
+        # which has a committed anchor on origin for its identity must
+        # report "broken" (the reverse-direction case anchor_verify_chain
+        # already covers) — skipping before ever calling the anchor-aware
+        # verifier let that case fall through to SKIP/GREEN instead. A
+        # genuinely missing ledger with no anchor anywhere still resolves to
+        # "unchained" inside anchor_verify_chain itself (base verify_chain's
+        # own missing-file handling), so this is additive, not a false RED.
         checked += 1
         try:
             _is_valid, violations, status, provenance = anchor_verify_chain(
@@ -389,7 +406,7 @@ def check_anchor_provenance(data_home: Path, projects: list[tuple[str, str]]) ->
     if checked == 0:
         return CheckResult(
             "D", "Chain-origin anchor provenance (ADR-034)", "SKIP",
-            "no t0_receipts.ndjson found with a resolvable project repo",
+            "no registered project has a resolvable repo to anchor-check against",
         )
     return CheckResult(
         "D", "Chain-origin anchor provenance (ADR-034)", "GREEN",

--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -494,21 +494,50 @@ def _read_remote_base_anchor(
 
 
 def check_anchor_immutability(base_content: str, head_content: str) -> list[dict]:
-    """Pure diff-logic for ADR §3's write-side rule: any key present in BOTH
-    base and head whose content changed, or present in base but removed in
-    head, is a violation. Brand-new keys in head are allowed. This is the
-    LOGIC the PR-2 GitHub Actions check invokes (base branch vs PR head) — no
+    """Pure diff-logic for ADR §3's write-side rule: append-only means neither
+    an existing key may change content NOR may a key (existing or brand-new)
+    be introduced more than once in head. Any key present in BOTH base and
+    head whose content changed, present in base but removed in head, or
+    appearing MORE THAN ONCE in head, is a violation. This is the LOGIC the
+    PR-2 GitHub Actions check invokes (base branch vs PR head) — no
     CI/workflow wiring lives in this module.
+
+    Finding 5 (ADR-034 fix-r1): a naive last-write-wins dict comprehension
+    over head's lines silently drops earlier duplicate occurrences of the
+    same key — a PR could rewrite an existing key's line to forged content
+    and then re-append the ORIGINAL line for that same key afterward, so the
+    last occurrence (the one a dict comprehension keeps) matches base and no
+    "modified" violation is ever raised, even though main would end up with
+    two lines sharing one key (a duplicate/corrupt anchor once merged, per
+    ``read_git_anchor``'s own "more than one match = corrupt" contract).
+    Counting occurrences per key in head, rather than collapsing to a dict,
+    catches that regardless of which occurrence a naive lookup would keep.
     """
-    base_by_key = {raw["key"]: raw for raw in _iter_anchor_lines(base_content) if "key" in raw}
-    head_by_key = {raw["key"]: raw for raw in _iter_anchor_lines(head_content) if "key" in raw}
+    base_by_key: dict[str, dict] = {}
+    for raw in _iter_anchor_lines(base_content):
+        if "key" in raw:
+            base_by_key[raw["key"]] = raw
+
+    head_occurrences: dict[str, list[dict]] = {}
+    for raw in _iter_anchor_lines(head_content):
+        if "key" in raw:
+            head_occurrences.setdefault(raw["key"], []).append(raw)
 
     violations: list[dict] = []
-    for key, base_record in base_by_key.items():
-        if key not in head_by_key:
+    for key in sorted(set(base_by_key) | set(head_occurrences)):
+        base_record = base_by_key.get(key)
+        occurrences = head_occurrences.get(key, [])
+
+        if base_record is not None and not occurrences:
             violations.append({"key": key, "violation": "removed"})
-        elif head_by_key[key] != base_record:
+            continue
+
+        if len(occurrences) > 1:
+            violations.append({"key": key, "violation": "duplicated"})
+
+        if base_record is not None and any(occ != base_record for occ in occurrences):
             violations.append({"key": key, "violation": "modified"})
+
     return violations
 
 
@@ -562,6 +591,11 @@ def check_branch_protection(
        residual is explicitly what this closes for the anchor check specifically).
     3. ``allow_force_pushes.enabled`` is false — a force-push could otherwise
        rewrite the anchor branch's history out from under the required check.
+       Only an EXPLICIT ``allow_force_pushes.enabled == False`` counts as
+       blocked; a missing key, a missing ``allow_force_pushes`` object, or a
+       non-boolean value is treated as force-pushes NOT blocked (fail-closed,
+       Finding 2 ADR-034 fix-r1) — an unparseable field must never be read as
+       the safe answer.
 
     Fail-CLOSED on anything that prevents a real answer — an unresolvable
     owner/repo, a `gh` failure (auth/network/404-unprotected), a malformed
@@ -644,7 +678,16 @@ def check_branch_protection(
     required_check_present = required_check_name in contexts
 
     enforce_admins = bool((payload.get("enforce_admins") or {}).get("enabled"))
-    force_pushes_blocked = not bool((payload.get("allow_force_pushes") or {}).get("enabled"))
+
+    # Fail-closed (Finding 2, ADR-034 fix-r1): only an explicit boolean
+    # `False` counts as "force-pushes blocked". A missing key, a missing
+    # `allow_force_pushes` object, or a non-boolean value must NOT be read as
+    # blocked — the prior `not bool(...get("enabled"))` treated all of those
+    # as `not bool(None)` == True == blocked, i.e. fail-OPEN on the one field
+    # this function exists to gate on.
+    allow_force_pushes = payload.get("allow_force_pushes")
+    force_pushes_enabled = allow_force_pushes.get("enabled") if isinstance(allow_force_pushes, dict) else None
+    force_pushes_blocked = isinstance(force_pushes_enabled, bool) and force_pushes_enabled is False
 
     confirmed = required_check_present and enforce_admins and force_pushes_blocked
     reason: str | None = None

--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -19,6 +19,7 @@ caller explicitly invokes it; landing this file changes no runtime behavior.
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 import sys as _sys
 from dataclasses import dataclass
@@ -43,6 +44,13 @@ from ndjson_hash_chain import verify_chain as _base_verify_chain  # noqa: E402
 
 
 ANCHOR_REL_PATH = Path("governance/chain-origin.ndjson")  # NOT under docs/ — see ADR §3 placement note
+
+# Must byte-match the `name:` of the job in
+# .github/workflows/anchor-immutability-check.yml — that job name IS the
+# GitHub required-status-check "context" that check_branch_protection() looks
+# for in required_status_checks. Keep both in sync by hand; there is no single
+# source both sides can import from (one is Python, the other YAML).
+ANCHOR_IMMUTABILITY_CHECK_NAME = "Anchor Immutability Check"
 
 
 class BranchProtectionUnconfirmedError(RuntimeError):
@@ -123,6 +131,24 @@ class SealResult:
     branch_name: str | None
     pr_url: str | None
     closed_epoch: int | None
+
+
+@dataclass(frozen=True)
+class BranchProtectionStatus:
+    """Result of the ADR §6 step 2b activation-precondition check (PR-2 scope).
+
+    ``confirmed`` is the ONLY field a caller should branch on to decide
+    whether ``seal_and_commit_origin(branch_protection_confirmed=...)`` may be
+    passed ``True`` — the other fields are diagnostic detail for ``reason``.
+    """
+
+    confirmed: bool
+    owner_repo: str | None
+    branch: str
+    required_check_present: bool
+    enforce_admins: bool
+    force_pushes_blocked: bool
+    reason: str | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -487,6 +513,163 @@ def check_anchor_immutability(base_content: str, head_content: str) -> list[dict
 
 
 # ---------------------------------------------------------------------------
+# Branch-protection precondition (ADR §6 step 2b, PR-2 scope)
+#
+# The caller-side check that may set seal_and_commit_origin's
+# branch_protection_confirmed=True. seal_and_commit_origin itself never shells
+# out to `gh` — it only trusts an explicit caller-supplied confirmation
+# (BranchProtectionUnconfirmedError above) — so a seal orchestration script
+# must call check_branch_protection() (or the CLI wrapper,
+# scripts/chain_branch_protection_check.py) first and pass its `.confirmed`
+# through.
+# ---------------------------------------------------------------------------
+
+
+def _owner_repo_from_remote(project_root: Path, remote: str = "origin") -> str | None:
+    """Resolve 'owner/repo' from `remote`'s URL (https or ssh form). None if the
+    remote isn't configured or its URL isn't a recognizable GitHub URL."""
+    proc = _git_run(project_root, "remote", "get-url", remote)
+    if proc.returncode != 0:
+        return None
+    url = proc.stdout.strip()
+    match = re.search(r"github\.com[:/]+([^/]+)/(.+?)(?:\.git)?/?$", url)
+    if not match:
+        return None
+    return f"{match.group(1)}/{match.group(2)}"
+
+
+def check_branch_protection(
+    project_root: Path,
+    branch: str = "main",
+    *,
+    required_check_name: str = ANCHOR_IMMUTABILITY_CHECK_NAME,
+    owner_repo: str | None = None,
+    timeout: int = 20,
+) -> BranchProtectionStatus:
+    """ADR §6 step 2b's machine-checkable activation precondition: is `branch`'s
+    GitHub branch protection ACTUALLY configured — not merely assumed — with
+    the anchor-immutability check required and enforce_admins on?
+
+    Calls ``gh api repos/{owner}/{repo}/branches/{branch}/protection`` (the
+    same endpoint ``scripts/commands/protect_branch.sh --show`` already uses)
+    and checks three things, ALL required for ``confirmed=True``:
+
+    1. ``required_check_name`` appears in ``required_status_checks`` — checked
+       against both the legacy ``contexts`` list and the newer ``checks[].context``
+       list, since GitHub has shipped both shapes over time.
+    2. ``enforce_admins.enabled`` is true — an admin/owner credential is bound
+       by the check too, not just ordinary contributors (ADR §5's admin-bypass
+       residual is explicitly what this closes for the anchor check specifically).
+    3. ``allow_force_pushes.enabled`` is false — a force-push could otherwise
+       rewrite the anchor branch's history out from under the required check.
+
+    Fail-CLOSED on anything that prevents a real answer — an unresolvable
+    owner/repo, a `gh` failure (auth/network/404-unprotected), a malformed
+    response, or `gh` not being installed all resolve ``confirmed=False`` with
+    ``reason`` set. Mirrors §2's "can't check is never assume fine": this
+    function never returns ``confirmed=True`` on anything less than a
+    positively-parsed, all-three-conditions-met response.
+    """
+    resolved_owner_repo = owner_repo or _owner_repo_from_remote(project_root)
+    if not resolved_owner_repo:
+        return BranchProtectionStatus(
+            confirmed=False,
+            owner_repo=None,
+            branch=branch,
+            required_check_present=False,
+            enforce_admins=False,
+            force_pushes_blocked=False,
+            reason="could not resolve owner/repo from git remote 'origin' (not a GitHub remote, or remote missing)",
+        )
+
+    try:
+        proc = subprocess.run(
+            ["gh", "api", f"repos/{resolved_owner_repo}/branches/{branch}/protection"],
+            capture_output=True,
+            text=True,
+            timeout=timeout,
+            cwd=str(project_root),
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return BranchProtectionStatus(
+            confirmed=False,
+            owner_repo=resolved_owner_repo,
+            branch=branch,
+            required_check_present=False,
+            enforce_admins=False,
+            force_pushes_blocked=False,
+            reason=f"gh api invocation failed: {type(exc).__name__}: {exc}",
+        )
+
+    if proc.returncode != 0:
+        return BranchProtectionStatus(
+            confirmed=False,
+            owner_repo=resolved_owner_repo,
+            branch=branch,
+            required_check_present=False,
+            enforce_admins=False,
+            force_pushes_blocked=False,
+            reason=f"gh api branch-protection lookup failed (rc={proc.returncode}): "
+            f"{(proc.stderr or '').strip()[:300]}",
+        )
+
+    try:
+        payload = json.loads(proc.stdout)
+    except json.JSONDecodeError as exc:
+        return BranchProtectionStatus(
+            confirmed=False,
+            owner_repo=resolved_owner_repo,
+            branch=branch,
+            required_check_present=False,
+            enforce_admins=False,
+            force_pushes_blocked=False,
+            reason=f"malformed gh api response: {exc}",
+        )
+    if not isinstance(payload, dict):
+        return BranchProtectionStatus(
+            confirmed=False,
+            owner_repo=resolved_owner_repo,
+            branch=branch,
+            required_check_present=False,
+            enforce_admins=False,
+            force_pushes_blocked=False,
+            reason=f"unexpected gh api response shape: {type(payload).__name__}",
+        )
+
+    required_status_checks = payload.get("required_status_checks") or {}
+    contexts: set[str] = set(required_status_checks.get("contexts") or [])
+    for check in required_status_checks.get("checks") or []:
+        if isinstance(check, dict) and check.get("context"):
+            contexts.add(check["context"])
+    required_check_present = required_check_name in contexts
+
+    enforce_admins = bool((payload.get("enforce_admins") or {}).get("enabled"))
+    force_pushes_blocked = not bool((payload.get("allow_force_pushes") or {}).get("enabled"))
+
+    confirmed = required_check_present and enforce_admins and force_pushes_blocked
+    reason: str | None = None
+    if not confirmed:
+        missing = []
+        if not required_check_present:
+            missing.append(f"required check {required_check_name!r} not in required_status_checks")
+        if not enforce_admins:
+            missing.append("enforce_admins not enabled")
+        if not force_pushes_blocked:
+            missing.append("force-pushes not blocked")
+        reason = "; ".join(missing)
+
+    return BranchProtectionStatus(
+        confirmed=confirmed,
+        owner_repo=resolved_owner_repo,
+        branch=branch,
+        required_check_present=required_check_present,
+        enforce_admins=enforce_admins,
+        force_pushes_blocked=force_pushes_blocked,
+        reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
 # Write side: seal_and_commit_origin (ADR §4, §7)
 # ---------------------------------------------------------------------------
 
@@ -554,12 +737,33 @@ def _commit_and_push_anchor(
     failures DO raise (RuntimeError via _git_run_checked): a half-sealed
     ledger with no anchor commit must read as `broken` per verify_chain's
     fail-closed contract, never silently swallowed (ADR §4).
+
+    Working-tree append is idempotent (PR-2 seal-idempotency fix, deferred
+    from PR-1 codex-regate-3): if the process crashes (or a later
+    checkout/add/commit call raises) AFTER this write but BEFORE the commit
+    lands, the dirty working tree carries `records` that HEAD does not — and
+    `seal_and_commit_origin`'s own noop/resume check only reads HEAD (via
+    `_read_local_head_anchor`), so it cannot see the leftover and would
+    re-append the same records on retry, producing two lines for the same key
+    once a commit eventually lands (`read_git_anchor` then reports
+    "corrupt"). Reading whatever is already on disk first and skipping keys
+    already present closes that regardless of exactly when the crash landed.
     """
     anchor_path = project_root / ANCHOR_REL_PATH
     anchor_path.parent.mkdir(parents=True, exist_ok=True)
-    with anchor_path.open("a", encoding="utf-8") as f:
-        for record in records:
-            f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
+
+    existing_keys: set[str] = set()
+    if anchor_path.exists():
+        existing_keys = {
+            raw["key"]
+            for raw in _iter_anchor_lines(anchor_path.read_text(encoding="utf-8"))
+            if "key" in raw
+        }
+    new_records = [record for record in records if record["key"] not in existing_keys]
+    if new_records:
+        with anchor_path.open("a", encoding="utf-8") as f:
+            for record in new_records:
+                f.write(json.dumps(record, sort_keys=True, separators=(",", ":")) + "\n")
 
     branch_name = _seal_branch_name(identity, epoch)
 

--- a/tests/test_anchor_immutability_workflow.py
+++ b/tests/test_anchor_immutability_workflow.py
@@ -1,0 +1,82 @@
+"""Structural regression tests for
+.github/workflows/anchor-immutability-check.yml (ADR-034 §3).
+
+These are not a real GitHub Actions run (dispatch item 5: "workflow-gedrag
+via de check-functie, niet via een echte GitHub-run" — the check-function
+behavior itself is exercised directly against
+chain_origin_anchor.check_anchor_immutability in
+tests/test_chain_origin_anchor.py's T6/T7). This file guards the properties
+the ADR requires of the WORKFLOW WIRING specifically: the job name matches
+the Python-side constant the branch-protection check looks for, the check is
+NOT continue-on-error (required from commit one, unlike attestation-gate.yml's
+own staged-advisory precedent — ADR §3 "C4" fix), the workflow parses as
+valid YAML, and it triggers on every pull_request (no path filter — a
+required status check needs the workflow to always report, ADR §3 note).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+from chain_origin_anchor import ANCHOR_IMMUTABILITY_CHECK_NAME  # noqa: E402
+
+WORKFLOW_PATH = (
+    Path(__file__).resolve().parents[1] / ".github" / "workflows" / "anchor-immutability-check.yml"
+)
+
+
+def test_workflow_file_exists():
+    assert WORKFLOW_PATH.is_file()
+
+
+def test_workflow_yaml_parses():
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert "jobs" in data
+    assert "anchor-immutability" in data["jobs"]
+
+
+def test_workflow_job_name_matches_python_constant():
+    """This job's `name:` IS the GitHub required-status-check "context" that
+    check_branch_protection() (ADR §6 step 2b) looks for — drift here would
+    make the branch-protection precondition unsatisfiable even when the
+    workflow itself is correctly required."""
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert f'name: "{ANCHOR_IMMUTABILITY_CHECK_NAME}"' in content
+
+
+def test_workflow_is_not_continue_on_error():
+    """ADR §3 "C4": required from commit one — NOT the staged-advisory pattern
+    attestation-gate.yml uses (continue-on-error: true). An advisory-only
+    write-side check is equivalent to no write-side defense for this ADR's
+    threat model."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job = data["jobs"]["anchor-immutability"]
+    assert "continue-on-error" not in job
+
+
+def test_workflow_triggers_on_every_pull_request_no_path_filter():
+    """No `paths:` filter at the workflow level — the job must always run (and
+    always report a status) so it can function as a required check; the
+    file-touched classification happens INSIDE the job, not via a trigger
+    filter that could make the workflow silently not run for some PRs."""
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "\non:\n  pull_request:" in content
+    assert "paths:" not in content
+
+
+def test_workflow_extracts_checker_code_from_base_branch_not_pr_head():
+    """Trust-anchor safety: the checking code must be extracted from
+    origin/main, mirroring attestation-gate.yml's base-branch-trust pattern —
+    a PR cannot weaken check_anchor_immutability and have that weakened copy
+    used to evaluate itself."""
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert 'git show "origin/main:scripts/lib/$f"' in content
+    assert "chain_origin_anchor.py" in content
+
+
+def test_workflow_invokes_check_anchor_immutability():
+    content = WORKFLOW_PATH.read_text(encoding="utf-8")
+    assert "check_anchor_immutability" in content

--- a/tests/test_anchor_immutability_workflow.py
+++ b/tests/test_anchor_immutability_workflow.py
@@ -12,6 +12,18 @@ NOT continue-on-error (required from commit one, unlike attestation-gate.yml's
 own staged-advisory precedent — ADR §3 "C4" fix), the workflow parses as
 valid YAML, and it triggers on every pull_request (no path filter — a
 required status check needs the workflow to always report, ADR §3 note).
+
+ADR-034 fix-r1 Finding 1: the trigger is `pull_request_target`, not
+`pull_request` — GitHub always runs a `pull_request_target` workflow using
+the JOB DEFINITION committed on the BASE branch, never the PR's own copy of
+this YAML. Under the old `pull_request` trigger a PR could rewrite this file
+into a no-op job with the same required-check name while also tampering
+governance/chain-origin.ndjson in the same diff, and its own neutered
+workflow version — not this one — is what GitHub would run. The tests below
+also guard the classic `pull_request_target` footgun: this job must never
+check out the PR head into the working tree or execute anything from it —
+the head commit may only be read as raw blob content via `git show`/`git
+diff`.
 """
 from __future__ import annotations
 
@@ -57,14 +69,41 @@ def test_workflow_is_not_continue_on_error():
     assert "continue-on-error" not in job
 
 
-def test_workflow_triggers_on_every_pull_request_no_path_filter():
-    """No `paths:` filter at the workflow level — the job must always run (and
+def test_workflow_triggers_on_pull_request_target_no_path_filter():
+    """`pull_request_target`, not `pull_request` (Finding 1, ADR-034 fix-r1):
+    GitHub always evaluates this workflow using the base-branch's copy of the
+    job steps, so a PR cannot neutralize its own gate by editing this file.
+    No `paths:` filter at the workflow level — the job must always run (and
     always report a status) so it can function as a required check; the
     file-touched classification happens INSIDE the job, not via a trigger
     filter that could make the workflow silently not run for some PRs."""
     content = WORKFLOW_PATH.read_text(encoding="utf-8")
-    assert "\non:\n  pull_request:" in content
+    assert "\non:\n  pull_request_target:" in content
     assert "paths:" not in content
+
+
+def test_workflow_never_checks_out_pr_head_ref():
+    """Classic `pull_request_target` footgun: checking out attacker-controlled
+    PR code and running it with the base branch's token. Every
+    `actions/checkout` step must resolve to the default (base-branch) ref —
+    none may point `ref:` at the PR head SHA. The head commit is only ever
+    read as raw blob content via `git show`/`git diff` further down, never
+    checked into the working tree or executed."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    job = data["jobs"]["anchor-immutability"]
+    for step in job["steps"]:
+        if str(step.get("uses", "")).startswith("actions/checkout"):
+            ref = str((step.get("with") or {}).get("ref", ""))
+            assert "head" not in ref, f"checkout step must not reference the PR head: {step}"
+
+
+def test_workflow_declares_minimal_read_only_permissions():
+    """`pull_request_target` inherits the repo's default token permissions
+    unless scoped down explicitly — this job never writes back to the repo,
+    so it declares `contents: read` (defense in depth alongside the
+    never-checkout-PR-head rule above)."""
+    data = yaml.safe_load(WORKFLOW_PATH.read_text(encoding="utf-8"))
+    assert data.get("permissions") == {"contents": "read"}
 
 
 def test_workflow_extracts_checker_code_from_base_branch_not_pr_head():

--- a/tests/test_chain_branch_protection_check.py
+++ b/tests/test_chain_branch_protection_check.py
@@ -104,6 +104,49 @@ def test_force_pushes_allowed_fails_closed(monkeypatch):
     assert "force-push" in (status.reason or "")
 
 
+def test_missing_allow_force_pushes_key_fails_closed(monkeypatch):
+    """Finding 2 (ADR-034 fix-r1): a payload with the required check present
+    and enforce_admins on, but NO `allow_force_pushes` key at all, must fail
+    closed — not silently read as "force-pushes blocked"."""
+    payload = {
+        "required_status_checks": {
+            "strict": True, "contexts": [ANCHOR_IMMUTABILITY_CHECK_NAME], "checks": [],
+        },
+        "enforce_admins": {"enabled": True},
+        # no "allow_force_pushes" key at all
+    }
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert status.force_pushes_blocked is False
+    assert "force-push" in (status.reason or "")
+
+
+def test_unparseable_allow_force_pushes_enabled_fails_closed(monkeypatch):
+    """`allow_force_pushes.enabled` present but not a boolean (malformed API
+    response) must also fail closed, not be coerced into "blocked"."""
+    payload = {
+        "required_status_checks": {
+            "strict": True, "contexts": [ANCHOR_IMMUTABILITY_CHECK_NAME], "checks": [],
+        },
+        "enforce_admins": {"enabled": True},
+        "allow_force_pushes": {"enabled": None},
+    }
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert status.force_pushes_blocked is False
+    assert "force-push" in (status.reason or "")
+
+
 # ---------------------------------------------------------------------------
 # Fail-closed on anything that prevents a real answer
 # ---------------------------------------------------------------------------

--- a/tests/test_chain_branch_protection_check.py
+++ b/tests/test_chain_branch_protection_check.py
@@ -1,0 +1,245 @@
+"""Tests for ADR-034 §6 step 2b's branch-protection activation precondition:
+``chain_origin_anchor.check_branch_protection`` / ``_owner_repo_from_remote``,
+and the CLI wrapper ``scripts/chain_branch_protection_check.py``.
+
+Mocks `gh api` output — no network, no real GitHub access. Covers the
+dispatch's required cases: protected-with-check, protected-without-check,
+unprotected, and api-error (all except the first must fail closed, mirroring
+verify_chain's "can't check is never assume fine" contract).
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import chain_origin_anchor as coa  # noqa: E402
+from chain_origin_anchor import ANCHOR_IMMUTABILITY_CHECK_NAME, check_branch_protection  # noqa: E402
+
+import chain_branch_protection_check as cli  # noqa: E402
+
+
+class _FakeCompletedProcess:
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = ""):
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _protection_payload(*, check_present: bool, enforce_admins: bool, force_pushes_blocked: bool) -> dict:
+    contexts = [ANCHOR_IMMUTABILITY_CHECK_NAME] if check_present else ["some-other-check"]
+    return {
+        "required_status_checks": {"strict": True, "contexts": contexts, "checks": []},
+        "enforce_admins": {"enabled": enforce_admins},
+        "allow_force_pushes": {"enabled": not force_pushes_blocked},
+    }
+
+
+def _run_git(*args: str, cwd) -> str:
+    result = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git {args} failed in {cwd}: {result.stderr}")
+    return result.stdout
+
+
+# ---------------------------------------------------------------------------
+# check_branch_protection — all three required conditions
+# ---------------------------------------------------------------------------
+
+
+def test_protected_with_check_confirms(monkeypatch):
+    payload = _protection_payload(check_present=True, enforce_admins=True, force_pushes_blocked=True)
+
+    def fake_run(cmd, **kwargs):
+        assert cmd[:2] == ["gh", "api"]
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is True
+    assert status.required_check_present is True
+    assert status.enforce_admins is True
+    assert status.force_pushes_blocked is True
+    assert status.reason is None
+
+
+def test_protected_without_required_check_fails_closed(monkeypatch):
+    payload = _protection_payload(check_present=False, enforce_admins=True, force_pushes_blocked=True)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert status.required_check_present is False
+    assert "required check" in (status.reason or "")
+
+
+def test_enforce_admins_off_fails_closed(monkeypatch):
+    payload = _protection_payload(check_present=True, enforce_admins=False, force_pushes_blocked=True)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "enforce_admins" in (status.reason or "")
+
+
+def test_force_pushes_allowed_fails_closed(monkeypatch):
+    payload = _protection_payload(check_present=True, enforce_admins=True, force_pushes_blocked=False)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "force-push" in (status.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed on anything that prevents a real answer
+# ---------------------------------------------------------------------------
+
+
+def test_unprotected_branch_fails_closed(monkeypatch):
+    """gh api returns non-zero (404) when a branch has no protection at all."""
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(1, stdout="", stderr='{"message":"Branch not protected","status":"404"}')
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "branch-protection lookup failed" in (status.reason or "")
+
+
+def test_api_timeout_fails_closed(monkeypatch):
+    """A transient gh failure (auth/network) must never read as confirmed."""
+
+    def fake_run(cmd, **kwargs):
+        raise subprocess.TimeoutExpired(cmd, 20)
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "gh api invocation failed" in (status.reason or "")
+
+
+def test_gh_not_installed_fails_closed(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        raise FileNotFoundError("gh: command not found")
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "gh api invocation failed" in (status.reason or "")
+
+
+def test_malformed_json_response_fails_closed(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout="not json")
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "malformed" in (status.reason or "")
+
+
+def test_non_dict_json_response_fails_closed(monkeypatch):
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout="[1, 2, 3]")
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    status = check_branch_protection(Path("/tmp"), "main", owner_repo="acme/repo")
+    assert status.confirmed is False
+    assert "unexpected gh api response shape" in (status.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# owner/repo resolution from the git remote
+# ---------------------------------------------------------------------------
+
+
+def test_owner_repo_resolved_from_github_https_remote(tmp_path):
+    _run_git("init", "-b", "main", str(tmp_path), cwd=tmp_path.parent)
+    _run_git("remote", "add", "origin", "https://github.com/Vinix24/vnx-orchestration.git", cwd=tmp_path)
+    resolved = coa._owner_repo_from_remote(tmp_path)
+    assert resolved == "Vinix24/vnx-orchestration"
+
+
+def test_owner_repo_resolved_from_github_ssh_remote(tmp_path):
+    _run_git("init", "-b", "main", str(tmp_path), cwd=tmp_path.parent)
+    _run_git("remote", "add", "origin", "git@github.com:Vinix24/vnx-orchestration.git", cwd=tmp_path)
+    resolved = coa._owner_repo_from_remote(tmp_path)
+    assert resolved == "Vinix24/vnx-orchestration"
+
+
+def test_owner_repo_none_for_non_github_remote(tmp_path):
+    _run_git("init", "-b", "main", str(tmp_path), cwd=tmp_path.parent)
+    _run_git("remote", "add", "origin", "/some/local/path/repo.git", cwd=tmp_path)
+    resolved = coa._owner_repo_from_remote(tmp_path)
+    assert resolved is None
+
+
+def test_owner_repo_none_when_remote_missing(tmp_path):
+    _run_git("init", "-b", "main", str(tmp_path), cwd=tmp_path.parent)
+    resolved = coa._owner_repo_from_remote(tmp_path)
+    assert resolved is None
+
+
+def test_no_resolvable_owner_repo_fails_closed(tmp_path):
+    _run_git("init", "-b", "main", str(tmp_path), cwd=tmp_path.parent)
+    status = check_branch_protection(tmp_path, "main")
+    assert status.confirmed is False
+    assert "could not resolve owner/repo" in (status.reason or "")
+
+
+# ---------------------------------------------------------------------------
+# CLI wrapper (scripts/chain_branch_protection_check.py)
+# ---------------------------------------------------------------------------
+
+
+def test_cli_exit_0_when_confirmed(monkeypatch, capsys):
+    payload = _protection_payload(check_present=True, enforce_admins=True, force_pushes_blocked=True)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    rc = cli.main(["--project-root", "/tmp", "--owner-repo", "acme/repo"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "CONFIRMED" in out
+
+
+def test_cli_exit_1_when_not_confirmed(monkeypatch, capsys):
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(1, stdout="", stderr="not found")
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    rc = cli.main(["--project-root", "/tmp", "--owner-repo", "acme/repo"])
+    assert rc == 1
+    out = capsys.readouterr().out
+    assert "NOT CONFIRMED" in out
+
+
+def test_cli_json_output(monkeypatch, capsys):
+    payload = _protection_payload(check_present=True, enforce_admins=True, force_pushes_blocked=True)
+
+    def fake_run(cmd, **kwargs):
+        return _FakeCompletedProcess(0, stdout=json.dumps(payload))
+
+    monkeypatch.setattr(coa.subprocess, "run", fake_run)
+    rc = cli.main(["--project-root", "/tmp", "--owner-repo", "acme/repo", "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["confirmed"] is True
+    assert out["owner_repo"] == "acme/repo"

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -590,6 +590,49 @@ def test_t7_immutability_check_accepts_new_key():
     assert check_anchor_immutability(base, head) == []
 
 
+def test_t8_immutability_check_rejects_forged_then_reappended_duplicate():
+    """Finding 5 (ADR-034 fix-r1): base has `id#1` once. Head rewrites that
+    line to FORGED content, then appends the ORIGINAL line for the same key
+    again afterward. A last-write-wins dict over head's lines would see the
+    final (original) occurrence, find it equal to base, and report no
+    violation at all — while main would end up with `id#1` duplicated
+    (corrupt per read_git_anchor's own contract) and having been forged in
+    between. Both the forgery and the duplication must be caught."""
+    base_record = {"key": "id#1", "ledger_identity": "id", "epoch": 1, "record_type": "open", "origin_hash": "aaa"}
+    forged_record = {**base_record, "origin_hash": "FORGED"}
+    base = json.dumps(base_record, sort_keys=True) + "\n"
+    head = (
+        json.dumps(forged_record, sort_keys=True)
+        + "\n"
+        + json.dumps(base_record, sort_keys=True)
+        + "\n"
+    )
+
+    violations = check_anchor_immutability(base, head)
+    assert {"key": "id#1", "violation": "duplicated"} in violations
+    assert {"key": "id#1", "violation": "modified"} in violations
+    assert len(violations) == 2
+
+
+def test_t8b_immutability_check_rejects_duplicated_brand_new_key():
+    """A brand-new key (never in base) introduced TWICE in head is also a
+    violation — append-only forbids introducing a duplicate key even when
+    the key itself has no prior history to modify."""
+    base_record = {"key": "id#1", "ledger_identity": "id", "epoch": 1, "record_type": "open"}
+    new_record = {"key": "id#2", "ledger_identity": "id", "epoch": 2, "record_type": "open"}
+    base = json.dumps(base_record, sort_keys=True) + "\n"
+    head = (
+        base
+        + json.dumps(new_record, sort_keys=True)
+        + "\n"
+        + json.dumps(new_record, sort_keys=True)
+        + "\n"
+    )
+
+    violations = check_anchor_immutability(base, head)
+    assert violations == [{"key": "id#2", "violation": "duplicated"}]
+
+
 # ---------------------------------------------------------------------------
 # T9-T11, T16: seal_and_commit_origin
 # ---------------------------------------------------------------------------

--- a/tests/test_chain_origin_anchor.py
+++ b/tests/test_chain_origin_anchor.py
@@ -776,6 +776,76 @@ def test_t16_seal_refuses_without_branch_protection_confirmed(git_repo, tmp_path
     assert len(ledger.read_text().splitlines()) == 1
 
 
+def test_seal_idempotency_crash_between_working_tree_write_and_commit_no_duplicate(
+    git_repo, tmp_path, monkeypatch
+):
+    """PR-2 item 4 (deferred from PR-1, codex-regate-3): _commit_and_push_anchor
+    appends `records` to the WORKING-TREE copy of governance/chain-origin.ndjson
+    BEFORE checkout/add/commit. A crash (or a raised git error) landing after
+    that write but before the commit leaves the dirty working tree holding a
+    record HEAD does not have. seal_and_commit_origin's own noop/resume check
+    only reads HEAD (`_read_local_head_anchor`) — it cannot see the leftover,
+    so a naive retry would re-append the SAME record, producing two lines for
+    the same key once a commit eventually lands (`read_git_anchor` = corrupt,
+    `verify_chain` = broken). The fix makes the working-tree append itself
+    idempotent by key; this reproduces the crash, then asserts a retry
+    produces no duplicate and verify_chain reports verified-segmented."""
+    ledger, data_dir = _ledger_and_data_dir(tmp_path)
+    append_chained_entry(ledger, {"seq": 0})  # marker-less genesis chain -> forces epoch-1 open
+
+    real_git_run_checked = coa._git_run_checked
+
+    def commit_crashes(project_root, *args, **kwargs):
+        if args and args[0] == "commit":
+            raise RuntimeError("simulated crash between working-tree write and commit")
+        return real_git_run_checked(project_root, *args, **kwargs)
+
+    monkeypatch.setattr(coa, "_git_run_checked", commit_crashes)
+    with pytest.raises(RuntimeError, match="simulated crash between working-tree write and commit"):
+        seal_and_commit_origin(
+            ledger,
+            git_repo,
+            project_id="vnx-dev",
+            project_data_dir=data_dir,
+            branch="main",
+            branch_protection_confirmed=True,
+        )
+
+    # Precondition: the dirty working tree already carries exactly ONE
+    # (uncommitted) record from the crashed attempt; HEAD has none.
+    anchor_path = git_repo / coa.ANCHOR_REL_PATH
+    dirty_lines = [line for line in anchor_path.read_text(encoding="utf-8").splitlines() if line.strip()]
+    assert len(dirty_lines) == 1
+
+    identity = ledger_identity("vnx-dev", ledger, data_dir)
+    key = coa.anchor_key(identity, 1)
+    assert coa._read_local_head_anchor(git_repo, key) is None
+
+    monkeypatch.setattr(coa, "_git_run_checked", real_git_run_checked)
+    result = _seal(git_repo, ledger)
+    assert result.action == "sealed"
+    assert result.epoch == 1
+
+    # No duplicate: exactly one line for this key reached origin.
+    committed_lines = [
+        line
+        for line in _run("git", "show", "origin/main:governance/chain-origin.ndjson", cwd=git_repo).splitlines()
+        if line.strip()
+    ]
+    assert len(committed_lines) == 1
+
+    record, provenance = read_git_anchor(git_repo, identity, 1)
+    assert provenance.resolved is True
+    assert record is not None
+    assert record != "corrupt"
+
+    ok, _violations, status, _prov = verify_chain(
+        ledger, project_root=git_repo, project_id="vnx-dev", project_data_dir=data_dir
+    )
+    assert ok is True
+    assert status == "verified-segmented"
+
+
 # ---------------------------------------------------------------------------
 # T12: existing behavior / read-path unchanged for callers that don't opt in
 # ---------------------------------------------------------------------------

--- a/tests/test_fabric_audit.py
+++ b/tests/test_fabric_audit.py
@@ -274,10 +274,38 @@ def test_check_d_deleted_ledger_with_anchor_is_red(tmp_path, monkeypatch):
     assert "vnx-dev" in r.detail
 
 
-def test_check_d_no_verifier_import_is_warn(monkeypatch, tmp_path):
+def test_check_d_missing_ledger_file_with_anchor_is_red(tmp_path, monkeypatch):
+    """Finding 3 (ADR-034 fix-r1): the ledger file is entirely ABSENT (not
+    merely emptied, as in test_check_d_deleted_ledger_with_anchor_is_red
+    above) while a git anchor exists on origin for this identity. The old
+    `if not ledger.exists(): continue` skipped this project before the
+    anchor-aware verifier ever ran, so `checked` stayed 0 and the whole
+    finding read as SKIP — silently missing the exact reverse-direction
+    tamper case check D exists to catch."""
+    data_home = tmp_path / "data"
+    project_root = _anchor_git_repo(tmp_path)
+    ledger = data_home / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    append_chained_entry(ledger, {"seq": 0})
+
+    monkeypatch.setattr(coa, "ensure_pr", lambda *a, **kw: {"pr_number": None, "created": False, "reason": "test"})
+    _seal_and_merge(project_root, ledger, data_home)
+
+    ledger.unlink()  # file gone entirely, not just emptied
+    assert not ledger.exists()
+
+    r = fa.check_anchor_provenance(data_home, [("vnx-dev", str(project_root))])
+    assert r.status == "RED"
+    assert "vnx-dev" in r.detail
+
+
+def test_check_d_no_verifier_import_is_red(monkeypatch, tmp_path):
+    """Finding 4 (ADR-034 fix-r1): an import failure means the anchor check
+    never ran — that must block the audit (RED), not read as a merely
+    advisory WARN that lets `main()` exit 0."""
     monkeypatch.setattr(fa, "anchor_verify_chain", None)
     r = fa.check_anchor_provenance(tmp_path, [("vnx-dev", "")])
-    assert r.status == "WARN"
+    assert r.status == "RED"
 
 
 def test_check_d_no_projects_is_skip(tmp_path):
@@ -314,6 +342,22 @@ def test_run_audit_resolves_project_id_from_file(tmp_path):
     projects, err = fa._load_project_ids(reg)
     b = fa.check_per_project_stores(data_home, projects, err)
     assert b.status == "GREEN"
+
+
+def test_main_exits_red_when_anchor_verifier_missing(monkeypatch, tmp_path, capsys):
+    """Finding 4 (ADR-034 fix-r1) end-to-end: an anchor-verifier import
+    failure must fail the whole `main()` invocation (exit 1), not let an
+    otherwise-clean fabric read as GREEN/GREEN-WITH-WARN while the
+    anchor-provenance check silently never ran."""
+    data_home = tmp_path / "data"
+    data_home.mkdir()
+    reg = _registry(tmp_path, [("vnx-dev", "vnx-orchestration")])
+    _mk_project(data_home, "vnx-dev")
+    monkeypatch.setattr(fa, "anchor_verify_chain", None)
+    rc = fa.main(["--data-home", str(data_home), "--registry", str(reg), "--json"])
+    out = json.loads(capsys.readouterr().out)
+    assert rc == 1
+    assert out["overall"] == "RED"
 
 
 def test_main_json_exit_code_red(tmp_path, capsys):

--- a/tests/test_fabric_audit.py
+++ b/tests/test_fabric_audit.py
@@ -1,6 +1,7 @@
 """Tests for scripts/fabric_audit.py — phase-0 fabric hardening audit (ADR-028)."""
 import json
 import os
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -8,8 +9,11 @@ from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 
 import fabric_audit as fa  # noqa: E402
+import chain_origin_anchor as coa  # noqa: E402
+from ndjson_hash_chain import append_chained_entry  # noqa: E402
 
 
 def _mk_project(data_home: Path, pid: str) -> None:
@@ -171,6 +175,122 @@ def test_partial_chain_ledger_is_red(tmp_path):
 def test_no_ledger_is_skip(tmp_path):
     _mk_project(tmp_path, "vnx-dev")
     r = fa.check_hash_chains(tmp_path, [("vnx-dev", "")])
+    assert r.status == "SKIP"
+
+
+# ── Check D: chain-origin anchor provenance (ADR-034) ───────────────────────
+
+
+def _run_git(*args: str, cwd) -> str:
+    result = subprocess.run(["git", *args], cwd=str(cwd), capture_output=True, text=True)
+    if result.returncode != 0:
+        raise RuntimeError(f"git {args} failed in {cwd}: {result.stderr}")
+    return result.stdout
+
+
+def _anchor_git_repo(tmp_path):
+    """A working-tree repo with a local bare 'origin' remote, so fetch/show/push
+    against origin/main work for real with no network access — mirrors
+    tests/test_chain_origin_anchor.py's git_repo fixture (kept local here so
+    this file doesn't need a cross-file fixture import)."""
+    bare = tmp_path / "origin.git"
+    _run_git("init", "--bare", "-b", "main", str(bare), cwd=tmp_path)
+    work = tmp_path / "repo"
+    _run_git("init", "-b", "main", str(work), cwd=tmp_path)
+    _run_git("config", "user.email", "test@example.com", cwd=work)
+    _run_git("config", "user.name", "Test", cwd=work)
+    (work / "README.md").write_text("seed\n", encoding="utf-8")
+    _run_git("add", "README.md", cwd=work)
+    _run_git("commit", "-m", "seed", cwd=work)
+    _run_git("remote", "add", "origin", str(bare), cwd=work)
+    _run_git("push", "-u", "origin", "main", cwd=work)
+    return work
+
+
+def _seal_and_merge(project_root, ledger, data_home, project_id="vnx-dev"):
+    result = coa.seal_and_commit_origin(
+        ledger,
+        project_root,
+        project_id=project_id,
+        project_data_dir=data_home / project_id,
+        branch="main",
+        branch_protection_confirmed=True,
+    )
+    assert result.action == "sealed"
+    _run_git("checkout", "main", cwd=project_root)
+    _run_git("merge", "--no-ff", "-m", f"merge {result.branch_name}", result.branch_name, cwd=project_root)
+    _run_git("push", "origin", "main", cwd=project_root)
+    return result
+
+
+def test_check_d_unchained_ledger_with_git_repo_is_green(tmp_path):
+    data_home = tmp_path / "data"
+    project_root = _anchor_git_repo(tmp_path)
+    ledger = data_home / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(json.dumps({"a": 1}) + "\n", encoding="utf-8")  # no prev_hash = unchained
+
+    r = fa.check_anchor_provenance(data_home, [("vnx-dev", str(project_root))])
+    assert r.status == "GREEN"
+    assert r.findings and r.findings[0]["status"] == "unchained"
+
+
+def test_check_d_sealed_ledger_reports_provenance(tmp_path, monkeypatch):
+    data_home = tmp_path / "data"
+    project_root = _anchor_git_repo(tmp_path)
+    ledger = data_home / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    append_chained_entry(ledger, {"seq": 0})
+
+    monkeypatch.setattr(coa, "ensure_pr", lambda *a, **kw: {"pr_number": None, "created": False, "reason": "test"})
+    _seal_and_merge(project_root, ledger, data_home)
+
+    r = fa.check_anchor_provenance(data_home, [("vnx-dev", str(project_root))])
+    assert r.status == "GREEN"
+    finding = r.findings[0]
+    assert finding["status"] == "verified-segmented"
+    assert finding["anchor_commit_sha"] is not None
+    assert finding["remote_url"] is not None
+
+
+def test_check_d_deleted_ledger_with_anchor_is_red(tmp_path, monkeypatch):
+    """Reverse-direction case (ADR §2): a git anchor exists, but the ledger was
+    reset — check D must go RED, not read as a clean 'unchained' (this is
+    exactly the gap check C alone leaves open, since it calls the BASE
+    verify_chain with no anchor awareness)."""
+    data_home = tmp_path / "data"
+    project_root = _anchor_git_repo(tmp_path)
+    ledger = data_home / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    append_chained_entry(ledger, {"seq": 0})
+
+    monkeypatch.setattr(coa, "ensure_pr", lambda *a, **kw: {"pr_number": None, "created": False, "reason": "test"})
+    _seal_and_merge(project_root, ledger, data_home)
+
+    ledger.write_text("", encoding="utf-8")  # reset / deleted content
+
+    r = fa.check_anchor_provenance(data_home, [("vnx-dev", str(project_root))])
+    assert r.status == "RED"
+    assert "vnx-dev" in r.detail
+
+
+def test_check_d_no_verifier_import_is_warn(monkeypatch, tmp_path):
+    monkeypatch.setattr(fa, "anchor_verify_chain", None)
+    r = fa.check_anchor_provenance(tmp_path, [("vnx-dev", "")])
+    assert r.status == "WARN"
+
+
+def test_check_d_no_projects_is_skip(tmp_path):
+    r = fa.check_anchor_provenance(tmp_path, [])
+    assert r.status == "SKIP"
+
+
+def test_check_d_unresolvable_project_root_is_skip(tmp_path):
+    data_home = tmp_path / "data"
+    ledger = data_home / "vnx-dev" / "state" / "t0_receipts.ndjson"
+    ledger.parent.mkdir(parents=True)
+    ledger.write_text(json.dumps({"a": 1}) + "\n", encoding="utf-8")
+    r = fa.check_anchor_provenance(data_home, [("vnx-dev", "")])  # empty path -> no resolvable repo
     assert r.status == "SKIP"
 
 


### PR DESCRIPTION
## Summary

ADR-034 §6/§7 PR-2 — the rest of the follow-up implementation after PR-1's core anchor library (#1181, merged). Implements the ADR literally, no redesign. `VNX_CHAIN_RECEIPTS` stays OFF; no default behavior change.

## Changes

1. **`.github/workflows/anchor-immutability-check.yml`** — required CI check (job name `Anchor Immutability Check`, matching `chain_origin_anchor.ANCHOR_IMMUTABILITY_CHECK_NAME`). Runs `check_anchor_immutability()` against `governance/chain-origin.ndjson` base-vs-head whenever that file is touched in a PR's diff. NOT `continue-on-error` (ADR §3 "C4" — required from commit one, unlike `attestation-gate.yml`'s staged-advisory precedent). Checking code is extracted from `origin/main`, never the PR tree, mirroring `attestation-gate.yml`'s base-branch-trust pattern.

2. **`chain_origin_anchor.check_branch_protection()` + `_owner_repo_from_remote()`** — the caller-side `gh api` verification that may set `seal_and_commit_origin`'s `branch_protection_confirmed=True` (ADR §6 step 2b). Confirms the anchor-immutability check is a required status check, `enforce_admins` is on, and force-pushes are blocked — all three required for `confirmed=True`. Fails closed on any `gh`/API error (auth, network, unprotected branch, malformed response, `gh` missing). CLI wrapper: `scripts/chain_branch_protection_check.py`.

3. **`fabric_audit.py` check D** — a new anchor-aware section that runs `chain_origin_anchor.verify_chain` per registered project against that project's own repo (`project_root` from the registry), surfacing `AnchorProvenance` (ref, `anchor_commit_sha`, `remote_url`) per ledger and going RED on `"broken"` — additive to check C, not a replacement (ADR §6 step 3's flip of check C's *own* `verify_chain` call stays a separate, later migration gated on step 2b per project).

4. **Seal-idempotency fix** (deferred from PR-1, codex-regate-3 OI on #1181): `_commit_and_push_anchor` appended new anchor records to the working-tree copy of `governance/chain-origin.ndjson` *before* checkout/add/commit. A crash (or a raised git error) landing after that write but before the commit left a dirty working tree carrying a record HEAD didn't have — `seal_and_commit_origin`'s own noop/resume check only reads HEAD, so a retry would re-append the same record, producing a duplicate key once a commit eventually landed (`read_git_anchor` → `"corrupt"`). Fixed by making the working-tree append idempotent: read whatever's already on disk first, skip keys already present.

## Verification

All commands run from the repo root with `python3 -m pytest`.

- Required baseline + this PR's chain-suite files together: `tests/test_chain_origin_anchor.py tests/test_ndjson_hash_chain.py tests/test_acceptance_idempotency.py tests/test_chain_epoch_seal.py tests/test_chain_state_projection.py tests/test_receipt_hashchain.py tests/test_schema_idempotency.py tests/test_chain_branch_protection_check.py tests/test_anchor_immutability_workflow.py tests/test_fabric_audit.py` → **199 passed**.
  - The 7 dispatch-listed files alone → **150 passed** (measured current-main baseline before this PR, same 7 files: **149 passed** — the dispatch's stated "baseline 147" is stale relative to `origin/main`'s actual post-PR-1 state; no regression either way, +1 is this PR's new seal-idempotency test).
  - New seal-idempotency regression test: `test_seal_idempotency_crash_between_working_tree_write_and_commit_no_duplicate` (in `test_chain_origin_anchor.py`) — reproduces the crash, retries, asserts exactly one committed line for the key and `verify_chain` → `"verified-segmented"`.
  - `tests/test_chain_branch_protection_check.py` (new, 17 tests) — all 3 required conditions individually, unprotected/api-error/malformed-response/gh-missing fail-closed cases, owner/repo resolution from https/ssh GitHub remotes and non-GitHub remotes, CLI wrapper exit codes + JSON output.
  - `tests/test_anchor_immutability_workflow.py` (new, 7 tests) — structural checks on the workflow YAML: job name matches the Python constant, not `continue-on-error`, no `paths:` filter (always reports), extracts from `origin/main`, invokes `check_anchor_immutability`.
  - `tests/test_fabric_audit.py` check D additions (6 new tests) — unchained-ledger GREEN, sealed-ledger provenance fields populated, reverse-direction (deleted ledger + existing anchor) RED, verifier-import-failure WARN, no-projects SKIP, unresolvable-project-root SKIP. Existing check A/B/C tests + the `run_audit` integration tests still pass unmodified.
- `python3 -m py_compile` on all changed/new Python files — clean.
- `python3 scripts/check_adr_003_no_sdk_imports.py` — PASS.
- Live smoke test: `python3 scripts/fabric_audit.py --json` against the real fleet (4 registered projects) — GREEN, correctly resolves each project's real GitHub remote SHA/URL via check D, all `"unchained"` as expected (chaining is fleet-wide OFF).
- Live smoke test: `python3 scripts/chain_branch_protection_check.py --project-root . --branch main --json` against this repo's real branch protection — correctly reports `confirmed=false` with reason `"required check 'Anchor Immutability Check' not in required_status_checks"` (expected: this workflow isn't in branch protection yet — that's an operator step *after* this PR merges, ADR §6 step 2a/2b).

## Open Items

- **Size deviation (reported per dispatch instructions, not silent):** the dispatch's code budget was "150-300 diff-regels" with tests/workflow-YAML excluded. Non-test, non-YAML code changes total ~375 lines (`scripts/lib/chain_origin_anchor.py` +210/-3, `scripts/fabric_audit.py` +91, `scripts/chain_branch_protection_check.py` +74 new). This is over budget; kept as-is rather than trimmed because the overage is concentrated in `check_branch_protection`'s three independently-checked, fail-closed conditions (ADR §6 step 2b is explicit about all three: required check, `enforce_admins`, no force-push) and check D's provenance surfacing — compressing either would mean skipping a condition the ADR names explicitly or dropping fail-closed error paths.
- **Operator follow-up required before ADR §6 step 2b can pass for real (not part of this PR's scope):** once this PR merges, `Anchor Immutability Check` must be added to `main`'s branch protection as a required status check (`enforce_admins` on, force-push disallowed) — e.g. via `scripts/commands/protect_branch.sh` or the GitHub UI — before `seal_and_commit_origin` can ever be called with a real `branch_protection_confirmed=True` for this repo. Verified live above: it is currently NOT configured (expected pre-merge state).
- ADR §6 step 3 (flipping `fabric_audit` check C's *own* `verify_chain` call — and the other 5 call sites named in the ADR: `chain_epoch_seal.py`, `evidence_bound_gate.py`, `governance_effectiveness_probe.py`, `audit_chain.py`, this module's own self-check) to the anchor-aware, fail-closed contract is explicitly out of scope here per the ADR's own sequencing (gated on step 2b passing per-project) and per this dispatch's "no flag-flip" instruction — check D is additive, not a replacement.
- Seal-cron/automation (wiring a scheduled `seal_and_commit_origin` run) is out of scope per the dispatch ("latere fase").
- `VNX_CHAIN_RECEIPTS` remains default-OFF; no fleet ledger anywhere starts chaining because of this PR.