### PR TITLE
feat(receipt-quality): PR-B0 codify ReceiptV2 + SynthesizedLaneReceipt schema contracts

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -27,7 +27,6 @@ import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
@@ -173,35 +172,29 @@ def ensure_receipt(
         return
 
     receipts_file = spec.state_dir / "t0_receipts.ndjson"
-    ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
     # receipt-quality PR-2: dispatch identity on the govern-synthesized emit
     # path — real role from spec/dispatch_metadata, else identity_unresolved
     # (fail-open; never the fake backend-developer default).
-    synthesized_receipt: dict = {
-        "event_type": "subprocess_completion",
-        "dispatch_id": spec.dispatch_id,
-        "terminal": spec.terminal_id,
-        "terminal_id": spec.terminal_id,
-        "status": "failed",
-        "source": "tmux_interactive_lane_synthesized",
-        "synthesized": True,
-        "failure_reason": raw.failure_reason,
-        "contract_status": contract_status,
-        "permission_enforcement": permission_enforcement,
-        "timestamp": ts,
-        "provider": "claude",
-        "sub_provider": "anthropic",
-        "model": spec.model or "unknown",
-        "lane": lane,
-        "role": _resolve_govern_role(spec),
-        "receipt_kind": "dispatch",
-    }
+    # receipt-quality PR-B0: the shape is codified in
+    # receipt_schema.SynthesizedLaneReceipt; to_dict() serializes
+    # byte-compatibly with the pre-PR-B0 literal.
+    from receipt_schema import SynthesizedLaneReceipt  # noqa: PLC0415
+
     # ADR-012 worker-permission enforcement audit marker (only when flag ON).
-    if worker_permission_enforcement_enabled():
-        synthesized_receipt["worker_permission_enforcement"] = "enforced"
-    if report_path is not None:
-        synthesized_receipt["report_path"] = str(report_path)
+    worker_enforcement = "enforced" if worker_permission_enforcement_enabled() else None
+    synthesized_receipt = SynthesizedLaneReceipt(
+        dispatch_id=spec.dispatch_id,
+        terminal_id=spec.terminal_id,
+        model=spec.model or "unknown",
+        lane=lane,
+        failure_reason=raw.failure_reason,
+        contract_status=contract_status,
+        permission_enforcement=permission_enforcement,
+        role=_resolve_govern_role(spec),
+        worker_permission_enforcement=worker_enforcement,
+        report_path=str(report_path) if report_path is not None else None,
+    ).to_dict()
 
     try:
         if _SCRIPTS_DIR not in sys.path:

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -22,7 +22,6 @@ import logging
 import os
 import re
 import sys
-from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
@@ -43,7 +42,7 @@ from append_receipt_internals.receipt_finalize import (
     commit_receipt_v2_fields,
 )
 from append_receipt_internals.validation import _validate_receipt
-from dispatch_identity import validate_receipt_kind
+from receipt_schema import ReceiptV2
 
 logger = logging.getLogger(__name__)
 
@@ -96,6 +95,10 @@ def emit_dispatch_receipt(
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
     uses.
+
+    The receipt shape itself is codified in ``receipt_schema.ReceiptV2``
+    (receipt-quality PR-B0) — construction validates ``receipt_kind`` and
+    ``to_dict()`` serializes byte-compatibly with the historical literal.
 
     Returns the receipt file path on success.
 
@@ -156,58 +159,41 @@ def emit_dispatch_receipt(
         RuntimeError: write failed
     """
     _validate_provider(provider)
-    # Receipt-quality PR-3: emit-time lint flipped warn -> raise now that
-    # every emit site is tagged (plan §3b). Hard-fail before any write.
-    receipt_kind = validate_receipt_kind(receipt_kind)
 
-    now_ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-
-    receipt: Dict[str, Any] = {
-        # ADR-035 §9 PR-5 (HIGH-6): stamped atomically with the trimmed v2
-        # shape in this same PR — never separately from the shape change.
-        "schema_version": 2,
-        "dispatch_id": dispatch_id,
-        "terminal_id": terminal_id,
-        "provider": provider,
-        "model": model,
-        # receipt-quality PR-1: dispatch identity — stamped unconditionally
-        # (like status) so the ledger distinguishes "unresolved" (null) from
-        # "pre-feature" (field absent).
-        "role": role,
-        "receipt_kind": receipt_kind,
-        "status": status,
-        # ADR-035 §3.2.1/§7.1 (r2 BLOCKING-1): stamped unconditionally, never
-        # keyed on status — task_complete marks "reached a terminal outcome",
-        # status carries which outcome (matches outcome_signals.py's
-        # task_complete-plus-status convention). This is the one field Path 1
-        # must add to survive contact with the shared validator below, which
-        # it has never faced before this PR.
-        "event_type": "task_complete",
-        "completion_pct": completion_pct,
-        "risk": risk,
-        "duration_seconds": round(float(duration_seconds), 3),
-        "token_usage": token_usage,
-        "cost_usd": cost_usd,
-        "findings": findings,
-        "pr_id": pr_id,
-        "report_path": report_path,
-        "events_path": events_path,
-        "timestamp": now_ts,
-    }
-    if permission_enforcement:
-        receipt["permission_enforcement"] = permission_enforcement
-    if mandate_id:
-        receipt["mandate_id"] = mandate_id
-    if final_prompt_path is not None:
-        receipt["final_prompt_path"] = final_prompt_path
-    if final_prompt_sha256 is not None:
-        receipt["final_prompt_sha256"] = final_prompt_sha256
-    if injection_reconstructs is not None:
-        receipt["injection_reconstructs"] = injection_reconstructs
-    if verification is not None:
-        receipt["verification"] = verification
-    if warnings is not None:
-        receipt["warnings"] = warnings
+    # Receipt-quality PR-B0: the v2 receipt shape is codified in
+    # receipt_schema.ReceiptV2 — the contract validates receipt_kind
+    # (receipt-quality PR-3 closed-set lint, warn -> raise: hard-fail before
+    # any write), normalizes duration_seconds, stamps schema_version /
+    # event_type=task_complete (ADR-035 §3.2.1/§7.1 r2 BLOCKING-1: never
+    # keyed on status) / timestamp, and serializes byte-compatibly with the
+    # pre-PR-B0 literal (same field order, same conditional-stamp guards).
+    # role stays stamped unconditionally (receipt-quality PR-1): None marks
+    # "identity was not resolvable" vs a pre-feature absent field.
+    receipt = ReceiptV2(
+        dispatch_id=dispatch_id,
+        terminal_id=terminal_id,
+        provider=provider,
+        model=model,
+        status=status,
+        completion_pct=completion_pct,
+        risk=risk,
+        findings=findings,
+        duration_seconds=duration_seconds,
+        token_usage=token_usage,
+        cost_usd=cost_usd,
+        pr_id=pr_id,
+        role=role,
+        receipt_kind=receipt_kind,
+        report_path=report_path,
+        events_path=events_path,
+        permission_enforcement=permission_enforcement,
+        mandate_id=mandate_id,
+        final_prompt_path=final_prompt_path,
+        final_prompt_sha256=final_prompt_sha256,
+        injection_reconstructs=injection_reconstructs,
+        verification=verification,
+        warnings=warnings,
+    ).to_dict()
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"
     receipt_path.parent.mkdir(parents=True, exist_ok=True)

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -1,0 +1,228 @@
+"""receipt_schema.py — codified receipt-shape contracts (receipt-quality PR-B0).
+
+Two receipt shapes are written into the canonical ledger today, and until now
+both were assembled as ad-hoc ``Dict`` literals at the emit sites:
+
+  - ``ReceiptV2`` — the governance-enriched dispatch receipt
+    (``schema_version: 2``) emitted by
+    ``governance_emit.emit_dispatch_receipt`` (ADR-035, Path 1).
+  - ``SynthesizedLaneReceipt`` — the lane-synthesized fallback completion
+    receipt emitted by ``dispatch_govern.ensure_receipt`` when the worker
+    never produced one (F1 guarantee).
+
+This module codifies each shape ONCE as a typed dataclass so later
+receipt-quality PRs (B1-B4) add typed fields instead of dict keys.
+
+Hard contracts:
+
+  - ``to_dict()`` is BYTE-COMPATIBLE with the pre-PR-B0 literal construction:
+    same field insertion order (the ledger writer serializes with
+    ``json.dumps(..., sort_keys=False)``), same unconditional-vs-conditional
+    stamping semantics (``role``/``pr_id``/``report_path``/``events_path``/
+    ``cost_usd`` are stamped even when ``None``; ``permission_enforcement``/
+    ``mandate_id`` are omitted when falsy; the remaining optional fields are
+    omitted only when ``None``).
+  - The ``receipt_kind`` closed-set lint (receipt-quality PR-3,
+    ``dispatch_identity.validate_receipt_kind``) is folded into each
+    contract's ``__post_init__`` — constructing a receipt object with a
+    missing/out-of-vocab kind raises ValueError before anything is written.
+  - This PR adds NO new receipt fields (that is B1-B4) and does not touch
+    ``IDEMPOTENCY_FIELDS``.
+"""
+
+from __future__ import annotations
+
+import sys
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+# Sibling scripts/lib modules must resolve even when a caller imports this
+# module by path without scripts/lib already on sys.path (mirrors
+# governance_emit.py / dispatch_identity.py).
+_LIB_DIR = str(Path(__file__).resolve().parent)
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from dispatch_identity import validate_receipt_kind  # noqa: E402
+
+
+def _utc_now_iso() -> str:
+    """Ledger timestamp format used by both emit paths (``%Y-%m-%dT%H:%M:%SZ``)."""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+@dataclass
+class ReceiptV2:
+    """The ADR-035 v2 dispatch receipt emitted by ``governance_emit``.
+
+    Field set derived from the actual pre-PR-B0 emit site
+    (``governance_emit.emit_dispatch_receipt``) — not from documentation.
+
+    Unconditionally stamped (serialized even when ``None``, so the ledger
+    distinguishes "unresolved" (null) from "pre-feature" (field absent)):
+    ``role``, ``pr_id``, ``report_path``, ``events_path``, ``cost_usd``.
+
+    Conditionally stamped (omitted from the serialized dict):
+    ``permission_enforcement`` and ``mandate_id`` when falsy (matches the
+    pre-PR-B0 truthiness guard); ``final_prompt_path``,
+    ``final_prompt_sha256``, ``injection_reconstructs``, ``verification`` and
+    ``warnings`` when ``None``.
+    """
+
+    dispatch_id: str
+    terminal_id: str
+    provider: str
+    model: str
+    status: str
+    completion_pct: int
+    risk: float
+    findings: List[Dict[str, Any]]
+    duration_seconds: float
+    token_usage: Dict[str, int]
+    receipt_kind: str
+    # Unconditionally stamped, None-able.
+    role: Optional[str] = None
+    pr_id: Optional[str] = None
+    report_path: Optional[str] = None
+    events_path: Optional[str] = None
+    cost_usd: Optional[float] = None
+    # Stamped from the contract's own defaults; overridable for tests.
+    event_type: str = "task_complete"
+    schema_version: int = 2
+    timestamp: Optional[str] = None  # None -> stamped with now at construction
+    # Conditionally stamped.
+    permission_enforcement: Optional[str] = None
+    mandate_id: Optional[str] = None
+    final_prompt_path: Optional[str] = None
+    final_prompt_sha256: Optional[str] = None
+    injection_reconstructs: Optional[bool] = None
+    verification: Optional[Dict[str, Any]] = None
+    warnings: Optional[List[Dict[str, Any]]] = None
+
+    def __post_init__(self) -> None:
+        # Receipt-quality PR-3: the closed-set lint lives in the contract now
+        # — an invalid kind fails construction, before any write.
+        self.receipt_kind = validate_receipt_kind(self.receipt_kind)
+        # Same normalization the pre-PR-B0 literal applied at build time.
+        self.duration_seconds = round(float(self.duration_seconds), 3)
+        if self.timestamp is None:
+            self.timestamp = _utc_now_iso()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to the ledger dict, byte-compatible with the pre-PR-B0
+        literal construction in ``governance_emit.emit_dispatch_receipt``
+        (same insertion order; the writer uses ``sort_keys=False``).
+        """
+        receipt: Dict[str, Any] = {
+            "schema_version": self.schema_version,
+            "dispatch_id": self.dispatch_id,
+            "terminal_id": self.terminal_id,
+            "provider": self.provider,
+            "model": self.model,
+            "role": self.role,
+            "receipt_kind": self.receipt_kind,
+            "status": self.status,
+            "event_type": self.event_type,
+            "completion_pct": self.completion_pct,
+            "risk": self.risk,
+            "duration_seconds": self.duration_seconds,
+            "token_usage": self.token_usage,
+            "cost_usd": self.cost_usd,
+            "findings": self.findings,
+            "pr_id": self.pr_id,
+            "report_path": self.report_path,
+            "events_path": self.events_path,
+            "timestamp": self.timestamp,
+        }
+        # Conditional stamps — same guards as the pre-PR-B0 emit site:
+        # truthiness for permission_enforcement / mandate_id, is-not-None for
+        # the rest.
+        if self.permission_enforcement:
+            receipt["permission_enforcement"] = self.permission_enforcement
+        if self.mandate_id:
+            receipt["mandate_id"] = self.mandate_id
+        if self.final_prompt_path is not None:
+            receipt["final_prompt_path"] = self.final_prompt_path
+        if self.final_prompt_sha256 is not None:
+            receipt["final_prompt_sha256"] = self.final_prompt_sha256
+        if self.injection_reconstructs is not None:
+            receipt["injection_reconstructs"] = self.injection_reconstructs
+        if self.verification is not None:
+            receipt["verification"] = self.verification
+        if self.warnings is not None:
+            receipt["warnings"] = self.warnings
+        return receipt
+
+
+@dataclass
+class SynthesizedLaneReceipt:
+    """The govern-synthesized fallback completion receipt (F1 guarantee)
+    emitted by ``dispatch_govern.ensure_receipt`` when the worker never
+    produced a receipt before the deadline.
+
+    Field set derived from the actual pre-PR-B0 emit site. Distinct from
+    ``ReceiptV2``: this is a ``subprocess_completion`` event with no
+    ``schema_version`` stamp, dual ``terminal``/``terminal_id`` keys, and the
+    ``tmux_interactive_lane_synthesized`` source marker
+    ``dedup_completion_receipts`` relies on to prefer worker-authored
+    receipts on readback.
+    """
+
+    dispatch_id: str
+    terminal_id: str
+    model: str
+    lane: str
+    failure_reason: Optional[str]
+    contract_status: str
+    permission_enforcement: str
+    role: Optional[str] = None
+    receipt_kind: str = "dispatch"
+    event_type: str = "subprocess_completion"
+    status: str = "failed"
+    source: str = "tmux_interactive_lane_synthesized"
+    synthesized: bool = True
+    provider: str = "claude"
+    sub_provider: str = "anthropic"
+    timestamp: Optional[str] = None  # None -> stamped with now at construction
+    # Conditionally stamped (is-not-None).
+    worker_permission_enforcement: Optional[str] = None
+    report_path: Optional[str] = None
+
+    def __post_init__(self) -> None:
+        self.receipt_kind = validate_receipt_kind(self.receipt_kind)
+        if self.timestamp is None:
+            self.timestamp = _utc_now_iso()
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to the ledger dict, byte-compatible with the pre-PR-B0
+        literal construction in ``dispatch_govern.ensure_receipt``.
+        """
+        receipt: Dict[str, Any] = {
+            "event_type": self.event_type,
+            "dispatch_id": self.dispatch_id,
+            "terminal": self.terminal_id,
+            "terminal_id": self.terminal_id,
+            "status": self.status,
+            "source": self.source,
+            "synthesized": self.synthesized,
+            "failure_reason": self.failure_reason,
+            "contract_status": self.contract_status,
+            "permission_enforcement": self.permission_enforcement,
+            "timestamp": self.timestamp,
+            "provider": self.provider,
+            "sub_provider": self.sub_provider,
+            "model": self.model,
+            "lane": self.lane,
+            "role": self.role,
+            "receipt_kind": self.receipt_kind,
+        }
+        if self.worker_permission_enforcement is not None:
+            receipt["worker_permission_enforcement"] = self.worker_permission_enforcement
+        if self.report_path is not None:
+            receipt["report_path"] = self.report_path
+        return receipt
+
+
+__all__ = ["ReceiptV2", "SynthesizedLaneReceipt"]

--- a/tests/test_governance_blockers_fix.py
+++ b/tests/test_governance_blockers_fix.py
@@ -227,12 +227,24 @@ class TestGovernanceEmitTimestamp:
     """H-1: emit_dispatch_receipt must use a single datetime.now() call."""
 
     def test_single_timestamp_call(self):
-        """now_ts and recorded_ts must derive from the same datetime.now() call."""
-        mod = __import__("governance_emit")
-        source = inspect.getsource(mod.emit_dispatch_receipt)
-        now_calls = re.findall(r"datetime\.now\(", source)
+        """The receipt timestamp must derive from a single datetime.now() call.
+
+        Receipt-quality PR-B0 moved timestamp stamping into the
+        ``receipt_schema`` contract (``ReceiptV2.__post_init__`` stamps via
+        the module-level ``_utc_now_iso`` helper); the single-call invariant
+        is now pinned at that seam. ``emit_dispatch_receipt`` delegates to
+        the contract and must not re-introduce its own datetime.now() call.
+        """
+        schema_mod = __import__("receipt_schema")
+        schema_source = inspect.getsource(schema_mod)
+        now_calls = re.findall(r"datetime\.now\(", schema_source)
         assert len(now_calls) == 1, (
-            f"emit_dispatch_receipt must call datetime.now() exactly once, found {len(now_calls)}"
+            f"receipt_schema must call datetime.now() exactly once, found {len(now_calls)}"
+        )
+        emit_mod = __import__("governance_emit")
+        emit_source = inspect.getsource(emit_mod.emit_dispatch_receipt)
+        assert not re.findall(r"datetime\.now\(", emit_source), (
+            "emit_dispatch_receipt must delegate timestamping to receipt_schema.ReceiptV2"
         )
 
     def test_recorded_ts_equals_now_ts(self):

--- a/tests/test_receipt_schema.py
+++ b/tests/test_receipt_schema.py
@@ -1,0 +1,280 @@
+"""test_receipt_schema.py — receipt-quality PR-B0 schema-contract tests.
+
+Verifies the codified receipt contracts (``receipt_schema.ReceiptV2`` /
+``SynthesizedLaneReceipt``) serialize BYTE-IDENTICALLY to the pre-PR-B0
+literal dict construction at the emit sites (``governance_emit`` /
+``dispatch_govern.ensure_receipt``) — this PR is a no-behavior-change
+refactor, so the emitted NDJSON must not change for the same inputs.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from receipt_schema import ReceiptV2, SynthesizedLaneReceipt  # noqa: E402
+
+
+def _serialize(receipt: dict) -> str:
+    """Mirror the ledger writer's serialization (append primitive:
+    ``json.dumps(..., separators=(",", ":"), sort_keys=False)``).
+    """
+    return json.dumps(receipt, separators=(",", ":"), sort_keys=False)
+
+
+# ---------------------------------------------------------------------------
+# Pre-PR-B0 reference constructions (copied verbatim from the old emit sites)
+# ---------------------------------------------------------------------------
+
+def _legacy_v2_build(**kw) -> dict:
+    """The pre-PR-B0 literal from governance_emit.emit_dispatch_receipt."""
+    receipt = {
+        "schema_version": 2,
+        "dispatch_id": kw["dispatch_id"],
+        "terminal_id": kw["terminal_id"],
+        "provider": kw["provider"],
+        "model": kw["model"],
+        "role": kw.get("role"),
+        "receipt_kind": kw["receipt_kind"],
+        "status": kw["status"],
+        "event_type": "task_complete",
+        "completion_pct": kw["completion_pct"],
+        "risk": kw["risk"],
+        "duration_seconds": round(float(kw["duration_seconds"]), 3),
+        "token_usage": kw["token_usage"],
+        "cost_usd": kw.get("cost_usd"),
+        "findings": kw["findings"],
+        "pr_id": kw.get("pr_id"),
+        "report_path": kw.get("report_path"),
+        "events_path": kw.get("events_path"),
+        "timestamp": kw["timestamp"],
+    }
+    if kw.get("permission_enforcement"):
+        receipt["permission_enforcement"] = kw["permission_enforcement"]
+    if kw.get("mandate_id"):
+        receipt["mandate_id"] = kw["mandate_id"]
+    if kw.get("final_prompt_path") is not None:
+        receipt["final_prompt_path"] = kw["final_prompt_path"]
+    if kw.get("final_prompt_sha256") is not None:
+        receipt["final_prompt_sha256"] = kw["final_prompt_sha256"]
+    if kw.get("injection_reconstructs") is not None:
+        receipt["injection_reconstructs"] = kw["injection_reconstructs"]
+    if kw.get("verification") is not None:
+        receipt["verification"] = kw["verification"]
+    if kw.get("warnings") is not None:
+        receipt["warnings"] = kw["warnings"]
+    return receipt
+
+
+def _legacy_synthesized_build(**kw) -> dict:
+    """The pre-PR-B0 literal from dispatch_govern.ensure_receipt."""
+    receipt = {
+        "event_type": "subprocess_completion",
+        "dispatch_id": kw["dispatch_id"],
+        "terminal": kw["terminal_id"],
+        "terminal_id": kw["terminal_id"],
+        "status": "failed",
+        "source": "tmux_interactive_lane_synthesized",
+        "synthesized": True,
+        "failure_reason": kw.get("failure_reason"),
+        "contract_status": kw["contract_status"],
+        "permission_enforcement": kw["permission_enforcement"],
+        "timestamp": kw["timestamp"],
+        "provider": "claude",
+        "sub_provider": "anthropic",
+        "model": kw["model"],
+        "lane": kw["lane"],
+        "role": kw.get("role"),
+        "receipt_kind": "dispatch",
+    }
+    if kw.get("worker_permission_enforcement") is not None:
+        receipt["worker_permission_enforcement"] = kw["worker_permission_enforcement"]
+    if kw.get("report_path") is not None:
+        receipt["report_path"] = kw["report_path"]
+    return receipt
+
+
+_TS = "2026-07-28T12:00:00Z"
+
+
+def _v2_kwargs_full() -> dict:
+    return dict(
+        dispatch_id="dispatch-20260728-test",
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-4-6",
+        role="backend-developer",
+        receipt_kind="dispatch",
+        status="success",
+        completion_pct=100,
+        risk=0.25,
+        duration_seconds=3.4567,
+        token_usage={"input": 100, "output": 50, "cache_hit": 0},
+        cost_usd=0.0123,
+        findings=[{"severity": "low", "message": "note"}],
+        pr_id="PR-1",
+        report_path="unified_reports/dispatch-20260728-test.md",
+        events_path="events/archive/T1/dispatch-20260728-test.ndjson",
+        timestamp=_TS,
+        permission_enforcement="enforced",
+        mandate_id="M-1",
+        final_prompt_path="prompts/final.md",
+        final_prompt_sha256="abc123",
+        injection_reconstructs=True,
+        verification={"method": "report-parser", "ok": True},
+        warnings=[{"code": "W1", "severity": "low", "message": "warn"}],
+    )
+
+
+def _v2_kwargs_minimal() -> dict:
+    return dict(
+        dispatch_id="dispatch-20260728-min",
+        terminal_id="T2",
+        provider="kimi",
+        model="kimi-k3",
+        role=None,
+        receipt_kind="build",
+        status="failed",
+        completion_pct=40,
+        risk=0.9,
+        duration_seconds=1.2,
+        token_usage={"input": 0, "output": 0, "cache_hit": 0},
+        cost_usd=None,
+        findings=[],
+        pr_id=None,
+        report_path=None,
+        events_path=None,
+        timestamp=_TS,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ReceiptV2 round-trip: old-literal vs contract serialize to equal JSON
+# ---------------------------------------------------------------------------
+
+def test_receipt_v2_roundtrip_full_fields_byte_identical():
+    kw = _v2_kwargs_full()
+    legacy_line = _serialize(_legacy_v2_build(**kw))
+    contract_line = _serialize(ReceiptV2(**kw).to_dict())
+    assert contract_line == legacy_line
+
+
+def test_receipt_v2_roundtrip_minimal_fields_byte_identical():
+    kw = _v2_kwargs_minimal()
+    legacy_line = _serialize(_legacy_v2_build(**kw))
+    contract_line = _serialize(ReceiptV2(**kw).to_dict())
+    assert contract_line == legacy_line
+
+
+def test_receipt_v2_unconditional_nulls_stamped():
+    """role/pr_id/report_path/events_path/cost_usd serialize as null, never
+    omitted — the ledger distinguishes "unresolved" from "pre-feature"."""
+    receipt = ReceiptV2(**_v2_kwargs_minimal()).to_dict()
+    for key in ("role", "pr_id", "report_path", "events_path", "cost_usd"):
+        assert key in receipt
+        assert receipt[key] is None
+
+
+def test_receipt_v2_conditional_fields_omitted_when_absent():
+    receipt = ReceiptV2(**_v2_kwargs_minimal()).to_dict()
+    for key in (
+        "permission_enforcement",
+        "mandate_id",
+        "final_prompt_path",
+        "final_prompt_sha256",
+        "injection_reconstructs",
+        "verification",
+        "warnings",
+    ):
+        assert key not in receipt
+
+
+def test_receipt_v2_permission_enforcement_falsy_omitted():
+    """Pre-PR-B0 guard was truthiness (not is-not-None): empty string omits."""
+    kw = _v2_kwargs_minimal()
+    kw["permission_enforcement"] = ""
+    kw["mandate_id"] = ""
+    receipt = ReceiptV2(**kw).to_dict()
+    assert "permission_enforcement" not in receipt
+    assert "mandate_id" not in receipt
+
+
+def test_receipt_v2_defaults_schema_version_event_type_and_timestamp():
+    kw = _v2_kwargs_minimal()
+    del kw["timestamp"]
+    receipt = ReceiptV2(**kw).to_dict()
+    assert receipt["schema_version"] == 2
+    assert receipt["event_type"] == "task_complete"
+    assert receipt["timestamp"]  # auto-stamped
+
+
+def test_receipt_v2_duration_rounded_three_decimals():
+    kw = _v2_kwargs_minimal()
+    kw["duration_seconds"] = 3.456789
+    assert ReceiptV2(**kw).to_dict()["duration_seconds"] == 3.457
+
+
+def test_receipt_v2_receipt_kind_closed_set_raises():
+    kw = _v2_kwargs_minimal()
+    kw["receipt_kind"] = "not-a-kind"
+    with pytest.raises(ValueError, match="Invalid receipt_kind"):
+        ReceiptV2(**kw)
+
+
+def test_receipt_v2_receipt_kind_missing_raises():
+    kw = _v2_kwargs_minimal()
+    kw["receipt_kind"] = None
+    with pytest.raises(ValueError, match="Invalid receipt_kind"):
+        ReceiptV2(**kw)
+
+
+# ---------------------------------------------------------------------------
+# SynthesizedLaneReceipt round-trip
+# ---------------------------------------------------------------------------
+
+def _synth_kwargs() -> dict:
+    return dict(
+        dispatch_id="dispatch-20260728-synth",
+        terminal_id="T3",
+        model="unknown",
+        lane="tmux_interactive",
+        failure_reason="worker_timeout",
+        contract_status="synthesized",
+        permission_enforcement="off",
+        role="identity_unresolved",
+        timestamp=_TS,
+    )
+
+
+def test_synthesized_receipt_roundtrip_byte_identical():
+    kw = _synth_kwargs()
+    legacy_line = _serialize(_legacy_synthesized_build(**kw))
+    contract_line = _serialize(SynthesizedLaneReceipt(**kw).to_dict())
+    assert contract_line == legacy_line
+
+
+def test_synthesized_receipt_roundtrip_with_optional_fields_byte_identical():
+    kw = _synth_kwargs()
+    kw["worker_permission_enforcement"] = "enforced"
+    kw["report_path"] = "unified_reports/dispatch-20260728-synth.md"
+    legacy_line = _serialize(_legacy_synthesized_build(**kw))
+    contract_line = _serialize(SynthesizedLaneReceipt(**kw).to_dict())
+    assert contract_line == legacy_line
+
+
+def test_synthesized_receipt_optional_fields_omitted_when_absent():
+    receipt = SynthesizedLaneReceipt(**_synth_kwargs()).to_dict()
+    assert "worker_permission_enforcement" not in receipt
+    assert "report_path" not in receipt
+
+
+def test_synthesized_receipt_receipt_kind_closed_set_raises():
+    kw = _synth_kwargs()
+    kw["receipt_kind"] = "bogus"
+    with pytest.raises(ValueError, match="Invalid receipt_kind"):
+        SynthesizedLaneReceipt(**kw)


### PR DESCRIPTION
## Summary

Track `receipt-quality`, Phase B PR-B0 (foundation for B1-B4; plan §7 blocker 3: schema FIRST, not deferred debt).

Codifies the two receipt shapes written into the canonical ledger ONCE as typed dataclasses in `scripts/lib/receipt_schema.py`, so Phase-B PRs add typed fields instead of ad-hoc dict keys:

- **`ReceiptV2`** — the ADR-035 v2 dispatch receipt (`schema_version: 2`) emitted by `governance_emit.emit_dispatch_receipt`. Field set enumerated from the actual emit site: 19 unconditional stamps (`schema_version`, `dispatch_id`, `terminal_id`, `provider`, `model`, `role`, `receipt_kind`, `status`, `event_type`, `completion_pct`, `risk`, `duration_seconds`, `token_usage`, `cost_usd`, `findings`, `pr_id`, `report_path`, `events_path`, `timestamp`) + 7 conditional (`permission_enforcement`, `mandate_id`, `final_prompt_path`, `final_prompt_sha256`, `injection_reconstructs`, `verification`, `warnings`).
- **`SynthesizedLaneReceipt`** — the govern-synthesized fallback completion receipt (`dispatch_govern.ensure_receipt`, F1 guarantee): 17 fixed stamps + 2 conditional (`worker_permission_enforcement`, `report_path`).
- The `receipt_kind` closed-set lint (PR-3) is folded into each contract's `__post_init__` — an out-of-vocab kind raises `ValueError` at construction, before any write.

## No behavior change

- `to_dict()` is **byte-identical** to the pre-PR-B0 literal construction for the same inputs: same field insertion order (the ledger writer serializes `json.dumps(..., sort_keys=False)`), same unconditional-null vs conditional-omission guards (`permission_enforcement`/`mandate_id` truthiness, rest is-not-None). Round-trip tests prove equality of the serialized NDJSON line.
- Consumers verified order-insensitive regardless: every Python reader is `json.loads` + name-based `.get()`; the shell dedup is substring grep; the authoritative idempotency key is `sort_keys=True` over `IDEMPOTENCY_FIELDS` (untouched).
- **No new receipt fields** (that is B1-B4). `IDEMPOTENCY_FIELDS` untouched.

## Changes

- `scripts/lib/receipt_schema.py` (new): `ReceiptV2`, `SynthesizedLaneReceipt`, `_utc_now_iso`.
- `scripts/lib/governance_emit.py`: `emit_dispatch_receipt` builds the receipt via `ReceiptV2(...).to_dict()`; drops the inline literal + now-unused `datetime` import.
- `scripts/lib/dispatch_govern.py`: `ensure_receipt` builds via `SynthesizedLaneReceipt(...).to_dict()`.
- `tests/test_receipt_schema.py` (new, 13 tests): round-trip byte-identity (old literal vs contract, full + minimal + optional-field variants), unconditional-null stamping, conditional-omission guards, duration rounding, timestamp defaulting, closed-set raise on both contracts.
- `tests/test_governance_blockers_fix.py::test_single_timestamp_call`: the H-1 single-`datetime.now()` invariant re-pinned at its new seam (the `receipt_schema` contract) — the only test coupled to the old inline literal.

## Verification

- New round-trip suite: 13/13 green.
- Targeted suites green: `test_governance_emit`, `test_dispatch_govern`, `test_receipt_kind_lint`, `test_receipt_v2_pr4_wiring`, `test_receipt_v2_pr5_schema_cutover`, `test_receipt_validation_warnings`, `test_final_prompt_integrity`, `test_worker_permission_enforcement_flag`, `test_emit_governance_retry`, `test_delegation_mandate`, `test_ndjson_hash_chain`, `test_append_receipt`, `test_governance_emit_local_gemma`.
- 12 failures in the wider targeted run verified **pre-existing on the base commit** (stash-diff comparison, 728 passed): 4 `test_dispatch_envelope` flag-gate, 2 stale source-greps in `test_governance_blockers_fix`, 4 `test_observability_linkage` env-dependent, 2 `test_tmux_interactive_dispatch`. Zero regressions introduced.
- Receipt processor ingestion: shared validator (`_validate_receipt`) accepts the shape (v2 cutover tests green); all ledger readers are name-based — no schema rejection possible from a byte-identical line.

## Open Items

- Codex may be rate-limited until Jul 28 19:08 — Option-B review after fix; Codex re-audit OI filed per merge.
- Pre-existing stale source-grep `test_recorded_ts_equals_now_ts` (fails on base too) left untouched — out of scope for this refactor.

Dispatch-ID: dispatch-20260728-rq-b0-receiptv2-schema
