### PR TITLE
fix(dispatch): reap dispatch process groups recorded at spawn (OI-877)

### DIFF
--- a/scripts/lib/dispatch_process_registry.py
+++ b/scripts/lib/dispatch_process_registry.py
@@ -1,0 +1,370 @@
+"""dispatch_process_registry.py — record & reap dispatch-scoped process groups (OI-877).
+
+A dispatch worker's session hooks can leave processes behind that outlive the
+dispatch and run entirely OUTSIDE the dispatch worktree.  Their repo-root
+resolves to the main checkout (the git common dir), so the worktree-scoped
+lsof scan in ``worktree_process_cleanup.kill_worktree_processes`` cannot see
+them — measured 2026-07-31: a ``session_reconcile_autoclose.sh``-spawned
+``planning_cli.py objective reconcile`` survived dispatch teardown and held the
+coordination DB write lock, blocking ``link_sessions_dispatches.py``.
+
+This module records the worker's process group(s) at spawn time — the one
+moment the lane still knows the group — and re-finds them at teardown by PGID.
+A process that has run away from the group (reparented to launchd, PPID 1)
+keeps its PGID, so it is still found.
+
+Conservatism: the registry only ever contains what a dispatch lane explicitly
+recorded, and teardown only signals a group when at least one recorded member
+PID still exists AND still carries the recorded PGID.  If there is any doubt
+(no entry, entry cleared, every member gone, or the PGID reused by an
+unrelated group), the kill does nothing and logs instead of guessing.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import signal
+import subprocess
+import time
+from pathlib import Path
+from typing import Iterable
+
+logger = logging.getLogger(__name__)
+
+# Matches the sanitization in dispatch_worktree_isolation so the registry key
+# for a dispatch is identical whichever teardown path resolves it.
+_UNSAFE_RE = re.compile(r"[^A-Za-z0-9_-]")
+_MAX_SAFE_ID_LEN = 60
+
+# SIGTERM grace period before SIGKILL — mirrors worktree_process_cleanup.
+_GRACE_SECONDS = 0.3
+
+
+def _sanitize_dispatch_id(dispatch_id: str) -> str:
+    """Return a filesystem-safe key for *dispatch_id*."""
+    return _UNSAFE_RE.sub("-", dispatch_id)[:_MAX_SAFE_ID_LEN]
+
+
+def _registry_dir(repo_root: Path) -> Path:
+    """Return the per-repo directory holding one JSON entry per dispatch."""
+    return Path(repo_root).resolve() / ".vnx-data" / "state" / "dispatch_pgids"
+
+
+def _entry_path(repo_root: Path, dispatch_id: str) -> Path:
+    return _registry_dir(repo_root) / f"{_sanitize_dispatch_id(dispatch_id)}.json"
+
+
+# ---------------------------------------------------------------------------
+# Recording
+# ---------------------------------------------------------------------------
+
+def _snapshot_group_members(pgid: int) -> list[int]:
+    """Return the member PIDs of *pgid* right now (empty on any failure)."""
+    try:
+        result = subprocess.run(
+            ["ps", "-g", str(pgid), "-o", "pid="],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+        return [
+            int(line.strip())
+            for line in result.stdout.splitlines()
+            if line.strip().isdigit()
+        ]
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return []
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dispatch_process_registry: ps -g %s failed: %s", pgid, exc)
+        return []
+
+
+def _load_entry(
+    dispatch_id: str, *, repo_root: Path
+) -> "dict[str, object] | None":
+    """Read the registry entry for *dispatch_id*; None when absent or corrupt."""
+    path = _entry_path(repo_root, dispatch_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        entry = json.loads(raw)
+        if not isinstance(entry, dict):
+            return None
+        return entry
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        logger.warning(
+            "dispatch_process_registry: unreadable entry %s: %s — "
+            "treating as absent (nothing to kill)",
+            path,
+            exc,
+        )
+        return None
+
+
+def _write_entry(dispatch_id: str, *, repo_root: Path, entry: dict) -> None:
+    """Atomically persist the registry entry for *dispatch_id*."""
+    from atomic_io import atomic_write_text  # noqa: PLC0415
+
+    path = _entry_path(repo_root, dispatch_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write_text(
+        path,
+        json.dumps(entry, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+
+
+def record_dispatch_pgids(
+    dispatch_id: str,
+    pgids: Iterable[int],
+    *,
+    repo_root: Path,
+) -> None:
+    """Record process groups belonging to *dispatch_id* for later teardown.
+
+    Each group is snapshotted with its current member PIDs so teardown can
+    verify the group is still the one this dispatch spawned (PID/PGID reuse
+    guard).  Appends to any existing entry for the same dispatch.  Never
+    raises: a failed record degrades to "worktree scan only" teardown.
+    """
+    if not dispatch_id or not pgids:
+        return
+    entry = _load_entry(dispatch_id, repo_root=repo_root) or {}
+    groups: dict[str, list[int]] = dict(entry.get("groups") or {})
+    for pgid in pgids:
+        try:
+            pgid_int = int(pgid)
+        except (TypeError, ValueError):
+            continue
+        members = _snapshot_group_members(pgid_int)
+        if members:
+            groups[str(pgid_int)] = members
+    if not groups:
+        return
+    entry["dispatch_id"] = dispatch_id
+    entry["recorded_at"] = time.time()
+    entry["groups"] = groups
+    try:
+        _write_entry(dispatch_id, repo_root=repo_root, entry=entry)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "dispatch_process_registry: failed to record pgids for %s: %s — "
+            "teardown will fall back to the worktree scan only",
+            dispatch_id,
+            exc,
+        )
+
+
+def load_dispatch_pgids(dispatch_id: str, *, repo_root: Path) -> list[int]:
+    """Return the recorded PGIDs for *dispatch_id* (empty when none)."""
+    entry = _load_entry(dispatch_id, repo_root=repo_root)
+    if not entry:
+        return []
+    groups = entry.get("groups") or {}
+    result: list[int] = []
+    for pgid_str in groups:
+        try:
+            result.append(int(pgid_str))
+        except (TypeError, ValueError):
+            continue
+    return sorted(result)
+
+
+def clear_dispatch_pgids(dispatch_id: str, *, repo_root: Path) -> None:
+    """Remove the registry entry for *dispatch_id*.  Idempotent, never raises."""
+    try:
+        _entry_path(repo_root, dispatch_id).unlink(missing_ok=True)
+    except OSError as exc:
+        logger.debug(
+            "dispatch_process_registry: clear failed for %s: %s",
+            dispatch_id,
+            exc,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Teardown
+# ---------------------------------------------------------------------------
+
+def _group_is_valid(pgid: int, member_pids: list[int]) -> bool:
+    """True when a recorded member still exists and still carries *pgid*.
+
+    Guards against PGID reuse: a group whose PGID was handed to an unrelated
+    process will not have any recorded member PID in it.
+    """
+    for pid in member_pids:
+        try:
+            if os.getpgid(pid) == pgid:
+                return True
+        except (ProcessLookupError, PermissionError):
+            continue
+    return False
+
+
+def kill_dispatch_pgids(
+    dispatch_id: str,
+    *,
+    repo_root: Path,
+    grace: float = _GRACE_SECONDS,
+) -> int:
+    """Kill the recorded process groups of *dispatch_id*.
+
+    SIGTERM then, after *grace*, SIGKILL — mirroring
+    ``worktree_process_cleanup.kill_worktree_processes``.  The caller's own
+    process group is never signalled.  A group is only signalled when at least
+    one recorded member PID is still alive in it.
+
+    Returns the number of process groups signalled (0 when nothing was
+    provably this dispatch's).
+    """
+    entry = _load_entry(dispatch_id, repo_root=repo_root)
+    if not entry:
+        logger.debug(
+            "dispatch_process_registry: no pgid entry for %s — nothing to do",
+            dispatch_id,
+        )
+        return 0
+    groups = entry.get("groups") or {}
+
+    own_pgid = os.getpgid(0)
+    targets: list[int] = []
+    for pgid_str, member_pids in groups.items():
+        try:
+            pgid = int(pgid_str)
+        except (TypeError, ValueError):
+            continue
+        if pgid == own_pgid:
+            logger.debug(
+                "dispatch_process_registry: skip pgid %s for %s (own group)",
+                pgid,
+                dispatch_id,
+            )
+            continue
+        members = (
+            [int(p) for p in member_pids if str(p).isdigit()]
+            if isinstance(member_pids, list)
+            else []
+        )
+        if _group_is_valid(pgid, members):
+            targets.append(pgid)
+        else:
+            logger.warning(
+                "dispatch_process_registry: NOT killing pgid %s for %s — "
+                "no recorded member alive with that PGID (group gone or PGID "
+                "reused); leaving it untouched",
+                pgid,
+                dispatch_id,
+            )
+
+    if not targets:
+        logger.debug(
+            "dispatch_process_registry: no valid target groups for %s",
+            dispatch_id,
+        )
+        return 0
+
+    for pgid in targets:
+        try:
+            os.killpg(pgid, signal.SIGTERM)
+        except (ProcessLookupError, PermissionError):
+            pass
+    time.sleep(grace)
+    for pgid in targets:
+        try:
+            os.killpg(pgid, signal.SIGKILL)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+    logger.info(
+        "dispatch_process_registry: signalled %d process group(s) for dispatch %s",
+        len(targets),
+        dispatch_id,
+    )
+    return len(targets)
+
+
+def cleanup_dispatch_processes(
+    dispatch_id: str,
+    wt_path: Path,
+    *,
+    repo_root: Path,
+) -> int:
+    """Kill dispatch processes via BOTH teardown mechanisms, then clear.
+
+    Mechanism 1 (existing): the worktree-scoped lsof scan — finds processes
+    with files or CWD inside *wt_path*.  Mechanism 2 (this module): the
+    pgid registry — finds dispatch processes recorded at spawn that run
+    outside the worktree.
+
+    Returns the total number of process groups signalled.
+    """
+    total = 0
+    try:
+        from worktree_process_cleanup import kill_worktree_processes  # noqa: PLC0415
+
+        total += kill_worktree_processes(wt_path)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "dispatch_process_registry: worktree scan failed for %s: %s",
+            dispatch_id,
+            exc,
+        )
+    total += kill_dispatch_pgids(dispatch_id, repo_root=repo_root)
+    clear_dispatch_pgids(dispatch_id, repo_root=repo_root)
+    return total
+
+
+# ---------------------------------------------------------------------------
+# Spawn-time capture helper (tmux lane)
+# ---------------------------------------------------------------------------
+
+def collect_descendant_pgids(root_pid: int) -> set[int]:
+    """Return the PGIDs of *root_pid* and every descendant of it.
+
+    Used by the tmux lane to record the worker's process groups right after
+    the SessionStart hooks have fired — at that point any hook-spawned
+    background process is already a member of the captured groups, so the
+    escaped orphan is re-findable at teardown even after reparenting.
+    """
+    try:
+        result = subprocess.run(
+            ["ps", "-axo", "pid=,ppid=,pgid="],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return set()
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("dispatch_process_registry: ps -axo failed: %s", exc)
+        return set()
+
+    children: dict[int, list[int]] = {}
+    pgid_of: dict[int, int] = {}
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) < 3:
+            continue
+        try:
+            pid, ppid, pgid = int(parts[0]), int(parts[1]), int(parts[2])
+        except ValueError:
+            continue
+        pgid_of[pid] = pgid
+        children.setdefault(ppid, []).append(pid)
+
+    seen: set[int] = set()
+    stack = [root_pid]
+    pgids: set[int] = set()
+    while stack:
+        pid = stack.pop()
+        if pid in seen:
+            continue
+        seen.add(pid)
+        if pid in pgid_of:
+            pgids.add(pgid_of[pid])
+        stack.extend(children.get(pid, []))
+    return pgids

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -237,6 +237,26 @@ def remove_dispatch_worktree(
             dispatch_id, _proc_exc,
         )
 
+    # OI-877: also reap process groups recorded for this dispatch at spawn
+    # time.  A dispatch process whose repo-root resolved to the MAIN checkout
+    # has nothing open inside the worktree, so the lsof scan cannot see it —
+    # the recorded PGID is the only handle that still reaches it (even after
+    # it was reparented to launchd / PPID 1).  Keep the worktree scan above;
+    # this is a second membership source, not a replacement.
+    try:
+        from dispatch_process_registry import (  # noqa: PLC0415
+            clear_dispatch_pgids,
+            kill_dispatch_pgids,
+        )
+        kill_dispatch_pgids(dispatch_id, repo_root=root)
+        clear_dispatch_pgids(dispatch_id, repo_root=root)
+    except Exception as _pgid_exc:
+        log.warning(
+            "remove_dispatch_worktree: pgid-based process cleanup failed for "
+            "%s: %s — continuing with worktree removal",
+            dispatch_id, _pgid_exc,
+        )
+
     with _worktree_lock(root):
         try:
             subprocess.run(

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -405,6 +405,37 @@ class SubprocessAdapter:
         self._processes[terminal_id] = process
         self._dispatch_ids[terminal_id] = dispatch_id
 
+        # OI-877: record the worker's process group so teardown can find
+        # dispatch processes that escape the worktree (their repo-root
+        # resolves to the main checkout).  Only when the worker runs inside an
+        # isolated dispatch worktree — that is the case whose teardown path
+        # (remove_dispatch_worktree) reads the registry.  The worker runs with
+        # preexec_fn=os.setsid, so its PGID == its PID.  Best-effort: a failed
+        # record degrades to worktree-scan-only teardown.
+        if dispatch_id and cwd is not None:
+            try:
+                _wt = Path(cwd).resolve()
+                if (
+                    len(_wt.parts) >= 3
+                    and _wt.parts[-3] == ".vnx-data"
+                    and _wt.parts[-2] == "worktrees"
+                    and _wt.name.startswith("dispatch-")
+                ):
+                    from dispatch_process_registry import (  # noqa: PLC0415
+                        record_dispatch_pgids,
+                    )
+                    record_dispatch_pgids(
+                        dispatch_id,
+                        [os.getpgid(process.pid)],
+                        repo_root=_wt.parents[2],
+                    )
+            except Exception as _rec_exc:
+                logger.debug(
+                    "subprocess_adapter: dispatch pgid record failed for %s: %s",
+                    dispatch_id,
+                    _rec_exc,
+                )
+
         # Archive previous dispatch events, then clear for new dispatch
         es = self._get_event_store()
         if es is not None:

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2321,6 +2321,49 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                 )
 
+            # OI-877: record the worker's process group(s) so teardown can find
+            # dispatch processes that escape the worktree (their repo-root
+            # resolves to the main checkout).  Capture at readiness — AFTER the
+            # SessionStart hooks have fired, so any hook-spawned background
+            # process is already a member of the captured groups and stays
+            # re-findable at teardown even after reparenting (PPID 1).  The
+            # pane shell's own group is excluded: only the worker's groups are
+            # recorded, never the dispatcher's.  Best-effort: a failed capture
+            # degrades to worktree-scan-only teardown.
+            if _ready and worktree_handle is not None:
+                try:
+                    from dispatch_process_registry import (  # noqa: PLC0415
+                        collect_descendant_pgids,
+                        record_dispatch_pgids,
+                    )
+                    _pane_pid_res = self._runner.run(
+                        ["display-message", "-p", "-t", pane_id, "#{pane_pid}"]
+                    )
+                    _pane_pid_str = (
+                        (_pane_pid_res.stdout or "").strip()
+                        if _pane_pid_res.returncode == 0
+                        else ""
+                    )
+                    if _pane_pid_str.isdigit():
+                        _pane_pid = int(_pane_pid_str)
+                        _worker_pgids = collect_descendant_pgids(_pane_pid)
+                        try:
+                            _worker_pgids.discard(os.getpgid(_pane_pid))
+                        except (ProcessLookupError, PermissionError):
+                            pass
+                        if _worker_pgids:
+                            record_dispatch_pgids(
+                                dispatch_id,
+                                sorted(_worker_pgids),
+                                repo_root=self._project_root,
+                            )
+                except Exception as _pgid_exc:
+                    logger.warning(
+                        "interactive: dispatch pgid capture failed for %s: %s",
+                        dispatch_id,
+                        _pgid_exc,
+                    )
+
             if attach:
                 self._attach(session)
 

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -290,6 +290,26 @@ def reap(handle: WorktreeHandle, classification: str) -> ReapResult:
                 "continuing with worktree removal",
                 handle.dispatch_id, _proc_exc,
             )
+        # OI-877: also reap process groups recorded for this dispatch at spawn
+        # time.  A dispatch process whose repo-root resolved to the MAIN
+        # checkout has nothing open inside the worktree, so the lsof scan
+        # cannot see it — the recorded PGID is the only handle that still
+        # reaches it (even after it was reparented to launchd / PPID 1).  The
+        # worktree scan above stays; this is a second membership source, not
+        # a replacement.
+        try:
+            from dispatch_process_registry import (  # noqa: PLC0415
+                clear_dispatch_pgids,
+                kill_dispatch_pgids,
+            )
+            kill_dispatch_pgids(handle.dispatch_id, repo_root=root)
+            clear_dispatch_pgids(handle.dispatch_id, repo_root=root)
+        except Exception as _pgid_exc:
+            logger.warning(
+                "reap: pgid-based process cleanup failed for %s: %s — "
+                "continuing with worktree removal",
+                handle.dispatch_id, _pgid_exc,
+            )
 
     with _flock_context(root):
         if classification == "clean":

--- a/scripts/lib/worktree_process_cleanup.py
+++ b/scripts/lib/worktree_process_cleanup.py
@@ -96,8 +96,8 @@ def kill_worktree_processes(wt_path: Path) -> int:
     for pgid in pgids:
         try:
             os.killpg(pgid, signal.SIGKILL)
-        except ProcessLookupError:
-            pass  # Already gone — that's fine.
+        except (ProcessLookupError, PermissionError):
+            pass  # Already gone (or only a zombie left) — that's fine.
 
     logger.info(
         "kill_worktree_processes: signalled %d process group(s) for %s",

--- a/tests/test_dispatch_process_registry.py
+++ b/tests/test_dispatch_process_registry.py
@@ -1,0 +1,323 @@
+"""tests/test_dispatch_process_registry.py — OI-877: reap dispatch processes outside the worktree.
+
+The worktree-scoped cleanup (``kill_worktree_processes``) finds processes that
+have files or CWD inside the dispatch worktree.  OI-877 is the second failure
+path: a dispatch process whose repo-root resolved to the MAIN checkout escapes
+the worktree entirely, so ``lsof +D <worktree>`` cannot see it.
+
+This suite verifies the pgid-registry teardown: process groups recorded at
+dispatch spawn time are re-found at teardown and killed even when they run
+outside the worktree and have been reparented to PID 1.
+
+Every test MUST fail against origin/main (the module does not exist there) and
+pass on this branch.  Run:
+    python -m pytest tests/test_dispatch_process_registry.py > /tmp/out.txt 2>&1; echo "exit=$?"
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+LIB_DIR = REPO_ROOT / "scripts" / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _pid_alive(pid: int) -> bool:
+    """Check if a process is actually running (not zombie/defunct)."""
+    try:
+        result = subprocess.run(
+            ["ps", "-p", str(pid), "-o", "state="],
+            capture_output=True, text=True, timeout=5,
+        )
+        state = result.stdout.strip()
+        return bool(state) and not state.startswith("Z")
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        try:
+            os.kill(pid, 0)
+            return True
+        except (ProcessLookupError, PermissionError):
+            return False
+
+
+def _reap(proc: subprocess.Popen) -> None:
+    """Reap a subprocess if it is still around (defensive)."""
+    try:
+        proc.wait(timeout=1)
+    except subprocess.TimeoutExpired:
+        proc.kill()
+        proc.wait(timeout=5)
+
+
+def _spawn_sleeping_child(cwd: Path, hold_db: "Path | None" = None) -> "tuple[subprocess.Popen, int, int]":
+    """Spawn a child in its own session; return (proc, pid, pgid).
+
+    When *hold_db* is given the child opens it with an immediate transaction,
+    holding the write lock, and prints ``pid pgid`` on stdout.
+    """
+    if hold_db is not None:
+        body = (
+            f"import sqlite3, time, os\n"
+            f"conn = sqlite3.connect('{hold_db}')\n"
+            f"conn.execute('BEGIN IMMEDIATE')\n"
+            f"print(f'{{os.getpid()}} {{os.getpgid(0)}}', flush=True)\n"
+            f"time.sleep(60)\n"
+        )
+    else:
+        body = (
+            "import time, os\n"
+            "print(f'{os.getpid()} {os.getpgid(0)}', flush=True)\n"
+            "time.sleep(60)\n"
+        )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", body],
+        cwd=str(cwd),
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+        start_new_session=True,
+    )
+    try:
+        out_line = proc.stdout.readline().strip()
+        pid_str, pgid_str = out_line.split()
+        return proc, int(pid_str), int(pgid_str)
+    except (ValueError, AttributeError):
+        _reap(proc)
+        pytest.fail("Failed to read child PID/PGID from stdout")
+
+
+# ---------------------------------------------------------------------------
+# Core DoD: dispatch child running OUTSIDE the worktree is reaped at teardown
+# ---------------------------------------------------------------------------
+
+def test_outside_worktree_dispatch_child_killed(tmp_path: Path):
+    """A dispatch child whose CWD is the main checkout (not the worktree) is killed."""
+    from dispatch_process_registry import cleanup_dispatch_processes, record_dispatch_pgids
+
+    worktree = tmp_path / "worktree"
+    main = tmp_path / "main"
+    worktree.mkdir()
+    main.mkdir()
+
+    # DB lives in the MAIN checkout, outside the worktree.
+    db_path = main / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.execute("INSERT INTO t VALUES (1)")
+    conn.commit()
+    conn.close()
+
+    # The dispatch child runs from the main checkout and holds the lock —
+    # the exact measured shape of OI-877 (cwd outside the worktree).
+    proc, child_pid, child_pgid = _spawn_sleeping_child(main, hold_db=db_path)
+    assert _pid_alive(child_pid), "child should be alive before teardown"
+
+    # Simulate the spawn-time record (what the dispatch lane records).
+    record_dispatch_pgids("dispatch-oi877", [child_pgid], repo_root=tmp_path)
+
+    # Worktree scan alone cannot see the child (it is outside the worktree).
+    from worktree_process_cleanup import kill_worktree_processes
+    assert kill_worktree_processes(worktree) == 0, (
+        "precondition: the child must be invisible to the worktree scan"
+    )
+
+    killed = cleanup_dispatch_processes("dispatch-oi877", worktree, repo_root=tmp_path)
+    assert killed >= 1, (
+        "cleanup must find the dispatch child via the recorded PGID "
+        "(OI-877 core DoD)"
+    )
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(child_pid):
+        time.sleep(0.1)
+    assert not _pid_alive(child_pid), (
+        f"child pid {child_pid} should be dead after pgid-based cleanup"
+    )
+    _reap(proc)
+
+
+# ---------------------------------------------------------------------------
+# Reparented (PPID 1) child is still recognised
+# ---------------------------------------------------------------------------
+
+def test_reparented_child_still_killed(tmp_path: Path):
+    """A dispatch child reparented to PID 1 keeps its PGID and is still reaped."""
+    from dispatch_process_registry import cleanup_dispatch_processes, record_dispatch_pgids
+
+    worktree = tmp_path / "worktree"
+    main = tmp_path / "main"
+    worktree.mkdir()
+    main.mkdir()
+
+    # Launcher spawns a grandchild in its own session, prints its pid/pgid,
+    # then exits — the grandchild is reparented to launchd (PPID 1).
+    launcher_file = tmp_path / "launcher.py"
+    launcher_file.write_text(
+        "import subprocess, sys\n"
+        "child = subprocess.Popen(\n"
+        "    [sys.executable, '-c', "
+        "'import os,sys,time; print(os.getpid(), os.getpgid(0), flush=True); time.sleep(60)'],\n"
+        "    start_new_session=True, stdout=subprocess.PIPE, text=True,\n"
+        ")\n"
+        "print(child.stdout.readline().strip(), flush=True)\n",
+        encoding="utf-8",
+    )
+    launcher = subprocess.Popen(
+        [sys.executable, str(launcher_file)],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        text=True,
+    )
+    out_line = launcher.stdout.readline().strip()
+    grandchild_pid_str, grandchild_pgid_str = out_line.split()
+    grandchild_pid = int(grandchild_pid_str)
+    grandchild_pgid = int(grandchild_pgid_str)
+
+    launcher.wait(timeout=10)
+    assert launcher.returncode == 0, "launcher should exit cleanly"
+
+    # Verify the grandchild is now reparented to PID 1.
+    ps = subprocess.run(
+        ["ps", "-p", str(grandchild_pid), "-o", "ppid="],
+        capture_output=True, text=True, timeout=5,
+    )
+    assert ps.stdout.strip() == "1", (
+        f"expected grandchild reparented to PPID 1, got {ps.stdout.strip()}"
+    )
+    assert _pid_alive(grandchild_pid), "grandchild should still be alive"
+
+    record_dispatch_pgids("dispatch-reparent", [grandchild_pgid], repo_root=tmp_path)
+
+    killed = cleanup_dispatch_processes("dispatch-reparent", worktree, repo_root=tmp_path)
+    assert killed >= 1, "reparented child must be reaped via its recorded PGID"
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(grandchild_pid):
+        time.sleep(0.1)
+    assert not _pid_alive(grandchild_pid), (
+        f"reparented child {grandchild_pid} should be dead after cleanup"
+    )
+
+
+# ---------------------------------------------------------------------------
+# The dispatcher's own process group is never touched
+# ---------------------------------------------------------------------------
+
+def test_own_process_group_untouched(tmp_path: Path):
+    """Recording + cleaning a dispatch whose PGID is the caller's own is a no-op."""
+    from dispatch_process_registry import kill_dispatch_pgids, record_dispatch_pgids
+
+    own_pgid = os.getpgid(0)
+    record_dispatch_pgids("dispatch-self", [own_pgid], repo_root=tmp_path)
+
+    killed = kill_dispatch_pgids("dispatch-self", repo_root=tmp_path)
+    assert killed == 0, "own process group must never be signalled"
+    assert os.getpgid(0) == own_pgid, "caller's PGID must be unchanged"
+
+
+# ---------------------------------------------------------------------------
+# A process of ANOTHER dispatch is never touched
+# ---------------------------------------------------------------------------
+
+def test_other_dispatch_untouched(tmp_path: Path):
+    """Cleaning dispatch-B must not touch a child recorded for dispatch-A."""
+    from dispatch_process_registry import cleanup_dispatch_processes, record_dispatch_pgids
+
+    worktree = tmp_path / "worktree"
+    main = tmp_path / "main"
+    worktree.mkdir()
+    main.mkdir()
+
+    proc, child_pid, child_pgid = _spawn_sleeping_child(main)
+    record_dispatch_pgids("dispatch-A", [child_pgid], repo_root=tmp_path)
+
+    killed = cleanup_dispatch_processes("dispatch-B", worktree, repo_root=tmp_path)
+    assert killed == 0, "cleaning a different dispatch must kill nothing"
+    assert _pid_alive(child_pid), (
+        f"child {child_pid} of dispatch-A must survive cleaning dispatch-B"
+    )
+
+    # Cleaning dispatch-A itself does kill it.
+    killed_a = cleanup_dispatch_processes("dispatch-A", worktree, repo_root=tmp_path)
+    assert killed_a >= 1
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(child_pid):
+        time.sleep(0.1)
+    assert not _pid_alive(child_pid)
+    _reap(proc)
+
+
+# ---------------------------------------------------------------------------
+# The existing worktree-scoped cleanup still works (through the combined path)
+# ---------------------------------------------------------------------------
+
+def test_worktree_based_cleanup_still_works(tmp_path: Path):
+    """A child inside the worktree is still reaped by the lsof-based scan."""
+    from dispatch_process_registry import cleanup_dispatch_processes
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    db_path = worktree / "test.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("CREATE TABLE t (x INTEGER)")
+    conn.commit()
+    conn.close()
+
+    proc, child_pid, _child_pgid = _spawn_sleeping_child(worktree, hold_db=db_path)
+    assert _pid_alive(child_pid)
+
+    # No pgid recorded: the combined cleanup must still catch the child via the
+    # worktree scan.
+    killed = cleanup_dispatch_processes("dispatch-wt", worktree, repo_root=tmp_path)
+    assert killed >= 1, "worktree-based cleanup must still work through the combined path"
+
+    deadline = time.monotonic() + 5.0
+    while time.monotonic() < deadline and _pid_alive(child_pid):
+        time.sleep(0.1)
+    assert not _pid_alive(child_pid)
+    _reap(proc)
+
+
+# ---------------------------------------------------------------------------
+# Registry hygiene
+# ---------------------------------------------------------------------------
+
+def test_record_load_clear_roundtrip(tmp_path: Path):
+    """Recording, loading and clearing the registry round-trips correctly."""
+    from dispatch_process_registry import (
+        clear_dispatch_pgids,
+        load_dispatch_pgids,
+        record_dispatch_pgids,
+    )
+
+    # Use the caller's own group so the record has live members to snapshot.
+    own_pgid = os.getpgid(0)
+    record_dispatch_pgids("dispatch-roundtrip", [own_pgid], repo_root=tmp_path)
+    assert load_dispatch_pgids("dispatch-roundtrip", repo_root=tmp_path) == [own_pgid]
+
+    clear_dispatch_pgids("dispatch-roundtrip", repo_root=tmp_path)
+    assert load_dispatch_pgids("dispatch-roundtrip", repo_root=tmp_path) == []
+
+
+def test_no_entry_kills_nothing(tmp_path: Path):
+    """Cleaning a dispatch with no recorded pgids is a no-op (returns 0)."""
+    from dispatch_process_registry import cleanup_dispatch_processes
+
+    worktree = tmp_path / "worktree"
+    worktree.mkdir()
+
+    killed = cleanup_dispatch_processes("dispatch-absent", worktree, repo_root=tmp_path)
+    assert killed == 0


