### PR TITLE
fix(kimi-spawn): fabrication guard commit-aware via tree-diff (supersedes #1224)

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -377,35 +377,84 @@ def _build_kimi_cmd(prompt: str, model: Optional[str], work_dir: Optional[Any]) 
     return cmd
 
 
-def _worktree_has_changes(worktree: Any) -> Optional[bool]:
-    """Return True/False for uncommitted git changes in *worktree*, or None if unknown.
+def _worktree_has_changes(worktree: Any, base_ref: str = "origin/main") -> Optional[bool]:
+    """Return True/False for REAL git work in *worktree*, or None if unknown.
 
-    None means the check itself could not be performed (git missing, *worktree*
-    is not a git repo, or the command timed out) — callers must treat that as
-    "cannot verify" and skip the fabrication-invariant rather than treating an
-    inability to check as evidence of fabrication.
+    True  — uncommitted/untracked changes (non-empty ``git status --porcelain``),
+            OR committed work whose TREE differs from the merge-base with
+            *base_ref* (the normal fix-forward: worker committed and pushed).
+    False — clean tree AND either no commits at all (unborn HEAD) or a committed
+            tree identical to the merge-base (genuine no-op, ``--allow-empty``
+            commit, or revert-back-to-base — all fabrication).
+    None  — the check itself could not be performed (git missing, *worktree* is
+            not a git repo, timeout, or unresolvable *base_ref*) — callers must
+            treat that as "cannot verify" and skip the fabrication-invariant
+            rather than treating an inability to check as evidence of
+            fabrication.
+
+    The committed-work half mirrors ``phantom_guard.compute_worktree_diff``: it
+    compares TREES (``git diff --quiet <merge-base> HEAD``), never commit COUNT,
+    so an empty commit or a commit reverting to the base tree cannot bypass the
+    guard.
     """
-    try:
-        proc = subprocess.run(
-            ["git", "status", "--porcelain"],
-            cwd=str(worktree),
-            capture_output=True,
-            text=True,
-            timeout=10,
-        )
-    except (OSError, subprocess.TimeoutExpired) as exc:
-        logger.warning(
-            "kimi_spawn: fabrication-invariant git status failed for %s (skipping check): %s",
-            worktree, exc,
-        )
+    wt = str(worktree)
+
+    def _git(args: list) -> Optional[subprocess.CompletedProcess]:
+        try:
+            return subprocess.run(
+                ["git", *args], cwd=wt, capture_output=True, text=True, timeout=10,
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            logger.warning(
+                "kimi_spawn: fabrication-invariant git %s failed for %s (skipping check): %s",
+                args[0] if args else "?", wt, exc,
+            )
+            return None
+
+    # 1. Uncommitted / untracked work.
+    status = _git(["status", "--porcelain"])
+    if status is None:
         return None
-    if proc.returncode != 0:
+    if status.returncode != 0:
         logger.warning(
             "kimi_spawn: fabrication-invariant git status exited %d for %s (skipping check): %s",
-            proc.returncode, worktree, (proc.stderr or "")[:200],
+            status.returncode, wt, (status.stderr or "")[:200],
         )
         return None
-    return bool(proc.stdout.strip())
+    if status.stdout.strip():
+        return True
+
+    # 2. Clean tree — committed work? Unborn HEAD means zero commits AND a clean
+    #    tree: a genuine no-op (still fabrication), not an unverifiable state.
+    head = _git(["rev-parse", "--verify", "HEAD"])
+    if head is None:
+        return None
+    if head.returncode != 0:
+        return False
+
+    # 3. Tree-diff against the merge-base with base_ref. TREE comparison, not
+    #    commit count: an empty commit or revert-to-base yields an identical
+    #    tree and therefore counts as NO work.
+    merge_base = _git(["merge-base", base_ref, "HEAD"])
+    if merge_base is None or merge_base.returncode != 0 or not merge_base.stdout.strip():
+        logger.warning(
+            "kimi_spawn: fabrication-invariant could not resolve merge-base of %s and HEAD for %s "
+            "(skipping check): %s",
+            base_ref, wt, ((merge_base.stderr or "")[:200] if merge_base is not None else "git error"),
+        )
+        return None
+    diff = _git(["diff", "--quiet", merge_base.stdout.strip(), "HEAD"])
+    if diff is None:
+        return None
+    if diff.returncode == 0:
+        return False  # trees identical → no real work
+    if diff.returncode == 1:
+        return True  # tree differs → real committed work
+    logger.warning(
+        "kimi_spawn: fabrication-invariant git diff exited %d for %s (skipping check): %s",
+        diff.returncode, wt, (diff.stderr or "")[:200],
+    )
+    return None
 
 
 # Inherited venv-activation vars that point Python at a FOREIGN site-packages.

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -1060,6 +1060,31 @@ class TestWorktreeHasChanges(unittest.TestCase):
     exercised against a real git repo, not a mocked subprocess, per the "tests
     run real code" convention."""
 
+    _GIT_ENV = {
+        **os.environ,
+        "GIT_AUTHOR_NAME": "test",
+        "GIT_AUTHOR_EMAIL": "test@example.com",
+        "GIT_COMMITTER_NAME": "test",
+        "GIT_COMMITTER_EMAIL": "test@example.com",
+    }
+
+    @classmethod
+    def _git(cls, tmp: str, *args: str) -> subprocess.CompletedProcess:
+        return subprocess.run(
+            ["git", *args], cwd=tmp, check=True, capture_output=True, text=True, env=cls._GIT_ENV,
+        )
+
+    @classmethod
+    def _init_repo_with_base(cls, tmp: str) -> None:
+        """Init a repo with one base commit and an origin/main ref pinned to it,
+        so the committed-work half of the guard has a resolvable base_ref."""
+        cls._git(tmp, "init", "-q")
+        Path(tmp, "base.txt").write_text("base\n")
+        cls._git(tmp, "add", "base.txt")
+        cls._git(tmp, "commit", "-q", "-m", "base")
+        sha = cls._git(tmp, "rev-parse", "HEAD").stdout.strip()
+        cls._git(tmp, "update-ref", "refs/remotes/origin/main", sha)
+
     def test_clean_worktree_returns_false(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
             subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
@@ -1073,6 +1098,52 @@ class TestWorktreeHasChanges(unittest.TestCase):
 
     def test_non_git_directory_returns_none(self) -> None:
         with tempfile.TemporaryDirectory() as tmp:
+            self.assertIsNone(_worktree_has_changes(Path(tmp)))
+
+    def test_committed_real_change_returns_true(self) -> None:
+        """A commit with actual file changes ahead of base is real work — the
+        normal fix-forward path the old status-only guard false-failed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            Path(tmp, "fix.py").write_text("print('fixed')\n")
+            self._git(tmp, "add", "fix.py")
+            self._git(tmp, "commit", "-q", "-m", "real fix")
+            self.assertIs(_worktree_has_changes(Path(tmp)), True)
+
+    def test_empty_commit_ahead_of_base_returns_false(self) -> None:
+        """`git commit --allow-empty` ahead of base with a clean tree is NOT
+        work — the commit-count bypass (codex finding on #1224) stays closed."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            self._git(tmp, "commit", "-q", "--allow-empty", "-m", "fake work")
+            self.assertIs(_worktree_has_changes(Path(tmp)), False)
+
+    def test_clean_tree_no_commits_returns_false(self) -> None:
+        """Unborn HEAD + clean tree: a genuine no-op is still fabrication."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._git(tmp, "init", "-q")
+            self.assertIs(_worktree_has_changes(Path(tmp)), False)
+
+    def test_uncommitted_edit_returns_true(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            Path(tmp, "base.txt").write_text("edited\n")
+            self.assertIs(_worktree_has_changes(Path(tmp)), True)
+
+    def test_untracked_file_returns_true(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            self._init_repo_with_base(tmp)
+            Path(tmp, "untracked.txt").write_text("new\n")
+            self.assertIs(_worktree_has_changes(Path(tmp)), True)
+
+    def test_unresolvable_base_ref_returns_none(self) -> None:
+        """Committed repo with no resolvable base_ref → None → caller skips the
+        invariant rather than false-rejecting."""
+        with tempfile.TemporaryDirectory() as tmp:
+            self._git(tmp, "init", "-q")
+            Path(tmp, "a.txt").write_text("a\n")
+            self._git(tmp, "add", "a.txt")
+            self._git(tmp, "commit", "-q", "-m", "only commit")
             self.assertIsNone(_worktree_has_changes(Path(tmp)))
 
 
@@ -1125,6 +1196,55 @@ class TestFabricationInvariant(unittest.TestCase):
             )
         self.assertIsNone(result.error)
         self.assertEqual(result.returncode, 0)
+
+    def test_tool_calls_with_real_commit_passes(self) -> None:
+        """Guard-path end-to-end against a REAL repo: a committed real change
+        ahead of base must NOT trip the fabrication invariant."""
+        with tempfile.TemporaryDirectory() as tmp:
+            TestWorktreeHasChanges._init_repo_with_base(tmp)
+            Path(tmp, "fix.py").write_text("print('fixed')\n")
+            TestWorktreeHasChanges._git(tmp, "add", "fix.py")
+            TestWorktreeHasChanges._git(tmp, "commit", "-q", "-m", "real fix")
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="Done, fix committed.",
+                events_written=3,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path(tmp),
+            )
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+
+    def test_tool_calls_empty_commit_still_fails(self) -> None:
+        """Guard-path end-to-end against a REAL repo: an empty commit ahead of
+        base is still fabrication — the invariant MUST fire."""
+        with tempfile.TemporaryDirectory() as tmp:
+            TestWorktreeHasChanges._init_repo_with_base(tmp)
+            TestWorktreeHasChanges._git(tmp, "commit", "-q", "--allow-empty", "-m", "fake work")
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="I fixed the bug and wrote the file.",
+                events_written=3,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path(tmp),
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
 
     def test_no_worktree_skips_check_gracefully(self) -> None:
         with patch("provider_spawns.kimi_spawn._worktree_has_changes") as mock_check:


### PR DESCRIPTION
## Summary

OI-801 — makes the kimi fabrication guard (`_worktree_has_changes` in `scripts/lib/provider_spawns/kimi_spawn.py`) commit-aware via **tree-diff**, replacing the commit-count approach of #1224.

**Problem:** the guard only checked `git status --porcelain` (uncommitted changes). A worker that commits its work — the normal, correct fix-forward — has a clean status, so the guard falsely recorded `status=failure` even though a correct PR was pushed (reproduced repeatedly on 2026-07-24).

**Why not commit-count (#1224):** codex review found commit-count lets an empty commit (`git commit --allow-empty`) or a revert-back-to-base-tree commit slip through as "work" — a fabrication bypass.

**Fix (tree-diff, mirrors `phantom_guard.compute_worktree_diff`):**
1. `git status --porcelain` non-empty → True (uncommitted/untracked work)
2. Else resolve `merge_base = git merge-base <base_ref> HEAD` and compare **trees** via `git diff --quiet <merge_base> HEAD` — tree differs → real work; tree identical (empty commit / revert-to-base / genuine no-op) → NO work
3. `base_ref="origin/main"` keyword param added; the only caller (same file, `_finalize_kimi_result`) works unchanged via the default
4. **None contract preserved:** any git error / unresolvable base / non-repo → None → caller skips the invariant, never false-rejects
5. **Unborn-HEAD handling preserved:** no commits + clean tree → False (still fabrication)

## Tests (`tests/test_kimi_spawn.py`, real git repos, both directions + bypass case)
- `test_committed_real_change_returns_true` — committed real change ahead of base → True (fixes the fleet-wide false-fail)
- `test_empty_commit_ahead_of_base_returns_false` — `--allow-empty` ahead of base → False → guard still fires (codex bypass closed)
- `test_clean_tree_no_commits_returns_false` — genuine no-op → fabrication
- `test_uncommitted_edit_returns_true` / `test_untracked_file_returns_true`
- `test_unresolvable_base_ref_returns_none` — invariant skipped, never false-rejects
- Guard-path end-to-end: `test_tool_calls_with_real_commit_passes` / `test_tool_calls_empty_commit_still_fails`

`python3 -m pytest tests/test_kimi_spawn.py -q` → **95 passed**