### PR TITLE
fix(kimi-lane): resolve registry-drift LLMNotSet, make K3 the explicit default

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -812,9 +812,23 @@ class ProviderAdapter:
         # ---- kimi ----
         if pv == Provider.KIMI:
             from provider_spawns.kimi_spawn import spawn_kimi  # noqa: PLC0415
+            from provider_dispatch import (  # noqa: PLC0415
+                KimiModelResolutionError,
+                _kimi_resolve_cli_model_arg,
+                _kimi_resolve_requested_key,
+            )
 
-            # None signals kimi CLI to use its own default; label used only for logging
-            model = plan.model if plan.model not in ("default", "") else None
+            # Shared resolver (20260721-kimi-lane-hardening): args.model/plan.model >
+            # VNX_KIMI_MODEL > registry K3 default; bare provider/alias tokens ("kimi",
+            # "kimi-default") normalize to the default; an unmapped/stale model_key RAISES
+            # instead of ever being passed raw to `-m` or silently substituted with K3.
+            try:
+                model = _kimi_resolve_cli_model_arg(_kimi_resolve_requested_key(plan.model))
+            except KimiModelResolutionError as exc:
+                return _AdapterResult(
+                    returncode=1, completion_text="", status="failure",
+                    error=f"kimi model resolution failed: {exc}",
+                )
             try:
                 result = spawn_kimi(
                     prompt=instruction,

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -752,7 +752,7 @@ def _constraint_model_for_provider(args: argparse.Namespace, provider: str) -> s
     if provider == "gemini":
         return args.model if (args.model and args.model != "sonnet") else os.environ.get("VNX_GEMINI_MODEL", "gemini-2.5-pro")
     if provider == "kimi":
-        return os.environ.get("VNX_KIMI_MODEL", "") or _resolve_kimi_model_label()
+        return _kimi_resolve_requested_key(getattr(args, "model", None))
     if provider == "deepseek-harness":
         from provider_spawns.deepseek_harness_spawn import resolve_harness_model  # noqa: PLC0415
 
@@ -1359,13 +1359,24 @@ def _resolve_codex_model() -> str:
     return next(iter(cfg.models.keys()))
 
 
-def _resolve_kimi_model_label() -> str:
-    """Load kimi CLI default model key from registry (kimi_cli section), fallback to 'kimi-default'.
+class KimiModelResolutionError(ValueError):
+    """A kimi model request could not be resolved to a verified kimi-cli model.
 
-    Returns the registry model key (e.g. 'kimi-default') so the receipt model field
-    is never the generic 'default' string when VNX_KIMI_MODEL is unset.
+    Raised instead of ever silently substituting the K3 default or passing an
+    unmapped/stale string through to ``-m`` (20260721-kimi-lane-hardening) — a bad
+    request must fail the dispatch loudly, not spawn a worker with a bogus model arg.
     """
-    _KIMI_FALLBACK = "kimi-default"
+
+
+def _resolve_kimi_model_label() -> str:
+    """Load the kimi CLI default model key from the registry's ``kimi_cli`` section.
+
+    Reads the explicit ``default_model`` flag (kimi_cli.default_model in
+    wave7_models.yaml) so the default is independent of YAML dict-key order;
+    falls back to the first model key when the flag is absent/stale, and to the
+    hardcoded 'kimi-k3' when the registry itself is unavailable.
+    """
+    _KIMI_FALLBACK = "kimi-k3"
     try:
         from providers import provider_registry as _reg
         registry = _reg.load()
@@ -1375,37 +1386,95 @@ def _resolve_kimi_model_label() -> str:
     cfg = registry.get("kimi_cli")
     if cfg is None or not cfg.models:
         return _KIMI_FALLBACK
+    default_key = getattr(cfg, "default_model", None)
+    if default_key and default_key in cfg.models:
+        return default_key
     return next(iter(cfg.models.keys()))
+
+
+# Bare provider/alias tokens a caller might pass as --model — these are NOT real
+# kimi-cli model ids and must never reach _kimi_resolve_cli_model_arg raw.
+_KIMI_BARE_ALIASES = frozenset({"kimi", "kimi-default", "kimi_cli"})
+# Sentinels meaning "no explicit model was requested" (D4 in dispatch_plan.py emits
+# "default" for non-claude lanes; dispatch-agent's own CLI default is "sonnet").
+_KIMI_MODEL_PLACEHOLDERS = frozenset({"", "default", "sonnet"})
+
+
+def _kimi_normalize_alias(model_key: str) -> str:
+    """Map a bare kimi provider/alias token to the registry's default model key."""
+    normalized = (model_key or "").strip().lower()
+    if normalized in _KIMI_BARE_ALIASES:
+        return _resolve_kimi_model_label()
+    return model_key
+
+
+def _kimi_resolve_requested_key(explicit_model: Optional[str]) -> str:
+    """Resolve the effective kimi model down to a registry KEY (not a CLI arg).
+
+    Shared by the spawn seam (dispatch_envelope.ProviderAdapter, _dispatch_kimi),
+    governance labeling, and the constraint pre-flight so all three agree on the
+    same requested model. Precedence (WS2, 20260721-kimi-lane-hardening):
+      1. ``explicit_model`` when set and not a placeholder ("default"/"sonnet"/"");
+      2. else the ``VNX_KIMI_MODEL`` env var (source-path override);
+      3. else the registry's K3-flagged default.
+    Bare provider/alias tokens ('kimi', 'kimi-default') are normalized to the
+    default key at whichever precedence step they appear. Never raises — callers
+    needing the CLI arg form (and its fail-loud validation) pass the result to
+    _kimi_resolve_cli_model_arg().
+    """
+    requested = (explicit_model or "").strip()
+    if requested and requested.lower() not in _KIMI_MODEL_PLACEHOLDERS:
+        return _kimi_normalize_alias(requested)
+    env_model = os.environ.get("VNX_KIMI_MODEL", "").strip()
+    if env_model:
+        return _kimi_normalize_alias(env_model)
+    return _resolve_kimi_model_label()
 
 
 def _kimi_resolve_cli_model_arg(model_key: str) -> str:
     """Return the CLI arg form for a kimi model key.
 
     The registry uses dashes (kimi-k2-6) but the kimi CLI 1.46.0 requires dots
-    (kimi-k2.6). The registry entry's cli_model_arg field carries the authoritative
-    CLI arg; fall back to model_key unchanged for entries without the field.
+    (kimi-k2.6) or slash-form managed ids (kimi-code/k3). The registry entry's
+    cli_model_arg field carries the authoritative CLI arg.
+
+    Fail-loud (never silently substitutes K3 or passes a stale/unmapped string
+    through as ``-m``): raises KimiModelResolutionError when the registry can't
+    be loaded, when model_key resolves to a disabled (dispatch_allowed=false)
+    entry, or when model_key matches nothing in the registry at all.
     """
     try:
         from providers import provider_registry as _reg
         registry = _reg.load()
     except Exception as e:
-        logger.warning("provider_dispatch: registry load for kimi cli arg failed: %s", e)
-        return model_key
+        raise KimiModelResolutionError(
+            f"kimi model registry unavailable — refusing to guess a CLI arg for {model_key!r}: {e}"
+        ) from e
     cfg = registry.get("kimi_cli")
     if cfg is None or not cfg.models:
-        return model_key
-    # Direct registry-key lookup (e.g. model_key='kimi-k2-6')
+        raise KimiModelResolutionError("kimi_cli registry section missing or empty")
+    # Direct registry-key lookup (e.g. model_key='kimi-k3')
     entry = cfg.models.get(model_key)
     if entry is not None:
+        if not getattr(entry, "dispatch_allowed", True):
+            raise KimiModelResolutionError(
+                f"kimi model {model_key!r} is disabled (dispatch_allowed=false) — "
+                "not a currently-dispatchable kimi-cli model"
+            )
         cli_arg = getattr(entry, "cli_model_arg", None)
         return cli_arg if cli_arg else model_key
-    # model_key may already be in CLI arg form (e.g. 'kimi-k2.6'); search by cli_model_arg
+    # model_key may already be in CLI arg form (e.g. 'kimi-code/k3'); search by cli_model_arg
     model_key_lower = model_key.lower()
     for e in cfg.models.values():
+        if not getattr(e, "dispatch_allowed", True):
+            continue
         cli_arg = getattr(e, "cli_model_arg", None)
         if cli_arg and cli_arg.lower() == model_key_lower:
             return model_key
-    return model_key
+    raise KimiModelResolutionError(
+        f"unmapped kimi model {model_key!r} — not a kimi_cli registry key or a known "
+        "cli_model_arg value; refusing to guess (no silent K3 substitution)"
+    )
 
 
 def _resolve_deepseek_model() -> str:
@@ -1648,8 +1717,11 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
     """Route to spawn_kimi for kimi-provider dispatches (Wave 7.7).
 
     Auth via ``kimi login`` (OAuth). No API key env var required.
-    Model resolved via VNX_KIMI_MODEL env var or kimi config default.
-    Wires EventStore as event_writer so kimi dispatches produce a NDJSON audit trail.
+    Model resolved via the shared precedence (args.model > VNX_KIMI_MODEL > K3
+    default — 20260721-kimi-lane-hardening); a bare dispatch with neither set
+    now resolves to the registry's K3 default instead of the kimi CLI's own
+    config default. Wires EventStore as event_writer so kimi dispatches produce
+    a NDJSON audit trail.
     """
     from provider_spawns.kimi_spawn import spawn_kimi
 
@@ -1664,10 +1736,14 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         )
         return 1
 
