### PR TITLE
fix(analyzer): reject placeholder dispatch_id, cleanup pollution, close token_usage chain

### DIFF
--- a/scripts/conversation_analyzer/parser.py
+++ b/scripts/conversation_analyzer/parser.py
@@ -16,6 +16,13 @@ class SessionParser:
 
     DISPATCH_TABLE_RE = re.compile(r'\|\s*\*\*Dispatch-ID\*\*\s*\|\s*([^\|]+?)\s*\|')
     DISPATCH_HEADER_RE = re.compile(r'Dispatch-ID:\s*(\S+)')
+    # Placeholder pattern: <any-text> — template placeholders like <dispatch_id>
+    # must never be treated as real IDs.
+    PLACEHOLDER_RE = re.compile(r'^<[^>]+>$')
+    # Dispatch IDs always start with a date-prefix (YYYYMMDD-). This is the
+    # minimum validation that rejects template placeholders, empty strings,
+    # and free-form text while accepting all real dispatch ID formats.
+    VALID_DISPATCH_ID_RE = re.compile(r'^\d{8}-')
 
     @staticmethod
     def session_id_from_path(jsonl_path: Path) -> str:
@@ -115,6 +122,27 @@ class SessionParser:
                 metrics.tool_calls_total += 1
                 self._count_tool(metrics, block.get("name", ""))
 
+    @classmethod
+    def _validate_dispatch_id(cls, raw: str) -> Optional[str]:
+        """Validate and normalise an extracted dispatch_id candidate.
+
+        Returns the trimmed string when it looks like a real dispatch ID,
+        or None when the value is a template placeholder, empty, or
+        otherwise not a valid ID.
+        """
+        if not raw:
+            return None
+        candidate = raw.strip()
+        if not candidate:
+            return None
+        # Reject template placeholders: <dispatch_id>, <any-text>, etc.
+        if cls.PLACEHOLDER_RE.match(candidate):
+            return None
+        # Require the YYYYMMDD- date-prefix that every real dispatch ID carries.
+        if not cls.VALID_DISPATCH_ID_RE.match(candidate):
+            return None
+        return candidate
+
     def _process_user(self, record: dict, metrics: SessionMetrics):
         metrics.user_message_count += 1
         if not metrics.dispatch_id and metrics.user_message_count <= 3:
@@ -126,7 +154,9 @@ class SessionParser:
             if not m:
                 m = self.DISPATCH_HEADER_RE.search(text)
             if m:
-                metrics.dispatch_id = m.group(1).strip()
+                validated = self._validate_dispatch_id(m.group(1))
+                if validated:
+                    metrics.dispatch_id = validated
 
     @staticmethod
     def _parse_timestamp(ts_str: str) -> Optional[datetime]:

--- a/scripts/link_sessions_dispatches.py
+++ b/scripts/link_sessions_dispatches.py
@@ -130,6 +130,120 @@ def link_reports_to_dispatches(conn: sqlite3.Connection) -> int:
     return updated
 
 
