### PR TITLE
fix(panel-reliability): OI-809/810/811 deliberation-panel reliability

### DIFF
--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -124,11 +124,28 @@ class DeliberationResult:
     contrarian: str = ""
     factcheck: str = ""
     synthesis: str = ""
+    # Coverage bookkeeping (OI-810): which lenses actually produced a real report vs
+    # silently degraded. Populated by run_deliberation right after the fan-out completes.
+    present_lenses: List[str] = field(default_factory=list)
+    failed_seats: List[Dict[str, str]] = field(default_factory=list)  # {provider, lens}
+
+    @property
+    def coverage(self) -> str:
+        """Human-readable coverage summary, e.g. "3/5 lenses present; glm-harness
+        (alternative-approaches lens) failed". A dead seat must never be rendered as if
+        it silently contributed to the panel (OI-810) — this is the explicit signal."""
+        total = len(self.fan_out)
+        present = len(self.present_lenses)
+        if not self.failed_seats:
+            return f"{present}/{total} lenses present"
+        failed = ", ".join(f"{s['provider']} ({s['lens']})" for s in self.failed_seats)
+        return f"{present}/{total} lenses present; {failed} failed"
 
     def to_report(self) -> str:
         lines = [
             f"# Deliberation panel — {self.mode}",
             f"\n**Question:** {self.question}\n",
+            f"**Coverage:** {self.coverage}\n",
             "## Synthesis (cited)\n",
             self.synthesis or "_(no synthesis)_",
             "\n---\n## Contrarian / red-team\n",
@@ -138,7 +155,8 @@ class DeliberationResult:
             "\n---\n## Divergent views (fan-out)\n",
         ]
         for fo in self.fan_out:
-            lines.append(f"\n### {fo['provider']} — lens: {fo['lens']}\n")
+            failed_tag = " — **[SEAT FAILED — no report]**" if _is_error(fo["text"]) else ""
+            lines.append(f"\n### {fo['provider']} — lens: {fo['lens']}{failed_tag}\n")
             lines.append(fo["text"] or "_(empty)_")
         return "\n".join(lines)
 
@@ -180,6 +198,54 @@ def _digest(fan_out: List[Dict[str, str]], limit: int = _REPORT_BACKSTOP) -> str
         text = _clip(text, fo.get("provider", "?"), limit)
         parts.append(f"[{fo['provider']} / {fo['lens']}]\n{text}")
     return "\n\n".join(parts)