-    model_key = os.environ.get("VNX_KIMI_MODEL", "") or None
-    model_label = model_key or _resolve_kimi_model_label()
-    # Resolve CLI arg form (e.g. kimi-k2-6 → kimi-k2.6 per kimi CLI 1.46.0)
-    model_cli_arg = _kimi_resolve_cli_model_arg(model_key) if model_key else None
+    explicit_model = getattr(args, "model", None)
+    try:
+        model_label = _kimi_resolve_requested_key(explicit_model)
+        model_cli_arg = _kimi_resolve_cli_model_arg(model_label)
+    except KimiModelResolutionError as _model_exc:
+        logger.error("_dispatch_kimi: model resolution failed for %r: %s", explicit_model, _model_exc)
+        print(f"_dispatch_kimi: model resolution failed: {_model_exc}", file=sys.stderr)
+        return 1
     enriched_instruction = _enrich_instruction(args)
     # Isolation + (bench) seed materialization. Fail-loud by design, never a
     # silent shared-checkout fallback. VNX_BENCH_REQUIRE_ISOLATION=1 (benchmark):

--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -39,6 +39,7 @@ class ProviderConfig:
     enabled: bool
     api_key_env: str
     models: Dict[str, ProviderModel] = field(default_factory=dict)
+    default_model: Optional[str] = None
 
 
 def _parse_model(data: dict) -> ProviderModel:
@@ -63,10 +64,12 @@ def _parse_provider(data: dict) -> ProviderConfig:
     models: Dict[str, ProviderModel] = {}
     for model_key, model_data in (data.get("models") or {}).items():
         models[model_key] = _parse_model(model_data)
+    default_model_raw = data.get("default_model")
     return ProviderConfig(
         enabled=bool(data.get("enabled", False)),
         api_key_env=str(data.get("api_key_env") or ""),
         models=models,
+        default_model=str(default_model_raw) if default_model_raw is not None else None,
     )
 
 

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -192,7 +192,34 @@ providers:
   kimi_cli:
     enabled: true
     api_key_env: ""  # no API key; OAuth via `kimi login`
+    # WS1 (20260721-kimi-lane-hardening): explicit default, independent of YAML key
+    # order — _resolve_kimi_model_label() reads this flag rather than "first dict key".
+    default_model: kimi-k3
     models:
