### PR TITLE
feat(receipt-quality): PR-B1 token-capture from claude transcripts

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -91,6 +91,11 @@ class _AdapterResult:
     error: Optional[str] = None
     timed_out: bool = False
     event_writer_failures: int = 0
+    # receipt-quality PR-B1: claude session_id (from the init event), threaded
+    # through to emit_dispatch_receipt so it can backfill token_usage from the
+    # local transcript when the spawn itself reported none. None for adapters
+    # with no session concept (e.g. codex).
+    session_id: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +236,7 @@ class ClaudeSubprocessAdapter:
                 status="failure",
                 token_usage=token_usage,
                 error=result.error,
+                session_id=result.session_id,
             )
         if result.timed_out:
             return _AdapterResult(
@@ -239,6 +245,7 @@ class ClaudeSubprocessAdapter:
                 status="timeout",
                 token_usage=token_usage,
                 timed_out=True,
+                session_id=result.session_id,
             )
         if result.stopped_early:
             return _AdapterResult(
@@ -246,6 +253,7 @@ class ClaudeSubprocessAdapter:
                 completion_text=(result.completion_text or ""),
                 status="success",
                 token_usage=token_usage,
+                session_id=result.session_id,
             )
         status = "success" if result.returncode == 0 else "failure"
         return _AdapterResult(
@@ -253,6 +261,7 @@ class ClaudeSubprocessAdapter:
             completion_text=(result.completion_text or ""),
             status=status,
             token_usage=token_usage,
+            session_id=result.session_id,
         )
 
 