+def clean_polluted_dispatch_ids(conn: sqlite3.Connection) -> int:
+    """NULL out session_analytics.dispatch_id where the literal placeholder
+    ``<dispatch_id>`` was stored instead of a real ID (OI-872).
+
+    Idempotent: only matches the exact literal; real dispatch IDs
+    (which always start with a date-prefix ``YYYYMMDD-``) are never
+    touched.  A second run is a no-op because the matching rows already
+    carry NULL.
+    """
+    cur = conn.cursor()
+    cur.execute(
+        "UPDATE session_analytics SET dispatch_id = NULL "
+        "WHERE dispatch_id = '<dispatch_id>'"
+    )
+    cleaned = cur.rowcount
+    if cleaned:
+        conn.commit()
+    return cleaned
+
+
+def backfill_receipt_token_usage(conn: sqlite3.Connection) -> int:
+    """Backfill ``token_usage`` in claude-lane receipts from session_analytics.
+
+    Walks ``t0_receipts.ndjson`` line by line.  For each claude-provider
+    receipt whose ``token_usage`` is null, empty, or marked unavailable,
+    looks up the matching row in ``session_analytics`` by ``dispatch_id``.
+    When token data is found, the receipt's ``token_usage`` is populated.
+
+    Lines that need no enrichment pass through verbatim.  The rewritten
+    file is staged in a ``.tmp`` sibling and atomically renamed on
+    success, so a mid-write crash leaves the original file intact.
+
+    Returns the count of enriched receipts.
+    """
+    if not RECEIPTS_FILE.exists():
+        return 0
+
+    # Build a lookup: dispatch_id -> token_usage dict from session_analytics.
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT dispatch_id, total_input_tokens, total_output_tokens, "
+        "       cache_creation_tokens, cache_read_tokens "
+        "FROM session_analytics "
+        "WHERE dispatch_id IS NOT NULL"
+    )
+    session_tokens: dict[str, dict[str, int]] = {}
+    for row in cur.fetchall():
+        did, inp, out, cc, cr = row
+        if any(v is not None and v > 0 for v in (inp, out, cc, cr)):
+            session_tokens[did] = {
+                "input": int(inp or 0),
+                "output": int(out or 0),
+                "cache_creation_5m": int(cc or 0),
+                "cache_creation_1h": 0,
+                "cache_read": int(cr or 0),
+            }
+
+    if not session_tokens:
+        return 0
+
+    tmp_path = RECEIPTS_FILE.with_suffix(".ndjson.tmp")
+    enriched = 0
+
+    try:
+        with open(RECEIPTS_FILE, "r", encoding="utf-8", errors="replace") as fin, \
+             open(tmp_path, "w", encoding="utf-8") as fout:
+            for line in fin:
+                line_stripped = line.strip()
+                if not line_stripped:
+                    continue
+                try:
+                    receipt = json.loads(line_stripped)
+                except json.JSONDecodeError:
+                    fout.write(line_stripped + "\n")
+                    continue
+
+                provider = receipt.get("provider", "")
+                dispatch_id = receipt.get("dispatch_id", "")
+                token_usage = receipt.get("token_usage")
+
+                needs_backfill = (
+                    provider == "claude"
+                    and dispatch_id
+                    and (
+                        token_usage is None
+                        or (isinstance(token_usage, dict) and (
+                            token_usage.get("unavailable")
+                            or (token_usage.get("input", 0) == 0
+                                and token_usage.get("output", 0) == 0)
+                        ))
+                    )
+                    and dispatch_id in session_tokens
+                )
+
+                if needs_backfill:
+                    receipt["token_usage"] = session_tokens[dispatch_id]
+                    enriched += 1
+
+                fout.write(json.dumps(receipt, sort_keys=False, ensure_ascii=False) + "\n")
+
+        # Atomic rename.
+        import os as _os
+        _os.replace(tmp_path, RECEIPTS_FILE)
+    except Exception:
+        # Clean up the temp file on failure — never leave a partial.
+        try:
+            tmp_path.unlink(missing_ok=True)
+        except OSError:
+            pass
+        raise
+
+    return enriched
+
+
 def main():
     if not DB_PATH.exists():
         print(f"ERROR: DB not found: {DB_PATH}")
@@ -144,14 +258,25 @@ def main():
 
     print("=== Nightly Session-Dispatch Linkage ===")
 
+    # Phase 1: Clean up placeholder-polluted dispatch_ids (OI-872).
+    cleaned = clean_polluted_dispatch_ids(conn)
+    print(f"  Placeholder dispatch_ids cleaned: {cleaned}")
+
+    # Phase 2: Link sessions to dispatches (bidirectional join).
     linked_sessions = link_sessions_to_dispatches(conn)
     print(f"  Sessions linked to dispatches: {linked_sessions}")
 
+    # Phase 3: Link receipt outcomes to dispatches.
     linked_receipts = link_receipts_to_dispatches(conn)
     print(f"  Receipt outcomes linked: {linked_receipts}")
 
+    # Phase 4: Link report findings to dispatches.
     linked_reports = link_reports_to_dispatches(conn)
     print(f"  Report findings linked: {linked_reports}")
+
+    # Phase 5: Backfill receipt token_usage from session_analytics (OI-872 chain closure).
+    enriched = backfill_receipt_token_usage(conn)
+    print(f"  Receipts enriched with token_usage: {enriched}")
 
     conn.close()
     print("Done.")

