### PR TITLE
feat(rv2-pr2): warnings-destination engine + validator

### DIFF
--- a/scripts/lib/append_receipt_internals/validation.py
+++ b/scripts/lib/append_receipt_internals/validation.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from typing import Any, Dict, Optional
 
 from .common import (
@@ -9,6 +10,11 @@ from .common import (
     EXIT_VALIDATION_ERROR,
     facade,
     get_facade_module,
+)
+from .warning_destination import (
+    DROP_REASON_ALLOWLIST,
+    LEGAL_DESTINATIONS,
+    LEGAL_SEVERITIES,
 )
 
 DISPATCH_REQUIRED_EVENTS = {
@@ -23,6 +29,12 @@ DISPATCH_REQUIRED_EVENTS = {
 }
 
 STATE_MUTATION_EVENTS = {"state_mutation"}
+
+# ADR-035 §3.2.1/§6.1 (r3 BLOCKING-1): a typo/garbage guard on the resolved
+# event-name value, never a membership/allow-list check — see §3.2.1 for why
+# a closed `LEGAL_EVENT_TYPES` enum was rejected (50+ live event_type
+# literals across the tree, growing).
+_EVENT_NAME_FORMAT = re.compile(r"^[a-z][a-z0-9_]*$")
 
 def _requires_dispatch_id(receipt: Dict[str, Any], event_name: str) -> bool:
     if event_name in DISPATCH_REQUIRED_EVENTS:
@@ -50,6 +62,137 @@ def _warn_if_review_gate_missing_dispatch_id(event_name: str, receipt: Dict[str,
             )
 
 
+def _resolve_schema_version(receipt: Dict[str, Any]) -> int:
+    """Absent/non-numeric `schema_version` means legacy v1 shape (ADR-035 §7)."""
+    raw = receipt.get("schema_version")
+    if raw is None:
+        return 1
+    try:
+        return int(raw)
+    except (TypeError, ValueError):
+        return 1
+
+
+def _resolve_event_name(receipt: Dict[str, Any], schema_version: int) -> str:
+    """ADR-035 §3.2.1 (r3 HIGH-2): for `schema_version >= 2`, `event_type`
+    alone is consulted — the legacy `event` alias is NOT a fallback for a
+    v2-shaped record. For `schema_version` absent/`1`, both keys are
+    consulted exactly as v1 always has (`event_type` first, `event` as
+    fallback) — this alias tolerance is unconditionally unchanged for v1."""
+    if schema_version >= 2:
+        return str(receipt.get("event_type") or "").strip()
+    return str(receipt.get("event_type") or receipt.get("event") or "").strip()
+
+
+def _validate_warning_entry(entry: Any, index: int) -> None:
+    """ADR-035 §6.1's full reject list for one `warnings[]` entry.
+
+    Stateless by design (§6.1): no rolling-window read here — the
+    destination-assignment engine (warning_destination.py) is the one
+    place that reads recurrence history and stamps `requires_tracking`;
+    this validator only checks the structural/matrix invariants against
+    what is already on the entry.
+    """
+    if not isinstance(entry, dict):
+        raise AppendReceiptError(
+            "invalid_warning_shape",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}] must be an object",
+        )
+
+    for required_key in ("code", "severity", "requires_tracking"):
+        if required_key not in entry:
+            raise AppendReceiptError(
+                "missing_required_key",
+                EXIT_VALIDATION_ERROR,
+                f"warnings[{index}] missing required key: {required_key}",
+            )
+
+    severity = entry.get("severity")
+    if severity not in LEGAL_SEVERITIES:
+        raise AppendReceiptError(
+            "invalid_warning_severity",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}].severity={severity!r} is not one of "
+            f"{sorted(LEGAL_SEVERITIES)}",
+        )
+
+    if "destination" not in entry:
+        raise AppendReceiptError(
+            "missing_required_key",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}] missing required key: destination",
+        )
+
+    destination = entry.get("destination")
+    if destination not in LEGAL_DESTINATIONS:
+        raise AppendReceiptError(
+            "invalid_warning_destination",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}].destination={destination!r} is not one of "
+            f"{sorted(LEGAL_DESTINATIONS)}",
+        )
+
+    if destination == "oi" and not entry.get("oi_id"):
+        raise AppendReceiptError(
+            "invalid_warning_oi_missing_id",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}].destination='oi' requires a non-null oi_id",
+        )
+
+    if destination == "oi_pending":
+        if entry.get("oi_id") is not None:
+            raise AppendReceiptError(
+                "invalid_warning_oi_pending_shape",
+                EXIT_VALIDATION_ERROR,
+                f"warnings[{index}].destination='oi_pending' requires oi_id=null "
+                f"(got {entry.get('oi_id')!r})",
+            )
+        if entry.get("reason") is None:
+            raise AppendReceiptError(
+                "invalid_warning_oi_pending_shape",
+                EXIT_VALIDATION_ERROR,
+                f"warnings[{index}].destination='oi_pending' requires a "
+                "non-null reason",
+            )
+
+    if destination == "dropped":
+        reason = entry.get("reason")
+        if reason is None or reason not in DROP_REASON_ALLOWLIST:
+            raise AppendReceiptError(
+                "invalid_warning_dropped_reason",
+                EXIT_VALIDATION_ERROR,
+                f"warnings[{index}].destination='dropped' requires a reason "
+                f"from {sorted(DROP_REASON_ALLOWLIST)}, got {reason!r}",
+            )
+
+    requires_tracking = entry.get("requires_tracking")
+
+    if requires_tracking is True and destination in ("counted", "dropped"):
+        raise AppendReceiptError(
+            "invalid_warning_tracking_destination_mismatch",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}].requires_tracking=True is incompatible with "
+            f"destination={destination!r}",
+        )
+
+    if severity == "blocker" and requires_tracking is not True:
+        raise AppendReceiptError(
+            "invalid_warning_severity_tracking_mismatch",
+            EXIT_VALIDATION_ERROR,
+            f"warnings[{index}].severity='blocker' requires "
+            f"requires_tracking=True (got {requires_tracking!r})",
+        )
+
+
+def _validate_warnings(receipt: Dict[str, Any]) -> None:
+    warnings_list = receipt.get("warnings")
+    if not warnings_list:
+        return
+    for index, entry in enumerate(warnings_list):
+        _validate_warning_entry(entry, index)
+
+
 def _validate_receipt(receipt: Dict[str, Any]) -> str:
     timestamp = str(receipt.get("timestamp", "")).strip()
     if not timestamp:
@@ -59,13 +202,25 @@ def _validate_receipt(receipt: Dict[str, Any]) -> str:
             "Missing required key: timestamp",
         )
 
-    event_name = str(receipt.get("event_type") or receipt.get("event") or "").strip()
+    schema_version = _resolve_schema_version(receipt)
+    event_name = _resolve_event_name(receipt, schema_version)
     if not event_name:
         raise AppendReceiptError(
             "missing_required_key",
             EXIT_VALIDATION_ERROR,
-            "Missing required key: event_type or event",
+            "Missing required key: event_type"
+            if schema_version >= 2
+            else "Missing required key: event_type or event",
         )
+
+    if not _EVENT_NAME_FORMAT.match(event_name):
+        raise AppendReceiptError(
+            "invalid_event_type_format",
+            EXIT_VALIDATION_ERROR,
+            f"event name {event_name!r} does not match ^[a-z][a-z0-9_]*$",
+        )
+
+    _validate_warnings(receipt)
 
     if _requires_dispatch_id(receipt, event_name):
         dispatch_id = str(receipt.get("dispatch_id", "")).strip()

--- a/scripts/lib/append_receipt_internals/warning_destination.py
+++ b/scripts/lib/append_receipt_internals/warning_destination.py
@@ -1,0 +1,318 @@
+"""Warning-destination engine — ADR-035 §6.1/§6.2/§6.4.
+
+Generalizes ``quality.py``'s single-warning-class dedup/promote logic
+(``_register_quality_open_items``, ``_count_quality_violations_against_store``)
+to an arbitrary ``warnings[]`` entry ``{code, severity, message}``. In one
+pass, ``assign_destination`` computes both ``destination`` and
+``requires_tracking`` for an entry — the same discipline §6.2 already
+applies to ``open_items_created`` (one computation, one place).
+
+PR-2 of the ADR-035 §9 decomposition: a library, not wired into either
+write path yet (that is PR-4). Nothing here is called by
+``append_receipt_payload`` or ``emit_dispatch_receipt``.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from .common import _emit, _get_open_items_manager
+
+_PACKAGE_DIR = Path(__file__).resolve().parent
+_SCRIPTS_LIB = _PACKAGE_DIR.parent
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+# ADR-035 §6.1: the four legal `destination` values.
+LEGAL_DESTINATIONS = frozenset({"oi", "oi_pending", "counted", "dropped"})
+
+# ADR-035 §6.1 (r3 HIGH-3): mirrors open_items_manager.py::SeverityLevel —
+# the same closed vocabulary _SEVERITY_MAP (quality.py) already normalizes
+# raw advisory severities into before calling add_item_programmatic.
+LEGAL_SEVERITIES = frozenset({"blocker", "warn", "info"})
+
+# ADR-035 §6.1 point 4: the closed allow-list of `destination: "dropped"`
+# reasons — a free-form excuse is never legal, only one of these four.
+DROP_REASON_ALLOWLIST = frozenset(
+    {
+        "retired_check",
+        "duplicate_of_blocker",
+        "superseded_by_code",
+        "operator_acknowledged_noise",
+    }
+)
+
+# ADR-035 §6.1 rule 1: default rolling-window recurrence threshold for
+# promoting a recurring `severity: "warn"` code to `destination: "oi"`.
+# Configurable per call via `assign_destination(..., threshold=...)`.
+DEFAULT_RECURRENCE_THRESHOLD = 3
+
+_COUNTER_FILENAME = "warning_recurrence_counts.json"
+
+
+class WarningDestinationError(ValueError):
+    """Raised when the engine is asked to compute an impossible destination.
+
+    Distinct from AppendReceiptError (validation.py): this is a programming-
+    error guard inside the engine itself (e.g. malformed input, contradictory
+    caller-supplied drop_reason) — the append-time validator (§6.1's reject
+    list) is the actual enforcement point for a receipt already on disk.
+    """
+
+
+def dedup_key_for(entry: Dict[str, Any]) -> str:
+    """The dedup key an oi-bound warning is promoted under (ADR-035 §6.3).
+
+    The pre-cutover quality-advisory dedup key (``qa:{check_id}:{file}:
+    {symbol}``) is preserved verbatim — as the v2 warning's own ``code``
+    value — so an already-tracked open item's dedup_key keeps matching a
+    v2 warning describing the same underlying check; the cutover creates
+    no duplicate or orphaned open items. Generalized to any warning class,
+    the dedup key IS the entry's ``code``: the generalized ``{code,
+    severity, message}`` shape carries no separate file/symbol fields to
+    fold in, so genericizing "per warning-code" means the code itself.
+    """
+    return str(entry.get("code") or "")
+
+
+def compute_requires_tracking(
+    severity: str,
+    recurrence_count: int,
+    *,
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+) -> bool:
+    """ADR-035 §6.1 rule 1 / matrix: True exactly when `severity == "blocker"`,
+    or `severity == "warn"` at/above the recurrence threshold. False
+    otherwise (warn below threshold, or info at any recurrence)."""
+    if severity == "blocker":
+        return True
+    if severity == "warn" and recurrence_count >= threshold:
+        return True
+    return False
+
+
+def derive_open_items_created(warnings_list: Optional[Any]) -> int:
+    """ADR-035 §6.2: `open_items_created` becomes derived — the count of
+    `warnings[]` entries on THIS receipt that resolved to
+    `destination: "oi"`. `oi_pending` entries are explicitly NOT counted:
+    no open item exists yet for them (that count only moves once §6.4's
+    reconcile step succeeds, which updates the open-items store directly,
+    never this immutable receipt field)."""
+    if not warnings_list:
+        return 0
+    return sum(
+        1
+        for entry in warnings_list
+        if isinstance(entry, dict) and entry.get("destination") == "oi"
+    )
+
+
+def _default_counter_path() -> Path:
+    from project_root import resolve_state_dir
+
+    return resolve_state_dir(__file__) / _COUNTER_FILENAME
+
+
+def _counter_lock_path(counter_path: Path) -> Path:
+    return counter_path.with_name(counter_path.name + ".lock")
+
+
+def _load_counter_data(counter_path: Path) -> Dict[str, int]:
+    if not counter_path.exists():
+        return {}
+    try:
+        with counter_path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return {}
+    if not isinstance(data, dict):
+        return {}
+    result: Dict[str, int] = {}
+    for key, value in data.items():
+        try:
+            result[str(key)] = int(value)
+        except (TypeError, ValueError):
+            continue
+    return result
+
+
+def _atomic_write_counter_data(counter_path: Path, data: Dict[str, int]) -> None:
+    counter_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = counter_path.with_name(f"{counter_path.name}.{os.getpid()}.tmp")
+    with tmp_path.open("w", encoding="utf-8") as fh:
+        json.dump(data, fh, separators=(",", ":"), sort_keys=True)
+    os.replace(tmp_path, counter_path)
+
+
+def _peek_counter(counter_path: Path, key: str) -> int:
+    """Read-only: current persisted occurrence count for `key` (0 if unseen)."""
+    return _load_counter_data(counter_path).get(key, 0)
+
+
+def _increment_counter(counter_path: Path, key: str) -> int:
+    """Atomically increment and persist the occurrence count for `key`.
+
+    This is Part C's "counted"-warning counter primitive — the rolling
+    per-code tally `receipt_query.py digest` (PR-7) will read. Locked
+    read-modify-write + atomic tmp-then-rename write, consistent with the
+    Codex Defense Checklist's rule for any rewrite of a persistent state
+    file consumed by concurrent callers.
+    """
+    lock_path = _counter_lock_path(counter_path)
+    lock_path.parent.mkdir(parents=True, exist_ok=True)
+    with lock_path.open("a+", encoding="utf-8") as lock_fh:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        try:
+            data = _load_counter_data(counter_path)
+            new_value = data.get(key, 0) + 1
+            data[key] = new_value
+            _atomic_write_counter_data(counter_path, data)
+            return new_value
+        finally:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+
+
+def _counter_key(code: str, scope: str) -> str:
+    return f"{code}:{scope}" if scope else code
+
+
+def assign_destination(
+    entry: Dict[str, Any],
+    *,
+    dispatch_id: str = "",
+    report_path: str = "",
+    pr_id: str = "",
+    scope: str = "",
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    recurrence_count: Optional[int] = None,
+    counter_path: Optional[Path] = None,
+    drop_reason: Optional[str] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Compute `{destination, oi_id, reason, requires_tracking}` for one
+    `warnings[]` entry `{code, severity, message}`, in a single pass
+    (ADR-035 §6.1/§6.4).
+
+    Args:
+        entry: the warning entry, at minimum `{code, severity}`.
+        dispatch_id/report_path/pr_id: forwarded to `add_item_programmatic`
+            when promotion fires.
+        scope: dispatch-adjacent scope (skill/terminal) the recurrence
+            threshold is keyed on alongside `code` — §6.1 rule 1.
+        threshold: recurrence threshold for `severity: "warn"` promotion.
+            Default 3, per §6.1.
+        recurrence_count: when given, used directly as "this occurrence's
+            recurrence count" — bypasses the on-disk rolling-window store
+            entirely, making the engine unit-testable deterministically
+            without a write-path. When omitted (the default production
+            path), the engine reads/increments a persistent per-(code,
+            scope) counter at `counter_path`.
+        counter_path: where the rolling-window/counted-counter is
+            persisted. Defaults to `<state_dir>/warning_recurrence_counts.json`
+            when omitted and `recurrence_count` was not injected.
+        drop_reason: when given (and the entry does not require tracking),
+            resolves to `destination: "dropped"` with this reason — must be
+            drawn from `DROP_REASON_ALLOWLIST`. Raises `WarningDestinationError`
+            if the entry requires tracking (a blocker/promoted-warn can
+            never be silently dropped) or the reason is not allow-listed.
+        open_items_manager_module: injectable `open_items_manager` module
+            (tests use this to control/observe the real OI store, or to
+            simulate an unreachable/locked store for the oi_pending path).
+
+    Returns:
+        A new dict: a copy of `entry` plus `destination`, `oi_id`, `reason`,
+        `requires_tracking`. The input `entry` is never mutated.
+    """
+    code = str(entry.get("code") or "").strip()
+    if not code:
+        raise WarningDestinationError("warning entry missing required 'code'")
+
+    severity = entry.get("severity")
+    if severity not in LEGAL_SEVERITIES:
+        raise WarningDestinationError(
+            f"warning entry has unrecognized severity: {severity!r} "
+            f"(expected one of {sorted(LEGAL_SEVERITIES)})"
+        )
+
+    message = entry.get("message", "") or ""
+
+    if severity == "warn":
+        if recurrence_count is not None:
+            effective_recurrence = recurrence_count
+        else:
+            path = counter_path or _default_counter_path()
+            effective_recurrence = _peek_counter(path, _counter_key(code, scope)) + 1
+        requires_tracking = compute_requires_tracking(
+            severity, effective_recurrence, threshold=threshold
+        )
+    elif severity == "blocker":
+        requires_tracking = True
+    else:  # info
+        requires_tracking = False
+
+    result: Dict[str, Any] = dict(entry)
+    result["requires_tracking"] = requires_tracking
+
+    if requires_tracking:
+        if drop_reason is not None:
+            raise WarningDestinationError(
+                "cannot set drop_reason on a warning that requires_tracking"
+            )
+        oim = open_items_manager_module or _get_open_items_manager()
+        dedup_key = dedup_key_for(entry)
+        try:
+            item_id, _created = oim.add_item_programmatic(
+                title=message or code,
+                severity=severity,
+                dispatch_id=dispatch_id,
+                report_path=report_path,
+                pr_id=pr_id,
+                details=message,
+                dedup_key=dedup_key,
+                source="warning_destination",
+            )
+            result["destination"] = "oi"
+            result["oi_id"] = item_id
+            result["reason"] = None
+        except Exception as exc:
+            # ADR-035 §6.4: the OI store itself failed (raised, or is
+            # unreachable/locked) — never swallow-and-log-only (the
+            # precursor's quality.py:146-147 bug this generalization
+            # closes). Stamp the specific failure so it is durably
+            # attributable and recoverable via reconcile-oi-pending.
+            _emit(
+                "WARN",
+                "warning_oi_promotion_failed",
+                warning_code=code,
+                dispatch_id=dispatch_id,
+                error=str(exc),
+            )
+            result["destination"] = "oi_pending"
+            result["oi_id"] = None
+            result["reason"] = str(exc)
+        return result
+
+    if drop_reason is not None:
+        if drop_reason not in DROP_REASON_ALLOWLIST:
+            raise WarningDestinationError(
+                f"drop_reason {drop_reason!r} is not in the allow-list "
+                f"{sorted(DROP_REASON_ALLOWLIST)}"
+            )
+        result["destination"] = "dropped"
+        result["oi_id"] = None
+        result["reason"] = drop_reason
+        return result
+
+    if recurrence_count is None:
+        path = counter_path or _default_counter_path()
+        _increment_counter(path, _counter_key(code, scope))
+
+    result["destination"] = "counted"
+    result["oi_id"] = None
+    result["reason"] = None
+    return result

