### PR TITLE
init: make all vnx init scaffold writes symlink-safe + atomic

### DIFF
--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -220,6 +220,122 @@ class TestVnxInitAtomicWriteSafety:
             assert planted.resolve() != version_file.resolve()
 
 
+class TestVnxInitSymlinkHardening:
+    """init-scaffold-symlink-hardening: every scaffold write is atomic +
+    symlink-safe (refuses escaping parent symlinks and symlink targets)."""
+
+    def test_escaping_parent_symlink_refused(self, tmp_path, tmp_path_factory):
+        # agents/ is a pre-planted symlink pointing OUTSIDE the project root:
+        # the agents/ scaffold writes must be refused, nothing lands outside.
+        outside = tmp_path_factory.mktemp("outside")
+        (tmp_path / "agents").symlink_to(outside, target_is_directory=True)
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc != 0
+        assert not (outside / "README.md").exists()
+        assert not (outside / "CLAUDE.md.template").exists()
+
+    def test_escaping_parent_symlink_error_names_component(
+        self, tmp_path, tmp_path_factory, capsys
+    ):
+        outside = tmp_path_factory.mktemp("outside")
+        (tmp_path / "agents").symlink_to(outside, target_is_directory=True)
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc != 0
+        err = capsys.readouterr().err
+        assert "symlink" in err
+        assert "agents" in err
+
+    def test_broken_symlink_at_profiles_path_refused(self, tmp_path, tmp_path_factory):
+        # A pre-planted (broken) symlink AT a scaffold target must be refused,
+        # never followed — the escape target must not be created.
+        outside_target = tmp_path_factory.mktemp("outside") / "profiles.yaml"
+        vnx_dir = tmp_path / ".vnx"
+        vnx_dir.mkdir()
+        (vnx_dir / "governance_profiles.yaml").symlink_to(outside_target)
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc != 0
+        assert not outside_target.exists()
+
+    def test_atomic_write_refuses_symlink_target_directly(self, tmp_path):
+        from vnx_cli.commands import init_cmd
+
+        outside = tmp_path / "outside.txt"
+        outside.write_text("do-not-touch\n")
+        link = tmp_path / "target.txt"
+        link.symlink_to(outside)
+
+        with pytest.raises(OSError, match="symlink"):
+            init_cmd._atomic_write(link, "payload\n", tmp_path)
+
+        # The symlink target is untouched and the link itself is left in place.
+        assert outside.read_text() == "do-not-touch\n"
+        assert link.is_symlink()
+
+    def test_atomic_write_refuses_path_outside_root(self, tmp_path, tmp_path_factory):
+        from vnx_cli.commands import init_cmd
+
+        outside = tmp_path_factory.mktemp("outside") / "file.txt"
+        with pytest.raises(OSError, match="outside project root"):
+            init_cmd._atomic_write(outside, "payload\n", tmp_path)
+        assert not outside.exists()
+
+    def test_raw_callsites_routed_through_atomic_write(self, tmp_path, monkeypatch):
+        # The three previously-raw writes (profiles / agents README /
+        # agents CLAUDE.md.template) must go through the atomic helper.
+        from vnx_cli.commands import init_cmd
+
+        written: list[Path] = []
+        orig = init_cmd._atomic_write
+
+        def spy(path, content, root):
+            written.append(Path(path))
+            return orig(path, content, root)
+
+        monkeypatch.setattr(init_cmd, "_atomic_write", spy)
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+
+        profiles = tmp_path / ".vnx" / "governance_profiles.yaml"
+        agents_readme = tmp_path / "agents" / "README.md"
+        agents_claude = tmp_path / "agents" / "CLAUDE.md.template"
+        assert profiles in written
+        assert agents_readme in written
+        assert agents_claude in written
+
+        # Content is unchanged from the scaffold constants.
+        assert profiles.read_text() == init_cmd.GOVERNANCE_PROFILES_YAML
+        assert agents_readme.read_text() == init_cmd.AGENTS_README
+        assert agents_claude.read_text() == init_cmd.CLAUDE_MD_TEMPLATE
+
+    def test_full_scaffold_no_regression(self, tmp_path):
+        # Normal (non-symlink) init still scaffolds every file correctly.
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        expected_files = [
+            ".vnx-project-id",
+            ".vnx/governance_profiles.yaml",
+            ".vnx/config.yml",
+            ".vnx-version",
+            "agents/README.md",
+            "agents/CLAUDE.md.template",
+            ".claude/terminals/T0/CLAUDE.md",
+            ".claude/settings.json",
+            "CLAUDE.md",
+            "FEATURE_PLAN.md",
+            ".gitignore",
+            "CODEOWNERS",
+            ".vnx-attest/allowed_signers",
+            ".vnx-attest/README.md",
+            ".github/workflows/attestation-gate.yml",
+        ]
+        for rel in expected_files:
+            assert (tmp_path / rel).is_file(), f"missing scaffold file: {rel}"
+
+
 class TestVnxInitAttestDelivery:
     """D5a + D5b: attestation trust-root and gate workflow delivery."""
 

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -192,13 +192,62 @@ _CODEOWNERS_ATTEST_BLOCK = """\
 """
 
 
