### PR TITLE
feat(receipt-quality): PR-B2 tool-call signals + dispatch->PR/rework columns

### DIFF
--- a/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
+++ b/scripts/hooks/pretooluse_block_raw_claude_spawn.sh
@@ -64,5 +64,18 @@ if [[ "$DECISION" == "block" ]]; then
   printf '{"decision":"block","reason":"Worker-dispatch moet via scripts/lib/subprocess_dispatch.py of provider_dispatch.py (governed, emit receipt). Rauwe claude -p/--dangerously-skip-permissions, kimi --print/-p, en codex exec bypassen de governance receipt-trail. Gebruik: python3 scripts/lib/provider_dispatch.py --provider <claude|kimi|codex> <dispatch_id>"}\n'
 fi
 
+# ── Tool-call signal aggregation (receipt-quality PR-B2, additive) ───────────
+# Best-effort record of this invocation for later receipt-time aggregation
+# (scripts/lib/toolcall_signals.py). No-op unless this is a dispatch that
+# exports VNX_TMUX_SIGNAL_DIR (same scoping as tmux_signal_stop_receipt.sh).
+# Never affects the decision above; writes to /dev/null so nothing leaks into
+# the hook's stdout (which Claude Code treats as the block/allow payload).
+if [[ -n "${VNX_TMUX_SIGNAL_DIR:-}" ]]; then
+  _TOOLCALL_BLOCKED=0
+  [[ "$DECISION" == "block" ]] && _TOOLCALL_BLOCKED=1
+  printf '%s' "$INPUT" | python3 "${HOOK_DIR}/../lib/toolcall_signals.py" \
+    --signal-dir "$VNX_TMUX_SIGNAL_DIR" --blocked "$_TOOLCALL_BLOCKED" >/dev/null 2>&1 || true
+fi
+
 # Exit 0 always — block/allow is communicated via JSON stdout, not exit code
 exit 0

--- a/scripts/hooks/pretooluse_block_subagent.sh
+++ b/scripts/hooks/pretooluse_block_subagent.sh
@@ -15,6 +15,9 @@
 
 set -euo pipefail
 
+# Resolve hook directory for the tool-call signal recorder (scripts/lib/).
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
 # ── Read hook payload ─────────────────────────────────────────────────────────
 INPUT="$(cat)"
 
@@ -31,6 +34,17 @@ fi
 
 # ── Emit block decision ──────────────────────────────────────────────────────
 printf '{"decision":"block","reason":"Subagents (Task tool) are disabled in this project. Route work through governed VNX lanes: tmux-spawn (scripts/lib/tmux_interactive_dispatch.py) or provider_dispatch.py — these emit receipts. See T0 CLAUDE.md worker-dispatch policy."}\n'
+
+# ── Tool-call signal aggregation (receipt-quality PR-B2, additive) ───────────
+# Every Task call reaching this point was just blocked above. Best-effort
+# record for later receipt-time aggregation (scripts/lib/toolcall_signals.py).
+# No-op unless this is a dispatch that exports VNX_TMUX_SIGNAL_DIR (same
+# scoping as tmux_signal_stop_receipt.sh). Writes to /dev/null so nothing
+# leaks into stdout (Claude Code treats hook stdout as the decision payload).
+if [[ -n "${VNX_TMUX_SIGNAL_DIR:-}" ]]; then
+  printf '%s' "$INPUT" | python3 "${HOOK_DIR}/../lib/toolcall_signals.py" \
+    --signal-dir "$VNX_TMUX_SIGNAL_DIR" --blocked 1 >/dev/null 2>&1 || true
+fi
 
 # Exit 0 always — block/allow is communicated via JSON stdout, not exit code
 exit 0

--- a/scripts/lib/append_receipt_internals/enrichment.py
+++ b/scripts/lib/append_receipt_internals/enrichment.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from pathlib import Path
 from typing import Any, Dict, Optional
 
@@ -242,6 +243,41 @@ def _enrich_cqs(enriched: Dict[str, Any], state_dir: Path) -> None:
         _emit("WARN", "cqs_calculation_failed", error=str(exc))
 
 