--- a/tests/test_link_sessions_dispatches_cleanup.py
+++ b/tests/test_link_sessions_dispatches_cleanup.py
@@ -1,0 +1,411 @@
+"""test_link_sessions_dispatches_cleanup.py — Tests for OI-872 dispatch_id cleanup
+and receipt token_usage backfill in link_sessions_dispatches.py.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+# Ensure vnx_paths module can resolve; link_sessions_dispatches uses it at import.
+os.environ.setdefault("VNX_PROJECT_ID", "vnx-dev")
+
+
+def _init_db_schema(conn: sqlite3.Connection) -> None:
+    """Create minimal session_analytics and dispatch_metadata for tests."""
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS session_analytics (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            session_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            project_path TEXT NOT NULL,
+            terminal TEXT,
+            session_date DATE NOT NULL,
+            total_input_tokens INTEGER DEFAULT 0,
+            total_output_tokens INTEGER DEFAULT 0,
+            cache_creation_tokens INTEGER DEFAULT 0,
+            cache_read_tokens INTEGER DEFAULT 0,
+            dispatch_id TEXT
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS dispatch_metadata (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL UNIQUE,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            terminal TEXT NOT NULL,
+            track TEXT NOT NULL,
+            session_id TEXT
+        )
+    """)
+    conn.commit()
+
+
+class TestCleanPollutedDispatchIds:
+    """Tests for clean_polluted_dispatch_ids() — OI-872 fix 2."""
+
+    def test_nulls_exact_literal(self, tmp_path):
+        """Only the exact '<dispatch_id>' literal is NULLed."""
+        from link_sessions_dispatches import clean_polluted_dispatch_ids
+
+        db_path = tmp_path / "test_cleanup.db"
+        conn = sqlite3.connect(str(db_path))
+        _init_db_schema(conn)
+
+        # Insert rows: one polluted, one with real id, one already NULL.
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id)
+            VALUES
+                ('polluted', '/test', '2026-07-31', '<dispatch_id>'),
+                ('real',     '/test', '2026-07-31', '20260731-123456-real-id'),
+                ('nulled',   '/test', '2026-07-31', NULL)
+        """)
+        conn.commit()
+
+        cleaned = clean_polluted_dispatch_ids(conn)
+        assert cleaned == 1
+
+        # Verify only the polluted row was NULLed.
+        rows = conn.execute(
+            "SELECT session_id, dispatch_id FROM session_analytics ORDER BY session_id"
+        ).fetchall()
+        assert rows == [
+            ("nulled", None),
+            ("polluted", None),
+            ("real", "20260731-123456-real-id"),
+        ]
+        conn.close()
+
+    def test_idempotent(self, tmp_path):
+        """Running the cleanup twice changes nothing extra."""
+        from link_sessions_dispatches import clean_polluted_dispatch_ids
+
+        db_path = tmp_path / "test_idempotent.db"
+        conn = sqlite3.connect(str(db_path))
+        _init_db_schema(conn)
+
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id)
+            VALUES
+                ('a', '/test', '2026-07-31', '<dispatch_id>'),
+                ('b', '/test', '2026-07-31', '<dispatch_id>')
+        """)
+        conn.commit()
+
+        first = clean_polluted_dispatch_ids(conn)
+        assert first == 2
+
+        second = clean_polluted_dispatch_ids(conn)
+        assert second == 0
+
+        # Both still NULL.
+        rows = conn.execute(
+            "SELECT dispatch_id FROM session_analytics"
+        ).fetchall()
+        assert all(r[0] is None for r in rows)
+        conn.close()
+
+    def test_leaves_real_ids_untouched(self, tmp_path):
+        """Real dispatch IDs matching YYYYMMDD-* are never altered."""
+        from link_sessions_dispatches import clean_polluted_dispatch_ids
+
+        db_path = tmp_path / "test_real_ids.db"
+        conn = sqlite3.connect(str(db_path))
+        _init_db_schema(conn)
+
+        real_ids = [
+            "20260731-123456-my-feature",
+            "20260603-abcdef-fix-A",
+            "20260101-000000-bench-run",
+        ]
+        for i, did in enumerate(real_ids):
+            conn.execute(
+                "INSERT INTO session_analytics "
+                "(session_id, project_path, session_date, dispatch_id) "
+                "VALUES (?, '/test', '2026-07-31', ?)",
+                (f"real-{i}", did),
+            )
+        conn.commit()
+
+        cleaned = clean_polluted_dispatch_ids(conn)
+        assert cleaned == 0
+
+        rows = conn.execute(
+            "SELECT dispatch_id FROM session_analytics ORDER BY id"
+        ).fetchall()
+        assert [r[0] for r in rows] == real_ids
+        conn.close()
+
+
+class TestBackfillReceiptTokenUsage:
+    """Tests for backfill_receipt_token_usage() — OI-872 fix 3 (chain closure)."""
+
+    def _setup_db(self, tmp_path: Path) -> sqlite3.Connection:
+        db_path = tmp_path / "test_backfill.db"
+        conn = sqlite3.connect(str(db_path))
+        _init_db_schema(conn)
+        return conn
+
+    def _write_receipts(self, state_dir: Path, receipts: list[dict]) -> Path:
+        receipt_file = state_dir / "t0_receipts.ndjson"
+        receipt_file.parent.mkdir(parents=True, exist_ok=True)
+        with open(receipt_file, "w", encoding="utf-8") as f:
+            for r in receipts:
+                f.write(json.dumps(r, sort_keys=False) + "\n")
+        return receipt_file
+
+    def test_enriches_claude_receipt_with_null_token_usage(self, tmp_path, monkeypatch):
+        """A claude receipt with null token_usage gets populated from session_analytics."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens,
+                 cache_creation_tokens, cache_read_tokens)
+            VALUES ('sess-1', '/project', '2026-07-31', '20260731-123456-test',
+                    5000, 3200, 400, 1200)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-123456-test",
+                "provider": "claude",
+                "token_usage": None,
+                "status": "success",
+                "terminal_id": "T1",
+            },
+            {
+                "dispatch_id": "20260731-999999-other",
+                "provider": "kimi",
+                "token_usage": {"input": 100, "output": 50},
+                "status": "success",
+                "terminal_id": "T2",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 1
+
+        # Read back the rewritten file.
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+
+        assert len(lines) == 2
+
+        claude = lines[0]
+        assert claude["token_usage"] == {
+            "input": 5000,
+            "output": 3200,
+            "cache_creation_5m": 400,
+            "cache_creation_1h": 0,
+            "cache_read": 1200,
+        }
+
+        # Kimi receipt untouched.
+        kimi = lines[1]
+        assert kimi["token_usage"] == {"input": 100, "output": 50}
+        conn.close()
+
+    def test_enriches_claude_receipt_with_empty_unavailable(self, tmp_path, monkeypatch):
+        """A claude receipt with unavailable token_usage gets backfilled."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens)
+            VALUES ('sess-2', '/project', '2026-07-31', '20260731-999999-fill',
+                    8000, 4500)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-999999-fill",
+                "provider": "claude",
+                "token_usage": {"input": 0, "output": 0, "unavailable": True},
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 1
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["token_usage"] == {
+            "input": 8000, "output": 4500,
+            "cache_creation_5m": 0, "cache_creation_1h": 0, "cache_read": 0,
+        }
+        conn.close()
+
+    def test_skips_when_no_session_data(self, tmp_path, monkeypatch):
+        """A claude receipt with no match in session_analytics is left untouched."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        # No session_analytics row for this dispatch.
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-000000-nomatch",
+                "provider": "claude",
+                "token_usage": None,
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 0
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["token_usage"] is None
+        conn.close()
+
+    def test_skips_already_populated_receipts(self, tmp_path, monkeypatch):
+        """A claude receipt with real token_usage is not overwritten."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens)
+            VALUES ('sess-3', '/project', '2026-07-31', '20260731-123456-has',
+                    100, 200)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-123456-has",
+                "provider": "claude",
+                "token_usage": {"input": 9999, "output": 8888},
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 0
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        # Original token_usage preserved.
+        assert lines[0]["token_usage"] == {"input": 9999, "output": 8888}
+        conn.close()
+
+    def test_idempotent(self, tmp_path, monkeypatch):
+        """Running the backfill twice does not double-count or corrupt."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens)
+            VALUES ('sess-idem', '/project', '2026-07-31', '20260731-idempotent-test',
+                    100, 200)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-idempotent-test",
+                "provider": "claude",
+                "token_usage": None,
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        first = backfill_receipt_token_usage(conn)
+        assert first == 1
+
+        second = backfill_receipt_token_usage(conn)
+        assert second == 0  # Already populated — skipped.
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["token_usage"] == {
+            "input": 100, "output": 200,
+            "cache_creation_5m": 0, "cache_creation_1h": 0, "cache_read": 0,
+        }
+        assert len(lines) == 1  # No duplicate appended.
+        conn.close()
+
+    def test_preserves_non_claude_lines_verbatim(self, tmp_path, monkeypatch):
+        """Non-claude receipt lines pass through unchanged."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+
+        state_dir = tmp_path / "state"
+        kimi_original = {
+            "dispatch_id": "20260731-kimi-test",
+            "provider": "kimi",
+            "token_usage": {"input": 50, "output": 30, "other_field": "keep"},
+            "status": "success",
+        }
+        original = self._write_receipts(state_dir, [kimi_original])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 0
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0] == kimi_original
+        conn.close()

