### PR TITLE
feat(worker-scope): PreToolUse enforcement hook, worktree-wired, default OFF

### DIFF
--- a/scripts/hooks/pretooluse_worker_scope_enforce.py
+++ b/scripts/hooks/pretooluse_worker_scope_enforce.py
@@ -1,0 +1,179 @@
+#!/usr/bin/env python3
+"""pretooluse_worker_scope_enforce.py — PreToolUse hook: worker-scope enforcement.
+
+Dispatch 20260724-worker-scope-enforce-hook. Fine-grained enforcement layer on
+top of the coarse ADR-012 ``--allowedTools``/``--disallowedTools`` launch-time
+posture: enforces ``match_bash_deny`` and ``match_file_write_scope`` from the
+worker permission SSOT (``.vnx/worker_permissions.yaml`` via
+``scripts/lib/worker_permissions.py``) on every Bash / Write / Edit / MultiEdit
+tool call. Reuses the existing matchers verbatim — no reimplementation of
+matching logic.
+
+Feasibility proven by docs/investigations/spike-worker-scope-hook-feasibility.md
+(E1-E4): PreToolUse hooks fire under --dangerously-skip-permissions, worktree-
+local settings are honored via cwd-based discovery, and config live-reloads.
+
+Claude Code hook contract (2.1+):
+  stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
+  stdout : {"decision":"block","reason":"..."} to block, empty to allow
+  exit   : 0 always — decision is communicated via JSON output, never exit code
+
+Gate: VNX_ENFORCE_WORKER_PERMISSIONS (see worker_permissions.
+worker_permission_enforcement_enabled(); default OFF). Unset/falsy → this hook
+is a pure no-op: every branch below returns ("allow", None) before any matcher
+runs. This mirrors the flag that already gates the coarse launch-time posture —
+this hook is the fine-grained (per-command, per-path glob) layer on top of it.
+
+Role resolution: VNX_WORKER_ROLE env var, exported into the worker's tmux pane
+by TmuxInteractiveDispatch._spawn_session() (E3 gap, closed in the same
+dispatch). When unset, resolve_worker_profile(None) falls back to the
+role-agnostic default_code_worker_profile(), which carries no bash_deny_patterns
+or file_write_scope — i.e. the hook never invents restrictions the SSOT does
+not declare for the resolved profile.
+
+Audit: every block decision appends one ``worker_scope_block`` event to
+$VNX_DATA_DIR/events/worker_scope_block.ndjson via atomic_io.audit_event_append
+(same audit channel as the rest of the fabric).
+
+Fail-open by construction: any missing dependency, malformed payload, or
+unexpected exception results in an "allow" decision. This hook must never be
+the reason a legitimate tool call is refused.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+_SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "lib"
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+try:
+    from worker_permissions import (  # noqa: E402
+        match_bash_deny,
+        match_file_write_scope,
+        resolve_worker_profile,
+        worker_permission_enforcement_enabled,
+    )
+    import project_root  # noqa: E402
+    from atomic_io import audit_event_append  # noqa: E402
+
+    _DEPS_AVAILABLE = True
+except Exception:  # noqa: BLE001 - hook must never crash the tool call on import
+    _DEPS_AVAILABLE = False
+
+_WRITE_LIKE_TOOLS = frozenset({"Write", "Edit", "MultiEdit"})
+
+
+def _relative_to_cwd(file_path: str, cwd: str) -> str:
+    """Best-effort: turn an absolute file_path into a path relative to cwd.
+
+    file_write_scope globs (e.g. "scripts/**") are project-relative. The hook
+    payload's cwd is the worker's working directory (the per-dispatch worktree
+    root for tmux/subprocess-spawned workers). A path that resolves outside
+    cwd (relpath starting with "..") is left absolute — match_file_write_scope
+    will then correctly fail to match any project-relative scope glob.
+    """
+    if not file_path or not os.path.isabs(file_path) or not cwd:
+        return file_path
+    try:
+        rel = os.path.relpath(file_path, cwd)
+    except ValueError:
+        return file_path
+    return file_path if rel.startswith("..") else rel
+
+
+def evaluate(payload: dict) -> "tuple[str, str | None]":
+    """Return (decision, reason) for one PreToolUse payload. decision is 'allow' or 'block'."""
+    if not _DEPS_AVAILABLE:
+        return "allow", None
+    if not worker_permission_enforcement_enabled():
+        return "allow", None
+
+    tool_name = payload.get("tool_name")
+    tool_input = payload.get("tool_input")
+    if not isinstance(tool_name, str) or not isinstance(tool_input, dict):
+        return "allow", None
+
+    role = os.environ.get("VNX_WORKER_ROLE") or None
+    profile = resolve_worker_profile(role)
+
+    if tool_name == "Bash":
+        command = tool_input.get("command")
+        if not isinstance(command, str) or not command:
+            return "allow", None
+        pattern = match_bash_deny(command, profile)
+        if pattern:
+            return (
+                "block",
+                f"worker-scope: Bash command matches bash_deny_patterns entry "
+                f"'{pattern}' for role '{profile.role}'",
+            )
+        return "allow", None
+
+    if tool_name in _WRITE_LIKE_TOOLS:
+        file_path = tool_input.get("file_path")
+        if not isinstance(file_path, str) or not file_path:
+            return "allow", None
+        cwd = payload.get("cwd")
+        cwd = cwd if isinstance(cwd, str) else ""
+        rel_path = _relative_to_cwd(file_path, cwd)
+        if not match_file_write_scope(rel_path, profile):
+            return (
+                "block",
+                f"worker-scope: write target '{rel_path}' is outside file_write_scope "
+                f"for role '{profile.role}'",
+            )
+        return "allow", None
+
+    return "allow", None
+
+
+def _emit_audit(tool_name: object, decision: str, reason: "str | None") -> None:
+    """Append one audit event for a block decision. Fail-open — never raises."""
+    if not _DEPS_AVAILABLE:
+        return
+    try:
+        data_dir = project_root.resolve_data_dir(__file__)
+        events_dir = data_dir / "events"
+        audit_event_append(
+            events_dir,
+            "worker_scope_block",
+            {
+                "tool_name": tool_name,
+                "decision": decision,
+                "reason": reason,
+                "role": os.environ.get("VNX_WORKER_ROLE") or "(unset)",
+                "dispatch_id": os.environ.get("VNX_CURRENT_DISPATCH_ID")
+                or os.environ.get("VNX_DISPATCH_ID")
+                or "(unset)",
+            },
+        )
+    except Exception:  # noqa: BLE001 - audit trail must never block or crash the hook
+        pass
+
+
+def main() -> None:
+    try:
+        raw = sys.stdin.read()
+        try:
+            payload = json.loads(raw) if raw.strip() else {}
+        except (json.JSONDecodeError, ValueError):
+            return
+        if not isinstance(payload, dict):
+            return
+
+        decision, reason = evaluate(payload)
+
+        if decision == "block":
+            sys.stdout.write(json.dumps({"decision": "block", "reason": reason}) + "\n")
+            _emit_audit(payload.get("tool_name"), decision, reason)
+    except Exception:  # noqa: BLE001 - absolute fail-open, never crash the hook
+        return
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/hooks/pretooluse_worker_scope_enforce.py
+++ b/scripts/hooks/pretooluse_worker_scope_enforce.py
@@ -43,9 +43,20 @@ the reason a legitimate tool call is refused.
 from __future__ import annotations
 
 import json
+import logging
 import os
 import sys
 from pathlib import Path
+
+logger = logging.getLogger("pretooluse_worker_scope_enforce")
+if not logger.handlers:
+    # Hook contract: stdout carries only the decision JSON — logs go to stderr.
+    _stderr_handler = logging.StreamHandler(sys.stderr)
+    _stderr_handler.setFormatter(
+        logging.Formatter("%(name)s: %(levelname)s: %(message)s")
+    )
+    logger.addHandler(_stderr_handler)
+    logger.setLevel(logging.WARNING)
 
 _SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "lib"
 if str(_SCRIPTS_LIB) not in sys.path:
@@ -152,11 +163,19 @@ def _emit_audit(tool_name: object, decision: str, reason: "str | None") -> None:
                 or "(unset)",
             },
         )
-    except Exception:  # noqa: BLE001 - audit trail must never block or crash the hook
-        pass
+    except Exception:  # audit trail must never block or crash the hook
+        logger.warning(
+            "worker-scope audit append failed for tool %r (decision=%s); "
+            "the %s audit event was NOT written",
+            tool_name,
+            decision,
+            "worker_scope_block",
+            exc_info=True,
+        )
 
 
 def main() -> None:
+    tool_name_ctx: object = None
     try:
         raw = sys.stdin.read()
         try:
@@ -165,13 +184,19 @@ def main() -> None:
             return
         if not isinstance(payload, dict):
             return
+        tool_name_ctx = payload.get("tool_name")
 
         decision, reason = evaluate(payload)
 
         if decision == "block":
             sys.stdout.write(json.dumps({"decision": "block", "reason": reason}) + "\n")
-            _emit_audit(payload.get("tool_name"), decision, reason)
-    except Exception:  # noqa: BLE001 - absolute fail-open, never crash the hook
+            _emit_audit(tool_name_ctx, decision, reason)
+    except Exception:  # absolute fail-open, never crash the hook
+        logger.exception(
+            "worker-scope hook failed unexpectedly for tool %r; failing open "
+            "with an implicit allow decision",
+            tool_name_ctx,
+        )
         return
 
 

--- a/scripts/hooks/pretooluse_worker_scope_enforce.sh
+++ b/scripts/hooks/pretooluse_worker_scope_enforce.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# PreToolUse Hook: Worker-scope enforcement (dispatch 20260724-worker-scope-enforce-hook)
+#
+# Purpose: fine-grained enforcement layer on top of the coarse ADR-012
+#          --allowedTools/--disallowedTools launch-time posture. Blocks a
+#          Bash call matching a role's bash_deny_patterns, or a Write/Edit/
+#          MultiEdit call targeting a path outside the role's file_write_scope.
+#          Delegates matching to the existing worker_permissions.py matchers
+#          (match_bash_deny / match_file_write_scope) — no reimplementation.
+#
+# Claude Code hook contract (2.1+):
+#   stdin  : JSON {tool_name, tool_input, session_id, cwd, transcript_path}
+#   stdout : {"decision":"block","reason":"..."} to block, empty to allow
+#   exit   : 0 always — block/allow is communicated via JSON stdout, never
+#            the exit code. A crashing core must never surface as a hook
+#            error, so the python invocation is hardened with `|| true`.
+#
+# Gate: VNX_ENFORCE_WORKER_PERMISSIONS (default OFF). Unset/0 → no-op, every
+#       tool call is allowed exactly as if this hook were not registered.
+#
+# Token budget: ~60 tokens/call — fast-path exits for non-matching tools
+# happen inside the Python core (pretooluse_worker_scope_enforce.py).
+
+set -uo pipefail
+
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CORE="${HOOK_DIR}/pretooluse_worker_scope_enforce.py"
+
+# Guard: core script must exist — fail open to avoid blocking all tool calls.
+if [[ ! -f "$CORE" ]]; then
+  exit 0
+fi
+
+# Fail open on any core error: a broken hook must never block or error out a
+# legitimate tool call. Block/allow is communicated via JSON stdout only.
+python3 "$CORE" || true
+
+exit 0

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -302,6 +302,85 @@ def _sanitize_session_name(raw: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Worker-scope PreToolUse enforcement hook wiring (spike E1/E2; default OFF)
+# ---------------------------------------------------------------------------
+
+# Command resolves the hook relative to the worktree it fires in (git rev-parse
+# returns the worktree root there) — same pattern as the existing spawn-blocker
+# hooks in .claude/settings.json.
+_WORKER_SCOPE_HOOK_COMMAND = (
+    "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+    "/scripts/hooks/pretooluse_worker_scope_enforce.sh\"'"
+)
+_WORKER_SCOPE_HOOK_MATCHER = "Bash|Write|Edit|MultiEdit"
+
+
+def _worker_scope_hook_entry() -> dict:
+    """The settings.json PreToolUse entry registering the worker-scope hook."""
+    return {
+        "matcher": _WORKER_SCOPE_HOOK_MATCHER,
+        "hooks": [
+            {
+                "type": "command",
+                "command": _WORKER_SCOPE_HOOK_COMMAND,
+                "timeout": 5000,
+            }
+        ],
+    }
+
+
+def _write_worker_scope_hook_settings(worktree_root: Path) -> Path:
+    """Register the worker-scope PreToolUse enforcement hook in a dispatch worktree.
+
+    Writes/merges ``.claude/settings.local.json`` (gitignored; spike-proven to be
+    honored via cwd-based discovery and to live-reload — see
+    docs/investigations/spike-worker-scope-hook-feasibility.md E1/E2) rather than
+    the git-tracked ``.claude/settings.json``, so the worktree's git status stays
+    clean and the worker can never accidentally commit the registration.
+
+    The hook itself is gated on ``VNX_ENFORCE_WORKER_PERMISSIONS`` (default OFF),
+    so registering it unconditionally is a guaranteed no-op until the fleet-wide
+    flip happens as a separate human-gated decision.
+
+    Idempotent: an identical hook command is never registered twice. Existing
+    unrelated keys and hook entries in the file are preserved.
+
+    Returns the settings file path written.
+    """
+    settings_path = worktree_root / ".claude" / "settings.local.json"
+    data: dict = {}
+    if settings_path.exists():
+        # A corrupt existing file must not be silently clobbered — surface it to
+        # the caller (which treats the whole write as best-effort).
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        if not isinstance(data, dict):
+            raise ValueError(
+                f"worker-scope hook settings: {settings_path} is not a JSON object"
+            )
+
+    hooks = data.setdefault("hooks", {})
+    pre_tool_use = hooks.setdefault("PreToolUse", [])
+
+    already_registered = any(
+        isinstance(entry, dict)
+        and any(
+            isinstance(hook, dict)
+            and hook.get("command") == _WORKER_SCOPE_HOOK_COMMAND
+            for hook in entry.get("hooks", [])
+        )
+        for entry in pre_tool_use
+    )
+    if not already_registered:
+        pre_tool_use.append(_worker_scope_hook_entry())
+
+    settings_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp_path = settings_path.with_suffix(settings_path.suffix + ".tmp")
+    tmp_path.write_text(json.dumps(data, indent=2) + "\n", encoding="utf-8")
+    os.replace(tmp_path, settings_path)
+    return settings_path
+
+
+# ---------------------------------------------------------------------------
 # Core lane
 # ---------------------------------------------------------------------------
 class TmuxInteractiveDispatch:
@@ -1007,6 +1086,7 @@ class TmuxInteractiveDispatch:
         cwd: Path,
         dispatch_id: str = "",
         session_uuid: "str | None" = None,
+        role: "str | None" = None,
     ) -> "tuple[str, str] | None":
         """Create a detached session; return (pane_id, window_id) or None.
 
