### PR TITLE
fix(provenance): narrow the receipt-provenance write transaction (PR-3)

### DIFF
--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -682,6 +682,14 @@ def reconcile_commit_provenance(
     Fill-once (never overwrites an existing pr_id) and independent of the tracks.pr_ref step —
     a dispatch with no track_id still gets its dispatch_metadata.pr_id stamped.
 
+    OI-851 (PR-3): the ``state_conn``/``qi_conn`` write transaction commits after each git-log
+    entry is processed, not once at the end of the whole scan — see the comment at the bottom of
+    the scan loop. This bounds how long another writer against ``runtime_coordination.db`` or
+    ``quality_intelligence.db`` can be blocked to "one commit's worth of linking writes" instead
+    of "the entire ``max_commits``-sized scan". ``conn`` itself is unaffected (see "Durability of
+    conn" below) — this is scoped to the two connections this function opens for the optional
+    pr_ref/pr_id linking steps.
+
     ``project_id``: ADR-007 composite-safety (fix-forward, Finding A). Callers that already
     operate on a per-project store (``objective_reconcile.run_reconcile``,
     ``scripts/reconcile_provenance.py``) know their own ``project_id`` up front — pass it here
@@ -842,6 +850,29 @@ def reconcile_commit_provenance(
                                 pr_id_linked += 1
                         except Exception as exc:  # noqa: BLE001
                             logger.debug("pr_id linking failed for %s: %s", dispatch_id, exc)
+
+            # OI-851 (PR-3): commit state_conn/qi_conn's write transaction here,
+            # per git-log entry, instead of leaving it open until the `finally`
+            # below runs — that used to hold the lock across the ENTIRE scan
+            # (up to `max_commits` entries). ``state_conn`` is skipped while
+            # borrowed (== ``conn``): this function never commits ``conn`` (see
+            # the durability note in the docstring), so a borrowed connection's
+            # transaction boundary stays the caller's to decide, exactly as
+            # before. ``qi_conn`` is never borrowed (always a fresh connection,
+            # see the comment above where it's opened) so it always commits
+            # here. A commit failure is non-fatal — logged at debug and the
+            # scan continues — matching this function's existing best-effort
+            # contract for the pr_ref/pr_id linking steps.
+            if state_conn is not None and not state_conn_borrowed:
+                try:
+                    state_conn.commit()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("failed to commit project state db mid-scan: %s", exc)
+            if qi_conn is not None:
+                try:
+                    qi_conn.commit()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug("failed to commit quality_intelligence db mid-scan: %s", exc)
     finally:
         if state_conn is not None and not state_conn_borrowed:
             try:

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -1058,6 +1058,85 @@ class TestReconcileCommitProvenanceCentralStateDir:
         conn.close()
 
 
+class TestReconcileCommitProvenanceTransactionNarrowing:
+    """OI-851 (PR-3): reconcile_commit_provenance used to open qi_conn once
+    and only commit it in the `finally` block after the ENTIRE git-log scan
+    completed -- holding qi_conn's write transaction open across every
+    remaining commit in the scan, not just the write that opened it. The fix
+    commits qi_conn (and state_conn, when it is not the caller's borrowed
+    `conn`) after each git-log entry's writes instead.
+
+    This spies on `_link_pr_to_dispatch_metadata` and records
+    `qi_conn.in_transaction` at the moment each call STARTS (before it does
+    its own write). Under the pre-fix code, commit 0's write leaves
+    qi_conn.in_transaction True until the whole scan finishes, so the second
+    and third calls would observe True. Under the fix, the first commit's
+    transaction is closed out before the second commit is even scanned, so
+    every call observes False.
+    """
+
+    def _make_qi_db_with_rows(self, state_dir, project_id, dispatch_ids):
+        qi_db = state_dir / "quality_intelligence.db"
+        qi_conn = sqlite3.connect(str(qi_db))
+        qi_conn.execute(
+            """
+            CREATE TABLE dispatch_metadata (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                dispatch_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                pr_id TEXT,
+                UNIQUE(project_id, dispatch_id)
+            )
+            """
+        )
+        for dispatch_id in dispatch_ids:
+            qi_conn.execute(
+                "INSERT INTO dispatch_metadata (dispatch_id, project_id, pr_id) "
+                "VALUES (?, ?, NULL)",
+                (dispatch_id, project_id),
+            )
+        qi_conn.commit()
+        qi_conn.close()
+
+    def test_qi_conn_transaction_not_held_across_scan(self, tmp_path, monkeypatch):
+        repo, state_dir, conn, env = _make_project(tmp_path)
+        project_id = "test-proj"
+        _seed_track(conn, "T-001", project_id)
+        dispatch_ids = [f"20260730-txn-narrow-{i}" for i in range(3)]
+        for dispatch_id in dispatch_ids:
+            _seed_dispatch(conn, dispatch_id, project_id, "T-001")
+        self._make_qi_db_with_rows(state_dir, project_id, dispatch_ids)
+        for i, dispatch_id in enumerate(dispatch_ids):
+            _commit(
+                repo,
+                f"feat(x): thing {i} (#{500 + i})\n\nDispatch-ID: {dispatch_id}",
+                env,
+            )
+
+        seen_in_transaction = []
+        real_fn = receipt_provenance._link_pr_to_dispatch_metadata
+
+        def _spy(qi_conn, pid, dispatch_id, pr_number):
+            seen_in_transaction.append(qi_conn.in_transaction)
+            return real_fn(qi_conn, pid, dispatch_id, pr_number)
+
+        monkeypatch.setattr(receipt_provenance, "_link_pr_to_dispatch_metadata", _spy)
+
+        result = reconcile_commit_provenance(
+            repo, conn, max_commits=10, project_id=project_id,
+        )
+        conn.commit()
+
+        assert result["pr_id_linked"] == 3
+        assert len(seen_in_transaction) == 3
+        assert seen_in_transaction == [False, False, False], (
+            "qi_conn's write transaction from an earlier commit was still "
+            "open when a later commit's write started -- the transaction is "
+            "being held across the scan instead of committed per entry"
+        )
+        conn.close()
+
+
 class TestReconcileCommitProvenanceLinkedPendingCommit:
     """Provenance-chain PR-A (2026-07-29): ``linked`` must not claim durability
     it hasn't earned. ``conn`` is caller-owned — this function never commits


### PR DESCRIPTION
## Summary

OI-851: `reconcile_commit_provenance` in `scripts/lib/receipt_provenance.py` opened
`state_conn` and `qi_conn` once and only committed them in the `finally` block after the
*entire* git-log scan completed — holding their write transaction open across every
remaining commit in the scan, not just the write that opened it.

## Changes

- `scripts/lib/receipt_provenance.py`: commit `state_conn` (when it is not the caller's
  borrowed `conn` — see `state_conn_borrowed`) and `qi_conn` after each git-log entry's
  writes, instead of only once at the end of the whole scan. `conn` itself (caller-owned,
  never committed by this function) is untouched — `linked`/`linked_pending_commit`
  semantics stay exactly as documented.
- `tests/test_receipt_provenance.py`: new regression test
  (`TestReconcileCommitProvenanceTransactionNarrowing`) that spies on
  `_link_pr_to_dispatch_metadata` and asserts `qi_conn.in_transaction` is `False` at the
  start of every call across a 3-commit scan — provably red on the pre-fix code (the
  second and third calls would see `True`, an open transaction inherited from the first).

## Verification

- `env -u VNX_CURRENT_DISPATCH_ID -u VNX_DISPATCH_ID .../python3.12 -m pytest tests/test_receipt_provenance.py -q` → **76 passed**
- `env -u VNX_CURRENT_DISPATCH_ID -u VNX_DISPATCH_ID .../python3.12 -m pytest tests/test_objective_reconcile.py tests/test_provenance_registry_population.py -q` → **68 passed**
  (env vars unset because this worktree's own `VNX_CURRENT_DISPATCH_ID` leaks into an
  unrelated pre-existing test's env-var fallback path — unrelated to this change)

### Writer-vs-writer benchmark (ad hoc, DB runs in WAL mode — reader-vs-writer never
blocks in WAL, so the DoD explicitly required two concurrent *writers*)

Ran the real `reconcile_commit_provenance` — OLD from `git show HEAD:...` (pre-fix),
NEW from the working tree — against an identical fixture (150 commits, each with a
`Dispatch-ID:` + PR trailer), with an 8ms delay injected into the real
`_link_pr_to_dispatch_metadata` call (representing realistic per-commit processing time;
without it the whole scan is sub-millisecond and OS-scheduling noise dominates any
signal). A second, independent connection to `quality_intelligence.db` (WAL mode) probed
with one paced write every 3ms throughout the scan:

| | OLD (pre-fix) | NEW (this PR) |
|---|---|---|
| scan wall time | 1650.8 ms | 1593.0 ms |
| concurrent writes that succeeded during the scan | 8 | 391 |
| max single concurrent-writer wait | **1482.9 ms** | **11.2 ms** |
| median concurrent-writer wait | 4.94 ms | 0.10 ms |

Max concurrent-writer block time drops ~132x (bounded to one git-log entry's writes
instead of the whole scan); successful interleaved writes go up ~49x for an
equivalent-duration scan.

## Open Items

None.

Dispatch-ID: 20260730-sfp3-provenance-txn

🤖 Generated with [Claude Code](https://claude.com/claude-code)