### PR TITLE
feat(dispatch): capture measured kimi tokens via session wire.jsonl harvest

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -505,7 +505,7 @@ def _harvest_session_token_usage(
             try:
                 import shutil as _shutil
                 _shutil.rmtree(zip_path.parent, ignore_errors=True)
-            except Exception:  # noqa: BLE001 — cleanup must never raise
+            except Exception:  # vnx-silent-except: cleanup must never raise
                 pass
 
 

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -12,7 +12,7 @@ would auto-dismiss its own tool calls (fabrication) rather than execute them.
 
 Authentication: OAuth via `kimi login` (operator-managed). No API key in spawn.
 
-OUTPUT FORMAT (kimi-cli 1.44.0, wire protocol 1.10):
+OUTPUT FORMAT (kimi-cli 1.46.0, wire protocol 1.10):
     `--output-format stream-json` emits Anthropic-style content-block message
     objects, one JSON object per line, with NO ``event_type`` field. Each line:
 
@@ -28,8 +28,16 @@ OUTPUT FORMAT (kimi-cli 1.44.0, wire protocol 1.10):
     ``text``); reasoning in blocks where ``type == "think"`` (field ``think``).
     The whole assistant message arrives end-loaded (after the model finishes
     thinking), so per-chunk stall detection must tolerate a long first-token gap.
-    Token/usage accounting is NOT reported by this format — usage is recorded as
-    explicitly-unavailable rather than a silently-measured zero.
+    Token/usage accounting is NOT reported by this format — measured on
+    kimi-cli 1.46.0 (the installed CLI) on both plain and tool-using workloads.
+    The default ``--print`` event-stream (no ``--output-format``) DOES carry a
+    ``StatusUpdate`` event with ``token_usage=TokenUsage(input_other, output,
+    input_cache_read, input_cache_creation)``, but as Python-repr display text,
+    not NDJSON — the line-based drainer would mis-parse it. The measured tokens
+    are instead recovered post-run from the session's ``wire.jsonl`` via
+    ``kimi export <session_id>`` (see ``_harvest_session_token_usage``). If that
+    harvest yields nothing, usage is recorded as explicitly-unavailable rather
+    than a silently-measured zero.
 
     Legacy ``event_type`` event-stream shapes (pre-1.44) are still parsed for
     backward compatibility.
@@ -43,9 +51,11 @@ from __future__ import annotations
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
-import time
+import tempfile
+import zipfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Dict, Optional
@@ -76,20 +86,24 @@ class KimiSpawnResult:
 
     @property
     def token_usage_measured(self) -> bool:
-        """True when actual token accounting was observed in the stream.
+        """True when actual token accounting was observed.
 