+      kimi-k3:
+        litellm_name: ""  # kimi CLI direct; not via LiteLLM
+        # Verified 20260721 against the installed kimi-cli 1.46.0's own ~/.kimi/config.toml
+        # (models."kimi-code/k3", 1M context, display_name "K3") — not guessed.
+        cli_model_arg: "kimi-code/k3"
+        cost_input_per_mtok: 0.60
+        cost_output_per_mtok: 2.50
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "coding-premium", "review", "analysis"]
+        dispatch_allowed: true
+      kimi-k2-7:
+        litellm_name: ""  # kimi CLI direct; not via LiteLLM
+        # Verified 20260721 against ~/.kimi/config.toml (models."kimi-code/kimi-for-coding",
+        # display_name "K2.7 Coding"; this is the CLI's OWN config default_model).
+        cli_model_arg: "kimi-code/kimi-for-coding"
+        cost_input_per_mtok: 0.60
+        cost_output_per_mtok: 2.50
+        max_tokens: 8192
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review", "analysis"]
+        dispatch_allowed: true
       kimi-default:
         litellm_name: ""  # kimi CLI direct; not via LiteLLM
         cost_input_per_mtok: 0.60   # estimate based on moonshot K2 pricing
@@ -210,5 +237,11 @@ providers:
         supports_streaming: true
         supports_tool_calls: true
         task_classes: ["coding-premium"]
-        dispatch_allowed: true
-        cli_model_arg: "kimi-k2.6"  # kimi CLI 1.46.0 requires dots; registry key uses dashes
+        # DISABLED 20260721 (kimi-lane-hardening): kimi-cli 1.46.0 has no "kimi-k2.6"/K2.6
+        # model (verified against the installed CLI's own config.toml — only kimi-code/k3,
+        # kimi-code/kimi-for-coding, and kimi-code/kimi-for-coding-highspeed exist; K2.6 was
+        # apparently retired/renamed upstream to K2.7). The old dot-form cli_model_arg was
+        # stale and unverifiable in this env, so it is cleared (not kept) rather than passed
+        # through — disabled here so the pre-flight registry check rejects it instead of a
+        # worker silently receiving a dead `-m` string.
+        dispatch_allowed: false

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -216,6 +216,7 @@ def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
     # Stub resolution helpers and token extractor to avoid registry/env access
     monkeypatch.setattr("provider_dispatch._resolve_codex_model", lambda: "gpt-codex-test")
     monkeypatch.setattr("provider_dispatch._resolve_kimi_model_label", lambda: "kimi-test")
+    monkeypatch.setattr("provider_dispatch._kimi_resolve_cli_model_arg", lambda k: "kimi-test-cli-arg")
     monkeypatch.setattr("provider_dispatch._resolve_deepseek_model", lambda: "deepseek/test")
     monkeypatch.setattr("provider_dispatch._resolve_zai_model", lambda m=None: "openrouter/glm-test")
     monkeypatch.setattr("provider_dispatch._resolve_moonshot_model", lambda m=None: "moonshot/kimi-test")