-def _atomic_write(path: Path, content: str) -> None:
+def _assert_symlink_safe(path: Path, root: Path) -> None:
+    """Refuse scaffold writes that would escape the project root via symlinks.
+
+    Raises OSError (fail loud, naming the offending component) when:
+      - ``path`` is not lexically under ``root``;
+      - ``path`` itself is an existing symlink (never follow/replace-through);
+      - any parent directory component between ``root`` and ``path`` is a
+        symlink whose target resolves OUTSIDE ``root``.
+
+    A symlink component that resolves back INSIDE the project root is allowed
+    (e.g. an operator linking .vnx-data to a sibling dir inside the project).
+    """
+    root_resolved = Path(root).resolve()
+    path = Path(path)
+    try:
+        rel = path.relative_to(root_resolved)
+    except ValueError:
+        raise OSError(
+            f"refusing to scaffold {path}: outside project root {root_resolved}"
+        ) from None
+    if path.is_symlink():
+        raise OSError(
+            f"refusing to write {path}: target is an existing symlink "
+            f"(-> {os.readlink(path)})"
+        )
+    current = root_resolved
+    for part in rel.parts[:-1]:
+        current = current / part
+        if current.is_symlink():
+            resolved = current.resolve()
+            if not _is_within(resolved, root_resolved):
+                raise OSError(
+                    f"refusing to write {path}: parent component {current} is a "
+                    f"symlink escaping the project root (-> {resolved})"
+                )
+
+
+def _atomic_write(path: Path, content: str, root: Path) -> None:
     """Write ``content`` to ``path`` via a tmp file + os.replace (atomic).
+
+    Symlink-safe: ``root`` is the project root being initialised; the write is
+    refused (OSError) if ``path`` or any parent component up to ``root`` is a
+    symlink escaping that root — the scaffold never lands outside the project.
 
     Uses a randomized temp name in the same directory so a pre-planted symlink
     at a fixed ``.tmp`` path cannot be followed/truncated (symlink-TOCTOU).
     """
+    _assert_symlink_safe(path, root)
     path.parent.mkdir(parents=True, exist_ok=True)
+    # Post-mkdir re-check: closes the window where a component was swapped for
+    # an escaping symlink between the pre-check and the directory creation.
+    if not _is_within(path.parent, root):
+        raise OSError(
+            f"refusing to write {path}: resolved parent {path.parent.resolve()} "
+            f"escapes project root {Path(root).resolve()}"
+        )
     fd, tmp_name = tempfile.mkstemp(
         dir=str(path.parent), prefix=f".{path.name}.", suffix=".tmp"
     )
@@ -233,7 +282,7 @@ def _write_project_id_marker(project_dir: Path, project_id: str) -> bool:
     if existing_lines and existing_lines[0].strip() == project_id:
         return False
     rest = existing_lines[1:] if len(existing_lines) > 1 else []
-    _atomic_write(marker, "\n".join([project_id, *rest]) + "\n")
+    _atomic_write(marker, "\n".join([project_id, *rest]) + "\n", project_dir)
     return True
 
 
