### PR TITLE
feat(rv2-pr6): receipt_query.py pull + by-dispatch

### DIFF
--- a/scripts/receipt_query.py
+++ b/scripts/receipt_query.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""receipt_query.py — the receipt-v2 pull interface (ADR-035 §5).
+
+This PR (ADR-035 §9 PR-6) ships two subcommands. ``by-pr``/``since``/``by-track``/
+``digest`` land in PR-7; wiring into the T0 cycle and retiring the tmux-pane push
+land in PR-8 — neither is touched here.
+
+  pull         — the tick primitive. Absorbs receipt_pull.py's cursor algorithm
+                 (parked branch feat/receipt-mailbox-delivery, commit 54089155),
+                 reimplemented against current main rather than resurrecting the
+                 branch: byte cursor in receipt_pull_cursor.json, read-then-advance,
+                 advances only past complete (newline-terminated) lines so a
+                 concurrent append's partial trailing line is never consumed early,
+                 resets to 0 on a truncated/rotated ledger, --seed-now sets the
+                 cursor to EOF (skip the backlog without deleting it), --peek reads
+                 without advancing.
+  by-dispatch  — thin wrapper over receipt_provenance.find_receipts_by_dispatch.
+                 No reimplementation.
+
+Both subcommands tolerate a mixed v1/v2 ledger: a line missing ``schema_version``
+is a v1 line, read like any other JSON object — never a reason to crash.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+if str(SCRIPT_DIR / "lib") not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from receipt_provenance import find_receipts_by_dispatch  # noqa: E402
+
+LEDGER_NAME = "t0_receipts.ndjson"
+CURSOR_NAME = "receipt_pull_cursor.json"
+
+
+def _ledger_path(state_dir: Path) -> Path:
+    return state_dir / LEDGER_NAME
+
+
+def _default_cursor_path(state_dir: Path) -> Path:
+    return state_dir / CURSOR_NAME
+
+
+def load_cursor(cursor_path: Path) -> int:
+    """Read the byte offset from ``cursor_path``. Missing or corrupt -> 0."""
+    if not cursor_path.exists():
+        return 0
+    try:
+        return int(json.loads(cursor_path.read_text(encoding="utf-8")).get("offset", 0))
+    except (json.JSONDecodeError, ValueError, OSError, TypeError):
+        return 0
+
+
+def save_cursor(cursor_path: Path, offset: int) -> None:
+    """Atomically persist ``offset`` to ``cursor_path`` (tmp write + os.replace)."""
+    tmp = cursor_path.with_suffix(cursor_path.suffix + ".tmp")
+    tmp.write_text(json.dumps({"offset": int(offset)}), encoding="utf-8")
+    os.replace(tmp, cursor_path)
+
+
+def pull_new_receipts(
+    ledger_path: Path,
+    cursor_offset: int = 0,
+) -> Tuple[List[Dict[str, Any]], int]:
+    """Read receipts appended after ``cursor_offset``. Returns ``(receipts, new_offset)``.
+
+    Read-then-advance: ``new_offset`` only ever moves past COMPLETE
+    (newline-terminated) lines, so a concurrent append's partial trailing line is
+    left untouched for the next pull. A truncated/rotated ledger (smaller than the
+    cursor) resets the cursor to 0. A malformed complete line is skipped, but the
+    cursor still advances past it — it will never parse on a later pull either.
+    Mixed v1/v2 lines are both plain JSON objects; no schema_version branching is
+    needed to read them.
+    """
+    receipts: List[Dict[str, Any]] = []
+    new_offset = cursor_offset
+    if not ledger_path.exists():
+        return receipts, new_offset
+    if ledger_path.stat().st_size < cursor_offset:
+        new_offset = 0
+        cursor_offset = 0
+    with open(ledger_path, "rb") as f:
+        f.seek(cursor_offset)
+        while True:
+            raw = f.readline()
+            if not raw:
+                break
+            if not raw.endswith(b"\n"):
+                break  # incomplete trailing line (mid-append) — do not advance past it
+            new_offset = f.tell()
+            try:
+                receipts.append(json.loads(raw.decode("utf-8")))
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                continue  # skip a malformed complete line; cursor already advanced past it
+    return receipts, new_offset
+
+
+def _format_receipt(r: Dict[str, Any]) -> str:
+    term = r.get("terminal_id", "?")
+    did = r.get("dispatch_id", "?")
+    status = r.get("status", "?")
+    schema_version = r.get("schema_version", 1)
+    pr = r.get("pr_id") or "-"
+    return f"  {term} {did} [{status}] schema_version={schema_version} pr={pr}"
+
+
+def _cmd_pull(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    cursor_path = Path(args.cursor_file) if args.cursor_file else _default_cursor_path(state_dir)
+
+    if args.seed_now:
+        eof = ledger.stat().st_size if ledger.exists() else 0
+        save_cursor(cursor_path, eof)
+        if args.json:
+            print(json.dumps({"seeded": True, "cursor": eof}))
+        else:
+            print(
+                f"cursor seeded to EOF ({eof} bytes) — "
+                "backlog skipped (still in the ledger, auditable)."
+            )
+        return 0
+
+    cursor = load_cursor(cursor_path)
+    receipts, new_offset = pull_new_receipts(ledger, cursor)
+
+    if args.json:
+        print(json.dumps(
+            {"count": len(receipts), "cursor": new_offset, "receipts": receipts},
+            indent=2,
+        ))
+    else:
+        print(f"{len(receipts)} new receipt(s) since cursor {cursor}:")
+        for r in receipts:
+            print(_format_receipt(r))
+
+    if not args.peek and new_offset != cursor:
+        save_cursor(cursor_path, new_offset)
+    return 0
+
+
+def _cmd_by_dispatch(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    receipts = find_receipts_by_dispatch(ledger, args.dispatch_id)
+
+    if args.json:
+        print(json.dumps(
+            {"dispatch_id": args.dispatch_id, "count": len(receipts), "receipts": receipts},
+            indent=2,
+        ))
+    else:
+        print(f"{len(receipts)} receipt(s) for dispatch {args.dispatch_id}:")
+        for r in receipts:
+            print(_format_receipt(r))
+    return 0
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Receipt v2 pull-model query interface (ADR-035 §5)",
+    )
+    sub = parser.add_subparsers(dest="cmd", required=True)
+
+    p_pull = sub.add_parser(
+        "pull", help="tick primitive — read receipts since the cursor, advance it",
+    )
+    p_pull.add_argument("--state-dir", required=True)
+    p_pull.add_argument(
+        "--cursor-file", default=None,
+        help="override the cursor file path (default: <state-dir>/receipt_pull_cursor.json)",
+    )
+    p_pull.add_argument(
+        "--seed-now", action="store_true",
+        help="set the cursor to EOF (skip the backlog; it stays on disk, auditable)",
+    )
+    p_pull.add_argument(
+        "--peek", action="store_true",
+        help="read new receipts without advancing the cursor",
+    )
+    p_pull.add_argument("--json", action="store_true")
+    p_pull.set_defaults(func=_cmd_pull)
+
+    p_by_dispatch = sub.add_parser(
+        "by-dispatch",
+        help="all receipts for a dispatch_id (wraps receipt_provenance.find_receipts_by_dispatch)",
+    )
+    p_by_dispatch.add_argument("dispatch_id")
+    p_by_dispatch.add_argument("--state-dir", required=True)
+    p_by_dispatch.add_argument("--json", action="store_true")
+    p_by_dispatch.set_defaults(func=_cmd_by_dispatch)
+
+    args = parser.parse_args(argv)
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_receipt_query.py
+++ b/tests/test_receipt_query.py
@@ -1,0 +1,282 @@
+#!/usr/bin/env python3
+"""ADR-035 §9 PR-6 — receipt_query.py: pull + by-dispatch.
+
+Covers T12 (pull read-then-advance; a concurrent append's partial trailing line
+is never consumed until it is newline-terminated) and T13 (pull --seed-now sets
+the cursor to EOF; the backlog is skipped but stays on disk and readable via
+by-dispatch), plus the surrounding cursor mechanics absorbed from the parked
+receipt_pull.py design (branch feat/receipt-mailbox-delivery, commit 54089155)
+and mixed v1/v2 ledger tolerance for both subcommands.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Dict
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import receipt_query as rq  # noqa: E402
+
+
+def _write_ledger(state_dir: Path, *receipts: Dict[str, Any], trailing_newline: bool = True) -> None:
+    lines = [json.dumps(r) for r in receipts]
+    text = "\n".join(lines)
+    if receipts and trailing_newline:
+        text += "\n"
+    (state_dir / rq.LEDGER_NAME).write_text(text, encoding="utf-8")
+
+
+def _r(did: str, terminal: str = "T2", status: str = "success", **overrides: Any) -> Dict[str, Any]:
+    receipt = {"dispatch_id": did, "terminal_id": terminal, "status": status, "pr_id": None}
+    receipt.update(overrides)
+    return receipt
+
+
+# ---------------------------------------------------------------------------
+# T12 — read-then-advance; concurrent partial trailing line is not consumed
+# ---------------------------------------------------------------------------
+
+def test_t12_incomplete_trailing_line_is_not_advanced_past(tmp_path):
+    _write_ledger(tmp_path, _r("d1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    # a concurrent append wrote a partial line (no closing brace/newline yet)
+    with open(ledger, "a", encoding="utf-8") as f:
+        f.write('{"dispatch_id": "d2-partial"')
+
+    receipts, off = rq.pull_new_receipts(ledger, 0)
+    assert [x["dispatch_id"] for x in receipts] == ["d1"]
+
+    # a second pull at the same cursor still doesn't see the partial line
+    receipts_again, off_again = rq.pull_new_receipts(ledger, off)
+    assert receipts_again == []
+    assert off_again == off
+
+    # now the writer completes the line
+    with open(ledger, "a", encoding="utf-8") as f:
+        f.write(', "terminal_id": "T1", "status": "success"}\n')
+    receipts2, off2 = rq.pull_new_receipts(ledger, off)
+    assert [x["dispatch_id"] for x in receipts2] == ["d2-partial"]
+    assert off2 > off
+
+
+def test_t12_read_then_advance_no_double_surface(tmp_path):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"), _r("d3"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts, off = rq.pull_new_receipts(ledger, 0)
+    assert [x["dispatch_id"] for x in receipts] == ["d1", "d2", "d3"]
+    # second pull from the advanced cursor surfaces nothing (no double-surface)
+    receipts2, off2 = rq.pull_new_receipts(ledger, off)
+    assert receipts2 == []
+    assert off2 == off
+
+
+def test_t12_surfaces_only_new_after_append(tmp_path):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    _, off = rq.pull_new_receipts(ledger, 0)
+    with open(ledger, "a", encoding="utf-8") as f:
+        f.write(json.dumps(_r("d3")) + "\n")
+    receipts, _ = rq.pull_new_receipts(ledger, off)
+    assert [x["dispatch_id"] for x in receipts] == ["d3"]
+
+
+def test_malformed_complete_line_skipped_but_advances(tmp_path):
+    ledger = tmp_path / rq.LEDGER_NAME
+    ledger.write_text(
+        json.dumps(_r("d1")) + "\n" + "{not json}\n" + json.dumps(_r("d2")) + "\n",
+        encoding="utf-8",
+    )
+    receipts, off = rq.pull_new_receipts(ledger, 0)
+    assert [x["dispatch_id"] for x in receipts] == ["d1", "d2"]
+    # cursor advanced past the garbage line too — it will never parse
+    assert off == ledger.stat().st_size
+
+
+def test_truncation_resets_cursor(tmp_path):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"), _r("d3"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    _, off = rq.pull_new_receipts(ledger, 0)
+    # ledger rotated/truncated to fewer bytes than the cursor
+    _write_ledger(tmp_path, _r("dX"))
+    receipts, _ = rq.pull_new_receipts(ledger, off)
+    assert [x["dispatch_id"] for x in receipts] == ["dX"]
+
+
+def test_missing_ledger_is_empty(tmp_path):
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts, off = rq.pull_new_receipts(ledger, 0)
+    assert receipts == [] and off == 0
+
+
+def test_cursor_persist_roundtrip(tmp_path):
+    cursor_path = rq._default_cursor_path(tmp_path)
+    assert rq.load_cursor(cursor_path) == 0
+    rq.save_cursor(cursor_path, 42)
+    assert rq.load_cursor(cursor_path) == 42
+
+
+def test_cursor_corrupt_file_defaults_to_zero(tmp_path):
+    cursor_path = rq._default_cursor_path(tmp_path)
+    cursor_path.write_text("not json", encoding="utf-8")
+    assert rq.load_cursor(cursor_path) == 0
+
+
+# ---------------------------------------------------------------------------
+# T13 — --seed-now sets cursor to EOF; backlog stays on disk + readable
+# ---------------------------------------------------------------------------
+
+def test_t13_seed_now_sets_cursor_to_eof_and_skips_backlog(tmp_path):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    eof = ledger.stat().st_size
+
+    rc = rq.main(["pull", "--state-dir", str(tmp_path), "--seed-now"])
+    assert rc == 0
+
+    cursor_path = rq._default_cursor_path(tmp_path)
+    assert rq.load_cursor(cursor_path) == eof
+
+    # backlog is skipped by a subsequent pull...
+    receipts, _ = rq.pull_new_receipts(ledger, rq.load_cursor(cursor_path))
+    assert receipts == []
+
+
+def test_t13_seed_now_backlog_stays_on_disk_and_readable_by_dispatch(tmp_path):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert ledger.exists()
+
+    rq.main(["pull", "--state-dir", str(tmp_path), "--seed-now"])
+
+    # the backlog receipt is still on disk, untouched — by-dispatch still finds it
+    receipts = rq.find_receipts_by_dispatch(ledger, "d1")
+    assert len(receipts) == 1
+    assert receipts[0]["dispatch_id"] == "d1"
+    assert ledger.read_text(encoding="utf-8").count("d1") >= 1
+
+
+def test_seed_now_on_missing_ledger_seeds_zero(tmp_path):
+    rc = rq.main(["pull", "--state-dir", str(tmp_path), "--seed-now"])
+    assert rc == 0
+    assert rq.load_cursor(rq._default_cursor_path(tmp_path)) == 0
+
+
+# ---------------------------------------------------------------------------
+# --peek and --cursor-file
+# ---------------------------------------------------------------------------
+
+def test_peek_does_not_advance_cursor(tmp_path, capsys):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"))
+    rc = rq.main(["pull", "--state-dir", str(tmp_path), "--peek", "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 2
+    # cursor was never persisted
+    assert rq.load_cursor(rq._default_cursor_path(tmp_path)) == 0
+
+    # a real (non-peek) pull still sees both receipts
+    rc2 = rq.main(["pull", "--state-dir", str(tmp_path), "--json"])
+    out2 = json.loads(capsys.readouterr().out)
+    assert out2["count"] == 2
+    assert rq.load_cursor(rq._default_cursor_path(tmp_path)) == out2["cursor"]
+
+
+def test_cursor_file_override(tmp_path):
+    _write_ledger(tmp_path, _r("d1"))
+    custom_cursor = tmp_path / "custom" / "my_cursor.json"
+    custom_cursor.parent.mkdir(parents=True, exist_ok=True)
+
+    rc = rq.main([
+        "pull", "--state-dir", str(tmp_path), "--cursor-file", str(custom_cursor),
+    ])
+    assert rc == 0
+    assert custom_cursor.exists()
+    # the default cursor location was never touched
+    assert not rq._default_cursor_path(tmp_path).exists()
+
+
+# ---------------------------------------------------------------------------
+# by-dispatch — thin wrapper over receipt_provenance.find_receipts_by_dispatch
+# ---------------------------------------------------------------------------
+
+def test_by_dispatch_returns_matching_receipts(tmp_path, capsys):
+    _write_ledger(tmp_path, _r("d1"), _r("d2"), _r("d1", status="failed"))
+    rc = rq.main(["by-dispatch", "d1", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["dispatch_id"] == "d1"
+    assert out["count"] == 2
+    assert {r["status"] for r in out["receipts"]} == {"success", "failed"}
+
+
+def test_by_dispatch_no_matches_is_empty_not_error(tmp_path, capsys):
+    _write_ledger(tmp_path, _r("d1"))
+    rc = rq.main(["by-dispatch", "does-not-exist", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 0
+    assert out["receipts"] == []
+
+
+def test_by_dispatch_missing_ledger_is_empty(tmp_path, capsys):
+    rc = rq.main(["by-dispatch", "d1", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Mixed v1/v2 ledger — neither subcommand crashes
+# ---------------------------------------------------------------------------
+
+def _v1_receipt(did: str) -> Dict[str, Any]:
+    # v1 lines carry no schema_version at all.
+    return {"dispatch_id": did, "terminal_id": "T1", "status": "success"}
+
+
+def _v2_receipt(did: str) -> Dict[str, Any]:
+    return {
+        "schema_version": 2,
+        "event_type": "task_complete",
+        "dispatch_id": did,
+        "terminal_id": "T2",
+        "status": "done",
+        "verdict": {"decision": "accept", "reason": "ok", "evidence_complete": True},
+    }
+
+
+def test_pull_handles_mixed_v1_v2_ledger(tmp_path):
+    _write_ledger(tmp_path, _v1_receipt("d1"), _v2_receipt("d2"), _v1_receipt("d3"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts, off = rq.pull_new_receipts(ledger, 0)
+    assert [r["dispatch_id"] for r in receipts] == ["d1", "d2", "d3"]
+    assert receipts[0].get("schema_version") is None
+    assert receipts[1]["schema_version"] == 2
+    assert off == ledger.stat().st_size
+
+
+def test_by_dispatch_handles_mixed_v1_v2_ledger(tmp_path, capsys):
+    _write_ledger(tmp_path, _v1_receipt("shared"), _v2_receipt("shared"))
+    rc = rq.main(["by-dispatch", "shared", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 2
+    versions = [r.get("schema_version") for r in out["receipts"]]
+    assert versions == [None, 2]
+
+
+def test_pull_text_output_handles_mixed_ledger(tmp_path, capsys):
+    _write_ledger(tmp_path, _v1_receipt("d1"), _v2_receipt("d2"))
+    rc = rq.main(["pull", "--state-dir", str(tmp_path)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "d1" in out and "schema_version=1" in out
+    assert "d2" in out and "schema_version=2" in out


### PR DESCRIPTION
## Summary
Receipt-v2 PR-6 (ADR-035 §5.2, §9). Ships the first two `scripts/receipt_query.py` subcommands:

- **`pull`** — the tick primitive. Absorbs the cursor algorithm from the parked `receipt_pull.py` (branch `feat/receipt-mailbox-delivery`, commit `54089155`), reimplemented against current `main` — the branch itself is not resurrected. Byte cursor in `receipt_pull_cursor.json`, read-then-advance, advances only past complete (newline-terminated) lines so a concurrent append's partial trailing line is never consumed early, resets to 0 on a truncated/rotated ledger, `--seed-now` sets the cursor to EOF (skips backlog without deleting it), `--peek` reads without advancing.
- **`by-dispatch <dispatch_id>`** — thin wrapper over the existing `receipt_provenance.find_receipts_by_dispatch`. No reimplementation.

Both subcommands tolerate a mixed v1/v2 ledger (a line missing `schema_version` is a v1 line) without crashing.

Out of scope (per dispatch): `by-pr`/`since`/`by-track`/`digest` (PR-7), wiring into the T0 cycle or push-retire (PR-8), resurrecting the parked branch.

## Changes
- `scripts/receipt_query.py` (new) — argparse CLI with `pull` and `by-dispatch` subcommands.
- `tests/test_receipt_query.py` (new) — 19 tests covering T12/T13 plus surrounding cursor mechanics and mixed-ledger tolerance.

## Verification
- `python3 -m pytest tests/test_receipt_query.py -v` → 19 passed (T12: read-then-advance/partial-trailing-line; T13: `--seed-now` EOF-seed + backlog stays readable via `by-dispatch`).
- `python3 -m pytest tests/test_receipt_provenance.py -q` → 57 passed (regression, unchanged).
- Manual CLI smoke test against a mixed v1/v2 ledger: `pull --json` and `by-dispatch --json` both return correctly, `--seed-now` on an empty state dir seeds cursor to 0.
- Push confirmed: `git ls-remote origin dispatch/20260722-rv2-pr6-receipt-query` → `b2dc4f0461999993724f04995ce3270ee4475ea3`

## Test plan
- [x] T12 — pull read-then-advance, partial trailing line not consumed until newline-terminated
- [x] T13 — `pull --seed-now` sets cursor to EOF, backlog stays on disk + readable
- [x] `tests/test_receipt_provenance.py` regression green

🤖 Generated with [Claude Code](https://claude.com/claude-code)