### PR TITLE
fix(panel): kimi-k2-7-code -> kimi-k3 + deepseek-v4-pro rename in panel/gate roster

### DIFF
--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -57,7 +57,7 @@ def _extract_verdict(text: str) -> dict:
             return obj
     return {}
 
-DEFAULT_MODEL = "kimi-k2-7-code"
+DEFAULT_MODEL = "kimi-k3"
 DEFAULT_TIMEOUT = 900
 MAX_DIFF_CHARS = 50000
 

--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -30,10 +30,10 @@ DispatcherFn = Callable[[str, str, str, str], str]
 # deepseek-harness is optional (needs its own key + hardening) — degrades gracefully if absent.
 DEFAULT_ROSTER: List[Tuple[str, str]] = [
     ("codex", "gpt-5.5"),
-    ("kimi", "kimi-k2-7-code"),
+    ("kimi", "kimi-k3"),
     ("claude", "sonnet"),
     ("glm-harness", "glm-5.2"),
-    ("deepseek-harness", "deepseek-reasoner"),
+    ("deepseek-harness", "deepseek-v4-pro"),
 ]
 
 

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -57,7 +57,7 @@ _CLAUDE_PROVIDERS = {"claude"}
 # retry only rescues transient flakes. glm-harness requires the local litellm proxy on :4141.
 DEFAULT_PANEL: List[Dict[str, str]] = [
     {"label": "opus", "provider": "claude", "model_arg": "opus"},
-    {"label": "kimi", "provider": "kimi", "model_arg": "kimi-k2-7-code"},
+    {"label": "kimi", "provider": "kimi", "model_arg": "kimi-k3"},
     {"label": "glm-5.2-harness", "provider": "glm-harness", "model_arg": "glm-5.2"},
     {"label": "deepseek", "provider": "deepseek-harness", "model_arg": "deepseek-v4-pro"},
     {"label": "codex", "provider": "codex", "model_arg": "gpt-5.5"},


### PR DESCRIPTION
Operator commit (Vincent, 4bff8431), routed through a PR + gate. Reconciles the kimi model-ID drift that caused the plan-gate kimi-seat to abstain this session (`model 'kimi-k2-7-code' is not registered`): renames the hardcoded `kimi-k2-7-code` -> `kimi-k3` (the current K3 default per #1190) and `deepseek-reasoner` -> `deepseek-v4-pro` across kimi_gate.py, deliberation_panel.py, plan_gate_panel.py.

🤖 Routed by T0 (Generated with Claude Code)