### PR TITLE
feat(monitor): producer-freshness monitor — stil falen binnen een dag zichtbaar

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -79,6 +79,26 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/path_parity_check.sh\"'",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/hooks/monitor_tripwire.sh\"'",
+            "timeout": 5000
+          }
+        ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
             "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/hooks/sessionstart.sh\"'",
             "timeout": 5000
           }

--- a/configs/producer_freshness.yaml
+++ b/configs/producer_freshness.yaml
@@ -1,0 +1,75 @@
+# Producer freshness registry — per-key cadence contract for every silent-failure-
+# prone producer in the VNX fabric.
+#
+# The monitor (scripts/producer_freshness_monitor.py) groups activity by each
+# producer's OWN key, never by table/directory level. A table can look alive
+# while individual keys are dead:
+#   - governance_metrics: dispatch_count/mean_cqs write daily while fpy and
+#     rework_rate have been dead since 2026-06-16.
+#   - dispatches: 35 rows, all from the dlv- producer; the dispatch door has
+#     not written since 2026-07-16.
+#   - review_gates: zero requests since 2026-07-25, zero results since
+#     2026-07-28, while dispatches with gate=codex_gate kept flowing.
+#
+# Placeholders expanded at load time: {state_dir}, {data_dir}, {project_id}.
+#
+# cadence_seconds: the maximum silence a key may have before it is reported.
+# The track goal is "silent failure visible within a day" for daily producers.
+version: 1
+
+producers:
+  # --- Review-gate layer (the 2026-07-31 incident) -------------------------
+  # Filenames: pr-<number>-<gate>.json; the gate name is the producer key.
+  - name: review_gate_requests
+    type: directory
+    path: "{state_dir}/review_gates/requests"
+    glob: "*.json"
+    key_regex: '^pr-[0-9]+-(?P<key>.+)\.json$'
+    timestamp: mtime
+    cadence_seconds: 86400
+    demand:
+      # Evidence that work kept flowing while the producer was silent:
+      # dispatch-door events newer than the key's last_seen.
+      type: ndjson_events
+      path: "{state_dir}/dispatch_register.ndjson"
+      timestamp_field: timestamp
+      label: dispatch_register events
+
+  - name: review_gate_results
+    type: directory
+    path: "{state_dir}/review_gates/results"
+    glob: "*.json"
+    key_regex: '^pr-[0-9]+-(?P<key>.+)\.json$'
+    timestamp: mtime
+    cadence_seconds: 86400
+    demand:
+      type: ndjson_events
+      path: "{state_dir}/dispatch_register.ndjson"
+      timestamp_field: timestamp
+      label: dispatch_register events
+
+  # --- Dispatch producers in runtime_coordination.db -----------------------
+  # Key = producer prefix of dispatch_id (text before the first '-').
+  # expected_keys makes a producer that writes NOTHING visible: an absent
+  # producer cannot be found by grouping rows that exist.
+  - name: dispatches_table
+    type: sqlite
+    db: "{state_dir}/runtime_coordination.db"
+    query: "SELECT dispatch_id, created_at FROM dispatches"
+    key_column: dispatch_id
+    key_transform: prefix
+    timestamp_column: created_at
+    cadence_seconds: 604800
+    expected_keys:
+      - dlv
+      - DISP
+
+  # --- Governance metrics in quality_intelligence.db -----------------------
+  # Key = metric_name. Nightly computation when healthy; 3 days grace.
+  - name: governance_metrics
+    type: sqlite
+    db: "{state_dir}/quality_intelligence.db"
+    query: "SELECT metric_name, MAX(computed_at) AS last_ts FROM governance_metrics GROUP BY metric_name"
+    key_column: metric_name
+    timestamp_column: last_ts
+    cadence_seconds: 259200

--- a/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
+++ b/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
@@ -1,0 +1,141 @@
+# Producer Freshness Monitor
+
+**Doel:** stil falen van producenten binnen een dag zichtbaar maken. Aanleiding
+(2026-07-31): de review-gate-laag lag er dagen stilletjes uit — nul requests sinds
+25-07, nul results sinds 28-07 — terwijl dispatches met `gate=codex_gate` gewoon
+doorgingen. De afwezigheid van een resultaat zag er identiek uit als "niets te doen".
+
+Het kernprincipe: **groepeer op de eigen sleutel van elke producent, nooit op
+tabel- of directory-niveau.** Een tabel kan levend ogen terwijl individuele
+sleutels dood zijn (`governance_metrics` schreef `dispatch_count` dagelijks terwijl
+`fpy`/`rework_rate` al zes weken dood waren; de `dispatches`-tabel had 35 rijen van
+de `dlv-`-producent terwijl de dispatch-deur sinds 16-07 niets meer schreef).
+
+## Onderdelen
+
+| # | Onderdeel | Bestand |
+|---|-----------|---------|
+| 1 | Per-sleutel versheidsdiff met cadans-drempel per producent, NDJSON-output | `scripts/lib/producer_freshness.py` + `configs/producer_freshness.yaml` |
+| 2 | Exit-status-capture launchd/cron/nohup → `job_exits.ndjson` | `scripts/lib/job_exit_capture.py` |
+| 3 | PATH/interpreter-pariteitscheck (voorgrond vs achtergrond) bij SessionStart | `scripts/lib/path_parity.py` + `scripts/hooks/path_parity_check.sh` |
+| 4 | Guard-fired-teller (observe-only) | `scripts/lib/guard_stats.py`, geïnstrumenteerd in `phantom_guard.py` en `plan_gate_enforcement.py` |
+| — | Sweep-CLI + heartbeat | `scripts/producer_freshness_monitor.py` |
+| — | Domme tripwire (bash + `find -mmin` only) | `hooks/monitor_tripwire.sh` |
+| — | Dagelijkse scheduling | `scripts/launchd/com.vnx.producer-freshness-monitor.plist` |
+
+## 1. Per-sleutel versheidsdiff
+
+De registry (`configs/producer_freshness.yaml`) declareert producenten met een
+`cadence_seconds`-drempel. Twee brontypes:
+
+- `directory` — glob files, sleutel uit bestandsnaam via `(?P<key>...)`-regex,
+  timestamp = mtime. (review_gates: `pr-<nr>-<gate>.json` → sleutel = gate-naam)
+- `sqlite` — read-only query, sleutel/timestamp uit kolommen; `key_transform:
+  prefix` groepeert op het deel vóór de eerste `-` (producent-prefix).
+  `expected_keys` maakt een producent die **helemaal niets** schrijft zichtbaar:
+  afwezigheid kan niet gevonden worden door bestaande rijen te groeperen.
+
+Elke finding bevat optioneel `demand`-bewijs: het aantal events in een
+demand-bron (bijv. `dispatch_register.ndjson`) dat nieuwer is dan de `last_seen`
+van de sleutel — "er viel wél werk terwijl deze producent zweeg".
+
+Output is NDJSON (`<state_dir>/producer_freshness.ndjson`): één
+`producer_freshness_sweep`-samenvatting plus één `producer_freshness_finding` per
+stille/missende sleutel. NDJSON houdt ADR-007 (composite UNIQUE/PK voor nieuwe
+centrale-DB-tabellen) buiten schot — de monitor opent geen centrale-DB-schrijfpad.
+
+## 2. Exit-status-capture
+
+Twee capture-paden naar `<state_dir>/job_exits.ndjson`:
+
+```bash
+# wrapper (cron/nohup/launchd ProgramArguments) — transparant: de exit-code van
+# het kind wordt ongemoeid teruggegeven.
+python3 scripts/lib/job_exit_capture.py --state-dir ... --job nightly-pipeline -- \
+    /bin/bash scripts/nightly_intelligence_pipeline.sh
+
+# harvest (draait automatisch mee in elke sweep) — leest launchctl list en
+# legt LastExitStatus van elke com.vnx.*-job vast. Vereist geen plist-wijziging;
+# zo had OI-850 (maanden exit 127) zichtbaar geweest.
+python3 scripts/lib/job_exit_capture.py --state-dir ... --harvest-launchd
+```
+
+De harvest dedupt via `job_exits_launchd_state.json`: een ongewijzigde status
+wordt niet opnieuw vastgelegd, behalve dat een aanhoudende non-zero status één
+keer per 24 uur herhaald wordt (een falende job mag niet één keer vuren en dan
+weer stil worden). Een niet-startbaar commando (missende interpreter, de
+OI-852-klasse) wordt als exit 127 vastgelegd in plaats van te raisen.
+
+## 3. PATH/interpreter-pariteitscheck
+
+OI-852 (Homebrew-relink brak de PATH-resolved `python3` voor achtergrond-jobs
+terwijl de voorgrond-shell bleef werken) vervuilde de diagnose van elk ander
+geval. De check is gesloten maar blijft bestaan: de relink kan opnieuw gebeuren.
+
+Bij SessionStart draait `scripts/hooks/path_parity_check.sh`, die
+`scripts/lib/path_parity.py` aanroept. Die probt `python3` tweemaal: met de
+ambient environment (voorgrond) en met een gescrubde environment met de
+launchd/cron-default `PATH=/usr/bin:/bin:/usr/sbin:/sbin` (achtergrond).
+Pariteit faalt bij een niet-draaiende achtergrond-interpreter of een
+major.minor-versieverschil; een executable-padverschil is informatief.
+Resultaat naar `<state>/path_parity.json`; bij breuk een SessionStart-warning.
+De hook faalt nooit de sessie (altijd exit 0).
+
+## 4. Guard-fired-teller
+
+"Deze guard staat al 30 dagen 100% op False" was onzichtbaar — een niet-vurende
+guard verdwijnt in `logger.debug`. `guard_stats.record_guard_evaluation(guard,
+fired)` appendt elke evaluatie naar `<state_dir>/guard_evaluations.ndjson`.
+
+**Harde eis: observe-only.** De teller wrapt de returnwaarde van een guard en
+verandert de beslissing nooit; een teller-fout wordt gelogd en geslikt, nooit
+gepropageerd. Geïnstrumenteerd: `phantom_guard.phantom_guard` (fired =
+`is_phantom`) en `plan_gate_enforcement.plan_gate_state` (fired = `UNRESOLVED`).
+
+```bash
+python3 scripts/lib/guard_stats.py --summary   # per guard: evaluations, fired_pct,
+                                               # suspect_silent (>=30d span, 0 firings)
+```
+
+## De ironie: de monitor kan zelf stil falen
+
+Twee verdedigingen:
+
+1. **Heartbeat bij elke run.** De sweep schrijft via `HealthBeacon` altijd
+   `<data_dir>/health/producer_freshness_monitor.json`, óók bij nul bevindingen.
+   Een sweep die niets vindt én niets schrijft is niet te onderscheiden van een
+   sweep die niet draaide.
+2. **Domme tripwire.** `hooks/monitor_tripwire.sh` (SessionStart, dus draait al
+   bij elke sessie) toetst alleen de leeftijd van dat heartbeat-bestand met
+   `find -mmin +1560` (26u). De tripwire deelt **geen code, geen DB-verbinding
+   en geen Python-interpreter** met de monitor: puur bash + find + jq/sed. Een
+   breuk als OI-852 mag niet tegelijk de monitor en zijn eigen alarm stilleggen.
+   Deze onafhankelijkheid is als test vastgelegd
+   (`tests/test_monitor_tripwire.py::test_tripwire_shares_no_code_db_or_interpreter_with_monitor`).
+
+## Bediening
+
+```bash
+# Handmatige sweep (schrijft report + heartbeat + launchd-harvest)
+python3 scripts/producer_freshness_monitor.py
+
+# Read-only tegen een willekeurige store (acceptatie/diagnose; schrijft niets)
+python3 scripts/producer_freshness_monitor.py \
+    --state-dir ~/.vnx-data/vnx-dev/state --no-write --human
+
+# Exit codes: 0=geen bevindingen, 11=stille producenten gevonden,
+#             20=IO-fout, 30=dependency/config-fout
+```
+
+Dagelijkse scheduling via `scripts/launchd/com.vnx.producer-freshness-monitor.plist`
+(06:00; vul `__VNX_REPO_ROOT__` in en `launchctl load -w`). De exit-status van de
+sweep zelf wordt door de volgende harvest in `job_exits.ndjson` vastgelegd, en de
+tripwire bewaakt de heartbeat — de monitor faalt nooit onzichtbaar.
+
+## Tests
+
+`tests/test_producer_freshness.py`, `tests/test_job_exit_capture.py`,
+`tests/test_path_parity.py`, `tests/test_guard_stats.py`,
+`tests/test_monitor_tripwire.py` — allemaal rood op `origin/main` (modules/
+scripts bestaan daar niet), groen op de branch. De acceptatietest draait de
+monitor read-only tegen de live store en eist de review-gate-laag als finding.

--- a/docs/operations/README.md
+++ b/docs/operations/README.md
@@ -18,6 +18,7 @@
 - Autonomous production guide: `AUTONOMOUS_PRODUCTION_GUIDE.md`
 - Transcript backup & archive: `TRANSCRIPT_BACKUP_ARCHIVE.md`
 - T0 context rotation (default OFF): `CONTEXT_ROTATION.md`