-        kimi-cli 1.44.0 stream-json does not report token accounting, so this
-        is False when token_usage is None (no token_count event was observed).
-        Available as an attribute for receipt/metadata consumers without being
-        part of the cross-provider frontmatter_fields() contract.
+        kimi-cli 1.46.0 stream-json does not report token accounting in the
+        stream; tokens are recovered post-run from the session's ``wire.jsonl``
+        (see ``_harvest_session_token_usage``). This is False when token_usage
+        is None — either the harvest was skipped (failed dispatch) or the
+        session export yielded no StatusUpdate. Available as an attribute for
+        receipt/metadata consumers without being part of the cross-provider
+        frontmatter_fields() contract.
         """
         return self.token_usage is not None
 
     def frontmatter_fields(self) -> Dict[str, Any]:
-        # kimi-cli 1.44.0 stream-json reports no token accounting, and completion_text
-        # is the (often empty) final message — not the agentic generation volume — so
-        # there is no reliable token count to report. Honest "unavailable" zeros with
-        # token_usage_measured=False; the scorer renders tokens/sec as n/a for kimi.
+        # kimi-cli 1.46.0 stream-json reports no token accounting in the stream,
+        # and completion_text is the (often empty) final message — not the agentic
+        # generation volume. Measured tokens arrive via the post-run wire.jsonl
+        # harvest (token_usage set) or stay honestly unavailable (token_usage=None,
+        # zeros + token_usage_measured=False; the scorer renders tokens/sec as n/a).
         usage = self.token_usage or {}
         return {
             "provider": "kimi",
@@ -375,6 +389,124 @@ def _build_kimi_cmd(prompt: str, model: Optional[str], work_dir: Optional[Any]) 
     if work_dir:
         cmd.extend(["-w", str(work_dir)])
     return cmd
+
+
+# kimi prints the resume handle to stderr after every --print run:
+#   "To resume this session: kimi -r <session_id>"
+# The session id is the key to the session's wire.jsonl, where the CLI records
+# the measured token accounting that stream-json itself never emits.
+_SESSION_ID_RE = re.compile(r"kimi\s+(-r|--resume)\s+([0-9a-fA-F-]+)")
+
+
+def _extract_session_id(stderr_text: str) -> Optional[str]:
+    """Return the kimi session id from the stderr resume line, or None.
+
+    ``kimi --print`` writes ``To resume this session: kimi -r <id>`` to stderr
+    on every run. The id is a UUID-ish string (dashes allowed). Missing or
+    malformed stderr returns None — the caller then skips the token harvest and
+    stays honestly unavailable.
+    """
+    m = _SESSION_ID_RE.search(stderr_text or "")
+    return m.group(2) if m else None
+
+
+def _parse_wire_token_usage(wire_jsonl: str) -> Optional[Dict[str, int]]:
+    """Aggregate ``StatusUpdate.token_usage`` from a session ``wire.jsonl``.
+
+    Each line is ``{"timestamp": ..., "message": {"type": "...", "payload": ...}}``.
+    A ``StatusUpdate`` payload carries the model call's accounting as
+    ``token_usage=TokenUsage(input_other, output, input_cache_read,
+    input_cache_creation)``. ``input_other`` and ``output`` are per-call NEW
+    tokens — summed across calls for the run total. ``input_cache_read`` is the
+    cumulative context-cache read for that call, so the LAST one is the run
+    total; ``input_cache_creation`` likewise.
+
+    Returns None when no StatusUpdate with a token_usage payload is present
+    (fail-open: the caller reports unavailable rather than a fabricated zero).
+    Malformed lines are skipped non-fatally.
+    """
+    total_input = 0
+    total_output = 0
+    last_cache_read = 0
+    last_cache_creation = 0
+    found = False
+    for line in (wire_jsonl or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        msg = obj.get("message")
+        if not isinstance(msg, dict) or msg.get("type") != "StatusUpdate":
+            continue
+        payload = msg.get("payload")
+        if not isinstance(payload, dict):
+            continue
+        tu = payload.get("token_usage")
+        if not isinstance(tu, dict):
+            continue
+        found = True
+        total_input += int(tu.get("input_other", 0) or 0)
+        total_output += int(tu.get("output", 0) or 0)
+        last_cache_read = int(tu.get("input_cache_read", 0) or 0)
+        last_cache_creation = int(tu.get("input_cache_creation", 0) or 0)
+    if not found:
+        return None
+    return {
+        "input_tokens": total_input,
+        "output_tokens": total_output,
+        "cache_read_tokens": last_cache_read,
+        "cache_creation_tokens": last_cache_creation,
+    }
+
+
+def _harvest_session_token_usage(
+    session_id: str,
+    env: Dict[str, str],
+    cwd_str: Optional[str] = None,
+    timeout: float = 30.0,
+) -> Optional[Dict[str, int]]:
+    """Export the session and read StatusUpdate token_usage from its wire.jsonl.
+
+    Keeps the lane's token-less stream-json output (canonical events unchanged)
+    while still reporting the API's measured token accounting: after a clean
+    run, ``kimi export <session_id> -o <tmp.zip> --yes`` materialises the
+    session archive and the ``wire.jsonl`` inside it records every StatusUpdate
+    the CLI saw. Fail-open: any failure (export error, missing wire.jsonl, no
+    StatusUpdate) returns None — the receipt stays 'unavailable', never broken.
+    """
+    zip_path: Optional[Path] = None
+    try:
+        tmp_dir = tempfile.mkdtemp(prefix="kimi-wire-")
+        zip_path = Path(tmp_dir) / "session.zip"
+        export_cmd = ["kimi", "export", session_id, "-o", str(zip_path), "--yes"]
+        proc = subprocess.run(
+            export_cmd,
+            capture_output=True, text=True, timeout=timeout, env=env, cwd=cwd_str,
+        )
+        if proc.returncode != 0 or not zip_path.exists():
+            logger.debug(
+                "kimi_spawn: session export failed (rc=%s) — tokens stay unavailable",
+                proc.returncode,
+            )
+            return None
+        with zipfile.ZipFile(zip_path) as zf:
+            wire = zf.read("wire.jsonl").decode("utf-8", errors="replace")
+        return _parse_wire_token_usage(wire)
+    except Exception as exc:  # noqa: BLE001 — harvest must never break the dispatch
+        logger.debug("kimi_spawn: token harvest failed (fail-open): %s", exc)
+        return None
+    finally:
+        if zip_path is not None:
+            try:
+                import shutil as _shutil
+                _shutil.rmtree(zip_path.parent, ignore_errors=True)
+            except Exception:  # noqa: BLE001 — cleanup must never raise
+                pass
 
 
 def _worktree_has_changes(worktree: Any, base_ref: str = "origin/main") -> Optional[bool]:
@@ -744,11 +876,16 @@ def spawn_kimi(
     Caller is responsible for lease/manifest/receipt/event-archive/retry.
 
     The per-chunk stall default is 1200s (overridable via VNX_KIMI_STALL_THRESHOLD):
-    Kimi is a reasoning model whose 1.44.0 content-block output is end-loaded, so
+    Kimi is a reasoning model whose 1.46.0 content-block output is end-loaded, so
     the first token can arrive only after a long reasoning gap (a 300s default
     spuriously killed adversarial-review dispatches mid-think). A FAILURE is
     returned (never a silent empty
     success) when the CLI emits output but no answer text is extracted.
+
+    Token accounting: stream-json never carries it (measured on 1.46.0). On a
+    clean run the session is exported post-run and the StatusUpdate token_usage
+    read from its ``wire.jsonl`` (``_harvest_session_token_usage``); result.token_usage
+    is filled when that succeeds, stays None otherwise — fail-open, no estimates.
 
     event_writer signature: ``(terminal_id, event_dict, dispatch_id=...)`` called
     per normalized event. Failures are counted in result.event_writer_failures.
@@ -826,7 +963,7 @@ def spawn_kimi(
         event_store=event_store, chunk_timeout=chunk_timeout,
         total_deadline=total_deadline,
     )
-    return _finalize_kimi_result(
+    result = _finalize_kimi_result(
         proc=proc, completion_text=completion_text,
         events_written=events_written, token_usage=token_usage,
         timed_out=timed_out, stopped_early=stopped_early,
@@ -837,3 +974,20 @@ def spawn_kimi(
         saw_tool_calls=saw_tool_calls,
         worktree=cwd,
     )
+
+    # Post-run token harvest. stream-json carries no token accounting (measured
+    # on kimi-cli 1.46.0), so on a clean run the session is exported and the
+    # StatusUpdate token_usage the CLI recorded is read from its wire.jsonl.
+    # Fail-open: no session id, export failure, or missing StatusUpdate leaves
+    # token_usage None — the receipt stays honestly unavailable, never broken.
+    if result.error is None and result.returncode == 0 and result.token_usage is None:
+        try:
+            stderr_text = proc.stderr.read().decode("utf-8", errors="replace") if proc.stderr else ""
+        except Exception:  # noqa: BLE001 — harvest must never break the dispatch
+            stderr_text = ""
+        session_id = _extract_session_id(stderr_text)
+        if session_id:
+            harvested = _harvest_session_token_usage(session_id, env, cwd_str)
+            if harvested:
+                result.token_usage = harvested
+    return result

--- a/tests/test_kimi_token_capture.py
+++ b/tests/test_kimi_token_capture.py
@@ -1,0 +1,355 @@
+"""Tests for kimi token capture — post-run wire.jsonl harvest (dispatch 20260731).
+
+Measured on kimi-cli 1.46.0: `--output-format stream-json` never carries token
+accounting, but the session's `wire.jsonl` (via `kimi export <session_id>`)
+records every `StatusUpdate.token_usage` as clean JSON. These tests cover:
+
+  * `_extract_session_id`       — the resume-line regex on stderr.
+  * `_parse_wire_token_usage`   — aggregating StatusUpdate.token_usage.
+  * `_harvest_session_token_usage` — export + zip read, fail-open.
+  * `spawn_kimi` wiring         — a clean run fills token_usage / measured=True;
+    harvest failure or a failed dispatch leaves tokens honestly unavailable.
+
+All new functions exist only on this branch — on origin/main the module import
+fails, so this file is red there and green here (the red-green contract).
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+import zipfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+# Make sure scripts/lib is on the path
+_LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from provider_spawns import kimi_spawn  # noqa: E402
+from provider_spawns.kimi_spawn import (  # noqa: E402
+    _extract_session_id,
+    _harvest_session_token_usage,
+    _parse_wire_token_usage,
+    spawn_kimi,
+)
+
+# Verbatim StatusUpdate message shape from a real kimi-cli 1.46.0 export.
+_STREAM_JSON_SESSION_ID = "c2f1ae72-7d30-46e0-8b41-ca8938a13b89"
+
+
+def _wire_line(msg_type: str, payload: dict) -> str:
+    return json.dumps({
+        "timestamp": 1785515300.0,
+        "message": {"type": msg_type, "payload": payload},
+    })
+
+
+def _status_update(input_other: int, output: int, cache_read: int, cache_creation: int = 0) -> str:
+    return _wire_line("StatusUpdate", {
+        "context_usage": 0.067,
+        "context_tokens": 17665,
+        "max_context_tokens": 262144,
+        "token_usage": {
+            "input_other": input_other,
+            "output": output,
+            "input_cache_read": cache_read,
+            "input_cache_creation": cache_creation,
+        },
+        "message_id": "chatcmpl-test",
+        "plan_mode": False,
+        "mcp_status": None,
+    })
+
+
+class TestExtractSessionId(unittest.TestCase):
+    def test_extracts_id_from_resume_line(self) -> None:
+        stderr = "\nTo resume this session: kimi -r %s\n" % _STREAM_JSON_SESSION_ID
+        self.assertEqual(_extract_session_id(stderr), _STREAM_JSON_SESSION_ID)
+
+    def test_accepts_long_resume_alias(self) -> None:
+        stderr = "To resume this session: kimi --resume %s" % _STREAM_JSON_SESSION_ID
+        self.assertEqual(_extract_session_id(stderr), _STREAM_JSON_SESSION_ID)
+
+    def test_returns_none_without_resume_line(self) -> None:
+        self.assertIsNone(_extract_session_id("kimi exited with code 1"))
+
+    def test_returns_none_on_none_and_empty(self) -> None:
+        self.assertIsNone(_extract_session_id(None))
+        self.assertIsNone(_extract_session_id(""))
+        self.assertIsNone(_extract_session_id("   \n  "))
+
+    def test_returns_none_on_malformed_id(self) -> None:
+        self.assertIsNone(_extract_session_id("kimi -r not-a-valid-id-!!"))
+
+
+class TestParseWireTokenUsage(unittest.TestCase):
+    def test_multi_step_run_sums_input_output_takes_last_cache(self) -> None:
+        wire = "\n".join([
+            _status_update(input_other=8449, output=38, cache_read=9216),
+            _status_update(input_other=71, output=33, cache_read=17664),
+        ])
+        usage = _parse_wire_token_usage(wire)
+        self.assertIsNotNone(usage)
+        # input_other and output are per-call NEW tokens -> summed for the run.
+        self.assertEqual(usage["input_tokens"], 8449 + 71)
+        self.assertEqual(usage["output_tokens"], 38 + 33)
+        # cache_read is the cumulative context-cache read -> last wins.
+        self.assertEqual(usage["cache_read_tokens"], 17664)
+        self.assertEqual(usage["cache_creation_tokens"], 0)
+
+    def test_single_step_run(self) -> None:
+        wire = _status_update(input_other=8438, output=31, cache_read=9216)
+        usage = _parse_wire_token_usage(wire)
+        self.assertEqual(usage["input_tokens"], 8438)
+        self.assertEqual(usage["output_tokens"], 31)
+        self.assertEqual(usage["cache_read_tokens"], 9216)
+
+    def test_returns_none_when_no_status_update(self) -> None:
+        wire = "\n".join([
+            _wire_line("TurnBegin", {"user_input": "hi"}),
+            _wire_line("TextPart", {"type": "text", "text": "okay"}),
+            _wire_line("TurnEnd", {}),
+        ])
+        self.assertIsNone(_parse_wire_token_usage(wire))
+
+    def test_skips_malformed_and_non_message_lines(self) -> None:
+        wire = "\n".join([
+            "not json at all",
+            '{"type": "metadata", "protocol_version": "1.10"}',
+            _wire_line("StepBegin", {"n": 1}),
+            _status_update(input_other=10, output=5, cache_read=3),
+        ])
+        usage = _parse_wire_token_usage(wire)
+        self.assertEqual(usage["input_tokens"], 10)
+        self.assertEqual(usage["output_tokens"], 5)
+
+    def test_returns_none_on_empty_input(self) -> None:
+        self.assertIsNone(_parse_wire_token_usage(""))
+        self.assertIsNone(_parse_wire_token_usage(None))
+
+    def test_handles_missing_token_usage_key(self) -> None:
+        wire = _wire_line("StatusUpdate", {"context_tokens": 10})
+        self.assertIsNone(_parse_wire_token_usage(wire))
+
+    def test_zero_token_usage_is_still_a_measured_event(self) -> None:
+        # A StatusUpdate with an explicit all-zero token_usage is a real event;
+        # the caller decides availability via the non-None return, not the zeros.
+        wire = _status_update(input_other=0, output=0, cache_read=0)
+        usage = _parse_wire_token_usage(wire)
+        self.assertIsNotNone(usage)
+        self.assertEqual(usage["input_tokens"], 0)
+
+
+class TestHarvestSessionTokenUsage(unittest.TestCase):
+    """`kimi export` + zip read, with the subprocess mocked (hermetic tests)."""
+
+    def _fake_export_writer(self, wire_content: str):
+        def _fake_export(cmd, **kwargs):
+            out_idx = cmd.index("-o") + 1
+            out_path = cmd[out_idx]
+            with zipfile.ZipFile(out_path, "w") as zf:
+                zf.writestr("wire.jsonl", wire_content)
+            return MagicMock(returncode=0)
+        return _fake_export
+
+    def test_happy_path_returns_aggregated_usage(self) -> None:
+        wire = "\n".join([
+            _status_update(input_other=8449, output=38, cache_read=9216),
+            _status_update(input_other=71, output=33, cache_read=17664),
+        ])
+        with patch.object(kimi_spawn.subprocess, "run",
+                          side_effect=self._fake_export_writer(wire)):
+            usage = _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={})
+        self.assertEqual(usage["input_tokens"], 8520)
+        self.assertEqual(usage["output_tokens"], 71)
+        self.assertEqual(usage["cache_read_tokens"], 17664)
+
+    def test_export_failure_returns_none(self) -> None:
+        with patch.object(kimi_spawn.subprocess, "run",
+                          return_value=MagicMock(returncode=1)):
+            usage = _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={})
+        self.assertIsNone(usage)
+
+    def test_missing_wire_jsonl_returns_none(self) -> None:
+        def _fake_export(cmd, **kwargs):
+            out_idx = cmd.index("-o") + 1
+            with zipfile.ZipFile(cmd[out_idx], "w") as zf:
+                zf.writestr("manifest.json", "{}")
+            return MagicMock(returncode=0)
+
+        with patch.object(kimi_spawn.subprocess, "run", side_effect=_fake_export):
+            usage = _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={})
+        self.assertIsNone(usage)
+
+    def test_no_status_update_returns_none(self) -> None:
+        wire = _wire_line("TurnEnd", {})
+        with patch.object(kimi_spawn.subprocess, "run",
+                          side_effect=self._fake_export_writer(wire)):
+            usage = _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={})
+        self.assertIsNone(usage)
+
+    def test_cleanup_removes_temp_dir(self) -> None:
+        wire = _status_update(input_other=1, output=1, cache_read=0)
+        with patch.object(kimi_spawn.subprocess, "run",
+                          side_effect=self._fake_export_writer(wire)):
+            _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={})
+        # The export dir lives under the system temp root; assert the mkdtemp
+        # prefix produces no leftover dirs after the harvest.
+        tmp_root = tempfile.gettempdir()
+        leftovers = [
+            p for p in Path(tmp_root).iterdir()
+            if p.is_dir() and p.name.startswith("kimi-wire-")
+        ]
+        self.assertEqual(leftovers, [], "temp export dirs must be cleaned up")
+
+    def test_builds_expected_export_argv(self) -> None:
+        captured: dict = {}
+
+        def _fake_export(cmd, **kwargs):
+            captured["cmd"] = cmd
+            captured["env"] = kwargs.get("env")
+            out_idx = cmd.index("-o") + 1
+            with zipfile.ZipFile(cmd[out_idx], "w") as zf:
+                zf.writestr("wire.jsonl", _status_update(input_other=1, output=1, cache_read=0))
+            return MagicMock(returncode=0)
+
+        with patch.object(kimi_spawn.subprocess, "run", side_effect=_fake_export):
+            _harvest_session_token_usage(_STREAM_JSON_SESSION_ID, env={"PATH": "/x"})
+        self.assertEqual(captured["cmd"][:2], ["kimi", "export"])
+        self.assertIn(_STREAM_JSON_SESSION_ID, captured["cmd"])
+        self.assertIn("--yes", captured["cmd"])
+        # The env must be passed through to the export subprocess.
+        self.assertEqual(captured["env"], {"PATH": "/x"})
+
+
+def _make_proc_with_stderr(events: list, returncode: int = 0, stderr_text: str = "") -> MagicMock:
+    """Fake Popen with real-pipe stdout (drain_stream needs fileno()) and a
+    BytesIO stderr carrying the kimi resume line."""
+    data = b"".join((json.dumps(e) + "\n").encode() for e in events)
+    read_fd, write_fd = os.pipe()
+
+    def _writer():
+        try:
+            os.write(write_fd, data)
+        finally:
+            os.close(write_fd)
+
+    writer_thread = threading.Thread(target=_writer, daemon=True)
+    writer_thread.start()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = returncode
+    fake_proc.poll.return_value = returncode
+    fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+    fake_proc.stderr = io.BytesIO(stderr_text.encode())
+    fake_proc.wait = MagicMock(return_value=returncode)
+    fake_proc.kill = MagicMock()
+    fake_proc._writer_thread = writer_thread
+    return fake_proc
+
+
+class TestSpawnKimiTokenHarvestWiring(unittest.TestCase):
+    """End-to-end through spawn_kimi: a clean run harvests tokens; harvest
+    failure or a failed dispatch leaves tokens honestly unavailable."""
+
+    _ANSWER_EVENTS = [
+        {"role": "assistant", "content": [{"type": "text", "text": "okay"}]},
+    ]
+
+    def _run(self, events, returncode=0, stderr_text="", harvest_return=None):
+        fake_proc = _make_proc_with_stderr(events, returncode=returncode, stderr_text=stderr_text)
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start, \
+                    patch("provider_spawns.kimi_spawn._harvest_session_token_usage",
+                          return_value=harvest_return) as mock_harvest:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi("prompt", dispatch_id="d-harvest", terminal_id="T1")
+        finally:
+            fake_proc._writer_thread.join(timeout=5)
+        return result, mock_harvest
+
+    def test_clean_run_with_resume_line_harvests_tokens(self) -> None:
+        stderr = "\nTo resume this session: kimi -r %s\n" % _STREAM_JSON_SESSION_ID
+        harvested = {"input_tokens": 8520, "output_tokens": 71, "cache_read_tokens": 17664}
+        result, mock_harvest = self._run(
+            self._ANSWER_EVENTS, returncode=0, stderr_text=stderr, harvest_return=harvested,
+        )
+        self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+        self.assertEqual(result.returncode, 0)
+        self.assertEqual(result.token_usage, harvested)
+        self.assertTrue(result.token_usage_measured)
+        # The harvest is keyed by the session id extracted from stderr.
+        mock_harvest.assert_called_once()
+        args, kwargs = mock_harvest.call_args
+        self.assertEqual(args[0], _STREAM_JSON_SESSION_ID)
+        # frontmatter_fields() must surface the measured numbers, not zeros.
+        fm = result.frontmatter_fields()
+        self.assertEqual(fm["token_usage"]["input"], 8520)
+        self.assertEqual(fm["token_usage"]["output"], 71)
+        self.assertEqual(fm["token_usage"]["cache_read"], 17664)
+
+    def test_harvest_none_leaves_tokens_unavailable(self) -> None:
+        stderr = "\nTo resume this session: kimi -r %s\n" % _STREAM_JSON_SESSION_ID
+        result, mock_harvest = self._run(
+            self._ANSWER_EVENTS, returncode=0, stderr_text=stderr, harvest_return=None,
+        )
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(result.token_usage)
+        self.assertFalse(result.token_usage_measured)
+        fm = result.frontmatter_fields()
+        self.assertEqual(fm["token_usage"], {"input": 0, "output": 0, "cache_read": 0})
+
+    def test_no_resume_line_skips_harvest(self) -> None:
+        result, mock_harvest = self._run(
+            self._ANSWER_EVENTS, returncode=0, stderr_text="kimi exited normally",
+            harvest_return=None,
+        )
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(result.token_usage)
+        mock_harvest.assert_not_called()
+
+    def test_failed_dispatch_skips_harvest(self) -> None:
+        # An error event forces rc=1 even though the process exits 0.
+        events = [{"event_type": "error", "message": "rate limit exceeded"}]
+        result, mock_harvest = self._run(events, returncode=0, stderr_text="",
+                                         harvest_return=None)
+        self.assertIsNotNone(result.error)
+        self.assertNotEqual(result.returncode, 0)
+        mock_harvest.assert_not_called()
+
+    def test_nonzero_exit_skips_harvest(self) -> None:
+        result, mock_harvest = self._run(
+            self._ANSWER_EVENTS, returncode=1, stderr_text="", harvest_return=None,
+        )
+        self.assertNotEqual(result.returncode, 0)
+        mock_harvest.assert_not_called()
+
+    def test_stderr_read_failure_still_succeeds(self) -> None:
+        """A broken stderr read must not break the dispatch — fail-open."""
+        fake_proc = _make_proc_with_stderr(self._ANSWER_EVENTS, returncode=0,
+                                           stderr_text="")
+        fake_proc.stderr.read = MagicMock(side_effect=OSError("boom"))
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start, \
+                    patch("provider_spawns.kimi_spawn._harvest_session_token_usage",
+                          return_value=None) as mock_harvest:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi("prompt", dispatch_id="d-harvest", terminal_id="T1")
+        finally:
+            fake_proc._writer_thread.join(timeout=5)
+        self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+        self.assertEqual(result.returncode, 0)
+        self.assertIsNone(result.token_usage)
+        mock_harvest.assert_not_called()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Kimi is the fleet's default build-worker, and its receipts carried no token data — the last gap in cost governance. This PR wires the measured token accounting into `KimiResult.token_usage` (`token_usage_measured=True`).

