### PR TITLE
fix(analyzer): project_id, ollama fast-fail, billing guard, atomic writes (OI-853, OI-855)

### DIFF
--- a/schemas/quality_intelligence.sql
+++ b/schemas/quality_intelligence.sql
@@ -345,7 +345,8 @@ CREATE INDEX IF NOT EXISTS idx_rule_confidence ON prevention_rules (confidence D
 -- Session-level metrics extracted from Claude Code JSONL logs
 CREATE TABLE IF NOT EXISTS session_analytics (
     id INTEGER PRIMARY KEY AUTOINCREMENT,
-    session_id TEXT NOT NULL UNIQUE,
+    session_id TEXT NOT NULL,
+    project_id TEXT NOT NULL,  -- ADR-007: NO default; writers fail-closed via resolve_stamp_project_id
     project_path TEXT NOT NULL,
     terminal TEXT,
     session_date DATE NOT NULL,
@@ -375,6 +376,7 @@ CREATE TABLE IF NOT EXISTS session_analytics (
     -- Heuristic flags (phase 2: no LLM needed)
     has_error_recovery BOOLEAN DEFAULT FALSE,
     has_context_reset BOOLEAN DEFAULT FALSE,
+    context_reset_count INTEGER DEFAULT 0,
     has_large_refactor BOOLEAN DEFAULT FALSE,
     has_test_cycle BOOLEAN DEFAULT FALSE,
     primary_activity TEXT,
@@ -384,13 +386,16 @@ CREATE TABLE IF NOT EXISTS session_analytics (
     deep_analysis_model TEXT,
     deep_analysis_at DATETIME,
 
-    -- Model identification
+    -- Model identification + dispatch tracking
     session_model TEXT DEFAULT 'unknown',
+    dispatch_id TEXT,
 
     -- Metadata
     file_size_bytes INTEGER,
     analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
-    analyzer_version TEXT DEFAULT '1.0.0'
+    analyzer_version TEXT DEFAULT '1.0.0',
+
+    UNIQUE (project_id, session_id)
 );
 
 CREATE INDEX IF NOT EXISTS idx_session_terminal ON session_analytics (terminal, session_date DESC);
@@ -398,6 +403,7 @@ CREATE INDEX IF NOT EXISTS idx_session_project ON session_analytics (project_pat
 CREATE INDEX IF NOT EXISTS idx_session_date ON session_analytics (session_date DESC);
 CREATE INDEX IF NOT EXISTS idx_session_activity ON session_analytics (primary_activity);
 CREATE INDEX IF NOT EXISTS idx_session_model ON session_analytics (session_model, session_date DESC);
+CREATE INDEX IF NOT EXISTS idx_session_dispatch ON session_analytics (dispatch_id);
 
 -- Improvement suggestions extracted from session analysis
 CREATE TABLE IF NOT EXISTS improvement_suggestions (

--- a/scripts/conversation_analyzer/deep_analyzer.py
+++ b/scripts/conversation_analyzer/deep_analyzer.py
@@ -9,6 +9,7 @@ from typing import Optional
 from .models import (
     SessionMetrics, SessionFlags,
     LLM_STRATEGY, OLLAMA_MODEL,
+    AUTO_CLAUSE_MAX_SESSIONS,
     DEEP_THRESHOLD_TOKENS, DEEP_THRESHOLD_TOOLS,
     log,
 )
@@ -21,6 +22,14 @@ class DeepAnalyzer:
     ANALYSIS_CATEGORIES = [
         "prompt", "hook", "template", "skill", "workflow", "architecture"
     ]
+
+    # Ollama availability probe: probed once per process, cached for the
+    # lifetime of the class. None = not probed yet, True/False = result.
+    _ollama_probed: Optional[bool] = None
+
+    # Claude-auto guard: set by the runner before processing sessions to
+    # inform the billing guard of the backlog size.
+    _session_backlog: int = 0
 
     SYSTEM_PROMPT = """You are a VNX orchestration system analyst. Analyze this Claude Code session summary and extract actionable improvement suggestions.
 
@@ -68,8 +77,21 @@ Respond with valid JSON:
 
         result_text = None
 
-        if LLM_STRATEGY in ("auto", "claude-only"):
+        # Billing guard: in "auto" mode, refuse the claude path when the
+        # session backlog exceeds the threshold. "claude-only" bypasses
+        # the guard — the operator explicitly opted in to metered spend.
+        if LLM_STRATEGY == "claude-only":
             result_text = self._try_claude_max(prompt)
+        elif LLM_STRATEGY == "auto":
+            if self._session_backlog <= AUTO_CLAUSE_MAX_SESSIONS:
+                result_text = self._try_claude_max(prompt)
+            else:
+                if self._session_backlog > 0:
+                    log("WARNING",
+                        f"auto: skipping claude path — {self._session_backlog} "
+                        f"session backlog exceeds AUTO_CLAUSE_MAX_SESSIONS "
+                        f"({AUTO_CLAUSE_MAX_SESSIONS}). "
+                        f"Use VNX_ANALYZER_LLM=claude-only to override.")
 
         if result_text is None and LLM_STRATEGY in ("auto", "ollama-only"):
             result_text = self._try_ollama(prompt)
@@ -79,6 +101,61 @@ Respond with valid JSON:
             return None
 
         return self._parse_response(result_text)
+
+    @classmethod
+    def set_session_backlog(cls, count: int):
+        """Inform the billing guard of the unanalyzed session count.
+
+        Called by the runner before processing begins. When LLM_STRATEGY is
+        "auto" and the count exceeds AUTO_CLAUSE_MAX_SESSIONS, the claude
+        path is refused to prevent metered-spend landmines.
+        """
+        cls._session_backlog = count
+
+    @classmethod
+    def _probe_ollama(cls) -> bool:
+        """Probe whether Ollama is available with a usable model.
+
+        Issues one GET /api/tags with a 3s timeout. Result is cached for the
+        process lifetime — this runs at most once, regardless of session count.
+        Returns False when the server is unreachable, has no models, or the
+        configured OLLAMA_MODEL is absent.
+        """
+        if cls._ollama_probed is not None:
+            return cls._ollama_probed
+
+        try:
+            import urllib.request
+            req = urllib.request.Request(
+                "http://localhost:11434/api/tags",
+                method="GET",
+            )
+            with urllib.request.urlopen(req, timeout=3) as resp:
+                body = json.loads(resp.read().decode("utf-8"))
+                models = body.get("models", [])
+                if not models:
+                    log("WARNING", "Ollama server reachable but has zero models installed; "
+                                   "deep analysis will be skipped for this run")
+                    cls._ollama_probed = False
+                    return False
+                model_names = {m.get("name", "") for m in models}
+                if OLLAMA_MODEL not in model_names:
+                    log("WARNING",
+                        f"Ollama model '{OLLAMA_MODEL}' not found in installed models "
+                        f"({', '.join(sorted(model_names)[:5])}"
+                        f"{'...' if len(model_names) > 5 else ''}); "
+                        f"deep analysis will be skipped for this run")
+                    cls._ollama_probed = False
+                    return False
+                log("INFO", f"Ollama probe OK: model '{OLLAMA_MODEL}' available "
+                            f"({len(models)} model(s) installed)")
+                cls._ollama_probed = True
+                return True
+        except Exception as e:
+            log("WARNING", f"Ollama probe failed ({e}); "
+                           f"deep analysis will be skipped for this run")
+            cls._ollama_probed = False
+            return False
 
     def _build_session_summary(self, jsonl_path: Path,
                                metrics: SessionMetrics,
@@ -152,8 +229,10 @@ Respond with valid JSON:
             log("WARNING", f"Claude CLI error: {e}")
             return None
 
-    @staticmethod
-    def _try_ollama(prompt: str) -> Optional[str]:
+    @classmethod
+    def _try_ollama(cls, prompt: str) -> Optional[str]:
+        if not cls._probe_ollama():
+            return None
         try:
             import urllib.request
             payload = json.dumps({

--- a/scripts/conversation_analyzer/intelligence_bridge.py
+++ b/scripts/conversation_analyzer/intelligence_bridge.py
@@ -167,7 +167,6 @@ def bridge_session_to_intelligence(conn: Any, metrics: SessionMetrics,
 
         antipatterns_written += _bridge_improvement_suggestions(conn, now)
 
-        conn.commit()
         log("INFO", f"  Bridge→intelligence: {patterns_written} success_patterns, "
                     f"{antipatterns_written} antipatterns")
 

--- a/scripts/conversation_analyzer/models.py
+++ b/scripts/conversation_analyzer/models.py
@@ -28,8 +28,15 @@ CLAUDE_PROJECTS_DIR = Path(
 )
 ANALYZER_VERSION = "1.1.0"
 
-LLM_STRATEGY = os.environ.get("VNX_ANALYZER_LLM", "auto")
+LLM_STRATEGY = os.environ.get("VNX_ANALYZER_LLM", "ollama-only")
 OLLAMA_MODEL = os.environ.get("VNX_OLLAMA_MODEL", "qwen2.5-coder:14b")
+
+# When LLM_STRATEGY="auto", refuse the claude path when the unanalyzed session
+# backlog exceeds this threshold. Protects against metered-spend landmines on
+# large backfills.  An operator can override with VNX_ANALYZER_LLM=claude-only.
+AUTO_CLAUSE_MAX_SESSIONS = int(
+    os.environ.get("VNX_ANALYZER_AUTO_MAX_SESSIONS", "50")
+)
 
 DEEP_THRESHOLD_TOKENS = 100_000
 DEEP_THRESHOLD_TOOLS = 100

--- a/scripts/conversation_analyzer/runner.py
+++ b/scripts/conversation_analyzer/runner.py
@@ -18,9 +18,11 @@ from .deep_analyzer import DeepAnalyzer
 from .generator import DigestGenerator
 from . import intelligence_bridge
 
-# project_scope is imported at the call site to avoid circular imports
-# from the models module (which itself imports vnx_paths). We import the
-# specific function at the module level so it's available for testing.
+# Deliberately NOT fatal at import: dry-run and parse-only entry points on
+# ConversationAnalyzer never touch _resolve_project_id and should not break
+# on an unrelated import failure. The sentinel below only matters to the one
+# method (_resolve_project_id) that enforces the ADR-007 tenant guarantee —
+# it raises there, at call time, instead of guessing a project_id.
 try:
     from project_scope import resolve_stamp_project_id, TenantUnresolved
 except ImportError:
@@ -208,24 +210,39 @@ class ConversationAnalyzer:
         ))
 
     def _resolve_project_id(self) -> str:
-        """Resolve the project_id for tenant-scoped writes (ADR-007).
+        """Resolve the project_id for tenant-scoped writes, fail-closed (ADR-007).
 
-        Sources from ``resolve_stamp_project_id`` with the DB path as authority.
-        Falls back to ``'vnx-dev'`` when no tenant source is configured, which is
-        the correct identity for the default single-tenant VNX installation.
+        Delegates to ``resolve_stamp_project_id(db_path=...)``, which already
+        weighs {DB-path layout, ``.vnx-project-id`` marker, ``VNX_PROJECT_ID``
+        env} as co-sources that must agree. There is no ``'vnx-dev'`` default:
+        ADR-007 explicitly rejects a stamped default as "a sentinel for
+        legitimate rows", and this analyzer runs against every VNX project,
+        not just this one — a guessed identity here would let another
+        tenant's sessions land in the wrong project's key space under the
+        ``UNIQUE (project_id, session_id)`` constraint.
+
+        Deliberately does NOT retry with a bare ``resolve_stamp_project_id()``
+        (env-only) on ``TenantUnresolved``: when the db_path-anchored call
+        raises because its sources conflict (path/marker disagree with env),
+        a retry that checks env alone would silently pick the env value and
+        paper over that conflict — the exact contamination this guard exists
+        to catch. Any ``TenantUnresolved`` propagates so the caller
+        (``analyze_session``) aborts and rolls back that one session's write;
+        the run continues with the next session.
+
+        A missing ``project_scope`` module (import failure) is treated the
+        same way — raised here at call time rather than made fatal at module
+        import. Other ``ConversationAnalyzer`` entry points (dry-run, parsing
+        only) never reach this method and should not be broken by an
+        unrelated import error; only the write path that actually needs the
+        tenant guarantee pays for enforcing it.
         """
-        if resolve_stamp_project_id is not None:
-            try:
-                return resolve_stamp_project_id(db_path=str(self.db_path))
-            except TenantUnresolved:
-                try:
-                    return resolve_stamp_project_id()
-                except TenantUnresolved:
-                    pass
-            except Exception:
-                pass
-        log("WARNING", "Could not resolve project_id; falling back to 'vnx-dev'")
-        return "vnx-dev"
+        if resolve_stamp_project_id is None:
+            raise TenantUnresolved(
+                "project_scope module is unavailable (import failed); "
+                "refusing to stamp a guessed project_id (ADR-007)"
+            )
+        return resolve_stamp_project_id(db_path=str(self.db_path))
 
     def _store_suggestions(self, suggestions: List[dict], digest_id: str):
         if not suggestions:

--- a/scripts/conversation_analyzer/runner.py
+++ b/scripts/conversation_analyzer/runner.py
@@ -144,8 +144,10 @@ class ConversationAnalyzer:
         except Exception:
             try:
                 self.conn.rollback()
-            except Exception:
-                pass
+            except Exception as rollback_exc:
+                log("ERROR", f"  Rollback failed for {metrics.session_id[:8]}...: "
+                             f"{rollback_exc} — connection may be left in a broken "
+                             f"state for the next session's write")
             log("ERROR", f"  Atomic write failed for {metrics.session_id[:8]}..., "
                          f"rolling back both session_analytics and intelligence rows")
             raise

--- a/scripts/conversation_analyzer/runner.py
+++ b/scripts/conversation_analyzer/runner.py
@@ -18,6 +18,15 @@ from .deep_analyzer import DeepAnalyzer
 from .generator import DigestGenerator
 from . import intelligence_bridge
 
+# project_scope is imported at the call site to avoid circular imports
+# from the models module (which itself imports vnx_paths). We import the
+# specific function at the module level so it's available for testing.
+try:
+    from project_scope import resolve_stamp_project_id, TenantUnresolved
+except ImportError:
+    resolve_stamp_project_id = None  # type: ignore[assignment]
+    TenantUnresolved = RuntimeError  # type: ignore[assignment,misc]
+
 
 def _get_claude_projects_dir() -> Path:
     """Late-bind CLAUDE_PROJECTS_DIR to support test patching via the package namespace."""
@@ -113,8 +122,6 @@ class ConversationAnalyzer:
                      f"err={flags.has_error_recovery} ctx={flags.has_context_reset} "
                      f"refactor={flags.has_large_refactor} test={flags.has_test_cycle}")
 
-        self.bridge_session_to_intelligence(metrics, flags)
-
         deep_result = None
         suggestions = []
         if deep_allowed and self.deep.should_deep_analyze(metrics, flags):
@@ -125,7 +132,22 @@ class ConversationAnalyzer:
                     sg["session_id"] = metrics.session_id
                 suggestions = deep_result.get("suggestions", [])
 
-        self._store_session(metrics, flags, deep_result)
+        # Single transaction over both writes (ADR-007 atomicity):
+        # _store_session first so a failing INSERT does not leave orphan
+        # intelligence rows from bridge_session_to_intelligence.
+        try:
+            self._store_session(metrics, flags, deep_result)
+            self.bridge_session_to_intelligence(metrics, flags)
+            self.conn.commit()
+        except Exception:
+            try:
+                self.conn.rollback()
+            except Exception:
+                pass
+            log("ERROR", f"  Atomic write failed for {metrics.session_id[:8]}..., "
+                         f"rolling back both session_analytics and intelligence rows")
+            raise
+
         log("SUCCESS", f"  Stored: {metrics.session_id[:8]}... "
                         f"tokens={metrics.total_output_tokens:,}")
 
@@ -144,10 +166,11 @@ class ConversationAnalyzer:
 
     def _store_session(self, metrics: SessionMetrics, flags: SessionFlags,
                        deep_result: Optional[dict]):
+        project_id = self._resolve_project_id()
         cur = self.conn.cursor()
         cur.execute("""
             INSERT OR REPLACE INTO session_analytics (
-                session_id, project_path, terminal, session_date,
+                session_id, project_id, project_path, terminal, session_date,
                 total_input_tokens, total_output_tokens,
                 cache_creation_tokens, cache_read_tokens,
                 tool_calls_total, tool_read_count, tool_edit_count,
@@ -160,9 +183,9 @@ class ConversationAnalyzer:
                 deep_analysis_json, deep_analysis_model, deep_analysis_at,
                 file_size_bytes, analyzer_version, session_model, dispatch_id
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
-                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                      ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
         """, (
-            metrics.session_id, metrics.project_path, metrics.terminal,
+            metrics.session_id, project_id, metrics.project_path, metrics.terminal,
             metrics.session_date,
             metrics.total_input_tokens, metrics.total_output_tokens,
             metrics.cache_creation_tokens, metrics.cache_read_tokens,
@@ -183,7 +206,26 @@ class ConversationAnalyzer:
             metrics.session_model or "unknown",
             metrics.dispatch_id or None,
         ))
-        self.conn.commit()
+
+    def _resolve_project_id(self) -> str:
+        """Resolve the project_id for tenant-scoped writes (ADR-007).
+
+        Sources from ``resolve_stamp_project_id`` with the DB path as authority.
+        Falls back to ``'vnx-dev'`` when no tenant source is configured, which is
+        the correct identity for the default single-tenant VNX installation.
+        """
+        if resolve_stamp_project_id is not None:
+            try:
+                return resolve_stamp_project_id(db_path=str(self.db_path))
+            except TenantUnresolved:
+                try:
+                    return resolve_stamp_project_id()
+                except TenantUnresolved:
+                    pass
+            except Exception:
+                pass
+        log("WARNING", "Could not resolve project_id; falling back to 'vnx-dev'")
+        return "vnx-dev"
 
     def _store_suggestions(self, suggestions: List[dict], digest_id: str):
         if not suggestions:
@@ -235,6 +277,9 @@ class ConversationAnalyzer:
         sessions = self.find_unanalyzed_sessions(project_filter, terminal_filter,
                                                   diagnostics=dry_run)
         log("INFO", f"Found {len(sessions)} unanalyzed sessions")
+
+        # Inform the deep analyzer of the backlog size for the billing guard.
+        self.deep.set_session_backlog(len(sessions))
 
         if not sessions:
             log("INFO", "Nothing to analyze")

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -8,6 +8,7 @@ Purpose: Initialize SQLite Quality Intelligence Database from schema
 from __future__ import annotations  # PEP 563: lazy annotation evaluation — Python 3.9 compat
 
 import os
+import re
 import sqlite3
 import shutil
 import sys
@@ -1258,6 +1259,54 @@ def _has_composite_unique(conn: sqlite3.Connection, table: str, columns: set[str
     return False
 
 
+def _capture_table_indexes(conn: sqlite3.Connection, table: str) -> list[tuple[str, str]]:
+    """Capture (name, sql) for every real index on ``table``, before a rebuild.
+
+    A hardcoded list of "the indexes this migration knows about" cannot know what
+    a given database actually has — different install/migration histories acquire
+    different indexes over time. Reading them straight from ``sqlite_master``
+    means a table rebuild preserves every index the live table has, including
+    ones no migration explicitly re-creates.
+
+    Excludes ``sqlite_autoindex_*`` entries: those back inline UNIQUE/PRIMARY KEY
+    clauses, have no replayable SQL (``sqlite_master.sql`` is NULL for them), and
+    SQLite regenerates them itself from the new table's own UNIQUE/PK clause.
+    """
+    rows = conn.execute(
+        "SELECT name, sql FROM sqlite_master WHERE type='index' AND tbl_name=?",
+        (table,),
+    ).fetchall()
+    return [
+        (name, sql) for name, sql in rows
+        if sql is not None and not name.startswith("sqlite_autoindex_")
+    ]
+
+
+def _replay_table_indexes(conn: sqlite3.Connection, captured: list[tuple[str, str]]) -> None:
+    """Idempotently replay indexes captured by :func:`_capture_table_indexes`.
+
+    SQLite strips ``IF NOT EXISTS`` from the DDL text it stores in
+    ``sqlite_master.sql`` even when the index was created with it — so the
+    captured SQL must have it re-injected before replay, otherwise a second
+    pass (or a name collision with an index created another way) raises
+    "index already exists" instead of no-op'ing.
+    """
+    for name, sql in captured:
+        if conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='index' AND name=?", (name,)
+        ).fetchone():
+            continue
+        if "IF NOT EXISTS" not in sql.upper():
+            sql = re.sub(
+                r"^(CREATE(?:\s+UNIQUE)?\s+INDEX)\s+",
+                r"\1 IF NOT EXISTS ",
+                sql,
+                count=1,
+                flags=re.IGNORECASE,
+            )
+        conn.execute(sql)
+
+
 def _migrate_v29(conn: sqlite3.Connection) -> None:
     """V29: session_analytics project_id + composite UNIQUE (project_id, session_id).
 
@@ -1271,6 +1320,29 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
     Table recreation is the only SQLite-safe way to alter a UNIQUE constraint.
     INSERT OR IGNORE preserves all existing rows (idempotent re-run guard: the
     composite UNIQUE check in step 0 skips the rebuild when already correct).
+
+    Codex round-4 fixes (index-preservation dispatch):
+
+    - The rebuild used to recreate only a hardcoded list of 6 indexes, silently
+      dropping any other index the live table happened to carry — including
+      ``ux_session_analytics_pid``, the ADR-007 composite UNIQUE from
+      _migrate_v27. Every real index is now captured from ``sqlite_master``
+      before the drop and replayed by name after the rename (see
+      :func:`_capture_table_indexes` / :func:`_replay_table_indexes`), so
+      nothing is lost regardless of which migration history produced it.
+    - The single-column dispatch_id index has two floating names across install
+      histories: the canonical base schema (schemas/quality_intelligence.sql)
+      creates ``idx_session_dispatch``, while legacy DBs upgraded through
+      _migrate_v5 carry ``idx_session_dispatch_id``. Canonical name going
+      forward is ``idx_session_dispatch`` (matches fresh installs) — the legacy
+      name is deliberately excluded from replay and the canonical one is
+      ensured explicitly, so every DB converges on one name instead of
+      accumulating both.
+    - Fail loudly instead of silently dropping data: if the live table has a
+      column the v29 staging DDL does not know about, raise rather than copy
+      only the intersecting columns.
+    - Fail loudly instead of trusting INSERT OR IGNORE: assert the copied row
+      count equals the source row count before swapping the table in.
     """
     # Step 0: Ensure project_id column exists before table recreation.
     cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
@@ -1294,15 +1366,26 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
     )
 
     if needs_rebuild:
-        # Step 1: Drop the cost_per_dispatch view (references session_analytics).
+        # Step 1: Capture every real index the live table has, before anything
+        # is dropped. This is what preserves indexes the hardcoded list below
+        # does not know about (e.g. ux_session_analytics_pid from _migrate_v27,
+        # idx_session_analytics_project from schemas/migrations/0010). The
+        # legacy idx_session_dispatch_id is deliberately excluded from replay —
+        # see the canonical-name note in step 7.
+        captured_indexes = [
+            (name, sql) for name, sql in _capture_table_indexes(conn, "session_analytics")
+            if name != "idx_session_dispatch_id"
+        ]
+
+        # Step 2: Drop the cost_per_dispatch view (references session_analytics).
         conn.execute("DROP VIEW IF EXISTS cost_per_dispatch")
 
-        # Step 2: Build the column list from the live table.
+        # Step 3: Build the column list from the live table.
         cols_info = conn.execute("PRAGMA table_info(session_analytics)").fetchall()
         col_names = [r[1] for r in cols_info]
         non_id_cols = [c for c in col_names if c != "id"]
 
-        # Step 3: Create staging table with composite UNIQUE and copy data.
+        # Step 4: Create staging table with composite UNIQUE and copy data.
         conn.execute("""
             CREATE TABLE _session_analytics_v29 (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -1344,50 +1427,60 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
                 UNIQUE (project_id, session_id)
             )
         """)
-        # Copy only columns that exist in both source and destination.
+        # Step 5: fail loudly if the live table has a column the staging DDL
+        # above does not know about — silently copying only the intersection
+        # would drop that column's data with no trace.
         dest_cols_info = conn.execute(
             "PRAGMA table_info(_session_analytics_v29)"
         ).fetchall()
         dest_cols = {r[1] for r in dest_cols_info}
-        shared_cols = [c for c in non_id_cols if c in dest_cols]
-        shared_list = ", ".join(shared_cols)
+        source_only = [c for c in non_id_cols if c not in dest_cols]
+        if source_only:
+            raise RuntimeError(
+                "V29 migration: session_analytics has column(s) "
+                f"{source_only} not present in the v29 staging schema — "
+                "refusing to silently drop data. Add them to the "
+                "CREATE TABLE _session_analytics_v29 DDL in _migrate_v29."
+            )
+        shared_list = ", ".join(non_id_cols)
+
+        # Step 6: copy the data, then fail loudly if INSERT OR IGNORE silently
+        # dropped any row (it can, on a duplicate (project_id, session_id)).
+        source_count = conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0]
         conn.execute(
             f"INSERT OR IGNORE INTO _session_analytics_v29 ({shared_list}) "
             f"SELECT {shared_list} FROM session_analytics"
         )
+        copied_count = conn.execute(
+            "SELECT COUNT(*) FROM _session_analytics_v29"
+        ).fetchone()[0]
+        if copied_count != source_count:
+            raise RuntimeError(
+                "V29 migration: row-count mismatch after copy — source had "
+                f"{source_count} row(s), staging table has {copied_count}. "
+                "INSERT OR IGNORE silently dropped row(s); refusing to swap "
+                "the table in."
+            )
 
-        # Step 4: Swap the table.
+        # Step 7: Swap the table.
         conn.execute("DROP TABLE session_analytics")
         conn.execute("ALTER TABLE _session_analytics_v29 RENAME TO session_analytics")
         log('INFO', 'Migrated session_analytics: composite UNIQUE (project_id, session_id) (ADR-007)')
 
-        # Step 5: Recreate indexes (dropped with the old table).
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_session_terminal "
-            "ON session_analytics (terminal, session_date DESC)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_session_project "
-            "ON session_analytics (project_path, session_date DESC)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_session_date "
-            "ON session_analytics (session_date DESC)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_session_activity "
-            "ON session_analytics (primary_activity)"
-        )
-        conn.execute(
-            "CREATE INDEX IF NOT EXISTS idx_session_model "
-            "ON session_analytics (session_model, session_date DESC)"
-        )
+        # Step 8: replay every captured index under its original name, then
+        # ensure the canonical dispatch_id index — idx_session_dispatch,
+        # matching the current base schema — regardless of which name (if
+        # any) the live table carried before the rebuild.
+        _replay_table_indexes(conn, captured_indexes)
         conn.execute(
             "CREATE INDEX IF NOT EXISTS idx_session_dispatch "
             "ON session_analytics (dispatch_id)"
         )
+        log('INFO', f'Replayed {len(captured_indexes)} captured session_analytics index(es) + ensured idx_session_dispatch')
 
-        # Step 6: Recreate the cost_per_dispatch view.
+        # Step 9: Recreate the cost_per_dispatch view.
         conn.execute("""
             CREATE VIEW IF NOT EXISTS cost_per_dispatch AS
             SELECT
@@ -1407,7 +1500,7 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
             LEFT JOIN session_analytics sa ON sa.dispatch_id = dm.dispatch_id
             WHERE dm.outcome_status IS NOT NULL
         """)
-        log('INFO', 'Recreated session_analytics indexes + cost_per_dispatch view')
+        log('INFO', 'Recreated cost_per_dispatch view')
 
     # Backfill NULL project_ids for any rows that predate the column addition.
     null_count = conn.execute(

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -1234,6 +1234,30 @@ def _migrate_v28(conn: sqlite3.Connection) -> None:
     log('INFO', 'Migrated: created pattern_injection_outcome table + indexes (ADR-007, v28)')
 
 
+def _has_composite_unique(conn: sqlite3.Connection, table: str, columns: set[str]) -> bool:
+    """Return True if ``table`` has a UNIQUE index/constraint over exactly ``columns``.
+
+    Reads the constraint from SQLite's own PRAGMA structures (index_list +
+    index_info) instead of comparing sqlite_master.sql text. The DDL text is
+    order- and quoting-sensitive — SQLite happily stores
+    ``UNIQUE ("session_id", "project_id")`` for a table declared with
+    ``UNIQUE (project_id, session_id)``, so a literal-string guard never
+    matches its own output. PRAGMA index_info reports the column SET
+    regardless of declared order or quoting.
+    """
+    for idx in conn.execute(f"PRAGMA index_list({table})").fetchall():
+        idx_name = idx[1]
+        is_unique = idx[2]
+        if not is_unique:
+            continue
+        idx_cols = {
+            r[2] for r in conn.execute(f"PRAGMA index_info({idx_name})").fetchall()
+        }
+        if idx_cols == columns:
+            return True
+    return False
+
+
 def _migrate_v29(conn: sqlite3.Connection) -> None:
     """V29: session_analytics project_id + composite UNIQUE (project_id, session_id).
 
@@ -1265,12 +1289,8 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
         conn.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
 
     # Idempotent guard: skip rebuild if composite UNIQUE already present.
-    tbl_sql = (conn.execute(
-        "SELECT sql FROM sqlite_master WHERE type='table' AND name='session_analytics'"
-    ).fetchone() or ("",))[0]
-    needs_rebuild = (
-        "UNIQUE (project_id, session_id)" not in tbl_sql
-        and "UNIQUE(project_id,session_id)" not in tbl_sql
+    needs_rebuild = not _has_composite_unique(
+        conn, "session_analytics", {"project_id", "session_id"}
     )
 
     if needs_rebuild:
@@ -1287,7 +1307,7 @@ def _migrate_v29(conn: sqlite3.Connection) -> None:
             CREATE TABLE _session_analytics_v29 (
                 id INTEGER PRIMARY KEY AUTOINCREMENT,
                 session_id TEXT NOT NULL,
-                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                project_id TEXT NOT NULL,
                 project_path TEXT NOT NULL,
                 terminal TEXT,
                 session_date DATE NOT NULL,

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -27,7 +27,7 @@ import schema_migration
 
 # Highest PRAGMA user_version stamped by bootstrap_qi_db.
 # Increment this constant whenever a new migration block is added.
-HIGHEST_QI_VERSION = 28
+HIGHEST_QI_VERSION = 29
 
 # VNX Base Configuration
 PATHS = ensure_env()
@@ -1234,6 +1234,172 @@ def _migrate_v28(conn: sqlite3.Connection) -> None:
     log('INFO', 'Migrated: created pattern_injection_outcome table + indexes (ADR-007, v28)')
 
 
+def _migrate_v29(conn: sqlite3.Connection) -> None:
+    """V29: session_analytics project_id + composite UNIQUE (project_id, session_id).
+
+    ADR-007: the original UNIQUE(session_id) constraint is single-tenant — two
+    projects with the same Claude-generated session_id would collide. Rebuild the
+    table with UNIQUE(project_id, session_id) so each tenant's rows are isolated.
+
+    Also adds project_id TEXT NOT NULL, context_reset_count, and dispatch_id columns
+    that were in the live DB but missing from the canonical schema.
+
+    Table recreation is the only SQLite-safe way to alter a UNIQUE constraint.
+    INSERT OR IGNORE preserves all existing rows (idempotent re-run guard: the
+    composite UNIQUE check in step 0 skips the rebuild when already correct).
+    """
+    # Step 0: Ensure project_id column exists before table recreation.
+    cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
+    if "project_id" not in cols:
+        conn.execute(
+            "ALTER TABLE session_analytics ADD COLUMN project_id TEXT NOT NULL DEFAULT 'vnx-dev'"
+        )
+        cols = {r[1] for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()}
+
+    # Ensure other missing columns exist (context_reset_count, dispatch_id).
+    if "context_reset_count" not in cols:
+        conn.execute(
+            "ALTER TABLE session_analytics ADD COLUMN context_reset_count INTEGER DEFAULT 0"
+        )
+    if "dispatch_id" not in cols:
+        conn.execute("ALTER TABLE session_analytics ADD COLUMN dispatch_id TEXT")
+
+    # Idempotent guard: skip rebuild if composite UNIQUE already present.
+    tbl_sql = (conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name='session_analytics'"
+    ).fetchone() or ("",))[0]
+    needs_rebuild = (
+        "UNIQUE (project_id, session_id)" not in tbl_sql
+        and "UNIQUE(project_id,session_id)" not in tbl_sql
+    )
+
+    if needs_rebuild:
+        # Step 1: Drop the cost_per_dispatch view (references session_analytics).
+        conn.execute("DROP VIEW IF EXISTS cost_per_dispatch")
+
+        # Step 2: Build the column list from the live table.
+        cols_info = conn.execute("PRAGMA table_info(session_analytics)").fetchall()
+        col_names = [r[1] for r in cols_info]
+        non_id_cols = [c for c in col_names if c != "id"]
+
+        # Step 3: Create staging table with composite UNIQUE and copy data.
+        conn.execute("""
+            CREATE TABLE _session_analytics_v29 (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                project_path TEXT NOT NULL,
+                terminal TEXT,
+                session_date DATE NOT NULL,
+                total_input_tokens INTEGER DEFAULT 0,
+                total_output_tokens INTEGER DEFAULT 0,
+                cache_creation_tokens INTEGER DEFAULT 0,
+                cache_read_tokens INTEGER DEFAULT 0,
+                tool_calls_total INTEGER DEFAULT 0,
+                tool_read_count INTEGER DEFAULT 0,
+                tool_edit_count INTEGER DEFAULT 0,
+                tool_bash_count INTEGER DEFAULT 0,
+                tool_grep_count INTEGER DEFAULT 0,
+                tool_write_count INTEGER DEFAULT 0,
+                tool_task_count INTEGER DEFAULT 0,
+                tool_other_count INTEGER DEFAULT 0,
+                message_count INTEGER DEFAULT 0,
+                user_message_count INTEGER DEFAULT 0,
+                assistant_message_count INTEGER DEFAULT 0,
+                duration_minutes REAL,
+                has_error_recovery BOOLEAN DEFAULT FALSE,
+                has_context_reset BOOLEAN DEFAULT FALSE,
+                context_reset_count INTEGER DEFAULT 0,
+                has_large_refactor BOOLEAN DEFAULT FALSE,
+                has_test_cycle BOOLEAN DEFAULT FALSE,
+                primary_activity TEXT,
+                deep_analysis_json TEXT,
+                deep_analysis_model TEXT,
+                deep_analysis_at DATETIME,
+                session_model TEXT DEFAULT 'unknown',
+                dispatch_id TEXT,
+                file_size_bytes INTEGER,
+                analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+                analyzer_version TEXT DEFAULT '1.0.0',
+                UNIQUE (project_id, session_id)
+            )
+        """)
+        # Copy only columns that exist in both source and destination.
+        dest_cols_info = conn.execute(
+            "PRAGMA table_info(_session_analytics_v29)"
+        ).fetchall()
+        dest_cols = {r[1] for r in dest_cols_info}
+        shared_cols = [c for c in non_id_cols if c in dest_cols]
+        shared_list = ", ".join(shared_cols)
+        conn.execute(
+            f"INSERT OR IGNORE INTO _session_analytics_v29 ({shared_list}) "
+            f"SELECT {shared_list} FROM session_analytics"
+        )
+
+        # Step 4: Swap the table.
+        conn.execute("DROP TABLE session_analytics")
+        conn.execute("ALTER TABLE _session_analytics_v29 RENAME TO session_analytics")
+        log('INFO', 'Migrated session_analytics: composite UNIQUE (project_id, session_id) (ADR-007)')
+
+        # Step 5: Recreate indexes (dropped with the old table).
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_terminal "
+            "ON session_analytics (terminal, session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_project "
+            "ON session_analytics (project_path, session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_date "
+            "ON session_analytics (session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_activity "
+            "ON session_analytics (primary_activity)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_model "
+            "ON session_analytics (session_model, session_date DESC)"
+        )
+        conn.execute(
+            "CREATE INDEX IF NOT EXISTS idx_session_dispatch "
+            "ON session_analytics (dispatch_id)"
+        )
+
+        # Step 6: Recreate the cost_per_dispatch view.
+        conn.execute("""
+            CREATE VIEW IF NOT EXISTS cost_per_dispatch AS
+            SELECT
+                dm.dispatch_id,
+                dm.terminal,
+                dm.role,
+                dm.gate,
+                dm.outcome_status,
+                sa.session_model,
+                sa.total_input_tokens,
+                sa.total_output_tokens,
+                sa.tool_calls_total,
+                sa.duration_minutes,
+                dm.pattern_count,
+                dm.instruction_char_count
+            FROM dispatch_metadata dm
+            LEFT JOIN session_analytics sa ON sa.dispatch_id = dm.dispatch_id
+            WHERE dm.outcome_status IS NOT NULL
+        """)
+        log('INFO', 'Recreated session_analytics indexes + cost_per_dispatch view')
+
+    # Backfill NULL project_ids for any rows that predate the column addition.
+    null_count = conn.execute(
+        "SELECT COUNT(*) FROM session_analytics WHERE project_id IS NULL"
+    ).fetchone()[0]
+    if null_count > 0:
+        conn.execute(
+            "UPDATE session_analytics SET project_id = 'vnx-dev' WHERE project_id IS NULL"
+        )
+        log('INFO', f'Backfilled project_id for {null_count} legacy session_analytics rows')
+
+
 # Registry mapping version → migration function.
 # bootstrap_qi_db iterates this in sorted key order after V1.
 MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
@@ -1264,6 +1430,7 @@ MIGRATIONS: dict[int, Callable[[sqlite3.Connection], None]] = {
     26: _migrate_v26,
     27: _migrate_v27,
     28: _migrate_v28,
+    29: _migrate_v29,
 }
 
 

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -1247,7 +1247,9 @@ class TestAtomicWrites:
             store_failed = True
             try:
                 analyzer.conn.rollback()
-            except Exception:
+            except Exception:  # vnx-silent-except: in-memory sqlite3 rollback() cannot itself
+                # raise here (no broken-connection scenario is under test); kept only for
+                # structural parity with the production atomic-write pattern this test exercises.
                 pass
 
         assert store_failed is True, "Expected _store_session to fail"

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -398,6 +398,7 @@ class TestStorage:
 
         analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
         analyzer.conn = conn
+        analyzer.db_path = Path(tempfile.mktemp(suffix=".db"))
 
         metrics = SessionMetrics(
             session_id="test-session-001",
@@ -413,7 +414,8 @@ class TestStorage:
         )
         flags = SessionFlags(primary_activity="coding")
 
-        analyzer._store_session(metrics, flags, None)
+        with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+            analyzer._store_session(metrics, flags, None)
 
         cur = conn.cursor()
         cur.execute("SELECT * FROM session_analytics WHERE session_id = 'test-session-001'")
@@ -667,6 +669,7 @@ class TestModelExtraction:
 
         analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
         analyzer.conn = conn
+        analyzer.db_path = Path(tempfile.mktemp(suffix=".db"))
 
         metrics = SessionMetrics(
             session_id="model-test-001",
@@ -676,7 +679,8 @@ class TestModelExtraction:
             session_model="claude-opus",
         )
         flags = SessionFlags(primary_activity="coding")
-        analyzer._store_session(metrics, flags, None)
+        with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+            analyzer._store_session(metrics, flags, None)
 
         cur = conn.cursor()
         cur.execute("SELECT session_model FROM session_analytics WHERE session_id = 'model-test-001'")
@@ -1192,7 +1196,8 @@ class TestAtomicWrites:
         # The bridge catches its own exception; no exception propagates.
         # The ABORT inside the trigger rolls back the implicit transaction
         # that includes the _store_session INSERT.
-        analyzer._store_session(metrics, flags, None)
+        with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+            analyzer._store_session(metrics, flags, None)
         analyzer.bridge_session_to_intelligence(metrics, flags)
         analyzer.conn.commit()
 
@@ -1234,7 +1239,8 @@ class TestAtomicWrites:
 
         store_failed = False
         try:
-            analyzer._store_session(metrics, flags, None)
+            with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+                analyzer._store_session(metrics, flags, None)
             analyzer.bridge_session_to_intelligence(metrics, flags)
             analyzer.conn.commit()
         except Exception:
@@ -1268,7 +1274,12 @@ class TestAtomicWrites:
         )
 
     def test_project_id_populated_on_insert(self):
-        """New rows have a non-NULL, non-empty project_id after _store_session."""
+        """New rows carry the resolved project_id when a tenant is configured.
+
+        The analyzer's db_path here is a bare tempfile (no .vnx-data/<pid>/state
+        layout, no .vnx-project-id marker), so VNX_PROJECT_ID env is the only
+        available tenant source.
+        """
         analyzer = _make_analyzer_with_intel_db()
         metrics = SessionMetrics(
             session_id="pid-test-001",
@@ -1278,8 +1289,9 @@ class TestAtomicWrites:
         )
         flags = SessionFlags()
 
-        analyzer._store_session(metrics, flags, None)
-        analyzer.conn.commit()
+        with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+            analyzer._store_session(metrics, flags, None)
+            analyzer.conn.commit()
 
         row = analyzer.conn.execute(
             "SELECT project_id FROM session_analytics WHERE session_id = 'pid-test-001'"
@@ -1288,8 +1300,99 @@ class TestAtomicWrites:
         pid = row[0]
         assert pid is not None, "project_id is NULL"
         assert pid != "", "project_id is empty string"
-        # With no VNX_PROJECT_ID set, the fallback is 'vnx-dev'
         assert pid == "vnx-dev", f"Expected 'vnx-dev', got {pid!r}"
+
+    def test_resolve_project_id_raises_when_unresolvable(self):
+        """No default: an unresolvable tenant raises rather than stamping 'vnx-dev'.
+
+        ADR-007 rejects a hardcoded default as "a sentinel for legitimate
+        rows" — this analyzer runs against every VNX project (sales-copilot,
+        seocrawler-v2, mission-control, ...), so a guessed identity here would
+        let another tenant's sessions collide under the
+        UNIQUE (project_id, session_id) constraint.
+        """
+        from project_scope import TenantUnresolved
+
+        analyzer = _make_analyzer_with_intel_db()
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_PROJECT_ID", None)
+            with pytest.raises(TenantUnresolved):
+                analyzer._resolve_project_id()
+
+    def test_store_session_raises_and_writes_nothing_when_tenant_unresolved(self):
+        """_store_session must not insert a row when project_id can't resolve."""
+        from project_scope import TenantUnresolved
+
+        analyzer = _make_analyzer_with_intel_db()
+        metrics = SessionMetrics(
+            session_id="unresolved-tenant-001",
+            project_path="/test",
+            terminal="T1",
+            session_date="2026-03-04",
+        )
+        flags = SessionFlags()
+
+        with patch.dict(os.environ, {}, clear=False):
+            os.environ.pop("VNX_PROJECT_ID", None)
+            with pytest.raises(TenantUnresolved):
+                analyzer._store_session(metrics, flags, None)
+
+        count = analyzer.conn.execute(
+            "SELECT COUNT(*) FROM session_analytics "
+            "WHERE session_id = 'unresolved-tenant-001'"
+        ).fetchone()[0]
+        assert count == 0, "row was inserted despite an unresolved project_id"
+
+    def test_resolve_project_id_raises_when_project_scope_missing(self):
+        """A project_scope import failure must not degrade to a guessed default.
+
+        Simulates the module-level ``except ImportError`` path by clearing the
+        cached reference on the runner module — the call-time raise is the
+        deliberate choice (see _resolve_project_id docstring): other
+        ConversationAnalyzer entry points that never call this method (dry-run,
+        parsing-only) should not be broken by an unrelated import error.
+        """
+        import conversation_analyzer.runner as runner_module
+        from project_scope import TenantUnresolved
+
+        analyzer = _make_analyzer_with_intel_db()
+        original = runner_module.resolve_stamp_project_id
+        runner_module.resolve_stamp_project_id = None
+        try:
+            with pytest.raises(TenantUnresolved):
+                analyzer._resolve_project_id()
+        finally:
+            runner_module.resolve_stamp_project_id = original
+
+    def test_resolve_project_id_conflict_does_not_fall_back_to_env(self, tmp_path):
+        """A path/env conflict must raise, never silently resolve to env.
+
+        Regression test for the fix-forward on PR #1248: _resolve_project_id
+        used to retry a bare, env-only resolve_stamp_project_id() whenever the
+        db_path-anchored call raised TenantUnresolved — including when that
+        raise came from a genuine SOURCE CONFLICT (db path says one tenant,
+        VNX_PROJECT_ID says another), not just "no source at all". That retry
+        silently returned the env value, papering over exactly the
+        cross-tenant contamination this guard exists to catch.
+        """
+        from project_scope import TenantUnresolved
+
+        db_dir = tmp_path / ".vnx-data" / "mission-control" / "state"
+        db_dir.mkdir(parents=True)
+        db_path = db_dir / "quality_intelligence.db"
+
+        conn = sqlite3.connect(":memory:")
+        conn.row_factory = sqlite3.Row
+        _create_schema(conn)
+        _create_intelligence_schema(conn)
+
+        analyzer = ConversationAnalyzer(db_path)
+        analyzer.conn = conn
+
+        with patch.dict(os.environ, {"VNX_PROJECT_ID": "vnx-dev"}):
+            with pytest.raises(TenantUnresolved):
+                analyzer._resolve_project_id()
 
 
 if __name__ == "__main__":

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -59,7 +59,8 @@ def _create_schema(conn: sqlite3.Connection):
     conn.executescript("""
         CREATE TABLE IF NOT EXISTS session_analytics (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
-            session_id TEXT NOT NULL UNIQUE,
+            session_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
             project_path TEXT NOT NULL,
             terminal TEXT,
             session_date DATE NOT NULL,
@@ -89,10 +90,11 @@ def _create_schema(conn: sqlite3.Connection):
             deep_analysis_model TEXT,
             deep_analysis_at DATETIME,
             session_model TEXT DEFAULT 'unknown',
+            dispatch_id TEXT,
             file_size_bytes INTEGER,
             analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
             analyzer_version TEXT DEFAULT '1.0.0',
-            dispatch_id TEXT
+            UNIQUE (project_id, session_id)
         );
         CREATE TABLE IF NOT EXISTS improvement_suggestions (
             id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -431,8 +433,8 @@ class TestStorage:
 
         # Insert a known session
         conn.execute(
-            "INSERT INTO session_analytics (session_id, project_path, session_date) "
-            "VALUES ('known-id', '/test', '2026-03-02')")
+            "INSERT INTO session_analytics (session_id, project_id, project_path, session_date) "
+            "VALUES ('known-id', 'vnx-dev', '/test', '2026-03-02')")
         conn.commit()
 
         analyzer = ConversationAnalyzer.__new__(ConversationAnalyzer)
@@ -697,23 +699,23 @@ class TestSessionBrief:
 
         today = datetime.now().strftime("%Y-%m-%d")
         sessions = [
-            ("s1", "/test", "T1", today, 5000, 2000, 100, 900, 10, "coding", 0, "claude-opus", 25.0),
-            ("s2", "/test", "T1", today, 6000, 3000, 200, 1800, 15, "refactoring", 0, "claude-opus", 30.0),
-            ("s3", "/test", "T2", today, 3000, 1500, 50, 500, 8, "research", 1, "claude-sonnet", 15.0),
-            ("s4", "/test", "T1", today, 4000, 1800, 80, 700, 12, "coding", 0, "claude-opus", 20.0),
-            ("s5", "/test", "T2", today, 2500, 1000, 40, 400, 6, "research", 0, "claude-sonnet", 10.0),
-            ("s6", "/test", "T1", today, 7000, 4000, 150, 1200, 20, "coding", 1, "claude-opus", 35.0),
+            ("s1", "vnx-dev", "/test", "T1", today, 5000, 2000, 100, 900, 10, "coding", 0, "claude-opus", 25.0),
+            ("s2", "vnx-dev", "/test", "T1", today, 6000, 3000, 200, 1800, 15, "refactoring", 0, "claude-opus", 30.0),
+            ("s3", "vnx-dev", "/test", "T2", today, 3000, 1500, 50, 500, 8, "research", 1, "claude-sonnet", 15.0),
+            ("s4", "vnx-dev", "/test", "T1", today, 4000, 1800, 80, 700, 12, "coding", 0, "claude-opus", 20.0),
+            ("s5", "vnx-dev", "/test", "T2", today, 2500, 1000, 40, 400, 6, "research", 0, "claude-sonnet", 10.0),
+            ("s6", "vnx-dev", "/test", "T1", today, 7000, 4000, 150, 1200, 20, "coding", 1, "claude-opus", 35.0),
         ]
 
         for s in sessions:
             conn.execute("""
                 INSERT INTO session_analytics (
-                    session_id, project_path, terminal, session_date,
+                    session_id, project_id, project_path, terminal, session_date,
                     total_input_tokens, total_output_tokens,
                     cache_creation_tokens, cache_read_tokens,
                     tool_calls_total, primary_activity,
                     has_error_recovery, session_model, duration_minutes
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """, s)
         conn.commit()
         return conn
@@ -741,9 +743,9 @@ class TestSessionBrief:
         for i, has_err in enumerate([1, 1, 0]):
             conn.execute("""
                 INSERT INTO session_analytics (
-                    session_id, project_path, terminal, session_date,
+                    session_id, project_id, project_path, terminal, session_date,
                     primary_activity, has_error_recovery, session_model
-                ) VALUES (?, '/test', 'T2', ?, 'coding', ?, 'claude-sonnet')
+                ) VALUES (?, 'vnx-dev', '/test', 'T2', ?, 'coding', ?, 'claude-sonnet')
             """, (f"err-test-{i}", today, has_err))
         conn.commit()
 
@@ -815,20 +817,20 @@ class TestSuggestedEdits:
         for i in range(6):
             conn.execute("""
                 INSERT INTO session_analytics (
-                    session_id, project_path, terminal, session_date,
+                    session_id, project_id, project_path, terminal, session_date,
                     total_output_tokens, cache_read_tokens, cache_creation_tokens,
                     primary_activity, has_error_recovery, session_model
-                ) VALUES (?, '/test', 'T1', ?, 50000, 900, 100, 'coding', ?, 'claude-opus')
+                ) VALUES (?, 'vnx-dev', '/test', 'T1', ?, 50000, 900, 100, 'coding', ?, 'claude-opus')
             """, (f"opus-{i}", today, 1 if i == 0 else 0))
 
         # 5 sonnet coding sessions (2 success, 3 error)
         for i in range(5):
             conn.execute("""
                 INSERT INTO session_analytics (
-                    session_id, project_path, terminal, session_date,
+                    session_id, project_id, project_path, terminal, session_date,
                     total_output_tokens, cache_read_tokens, cache_creation_tokens,
                     primary_activity, has_error_recovery, session_model
-                ) VALUES (?, '/test', 'T2', ?, 30000, 400, 100, 'coding', ?, 'claude-sonnet')
+                ) VALUES (?, 'vnx-dev', '/test', 'T2', ?, 30000, 400, 100, 'coding', ?, 'claude-sonnet')
             """, (f"sonnet-{i}", today, 0 if i < 2 else 1))
         conn.commit()
 
@@ -1147,6 +1149,147 @@ class TestBridgeSessionToIntelligence:
 
         count = analyzer.conn.execute("SELECT COUNT(*) FROM antipatterns").fetchone()[0]
         assert count == 0
+
+
+# ---------------------------------------------------------------------------
+# Atomicity: session_analytics + intelligence bridge in one transaction
+# ---------------------------------------------------------------------------
+
+class TestAtomicWrites:
+    """session_analytics and intelligence writes must be atomic."""
+
+    def test_session_stored_before_bridge(self):
+        """_store_session is called before bridge_session_to_intelligence.
+
+        The INSERT into session_analytics runs first. When the bridge fails
+        mid-write, the ABORT-level rollback undoes both writes — no orphan
+        session_analytics row remains. The bridge catches its own exceptions
+        internally and does not re-raise; the caller's commit() commits an
+        empty transaction.
+        """
+        analyzer = _make_analyzer_with_intel_db()
+
+        # Install a trigger that makes the first intelligence INSERT fail
+        # after session_analytics has already been written. This simulates
+        # the bridge failing mid-write.
+        analyzer.conn.execute("""
+            CREATE TRIGGER IF NOT EXISTS _test_force_bridge_fail
+            BEFORE INSERT ON success_patterns
+            BEGIN
+                SELECT RAISE(ABORT, 'simulated bridge failure');
+            END
+        """)
+
+        metrics = SessionMetrics(
+            session_id="atomic-test-001",
+            project_path="/test",
+            terminal="T1",
+            session_date="2026-03-04",
+        )
+        flags = SessionFlags(has_test_cycle=True)
+
+        # Simulate the atomic write pattern from analyze_session.
+        # The bridge catches its own exception; no exception propagates.
+        # The ABORT inside the trigger rolls back the implicit transaction
+        # that includes the _store_session INSERT.
+        analyzer._store_session(metrics, flags, None)
+        analyzer.bridge_session_to_intelligence(metrics, flags)
+        analyzer.conn.commit()
+
+        # Verify: neither write landed — the ABORT rolled back everything.
+        sa_rows = analyzer.conn.execute(
+            "SELECT COUNT(*) FROM session_analytics WHERE session_id = 'atomic-test-001'"
+        ).fetchone()[0]
+        sp_rows = analyzer.conn.execute(
+            "SELECT COUNT(*) FROM success_patterns"
+        ).fetchone()[0]
+
+        assert sa_rows == 0, (
+            f"session_analytics has {sa_rows} row(s) — "
+            "INSERT survived the bridge-triggered ABORT"
+        )
+        assert sp_rows == 0, (
+            f"success_patterns has {sp_rows} row(s) — "
+            "bridge wrote despite trigger"
+        )
+
+    def test_no_orphan_intelligence_on_session_failure(self):
+        """When session_analytics INSERT fails, no intelligence rows are written.
+
+        The bridge is called AFTER _store_session. If _store_session raises,
+        the bridge code is never reached at all — structural atomicity without
+        needing a transaction rollback.
+        """
+        analyzer = _make_analyzer_with_intel_db()
+        metrics = SessionMetrics(
+            session_id="orphan-test-001",
+            project_path="/test",
+            terminal="T1",
+            session_date="2026-03-04",
+        )
+        flags = SessionFlags(has_test_cycle=True)
+
+        # Drop the session_analytics table to force _store_session to fail.
+        analyzer.conn.execute("DROP TABLE IF EXISTS session_analytics")
+
+        store_failed = False
+        try:
+            analyzer._store_session(metrics, flags, None)
+            analyzer.bridge_session_to_intelligence(metrics, flags)
+            analyzer.conn.commit()
+        except Exception:
+            store_failed = True
+            try:
+                analyzer.conn.rollback()
+            except Exception:
+                pass
+
+        assert store_failed is True, "Expected _store_session to fail"
+
+        # Recreate session_analytics to query intelligence tables (which share
+        # the same in-memory DB but were never reached).
+        _create_schema(analyzer.conn)
+        _create_intelligence_schema(analyzer.conn)
+
+        sp_rows = analyzer.conn.execute(
+            "SELECT COUNT(*) FROM success_patterns"
+        ).fetchone()[0]
+        ap_rows = analyzer.conn.execute(
+            "SELECT COUNT(*) FROM antipatterns"
+        ).fetchone()[0]
+
+        assert sp_rows == 0, (
+            f"success_patterns has {sp_rows} orphan row(s) — "
+            "bridge ran despite _store_session failure"
+        )
+        assert ap_rows == 0, (
+            f"antipatterns has {ap_rows} orphan row(s) — "
+            "bridge ran despite _store_session failure"
+        )
+
+    def test_project_id_populated_on_insert(self):
+        """New rows have a non-NULL, non-empty project_id after _store_session."""
+        analyzer = _make_analyzer_with_intel_db()
+        metrics = SessionMetrics(
+            session_id="pid-test-001",
+            project_path="/test",
+            terminal="T1",
+            session_date="2026-03-04",
+        )
+        flags = SessionFlags()
+
+        analyzer._store_session(metrics, flags, None)
+        analyzer.conn.commit()
+
+        row = analyzer.conn.execute(
+            "SELECT project_id FROM session_analytics WHERE session_id = 'pid-test-001'"
+        ).fetchone()
+        assert row is not None, "Row was not inserted"
+        pid = row[0]
+        assert pid is not None, "project_id is NULL"
+        assert pid != "", "project_id is empty string"
+        # With no VNX_PROJECT_ID set, the fallback is 'vnx-dev'
+        assert pid == "vnx-dev", f"Expected 'vnx-dev', got {pid!r}"
 
 
 if __name__ == "__main__":

--- a/tests/test_migrate_v29_guard.py
+++ b/tests/test_migrate_v29_guard.py
@@ -1,0 +1,208 @@
+#!/usr/bin/env python3
+"""Tests for migration V29's idempotency guard and rebuilt-table default.
+
+Covers two defects found on PR #1248's original _migrate_v29 (session_analytics
+composite UNIQUE (project_id, session_id), ADR-007):
+
+  1. The re-run guard compared literal SQL text against sqlite_master.sql, which
+     never matches SQLite's own reformatted DDL (reversed column order, quoted
+     identifiers). _has_composite_unique reads PRAGMA index_list/index_info
+     instead, so it is order- and quoting-independent.
+  2. The rebuilt staging table declared `project_id TEXT NOT NULL DEFAULT
+     'vnx-dev'`, which survived the RENAME and left migrated tables carrying a
+     default the canonical schema explicitly forbids (ADR-007: writers fail
+     closed via resolve_stamp_project_id, never a silent vnx-dev fallback).
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import quality_db_init as qdi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_legacy_session_analytics_db(path: Path, row_count: int = 3) -> sqlite3.Connection:
+    """Legacy V3-era shape: single-column UNIQUE(session_id), no project_id."""
+    conn = sqlite3.connect(str(path))
+    conn.isolation_level = None
+    conn.executescript("""
+        CREATE TABLE session_analytics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL UNIQUE,
+            project_path TEXT NOT NULL,
+            terminal TEXT,
+            session_date DATE NOT NULL,
+            total_input_tokens INTEGER DEFAULT 0,
+            session_model TEXT DEFAULT 'unknown',
+            analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            analyzer_version TEXT DEFAULT '1.0.0'
+        );
+        CREATE TABLE dispatch_metadata (
+            dispatch_id TEXT,
+            terminal TEXT,
+            role TEXT,
+            gate TEXT,
+            outcome_status TEXT,
+            pattern_count INTEGER,
+            instruction_char_count INTEGER
+        );
+        CREATE VIEW cost_per_dispatch AS
+            SELECT dm.dispatch_id, dm.terminal, dm.role, dm.gate, dm.outcome_status
+            FROM dispatch_metadata dm;
+    """)
+    for i in range(row_count):
+        conn.execute(
+            "INSERT INTO session_analytics (session_id, project_path, session_date) "
+            "VALUES (?, ?, ?)",
+            (f"sess-{i:04d}", "/some/path", "2026-01-01"),
+        )
+    conn.commit()
+    return conn
+
+
+def _table_sql(conn: sqlite3.Connection, table: str) -> str:
+    row = conn.execute(
+        "SELECT sql FROM sqlite_master WHERE type='table' AND name=?", (table,)
+    ).fetchone()
+    return row[0] if row else ""
+
+
+def _sql_trace(conn: sqlite3.Connection) -> list[str]:
+    """Attach a trace callback and return the (mutable) list it appends to."""
+    log: list[str] = []
+    conn.set_trace_callback(lambda sql: log.append(sql))
+    return log
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — guard must be order/quoting independent
+# ---------------------------------------------------------------------------
+
+class TestCompositeUniqueGuard:
+    def test_matches_reversed_and_quoted_column_order(self, tmp_path):
+        """The live-DB shape: UNIQUE ("session_id", "project_id") — reversed order,
+        quoted identifiers. A literal string-match guard never matches this."""
+        db = tmp_path / "reversed.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("""
+            CREATE TABLE session_analytics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                UNIQUE ("session_id", "project_id")
+            )
+        """)
+        assert qdi._has_composite_unique(
+            conn, "session_analytics", {"project_id", "session_id"}
+        ) is True
+        conn.close()
+
+    def test_rejects_single_column_unique(self, tmp_path):
+        """A legacy single-column UNIQUE(session_id) must NOT be mistaken for
+        the composite (project_id, session_id) constraint — the guard must
+        still trigger a rebuild in this case."""
+        db = tmp_path / "legacy.db"
+        conn = _make_legacy_session_analytics_db(db)
+        assert qdi._has_composite_unique(
+            conn, "session_analytics", {"project_id", "session_id"}
+        ) is False
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Finding 1 — full migration idempotency
+# ---------------------------------------------------------------------------
+
+class TestMigrateV29Idempotency:
+    def test_second_run_is_noop_on_legacy_fixture(self, tmp_path):
+        db = tmp_path / "legacy.db"
+        conn = _make_legacy_session_analytics_db(db, row_count=5)
+
+        # First run must rebuild (legacy single-column UNIQUE).
+        trace = _sql_trace(conn)
+        qdi._migrate_v29(conn)
+        conn.commit()
+        assert any("CREATE TABLE _session_analytics_v29" in s for s in trace)
+
+        row_count_after_first = conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0]
+        assert row_count_after_first == 5
+
+        # Second run on the now-composite-UNIQUE table must be a no-op.
+        trace.clear()
+        qdi._migrate_v29(conn)
+        conn.commit()
+        assert not any("CREATE TABLE _session_analytics_v29" in s for s in trace)
+        assert not any("DROP TABLE session_analytics" in s for s in trace)
+
+        row_count_after_second = conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0]
+        assert row_count_after_second == 5
+
+        conn.close()
+
+    def test_noop_when_already_migrated_with_reversed_column_order(self, tmp_path):
+        """Simulates the real live-DB shape post-migration: composite UNIQUE
+        already present but recorded in reversed/quoted form. Must not rebuild."""
+        db = tmp_path / "already_migrated.db"
+        conn = sqlite3.connect(str(db))
+        conn.execute("""
+            CREATE TABLE session_analytics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                project_id TEXT NOT NULL,
+                project_path TEXT NOT NULL,
+                session_date DATE NOT NULL,
+                UNIQUE ("session_id", "project_id")
+            )
+        """)
+        conn.commit()
+
+        trace = _sql_trace(conn)
+        qdi._migrate_v29(conn)
+        conn.commit()
+        assert not any("CREATE TABLE _session_analytics_v29" in s for s in trace)
+        assert not any("DROP TABLE session_analytics" in s for s in trace)
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# Finding 2 — rebuilt table must carry NO default on project_id
+# ---------------------------------------------------------------------------
+
+class TestNoProjectIdDefaultAfterRebuild:
+    def test_rebuilt_table_has_no_project_id_default(self, tmp_path):
+        db = tmp_path / "legacy.db"
+        conn = _make_legacy_session_analytics_db(db, row_count=2)
+
+        qdi._migrate_v29(conn)
+        conn.commit()
+
+        sql = _table_sql(conn, "session_analytics")
+        assert "DEFAULT 'vnx-dev'" not in sql
+        assert "UNIQUE (project_id, session_id)" in sql
+
+        col_info = {
+            r[1]: r[4]  # name -> dflt_value
+            for r in conn.execute("PRAGMA table_info(session_analytics)").fetchall()
+        }
+        assert col_info["project_id"] is None
+        conn.close()

--- a/tests/test_migrate_v29_index_preservation.py
+++ b/tests/test_migrate_v29_index_preservation.py
@@ -1,0 +1,299 @@
+#!/usr/bin/env python3
+"""Tests for the codex round-4 finding on migration V29 (PR #1248, FINAL: FAIL Q4).
+
+_migrate_v29's session_analytics rebuild (scripts/quality_db_init.py) dropped
+the original table and recreated a hardcoded list of 6 indexes, silently
+losing any index outside that list. Measured against the live
+~/.vnx-data/vnx-dev/state/quality_intelligence.db, three were lost:
+
+  - ux_session_analytics_pid — the ADR-007 UNIQUE (project_id, id) constraint
+    from _migrate_v27. Losing this is a governance-constraint regression, not
+    a performance one.
+  - idx_session_analytics_project on (project_id), from
+    schemas/migrations/0010_add_project_id.sql.
+  - idx_session_dispatch_id on (dispatch_id) — replaced by a DIFFERENTLY named
+    idx_session_dispatch, so the rebuild also left two conventions floating.
+
+Covers:
+  1. Every real (non-autoindex) index the live table has survives the rebuild,
+     captured from sqlite_master rather than a hardcoded list — including an
+     index no migration in this file has ever heard of.
+  2. The dispatch_id index converges on exactly one canonical name
+     (idx_session_dispatch, matching the current base schema) regardless of
+     which name the live table carried before the rebuild.
+  3. A column present in the live table but absent from the v29 staging DDL
+     raises instead of being silently dropped.
+  4. A row-count mismatch after the INSERT OR IGNORE copy raises instead of
+     silently proceeding with fewer rows than the source had.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "scripts"
+LIB_DIR = SCRIPTS_DIR / "lib"
+
+for _p in (str(SCRIPTS_DIR), str(LIB_DIR)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import quality_db_init as qdi  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_live_shaped_db(path: Path, row_count: int = 5) -> sqlite3.Connection:
+    """Reproduce the real live-DB shape measured on vnx-dev at user_version=28:
+    9 indexes total (8 real + 1 sqlite_autoindex from the single-column UNIQUE
+    on session_id), project_id already present as a plain column (added by an
+    earlier ALTER, not yet part of a composite UNIQUE).
+    """
+    conn = sqlite3.connect(str(path))
+    conn.isolation_level = None
+    conn.executescript("""
+        CREATE TABLE session_analytics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            project_path TEXT NOT NULL,
+            terminal TEXT,
+            session_date DATE NOT NULL,
+            total_input_tokens INTEGER DEFAULT 0,
+            session_model TEXT DEFAULT 'unknown',
+            dispatch_id TEXT,
+            primary_activity TEXT,
+            context_reset_count INTEGER DEFAULT 0,
+            analyzed_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+            analyzer_version TEXT DEFAULT '1.0.0'
+        );
+        CREATE INDEX idx_session_terminal ON session_analytics (terminal, session_date DESC);
+        CREATE INDEX idx_session_project ON session_analytics (project_path, session_date DESC);
+        CREATE INDEX idx_session_date ON session_analytics (session_date DESC);
+        CREATE INDEX idx_session_activity ON session_analytics (primary_activity);
+        CREATE INDEX idx_session_model ON session_analytics (session_model, session_date DESC);
+        CREATE INDEX idx_session_dispatch_id ON session_analytics (dispatch_id);
+        CREATE INDEX idx_session_analytics_project ON session_analytics (project_id);
+        CREATE UNIQUE INDEX ux_session_analytics_pid ON session_analytics (project_id, id);
+
+        CREATE TABLE dispatch_metadata (
+            dispatch_id TEXT,
+            terminal TEXT,
+            role TEXT,
+            gate TEXT,
+            outcome_status TEXT,
+            pattern_count INTEGER,
+            instruction_char_count INTEGER
+        );
+        CREATE VIEW cost_per_dispatch AS
+            SELECT dm.dispatch_id, dm.terminal, dm.role, dm.gate, dm.outcome_status
+            FROM dispatch_metadata dm;
+    """)
+    for i in range(row_count):
+        conn.execute(
+            "INSERT INTO session_analytics (session_id, project_id, project_path, session_date) "
+            "VALUES (?, ?, ?, ?)",
+            (f"sess-{i:04d}", "vnx-dev", "/some/path", "2026-01-01"),
+        )
+    conn.commit()
+    return conn
+
+
+def _index_signatures(conn: sqlite3.Connection, table: str) -> dict[str, tuple[bool, frozenset]]:
+    """Map index name -> (is_unique, frozenset(columns)) for every real index."""
+    out = {}
+    for idx in conn.execute(f"PRAGMA index_list({table})").fetchall():
+        name, is_unique = idx[1], bool(idx[2])
+        if name.startswith("sqlite_autoindex_"):
+            continue
+        cols = frozenset(
+            r[2] for r in conn.execute(f"PRAGMA index_info({name})").fetchall()
+        )
+        out[name] = (is_unique, cols)
+    return out
+
+
+# ---------------------------------------------------------------------------
+# 1 + 2: index preservation + canonical dispatch_id naming
+# ---------------------------------------------------------------------------
+
+class TestIndexPreservation:
+    def test_all_live_indexes_survive_rebuild(self, tmp_path):
+        db = tmp_path / "live_shaped.db"
+        conn = _make_live_shaped_db(db, row_count=7)
+
+        before = _index_signatures(conn, "session_analytics")
+        assert set(before) == {
+            "idx_session_terminal", "idx_session_project", "idx_session_date",
+            "idx_session_activity", "idx_session_model", "idx_session_dispatch_id",
+            "idx_session_analytics_project", "ux_session_analytics_pid",
+        }
+
+        qdi._migrate_v29(conn)
+        conn.commit()
+
+        after = _index_signatures(conn, "session_analytics")
+
+        # The ADR-007 composite UNIQUE from _migrate_v27 must survive the
+        # rebuild — this was the blocking finding (governance constraint, not
+        # a performance regression).
+        assert "ux_session_analytics_pid" in after
+        assert after["ux_session_analytics_pid"] == (True, frozenset({"project_id", "id"}))
+
+        # idx_session_analytics_project (from schemas/migrations/0010) must
+        # also survive — it was not on the hardcoded recreate list either.
+        assert "idx_session_analytics_project" in after
+        assert after["idx_session_analytics_project"] == (False, frozenset({"project_id"}))
+
+        # Every other pre-existing real index survives under its own name.
+        for name in ("idx_session_terminal", "idx_session_project", "idx_session_date",
+                     "idx_session_activity", "idx_session_model"):
+            assert name in after, f"{name} was dropped by the rebuild"
+            assert before[name] == after[name]
+
+        # dispatch_id: exactly one canonical index survives (idx_session_dispatch,
+        # matching the current base schema) — the legacy name is gone, not
+        # floating alongside it.
+        assert "idx_session_dispatch" in after
+        assert after["idx_session_dispatch"] == (False, frozenset({"dispatch_id"}))
+        assert "idx_session_dispatch_id" not in after
+
+        # No index count drift: 7 preserved-by-name + 1 renamed (dispatch_id) = 8.
+        assert len(after) == 8
+
+        assert conn.execute("SELECT COUNT(*) FROM session_analytics").fetchone()[0] == 7
+        conn.close()
+
+    def test_unknown_index_outside_any_hardcoded_list_survives(self, tmp_path):
+        """Structural proof: an index this migration file has never named
+        anywhere still survives, because it is captured from sqlite_master
+        rather than looked up in a list."""
+        db = tmp_path / "unknown_index.db"
+        conn = _make_live_shaped_db(db, row_count=2)
+        conn.execute(
+            "CREATE INDEX idx_totally_unrelated_marker "
+            "ON session_analytics (analyzer_version)"
+        )
+        conn.commit()
+
+        qdi._migrate_v29(conn)
+        conn.commit()
+
+        after = _index_signatures(conn, "session_analytics")
+        assert "idx_totally_unrelated_marker" in after
+        assert after["idx_totally_unrelated_marker"] == (False, frozenset({"analyzer_version"}))
+        conn.close()
+
+    def test_second_run_after_index_preserving_rebuild_is_noop(self, tmp_path):
+        db = tmp_path / "live_shaped.db"
+        conn = _make_live_shaped_db(db, row_count=3)
+
+        qdi._migrate_v29(conn)
+        conn.commit()
+        after_first = _index_signatures(conn, "session_analytics")
+
+        # Re-running directly (bypassing the user_version gate) must not error
+        # and must not change the index set — _has_composite_unique already
+        # sees the correct shape, so needs_rebuild is False.
+        qdi._migrate_v29(conn)
+        conn.commit()
+        after_second = _index_signatures(conn, "session_analytics")
+
+        assert after_first == after_second
+        assert conn.execute("SELECT COUNT(*) FROM session_analytics").fetchone()[0] == 3
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 3: source-only-column guard
+# ---------------------------------------------------------------------------
+
+class TestSourceOnlyColumnGuard:
+    def test_raises_when_live_table_has_column_staging_ddl_lacks(self, tmp_path):
+        db = tmp_path / "extra_column.db"
+        conn = _make_live_shaped_db(db, row_count=2)
+        conn.execute(
+            "ALTER TABLE session_analytics ADD COLUMN totally_unknown_column TEXT"
+        )
+        conn.execute(
+            "UPDATE session_analytics SET totally_unknown_column = 'must-not-be-dropped'"
+        )
+        conn.commit()
+
+        with pytest.raises(RuntimeError, match="totally_unknown_column"):
+            qdi._migrate_v29(conn)
+
+        # The guard must fire before the destructive DROP TABLE step — the
+        # original table (and its data) must still be intact.
+        assert conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='session_analytics'"
+        ).fetchone() is not None
+        assert conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0] == 2
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# 4: copy-count assertion
+# ---------------------------------------------------------------------------
+
+class TestCopyCountAssertion:
+    def test_raises_on_row_count_mismatch_after_copy(self, tmp_path):
+        """A pre-composite-UNIQUE table with no per-column uniqueness at all
+        (an even-older legacy shape) can carry two rows that collide on
+        (project_id, session_id). INSERT OR IGNORE silently drops one on
+        copy — the migration must refuse to proceed rather than swap in a
+        table with fewer rows than the source had.
+        """
+        db = tmp_path / "duplicate_rows.db"
+        conn = sqlite3.connect(str(db))
+        conn.isolation_level = None
+        conn.executescript("""
+            CREATE TABLE session_analytics (
+                id INTEGER PRIMARY KEY AUTOINCREMENT,
+                session_id TEXT NOT NULL,
+                project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+                project_path TEXT NOT NULL,
+                session_date DATE NOT NULL
+            );
+            CREATE TABLE dispatch_metadata (
+                dispatch_id TEXT, terminal TEXT, role TEXT, gate TEXT,
+                outcome_status TEXT, pattern_count INTEGER, instruction_char_count INTEGER
+            );
+            CREATE VIEW cost_per_dispatch AS
+                SELECT dm.dispatch_id, dm.terminal, dm.role, dm.gate, dm.outcome_status
+                FROM dispatch_metadata dm;
+        """)
+        # Two rows that collide on (project_id, session_id) — legal here
+        # because this legacy shape has no UNIQUE constraint at all.
+        conn.execute(
+            "INSERT INTO session_analytics (session_id, project_id, project_path, session_date) "
+            "VALUES ('dup-session', 'vnx-dev', '/p', '2026-01-01')"
+        )
+        conn.execute(
+            "INSERT INTO session_analytics (session_id, project_id, project_path, session_date) "
+            "VALUES ('dup-session', 'vnx-dev', '/p', '2026-01-01')"
+        )
+        conn.commit()
+
+        source_count_before = conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0]
+        assert source_count_before == 2
+
+        with pytest.raises(RuntimeError, match="row-count mismatch"):
+            qdi._migrate_v29(conn)
+
+        # Must not have swapped in the lossy table — original still intact.
+        assert conn.execute(
+            "SELECT COUNT(*) FROM session_analytics"
+        ).fetchone()[0] == 2
+        conn.close()


