### PR TITLE
fix(dispatch-worktree): resolve consumer project root, never central install

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -1264,11 +1264,21 @@ def run_envelope_plan(
     from dispatch_worktree_isolation import (  # noqa: PLC0415
         create_dispatch_worktree,
         remove_dispatch_worktree,
+        resolve_consumer_project_root,
     )
 
     wt_path: Optional[Path] = None
     try:
-        wt_path = create_dispatch_worktree(plan.dispatch_id)
+        # Resolve the CONSUMER project root explicitly (VNX_PROJECT_ROOT / CWD-git,
+        # never __file__) so a central-install consumer (SC/MC/SEO/...) gets its
+        # worktree under ITS OWN project — not the shared ~/.vnx-system checkout
+        # this lane code lives under in a central install (P0 provider-worktree-
+        # root-fix). Resolved once and reused for both create and remove below so
+        # a fluctuating ambient CWD can't split the two onto different roots.
+        # Any resolution failure is handled by the same fail-loud path below as
+        # a worktree-creation failure — never falls back to a shared checkout.
+        _consumer_project_root = resolve_consumer_project_root()
+        wt_path = create_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
     except Exception as _wt_exc:
         _isolation_error = (
             f"isolation required (require_worktree) but worktree creation failed "
@@ -1311,7 +1321,7 @@ def run_envelope_plan(
         except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
             _phantom_diff = None
     finally:
-        remove_dispatch_worktree(plan.dispatch_id)
+        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
 
     report_path, receipt_path = _govern(
         enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -24,6 +24,32 @@ log = logging.getLogger(__name__)
 _UNSAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
 _MAX_SAFE_ID_LEN = 60
 
+# The shared VNX central-install tree (e.g. ~/.vnx-system/versions/<v>/). A
+# dispatch worktree must NEVER be created here — see CentralInstallWorktreeError.
+_CENTRAL_INSTALL_ROOT = Path.home() / ".vnx-system"
+
+
+class CentralInstallWorktreeError(RuntimeError):
+    """Raised when dispatch-worktree resolution would land inside the shared
+    VNX central install tree (``~/.vnx-system/...``) instead of a consumer
+    project.
+
+    A dispatch worktree must NEVER be created there: ``git worktree add``
+    against the shared fabric checkout that every central-install consumer
+    (SC/MC/SEO/...) reads from causes cross-consumer branch/worktree
+    collisions (P0 provider-worktree-root-fix). Callers must resolve and pass
+    an explicit consumer ``project_root`` instead of relying on the
+    ``__file__``-based fallback — see ``resolve_consumer_project_root()``.
+    """
+
+
+def _is_central_install_path(path: Path) -> bool:
+    try:
+        path.resolve().relative_to(_CENTRAL_INSTALL_ROOT.resolve())
+        return True
+    except (OSError, ValueError):
+        return False
+
 
 def _sanitize_dispatch_id(dispatch_id: str) -> str:
     """Return a filesystem- and git-branch-safe version of dispatch_id."""
@@ -46,12 +72,44 @@ def _dispatch_worktree_dir(project_root: Path, dispatch_id: str) -> Path:
 
 def _resolve_project_root(project_root: Optional[Path]) -> Path:
     if project_root is not None:
-        return project_root.resolve()
-    try:
-        from project_root import resolve_project_root  # type: ignore[attr-defined]
-        return Path(resolve_project_root(__file__)).resolve()
-    except Exception:
-        return Path(__file__).resolve().parents[2]
+        root = project_root.resolve()
+    else:
+        try:
+            from project_root import resolve_project_root  # type: ignore[attr-defined]
+            root = Path(resolve_project_root(__file__)).resolve()
+        except Exception:
+            root = Path(__file__).resolve().parents[2]
+
+    if _is_central_install_path(root):
+        raise CentralInstallWorktreeError(
+            f"dispatch-worktree root resolved to the shared VNX central install "
+            f"({root}) instead of a consumer project; refusing to create/remove a "
+            f"worktree there. Pass an explicit consumer project_root — see "
+            f"resolve_consumer_project_root()."
+        )
+    return root
+
+
+def resolve_consumer_project_root() -> Path:
+    """Resolve the CONSUMER project root a dispatch worktree must be created in.
+
+    Delegates to ``vnx_paths.resolve_paths()["PROJECT_ROOT"]`` — the canonical
+    resolver that already threads ``VNX_PROJECT_ROOT`` (exported by the
+    central-install shim) and CWD-git-toplevel resolution ahead of any
+    ``__file__``-based fallback. This is the same resolver ``gate_executor``
+    passes into ``create_gate_worktree`` (OI-708) and that the tmux lane's
+    ``_resolve_invocation_project_root`` mirrors, so a consumer running the
+    central install (SC/MC/SEO/...) resolves to ITS OWN project instead of the
+    shared ``~/.vnx-system`` checkout — the root cause of cross-consumer
+    dispatch-worktree collisions (P0 provider-worktree-root-fix).
+
+    Callers MUST pass the result explicitly:
+    ``create_dispatch_worktree(..., project_root=resolve_consumer_project_root())``.
+    Relying on ``create_dispatch_worktree``'s own zero-arg ``__file__`` fallback
+    resolves the shared fabric install in a central-install consumer.
+    """
+    from vnx_paths import resolve_paths  # noqa: PLC0415
+    return Path(resolve_paths()["PROJECT_ROOT"]).resolve()
 
 
 @contextmanager

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1128,9 +1128,20 @@ def _create_provider_worktree(dispatch_id: str) -> Path:
 
     Only called when VNX_ISOLATED_WORKTREE=1.  Returns the worktree Path on
     success, raises RuntimeError on failure — no shared-checkout fallback.
+
+    Resolves the CONSUMER project root explicitly (dispatch_worktree_isolation.
+    resolve_consumer_project_root) and threads it into create_dispatch_worktree
+    — never lets the callee fall back to its own __file__ location, which in a
+    central install resolves to the shared ~/.vnx-system checkout instead of
+    the operator's project (the root cause of cross-consumer dispatch-worktree
+    collisions; P0 provider-worktree-root-fix).
     """
-    from dispatch_worktree_isolation import create_dispatch_worktree  # noqa: PLC0415
-    wt_path = create_dispatch_worktree(dispatch_id)
+    from dispatch_worktree_isolation import (  # noqa: PLC0415
+        create_dispatch_worktree,
+        resolve_consumer_project_root,
+    )
+    project_root = resolve_consumer_project_root()
+    wt_path = create_dispatch_worktree(dispatch_id, project_root=project_root)
     logger.info("provider isolation: worktree created at %s (dispatch=%s)", wt_path, dispatch_id)
     return wt_path
 
@@ -1174,10 +1185,18 @@ def _prepare_provider_workdir(
 
 
 def _remove_provider_worktree(dispatch_id: str) -> None:
-    """Remove the isolated worktree for a provider dispatch.  Best-effort; idempotent."""
+    """Remove the isolated worktree for a provider dispatch.  Best-effort; idempotent.
+
+    Resolves the same consumer project_root as _create_provider_worktree —
+    otherwise the __file__ fallback would try to remove a worktree that was
+    never created there (in a central install), silently leaking the real one.
+    """
     try:
-        from dispatch_worktree_isolation import remove_dispatch_worktree  # noqa: PLC0415
-        remove_dispatch_worktree(dispatch_id)
+        from dispatch_worktree_isolation import (  # noqa: PLC0415
+            remove_dispatch_worktree,
+            resolve_consumer_project_root,
+        )
+        remove_dispatch_worktree(dispatch_id, project_root=resolve_consumer_project_root())
         logger.info("provider isolation: worktree removed (dispatch=%s)", dispatch_id)
     except Exception as exc:
         logger.warning(

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -701,7 +701,7 @@ if __name__ == "__main__":
     # Default (unset): no change — proven path runs exactly as before.
     _isolated = os.environ.get("VNX_ISOLATED_WORKTREE") == "1"
     _isolation_wt_path = None
-    _isolation_project_root = Path(__file__).resolve().parents[2]
+    _isolation_project_root = None
     if _isolated:
         try:
             import logging as _log_mod
@@ -712,7 +712,15 @@ if __name__ == "__main__":
             from dispatch_worktree_isolation import (
                 create_dispatch_worktree as _create_wt,
                 remove_dispatch_worktree as _remove_wt,
+                resolve_consumer_project_root as _resolve_consumer_root,
             )
+            # Resolve the CONSUMER project root (VNX_PROJECT_ROOT / CWD-git,
+            # never __file__) so a central-install consumer gets its worktree
+            # under ITS OWN project — not the shared ~/.vnx-system checkout
+            # this lane code lives under in a central install (P0
+            # provider-worktree-root-fix). Any resolution failure is handled
+            # by the same fail-loud abort below as a worktree-creation failure.
+            _isolation_project_root = _resolve_consumer_root()
             _isolation_wt_path = _create_wt(
                 args.dispatch_id,
                 project_root=_isolation_project_root,

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -501,19 +501,21 @@ class TestEnvelopeWorktreeIsolation:
             adapter_calls.append({"cwd": cwd})
             return _fake_adapter_success()
 
-        with patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
              patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
              patch.object(ProviderAdapter, "run", fake_adapter_run), \
              patch("dispatch_envelope._govern", return_value=(None, fake_receipt)):
             result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
 
         assert result.status == "success"
-        mock_create.assert_called_once_with("wt-cwd-test")
+        mock_create.assert_called_once_with("wt-cwd-test", project_root=_fake_consumer_root)
         assert adapter_calls, "ProviderAdapter.run was not called"
         assert adapter_calls[0]["cwd"] == _FAKE_WT_PATH, (
             f"expected cwd={_FAKE_WT_PATH}, got cwd={adapter_calls[0]['cwd']}"
         )
-        mock_remove.assert_called_once_with("wt-cwd-test")
+        mock_remove.assert_called_once_with("wt-cwd-test", project_root=_fake_consumer_root)
 
     def test_worktree_removed_on_spawn_failure(self, tmp_path):
         """remove_dispatch_worktree is called even when ProviderAdapter.run raises."""
@@ -527,13 +529,15 @@ class TestEnvelopeWorktreeIsolation:
         def bad_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):
             raise RuntimeError("spawn exploded")
 
-        with patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH), \
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=_FAKE_WT_PATH), \
              patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove, \
              patch.object(ProviderAdapter, "run", bad_adapter_run):
             with pytest.raises(RuntimeError, match="spawn exploded"):
                 run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
 
-        mock_remove.assert_called_once_with("wt-rm-fail-test")
+        mock_remove.assert_called_once_with("wt-rm-fail-test", project_root=_fake_consumer_root)
 
     def test_worktree_creation_failure_aborts_dispatch(self, tmp_path):
         """Worktree creation failure → dispatch aborts (status=failure, rc!=0), spawn NOT called."""
@@ -548,7 +552,7 @@ class TestEnvelopeWorktreeIsolation:
 
         adapter_calls: list = []
 
-        def bad_create(dispatch_id):
+        def bad_create(dispatch_id, project_root=None):
             raise RuntimeError("no disk space")
 
         def spy_adapter_run(self, plan_arg, instruction, *, event_writer=None, cwd=None):

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -381,25 +381,56 @@ class TestLiteLLMIsolation:
 
 class TestProviderWorktreeHelpers:
     def test_create_returns_path_on_success(self, tmp_path):
-        with patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=tmp_path) as mock_create:
+        consumer_root = tmp_path / "consumer"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=tmp_path) as mock_create:
             result = provider_dispatch._create_provider_worktree("helper-create-test")
         assert result == tmp_path
-        mock_create.assert_called_once_with("helper-create-test")
+        mock_create.assert_called_once_with("helper-create-test", project_root=consumer_root)
 
     def test_create_raises_on_runtime_error(self):
-        with patch("dispatch_worktree_isolation.create_dispatch_worktree", side_effect=RuntimeError("disk full")):
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=Path("/tmp/consumer")), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree", side_effect=RuntimeError("disk full")):
             with pytest.raises(RuntimeError, match="disk full"):
                 provider_dispatch._create_provider_worktree("helper-fail-test")
 
     def test_remove_is_best_effort(self):
         """_remove_provider_worktree must not raise even if underlying call fails."""
-        with patch("dispatch_worktree_isolation.remove_dispatch_worktree", side_effect=Exception("gone")):
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=Path("/tmp/consumer")), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree", side_effect=Exception("gone")):
             provider_dispatch._remove_provider_worktree("remove-fail-test")
 
     def test_remove_calls_underlying(self):
-        with patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove:
+        consumer_root = Path("/tmp/consumer")
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=consumer_root), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove:
             provider_dispatch._remove_provider_worktree("remove-ok-test")
-        mock_remove.assert_called_once_with("remove-ok-test")
+        mock_remove.assert_called_once_with("remove-ok-test", project_root=consumer_root)
+
+    def test_remove_best_effort_when_resolver_raises(self):
+        """A resolver failure must also be swallowed — remove is best-effort end-to-end."""
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", side_effect=RuntimeError("no git")):
+            provider_dispatch._remove_provider_worktree("remove-resolver-fail-test")
+
+
+class TestResolveConsumerProjectRoot:
+    """Regression: the invocation-context project root wins over __file__-based
+    resolution — the exact consumer scenario (P0 provider-worktree-root-fix):
+    the lane code executes from inside a central-install-like tree, but
+    VNX_PROJECT_ROOT (exported by the central-install shim) names the
+    operator's actual project elsewhere, and that must win.
+    """
+
+    def test_vnx_project_root_env_wins_over_file_location(self, tmp_path, monkeypatch):
+        from dispatch_worktree_isolation import resolve_consumer_project_root
+
+        consumer_project = tmp_path / "my-consumer-project"
+        consumer_project.mkdir()
+        monkeypatch.setenv("VNX_PROJECT_ROOT", str(consumer_project))
+
+        resolved = resolve_consumer_project_root()
+
+        assert resolved == consumer_project.resolve()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_subprocess_dispatch_worktree_isolation.py
+++ b/tests/test_subprocess_dispatch_worktree_isolation.py
@@ -169,6 +169,46 @@ class TestCreateDispatchWorktree:
         assert result == expected_wt.resolve()
 
 
+class TestCentralInstallGuard:
+    """P0 provider-worktree-root-fix: a dispatch worktree must NEVER be created
+    (or removed) inside the shared VNX central install tree
+    (``~/.vnx-system/...``) — that would run `git worktree` against the fabric
+    checkout every central-install consumer (SC/MC/SEO/...) reads from,
+    colliding across unrelated consumers. Resolution must fail loud instead.
+    """
+
+    def test_create_raises_when_project_root_is_central_install(self):
+        from dispatch_worktree_isolation import (
+            CentralInstallWorktreeError,
+            create_dispatch_worktree,
+        )
+
+        central_install_path = Path.home() / ".vnx-system" / "versions" / "v1.9.9"
+
+        with patch("dispatch_worktree_isolation.subprocess.run") as mock_run:
+            with pytest.raises(CentralInstallWorktreeError):
+                create_dispatch_worktree("central-install-guard-test", project_root=central_install_path)
+
+        assert not mock_run.called, "guard must fire before any git subprocess call"
+
+    def test_remove_raises_when_project_root_is_central_install(self):
+        from dispatch_worktree_isolation import (
+            CentralInstallWorktreeError,
+            remove_dispatch_worktree,
+        )
+
+        central_install_path = Path.home() / ".vnx-system" / "current"
+
+        with pytest.raises(CentralInstallWorktreeError):
+            remove_dispatch_worktree("central-install-guard-remove-test", project_root=central_install_path)
+
+    def test_consumer_project_root_outside_central_install_is_unaffected(self, tmp_path):
+        """A normal consumer project_root (not under ~/.vnx-system) must resolve cleanly."""
+        from dispatch_worktree_isolation import _resolve_project_root
+
+        assert _resolve_project_root(tmp_path) == tmp_path.resolve()
+
+
 class TestRemoveDispatchWorktree:
     def test_calls_remove_force_and_prune(self, tmp_path):
         from dispatch_worktree_isolation import remove_dispatch_worktree, _dispatch_worktree_dir


### PR DESCRIPTION
## Summary
- `create_dispatch_worktree()` resolved its project root via `__file__`-first git-toplevel resolution. In a central-install consumer (SC/MC/SEO/...) that resolves to the shared `~/.vnx-system/versions/<v>/` fabric checkout instead of the operator's own project, since none of the production call sites ever passed an explicit `project_root`. This causes `git worktree add` to run against the shared fabric repo, colliding across every consumer that dispatches governed kimi/deepseek/glm work through the central install — the fleet-wide P0 blocker.
- Added `resolve_consumer_project_root()` to `dispatch_worktree_isolation.py`, delegating to `vnx_paths.resolve_paths()["PROJECT_ROOT"]` — the same `VNX_PROJECT_ROOT`/CWD-git resolver `gate_executor` already uses correctly for `create_gate_worktree` (OI-708).
- Threaded it explicitly through every real call site (investigation found 4, not just the 1 named in the dispatch):
  - `provider_dispatch._create_provider_worktree` / `_remove_provider_worktree`
  - `dispatch_envelope.run_envelope_plan` — the **actual** single-entry-door path for `plan.lane == "provider"` (kimi/deepseek/glm dispatched via `vnx dispatch`); this was silently broken the same way and is the real production blocker, not just the CLI-invoked `provider_dispatch.py` path.
  - `subprocess_dispatch.py`'s `VNX_ISOLATED_WORKTREE=1` block (previously hardcoded `Path(__file__).resolve().parents[2]` — an even more naive version of the same bug).
- Added a fail-loud `CentralInstallWorktreeError` guard inside `_resolve_project_root()` so any future caller that forgets to pass `project_root` refuses instead of silently colliding with the fabric checkout.

## Changes
- `scripts/lib/dispatch_worktree_isolation.py` — `CentralInstallWorktreeError`, `_is_central_install_path()`, `resolve_consumer_project_root()`, guard wired into `_resolve_project_root()`.
- `scripts/lib/provider_dispatch.py` — `_create_provider_worktree`/`_remove_provider_worktree` now resolve and pass `project_root=` explicitly.
- `scripts/lib/dispatch_envelope.py` — `run_envelope_plan` resolves the consumer root once and reuses it for both create and remove.
- `scripts/lib/subprocess_dispatch.py` — isolated-worktree block now uses `resolve_consumer_project_root()` instead of the hardcoded `parents[2]` fallback.
- Tests updated/added: `tests/test_provider_dispatch_worktree_isolation.py`, `tests/test_dispatch_envelope_plan.py`, `tests/test_subprocess_dispatch_worktree_isolation.py`.

## Verification
- `python3 -m pytest tests/test_subprocess_dispatch_worktree_isolation.py tests/test_provider_dispatch_worktree_isolation.py tests/test_dispatch_envelope_plan.py tests/test_dispatch_envelope_fail_loud.py tests/test_final_prompt_integrity.py tests/test_gate_worktree.py tests/test_subprocess_dispatch.py -q` → 103+9 passed, 2 pre-existing unrelated failures (confirmed identical via `git stash` on unmodified code — an artifact of running the suite from inside this dispatch's own linked git worktree, where `.git` is a file not a directory).
- `python3 -m pytest tests/ -q -k "provider_dispatch or dispatch_envelope or worktree or wave4_path_resolver or wave4_central_install or subprocess_dispatch"` → 602 passed, 29 failed — byte-identical failing-test list confirmed via `git stash` to be pre-existing on `main`, unrelated to this change.
- New regression coverage: `TestCentralInstallGuard` (create/remove both raise `CentralInstallWorktreeError` when `project_root` resolves under `~/.vnx-system`, guard fires before any git subprocess call) and `TestResolveConsumerProjectRoot::test_vnx_project_root_env_wins_over_file_location` (simulates the exact consumer scenario: `VNX_PROJECT_ROOT`, as exported by the central-install shim, wins over any `__file__`-based resolution).

## Open Items
- `dispatch_envelope._resolve_fix_forward_diff()` (`scripts/lib/dispatch_envelope.py:399-419`) defaults its `repo` param to `project_root.resolve_project_root` — the same `__file__`-first resolver class, but only used in a best-effort fix-forward diff fallback for existing-PR dispatches. Left out of scope for this P0 (narrower blast radius, not on the worktree-creation path); flagging for a follow-up track if it proves to matter for central-install consumers.
- `subprocess_dispatch.py`'s isolated-worktree block lives inside `if __name__ == "__main__":` (script-level, not an importable function), so it has no direct unit test — verified via syntax check, fresh import, and code review (mirrors the already-unit-tested `resolve_consumer_project_root()`/`create_dispatch_worktree()` contract) rather than a dedicated regression test.
- This PR fixes resolution; it does not itself verify against a real central install (`~/.vnx-system/...`) end-to-end — that requires a live consumer environment (SC/MC/SEO) to confirm the fleet-wide unblock, per the dispatch's stated "propagate to central before those sessions can dispatch kimi" follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)