### PR TITLE
fix(kimi-spawn): make fabrication guard commit-aware (OI-801)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -1163,6 +1163,10 @@ class ProviderAdapter:
                 # longer deadline (e.g. stage_spec_bundle's 3600s default) was previously
                 # silently capped short (memory: provider-lane-900s-deadline-kills-builds).
                 total_deadline=float(plan.deadline_seconds),
+                # OI-801: thread the plan's base_ref into the fabrication
+                # guard's commit-aware worktree check (a seeded base like a
+                # fixture branch must not read origin/main as the merge-base).
+                base_ref=plan.base_ref or "origin/main",
             )
         except BrokenPipeError as exc:
             return _AdapterResult(

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -377,17 +377,17 @@ def _build_kimi_cmd(prompt: str, model: Optional[str], work_dir: Optional[Any]) 
     return cmd
 
 
-def _worktree_has_changes(worktree: Any) -> Optional[bool]:
-    """Return True/False for uncommitted git changes in *worktree*, or None if unknown.
+def _run_invariant_git(worktree: Any, args: list) -> Optional[subprocess.CompletedProcess]:
+    """Run a fabrication-invariant git command; None on timeout/OS-level failure.
 
-    None means the check itself could not be performed (git missing, *worktree*
-    is not a git repo, or the command timed out) — callers must treat that as
-    "cannot verify" and skip the fabrication-invariant rather than treating an
-    inability to check as evidence of fabrication.
+    A non-zero exit is NOT collapsed to None here — some checks (e.g. an unborn
+    HEAD) carry a definitive answer in their exit code, so the caller inspects
+    ``returncode`` itself. None is reserved for "the command never ran"
+    (git missing, timeout), the true cannot-verify case.
     """
     try:
-        proc = subprocess.run(
-            ["git", "status", "--porcelain"],
+        return subprocess.run(
+            ["git", *args],
             cwd=str(worktree),
             capture_output=True,
             text=True,
@@ -395,17 +395,85 @@ def _worktree_has_changes(worktree: Any) -> Optional[bool]:
         )
     except (OSError, subprocess.TimeoutExpired) as exc:
         logger.warning(
-            "kimi_spawn: fabrication-invariant git status failed for %s (skipping check): %s",
-            worktree, exc,
+            "kimi_spawn: fabrication-invariant git %s failed for %s (skipping check): %s",
+            args[0], worktree, exc,
         )
         return None
-    if proc.returncode != 0:
+
+
+def _worktree_has_changes(worktree: Any, base_ref: str = "origin/main") -> Optional[bool]:
+    """Return True/False for real work in *worktree*, or None if unknown.
+
+    COMMIT-AWARE (OI-801): True when EITHER
+      - ``git status --porcelain`` is non-empty (uncommitted / untracked work), OR
+      - HEAD carries COMMITTED work ahead of *base_ref* — merge-base +
+        ``git rev-list --count <merge_base>..HEAD`` > 0, mirroring
+        ``phantom_guard.compute_worktree_diff``. A worker that committed its
+        work (the normal, correct behavior) leaves a clean ``git status`` and
+        must NOT be misread as fabrication.
+    False only when BOTH are empty (genuine no-op — still fabrication).
+
+    None means the check itself could not be performed (git missing, *worktree*
+    is not a git repo, the base ref does not resolve, or a command timed out)
+    — callers must treat that as "cannot verify" and skip the
+    fabrication-invariant rather than treating an inability to check as
+    evidence of fabrication. One exception: an UNBORN HEAD (no commits at
+    all) on an otherwise clean tree is a definitive "no work", not a
+    cannot-verify, so it returns False.
+    """
+    status = _run_invariant_git(worktree, ["status", "--porcelain"])
+    if status is None:
+        return None
+    if status.returncode != 0:
         logger.warning(
             "kimi_spawn: fabrication-invariant git status exited %d for %s (skipping check): %s",
-            proc.returncode, worktree, (proc.stderr or "")[:200],
+            status.returncode, worktree, (status.stderr or "")[:200],
         )
         return None
-    return bool(proc.stdout.strip())
+    if status.stdout.strip():
+        return True
+
+    # Clean tree — committed work can still be present ahead of base_ref.
+    head = _run_invariant_git(worktree, ["rev-parse", "--verify", "HEAD"])
+    if head is None:
+        return None
+    if head.returncode != 0:
+        # Unborn HEAD: zero commits and a clean tree — a definitive no-op.
+        return False
+
+    base = (base_ref or "").strip() or "origin/main"
+    merge_base = _run_invariant_git(worktree, ["merge-base", base, "HEAD"])
+    if merge_base is None:
+        return None
+    if merge_base.returncode != 0 or not merge_base.stdout.strip():
+        # Base ref unresolvable / unrelated histories — cannot verify.
+        logger.warning(
+            "kimi_spawn: fabrication-invariant git merge-base vs %s exited %d for %s "
+            "(skipping check): %s",
+            base, merge_base.returncode, worktree, (merge_base.stderr or "")[:200],
+        )
+        return None
+
+    ahead = _run_invariant_git(
+        worktree, ["rev-list", "--count", f"{merge_base.stdout.strip()}..HEAD"],
+    )
+    if ahead is None:
+        return None
+    if ahead.returncode != 0:
+        logger.warning(
+            "kimi_spawn: fabrication-invariant git rev-list exited %d for %s (skipping check): %s",
+            ahead.returncode, worktree, (ahead.stderr or "")[:200],
+        )
+        return None
+    try:
+        return int(ahead.stdout.strip()) > 0
+    except ValueError:
+        logger.warning(
+            "kimi_spawn: fabrication-invariant rev-list count unparseable for %s "
+            "(skipping check): %r",
+            worktree, ahead.stdout.strip()[:100],
+        )
+        return None
 
 
 # Inherited venv-activation vars that point Python at a FOREIGN site-packages.
@@ -599,6 +667,7 @@ def _finalize_kimi_result(
     raw_samples: Optional[list] = None,
     saw_tool_calls: bool = False,
     worktree: Optional[Any] = None,
+    base_ref: str = "origin/main",
 ) -> KimiSpawnResult:
     """Wait for process exit and return a KimiSpawnResult.
 
@@ -622,7 +691,7 @@ def _finalize_kimi_result(
 
     worktree_unchanged = False
     if saw_tool_calls and worktree is not None:
-        worktree_unchanged = _worktree_has_changes(worktree) is False
+        worktree_unchanged = _worktree_has_changes(worktree, base_ref=base_ref) is False
 
     if errors_captured:
         error: Optional[str] = "\n".join(errors_captured)
@@ -686,6 +755,7 @@ def spawn_kimi(
     chunk_timeout: float = 1200.0,
     total_deadline: float = 900.0,
     event_store: Optional[Any] = None,
+    base_ref: Optional[str] = None,
     **kwargs: Any,
 ) -> KimiSpawnResult:
     """Spawn ``kimi --print --output-format stream-json --yolo -p <prompt>``.
@@ -787,4 +857,5 @@ def spawn_kimi(
         raw_samples=raw_samples,
         saw_tool_calls=saw_tool_calls,
         worktree=cwd,
+        base_ref=(base_ref or "").strip() or "origin/main",
     )

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -508,6 +508,7 @@ class TestSpawnKimiSubprocess(unittest.TestCase):
 
 def _spawn_kimi_with_events(
     events: list, returncode: int = 0, cwd=None, event_writer=None,
+    base_ref=None,
 ) -> KimiSpawnResult:
     """Run spawn_kimi with a real-pipe-backed fake process emitting the given events.
 
@@ -540,7 +541,7 @@ def _spawn_kimi_with_events(
             mock_start.return_value = (fake_proc, None)
             result = spawn_kimi(
                 "prompt", dispatch_id="d1", terminal_id="T1", cwd=cwd,
-                event_writer=event_writer,
+                event_writer=event_writer, base_ref=base_ref,
             )
     finally:
         writer_thread.join(timeout=5)
@@ -1060,6 +1061,22 @@ class TestWorktreeHasChanges(unittest.TestCase):
     exercised against a real git repo, not a mocked subprocess, per the "tests
     run real code" convention."""
 
+    @staticmethod
+    def _git(cwd: str, *args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test",
+             *args],
+            cwd=cwd, check=True, capture_output=True,
+        )
+
+    @classmethod
+    def _init_repo_with_base(cls, tmp: str, base_ref: str = "main") -> None:
+        """Init a repo with one initial commit on *base_ref* (the merge base)."""
+        cls._git(tmp, "init", "-q", "-b", base_ref)
+        Path(tmp, "seed.txt").write_text("seed")
+        cls._git(tmp, "add", "seed.txt")
+        cls._git(tmp, "commit", "-q", "-m", "initial")
+
     def test_clean_worktree_returns_false(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
@@ -1074,6 +1091,46 @@ class TestWorktreeHasChanges(unittest.TestCase):
     def test_non_git_directory_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             self.assertIsNone(_worktree_has_changes(Path(tmp)))
+
+    # --- OI-801: commit-aware fabrication guard ---
+
+    def test_committed_work_ahead_of_base_returns_true(self) -> None:
+        """REGRESSION (OI-801): a worker that COMMITTED its work leaves a clean
+        `git status`, yet must count as real work — this was the false-failure
+        that rejected dispatches #1222/#1223."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            self._git(tmp, "checkout", "-q", "-b", "dispatch/work")
+            Path(tmp, "deliverable.py").write_text("print('done')\n")
+            self._git(tmp, "add", "deliverable.py")
+            self._git(tmp, "commit", "-q", "-m", "worker deliverable")
+            self.assertIs(_worktree_has_changes(Path(tmp), base_ref="main"), True)
+
+    def test_clean_tree_no_commits_ahead_returns_false(self) -> None:
+        """SAFETY: commits exist (the base) but NOTHING is ahead of it and the
+        tree is clean — a genuine no-op must still read as fabrication."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            self._git(tmp, "checkout", "-q", "-b", "dispatch/noop")
+            self.assertIs(_worktree_has_changes(Path(tmp), base_ref="main"), False)
+
+    def test_uncommitted_edit_on_committed_branch_returns_true(self) -> None:
+        """Uncommitted-only edit (no commit) still counts — existing behavior
+        preserved on top of the commit-aware path."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            Path(tmp, "seed.txt").write_text("edited")
+            self.assertIs(_worktree_has_changes(Path(tmp), base_ref="main"), True)
+
+    def test_unresolvable_base_ref_returns_none(self) -> None:
+        """A failed commit-check must NOT turn into a false accept or a false
+        reject: base ref that does not resolve -> None (cannot verify -> the
+        caller skips the invariant)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            self.assertIsNone(
+                _worktree_has_changes(Path(tmp), base_ref="origin/nonexistent")
+            )
 
 
 class TestFabricationInvariant(unittest.TestCase):
@@ -1208,6 +1265,48 @@ class TestKimiFabricationInvariantEndToEnd(unittest.TestCase):
         result = _spawn_kimi_with_events(self._TOOL_CALL_EVENTS, cwd=None)
         self.assertIsNone(result.error)
         self.assertEqual(result.returncode, 0)
+
+    @staticmethod
+    def _git(cwd: str, *args: str) -> None:
+        subprocess.run(
+            ["git", "-c", "user.email=test@example.com", "-c", "user.name=Test",
+             *args],
+            cwd=cwd, check=True, capture_output=True,
+        )
+
+    def test_tool_calls_with_committed_work_passes(self) -> None:
+        """END-TO-END REGRESSION (OI-801): clean `git status` but COMMITTED work
+        ahead of base — the guard must NOT fire (the #1222/#1223 false-failure)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._git(tmp, "init", "-q", "-b", "main")
+            Path(tmp, "seed.txt").write_text("seed")
+            self._git(tmp, "add", "seed.txt")
+            self._git(tmp, "commit", "-q", "-m", "initial")
+            self._git(tmp, "checkout", "-q", "-b", "dispatch/work")
+            Path(tmp, "deliverable.py").write_text("print('done')\n")
+            self._git(tmp, "add", "deliverable.py")
+            self._git(tmp, "commit", "-q", "-m", "worker deliverable")
+            result = _spawn_kimi_with_events(
+                self._TOOL_CALL_EVENTS, cwd=tmp, base_ref="main",
+            )
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+
+    def test_tool_calls_no_commits_ahead_still_fails_loud(self) -> None:
+        """END-TO-END SAFETY: branch with zero commits ahead of base and a clean
+        tree — the fabrication guard MUST still fire."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._git(tmp, "init", "-q", "-b", "main")
+            Path(tmp, "seed.txt").write_text("seed")
+            self._git(tmp, "add", "seed.txt")
+            self._git(tmp, "commit", "-q", "-m", "initial")
+            self._git(tmp, "checkout", "-q", "-b", "dispatch/noop")
+            result = _spawn_kimi_with_events(
+                self._TOOL_CALL_EVENTS, cwd=tmp, base_ref="main",
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Root cause
`_worktree_has_changes` (`scripts/lib/provider_spawns/kimi_spawn.py`) ran only `git status --porcelain` — TRUE only for **uncommitted** changes. When a kimi worker **commits** its work (the normal, correct behavior — and every fix-forward), `git status` is clean, so the fabrication guard fired: *"kimi emitted tool_calls but the dispatch worktree shows no git changes — completion without execution."*

This **false-failed all three real kimi dispatches on 2026-07-24** (#1222, #1223, the lint fix-forward) — each committed + pushed a correct PR, yet the dispatch was recorded `status=failure`.

## Fix
`_worktree_has_changes(worktree, base_ref="origin/main")` is now **commit-aware**, mirroring `phantom_guard.compute_worktree_diff`:

- **True** if `git status --porcelain` is non-empty (uncommitted/untracked — unchanged), **OR** HEAD is ahead of base (`git merge-base <base_ref> HEAD` + `git rev-list --count <merge_base>..HEAD > 0`)
- **False** only when BOTH are empty — a genuine no-op **still fires the guard** (detection not weakened)
- **None** contract preserved/extended: git errors/timeouts, non-repos, and unresolvable base refs → None (cannot verify → caller skips the invariant; never a false accept or false reject). An **unborn HEAD** on a clean tree is a definitive no-op → False.

`base_ref` threads from `ExecutionPlan.base_ref` → `spawn_kimi` → `_finalize_kimi_result` → `_worktree_has_changes` (defaults to `origin/main`).

## Tests (both directions, real git repos)
- **(a) REGRESSION**: committed work ahead of base + clean status → `True` → guard does **not** fire (unit + end-to-end through `spawn_kimi`) — today's bug
- **(b) SAFETY**: zero commits ahead + clean tree → `False` → guard **still fires** (unit + end-to-end)
- **(c)** uncommitted-only edit → `True` (preserved)
- **(d)** untracked-only new file → `True` (preserved)
- **(e)** git error / non-repo / unresolvable base → `None` → invariant skipped

`python3 -m pytest -k "kimi_spawn or fabrication or worktree_has_changes" -q` → **134 passed**. (5 failures in the broader `dispatch_envelope or phantom` selection are pre-existing on the base tree — verified via stash.)

Dispatch-ID: 20260724-fabrication-guard-commit-aware