### PR DESCRIPTION
## What

Fixes four defects that prevented the conversation analyzer from writing rows since 2026-06-21.

### 1. session_analytics INSERT omitted project_id (OI-853)

The live DB has `project_id TEXT NOT NULL` with no default, but the INSERT in `_store_session` didn't include it. Every insert violated the NOT NULL constraint and the analyzer wrote nothing.

**Fix:** Added `project_id` to the INSERT column list, sourced via `resolve_stamp_project_id` per ADR-007. Schema updated to include the column with composite `UNIQUE(project_id, session_id)`. Migration v29 rebuilds the table idempotently, preserving all 1096 existing rows.

### 2. Ollama hung 120s/session with no models installed (OI-853)

`_try_ollama` did a POST with `timeout=120` per session. The server was reachable but had zero models. Across a 7825-session backlog that's a stall.

**Fix:** Added a class-level availability probe (`_probe_ollama`): one `GET /api/tags` with 3s timeout. Result cached per process. `_try_ollama` returns None immediately when probe says unavailable.

### 3. Billing guard on LLM strategy (OI-855)

`LLM_STRATEGY=auto` defaulted to claude-first — a metered-spend landmine when the job starts succeeding on a large backlog.

**Fix:** Default flipped to `ollama-only`. In `auto` mode, the claude path is refused when the session backlog exceeds `AUTO_CLAUSE_MAX_SESSIONS` (default 50, configurable via `VNX_ANALYZER_AUTO_MAX_SESSIONS`). `claude-only` bypasses the guard for operators who explicitly opt in.

### 4. Partial write between session_analytics and intelligence tables (OI-853)

`bridge_session_to_intelligence` wrote intelligence rows BEFORE `_store_session`, leaving orphan rows when the INSERT failed.

**Fix:** Both writes share one transaction. `_store_session` runs first; if either fails, the transaction rolls back both. Removed internal commits from both methods — the caller manages the transaction.

## Verification

- **Bounded run** on DB copy: 5 sessions written, all with non-NULL `project_id`, 0 errors
- **Migration v29** on 1096-row DB copy: all rows preserved, composite UNIQUE verified, idempotent
- **Ollama probe**: first call 0.058s, subsequent calls 0.000s, `_try_ollama` skips 120s POST
- **Tests**: 57 pass (55 + 2 exception handling), 3 new atomicity tests, 2 pre-existing failures confirmed on unmodified tree

🤖 Generated with [Claude Code](https://claude.com/claude-code)