### PR TITLE
fix(provenance): commit the automated sweep instead of silently rolling it back

### DIFF
--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -610,6 +610,16 @@ def _run_provenance_sweep(
                     exc_info=True,
                 )
             else:
+                # ``result["linked_pending_commit"]`` was computed by
+                # reconcile_commit_provenance BEFORE this commit — it mirrors
+                # ``linked`` because prov_conn's implicit transaction was
+                # still open at that point. Now that prov_conn.commit() has
+                # actually succeeded, every one of those writes is durable:
+                # the caller-visible count must reflect that, not the
+                # pre-commit snapshot, or it repeats the exact "non-zero
+                # pending after a successful commit" lie this field exists
+                # to prevent.
+                result["linked_pending_commit"] = 0
                 provenance = result
         finally:
             prov_conn.close()

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -571,6 +571,53 @@ def _resolve_effective_repo_root() -> Path:
     return Path.cwd()
 
 
+def _run_provenance_sweep(
+    state_dir: Path, repo_root: Path, project_id: str,
+) -> Dict[str, int]:
+    """Scan recent commits for dispatch->commit provenance links.
+
+    Best-effort at the scan/link level, exactly as before: a git or SQL error
+    while reading/registering leaves ``provenance`` at the zero-default and is
+    logged at debug, never blocking the rest of ``run_reconcile``.
+
+    A COMMIT failure is a different class of problem. ``reconcile_commit_provenance``
+    writes into ``prov_conn`` under sqlite3's implicit transaction — those rows are
+    invisible outside this call until ``commit()`` succeeds. Folding a commit failure
+    into the same debug-level catch-all would repeat the exact bug this function
+    fixes: reporting non-zero ``linked`` counts for edges that never survived. So a
+    commit failure is logged loudly (``log.error``) and the returned counts fall
+    back to the zero-default rather than the pre-commit ``result``.
+    """
+    provenance: Dict[str, int] = {"scanned": 0, "linked": 0}
+    try:
+        from receipt_provenance import reconcile_commit_provenance  # noqa: PLC0415
+        db_path = state_dir / track_reconciler.DB_FILENAME
+        prov_conn = sqlite3.connect(str(db_path), timeout=10.0)
+        prov_conn.row_factory = sqlite3.Row
+        try:
+            # Finding A (ADR-007 composite-safety): this reconcile pipeline
+            # already operates on a single project_id's per-project store —
+            # pass it through so the dispatch_metadata.pr_id backfill never
+            # falls back to an ambiguous dispatch_id-only lookup.
+            result = reconcile_commit_provenance(repo_root, prov_conn, project_id=project_id)
+            try:
+                prov_conn.commit()
+            except sqlite3.Error:
+                log.error(
+                    "provenance sweep: commit failed — %d scanned/%d linked "
+                    "edge(s) rolled back, not counted",
+                    result.get("scanned", 0), result.get("linked", 0),
+                    exc_info=True,
+                )
+            else:
+                provenance = result
+        finally:
+            prov_conn.close()
+    except Exception as exc:  # noqa: BLE001
+        log.debug("provenance sweep non-fatal: %s", exc)
+    return provenance
+
+
 def run_reconcile(
     state_dir: Path,
     project_id: str,
@@ -601,22 +648,7 @@ def run_reconcile(
     # ------------------------------------------------------------------ step 1
     # Provenance sweep — best-effort; never blocks the rest.
     # ------------------------------------------------------------------ step 1
-    provenance: Dict[str, int] = {"scanned": 0, "linked": 0}
-    try:
-        from receipt_provenance import reconcile_commit_provenance  # noqa: PLC0415
-        db_path = state_dir / track_reconciler.DB_FILENAME
-        prov_conn = sqlite3.connect(str(db_path), timeout=10.0)
-        prov_conn.row_factory = sqlite3.Row
-        try:
-            # Finding A (ADR-007 composite-safety): this reconcile pipeline
-            # already operates on a single project_id's per-project store —
-            # pass it through so the dispatch_metadata.pr_id backfill never
-            # falls back to an ambiguous dispatch_id-only lookup.
-            provenance = reconcile_commit_provenance(repo_root, prov_conn, project_id=project_id)
-        finally:
-            prov_conn.close()
-    except Exception as exc:  # noqa: BLE001
-        log.debug("provenance sweep non-fatal: %s", exc)
+    provenance = _run_provenance_sweep(state_dir, repo_root, project_id)
 
     # ------------------------------------------------------------------ step 2
     # Derived refresh — persists derived_status for every track.

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -663,11 +663,18 @@ def reconcile_commit_provenance(
     composite-unique key). When omitted (back-compat), falls back to
     ``_resolve_dispatch_project_id``, which itself abstains (returns None, no stamp) on any
     cross-tenant ``dispatch_id`` collision rather than guessing.
+
+    Durability of ``conn``: this function never commits or rolls back ``conn`` — it is
+    caller-owned (see the ``state_conn_borrowed`` handling below), so the caller decides the
+    transaction boundary. This means ``linked`` reflects register calls that did not raise,
+    not writes confirmed durable. The returned ``linked_pending_commit`` exposes that gap
+    directly (mirrors ``linked`` while ``conn.in_transaction`` is still True; 0 once the
+    caller has committed) — a caller must commit ``conn`` for ``linked`` to mean anything.
     """
     try:
         from trace_token_validator import extract_trace_tokens  # noqa: PLC0415
     except Exception:
-        return {"scanned": 0, "linked": 0}
+        return {"scanned": 0, "linked": 0, "linked_pending_commit": 0}
     try:
         # Null-record-separated SHA + full body, so multi-line commit bodies stay intact.
         result = subprocess.run(
@@ -676,9 +683,9 @@ def reconcile_commit_provenance(
             capture_output=True, text=True, timeout=20,
         )
     except (subprocess.SubprocessError, OSError):
-        return {"scanned": 0, "linked": 0}
+        return {"scanned": 0, "linked": 0, "linked_pending_commit": 0}
     if result.returncode != 0:
-        return {"scanned": 0, "linked": 0}
+        return {"scanned": 0, "linked": 0, "linked_pending_commit": 0}
 
     # Resolve the state dir once; both DB connections below hang off it.
     # Failure here is non-fatal — provenance reconciliation must keep working
@@ -780,9 +787,21 @@ def reconcile_commit_provenance(
             except Exception as exc:  # noqa: BLE001
                 logger.debug("failed to commit/close quality_intelligence db: %s", exc)
 
+    # ``linked`` counts calls to register_provenance_link that did not raise —
+    # it says nothing about whether those writes survive ``conn``'s eventual
+    # close(). ``conn`` is caller-owned (see the ``state_conn_borrowed`` guard
+    # above): this function never commits it, so at this point sqlite3's
+    # implicit transaction is still open for every write ``linked`` counts.
+    # ``linked_pending_commit`` makes that risk explicit instead of letting a
+    # caller — or a log line — read ``linked`` as already-durable. It mirrors
+    # ``linked`` whenever the transaction is still open (the historical bug:
+    # a caller that closes without committing loses exactly this many rows)
+    # and drops to 0 once the caller has committed (or nothing was written).
+    linked_pending_commit = linked if conn.in_transaction else 0
     return {
         "scanned": scanned,
         "linked": linked,
+        "linked_pending_commit": linked_pending_commit,
         "pr_ref_linked": pr_ref_linked,
         "pr_id_linked": pr_id_linked,
     }

--- a/scripts/reconcile_provenance.py
+++ b/scripts/reconcile_provenance.py
@@ -88,6 +88,12 @@ def main(argv: "list[str] | None" = None) -> int:
             repo_root, conn, max_commits=args.max_commits, project_id=project_id,
         )
         conn.commit()
+        # reconcile_commit_provenance computed linked_pending_commit BEFORE
+        # this commit (conn's implicit transaction was still open then) — now
+        # that conn.commit() has actually succeeded, those writes are
+        # durable. Report that, not the pre-commit snapshot (mirrors the
+        # same fix in objective_reconcile._run_provenance_sweep).
+        result["linked_pending_commit"] = 0
     finally:
         conn.close()
 

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1430,6 +1430,26 @@ class TestRunProvenanceSweepCommitSurvivesClose:
         verify_conn.close()
         assert {r[0] for r in rows} == set(dispatch_ids)
 
+    def test_linked_pending_commit_is_zero_after_successful_sweep(self, tmp_path):
+        """PR-A fix-forward: reconcile_commit_provenance computes
+        ``linked_pending_commit`` BEFORE ``_run_provenance_sweep``'s own
+        ``prov_conn.commit()`` runs — at that point prov_conn.in_transaction
+        is still True, so the raw value mirrors ``linked`` regardless of
+        whether the commit that follows actually succeeds. Once
+        _run_provenance_sweep's commit has succeeded, the rows ARE durable
+        and the caller-visible count must say so (0), not echo the
+        pre-commit snapshot — anything else is exactly the "non-zero pending
+        after a successful commit" lie linked_pending_commit exists to rule
+        out."""
+        repo, state_dir, env = _make_git_project(tmp_path)
+        dispatch_id = "20260729-pending-after-commit-check"
+        _git_commit_with_dispatch_id(repo, dispatch_id, env)
+
+        result = objective_reconcile._run_provenance_sweep(state_dir, repo, PROJECT_ID)
+
+        assert result["linked"] == 1
+        assert result["linked_pending_commit"] == 0
+
 
 class TestRunProvenanceSweepCommitFailureIsLoud:
     """A commit failure must be visible (log.error), not swallowed at debug
@@ -1465,6 +1485,20 @@ class TestRunProvenanceSweepCommitFailureIsLoud:
         error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
         assert error_records, "a failed commit must be logged loudly, not swallowed at debug"
         assert "commit failed" in error_records[0].getMessage()
+
+        # The zeroed counts are the SHAPE of the claim; prove the substance
+        # too — _run_provenance_sweep's own prov_conn is already closed by
+        # the time it returns (its finally: block closes it regardless of
+        # commit outcome). Open a fresh connection and confirm the row the
+        # broken commit() claimed to roll back is actually gone, not just
+        # that the returned dict said zero.
+        verify_conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = verify_conn.execute(
+            "SELECT commit_sha FROM provenance_registry WHERE dispatch_id = ?",
+            (dispatch_id,),
+        ).fetchone()
+        verify_conn.close()
+        assert row is None, "a failed commit must not leave the row behind after close()"
 
         # And it must not have been double-logged at debug-only either — the
         # loud path replaces the silent one for this failure, it doesn't also

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1344,3 +1344,149 @@ def test_objective_close_dry_run_threads_repo_root_into_evidence(tmp_path, monke
     # if repo_root were dropped and the CWD-git-root roadmap read instead).
     ev = real_close_evidence(str(sd), "T-dry", PROJECT_ID, repo_root=Path(str(repo)).resolve())
     assert ev["pr_merged"] is True
+
+
+# ---------------------------------------------------------------------------
+# _run_provenance_sweep — commit-survives-close regression (PR-A, 2026-07-29)
+#
+# Root cause: objective_reconcile.py opened a connection, let
+# reconcile_commit_provenance write hundreds of rows into it, and closed the
+# connection without ever calling commit(). sqlite3's default isolation_level
+# opens an implicit transaction on the first DML; close() without commit()
+# rolls it back. Every automated provenance sweep since 2026-07-04 (#996) was
+# silently a no-op. See claudedocs/provenance-chain-root-cause-20260729.md.
+# ---------------------------------------------------------------------------
+
+import logging  # noqa: E402
+from runtime_coordination import init_schema as _rc_init_schema  # noqa: E402
+
+_GIT_ENV_TEMPLATE = {
+    "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+    "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+    "GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null",
+}
+
+
+def _make_git_project(tmp_path: Path):
+    """Real git repo + a state_dir with the provenance_registry schema (v6) applied."""
+    repo = tmp_path / "prov-repo"
+    repo.mkdir()
+    env = dict(_GIT_ENV_TEMPLATE, HOME=str(tmp_path))
+    subprocess.run(["git", "init", "-q"], cwd=repo, env=env, check=True)
+    state_dir = tmp_path / "prov-state"
+    _rc_init_schema(state_dir)
+    return repo, state_dir, env
+
+
+def _git_commit_with_dispatch_id(
+    repo: Path, dispatch_id: str, env: Dict[str, str], *, message: str = "feat(x): thing",
+) -> None:
+    i = len(list(repo.glob("*.txt")))
+    f = repo / f"f{i}.txt"
+    f.write_text(str(i))
+    subprocess.run(["git", "add", str(f)], cwd=repo, env=env, check=True)
+    subprocess.run(
+        ["git", "commit", "-q", "-m", f"{message}\n\nDispatch-ID: {dispatch_id}"],
+        cwd=repo, env=env, check=True,
+    )
+
+
+class TestRunProvenanceSweepCommitSurvivesClose:
+    """Regression test: red without prov_conn.commit(), green with it."""
+
+    def test_provenance_write_survives_connection_close(self, tmp_path):
+        repo, state_dir, env = _make_git_project(tmp_path)
+        dispatch_id = "20260729-survives-close-check"
+        _git_commit_with_dispatch_id(repo, dispatch_id, env)
+
+        result = objective_reconcile._run_provenance_sweep(state_dir, repo, PROJECT_ID)
+        assert result["linked"] == 1
+
+        # Re-open a FRESH connection: proves the row survives close(), not
+        # merely that it was visible within the still-open transaction that
+        # wrote it (which the old, buggy code would also have shown).
+        verify_conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = verify_conn.execute(
+            "SELECT commit_sha FROM provenance_registry WHERE dispatch_id = ?",
+            (dispatch_id,),
+        ).fetchone()
+        verify_conn.close()
+        assert row is not None
+        assert row[0] is not None
+
+    def test_multiple_commits_all_survive(self, tmp_path):
+        repo, state_dir, env = _make_git_project(tmp_path)
+        dispatch_ids = [f"20260729-survives-{i}" for i in range(3)]
+        for dispatch_id in dispatch_ids:
+            _git_commit_with_dispatch_id(repo, dispatch_id, env)
+
+        result = objective_reconcile._run_provenance_sweep(state_dir, repo, PROJECT_ID)
+        assert result["linked"] == 3
+
+        verify_conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        rows = verify_conn.execute(
+            "SELECT dispatch_id FROM provenance_registry WHERE commit_sha IS NOT NULL"
+        ).fetchall()
+        verify_conn.close()
+        assert {r[0] for r in rows} == set(dispatch_ids)
+
+
+class TestRunProvenanceSweepCommitFailureIsLoud:
+    """A commit failure must be visible (log.error), not swallowed at debug
+    alongside ordinary non-fatal scan errors — and the returned counts must
+    not claim durability that a failed commit rolled back."""
+
+    def test_commit_failure_logs_error_and_zeroes_counts(self, tmp_path, monkeypatch, caplog):
+        repo, state_dir, env = _make_git_project(tmp_path)
+        dispatch_id = "20260729-commit-failure-check"
+        _git_commit_with_dispatch_id(repo, dispatch_id, env)
+
+        # sqlite3.Connection is an immutable builtin type — instance/class
+        # attributes can't be monkeypatched directly. Subclass it and make
+        # objective_reconcile's own sqlite3.connect() hand out that subclass,
+        # so only the connection this call opens has a broken commit().
+        class _CommitFailsConnection(sqlite3.Connection):
+            def commit(self):
+                raise sqlite3.OperationalError("simulated disk I/O error")
+
+        real_connect = sqlite3.connect
+
+        def _connect_with_broken_commit(*args, **kwargs):
+            kwargs["factory"] = _CommitFailsConnection
+            return real_connect(*args, **kwargs)
+
+        monkeypatch.setattr(objective_reconcile.sqlite3, "connect", _connect_with_broken_commit)
+
+        with caplog.at_level(logging.DEBUG, logger="objective_reconcile"):
+            result = objective_reconcile._run_provenance_sweep(state_dir, repo, PROJECT_ID)
+
+        # Commit failed -> nothing durable, so the counts must not lie.
+        assert result == {"scanned": 0, "linked": 0}
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert error_records, "a failed commit must be logged loudly, not swallowed at debug"
+        assert "commit failed" in error_records[0].getMessage()
+
+        # And it must not have been double-logged at debug-only either — the
+        # loud path replaces the silent one for this failure, it doesn't also
+        # fall through to the generic "provenance sweep non-fatal" catch.
+        debug_msgs = [
+            r.getMessage() for r in caplog.records
+            if r.levelno == logging.DEBUG
+        ]
+        assert not any("non-fatal" in m for m in debug_msgs)
+
+    def test_ordinary_scan_error_stays_quiet_and_non_fatal(self, tmp_path, caplog):
+        # A state_dir whose parent doesn't exist makes sqlite3.connect() raise
+        # before reconcile_commit_provenance ever runs — the pre-existing
+        # "best-effort, never blocks the rest" contract for scan-level
+        # failures must be unchanged: quiet (debug only), zero result.
+        missing_state_dir = tmp_path / "does-not-exist" / "state"
+        repo = tmp_path / "some-repo"
+        repo.mkdir()
+
+        with caplog.at_level(logging.DEBUG, logger="objective_reconcile"):
+            result = objective_reconcile._run_provenance_sweep(missing_state_dir, repo, PROJECT_ID)
+
+        assert result == {"scanned": 0, "linked": 0}
+        error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not error_records, "an ordinary scan miss must stay non-fatal, not escalate to error"

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -164,12 +164,12 @@ def test_reconcile_ignores_tokenless_commits(tmp_path):
 
 
 def test_reconcile_bad_repo_is_fail_open(tmp_path):
-    # Not a git repo -> git log fails -> {scanned:0, linked:0}, never raises.
+    # Not a git repo -> git log fails -> zero counts, never raises.
     sd = _state_dir(tmp_path)
     conn = sqlite3.connect(sd / "runtime_coordination.db")
     result = reconcile_commit_provenance(tmp_path / "not-a-repo", conn, max_commits=50)
     conn.close()
-    assert result == {"scanned": 0, "linked": 0}
+    assert result == {"scanned": 0, "linked": 0, "linked_pending_commit": 0}
 
 
 if __name__ == "__main__":

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -940,6 +940,75 @@ class TestReconcileCommitProvenanceTrackLinkage:
         assert reg["commit_sha"] is not None
 
 
+class TestReconcileCommitProvenanceLinkedPendingCommit:
+    """Provenance-chain PR-A (2026-07-29): ``linked`` must not claim durability
+    it hasn't earned. ``conn`` is caller-owned — this function never commits
+    it — so ``linked`` alone only means "the register call didn't raise", not
+    "this row survives conn.close()". ``linked_pending_commit`` makes the gap
+    visible instead of letting a caller (or a log line) read ``linked`` as
+    already-durable."""
+
+    DISPATCH_ID = "20260729-pending-commit-check"
+
+    def test_mirrors_linked_before_caller_commits(self, tmp_path):
+        repo, _state_dir, conn, env = _make_project(tmp_path)
+        _seed_track(conn, "T-001", "test-proj")
+        _seed_dispatch(conn, self.DISPATCH_ID, "test-proj", "T-001")
+        _commit(repo, f"feat(x): do thing\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+
+        assert result["linked"] == 1
+        # conn has NOT been committed yet: sqlite3's implicit transaction is
+        # still open, so the write is one dropped connection away from
+        # vanishing exactly like the historical objective_reconcile.py bug.
+        assert conn.in_transaction is True
+        assert result["linked_pending_commit"] == 1
+        conn.commit()
+        conn.close()
+
+    def test_zero_when_nothing_written(self, tmp_path):
+        repo, _state_dir, conn, env = _make_project(tmp_path)
+        _commit(repo, "chore: unrelated commit with no trace token", env)
+
+        result = reconcile_commit_provenance(repo, conn, max_commits=10)
+
+        assert result["linked"] == 0
+        assert result["linked_pending_commit"] == 0
+        conn.close()
+
+    def test_zero_under_autocommit_because_nothing_is_actually_pending(self, tmp_path):
+        """linked_pending_commit must track real durability risk, not just
+        linked > 0. Under autocommit (isolation_level=None) every statement
+        commits immediately, so nothing is pending even though this function
+        itself never calls .commit()."""
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        conn.close()
+        auto_conn = sqlite3.connect(
+            str(state_dir / "runtime_coordination.db"), isolation_level=None
+        )
+        auto_conn.row_factory = sqlite3.Row
+        _seed_track(auto_conn, "T-002", "test-proj")
+        _seed_dispatch(auto_conn, self.DISPATCH_ID, "test-proj", "T-002")
+        _commit(repo, f"feat(y): do thing\n\nDispatch-ID: {self.DISPATCH_ID}", env)
+
+        result = reconcile_commit_provenance(repo, auto_conn, max_commits=10)
+
+        assert result["linked"] == 1
+        assert auto_conn.in_transaction is False
+        assert result["linked_pending_commit"] == 0
+
+        # Prove it: close WITHOUT ever calling .commit() and the row survives.
+        auto_conn.close()
+        verify_conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+        row = verify_conn.execute(
+            "SELECT commit_sha FROM provenance_registry WHERE dispatch_id = ?",
+            (self.DISPATCH_ID,),
+        ).fetchone()
+        assert row is not None and row[0] is not None
+        verify_conn.close()
+
+
 # ---------------------------------------------------------------------------
 # receipt-quality PR-B2 — dispatch_metadata.pr_id backfill (sibling of
 # tracks.pr_ref, a different database: quality_intelligence.db)


### PR DESCRIPTION
## Summary

`objective_reconcile.py:606-618` opened a sqlite3 connection, let `reconcile_commit_provenance` write hundreds of dispatch→commit rows into it, then closed the connection **without calling `commit()`**. Python's `sqlite3` opens an implicit transaction on the first DML under the default isolation level; `close()` without `commit()` rolls it back. Every automated provenance sweep since #996 (2026-07-04) has been silently a no-op — measured effect: 478 rows in `provenance_registry`, 0 with `pr_number`, 1 with `commit_sha`, everything stuck at `chain_status=incomplete`.

Root-cause analysis: `claudedocs/provenance-chain-root-cause-20260729.md`.

Scope, per dispatch instructions: only the missing commit + the misleading counter. `pr_number` propagation, state-dir resolution, the `receipt_id` predicate, and the tmux gate are explicitly out of scope (PR-B).

## Changes

- **`scripts/lib/objective_reconcile.py`** — extracted the provenance-sweep block into a new `_run_provenance_sweep()` helper and added `prov_conn.commit()`. A commit failure is logged loudly (`log.error` + `exc_info`) and the returned counts fall back to the zero-default, instead of folding into the pre-existing debug-level `except Exception: log.debug(...)` that masked this exact bug for weeks. Ordinary scan/git errors keep the prior best-effort, non-fatal behavior unchanged.
- **`scripts/lib/receipt_provenance.py`** — `reconcile_commit_provenance`'s `linked` counter was incremented immediately after `register_provenance_link`, before any durability (`conn` is caller-owned; this function never commits it). Added a `linked_pending_commit` field that mirrors `linked` while `conn.in_transaction` is still True — exactly the historical bug's condition — and drops to 0 once the caller has committed. Applied consistently to all return paths (including the three early best-effort returns).

## Verification

Regression test proving the fix (red without it, green with it) — `tests/test_objective_reconcile.py::TestRunProvenanceSweepCommitSurvivesClose`:
- Writes a real commit with a `Dispatch-ID:` trailer, runs `_run_provenance_sweep`, then **re-opens a fresh connection** to confirm the row survived `close()` (not just that it was visible within the same still-open transaction).
- I independently reproduced the exact pre-fix call pattern (connect → `reconcile_commit_provenance` → `close()` without commit) directly against the unmodified `receipt_provenance.py`: it reported `linked=1` while a fresh connection showed the row gone — confirming the historical lie and that this test catches it.

Loud-failure test — `TestRunProvenanceSweepCommitFailureIsLoud`:
- Simulates a `commit()` failure (custom `sqlite3.Connection` subclass via connection factory) and asserts an ERROR-level log record exists and the returned counts are zeroed, not silently absorbed into the debug-level catch.
- A second test confirms an ordinary scan-level error (missing state dir) still stays quiet/non-fatal — the pre-existing contract for that class of failure is unchanged.

Counter-honesty tests — `tests/test_receipt_provenance.py::TestReconcileCommitProvenanceLinkedPendingCommit`:
- `linked_pending_commit` mirrors `linked` before the caller commits.
- Is `0` when nothing was written.
- Is `0` under autocommit (`isolation_level=None`), where writes are durable immediately even though this function still never calls `.commit()` — proving the field tracks real durability risk, not just `linked > 0`.

Test commands run:
```
python3 -m pytest tests/test_objective_reconcile.py tests/test_receipt_provenance.py \
  tests/test_git_provenance.py tests/test_provenance_registry_population.py \
  tests/test_provenance_verification.py -q
# 176 passed
```
One pre-existing exact-dict-equality assertion in `tests/test_provenance_registry_population.py::test_reconcile_bad_repo_is_fail_open` was updated to include the new `linked_pending_commit` key (genuine, expected fallout from the new field — not masked).

Also ran the wider `provenance`/`reconcile`-filtered suite (`-k "provenance or reconcile"`, 366 tests) to check for indirect impact: 3 unrelated pre-existing failures in `test_terminal_state_reconciler.py` / `test_track_reconciler.py` (confirmed present on `main` without this branch's changes, in modules this PR does not touch). No regressions from this change.

Note: 3 tests in `test_receipt_provenance.py` (`TestEnrichReceiptProvenance::test_handles_receipt_with_no_dispatch_id`, `TestValidateReceiptProvenance::test_detects_missing_dispatch_id`, `test_broken_chain_no_dispatch_no_git`) fail only when run inside this dispatch's own shell, because the harness sets `VNX_CURRENT_DISPATCH_ID`/`VNX_DISPATCH_ID` in the environment and those tests don't isolate against it. Confirmed pre-existing (fails identically on `main`) and unrelated to this PR; passes cleanly with those env vars unset. Not fixed here — out of scope.

No manual `reconcile_provenance.py` run was made against any production store, per dispatch instructions.

## Open Items

None within this PR's scope. Per the root-cause doc's fix-order, PR-B covers: `pr_number` propagation into `register_provenance_link` (receipt_provenance.py:740), state-dir resolution via the central per-project store, the `receipt_id` completeness predicate for lane-synthesized receipts, and the `VNX_TMUX_SESSION_ID` gate on `dispatch_metadata` writes.

Dispatch-ID: 20260729-provenance-pr-a-commit-sonnet