### PR TITLE
feat(worker-provider-free-choice): PR-2 door coercion honors ModelPin.semantics

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -664,25 +664,21 @@ def build_runtime_snapshot(
 
     # P1-#3: model_pins from SSOT
     model_pin_specs = _load_model_pins_from_yaml()  # dict[str, ModelPin]
-    # Legacy string-valued view for the effective_model computation below — this PR
-    # (worker-provider-free-choice PR-1) only changes the contract type, not the
-    # coercion behavior; PR-2 replaces this computation to honor pin.semantics.
-    model_pins = {slot: pin.model for slot, pin in model_pin_specs.items()}
 
     # P0-1: effective model — same computation compile_plan uses in D4
     #
-    # worker-provider-kimi-flip (20260723): model_pins now resolves T1/T2/T3 to
+    # worker-provider-kimi-flip (20260723): model_pin_specs now resolves T1/T2/T3 to
     # "kimi-k3" (workers-kimi-pinned). The "sonnet" fallback below is intentionally
     # UNCHANGED — it only fires when is_claude_lane is True (an explicit provider=
     # claude override, or a non-standard target_slot with no pin) and spec.model was
     # not given; it must stay a valid Claude model name. If an explicit claude
-    # override lands on T1/T2/T3, model_pins.get() returns "kimi-k3" (a non-Claude
-    # label) which correctly fails the check_registry gate below (model-not-in-
-    # current-registry, blocking) instead of silently dispatching sonnet — matching
-    # the "kimi-only, no fallback" policy (fail loud, never a silent claude rescue).
-    # The ONLY sanctioned way past that reject is the gated, audited operator
-    # escape-hatch directly below (worker-claude-override); everything else about
-    # the default path is unchanged.
+    # override lands on T1/T2/T3 under a `floor` pin, the resolved model is
+    # "kimi-k3" (a non-Claude label) which correctly fails the check_registry gate
+    # below (model-not-in-current-registry, blocking) instead of silently
+    # dispatching sonnet — matching the "kimi-only, no fallback" policy (fail loud,
+    # never a silent claude rescue). The ONLY sanctioned way past that reject is
+    # the gated, audited operator escape-hatch directly below (worker-claude-
+    # override); everything else about the default path is unchanged.
     is_claude_lane = spec.provider == Provider.CLAUDE
 
     # worker-claude-override gate (escape-hatch-worker-claude): evaluate the
@@ -724,7 +720,19 @@ def build_runtime_snapshot(
             # bypass of the constraint engine.
             effective_model = spec.model or "sonnet"
         else:
-            effective_model = model_pins.get(spec.target_slot) or spec.model or "sonnet"
+            # worker-provider-free-choice PR-2: honor ModelPin.semantics instead of
+            # always coercing to the pin. "floor" is today's behavior verbatim —
+            # spec.model is ignored, the pin always wins. "default" is advisory —
+            # spec.model wins when set, the pin only fills in when spec carries no
+            # model at all. The `or "sonnet"` tail stays the last-resort fallback
+            # on both branches.
+            pin = model_pin_specs.get(spec.target_slot)
+            if pin is None:
+                effective_model = spec.model or "sonnet"
+            elif pin.semantics == "floor":
+                effective_model = pin.model or "sonnet"
+            else:  # "default" — loader fails loud on any other value at load time
+                effective_model = spec.model or pin.model or "sonnet"
     else:
         effective_model = spec.model or "default"
 

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -55,6 +55,7 @@ from dispatch_spec import (
     Provider,
     Reject,
     ValidatedSpec,
+    validate,
 )
 
 
@@ -1238,6 +1239,126 @@ def test_load_model_pins_unreadable_yaml_fails_loud_and_falls_back(tmp_path, cap
     assert pins["T0"] == ModelPin(model="opus", semantics="floor")
     assert any("model-pins YAML unreadable" in rec.message for rec in caplog.records), (
         "unreadable YAML must log loudly, not silently fall back"
+    )
+
+
+# ---------------------------------------------------------------------------
+# worker-provider-free-choice PR-2 — door coercion honors ModelPin.semantics
+#
+# These call build_runtime_snapshot() directly (bypassing compile_plan/D4, which
+# still unconditionally coerces to the pin until PR-3) so the assertions target
+# exactly what PR-2 controls: the model fed into the constraint check. A
+# blocking kimi-via-cli-only verdict is the observable proxy for "effective_model
+# resolved to kimi-k3"; its absence proves the requested claude model won instead
+# (constraint_enforcer's kimi-substring guard fires on ANY non-kimi provider
+# carrying a kimi-branded model, so this proxy is exact, not approximate).
+# ---------------------------------------------------------------------------
+
+def _write_default_semantics_workers_pin_yaml(providers_dir: Path) -> None:
+    """A fabricated SSOT where workers-kimi-pinned carries pin_semantics: default.
+
+    The real provider_constraints.yaml stays 'floor' throughout PR-2 (see
+    test_load_model_pins_reads_floor_semantics_from_real_yaml) -- the 'default'
+    branch in dispatch_cli's coercion is only reachable via a fixture like this.
+    """
+    import yaml as _yaml
+    providers_dir.mkdir(parents=True, exist_ok=True)
+    (providers_dir / "provider_constraints.yaml").write_text(_yaml.safe_dump({
+        "version": 1,
+        "constraints": [
+            {
+                "id": "workers-kimi-pinned",
+                "rule": "require_route",
+                "required_route": {"role": ["T1", "T2", "T3"], "model": "kimi-k3"},
+                "pin_semantics": "default",
+            },
+        ],
+    }))
+
+
+def test_build_runtime_snapshot_floor_ignores_explicit_differing_model(tmp_path):
+    """'floor' is today's behavior verbatim: spec.model is ignored and the pin
+    always wins, even when spec.model is an explicit, differing claude model.
+    Uses the REAL (non-fabricated) SSOT, which declares floor throughout PR-2."""
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Floor coercion\n\nExplicit sonnet must be ignored under the floor pin.\n",
+        staging_id="20260729-staging-floor-explicit",
+        dispatch_id="20260729-floor-explicit-diff",
+        provider="claude",
+        target_slot="T1",
+        model="sonnet",
+    )
+    spec = load_spec(spec_file)
+    vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+    assert not isinstance(vspec, Reject)
+
+    snapshot = build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
+
+    assert snapshot.model_pins["T1"] == ModelPin(model="kimi-k3", semantics="floor")
+    kimi_blocks = [v for v in snapshot.constraint_verdicts if v.code == "kimi-via-cli-only"]
+    assert kimi_blocks and kimi_blocks[0].severity == "blocking", (
+        "floor semantics must ignore the explicit differing spec.model (sonnet) and "
+        "feed the pinned kimi-k3 into the constraint check, exactly like before PR-2"
+    )
+
+
+def test_build_runtime_snapshot_default_semantics_spec_model_wins(tmp_path):
+    """Under a fabricated 'default' pin, an explicit spec.model wins over the pin:
+    the constraint check runs against the REQUESTED model, so kimi-via-cli-only
+    never fires even though T1 carries a kimi-k3 pin."""
+    providers_dir = tmp_path / "lib" / "providers"
+    _write_default_semantics_workers_pin_yaml(providers_dir)
+
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Default semantics\n\nExplicit sonnet must win over the kimi-k3 pin.\n",
+        staging_id="20260729-staging-default-wins",
+        dispatch_id="20260729-default-wins",
+        provider="claude",
+        target_slot="T1",
+        model="sonnet",
+    )
+    spec = load_spec(spec_file)
+    vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+    assert not isinstance(vspec, Reject)
+
+    with patch("dispatch_cli._LIB_DIR", tmp_path / "lib"):
+        snapshot = build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
+
+    assert snapshot.model_pins["T1"] == ModelPin(model="kimi-k3", semantics="default")
+    assert not any(v.code == "kimi-via-cli-only" for v in snapshot.constraint_verdicts), (
+        "default semantics: spec.model (sonnet) must win over the kimi-k3 pin, so "
+        "the constraint check must never see kimi-k3 for this dispatch"
+    )
+
+
+def test_build_runtime_snapshot_default_semantics_fills_pin_when_model_absent(tmp_path):
+    """Under a fabricated 'default' pin, a spec that carries NO model at all still
+    gets the pin as a fallback -- 'default' is advisory, not 'no pin at all'."""
+    providers_dir = tmp_path / "lib" / "providers"
+    _write_default_semantics_workers_pin_yaml(providers_dir)
+
+    data_dir, spec_file = _make_bundle_spec(
+        tmp_path,
+        instruction_text="# Default semantics, no explicit model\n\nMust fall back to the pin.\n",
+        staging_id="20260729-staging-default-fallback",
+        dispatch_id="20260729-default-fallback",
+        provider="claude",
+        target_slot="T1",
+    )
+    spec = load_spec(spec_file)
+    vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+    assert not isinstance(vspec, Reject)
+
+    with patch("dispatch_cli._LIB_DIR", tmp_path / "lib"):
+        snapshot = build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
+
+    assert snapshot.model_pins["T1"] == ModelPin(model="kimi-k3", semantics="default")
+    kimi_blocks = [v for v in snapshot.constraint_verdicts if v.code == "kimi-via-cli-only"]
+    assert kimi_blocks and kimi_blocks[0].severity == "blocking", (
+        "no spec.model -> the pin (kimi-k3) must still be used as a fallback under "
+        "'default' semantics, tripping kimi-via-cli-only exactly like the floor case"
     )
 
 


### PR DESCRIPTION
## Summary

PR-2 of 5 in the `worker-provider-free-choice` track (see `claudedocs/plans/worker-provider-free-choice.md`, revision 2). Follows PR-1 (#1239, `ModelPin` contract).

`dispatch_cli.py`'s door-coercion (`build_runtime_snapshot`'s `effective_model` computation, previously at line 690) now honors `ModelPin.semantics` instead of unconditionally coercing to the pin:

- `semantics == "floor"` — today's behavior verbatim. `spec.model` is ignored; the pin always wins.
- `semantics == "default"` — advisory. `spec.model` wins when set; the pin only fills in when the spec carries no model at all.
- The `or "sonnet"` last-resort fallback is unchanged on both branches.

The now-unused `model_pins` string-valued legacy view (built solely to feed the old coercion line) was removed; the coercion reads `model_pin_specs` (the `ModelPin` mapping) directly.

## Why this is behavior-neutral

`provider_constraints.yaml` declares `pin_semantics: floor` on both `t0-opus-only` and `workers-kimi-pinned` (landed in PR-1, #1239). Every pin the door resolves today is `floor`, so this PR produces byte-identical `effective_model` values and identical rejects to before. The `default` branch is new code with no production reachability yet — it's exercised only via a fabricated YAML fixture in the new tests. The YAML flip to `default` is PR-4, not this PR.

**Untouched, per the plan's guardrails:**
- `dispatch_plan.py:196-211` (D4) — that's PR-3's job. D4 still unconditionally coerces to the pin regardless of semantics; this is a known, documented intermediate state.
- `VNX_OVERRIDE_WORKER_CLAUDE` / override plumbing — PR-5.
- The constraint engine (`providers/constraint_enforcer.py`) — both guards (kimi-substring, registry) are untouched and still fire on the coerced model.

## Changes

- `scripts/lib/dispatch_cli.py` — `build_runtime_snapshot`: replaced the single-line pin coercion with a semantics-aware branch; removed the dead `model_pins` string view; updated two stale comments that referenced it.
- `tests/test_dispatch_cli.py` — added `validate` to the `dispatch_spec` import; added a new PR-2 test section:
  - `test_build_runtime_snapshot_floor_ignores_explicit_differing_model` — floor semantics (real SSOT) ignores an explicit, differing `spec.model`.
  - `test_build_runtime_snapshot_default_semantics_spec_model_wins` — fabricated `default` fixture: `spec.model` wins over the pin.
  - `test_build_runtime_snapshot_default_semantics_fills_pin_when_model_absent` — fabricated `default` fixture: pin fills in when `spec.model` is absent.

  These call `build_runtime_snapshot()` directly (not the full `run_dispatch` → `compile_plan` path) so the assertions target exactly what this PR controls — the constraint check's input model — rather than `plan.model`, which D4 still recomputes independently until PR-3 lands. Presence/absence of a blocking `kimi-via-cli-only` verdict is used as the observable proxy for whether `effective_model` resolved to `kimi-k3` vs. the requested claude model (exact, not approximate — `constraint_enforcer`'s kimi-substring guard fires on any non-kimi provider carrying a kimi-branded model).

## Verification

Full command: `python3 -m pytest tests/test_dispatch_cli.py tests/test_dispatch_plan.py tests/test_context_rotation.py tests/test_constraint_enforcer_kimi_bare_alias.py tests/test_dispatch_agent_deadline_passthrough.py tests/test_dispatch_bridge_staging.py tests/test_dispatch_door_authority.py tests/test_dispatch_enforcement.py tests/test_dispatch_envelope_fail_loud.py tests/test_dispatch_sh_contract.py tests/test_dispatch_sidedoor_audit.py tests/test_dispatch_spec.py tests/test_door_flip_d1_routing.py tests/test_gate_findings_bridge.py tests/test_glm_harness_normalization.py tests/test_plan_gate_enforcement.py tests/test_pretooluse_spawn_detector.py tests/test_provider_dispatch_entry.py tests/test_smart_router_wiring.py tests/test_vnx_tag_vocabulary.py tests/test_vnx_tagger.py -q`

Result: **820 passed**, 0 failed.

Specifically confirmed still green (named in the dispatch as the behavior-neutrality bar):
- `test_no_override_claude_on_build_worker_still_hard_rejects` (`tests/test_dispatch_cli.py`)
- T0-floor guards: `test_dispatch_cli.py` T0-related tests, `test_context_rotation.py` (`979-998` equivalent — file has since shifted line numbers but content is present and green)
- Full `kimi-via-cli-only` suite (`test_constraint_enforcer_kimi_bare_alias.py` + in-file kimi tests)

`tests/test_subprocess_cheap_lane.py` and `tests/test_tmux_interactive_dispatch.py` have 7 pre-existing failures (routing-policy fixtures + a completion-protocol string-match test that appears to compare against this dispatch's own prompt template). Verified identical on unmodified `main` via `git stash` before/after — unrelated to this change, not touched by this PR.

## Open Items

None. PR-3 (D4 semantics), PR-4 (the YAML flip to `default`), and PR-5 (override retirement) remain as separate, already-planned PRs.