--- a/tests/test_kimi_model_resolver.py
+++ b/tests/test_kimi_model_resolver.py
@@ -1,0 +1,471 @@
+"""Tests for the kimi model resolver (Dispatch-ID: 20260721-kimi-lane-hardening).
+
+Covers WS1 (registry: verified CLI strings, explicit K3 default, fail-loud resolver)
+and WS2 (honoring args.model at the kimi spawn seam with an unambiguous precedence),
+across both reachable seams:
+  - scripts/lib/dispatch_envelope.py ProviderAdapter.run() kimi branch (governed/door path)
+  - scripts/lib/provider_dispatch.py _dispatch_kimi (legacy CLI path)
+
+All tests use registry fixtures / mocks — none invoke the live kimi-cli OAuth binary.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+
+# ---------------------------------------------------------------------------
+# WS1 — registry: default_model flag + verified entries
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryDefaultModelFlag:
+    def test_provider_config_has_default_model_field(self):
+        from providers.provider_registry import ProviderConfig
+
+        cfg = ProviderConfig(enabled=True, api_key_env="", default_model="kimi-k3")
+        assert cfg.default_model == "kimi-k3"
+
+    def test_provider_config_default_model_defaults_to_none(self):
+        from providers.provider_registry import ProviderConfig
+
+        cfg = ProviderConfig(enabled=True, api_key_env="")
+        assert cfg.default_model is None
+
+    def test_wave7_yaml_kimi_cli_default_model_is_k3(self):
+        from providers.provider_registry import load
+
+        registry = load()
+        assert registry["kimi_cli"].default_model == "kimi-k3"
+
+    def test_resolve_kimi_model_label_honors_default_model_flag_independent_of_key_order(self):
+        """A fabricated registry with kimi-k3 as the LAST dict key must still resolve to
+        kimi-k3 via the default_model flag, not "first dict key" (loader/schema edit)."""
+        import provider_dispatch as pd
+        from providers.provider_registry import ProviderConfig, ProviderModel
+
+        def _model(cli_arg):
+            return ProviderModel(
+                litellm_name="", cost_input_per_mtok=0.0, cost_output_per_mtok=0.0,
+                max_tokens=8192, supports_streaming=True, supports_tool_calls=True,
+                cli_model_arg=cli_arg, dispatch_allowed=True,
+            )
+
+        fake_cfg = ProviderConfig(
+            enabled=True, api_key_env="", default_model="kimi-k3",
+            models={
+                "kimi-k2-7": _model("kimi-code/kimi-for-coding"),  # listed FIRST
+                "kimi-k3": _model("kimi-code/k3"),                  # listed LAST
+            },
+        )
+        with patch("providers.provider_registry.load", return_value={"kimi_cli": fake_cfg}):
+            assert pd._resolve_kimi_model_label() == "kimi-k3"
+
+    def test_resolve_kimi_model_label_falls_back_to_first_key_when_flag_stale(self):
+        """default_model pointing at a nonexistent key falls back to 'first dict key',
+        not a crash."""
+        import provider_dispatch as pd
+        from providers.provider_registry import ProviderConfig, ProviderModel
+
+        model = ProviderModel(
+            litellm_name="", cost_input_per_mtok=0.0, cost_output_per_mtok=0.0,
+            max_tokens=8192, supports_streaming=True, supports_tool_calls=True,
+        )
+        fake_cfg = ProviderConfig(
+            enabled=True, api_key_env="", default_model="kimi-does-not-exist",
+            models={"kimi-k2-7": model},
+        )
+        with patch("providers.provider_registry.load", return_value={"kimi_cli": fake_cfg}):
+            assert pd._resolve_kimi_model_label() == "kimi-k2-7"
+
+
+class TestVerifiedRegistryEntries:
+    """kimi-cli 1.46.0 model strings, verified 20260721 against the installed CLI's own
+    ~/.kimi/config.toml (models."kimi-code/k3", "kimi-code/kimi-for-coding")."""
+
+    def test_kimi_k3_cli_model_arg_verified(self):
+        from providers.provider_registry import load
+
+        entry = load()["kimi_cli"].models["kimi-k3"]
+        assert entry.cli_model_arg == "kimi-code/k3"
+        assert entry.dispatch_allowed is True
+
+    def test_kimi_k2_7_cli_model_arg_verified(self):
+        from providers.provider_registry import load
+
+        entry = load()["kimi_cli"].models["kimi-k2-7"]
+        assert entry.cli_model_arg == "kimi-code/kimi-for-coding"
+        assert entry.dispatch_allowed is True
+
+    def test_kimi_k2_6_disabled_and_cleared(self):
+        """Retired upstream — disabled rather than left dispatchable with a stale arg."""
+        from providers.provider_registry import load
+
+        entry = load()["kimi_cli"].models["kimi-k2-6"]
+        assert entry.dispatch_allowed is False
+
+
+# ---------------------------------------------------------------------------
+# WS2 — _kimi_resolve_requested_key: precedence + bare-alias normalization
+# ---------------------------------------------------------------------------
+
+
+class TestResolveRequestedKeyPrecedence:
+    def test_explicit_model_wins_over_env(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-k2-7")
+        assert pd._kimi_resolve_requested_key("kimi-k3") == "kimi-k3"
+
+    def test_env_used_when_no_explicit_model(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-k2-7")
+        assert pd._kimi_resolve_requested_key(None) == "kimi-k2-7"
+
+    def test_default_placeholder_falls_through_to_env(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-k2-7")
+        assert pd._kimi_resolve_requested_key("default") == "kimi-k2-7"
+
+    def test_sonnet_placeholder_falls_through_to_env(self, monkeypatch):
+        """'sonnet' is dispatch-agent's own CLI default, not a real kimi model request."""
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-k2-7")
+        assert pd._kimi_resolve_requested_key("sonnet") == "kimi-k2-7"
+
+    def test_none_case_resolves_to_k3_default(self, monkeypatch):
+        """No explicit model, no env var -> the registry's K3-flagged default (WS2 #3)."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        assert pd._kimi_resolve_requested_key(None) == "kimi-k3"
+
+    def test_empty_string_env_treated_as_unset(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "")
+        assert pd._kimi_resolve_requested_key(None) == "kimi-k3"
+
+    @pytest.mark.parametrize("bare_token", ["kimi", "kimi-default", "KIMI", "Kimi-Default"])
+    def test_bare_provider_alias_resolves_to_k3_default(self, monkeypatch, bare_token):
+        """'kimi'/'kimi-default' are provider/alias tokens, not model ids — resolve to K3."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        assert pd._kimi_resolve_requested_key(bare_token) == "kimi-k3"
+
+    def test_bare_alias_via_env_also_resolves(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-default")
+        assert pd._kimi_resolve_requested_key(None) == "kimi-k3"
+
+    def test_explicit_real_model_id_passes_through_unresolved(self, monkeypatch):
+        """A real model id (not a bare alias) is returned as-is — validity is checked later
+        by _kimi_resolve_cli_model_arg, not by this precedence resolver."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        assert pd._kimi_resolve_requested_key("kimi-k2-7") == "kimi-k2-7"
+        assert pd._kimi_resolve_requested_key("kimi-bogus") == "kimi-bogus"
+
+
+# ---------------------------------------------------------------------------
+# WS1 — _kimi_resolve_cli_model_arg: fail-loud, no substitution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveCliModelArgFailLoud:
+    def test_verified_key_resolves_to_verified_cli_arg(self):
+        import provider_dispatch as pd
+
+        assert pd._kimi_resolve_cli_model_arg("kimi-k3") == "kimi-code/k3"
+        assert pd._kimi_resolve_cli_model_arg("kimi-k2-7") == "kimi-code/kimi-for-coding"
+
+    def test_unmapped_model_raises_not_returns_raw(self):
+        """The core bug being fixed: an unmapped model must never come back unchanged."""
+        import provider_dispatch as pd
+
+        with pytest.raises(pd.KimiModelResolutionError):
+            pd._kimi_resolve_cli_model_arg("kimi-bogus")
+
+    def test_unmapped_model_never_silently_substitutes_k3(self):
+        import provider_dispatch as pd
+
+        with pytest.raises(pd.KimiModelResolutionError) as exc_info:
+            pd._kimi_resolve_cli_model_arg("kimi-bogus")
+        assert "kimi-code/k3" not in str(exc_info.value)
+
+    def test_disabled_model_raises(self):
+        import provider_dispatch as pd
+
+        with pytest.raises(pd.KimiModelResolutionError, match="disabled"):
+            pd._kimi_resolve_cli_model_arg("kimi-k2-6")
+
+    def test_registry_load_failure_raises_not_returns_raw(self):
+        import provider_dispatch as pd
+
+        with patch("providers.provider_registry.load", side_effect=FileNotFoundError("no yaml")):
+            with pytest.raises(pd.KimiModelResolutionError):
+                pd._kimi_resolve_cli_model_arg("kimi-k3")
+
+    def test_kimi_cli_section_missing_raises(self):
+        import provider_dispatch as pd
+
+        with patch("providers.provider_registry.load", return_value={}):
+            with pytest.raises(pd.KimiModelResolutionError):
+                pd._kimi_resolve_cli_model_arg("kimi-k3")
+
+    def test_reverse_lookup_still_works_for_cli_arg_form_input(self):
+        """A caller already passing the CLI-arg form ('kimi-code/k3') gets it back unchanged."""
+        import provider_dispatch as pd
+
+        assert pd._kimi_resolve_cli_model_arg("kimi-code/k3") == "kimi-code/k3"
+
+
+# ---------------------------------------------------------------------------
+# WS2 — _dispatch_kimi (legacy/secondary seam): args.model honored end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _build_args(**overrides):
+    defaults = {
+        "provider": "kimi",
+        "terminal_id": "T1",
+        "dispatch_id": "test-dispatch-kimi-resolver",
+        "instruction": "Say hi",
+        "model": "sonnet",
+        "max_retries": 3,
+        "no_auto_commit": False,
+        "gate": "",
+        "dispatch_paths": "",
+        "pr_id": None,
+        "role": None,
+    }
+    defaults.update(overrides)
+    return argparse.Namespace(**defaults)
+
+
+class TestDispatchKimiModelResolution:
+    def _make_success_result(self):
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        return KimiSpawnResult(
+            returncode=0, completion_text="hi", events_written=1, session_id=None,
+            timed_out=False, token_usage={"input_tokens": 1, "output_tokens": 1},
+        )
+
+    def test_none_case_spawns_with_k3_cli_arg(self, monkeypatch):
+        """A bare dispatch (args.model='sonnet' placeholder, no env) resolves to K3 — the
+        None-case bug (line ~1670 pre-fix: model_cli_arg stayed None -> CLI's own default)."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        args = _build_args(model="sonnet")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
+             patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/r.ndjson")), \
+             patch("governance_emit.emit_unified_report", return_value=Path("/tmp/r.md")):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 0
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/k3"
+
+    def test_explicit_model_honored_over_default(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        args = _build_args(model="kimi-k2-7")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
+             patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/r.ndjson")), \
+             patch("governance_emit.emit_unified_report", return_value=Path("/tmp/r.md")):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 0
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/kimi-for-coding"
+
+    def test_env_var_honored_when_no_explicit_model(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.setenv("VNX_KIMI_MODEL", "kimi-k2-7")
+        args = _build_args(model="sonnet")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
+             patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/r.ndjson")), \
+             patch("governance_emit.emit_unified_report", return_value=Path("/tmp/r.md")):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 0
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/kimi-for-coding"
+
+    def test_bare_provider_alias_resolves_to_k3(self, monkeypatch):
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        args = _build_args(model="kimi")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()), \
+             patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/r.ndjson")), \
+             patch("governance_emit.emit_unified_report", return_value=Path("/tmp/r.md")):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 0
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/k3"
+
+    def test_bogus_model_fails_loud_never_spawns(self, monkeypatch):
+        """--model kimi-bogus must fail before spawn_kimi is ever invoked — no `-m` emitted,
+        no silent K3 substitution."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        args = _build_args(model="kimi-bogus")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 1
+        spawn_mock.assert_not_called()
+
+    def test_disabled_model_fails_loud_never_spawns(self, monkeypatch):
+        """--model kimi-k2-6 (retired/disabled) must fail before spawn — no stale arg passed."""
+        import provider_dispatch as pd
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        args = _build_args(model="kimi-k2-6")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("event_store.EventStore", return_value=MagicMock()):
+            exit_code = pd._dispatch_kimi(args)
+
+        assert exit_code == 1
+        spawn_mock.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# WS2 — ProviderAdapter.run() kimi branch (governed/door seam, dispatch_envelope.py)
+# ---------------------------------------------------------------------------
+
+
+def _make_kimi_plan(tmp_path, model):
+    """Minimal ExecutionPlan for the kimi provider (dispatch_envelope.ProviderAdapter)."""
+    from dispatch_plan import ExecutionPlan
+    from dispatch_spec import DispatchPath, Isolation, Provider
+
+    instruction_file = tmp_path / "inst.md"
+    instruction_file.write_text("test instruction", encoding="utf-8")
+    import hashlib
+
+    sha = hashlib.sha256(instruction_file.read_bytes()).hexdigest()
+    return ExecutionPlan(
+        dispatch_id="test-kimi-seam",
+        project_id="test-project",
+        provider=Provider.KIMI,
+        model=model,
+        lane="provider",
+        adapter="provider",
+        target_id="ephemeral",
+        billing="subscription",
+        serialization_class=None,
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="n/a",
+        deadline_seconds=3600,
+        base_ref="origin/main",
+        dispatch_paths=(),
+        instruction_file=instruction_file,
+        route_reason="test",
+        instruction_sha256=sha,
+    )
+
+
+class TestProviderAdapterKimiSeam:
+    def _make_success_result(self):
+        from provider_spawns.kimi_spawn import KimiSpawnResult
+
+        return KimiSpawnResult(
+            returncode=0, completion_text="hi", events_written=1, session_id=None,
+            timed_out=False, token_usage={"input_tokens": 1, "output_tokens": 1},
+        )
+
+    def test_explicit_model_reaches_spawn_as_verified_cli_arg(self, tmp_path, monkeypatch):
+        from dispatch_envelope import ProviderAdapter
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        plan = _make_kimi_plan(tmp_path, model="kimi-k3")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("provider_dispatch._extract_token_usage", return_value={}):
+            result = ProviderAdapter().run(plan, "prompt")
+
+        assert result.status == "success"
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/k3"
+
+    def test_default_placeholder_resolves_to_k3(self, tmp_path, monkeypatch):
+        from dispatch_envelope import ProviderAdapter
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        plan = _make_kimi_plan(tmp_path, model="default")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("provider_dispatch._extract_token_usage", return_value={}):
+            result = ProviderAdapter().run(plan, "prompt")
+
+        assert result.status == "success"
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/k3"
+
+    def test_bogus_model_fails_loud_never_spawns(self, tmp_path, monkeypatch):
+        from dispatch_envelope import ProviderAdapter
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        plan = _make_kimi_plan(tmp_path, model="kimi-bogus")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock):
+            result = ProviderAdapter().run(plan, "prompt")
+
+        assert result.status == "failure"
+        assert "kimi-code/k3" not in (result.error or "")
+        spawn_mock.assert_not_called()
+
+    def test_bare_provider_alias_resolves_to_k3(self, tmp_path, monkeypatch):
+        from dispatch_envelope import ProviderAdapter
+
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        plan = _make_kimi_plan(tmp_path, model="kimi")
+        spawn_mock = MagicMock(return_value=self._make_success_result())
+
+        with patch("provider_spawns.kimi_spawn.spawn_kimi", spawn_mock), \
+             patch("provider_dispatch._extract_token_usage", return_value={}):
+            result = ProviderAdapter().run(plan, "prompt")
+
+        assert result.status == "success"
+        assert spawn_mock.call_args.kwargs["model"] == "kimi-code/k3"

--- a/tests/test_pr10_provider_string_canon.py
+++ b/tests/test_pr10_provider_string_canon.py
@@ -3,8 +3,9 @@
 Covers the five fixes in PR-10:
   P2-1: model sentinel "default"/None must not over-reject via model-not-in-current-registry
   P2-2: deepseek-harness registry key maps to "deepseek"
-  kimi: kimi-k2.6 (CLI dots) and kimi-k2-6 (registry dashes) both pass constraint;
-        spawn receives CLI arg form (kimi-k2.6)
+  kimi: kimi-k3 / kimi-k2-7 (verified kimi-cli 1.46.0 registry keys) pass constraint,
+        spawn receives the verified CLI arg form; kimi-k2-6/kimi-k2.6 is retired
+        upstream (20260721-kimi-lane-hardening) and is now dispatch_allowed=false
   GLM:  glm-5/5.1 route -> litellm:zai; glm-4.5/4.6 stay blocked
   split: kimi_cli entries are dispatch_allowed=True; moonshot entries are dispatch_allowed=False
 """
@@ -109,21 +110,31 @@ class TestDeepseekHarnessRegistryKey:
 
 class TestKimiKeyArgMapping:
 
-    def test_kimi_k2_6_dot_form_passes_constraint(self, enforcer):
-        """VNX_KIMI_MODEL=kimi-k2.6 (CLI form) must pass the registry constraint."""
+    def test_kimi_k3_passes_constraint(self, enforcer):
+        """model=kimi-k3 (verified kimi-cli 1.46.0 default) must pass the registry constraint."""
         violations = enforcer.check_constraints(
-            provider="kimi", model="kimi-k2.6", check_registry=True,
+            provider="kimi", model="kimi-k3", check_registry=True,
         )
         codes = [v.code for v in violations]
         assert "model-not-in-current-registry" not in codes, codes
 
-    def test_kimi_k2_6_dash_form_passes_constraint(self, enforcer):
-        """model=kimi-k2-6 (registry key form) must pass the registry constraint."""
+    def test_kimi_k2_7_passes_constraint(self, enforcer):
+        """model=kimi-k2-7 (verified kimi-cli 1.46.0 model) must pass the registry constraint."""
+        violations = enforcer.check_constraints(
+            provider="kimi", model="kimi-k2-7", check_registry=True,
+        )
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" not in codes, codes
+
+    def test_kimi_k2_6_now_deprecated_blocked(self, enforcer):
+        """kimi-k2-6/kimi-k2.6 is retired in kimi-cli 1.46.0 (no such model in the CLI's own
+        config; superseded by kimi-for-coding/K2.7) — disabled via dispatch_allowed=false so
+        the registry check rejects it instead of a worker silently receiving a dead CLI arg."""
         violations = enforcer.check_constraints(
             provider="kimi", model="kimi-k2-6", check_registry=True,
         )
         codes = [v.code for v in violations]
-        assert "model-not-in-current-registry" not in codes, codes
+        assert "model-not-in-current-registry" in codes, codes
 
     def test_kimi_default_passes_constraint(self, enforcer):
         violations = enforcer.check_constraints(
@@ -142,27 +153,39 @@ class TestKimiKeyArgMapping:
         # kimi-k2-0905-default is only in moonshot (dispatch_allowed=false), not kimi_cli
         assert "model-not-in-current-registry" in codes, codes
 
-    def test_kimi_cli_resolve_arg_dot_form_returns_dot(self):
+    def test_kimi_cli_resolve_arg_k3_returns_verified_string(self):
         import provider_dispatch as pd
-        result = pd._kimi_resolve_cli_model_arg("kimi-k2.6")
-        assert result == "kimi-k2.6"
+        result = pd._kimi_resolve_cli_model_arg("kimi-k3")
+        assert result == "kimi-code/k3"
 
-    def test_kimi_cli_resolve_arg_dash_form_returns_dot(self):
+    def test_kimi_cli_resolve_arg_k2_7_returns_verified_string(self):
         import provider_dispatch as pd
-        result = pd._kimi_resolve_cli_model_arg("kimi-k2-6")
-        assert result == "kimi-k2.6"
+        result = pd._kimi_resolve_cli_model_arg("kimi-k2-7")
+        assert result == "kimi-code/kimi-for-coding"
 
     def test_kimi_cli_resolve_arg_default_unchanged(self):
         import provider_dispatch as pd
         result = pd._kimi_resolve_cli_model_arg("kimi-default")
         assert result == "kimi-default"
 
-    def test_kimi_constraint_not_fail_closed_on_k2_6(self, enforcer):
-        """k2.6 must NOT raise ConstraintViolationError — not a forbidden route."""
+    def test_kimi_cli_resolve_arg_k2_6_raises_disabled(self):
+        """kimi-k2-6 is dispatch_allowed=false (retired) — resolving it must fail loud,
+        never silently pass the old dash-form key through as a `-m` argument."""
+        import provider_dispatch as pd
+        with pytest.raises(pd.KimiModelResolutionError):
+            pd._kimi_resolve_cli_model_arg("kimi-k2-6")
+
+    def test_kimi_constraint_fail_closed_on_k2_6(self, enforcer):
+        """kimi-k2-6 IS now blocked — it is retired/dispatch_allowed=false, not a forbidden route."""
+        with pytest.raises(ConstraintViolationError, match="model-not-in-current-registry"):
+            enforcer.enforce(provider="kimi", model="kimi-k2-6", check_registry=True)
+
+    def test_kimi_constraint_not_fail_closed_on_k3(self, enforcer):
+        """kimi-k3 must NOT raise ConstraintViolationError — the verified, dispatchable default."""
         try:
-            enforcer.enforce(provider="kimi", model="kimi-k2.6", check_registry=True)
+            enforcer.enforce(provider="kimi", model="kimi-k3", check_registry=True)
         except ConstraintViolationError as e:
-            pytest.fail(f"kimi-k2.6 should not be blocked but got: {e}")
+            pytest.fail(f"kimi-k3 should not be blocked but got: {e}")
 
 
 # ---------------------------------------------------------------------------
@@ -217,10 +240,23 @@ class TestKimiDispatchAllowedSplit:
         entry = registry["kimi_cli"].models["kimi-default"]
         assert entry.dispatch_allowed is True
 
-    def test_kimi_cli_kimi_k2_6_dispatch_allowed(self):
+    def test_kimi_cli_kimi_k2_6_dispatch_disabled(self):
+        """kimi-k2-6 is retired upstream (20260721-kimi-lane-hardening) — dispatch_allowed=False."""
         from providers.provider_registry import load
         registry = load()
         entry = registry["kimi_cli"].models["kimi-k2-6"]
+        assert entry.dispatch_allowed is False
+
+    def test_kimi_cli_kimi_k3_dispatch_allowed(self):
+        from providers.provider_registry import load
+        registry = load()
+        entry = registry["kimi_cli"].models["kimi-k3"]
+        assert entry.dispatch_allowed is True
+
+    def test_kimi_cli_kimi_k2_7_dispatch_allowed(self):
+        from providers.provider_registry import load
+        registry = load()
+        entry = registry["kimi_cli"].models["kimi-k2-7"]
         assert entry.dispatch_allowed is True
 
     def test_moonshot_kimi_k2_0905_not_dispatch_allowed(self):
@@ -235,11 +271,30 @@ class TestKimiDispatchAllowedSplit:
         entry = registry["moonshot"].models["kimi-k2-6"]
         assert entry.dispatch_allowed is False
 
-    def test_kimi_cli_k2_6_has_cli_model_arg(self):
+    def test_kimi_cli_k2_6_cli_model_arg_cleared(self):
+        """The stale dot-form cli_model_arg is cleared (not kept) on the disabled entry —
+        it was never verified against a live kimi-cli 1.46.0 model."""
         from providers.provider_registry import load
         registry = load()
         entry = registry["kimi_cli"].models["kimi-k2-6"]
-        assert entry.cli_model_arg == "kimi-k2.6"
+        assert not entry.cli_model_arg
+
+    def test_kimi_cli_k3_has_verified_cli_model_arg(self):
+        from providers.provider_registry import load
+        registry = load()
+        entry = registry["kimi_cli"].models["kimi-k3"]
+        assert entry.cli_model_arg == "kimi-code/k3"
+
+    def test_kimi_cli_k2_7_has_verified_cli_model_arg(self):
+        from providers.provider_registry import load
+        registry = load()
+        entry = registry["kimi_cli"].models["kimi-k2-7"]
+        assert entry.cli_model_arg == "kimi-code/kimi-for-coding"
+
+    def test_kimi_cli_default_model_flag(self):
+        from providers.provider_registry import load
+        registry = load()
+        assert registry["kimi_cli"].default_model == "kimi-k3"
 
     def test_moonshot_not_a_governed_dispatch_route(self, enforcer):
         """moonshot models are dispatch_allowed=False — registry check rejects them."""

--- a/tests/test_receipt_deterministic_fixes.py
+++ b/tests/test_receipt_deterministic_fixes.py
@@ -79,12 +79,12 @@ class TestResolveKimiModelLabel:
         assert result != "default", "should not return generic 'default' — use registry key"
 
     def test_fallback_when_registry_unavailable(self):
-        """When registry raises, falls back to 'kimi-default'."""
+        """When registry raises, falls back to the K3 default (20260721-kimi-lane-hardening)."""
         import provider_dispatch
 
         with patch("providers.provider_registry.load", side_effect=FileNotFoundError("no yaml")):
             result = provider_dispatch._resolve_kimi_model_label()
-        assert result == "kimi-default"
+        assert result == "kimi-k3"
 
     def test_fallback_when_kimi_cli_missing_from_registry(self):
         """When kimi_cli section is absent, returns hardcoded fallback."""
@@ -93,7 +93,7 @@ class TestResolveKimiModelLabel:
         mock_registry = {}  # empty — no 'kimi_cli' key
         with patch("providers.provider_registry.load", return_value=mock_registry):
             result = provider_dispatch._resolve_kimi_model_label()
-        assert result == "kimi-default"
+        assert result == "kimi-k3"
 
 
 class TestDispatchCodexModelNonEmpty:


### PR DESCRIPTION
## Summary

Fixes the consumer kimi lane (`vnx dispatch-agent --model kimi-*` → `LLMNotSet`/empty stream-json).

**TASK 0 traced seam (confirmed, not assumed):** the reachable seam for the consumer path is `dispatch_envelope.py` `ProviderAdapter.run()`'s kimi branch (was line 817), which passed `plan.model` **raw** to `spawn_kimi`, entirely bypassing `_kimi_resolve_cli_model_arg`. `_dispatch_kimi` (`provider_dispatch.py`) is a secondary/legacy path reached only via `provider_dispatch.py`'s own argparse CLI, not through the door — also fixed for consistency.

The registry's `cli_model_arg` values were additionally stale: `kimi-k2.6` does not exist in the installed kimi-cli 1.46.0 (verified against `~/.kimi/config.toml`; only `kimi-code/k3`, `kimi-code/kimi-for-coding`, `kimi-code/kimi-for-coding-highspeed` exist).

## Changes

**WS1 — registry (`scripts/lib/providers/wave7_models.yaml`, `provider_registry.py`, `provider_dispatch.py`)**
- Added verified `kimi-k3` (`cli_model_arg: kimi-code/k3`) and `kimi-k2-7` (`cli_model_arg: kimi-code/kimi-for-coding`) entries.
- Added an explicit `default_model: kimi-k3` flag at the `kimi_cli` level; `ProviderConfig` gained a `default_model` field (loader/schema edit) so `_resolve_kimi_model_label()` no longer depends on YAML dict-key order.
- Disabled the stale `kimi-k2-6`/`kimi-k2.6` entry (`dispatch_allowed: false`, `cli_model_arg` cleared) — no such model exists in the verified CLI.
- `_kimi_resolve_cli_model_arg()` now raises `KimiModelResolutionError` (never returns the raw/unmapped key) on registry-load failure, a disabled entry, or a genuinely unmapped model — no silent K3 substitution, no silent stale-string passthrough.

**WS2 — seam wiring**
- New shared `_kimi_resolve_requested_key()`: precedence `args.model`/`plan.model` (not a `default`/`sonnet`/empty placeholder) → `VNX_KIMI_MODEL` env → registry K3 default. Bare provider/alias tokens (`kimi`, `kimi-default`) normalize to the default at whichever step they appear.
- Wired into all three places that need to agree: the envelope's kimi branch (primary seam), `_dispatch_kimi` (secondary seam — also fixes the pre-existing "`None` model_key never resolves" bug so a bare dispatch now gets K3 instead of the CLI's own default), and `_constraint_model_for_provider`'s kimi branch (pre-flight/governance labeling, previously ignored `args.model` entirely).

## Verification

Targeted suite (all kimi/provider-dispatch/envelope/registry tests), before vs. after compared against `origin/main` via `git stash`:

```
python3 -m pytest tests/test_kimi_model_resolver.py tests/test_pr10_provider_string_canon.py \
  tests/test_receipt_deterministic_fixes.py tests/test_constraint_enforcer_kimi_valid.py \
  tests/test_provider_dispatch_kimi.py tests/test_kimi_spawn.py tests/test_wave7_kimi_smoke.py \
  tests/test_dispatch_envelope_plan.py tests/test_dispatch_envelope.py tests/test_kimi_wrapper.py -q
# 249 passed, 8 failed
```

All 8 failures are **pre-existing on origin/main**, confirmed via `git stash` + re-run in isolation before touching anything — unrelated to this change (a sandboxed-worktree `.git/worktrees` path issue, and a `mock_emit()`/`event_store` kwarg signature mismatch in two receipt tests). None involve kimi model resolution.

37 new tests added in `tests/test_kimi_model_resolver.py` covering: registry `default_model` flag independent of key order, verified CLI strings, precedence (explicit > env > K3 default), bare-alias normalization, fail-loud on unmapped/disabled/registry-unavailable (no substitution), and both seams (`ProviderAdapter.run()` kimi branch + `_dispatch_kimi`) end-to-end with mocked `spawn_kimi` — no live CLI invoked.

A broader sweep (`-k "kimi or provider_registry or provider_dispatch or dispatch_envelope or ..."`, ~924 tests) showed zero regressions vs. baseline; a full-suite run was attempted but the repo's ~17.5k-test suite runs too slowly in this sandbox to complete (killed after 15 min at ~0% progress with no forward motion — a pre-existing environment characteristic, not something this diff caused).

## Open Items

1. **Door pre-flight gate does not honor the bare-alias normalization for `vnx dispatch-agent --model kimi`.** Confirmed via direct call: `_model_in_registry('kimi', None, 'kimi')` → `False` (the door's `dispatch_cli.build_runtime_snapshot`/`constraint_enforcer._model_in_registry` pre-flight check is a **different, earlier gate** than the one this PR fixes, and uses the raw `spec.model` — not `_kimi_resolve_requested_key`). Net effect: `vnx dispatch-agent --model kimi-k3` works end-to-end (verified); a **bare** `vnx dispatch-agent --model kimi` (no explicit model id) would currently be rejected at this earlier pre-flight stage with `model-not-in-current-registry`, before ever reaching this PR's fix. By contrast the **legacy** `provider_dispatch.py` CLI path already normalizes the bare alias in `_constraint_model_for_provider` before its own registry check, so bare `--model kimi` works end-to-end there today. Fixing the door's gate would mean touching `constraint_enforcer.py`/`dispatch_cli.py` (shared by every provider, not kimi-specific) — out of this PR's listed file scope. Deferred; reproducing case included above.
2. **Envelope-path receipt/governance labeling for a default/unresolved `plan.model`** (e.g. `"default"`/`"sonnet"`) still shows the raw placeholder in the receipt, not the resolved key — confirmed this is a **pre-existing, cross-provider gap** in `run_envelope_plan`/`_govern` (codex has the identical gap via its own `_resolve_codex_model()`), not something introduced or unique to kimi. Fixing it symmetrically for all providers is out of scope here (dispatch explicitly excludes codex/glm/deepseek lane changes). `_dispatch_kimi`'s own receipt label (the in-scope secondary seam) **is** fixed — it now derives from the resolved key.
3. **Edge propagation** (publishing to `~/.vnx-system/versions/edge`) is an operational post-merge step for T0/operator — not done here.
4. **phantom_guard()** was not modified (out of scope, confirmed correct per dispatch instructions) and no reproducing case of a false phantom-reject was hit during this fix, so there is nothing to flag there.

Dispatch-ID: 20260721-kimi-lane-hardening