### PR TITLE
fix(providers): flip build-worker default pin kimi-k3 -> sonnet (kimi quota exhausted)

### DIFF
--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -53,9 +53,11 @@ constraints:
     audit_severity: warn
     override_allowed: true
 
-  # id intentionally retained as `workers-kimi-pinned` across this value-flip:
-  # the pin-loader (_load_model_pins_from_yaml() in scripts/lib/dispatch_cli.py)
-  # hard-keys on this exact string; renaming it drops the pin back to default.
+  # NOTE: id intentionally retained as `workers-kimi-pinned` even though the
+  # pinned model below is sonnet, not kimi-k3. The pin-loader
+  # (_load_model_pins_from_yaml in scripts/lib/dispatch_cli.py) hard-keys on
+  # this exact string (`elif cid == "workers-kimi-pinned"`) — renaming the id
+  # drops the pin back to its default.
   - id: workers-kimi-pinned
     rule: require_route
     required_route:
@@ -65,9 +67,9 @@ constraints:
       Build-worker terminals (T1/T2/T3) default to Sonnet (operator directive
       2026-07-24, kimi-quota-exhausted): the kimi CLI OAuth quota is spent
       fleet-wide, so the kimi-k3 pin failed loud on every build dispatch
-      against kimi-via-cli-only. Reverted to the Sonnet default until the
-      kimi quota resets (drain-to-reset). Opus stays reserved for T0
-      (t0-opus-only). This value-flip is the tactical step; the durable
+      against kimi-via-cli-only. Reverted to the Sonnet default until the kimi
+      quota resets (drain-to-reset). Opus stays reserved for the T0
+      orchestrator role. This value-flip is the tactical step; the durable
       reshape to a free, model-agnostic per-dispatch provider choice (soft
       default, no escape-hatch) is track worker-provider-free-choice.
     enforcement: code_warn

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -53,18 +53,23 @@ constraints:
     audit_severity: warn
     override_allowed: true
 
+  # id intentionally retained as `workers-kimi-pinned` across this value-flip:
+  # the pin-loader (_load_model_pins_from_yaml() in scripts/lib/dispatch_cli.py)
+  # hard-keys on this exact string; renaming it drops the pin back to default.
   - id: workers-kimi-pinned
     rule: require_route
     required_route:
       role: [T1, T2, T3]
-      model: kimi-k3
+      model: sonnet
     reason: >-
