### PR TITLE
[codex] Add panel seats filter

### DIFF
--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """`vnx panel` runner — multi-provider deliberation panel for complex, multi-view questions.
 
-    python3 scripts/panel.py <mode> "<question>" [--context-file F] [--timeout S] [--out F]
+    python3 scripts/panel.py <mode> "<question>" [--context-file F] [--timeout S] [--out F] [--seats LIST]
 
 Modes: sweep | research | architecture | strategy. Runs the 4-stage deliberation
 (diverge → contrarian → verify → synthesis) via the governed review-lane dispatcher, then
@@ -19,7 +19,7 @@ _LIB = Path(__file__).resolve().parent / "lib"
 if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
 
-from deliberation_panel import MODES, run_deliberation  # noqa: E402
+from deliberation_panel import DEFAULT_ROSTER, MODES, run_deliberation  # noqa: E402
 
 
 def _resolve_reports_dir() -> Path:
@@ -33,6 +33,25 @@ def _resolve_reports_dir() -> Path:
     return d
 
 
+def _parse_seats(value: str | None) -> "list[tuple[str, str]] | None":
+    if value is None:
+        return None
+
+    seats = [part.strip() for part in value.split(",")]
+    if not seats or any(not seat for seat in seats):
+        known = ", ".join(sorted(provider for provider, _ in DEFAULT_ROSTER))
+        raise ValueError(f"--seats must be a comma-list of known seats: {known}")
+
+    known_roster = {provider: (provider, model) for provider, model in DEFAULT_ROSTER}
+    unknown = [seat for seat in seats if seat not in known_roster]
+    if unknown:
+        known = ", ".join(sorted(known_roster))
+        bad = ", ".join(unknown)
+        raise ValueError(f"unknown --seats value(s): {bad}; known seats: {known}")
+
+    return [known_roster[seat] for seat in seats]
+
+
 def main(argv: "list[str] | None" = None) -> int:
     parser = argparse.ArgumentParser(description="VNX multi-provider deliberation panel")
     parser.add_argument("mode", choices=sorted(MODES), help="deliberation mode")
@@ -40,7 +59,14 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument("--context-file", default=None, help="file whose contents ground every stage")
     parser.add_argument("--timeout", type=int, default=900, help="per-panelist timeout seconds")
     parser.add_argument("--out", default=None, help="write the report here (default: unified_reports/)")
+    parser.add_argument("--seats", default=None, help="comma-list of seats to run; default = full fleet")
     args = parser.parse_args(argv)
+
+    try:
+        roster = _parse_seats(args.seats)
+    except ValueError as exc:
+        print(f"panel: {exc}", file=sys.stderr)
+        return 2
 
     context = ""
     if args.context_file:
@@ -60,7 +86,10 @@ def main(argv: "list[str] | None" = None) -> int:
     dispatcher = _make_default_dispatcher(data_dir, args.timeout)
 
     print(f"[panel] mode={args.mode} — running 4-stage deliberation across the fleet ...", file=sys.stderr)
-    result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context)
+    if roster is None:
+        result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context)
+    else:
+        result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context, roster=roster)
     report = result.to_report()
 
     out = Path(args.out) if args.out else (_resolve_reports_dir() / f"panel-{args.mode}-{uuid.uuid4().hex[:8]}.md")

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -1,0 +1,102 @@
+#!/usr/bin/env python3
+"""Tests for scripts/panel.py CLI roster filtering."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+class _FakeResult:
+    def to_report(self) -> str:
+        return "# fake panel report\n"
+
+
+def _load_panel_cli():
+    spec = importlib.util.spec_from_file_location("panel_cli_under_test", REPO_ROOT / "scripts" / "panel.py")
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_seats_filters_to_requested_roster(tmp_path, monkeypatch):
+    panel = _load_panel_cli()
+    calls = {}
+
+    def fake_dispatcher_factory(data_dir, timeout):
+        calls["dispatcher_factory"] = {"data_dir": data_dir, "timeout": timeout}
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        calls["run_deliberation"] = {"args": args, "kwargs": kwargs}
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main([
+        "sweep",
+        "audit src/",
+        "--seats",
+        "codex,claude",
+        "--out",
+        str(tmp_path / "report.md"),
+    ])
+
+    assert rc == 0
+    assert calls["run_deliberation"]["kwargs"]["roster"] == [
+        ("codex", "gpt-5.5"),
+        ("claude", "sonnet"),
+    ]
+
+
+def test_unknown_seat_errors_without_dispatch(tmp_path, monkeypatch, capsys):
+    panel = _load_panel_cli()
+
+    def fail_dispatcher_factory(data_dir, timeout):
+        raise AssertionError("dispatcher must not be built for invalid --seats")
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fail_dispatcher_factory)
+
+    rc = panel.main([
+        "sweep",
+        "audit src/",
+        "--seats",
+        "codex,bogus",
+        "--out",
+        str(tmp_path / "report.md"),
+    ])
+
+    captured = capsys.readouterr()
+    assert rc == 2
+    assert "panel: unknown --seats value(s): bogus" in captured.err
+    assert "known seats:" in captured.err
+
+
+def test_default_omits_roster_kwarg_to_preserve_full_fleet_path(tmp_path, monkeypatch):
+    panel = _load_panel_cli()
+    calls = {}
+
+    def fake_dispatcher_factory(data_dir, timeout):
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        calls["run_deliberation"] = {"args": args, "kwargs": kwargs}
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main([
+        "sweep",
+        "audit src/",
+        "--out",
+        str(tmp_path / "report.md"),
+    ])
+
+    assert rc == 0
+    assert "roster" not in calls["run_deliberation"]["kwargs"]


### PR DESCRIPTION
## Summary
Adds an additive `--seats` roster filter to `scripts/panel.py` so business-panel callers can restrict the deliberation fleet to selected seats.

## Why
The business-panel skill already passes `--seats`, but the CLI did not accept it. That meant selected seats could not be enforced at the runner layer, creating a data-sovereignty risk for customer-scoped calls.

## Changes
- Adds `--seats` CLI parsing with validation against `deliberation_panel.DEFAULT_ROSTER`.
- Passes a filtered `roster` to `run_deliberation` only when `--seats` is provided.
- Leaves the no-`--seats` path calling `run_deliberation` without a `roster` kwarg, preserving existing full-fleet behavior.
- Adds CLI tests for filtered seats, unknown seats, and the default full-fleet path.

## Verification
- `python3 -m pytest tests/test_panel_cli.py tests/test_deliberation_panel.py tests/test_plan_gate_panel.py` (`78 passed`)
- `python3 -c "import ast; ast.parse(open('scripts/panel.py').read())"`
- `python3 scripts/panel.py --help`