@@ -268,7 +317,7 @@ def _scaffold_claude_dir(project_dir: Path, tmpl_root: Path, ctx: dict, force: b
     t0_md = claude_dir / "terminals" / "T0" / "CLAUDE.md"
     t0_md.parent.mkdir(parents=True, exist_ok=True)
     if not t0_md.exists() or force:
-        _atomic_write(t0_md, _render_template(tmpl_root / "terminals" / "T0_claude_md.j2", ctx))
+        _atomic_write(t0_md, _render_template(tmpl_root / "terminals" / "T0_claude_md.j2", ctx), project_dir)
         print(f"  created {t0_md.relative_to(project_dir)}")
     else:
         print(f"  exists  {t0_md.relative_to(project_dir)}")
@@ -282,7 +331,7 @@ def _scaffold_claude_dir(project_dir: Path, tmpl_root: Path, ctx: dict, force: b
 
     settings_path = claude_dir / "settings.json"
     if not settings_path.exists() or force:
-        _atomic_write(settings_path, _render_template(tmpl_root / "settings.json.j2", ctx))
+        _atomic_write(settings_path, _render_template(tmpl_root / "settings.json.j2", ctx), project_dir)
         print(f"  created {settings_path.relative_to(project_dir)}")
     else:
         print(f"  exists  {settings_path.relative_to(project_dir)}")
@@ -311,11 +360,11 @@ def _write_vnx_version(project_dir: Path, version: str, set_version: str | None 
     path = project_dir / ".vnx-version"
     existed = path.is_file()
     if set_version:
-        _atomic_write(path, set_version + "\n")
+        _atomic_write(path, set_version + "\n", project_dir)
         return "set" if existed else "created"
     if existed:
         return "preserved"
-    _atomic_write(path, version + "\n")
+    _atomic_write(path, version + "\n", project_dir)
     return "created"
 
 
@@ -324,7 +373,7 @@ def _write_root_claude_md(project_dir: Path, tmpl_root: Path, ctx: dict, force: 
     if path.exists() and not force:
         print("  exists  CLAUDE.md")
         return
-    _atomic_write(path, _render_template(tmpl_root / "claude_md.j2", ctx))
+    _atomic_write(path, _render_template(tmpl_root / "claude_md.j2", ctx), project_dir)
     print("  created CLAUDE.md")
 
 
@@ -338,6 +387,7 @@ def _write_feature_plan(project_dir: Path, force: bool) -> None:
         "# Feature Plan\n\n"
         "<!-- Start a new track: vnx track new <id>"
         " --project-id <proj-id> --title '...' --goal '...' -->\n",
+        project_dir,
     )
     print("  created FEATURE_PLAN.md")
 
@@ -354,7 +404,7 @@ def _update_gitignore(project_dir: Path) -> None:
         new_content = content.rstrip() + "\n\n# VNX runtime state\n" + marker + "\n"
     else:
         new_content = "# VNX runtime state\n" + marker + "\n"
-    _atomic_write(gi_path, new_content)
+    _atomic_write(gi_path, new_content, project_dir)
     print(f"  updated .gitignore (added {marker})")
 
 
@@ -561,14 +611,14 @@ def _provision_attest_trust_root(project_dir: Path, force: bool) -> None:
 
     signers_path = attest_dir / "allowed_signers"
     if not signers_path.exists() or force:
-        _atomic_write(signers_path, _ATTEST_ALLOWED_SIGNERS_SCAFFOLD)
+        _atomic_write(signers_path, _ATTEST_ALLOWED_SIGNERS_SCAFFOLD, project_dir)
         print(f"  created .vnx-attest/allowed_signers (scaffold — no key generated)")
     else:
         print(f"  exists  .vnx-attest/allowed_signers")
 
     readme_path = attest_dir / "README.md"
     if not readme_path.exists() or force:
-        _atomic_write(readme_path, _ATTEST_README_CONTENT)
+        _atomic_write(readme_path, _ATTEST_README_CONTENT, project_dir)
         print(f"  created .vnx-attest/README.md")
     else:
         print(f"  exists  .vnx-attest/README.md")
@@ -586,7 +636,7 @@ def _provision_attest_trust_root(project_dir: Path, force: bool) -> None:
         print(f"  exists  CODEOWNERS (attest entries already present)")
     else:
         new_content = existing.rstrip() + _CODEOWNERS_ATTEST_BLOCK
-        _atomic_write(codeowners_path, new_content)
+        _atomic_write(codeowners_path, new_content, project_dir)
         print(f"  {'updated' if existing else 'created'} CODEOWNERS (added attest trust-root entries)")
 
 
@@ -613,7 +663,7 @@ def _provision_github_workflow(project_dir: Path) -> None:
         return
 
     dest.parent.mkdir(parents=True, exist_ok=True)
-    _atomic_write(dest, template_path.read_text(encoding="utf-8"))
+    _atomic_write(dest, template_path.read_text(encoding="utf-8"), project_dir)
     print(f"  created .github/workflows/attestation-gate.yml")
 
 
@@ -656,6 +706,20 @@ def vnx_init(args) -> int:
         print(f"  error: {exc}", file=sys.stderr)
         return 1
 
+    # Every scaffold write below goes through the symlink-safe _atomic_write;
+    # a refusal (hostile/escaping symlink in the target tree) aborts init with
+    # a clear error instead of writing outside the project root.
+    try:
+        return _vnx_init_scaffold(
+            project_dir, template, force, set_version, project_id
+        )
+    except OSError as exc:
+        print(f"\n  error: scaffold write refused: {exc}", file=sys.stderr)
+        return 1
+
+
+def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) -> int:
+    """Scaffold body of vnx_init (split out so OSError refusals fail clean)."""
     # --- tracked, in-project config (tiny footprint) ----------------------
     vnx_dir = project_dir / ".vnx"
     vnx_dir.mkdir(parents=True, exist_ok=True)
@@ -667,7 +731,7 @@ def vnx_init(args) -> int:
 
     profiles_path = vnx_dir / "governance_profiles.yaml"
     if not profiles_path.exists():
-        profiles_path.write_text(GOVERNANCE_PROFILES_YAML)
+        _atomic_write(profiles_path, GOVERNANCE_PROFILES_YAML, project_dir)
         print(f"  created {profiles_path.relative_to(project_dir)}")
     else:
         print(f"  exists  {profiles_path.relative_to(project_dir)}")
@@ -683,6 +747,7 @@ def vnx_init(args) -> int:
             f'project_root: "{project_dir}"\n'
             f'project_id: "{project_id}"\n'
             f'vnx_data_dir: "{data_root}"\n',
+            project_dir,
         )
         print(f"  created {config_path.relative_to(project_dir)}")
     else:
@@ -693,14 +758,14 @@ def vnx_init(args) -> int:
     agents_dir.mkdir(exist_ok=True)
     readme_path = agents_dir / "README.md"
     if not readme_path.exists():
-        readme_path.write_text(AGENTS_README)
+        _atomic_write(readme_path, AGENTS_README, project_dir)
         print(f"  created {readme_path.relative_to(project_dir)}")
     else:
         print(f"  exists  {readme_path.relative_to(project_dir)}")
 
     claude_md = agents_dir / "CLAUDE.md.template"
     if not claude_md.exists():
-        claude_md.write_text(CLAUDE_MD_TEMPLATE)
+        _atomic_write(claude_md, CLAUDE_MD_TEMPLATE, project_dir)
         print(f"  created {claude_md.relative_to(project_dir)}")
     else:
         print(f"  exists  {claude_md.relative_to(project_dir)}")


### PR DESCRIPTION
## Summary

All `vnx init` scaffold writes are now atomic AND symlink-safe. Closes dispatch `20260723-init-scaffold-symlink-harden` (track: init-scaffold-symlink-hardening).

**Two gaps fixed:**

1. **Raw writes bypassed the atomic helper** — `.vnx/governance_profiles.yaml`, `agents/README.md`, and `agents/CLAUDE.md.template` used raw `write_text()`. All scaffold writes now go through `_atomic_write` (verified by grep: only the atomic temp write and the append-only audit log remain).

2. **No symlink-safety on the write path** — `_atomic_write` followed pre-planted symlinks in parent dirs, letting scaffold content land outside the project root. Now:
   - New `_assert_symlink_safe(path, root)` refuses (OSError naming the offending component) when the target is an existing symlink, or any parent component up to the project root is a symlink escaping the root (reuses `_is_within`).
   - Post-`mkdir` containment re-check narrows the check→create window.
   - `vnx_init` catches the refusal and exits rc=1 with a clear error instead of a traceback.

WHAT is scaffolded is unchanged — same files, same content; only HOW. Hardening kept local to `init_cmd._atomic_write` (shared `scripts/lib/atomic_io.py` has many external callers and no project-root concept; rationale in the unified report).

## Tests

New `TestVnxInitSymlinkHardening` (7 tests): escaping parent symlink refused (nothing lands outside), error names offending component, broken symlink at profiles path refused, direct unit refusals, raw callsites routed through the helper with byte-identical content, full-scaffold no-regression.

```
tests/test_cli_init.py: 32 passed
broader init suite (test_vnx_init, test_init_migrate_bootstrap, test_w_init_project_id_threading, test_migrate_pool_seed, test_vnx_cli): 119 passed, 2 failed — both reproduced on the clean branch (pre-existing, unrelated)
```

Unified report: `$VNX_DATA_DIR/unified_reports/20260723-init-scaffold-symlink-harden.md`