+- Producer freshness monitor (silent-failure detection): `PRODUCER_FRESHNESS_MONITOR.md`
 
 > **Note**: `MONITORING_GUIDE.md` was retired. Runtime monitoring is now available
 > via the dashboard server (`dashboard/serve_dashboard.py`) at `/api/health`.

--- a/hooks/monitor_tripwire.sh
+++ b/hooks/monitor_tripwire.sh
@@ -1,0 +1,70 @@
+#!/bin/bash
+# monitor_tripwire.sh — the deliberately DUMB tripwire for the producer-freshness monitor.
+#
+# A monitor that detects silent failure can itself fail silently. The monitor's
+# own heartbeat (scripts/producer_freshness_monitor.py writes it on EVERY run,
+# including zero-finding runs) is checked here by testing ONLY the file's age
+# with `find -mmin` — nothing more.
+#
+# Independence contract (the whole point): this script shares NO code, NO DB
+# connection and NO Python interpreter with the monitor it watches. A break
+# like OI-852 (background python3 broken by a Homebrew relink) may kill the
+# monitor, but it cannot kill this alarm at the same time. Do not "improve"
+# this script by importing shared helpers — dumbness is the feature.
+#
+# Runs at SessionStart (registered in .claude/settings.json), a path that
+# already executes every session. Always exits 0; never blocks a session.
+set -u
+
+# Drain the hook payload from stdin.
+cat >/dev/null 2>&1 || true
+
+# Max heartbeat age in minutes before the tripwire fires (default: 26h — the
+# sweep is scheduled daily, so 26h allows schedule jitter, never a lost day).
+MAX_AGE_MIN="${VNX_TRIPWIRE_MAX_AGE_MIN:-1560}"
+
+# Heartbeat locations to check. Test override: VNX_TRIPWIRE_HEARTBEAT_GLOB.
+if [ -n "${VNX_TRIPWIRE_HEARTBEAT_GLOB:-}" ]; then
+  CANDIDATES="$VNX_TRIPWIRE_HEARTBEAT_GLOB"
+else
+  CANDIDATES="$HOME/.vnx-data/*/health/producer_freshness_monitor.json"
+  if [ -n "${VNX_DATA_DIR:-}" ]; then
+    CANDIDATES="$VNX_DATA_DIR/health/producer_freshness_monitor.json $CANDIDATES"
+  fi
+fi
+
+FOUND=0
+STALE=""
+# shellcheck disable=SC2086  # intentional glob expansion of CANDIDATES
+for hb in $CANDIDATES; do
+  [ -f "$hb" ] || continue
+  FOUND=1
+  if [ -n "$(find "$hb" -mmin +"$MAX_AGE_MIN" 2>/dev/null)" ]; then
+    STALE="$STALE $hb"
+  fi
+done
+
+warn() {
+  # Emit a SessionStart additionalContext warning. jq if present, manual JSON
+  # otherwise — either way we exit 0 afterwards.
+  msg="$1"
+  if command -v jq >/dev/null 2>&1; then
+    jq -nc --arg msg "$msg" \
+      '{hookSpecificOutput:{hookEventName:"SessionStart",additionalContext:$msg}}'
+  else
+    escaped=$(printf '%s' "$msg" | sed 's/\\/\\\\/g; s/"/\\"/g')
+    printf '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":"%s"}}\n' "$escaped"
+  fi
+}
+
+if [ "$FOUND" -eq 0 ]; then
+  warn "producer-freshness monitor tripwire: NO heartbeat file found under ~/.vnx-data/*/health/ — the monitor may never have run. Silent-failure detection is BLIND until scripts/producer_freshness_monitor.py runs once."
+  exit 0
+fi
+
+if [ -n "$STALE" ]; then
+  warn "producer-freshness monitor tripwire: heartbeat older than ${MAX_AGE_MIN}m:$STALE — the freshness sweep itself is silently down. Silent-failure detection is BLIND."
+  exit 0
+fi
+
+exit 0

--- a/scripts/hooks/path_parity_check.sh
+++ b/scripts/hooks/path_parity_check.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# path_parity_check.sh — SessionStart hook: foreground vs background python3 parity.
+#
+# OI-852 (Homebrew relink broke the background PATH-resolved python3 while the
+# foreground shell kept working) contaminated the diagnosis of every other
+# silent failure. The issue is closed; this check stays so the NEXT relink is
+# caught at session start instead of after days of confusion.
+#
+# Fail-soft by contract: this hook NEVER fails the session (always exit 0) and
+# takes well under the 5s SessionStart budget on a healthy machine.
+set -u
+
+# Drain the hook payload from stdin.
+cat >/dev/null 2>&1 || true
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+CHECKER="$ROOT/scripts/lib/path_parity.py"
+if [ ! -f "$CHECKER" ]; then
+  exit 0
+fi
+
+STATE_DIR="${VNX_STATE_DIR:-$ROOT/.vnx-data/state}"
+OUT="$STATE_DIR/path_parity.json"
+
+RESULT="$(python3 "$CHECKER" --write "$OUT" --no-fail 2>/dev/null)" || exit 0
+
+# Surface a warning into the session context only when parity is broken.
+case "$RESULT" in
+  *'"parity": false'*)
+    python3 - "$RESULT" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    result = json.loads(sys.argv[1])
+except ValueError:
+    sys.exit(0)
+kinds = ", ".join(m.get("kind", "?") for m in result.get("mismatches", []))
+msg = ("PATH/interpreter parity BROKEN (%s). Foreground and background "
+       "(launchd/cron) python3 diverge — background jobs may be failing while "
+       "the foreground looks healthy (OI-852 class). Details: path_parity.json" % kinds)
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart",
+                                         "additionalContext": msg}}))
+PYEOF
+    ;;
+esac
+
+exit 0

--- a/scripts/launchd/com.vnx.producer-freshness-monitor.plist
+++ b/scripts/launchd/com.vnx.producer-freshness-monitor.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.vnx.producer-freshness-monitor</string>
+  <!--
+    Daily producer-freshness sweep. Replace __VNX_REPO_ROOT__ with the repo
+    checkout path at install time (same placeholder pattern as
+    com.vnx.nightly-intelligence-pipeline.plist), e.g.:
+
+      sed "s|__VNX_REPO_ROOT__|$HOME/Development/vnx-orchestration|g" \
+        com.vnx.producer-freshness-monitor.plist > ~/Library/LaunchAgents/
+      launchctl load -w ~/Library/LaunchAgents/com.vnx.producer-freshness-monitor.plist
+
+    The sweep's own exit status is captured back into job_exits.ndjson by the
+    launchd harvest inside the next run — the monitor's scheduling failures
+    are visible in the same stream it maintains. Its heartbeat is watched by
+    the independent hooks/monitor_tripwire.sh (bash + find only).
+  -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd __VNX_REPO_ROOT__ &amp;&amp; exec python3 scripts/producer_freshness_monitor.py</string>
+  </array>
+  <key>StartCalendarInterval</key>
+  <dict>
+    <key>Hour</key><integer>6</integer>
+    <key>Minute</key><integer>0</integer>
+  </dict>
+  <key>StandardOutPath</key><string>/tmp/vnx-producer-freshness.log</string>
+  <key>StandardErrorPath</key><string>/tmp/vnx-producer-freshness.err</string>
+</dict>
+</plist>

