### PR TITLE
feat(rv2-pr4b): migrate cqs_calculator off quality_advisory

### DIFF
--- a/scripts/lib/cqs_calculator.py
+++ b/scripts/lib/cqs_calculator.py
@@ -10,15 +10,26 @@ Scoring components (weighted, 7 total):
   - Effort efficiency (15%): Token usage vs median for role
   - Error density (10%): Error/fail messages ratio in JSONL
   - Rework indicator (10%): Same gate+pr_id dispatched before?
-  - T0 Advisory (10%): quality_advisory.t0_recommendation decision + risk_score
+  - T0 Advisory (10%): verdict.decision + warnings[] severity risk
   - Open Items Delta (10%): Created vs resolved open items balance
+
+T0 Advisory reads receipt["verdict"]/receipt["warnings"] (ADR-035 §3.1/§6) as
+its primary source — migrated by ADR-035 §9 PR-4b, the required prerequisite
+before PR-5 drops receipt["quality_advisory"] (§3.3, HIGH-5). It falls back to
+receipt["quality_advisory"] only when verdict{} is absent (a receipt written
+before PR-4, or a DB-projection round-trip like update_dispatch_cqs.py
+replaying a historical quality_advisory_json column) — quality_advisory{}
+itself is not removed from the receipt shape until PR-5, so this reader must
+keep tolerating it until then.
 """
 
 from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from quality_advisory import RISK_WEIGHT_BLOCKING, RISK_WEIGHT_WARNING
 
 # Normalize the ~166 unique status values into 5 categories
 STATUS_MAP: Dict[str, str] = {
@@ -79,7 +90,7 @@ def _score_completion(receipt: Dict[str, Any]) -> float:
         score += 100
         signals += 1
 
-    gate = receipt.get("gate_passed") or receipt.get("quality_advisory", {}).get("t0_recommendation", {}).get("decision") == "approve"
+    gate = receipt.get("gate_passed") or _t0_decision_is_accept(receipt)
     if gate:
         score += 100
         signals += 1
@@ -177,8 +188,71 @@ def _score_rework(dispatch_id: str, gate: str | None, pr_id: str | None, db_path
         return 100.0
 
 
+def _t0_decision_is_accept(receipt: Dict[str, Any]) -> bool:
+    """True when the T0 decision reads as an outright accept/approve.
+
+    Reads verdict.decision (ADR-035 §3.1, PR-4-populated receipts) when
+    present. Falls back to quality_advisory.t0_recommendation.decision only
+    for a receipt that has no verdict{} at all — a receipt written before
+    PR-4, or a DB-projection round-trip (e.g. update_dispatch_cqs.py
+    replaying a historical dispatch_metadata.quality_advisory_json column,
+    OI-1175) that predates this migration. quality_advisory{} itself is not
+    removed until PR-5 (§3.3), so it must still be readable here until then.
+    """
+    verdict = receipt.get("verdict")
+    if isinstance(verdict, dict) and "decision" in verdict:
+        return verdict.get("decision") == "accept"
+
+    advisory = receipt.get("quality_advisory") or {}
+    rec = advisory.get("t0_recommendation") or {}
+    return rec.get("decision") == "approve"
+
+
+def _reconstruct_t0_risk_score(warnings: List[Any]) -> float:
+    """Reconstruct a 0-100 risk score from warnings[] severities.
+
+    Weighted identically to the pre-v2 quality_advisory.calculate_risk_score
+    (RISK_WEIGHT_BLOCKING/RISK_WEIGHT_WARNING): ADR-035 §6.3 preserves each
+    quality check's severity 1:1 onto its warnings[] entry's severity
+    (blocking->blocker, warning->warn), so summing warnings[] here reproduces
+    the same number the old quality_advisory dry-run produced.
+    """
+    score = 0
+    for entry in warnings:
+        severity = (entry or {}).get("severity")
+        if severity == "blocker":
+            score += RISK_WEIGHT_BLOCKING
+        elif severity == "warn":
+            score += RISK_WEIGHT_WARNING
+    return min(score, 100)
+
+
+def _blend_t0_advisory(decision_score: float, risk_score: float) -> float:
+    """70% decision weight, 30% inverse risk score — the blend itself is
+    unchanged across the quality_advisory{}->verdict{}/warnings[] migration
+    (ADR-035 §9 PR-4b), only the two inputs' source shape differs."""
+    return decision_score * 0.7 + max(0, 100 - risk_score) * 0.3
+
+
 def _score_t0_advisory(receipt: Dict[str, Any]) -> float:
