### PR TITLE
fix(gate): isolate codex/gemini gate subprocess in a PR-branch worktree

### DIFF
--- a/scripts/gate_runner.py
+++ b/scripts/gate_runner.py
@@ -28,6 +28,7 @@ from headless_adapter import gate_timeout, gate_stall_threshold
 import gate_recorder as _rec
 import gate_artifacts as _art
 import vertex_ai_runner as _vtx
+from gate_worktree import create_gate_worktree, remove_gate_worktree, GateWorktreeError
 from prompt_assembler import PromptAssembler, format_for_provider
 
 _REVIEWER_VERDICT_TEMPLATE = (
@@ -61,11 +62,18 @@ GATE_CLI_ARGS: Dict[str, List[str]] = {
 class GateRunner:
     """Subprocess-based gate execution with timeout and stall detection."""
 
-    def __init__(self, state_dir: Path, reports_dir: Path) -> None:
+    def __init__(
+        self, state_dir: Path, reports_dir: Path, *, project_root: Optional[Path] = None,
+    ) -> None:
         self._state_dir = state_dir
         self._reports_dir = reports_dir
         self._requests_dir = state_dir / "review_gates" / "requests"
         self._results_dir = state_dir / "review_gates" / "results"
+        # Explicit project root for isolated gate-worktree checkout (OI-708).
+        # When unset, create_gate_worktree/remove_gate_worktree fall back to
+        # git-based auto-detection — callers that construct GateRunner from a
+        # resolved ReviewGateManager should always pass this explicitly.
+        self._project_root = project_root
 
     def run(
         self,
@@ -159,12 +167,46 @@ class GateRunner:
         self, *, gate: str, binary: str, prompt: str,
         pr_number: Optional[int], pr_id: str, request_payload: Dict[str, Any],
     ) -> Dict[str, Any]:
-        """Execute gate via subprocess with stall detection, then record result."""
-        result = self._run_with_stall_detection(
-            gate=gate, binary=binary, prompt=prompt,
-            timeout=gate_timeout(gate), stall_threshold=gate_stall_threshold(gate),
-            request_payload=request_payload,
-        )
+        """Execute gate via subprocess with stall detection, then record result.
+
+        Runs the subprocess with `cwd` at an isolated worktree checked out from
+        `origin/<branch>` (OI-708) so the gate agent's own file reads (sed/rg/
+        cat, etc.) reflect the PR branch under review instead of the
+        orchestrator's local (possibly stale) checkout. If worktree creation
+        itself fails, the gate fails loud here — no silent fallback to the
+        ambient checkout. Once created, the worktree is removed unconditionally
+        afterward, whether the subprocess run succeeds or fails.
+        """
+        if pr_id:
+            identifier = pr_id
+        elif pr_number is not None:
+            identifier = str(pr_number)
+        else:
+            identifier = "unknown"
+        try:
+            worktree_path = create_gate_worktree(
+                branch=request_payload.get("branch", ""), gate=gate, identifier=identifier,
+                project_root=self._project_root,
+            )
+        except GateWorktreeError as exc:
+            return _rec.record_failure_simple(
+                gate=gate, pr_number=pr_number, pr_id=pr_id,
+                reason="worktree_checkout_failed",
+                reason_detail=str(exc),
+                request_payload=request_payload,
+                requests_dir=self._requests_dir, results_dir=self._results_dir,
+            )
+
+        try:
+            result = self._run_with_stall_detection(
+                gate=gate, binary=binary, prompt=prompt,
+                timeout=gate_timeout(gate), stall_threshold=gate_stall_threshold(gate),
+                request_payload=request_payload,
+                cwd=worktree_path,
+            )
+        finally:
+            remove_gate_worktree(worktree_path, project_root=self._project_root)
+
         if result["status"] == "failed":
             return _rec.record_failure(
                 gate=gate, pr_number=pr_number, pr_id=pr_id,
@@ -414,8 +456,14 @@ class GateRunner:
         timeout: int,
         stall_threshold: int,
         request_payload: Dict[str, Any],
+        cwd: Optional[Path] = None,
     ) -> Dict[str, Any]:
-        """Spawn subprocess and monitor for timeout/stall (GATE-6/7/8)."""
+        """Spawn subprocess and monitor for timeout/stall (GATE-6/7/8).
+
+        `cwd` (OI-708) pins the subprocess's working directory to the isolated
+        gate worktree so the gate agent's own file reads match the PR branch
+        under review instead of the orchestrator's ambient checkout.
+        """
         cmd = self._build_gate_cmd(gate, binary, request_payload)
         start = time.monotonic()
         try:
@@ -423,6 +471,7 @@ class GateRunner:
                 cmd,
                 stdin=subprocess.PIPE, stdout=subprocess.PIPE, stderr=subprocess.PIPE,
                 start_new_session=True,
+                cwd=str(cwd) if cwd else None,
             )
         except OSError as exc:
             return {

--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -127,6 +127,7 @@ class GateExecutorMixin:
         runner = GateRunner(
             state_dir=self.state_dir,
             reports_dir=self.reports_dir,
+            project_root=Path(self.paths["PROJECT_ROOT"]),
         )
         return runner.run(
             gate=gate,

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -42,6 +42,8 @@ EXECUTION_FAILURE_REASONS: frozenset = frozenset({
     "exit_nonzero", "timeout", "stall", "stalled", "killed",
     # Subprocess / binary
     "subprocess_error", "subprocess_failed", "binary_not_found",
+    # Isolated-checkout setup (OI-708)
+    "worktree_checkout_failed",
     # Artifact and content issues
     "artifact_materialization_error", "artifact_materialization_failed",
     "empty_review_content", "validation_failed",

--- a/scripts/lib/gate_worktree.py
+++ b/scripts/lib/gate_worktree.py
@@ -190,23 +190,28 @@ def remove_gate_worktree(wt_path: Optional[Path], *, project_root: Optional[Path
                     "git worktree remove failed: %s; falling back to shutil.rmtree", detail,
                 )
                 resolved = wt_path.resolve()
-                managed_root = (root / ".vnx-data" / "worktrees").resolve()
-                try:
-                    resolved.relative_to(managed_root)
-                except ValueError:
-                    log.warning(
-                        "refusing rmtree: %s is not under the managed worktree root %s",
-                        resolved, managed_root,
-                    )
-                    return
-                if not resolved.name.startswith(_MANAGED_WORKTREE_PREFIX):
-                    log.warning(
-                        "refusing rmtree: %s leaf name does not start with the managed "
-                        "prefix %r", resolved, _MANAGED_WORKTREE_PREFIX,
-                    )
-                    return
                 if wt_path.is_symlink():
                     log.warning("refusing rmtree: %s is a symlink", wt_path)
+                    return
+                # Verify the STRUCTURE of the actual path being removed — a
+                # managed gate worktree always looks like
+                # ``.vnx-data/worktrees/gate-*`` — rather than reconstructing
+                # an expected root from project_root (which may itself fall
+                # back to a __file__-anchored resolution). All three checks
+                # are plain string comparisons on `resolved`, a function
+                # parameter, never a Path(...) join.
+                grandparent_name = resolved.parent.parent.name
+                parent_name = resolved.parent.name
+                if not (
+                    resolved.name.startswith(_MANAGED_WORKTREE_PREFIX)
+                    and parent_name == "worktrees"
+                    and grandparent_name == ".vnx-data"
+                ):
+                    log.warning(
+                        "refusing rmtree: %s does not match the managed gate-worktree "
+                        "structure ('.vnx-data/worktrees/%s*'); got parent=%r grandparent=%r",
+                        resolved, _MANAGED_WORKTREE_PREFIX, parent_name, grandparent_name,
+                    )
                     return
                 shutil.rmtree(str(resolved), ignore_errors=True)
 

--- a/scripts/lib/gate_worktree.py
+++ b/scripts/lib/gate_worktree.py
@@ -32,6 +32,15 @@ log = logging.getLogger(__name__)
 _UNSAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
 _MAX_SAFE_LEN = 60
 
+# Conservative git ref-name allowlist: must start with an alnum (never '-', so
+# a branch cannot be mistaken for a git option), and contain only the chars
+# real branch names use. Whitespace of any kind is excluded implicitly.
+_SAFE_BRANCH_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
+
+# Managed worktree directory prefix — must match _worktree_dir() below. Used
+# by remove_gate_worktree to scope its shutil.rmtree fallback.
+_MANAGED_WORKTREE_PREFIX = "gate-"
+
 
 class GateWorktreeError(RuntimeError):
     """Raised when a gate's isolated worktree cannot be created.
@@ -60,8 +69,22 @@ def _worktree_dir(project_root: Path, gate: str, identifier: str) -> Path:
     token = secrets.token_hex(4)
     return (
         project_root / ".vnx-data" / "worktrees"
-        / f"gate-{_sanitize(gate)}-{_sanitize(identifier)}-{token}"
+        / f"{_MANAGED_WORKTREE_PREFIX}{_sanitize(gate)}-{_sanitize(identifier)}-{token}"
     )
+
+
+def _validate_branch(branch: str, *, gate: str, identifier: str) -> None:
+    """Reject any branch that is not a safe git ref name.
+
+    MUST run before any git subprocess call: a branch beginning with '-'
+    (e.g. ``--upload-pack=...``) would otherwise be parsed by git as an
+    option rather than a ref.
+    """
+    if not _SAFE_BRANCH_RE.match(branch):
+        raise GateWorktreeError(
+            f"create_gate_worktree: unsafe branch {branch!r} rejected before any git call "
+            f"(gate={gate!r}, identifier={identifier!r})"
+        )
 
 
 @contextmanager
@@ -105,6 +128,7 @@ def create_gate_worktree(
             "create_gate_worktree requires a non-empty branch "
             f"(gate={gate!r}, identifier={identifier!r})"
         )
+    _validate_branch(branch, gate=gate, identifier=identifier)
 
     root = _resolve_project_root(project_root)
     wt_path = _worktree_dir(root, gate, identifier)
@@ -166,7 +190,21 @@ def remove_gate_worktree(wt_path: Optional[Path], *, project_root: Optional[Path
                     "git worktree remove failed: %s; falling back to shutil.rmtree", detail,
                 )
                 resolved = wt_path.resolve()
-                resolved.relative_to(root)  # safety: refuse rmtree outside project root
+                managed_root = (root / ".vnx-data" / "worktrees").resolve()
+                try:
+                    resolved.relative_to(managed_root)
+                except ValueError:
+                    log.warning(
+                        "refusing rmtree: %s is not under the managed worktree root %s",
+                        resolved, managed_root,
+                    )
+                    return
+                if not resolved.name.startswith(_MANAGED_WORKTREE_PREFIX):
+                    log.warning(
+                        "refusing rmtree: %s leaf name does not start with the managed "
+                        "prefix %r", resolved, _MANAGED_WORKTREE_PREFIX,
+                    )
+                    return
                 if wt_path.is_symlink():
                     log.warning("refusing rmtree: %s is a symlink", wt_path)
                     return

--- a/scripts/lib/gate_worktree.py
+++ b/scripts/lib/gate_worktree.py
@@ -1,0 +1,184 @@
+"""gate_worktree.py — ephemeral git worktree checkout for gate execution (OI-708).
+
+codex_gate and gemini_review spawn a real CLI agent (codex/gemini) that can run
+its own shell tools (sed/rg/cat/...) against whatever `cwd` the subprocess
+inherits. The gate's diff is fetched authoritatively via `gh pr diff`, but the
+agent's OWN file reads previously hit the orchestrator's ambient working
+directory — which can be stale relative to the PR branch (uncommitted local
+drift, or simply not fast-forwarded to `origin/<branch>` HEAD).
+
+This module checks out `origin/<branch>` into an isolated, detached-HEAD git
+worktree so the gate subprocess's `cwd` matches the diff it is reviewing, and
+removes the worktree unconditionally afterward (success or failure) so no
+per-execution worktree leaks and the orchestrator's own checkout is never
+touched (no `git checkout` in the caller's tree).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import logging
+import re
+import secrets
+import shutil
+import subprocess
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Optional
+
+log = logging.getLogger(__name__)
+
+# Collapse any char that is not alphanumeric, hyphen, or underscore.
+_UNSAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+_MAX_SAFE_LEN = 60
+
+
+class GateWorktreeError(RuntimeError):
+    """Raised when a gate's isolated worktree cannot be created.
+
+    Callers MUST treat this as a gate execution failure — never fall back to
+    running the gate subprocess in the orchestrator's ambient checkout, as
+    that reintroduces the stale-checkout bug this module exists to fix.
+    """
+
+
+def _sanitize(value: str) -> str:
+    return _UNSAFE_RE.sub("-", value or "")[:_MAX_SAFE_LEN] or "unknown"
+
+
+def _resolve_project_root(project_root: Optional[Path]) -> Path:
+    if project_root is not None:
+        return project_root.resolve()
+    try:
+        from project_root import resolve_project_root  # type: ignore[attr-defined]
+        return Path(resolve_project_root(__file__)).resolve()
+    except Exception:
+        return Path(__file__).resolve().parents[2]
+
+
+def _worktree_dir(project_root: Path, gate: str, identifier: str) -> Path:
+    token = secrets.token_hex(4)
+    return (
+        project_root / ".vnx-data" / "worktrees"
+        / f"gate-{_sanitize(gate)}-{_sanitize(identifier)}-{token}"
+    )
+
+
+@contextmanager
+def _worktree_lock(root: Path):
+    """Serialize `git worktree` add/remove via an exclusive fcntl lock.
+
+    Uses the SAME lock path as dispatch_worktree_isolation / tmux_worktree
+    (``<repo>/.git/worktrees/.vnx-lock``) so gate execution never races other
+    lanes' concurrent ``git worktree add/remove`` against this repo.
+    """
+    lock_dir = (root / ".git").resolve() / "worktrees"
+    lock_dir.mkdir(parents=True, exist_ok=True)
+    lock_path = lock_dir / ".vnx-lock"
+    with open(lock_path, "a") as lf:
+        fcntl.flock(lf, fcntl.LOCK_EX)
+        try:
+            yield
+        finally:
+            fcntl.flock(lf, fcntl.LOCK_UN)
+
+
+def create_gate_worktree(
+    *,
+    branch: str,
+    gate: str,
+    identifier: str,
+    project_root: Optional[Path] = None,
+) -> Path:
+    """Fetch origin/<branch> and check it out into an isolated detached worktree.
+
+    Steps:
+      1. git fetch origin <branch>
+      2. git worktree add --detach <path> origin/<branch>
+
+    Raises GateWorktreeError when branch is empty or either git step fails —
+    callers must fail the gate rather than silently falling back to the
+    orchestrator's (possibly stale) checkout.
+    """
+    if not branch:
+        raise GateWorktreeError(
+            "create_gate_worktree requires a non-empty branch "
+            f"(gate={gate!r}, identifier={identifier!r})"
+        )
+
+    root = _resolve_project_root(project_root)
+    wt_path = _worktree_dir(root, gate, identifier)
+    wt_path.parent.mkdir(parents=True, exist_ok=True)
+
+    try:
+        subprocess.run(
+            ["git", "fetch", "origin", branch],
+            cwd=str(root), check=True, capture_output=True, text=True, timeout=30,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise GateWorktreeError(
+            f"create_gate_worktree: git fetch origin {branch!r} failed: {detail}"
+        ) from exc
+
+    try:
+        with _worktree_lock(root):
+            subprocess.run(
+                ["git", "worktree", "add", "--detach", str(wt_path), f"origin/{branch}"],
+                cwd=str(root), check=True, capture_output=True, text=True, timeout=30,
+            )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise GateWorktreeError(
+            f"create_gate_worktree: git worktree add failed for gate={gate!r} "
+            f"branch={branch!r}: {detail}"
+        ) from exc
+
+    log.info("gate worktree created: %s (origin/%s, detached)", wt_path, branch)
+    return wt_path.resolve()
+
+
+def remove_gate_worktree(wt_path: Optional[Path], *, project_root: Optional[Path] = None) -> None:
+    """Remove a gate worktree. Best-effort + idempotent — never raises.
+
+    Called on both success and failure paths (including when the gate
+    subprocess itself failed) so no worktree ever leaks past one gate
+    execution.
+    """
+    if not wt_path:
+        return
+    wt_path = Path(wt_path)
+    if not wt_path.exists():
+        return
+
+    root = _resolve_project_root(project_root)
+    try:
+        with _worktree_lock(root):
+            try:
+                subprocess.run(
+                    ["git", "worktree", "remove", "--force", str(wt_path)],
+                    cwd=str(root), check=True, capture_output=True, text=True, timeout=30,
+                )
+                log.info("gate worktree removed: %s", wt_path)
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+                detail = getattr(exc, "stderr", "") or str(exc)
+                log.warning(
+                    "git worktree remove failed: %s; falling back to shutil.rmtree", detail,
+                )
+                resolved = wt_path.resolve()
+                resolved.relative_to(root)  # safety: refuse rmtree outside project root
+                if wt_path.is_symlink():
+                    log.warning("refusing rmtree: %s is a symlink", wt_path)
+                    return
+                shutil.rmtree(str(resolved), ignore_errors=True)
+
+            try:
+                subprocess.run(
+                    ["git", "worktree", "prune"],
+                    cwd=str(root), check=True, capture_output=True, text=True, timeout=30,
+                )
+            except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+                detail = getattr(exc, "stderr", "") or str(exc)
+                log.warning("git worktree prune failed: %s", detail)
+    except Exception as exc:  # pragma: no cover - cleanup must never raise
+        log.warning("remove_gate_worktree: unexpected error removing %s: %s", wt_path, exc)

--- a/tests/test_gate_execution_certification.py
+++ b/tests/test_gate_execution_certification.py
@@ -28,7 +28,17 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_runner
 from gate_runner import GateRunner
+
+
+@pytest.fixture(autouse=True)
+def _fake_gate_worktree(tmp_path, monkeypatch):
+    """Default OI-708 worktree checkout to a no-op fake — see test_gate_runner.py."""
+    fake_path = tmp_path / "_fake_gate_worktree"
+    monkeypatch.setattr(gate_runner, "create_gate_worktree", lambda **kw: fake_path)
+    monkeypatch.setattr(gate_runner, "remove_gate_worktree", lambda *a, **kw: None)
+    return fake_path
 
 
 @pytest.fixture

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -27,7 +27,25 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_runner
 from gate_runner import GateRunner
+
+
+@pytest.fixture(autouse=True)
+def _fake_gate_worktree(tmp_path, monkeypatch):
+    """Default OI-708 worktree checkout to a no-op fake for tests unrelated to it.
+
+    Without this, every `runner.run(gate="codex_gate"/"gemini_review", ...)`
+    call in this file would try a REAL `git fetch`/`git worktree add` (see
+    gate_worktree.create_gate_worktree), which is neither hermetic nor fast.
+    Tests that specifically exercise the worktree-checkout mechanism override
+    these via their own ``with patch(...)`` block, which nests correctly over
+    this default for the duration of that test.
+    """
+    fake_path = tmp_path / "_fake_gate_worktree"
+    monkeypatch.setattr(gate_runner, "create_gate_worktree", lambda **kw: fake_path)
+    monkeypatch.setattr(gate_runner, "remove_gate_worktree", lambda *a, **kw: None)
+    return fake_path
 
 
 @pytest.fixture
@@ -811,3 +829,195 @@ class TestGateTimeoutConfig:
         from headless_adapter import gate_timeout, gate_stall_threshold
         assert gate_timeout("unknown_gate") == 600  # DEFAULT_TIMEOUT
         assert gate_stall_threshold("unknown_gate") == 60
+
+
+class TestGateWorktreeCheckout:
+    """OI-708: codex_gate/gemini_review subprocess must run with cwd at an
+    isolated worktree checked out from origin/<branch>, never the
+    orchestrator's ambient checkout. See scripts/lib/gate_worktree.py.
+
+    These tests override the file-level `_fake_gate_worktree` autouse fixture
+    with explicit patches so they can assert on the exact call args.
+    """
+
+    @staticmethod
+    def _mock_completed_proc(output: bytes, pid=55555):
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stdout.fileno.return_value = 10
+        mock_proc.stderr.fileno.return_value = 11
+        mock_proc.poll.return_value = 0
+        mock_proc.returncode = 0
+        mock_proc.pid = pid
+
+        read_count = [0]
+
+        def mock_os_read(fd, size):
+            read_count[0] += 1
+            if fd == 10 and read_count[0] == 1:
+                return output
+            return b""
+
+        return mock_proc, mock_os_read
+
+    def test_subprocess_cwd_is_the_created_worktree(self, gate_env, monkeypatch, tmp_path):
+        """Popen must receive cwd= the exact path returned by create_gate_worktree."""
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"],
+            reports_dir=gate_env["reports_dir"],
+            project_root=gate_env["project_root"],
+        )
+
+        report_path = str(gate_env["reports_dir"] / "worktree-cwd-report.md")
+        payload = _make_request_payload(
+            gate="codex_gate", report_path=report_path, branch="fix/oi-708",
+        )
+
+        fake_worktree = tmp_path / "isolated-worktree-abcd1234"
+        review_output = b'{"type":"message","message":"LGTM"}\nAll clear.\nNo issues.\n'
+        mock_proc, mock_os_read = self._mock_completed_proc(review_output)
+
+        with patch("gate_runner.create_gate_worktree", return_value=fake_worktree) as mock_create, \
+             patch("gate_runner.remove_gate_worktree") as mock_remove, \
+             patch("gate_runner.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("gate_runner.select.select", return_value=([], [], [])), \
+             patch("gate_runner.os.read", side_effect=mock_os_read), \
+             patch("gate_runner.os.getpgid", return_value=mock_proc.pid):
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
+
+        assert result["status"] == "completed"
+
+        # create_gate_worktree called with the request's branch, gate name, PR
+        # identifier, and the GateRunner's own resolved project_root.
+        mock_create.assert_called_once_with(
+            branch="fix/oi-708", gate="codex_gate", identifier="1",
+            project_root=gate_env["project_root"],
+        )
+
+        # The codex subprocess must run with cwd = the created worktree, not
+        # the orchestrator's ambient cwd (which Popen would inherit if cwd=None).
+        popen_kwargs = mock_popen.call_args.kwargs
+        assert popen_kwargs["cwd"] == str(fake_worktree)
+
+        mock_remove.assert_called_once_with(fake_worktree, project_root=gate_env["project_root"])
+
+    def test_worktree_removed_on_subprocess_timeout(self, gate_env, monkeypatch):
+        """remove_gate_worktree must run even when the gate subprocess times out."""
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+        monkeypatch.setenv("VNX_CODEX_GATE_TIMEOUT", "1")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"], reports_dir=gate_env["reports_dir"],
+        )
+
+        report_path = str(gate_env["reports_dir"] / "worktree-timeout-report.md")
+        payload = _make_request_payload(gate="codex_gate", report_path=report_path)
+
+        fake_worktree = Path("/fake/gate-worktree-timeout")
+        mock_proc = MagicMock()
+        mock_proc.stdin = MagicMock()
+        mock_proc.stdout = MagicMock()
+        mock_proc.stderr = MagicMock()
+        mock_proc.stdout.fileno.return_value = 10
+        mock_proc.stderr.fileno.return_value = 11
+        mock_proc.poll.return_value = None  # never finishes
+        mock_proc.pid = 66666
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = MagicMock()
+
+        real_monotonic = time.monotonic
+        call_count = [0]
+        base_time = [real_monotonic()]
+
+        def fake_monotonic():
+            call_count[0] += 1
+            return base_time[0] + (call_count[0] * 0.5)
+
+        with patch("gate_runner.create_gate_worktree", return_value=fake_worktree), \
+             patch("gate_runner.remove_gate_worktree") as mock_remove, \
+             patch("gate_runner.subprocess.Popen", return_value=mock_proc), \
+             patch("gate_runner.select.select", return_value=([], [], [])), \
+             patch("gate_runner.time.monotonic", side_effect=fake_monotonic), \
+             patch("gate_runner.os.getpgid", return_value=mock_proc.pid), \
+             patch("gate_runner.os.killpg"):
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
+
+        assert result["status"] == "failed"
+        assert result["reason"] in ("timeout", "stall")
+        mock_remove.assert_called_once_with(fake_worktree, project_root=None)
+
+    def test_worktree_creation_failure_fails_gate_without_running_subprocess(
+        self, gate_env, monkeypatch,
+    ):
+        """No stale-checkout fallback: when the worktree can't be created, the
+        gate must fail loudly and codex/gemini must NEVER run against the
+        orchestrator's ambient (possibly stale) checkout."""
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"], reports_dir=gate_env["reports_dir"],
+        )
+
+        payload = _make_request_payload(gate="codex_gate", branch="fix/oi-708")
+
+        with patch(
+            "gate_runner.create_gate_worktree",
+            side_effect=gate_runner.GateWorktreeError(
+                "git fetch origin fix/oi-708 failed: no route to host",
+            ),
+        ) as mock_create, \
+             patch("gate_runner.remove_gate_worktree") as mock_remove, \
+             patch("gate_runner.subprocess.Popen") as mock_popen:
+            result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
+
+        mock_create.assert_called_once()
+        mock_popen.assert_not_called()
+        mock_remove.assert_not_called()
+
+        assert result["status"] == "failed"
+        assert result["reason"] == "worktree_checkout_failed"
+        assert "no route to host" in result["reason_detail"]
+
+        result_file = gate_env["results_dir"] / "pr-1-codex_gate.json"
+        assert result_file.exists()
+        saved = json.loads(result_file.read_text(encoding="utf-8"))
+        assert saved["status"] == "failed"
+        assert saved["reason"] == "worktree_checkout_failed"
+
+    def test_project_root_threaded_from_gate_runner_constructor(
+        self, gate_env, monkeypatch, tmp_path,
+    ):
+        """GateRunner(project_root=...) must reach create_gate_worktree and
+        remove_gate_worktree, matching how ReviewGateManager constructs it."""
+        monkeypatch.setattr("shutil.which", lambda b: "/usr/bin/fake")
+
+        custom_root = tmp_path / "custom-project-root"
+        custom_root.mkdir()
+        runner = GateRunner(
+            state_dir=gate_env["state_dir"], reports_dir=gate_env["reports_dir"],
+            project_root=custom_root,
+        )
+
+        report_path = str(gate_env["reports_dir"] / "project-root-report.md")
+        payload = _make_request_payload(gate="gemini_review", report_path=report_path)
+        fake_worktree = tmp_path / "isolated-worktree-xyz"
+        review_output = b"LGTM\nAll clear.\nNo issues.\n"
+        mock_proc, mock_os_read = self._mock_completed_proc(review_output, pid=44444)
+
+        with patch("gate_runner.create_gate_worktree", return_value=fake_worktree) as mock_create, \
+             patch("gate_runner.remove_gate_worktree") as mock_remove, \
+             patch("gate_runner.subprocess.Popen", return_value=mock_proc), \
+             patch("gate_runner.select.select", return_value=([], [], [])), \
+             patch("gate_runner.os.read", side_effect=mock_os_read), \
+             patch("gate_runner.os.getpgid", return_value=44444):
+            runner.run(gate="gemini_review", request_payload=payload, pr_number=1)
+
+        mock_create.assert_called_once_with(
+            branch=payload["branch"], gate="gemini_review", identifier="1",
+            project_root=custom_root,
+        )
+        mock_remove.assert_called_once_with(fake_worktree, project_root=custom_root)

--- a/tests/test_gate_runner_vertex.py
+++ b/tests/test_gate_runner_vertex.py
@@ -27,12 +27,22 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_runner
 from gate_runner import GateRunner
 
 
 # ---------------------------------------------------------------------------
 # Shared fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_gate_worktree(tmp_path, monkeypatch):
+    """Default OI-708 worktree checkout to a no-op fake — see test_gate_runner.py."""
+    fake_path = tmp_path / "_fake_gate_worktree"
+    monkeypatch.setattr(gate_runner, "create_gate_worktree", lambda **kw: fake_path)
+    monkeypatch.setattr(gate_runner, "remove_gate_worktree", lambda *a, **kw: None)
+    return fake_path
 
 
 @pytest.fixture

--- a/tests/test_gate_worktree.py
+++ b/tests/test_gate_worktree.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Tests for gate_worktree.py — isolated git worktree checkout for gate execution (OI-708).
+
+Uses real, disposable git repos under tmp_path (never touches the actual
+vnx-orchestration checkout) so the create/remove lifecycle is verified
+end-to-end: origin/<branch> content lands in the worktree even when the
+local (caller) repo's own working tree is stale or has never fetched that
+branch — the exact scenario that made codex's own file reads (sed/rg/cat)
+unreliable when run with cwd at the orchestrator's ambient checkout.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from gate_worktree import GateWorktreeError, create_gate_worktree, remove_gate_worktree
+
+
+def _run_git(args, cwd):
+    result = subprocess.run(
+        ["git", *args], cwd=str(cwd), capture_output=True, text=True, timeout=15,
+    )
+    assert result.returncode == 0, f"git {args} failed: {result.stderr}"
+    return result.stdout
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _run_git(["init", "-b", "main"], path)
+    _run_git(["config", "user.email", "test@example.invalid"], path)
+    _run_git(["config", "user.name", "Test"], path)
+
+
+@pytest.fixture
+def origin_and_local(tmp_path):
+    """Build an 'origin' repo with a feature branch pushed only there, and a
+    'local' clone that never fetched it — mirroring an orchestrator checkout
+    that is stale relative to the PR branch under review.
+    """
+    origin = tmp_path / "origin"
+    _init_repo(origin)
+    (origin / "marker.txt").write_text("BASE\n")
+    _run_git(["add", "marker.txt"], origin)
+    _run_git(["commit", "-m", "base"], origin)
+
+    local = tmp_path / "local"
+    _run_git(["clone", str(origin), str(local)], tmp_path)
+    _run_git(["config", "user.email", "test@example.invalid"], local)
+    _run_git(["config", "user.name", "Test"], local)
+
+    # Push a feature branch to origin with content the local clone never sees.
+    _run_git(["checkout", "-b", "feature/oi-708"], origin)
+    (origin / "marker.txt").write_text("FRESH_FROM_PR_BRANCH\n")
+    _run_git(["add", "marker.txt"], origin)
+    _run_git(["commit", "-m", "feature work"], origin)
+    _run_git(["checkout", "main"], origin)
+
+    return {"origin": origin, "local": local}
+
+
+class TestCreateGateWorktree:
+    def test_worktree_content_matches_origin_branch_not_local_stale_tree(self, origin_and_local):
+        """The created worktree must reflect origin/<branch> HEAD, even though
+        the local repo's own working tree never fetched that branch before."""
+        local = origin_and_local["local"]
+
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="99",
+            project_root=local,
+        )
+        try:
+            assert wt_path.exists()
+            assert (wt_path / "marker.txt").read_text() == "FRESH_FROM_PR_BRANCH\n"
+            # local's own checked-out working tree is untouched (still on main/BASE).
+            assert (local / "marker.txt").read_text() == "BASE\n"
+            local_branch = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], local).strip()
+            assert local_branch == "main"
+        finally:
+            remove_gate_worktree(wt_path, project_root=local)
+
+    def test_worktree_is_detached_head(self, origin_and_local):
+        """--detach avoids colliding on a named branch across concurrent gates."""
+        local = origin_and_local["local"]
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="gemini_review", identifier="7",
+            project_root=local,
+        )
+        try:
+            branch_name = _run_git(["rev-parse", "--abbrev-ref", "HEAD"], wt_path).strip()
+            assert branch_name == "HEAD"
+        finally:
+            remove_gate_worktree(wt_path, project_root=local)
+
+    def test_empty_branch_raises_without_touching_git(self, origin_and_local):
+        local = origin_and_local["local"]
+        with pytest.raises(GateWorktreeError, match="non-empty branch"):
+            create_gate_worktree(branch="", gate="codex_gate", identifier="1", project_root=local)
+
+    def test_nonexistent_branch_raises_gate_worktree_error(self, origin_and_local):
+        local = origin_and_local["local"]
+        with pytest.raises(GateWorktreeError):
+            create_gate_worktree(
+                branch="does/not/exist", gate="codex_gate", identifier="1", project_root=local,
+            )
+        # No leaked worktree directory for a failed creation.
+        worktrees_dir = local / ".vnx-data" / "worktrees"
+        if worktrees_dir.exists():
+            assert list(worktrees_dir.iterdir()) == []
+
+
+class TestRemoveGateWorktree:
+    def test_remove_deletes_worktree_and_updates_git_metadata(self, origin_and_local):
+        local = origin_and_local["local"]
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="5", project_root=local,
+        )
+        assert wt_path.exists()
+
+        remove_gate_worktree(wt_path, project_root=local)
+
+        assert not wt_path.exists()
+        listing = _run_git(["worktree", "list"], local)
+        assert str(wt_path) not in listing
+
+    def test_remove_is_idempotent(self, origin_and_local):
+        local = origin_and_local["local"]
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="6", project_root=local,
+        )
+        remove_gate_worktree(wt_path, project_root=local)
+        # Second call on an already-removed path must be a silent no-op.
+        remove_gate_worktree(wt_path, project_root=local)
+
+    def test_remove_none_is_a_noop(self):
+        remove_gate_worktree(None)  # must not raise
+
+    def test_remove_nonexistent_path_is_a_noop(self, tmp_path):
+        remove_gate_worktree(tmp_path / "never-existed")  # must not raise
+
+
+class TestConcurrentGatesDoNotCollide:
+    def test_two_worktrees_for_same_branch_get_distinct_paths(self, origin_and_local):
+        """Two concurrent gate executions on the same PR (e.g. codex + gemini)
+        must not collide on the same worktree path."""
+        local = origin_and_local["local"]
+        wt_a = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="10", project_root=local,
+        )
+        wt_b = create_gate_worktree(
+            branch="feature/oi-708", gate="gemini_review", identifier="10", project_root=local,
+        )
+        try:
+            assert wt_a != wt_b
+            assert wt_a.exists() and wt_b.exists()
+        finally:
+            remove_gate_worktree(wt_a, project_root=local)
+            remove_gate_worktree(wt_b, project_root=local)

