### PR TITLE
feat(receipt-quality): PR-2 propagate role into govern-synthesized receipts

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -47,6 +47,49 @@ logger = logging.getLogger(__name__)
 # since the tmux dispatch.sh sets PYTHONPATH to scripts/lib only (not scripts/).
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
 
+# The fake default stamped by writers that never resolved a real role. The
+# receipt trail must never propagate it (mirrors dispatch_identity).
+_FAKE_DEFAULT_ROLE = "backend-developer"
+
+# Stamped when no real role is resolvable — NEVER "unknown", NEVER the fake
+# backend-developer default (receipt-quality track).
+_IDENTITY_UNRESOLVED = "identity_unresolved"
+
+
+def _resolve_govern_role(spec: "GovernSpec") -> str:
+    """Resolve the dispatch's real role for govern-emitted receipts/frontmatter.
+
+    Receipt-quality PR-2: propagate dispatch identity into the GOVERN-
+    SYNTHESIZED emit path via the same resolver PR-1 added for the v2 emit
+    path (``dispatch_identity.resolve_dispatch_role``).
+
+    Order:
+      1. ``spec.role`` when genuinely set (never the fake default).
+      2. ``dispatch_metadata`` via the PR-1 resolver, keyed on
+         ``(dispatch_id, project_id)`` per ADR-007.
+      3. ``"identity_unresolved"``.
+
+    FAIL-OPEN: never raises — receipt/report emission must not break on the
+    identity join.
+    """
+    spec_role = (spec.role or "").strip()
+    if spec_role and spec_role != _FAKE_DEFAULT_ROLE:
+        return spec_role
+    resolved: Optional[str] = None
+    try:
+        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        from dispatch_cli import _resolve_project_id  # noqa: PLC0415
+        resolved = resolve_dispatch_role(
+            spec.dispatch_id, _resolve_project_id(), state_dir=spec.state_dir,
+        )
+    except Exception:  # noqa: BLE001 — identity join is fail-open
+        logger.debug(
+            "govern: role resolution failed open dispatch=%s",
+            spec.dispatch_id, exc_info=True,
+        )
+        resolved = None
+    return resolved or _IDENTITY_UNRESOLVED
+
 
 # ---------------------------------------------------------------------------
 # Receipt dedup — authored > synthesized, newest timestamp wins within tier