--- a/tests/test_session_parser_dispatch_id.py
+++ b/tests/test_session_parser_dispatch_id.py
@@ -1,0 +1,166 @@
+"""test_session_parser_dispatch_id.py — Unit tests for dispatch_id validation in SessionParser.
+
+Verifies the Cluster-B (OI-872) fix: the parser must reject template placeholders
+like <dispatch_id>, accept real dispatch IDs, and leave dispatch_id empty (None)
+when no reliable ID is found.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+# Add scripts/ to path so the conversation_analyzer package can be imported.
+SCRIPTS_DIR = Path(__file__).resolve().parents[1] / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+from conversation_analyzer.parser import SessionParser
+
+
+@pytest.fixture
+def parser():
+    return SessionParser()
+
+
+def _make_user_record(text: str) -> dict:
+    return {"type": "user", "message": {"content": text}}
+
+
+def _make_metrics():
+    from conversation_analyzer.models import SessionMetrics
+    return SessionMetrics()
+
+
+class TestValidateDispatchId:
+    """Tests for SessionParser._validate_dispatch_id — the validation gate."""
+
+    def test_null_for_empty_string(self):
+        """Empty string returns None."""
+        assert SessionParser._validate_dispatch_id("") is None
+
+    def test_null_for_whitespace_only(self):
+        """Whitespace-only string returns None."""
+        assert SessionParser._validate_dispatch_id("   ") is None
+
+    def test_null_for_none(self):
+        """None input returns None (fails open — caller handles it)."""
+        assert SessionParser._validate_dispatch_id(None) is None  # type: ignore[arg-type]
+
+    def test_rejects_placeholder_dispatch_id(self):
+        """The literal <dispatch_id> template placeholder is rejected."""
+        assert SessionParser._validate_dispatch_id("<dispatch_id>") is None
+
+    def test_rejects_placeholder_with_whitespace(self):
+        """<dispatch_id> with surrounding whitespace is rejected."""
+        assert SessionParser._validate_dispatch_id("  <dispatch_id>  ") is None
+
+    def test_rejects_any_angle_bracket_placeholder(self):
+        """Any <...> template placeholder is rejected."""
+        for placeholder in [
+            "<dispatch_id>",
+            "<your-dispatch-id>",
+            "<id>",
+            "<REPLACE_ME>",
+            "<TODO>",
+            "<placeholder>",
+        ]:
+            assert SessionParser._validate_dispatch_id(placeholder) is None, (
+                f"Expected {placeholder!r} to be rejected"
+            )
+
+    def test_rejects_free_form_text(self):
+        """Free-form text that is not a dispatch ID is rejected."""
+        assert SessionParser._validate_dispatch_id("a plain sentence") is None
+
+    def test_rejects_empty_angle_brackets(self):
+        """Empty angle brackets <> are rejected."""
+        assert SessionParser._validate_dispatch_id("<>") is None
+
+    def test_accepts_real_dispatch_id_date_prefix(self):
+        """A real dispatch ID starting with YYYYMMDD- is accepted."""
+        real_id = "20260731-clusterB-analyzer-dispatchid"
+        assert SessionParser._validate_dispatch_id(real_id) == real_id
+
+    def test_accepts_real_dispatch_id_with_time(self):
+        """A dispatch ID with full YYYYMMDD-HHMMSS- is accepted."""
+        real_id = "20260603-123456-feature-name-A"
+        assert SessionParser._validate_dispatch_id(real_id) == real_id
+
+    def test_accepts_with_surrounding_whitespace(self):
+        """Whitespace is stripped from a valid ID."""
+        assert SessionParser._validate_dispatch_id("  20260731-my-feature  ") == "20260731-my-feature"
+
+    def test_rejects_non_date_prefix(self):
+        """An otherwise plausible ID missing the date prefix is rejected."""
+        assert SessionParser._validate_dispatch_id("fix-dispatch-id-bug") is None
+
+    def test_rejects_partial_date(self):
+        """A partial date prefix (fewer than 8 digits) is rejected."""
+        assert SessionParser._validate_dispatch_id("2026073-broken") is None
+
+    def test_rejects_bench_id_missing_date_prefix(self):
+        """Bench IDs like bench-* lack a date prefix — correctly rejected as non-dispatch IDs."""
+        assert SessionParser._validate_dispatch_id(
+            "bench-claude-opus-4-7-05_extractor_subclass-r1-20260604-142018"
+        ) is None
+
+
+class TestProcessUserDispatchId:
+    """Integration-style tests: _process_user sets dispatch_id only for valid IDs."""
+
+    def test_no_dispatch_id_when_message_has_none(self, parser):
+        """dispatch_id remains empty when no dispatch table or header is present."""
+        metrics = _make_metrics()
+        record = _make_user_record("Just a regular user message.")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == ""
+
+    def test_null_for_placeholder_in_table(self, parser):
+        """<dispatch_id> in a dispatch table row is rejected — no ID stored."""
+        metrics = _make_metrics()
+        record = _make_user_record("| **Dispatch-ID** | <dispatch_id> |")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == ""
+
+    def test_null_for_placeholder_in_header(self, parser):
+        """<dispatch_id> in a Dispatch-ID header is rejected."""
+        metrics = _make_metrics()
+        record = _make_user_record("Dispatch-ID: <dispatch_id>")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == ""
+
+    def test_real_id_from_table(self, parser):
+        """A real dispatch ID in a table row is accepted."""
+        metrics = _make_metrics()
+        record = _make_user_record("| **Dispatch-ID** | 20260731-123456-my-feature |")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == "20260731-123456-my-feature"
+
+    def test_real_id_from_header(self, parser):
+        """A real dispatch ID in a Dispatch-ID header is accepted."""
+        metrics = _make_metrics()
+        record = _make_user_record("Dispatch-ID: 20260731-123456-my-feature")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == "20260731-123456-my-feature"
+
+    def test_only_first_three_messages_checked(self, parser):
+        """After 3 user messages, the parser stops looking for a dispatch ID."""
+        metrics = _make_metrics()
+        # First 3 have no dispatch ID
+        for _ in range(3):
+            parser._process_user(_make_user_record("regular message"), metrics)
+        # 4th message has a real ID but should be ignored
+        parser._process_user(
+            _make_user_record("| **Dispatch-ID** | 20260731-123456-real |"), metrics)
+        assert metrics.dispatch_id == ""
+
+    def test_first_id_wins(self, parser):
+        """The first valid dispatch ID found is kept; later ones are ignored."""
+        metrics = _make_metrics()
+        record1 = _make_user_record("| **Dispatch-ID** | 20260731-123456-first |")
+        record2 = _make_user_record("| **Dispatch-ID** | 20260731-123456-second |")
+        parser._process_user(record1, metrics)
+        parser._process_user(record2, metrics)
+        assert metrics.dispatch_id == "20260731-123456-first"


### PR DESCRIPTION
## Problem (OI-872)

`session_analytics.dispatch_id` stored the literal template placeholder `<dispatch_id>` instead of real dispatch IDs — 760 out of 1146 rows. Intelligence injections containing `<dispatch_id>` in template text matched the `DISPATCH_TABLE_RE` regex, and the parser stored the placeholder verbatim without validation.

Consequence: 94% of July claude dispatches report zero token usage in `t0_receipts.ndjson` despite complete token data existing in `session_analytics`. The join key was broken, so cost-driven routing was impossible.

## Changes

### 1. Fix the source — `parser.py`

Added `_validate_dispatch_id()` gate that:
- Rejects `<...>` template placeholders
- Requires `^\d{8}-` date-prefix (all real dispatch IDs start with YYYYMMDD-)
- Returns `None` for invalid values (stored as NULL, not a placeholder)

### 2. Clean up pollution — `link_sessions_dispatches.py`

- `clean_polluted_dispatch_ids()` — NULLs the exact literal `<dispatch_id>`, idempotent, leaves real IDs untouched
- `backfill_receipt_token_usage()` — backfills `token_usage` in claude receipts from `session_analytics` via the (now working) dispatch_id join. Atomic rewrite via tmp + os.replace.

### 3. Tests

- `tests/test_session_parser_dispatch_id.py` — 21 tests (validation gate + `_process_user` integration)
- `tests/test_link_sessions_dispatches_cleanup.py` — 9 tests (cleanup idempotency + backfill enrichment)

30 new tests, all green. Existing test suite unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)