-    """Score from quality_advisory.t0_recommendation (0-100)."""
+    """Score from verdict.decision + warnings[] severity risk (0-100).
+
+    Reads the v2 shape PR-4 now populates on both write paths. Falls back to
+    the pre-v2 quality_advisory{} shape only when verdict{} is absent (see
+    `_t0_decision_is_accept`'s docstring for why that fallback is still
+    needed pre-PR-5) — a receipt carrying both is scored from verdict{}/
+    warnings[] only, never a blend of the two sources.
+    """
+    verdict = receipt.get("verdict")
+    if isinstance(verdict, dict) and "decision" in verdict:
+        decision = verdict.get("decision")
+        warnings = receipt.get("warnings")
+        risk_score = _reconstruct_t0_risk_score(warnings) if isinstance(warnings, list) else 0
+
+        decision_scores = {"accept": 100.0, "investigate": 60.0, "reject": 0.0}
+        decision_score = decision_scores.get(decision, 50.0)
+        return _blend_t0_advisory(decision_score, risk_score)
+
     advisory = receipt.get("quality_advisory")
     if not isinstance(advisory, dict):
         return 50.0  # neutral
@@ -187,14 +261,12 @@ def _score_t0_advisory(receipt: Dict[str, Any]) -> float:
     if not isinstance(rec, dict):
         return 50.0
 
-    decision = rec.get("decision", "approve")
+    legacy_decision = rec.get("decision", "approve")
     risk_score = advisory.get("summary", {}).get("risk_score", 0)
 
-    decision_scores = {"approve": 100.0, "approve_with_followup": 60.0, "hold": 0.0}
-    decision_score = decision_scores.get(decision, 50.0)
-
-    # Blend: 70% decision weight, 30% inverse risk score
-    return decision_score * 0.7 + max(0, 100 - risk_score) * 0.3
+    legacy_decision_scores = {"approve": 100.0, "approve_with_followup": 60.0, "hold": 0.0}
+    decision_score = legacy_decision_scores.get(legacy_decision, 50.0)
+    return _blend_t0_advisory(decision_score, risk_score)
 
 
 def _score_open_items_delta(receipt: Dict[str, Any]) -> float:

