### PR TITLE
fix(oi): land acceptance-criterion guard in source repo

### DIFF
--- a/scripts/open_items_manager.py
+++ b/scripts/open_items_manager.py
@@ -38,6 +38,65 @@ ROLLBACK_ENV_FLAG = "VNX_STATE_SIMPLIFICATION_ROLLBACK"
 SeverityLevel = Literal["blocker", "warn", "info"]
 ItemStatus = Literal["open", "done", "deferred", "wontfix"]
 
+# ---------------------------------------------------------------------------
+# Acceptance-criterion rejection guard (2026-07-30 mission-control cleanup)
+# ---------------------------------------------------------------------------
+# Gate-steps and acceptance criteria that describe SUCCESS are not open items.
+# Examples of titles that describe a passing check, not a problem:
+#   "pytest tests/... -v groen"
+#   "codex gate green"
+#   "CI green"
+#   "manual smoke: ..."
+#   "Migration apply"
+# The 2026-07-30 cleanup closed 94 such items; 87 came from a single-day
+# T0 session.  This guard blocks the CLI `add` command (unless --force) and
+# raises ValueError from `add_item_programmatic`.  Callers that genuinely
+# need to track a gate-failure can phrase the title as a problem.
+_ACCEPTANCE_CRITERION_PATTERNS = [
+    re.compile(
+        r'(?:pytest|npm run test(?::unit)?).*\bgroen\b',
+        re.IGNORECASE,
+    ),
+    re.compile(r'check \+ build \+ test:unit.*\bgroen\b', re.IGNORECASE),
+    re.compile(r'gh pr checks.*\bgroen\b', re.IGNORECASE),
+    re.compile(r'\bcodex gate green\b', re.IGNORECASE),
+    re.compile(r'\bgemini gate green\b', re.IGNORECASE),
+    re.compile(r'^CI green$', re.IGNORECASE),
+    re.compile(r'^manual smoke:', re.IGNORECASE),
+    re.compile(r'^Migration apply', re.IGNORECASE),
+    re.compile(
+        r'codex-\s*\+\s*gemini-gate.*(?:passed|completed)',
+        re.IGNORECASE,
+    ),
+]
+
+_REJECTION_MESSAGE = (
+    "REJECTED: title describes a successful acceptance-criterion or gate-step,"
+    " not a problem. Open items track risks, blockers, and warnings — not"
+    " check-off steps that passed. If the step genuinely FAILED, rephrase the"
+    " title as a problem statement (e.g. \"codex gate FAILED: 3 findings"
+    " in …\"). Use --force to bypass this guard."
+)
+
+
+def is_acceptance_criterion(title: str) -> bool:
+    """Return True if *title* describes a passing gate step or check-off,
+    not a problem that needs tracking."""
+    for pattern in _ACCEPTANCE_CRITERION_PATTERNS:
+        if pattern.search(title):
+            return True
+    return False
+
+
+def _validate_title_not_acceptance_criterion(title: str,
+                                             force: bool = False) -> None:
+    """Raise ValueError if *title* looks like an acceptance-criterion check-off
+    rather than a problem statement.  *force* bypasses the guard."""
+    if force:
+        return
+    if is_acceptance_criterion(title):
+        raise ValueError(_REJECTION_MESSAGE)
+
 
 def _env_flag(name: str) -> Optional[bool]:
     value = os.environ.get(name)
