### PR TITLE
fix(kimi-lane): door pre-flight bare-alias normalization + function-size split (#1190 follow-ups)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -811,39 +811,7 @@ class ProviderAdapter:
 
         # ---- kimi ----
         if pv == Provider.KIMI:
-            from provider_spawns.kimi_spawn import spawn_kimi  # noqa: PLC0415
-            from provider_dispatch import (  # noqa: PLC0415
-                KimiModelResolutionError,
-                _kimi_resolve_cli_model_arg,
-                _kimi_resolve_requested_key,
-            )
-
-            # Shared resolver (20260721-kimi-lane-hardening): args.model/plan.model >
-            # VNX_KIMI_MODEL > registry K3 default; bare provider/alias tokens ("kimi",
-            # "kimi-default") normalize to the default; an unmapped/stale model_key RAISES
-            # instead of ever being passed raw to `-m` or silently substituted with K3.
-            try:
-                model = _kimi_resolve_cli_model_arg(_kimi_resolve_requested_key(plan.model))
-            except KimiModelResolutionError as exc:
-                return _AdapterResult(
-                    returncode=1, completion_text="", status="failure",
-                    error=f"kimi model resolution failed: {exc}",
-                )
-            try:
-                result = spawn_kimi(
-                    prompt=instruction,
-                    model=model,
-                    dispatch_id=plan.dispatch_id,
-                    terminal_id=plan.target_id,
-                    event_writer=event_writer,
-                    cwd=cwd,
-                )
-            except BrokenPipeError as exc:
-                return _AdapterResult(
-                    returncode=1, completion_text="", status="failure",
-                    error=f"kimi spawn BrokenPipeError: {exc}",
-                )
-            return _map_generic_spawn_result(result, pv.value)
+            return self._run_kimi(plan, instruction, event_writer=event_writer, cwd=cwd)
 
         # ---- gemini ----
         if pv == Provider.GEMINI:
@@ -1080,6 +1048,53 @@ class ProviderAdapter:
             f"claude and auto do not route through the provider envelope "
             f"(claude_tmux_subscription is executed by the tmux lane, wired in PR-4)"
         )
