### PR TITLE
feat(rv2-pr7): receipt_query.py by-pr/since/by-track/digest + reconcile-oi-pending

### DIFF
--- a/scripts/receipt_query.py
+++ b/scripts/receipt_query.py
@@ -1,24 +1,48 @@
 #!/usr/bin/env python3
 """receipt_query.py — the receipt-v2 pull interface (ADR-035 §5).
 
-This PR (ADR-035 §9 PR-6) ships two subcommands. ``by-pr``/``since``/``by-track``/
-``digest`` land in PR-7; wiring into the T0 cycle and retiring the tmux-pane push
-land in PR-8 — neither is touched here.
+PR-6 (ADR-035 §9) shipped ``pull``/``by-dispatch``. This PR (§9 PR-7) adds the
+rest of the interface plus the §6.4 oi_pending follow-up loop:
 
-  pull         — the tick primitive. Absorbs receipt_pull.py's cursor algorithm
-                 (parked branch feat/receipt-mailbox-delivery, commit 54089155),
-                 reimplemented against current main rather than resurrecting the
-                 branch: byte cursor in receipt_pull_cursor.json, read-then-advance,
-                 advances only past complete (newline-terminated) lines so a
-                 concurrent append's partial trailing line is never consumed early,
-                 resets to 0 on a truncated/rotated ledger, --seed-now sets the
-                 cursor to EOF (skip the backlog without deleting it), --peek reads
-                 without advancing.
-  by-dispatch  — thin wrapper over receipt_provenance.find_receipts_by_dispatch.
-                 No reimplementation.
+  pull               — the tick primitive. Absorbs receipt_pull.py's cursor
+                        algorithm (parked branch feat/receipt-mailbox-delivery,
+                        commit 54089155), reimplemented against current main
+                        rather than resurrecting the branch: byte cursor in
+                        receipt_pull_cursor.json, read-then-advance, advances
+                        only past complete (newline-terminated) lines so a
+                        concurrent append's partial trailing line is never
+                        consumed early, resets to 0 on a truncated/rotated
+                        ledger, --seed-now sets the cursor to EOF (skip the
+                        backlog without deleting it), --peek reads without
+                        advancing.
+  by-dispatch        — thin wrapper over receipt_provenance.find_receipts_by_dispatch.
+                        No reimplementation.
+  by-pr, since       — new, linear-scan-with-predicate over ``pr_id``/``timestamp``
+                        (§5.2 — no new index or SQLite projection, §8 non-goal).
+  by-track           — NOT a linear scan: the receipt carries no track_id field
+                        (§4). A two-step join instead, reusing existing code:
+                        (1) the same ``dispatch_id FROM dispatches WHERE track = ?
+                        AND project_id = ?`` query ``tracks.get_recent_receipts``
+                        already runs; (2) ``find_receipts_by_dispatch`` per
+                        resolved dispatch_id. No new index, no receipt-shape change.
+  digest             — verdict counts (accept/investigate/reject) over a window,
+                        the top ``warnings[]`` codes at destination:"counted",
+                        and a second tally — "N warnings met oi_pending zonder
+                        resolutie" (§6.4), computed as a dedup_key join against
+                        the CURRENT open-items store, never a rewrite of the
+                        (immutable) receipt line.
+  reconcile-oi-pending — scans the ledger for still-unresolved oi_pending
+                        warnings and retries add_item_programmatic per entry
+                        using the preserved dedup_key (§6.4). An entry whose
+                        originating receipt is older than --max-age-days and
+                        still fails is reported as escalated — surfaced via
+                        digest, not a new alerting channel.
 
-Both subcommands tolerate a mixed v1/v2 ledger: a line missing ``schema_version``
-is a v1 line, read like any other JSON object — never a reason to crash.
+Every subcommand tolerates a mixed v1/v2 ledger: a line missing
+``schema_version`` is a v1 line, read like any other JSON object — never a
+reason to crash. A ``schema_version``-absent or ``verdict``-absent line buckets
+under an explicit ``"unknown"`` verdict in ``digest``, never crashing or being
+silently miscounted as a real verdict (§5.2).
 """
 
 from __future__ import annotations
@@ -26,18 +50,29 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import re
+import sqlite3
 import sys
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional, Tuple
 
 SCRIPT_DIR = Path(__file__).resolve().parent
 if str(SCRIPT_DIR / "lib") not in sys.path:
     sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+if str(SCRIPT_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPT_DIR))
 
 from receipt_provenance import find_receipts_by_dispatch  # noqa: E402
 
 LEDGER_NAME = "t0_receipts.ndjson"
 CURSOR_NAME = "receipt_pull_cursor.json"
+RUNTIME_COORDINATION_DB_NAME = "runtime_coordination.db"
+DEFAULT_PROJECT_ID = "vnx-dev"
+DEFAULT_DIGEST_WINDOW = "24h"
+DEFAULT_RECONCILE_MAX_AGE_DAYS = 7.0
+
+_open_items_manager_cache: Optional[Any] = None
 
 
 def _ledger_path(state_dir: Path) -> Path:
@@ -102,6 +137,319 @@ def pull_new_receipts(
     return receipts, new_offset
 
 
+def _iter_ledger(ledger_path: Path):
+    """Yield each parsed JSON object in ``ledger_path``. Missing file -> no
+    iterations. A blank or malformed line is skipped, never raised — the same
+    tolerance ``find_receipts_by_dispatch`` already applies (§5.2: every
+    subcommand must handle a mixed v1/v2 ledger without crashing)."""
+    if not ledger_path.exists():
+        return
+    with ledger_path.open("r", encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                yield json.loads(line)
+            except json.JSONDecodeError:
+                continue
+
+
+def _parse_iso8601(value: Any) -> Optional[datetime]:
+    """Best-effort ISO8601 parse, tolerant of a trailing ``Z``. Returns None
+    (never raises) for anything that isn't a parseable timestamp string — a
+    receipt missing/mangling ``timestamp`` must not crash a scan."""
+    if not isinstance(value, str) or not value.strip():
+        return None
+    v = value.strip()
+    if v.endswith("Z"):
+        v = v[:-1] + "+00:00"
+    try:
+        dt = datetime.fromisoformat(v)
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def find_receipts_by_pr(ledger_path: Path, pr_id: str) -> List[Dict[str, Any]]:
+    """`by-pr` (ADR-035 §5.2) — linear scan-with-predicate over ``pr_id``, the
+    same approach ``find_receipts_by_dispatch`` already uses (no new index —
+    §8 non-goal). Mixed v1/v2 tolerant: both shapes carry ``pr_id``."""
+    matches: List[Dict[str, Any]] = []
+    target = str(pr_id)
+    for entry in _iter_ledger(ledger_path):
+        entry_pr = entry.get("pr_id")
+        if entry_pr is not None and str(entry_pr) == target:
+            matches.append(entry)
+    return matches
+
+
+def find_receipts_since(ledger_path: Path, since_iso: str) -> List[Dict[str, Any]]:
+    """`since` (ADR-035 §5.2) — linear scan-with-predicate over ``timestamp``
+    (v2 and legacy v1 both carry it — §3.2). Raises ValueError only for an
+    unparseable ``since_iso`` argument itself; a receipt line with a missing
+    or unparseable ``timestamp`` is skipped, never a reason to crash the scan.
+    """
+    threshold = _parse_iso8601(since_iso)
+    if threshold is None:
+        raise ValueError(f"invalid ISO8601 timestamp: {since_iso!r}")
+
+    matches: List[Dict[str, Any]] = []
+    for entry in _iter_ledger(ledger_path):
+        ts = _parse_iso8601(entry.get("timestamp"))
+        if ts is not None and ts >= threshold:
+            matches.append(entry)
+    return matches
+
+
+def _dispatch_ids_for_track(state_dir: Path, track_id: str, project_id: str) -> List[str]:
+    """The `dispatches WHERE track = ? AND project_id = ?` half of `by-track`'s
+    join (ADR-035 §5.2) — the identical query ``tracks.get_recent_receipts``
+    (scripts/lib/tracks.py) already runs today. Returns `[]`, never raises,
+    when the state DB is missing, predates the `track` column, or has no
+    `dispatches` table at all (T26) — `PRAGMA table_info` on an absent table
+    returns an empty result set rather than erroring, so the missing-table and
+    missing-column cases collapse into the same check.
+    """
+    db_path = Path(state_dir) / RUNTIME_COORDINATION_DB_NAME
+    if not db_path.exists():
+        return []
+    try:
+        conn = sqlite3.connect(str(db_path))
+    except sqlite3.Error:
+        return []
+    try:
+        has_track_column = any(
+            row[1] == "track" for row in conn.execute("PRAGMA table_info(dispatches)")
+        )
+        if not has_track_column:
+            return []
+        try:
+            rows = conn.execute(
+                "SELECT dispatch_id FROM dispatches WHERE track = ? AND project_id = ?",
+                (track_id, project_id),
+            ).fetchall()
+        except sqlite3.Error:
+            return []
+        return [row[0] for row in rows]
+    finally:
+        conn.close()
+
+
+def find_receipts_by_track(
+    state_dir: Path,
+    ledger_path: Path,
+    track_id: str,
+    project_id: str,
+) -> List[Dict[str, Any]]:
+    """`by-track` (ADR-035 §5.2) — NOT a linear scan (the receipt carries no
+    `track_id` field, §4/§8). A two-step join reusing existing code: resolve
+    `dispatch_id`s for (track_id, project_id) via the same query
+    `tracks.get_recent_receipts` already runs, then wrap
+    `find_receipts_by_dispatch` per dispatch_id — the same lookup `by-dispatch`
+    already wraps. No new index, no receipt-shape change. Returns `[]`, never
+    raises, when the track has no dispatches or the state DB predates the
+    `track` column (T26)."""
+    dispatch_ids = _dispatch_ids_for_track(state_dir, track_id, project_id)
+    receipts: List[Dict[str, Any]] = []
+    for dispatch_id in dispatch_ids:
+        receipts.extend(find_receipts_by_dispatch(ledger_path, dispatch_id))
+    return receipts
+
+
+def _parse_window(window_str: str) -> timedelta:
+    """Parse a `--window` value like `24h`/`30m`/`7d`/`3600s` into a timedelta."""
+    match = re.fullmatch(r"(\d+)([smhd])", (window_str or "").strip())
+    if not match:
+        raise ValueError(
+            f"invalid --window value: {window_str!r} (expected e.g. '24h', '30m', '7d', '3600s')"
+        )
+    amount, unit = int(match.group(1)), match.group(2)
+    unit_seconds = {"s": 1, "m": 60, "h": 3600, "d": 86400}[unit]
+    return timedelta(seconds=amount * unit_seconds)
+
+
+def _load_open_items_manager() -> Any:
+    """Lazy, cached import of the real `open_items_manager` module — mirrors
+    `append_receipt_internals.common._get_open_items_manager`'s pattern.
+    Callers that need test isolation (a per-test STATE_DIR) pass their own
+    `open_items_manager_module` instead of relying on this cache."""
+    global _open_items_manager_cache
+    if _open_items_manager_cache is None:
+        import open_items_manager as _oim  # noqa: PLC0415
+
+        _open_items_manager_cache = _oim
+    return _open_items_manager_cache
+
+
+def _unresolved_oi_pending(
+    entries: List[Dict[str, Any]],
+    open_items_manager_module: Optional[Any],
+) -> List[Dict[str, Any]]:
+    """ADR-035 §6.4: an `oi_pending` warning is "resolved" the moment a
+    matching open item exists in the CURRENT open-items store, joined by
+    `dedup_key` (the warning's `code` — `warning_destination.dedup_key_for`)
+    — never by re-reading the (immutable) receipt line, which never changes.
+    `entries` is a list of `{dispatch_id, code}` dicts pulled from `warnings[]`
+    entries with `destination == "oi_pending"`."""
+    if not entries:
+        return []
+    oim = open_items_manager_module or _load_open_items_manager()
+    data = oim.load_items()
+    unresolved = []
+    for entry in entries:
+        dedup_key = entry.get("code") or ""
+        if not dedup_key or oim._find_by_dedup_key(data, dedup_key) is None:
+            unresolved.append(entry)
+    return unresolved
+
+
+def compute_digest(
+    ledger_path: Path,
+    *,
+    window: str = DEFAULT_DIGEST_WINDOW,
+    now: Optional[datetime] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """`digest` (ADR-035 §5.2/§6.4): verdict counts (accept/investigate/reject)
+    over `window`, the top `warnings[]` codes at `destination: "counted"`, and
+    the "N warnings met oi_pending zonder resolutie" tally.
+
+    A line missing `schema_version`/`verdict` entirely (legacy v1, or any
+    line the writer never stamped a verdict onto) buckets under an explicit
+    `"unknown"` verdict count — never crashes, never silently miscounted as
+    a real verdict (T17). `open_items_manager_module` is a test-injection
+    seam (mirrors `warning_destination.assign_destination`'s own seam);
+    production callers rely on the default (the real on-disk OI store).
+    """
+    delta = _parse_window(window)
+    now = now or datetime.now(timezone.utc)
+    cutoff = now - delta
+
+    verdict_counts: Dict[str, int] = {"accept": 0, "investigate": 0, "reject": 0, "unknown": 0}
+    counted_codes: Dict[str, int] = {}
+    oi_pending_candidates: List[Dict[str, Any]] = []
+
+    for entry in _iter_ledger(ledger_path):
+        ts = _parse_iso8601(entry.get("timestamp"))
+        if ts is None or ts < cutoff:
+            continue
+
+        verdict = entry.get("verdict")
+        decision = verdict.get("decision") if isinstance(verdict, dict) else None
+        if decision not in ("accept", "investigate", "reject"):
+            decision = "unknown"
+        verdict_counts[decision] += 1
+
+        for warning in entry.get("warnings") or []:
+            if not isinstance(warning, dict):
+                continue
+            destination = warning.get("destination")
+            code = str(warning.get("code") or "")
+            if destination == "counted" and code:
+                counted_codes[code] = counted_codes.get(code, 0) + 1
+            elif destination == "oi_pending":
+                oi_pending_candidates.append({
+                    "dispatch_id": entry.get("dispatch_id"),
+                    "code": code,
+                })
+
+    unresolved = _unresolved_oi_pending(oi_pending_candidates, open_items_manager_module)
+    top_counted = sorted(counted_codes.items(), key=lambda kv: (-kv[1], kv[0]))
+
+    return {
+        "window": window,
+        "verdict_counts": verdict_counts,
+        "counted_warnings": [{"code": code, "count": count} for code, count in top_counted],
+        "oi_pending_unresolved_count": len(unresolved),
+        "oi_pending_unresolved": unresolved,
+    }
+
+
+def _age_in_days(timestamp: Any, now: datetime) -> Optional[float]:
+    ts = _parse_iso8601(timestamp)
+    if ts is None:
+        return None
+    return (now - ts).total_seconds() / 86400.0
+
+
+def reconcile_oi_pending(
+    ledger_path: Path,
+    *,
+    max_age_days: float = DEFAULT_RECONCILE_MAX_AGE_DAYS,
+    now: Optional[datetime] = None,
+    open_items_manager_module: Optional[Any] = None,
+) -> Dict[str, Any]:
+    """`reconcile-oi-pending` (ADR-035 §6.4): scans the ledger for every
+    `warnings[]` entry with `destination == "oi_pending"` and retries
+    `add_item_programmatic` per entry, using the preserved `dedup_key` (the
+    warning's `code`). `add_item_programmatic` is itself dedup-safe — an
+    already-resolved entry (a matching item created by an earlier reconcile,
+    or by a concurrent writer) just returns the existing item id — so this
+    never double-creates. Never rewrites the (immutable) receipt line; the
+    only observable effect is the open-items store gaining a matching item,
+    which `digest`'s oi_pending tally reads at query time (T34).
+
+    An entry whose ORIGINATING receipt's own `timestamp` is older than
+    `max_age_days` and still fails to promote is reported as escalated in the
+    return value — surfaced via `digest`, not a new alerting channel (§6.4).
+    No new retry-count store: age is measured from the receipt already on
+    disk, not a separately persisted attempt counter.
+    """
+    now = now or datetime.now(timezone.utc)
+    oim = open_items_manager_module or _load_open_items_manager()
+
+    pending_entries: List[Tuple[Dict[str, Any], Dict[str, Any]]] = []
+    for receipt in _iter_ledger(ledger_path):
+        for warning in receipt.get("warnings") or []:
+            if isinstance(warning, dict) and warning.get("destination") == "oi_pending":
+                pending_entries.append((receipt, warning))
+
+    reconciled = 0
+    still_pending = 0
+    escalated: List[Dict[str, Any]] = []
+
+    for receipt, warning in pending_entries:
+        code = str(warning.get("code") or "")
+        if not code:
+            still_pending += 1
+            continue
+
+        dispatch_id = str(receipt.get("dispatch_id") or "")
+        message = warning.get("message") or ""
+        try:
+            oim.add_item_programmatic(
+                title=message or code,
+                severity=warning.get("severity"),
+                dispatch_id=dispatch_id,
+                report_path=str(receipt.get("report_path") or ""),
+                pr_id=str(receipt.get("pr_id") or ""),
+                details=message,
+                dedup_key=code,
+                source="reconcile-oi-pending",
+            )
+            reconciled += 1
+        except Exception as exc:  # noqa: BLE001 — OI store failure must never crash the scan
+            still_pending += 1
+            age_days = _age_in_days(receipt.get("timestamp"), now)
+            if age_days is not None and age_days >= max_age_days:
+                escalated.append({
+                    "dispatch_id": dispatch_id,
+                    "code": code,
+                    "age_days": round(age_days, 2),
+                    "error": str(exc),
+                })
+
+    return {
+        "scanned": len(pending_entries),
+        "reconciled": reconciled,
+        "still_pending": still_pending,
+        "escalated": escalated,
+    }
+
+
 def _format_receipt(r: Dict[str, Any]) -> str:
     term = r.get("terminal_id", "?")
     did = r.get("dispatch_id", "?")
@@ -163,6 +511,104 @@ def _cmd_by_dispatch(args: argparse.Namespace) -> int:
     return 0
 
 
+def _cmd_by_pr(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    receipts = find_receipts_by_pr(ledger, args.pr_id)
+
+    if args.json:
+        print(json.dumps(
+            {"pr_id": args.pr_id, "count": len(receipts), "receipts": receipts},
+            indent=2,
+        ))
+    else:
+        print(f"{len(receipts)} receipt(s) for pr {args.pr_id}:")
+        for r in receipts:
+            print(_format_receipt(r))
+    return 0
+
+
+def _cmd_since(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    try:
+        receipts = find_receipts_since(ledger, args.timestamp)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(
+            {"since": args.timestamp, "count": len(receipts), "receipts": receipts},
+            indent=2,
+        ))
+    else:
+        print(f"{len(receipts)} receipt(s) since {args.timestamp}:")
+        for r in receipts:
+            print(_format_receipt(r))
+    return 0
+
+
+def _cmd_by_track(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    receipts = find_receipts_by_track(state_dir, ledger, args.track_id, args.project_id)
+
+    if args.json:
+        print(json.dumps(
+            {
+                "track_id": args.track_id,
+                "project_id": args.project_id,
+                "count": len(receipts),
+                "receipts": receipts,
+            },
+            indent=2,
+        ))
+    else:
+        print(f"{len(receipts)} receipt(s) for track {args.track_id} (project {args.project_id}):")
+        for r in receipts:
+            print(_format_receipt(r))
+    return 0
+
+
+def _cmd_digest(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    try:
+        result = compute_digest(ledger, window=args.window)
+    except ValueError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 1
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        vc = result["verdict_counts"]
+        print(f"digest (window={result['window']}):")
+        print(
+            f"  verdict: accept={vc['accept']} investigate={vc['investigate']} "
+            f"reject={vc['reject']} unknown={vc['unknown']}"
+        )
+        print(f"  counted warnings (top codes): {result['counted_warnings']}")
+        print(f"  oi_pending zonder resolutie: {result['oi_pending_unresolved_count']}")
+    return 0
+
+
+def _cmd_reconcile_oi_pending(args: argparse.Namespace) -> int:
+    state_dir = Path(args.state_dir)
+    ledger = _ledger_path(state_dir)
+    result = reconcile_oi_pending(ledger, max_age_days=args.max_age_days)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(
+            f"scanned={result['scanned']} reconciled={result['reconciled']} "
+            f"still_pending={result['still_pending']} escalated={len(result['escalated'])}"
+        )
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     parser = argparse.ArgumentParser(
         description="Receipt v2 pull-model query interface (ADR-035 §5)",
@@ -196,6 +642,57 @@ def main(argv: Optional[List[str]] = None) -> int:
     p_by_dispatch.add_argument("--state-dir", required=True)
     p_by_dispatch.add_argument("--json", action="store_true")
     p_by_dispatch.set_defaults(func=_cmd_by_dispatch)
+
+    p_by_pr = sub.add_parser(
+        "by-pr",
+        help="all receipts for a pr_id (linear scan, no new index — §8 non-goal)",
+    )
+    p_by_pr.add_argument("pr_id")
+    p_by_pr.add_argument("--state-dir", required=True)
+    p_by_pr.add_argument("--json", action="store_true")
+    p_by_pr.set_defaults(func=_cmd_by_pr)
+
+    p_since = sub.add_parser(
+        "since",
+        help="all receipts with timestamp >= the given ISO8601 timestamp (linear scan)",
+    )
+    p_since.add_argument("timestamp", help="ISO8601 timestamp, e.g. 2026-07-20T00:00:00Z")
+    p_since.add_argument("--state-dir", required=True)
+    p_since.add_argument("--json", action="store_true")
+    p_since.set_defaults(func=_cmd_since)
+
+    p_by_track = sub.add_parser(
+        "by-track",
+        help="all receipts for dispatches belonging to a track (SQLite join, §5.2)",
+    )
+    p_by_track.add_argument("track_id")
+    p_by_track.add_argument("--state-dir", required=True)
+    p_by_track.add_argument(
+        "--project-id", default=os.environ.get("VNX_PROJECT_ID", DEFAULT_PROJECT_ID),
+    )
+    p_by_track.add_argument("--json", action="store_true")
+    p_by_track.set_defaults(func=_cmd_by_track)
+
+    p_digest = sub.add_parser(
+        "digest",
+        help="verdict counts + counted-warning top codes + oi_pending-unresolved tally",
+    )
+    p_digest.add_argument("--state-dir", required=True)
+    p_digest.add_argument("--window", default=DEFAULT_DIGEST_WINDOW)
+    p_digest.add_argument("--json", action="store_true")
+    p_digest.set_defaults(func=_cmd_digest)
+
+    p_reconcile = sub.add_parser(
+        "reconcile-oi-pending",
+        help="retry add_item_programmatic for unresolved oi_pending warnings (§6.4)",
+    )
+    p_reconcile.add_argument("--state-dir", required=True)
+    p_reconcile.add_argument(
+        "--max-age-days", type=float, default=DEFAULT_RECONCILE_MAX_AGE_DAYS,
+        help="a still-failing entry older than this (by its receipt's own timestamp) escalates",
+    )
+    p_reconcile.add_argument("--json", action="store_true")
+    p_reconcile.set_defaults(func=_cmd_reconcile_oi_pending)
 
     args = parser.parse_args(argv)
     return args.func(args)

--- a/tests/test_receipt_query.py
+++ b/tests/test_receipt_query.py
@@ -1,20 +1,36 @@
 #!/usr/bin/env python3
-"""ADR-035 §9 PR-6 — receipt_query.py: pull + by-dispatch.
+"""ADR-035 §9 PR-6/PR-7 — receipt_query.py: the full pull-model query interface.
 
-Covers T12 (pull read-then-advance; a concurrent append's partial trailing line
-is never consumed until it is newline-terminated) and T13 (pull --seed-now sets
-the cursor to EOF; the backlog is skipped but stays on disk and readable via
-by-dispatch), plus the surrounding cursor mechanics absorbed from the parked
-receipt_pull.py design (branch feat/receipt-mailbox-delivery, commit 54089155)
-and mixed v1/v2 ledger tolerance for both subcommands.
+PR-6 covers T12 (pull read-then-advance; a concurrent append's partial
+trailing line is never consumed until it is newline-terminated) and T13 (pull
+--seed-now sets the cursor to EOF; the backlog is skipped but stays on disk
+and readable via by-dispatch), plus the surrounding cursor mechanics absorbed
+from the parked receipt_pull.py design (branch feat/receipt-mailbox-delivery,
+commit 54089155) and mixed v1/v2 ledger tolerance for both subcommands.
+
+PR-7 covers T14 (by-pr), T15 (by-track join, mixed v1/v2), T16 (since), T17
+(digest buckets a verdict-less/v1 line under an explicit "unknown"), T26
+(by-track returns [] rather than erroring when the track has no dispatches or
+the state DB predates the track column), and T34 (an unresolved oi_pending
+warning counts in digest's tally; reconcile-oi-pending resolving it — by
+creating a real open item with a matching dedup_key — drops it out, proving
+the join reads the CURRENT open-items store rather than the immutable
+receipt line).
 """
 
 from __future__ import annotations
 
+import importlib.util
 import json
+import os
+import sqlite3
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict
+from unittest.mock import patch
+
+import pytest
 
 TESTS_DIR = Path(__file__).resolve().parent
 VNX_ROOT = TESTS_DIR.parent
@@ -280,3 +296,488 @@ def test_pull_text_output_handles_mixed_ledger(tmp_path, capsys):
     out = capsys.readouterr().out
     assert "d1" in out and "schema_version=1" in out
     assert "d2" in out and "schema_version=2" in out
+
+
+# ---------------------------------------------------------------------------
+# PR-7 helpers
+# ---------------------------------------------------------------------------
+
+def _v1_with(did: str, **overrides: Any) -> Dict[str, Any]:
+    r = _v1_receipt(did)
+    r.update(overrides)
+    return r
+
+
+def _v2_with(did: str, **overrides: Any) -> Dict[str, Any]:
+    r = _v2_receipt(did)
+    r.update(overrides)
+    return r
+
+
+class _NeverCalledOIM:
+    """Fails loudly if digest ever touches the OI store when there are no
+    `oi_pending` warnings to resolve — proves the join is skipped, not just
+    empty, when there is nothing to join against."""
+
+    def load_items(self):
+        raise AssertionError("open_items_manager must not be touched with no oi_pending warnings")
+
+    def _find_by_dedup_key(self, data, key):
+        raise AssertionError("open_items_manager must not be touched with no oi_pending warnings")
+
+
+def _load_oim(tmp_path: Path):
+    """Fresh, isolated open_items_manager module bound to a per-test STATE_DIR
+    (mirrors tests/test_warning_destination.py's helper) — exercises the REAL
+    add_item_programmatic/dedup path, not a mock."""
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(VNX_ROOT),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+
+    mod_name = f"open_items_manager_rq_test_{tmp_path.name}"
+    with patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, SCRIPTS_DIR / "open_items_manager.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# T14 — by-pr: linear scan over pr_id, mixed v1/v2 ledger
+# ---------------------------------------------------------------------------
+
+def test_t14_by_pr_returns_every_matching_receipt(tmp_path):
+    _write_ledger(
+        tmp_path,
+        _v1_with("d1", pr_id="100"),
+        _v2_with("d2", pr_id="200"),
+        _v1_with("d3", pr_id="100"),
+        _v2_with("d4", pr_id="300"),
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts = rq.find_receipts_by_pr(ledger, "100")
+    assert {r["dispatch_id"] for r in receipts} == {"d1", "d3"}
+
+
+def test_t14_by_pr_matches_across_schema_versions(tmp_path):
+    _write_ledger(tmp_path, _v1_with("d1", pr_id="7"), _v2_with("d2", pr_id="7"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts = rq.find_receipts_by_pr(ledger, "7")
+    assert {r["dispatch_id"] for r in receipts} == {"d1", "d2"}
+
+
+def test_by_pr_matches_int_and_str_pr_id(tmp_path):
+    _write_ledger(tmp_path, _r("d1", pr_id=123))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert [r["dispatch_id"] for r in rq.find_receipts_by_pr(ledger, "123")] == ["d1"]
+
+
+def test_by_pr_no_match_is_empty_not_error(tmp_path):
+    _write_ledger(tmp_path, _r("d1", pr_id="1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_pr(ledger, "999") == []
+
+
+def test_by_pr_missing_ledger_is_empty(tmp_path):
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_pr(ledger, "1") == []
+
+
+def test_by_pr_cli(tmp_path, capsys):
+    _write_ledger(tmp_path, _r("d1", pr_id="42"), _r("d2", pr_id="43"))
+    rc = rq.main(["by-pr", "42", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 1
+    assert out["receipts"][0]["dispatch_id"] == "d1"
+
+
+# ---------------------------------------------------------------------------
+# T16 — since: linear scan over timestamp, v2 + legacy v1
+# ---------------------------------------------------------------------------
+
+def test_t16_since_filters_v2_and_legacy_v1_timestamps(tmp_path):
+    _write_ledger(
+        tmp_path,
+        _v1_with("d1", timestamp="2026-07-01T00:00:00Z"),
+        _v2_with("d2", timestamp="2026-07-15T00:00:00Z"),
+        _v1_with("d3", timestamp="2026-07-20T00:00:00Z"),
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts = rq.find_receipts_since(ledger, "2026-07-10T00:00:00Z")
+    assert {r["dispatch_id"] for r in receipts} == {"d2", "d3"}
+
+
+def test_since_boundary_is_inclusive(tmp_path):
+    _write_ledger(tmp_path, _r("d1", timestamp="2026-07-10T00:00:00Z"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts = rq.find_receipts_since(ledger, "2026-07-10T00:00:00Z")
+    assert [r["dispatch_id"] for r in receipts] == ["d1"]
+
+
+def test_since_skips_missing_or_unparseable_timestamp_without_crashing(tmp_path):
+    _write_ledger(
+        tmp_path,
+        _r("d1"),  # no timestamp field at all
+        _r("d2", timestamp="not-a-date"),
+        _r("d3", timestamp="2026-07-20T00:00:00Z"),
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    receipts = rq.find_receipts_since(ledger, "2026-01-01T00:00:00Z")
+    assert [r["dispatch_id"] for r in receipts] == ["d3"]
+
+
+def test_since_invalid_argument_raises_value_error(tmp_path):
+    ledger = tmp_path / rq.LEDGER_NAME
+    with pytest.raises(ValueError):
+        rq.find_receipts_since(ledger, "not-iso8601")
+
+
+def test_since_cli_reports_error_for_invalid_timestamp(tmp_path):
+    rc = rq.main(["since", "garbage", "--state-dir", str(tmp_path)])
+    assert rc == 1
+
+
+def test_since_cli(tmp_path, capsys):
+    _write_ledger(
+        tmp_path,
+        _r("d1", timestamp="2026-07-01T00:00:00Z"),
+        _r("d2", timestamp="2026-07-20T00:00:00Z"),
+    )
+    rc = rq.main(["since", "2026-07-10T00:00:00Z", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 1
+    assert out["receipts"][0]["dispatch_id"] == "d2"
+
+
+# ---------------------------------------------------------------------------
+# T15/T26 — by-track: SQLite join (dispatches.track), NOT a linear scan
+# ---------------------------------------------------------------------------
+
+def _create_runtime_db(state_dir: Path, *, with_track_column: bool = True) -> Path:
+    db_path = state_dir / rq.RUNTIME_COORDINATION_DB_NAME
+    conn = sqlite3.connect(str(db_path))
+    try:
+        columns = (
+            "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+            "dispatch_id TEXT NOT NULL, "
+            "project_id TEXT NOT NULL DEFAULT 'vnx-dev'"
+        )
+        if with_track_column:
+            columns += ", track TEXT"
+        conn.execute(f"CREATE TABLE dispatches ({columns}, UNIQUE(dispatch_id, project_id))")
+        conn.commit()
+    finally:
+        conn.close()
+    return db_path
+
+
+def _insert_dispatch(db_path: Path, dispatch_id: str, project_id: str, track: str) -> None:
+    conn = sqlite3.connect(str(db_path))
+    try:
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id, track) VALUES (?, ?, ?)",
+            (dispatch_id, project_id, track),
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def test_t15_by_track_returns_receipts_for_joined_dispatch_ids_mixed_shapes(tmp_path):
+    db_path = _create_runtime_db(tmp_path)
+    _insert_dispatch(db_path, "d1", "vnx-dev", "track-a")
+    _insert_dispatch(db_path, "d2", "vnx-dev", "track-a")
+    _insert_dispatch(db_path, "d3", "vnx-dev", "track-b")  # different track — excluded
+
+    _write_ledger(tmp_path, _v1_with("d1"), _v2_with("d2"), _v1_with("d3"))
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    receipts = rq.find_receipts_by_track(tmp_path, ledger, "track-a", "vnx-dev")
+    assert {r["dispatch_id"] for r in receipts} == {"d1", "d2"}
+    # join key is dispatch_id, not schema_version — both shapes are returned
+    versions = {r.get("schema_version") for r in receipts}
+    assert versions == {None, 2}
+
+
+def test_t15_by_track_scopes_by_project_id(tmp_path):
+    db_path = _create_runtime_db(tmp_path)
+    _insert_dispatch(db_path, "d1", "proj-a", "track-x")
+    _insert_dispatch(db_path, "d2", "proj-b", "track-x")  # same track, different project
+
+    _write_ledger(tmp_path, _r("d1"), _r("d2"))
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    receipts = rq.find_receipts_by_track(tmp_path, ledger, "track-x", "proj-a")
+    assert [r["dispatch_id"] for r in receipts] == ["d1"]
+
+
+def test_t26_by_track_empty_when_track_has_no_dispatches(tmp_path):
+    _create_runtime_db(tmp_path)  # table exists, no rows at all
+    _write_ledger(tmp_path, _r("d1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_track(tmp_path, ledger, "no-such-track", "vnx-dev") == []
+
+
+def test_t26_by_track_empty_when_state_db_missing(tmp_path):
+    _write_ledger(tmp_path, _r("d1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_track(tmp_path, ledger, "track-a", "vnx-dev") == []
+
+
+def test_t26_by_track_empty_when_track_column_missing(tmp_path):
+    _create_runtime_db(tmp_path, with_track_column=False)
+    _write_ledger(tmp_path, _r("d1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_track(tmp_path, ledger, "track-a", "vnx-dev") == []
+
+
+def test_t26_by_track_empty_when_dispatches_table_missing(tmp_path):
+    db_path = tmp_path / rq.RUNTIME_COORDINATION_DB_NAME
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE other_table (id INTEGER)")
+    conn.commit()
+    conn.close()
+
+    _write_ledger(tmp_path, _r("d1"))
+    ledger = tmp_path / rq.LEDGER_NAME
+    assert rq.find_receipts_by_track(tmp_path, ledger, "track-a", "vnx-dev") == []
+
+
+def test_by_track_cli(tmp_path, capsys):
+    db_path = _create_runtime_db(tmp_path)
+    _insert_dispatch(db_path, "d1", "vnx-dev", "track-a")
+    _write_ledger(tmp_path, _r("d1"))
+    rc = rq.main([
+        "by-track", "track-a", "--state-dir", str(tmp_path), "--project-id", "vnx-dev", "--json",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["count"] == 1
+    assert out["receipts"][0]["dispatch_id"] == "d1"
+
+
+# ---------------------------------------------------------------------------
+# T17 — digest: mixed ledger buckets a verdict-less line as "unknown"
+# ---------------------------------------------------------------------------
+
+def test_t17_digest_buckets_v1_lines_as_unknown_verdict(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    _write_ledger(
+        tmp_path,
+        _v1_with("d1", timestamp="2026-07-22T00:00:00Z"),  # no verdict at all -> unknown
+        _v2_with("d2", timestamp="2026-07-22T01:00:00Z"),  # verdict.decision == accept
+        {
+            **_v2_with("d3", timestamp="2026-07-22T02:00:00Z"),
+            "verdict": {"decision": "reject", "reason": "x", "evidence_complete": True},
+        },
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, open_items_manager_module=_NeverCalledOIM(),
+    )
+    assert result["verdict_counts"] == {"accept": 1, "investigate": 0, "reject": 1, "unknown": 1}
+
+
+def test_digest_never_crashes_on_non_dict_verdict(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    _write_ledger(
+        tmp_path,
+        {"dispatch_id": "d1", "timestamp": "2026-07-22T00:00:00Z", "verdict": "not-a-dict"},
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, open_items_manager_module=_NeverCalledOIM(),
+    )
+    assert result["verdict_counts"]["unknown"] == 1
+
+
+def test_digest_window_excludes_older_receipts(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    _write_ledger(
+        tmp_path,
+        _v2_with("old", timestamp="2026-07-20T00:00:00Z"),  # > 24h ago -> excluded
+        _v2_with("new", timestamp="2026-07-22T11:00:00Z"),  # within window
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, open_items_manager_module=_NeverCalledOIM(),
+    )
+    assert sum(result["verdict_counts"].values()) == 1
+
+
+def test_digest_counted_warnings_top_codes(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+    def _receipt_with_counted(did: str, code: str, ts: str) -> Dict[str, Any]:
+        r = _v2_with(did, timestamp=ts)
+        r["warnings"] = [{
+            "code": code, "severity": "warn", "destination": "counted",
+            "oi_id": None, "reason": None, "requires_tracking": False,
+        }]
+        return r
+
+    _write_ledger(
+        tmp_path,
+        _receipt_with_counted("d1", "report_contract_invalid", "2026-07-22T01:00:00Z"),
+        _receipt_with_counted("d2", "report_contract_invalid", "2026-07-22T02:00:00Z"),
+        _receipt_with_counted("d3", "other_code", "2026-07-22T03:00:00Z"),
+    )
+    ledger = tmp_path / rq.LEDGER_NAME
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, open_items_manager_module=_NeverCalledOIM(),
+    )
+    assert result["counted_warnings"][0] == {"code": "report_contract_invalid", "count": 2}
+
+
+def test_digest_invalid_window_raises(tmp_path):
+    ledger = tmp_path / rq.LEDGER_NAME
+    with pytest.raises(ValueError):
+        rq.compute_digest(ledger, window="banana")
+
+
+def test_digest_cli(tmp_path, capsys):
+    _write_ledger(tmp_path, _v2_with("d1", timestamp="2026-07-22T01:00:00Z"))
+    rc = rq.main(["digest", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "verdict_counts" in out
+    assert out["window"] == "24h"
+
+
+# ---------------------------------------------------------------------------
+# T34 — oi_pending drops out of digest's tally after reconcile-oi-pending
+# ---------------------------------------------------------------------------
+
+def _oi_pending_receipt(did: str, code: str, ts: str, **overrides: Any) -> Dict[str, Any]:
+    r = _v2_with(did, timestamp=ts, **overrides)
+    r["warnings"] = [{
+        "code": code,
+        "severity": "blocker",
+        "message": "worker wrote outside declared scope",
+        "destination": "oi_pending",
+        "oi_id": None,
+        "reason": "store lock held by pid 4821",
+        "requires_tracking": True,
+    }]
+    return r
+
+
+def test_t34_oi_pending_drops_out_of_digest_tally_after_reconcile(tmp_path):
+    oim = _load_oim(tmp_path)
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-22T01:00:00Z",
+        report_path="reports/d1.md", pr_id="42",
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+    raw_before = ledger.read_text(encoding="utf-8")
+
+    before = rq.compute_digest(ledger, window="24h", now=now, open_items_manager_module=oim)
+    assert before["oi_pending_unresolved_count"] == 1
+    assert before["oi_pending_unresolved"][0]["dispatch_id"] == "d1"
+
+    result = rq.reconcile_oi_pending(ledger, now=now, open_items_manager_module=oim)
+    assert result["scanned"] == 1
+    assert result["reconciled"] == 1
+    assert result["still_pending"] == 0
+
+    # a real open item now exists with a dedup_key matching the warning's code
+    data = oim.load_items()
+    match = oim._find_by_dedup_key(data, "worker_permission_violation")
+    assert match is not None
+    assert match["status"] == "open"
+
+    after = rq.compute_digest(ledger, window="24h", now=now, open_items_manager_module=oim)
+    assert after["oi_pending_unresolved_count"] == 0
+
+    # the receipt line itself never changed — the join reads the OI store,
+    # never a rewrite of the immutable ledger line (ADR-005/§6.4).
+    assert ledger.read_text(encoding="utf-8") == raw_before
+
+
+def test_reconcile_oi_pending_escalates_stale_still_failing_entries(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-01T00:00:00Z",  # 21 days old
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    class _AlwaysFailingOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise RuntimeError("store still unreachable")
+
+    result = rq.reconcile_oi_pending(
+        ledger, now=now, max_age_days=7.0, open_items_manager_module=_AlwaysFailingOIM(),
+    )
+    assert result["scanned"] == 1
+    assert result["reconciled"] == 0
+    assert result["still_pending"] == 1
+    assert len(result["escalated"]) == 1
+    assert result["escalated"][0]["code"] == "worker_permission_violation"
+
+
+def test_reconcile_oi_pending_no_escalation_for_recent_failures(tmp_path):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-22T11:00:00Z",  # 1 hour old
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    class _AlwaysFailingOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise RuntimeError("store still unreachable")
+
+    result = rq.reconcile_oi_pending(
+        ledger, now=now, max_age_days=7.0, open_items_manager_module=_AlwaysFailingOIM(),
+    )
+    assert result["still_pending"] == 1
+    assert result["escalated"] == []
+
+
+def test_reconcile_oi_pending_missing_code_is_skipped_not_crashed(tmp_path):
+    receipt = _v2_with("d1", timestamp="2026-07-22T01:00:00Z")
+    receipt["warnings"] = [{
+        "severity": "blocker", "message": "m", "destination": "oi_pending",
+        "oi_id": None, "reason": "err", "requires_tracking": True,
+    }]
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    result = rq.reconcile_oi_pending(ledger, open_items_manager_module=_NeverCalledOIM())
+    assert result["scanned"] == 1
+    assert result["reconciled"] == 0
+    assert result["still_pending"] == 1
+
+
+def test_reconcile_oi_pending_cli(tmp_path, capsys):
+    oim = _load_oim(tmp_path)
+    receipt = _oi_pending_receipt("d1", "some_check", "2026-07-22T01:00:00Z")
+    _write_ledger(tmp_path, receipt)
+
+    with patch.object(rq, "_load_open_items_manager", return_value=oim):
+        rc = rq.main(["reconcile-oi-pending", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    # open_items_manager.add_item_programmatic prints its own "Digest updated"
+    # line as a side effect (generate_digest()) — parse from the JSON's own
+    # opening brace so that real, unrelated stdout noise doesn't fail the test.
+    raw = capsys.readouterr().out
+    out = json.loads(raw[raw.index("{"):])
+    assert out["scanned"] == 1
+    assert out["reconciled"] == 1


### PR DESCRIPTION
## Summary

Receipt-v2 PR-7 (ADR-035 §5.2, §6.4, §9 PR-7): the remaining `receipt_query.py` subcommands plus the oi_pending follow-up loop.

- `by-pr <pr_id>` — linear scan-with-predicate over `pr_id` (same approach as `find_receipts_by_dispatch`), mixed v1/v2 tolerant.
- `since <ISO8601>` — linear scan-with-predicate over `timestamp` (v2 + legacy v1).
- `by-track <track_id>` — **not** a linear scan (the receipt carries no `track_id` field, §4/§8). A two-step join: `SELECT dispatch_id FROM dispatches WHERE track = ? AND project_id = ?` (the identical query `tracks.get_recent_receipts` already runs), then `find_receipts_by_dispatch` per resolved dispatch_id. No new index, no receipt-shape change. Returns `[]` (never errors) when the track has no dispatches or the state DB predates the `track` column.
- `digest [--window 24h]` — verdict counts (accept/investigate/reject, absent/non-dict verdict → explicit `"unknown"`), top `warnings[]` codes at `destination:"counted"`, and a second tally: "N warnings met oi_pending zonder resolutie" — computed as a dedup_key join against the *current* open-items store (never a rewrite of the immutable receipt line).
- `reconcile-oi-pending` — scans the ledger for still-unresolved `oi_pending` warnings and retries `add_item_programmatic` per entry via the preserved `dedup_key`. An entry whose originating receipt is older than `--max-age-days` and still fails is reported as escalated (surfaced via `digest`, not a new alerting channel).

## Test plan

- [x] T14 — `by-pr` returns every matching receipt across a mixed v1/v2 ledger
- [x] T15 — `by-track` join returns receipts for resolved dispatch_ids regardless of schema_version
- [x] T16 — `since` filters correctly on `timestamp` for v2 and legacy v1
- [x] T17 — `digest` buckets a verdict-less/v1 line under an explicit `"unknown"`, never crashing
- [x] T26 — `by-track` returns `[]` (not an error) when the track has no dispatches or the state DB predates the `track` column
- [x] T34 — an unresolved `oi_pending` warning counts in `digest`'s tally; `reconcile-oi-pending` creating a real matching open item drops it out, proving the join reads the live open-items store, not the receipt line
- [x] `python3 -m pytest tests/test_receipt_query.py tests/test_receipt_provenance.py -q` → 106 passed (with `VNX_CURRENT_DISPATCH_ID` unset — see report note on 3 pre-existing env-induced failures otherwise)
- [x] Push verified: `git ls-remote origin dispatch/20260722-rv2-pr7-query-digest` → `896cfcfc96904640c45f0e65effeee21dd33e410`, matches local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)