### PR DESCRIPTION
## What

The worktree teardown cleanup (`kill_worktree_processes`) only finds processes with files or CWD inside the worktree (`lsof +D`). A dispatch process whose repo-root resolved to the **main checkout** escapes that scope entirely and survives teardown, holding the coordination DB write lock (measured 31-07 16:05: PID 89569 `planning_cli.py objective reconcile` with PPID 1, blocking `link_sessions_dispatches.py`).

This PR adds a **second, spawn-time membership source**: the dispatch lane records the worker's process group(s) the moment it starts them; teardown re-finds them by recorded PGID — including a group whose members were reparented to launchd (PPID 1). The existing worktree scan is untouched and still runs first.

## Changes

- **`scripts/lib/dispatch_process_registry.py`** (new): per-dispatch PGID registry under `<repo>/.vnx-data/state/dispatch_pgids/<id>.json`. Member-PID snapshot at record time; at teardown a group is only signalled when at least one recorded member still exists AND still carries the recorded PGID (PID/PGID-reuse guard). Own process group never signalled. SIGTERM → grace → SIGKILL.
- **`dispatch_worktree_isolation.py`** and **`tmux_worktree.py`**: teardown now also calls `kill_dispatch_pgids` + `clear_dispatch_pgids` after the existing worktree scan.
- **`subprocess_adapter.py`**: records the worker PGID right after `Popen` (isolated-worktree case only; `setsid` → PGID == PID).
- **`tmux_interactive_dispatch.py`**: records the worker's descendant process groups from the tmux pane at readiness (after SessionStart hooks fired), excluding the pane shell's own group.
- **`worktree_process_cleanup.py`**: SIGKILL loop also catches `PermissionError` — macOS returns EPERM when the group only has a zombie left after SIGTERM; previously this crashed the whole cleanup.
- **`tests/test_dispatch_process_registry.py`** (new): 7 tests.

## Verification

**Every new test is RED on `origin/main` and GREEN on this branch** (module absent on main → `ModuleNotFoundError`):

```
# origin/main
python -m pytest tests/test_dispatch_process_registry.py > /tmp/oi877-final-main.txt 2>&1; echo "exit=$?"   # exit=1 (7 failed)

# this branch
python -m pytest tests/test_dispatch_process_registry.py > /tmp/oi877-final-branch.txt 2>&1; echo "exit=$?"  # exit=0 (7 passed)
```

Coverage:
- child process outside the worktree but belonging to the dispatch → killed at teardown (core DoD, the measured shape)
- child reparented to PPID 1 → still recognised and killed
- dispatcher's own process group → untouched (`test_kill_does_not_kill_caller` stays green)
- process of a different dispatch → untouched
- existing worktree-based cleanup → still works (63 combined tests pass: new 7 + existing worktree-cleanup 4 + tmux worktree/lane 52)

## Mechanism note

Verified `git rev-parse --show-toplevel` inside a linked worktree returns the **worktree**, not the main checkout. The task's presumed "hook resolves repo-root via common dir" path is therefore not how the measured orphan escaped; the recorded-PGID approach still reaches the dispatch's own worker children regardless of which checkout their hook resolved to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)