### PR TITLE
fix(plan-gate): surface doc truncation in gate verdict + raise ARG_MAX-derived cap

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -91,16 +91,75 @@ _VERDICT_CONTRACT = (
 # The plan doc is untrusted input inlined into each panelist's instruction. Two guards:
 #  - a doc must not be able to inject its own verdict fence (verdict spoofing);
 #  - a doc must not blow argv past ARG_MAX when passed as --instruction.
-MAX_DOC_CHARS = 60000
+#
+# DEFAULT_MAX_DOC_CHARS derivation (OI-858-class visibility fix, 2026-07-31): the previous
+# 60_000 was a 10x-too-conservative guess. Measured on this platform (macOS):
+# `getconf ARG_MAX` = 1_048_576 bytes — the ceiling execve() enforces on the COMBINED argv +
+# inherited-environment size for the provider_dispatch.py subprocess this doc is inlined
+# into (the claude/tmux lane instead writes the doc to a temp file and never inlines it, so
+# this cap only bites the kimi/glm/deepseek/codex provider lanes). Budget:
+#   - this module's own wrapper text (rubric + verdict contract + track/report boilerplate)
+#     measures ~1.2k chars around the doc body — negligible;
+#   - the subprocess's inherited environment measured ~3.7KB on this dev machine; budgeted
+#     here at a generous 150_000 bytes so the cap stays safe on much heavier CI/dev
+#     environments too;
+#   - the remaining ~898_000-byte margin is divided by 2 (not 1) bytes/char as a safety
+#     factor for non-ASCII plan-doc content (typographic quotes, em-dashes, arrows), which
+#     costs more than 1 byte/char in UTF-8, rather than assuming pure-ASCII.
+# That yields ~449k chars of headroom; DEFAULT_MAX_DOC_CHARS is set to a round 400_000 —
+# 6.7x the previous cap, comfortably inside the computed margin even under the pessimistic
+# 2-bytes/char assumption (400_000 * 2 = 800_000 doc bytes + 150_000 overhead = 950_000,
+# still ~98KB under ARG_MAX). Overridable via VNX_PLAN_GATE_MAX_DOC_CHARS (same pattern as
+# VNX_PANEL_RETRY) for an exceptional oversized plan.
+DEFAULT_MAX_DOC_CHARS = 400_000
+MAX_DOC_CHARS = DEFAULT_MAX_DOC_CHARS  # the no-override default; effective cap is _max_doc_chars()
+
+
+def _max_doc_chars() -> int:
+    """Effective plan-doc truncation cap: ``VNX_PLAN_GATE_MAX_DOC_CHARS`` override, default
+    ``DEFAULT_MAX_DOC_CHARS``. A malformed or non-positive value falls back to the default —
+    same override pattern as ``_panel_retry_count``."""
+    raw = os.environ.get("VNX_PLAN_GATE_MAX_DOC_CHARS", "").strip()
+    if not raw:
+        return DEFAULT_MAX_DOC_CHARS
+    try:
+        value = int(raw)
+    except ValueError:
+        return DEFAULT_MAX_DOC_CHARS
+    return value if value > 0 else DEFAULT_MAX_DOC_CHARS
 
 
 def _sanitize_doc(doc_text: str) -> str:
     # Neutralize any embedded verdict fence so a plan doc cannot spoof a PASS: a space
     # after the backticks breaks the exact ```vnx-plan-verdict opener parse_verdict matches.
     safe = doc_text.replace("```" + VERDICT_FENCE, "``` " + VERDICT_FENCE + " (neutralized)")
-    if len(safe) > MAX_DOC_CHARS:
-        safe = safe[:MAX_DOC_CHARS] + f"\n\n[... plan doc truncated at {MAX_DOC_CHARS} chars for the gate ...]"
+    limit = _max_doc_chars()
+    if len(safe) > limit:
+        safe = safe[:limit] + f"\n\n[... plan doc truncated at {limit} chars for the gate ...]"
     return safe
+
+
+def _doc_truncation_info(doc_text: str) -> Dict[str, Any]:
+    """Whether ``_sanitize_doc`` will truncate this doc when inlined into a panelist
+    instruction, and by how much.
+
+    Mirrors ``_sanitize_doc``'s length check EXACTLY (same verdict-fence neutralization,
+    same effective cap) so the info reported here can never drift from what actually gets
+    truncated. This is the fix for the silent-partial-read defect: a gate that only reads
+    part of its input must say so in the verdict it hands back, not just in the panelist's
+    own prompt — see ``run_panel``, which attaches this to the top-level result and folds a
+    note into the summary rationale whenever ``truncated`` is True.
+    """
+    safe = doc_text.replace("```" + VERDICT_FENCE, "``` " + VERDICT_FENCE + " (neutralized)")
+    limit = _max_doc_chars()
+    original_chars = len(safe)
+    truncated = original_chars > limit
+    return {
+        "truncated": truncated,
+        "original_chars": original_chars,
+        "kept_chars": min(original_chars, limit),
+        "limit_chars": limit,
+    }
 
 
 _RUBRIC = (
@@ -637,6 +696,7 @@ def run_panel(
     panel = panel or DEFAULT_PANEL
     dispatcher = dispatcher or _make_default_dispatcher(data_dir, timeout_seconds)
     doc_text = Path(doc_path).read_text(encoding="utf-8")
+    doc_truncation = _doc_truncation_info(doc_text)
     instruction = build_plan_review_instruction(doc_text, track_id)
 
     retries = _panel_retry_count()
@@ -657,10 +717,27 @@ def run_panel(
         results.append(result)
 
     summary = apply_panel_rule(results)
+    if doc_truncation["truncated"]:
+        # The gate must never certify a verdict while silently hiding that it only read
+        # PART of the plan — fold an explicit, quantified note into the rationale (the one
+        # field every consumer — CLI text, --json, callers reading result["summary"]) already
+        # surfaces, alongside the structured detail below for a caller that wants the exact
+        # counts.
+        pct = 100.0 * doc_truncation["kept_chars"] / doc_truncation["original_chars"]
+        summary = {
+            **summary,
+            "rationale": (
+                summary["rationale"]
+                + f"; PLAN DOC TRUNCATED: gate read {doc_truncation['kept_chars']} of "
+                f"{doc_truncation['original_chars']} chars ({pct:.1f}%) — verdict may be "
+                "based on an incomplete plan"
+            ),
+        }
     return {
         "track_id": track_id,
         "project_id": project_id,
         "decision": summary["decision"],
         "summary": summary,
         "panelists": [r.__dict__ for r in results],
+        "doc_truncation": doc_truncation,
     }

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2096,6 +2096,14 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
             f"Plan gate: {result['decision']}  "
             f"({s['pass_count']} pass / {s['revise_count']} revise / {s['block_count']} block)"
         )
+        trunc = result.get("doc_truncation") or {}
+        if trunc.get("truncated"):
+            pct = 100.0 * trunc["kept_chars"] / trunc["original_chars"]
+            print(
+                f"  ** PLAN DOC TRUNCATED: gate read {trunc['kept_chars']} of "
+                f"{trunc['original_chars']} chars ({pct:.1f}%) — this verdict may be based "
+                "on an incomplete plan **"
+            )
         print(f"  {s['rationale']}")
         for p in result["panelists"]:
             mark = p["verdict"].upper() if p["dispatched"] else "NO-VERDICT"

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -645,6 +645,100 @@ def test_sanitize_doc_caps_huge_doc():
     assert "truncated" in out
 
 
+# --------------------------------------------------------------------------
+# doc-truncation VISIBILITY (a gate that reads only part of its input must say
+# so in the verdict, not just in the panelist's own prompt) + the raised,
+# platform-measured ARG_MAX-derived cap, with an env override.
+# --------------------------------------------------------------------------
+
+def test_max_doc_chars_default_is_400k(monkeypatch):
+    monkeypatch.delenv("VNX_PLAN_GATE_MAX_DOC_CHARS", raising=False)
+    assert pgp._max_doc_chars() == 400_000 == pgp.DEFAULT_MAX_DOC_CHARS
+
+
+def test_max_doc_chars_honors_env_override(monkeypatch):
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "12345")
+    assert pgp._max_doc_chars() == 12345
+
+
+def test_max_doc_chars_malformed_or_non_positive_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "not-a-number")
+    assert pgp._max_doc_chars() == pgp.DEFAULT_MAX_DOC_CHARS
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "0")
+    assert pgp._max_doc_chars() == pgp.DEFAULT_MAX_DOC_CHARS
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "-1")
+    assert pgp._max_doc_chars() == pgp.DEFAULT_MAX_DOC_CHARS
+
+
+def test_doc_truncation_info_reports_no_truncation_for_small_doc(monkeypatch):
+    monkeypatch.delenv("VNX_PLAN_GATE_MAX_DOC_CHARS", raising=False)
+    small = "## Problem\n## Approach\n"
+    info = pgp._doc_truncation_info(small)
+    assert info == {
+        "truncated": False,
+        "original_chars": len(small),
+        "kept_chars": len(small),
+        "limit_chars": pgp.DEFAULT_MAX_DOC_CHARS,
+    }
+
+
+def test_doc_truncation_info_reports_exact_counts_when_truncated(monkeypatch):
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "100")
+    doc = "y" * 250
+    info = pgp._doc_truncation_info(doc)
+    assert info == {
+        "truncated": True,
+        "original_chars": 250,
+        "kept_chars": 100,
+        "limit_chars": 100,
+    }
+
+
+def test_run_panel_surfaces_doc_truncation_in_result_and_rationale(tmp_path, monkeypatch):
+    """The core visibility fix: a truncated doc must show up in the RESULT the operator
+    reads (top-level ``doc_truncation`` key, for --json and any programmatic caller) AND
+    in the human-readable summary rationale (so a truncation can never be missed just by
+    reading the one-line verdict) — never silently only in the panelist's own prompt."""
+    monkeypatch.setenv("VNX_PLAN_GATE_MAX_DOC_CHARS", "200")
+    doc = tmp_path / "plan.md"
+    doc.write_text("z" * 500, encoding="utf-8")
+
+    out = pgp.run_panel(
+        doc,
+        track_id="feat-trunc",
+        project_id="p1",
+        panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+        dispatcher=lambda provider, model_arg, instruction, dispatch_id: _make_report_with_fence("pass"),
+    )
+
+    assert out["doc_truncation"] == {
+        "truncated": True,
+        "original_chars": 500,
+        "kept_chars": 200,
+        "limit_chars": 200,
+    }
+    assert "PLAN DOC TRUNCATED" in out["summary"]["rationale"]
+    assert "200 of 500 chars" in out["summary"]["rationale"]
+    # the decision itself is untouched by truncation-visibility — only the disclosure is added
+    assert out["decision"] == "PASS"
+
+
+def test_run_panel_no_truncation_note_when_doc_fits(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_PLAN_GATE_MAX_DOC_CHARS", raising=False)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+
+    out = pgp.run_panel(
+        doc,
+        track_id="feat-fits",
+        project_id="p1",
+        panel=[{"label": "opus", "provider": "claude", "model_arg": "opus"}],
+        dispatcher=lambda provider, model_arg, instruction, dispatch_id: _make_report_with_fence("pass"),
+    )
+    assert out["doc_truncation"]["truncated"] is False
+    assert "TRUNCATED" not in out["summary"]["rationale"]
+
+
 def test_rule_empty_panel_is_not_pass():
     # a misconfigured empty panel must never fall through to PASS (kimi finding 8)
     d = pgp.apply_panel_rule([])


### PR DESCRIPTION
## Summary

The plan-gate panel (`scripts/lib/plan_gate_panel.py`) truncates plan docs over `MAX_DOC_CHARS` before inlining them into a panelist's instruction. The panelist's own prompt gets a `[... plan doc truncated at N chars for the gate ...]` marker, but the gate's own verdict — the summary line the operator actually reads, and the `--json` result — never mentioned it. In the reported Mission Control incident, a 95,967-char plan was truncated to 62.5% for every lane across four gate rounds; two of four findings in the final round were artifacts of sections that had fallen outside the window (including the ADR-007 section), and only one of the four lanes even noticed the truncation itself.

Two independent fixes, in the order of importance given in the dispatch:

**1. Visibility (the real defect).** `run_panel()` now computes truncation info once (`_doc_truncation_info`) and:
- attaches it as a top-level `doc_truncation` key on the returned result (`{"truncated", "original_chars", "kept_chars", "limit_chars"}`) — visible in `--json` output and to any programmatic caller,
- folds an explicit `"PLAN DOC TRUNCATED: gate read N of M chars (X%) — verdict may be based on an incomplete plan"` note into `summary["rationale"]`.

`cmd_plan_gate_run` also prints this as its own line directly under the decision in human-readable mode, so it can't be missed by only reading the one-line verdict. The pass/fail rule (`apply_panel_rule`) is untouched — this is a disclosure fix, not a new gating rule.

**2. The threshold.** `MAX_DOC_CHARS` raised from `60_000` to `400_000`, overridable via `VNX_PLAN_GATE_MAX_DOC_CHARS` (same override pattern as the existing `VNX_PANEL_RETRY`). Measured on this platform: `getconf ARG_MAX` = `1_048_576` bytes. Full derivation is documented at the constant in `plan_gate_panel.py` — budgets for this module's own wrapper text (~1.2k chars), the subprocess's inherited environment (measured ~3.7KB here, budgeted generously at 150_000 bytes for heavier CI/dev environments), and a pessimistic 2-bytes/char safety factor for non-ASCII content, still leaving ~98KB of headroom under `ARG_MAX`.

The second guard in `_sanitize_doc` (verdict-fence neutralization, anti-spoofing) is untouched.

## Changes

- `scripts/lib/plan_gate_panel.py`:
  - `MAX_DOC_CHARS` → `DEFAULT_MAX_DOC_CHARS = 400_000` (kept `MAX_DOC_CHARS` as the no-override default for existing test/reference compatibility)
  - new `_max_doc_chars()` — reads `VNX_PLAN_GATE_MAX_DOC_CHARS`, same fallback pattern as `_panel_retry_count()`
  - `_sanitize_doc()` now reads the cap via `_max_doc_chars()` instead of the frozen constant
  - new `_doc_truncation_info()` — mirrors `_sanitize_doc`'s exact length check, returns truncation counts
  - `run_panel()` — computes `doc_truncation`, folds a note into `summary["rationale"]` when truncated, returns `doc_truncation` at the top level of the result
- `scripts/planning_cli.py`: `cmd_plan_gate_run` prints the truncation line in human-readable mode
- `tests/test_plan_gate_panel.py`: extended `test_sanitize_doc_caps_huge_doc` context with new tests for `_max_doc_chars()` (default/override/malformed), `_doc_truncation_info()` (untruncated/truncated exact counts), and `run_panel()` surfacing truncation in both the top-level result and the rationale (plus a negative test confirming no truncation note when the doc fits)

## Verification

```
python3 -m pytest tests/test_plan_gate_panel.py -v
```
74 passed in 0.44s (up from the original test count; all pre-existing tests pass unchanged, 7 new tests added for the visibility fix + threshold override).

Also ran, to confirm no regressions in adjacent suites (all pass, and the same pre-existing 18 failures in `test_horizon_parity.py`/`test_planning_cli_objective.py` reproduce identically on `main` without this change — confirmed via `git stash`):
```
python3 -m pytest tests/test_dispatch_sidedoor_audit.py tests/test_plan_gate_effectiveness_probe.py tests/test_runtime_adapter_certification.py tests/test_glm_harness_normalization.py -q
```
62 passed in 3.46s.

`python3 -c "import ast; ast.parse(...)"` syntax check passed on both modified `.py` files.

## Open Items

None.

Dispatch-ID: D-2e099f11