### PR TITLE
feat(worker-provider-free-choice): PR-1 ModelPin contract, behavior-neutral

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -38,6 +38,7 @@ from dispatch_spec import (  # noqa: E402
 from dispatch_plan import (  # noqa: E402
     ConstraintVerdict,
     ExecutionPlan,
+    ModelPin,
     RuntimeSnapshot,
     compile_plan,
 )
@@ -230,11 +231,11 @@ def _print_plan(plan: ExecutionPlan, fp: str) -> None:
 # P1-#3: model pins from SSOT
 # ---------------------------------------------------------------------------
 
-_DEFAULT_MODEL_PINS: dict[str, str] = {
-    "T0": "opus",
-    "T1": "kimi-k3",
-    "T2": "kimi-k3",
-    "T3": "kimi-k3",
+_DEFAULT_MODEL_PINS: dict[str, ModelPin] = {
+    "T0": ModelPin(model="opus", semantics="floor"),
+    "T1": ModelPin(model="kimi-k3", semantics="floor"),
+    "T2": ModelPin(model="kimi-k3", semantics="floor"),
+    "T3": ModelPin(model="kimi-k3", semantics="floor"),
 }
 
 # worker-claude-override (escape-hatch-worker-claude, 2026-07-23): gated, audited
@@ -250,33 +251,65 @@ WORKER_CLAUDE_OVERRIDE_ENV = "VNX_OVERRIDE_WORKER_CLAUDE"
 WORKER_CLAUDE_OVERRIDE_REASON_ENV = "VNX_OVERRIDE_WORKER_CLAUDE_REASON"
 
 
-def _load_model_pins_from_yaml() -> dict[str, str]:
-    """Load T0/T1/T2/T3 model pins from provider_constraints.yaml SSOT.
+_KNOWN_PIN_SEMANTICS = frozenset({"floor", "default"})
 
-    Falls back to DEFAULT_MODEL_PINS on any read/parse error (never raises).
+
+def _load_model_pins_from_yaml() -> dict[str, ModelPin]:
+    """Load T0/T1/T2/T3 model pins (with pin semantics) from provider_constraints.yaml SSOT.
+
+    Read/parse failures (missing file, invalid YAML, unsupported schema version) are NOT
+    silently swallowed: they are logged loudly and fall back to _DEFAULT_MODEL_PINS, which
+    itself carries explicit semantics — the fallback reproduces the intended pin state, it
+    never silently softens it (dispatch_cli-part of OI-826).
+
+    An unrecognized `pin_semantics` value on a present constraint is a config-authoring
+    error, not a read failure, and is a categorically different case: it is NEVER silently
+    interpreted as `floor` or `default` and is NOT caught here — it propagates so the
+    dispatch fails loud (caught by run_dispatch's outer runtime-error handler).
     """
     yaml_path = _LIB_DIR / "providers" / "provider_constraints.yaml"
     try:
         import yaml  # noqa: PLC0415
         with yaml_path.open(encoding="utf-8") as fh:
             data = yaml.safe_load(fh)
-        if not isinstance(data, dict) or data.get("version") != 1:
-            return dict(_DEFAULT_MODEL_PINS)
-        pins: dict[str, str] = {}
-        for constraint in (data.get("constraints") or []):
-            cid = str(constraint.get("id", ""))
-            required = constraint.get("required_route") or {}
-            model = required.get("model")
-            if not model:
-                continue
-            if cid == "t0-opus-only":
-                pins["T0"] = str(model)
-            elif cid == "workers-kimi-pinned":
-                for slot in ("T1", "T2", "T3"):
-                    pins[slot] = str(model)
-        return {**_DEFAULT_MODEL_PINS, **pins}
-    except Exception:
+    except Exception as exc:
+        logger.error(
+            "[dispatch_cli] model-pins YAML unreadable at %s (%s) — falling back to "
+            "_DEFAULT_MODEL_PINS",
+            yaml_path, exc,
+        )
         return dict(_DEFAULT_MODEL_PINS)
+
+    if not isinstance(data, dict) or data.get("version") != 1:
+        logger.error(
+            "[dispatch_cli] model-pins YAML at %s has a missing/unsupported version "
+            "(expected 1) — falling back to _DEFAULT_MODEL_PINS",
+            yaml_path,
+        )
+        return dict(_DEFAULT_MODEL_PINS)
+
+    pins: dict[str, ModelPin] = {}
+    for constraint in (data.get("constraints") or []):
+        cid = str(constraint.get("id", ""))
+        required = constraint.get("required_route") or {}
+        model = required.get("model")
+        if not model:
+            continue
+        # Missing pin_semantics on a present constraint reads as "floor" — a
+        # not-yet-migrated constraint must never silently soften.
+        semantics = constraint.get("pin_semantics", "floor")
+        if semantics not in _KNOWN_PIN_SEMANTICS:
+            raise ValueError(
+                f"provider_constraints.yaml constraint {cid!r} has unknown "
+                f"pin_semantics {semantics!r} (expected 'floor' or 'default')"
+            )
+        pin = ModelPin(model=str(model), semantics=semantics)
+        if cid == "t0-opus-only":
+            pins["T0"] = pin
+        elif cid == "workers-kimi-pinned":
+            for slot in ("T1", "T2", "T3"):
+                pins[slot] = pin
+    return {**_DEFAULT_MODEL_PINS, **pins}
 
 
 # ---------------------------------------------------------------------------
@@ -630,7 +663,11 @@ def build_runtime_snapshot(
     via = _via_for_provider(provider_value, sub_provider)
 
     # P1-#3: model_pins from SSOT
-    model_pins = _load_model_pins_from_yaml()
+    model_pin_specs = _load_model_pins_from_yaml()  # dict[str, ModelPin]
+    # Legacy string-valued view for the effective_model computation below — this PR
+    # (worker-provider-free-choice PR-1) only changes the contract type, not the
+    # coercion behavior; PR-2 replaces this computation to honor pin.semantics.
+    model_pins = {slot: pin.model for slot, pin in model_pin_specs.items()}
 
     # P0-1: effective model — same computation compile_plan uses in D4
     #
@@ -830,12 +867,12 @@ def build_runtime_snapshot(
 
     # worker-claude-override: strip the kimi-k3 pin for THIS dispatch's snapshot
     # only, so compile_plan's D4 resolves the requested claude model instead of the
-    # pin. The loaded model_pins dict itself is never mutated; every dispatch that
-    # does not carry the override still sees the full pins (kimi stays default).
-    snapshot_model_pins = model_pins
+    # pin. The loaded model_pin_specs dict itself is never mutated; every dispatch
+    # that does not carry the override still sees the full pins (kimi stays default).
+    snapshot_model_pins = model_pin_specs
     if worker_claude_override_reason is not None:
         snapshot_model_pins = {
-            slot: pin for slot, pin in model_pins.items() if slot != spec.target_slot
+            slot: pin for slot, pin in model_pin_specs.items() if slot != spec.target_slot
         }
 
     return RuntimeSnapshot(

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -38,12 +38,29 @@ class ConstraintVerdict:
 
 
 @dataclass(frozen=True)
+class ModelPin:
+    """A model pin carrying enforcement semantics, not just a model name.
+
+    floor:   coercive — spec.model is ignored, the pin always wins (today's
+             behavior for both t0-opus-only and workers-kimi-pinned).
+    default: advisory — spec.model wins when the caller set one; the pin is
+             only used as a fallback when spec.model is absent.
+
+    worker-provider-free-choice PR-1: this type only carries the contract.
+    D4 below still ignores `semantics` and always coerces to the pin
+    (gedragsneutraal) — honoring `semantics` is PR-3's job.
+    """
+    model: str
+    semantics: str  # "floor" | "default"
+
+
+@dataclass(frozen=True)
 class RuntimeSnapshot:
     constraint_verdicts: tuple[ConstraintVerdict, ...] = ()
     staging_promoted: bool = False
     target_health: Mapping[str, str] = field(default_factory=dict)    # target_id -> "healthy"|"unhealthy"|"offline"
     target_capable: Mapping[str, bool] = field(default_factory=dict)  # target_id -> capability match
-    model_pins: Mapping[str, str] = field(default_factory=dict)       # target_slot -> pinned model
+    model_pins: Mapping[str, ModelPin] = field(default_factory=dict)  # target_slot -> pin (model + semantics)
     claude_serial_enabled: bool = True
 
 
@@ -195,7 +212,8 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     # rather than silently falling back to sonnet (kimi-only, no fallback policy).
     target_slot = spec.target_slot
     if is_claude_lane:
-        pinned = snapshot.model_pins.get(target_slot)
+        pin = snapshot.model_pins.get(target_slot)
+        pinned = pin.model if pin is not None else None
         requested = spec.model
         if pinned:
             if requested and requested != pinned:

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -22,6 +22,14 @@
 #   audit_severity   blocking | warn | info
 #   override_allowed bool; when true operator may bypass via env flag
 #                    VNX_OVERRIDE_<UPPERCASED_ID_WITH_UNDERSCORES>=1
+#   pin_semantics    floor | default; only meaningful on require_route constraints
+#                    consumed as a model pin (t0-opus-only, workers-kimi-pinned).
+#                    floor = coercive, spec.model is ignored, the pin always wins.
+#                    default = advisory, spec.model wins when the caller set one.
+#                    Missing on a present constraint reads as floor (never silently
+#                    softens); an unrecognized value fails loud at load time
+#                    (worker-provider-free-choice PR-1, scripts/lib/dispatch_cli.py
+#                    _load_model_pins_from_yaml).
 
 version: 1
 
@@ -52,6 +60,7 @@ constraints:
     enforcement: code_warn
     audit_severity: warn
     override_allowed: true
+    pin_semantics: floor
 
   # NOTE: id intentionally retained as `workers-kimi-pinned`. The pin-loader
   # (_load_model_pins_from_yaml in scripts/lib/dispatch_cli.py) hard-keys on
@@ -76,6 +85,7 @@ constraints:
     enforcement: code_warn
     audit_severity: warn
     override_allowed: true
+    pin_semantics: floor
 
   - id: no-anthropic-sdk
     rule: forbid_import

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -43,6 +43,7 @@ from providers.constraint_enforcer import (
 from dispatch_plan import (
     ConstraintVerdict,
     ExecutionPlan,
+    ModelPin,
     RuntimeSnapshot,
     compile_plan,
 )
@@ -120,7 +121,12 @@ def _clean_snapshot(*, staging_promoted: bool = True) -> RuntimeSnapshot:
         staging_promoted=staging_promoted,
         target_health={"ephemeral": "healthy", "T1": "healthy"},
         target_capable={"ephemeral": True, "T1": True},
-        model_pins={"T0": "opus", "T1": "sonnet", "T2": "sonnet", "T3": "sonnet"},
+        model_pins={
+            "T0": ModelPin(model="opus", semantics="floor"),
+            "T1": ModelPin(model="sonnet", semantics="floor"),
+            "T2": ModelPin(model="sonnet", semantics="floor"),
+            "T3": ModelPin(model="sonnet", semantics="floor"),
+        },
     )
 
 
@@ -1106,12 +1112,14 @@ def test_forbid_route_blocking_verdict_rejects_dispatch(tmp_path):
 # ---------------------------------------------------------------------------
 
 def test_default_model_pins_flip_workers_to_kimi_k3():
-    """_DEFAULT_MODEL_PINS must pin T1/T2/T3 to kimi-k3 post-flip; T0 stays opus."""
+    """_DEFAULT_MODEL_PINS must pin T1/T2/T3 to kimi-k3 post-flip; T0 stays opus.
+    worker-provider-free-choice PR-1: pins now carry explicit floor semantics —
+    ModelPin, not a bare string."""
     assert _DEFAULT_MODEL_PINS == {
-        "T0": "opus",
-        "T1": "kimi-k3",
-        "T2": "kimi-k3",
-        "T3": "kimi-k3",
+        "T0": ModelPin(model="opus", semantics="floor"),
+        "T1": ModelPin(model="kimi-k3", semantics="floor"),
+        "T2": ModelPin(model="kimi-k3", semantics="floor"),
+        "T3": ModelPin(model="kimi-k3", semantics="floor"),
     }
 
 
@@ -1119,12 +1127,13 @@ def test_load_model_pins_from_yaml_reads_workers_kimi_pinned():
     """_load_model_pins_from_yaml() matches the RENAMED constraint id
     (workers-kimi-pinned, not workers-sonnet-pinned) and loads its
     required_route.model (kimi-k3) for T1/T2/T3 from the real
-    provider_constraints.yaml SSOT. T0 still resolves via t0-opus-only."""
+    provider_constraints.yaml SSOT. T0 still resolves via t0-opus-only.
+    Both constraints declare pin_semantics: floor in the SSOT (PR-1)."""
     pins = _load_model_pins_from_yaml()
-    assert pins["T0"] == "claude-opus-4-8"
-    assert pins["T1"] == "kimi-k3"
-    assert pins["T2"] == "kimi-k3"
-    assert pins["T3"] == "kimi-k3"
+    assert pins["T0"] == ModelPin(model="claude-opus-4-8", semantics="floor")
+    assert pins["T1"] == ModelPin(model="kimi-k3", semantics="floor")
+    assert pins["T2"] == ModelPin(model="kimi-k3", semantics="floor")
+    assert pins["T3"] == ModelPin(model="kimi-k3", semantics="floor")
 
 
 def test_load_model_pins_from_yaml_ignores_stale_sonnet_pinned_id(tmp_path):
@@ -1147,9 +1156,89 @@ def test_load_model_pins_from_yaml_ignores_stale_sonnet_pinned_id(tmp_path):
     }))
     with patch("dispatch_cli._LIB_DIR", tmp_path):
         pins = _load_model_pins_from_yaml()
