### PR TITLE
feat(release): vnx release publish --tag + pin-safe GC prune

### DIFF
--- a/install-central.sh
+++ b/install-central.sh
@@ -16,6 +16,7 @@ VERSION="v1.0.0"
 TARGET_DIR="${HOME}/.vnx-system"
 SOURCE_URL="https://github.com/Vinix24/vnx-orchestration"
 DRY_RUN=false
+MATERIALIZE_ONLY=false
 
 # Defined early so arg parsing can call it before helpers are defined.
 validate_version() {
@@ -48,6 +49,11 @@ while [ $# -gt 0 ]; do
       SOURCE_URL="${1#*=}"; shift ;;
     --dry-run)
       DRY_RUN=true; shift ;;
+    --materialize-only)
+      # Produce versions/<version>/ only: skip the current-symlink swap, shim
+      # install, and post-install verification. Used by `vnx release publish`,
+      # which owns the (optional, --set-current-gated) cutover itself.
+      MATERIALIZE_ONLY=true; shift ;;
     -h|--help)
       cat <<HELP
 Usage: install-central.sh [OPTIONS]
@@ -57,6 +63,7 @@ Options:
   --version <ver>   Version to install (default: v1.0.0)
   --source <url>    Git source URL (default: github.com/Vinix24/vnx-orchestration)
   --dry-run         Print steps without touching filesystem
+  --materialize-only  Only materialize versions/<version>/ (no current flip, no shim)
   -h, --help        Show this help
 
 Examples:
@@ -184,8 +191,12 @@ clone_version() {
   run mkdir -p "$(dirname "$version_dir")"
 
   local clone_url="$SOURCE_URL"
-  # Normalize: add https:// if not present
-  if [[ "$clone_url" != https://* ]] && [[ "$clone_url" != git@* ]] && [[ "$clone_url" != http://* ]]; then
+  # Normalize: add https:// if not present. Local sources (existing path or
+  # file:// URL) are used as-is — `vnx release publish` passes a temp checkout
+  # dir as --source, and prepending https:// would break the clone.
+  if [ -e "$clone_url" ] || [[ "$clone_url" == file://* ]]; then
+    : # local source — no URL normalization
+  elif [[ "$clone_url" != https://* ]] && [[ "$clone_url" != git@* ]] && [[ "$clone_url" != http://* ]]; then
     clone_url="https://${clone_url}"
   fi
 
@@ -363,6 +374,12 @@ main() {
 
   check_prereqs
   clone_version
+
+  if [ "$MATERIALIZE_ONLY" = "true" ]; then
+    success "Materialized ${VERSION} at ${TARGET_DIR}/versions/${VERSION} (no current flip, no shim)"
+    return 0
+  fi
+
   if [ -L "${TARGET_DIR}/current" ]; then
     _PREVIOUS_TARGET=$(readlink "${TARGET_DIR}/current")
   fi

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -3,6 +3,7 @@
 
 import io
 import json
+import os
 import subprocess
 import sys
 from argparse import Namespace
@@ -23,6 +24,8 @@ from vnx_cli.commands.update import (
     _list_version_dirs,
     _current_target,
     _prune_old_versions,
+    _collect_protected_versions,
+    _load_fleet_pins,
     _atomic_symlink_flip,
     _validate_version_name,
     _fetch_version,
@@ -55,12 +58,13 @@ def _git_origin(tmp_path: Path) -> Path:
     return origin
 
 
-def _update_args(*, to_version=None, keep_last=DEFAULT_KEEP_LAST, dry_run=False, rollback=False):
+def _update_args(*, to_version=None, keep_last=DEFAULT_KEEP_LAST, dry_run=False, rollback=False, protect_pins=None):
     return Namespace(
         to_version=to_version,
         keep_last=keep_last,
         dry_run=dry_run,
         rollback=rollback,
+        protect_pins=protect_pins,
     )
 
 
@@ -687,3 +691,246 @@ def test_vnx_update_dry_run_does_not_repair_marker(tmp_path, monkeypatch):
     vnx_update(_update_args(to_version="edge", dry_run=True))
 
     assert not (active / INSTALL_MODE_MARKER).exists()
+
+
+# ---------------------------------------------------------------------------
+# Pin-safe GC: _prune_old_versions never prunes a pinned/protected version
+# ---------------------------------------------------------------------------
+
+def _version_dirs(root: Path, names, *, oldest_first=True):
+    """Create version dirs with strictly increasing mtimes (deterministic age)."""
+    dirs = []
+    ordered = names if oldest_first else list(reversed(names))
+    base = 1_700_000_000
+    for i, name in enumerate(ordered):
+        d = root / "versions" / name
+        d.mkdir(parents=True, exist_ok=True)
+        ts = base + i * 100
+        os.utime(d, (ts, ts))
+        dirs.append(d)
+    return dirs
+
+
+def _empty_registry(tmp_path, monkeypatch):
+    """Point the fleet registry at a nonexistent path for hermetic tests."""
+    missing = tmp_path / "no-such-registry.json"
+    monkeypatch.setenv("VNX_PROJECT_REGISTRY", str(missing))
+    return missing
+
+
+def _audit_events(audit_log: Path):
+    return [json.loads(line) for line in audit_log.read_text().strip().splitlines()]
+
+
+def test_prune_protects_cli_protect_pins(tmp_path, monkeypatch):
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        protect_pins="v1.0.1,v1.0.2", audit_log=audit_log,
+    )
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    # v1.0.1 and v1.0.2 are prune candidates (oldest of 5, keep 3) but protected.
+    assert remaining == ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+
+    events = _audit_events(audit_log)
+    protected_events = [e for e in events if e["event_type"] == "central_install_prune_protected"]
+    assert sorted(e["protected_version"] for e in protected_events) == ["v1.0.1", "v1.0.2"]
+    for event in protected_events:
+        assert event["keep_last_N"] == 3
+        assert any("--protect-pins" in r for r in event["reasons"])
+        assert "timestamp" in event and event["timestamp"]
+    # Nothing was actually pruned (both candidates protected), so no prune events.
+    assert not [e for e in events if e["event_type"] == "central_install_prune"]
+
+
+def test_prune_protects_versions_from_protected_versions_file(tmp_path, monkeypatch):
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    # v-prefix normalization: the file lists the bare form, the dir is v-prefixed.
+    (tmp_path / "protected-versions").write_text(
+        "# operator-curated GC protection\n1.0.1\n\n", encoding="utf-8"
+    )
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    # v1.0.2 pruned (unprotected candidate); v1.0.1 survives via the file.
+    assert remaining == ["v1.0.1", "v1.0.3", "v1.0.4", "v1.0.5"]
+
+    events = _audit_events(audit_log)
+    protected_events = [e for e in events if e["event_type"] == "central_install_prune_protected"]
+    assert len(protected_events) == 1
+    assert protected_events[0]["protected_version"] == "v1.0.1"
+    assert any("protected-versions" in r for r in protected_events[0]["reasons"])
+    pruned = [e["pruned_version"] for e in events if e["event_type"] == "central_install_prune"]
+    assert pruned == ["v1.0.2"]
+
+
+def test_prune_protects_fleet_registry_pins(tmp_path, monkeypatch):
+    """A pin in any registered consumer project's .vnx-version protects the dir."""
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    consumer = tmp_path / "consumer-project"
+    consumer.mkdir()
+    (consumer / ".vnx-version").write_text("v1.0.1\n", encoding="utf-8")
+    registry = tmp_path / "projects.json"
+    registry.write_text(
+        json.dumps({"schema_version": 2, "projects": [{"path": str(consumer)}]}),
+        encoding="utf-8",
+    )
+
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        registry_path=registry, audit_log=audit_log,
+    )
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == ["v1.0.1", "v1.0.3", "v1.0.4", "v1.0.5"]
+
+    events = _audit_events(audit_log)
+    protected_events = [e for e in events if e["event_type"] == "central_install_prune_protected"]
+    assert len(protected_events) == 1
+    assert protected_events[0]["protected_version"] == "v1.0.1"
+    assert any("pinned by project" in r for r in protected_events[0]["reasons"])
+
+
+def test_prune_protection_sources_union(tmp_path, monkeypatch):
+    """Registry + protected-versions file + --protect-pins all union together."""
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    consumer = tmp_path / "consumer-project"
+    consumer.mkdir()
+    (consumer / ".vnx-version").write_text("v1.0.1\n", encoding="utf-8")
+    registry = tmp_path / "projects.json"
+    registry.write_text(
+        json.dumps({"projects": [{"path": str(consumer)}]}), encoding="utf-8"
+    )
+    (tmp_path / "protected-versions").write_text("v1.0.2\n", encoding="utf-8")
+
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        protect_pins="v1.0.3", registry_path=registry,
+        audit_log=tmp_path / "events" / "central_install.ndjson",
+    )
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+
+
+def test_prune_protection_dry_run_no_deletion_no_audit(tmp_path, monkeypatch):
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _prune_old_versions(
+            tmp_path, keep_last=3, dry_run=True,
+            protect_pins="v1.0.1", audit_log=audit_log,
+        )
+
+    output = buf.getvalue()
+    assert "[dry-run] Would protect from prune:" in output
+    assert "v1.0.1" in output
+    assert len(list((tmp_path / "versions").iterdir())) == 5
+    assert not audit_log.exists()
+
+
+def test_prune_keep_last_still_prunes_unprotected(tmp_path, monkeypatch):
+    """Protecting one candidate must not shield the other old candidates."""
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5", "v1.0.6"]
+    _version_dirs(tmp_path, names)
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        protect_pins="v1.0.1",
+        audit_log=tmp_path / "events" / "central_install.ndjson",
+    )
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    # 3 prune candidates (v1.0.1..v1.0.3): v1.0.1 protected, other two pruned.
+    assert remaining == ["v1.0.1", "v1.0.4", "v1.0.5", "v1.0.6"]
+
+
+def test_prune_protection_ignores_malformed_entries(tmp_path, monkeypatch, capsys):
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        protect_pins="../escape,v1.0.1,foo;rm -rf /",
+        audit_log=tmp_path / "events" / "central_install.ndjson",
+    )
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert "v1.0.1" in remaining
+    assert "v1.0.2" not in remaining
+    captured = capsys.readouterr()
+    assert "malformed protected version" in captured.err
+
+
+def test_collect_protected_versions_normalizes_v_prefix(tmp_path, monkeypatch):
+    _empty_registry(tmp_path, monkeypatch)
+    protected = _collect_protected_versions(tmp_path, protect_pins="v1.3.0,1.2.3")
+    assert "1.3.0" in protected
+    assert "1.2.3" in protected
+
+
+def test_load_fleet_pins_skips_missing_and_malformed(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    pinned = tmp_path / "pinned-project"
+    pinned.mkdir()
+    (pinned / ".vnx-version").write_text("v2.0.0\n", encoding="utf-8")
+    unpinned = tmp_path / "unpinned-project"
+    unpinned.mkdir()
+    malformed = tmp_path / "malformed-project"
+    malformed.mkdir()
+    (malformed / ".vnx-version").write_text("../escape\n", encoding="utf-8")
+    registry = tmp_path / "projects.json"
+    registry.write_text(
+        json.dumps({"projects": [
+            {"path": str(pinned)},
+            {"path": str(unpinned)},
+            {"path": str(malformed)},
+            {"path": str(tmp_path / "does-not-exist")},
+            {},  # no path key
+        ]}),
+        encoding="utf-8",
+    )
+
+    pins = _load_fleet_pins(registry)
+
+    assert list(pins.keys()) == ["2.0.0"]
+    assert any("pinned by project" in s for s in pins["2.0.0"])
+
+
+def test_vnx_update_dry_run_threads_protect_pins(tmp_path, monkeypatch):
+    """End-to-end: vnx_update --dry-run surfaces pin protection in prune plan."""
+    _empty_registry(tmp_path, monkeypatch)
+    monkeypatch.setenv("VNX_HOME_ROOT", str(tmp_path))
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = vnx_update(_update_args(to_version="edge", dry_run=True, protect_pins="v1.0.1"))
+
+    output = buf.getvalue()
+    assert rc == 0
+    assert "Would protect from prune" in output
+    assert len(list((tmp_path / "versions").iterdir())) == 5

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -20,6 +20,7 @@ if str(REPO_ROOT) not in sys.path:
 import vnx_cli.commands.update as update_module
 from vnx_cli.commands.update import (
     vnx_update,
+    ProtectionSetUnavailable,
     _resolve_root,
     _list_version_dirs,
     _current_target,
@@ -184,7 +185,7 @@ def test_dry_run_schema_warning_present(tmp_path, monkeypatch):
     with redirect_stdout(buf):
         vnx_update(args)
 
-    assert "schema-bootstrap" in buf.getvalue().lower() or "central-4" in buf.getvalue().lower()
+    assert "would migrate all central per-project stores" in buf.getvalue().lower()
 
 
 # ---------------------------------------------------------------------------
@@ -917,6 +918,164 @@ def test_load_fleet_pins_skips_missing_and_malformed(tmp_path, monkeypatch):
 
     assert list(pins.keys()) == ["2.0.0"]
     assert any("pinned by project" in s for s in pins["2.0.0"])
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed GC: an undeterminable protected set aborts the prune entirely
+# ---------------------------------------------------------------------------
+
+def test_prune_aborts_on_malformed_fleet_registry(tmp_path, monkeypatch, capsys):
+    """Registry EXISTS but JSON parse fails => fail CLOSED: nothing pruned."""
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    registry = tmp_path / "projects.json"
+    registry.write_text("{ not valid json", encoding="utf-8")
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=False,
+        registry_path=registry, audit_log=audit_log,
+    )
+
+    # Fail-closed: NO version dir was deleted.
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == names
+
+    captured = capsys.readouterr()
+    assert "GC prune ABORTED (fail-closed)" in captured.err
+    assert str(registry) in captured.err
+
+    events = _audit_events(audit_log)
+    aborted = [e for e in events if e["event_type"] == "central_install_prune_aborted"]
+    assert len(aborted) == 1
+    assert aborted[0]["source"] == str(registry)
+    assert aborted[0]["keep_last_N"] == 3
+    assert "reason" in aborted[0] and aborted[0]["reason"]
+    assert "timestamp" in aborted[0] and aborted[0]["timestamp"]
+    # No prune/protected events — the prune never ran.
+    assert not [e for e in events if e["event_type"] == "central_install_prune"]
+    assert not [e for e in events if e["event_type"] == "central_install_prune_protected"]
+
+
+def test_prune_aborts_on_unreadable_fleet_registry_oserror(tmp_path, monkeypatch, capsys):
+    """Registry EXISTS but the read itself fails (chmod 000) => fail CLOSED."""
+    if hasattr(os, "geteuid") and os.geteuid() == 0:
+        pytest.skip("root can read chmod-000 files — OSError path unreachable")
+    registry = tmp_path / "projects.json"
+    registry.write_text(json.dumps({"projects": []}), encoding="utf-8")
+    registry.chmod(0o000)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    try:
+        _prune_old_versions(
+            tmp_path, keep_last=3, dry_run=False,
+            registry_path=registry, audit_log=audit_log,
+        )
+    finally:
+        registry.chmod(0o644)
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == names
+    captured = capsys.readouterr()
+    assert "GC prune ABORTED (fail-closed)" in captured.err
+    aborted = [
+        e for e in _audit_events(audit_log)
+        if e["event_type"] == "central_install_prune_aborted"
+    ]
+    assert len(aborted) == 1
+    assert aborted[0]["source"] == str(registry)
+
+
+def test_prune_aborts_on_unreadable_protected_versions_file(tmp_path, monkeypatch, capsys):
+    """protected-versions EXISTS but is unreadable (invalid UTF-8) => fail CLOSED."""
+    _empty_registry(tmp_path, monkeypatch)
+    (tmp_path / "protected-versions").write_bytes(b"v1.0.1\n\xff\xfe not utf-8\n")
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    # Fail-closed: NO version dir was deleted — not even the unprotected v1.0.2.
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == names
+
+    captured = capsys.readouterr()
+    assert "GC prune ABORTED (fail-closed)" in captured.err
+    assert "protected-versions" in captured.err
+
+    aborted = [
+        e for e in _audit_events(audit_log)
+        if e["event_type"] == "central_install_prune_aborted"
+    ]
+    assert len(aborted) == 1
+    assert "protected-versions" in aborted[0]["source"]
+
+
+def test_prune_abort_dry_run_warns_without_audit(tmp_path, monkeypatch, capsys):
+    """Dry-run also aborts pruning, but (like all dry-run paths) writes no audit."""
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    registry = tmp_path / "projects.json"
+    registry.write_text("{ not valid json", encoding="utf-8")
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(
+        tmp_path, keep_last=3, dry_run=True,
+        registry_path=registry, audit_log=audit_log,
+    )
+
+    assert len(list((tmp_path / "versions").iterdir())) == 5
+    captured = capsys.readouterr()
+    assert "GC prune ABORTED (fail-closed)" in captured.err
+    assert not audit_log.exists()
+
+
+def test_prune_absent_sources_still_prunes_unprotected(tmp_path, monkeypatch):
+    """ABSENT registry + ABSENT protected-versions file = no pins, NOT a failure:
+    normal pruning of unprotected candidates still happens."""
+    _empty_registry(tmp_path, monkeypatch)
+    assert not (tmp_path / "protected-versions").exists()
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == ["v1.0.3", "v1.0.4", "v1.0.5"]
+    events = _audit_events(audit_log)
+    assert sorted(e["pruned_version"] for e in events if e["event_type"] == "central_install_prune") == [
+        "v1.0.1", "v1.0.2",
+    ]
+    assert not [e for e in events if e["event_type"] == "central_install_prune_aborted"]
+
+
+def test_load_fleet_pins_raises_on_malformed_registry(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PROJECT_REGISTRY", raising=False)
+    registry = tmp_path / "projects.json"
+    registry.write_text("{ not valid json", encoding="utf-8")
+
+    with pytest.raises(ProtectionSetUnavailable) as excinfo:
+        _load_fleet_pins(registry)
+
+    assert excinfo.value.source == str(registry)
+    assert isinstance(excinfo.value.cause, json.JSONDecodeError)
+
+
+def test_collect_protected_versions_raises_on_unreadable_file(tmp_path, monkeypatch):
+    _empty_registry(tmp_path, monkeypatch)
+    pfile = tmp_path / "protected-versions"
+    pfile.write_bytes(b"\xff\xfe not utf-8")
+
+    with pytest.raises(ProtectionSetUnavailable) as excinfo:
+        _collect_protected_versions(tmp_path)
+
+    assert excinfo.value.source == str(pfile)
 
 
 def test_vnx_update_dry_run_threads_protect_pins(tmp_path, monkeypatch):

--- a/tests/test_vnx_release_publish.py
+++ b/tests/test_vnx_release_publish.py
@@ -1,0 +1,321 @@
+#!/usr/bin/env python3
+"""Tests for vnx release publish (git tag -> immutable central version)."""
+
+import io
+import json
+import stat
+import subprocess
+import sys
+from argparse import Namespace
+from contextlib import redirect_stdout
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from vnx_cli.commands.release import (
+    vnx_release,
+    vnx_release_publish,
+    _tag_exists,
+)
+from vnx_cli.commands.update import INSTALL_MODE_MARKER, INSTALL_MODE_VALUE
+
+
+STUB_INSTALL_CENTRAL = """#!/usr/bin/env bash
+# Hermetic stand-in for install-central.sh --materialize-only: parse the flags
+# and materialize an (empty) immutable version dir, nothing else.
+set -euo pipefail
+VERSION=""
+TARGET=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) VERSION="$2"; shift 2 ;;
+    --target)  TARGET="$2";  shift 2 ;;
+    --source)  shift 2 ;;
+    --materialize-only) shift ;;
+    *) echo "stub: unknown arg $1" >&2; exit 1 ;;
+  esac
+done
+[ -n "$VERSION" ] && [ -n "$TARGET" ]
+mkdir -p "${TARGET}/versions/${VERSION}"
+echo "stub-materialized ${VERSION}"
+"""
+
+
+def _git_repo_with_tag(path: Path, tag: str, *, extra_tags=()) -> Path:
+    path.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init", "-q"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.email", "t@example.com"], cwd=path, check=True)
+    subprocess.run(["git", "config", "user.name", "tester"], cwd=path, check=True)
+    (path / "README.md").write_text("test\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=path, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "init"], cwd=path, check=True)
+    for t in (tag, *extra_tags):
+        subprocess.run(["git", "tag", t], cwd=path, check=True)
+    return path
+
+
+@pytest.fixture
+def stub_install_central(tmp_path, monkeypatch):
+    stub = tmp_path / "install-central.sh"
+    stub.write_text(STUB_INSTALL_CENTRAL, encoding="utf-8")
+    stub.chmod(stub.stat().st_mode | stat.S_IXUSR)
+    monkeypatch.setenv("VNX_INSTALL_CENTRAL_SCRIPT", str(stub))
+    return stub
+
+
+@pytest.fixture
+def central_root(tmp_path, monkeypatch):
+    """Isolated central store + isolated audit log location."""
+    root = tmp_path / "vnx-system"
+    monkeypatch.setenv("VNX_HOME_ROOT", str(root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "vnx-data"))
+    return root
+
+
+def _publish_args(*, tag="v1.3.1", repo=None, dry_run=False, set_current=False):
+    return Namespace(
+        tag=tag,
+        repo=repo,
+        dry_run=dry_run,
+        set_current=set_current,
+    )
+
+
+def _capture(args):
+    out_buf = io.StringIO()
+    with redirect_stdout(out_buf):
+        rc = vnx_release_publish(args)
+    return out_buf.getvalue(), rc
+
+
+def _audit_events(central_root: Path):
+    log = central_root.parent / "vnx-data" / "events" / "central_install.ndjson"
+    if not log.exists():
+        return []
+    return [json.loads(line) for line in log.read_text().strip().splitlines()]
+
+
+# ---------------------------------------------------------------------------
+# _tag_exists
+# ---------------------------------------------------------------------------
+
+def test_tag_exists_true_for_local_repo(tmp_path):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    assert _tag_exists(str(repo), "v1.3.1") is True
+
+
+def test_tag_exists_false_for_missing_tag(tmp_path):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    assert _tag_exists(str(repo), "v9.9.9") is False
+
+
+# ---------------------------------------------------------------------------
+# publish --dry-run
+# ---------------------------------------------------------------------------
+
+def test_dry_run_prints_planned_materialize(tmp_path, central_root):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), dry_run=True))
+
+    assert rc == 0
+    assert "[dry-run]" in out
+    assert "materialize" in out
+    assert "v1.3.1" in out
+    assert str(central_root / "versions" / "v1.3.1") in out
+    # Dry-run mutates nothing.
+    assert not (central_root / "versions").exists()
+    assert not (central_root / "current").exists()
+
+
+def test_dry_run_reports_no_flip_by_default(tmp_path, central_root):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), dry_run=True, set_current=False))
+
+    assert rc == 0
+    assert "current NOT flipped" in out
+
+
+def test_dry_run_reports_planned_flip_with_set_current(tmp_path, central_root):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), dry_run=True, set_current=True))
+
+    assert rc == 0
+    assert "Would flip current" in out
+    assert not (central_root / "current").exists()
+
+
+# ---------------------------------------------------------------------------
+# Immutability + validation refusals (apply to dry-run AND real runs)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("dry_run", [True, False])
+def test_publish_refuses_already_existing_version(tmp_path, central_root, capsys, dry_run):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    existing = central_root / "versions" / "v1.3.1"
+    existing.mkdir(parents=True)
+    sentinel = existing / "sentinel.txt"
+    sentinel.write_text("untouched\n", encoding="utf-8")
+
+    rc = vnx_release_publish(_publish_args(repo=str(repo), dry_run=dry_run))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "immutable" in captured.err
+    assert "already exists" in captured.err
+    # The existing dir is never touched.
+    assert sentinel.read_text(encoding="utf-8") == "untouched\n"
+
+
+def test_publish_refuses_missing_tag(tmp_path, central_root, capsys):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+
+    rc = vnx_release_publish(_publish_args(tag="v9.9.9", repo=str(repo)))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "not found" in captured.err
+    assert not (central_root / "versions").exists()
+
+
+def test_publish_rejects_invalid_tag_name(tmp_path, central_root, capsys):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+
+    rc = vnx_release_publish(_publish_args(tag="../../outside", repo=str(repo)))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "invalid version name" in captured.err
+    assert not (central_root / "versions").exists()
+
+
+def test_publish_requires_tag(central_root, capsys):
+    rc = vnx_release_publish(_publish_args(tag=None))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "--tag" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# Real publish (hermetic: stub install-central.sh, local git repo, temp root)
+# ---------------------------------------------------------------------------
+
+def test_publish_materializes_version_dir_and_marker(
+    tmp_path, central_root, stub_install_central
+):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo)))
+
+    assert rc == 0
+    target_dir = central_root / "versions" / "v1.3.1"
+    assert target_dir.is_dir()
+    marker = target_dir / INSTALL_MODE_MARKER
+    assert marker.is_file()
+    assert marker.read_text(encoding="utf-8").strip() == INSTALL_MODE_VALUE
+    assert "Published:" in out
+
+    events = _audit_events(central_root)
+    publish_events = [e for e in events if e["event_type"] == "central_release_publish"]
+    assert len(publish_events) == 1
+    assert publish_events[0]["tag"] == "v1.3.1"
+    assert publish_events[0]["set_current"] is False
+    assert publish_events[0]["version_dir"] == str(target_dir)
+
+
+def test_publish_does_not_flip_current_by_default(
+    tmp_path, central_root, stub_install_central
+):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), set_current=False))
+
+    assert rc == 0
+    assert not (central_root / "current").exists()
+    assert "current NOT flipped" in out
+
+
+def test_publish_set_current_flips_atomically(
+    tmp_path, central_root, stub_install_central
+):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo), set_current=True))
+
+    assert rc == 0
+    target_dir = central_root / "versions" / "v1.3.1"
+    current = central_root / "current"
+    assert current.is_symlink()
+    assert current.resolve() == target_dir.resolve()
+    assert "Activated:" in out
+
+    events = _audit_events(central_root)
+    flip_events = [e for e in events if e["event_type"] == "central_install_update"]
+    assert any(e["phase"] == "before_flip" for e in flip_events)
+    assert any(
+        e["phase"] == "after_flip" and e["to_version"] == "v1.3.1" and e["success"] is True
+        for e in flip_events
+    )
+
+
+def test_publish_second_run_refused_after_first_publish(
+    tmp_path, central_root, stub_install_central, capsys
+):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    _, rc = _capture(_publish_args(repo=str(repo)))
+    assert rc == 0
+
+    # Re-publishing the same tag must be refused (immutability).
+    rc = vnx_release_publish(_publish_args(repo=str(repo)))
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "immutable" in captured.err
+
+
+def test_publish_real_install_central_materialize_only(
+    tmp_path, central_root, monkeypatch
+):
+    """Integration with the REAL install-central.sh --materialize-only: the
+    version dir is produced, `current` and the shim are NOT touched."""
+    monkeypatch.delenv("VNX_INSTALL_CENTRAL_SCRIPT", raising=False)
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    out, rc = _capture(_publish_args(repo=str(repo)))
+
+    assert rc == 0, out
+    target_dir = central_root / "versions" / "v1.3.1"
+    assert target_dir.is_dir()
+    assert (target_dir / "README.md").is_file()  # cloned content, not an empty dir
+    assert (target_dir / INSTALL_MODE_MARKER).is_file()
+    # Materialize-only: no cutover, no shim, no verify-install artifacts.
+    assert not (central_root / "current").exists()
+    assert not (central_root / "bin").exists()
+
+
+# ---------------------------------------------------------------------------
+# release dispatcher
+# ---------------------------------------------------------------------------
+
+def test_release_requires_subcommand(capsys):
+    rc = vnx_release(Namespace(release_subcommand=None))
+
+    assert rc == 1
+    captured = capsys.readouterr()
+    assert "subcommand" in captured.err
+
+
+def test_release_dispatches_publish(tmp_path, central_root, monkeypatch):
+    repo = _git_repo_with_tag(tmp_path / "origin", "v1.3.1")
+    args = Namespace(
+        release_subcommand="publish",
+        tag="v1.3.1",
+        repo=str(repo),
+        dry_run=True,
+        set_current=False,
+    )
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        rc = vnx_release(args)
+
+    assert rc == 0
+    assert "[dry-run]" in buf.getvalue()

