### PR TITLE
feat(receipt-quality): PR-4 converter role resolver + write-time capture-gap backfill

### DIFF
--- a/scripts/lib/dispatch_identity.py
+++ b/scripts/lib/dispatch_identity.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 import sqlite3
 import sys
 from pathlib import Path
@@ -27,6 +28,34 @@ logger = logging.getLogger(__name__)
 # The fake default stamped by writers that never resolved a real role. The
 # trail must stop propagating it — treated as "no real role".
 _FAKE_DEFAULT_ROLE = "backend-developer"
+
+# Receipt-quality PR-4: instruction-header source used by the write-time
+# capture-gap backfill (mirrors subprocess_dispatch._ROLE_HEADER_RE).
+_ROLE_HEADER_RE = re.compile(r"^Role:\s*(\S+)", re.MULTILINE)
+
+
+def normalize_role(role: Optional[str]) -> Optional[str]:
+    """Normalize a write-time role value.
+
+    Returns the stripped role, or None when the value is empty/None or the
+    fake ``backend-developer`` default. Writers must persist NULL instead of
+    the fake literal so the emit-side resolver stamps ``identity_unresolved``
+    rather than propagating a fabricated identity.
+    """
+    if not role:
+        return None
+    role = str(role).strip()
+    if not role or role == _FAKE_DEFAULT_ROLE:
+        return None
+    return role
+
+
+def extract_role_from_instruction(instruction: Optional[str]) -> Optional[str]:
+    """Return the role from a ``Role: <name>`` header in the instruction, or None."""
+    if not instruction:
+        return None
+    m = _ROLE_HEADER_RE.search(instruction)
+    return m.group(1) if m else None
 
 # Receipt-quality PR-3 (plan §3b): the authoritative closed set of
 # ``receipt_kind`` values. Stamped per-emitter from the emitter's own

--- a/scripts/lib/dispatch_metadata_db.py
+++ b/scripts/lib/dispatch_metadata_db.py
@@ -41,6 +41,13 @@ from typing import Optional
 
 logger = logging.getLogger(__name__)
 