-      Build-worker terminals default to kimi-k3 via the kimi CLI OAuth lane
-      (operator directive 2026-07-23, worker-provider-kimi-flip-decision):
-      kimi is proven agentic (--yolo + -w execute tools, #1210) and the
-      subscription-flat OAuth quota keeps cost predictable. Sonnet remains
-      available as an explicit operator override; Opus is reserved for T0.
-      No automatic claude/sonnet fallback — a routing miss fails loud.
+      Build-worker terminals (T1/T2/T3) default to Sonnet (operator directive
+      2026-07-24, kimi-quota-exhausted): the kimi CLI OAuth quota is spent
+      fleet-wide, so the kimi-k3 pin failed loud on every build dispatch
+      against kimi-via-cli-only. Reverted to the Sonnet default until the
+      kimi quota resets (drain-to-reset). Opus stays reserved for T0
+      (t0-opus-only). This value-flip is the tactical step; the durable
+      reshape to a free, model-agnostic per-dispatch provider choice (soft
+      default, no escape-hatch) is track worker-provider-free-choice.
     enforcement: code_warn
     audit_severity: warn
     override_allowed: true

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -105,8 +105,9 @@ class TestT0OpusOnly:
 
 
 # ---------------------------------------------------------------------------
-# workers-kimi-pinned — require_route role=[T1,T2,T3] model=kimi-k3
-# (worker-provider-kimi-flip, 2026-07-23 — renamed from workers-sonnet-pinned)
+# workers-kimi-pinned — require_route role=[T1,T2,T3] model=sonnet
+# (id retained from worker-provider-kimi-flip, 2026-07-23; value reverted to
+# sonnet 2026-07-24 — kimi CLI OAuth quota exhausted fleet-wide)
 # ---------------------------------------------------------------------------
 
 class TestWorkersKimiPinned:
@@ -116,16 +117,18 @@ class TestWorkersKimiPinned:
             real_enforcer.enforce(terminal_id="T1", model="claude-opus-4-8")
         assert "workers-kimi-pinned" in caplog.text
 
-    def test_t2_with_kimi_k3_allowed(self, real_enforcer: ConstraintEnforcer, caplog):
+    def test_t2_with_kimi_k3_now_warns(self, real_enforcer: ConstraintEnforcer, caplog):
+        """kimi-k3 was the pinned model pre-revert (worker-provider-kimi-flip,
+        2026-07-23); post-revert (kimi-quota-exhausted, 2026-07-24) it's a
+        deviation from the sonnet pin and warns."""
         with caplog.at_level("WARNING"):
             real_enforcer.enforce(provider="kimi", terminal_id="T2", model="kimi-k3")
-        assert "workers-kimi-pinned" not in caplog.text
-
-    def test_t2_with_sonnet_now_warns(self, real_enforcer: ConstraintEnforcer, caplog):
-        """Sonnet was the pinned model pre-flip; it's now a deviation that warns."""
-        with caplog.at_level("WARNING"):
-            real_enforcer.enforce(terminal_id="T2", model="claude-sonnet-4-6")
         assert "workers-kimi-pinned" in caplog.text
+
+    def test_t2_with_sonnet_allowed(self, real_enforcer: ConstraintEnforcer, caplog):
+        with caplog.at_level("WARNING"):
+            real_enforcer.enforce(terminal_id="T2", model="sonnet")
+        assert "workers-kimi-pinned" not in caplog.text
 
     def test_t3_with_haiku_warns(self, real_enforcer: ConstraintEnforcer, caplog):
         with caplog.at_level("WARNING"):
@@ -353,12 +356,11 @@ class TestRoute1Requirements:
         assert any(v.code == "workers-kimi-pinned" and v.override_applied for v in violations)
         assert "overridden" in caplog.text
 
-    def test_clean_dispatch_unaffected(self):
-        """A genuinely clean T1 dispatch post worker-provider-kimi-flip (2026-07-23)
-        requests the pinned kimi-k3 model — previously this asserted provider=claude
-        model=sonnet was clean, which is no longer true (sonnet now deviates from
-        workers-kimi-pinned and produces a warn; see test_clean_dispatch_claude_sonnet
-        below for that case)."""
+    def test_kimi_k3_now_warns_post_revert(self):
+        """kimi-k3 was the pinned model under worker-provider-kimi-flip (2026-07-23);
+        after the kimi-quota-exhausted revert (2026-07-24) it deviates from the
+        sonnet pin and produces exactly one warn-severity violation — not
+        blocking, and not silently swallowed."""
         violations = check_constraints(
             provider="kimi",
             model="kimi-k3",
@@ -366,12 +368,12 @@ class TestRoute1Requirements:
             via="cli",
             check_registry=True,
         )
-        assert violations == []
+        assert not any(v.severity == "blocking" for v in violations)
+        assert any(v.code == "workers-kimi-pinned" and v.severity == "warn" for v in violations)
 
-    def test_clean_dispatch_claude_sonnet_now_warns(self):
-        """provider=claude, model=sonnet on T1 deviates from the kimi-k3 pin
-        (workers-kimi-pinned) and produces exactly one warn-severity violation —
-        not blocking, and not silently swallowed."""
+    def test_clean_dispatch_claude_sonnet(self):
+        """A genuinely clean T1 dispatch post kimi-quota-exhausted revert
+        (2026-07-24) requests the pinned sonnet model."""
         violations = check_constraints(
             provider="claude",
             model="sonnet",
@@ -379,8 +381,7 @@ class TestRoute1Requirements:
             via="cli",
             check_registry=True,
         )
-        assert not any(v.severity == "blocking" for v in violations)
-        assert any(v.code == "workers-kimi-pinned" and v.severity == "warn" for v in violations)
+        assert violations == []
 
     def test_model_not_in_current_registry_blocks(self):
         violations = check_constraints(

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1116,15 +1116,16 @@ def test_default_model_pins_flip_workers_to_kimi_k3():
 
 
 def test_load_model_pins_from_yaml_reads_workers_kimi_pinned():
-    """_load_model_pins_from_yaml() matches the RENAMED constraint id
-    (workers-kimi-pinned, not workers-sonnet-pinned) and loads its
-    required_route.model (kimi-k3) for T1/T2/T3 from the real
-    provider_constraints.yaml SSOT. T0 still resolves via t0-opus-only."""
+    """_load_model_pins_from_yaml() matches the (intentionally retained) constraint
+    id workers-kimi-pinned and loads its required_route.model for T1/T2/T3 from the
+    real provider_constraints.yaml SSOT. Value reverted to sonnet 2026-07-24
+    (kimi CLI OAuth quota exhausted fleet-wide) — id unchanged so this loader's
+    id-string match keeps working. T0 still resolves via t0-opus-only."""
     pins = _load_model_pins_from_yaml()
     assert pins["T0"] == "claude-opus-4-8"
-    assert pins["T1"] == "kimi-k3"
-    assert pins["T2"] == "kimi-k3"
-    assert pins["T3"] == "kimi-k3"
+    assert pins["T1"] == "sonnet"
+    assert pins["T2"] == "sonnet"
+    assert pins["T3"] == "sonnet"
 
 
 def test_load_model_pins_from_yaml_ignores_stale_sonnet_pinned_id(tmp_path):
@@ -1196,15 +1197,15 @@ def test_raw_kimi_model_rejected_despite_workers_sonnet_pin(tmp_path, monkeypatc
     assert "kimi-via-cli-only" in err
 
 
-def test_raw_opus_model_pin_now_rejects_explicit_claude_override(tmp_path, monkeypatch):
-    """worker-provider-kimi-flip (2026-07-23): the workers-kimi-pinned SSOT now resolves T1's
-    pin to "kimi-k3" regardless of the requested model. An explicit provider=claude override on
-    T1 (e.g. --model opus) is pinned to that same "kimi-k3" label, which is not a valid Claude
-    model — the registry gate (check_registry=True) correctly REJECTS it (blocking,
-    model-not-in-current-registry) instead of silently proceeding on a claude lane. This is the
-    intended "kimi-only, no fallback" behavior: there is no warn-and-proceed escape hatch left
-    for a claude override on a build-worker role. (Formerly this scenario pinned to
-    claude-sonnet-5 and proceeded under workers-sonnet-pinned — see git history.)"""
+def test_raw_opus_model_pin_now_succeeds_pinned_to_sonnet(tmp_path, monkeypatch):
+    """kimi-quota-exhausted revert (2026-07-24): the workers-kimi-pinned SSOT (id
+    retained, value reverted) now resolves T1's pin to "sonnet", a valid Claude
+    model. An explicit provider=claude override on T1 (e.g. --model opus) is
+    pinned down to sonnet with a warn-only "model-tier" advisory — the registry
+    gate (check_registry=True) no longer rejects it, since sonnet is a real Claude
+    model (unlike the interim kimi-k3 label). No blocking violation, no executor
+    skip. (Formerly — worker-provider-kimi-flip, 2026-07-23 — this scenario pinned
+    to kimi-k3 and was hard-rejected; see git history.)"""
     data_dir = tmp_path / "vnx-data"
     staging_id = "20260713-staging-opus-pin"
     bundle_dir = data_dir / "dispatches" / "pending" / staging_id
@@ -1233,14 +1234,17 @@ def test_raw_opus_model_pin_now_rejects_explicit_claude_override(tmp_path, monke
     spec_file = bundle_dir / "dispatch-spec.json"
     spec_file.write_text(json.dumps(spec_dict), encoding="utf-8")
 
-    with patch("dispatch_cli._execute_claude") as mock_execute:
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file)
 
-    assert rc == 1, (
-        "requested opus on T1 pins to kimi-k3 (workers-kimi-pinned) and must be rejected — "
-        "no silent claude fallback for a build-worker role"
+    assert rc == 0, (
+        "requested opus on T1 pins to sonnet (workers-kimi-pinned, value reverted) and "
+        "must proceed — the pin target is a valid Claude model again"
     )
-    mock_execute.assert_not_called()
+    mock_execute.assert_called_once()
+    plan_arg = mock_execute.call_args[0][0]
+    assert plan_arg.model == "sonnet"
+    assert any("requested opus, pinned sonnet" in w for w in plan_arg.warnings)
 
 
 # ---------------------------------------------------------------------------
@@ -2144,13 +2148,20 @@ def test_worker_claude_override_without_reason_is_blocking_refusal(tmp_path, mon
     assert "worker-claude-override-reason-required" in err
 
 
-def test_no_override_claude_on_build_worker_still_hard_rejects(tmp_path, monkeypatch, capsys):
-    """DEFAULT INTACT: no override env + provider=claude + T1 => still hard-rejected
-    via the kimi-k3 registry failure (model-not-in-current-registry, blocking).
-    No silent claude fallback is ever introduced."""
+def test_no_override_claude_on_build_worker_now_succeeds_pinned_to_sonnet(tmp_path, monkeypatch):
+    """kimi-quota-exhausted revert (2026-07-24): no override env + provider=claude +
+    T1 (no explicit model) now resolves via the reverted sonnet pin and PROCEEDS —
+    sonnet is a valid Claude model, so neither kimi-via-cli-only nor
+    model-not-in-current-registry fires. The escape-hatch override is no longer
+    required to route a plain claude dispatch onto a build-worker slot; it still
+    adds its own audited warn entry when explicitly invoked (see
+    test_worker_claude_override_routes_build_worker_to_claude_tmux), but a
+    no-override claude dispatch is no longer hard-rejected by default. (Formerly —
+    worker-provider-kimi-flip, 2026-07-23 — this was a kimi-k3 registry
+    hard-reject; see git history.)"""
     data_dir, spec_file = _make_bundle_spec(
         tmp_path,
-        instruction_text="# No override\n\nThis must keep hard-rejecting.\n",
+        instruction_text="# No override\n\nThis now proceeds via the sonnet pin.\n",
         staging_id="20260723-staging-no-override",
         dispatch_id="20260723-no-override-reject",
         provider="claude",
@@ -2160,16 +2171,14 @@ def test_no_override_claude_on_build_worker_still_hard_rejects(tmp_path, monkeyp
     monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
     _clear_worker_claude_override_env(monkeypatch)
 
-    with patch("dispatch_cli._execute_claude") as mock_execute:
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
         rc = run_dispatch(spec_file)
 
-    assert rc == 1, "default kimi-k3 hard-reject must stand without the override env"
-    mock_execute.assert_not_called()
-    err = capsys.readouterr().err
-    # The emergent reject surfaces as the first blocking verdict for a kimi-branded
-    # model on the claude lane (kimi-via-cli-only fires ahead of the registry gate).
-    assert "kimi-via-cli-only" in err or "model-not-in-current-registry" in err
-    assert "worker-claude-override" not in err
+    assert rc == 0, "sonnet pin (workers-kimi-pinned, value reverted) must let a plain claude dispatch proceed"
+    mock_execute.assert_called_once()
+    plan_arg = mock_execute.call_args[0][0]
+    assert plan_arg.model == "sonnet"
+    assert not any("worker-claude-override" in w for w in plan_arg.warnings)
 
 
 def test_no_override_kimi_build_dispatch_unchanged(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary
The kimi CLI OAuth quota is spent fleet-wide (2026-07-24), so the `workers-kimi-pinned`
default (`model: kimi-k3`) fails loud on every build-worker dispatch. MC and SC both hit
this and manually flipped their local edge-install YAML to `sonnet` to unblock — that edit
is ephemeral (ungoverned, wiped by the next version cut). This PR lands the durable,
governed flip in the source SSOT so the whole fleet gets it and it survives cuts.

Tactical value-flip only. The full reshape (soft default, retire the
`VNX_OVERRIDE_WORKER_CLAUDE` escape-hatch, free model-agnostic per-dispatch provider
choice) is the rest of track `worker-provider-free-choice` and is out of scope here.

## Changes
- `scripts/lib/providers/provider_constraints.yaml`, constraint `workers-kimi-pinned`:
  - `required_route.model`: `kimi-k3` -> `sonnet`
  - `reason` text updated to record the operator directive (2026-07-24) and rationale,
    worded to avoid a `t0-opus-only` substring collision with an unrelated caplog test
  - Added a YAML comment noting the id is intentionally retained (the pin-loader in
    `scripts/lib/dispatch_cli.py` hard-keys on the exact string `workers-kimi-pinned`)
- `tests/test_constraint_enforcer.py` + `tests/test_dispatch_cli.py`: updated the 7 tests
  that hardcoded the pre-flip `kimi-k3` pin as the expected/clean model, to match the
  reverted `sonnet` default (see the dispatch report for the full list)
- No other Python/schema changes. `enforcement`, `audit_severity`, `override_allowed`
  unchanged.

## Test plan
- [x] `_load_model_pins_from_yaml()` resolves `{'T0': 'claude-opus-4-8', 'T1': 'sonnet', 'T2': 'sonnet', 'T3': 'sonnet'}`
- [x] YAML parses via `yaml.safe_load`
- [x] Grep-confirmed exactly one `model: sonnet` under `workers-kimi-pinned`, no remaining `model: kimi-k3`
- [x] `tests/test_constraint_enforcer.py` + `tests/test_dispatch_cli.py` — **160 passed, 1 skipped, 0 failed**
- [x] Broader kimi/pin-referencing test sweep (7 more files) — 155 passed, 3 failed; all 3
  confirmed pre-existing and unrelated (reproduced identically on unmodified `main` via `git stash`)

Full verification detail: `.vnx-data/unified_reports/20260724-worker-pin-flip-kimi-to-sonnet.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)