### PR TITLE
fix(dispatch): door writes dispatches row on acceptance (OI-847)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -16,6 +16,7 @@ import json
 import logging
 import os
 import sys
+from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import Optional
 
@@ -565,17 +566,103 @@ def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optiona
     )
 
 
+def _persist_dispatch_row(spec: DispatchSpec, *, state_dir: Path) -> None:
+    """Best-effort: create the dispatches tracker row for a door-accepted dispatch.
+
+    The door is the single entry point for dispatches, yet historically never
+    wrote a row to dispatches (runtime_coordination.db) — only the deliverable
+    layer (planning_cli.py, `dlv-` ids) did. Three consumers read this table for
+    door dispatches and all silently no-op without a row:
+
+    1. ``_persist_track_id`` (UPDATE-only) — track linkage, symptom TL-D1;
+    2. ``dispatch_outcome_classifier.reconcile_all_dispatch_outcomes`` — reads
+       the dispatch-id population plus ``state``/``track``/``created_at`` here;
+    3. ``receipt_provenance._link_pr_to_track`` — reads ``track_id`` by
+       ``dispatch_id`` for the TL-D2 tracks.pr_ref auto-propagation on merge.
+
+    Called from run_dispatch AFTER validation + plan compile and BEFORE the lane
+    choice, so rejected dispatches never get a row and in-flight dispatches are
+    visible to live queries.
+
+    ``state='proposed'`` deliberately: 'queued' would be claimed by the worker
+    pool (its claim query keys on state='queued') and, without a staged pool
+    bundle, rot into timed_out/expired via the stuck sweep; the supervisor's
+    stuck/ghost sweeps key on claimed/delivering/accepted/running. 'proposed'
+    is invisible to all of those — the same state the deliverable layer uses.
+
+    Idempotent per ADR-007's composite UNIQUE(dispatch_id, project_id): a retry
+    or fix-forward with the same id finds the existing row and leaves it
+    untouched. Never raises: tracker bookkeeping must never block the door.
+    """
+    db_path = _tracks_db_path(state_dir)
+    if not db_path.exists():
+        return
+    import sqlite3 as _sqlite3
+    try:
+        conn = _sqlite3.connect(str(db_path), timeout=10.0)
+        try:
+            if conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'dispatches'"
+            ).fetchone() is None:
+                return
+            has_project = _has_col(conn, "dispatches", "project_id")
+            track_id = (spec.track_id or "").strip()
+            if track_id and not _has_col(conn, "dispatches", "track_id"):
+                conn.execute("ALTER TABLE dispatches ADD COLUMN track_id TEXT")
+                conn.commit()
+            # Idempotency: an existing row (retry / fix-forward / deliverable
+            # layer) is left untouched — never a second row, never a mutation.
+            if has_project:
+                existing = conn.execute(
+                    "SELECT 1 FROM dispatches WHERE dispatch_id = ? AND project_id = ?",
+                    (spec.dispatch_id, spec.project_id),
+                ).fetchone()
+            else:
+                existing = conn.execute(
+                    "SELECT 1 FROM dispatches WHERE dispatch_id = ?",
+                    (spec.dispatch_id,),
+                ).fetchone()
+            if existing is not None:
+                return
+            cols = ["dispatch_id"]
+            vals = [spec.dispatch_id]
+            if has_project:
+                cols.append("project_id")
+                vals.append(spec.project_id)
+            cols.append("state")
+            vals.append("proposed")
+            if track_id:
+                cols.append("track_id")
+                vals.append(track_id)
+            now = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
+                "+00:00", "Z"
+            )
+            for ts_col in ("created_at", "updated_at"):
+                if _has_col(conn, "dispatches", ts_col):
+                    cols.append(ts_col)
+                    vals.append(now)
+            placeholders = ", ".join("?" for _ in cols)
+            conn.execute(
+                f"INSERT INTO dispatches ({', '.join(cols)}) VALUES ({placeholders})",
+                vals,
+            )
+            conn.commit()
+        finally:
+            conn.close()
+    except Exception as exc:
+        logger.debug("[dispatch_cli] dispatch row persist skipped: %s", exc)
+
+
 def _persist_track_id(spec: DispatchSpec, *, state_dir: Path) -> None:
     """Best-effort: attach spec.track_id to an EXISTING dispatches row (UPDATE-only).
 
-    Never INSERTs. The dispatches table (runtime_coordination.db) is read by the
-    worker-pool claim query, the runtime reconciler, and the runtime supervisor's
-    stuck/ghost-dispatch sweeps, all keyed off `state`. Fabricating a row for the
-    leaseless claude-tmux lane (which has no pre-existing tracker row) risks
-    tripping those sweeps. D2 treats an absent/None track_id as a no-op, so a
-    dispatch with no pre-existing row is a safe, anticipated case here, not a
-    partial failure. Adds the track_id column additively (_has_col-guarded) when
-    missing. Never raises.
+    Never INSERTs — row creation is the door's job (``_persist_dispatch_row``,
+    invoked earlier in run_dispatch, right after validation + plan compile).
+    When that row exists this UPDATE stamps the track_id onto it; D2 treats an
+    absent/None track_id as a no-op, so a dispatch whose row could not be
+    created (e.g. no runtime_coordination.db yet) is a safe, anticipated case
+    here, not a partial failure. Adds the track_id column additively
+    (_has_col-guarded) when missing. Never raises.
     """
     track_id = (spec.track_id or "").strip()
     if not track_id:
@@ -1076,6 +1163,14 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                 )
             except Exception as exc:
                 logger.debug("[dispatch_cli] scout pre-pass skipped: %s", exc)
+
+            # The dispatch is irrevocably accepted here (validated, plan
+            # compiled): create its dispatches tracker row BEFORE the lane
+            # choice so _persist_track_id, reconcile_all_dispatch_outcomes and
+            # the TL-D2 pr_ref propagation all have a row to read. Idempotent
+            # (retry/fix-forward safe), state='proposed' (invisible to the
+            # claim/stuck/ghost sweeps), best-effort — never blocks the door.
+            _persist_dispatch_row(vspec.spec, state_dir=state_dir)
 
             # TL-D1: export the resolved track_id alongside VNX_CURRENT_DISPATCH_ID and
             # persist it onto the dispatch tracker row so D2 can propagate it to

--- a/tests/test_dispatch_door_row.py
+++ b/tests/test_dispatch_door_row.py
@@ -1,0 +1,280 @@
+"""test_dispatch_door_row.py — OI-847: the door writes a dispatches row.
+
+Root cause under test: the single-entry dispatch door (dispatch_cli.run_dispatch)
+never INSERTed a row into dispatches (runtime_coordination.db) — only the
+deliverable layer (planning_cli.py, `dlv-` ids) did. That one missing write
+starved three consumers:
+
+1. ``_persist_track_id`` (UPDATE-only) — its UPDATE hit zero rows (symptom 1);
+2. ``reconcile_all_dispatch_outcomes`` — empty dispatch-id population, so
+   "nothing to reconcile" looked identical to "everything reconciled";
+3. TL-D2 ``receipt_provenance._link_pr_to_track`` — no track_id row to read,
+   so tracks.pr_ref auto-propagation on merge never fired.
+
+Every test in this file is RED on origin/main (no row is ever created there)
+and GREEN on the fix branch. Tests run against a throwaway DB under tmp_path —
+never the live central store.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import _persist_track_id, load_spec, run_dispatch
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+def _make_coordination_db(state_dir: Path, *, tracks: "dict[str, str] | None" = None) -> Path:
+    """Minimal runtime_coordination.db mirroring the v10 dispatches schema.
+
+    Composite UNIQUE(dispatch_id, project_id) per ADR-007; created_at /
+    updated_at present so the door's row carries timestamps the outcome
+    classifier's age computation can parse. No track_id column on purpose:
+    the door must add it additively (_has_col-guarded), as _persist_track_id
+    already does.
+    """
+    state_dir.mkdir(parents=True, exist_ok=True)
+    db_path = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev',
+            state TEXT NOT NULL DEFAULT 'queued',
+            track TEXT,
+            priority TEXT DEFAULT 'P2',
+            created_at TEXT,
+            updated_at TEXT,
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE tracks (
+            track_id TEXT NOT NULL PRIMARY KEY,
+            phase TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev'
+        )
+        """
+    )
+    for tid, phase in (tracks or {}).items():
+        conn.execute(
+            "INSERT INTO tracks (track_id, phase, project_id) VALUES (?, ?, 'vnx-dev')",
+            (tid, phase),
+        )
+    conn.commit()
+    conn.close()
+    return db_path
+
+
+def _make_bundle(
+    tmp_path: Path,
+    *,
+    staging_id: str,
+    dispatch_id: str,
+    track_id: "str | None" = "oi-847-track",
+    schema_version: int = 1,
+) -> "tuple[Path, Path]":
+    """A promoted-style staged bundle (spec + instruction inside the bundle dir).
+
+    Returns (data_dir, spec_file).
+    """
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    instruction = bundle_dir / "instruction.md"
+    instruction.write_text("Do something useful.", encoding="utf-8")
+    spec = {
+        "schema_version": schema_version,
+        "project_id": "vnx-dev",
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(instruction),
+        "role": "backend-developer",
+        "target_slot": "T0",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    if track_id is not None:
+        spec["track_id"] = track_id
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+def _read_row(db_path: Path, dispatch_id: str):
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT * FROM dispatches WHERE dispatch_id = ?", (dispatch_id,)
+    ).fetchone()
+    conn.close()
+    return row
+
+
+def _row_count(db_path: Path) -> int:
+    conn = sqlite3.connect(str(db_path))
+    count = conn.execute("SELECT COUNT(*) FROM dispatches").fetchone()[0]
+    conn.close()
+    return count
+
+
+# ---------------------------------------------------------------------------
+# 1. A dispatch through the door yields a row with the columns the three
+#    consumers read (dispatch_id, project_id, state, track_id, created_at).
+# ---------------------------------------------------------------------------
+
+def test_door_creates_dispatch_row(tmp_path, monkeypatch):
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi847-row",
+        dispatch_id="20260731-oi847-row-created",
+    )
+    db_path = _make_coordination_db(
+        data_dir / "state", tracks={"oi-847-track": "active"}
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    row = _read_row(db_path, "20260731-oi847-row-created")
+    assert row is not None, "door must create a dispatches row for an accepted dispatch"
+    assert row["project_id"] == "vnx-dev"
+    # 'proposed': visible to live queries, invisible to claim/stuck/ghost sweeps
+    assert row["state"] == "proposed"
+    # symptom 1 consumer: the track_id column _persist_track_id / D2 read
+    assert row["track_id"] == "oi-847-track"
+    # symptom 2 consumer: created_at feeds the classifier's age computation
+    assert row["created_at"]
+
+
+# ---------------------------------------------------------------------------
+# 2. Symptom 1 DoD: after the door ran, _persist_track_id's UPDATE actually
+#    hits a row (on main it updated zero rows — a silent no-op).
+# ---------------------------------------------------------------------------
+
+def test_persist_track_id_hits_row_after_door(tmp_path, monkeypatch):
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi847-tl",
+        dispatch_id="20260731-oi847-track-link",
+    )
+    db_path = _make_coordination_db(
+        data_dir / "state", tracks={"oi-847-track": "active"}
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+    assert rc == 0
+
+    # Blank the column, then prove _persist_track_id's UPDATE lands on a row.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute(
+        "UPDATE dispatches SET track_id = NULL WHERE dispatch_id = ?",
+        ("20260731-oi847-track-link",),
+    )
+    conn.commit()
+    conn.close()
+
+    spec = load_spec(spec_file)
+    _persist_track_id(spec, state_dir=data_dir / "state")
+
+    row = _read_row(db_path, "20260731-oi847-track-link")
+    assert row is not None, "no dispatches row — _persist_track_id updated zero rows"
+    assert row["track_id"] == "oi-847-track", (
+        "_persist_track_id must stamp track_id onto the door-created row"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotency: the same dispatch through the door twice (retry /
+#    fix-forward) creates no second row and leaves the first untouched.
+# ---------------------------------------------------------------------------
+
+def test_retry_is_idempotent(tmp_path, monkeypatch):
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi847-retry",
+        dispatch_id="20260731-oi847-retry",
+    )
+    db_path = _make_coordination_db(
+        data_dir / "state", tracks={"oi-847-track": "active"}
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        assert run_dispatch(spec_file) == 0
+    first = _read_row(db_path, "20260731-oi847-retry")
+    assert first is not None
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        assert run_dispatch(spec_file) == 0
+
+    assert _row_count(db_path) == 1, "retry must not create a second dispatches row"
+    second = _read_row(db_path, "20260731-oi847-retry")
+    assert dict(second) == dict(first), "retry must leave the first row untouched"
+
+
+# ---------------------------------------------------------------------------
+# 4. A rejected dispatch yields NO row; an accepted one yields exactly its own.
+# ---------------------------------------------------------------------------
+
+def test_rejected_dispatch_creates_no_row(tmp_path, monkeypatch):
+    db_path = _make_coordination_db(
+        tmp_path / "vnx-data" / "state", tracks={"oi-847-track": "active"}
+    )
+
+    # Rejected: schema_version=99 fails validate() before any acceptance.
+    data_dir, bad_spec = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi847-reject",
+        dispatch_id="20260731-oi847-rejected",
+        schema_version=99,
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0) as mock_execute:
+        rc = run_dispatch(bad_spec)
+    assert rc == 1
+    mock_execute.assert_not_called()
+
+    # Accepted: same store, valid spec.
+    _, good_spec = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi847-accept",
+        dispatch_id="20260731-oi847-accepted",
+    )
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(good_spec)
+    assert rc == 0
+
+    assert _row_count(db_path) == 1, (
+        "exactly one row: the accepted dispatch's; the rejected one must add none"
+    )
+    assert _read_row(db_path, "20260731-oi847-rejected") is None
+    assert _read_row(db_path, "20260731-oi847-accepted") is not None