--- a/tests/test_receipt_validation_warnings.py
+++ b/tests/test_receipt_validation_warnings.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Tests for the ADR-035 §6.1/§3.2.1 warnings[]/event_type reject-list
+extension in scripts/lib/append_receipt_internals/validation.py::_validate_receipt.
+
+Covers the PR-2 mandatory subset: T6, T31-T33, T36-T38, plus the
+event-name format-guard checks §3.2.1/§6.1 requires alongside T38's
+schema_version gating.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from append_receipt_internals.common import AppendReceiptError  # noqa: E402
+from append_receipt_internals.validation import _validate_receipt  # noqa: E402
+from append_receipt_internals.warning_destination import (  # noqa: E402
+    DROP_REASON_ALLOWLIST,
+)
+
+
+def _receipt(
+    *,
+    event_type: Optional[str] = "task_complete",
+    dispatch_id: str = "DISP-TEST-001",
+    warnings: Optional[List[Dict[str, Any]]] = None,
+    **extra: Any,
+) -> Dict[str, Any]:
+    receipt: Dict[str, Any] = {
+        "timestamp": "2026-07-22T10:00:00Z",
+        "dispatch_id": dispatch_id,
+    }
+    if event_type is not None:
+        receipt["event_type"] = event_type
+    if warnings is not None:
+        receipt["warnings"] = warnings
+    receipt.update(extra)
+    return receipt
+
+
+def _tracked_blocker(**overrides: Any) -> Dict[str, Any]:
+    entry = {
+        "code": "worker_permission_violation",
+        "severity": "blocker",
+        "message": "worker wrote outside its declared file-write scope",
+        "destination": "oi",
+        "oi_id": "OI-001",
+        "reason": None,
+        "requires_tracking": True,
+    }
+    entry.update(overrides)
+    return entry
+
+
+def _counted_warn(**overrides: Any) -> Dict[str, Any]:
+    entry = {
+        "code": "report_contract_invalid",
+        "severity": "warn",
+        "message": "Summary section missing",
+        "destination": "counted",
+        "oi_id": None,
+        "reason": None,
+        "requires_tracking": False,
+    }
+    entry.update(overrides)
+    return entry
+
+
+# ── T6 — dropped + reason:null is rejected ─────────────────────────────────
+
+
+def test_t6_dropped_with_null_reason_rejected():
+    entry = _counted_warn(destination="dropped", reason=None)
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+def test_t6_valid_receipt_with_no_warnings_still_validates():
+    _validate_receipt(_receipt())  # must not raise
+
+
+# ── T31 — oi_pending legal only with oi_id:null + non-null reason ─────────
+
+
+def test_t31_oi_pending_legal_shape_accepted():
+    entry = _tracked_blocker(destination="oi_pending", oi_id=None, reason="store lock held")
+    _validate_receipt(_receipt(warnings=[entry]))  # must not raise
+
+
+def test_t31_oi_pending_with_non_null_oi_id_rejected():
+    entry = _tracked_blocker(destination="oi_pending", oi_id="OI-001", reason="store lock held")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+def test_t31_oi_pending_with_null_reason_rejected():
+    entry = _tracked_blocker(destination="oi_pending", oi_id=None, reason=None)
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+# ── T32 — requires_tracking:true paired with counted/dropped is rejected ──
+
+
+@pytest.mark.parametrize("destination", ["counted", "dropped"])
+def test_t32_requires_tracking_true_with_counted_or_dropped_rejected(destination):
+    entry = _tracked_blocker(destination=destination, oi_id=None)
+    if destination == "dropped":
+        entry["reason"] = "retired_check"
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+def test_t32_requires_tracking_true_with_oi_or_oi_pending_accepted():
+    _validate_receipt(_receipt(warnings=[_tracked_blocker()]))
+    entry = _tracked_blocker(destination="oi_pending", oi_id=None, reason="pending")
+    _validate_receipt(_receipt(warnings=[entry]))
+
+
+# ── T33 — dropped reason must come from the closed allow-list ─────────────
+
+
+def test_t33_dropped_reason_outside_allowlist_rejected():
+    entry = _counted_warn(destination="dropped", reason="meh, not important")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+@pytest.mark.parametrize("reason", sorted(DROP_REASON_ALLOWLIST))
+def test_t33_dropped_reason_in_allowlist_accepted(reason):
+    entry = _counted_warn(destination="dropped", reason=reason)
+    _validate_receipt(_receipt(warnings=[entry]))  # must not raise
+
+
+# ── T36 — severity outside {blocker, warn, info} is rejected ──────────────
+
+
+def test_t36_severity_critical_rejected():
+    entry = _tracked_blocker(severity="critical")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+@pytest.mark.parametrize("severity", ["blocker", "warn", "info"])
+def test_t36_legal_severities_accepted(severity):
+    entry = _counted_warn(severity=severity, requires_tracking=(severity == "blocker"))
+    if severity == "blocker":
+        entry["destination"] = "oi"
+        entry["oi_id"] = "OI-002"
+    _validate_receipt(_receipt(warnings=[entry]))  # must not raise
+
+
+# ── T37 — severity:blocker + requires_tracking:false rejected regardless ──
+# ── of destination (incl. an otherwise-legal "counted")                  ──
+
+
+def test_t37_blocker_requires_tracking_false_rejected_with_counted_destination():
+    """The exact r3 HIGH-3 scenario: {severity: blocker, requires_tracking:
+    false, destination: counted} — legal under check 1 alone, rejected only
+    by check 2 (severity => requires_tracking)."""
+    entry = _counted_warn(severity="blocker", requires_tracking=False, destination="counted")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+def test_t37_blocker_requires_tracking_false_rejected_with_oi_destination():
+    entry = _tracked_blocker(requires_tracking=False)
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(warnings=[entry]))
+
+
+# ── T38 — event/event_type alias boundary is schema_version-gated ────────
+
+
+def test_t38_schema_version_2_with_event_alias_and_no_event_type_rejected():
+    receipt = _receipt(event_type=None, schema_version=2, event="task_complete")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(receipt)
+
+
+def test_t38_schema_version_absent_same_shape_still_validates_via_alias():
+    receipt = _receipt(event_type=None, event="task_complete")
+    _validate_receipt(receipt)  # must not raise
+
+
+def test_t38_schema_version_1_same_shape_still_validates_via_alias():
+    receipt = _receipt(event_type=None, schema_version=1, event="task_complete")
+    _validate_receipt(receipt)  # must not raise
+
+
+def test_t38_schema_version_2_with_event_type_present_validates():
+    receipt = _receipt(event_type="task_complete", schema_version=2)
+    _validate_receipt(receipt)  # must not raise
+
+
+def test_t38_schema_version_2_with_empty_event_type_and_event_alias_rejected():
+    receipt = _receipt(event_type="", schema_version=2, event="task_complete")
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(receipt)
+
+
+# ── event-name format guard — typo/garbage guard, never a membership test ─
+
+
+def test_event_name_format_guard_rejects_camelcase():
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(event_type="TaskComplete"))
+
+
+def test_event_name_format_guard_rejects_embedded_whitespace():
+    with pytest.raises(AppendReceiptError):
+        _validate_receipt(_receipt(event_type="task complete"))
+
+
+def test_event_name_format_guard_accepts_never_before_seen_snake_case_value():
+    """Proves the guard is required-and-non-empty + format, never a closed
+    enum (r3 BLOCKING-1) — a brand-new event_type value is accepted."""
+    _validate_receipt(_receipt(event_type="a_new_gate_event_2026"))  # must not raise