--- a/scripts/lib/guard_stats.py
+++ b/scripts/lib/guard_stats.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""guard_stats.py — guard-fired counter: how often does each guard fire?
+
+A guard that evaluates to False (does not fire) for 30 straight days is either
+a healthy guard or a dead guard — and from the outside both look identical,
+because a non-firing guard disappears into ``logger.debug``. This module makes
+the difference visible by recording every evaluation of an instrumented guard
+to ``<state_dir>/guard_evaluations.ndjson``:
+
+    {"timestamp", "event_type": "guard_evaluation", "guard", "fired", "detail"}
+
+Hard contract: the counter is OBSERVE-ONLY. ``record_guard_evaluation`` never
+raises and never alters the guard's verdict — instrumentation wraps a guard's
+return value, it does not touch the decision.
+
+``summarize`` turns the stream into per-guard stats, flagging
+``suspect_silent``: guards with a long evaluation span that NEVER fired (the
+"100% False for 30 days" case), and ``never_evaluated`` is impossible to say
+from data — which is precisely why evaluation, not just firing, is recorded.
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+from ndjson_io import fsync_fileno, iter_ndjson
+
+_LOG = logging.getLogger(__name__)
+
+GUARD_EVALUATIONS_FILENAME = "guard_evaluations.ndjson"
+# A guard with an evaluation span of at least this many days and zero firings
+# is flagged suspect_silent.
+SUSPECT_SILENT_DAYS = 30
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _default_state_dir() -> Optional[Path]:
+    env = os.environ.get("VNX_STATE_DIR")
+    if env:
+        return Path(env)
+    data_dir = os.environ.get("VNX_DATA_DIR")
+    if data_dir:
+        return Path(data_dir) / "state"
+    return None
+
+
+def guard_evaluations_path(state_dir: Optional[Path] = None) -> Optional[Path]:
+    base = Path(state_dir) if state_dir else _default_state_dir()
+    return base / GUARD_EVALUATIONS_FILENAME if base else None
+
+
+def record_guard_evaluation(
+    guard: str,
+    fired: bool,
+    *,
+    detail: Optional[Dict[str, Any]] = None,
+    state_dir: Optional[Path] = None,
+) -> bool:
+    """Append one guard evaluation. OBSERVE-ONLY: never raises, so it can sit
+    on any guard's return path without changing semantics. Returns True when
+    the record was written."""
+    try:
+        path = guard_evaluations_path(state_dir)
+        if path is None:
+            _LOG.debug("guard_stats: no state dir resolvable — evaluation of %s not recorded", guard)
+            return False
+        path.parent.mkdir(parents=True, exist_ok=True)
+        record: Dict[str, Any] = {
+            "timestamp": _now_iso(),
+            "event_type": "guard_evaluation",
+            "guard": guard,
+            "fired": bool(fired),
+        }
+        if detail:
+            record["detail"] = detail
+        with open(path, "a", encoding="utf-8") as fh:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            try:
+                fh.write(json.dumps(record, ensure_ascii=False, default=str))
+                fh.write("\n")
+                fh.flush()
+                fsync_fileno(fh, context=str(path))
+            finally:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+        return True
+    except Exception as exc:  # noqa: BLE001 — observe-only: a counter failure must NEVER break a guard
+        _LOG.warning("guard_stats: could not record evaluation of %s: %s", guard, exc)
+        return False
+
+
+def _parse_ts(value: Any) -> Optional[float]:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def summarize(
+    state_dir: Optional[Path] = None,
+    *,
+    now: Optional[float] = None,
+    suspect_silent_days: int = SUSPECT_SILENT_DAYS,
+) -> Dict[str, Any]:
+    """Per-guard evaluation stats from the NDJSON stream.
+
+    Per guard: evaluations, fired count/pct, first/last evaluation, last
+    firing, and ``suspect_silent`` — True when the guard has been evaluated
+    over a span of >= ``suspect_silent_days`` days without EVER firing.
+    """
+    now = time.time() if now is None else now
+    path = guard_evaluations_path(state_dir)
+    guards: Dict[str, Dict[str, Any]] = {}
+    if path is not None:
+        for record in iter_ndjson(path):
+            if not isinstance(record, dict) or record.get("event_type") != "guard_evaluation":
+                continue
+            name = record.get("guard")
+            if not name:
+                continue
+            ts = _parse_ts(record.get("timestamp"))
+            stats = guards.setdefault(
+                name,
+                {"evaluations": 0, "fired": 0, "first_eval_ts": None, "last_eval_ts": None, "last_fired_ts": None},
+            )
+            stats["evaluations"] += 1
+            if record.get("fired"):
+                stats["fired"] += 1
+                if ts is not None and (stats["last_fired_ts"] is None or ts > stats["last_fired_ts"]):
+                    stats["last_fired_ts"] = ts
+            if ts is not None:
+                if stats["first_eval_ts"] is None or ts < stats["first_eval_ts"]:
+                    stats["first_eval_ts"] = ts
+                if stats["last_eval_ts"] is None or ts > stats["last_eval_ts"]:
+                    stats["last_eval_ts"] = ts
+
+    out: Dict[str, Any] = {"guards": {}, "suspect_silent_days": suspect_silent_days}
+    for name in sorted(guards):
+        stats = guards[name]
+        evaluations = stats["evaluations"]
+        fired = stats["fired"]
+        span_days = 0.0
+        if stats["first_eval_ts"] is not None and stats["last_eval_ts"] is not None:
+            span_days = (stats["last_eval_ts"] - stats["first_eval_ts"]) / 86400.0
+        suspect = fired == 0 and span_days >= suspect_silent_days
+        out["guards"][name] = {
+            "evaluations": evaluations,
+            "fired": fired,
+            "fired_pct": round(100.0 * fired / evaluations, 1) if evaluations else 0.0,
+            "span_days": round(span_days, 1),
+            "last_fired": (
+                datetime.fromtimestamp(stats["last_fired_ts"], tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+                if stats["last_fired_ts"] is not None
+                else None
+            ),
+            "days_since_last_fired": (
+                round((now - stats["last_fired_ts"]) / 86400.0, 1)
+                if stats["last_fired_ts"] is not None
+                else None
+            ),
+            "suspect_silent": suspect,
+        }
+    return out
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="Summarize guard-fired counters")
+    parser.add_argument("--summary", action="store_true", help="Print per-guard stats as JSON")
+    parser.add_argument("--state-dir", default=None)
+    args = parser.parse_args(argv)
+    result = summarize(Path(args.state_dir) if args.state_dir else None)
+    print(json.dumps(result, indent=2, sort_keys=True))
+    suspect = [g for g, s in result["guards"].items() if s["suspect_silent"]]
+    return 11 if suspect else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/job_exit_capture.py
+++ b/scripts/lib/job_exit_capture.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+"""job_exit_capture.py — exit-status capture for launchd / cron / nohup jobs.
+
+OI-850 ran for months on exit 127 and nobody read it: launchd plists redirect
+stdout/stderr to a log file and the exit code evaporates. This module gives
+every scheduled job two capture paths into ``<state_dir>/job_exits.ndjson``:
+
+  1. wrapper  — run the job THROUGH this module:
+        python3 scripts/lib/job_exit_capture.py --state-dir ... --job nightly-pipeline -- \
+            /bin/bash scripts/nightly_intelligence_pipeline.sh
+     The child exit code is recorded (with duration) and returned unchanged,
+     so wrapping never alters job semantics. Works for cron and nohup lines.
+
+  2. harvest  — ``harvest_launchd()`` reads ``launchctl list`` and records the
+     LastExitStatus of every ``com.vnx.*`` job. No plist changes needed; this
+     is exactly how an exit-127 loop like OI-850 surfaces. A small cache file
+     (``job_exits_launchd_state.json``) dedups unchanged statuses so a harvest
+     per sweep does not flood the NDJSON stream; a persistent non-zero status
+     is re-recorded once per RE_RECORD_SECONDS so an ongoing failure stays
+     visible instead of firing once and going quiet.
+
+Record shape (NDJSON, one per line):
+    {"timestamp", "event_type": "job_exit", "job", "exit_code",
+     "duration_seconds" (wrapper only), "source": "wrapper"|"launchd_harvest"}
+"""
+from __future__ import annotations
+
+import argparse
+import fcntl
+import json
+import logging
+import os
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence
+
+_LOG = logging.getLogger(__name__)
+
+JOB_EXITS_FILENAME = "job_exits.ndjson"
+HARVEST_CACHE_FILENAME = "job_exits_launchd_state.json"
+LAUNCHD_LABEL_PREFIX = "com.vnx."
+# A persistently-failing job is re-recorded at most once per day per label.
+RE_RECORD_SECONDS = 86400
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def record_job_exit(
+    state_dir: Path,
+    *,
+    job: str,
+    exit_code: int,
+    source: str,
+    duration_seconds: Optional[float] = None,
+    detail: Optional[Dict[str, Any]] = None,
+) -> Path:
+    """Append one job-exit record (locked append + fsync). Returns the path."""
+    path = Path(state_dir) / JOB_EXITS_FILENAME
+    path.parent.mkdir(parents=True, exist_ok=True)
+    record: Dict[str, Any] = {
+        "timestamp": _now_iso(),
+        "event_type": "job_exit",
+        "job": job,
+        "exit_code": int(exit_code),
+        "source": source,
+    }
+    if duration_seconds is not None:
+        record["duration_seconds"] = round(float(duration_seconds), 3)
+    if detail:
+        record["detail"] = detail
+    with open(path, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            fh.write(json.dumps(record, ensure_ascii=False, default=str))
+            fh.write("\n")
+            fh.flush()
+            try:
+                os.fsync(fh.fileno())
+            except OSError as exc:
+                _LOG.warning("job_exit_capture: fsync failed for %s: %s", path, exc)
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+    return path
+
+
+def run_and_record(state_dir: Path, *, job: str, argv: Sequence[str]) -> int:
+    """Run ``argv``, record its exit code, and return it unchanged.
+
+    The wrapper is transparent: whatever the child exits is what the caller
+    (launchd/cron/nohup) sees, so wrapping never changes job semantics.
+    """
+    if not argv:
+        raise ValueError("run_and_record requires a command after '--'")
+    start = time.monotonic()
+    try:
+        proc = subprocess.run(list(argv), check=False)
+        code = proc.returncode
+    except OSError as exc:
+        # The job itself could not even start (e.g. interpreter missing —
+        # the OI-850/OI-852 class). Record 127, the shell's "command not
+        # found", so the failure is visible in the same stream.
+        _LOG.warning("job_exit_capture: could not start %s: %s", argv[0], exc)
+        code = 127
+    duration = time.monotonic() - start
+    record_job_exit(
+        state_dir,
+        job=job,
+        exit_code=code,
+        duration_seconds=duration,
+        source="wrapper",
+    )
+    return code
+
+
+def _parse_launchctl_list(output: str) -> List[Dict[str, Any]]:
+    """Parse ``launchctl list`` output: 'PID<TAB>Status<TAB>Label' per line."""
+    jobs: List[Dict[str, Any]] = []
+    for line in output.splitlines():
+        parts = line.split("\t")
+        if len(parts) != 3:
+            continue
+        pid_raw, status_raw, label = parts
+        try:
+            status = int(status_raw)
+        except ValueError:
+            continue
+        jobs.append(
+            {
+                "label": label.strip(),
+                "pid": None if pid_raw.strip() == "-" else int(pid_raw),
+                "last_exit_status": status,
+            }
+        )
+    return jobs
+
+
+def _load_harvest_cache(path: Path) -> Dict[str, Any]:
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            data = json.load(fh)
+        return data if isinstance(data, dict) else {}
+    except FileNotFoundError:
+        return {}
+    except (OSError, json.JSONDecodeError) as exc:
+        _LOG.warning("job_exit_capture: harvest cache %s unreadable, starting fresh: %s", path, exc)
+        return {}
+
+
+def harvest_launchd(
+    state_dir: Path,
+    *,
+    runner: Any = None,
+    label_prefix: str = LAUNCHD_LABEL_PREFIX,
+    now: Optional[float] = None,
+) -> Dict[str, Any]:
+    """Record LastExitStatus for every launchd job whose label starts with
+    ``label_prefix``. Dedup via a cache file: a status identical to the last
+    harvest is only re-recorded after RE_RECORD_SECONDS when non-zero.
+
+    ``runner`` is injectable for tests; defaults to subprocess.run.
+    """
+    run = runner or subprocess.run
+    now = time.time() if now is None else now
+    state_dir = Path(state_dir)
+    try:
+        proc = run(["launchctl", "list"], capture_output=True, text=True, check=False)
+    except OSError as exc:
+        _LOG.warning("job_exit_capture: launchctl unavailable: %s", exc)
+        return {"harvested": 0, "recorded": 0, "error": str(exc)}
+    if proc.returncode != 0:
+        _LOG.warning("job_exit_capture: launchctl list exited %s", proc.returncode)
+        return {"harvested": 0, "recorded": 0, "error": f"launchctl exit {proc.returncode}"}
+
+    cache_path = state_dir / HARVEST_CACHE_FILENAME
+    cache = _load_harvest_cache(cache_path)
+    harvested = 0
+    recorded = 0
+    for job in _parse_launchctl_list(proc.stdout):
+        label = job["label"]
+        if not label.startswith(label_prefix):
+            continue
+        harvested += 1
+        status = job["last_exit_status"]
+        cached = cache.get(label) or {}
+        unchanged = cached.get("last_exit_status") == status
+        recently_recorded = (now - float(cached.get("recorded_ts", 0))) < RE_RECORD_SECONDS
+        if unchanged and (status == 0 or recently_recorded):
+            continue
+        record_job_exit(
+            state_dir,
+            job=label,
+            exit_code=status,
+            source="launchd_harvest",
+            detail={"pid": job["pid"]},
+        )
+        recorded += 1
+        cache[label] = {"last_exit_status": status, "recorded_ts": now}
+
+    try:
+        cache_path.write_text(json.dumps(cache, indent=2, sort_keys=True), encoding="utf-8")
+    except OSError as exc:
+        _LOG.warning("job_exit_capture: could not write harvest cache %s: %s", cache_path, exc)
+    return {"harvested": harvested, "recorded": recorded}
+
+
+def _default_state_dir() -> Path:
+    env = os.environ.get("VNX_STATE_DIR") or (
+        os.path.join(os.environ["VNX_DATA_DIR"], "state") if os.environ.get("VNX_DATA_DIR") else None
+    )
+    if not env:
+        raise SystemExit("job_exit_capture: pass --state-dir or set VNX_STATE_DIR / VNX_DATA_DIR")
+    return Path(env)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("--state-dir", default=None, help="VNX state dir (default: $VNX_STATE_DIR)")
+    parser.add_argument("--job", default=None, help="Job name for wrapper mode")
+    parser.add_argument("--harvest-launchd", action="store_true", help="Harvest launchctl LastExitStatus")
+    parser.add_argument("--label-prefix", default=LAUNCHD_LABEL_PREFIX)
+    parser.add_argument("command", nargs=argparse.REMAINDER, help="Wrapper mode: command after '--'")
+    args = parser.parse_args(argv)
+
+    state_dir = Path(args.state_dir) if args.state_dir else _default_state_dir()
+
+    if args.harvest_launchd:
+        result = harvest_launchd(state_dir, label_prefix=args.label_prefix)
+        print(json.dumps(result))
+        return 0
+
+    command = list(args.command)
+    if command and command[0] == "--":
+        command = command[1:]
+    if not args.job or not command:
+        parser.error("wrapper mode needs --job NAME -- COMMAND...")
+    return run_and_record(state_dir, job=args.job, argv=command)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/path_parity.py
+++ b/scripts/lib/path_parity.py
@@ -1,0 +1,193 @@
+#!/usr/bin/env python3
+"""path_parity.py — PATH/interpreter parity check: foreground vs background.
+
+OI-852: a Homebrew relink left the PATH-resolved ``python3`` that launchd /
+cron / nohup jobs see broken (or different) while the interactive foreground
+shell — with its aliases and brewed PATH — kept working. Every diagnosis made
+from the foreground was contaminated: "works here" proved nothing about the
+jobs that were actually failing. OI-852 is closed, but the relink that caused
+it can happen again, so the check stays.
+
+The check probes ``python3`` twice:
+  foreground — the ambient environment this process inherited;
+  background — a scrubbed environment with the launchd/cron default PATH
+               (``/usr/bin:/bin:/usr/sbin:/sbin``), no aliases, no profile.
+
+Parity fails when the background interpreter is unrunnable, or when its
+major.minor version differs from the foreground's. An executable-PATH
+difference alone is informational (macOS jobs legitimately resolve a
+different binary than a brewed shell) — it is recorded, not flagged.
+
+The library is pure/injectable for tests; the CLI is used by
+scripts/hooks/path_parity_check.sh at SessionStart.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import subprocess
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+_LOG = logging.getLogger(__name__)
+
+# launchd/cron default PATH on macOS — what a background job actually gets.
+BACKGROUND_PATH = "/usr/bin:/bin:/usr/sbin:/sbin"
+
+_PROBE = (
+    "import json,sys;"
+    "print(json.dumps({"
+    "'executable':sys.executable,"
+    "'version':sys.version.split()[0],"
+    "'prefix':sys.prefix}))"
+)
+
+
+def probe_interpreter(runner: Any = None, *, env: Optional[Dict[str, str]] = None) -> Dict[str, Any]:
+    """Probe what ``python3`` resolves to under ``env`` (None = ambient).
+
+    Returns {ok, executable, version, prefix, error}. Never raises — an
+    unstartable interpreter is exactly what this check exists to report.
+    """
+    run = runner or subprocess.run
+    try:
+        proc = run(
+            ["python3", "-c", _PROBE],
+            capture_output=True,
+            text=True,
+            check=False,
+            env=env,
+            timeout=15,
+        )
+    except (OSError, subprocess.TimeoutExpired) as exc:
+        return {"ok": False, "executable": None, "version": None, "prefix": None, "error": str(exc)}
+    if proc.returncode != 0:
+        return {
+            "ok": False,
+            "executable": None,
+            "version": None,
+            "prefix": None,
+            "error": (proc.stderr or proc.stdout or "").strip()[:500] or f"exit {proc.returncode}",
+        }
+    try:
+        data = json.loads(proc.stdout.strip().splitlines()[-1])
+    except (ValueError, IndexError) as exc:
+        return {
+            "ok": False,
+            "executable": None,
+            "version": None,
+            "prefix": None,
+            "error": f"unparseable probe output: {exc}",
+        }
+    return {
+        "ok": True,
+        "executable": data.get("executable"),
+        "version": data.get("version"),
+        "prefix": data.get("prefix"),
+        "error": None,
+    }
+
+
+def background_env() -> Dict[str, str]:
+    """A scrubbed environment mimicking launchd/cron: default PATH, no profile."""
+    return {
+        "PATH": BACKGROUND_PATH,
+        "HOME": os.environ.get("HOME", "/"),
+        "USER": os.environ.get("USER", ""),
+        "LANG": os.environ.get("LANG", "en_US.UTF-8"),
+    }
+
+
+def _major_minor(version: Optional[str]) -> Optional[str]:
+    if not version:
+        return None
+    parts = version.split(".")
+    return ".".join(parts[:2]) if len(parts) >= 2 else version
+
+
+def compare_parity(foreground: Dict[str, Any], background: Dict[str, Any]) -> Dict[str, Any]:
+    """Decide parity from two probe results. Pure — no I/O, fully testable."""
+    mismatches = []
+    info = []
+
+    if not foreground.get("ok"):
+        # The foreground being broken is reported but cannot be compared
+        # against — treat as a parity failure of its own kind.
+        mismatches.append({"kind": "foreground_interpreter_broken", "error": foreground.get("error")})
+    if not background.get("ok"):
+        mismatches.append({"kind": "background_interpreter_broken", "error": background.get("error")})
+
+    fg_mm = _major_minor(foreground.get("version"))
+    bg_mm = _major_minor(background.get("version"))
+    if foreground.get("ok") and background.get("ok") and fg_mm != bg_mm:
+        mismatches.append(
+            {
+                "kind": "version_mismatch",
+                "foreground_version": foreground.get("version"),
+                "background_version": background.get("version"),
+            }
+        )
+
+    if (
+        foreground.get("ok")
+        and background.get("ok")
+        and foreground.get("executable") != background.get("executable")
+    ):
+        info.append(
+            {
+                "kind": "executable_differs",
+                "foreground": foreground.get("executable"),
+                "background": background.get("executable"),
+            }
+        )
+
+    return {
+        "parity": not mismatches,
+        "mismatches": mismatches,
+        "info": info,
+    }
+
+
+def check_parity(runner: Any = None) -> Dict[str, Any]:
+    """Probe foreground + background and decide parity."""
+    foreground = probe_interpreter(runner=runner)
+    background = probe_interpreter(runner=runner, env=background_env())
+    result = compare_parity(foreground, background)
+    result.update(
+        {
+            "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+            "foreground": foreground,
+            "background": background,
+            "background_path": BACKGROUND_PATH,
+        }
+    )
+    return result
+
+
+def main(argv: Optional[list] = None) -> int:
+    parser = argparse.ArgumentParser(description="Foreground/background python3 parity check")
+    parser.add_argument("--write", default=None, help="Write the result JSON to this path")
+    parser.add_argument("--no-fail", action="store_true", help="Always exit 0 (hook mode)")
+    args = parser.parse_args(argv)
+
+    result = check_parity()
+
+    if args.write:
+        try:
+            out = Path(args.write)
+            out.parent.mkdir(parents=True, exist_ok=True)
+            out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
+        except OSError as exc:
+            _LOG.warning("path_parity: could not write %s: %s", args.write, exc)
+
+    print(json.dumps(result))
+    if result["parity"] or args.no_fail:
+        return 0
+    return 11
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -96,6 +96,44 @@ def phantom_guard(
     task_class: Optional[str] = None,
     read_only: Optional[bool] = None,
 ) -> PhantomVerdict:
+    """Public guard entry — pure decision PLUS an observe-only counter.
+
+    The guard-fired counter (guard_stats) records every evaluation so a guard
+    that sits at 100% not-fired for weeks is visible instead of vanishing
+    into logger.debug. The recording NEVER alters the verdict: it wraps the
+    return value, it does not touch the decision. A counter failure is
+    swallowed inside guard_stats and cannot break the guard.
+    """
+    verdict = _phantom_guard_decision(
+        status=status,
+        worktree_diff=worktree_diff,
+        token_usage=token_usage,
+        role=role,
+        task_class=task_class,
+        read_only=read_only,
+    )
+    try:
+        import guard_stats  # noqa: PLC0415
+
+        guard_stats.record_guard_evaluation(
+            "phantom_guard",
+            verdict.is_phantom,
+            detail={"status": status, "role": role, "task_class": task_class},
+        )
+    except Exception as exc:  # noqa: BLE001 — observe-only: never break the guard on the counter
+        _LOG.warning("phantom_guard: guard-fired counter failed (verdict unchanged): %s", exc)
+    return verdict
+
+
+def _phantom_guard_decision(
+    *,
+    status: Optional[str],
+    worktree_diff: Optional[str],
+    token_usage: Optional[int] = None,
+    role: Optional[str] = None,
+    task_class: Optional[str] = None,
+    read_only: Optional[bool] = None,
+) -> PhantomVerdict:
     """Pure decision. See module docstring for the rule. worktree_diff is the REAL diff of the
     worker's worktree/branch (caller-computed), NOT the receipt's main-repo provenance."""
     if read_only:

--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -87,6 +87,11 @@ def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
 def plan_gate_state(db_path: "str | Path", track_id: str, project_id: str) -> str:
     """Return ``PASSED`` / ``UNRESOLVED`` / ``UNSUPPORTED`` for a track's plan-first gate.
 
+    Records every evaluation to the observe-only guard-fired counter
+    (guard_stats; fired == UNRESOLVED) so a plan gate that never blocks for
+    weeks is visible as a statistic instead of vanishing into logs. The
+    counter wraps the return value and can never alter it.
+
     Read-only URI connection: a missing DB file raises immediately rather than
     silently creating an empty one (callers degrade any exception to a WARN — never
     crash the door). ``UNSUPPORTED`` when the schema lacks ``track_open_items`` or its
@@ -96,6 +101,26 @@ def plan_gate_state(db_path: "str | Path", track_id: str, project_id: str) -> st
     Only the ``OI-PLAN-<track>`` blocker counts here; other unresolved ``blocks``
     open-items are the closure gate's concern, not the plan-first gate's.
     """
+    state = _plan_gate_state_decision(db_path, track_id, project_id)
+    try:
+        import logging  # noqa: PLC0415
+
+        import guard_stats  # noqa: PLC0415
+
+        guard_stats.record_guard_evaluation(
+            "plan_gate_state",
+            state == UNRESOLVED,
+            detail={"track_id": track_id, "state": state},
+        )
+    except Exception as exc:  # noqa: BLE001 — observe-only: never break the gate on the counter
+        logging.getLogger(__name__).warning(
+            "plan_gate_enforcement: guard-fired counter failed (state unchanged): %s", exc
+        )
+    return state
+
+
+def _plan_gate_state_decision(db_path: "str | Path", track_id: str, project_id: str) -> str:
+    """The read-only plan-gate decision (see ``plan_gate_state`` for the contract)."""
     conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
     try:
         if not (_has_table(conn, "track_open_items") and _has_col(conn, "track_open_items", "resolved_at")):

--- a/scripts/lib/producer_freshness.py
+++ b/scripts/lib/producer_freshness.py
@@ -1,0 +1,442 @@
+"""producer_freshness.py — per-key freshness diff for VNX producers.
+
+The core distinction this module enforces: group activity by each producer's
+OWN key, never by table/directory level. A table can look alive while
+individual keys are dead (governance_metrics wrote dispatch_count daily while
+fpy/rework_rate were dead for six weeks; the dispatches table held 35 dlv-
+rows while the dispatch door had written nothing since 2026-07-16; the
+review-gate layer produced zero requests/results while gate=codex_gate
+dispatches kept flowing — the 2026-07-31 incident this monitor exists to
+catch within a day).
+
+Producers are declared in ``configs/producer_freshness.yaml``. Two source
+types:
+
+  directory — glob files, extract the key from the filename via a regex
+              (``(?P<key>...)`` group), timestamp = file mtime.
+  sqlite    — run a read-only query, take key/timestamp columns from each
+              row (optionally transform the key, e.g. ``prefix`` =
+              text before the first '-').
+
+A producer may declare ``expected_keys``: keys that MUST appear. A producer
+that writes nothing at all can never be detected by grouping existing rows —
+absence has to be asserted, not observed.
+
+Output is NDJSON (append-only ``producer_freshness.ndjson`` in the state
+dir): one ``producer_freshness_sweep`` summary record per run plus one
+``producer_freshness_finding`` record per stale/missing key. NDJSON keeps
+ADR-007 (composite UNIQUE/PK over project_id for new central-DB tables) out
+of scope — this monitor opens no central-DB write path at all.
+
+Self-monitoring: every sweep writes a HealthBeacon heartbeat, INCLUDING runs
+with zero findings — a sweep that finds nothing and writes nothing is
+indistinguishable from a sweep that never ran. The dumb tripwire
+(``hooks/monitor_tripwire.sh``) checks only that heartbeat's age and shares
+no code, no DB connection and no interpreter with this module.
+"""
+from __future__ import annotations
+
+import fcntl
+import json
+import logging
+import re
+import sqlite3
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+from ndjson_io import fsync_fileno, iter_ndjson
+
+_LOG = logging.getLogger(__name__)
+
+REPORT_FILENAME = "producer_freshness.ndjson"
+HEARTBEAT_COMPONENT = "producer_freshness_monitor"
+HEARTBEAT_INTERVAL_SECONDS = 86400
+
+_STATUS_OK = "ok"
+_STATUS_STALE = "stale"
+_STATUS_ERROR = "error"
+
+
+# ---------------------------------------------------------------------------
+# Timestamp helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_ts(value: Any) -> Optional[float]:
+    """Parse a timestamp to epoch seconds.
+
+    Accepts epoch numbers and ISO-8601 strings (``2026-07-16T13:40:13.123Z``,
+    ``2026-06-16 02:09:06``). Naive datetimes are read as UTC — the fabric's
+    sqlite writers store UTC. Returns None when unparseable.
+    """
+    if value is None:
+        return None
+    if isinstance(value, (int, float)):
+        return float(value)
+    if not isinstance(value, str) or not value.strip():
+        return None
+    text = value.strip()
+    try:
+        return float(text)
+    except ValueError:
+        pass
+    try:
+        parsed = datetime.fromisoformat(text.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    return parsed.timestamp()
+
+
+def _iso(ts: Optional[float]) -> Optional[str]:
+    if ts is None:
+        return None
+    return datetime.fromtimestamp(ts, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# Registry loading
+# ---------------------------------------------------------------------------
+
+
+def load_registry(config_path: Path) -> List[Dict[str, Any]]:
+    """Load the producer registry YAML. Raises ImportError/ValueError on
+    missing dependency or malformed config — the CLI maps those to exit
+    codes; the library stays honest about bad input."""
+    import yaml  # noqa: PLC0415 — lazy: keeps the importable surface stdlib-only
+
+    with open(config_path, "r", encoding="utf-8") as fh:
+        data = yaml.safe_load(fh)
+    if not isinstance(data, dict) or not isinstance(data.get("producers"), list):
+        raise ValueError(f"producer registry {config_path} has no 'producers' list")
+    return data["producers"]
+
+
+def _expand(value: Any, *, state_dir: Path, data_dir: Path, project_id: str) -> Any:
+    if isinstance(value, str):
+        return value.format(state_dir=state_dir, data_dir=data_dir, project_id=project_id)
+    if isinstance(value, dict):
+        return {k: _expand(v, state_dir=state_dir, data_dir=data_dir, project_id=project_id) for k, v in value.items()}
+    if isinstance(value, list):
+        return [_expand(v, state_dir=state_dir, data_dir=data_dir, project_id=project_id) for v in value]
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Source scanners — each returns {key: last_seen_epoch}
+# ---------------------------------------------------------------------------
+
+
+def scan_directory(spec: Dict[str, Any], *, now: float) -> Dict[str, Optional[float]]:
+    """Group files under ``path``/``glob`` by the ``key_regex`` (?P<key>) group.
+
+    Timestamp source is file mtime. Files whose name does not match the regex
+    are bucketed under their own filename (still visible, never dropped).
+    """
+    root = Path(spec["path"])
+    out: Dict[str, Optional[float]] = {}
+    if not root.is_dir():
+        return out
+    pattern = spec.get("glob") or "*"
+    key_re = re.compile(spec["key_regex"]) if spec.get("key_regex") else None
+    for entry in root.glob(pattern):
+        if not entry.is_file():
+            continue
+        key = entry.name
+        if key_re is not None:
+            match = key_re.match(entry.name)
+            if match and "key" in match.groupdict():
+                key = match.group("key")
+        try:
+            ts: Optional[float] = entry.stat().st_mtime
+        except OSError as exc:
+            _LOG.warning("producer_freshness: stat failed for %s: %s", entry, exc)
+            ts = None
+        prev = out.get(key)
+        if prev is None or (ts is not None and ts > prev):
+            out[key] = ts
+    return out
+
+
+def scan_sqlite(spec: Dict[str, Any], *, now: float) -> Dict[str, Optional[float]]:
+    """Run the spec's query READ-ONLY and group rows by key column.
+
+    Read-only URI: a missing DB raises ``sqlite3.OperationalError`` (callers
+    degrade to an error entry) instead of silently creating an empty file.
+    """
+    db_path = Path(spec["db"])
+    conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=10.0)
+    try:
+        cursor = conn.execute(spec["query"])
+        col_names = [d[0] for d in cursor.description or []]
+        rows = cursor.fetchall()
+    finally:
+        conn.close()
+    key_idx = col_names.index(spec["key_column"])
+    ts_idx = col_names.index(spec["timestamp_column"])
+    transform = spec.get("key_transform")
+    out: Dict[str, Optional[float]] = {}
+    for row in rows:
+        raw_key = row[key_idx]
+        if raw_key is None:
+            continue
+        key = str(raw_key)
+        if transform == "prefix":
+            key = key.split("-", 1)[0]
+        ts = _parse_ts(row[ts_idx])
+        prev = out.get(key)
+        if key not in out or (ts is not None and (prev is None or ts > prev)):
+            out[key] = ts
+    return out
+
+
+_SCANNERS: Dict[str, Callable[..., Dict[str, Optional[float]]]] = {
+    "directory": scan_directory,
+    "sqlite": scan_sqlite,
+}
+
+
+# ---------------------------------------------------------------------------
+# Demand evidence — "work kept flowing while this key was silent"
+# ---------------------------------------------------------------------------
+
+
+def count_demand_events(spec: Dict[str, Any], *, since_ts: Optional[float], now: float) -> Optional[int]:
+    """Count demand-source events newer than ``since_ts`` (or the last cadence
+    window when ``since_ts`` is None — a producer that never wrote).
+
+    Returns None when no demand source is configured or it is unreadable —
+    demand evidence is corroborating, never load-bearing.
+    """
+    demand = spec.get("demand")
+    if not isinstance(demand, dict):
+        return None
+    if demand.get("type") != "ndjson_events":
+        _LOG.warning("producer_freshness: unsupported demand type %r", demand.get("type"))
+        return None
+    path = Path(demand["path"])
+    ts_field = demand.get("timestamp_field", "timestamp")
+    if since_ts is None:
+        since_ts = now - float(spec.get("cadence_seconds", 86400))
+    count = 0
+    try:
+        for record in iter_ndjson(path):
+            if not isinstance(record, dict):
+                continue
+            ts = _parse_ts(record.get(ts_field))
+            if ts is not None and ts > since_ts:
+                count += 1
+    except OSError as exc:
+        _LOG.warning("producer_freshness: demand source %s unreadable: %s", path, exc)
+        return None
+    return count
+
+
+# ---------------------------------------------------------------------------
+# Evaluation
+# ---------------------------------------------------------------------------
+
+
+def evaluate_producer(spec: Dict[str, Any], *, now: float) -> Dict[str, Any]:
+    """Evaluate one producer spec into a report section with findings."""
+    name = spec.get("name", "(unnamed)")
+    cadence = float(spec.get("cadence_seconds", 86400))
+    scanner = _SCANNERS.get(spec.get("type"))
+    section: Dict[str, Any] = {
+        "producer": name,
+        "type": spec.get("type"),
+        "cadence_seconds": cadence,
+        "keys": [],
+        "findings": [],
+    }
+    if scanner is None:
+        section["error"] = f"unknown producer type {spec.get('type')!r}"
+        section["status"] = _STATUS_ERROR
+        return section
+
+    try:
+        last_seen = scanner(spec, now=now)
+    except (OSError, sqlite3.Error, ValueError, KeyError) as exc:
+        # A producer whose source is unreadable is itself a finding: the
+        # absence of data must never read as "nothing to do".
+        section["error"] = f"{type(exc).__name__}: {exc}"
+        section["status"] = _STATUS_ERROR
+        section["findings"].append(
+            {
+                "producer": name,
+                "key": None,
+                "kind": "source_unreadable",
+                "error": section["error"],
+                "cadence_seconds": cadence,
+            }
+        )
+        return section
+
+    expected = [str(k) for k in spec.get("expected_keys") or []]
+    for key in expected:
+        if key not in last_seen:
+            last_seen[key] = None  # asserted absence — evaluated below
+
+    for key in sorted(last_seen):
+        ts = last_seen[key]
+        silence = None if ts is None else max(0.0, now - ts)
+        entry: Dict[str, Any] = {
+            "key": key,
+            "last_seen_ts": ts,
+            "last_seen": _iso(ts),
+            "silence_seconds": silence,
+        }
+        section["keys"].append(entry)
+
+        stale = ts is None or (silence is not None and silence > cadence)
+        if not stale:
+            continue
+        finding: Dict[str, Any] = {
+            "producer": name,
+            "key": key,
+            "kind": "missing" if ts is None else "stale",
+            "last_seen": _iso(ts),
+            "silence_seconds": silence,
+            "silence_days": None if silence is None else round(silence / 86400.0, 2),
+            "cadence_seconds": cadence,
+        }
+        if key in expected and ts is None:
+            finding["expected_key_absent"] = True
+        demand = count_demand_events(spec, since_ts=ts, now=now)
+        if demand is not None:
+            finding["demand"] = {
+                "source": (spec.get("demand") or {}).get("label") or (spec.get("demand") or {}).get("path"),
+                "events_since_last_seen": demand,
+            }
+        section["findings"].append(finding)
+
+    section["status"] = _STATUS_STALE if section["findings"] else _STATUS_OK
+    return section
+
+
+def run_sweep(
+    state_dir: Path,
+    registry: List[Dict[str, Any]],
+    *,
+    now: Optional[float] = None,
+    project_id: str = "",
+) -> Dict[str, Any]:
+    """Evaluate every producer in the registry. Pure: performs NO writes."""
+    now = time.time() if now is None else now
+    state_dir = Path(state_dir)
+    data_dir = state_dir.parent if state_dir.name == "state" else state_dir
+    sections: List[Dict[str, Any]] = []
+    findings: List[Dict[str, Any]] = []
+    for raw_spec in registry:
+        spec = _expand(raw_spec, state_dir=state_dir, data_dir=data_dir, project_id=project_id)
+        section = evaluate_producer(spec, now=now)
+        sections.append(section)
+        findings.extend(section["findings"])
+    return {
+        "run_id": uuid.uuid4().hex[:12],
+        "timestamp": _now_iso(),
+        "state_dir": str(state_dir),
+        "producers_evaluated": len(sections),
+        "keys_evaluated": sum(len(s["keys"]) for s in sections),
+        "findings_count": len(findings),
+        "status": _STATUS_STALE if findings else _STATUS_OK,
+        "producers": sections,
+        "findings": findings,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Writes — NDJSON report + always-on heartbeat
+# ---------------------------------------------------------------------------
+
+
+def _append_ndjson_locked(path: Path, records: List[Dict[str, Any]]) -> None:
+    """Locked append of NDJSON records (fcntl.flock + fsync before release)."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            for record in records:
+                fh.write(json.dumps(record, ensure_ascii=False, default=str))
+                fh.write("\n")
+            fh.flush()
+            fsync_fileno(fh, context=str(path))
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def append_report(state_dir: Path, report: Dict[str, Any]) -> Path:
+    """Append the sweep summary + one record per finding to the NDJSON report."""
+    path = Path(state_dir) / REPORT_FILENAME
+    records: List[Dict[str, Any]] = [
+        {
+            "event_type": "producer_freshness_sweep",
+            "run_id": report["run_id"],
+            "timestamp": report["timestamp"],
+            "producers_evaluated": report["producers_evaluated"],
+            "keys_evaluated": report["keys_evaluated"],
+            "findings_count": report["findings_count"],
+            "status": report["status"],
+        }
+    ]
+    for finding in report["findings"]:
+        records.append(
+            {
+                "event_type": "producer_freshness_finding",
+                "run_id": report["run_id"],
+                "timestamp": report["timestamp"],
+                **finding,
+            }
+        )
+    _append_ndjson_locked(path, records)
+    return path
+
+
+def write_heartbeat(state_dir: Path, report: Dict[str, Any]) -> Path:
+    """Write the sweep heartbeat via the canonical HealthBeacon.
+
+    Called on EVERY run, including zero-finding runs — a sweep that finds
+    nothing and writes nothing is indistinguishable from a sweep that never
+    ran. ``hooks/monitor_tripwire.sh`` watches only this file's age.
+    """
+    from health_beacon import HealthBeacon  # noqa: PLC0415
+
+    state_dir = Path(state_dir)
+    data_dir = state_dir.parent if state_dir.name == "state" else state_dir
+    beacon = HealthBeacon(
+        data_dir,
+        HEARTBEAT_COMPONENT,
+        expected_interval_seconds=HEARTBEAT_INTERVAL_SECONDS,
+    )
+    beacon.heartbeat_strict(
+        status=report["status"],
+        details={
+            "run_id": report["run_id"],
+            "findings_count": report["findings_count"],
+            "producers_evaluated": report["producers_evaluated"],
+            "keys_evaluated": report["keys_evaluated"],
+        },
+    )
+    return beacon.path
+
+
+__all__ = [
+    "REPORT_FILENAME",
+    "HEARTBEAT_COMPONENT",
+    "load_registry",
+    "scan_directory",
+    "scan_sqlite",
+    "count_demand_events",
+    "evaluate_producer",
+    "run_sweep",
+    "append_report",
+    "write_heartbeat",
+]

--- a/scripts/producer_freshness_monitor.py
+++ b/scripts/producer_freshness_monitor.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""producer_freshness_monitor.py — sweep CLI for the producer-freshness monitor.
+
+Runs the per-key freshness diff (scripts/lib/producer_freshness.py) over the
+registry in configs/producer_freshness.yaml, harvests launchd job exit codes
+(scripts/lib/job_exit_capture.py) in the same run so one scheduled sweep
+covers both silent-failure classes, appends an NDJSON report, and writes a
+heartbeat on EVERY run — including runs with zero findings, because a sweep
+that finds nothing and writes nothing is indistinguishable from a sweep that
+never ran. hooks/monitor_tripwire.sh watches only that heartbeat's age.
+
+Exit codes (house style, cf. check_intelligence_health.py):
+    0  EXIT_OK          sweep ran, no findings
+    11 EXIT_HEALTH      sweep ran, stale/missing producers found
+    20 EXIT_IO          state dir / report not writable
+    30 EXIT_DEPENDENCY  registry missing/malformed, PyYAML unavailable
+
+``--no-write`` performs a read-only sweep (acceptance runs against the live
+store): nothing is appended, no heartbeat is written, no harvest cache is
+touched; the report goes to stdout only.
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from typing import Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+from cli_output import emit_json, emit_human  # noqa: E402
+
+EXIT_OK = 0
+EXIT_HEALTH = 11
+EXIT_IO = 20
+EXIT_DEPENDENCY = 30
+
+DEFAULT_CONFIG = SCRIPT_DIR.parent / "configs" / "producer_freshness.yaml"
+
+
+def _default_state_dir() -> Path:
+    from vnx_paths import ensure_env  # noqa: PLC0415
+
+    env = ensure_env()
+    return Path(env["VNX_STATE_DIR"])
+
+
+def _human_lines(report: Dict[str, object]) -> str:
+    lines = [
+        f"producer-freshness sweep {report['run_id']} — status={report['status']} "
+        f"findings={report['findings_count']} "
+        f"(producers={report['producers_evaluated']}, keys={report['keys_evaluated']})",
+    ]
+    for finding in report["findings"]:  # type: ignore[index]
+        if finding.get("kind") == "missing":
+            lines.append(
+                f"  MISSING {finding['producer']}/{finding['key']}: expected key has never written"
+            )
+        elif finding.get("kind") == "source_unreadable":
+            lines.append(f"  ERROR   {finding['producer']}: {finding.get('error')}")
+        else:
+            demand = finding.get("demand") or {}
+            demand_txt = ""
+            if demand:
+                demand_txt = (
+                    f" — demand while silent: {demand.get('events_since_last_seen')} "
+                    f"{demand.get('source')}"
+                )
+            lines.append(
+                f"  STALE   {finding['producer']}/{finding['key']}: last_seen={finding['last_seen']} "
+                f"({finding['silence_days']}d ago, cadence {finding['cadence_seconds']}s){demand_txt}"
+            )
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="Per-key producer freshness sweep")
+    parser.add_argument("--config", default=str(DEFAULT_CONFIG), help="producer registry YAML")
+    parser.add_argument("--state-dir", default=None, help="VNX state dir (default: resolved via vnx_paths)")
+    parser.add_argument("--no-write", action="store_true", help="read-only sweep; report to stdout only")
+    parser.add_argument("--skip-job-exits", action="store_true", help="do not harvest launchd exit codes")
+    parser.add_argument("--human", action="store_true", help="human-readable output")
+    args = parser.parse_args(argv)
+
+    try:
+        import producer_freshness as pf  # noqa: PLC0415
+    except ImportError as exc:
+        emit_json({"ok": False, "error": {"code": "dependency", "message": str(exc)}})
+        return EXIT_DEPENDENCY
+
+    try:
+        registry = pf.load_registry(Path(args.config))
+    except ImportError as exc:
+        emit_json({"ok": False, "error": {"code": "dependency", "message": f"PyYAML: {exc}"}})
+        return EXIT_DEPENDENCY
+    except (OSError, ValueError) as exc:
+        emit_json({"ok": False, "error": {"code": "dependency", "message": f"registry: {exc}"}})
+        return EXIT_DEPENDENCY
+
+    try:
+        state_dir = Path(args.state_dir) if args.state_dir else _default_state_dir()
+    except (OSError, RuntimeError, KeyError) as exc:
+        emit_json({"ok": False, "error": {"code": "io", "message": f"state dir: {exc}"}})
+        return EXIT_IO
+
+    report = pf.run_sweep(state_dir, registry)
+
+    job_exits: Dict[str, object] = {"skipped": True}
+    if not args.skip_job_exits and not args.no_write:
+        try:
+            import job_exit_capture  # noqa: PLC0415
+
+            job_exits = job_exit_capture.harvest_launchd(state_dir)
+        except (ImportError, OSError) as exc:
+            # The harvest is a bonus signal in the same run; its failure must
+            # not suppress the freshness findings.
+            job_exits = {"skipped": False, "error": str(exc)}
+    report["job_exits"] = job_exits
+
+    if not args.no_write:
+        try:
+            report_path = pf.append_report(state_dir, report)
+            heartbeat_path = pf.write_heartbeat(state_dir, report)  # EVERY run, even 0 findings
+        except OSError as exc:
+            emit_json({"ok": False, "error": {"code": "io", "message": str(exc)}})
+            return EXIT_IO
+        report["report_path"] = str(report_path)
+        report["heartbeat_path"] = str(heartbeat_path)
+
+    if args.human:
+        emit_human(_human_lines(report))
+    else:
+        emit_json(report)
+    return EXIT_HEALTH if report["findings_count"] else EXIT_OK
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_guard_stats.py
+++ b/tests/test_guard_stats.py
@@ -1,0 +1,138 @@
+"""Tests for the guard-fired counter (scripts/lib/guard_stats.py) and its
+observe-only instrumentation of phantom_guard and plan_gate_enforcement.
+
+RED against origin/main: guard_stats does not exist there and neither guard
+records evaluations, so the counter assertions fail. GREEN on this branch.
+"""
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import guard_stats  # noqa: E402
+import phantom_guard  # noqa: E402
+import plan_gate_enforcement  # noqa: E402
+
+
+def _read_evals(state_dir: Path) -> list:
+    path = state_dir / guard_stats.GUARD_EVALUATIONS_FILENAME
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def _iso_days_ago(days: float) -> str:
+    return datetime.fromtimestamp(time.time() - days * 86400, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# The counter itself
+# ---------------------------------------------------------------------------
+
+
+def test_record_and_summarize(tmp_path: Path) -> None:
+    assert guard_stats.record_guard_evaluation("g1", True, state_dir=tmp_path) is True
+    guard_stats.record_guard_evaluation("g1", False, state_dir=tmp_path)
+    guard_stats.record_guard_evaluation("g1", False, state_dir=tmp_path)
+    guard_stats.record_guard_evaluation("g2", False, state_dir=tmp_path)
+
+    records = _read_evals(tmp_path)
+    assert all(r["event_type"] == "guard_evaluation" for r in records)
+
+    summary = guard_stats.summarize(tmp_path)
+    assert summary["guards"]["g1"]["evaluations"] == 3
+    assert summary["guards"]["g1"]["fired"] == 1
+    assert summary["guards"]["g1"]["fired_pct"] == 33.3
+    assert summary["guards"]["g1"]["suspect_silent"] is False
+
+
+def test_summarize_flags_guard_silent_for_30_days(tmp_path: Path) -> None:
+    """"This guard has been 100% False for 30 days" must be a statistic, not
+    a logger.debug line that nobody reads."""
+    path = tmp_path / guard_stats.GUARD_EVALUATIONS_FILENAME
+    lines = []
+    for days in (40, 30, 20, 10, 1):
+        lines.append(
+            json.dumps(
+                {
+                    "timestamp": _iso_days_ago(days),
+                    "event_type": "guard_evaluation",
+                    "guard": "never_fires",
+                    "fired": False,
+                }
+            )
+        )
+    path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    summary = guard_stats.summarize(tmp_path)
+    guard = summary["guards"]["never_fires"]
+    assert guard["evaluations"] == 5
+    assert guard["fired"] == 0
+    assert guard["fired_pct"] == 0.0
+    assert guard["suspect_silent"] is True
+
+
+def test_record_is_observe_only_and_never_raises(tmp_path: Path) -> None:
+    # An unwritable state dir (a file where a directory is needed) must not
+    # propagate — the counter can never break the guard it observes.
+    blocker = tmp_path / "blocked"
+    blocker.write_text("x", encoding="utf-8")
+    assert guard_stats.record_guard_evaluation("g", True, state_dir=blocker / "sub") is False
+
+
+# ---------------------------------------------------------------------------
+# Instrumentation: verdict semantics UNCHANGED, evaluations recorded
+# ---------------------------------------------------------------------------
+
+
+def test_phantom_guard_phantom_verdict_unchanged_and_counted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    verdict = phantom_guard.phantom_guard(status="done", worktree_diff="", role="developer")
+    assert verdict.is_phantom is True  # semantics unchanged
+    records = _read_evals(tmp_path)
+    assert len(records) == 1
+    assert records[0]["guard"] == "phantom_guard"
+    assert records[0]["fired"] is True
+
+
+def test_phantom_guard_ok_verdict_unchanged_and_counted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    verdict = phantom_guard.phantom_guard(status="done", worktree_diff="", role="code-reviewer")
+    assert verdict.is_phantom is False  # review role exemption intact
+    verdict2 = phantom_guard.phantom_guard(status="done", worktree_diff="+ real change", role="developer")
+    assert verdict2.is_phantom is False  # non-empty diff exemption intact
+    records = _read_evals(tmp_path)
+    assert [r["fired"] for r in records] == [False, False]
+
+
+def test_plan_gate_state_verdict_unchanged_and_counted(tmp_path: Path, monkeypatch) -> None:
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path / "state"))
+    db = tmp_path / "future.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "CREATE TABLE track_open_items (track_id TEXT, project_id TEXT, oi_id TEXT, "
+            "link_type TEXT, resolved_at TEXT)"
+        )
+        conn.execute(
+            "INSERT INTO track_open_items VALUES ('trk-1', 'proj', 'OI-PLAN-trk-1', 'blocks', NULL)"
+        )
+        conn.execute(
+            "INSERT INTO track_open_items VALUES ('trk-2', 'proj', 'OI-PLAN-trk-2', 'blocks', '2026-07-01')"
+        )
+        conn.commit()
+    finally:
+        conn.close()
+
+    assert plan_gate_enforcement.plan_gate_state(db, "trk-1", "proj") == plan_gate_enforcement.UNRESOLVED
+    assert plan_gate_enforcement.plan_gate_state(db, "trk-2", "proj") == plan_gate_enforcement.PASSED
+
+    records = _read_evals(tmp_path / "state")
+    assert [r["guard"] for r in records] == ["plan_gate_state", "plan_gate_state"]
+    assert [r["fired"] for r in records] == [True, False]