+
+    def _run_kimi(
+        self,
+        plan: "ExecutionPlan",
+        instruction: str,
+        *,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        """Kimi spawn branch, extracted from run() (OI-709 function-size gate).
+
+        Pure extraction — behavior identical to the former inline kimi branch.
+        """
+        from dispatch_spec import Provider  # noqa: PLC0415
+        from provider_spawns.kimi_spawn import spawn_kimi  # noqa: PLC0415
+        from provider_dispatch import (  # noqa: PLC0415
+            KimiModelResolutionError,
+            _kimi_resolve_cli_model_arg,
+            _kimi_resolve_requested_key,
+        )
+
+        # Shared resolver (20260721-kimi-lane-hardening): args.model/plan.model >
+        # VNX_KIMI_MODEL > registry K3 default; bare provider/alias tokens ("kimi",
+        # "kimi-default") normalize to the default; an unmapped/stale model_key RAISES
+        # instead of ever being passed raw to `-m` or silently substituted with K3.
+        try:
+            model = _kimi_resolve_cli_model_arg(_kimi_resolve_requested_key(plan.model))
+        except KimiModelResolutionError as exc:
+            return _AdapterResult(
+                returncode=1, completion_text="", status="failure",
+                error=f"kimi model resolution failed: {exc}",
+            )
+        try:
+            result = spawn_kimi(
+                prompt=instruction,
+                model=model,
+                dispatch_id=plan.dispatch_id,
+                terminal_id=plan.target_id,
+                event_writer=event_writer,
+                cwd=cwd,
+            )
+        except BrokenPipeError as exc:
+            return _AdapterResult(
+                returncode=1, completion_text="", status="failure",
+                error=f"kimi spawn BrokenPipeError: {exc}",
+            )
+        return _map_generic_spawn_result(result, Provider.KIMI.value)
 
 
 def run_envelope_plan(

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -222,7 +222,8 @@ def _kimi_bare_alias_registry_default(model_norm: str) -> Optional[str]:
         return None
     try:
         registry = _load_registry()
-    except Exception:
+    except Exception as e:
+        logger.warning("constraint_enforcer: registry load for kimi bare-alias default failed: %s", e)
         return None
     cfg = registry.get("kimi_cli")
     if cfg is None:

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -81,6 +81,14 @@ def _provider_parts(provider: Optional[str], sub_provider: Optional[str]) -> tup
 
 _NATIVE_CLI_PROVIDERS = frozenset({"claude", "codex", "gemini", "kimi"})
 
+# Bare provider/alias tokens a caller might pass as --model for the kimi provider —
+# mirrors provider_dispatch._KIMI_BARE_ALIASES (20260721-kimi-lane-hardening, OI-707).
+# These are NOT real kimi-cli model ids; normalized to the registry default before
+# the model-in-registry gate below so a bare `--model kimi` isn't rejected at this
+# earlier door pre-flight (the shared resolver in provider_dispatch already handles
+# them once the plan reaches ProviderAdapter.run(), but this gate runs first).
+_KIMI_BARE_ALIASES = frozenset({"kimi", "kimi-default", "kimi_cli"})
+
 
 def _effective_provider(provider: Optional[str], sub_provider: Optional[str]) -> Optional[str]:
     base, sub = _provider_parts(provider, sub_provider)
@@ -201,6 +209,26 @@ def _model_matches(model: Optional[str], spec: Any) -> bool:
     if model is None:
         return False
     return bool(_registry_model_aliases(model) & _registry_model_aliases(str(spec)))
+
+
+def _kimi_bare_alias_registry_default(model_norm: str) -> Optional[str]:
+    """Resolve a bare kimi alias ('kimi', 'kimi-default', 'kimi_cli') to the
+    registry's kimi_cli.default_model key — single source of truth, no hardcoded
+    model id (OI-707). Returns None for anything that isn't a recognized bare
+    alias, so a real/unmapped id (e.g. 'kimi-bogus') is left untouched and still
+    fails the registry gate below instead of being silently substituted.
+    """
+    if model_norm not in _KIMI_BARE_ALIASES:
+        return None
+    try:
+        registry = _load_registry()
+    except Exception:
+        return None
+    cfg = registry.get("kimi_cli")
+    if cfg is None:
+        return None
+    default_key = getattr(cfg, "default_model", None)
+    return default_key or None
 
 
 def _model_in_registry(provider: Optional[str], sub_provider: Optional[str], model: Optional[str]) -> bool:
@@ -520,16 +548,25 @@ class ConstraintEnforcer:
                 message=f"Route forbidden: {model} is deprecated; use glm-5.1.",
             ))
 
-        if check_registry and model and not _model_in_registry(base, sub, model):
-            registry_key = _registry_key_for(base, sub) or "unknown"
-            violations.append(ConstraintViolation(
-                code="model-not-in-current-registry",
-                severity="blocking",
-                message=(
-                    f"Route forbidden: model {model!r} is not registered for "
-                    f"provider {provider!r} (registry key {registry_key!r})."
-                ),
-            ))
+        if check_registry and model:
+            # OI-707: a bare `--model kimi`/`kimi-default` reaching this door
+            # pre-flight normalizes to the registry default before the lookup —
+            # a real unmapped id (e.g. 'kimi-bogus') is untouched and still fails.
+            registry_check_model = model
+            if _norm(base) == "kimi":
+                bare_alias_default = _kimi_bare_alias_registry_default(model_norm)
+                if bare_alias_default:
+                    registry_check_model = bare_alias_default
+            if not _model_in_registry(base, sub, registry_check_model):
+                registry_key = _registry_key_for(base, sub) or "unknown"
+                violations.append(ConstraintViolation(
+                    code="model-not-in-current-registry",
+                    severity="blocking",
+                    message=(
+                        f"Route forbidden: model {model!r} is not registered for "
+                        f"provider {provider!r} (registry key {registry_key!r})."
+                    ),
+                ))
 
         return violations
 