--- a/tests/test_warning_destination.py
+++ b/tests/test_warning_destination.py
@@ -1,0 +1,378 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/append_receipt_internals/warning_destination.py
+(ADR-035 §6.1/§6.2/§6.4). Covers the PR-2 mandatory subset: T7, T8, T9,
+plus unit coverage for the pure helpers (`compute_requires_tracking`,
+`dedup_key_for`, `derive_open_items_created`) and the `oi_pending`
+fallback (§6.4).
+
+Library-level unit tests only — PR-2 wires no writer. Real
+`open_items_manager` interaction is exercised via an isolated, per-test
+STATE_DIR (mirrors tests/test_open_items_dedup_status.py's pattern), not
+the process-wide facade cache.
+"""
+
+from __future__ import annotations
+
+import copy
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from append_receipt_internals.warning_destination import (  # noqa: E402
+    DEFAULT_RECURRENCE_THRESHOLD,
+    DROP_REASON_ALLOWLIST,
+    LEGAL_DESTINATIONS,
+    LEGAL_SEVERITIES,
+    WarningDestinationError,
+    assign_destination,
+    compute_requires_tracking,
+    dedup_key_for,
+    derive_open_items_created,
+)
+
+
+def _load_oim(tmp_path: Path):
+    """Fresh, isolated open_items_manager module bound to a per-test
+    STATE_DIR — mirrors tests/test_open_items_dedup_status.py's helper so
+    T7 exercises the REAL add_item_programmatic/dedup path, not a mock."""
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(VNX_ROOT),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+
+    mod_name = f"open_items_manager_wd_test_{tmp_path.name}"
+    from unittest.mock import patch
+
+    with patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, SCRIPTS_DIR / "open_items_manager.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+class _NeverCalledOIM:
+    """Fails loudly if the engine ever calls add_item_programmatic on it —
+    used to prove a non-tracked (counted/dropped) entry never touches the
+    OI store (T8's 'no OI spam' guarantee)."""
+
+    def add_item_programmatic(self, **kwargs):
+        raise AssertionError(
+            "add_item_programmatic must not be called for a non-tracked warning"
+        )
+
+
+class _FailingOIM:
+    def __init__(self, error_message: str):
+        self._error_message = error_message
+
+    def add_item_programmatic(self, **kwargs):
+        raise RuntimeError(self._error_message)
+
+
+# ── T7 — warn recurring >= threshold promotes to OI, dedup continuity ─────
+
+
+def test_t7_warn_at_threshold_promotes_to_oi_with_real_open_item(tmp_path):
+    oim = _load_oim(tmp_path)
+    entry = {"code": "worker_permission_violation", "severity": "warn", "message": "recurring"}
+
+    result = assign_destination(
+        entry,
+        recurrence_count=DEFAULT_RECURRENCE_THRESHOLD,
+        open_items_manager_module=oim,
+        dispatch_id="DISP-1",
+    )
+
+    assert result["destination"] == "oi"
+    assert result["oi_id"] is not None
+    assert result["reason"] is None
+    assert result["requires_tracking"] is True
+
+    data = oim.load_items()
+    assert len(data["items"]) == 1
+    assert data["items"][0]["dedup_key"] == "worker_permission_violation"
+
+
+def test_t7_repeat_occurrence_hits_same_dedup_key_and_does_not_duplicate(tmp_path):
+    oim = _load_oim(tmp_path)
+    entry = {"code": "worker_permission_violation", "severity": "warn", "message": "recurring"}
+
+    first = assign_destination(
+        entry, recurrence_count=3, open_items_manager_module=oim, dispatch_id="DISP-1"
+    )
+    second = assign_destination(
+        entry, recurrence_count=4, open_items_manager_module=oim, dispatch_id="DISP-2"
+    )
+
+    assert first["destination"] == second["destination"] == "oi"
+    assert first["oi_id"] == second["oi_id"]
+    assert len(oim.load_items()["items"]) == 1
+
+
+def test_t7_blocker_always_promotes_regardless_of_recurrence(tmp_path):
+    oim = _load_oim(tmp_path)
+    entry = {"code": "worker_permission_violation", "severity": "blocker", "message": "m"}
+
+    result = assign_destination(
+        entry, recurrence_count=0, open_items_manager_module=oim, dispatch_id="DISP-1"
+    )
+
+    assert result["destination"] == "oi"
+    assert result["oi_id"] is not None
+    assert result["requires_tracking"] is True
+
+
+def test_t7_default_path_persisted_counter_reaches_threshold_and_promotes(tmp_path):
+    """Exercises the real rolling-window default path (no recurrence_count
+    injection) end to end: three real calls against the same counter_path
+    accumulate to the threshold and the third promotes."""
+    oim = _load_oim(tmp_path / "oi_store")
+    counter_path = tmp_path / "counts.json"
+    entry = {"code": "recurring_check", "severity": "warn", "message": "m"}
+
+    r1 = assign_destination(entry, counter_path=counter_path, open_items_manager_module=oim, dispatch_id="D1")
+    r2 = assign_destination(entry, counter_path=counter_path, open_items_manager_module=oim, dispatch_id="D1")
+    r3 = assign_destination(entry, counter_path=counter_path, open_items_manager_module=oim, dispatch_id="D1")
+
+    assert r1["destination"] == "counted"
+    assert r2["destination"] == "counted"
+    assert r3["destination"] == "oi"
+    assert r3["oi_id"] is not None
+
+
+# ── T8 — warn below threshold: destination=counted, counter accumulates ───
+
+
+def test_t8_warn_below_threshold_is_counted_and_never_touches_oi_store():
+    entry = {"code": "low_severity_thing", "severity": "warn", "message": "m"}
+
+    result = assign_destination(
+        entry,
+        recurrence_count=1,
+        open_items_manager_module=_NeverCalledOIM(),
+    )
+
+    assert result["destination"] == "counted"
+    assert result["oi_id"] is None
+    assert result["reason"] is None
+    assert result["requires_tracking"] is False
+
+
+def test_t8_repeated_occurrences_increment_persisted_counter_without_oi_spam(tmp_path):
+    counter_path = tmp_path / "counts.json"
+    entry = {"code": "low_severity_thing", "severity": "warn", "message": "m"}
+
+    for _ in range(2):
+        result = assign_destination(
+            entry,
+            counter_path=counter_path,
+            open_items_manager_module=_NeverCalledOIM(),
+        )
+        assert result["destination"] == "counted"
+
+    data = json.loads(counter_path.read_text(encoding="utf-8"))
+    assert data["low_severity_thing"] == 2
+
+
+def test_t8_info_severity_never_promotes_regardless_of_recurrence():
+    entry = {"code": "informational_thing", "severity": "info", "message": "m"}
+
+    result = assign_destination(
+        entry,
+        recurrence_count=1000,
+        open_items_manager_module=_NeverCalledOIM(),
+    )
+
+    assert result["destination"] == "counted"
+    assert result["requires_tracking"] is False
+
+
+# ── T9 — report_contract_invalid warning code: counted from first occurrence ─
+
+
+def test_t9_report_contract_invalid_counted_from_first_occurrence():
+    """Proves the 2274x-noise class is bounded+visible (destination=counted)
+    from the very first occurrence — never an unwindowed dead flag."""
+    entry = {"code": "report_contract_invalid", "severity": "warn", "message": "Summary missing"}
+
+    result = assign_destination(
+        entry,
+        recurrence_count=1,
+        open_items_manager_module=_NeverCalledOIM(),
+    )
+
+    assert result["destination"] == "counted"
+    assert result["requires_tracking"] is False
+
+
+# ── §6.4 — oi_pending fallback when the OI store itself fails ─────────────
+
+
+def test_oi_pending_on_add_item_programmatic_failure_for_blocker():
+    entry = {"code": "worker_permission_violation", "severity": "blocker", "message": "m"}
+    failing = _FailingOIM("[Errno 11] store lock held by pid 4821")
+
+    result = assign_destination(entry, open_items_manager_module=failing, dispatch_id="D1")
+
+    assert result["destination"] == "oi_pending"
+    assert result["oi_id"] is None
+    assert result["reason"] == "[Errno 11] store lock held by pid 4821"
+    assert result["requires_tracking"] is True
+
+
+def test_oi_pending_on_add_item_programmatic_failure_for_promoted_warn():
+    entry = {"code": "recurring_thing", "severity": "warn", "message": "m"}
+    failing = _FailingOIM("store unreachable")
+
+    result = assign_destination(
+        entry, recurrence_count=DEFAULT_RECURRENCE_THRESHOLD, open_items_manager_module=failing
+    )
+
+    assert result["destination"] == "oi_pending"
+    assert result["oi_id"] is None
+    assert result["reason"] == "store unreachable"
+
+
+# ── compute_requires_tracking — pure rule (§6.1 rule 1) ───────────────────
+
+
+def test_compute_requires_tracking_blocker_always_true():
+    assert compute_requires_tracking("blocker", 0) is True
+    assert compute_requires_tracking("blocker", 999) is True
+
+
+def test_compute_requires_tracking_warn_below_threshold_false():
+    assert compute_requires_tracking("warn", 2, threshold=3) is False
+
+
+def test_compute_requires_tracking_warn_at_or_above_threshold_true():
+    assert compute_requires_tracking("warn", 3, threshold=3) is True
+    assert compute_requires_tracking("warn", 4, threshold=3) is True
+
+
+def test_compute_requires_tracking_info_never_true():
+    assert compute_requires_tracking("info", 1000) is False
+
+
+# ── dedup_key_for — §6.3 continuity ────────────────────────────────────────
+
+
+def test_dedup_key_for_is_verbatim_code():
+    entry = {"code": "qa:missing_docstring:foo.py:bar_func", "severity": "warn"}
+    assert dedup_key_for(entry) == "qa:missing_docstring:foo.py:bar_func"
+
+
+def test_dedup_key_for_missing_code_is_empty_string():
+    assert dedup_key_for({}) == ""
+
+
+# ── derive_open_items_created — §6.2 ───────────────────────────────────────
+
+
+def test_derive_open_items_created_counts_oi_destination_only():
+    warnings = [
+        {"destination": "oi"},
+        {"destination": "oi_pending"},
+        {"destination": "counted"},
+        {"destination": "dropped"},
+        {"destination": "oi"},
+    ]
+    assert derive_open_items_created(warnings) == 2
+
+
+def test_derive_open_items_created_oi_pending_not_counted():
+    assert derive_open_items_created([{"destination": "oi_pending"}]) == 0
+
+
+@pytest.mark.parametrize("value", [None, []])
+def test_derive_open_items_created_empty_or_none_is_zero(value):
+    assert derive_open_items_created(value) == 0
+
+
+# ── drop_reason — caller-requested drop, allow-listed only ─────────────────
+
+
+def test_assign_destination_drop_reason_allowlisted_accepted():
+    entry = {"code": "retired_thing", "severity": "info", "message": "m"}
+    result = assign_destination(entry, recurrence_count=0, drop_reason="retired_check")
+    assert result["destination"] == "dropped"
+    assert result["reason"] == "retired_check"
+    assert result["oi_id"] is None
+
+
+@pytest.mark.parametrize("reason", sorted(DROP_REASON_ALLOWLIST))
+def test_assign_destination_every_allowlisted_reason_accepted(reason):
+    entry = {"code": "x", "severity": "info"}
+    result = assign_destination(entry, recurrence_count=0, drop_reason=reason)
+    assert result["destination"] == "dropped"
+    assert result["reason"] == reason
+
+
+def test_assign_destination_drop_reason_outside_allowlist_raises():
+    entry = {"code": "x", "severity": "info"}
+    with pytest.raises(WarningDestinationError):
+        assign_destination(entry, recurrence_count=0, drop_reason="because I said so")
+
+
+def test_assign_destination_drop_reason_rejected_when_requires_tracking():
+    entry = {"code": "x", "severity": "blocker"}
+    with pytest.raises(WarningDestinationError):
+        assign_destination(entry, drop_reason="retired_check")
+
+
+# ── input validation — defense in depth ────────────────────────────────────
+
+
+def test_assign_destination_rejects_missing_code():
+    with pytest.raises(WarningDestinationError):
+        assign_destination({"severity": "info"}, recurrence_count=0)
+
+
+def test_assign_destination_rejects_unrecognized_severity():
+    with pytest.raises(WarningDestinationError):
+        assign_destination({"code": "x", "severity": "critical"}, recurrence_count=0)
+
+
+def test_assign_destination_does_not_mutate_input_entry():
+    entry = {"code": "x", "severity": "info", "message": "m"}
+    before = copy.deepcopy(entry)
+    assign_destination(entry, recurrence_count=0)
+    assert entry == before
+
+
+def test_assign_destination_result_is_new_dict():
+    entry = {"code": "x", "severity": "info", "message": "m"}
+    result = assign_destination(entry, recurrence_count=0)
+    assert result is not entry
+    assert result["code"] == "x"
+
+
+# ── module constants sanity ────────────────────────────────────────────────
+
+
+def test_legal_destinations_are_exactly_the_four_from_adr():
+    assert LEGAL_DESTINATIONS == {"oi", "oi_pending", "counted", "dropped"}
+
+
+def test_legal_severities_match_open_items_manager_severity_level():
+    assert LEGAL_SEVERITIES == {"blocker", "warn", "info"}


### PR DESCRIPTION
## Summary
PR-2 of the ADR-035 §9 receipt-v2 decomposition. Implements the warnings-destination engine and extends the append validator per §6.1/§6.2/§6.4 — library only, no write-path wiring (that's PR-3/PR-4).

## Changes
- `scripts/lib/append_receipt_internals/warning_destination.py` (new): `assign_destination()` computes `destination` + `requires_tracking` for a `warnings[]` entry `{code, severity, message}` in one pass, generalizing `quality.py::_register_quality_open_items`/`_count_quality_violations_against_store`.
  - Promotion (`oi`) calls `open_items_manager.add_item_programmatic` with the §6.3 dedup-key continuity (`code` verbatim).
  - `oi_pending` fallback when the OI store raises/is unreachable — stamps the caught exception message as `reason`, never swallow-and-log-only (closes the `quality.py:146-147` silent-loss bug, §6.4).
  - Recurrence threshold (default 3, configurable) is injectable for deterministic tests, with a real persistent per-(code,scope) counter as the default production path (atomic tmp+rename write, fcntl-locked).
  - `derive_open_items_created()` — §6.2's derivation of `open_items_created` from `warnings[]` (oi-only, oi_pending excluded).
- `scripts/lib/append_receipt_internals/validation.py`: extends `_validate_receipt` with the full §6.1 reject list — four-value `destination` enum, missing/invalid `code`/`severity`/`requires_tracking`, the severity×destination matrix (two stateless checks per r3 HIGH-3), the closed drop-reason allow-list, and `event_type`/`event` alias handling now gated on `schema_version` (r3 HIGH-2) plus the `^[a-z][a-z0-9_]*$` format guard (r3 BLOCKING-1, never a closed enum).

## Verification
`python3 -m pytest tests/test_warning_destination.py tests/test_receipt_validation_warnings.py -q` → **60 passed**, covering the mandated T6-T9/T31-T33/T36-T38 set plus supporting unit coverage for the pure helpers and the `oi_pending` fallback.

Regression sanity (`tests/test_ndjson_hash_chain.py tests/test_acceptance_idempotency.py scripts/lib/append_receipt_internals/`): **66 passed**.

Broader sweep (`tests/ -k "receipt or quality or open_item"`, excluding the interactive-dispatch integration file): **1176 passed, 34 failed, 2 skipped** — all 34 failures reproduce identically on `main` with this branch's changes reverted (confirmed via a same-scope baseline re-run), i.e. pre-existing and unrelated to this PR.

Remote push verified: `git ls-remote origin dispatch/20260722-rv2-pr2-warnings-engine` → `38787c85c1b829dad4196b41ff7420fcc58f80e3`.

## Test plan
- [x] `pytest tests/test_warning_destination.py tests/test_receipt_validation_warnings.py -q` — 60 passed
- [x] `pytest tests/test_ndjson_hash_chain.py tests/test_acceptance_idempotency.py scripts/lib/append_receipt_internals/ -q` — 66 passed
- [x] v1-path alias tolerance (`event` fallback when `schema_version` absent/1) confirmed green (T38)

## Open Items
None — PR-3 (shared append primitive) and PR-4 (wiring) are separate dispatches per the ADR-035 §9 decomposition; this PR is additive dead code by design.