### PR TITLE
fix(wpfc): D4 honours ModelPin.semantics — PR-3

### DIFF
--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -46,9 +46,8 @@ class ModelPin:
     default: advisory — spec.model wins when the caller set one; the pin is
              only used as a fallback when spec.model is absent.
 
-    worker-provider-free-choice PR-1: this type only carries the contract.
-    D4 below still ignores `semantics` and always coerces to the pin
-    (gedragsneutraal) — honoring `semantics` is PR-3's job.
+    worker-provider-free-choice PR-1 added this type; PR-3 wired D4 to honour
+    the semantics field.
     """
     model: str
     semantics: str  # "floor" | "default"
@@ -202,26 +201,42 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
 
     # D4 — model tier; warn-only pins are NOT a Reject
     #
+    # worker-provider-free-choice PR-3: D4 honours ModelPin.semantics.
+    #   floor:   the pin always wins (coercive — today's behaviour for all slots).
+    #   default: spec.model wins when the caller set one; the pin is the fallback
+    #            when spec.model is absent.
+    #
     # worker-provider-kimi-flip (20260723): snapshot.model_pins now resolves T1/T2/T3
     # to "kimi-k3". This branch only runs when is_claude_lane is True (explicit
     # provider=claude). The "sonnet" fallback below deliberately stays a valid Claude
     # model name — it is the no-pin-found default for the claude lane specifically,
     # not a worker-role default. When a pin IS found for a claude-lane T1/T2/T3
-    # (pinned="kimi-k3"), `model = pinned` intentionally yields a non-Claude label;
-    # the D3 registry/constraint gate upstream rejects that combination fail-loud
-    # rather than silently falling back to sonnet (kimi-only, no fallback policy).
+    # (pinned="kimi-k3") with floor semantics, `model = pinned` intentionally yields
+    # a non-Claude label; the D3 registry/constraint gate upstream rejects that
+    # combination fail-loud rather than silently falling back to sonnet (kimi-only,
+    # no fallback policy).
     target_slot = spec.target_slot
     if is_claude_lane:
         pin = snapshot.model_pins.get(target_slot)
         pinned = pin.model if pin is not None else None
         requested = spec.model
         if pinned:
-            if requested and requested != pinned:
+            if pin.semantics == "default" and requested and requested != pinned:
+                # Default semantics: the caller's explicit model choice wins.
+                warnings.append(
+                    f"model-tier: requested {requested} over pinned {pinned}"
+                    f" for {target_slot} (default semantics — request honoured)"
+                )
+                model = requested
+            elif requested and requested != pinned:
+                # Floor semantics (or unrecognised — treat as floor): the pin wins.
                 warnings.append(
                     f"model-tier: requested {requested}, pinned {pinned}"
-                    f" for {target_slot} (override-able)"
+                    f" for {target_slot} (floor semantics — pin honoured)"
                 )
-            model = pinned
+                model = pinned
+            else:
+                model = pinned
         else:
             model = requested or "sonnet"
     else:

--- a/tests/test_dispatch_plan.py
+++ b/tests/test_dispatch_plan.py
@@ -279,6 +279,60 @@ class TestModelTierPin:
         assert isinstance(plan, ExecutionPlan)
         assert plan.model == "sonnet"
 
+    # -- wpfc PR-3: D4 honours pin.semantics ---------------------------------
+
+    def test_floor_pin_ignores_explicit_model(self, tmp_path: Path) -> None:
+        """floor semantics: the pin always wins, even against an explicit spec.model."""
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T1", model="sonnet", tmp_path=tmp_path,
+        )
+        snapshot = _healthy_snapshot(
+            model_pins={"T1": ModelPin(model="kimi-k3", semantics="floor")},
+        )
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "kimi-k3", "floor pin must ignore the explicit model request"
+        assert any("floor semantics" in w for w in plan.warnings)
+
+    def test_default_pin_honours_explicit_model(self, tmp_path: Path) -> None:
+        """default semantics: spec.model wins when the caller set one."""
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T1", model="sonnet", tmp_path=tmp_path,
+        )
+        snapshot = _healthy_snapshot(
+            model_pins={"T1": ModelPin(model="kimi-k3", semantics="default")},
+        )
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "sonnet", "default pin must honour the explicit model request"
+        assert any("default semantics" in w for w in plan.warnings)
+
+    def test_default_pin_falls_back_when_no_model_requested(self, tmp_path: Path) -> None:
+        """default semantics: when spec.model is absent, the pin is the fallback."""
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T1", tmp_path=tmp_path,
+        )
+        snapshot = _healthy_snapshot(
+            model_pins={"T1": ModelPin(model="kimi-k3", semantics="default")},
+        )
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "kimi-k3", "default pin must be the fallback when no model is requested"
+        assert not any("model-tier" in w for w in plan.warnings)
+
+    def test_default_pin_silent_when_request_matches_pin(self, tmp_path: Path) -> None:
+        """default semantics: no warning when the request matches the pinned model."""
+        vspec = _make_vspec(
+            provider=Provider.CLAUDE, target_slot="T1", model="sonnet", tmp_path=tmp_path,
+        )
+        snapshot = _healthy_snapshot(
+            model_pins={"T1": ModelPin(model="sonnet", semantics="default")},
+        )
+        plan = compile_plan(vspec, snapshot)
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.model == "sonnet"
+        assert not any("model-tier" in w for w in plan.warnings)
+
 
 # ---------------------------------------------------------------------------
 # test_isolation_always_worktree


### PR DESCRIPTION
## What

PR-3 of the worker-provider-free-choice track. D4 in `compile_plan()` now reads `pin.semantics` and branches:
- **floor**: pin always wins (coercive — today's behaviour, unchanged)
- **default**: `spec.model` wins when the caller set one; the pin is the fallback when `spec.model` is absent

## Why this is behaviour-neutral

Every slot declares `floor` in both `_DEFAULT_MODEL_PINS` and `provider_constraints.yaml`. Every path takes the floor branch and produces exactly today's `effective_model`. PR-4 flips one YAML line to `default` — that is the first moment observable behaviour changes.

## Changes

- `scripts/lib/dispatch_plan.py`: D4 now branches on `pin.semantics`, warning text matches the branch that ran
- `tests/test_dispatch_plan.py`: 4 new tests covering both branches

## Verification

```
tests/test_dispatch_plan.py — 93 passed
tests/test_dispatch_cli.py — 116 passed
test_no_override_claude_on_build_worker_still_hard_rejects — green, unmodified
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)