### PR TITLE
fix(dispatch): atomic dispatch-id claim on isolated worktrees (OI-861)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -4,16 +4,30 @@ Feature-flag gated: only active when VNX_ISOLATED_WORKTREE=1.
 Each dispatch gets a fresh worktree rooted at origin/main under
 .vnx-data/worktrees/dispatch-{safe_id}/.  The worktree is removed
 (success OR failure) so no state leaks between dispatches.
+
+Dispatch-identity binding (OI-861):
+A worktree's path is derived from the dispatch id, but the path alone does
+not prove identity.  Two dispatches fired back-to-back on the same lane can
+cross: one worker ends up in the other's worktree and — worst case — one
+completion reaps the other's still-live worktree.  Every worktree created
+here is therefore STAMPED with an atomic dispatch-id claim (O_EXCL), keyed on
+``(project_root, safe_dispatch_id)``, mirroring ``dispatch_process_registry``.
+``verify_worktree_identity()`` is the hard refusal a worker must call before
+doing any work in an offered worktree: a stamped id that differs from the
+worker's own dispatch id fails loud instead of running for 25 minutes on the
+wrong identity.
 """
 
 from __future__ import annotations
 
 import fcntl
+import json
 import logging
 import os
 import re
 import shutil
 import subprocess
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
@@ -43,6 +57,29 @@ class CentralInstallWorktreeError(RuntimeError):
     """
 
 
+class WorktreeClaimError(RuntimeError):
+    """Base class for dispatch-worktree identity/claim failures (OI-861)."""
+
+
+class WorktreeIdentityConflict(WorktreeClaimError):
+    """The worktree is already claimed by a DIFFERENT dispatch id.
+
+    This is the OI-861 crossing: a worker being offered a worktree that is
+    stamped for another dispatch.  The worker MUST stop — running on the wrong
+    identity delivers nothing and can have its worktree reaped mid-flight by
+    the other dispatch's completion.
+    """
+
+
+class WorktreeIdentityMissing(WorktreeClaimError):
+    """The worktree carries no dispatch-id claim at all.
+
+    Identity cannot be verified, so a worker must not operate in it.  A missing
+    claim means the worktree predates the stamping mechanism or was created by
+    a lane that does not stamp — either way it is not provably this dispatch's.
+    """
+
+
 def _is_central_install_path(path: Path) -> bool:
     try:
         path.resolve().relative_to(_CENTRAL_INSTALL_ROOT.resolve())
@@ -68,6 +105,213 @@ def _dispatch_worktree_dir(project_root: Path, dispatch_id: str) -> Path:
     if root_override:
         return Path(root_override).expanduser().resolve() / f"dispatch-{safe_id}"
     return project_root / ".vnx-data" / "worktrees" / f"dispatch-{safe_id}"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-id claim registry (OI-861)