### PR DESCRIPTION
## OI-847 — de deur schrijft geen rij: gedeelde wortel onder drie symptomen

**Wortel, niet de takken:** de single-entry door (`dispatch_cli.run_dispatch`) maakte nooit een rij aan in `dispatches` (runtime_coordination.db). De enige schrijver was de deliverable-laag (`planning_cli.py`, `dlv-`-prefix — 35 rijen, nieuwste 2026-07-16, 0 rijen met datumprefix). Die ene ontbrekende write verklaart drie los gefilede defecten:

1. **Track-linkage** — `_persist_track_id` is bewust UPDATE-only; zonder rij raakt de UPDATE nul rijen.
2. **`dispatch_outcomes`** — `reconcile_all_dispatch_outcomes` leest de dispatch-id-set uit dezelfde tabel; lege set ≡ "alles gereconcilieerd".
3. **Provenance-PR-koppeling** — TL-D2 `_link_pr_to_track` leest `track_id` per `dispatch_id`; geen rij → propagatie naar `tracks.pr_ref` vuurt nooit.

## Wat er gebouwd is

**1. Insert-punt** (`scripts/lib/dispatch_cli.py`, `run_dispatch`): ná `validate()` + `compile_plan()` (de dispatch is onherroepelijk geaccepteerd), vóór de lane-keuze — en vóór `_persist_track_id`, zodat diens UPDATE in de productie-flow nu een rij raakt. Afgewezen dispatches (validate/compile Reject) returnen eerder → geen rij. Dry-run schrijft niets.

