### PR TITLE
fix(dispatch): classify sqlite lock-busy as CoordinationLockError on coordination writes (OI-880)

### DIFF
--- a/scripts/lib/coordination_retry.py
+++ b/scripts/lib/coordination_retry.py
@@ -55,3 +55,45 @@ def rearm_busy_timeout(conn: sqlite3.Connection, deadline: float) -> None:
 def deadline_for_timeout(timeout: float) -> float:
     """Return a monotonic deadline *timeout* seconds from now."""
     return time.monotonic() + timeout
+
+
+def is_lock_timeout_error(exc: BaseException) -> bool:
+    """Classify *exc* as a coordination lock-timeout failure (OI-880).
+
+    Two distinct failures surface when a coordination write loses the lock
+    race, and both must reach the caller as :exc:`CoordinationLockError`:
+
+    - the deadline sentinel that :func:`rearm_busy_timeout` raises once the
+      deadline has already passed, and
+    - the ``sqlite3.OperationalError`` SQLite itself raises when a statement
+      exhausts its ``busy_timeout`` while another connection still holds the
+      write lock (``database is locked``).  That error is what the call sites'
+      generic ``except Exception`` / ``except sqlite3.Error`` used to swallow at
+      WARNING — a silently lost audit event.
+
+    The classification is content-based, not type-only: ``OperationalError``
+    covers real bugs too (``no such table``, ``no such column``, ...) and those
+    must NOT be treated as lock contention.  Prefer the structured
+    ``sqlite_errorcode`` / ``sqlite_errorname`` attributes (Python 3.11+)
+    against SQLITE_BUSY / SQLITE_LOCKED — including extended codes via the
+    low-byte primary mask, mirroring ``migrate_future_system._is_busy_or_locked``
+    — and fall back to the message substring only when no error code is
+    attached (e.g. an exception constructed in a test).
+    """
+    if isinstance(exc, CoordinationLockError):
+        return True
+    if not isinstance(exc, sqlite3.OperationalError):
+        return False
+    code = getattr(exc, "sqlite_errorcode", None)
+    if isinstance(code, int):
+        if code in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+            return True
+        if (code & 0xFF) in (sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED):
+            return True
+        # A structured code that is not BUSY/LOCKED is authoritative — the
+        # exception is definitively not a lock conflict, whatever its message
+        # says.  Falling through to the message check here would let a
+        # non-standard message flip a real bug into a lock timeout.
+        return False
+    message = str(exc).lower()
+    return "locked" in message or "busy" in message

--- a/scripts/lib/intelligence_selector.py
+++ b/scripts/lib/intelligence_selector.py
@@ -488,7 +488,13 @@ class IntelligenceSelector:
             return None
         event_type = "intelligence_injection" if result.items_injected > 0 else "intelligence_suppression"
         reason = f"injected {result.items_injected} items at {result.injection_point}" if result.items_injected > 0 else "no items met minimum thresholds"
-        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, rearm_busy_timeout
+        # Classification lives in coordination_retry, not here: both writers
+        # (this one and _recording.record_injection_audit) must recognize the
+        # same lock-busy failures, and the helper owns that contract.  OI-880:
+        # SQLite's own "database is locked" OperationalError is the same lost
+        # lock race the deadline sentinel reports, so it must reach callers as
+        # CoordinationLockError too — not vanish into the generic except below.
+        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, is_lock_timeout_error, rearm_busy_timeout
         deadline = deadline_for_timeout(DEFAULT_LOCK_TIMEOUT_SECONDS)
         try:
             with get_connection(state_dir, timeout=DEFAULT_LOCK_TIMEOUT_SECONDS) as conn:
@@ -500,6 +506,12 @@ class IntelligenceSelector:
         except CoordinationLockError:
             raise
         except Exception as exc:
