### PR TITLE
feat(vnx-cli): honor .vnx-version pin via startup re-exec (pip-cli-honor-pin-via-reexec)

### DIFF
--- a/tests/test_vnx_cli_reexec.py
+++ b/tests/test_vnx_cli_reexec.py
@@ -1,0 +1,257 @@
+#!/usr/bin/env python3
+"""Tests for vnx_cli/_reexec.py — pip-CLI honors .vnx-version via re-exec.
+
+Design-track ``pip-cli-honor-pin-via-reexec``. All tests run against a FAKE
+central store under tmp_path; the operator's real ~/.vnx-system install and
+.vnx-data runtime state are never touched.
+"""
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+# Ensure the repo root is on sys.path so vnx_cli is importable without install
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli import _engine
+from vnx_cli import _reexec
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def central_store(tmp_path, monkeypatch):
+    """A fake central store: <tmp>/versions/v1.3.0 stamped as the RUNNING
+    central install (marker + VERSION + vnx_cli package), with engine_root()
+    pointed at it."""
+    versions = tmp_path / "versions"
+    running = versions / "v1.3.0"
+    (running / "vnx_cli").mkdir(parents=True)
+    (running / "vnx_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (running / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    (running / "VERSION").write_text("1.3.0\n", encoding="utf-8")
+    monkeypatch.setattr(_engine, "engine_root", lambda: running)
+    # Hermetic: no inherited loop-guard flag / PYTHONPATH from the outer env.
+    monkeypatch.delenv(_reexec.REEXEC_ENV_FLAG, raising=False)
+    monkeypatch.delenv("PYTHONPATH", raising=False)
+    return versions
+
+
+@pytest.fixture()
+def execv_spy(monkeypatch):
+    """Capture os.execv calls instead of replacing the test process."""
+    calls = []
+    monkeypatch.setattr(os, "execv", lambda path, args: calls.append((path, list(args))))
+    return calls
+
+
+def _add_version(versions: Path, name: str, version_file: str) -> Path:
+    d = versions / name
+    (d / "vnx_cli").mkdir(parents=True)
+    (d / "vnx_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (d / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    (d / "VERSION").write_text(f"{version_file}\n", encoding="utf-8")
+    return d
+
+
+def _pin(project_dir: Path, value: str) -> Path:
+    project_dir.mkdir(parents=True, exist_ok=True)
+    (project_dir / ".vnx-version").write_text(f"{value}\n", encoding="utf-8")
+    return project_dir
+
+
+# ---------------------------------------------------------------------------
+# No-op cases
+# ---------------------------------------------------------------------------
+
+def test_no_pin_file_no_reexec(central_store, execv_spy, tmp_path):
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_pin_equals_running_version_no_reexec(central_store, execv_spy, tmp_path):
+    _pin(tmp_path, "1.3.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_pin_matches_running_with_decorative_v(central_store, execv_spy, tmp_path):
+    """Pin 'v1.3.0' must match running VERSION '1.3.0' (decorative v)."""
+    _pin(tmp_path, "v1.3.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_dev_checkout_never_reexecs(central_store, execv_spy, tmp_path, monkeypatch):
+    """Without the .vnx-install-mode=central marker the run is a dev checkout:
+    no re-exec even when the pin names a different, installed version."""
+    (central_store / "v1.3.0" / ".vnx-install-mode").unlink()
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_loop_guard_blocks_second_reexec(central_store, execv_spy, tmp_path, monkeypatch):
+    """VNX_PIN_REEXECED already equal to the pin -> never exec again, even
+    though the running version still differs (off-by-a-hair detection)."""
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    monkeypatch.setenv(_reexec.REEXEC_ENV_FLAG, "v1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_loop_guard_normalizes_decorative_v(central_store, execv_spy, tmp_path, monkeypatch):
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "1.2.0")
+    monkeypatch.setenv(_reexec.REEXEC_ENV_FLAG, "v1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+# ---------------------------------------------------------------------------
+# Re-exec fires
+# ---------------------------------------------------------------------------
+
+def test_pin_different_installed_version_reexecs(central_store, execv_spy, tmp_path, monkeypatch):
+    pinned = _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    argv = ["status", "--project-dir", str(tmp_path), "--json"]
+    _reexec.maybe_reexec_pinned(argv)
+
+    assert len(execv_spy) == 1
+    python, args = execv_spy[0]
+    assert python == sys.executable
+    assert args == [sys.executable, "-m", "vnx_cli.main", *argv]
+    # Loop-guard armed + pinned install on PYTHONPATH for the exec'd process.
+    assert os.environ[_reexec.REEXEC_ENV_FLAG] == "v1.2.0"
+    assert os.environ["PYTHONPATH"].split(os.pathsep)[0] == str(pinned)
+
+
+def test_pin_without_v_resolves_v_prefixed_dir(central_store, execv_spy, tmp_path):
+    """Pin '1.2.0' must find the 'v1.2.0' dir in the central store."""
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert len(execv_spy) == 1
+
+
+def test_existing_pythonpath_preserved_after_pinned_paths(central_store, execv_spy, tmp_path, monkeypatch):
+    pinned = _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    monkeypatch.setenv("PYTHONPATH", "/opt/custom")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    parts = os.environ["PYTHONPATH"].split(os.pathsep)
+    assert parts[0] == str(pinned)
+    assert parts[-1] == "/opt/custom"
+
+
+def test_project_dir_equals_form_honored(central_store, execv_spy, tmp_path):
+    """--project-dir=DIR form must be picked up from argv."""
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    _reexec.maybe_reexec_pinned([f"--project-dir={tmp_path}"])
+    assert len(execv_spy) == 1
+
+
+def test_cwd_used_when_no_project_dir_arg(central_store, execv_spy, tmp_path, monkeypatch):
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    monkeypatch.chdir(tmp_path)
+    _reexec.maybe_reexec_pinned([])
+    assert len(execv_spy) == 1
+
+
+# ---------------------------------------------------------------------------
+# Fail-open cases (warning + continue, never execv, never crash)
+# ---------------------------------------------------------------------------
+
+def test_fail_open_pinned_dir_missing(central_store, execv_spy, tmp_path, capsys):
+    _pin(tmp_path, "v9.9.9")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+    assert "WARNING" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("bad", ["../evil", "bad;rm", "a b", "v1.2.0/..", ".."])
+def test_fail_open_malformed_pin(central_store, execv_spy, tmp_path, capsys, bad):
+    _pin(tmp_path, bad)
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_fail_open_empty_pin_file(central_store, execv_spy, tmp_path):
+    tmp_path.joinpath(".vnx-version").write_text("\n", encoding="utf-8")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+
+
+def test_fail_open_pinned_dir_missing_vnx_cli(central_store, execv_spy, tmp_path, capsys):
+    """A versions/<pin> dir without a vnx_cli package is not exec-able."""
+    broken = central_store / "v1.2.0"
+    broken.mkdir(parents=True)
+    (broken / "VERSION").write_text("1.2.0\n", encoding="utf-8")
+    _pin(tmp_path, "v1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_fail_open_execv_oserror(central_store, tmp_path, monkeypatch, capsys):
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+
+    def _boom(path, args):
+        raise OSError("exec format error")
+
+    monkeypatch.setattr(os, "execv", _boom)
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])  # must not raise
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_fail_open_unexpected_exception(central_store, execv_spy, tmp_path, monkeypatch, capsys):
+    """Any unexpected failure inside the check degrades to current version."""
+    monkeypatch.setattr(
+        _reexec, "_read_pin", lambda *_: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])  # must not raise
+    assert "WARNING" in capsys.readouterr().err
+
+
+def test_fail_open_symlink_escape_refused(central_store, execv_spy, tmp_path, capsys):
+    """A versions/<pin> symlink resolving OUTSIDE the versions root is refused."""
+    outside = tmp_path / "elsewhere"
+    (outside / "vnx_cli").mkdir(parents=True)
+    (outside / "vnx_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (central_store / "v1.2.0").symlink_to(outside)
+    _pin(tmp_path, "v1.2.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+    assert execv_spy == []
+    assert "WARNING" in capsys.readouterr().err
+
+
+# ---------------------------------------------------------------------------
+# main() integration
+# ---------------------------------------------------------------------------
+
+def test_main_invokes_reexec_first(monkeypatch):
+    """main() must run the pin re-exec check before argparse dispatch."""
+    import vnx_cli.main as main_mod
+
+    calls = []
+    monkeypatch.setattr(
+        "vnx_cli._reexec.maybe_reexec_pinned", lambda: calls.append("reexec")
+    )
+    monkeypatch.setattr(sys, "argv", ["vnx", "--version"])
+    with pytest.raises(SystemExit) as excinfo:
+        main_mod.main()
+    assert excinfo.value.code == 0
+    assert calls == ["reexec"]

--- a/vnx_cli/_engine.py
+++ b/vnx_cli/_engine.py
@@ -38,9 +38,10 @@ def engine_root() -> Path:
     selection. The pip-installed CLI and the pinned engine are API-coupled, so
     swapping the engine root based on a pin can crash commands that call new
     APIs against an old engine (e.g. ``deliver_via_door(deadline_seconds=...)``).
-    Honoring the pin from a pip install is tracked as design-track
-    ``pip-cli-honor-pin-via-reexec``; until that lands, ``vnx init --set-version``
-    writes the pin file but the running pip CLI keeps using its own engine.
+    The pin is instead honored by RE-EXEC'ing the pinned install as a whole
+    (its ``vnx_cli`` + its engine) at startup — see
+    ``vnx_cli/_reexec.py`` (design-track ``pip-cli-honor-pin-via-reexec``).
+    This in-process resolver keeps using its own engine.
     """
     parent = Path(__file__).resolve().parent.parent
     packaged = parent / "vnx_orchestration"

--- a/vnx_cli/_reexec.py
+++ b/vnx_cli/_reexec.py
@@ -1,0 +1,252 @@
+#!/usr/bin/env python3
+"""Startup pin re-exec for the pip ``vnx`` console script.
+
+Design-track ``pip-cli-honor-pin-via-reexec``. The pip CLI is API-coupled to
+its engine (see the NOTE in ``vnx_cli/_engine.py::engine_root``), so honoring
+a project's ``.vnx-version`` pin by swapping the engine root in-process can
+crash a new CLI against an old engine. Instead, when the pin names a
+DIFFERENT version than the one currently running, this module re-execs the
+pinned version's ENTIRE install (its ``vnx_cli`` + its engine, consistent)
+BEFORE any engine code loads: ``python -m vnx_cli.main`` with the pinned
+install's root on ``PYTHONPATH``.
+
+Safety contract (shared binary — non-negotiable):
+
+* Loop-guard: ``VNX_PIN_REEXECED`` is set to the pin before execv; a process
+  that already re-exec'd to that pin never re-execs again. This survives
+  off-by-a-hair version detection in the pinned tree.
+* Fail-open: ANY ambiguity (unreadable/malformed pin, pinned version missing
+  from the central store, unresolvable interpreter, execv failure) logs a
+  warning and continues with the CURRENT version. A pin problem must never
+  break the CLI — it degrades to "ran the default version".
+* Dev checkouts never re-exec: the re-exec only fires when the RUNNING
+  engine root carries the ``.vnx-install-mode=central`` marker written by
+  install-central.sh.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+REEXEC_ENV_FLAG = "VNX_PIN_REEXECED"
+
+PIN_FILE_NAME = ".vnx-version"
+INSTALL_MODE_MARKER = ".vnx-install-mode"
+INSTALL_MODE_VALUE = "central"
+
+# Same pin alphabet as the central-install shim (bin/vnx in ~/.vnx-system)
+# and `vnx init --set-version`. Forbids '/' and shell metacharacters.
+_PIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _warn(msg: str) -> None:
+    print(f"[vnx-reexec] WARNING: {msg}", file=sys.stderr)
+
+
+def _normalize_version(value: str) -> str:
+    """Normalize a version string for comparison.
+
+    Central version dirs are named e.g. ``v1.3.0`` while their ``VERSION``
+    file contains ``1.3.0``; treat a single leading ``v`` before a digit as
+    decorative so the two compare equal.
+    """
+    v = value.strip()
+    if len(v) > 1 and v[0] in "vV" and v[1].isdigit():
+        v = v[1:]
+    return v
+
+
+def _resolve_project_dir(argv: List[str]) -> Path:
+    """Resolve the project dir the way ``main.py`` does: ``--project-dir``
+    (last occurrence wins, both ``--project-dir DIR`` and ``--project-dir=DIR``
+    forms) else the current directory. Fail-open to cwd on any oddity."""
+    project_dir = "."
+    i = 0
+    while i < len(argv):
+        arg = argv[i]
+        if arg == "--project-dir" and i + 1 < len(argv):
+            project_dir = argv[i + 1]
+            i += 2
+            continue
+        if arg.startswith("--project-dir="):
+            project_dir = arg.split("=", 1)[1]
+        i += 1
+    try:
+        return Path(project_dir).expanduser().resolve()
+    except OSError:
+        return Path.cwd()
+
+
+def _read_pin(project_dir: Path) -> Optional[str]:
+    """Return the validated pin from ``project_dir/.vnx-version``.
+
+    None when there is no usable pin (absent, empty, unreadable, malformed) —
+    every one of those is a no-re-exec outcome.
+    """
+    pin_file = project_dir / PIN_FILE_NAME
+    if not pin_file.is_file():
+        return None
+    try:
+        lines = pin_file.read_text(encoding="utf-8").splitlines()
+        first = lines[0].strip() if lines else ""
+    except OSError as exc:
+        _warn(f"cannot read {pin_file} ({exc}); running current version")
+        return None
+    if not first:
+        return None
+    if first in (".", "..") or not _PIN_RE.match(first):
+        _warn(f"malformed pin {first!r} in {pin_file}; running current version")
+        return None
+    return first
+
+
+def _is_central_install(engine_root: Path) -> bool:
+    """True when the running engine root carries the central-install marker.
+
+    Mirrors the marker check in ``scripts/lib/vnx_paths.py::_is_central_install``
+    (the marker is only written by install-central.sh). Kept as a direct file
+    read so the re-exec decision needs no engine bootstrap.
+    """
+    marker = engine_root / INSTALL_MODE_MARKER
+    try:
+        return (
+            marker.is_file()
+            and marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+        )
+    except OSError:
+        return False
+
+
+def _running_version(engine_root: Path) -> Optional[str]:
+    """The version of the code this process actually loaded (its VERSION file)."""
+    try:
+        text = (engine_root / "VERSION").read_text(encoding="utf-8").strip()
+    except OSError:
+        return None
+    return text or None
+
+
+def _versions_dir(engine_root: Path) -> Path:
+    """The central store's ``versions/`` dir.
+
+    A central install always lives at ``<root>/versions/<v>``, so the running
+    engine root's parent IS the versions dir (this also honors custom roots
+    naturally). Fall back to ``$VNX_HOME_ROOT/versions`` then the default
+    ``~/.vnx-system/versions`` for non-standard layouts.
+    """
+    if engine_root.parent.name == "versions":
+        return engine_root.parent
+    env_root = os.environ.get("VNX_HOME_ROOT")
+    if env_root:
+        return Path(env_root).expanduser().resolve() / "versions"
+    return Path.home() / ".vnx-system" / "versions"
+
+
+def _resolve_pinned_dir(versions_dir: Path, pin: str) -> Optional[Path]:
+    """Find the pinned install in the central store.
+
+    Tries the pin as written, then the ``v``-prefixed / unprefixed spellings
+    (the pin file and the dir name may differ on the decorative ``v``).
+    Refuses any entry that resolves outside ``versions_dir`` (symlink escape),
+    mirroring the shim's realpath guard.
+    """
+    candidates = [pin]
+    norm = _normalize_version(pin)
+    for alt in (f"v{norm}", norm):
+        if alt and alt not in candidates:
+            candidates.append(alt)
+    for name in candidates:
+        candidate = versions_dir / name
+        if not candidate.is_dir():
+            continue
+        try:
+            if candidate.resolve().parent != versions_dir.resolve():
+                _warn(
+                    f"pinned version {pin!r} escapes the versions root "
+                    f"({versions_dir}); running current version"
+                )
+                return None
+        except OSError as exc:
+            _warn(f"cannot resolve pinned version dir {candidate} ({exc}); "
+                  "running current version")
+            return None
+        return candidate
+    return None
+
+
+def maybe_reexec_pinned(argv: Optional[List[str]] = None) -> None:
+    """Re-exec the pinned central install when the project pins another version.
+
+    Call as the FIRST thing ``main()`` does, before argparse dispatch. Either
+    replaces the process (os.execv — never returns) or returns to let the
+    current version continue. Never raises: the whole body is fail-open.
+    """
+    if argv is None:
+        argv = sys.argv[1:]
+    try:
+        _maybe_reexec_pinned(argv)
+    except Exception as exc:  # fail-open: a pin problem must never break the CLI
+        _warn(f"pin re-exec check failed ({exc}); running current version")
+
+
+def _maybe_reexec_pinned(argv: List[str]) -> None:
+    pin = _read_pin(_resolve_project_dir(argv))
+    if pin is None:
+        return
+
+    # Loop-guard: already re-exec'd to this exact pin — never exec again.
+    already = os.environ.get(REEXEC_ENV_FLAG, "").strip()
+    if already and _normalize_version(already) == _normalize_version(pin):
+        return
+
+    from vnx_cli import _engine
+
+    engine_root = _engine.engine_root()
+    if not _is_central_install(engine_root):
+        return  # dev checkout / non-central install: never re-exec
+
+    running = _running_version(engine_root)
+    if running is not None and _normalize_version(running) == _normalize_version(pin):
+        return  # already running the pinned version
+
+    versions_dir = _versions_dir(engine_root)
+    pinned_dir = _resolve_pinned_dir(versions_dir, pin)
+    if pinned_dir is None:
+        _warn(
+            f"pinned version {pin!r} is not installed under {versions_dir}; "
+            f"running current version ({running or 'unknown'})"
+        )
+        return
+
+    if not (pinned_dir / "vnx_cli" / "__init__.py").is_file():
+        _warn(
+            f"pinned install {pinned_dir} has no vnx_cli package; "
+            "running current version"
+        )
+        return
+
+    python = sys.executable
+    if not python:
+        _warn("cannot resolve the current python executable; running current version")
+        return
+
+    # Re-exec the pinned install as a WHOLE: its vnx_cli resolves its own
+    # sibling engine, so CLI and engine always come from the same version.
+    os.environ[REEXEC_ENV_FLAG] = pin
+    pythonpath = [
+        str(pinned_dir),
+        str(pinned_dir / "scripts"),
+        str(pinned_dir / "scripts" / "lib"),
+    ]
+    existing = os.environ.get("PYTHONPATH")
+    if existing:
+        pythonpath.append(existing)
+    os.environ["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    try:
+        os.execv(python, [python, "-m", "vnx_cli.main", *argv])
+    except OSError as exc:
+        _warn(f"re-exec to pinned version {pin!r} failed ({exc}); running current version")

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -180,9 +180,9 @@ def _register_init_subparser(subparsers: argparse.Action) -> None:
         default=None,
         metavar="VERSION",
         help="explicitly (re)write the .vnx-version pin to VERSION, even if a pin "
-             "already exists; must match [A-Za-z0-9._-]+. The pin is written but "
-             "the running pip CLI still resolves its own engine until the "
-             "pip-cli-honor-pin-via-reexec design-track lands",
+             "already exists; must match [A-Za-z0-9._-]+. The central-install pip "
+             "CLI honors the pin by re-exec'ing the pinned version at startup "
+             "(vnx_cli/_reexec.py)",
     )
 
 
@@ -1024,6 +1024,13 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
 
 
 def main() -> None:
+    # FIRST: honor a project's .vnx-version pin by re-exec'ing the pinned
+    # central install (vnx_cli + engine stay version-consistent). No-op for
+    # dev checkouts, matching pins, and any ambiguity (fail-open).
+    from vnx_cli._reexec import maybe_reexec_pinned
+
+    maybe_reexec_pinned()
+
     parser = argparse.ArgumentParser(
         prog="vnx",
         description="VNX — governance-first multi-agent orchestration for AI CLI workers",


### PR DESCRIPTION
## Summary

The pip `vnx` CLI ignored a project's `.vnx-version` pin — it ran whatever version its editable/wheel pointed at. Because `vnx_cli` is API-coupled to its engine (see the NOTE in `_engine.py::engine_root`), the pin **cannot** be honored by swapping the engine root in-process. This PR implements the design-track fix: **re-exec, not engine-swap**.

When a central-install run pins a DIFFERENT version than the one running, `main()` re-execs the pinned install **as a whole** (`python -m vnx_cli.main` with the pinned root on PYTHONPATH) as the first thing before argparse dispatch — CLI and engine always come from the same version.

## Safety contract (shared binary)

- **Loop-guard**: `VNX_PIN_REEXECED=<pin>` set before execv; a process already re-exec'd to that pin never execs again (survives off-by-a-hair version detection).
- **Fail-open**: any ambiguity — unreadable/malformed pin, pinned version missing from the store, symlink escape outside the versions root, missing pinned `vnx_cli`, execv failure, any unexpected exception — logs a `[vnx-reexec] WARNING` and continues with the current version. A pin problem never breaks the CLI.
- **Dev checkouts never re-exec**: only runs when the running engine root carries `.vnx-install-mode=central`.
- Decorative-`v` normalization: pin `v1.3.0` matches running VERSION `1.3.0`; dir lookup tries pin / `v`-prefixed / unprefixed spellings.

## Changes

- `vnx_cli/_reexec.py` (new): the startup re-exec module.
- `vnx_cli/main.py`: `main()` calls `maybe_reexec_pinned()` first; stale `--set-version` help text updated.
- `vnx_cli/_engine.py`: NOTE docstring updated (in-process resolution deliberately unchanged).
- `tests/test_vnx_cli_reexec.py` (new): 23 tests over a fake central store — no-op, re-exec-fires (argv/env asserted via monkeypatched `os.execv`), loop-guard, fail-open, and `main()` integration.

## Verification

- New suite: **23 passed**. Existing `test_vnx_cli*.py` + lockstep/doctor/install-marker suites: **79 passed**. `test_install_central.sh`: **43 passed**.
- Real smoke in /tmp (operator install untouched): pin v1.2.0 vs running 9.9.9 → re-exec fired, `vnx version` reported **VNX 1.2.0**; loop-guard / no-pin / missing-pin scenarios all behaved per contract.
- `tests/test_vnx_cli_update.py::test_dry_run_schema_warning_present` fails identically on clean base (verified via `git stash`) — pre-existing, unrelated.

Dispatch-ID: 20260723-pip-cli-honor-pin-reexec-r2
Track: pip-cli-honor-pin-via-reexec
Report: `$VNX_DATA_DIR/unified_reports/20260723-pip-cli-honor-pin-reexec-r2.md`