+#
+# A worktree's identity is its CLAIM, not its path.  One JSON entry per
+# sanitized dispatch id under <repo_root>/.vnx-data/state/dispatch_worktree_claims/
+# — the same per-repo state-dir shape as dispatch_process_registry.  The claim
+# is created with O_EXCL so exactly one dispatch ever wins a given slot; every
+# later reader compares the stamped dispatch_id against its own before
+# operating in or removing the worktree.
+# ---------------------------------------------------------------------------
+
+def _claim_dir(repo_root: Path) -> Path:
+    return Path(repo_root).resolve() / ".vnx-data" / "state" / "dispatch_worktree_claims"
+
+
+def _claim_path(repo_root: Path, safe_id: str) -> Path:
+    return _claim_dir(repo_root) / f"{safe_id}.json"
+
+
+def _read_claim_entry(repo_root: Path, safe_id: str) -> "dict | None":
+    """Read the claim for *safe_id*; None when absent or corrupt (never raises)."""
+    path = _claim_path(repo_root, safe_id)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        entry = json.loads(raw)
+        if not isinstance(entry, dict):
+            return None
+        return entry
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning(
+            "dispatch_worktree_isolation: unreadable claim %s: %s — "
+            "treating as absent",
+            path,
+            exc,
+        )
+        return None
+
+
+def _read_claim(repo_root: Path, dispatch_id: str) -> "dict | None":
+    return _read_claim_entry(repo_root, _sanitize_dispatch_id(dispatch_id))
+
+
+def _write_claim_atomic(
+    dispatch_id: str,
+    *,
+    repo_root: Path,
+    worktree_path: Path,
+) -> dict:
+    """Claim *worktree_path* for *dispatch_id* with an O_EXCL write.
+
+    This is the load-bearing atomicity of the identity binding: if the claim
+    file already exists the write fails and the caller must decide whether the
+    existing claim is the same dispatch (idempotent re-entry) or a different
+    one (OI-861 crossing → WorktreeIdentityConflict).
+    """
+    safe_id = _sanitize_dispatch_id(dispatch_id)
+    path = _claim_path(repo_root, safe_id)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    claim = {
+        "dispatch_id": dispatch_id,
+        "safe_id": safe_id,
+        "project_root": str(Path(repo_root).resolve()),
+        "worktree_path": str(Path(worktree_path).resolve()),
+        "claimed_at": time.time(),
+    }
+    try:
+        with open(path, "x", encoding="utf-8") as fh:
+            json.dump(claim, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+    except FileExistsError:
+        raise WorktreeClaimError(
+            f"claim already exists for dispatch {dispatch_id!r} ({path})"
+        ) from None
+    log.info(
+        "dispatch worktree claimed: %s -> dispatch %s",
+        claim["worktree_path"],
+        dispatch_id,
+    )
+    return claim
+
+
+def _clear_claim(repo_root: Path, dispatch_id: str) -> None:
+    """Remove the claim for *dispatch_id*.  Idempotent, never raises."""
+    try:
+        _claim_path(repo_root, _sanitize_dispatch_id(dispatch_id)).unlink(missing_ok=True)
+    except OSError as exc:
+        log.debug(
+            "dispatch_worktree_isolation: clear claim failed for %s: %s",
+            dispatch_id,
+            exc,
+        )
+
+
+def _claim_belongs_to_or_raise(
+    dispatch_id: str,
+    claim: dict,
+    worktree_path: Path,
+) -> None:
+    """Raise WorktreeIdentityConflict when *claim* is not *dispatch_id*'s.
+
+    The single canonical OI-861 refusal: a worktree already claimed by another
+    dispatch identity must never be reused — not by a second create, not by a
+    worker's verification, not by a teardown.
+    """
+    stamped_id = claim.get("dispatch_id")
+    if stamped_id != dispatch_id:
+        raise WorktreeIdentityConflict(
+            f"worktree {worktree_path} is already claimed by dispatch "
+            f"{stamped_id!r}, not {dispatch_id!r}; refusing — a worktree must "
+            f"never be shared by two dispatch identities"
+        )
+    recorded_path = claim.get("worktree_path")
+    if recorded_path:
+        recorded = Path(recorded_path).resolve()
+        if recorded != Path(worktree_path).resolve():
+            raise WorktreeClaimError(
+                f"worktree {worktree_path} is claimed by {dispatch_id!r} but "
+                f"the claim points at {recorded}; refusing"
+            )
+
+
+def _repo_root_from_worktree_path(worktree_path: Path) -> Path:
+    """Derive the project root from a standard dispatch-worktree path.
+
+    ``<root>/.vnx-data/worktrees/dispatch-<safe>`` → ``<root>``.  Worktrees
+    living under ``VNX_BENCH_WORKTREE_ROOT`` carry no structural marker, so
+    their callers must pass ``project_root`` explicitly.
+    """
+    resolved = Path(worktree_path).resolve()
+    if resolved.parent.name == "worktrees" and resolved.parent.parent.name == ".vnx-data":
+        return resolved.parent.parent.parent
+    raise WorktreeClaimError(
+        f"cannot derive the project root from worktree path {resolved}; "
+        f"pass project_root explicitly (the worktree may live under "
+        f"VNX_BENCH_WORKTREE_ROOT)"
+    )
+
+
+def verify_worktree_identity(
+    dispatch_id: str,
+    worktree_path: Path,
+    *,
+    project_root: "Optional[Path]" = None,
+) -> dict:
+    """Verify that *worktree_path* is stamped for *dispatch_id*.  Fail-loud.
+
+    A worker that is offered a worktree MUST call this before doing any work.
+    Operating in a worktree whose stamped dispatch id differs from its own is
+    the exact OI-861 failure that ran for 25 minutes and delivered nothing.
+
+    The claim is looked up by the safe id carved out of the WORKTREE'S OWN NAME
+    (``dispatch-<safe>``), not the caller's dispatch id — so a worker offered
+    the wrong worktree reads the owner's claim and gets a truthful
+    ``WorktreeIdentityConflict`` instead of a misleading "no claim".
+
+    Raises:
+        WorktreeIdentityMissing: the worktree carries no dispatch-id claim.
+        WorktreeIdentityConflict: the worktree is stamped for a different
+            dispatch id (or the offered path is not a dispatch worktree).
+        WorktreeClaimError: the claim is corrupt or points at another path.
+
+    Returns the claim dict on success.
+    """
+    resolved_wt = Path(worktree_path).resolve()
+    root = (
+        _resolve_project_root(project_root)
+        if project_root is not None
+        else _repo_root_from_worktree_path(resolved_wt)
+    )
+
+    name = resolved_wt.name
+    path_safe_id = (
+        name[len("dispatch-"):] if name.startswith("dispatch-") else ""
+    )
+    claim = (
+        _read_claim_entry(root, path_safe_id)
+        if path_safe_id
+        else _read_claim(root, dispatch_id)
+    )
+
+    if claim is None:
+        raise WorktreeIdentityMissing(
+            f"worktree {resolved_wt} carries no dispatch-id claim; refusing to "
+            f"operate in an unclaimed worktree (expected dispatch "
+            f"{dispatch_id!r})"
+        )
+
+    stamped_id = claim.get("dispatch_id")
+    if stamped_id != dispatch_id:
+        raise WorktreeIdentityConflict(
+            f"worktree {resolved_wt} is stamped for dispatch {stamped_id!r}, "
+            f"not {dispatch_id!r}; refusing to operate on the wrong identity"
+        )
+
+    recorded_path = claim.get("worktree_path")
+    if recorded_path:
+        recorded = Path(recorded_path).resolve()
+        if recorded != resolved_wt:
+            raise WorktreeClaimError(
+                f"worktree {resolved_wt} is claimed by {dispatch_id!r} but the "
+                f"claim points at {recorded}; refusing"
+            )
+    return claim
 
 
 def _resolve_project_root(project_root: Optional[Path]) -> Path:
@@ -177,8 +421,21 @@ def create_dispatch_worktree(
                 base_ref, (exc.stderr or "").strip(),
             )
 
-    try:
-        with _worktree_lock(root):
+    with _worktree_lock(root):
+        # OI-861 identity check BEFORE creating: if this worktree already exists
+        # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
+        # same-id re-entry (double-fire/retry) is idempotent and returns the
+        # existing, correctly-stamped worktree.
+        existing = _read_claim(root, dispatch_id)
+        if existing is not None:
+            _claim_belongs_to_or_raise(dispatch_id, existing, wt_path)
+            log.info(
+                "dispatch worktree already exists (claimed by %s): %s",
+                dispatch_id, wt_path,
+            )
+            return wt_path.resolve()
+
+        try:
             subprocess.run(
                 [
                     "git", "worktree", "add",
@@ -191,10 +448,28 @@ def create_dispatch_worktree(
                 capture_output=True,
                 text=True,
             )
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"create_dispatch_worktree failed for {dispatch_id!r}: {(exc.stderr or '').strip()}"
-        ) from exc
+        except subprocess.CalledProcessError as exc:
+            # A concurrent dispatch collided on this slot between our identity
+            # check and the git add.  Re-read the claim: a different stamped id
+            # is the OI-861 crossing — fail loud with the identity error.
+            raced = _read_claim(root, dispatch_id)
+            if raced is not None:
+                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+            raise RuntimeError(
+                f"create_dispatch_worktree failed for {dispatch_id!r}: "
+                f"{(exc.stderr or '').strip()}"
+            ) from exc
+
+        # Claim the freshly-created worktree atomically (O_EXCL).  From here on
+        # the worktree's identity is bound to dispatch_id and no other dispatch
+        # may reuse it.
+        try:
+            _write_claim_atomic(dispatch_id, repo_root=root, worktree_path=wt_path)
+        except WorktreeClaimError:
+            raced = _read_claim(root, dispatch_id)
+            if raced is not None:
+                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+            raise
 
     log.info("dispatch worktree created: %s (branch %s)", wt_path, branch_name)
     return wt_path.resolve()
@@ -220,8 +495,18 @@ def remove_dispatch_worktree(
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
 
     if not wt_path.exists():
+        # Nothing to remove.  Drop any stale claim so a later dispatch mapping
+        # to this safe id can claim cleanly (idempotent, never raises).
+        _clear_claim(root, dispatch_id)
         log.debug("remove_dispatch_worktree: already absent: %s", wt_path)
         return
+
+    # OI-861 hard refusal on teardown: never reap a worktree that is stamped
+    # for a DIFFERENT dispatch id.  This is the "one's worktree reaped
+    # mid-flight by the other's completion" half of the race.
+    claim = _read_claim(root, dispatch_id)
+    if claim is not None:
+        _claim_belongs_to_or_raise(dispatch_id, claim, wt_path)
 
     # OI-873: kill processes still running inside this worktree BEFORE
     # attempting removal.  A zombie hook (bash + python child) will hold
@@ -291,6 +576,10 @@ def remove_dispatch_worktree(
             )
         except subprocess.CalledProcessError as exc:
             log.warning("git worktree prune failed: %s", (exc.stderr or "").strip())
+
+        # The worktree is gone — release its identity claim so a later dispatch
+        # mapping to the same safe id can claim cleanly.
+        _clear_claim(root, dispatch_id)
 
     # Best-effort: delete the local dispatch branch (it lives on origin).
     safe_id = _sanitize_dispatch_id(dispatch_id)

--- a/tests/test_dispatch_worktree_identity_race.py
+++ b/tests/test_dispatch_worktree_identity_race.py
@@ -1,0 +1,288 @@
+"""test_dispatch_worktree_identity_race.py — OI-861 dispatch-identity crossing.
+
+Two dispatches fired back-to-back on the same lane must never share a worktree
+or inherit each other's identity.  This exercises the dispatch-id-keyed atomic
+claim in dispatch_worktree_isolation:
+
+  1. Concurrent claims on the SAME worktree slot (two dispatch ids that
+     sanitize to the same safe id): exactly one wins, the loser gets a clean
+     WorktreeIdentityConflict — never a silent shared worktree.
+  2. Hard refusal: a worker offered a worktree stamped for a different dispatch
+     id gets a fail-loud WorktreeIdentityConflict via verify_worktree_identity.
+  3. Teardown refusal: remove_dispatch_worktree refuses to reap a worktree it
+     does not own.
+  4. Same-dispatch re-entry is idempotent; remove clears the claim so the slot
+     can be claimed again.
+
+The concurrency is REAL: every iteration spawns two threads behind a barrier
+that both fire create_dispatch_worktree at the same instant on the same slot.
+A retry loop that re-ran the same call N times would re-hit the same serialized
+window and prove nothing; this test exercises genuine simultaneous claims.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a real git repo on branch main with one committed seed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "race-test@vnx"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "VNX Race Test"], check=True
+    )
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True
+    )
+    return repo
+
+
+def _colliding_dispatch_ids(index: int) -> "tuple[str, str]":
+    """Two dispatch ids that sanitize to the SAME safe id.
+
+    ``dispatch_worktree_isolation._sanitize_dispatch_id`` collapses ``.`` to
+    ``-``, so ``-lock.reclaim.timeout`` and ``-lock-reclaim-timeout`` both land
+    on ``-lock-reclaim-timeout`` → the same worktree path and branch.  This is
+    the narrowest way to make two *different* dispatch identities contend for
+    one slot, which is exactly the OI-861 crossing.
+    """
+    stem = f"20260730-race{index}"
+    return f"{stem}-lock-reclaim-timeout", f"{stem}.lock.reclaim.timeout"
+
+
+def _run_concurrent_claim(
+    repo: Path, id_a: str, id_b: str
+) -> "tuple[dict, dict]":
+    """Fire two create_dispatch_worktree calls simultaneously.
+
+    Both threads wait on a barrier so they enter at the same instant.  Returns
+    (outcome_a, outcome_b) where each is {"status": "ok", "path": Path} or
+    {"status": "err", "exc": Exception}.
+    """
+    from dispatch_worktree_isolation import create_dispatch_worktree
+
+    barrier = threading.Barrier(2)
+    outcomes: dict[str, dict] = {}
+
+    def _claim(dispatch_id: str, key: str) -> None:
+        try:
+            barrier.wait(timeout=30)
+            path = create_dispatch_worktree(dispatch_id, project_root=repo)
+            outcomes[key] = {"status": "ok", "path": path}
+        except Exception as exc:  # noqa: BLE001 — the test must observe the raw error
+            outcomes[key] = {"status": "err", "exc": exc}
+
+    threads = [
+        threading.Thread(target=_claim, args=(id_a, "a")),
+        threading.Thread(target=_claim, args=(id_b, "b")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=90)
+    assert not any(t.is_alive() for t in threads), "claim thread hung"
+    return outcomes["a"], outcomes["b"]
+
+
+# ─── the race: two concurrent claims on one slot ────────────────────────────
+
+class TestConcurrentClaimRace:
+    def test_exactly_one_winner_per_slot(self, tmp_path, monkeypatch):
+        """Concurrent same-slot claims: one winner, one clean identity conflict.
+
+        Repeated across 12 fresh slots so the outcome is shown to be stable,
+        not a one-off — every iteration is a genuine barrier-synchronized pair
+        of claims.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        for i in range(12):
+            id_a, id_b = _colliding_dispatch_ids(i)
+            outcome_a, outcome_b = _run_concurrent_claim(repo, id_a, id_b)
+
+            ok = [o for o in (outcome_a, outcome_b) if o["status"] == "ok"]
+            err = [o for o in (outcome_a, outcome_b) if o["status"] == "err"]
+            assert len(ok) == 1, (
+                f"iteration {i}: expected exactly one winner, got {len(ok)} "
+                f"(a={outcome_a['status']}, b={outcome_b['status']})"
+            )
+            assert len(err) == 1, (
+                f"iteration {i}: expected exactly one loser, got {len(err)}"
+            )
+
+            loser_exc = err[0]["exc"]
+            assert isinstance(loser_exc, WorktreeIdentityConflict), (
+                f"iteration {i}: loser must fail with WorktreeIdentityConflict, "
+                f"got {type(loser_exc).__name__}: {loser_exc}"
+            )
+            assert "claimed by dispatch" in str(loser_exc), (
+                f"iteration {i}: loser error must name the conflict, got: {loser_exc}"
+            )
+
+            winner_id = id_a if outcome_a["status"] == "ok" else id_b
+            loser_id = id_b if outcome_a["status"] == "ok" else id_a
+            winner_path = ok[0]["path"]
+
+            # The winner's worktree is provably the winner's...
+            claim = verify_worktree_identity(winner_id, winner_path)
+            assert claim["dispatch_id"] == winner_id
+            # ...and the loser is hard-refused on the very same worktree.
+            with pytest.raises(WorktreeIdentityConflict, match="stamped for dispatch"):
+                verify_worktree_identity(loser_id, winner_path)
+
+    def test_same_dispatch_second_create_is_idempotent(self, tmp_path, monkeypatch):
+        """Double-fire of the SAME dispatch id reuses its own claimed worktree."""
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-sfp1b-lock-reclaim-timeout"
+
+        first = create_dispatch_worktree(dispatch_id, project_root=repo)
+        second = create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        assert first == second
+        assert first.exists()
+        verify_worktree_identity(dispatch_id, first)
+
+
+# ─── hard refusal: worker offered the wrong worktree ────────────────────────
+
+class TestVerifyWorktreeIdentity:
+    def test_owner_verifies(self, tmp_path, monkeypatch):
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-owner-dispatch"
+        wt = create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        claim = verify_worktree_identity(dispatch_id, wt)
+        assert claim["dispatch_id"] == dispatch_id
+        assert claim["worktree_path"] == str(wt.resolve())
+
+    def test_other_dispatch_is_rejected(self, tmp_path, monkeypatch):
+        """A worker offered a worktree stamped for another dispatch fails loud.
+
+        This is the literal OI-861 measurement: the sfp1b session was handed
+        sfp2b's worktree.  With the stamp in place the sfp1b worker's identity
+        check must reject it before doing any work.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        owner = "20260730-sfp2b-failclosed-tenant"
+        intruder = "20260730-sfp1b-lock-reclaim-timeout"
+
+        wt = create_dispatch_worktree(owner, project_root=repo)
+
+        with pytest.raises(WorktreeIdentityConflict) as excinfo:
+            verify_worktree_identity(intruder, wt)
+        message = str(excinfo.value)
+        assert owner in message
+        assert intruder in message
+        assert "stamped for dispatch" in message
+
+    def test_unclaimed_worktree_is_rejected(self, tmp_path):
+        """No stamp → identity cannot be verified → hard refusal."""
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityMissing,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        worktrees_dir = repo / ".vnx-data" / "worktrees"
+        unclaimed = worktrees_dir / "dispatch-20260730-no-claim"
+        unclaimed.mkdir(parents=True)
+
+        with pytest.raises(WorktreeIdentityMissing, match="no dispatch-id claim"):
+            verify_worktree_identity("20260730-no-claim", unclaimed, project_root=repo)
+
+
+# ─── teardown refusal: never reap a worktree you do not own ─────────────────
+
+class TestRemoveRefusal:
+    def test_remove_refuses_other_dispatch_worktree(self, tmp_path, monkeypatch):
+        """remove() must not reap a worktree stamped for a different dispatch.
+
+        This is the "one's worktree reaped mid-flight by the other's
+        completion" half of the OI-861 race.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            _dispatch_worktree_dir,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        owner = "20260730-owner-remove"
+        intruder = "20260730.owner.remove"  # sanitizes identically to owner
+
+        wt = create_dispatch_worktree(owner, project_root=repo)
+
+        with pytest.raises(WorktreeIdentityConflict, match="already claimed by dispatch"):
+            remove_dispatch_worktree(intruder, project_root=repo)
+
+        # The worktree survives and is still verifiable by its owner.
+        assert _dispatch_worktree_dir(repo, owner).exists()
+        verify_worktree_identity(owner, wt)
+
+    def test_remove_clears_claim_then_recreate(self, tmp_path, monkeypatch):
+        """After a legit remove, the slot is free for a fresh claim."""
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityMissing,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-recreate-cycle"
+
+        first = create_dispatch_worktree(dispatch_id, project_root=repo)
+        remove_dispatch_worktree(dispatch_id, project_root=repo)
+        assert not first.exists()
+
+        # Claim is gone → the stale path no longer verifies for anyone.
+        with pytest.raises(WorktreeIdentityMissing):
+            verify_worktree_identity(dispatch_id, first)
+
+        second = create_dispatch_worktree(dispatch_id, project_root=repo)
+        assert second.exists()
+        verify_worktree_identity(dispatch_id, second)


### PR DESCRIPTION
## What

Two dispatches fired back-to-back on the same lane can cross identities. Measured 30-07: the tmux session `vnx-20260730-sfp1b-lock-reclaim-timeout` ran on branch `dispatch/20260730-sfp1b-...` but was handed the **sfp2b** worktree (`dispatch-20260730-sfp2b-failclosed-tenant`). The worker noticed and stopped, but only after noticing — sfp1b's assignment never executed (0 changed files after 25 min), and the other worker's completion reaped a still-live worktree.

Root cause: the worktree path is derived from `dispatch_id` but never *bound* to it. Nothing stamps the worktree with the dispatch that owns it, so a delivery race can offer a worker the wrong worktree and teardown can reap a worktree it does not own. The staged bundles were verified correct — the crossing is in delivery/slot assignment, exactly the class this PR closes.

This PR stamps every isolated worktree with an **atomic dispatch-id claim** and adds hard refusals on identity mismatch, following the pattern from `dispatch_process_registry` (OI-877).

## Changes

- **`scripts/lib/dispatch_worktree_isolation.py`**
  - New claim registry under `<repo>/.vnx-data/state/dispatch_worktree_claims/<safe_id>.json`, keyed on `(project_root, safe_dispatch_id)` — one JSON entry per sanitized dispatch id, same state-dir shape as `dispatch_process_registry`.
  - `create_dispatch_worktree`: claims the freshly-created worktree with an **O_EXCL** write (the atomic boundary — exactly one dispatch ever wins a slot). A pre-check under the existing `_worktree_lock` refuses immediately when the slot is already claimed by a **different** dispatch id (`WorktreeIdentityConflict`); same-id re-entry (double-fire/retry) is idempotent and returns the existing, correctly-stamped worktree.
  - `verify_worktree_identity()`: the hard refusal a worker must call before doing any work in an offered worktree. Looks up the claim by the safe id carved from the worktree's own name, so a worker offered the wrong worktree reads the owner's claim and gets a truthful `WorktreeIdentityConflict` ("stamped for dispatch X, not Y") instead of a misleading "no claim". A worktree with no stamp at all fails with `WorktreeIdentityMissing`.
  - `remove_dispatch_worktree`: refuses to reap a worktree stamped for a **different** dispatch id (the "reaped mid-flight" half of the race); clears the claim after a legitimate removal so the slot can be claimed again.

## Verification

**Regression test is RED on `origin/main`, GREEN on this branch** (new symbols absent on main → `ImportError`):

```
# origin/main
python -m pytest tests/test_dispatch_worktree_identity_race.py   # 7 failed (ImportError)

# this branch
python -m pytest tests/test_dispatch_worktree_identity_race.py   # 7 passed
```

The core test (`test_exactly_one_winner_per_slot`) builds **real concurrency**: two threads behind a `threading.Barrier` fire `create_dispatch_worktree` at the same instant on the same slot (two dispatch ids that sanitize to one safe id), repeated across 12 fresh slots. Every iteration produces exactly one winner and one clean `WorktreeIdentityConflict` that names the conflicting dispatch — never a silent shared worktree.

Other coverage:
- worker offered the wrong worktree → `verify_worktree_identity` rejects with a message naming both ids (the literal sfp1b/sfp2b shape)
- unclaimed worktree → `WorktreeIdentityMissing`
- `remove` of another dispatch's worktree → refused, worktree survives, owner still verifies
- same-dispatch double-fire → idempotent same path; remove-then-recreate → clean slot reuse

Existing related suite stays green: `test_subprocess_dispatch_worktree_isolation`, `test_provider_dispatch_worktree_isolation`, `test_dispatch_envelope_*`, `test_phantom_guard_*` (64 passed; 1 pre-existing env failure `test_repo_root_no_override` caused by running from inside a `.vnx-data/worktrees/...` path — reproduced on clean `origin/main`). `ruff check` clean; `ci_lint_patterns` gate clean (0 findings, full scan).

## Scope

Only `scripts/lib/dispatch_worktree_isolation.py` + the new test file were touched, per the dispatch constraints (other workers are in other files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)