## Measurement (kimi-cli 1.46.0, the installed CLI)

- `--output-format stream-json` (the lane's form): **no token accounting** on plain and tool-using workloads — one/two content-block messages, no usage fields. The `1.44.0` claim in the docstring is still accurate for the stream-json form.
- Default `--print` event-stream (no `--output-format`): **has** `StatusUpdate.token_usage=TokenUsage(input_other, output, input_cache_read, input_cache_creation)` — but as Python-repr display text, not NDJSON. Switching output form would break the line-based drainer and every dispatch.
- Discovery: `kimi export <session_id>` (session id from the stderr resume line) yields a `wire.jsonl` with the same wire-protocol events as clean JSON, including `StatusUpdate.token_usage`. Verified for stream-json runs, cross-cwd, overwrite-safe.

## Design

Keep `stream-json` unchanged (canonical events intact — zero functional loss). After a clean run, export the session and read `StatusUpdate.token_usage` from its `wire.jsonl`, filling `KimiResult.token_usage`. Fail-open and honest: no session id, export failure, or missing StatusUpdate leaves tokens `unavailable`; no estimates ever.

## Verification (red-green contract)

New `tests/test_kimi_token_capture.py` (24 tests):

- **Red on origin/main** (temp worktree at `origin/main`, HEAD `c939af26`): `ImportError: cannot import name '_extract_session_id'` → `exit=2`.
- **Green on branch**: `24 passed` → `exit=0`.
- Existing kimi suite (9 files): `265 passed` → `exit=0`.
- Provider/spawn sweep: `169 passed` → `exit=0`.
- `ruff check` on both changed files: clean.

## Scope

`scripts/lib/governance_emit.py` and `scripts/link_sessions_dispatches.py` untouched (OI-884 parallel dispatch owns those). Unified report: `$VNX_DATA_DIR/unified_reports/20260731-kimi-token-capture-measure.md` with the raw measurement output of both invocation forms.

## Open items

- Aggregation: `input_other`/`output` summed across StatusUpdate events; `input_cache_read`/`input_cache_creation` last-wins (cumulative semantics). Documented in code.
- Harvest runs only on clean runs (rc=0, no error event) — failed/timeout dispatches stay `unavailable`.
- ~0.5–1s local latency per dispatch from the export step; no API call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)