+def _enrich_toolcall_signals(enriched: Dict[str, Any]) -> None:
+    """receipt-quality PR-B2 fix-forward (Finding C): aggregate PreToolUse-hook
+    tool-call signals (scripts/lib/toolcall_signals.py) onto the tmux-interactive
+    lane's worker-authored completion receipt.
+
+    This is the Path-2 write (append_receipt_payload, used by the tmux-spawn
+    lane's own ``append_receipt.py`` completion call) — a distinct code path
+    from ``governance_emit.emit_dispatch_receipt`` (Path 1, ReceiptV2), which
+    already aggregates signals for the provider/subprocess lanes. Reads the
+    same ``VNX_TMUX_SIGNAL_DIR`` the PreToolUse hooks wrote to, inherited from
+    this worker's own process environment (the tmux lane exports it into the
+    pane's shell before the worker session starts).
+
+    FAIL-OPEN: an aggregation error or absent signal log must never break
+    receipt enrichment. Uses ``setdefault`` so a caller-supplied value (e.g. a
+    replay/backfill receipt that already carries these fields) is never
+    overwritten. Fields stay unset (omitted from the ledger line) when no
+    signal log exists — distinct from "confirmed zero tool calls", matching
+    ReceiptV2's None-omission contract for the same fields on the other paths.
+    """
+    try:
+        signal_dir = os.environ.get("VNX_TMUX_SIGNAL_DIR")
+        if not signal_dir:
+            return
+        from toolcall_signals import aggregate_toolcall_signals  # noqa: PLC0415
+        signals = aggregate_toolcall_signals(signal_dir)
+        if not signals:
+            return
+        enriched.setdefault("tool_call_count", signals["tool_call_count"])
+        enriched.setdefault("tool_call_failures", signals["tool_call_failures"])
+        enriched.setdefault("tool_call_retries", signals["tool_call_retries"])
+    except Exception as exc:  # noqa: BLE001 — observability signal must never break receipt append
+        _emit("WARN", "toolcall_signal_enrichment_failed", error=str(exc))
+
+
 def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path] = None) -> Dict[str, Any]:
     """Enrich completion receipts with provenance, session, and terminal snapshot.
 
@@ -265,6 +301,7 @@ def _enrich_completion_receipt(receipt: Dict[str, Any], repo_root: Optional[Path
     _enrich_session_metadata(enriched, state_dir)
     _enrich_provenance_linkage(enriched, state_dir)
     _enrich_terminal_snapshot(enriched, state_dir)
+    _enrich_toolcall_signals(enriched)
 
     if _is_subprocess_intermediate_completion(receipt):
         return enriched

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -601,6 +601,29 @@ def _govern(
                 )
                 _role = None
             _role = _role or "identity_unresolved"
+
+            # receipt-quality PR-B2 fix-forward (Finding C): aggregate
+            # PreToolUse-hook tool-call signals for this dispatch
+            # (toolcall_signals.py), mirroring provider_dispatch._emit_
+            # governance's wiring so the claude/subprocess-adapter lane also
+            # populates these fields when VNX_TMUX_SIGNAL_DIR is set.
+            # FAIL-OPEN — an aggregation error or absent signal log must
+            # never break receipt emission; each field simply stays None
+            # (omitted by ReceiptV2).
+            _toolcall_signals: Dict[str, int] = {}
+            try:
+                _signal_dir = os.environ.get("VNX_TMUX_SIGNAL_DIR")
+                if _signal_dir:
+                    from toolcall_signals import aggregate_toolcall_signals  # noqa: PLC0415
+                    _toolcall_signals = aggregate_toolcall_signals(_signal_dir) or {}
+            except Exception:  # noqa: BLE001 — observability signal must never break receipt emission
+                logger.debug(
+                    "envelope._govern: toolcall signal aggregation failed dispatch=%s (non-fatal)",
+                    spec.dispatch_id,
+                    exc_info=True,
+                )
+                _toolcall_signals = {}
+
             receipt_path = emit_dispatch_receipt(
                 dispatch_id=spec.dispatch_id,
                 terminal_id=spec.terminal_id,
@@ -630,6 +653,9 @@ def _govern(
                 role=_role,
                 receipt_kind="dispatch",
                 session_id=adapter_result.session_id,
+                tool_call_count=_toolcall_signals.get("tool_call_count"),
+                tool_call_failures=_toolcall_signals.get("tool_call_failures"),
+                tool_call_retries=_toolcall_signals.get("tool_call_retries"),
             )
         except Exception as exc:
             raise EnvelopeGovernError(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -92,6 +92,9 @@ def emit_dispatch_receipt(
     role: Optional[str] = None,
     receipt_kind: Optional[str] = None,
     session_id: Optional[str] = None,
+    tool_call_count: Optional[int] = None,
+    tool_call_failures: Optional[int] = None,
+    tool_call_retries: Optional[int] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -163,6 +166,12 @@ def emit_dispatch_receipt(
     (fix-r1) — exactly like Path 2 (``append_receipt_payload``). Only
     stamped when provided.
 
+    ``tool_call_count`` / ``tool_call_failures`` / ``tool_call_retries``:
+    receipt-quality PR-B2 — PreToolUse-hook signal counts for this dispatch,
+    aggregated by the caller via ``toolcall_signals.aggregate_toolcall_
+    signals``. Only stamped when provided (None omits the field — no signal
+    log means no observation, not "confirmed zero calls").
+
     Raises:
         ValueError: provider field doesn't match required pattern, or
             receipt_kind missing / outside the closed set (PR-3 lint raise)
@@ -221,6 +230,9 @@ def emit_dispatch_receipt(
         injection_reconstructs=injection_reconstructs,
         verification=verification,
         warnings=warnings,
+        tool_call_count=tool_call_count,
+        tool_call_failures=tool_call_failures,
+        tool_call_retries=tool_call_retries,
     ).to_dict()
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -608,7 +608,11 @@ def run_reconcile(
         prov_conn = sqlite3.connect(str(db_path), timeout=10.0)
         prov_conn.row_factory = sqlite3.Row
         try:
-            provenance = reconcile_commit_provenance(repo_root, prov_conn)
+            # Finding A (ADR-007 composite-safety): this reconcile pipeline
+            # already operates on a single project_id's per-project store —
+            # pass it through so the dispatch_metadata.pr_id backfill never
+            # falls back to an ambiguous dispatch_id-only lookup.
+            provenance = reconcile_commit_provenance(repo_root, prov_conn, project_id=project_id)
         finally:
             prov_conn.close()
     except Exception as exc:  # noqa: BLE001

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -672,6 +672,24 @@ def _emit_governance(
         _role = None
     _role = _role or "identity_unresolved"
 
+    # receipt-quality PR-B2: aggregate PreToolUse-hook tool-call signals for
+    # this dispatch (scripts/lib/toolcall_signals.py). FAIL-OPEN — an
+    # aggregation error or absent signal log must never break receipt
+    # emission; each field simply stays None (omitted by ReceiptV2).
+    _toolcall_signals: Dict[str, int] = {}
+    try:
+        _signal_dir = os.environ.get("VNX_TMUX_SIGNAL_DIR")
+        if _signal_dir:
+            from toolcall_signals import aggregate_toolcall_signals  # noqa: PLC0415
+            _toolcall_signals = aggregate_toolcall_signals(_signal_dir) or {}
+    except Exception:  # noqa: BLE001 — observability signal must never break receipt emission
+        logger.debug(
+            "_emit_governance: toolcall signal aggregation failed dispatch=%s (non-fatal)",
+            getattr(args, "dispatch_id", "?"),
+            exc_info=True,
+        )
+        _toolcall_signals = {}
+
     for attempt in range(_EMIT_MAX_RETRIES):
         try:
             receipt_path = emit_dispatch_receipt(
@@ -721,7 +739,21 @@ def _emit_governance(
                 # benchmark exemption path (the only route that reaches this
                 # provider="claude" case) can backfill token_usage from the
                 # local transcript. No-op for every other provider.
-                session_id=getattr(args, "session_id", None) or os.environ.get("VNX_SESSION_ID"),
+                # OI-819 (codex PR-B1 review, Finding 2): prefer the
+                # authoritative init-event session_id off the spawn result
+                # (dispatch_envelope.py already does this for its own
+                # emit_dispatch_receipt call) — args.session_id/VNX_SESSION_ID
+                # can silently no-op or harvest an unrelated transcript.
+                # getattr() stays None-safe for result objects with no
+                # session_id concept (non-claude providers; _ClaudeResult).
+                session_id=(
+                    getattr(result, "session_id", None)
+                    or getattr(args, "session_id", None)
+                    or os.environ.get("VNX_SESSION_ID")
+                ),
+                tool_call_count=_toolcall_signals.get("tool_call_count"),
+                tool_call_failures=_toolcall_signals.get("tool_call_failures"),
+                tool_call_retries=_toolcall_signals.get("tool_call_retries"),
             )
             print(f"Receipt: {receipt_path}", file=sys.stderr)
             break

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -563,6 +563,52 @@ def _link_pr_to_track(
     return True
 
 
+def _resolve_dispatch_project_id(state_conn: sqlite3.Connection, dispatch_id: str) -> Optional[str]:
+    """Resolve ``project_id`` for ``dispatch_id`` from the RC ``dispatches`` table.
+
+    Kept independent from ``_link_pr_to_track``'s own project_id resolution
+    (rather than refactored into it) to avoid touching that already-tested path.
+    Returns None when the column is absent or no row matches — callers must
+    treat that as "cannot scope a composite-keyed write", never default to a
+    guessed tenant.
+    """
+    if not _has_column(state_conn, "dispatches", "project_id"):
+        return None
+    row = state_conn.execute(
+        "SELECT project_id FROM dispatches WHERE dispatch_id = ?", (dispatch_id,)
+    ).fetchone()
+    return row[0] if row else None
+
+
+def _link_pr_to_dispatch_metadata(
+    qi_conn: sqlite3.Connection,
+    project_id: str,
+    dispatch_id: str,
+    pr_number: int,
+) -> bool:
+    """Fill-once: stamp ``dispatch_metadata.pr_id`` (quality_intelligence.db)
+    for this dispatch when currently empty.
+
+    Sibling of ``rework_attribution._persist_parent``'s fill-once contract for
+    the other dormant ``dispatch_metadata`` column. Idempotent: a ``pr_id``
+    already present is never overwritten (first writer wins) — matches
+    ``dispatch_metadata_db.upsert_dispatch_provider_row``'s COALESCE semantics
+    for the same column. Returns True only when a row was actually updated.
+    """
+    if not _has_column(qi_conn, "dispatch_metadata", "pr_id"):
+        return False
+    try:
+        cur = qi_conn.execute(
+            "UPDATE dispatch_metadata SET pr_id = ? "
+            "WHERE project_id = ? AND dispatch_id = ? "
+            "AND (pr_id IS NULL OR pr_id = '')",
+            (f"#{pr_number}", project_id, dispatch_id),
+        )
+        return cur.rowcount > 0
+    except sqlite3.Error:
+        return False
+
+
 def reconcile_commit_provenance(
     repo_root: "str | Path",
     conn: sqlite3.Connection,
@@ -579,6 +625,12 @@ def reconcile_commit_provenance(
     D2 extension: commits that carry a PR number (``(#NNN)``) and resolve to a dispatch with a
     ``track_id`` also upsert that PR onto ``tracks.pr_ref`` in the project state store. This
     step is order-independent with D1: if ``track_id`` is absent/NULL, the PR-link is skipped.
+
+    receipt-quality PR-B2 extension: the same discovered ``(dispatch_id, pr_number)`` pair also
+    fills the sibling dormant column ``dispatch_metadata.pr_id`` (a different database,
+    quality_intelligence.db, alongside runtime_coordination.db under the same state dir).
+    Fill-once (never overwrites an existing pr_id) and independent of the tracks.pr_ref step —
+    a dispatch with no track_id still gets its dispatch_metadata.pr_id stamped.
     """
     try:
         from trace_token_validator import extract_trace_tokens  # noqa: PLC0415