+            if is_lock_timeout_error(exc):
+                raise CoordinationLockError(
+                    "Coordination DB write lock deadline exhausted — "
+                    "database is locked after busy_timeout; "
+                    "audit event NOT written"
+                ) from exc
             logger.warning("emit_event: failed to append coordination event for dispatch %s: %s", result.dispatch_id, exc)
             return None
 

--- a/scripts/lib/intelligence_sources/_recording.py
+++ b/scripts/lib/intelligence_sources/_recording.py
@@ -57,13 +57,16 @@ def record_injection_audit(
     suppressed_json = json.dumps([s.to_dict() for s in result.suppressed])
     ab_arm = getattr(result, "ab_arm", "treatment") or "treatment"
     try:
-        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, rearm_busy_timeout
+        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, is_lock_timeout_error, rearm_busy_timeout
     except ImportError:
         import time as _time
         CoordinationLockError = Exception
         DEFAULT_LOCK_TIMEOUT_SECONDS = 10.0
         def deadline_for_timeout(t): return _time.monotonic() + t
         def rearm_busy_timeout(conn, deadline): pass
+        # Degraded path: the sentinel handler below (`except CoordinationLockError:
+        # raise`) already re-raises everything, so this branch is never reached.
+        def is_lock_timeout_error(exc): return False
     deadline = deadline_for_timeout(DEFAULT_LOCK_TIMEOUT_SECONDS)
     try:
         with get_connection(state_dir, timeout=DEFAULT_LOCK_TIMEOUT_SECONDS) as conn:
@@ -119,6 +122,16 @@ def record_injection_audit(
     except CoordinationLockError:
         raise
     except sqlite3.Error as e:
+        # OI-880: SQLite's own lock-busy OperationalError must surface as
+        # CoordinationLockError, not vanish at WARNING.  Classification is
+        # content-based in coordination_retry.is_lock_timeout_error — a
+        # non-lock error (no such table, ...) keeps the existing swallow path.
+        if is_lock_timeout_error(e):
+            raise CoordinationLockError(
+                "Coordination DB write lock deadline exhausted — "
+                "database is locked after busy_timeout; "
+                "audit row NOT written"
+            ) from e
         logger.warning("Failed to record injection audit: %s", e)
 
 
@@ -147,13 +160,16 @@ def record_pattern_usage(
     pu_has_project = has_column_fn("pattern_usage", "project_id")
     dpo_has_project = has_column_fn("dispatch_pattern_offered", "project_id")
     try:
-        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, rearm_busy_timeout
+        from coordination_retry import CoordinationLockError, DEFAULT_LOCK_TIMEOUT_SECONDS, deadline_for_timeout, is_lock_timeout_error, rearm_busy_timeout
     except ImportError:
         import time as _time
         CoordinationLockError = Exception
         DEFAULT_LOCK_TIMEOUT_SECONDS = 10.0
         def deadline_for_timeout(t): return _time.monotonic() + t
         def rearm_busy_timeout(conn, deadline): pass
+        # Degraded path: the sentinel handler below (`except CoordinationLockError:
+        # raise`) already re-raises everything, so this branch is never reached.
+        def is_lock_timeout_error(exc): return False
     deadline = deadline_for_timeout(DEFAULT_LOCK_TIMEOUT_SECONDS)
     try:
         rearm_busy_timeout(db, deadline)
@@ -204,6 +220,15 @@ def record_pattern_usage(
     except CoordinationLockError:
         raise
     except sqlite3.Error as e:
+        # Same OI-880 classification as record_injection_audit: a lock-busy
+        # OperationalError must surface as CoordinationLockError, a real
+        # sqlite error keeps the existing swallow path.
+        if is_lock_timeout_error(e):
+            raise CoordinationLockError(
+                "Coordination DB write lock deadline exhausted — "
+                "database is locked after busy_timeout; "
+                "pattern usage rows NOT written"
+            ) from e
         logger.warning("Failed to record pattern usage: %s", e)
 
 

--- a/tests/test_intelligence_selector_exception_handling.py
+++ b/tests/test_intelligence_selector_exception_handling.py
@@ -92,14 +92,23 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
     """record_injection with a broken DB logs instead of crashing."""
 
     def test_corrupt_db_logs_warning(self) -> None:
-        """sqlite3.Error during injection audit write surfaces as log.warning."""
+        """A genuinely corrupt DB (non-lock sqlite error) logs, not crashes.
+
+        OI-880: only lock-busy errors are reclassified as CoordinationLockError.
+        A non-lock OperationalError (corrupt DB, no such table, ...) keeps the
+        existing swallow path, so a broken store still logs at WARNING instead
+        of taking the dispatch down.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             sel = _make_selector(tmp)
             result = _make_result()
 
             import runtime_coordination as _rc
             with (
-                patch.object(_rc, "get_connection", side_effect=sqlite3.OperationalError("db locked")),
+                patch.object(
+                    _rc, "get_connection",
+                    side_effect=sqlite3.OperationalError("database disk image is malformed"),
+                ),
                 self.assertLogs("intelligence_sources._recording", level="WARNING") as cm,
             ):
                 sel.record_injection(result)
@@ -112,9 +121,11 @@ class TestCorruptStateLogsWarning(unittest.TestCase):
         from contextlib import contextmanager
 
         @contextmanager
-        def _noop_conn(_state_dir):
+        def _noop_conn(_state_dir, timeout=10.0):
             conn = MagicMock(spec=sqlite3.Connection)
             conn.execute.return_value = MagicMock()
+            # PRAGMA table_info probe returns no rows → legacy insert path.
+            conn.execute.return_value.fetchall.return_value = []
             conn.commit.return_value = None
             yield conn
 

--- a/tests/test_oi880_lock_error_classification.py
+++ b/tests/test_oi880_lock_error_classification.py
@@ -1,0 +1,299 @@
+"""tests/test_oi880_lock_error_classification.py — OI-880: lock-busy errors from the write path.
+
+The lock-retry helper (coordination_retry.rearm_busy_timeout) only raises
+CoordinationLockError when the deadline is already exhausted at call time.  The
+write path can instead hit SQLite's OWN ``sqlite3.OperationalError: database is
+locked`` when a statement exhausts its busy_timeout on a held lock.  That error
+was swallowed by the call sites' generic ``except Exception`` / ``except
+sqlite3.Error`` at WARNING level — a silently lost audit event.
+
+These tests drive the actual write path under contention (a second connection
+holding the write lock) and assert the lock-busy error surfaces as
+CoordinationLockError instead of vanishing.  They fail against the pre-fix code
+(which swallows) and pass once the classification is in place.
+
+Run against a temporary DB only — never the live central store.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = REPO_ROOT / "scripts" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+import coordination_retry  # noqa: E402  (sys.path bootstrap above)
+from coordination_retry import CoordinationLockError  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def short_lock_timeout(monkeypatch):
+    """Shrink the 5s default lock deadline to 1s so contention tests stay fast.
+
+    The call sites import DEFAULT_LOCK_TIMEOUT_SECONDS from coordination_retry
+    at call time, so patching the module attribute is sufficient.
+    """
+    monkeypatch.setattr(coordination_retry, "DEFAULT_LOCK_TIMEOUT_SECONDS", 1.0)
+    yield
+
+
+def _init_coordination_events(db_path: Path) -> None:
+    """Minimal coordination_events schema (no project_id → legacy insert path)."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            event_id    TEXT NOT NULL,
+            event_type  TEXT NOT NULL,
+            entity_type TEXT NOT NULL,
+            entity_id   TEXT NOT NULL,
+            from_state  TEXT,
+            to_state    TEXT,
+            actor       TEXT NOT NULL DEFAULT 'runtime',
+            reason      TEXT,
+            metadata_json TEXT NOT NULL DEFAULT '{}',
+            occurred_at TEXT NOT NULL
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _init_intelligence_injections(db_path: Path) -> None:
+    """Minimal intelligence_injections schema (no project_id / ab_arm columns)."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS intelligence_injections (
+            injection_id     TEXT PRIMARY KEY,
+            dispatch_id      TEXT NOT NULL,
+            injection_point  TEXT NOT NULL,
+            task_class       TEXT,
+            items_injected   INTEGER NOT NULL DEFAULT 0,
+            items_suppressed INTEGER NOT NULL DEFAULT 0,
+            payload_chars    INTEGER NOT NULL DEFAULT 0,
+            items_json       TEXT NOT NULL DEFAULT '{}',
+            suppressed_json  TEXT NOT NULL DEFAULT '{}'
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _hold_write_lock(db_path: str, hold_secs: float, ready: threading.Event) -> None:
+    """Acquire a write lock on *db_path* and hold it for *hold_secs*."""
+    conn = sqlite3.connect(db_path, timeout=1)
+    conn.execute("PRAGMA busy_timeout = 1000")
+    conn.execute("BEGIN IMMEDIATE")
+    ready.set()  # Signal that the lock is held.
+    time.sleep(hold_secs)
+    conn.rollback()
+    conn.close()
+
+
+def _make_injection_result(dispatch_id: str, n_items: int = 0):
+    """Build a minimal InjectionResult; empty items → suppression event."""
+    from intelligence_sources._common import IntelligenceItem, SuppressionRecord
+    from intelligence_sources._models import InjectionResult
+
+    items = [
+        IntelligenceItem(
+            item_id=f"intel_test_{i}",
+            item_class="proven_pattern",
+            title="test pattern",
+            content="test content",
+            confidence=0.9,
+            evidence_count=2,
+            last_seen="2026-07-31T00:00:00Z",
+            scope_tags=[],
+        )
+        for i in range(n_items)
+    ]
+    return InjectionResult(
+        injection_point="dispatch_create",
+        injected_at="2026-07-31T00:00:00Z",
+        items=items,
+        suppressed=[SuppressionRecord(item_class="proven_pattern", reason="test")],
+        task_class="coding_interactive",
+        dispatch_id=dispatch_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write path under real contention — the gap the existing helper-only tests miss
+# ---------------------------------------------------------------------------
+
+def test_emit_event_lock_busy_error_not_swallowed(tmp_path, short_lock_timeout):
+    """emit_event must NOT swallow SQLite's own ``database is locked`` error.
+
+    Pre-fix: the OperationalError falls into the generic ``except Exception``,
+    logs at WARNING and returns None — the audit event is silently lost.
+    """
+    from intelligence_selector import IntelligenceSelector
+
+    state_dir = tmp_path / "coord"
+    db_path = state_dir / "runtime_coordination.db"
+    _init_coordination_events(db_path)
+
+    selector = IntelligenceSelector(coord_db_state_dir=str(state_dir))
+    result = _make_injection_result("dispatch-oi880-test-1")
+
+    ready = threading.Event()
+    holder = threading.Thread(
+        target=_hold_write_lock, args=(str(db_path), 3.0, ready), daemon=True
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=5), "lock holder did not acquire the write lock"
+        with pytest.raises(CoordinationLockError):
+            selector.emit_event(result)
+    finally:
+        holder.join(timeout=10)
+        selector.close()
+
+
+def test_record_injection_audit_lock_busy_error_not_swallowed(tmp_path, short_lock_timeout):
+    """record_injection_audit must NOT swallow SQLite's ``database is locked``.
+
+    Pre-fix: the OperationalError is caught by ``except sqlite3.Error`` and
+    swallowed at WARNING — the audit row is silently lost.
+    """
+    from intelligence_sources._recording import record_injection_audit
+
+    state_dir = tmp_path / "coord"
+    db_path = state_dir / "runtime_coordination.db"
+    _init_intelligence_injections(db_path)
+
+    result = _make_injection_result("dispatch-oi880-test-2")
+
+    ready = threading.Event()
+    holder = threading.Thread(
+        target=_hold_write_lock, args=(str(db_path), 3.0, ready), daemon=True
+    )
+    holder.start()
+    try:
+        assert ready.wait(timeout=5), "lock holder did not acquire the write lock"
+        with pytest.raises(CoordinationLockError):
+            record_injection_audit(result, state_dir, None)
+    finally:
+        holder.join(timeout=10)
+
+
+def test_record_injection_lock_busy_propagates(tmp_path):
+    """record_injection surfaces a lock-busy get_connection error loudly.
+
+    Pre-fix: the OperationalError is swallowed by ``except sqlite3.Error`` and
+    the method returns normally — the audit row is silently lost.
+    """
+    from unittest.mock import patch
+
+    from intelligence_selector import IntelligenceSelector
+
+    state_dir = tmp_path / "coord"
+    selector = IntelligenceSelector(coord_db_state_dir=str(state_dir))
+    result = _make_injection_result("dispatch-oi880-test-4")
+
+    import runtime_coordination as _rc
+
+    with patch.object(
+        _rc, "get_connection", side_effect=sqlite3.OperationalError("database is locked")
+    ):
+        with pytest.raises(CoordinationLockError):
+            selector.record_injection(result)
+    selector.close()
+
+
+def test_record_pattern_usage_lock_busy_error_not_swallowed(tmp_path, short_lock_timeout, monkeypatch):
+    """record_pattern_usage applies the same classification (OI-880).
+
+    Uses a monkeypatched upsert to raise SQLite's lock-busy error deterministically
+    — the quality DB is caller-owned, so real thread contention is not the write path.
+    """
+    from intelligence_sources._recording import record_pattern_usage
+
+    db_path = tmp_path / "quality_intelligence.db"
+    db = sqlite3.connect(str(db_path))
+    db.row_factory = sqlite3.Row
+
+    def _fake_resolve(_db, table, preferred, fallback):
+        return ("pattern_id",)
+
+    def _boom(_db, item, now, project_id, has_project, conflict_target):
+        raise sqlite3.OperationalError("database is locked")
+
+    monkeypatch.setattr(
+        "intelligence_sources._recording._resolve_conflict_target", _fake_resolve
+    )
+    monkeypatch.setattr(
+        "intelligence_sources._recording._upsert_pattern_usage", _boom
+    )
+    monkeypatch.setattr(
+        "intelligence_sources._recording._upsert_dispatch_pattern_offered",
+        lambda *a, **k: None,
+    )
+
+    result = _make_injection_result("dispatch-oi880-test-3", n_items=1)
+    try:
+        with pytest.raises(CoordinationLockError):
+            record_pattern_usage(result, db, lambda _t, _c: True)
+    finally:
+        db.close()
+
+
+# ---------------------------------------------------------------------------
+# Content-based classification — a non-lock OperationalError is NOT contention
+# ---------------------------------------------------------------------------
+
+def test_is_lock_timeout_error_is_content_based():
+    """OperationalError covers real bugs too; only lock-busy is contention.
+
+    Fails on the pre-fix code with an ImportError (the helper did not exist).
+    """
+    from coordination_retry import is_lock_timeout_error
+
+    # Message fallback — a hand-constructed OperationalError carries no
+    # sqlite_errorcode, so the classifier must still recognise lock-busy.
+    assert is_lock_timeout_error(sqlite3.OperationalError("database is locked"))
+    assert is_lock_timeout_error(sqlite3.OperationalError("database table is locked"))
+    assert is_lock_timeout_error(CoordinationLockError("deadline exhausted"))
+
+    # Real bugs are NOT lock contention and must keep the existing swallow path.
+    assert not is_lock_timeout_error(
+        sqlite3.OperationalError("no such table: coordination_events")
+    )
+    assert not is_lock_timeout_error(
+        sqlite3.OperationalError("no such column: project_id")
+    )
+    assert not is_lock_timeout_error(
+        sqlite3.IntegrityError("UNIQUE constraint failed: pattern_usage.pattern_id")
+    )
+    assert not is_lock_timeout_error(ValueError("not a sqlite error"))
+
+    # Structured code path (Python 3.11+): BUSY / LOCKED, incl. extended codes.
+    busy = sqlite3.OperationalError("db locked")
+    busy.sqlite_errorcode = sqlite3.SQLITE_BUSY
+    locked = sqlite3.OperationalError("db locked")
+    locked.sqlite_errorcode = sqlite3.SQLITE_LOCKED
+    extended = sqlite3.OperationalError("db locked")
+    extended.sqlite_errorcode = sqlite3.SQLITE_BUSY_SNAPSHOT
+    real_bug = sqlite3.OperationalError("db locked")
+    real_bug.sqlite_errorcode = sqlite3.SQLITE_ERROR
+    assert is_lock_timeout_error(busy)
+    assert is_lock_timeout_error(locked)
+    assert is_lock_timeout_error(extended)
+    assert not is_lock_timeout_error(real_bug)


### PR DESCRIPTION
## OI-880 — the lock-retry catches its own sentinel, not the error that actually happens

`rearm_busy_timeout` only raises `CoordinationLockError` when the deadline is already exhausted at call time. When SQLite itself throws `sqlite3.OperationalError: database is locked` (a statement exhausted its `busy_timeout` on a held lock), the error was swallowed by:

- `emit_event`'s generic `except Exception` → logged at WARNING, returned `None`
- `record_injection_audit`'s `except sqlite3.Error` → logged at WARNING, returned

The audit event vanished with no failure signal. Live-measured 31-07 16:31 with two dispatches running plus a third.

## Fix

- `coordination_retry.is_lock_timeout_error()` — content-based classification: prefers `sqlite_errorcode` (SQLITE_BUSY / SQLITE_LOCKED incl. extended low-byte mask, Python 3.11+), falls back to message substring only when no code is attached. `no such table` and other real bugs are explicitly NOT lock contention.
- Both named call sites plus `record_pattern_usage` (same structural bug in the same file) reclassify a lock-busy `OperationalError` as `CoordinationLockError` and propagate; non-lock sqlite errors keep the existing swallow path.
- `CoordinationLockError` propagation contract unchanged — nothing that catches it changed, only what gets classified as it.
- Classification lives in `coordination_retry` (the source) rather than the call sites so both writers recognize the same failures and the helper owns the contract.

## Verification — red on `origin/main`, green on this branch

`tests/test_oi880_lock_error_classification.py` drives the real write path under a held write lock:

| Test | `origin/main` | this branch |
|---|---|---|
| `test_emit_event_lock_busy_error_not_swallowed` | DID NOT RAISE (swallowed at WARNING) | PASS |
| `test_record_injection_audit_lock_busy_error_not_swallowed` | DID NOT RAISE (swallowed at `_recording.py:122`) | PASS |
| `test_record_injection_lock_busy_propagates` | DID NOT RAISE | PASS |
| `test_record_pattern_usage_lock_busy_error_not_swallowed` | DID NOT RAISE (swallowed at `_recording.py:207`) | PASS |
| `test_is_lock_timeout_error_is_content_based` | ImportError (helper absent) | PASS |

origin/main run: `5 failed, 10 passed, exit=1`
this branch run: `5 passed (+ existing suite), exit=0`

The captured logs on the origin/main run show the exact bug: `emit_event: failed to append coordination event ... database is locked` and `Failed to record injection audit: database is locked`.

Also updated `tests/test_intelligence_selector_exception_handling.py`:
- `test_corrupt_db_logs_warning` now uses a genuine non-lock error (`database disk image is malformed`) — `"db locked"` is now intentionally loud, so it no longer stands in for a corrupt DB.
- `test_stamp_source_ids_db_error_logs_debug` mock now accepts `get_connection`'s `timeout` kwarg (pre-existing failure on origin/main).

## Tests

`148 passed` across the lock-retry, intelligence injection/selector, and pattern-usage suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)