### PR TITLE
fix(role): modernise T0 role and skill — free-per-dispatch pins, horizon planning, serial lane

### DIFF
--- a/.claude/skills/t0-orchestrator/SKILL.md
+++ b/.claude/skills/t0-orchestrator/SKILL.md
@@ -31,10 +31,12 @@ parallel path:
   Lane rule the door enforces: **`claude`/Opus → tmux-spawn lane** (subscription, June-15
   escape; never `provider_dispatch`, never headless `claude -p`); `kimi`/`glm`/`deepseek`
   → `provider_dispatch`. Known interim side door being consolidated by PR-12: the PM
-  plan-gate panel (`plan_gate_panel.py`) calls lanes directly until the door is wired.
-- **Feature/build planning** goes through the roadmap layer (`vnx roadmap`,
-  `roadmap_manager.py`, `build_strategy_projection.py` — waves/objectives), NOT
-  ad-hoc plan docs scattered in `claudedocs/`.
+  horizon plan-gate panel (`plan_gate_panel.py`) calls lanes directly until the door is wired.
+- **Feature/build planning** goes through Horizon, the future-state layer:
+  `vnx objective {list,show,drift,close}`, `vnx deliverable {add,list,promote}`.
+  The tracks DB is the SSOT; ROADMAP.yaml is a static example. Use the `horizon`
+  skill for planning and plan-first gate panel decisions. See
+  `vnx_cli/commands/horizon.py`. NOT ad-hoc plan docs in `claudedocs/`.
 - **Open items** flow through the report contract `## Open Items` → receipt processor
   → OI ledger, NOT inline-in-a-doc. Inspect/resolve via the OI tooling; close only
   evidence-backed items; create a new OI when out-of-scope risk appears.
@@ -43,7 +45,11 @@ parallel path:
 
 ## 1. Runtime guardrails
 
-- T0 = Claude Opus only. T1/T2 = Sonnet-pinned unless the operator reconfigures.
+- T0 = Claude Opus only (`t0-opus-only`, pin_semantics=floor).
+  T1/T2/T3 = free per-dispatch provider/model choice; kimi-k3 fills in when the
+  spec carries no explicit model (`workers-kimi-pinned`, pin_semantics=default).
+  `provider=claude` for a build-worker still requires `VNX_OVERRIDE_WORKER_CLAUDE=1`
+  with an audit reason.
 - Do not rely on runtime `/model` switching. Re-verify worker readiness before the payload.
 - Tri-file for workers (`CLAUDE.md`/`AGENTS.md`/`GEMINI.md`); T0 itself uses `CLAUDE.md`.
 - `Bash` is for orchestration/state only — never write/edit tooling for implementation.
@@ -67,7 +73,7 @@ parallel path:
 3. REJECT      status=failure OR risk>0.8 OR blocking findings       → REJECT
 4. ESCALATE    architectural change OR new dependency OR policy      → ESCALATE
 5. INVESTIGATE risk 0.3–0.8 OR advisory=hold                         → DISPATCH follow-up to T3
-6. TERMINAL    all terminals busy (none ready)                       → WAIT
+6. SERIAL      dispatch needs claude-tmux lane AND lane occupied      → WAIT
 7. COMPLETE    completion=100 AND no blockers AND no pending OIs     → COMPLETE
 8. DEFAULT     receipt valid AND work pending                        → DISPATCH
 ```

--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -79,7 +79,8 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 - All dispatches go through the single-entry door `vnx dispatch <pending-id>`, which decides the lane. Calling a lane script directly is a side door (rollback only: `VNX_DISPATCH_LEGACY=1`).
 - Source vs. consumer: the door above (`bin/vnx dispatch <id>`) is the fabric source repo's form. In a pip-installed consumer repo (no `bin/`), the equivalent governed door is `vnx dispatch-agent --agent <name>` (it routes through the same `deliver_via_door` bridge); `vnx pool` replaces `bin/vnx pool`.
 - Provider→lane (hard): `claude`/Opus/Sonnet route via the tmux-spawn lane (`scripts/lib/tmux_interactive_dispatch.py`, interactive, subscription-preserving) — NEVER `provider_dispatch`, NEVER `claude -p`. `kimi`/`glm`/`deepseek` route via `provider_dispatch.py`.
-- Default worker: kimi-k3 (via `provider_dispatch.py`, kimi-only, no fallback — worker-provider-kimi-flip, 2026-07-23). Stage build dispatches with `provider="kimi", model="kimi-k3"` explicitly. For complex reasoning: `--model sonnet` (claude) with `VNX_OVERRIDE_WORKERS_KIMI_PINNED=1`. T0 stays Opus (`t0-opus-only`).
+- Build-worker provider and model are a **free per-dispatch choice**: what the dispatch spec says wins (`workers-kimi-pinned`, pin_semantics=default). kimi-k3 is only the default when the spec carries no explicit model — no override env needed. T0 stays Opus as a governance floor (`t0-opus-only`, pin_semantics=floor).
+- `provider=claude` for a build-worker still routes through a separate gate: `VNX_OVERRIDE_WORKER_CLAUDE=1` with an audit reason (`dispatch_cli.py:691-705`). Track `worker-provider-free-choice` aims to eventually remove this remaining lock.
 - No Claude Code subagents (Task tool). Full decision rule: `docs/core/DISPATCH_RULES.md`.
 
 ## Crash Recovery (on-demand only)
@@ -102,7 +103,7 @@ Project files describe the project; the fabric describes itself. A repo's `CLAUD
 ## Runtime Policy
 
 - T0 runtime is Claude Opus only.
