### PR TITLE
fix(dispatch): thread requires_mcp through the plan boundary (OI-865)

### DIFF
--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -319,6 +319,7 @@ cmd_dispatch() {
   local model_override="${VNX_MODEL:-sonnet}"
   local adapter_override=""
   local dry_run=0
+  local requires_mcp_cli=""
 
   if [ "$#" -eq 0 ]; then
     err "[dispatch] No dispatch file specified. Use: vnx dispatch <file.md>"
@@ -345,6 +346,8 @@ Options:
   --model <model>       Override model (default: sonnet)
   --adapter <lane>      Delivery lane: tmux (default) or subprocess (burst).
                         Precedence: --adapter > 'Adapter:' header > VNX_ADAPTER env > tmux
+  --requires-mcp        Preserve ambient MCP config (Requires-MCP: true header) instead
+                        of the force-empty scoped posture
   --dry-run             Show what would happen without dispatching
   -h, --help            Show this help
 
@@ -384,6 +387,8 @@ HELP
         adapter_override="$2"; shift 2 ;;
       --adapter=*)
         adapter_override="${1#*=}"; shift ;;
+      --requires-mcp)
+        requires_mcp_cli="--requires-mcp"; shift ;;
       --dry-run|-n)
         dry_run=1; shift ;;
       -h|--help)
@@ -403,6 +408,8 @@ Options:
   --model <model>       Override model (default: sonnet)
   --adapter <lane>      Delivery lane: tmux (default) or subprocess (burst).
                         Precedence: --adapter > 'Adapter:' header > VNX_ADAPTER env > tmux
+  --requires-mcp        Preserve ambient MCP config (Requires-MCP: true header) instead
+                        of the force-empty scoped posture
   --dry-run             Show what would happen without dispatching
   -h, --help            Show this help
 
@@ -514,6 +521,18 @@ HELP
   local dispatch_id
   dispatch_id=$(_d_generate_dispatch_id "$slug" "$track")
 
+  # Derive requires_mcp from the Requires-MCP: header (mirrors dispatch_deliver.sh's
+  # sed pattern), unless --requires-mcp was passed explicitly — the CLI flag wins.
+  local _requires_mcp="false"
+  if [ -z "$requires_mcp_cli" ]; then
+    _requires_mcp=$(sed -n 's/^Requires-MCP:[[:space:]]*//Ip' "$abs_file" 2>/dev/null | sed 's/#.*//' | tr -d ' ' | tr '[:upper:]' '[:lower:]')
+    _requires_mcp="${_requires_mcp:-false}"
+  fi
+  local _mcp_flag=()
+  if [ "$_requires_mcp" = "true" ] || [ -n "$requires_mcp_cli" ]; then
+    _mcp_flag=(--requires-mcp)
+  fi
+
   log "[dispatch] File:       $(basename "$abs_file")"
   log "[dispatch] Terminal:   $terminal (Track $track)"
   log "[dispatch] Role:       ${role:-<none>}"
@@ -521,6 +540,7 @@ HELP
   log "[dispatch] Feature:    ${feature:-<none>}"
   log "[dispatch] Model:      $model_override"
   log "[dispatch] Adapter:    $adapter$([ "$adapter" = tmux ] && printf ' (default, subscription)' || printf ' (burst, paid)')"