--- a/vnx_cli/commands/release.py
+++ b/vnx_cli/commands/release.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""vnx release publish — materialize an immutable central version from a git tag.
+
+Given a git tag, produce ``<root>/versions/<tag>/`` via install-central.sh
+(materialize-only: no shim install, no ``current`` flip), stamp the
+install-mode marker, and — only with explicit ``--set-current`` — atomically
+flip ``current -> <tag>``. Published versions are immutable: publishing a tag
+whose version dir already exists is refused, never overwritten.
+
+The live cutover (``--set-current``) is an operator action; the default is
+publish-without-cutover so a release can be staged and verified first.
+"""
+
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+from vnx_cli.commands.update import (
+    INSTALL_MODE_MARKER,
+    VNX_GIT_REMOTE,
+    _atomic_symlink_flip,
+    _current_target,
+    _emit_audit_event,
+    _git_toplevel,
+    _resolve_root,
+    _validate_version_name,
+    _write_install_marker,
+)
+
+INSTALL_CENTRAL_SCRIPT = Path(__file__).resolve().parent.parent.parent / "install-central.sh"
+
+
+def _resolve_install_central() -> Path:
+    env = os.environ.get("VNX_INSTALL_CENTRAL_SCRIPT")
+    if env:
+        return Path(env).expanduser().resolve()
+    return INSTALL_CENTRAL_SCRIPT
+
+
+def _resolve_repo(args) -> str:
+    repo = getattr(args, "repo", None)
+    if repo:
+        return repo
+    toplevel = _git_toplevel(Path.cwd())
+    if toplevel is not None:
+        return str(toplevel)
+    return VNX_GIT_REMOTE
+
+
+def _tag_exists(repo: str, tag: str) -> bool:
+    """True when ``refs/tags/<tag>`` exists in ``repo`` (local path or remote URL)."""
+    if Path(repo).is_dir():
+        result = subprocess.run(
+            ["git", "-C", repo, "rev-parse", "-q", "--verify", f"refs/tags/{tag}"],
+            capture_output=True,
+        )
+        return result.returncode == 0
+    result = subprocess.run(
+        ["git", "ls-remote", "--tags", repo, tag],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return bool(result.stdout.strip())
+
+
+def _materialize_from_tag(root: Path, repo: str, tag: str) -> Path:
+    """Materialize ``versions/<tag>/`` from ``repo``'s tag via install-central.sh.
+
+    Clones the source repo into a temp dir, checks out the tag, then runs
+    ``install-central.sh --materialize-only`` so the version dir is produced
+    by the same code path as a normal central install (immutable layout,
+    tenant-marker strip) — without touching ``current`` or the shim.
+    """
+    target_dir = root / "versions" / tag
+    install_central = _resolve_install_central()
+    if not install_central.is_file():
+        raise FileNotFoundError(f"install-central.sh not found: {install_central}")
+
+    tmp = Path(tempfile.mkdtemp(prefix="vnx-release-"))
+    try:
+        checkout = tmp / "checkout"
+        print(f"Cloning {repo} -> {checkout} ...")
+        subprocess.run(["git", "clone", "--quiet", repo, str(checkout)], check=True)
+        subprocess.run(
+            ["git", "-C", str(checkout), "checkout", "--quiet", tag], check=True
+        )
+        subprocess.run(
+            [
+                "bash", str(install_central),
+                "--version", tag,
+                "--source", str(checkout),
+                "--target", str(root),
+                "--materialize-only",
+            ],
+            check=True,
+        )
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+    if not target_dir.is_dir():
+        raise RuntimeError(
+            f"materialization reported success but {target_dir} does not exist"
+        )
+    _write_install_marker(target_dir)
+    return target_dir
+
+
+def vnx_release_publish(args) -> int:
+    tag: "str | None" = getattr(args, "tag", None)
+    dry_run: bool = getattr(args, "dry_run", False)
+    set_current: bool = getattr(args, "set_current", False)
+
+    if not tag:
+        print("Error: --tag <vX.Y.Z> is required.", file=sys.stderr)
+        return 1
+    try:
+        tag = _validate_version_name(tag)
+    except ValueError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    root = _resolve_root()
+    target_dir = root / "versions" / tag
+
+    # Immutability: a published version is never overwritten.
+    if target_dir.exists():
+        print(
+            f"Error: version '{tag}' already exists at {target_dir} — "
+            "published versions are immutable; refusing to overwrite.",
+            file=sys.stderr,
+        )
+        return 1
+
+    repo = _resolve_repo(args)
+
+    try:
+        if not _tag_exists(repo, tag):
+            print(f"Error: tag '{tag}' not found in {repo}", file=sys.stderr)
+            return 1
+    except FileNotFoundError:
+        print("Error: git executable not found in PATH", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"Error: git operation failed: {exc}", file=sys.stderr)
+        return 1
+
+    if dry_run:
+        print(f"[dry-run] VNX_HOME_ROOT: {root}")
+        print(
+            f"[dry-run] Would materialize tag '{tag}' from {repo} -> {target_dir} "
+            f"(install-central.sh --version {tag} --materialize-only)"
+        )
+        print(f"[dry-run] Would write {INSTALL_MODE_MARKER}=central into {target_dir}")
+        if set_current:
+            current = _current_target(root)
+            current_name = current.name if current else None
+            print(
+                f"[dry-run] Would flip current ({current_name}) -> {tag} "
+                "(--set-current passed)"
+            )
+        else:
+            print("[dry-run] current NOT flipped (publish only; pass --set-current to cut over)")
+        return 0
+
+    try:
+        target_dir = _materialize_from_tag(root, repo, tag)
+    except FileNotFoundError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+    except subprocess.CalledProcessError as exc:
+        print(f"Error: materialization failed: {exc}", file=sys.stderr)
+        return 1
+    except (RuntimeError, OSError) as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    _emit_audit_event(
+        "central_release_publish",
+        {"tag": tag, "version_dir": str(target_dir), "set_current": set_current},
+    )
+    print(f"Published: {target_dir}")
+
+    if set_current:
+        _atomic_symlink_flip(root, target_dir, dry_run=False)
+    else:
+        print("current NOT flipped (publish only; pass --set-current to cut over).")
+
+    return 0
+
+
+def vnx_release(args) -> int:
+    if getattr(args, "release_subcommand", None) == "publish":
+        return vnx_release_publish(args)
+    print("Error: a release subcommand is required (publish).", file=sys.stderr)
+    return 1

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -14,9 +14,13 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from vnx_cli._reexec import PIN_FILE_NAME, _PIN_RE, _normalize_version
+
 
 VNX_GIT_REMOTE = "https://github.com/Vinix24/vnx-orchestration.git"
 DEFAULT_KEEP_LAST = 3
+DEFAULT_REGISTRY_PATH = Path.home() / ".vnx" / "projects.json"
+PROTECTED_VERSIONS_FILE = "protected-versions"
 
 _VERSION_RE = re.compile(r"^(edge|latest|v?\d+\.\d+\.\d+(?:-[\w.]+)?)$")
 
@@ -275,11 +279,115 @@ def _atomic_symlink_flip(
     print(f"Activated: {current} -> {target_dir}")
 
 
+def _iter_pin_values(text: str) -> list:
+    """Yield validated pin values from newline/comma separated text.
+
+    Blank lines and ``#`` comments are ignored; values that violate the pin
+    alphabet (same regex as the re-exec keystone and the shim) are skipped
+    with a warning instead of aborting the whole protection sweep.
+    """
+    values = []
+    for raw in re.split(r"[\n,]", text):
+        value = raw.strip()
+        if not value or value.startswith("#"):
+            continue
+        if value in (".", "..") or not _PIN_RE.match(value):
+            print(f"[warn] ignoring malformed protected version: {value!r}", file=sys.stderr)
+            continue
+        values.append(value)
+    return values
+
+
+def _load_fleet_pins(registry_path: "Path | None" = None) -> dict:
+    """Collect ``{normalized_pin: {sources}}`` from the fleet project registry.
+
+    Reads the same ``~/.vnx/projects.json`` registry the fabric already uses
+    (scripts/commands/registry.sh, scripts/lib/vnx_identity.py) and harvests
+    each registered project's ``.vnx-version`` pin. A pruned pinned version
+    silently degrades that project's ``vnx`` to ``current`` (the re-exec
+    keystone fails open), so every pin found here protects its version dir.
+    """
+    if registry_path is None:
+        env_registry = os.environ.get("VNX_PROJECT_REGISTRY")
+        registry_path = (
+            Path(env_registry).expanduser() if env_registry else DEFAULT_REGISTRY_PATH
+        )
+    protected: dict = {}
+    try:
+        data = json.loads(registry_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return protected
+    for entry in data.get("projects", []) or []:
+        project_path = entry.get("path")
+        if not project_path:
+            continue
+        project_dir = Path(project_path).expanduser()
+        pin_file = project_dir / PIN_FILE_NAME
+        try:
+            if not pin_file.is_file():
+                continue
+            lines = pin_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        pin = lines[0].strip() if lines else ""
+        if not pin or pin in (".", "..") or not _PIN_RE.match(pin):
+            continue
+        protected.setdefault(_normalize_version(pin), set()).add(
+            f"pinned by project {project_dir}"
+        )
+    return protected
+
+
+def _collect_protected_versions(
+    root: Path,
+    protect_pins: "str | list | None" = None,
+    registry_path: "Path | None" = None,
+    protected_file: "Path | None" = None,
+) -> dict:
+    """Union of all version-protection sources: ``{normalized_pin: {reasons}}``.
+
+    Sources (all optional, all unioned):
+
+    1. Fleet registry: every registered consumer project's ``.vnx-version``.
+    2. ``<root>/protected-versions``: operator-curated newline file.
+    3. ``--protect-pins``: explicit comma-separated CLI argument.
+
+    Normalization matches ``vnx_cli._reexec._normalize_version`` so a pin of
+    ``1.3.0`` protects the version dir ``v1.3.0`` (and vice versa).
+    """
+    protected = _load_fleet_pins(registry_path)
+
+    pfile = protected_file or (root / PROTECTED_VERSIONS_FILE)
+    try:
+        if pfile.is_file():
+            for value in _iter_pin_values(pfile.read_text(encoding="utf-8")):
+                protected.setdefault(_normalize_version(value), set()).add(
+                    f"listed in {pfile}"
+                )
+    except OSError:
+        pass
+
+    if protect_pins:
+        text = protect_pins if isinstance(protect_pins, str) else ",".join(protect_pins)
+        for value in _iter_pin_values(text):
+            protected.setdefault(_normalize_version(value), set()).add("--protect-pins")
+
+    return protected
+
+
 def _prune_old_versions(
-    root: Path, keep_last: int, dry_run: bool, audit_log: "Path | None" = None
+    root: Path,
+    keep_last: int,
+    dry_run: bool,
+    audit_log: "Path | None" = None,
+    protect_pins: "str | list | None" = None,
+    registry_path: "Path | None" = None,
 ) -> None:
     versions = _list_version_dirs(root)
     current = _current_target(root)
+    protected = _collect_protected_versions(
+        root, protect_pins=protect_pins, registry_path=registry_path
+    )
 
     # Keep the newest keep_last dirs; prune anything older, skip current
     if len(versions) <= keep_last:
@@ -288,6 +396,23 @@ def _prune_old_versions(
     to_prune = versions[: len(versions) - keep_last]
     for version_dir in to_prune:
         if current and version_dir.resolve() == current.resolve():
+            continue
+        reasons = sorted(protected.get(_normalize_version(version_dir.name), ()))
+        if reasons:
+            reason_text = "; ".join(reasons)
+            if dry_run:
+                print(f"[dry-run] Would protect from prune: {version_dir} ({reason_text})")
+            else:
+                _emit_audit_event(
+                    "central_install_prune_protected",
+                    {
+                        "protected_version": version_dir.name,
+                        "keep_last_N": keep_last,
+                        "reasons": reasons,
+                    },
+                    audit_log=audit_log,
+                )
+                print(f"Protected from prune: {version_dir} ({reason_text})")
             continue
         if dry_run:
             print(f"[dry-run] Would prune: {version_dir}")
@@ -329,6 +454,7 @@ def vnx_update(args) -> int:
     keep_last: int = getattr(args, "keep_last", DEFAULT_KEEP_LAST)
     dry_run: bool = getattr(args, "dry_run", False)
     rollback: bool = getattr(args, "rollback", False)
+    protect_pins = getattr(args, "protect_pins", None)
 
     root = _resolve_root()
 
@@ -357,7 +483,9 @@ def vnx_update(args) -> int:
     try:
         target_dir = _fetch_version(root, target, dry_run=dry_run)
         _atomic_symlink_flip(root, target_dir, dry_run=dry_run)
-        _prune_old_versions(root, keep_last=keep_last, dry_run=dry_run)
+        _prune_old_versions(
+            root, keep_last=keep_last, dry_run=dry_run, protect_pins=protect_pins
+        )
     except FileNotFoundError:
         print("Error: git executable not found in PATH", file=sys.stderr)
         return 1

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -32,6 +32,22 @@ INSTALL_MODE_MARKER = ".vnx-install-mode"
 INSTALL_MODE_VALUE = "central"
 
 
+class ProtectionSetUnavailable(Exception):
+    """The set of GC-protected versions could not be reliably determined.
+
+    Raised instead of returning a partial protected set: pruning while blind
+    to what is pinned is exactly the catastrophe GC-protect exists to prevent,
+    so any read/parse failure of a protection source that EXISTS must surface,
+    never be swallowed. Carries the offending ``source`` path and the
+    underlying ``cause``.
+    """
+
+    def __init__(self, source, cause: BaseException):
+        self.source = str(source)
+        self.cause = cause
+        super().__init__(f"cannot determine protected versions from {source}: {cause}")
+
+
 def _resolve_root() -> Path:
     env_root = os.environ.get("VNX_HOME_ROOT")
     if env_root:
@@ -314,9 +330,17 @@ def _load_fleet_pins(registry_path: "Path | None" = None) -> dict:
         )
     protected: dict = {}
     try:
-        data = json.loads(registry_path.read_text(encoding="utf-8"))
-    except (OSError, json.JSONDecodeError):
+        text = registry_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        # Absent registry legitimately means "no pins from this source".
         return protected
+    except (OSError, UnicodeDecodeError) as exc:
+        # A registry that EXISTS but cannot be read => fail CLOSED.
+        raise ProtectionSetUnavailable(registry_path, exc) from exc
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise ProtectionSetUnavailable(registry_path, exc) from exc
     for entry in data.get("projects", []) or []:
         project_path = entry.get("path")
         if not project_path:
@@ -327,8 +351,13 @@ def _load_fleet_pins(registry_path: "Path | None" = None) -> dict:
             if not pin_file.is_file():
                 continue
             lines = pin_file.read_text(encoding="utf-8").splitlines()
-        except OSError:
+        except FileNotFoundError:
+            # Raced removal between stat and read = absent, not a failure.
             continue
+        except (OSError, UnicodeDecodeError) as exc:
+            # A pin file that EXISTS but cannot be read => fail CLOSED: its
+            # pin must not silently become eligible for deletion.
+            raise ProtectionSetUnavailable(pin_file, exc) from exc
         pin = lines[0].strip() if lines else ""
         if not pin or pin in (".", "..") or not _PIN_RE.match(pin):
             continue
@@ -358,14 +387,21 @@ def _collect_protected_versions(
     protected = _load_fleet_pins(registry_path)
 
     pfile = protected_file or (root / PROTECTED_VERSIONS_FILE)
-    try:
-        if pfile.is_file():
-            for value in _iter_pin_values(pfile.read_text(encoding="utf-8")):
+    if pfile.is_file():
+        try:
+            text = pfile.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            # Raced removal between stat and read = absent, not a failure.
+            text = None
+        except (OSError, UnicodeDecodeError) as exc:
+            # An operator protection file that EXISTS but cannot be read =>
+            # fail CLOSED: the versions it protects must not be pruned blind.
+            raise ProtectionSetUnavailable(pfile, exc) from exc
+        if text is not None:
+            for value in _iter_pin_values(text):
                 protected.setdefault(_normalize_version(value), set()).add(
                     f"listed in {pfile}"
                 )
-    except OSError:
-        pass
 
     if protect_pins:
         text = protect_pins if isinstance(protect_pins, str) else ",".join(protect_pins)
@@ -385,9 +421,31 @@ def _prune_old_versions(
 ) -> None:
     versions = _list_version_dirs(root)
     current = _current_target(root)
-    protected = _collect_protected_versions(
-        root, protect_pins=protect_pins, registry_path=registry_path
-    )
+
+    # FAIL-CLOSED: if the protected set cannot be reliably determined, prune
+    # NOTHING. Pruning while blind to what is pinned is the exact catastrophe
+    # GC-protect exists to prevent.
+    try:
+        protected = _collect_protected_versions(
+            root, protect_pins=protect_pins, registry_path=registry_path
+        )
+    except ProtectionSetUnavailable as exc:
+        print(
+            f"[warn] GC prune ABORTED (fail-closed): {exc}. "
+            "No versions were deleted.",
+            file=sys.stderr,
+        )
+        if not dry_run:
+            _emit_audit_event(
+                "central_install_prune_aborted",
+                {
+                    "reason": str(exc),
+                    "source": exc.source,
+                    "keep_last_N": keep_last,
+                },
+                audit_log=audit_log,
+            )
+        return
 
     # Keep the newest keep_last dirs; prune anything older, skip current
     if len(versions) <= keep_last:

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -261,6 +261,53 @@ def _register_update_subparser(subparsers: argparse.Action) -> None:
         action="store_true",
         help="revert current symlink to the previous version",
     )
+    update_parser.add_argument(
+        "--protect-pins",
+        dest="protect_pins",
+        default=None,
+        metavar="V,V,...",
+        help="comma-separated versions to protect from GC prune, in addition to "
+             "fleet .vnx-version pins (from ~/.vnx/projects.json) and the "
+             "<root>/protected-versions file",
+    )
+
+
+def _register_release_subparser(subparsers: argparse.Action) -> None:
+    release_parser = subparsers.add_parser(
+        "release",
+        help="release management (publish immutable central versions from git tags)",
+    )
+    release_subs = release_parser.add_subparsers(
+        dest="release_subcommand", metavar="SUBCOMMAND"
+    )
+
+    publish_parser = release_subs.add_parser(
+        "publish",
+        help="materialize a git tag into the central version store (immutable)",
+    )
+    publish_parser.add_argument(
+        "--tag",
+        required=True,
+        metavar="vX.Y.Z",
+        help="git tag to publish (must exist and match the version alphabet)",
+    )
+    publish_parser.add_argument(
+        "--repo",
+        default=None,
+        metavar="PATH_OR_URL",
+        help="git repo containing the tag (default: current repo, else the VNX remote)",
+    )
+    publish_parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print planned actions without making filesystem changes",
+    )
+    publish_parser.add_argument(
+        "--set-current",
+        dest="set_current",
+        action="store_true",
+        help="also flip current -> <tag> (default OFF: publish without cutover)",
+    )
 
 
 def _register_dispatch_agent_subparser(subparsers: argparse.Action) -> None:
@@ -982,6 +1029,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.update import vnx_update
         sys.exit(vnx_update(args))
 
+    elif args.command == "release":
+        from vnx_cli.commands.release import vnx_release
+        sys.exit(vnx_release(args))
+
     elif args.command == "track":
         from vnx_cli.commands.track import vnx_track
         sys.exit(vnx_track(args))
@@ -1050,6 +1101,7 @@ def main() -> None:
     _register_pool_subparser(subparsers)
     _register_role_subparser(subparsers)
     _register_update_subparser(subparsers)
+    _register_release_subparser(subparsers)
     _register_dispatch_agent_subparser(subparsers)
     _register_track_subparser(subparsers)
     _register_handoff_subparser(subparsers)


### PR DESCRIPTION
## Dispatch

`20260723-release-publish-on-tag` (track `vnx-release-publish-on-tag`, P1, KIMI worker).

Scope boundary honored: mechanism + dry-run only — **no live fleet mutation** (no `current` flip, no version delete, no real cut). The live v1.3.1 cut is deferred to the operator.

## Deliverable A — pin-safe GC (safety-critical)

`_prune_old_versions` now never prunes a version that ANY fleet project pins via `.vnx-version` (the re-exec keystone fails open — a pruned pinned version silently degrades that project's `vnx` to `current`):

- Protected set = union of: (1) every registered consumer project's `.vnx-version` from the fabric's own `~/.vnx/projects.json` registry, (2) `<root>/protected-versions` newline file, (3) new `vnx update --protect-pins v,v,...`.
- Normalization reuses `_reexec._normalize_version` (decorative `v`-prefix), so pin `1.3.0` protects dir `v1.3.0`.
- `current` skip and `keep_last` semantics unchanged; protection never shields other unprotected old candidates.
- New `central_install_prune_protected` NDJSON audit event names each protected version and why.

## Deliverable B — `vnx release publish --tag <vX.Y.Z> [--dry-run] [--set-current]`

1. Validates the tag against the version alphabet (`_validate_version_name`) and verifies it exists (local `rev-parse` / remote `ls-remote`).
2. Refuses to overwrite an existing `versions/<tag>/` — published versions are immutable.
3. Materializes: temp clone → tag checkout → `install-central.sh --materialize-only` → `_write_install_marker` (`.vnx-install-mode=central` in the version dir).
4. `--set-current` (default OFF): only then the atomic `current -> <tag>` flip via the existing `_atomic_symlink_flip`. Default is publish without cutover.
5. `--dry-run` prints every planned action and mutates nothing. `central_release_publish` audit event on real publishes.

`install-central.sh`: new `--materialize-only` mode (clone + marker + tenant-strip only; no `current` swap, no shim, no verify); `--source` local paths no longer get an `https://` prefix mangled onto them.

## Verification

```
97 passed, 1 deselected in 4.25s   # tests/test_vnx_cli_update.py + test_vnx_release_publish.py + wave4 update/install suites
bash tests/test_install_central.sh → 43 passed, 0 failed
```

The deselected `test_dry_run_schema_warning_present` is a **pre-existing failure on main** (asserts a "schema-bootstrap"/"central-4" hint that HEAD's `update.py` never prints; untouched by this diff).

Live CLI smoke (temp root, dry-run only): `release publish --tag v1.3.0 --dry-run` prints the materialize + marker plan and reports "current NOT flipped"; `update --dry-run --protect-pins` prints "Would protect from prune" for both the file-listed and CLI-listed versions.

Full unified report: `$VNX_DATA_DIR/unified_reports/20260723-release-publish-on-tag.md`

## Open Items

- **LIVE v1.3.1 cut (materialize tag + `--set-current`) is deferred to the operator**, gated outside this dispatch.
- Pre-existing `test_dry_run_schema_warning_present` failure on main → follow-up (restore hint or fix assertion).