@@ -596,26 +648,48 @@ def reconcile_commit_provenance(
     if result.returncode != 0:
         return {"scanned": 0, "linked": 0}
 
+    # Resolve the state dir once; both DB connections below hang off it.
+    # Failure here is non-fatal — provenance reconciliation must keep working
+    # exactly as before, just without the pr_ref/pr_id linking steps.
+    state_dir: Optional[Path] = None
+    try:
+        from vnx_paths import resolve_state_dir  # noqa: PLC0415
+        state_dir = resolve_state_dir(repo_root)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not resolve state dir for pr linking: %s", exc)
+        state_dir = None
+
     # Open the project state DB once for the optional track.pr_ref upsert. If the
     # supplied ``conn`` already targets that DB, reuse it to avoid a second connection
     # (and the resulting lock contention in single-threaded callers). Failures here
     # are non-fatal: provenance reconciliation must keep working exactly as before.
     state_conn: Optional[sqlite3.Connection] = None
     state_conn_borrowed = False
-    try:
-        from vnx_paths import resolve_state_dir  # noqa: PLC0415
-        state_dir = resolve_state_dir(repo_root)
-        state_db = (state_dir / "runtime_coordination.db").resolve()
-        if _connection_targets_db(conn, state_db):
-            state_conn = conn
-            state_conn_borrowed = True
-        else:
-            state_conn = sqlite3.connect(str(state_db), timeout=10.0)
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("could not open project state db for pr_ref linking: %s", exc)
-        state_conn = None
+    # receipt-quality PR-B2: quality_intelligence.db lives beside
+    # runtime_coordination.db under the same state dir — always a fresh
+    # connection (dispatch_metadata is never the registry's own DB).
+    qi_conn: Optional[sqlite3.Connection] = None
+    if state_dir is not None:
+        try:
+            state_db = (state_dir / "runtime_coordination.db").resolve()
+            if _connection_targets_db(conn, state_db):
+                state_conn = conn
+                state_conn_borrowed = True
+            else:
+                state_conn = sqlite3.connect(str(state_db), timeout=10.0)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("could not open project state db for pr_ref linking: %s", exc)
+            state_conn = None
 
-    scanned = linked = pr_ref_linked = 0
+        try:
+            qi_db = (state_dir / "quality_intelligence.db").resolve()
+            if qi_db.exists():
+                qi_conn = sqlite3.connect(str(qi_db), timeout=10.0)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("could not open quality_intelligence.db for pr_id linking: %s", exc)
+            qi_conn = None
+
+    scanned = linked = pr_ref_linked = pr_id_linked = 0
     try:
         for entry in result.stdout.split("\x1e"):
             entry = entry.strip()
@@ -643,6 +717,16 @@ def reconcile_commit_provenance(
                         pr_ref_linked += 1
                 except Exception as exc:  # noqa: BLE001
                     logger.debug("pr_ref linking failed for %s: %s", dispatch_id, exc)
+
+                if qi_conn is not None:
+                    try:
+                        project_id = _resolve_dispatch_project_id(state_conn, dispatch_id)
+                        if project_id and _link_pr_to_dispatch_metadata(
+                            qi_conn, project_id, dispatch_id, pr_number
+                        ):
+                            pr_id_linked += 1
+                    except Exception as exc:  # noqa: BLE001
+                        logger.debug("pr_id linking failed for %s: %s", dispatch_id, exc)
     finally:
         if state_conn is not None and not state_conn_borrowed:
             try:
@@ -650,8 +734,19 @@ def reconcile_commit_provenance(
                 state_conn.close()
             except Exception as exc:  # noqa: BLE001
                 logger.debug("failed to commit/close project state db: %s", exc)
+        if qi_conn is not None:
+            try:
+                qi_conn.commit()
+                qi_conn.close()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("failed to commit/close quality_intelligence db: %s", exc)
 
-    return {"scanned": scanned, "linked": linked, "pr_ref_linked": pr_ref_linked}
+    return {
+        "scanned": scanned,
+        "linked": linked,
+        "pr_ref_linked": pr_ref_linked,
+        "pr_id_linked": pr_id_linked,
+    }
 
 
 def get_provenance_link(

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -568,16 +568,28 @@ def _resolve_dispatch_project_id(state_conn: sqlite3.Connection, dispatch_id: st
 
     Kept independent from ``_link_pr_to_track``'s own project_id resolution
     (rather than refactored into it) to avoid touching that already-tested path.
-    Returns None when the column is absent or no row matches — callers must
-    treat that as "cannot scope a composite-keyed write", never default to a
-    guessed tenant.
+    Returns None when the column is absent, no row matches, OR more than one
+    DISTINCT project_id matches — callers must treat that as "cannot scope a
+    composite-keyed write", never default to a guessed tenant.
+
+    ADR-007: ``dispatches`` is composite-unique on ``(dispatch_id,
+    project_id)``, so the same ``dispatch_id`` can legitimately exist under
+    multiple tenants. A plain ``SELECT ... WHERE dispatch_id = ?`` (pre-fix)
+    would silently resolve an arbitrary row and let the caller stamp the
+    wrong tenant's ``dispatch_metadata.pr_id``. Only unambiguous
+    (single-tenant) matches resolve here; a cross-tenant collision abstains
+    rather than guesses. Prefer callers that already know their own
+    ``project_id`` (passed explicitly) over this lookup — see
+    ``reconcile_commit_provenance``'s ``project_id`` parameter.
     """
     if not _has_column(state_conn, "dispatches", "project_id"):
         return None
-    row = state_conn.execute(
-        "SELECT project_id FROM dispatches WHERE dispatch_id = ?", (dispatch_id,)
-    ).fetchone()
-    return row[0] if row else None
+    rows = state_conn.execute(
+        "SELECT DISTINCT project_id FROM dispatches WHERE dispatch_id = ?", (dispatch_id,)
+    ).fetchall()
+    if len(rows) != 1:
+        return None
+    return rows[0][0]
 
 
 def _link_pr_to_dispatch_metadata(
@@ -594,6 +606,15 @@ def _link_pr_to_dispatch_metadata(
     already present is never overwritten (first writer wins) — matches
     ``dispatch_metadata_db.upsert_dispatch_provider_row``'s COALESCE semantics
     for the same column. Returns True only when a row was actually updated.
+
+    Stores the BARE numeric PR id (``str(pr_number)``, no leading ``#``) —
+    matching the existing convention prior-round-intelligence consumers
+    (e.g. ``prior_round_injector.py``) rely on to build
+    ``review_gates/results/pr-{pr_id}-{gate}.json`` paths. A ``#``-prefixed
+    value would never match those bare-numeric-keyed paths, silently
+    disabling prior-round findings for backfilled rows. Distinct from
+    ``tracks.pr_ref`` (``_link_pr_to_track`` above), which legitimately keeps
+    the ``#``-prefixed display format for its own, unrelated column.
     """
     if not _has_column(qi_conn, "dispatch_metadata", "pr_id"):
         return False
@@ -602,7 +623,7 @@ def _link_pr_to_dispatch_metadata(
             "UPDATE dispatch_metadata SET pr_id = ? "
             "WHERE project_id = ? AND dispatch_id = ? "
             "AND (pr_id IS NULL OR pr_id = '')",
-            (f"#{pr_number}", project_id, dispatch_id),
+            (str(pr_number), project_id, dispatch_id),
         )
         return cur.rowcount > 0
     except sqlite3.Error:
@@ -614,6 +635,7 @@ def reconcile_commit_provenance(
     conn: sqlite3.Connection,
     *,
     max_commits: int = 300,
+    project_id: Optional[str] = None,
 ) -> Dict[str, int]:
     """Close the dispatch->commit link: scan recent git commits for a ``Dispatch-ID:`` trace token
     and register each commit's SHA against its dispatch_id in the provenance_registry.
@@ -631,6 +653,16 @@ def reconcile_commit_provenance(
     quality_intelligence.db, alongside runtime_coordination.db under the same state dir).
     Fill-once (never overwrites an existing pr_id) and independent of the tracks.pr_ref step —
     a dispatch with no track_id still gets its dispatch_metadata.pr_id stamped.
+
+    ``project_id``: ADR-007 composite-safety (fix-forward, Finding A). Callers that already
+    operate on a per-project store (``objective_reconcile.run_reconcile``,
+    ``scripts/reconcile_provenance.py``) know their own ``project_id`` up front — pass it here
+    so the ``dispatch_metadata.pr_id`` backfill uses it directly instead of re-resolving by
+    ``dispatch_id`` alone (a lookup that cannot distinguish which tenant a colliding
+    ``dispatch_id`` belongs to under the ``dispatches`` table's ``(dispatch_id, project_id)``
+    composite-unique key). When omitted (back-compat), falls back to
+    ``_resolve_dispatch_project_id``, which itself abstains (returns None, no stamp) on any
+    cross-tenant ``dispatch_id`` collision rather than guessing.
     """
     try:
         from trace_token_validator import extract_trace_tokens  # noqa: PLC0415
@@ -720,9 +752,16 @@ def reconcile_commit_provenance(
 
                 if qi_conn is not None:
                     try:
-                        project_id = _resolve_dispatch_project_id(state_conn, dispatch_id)
-                        if project_id and _link_pr_to_dispatch_metadata(
-                            qi_conn, project_id, dispatch_id, pr_number
+                        # Finding A: prefer the caller-supplied project_id (the
+                        # reconciliation loop's own tenant scope) over
+                        # re-resolving by dispatch_id alone — a lookup that
+                        # cannot disambiguate a cross-tenant dispatch_id
+                        # collision under the ADR-007 composite-unique key.
+                        _dispatch_pid = project_id or _resolve_dispatch_project_id(
+                            state_conn, dispatch_id
+                        )
+                        if _dispatch_pid and _link_pr_to_dispatch_metadata(
+                            qi_conn, _dispatch_pid, dispatch_id, pr_number
                         ):
                             pr_id_linked += 1
                     except Exception as exc:  # noqa: BLE001

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -26,8 +26,10 @@ Hard contracts:
     ``dispatch_identity.validate_receipt_kind``) is folded into each
     contract's ``__post_init__`` — constructing a receipt object with a
     missing/out-of-vocab kind raises ValueError before anything is written.
-  - This PR adds NO new receipt fields (that is B1-B4) and does not touch
-    ``IDEMPOTENCY_FIELDS``.
+  - PR-B0 itself added NO new receipt fields and did not touch
+    ``IDEMPOTENCY_FIELDS``. Later receipt-quality PRs (B2+) add typed,
+    conditionally-stamped fields on top of this contract -- additive only,
+    still never touching ``IDEMPOTENCY_FIELDS``.
 """
 
 from __future__ import annotations
@@ -100,6 +102,13 @@ class ReceiptV2:
     injection_reconstructs: Optional[bool] = None
     verification: Optional[Dict[str, Any]] = None
     warnings: Optional[List[Dict[str, Any]]] = None
+    # receipt-quality PR-B2: PreToolUse-hook tool-call signals, aggregated by
+    # toolcall_signals.aggregate_toolcall_signals() from the per-dispatch
+    # tmux-signal-dir NDJSON log. None (omitted) when no signal log exists for
+    # this dispatch -- distinct from "confirmed zero tool calls".
+    tool_call_count: Optional[int] = None
+    tool_call_failures: Optional[int] = None
+    tool_call_retries: Optional[int] = None
 
     def __post_init__(self) -> None:
         # Receipt-quality PR-3: the closed-set lint lives in the contract now
@@ -153,6 +162,12 @@ class ReceiptV2:
             receipt["verification"] = self.verification
         if self.warnings is not None:
             receipt["warnings"] = self.warnings
+        if self.tool_call_count is not None:
+            receipt["tool_call_count"] = self.tool_call_count
+        if self.tool_call_failures is not None:
+            receipt["tool_call_failures"] = self.tool_call_failures
+        if self.tool_call_retries is not None:
+            receipt["tool_call_retries"] = self.tool_call_retries
         return receipt
 
 

--- a/scripts/lib/toolcall_signals.py
+++ b/scripts/lib/toolcall_signals.py
@@ -1,0 +1,175 @@
+"""toolcall_signals.py — per-dispatch tool-call signal aggregation (receipt-quality PR-B2).
+
+The PreToolUse hooks already registered for Bash and Task in .claude/settings.json
+(``scripts/hooks/pretooluse_block_raw_claude_spawn.sh``,
+``scripts/hooks/pretooluse_block_subagent.sh``) fire on every Bash/Task tool call a
+dispatch's Claude Code session makes -- a live, already-wired channel -- but until now
+nothing recorded those firings anywhere, so "how many tool calls, how many were
+blocked, how many were retried" was unobservable per dispatch.
+
+This module is the write+read side of that channel:
+
+  - ``record_toolcall_event()`` is called from the tail of each PreToolUse hook
+    (best-effort, fail-open, never touches the hook's stdout/decision). It appends
+    one NDJSON line to ``<signal_dir>/toolcalls.ndjson`` -- ``signal_dir`` is the
+    same per-dispatch ``$VNX_TMUX_SIGNAL_DIR`` scratch directory the tmux-signal
+    hooks (``tmux_signal_stop_receipt.sh`` et al.) already use.
+  - ``aggregate_toolcall_signals()`` is called once at receipt-emit time
+    (``provider_dispatch._emit_governance``) to fold the log into three additive
+    receipt fields (``receipt_schema.ReceiptV2.tool_call_count`` /
+    ``tool_call_failures`` / ``tool_call_retries``).
+
+Scoped to dispatches that export ``VNX_TMUX_SIGNAL_DIR`` (tmux-spawn dispatches
+today): the same scoping convention ``tmux_signal_stop_receipt.sh`` already uses.
+Non-Claude-Code providers (codex, kimi, gemini CLIs) never go through Claude Code's
+hook system at all, so this channel is silent for them by construction --
+``aggregate_toolcall_signals()`` returns ``None`` and the receipt fields stay omitted
+(``ReceiptV2``'s existing None-omission contract).
+
+Fail-open everywhere: ``record_toolcall_event`` never raises (hook context -- a
+failure here must never block or alter the PreToolUse decision); ``aggregate_toolcall_
+signals`` never raises (receipt-emit context -- an aggregation failure must never
+break receipt emission).
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import logging
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_SIGNAL_FILENAME = "toolcalls.ndjson"
+
+
+def _utc_now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _input_signature(tool_input: Any) -> str:
+    """Stable short hash of a tool call's input, used to detect retries (the same
+    tool_name reissued with the same input). ``sort_keys`` makes key-order
+    variation in an equivalent dict not spuriously break a retry match.
+    """
+    try:
+        blob = json.dumps(tool_input, sort_keys=True, default=str)
+    except (TypeError, ValueError):
+        blob = str(tool_input)
+    return hashlib.sha256(blob.encode("utf-8", errors="ignore")).hexdigest()[:16]
+
+
+def record_toolcall_event(
+    signal_dir: "str | Path",
+    hook_payload: Dict[str, Any],
+    *,
+    blocked: bool,
+) -> None:
+    """Append one tool-call signal line to ``<signal_dir>/toolcalls.ndjson``.
+
+    ``hook_payload`` is the raw PreToolUse hook stdin JSON
+    (``{tool_name, tool_input, session_id, cwd, transcript_path}``); only
+    ``tool_name``/``tool_input`` are used. ``blocked`` records whether the hook's
+    OWN decision for this invocation was to block the call.
+
+    Best-effort: never raises. A hook that logs a signal must never fail the tool
+    call it is observing.
+    """
+    try:
+        signal_dir = Path(signal_dir)
+        signal_dir.mkdir(parents=True, exist_ok=True)
+        entry = {
+            "tool_name": hook_payload.get("tool_name") or "",
+            "signature": _input_signature(hook_payload.get("tool_input")),
+            "blocked": bool(blocked),
+            "timestamp": _utc_now_iso(),
+        }
+        path = signal_dir / _SIGNAL_FILENAME
+        with path.open("a", encoding="utf-8") as fh:
+            fcntl.flock(fh, fcntl.LOCK_EX)
+            try:
+                fh.write(json.dumps(entry) + "\n")
+            finally:
+                fcntl.flock(fh, fcntl.LOCK_UN)
+    except Exception:  # noqa: BLE001 — hook context: must never raise or block the tool call
+        logger.debug("toolcall_signals: record failed (non-fatal)", exc_info=True)
+
+
+def aggregate_toolcall_signals(signal_dir: "str | Path") -> Optional[Dict[str, int]]:
+    """Fold a dispatch's ``toolcalls.ndjson`` into receipt-ready counts.
+
+    Returns ``{tool_call_count, tool_call_failures, tool_call_retries}``, or
+    ``None`` when the signal file is absent/unreadable/empty (distinct from
+    "confirmed zero calls" -- mirrors ``token_harvest.py``'s None-vs-zero
+    convention). A malformed line is skipped rather than aborting the whole
+    aggregation. Never raises.
+    """
+    try:
+        path = Path(signal_dir) / _SIGNAL_FILENAME
+        if not path.is_file():
+            return None
+        seen: Dict[tuple, int] = {}
+        total = 0
+        failures = 0
+        with path.open("r", encoding="utf-8", errors="ignore") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    entry = json.loads(line)
+                except json.JSONDecodeError:
+                    continue
+                if not isinstance(entry, dict):
+                    continue
+                total += 1
+                if entry.get("blocked"):
+                    failures += 1
+                key = (entry.get("tool_name"), entry.get("signature"))
+                seen[key] = seen.get(key, 0) + 1
+        if total == 0:
+            return None
+        retries = sum(n - 1 for n in seen.values() if n > 1)
+        return {
+            "tool_call_count": total,
+            "tool_call_failures": failures,
+            "tool_call_retries": retries,
+        }
+    except OSError:
+        logger.debug("toolcall_signals: aggregate failed (non-fatal)", exc_info=True)
+        return None
+
+
+def _cli_main() -> int:
+    """CLI entry so the (bash) PreToolUse hooks can record a signal without a
+    Python import: ``echo "$INPUT" | python3 toolcall_signals.py --signal-dir DIR
+    --blocked {0,1}``. Fail-open: malformed/absent stdin never breaks the hook.
+    """
+    import argparse
+    import sys
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--signal-dir", required=True)
+    parser.add_argument("--blocked", choices=("0", "1"), required=True)
+    args = parser.parse_args()
+
+    try:
+        payload = json.load(sys.stdin)
+    except Exception:  # noqa: BLE001 — fail-open: never break the calling hook
+        return 0
+    if not isinstance(payload, dict):
+        return 0
+
+    record_toolcall_event(args.signal_dir, payload, blocked=(args.blocked == "1"))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(_cli_main())
+
+
+__all__ = ["record_toolcall_event", "aggregate_toolcall_signals"]

--- a/scripts/reconcile_provenance.py
+++ b/scripts/reconcile_provenance.py
@@ -80,7 +80,13 @@ def main(argv: "list[str] | None" = None) -> int:
             print(json.dumps(result) if args.json else
                   "reconcile_provenance: provenance_registry table missing — nothing to do")
             return EXIT_OK
-        result = reconcile_commit_provenance(repo_root, conn, max_commits=args.max_commits)
+        # Finding A (ADR-007 composite-safety): project_id is already resolved
+        # above for this per-project store — pass it through so the
+        # dispatch_metadata.pr_id backfill never falls back to an ambiguous
+        # dispatch_id-only lookup.
+        result = reconcile_commit_provenance(
+            repo_root, conn, max_commits=args.max_commits, project_id=project_id,
+        )
         conn.commit()
     finally:
         conn.close()

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -759,3 +759,55 @@ class TestClaudeAdapterCapturesCompletionText:
         assert adapter_result.completion_text == "def foo(): pass", (
             f"Expected 'def foo(): pass', got {adapter_result.completion_text!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# receipt-quality PR-B2 fix-forward (Finding C): _govern() aggregates
+# PreToolUse-hook tool-call signals (toolcall_signals.py) onto the receipt
+# for the claude/subprocess-adapter lane, mirroring the wiring
+# provider_dispatch._emit_governance already had
+# (tests/test_receipt_v2_pr_b2_wiring.py) and the tmux-interactive lane's
+# worker-authored receipt now also has
+# (tests/test_toolcall_signals_tmux_lane_wiring.py).
+# ---------------------------------------------------------------------------
+
+
+class TestClaudeEnvelopeToolcallSignals:
+    def _run(self, spec, claude_result):
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec)
+
+        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            result = run_envelope(spec, lane="claude-subprocess")
+
+        return result, mock_receipt
+
+    def test_toolcall_signals_aggregated_onto_receipt(self, spec_claude, monkeypatch, tmp_path):
+        from toolcall_signals import record_toolcall_event
+
+        signal_dir = tmp_path / "tmux-signal"
+        record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+        record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "claude -p x"}}, blocked=True)
+        record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+        record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+        monkeypatch.setenv("VNX_TMUX_SIGNAL_DIR", str(signal_dir))
+
+        claude_result = _FakeClaudeResult(returncode=0)
+        _, mock_receipt = self._run(spec_claude, claude_result)
+
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["tool_call_count"] == 4
+        assert mock_receipt.call_args[1]["tool_call_failures"] == 1
+        assert mock_receipt.call_args[1]["tool_call_retries"] == 1
+
+    def test_toolcall_signals_absent_when_signal_dir_unset(self, spec_claude, monkeypatch):
+        monkeypatch.delenv("VNX_TMUX_SIGNAL_DIR", raising=False)
+
+        claude_result = _FakeClaudeResult(returncode=0)
+        _, mock_receipt = self._run(spec_claude, claude_result)
+
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["tool_call_count"] is None
+        assert mock_receipt.call_args[1]["tool_call_failures"] is None
+        assert mock_receipt.call_args[1]["tool_call_retries"] is None

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -28,6 +28,7 @@ VNX_ROOT = TESTS_DIR.parent
 SCRIPTS_LIB = VNX_ROOT / "scripts" / "lib"
 sys.path.insert(0, str(SCRIPTS_LIB))
 
+import receipt_provenance
 from receipt_provenance import (
     CHAIN_STATUS_BROKEN,
     CHAIN_STATUS_COMPLETE,
@@ -995,7 +996,29 @@ class TestReconcileCommitProvenanceDispatchMetadataPrId:
         conn.commit()
 
         assert result["pr_id_linked"] == 1
-        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "#412"
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "412"
+        conn.close()
+
+    def test_stores_bare_numeric_pr_id_not_hash_prefixed(self, tmp_path):
+        """Codex-gate Finding B (fix-forward, PR #1235): dispatch_metadata.pr_id
+        must be the BARE numeric PR id, not "#412" -- prior-round-intelligence
+        consumers (prior_round_injector.py) build
+        review_gates/results/pr-{pr_id}-{gate}.json paths from this value
+        verbatim, and a "#"-prefixed value never matches a bare-numeric-keyed
+        path. Distinct from tracks.pr_ref (test_links_pr_ref_from_squash_merge
+        above), which legitimately keeps the "#"-prefixed display format."""
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        stored = _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID)
+        assert stored == "412"
+        assert not stored.startswith("#")
         conn.close()
 
     def test_idempotent_second_reconcile_is_noop(self, tmp_path):
@@ -1011,7 +1034,7 @@ class TestReconcileCommitProvenanceDispatchMetadataPrId:
 
         assert first["pr_id_linked"] == 1
         assert second["pr_id_linked"] == 0
-        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "#412"
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "412"
         conn.close()
 
     def test_never_overwrites_existing_pr_id(self, tmp_path):
@@ -1073,4 +1096,110 @@ class TestReconcileCommitProvenanceDispatchMetadataPrId:
         assert result["pr_id_linked"] == 0
         assert _read_pr_id(state_dir, "other-proj", self.DISPATCH_ID) is None
         conn.close()
+        conn.close()
+
+    def test_explicit_project_id_bypasses_ambiguous_lookup(self, tmp_path, monkeypatch):
+        """Codex-gate Finding A (fix-forward, PR #1235): when the caller already
+        knows its own project_id (the reconciliation loop operates on a
+        per-project store), reconcile_commit_provenance uses it directly for
+        the dispatch_metadata.pr_id backfill instead of re-resolving by
+        dispatch_id alone -- a lookup that cannot disambiguate a same-
+        dispatch_id row under a different project_id (ADR-007 composite key).
+        Proven here by making the fallback resolver raise: if it were called
+        despite project_id being supplied, this test would fail loudly rather
+        than silently passing on the resolver's own (also-correct) answer."""
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        def _must_not_be_called(*_args, **_kwargs):
+            raise AssertionError(
+                "_resolve_dispatch_project_id must not be called when the "
+                "caller already supplied project_id"
+            )
+        monkeypatch.setattr(receipt_provenance, "_resolve_dispatch_project_id", _must_not_be_called)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10, project_id="test-proj")
+        conn.commit()
+
+        assert result["pr_id_linked"] == 1
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "412"
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# receipt-quality PR-B2 fix-forward (Finding A) — _resolve_dispatch_project_id
+# must be ADR-007 composite-safe: a dispatch_id colliding across more than one
+# project_id (dispatches is UNIQUE(dispatch_id, project_id), so this is a
+# legitimate multi-tenant state, not corruption) must abstain (None) rather
+# than resolve an arbitrary/first row and let a downstream composite-scoped
+# UPDATE stamp the wrong tenant's dispatch_metadata.pr_id.
+# ---------------------------------------------------------------------------
+
+
+class TestResolveDispatchProjectIdCompositeSafety:
+    def _make_conn(self, tmp_path):
+        """Minimal dispatches table with the ADR-007 composite-unique key
+        (mirrors schemas/runtime_coordination_v10.sql), independent of
+        _make_project's legacy single-column-UNIQUE(dispatch_id) table (which
+        cannot represent the collision this test exercises at all)."""
+        db_path = tmp_path / "rc.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """
+            CREATE TABLE dispatches (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                state TEXT NOT NULL DEFAULT 'queued',
+                UNIQUE(dispatch_id, project_id)
+            )
+            """
+        )
+        conn.commit()
+        return conn
+
+    def test_unambiguous_single_project_resolves(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id) VALUES (?, ?)",
+            ("dispatch-x", "proj-a"),
+        )
+        conn.commit()
+
+        assert receipt_provenance._resolve_dispatch_project_id(conn, "dispatch-x") == "proj-a"
+        conn.close()
+
+    def test_cross_tenant_collision_abstains(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id) VALUES (?, ?)",
+            ("dispatch-x", "proj-a"),
+        )
+        conn.execute(
+            "INSERT INTO dispatches (dispatch_id, project_id) VALUES (?, ?)",
+            ("dispatch-x", "proj-b"),
+        )
+        conn.commit()
+
+        assert receipt_provenance._resolve_dispatch_project_id(conn, "dispatch-x") is None
+        conn.close()
+
+    def test_no_matching_row_returns_none(self, tmp_path):
+        conn = self._make_conn(tmp_path)
+        assert receipt_provenance._resolve_dispatch_project_id(conn, "nonexistent") is None
+        conn.close()
+
+    def test_missing_project_id_column_returns_none(self, tmp_path):
+        db_path = tmp_path / "rc-legacy.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "CREATE TABLE dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL UNIQUE)"
+        )
+        conn.execute("INSERT INTO dispatches (dispatch_id) VALUES (?)", ("dispatch-x",))
+        conn.commit()
+
+        assert receipt_provenance._resolve_dispatch_project_id(conn, "dispatch-x") is None
         conn.close()

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -937,4 +937,140 @@ class TestReconcileCommitProvenanceTrackLinkage:
             (self.DISPATCH_ID,),
         ).fetchone()
         assert reg["commit_sha"] is not None
+
+
+# ---------------------------------------------------------------------------
+# receipt-quality PR-B2 — dispatch_metadata.pr_id backfill (sibling of
+# tracks.pr_ref, a different database: quality_intelligence.db)
+# ---------------------------------------------------------------------------
+
+
+def _make_qi_dispatch_metadata(state_dir, project_id, dispatch_id, pr_id=None):
+    """Minimal quality_intelligence.db with just the dispatch_metadata columns
+    reconcile_commit_provenance's pr_id backfill touches (mirrors the
+    hand-rolled _add_track_layer helper's minimal-schema style above)."""
+    qi_db = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(str(qi_db))
+    conn.execute(
+        """
+        CREATE TABLE dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            pr_id TEXT,
+            UNIQUE(project_id, dispatch_id)
+        )
+        """
+    )
+    conn.execute(
+        "INSERT INTO dispatch_metadata (dispatch_id, project_id, pr_id) VALUES (?, ?, ?)",
+        (dispatch_id, project_id, pr_id),
+    )
+    conn.commit()
+    conn.close()
+    return qi_db
+
+
+def _read_pr_id(state_dir, project_id, dispatch_id):
+    conn = sqlite3.connect(str(state_dir / "quality_intelligence.db"))
+    row = conn.execute(
+        "SELECT pr_id FROM dispatch_metadata WHERE project_id = ? AND dispatch_id = ?",
+        (project_id, dispatch_id),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
+class TestReconcileCommitProvenanceDispatchMetadataPrId:
+    DISPATCH_ID = "20260728-rq-b2-provenance-prid"
+
+    def test_fills_empty_pr_id_from_commit(self, tmp_path):
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert result["pr_id_linked"] == 1
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "#412"
+        conn.close()
+
+    def test_idempotent_second_reconcile_is_noop(self, tmp_path):
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        first = reconcile_commit_provenance(repo, conn, max_commits=10)
+        second = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert first["pr_id_linked"] == 1
+        assert second["pr_id_linked"] == 0
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "#412"
+        conn.close()
+
+    def test_never_overwrites_existing_pr_id(self, tmp_path):
+        """Fill-once: a pr_id already present is never clobbered by a later
+        commit referencing a different PR number."""
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID, pr_id="#100")
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert result["pr_id_linked"] == 0
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) == "#100"
+        conn.close()
+
+    def test_no_pr_number_leaves_pr_id_null(self, tmp_path):
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "test-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert result["pr_id_linked"] == 0
+        assert _read_pr_id(state_dir, "test-proj", self.DISPATCH_ID) is None
+        conn.close()
+
+    def test_missing_qi_db_is_noop_not_fatal(self, tmp_path):
+        """No quality_intelligence.db at all (project never bootstrapped it) --
+        the RC-side pr_ref linkage must keep working exactly as before."""
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        assert not (state_dir / "quality_intelligence.db").exists()
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert result["pr_id_linked"] == 0
+        assert result["pr_ref_linked"] == 1
+        conn.close()
+
+    def test_wrong_project_id_row_is_noop(self, tmp_path):
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _make_qi_dispatch_metadata(state_dir, "other-proj", self.DISPATCH_ID)
+        _commit(repo, f"feat(x): do thing (#412)\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+        conn.commit()
+
+        assert result["pr_id_linked"] == 0
+        assert _read_pr_id(state_dir, "other-proj", self.DISPATCH_ID) is None
+        conn.close()
         conn.close()

--- a/tests/test_receipt_schema.py
+++ b/tests/test_receipt_schema.py
@@ -234,6 +234,43 @@ def test_receipt_v2_receipt_kind_missing_raises():
 
 
 # ---------------------------------------------------------------------------
+# receipt-quality PR-B2: tool-call signal fields (additive, conditionally
+# stamped like final_prompt_path/verification/warnings — omitted when None)
+# ---------------------------------------------------------------------------
+
+def test_receipt_v2_toolcall_fields_omitted_when_absent():
+    """Minimal kwargs (no toolcall fields passed) stays byte-identical to the
+    pre-PR-B2 shape — proven separately by the roundtrip tests above."""
+    receipt = ReceiptV2(**_v2_kwargs_minimal()).to_dict()
+    for key in ("tool_call_count", "tool_call_failures", "tool_call_retries"):
+        assert key not in receipt
+
+
+def test_receipt_v2_toolcall_fields_stamped_when_provided():
+    kw = _v2_kwargs_minimal()
+    kw["tool_call_count"] = 5
+    kw["tool_call_failures"] = 1
+    kw["tool_call_retries"] = 2
+    receipt = ReceiptV2(**kw).to_dict()
+    assert receipt["tool_call_count"] == 5
+    assert receipt["tool_call_failures"] == 1
+    assert receipt["tool_call_retries"] == 2
+
+
+def test_receipt_v2_toolcall_zero_is_stamped_not_omitted():
+    """0 is a real observation ('confirmed zero'), distinct from None
+    ('no signal log') -- must not be treated as falsy-omit."""
+    kw = _v2_kwargs_minimal()
+    kw["tool_call_count"] = 0
+    kw["tool_call_failures"] = 0
+    kw["tool_call_retries"] = 0
+    receipt = ReceiptV2(**kw).to_dict()
+    assert receipt["tool_call_count"] == 0
+    assert receipt["tool_call_failures"] == 0
+    assert receipt["tool_call_retries"] == 0
+
+
+# ---------------------------------------------------------------------------
 # SynthesizedLaneReceipt round-trip
 # ---------------------------------------------------------------------------
 

--- a/tests/test_receipt_v2_pr_b2_wiring.py
+++ b/tests/test_receipt_v2_pr_b2_wiring.py
@@ -1,0 +1,189 @@
+"""test_receipt_v2_pr_b2_wiring.py — receipt-quality PR-B2 end-to-end wiring tests.
+
+Covers the two _emit_governance (scripts/lib/provider_dispatch.py) changes landed
+in this PR:
+
+  - OI-819 (codex PR-B1 review, Finding 2): the ``session_id`` kwarg passed to
+    ``governance_emit.emit_dispatch_receipt`` now prefers the spawn result's own
+    ``session_id`` over ``args.session_id``/``$VNX_SESSION_ID``.
+  - Tool-call signal aggregation: ``VNX_TMUX_SIGNAL_DIR``'s ``toolcalls.ndjson``
+    (scripts/lib/toolcall_signals.py) is folded into ``tool_call_count`` /
+    ``tool_call_failures`` / ``tool_call_retries`` on the emitted ReceiptV2.
+
+Mirrors tests/test_receipt_v2_pr4_wiring.py's capture-the-real-kwargs pattern
+(patch governance_emit.emit_dispatch_receipt with a side_effect that both
+records and delegates) so these prove the WIRING, not just the pure functions
+already unit-tested in isolation (test_toolcall_signals.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, Dict
+from unittest.mock import patch
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import governance_emit  # noqa: E402
+import provider_dispatch  # noqa: E402
+from toolcall_signals import record_toolcall_event  # noqa: E402
+
+
+def _read_lines(receipts_path: Path) -> list:
+    if not receipts_path.exists():
+        return []
+    return [json.loads(l) for l in receipts_path.read_text().splitlines() if l.strip()]
+
+
+def _run_emit_governance(monkeypatch, tmp_path, *, args, result, provider="claude"):
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path / "state"))
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    (tmp_path / "state").mkdir(exist_ok=True)
+    (tmp_path / "data").mkdir(exist_ok=True)
+
+    captured: Dict[str, Any] = {}
+    real_emit = governance_emit.emit_dispatch_receipt
+
+    def _capture(**kwargs):
+        captured.update(kwargs)
+        return real_emit(**kwargs)
+
+    now = datetime.now(timezone.utc)
+    with patch("governance_emit.emit_dispatch_receipt", side_effect=_capture):
+        provider_dispatch._emit_governance(args, provider, "some-model", result, now, now, "success")
+
+    receipts_path = tmp_path / "state" / "t0_receipts.ndjson"
+    return captured, _read_lines(receipts_path)
+
+
+# ---------------------------------------------------------------------------
+# OI-819 — session_id preference order: result > args > env
+# ---------------------------------------------------------------------------
+
+
+def test_session_id_prefers_result_over_args_and_env(monkeypatch, tmp_path):
+    monkeypatch.setenv("VNX_SESSION_ID", "env-session-loses")
+    args = argparse.Namespace(
+        dispatch_id="b2-sessid-result-wins", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None, session_id="args-session-loses",
+    )
+    result = SimpleNamespace(
+        completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1},
+        session_id="result-session-wins",
+    )
+    captured, _ = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+    assert captured["session_id"] == "result-session-wins"
+
+
+def test_session_id_falls_back_to_args_when_result_has_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("VNX_SESSION_ID", "env-session-loses")
+    args = argparse.Namespace(
+        dispatch_id="b2-sessid-args-wins", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None, session_id="args-session-wins",
+    )
+    # A result object with no session_id concept at all (mirrors _ClaudeResult
+    # in provider_dispatch.py, which carries only completion_text/token_usage).
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+    captured, _ = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+    assert captured["session_id"] == "args-session-wins"
+
+
+def test_session_id_falls_back_to_env_when_result_and_args_have_none(monkeypatch, tmp_path):
+    monkeypatch.setenv("VNX_SESSION_ID", "env-session-wins")
+    args = argparse.Namespace(
+        dispatch_id="b2-sessid-env-wins", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None,
+    )
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+    captured, _ = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+    assert captured["session_id"] == "env-session-wins"
+
+
+def test_session_id_none_when_nothing_set(monkeypatch, tmp_path):
+    monkeypatch.delenv("VNX_SESSION_ID", raising=False)
+    args = argparse.Namespace(
+        dispatch_id="b2-sessid-none", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None,
+    )
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+    captured, _ = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+    assert captured["session_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# Tool-call signal aggregation wiring
+# ---------------------------------------------------------------------------
+
+
+def test_toolcall_signals_aggregated_onto_receipt(monkeypatch, tmp_path):
+    signal_dir = tmp_path / "tmux-signal"
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "claude -p x"}}, blocked=True)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+    monkeypatch.setenv("VNX_TMUX_SIGNAL_DIR", str(signal_dir))
+
+    args = argparse.Namespace(
+        dispatch_id="b2-toolcalls-present", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None,
+    )
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+
+    captured, lines = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+
+    assert captured["tool_call_count"] == 4
+    assert captured["tool_call_failures"] == 1
+    assert captured["tool_call_retries"] == 1
+    line = lines[-1]
+    assert line["tool_call_count"] == 4
+    assert line["tool_call_failures"] == 1
+    assert line["tool_call_retries"] == 1
+
+
+def test_toolcall_signals_absent_when_signal_dir_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("VNX_TMUX_SIGNAL_DIR", raising=False)
+
+    args = argparse.Namespace(
+        dispatch_id="b2-toolcalls-absent", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None,
+    )
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+
+    captured, lines = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+
+    assert captured["tool_call_count"] is None
+    assert captured["tool_call_failures"] is None
+    assert captured["tool_call_retries"] is None
+    line = lines[-1]
+    assert "tool_call_count" not in line
+    assert "tool_call_failures" not in line
+    assert "tool_call_retries" not in line
+
+
+def test_toolcall_signals_absent_when_signal_dir_empty(monkeypatch, tmp_path):
+    """VNX_TMUX_SIGNAL_DIR set but no toolcalls.ndjson written -> still None,
+    never a crash, never a fabricated zero."""
+    signal_dir = tmp_path / "tmux-signal-empty"
+    signal_dir.mkdir()
+    monkeypatch.setenv("VNX_TMUX_SIGNAL_DIR", str(signal_dir))
+
+    args = argparse.Namespace(
+        dispatch_id="b2-toolcalls-empty-dir", terminal_id="T1", instruction="do thing",
+        pr_id=None, mandate_id=None,
+    )
+    result = SimpleNamespace(completion_text="done", token_usage={"input_tokens": 1, "output_tokens": 1})
+
+    captured, _ = _run_emit_governance(monkeypatch, tmp_path, args=args, result=result)
+
+    assert captured["tool_call_count"] is None

--- a/tests/test_toolcall_signals.py
+++ b/tests/test_toolcall_signals.py
@@ -1,0 +1,113 @@
+"""test_toolcall_signals.py — receipt-quality PR-B2 tool-call signal tests.
+
+Covers the record+aggregate round-trip (scripts/lib/toolcall_signals.py): the
+per-dispatch NDJSON log a PreToolUse hook writes to, and the aggregation
+governance_emit/_emit_governance folds into ReceiptV2.tool_call_count /
+tool_call_failures / tool_call_retries.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+from toolcall_signals import aggregate_toolcall_signals, record_toolcall_event  # noqa: E402
+
+
+def test_aggregate_missing_signal_dir_returns_none(tmp_path):
+    assert aggregate_toolcall_signals(tmp_path / "does-not-exist") is None
+
+
+def test_aggregate_empty_signal_file_returns_none(tmp_path):
+    (tmp_path / "toolcalls.ndjson").write_text("", encoding="utf-8")
+    assert aggregate_toolcall_signals(tmp_path) is None
+
+
+def test_record_then_aggregate_counts_total_calls(tmp_path):
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "pwd"}}, blocked=False)
+    record_toolcall_event(tmp_path, {"tool_name": "Task", "tool_input": {"prompt": "x"}}, blocked=True)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    assert signals == {"tool_call_count": 3, "tool_call_failures": 1, "tool_call_retries": 0}
+
+
+def test_blocked_call_counted_as_failure(tmp_path):
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "claude -p x"}}, blocked=True)
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    assert signals["tool_call_count"] == 2
+    assert signals["tool_call_failures"] == 1
+
+
+def test_repeated_identical_call_counts_as_retry(tmp_path):
+    payload = {"tool_name": "Bash", "tool_input": {"command": "pytest tests/foo.py"}}
+    record_toolcall_event(tmp_path, payload, blocked=False)
+    record_toolcall_event(tmp_path, payload, blocked=False)
+    record_toolcall_event(tmp_path, payload, blocked=False)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    assert signals["tool_call_count"] == 3
+    # 3 identical (tool_name, signature) occurrences -> 2 retries (first is the original call).
+    assert signals["tool_call_retries"] == 2
+
+
+def test_same_tool_different_input_is_not_a_retry(tmp_path):
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "ls a"}}, blocked=False)
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "ls b"}}, blocked=False)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    assert signals["tool_call_count"] == 2
+    assert signals["tool_call_retries"] == 0
+
+
+def test_key_order_independent_input_is_a_retry_match(tmp_path):
+    """Equivalent dict key ordering must not spuriously break a retry match."""
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"a": 1, "b": 2}}, blocked=False)
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"b": 2, "a": 1}}, blocked=False)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    assert signals["tool_call_count"] == 2
+    assert signals["tool_call_retries"] == 1
+
+
+def test_malformed_line_is_skipped_not_fatal(tmp_path):
+    path = tmp_path / "toolcalls.ndjson"
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {}}, blocked=False)
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write("not valid json\n")
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {}}, blocked=False)
+
+    signals = aggregate_toolcall_signals(tmp_path)
+    # Two well-formed lines with identical input -> 1 retry; the garbage line
+    # in between is silently skipped rather than aborting aggregation.
+    assert signals["tool_call_count"] == 2
+    assert signals["tool_call_retries"] == 1
+
+
+def test_record_creates_signal_dir_when_absent(tmp_path):
+    signal_dir = tmp_path / "nested" / "scratch"
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {}}, blocked=False)
+    assert (signal_dir / "toolcalls.ndjson").is_file()
+
+
+def test_record_never_raises_on_unwritable_dir(tmp_path):
+    """A file where a directory is expected must not raise -- record is
+    called from a hook context where a failure must never break the tool call."""
+    blocked_path = tmp_path / "not-a-dir"
+    blocked_path.write_text("x", encoding="utf-8")
+    record_toolcall_event(blocked_path, {"tool_name": "Bash", "tool_input": {}}, blocked=False)  # must not raise
+
+
+def test_recorded_entry_shape(tmp_path):
+    record_toolcall_event(tmp_path, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=True)
+    line = (tmp_path / "toolcalls.ndjson").read_text(encoding="utf-8").strip()
+    entry = json.loads(line)
+    assert entry["tool_name"] == "Bash"
+    assert entry["blocked"] is True
+    assert "signature" in entry
+    assert "timestamp" in entry

