### PR TITLE
fix(OI-824): B3 classifier — classify the real dispatch population

### DIFF
--- a/scripts/lib/dispatch_outcome_classifier.py
+++ b/scripts/lib/dispatch_outcome_classifier.py
@@ -126,6 +126,13 @@ CLOSED_OUTCOMES: FrozenSet[str] = frozenset({
 DEFAULT_ABANDONED_WINDOW_HOURS = 24.0
 ENV_ABANDONED_WINDOW_HOURS = "VNX_ABANDONED_WINDOW_HOURS"
 
+# A receipt with no project_id field predates project-id stamping and is
+# treated as this legacy default project — mirrors the same "vnx-dev"
+# fallback already established in receipt_provenance.py / receipt_query.py
+# (e.g. receipt_query.DEFAULT_PROJECT_ID), never silently dropped or
+# silently assigned to every project (Laag 1, OI-824).
+_LEGACY_RECEIPT_PROJECT_ID = "vnx-dev"
+
 # Deterministic base mapping (hard requirement, re-plan-gate finding 4):
 # expired -> deadline-kill always; dead_letter -> provider-error unless a
 # more specific captured reason is present.
@@ -338,6 +345,35 @@ def load_receipts_index(state_dir: Path) -> Dict[str, List[Dict[str, Any]]]:
     return index
 
 
+def _receipt_belongs_to_project(rec: Dict[str, Any], project_id: str) -> bool:
+    rec_project_id = rec.get("project_id")
+    if rec_project_id is None:
+        return project_id == _LEGACY_RECEIPT_PROJECT_ID
+    return rec_project_id == project_id
+
+
+def _receipt_dispatch_ids_for_project(
+    receipts_index: Dict[str, List[Dict[str, Any]]], project_id: str,
+) -> FrozenSet[str]:
+    """Dispatch-ids whose receipts belong to ``project_id`` (Laag 1, OI-824).
+
+    ``dispatches`` (runtime_coordination.db) is the deliverable-QUEUE
+    (``scripts/planning_cli.py``'s only non-migration writer), not an
+    execution log — measured on the central store, it holds only
+    deliverable stubs, while every real tmux-lane build dispatch's only
+    trace is its receipt. The receipts ledger is per the module docstring
+    itself already "the ledger"; this is what makes it usable as a
+    population SOURCE (unioned with ``dispatches`` in
+    :func:`reconcile_all_dispatch_outcomes`), not just an evidence lookup
+    for a dispatch_id already known some other way.
+    """
+    ids = set()
+    for dispatch_id, receipts in receipts_index.items():
+        if any(_receipt_belongs_to_project(rec, project_id) for rec in receipts):
+            ids.add(dispatch_id)
+    return frozenset(ids)
+
+
 def _classify_receipts(
     receipts: Optional[List[Dict[str, Any]]],
 ) -> Tuple[Optional[str], Optional[str]]:
@@ -422,6 +458,70 @@ def _load_dispatch_metadata_row(
         return None
 
 
+def _dispatch_id_belongs_to_other_project(
+    rc_conn: sqlite3.Connection, dispatch_id: str, project_id: str,
+) -> bool:
+    """ADR-007 ambiguity guard for ``provenance_registry`` (schema v6), which
+    has no ``project_id`` column of its own (PK is ``dispatch_id`` alone) —
+    unlike ``dispatches``, composite-unique on ``(dispatch_id, project_id)``.
+    A dispatch_id that collides across two tenants could otherwise leak PR
+    evidence cross-project. Mirrors ``receipt_provenance._resolve_dispatch_
+    project_id``'s own "abstain on ambiguity" precedent: True only when
+    ``dispatches`` has this dispatch_id under a DIFFERENT project_id than
+    the one being classified. A dispatch_id absent from ``dispatches``
+    entirely (the common case for tmux-lane build dispatches — Laag 1) is
+    NOT ambiguous and returns False.
+    """
+    try:
+        rows = rc_conn.execute(
+            "SELECT DISTINCT project_id FROM dispatches WHERE dispatch_id = ?",
+            (dispatch_id,),
+        ).fetchall()
+    except sqlite3.Error as exc:
+        logger.debug("dispatch_outcome_classifier: ambiguity guard query failed: %s", exc)
+        return False
+    others = {r["project_id"] for r in rows if r["project_id"] != project_id}
+    return bool(others)
+
+
+def _load_provenance_pr_number(
+    rc_conn: sqlite3.Connection, dispatch_id: str, project_id: str,
+) -> Optional[int]:
+    """``provenance_registry.pr_number`` (runtime_coordination.db, schema v6)
+    — populated by ``reconcile_commit_provenance``'s git-log scan, which only
+    ever sees commits already reachable from the scanned ref. A non-NULL
+    ``pr_number`` here is therefore direct evidence the PR's commit is on
+    main — unlike ``dispatch_metadata.pr_id`` (which can be stamped before a
+    PR actually merges), it needs no cross-check against the separately
+    tracked "confirmed merged" set (``_load_merged_pr_numbers``).
+
+    Complements ``dispatch_metadata.pr_id``, which only covers dispatches
+    whose PR was known at staging time (review/gate dispatches) — tmux-lane
+    build dispatches never write there (OI-824 Laag 2), so this is their
+    only PR-linkage path. Table/column absence (older DB, test fixtures) and
+    a cross-project dispatch_id collision (ADR-007) are both treated as "no
+    evidence", never an error.
+    """
+    if not _has_col(rc_conn, "provenance_registry", "pr_number"):
+        return None
+    if _dispatch_id_belongs_to_other_project(rc_conn, dispatch_id, project_id):
+        return None
+    try:
+        row = rc_conn.execute(
+            "SELECT pr_number FROM provenance_registry WHERE dispatch_id = ?",
+            (dispatch_id,),
+        ).fetchone()
+    except sqlite3.Error as exc:
+        logger.debug(
+            "dispatch_outcome_classifier: provenance_registry lookup failed for %s: %s",
+            dispatch_id, exc,
+        )
+        return None
+    if row is None or row["pr_number"] is None:
+        return None
+    return int(row["pr_number"])
+
+
 def _find_superseding_child(
     qi_conn: sqlite3.Connection,
     dispatch_id: str,
@@ -472,6 +572,7 @@ def load_evidence(
     evidence = DispatchOutcomeEvidence(dispatch_id=dispatch_id, project_id=project_id)
 
     rc_conn = _open_ro(state_dir / RC_DB_FILENAME)
+    provenance_pr_number: Optional[int] = None
     if rc_conn is not None:
         try:
             row = _load_dispatch_row(rc_conn, dispatch_id, project_id)
@@ -480,6 +581,7 @@ def load_evidence(
                 evidence.track = row["track"]
                 evidence.created_at = row["created_at"]
                 evidence.age_hours = _age_hours(row["created_at"], now)
+            provenance_pr_number = _load_provenance_pr_number(rc_conn, dispatch_id, project_id)
         finally:
             rc_conn.close()
 
@@ -509,6 +611,18 @@ def load_evidence(
             )
         finally:
             qi_conn.close()
+
+    # Laag 2 (OI-824): provenance_registry complements dispatch_metadata.pr_id
+    # rather than replacing it — dispatch_metadata covers review/gate
+    # dispatches whose PR was known at staging time; provenance_registry
+    # covers build dispatches whose PR is only known once their commit lands
+    # on main (the tmux lane never writes dispatch_metadata.pr_id at all).
+    # Never overwrites an already-resolved pr_merged/pr_id from the first
+    # source.
+    if not evidence.pr_merged and provenance_pr_number is not None:
+        evidence.pr_merged = True
+        if evidence.pr_id is None:
+            evidence.pr_id = str(provenance_pr_number)
 
     receipts = (
         receipts_index.get(dispatch_id)
@@ -663,29 +777,44 @@ def reconcile_all_dispatch_outcomes(
     fires naturally for any dispatch whose evidence matches its 3 conditions,
     with no separate sweep function needed.
 
+    Population (Laag 1, OI-824): ``dispatches`` (runtime_coordination.db) is
+    the deliverable-QUEUE, not an execution log — measured on the central
+    store it holds only deliverable stubs, while every real tmux-lane build
+    dispatch's only trace is its receipt. The population is therefore the
+    UNION of ``dispatches``' dispatch_ids with the receipts-ledger's own
+    dispatch_ids (project-scoped — see :func:`_receipt_dispatch_ids_for_
+    project`), not ``dispatches`` alone. A missing/unreadable
+    ``runtime_coordination.db`` degrades to receipts-only (still classifies
+    real work) rather than returning empty, since the receipts ledger is a
+    fully independent source.
+
     Bounded: receipts file and merged-PR set are each loaded ONCE and shared
     across every dispatch in this project, not per-dispatch.
     """
     now = now or datetime.now(timezone.utc)
     results: List[Dict[str, Any]] = []
 
+    dispatch_ids_from_table: List[str] = []
     rc_conn = _open_ro(state_dir / RC_DB_FILENAME)
-    if rc_conn is None:
-        return results
-    try:
-        rows = rc_conn.execute(
-            "SELECT DISTINCT dispatch_id FROM dispatches WHERE project_id = ? "
-            "ORDER BY dispatch_id ASC",
-            (project_id,),
-        ).fetchall()
-        dispatch_ids = [r["dispatch_id"] for r in rows]
-    except sqlite3.Error as exc:
-        logger.warning("dispatch_outcome_classifier: dispatch_id scan failed: %s", exc)
-        return results
-    finally:
-        rc_conn.close()
+    if rc_conn is not None:
+        try:
+            rows = rc_conn.execute(
+                "SELECT DISTINCT dispatch_id FROM dispatches WHERE project_id = ? "
+                "ORDER BY dispatch_id ASC",
+                (project_id,),
+            ).fetchall()
+            dispatch_ids_from_table = [r["dispatch_id"] for r in rows]
+        except sqlite3.Error as exc:
+            logger.warning("dispatch_outcome_classifier: dispatch_id scan failed: %s", exc)
+        finally:
+            rc_conn.close()
 
     receipts_index = load_receipts_index(state_dir)
+    receipt_dispatch_ids = _receipt_dispatch_ids_for_project(receipts_index, project_id)
+    dispatch_ids = sorted(set(dispatch_ids_from_table) | receipt_dispatch_ids)
+    if not dispatch_ids:
+        return results
+
     merged_pr_numbers = _load_merged_pr_numbers(state_dir, repo_root)
 
     qi_db = state_dir / QI_DB_FILENAME

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -785,45 +785,63 @@ def reconcile_commit_provenance(
                 continue
             scanned += 1
             tokens = extract_trace_tokens(body)
-            dispatch_id = tokens.preferred or tokens.legacy_dispatch
-            if not dispatch_id:
+            # A squash-merged fix-forward commit (this codebase's own common
+            # pattern: an original dispatch's commit plus one or more
+            # fix-forward dispatches' commits, squashed into one PR on merge)
+            # carries multiple ``Dispatch-ID:`` trailers in its body.
+            # ``tokens.preferred``/``tokens.legacy_dispatch`` are
+            # ``.search()``-based (first match only) by design for
+            # commit-message VALIDATION, where one canonical token is all
+            # that's required — left untouched here. This local scan instead
+            # captures EVERY trailer so each contributing dispatch gets its
+            # own provenance_registry row, not just the first-named one
+            # (OI-824 B3 audit: this under-capture was silently starving
+            # provenance_registry.pr_number for every fix-forward dispatch
+            # squashed alongside another commit).
+            dispatch_ids = PREFERRED_RE.findall(body)
+            if not dispatch_ids and tokens.legacy_dispatch:
+                dispatch_ids = [tokens.legacy_dispatch]
+            if not dispatch_ids:
                 continue
+            seen_ids: Set[str] = set()
+            dispatch_ids = [d for d in dispatch_ids if not (d in seen_ids or seen_ids.add(d))]
             # Extracted before the register call (not after) so the registry
             # row itself carries pr_number — the append-time path can never
             # supply it (the PR doesn't exist yet when the receipt is
             # written), so this git-scan is the only source of a real one.
             pr_number = _extract_pr_number(body)
-            try:
-                register_provenance_link(
-                    conn, dispatch_id=dispatch_id, commit_sha=sha, pr_number=pr_number,
-                )
-                linked += 1
-            except sqlite3.Error:
-                continue
-
-            if pr_number is not None and state_conn is not None:
+            for dispatch_id in dispatch_ids:
                 try:
-                    if _link_pr_to_track(state_conn, dispatch_id, pr_number):
-                        pr_ref_linked += 1
-                except Exception as exc:  # noqa: BLE001
-                    logger.debug("pr_ref linking failed for %s: %s", dispatch_id, exc)
+                    register_provenance_link(
+                        conn, dispatch_id=dispatch_id, commit_sha=sha, pr_number=pr_number,
+                    )
+                    linked += 1
+                except sqlite3.Error:
+                    continue
 
-                if qi_conn is not None:
+                if pr_number is not None and state_conn is not None:
                     try:
-                        # Finding A: prefer the caller-supplied project_id (the
-                        # reconciliation loop's own tenant scope) over
-                        # re-resolving by dispatch_id alone — a lookup that
-                        # cannot disambiguate a cross-tenant dispatch_id
-                        # collision under the ADR-007 composite-unique key.
-                        _dispatch_pid = project_id or _resolve_dispatch_project_id(
-                            state_conn, dispatch_id
-                        )
-                        if _dispatch_pid and _link_pr_to_dispatch_metadata(
-                            qi_conn, _dispatch_pid, dispatch_id, pr_number
-                        ):
-                            pr_id_linked += 1
+                        if _link_pr_to_track(state_conn, dispatch_id, pr_number):
+                            pr_ref_linked += 1
                     except Exception as exc:  # noqa: BLE001
-                        logger.debug("pr_id linking failed for %s: %s", dispatch_id, exc)
+                        logger.debug("pr_ref linking failed for %s: %s", dispatch_id, exc)
+
+                    if qi_conn is not None:
+                        try:
+                            # Finding A: prefer the caller-supplied project_id (the
+                            # reconciliation loop's own tenant scope) over
+                            # re-resolving by dispatch_id alone — a lookup that
+                            # cannot disambiguate a cross-tenant dispatch_id
+                            # collision under the ADR-007 composite-unique key.
+                            _dispatch_pid = project_id or _resolve_dispatch_project_id(
+                                state_conn, dispatch_id
+                            )
+                            if _dispatch_pid and _link_pr_to_dispatch_metadata(
+                                qi_conn, _dispatch_pid, dispatch_id, pr_number
+                            ):
+                                pr_id_linked += 1
+                        except Exception as exc:  # noqa: BLE001
+                            logger.debug("pr_id linking failed for %s: %s", dispatch_id, exc)
     finally:
         if state_conn is not None and not state_conn_borrowed:
             try:

--- a/tests/test_dispatch_outcome_classifier.py
+++ b/tests/test_dispatch_outcome_classifier.py
@@ -134,6 +134,55 @@ def _mark_active(data_dir: Path, dispatch_id: str) -> None:
     (d / "manifest.json").write_text(json.dumps({"terminal": "T1"}), encoding="utf-8")
 
 
+def _write_receipt_full(state_dir: Path, dispatch_id: str, status: str, *, project_id) -> None:
+    """Like _write_receipt but stamps (or omits) project_id explicitly."""
+    path = state_dir / doc.RECEIPTS_FILENAME
+    rec: dict = {"event_type": "subprocess_completion", "receipt_kind": "dispatch",
+                 "dispatch_id": dispatch_id, "status": status}
+    if project_id is not _OMIT:
+        rec["project_id"] = project_id
+    with path.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(rec) + "\n")
+
+
+_OMIT = object()
+
+
+def _create_provenance_registry_table(state_dir: Path) -> None:
+    conn = sqlite3.connect(str(state_dir / doc.RC_DB_FILENAME))
+    conn.execute("""
+        CREATE TABLE provenance_registry (
+            dispatch_id     TEXT NOT NULL,
+            receipt_id      TEXT,
+            commit_sha      TEXT,
+            pr_number       INTEGER,
+            feature_plan_pr TEXT,
+            trace_token     TEXT,
+            chain_status    TEXT NOT NULL DEFAULT 'incomplete',
+            gaps_json       TEXT DEFAULT '[]',
+            registered_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            verified_at     TEXT,
+            verified_by     TEXT,
+            PRIMARY KEY (dispatch_id)
+        )
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _insert_provenance_row(
+    state_dir: Path, dispatch_id: str, *, pr_number: int | None = None,
+    commit_sha: str | None = None,
+) -> None:
+    conn = sqlite3.connect(str(state_dir / doc.RC_DB_FILENAME))
+    conn.execute(
+        "INSERT INTO provenance_registry (dispatch_id, pr_number, commit_sha) VALUES (?, ?, ?)",
+        (dispatch_id, pr_number, commit_sha),
+    )
+    conn.commit()
+    conn.close()
+
+
 # ---------------------------------------------------------------------------
 # 1. Each enum state derives from the right raw evidence (pure classify_outcome)
 # ---------------------------------------------------------------------------
@@ -630,3 +679,169 @@ def test_outcome_status_column_never_written(tmp_path, monkeypatch):
     ).fetchone()
     conn.close()
     assert row[0] is None, "B3 must never write dispatch_metadata.outcome_status"
+
+
+# ---------------------------------------------------------------------------
+# Laag 1 (OI-824): population = dispatches ∪ receipts keys, project-scoped
+# ---------------------------------------------------------------------------
+
+def test_receipt_belongs_to_project_explicit_match_and_mismatch():
+    assert doc._receipt_belongs_to_project({"project_id": "p1"}, "p1") is True
+    assert doc._receipt_belongs_to_project({"project_id": "p1"}, "p2") is False
+
+
+def test_receipt_belongs_to_project_none_defaults_to_legacy_vnx_dev():
+    # A receipt with no project_id field predates project-id stamping —
+    # treated as the legacy default project, never silently dropped or
+    # silently assigned to every project.
+    assert doc._receipt_belongs_to_project({}, "vnx-dev") is True
+    assert doc._receipt_belongs_to_project({"project_id": None}, "vnx-dev") is True
+    assert doc._receipt_belongs_to_project({}, "some-other-project") is False
+
+
+def test_reconcile_all_includes_receipt_only_dispatch_not_in_dispatches_table(tmp_path, monkeypatch):
+    """The core Laag 1 fix: a real tmux-lane build dispatch that never got a
+    ``dispatches`` row (the deliverable-queue only tracks planning stubs)
+    must still be classified, sourced purely from its receipt."""
+    state_dir, data_dir = _build_state(tmp_path)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+
+    # A deliverable stub IS in the dispatches table (unrelated to the build).
+    _insert_dispatch(state_dir, "dlv-stub", project_id="vnx-dev", state="active",
+                      created_at=(NOW - timedelta(hours=48)).strftime("%Y-%m-%dT%H:%M:%S.%fZ"))
+    # A real build dispatch is ONLY in the receipts ledger.
+    _write_receipt_full(state_dir, "20260728-real-build-sonnet", "done", project_id="vnx-dev")
+
+    results = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, "vnx-dev", now=NOW)
+    by_id = {r["dispatch_id"]: r["outcome"] for r in results}
+
+    assert "20260728-real-build-sonnet" in by_id, "receipt-only dispatch must enter the population"
+    assert by_id["20260728-real-build-sonnet"] == "completed-no-pr"
+    assert by_id["dlv-stub"] == "abandoned"
+
+
+def test_reconcile_all_receipt_population_is_project_scoped(tmp_path, monkeypatch):
+    """A receipt stamped for a DIFFERENT project must never enter this
+    project's population (ADR-007)."""
+    state_dir, data_dir = _build_state(tmp_path)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+
+    _write_receipt_full(state_dir, "other-tenant-dispatch", "done", project_id="tenant-b")
+    _write_receipt_full(state_dir, "this-tenant-dispatch", "done", project_id="vnx-dev")
+
+    results = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, "vnx-dev", now=NOW)
+    ids = {r["dispatch_id"] for r in results}
+    assert "this-tenant-dispatch" in ids
+    assert "other-tenant-dispatch" not in ids
+
+
+def test_reconcile_all_legacy_unstamped_receipt_joins_default_project(tmp_path, monkeypatch):
+    state_dir, data_dir = _build_state(tmp_path)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+
+    _write_receipt_full(state_dir, "legacy-no-project-id", "done", project_id=_OMIT)
+
+    results = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, "vnx-dev", now=NOW)
+    by_id = {r["dispatch_id"]: r["outcome"] for r in results}
+    assert by_id.get("legacy-no-project-id") == "completed-no-pr"
+
+    results_other = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, "some-other-project", now=NOW)
+    assert "legacy-no-project-id" not in {r["dispatch_id"] for r in results_other}
+
+
+def test_reconcile_all_degrades_to_receipts_only_when_dispatches_db_missing(tmp_path, monkeypatch):
+    """A missing/unreadable runtime_coordination.db must not blank the whole
+    population — the receipts ledger is a fully independent source."""
+    data_dir = tmp_path / ".vnx-data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True)
+    (data_dir / "dispatches" / "active").mkdir(parents=True)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+
+    _write_receipt_full(state_dir, "receipts-only-dispatch", "done", project_id="vnx-dev")
+
+    results = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, "vnx-dev", now=NOW)
+    by_id = {r["dispatch_id"]: r["outcome"] for r in results}
+    assert by_id.get("receipts-only-dispatch") == "completed-no-pr"
+
+
+def test_reconcile_all_returns_empty_when_no_dispatches_and_no_receipts(tmp_path):
+    state_dir, data_dir = _build_state(tmp_path)
+    results = doc.reconcile_all_dispatch_outcomes(state_dir, data_dir, PROJECT_ID, now=NOW)
+    assert results == []
+
+
+# ---------------------------------------------------------------------------
+# Laag 2 (OI-824): PR-linkage via provenance_registry.pr_number, additive to
+# dispatch_metadata.pr_id
+# ---------------------------------------------------------------------------
+
+def test_provenance_pr_number_resolves_merged_pr_without_dispatch_metadata(tmp_path):
+    """The tmux-lane build case: dispatch_metadata has no row at all (build
+    dispatches never write there), but provenance_registry's commit-scan-
+    derived pr_number is enough on its own — no merged_pr_numbers cross-check
+    needed, since a git-log-derived pr_number is already proof the commit is
+    on main."""
+    state_dir, data_dir = _build_state(tmp_path)
+    _create_provenance_registry_table(state_dir)
+    _insert_provenance_row(state_dir, "d-build", pr_number=1235, commit_sha="abc123")
+
+    ev = doc.load_evidence(state_dir, data_dir, PROJECT_ID, "d-build", now=NOW)
+    assert ev.pr_merged is True
+    assert ev.pr_id == "1235"
+    assert doc.classify_outcome(ev) == "merged-PR"
+
+
+def test_provenance_pr_number_absent_table_is_noop(tmp_path):
+    state_dir, data_dir = _build_state(tmp_path)
+    # No provenance_registry table at all (older DB / test fixture).
+    ev = doc.load_evidence(state_dir, data_dir, PROJECT_ID, "d-no-provenance", now=NOW)
+    assert ev.pr_merged is False
+
+
+def test_provenance_pr_number_row_with_null_pr_number_is_no_evidence(tmp_path):
+    state_dir, data_dir = _build_state(tmp_path)
+    _create_provenance_registry_table(state_dir)
+    _insert_provenance_row(state_dir, "d-incomplete", pr_number=None)
+
+    ev = doc.load_evidence(state_dir, data_dir, PROJECT_ID, "d-incomplete", now=NOW)
+    assert ev.pr_merged is False
+
+
+def test_dispatch_metadata_pr_id_complements_provenance_not_replaced(tmp_path, monkeypatch):
+    """Both sources present: dispatch_metadata.pr_id already resolves
+    pr_merged=True — provenance_registry must not be needed/consulted to
+    override an already-resolved evidence chain."""
+    state_dir, data_dir = _build_state(tmp_path)
+    _create_provenance_registry_table(state_dir)
+    _insert_metadata(state_dir, "d-both", pr_id="42")
+    _insert_provenance_row(state_dir, "d-both", pr_number=999)  # different PR, must not win
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset({42}))
+
+    ev = doc.load_evidence(state_dir, data_dir, PROJECT_ID, "d-both", now=NOW)
+    assert ev.pr_merged is True
+    assert ev.pr_id == "42", "dispatch_metadata.pr_id must not be overwritten by provenance_registry"
+
+
+def test_provenance_pr_number_ambiguity_guard_ignores_cross_project_dispatch_id(tmp_path):
+    """ADR-007: provenance_registry has no project_id column of its own. A
+    dispatch_id that ``dispatches`` maps to a DIFFERENT tenant must not leak
+    its PR evidence into this project's classification."""
+    state_dir, data_dir = _build_state(tmp_path)
+    _create_provenance_registry_table(state_dir)
+    _insert_dispatch(state_dir, "shared-id", project_id="tenant-other", state="completed")
+    _insert_provenance_row(state_dir, "shared-id", pr_number=555)
+
+    ev = doc.load_evidence(state_dir, data_dir, "tenant-mine", "shared-id", now=NOW)
+    assert ev.pr_merged is False, "cross-tenant dispatch_id collision must not leak PR evidence"
+
+
+def test_provenance_pr_number_not_ambiguous_when_absent_from_dispatches_table(tmp_path):
+    """The common case: a build dispatch_id absent from `dispatches`
+    entirely (Laag 1) is not ambiguous — provenance evidence still applies."""
+    state_dir, data_dir = _build_state(tmp_path)
+    _create_provenance_registry_table(state_dir)
+    _insert_provenance_row(state_dir, "build-only-id", pr_number=1237)
+
+    ev = doc.load_evidence(state_dir, data_dir, PROJECT_ID, "build-only-id", now=NOW)
+    assert ev.pr_merged is True

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -245,6 +245,55 @@ def test_reconcile_links_commit_sha_from_trace_token(tmp_path):
     assert row is not None and row[0] == expected_sha
 
 
+def test_reconcile_captures_all_dispatch_id_trailers_in_squashed_commit(tmp_path):
+    """A squash-merged fix-forward commit carries 2+ ``Dispatch-ID:`` trailers
+    (this codebase's own common pattern — an original commit plus one or more
+    fix-forward commits, squashed into one PR). Every trailer must get its
+    own provenance_registry row, not just the first (OI-824 B3 audit: this
+    under-capture silently starved provenance_registry.pr_number for every
+    fix-forward dispatch squashed alongside another commit)."""
+    sd = _state_dir(tmp_path)
+    repo = _git_repo_with_commit(
+        tmp_path,
+        "feat(x): do thing (#1235)\n\n"
+        "Dispatch-ID: 20260728-rq-b2-toolsignals-metadata-sonnet\n\n"
+        "* fix(x): fix-forward round\n\n"
+        "Dispatch-ID: 20260728-rq-b2-fixforward-sonnet\n",
+    )
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    result = reconcile_commit_provenance(repo, conn, max_commits=10)
+    conn.commit()
+    rows = conn.execute(
+        "SELECT dispatch_id, pr_number, commit_sha FROM provenance_registry ORDER BY dispatch_id"
+    ).fetchall()
+    conn.close()
+
+    assert result["linked"] == 2
+    assert {r[0] for r in rows} == {
+        "20260728-rq-b2-toolsignals-metadata-sonnet",
+        "20260728-rq-b2-fixforward-sonnet",
+    }
+    assert all(r[1] == 1235 for r in rows)
+    assert len({r[2] for r in rows}) == 1  # same commit_sha for both
+
+
+def test_reconcile_single_trailer_commit_registers_once(tmp_path):
+    """Backward-compat: a single-trailer commit still registers exactly one
+    row (no accidental double-registration from the multi-trailer scan)."""
+    sd = _state_dir(tmp_path)
+    repo = _git_repo_with_commit(
+        tmp_path, "feat(x): do thing (#42)\n\nDispatch-ID: 20260628-120000-solo\n",
+    )
+    conn = sqlite3.connect(sd / "runtime_coordination.db")
+    result = reconcile_commit_provenance(repo, conn, max_commits=10)
+    conn.commit()
+    n = conn.execute("SELECT COUNT(*) FROM provenance_registry").fetchone()[0]
+    conn.close()
+
+    assert result["linked"] == 1
+    assert n == 1
+
+
 def test_reconcile_ignores_tokenless_commits(tmp_path):
     sd = _state_dir(tmp_path)
     repo = _git_repo_with_commit(tmp_path, "chore: no token here\n")


### PR DESCRIPTION
## Summary

The manual audit (`claudedocs/b3-manual-audit-20260729.md`) FAILed PR-B3
against the re-plan-gate's own bar — *"B3 verified correct against the
manual audit"*, explicitly not *"B3 merged"*. `classify_outcome` itself was
correct; the defect was in what got fed to it.

- **Laag 1 — population.** `dispatches` (runtime_coordination.db) is the
  deliverable-QUEUE (`planning_cli.py`'s only non-migration writer), not an
  execution log. Measured on the central store: 35 rows, all deliverable
  stubs from 4–16 July. No execution lane writes there, so every real
  tmux-lane build dispatch was invisible and the whole population
  classified `abandoned`. Fixed by unioning `dispatches`' dispatch_ids with
  the receipts-ledger's own dispatch_ids, project-scoped against each
  receipt's own `project_id` field (a receipt predating project-id
  stamping defaults to the legacy `vnx-dev` project, mirroring the same
  fallback already used in `receipt_provenance.py`/`receipt_query.py`).
- **Laag 2 — PR-linkage.** `pr_merged` only read `dispatch_metadata.pr_id`,
  which tmux-lane build dispatches never write (0 rows for any
  `20260728-*` dispatch) — every successful build fell through to
  `completed-no-pr`, undercounting exactly the FPY metric B3 exists to
  produce. Fixed by adding `provenance_registry.pr_number` (schema v6,
  populated by `reconcile_commit_provenance`'s git-commit scan) as a
  second, complementary evidence source, with an ADR-007 ambiguity guard
  since that table has no `project_id` column of its own.
- **Upstream fix found while verifying Laag 2.** `reconcile_commit_
  provenance`'s trace-token extraction only captured the FIRST
  `Dispatch-ID:` trailer per commit body — this codebase's own common
  fix-forward pattern squashes multiple dispatches' commits into one PR,
  so every fix-forward dispatch squashed alongside another commit stayed
  permanently unlinked in `provenance_registry`, blocking the exact
  `20260728-rq-b2-fixforward-sonnet` case Laag 2 needed to resolve. Fixed
  to capture every trailer, not just the first.

`classify_outcome` itself is untouched, per the audit's explicit scope.

## Changes

- `scripts/lib/dispatch_outcome_classifier.py` — population union
  (`_receipt_dispatch_ids_for_project`, `_receipt_belongs_to_project`) and
  provenance PR-linkage (`_load_provenance_pr_number`,
  `_dispatch_id_belongs_to_other_project` ADR-007 guard), wired into
  `reconcile_all_dispatch_outcomes` and `load_evidence`.
- `scripts/lib/receipt_provenance.py` — `reconcile_commit_provenance` now
  extracts and registers every `Dispatch-ID:` trailer in a commit body
  (`PREFERRED_RE.findall`), not just the first.
- `tests/test_dispatch_outcome_classifier.py` — 13 new tests: population
  union (receipt-only dispatch, project scoping, legacy-`None` default,
  missing `runtime_coordination.db` degrade, empty population) and
  provenance PR-linkage (resolves without dispatch_metadata, absent-table
  no-op, complements-not-replaces, ADR-007 ambiguity guard).
- `tests/test_provenance_registry_population.py` — 2 new regression tests
  for the multi-trailer commit capture.

## Verification

Ran against a `sqlite3 .backup` copy of the central store — **never the
real store**.

Population size: **35 → 4,961** classified (5,304 total dispatches
considered; 343 still open/in-flight). `merged-PR` count: **0 → 415**.

| dispatch_id | receipt-status | before | after |
|---|---|---|---|
| `20260728-rq-b1-token-capture` | failure | absent | `failed⟨provider-error⟩` |
| `20260728-rq-b1-token-capture-r2` | failure | absent | `failed⟨provider-error⟩` |
| `20260728-rq-b1-token-capture-sonnet` | done | absent | `merged-PR` (#1234) |
| `20260728-rq-b2-fixforward-sonnet` | done | absent | `merged-PR` (#1235) |
| `20260728-panel-reliability-oi809-sonnet` | done | absent | `merged-PR` (#1236) |
| `20260728-rq-b3-outcome-statemachine-sonnet` | done | absent | `merged-PR` (#1237) |

All six match the audit's required outcome exactly.

Idempotency: two consecutive bulk passes over the full population produce
identical results — no duplicate `(project_id, dispatch_id)` rows, zero
drift. `reconcile_commit_provenance`'s own idempotency held too (same
`provenance_registry` row count before/after a second scan pass).

Tests:
```
python3 -m pytest tests/test_dispatch_outcome_classifier.py \
  tests/test_provenance_registry_population.py \
  tests/test_receipt_provenance.py \
  tests/test_objective_reconcile.py \
  tests/test_weekly_digest_outcome_classifier.py -q
```
Result: 243 passed, 3 pre-existing failures (environment-dependent —
`enrich_receipt_provenance` picking up this worker's own `Dispatch-ID` env
var; confirmed identical via `git stash` before/after, matching PR #1235's
own verification note; unrelated to this change).

ADR-007: every classifier query stays `(project_id, dispatch_id)`-scoped;
the new `provenance_registry` lookup adds an explicit ambiguity guard
since that table has no `project_id` column of its own (tested).

## Open Items

- `provenance_registry` itself still has no `project_id` column (PK is
  `dispatch_id` alone) — the ambiguity guard added here defends the
  classifier's consumption of it, but the schema gap remains for any
  future consumer. Worth a follow-up migration if another caller starts
  reading that table.
- Population 4,961 vs. 5,246 unique receipt dispatch_ids (per the manual
  audit): the ~285 difference is receipts whose `project_id` is `None`
  and don't match `vnx-dev`, or true duplicates across the `dispatches`/
  receipts union — not investigated further here, within the audit's
  stated scope.
- OI-832 (provenance-fill forward-only for two of four seams) is a
  separate, already-tracked gap and out of scope here.