### PR TITLE
feat(install): make pinned version dirs read-only after install

### DIFF
--- a/install-central.sh
+++ b/install-central.sh
@@ -133,6 +133,44 @@ strip_tenant_marker() {
 }
 
 # ---------------------------------------------------------------------------
+# lock_version_dir / unlock_version_dir — read-only enforcement for pinned versions
+# ---------------------------------------------------------------------------
+# After a successful install, pinned version dirs (vX.Y.Z) are made read-only so
+# no worker or script can accidentally write into the shared immutable code tree.
+# ``edge`` is always writable (a living checkout).  Idempotent re-runs of
+# clone_version temporarily unlock, write, then re-lock.
+#
+# Failure to lock is treated as a loud error, never a silent skip — a dir left
+# writable can silently absorb worker writes with zero signal (no git diff, no
+# failing test until a clean checkout).
+lock_version_dir() {
+  local version_dir="$1"
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] chmod -R a-w ${version_dir}"
+    return 0
+  fi
+  if [ "$(basename "$version_dir")" = "edge" ]; then
+    return 0
+  fi
+  chmod -R a-w "$version_dir" 2>/dev/null || {
+    echo "[install-central] [x] Failed to make version dir read-only: ${version_dir}" >&2
+    return 1
+  }
+}
+
+unlock_version_dir() {
+  local version_dir="$1"
+  if [ "$DRY_RUN" = "true" ]; then
+    echo "  [dry-run] chmod -R u+w ${version_dir}"
+    return 0
+  fi
+  if [ "$(basename "$version_dir")" = "edge" ]; then
+    return 0
+  fi
+  chmod -R u+w "$version_dir" 2>/dev/null || true
+}
+
+# ---------------------------------------------------------------------------
 # check_prereqs — fail-fast on missing dependencies
 # ---------------------------------------------------------------------------
 check_prereqs() {
@@ -182,8 +220,11 @@ clone_version() {
     info "Version ${VERSION} already installed at ${version_dir} — skipping clone"
     # Idempotent: ensure the marker exists even on a pre-existing version dir
     # (e.g. cloned before this installer learned to write it).
+    # The dir may be read-only (locked) — unlock, write, re-lock.
+    unlock_version_dir "$version_dir"
     write_install_marker "$version_dir"
     strip_tenant_marker "$version_dir"
+    lock_version_dir "$version_dir" || die "Failed to lock version dir: ${version_dir}"
     return 0
   fi
 
@@ -211,6 +252,7 @@ clone_version() {
 
   write_install_marker "$version_dir"
   strip_tenant_marker "$version_dir"
+  lock_version_dir "$version_dir" || die "Failed to lock version dir: ${version_dir}"
   success "Cloned ${VERSION} to ${version_dir}"
 }
 

--- a/scripts/lib/vnx_version_ro.py
+++ b/scripts/lib/vnx_version_ro.py
@@ -1,0 +1,144 @@
+#!/usr/bin/env python3
+"""Version directory read-only enforcement.
+
+After a successful install or update, pinned version directories under
+``~/.vnx-system/versions/<v>/`` (every ``vX.Y.Z``) are made read-only so
+that no worker, script, or tool can accidentally write into the shared
+immutable code tree.  ``edge`` is always left writable (it is a living
+checkout).  Install and update flows temporarily unlock the directory,
+perform their work, then re-lock it — even when an error occurs part-way
+through.
+
+Why OS-level, not worker-permission-level
+------------------------------------------
+Two reasons, both measured:
+
+1. The written path resolves INSIDE the consumer's worktree before
+   symlink resolution, so path-prefix deny rules do not catch it.
+2. The capability binding in ``.vnx/worker_permissions.yaml`` is
+   claude-bound.  A kimi or codex worker via the native CLI never sees
+   those rules; kimi is the fleet default build-worker.
+
+A read-only bit is OS-enforced and effective across providers, tools,
+and symlinks.
+
+Public API
+----------
+- ``make_readonly(version_dir)`` — remove all write bits recursively.
+- ``make_writable(version_dir)`` — restore user-write bits recursively.
+- ``is_readonly(version_dir)`` — test whether the directory's user-write
+  bit is cleared.
+- ``writeable_version_dir(version_dir)`` — context manager that
+  temporarily unlocks, yields, then re-locks.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Iterator
+
+
+def _is_pinned(version_dir: Path) -> bool:
+    """True when ``version_dir`` is a pinned version, not ``edge``."""
+    return version_dir.name != "edge"
+
+
+def _chmod_one(path: Path, *, remove_write: bool) -> None:
+    """Add or remove all write bits from *one* filesystem entry."""
+    try:
+        st = path.lstat()
+    except OSError:
+        return  # broken symlink or racy deletion
+    mode = st.st_mode
+    if remove_write:
+        new_mode = mode & ~(stat.S_IWUSR | stat.S_IWGRP | stat.S_IWOTH)
+    else:
+        new_mode = mode | stat.S_IWUSR
+    if new_mode != mode:
+        try:
+            os.chmod(str(path), new_mode, follow_symlinks=False)
+        except OSError:
+            pass  # defensive: never crash traversal on a single entry
+
+
+def _chmod_recursive(root: Path, *, remove_write: bool) -> None:
+    """Recursively add or remove write permissions under *root*."""
+    for dirpath_str, dirnames, filenames in os.walk(str(root), followlinks=False):
+        dirpath = Path(dirpath_str)
+        _chmod_one(dirpath, remove_write=remove_write)
+        for name in filenames:
+            _chmod_one(dirpath / name, remove_write=remove_write)
+
+
+def make_readonly(version_dir: Path) -> None:
+    """Recursively remove all write bits from ``version_dir``.
+
+    No-op for ``edge`` (a living checkout must stay writable) and for
+    non-existent or non-directory paths.
+
+    Raises nothing — chmod failures on individual entries are silently
+    skipped so traversal never aborts the whole tree.  If the final
+    state is wrong the caller will detect that and fail loud.
+    """
+    if not _is_pinned(version_dir):
+        return
+    if not version_dir.is_dir():
+        return
+    _chmod_recursive(version_dir, remove_write=True)
+
+
+def make_writable(version_dir: Path) -> None:
+    """Recursively add user-write bit to every entry under ``version_dir``.
+
+    No-op for ``edge`` and for non-existent/non-directory paths.
+    See ``make_readonly`` for the error-handling rationale.
+    """
+    if not _is_pinned(version_dir):
+        return
+    if not version_dir.is_dir():
+        return
+    _chmod_recursive(version_dir, remove_write=False)
+
+
+def is_readonly(version_dir: Path) -> bool:
+    """True when the directory's user-write bit is cleared.
+
+    Tests only the directory itself (not recursive).  Returns False for
+    ``edge`` (conceptually never read-only) and for non-existent paths.
+    """
+    if not _is_pinned(version_dir):
+        return False
+    if not version_dir.is_dir():
+        return False
+    try:
+        mode = version_dir.stat().st_mode
+    except OSError:
+        return False
+    return not (mode & stat.S_IWUSR)
+
+
+@contextmanager
+def writeable_version_dir(version_dir: Path) -> Iterator[None]:
+    """Context manager: temporarily unlock a version dir, re-lock on exit.
+
+    Usage::
+
+        with writeable_version_dir(version_dir):
+            subprocess.run(["git", "-C", str(version_dir), "pull"])
+
+    The directory is unlocked before the body runs and re-locked in the
+    ``finally`` block.  ``edge`` is never touched.  If the directory was
+    already writable on entry it is left writable on exit (a nested
+    unlock inside another writer's context manager).
+    """
+    was_readonly = is_readonly(version_dir)
+    if was_readonly:
+        make_writable(version_dir)
+    try:
+        yield
+    finally:
+        if was_readonly:
+            make_readonly(version_dir)

--- a/tests/test_version_readonly.py
+++ b/tests/test_version_readonly.py
@@ -1,0 +1,356 @@
+"""Test read-only enforcement for pinned version directories.
+
+The vnx_version_ro module makes pinned version directories (vX.Y.Z)
+read-only after install/update while leaving ``edge`` writable.  These
+tests exercise the Python utility directly and the install-central.sh
+bash integration.
+
+Tests are written to fail against the current code before the
+vnx_version_ro module and install-central.sh changes are applied.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+import subprocess
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+# Late import: the module lives in scripts/lib/, not on the default
+# PYTHONPATH for tests.  pytest's conftest.py adds scripts/lib/ to
+# sys.path so the import works in test runs.
+from vnx_version_ro import (
+    is_readonly,
+    make_readonly,
+    make_writable,
+    writeable_version_dir,
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+def _assert_writable(path: Path) -> None:
+    """Assert the user-write bit is SET on *path*."""
+    mode = path.stat().st_mode
+    assert mode & stat.S_IWUSR, f"expected {path} to be user-writable"
+
+
+def _assert_readonly(path: Path) -> None:
+    """Assert the user-write bit is CLEARED on *path*."""
+    mode = path.stat().st_mode
+    assert not (mode & stat.S_IWUSR), f"expected {path} to be read-only"
+
+
+def _write_file_should_fail(path: Path, filename: str = "test_write.txt") -> None:
+    """Attempt to create a file in *path*; must raise PermissionError."""
+    target = path / filename
+    with pytest.raises(PermissionError):
+        target.write_text("should not be able to write")
+
+
+def _write_file_should_succeed(path: Path, filename: str = "test_write.txt") -> None:
+    """Create a file in *path*; must succeed (dir is writable)."""
+    target = path / filename
+    target.write_text("writable")
+    target.unlink()  # cleanup
+
+
+# ── test 1: pinned version dir is read-only after make_readonly ──────────────
+
+def test_pinned_version_not_writable_after_lock(tmp_path: Path) -> None:
+    """After make_readonly, a pinned version dir rejects writes."""
+    version_dir = tmp_path / "v1.3.1"
+    version_dir.mkdir()
+    # Prove it starts writable
+    _write_file_should_succeed(version_dir, "before.txt")
+    assert not is_readonly(version_dir)
+
+    make_readonly(version_dir)
+
+    assert is_readonly(version_dir)
+    _write_file_should_fail(version_dir, "after.txt")
+
+
+def test_make_readonly_recursive(tmp_path: Path) -> None:
+    """make_readonly removes write bits from files AND subdirectories."""
+    version_dir = tmp_path / "v1.0.0"
+    scripts_dir = version_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    script = scripts_dir / "tool.py"
+    script.write_text("print('hello')")
+
+    make_readonly(version_dir)
+
+    _assert_readonly(version_dir)
+    _assert_readonly(scripts_dir)
+    _assert_readonly(script)
+    # Files inside cannot be overwritten
+    with pytest.raises(PermissionError):
+        script.write_text("would overwrite")
+
+
+def test_make_writable_restores_write_bits(tmp_path: Path) -> None:
+    """make_writable restores the user-write bit after make_readonly."""
+    version_dir = tmp_path / "v2.0.0"
+    version_dir.mkdir()
+
+    make_readonly(version_dir)
+    assert is_readonly(version_dir)
+
+    make_writable(version_dir)
+    assert not is_readonly(version_dir)
+    _write_file_should_succeed(version_dir)
+
+
+# ── test 2: edge stays writable ──────────────────────────────────────────────
+
+def test_edge_never_readonly(tmp_path: Path) -> None:
+    """edge is always writable; make_readonly and is_readonly are no-ops."""
+    edge_dir = tmp_path / "edge"
+    edge_dir.mkdir()
+
+    assert not is_readonly(edge_dir)
+
+    make_readonly(edge_dir)
+    assert not is_readonly(edge_dir)
+    _write_file_should_succeed(edge_dir, "still_writable.txt")
+
+
+def test_edge_ignored_by_make_writable(tmp_path: Path) -> None:
+    """make_writable is a no-op for edge (nothing to restore)."""
+    edge_dir = tmp_path / "edge"
+    edge_dir.mkdir()
+
+    # No error, no change
+    make_writable(edge_dir)
+    assert not is_readonly(edge_dir)
+
+
+# ── test 3: install flow can write and leaves dir read-only ──────────────────
+
+def test_context_manager_unlocks_and_relocks(tmp_path: Path) -> None:
+    """writeable_version_dir unlocks for writes, re-locks on exit."""
+    version_dir = tmp_path / "v1.3.1"
+    version_dir.mkdir()
+    make_readonly(version_dir)
+    assert is_readonly(version_dir)
+
+    with writeable_version_dir(version_dir):
+        # Inside the context the dir must be writable
+        assert not is_readonly(version_dir)
+        _write_file_should_succeed(version_dir, "during_install.txt")
+
+    # After the context the dir must be read-only again
+    assert is_readonly(version_dir)
+    _write_file_should_fail(version_dir, "after_install.txt")
+
+
+def test_context_manager_nested_is_idempotent(tmp_path: Path) -> None:
+    """Nested writeable_version_dir calls don't double-unlock or leak."""
+    version_dir = tmp_path / "v1.0.0"
+    version_dir.mkdir()
+    make_readonly(version_dir)
+
+    with writeable_version_dir(version_dir):
+        assert not is_readonly(version_dir)
+        with writeable_version_dir(version_dir):  # nested: already writable
+            assert not is_readonly(version_dir)
+            _write_file_should_succeed(version_dir, "nested.txt")
+        # Inner exit: dir was writable on entry, stays writable
+        assert not is_readonly(version_dir)
+    # Outer exit: dir was read-only on entry, re-locked
+    assert is_readonly(version_dir)
+
+
+def test_context_manager_noop_when_already_writable(tmp_path: Path) -> None:
+    """When the dir is already writable, the context manager is a no-op."""
+    version_dir = tmp_path / "v1.2.0"
+    version_dir.mkdir()
+    # No make_readonly — dir is writable from creation
+    assert not is_readonly(version_dir)
+
+    with writeable_version_dir(version_dir):
+        _write_file_should_succeed(version_dir, "writable.txt")
+
+    # Was writable on entry → stays writable (not locked)
+    assert not is_readonly(version_dir)
+
+
+# ── test 4: error mid-install leaves dir not writable (finally block) ────────
+
+def test_context_manager_relocks_on_exception(tmp_path: Path) -> None:
+    """When an exception occurs inside the context, the finally block re-locks."""
+    version_dir = tmp_path / "v1.3.0"
+    version_dir.mkdir()
+    make_readonly(version_dir)
+    assert is_readonly(version_dir)
+
+    with pytest.raises(RuntimeError, match="simulated failure"):
+        with writeable_version_dir(version_dir):
+            assert not is_readonly(version_dir)
+            _write_file_should_succeed(version_dir, "before_error.txt")
+            raise RuntimeError("simulated failure mid-install")
+
+    # finally block must have re-locked
+    assert is_readonly(version_dir)
+    _write_file_should_fail(version_dir, "after_error.txt")
+
+
+def test_context_manager_relocks_on_os_error(tmp_path: Path) -> None:
+    """Even on OSError (e.g. disk full), the finally block re-locks."""
+    version_dir = tmp_path / "v1.3.1"
+    version_dir.mkdir()
+    make_readonly(version_dir)
+
+    try:
+        with writeable_version_dir(version_dir):
+            # Simulate any kind of error that aborts the write
+            raise OSError("disk full during write")
+    except OSError:
+        pass
+
+    assert is_readonly(version_dir)
+
+
+# ── edge cases ───────────────────────────────────────────────────────────────
+
+def test_is_readonly_non_existent(tmp_path: Path) -> None:
+    """is_readonly returns False for non-existent paths."""
+    assert not is_readonly(tmp_path / "does_not_exist")
+
+
+def test_is_readonly_file_not_dir(tmp_path: Path) -> None:
+    """is_readonly returns False for regular files."""
+    f = tmp_path / "some_file.txt"
+    f.write_text("not a dir")
+    assert not is_readonly(f)
+
+
+def test_make_readonly_non_existent_no_error(tmp_path: Path) -> None:
+    """make_readonly on a non-existent path does not raise."""
+    make_readonly(tmp_path / "nope" / "v9.9.9")
+    # No exception = pass
+
+
+# ── install-central.sh integration ───────────────────────────────────────────
+
+_INSTALL_CENTRAL = _REPO_ROOT / "install-central.sh"
+
+
+def _run_install_central_driver(driver: str, *, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    """Source install-central.sh (minus main) and run *driver* bash."""
+    body = _INSTALL_CENTRAL.read_text(encoding="utf-8")
+    head, sep, tail = body.rpartition('main "$@"')
+    assert sep, 'expected trailing main "$@"'
+    program = head + "\n" + driver + "\n"
+    env = {k: v for k, v in os.environ.items() if not k.startswith("VNX_")}
+    return subprocess.run(
+        ["bash", "-c", program],
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_clone_version_locks_after_fresh_clone(tmp_path: Path) -> None:
+    """After a fresh clone, clone_version locks the version dir."""
+    target = tmp_path / "vnx-system"
+    version = "v9.9.9-test-readonly"
+
+    # Use a local git repo as source so we don't hit the network.
+    # Create a minimal git repo with a tag.
+    source = tmp_path / "source-repo"
+    source.mkdir()
+    subprocess.run(["git", "-C", str(source), "init"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "config", "user.email", "test@test"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "config", "user.name", "Test"], check=True, capture_output=True)
+    (source / "VERSION").write_text("9.9.9\n")
+    (source / ".gitignore").write_text("__pycache__/\n")
+    subprocess.run(["git", "-C", str(source), "add", "-A"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "commit", "-m", "init"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(source), "tag", version], check=True, capture_output=True)
+    # Remove the tag so clone can use it as a branch (--branch needs a branch or tag)
+    # git clone --branch works with tags too, so this should be fine.
+
+    driver = (
+        f'TARGET_DIR="{target}"\n'
+        f'VERSION="{version}"\n'
+        f'SOURCE_URL="{source}"\n'
+        "DRY_RUN=false\n"
+        "clone_version\n"
+    )
+    result = _run_install_central_driver(driver)
+    assert result.returncode == 0, f"clone_version failed:\n{result.stderr}\n{result.stdout}"
+
+    version_dir = target / "versions" / version
+    assert version_dir.is_dir(), f"version dir not created at {version_dir}"
+    _assert_readonly(version_dir)
+    # The marker file must still be readable
+    marker = version_dir / ".vnx-install-mode"
+    assert marker.is_file()
+    assert "central" in marker.read_text(encoding="utf-8")
+
+
+def test_clone_version_locks_after_existing_dir(tmp_path: Path) -> None:
+    """When the dir already exists (idempotent run), clone_version re-locks."""
+    target = tmp_path / "vnx-system"
+    version = "v9.9.9-test-idem"
+
+    # Create a minimal version dir that already exists (simulating prior locked state)
+    version_dir = target / "versions" / version
+    version_dir.mkdir(parents=True)
+    (version_dir / "VERSION").write_text("9.9.9\n")
+    make_readonly(version_dir)
+    assert is_readonly(version_dir)
+
+    # Run clone_version on the existing (locked) dir — must unlock, write
+    # marker, and re-lock.
+    driver = (
+        f'TARGET_DIR="{target}"\n'
+        f'VERSION="{version}"\n'
+        "DRY_RUN=false\n"
+        "clone_version\n"
+    )
+    result = _run_install_central_driver(driver)
+    assert result.returncode == 0, f"clone_version failed:\n{result.stderr}\n{result.stdout}"
+
+    assert is_readonly(version_dir)
+    marker = version_dir / ".vnx-install-mode"
+    assert marker.is_file()
+    assert "central" in marker.read_text(encoding="utf-8")
+
+
+def test_clone_version_skips_lock_for_edge(tmp_path: Path) -> None:
+    """clone_version does NOT lock the edge version dir.
+
+    Exercises the existing-dir (idempotent) branch of clone_version since
+    a fresh clone of 'edge' requires the source repo to have an 'edge' branch
+    (clone_version passes --branch $VERSION directly, not main→edge mapped).
+    The lock decision is in lock_version_dir, which is the unit under test.
+    """
+    target = tmp_path / "vnx-system"
+    version = "edge"
+    version_dir = target / "versions" / version
+    version_dir.mkdir(parents=True)
+    (version_dir / "VERSION").write_text("edge\n")
+
+    driver = (
+        f'TARGET_DIR="{target}"\n'
+        f'VERSION="{version}"\n'
+        "DRY_RUN=false\n"
+        "clone_version\n"
+    )
+    result = _run_install_central_driver(driver)
+    assert result.returncode == 0, f"clone_version failed:\n{result.stderr}\n{result.stdout}"
+
+    assert version_dir.is_dir()
+    _assert_writable(version_dir)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(pytest.main([__file__, "-v"]))

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -16,6 +16,12 @@ from pathlib import Path
 
 from vnx_cli._reexec import PIN_FILE_NAME, _PIN_RE, _normalize_version
 
+# Late import: vnx_version_ro lives in the engine tree (scripts/lib/), not in
+# the pip CLI tree, so we import it inside the functions that need it rather
+# than at module level.  This keeps the pip CLI importable without the engine
+# on sys.path and without a try/except wrapper.
+_VNX_VERSION_RO_MODULE = "vnx_version_ro"
+
 
 VNX_GIT_REMOTE = "https://github.com/Vinix24/vnx-orchestration.git"
 DEFAULT_KEEP_LAST = 3
@@ -136,10 +142,19 @@ def _fetch_version(
 
     if target_dir.is_dir():
         print(f"Pulling {target} in {target_dir}...")
-        subprocess.run(
-            ["git", "-C", str(target_dir), "pull", "--ff-only"],
-            check=True,
-        )
+        from vnx_cli import _engine as _eng2
+        _eng2.ensure_engine_on_path()
+        from vnx_version_ro import writeable_version_dir as _wvd
+        with _wvd(target_dir):
+            subprocess.run(
+                ["git", "-C", str(target_dir), "pull", "--ff-only"],
+                check=True,
+            )
+            # Strip and marker happen inside the context so the dir is
+            # writable for both.  _write_install_marker has its own inner
+            # context manager that is a no-op when already writable.
+            _strip_tenant_marker(target_dir)
+            _write_install_marker(target_dir, audit_log=audit_log)
     else:
         ref = "main" if target == "edge" else target
         print(f"Cloning {VNX_GIT_REMOTE} (ref={ref}) -> {target_dir}...")
@@ -148,14 +163,14 @@ def _fetch_version(
              VNX_GIT_REMOTE, str(target_dir)],
             check=True,
         )
+        _strip_tenant_marker(target_dir)
+        _write_install_marker(target_dir, audit_log=audit_log)
+        # Lock the freshly cloned pinned version dir (edge stays writable).
+        from vnx_cli import _engine as _eng3
+        _eng3.ensure_engine_on_path()
+        from vnx_version_ro import make_readonly as _mkro
+        _mkro(target_dir)
 
-    # The installed engine tree must be TENANT-NEUTRAL. The repo tracks its own
-    # `.vnx-project-id = vnx-dev`, so a clone/pull drags that marker into the shared
-    # version dir. In central-install mode the door's CWD is this tree; a stray marker
-    # there makes CWD-based project_id resolution return `vnx-dev` for EVERY consumer
-    # (the fleet-wide misroute/hard-reject class). Strip it after every fetch.
-    _strip_tenant_marker(target_dir)
-    _write_install_marker(target_dir, audit_log=audit_log)
     return target_dir
 
 
@@ -198,13 +213,15 @@ def _write_install_marker(version_dir: Path, audit_log: "Path | None" = None) ->
     from vnx_cli import _engine
     _engine.ensure_engine_on_path()
     from atomic_io import atomic_write_text
+    from vnx_version_ro import writeable_version_dir
 
-    atomic_write_text(version_dir / INSTALL_MODE_MARKER, f"{INSTALL_MODE_VALUE}\n")
-    _emit_audit_event(
-        "central_install_marker_written",
-        {"version_dir": str(version_dir)},
-        audit_log=audit_log,
-    )
+    with writeable_version_dir(version_dir):
+        atomic_write_text(version_dir / INSTALL_MODE_MARKER, f"{INSTALL_MODE_VALUE}\n")
+        _emit_audit_event(
+            "central_install_marker_written",
+            {"version_dir": str(version_dir)},
+            audit_log=audit_log,
+        )
 
 
 def _is_under_versions(root: Path, version_dir: Path) -> bool:
@@ -481,6 +498,10 @@ def _prune_old_versions(
                 audit_log=audit_log,
             )
             print(f"Pruning: {version_dir}")
+            from vnx_cli import _engine as _eng4
+            _eng4.ensure_engine_on_path()
+            from vnx_version_ro import make_writable as _mkw
+            _mkw(version_dir)
             shutil.rmtree(version_dir)
 
 


### PR DESCRIPTION
## What

Pinned version directories under `~/.vnx-system/versions/<v>/` are now made read-only (`chmod -R a-w`) after a successful install or update. `edge` stays writable as a living checkout.

Install and update flows temporarily unlock the directory, perform their work, and re-lock — even when an error occurs part-way through. Uses a Python context manager (`writeable_version_dir`) and bash helpers (`lock_version_dir`/`unlock_version_dir`).

## Why

**OI-953:** A worker wrote into `scripts/open_items_manager.py` in the shared `~/.vnx-system/versions/v1.3.1/` tree. The write produced zero signal: no git diff, no failing test until a clean checkout. Two reasons why worker-permissions couldn't catch this:

1. The written path resolves INSIDE the worktree before symlink resolution (path-prefix deny rules don't see the real target).
2. The capability binding in `.vnx/worker_permissions.yaml` is claude-bound — kimi (fleet-default build-worker) and codex workers via native CLI never see it.

A read-only bit is OS-enforced, provider-agnostic, and works across symlinks.

## Measurement

Non-`.git`, non-`__pycache__` files modified in pinned version dirs in 7 days: **exactly one** — the worker accident that triggered this (OI-953). Zero legitimate runtime writes.

## Changes

| File | Action |
|---|---|
| `scripts/lib/vnx_version_ro.py` | New: `make_readonly`, `make_writable`, `is_readonly`, `writeable_version_dir` context manager |
| `install-central.sh` | Modified: `lock_version_dir`/`unlock_version_dir` helpers, integrated into `clone_version` |
| `vnx_cli/commands/update.py` | Modified: context manager in `_fetch_version`, `_write_install_marker`, `_prune_old_versions` |
| `tests/test_version_readonly.py` | New: 16 tests (all pass) |

## Tests

- 16 new tests pass
- 27 existing tests (install marker, update, contamination check) pass — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)