--- a/tests/test_toolcall_signals_tmux_lane_wiring.py
+++ b/tests/test_toolcall_signals_tmux_lane_wiring.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""test_toolcall_signals_tmux_lane_wiring.py — receipt-quality PR-B2 fix-forward (Finding C).
+
+Codex gate (PR #1235) flagged that PreToolUse hooks write tool-call signals
+into $VNX_TMUX_SIGNAL_DIR on every tmux-interactive dispatch, but nothing
+ever aggregated them for the receipt THAT lane actually writes: the
+worker-authored completion receipt (event_type=subprocess_completion),
+appended directly via scripts/append_receipt.py -- the exact command the
+tmux lane's Completion Protocol footer instructs every worker to run at the
+end of its dispatch. Only the provider/subprocess lanes' ReceiptV2 path
+(governance_emit.emit_dispatch_receipt) aggregated signals before this fix;
+the tmux lane's own receipt (append_receipt_payload / Path 2, enriched by
+append_receipt_internals.enrichment._enrich_completion_receipt) never did,
+so the feature was inert on its primary (and today only) signal-producing
+lane.
+
+Mirrors tests/test_append_receipt.py's real-subprocess pattern (invokes the
+actual append_receipt.py CLI, not a mock) so this proves the WIRING through
+the real enrichment pipeline, not just the pure aggregator already unit-
+tested in isolation (tests/test_toolcall_signals.py).
+
+Sibling coverage: tests/test_receipt_v2_pr_b2_wiring.py (provider_dispatch
+lane), tests/test_dispatch_envelope.py (dispatch_envelope._govern, the
+subprocess/claude-adapter lane).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+APPEND_SCRIPT = SCRIPTS_DIR / "append_receipt.py"
+
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from toolcall_signals import record_toolcall_event  # noqa: E402
+
+
+def _build_env(tmp_path: Path, *, signal_dir: "Optional[Path]" = None) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    env["PROJECT_ROOT"] = str(tmp_path)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    env["VNX_STATE_DIR"] = str(state_dir)
+    env["VNX_HOME"] = str(VNX_ROOT)
+    if signal_dir is not None:
+        env["VNX_TMUX_SIGNAL_DIR"] = str(signal_dir)
+    else:
+        env.pop("VNX_TMUX_SIGNAL_DIR", None)
+    return env
+
+
+def _run_append(payload: str, env: dict) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(APPEND_SCRIPT)],
+        input=payload,
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+def _build_completion_receipt(dispatch_id: str) -> dict:
+    """Mirrors the tmux lane's Completion Protocol footer payload shape --
+    the worker-authored receipt every tmux-spawn dispatch appends directly
+    via append_receipt.py at the end of its run."""
+    return {
+        "event_type": "subprocess_completion",
+        "receipt_kind": "dispatch",
+        "dispatch_id": dispatch_id,
+        "terminal": "T1",
+        "terminal_id": "T1",
+        "status": "done",
+        "source": "tmux_interactive",
+        "timestamp": "2026-07-28T10:00:00Z",
+        "provider": "claude",
+        "sub_provider": "anthropic",
+        "model": "sonnet",
+        "lane": "tmux_interactive",
+    }
+
+
+def _last_receipt(tmp_path: Path) -> dict:
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    lines = receipts_file.read_text(encoding="utf-8").strip().splitlines()
+    return json.loads(lines[-1])
+
+
+def test_tmux_lane_completion_receipt_carries_toolcall_signals(tmp_path: Path):
+    signal_dir = tmp_path / "tmux-signal"
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "claude -p x"}}, blocked=True)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "pytest"}}, blocked=False)
+
+    env = _build_env(tmp_path, signal_dir=signal_dir)
+    receipt = _build_completion_receipt("b2fix-tmux-toolcalls-present")
+
+    result = _run_append(json.dumps(receipt), env)
+    assert result.returncode == 0, result.stderr
+
+    stored = _last_receipt(tmp_path)
+    assert stored["tool_call_count"] == 4
+    assert stored["tool_call_failures"] == 1
+    assert stored["tool_call_retries"] == 1
+
+
+def test_tmux_lane_completion_receipt_omits_signals_when_dir_unset(tmp_path: Path):
+    env = _build_env(tmp_path, signal_dir=None)
+    receipt = _build_completion_receipt("b2fix-tmux-toolcalls-absent")
+
+    result = _run_append(json.dumps(receipt), env)
+    assert result.returncode == 0, result.stderr
+
+    stored = _last_receipt(tmp_path)
+    assert "tool_call_count" not in stored
+    assert "tool_call_failures" not in stored
+    assert "tool_call_retries" not in stored
+
+
+def test_tmux_lane_completion_receipt_omits_signals_when_dir_empty(tmp_path: Path):
+    """VNX_TMUX_SIGNAL_DIR set but no toolcalls.ndjson written yet (e.g. a
+    worker whose dispatch made no Bash/Task tool calls before completing) --
+    still None, never a crash, never a fabricated zero."""
+    signal_dir = tmp_path / "tmux-signal-empty"
+    signal_dir.mkdir()
+    env = _build_env(tmp_path, signal_dir=signal_dir)
+    receipt = _build_completion_receipt("b2fix-tmux-toolcalls-empty-dir")
+
+    result = _run_append(json.dumps(receipt), env)
+    assert result.returncode == 0, result.stderr
+
+    stored = _last_receipt(tmp_path)
+    assert "tool_call_count" not in stored
+
+
+def test_tmux_lane_completion_receipt_never_overwrites_caller_supplied_signals(tmp_path: Path):
+    """setdefault contract: a receipt that already carries tool_call_count
+    (e.g. a replay/backfill receipt) is never overwritten by aggregation."""
+    signal_dir = tmp_path / "tmux-signal-conflict"
+    record_toolcall_event(signal_dir, {"tool_name": "Bash", "tool_input": {"command": "ls"}}, blocked=False)
+
+    env = _build_env(tmp_path, signal_dir=signal_dir)
+    receipt = _build_completion_receipt("b2fix-tmux-toolcalls-preset")
+    receipt["tool_call_count"] = 99
+
+    result = _run_append(json.dumps(receipt), env)
+    assert result.returncode == 0, result.stderr
+
+    stored = _last_receipt(tmp_path)
+    assert stored["tool_call_count"] == 99