+
+
+# Per-hop budget for carrying an EARLIER stage's already-substantial output INTO a LATER
+# stage's prompt (OI-809). Distinct from _REPORT_BACKSTOP: that bounds one seat's raw
+# report once, generously, against a pathological runaway. This bounds what gets
+# RE-EMBEDDED at every downstream stage transition. Without it, the full fan-out digest
+# (up to 5 seats x _REPORT_BACKSTOP each) plus the contrarian output plus the verify
+# output all get re-embedded VERBATIM into the synthesis prompt — ~85% duplicated
+# material, observed live as 2216- and 3751-line prompts — until a fixed-length cut
+# (here or downstream in the dispatch lane) trims the prompt mid-sentence BEFORE the
+# stage instruction, so the seat receives corrupted context with its task missing.
+_DISTILLATE_BUDGET = int(os.environ.get("VNX_PANEL_DISTILLATE_BUDGET", "6000"))
+
+
+def _distill(text: str, tag: str, limit: int = _DISTILLATE_BUDGET) -> str:
+    """Bound prior-stage material before a downstream stage's prompt carries it forward.
+
+    Applied at every stage transition (diverge->contrarian->verify->synthesis) so the
+    prompt stays bounded regardless of how many hops a piece of text has already passed
+    through — the cascading-verbatim growth is exactly the OI-809 bug. Trimming is always
+    logged loudly, never silent (same discipline as _clip)."""
+    t = (text or "").strip()
+    if len(t) <= limit:
+        return t
+    logger.warning(
+        "panel distillate: %s trimmed to %d chars for the downstream stage (was %d) — "
+        "raise VNX_PANEL_DISTILLATE_BUDGET if this loses signal",
+        tag, limit, len(t),
+    )
+    return t[:limit] + f"\n…[{tag} truncated to fit the downstream-stage budget]"
+
+
+def _stage_prompt(instruction: str, context_sections: List[Tuple[str, str]], reminder: str) -> str:
+    """Assemble a downstream-stage prompt with the INSTRUCTION FIRST and the (already
+    distilled/bounded) prior-stage context AFTER.
+
+    A fixed-length truncation applied anywhere downstream of this function — this
+    module's own backstop or the dispatch lane's — can then only ever cut into the
+    context tail, never the instruction the seat must follow. The old layout embedded
+    the instruction LAST, after the full verbatim prior-stage material, so a truncation
+    upstream of the seat cut the instruction away entirely and the seat received corrupt
+    context with no task (OI-809). The trailing reminder is a resilience bonus, never
+    load-bearing, since the real instruction already led."""
+    parts = [instruction]
+    for label, text in context_sections:
+        parts.append(f"\n--- {label} ---\n{text}\n--- END {label} ---")
+    parts.append(f"\n{reminder}")
+    return "\n".join(parts)
 
 
 def run_deliberation(
@@ -225,16 +291,42 @@ def run_deliberation(
     order = {p: i for i, (p, _) in enumerate(roster)}
     result.fan_out.sort(key=lambda fo: order.get(fo["provider"], 99))
 
-    digest = _digest(result.fan_out)
+    # Coverage bookkeeping (OI-810): a failed/empty seat must never silently look like a
+    # contributing lens. Exclude it from what downstream stages see, and record it so the
+    # result/report say so explicitly.
+    present_fan_out = [fo for fo in result.fan_out if not _is_error(fo["text"])]
+    failed_fan_out = [fo for fo in result.fan_out if _is_error(fo["text"])]
+    result.present_lenses = [fo["lens"] for fo in present_fan_out]
+    result.failed_seats = [{"provider": fo["provider"], "lens": fo["lens"]} for fo in failed_fan_out]
+    if failed_fan_out:
+        logger.warning(
+            "panel: %d/%d seats produced no usable report (%s) — %s",
+            len(failed_fan_out), len(result.fan_out),
+            ", ".join(f"{fo['provider']} ({fo['lens']})" for fo in failed_fan_out),
+            result.coverage,
+        )
+
+    digest = _digest(present_fan_out)
+    coverage_note = (
+        f"PANEL COVERAGE: {result.coverage}. Reason only from the lenses that actually "
+        "responded — a failed seat contributed NOTHING; do not assume its perspective is "
+        "represented.\n"
+    ) if failed_fan_out else ""
 
     # ── Stage 2: CONTRARIAN (one red-team seat — the strongest reasoner) ──────
-    contra_prompt = (
+    # Instruction FIRST, bounded distillate of stage 1 AFTER (OI-809) — a downstream
+    # truncation can then only cut into the (already bounded) context, never the task.
+    contra_instruction = (
         f"You are the RED TEAM on a deliberation panel ({spec.description}).\n"
-        f"QUESTION: {question}\n{ctx_block}\n"
-        f"The panel said:\n{digest}\n\n"
-        f"Attack the emerging consensus. Focus on: {spec.contrarian_focus}. "
+        f"QUESTION: {question}\n{ctx_block}\n{coverage_note}"
+        f"Attack the emerging consensus below. Focus on: {spec.contrarian_focus}. "
         "Name what everyone MISSED, steelman the dissent, and flag any claim stated as fact "
         "without evidence. Do not be agreeable. Terse, concrete."
+    )
+    contra_prompt = _stage_prompt(
+        contra_instruction,
+        [("The panel said (fan-out digest, distilled)", _distill(digest, "fan-out digest"))],
+        reminder=f"Reminder: attack the consensus above. Focus: {spec.contrarian_focus}.",
     )
     result.contrarian = _first_ok(
         dispatcher, _ordered_seats(roster, ("codex", "deepseek-harness", "claude")),
@@ -242,13 +334,21 @@ def run_deliberation(
     )
 
     # ── Stage 3: VERIFY (adversarial factcheck of the top claims) ────────────
-    verify_prompt = (
+    verify_instruction = (
         f"You are the VERIFY pass on a deliberation panel ({spec.description}).\n"
-        f"QUESTION: {question}\n{ctx_block}\n"
-        f"Panel findings:\n{digest}\n\nRed-team:\n{_clip(result.contrarian, 'contrarian')}\n\n"
-        f"Take the TOP 5 concrete claims across the above and adversarially verify each against "
-        f"{spec.verify_target}. Mark each: CONFIRMED / REFUTED / UNVERIFIABLE, with the specific "
-        "evidence (file:line or source). Default to REFUTED/UNVERIFIABLE when evidence is thin."
+        f"QUESTION: {question}\n{ctx_block}\n{coverage_note}"
+        "Take the TOP 5 concrete claims across the panel findings and red-team output below "
+        f"and adversarially verify each against {spec.verify_target}. Mark each: CONFIRMED / "
+        "REFUTED / UNVERIFIABLE, with the specific evidence (file:line or source). Default to "
+        "REFUTED/UNVERIFIABLE when evidence is thin."
+    )
+    verify_prompt = _stage_prompt(
+        verify_instruction,
+        [
+            ("Panel findings", _distill(digest, "fan-out digest")),
+            ("Red-team", _distill(result.contrarian, "contrarian")),
+        ],
+        reminder=f"Reminder: verify the TOP 5 claims above against {spec.verify_target}.",
     )
     result.factcheck = _first_ok(
         dispatcher, _ordered_seats(roster, ("codex", "kimi", "claude")),
@@ -256,14 +356,21 @@ def run_deliberation(
     )
 
     # ── Stage 4: SYNTHESIS (one cited report) ────────────────────────────────
-    synth_prompt = (
+    synth_instruction = (
         f"You are the SYNTHESISER on a deliberation panel ({spec.description}).\n"
-        f"QUESTION: {question}\n{ctx_block}\n"
-        f"Divergent views:\n{digest}\n\nRed-team:\n{_clip(result.contrarian, 'contrarian')}\n\n"
-        f"Verification:\n{_clip(result.factcheck, 'verify')}\n\n"
+        f"QUESTION: {question}\n{ctx_block}\n{coverage_note}"
         f"Produce {spec.synth_goal}. Structure: CONSENSUS (verified), CONTESTED (surviving "
         "dissent), VERIFIED CLAIMS (ranked, with evidence), OPEN QUESTIONS. Dedupe. Cite "
         "file:line / sources. Do not invent agreement that isn't there."
+    )
+    synth_prompt = _stage_prompt(
+        synth_instruction,
+        [
+            ("Divergent views", _distill(digest, "fan-out digest")),
+            ("Red-team", _distill(result.contrarian, "contrarian")),
+            ("Verification", _distill(result.factcheck, "verify")),
+        ],
+        reminder=f"Reminder: produce {spec.synth_goal}. Do not invent agreement that isn't there.",
     )
     result.synthesis = _first_ok(
         dispatcher, _ordered_seats(roster, ("claude", "codex", "kimi")),

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -54,6 +54,18 @@ _FAKE_DEFAULT_ROLE = "backend-developer"
 # backend-developer default (receipt-quality track).
 _IDENTITY_UNRESOLVED = "identity_unresolved"
 
+# The plan-gate's own role — a worker report ending in a ```vnx-plan-verdict``` fence.
+_PLAN_REVIEWER_ROLE = "plan-reviewer"
+
+# Roles whose worker output is a free-form review/analysis, never a standard
+# ## Changes / ## Verification report — govern() must not run the report-body contract
+# over these, nor synthesize over an authored body (synthesis summarizes a git diff;
+# these roles produce no diff by design). "plan-reviewer" additionally requires the
+# vnx-plan-verdict fence (see _govern_impl); other freeform roles just require non-empty
+# authored text. "deliberation-panelist" is the vnx panel's diverge/contrarian/verify/
+# synthesis stage worker (OI-811) — free-form panel analysis, no verdict fence.
+_FREEFORM_ROLES = frozenset({_PLAN_REVIEWER_ROLE, "deliberation-panelist"})
+
 
 def _resolve_govern_role(spec: "GovernSpec") -> str:
     """Resolve the dispatch's real role for govern-emitted receipts/frontmatter.
@@ -435,7 +447,7 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
             # trigger synthesis, which strips the fence and breaks parse_verdict in the
             # plan-gate panel.  Accept the report as authored when it is non-empty and
             # contains the verdict fence opener; do not overwrite it with a git-diff body.
-            if spec.role == "plan-reviewer":
+            if spec.role == _PLAN_REVIEWER_ROLE:
                 _verdict_marker = "```vnx-plan-verdict"
                 if candidate.strip() and _verdict_marker in candidate:
                     body = candidate
@@ -450,6 +462,25 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
                         "govern: plan-reviewer report exists but has no verdict fence for"
                         " dispatch=%s — synthesizing (parse_error will surface to panel)",
                         dispatch_id,
+                    )
+            elif spec.role in _FREEFORM_ROLES:
+                # e.g. deliberation-panelist (OI-811): the diverge/contrarian/verify/
+                # synthesis stage worker writes free-form panel analysis — no
+                # ## Changes/## Verification headings, and no plan-verdict fence either.
+                # Accept any non-empty authored text as-is.
+                if candidate.strip():
+                    body = candidate
+                    contract_status = "authored"
+                    logger.info(
+                        "govern: %s report accepted as authored for dispatch=%s"
+                        " (free-form role, standard contract validation skipped)",
+                        spec.role, dispatch_id,
+                    )
+                else:
+                    logger.info(
+                        "govern: %s report exists but is empty for dispatch=%s —"
+                        " synthesizing",
+                        spec.role, dispatch_id,
                     )
             else:
                 bv = validate_body(candidate, pr_id=spec.pr_id)
@@ -472,12 +503,13 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         contract_status = "synthesized"
 
     # -- c. Validate final body — applies to BOTH authored and synthesized ----
-    # plan-reviewer authored bodies skip standard contract validation: the reviewer
-    # writes a free-form analysis + verdict fence, not a ## Changes / ## Verification
-    # report.  Applying validate_body would always flag it as "violated" and (under
-    # enforce mode) block the emit.  Since the fence check already ran in step (a),
-    # accept the authored body as-is and skip the heading scan entirely.
-    if spec.role == "plan-reviewer" and contract_status == "authored":
+    # plan-reviewer (and other freeform-role, e.g. deliberation-panelist) authored
+    # bodies skip standard contract validation: the worker writes a free-form
+    # analysis, not a ## Changes / ## Verification report.  Applying validate_body
+    # would always flag it as "violated" and (under enforce mode) block the emit.
+    # Since the freeform check already ran in step (a), accept the authored body
+    # as-is and skip the heading scan entirely.
+    if spec.role in _FREEFORM_ROLES and contract_status == "authored":
         final_bv = None  # type: ignore[assignment]
     else:
         final_bv = validate_body(body, pr_id=spec.pr_id)

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -50,7 +50,13 @@ _LOG = logging.getLogger(__name__)
 
 # SSOT for review roles — kept in sync with the kimi-routing predicate (item C). A reviewer's
 # job is a verdict, not a diff, so it is never a phantom for "no changes".
-REVIEW_ROLES = frozenset({"plan-reviewer", "code-reviewer", "security-reviewer", "reviewer"})
+# "deliberation-panelist" (OI-811, the vnx panel's diverge/contrarian/verify/synthesis
+# stage worker) belongs here for the same reason: it produces analysis/prose, not a code
+# diff, so an empty worktree diff is expected, never evidence of fabrication.
+REVIEW_ROLES = frozenset({
+    "plan-reviewer", "code-reviewer", "security-reviewer", "reviewer",
+    "deliberation-panelist",
+})
 
 # SSOT for review/analysis task_class values — a second key onto the same exemption for callers
 # that route by task_class rather than a REVIEW_ROLES-matching role string. "research_structured"

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -164,6 +164,29 @@ def build_plan_review_instruction_fileref(
     )
 
 
+def build_generic_fileref_instruction(doc_path: str, report_path: str) -> str:
+    """Render a generic (NON-plan-review) file-ref instruction for the claude/tmux lane.
+
+    OI-811: ``_make_default_dispatcher`` is reused by callers whose instruction is NOT a
+    plan review — e.g. the deliberation panel's diverge/contrarian/verify/synthesis
+    stages. Wrapping their prompt in ``build_plan_review_instruction_fileref`` (which
+    tells the worker "you are an independent plan reviewer... review the IMPLEMENTATION
+    PLAN") caused a plan-reviewer-role worker to correctly reject the file as not a plan,
+    corrupting the panel stage. This variant carries the file-ref benefit (short
+    instruction string, avoids the bracketed-paste ingestion timeout on a large prompt)
+    WITHOUT the plan-review framing — the worker is simply told to follow the referenced
+    instruction and write its response to ``report_path``.
+    """
+    return (
+        f"Read your complete instruction from this file:\n\n"
+        f"  {doc_path}\n\n"
+        "Follow it in full.\n\n"
+        f"REPORT FILE (MANDATORY): Write your complete response to this exact file path:\n\n"
+        f"  {report_path}\n\n"
+        "Do NOT write to any other path. The caller reads only that file."
+    )
+
+
 def _strip_trailing_commas(text: str) -> str:
     """Remove a trailing comma immediately before a closing ``}``/``]`` (a recurring
     codex/glm flake: ``{"a": 1,}``)."""
@@ -416,6 +439,7 @@ def _resolve_data_dir(data_dir: Optional[str]) -> Path:
 
 def _make_default_dispatcher(
     data_dir: Optional[str], timeout_seconds: int,
+    *, role: str = "plan-reviewer",
 ) -> DispatcherFn:
     """Real dispatcher: run a panelist through its governed lane, return the report text.
 
@@ -428,6 +452,13 @@ def _make_default_dispatcher(
                            NOT provider_dispatch (refuses claude), NOT headless `claude -p`
                            (bills API credits post-cutover).
       kimi/glm/deepseek -> provider_dispatch (constraint-safe per provider).
+
+    ``role``: OI-811 — this factory is reused by callers whose instruction is NOT a plan
+    review (e.g. the deliberation panel's diverge/contrarian/verify/synthesis stages).
+    Defaults to "plan-reviewer" for backward compatibility with ``run_panel``. A caller
+    with a different role gets the generic (non-plan-framed) file-ref instruction on the
+    claude/tmux lane, and that role is stamped on both lanes' ``--role`` so govern() and
+    the phantom-guard evaluate it correctly instead of being told it is a plan review.
     """
     base = _resolve_data_dir(data_dir)
 
@@ -470,18 +501,26 @@ def _make_default_dispatcher(
                     _tmp_doc_path = fh.name
 
                 # Short instruction: rubric + verdict contract + explicit report-path directive.
-                # No 50k doc body — the worker reads it from _tmp_doc_path.
-                claude_instruction = build_plan_review_instruction_fileref(
-                    doc_path=_tmp_doc_path,
-                    track_id="<see file>",
-                    report_path=report_path_str,
-                )
+                # No 50k doc body — the worker reads it from _tmp_doc_path. A non-plan-review
+                # caller (OI-811) gets the generic file-ref framing instead — never told it is
+                # reviewing an IMPLEMENTATION PLAN.
+                if role == "plan-reviewer":
+                    claude_instruction = build_plan_review_instruction_fileref(
+                        doc_path=_tmp_doc_path,
+                        track_id="<see file>",
+                        report_path=report_path_str,
+                    )
+                else:
+                    claude_instruction = build_generic_fileref_instruction(
+                        doc_path=_tmp_doc_path,
+                        report_path=report_path_str,
+                    )
 
                 cmd = [
                     sys.executable, str(TMUX_INTERACTIVE_DISPATCH),
                     "--dispatch-id", dispatch_id,
                     "--model", model_arg,
-                    "--role", "plan-reviewer",
+                    "--role", role,
                     "--instruction", claude_instruction,
                     "--deadline-seconds", str(timeout_seconds),
                     # A plan review is READ-ONLY (reads the doc file, writes a verdict report) —
@@ -506,7 +545,7 @@ def _make_default_dispatcher(
                     "--terminal-id", "plan-gate",
                     "--dispatch-id", dispatch_id,
                     "--model", model_arg,
-                    "--role", "plan-reviewer",
+                    "--role", role,
                     "--instruction", instruction,
                     "--no-auto-commit",
                 ]

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -83,7 +83,13 @@ def main(argv: "list[str] | None" = None) -> int:
     # → no cited synthesis (sales-copilot T0, 2026-07-10). unified_reports_dir().parent IS
     # that data_dir, so the write-path and read-path agree.
     data_dir = str(_resolve_reports_dir().parent)
-    dispatcher = _make_default_dispatcher(data_dir, args.timeout)
+    # role="deliberation-panelist" (OI-811): _make_default_dispatcher defaults to
+    # "plan-reviewer" for its original run_panel caller. A diverge/contrarian/verify/
+    # synthesis prompt is NOT a plan review — tagging it plan-reviewer wrapped it in
+    # "you are an independent plan reviewer... review the IMPLEMENTATION PLAN" framing,
+    # which a plan-reviewer-role worker correctly rejected as not a plan, corrupting the
+    # panel stage.
+    dispatcher = _make_default_dispatcher(data_dir, args.timeout, role="deliberation-panelist")
 
     print(f"[panel] mode={args.mode} — running 4-stage deliberation across the fleet ...", file=sys.stderr)
     if roster is None:

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -33,6 +33,23 @@ class _Recorder:
         return [c["prompt"] for c in self.calls if f"-{stage}-" in c["did"]]
 
 
+class _HugeRecorder:
+    """Fake dispatcher: returns a HUGE fixed reply for every call (so digest/contrarian/
+    factcheck all balloon like a live cascading-verbatim run would) while still recording
+    every (provider, prompt, did) so a test can inspect the ACTUAL prompt built for a
+    later stage."""
+    def __init__(self, size=50_000):
+        self.calls = []
+        self.size = size
+
+    def __call__(self, provider, model, prompt, did):
+        self.calls.append({"provider": provider, "prompt": prompt, "did": did})
+        return "H" * self.size
+
+    def stage_prompts(self, stage: str):
+        return [c["prompt"] for c in self.calls if f"-{stage}-" in c["did"]]
+
+
 ROSTER = [("codex", "gpt-5.5"), ("kimi", "k2"), ("claude", "sonnet")]
 
 
@@ -209,3 +226,152 @@ class TestReportBackstop:
             clipped = dp._clip(text_past_old_limit, "contrarian", limit=dp._REPORT_BACKSTOP)
         assert len(clipped) == 20_000  # far past the old 6000-char cut, still passed whole
         assert not caplog.records
+
+
+class TestStageDistillation:
+    """OI-809 (BLOCKER): each downstream stage must carry a BOUNDED distillate of prior
+    stages, not the full verbatim material re-embedded at every hop — and the stage
+    instruction must survive regardless of how large prior stages were."""
+
+    def test_distill_passes_small_text_whole_and_silent(self, caplog):
+        small = "y" * 500
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            out = dp._distill(small, "contrarian", limit=6000)
+        assert out == small
+        assert not caplog.records
+
+    def test_distill_bounds_and_warns_on_large_text(self, caplog):
+        big = "x" * 20_000
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            out = dp._distill(big, "contrarian", limit=6000)
+        assert len(out) < 6100  # bounded to the limit (+ short truncation notice)
+        warnings = [r for r in caplog.records if "distillate" in r.message]
+        assert warnings, "distillation trim must emit a loud warning, never fail silently"
+        assert "contrarian" in warnings[0].message
+        assert "VNX_PANEL_DISTILLATE_BUDGET" in warnings[0].message
+
+    def test_default_distillate_budget_is_much_smaller_than_report_backstop(self):
+        """The distillate budget is a per-hop carry-forward cap, not the generous
+        single-report backstop — it must be meaningfully smaller so cascading across
+        3 downstream stages does not reproduce the old blow-up."""
+        assert dp._DISTILLATE_BUDGET < dp._REPORT_BACKSTOP
+
+    def test_distillate_budget_env_var_override(self):
+        lib_dir = str(REPO_ROOT / "scripts" / "lib")
+        code = (
+            f"import sys; sys.path.insert(0, {lib_dir!r}); import deliberation_panel as dp; "
+            "print(dp._DISTILLATE_BUDGET)"
+        )
+        env = {**os.environ, "VNX_PANEL_DISTILLATE_BUDGET": "999"}
+        result = subprocess.run(
+            [sys.executable, "-c", code], env=env, capture_output=True, text=True, check=True,
+        )
+        assert result.stdout.strip() == "999"
+
+    def test_synthesis_prompt_bounded_and_instruction_survives_huge_prior_stages(self):
+        """The exact OI-809 failure mode: every stage returns a HUGE report (as a live
+        cascading-verbatim run would produce). The synthesis stage's prompt must (a)
+        still contain its own instruction/ask, (b) stay far smaller than the old
+        3x-full-blob cascade, and (c) place the instruction BEFORE the bulky context so
+        a tail-truncation downstream can only ever cut context, never the task."""
+        rec = _HugeRecorder(size=50_000)
+        dp.run_deliberation("sweep", "audit src/", dispatcher=rec, roster=ROSTER, max_workers=3)
+        synth_prompts = rec.stage_prompts("synth")
+        assert len(synth_prompts) == 1
+        synth_prompt = synth_prompts[0]
+
+        # (a) the synthesis instruction/ask is present, not truncated away
+        assert "SYNTHESISER" in synth_prompt
+        assert "Produce" in synth_prompt and "CONSENSUS" in synth_prompt
+
+        # (b) carried-forward material is DISTILLED (bounded), not the raw huge blobs —
+        # the old cascading-verbatim approach would put ~3 x 50_000 = 150_000+ chars of
+        # digest/contrarian/factcheck into this single prompt.
+        assert len(synth_prompt) < 30_000, (
+            f"synth prompt is {len(synth_prompt)} chars — prior-stage material was not "
+            "bounded before being carried into this stage"
+        )
+
+        # (c) instruction precedes the bulky context
+        instr_pos = synth_prompt.index("SYNTHESISER")
+        context_pos = synth_prompt.index("H" * 100)
+        assert instr_pos < context_pos
+
+    def test_instruction_survives_a_simulated_downstream_tail_truncation(self):
+        """Even if some layer downstream of this module applies its own fixed-length cut
+        (the lane, or a future backstop), the now-bounded prompt's instruction — sitting
+        at the front — must survive a truncation that would have destroyed it under the
+        old (instruction-last) layout."""
+        rec = _HugeRecorder(size=50_000)
+        dp.run_deliberation("sweep", "audit src/", dispatcher=rec, roster=ROSTER, max_workers=3)
+        synth_prompt = rec.stage_prompts("synth")[0]
+        simulated_cut = synth_prompt[:40_000]
+        assert "SYNTHESISER" in simulated_cut
+        assert "Produce" in simulated_cut
+
+
+class TestCoverageAwareDegradation:
+    """OI-810 (warn): a failed/empty seat must yield explicit degraded coverage, never a
+    phantom full-coverage render."""
+
+    def test_failed_seat_recorded_as_degraded_coverage(self):
+        def flaky(provider, model, prompt, did):
+            if provider == "kimi":
+                return ""  # the glm-harness class of failure: fast exit, no text
+            return f"ok-{provider}"
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
+        assert len(res.present_lenses) == 2
+        assert len(res.failed_seats) == 1
+        assert res.failed_seats[0]["provider"] == "kimi"
+        assert "2/3" in res.coverage
+        assert "kimi" in res.coverage
+
+    def test_all_seats_present_reports_full_coverage_without_failed_note(self):
+        rec = _Recorder()
+        res = dp.run_deliberation("sweep", "q", dispatcher=rec, roster=ROSTER, max_workers=3)
+        assert res.failed_seats == []
+        assert len(res.present_lenses) == 3
+        assert res.coverage == "3/3 lenses present"
+
+    def test_report_surfaces_degraded_coverage_not_phantom_full(self):
+        def flaky(provider, model, prompt, did):
+            if provider == "kimi":
+                return ""
+            return f"ok-{provider}"
+
+        res = dp.run_deliberation("sweep", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
+        report = res.to_report()
+        assert "Coverage" in report
+        assert "2/3" in report
+        assert "SEAT FAILED" in report  # the dead seat is rendered loudly, not silently
+
+    def test_digest_excludes_failed_seats_from_downstream_stages(self):
+        rec_calls = []
+
+        def mixed(provider, model, prompt, did):
+            rec_calls.append({"provider": provider, "prompt": prompt, "did": did})
+            if provider == "kimi" and "-diverge-" in did:
+                raise RuntimeError("kimi down")
+            return f"<<{provider}>>"
+
+        dp.run_deliberation("sweep", "q", dispatcher=mixed, roster=ROSTER, max_workers=3)
+        contra_prompts = [c["prompt"] for c in rec_calls if "-contrarian-" in c["did"]]
+        assert len(contra_prompts) == 1
+        prompt = contra_prompts[0]
+        # the failed kimi seat's fan-out entry (its raw error text) must not leak into the
+        # digest as if it were real analysis — but the coverage note (which names the
+        # failed seat so the seat reasons about the true present-lens set) is expected.
+        assert "dispatch error" not in prompt
+        assert "PANEL COVERAGE" in prompt and "kimi" in prompt
+
+    def test_logs_a_loud_warning_on_degraded_coverage(self, caplog):
+        def flaky(provider, model, prompt, did):
+            if provider == "kimi":
+                return ""
+            return f"ok-{provider}"
+
+        with caplog.at_level(logging.WARNING, logger="deliberation_panel"):
+            dp.run_deliberation("sweep", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
+        warnings = [r for r in caplog.records if "usable report" in r.message]
+        assert warnings, "a failed seat must be logged loudly, never silently"

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -55,6 +55,7 @@ def _make_spec(data_dir: Path, state_dir: Path, **kwargs) -> GovernSpec:
         pr_id=kwargs.get("pr_id"),
         base_sha=kwargs.get("base_sha"),
         worktree_path=kwargs.get("worktree_path"),
+        role=kwargs.get("role"),
     )
 
 
@@ -198,6 +199,81 @@ def test_govern_authored_preserves_worker_body(tmp_data, tmp_state, monkeypatch)
     assert "## Open Items" in content
     # Worker's specific text content must be preserved.
     assert "Implemented the feature correctly" in content
+
+
+# ---------------------------------------------------------------------------
+# OI-811: freeform-role reports (deliberation-panelist) — free-form panel-stage
+# analysis, no ## Changes/## Verification headings and no plan-verdict fence. Must be
+# accepted as authored (never synthesized-over) and must skip the standard report-body
+# contract, the same way plan-reviewer already does.
+# ---------------------------------------------------------------------------
+
+def test_govern_deliberation_panelist_report_accepted_as_authored_without_fence(
+    tmp_data, tmp_state, monkeypatch,
+):
+    """A deliberation-panelist report has NEITHER the standard contract headings NOR a
+    vnx-plan-verdict fence — it is free-form panel analysis. It must still be accepted
+    as authored (not synthesized-over, which would replace it with an empty git-diff
+    body since a panel dispatch produces no commit)."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    panel_body = (
+        "You are the SYNTHESISER on a deliberation panel (codebase sweep).\n\n"
+        "CONSENSUS: the auth module has a real vulnerability at auth.py:42.\n"
+        "CONTESTED: whether the fix requires a migration.\n"
+    )
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text(panel_body, encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, role="deliberation-panelist")
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    content = outcome.report_path.read_text(encoding="utf-8")
+    assert "auth.py:42" in content
+
+
+def test_govern_deliberation_panelist_empty_report_falls_through_to_synthesis(
+    tmp_data, tmp_state, monkeypatch,
+):
+    """An empty deliberation-panelist report (the seat produced nothing) must NOT be
+    accepted as authored — it falls through to synthesis like any other empty report."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text("   \n", encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, role="deliberation-panelist")
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status != "authored"
+
+
+def test_govern_deliberation_panelist_skips_standard_contract_validation(
+    tmp_data, tmp_state, monkeypatch,
+):
+    """A deliberation-panelist authored body — which by design lacks ## Changes/##
+    Verification/## Open Items — must not be flagged 'violated' by the standard
+    report-body contract, even in enforce mode."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+    monkeypatch.setenv("VNX_CONTRACT_VALIDATE", "enforce")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text("Terse panel analysis with no standard headings.\n", encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, role="deliberation-panelist")
+    raw = _make_raw()
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
 
 
 def test_govern_authored_not_double_stamped(tmp_data, tmp_state, monkeypatch):

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -27,8 +27,8 @@ def test_seats_filters_to_requested_roster(tmp_path, monkeypatch):
     panel = _load_panel_cli()
     calls = {}
 
-    def fake_dispatcher_factory(data_dir, timeout):
-        calls["dispatcher_factory"] = {"data_dir": data_dir, "timeout": timeout}
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        calls["dispatcher_factory"] = {"data_dir": data_dir, "timeout": timeout, "role": role}
         return lambda provider, model, prompt, dispatch_id: "ok"
 
     def fake_run_deliberation(*args, **kwargs):
@@ -52,12 +52,13 @@ def test_seats_filters_to_requested_roster(tmp_path, monkeypatch):
         ("codex", "gpt-5.5"),
         ("claude", "sonnet"),
     ]
+    assert calls["dispatcher_factory"]["role"] == "deliberation-panelist"
 
 
 def test_unknown_seat_errors_without_dispatch(tmp_path, monkeypatch, capsys):
     panel = _load_panel_cli()
 
-    def fail_dispatcher_factory(data_dir, timeout):
+    def fail_dispatcher_factory(data_dir, timeout, role=None):
         raise AssertionError("dispatcher must not be built for invalid --seats")
 
     monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fail_dispatcher_factory)
@@ -81,7 +82,7 @@ def test_default_omits_roster_kwarg_to_preserve_full_fleet_path(tmp_path, monkey
     panel = _load_panel_cli()
     calls = {}
 
-    def fake_dispatcher_factory(data_dir, timeout):
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
         return lambda provider, model, prompt, dispatch_id: "ok"
 
     def fake_run_deliberation(*args, **kwargs):
@@ -100,3 +101,26 @@ def test_default_omits_roster_kwarg_to_preserve_full_fleet_path(tmp_path, monkey
 
     assert rc == 0
     assert "roster" not in calls["run_deliberation"]["kwargs"]
+
+
+def test_dispatcher_factory_receives_non_plan_reviewer_role(tmp_path, monkeypatch):
+    """OI-811: panel.py must not dispatch its stage prompts under the plan-reviewer role —
+    that framing caused a plan-reviewer-role worker to reject a non-plan panel artifact."""
+    panel = _load_panel_cli()
+    calls = {}
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        calls["role"] = role
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
+
+    assert rc == 0
+    assert calls["role"] == "deliberation-panelist"
+    assert calls["role"] != "plan-reviewer"

--- a/tests/test_phantom_guard.py
+++ b/tests/test_phantom_guard.py
@@ -10,6 +10,16 @@ def test_review_role_is_never_phantom():
     assert not v.is_phantom
 
 
+def test_deliberation_panelist_role_is_never_phantom():
+    # OI-811: a panel stage's deliverable (diverge/contrarian/verify/synthesis
+    # analysis) is prose, not a code diff — a real dispatch with real tokens and no
+    # worktree diff is expected, never evidence of fabrication.
+    v = pg.phantom_guard(
+        status="done", worktree_diff="", token_usage=4321, role="deliberation-panelist",
+    )
+    assert not v.is_phantom
+
+
 def test_non_completion_status_is_not_phantom():
     v = pg.phantom_guard(status="failed", worktree_diff="", token_usage=None, role="backend-developer")
     assert not v.is_phantom

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -882,6 +882,99 @@ def test_claude_lane_dispatcher_writes_temp_file_and_cleans_up(tmp_path):
 
 
 # --------------------------------------------------------------------------
+# OI-811: _make_default_dispatcher is reused by non-plan-review callers (the vnx
+# deliberation panel). A caller-supplied ``role`` must (a) route the claude/tmux lane
+# through the GENERIC file-ref instruction, never the "you are an independent plan
+# reviewer... review the IMPLEMENTATION PLAN" framing, and (b) be stamped as --role on
+# both the claude/tmux lane and the provider lane so govern()/phantom-guard evaluate the
+# dispatch under its real role instead of a hardcoded plan-reviewer.
+# --------------------------------------------------------------------------
+
+def test_default_role_is_still_plan_reviewer_for_backward_compat(tmp_path):
+    """run_panel's own dispatcher (no role kwarg) must keep routing as plan-reviewer."""
+    import unittest.mock as mock
+
+    seen_cmds = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(pgp, "_read_report", return_value=_make_report_with_fence("pass")):
+            dispatcher("claude", "opus", "some plan text", "plan-gate-feat-x-opus-abc123")
+
+    assert len(seen_cmds) == 1
+    cmd = seen_cmds[0]
+    assert cmd[cmd.index("--role") + 1] == "plan-reviewer"
+    instr = cmd[cmd.index("--instruction") + 1]
+    assert "independent plan reviewer" in instr.lower()
+
+
+def test_non_plan_role_claude_lane_uses_generic_instruction_not_plan_framing(tmp_path):
+    """A caller with role != 'plan-reviewer' must not have its instruction wrapped as an
+    'independent plan reviewer... IMPLEMENTATION PLAN' review — that framing caused a
+    plan-reviewer-role worker to correctly reject a non-plan artifact ('this is not a
+    plan'), corrupting the deliberation panel's stage output."""
+    import unittest.mock as mock
+
+    seen_cmds = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60, role="deliberation-panelist")
+
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
+            dispatcher(
+                "claude", "sonnet",
+                "You are one seat on a deliberation panel. QUESTION: audit src/",
+                "panel-sweep-diverge-0-abc123",
+            )
+
+    assert len(seen_cmds) == 1
+    cmd = seen_cmds[0]
+    assert cmd[cmd.index("--role") + 1] == "deliberation-panelist"
+    instr = cmd[cmd.index("--instruction") + 1]
+    assert "independent plan reviewer" not in instr.lower()
+    assert "implementation plan" not in instr.lower()
+    # the file-ref benefit (short instruction, doc read from disk) is preserved
+    assert "Read your complete instruction from this file" in instr
+
+
+def test_non_plan_role_provider_lane_passes_role_through(tmp_path):
+    """kimi/glm/deepseek dispatches for a non-plan-review caller must also carry the
+    real role, not a hardcoded 'plan-reviewer' — the provider lane inlines the
+    instruction unchanged either way (no plan-framing risk there), but the role tag
+    still feeds govern()/phantom-guard/receipts."""
+    import unittest.mock as mock
+
+    seen_cmds = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_cmds.append(cmd)
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60, role="deliberation-panelist")
+
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
+            dispatcher("kimi", "kimi-k3", "some panel prompt", "panel-sweep-diverge-1-def456")
+
+    assert len(seen_cmds) == 1
+    cmd = seen_cmds[0]
+    assert cmd[cmd.index("--role") + 1] == "deliberation-panelist"
+    assert cmd[cmd.index("--instruction") + 1] == "some panel prompt"
+
+
+# --------------------------------------------------------------------------
 # scoped-spawn fix (2026-07-14): tmux_interactive_dispatch.dispatch()'s D2.2 scoping
 # precondition (tmux_interactive_dispatch.py, "D2.2 scoping precondition" -- fail-closed:
 # a working_tree_only dispatch is refused unless the env carries VNX_WORKER_SCOPED=1 or


### PR DESCRIPTION
## Summary
Fixes three bugs filed 2026-07-28 by MC-T0 against the multi-stage deliberation panel engine (`scripts/lib/deliberation_panel.py`, driven by `scripts/panel.py` / `vnx panel`), confirmed against the tree before changing anything.

- **OI-809 (BLOCKER)** — stage transitions (contrarian/verify/synthesis) re-embedded the FULL verbatim fan-out digest + prior-stage outputs at every hop (~85% duplication, observed 2216/3751-line prompts) until a fixed-length truncation cut the prompt mid-sentence *before* the stage instruction, corrupting the synthesis stage with input-only context. Fixed by (a) a new bounded per-hop distillate (`_distill`, `VNX_PANEL_DISTILLATE_BUDGET`, default 6000 chars) replacing the full-digest re-embed, and (b) restructuring every downstream stage prompt to put the instruction FIRST, with the (now bounded) context after — so any downstream truncation can only ever cut context, never the task.
- **OI-810 (warn)** — a dead seat (e.g. glm-harness exiting 1 in ~0.009s with no response) was silently rendered as if it had contributed. `DeliberationResult` now tracks `present_lenses`/`failed_seats`/`coverage` explicitly, `to_report()` surfaces a `**Coverage:** N/M lenses present; X failed` line and flags a failed seat's fan-out entry with `**[SEAT FAILED — no report]**`, and every downstream stage gets an explicit coverage note so its reasoning is aware of the true present-lens set. Failed seats are excluded from what's carried into later stages.
- **OI-811 (warn)** — `plan_gate_panel._make_default_dispatcher` (reused by both the real plan-gate and the deliberation panel) unconditionally wrapped every claude/tmux-lane instruction in "you are an independent plan reviewer... review the IMPLEMENTATION PLAN" framing and hardcoded `--role plan-reviewer` on both lanes — so a panel stage prompt got rejected by the worker as "this is not a plan". `_make_default_dispatcher` now takes a `role` kwarg (default `plan-reviewer`, unchanged for `run_panel`); a different role gets a generic (non-plan-framed) file-ref instruction and the real role stamped on `--role` for both lanes. `scripts/panel.py` now passes `role="deliberation-panelist"`. `dispatch_govern.py`'s freeform-contract bypass and `phantom_guard.py`'s `REVIEW_ROLES` were generalized to cover the new role so a real no-diff panel dispatch is neither synthesized-over nor flagged as fabricated.

## Changes
- `scripts/lib/deliberation_panel.py` — `_distill`/`_stage_prompt` helpers; `DeliberationResult.present_lenses`/`failed_seats`/`coverage`; instruction-first stage prompts; coverage-aware digest filtering.
- `scripts/lib/plan_gate_panel.py` — `_make_default_dispatcher(..., role=...)`; `build_generic_fileref_instruction`.
- `scripts/lib/dispatch_govern.py` — generalized `_FREEFORM_ROLES` bypass (was `plan-reviewer`-only).
- `scripts/lib/phantom_guard.py` — `deliberation-panelist` added to `REVIEW_ROLES`.
- `scripts/panel.py` — passes `role="deliberation-panelist"`.
- Tests: `tests/test_deliberation_panel.py` (+28 assertions across distillation/coverage), `tests/test_plan_gate_panel.py`, `tests/test_panel_cli.py`, `tests/test_dispatch_govern.py`, `tests/test_phantom_guard.py`.

## Test plan
- [x] `pytest tests/test_deliberation_panel.py -q` — 28 passed
- [x] `pytest tests/test_panel_cli.py -q` — 4 passed
- [x] `pytest tests/test_plan_gate_panel.py -q` — 67 passed
- [x] `pytest tests/test_dispatch_govern.py -q` — 62 passed
- [x] `pytest tests/test_phantom_guard.py tests/test_phantom_guard_inline.py tests/test_phantom_guard_fix_forward.py -q` — 50 passed
- [x] `pytest tests/test_subprocess_dispatch_govern.py tests/test_governance_emit.py -q` — confirmed unaffected
- [x] Verified `tests/test_provider_dispatch_governance_integration.py` failures (18) are pre-existing on `origin/main`, unrelated to this change (reproduced identically via `git stash`)
- Full suite not run per dispatch instructions (targeted tests only; CI runs the rest)

Dispatch-ID: 20260728-panel-reliability-oi809-sonnet

🤖 Generated with [Claude Code](https://claude.com/claude-code)