### PR TITLE
fix(smart_router): migrate discontinued deepseek-chat → deepseek-v4-flash

### DIFF
--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -2,8 +2,9 @@
 
 Tier→provider mappings (honoring provider_constraints.yaml):
   tier-zero → local Gemma e4b via MLX; fallback Ollama
-  tier-low  → DeepSeek via Claude-harness key-auth (DEEPSEEK_API_KEY required)
-               OR Kimi via CLI (kimi-via-cli-only constraint)
+  tier-low  → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
+               (DEEPSEEK_API_KEY required) OR Kimi via CLI (kimi-via-cli-only
+               constraint)
   tier-mid  → claude-sonnet-4-6
   tier-high → claude-opus-4-8
 
@@ -97,7 +98,7 @@ def resolve_tier_route(tier: str, env: Optional[dict] = None) -> TierRoute:
             return TierRoute(
                 tier=tier,
                 provider="deepseek",
-                model="deepseek-chat",
+                model="deepseek-v4-flash",  # deepseek-chat discontinued 2026-07-24
                 lane="claude_harness_keyed",
                 env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
                 fallback=_ROUTE_KIMI,

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -60,6 +60,15 @@ def test_tier_low_with_deepseek_key_uses_harness():
     assert "DEEPSEEK_API_KEY" in route.env_requirements
 
 
+def test_tier_low_deepseek_route_uses_v4_flash():
+    """tier-low DeepSeek route must use deepseek-v4-flash — deepseek-chat was
+    discontinued by the provider on 2026-07-24."""
+    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
+    route = resolve_tier_route(TIER_LOW, env=env)
+    assert route.provider == "deepseek"
+    assert route.model == "deepseek-v4-flash"
+
+
 def test_deepseek_harness_blocked_without_key():
     """Empty DEEPSEEK_API_KEY falls back to Kimi (subscription route blocked)."""
     route = resolve_tier_route(TIER_LOW, env={"DEEPSEEK_API_KEY": ""})


### PR DESCRIPTION
## Summary

`deepseek-chat` is discontinued by the provider on **2026-07-24**. The only live hardcode was the TIER_LOW DeepSeek `TierRoute` in `scripts/lib/providers/smart_router/tier_routing.py:100` — once retired it would fail model-not-found and silently fall through to the Kimi fallback, degrading cost-aware routing.

## Changes

- `tier_routing.py`: TIER_LOW DeepSeek route `model="deepseek-chat"` → `model="deepseek-v4-flash"` (documented fast-lane successor in `routing_recommendations.yaml`, priced in the cost-aware router); docstring updated.
- `tests/smart_router/test_tier_routing.py`: added `test_tier_low_deepseek_route_uses_v4_flash` regression test.

The only remaining `deepseek-chat` reference repo-wide is a factually-correct historical mapping comment in `deepseek_harness_spawn.py:60` — intentionally left. No registry alias maps a logical id to `deepseek-chat`.

## Verification

- `tests/smart_router/test_tier_routing.py`: **13/13 passed** (incl. new regression test).
- Full smart_router suite: 203 passed, 4 failed — all 4 failures are **pre-existing** (verified by re-running on the unmodified branch); they are stale relative to the 2026-07-23 workers-kimi-pinned directive and out of scope here.

Dispatch-ID: dispatch-20260723-deepseek-flash-migrate