### PR DESCRIPTION
## Summary

Track `receipt-quality`, Phase B PR-B2. Two additive observability signals plus
one small follow-up fix from the PR-B1 codex review, per the dispatch spec.

- **Tool-call signals**: the two existing PreToolUse hooks
  (`pretooluse_block_raw_claude_spawn.sh` for Bash, `pretooluse_block_subagent.sh`
  for Task — both already wired in `.claude/settings.json`, unchanged there) now
  append a signal line per invocation to `$VNX_TMUX_SIGNAL_DIR/toolcalls.ndjson`
  via a new `scripts/lib/toolcall_signals.py`. `provider_dispatch._emit_governance`
  aggregates that log (`tool_call_count`/`tool_call_failures`/`tool_call_retries`)
  and threads it through `governance_emit.emit_dispatch_receipt` into three new,
  conditionally-stamped `ReceiptV2` fields.
- **dispatch→PR column**: `reconcile_commit_provenance` (`scripts/lib/receipt_provenance.py`)
  already scans git commits for `Dispatch-ID:`+`(#NNN)` pairs and fills
  `tracks.pr_ref`. It now ALSO fill-once-stamps the dormant
  `dispatch_metadata.pr_id` (quality_intelligence.db) for the same pair — a
  different database, independent of whether the dispatch has a track.