+  log "[dispatch] Requires-MCP: $([ "${#_mcp_flag[@]}" -gt 0 ] && printf 'yes' || printf 'no')"
   log "[dispatch] DispatchID: $dispatch_id"
 
   if [ "$dry_run" -eq 1 ]; then
@@ -580,6 +600,7 @@ HELP
       --model "$model_override" \
       --worker-label "$terminal" \
       ${role:+--role "$role"} \
+      ${_mcp_flag[@]+"${_mcp_flag[@]}"} \
       || exit_code=$?
   else
     # OPT-IN burst lane: paid headless SubprocessAdapter.
@@ -593,6 +614,7 @@ HELP
       --model "$model_override" \
       ${role:+--role "$role"} \
       ${_ar_flag[@]+"${_ar_flag[@]}"} \
+      ${_mcp_flag[@]+"${_mcp_flag[@]}"} \
       || exit_code=$?
   fi
 

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -223,6 +223,7 @@ def _print_plan(plan: ExecutionPlan, fp: str) -> None:
     print(f"  lane:         {plan.lane}")
     print(f"  target_id:    {plan.target_id}")
     print(f"  billing:      {plan.billing}")
+    print(f"  requires_mcp: {plan.requires_mcp}")
     print(f"  route_reason: {plan.route_reason}")
     for w in plan.warnings:
         print(f"  [WARN] {w}")
@@ -1170,6 +1171,7 @@ def _execute_claude(
         deadline_seconds=plan.deadline_seconds,
         base_ref=plan.base_ref,
         isolated_worktree=True,
+        requires_mcp=plan.requires_mcp,
     )
     return 0 if result.success else 1
 

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -94,6 +94,15 @@ class ExecutionPlan:
     role: Optional[str] = None          # carried from DispatchSpec for the phantom-guard review
                                         # exemption (codex P0.2 F2). NOT in digest() — advisory only,
                                         # must not perturb the permit fingerprint.
+    requires_mcp: bool = False          # OI-865: True keeps the worker's ambient MCP config instead
+                                        # of the force-empty scoped posture. Default False is the
+                                        # choice for a MISSING spec field: DispatchSpec.requires_mcp
+                                        # defaults to False and the tmux lane's dispatch() defaults to
+                                        # False, so a spec that omits the field lands on exactly the
+                                        # value today's code already uses — never silently "no MCP"
+                                        # for a dispatch that already gets MCP. It IS in digest():
+                                        # MCP access changes worker behavior, so a permit for a
+                                        # requires_mcp plan must not validate a force-empty plan.
 
     def digest(self) -> str:
         """Stable sha256 over the canonical, order-independent field set.
@@ -113,6 +122,7 @@ class ExecutionPlan:
             "isolation": self.isolation.value,
             "require_worktree": self.require_worktree,
             "seed_materialize": self.seed_materialize,
+            "requires_mcp": self.requires_mcp,
             "instruction_delivery": self.instruction_delivery,
             "report_contract": self.report_contract,
             "warmup": self.warmup,
@@ -298,6 +308,7 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         isolation=isolation,
         require_worktree=require_worktree,
         seed_materialize=seed_materialize,
+        requires_mcp=spec.requires_mcp,
         instruction_delivery=instruction_delivery,
         report_contract=report_contract,
         warmup=warmup,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2756,6 +2756,11 @@ def main(argv: "list[str] | None" = None) -> int:
         help="spawn worker in the main repo checkout (opt-out of isolation)",
     )
     parser.add_argument("--base-ref", default="origin/main")
+    parser.add_argument(
+        "--requires-mcp", action="store_true", default=False, dest="requires_mcp",
+        help="Preserve ambient MCP config for this dispatch instead of the default "
+             "force-empty scoped posture (spec requires_mcp: true / Requires-MCP: true).",
+    )
     # ADR-006: staging→pending→promote gate enforcement.
     parser.add_argument(
         "--from-staging-id", default=None, dest="from_staging_id",
@@ -2804,6 +2809,7 @@ def main(argv: "list[str] | None" = None) -> int:
         isolated_worktree=args.isolated_worktree,
         base_ref=args.base_ref,
         working_tree_only=args.working_tree_only,
+        requires_mcp=args.requires_mcp,
     )
     print(json.dumps(result.__dict__, default=str))
     return 0 if result.success else 1

--- a/tests/test_dispatch_lane_routing.py
+++ b/tests/test_dispatch_lane_routing.py
@@ -30,7 +30,12 @@ sys.exit(0)
 """
 
 
-def _make_env(tmp_path: Path, *, header_adapter: str | None = None) -> dict:
+def _make_env(
+    tmp_path: Path,
+    *,
+    header_adapter: str | None = None,
+    header_requires_mcp: bool = False,
+) -> dict:
     """Build a fake VNX_HOME with stub delivery scripts + a pending dispatch file."""
     vnx_home = tmp_path / "vnx_home"
     lib = vnx_home / "scripts" / "lib"
@@ -47,6 +52,8 @@ def _make_env(tmp_path: Path, *, header_adapter: str | None = None) -> dict:
     header = "[[TARGET:T1]]\nRole: backend-developer\nGate: G1\nFeature: demo\n"
     if header_adapter is not None:
         header += f"Adapter: {header_adapter}\n"
+    if header_requires_mcp:
+        header += "Requires-MCP: true\n"
     df = dispatch_dir / "pending" / "demo.md"
     df.write_text(header + "\nDo the thing.\n")
 
@@ -203,6 +210,40 @@ def test_auto_route_yields_to_vnx_adapter_env(tmp_path):
     res = _run(e, vnx_adapter="tmux", extra_env={"VNX_AUTO_ROUTE": "1"})
     assert res.returncode == 0, res.stderr
     assert _lane(e)["lane"] == "tmux"
+
+
+# ---------------------------------------------------------------------------
+# OI-865 — requires_mcp forwarding (--requires-mcp flag + Requires-MCP: header)
+# ---------------------------------------------------------------------------
+
+def test_requires_mcp_flag_forwarded_to_tmux(tmp_path):
+    """--requires-mcp on the raw-file lane reaches the tmux CLI argv."""
+    e = _make_env(tmp_path)
+    res = _run(e, "--requires-mcp")
+    assert res.returncode == 0, res.stderr
+    rec = _lane(e)
+    assert rec["lane"] == "tmux"
+    assert "--requires-mcp" in rec["argv"], "tmux CLI must receive --requires-mcp"
+
+
+def test_requires_mcp_flag_forwarded_to_subprocess(tmp_path):
+    """--requires-mcp also reaches the opt-in subprocess lane argv."""
+    e = _make_env(tmp_path)
+    res = _run(e, "--requires-mcp", "--adapter", "subprocess")
+    assert res.returncode == 0, res.stderr
+    rec = _lane(e)
+    assert rec["lane"] == "subprocess"
+    assert "--requires-mcp" in rec["argv"], "subprocess CLI must receive --requires-mcp"
+
+
+def test_requires_mcp_header_forwarded(tmp_path):
+    """'Requires-MCP: true' in the dispatch file header is honoured without a flag."""
+    e = _make_env(tmp_path, header_requires_mcp=True)
+    res = _run(e)
+    assert res.returncode == 0, res.stderr
+    assert "--requires-mcp" in _lane(e)["argv"], (
+        "Requires-MCP: true header must forward --requires-mcp to the delivery script"
+    )
 
 
 if __name__ == "__main__":

--- a/tests/test_requires_mcp_propagation.py
+++ b/tests/test_requires_mcp_propagation.py
@@ -1,0 +1,222 @@
+"""test_requires_mcp_propagation.py — OI-865: requires_mcp must survive the plan boundary.
+
+The field exists in DispatchSpec (dispatch_spec.py:100) and is read by the door
+(dispatch_cli.load_spec), but was dropped at compile_plan: ExecutionPlan had no
+field and _execute_claude never forwarded it, so a dispatch staged with
+requires_mcp:true lost its ambient MCP under scoped mode (blocks #1252's default
+worker-capability scoping flip).
+
+Every test in this file is RED on origin/main (the field does not exist there)
+and GREEN once the propagation is wired end-to-end:
+  spec.requires_mcp -> compile_plan -> ExecutionPlan.requires_mcp
+                     -> _execute_claude -> lane.dispatch(requires_mcp=...)
+                     -> tmux CLI --requires-mcp -> lane.dispatch(requires_mcp=...)
+"""
+from __future__ import annotations
+
+import hashlib
+import inspect
+import sys
+from pathlib import Path
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import _execute_claude
+from dispatch_internal import issue_permit
+from dispatch_plan import ExecutionPlan, RuntimeSnapshot, compile_plan
+from dispatch_spec import DispatchSpec, Isolation, Provider, ValidatedSpec
+from tmux_interactive_dispatch import InteractiveDispatchResult, TmuxInteractiveDispatch, main
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fake_instruction_file(tmp_path: Path, text: str = "# MCP propagation test\n") -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text(text, encoding="utf-8")
+    return f
+
+
+def _make_vspec(*, requires_mcp: bool | None = None, tmp_path: Path) -> ValidatedSpec:
+    """Build a ValidatedSpec; requires_mcp=None omits the field (uses the dataclass default)."""
+    kwargs: dict = {}
+    if requires_mcp is not None:
+        kwargs["requires_mcp"] = requires_mcp
+    ifile = _fake_instruction_file(tmp_path)
+    spec = DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="mcp-propagate-001",
+        staging_id="staging-mcp-001",
+        instruction_file=ifile,
+        role="backend-developer",
+        target_slot="T1",
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        **kwargs,
+    )
+    instruction_text = ifile.read_text(encoding="utf-8")
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+    )
+
+
+def _healthy_snapshot() -> RuntimeSnapshot:
+    return RuntimeSnapshot(staging_promoted=True)
+
+
+def _make_mcp_plan(tmp_path: Path, *, requires_mcp: bool) -> ExecutionPlan:
+    """A valid claude-lane plan with a matching instruction sha256 for _execute_claude."""
+    ifile = _fake_instruction_file(tmp_path)
+    sha = hashlib.sha256(ifile.read_text(encoding="utf-8").encode("utf-8")).hexdigest()
+    return ExecutionPlan(
+        dispatch_id="mcp-exec-001",
+        project_id="vnx-dev",
+        provider=Provider.CLAUDE,
+        model="sonnet",
+        lane="claude_tmux_subscription",
+        adapter="tmux_claude",
+        target_id="ephemeral",
+        billing="subscription",
+        serialization_class="claude-tmux",
+        isolation=Isolation.WORKTREE,
+        require_worktree=True,
+        seed_materialize=False,
+        instruction_delivery="file_ref",
+        report_contract="required",
+        warmup="verify_strict",
+        deadline_seconds=3600,
+        base_ref="origin/main",
+        dispatch_paths=(),
+        instruction_file=ifile,
+        route_reason="D11,D3,D1,D2,D4,D5,D6,D7,D8,D9,D10,D12",
+        instruction_sha256=sha,
+        requires_mcp=requires_mcp,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Plan boundary — compile_plan must carry requires_mcp (kernel DoD)
+# ---------------------------------------------------------------------------
+
+class TestCompilePlanPropagatesRequiresMcp:
+    def test_true_reaches_plan(self, tmp_path: Path) -> None:
+        plan = compile_plan(_make_vspec(requires_mcp=True, tmp_path=tmp_path), _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.requires_mcp is True, "requires_mcp:true must survive compile_plan"
+
+    def test_false_reaches_plan(self, tmp_path: Path) -> None:
+        plan = compile_plan(_make_vspec(requires_mcp=False, tmp_path=tmp_path), _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.requires_mcp is False, "requires_mcp:false must survive compile_plan"
+
+    def test_missing_field_defaults_false(self, tmp_path: Path) -> None:
+        plan = compile_plan(_make_vspec(tmp_path=tmp_path), _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.requires_mcp is False, (
+            "a spec without the field must default to False, matching DispatchSpec's default"
+        )
+
+    def test_default_matches_todays_lane_default(self, tmp_path: Path) -> None:
+        """A missing field lands on exactly the value today's lane already uses.
+
+        The tmux lane's dispatch() has always defaulted requires_mcp=False, so a
+        spec that omits the field gets the same ambient-MCP behavior as today —
+        the default must NOT silently mean "no MCP" for dispatches that already
+        keep their MCP.
+        """
+        plan = compile_plan(_make_vspec(tmp_path=tmp_path), _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        lane_default = inspect.signature(TmuxInteractiveDispatch.dispatch).parameters[
+            "requires_mcp"
+        ].default
+        assert plan.requires_mcp is lane_default is False
+
+    def test_requires_mcp_changes_digest(self, tmp_path: Path) -> None:
+        """MCP access alters worker behavior, so it must perturb the permit fingerprint."""
+        plan_true = compile_plan(_make_vspec(requires_mcp=True, tmp_path=tmp_path), _healthy_snapshot())
+        plan_false = compile_plan(_make_vspec(requires_mcp=False, tmp_path=tmp_path), _healthy_snapshot())
+        assert isinstance(plan_true, ExecutionPlan)
+        assert isinstance(plan_false, ExecutionPlan)
+        assert plan_true.digest() != plan_false.digest(), (
+            "digest() must distinguish requires_mcp: true from false"
+        )
+
+
+# ---------------------------------------------------------------------------
+# _execute_claude must forward the plan field to the lane
+# ---------------------------------------------------------------------------
+
+class TestExecuteClaudeForwardsRequiresMcp:
+    def test_true_reaches_lane(self, tmp_path: Path) -> None:
+        plan = _make_mcp_plan(tmp_path, requires_mcp=True)
+        permit = issue_permit(plan)
+        with patch(
+            "tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+            return_value=MagicMock(success=True),
+        ) as mock_dispatch:
+            _execute_claude(plan, permit, state_dir=tmp_path / "state", data_dir=tmp_path)
+        mock_dispatch.assert_called_once()
+        _, kwargs = mock_dispatch.call_args
+        assert kwargs["requires_mcp"] is True
+
+    def test_false_reaches_lane(self, tmp_path: Path) -> None:
+        plan = _make_mcp_plan(tmp_path, requires_mcp=False)
+        permit = issue_permit(plan)
+        with patch(
+            "tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch",
+            return_value=MagicMock(success=True),
+        ) as mock_dispatch:
+            _execute_claude(plan, permit, state_dir=tmp_path / "state", data_dir=tmp_path)
+        mock_dispatch.assert_called_once()
+        _, kwargs = mock_dispatch.call_args
+        assert kwargs["requires_mcp"] is False
+
+
+# ---------------------------------------------------------------------------
+# tmux CLI --requires-mcp must reach the lane
+# ---------------------------------------------------------------------------
+
+class TestTmuxCliForwardsRequiresMcp:
+    def _run_main(self, tmp_path: Path, *extra_args: str) -> tuple[int, dict]:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        seen: dict = {}
+
+        def fake_dispatch(self_inner, instruction, dispatch_id, **kwargs):
+            seen.update(kwargs)
+            return InteractiveDispatchResult(success=True, dispatch_id=dispatch_id)
+
+        with patch.object(TmuxInteractiveDispatch, "dispatch", fake_dispatch):
+            with patch("tmux_interactive_dispatch._resolve_state_dir", return_value=state_dir):
+                rc = main([
+                    "--dispatch-id", "cli-mcp-flag",
+                    "--instruction", "do it",
+                    "--shared-worktree",
+                    "--allow-unstaged", "--reason", "ci-test",
+                    *extra_args,
+                ])
+        return rc, seen
+
+    def test_flag_true_reaches_lane(self, tmp_path: Path) -> None:
+        rc, seen = self._run_main(tmp_path, "--requires-mcp")
+        assert rc == 0
+        assert seen["requires_mcp"] is True
+
+    def test_absent_defaults_false(self, tmp_path: Path) -> None:
+        rc, seen = self._run_main(tmp_path)
+        assert rc == 0
+        assert seen["requires_mcp"] is False
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Problem

`DispatchSpec.requires_mcp` was dropped at the plan boundary. The field exists and is written (`dispatch_spec.py:100`), the door reads it (`dispatch_cli.py:189`), but `ExecutionPlan` had no field, `compile_plan` never carried it, `_execute_claude` never forwarded it, the tmux CLI had no `--requires-mcp` argument, and `dispatch.sh` passed no MCP flag.

Consequence: a dispatch staged with `requires_mcp: true` loses its ambient MCP under scoped mode. The opt-out never arrives. This blocks #1252 (worker capability scoping default on for tmux-spawn workers), which flips `VNX_WORKER_SCOPED=1` and would fleet-broadly remove MCP with an opt-out that provably doesn't arrive.

## Change

Wire the field end-to-end, spec → plan → lane:

1. **`ExecutionPlan.requires_mcp`** — new field, filled from the spec in `compile_plan`. Included in `digest()`: MCP access changes worker behavior, so a permit for a `requires_mcp` plan must not validate a force-empty plan.
2. **`_execute_claude`** — forwards `plan.requires_mcp` to `lane.dispatch()`.
3. **tmux CLI** — accepts `--requires-mcp`, forwards to `dispatch()` (which already had the plumbing: `_default_launch_command`, `_wp_build_claude_scope_args`).
4. **`dispatch.sh`** — accepts `--requires-mcp` (CLI wins) or derives it from the `Requires-MCP:` header (mirrors `dispatch_deliver.sh`), passing it to both the tmux and subprocess delivery scripts.

## Default choice (missing field)

`requires_mcp=False` — explicitly documented at the field declaration in `ExecutionPlan`. `DispatchSpec.requires_mcp` defaults to `False` and the tmux lane's `dispatch()` defaults to `False`, so a spec that omits the field lands on exactly the value today's code already uses. A missing field can never silently mean "no MCP" for a dispatch that already gets MCP. **No defaults are flipped in this PR** — field carry-through only.

## Verification

Every test is **red on `origin/main`** and green on this branch:

| Test | origin/main | branch |
|---|---|---|
| `tests/test_requires_mcp_propagation.py` (9 tests) | 9 failed | 9 passed |
| `tests/test_dispatch_lane_routing.py -k requires_mcp` (3 tests) | 3 failed | 3 passed |

Red-run evidence:
```
$ python -m pytest tests/test_requires_mcp_propagation.py   # on origin/main worktree
9 failed in 0.24s
$ python -m pytest tests/test_dispatch_lane_routing.py -k requires_mcp   # on origin/main worktree
3 failed in 0.57s
```

Green-run evidence:
```
$ python -m pytest tests/test_requires_mcp_propagation.py
9 passed in 0.24s
$ python -m pytest tests/test_dispatch_lane_routing.py -k requires_mcp
3 passed in 1.05s
```

Real propagation via `compile_plan`:
```
true     -> plan.requires_mcp = True
false    -> plan.requires_mcp = False
missing  -> plan.requires_mcp = False
```

Core regression suite: `test_dispatch_plan.py` + `test_dispatch_cli.py` + `test_requires_mcp_propagation.py` + `test_dispatch_lane_routing.py` = **237 passed**. Envelope/plan-construction files (envelope_plan, envelope_fail_loud, final_prompt_integrity, kimi_model_resolver) = **84 passed**. Full relevant suite: 510 passed, 3 pre-existing tmux failures that also fail on `origin/main` (confirmed against a clean main worktree).

Lint gate (`scripts/ci_lint_patterns.py`): clean.

## Open Items

None.