-    assert pins["T1"] == "kimi-k3", "stale workers-sonnet-pinned id must not override the default pin"
-    assert pins["T2"] == "kimi-k3"
-    assert pins["T3"] == "kimi-k3"
+    assert pins["T1"] == ModelPin(model="kimi-k3", semantics="floor"), (
+        "stale workers-sonnet-pinned id must not override the default pin"
+    )
+    assert pins["T2"] == ModelPin(model="kimi-k3", semantics="floor")
+    assert pins["T3"] == ModelPin(model="kimi-k3", semantics="floor")
+
+
+# ---------------------------------------------------------------------------
+# worker-provider-free-choice PR-1 — ModelPin contract tests
+# ---------------------------------------------------------------------------
+
+def test_load_model_pins_reads_floor_semantics_from_real_yaml():
+    """Both t0-opus-only and workers-kimi-pinned declare pin_semantics: floor in the
+    real SSOT; PR-1 only introduces the contract, it does not flip anything to default."""
+    pins = _load_model_pins_from_yaml()
+    assert pins["T0"].semantics == "floor"
+    assert pins["T1"].semantics == "floor"
+    assert pins["T2"].semantics == "floor"
+    assert pins["T3"].semantics == "floor"
+
+
+def test_load_model_pins_missing_pin_semantics_reads_as_floor(tmp_path):
+    """A present constraint that has not been migrated to carry pin_semantics must
+    never silently soften to 'default' — it reads as 'floor'."""
+    import yaml as _yaml
+    providers_dir = tmp_path / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "provider_constraints.yaml").write_text(_yaml.safe_dump({
+        "version": 1,
+        "constraints": [
+            {
+                "id": "t0-opus-only",
+                "rule": "require_route",
+                "required_route": {"role": "T0", "model": "claude-opus-4-8"},
+                # pin_semantics intentionally absent
+            },
+        ],
+    }))
+    with patch("dispatch_cli._LIB_DIR", tmp_path):
+        pins = _load_model_pins_from_yaml()
+    assert pins["T0"] == ModelPin(model="claude-opus-4-8", semantics="floor")
+
+
+def test_load_model_pins_unknown_semantics_fails_loud(tmp_path):
+    """An unrecognized pin_semantics value is a config-authoring error and must never
+    be silently interpreted as 'floor' or 'default' — it raises instead of falling back."""
+    import yaml as _yaml
+    providers_dir = tmp_path / "providers"
+    providers_dir.mkdir()
+    (providers_dir / "provider_constraints.yaml").write_text(_yaml.safe_dump({
+        "version": 1,
+        "constraints": [
+            {
+                "id": "t0-opus-only",
+                "rule": "require_route",
+                "required_route": {"role": "T0", "model": "claude-opus-4-8"},
+                "pin_semantics": "sometimes",
+            },
+        ],
+    }))
+    with patch("dispatch_cli._LIB_DIR", tmp_path):
+        with pytest.raises(ValueError, match="pin_semantics"):
+            _load_model_pins_from_yaml()
+
+
+def test_load_model_pins_unreadable_yaml_fails_loud_and_falls_back(tmp_path, caplog):
+    """Missing/unreadable YAML is a read failure, not a config-authoring error: it
+    logs loudly (observable, unlike the old silent bare-except) AND still returns the
+    fallback, which itself carries explicit floor semantics."""
+    import logging
+    providers_dir = tmp_path / "providers"
+    providers_dir.mkdir()
+    # No provider_constraints.yaml written at all -> FileNotFoundError on open()
+
+    with patch("dispatch_cli._LIB_DIR", tmp_path):
+        with caplog.at_level(logging.ERROR):
+            pins = _load_model_pins_from_yaml()
+
+    assert pins == _DEFAULT_MODEL_PINS
+    assert pins["T0"] == ModelPin(model="opus", semantics="floor")
+    assert any("model-pins YAML unreadable" in rec.message for rec in caplog.records), (
+        "unreadable YAML must log loudly, not silently fall back"
+    )
 
 
 def test_raw_kimi_model_rejected_despite_workers_sonnet_pin(tmp_path, monkeypatch, capsys):

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -23,6 +23,7 @@ from dispatch_internal import is_valid_instruction_hash, issue_permit, require_p
 from dispatch_plan import (
     ConstraintVerdict,
     ExecutionPlan,
+    ModelPin,
     RuntimeSnapshot,
     compile_plan,
 )
