### PR TITLE
fix(vnx_cli): harden pin re-exec against cwd-local vnx_cli shadow

### DIFF
--- a/tests/test_vnx_cli_reexec.py
+++ b/tests/test_vnx_cli_reexec.py
@@ -40,6 +40,7 @@ def central_store(tmp_path, monkeypatch):
     # Hermetic: no inherited loop-guard flag / PYTHONPATH from the outer env.
     monkeypatch.delenv(_reexec.REEXEC_ENV_FLAG, raising=False)
     monkeypatch.delenv("PYTHONPATH", raising=False)
+    monkeypatch.delenv("PYTHONSAFEPATH", raising=False)
     return versions
 
 
@@ -129,10 +130,27 @@ def test_pin_different_installed_version_reexecs(central_store, execv_spy, tmp_p
     assert len(execv_spy) == 1
     python, args = execv_spy[0]
     assert python == sys.executable
-    assert args == [sys.executable, "-m", "vnx_cli.main", *argv]
+    assert args == [sys.executable, "-P", "-m", "vnx_cli.main", *argv]
     # Loop-guard armed + pinned install on PYTHONPATH for the exec'd process.
     assert os.environ[_reexec.REEXEC_ENV_FLAG] == "v1.2.0"
     assert os.environ["PYTHONPATH"].split(os.pathsep)[0] == str(pinned)
+
+
+def test_reexec_sets_safepath_against_cwd_shadow(central_store, execv_spy, tmp_path):
+    """cwd-shadow hardening: `python -m` prepends cwd to sys.path ahead of
+    PYTHONPATH, so a cwd-local `vnx_cli/` would shadow the pinned install.
+    The re-exec must set PYTHONSAFEPATH=1 in the environment AND pass the
+    explicit `-P` flag BEFORE `-m` so the pinned install always wins."""
+    _add_version(central_store, "v1.2.0", "1.2.0")
+    _pin(tmp_path, "v1.2.0")
+    argv = ["--project-dir", str(tmp_path)]
+    _reexec.maybe_reexec_pinned(argv)
+
+    assert len(execv_spy) == 1
+    _, args = execv_spy[0]
+    assert os.environ["PYTHONSAFEPATH"] == "1"
+    assert "-P" in args and "-m" in args
+    assert args.index("-P") < args.index("-m")
 
 
 def test_pin_without_v_resolves_v_prefixed_dir(central_store, execv_spy, tmp_path):

--- a/vnx_cli/_reexec.py
+++ b/vnx_cli/_reexec.py
@@ -246,7 +246,16 @@ def _maybe_reexec_pinned(argv: List[str]) -> None:
     if existing:
         pythonpath.append(existing)
     os.environ["PYTHONPATH"] = os.pathsep.join(pythonpath)
+    # cwd-shadow hardening: `python -m` prepends the process's CWD to
+    # sys.path ahead of PYTHONPATH, so a cwd-local `vnx_cli/` (a dev checkout
+    # or a vendored copy in a consumer repo) would SHADOW the pinned install.
+    # PYTHONSAFEPATH=1 + the explicit `-P` flag (both Python 3.11+, and
+    # pyproject declares requires-python >= 3.11) tell the re-exec'd
+    # interpreter not to prepend cwd, so the pinned vnx_cli on PYTHONPATH
+    # always wins. Both are set belt-and-suspenders: env var survives any
+    # argv rewrapping by a wrapper, -P documents the intent at the call site.
+    os.environ["PYTHONSAFEPATH"] = "1"
     try:
-        os.execv(python, [python, "-m", "vnx_cli.main", *argv])
+        os.execv(python, [python, "-P", "-m", "vnx_cli.main", *argv])
     except OSError as exc:
         _warn(f"re-exec to pinned version {pin!r} failed ({exc}); running current version")


### PR DESCRIPTION
## Summary

The startup pin re-exec (#1213) invoked the pinned install as `python -m vnx_cli.main`. CPython's `-m` prepends the process's cwd to `sys.path` ahead of `PYTHONPATH`, so a cwd-local `vnx_cli/` (dev checkout or vendored copy in a consumer repo) would SHADOW the pinned install — the re-exec'd process would import the wrong `vnx_cli`, exactly the version-inconsistency the pin keystone exists to prevent.

Fix: set `PYTHONSAFEPATH=1` before `execv` AND pass the explicit `-P` flag (`python -P -m vnx_cli.main`). Both are Python 3.11+; `pyproject.toml` declares `requires-python = ">=3.11,<3.14"`, so both are guaranteed valid fleet-wide. Used together belt-and-suspenders.

All existing safety properties untouched: loop-guard (`VNX_PIN_REEXECED`), fail-open on all ambiguity, dev-checkout never re-execs, symlink-escape guard.

## Changes

- `vnx_cli/_reexec.py`: `PYTHONSAFEPATH=1` env var + `-P` in exec argv, with an explanatory comment.
- `tests/test_vnx_cli_reexec.py`: new `test_reexec_sets_safepath_against_cwd_shadow` (asserts env var at exec time and `-P` before `-m` in argv); updated existing argv assertion; fixture now hermetic w.r.t. `PYTHONSAFEPATH`.

## Verification

`python3 -m pytest tests/test_vnx_cli_reexec.py -v` — **24/24 passed** (incl. all loop-guard / fail-open / dev-checkout / symlink-escape tests).

## Open Items

None.

---
Dispatch-ID: `20260723-reexec-cwd-shadow-harden` | Track: `reexec-m-cwd-shadow-harden` (P2, MUST land before the release-cut activates the re-exec) | Report: `$VNX_DATA_DIR/unified_reports/20260723-reexec-cwd-shadow-harden.md`