- **parent_dispatch**: already has a dedicated, tested attribution engine
  (`scripts/lib/rework_attribution.py` + `scripts/attribute_rework.py`, git-blame
  based). Left untouched — re-implementing it would duplicate working code.
- **OI-819 fix (codex PR-B1 review, Finding 2)**: `_emit_governance`'s
  `session_id` kwarg now prefers `result.session_id` over
  `args.session_id`/`$VNX_SESSION_ID`, matching `dispatch_envelope.py`'s
  existing precedent.

## Changes

- `scripts/lib/toolcall_signals.py` (new) — record/aggregate NDJSON tool-call signal log.
- `scripts/hooks/pretooluse_block_raw_claude_spawn.sh`, `scripts/hooks/pretooluse_block_subagent.sh` — append a signal line after their existing block/allow decision (no `.claude/settings.json` change needed — both hooks were already registered).
- `scripts/lib/receipt_schema.py` — `ReceiptV2` gains `tool_call_count`/`tool_call_failures`/`tool_call_retries` (conditionally stamped, omitted when `None`).
- `scripts/lib/governance_emit.py` — `emit_dispatch_receipt` accepts and threads the three new kwargs.
- `scripts/lib/provider_dispatch.py` — `_emit_governance` aggregates the signal log (fail-open) and fixes the `session_id` precedence (OI-819).
- `scripts/lib/receipt_provenance.py` — `reconcile_commit_provenance` also opens `quality_intelligence.db` and fill-once-stamps `dispatch_metadata.pr_id` via new helpers `_resolve_dispatch_project_id`/`_link_pr_to_dispatch_metadata`.
- Tests: `tests/test_toolcall_signals.py` (new, 11 tests), `tests/test_receipt_v2_pr_b2_wiring.py` (new, 7 tests), extended `tests/test_receipt_schema.py` (+3), extended `tests/test_receipt_provenance.py` (+6).