+# Receipt-quality PR-4: write-time role normalization (fake backend-developer
+# default -> NULL). Imported defensively; degradation keeps prior behaviour.
+try:
+    from dispatch_identity import normalize_role as _normalize_role  # noqa: E402
+except Exception:  # pragma: no cover - sibling module available in-tree
+    _normalize_role = None  # type: ignore[assignment]
+
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     try:
@@ -141,6 +148,16 @@ def upsert_dispatch_provider_row(
         raise ValueError("upsert_dispatch_provider_row: terminal is required")
     if not (provider or "").strip():
         raise ValueError("upsert_dispatch_provider_row: provider is required")
+
+    # Receipt-quality PR-4: never persist the fake backend-developer default —
+    # normalize it to NULL at write time so the emit-side resolver stamps
+    # identity_unresolved instead of propagating a fabricated identity. The
+    # UPDATE's COALESCE then also stops a fake/empty role from nulling an
+    # existing real role.
+    if _normalize_role is not None:
+        role = _normalize_role(role)
+    else:
+        role = role or None
 
     db_path = Path(db_path)
     if not db_path.exists():

--- a/scripts/lib/intelligence_backfill.py
+++ b/scripts/lib/intelligence_backfill.py
@@ -1,10 +1,15 @@
 #!/usr/bin/env python3
 """
-intelligence_backfill.py — retroactive scope_tags population for quality_intelligence.db.
+intelligence_backfill.py — retroactive backfills for quality_intelligence.db.
 
-Updates success_patterns and antipatterns where category is NULL or empty,
-based on keyword matching in title+description. Safe to re-run (idempotent
-because it only touches rows with empty category).
+1. scope_tags: updates success_patterns and antipatterns where category is
+   NULL or empty, based on keyword matching in title+description.
+2. dispatch_metadata.role (receipt-quality PR-4): fills rows whose role is
+   NULL/empty or the fake ``backend-developer`` default with a genuine
+   receipt-carried role from t0_receipts.ndjson; rows without a derivable
+   role stay NULL (the emit-side resolver stamps ``identity_unresolved``).
+
+Safe to re-run (idempotent — each pass only touches still-unfilled rows).
 
 Usage:
     python3 scripts/lib/intelligence_backfill.py [--db PATH] [--dry-run]
@@ -12,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import re
@@ -23,6 +29,18 @@ from typing import Dict, List, Optional, Tuple
 _SCRIPTS_LIB = Path(__file__).resolve().parent
 if str(_SCRIPTS_LIB) not in sys.path:
     sys.path.insert(0, str(_SCRIPTS_LIB))
+
+try:
+    # Receipt-quality PR-4: capture-gap role backfill for dispatch_metadata.
+    from dispatch_identity import _FAKE_DEFAULT_ROLE, normalize_role
+except Exception:  # pragma: no cover - sibling module available in-tree
+    _FAKE_DEFAULT_ROLE = "backend-developer"
+
+    def normalize_role(role):  # type: ignore[no-redef]
+        if not role:
+            return None
+        role = str(role).strip()
+        return None if (not role or role == _FAKE_DEFAULT_ROLE) else role
 
 try:
     from project_root import resolve_project_root
@@ -103,6 +121,95 @@ def backfill_table(
     return checked, updated
 
 
+def _load_receipt_roles(receipts_file: Path) -> Dict[str, str]:
+    """Latest genuine role per dispatch_id from t0_receipts.ndjson.
+
+    Receipt-quality PR-4: post-PR-1 receipts carry the resolved dispatch role.
+    Only genuine roles are collected (``identity_unresolved`` / fake / empty
+    excluded). Later lines win (append order). Fail-open: unreadable or
+    malformed lines are skipped.
+    """
+    roles: Dict[str, str] = {}
+    try:
+        lines = receipts_file.read_text(encoding="utf-8").splitlines()
+    except OSError as exc:
+        logger.warning("role backfill: cannot read receipts %s: %s", receipts_file, exc)
+        return roles
+    for line in lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            rec = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(rec, dict):
+            continue
+        dispatch_id = rec.get("dispatch_id")
+        role = normalize_role(rec.get("role"))
+        if role == "identity_unresolved":
+            role = None
+        if dispatch_id and role:
+            roles[str(dispatch_id)] = role
+    return roles
+
+
+def backfill_dispatch_metadata_roles(
+    conn: sqlite3.Connection,
+    receipts_file: Optional[Path],
+    *,
+    dry_run: bool = False,
+) -> Tuple[int, int]:
+    """Backfill dispatch_metadata.role for rows with NULL/empty/fake role.
+
+    Genuine source: the receipt-carried role in t0_receipts.ndjson (PR-1+).
+    Rows without a derivable genuine role are left NULL — the emit-side
+    resolver stamps ``identity_unresolved`` for them. Idempotent: once a real
+    role is stamped the row no longer matches the selection.
+
+    Returns (checked, updated) counts.
+    """
+    try:
+        rows = conn.execute(
+            "SELECT id, dispatch_id FROM dispatch_metadata "
+            "WHERE role IS NULL OR role = '' OR role = ?",
+            (_FAKE_DEFAULT_ROLE,),
+        ).fetchall()
+    except sqlite3.Error as exc:
+        logger.warning("backfill_dispatch_metadata_roles: query failed: %s", exc)
+        return 0, 0
+
+    receipt_roles = _load_receipt_roles(receipts_file) if receipts_file else {}
+    checked = len(rows)
+    updated = 0
+
+    for row_id, dispatch_id in rows:
+        role = receipt_roles.get(dispatch_id)
+        if not role:
+            continue
+        if not dry_run:
+            try:
+                conn.execute(
+                    "UPDATE dispatch_metadata SET role = ? WHERE id = ?",
+                    (role, row_id),
+                )
+            except sqlite3.Error as exc:
+                logger.warning(
+                    "backfill_dispatch_metadata_roles: update failed for id=%s: %s",
+                    row_id, exc,
+                )
+                continue
+        updated += 1
+
+    if not dry_run and updated > 0:
+        try:
+            conn.commit()
+        except sqlite3.Error as exc:
+            logger.warning("backfill_dispatch_metadata_roles: commit failed: %s", exc)
+
+    return checked, updated
+
+
 def run_backfill(db_path: Path, *, dry_run: bool = False) -> Dict[str, Dict[str, int]]:
     """Run the full backfill and return a per-table summary dict."""
     if not db_path.exists():
@@ -121,6 +228,20 @@ def run_backfill(db_path: Path, *, dry_run: bool = False) -> Dict[str, Dict[str,
                 "backfill %s: checked=%d updated=%d dry_run=%s",
                 table, checked, updated, dry_run,
             )
+        # Receipt-quality PR-4: dispatch_metadata role capture-gap backfill.
+        # Receipts live next to the DB in the state dir; absent file simply
+        # yields zero updates (rows stay NULL -> identity_unresolved at emit).
+        receipts_file = db_path.parent / "t0_receipts.ndjson"
+        checked, updated = backfill_dispatch_metadata_roles(
+            conn,
+            receipts_file if receipts_file.exists() else None,
+            dry_run=dry_run,
+        )
+        results["dispatch_metadata.role"] = {"checked": checked, "updated": updated}
+        logger.info(
+            "backfill dispatch_metadata.role: checked=%d updated=%d dry_run=%s",
+            checked, updated, dry_run,
+        )
     finally:
         conn.close()
 

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -499,6 +499,22 @@ def _record_provider_metadata(
         from dispatch_metadata_db import upsert_dispatch_provider_row  # noqa: PLC0415
         db_path = Path(state_dir) / "quality_intelligence.db"
         terminal = getattr(args, "terminal_id", "") or ""
+        # Receipt-quality PR-4: capture-gap backfill at metadata-WRITE time.
+        # Derive a genuine role: normalize the fake backend-developer default
+        # away, then recover from the instruction's "Role:" header. Where no
+        # real role is derivable, leave null — the resolver stamps
+        # identity_unresolved at emit.
+        role = getattr(args, "role", None)
+        try:
+            from dispatch_identity import (  # noqa: PLC0415
+                extract_role_from_instruction,
+                normalize_role,
+            )
+            role = normalize_role(role) or extract_role_from_instruction(
+                getattr(args, "instruction", "") or ""
+            )
+        except Exception:  # noqa: BLE001 — role derivation is non-fatal
+            role = role or None
         upsert_dispatch_provider_row(
             db_path,
             dispatch_id=args.dispatch_id,
@@ -506,7 +522,7 @@ def _record_provider_metadata(
             provider=provider,
             model=model_used or None,
             track=_TERMINAL_TRACK.get(terminal, "headless"),
-            role=getattr(args, "role", None),
+            role=role,
             gate=getattr(args, "gate", None) or None,
             pr_id=getattr(args, "pr_id", None),
             outcome_status=status,

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -178,6 +178,34 @@ def _load_route_decision(dispatch_id: str, state_dir: Path) -> Optional[Dict[str
         return None
 
 
+def _resolve_report_role(
+    dispatch_id: str, merged: Dict[str, Any], state_dir: Optional[Path]
+) -> str:
+    """Resolve the dispatch's real role from dispatch_metadata (PR-4).
+
+    FAIL-OPEN contract (mirrors PR-1/PR-2): any resolution error, missing DB,
+    missing row, null/empty role, or the fake ``backend-developer`` default
+    degrades to ``identity_unresolved`` — never ``unknown``, never the fake
+    literal, never raises.
+    """
+    role: Optional[str] = None
+    try:
+        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        project_id = merged.get("project_id") or None
+        if not project_id:
+            from dispatch_cli import _resolve_project_id  # noqa: PLC0415
+            project_id = _resolve_project_id()
+        role = resolve_dispatch_role(dispatch_id, project_id, state_dir=state_dir)
+    except Exception:  # noqa: BLE001 — identity join is fail-open
+        logger.debug(
+            "report_to_receipt_converter: role resolution failed open dispatch=%s",
+            dispatch_id,
+            exc_info=True,
+        )
+        role = None
+    return role or "identity_unresolved"
+
+
 def build_receipt_from_report(
     report_path: Path, text: str, *, state_dir: Optional[Path] = None
 ) -> Optional[Dict[str, Any]]:
@@ -247,9 +275,12 @@ def build_receipt_from_report(
     # append_receipt_payload()'s rolling cache deduplicate same-cycle runs.
     base: Dict[str, Any] = {
         "dispatch_id": dispatch_id,
-        # Receipt-quality PR-3: converter receipts are dispatch-lane outcomes;
-        # role propagation for this path lands in PR-4 (kind-only here).
+        # Receipt-quality PR-3: converter receipts are dispatch-lane outcomes
+        # (closed-set receipt_kind; the emit-time lint raises on untagged).
         "receipt_kind": "dispatch",
+        # Receipt-quality PR-4: real role from dispatch_metadata via the
+        # resolver; fail-open to identity_unresolved (never unknown / fake).
+        "role": _resolve_report_role(dispatch_id, merged, state_dir),
         "task_id": merged.get("task_id", "unknown"),
         "terminal": merged.get("terminal", "unknown"),
         "provider": merged.get("provider", "unknown"),

--- a/scripts/log_dispatch_metadata.py
+++ b/scripts/log_dispatch_metadata.py
@@ -19,6 +19,14 @@ try:
 except Exception as exc:
     raise SystemExit(f"Failed to load vnx_paths: {exc}")
 
+try:
+    # Receipt-quality PR-4: normalize the fake backend-developer default to
+    # NULL at write time (resolver stamps identity_unresolved at emit).
+    from dispatch_identity import normalize_role as _normalize_role
+except Exception:  # pragma: no cover - sibling module available in-tree
+    def _normalize_role(role):
+        return role or None
+
 
 def _has_column(conn: sqlite3.Connection, table: str, column: str) -> bool:
     try:
@@ -96,7 +104,7 @@ def main():
             return 1
     now_iso = datetime.utcnow().isoformat()
     _dispatch_vals = (
-        args.role or None,
+        _normalize_role(args.role),
         args.skill_name or None,
         args.gate or None,
         args.cognition,
@@ -123,9 +131,12 @@ def main():
             args.dispatch_id, args.terminal, args.track,
             *_dispatch_vals, now_iso, project_id_val,
         ))
+        # role=COALESCE(?, role): a re-call without a role (or with the fake
+        # default, normalized to NULL above) must not null an existing real
+        # role; a genuine new role still overwrites (PR-4 capture-gap fix).
         cur.execute("""
             UPDATE dispatch_metadata SET
-                terminal=?, track=?, role=?, skill_name=?, gate=?,
+                terminal=?, track=?, role=COALESCE(?, role), skill_name=?, gate=?,
                 cognition=?, priority=?, pr_id=?,
                 pattern_count=?, prevention_rule_count=?, intelligence_json=?,
                 instruction_char_count=?, context_file_count=?, target_open_items=?
@@ -148,7 +159,7 @@ def main():
         ))
         cur.execute("""
             UPDATE dispatch_metadata SET
-                terminal=?, track=?, role=?, skill_name=?, gate=?,
+                terminal=?, track=?, role=COALESCE(?, role), skill_name=?, gate=?,
                 cognition=?, priority=?, pr_id=?,
                 pattern_count=?, prevention_rule_count=?, intelligence_json=?,
                 instruction_char_count=?, context_file_count=?, target_open_items=?

--- a/tests/test_dispatch_identity.py
+++ b/tests/test_dispatch_identity.py
@@ -16,7 +16,11 @@ import pytest
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 
 import dispatch_identity
-from dispatch_identity import resolve_dispatch_role
+from dispatch_identity import (
+    extract_role_from_instruction,
+    normalize_role,
+    resolve_dispatch_role,
+)
 
 
 def _make_db(state_dir: Path, rows):
@@ -101,3 +105,34 @@ def test_resolve_query_error_fails_open(tmp_path, monkeypatch):
 def test_resolve_empty_identifiers_return_none(tmp_path):
     assert resolve_dispatch_role("", "vnx-dev", state_dir=tmp_path) is None
     assert resolve_dispatch_role("disp-1", "", state_dir=tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# PR-4 write-time helpers: normalize_role / extract_role_from_instruction
+# ---------------------------------------------------------------------------
+
+def test_normalize_role_strips_and_keeps_real_role():
+    assert normalize_role("quality-engineer") == "quality-engineer"
+    assert normalize_role("  debugger  ") == "debugger"
+
+
+def test_normalize_role_fake_default_returns_none():
+    # The fake backend-developer default must never be persisted.
+    assert normalize_role("backend-developer") is None
+
+
+def test_normalize_role_empty_or_none_returns_none():
+    assert normalize_role(None) is None
+    assert normalize_role("") is None
+    assert normalize_role("   ") is None
+
+
+def test_extract_role_from_instruction_header():
+    assert extract_role_from_instruction("Role: debugger\n\nDo the thing") == "debugger"
+    assert extract_role_from_instruction("# Dispatch\nRole: quality-engineer\nBody") == "quality-engineer"
+
+
+def test_extract_role_from_instruction_absent_returns_none():
+    assert extract_role_from_instruction("no header here") is None
+    assert extract_role_from_instruction("") is None
+    assert extract_role_from_instruction(None) is None

--- a/tests/test_pr4_role_capture_backfill.py
+++ b/tests/test_pr4_role_capture_backfill.py
@@ -1,0 +1,434 @@
+#!/usr/bin/env python3
+"""Tests for receipt-quality PR-4 — capture-gap role backfill at metadata-WRITE time.
+
+Covers:
+  1. dispatch_metadata_db.upsert_dispatch_provider_row — fake backend-developer
+     default normalized to NULL; real role stamped; UPDATE never nulls an
+     existing real role.
+  2. provider_dispatch._record_provider_metadata — derives a genuine role from
+     the instruction's "Role:" header when args.role is absent/fake; leaves
+     NULL when nothing genuine is derivable.
+  3. log_dispatch_metadata.py — re-call without --role does not null an
+     existing real role; fake --role is normalized to NULL.
+  4. intelligence_backfill.backfill_dispatch_metadata_roles — fills role from
+     receipt-carried roles; leaves NULL when no genuine role is derivable;
+     dry-run writes nothing.
+
+Dispatch-ID: 20260728-rq-pr4-converter-backfill-r2
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+import tempfile
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+for p in (str(LIB_DIR), str(SCRIPTS_DIR)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+from dispatch_metadata_db import upsert_dispatch_provider_row  # noqa: E402
+from provider_dispatch import _record_provider_metadata  # noqa: E402
+
+# scripts/intelligence_backfill.py shadows scripts/lib/intelligence_backfill.py
+# when another test module imported the scripts/ variant first — load the lib
+# module explicitly by path under a unique name.
+import importlib.util as _ilu  # noqa: E402
+
+_spec = _ilu.spec_from_file_location(
+    "intelligence_backfill_lib", LIB_DIR / "intelligence_backfill.py"
+)
+_ib = _ilu.module_from_spec(_spec)
+_spec.loader.exec_module(_ib)
+backfill_dispatch_metadata_roles = _ib.backfill_dispatch_metadata_roles
+run_backfill = _ib.run_backfill
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_db(path: Path) -> None:
+    """Minimal post-migration dispatch_metadata schema."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(path))
+    conn.executescript("""
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            terminal TEXT NOT NULL,
+            track TEXT NOT NULL,
+            provider TEXT,
+            model TEXT,
+            role TEXT,
+            gate TEXT,
+            pr_id TEXT,
+            dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            completed_at DATETIME,
+            outcome_status TEXT,
+            outcome_report_path TEXT,
+            UNIQUE (project_id, dispatch_id)
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _read_role(db: Path, dispatch_id: str):
+    conn = sqlite3.connect(str(db))
+    try:
+        row = conn.execute(
+            "SELECT role FROM dispatch_metadata WHERE dispatch_id=?",
+            (dispatch_id,),
+        ).fetchone()
+    finally:
+        conn.close()
+    return row[0] if row else None
+
+
+# ---------------------------------------------------------------------------
+# 1. upsert_dispatch_provider_row — write-time normalization
+# ---------------------------------------------------------------------------
+
+class TestUpsertRoleNormalization:
+    def test_fake_default_normalized_to_null_on_insert(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        ok = upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-fake-role",
+            terminal="T1",
+            provider="claude",
+            role="backend-developer",
+            project_id="vnx-dev",
+        )
+        assert ok
+        assert _read_role(db, "pr4-fake-role") is None
+
+    def test_real_role_stamped_verbatim(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        ok = upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-real-role",
+            terminal="T1",
+            provider="claude",
+            role="quality-engineer",
+            project_id="vnx-dev",
+        )
+        assert ok
+        assert _read_role(db, "pr4-real-role") == "quality-engineer"
+
+    def test_update_with_fake_role_does_not_null_existing_real_role(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-keep-role",
+            terminal="T1",
+            provider="claude",
+            role="debugger",
+            project_id="vnx-dev",
+        )
+        # Second write carries only the fake default — must not clobber.
+        upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-keep-role",
+            terminal="T1",
+            provider="codex",
+            role="backend-developer",
+            outcome_status="success",
+            project_id="vnx-dev",
+        )
+        assert _read_role(db, "pr4-keep-role") == "debugger"
+
+    def test_update_with_none_role_does_not_null_existing_real_role(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-keep-role-2",
+            terminal="T1",
+            provider="claude",
+            role="reviewer",
+            project_id="vnx-dev",
+        )
+        upsert_dispatch_provider_row(
+            db,
+            dispatch_id="pr4-keep-role-2",
+            terminal="T1",
+            provider="claude",
+            role=None,
+            project_id="vnx-dev",
+        )
+        assert _read_role(db, "pr4-keep-role-2") == "reviewer"
+
+
+# ---------------------------------------------------------------------------
+# 2. provider_dispatch._record_provider_metadata — Role:-header derivation
+# ---------------------------------------------------------------------------
+
+class TestRecordProviderMetadataRoleDerivation:
+    def _state_dir(self, tmp_path: Path) -> Path:
+        # Store-derived tenant resolution needs the .vnx-data/<pid>/state layout.
+        state_dir = tmp_path / ".vnx-data" / "vnx-dev" / "state"
+        state_dir.mkdir(parents=True, exist_ok=True)
+        _make_db(state_dir / "quality_intelligence.db")
+        return state_dir
+
+    def _args(self, **overrides) -> argparse.Namespace:
+        base = dict(
+            dispatch_id="pr4-provider-dispatch",
+            terminal_id="T2",
+            role=None,
+            instruction="",
+            gate=None,
+            pr_id=None,
+        )
+        base.update(overrides)
+        return argparse.Namespace(**base)
+
+    def test_role_derived_from_instruction_header(self, tmp_path):
+        state_dir = self._state_dir(tmp_path)
+        args = self._args(instruction="Role: security-engineer\n\nDo the thing")
+        _record_provider_metadata(args, "kimi", "success", tmp_path / "report.md", state_dir)
+        assert _read_role(state_dir / "quality_intelligence.db", "pr4-provider-dispatch") == "security-engineer"
+
+    def test_fake_role_falls_through_to_instruction_header(self, tmp_path):
+        state_dir = self._state_dir(tmp_path)
+        args = self._args(
+            role="backend-developer",
+            instruction="Role: data-analyst\n\nDo the thing",
+        )
+        _record_provider_metadata(args, "codex", "success", tmp_path / "report.md", state_dir)
+        assert _read_role(state_dir / "quality_intelligence.db", "pr4-provider-dispatch") == "data-analyst"
+
+    def test_real_role_wins_over_instruction_header(self, tmp_path):
+        state_dir = self._state_dir(tmp_path)
+        args = self._args(
+            role="quality-engineer",
+            instruction="Role: data-analyst\n\nDo the thing",
+        )
+        _record_provider_metadata(args, "gemini", "success", tmp_path / "report.md", state_dir)
+        assert _read_role(state_dir / "quality_intelligence.db", "pr4-provider-dispatch") == "quality-engineer"
+
+    def test_no_derivable_role_leaves_null(self, tmp_path):
+        state_dir = self._state_dir(tmp_path)
+        args = self._args(role="backend-developer", instruction="no header here")
+        _record_provider_metadata(args, "claude", "success", tmp_path / "report.md", state_dir)
+        assert _read_role(state_dir / "quality_intelligence.db", "pr4-provider-dispatch") is None
+
+
+# ---------------------------------------------------------------------------
+# 3. log_dispatch_metadata.py — no nulling on re-call, fake normalized
+# ---------------------------------------------------------------------------
+
+class TestLogDispatchMetadataRole:
+    def _make_log_db(self, db_path: Path) -> None:
+        """Full column set log_dispatch_metadata.py writes to."""
+        db_path.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript("""
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                terminal TEXT NOT NULL,
+                track TEXT NOT NULL,
+                provider TEXT,
+                model TEXT,
+                role TEXT,
+                skill_name TEXT,
+                gate TEXT,
+                pr_id TEXT,
+                dispatched_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                target_open_items TEXT,
+                pattern_count INTEGER DEFAULT 0,
+                prevention_rule_count INTEGER DEFAULT 0,
+                intelligence_json TEXT,
+                instruction_char_count INTEGER DEFAULT 0,
+                context_file_count INTEGER DEFAULT 0,
+                cognition TEXT DEFAULT 'normal',
+                priority TEXT DEFAULT 'P1',
+                UNIQUE (project_id, dispatch_id)
+            );
+        """)
+        conn.commit()
+        conn.close()
+
+    def _run_script(self, db_path: Path, *extra_args: str) -> subprocess.CompletedProcess:
+        env = os.environ.copy()
+        env["VNX_STATE_DIR"] = str(db_path.parent)
+        env["VNX_DATA_DIR"] = str(db_path.parent.parent)
+        env["VNX_PROJECT_ID"] = "vnx-dev"
+        return subprocess.run(
+            [sys.executable, str(SCRIPTS_DIR / "log_dispatch_metadata.py"), *extra_args],
+            env=env,
+            capture_output=True,
+            text=True,
+        )
+
+    def test_recall_without_role_does_not_null_existing_real_role(self, tmp_path):
+        db = tmp_path / "state" / "quality_intelligence.db"
+        self._make_log_db(db)
+        r1 = self._run_script(
+            db,
+            "--dispatch-id", "pr4-log-keep",
+            "--terminal", "T1",
+            "--track", "A",
+            "--role", "quality-engineer",
+        )
+        assert r1.returncode == 0, f"first call failed: {r1.stderr}"
+        assert _read_role(db, "pr4-log-keep") == "quality-engineer"
+
+        # Re-call without --role (the old contract nulled the role here).
+        r2 = self._run_script(
+            db,
+            "--dispatch-id", "pr4-log-keep",
+            "--terminal", "T1",
+            "--track", "A",
+        )
+        assert r2.returncode == 0, f"second call failed: {r2.stderr}"
+        assert _read_role(db, "pr4-log-keep") == "quality-engineer"
+
+    def test_fake_role_normalized_to_null(self, tmp_path):
+        db = tmp_path / "state" / "quality_intelligence.db"
+        self._make_log_db(db)
+        r = self._run_script(
+            db,
+            "--dispatch-id", "pr4-log-fake",
+            "--terminal", "T1",
+            "--track", "A",
+            "--role", "backend-developer",
+        )
+        assert r.returncode == 0, f"script failed: {r.stderr}"
+        assert _read_role(db, "pr4-log-fake") is None
+
+
+# ---------------------------------------------------------------------------
+# 4. intelligence_backfill — dispatch_metadata role backfill from receipts
+# ---------------------------------------------------------------------------
+
+class TestIntelligenceBackfillRoles:
+    def _write_receipts(self, state_dir: Path, records) -> Path:
+        receipts = state_dir / "t0_receipts.ndjson"
+        receipts.write_text(
+            "\n".join(json.dumps(r) for r in records) + "\n",
+            encoding="utf-8",
+        )
+        return receipts
+
+    def _seed_role(self, db: Path, dispatch_id: str, role) -> None:
+        conn = sqlite3.connect(str(db))
+        conn.execute(
+            "INSERT INTO dispatch_metadata (dispatch_id, project_id, terminal, track, role) "
+            "VALUES (?, 'vnx-dev', 'T1', 'A', ?)",
+            (dispatch_id, role),
+        )
+        conn.commit()
+        conn.close()
+
+    def test_fills_role_from_receipt_carried_role(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "pr4-bf-1", None)
+        self._seed_role(db, "pr4-bf-2", "backend-developer")  # fake default
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "pr4-bf-1", "role": "debugger"},
+            {"dispatch_id": "pr4-bf-2", "role": "reviewer"},
+        ])
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(conn, receipts)
+        conn.close()
+        assert checked == 2
+        assert updated == 2
+        assert _read_role(db, "pr4-bf-1") == "debugger"
+        assert _read_role(db, "pr4-bf-2") == "reviewer"
+
+    def test_leaves_null_when_no_genuine_role_derivable(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "pr4-bf-3", None)
+        self._seed_role(db, "pr4-bf-4", "backend-developer")
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "pr4-bf-3", "role": "identity_unresolved"},
+            {"dispatch_id": "pr4-bf-4", "role": "backend-developer"},
+        ])
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(conn, receipts)
+        conn.close()
+        assert checked == 2
+        assert updated == 0
+        assert _read_role(db, "pr4-bf-3") is None
+        assert _read_role(db, "pr4-bf-4") == "backend-developer"  # untouched (no genuine source)
+
+    def test_real_role_rows_not_selected(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "pr4-bf-5", "quality-engineer")
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "pr4-bf-5", "role": "debugger"},
+        ])
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(conn, receipts)
+        conn.close()
+        assert checked == 0
+        assert updated == 0
+        assert _read_role(db, "pr4-bf-5") == "quality-engineer"
+
+    def test_dry_run_writes_nothing(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "pr4-bf-6", None)
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "pr4-bf-6", "role": "debugger"},
+        ])
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(conn, receipts, dry_run=True)
+        conn.close()
+        assert checked == 1
+        assert updated == 1
+        assert _read_role(db, "pr4-bf-6") is None  # dry-run: no write
+
+    def test_missing_receipts_file_is_noop(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "pr4-bf-7", None)
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(conn, None)
+        conn.close()
+        assert checked == 1
+        assert updated == 0
+        assert _read_role(db, "pr4-bf-7") is None
+
+    def test_run_backfill_includes_role_summary(self, tmp_path):
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        # patterns tables so the category backfill has something to scan
+        conn = sqlite3.connect(str(db))
+        conn.executescript("""
+            CREATE TABLE success_patterns (id INTEGER PRIMARY KEY, title TEXT, description TEXT, category TEXT);
+            CREATE TABLE antipatterns (id INTEGER PRIMARY KEY, title TEXT, description TEXT, category TEXT);
+        """)
+        conn.commit()
+        conn.close()
+        self._seed_role(db, "pr4-bf-8", None)
+        self._write_receipts(tmp_path, [{"dispatch_id": "pr4-bf-8", "role": "debugger"}])
+        results = run_backfill(db)
+        assert results["dispatch_metadata.role"] == {"checked": 1, "updated": 1}
+        assert _read_role(db, "pr4-bf-8") == "debugger"
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -533,6 +533,99 @@ class TestContractValidation:
 
 
 # ---------------------------------------------------------------------------
