### PR TITLE
feat(rv2-pr4): wire verdict{} + warnings[] + verification{} into both write paths

### DIFF
--- a/scripts/lib/append_receipt_internals/git_provenance.py
+++ b/scripts/lib/append_receipt_internals/git_provenance.py
@@ -65,6 +65,11 @@ def _build_git_provenance(repo_root: Path) -> Dict[str, Any]:
                 "insertions": _extract_shortstat_value(shortstat, "insertion"),
                 "deletions": _extract_shortstat_value(shortstat, "deletion"),
             }
+            # ADR-035 §3.1.1/§3.2 (r2 HIGH-4): the changed-file list the
+            # doc-only invariant needs — same is_dirty gate, alongside the
+            # existing --shortstat call, no new git-invocation class.
+            name_only = _safe_subprocess(["git", "diff", "--name-only"], cwd=git_root) or ""
+            diff_summary["paths"] = [p for p in name_only.splitlines() if p.strip()]
 
     git_dir = _safe_subprocess(["git", "rev-parse", "--git-dir"], cwd=git_root) or ""
     git_common_dir = _safe_subprocess(["git", "rev-parse", "--git-common-dir"], cwd=git_root) or ""

--- a/scripts/lib/append_receipt_internals/idempotency.py
+++ b/scripts/lib/append_receipt_internals/idempotency.py
@@ -9,7 +9,7 @@ import logging
 import os
 import time
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional
 
 from .common import (
     AppendReceiptError,
@@ -194,8 +194,23 @@ def _write_receipt_under_lock(
     cache_path: Path,
     idempotency_key: str,
     cache_window_seconds: int,
+    *,
+    pre_write_hook: Optional[Callable[[Dict[str, Any]], None]] = None,
 ) -> AppendResult:
-    """Acquire the append lock and either write the receipt or skip as duplicate."""
+    """Acquire the append lock and either write the receipt or skip as duplicate.
+
+    ``pre_write_hook``, when given, runs INSIDE the lock exactly once the
+    idempotency check has confirmed this receipt is not a duplicate and WILL
+    be physically written — never on a duplicate hit. It receives ``receipt``
+    and may mutate it in place before the JSON line is serialized.
+
+    ADR-035 §9 PR-4 fix-r1: this is the seam the receipt-v2 warning
+    side-effect commit (``receipt_finalize.commit_receipt_v2_fields``) uses
+    so that promoting a warning to an open item / incrementing its
+    recurrence counter only happens for a receipt that actually lands in
+    the ledger — a deduped receipt must never touch the open-items store or
+    the counter.
+    """
     lock_path = _lock_file_for(receipt_path)
     min_epoch = time.time() - max(1, int(cache_window_seconds))
 
@@ -215,6 +230,9 @@ def _write_receipt_under_lock(
                     receipts_file=receipt_path,
                     idempotency_key=idempotency_key,
                 )
+
+            if pre_write_hook is not None:
+                pre_write_hook(receipt)
 
             # Hash-chain stamping (flag-gated). The read-tail + stamp happens
             # here, INSIDE the LOCK_EX block and BEFORE the receipt write, so

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -26,7 +26,7 @@ from .idempotency import (
     _resolve_receipts_file,
     _write_receipt_under_lock,
 )
-from .receipt_finalize import finalize_receipt_v2_fields
+from .receipt_finalize import classify_receipt_v2_warnings, commit_receipt_v2_fields
 from .validation import _validate_receipt
 
 import logging
@@ -364,10 +364,14 @@ def append_receipt_payload(
     # Keep the resolved receipt path aligned with any gate-stream reroute.
     receipt_path = _resolve_receipts_file(receipts_file).expanduser().resolve()
 
-    # ADR-035 §9 PR-4: wire verdict{}/warnings[] into the receipt, additively,
-    # before the shared validator sees it. Both write paths call this same
-    # finalize function (governance_emit.emit_dispatch_receipt is the other).
-    finalize_receipt_v2_fields(receipt)
+    # ADR-035 §9 PR-4 (fix-r1): pure classification of warnings[] (no side
+    # effects — no OI-store writes, no counter increments) before the shared
+    # validator sees it. Both write paths call this same classify step
+    # (governance_emit.emit_dispatch_receipt is the other). The matching
+    # side-effect commit (commit_receipt_v2_fields) runs only once
+    # _write_receipt_under_lock confirms this receipt is not a duplicate and
+    # will actually be written — see that function's pre_write_hook.
+    classify_receipt_v2_warnings(receipt)
 
     event_name = _validate_receipt(receipt)
     idempotency_key = _compute_idempotency_key(receipt, event_name)
@@ -385,6 +389,7 @@ def append_receipt_payload(
         cache_path,
         idempotency_key,
         cache_window_seconds,
+        pre_write_hook=commit_receipt_v2_fields,
     )
 
     if result.status == "appended":

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -26,6 +26,7 @@ from .idempotency import (
     _resolve_receipts_file,
     _write_receipt_under_lock,
 )
+from .receipt_finalize import finalize_receipt_v2_fields
 from .validation import _validate_receipt
 
 import logging
@@ -362,6 +363,11 @@ def append_receipt_payload(
     receipts_file = _maybe_reroute_to_gate_stream(receipt, receipts_file)
     # Keep the resolved receipt path aligned with any gate-stream reroute.
     receipt_path = _resolve_receipts_file(receipts_file).expanduser().resolve()
+
+    # ADR-035 §9 PR-4: wire verdict{}/warnings[] into the receipt, additively,
+    # before the shared validator sees it. Both write paths call this same
+    # finalize function (governance_emit.emit_dispatch_receipt is the other).
+    finalize_receipt_v2_fields(receipt)
 
     event_name = _validate_receipt(receipt)
     idempotency_key = _compute_idempotency_key(receipt, event_name)

--- a/scripts/lib/append_receipt_internals/receipt_finalize.py
+++ b/scripts/lib/append_receipt_internals/receipt_finalize.py
@@ -1,13 +1,40 @@
-"""Receipt-v2 finalize step — ADR-035 §9 PR-4.
+"""Receipt-v2 finalize step — ADR-035 §9 PR-4 (+ fix-r1 classify/commit split).
 
 Wires PR-1 (``receipt_verdict.compute_verdict``) and PR-2 (the
 warning-destination engine, ``warning_destination.assign_destination``) into
 the receipt dict immediately before the shared validator/append primitive
-(§7.1) sees it. Both write paths call this SAME function —
+(§7.1) sees it. Both write paths call the SAME functions —
 ``append_receipt_internals.payload.append_receipt_payload`` (Path 2) and
 ``governance_emit.emit_dispatch_receipt`` (Path 1) — so ``verdict{}`` and
 ``warnings[]`` land identically regardless of which writer produced the
 receipt (Codex Defense Checklist: same fix to all handlers).
+
+fix-r1: ``assign_destination``'s side effects (open-items promotion,
+recurrence-counter increment) used to run inline, BEFORE the shared
+validator and the idempotency-dedup check — so a receipt later rejected by
+the validator or skipped as a duplicate had already created an open item /
+bumped the counter for a line that never lands in the ledger. This module
+now splits the work into two phases:
+
+  - ``classify_receipt_v2_warnings`` (pure, no I/O beyond a read-only
+    recurrence-counter peek): computes ``destination``/``requires_tracking``
+    with an ``oi_id: None`` placeholder for anything requiring tracking —
+    exactly what ``compute_verdict`` needs (blocker warning -> reject;
+    unresolved ``oi_pending`` -> investigate). Called BEFORE
+    ``_validate_receipt``.
+  - ``commit_receipt_v2_fields`` (the deferred write): resolves the
+    placeholder to its real outcome (calls ``add_item_programmatic``,
+    increments the counter) and recomputes ``verdict{}`` from the
+    now-final ``warnings[]``. Passed as the ``pre_write_hook`` into
+    ``_write_receipt_under_lock`` (idempotency.py) — invoked ONLY once the
+    shared append primitive has confirmed under the append lock that this
+    receipt is not a duplicate and will actually be written. A deduped or
+    validator-rejected receipt never reaches this function, so it never
+    touches the open-items store or the counter.
+
+``finalize_receipt_v2_fields`` remains as the all-in-one composition
+(classify + commit back-to-back) for direct callers that don't need the
+deferred-commit split (e.g. unit tests exercising the engine in isolation).
 
 Additive only: no ``schema_version`` stamp, no field removed/renamed (PR-5).
 """
@@ -25,26 +52,25 @@ if str(_LIB_DIR) not in sys.path:
 from receipt_verdict import compute_verdict  # noqa: E402
 
 from .warning_destination import (  # noqa: E402
+    _PENDING_COMMIT_REASON,
     DEFAULT_RECURRENCE_THRESHOLD,
-    assign_destination,
+    classify_destination,
+    commit_destination,
     derive_open_items_created,
 )
 
 
-def _finalize_warnings(
+def classify_receipt_v2_warnings(
     receipt: Dict[str, Any],
     *,
-    dispatch_id: str,
-    report_path: str,
-    pr_id: str,
-    threshold: int,
-    counter_path: Optional[Path],
-    open_items_manager_module: Optional[Any],
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    counter_path: Optional[Path] = None,
 ) -> None:
-    """ADR-035 §6.1/§6.2: run any ``warnings[]`` entry that has not already
-    been assigned a ``destination`` through the destination-assignment
-    engine, then derive ``open_items_created`` from the resolved
-    ``warnings[]``.
+    """ADR-035 §6.1 (fix-r1, phase 1 — pure): run any ``warnings[]`` entry
+    that has not already been assigned a ``destination`` through the
+    side-effect-free ``classify_destination``. Never calls
+    ``add_item_programmatic`` and never increments the recurrence counter —
+    safe to run before the receipt is validated or checked for a duplicate.
 
     Only touches the receipt when it actually carries ``warnings[]`` — a
     receipt with no ``warnings[]`` key is left alone, including whatever
@@ -59,22 +85,82 @@ def _finalize_warnings(
     processed = []
     for entry in warnings_list:
         if isinstance(entry, dict) and "destination" not in entry:
+            kwargs: Dict[str, Any] = dict(threshold=threshold)
+            if counter_path is not None:
+                kwargs["counter_path"] = counter_path
+            processed.append(classify_destination(entry, **kwargs))
+        else:
+            processed.append(entry)
+
+    receipt["warnings"] = processed
+
+
+def commit_receipt_v2_warnings(
+    receipt: Dict[str, Any],
+    *,
+    counter_path: Optional[Path] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> None:
+    """ADR-035 §6.1/§6.2 (fix-r1, phase 2 — the deferred write): commit the
+    side effect for any ``warnings[]`` entry ``classify_receipt_v2_warnings``
+    classified (recognised by its pending-commit placeholder reason), then
+    derive ``open_items_created`` from the now-committed ``warnings[]``.
+
+    An entry the caller already supplied a final ``destination`` for
+    (present before classification ever ran) is left untouched here too —
+    it was never classified, so it is never committed.
+
+    MUST be called only once the shared append primitive has confirmed this
+    receipt will actually be written (see module docstring).
+    """
+    warnings_list = receipt.get("warnings")
+    if not warnings_list:
+        return
+
+    dispatch_id = str(receipt.get("dispatch_id") or "")
+    report_path = str(receipt.get("report_path") or "")
+    pr_id = str(receipt.get("pr_id") or "")
+
+    committed = []
+    for entry in warnings_list:
+        if isinstance(entry, dict) and entry.get("reason") == _PENDING_COMMIT_REASON:
             kwargs: Dict[str, Any] = dict(
                 dispatch_id=dispatch_id,
                 report_path=report_path,
                 pr_id=pr_id,
-                threshold=threshold,
             )
             if counter_path is not None:
                 kwargs["counter_path"] = counter_path
             if open_items_manager_module is not None:
                 kwargs["open_items_manager_module"] = open_items_manager_module
-            processed.append(assign_destination(entry, **kwargs))
+            committed.append(commit_destination(entry, **kwargs))
         else:
-            processed.append(entry)
+            committed.append(entry)
 
-    receipt["warnings"] = processed
-    receipt["open_items_created"] = derive_open_items_created(processed)
+    receipt["warnings"] = committed
+    receipt["open_items_created"] = derive_open_items_created(committed)
+
+
+def commit_receipt_v2_fields(
+    receipt: Dict[str, Any],
+    *,
+    counter_path: Optional[Path] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> None:
+    """fix-r1 phase 2, full: commit the deferred warning side effects, then
+    (re)compute ``verdict{}`` from the now-final ``warnings[]`` state.
+
+    This is the ``pre_write_hook`` both write paths pass into
+    ``_write_receipt_under_lock`` — invoked only once the append primitive,
+    under the append lock, has confirmed this receipt is not a duplicate and
+    will actually be written.
+    """
+    commit_receipt_v2_warnings(
+        receipt,
+        counter_path=counter_path,
+        open_items_manager_module=open_items_manager_module,
+    )
+    receipt["verdict"] = compute_verdict(receipt)
 
 
 def finalize_receipt_v2_fields(
@@ -85,31 +171,25 @@ def finalize_receipt_v2_fields(
     open_items_manager_module: Optional[Any] = None,
 ) -> None:
     """Mutate ``receipt`` in place: process ``warnings[]`` (if present)
-    through the destination-assignment engine, then compute ``verdict{}``
-    from the receipt's (now finalized) shape.
+    through the destination-assignment engine (classify THEN commit,
+    back-to-back), then compute ``verdict{}`` from the receipt's (now
+    finalized) shape.
 
-    Called by both write paths, always the last step before
-    ``_validate_receipt``/``_write_receipt_under_lock`` (§7.1) — ``verdict{}``
-    must see the resolved ``warnings[]`` destinations and any
-    ``verification{}`` the caller already stamped.
+    fix-r1: this all-in-one composition is for direct callers that want the
+    pre-split, no-deferred-commit behavior (e.g. warning-engine unit tests).
+    The write paths (``append_receipt_internals.payload``,
+    ``governance_emit``) call ``classify_receipt_v2_warnings`` before
+    validation and ``commit_receipt_v2_fields`` as the append primitive's
+    ``pre_write_hook`` instead — see the module docstring.
 
     ``threshold``/``counter_path``/``open_items_manager_module`` are
     test-injection seams (mirrors ``assign_destination``'s own signature);
     production callers use the defaults (the real on-disk recurrence
     counter and the real ``open_items_manager``).
     """
-    dispatch_id = str(receipt.get("dispatch_id") or "")
-    report_path = str(receipt.get("report_path") or "")
-    pr_id = str(receipt.get("pr_id") or "")
-
-    _finalize_warnings(
+    classify_receipt_v2_warnings(receipt, threshold=threshold, counter_path=counter_path)
+    commit_receipt_v2_fields(
         receipt,
-        dispatch_id=dispatch_id,
-        report_path=report_path,
-        pr_id=pr_id,
-        threshold=threshold,
         counter_path=counter_path,
         open_items_manager_module=open_items_manager_module,
     )
-
-    receipt["verdict"] = compute_verdict(receipt)

--- a/scripts/lib/append_receipt_internals/receipt_finalize.py
+++ b/scripts/lib/append_receipt_internals/receipt_finalize.py
@@ -1,0 +1,115 @@
+"""Receipt-v2 finalize step — ADR-035 §9 PR-4.
+
+Wires PR-1 (``receipt_verdict.compute_verdict``) and PR-2 (the
+warning-destination engine, ``warning_destination.assign_destination``) into
+the receipt dict immediately before the shared validator/append primitive
+(§7.1) sees it. Both write paths call this SAME function —
+``append_receipt_internals.payload.append_receipt_payload`` (Path 2) and
+``governance_emit.emit_dispatch_receipt`` (Path 1) — so ``verdict{}`` and
+``warnings[]`` land identically regardless of which writer produced the
+receipt (Codex Defense Checklist: same fix to all handlers).
+
+Additive only: no ``schema_version`` stamp, no field removed/renamed (PR-5).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from receipt_verdict import compute_verdict  # noqa: E402
+
+from .warning_destination import (  # noqa: E402
+    DEFAULT_RECURRENCE_THRESHOLD,
+    assign_destination,
+    derive_open_items_created,
+)
+
+
+def _finalize_warnings(
+    receipt: Dict[str, Any],
+    *,
+    dispatch_id: str,
+    report_path: str,
+    pr_id: str,
+    threshold: int,
+    counter_path: Optional[Path],
+    open_items_manager_module: Optional[Any],
+) -> None:
+    """ADR-035 §6.1/§6.2: run any ``warnings[]`` entry that has not already
+    been assigned a ``destination`` through the destination-assignment
+    engine, then derive ``open_items_created`` from the resolved
+    ``warnings[]``.
+
+    Only touches the receipt when it actually carries ``warnings[]`` — a
+    receipt with no ``warnings[]`` key is left alone, including whatever
+    pre-v2 mechanism (the ``quality_advisory`` dry-run count) already set
+    ``open_items_created``; migrating that mechanism onto ``warnings[]`` is
+    PR-4b/PR-5, out of scope here.
+    """
+    warnings_list = receipt.get("warnings")
+    if not warnings_list:
+        return
+
+    processed = []
+    for entry in warnings_list:
+        if isinstance(entry, dict) and "destination" not in entry:
+            kwargs: Dict[str, Any] = dict(
+                dispatch_id=dispatch_id,
+                report_path=report_path,
+                pr_id=pr_id,
+                threshold=threshold,
+            )
+            if counter_path is not None:
+                kwargs["counter_path"] = counter_path
+            if open_items_manager_module is not None:
+                kwargs["open_items_manager_module"] = open_items_manager_module
+            processed.append(assign_destination(entry, **kwargs))
+        else:
+            processed.append(entry)
+
+    receipt["warnings"] = processed
+    receipt["open_items_created"] = derive_open_items_created(processed)
+
+
+def finalize_receipt_v2_fields(
+    receipt: Dict[str, Any],
+    *,
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    counter_path: Optional[Path] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> None:
+    """Mutate ``receipt`` in place: process ``warnings[]`` (if present)
+    through the destination-assignment engine, then compute ``verdict{}``
+    from the receipt's (now finalized) shape.
+
+    Called by both write paths, always the last step before
+    ``_validate_receipt``/``_write_receipt_under_lock`` (§7.1) — ``verdict{}``
+    must see the resolved ``warnings[]`` destinations and any
+    ``verification{}`` the caller already stamped.
+
+    ``threshold``/``counter_path``/``open_items_manager_module`` are
+    test-injection seams (mirrors ``assign_destination``'s own signature);
+    production callers use the defaults (the real on-disk recurrence
+    counter and the real ``open_items_manager``).
+    """
+    dispatch_id = str(receipt.get("dispatch_id") or "")
+    report_path = str(receipt.get("report_path") or "")
+    pr_id = str(receipt.get("pr_id") or "")
+
+    _finalize_warnings(
+        receipt,
+        dispatch_id=dispatch_id,
+        report_path=report_path,
+        pr_id=pr_id,
+        threshold=threshold,
+        counter_path=counter_path,
+        open_items_manager_module=open_items_manager_module,
+    )
+
+    receipt["verdict"] = compute_verdict(receipt)

--- a/scripts/lib/append_receipt_internals/warning_destination.py
+++ b/scripts/lib/append_receipt_internals/warning_destination.py
@@ -54,6 +54,16 @@ DEFAULT_RECURRENCE_THRESHOLD = 3
 
 _COUNTER_FILENAME = "warning_recurrence_counts.json"
 
+# ADR-035 §9 PR-4 fix-r1: internal marker stamped into `reason` by
+# `classify_destination` for an entry whose side effect (OI-store promotion
+# or counter increment) is DEFERRED, not yet performed. `commit_destination`
+# looks for this exact sentinel to know which entries still need their
+# write-side primitive called — never a real drop_reason (constrained to
+# `DROP_REASON_ALLOWLIST`) or a real OI-store failure message, so it can
+# never collide with a legitimate persisted value. Always overwritten by
+# `commit_destination` before an entry reaches disk.
+_PENDING_COMMIT_REASON = "__pending_append_commit__"
+
 
 class WarningDestinationError(ValueError):
     """Raised when the engine is asked to compute an impossible destination.
@@ -181,52 +191,34 @@ def _counter_key(code: str, scope: str) -> str:
     return f"{code}:{scope}" if scope else code
 
 
-def assign_destination(
+def classify_destination(
     entry: Dict[str, Any],
     *,
-    dispatch_id: str = "",
-    report_path: str = "",
-    pr_id: str = "",
     scope: str = "",
     threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
     recurrence_count: Optional[int] = None,
     counter_path: Optional[Path] = None,
     drop_reason: Optional[str] = None,
-    open_items_manager_module: Optional[Any] = None,
 ) -> Dict[str, Any]:
-    """Compute `{destination, oi_id, reason, requires_tracking}` for one
-    `warnings[]` entry `{code, severity, message}`, in a single pass
-    (ADR-035 §6.1/§6.4).
+    """Side-effect-free half of `assign_destination` (ADR-035 §9 PR-4 fix-r1).
 
-    Args:
-        entry: the warning entry, at minimum `{code, severity}`.
-        dispatch_id/report_path/pr_id: forwarded to `add_item_programmatic`
-            when promotion fires.
-        scope: dispatch-adjacent scope (skill/terminal) the recurrence
-            threshold is keyed on alongside `code` — §6.1 rule 1.
-        threshold: recurrence threshold for `severity: "warn"` promotion.
-            Default 3, per §6.1.
-        recurrence_count: when given, used directly as "this occurrence's
-            recurrence count" — bypasses the on-disk rolling-window store
-            entirely, making the engine unit-testable deterministically
-            without a write-path. When omitted (the default production
-            path), the engine reads/increments a persistent per-(code,
-            scope) counter at `counter_path`.
-        counter_path: where the rolling-window/counted-counter is
-            persisted. Defaults to `<state_dir>/warning_recurrence_counts.json`
-            when omitted and `recurrence_count` was not injected.
-        drop_reason: when given (and the entry does not require tracking),
-            resolves to `destination: "dropped"` with this reason — must be
-            drawn from `DROP_REASON_ALLOWLIST`. Raises `WarningDestinationError`
-            if the entry requires tracking (a blocker/promoted-warn can
-            never be silently dropped) or the reason is not allow-listed.
-        open_items_manager_module: injectable `open_items_manager` module
-            (tests use this to control/observe the real OI store, or to
-            simulate an unreachable/locked store for the oi_pending path).
+    Computes `{destination, oi_id, reason, requires_tracking}` for one
+    `warnings[]` entry WITHOUT touching the open-items store or the
+    persistent recurrence counter — the only I/O is a read-only peek at the
+    counter (never an increment), needed to decide `requires_tracking` for a
+    `severity: "warn"` entry.
 
-    Returns:
-        A new dict: a copy of `entry` plus `destination`, `oi_id`, `reason`,
-        `requires_tracking`. The input `entry` is never mutated.
+    An entry that `requires_tracking` gets the placeholder
+    `destination: "oi_pending"` / `oi_id: None` — the real
+    `add_item_programmatic` call (and its oi/oi_pending resolution) is
+    deferred to `commit_destination`. An entry that resolves to `"counted"`
+    similarly gets a placeholder `reason` (`_PENDING_COMMIT_REASON`) marking
+    that its counter increment is still pending. `"dropped"` needs no
+    placeholder: it is a pure, final decision from the caller-supplied
+    `drop_reason` alone.
+
+    See `assign_destination` for the full parameter contract this mirrors.
+    Never mutates `entry`; always returns a new dict.
     """
     code = str(entry.get("code") or "").strip()
     if not code:
@@ -238,8 +230,6 @@ def assign_destination(
             f"warning entry has unrecognized severity: {severity!r} "
             f"(expected one of {sorted(LEGAL_SEVERITIES)})"
         )
-
-    message = entry.get("message", "") or ""
 
     if severity == "warn":
         if recurrence_count is not None:
@@ -263,8 +253,69 @@ def assign_destination(
             raise WarningDestinationError(
                 "cannot set drop_reason on a warning that requires_tracking"
             )
+        result["destination"] = "oi_pending"
+        result["oi_id"] = None
+        result["reason"] = _PENDING_COMMIT_REASON
+        return result
+
+    if drop_reason is not None:
+        if drop_reason not in DROP_REASON_ALLOWLIST:
+            raise WarningDestinationError(
+                f"drop_reason {drop_reason!r} is not in the allow-list "
+                f"{sorted(DROP_REASON_ALLOWLIST)}"
+            )
+        result["destination"] = "dropped"
+        result["oi_id"] = None
+        result["reason"] = drop_reason
+        return result
+
+    result["destination"] = "counted"
+    result["oi_id"] = None
+    result["reason"] = _PENDING_COMMIT_REASON
+    return result
+
+
+def commit_destination(
+    classified: Dict[str, Any],
+    *,
+    dispatch_id: str = "",
+    report_path: str = "",
+    pr_id: str = "",
+    scope: str = "",
+    recurrence_count: Optional[int] = None,
+    counter_path: Optional[Path] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Side-effect commit half of `assign_destination` (ADR-035 §9 PR-4
+    fix-r1). Takes a `classify_destination`-produced entry and performs the
+    deferred write:
+
+      - `destination: "oi_pending"` with the pending-commit placeholder
+        reason and `requires_tracking: True`: calls `add_item_programmatic`,
+        resolving to `"oi"` + a real `oi_id` on success, or staying
+        `"oi_pending"` with the real failure reason on error — exactly the
+        outcome `assign_destination` used to compute inline (ADR-035 §6.4).
+      - `destination: "counted"` with the pending-commit placeholder reason:
+        increments the persisted recurrence counter, then resolves `reason`
+        back to `None`.
+      - anything else (a pre-resolved `"dropped"`, or an already-committed
+        entry): passed through unchanged — never double-committed.
+
+    Callers MUST only invoke this once the shared append primitive has
+    confirmed the receipt carrying `classified` will actually be written
+    (not deduped, not rejected by the validator) — committing a side effect
+    for a receipt that never lands on disk is exactly the bug this split
+    fixes. Never mutates `classified`; always returns a new dict.
+    """
+    destination = classified.get("destination")
+    result: Dict[str, Any] = dict(classified)
+
+    if destination == "oi_pending" and classified.get("requires_tracking"):
+        code = str(classified.get("code") or "")
+        severity = classified.get("severity")
+        message = classified.get("message", "") or ""
         oim = open_items_manager_module or _get_open_items_manager()
-        dedup_key = dedup_key_for(entry)
+        dedup_key = dedup_key_for(classified)
         try:
             item_id, _created = oim.add_item_programmatic(
                 title=message or code,
@@ -297,22 +348,88 @@ def assign_destination(
             result["reason"] = str(exc)
         return result
 
-    if drop_reason is not None:
-        if drop_reason not in DROP_REASON_ALLOWLIST:
-            raise WarningDestinationError(
-                f"drop_reason {drop_reason!r} is not in the allow-list "
-                f"{sorted(DROP_REASON_ALLOWLIST)}"
-            )
-        result["destination"] = "dropped"
-        result["oi_id"] = None
-        result["reason"] = drop_reason
+    if destination == "counted" and classified.get("reason") == _PENDING_COMMIT_REASON:
+        code = str(classified.get("code") or "")
+        if recurrence_count is None:
+            path = counter_path or _default_counter_path()
+            _increment_counter(path, _counter_key(code, scope))
+        result["reason"] = None
         return result
 
-    if recurrence_count is None:
-        path = counter_path or _default_counter_path()
-        _increment_counter(path, _counter_key(code, scope))
-
-    result["destination"] = "counted"
-    result["oi_id"] = None
-    result["reason"] = None
     return result
+
+
+def assign_destination(
+    entry: Dict[str, Any],
+    *,
+    dispatch_id: str = "",
+    report_path: str = "",
+    pr_id: str = "",
+    scope: str = "",
+    threshold: int = DEFAULT_RECURRENCE_THRESHOLD,
+    recurrence_count: Optional[int] = None,
+    counter_path: Optional[Path] = None,
+    drop_reason: Optional[str] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """Compute `{destination, oi_id, reason, requires_tracking}` for one
+    `warnings[]` entry `{code, severity, message}`, in a single pass
+    (ADR-035 §6.1/§6.4).
+
+    ADR-035 §9 PR-4 fix-r1: composed from `classify_destination` (pure) +
+    `commit_destination` (the write-side primitive) run back-to-back — same
+    externally-observable result as before the split, for callers (this
+    function, and `receipt_finalize.finalize_receipt_v2_fields`) that want
+    the old all-in-one behavior with no deferred-commit step. The write
+    paths (`append_receipt_internals.payload`, `governance_emit`) call the
+    two halves separately instead, so the commit only fires once the append
+    primitive confirms the receipt will actually be written.
+
+    Args:
+        entry: the warning entry, at minimum `{code, severity}`.
+        dispatch_id/report_path/pr_id: forwarded to `add_item_programmatic`
+            when promotion fires.
+        scope: dispatch-adjacent scope (skill/terminal) the recurrence
+            threshold is keyed on alongside `code` — §6.1 rule 1.
+        threshold: recurrence threshold for `severity: "warn"` promotion.
+            Default 3, per §6.1.
+        recurrence_count: when given, used directly as "this occurrence's
+            recurrence count" — bypasses the on-disk rolling-window store
+            entirely, making the engine unit-testable deterministically
+            without a write-path. When omitted (the default production
+            path), the engine reads/increments a persistent per-(code,
+            scope) counter at `counter_path`.
+        counter_path: where the rolling-window/counted-counter is
+            persisted. Defaults to `<state_dir>/warning_recurrence_counts.json`
+            when omitted and `recurrence_count` was not injected.
+        drop_reason: when given (and the entry does not require tracking),
+            resolves to `destination: "dropped"` with this reason — must be
+            drawn from `DROP_REASON_ALLOWLIST`. Raises `WarningDestinationError`
+            if the entry requires tracking (a blocker/promoted-warn can
+            never be silently dropped) or the reason is not allow-listed.
+        open_items_manager_module: injectable `open_items_manager` module
+            (tests use this to control/observe the real OI store, or to
+            simulate an unreachable/locked store for the oi_pending path).
+
+    Returns:
+        A new dict: a copy of `entry` plus `destination`, `oi_id`, `reason`,
+        `requires_tracking`. The input `entry` is never mutated.
+    """
+    classified = classify_destination(
+        entry,
+        scope=scope,
+        threshold=threshold,
+        recurrence_count=recurrence_count,
+        counter_path=counter_path,
+        drop_reason=drop_reason,
+    )
+    return commit_destination(
+        classified,
+        dispatch_id=dispatch_id,
+        report_path=report_path,
+        pr_id=pr_id,
+        scope=scope,
+        recurrence_count=recurrence_count,
+        counter_path=counter_path,
+        open_items_manager_module=open_items_manager_module,
+    )

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -451,6 +451,72 @@ def _resolve_fix_forward_diff(
     return pushed_diff if pushed_diff.strip() else own_diff
 
 
+def _unknown_verification() -> Dict[str, Any]:
+    """ADR-035 §3.1.1 fallback: an explicit 'we don't know' beats the
+    current silent absence — used when no report is on disk to extract from."""
+    return {
+        "method": "unknown",
+        "tests_run": None,
+        "tests_passed": None,
+        "tests_failed": None,
+        "command": None,
+        "pr_ref": None,
+        "push_verified": None,
+        "spec_deviation": None,
+    }
+
+
+def _verification_from_report(report_path: Optional[Path]) -> Dict[str, Any]:
+    """ADR-035 §3.1.1 — envelope sub-path: `emit_unified_report` already ran,
+    so the markdown report is on disk by the time the receipt is written.
+    Threads the SAME `report_parser.py::extract_validation` regex extractor
+    Path 2 already uses into this call — no new extraction mechanism, no new
+    report format (§8 non-goal).
+
+    Never raises: any extraction failure degrades to `method: "unknown"`
+    rather than blocking the (fail-closed) receipt write.
+    """
+    if report_path is None or not report_path.exists():
+        return _unknown_verification()
+
+    try:
+        content = report_path.read_text(encoding="utf-8", errors="ignore")
+
+        _scripts_dir = str(Path(__file__).resolve().parent.parent)
+        if _scripts_dir not in sys.path:
+            sys.path.insert(0, _scripts_dir)
+        from report_parser import ReportParser  # noqa: PLC0415
+
+        extracted = ReportParser().extract_validation(content)
+        tests_passed = int(extracted.get("tests_passed") or 0)
+        tests_failed = int(extracted.get("tests_failed") or 0)
+        tests_run = tests_passed + tests_failed
+
+        if tests_run > 0:
+            method = "pytest"
+        elif extracted.get("quality_gates"):
+            method = "manual"
+        else:
+            method = "unknown"
+
+        return {
+            "method": method,
+            "tests_run": tests_run if tests_run > 0 else None,
+            "tests_passed": tests_passed if tests_run > 0 else None,
+            "tests_failed": tests_failed if tests_run > 0 else None,
+            "command": None,
+            "pr_ref": None,
+            "push_verified": None,
+            "spec_deviation": None,
+        }
+    except Exception as exc:  # noqa: BLE001 — never block the receipt write
+        logger.warning(
+            "envelope._verification_from_report: extraction failed for %s: %s",
+            report_path, exc,
+        )
+        return _unknown_verification()
+
+
 def _govern(
     spec: EnvelopeSpec,
     adapter_result: _AdapterResult,
@@ -528,6 +594,10 @@ def _govern(
                     if integrity is not None
                     else None
                 ),
+                # ADR-035 §3.1.1: envelope sub-path — the report is already
+                # on disk (emit_unified_report ran above), so extract
+                # verification{} from it via the shared regex extractor.
+                verification=_verification_from_report(report_path),
             )
         except Exception as exc:
             raise EnvelopeGovernError(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -38,6 +38,7 @@ from append_receipt_internals.idempotency import (
     _compute_idempotency_key,
     _write_receipt_under_lock,
 )
+from append_receipt_internals.receipt_finalize import finalize_receipt_v2_fields
 from append_receipt_internals.validation import _validate_receipt
 
 logger = logging.getLogger(__name__)
@@ -83,6 +84,8 @@ def emit_dispatch_receipt(
     final_prompt_path: Optional[str] = None,
     final_prompt_sha256: Optional[str] = None,
     injection_reconstructs: Optional[bool] = None,
+    verification: Optional[Dict[str, Any]] = None,
+    warnings: Optional[List[Dict[str, Any]]] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -112,6 +115,21 @@ def emit_dispatch_receipt(
     recorded intelligence injections literally reconstruct that body. Each is only
     stamped when provided so lanes that do not yet compute integrity keep a
     byte-identical receipt shape.
+
+    ``verification``: ADR-035 §3.1.1 — the v2 ``verification{}`` object. The
+    envelope sub-path (``dispatch_envelope.py``) threads the report already on
+    disk through ``report_parser.py::extract_validation`` and passes the
+    result here; the multi-provider sub-path (``provider_dispatch.py``) passes
+    ``{"method": "pending-report", ...}`` explicitly, since ``report_path`` is
+    not yet a real file at call time on that sub-path. Only stamped when
+    provided, so callers that do not yet compute it keep a byte-identical
+    receipt shape.
+
+    ``warnings``: ADR-035 §6.1 — raw ``{code, severity, message}`` entries.
+    Run through the destination-assignment engine (via
+    ``finalize_receipt_v2_fields``, called below) before the receipt is
+    validated/appended, exactly like Path 2 (``append_receipt_payload``).
+    Only stamped when provided.
 
     Raises:
         ValueError: provider field doesn't match required pattern
@@ -157,11 +175,19 @@ def emit_dispatch_receipt(
         receipt["final_prompt_sha256"] = final_prompt_sha256
     if injection_reconstructs is not None:
         receipt["injection_reconstructs"] = injection_reconstructs
+    if verification is not None:
+        receipt["verification"] = verification
+    if warnings is not None:
+        receipt["warnings"] = warnings
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
+        # ADR-035 §9 PR-4: wire verdict{}/warnings[] into the receipt,
+        # additively, before the shared validator sees it — the same
+        # finalize function append_receipt_payload (Path 2) calls.
+        finalize_receipt_v2_fields(receipt)
         event_name = _validate_receipt(receipt)
         idempotency_key = _compute_idempotency_key(receipt, event_name)
         cache_path = _cache_file_for(receipt_path)

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -38,7 +38,10 @@ from append_receipt_internals.idempotency import (
     _compute_idempotency_key,
     _write_receipt_under_lock,
 )
-from append_receipt_internals.receipt_finalize import finalize_receipt_v2_fields
+from append_receipt_internals.receipt_finalize import (
+    classify_receipt_v2_warnings,
+    commit_receipt_v2_fields,
+)
 from append_receipt_internals.validation import _validate_receipt
 
 logger = logging.getLogger(__name__)
@@ -126,10 +129,12 @@ def emit_dispatch_receipt(
     receipt shape.
 
     ``warnings``: ADR-035 §6.1 — raw ``{code, severity, message}`` entries.
-    Run through the destination-assignment engine (via
-    ``finalize_receipt_v2_fields``, called below) before the receipt is
-    validated/appended, exactly like Path 2 (``append_receipt_payload``).
-    Only stamped when provided.
+    Classified (side-effect-free) via ``classify_receipt_v2_warnings``
+    before the receipt is validated, then committed (open-items promotion,
+    counter increment) via ``commit_receipt_v2_fields`` only once the
+    append primitive confirms the receipt will actually be written
+    (fix-r1) — exactly like Path 2 (``append_receipt_payload``). Only
+    stamped when provided.
 
     Raises:
         ValueError: provider field doesn't match required pattern
@@ -184,10 +189,15 @@ def emit_dispatch_receipt(
     receipt_path.parent.mkdir(parents=True, exist_ok=True)
 
     try:
-        # ADR-035 §9 PR-4: wire verdict{}/warnings[] into the receipt,
-        # additively, before the shared validator sees it — the same
-        # finalize function append_receipt_payload (Path 2) calls.
-        finalize_receipt_v2_fields(receipt)
+        # ADR-035 §9 PR-4 (fix-r1): pure classification of warnings[] (no
+        # side effects) before the shared validator sees it — the same
+        # classify step append_receipt_payload (Path 2) calls. The matching
+        # side-effect commit (open-items promotion, counter increment) is
+        # deferred to commit_receipt_v2_fields, passed below as
+        # pre_write_hook so it only fires once _write_receipt_under_lock
+        # confirms this receipt is not a duplicate and will actually be
+        # written.
+        classify_receipt_v2_warnings(receipt)
         event_name = _validate_receipt(receipt)
         idempotency_key = _compute_idempotency_key(receipt, event_name)
         cache_path = _cache_file_for(receipt_path)
@@ -197,6 +207,7 @@ def emit_dispatch_receipt(
             cache_path,
             idempotency_key,
             _RECEIPT_CACHE_WINDOW_SECONDS,
+            pre_write_hook=commit_receipt_v2_fields,
         )
     except AppendReceiptError as exc:
         raise RuntimeError(

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -662,6 +662,22 @@ def _emit_governance(
                 injection_reconstructs=(
                     getattr(_integrity, "injection_reconstructs", None) if _integrity is not None else None
                 ),
+                # ADR-035 §3.1.1: multi-provider sub-path — this call runs
+                # BEFORE emit_unified_report below, so report_path is a
+                # precomputed string with no file behind it yet. Stamp
+                # method="pending-report" explicitly, never a silent blank —
+                # this sub-path is never backfilled (append-only, no second
+                # write for this dispatch_id).
+                verification={
+                    "method": "pending-report",
+                    "tests_run": None,
+                    "tests_passed": None,
+                    "tests_failed": None,
+                    "command": None,
+                    "pr_ref": None,
+                    "push_verified": None,
+                    "spec_deviation": None,
+                },
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -535,8 +535,10 @@ class ReportParser:
 
     def _extract_section(self, content: str, section_name: str) -> Optional[str]:
         """Extract a specific section from markdown content"""
-        # Find section header
-        pattern = re.compile(rf'^#{1,3}\s*{section_name}.*?$', re.MULTILINE | re.IGNORECASE)
+        # Find section header. Note: {{1,3}} (double-braced) is required — a
+        # bare {1,3} inside an f-string is parsed as the tuple literal (1, 3),
+        # not the regex quantifier, and silently never matches any heading.
+        pattern = re.compile(rf'^#{{1,3}}\s*{section_name}.*?$', re.MULTILINE | re.IGNORECASE)
         match = pattern.search(content)
 
         if not match:

--- a/tests/test_git_provenance.py
+++ b/tests/test_git_provenance.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/append_receipt_internals/git_provenance.py::_build_git_provenance
+(ADR-035 §3.1.1/§3.2, r2 HIGH-4) — the changed-file `paths` addition to
+`diff_summary`, needed by the doc-only invariant.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+from append_receipt_internals.git_provenance import _build_git_provenance  # noqa: E402
+
+
+def _run(cmd, cwd):
+    subprocess.run(cmd, cwd=str(cwd), check=True, capture_output=True, text=True)
+
+
+@pytest.fixture()
+def git_repo(tmp_path):
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _run(["git", "init", "-q"], repo)
+    _run(["git", "config", "user.email", "test@example.com"], repo)
+    _run(["git", "config", "user.name", "Test"], repo)
+    (repo / "docs").mkdir()
+    (repo / "README.md").write_text("hello\n", encoding="utf-8")
+    (repo / "docs" / "ADR.md").write_text("adr\n", encoding="utf-8")
+    (repo / "scripts.py").write_text("print(1)\n", encoding="utf-8")
+    _run(["git", "add", "."], repo)
+    _run(["git", "commit", "-q", "-m", "init"], repo)
+    return repo
+
+
+def test_paths_absent_when_clean(git_repo):
+    provenance = _build_git_provenance(git_repo)
+    assert provenance["is_dirty"] is False
+    assert provenance["diff_summary"] is None
+
+
+def test_paths_lists_changed_files_when_dirty(git_repo):
+    (git_repo / "docs" / "ADR.md").write_text("adr changed\n", encoding="utf-8")
+    (git_repo / "scripts.py").write_text("print(2)\n", encoding="utf-8")
+
+    provenance = _build_git_provenance(git_repo)
+    assert provenance["is_dirty"] is True
+    assert provenance["diff_summary"] is not None
+    paths = provenance["diff_summary"]["paths"]
+    assert set(paths) == {"docs/ADR.md", "scripts.py"}
+
+
+def test_paths_all_docs_when_only_docs_changed(git_repo):
+    (git_repo / "docs" / "ADR.md").write_text("adr changed again\n", encoding="utf-8")
+
+    provenance = _build_git_provenance(git_repo)
+    paths = provenance["diff_summary"]["paths"]
+    assert paths == ["docs/ADR.md"]
+    assert all(p.startswith("docs/") and p.endswith(".md") for p in paths)
+
+
+def test_paths_uses_same_is_dirty_gate_as_shortstat(git_repo):
+    """paths is populated inside the same `if is_dirty` branch as shortstat —
+    both are present together or both absent, never one without the other."""
+    provenance = _build_git_provenance(git_repo)
+    assert ("paths" in (provenance["diff_summary"] or {})) == (provenance["diff_summary"] is not None)
+
+    (git_repo / "README.md").write_text("hello changed\n", encoding="utf-8")
+    provenance = _build_git_provenance(git_repo)
+    assert "paths" in provenance["diff_summary"]
+    assert "files_changed" in provenance["diff_summary"]

--- a/tests/test_receipt_v2_pr4_wiring.py
+++ b/tests/test_receipt_v2_pr4_wiring.py
@@ -1,0 +1,503 @@
+#!/usr/bin/env python3
+"""ADR-035 §9 PR-4 — end-to-end wiring tests.
+
+PR-1 (receipt_verdict.compute_verdict) and PR-2 (the warning-destination
+engine) landed as additive libraries, unit-tested in isolation
+(test_receipt_verdict.py, test_warning_destination.py). This file proves the
+WIRING: that both write paths — append_receipt_internals.payload
+.append_receipt_payload (Path 2) and governance_emit.emit_dispatch_receipt
+(Path 1, both its envelope and multi-provider sub-paths) — now stamp
+verdict{}/warnings[]/verification{} on a REAL appended receipt, not just on
+a receipt dict handed directly to the pure functions.
+
+Covers: T3-T9 (end-to-end on both paths), T22 (validator rejection on both
+paths), T23/T35 (doc-only invariant, end-to-end), T24 (envelope sub-path
+verification extraction), T25 (multi-provider sub-path pending-report).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import append_receipt as ar  # noqa: E402 — registers the Path-2 facade
+import governance_emit  # noqa: E402
+
+from append_receipt_internals.common import AppendReceiptError  # noqa: E402
+from append_receipt_internals.receipt_finalize import finalize_receipt_v2_fields  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers
+# ---------------------------------------------------------------------------
+
+
+def _read_lines(receipts_path: Path) -> list:
+    if not receipts_path.exists():
+        return []
+    return [json.loads(l) for l in receipts_path.read_text().splitlines() if l.strip()]
+
+
+def _path2_append(receipt: Dict[str, Any], receipts_path: Path):
+    """Path 2: append_receipt_payload, isolated (no project_id -> no central mirror)."""
+    return ar.append_receipt_payload(
+        receipt, receipts_file=str(receipts_path), skip_enrichment=True,
+    )
+
+
+def _path1_emit(receipts_path: Path, *, status: str, verification=None, dispatch_id="path1-test"):
+    """Path 1: governance_emit.emit_dispatch_receipt."""
+    return governance_emit.emit_dispatch_receipt(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-5",
+        pr_id=None,
+        status=status,
+        completion_pct=100 if status == "success" else 0,
+        risk=0.0,
+        findings=[],
+        duration_seconds=1.0,
+        token_usage={"input": 1, "output": 1},
+        cost_usd=None,
+        state_dir=receipts_path.parent,
+        verification=verification,
+    )
+
+
+def _base_path2_receipt(dispatch_id: str, **overrides: Any) -> Dict[str, Any]:
+    receipt = {
+        "timestamp": "2026-07-22T10:00:00Z",
+        "event_type": "task_complete",
+        "dispatch_id": dispatch_id,
+        "status": "done",
+    }
+    receipt.update(overrides)
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# T3 — reject on hard-failure status, both paths
+# ---------------------------------------------------------------------------
+
+
+def test_t3_path2_reject_on_hard_failure_status(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt("t3-path2", status="failed")
+    result = _path2_append(receipt, receipts_path)
+    assert result.status == "appended"
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "reject"
+
+
+def test_t3_path1_reject_on_hard_failure_status(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    _path1_emit(receipts_path, status="failure", dispatch_id="t3-path1")
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "reject"
+
+
+# ---------------------------------------------------------------------------
+# T4 — investigate: success status, no/incomplete verification evidence
+# ---------------------------------------------------------------------------
+
+
+def test_t4_path2_investigate_no_verification(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt("t4-path2", status="done")
+    _path2_append(receipt, receipts_path)
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "investigate"
+
+
+def test_t4_path1_investigate_no_verification(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    _path1_emit(receipts_path, status="success", dispatch_id="t4-path1")
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "investigate"
+    assert line["verdict"]["evidence_complete"] is True  # method absent, not an "incomplete" method
+
+
+# ---------------------------------------------------------------------------
+# T5 — accept: success status, clean verification evidence
+# ---------------------------------------------------------------------------
+
+
+def test_t5_path2_accept_clean_verification(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt(
+        "t5-path2",
+        status="done",
+        verification={"method": "pytest", "tests_run": 12, "tests_passed": 12, "tests_failed": 0},
+    )
+    _path2_append(receipt, receipts_path)
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "accept"
+    assert line["verdict"]["evidence_complete"] is True
+
+
+def test_t5_path1_accept_clean_verification(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    _path1_emit(
+        receipts_path,
+        status="success",
+        dispatch_id="t5-path1",
+        verification={"method": "pytest", "tests_run": 5, "tests_passed": 5, "tests_failed": 0},
+    )
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "accept"
+
+
+# ---------------------------------------------------------------------------
+# T6 / T22 — validator rejection on BOTH write paths (closes BLOCKING-3's
+# bypass end-to-end: the shared primitive's validator, not just Path 2)
+# ---------------------------------------------------------------------------
+
+
+def test_t6_path2_dropped_null_reason_rejected(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    entry = {
+        "code": "x", "severity": "warn", "message": "m",
+        "destination": "dropped", "oi_id": None, "reason": None, "requires_tracking": False,
+    }
+    receipt = _base_path2_receipt("t6-path2", warnings=[entry])
+    with pytest.raises(AppendReceiptError):
+        _path2_append(receipt, receipts_path)
+    assert not _read_lines(receipts_path)
+
+
+def test_t6_path1_dropped_null_reason_rejected(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    entry = {
+        "code": "x", "severity": "warn", "message": "m",
+        "destination": "dropped", "oi_id": None, "reason": None, "requires_tracking": False,
+    }
+    with pytest.raises(RuntimeError):
+        governance_emit.emit_dispatch_receipt(
+            dispatch_id="t6-path1", terminal_id="T1", provider="claude",
+            model="claude-sonnet-5", pr_id=None, status="success",
+            completion_pct=100, risk=0.0, findings=[], duration_seconds=1.0,
+            token_usage={"input": 1, "output": 1}, cost_usd=None,
+            state_dir=receipts_path.parent,
+            verification={"method": "pytest", "tests_run": 1, "tests_passed": 1, "tests_failed": 0},
+            warnings=[entry],
+        )
+    assert not _read_lines(receipts_path)
+
+
+@pytest.mark.parametrize(
+    "bad_entry",
+    [
+        {"code": "x", "severity": "warn", "destination": "ignored", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"severity": "warn", "destination": "counted", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"code": "x", "destination": "counted", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"code": "x", "severity": "warn", "destination": "oi", "oi_id": None, "reason": None, "requires_tracking": True},
+    ],
+    ids=["illegal-destination", "missing-code", "missing-severity", "oi-missing-oi_id"],
+)
+def test_t22_path2_rejects_illegal_warnings(tmp_path, bad_entry):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt("t22-path2", warnings=[bad_entry])
+    with pytest.raises(AppendReceiptError):
+        _path2_append(receipt, receipts_path)
+    assert not _read_lines(receipts_path)
+
+
+@pytest.mark.parametrize(
+    "bad_entry",
+    [
+        {"code": "x", "severity": "warn", "destination": "ignored", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"severity": "warn", "destination": "counted", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"code": "x", "destination": "counted", "oi_id": None, "reason": None, "requires_tracking": False},
+        {"code": "x", "severity": "warn", "destination": "oi", "oi_id": None, "reason": None, "requires_tracking": True},
+    ],
+    ids=["illegal-destination", "missing-code", "missing-severity", "oi-missing-oi_id"],
+)
+def test_t22_path1_rejects_illegal_warnings(tmp_path, bad_entry):
+    """T22 on Path 1: emit_dispatch_receipt (the real Path-1 writer) with an
+    illegal warnings[] entry — proves the validator now binds to Path 1 too,
+    not just Path 2 (closes BLOCKING-3's bypass end-to-end)."""
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    with pytest.raises((AppendReceiptError, RuntimeError)):
+        governance_emit.emit_dispatch_receipt(
+            dispatch_id="t22-path1", terminal_id="T1", provider="claude",
+            model="claude-sonnet-5", pr_id=None, status="success",
+            completion_pct=100, risk=0.0, findings=[], duration_seconds=1.0,
+            token_usage={"input": 1, "output": 1}, cost_usd=None,
+            state_dir=receipts_path.parent,
+            verification={"method": "pytest", "tests_run": 1, "tests_passed": 1, "tests_failed": 0},
+            warnings=[bad_entry],
+        )
+    assert not _read_lines(receipts_path)
+
+
+# ---------------------------------------------------------------------------
+# T7-T9 — warnings[] flow through the destination-assignment engine when
+# driven through the shared primitive (finalize_receipt_v2_fields) that both
+# write paths call — not just assign_destination() in isolation.
+# ---------------------------------------------------------------------------
+
+
+def _load_oim(tmp_path: Path):
+    """Fresh, isolated open_items_manager bound to a per-test STATE_DIR —
+    mirrors test_warning_destination.py's helper (real add_item_programmatic,
+    not a mock)."""
+    import importlib.util
+    import os
+    from unittest.mock import patch as _patch
+
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(VNX_ROOT),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+    mod_name = f"open_items_manager_pr4wiring_{tmp_path.name}"
+    with _patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(mod_name, SCRIPTS_DIR / "open_items_manager.py")
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+def test_t7_finalize_promotes_recurring_warn_to_oi(tmp_path):
+    oim = _load_oim(tmp_path)
+    counter_path = tmp_path / "counts.json"
+
+    def _fresh_receipt(dispatch_id):
+        return {
+            "dispatch_id": dispatch_id, "status": "done", "event_type": "task_complete",
+            "timestamp": "2026-07-22T10:00:00Z",
+            # A freshly-authored raw entry each "receipt" — no destination yet,
+            # simulating three independent dispatches hitting the same check.
+            "warnings": [{"code": "recurring_check", "severity": "warn", "message": "m"}],
+        }
+
+    receipt = None
+    for i in range(3):
+        receipt = _fresh_receipt(f"t7-finalize-{i}")
+        finalize_receipt_v2_fields(receipt, counter_path=counter_path, open_items_manager_module=oim)
+
+    assert receipt["warnings"][0]["destination"] == "oi"
+    assert receipt["warnings"][0]["oi_id"] is not None
+    assert receipt["open_items_created"] == 1
+    # A promoted warn-severity entry (not blocker) doesn't force reject —
+    # verdict still falls through to investigate on missing test evidence.
+    assert receipt["verdict"]["decision"] == "investigate"
+
+
+def test_t8_finalize_warn_below_threshold_is_counted(tmp_path):
+    counter_path = tmp_path / "counts.json"
+    receipt = {
+        "dispatch_id": "t8-finalize", "status": "done", "event_type": "task_complete",
+        "timestamp": "2026-07-22T10:00:00Z",
+        "warnings": [{"code": "below_threshold_check", "severity": "warn", "message": "m"}],
+    }
+
+    class _NeverCalledOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise AssertionError("must not touch the OI store below threshold")
+
+    finalize_receipt_v2_fields(receipt, counter_path=counter_path, open_items_manager_module=_NeverCalledOIM())
+
+    assert receipt["warnings"][0]["destination"] == "counted"
+    assert receipt["open_items_created"] == 0
+
+
+def test_t9_finalize_report_contract_invalid_counted_from_first_occurrence(tmp_path):
+    counter_path = tmp_path / "counts.json"
+    receipt = {
+        "dispatch_id": "t9-finalize", "status": "done", "event_type": "task_complete",
+        "timestamp": "2026-07-22T10:00:00Z",
+        "warnings": [{"code": "report_contract_invalid", "severity": "warn", "message": "Summary missing"}],
+    }
+
+    finalize_receipt_v2_fields(receipt, counter_path=counter_path)
+
+    assert receipt["warnings"][0]["destination"] == "counted"
+    assert receipt["warnings"][0]["requires_tracking"] is False
+    assert receipt["open_items_created"] == 0
+
+
+# ---------------------------------------------------------------------------
+# T23 / T35 — doc-only invariant, end-to-end through the real write path
+# ---------------------------------------------------------------------------
+
+
+def test_t23_path2_nondocs_path_forces_investigate(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt(
+        "t23-path2",
+        status="done",
+        verification={"method": "n/a"},
+        provenance={"diff_summary": {"paths": ["docs/ADR.md", "scripts/lib/foo.py"]}},
+    )
+    _path2_append(receipt, receipts_path)
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "investigate"
+
+
+def test_t35_path2_missing_paths_forces_investigate(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = _base_path2_receipt(
+        "t35-path2",
+        status="done",
+        verification={"method": "n/a"},
+    )
+    _path2_append(receipt, receipts_path)
+    line = _read_lines(receipts_path)[-1]
+    assert line["verdict"]["decision"] == "investigate"
+
+
+def test_t23_path1_nondocs_path_forces_investigate(tmp_path):
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    governance_emit.emit_dispatch_receipt(
+        dispatch_id="t23-path1", terminal_id="T1", provider="claude",
+        model="claude-sonnet-5", pr_id=None, status="success",
+        completion_pct=100, risk=0.0, findings=[], duration_seconds=1.0,
+        token_usage={"input": 1, "output": 1}, cost_usd=None,
+        state_dir=receipts_path.parent,
+        verification={"method": "n/a"},
+    )
+    line = _read_lines(receipts_path)[-1]
+    # Path 1 stamps no provenance today (§3.1.1's invariant is fail-safe on
+    # absence) -> paths is unproven doc-only-ness -> investigate.
+    assert line["verdict"]["decision"] == "investigate"
+
+
+# ---------------------------------------------------------------------------
+# T24 — envelope sub-path: verification{} populated from the report already
+# on disk, via the same extract_validation regex extractor Path 2 uses.
+# ---------------------------------------------------------------------------
+
+
+def test_t24_envelope_subpath_verification_from_report(tmp_path):
+    import dispatch_envelope
+    from dispatch_envelope import EnvelopeSpec, run_envelope
+
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True)
+    (data_dir / "unified_reports").mkdir(parents=True)
+    spec = EnvelopeSpec(
+        dispatch_id="t24-envelope",
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-5.2-codex",
+        instruction="implement the feature",
+        role="backend-developer",
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+    codex_result = SimpleNamespace(
+        returncode=0,
+        completion_text="Implemented the feature.\n\n## Validation\n\n12 tests passed, 0 failed\n",
+        timed_out=False,
+        stopped_early=False,
+        token_usage={"input_tokens": 100, "output_tokens": 50},
+        error=None,
+        event_writer_failures=0,
+    )
+
+    captured: Dict[str, Any] = {}
+    real_emit = governance_emit.emit_dispatch_receipt
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return real_emit(**kwargs)
+
+    with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
+         patch("governance_emit.emit_dispatch_receipt", side_effect=_capture):
+        run_envelope(spec, lane="codex")
+
+    assert captured["verification"]["method"] == "pytest"
+    assert captured["verification"]["tests_run"] == 12
+    assert captured["verification"]["tests_passed"] == 12
+    assert captured["verification"]["tests_failed"] == 0
+
+    report_path = data_dir / "unified_reports" / "t24-envelope.md"
+    assert report_path.exists()
+    assert "## Validation" in report_path.read_text()
+
+    line = _read_lines(state_dir / "t0_receipts.ndjson")[-1]
+    assert line["verification"]["method"] == "pytest"
+    assert line["verdict"]["decision"] == "accept"
+
+
+def test_t24_envelope_subpath_no_report_degrades_to_unknown(tmp_path):
+    """No report on disk (report emit failed) -> method='unknown', never a crash."""
+    from dispatch_envelope import _verification_from_report
+
+    result = _verification_from_report(None)
+    assert result["method"] == "unknown"
+    assert result["tests_run"] is None
+
+
+# ---------------------------------------------------------------------------
+# T25 — multi-provider sub-path: verification.method='pending-report',
+# verdict='investigate', evidence_complete=False, and never rewritten by a
+# later write for the same dispatch_id.
+# ---------------------------------------------------------------------------
+
+
+def test_t25_multi_provider_subpath_pending_report(tmp_path, monkeypatch):
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    (tmp_path / "state").mkdir()
+    (tmp_path / "data").mkdir()
+
+    import provider_dispatch
+
+    args = argparse.Namespace(
+        dispatch_id="t25-multiprovider",
+        terminal_id="T1",
+        instruction="do the thing",
+        pr_id=None,
+        mandate_id=None,
+    )
+    result = SimpleNamespace(
+        completion_text="done",
+        token_usage={"input_tokens": 10, "output_tokens": 5},
+    )
+    now = datetime.now(timezone.utc)
+
+    provider_dispatch._emit_governance(args, "codex", "gpt-5.2-codex", result, now, now, "success")
+
+    receipts_path = tmp_path / "state" / "t0_receipts.ndjson"
+    lines = _read_lines(receipts_path)
+    assert len(lines) == 1, "receipt-first ordering: exactly one write for this dispatch_id"
+    line = lines[0]
+    assert line["verification"]["method"] == "pending-report"
+    assert line["verdict"]["decision"] == "investigate"
+    assert line["verdict"]["evidence_complete"] is False
+
+    # Report emission runs AFTER the receipt on this sub-path (ADR-035
+    # §3.1.1) -- confirm it writes only the .md file, never a second
+    # receipt line for the same dispatch_id (append-only, no backfill).
+    report_path = tmp_path / "data" / "unified_reports" / "t25-multiprovider.md"
+    assert report_path.exists()
+    assert len(_read_lines(receipts_path)) == 1

--- a/tests/test_receipt_v2_pr4_wiring.py
+++ b/tests/test_receipt_v2_pr4_wiring.py
@@ -501,3 +501,104 @@ def test_t25_multi_provider_subpath_pending_report(tmp_path, monkeypatch):
     report_path = tmp_path / "data" / "unified_reports" / "t25-multiprovider.md"
     assert report_path.exists()
     assert len(_read_lines(receipts_path)) == 1
+
+
+# ---------------------------------------------------------------------------
+# fix-r1 — the classify/commit split: a deduped or validator-rejected
+# receipt must never commit a warning's side effects (OI-store promotion,
+# recurrence-counter increment). Both go through the REAL write path
+# (append_receipt_payload, Path 2) so the assertion covers the actual
+# ordering inside _write_receipt_under_lock's pre_write_hook wiring, not
+# just the finalize_receipt_v2_fields all-in-one composition T7-T9 exercise.
+# ---------------------------------------------------------------------------
+
+
+def test_fixr1_dedup_never_commits_warning_side_effects(tmp_path, monkeypatch):
+    """A receipt that idempotency dedups (same dispatch_id, second append
+    attempt) must not touch the OI store or bump the recurrence counter on
+    the deduped attempt -- only the first (actually-appended) attempt may
+    commit those side effects. Proven with an OIM call-count spy plus the
+    on-disk counter value before/after the duplicate attempt."""
+    import append_receipt_internals.warning_destination as wd
+
+    counter_path = tmp_path / "counts.json"
+    monkeypatch.setattr(wd, "_default_counter_path", lambda: counter_path)
+
+    oi_calls = {"n": 0}
+
+    class _CountingOIM:
+        def add_item_programmatic(self, **kwargs):
+            oi_calls["n"] += 1
+            return f"OI-{oi_calls['n']}", True
+
+    monkeypatch.setattr(wd, "_get_open_items_manager", lambda: _CountingOIM())
+
+    def _fresh_receipt():
+        return _base_path2_receipt(
+            "fixr1-dedup",
+            warnings=[
+                {"code": "dedup_blocker_check", "severity": "blocker", "message": "m"},
+                {"code": "dedup_counted_check", "severity": "warn", "message": "m"},
+            ],
+        )
+
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+
+    result1 = _path2_append(_fresh_receipt(), receipts_path)
+    assert result1.status == "appended"
+    assert oi_calls["n"] == 1
+    counter_after_first = json.loads(counter_path.read_text(encoding="utf-8"))
+    assert counter_after_first["dedup_counted_check"] == 1
+
+    result2 = _path2_append(_fresh_receipt(), receipts_path)
+    assert result2.status == "duplicate"
+    # Neither side effect fires a second time for the deduped attempt.
+    assert oi_calls["n"] == 1
+    counter_after_dup = json.loads(counter_path.read_text(encoding="utf-8"))
+    assert counter_after_dup["dedup_counted_check"] == 1
+
+    lines = _read_lines(receipts_path)
+    assert len(lines) == 1
+    assert lines[0]["warnings"][0]["destination"] == "oi"
+    assert lines[0]["warnings"][1]["destination"] == "counted"
+
+
+def test_fixr1_validator_rejection_never_commits_warning_side_effects(tmp_path, monkeypatch):
+    """A receipt the shared validator rejects (here: missing dispatch_id on
+    a task_complete event, discovered by _validate_receipt AFTER
+    classification has already run) must never touch the OI store or the
+    recurrence counter. Classification itself (pure, read-only counter
+    peek) is allowed to run; the commit that would call
+    add_item_programmatic / increment the counter must never fire for a
+    receipt that ends up rejected."""
+    import append_receipt_internals.warning_destination as wd
+
+    counter_path = tmp_path / "counts.json"
+    monkeypatch.setattr(wd, "_default_counter_path", lambda: counter_path)
+
+    class _NeverCalledOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise AssertionError("must not touch the OI store for a rejected receipt")
+
+    monkeypatch.setattr(wd, "_get_open_items_manager", lambda: _NeverCalledOIM())
+
+    receipts_path = tmp_path / "t0_receipts.ndjson"
+    receipt = {
+        "timestamp": "2026-07-22T10:00:00Z",
+        "event_type": "task_complete",
+        "status": "done",
+        # dispatch_id deliberately omitted: task_complete requires one
+        # (_requires_dispatch_id), so _validate_receipt rejects this receipt
+        # AFTER classify_receipt_v2_warnings has already produced its
+        # placeholder destinations.
+        "warnings": [
+            {"code": "reject_blocker_check", "severity": "blocker", "message": "m"},
+            {"code": "reject_counted_check", "severity": "warn", "message": "m"},
+        ],
+    }
+
+    with pytest.raises(AppendReceiptError):
+        _path2_append(receipt, receipts_path)
+
+    assert not _read_lines(receipts_path)
+    assert not counter_path.exists()


### PR DESCRIPTION
Receipt-v2 PR-4 (ADR-035 §9). Both write paths call a shared `finalize_receipt_v2_fields` through PR-3's primitive: `verdict{}` via `compute_verdict`, `warnings[]` via the destination engine (`open_items_created` derived), `verification{}` from the on-disk report (envelope) / `pending-report` (multi-provider), and `provenance.diff_summary.paths` via `git diff --name-only`. Additive — no `schema_version` stamp yet (PR-5).

## Verification
- New end-to-end: `test_receipt_v2_pr4_wiring.py` + `test_git_provenance.py` = 29 passed (T3-T9, T22 both paths, T23/T24/T25/T35, paths).
- Regression-sanity: `test_ndjson_hash_chain` + `test_acceptance_idempotency` + `test_governance_emit` + `test_receipt_validation_warnings` + `test_warning_destination` = 165 passed.
- Broad sweep: 683 passed / 29 pre-existing failures (A/B-confirmed on origin/main, none touch verdict/warnings/verification/paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)