@@ -132,6 +175,9 @@ def ensure_receipt(
     receipts_file = spec.state_dir / "t0_receipts.ndjson"
     ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
+    # receipt-quality PR-2: dispatch identity on the govern-synthesized emit
+    # path — real role from spec/dispatch_metadata, else identity_unresolved
+    # (fail-open; never the fake backend-developer default).
     synthesized_receipt: dict = {
         "event_type": "subprocess_completion",
         "dispatch_id": spec.dispatch_id,
@@ -148,6 +194,8 @@ def ensure_receipt(
         "sub_provider": "anthropic",
         "model": spec.model or "unknown",
         "lane": lane,
+        "role": _resolve_govern_role(spec),
+        "receipt_kind": "dispatch",
     }
     # ADR-012 worker-permission enforcement audit marker (only when flag ON).
     if worker_permission_enforcement_enabled():
@@ -190,6 +238,8 @@ class GovernSpec:
     # with a vnx-plan-verdict fence — it intentionally lacks the standard contract
     # headings (## Changes / ## Verification / ## Open Items).  govern() must not
     # synthesize over it: synthesis strips the fence and breaks parse_verdict.
+    # receipt-quality PR-2: a genuinely-set spec role also threads through into
+    # govern-emitted receipts and report frontmatter (see _resolve_govern_role).
     role: Optional[str] = None
 
 
@@ -489,7 +539,9 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         "model": _model,
         "terminal_id": spec.terminal_id,
         "pool_id": "interactive",
-        "role": "backend-developer",
+        # receipt-quality PR-2: resolved dispatch identity, not the hardcoded
+        # fake default the converter would otherwise drop/misread.
+        "role": _resolve_govern_role(spec),
         "task_class": "implementation",
         "pr_id": spec.pr_id or "none",
         "duration_seconds": float(raw.duration_seconds),

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -938,6 +938,136 @@ def test_ensure_receipt_idempotent(tmp_data, tmp_state):
 
 
 # ---------------------------------------------------------------------------
+# Receipt-quality PR-2 — role + receipt_kind on the govern-synthesized path
+# ---------------------------------------------------------------------------
+
+def _make_metadata_db(state_dir: Path, rows):
+    """Create a minimal quality_intelligence.db with dispatch_metadata rows."""
+    import sqlite3
+    conn = sqlite3.connect(str(state_dir / "quality_intelligence.db"))
+    conn.execute(
+        "CREATE TABLE dispatch_metadata ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " dispatch_id TEXT NOT NULL,"
+        " project_id TEXT NOT NULL,"
+        " role TEXT"
+        ")"
+    )
+    for dispatch_id, project_id, role in rows:
+        conn.execute(
+            "INSERT INTO dispatch_metadata (dispatch_id, project_id, role) VALUES (?, ?, ?)",
+            (dispatch_id, project_id, role),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _fire_ensure_receipt(spec, tmp_state):
+    raw = GovernRaw(receipt=None, duration_seconds=60.0)
+    ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
+                   contract_status="synthesized", permission_enforcement="soft")
+    receipts_file = tmp_state / "t0_receipts.ndjson"
+    assert receipts_file.exists(), "ensure_receipt must create t0_receipts.ndjson"
+    return json.loads(receipts_file.read_text().splitlines()[0])
+
+
+def test_ensure_receipt_propagates_real_role_from_metadata(tmp_data, tmp_state, monkeypatch):
+    """A govern-synthesized receipt carries the real (non-backend-developer) role
+    from dispatch_metadata when the DB has one for that dispatch."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    _make_metadata_db(tmp_state, [("test-govern-001", "vnx-dev", "debugger")])
+
+    spec = _make_spec(tmp_data, tmp_state)
+    receipt = _fire_ensure_receipt(spec, tmp_state)
+
+    assert receipt["role"] == "debugger"
+    assert receipt["receipt_kind"] == "dispatch"
+
+
+def test_ensure_receipt_identity_unresolved_when_no_metadata(tmp_data, tmp_state, monkeypatch):
+    """No metadata row -> identity_unresolved, NEVER unknown/backend-developer."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+
+    spec = _make_spec(tmp_data, tmp_state)
+    receipt = _fire_ensure_receipt(spec, tmp_state)
+
+    assert receipt["role"] == "identity_unresolved"
+    assert receipt["role"] not in ("unknown", "backend-developer")
+    assert receipt["receipt_kind"] == "dispatch"
+
+
+def test_ensure_receipt_spec_role_threads_through(tmp_data, tmp_state):
+    """A genuinely-set spec role (e.g. plan-reviewer) wins over the DB join."""
+    spec = _make_spec(tmp_data, tmp_state)
+    spec.role = "plan-reviewer"
+    receipt = _fire_ensure_receipt(spec, tmp_state)
+
+    assert receipt["role"] == "plan-reviewer"
+    assert receipt["receipt_kind"] == "dispatch"
+
+
+def test_ensure_receipt_fake_default_spec_role_falls_through(tmp_data, tmp_state, monkeypatch):
+    """A spec role of the fake default is NOT propagated — resolver takes over."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    _make_metadata_db(tmp_state, [("test-govern-001", "vnx-dev", "reviewer")])
+
+    spec = _make_spec(tmp_data, tmp_state)
+    spec.role = "backend-developer"
+    receipt = _fire_ensure_receipt(spec, tmp_state)
+
+    assert receipt["role"] == "reviewer"
+
+
+def test_govern_synthesized_frontmatter_role_from_metadata(tmp_data, tmp_state, monkeypatch):
+    """The govern-emitted report frontmatter stamps the resolved role, not the
+    hardcoded backend-developer default."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_RECEIPT_FALLBACK", "1")
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    _make_metadata_db(tmp_state, [("test-govern-001", "vnx-dev", "debugger")])
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=3600.0)
+
+    with patch("dispatch_govern._git_summary",
+               return_value="No commit; timeout. Body synthesized."), \
+         patch("dispatch_govern._git_changes", return_value="No git diff available"):
+        outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.report_path is not None
+    from dispatch_govern import _split_yaml_frontmatter
+    fm, _body = _split_yaml_frontmatter(
+        Path(outcome.report_path).read_text(encoding="utf-8")
+    )
+    assert fm.get("role") == "debugger"
+
+
+def test_govern_synthesized_frontmatter_identity_unresolved(tmp_data, tmp_state, monkeypatch):
+    """Unresolved identity stamps identity_unresolved in frontmatter — never the
+    fake backend-developer hardcode."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_RECEIPT_FALLBACK", "1")
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+
+    spec = _make_spec(tmp_data, tmp_state)
+    raw = GovernRaw(receipt=None, duration_seconds=3600.0)
+
+    with patch("dispatch_govern._git_summary",
+               return_value="No commit; timeout. Body synthesized."), \
+         patch("dispatch_govern._git_changes", return_value="No git diff available"):
+        outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.report_path is not None
+    from dispatch_govern import _split_yaml_frontmatter
+    fm, _body = _split_yaml_frontmatter(
+        Path(outcome.report_path).read_text(encoding="utf-8")
+    )
+    assert fm.get("role") == "identity_unresolved"
+
+
+# ---------------------------------------------------------------------------
 # govern() + ensure_receipt integration — timeout path appends synthesized receipt
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Track `receipt-quality`, Phase A PR-2. Extends the PR-1 (#1229) `dispatch_identity.resolve_dispatch_role(dispatch_id, project_id)` resolver to the **govern-synthesized** emit path in `scripts/lib/dispatch_govern.py`.

## Changes

- **`ensure_receipt`** (lane-synthesized fallback receipt via `append_receipt_payload`): now stamps `role` + `receipt_kind="dispatch"` on the synthesized payload. Resolution order: `spec.role` when genuinely set → `dispatch_metadata` via the PR-1 resolver → `identity_unresolved`. Fail-open: NEVER `unknown`, NEVER a fake `backend-developer`.
- **Report frontmatter**: the `role: backend-developer` hardcode is replaced by the same resolved role.
- **`GovernSpec.role`**: field already existed in-tree (plan-reviewer support); docstring now notes it also threads into receipts/frontmatter.
- New `_resolve_govern_role(spec)` helper mirrors the PR-1 fail-open contract — resolver errors degrade to `identity_unresolved`, never raise.

Additive keyword fields only; `IDEMPOTENCY_FIELDS` untouched; `task_id`/`terminal` defaults untouched.

## Tree verification vs dispatch note

- `_append_synthesized_receipt` (~line 1984 in the dispatch) does **not** exist in the current tree — `ensure_receipt` is the single govern-synthesized receipt emit (verified by grep); propagation applied there.
- `GovernSpec.role` already existed; no dataclass change needed.
- `claudedocs/plans/receipt-quality.md` is not in the repo; the windowed acceptance query runs post-merge on the live ledger (windowed, append-only — no retro-rewrite).

## Verification

- `tests/test_dispatch_govern.py`: 6 new tests — real-role-from-metadata on synthesized receipt, `identity_unresolved` fallback, spec-role thread-through, fake-default fall-through, frontmatter role from metadata, frontmatter `identity_unresolved`.
- `pytest tests/test_dispatch_govern.py tests/test_dispatch_identity.py tests/test_governance_emit.py` → **109 passed**.
- `pytest tests/test_tmux_interactive_dispatch.py tests/test_report_to_receipt_converter.py tests/test_append_receipt.py tests/test_append_receipt_identity.py tests/test_subprocess_dispatch.py` → 247 passed, 2 failed — both failures reproduce on the clean tree (pre-existing, unrelated).
- New-window acceptance (post-merge, live ledger): over govern-synthesized receipts emitted after this PR, `with_real_role/dispatch` → ~1.0 for that path; `identity_unresolved` ≤ 30% of windowed dispatch population.

## Codex note

Codex CLI rate-limited until Jul 28 19:08 — Option-B review after fix (VNX CI green + T0 diff-review); codex re-audit OI to be filed per merge.