--- a/tests/test_cqs_calculator.py
+++ b/tests/test_cqs_calculator.py
@@ -12,6 +12,8 @@ SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
 sys.path.insert(0, str(SCRIPT_DIR))
 
 from cqs_calculator import (
+    _reconstruct_t0_risk_score,
+    _score_completion,
     _score_t0_advisory,
     _score_open_items_delta,
     calculate_cqs,
@@ -19,26 +21,54 @@ from cqs_calculator import (
 )
 
 
-# ── T0 Advisory scoring ──
+# ── Completion gate shortcut (ADR-035 §9 PR-4b: verdict.decision, not quality_advisory) ──
+
+
+def test_score_completion_gate_from_verdict_accept():
+    receipt = {"verdict": {"decision": "accept"}}
+    # gate signal only (report_path/pr_merged absent) → 100/3
+    assert _score_completion(receipt) == pytest.approx(100.0 / 3)
+
+
+def test_score_completion_gate_from_verdict_non_accept():
+    receipt = {"verdict": {"decision": "investigate"}}
+    assert _score_completion(receipt) == pytest.approx(0.0)
+
+
+def test_score_completion_gate_legacy_fallback_when_verdict_absent():
+    receipt = {"quality_advisory": {"t0_recommendation": {"decision": "approve"}}}
+    assert _score_completion(receipt) == pytest.approx(100.0 / 3)
+
+
+def test_score_completion_gate_verdict_priority_over_legacy():
+    receipt = {
+        "verdict": {"decision": "investigate"},
+        "quality_advisory": {"t0_recommendation": {"decision": "approve"}},
+    }
+    assert _score_completion(receipt) == pytest.approx(0.0)
+
+
+def test_score_completion_gate_passed_flag_still_wins():
+    receipt = {"gate_passed": True}
+    assert _score_completion(receipt) == pytest.approx(100.0 / 3)
+
+
+# ── T0 Advisory scoring (ADR-035 §9 PR-4b: verdict{}/warnings[], not quality_advisory{}) ──
 
 
 def test_score_t0_advisory_approve():
-    receipt = {
-        "quality_advisory": {
-            "t0_recommendation": {"decision": "approve"},
-            "summary": {"risk_score": 0},
-        }
-    }
+    receipt = {"verdict": {"decision": "accept"}, "warnings": []}
     score = _score_t0_advisory(receipt)
     assert score == pytest.approx(100.0)
 
 
 def test_score_t0_advisory_hold():
     receipt = {
-        "quality_advisory": {
-            "t0_recommendation": {"decision": "hold"},
-            "summary": {"risk_score": 100},
-        }
+        "verdict": {"decision": "reject"},
+        "warnings": [
+            {"severity": "blocker"},
+            {"severity": "blocker"},
+        ],
     }
     score = _score_t0_advisory(receipt)
     assert score == pytest.approx(0.0)
@@ -46,10 +76,13 @@ def test_score_t0_advisory_hold():
 
 def test_score_t0_advisory_followup_blended():
     receipt = {
-        "quality_advisory": {
-            "t0_recommendation": {"decision": "approve_with_followup"},
-            "summary": {"risk_score": 40},
-        }
+        "verdict": {"decision": "investigate"},
+        "warnings": [
+            {"severity": "warn"},
+            {"severity": "warn"},
+            {"severity": "warn"},
+            {"severity": "warn"},
+        ],
     }
     # 60 * 0.7 + (100-40) * 0.3 = 42 + 18 = 60
     score = _score_t0_advisory(receipt)
@@ -62,9 +95,109 @@ def test_score_t0_advisory_missing():
 
 
 def test_score_t0_advisory_unavailable():
-    receipt = {"quality_advisory": {"status": "unavailable"}}
+    receipt = {"verdict": {"status": "unavailable"}}
     score = _score_t0_advisory(receipt)
     assert score == pytest.approx(50.0)
+
+
+def test_score_t0_advisory_legacy_fallback_when_verdict_absent():
+    """A receipt written before PR-4 (or a DB-projection round-trip like
+    update_dispatch_cqs.py replaying a historical quality_advisory_json
+    column, OI-1175) has no verdict{} at all yet — the reader must still
+    score it from quality_advisory{} until PR-5 removes that field."""
+    receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "hold"},
+            "summary": {"risk_score": 100},
+        }
+    }
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(0.0)
+
+
+def test_score_t0_advisory_verdict_takes_priority_over_legacy():
+    """When a receipt carries both shapes (mixed-rollout window), verdict{}/
+    warnings[] wins outright — never blended with quality_advisory{}."""
+    receipt = {
+        "verdict": {"decision": "accept"},
+        "warnings": [],
+        "quality_advisory": {
+            "t0_recommendation": {"decision": "hold"},
+            "summary": {"risk_score": 100},
+        },
+    }
+    score = _score_t0_advisory(receipt)
+    assert score == pytest.approx(100.0)
+
+
+# ── T28: CQS-score parity — quality_advisory{}-shaped input vs the equivalent
+#    warnings[]/verdict{}-shaped input must yield the SAME T0-Advisory score
+#    (ADR-035 §3.3 HIGH-5, the regression guard required before PR-5 drops
+#    quality_advisory{}). `_legacy_score_t0_advisory` below is a frozen copy
+#    of the pre-migration formula (the exact code _score_t0_advisory carried
+#    before this PR) — the oracle this test proves the migrated reader still
+#    agrees with, for equivalent inputs expressed in each shape.
+
+
+def _legacy_score_t0_advisory(receipt):
+    advisory = receipt.get("quality_advisory")
+    if not isinstance(advisory, dict):
+        return 50.0
+
+    rec = advisory.get("t0_recommendation")
+    if not isinstance(rec, dict):
+        return 50.0
+
+    decision = rec.get("decision", "approve")
+    risk_score = advisory.get("summary", {}).get("risk_score", 0)
+
+    decision_scores = {"approve": 100.0, "approve_with_followup": 60.0, "hold": 0.0}
+    decision_score = decision_scores.get(decision, 50.0)
+
+    return decision_score * 0.7 + max(0, 100 - risk_score) * 0.3
+
+
+@pytest.mark.parametrize(
+    "legacy_decision,legacy_risk_score,new_decision,warning_severities",
+    [
+        ("approve", 0, "accept", []),
+        ("approve", 20, "accept", ["warn", "warn"]),
+        ("approve_with_followup", 40, "investigate", ["warn"] * 4),
+        ("approve_with_followup", 50, "investigate", ["blocker"]),
+        ("hold", 100, "reject", ["blocker", "blocker"]),
+        ("hold", 60, "reject", ["blocker", "warn"]),
+    ],
+)
+def test_t28_cqs_score_parity_quality_advisory_vs_verdict_warnings(
+    legacy_decision, legacy_risk_score, new_decision, warning_severities
+):
+    legacy_receipt = {
+        "quality_advisory": {
+            "t0_recommendation": {"decision": legacy_decision},
+            "summary": {"risk_score": legacy_risk_score},
+        }
+    }
+    new_receipt = {
+        "verdict": {"decision": new_decision},
+        "warnings": [{"severity": s} for s in warning_severities],
+    }
+
+    legacy_score = _legacy_score_t0_advisory(legacy_receipt)
+    new_score = _score_t0_advisory(new_receipt)
+
+    assert new_score == pytest.approx(legacy_score)
+
+
+def test_t28_risk_score_reconstruction_matches_legacy_weights():
+    # RISK_WEIGHT_BLOCKING=50, RISK_WEIGHT_WARNING=10 (quality_advisory.py) —
+    # 1 blocker + 2 warn = 50 + 20 = 70, same as the legacy dry-run's weighted sum.
+    warnings = [{"severity": "blocker"}, {"severity": "warn"}, {"severity": "warn"}]
+    assert _reconstruct_t0_risk_score(warnings) == pytest.approx(70)
+
+
+def test_t28_risk_score_reconstruction_caps_at_100():
+    warnings = [{"severity": "blocker"}] * 5  # 250 raw, capped
+    assert _reconstruct_t0_risk_score(warnings) == pytest.approx(100)
 
 
 # ── Open Items Delta scoring ──