-- `T1` and `T2` are manually kimi-k3-pinned (worker-provider-kimi-flip, 2026-07-23); do not assume runtime `/model` switching works.
+- `T1`/`T2`/`T3` build-worker provider and model are a free per-dispatch choice (worker-provider-free-choice). kimi-k3 fills in only when the dispatch spec carries no explicit model. Do not assume runtime `/model` switching works.
 - `T3` is a Claude review/certification terminal and must be treated as modal-sensitive after `/clear`.
 - Tri-file support (`CLAUDE.md`, `AGENTS.md`, `GEMINI.md`) is fleet-wide, including T0 (deliberate,
   as of the provider-agnostic role sync): an orchestrator session may run under Claude

--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -138,7 +138,8 @@ case "$TERMINAL" in
     fi
 
     ADDITIONAL_CONTEXT="T0 Master Orchestrator Active${PROJECT_NAME:+ — $PROJECT_NAME}
-Available skills: @t0-orchestrator @architect @planner
+Core skills: @t0-orchestrator @horizon @planner @architect @panel @fabric-reference
+Full registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer)
 Use /t0-orchestrator for orchestration decisions and receipt processing
 
 Terminals:
@@ -146,7 +147,7 @@ $(echo -e "${T0_TERMINAL_STATES:-No terminal state data}")
 ${T0_OPEN_ITEMS:-No open items data}
 
 CRITICAL: After every completion receipt, check quality advisory + open items before proceeding.