@@ -620,6 +629,7 @@ def _govern(
                 verification=_verification_from_report(report_path),
                 role=_role,
                 receipt_kind="dispatch",
+                session_id=adapter_result.session_id,
             )
         except Exception as exc:
             raise EnvelopeGovernError(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -91,6 +91,7 @@ def emit_dispatch_receipt(
     warnings: Optional[List[Dict[str, Any]]] = None,
     role: Optional[str] = None,
     receipt_kind: Optional[str] = None,
+    session_id: Optional[str] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -145,6 +146,15 @@ def emit_dispatch_receipt(
     emitter's own knowledge; a missing or out-of-vocab value raises
     ValueError before anything is written.
 
+    ``session_id``: receipt-quality PR-B1 — when the caller-supplied
+    ``token_usage`` is empty or explicitly marked ``unavailable`` (the claude
+    subscription lane has no live usage API) and ``provider`` is ``claude``,
+    the local Claude Code session transcript
+    (``~/.claude/projects/*/<session_id>.jsonl``) is harvested via
+    ``token_harvest.harvest_session_tokens`` and used instead. Fail-open: any
+    harvest problem (no session_id, no transcript, kimi/other providers)
+    leaves ``token_usage`` exactly as the caller supplied it.
+
     ``warnings``: ADR-035 §6.1 — raw ``{code, severity, message}`` entries.
     Classified (side-effect-free) via ``classify_receipt_v2_warnings``
     before the receipt is validated, then committed (open-items promotion,
@@ -159,6 +169,24 @@ def emit_dispatch_receipt(
         RuntimeError: write failed
     """
     _validate_provider(provider)
+
+    # Receipt-quality PR-B1: backfill token_usage for the claude lane from the
+    # local Claude Code session transcript when the caller has nothing usable
+    # (no live usage API on the subscription lane). Only ever tightens the
+    # data — a caller-supplied real token_usage is never overwritten, and any
+    # harvest failure (no session_id, no transcript, non-claude providers)
+    # leaves token_usage exactly as passed in.
+    if provider == "claude" and session_id and (not token_usage or token_usage.get("unavailable")):
+        try:
+            from token_harvest import harvest_session_tokens  # noqa: PLC0415
+            harvested = harvest_session_tokens(session_id)
+            if harvested and not harvested.get("unavailable"):
+                token_usage = harvested
+        except Exception as exc:  # noqa: BLE001 — harvesting must never break receipt emission
+            logger.debug(
+                "emit_dispatch_receipt: token harvest failed for dispatch=%s session_id=%s: %s",
+                dispatch_id, session_id, exc,
+            )
 
     # Receipt-quality PR-B0: the v2 receipt shape is codified in
     # receipt_schema.ReceiptV2 — the contract validates receipt_kind

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -717,6 +717,11 @@ def _emit_governance(
                 },
                 role=_role,
                 receipt_kind="dispatch",
+                # receipt-quality PR-B1: threaded through so the claude-lane
+                # benchmark exemption path (the only route that reaches this
+                # provider="claude" case) can backfill token_usage from the
+                # local transcript. No-op for every other provider.
+                session_id=getattr(args, "session_id", None) or os.environ.get("VNX_SESSION_ID"),
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break

--- a/scripts/lib/token_harvest.py
+++ b/scripts/lib/token_harvest.py
@@ -1,0 +1,185 @@
+"""token_harvest.py — per-session token-usage harvester from Claude Code
+transcripts (receipt-quality PR-B1).
+
+The claude/opus/sonnet tmux subscription lane has no live token-usage API —
+today a claude-lane receipt's ``token_usage`` is either a best-effort pane-TUI
+regex parse (report frontmatter only) or an explicit ``unavailable`` marker.
+The real per-turn accounting already exists locally: the Claude Code CLI
+persists every session's transcript to
+``~/.claude/projects/<encoded-cwd>/<session_id>.jsonl``, and each assistant
+message carries a ``usage`` block (``input_tokens``, ``output_tokens``,
+``cache_creation_input_tokens`` with an ``ephemeral_5m``/``ephemeral_1h``
+split under ``cache_creation``, ``cache_read_input_tokens``).
+
+This module harvests that transcript, deduped by ``message.id`` — Claude Code
+rewrites the same message repeatedly while it streams/uses tools, each
+rewrite carrying the message's own cumulative usage, so naive per-line
+summing would multiply-count every message by how many times it was
+redrawn.
+
+READ-ONLY: never writes, never raises. Kimi and other non-Claude-Code
+providers have no local transcript and always resolve to the ``unavailable``
+marker here — there is no kimi-token-capture in this module (kimi capture is
+a separate, out-of-scope change; see the receipt-quality plan §Phase B).
+"""
+
+from __future__ import annotations
+
+import glob
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+# Shape matches receipt_schema.ReceiptV2.token_usage. Zeroed counters (rather
+# than an absent dict) plus an explicit ``unavailable`` flag mirrors the
+# existing convention in provider_dispatch._extract_token_usage — callers can
+# tell "confirmed zero" apart from "no data reported".
+_UNAVAILABLE: Dict[str, Any] = {
+    "input": 0,
+    "output": 0,
+    "cache_creation_5m": 0,
+    "cache_creation_1h": 0,
+    "cache_read": 0,
+    "unavailable": True,
+}
+
+
+def _default_claude_projects_dir() -> Path:
+    """Resolve ``~/.claude/projects``, overridable for tests via env var."""
+    override = os.environ.get("VNX_CLAUDE_PROJECTS_DIR", "").strip()
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".claude" / "projects"
+
+
+def _find_transcript(session_id: str, projects_dir: Path) -> Optional[Path]:
+    """Locate the transcript file for ``session_id`` under ``projects_dir``.
+
+    A session_id is a UUID assigned once per Claude Code session, so exactly
+    one match is expected. If more than one is somehow found (e.g. a stale
+    copy), the most recently modified file wins rather than raising.
+    """
+    pattern = str(projects_dir / "*" / f"{session_id}.jsonl")
+    matches = glob.glob(pattern)
+    if not matches:
+        return None
+    if len(matches) > 1:
+        matches.sort(key=lambda p: os.path.getmtime(p), reverse=True)
+        logger.warning(
+            "token_harvest: %d transcripts matched session_id=%s — using most recently modified",
+            len(matches), session_id,
+        )
+    return Path(matches[0])
+
+
+def _sum_transcript_usage(transcript_path: Path) -> Optional[Dict[str, int]]:
+    """Sum the four token classes across assistant messages, deduped by
+    ``message.id``. Returns None when the file carries no assistant usage
+    entries at all (distinct from "found the file but usage is genuinely 0").
+    """
+    seen: Dict[str, Dict[str, Any]] = {}
+    fallback_order = 0
+    try:
+        with open(transcript_path, "r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                message = entry.get("message")
+                if not isinstance(message, dict) or message.get("role") != "assistant":
+                    continue
+                usage = message.get("usage")
+                if not isinstance(usage, dict):
+                    continue
+                msg_id = message.get("id")
+                if not msg_id:
+                    # No id on this entry (rare) — treat every occurrence as
+                    # distinct rather than dropping it via a shared falsy key.
+                    msg_id = f"__noid_{fallback_order}"
+                    fallback_order += 1
+                seen[msg_id] = usage
+    except OSError as exc:
+        logger.debug("token_harvest: failed reading transcript %s: %s", transcript_path, exc)
+        return None
+
+    if not seen:
+        return None
+
+    totals = {
+        "input": 0,
+        "output": 0,
+        "cache_creation_5m": 0,
+        "cache_creation_1h": 0,
+        "cache_read": 0,
+    }
+    for usage in seen.values():
+        totals["input"] += int(usage.get("input_tokens", 0) or 0)
+        totals["output"] += int(usage.get("output_tokens", 0) or 0)
+        totals["cache_read"] += int(usage.get("cache_read_input_tokens", 0) or 0)
+        creation = usage.get("cache_creation")
+        if isinstance(creation, dict):
+            totals["cache_creation_5m"] += int(creation.get("ephemeral_5m_input_tokens", 0) or 0)
+            totals["cache_creation_1h"] += int(creation.get("ephemeral_1h_input_tokens", 0) or 0)
+        else:
+            # Pre-split transcript entries carry only the flat total — bucket
+            # it under the 5m TTL, the API's default ephemeral-cache lifetime.
+            totals["cache_creation_5m"] += int(usage.get("cache_creation_input_tokens", 0) or 0)
+    return totals
+
+
+def harvest_session_tokens(
+    session_id: Optional[str],
+    project_id: Optional[str] = None,
+    *,
+    claude_projects_dir: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Harvest cumulative token usage for a Claude Code session transcript.
+
+    Returns a dict shaped for ``receipt_schema.ReceiptV2.token_usage``:
+    ``{input, output, cache_creation_5m, cache_creation_1h, cache_read}``.
+    Fails open to the ``unavailable`` marker (zeroed counters plus
+    ``unavailable: True``) — never raises — when ``session_id`` is empty, no
+    transcript is found under ``~/.claude/projects/*/<session_id>.jsonl``, or
+    the transcript carries no assistant ``usage`` entries.
+
+    ``project_id`` is accepted for interface symmetry with other
+    dispatch-identity resolvers (e.g. ``dispatch_identity.resolve_dispatch_role``)
+    but is not needed to locate the transcript: ``session_id`` is already a
+    UUID unique across all projects.
+    """
+    del project_id  # not needed to locate the transcript; kept for call-site symmetry
+    session_id = (session_id or "").strip()
+    if not session_id:
+        return dict(_UNAVAILABLE)
+
+    projects_dir = claude_projects_dir or _default_claude_projects_dir()
+    if not projects_dir.is_dir():
+        return dict(_UNAVAILABLE)
+
+    try:
+        transcript_path = _find_transcript(session_id, projects_dir)
+    except OSError as exc:
+        logger.debug("token_harvest: transcript lookup failed for session_id=%s: %s", session_id, exc)
+        return dict(_UNAVAILABLE)
+
+    if transcript_path is None:
+        return dict(_UNAVAILABLE)
+
+    totals = _sum_transcript_usage(transcript_path)
+    if totals is None:
+        return dict(_UNAVAILABLE)
+
+    return totals
+
+
+__all__ = ["harvest_session_tokens"]

--- a/tests/test_token_harvest.py
+++ b/tests/test_token_harvest.py
@@ -1,0 +1,336 @@
+"""test_token_harvest.py — receipt-quality PR-B1 token-capture tests.
+
+Covers the transcript harvester (scripts/lib/token_harvest.py) in isolation,
+plus its wiring into governance_emit.emit_dispatch_receipt for the claude
+lane.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from token_harvest import harvest_session_tokens  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixture helpers
+# ---------------------------------------------------------------------------
+
+def _assistant_line(message_id: str, usage: dict) -> str:
+    return json.dumps({
+        "type": "assistant",
+        "message": {"role": "assistant", "id": message_id, "usage": usage},
+    })
+
+
+def _write_transcript(projects_dir: Path, session_id: str, lines: list) -> Path:
+    project_dir = projects_dir / "-Users-test-some-project"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    transcript = project_dir / f"{session_id}.jsonl"
+    transcript.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    return transcript
+
+
+_FULL_USAGE = {
+    "input_tokens": 100,
+    "output_tokens": 20,
+    "cache_read_input_tokens": 2,
+    "cache_creation_input_tokens": 15,
+    "cache_creation": {
+        "ephemeral_5m_input_tokens": 10,
+        "ephemeral_1h_input_tokens": 5,
+    },
+}
+
+
+# ---------------------------------------------------------------------------
+# harvest_session_tokens — sums + dedups correctly
+# ---------------------------------------------------------------------------
+
+def test_harvest_sums_single_message(tmp_path):
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-1", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    result = harvest_session_tokens("session-1", claude_projects_dir=projects_dir)
+    assert result == {
+        "input": 100,
+        "output": 20,
+        "cache_creation_5m": 10,
+        "cache_creation_1h": 5,
+        "cache_read": 2,
+    }
+
+
+def test_harvest_dedups_by_message_id(tmp_path):
+    """Claude Code rewrites the same message repeatedly while streaming —
+    each rewrite carries the SAME cumulative usage. Naive per-line summing
+    would multiply-count every redraw; only the last write per message.id
+    must be counted once."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-2", [
+        _assistant_line("msg_1", _FULL_USAGE),
+        _assistant_line("msg_1", _FULL_USAGE),
+        _assistant_line("msg_1", _FULL_USAGE),
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    result = harvest_session_tokens("session-2", claude_projects_dir=projects_dir)
+    assert result["input"] == 100
+    assert result["output"] == 20
+    assert result["cache_creation_5m"] == 10
+    assert result["cache_creation_1h"] == 5
+    assert result["cache_read"] == 2
+    assert "unavailable" not in result
+
+
+def test_harvest_sums_across_distinct_messages(tmp_path):
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-3", [
+        _assistant_line("msg_1", _FULL_USAGE),
+        _assistant_line("msg_1", _FULL_USAGE),  # duplicate rewrite of msg_1
+        _assistant_line("msg_2", {
+            "input_tokens": 50,
+            "output_tokens": 5,
+            "cache_read_input_tokens": 1,
+            "cache_creation_input_tokens": 0,
+            "cache_creation": {"ephemeral_5m_input_tokens": 0, "ephemeral_1h_input_tokens": 0},
+        }),
+    ])
+    result = harvest_session_tokens("session-3", claude_projects_dir=projects_dir)
+    assert result == {
+        "input": 150,
+        "output": 25,
+        "cache_creation_5m": 10,
+        "cache_creation_1h": 5,
+        "cache_read": 3,
+    }
+
+
+def test_harvest_legacy_flat_cache_creation_bucketed_as_5m(tmp_path):
+    """Pre-split transcripts (no cache_creation sub-object) bucket the flat
+    cache_creation_input_tokens total under the 5m TTL (the API default)."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-4", [
+        _assistant_line("msg_1", {
+            "input_tokens": 10,
+            "output_tokens": 2,
+            "cache_read_input_tokens": 0,
+            "cache_creation_input_tokens": 7,
+        }),
+    ])
+    result = harvest_session_tokens("session-4", claude_projects_dir=projects_dir)
+    assert result["cache_creation_5m"] == 7
+    assert result["cache_creation_1h"] == 0
+
+
+def test_harvest_ignores_non_assistant_and_malformed_lines(tmp_path):
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-5", [
+        json.dumps({"type": "user", "message": {"role": "user", "content": "hi"}}),
+        "not-json-at-all {{{",
+        json.dumps({"type": "assistant", "message": {"role": "assistant", "id": "msg_no_usage"}}),
+        _assistant_line("msg_1", {
+            "input_tokens": 5, "output_tokens": 1,
+            "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+        }),
+        "",
+    ])
+    result = harvest_session_tokens("session-5", claude_projects_dir=projects_dir)
+    assert result["input"] == 5
+    assert result["output"] == 1
+    assert "unavailable" not in result
+
+
+# ---------------------------------------------------------------------------
+# Fail-open unavailable marker
+# ---------------------------------------------------------------------------
+
+def test_harvest_unavailable_when_session_id_empty(tmp_path):
+    result = harvest_session_tokens("", claude_projects_dir=tmp_path / "projects")
+    assert result["unavailable"] is True
+    assert result["input"] == 0
+
+
+def test_harvest_unavailable_when_session_id_none(tmp_path):
+    result = harvest_session_tokens(None, claude_projects_dir=tmp_path / "projects")
+    assert result["unavailable"] is True
+
+
+def test_harvest_unavailable_when_projects_dir_missing(tmp_path):
+    result = harvest_session_tokens(
+        "session-x", claude_projects_dir=tmp_path / "does-not-exist"
+    )
+    assert result["unavailable"] is True
+
+
+def test_harvest_unavailable_when_no_matching_transcript(tmp_path):
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-real", [_assistant_line("msg_1", _FULL_USAGE)])
+    result = harvest_session_tokens("session-does-not-exist", claude_projects_dir=projects_dir)
+    assert result["unavailable"] is True
+
+
+def test_harvest_unavailable_when_transcript_has_no_usage(tmp_path):
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-6", [
+        json.dumps({"type": "assistant", "message": {"role": "assistant", "id": "m1"}}),
+    ])
+    result = harvest_session_tokens("session-6", claude_projects_dir=projects_dir)
+    assert result["unavailable"] is True
+
+
+def test_harvest_kimi_style_no_transcript_is_unavailable(tmp_path):
+    """Kimi runs outside Claude Code and never produces a transcript — this
+    is the same code path as 'no matching transcript found'."""
+    projects_dir = tmp_path / "projects"
+    projects_dir.mkdir(parents=True)
+    result = harvest_session_tokens("kimi-session-abc", claude_projects_dir=projects_dir)
+    assert result["unavailable"] is True
+
+
+# ---------------------------------------------------------------------------
+# Wiring: governance_emit.emit_dispatch_receipt backfills claude receipts
+# ---------------------------------------------------------------------------
+
+def test_claude_receipt_carries_harvested_token_usage(tmp_path, monkeypatch):
+    """A claude-lane receipt emitted with an 'unavailable' token_usage marker
+    and a resolvable session_id now carries real harvested counts."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-receipt-1", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    monkeypatch.setenv("VNX_CLAUDE_PROJECTS_DIR", str(projects_dir))
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-test",
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-4-6",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-receipt-1",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {
+        "input": 100,
+        "output": 20,
+        "cache_creation_5m": 10,
+        "cache_creation_1h": 5,
+        "cache_read": 2,
+    }
+
+
+def test_claude_receipt_keeps_real_token_usage_when_already_present(tmp_path, monkeypatch):
+    """A caller-supplied real token_usage is never overwritten by the harvester,
+    even when a (different) transcript exists for the session_id."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-receipt-2", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    monkeypatch.setenv("VNX_CLAUDE_PROJECTS_DIR", str(projects_dir))
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    real_usage = {"input": 9, "output": 3, "cache_hit": 0}
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-test-2",
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-4-6",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage=real_usage,
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-receipt-2",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == real_usage
+
+
+def test_kimi_receipt_never_harvests(tmp_path, monkeypatch):
+    """Kimi stays 'unavailable' in this PR — the harvest guard is claude-only."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-kimi", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    monkeypatch.setenv("VNX_CLAUDE_PROJECTS_DIR", str(projects_dir))
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-kimi",
+        terminal_id="T1",
+        provider="kimi",
+        model="kimi-k3",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-kimi",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {"unavailable": True}
+
+
+def test_claude_receipt_no_session_id_keeps_marker(tmp_path):
+    """No session_id supplied — the harvest guard never fires (old behavior)."""
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-no-session",
+        terminal_id="T1",
+        provider="claude",
+        model="claude-sonnet-4-6",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {"unavailable": True}


### PR DESCRIPTION
## Summary
Track `receipt-quality`, Phase B PR-B1 (plan: `claudedocs/plans/receipt-quality.md` §7). Adds a read-only harvester that fills `ReceiptV2.token_usage` for the claude/opus/sonnet lane from the local Claude Code session transcript, since the subscription lane has no live token-usage API.

## Changes
- **New `scripts/lib/token_harvest.py`**: `harvest_session_tokens(session_id, project_id=None)` globs `~/.claude/projects/*/<session_id>.jsonl`, sums `input_tokens` / `output_tokens` / `cache_read_input_tokens` / `cache_creation.{ephemeral_5m,ephemeral_1h}_input_tokens` across assistant messages **deduped by `message.id`** (Claude Code rewrites the same message repeatedly while streaming — naive per-line summing would multiply-count every rewrite). Fails open to an explicit `unavailable` marker (never raises) when `session_id` is empty, no transcript matches, or the transcript carries no usage entries. `VNX_CLAUDE_PROJECTS_DIR` env override for tests.
- **`scripts/lib/governance_emit.py`**: `emit_dispatch_receipt` gains an additive `session_id: Optional[str] = None` kwarg. When `provider == "claude"` and the caller-supplied `token_usage` is empty or marked `unavailable`, harvests from the transcript and substitutes the result — a real caller-supplied `token_usage` is never overwritten.
- **`scripts/lib/dispatch_envelope.py`**: `_AdapterResult` gains `session_id`; `ClaudeSubprocessAdapter.run()` threads `result.session_id` (already extracted from `spawn_claude`'s init event) through every return path; `_govern()` passes it to `emit_dispatch_receipt`.
- **`scripts/lib/provider_dispatch.py`**: `_emit_governance` passes `session_id=getattr(args, "session_id", None) or os.environ.get("VNX_SESSION_ID")` — a no-op for every non-claude provider, and covers the narrow claude-benchmark-exemption path.
- Kimi stays `unavailable` in this PR (runs outside Claude Code, no local transcript) — out of scope per plan §7.

## Verification
- `pytest tests/test_token_harvest.py tests/test_receipt_schema.py -x -q` → **28 passed**.
- New tests cover: message.id dedup (incl. 4x-repeated identical rewrites of one message), summing across distinct messages, legacy flat `cache_creation_input_tokens` bucketed as 5m, malformed/non-assistant lines ignored, fail-open `unavailable` (empty session_id, missing projects dir, no matching transcript, no usage entries, kimi-style no-transcript), and end-to-end: a claude receipt emitted with an `unavailable` marker + resolvable `session_id` now carries real harvested `token_usage`; a caller-supplied real `token_usage` is never overwritten; non-claude providers and missing `session_id` never trigger the harvest.
- Syntax + import sanity checked for all 4 touched/added modules (`ast.parse` + direct import).
- Per dispatch instructions, only the targeted token/receipt-schema tests were run — not the full suite (CI covers that).

## Open Items
None.