--- a/tests/test_gate_worktree.py
+++ b/tests/test_gate_worktree.py
@@ -146,6 +146,100 @@ class TestRemoveGateWorktree:
         remove_gate_worktree(tmp_path / "never-existed")  # must not raise
 
 
+class TestBranchInjectionRejected:
+    """Finding 1 (fix-r1): a branch beginning with '-' (e.g. an injected git
+    option like --upload-pack=...) must be rejected before ANY git subprocess
+    runs — git would otherwise parse it as an option, not a ref."""
+
+    @pytest.mark.parametrize(
+        "unsafe_branch",
+        [
+            "--upload-pack=evil",
+            "-x",
+            "-",
+            "foo bar",
+            "foo\tbar",
+            "\n",
+        ],
+    )
+    def test_unsafe_branch_raises_before_any_git_call(
+        self, origin_and_local, monkeypatch, unsafe_branch,
+    ):
+        local = origin_and_local["local"]
+
+        def _fail_if_called(*args, **kwargs):
+            raise AssertionError(
+                f"subprocess.run must not be called for unsafe branch {unsafe_branch!r}: "
+                f"args={args!r}"
+            )
+
+        monkeypatch.setattr("gate_worktree.subprocess.run", _fail_if_called)
+
+        with pytest.raises(GateWorktreeError, match="unsafe branch"):
+            create_gate_worktree(
+                branch=unsafe_branch, gate="codex_gate", identifier="1", project_root=local,
+            )
+
+    def test_safe_branch_with_slashes_and_hyphens_still_allowed(self, origin_and_local):
+        """Regression guard: the allowlist must not reject ordinary branch
+        names like 'feature/oi-708' used throughout the rest of this suite."""
+        local = origin_and_local["local"]
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="1", project_root=local,
+        )
+        try:
+            assert wt_path.exists()
+        finally:
+            remove_gate_worktree(wt_path, project_root=local)
+
+
+class TestRemoveGateWorktreeRmtreeScope:
+    """Finding 2 (fix-r1): the shutil.rmtree fallback (used when `git worktree
+    remove --force` fails) must only ever touch the managed
+    `.vnx-data/worktrees/gate-*` subtree, never an arbitrary directory that
+    merely happens to sit under project_root.
+    """
+
+    def test_refuses_path_outside_managed_worktrees_dir(self, origin_and_local):
+        local = origin_and_local["local"]
+        # Under project_root, but NOT under .vnx-data/worktrees/. Named with
+        # the managed 'gate-' prefix so this isolates the managed-root check
+        # from the leaf-prefix check.
+        rogue = local / "some-other-dir" / "gate-not-managed"
+        rogue.mkdir(parents=True)
+        (rogue / "keepme.txt").write_text("do not delete\n")
+
+        remove_gate_worktree(rogue, project_root=local)
+
+        assert rogue.exists()
+        assert (rogue / "keepme.txt").exists()
+
+    def test_refuses_leaf_without_gate_prefix_even_under_managed_root(self, origin_and_local):
+        local = origin_and_local["local"]
+        rogue = local / ".vnx-data" / "worktrees" / "not-a-gate-worktree"
+        rogue.mkdir(parents=True)
+        (rogue / "keepme.txt").write_text("do not delete\n")
+
+        remove_gate_worktree(rogue, project_root=local)
+
+        assert rogue.exists()
+        assert (rogue / "keepme.txt").exists()
+
+    def test_still_removes_legitimate_gate_worktree_via_rmtree_fallback(self, origin_and_local):
+        """A plain directory living at the exact path/naming a real
+        create_gate_worktree() call produces, but not registered with git (so
+        `git worktree remove --force` fails and the rmtree fallback fires),
+        must still be deleted."""
+        local = origin_and_local["local"]
+        legit = local / ".vnx-data" / "worktrees" / "gate-codex_gate-1-deadbeef"
+        legit.mkdir(parents=True)
+        (legit / "marker.txt").write_text("scratch\n")
+
+        remove_gate_worktree(legit, project_root=local)
+
+        assert not legit.exists()
+
+
 class TestConcurrentGatesDoNotCollide:
     def test_two_worktrees_for_same_branch_get_distinct_paths(self, origin_and_local):
         """Two concurrent gate executions on the same PR (e.g. codex + gemini)

--- a/tests/test_gemini_vertex_routing.py
+++ b/tests/test_gemini_vertex_routing.py
@@ -23,6 +23,7 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
 
+import gate_runner
 from gate_runner import GateRunner
 import vertex_ai_runner as _vtx
 
@@ -30,6 +31,15 @@ import vertex_ai_runner as _vtx
 # ---------------------------------------------------------------------------
 # Fixtures
 # ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _fake_gate_worktree(tmp_path, monkeypatch):
+    """Default OI-708 worktree checkout to a no-op fake — see test_gate_runner.py."""
+    fake_path = tmp_path / "_fake_gate_worktree"
+    monkeypatch.setattr(gate_runner, "create_gate_worktree", lambda **kw: fake_path)
+    monkeypatch.setattr(gate_runner, "remove_gate_worktree", lambda *a, **kw: None)
+    return fake_path
 
 
 @pytest.fixture


### PR DESCRIPTION
## Summary

OI-708: codex_gate/gemini_review's own subprocess file reads (sed/rg/cat)
inherited the orchestrator's ambient checkout as `cwd`, which can be stale
relative to `origin/<branch>` (the PR head) even when the diff itself
(fetched via `gh pr diff`) is correct. Fixes by checking out `origin/<branch>`
into an isolated, detached-HEAD git worktree and pinning the gate
subprocess's `cwd` there, removing the worktree unconditionally afterward.

Traced call site: `bin/vnx gate` → `review_gate_manager.py request-and-execute`
→ `GateExecutorMixin.execute_gate` → `GateRunner.run` → `_run_subprocess_path`
→ `_run_with_stall_detection` → `subprocess.Popen(...)` (previously no `cwd=`
at all). Full trace + evidence in the dispatch report.

- `scripts/lib/gate_worktree.py` (new): `create_gate_worktree`/`remove_gate_worktree`,
  fetch + `git worktree add --detach`, shared fcntl lock with the existing
  dispatch-worktree isolation modules, fail-loud on checkout failure (no
  silent fallback to the ambient checkout).
- `scripts/gate_runner.py`: threads `cwd` through to `subprocess.Popen`;
  worktree-creation failure records a `worktree_checkout_failed` result and
  never invokes the gate subprocess.
- `scripts/lib/gate_executor.py`: threads the resolved `PROJECT_ROOT` into
  `GateRunner` so worktree checkout resolves against the right repo.
- `scripts/lib/gate_recorder.py`: classifies `worktree_checkout_failed` as an
  execution failure (not a semantic gate verdict).

Vertex-routed gemini (`_run_vertex_path`) is untouched — it already reads
file content via `git show <branch>:<path>` (immune to working-tree
staleness), confirmed during tracing.

## Test plan

- [x] New `tests/test_gate_worktree.py` (9 tests) against real, disposable
      git repos under `tmp_path` — verifies worktree content matches
      `origin/<branch>` HEAD even when the local repo never fetched it,
      detached HEAD, failure paths leak nothing, idempotent removal,
      concurrent gates get distinct worktree paths.
- [x] New `TestGateWorktreeCheckout` in `tests/test_gate_runner.py` (4 tests,
      mocked) — `Popen` receives `cwd=` the created worktree path; worktree
      removed even on subprocess timeout; worktree-creation failure fails
      the gate without ever calling `Popen`; `project_root` threads from the
      `GateRunner` constructor.
- [x] `tests/test_review_gate_manager.py tests/test_review_gate_dispatch_id.py
      tests/test_codex_final_gate.py tests/test_gate_runner.py
      tests/test_gate_execution_certification.py
      tests/test_gemini_prompt_no_duplicate.py tests/test_gemini_vertex_routing.py
      tests/test_gate_runner_vertex.py tests/test_gate_runner_reviewer_prompt.py
      tests/test_gate_worktree.py` — 165 passed, 14 pre-existing failures
      (confirmed via `git stash` to exist on main independent of this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)