### PR TITLE
feat(receipt-quality): PR-1 propagate role + receipt_kind into v2 emit

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -572,6 +572,26 @@ def _govern(
         receipt_path = ndjson_path
     else:
         try:
+            # receipt-quality PR-1: resolve dispatch identity (role) from
+            # dispatch_metadata just before the emit. FAIL-OPEN — a resolver
+            # error must never break receipt emission.
+            try:
+                from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+                _project_id = getattr(spec, "project_id", None)
+                if not _project_id:
+                    from dispatch_cli import _resolve_project_id  # noqa: PLC0415
+                    _project_id = _resolve_project_id()
+                _role = resolve_dispatch_role(
+                    spec.dispatch_id, _project_id, state_dir=spec.state_dir,
+                )
+            except Exception:  # noqa: BLE001 — identity join is fail-open
+                logger.debug(
+                    "envelope._govern: role resolution failed open dispatch=%s",
+                    spec.dispatch_id,
+                    exc_info=True,
+                )
+                _role = None
+            _role = _role or "identity_unresolved"
             receipt_path = emit_dispatch_receipt(
                 dispatch_id=spec.dispatch_id,
                 terminal_id=spec.terminal_id,
@@ -598,6 +618,8 @@ def _govern(
                 # on disk (emit_unified_report ran above), so extract
                 # verification{} from it via the shared regex extractor.
                 verification=_verification_from_report(report_path),
+                role=_role,
+                receipt_kind="dispatch",
             )
         except Exception as exc:
             raise EnvelopeGovernError(

--- a/scripts/lib/dispatch_identity.py
+++ b/scripts/lib/dispatch_identity.py
@@ -22,12 +22,6 @@ _SCRIPTS_LIB = Path(__file__).resolve().parent
 if str(_SCRIPTS_LIB) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_LIB))
 
-try:
-    from project_root import resolve_project_root
-    _PROJECT_ROOT = resolve_project_root(__file__)
-except (ImportError, RuntimeError):
-    _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
-
 logger = logging.getLogger(__name__)
 
 # The fake default stamped by writers that never resolved a real role. The
@@ -39,7 +33,8 @@ def _resolve_db_path(state_dir: Optional[Path] = None) -> Optional[Path]:
     """Locate quality_intelligence.db — same resolution as intelligence_backfill.
 
     Order: explicit state_dir → VNX_STATE_DIR env → canonical vnx_paths
-    resolver → repo-local .vnx-data/state last resort. Never raises.
+    resolver. If none of those resolve to an existing DB, return None
+    (fail-open — no repo-local guess). Never raises.
     """
     try:
         if state_dir is not None:
@@ -61,9 +56,6 @@ def _resolve_db_path(state_dir: Optional[Path] = None) -> Optional[Path]:
                 "dispatch_identity: vnx_paths canonical resolver unavailable",
                 exc_info=True,
             )
-        candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
-        if candidate.exists():
-            return candidate
     except Exception:
         logger.debug("dispatch_identity: db path resolution failed", exc_info=True)
     return None

