### PR TITLE
fix(panel): feed full seat reports into digest, drop 6000-char cut

### DIFF
--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -19,9 +19,13 @@ provider string through its correct lane.
 from __future__ import annotations
 
 import concurrent.futures as _cf
+import logging
+import os
 import uuid
 from dataclasses import dataclass, field
 from typing import Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
 
 # A dispatcher runs one panelist and returns its report text.
 DispatcherFn = Callable[[str, str, str, str], str]
@@ -139,26 +143,42 @@ class DeliberationResult:
         return "\n".join(lines)
 
 
-# Per-seat char budget fed into the sequential stages (contrarian/verify/synthesis).
-# Was 1500 and got entirely consumed by each report's echoed frontmatter + instruction +
-# shared context, so the downstream seats saw only boilerplate, never the analysis
-# (sales-copilot panel, 2026-07-18). Heuristic echo-stripping was attempted in two
-# follow-up fix rounds but proved fragile (codex-gate kept finding edge cases), so we
-# deliberately fall back to the robust minimum: a plain budget that keeps boilerplate
-# but leaves room for the actual analysis.
-_DIGEST_LIMIT = 6000
+# Per-report backstop fed into the sequential stages (contrarian/verify/synthesis). This is
+# NOT a normal-case truncation — full seat reports (~15-25k tokens total across a 5-seat
+# fan-out) fit easily in a modern context window, so the digest feeds them WHOLE. A prior
+# 6000-char budget was consumed entirely by each report's echoed frontmatter + instruction +
+# shared context, so downstream stages saw only boilerplate and never the analysis, and it
+# degraded silently for a whole session (sales-copilot panel, 2026-07-18/22). Heuristic
+# echo-stripping and a model-emitted sentinel were both considered and rejected — fragile,
+# or dependent on model cooperation. This backstop exists only to bound a pathological
+# runaway report; hitting it must never be silent (see _clip).
+_REPORT_BACKSTOP = int(os.environ.get("VNX_PANEL_REPORT_BACKSTOP", "40000"))
 
 
-def _digest(fan_out: List[Dict[str, str]], limit: int = _DIGEST_LIMIT) -> str:
-    """Compact digest of the fan-out for the contrarian/verify/synthesis stages.
+def _clip(text: str, tag: str, limit: int = _REPORT_BACKSTOP) -> str:
+    """Pass text through whole unless it exceeds the generous backstop. A clip is always
+    logged loudly — silent degradation is the exact bug this replaces."""
+    if len(text) > limit:
+        logger.warning(
+            "panel digest: report for %s clipped at %d chars (was %d) — raise VNX_PANEL_REPORT_BACKSTOP",
+            tag, limit, len(text),
+        )
+        return text[:limit]
+    return text
 
-    Budget-only: no heuristic echo-stripping. Downstream seats can read past the
-    boilerplate; the important thing is that the analysis is not truncated.
+
+def _digest(fan_out: List[Dict[str, str]], limit: int = _REPORT_BACKSTOP) -> str:
+    """Full digest of the fan-out for the contrarian/verify/synthesis stages.
+
+    Feeds each seat's FULL report text — no normal-case truncation. ``limit`` is a
+    generous per-report backstop against a pathological runaway report only; hitting it
+    is always logged (see _clip), never silent.
     """
     parts = []
     for fo in fan_out:
         text = (fo.get("text") or "").strip()
-        parts.append(f"[{fo['provider']} / {fo['lens']}]\n{text[:limit]}")
+        text = _clip(text, fo.get("provider", "?"), limit)
+        parts.append(f"[{fo['provider']} / {fo['lens']}]\n{text}")
     return "\n\n".join(parts)
 
 
@@ -225,7 +245,7 @@ def run_deliberation(
     verify_prompt = (
         f"You are the VERIFY pass on a deliberation panel ({spec.description}).\n"
         f"QUESTION: {question}\n{ctx_block}\n"
-        f"Panel findings:\n{digest}\n\nRed-team:\n{result.contrarian[:_DIGEST_LIMIT]}\n\n"
+        f"Panel findings:\n{digest}\n\nRed-team:\n{_clip(result.contrarian, 'contrarian')}\n\n"
         f"Take the TOP 5 concrete claims across the above and adversarially verify each against "
         f"{spec.verify_target}. Mark each: CONFIRMED / REFUTED / UNVERIFIABLE, with the specific "
         "evidence (file:line or source). Default to REFUTED/UNVERIFIABLE when evidence is thin."
@@ -239,8 +259,8 @@ def run_deliberation(
     synth_prompt = (
         f"You are the SYNTHESISER on a deliberation panel ({spec.description}).\n"
         f"QUESTION: {question}\n{ctx_block}\n"
-        f"Divergent views:\n{digest}\n\nRed-team:\n{result.contrarian[:_DIGEST_LIMIT]}\n\n"
-        f"Verification:\n{result.factcheck[:_DIGEST_LIMIT]}\n\n"
+        f"Divergent views:\n{digest}\n\nRed-team:\n{_clip(result.contrarian, 'contrarian')}\n\n"
+        f"Verification:\n{_clip(result.factcheck, 'verify')}\n\n"
         f"Produce {spec.synth_goal}. Structure: CONSENSUS (verified), CONTESTED (surviving "
         "dissent), VERIFIED CLAIMS (ranked, with evidence), OPEN QUESTIONS. Dedupe. Cite "
         "file:line / sources. Do not invent agreement that isn't there."

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -4,6 +4,9 @@ Uses a FAKE dispatcher (records calls) so no live provider is hit."""
 
 from __future__ import annotations
 