@@ -146,9 +205,14 @@ def add_item_programmatic(
 
     Uses fcntl.flock on a dedicated lock file for concurrent terminal safety.
 
+    Raises:
+        ValueError: if *title* describes a passing acceptance criterion rather
+                    than a problem.  Callers must rephrase as a problem statement.
+
     Returns:
         (item_id, created): item_id is existing or new, created is False if deduplicated.
     """
+    _validate_title_not_acceptance_criterion(title)
     with _with_items_lock():
         data = load_items()
 
@@ -196,6 +260,9 @@ def add_item_programmatic(
 
 def add_item(args):
     """Add new open item"""
+    _validate_title_not_acceptance_criterion(
+        args.title, force=getattr(args, 'force', False)
+    )
     with _with_items_lock():
         data = load_items()
 
@@ -828,6 +895,8 @@ def main():
     add_parser.add_argument('--pr', help='Associated PR ID')
     add_parser.add_argument('--report', help='Origin report path')
     add_parser.add_argument('--details', help='Additional details')
+    add_parser.add_argument('--force', action='store_true', default=False,
+                            help='Bypass acceptance-criterion rejection guard')
 
     # Close command
     close_parser = subparsers.add_parser('close', help='Close item as done')
@@ -927,7 +996,11 @@ def main():
     if args.command == 'list':
         list_items(args)
     elif args.command == 'add':
-        add_item(args)
+        try:
+            add_item(args)
+        except ValueError as exc:
+            print(f"❌ {exc}", file=sys.stderr)
+            return 1
     elif args.command == 'close':
         close_item(args)
     elif args.command == 'defer':

--- a/tests/test_open_items_acceptance_criterion_guard.py
+++ b/tests/test_open_items_acceptance_criterion_guard.py
@@ -1,0 +1,204 @@
+#!/usr/bin/env python3
+"""Acceptance-criterion rejection guard for open items — prevents tracking
+gate-steps and check-off items that describe SUCCESS rather than a problem.
+
+Each test must fail against the unpatched code. A test that passes without
+the guard measures nothing.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+SCRIPTS_DIR = TESTS_DIR.parent / "scripts"
+
+
+def _load_oim(tmp_path: Path):
+    """Reload open_items_manager with a clean per-test STATE_DIR."""
+    env_patch = {
+        "VNX_DATA_DIR": str(tmp_path / "data"),
+        "VNX_DATA_DIR_EXPLICIT": "1",
+        "VNX_STATE_DIR": str(tmp_path / "data" / "state"),
+        "VNX_HOME": str(TESTS_DIR.parent),
+    }
+    (tmp_path / "data" / "state").mkdir(parents=True, exist_ok=True)
+
+    mod_name = f"open_items_manager_test_{tmp_path.name}"
+    with patch.dict(os.environ, env_patch):
+        spec = importlib.util.spec_from_file_location(
+            mod_name, SCRIPTS_DIR / "open_items_manager.py"
+        )
+        mod = importlib.util.module_from_spec(spec)
+        sys.modules[mod_name] = mod
+        try:
+            spec.loader.exec_module(mod)
+        except Exception:
+            del sys.modules[mod_name]
+            raise
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Each individual pattern from _ACCEPTANCE_CRITERION_PATTERNS
+# ---------------------------------------------------------------------------
+
+ACCEPTANCE_CRITERION_TITLES = [
+    # (1) pytest|npm run test… groen
+    "pytest tests/test_foo.py -v groen",
+    "npm run test -- groen",
+    "npm run test:unit -- groen",
+    # (2) check + build + test:unit … groen
+    "check + build + test:unit groen",
+    # (3) gh pr checks … groen
+    "gh pr checks groen",
+    # (4) codex gate green
+    "codex gate green",
+    # (5) gemini gate green
+    "gemini gate green",
+    # (6) CI green
+    "CI green",
+    # (7) manual smoke:
+    "manual smoke: login flow works",
+    # (8) Migration apply
+    "Migration apply",
+    # (9) codex- + gemini-gate … passed/completed
+    "codex- + gemini-gate passed",
+    "codex-+gemini-gate completed",
+]
+
+
+@pytest.mark.parametrize("title", ACCEPTANCE_CRITERION_TITLES)
+def test_is_acceptance_criterion_rejects_pattern(title: str, tmp_path: Path):
+    """Every pattern in _ACCEPTANCE_CRITERION_PATTERNS must reject the title."""
+    oim = _load_oim(tmp_path)
+    assert oim.is_acceptance_criterion(title) is True, (
+        f"is_acceptance_criterion({title!r}) returned False — "
+        "this title should match an acceptance-criterion pattern"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Valid problem title — must NOT be rejected
+# ---------------------------------------------------------------------------
+
+VALID_PROBLEM_TITLES = [
+    "codex gate FAILED: 3 findings in scripts/foo.py",
+    "pytest fails: 5 errors in test suite",
+    "Memory leak in dispatch processor under high concurrency",
+    "npm build broken on main branch",
+    "ci pipeline broken: docker build timeout",
+]
+
+
+@pytest.mark.parametrize("title", VALID_PROBLEM_TITLES)
+def test_is_acceptance_criterion_accepts_problem(title: str, tmp_path: Path):
+    """A real problem title must NOT match any acceptance-criterion pattern."""
+    oim = _load_oim(tmp_path)
+    assert oim.is_acceptance_criterion(title) is False, (
+        f"is_acceptance_criterion({title!r}) returned True — "
+        "this is a genuine problem, not a passing gate-step"
+    )
+
+
+# ---------------------------------------------------------------------------
+# _validate_title_not_acceptance_criterion
+# ---------------------------------------------------------------------------
+
+def test_validate_raises_valueerror_for_acceptance_criterion(tmp_path: Path):
+    """_validate_title_not_acceptance_criterion raises ValueError on a gate-step title."""
+    oim = _load_oim(tmp_path)
+    with pytest.raises(ValueError, match="REJECTED"):
+        oim._validate_title_not_acceptance_criterion("codex gate green")
+
+
+def test_validate_passes_for_problem_title(tmp_path: Path):
+    """_validate_title_not_acceptance_criterion does nothing for a real problem."""
+    oim = _load_oim(tmp_path)
+    oim._validate_title_not_acceptance_criterion("memory leak in dispatch worker")
+
+
+def test_validate_force_bypasses_guard(tmp_path: Path):
+    """force=True skips the guard even for an acceptance-criterion title."""
+    oim = _load_oim(tmp_path)
+    oim._validate_title_not_acceptance_criterion("codex gate green", force=True)
+
+
+# ---------------------------------------------------------------------------
+# add_item_programmatic raises ValueError
+# ---------------------------------------------------------------------------
+
+def test_add_item_programmatic_raises_valueerror(tmp_path: Path):
+    """add_item_programmatic raises ValueError on acceptance-criterion title."""
+    oim = _load_oim(tmp_path)
+    with pytest.raises(ValueError, match="REJECTED"):
+        oim.add_item_programmatic(
+            title="pytest tests/ -v groen",
+            severity="info",
+            dispatch_id="DISP-TEST-001",
+        )
+
+
+def test_add_item_programmatic_accepts_problem(tmp_path: Path):
+    """add_item_programmatic succeeds for a genuine problem title."""
+    oim = _load_oim(tmp_path)
+    # Guard must classify this as a non-criterion (fails AttributeError without patch)
+    assert oim.is_acceptance_criterion(
+        "codex gate FAILED: 3 findings in scripts/foo.py"
+    ) is False
+    item_id, created = oim.add_item_programmatic(
+        title="codex gate FAILED: 3 findings in scripts/foo.py",
+        severity="blocker",
+        dispatch_id="DISP-TEST-002",
+    )
+    assert created is True
+    assert item_id.startswith("OI-")
+
+
+# ---------------------------------------------------------------------------
+# CLI add path respects --force
+# ---------------------------------------------------------------------------
+
+class _Args:
+    """Minimal argparse.Namespace stub for testing add_item directly."""
+
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)
+
+
+def test_add_item_rejects_acceptance_criterion(tmp_path: Path):
+    """The CLI add_item function raises ValueError on acceptance-criterion title."""
+    oim = _load_oim(tmp_path)
+    args = _Args(
+        title="gemini gate green",
+        severity="info",
+        dispatch="DISP-CLI-001",
+        pr=None,
+        report=None,
+        details=None,
+    )
+    with pytest.raises(ValueError, match="REJECTED"):
+        oim.add_item(args)
+
+
+def test_add_item_force_bypasses_guard(tmp_path: Path):
+    """--force flag bypasses the acceptance-criterion rejection."""
+    oim = _load_oim(tmp_path)
+    # Guard must classify this as a criterion (fails AttributeError without patch)
+    assert oim.is_acceptance_criterion("gemini gate green") is True
+    args = _Args(
+        title="gemini gate green",
+        severity="info",
+        dispatch="DISP-CLI-002",
+        pr=None,
+        report=None,
+        details=None,
+        force=True,
+    )
+    oim.add_item(args)  # does not raise → guard was bypassed


### PR DESCRIPTION
## What

Lands the open-items acceptance-criterion guard from a previously orphaned commit (`cc37775b` in `~/.vnx-system/versions/v1.3.1/`) into the canonical source repo.

## Why

A 2026-07-30 cleanup closed 94 open items whose titles described passing gate-steps ("codex gate green", "pytest ... groen", "manual smoke:", etc.) instead of actual problems. 87 of those came from a single T0 session. The guard was written directly in the shared install and never committed to any git branch.

## Changes

**`scripts/open_items_manager.py``** (+74/-1):
- 9 compiled regexes matching acceptance-criterion titles
- `is_acceptance_criterion(title)` and `_validate_title_not_acceptance_criterion(title, force=False)`
- `add_item_programmatic()` validates unconditionally (raises `ValueError`)
- CLI `add` validates unless `--force` is passed
- `import re` was already present

**`tests/test_open_items_acceptance_criterion_guard.py``** (new, 24 tests):
- 12 parametrized: each pattern rejected
- 5 parametrized: valid problem titles accepted
- ValueError on acceptance criterion, passes on valid
- Force=True bypasses guard
- CLI --force path respected

## Verification

- 24/24 pass with patch
- 24/24 fail without patch (no vacuously-green tests)
- All existing open_items tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)