+# Part 7b: dispatch identity propagation (receipt-quality PR-4)
+# ---------------------------------------------------------------------------
+
+class TestIdentityPropagation:
+    """Converter receipts carry the real role from dispatch_metadata via
+    dispatch_identity.resolve_dispatch_role; fail-open to identity_unresolved
+    (never "unknown", never the fake backend-developer literal).
+    """
+
+    def _make_metadata_db(self, state_dir: Path, rows) -> None:
+        import sqlite3
+        db_path = state_dir / "quality_intelligence.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE dispatch_metadata ("
+            " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            " dispatch_id TEXT NOT NULL,"
+            " project_id TEXT NOT NULL,"
+            " role TEXT"
+            ")"
+        )
+        for dispatch_id, project_id, role in rows:
+            conn.execute(
+                "INSERT INTO dispatch_metadata (dispatch_id, project_id, role) VALUES (?, ?, ?)",
+                (dispatch_id, project_id, role),
+            )
+        conn.commit()
+        conn.close()
+
+    def test_receipt_carries_real_role_when_db_has_one(self, tmp_path, state_dir):
+        dispatch_id = "20260728-pr4-real-role"
+        self._make_metadata_db(state_dir, [(dispatch_id, "vnx-dev", "debugger")])
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, project_id="vnx-dev")
+
+        result = convert_report_to_receipt(
+            report, receipts_file=str(state_dir / "t0_receipts.ndjson")
+        )
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["role"] == "debugger"
+        assert r["receipt_kind"] == "dispatch"
+
+    def test_receipt_stamps_identity_unresolved_when_no_metadata(self, tmp_path, state_dir):
+        dispatch_id = "20260728-pr4-unresolved"
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id)
+
+        result = convert_report_to_receipt(
+            report, receipts_file=str(state_dir / "t0_receipts.ndjson")
+        )
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["role"] == "identity_unresolved"
+        assert r["role"] != "unknown"
+
+    def test_receipt_never_propagates_fake_default(self, tmp_path, state_dir):
+        dispatch_id = "20260728-pr4-fake-default"
+        self._make_metadata_db(state_dir, [(dispatch_id, "vnx-dev", "backend-developer")])
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, project_id="vnx-dev")
+
+        result = convert_report_to_receipt(
+            report, receipts_file=str(state_dir / "t0_receipts.ndjson")
+        )
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["role"] == "identity_unresolved"
+
+    def test_role_resolution_error_fails_open(self, tmp_path, state_dir, monkeypatch):
+        import dispatch_identity
+        monkeypatch.setattr(
+            dispatch_identity,
+            "resolve_dispatch_role",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")),
+        )
+        dispatch_id = "20260728-pr4-failopen"
+        report = tmp_path / f"{dispatch_id}.md"
+        _write_frontmatter_report(report, dispatch_id, project_id="vnx-dev")
+
+        result = convert_report_to_receipt(
+            report, receipts_file=str(state_dir / "t0_receipts.ndjson")
+        )
+
+        assert result is not None
+        r = _receipts(state_dir)[0]
+        assert r["role"] == "identity_unresolved"
+
+
+# ---------------------------------------------------------------------------
 # Part 8: smart_router strategy-tag detection (PR-SR-FIX-1)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_tmux_interactive_dispatch_metadata.py