@@ -130,10 +263,8 @@ def test_full_cqs_7_components(mock_median):
     receipt = {
         "status": "task_complete",
         "report_path": "/some/report.md",
-        "quality_advisory": {
-            "t0_recommendation": {"decision": "approve"},
-            "summary": {"risk_score": 10},
-        },
+        "verdict": {"decision": "accept"},
+        "warnings": [{"severity": "warn"}],
         "open_items_created": 0,
         "open_items_resolved": 1,
     }


### PR DESCRIPTION
## Summary
- ADR-035 §9 PR-4b: prerequisite for PR-5, which drops `quality_advisory{}` from the receipt shape.
- Migrates `scripts/lib/cqs_calculator.py`'s T0-Advisory scoring (`_score_t0_advisory`, 10% of the CQS score) and `_score_completion`'s gate shortcut off `receipt.get("quality_advisory")` onto the `verdict{}`/`warnings[]` shape ADR-035 PR-4 now populates on both write paths.
- Falls back to `quality_advisory{}` only when `verdict{}` is absent (a receipt written before PR-4, or a DB-projection round-trip like `update_dispatch_cqs.py` replaying a historical `quality_advisory_json` column, OI-1175) — `quality_advisory{}` itself is not removed until PR-5, so this reader must keep tolerating it until then. When both are present, `verdict{}`/`warnings[]` wins outright, never blended.
- No score change for equivalent inputs — same weighting (70% decision / 30% inverse risk), same `RISK_WEIGHT_BLOCKING`/`RISK_WEIGHT_WARNING` constants (imported from `quality_advisory.py`) used to reconstruct a 0-100 risk score from `warnings[]` severities.