--- a/tests/test_constraint_enforcer_kimi_bare_alias.py
+++ b/tests/test_constraint_enforcer_kimi_bare_alias.py
@@ -1,0 +1,117 @@
+"""OI-707 — door pre-flight must normalize a bare kimi alias before the registry gate.
+
+Repro this closes: `_model_in_registry('kimi', None, 'kimi')` -> False. A bare
+`vnx dispatch-agent --model kimi` (provider name, not a model id) was rejected by
+the door pre-flight (`dispatch_cli.build_runtime_snapshot` ->
+`constraint_enforcer.check_constraints(check_registry=True)`) BEFORE ever reaching
+ProviderAdapter.run()'s shared kimi resolver (20260721-kimi-lane-hardening,
+_kimi_resolve_requested_key/_kimi_resolve_cli_model_arg). `--model kimi-k3`
+(explicit id) already worked end-to-end.
+
+The fix normalizes bare kimi aliases ('kimi', 'kimi-default', 'kimi_cli') to the
+registry's kimi_cli.default_model flag BEFORE the model-in-registry check —
+single source of truth, no hardcoded model id. A real/unmapped id (e.g.
+'kimi-bogus') must still be rejected: this is a targeted alias normalization,
+not a weakened gate.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(_LIB))
+
+from providers.constraint_enforcer import ConstraintEnforcer, _kimi_bare_alias_registry_default
+
+
+@pytest.fixture(scope="module")
+def enforcer() -> ConstraintEnforcer:
+    return ConstraintEnforcer()
+
+
+# ---------------------------------------------------------------------------
+# Against the real (committed, static) registry — same convention as
+# test_pr10_provider_string_canon.py::TestKimiKeyArgMapping.
+# ---------------------------------------------------------------------------
+
+
+class TestBareKimiAliasAgainstRealRegistry:
+
+    def test_bare_kimi_passes_registry_check(self, enforcer):
+        """The exact OI-707 repro: model='kimi' (bare provider name) must now pass."""
+        violations = enforcer.check_constraints(provider="kimi", model="kimi", check_registry=True)
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" not in codes, codes
+
+    def test_bare_kimi_default_alias_passes_registry_check(self, enforcer):
+        violations = enforcer.check_constraints(
+            provider="kimi", model="kimi-default", check_registry=True,
+        )
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" not in codes, codes
+
+    def test_explicit_kimi_k3_still_passes(self, enforcer):
+        """Explicit model ids must keep passing unchanged (no regression)."""
+        violations = enforcer.check_constraints(provider="kimi", model="kimi-k3", check_registry=True)
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" not in codes, codes
+
+    def test_unmapped_kimi_model_still_rejected(self, enforcer):
+        """A real/unmapped id must still fail — the alias fix must not weaken the gate."""
+        violations = enforcer.check_constraints(
+            provider="kimi", model="kimi-bogus", check_registry=True,
+        )
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" in codes, codes
+
+    def test_non_kimi_provider_not_special_cased(self, enforcer):
+        """The alias normalization is kimi-only: the literal string 'kimi' as a model
+        for another provider must not get a free pass."""
+        violations = enforcer.check_constraints(provider="codex", model="kimi", check_registry=True)
+        codes = [v.code for v in violations]
+        assert "model-not-in-current-registry" in codes, codes
+
+
+# ---------------------------------------------------------------------------
+# Mocked registry — proves the helper reads kimi_cli.default_model dynamically
+# (single source of truth), never hardcodes "kimi-k3".
+# ---------------------------------------------------------------------------
+
+
+class TestBareAliasHelperReadsRegistryDefaultDynamically:
+
+    def test_returns_none_for_non_alias_model(self):
+        assert _kimi_bare_alias_registry_default("kimi-bogus") is None
+
+    def test_resolves_to_registrys_default_model_flag(self, monkeypatch):
+        fake_cfg = SimpleNamespace(default_model="some-future-default")
+        monkeypatch.setattr(
+            "providers.constraint_enforcer._load_registry",
+            lambda: {"kimi_cli": fake_cfg},
+        )
+        assert _kimi_bare_alias_registry_default("kimi") == "some-future-default"
+        assert _kimi_bare_alias_registry_default("kimi-default") == "some-future-default"
+        assert _kimi_bare_alias_registry_default("kimi_cli") == "some-future-default"
+
+    def test_returns_none_when_registry_unavailable(self, monkeypatch):
+        def _boom():
+            raise RuntimeError("registry unavailable")
+
+        monkeypatch.setattr("providers.constraint_enforcer._load_registry", _boom)
+        assert _kimi_bare_alias_registry_default("kimi") is None
+
+    def test_returns_none_when_kimi_cli_section_missing(self, monkeypatch):
+        monkeypatch.setattr("providers.constraint_enforcer._load_registry", lambda: {})
+        assert _kimi_bare_alias_registry_default("kimi") is None
+
+    def test_returns_none_when_default_model_flag_absent(self, monkeypatch):
+        fake_cfg = SimpleNamespace(default_model=None)
+        monkeypatch.setattr(
+            "providers.constraint_enforcer._load_registry",
+            lambda: {"kimi_cli": fake_cfg},
+        )
+        assert _kimi_bare_alias_registry_default("kimi") is None

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -15,6 +15,7 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
 from typing import Any, Dict, Optional
 from unittest.mock import MagicMock, patch
 
@@ -187,8 +188,18 @@ def test_rejects_non_provider_lane(tmp_path):
 # ---------------------------------------------------------------------------
 
 
-def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
-    """Each supported provider routes to its spawn_*; no _dispatch_* wrappers invoked."""
+@pytest.fixture
+def stubbed_provider_spawns(monkeypatch):
+    """Stub every provider spawn_* and resolver helper (registry/env/CLI-free).
+
+    Split out of the former single test_provider_adapter_routes_each_provider
+    (OI-709, function-size gate) so each provider gets its own <70-line test
+    function while sharing the same routing-mock setup.
+
+    Returns a SimpleNamespace(calls, litellm_calls, dispatch_wrapper_called) —
+    `calls`/`litellm_calls` record each spawn_* invocation; `dispatch_wrapper_called`
+    must stay empty (the envelope must never call a _dispatch_* wrapper directly).
+    """
     calls: Dict[str, Dict[str, Any]] = {}
     litellm_calls: list = []
 
@@ -230,7 +241,7 @@ def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
     )
 
     # Track _dispatch_* calls — must all remain uncalled
-    dispatch_wrapper_called = []
+    dispatch_wrapper_called: list = []
     for fn_name in [
         "_dispatch_codex", "_dispatch_kimi", "_dispatch_gemini",
         "_dispatch_litellm", "_dispatch_deepseek_harness", "_dispatch_local_gemma",
@@ -241,65 +252,99 @@ def test_provider_adapter_routes_each_provider(tmp_path, monkeypatch):
             return _bad
         monkeypatch.setattr(f"provider_dispatch.{fn_name}", _make_bad(fn_name))
 
-    adapter = ProviderAdapter()
-    instruction_file = tmp_path / "inst.md"
-    instruction_file.write_text("test instruction", encoding="utf-8")
+    return SimpleNamespace(
+        calls=calls, litellm_calls=litellm_calls, dispatch_wrapper_called=dispatch_wrapper_called
+    )
 
-    # codex
-    calls.clear()
+
+def test_provider_adapter_routes_codex(tmp_path, stubbed_provider_spawns):
+    """codex routes to spawn_codex; no _dispatch_* wrapper invoked."""
+    adapter = ProviderAdapter()
     r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.CODEX, model="default"), "prompt")
     assert r.status == "success", f"codex: {r}"
-    assert "codex" in calls
+    assert "codex" in stubbed_provider_spawns.calls
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # kimi
-    calls.clear()
+
+def test_provider_adapter_routes_kimi(tmp_path, stubbed_provider_spawns):
+    """kimi routes to spawn_kimi (via ProviderAdapter._run_kimi); no _dispatch_* wrapper invoked."""
+    adapter = ProviderAdapter()
     r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.KIMI, model="default"), "prompt")
     assert r.status == "success", f"kimi: {r}"
-    assert "kimi" in calls
+    assert "kimi" in stubbed_provider_spawns.calls
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # gemini
-    calls.clear()
+
+def test_provider_adapter_routes_gemini(tmp_path, stubbed_provider_spawns):
+    """gemini routes to spawn_gemini; no _dispatch_* wrapper invoked."""
+    adapter = ProviderAdapter()
     r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.GEMINI, model="default"), "prompt")
     assert r.status == "success", f"gemini: {r}"
-    assert "gemini" in calls
+    assert "gemini" in stubbed_provider_spawns.calls
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # litellm:deepseek
-    litellm_calls.clear()
-    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_DEEPSEEK, model="default"), "prompt")
+
+def test_provider_adapter_routes_litellm_deepseek(tmp_path, stubbed_provider_spawns):
+    """litellm:deepseek routes to spawn_litellm with the resolved deepseek model."""
+    adapter = ProviderAdapter()
+    r = adapter.run(
+        _make_provider_plan(tmp_path, provider=Provider.LITELLM_DEEPSEEK, model="default"), "prompt"
+    )
     assert r.status == "success", f"litellm:deepseek: {r}"
+    litellm_calls = stubbed_provider_spawns.litellm_calls
     assert litellm_calls, "spawn_litellm not called for litellm:deepseek"
     assert litellm_calls[-1]["kwargs"].get("sub_provider") == "deepseek"
     assert litellm_calls[-1]["kwargs"].get("model") == "deepseek/test"
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # litellm:zai — model resolved to the zai registry model
-    litellm_calls.clear()
-    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_ZAI, model="default"), "prompt")
+
+def test_provider_adapter_routes_litellm_zai(tmp_path, stubbed_provider_spawns):
+    """litellm:zai routes to spawn_litellm with the resolved zai registry model."""
+    adapter = ProviderAdapter()
+    r = adapter.run(
+        _make_provider_plan(tmp_path, provider=Provider.LITELLM_ZAI, model="default"), "prompt"
+    )
     assert r.status == "success", f"litellm:zai: {r}"
+    litellm_calls = stubbed_provider_spawns.litellm_calls
     assert litellm_calls, "spawn_litellm not called for litellm:zai"
     assert litellm_calls[-1]["kwargs"].get("sub_provider") == "zai"
     assert litellm_calls[-1]["kwargs"].get("model") == "openrouter/glm-test"
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # litellm:moonshot
-    litellm_calls.clear()
-    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LITELLM_MOONSHOT, model="default"), "prompt")
+
+def test_provider_adapter_routes_litellm_moonshot(tmp_path, stubbed_provider_spawns):
+    """litellm:moonshot routes to spawn_litellm with sub_provider=moonshot."""
+    adapter = ProviderAdapter()
+    r = adapter.run(
+        _make_provider_plan(tmp_path, provider=Provider.LITELLM_MOONSHOT, model="default"), "prompt"
+    )
     assert r.status == "success", f"litellm:moonshot: {r}"
+    litellm_calls = stubbed_provider_spawns.litellm_calls
     assert litellm_calls, "spawn_litellm not called for litellm:moonshot"
     assert litellm_calls[-1]["kwargs"].get("sub_provider") == "moonshot"
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # deepseek-harness
-    calls.clear()
-    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.DEEPSEEK_HARNESS, model="default"), "prompt")
+
+def test_provider_adapter_routes_deepseek_harness(tmp_path, stubbed_provider_spawns):
+    """deepseek-harness routes to spawn_deepseek_harness; no _dispatch_* wrapper invoked."""
+    adapter = ProviderAdapter()
+    r = adapter.run(
+        _make_provider_plan(tmp_path, provider=Provider.DEEPSEEK_HARNESS, model="default"), "prompt"
+    )
     assert r.status == "success", f"deepseek-harness: {r}"
-    assert "deepseek_harness" in calls
+    assert "deepseek_harness" in stubbed_provider_spawns.calls
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
-    # local-gemma
-    calls.clear()
-    r = adapter.run(_make_provider_plan(tmp_path, provider=Provider.LOCAL_GEMMA, model="default"), "prompt")
+
+def test_provider_adapter_routes_local_gemma(tmp_path, stubbed_provider_spawns):
+    """local-gemma routes to spawn_local_gemma; no _dispatch_* wrapper invoked."""
+    adapter = ProviderAdapter()
+    r = adapter.run(
+        _make_provider_plan(tmp_path, provider=Provider.LOCAL_GEMMA, model="default"), "prompt"
+    )
     assert r.status == "success", f"local-gemma: {r}"
-    assert "local_gemma" in calls
-
-    # No _dispatch_* wrappers must have been invoked
-    assert dispatch_wrapper_called == [], f"_dispatch_* wrappers were invoked: {dispatch_wrapper_called}"
+    assert "local_gemma" in stubbed_provider_spawns.calls
+    assert stubbed_provider_spawns.dispatch_wrapper_called == []
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups from the #1190 (kimi-lane-hardening) review, both PR-scoped and code-grounded against origin/main.

**OI-707** — `vnx dispatch-agent --model kimi` (bare provider name, no explicit model id) was rejected at the door pre-flight with `model-not-in-current-registry`, before ever reaching `ProviderAdapter.run()`'s shared kimi resolver added in #1190. `constraint_enforcer.check_constraints` now normalizes a bare kimi alias (`kimi`, `kimi-default`, `kimi_cli`) to the registry's `kimi_cli.default_model` flag before the registry gate — single source of truth, no hardcoded model id. `--model kimi-k3` (explicit id) already worked and is unchanged; a real/unmapped id (e.g. `kimi-bogus`) still fails the gate.

**OI-709** — codex-gate flagged two oversized functions in #1190:
1. `ProviderAdapter.run()`'s kimi branch (imports + try/except resolver calls) extracted into a private `_run_kimi()` helper — pure extraction, identical behavior.
2. `test_provider_adapter_routes_each_provider` split into one test per provider (codex/kimi/gemini/litellm:deepseek/litellm:zai/litellm:moonshot/deepseek-harness/local-gemma), sharing a `stubbed_provider_spawns` fixture for the common mock setup.

## Changes

- `scripts/lib/dispatch_envelope.py` — `ProviderAdapter._run_kimi()` extracted from `run()`'s kimi branch (316 → 284 total lines; the kimi branch itself dropped from ~35 to a 2-line call). **Note:** `run()` still exceeds a 70-line budget — it dispatches across 7 providers, each already tens of lines, a pre-existing condition unrelated to the kimi branch (confirmed: the function was already ~300 lines *before* #1190's kimi changes). Extracting the other 6 provider branches was out of this dispatch's stated scope.
- `scripts/lib/providers/constraint_enforcer.py` — added `_KIMI_BARE_ALIASES` + `_kimi_bare_alias_registry_default()` (reads `kimi_cli.default_model` from the registry, mirrors `provider_dispatch._kimi_normalize_alias`'s alias set without a circular import), wired into the `check_registry` gate in `check_constraints`.
- `tests/test_dispatch_envelope_plan.py` — replaced the single oversized `test_provider_adapter_routes_each_provider` with a `stubbed_provider_spawns` fixture + 8 per-provider tests (all <70 lines).
- `tests/test_constraint_enforcer_kimi_bare_alias.py` (new) — 10 tests: real-registry coverage of the OI-707 repro (`model='kimi'`, `'kimi-default'`, `'kimi-k3'`, `'kimi-bogus'`, cross-provider non-special-casing) + mocked-registry coverage proving the helper reads `default_model` dynamically (not hardcoded).

## Verification

```
python3 -m pytest tests/test_dispatch_envelope_plan.py tests/test_pr10_provider_string_canon.py \
  tests/test_kimi_model_resolver.py tests/test_constraint_enforcer.py \
  tests/test_constraint_enforcer_kimi_valid.py tests/test_constraint_enforcer_kimi_bare_alias.py -q
```
**167 passed, 3 failed, 1 skipped.**

All 3 failures confirmed pre-existing on origin/main via `git stash` (+ `git stash -u` to also exclude the new untracked test file) and re-running identically: 2 in `test_dispatch_envelope_plan.py` (`.git/worktrees` path error specific to this sandboxed nested-worktree environment) + 1 in `test_constraint_enforcer.py::TestWorkersSonnetPinned::test_t2_with_sonnet_allowed` (stale `claude-sonnet-4-6` fixture vs. the 2026-07-05 Sonnet-5 bump — unrelated to this diff).

Broader regression sweep:
```
python3 -m pytest tests/ -q -k "kimi or constraint_enforcer or dispatch_envelope or provider_dispatch or provider_registry"
```
32 failed, 661 passed (baseline: 32 failed, 644 passed — same 32 failures, identical set, confirmed via `git stash -u`).

Direct acceptance-criteria check against the live registry:
```
provider=kimi model=kimi        -> []  (was: model-not-in-current-registry)
provider=kimi model=kimi-default -> []
provider=kimi model=kimi-k3     -> []
provider=kimi model=kimi-bogus  -> ['model-not-in-current-registry']  (still rejected)
```

`python3 -m py_compile` + `ruff check` clean on all modified files (pre-existing `ruff`/lint findings, e.g. forward-ref `F821`s and `E402` from the `sys.path.insert` test pattern, confirmed unchanged vs. baseline).

## Open Items

1. **`ProviderAdapter.run()` still exceeds a 70-line budget** (284 lines) — inherent to dispatching across 7 providers, each already substantial; extracting the kimi branch alone (as this dispatch scoped) cannot get the whole function under that bar. A full fix would mean extracting all 7 provider branches into private helpers — out of this dispatch's stated scope (only the kimi branch was named). Flagging as a deferred follow-up if the codex-gate re-flags the residual size.
2. No live kimi-cli invoked anywhere in the new/modified tests (fixtures + real static registry file only, per dispatch instruction).
3. `phantom_guard()`, receipt-v2, and codex/glm/deepseek lanes were not touched (out of scope, confirmed).

None of the above blocks this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)