--- a/tests/test_job_exit_capture.py
+++ b/tests/test_job_exit_capture.py
@@ -1,0 +1,118 @@
+"""Tests for job exit-status capture (scripts/lib/job_exit_capture.py).
+
+RED against origin/main (module does not exist), GREEN on this branch.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import job_exit_capture as jec  # noqa: E402
+
+
+def _read_exits(state_dir: Path) -> list:
+    path = state_dir / jec.JOB_EXITS_FILENAME
+    if not path.exists():
+        return []
+    return [json.loads(line) for line in path.read_text().splitlines() if line.strip()]
+
+
+def test_wrapper_records_exit_127_oi850_shape(tmp_path: Path) -> None:
+    """The OI-850 case: a job dying on 127 for months must land in job_exits."""
+    rc = jec.run_and_record(tmp_path, job="nightly-pipeline", argv=["/bin/sh", "-c", "exit 127"])
+    assert rc == 127  # transparent: the child's code is returned unchanged
+    records = _read_exits(tmp_path)
+    assert len(records) == 1
+    assert records[0]["job"] == "nightly-pipeline"
+    assert records[0]["exit_code"] == 127
+    assert records[0]["source"] == "wrapper"
+    assert "duration_seconds" in records[0]
+
+
+def test_wrapper_records_success(tmp_path: Path) -> None:
+    rc = jec.run_and_record(tmp_path, job="ok-job", argv=["/bin/sh", "-c", "exit 0"])
+    assert rc == 0
+    records = _read_exits(tmp_path)
+    assert records[0]["exit_code"] == 0
+
+
+def test_wrapper_records_unstartable_command_as_127(tmp_path: Path) -> None:
+    """A missing interpreter (the OI-852 class) must surface, not raise."""
+    rc = jec.run_and_record(tmp_path, job="broken", argv=["/nonexistent/python3", "x.py"])
+    assert rc == 127
+    records = _read_exits(tmp_path)
+    assert records[0]["exit_code"] == 127
+
+
+class _FakeProc:
+    def __init__(self, stdout: str, returncode: int = 0):
+        self.stdout = stdout
+        self.stderr = ""
+        self.returncode = returncode
+
+
+def _fake_runner(stdout: str):
+    def run(cmd, capture_output=False, text=False, check=False):
+        return _FakeProc(stdout)
+
+    return run
+
+
+LAUNCHCTL_SAMPLE = (
+    "PID\tStatus\tLabel\n"
+    "-\t0\tcom.apple.unrelated\n"
+    "481\t0\tcom.vnx.dashboard\n"
+    "-\t127\tcom.vnx.nightly-intelligence-pipeline\n"
+)
+
+
+def test_harvest_launchd_records_nonzero_and_new_labels(tmp_path: Path) -> None:
+    result = jec.harvest_launchd(tmp_path, runner=_fake_runner(LAUNCHCTL_SAMPLE), now=1000.0)
+    assert result["harvested"] == 2  # com.apple.* ignored
+    assert result["recorded"] == 2  # first sighting records both vnx jobs
+    records = _read_exits(tmp_path)
+    by_job = {r["job"]: r for r in records}
+    assert by_job["com.vnx.nightly-intelligence-pipeline"]["exit_code"] == 127
+    assert by_job["com.vnx.nightly-intelligence-pipeline"]["source"] == "launchd_harvest"
+    assert by_job["com.vnx.dashboard"]["exit_code"] == 0
+
+
+def test_harvest_launchd_dedups_unchanged_statuses(tmp_path: Path) -> None:
+    jec.harvest_launchd(tmp_path, runner=_fake_runner(LAUNCHCTL_SAMPLE), now=1000.0)
+    # Second harvest, same statuses: the persistent 127 is still within the
+    # re-record window, so nothing new is appended.
+    result = jec.harvest_launchd(tmp_path, runner=_fake_runner(LAUNCHCTL_SAMPLE), now=2000.0)
+    assert result["recorded"] == 0
+    assert len(_read_exits(tmp_path)) == 2
+
+
+def test_harvest_launchd_rerecords_persistent_failure_and_recovery(tmp_path: Path) -> None:
+    jec.harvest_launchd(tmp_path, runner=_fake_runner(LAUNCHCTL_SAMPLE), now=1000.0)
+    # A day later the failure persists -> re-recorded (a broken job must not
+    # fire once and go quiet).
+    result = jec.harvest_launchd(
+        tmp_path, runner=_fake_runner(LAUNCHCTL_SAMPLE), now=1000.0 + jec.RE_RECORD_SECONDS + 1
+    )
+    assert result["recorded"] == 1
+    # Recovery (127 -> 0) is a status change -> recorded.
+    recovered = LAUNCHCTL_SAMPLE.replace("-\t127\tcom.vnx.nightly", "-\t0\tcom.vnx.nightly")
+    result = jec.harvest_launchd(
+        tmp_path, runner=_fake_runner(recovered), now=1000.0 + 2 * jec.RE_RECORD_SECONDS
+    )
+    assert result["recorded"] == 1
+    last = _read_exits(tmp_path)[-1]
+    assert last["job"] == "com.vnx.nightly-intelligence-pipeline"
+    assert last["exit_code"] == 0
+
+
+def test_harvest_launchd_handles_missing_launchctl(tmp_path: Path) -> None:
+    def bad_runner(cmd, capture_output=False, text=False, check=False):
+        raise OSError("launchctl not found")
+
+    result = jec.harvest_launchd(tmp_path, runner=bad_runner)
+    assert result["harvested"] == 0
+    assert "error" in result

--- a/tests/test_monitor_tripwire.py
+++ b/tests/test_monitor_tripwire.py
@@ -1,0 +1,87 @@
+"""Tests for the dumb monitor tripwire (hooks/monitor_tripwire.sh).
+
+RED against origin/main (the script does not exist), GREEN on this branch.
+
+The tripwire's independence contract — no shared code, no DB, no Python
+interpreter with the monitor it watches — is asserted as a test, so a future
+"helpful" refactor that imports shared tooling fails CI.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import time
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+TRIPWIRE = REPO_ROOT / "hooks" / "monitor_tripwire.sh"
+
+
+def _run_tripwire(env_overrides: dict) -> subprocess.CompletedProcess:
+    env = dict(os.environ)
+    env.update(env_overrides)
+    return subprocess.run(
+        ["bash", str(TRIPWIRE)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        check=False,
+        env=env,
+        timeout=10,
+    )
+
+
+def _write_heartbeat(path: Path, age_seconds: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"component": "producer_freshness_monitor", "status": "ok"}), encoding="utf-8")
+    ts = time.time() - age_seconds
+    os.utime(path, (ts, ts))
+
+
+def test_tripwire_shares_no_code_db_or_interpreter_with_monitor() -> None:
+    """The independence contract IS the feature (an OI-852-class break must
+    not kill monitor and alarm together). Keep the tripwire dumb."""
+    text = TRIPWIRE.read_text(encoding="utf-8")
+    # Strip comment lines: the contract is about what the script EXECUTES.
+    code = "\n".join(
+        line for line in text.splitlines() if not line.lstrip().startswith("#")
+    ).lower()
+    assert "python" not in code, "tripwire must not use the Python interpreter"
+    assert "sqlite" not in code, "tripwire must not open a DB connection"
+    assert "scripts/lib" not in code, "tripwire must not import shared monitor code"
+    assert "find " in code, "tripwire checks the heartbeat age with find -mmin"
+
+
+def test_tripwire_quiet_on_fresh_heartbeat(tmp_path: Path) -> None:
+    hb = tmp_path / "health" / "producer_freshness_monitor.json"
+    _write_heartbeat(hb, age_seconds=300)
+    proc = _run_tripwire({"VNX_TRIPWIRE_HEARTBEAT_GLOB": str(hb)})
+    assert proc.returncode == 0
+    assert proc.stdout.strip() == ""
+
+
+def test_tripwire_fires_on_stale_heartbeat(tmp_path: Path) -> None:
+    hb = tmp_path / "health" / "producer_freshness_monitor.json"
+    _write_heartbeat(hb, age_seconds=2 * 86400)
+    proc = _run_tripwire({"VNX_TRIPWIRE_HEARTBEAT_GLOB": str(hb)})
+    assert proc.returncode == 0  # never blocks a session
+    assert "tripwire" in proc.stdout
+    assert "older than" in proc.stdout
+    assert "additionalContext" in proc.stdout
+
+
+def test_tripwire_fires_when_heartbeat_missing(tmp_path: Path) -> None:
+    proc = _run_tripwire({"VNX_TRIPWIRE_HEARTBEAT_GLOB": str(tmp_path / "nope" / "*.json")})
+    assert proc.returncode == 0
+    assert "NO heartbeat" in proc.stdout
+
+
+def test_tripwire_threshold_is_configurable(tmp_path: Path) -> None:
+    hb = tmp_path / "health" / "producer_freshness_monitor.json"
+    _write_heartbeat(hb, age_seconds=3600)  # 1h old
+    # Default threshold (26h): quiet.
+    assert _run_tripwire({"VNX_TRIPWIRE_HEARTBEAT_GLOB": str(hb)}).stdout.strip() == ""
+    # Tight threshold (30 min): fires.
+    proc = _run_tripwire({"VNX_TRIPWIRE_HEARTBEAT_GLOB": str(hb), "VNX_TRIPWIRE_MAX_AGE_MIN": "30"})
+    assert "older than 30m" in proc.stdout

