### PR TITLE
feat(oi-bridge-tick): wire OI->track bridge into the supervisor tick

### DIFF
--- a/scripts/dispatcher_minimal.sh
+++ b/scripts/dispatcher_minimal.sh
@@ -602,6 +602,7 @@ process_dispatches() {
     _cleanup_stuck_dispatches
     _unified_supervisor_lease_sweep_tick
     _maybe_auto_seed_tracks
+    _maybe_oi_bridge_tick
     _maybe_objective_reconcile
     _maybe_learning_cycle
 

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -97,10 +97,17 @@ _maybe_oi_bridge_tick() {
         --project-id "$VNX_PROJECT_ID" \
         --state-dir "$STATE_DIR" \
         >> "$log_file" 2>&1 || rc=$?
-    if [[ "$rc" == "0" || "$rc" == "4" ]]; then
-        echo "1" > "$fresh_file"
+    # Exit 4 is import_open_items_to_tracks.py's own exit contract for "the
+    # track_open_items commit succeeded, but the post-commit ledger-emit step
+    # only warned" — the write already landed, so freshness still holds. Any
+    # other non-zero exit means the commit itself is suspect and freshness
+    # must fail closed.
+    local -r OI_BRIDGE_RC_LEDGER_WARN=4
+    if [[ "$rc" == "0" || "$rc" == "$OI_BRIDGE_RC_LEDGER_WARN" ]]; then
+        printf '%s' "1" > "$fresh_file.tmp.$$" && mv -f "$fresh_file.tmp.$$" "$fresh_file"
+        log "V-OI-BRIDGE INFO: OI bridge tick succeeded (exit $rc); freshness=1 written to $fresh_file"
     else
-        echo "0" > "$fresh_file"
+        printf '%s' "0" > "$fresh_file.tmp.$$" && mv -f "$fresh_file.tmp.$$" "$fresh_file"
         log "V-OI-BRIDGE WARN: OI bridge tick failed (exit $rc); see $log_file — reconcile-apply is gated this cycle until the next successful bridge run"
     fi
     echo "$now" > "$state_file"

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -17,6 +17,7 @@
 #   VNX_LEASE_SWEEP_INTERVAL_SEC   — seconds between lease_sweep calls; default 30
 #   VNX_LEARNING_ENABLED           — "1" enables the daily learning cycle tick; default 0 (off)
 #   VNX_LEARNING_CYCLE_INTERVAL    — seconds between learning cycle runs; default 86400 (daily)
+#   VNX_OI_BRIDGE_INTERVAL         — seconds between OI→track bridge runs; default 900 (D1)
 
 # _maybe_runtime_supervise — throttled RuntimeSupervisor.supervise_all() tick (SUP-PR3).
 # Invokes scripts/lib/runtime_supervise.py at most once per
@@ -55,6 +56,56 @@ _maybe_auto_seed_tracks() {
         >> "$log_file" 2>&1 || true
 }
 
+# _maybe_oi_bridge_tick — throttled OI→track bridge tick (D1, oi-bridge-continuous).
+# Invokes scripts/import_open_items_to_tracks.py at most once per
+# VNX_OI_BRIDGE_INTERVAL seconds when VNX_SUPERVISOR_MODE=unified — the SAME
+# gating condition as _maybe_objective_reconcile (no separate divergent flag).
+# Called BEFORE _maybe_objective_reconcile in process_dispatches() so the
+# reconciler's derived_status / close_track_if_done blocker-check reads
+# freshly-synced track_open_items in the same tick. The bridge already dedupes
+# on (project_id, oi_id) (R4.4), so a repeated run is idempotent — no duplicate
+# track_open_items rows.
+#
+# Best-effort: a bridge failure never crashes the supervisor. It DOES persist a
+# freshness signal at $STATE_DIR/.oi_bridge_fresh ("1" iff the run's exit code
+# means track_open_items committed successfully — 0 clean, or 4 which is only a
+# post-commit ledger-emit warning per import_open_items_to_tracks.py's own exit
+# contract; any other exit code, or the python3 invocation failing outright,
+# writes "0"). _maybe_objective_reconcile reads this file before adding --apply
+# so auto-close never trusts a track_open_items snapshot a failed bridge run
+# left stale (safety-critical — see claudedocs/plan-oi-bridge-continuous.md).
+# Default (unset/legacy VNX_SUPERVISOR_MODE) = no behaviour change.
+_maybe_oi_bridge_tick() {
+    [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
+    local interval="${VNX_OI_BRIDGE_INTERVAL:-900}"
+    local state_file="$STATE_DIR/.last_oi_bridge_ts"
+    local fresh_file="$STATE_DIR/.oi_bridge_fresh"
+    local now last
+    now=$(date +%s)
+    last=0
+    if [[ -f "$state_file" ]]; then
+        last=$(cat "$state_file" 2>/dev/null || echo 0)
+        [[ "$last" =~ ^[0-9]+$ ]] || last=0
+    fi
+    if (( now - last < interval )); then
+        return 0
+    fi
+    local log_file="$VNX_LOGS_DIR/oi_bridge.log"
+    mkdir -p "$(dirname "$log_file")"
+    local rc=0
+    python3 "$VNX_DIR/scripts/import_open_items_to_tracks.py" \
+        --project-id "$VNX_PROJECT_ID" \
+        --state-dir "$STATE_DIR" \
+        >> "$log_file" 2>&1 || rc=$?
+    if [[ "$rc" == "0" || "$rc" == "4" ]]; then
+        echo "1" > "$fresh_file"
+    else
+        echo "0" > "$fresh_file"
+        log "V-OI-BRIDGE WARN: OI bridge tick failed (exit $rc); see $log_file — reconcile-apply is gated this cycle until the next successful bridge run"
+    fi
+    echo "$now" > "$state_file"
+}
+
 # _maybe_objective_reconcile — throttled git-grounded reconcile tick (D4).
 # Invokes `objective reconcile` at most once per VNX_OBJECTIVE_RECONCILE_INTERVAL seconds
 # when VNX_SUPERVISOR_MODE=unified. Auto-close is ON BY DEFAULT (operator directive
@@ -64,6 +115,14 @@ _maybe_auto_seed_tracks() {
 # default keeps the horizon in sync with git reality; the streak is still computed for
 # observability but no longer gates the flip. Best-effort (|| true); logged to
 # objective_reconcile.log. Default (unset/legacy VNX_SUPERVISOR_MODE) = no behaviour change.
+#
+# D1 bridge-freshness gate: --apply is additionally conditioned on
+# $STATE_DIR/.oi_bridge_fresh == "1" (written by _maybe_oi_bridge_tick, which
+# runs earlier in the same process_dispatches() cycle). A missing/failed/
+# unattempted bridge signal fails CLOSED — reconcile still runs (advisory
+# derived_status refresh + summary/history), it just withholds --apply for
+# this cycle rather than auto-closing against a track_open_items snapshot that
+# may not reflect the current open-items store.
 _maybe_objective_reconcile() {
     [[ "${VNX_SUPERVISOR_MODE:-legacy}" == "unified" ]] || return 0
     local interval="${VNX_OBJECTIVE_RECONCILE_INTERVAL:-900}"
@@ -87,7 +146,16 @@ _maybe_objective_reconcile() {
         --state-dir "$STATE_DIR"
     )
     if [[ "${VNX_AUTO_CLOSE:-1}" != "0" ]]; then
-        cmd+=(--apply)
+        local oi_bridge_fresh="0"
+        local fresh_file="$STATE_DIR/.oi_bridge_fresh"
+        if [[ -f "$fresh_file" ]]; then
+            oi_bridge_fresh=$(cat "$fresh_file" 2>/dev/null || echo 0)
+        fi
+        if [[ "$oi_bridge_fresh" == "1" ]]; then
+            cmd+=(--apply)
+        else
+            log "V-OI-BRIDGE WARN: skipping --apply for this objective-reconcile tick — OI bridge freshness signal is '$oi_bridge_fresh' (expected '1'); auto-close withheld until the next successful bridge run"
+        fi
     fi
     "${cmd[@]}" >> "$log_file" 2>&1 || true
     echo "$now" > "$state_file"

--- a/tests/test_dispatcher_resilience.py
+++ b/tests/test_dispatcher_resilience.py
@@ -64,6 +64,9 @@ def _run_scan(scenario_setup: str) -> subprocess.CompletedProcess:
         _cleanup_stuck_dispatches() { :; }
         _unified_supervisor_lease_sweep_tick() { :; }
         _maybe_auto_seed_tracks() { :; }
+        _maybe_oi_bridge_tick() { :; }
+        _maybe_objective_reconcile() { :; }
+        _maybe_learning_cycle() { :; }
         extract_agent_role() { echo "backend-developer"; }
 
         PENDING_DIR="$1"

--- a/tests/test_oi_bridge_supervisor_tick.py
+++ b/tests/test_oi_bridge_supervisor_tick.py
@@ -249,6 +249,77 @@ def test_bridge_tick_failure_survives_and_marks_not_fresh(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# Freshness-state write is atomic (tmp+rename), never a truncating redirect
+# ---------------------------------------------------------------------------
+
+def test_bridge_tick_writes_freshness_file_via_atomic_rename(tmp_path):
+    """A crash/kill mid-write must never leave a corrupt/empty
+    $STATE_DIR/.oi_bridge_fresh for _maybe_objective_reconcile to read as an
+    auto-close green light. The write MUST go through tmp+rename, not a bare
+    truncating `>` redirect straight onto the canonical path."""
+    source = TICKS_SH.read_text()
+    match = re.search(
+        r"^_maybe_oi_bridge_tick\(\) \{\n.*?^\}\n", source, re.MULTILINE | re.DOTALL,
+    )
+    assert match, "could not locate _maybe_oi_bridge_tick() in dispatcher_supervisor_ticks.sh"
+    body = match.group(0)
+
+    # The old buggy pattern must be gone.
+    assert 'echo "1" > "$fresh_file"' not in body
+    assert 'echo "0" > "$fresh_file"' not in body
+
+    # The new pattern must be present: write to a tmp sibling, then rename.
+    assert ".tmp.$$" in body, "freshness write must land on a tmp sibling first"
+    assert "mv -f" in body, "freshness write must complete via an atomic rename"
+
+    # Functional check: a real tick still produces the correct final content
+    # and leaves no stray tmp file behind.
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+    _seed_blocking_oi(state_dir)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OI_BRIDGE_INTERVAL"] = "0"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc.returncode == 0, proc.stderr
+
+    fresh_file = state_dir / ".oi_bridge_fresh"
+    assert fresh_file.read_text().strip() == "1"
+
+    stray_tmp = list(state_dir.glob(".oi_bridge_fresh.tmp.*"))
+    assert stray_tmp == [], f"tmp file(s) left behind after rename: {stray_tmp}"
+
+    log_capture = Path(env["VNX_LOG_CAPTURE"]).read_text()
+    assert "freshness=1 written" in log_capture
+
+
+def test_bridge_tick_failure_writes_freshness_via_atomic_rename_too(tmp_path):
+    """The '0' (not-fresh) branch must use the same atomic tmp+rename path,
+    not just the '1' (fresh) branch."""
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+    # No open_items.json — bridge failure (exit 3), same as
+    # test_bridge_tick_failure_survives_and_marks_not_fresh.
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OI_BRIDGE_INTERVAL"] = "0"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc.returncode == 0, proc.stderr
+
+    fresh_file = state_dir / ".oi_bridge_fresh"
+    assert fresh_file.read_text().strip() == "0"
+
+    stray_tmp = list(state_dir.glob(".oi_bridge_fresh.tmp.*"))
+    assert stray_tmp == [], f"tmp file(s) left behind after rename: {stray_tmp}"
+
+
+# ---------------------------------------------------------------------------
 # Reconcile freshness gate: --apply withheld unless bridge signal == "1"
 # ---------------------------------------------------------------------------
 

--- a/tests/test_oi_bridge_supervisor_tick.py
+++ b/tests/test_oi_bridge_supervisor_tick.py
@@ -1,0 +1,389 @@
+"""tests/test_oi_bridge_supervisor_tick.py — D1 (oi-bridge-continuous PR-1).
+
+Verifies the OI→track bridge is wired into the dispatcher SUPERVISOR tick
+(scripts/lib/dispatcher_supervisor_ticks.sh: _maybe_oi_bridge_tick), NOT
+RoadmapManager.autopilot_tick() (default-off, no continuous cadence):
+
+  * flag-gated: VNX_SUPERVISOR_MODE!=unified is a no-op (bit-identical legacy).
+  * a new OI with a valid pr_ref is bridged into track_open_items by one tick
+    call; a second tick call makes no duplicate row (idempotent, R4.4).
+  * a bridge failure (malformed/absent open_items.json) never crashes the
+    supervisor (best-effort, survives `set -euo pipefail`) and writes the
+    freshness signal ($STATE_DIR/.oi_bridge_fresh) to "0".
+  * _maybe_objective_reconcile withholds --apply when the bridge freshness
+    signal is not "1" (missing, or explicitly "0") — the safety-critical
+    bridge-failure <-> reconcile-freshness coupling — and includes --apply
+    once the signal reads "1".
+  * process_dispatches() calls the bridge tick BEFORE the reconcile tick (the
+    bridge must run first so the reconciler's derived_status / blocker-check
+    reads freshly-synced track_open_items in the same tick).
+
+Real bridge script + real (temp) SQLite DB — no mocking of
+import_open_items_to_tracks.py itself (out of scope for D1: only the caller
+changed). The reconcile leg uses a stub `python3` on PATH to capture the
+built command line without running the (already independently tested)
+objective_reconcile machinery.
+"""
+from __future__ import annotations
+
+import os
+import re
+import sqlite3
+import stat
+import subprocess
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TICKS_SH = REPO_ROOT / "scripts" / "lib" / "dispatcher_supervisor_ticks.sh"
+DISPATCHER_SH = REPO_ROOT / "scripts" / "dispatcher_minimal.sh"
+MIGRATIONS = REPO_ROOT / "schemas" / "migrations"
+
+_LIB = REPO_ROOT / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+PROJECT_ID = "test-oi-bridge-tick"
+
+
+# ---------------------------------------------------------------------------
+# DB fixture (mirrors tests/test_oi_track_bridge.py _build_db_v30)
+# ---------------------------------------------------------------------------
+
+def _build_db_v30(state_dir: Path) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT,
+            occurred_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            project_id TEXT
+        )
+    """)
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+    ]:
+        sql = (MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+
+
+def _link_rows(state_dir: Path, oi_id: str) -> list:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.row_factory = sqlite3.Row
+    rows = [dict(r) for r in conn.execute(
+        "SELECT track_id, link_type, resolved_at FROM track_open_items "
+        "WHERE project_id = ? AND oi_id = ? ORDER BY track_id",
+        (PROJECT_ID, oi_id),
+    )]
+    conn.close()
+    return rows
+
+
+# ---------------------------------------------------------------------------
+# Bash harness: source the real ticks file, call the real functions
+# ---------------------------------------------------------------------------
+
+def _base_env(state_dir: Path, tmp_path: Path) -> dict:
+    env = dict(os.environ)
+    env["VNX_SUPERVISOR_MODE"] = "unified"
+    env["STATE_DIR"] = str(state_dir)
+    env["VNX_LOGS_DIR"] = str(tmp_path / "logs")
+    env["VNX_DIR"] = str(REPO_ROOT)
+    env["VNX_DATA_DIR"] = str(state_dir.parent)
+    env["VNX_PROJECT_ID"] = PROJECT_ID
+    return env
+
+
+def _run_bash(body: str, env: dict) -> subprocess.CompletedProcess:
+    """Source the real dispatcher_supervisor_ticks.sh and run `body` under
+    `set -euo pipefail` — a bridge failure that trips an unguarded bare
+    command would abort here before SURVIVED prints (best-effort regression)."""
+    script = textwrap.dedent(f"""\
+        set -euo pipefail
+        log() {{ printf '[log] %s\\n' "$*" >> "$VNX_LOG_CAPTURE"; }}
+        source "{TICKS_SH}"
+        {body}
+        echo "SURVIVED:$?"
+        """)
+    return subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, env=env, timeout=30,
+    )
+
+
+def _seed_blocking_oi(state_dir: Path, *, oi_id: str = "OI-1", pr_ref: str = "#100") -> None:
+    tracks_lib.create_track(
+        state_dir, "T-bridge", PROJECT_ID, "T-bridge", "goal",
+        phase="active", pr_ref=pr_ref,
+    )
+    import json
+    (state_dir / "open_items.json").write_text(
+        json.dumps({"items": [
+            {"id": oi_id, "severity": "blocker", "status": "open",
+             "title": "blocking item", "pr_id": pr_ref},
+        ]}),
+        encoding="utf-8",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Gating: legacy mode is a no-op
+# ---------------------------------------------------------------------------
+
+def test_bridge_tick_noop_in_legacy_mode(tmp_path):
+    """VNX_SUPERVISOR_MODE unset/legacy: the bridge never runs, no state/fresh files."""
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+    _seed_blocking_oi(state_dir)
+
+    env = _base_env(state_dir, tmp_path)
+    env.pop("VNX_SUPERVISOR_MODE", None)  # legacy (unset)
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc.returncode == 0, proc.stderr
+    assert "SURVIVED:0" in proc.stdout
+
+    assert not (state_dir / ".oi_bridge_fresh").exists()
+    assert _link_rows(state_dir, "OI-1") == []
+
+
+# ---------------------------------------------------------------------------
+# Bridge tick: links + idempotent second tick
+# ---------------------------------------------------------------------------
+
+def test_bridge_tick_links_new_oi_and_second_tick_is_idempotent(tmp_path):
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+    _seed_blocking_oi(state_dir)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OI_BRIDGE_INTERVAL"] = "0"  # never throttled within this test
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    # First tick — links the blocking OI.
+    proc1 = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc1.returncode == 0, proc1.stderr
+    assert "SURVIVED:0" in proc1.stdout
+
+    rows = _link_rows(state_dir, "OI-1")
+    assert len(rows) == 1
+    assert rows[0]["track_id"] == "T-bridge"
+    assert rows[0]["link_type"] == "blocks"
+    assert rows[0]["resolved_at"] is None
+
+    fresh_file = state_dir / ".oi_bridge_fresh"
+    assert fresh_file.read_text().strip() == "1"
+
+    # Second tick — idempotent, no duplicate row.
+    proc2 = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc2.returncode == 0, proc2.stderr
+    assert "SURVIVED:0" in proc2.stdout
+
+    rows2 = _link_rows(state_dir, "OI-1")
+    assert len(rows2) == 1, "second tick must not create a duplicate track_open_items row"
+    assert fresh_file.read_text().strip() == "1"
+
+
+# ---------------------------------------------------------------------------
+# Bridge failure: survives, freshness signal flips to "0"
+# ---------------------------------------------------------------------------
+
+def test_bridge_tick_failure_survives_and_marks_not_fresh(tmp_path):
+    """No open_items.json → BridgeSourceError (CLI exit 3). The tick must not
+    crash the supervisor (best-effort) and must persist fresh="0"."""
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+    # Deliberately no open_items.json written — source absent (C-N1, exit 3).
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OI_BRIDGE_INTERVAL"] = "0"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc.returncode == 0, f"bridge failure must not crash the tick: {proc.stderr}"
+    assert "SURVIVED:0" in proc.stdout
+
+    fresh_file = state_dir / ".oi_bridge_fresh"
+    assert fresh_file.exists()
+    assert fresh_file.read_text().strip() == "0"
+
+    log_capture = Path(env["VNX_LOG_CAPTURE"]).read_text()
+    assert "WARN" in log_capture and "OI bridge tick failed" in log_capture
+
+
+# ---------------------------------------------------------------------------
+# Reconcile freshness gate: --apply withheld unless bridge signal == "1"
+# ---------------------------------------------------------------------------
+
+def _fake_python3(tmp_path: Path, capture_file: Path) -> Path:
+    """A stub `python3` that captures argv (for planning_cli.py invocations
+    only) and exits 0, so the reconcile leg's --apply gating can be asserted
+    without running the (separately, exhaustively tested) real reconcile CLI."""
+    bin_dir = tmp_path / "fakebin"
+    bin_dir.mkdir(parents=True, exist_ok=True)
+    stub = bin_dir / "python3"
+    stub.write_text(textwrap.dedent(f"""\
+        #!/bin/bash
+        printf '%s\\n' "$*" >> "{capture_file}"
+        exit 0
+        """))
+    stub.chmod(stub.stat().st_mode | stat.S_IEXEC | stat.S_IXGRP | stat.S_IXOTH)
+    return bin_dir
+
+
+def test_reconcile_withholds_apply_when_bridge_fresh_file_absent(tmp_path):
+    """No .oi_bridge_fresh file at all (bridge never attempted) fails CLOSED:
+    --apply must not be appended even though VNX_AUTO_CLOSE defaults to on."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+
+    capture = tmp_path / "reconcile_argv.txt"
+    fakebin = _fake_python3(tmp_path, capture)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OBJECTIVE_RECONCILE_INTERVAL"] = "0"
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_objective_reconcile", env)
+    assert proc.returncode == 0, proc.stderr
+    assert "SURVIVED:0" in proc.stdout
+
+    argv = capture.read_text()
+    assert "--apply" not in argv, f"--apply must be withheld with no bridge signal: {argv!r}"
+
+    log_capture = Path(env["VNX_LOG_CAPTURE"]).read_text()
+    assert "skipping --apply" in log_capture
+
+
+def test_reconcile_withholds_apply_when_bridge_marked_not_fresh(tmp_path):
+    """A bridge tick that explicitly failed this cycle (fresh="0") also gates
+    --apply — the safety-critical bridge-failure <-> reconcile-freshness link."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / ".oi_bridge_fresh").write_text("0", encoding="utf-8")
+
+    capture = tmp_path / "reconcile_argv.txt"
+    fakebin = _fake_python3(tmp_path, capture)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OBJECTIVE_RECONCILE_INTERVAL"] = "0"
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_objective_reconcile", env)
+    assert proc.returncode == 0, proc.stderr
+
+    argv = capture.read_text()
+    assert "--apply" not in argv
+
+
+def test_reconcile_includes_apply_when_bridge_marked_fresh(tmp_path):
+    """A successful bridge run (fresh="1") allows --apply through, as before D1
+    (VNX_AUTO_CLOSE default-on behaviour is preserved when data is fresh)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / ".oi_bridge_fresh").write_text("1", encoding="utf-8")
+
+    capture = tmp_path / "reconcile_argv.txt"
+    fakebin = _fake_python3(tmp_path, capture)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OBJECTIVE_RECONCILE_INTERVAL"] = "0"
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_objective_reconcile", env)
+    assert proc.returncode == 0, proc.stderr
+
+    argv = capture.read_text()
+    assert "--apply" in argv
+
+
+def test_reconcile_never_applies_when_auto_close_explicitly_off(tmp_path):
+    """VNX_AUTO_CLOSE=0 still suppresses --apply regardless of bridge freshness
+    (pre-D1 opt-out is untouched by the new gate)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir / ".oi_bridge_fresh").write_text("1", encoding="utf-8")
+
+    capture = tmp_path / "reconcile_argv.txt"
+    fakebin = _fake_python3(tmp_path, capture)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OBJECTIVE_RECONCILE_INTERVAL"] = "0"
+    env["VNX_AUTO_CLOSE"] = "0"
+    env["PATH"] = f"{fakebin}:{env['PATH']}"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_objective_reconcile", env)
+    assert proc.returncode == 0, proc.stderr
+
+    argv = capture.read_text()
+    assert "--apply" not in argv
+
+
+# ---------------------------------------------------------------------------
+# Call-order guard: bridge tick runs BEFORE reconcile in process_dispatches()
+# ---------------------------------------------------------------------------
+
+def test_process_dispatches_calls_bridge_before_reconcile():
+    """Static guard: _maybe_oi_bridge_tick must appear before
+    _maybe_objective_reconcile in process_dispatches() — the reconciler's
+    blocker-check must read the freshly-synced track_open_items from the SAME
+    tick (plan-gate requirement, claudedocs/plan-oi-bridge-continuous.md)."""
+    source = DISPATCHER_SH.read_text()
+    match = re.search(
+        r"^process_dispatches\(\) \{\n.*?^\}\n", source, re.MULTILINE | re.DOTALL,
+    )
+    assert match, "could not locate process_dispatches() in dispatcher_minimal.sh"
+    body = match.group(0)
+
+    bridge_pos = body.find("_maybe_oi_bridge_tick")
+    reconcile_pos = body.find("_maybe_objective_reconcile")
+    assert bridge_pos != -1, "process_dispatches() must call _maybe_oi_bridge_tick"
+    assert reconcile_pos != -1, "process_dispatches() must call _maybe_objective_reconcile"
+    assert bridge_pos < reconcile_pos, (
+        "_maybe_oi_bridge_tick must run BEFORE _maybe_objective_reconcile in the same tick"
+    )


### PR DESCRIPTION
## Summary
- D1 (PR-1 of 2, `oi-bridge-continuous` track): wires `import_open_items_to_tracks()` (`scripts/import_open_items_to_tracks.py:554`) into the **dispatcher supervisor tick** — the point where `_maybe_objective_reconcile` already runs — instead of `RoadmapManager.autopilot_tick()`, which is default-off and has no continuous cadence. Finding: 457 open items, only ~22 ever bridged.
- New `_maybe_oi_bridge_tick()` in `scripts/lib/dispatcher_supervisor_ticks.sh`, gated by the same `VNX_SUPERVISOR_MODE=unified` condition as reconcile (no separate divergent flag), called immediately **before** `_maybe_objective_reconcile` in `process_dispatches()` (`scripts/dispatcher_minimal.sh`).
- **Safety-critical bridge-failure ↔ reconcile-freshness coupling**: the bridge tick persists a freshness signal (`$STATE_DIR/.oi_bridge_fresh`, "1"/"0") based on the bridge CLI's own exit-code contract (0 = clean, 4 = post-commit ledger-emit-only warning — DB still committed/fresh; any other code = not fresh). `_maybe_objective_reconcile` now withholds `--apply` unless that signal reads "1" — a failed or never-attempted bridge run can no longer let auto-close act on a stale `track_open_items` snapshot (`close_track_if_done`'s unresolved-blocker check would otherwise miss a blocker the bridge failed to write). Reconcile still runs in check mode either way; best-effort throughout (no supervisor crash).
- Drive-by fix: `tests/test_dispatcher_resilience.py`'s bash harness was missing stubs for `_maybe_objective_reconcile` / `_maybe_learning_cycle`, so all 4 of its scenario tests were already failing with "command not found" before this change (pre-existing gap, unrelated to the bridge). Added the missing stubs plus one for the new `_maybe_oi_bridge_tick`.

## Changes
- `scripts/lib/dispatcher_supervisor_ticks.sh`: new `_maybe_oi_bridge_tick()` (throttled via `VNX_OI_BRIDGE_INTERVAL`, default 900s, mirroring the reconcile tick's pattern); `_maybe_objective_reconcile()` now reads `.oi_bridge_fresh` before adding `--apply`.
- `scripts/dispatcher_minimal.sh`: `process_dispatches()` now calls `_maybe_oi_bridge_tick` before `_maybe_objective_reconcile`.
- `tests/test_dispatcher_resilience.py`: added missing bash-harness stubs (pre-existing gap).
- `tests/test_oi_bridge_supervisor_tick.py` (new): 8 tests — legacy-mode no-op, bridge links a new OI + second tick is idempotent (no duplicate `track_open_items` row), bridge failure survives `set -euo pipefail` and marks fresh="0", reconcile withholds `--apply` when the fresh signal is absent/"0", includes it when fresh="1", `VNX_AUTO_CLOSE=0` still suppresses `--apply` regardless of freshness, and a static guard that `_maybe_oi_bridge_tick` runs before `_maybe_objective_reconcile` in `process_dispatches()`.

## Verification
- `bash -n scripts/lib/dispatcher_supervisor_ticks.sh scripts/dispatcher_minimal.sh` → OK.
- `python3 -m pytest tests/test_oi_bridge_supervisor_tick.py tests/test_dispatcher_resilience.py tests/test_dispatcher_supervisor.py tests/test_objective_reconcile.py tests/test_oi_track_bridge.py tests/test_autopilot_tick_bridge.py tests/test_get_terminal_claimed_by.py -q` → **218 passed**, 0 failed.
- Remote branch pushed and verified: `git ls-remote origin dispatch/20260722-oi-bridge-tick` → `5cf00162453258b5797a478b3ef7886e3d95b991`.
- A full-repo `pytest tests/` run was also kicked off for broader sanity; it was still running in the background at report time (large suite) — the targeted regression sweep above already covers every existing test file that references the modified functions/files.

## Open Items
- D2 (PR-2, follow-up, out of scope here): dashboard governance-view (`link_type='blocks' AND resolved_at IS NULL`, explicit `project_id`) per `claudedocs/plan-oi-bridge-continuous.md`.
- `import_open_items_to_tracks()` itself was not touched (per scope) — only its new caller.
- No change to the C3-N4 event-ordering tradeoff.

Dispatch-ID: 20260722-oi-bridge-tick