@@ -1017,12 +1097,19 @@ class TmuxInteractiveDispatch:
 
         When ``session_uuid`` is provided it is exported as ``VNX_CLAUDE_SESSION_ID``
         so the SessionStart hook can verify the pre-assigned id took (F1.1).
+
+        When ``role`` is provided it is exported as ``VNX_WORKER_ROLE`` so the
+        worker-scope PreToolUse enforcement hook
+        (scripts/hooks/pretooluse_worker_scope_enforce.py) can resolve which
+        role's permission profile to enforce (spike E3 gap).
         """
         args = ["new-session", "-d", "-s", session, "-c", str(cwd)]
         if dispatch_id:
             args += ["-e", f"VNX_CURRENT_DISPATCH_ID={dispatch_id}"]
         if session_uuid:
             args += ["-e", f"VNX_CLAUDE_SESSION_ID={session_uuid}"]
+        if role:
+            args += ["-e", f"VNX_WORKER_ROLE={role}"]
         args += ["-P", "-F", "#{pane_id}"]
         res = self._runner.run(args)
         if res.returncode != 0:
@@ -1936,6 +2023,23 @@ class TmuxInteractiveDispatch:
                     worktree_path=str(worktree_handle.path) if worktree_handle else None,
                 )
 
+            if worktree_handle is not None:
+                # Worker-scope PreToolUse enforcement hook (gated ON by
+                # VNX_ENFORCE_WORKER_PERMISSIONS, default OFF; spike E1/E2):
+                # register the hook in the fresh worktree BEFORE the tmux session
+                # spawns so cwd-based settings discovery has it from the first
+                # tool call. Best-effort: the hook is fail-open anyway, so a
+                # failed write must never abort the dispatch.
+                try:
+                    _write_worker_scope_hook_settings(Path(cwd))
+                except Exception as exc:  # noqa: BLE001 - hook wiring is best-effort
+                    logger.warning(
+                        "interactive: worker-scope hook settings write failed "
+                        "for %s: %s",
+                        dispatch_id,
+                        exc,
+                    )
+
         # Per-dispatch hook signal dir: the SessionStart / UserPromptSubmit / Stop
         # hooks (guarded by VNX_TMUX_SIGNAL_DIR + VNX_DISPATCH_ID) drop sentinels
         # here. Best-effort: if mkdtemp fails the lane silently degrades to the
@@ -2031,7 +2135,9 @@ class TmuxInteractiveDispatch:
         window_id: "str | None" = None
         try:
             # 1. Spawn detached session
-            spawned = self._spawn_session(session, cwd, dispatch_id, session_uuid=session_uuid)
+            spawned = self._spawn_session(
+                session, cwd, dispatch_id, session_uuid=session_uuid, role=role
+            )
             if spawned is None:
                 self._emit_event(
                     "interactive_spawn_failed",

--- a/tests/test_pretooluse_worker_scope_enforce.py
+++ b/tests/test_pretooluse_worker_scope_enforce.py
@@ -1,0 +1,404 @@
+#!/usr/bin/env python3
+"""Tests for scripts/hooks/pretooluse_worker_scope_enforce.{py,sh}.
+
+Dispatch 20260724-worker-scope-enforce-hook. Covers the required 5-case matrix:
+  (a) a bash_deny command is blocked
+  (b) an out-of-scope file write is blocked
+  (c) an in-scope write + an allowed command pass
+  (d) flag OFF (unset or != "1") => guaranteed no-op for all of the above
+  (e) a block emits the worker_scope_block audit receipt
+
+Plus unit coverage of evaluate() semantics (role resolution, path relativizing,
+malformed payloads) and the JSON/exit-code hook contract (exit 0 always,
+{"decision":"block","reason":...} on stdout only for blocks).
+
+Audit side effects are redirected to a tmp dir via VNX_DATA_DIR +
+VNX_DATA_DIR_EXPLICIT=1 so no test ever writes into real .vnx-data state.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+HOOK_DIR = REPO_ROOT / "scripts" / "hooks"
+HOOK_SH = HOOK_DIR / "pretooluse_worker_scope_enforce.sh"
+HOOK_PY = HOOK_DIR / "pretooluse_worker_scope_enforce.py"
+
+sys.path.insert(0, str(HOOK_DIR))
+import pretooluse_worker_scope_enforce as hook  # noqa: E402
+
+ROLE = "test-engineer"  # bash_deny: git push*; file_write_scope: tests/**, scripts/check_*
+
+
+def make_payload(
+    tool_name: str,
+    tool_input: dict,
+    cwd: str = "/wt",
+) -> str:
+    return json.dumps(
+        {
+            "tool_name": tool_name,
+            "tool_input": tool_input,
+            "session_id": "test-session-worker-scope",
+            "cwd": cwd,
+            "transcript_path": "/tmp/test.jsonl",
+        }
+    )
+
+
+def run_hook(
+    payload: str,
+    *,
+    enforce: bool,
+    role: "str | None" = ROLE,
+    data_dir: "Path | None" = None,
+    extra_env: "dict | None" = None,
+) -> subprocess.CompletedProcess:
+    """Run the .sh launcher end-to-end with a controlled environment."""
+    env = dict(os.environ)
+    # Deterministic baseline: the gate flag must never leak in from the shell.
+    env.pop("VNX_ENFORCE_WORKER_PERMISSIONS", None)
+    env.pop("VNX_WORKER_ROLE", None)
+    if enforce:
+        env["VNX_ENFORCE_WORKER_PERMISSIONS"] = "1"
+    if role is not None:
+        env["VNX_WORKER_ROLE"] = role
+    if data_dir is not None:
+        env["VNX_DATA_DIR"] = str(data_dir)
+        env["VNX_DATA_DIR_EXPLICIT"] = "1"
+    if extra_env:
+        env.update(extra_env)
+    return subprocess.run(
+        ["bash", str(HOOK_SH)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+        timeout=30,
+    )
+
+
+def parse_block(stdout: str) -> dict:
+    """Assert stdout is exactly one block decision and return it."""
+    lines = [ln for ln in stdout.strip().splitlines() if ln.strip()]
+    assert len(lines) == 1, f"expected exactly one JSON line on stdout, got: {stdout!r}"
+    decision = json.loads(lines[0])
+    assert decision["decision"] == "block"
+    assert decision.get("reason")
+    return decision
+
+
+class HookTestCase(unittest.TestCase):
+    def setUp(self) -> None:
+        import tempfile
+
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        self.tmp = Path(self._tmp.name)
+        self.data_dir = self.tmp / "vnx-data"
+        self.wt = self.tmp / "wt"
+        self.wt.mkdir()
+
+
+class TestEnforcementMatrix(HookTestCase):
+    """The required 5-case test matrix, end-to-end through the .sh launcher."""
+
+    def test_a_bash_deny_command_is_blocked(self):
+        res = run_hook(
+            make_payload("Bash", {"command": "git push origin main"}),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        decision = parse_block(res.stdout)
+        self.assertIn("git push*", decision["reason"])
+        self.assertIn(ROLE, decision["reason"])
+
+    def test_b_out_of_scope_file_write_is_blocked(self):
+        target = self.wt / "docs" / "x.md"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        decision = parse_block(res.stdout)
+        self.assertIn("docs/x.md", decision["reason"])
+        self.assertIn("file_write_scope", decision["reason"])
+
+    def test_c_in_scope_write_and_allowed_command_pass(self):
+        # In-scope write (tests/** for test-engineer) -> allow (empty stdout).
+        target = self.wt / "tests" / "test_x.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "", res.stdout)
+
+        # Allowed command (no bash_deny_patterns match) -> allow.
+        res = run_hook(
+            make_payload("Bash", {"command": "pytest -q"}),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "", res.stdout)
+
+    def test_d_flag_off_is_noop(self):
+        """Flag unset AND explicitly '0': every case above passes through untouched."""
+        payloads = [
+            make_payload("Bash", {"command": "git push origin main"}),
+            make_payload(
+                "Write",
+                {"file_path": str(self.wt / "docs" / "x.md")},
+                cwd=str(self.wt),
+            ),
+            make_payload("Bash", {"command": "pytest -q"}),
+        ]
+        for flag_value in (None, "0"):
+            extra = (
+                {} if flag_value is None else {"VNX_ENFORCE_WORKER_PERMISSIONS": flag_value}
+            )
+            for payload in payloads:
+                res = run_hook(
+                    payload,
+                    enforce=False,
+                    data_dir=self.data_dir,
+                    extra_env=extra,
+                )
+                self.assertEqual(res.returncode, 0, res.stderr)
+                self.assertEqual(
+                    res.stdout.strip(),
+                    "",
+                    f"flag OFF ({flag_value!r}) must be a no-op, got stdout: {res.stdout!r}",
+                )
+        # No audit events may be emitted when the flag is off.
+        self.assertFalse((self.data_dir / "events").exists())
+
+    def test_e_block_emits_audit_receipt(self):
+        res = run_hook(
+            make_payload("Bash", {"command": "git push origin main"}),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_CURRENT_DISPATCH_ID": "20260724-test-dispatch"},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        parse_block(res.stdout)
+
+        events_file = self.data_dir / "events" / "worker_scope_block.ndjson"
+        self.assertTrue(events_file.exists(), "block must emit a worker_scope_block audit event")
+        records = [
+            json.loads(ln)
+            for ln in events_file.read_text(encoding="utf-8").splitlines()
+            if ln.strip()
+        ]
+        self.assertEqual(len(records), 1)
+        record = records[0]
+        self.assertEqual(record["event_type"], "worker_scope_block")
+        self.assertEqual(record["decision"], "block")
+        self.assertEqual(record["tool_name"], "Bash")
+        self.assertEqual(record["role"], ROLE)
+        self.assertEqual(record["dispatch_id"], "20260724-test-dispatch")
+        self.assertIn("git push*", record["reason"])
+
+
+class TestEvaluateUnit(HookTestCase):
+    """Unit coverage of evaluate() — in-process, no subprocess."""
+
+    def _env(self, **overrides):
+        env = {
+            "VNX_ENFORCE_WORKER_PERMISSIONS": "1",
+            "VNX_WORKER_ROLE": ROLE,
+        }
+        env.update(overrides)
+        return patch.dict(os.environ, env, clear=False)
+
+    def test_flag_off_allows_deny_matching_command(self):
+        payload = json.loads(make_payload("Bash", {"command": "git push origin main"}))
+        with patch.dict(os.environ, {"VNX_ENFORCE_WORKER_PERMISSIONS": "0"}, clear=False):
+            self.assertEqual(hook.evaluate(payload), ("allow", None))
+
+    def test_bash_deny_block(self):
+        payload = json.loads(make_payload("Bash", {"command": "git push -f origin x"}))
+        with self._env():
+            decision, reason = hook.evaluate(payload)
+        self.assertEqual(decision, "block")
+        self.assertIn("bash_deny_patterns", reason)
+
+    def test_multiedit_out_of_scope_block(self):
+        payload = json.loads(
+            make_payload("MultiEdit", {"file_path": "/wt/dashboard/app.py"}, cwd="/wt")
+        )
+        with self._env():
+            decision, reason = hook.evaluate(payload)
+        self.assertEqual(decision, "block")
+        self.assertIn("dashboard/app.py", reason)
+
+    def test_edit_in_scope_allow(self):
+        payload = json.loads(
+            make_payload("Edit", {"file_path": "/wt/tests/test_y.py"}, cwd="/wt")
+        )
+        with self._env():
+            self.assertEqual(hook.evaluate(payload), ("allow", None))
+
+    def test_write_outside_cwd_tree_is_blocked(self):
+        """An absolute path outside the worktree can never match a project-relative scope glob."""
+        payload = json.loads(
+            make_payload("Write", {"file_path": "/etc/passwd"}, cwd="/wt")
+        )
+        with self._env():
+            decision, _ = hook.evaluate(payload)
+        self.assertEqual(decision, "block")
+
+    def test_role_unset_falls_back_to_default_profile(self):
+        """Without VNX_WORKER_ROLE the role-agnostic default profile carries no
+        fine-grained deny/scope lists — the hook never invents restrictions."""
+        payload = json.loads(make_payload("Bash", {"command": "git push origin main"}))
+        with patch.dict(os.environ, {"VNX_ENFORCE_WORKER_PERMISSIONS": "1"}, clear=False):
+            with patch.dict(os.environ, {}, clear=False):
+                os.environ.pop("VNX_WORKER_ROLE", None)
+                self.assertEqual(hook.evaluate(payload), ("allow", None))
+
+    def test_malformed_payloads_allow(self):
+        with self._env():
+            self.assertEqual(hook.evaluate({}), ("allow", None))
+            self.assertEqual(hook.evaluate({"tool_name": "Bash"}), ("allow", None))
+            self.assertEqual(
+                hook.evaluate({"tool_name": "Bash", "tool_input": "nope"}),
+                ("allow", None),
+            )
+            self.assertEqual(
+                hook.evaluate({"tool_name": "Bash", "tool_input": {}}),
+                ("allow", None),
+            )
+
+    def test_unrelated_tool_allow(self):
+        payload = json.loads(make_payload("Read", {"file_path": "/wt/docs/x.md"}, cwd="/wt"))
+        with self._env():
+            self.assertEqual(hook.evaluate(payload), ("allow", None))
+
+    def test_relative_to_cwd(self):
+        self.assertEqual(
+            hook._relative_to_cwd("/wt/scripts/a.py", "/wt"), "scripts/a.py"
+        )
+        # Outside cwd stays absolute so no project-relative glob can match it.
+        self.assertEqual(
+            hook._relative_to_cwd("/other/a.py", "/wt"), "/other/a.py"
+        )
+        # Relative paths and empty inputs pass through untouched.
+        self.assertEqual(hook._relative_to_cwd("scripts/a.py", "/wt"), "scripts/a.py")
+        self.assertEqual(hook._relative_to_cwd("/wt/a.py", ""), "/wt/a.py")
+
+
+class TestHookContract(HookTestCase):
+    """Hook contract: exit 0 always; stdout empty unless blocking."""
+
+    def test_malformed_json_stdin_allow(self):
+        res = run_hook("not json at all", enforce=True, data_dir=self.data_dir)
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(res.stdout.strip(), "")
+
+    def test_empty_stdin_allow(self):
+        res = run_hook("", enforce=True, data_dir=self.data_dir)
+        self.assertEqual(res.returncode, 0)
+        self.assertEqual(res.stdout.strip(), "")
+
+    def test_core_missing_fails_open(self):
+        """If the .py core is absent the launcher must exit 0 with no output."""
+        import shutil
+        import stat
+        import tempfile as _tempfile
+
+        with _tempfile.TemporaryDirectory() as td:
+            td_path = Path(td)
+            shutil.copy(HOOK_SH, td_path / HOOK_SH.name)
+            (td_path / HOOK_SH.name).chmod(
+                (td_path / HOOK_SH.name).stat().st_mode | stat.S_IXUSR
+            )
+            res = subprocess.run(
+                ["bash", str(td_path / HOOK_SH.name)],
+                input=make_payload("Bash", {"command": "git push origin main"}),
+                capture_output=True,
+                text=True,
+                env={
+                    **os.environ,
+                    "VNX_ENFORCE_WORKER_PERMISSIONS": "1",
+                    "VNX_WORKER_ROLE": ROLE,
+                },
+                timeout=30,
+            )
+            self.assertEqual(res.returncode, 0, res.stderr)
+            self.assertEqual(res.stdout.strip(), "")
+
+
+class TestSubprocessLaneMarker(HookTestCase):
+    """E4 marker — subprocess lane (``claude -p``) hook discoverability.
+
+    What this test proves (statically, in-PR):
+      1. The subprocess lane (scripts/lib/subprocess_adapter.py) never passes a
+         ``--settings`` flag, so a headless ``claude -p`` spawn falls back to the
+         same cwd-based settings discovery that the spike proved live for the
+         tmux lane (E1/E2) — the discovery mechanism is identical by construction.
+      2. The registration written at worktree allocation resolves the hook via
+         ``git rev-parse --show-toplevel`` from the process cwd, so ANY lane whose
+         cwd is the dispatch worktree discovers the same hook — no tmux-specific
+         machinery is involved in the hook path.
+      3. The hook assets the registration points at exist and are executable.
+
+    What remains DEFERRED (explicit, per spike E4 recommendation): a live-fire
+    marker test proving a PreToolUse hook actually fires inside a real
+    ``claude -p`` process. That cannot be proven in this PR: it requires spawning
+    a live provider subprocess, which (a) is blocked by design inside this repo by
+    scripts/hooks/pretooluse_block_raw_claude_spawn.sh (raw claude -p spawns are
+    governance-bypass blocks), and (b) consumes provider quota for a question the
+    spike already scoped to a dedicated subprocess-lane dispatch. Until that
+    dispatch runs, treat subprocess-lane enforcement as assume-until-proven: the
+    coarse launch-time posture (--allowedTools/--permission-mode, ADR-012) remains
+    the enforcement layer of record for that lane.
+    """
+
+    def test_subprocess_lane_has_no_settings_flag(self):
+        src = (REPO_ROOT / "scripts" / "lib" / "subprocess_adapter.py").read_text(
+            encoding="utf-8"
+        )
+        self.assertNotIn(
+            "--settings",
+            src,
+            "subprocess lane must not override settings discovery with --settings; "
+            "cwd-based discovery is the mechanism the worktree hook wiring relies on",
+        )
+
+    def test_hook_registration_uses_cwd_relative_resolution(self):
+        from tmux_interactive_dispatch import _worker_scope_hook_entry
+
+        sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+        entry = _worker_scope_hook_entry()
+        command = entry["hooks"][0]["command"]
+        self.assertIn(
+            "git rev-parse --show-toplevel",
+            command,
+            "hook command must resolve from the firing process's cwd so both lanes "
+            "discover it identically",
+        )
+        self.assertEqual(entry["matcher"], "Bash|Write|Edit|MultiEdit")
+
+    def test_hook_assets_exist_and_launcher_is_executable(self):
+        self.assertTrue(HOOK_PY.exists())
+        self.assertTrue(HOOK_SH.exists())
+        self.assertTrue(
+            os.access(HOOK_SH, os.X_OK),
+            "launcher must be executable for the settings registration to work",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -4466,5 +4466,183 @@ class TestCompletionHardeningP12(_LaneTestCase):
         self.assertEqual(len(matches), 0, "Non-matching pending receipt must not be returned")
 
 
+class TestWorkerRoleExport(_LaneTestCase):
+    """Spike E3 gap closure: _spawn_session exports VNX_WORKER_ROLE into the pane env."""
+
+    def _new_session_cmd(self, fake: FakeTmux) -> list:
+        cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertTrue(cmds, "new-session was not invoked")
+        return cmds[0]
+
+    def test_role_exported_in_new_session(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, role="backend-developer")
+
+        self.assertTrue(result.success, result.failure_reason)
+        ns_cmd = self._new_session_cmd(fake)
+        self.assertIn("-e", ns_cmd)
+        self.assertIn("VNX_WORKER_ROLE=backend-developer", ns_cmd)
+        # Existing exports are preserved.
+        self.assertIn(f"VNX_CURRENT_DISPATCH_ID={self.DISPATCH_ID}", ns_cmd)
+
+    def test_role_absent_when_none(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, role=None)
+
+        self.assertTrue(result.success, result.failure_reason)
+        ns_cmd = self._new_session_cmd(fake)
+        self.assertNotIn("VNX_WORKER_ROLE", " ".join(ns_cmd))
+
+
+class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
+    """Worktree-allocation seam: the worker-scope PreToolUse hook is registered
+    in the fresh worktree's .claude/settings.local.json before the session spawns."""
+
+    def test_write_hook_settings_fresh_worktree(self):
+        from tmux_interactive_dispatch import (
+            _WORKER_SCOPE_HOOK_COMMAND,
+            _write_worker_scope_hook_settings,
+        )
+
+        wt = self.state_dir / "wt-fresh"
+        wt.mkdir()
+        settings_path = _write_worker_scope_hook_settings(wt)
+
+        self.assertEqual(settings_path, wt / ".claude" / "settings.local.json")
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        pre = data["hooks"]["PreToolUse"]
+        self.assertEqual(len(pre), 1)
+        entry = pre[0]
+        self.assertEqual(entry["matcher"], "Bash|Write|Edit|MultiEdit")
+        self.assertEqual(entry["hooks"][0]["type"], "command")
+        self.assertEqual(entry["hooks"][0]["command"], _WORKER_SCOPE_HOOK_COMMAND)
+        # The command resolves the hook from the worktree it fires in (cwd-based
+        # discovery), same pattern as the existing spawn-blocker hooks.
+        self.assertIn("git rev-parse --show-toplevel", entry["hooks"][0]["command"])
+        self.assertIn(
+            "scripts/hooks/pretooluse_worker_scope_enforce.sh",
+            entry["hooks"][0]["command"],
+        )
+
+    def test_write_hook_settings_merges_existing_and_is_idempotent(self):
+        from tmux_interactive_dispatch import _write_worker_scope_hook_settings
+
+        wt = self.state_dir / "wt-merge"
+        (wt / ".claude").mkdir(parents=True)
+        settings_path = wt / ".claude" / "settings.local.json"
+        existing = {
+            "someOtherKey": True,
+            "hooks": {
+                "PreToolUse": [
+                    {"matcher": "Bash", "hooks": [{"type": "command", "command": "other"}]}
+                ],
+                "SessionStart": [
+                    {"matcher": "", "hooks": [{"type": "command", "command": "s"}]}
+                ],
+            },
+        }
+        settings_path.write_text(json.dumps(existing), encoding="utf-8")
+
+        _write_worker_scope_hook_settings(wt)
+        _write_worker_scope_hook_settings(wt)  # second run must not duplicate
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertTrue(data["someOtherKey"])
+        self.assertEqual(len(data["hooks"]["SessionStart"]), 1)
+        pre = data["hooks"]["PreToolUse"]
+        self.assertEqual(len(pre), 2, "existing entry preserved + exactly one hook entry")
+        ours = [
+            e
+            for e in pre
+            if any("worker_scope_enforce" in h.get("command", "") for h in e["hooks"])
+        ]
+        self.assertEqual(len(ours), 1, "hook must be registered exactly once (idempotent)")
+
+    def test_write_hook_settings_corrupt_file_raises(self):
+        from tmux_interactive_dispatch import _write_worker_scope_hook_settings
+
+        wt = self.state_dir / "wt-corrupt"
+        (wt / ".claude").mkdir(parents=True)
+        (wt / ".claude" / "settings.local.json").write_text("{not json", encoding="utf-8")
+        with self.assertRaises(Exception):
+            _write_worker_scope_hook_settings(wt)
+
+    def test_dispatch_writes_hook_settings_into_allocated_worktree(self):
+        """End-to-end at the allocation seam: an isolated-worktree dispatch leaves
+        the hook registration in the worktree's .claude/settings.local.json."""
+        wt = self.state_dir / "wt-allocated"
+        wt.mkdir()
+        handle = WorktreeHandle(
+            path=wt,
+            branch="dispatch/test",
+            base_sha="0" * 40,
+            base_ref="origin/main",
+            dispatch_id=self.DISPATCH_ID,
+        )
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        autopr_ok = MagicMock(ok=True, reason=None)
+        with (
+            patch("tmux_interactive_dispatch.allocate", return_value=handle),
+            patch("tmux_interactive_dispatch.classify", return_value="clean"),
+            patch(
+                "tmux_interactive_dispatch.reap",
+                return_value=ReapResult(removed=True),
+            ),
+            patch.object(lane, "_enforce_pr_exists", return_value=autopr_ok),
+        ):
+            result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertTrue(result.success, result.failure_reason)
+        settings_path = wt / ".claude" / "settings.local.json"
+        self.assertTrue(
+            settings_path.exists(),
+            "worktree allocation must register the worker-scope hook settings",
+        )
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        commands = [
+            h.get("command", "")
+            for e in data["hooks"]["PreToolUse"]
+            for h in e.get("hooks", [])
+        ]
+        self.assertTrue(
+            any("pretooluse_worker_scope_enforce.sh" in c for c in commands),
+            f"hook command not found in written settings: {commands}",
+        )
+
+    def test_dispatch_hook_settings_write_failure_does_not_abort(self):
+        """Best-effort wiring: a failing settings write must never abort the dispatch."""
+        wt = self.state_dir / "wt-failwrite"
+        wt.mkdir()
+        handle = WorktreeHandle(
+            path=wt,
+            branch="dispatch/test",
+            base_sha="0" * 40,
+            base_ref="origin/main",
+            dispatch_id=self.DISPATCH_ID,
+        )
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        autopr_ok = MagicMock(ok=True, reason=None)
+        with (
+            patch("tmux_interactive_dispatch.allocate", return_value=handle),
+            patch("tmux_interactive_dispatch.classify", return_value="clean"),
+            patch(
+                "tmux_interactive_dispatch.reap",
+                return_value=ReapResult(removed=True),
+            ),
+            patch.object(lane, "_enforce_pr_exists", return_value=autopr_ok),
+            patch(
+                "tmux_interactive_dispatch._write_worker_scope_hook_settings",
+                side_effect=OSError("disk full"),
+            ),
+        ):
+            result = self._fast_dispatch(lane, isolated_worktree=True)
+
+        self.assertTrue(result.success, result.failure_reason)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

Builds the worker-scope PreToolUse enforcement hook whose feasibility was proven by the merged spike (#1196, `docs/investigations/spike-worker-scope-hook-feasibility.md`, E1–E4). The hook enforces `match_bash_deny` + `match_file_write_scope` from the worker permission SSOT (`.vnx/worker_permissions.yaml`) per tool call, gated behind `VNX_ENFORCE_WORKER_PERMISSIONS=1`. **Default stays OFF** — absent/falsy flag is a guaranteed no-op; the fleet-wide flip is a separate human-gated decision.

Dispatch-ID: `20260724-worker-scope-enforce-hook`

## What changed

1. **Hook** — `scripts/hooks/pretooluse_worker_scope_enforce.{py,sh}` (finalized from the unverified PoC at `8fad5d10`):
   - Reads the PreToolUse event on stdin, resolves the role via `VNX_WORKER_ROLE`, loads `worker_permissions.yaml` via the **existing** `worker_permissions` matchers (no matching-logic reimplementation).
   - BLOCKs (JSON `{"decision":"block","reason":...}`) on a `bash_deny_patterns` hit or an out-of-`file_write_scope` Write/Edit/MultiEdit; allows otherwise; exit code always 0.
   - Emits a `worker_scope_block` audit event per block (`$VNX_DATA_DIR/events/worker_scope_block.ndjson`, same `atomic_io` channel as the rest of the fabric).
   - Fail-open by construction: missing deps, malformed payloads, core crash → allow. The `.sh` launcher was hardened vs the PoC (`set -e` removed, `|| true`, missing-core guard).
2. **Worktree wiring (tmux-interactive lane)** — at worktree allocation, `_write_worker_scope_hook_settings()` writes/merges the hook registration into the worktree's `.claude/settings.local.json` **before** the session spawns. Deviation from the dispatch's literal `.claude/settings.json` wording, grounded in the spike (design authority): `settings.local.json` is gitignored, spike-proven honored via cwd-based discovery + live-reload (E1/E2), and keeps the worktree's git status clean so the worker can never accidentally commit the registration. Idempotent merge; best-effort (a failed write logs a warning and never aborts the dispatch).
3. **E3 gap closed** — `_spawn_session()` now exports `VNX_WORKER_ROLE=<role>` into the worker pane (next to `VNX_CURRENT_DISPATCH_ID`), so the hook enforces the actual role's profile instead of the role-agnostic fallback.
4. **Tests** — `tests/test_pretooluse_worker_scope_enforce.py` (20 tests): the required 5-case matrix — (a) bash_deny blocked, (b) out-of-scope write blocked, (c) in-scope write + allowed command pass, (d) flag OFF (unset **and** `0`) no-op incl. zero audit events, (e) block emits the audit receipt — plus `evaluate()` unit coverage (role fallback, cwd-relativizing, outside-tree writes, malformed payloads) and hook-contract tests (exit 0 always, malformed stdin, missing-core fail-open). `tests/test_tmux_interactive_dispatch.py` (+7): `VNX_WORKER_ROLE` export (present/absent), settings write/merge/idempotency/corrupt-file, dispatch-level wiring into an allocated worktree, and write-failure-does-not-abort.
5. **E4 (subprocess lane)** — cannot be live-proven in this PR: a real `claude -p` spawn is governance-blocked by design inside this repo (`pretooluse_block_raw_claude_spawn.sh`) and the spike scoped that proof to a dedicated subprocess-lane dispatch. Instead, static marker tests (`TestSubprocessLaneMarker`) assert the lane passes no `--settings` flag and the hook registration resolves cwd-relatively (`git rev-parse --show-toplevel`), so discovery is identical by construction. The deferral is documented explicitly in the test class docstring. Until proven, the coarse ADR-012 launch-time posture remains the enforcement layer of record for that lane.

## Verification

- `python3 -m pytest tests/ -k "worker_scope or pretooluse_worker_scope" -q` → **20 passed**
- New spawner/wiring tests → **7 passed**; full `test_tmux_interactive_dispatch.py` + worker-permission suites: 315 passed, 2 failed — both failures reproduce on a clean tree (pre-existing, verified via `git stash`).
- Default-OFF no-op proven: with `VNX_ENFORCE_WORKER_PERMISSIONS` unset, every matrix case passes through with empty stdout and no audit events (test `test_d_flag_off_is_noop`).
- `grep -n "VNX_WORKER_ROLE" scripts/lib/tmux_interactive_dispatch.py` → lines 1101 (docstring), 1112 (`-e VNX_WORKER_ROLE={role}` export).

## Notes

- `VNX_ENFORCE_WORKER_PERMISSIONS` is **not** enabled anywhere by this PR.
- The hook registration in each worktree is inert until the flag flip; the flag itself is read by the hook at call time in the worker's pane env.