@@ -255,7 +256,8 @@ class TestBlockingConstraint:
 class TestModelTierPin:
     def test_t0_pinned_to_opus(self, tmp_path: Path) -> None:
         vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T0", tmp_path=tmp_path)
-        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        snapshot = _healthy_snapshot(model_pins={"T0": ModelPin(model="opus", semantics="floor")})
+        plan = compile_plan(vspec, snapshot)
         assert isinstance(plan, ExecutionPlan)
         assert plan.model == "opus"
         assert not any("model-tier" in w for w in plan.warnings)
@@ -264,14 +266,16 @@ class TestModelTierPin:
         vspec = _make_vspec(
             provider=Provider.CLAUDE, target_slot="T0", model="sonnet", tmp_path=tmp_path
         )
-        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T0": "opus"}))
+        snapshot = _healthy_snapshot(model_pins={"T0": ModelPin(model="opus", semantics="floor")})
+        plan = compile_plan(vspec, snapshot)
         assert isinstance(plan, ExecutionPlan)
         assert plan.model == "opus"
         assert any("model-tier" in w for w in plan.warnings)
 
     def test_t1_pinned_to_sonnet(self, tmp_path: Path) -> None:
         vspec = _make_vspec(provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path)
-        plan = compile_plan(vspec, _healthy_snapshot(model_pins={"T1": "sonnet"}))
+        snapshot = _healthy_snapshot(model_pins={"T1": ModelPin(model="sonnet", semantics="floor")})
+        plan = compile_plan(vspec, snapshot)
         assert isinstance(plan, ExecutionPlan)
         assert plan.model == "sonnet"
 