--- a/tests/test_path_parity.py
+++ b/tests/test_path_parity.py
@@ -1,0 +1,96 @@
+"""Tests for the PATH/interpreter parity check (scripts/lib/path_parity.py).
+
+RED against origin/main (module does not exist), GREEN on this branch.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+import path_parity  # noqa: E402
+
+
+def _probe(executable: str, version: str, ok: bool = True, error=None) -> dict:
+    return {"ok": ok, "executable": executable, "version": version, "prefix": "/x", "error": error}
+
+
+def test_parity_holds_on_same_version() -> None:
+    fg = _probe("/opt/homebrew/bin/python3", "3.12.4")
+    bg = _probe("/usr/bin/python3", "3.12.1")
+    result = path_parity.compare_parity(fg, bg)
+    assert result["parity"] is True
+    # A different executable PATH on the same major.minor is informational
+    # (macOS jobs legitimately resolve another binary), never a failure.
+    assert result["mismatches"] == []
+    assert result["info"][0]["kind"] == "executable_differs"
+
+
+def test_parity_breaks_on_version_mismatch() -> None:
+    fg = _probe("/opt/homebrew/bin/python3", "3.12.4")
+    bg = _probe("/usr/bin/python3", "3.9.6")
+    result = path_parity.compare_parity(fg, bg)
+    assert result["parity"] is False
+    assert result["mismatches"][0]["kind"] == "version_mismatch"
+
+
+def test_parity_breaks_when_background_interpreter_broken() -> None:
+    """The OI-852 case: foreground healthy, PATH-resolved background python3 dead."""
+    fg = _probe("/opt/homebrew/bin/python3", "3.12.4")
+    bg = _probe(None, None, ok=False, error="python3: command not found")
+    result = path_parity.compare_parity(fg, bg)
+    assert result["parity"] is False
+    assert result["mismatches"][0]["kind"] == "background_interpreter_broken"
+
+
+def test_parity_breaks_when_foreground_interpreter_broken() -> None:
+    fg = _probe(None, None, ok=False, error="bad interpreter")
+    bg = _probe("/usr/bin/python3", "3.12.1")
+    result = path_parity.compare_parity(fg, bg)
+    assert result["parity"] is False
+    assert result["mismatches"][0]["kind"] == "foreground_interpreter_broken"
+
+
+class _FakeProc:
+    def __init__(self, stdout: str = "", returncode: int = 0, stderr: str = ""):
+        self.stdout = stdout
+        self.stderr = stderr
+        self.returncode = returncode
+
+
+def test_probe_interpreter_parses_real_shape() -> None:
+    payload = json.dumps({"executable": "/usr/bin/python3", "version": "3.9.6", "prefix": "/usr"})
+
+    def runner(cmd, capture_output=False, text=False, check=False, env=None, timeout=None):
+        return _FakeProc(stdout=payload + "\n")
+
+    probe = path_parity.probe_interpreter(runner=runner, env={"PATH": "/usr/bin:/bin"})
+    assert probe["ok"] is True
+    assert probe["executable"] == "/usr/bin/python3"
+    assert probe["version"] == "3.9.6"
+
+
+def test_probe_interpreter_never_raises_on_broken_python() -> None:
+    def runner(cmd, capture_output=False, text=False, check=False, env=None, timeout=None):
+        raise OSError("python3 not found")
+
+    probe = path_parity.probe_interpreter(runner=runner)
+    assert probe["ok"] is False
+    assert "not found" in probe["error"]
+
+
+def test_probe_interpreter_flags_nonzero_exit() -> None:
+    def runner(cmd, capture_output=False, text=False, check=False, env=None, timeout=None):
+        return _FakeProc(stdout="", returncode=1, stderr="dyld: Library not loaded")
+
+    probe = path_parity.probe_interpreter(runner=runner)
+    assert probe["ok"] is False
+    assert "dyld" in probe["error"]
+
+
+def test_background_env_uses_launchd_default_path() -> None:
+    env = path_parity.background_env()
+    assert env["PATH"] == path_parity.BACKGROUND_PATH

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -1,0 +1,273 @@
+"""Tests for the per-key producer-freshness sweep (scripts/lib/producer_freshness.py).
+
+Every test in this file is RED against origin/main (the module, config and CLI
+do not exist there) and GREEN on the producer-freshness-monitor branch.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+import producer_freshness as pf  # noqa: E402
+
+NOW = time.time()
+DAY = 86400
+
+
+def _touch(path: Path, age_seconds: float) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("{}\n", encoding="utf-8")
+    ts = NOW - age_seconds
+    os.utime(path, (ts, ts))
+
+
+def _make_review_gates(state_dir: Path) -> None:
+    # The 2026-07-31 incident shape: codex_gate requests silent ~6 days,
+    # results silent ~3 days; kimi_gate results fresh.
+    _touch(state_dir / "review_gates" / "requests" / "pr-1228-codex_gate.json", 6 * DAY)
+    _touch(state_dir / "review_gates" / "requests" / "pr-1220-kimi_gate.json", 6 * DAY)
+    _touch(state_dir / "review_gates" / "results" / "pr-1228-codex_gate.json", 3 * DAY)
+    _touch(state_dir / "review_gates" / "results" / "pr-1233-kimi_gate.json", 0.5 * DAY)
+
+
+def _make_demand_register(state_dir: Path, events_after_iso_ts: float, n: int) -> None:
+    lines = []
+    for i in range(n):
+        ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(events_after_iso_ts + 3600 * (i + 1)))
+        lines.append(json.dumps({"timestamp": ts, "event": "dispatch_started", "dispatch_id": f"DISP-{i:03d}"}))
+    (state_dir / "dispatch_register.ndjson").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def _make_runtime_db(state_dir: Path) -> None:
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("CREATE TABLE dispatches (dispatch_id TEXT, created_at TEXT)")
+        # Only the dlv- producer ever wrote, and it stopped 15 days ago.
+        for i in range(3):
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(NOW - (15 + i) * DAY))
+            conn.execute("INSERT INTO dispatches VALUES (?, ?)", (f"dlv-{i:04d}-x", ts))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _make_quality_db(state_dir: Path) -> None:
+    db = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute("CREATE TABLE governance_metrics (metric_name TEXT, computed_at TEXT)")
+        old = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(NOW - 45 * DAY))
+        fresh = time.strftime("%Y-%m-%d %H:%M:%S", time.gmtime(NOW - 0.1 * DAY))
+        conn.execute("INSERT INTO governance_metrics VALUES ('fpy', ?)", (old,))
+        conn.execute("INSERT INTO governance_metrics VALUES ('rework_rate', ?)", (old,))
+        conn.execute("INSERT INTO governance_metrics VALUES ('dispatch_count', ?)", (fresh,))
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _registry(state_dir: Path) -> list:
+    return [
+        {
+            "name": "review_gate_requests",
+            "type": "directory",
+            "path": str(state_dir / "review_gates" / "requests"),
+            "glob": "*.json",
+            "key_regex": r"^pr-[0-9]+-(?P<key>.+)\.json$",
+            "timestamp": "mtime",
+            "cadence_seconds": DAY,
+            "demand": {
+                "type": "ndjson_events",
+                "path": str(state_dir / "dispatch_register.ndjson"),
+                "timestamp_field": "timestamp",
+                "label": "dispatch_register events",
+            },
+        },
+        {
+            "name": "review_gate_results",
+            "type": "directory",
+            "path": str(state_dir / "review_gates" / "results"),
+            "glob": "*.json",
+            "key_regex": r"^pr-[0-9]+-(?P<key>.+)\.json$",
+            "timestamp": "mtime",
+            "cadence_seconds": DAY,
+            "demand": {
+                "type": "ndjson_events",
+                "path": str(state_dir / "dispatch_register.ndjson"),
+                "timestamp_field": "timestamp",
+                "label": "dispatch_register events",
+            },
+        },
+        {
+            "name": "dispatches_table",
+            "type": "sqlite",
+            "db": str(state_dir / "runtime_coordination.db"),
+            "query": "SELECT dispatch_id, created_at FROM dispatches",
+            "key_column": "dispatch_id",
+            "key_transform": "prefix",
+            "timestamp_column": "created_at",
+            "cadence_seconds": 7 * DAY,
+            "expected_keys": ["dlv", "DISP"],
+        },
+        {
+            "name": "governance_metrics",
+            "type": "sqlite",
+            "db": str(state_dir / "quality_intelligence.db"),
+            "query": "SELECT metric_name, MAX(computed_at) AS last_ts FROM governance_metrics GROUP BY metric_name",
+            "key_column": "metric_name",
+            "timestamp_column": "last_ts",
+            "cadence_seconds": 3 * DAY,
+        },
+    ]
+
+
+@pytest.fixture()
+def fake_state(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _make_review_gates(state_dir)
+    _make_demand_register(state_dir, NOW - 3 * DAY, 5)
+    _make_runtime_db(state_dir)
+    _make_quality_db(state_dir)
+    return state_dir
+
+
+def _findings_by(report: dict, producer: str) -> dict:
+    return {f["key"]: f for f in report["findings"] if f["producer"] == producer}
+
+
+def test_real_config_loads() -> None:
+    registry = pf.load_registry(REPO_ROOT / "configs" / "producer_freshness.yaml")
+    names = [p["name"] for p in registry]
+    assert names == ["review_gate_requests", "review_gate_results", "dispatches_table", "governance_metrics"]
+
+
+def test_sweep_finds_silent_review_gate_keys(fake_state: Path) -> None:
+    report = pf.run_sweep(fake_state, _registry(fake_state), now=NOW)
+    requests = _findings_by(report, "review_gate_requests")
+    results = _findings_by(report, "review_gate_results")
+    # codex_gate is silent beyond its 1-day cadence in BOTH layers.
+    assert requests["codex_gate"]["kind"] == "stale"
+    assert results["codex_gate"]["kind"] == "stale"
+    assert results["codex_gate"]["silence_days"] == pytest.approx(3.0, abs=0.05)
+    # kimi_gate results are fresh — per-key grouping must NOT condemn the
+    # whole directory just because one key is dead (and vice versa).
+    assert "kimi_gate" not in results
+    # Demand evidence: dispatches kept flowing while the gate was silent.
+    assert results["codex_gate"]["demand"]["events_since_last_seen"] >= 1
+    assert report["status"] == "stale"
+
+
+def test_sweep_finds_dead_sqlite_keys_and_absent_producer(fake_state: Path) -> None:
+    report = pf.run_sweep(fake_state, _registry(fake_state), now=NOW)
+    dispatches = _findings_by(report, "dispatches_table")
+    # The dlv producer is stale (15 days > 7-day cadence)...
+    assert dispatches["dlv"]["kind"] == "stale"
+    # ...and the dispatch-door producer is entirely ABSENT: a producer that
+    # writes nothing can only be caught by an expected-key assertion.
+    assert dispatches["DISP"]["kind"] == "missing"
+    assert dispatches["DISP"]["expected_key_absent"] is True
+
+    metrics = _findings_by(report, "governance_metrics")
+    # Table looks alive (dispatch_count fresh) but fpy/rework_rate are dead —
+    # the exact governance_metrics case. Only per-key grouping sees this.
+    assert metrics["fpy"]["kind"] == "stale"
+    assert metrics["rework_rate"]["kind"] == "stale"
+    assert "dispatch_count" not in metrics
+
+
+def test_unreadable_source_is_a_finding_not_silence(tmp_path: Path) -> None:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    spec = {
+        "name": "broken_db_producer",
+        "type": "sqlite",
+        "db": str(state_dir / "does_not_exist.db"),
+        "query": "SELECT k, t FROM x",
+        "key_column": "k",
+        "timestamp_column": "t",
+        "cadence_seconds": DAY,
+    }
+    report = pf.run_sweep(state_dir, [spec], now=NOW)
+    assert report["findings_count"] == 1
+    assert report["findings"][0]["kind"] == "source_unreadable"
+    assert report["status"] == "stale"
+
+
+def test_report_and_heartbeat_written_every_run(tmp_path: Path) -> None:
+    """The heartbeat lands even on a zero-finding run — a sweep that finds
+    nothing and writes nothing is indistinguishable from one that never ran."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    fresh_dir = state_dir / "fresh"
+    _touch(fresh_dir / "pr-1-codex_gate.json", 60)
+    spec = {
+        "name": "fresh_producer",
+        "type": "directory",
+        "path": str(fresh_dir),
+        "glob": "*.json",
+        "key_regex": r"^pr-[0-9]+-(?P<key>.+)\.json$",
+        "timestamp": "mtime",
+        "cadence_seconds": DAY,
+    }
+    report = pf.run_sweep(state_dir, [spec], now=NOW)
+    assert report["findings_count"] == 0
+    assert report["status"] == "ok"
+
+    report_path = pf.append_report(state_dir, report)
+    heartbeat_path = pf.write_heartbeat(state_dir, report)
+
+    records = [json.loads(line) for line in report_path.read_text().splitlines() if line.strip()]
+    assert len(records) == 1
+    assert records[0]["event_type"] == "producer_freshness_sweep"
+    assert records[0]["status"] == "ok"
+
+    beacon = json.loads(heartbeat_path.read_text())
+    assert beacon["component"] == "producer_freshness_monitor"
+    assert beacon["status"] == "ok"
+    assert heartbeat_path.parent.name == "health"
+
+
+def test_report_appends_findings_as_ndjson(fake_state: Path) -> None:
+    report = pf.run_sweep(fake_state, _registry(fake_state), now=NOW)
+    report_path = pf.append_report(fake_state, report)
+    records = [json.loads(line) for line in report_path.read_text().splitlines() if line.strip()]
+    kinds = {r["event_type"] for r in records}
+    assert "producer_freshness_sweep" in kinds
+    assert "producer_freshness_finding" in kinds
+    finding_records = [r for r in records if r["event_type"] == "producer_freshness_finding"]
+    assert len(finding_records) == report["findings_count"]
+    assert all(r["run_id"] == report["run_id"] for r in records)
+
+
+def test_cli_no_write_touches_nothing_and_reports(fake_state: Path, capsys, monkeypatch) -> None:
+    """The acceptance mode against the live store: read-only, findings on stdout."""
+    import producer_freshness_monitor as cli  # noqa: PLC0415
+
+    before = {p for p in fake_state.rglob("*")}
+    rc = cli.main(
+        [
+            "--config",
+            str(REPO_ROOT / "configs" / "producer_freshness.yaml"),
+            "--state-dir",
+            str(fake_state),
+            "--no-write",
+        ]
+    )
+    after = {p for p in fake_state.rglob("*")}
+    assert rc == cli.EXIT_HEALTH
+    assert before == after, "--no-write must not create/modify any file"
+    out = json.loads(capsys.readouterr().out)
+    assert out["status"] == "stale"
+    assert any(f["producer"] == "review_gate_results" for f in out["findings"])


### PR DESCRIPTION
# Producer-freshness monitor — stil falen wordt binnen een dag zichtbaar

Track: `producer-freshness-monitor`. Basis: `origin/main` @ `f467b181` (incl. PR #1262).

## De vier onderdelen

| # | Onderdeel | Implementatie |
|---|-----------|---------------|
| 1 | Per-sleutel versheidsdiff, cadans per producent, NDJSON | `scripts/lib/producer_freshness.py` + `configs/producer_freshness.yaml` + CLI `scripts/producer_freshness_monitor.py` |
| 2 | Exit-status-capture launchd/cron/nohup → `job_exits.ndjson` | `scripts/lib/job_exit_capture.py` (transparante wrapper + `launchctl list` LastExitStatus-harvest met dedup-cache) |
| 3 | PATH/interpreter-pariteitscheck bij SessionStart | `scripts/lib/path_parity.py` + `scripts/hooks/path_parity_check.sh` (geregistreerd in `.claude/settings.json`) |
| 4 | Guard-fired-teller, observe-only | `scripts/lib/guard_stats.py`; geïnstrumenteerd: `phantom_guard.phantom_guard` (fired = `is_phantom`) en `plan_gate_enforcement.plan_gate_state` (fired = `UNRESOLVED`) |

Kern van onderdeel 1: groepering op de **eigen sleutel** van elke producent, nooit op tabelniveau. `expected_keys` maakt een producent die helemaal niets schrijft zichtbaar (afwezigheid is niet vindbaar door bestaande rijen te groeperen). Output is NDJSON (`producer_freshness.ndjson`), dus ADR-007 blijft buiten schot — de monitor opent geen centrale-DB-schrijfpad. Findings dragen `demand`-bewijs: events in `dispatch_register.ndjson` nieuwer dan de `last_seen` van de sleutel ("er viel wél werk terwijl deze producent zweeg").

De guard-teller (4) is strikt observe-only: hij wrapt de returnwaarde, raakt de beslissing nooit, en een teller-fout wordt gelogd en geslikt. Semantiek onveranderd — bewezen door de bestaande suites (93 tests, zie onder).

## De ironie opgelost

- De sweep schrijft via `HealthBeacon` **bij elke run** `<data_dir>/health/producer_freshness_monitor.json`, ook bij nul bevindingen.
- `hooks/monitor_tripwire.sh` (SessionStart) toetst **alleen de leeftijd** van dat heartbeat-bestand met `find -mmin +1560`. Puur bash + find + jq/sed: **geen gedeelde code, geen DB-verbinding, geen Python-interpreter** met de monitor. Die onafhankelijkheid is als test vastgelegd (`test_tripwire_shares_no_code_db_or_interpreter_with_monitor`), zodat een "handige" refactor die gedeelde tooling importeert in CI faalt.

## Acceptatietest — de monitor tegen de echte data (de eis waarop gereviewd wordt)

Read-only run tegen de live store (`--no-write`; geverifieerd dat er geen enkel bestand in `~/.vnx-data/vnx-dev/` is aangemaakt of gewijzigd — zie ook `test_cli_no_write_touches_nothing_and_reports`):

```
$ python3 scripts/producer_freshness_monitor.py --state-dir ~/.vnx-data/vnx-dev/state --no-write --human
exit=11
producer-freshness sweep ab0a7d3b7b45 — status=stale findings=11 (producers=4, keys=13)
  STALE   review_gate_requests/codex_gate: last_seen=2026-07-25T14:40:21Z (6.01d ago, cadence 86400.0s) — demand while silent: 43 dispatch_register events
  STALE   review_gate_requests/gemini_review: last_seen=2026-07-06T15:33:32Z (24.98d ago, cadence 86400.0s) — demand while silent: 368 dispatch_register events
  STALE   review_gate_results/codex_gate: last_seen=2026-07-25T14:40:21Z (6.01d ago, cadence 86400.0s) — demand while silent: 43 dispatch_register events
  STALE   review_gate_results/gemini_review: last_seen=2026-07-06T15:33:32Z (24.98d ago, cadence 86400.0s) — demand while silent: 368 dispatch_register events
  STALE   review_gate_results/kimi_gate: last_seen=2026-07-28T16:42:53Z (2.93d ago, cadence 86400.0s) — demand while silent: 2 dispatch_register events
  MISSING dispatches_table/DISP: expected key has never written
  STALE   dispatches_table/dlv: last_seen=2026-07-16T13:40:13Z (15.05d ago, cadence 604800.0s)
  STALE   governance_metrics/fpy: last_seen=2026-06-16T02:09:06Z (45.53d ago, cadence 259200.0s)
  STALE   governance_metrics/gate_velocity_hours: last_seen=2026-06-16T02:09:06Z (45.53d ago, cadence 259200.0s)
  STALE   governance_metrics/oi_resolution_rate: last_seen=2026-06-21T02:09:08Z (40.53d ago, cadence 259200.0s)
  STALE   governance_metrics/rework_rate: last_seen=2026-06-16T02:09:06Z (45.53d ago, cadence 259200.0s)
```

**De stilgevallen review-gate-laag wordt gemeld**: nul resultaten sinds `pr-1233-kimi_gate.json` (28-07 18:42 CEST = 16:42 UTC — exact het bestand uit de opdracht), nul requests sinds 25-07, mét het demand-bewijs dat er in die periode wél dispatches door de deur gingen (43 resp. 2 register-events). Bonus-observaties op echte data: het tweede geval uit de opdracht (dispatch-deur-producent `DISP` volledig afwezig, `dlv` 15 dagen stil) en de zes weken dode `fpy`/`rework_rate`-sleutels in een levend ogende `governance_metrics`-tabel. Aanscherping van de aanleiding: de requests-laag ligt niet drie maar **zes** dagen stil; `kimi_gate` schrijft nooit request-files (alleen results) en is daarom bewust géén finding in de requests-laag.

## Verificatie: rood op origin/main, groen op deze branch

**Rood** — zelfde vijf testbestanden tegen een kale `origin/main`-worktree (`/tmp/vnx-pfm-base`, inmiddels opgeruimd):

```
$ python3 -m pytest tests/test_producer_freshness.py tests/test_job_exit_capture.py tests/test_path_parity.py tests/test_guard_stats.py tests/test_monitor_tripwire.py > /tmp/pfm_tests_main.txt 2>&1; echo "exit=$?"
exit=2
E   ModuleNotFoundError: No module named 'path_parity'
E   ModuleNotFoundError: No module named 'guard_stats'
... (4 collection errors: producer_freshness, job_exit_capture, path_parity, guard_stats bestaan niet op main)

$ python3 -m pytest tests/test_monitor_tripwire.py > /tmp/pfm_tripwire_main.txt 2>&1; echo "exit=$?"
exit=1
E       FileNotFoundError: hooks/monitor_tripwire.sh
============================== 5 failed in 0.17s ===============================
```

**Groen** — op deze branch:

```
$ python3 -m pytest tests/test_producer_freshness.py tests/test_job_exit_capture.py tests/test_path_parity.py tests/test_guard_stats.py tests/test_monitor_tripwire.py -p no:cacheprovider > /tmp/pfm_final_branch.txt 2>&1; echo "exit=$?"
exit=0
============================== 33 passed in 0.55s ==============================
```

**Geen semantiek-regressie door de guard-instrumentatie** — bestaande suites ongewijzigd groen:

```
$ python3 -m pytest tests/test_phantom_guard.py tests/test_phantom_guard_branch_fallback.py tests/test_phantom_guard_fix_forward.py tests/test_phantom_guard_inline.py tests/test_phantom_guard_oi869_oi870.py tests/test_plan_gate_enforcement.py -p no:cacheprovider > /tmp/pfm_regression.txt 2>&1; echo "exit=$?"
exit=0
============================== 93 passed in 4.28s ==============================
```

**Lint-gate** (`scripts/ci_lint_patterns.py --scan-stdin` over de daadwerkelijke added lines, zoals de CI-job draait): exit=0. `ruff check`: clean. Geen `except Exception: pass` — elke swallow logt.

## Live-incident van de pariteitscheck zelf

De eerste smoke-run van de SessionStart-hook vond direct een echte divergentie op deze machine: achtergrond-jobs (launchd-PATH) resolven `python3` naar **Xcode 3.9.6**, de voorgrond-shell naar **Homebrew 3.12.11** (`version_mismatch`). Precies de OI-852-klasse die deze check moet vangen. (De smoke-run schreef per ongeluk `path_parity.json` in de live store omdat `VNX_STATE_DIR` in deze shell daarheen wijst; dat ene bestand is verwijderd en de store is hersteld — verder is niets geschreven.)

## Bediening na merge

- Handmatig: `python3 scripts/producer_freshness_monitor.py` (exit 11 bij bevindingen).
- Read-only diagnose: `--state-dir <store>/state --no-write --human`.
- Dagelijks om 06:00 via `scripts/launchd/com.vnx.producer-freshness-monitor.plist` (invullen `__VNX_REPO_ROOT__`, `launchctl load -w`). De sweep oogst tegelijk launchd-exit-codes; zijn eigen exit-status verschijnt via de volgende harvest in `job_exits.ndjson`; zijn heartbeat wordt door de onafhankelijke tripwire bewaakt.
- Docs: `docs/operations/PRODUCER_FRESHNESS_MONITOR.md`.