--- a/scripts/lib/dispatch_identity.py
+++ b/scripts/lib/dispatch_identity.py
@@ -1,0 +1,117 @@
+#!/usr/bin/env python3
+"""dispatch_identity.py — resolve the dispatch's real role from dispatch_metadata.
+
+Receipt-quality track PR-1: receipts in the canonical ledger carry no `role`,
+yet ``dispatch_metadata`` (quality_intelligence.db) already holds a real role
+for most dispatches, keyed on ``(dispatch_id, project_id)`` per ADR-007. This
+module propagates that identity into the v2 receipt emit.
+
+FAIL-OPEN contract: any DB-missing / table-missing / query error returns None
+and never raises — receipt emission must never break on the identity join.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from typing import Optional
+
+_SCRIPTS_LIB = Path(__file__).resolve().parent
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+try:
+    from project_root import resolve_project_root
+    _PROJECT_ROOT = resolve_project_root(__file__)
+except (ImportError, RuntimeError):
+    _PROJECT_ROOT = Path(__file__).resolve().parent.parent.parent
+
+logger = logging.getLogger(__name__)
+
+# The fake default stamped by writers that never resolved a real role. The
+# trail must stop propagating it — treated as "no real role".
+_FAKE_DEFAULT_ROLE = "backend-developer"
+
+
+def _resolve_db_path(state_dir: Optional[Path] = None) -> Optional[Path]:
+    """Locate quality_intelligence.db — same resolution as intelligence_backfill.
+
+    Order: explicit state_dir → VNX_STATE_DIR env → canonical vnx_paths
+    resolver → repo-local .vnx-data/state last resort. Never raises.
+    """
+    try:
+        if state_dir is not None:
+            candidate = Path(state_dir) / "quality_intelligence.db"
+            if candidate.exists():
+                return candidate
+        state_dir_env = os.environ.get("VNX_STATE_DIR")
+        if state_dir_env:
+            candidate = Path(state_dir_env) / "quality_intelligence.db"
+            if candidate.exists():
+                return candidate
+        try:
+            from vnx_paths import resolve_paths
+            candidate = Path(resolve_paths()["VNX_STATE_DIR"]) / "quality_intelligence.db"
+            if candidate.exists():
+                return candidate
+        except Exception:
+            logger.debug(
+                "dispatch_identity: vnx_paths canonical resolver unavailable",
+                exc_info=True,
+            )
+        candidate = _PROJECT_ROOT / ".vnx-data" / "state" / "quality_intelligence.db"
+        if candidate.exists():
+            return candidate
+    except Exception:
+        logger.debug("dispatch_identity: db path resolution failed", exc_info=True)
+    return None
+
+
+def resolve_dispatch_role(
+    dispatch_id: str,
+    project_id: str,
+    state_dir: Optional[Path] = None,
+) -> Optional[str]:
+    """Return the real role for a dispatch, or None when unresolved.
+
+    Queries ``dispatch_metadata`` on the ADR-007 composite key, latest row
+    wins. Returns None for missing rows, null/empty roles, and the literal
+    ``"backend-developer"`` fake default. FAIL-OPEN: never raises.
+    """
+    try:
+        if not dispatch_id or not project_id:
+            return None
+        db_path = _resolve_db_path(state_dir)
+        if db_path is None:
+            logger.debug(
+                "dispatch_identity: no quality_intelligence.db found "
+                "(dispatch=%s project=%s)", dispatch_id, project_id,
+            )
+            return None
+        conn = sqlite3.connect(str(db_path))
+        try:
+            row = conn.execute(
+                "SELECT role FROM dispatch_metadata "
+                "WHERE dispatch_id=? AND project_id=? ORDER BY id DESC LIMIT 1",
+                (dispatch_id, project_id),
+            ).fetchone()
+        finally:
+            conn.close()
+        if not row:
+            return None
+        role = row[0]
+        if not role or not str(role).strip():
+            return None
+        role = str(role).strip()
+        if role == _FAKE_DEFAULT_ROLE:
+            return None
+        return role
+    except Exception:
+        logger.debug(
+            "dispatch_identity: role resolution failed open "
+            "(dispatch=%s project=%s)", dispatch_id, project_id,
+            exc_info=True,
+        )
+        return None

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -89,6 +89,8 @@ def emit_dispatch_receipt(
     injection_reconstructs: Optional[bool] = None,
     verification: Optional[Dict[str, Any]] = None,
     warnings: Optional[List[Dict[str, Any]]] = None,
+    role: Optional[str] = None,
+    receipt_kind: Optional[str] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -128,6 +130,13 @@ def emit_dispatch_receipt(
     provided, so callers that do not yet compute it keep a byte-identical
     receipt shape.
 
+    ``role`` / ``receipt_kind``: receipt-quality track PR-1 — dispatch identity
+    propagated from ``dispatch_metadata`` (via
+    ``dispatch_identity.resolve_dispatch_role``) by the caller. Stamped
+    unconditionally (like ``status``): ``None`` when the caller could not
+    resolve a real role, so the ledger records "identity was not resolvable"
+    instead of silently omitting the field.
+
     ``warnings``: ADR-035 §6.1 — raw ``{code, severity, message}`` entries.
     Classified (side-effect-free) via ``classify_receipt_v2_warnings``
     before the receipt is validated, then committed (open-items promotion,
@@ -152,6 +161,11 @@ def emit_dispatch_receipt(
         "terminal_id": terminal_id,
         "provider": provider,
         "model": model,
+        # receipt-quality PR-1: dispatch identity — stamped unconditionally
+        # (like status) so the ledger distinguishes "unresolved" (null) from
+        # "pre-feature" (field absent).
+        "role": role,
+        "receipt_kind": receipt_kind,
         "status": status,
         # ADR-035 §3.2.1/§7.1 (r2 BLOCKING-1): stamped unconditionally, never
         # keyed on status — task_complete marks "reached a terminal outcome",

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -635,6 +635,27 @@ def _emit_governance(
     # auto-vivified Mock child.
     _integrity = vars(args).get("_final_prompt_integrity")
 
+    # receipt-quality PR-1: resolve dispatch identity (role) from
+    # dispatch_metadata just before the emit. FAIL-OPEN — a resolver error
+    # must never break receipt emission.
+    try:
+        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        _project_id = vars(args).get("project_id")
+        if not _project_id:
+            from dispatch_cli import _resolve_project_id  # noqa: PLC0415
+            _project_id = _resolve_project_id()
+        _role = resolve_dispatch_role(
+            args.dispatch_id, _project_id, state_dir=state_dir,
+        )
+    except Exception:  # noqa: BLE001 — identity join is fail-open
+        logger.debug(
+            "_emit_governance: role resolution failed open dispatch=%s",
+            getattr(args, "dispatch_id", "?"),
+            exc_info=True,
+        )
+        _role = None
+    _role = _role or "identity_unresolved"
+
     for attempt in range(_EMIT_MAX_RETRIES):
         try:
             receipt_path = emit_dispatch_receipt(
@@ -678,6 +699,8 @@ def _emit_governance(
                     "push_verified": None,
                     "spec_deviation": None,
                 },
+                role=_role,
+                receipt_kind="dispatch",
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break

--- a/tests/test_dispatch_identity.py
+++ b/tests/test_dispatch_identity.py
@@ -1,0 +1,103 @@
+"""test_dispatch_identity.py — tests for the dispatch_identity role resolver.
+
+Receipt-quality track PR-1: role propagation from dispatch_metadata
+(quality_intelligence.db) into the v2 receipt emit. FAIL-OPEN contract:
+resolver errors return None, never raise.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import dispatch_identity
+from dispatch_identity import resolve_dispatch_role
+
+
+def _make_db(state_dir: Path, rows):
+    """Create a minimal quality_intelligence.db with dispatch_metadata rows."""
+    db_path = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "CREATE TABLE dispatch_metadata ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " dispatch_id TEXT NOT NULL,"
+        " project_id TEXT NOT NULL,"
+        " role TEXT"
+        ")"
+    )
+    for dispatch_id, project_id, role in rows:
+        conn.execute(
+            "INSERT INTO dispatch_metadata (dispatch_id, project_id, role) VALUES (?, ?, ?)",
+            (dispatch_id, project_id, role),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def test_resolve_real_role_from_db(tmp_path):
+    _make_db(tmp_path, [("disp-1", "vnx-dev", "debugger")])
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) == "debugger"
+
+
+def test_resolve_latest_row_wins(tmp_path):
+    # Composite key per ADR-007, ORDER BY id DESC LIMIT 1.
+    _make_db(tmp_path, [("disp-1", "vnx-dev", "reviewer"), ("disp-1", "vnx-dev", "debugger")])
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) == "debugger"
+
+
+def test_resolve_respects_project_id_composite_key(tmp_path):
+    _make_db(tmp_path, [("disp-1", "other-project", "debugger")])
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_backend_developer_returns_none(tmp_path):
+    # The fake default must not be propagated into the receipt trail.
+    _make_db(tmp_path, [("disp-1", "vnx-dev", "backend-developer")])
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_null_or_empty_role_returns_none(tmp_path):
+    _make_db(tmp_path, [("disp-1", "vnx-dev", None), ("disp-2", "vnx-dev", "  ")])
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+    assert resolve_dispatch_role("disp-2", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_missing_row_returns_none(tmp_path):
+    _make_db(tmp_path, [("disp-1", "vnx-dev", "debugger")])
+    assert resolve_dispatch_role("disp-absent", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_table_missing_fails_open(tmp_path):
+    # DB exists but dispatch_metadata table does not → None, no raise.
+    conn = sqlite3.connect(str(tmp_path / "quality_intelligence.db"))
+    conn.execute("CREATE TABLE something_else (id INTEGER)")
+    conn.commit()
+    conn.close()
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_db_missing_fails_open(tmp_path, monkeypatch):
+    # No resolvable DB anywhere → None, no raise.
+    monkeypatch.setattr(dispatch_identity, "_resolve_db_path", lambda state_dir=None: None)
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_query_error_fails_open(tmp_path, monkeypatch):
+    # A connect/query blow-up must degrade to None, never propagate.
+    monkeypatch.setattr(
+        dispatch_identity.sqlite3, "connect",
+        lambda *a, **k: (_ for _ in ()).throw(sqlite3.Error("boom")),
+    )
+    assert resolve_dispatch_role("disp-1", "vnx-dev", state_dir=tmp_path) is None
+
+
+def test_resolve_empty_identifiers_return_none(tmp_path):
+    assert resolve_dispatch_role("", "vnx-dev", state_dir=tmp_path) is None
+    assert resolve_dispatch_role("disp-1", "", state_dir=tmp_path) is None

--- a/tests/test_governance_emit.py
+++ b/tests/test_governance_emit.py
@@ -431,3 +431,32 @@ def test_unified_report_includes_findings(tmp_data):
     path = emit_unified_report(**kwargs)
     assert "Something smells" in path.read_text()
     assert "WARNING" in path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# Receipt-quality PR-1 — role + receipt_kind propagation
+# ---------------------------------------------------------------------------
+
+def test_emit_stamps_role_and_receipt_kind(tmp_state):
+    kwargs = _base_receipt_kwargs(tmp_state)
+    kwargs["role"] = "reviewer"
+    kwargs["receipt_kind"] = "dispatch"
+    emit_dispatch_receipt(**kwargs)
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["role"] == "reviewer"
+    assert data["receipt_kind"] == "dispatch"
+
+
+def test_emit_defaults_none_when_absent(tmp_state):
+    # Omitting the params still emits a valid receipt with role/receipt_kind
+    # stamped as null (unconditional, like status) — no crash.
+    emit_dispatch_receipt(**_base_receipt_kwargs(tmp_state))
+    data = json.loads((tmp_state / "t0_receipts.ndjson").read_text().strip())
+    assert data["role"] is None
+    assert data["receipt_kind"] is None
+
+
+def test_idempotency_fields_unchanged():
+    from append_receipt_internals.idempotency import IDEMPOTENCY_FIELDS
+    assert "role" not in IDEMPOTENCY_FIELDS
+    assert "receipt_kind" not in IDEMPOTENCY_FIELDS


### PR DESCRIPTION
Receipt-quality PR-1 (re-landing on main). Contains 4d76f6cb (propagate role+receipt_kind into the v2 emit via a dispatch_metadata join) + 5e97dff3 (drop repo-local .vnx-data DB fallback, central-mode gate clean). Supersedes #1227/#1228 (which were mis-based on the PR-1 branch and never reached main). CI was green + T0-reviewed on the identical tree; merging under Option B (codex quota exhausted until Jul 28, gemini unavailable) per operator authorization 2026-07-25. Codex re-audit tracked in OI-805.