**2. Kolommen** — alleen wat de drie consumenten lezen: `dispatch_id`, `project_id`, `state`, `track_id` (additieve `_has_col`-guardeerde ALTER, bestaand patroon), `created_at`/`updated_at`.
   - `state='proposed'`: de claim-query van de worker-pool pakt alleen `'queued'` (een `'queued'`-rij zonder gestage pool-bundle zou geclaimd worden en wegrotten naar `timed_out`/`expired` via de stuck-sweep); stuck- en ghost-sweeps keyen op `claimed/delivering/accepted/running`. `'proposed'` is voor al die sweeps onzichtbaar — dezelfde staat als de `dlv-`-rijen. Wel zichtbaar voor live-vragen en de outcome-classifier-populatie.
   - `track`-kolom bewust **niet** gezet: `track_reconciler` keyt daarop voor `derived_status`; de D1/D2-consumenten gebruiken de `track_id`-kolom. Minimaal = geen track-status-side-effects.

**3. Idempotentie** — SELECT-dan-INSERT onder de bestaande composite `UNIQUE(dispatch_id, project_id)`: retry/fix-forward vindt de bestaande rij en laat hem ongemoeid (geen tweede rij, geen mutatie). Best-effort, never-raises (spiegelt `_persist_track_id`): bookkeeping blokkeert de deur nooit.