+++ b/tests/test_tmux_interactive_dispatch_metadata.py
@@ -97,7 +97,7 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
         receipt={"status": "done"},
         duration_seconds=1.0,
         model="sonnet",
-        role="backend-developer",
+        role="quality-engineer",
         pr_id="42",
         session_id=session_id,
     )
@@ -108,7 +108,7 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
     assert row is not None
     assert row["provider"] == "claude"
     assert row["model"] == "sonnet"
-    assert row["role"] == "backend-developer"
+    assert row["role"] == "quality-engineer"
     assert row["terminal"] == "T1"
     assert row["track"] == "A"
     assert row["gate"] is None
@@ -117,6 +117,31 @@ def test_metadata_row_written_when_session_id_flag_set(tmp_path, monkeypatch, fa
     assert row["outcome_report_path"] == str(fake_govern.report_path)
     assert row["project_id"] == "vnx-dev"
     assert row["session_id"] == session_id
+
+
+def test_metadata_fake_default_role_normalized_to_null(tmp_path, monkeypatch, fake_govern):
+    """Receipt-quality PR-4: the fake backend-developer default is NEVER stored
+    verbatim — the writer normalizes it to NULL so the emit-side resolver
+    stamps identity_unresolved (new contract; supersedes the old
+    store-the-fake-literal behaviour)."""
+    monkeypatch.setenv("VNX_TMUX_SESSION_ID", "1")
+    state_dir = _bootstrap_state(tmp_path)
+    lane = _make_lane(state_dir)
+
+    lane._govern_report(
+        dispatch_id="20260628-tmux-meta-fake",
+        terminal_id="T1",
+        instruction="do the thing",
+        receipt={"status": "done"},
+        duration_seconds=1.0,
+        model="sonnet",
+        role="backend-developer",
+    )
+
+    db = state_dir / "quality_intelligence.db"
+    row = _read_row(db, "20260628-tmux-meta-fake")
+    assert row is not None
+    assert row["role"] is None
 
 
 def test_metadata_row_not_written_when_flag_unset(tmp_path, monkeypatch, fake_govern):


### PR DESCRIPTION
## Receipt-quality Phase A PR-4 (plan §4) — RETRY r2

Supersedes the killed r1 attempt (20-min output-timeout, nothing committed). This attempt ran **targeted tests only** and committed/pushed early.

### Changes

1. **Converter** (`scripts/lib/report_to_receipt_converter.py`) — resolves `role` via `dispatch_identity.resolve_dispatch_role(dispatch_id, project_id)` instead of defaulting identity to `unknown`. Fail-open to `identity_unresolved` — never `unknown`, never the fake `backend-developer` literal. `receipt_kind` stays the closed-set `dispatch` stamp (PR-3 lint raises on untagged).

2. **Capture-gap backfill at metadata-WRITE time**:
   - `dispatch_identity.py` — new shared helpers `normalize_role()` (fake default → `None`) and `extract_role_from_instruction()` (`Role:` header).
   - `dispatch_metadata_db.upsert_dispatch_provider_row` — normalizes the fake `backend-developer` default to NULL at write time; UPDATE COALESCE stops fake/empty role from nulling an existing real role.
   - `provider_dispatch._record_provider_metadata` — derives a genuine role at write time (normalized `args.role`, then instruction `Role:` header); NULL when nothing genuine derivable.
   - `log_dispatch_metadata.py` — normalizes fake `--role` to NULL; `role=COALESCE(?, role)` in both UPDATEs so a re-call without a role no longer nulls an existing real role.
   - `intelligence_backfill.py` — new `backfill_dispatch_metadata_roles()`: fills NULL/empty/fake `dispatch_metadata.role` from genuine receipt-carried roles in `t0_receipts.ndjson` (`identity_unresolved`/fake excluded); wired into `run_backfill` + CLI summary, dry-run safe.

3. Additive only — `IDEMPOTENCY_FIELDS`/dedup defaults untouched; no ledger retro-rewrite.

### Verification (targeted only — full suite left to CI)

- `pytest tests/test_dispatch_identity.py tests/test_report_to_receipt_converter.py tests/test_pr4_role_capture_backfill.py tests/test_tmux_interactive_dispatch_metadata.py tests/test_dispatch_metadata_provider_migration.py tests/test_backfill_dispatch_metadata.py tests/test_dispatch_govern.py tests/test_append_receipt_identity.py tests/test_governance_emit.py` → **262 passed**
- Related identity/metadata files (`test_dispatch_metadata_resolver`, `test_report_parser_dispatch_identity`, `test_observability_linkage`, `test_provider_dispatch_event_rotation`, `test_subprocess_dispatch_identity`, `test_task_subclass`, `test_dispatch_register_identity_partial`): 90 passed, 5 failed — **verified pre-existing on base** (same 5 fail with changes stashed; part of the ~19 known unrelated base failures).
- New tests: converter real-role / identity_unresolved / fake-never-propagated / fail-open; upsert normalization; provider `Role:`-header derivation; log_dispatch_metadata no-null + fake→NULL (subprocess); backfill fill/no-source/dry-run/no-receipts/summary.
- Old-contract test updated: `test_tmux_interactive_dispatch_metadata.py` no longer asserts the fake `backend-developer` literal stored verbatim (now asserts a real role; new test pins fake → NULL).

Dispatch-ID: 20260728-rq-pr4-converter-backfill-r2