## Changes
- `scripts/lib/cqs_calculator.py`:
  - `_score_completion`'s `gate` shortcut now calls new `_t0_decision_is_accept(receipt)` (verdict.decision=="accept", falling back to legacy quality_advisory read) instead of reading `quality_advisory` inline.
  - `_score_t0_advisory` now reads `verdict.decision` + `warnings[]` severities as primary source, falling back to the legacy `quality_advisory.t0_recommendation`/`summary.risk_score` shape only when `verdict{}` is absent.
  - New helpers: `_t0_decision_is_accept`, `_reconstruct_t0_risk_score`, `_blend_t0_advisory` (shared blend formula, unchanged: `decision_score * 0.7 + max(0, 100 - risk_score) * 0.3`).
  - New import: `from quality_advisory import RISK_WEIGHT_BLOCKING, RISK_WEIGHT_WARNING`.
- `tests/test_cqs_calculator.py`:
  - Existing `_score_t0_advisory` unit tests converted to the new `verdict{}`/`warnings[]` shape (same expected scores as before).
  - New T28 parity tests: `quality_advisory{}`-shaped input vs. the equivalent `verdict{}`/`warnings[]`-shaped input produce the same T0-Advisory score, via a frozen legacy-formula oracle (`_legacy_score_t0_advisory`) compared against the migrated production function, parametrized over approve/hold/approve_with_followup scenarios.
  - New tests for the legacy fallback and new-shape-takes-priority behavior, for both `_score_t0_advisory` and `_score_completion`'s gate shortcut.
  - New tests for `_reconstruct_t0_risk_score` (weight reconstruction, 100-cap).

## Verification
- `python3 -m pytest tests/test_cqs_calculator.py -v` — 27 passed (was 12 before this PR; net +15 new tests).
- `python3 -m pytest tests/ -k cqs -q` — 37 passed (was 29 passed / 2 failed on `origin/main` prior to this change — `test_update_dispatch_cqs.py::test_quality_advisory_used_in_cqs` and `::test_stripped_payload_previously_gave_neutral_advisory` now pass via the legacy fallback).
- `python3 -m pytest tests/test_cqs_calculator.py tests/test_update_dispatch_cqs.py tests/test_receipt_instruction_hash.py -q` (every test file that imports `cqs_calculator`/`calculate_cqs`) — 39 passed, 2 pre-existing failures confirmed unrelated (`test_receipt_instruction_hash.py`'s two `manifest_sha256_read_failed` log-format assertions, failing identically on `origin/main` before this change).
- Spot-checked adjacent `calculate_cqs` callers: `tests/test_pre_merge_gate.py` (48 passed), `tests/test_gate_findings_bridge.py`/`test_governance_path_alignment.py`/`test_pre_merge_gate_net_deletion.py`/`test_planning_cli_objective.py` (39 passed, 2 pre-existing unrelated failures confirmed via `git stash` against `origin/main`).
- Grepped all `tests/*.py` referencing `quality_advisory` and ran the ones not already covered above (`test_agent_os_certification.py`, `test_append_receipt_register_emit.py`, `test_migration_phase1_project_id.py`, `test_quality_advisory_pipeline.py`, `test_schema_init_view_ordering.py`) — 149 passed, 1 pre-existing unrelated failure confirmed via `git stash` (`TestTerminalSnapshot::test_snapshot_terminal_fields`, a `claimed_by` field assertion unrelated to CQS).
- `python3 -c "import ast; ast.parse(open('scripts/lib/cqs_calculator.py').read())"` — syntax OK.
- Pushed SHA: `1d5890534c2d153aa94fd8ef794bd66fe7b860c0` (confirmed via `git ls-remote origin dispatch/20260722-rv2-pr4b-cqs-migrate`).

## Open Items
None.

Dispatch-ID: 20260722-rv2-pr4b-cqs-migrate