**ADR-007:** de bestaande sleutel voldoet — composite `UNIQUE(dispatch_id, project_id)` (schemas/runtime_coordination_v10.sql, migratie 0017); de INSERT stamt `project_id`. ⚠️ Gerapporteerd, niet stilzwijgend omheen gewerkt: `receipt_provenance._link_pr_to_track` leest per `dispatch_id` **zonder** project-filter — een cross-tenant id-collision resolveert daar een willekeurige rij. Pre-existing, geen verslechtering door deze wijziging.

De 35 `dlv-`-rijen zijn onaangeroerd; de deliverable-laag blijft zijn eigen rijen schrijven.

## Verificatie — rood op main, groen op branch

`tests/test_dispatch_door_row.py` (4 tests, tijdelijke DB onder tmp_path — nooit de live store):

| test | origin/main (d9492849) | deze branch |
|---|---|---|
| `test_door_creates_dispatch_row` — rij met de kolommen die de 3 consumenten lezen | ❌ FAIL (geen rij) | ✅ |
| `test_persist_track_id_hits_row_after_door` — DoD symptoom 1 | ❌ FAIL (UPDATE raakt 0 rijen) | ✅ |
| `test_retry_is_idempotent` — geen tweede rij, eerste onbeschadigd | ❌ FAIL | ✅ |
| `test_rejected_dispatch_creates_no_row` — afgewezen → géén rij, geaccepteerd → exact 1 | ❌ FAIL (count 0 ≠ 1) | ✅ |

Uitvoer (exit-codes expliciet, geen pipes op de run):

```
# origin/main (tijdelijke worktree op d9492849):
python -m pytest tests/test_dispatch_door_row.py > /tmp/oi847_main.txt 2>&1; echo "exit=$?"
→ exit=1   (4 failed)

# deze branch:
python -m pytest tests/test_dispatch_door_row.py > /tmp/oi847_branch.txt 2>&1; echo "exit=$?"
→ exit=0   (4 passed)
```

Regressie: `tests/test_dispatch_cli.py` + `tests/test_dispatch_outcome_classifier.py` + `tests/dispatch/` + `tests/test_provider_dispatch_entry.py` + `tests/test_dispatch_enforcement.py` → **239 passed**, exit=0.