### PR TITLE
fix(skills): drop paths: scoping from horizon/planner/control-centre

### DIFF
--- a/.claude/skills/control-centre/SKILL.md
+++ b/.claude/skills/control-centre/SKILL.md
@@ -6,7 +6,6 @@ description: >
 user-invocable: true
 disable-model-invocation: true
 allowed-tools: [Read, Grep, Glob, Bash]
-paths: ["claudedocs/**"]
 ---
 
 # Control Centre — multi-project T0 supervisor

--- a/.claude/skills/horizon/SKILL.md
+++ b/.claude/skills/horizon/SKILL.md
@@ -12,7 +12,6 @@ description: >
   via the backward-compat alias in `.claude/skills/pm/SKILL.md`.)
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
-paths: [".vnx-data/**", "claudedocs/**", "ROADMAP.yaml"]
 ---
 
 # Horizon — strategic future-state owner

--- a/.claude/skills/planner/SKILL.md
+++ b/.claude/skills/planner/SKILL.md
@@ -8,7 +8,6 @@ description: >
   (`vnx horizon`, alias `vnx objective`); the repo FEATURE_PLAN.md is a generated generic
   example, not the source.
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
-paths: ["FEATURE_PLAN.md", "claudedocs/**"]
 ---
 
 # Planning Specialist

--- a/skills/horizon/SKILL.md
+++ b/skills/horizon/SKILL.md
@@ -12,7 +12,6 @@ description: >
   via the backward-compat alias in `.claude/skills/pm/SKILL.md`.)
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
-paths: [".vnx-data/**", "claudedocs/**", "ROADMAP.yaml"]
 ---
 
 # Horizon — strategic future-state owner


### PR DESCRIPTION
## Summary

`paths:` in skill frontmatter directory-scopes a skill: it's only offered when the session cwd
falls inside one of the listed paths. T0 runs from `.claude/terminals/T0`, matching none of the
`paths:` on `horizon`, `planner`, `control-centre` — so these three were never offered to the
orchestrator. The `paths:` values were data-read locations, not usage locations (that's the bug).
`fabric-reference` and `panel` carry no `paths:` and are scoped fine by `description` alone.

## Changes

- `skills/horizon/SKILL.md` + `.claude/skills/horizon/SKILL.md`: removed `paths:` (both copies,
  were identical before and after)
- `.claude/skills/planner/SKILL.md`: removed `paths:` — **`skills/planner/SKILL.md` had no
  `paths:` key to begin with**, the two copies had already drifted before this change
- `.claude/skills/control-centre/SKILL.md`: removed `paths:` — **`skills/control-centre/SKILL.md`
  does not exist**; control-centre has only ever had a `.claude/skills/` copy, never a shipped one
- `t0-orchestrator` intentionally untouched (separate delivery mechanism: SessionStart hook +
  `disable-model-invocation: true`) — needs separate treatment

## Verification

- `diff -q` horizon: identical, both before and after
- `diff -q` planner / t0-orchestrator: **were already non-identical before this PR** (description,
  body, and — for planner — the `paths:` key itself only existed on one side). Contradicts the
  dispatch's premise of "byte-identical copies" for 2 of 3 target skills, and control-centre never
  had a root copy at all — this is written up in detail in the report.
- YAML frontmatter parses clean on all 4 touched files (checked with `yaml.safe_load`)
- Frontmatter diff isolated to the single `paths:` line removed per file, nothing else touched
- No sync tool owns `skills/` ↔ `.claude/skills/` inside this repo — `vnx skills sync` pulls from
  an external `$VNX_HOME/skills` into a *consumer* project and explicitly refuses to run when the
  target is the fabric's own checkout (`_guard_not_vnx_home`)
- `tests/test_t0_skill_consistency.py` (only test referencing a target-adjacent SKILL.md) has 4
  pre-existing failures on `t0-orchestrator`/`CLAUDE.md`, reproduced identically on `main` via
  `git stash` — unrelated to this change
- No test/CI validates `paths:`/frontmatter semantics anywhere in the repo
- Mid-session, real-time signal: after the edit, the live available-skills listing in this very
  session started showing `horizon` and `planner` (absent before) — without a session restart.
  `control-centre` still didn't show, plausibly because it separately carries
  `disable-model-invocation: true`. The authoritative check is still a fresh T0 session, per the
  dispatch's Definition of Done.

## Test plan

- [x] `diff -q` per pair (see above, one contradicts the dispatch's premise)
- [x] YAML frontmatter parses for all 4 touched files
- [x] Frontmatter-only diff shows single-line removal, nothing else changed
- [x] Confirmed no CI/test gate on skill frontmatter exists
- [ ] Operator: start a fresh T0 session and confirm `horizon` appears in the available-skills list

🤖 Generated with [Claude Code](https://claude.com/claude-code)