### PR TITLE
fix(objective-close): --attest records the real delivering PR via --pr

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -826,11 +826,14 @@ def _close_with_attest(
 ) -> int:
     """Attested close path for ops-tracks with no PR evidence.
 
-    Human-gated: --attest REQUIRES --apply AND --approval-id. Sets
-    tracks.pr_ref = 'ops-attest:<YYYY-MM-DD>', emits an audit event, then walks
-    the track's declared phase to 'done' through tracks.transition_phase (the
-    single-writer). This is an explicit operator override; it does NOT resolve
-    blocker open-items.
+    Human-gated: --attest REQUIRES --apply AND --approval-id. When --pr is given,
+    stamps the real delivering PR ref (normalized via `_merge_pr_refs`, same
+    shape as `link-pr`) as tracks.pr_ref instead of the date stamp — this
+    grounds the track for the reconciler. Without --pr, fails open to
+    tracks.pr_ref = 'ops-attest:<YYYY-MM-DD>' exactly as before. Either way an
+    audit event is emitted, then the track's declared phase is walked to 'done'
+    through tracks.transition_phase (the single-writer). This is an explicit
+    operator override; it does NOT resolve blocker open-items.
     """
     if not args.apply:
         print(
@@ -903,8 +906,26 @@ def _close_with_attest(
         return 2
     payload["path"] = [declared, *path]
 
+    # Resolve the ref to stamp: a real PR (via --pr, normalized like `link-pr`)
+    # when given, else the fail-open ops-attest date stamp (unchanged default).
+    raw_pr_args = list(getattr(args, "pr", None) or [])
+    resolved_pr_ref: Optional[str] = None
+    if raw_pr_args:
+        resolved_pr_ref, _pr_added, _pr_already = _merge_pr_refs(None, raw_pr_args)
+        if resolved_pr_ref is None:
+            payload["action"] = "rejected_invalid_pr"
+            if args.json:
+                print(json.dumps(payload, indent=2, default=str))
+            else:
+                print(f"\nvnx objective close --attest — {track_id} (project '{project_id}')\n")
+                print(
+                    f"  ERROR: no valid PR refs provided via --pr: {raw_pr_args!r}. "
+                    "No change made.\n"
+                )
+            return 2
+
     # Stamp the explicit attestation on the track.
-    attest_ref = f"ops-attest:{date.today().isoformat()}"
+    attest_ref = resolved_pr_ref or f"ops-attest:{date.today().isoformat()}"
     conn = _db_conn(state_dir)
     try:
         conn.execute(
@@ -915,14 +936,21 @@ def _close_with_attest(
     finally:
         conn.close()
 
-    # Audit the operator attestation (reason + approval_id).
+    # Audit the operator attestation (reason + approval_id + full PR provenance:
+    # raw --pr args as given, and the resolved ref actually stamped).
     tracks_lib._emit_track_event(
         state_dir,
         "track_ops_attest",
         track_id,
         project_id,
         "operator",
-        {"reason": reason, "approval_id": approval_id, "pr_ref": attest_ref},
+        {
+            "reason": reason,
+            "approval_id": approval_id,
+            "pr_ref": attest_ref,
+            "pr_arg_raw": raw_pr_args,
+            "pr_arg_resolved": resolved_pr_ref,
+        },
     )
 
     # Walk the legal phase path via the single-writer.
@@ -1016,8 +1044,13 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
 
     --attest <reason> is the escape hatch for ops-tracks with no PR evidence
     (e.g. a fleet-sync or docs-sweep). It still requires --apply + --approval-id,
-    writes tracks.pr_ref = 'ops-attest:<date>', emits an audit event, then walks
-    the phase to 'done'. It does NOT resolve blocker open-items.
+    emits an audit event, then walks the phase to 'done'. It does NOT resolve
+    blocker open-items. When --pr is also given, it records the real delivering
+    PR (normalized like `link-pr`) as tracks.pr_ref, so the track can later be
+    grounded by the reconciler instead of carrying a date stamp forever. Without
+    --pr, it fails open to tracks.pr_ref = 'ops-attest:<date>' exactly as before.
+    --pr without --attest is rejected — use `link-pr` to link a ref without
+    closing.
     """
     state_dir = _resolve_state_dir(args.state_dir)
     project_id = args.project_id
@@ -1030,6 +1063,14 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
         repo_root = None
 
     attest_reason = getattr(args, "attest", None)
+    if getattr(args, "pr", None) and attest_reason is None:
+        print(
+            "objective close: --pr requires --attest (to record the delivering PR on an "
+            "attested close). To link a PR ref without closing the track, use "
+            "`vnx objective link-pr <track_id> <pr>` instead. No change made.",
+            file=sys.stderr,
+        )
+        return 2
     if attest_reason is not None:
         return _close_with_attest(args, state_dir, track_id, project_id, attest_reason, repo_root)
 
@@ -2221,7 +2262,15 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     p_close.add_argument(
         "--attest", default=None, metavar="REASON",
-        help="operator attestation for ops-tracks with no PR evidence (requires --apply --approval-id)",
+        help="operator attestation for ops-tracks with no PR evidence (requires --apply "
+             "--approval-id). Records the real PR via --pr when given, else fails open to "
+             "ops-attest:<date>",
+    )
+    p_close.add_argument(
+        "--pr", action="append", default=None, metavar="NNN",
+        help="delivering PR ref(s) as #NNN or NNN, comma-separated or repeated. Only valid "
+             "with --attest: records the real PR as pr_ref instead of ops-attest:<date>. "
+             "Without --attest, use `vnx objective link-pr` instead.",
     )
     p_close.set_defaults(func=cmd_objective_close)
 

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -197,6 +197,7 @@ def _close_args(
     apply: bool = False,
     approval_id: str = "",
     attest: str | None = None,
+    pr: list[str] | None = None,
     include_parked: bool = False,
     project_id: str = PROJECT_ID,
     json: bool = False,
@@ -208,6 +209,7 @@ def _close_args(
         apply=apply,
         approval_id=approval_id,
         attest=attest,
+        pr=pr,
         include_parked=include_parked,
         json=json,
         repo_root="",
@@ -279,6 +281,93 @@ def test_close_attest_advances_ops_track_and_writes_audit(tmp_path):
     assert details["reason"] == "fleet-sync"
     assert details["approval_id"] == "APR-OPS"
     assert details["pr_ref"].startswith("ops-attest:")
+
+
+def test_close_attest_with_pr_stamps_real_ref_not_date(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "ops", PROJECT_ID, title="fleet sync", goal_state="done", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "ops", apply=True, approval_id="APR-OPS", attest="fleet-sync", pr=["1234"])
+    )
+    assert rc == 0
+    assert _phase(sd, "ops") == "done"
+    assert _pr_ref(sd, "ops") == "#1234"
+    assert not _pr_ref(sd, "ops").startswith("ops-attest:")
+
+    events = _track_events(sd, "ops", "track_ops_attest")
+    assert len(events) == 1
+    details = events[0]["details"]
+    assert details["pr_ref"] == "#1234"
+    assert details["pr_arg_raw"] == ["1234"]
+    assert details["pr_arg_resolved"] == "#1234"
+
+
+def test_close_attest_with_multi_pr_stamps_ordered_deduped_ref(tmp_path):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "ops", PROJECT_ID, title="fleet sync", goal_state="done", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "ops", apply=True, approval_id="APR-OPS", attest="fleet-sync",
+                    pr=["1199,1200"])
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "ops") == "#1199,#1200"
+
+    events = _track_events(sd, "ops", "track_ops_attest")
+    assert events[0]["details"]["pr_ref"] == "#1199,#1200"
+
+
+def test_close_attest_pr_normalization_variants(tmp_path):
+    # Bare number, '#'-prefixed, and repeated --pr all resolve via _merge_pr_refs.
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "bare", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "bare", apply=True, approval_id="A", attest="r", pr=["1234"])
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "bare") == "#1234"
+
+    tracks_lib.create_track(sd, "hashed", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "hashed", apply=True, approval_id="A", attest="r", pr=["#1234"])
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "hashed") == "#1234"
+
+    tracks_lib.create_track(sd, "repeated", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "repeated", apply=True, approval_id="A", attest="r", pr=["1234", "1235"])
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "repeated") == "#1234,#1235"
+
+
+def test_close_pr_without_attest_is_rejected_no_write(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued", pr_ref="")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "T", apply=True, approval_id="A", pr=["1234"])
+    )
+    assert rc != 0
+    out = (capsys.readouterr().err)
+    assert "--attest" in out and "link-pr" in out
+    assert _phase(sd, "T") == "queued"
+    assert _pr_ref(sd, "T") == ""
+
+
+def test_close_attest_pr_scoped_to_project_id(tmp_path):
+    # ADR-007: the UPDATE stays WHERE track_id=? AND project_id=? — a same-named
+    # track in another project must not be touched.
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    tracks_lib.create_track(sd, "T", "other-proj", title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "T", apply=True, approval_id="A", attest="r", pr=["1234"],
+                    project_id=PROJECT_ID)
+    )
+    assert rc == 0
+    assert _pr_ref(sd, "T", PROJECT_ID) == "#1234"
+    assert _pr_ref(sd, "T", "other-proj") == ""
+    assert _phase(sd, "T", "other-proj") == "queued"
 
 
 def test_close_attest_without_apply_or_approval_is_rejected(tmp_path, capsys):


### PR DESCRIPTION
## Summary
- `vnx objective close --attest <REASON>` always stamped `tracks.pr_ref = "ops-attest:<date>"`, with no way to record the real delivering PR. Once attest-closed, a track carries a date stamp forever — the reconciler has nothing to verify, so derived_status can't ground (some tracks show stale queued/blocked despite phase=done).
- Adds `--pr` to `objective close`. Only valid with `--attest`: stamps the real PR ref (normalized via the existing `_merge_pr_refs`, same shape as `link-pr`: `#NNN`/`NNN`, comma-separated or repeated) instead of the date stamp.
- Without `--pr`, `--attest` behaves exactly as before (regression-guarded by test).
- `--pr` without `--attest` is rejected (non-zero exit, no write) — points the operator at `link-pr` for linking a ref without closing.
- Audit event (`track_ops_attest`) now carries both the raw `--pr` args and the resolved ref for full provenance.

## Changes
- `scripts/planning_cli.py`
  - `p_close` argparse: new `--pr` (`action="append"`), updated `--attest` help text.
  - `_close_with_attest`: resolves `--pr` via `_merge_pr_refs`, stamps the real ref when given (rejects cleanly on invalid refs), else keeps the `ops-attest:<date>` fallback. Audit event payload gains `pr_arg_raw` / `pr_arg_resolved`.
  - `cmd_objective_close`: rejects `--pr` passed without `--attest` (stderr message, exit 2, no DB write) before dispatching to any close path.
  - Docstrings for both functions updated to describe the new behavior.
- `tests/test_planning_cli.py`
  - `_close_args` helper: new `pr` kwarg.
  - New tests: real-ref stamping, multi-PR ordered/deduped stamping, `--pr` normalization variants (`1234`, `#1234`, repeated), `--pr` without `--attest` rejection, ADR-007 project_id scoping.

## Verification
Ran (from the worktree root):
```
python3 -m pytest tests/test_planning_cli.py tests/test_objective_close.py -q
# 33 passed
```
Also ran each sibling planning_cli/track test module individually to check for regressions:
```
tests/test_objective_close.py           15 passed
tests/test_objective_reconcile.py       50 passed
tests/test_objective_reopen.py           6 passed
tests/test_planning_cli.py              18 passed
tests/test_planning_cli_lane_hint.py    14 passed
tests/test_planning_cli_objective.py     2 failed, 7 passed  (pre-existing, confirmed via git stash on clean main — unrelated to this change)
tests/test_planning_cli_objective_add.py 6 passed
tests/test_track_cli.py                 15 failed, 3 passed  (pre-existing fixture/env issue, confirmed via git stash on clean main — unrelated to this change)
```
Confirmed argparse wiring directly: `--pr 1199,1200`, repeated `--pr`, and the `None` default all parse as expected through `_build_parser()`.

## Test plan
- [x] `--attest ... --pr 1234 --apply --approval-id X` stamps `pr_ref == "#1234"`, not an ops-attest stamp
- [x] `--attest ... --pr 1199,1200` stamps `#1199,#1200` in order, deduped
- [x] `--attest ...` with no `--pr` still stamps `ops-attest:<today>` (regression guard)
- [x] `--pr` normalization: `1234`, `#1234`, repeated `--pr` all resolve correctly
- [x] `--pr` without `--attest` is rejected, non-zero exit, no write
- [x] ADR-007 scoping preserved (`WHERE track_id=? AND project_id=?`)

## Open Items
None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)