### PR TITLE
feat(rv2-pr8): pull cadence doc + push retired behind flag + reconcile failure surfacing

### DIFF
--- a/docs/core/DISPATCH_RULES.md
+++ b/docs/core/DISPATCH_RULES.md
@@ -145,3 +145,20 @@ Proven end-to-end sequence for a T0 that has no role file loaded (no `.claude/te
 3. **Dry-run the door** — `bin/vnx dispatch <dispatch-id> --dry-run`. A bare dispatch-id with an existing bundle at `pending/<id>/dispatch-spec.json` routes to the door, not the legacy lane; `--dry-run` prints the compiled plan + permit fingerprint (lane/model/billing/route_reason) and spawns nothing.
 4. **Fire** — `bin/vnx dispatch <dispatch-id>`. The single-entry door selects the lane per §5/§8: claude/Opus/Sonnet → tmux-subscription lane; kimi/glm/deepseek → `provider_dispatch.py`.
 5. **After merge** — `python3 scripts/planning_cli.py objective link-pr <track-id> <pr-number>`. **Caveat:** `stage_spec_bundle`'s written spec payload has no `track_id` field (`scripts/lib/dispatch_bridge.py:166-195`), so a bridge-staged dispatch's `track_id` is always absent at the door. The TL-D2 auto-propagation that upserts `tracks.pr_ref` from `dispatch.track_id` on merge (`reconcile_commit_provenance`, #1034) therefore never fires for dispatches staged this way — `link-pr` is currently the only way to record the PR on the track for this path.
+
+## 13. Receipt pull cadence — T0 cycle step 0 (ADR-035 §5/§5.3, §9 PR-8)
+
+Receipts are no longer pushed into the T0 pane by default. **Step 0 of every T0 cycle, before reading any receipt, is a pull:**
+
+```bash
+python3 scripts/receipt_query.py pull --state-dir <state-dir> --json
+```
+
+- Reads everything appended to `t0_receipts.ndjson` since T0's own cursor (`receipt_pull_cursor.json` in the same state dir) and advances the cursor past what it read. A concurrent writer's not-yet-newline-terminated line is never consumed early (safe against a mid-append race).
+- **First use on a given state dir:** run once with `--seed-now` to set the cursor to EOF and skip the historical backlog (the backlog stays on disk, still reachable via `by-dispatch`/`by-pr`/`since` — nothing is deleted).
+- `--peek` reads without advancing the cursor, for a look-without-consuming check.
+- Follow the pull with `python3 scripts/receipt_query.py digest --state-dir <state-dir> --json` for the accept/investigate/reject rollup, and periodically (same cadence, not a separate operational task) `python3 scripts/receipt_query.py reconcile-oi-pending --state-dir <state-dir> --json` to retry any `oi_pending` warnings — see ADR-035 §6.4. An entry that keeps failing past `--max-age-days` (default 7) shows up in both `reconcile-oi-pending`'s own `escalated`/`failed` counts and in `digest`'s `oi_pending_escalated_count` — a standing operator obligation, not a new alerting channel.
+- This replaces waiting for `rp_delivery.sh`'s tmux pane-paste (`_deliver_receipt_to_t0_pane` / `_rpd_deliver_digest`), which is now suppressed by default (`VNX_RECEIPT_T0_PUSH` defaults to `0` — set it to `1` only as the transition escape hatch, e.g. a T0 setup that cannot run a pull cadence yet). The push code path and the flag are **kept**, not removed (§8/ADR-035 §5.3) — retiring them outright is a separate follow-up PR. The durability half (`send_receipt_to_t0`'s write-first-then-attempt-delivery) is untouched either way: the ledger line lands regardless of whether the pane notification fires.
+- **OI-188 note:** this step belongs in the `t0-orchestrator` skill's cycle steps (`.claude/skills/t0-orchestrator/SKILL.md` §"2. Primary workflow"), mirroring the parked commit `24f71d22`'s intent. No lane can reliably write under `.claude/skills/` (Claude treats it read-only) — this section is the canonical, git-tracked source until an operator applies the equivalent edit to the skill file by hand. Track as an operator follow-up, not something to force through a lane edit.
+
+See also: `docs/operations/RECEIPT_PIPELINE.md` (pipeline mechanics), ADR-035 §5 (pull interface design), §5.3 (push retirement), §6.4 (`oi_pending` lifecycle + escalation).

--- a/docs/operations/RECEIPT_PIPELINE.md
+++ b/docs/operations/RECEIPT_PIPELINE.md
@@ -81,10 +81,10 @@ rp_delivery.sh delivers the receipt to the T0 pane (outbox pattern)
 - `scripts/receipt_processor.sh` watches `VNX_REPORTS_DIR` (and `VNX_REPORTS_DIR/headless`) for new reports. Monitor mode processes only reports newer than startup; catchup mode reprocesses a recent window.
 - `scripts/report_parser.py` extracts the receipt fields from the report.
 - `scripts/append_receipt.py` performs the append. This is the path that applies hash-chaining when `VNX_CHAIN_RECEIPTS=1` (see below).
-- Delivery to T0 uses an **outbox pattern** (`scripts/lib/receipt_processor/rp_delivery.sh`): the receipt is persisted to `receipts/pending/` first, then delivered to the T0 tmux pane via `tmux load-buffer` → `paste-buffer` → `Enter`. A retry poller re-delivers anything still pending after a restart. Write-first guarantees no receipt is lost if delivery fails.
+- Delivery to T0 uses an **outbox pattern** (`scripts/lib/receipt_processor/rp_delivery.sh`): the receipt is persisted to `receipts/pending/` first, then — only when `VNX_RECEIPT_T0_PUSH=1` (opt-in transition escape hatch; **default is `0`** since ADR-035 §5.3/§9 PR-8) — delivered to the T0 tmux pane via `tmux load-buffer` → `paste-buffer` → `Enter`. A retry poller re-delivers anything still pending after a restart when the push is enabled. Write-first guarantees no receipt is lost regardless of the push flag; the pull interface (`scripts/receipt_query.py pull`, `docs/core/DISPATCH_RULES.md` §13) is the default way T0 becomes aware of new receipts now.
 - `scripts/report_watcher.sh` is **deprecated** (it exits 0 immediately); `receipt_processor.sh` is the single watcher.
 
-Report delivery via the T0 tmux pane requires a tmux pane to be present. Headless and CLI flows write the ledger line regardless; the pane paste is the T0-notification step, not the audit write.
+Report delivery via the T0 tmux pane (`VNX_RECEIPT_T0_PUSH=1`) requires a tmux pane to be present. Headless and CLI flows write the ledger line regardless; the pane paste is an opt-in T0-notification step, not the audit write — `scripts/receipt_query.py pull` is the default notification path (`docs/core/DISPATCH_RULES.md` §13).
 
 ## The mandatory report contract
 
@@ -138,7 +138,7 @@ Common causes: processor not running; report predates monitor-mode startup (use 
 
 ### Receipt written but T0 did not see it
 
-Receipt delivery to T0 is a tmux pane paste. It works from a CLI or desktop tmux session but not from a mobile remote-control session. If receipts are on disk (`tail .vnx-data/state/t0_receipts.ndjson`) but T0 shows nothing, check the delivery surface before suspecting the pipeline — the audit write already succeeded.
+As of ADR-035 §5.3 (§9 PR-8), `VNX_RECEIPT_T0_PUSH` defaults to `0` — the tmux pane paste is suppressed by default, and T0 is expected to pull instead: `python3 scripts/receipt_query.py pull --state-dir <state-dir>` (cadence + rationale: `docs/core/DISPATCH_RULES.md` §13). Set `VNX_RECEIPT_T0_PUSH=1` to re-enable the legacy pane push as a transition escape hatch — it works from a CLI or desktop tmux session but not from a mobile remote-control session. Either way, if receipts are on disk (`tail .vnx-data/state/t0_receipts.ndjson`) but T0 shows nothing, check the delivery/pull surface before suspecting the pipeline — the audit write already succeeded.
 
 ### Verify ledger integrity
 

--- a/scripts/lib/receipt_processor/rp_delivery.sh
+++ b/scripts/lib/receipt_processor/rp_delivery.sh
@@ -6,8 +6,11 @@
 #           extract_receipt_fields() from rp_extract.sh,
 #           get_pane_id_smart() from pane_manager,
 #           _rf_* fields, $RECEIPTS_PENDING_DIR, $RECEIPTS_PROCESSED_DIR
-# Env flags (OI-654): VNX_RECEIPT_T0_PUSH=1 (default) pushes to the T0 tmux
-#           pane; 0 suppresses the push (ndjson append + outbox still happen).
+# Env flags (OI-654, default flipped by ADR-035 §5.3/§9 PR-8):
+#           VNX_RECEIPT_T0_PUSH=0 (default) suppresses the pane-paste push —
+#           ndjson append + outbox still happen; T0 is expected to pull instead
+#           (scripts/receipt_query.py pull, docs/core/DISPATCH_RULES.md §13).
+#           1 re-enables the legacy tmux pane push as a transition escape hatch.
 #           VNX_RECEIPT_DIGEST_THRESHOLD=5 (default) collapses a pending stack
 #           bigger than this into one digest paste instead of N individual ones.
 #           VNX_RECEIPT_VERIFY_MAX_RETRIES=3 (default) caps how many failed
@@ -95,12 +98,13 @@ _deliver_receipt_to_t0_pane() {
             ;;
     esac
 
-    # Push-switch (OI-654): T0's polling on report-files instead of pane pushes
-    # doesn't need the paste. Suppress it entirely — ndjson append already
-    # happened upstream in append_and_track_receipt(), so the audit trail is
-    # intact; only the tmux side-channel notification is skipped.
-    if [ "${VNX_RECEIPT_T0_PUSH:-1}" = "0" ]; then
-        log "INFO" "delivery_mode=suppressed dispatch_id=$dispatch_id (VNX_RECEIPT_T0_PUSH=0)"
+    # Push-switch (OI-654; default flipped OFF by ADR-035 §5.3/§9 PR-8): T0
+    # pulls (scripts/receipt_query.py pull) instead of consuming pane pushes
+    # now. Suppress the paste unless explicitly re-enabled — ndjson append
+    # already happened upstream in append_and_track_receipt(), so the audit
+    # trail is intact; only the tmux side-channel notification is skipped.
+    if [ "${VNX_RECEIPT_T0_PUSH:-0}" != "1" ]; then
+        log "INFO" "delivery_mode=suppressed dispatch_id=$dispatch_id (VNX_RECEIPT_T0_PUSH!=1)"
         return 0
     fi
 
@@ -168,8 +172,8 @@ _rpd_deliver_digest() {
     local oldest_dispatch_id="$2"
     local id_list="$3"
 
-    if [ "${VNX_RECEIPT_T0_PUSH:-1}" = "0" ]; then
-        log "INFO" "delivery_mode=suppressed digest count=$count (VNX_RECEIPT_T0_PUSH=0)"
+    if [ "${VNX_RECEIPT_T0_PUSH:-0}" != "1" ]; then
+        log "INFO" "delivery_mode=suppressed digest count=$count (VNX_RECEIPT_T0_PUSH!=1)"
         return 0
     fi
 

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -59,10 +59,11 @@ PID_FILE="$VNX_PIDS_DIR/receipt_processor.pid"
 RECEIPTS_PENDING_DIR="${VNX_DATA_DIR}/receipts/pending"
 RECEIPTS_PROCESSED_DIR="${VNX_DATA_DIR}/receipts/processed"
 RECEIPT_RETRY_INTERVAL="${VNX_RECEIPT_RETRY_INTERVAL:-10}"  # seconds between pending retry sweeps
-# VNX_RECEIPT_T0_PUSH=1 (default) pushes each receipt to the T0 tmux pane via
-# paste-buffer; 0 suppresses the push entirely — ndjson append + outbox
-# processing still happen (audit trail intact), only the pane notification is
-# skipped. For T0's that poll report-files instead of consuming pane pushes.
+# VNX_RECEIPT_T0_PUSH=0 (default, ADR-035 §5.3/§9 PR-8) suppresses the pane
+# push entirely — ndjson append + outbox processing still happen (audit trail
+# intact), only the pane notification is skipped. T0 pulls instead
+# (scripts/receipt_query.py pull, docs/core/DISPATCH_RULES.md §13). 1
+# re-enables the legacy tmux paste as a transition escape hatch.
 # Read directly (no indirection var) by rp_delivery.sh at delivery time.
 # VNX_RECEIPT_DIGEST_THRESHOLD=5 (default) — once more than this many distinct
 # dispatch_ids are stacked in receipts/pending/, the retry sweep sends ONE

--- a/scripts/receipt_query.py
+++ b/scripts/receipt_query.py
@@ -357,6 +357,13 @@ def compute_digest(
     threshold, §9 PR-8 — the failure isn't a one-off logged-and-forgotten
     event, it stays visible here every time digest runs until it resolves).
 
+    `window` scopes the verdict counts, the counted-warning codes, and the
+    `oi_pending_unresolved` tally — but escalation is computed over EVERY
+    `oi_pending` warning in the ledger, regardless of `window`. An entry
+    older than `window` still needs to escalate once it passes `max_age_days`;
+    scoping escalation to `window` would mean an entry old enough to fall out
+    of the window could never be escalated, defeating the age-based rule.
+
     A line missing `schema_version`/`verdict` entirely (legacy v1, or any
     line the writer never stamped a verdict onto) buckets under an explicit
     `"unknown"` verdict count — never crashes, never silently miscounted as
@@ -370,11 +377,31 @@ def compute_digest(
 
     verdict_counts: Dict[str, int] = {"accept": 0, "investigate": 0, "reject": 0, "unknown": 0}
     counted_codes: Dict[str, int] = {}
-    oi_pending_candidates: List[Dict[str, Any]] = []
+    oi_pending_window_candidates: List[Dict[str, Any]] = []
+    oi_pending_all_candidates: List[Dict[str, Any]] = []
 
     for entry in _iter_ledger(ledger_path):
         ts = _parse_iso8601(entry.get("timestamp"))
-        if ts is None or ts < cutoff:
+        in_window = ts is not None and ts >= cutoff
+
+        for warning in entry.get("warnings") or []:
+            if not isinstance(warning, dict):
+                continue
+            destination = warning.get("destination")
+            code = str(warning.get("code") or "")
+            if destination == "oi_pending":
+                candidate = {
+                    "dispatch_id": entry.get("dispatch_id"),
+                    "code": code,
+                    "timestamp": entry.get("timestamp"),
+                }
+                oi_pending_all_candidates.append(candidate)
+                if in_window:
+                    oi_pending_window_candidates.append(candidate)
+            elif destination == "counted" and code and in_window:
+                counted_codes[code] = counted_codes.get(code, 0) + 1
+
+        if not in_window:
             continue
 
         verdict = entry.get("verdict")
@@ -383,22 +410,12 @@ def compute_digest(
             decision = "unknown"
         verdict_counts[decision] += 1
 
-        for warning in entry.get("warnings") or []:
-            if not isinstance(warning, dict):
-                continue
-            destination = warning.get("destination")
-            code = str(warning.get("code") or "")
-            if destination == "counted" and code:
-                counted_codes[code] = counted_codes.get(code, 0) + 1
-            elif destination == "oi_pending":
-                oi_pending_candidates.append({
-                    "dispatch_id": entry.get("dispatch_id"),
-                    "code": code,
-                    "timestamp": entry.get("timestamp"),
-                })
-
-    unresolved = _unresolved_oi_pending(oi_pending_candidates, open_items_manager_module)
-    escalated = _escalated_oi_pending(unresolved, now, max_age_days)
+    # escalation reads the full (window-independent) set; the tally below
+    # filters that same result down to the window-scoped candidates so the
+    # OI store is only ever loaded once per digest call.
+    all_unresolved = _unresolved_oi_pending(oi_pending_all_candidates, open_items_manager_module)
+    unresolved = [entry for entry in all_unresolved if entry in oi_pending_window_candidates]
+    escalated = _escalated_oi_pending(all_unresolved, now, max_age_days)
     top_counted = sorted(counted_codes.items(), key=lambda kv: (-kv[1], kv[0]))
 
     return {

--- a/scripts/receipt_query.py
+++ b/scripts/receipt_query.py
@@ -27,16 +27,30 @@ rest of the interface plus the §6.4 oi_pending follow-up loop:
                         resolved dispatch_id. No new index, no receipt-shape change.
   digest             — verdict counts (accept/investigate/reject) over a window,
                         the top ``warnings[]`` codes at destination:"counted",
-                        and a second tally — "N warnings met oi_pending zonder
+                        a tally — "N warnings met oi_pending zonder
                         resolutie" (§6.4), computed as a dedup_key join against
                         the CURRENT open-items store, never a rewrite of the
-                        (immutable) receipt line.
+                        (immutable) receipt line, and a further
+                        ``oi_pending_escalated_count`` of those unresolved
+                        entries already past ``--max-age-days`` — the same
+                        read-only age check reconcile-oi-pending applies,
+                        computed here without attempting any write, so an
+                        entry that keeps failing shows up every time digest
+                        runs, not just when someone happens to invoke
+                        reconcile-oi-pending directly (§9 PR-8 fold-in).
   reconcile-oi-pending — scans the ledger for still-unresolved oi_pending
                         warnings and retries add_item_programmatic per entry
-                        using the preserved dedup_key (§6.4). An entry whose
-                        originating receipt is older than --max-age-days and
-                        still fails is reported as escalated — surfaced via
-                        digest, not a new alerting channel.
+                        using the preserved dedup_key (§6.4). A real
+                        add_item_programmatic failure is counted in ``failed``
+                        (distinct from ``still_pending``'s missing-code skips)
+                        and logged to stderr — never a bare swallow (codex
+                        finding folded in from PR-7, §9 PR-8) — while staying
+                        best-effort (one bad entry never crashes the scan). An
+                        entry whose originating receipt is older than
+                        --max-age-days and still fails is reported as
+                        escalated — surfaced via digest's
+                        oi_pending_escalated_count, not a new alerting
+                        channel.
 
 Every subcommand tolerates a mixed v1/v2 ledger: a line missing
 ``schema_version`` is a v1 line, read like any other JSON object — never a
@@ -306,16 +320,42 @@ def _unresolved_oi_pending(
     return unresolved
 
 
+def _escalated_oi_pending(
+    unresolved: List[Dict[str, Any]],
+    now: datetime,
+    max_age_days: float,
+) -> List[Dict[str, Any]]:
+    """§6.4's escalation rule, applied read-only: an unresolved `oi_pending`
+    entry (already computed by `_unresolved_oi_pending` — still no matching
+    open item in the store) whose ORIGINATING receipt is older than
+    `max_age_days` has been failing to reconcile long enough to escalate.
+    No new retry-count store — age is measured from the receipt already on
+    disk (the same rule `reconcile_oi_pending` applies), so this never needs
+    to actually attempt `add_item_programmatic` to know an entry is stuck."""
+    escalated: List[Dict[str, Any]] = []
+    for entry in unresolved:
+        age_days = _age_in_days(entry.get("timestamp"), now)
+        if age_days is not None and age_days >= max_age_days:
+            escalated.append({**entry, "age_days": round(age_days, 2)})
+    return escalated
+
+
 def compute_digest(
     ledger_path: Path,
     *,
     window: str = DEFAULT_DIGEST_WINDOW,
     now: Optional[datetime] = None,
+    max_age_days: float = DEFAULT_RECONCILE_MAX_AGE_DAYS,
     open_items_manager_module: Optional[Any] = None,
 ) -> Dict[str, Any]:
     """`digest` (ADR-035 §5.2/§6.4): verdict counts (accept/investigate/reject)
     over `window`, the top `warnings[]` codes at `destination: "counted"`, and
-    the "N warnings met oi_pending zonder resolutie" tally.
+    the "N warnings met oi_pending zonder resolutie" tally — plus, per §6.4's
+    follow-up obligation ("surfaced via T0 digest, not a new alerting
+    channel"), an `oi_pending_escalated_count` tally of unresolved entries
+    already past `max_age_days` (`reconcile-oi-pending`'s own escalation
+    threshold, §9 PR-8 — the failure isn't a one-off logged-and-forgotten
+    event, it stays visible here every time digest runs until it resolves).
 
     A line missing `schema_version`/`verdict` entirely (legacy v1, or any
     line the writer never stamped a verdict onto) buckets under an explicit
@@ -354,9 +394,11 @@ def compute_digest(
                 oi_pending_candidates.append({
                     "dispatch_id": entry.get("dispatch_id"),
                     "code": code,
+                    "timestamp": entry.get("timestamp"),
                 })
 
     unresolved = _unresolved_oi_pending(oi_pending_candidates, open_items_manager_module)
+    escalated = _escalated_oi_pending(unresolved, now, max_age_days)
     top_counted = sorted(counted_codes.items(), key=lambda kv: (-kv[1], kv[0]))
 
     return {
@@ -365,6 +407,8 @@ def compute_digest(
         "counted_warnings": [{"code": code, "count": count} for code, count in top_counted],
         "oi_pending_unresolved_count": len(unresolved),
         "oi_pending_unresolved": unresolved,
+        "oi_pending_escalated_count": len(escalated),
+        "oi_pending_escalated": escalated,
     }
 
 
@@ -394,9 +438,19 @@ def reconcile_oi_pending(
 
     An entry whose ORIGINATING receipt's own `timestamp` is older than
     `max_age_days` and still fails to promote is reported as escalated in the
-    return value — surfaced via `digest`, not a new alerting channel (§6.4).
-    No new retry-count store: age is measured from the receipt already on
-    disk, not a separately persisted attempt counter.
+    return value — surfaced via `digest`'s `oi_pending_escalated_count`
+    (computed independently, read-only, by `_escalated_oi_pending`), not a
+    new alerting channel (§6.4). No new retry-count store: age is measured
+    from the receipt already on disk, not a separately persisted attempt
+    counter.
+
+    A real `add_item_programmatic` failure (store unreachable/locked, raises)
+    is never a bare log-and-forget: it is counted in `failed` (distinct from
+    `still_pending`'s missing-`code` skips, so a caller can tell "nothing to
+    do" from "this genuinely failed"), and a one-line diagnostic is written to
+    stderr — this scan stays best-effort (it must never crash on one bad
+    entry), but a failure must be visible, not silently swallowed (codex
+    finding folded in from PR-7, §9 PR-8).
     """
     now = now or datetime.now(timezone.utc)
     oim = open_items_manager_module or _load_open_items_manager()
@@ -409,6 +463,7 @@ def reconcile_oi_pending(
 
     reconciled = 0
     still_pending = 0
+    failed = 0
     escalated: List[Dict[str, Any]] = []
 
     for receipt, warning in pending_entries:
@@ -431,8 +486,16 @@ def reconcile_oi_pending(
                 source="reconcile-oi-pending",
             )
             reconciled += 1
-        except Exception as exc:  # noqa: BLE001 — OI store failure must never crash the scan
+        except Exception as exc:  # noqa: BLE001 — best-effort scan must never crash on one
+            # bad entry, but the failure must be counted and logged, never a
+            # silent swallow (codex finding folded in from PR-7, §9 PR-8).
             still_pending += 1
+            failed += 1
+            print(
+                f"reconcile-oi-pending: FAILED to promote dedup_key={code!r} "
+                f"dispatch_id={dispatch_id!r}: {exc}",
+                file=sys.stderr,
+            )
             age_days = _age_in_days(receipt.get("timestamp"), now)
             if age_days is not None and age_days >= max_age_days:
                 escalated.append({
@@ -446,6 +509,7 @@ def reconcile_oi_pending(
         "scanned": len(pending_entries),
         "reconciled": reconciled,
         "still_pending": still_pending,
+        "failed": failed,
         "escalated": escalated,
     }
 
@@ -575,7 +639,7 @@ def _cmd_digest(args: argparse.Namespace) -> int:
     state_dir = Path(args.state_dir)
     ledger = _ledger_path(state_dir)
     try:
-        result = compute_digest(ledger, window=args.window)
+        result = compute_digest(ledger, window=args.window, max_age_days=args.max_age_days)
     except ValueError as exc:
         print(f"error: {exc}", file=sys.stderr)
         return 1
@@ -591,6 +655,8 @@ def _cmd_digest(args: argparse.Namespace) -> int:
         )
         print(f"  counted warnings (top codes): {result['counted_warnings']}")
         print(f"  oi_pending zonder resolutie: {result['oi_pending_unresolved_count']}")
+        print(f"  oi_pending escalated (>{args.max_age_days}d, still failing): "
+              f"{result['oi_pending_escalated_count']}")
     return 0
 
 
@@ -604,7 +670,8 @@ def _cmd_reconcile_oi_pending(args: argparse.Namespace) -> int:
     else:
         print(
             f"scanned={result['scanned']} reconciled={result['reconciled']} "
-            f"still_pending={result['still_pending']} escalated={len(result['escalated'])}"
+            f"still_pending={result['still_pending']} failed={result['failed']} "
+            f"escalated={len(result['escalated'])}"
         )
     return 0
 
@@ -675,10 +742,14 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     p_digest = sub.add_parser(
         "digest",
-        help="verdict counts + counted-warning top codes + oi_pending-unresolved tally",
+        help="verdict counts + counted-warning top codes + oi_pending-unresolved/escalated tallies",
     )
     p_digest.add_argument("--state-dir", required=True)
     p_digest.add_argument("--window", default=DEFAULT_DIGEST_WINDOW)
+    p_digest.add_argument(
+        "--max-age-days", type=float, default=DEFAULT_RECONCILE_MAX_AGE_DAYS,
+        help="same threshold as reconcile-oi-pending's escalation rule (§6.4)",
+    )
     p_digest.add_argument("--json", action="store_true")
     p_digest.set_defaults(func=_cmd_digest)
 

--- a/tests/test_receipt_query.py
+++ b/tests/test_receipt_query.py
@@ -781,3 +781,144 @@ def test_reconcile_oi_pending_cli(tmp_path, capsys):
     out = json.loads(raw[raw.index("{"):])
     assert out["scanned"] == 1
     assert out["reconciled"] == 1
+
+
+# ---------------------------------------------------------------------------
+# §9 PR-8 fold-in — reconcile-oi-pending failure surfacing, never a silent
+# swallow: a real add_item_programmatic failure is counted in `failed`
+# (distinct from `still_pending`'s missing-code skips) and logged to stderr,
+# while the scan itself stays best-effort (one bad entry never crashes it).
+# ---------------------------------------------------------------------------
+
+def test_reconcile_oi_pending_failure_is_counted_and_logged_not_swallowed(tmp_path, capsys):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-22T11:00:00Z",  # 1h old, not escalated
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    class _AlwaysFailingOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise RuntimeError("store still unreachable")
+
+    result = rq.reconcile_oi_pending(
+        ledger, now=now, max_age_days=7.0, open_items_manager_module=_AlwaysFailingOIM(),
+    )
+    assert result["scanned"] == 1
+    assert result["reconciled"] == 0
+    assert result["still_pending"] == 1
+    assert result["failed"] == 1  # a genuine store failure, not a missing-code skip
+    assert result["escalated"] == []  # too recent to escalate yet
+
+    stderr = capsys.readouterr().err
+    assert "worker_permission_violation" in stderr
+    assert "store still unreachable" in stderr
+
+
+def test_reconcile_oi_pending_missing_code_is_not_counted_as_failed(tmp_path):
+    receipt = _v2_with("d1", timestamp="2026-07-22T01:00:00Z")
+    receipt["warnings"] = [{
+        "severity": "blocker", "message": "m", "destination": "oi_pending",
+        "oi_id": None, "reason": "err", "requires_tracking": True,
+    }]
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    result = rq.reconcile_oi_pending(ledger, open_items_manager_module=_NeverCalledOIM())
+    assert result["still_pending"] == 1
+    assert result["failed"] == 0  # skipped before any add_item_programmatic attempt
+
+
+def test_reconcile_oi_pending_cli_reports_failed_count(tmp_path, capsys):
+    receipt = _oi_pending_receipt("d1", "some_check", "2026-07-22T01:00:00Z")
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    class _AlwaysFailingOIM:
+        def add_item_programmatic(self, **kwargs):
+            raise RuntimeError("boom")
+
+    with patch.object(rq, "_load_open_items_manager", return_value=_AlwaysFailingOIM()):
+        rc = rq.main(["reconcile-oi-pending", "--state-dir", str(tmp_path), "--json"])
+    assert rc == 0
+    raw = capsys.readouterr().out
+    out = json.loads(raw[raw.index("{"):])
+    assert out["failed"] == 1
+
+
+# ---------------------------------------------------------------------------
+# digest — oi_pending_escalated_count (§6.4 follow-up obligation, §9 PR-8):
+# a still-unresolved oi_pending warning past --max-age-days shows up in
+# digest every time it runs, computed read-only (no add_item_programmatic
+# retry attempted here — that stays reconcile-oi-pending's job).
+# ---------------------------------------------------------------------------
+
+def test_digest_surfaces_oi_pending_escalated_count_for_stale_entries(tmp_path):
+    oim = _load_oim(tmp_path)
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-01T00:00:00Z",  # 21 days old
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    result = rq.compute_digest(
+        ledger, window="30d", now=now, max_age_days=7.0, open_items_manager_module=oim,
+    )
+    assert result["oi_pending_unresolved_count"] == 1
+    assert result["oi_pending_escalated_count"] == 1
+    assert result["oi_pending_escalated"][0]["dispatch_id"] == "d1"
+    assert result["oi_pending_escalated"][0]["age_days"] >= 7.0
+
+
+def test_digest_does_not_escalate_recent_oi_pending_entries(tmp_path):
+    oim = _load_oim(tmp_path)
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-22T11:00:00Z",  # 1 hour old
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, max_age_days=7.0, open_items_manager_module=oim,
+    )
+    assert result["oi_pending_unresolved_count"] == 1
+    assert result["oi_pending_escalated_count"] == 0
+    assert result["oi_pending_escalated"] == []
+
+
+def test_digest_escalation_drops_out_after_reconcile_resolves_it(tmp_path):
+    oim = _load_oim(tmp_path)
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-01T00:00:00Z",  # 21 days old
+        report_path="reports/d1.md", pr_id="42",
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    before = rq.compute_digest(
+        ledger, window="30d", now=now, max_age_days=7.0, open_items_manager_module=oim,
+    )
+    assert before["oi_pending_escalated_count"] == 1
+
+    result = rq.reconcile_oi_pending(ledger, now=now, open_items_manager_module=oim)
+    assert result["reconciled"] == 1
+
+    after = rq.compute_digest(
+        ledger, window="30d", now=now, max_age_days=7.0, open_items_manager_module=oim,
+    )
+    assert after["oi_pending_escalated_count"] == 0
+    assert after["oi_pending_unresolved_count"] == 0
+
+
+def test_digest_cli_max_age_days_flag(tmp_path, capsys):
+    _write_ledger(tmp_path, _v2_with("d1", timestamp="2026-07-22T01:00:00Z"))
+    rc = rq.main([
+        "digest", "--state-dir", str(tmp_path), "--max-age-days", "3", "--json",
+    ])
+    assert rc == 0
+    out = json.loads(capsys.readouterr().out)
+    assert "oi_pending_escalated_count" in out

--- a/tests/test_receipt_query.py
+++ b/tests/test_receipt_query.py
@@ -889,6 +889,28 @@ def test_digest_does_not_escalate_recent_oi_pending_entries(tmp_path):
     assert result["oi_pending_escalated"] == []
 
 
+def test_digest_escalates_oi_pending_entry_outside_digest_window(tmp_path):
+    # Regression guard: escalation must scope the FULL oi_pending set, not
+    # the digest-window-filtered one. An entry 21 days old is well outside a
+    # 24h window (so the window-scoped tally excludes it), but it is past
+    # max_age_days=7 and must still show up as escalated.
+    oim = _load_oim(tmp_path)
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    receipt = _oi_pending_receipt(
+        "d1", "worker_permission_violation", "2026-07-01T00:00:00Z",  # 21 days old
+    )
+    _write_ledger(tmp_path, receipt)
+    ledger = tmp_path / rq.LEDGER_NAME
+
+    result = rq.compute_digest(
+        ledger, window="24h", now=now, max_age_days=7.0, open_items_manager_module=oim,
+    )
+    assert result["oi_pending_unresolved_count"] == 0  # outside the window -> tally excludes it
+    assert result["oi_pending_escalated_count"] == 1  # but escalation is window-independent
+    assert result["oi_pending_escalated"][0]["dispatch_id"] == "d1"
+    assert result["oi_pending_escalated"][0]["age_days"] >= 7.0
+
+
 def test_digest_escalation_drops_out_after_reconcile_resolves_it(tmp_path):
     oim = _load_oim(tmp_path)
     now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_rp_delivery_gates.sh
+++ b/tests/test_rp_delivery_gates.sh
@@ -1,13 +1,20 @@
 #!/usr/bin/env bash
 # Tests for rp_delivery.sh (OI-654: submit-verify + dedupe + digest + push-switch)
 #
+# ADR-035 §5.3/§9 PR-8 flipped VNX_RECEIPT_T0_PUSH's default from 1 (push) to 0
+# (suppressed — T0 pulls instead, scripts/receipt_query.py pull). Tests that
+# exercise the tmux paste path (submit-verify, dedupe, digest, force-process,
+# load-buffer failure) now explicitly `export VNX_RECEIPT_T0_PUSH=1` — they are
+# testing the transition-escape-hatch push mechanism itself, not the default.
+#
 # Coverage:
-#   - Baseline: default env (push=1, unset) still pastes + verifies + processes (no regression)
-#   - Submit-verify: empty input line after Enter -> verified -> pending file moves to processed
-#   - Submit-verify: non-empty input line after Enter -> NOT verified -> stays pending, WARN logged
-#   - Dedupe: 3 pending files, same dispatch_id -> exactly 1 paste-buffer call, all 3 processed
-#   - Digest: pending dispatches over threshold -> exactly 1 digest paste, all processed
-#   - Push-switch: VNX_RECEIPT_T0_PUSH=0 -> zero tmux calls, item still moves to processed (suppressed)
+#   - Baseline: default env (push unset -> 0, suppressed) makes zero tmux calls, still processed
+#   - Submit-verify (push=1): empty input line after Enter -> verified -> pending file moves to processed
+#   - Submit-verify (push=1): non-empty input line after Enter -> NOT verified -> stays pending, WARN logged
+#   - Dedupe (push=1): 3 pending files, same dispatch_id -> exactly 1 paste-buffer call, all 3 processed
+#   - Digest (push=1): pending dispatches over threshold -> exactly 1 digest paste, all processed
+#   - Push-switch: VNX_RECEIPT_T0_PUSH=0 (explicit, same as default) -> zero tmux calls, still processed
+#   - Push-switch: VNX_RECEIPT_T0_PUSH=1 (explicit override) -> pane push re-enabled
 #
 # Mirrors the function-override tmux mock pattern from tests/test_input_mode_guard.sh.
 
@@ -112,24 +119,25 @@ source "$PROJECT_ROOT/scripts/lib/receipt_processor/rp_extract.sh"
 source "$PROJECT_ROOT/scripts/lib/receipt_processor/rp_delivery.sh"
 
 # ===========================================================================
-# Test 0: Baseline — default env (VNX_RECEIPT_T0_PUSH unset) still delivers
+# Test 0: Baseline — default env (VNX_RECEIPT_T0_PUSH unset -> 0) is suppressed
 # ===========================================================================
 reset_mocks
 write_pending "d-000-1.json" "d-000"
-set_capture_response ""   # empty input line -> verified
+set_capture_response ""   # irrelevant when suppressed — never reaches capture-pane
 _retry_pending_receipts
 
-assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
-    "T0: baseline (push unset) sends exactly 1 paste-buffer"
+assert_eq "0" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T0: baseline (push unset, new default) sends zero paste-buffer calls"
 assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
-    "T0: baseline pending item moved to processed"
+    "T0: baseline pending item still moved to processed (suppressed = success)"
 assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
     "T0: baseline pending dir empty after delivery"
 
 # ===========================================================================
-# Test 1: Submit-verify success — empty input line -> processed
+# Test 1: Submit-verify success (push=1) — empty input line -> processed
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-101-1.json" "d-101"
 set_capture_response ""
 _retry_pending_receipts
@@ -138,11 +146,13 @@ assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
     "T1: verified-empty input line -> item moved to processed"
 assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
     "T1: verified-empty input line -> pending dir empty"
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 2: Submit-verify failure — non-empty input line -> stays pending
+# Test 2: Submit-verify failure (push=1) — non-empty input line -> stays pending
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-102-1.json" "d-102"
 set_capture_response "Report: /tmp/r.md"   # residual receipt text still in input line
 _retry_pending_receipts
@@ -153,11 +163,13 @@ assert_eq "1" "$(count_files "$RECEIPTS_PENDING_DIR")" \
     "T2: unverified (non-empty input line) -> item stays pending"
 assert_file_contains "$PROCESSING_LOG" "Submit-verify failed" \
     "T2: WARN logged for unverified submit"
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 3: Dedupe — 3 pending files, same dispatch_id -> 1 delivery
+# Test 3: Dedupe (push=1) — 3 pending files, same dispatch_id -> 1 delivery
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-dup-1.json" "d-dup"
 write_pending "d-dup-2.json" "d-dup"
 write_pending "d-dup-3.json" "d-dup"
@@ -172,11 +184,13 @@ assert_eq "0" "$(count_files "$RECEIPTS_PENDING_DIR")" \
     "T3: pending dir empty after deduped delivery"
 assert_file_contains "$PROCESSING_LOG" "Deduped 3 pending receipts for dispatch_id=d-dup" \
     "T3: dedupe logged"
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 4: Digest — 6 distinct pending dispatches (> default threshold 5) -> 1 digest
+# Test 4: Digest (push=1) — 6 distinct pending dispatches (> default threshold 5) -> 1 digest
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-digest-1.json" "d-digest-1"
 write_pending "d-digest-2.json" "d-digest-2"
 write_pending "d-digest-3.json" "d-digest-3"
@@ -194,11 +208,13 @@ assert_file_contains "$MOCK_LOADED_BUFFER" "RECEIPT-DIGEST: 6 receipts pending" 
     "T4: digest message states the correct count"
 assert_file_contains "$MOCK_LOADED_BUFFER" "oudste: d-digest-1" \
     "T4: digest message names the oldest dispatch_id"
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 4b: Digest threshold is configurable via VNX_RECEIPT_DIGEST_THRESHOLD
+# Test 4b: Digest threshold is configurable via VNX_RECEIPT_DIGEST_THRESHOLD (push=1)
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 export VNX_RECEIPT_DIGEST_THRESHOLD=1
 write_pending "d-cfg-1.json" "d-cfg-1"
 write_pending "d-cfg-2.json" "d-cfg-2"
@@ -208,6 +224,7 @@ _retry_pending_receipts
 assert_file_contains "$MOCK_LOADED_BUFFER" "RECEIPT-DIGEST" \
     "T4b: lowered threshold (1) triggers digest for just 2 dispatches"
 unset VNX_RECEIPT_DIGEST_THRESHOLD
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
 # Test 5: Push-switch — VNX_RECEIPT_T0_PUSH=0 -> zero tmux calls, still processed
@@ -229,7 +246,9 @@ assert_file_contains "$PROCESSING_LOG" "delivery_mode=suppressed dispatch_id=d-p
 unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 6: Push-switch default (unset) behaves exactly like push=1 (no surprise)
+# Test 6: Push-switch default (unset) behaves like push=0 — suppressed
+# (ADR-035 §5.3/§9 PR-8 flipped the default; §5.3 formalizes the operator's
+# post-#1178 practice into the script's own baked-in default)
 # ===========================================================================
 reset_mocks
 receipt_json='{"dispatch_id":"d-push-default","terminal":"T2","status":"success","event_type":"task_complete","timestamp":"2026-07-16T10:00:00Z","report_path":"/tmp/r.md"}'
@@ -237,16 +256,35 @@ extract_receipt_fields "$receipt_json"
 set_capture_response ""
 send_receipt_to_t0 "$receipt_json" "T2"
 
-assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
-    "T6: default (VNX_RECEIPT_T0_PUSH unset) still pastes — no behavior change"
+assert_eq "0" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T6: default (VNX_RECEIPT_T0_PUSH unset) makes zero paste-buffer calls (new default)"
 assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
-    "T6: default push delivers and processes normally"
+    "T6: default-suppressed delivery still moves item to processed"
+assert_file_contains "$PROCESSING_LOG" "delivery_mode=suppressed dispatch_id=d-push-default" \
+    "T6: default suppressed delivery_mode logged"
 
 # ===========================================================================
-# Test 7 (finding 4): verify-fail cap -> force-processed after N retries,
-# no (N+1)th paste attempted
+# Test 6b: explicit VNX_RECEIPT_T0_PUSH=1 override re-enables the pane push
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
+receipt_json='{"dispatch_id":"d-push-on","terminal":"T2","status":"success","event_type":"task_complete","timestamp":"2026-07-16T10:00:00Z","report_path":"/tmp/r.md"}'
+extract_receipt_fields "$receipt_json"
+set_capture_response ""
+send_receipt_to_t0 "$receipt_json" "T2"
+
+assert_eq "1" "$(grep -c '^paste-buffer$' "$MOCK_CALL_LOG")" \
+    "T6b: explicit VNX_RECEIPT_T0_PUSH=1 makes exactly 1 paste-buffer call"
+assert_eq "1" "$(count_files "$RECEIPTS_PROCESSED_DIR")" \
+    "T6b: explicit push=1 delivers and processes normally"
+unset VNX_RECEIPT_T0_PUSH
+
+# ===========================================================================
+# Test 7 (finding 4, push=1): verify-fail cap -> force-processed after N
+# retries, no (N+1)th paste attempted
+# ===========================================================================
+reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-cap-1.json" "d-cap"
 set_capture_response "Report: /tmp/r.md"   # always unverified
 
@@ -297,10 +335,11 @@ assert_file_contains "$PROCESSING_LOG" "jq not found" \
     "T8: jq-absence error logged"
 
 # ===========================================================================
-# Test 9 (finding 1a): load-buffer failure -> paste sequence aborts,
+# Test 9 (finding 1a, push=1): load-buffer failure -> paste sequence aborts,
 # item stays pending
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-lb-1.json" "d-lb"
 touch "$MOCK_LOADBUFFER_FAIL_FLAG"
 set_capture_response ""
@@ -315,11 +354,13 @@ assert_eq "1" "$(count_files "$RECEIPTS_PENDING_DIR")" \
 assert_file_contains "$PROCESSING_LOG" "Failed to load-buffer" \
     "T9: load-buffer failure logged"
 rm -f "$MOCK_LOADBUFFER_FAIL_FLAG"
+unset VNX_RECEIPT_T0_PUSH
 
 # ===========================================================================
-# Test 10 (finding 3): digest message includes the dispatch_id list
+# Test 10 (finding 3, push=1): digest message includes the dispatch_id list
 # ===========================================================================
 reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
 write_pending "d-idlist-1.json" "d-idlist-1"
 write_pending "d-idlist-2.json" "d-idlist-2"
 write_pending "d-idlist-3.json" "d-idlist-3"


### PR DESCRIPTION
## Summary

Receipt-v2 PR-8 (ADR-035 §5.3, §9 PR-8) — three parts:

- **A. Pull cadence, documented.** T0's cycle step 0 (`scripts/receipt_query.py pull` — read since cursor, `--seed-now` to skip backlog once, `--peek`, then `digest`/`reconcile-oi-pending` on the same cadence) is now a git-tracked, editable section: `docs/core/DISPATCH_RULES.md` §13. `.claude/skills/` is lane-read-only (OI-188), so the skill-file mirror of this (parked commit `24f71d22`'s intent) is called out as an operator follow-up rather than forced through a lane edit. Cross-reference added in `docs/operations/RECEIPT_PIPELINE.md` (no v2.0.0 rewrite — that's PR-9).
- **B. Push retired behind the existing flag, not removed.** `rp_delivery.sh`'s `VNX_RECEIPT_T0_PUSH` default flips from `1` (push) to `0` (suppressed) — formalizing the operator's post-#1178 practice into the script's own default. The flag and the pane-paste code path (`_deliver_receipt_to_t0_pane`, `_rpd_deliver_digest`) stay as the transition escape hatch (`VNX_RECEIPT_T0_PUSH=1` re-enables it); removing them outright is a separate follow-up PR (§8). `send_receipt_to_t0`'s write-first durability half is untouched.
- **C. reconcile-oi-pending failure surfacing (PR-7 codex finding, folded in).** The bare `except Exception` in `reconcile_oi_pending` no longer silently swallows a real `add_item_programmatic` failure: it's counted in a new, distinct `failed` field (separate from `still_pending`'s missing-`code` skips) and logged to stderr. `digest` gains `oi_pending_escalated_count`/`oi_pending_escalated` — computed read-only from the same age-threshold rule `reconcile-oi-pending` already applies — so a stuck `oi_pending` warning stays visible every time `digest` runs, not just when someone happens to invoke `reconcile-oi-pending` directly. The scan stays best-effort (one bad entry never crashes it).

## Test plan

- [x] A: `docs/core/DISPATCH_RULES.md` §13 exists (git-tracked, editable) with the pull → digest → reconcile-oi-pending cadence.
- [x] B: `VNX_RECEIPT_T0_PUSH` unset/`0` → zero tmux paste calls (verified via `tests/test_rp_delivery_gates.sh` T0/T5/T6); `=1` → pane push works (T1–T4, T6b, T7, T9, T10). `bash -n` clean on both modified shell files.
- [x] C: `reconcile-oi-pending` with a forced OI-store failure → scan doesn't crash, `failed > 0`, stderr carries the diagnostic, `digest`'s `oi_pending_escalated_count` reflects a stale unresolved entry past `--max-age-days` and drops to 0 once reconciled.
- [x] `bash tests/test_rp_delivery_gates.sh` → 42 passed, 0 failed
- [x] `VNX_CURRENT_DISPATCH_ID= python3 -m pytest tests/test_receipt_query.py tests/test_receipt_provenance.py tests/test_warning_destination.py tests/test_open_items_dedup_status.py -q` → 151 passed (unsetting `VNX_CURRENT_DISPATCH_ID` avoids a pre-existing, unrelated env-induced failure in `test_receipt_provenance.py` noted in the PR-7 report; with it left at this worker's own dispatch-id value, 3 of those pre-existing tests fail exactly as before this change)
- [x] Push verified: `git ls-remote origin dispatch/20260722-rv2-pr8-pull-cutover` → `dc16643fd13767ea5a1f5ed7a8c07058e34d1d6e`, matches local HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)