### PR TITLE
fix(receipt): harvest token_usage for all claude-harness providers (OI-884)

### DIFF
--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -43,6 +43,7 @@ from append_receipt_internals.receipt_finalize import (
 )
 from append_receipt_internals.validation import _validate_receipt
 from receipt_schema import ReceiptV2
+from token_harvest import CLAUDE_HARNESS_PROVIDERS
 
 logger = logging.getLogger(__name__)
 
@@ -153,9 +154,11 @@ def emit_dispatch_receipt(
     ValueError before anything is written.
 
     ``session_id``: receipt-quality PR-B1 — when the caller-supplied
-    ``token_usage`` is empty or explicitly marked ``unavailable`` (the claude
-    subscription lane has no live usage API) and ``provider`` is ``claude``,
-    the local Claude Code session transcript
+    ``token_usage`` is empty or explicitly marked ``unavailable`` (the
+    subscription/harness lanes have no live usage API) and ``provider`` is a
+    member of ``token_harvest.CLAUDE_HARNESS_PROVIDERS`` (claude,
+    deepseek-harness, glm-harness — every lane that runs through the Claude
+    Code harness), the local Claude Code session transcript
     (``~/.claude/projects/*/<session_id>.jsonl``) is harvested via
     ``token_harvest.harvest_session_tokens`` and used instead. Fail-open: any
     harvest problem (no session_id, no transcript, kimi/other providers)
@@ -187,13 +190,13 @@ def emit_dispatch_receipt(
     """
     _validate_provider(provider)
 
-    # Receipt-quality PR-B1: backfill token_usage for the claude lane from the
-    # local Claude Code session transcript when the caller has nothing usable
-    # (no live usage API on the subscription lane). Only ever tightens the
-    # data — a caller-supplied real token_usage is never overwritten, and any
-    # harvest failure (no session_id, no transcript, non-claude providers)
+    # Receipt-quality PR-B1: backfill token_usage for the claude-harness lanes
+    # from the local Claude Code session transcript when the caller has nothing
+    # usable (no live usage API on the subscription lane). Only ever tightens
+    # the data — a caller-supplied real token_usage is never overwritten, and
+    # any harvest failure (no session_id, no transcript, non-harness providers)
     # leaves token_usage exactly as passed in.
-    if provider == "claude" and session_id and (not token_usage or token_usage.get("unavailable")):
+    if provider in CLAUDE_HARNESS_PROVIDERS and session_id and (not token_usage or token_usage.get("unavailable")):
         try:
             from token_harvest import harvest_session_tokens  # noqa: PLC0415
             harvested = harvest_session_tokens(session_id)

--- a/scripts/lib/token_harvest.py
+++ b/scripts/lib/token_harvest.py
@@ -17,10 +17,13 @@ rewrite carrying the message's own cumulative usage, so naive per-line
 summing would multiply-count every message by how many times it was
 redrawn.
 
-READ-ONLY: never writes, never raises. Kimi and other non-Claude-Code
-providers have no local transcript and always resolve to the ``unavailable``
-marker here — there is no kimi-token-capture in this module (kimi capture is
-a separate, out-of-scope change; see the receipt-quality plan §Phase B).
+READ-ONLY: never writes, never raises. Only the providers in
+``CLAUDE_HARNESS_PROVIDERS`` (claude, deepseek-harness, glm-harness) run
+through the Claude Code harness and leave a harvestable transcript; every
+other provider (kimi included) has no local transcript and always resolves to
+the ``unavailable`` marker here — there is no kimi-token-capture in this
+module (kimi capture is a separate, out-of-scope change; see the
+receipt-quality plan §Phase B).
 """
 
 from __future__ import annotations
@@ -33,6 +36,17 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
+
+# Providers whose dispatches run through the Claude Code harness and therefore
+# leave a local session transcript that ``harvest_session_tokens`` can read.
+# ``claude`` is the native lane; ``deepseek-harness`` and ``glm-harness`` run
+# through the same claude-CLI harness with a redirected ``ANTHROPIC_BASE_URL``,
+# so their receipts carry a different provider string but an identical
+# transcript. Kimi is deliberately absent: it has its own CLI and leaves no
+# Claude transcript — its token capture runs through a separate route.
+# A third harness provider only needs adding here; both consumers
+# (governance_emit, link_sessions_dispatches) import this same set.
+CLAUDE_HARNESS_PROVIDERS = frozenset({"claude", "deepseek-harness", "glm-harness"})
 
 # Shape matches receipt_schema.ReceiptV2.token_usage. Zeroed counters (rather
 # than an absent dict) plus an explicit ``unavailable`` flag mirrors the
@@ -182,4 +196,4 @@ def harvest_session_tokens(
     return totals
 
 
-__all__ = ["harvest_session_tokens"]
+__all__ = ["CLAUDE_HARNESS_PROVIDERS", "harvest_session_tokens"]

--- a/scripts/link_sessions_dispatches.py
+++ b/scripts/link_sessions_dispatches.py
@@ -19,8 +19,9 @@ sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 try:
     from vnx_paths import ensure_env
     from report_findings_migration import ensure_report_findings_table
+    from token_harvest import CLAUDE_HARNESS_PROVIDERS
 except Exception as exc:
-    raise SystemExit(f"Failed to load vnx_paths or report_findings_migration: {exc}")
+    raise SystemExit(f"Failed to load vnx_paths, report_findings_migration, or token_harvest: {exc}")
 
 PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
@@ -151,12 +152,15 @@ def clean_polluted_dispatch_ids(conn: sqlite3.Connection) -> int:
 
 
 def backfill_receipt_token_usage(conn: sqlite3.Connection) -> int:
-    """Backfill ``token_usage`` in claude-lane receipts from session_analytics.
+    """Backfill ``token_usage`` in claude-harness receipts from session_analytics.
 
-    Walks ``t0_receipts.ndjson`` line by line.  For each claude-provider
-    receipt whose ``token_usage`` is null, empty, or marked unavailable,
-    looks up the matching row in ``session_analytics`` by ``dispatch_id``.
-    When token data is found, the receipt's ``token_usage`` is populated.
+    Walks ``t0_receipts.ndjson`` line by line.  For each receipt whose
+    provider is in ``token_harvest.CLAUDE_HARNESS_PROVIDERS`` (claude,
+    deepseek-harness, glm-harness — every lane that runs through the Claude
+    Code harness) and whose ``token_usage`` is null, empty, or marked
+    unavailable, looks up the matching row in ``session_analytics`` by
+    ``dispatch_id``. When token data is found, the receipt's ``token_usage``
+    is populated.
 
     Lines that need no enrichment pass through verbatim.  The rewritten
     file is staged in a ``.tmp`` sibling and atomically renamed on
@@ -211,7 +215,7 @@ def backfill_receipt_token_usage(conn: sqlite3.Connection) -> int:
                 token_usage = receipt.get("token_usage")
 
                 needs_backfill = (
-                    provider == "claude"
+                    provider in CLAUDE_HARNESS_PROVIDERS
                     and dispatch_id
                     and (
                         token_usage is None

--- a/tests/test_link_sessions_dispatches_cleanup.py
+++ b/tests/test_link_sessions_dispatches_cleanup.py
@@ -409,3 +409,90 @@ class TestBackfillReceiptTokenUsage:
             lines = [json.loads(line) for line in f if line.strip()]
         assert lines[0] == kimi_original
         conn.close()
+
+    # OI-884: deepseek-harness / glm-harness run through the Claude Code
+    # harness and must be backfilled by the same set as the emit path.
+
+    def test_enriches_deepseek_harness_receipt_with_null_token_usage(self, tmp_path, monkeypatch):
+        """A deepseek-harness receipt with null token_usage gets populated."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens,
+                 cache_creation_tokens, cache_read_tokens)
+            VALUES ('sess-ds', '/project', '2026-07-31', '20260731-123456-ds',
+                    5000, 3200, 400, 1200)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-123456-ds",
+                "provider": "deepseek-harness",
+                "token_usage": None,
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 1
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["token_usage"] == {
+            "input": 5000, "output": 3200,
+            "cache_creation_5m": 400, "cache_creation_1h": 0, "cache_read": 1200,
+        }
+        conn.close()
+
+    def test_enriches_glm_harness_receipt_with_null_token_usage(self, tmp_path, monkeypatch):
+        """A glm-harness receipt with null token_usage gets populated."""
+        from link_sessions_dispatches import backfill_receipt_token_usage
+
+        conn = self._setup_db(tmp_path)
+        conn.execute("""
+            INSERT INTO session_analytics
+                (session_id, project_path, session_date, dispatch_id,
+                 total_input_tokens, total_output_tokens,
+                 cache_creation_tokens, cache_read_tokens)
+            VALUES ('sess-glm', '/project', '2026-07-31', '20260731-123456-glm',
+                    7000, 2100, 300, 900)
+        """)
+        conn.commit()
+
+        state_dir = tmp_path / "state"
+        original = self._write_receipts(state_dir, [
+            {
+                "dispatch_id": "20260731-123456-glm",
+                "provider": "glm-harness",
+                "token_usage": None,
+                "status": "success",
+                "terminal_id": "T1",
+            },
+        ])
+
+        monkeypatch.setattr(
+            "link_sessions_dispatches.RECEIPTS_FILE", original)
+        monkeypatch.setattr(
+            "link_sessions_dispatches.STATE_DIR", state_dir)
+
+        enriched = backfill_receipt_token_usage(conn)
+        assert enriched == 1
+
+        with open(original, "r") as f:
+            lines = [json.loads(line) for line in f if line.strip()]
+        assert lines[0]["token_usage"] == {
+            "input": 7000, "output": 2100,
+            "cache_creation_5m": 300, "cache_creation_1h": 0, "cache_read": 900,
+        }
+        conn.close()

--- a/tests/test_token_harvest.py
+++ b/tests/test_token_harvest.py
@@ -8,6 +8,7 @@ lane.
 from __future__ import annotations
 
 import json
+import os
 import sys
 from pathlib import Path
 
@@ -334,3 +335,151 @@ def test_claude_receipt_no_session_id_keeps_marker(tmp_path):
     line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
     data = json.loads(line)
     assert data["token_usage"] == {"unavailable": True}
+
+
+# ---------------------------------------------------------------------------
+# OI-884: deepseek-harness / glm-harness run through the Claude Code harness
+# (claude_harness_keyed, redirected ANTHROPIC_BASE_URL) and leave a full
+# transcript — their receipts must harvest exactly like the native claude lane.
+# ---------------------------------------------------------------------------
+
+def test_deepseek_harness_receipt_carries_harvested_token_usage(tmp_path, monkeypatch):
+    """A deepseek-harness receipt with an 'unavailable' marker and a resolvable
+    session_id carries real harvested counts (core OI-884 DoD)."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-receipt-ds", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    monkeypatch.setenv("VNX_CLAUDE_PROJECTS_DIR", str(projects_dir))
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-deepseek",
+        terminal_id="T1",
+        provider="deepseek-harness",
+        model="deepseek-v4-flash",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-receipt-ds",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {
+        "input": 100,
+        "output": 20,
+        "cache_creation_5m": 10,
+        "cache_creation_1h": 5,
+        "cache_read": 2,
+    }
+
+
+def test_glm_harness_receipt_carries_harvested_token_usage(tmp_path, monkeypatch):
+    """A glm-harness receipt with an 'unavailable' marker and a resolvable
+    session_id carries real harvested counts (core OI-884 DoD)."""
+    projects_dir = tmp_path / "projects"
+    _write_transcript(projects_dir, "session-receipt-glm", [
+        _assistant_line("msg_1", _FULL_USAGE),
+    ])
+    monkeypatch.setenv("VNX_CLAUDE_PROJECTS_DIR", str(projects_dir))
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-glm",
+        terminal_id="T1",
+        provider="glm-harness",
+        model="glm-5.2",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-receipt-glm",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {
+        "input": 100,
+        "output": 20,
+        "cache_creation_5m": 10,
+        "cache_creation_1h": 5,
+        "cache_read": 2,
+    }
+
+
+def test_deepseek_harness_missing_transcript_fails_open(tmp_path, monkeypatch):
+    """Fail-open: a deepseek-harness receipt whose transcript is missing still
+    emits. The guard now fires for harness providers (the OI-884 broadening),
+    harvest resolves to unavailable, and the caller-supplied marker is
+    preserved — the receipt is never broken by a missing transcript."""
+    import token_harvest as th
+
+    calls = []
+    real = th.harvest_session_tokens
+
+    def spy(*args, **kwargs):
+        calls.append(args)
+        return real(*args, **kwargs)
+
+    monkeypatch.setattr(th, "harvest_session_tokens", spy)
+
+    from governance_emit import emit_dispatch_receipt
+
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    emit_dispatch_receipt(
+        dispatch_id="dispatch-b1-ds-missing",
+        terminal_id="T1",
+        provider="deepseek-harness",
+        model="deepseek-v4-flash",
+        pr_id=None,
+        status="success",
+        completion_pct=100,
+        risk=0.0,
+        findings=[],
+        duration_seconds=3.5,
+        token_usage={"unavailable": True},
+        cost_usd=None,
+        state_dir=state_dir,
+        receipt_kind="dispatch",
+        session_id="session-does-not-exist",
+    )
+    line = (state_dir / "t0_receipts.ndjson").read_text().strip().splitlines()[-1]
+    data = json.loads(line)
+    assert data["token_usage"] == {"unavailable": True}
+    assert len(calls) == 1  # the guard fired for a harness provider
+
+
+def test_emit_and_backfill_share_one_harness_provider_set():
+    """OI-884: both consumers gate on the exact same single source of truth,
+    so the nightly backfill can never cover a different set than the emit
+    path. A third harness provider only needs adding in token_harvest."""
+    os.environ.setdefault("VNX_PROJECT_ID", "vnx-dev")
+    import governance_emit
+    import link_sessions_dispatches
+    import token_harvest
+
+    assert governance_emit.CLAUDE_HARNESS_PROVIDERS is token_harvest.CLAUDE_HARNESS_PROVIDERS
+    assert link_sessions_dispatches.CLAUDE_HARNESS_PROVIDERS is token_harvest.CLAUDE_HARNESS_PROVIDERS
+    assert token_harvest.CLAUDE_HARNESS_PROVIDERS == frozenset(
+        {"claude", "deepseek-harness", "glm-harness"}
+    )
+    assert "kimi" not in token_harvest.CLAUDE_HARNESS_PROVIDERS


### PR DESCRIPTION
## OI-884 — de token-harvest vraagt naar de provider in plaats van naar het transcript

`deepseek-harness` en `glm-harness` draaien beide via de claude-harness (`claude_harness_keyed`, geredirecte `ANTHROPIC_BASE_URL`) en produceren dus een volwaardig Claude Code transcript. Hun receipt draagt echter `provider="deepseek-harness"` respectievelijk `"glm-harness"`, dus de harvest (`provider == "claude"`) vuurde nooit.

De verbreding zit op beide plekken, met één bron van waarheid.

### Changes
- **`scripts/lib/token_harvest.py`**: nieuw `CLAUDE_HARNESS_PROVIDERS = frozenset({"claude", "deepseek-harness", "glm-harness"})` — de enige plek waar de verzameling vastligt. Een derde harness-provider hoeft straks op één plek toegevoegd te worden. Kimi staat er bewust buiten (eigen CLI, geen Claude-transcript, aparte capture-route).
- **`scripts/lib/governance_emit.py`**: harvest-gate verbreed van `provider == "claude"` naar `provider in CLAUDE_HARNESS_PROVIDERS`.
- **`scripts/link_sessions_dispatches.py`**: nachtelijke backfill gebruikt dezelfde constante, dus dekt exact dezelfde verzameling als de emit.
- Fail-open-gedrag ongewijzigd: een ontbrekend of onleesbaar transcript breekt de receipt niet; de harvest-resultaat-guard (`if harvested and not harvested.get("unavailable")`) is ongemoeid.

### Verification — rood op `origin/main`, groen op deze branch

Alle 6 nieuwe tests draaien rood tegen `origin/main`-source en groen op deze branch.

**Rood tegen origin/main** (source = `origin/main`, nieuwe tests overgekopieerd):
```
python -m pytest tests/test_token_harvest.py tests/test_link_sessions_dispatches_cleanup.py
6 failed, 24 passed
FAILED test_token_harvest.py::test_deepseek_harness_receipt_carries_harvested_token_usage
FAILED test_token_harvest.py::test_glm_harness_receipt_carries_harvested_token_usage
FAILED test_token_harvest.py::test_deepseek_harness_missing_transcript_fails_open
FAILED test_token_harvest.py::test_emit_and_backfill_share_one_harness_provider_set
FAILED test_link_sessions_dispatches_cleanup.py::...::test_enriches_deepseek_harness_receipt_with_null_token_usage
FAILED test_link_sessions_dispatches_cleanup.py::...::test_enriches_glm_harness_receipt_with_null_token_usage
```

**Groen op deze branch** (exit=0):
```
python -m pytest tests/test_token_harvest.py tests/test_link_sessions_dispatches_cleanup.py tests/test_governance_emit_schema.py
46 passed
```

De fail-open-test (`test_deepseek_harness_missing_transcript_fails_open`) is rood op main via een spy: op main vuurt de guard voor `deepseek-harness` niet (0 harvest-calls), op deze branch wel (1 call) én de receipt wordt nog steeds geschreven met de ongewijzigde marker.

### Coverage per DoD-eis
- `deepseek-harness` + bestaand transcript → `token_usage` gevuld (emit + backfill)
- `glm-harness` + bestaand transcript → `token_usage` gevuld (emit + backfill)
- `claude` blijft werken → bestaande tests `test_claude_receipt_carries_harvested_token_usage` + `test_enriches_claude_receipt_*`
- `kimi` ongemoeid → bestaande tests `test_kimi_receipt_never_harvests` + `test_preserves_non_claude_lines_verbatim`
- backfill = exact zelfde verzameling als emit → `test_emit_and_backfill_share_one_harness_provider_set` (beide consumer-modules importeren dezelfde constante)
- ontbrekend/onleesbaar transcript breekt de receipt niet → `test_deepseek_harness_missing_transcript_fails_open`

Lint-gate (`scripts/ci_lint_patterns.py --scan-stdin` over de added lines): pass, exit=0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)