### PR TITLE
fix(receipt-quality): PR-1 fix-forward — drop repo-local DB fallback

### DIFF
--- a/scripts/lib/dispatch_identity.py
+++ b/scripts/lib/dispatch_identity.py
@@ -22,12 +22,6 @@ _SCRIPTS_LIB = Path(__file__).resolve().parent
 if str(_SCRIPTS_LIB) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_LIB))
 
-try:
-    from project_root import resolve_project_root
-    _PROJECT_ROOT = resolve_project_root(__file__)
-except (ImportError, RuntimeError):
-    _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-
 logger = logging.getLogger(__name__)
 
 # The fake default stamped by writers that never resolved a real role. The
@@ -39,7 +33,8 @@ def _resolve_db_path(state_dir: Optional[Path] = None) -> Optional[Path]:
     """Locate quality_intelligence.db — same resolution as intelligence_backfill.
 
     Order: explicit state_dir → VNX_STATE_DIR env → canonical vnx_paths
-    resolver → repo-local .vnx-data/state last resort. Never raises.
+    resolver. If none of those resolve to an existing DB, return None
+    (fail-open — no repo-local guess). Never raises.
     """
     try:
         if state_dir is not None:
@@ -61,9 +56,6 @@ def _resolve_db_path(state_dir: Optional[Path] = None) -> Optional[Path]:
                 "dispatch_identity: vnx_paths canonical resolver unavailable",
                 exc_info=True,
             )
-        candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
-        if candidate.exists():
-            return candidate
     except Exception:
         logger.debug("dispatch_identity: db path resolution failed", exc_info=True)
     return None


### PR DESCRIPTION
## Summary
Surgical fix-forward on PR-1: `_resolve_db_path` in `scripts/lib/dispatch_identity.py` no longer falls back to a repo-local `.vnx-data/state/quality_intelligence.db` — that literal forked state from the central store (#1043 footgun) and tripped the central-mode path gate (`tests/test_central_mode_path_gate.py::test_current_tree_passes`, CI Profile A).

Resolution order is now canonical only:
1. explicit `state_dir`
2. `VNX_STATE_DIR` env
3. `resolve_paths()["VNX_STATE_DIR"] / "quality_intelligence.db"`

If none resolve to an existing DB, returns `None` — fail-open, as `resolve_dispatch_role` already stamps `identity_unresolved` in that case. The now-dead `_PROJECT_ROOT` import/assignment was removed too.

Dispatch: 20260725-receipt-identity-pr1fix (track: receipt-quality)

## Verification
- `pytest tests/test_dispatch_identity.py tests/test_governance_emit.py -q` — green
- `pytest tests/test_central_mode_path_gate.py -q` — green (69 passed combined)
- `rg "\.vnx-data" scripts/lib/dispatch_identity.py` — no matches