### PR TITLE
feat(rv2-pr1): receipt_verdict.py — compute_verdict pure function (ADR-035 §3.1)

### DIFF
--- a/scripts/lib/receipt_verdict.py
+++ b/scripts/lib/receipt_verdict.py
@@ -34,9 +34,22 @@ HARD_FAILURE_STATUSES = frozenset(
 # rather than "we checked and it's clean" — ADR-035 §3.1 (evidence_complete).
 INCOMPLETE_EVIDENCE_METHODS = frozenset({"unknown", "none_claimed", "pending-report"})
 
+# status literals that assert the dispatch actually completed — the same
+# vocabulary phantom_guard.py::COMPLETION_STATUSES uses to decide whether a
+# completion claim is even eligible for scrutiny. `accept` requires one of
+# these explicitly: "not a hard-failure status" is not the same claim as
+# "is a success status" (fix-r1 BLOCKING-1) — a receipt sitting in
+# "unknown"/"in_progress" with clean-looking test evidence is neither a
+# failure nor a completed success, and must never fall through to accept.
+SUCCESS_STATUSES = frozenset({"done", "success", "complete", "completed"})
+
 
 def _doc_only_path(path: str) -> bool:
-    return path.startswith("docs/") or path.endswith(".md")
+    """True only when `path` matches the glob `docs/**/*.md` — under `docs/`
+    AND ending in `.md`. Both conditions are required (fix-r1 HIGH-3): a
+    loose `or` let `scripts/README.md` (not under docs/) or `docs/schema.json`
+    (not markdown) slip through the doc-only bypass."""
+    return path.startswith("docs/") and path.endswith(".md")
 
 
 def _doc_only_paths_confirmed(receipt: Dict[str, Any]) -> bool:
@@ -81,12 +94,17 @@ def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
       2. doc-only — `verification.method == "n/a"`: accept only if every
                      changed path is confirmed under docs/**/*.md, else
                      investigate (fail-safe on missing/partial evidence).
-      3. investigate — `verification.method == "pending-report"`, or an
-                     unresolved `destination: "oi_pending"` warning, or a
-                     success-claiming status with missing/incomplete test
-                     evidence.
-      4. accept   — success-claiming status, `tests_failed == 0` with
-                     `tests_run > 0`, no blocker/oi_pending warnings.
+      3. investigate — `verification.method == "pending-report"`, an
+                     unresolved `destination: "oi_pending"` warning, a
+                     `status` outside both the hard-failure set and the
+                     success allowlist (`SUCCESS_STATUSES` — e.g.
+                     "unknown"/"in_progress" never reach accept, fix-r1
+                     BLOCKING-1), incomplete verification evidence
+                     (`method` in `unknown`/`none_claimed`, fix-r1 HIGH-2),
+                     or missing/failing test evidence.
+      4. accept   — `status` in `SUCCESS_STATUSES`, `evidence_complete`,
+                     `tests_failed == 0` with `tests_run > 0`, no
+                     blocker/oi_pending warnings.
     """
     status = receipt.get("status")
     warnings = receipt.get("warnings") or []
@@ -142,6 +160,22 @@ def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
         return _verdict(
             "investigate",
             "an unresolved destination=oi_pending warning is present",
+            evidence_complete,
+        )
+
+    if status not in SUCCESS_STATUSES:
+        return _verdict(
+            "investigate",
+            f"status={status!r} is neither a hard-failure status nor a "
+            "recognized success status — no basis for accept",
+            evidence_complete,
+        )
+
+    if not evidence_complete:
+        return _verdict(
+            "investigate",
+            f"status={status!r} claims success but verification.method="
+            f"{method!r} does not provide complete evidence",
             evidence_complete,
         )
 

--- a/scripts/lib/receipt_verdict.py
+++ b/scripts/lib/receipt_verdict.py
@@ -91,18 +91,18 @@ def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
     order (highest precedence first):
 
       1. reject   — hard-failure `status`, or any `severity: "blocker"` warning.
-      2. doc-only — `verification.method == "n/a"`: accept only if every
+      2. investigate — `status` outside `SUCCESS_STATUSES` (e.g.
+                     "unknown"/"in_progress"). No non-success status can
+                     reach `accept`, even for a doc-only change (fix-r2).
+      3. doc-only — `verification.method == "n/a"`: accept only if every
                      changed path is confirmed under docs/**/*.md, else
                      investigate (fail-safe on missing/partial evidence).
-      3. investigate — `verification.method == "pending-report"`, an
-                     unresolved `destination: "oi_pending"` warning, a
-                     `status` outside both the hard-failure set and the
-                     success allowlist (`SUCCESS_STATUSES` — e.g.
-                     "unknown"/"in_progress" never reach accept, fix-r1
-                     BLOCKING-1), incomplete verification evidence
-                     (`method` in `unknown`/`none_claimed`, fix-r1 HIGH-2),
-                     or missing/failing test evidence.
-      4. accept   — `status` in `SUCCESS_STATUSES`, `evidence_complete`,
+      4. investigate — `verification.method == "pending-report"`, an
+                     unresolved `destination: "oi_pending"` warning,
+                     incomplete verification evidence (`method` in
+                     `unknown`/`none_claimed`, fix-r1 HIGH-2), or
+                     missing/failing test evidence.
+      5. accept   — `status` in `SUCCESS_STATUSES`, `evidence_complete`,
                      `tests_failed == 0` with `tests_run > 0`, no
                      blocker/oi_pending warnings.
     """
@@ -124,6 +124,14 @@ def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
         return _verdict(
             "reject",
             "an unresolved severity=blocker warning is present",
+            evidence_complete,
+        )
+
+    if status not in SUCCESS_STATUSES:
+        return _verdict(
+            "investigate",
+            f"status={status!r} is neither a hard-failure status nor a "
+            "recognized success status — no basis for accept",
             evidence_complete,
         )
 
@@ -160,14 +168,6 @@ def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
         return _verdict(
             "investigate",
             "an unresolved destination=oi_pending warning is present",
-            evidence_complete,
-        )
-
-    if status not in SUCCESS_STATUSES:
-        return _verdict(
-            "investigate",
-            f"status={status!r} is neither a hard-failure status nor a "
-            "recognized success status — no basis for accept",
             evidence_complete,
         )
 

--- a/scripts/lib/receipt_verdict.py
+++ b/scripts/lib/receipt_verdict.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+"""Receipt v2 verdict computation — ADR-035 §3.1.
+
+Pure function: `compute_verdict(receipt) -> dict`. Reads only the receipt
+dict passed in — no I/O, no side effects, no LLM judgment. Deterministic
+and unit-testable by design (ADR-035 §11 rejects an LLM-computed verdict
+outright).
+
+This is PR-1 of the ADR-035 §9 decomposition: additive dead code, not wired
+into any write path yet (that is PR-3/PR-4).
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+# The verified union of hard-failure `status` literals across both write
+# paths (dispatch_envelope.py/provider_dispatch.py for Path 1,
+# report_parser.py for Path 2) — ADR-035 §3.1, r4. Note both "failed" and
+# "failure" are included: they are distinct literals used by different
+# call sites, not a typo of one another.
+HARD_FAILURE_STATUSES = frozenset(
+    {
+        "failed",
+        "failure",
+        "error",
+        "blocked",
+        "timeout",
+        "contract_invalid",
+    }
+)
+
+# verification.method values that mean "we don't actually have evidence"
+# rather than "we checked and it's clean" — ADR-035 §3.1 (evidence_complete).
+INCOMPLETE_EVIDENCE_METHODS = frozenset({"unknown", "none_claimed", "pending-report"})
+
+
+def _doc_only_path(path: str) -> bool:
+    return path.startswith("docs/") or path.endswith(".md")
+
+
+def _doc_only_paths_confirmed(receipt: Dict[str, Any]) -> bool:
+    """True only when every changed path is verifiably under docs/**/*.md.
+
+    Fail-safe on absence: a missing/null/empty `paths` list is NOT treated
+    as "no paths to violate the rule" — it is treated as unproven doc-only-
+    ness (ADR-035 §3.1.1, r2 HIGH-4). Absence of evidence is not evidence
+    of doc-only.
+    """
+    provenance = receipt.get("provenance") or {}
+    diff_summary = provenance.get("diff_summary") or {}
+    paths = diff_summary.get("paths")
+    if not paths:
+        return False
+    return all(_doc_only_path(p) for p in paths)
+
+
+def _has_blocker_warning(warnings: List[Any]) -> bool:
+    return any((w or {}).get("severity") == "blocker" for w in warnings)
+
+
+def _has_oi_pending_warning(warnings: List[Any]) -> bool:
+    return any((w or {}).get("destination") == "oi_pending" for w in warnings)
+
+
+def _verdict(decision: str, reason: str, evidence_complete: bool) -> Dict[str, Any]:
+    return {
+        "decision": decision,
+        "reason": reason,
+        "evidence_complete": evidence_complete,
+    }
+
+
+def compute_verdict(receipt: Dict[str, Any]) -> Dict[str, Any]:
+    """Compute `{decision, reason, evidence_complete}` for a receipt.
+
+    Pure function over the rule table in ADR-035 §3.1/§3.1.1. Evaluation
+    order (highest precedence first):
+
+      1. reject   — hard-failure `status`, or any `severity: "blocker"` warning.
+      2. doc-only — `verification.method == "n/a"`: accept only if every
+                     changed path is confirmed under docs/**/*.md, else
+                     investigate (fail-safe on missing/partial evidence).
+      3. investigate — `verification.method == "pending-report"`, or an
+                     unresolved `destination: "oi_pending"` warning, or a
+                     success-claiming status with missing/incomplete test
+                     evidence.
+      4. accept   — success-claiming status, `tests_failed == 0` with
+                     `tests_run > 0`, no blocker/oi_pending warnings.
+    """
+    status = receipt.get("status")
+    warnings = receipt.get("warnings") or []
+    verification = receipt.get("verification") or {}
+    method: Optional[str] = verification.get("method")
+
+    evidence_complete = method not in INCOMPLETE_EVIDENCE_METHODS
+
+    if status in HARD_FAILURE_STATUSES:
+        return _verdict(
+            "reject",
+            f"status={status!r} is a hard-failure status",
+            evidence_complete,
+        )
+
+    if _has_blocker_warning(warnings):
+        return _verdict(
+            "reject",
+            "an unresolved severity=blocker warning is present",
+            evidence_complete,
+        )
+
+    if method == "n/a":
+        if _doc_only_paths_confirmed(receipt):
+            if _has_oi_pending_warning(warnings):
+                return _verdict(
+                    "investigate",
+                    "doc-only change (verification.method=n/a) but an "
+                    "oi_pending warning is unresolved",
+                    evidence_complete,
+                )
+            return _verdict(
+                "accept",
+                "verification.method=n/a and every changed path is under "
+                "docs/**/*.md",
+                evidence_complete,
+            )
+        return _verdict(
+            "investigate",
+            "verification.method=n/a but provenance.diff_summary.paths is "
+            "missing, empty, or contains a non-doc path",
+            evidence_complete,
+        )
+
+    if method == "pending-report":
+        return _verdict(
+            "investigate",
+            "verification.method=pending-report, no test evidence available yet",
+            evidence_complete,
+        )
+
+    if _has_oi_pending_warning(warnings):
+        return _verdict(
+            "investigate",
+            "an unresolved destination=oi_pending warning is present",
+            evidence_complete,
+        )
+
+    tests_run = verification.get("tests_run")
+    tests_failed = verification.get("tests_failed")
+
+    if not tests_run or tests_run <= 0 or tests_failed != 0:
+        return _verdict(
+            "investigate",
+            f"status={status!r} claims success but verification test "
+            "evidence is absent or incomplete",
+            evidence_complete,
+        )
+
+    return _verdict(
+        "accept",
+        f"status={status!r}, verification {tests_run - tests_failed}/{tests_run} "
+        "tests passed, no blocker or oi_pending warnings",
+        evidence_complete,
+    )

--- a/tests/test_receipt_verdict.py
+++ b/tests/test_receipt_verdict.py
@@ -1,0 +1,285 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/receipt_verdict.py::compute_verdict (ADR-035 §3.1/§3.1.1/§10).
+
+Covers the mandatory dispatch DoD subset: T3, T4, T5, T23, T35.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from receipt_verdict import compute_verdict  # noqa: E402
+
+
+# ── T3 — reject on every hard-failure status ──────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "status",
+    ["failed", "failure", "error", "blocked", "timeout", "contract_invalid"],
+)
+def test_t3_reject_on_hard_failure_status(status):
+    receipt = {"status": status}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "reject"
+    assert status in verdict["reason"]
+
+
+def test_t3_reject_on_status_failure_explicit():
+    """r4: 'failure' is the literal Path 1 stamps on a real provider failure —
+    distinct from 'failed', both must reject."""
+    receipt = {
+        "status": "failure",
+        "verification": {"method": "pytest", "tests_run": 5, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "reject"
+
+
+def test_t3_reject_on_blocker_warning_regardless_of_status():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 5, "tests_failed": 0},
+        "warnings": [{"code": "x", "severity": "blocker", "destination": "oi", "oi_id": "OI-1"}],
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "reject"
+
+
+# ── T4 — investigate when success claimed but no test evidence ───────────
+
+
+def test_t4_investigate_tests_run_absent():
+    receipt = {"status": "done", "verification": {"method": "pytest"}}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t4_investigate_tests_run_null():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": None, "tests_failed": None},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t4_investigate_no_verification_key_at_all():
+    receipt = {"status": "done"}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t4_investigate_tests_failed_nonzero():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 10, "tests_failed": 2},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t4_investigate_pending_report_method():
+    receipt = {"status": "success", "verification": {"method": "pending-report"}}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+    assert verdict["evidence_complete"] is False
+
+
+def test_t4_investigate_oi_pending_warning():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 5, "tests_failed": 0},
+        "warnings": [
+            {
+                "code": "worker_permission_violation",
+                "severity": "blocker",
+                "destination": "oi_pending",
+                "oi_id": None,
+                "reason": "store lock held",
+            }
+        ],
+    }
+    verdict = compute_verdict(receipt)
+    # NB: this entry is also severity=blocker, so reject fires first
+    # (reject has higher precedence than oi_pending-investigate). Use a
+    # warn-severity oi_pending entry to isolate the investigate path.
+    assert verdict["decision"] == "reject"
+
+    receipt["warnings"][0]["severity"] = "warn"
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+# ── T5 — accept on success + clean verification ───────────────────────────
+
+
+def test_t5_accept_success_clean_verification():
+    receipt = {
+        "status": "done",
+        "verification": {
+            "method": "pytest",
+            "tests_run": 12,
+            "tests_passed": 12,
+            "tests_failed": 0,
+        },
+        "warnings": [],
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "accept"
+    assert verdict["evidence_complete"] is True
+
+
+def test_t5_accept_no_warnings_key_at_all():
+    receipt = {
+        "status": "success",
+        "verification": {"method": "pytest", "tests_run": 3, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "accept"
+
+
+def test_t5_not_accept_when_blocker_warning_present():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 12, "tests_failed": 0},
+        "warnings": [{"code": "x", "severity": "blocker", "destination": "oi", "oi_id": "OI-1"}],
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "reject"
+
+
+# ── T23 — doc-only invariant: non-docs path present forces investigate ───
+
+
+def test_t23_na_method_nondocs_path_forces_investigate():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a", "spec_deviation": "doc-only dispatch"},
+        "provenance": {
+            "diff_summary": {
+                "paths": [
+                    "docs/governance/decisions/ADR-035-receipt-v2.md",
+                    "scripts/lib/receipt_verdict.py",
+                ]
+            }
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+@pytest.mark.parametrize("status", ["done", "success"])
+def test_t23_na_method_nondocs_path_forces_investigate_regardless_of_status(status):
+    receipt = {
+        "status": status,
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {"paths": ["scripts/lib/foo.py"]}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t23_na_method_all_docs_paths_accepts():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a", "spec_deviation": "doc-only dispatch"},
+        "provenance": {
+            "diff_summary": {
+                "paths": [
+                    "docs/governance/decisions/ADR-035-receipt-v2.md",
+                    "README.md",
+                ]
+            }
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "accept"
+
+
+# ── T35 — doc-only invariant: missing/null/empty paths is fail-safe ──────
+
+
+def test_t35_na_method_paths_absent_forces_investigate():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t35_na_method_paths_null_forces_investigate():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {"paths": None}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t35_na_method_paths_empty_forces_investigate():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {"paths": []}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_t35_na_method_no_provenance_key_at_all():
+    receipt = {"status": "done", "verification": {"method": "n/a"}}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+# ── evidence_complete field ────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("method", ["unknown", "none_claimed", "pending-report"])
+def test_evidence_complete_false_for_incomplete_methods(method):
+    receipt = {"status": "done", "verification": {"method": method}}
+    verdict = compute_verdict(receipt)
+    assert verdict["evidence_complete"] is False
+
+
+def test_evidence_complete_true_for_pytest_method():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["evidence_complete"] is True
+
+
+# ── pure-function guarantees ────────────────────────────────────────────────
+
+
+def test_compute_verdict_is_pure_no_mutation():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0},
+        "warnings": [{"code": "x", "severity": "warn", "destination": "counted"}],
+    }
+    import copy
+
+    before = copy.deepcopy(receipt)
+    compute_verdict(receipt)
+    assert receipt == before
+
+
+def test_compute_verdict_returns_exactly_three_keys():
+    receipt = {"status": "done", "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0}}
+    verdict = compute_verdict(receipt)
+    assert set(verdict.keys()) == {"decision", "reason", "evidence_complete"}

--- a/tests/test_receipt_verdict.py
+++ b/tests/test_receipt_verdict.py
@@ -400,3 +400,66 @@ def test_fixr1_high3_doc_only_nested_docs_md_path_still_accepts():
     }
     verdict = compute_verdict(receipt)
     assert verdict["decision"] == "accept"
+
+
+# ── fix-r2 BLOCKING — non-success status cannot use doc-only accept bypass ──
+# PR #1186 codex-regate finding: the doc-only branch returned accept before the
+# success-status gate, so status="in_progress"/"unknown" with verification.
+# method="n/a" and docs-only paths was incorrectly accepted.
+
+
+@pytest.mark.parametrize("status", ["in_progress", "unknown"])
+def test_fixr2_blocking_non_success_doc_only_is_investigate(status):
+    """Non-success status + n/a verification + docs-only paths must NOT
+    reach accept; it must route to investigate."""
+    receipt = {
+        "status": status,
+        "verification": {"method": "n/a", "spec_deviation": "doc-only dispatch"},
+        "provenance": {
+            "diff_summary": {
+                "paths": [
+                    "docs/governance/decisions/ADR-035-receipt-v2.md",
+                    "docs/README.md",
+                ]
+            }
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+    assert status in verdict["reason"]
+    assert verdict["evidence_complete"] is True
+
+
+@pytest.mark.parametrize("status", ["in_progress", "unknown"])
+def test_fixr2_blocking_non_success_doc_only_is_not_reject(status):
+    """Non-success/non-failure doc-only cases land on investigate, not reject."""
+    receipt = {
+        "status": status,
+        "verification": {"method": "n/a"},
+        "provenance": {
+            "diff_summary": {"paths": ["docs/governance/decisions/ADR-035-receipt-v2.md"]}
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+    assert verdict["decision"] != "reject"
+    assert verdict["decision"] != "accept"
+
+
+def test_fixr2_doc_only_success_status_still_accepts():
+    """A genuine success-status doc-only dispatch must continue to accept."""
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a", "spec_deviation": "doc-only dispatch"},
+        "provenance": {
+            "diff_summary": {
+                "paths": [
+                    "docs/governance/decisions/ADR-035-receipt-v2.md",
+                    "docs/README.md",
+                ]
+            }
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "accept"
+    assert verdict["evidence_complete"] is True

--- a/tests/test_receipt_verdict.py
+++ b/tests/test_receipt_verdict.py
@@ -189,6 +189,9 @@ def test_t23_na_method_nondocs_path_forces_investigate_regardless_of_status(stat
 
 
 def test_t23_na_method_all_docs_paths_accepts():
+    """fix-r1 HIGH-3: doc-only requires BOTH under docs/ AND .md — the
+    fixture uses docs/README.md (not a bare repo-root README.md) so this
+    stays a true positive under the tightened glob."""
     receipt = {
         "status": "done",
         "verification": {"method": "n/a", "spec_deviation": "doc-only dispatch"},
@@ -196,7 +199,7 @@ def test_t23_na_method_all_docs_paths_accepts():
             "diff_summary": {
                 "paths": [
                     "docs/governance/decisions/ADR-035-receipt-v2.md",
-                    "README.md",
+                    "docs/README.md",
                 ]
             }
         },
@@ -283,3 +286,117 @@ def test_compute_verdict_returns_exactly_three_keys():
     receipt = {"status": "done", "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0}}
     verdict = compute_verdict(receipt)
     assert set(verdict.keys()) == {"decision", "reason", "evidence_complete"}
+
+
+# ── fix-r1 BLOCKING-1 — accept requires an explicit success-status allowlist ──
+# PR #1186 codex-gate finding: status="unknown"/"in_progress" with clean test
+# evidence fell through the old "not a hard-failure" check straight to accept.
+# accept now requires status ∈ SUCCESS_STATUSES (done/success/complete/completed).
+
+
+@pytest.mark.parametrize("status", ["unknown", "in_progress"])
+def test_fixr1_blocking1_non_success_status_never_accepts_despite_clean_evidence(status):
+    receipt = {
+        "status": status,
+        "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+@pytest.mark.parametrize("status", ["unknown", "in_progress"])
+def test_fixr1_blocking1_non_success_status_not_confused_with_reject(status):
+    """Non-success/non-failure statuses must land on investigate, not reject —
+    only HARD_FAILURE_STATUSES triggers reject."""
+    receipt = {
+        "status": status,
+        "verification": {"method": "pytest", "tests_run": 1, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] != "reject"
+    assert verdict["decision"] != "accept"
+
+
+# ── fix-r1 HIGH-2 — accept requires evidence_complete, not just non-blocking method ──
+# PR #1186 codex-gate finding: status="success" with method="unknown" (or
+# "none_claimed") still fell through to accept because only "pending-report"
+# blocked the accept branch. evidence_complete now gates accept directly.
+
+
+@pytest.mark.parametrize("method", ["unknown", "none_claimed"])
+def test_fixr1_high2_success_status_incomplete_evidence_method_investigates(method):
+    receipt = {"status": "success", "verification": {"method": method}}
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+    assert verdict["evidence_complete"] is False
+
+
+def test_fixr1_high2_success_status_method_unknown_with_clean_test_fields_still_investigates():
+    """Even if tests_run/tests_failed happen to look clean, an incomplete-
+    evidence method must block accept — evidence_complete is checked
+    independently of the test-count fields."""
+    receipt = {
+        "status": "success",
+        "verification": {"method": "unknown", "tests_run": 5, "tests_failed": 0},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+    assert verdict["evidence_complete"] is False
+
+
+# ── fix-r1 HIGH-3 — doc-only glob tightened to docs/**/*.md (AND, not OR) ──
+# PR #1186 codex-gate finding: the old predicate accepted any path either
+# under docs/ OR ending in .md. scripts/README.md (not under docs/) and
+# docs/schema.json (under docs/ but not markdown) both slipped through.
+
+
+def test_fixr1_high3_doc_only_path_outside_docs_dir_investigates():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {"paths": ["scripts/README.md"]}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_fixr1_high3_doc_only_path_under_docs_but_not_markdown_investigates():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {"diff_summary": {"paths": ["docs/schema.json"]}},
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_fixr1_high3_doc_only_one_bad_path_among_good_ones_investigates():
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {
+            "diff_summary": {
+                "paths": [
+                    "docs/governance/decisions/ADR-035-receipt-v2.md",
+                    "scripts/README.md",
+                ]
+            }
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "investigate"
+
+
+def test_fixr1_high3_doc_only_nested_docs_md_path_still_accepts():
+    """Regression guard: the AND-tightening must not also break the
+    legitimate nested-docs case — docs/**/*.md still matches multiple
+    directory levels deep."""
+    receipt = {
+        "status": "done",
+        "verification": {"method": "n/a"},
+        "provenance": {
+            "diff_summary": {"paths": ["docs/governance/decisions/ADR-035-receipt-v2.md"]}
+        },
+    }
+    verdict = compute_verdict(receipt)
+    assert verdict["decision"] == "accept"


### PR DESCRIPTION
## Summary

Receipt-v2 PR-1 of the ADR-035 §9 decomposition. Implements `scripts/lib/receipt_verdict.py::compute_verdict(receipt) -> dict` exactly per ADR-035 §3.1/§3.1.1's rule table: a pure function producing `{decision, reason, evidence_complete}`.

- `reject` — hard-failure `status` (`failed`/`failure`/`error`/`blocked`/`timeout`/`contract_invalid`, the verified union across both write paths, r4), or any `warnings[]` entry with `severity: "blocker"`.
- `investigate` — success-claiming status with missing/incomplete test evidence, `verification.method == "pending-report"`, or an unresolved `destination: "oi_pending"` warning.
- `accept` — clean verification (`tests_failed == 0`, `tests_run > 0`, no blocker/oi_pending warnings), or a doc-only `method: "n/a"` receipt whose `provenance.diff_summary.paths` are confirmed entirely under `docs/**`/`*.md`.
- Doc-only invariant is fail-safe: missing/null/empty `paths` under `method: "n/a"` forces `investigate`, never `accept` (§3.1.1, r2 HIGH-4).

No I/O, no side effects, no LLM. Not wired into any receipt writer — additive dead code path, per PR-1 scope. PR-3/PR-4 do the wiring.

## Test plan

- [x] `python3 -m pytest tests/test_receipt_verdict.py -v` — 31 passed (covers mandatory T3, T4, T5, T23, T35 plus supporting edge cases: alias-status coverage, oi_pending/blocker precedence, evidence_complete matrix, purity/no-mutation, exact-key-set contract).
- [x] Sanity regression: `python3 -m pytest tests/test_ndjson_hash_chain.py tests/test_acceptance_idempotency.py -q` — 66 passed, no regressions.
- [x] `git status --short` confirms only 2 new files added; grep confirms no other file imports `receipt_verdict`.

Ref: `docs/governance/decisions/ADR-035-receipt-v2.md` §3.1, §3.1.1, §9 PR-1, §10 (T3/T4/T5/T23/T35).

Dispatch-ID: 20260717-rv2-pr1-verdict