### PR DESCRIPTION
## Summary
Deliverable 1 of 5 for track `worker-provider-free-choice` (see `claudedocs/plans/worker-provider-free-choice.md`, revisie 2). Introduces `ModelPin(model, semantics)` as the contract for `RuntimeSnapshot.model_pins`, replacing the bare model-name string. This PR is **behavior-neutral**: every existing routing outcome is identical before/after, because both `t0-opus-only` and `workers-kimi-pinned` declare `pin_semantics: floor` in the SSOT — exactly today's coercive behavior. PR-4 (later) flips `workers-kimi-pinned` to `default` via a single YAML line; that's the only PR that changes observable routing.

## Changes
- `scripts/lib/dispatch_plan.py`: new frozen `ModelPin` dataclass (`model: str`, `semantics: str`); `RuntimeSnapshot.model_pins` type changed to `Mapping[str, ModelPin]`; D4 in `compile_plan` unwraps `pin.model` at the retrieval point only — the rest of D4's logic (lines 199-211) is untouched.
- `scripts/lib/dispatch_cli.py`: `_DEFAULT_MODEL_PINS` now carries `ModelPin` values with explicit `floor` semantics for T0-T3. `_load_model_pins_from_yaml()` reads a new `pin_semantics` field per constraint (missing field on a present constraint → `floor`; unrecognized value → raises `ValueError`, never silently coerced). The previously-silent bare `except Exception: return dict(_DEFAULT_MODEL_PINS)` now logs loudly (`logger.error`) before falling back — the dispatch_cli half of OI-826. `build_runtime_snapshot`'s door-coercion computation (`dispatch_cli.py:690`, PR-2's job) is untouched — it now operates on a derived string view (`model_pins = {slot: pin.model for slot, pin in model_pin_specs.items()}`) so its behavior stays byte-identical.
- `scripts/lib/providers/provider_constraints.yaml`: added `pin_semantics: floor` to `t0-opus-only` and `workers-kimi-pinned`, plus schema documentation in the header block.
- Tests: migrated the 4 pin-shape tests that assert on the old string form (`test_default_model_pins_flip_workers_to_kimi_k3`, `test_load_model_pins_from_yaml_reads_workers_kimi_pinned`, `test_load_model_pins_from_yaml_ignores_stale_sonnet_pinned_id`, `TestModelTierPin`'s 3 methods) to construct/assert `ModelPin` instances. Also updated the shared `_clean_snapshot()` fixture in `test_dispatch_cli.py` (not itself a "shape" test, but needed so the ~4 other tests that reach D4 via a mocked snapshot keep passing under the new `.model` unwrap). Added 4 new tests: floor read from the real YAML, missing-field defaults to floor, unknown value fails loud, unreadable/missing YAML fails loud and falls back with semantics.

## Verification
- `python3 -m pytest tests/test_dispatch_plan.py tests/test_dispatch_cli.py -v` → **202 passed**, 0 failed.
- Full dispatch-suite sweep: `python3 -m pytest tests/test_dispatch*.py tests/test_provider_dispatch*.py tests/test_subprocess_dispatch*.py tests/test_dispatcher*.py -q` → 43 failed, 1411 passed. Verified via `git stash` that the exact same 43 tests fail identically on the pre-PR baseline (worktree/environment-specific: missing `.git/worktrees` as a real directory in this worktree checkout, missing sqlite tables, thread-timing flakiness) — none touch `dispatch_plan.py`/`dispatch_cli.py`'s model-pin code, and none are newly broken by this change.
- Explicitly confirmed `test_no_override_claude_on_build_worker_still_hard_rejects` (the design doc's named floor-regression guard) stays green.

## Open Items
None — PR-1 is scoped exactly to the ModelPin contract per the plan; PR-2 (door-coercion honors semantics), PR-3 (D4 honors semantics), PR-4 (the YAML flip), and PR-5 (retire the escape-hatch env-vars) are separate, already-scoped follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)