## Verification

Targeted tests only (per dispatch instruction — CI runs the full suite):

```
python3 -m pytest tests/test_toolcall_signals.py tests/test_receipt_schema.py \
  tests/test_receipt_v2_pr_b2_wiring.py tests/test_receipt_v2_pr4_wiring.py \
  tests/test_receipt_provenance.py tests/test_governance_emit.py \
  tests/test_governance_emit_schema.py tests/test_provenance_registry_population.py \
  tests/test_token_harvest.py -q
```
Result: 199 passed, 3 failed — the 3 failures (`TestEnrichReceiptProvenance::test_handles_receipt_with_no_dispatch_id`,
`TestValidateReceiptProvenance::test_detects_missing_dispatch_id`,
`TestValidateReceiptProvenance::test_broken_chain_no_dispatch_no_git`) are
pre-existing on `origin/main` (verified via `git stash` before/after — identical
failures on the unmodified base commit), unrelated to this PR.

Also ran the broader `test_provider_dispatch_governance_integration.py` /
`test_provider_dispatch_deepseek_harness.py` / `test_wave7_fixes.py` suites and
confirmed the same failure counts pre-exist on base `origin/main` (kimi model-registry
and `MagicMock` JSON-serialization issues, unrelated to this change).

`bash -n` clean on both modified hook scripts.