-Skills must NOT use @ prefix in Role field. Check .vnx/skills/skills.yaml for valid skills.${T0_SKILL_BODY:+
+Skills must NOT use @ prefix in Role field. Skill registry: skills/skills.yaml (repo) or \$VNX_SKILLS_DIR/skills.yaml (consumer).${T0_SKILL_BODY:+
 
 ---
 $T0_SKILL_BODY}"

--- a/tests/test_sessionstart_hook.py
+++ b/tests/test_sessionstart_hook.py
@@ -126,6 +126,47 @@ class TestOtherTerminalsUnaffected:
         assert "UNIQUE-PLAYBOOK-MARKER-4f8e1c" not in ctx
 
 
+class TestHookContextContent:
+    """The hook's own text (not the injected skill body) carries references
+    that must stay current. These tests verify the corrected references
+    without coupling to the exact skill body content."""
+
+    def test_skills_registry_path_is_correct(self, tmp_path):
+        """Line 142 + line 150: both references point to skills/skills.yaml,
+        not the non-existent .vnx/skills/skills.yaml."""
+        project = _make_project(tmp_path)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "skills/skills.yaml" in ctx
+        assert ".vnx/skills/skills.yaml" not in ctx
+
+    def test_core_skills_list_includes_horizon_panel_fabric_reference(self, tmp_path):
+        """Line 141: the core skills list includes the skills T0 actually
+        routes to: horizon, panel, fabric-reference (added 2026-07-31)."""
+        project = _make_project(tmp_path)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        assert "@horizon" in ctx
+        assert "@panel" in ctx
+        assert "@fabric-reference" in ctx
+
+    def test_old_pin_language_is_absent(self, tmp_path):
+        """Sonnet-pinned language in the runtime guardrails section was
+        replaced with free-per-dispatch wording."""
+        project = _make_project(tmp_path)
+        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
+        skill_dir.mkdir(parents=True)
+        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+
+        out = _run_hook(project / ".claude" / "terminals" / "T0")
+        ctx = out["hookSpecificOutput"]["additionalContext"]
+        # The mock SKILL_BODY uses the old text, so this test only verifies
+        # the hook's own framing lines don't use stale language.
+        assert "Sonnet-pinned" not in ctx.split("UNIQUE-PLAYBOOK-MARKER")[0]
+
+
 class TestNonVnxDirectory:
     def test_exits_silently_outside_a_terminal_directory(self, tmp_path):
         r = subprocess.run(

--- a/tests/test_sessionstart_hook.py
+++ b/tests/test_sessionstart_hook.py
@@ -152,19 +152,28 @@ class TestHookContextContent:
         assert "@panel" in ctx
         assert "@fabric-reference" in ctx
 
-    def test_old_pin_language_is_absent(self, tmp_path):
-        """Sonnet-pinned language in the runtime guardrails section was
-        replaced with free-per-dispatch wording."""
-        project = _make_project(tmp_path)
-        skill_dir = project / ".claude" / "skills" / "t0-orchestrator"
-        skill_dir.mkdir(parents=True)
-        (skill_dir / "SKILL.md").write_text(SKILL_BODY)
+    def test_old_pin_language_is_absent(self):
+        """Sonnet-pinned and VNX_OVERRIDE_WORKERS_KIMI_PINNED must not appear
+        in the T0 role or skill files after the free-per-dispatch
+        modernisation (PR #1257). Conversely, pin_semantics and the free
+        per-dispatch choice wording must be present.
 
-        out = _run_hook(project / ".claude" / "terminals" / "T0")
-        ctx = out["hookSpecificOutput"]["additionalContext"]
-        # The mock SKILL_BODY uses the old text, so this test only verifies
-        # the hook's own framing lines don't use stale language.
-        assert "Sonnet-pinned" not in ctx.split("UNIQUE-PLAYBOOK-MARKER")[0]
+        This test reads the real repo files, not a mock fixture — it fails
+        against origin/main where the old pin language still lives."""
+        skill_md = REPO / ".claude" / "skills" / "t0-orchestrator" / "SKILL.md"
+        role_md = REPO / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+        skill_text = skill_md.read_text()
+        role_text = role_md.read_text()
+        combined = skill_text + role_text
+
+        # Old pin language must be gone from both files.
+        assert "Sonnet-pinned" not in combined
+        assert "VNX_OVERRIDE_WORKERS_KIMI_PINNED" not in combined
+
+        # New pin semantics must be present.
+        assert "pin_semantics" in combined
+        assert "per-dispatch" in combined
 
 
 class TestNonVnxDirectory:


### PR DESCRIPTION
## Wat

Moderniseert het T0 rolbestand (`role-orchestrator.md`) en de `t0-orchestrator` skill (`SKILL.md`) plus de SessionStart hook (`sessionstart.sh`).

### 1. Provider-pin taal vervangen

**Was:** workers "kimi-k3-pinned", T1/T2 "manually pinned", `VNX_OVERRIDE_WORKERS_KIMI_PINNED=1` nodig voor model-keuze.

**Is:** free per-dispatch choice. `workers-kimi-pinned` heeft `pin_semantics: default` (advisory) — wat de dispatch-spec zegt, wint. kimi-k3 vult alleen in als de spec geen model noemt. T0 blijft Opus als governance-vloer (`pin_semantics: floor`).

Geverifieerd in `dispatch_cli.py:734-735`: `spec.model or pin.model or "sonnet"`. Een dispatch met `model=deepseek-v4-pro` kreeg deepseek-v4-pro met alleen advisory warn — geen override-env nodig.

`provider=claude` voor build-workers blijft wel gepind (`VNX_OVERRIDE_WORKER_CLAUDE=1` met audit-reason, `dispatch_cli.py:691-705`).

### 2. Planning: roadmap → horizon

`roadmap_manager.py`, `build_strategy_projection.py`, `vnx roadmap` → `vnx objective {list,show,drift,close}`, `vnx deliverable {add,list,promote}`, `horizon` skill. "PM" → "horizon" in plan-gate referentie.

### 3. Beslissingsboom: TERMINAL → SERIAL

"all terminals busy" vervangen door "dispatch needs claude-tmux lane AND lane occupied" — consistent met sectie 5 van de skill (provider lanes parallel, claude-tmux subscription-session-capped).

### 4. Dode verwijzingen sessionstart.sh

- Skills-lijst: `@t0-orchestrator @architect @planner` → aangevuld met `@horizon @panel @fabric-reference` + registry pointer
- `.vnx/skills/skills.yaml` → `skills/skills.yaml` (.vnx/ bevat geen skills/ directory)

### 5. Injectie geverifieerd

Hook gesimuleerd als T0-terminal: `# T0 Orchestrator` heading aanwezig (6562 chars, 126 lines), alle 6 SKILL.md secties aanwezig. 9/9 tests groen.

## Files

| File | Delta |
|---|---|
| `.claude/terminals/T0/role-orchestrator.md` | +3/-2 |
| `.claude/skills/t0-orchestrator/SKILL.md` | +13/-5 |
| `hooks/sessionstart.sh` | +3/-2 |
| `tests/test_sessionstart_hook.py` | +41/-0 |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