+import logging
+import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -137,3 +140,72 @@ class TestDigestBudget:
         digest = dp._digest(fan_out)
         assert analysis_marker in digest
         assert digest.count("issue ") == 55
+
+    def test_large_context_echo_does_not_cut_analysis(self):
+        """A report whose echoed provenance/context ALONE exceeds the old 6000-char budget
+        (an 11.7KB --context-file reproduced the bug live) must still surface the analysis
+        that comes after it — the exact failure mode that degraded the panel silently."""
+        analysis_marker = "ANALYSIS_ONLY_MARKER_XYZ_789"
+        echoed_context = "context line: lorem ipsum dolor sit amet consectetur adipiscing\n" * 200
+        assert len(echoed_context) > 12_000, f"echo size {len(echoed_context)} must exceed 12KB"
+        report = (
+            "---\ntitle: panel report\nprovider: codex\n---\n"
+            "## Instruction\nYou are one seat on a deliberation panel.\n"
+            "QUESTION: audit src/\n\n## Shared context\n"
+            + echoed_context
+            + f"\n\nFindings:\n{analysis_marker}\nreal analysis text follows here."
+        )
+        assert len(report) > 12_000
+        fan_out = [{"provider": "codex", "lens": "security", "text": report}]
+        digest = dp._digest(fan_out)
+        assert analysis_marker in digest, "analysis was cut off — the old truncation bug is back"
+
+
+class TestReportBackstop:
+    """The generous per-report backstop replaces the old normal-case 6000-char truncation.
+    It must never fire on realistic reports, and when it DOES fire (pathological runaway
+    report), the clip must be loud (a warning), never silent."""
+
+    def test_report_under_backstop_passed_whole(self, caplog):
+        text = "a" * 1000
+        fan_out = [{"provider": "codex", "lens": "security", "text": text}]
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            digest = dp._digest(fan_out, limit=5000)
+        assert text in digest
+        assert not any("clipped" in r.message for r in caplog.records)
+
+    def test_report_over_backstop_is_clipped_and_warns(self, caplog):
+        text = "b" * 6000
+        fan_out = [{"provider": "codex", "lens": "security", "text": text}]
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            digest = dp._digest(fan_out, limit=5000)
+        body = digest.split("]\n", 1)[1]
+        assert len(body) == 5000
+        warnings = [r for r in caplog.records if "clipped" in r.message]
+        assert warnings, "clipping must emit a loud warning, never fail silently"
+        assert "codex" in warnings[0].message
+        assert "VNX_PANEL_REPORT_BACKSTOP" in warnings[0].message
+
+    def test_default_backstop_is_generous(self):
+        """The default backstop is a pathological-runaway guard, not a normal-case limit —
+        it must comfortably exceed any realistic single-seat report."""
+        assert dp._REPORT_BACKSTOP >= 40_000
+
+    def test_backstop_env_var_override(self):
+        lib_dir = str(REPO_ROOT / "scripts" / "lib")
+        code = f"import sys; sys.path.insert(0, {lib_dir!r}); import deliberation_panel as dp; print(dp._REPORT_BACKSTOP)"
+        env = {**os.environ, "VNX_PANEL_REPORT_BACKSTOP": "12345"}
+        result = subprocess.run(
+            [sys.executable, "-c", code], env=env, capture_output=True, text=True, check=True,
+        )
+        assert result.stdout.strip() == "12345"
+
+    def test_downstream_slices_use_backstop_not_old_limit(self, caplog):
+        """result.contrarian / result.factcheck feeding into later stages must go through the
+        same generous backstop (_clip), not the removed 6000-char slice — text well past the
+        old 6000-char budget but under the default backstop must survive whole."""
+        text_past_old_limit = "c" * 20_000
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            clipped = dp._clip(text_past_old_limit, "contrarian", limit=dp._REPORT_BACKSTOP)
+        assert len(clipped) == 20_000  # far past the old 6000-char cut, still passed whole
+        assert not caplog.records


### PR DESCRIPTION
## Summary
- The panel's contrarian/verify/synthesis stages fed each seat's full report through a flat `text[:6000]` slice. Since the report begins with lane-written provenance (frontmatter, instruction echo, shared context) *before* the model's analysis, a large `--context-file` (e.g. 11.7KB) made the echoed provenance alone exceed the whole budget — the analysis was silently dropped for every downstream stage.
- Replaces the normal-case truncation with a full-text digest (5 seat reports fit easily in a modern context window) and a generous per-report backstop (`VNX_PANEL_REPORT_BACKSTOP`, default 40000) that only guards against a pathological runaway report.
- A clip is now always logged loudly (`logger.warning`) — silent degradation is exactly the bug this replaces.
- No sentinel, no heuristic echo-stripping, no model cooperation — the fix is a deterministic budget change only, per the two prior fragile attempts that were rejected.
- The optional secondary cleanup (dropping the redundant `ctx_block` from downstream stage prompts) was evaluated and reverted: it broke the existing `test_context_injected_into_every_stage` backward-compat contract, so the core fix stands alone as directed ("if it complicates, leave it").

## Test plan
- [x] `pytest tests/test_deliberation_panel.py -v` — 17 passed (11 existing + 6 new)
- [x] New: `_digest` over a report whose echoed context alone exceeds 12KB still surfaces the analysis in full
- [x] New: report under the backstop passed whole, no warning; report over the backstop clipped to the limit AND emits a warning naming the seat + the env var to raise
- [x] New: default backstop is generous (>=40000); env var override verified via subprocess
- [x] `pytest tests/test_panel_cli.py tests/test_plan_gate_panel.py -q` — 67 passed (no regressions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)