## Open Items

- The tmux-interactive lane (the lane this very worker runs on) writes its receipt
  via `report_to_receipt_converter.py`, which builds a raw dict, NOT `ReceiptV2` —
  so today's dominant claude/sonnet lane will not show `tool_call_count` etc. on
  its own receipts yet. The signal-collection side (hooks + `VNX_TMUX_SIGNAL_DIR`)
  works for that lane today; the aggregation sink is deliberately restricted to the
  officially codified `ReceiptV2` contract per the dispatch's "do not bypass the
  contract" instruction. Closing this gap requires migrating that converter onto
  `ReceiptV2`, which is a separate, larger change — flagging for a future PR rather
  than scope-creeping it into B2.
- `VNX_TMUX_SIGNAL_DIR` is only exported into the tmux-spawn pane environment
  today; `provider_dispatch.py`-driven lanes (codex/kimi/gemini/deepseek-harness/
  glm-harness) don't set it, so their receipts will also show the new fields as
  `None` until/unless that env var is threaded into their subprocess spawns too.
- `reconcile_commit_provenance` / `scripts/reconcile_provenance.py` is not on an
  automatic schedule in this repo (invoked via `objective_reconcile.py` and
  ad-hoc); the `pr_id` backfill only fires when that reconciliation runs.

Dispatch-ID: 20260728-rq-b2-toolsignals-metadata-sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)