### PR TITLE
fix(kimi-spawn): raise per-chunk stall-timeout default 600s -> 1200s

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -683,7 +683,7 @@ def spawn_kimi(
     on_event: Optional[Callable[[Any], Optional[bool]]] = None,
     extra_env: Optional[Dict[str, str]] = None,
     cwd: Optional[Any] = None,
-    chunk_timeout: float = 600.0,
+    chunk_timeout: float = 1200.0,
     total_deadline: float = 900.0,
     event_store: Optional[Any] = None,
     **kwargs: Any,
@@ -694,7 +694,7 @@ def spawn_kimi(
     Returns KimiSpawnResult(returncode=127) when the kimi binary is absent.
     Caller is responsible for lease/manifest/receipt/event-archive/retry.
 
-    The per-chunk stall default is 600s (overridable via VNX_KIMI_STALL_THRESHOLD):
+    The per-chunk stall default is 1200s (overridable via VNX_KIMI_STALL_THRESHOLD):
     Kimi is a reasoning model whose 1.44.0 content-block output is end-loaded, so
     the first token can arrive only after a long reasoning gap (a 300s default
     spuriously killed adversarial-review dispatches mid-think). A FAILURE is


### PR DESCRIPTION
## Summary
Raise the kimi worker per-chunk stall-timeout default from 600s to 1200s. Kimi is now the default build-worker and thinks silently for long stretches on complex work; the 600s default SIGTERMed workers mid-think (it killed the pip-cli-honor-pin-via-reexec keystone at 600s, which only succeeded with a manual `VNX_KIMI_STALL_THRESHOLD=1800` override).

Dispatch: dispatch-20260723-kimi-stall-raise-1200 (track: kimi-stall-threshold-raise-1200)

## Changes
- `scripts/lib/provider_spawns/kimi_spawn.py`:
  - `spawn_kimi(..., chunk_timeout: float = 600.0)` → `1200.0`
  - Docstring updated: "The per-chunk stall default is 600s" → "1200s"
- `VNX_KIMI_STALL_THRESHOLD` env override unchanged; `total_deadline`/`VNX_KIMI_TIMEOUT` untouched.
- No tests asserted the 600.0 default (verified via grep over `tests/`), so no test changes needed.

## Verification
- `inspect.signature(spawn_kimi)` shows `chunk_timeout` default = `1200.0`; `VNX_KIMI_STALL_THRESHOLD=1800` override still wins (env read path unchanged).
- `pytest tests/test_kimi_spawn.py tests/test_kimi_spawn_camelcase.py` → **124 passed**.

## Open Items
- None.