### PR TITLE
fix(plan-gate): probe degraded fires on all-attest, persist per-seat verdicts (OI-888)

### DIFF
--- a/scripts/lib/plan_gate_effectiveness_probe.py
+++ b/scripts/lib/plan_gate_effectiveness_probe.py
@@ -1,31 +1,40 @@
 """plan_gate_effectiveness_probe — read-only health probe for the
 plan-gate-panel subsystem (framework-status-audit-and-cockpit PR-7).
 
-Two REAL, persisted signal sources (kimi finding — name the source):
+Three REAL, persisted signal sources (kimi finding — name the source):
 
 1. ``.vnx-attest/plan-gates.ndjson`` — the same panel attestation ledger the
-   governance probe verifies, read here for its ``resolver`` field. Per-panelist
-   pass/revise/block counts are NOT persisted anywhere (only the final resolved
-   ``plan_gate_pass`` record survives — see ``plan_gate_panel.run_panel`` /
-   ``planning_cli.py``); ``resolver`` is the only durable proxy for whether a
-   track's plan gate converged organically via the panel run (``"run"``) or
-   needed a manual operator override (``"attest"`` — ``planning_cli.py``'s
-   ``plan-gate attest`` command, the escape hatch for a panel that did not
-   converge on its own).
-2. The ``OI-PLAN-<track>`` blocker rows in ``track_open_items`` (the runtime
+   governance probe verifies, read here for its ``resolver`` field. ``resolver``
+   is a closed ``run`` | ``attest`` choice (``plan_gate_evidence``): the durable
+   proxy for whether a track's plan gate converged organically via the panel run
+   (``"run"``) or needed a manual operator override (``"attest"`` —
+   ``planning_cli.py``'s ``plan-gate attest`` command, the escape hatch for a
+   panel that did not converge on its own).
+2. ``.vnx-attest/plan-gate-seats.ndjson`` — the per-seat verdict ledger (OI-888).
+   ``plan_gate_panel.run_panel`` appends one append-only, hash-chained
+   ``plan_gate_seat`` record per panelist per run (panelist id, model, effective
+   verdict incl. abstain, and whether a report was returned at all). The
+   per-panelist pass/revise/block counts previously survived nowhere — only the
+   final resolved ``plan_gate_pass`` record was durable — so a degraded seat (3
+   of 5 responding, say) was only visible during a live run.
+3. The ``OI-PLAN-<track>`` blocker rows in ``track_open_items`` (the runtime
    coordination DB), under ``VNX_DATA_DIR`` — the same table
    ``plan_gate_enforcement.plan_gate_state()`` reads per-track, queried here
    in aggregate across every track.
 
 Health is `ok` when gates resolve without a stuck backlog and organic panel
 convergence is not swamped by manual overrides; `degraded` when a blocker has
-sat open past the staleness window, or every resolved gate on record required a
-manual attest (the panel itself never converged unassisted) — both read as
-"panel verdicts disagree" in the PRD's vocabulary.
+sat open past the staleness window, or every gate on record was resolved by
+manual attest (the panel itself never converged unassisted) — regardless of the
+OI-PLAN resolution count, because the ledger is the durable record of whether
+the panel converged (OI-888). Both read as "panel verdicts disagree" in the
+PRD's vocabulary.
 
-Deliberately NOT checked (kimi finding): whether complex tracks skip the panel
-(``VNX_PLAN_GATE_COMPLEX_ONLY``) — the scope-skip read-site does not exist yet
-(deferred to ``review-floor-enforcer``), so there is no signal to probe.
+Scope-skip signal (OI-888): whether complex tracks skip the panel
+(``VNX_PLAN_GATE_COMPLEX_ONLY``) has NO read-site yet — it is deferred to
+``review-floor-enforcer``. The probe reports that explicitly
+(``scope_skip_read_site: "missing"``) instead of staying silent about a signal
+it cannot see.
 """
 from __future__ import annotations
 
@@ -44,9 +53,20 @@ from effectiveness_probe import EffectivenessProbe, register_probe  # noqa: E402
 from ndjson_hash_chain import walk_chain  # noqa: E402
 
 LEDGER_RELPATH = ".vnx-attest/plan-gates.ndjson"
+SEAT_LEDGER_RELPATH = ".vnx-attest/plan-gate-seats.ndjson"
 COORDINATION_DB_FILENAME = "runtime_coordination.db"
 STALE_DAYS = 7
 _PLAN_OI_PREFIX = "OI-PLAN-"
+# The signal fields that count as "activity" for the unknown-vs-anything split.
+# ``scope_skip_read_site`` is deliberately excluded: its value is a constant
+# string (truthy) and would otherwise make every state look active.
+_ACTIVITY_KEYS = (
+    "ledger_total",
+    "oi_plan_unresolved",
+    "oi_plan_stale_unresolved",
+    "oi_plan_resolved",
+    "seat_total",
+)
 
 
 def _has_table(conn: sqlite3.Connection, name: str) -> bool:
@@ -73,6 +93,9 @@ class PlanGateEffectivenessProbe(EffectivenessProbe):
     def _ledger_path(self) -> Path:
         return self._repo_root / LEDGER_RELPATH
 
+    def _seat_ledger_path(self) -> Path:
+        return self._repo_root / SEAT_LEDGER_RELPATH
+
     def _db_path(self) -> Path:
         return self._state_dir / COORDINATION_DB_FILENAME
 
@@ -87,6 +110,30 @@ class PlanGateEffectivenessProbe(EffectivenessProbe):
                 ledger_total += 1
                 if entry.get("resolver") == "attest":
                     ledger_attest_count += 1
+
+        seat_total = 0
+        seat_responded = 0
+        seat_abstain = 0
+        seat_pass = 0
+        seat_revise = 0
+        seat_block = 0
+        seat_path = self._seat_ledger_path()
+        if seat_path.exists():
+            for _line_no, entry, _hash in walk_chain(seat_path):
+                if not isinstance(entry, dict) or entry.get("type") != "plan_gate_seat":
+                    continue
+                seat_total += 1
+                if entry.get("responded"):
+                    seat_responded += 1
+                verdict = entry.get("verdict")
+                if verdict == "pass":
+                    seat_pass += 1
+                elif verdict == "revise":
+                    seat_revise += 1
+                elif verdict == "block":
+                    seat_block += 1
+                elif verdict == "abstain":
+                    seat_abstain += 1
 
         oi_plan_unresolved = 0
         oi_plan_stale_unresolved = 0
@@ -118,27 +165,52 @@ class PlanGateEffectivenessProbe(EffectivenessProbe):
             "oi_plan_unresolved": oi_plan_unresolved,
             "oi_plan_stale_unresolved": oi_plan_stale_unresolved,
             "oi_plan_resolved": oi_plan_resolved,
+            "seat_total": seat_total,
+            "seat_responded": seat_responded,
+            "seat_abstain": seat_abstain,
+            "seat_pass": seat_pass,
+            "seat_revise": seat_revise,
+            "seat_block": seat_block,
+            "scope_skip_read_site": "missing",
         }
 
     def signal(self, raw: Dict[str, Any]) -> str:
-        if not any(raw.values()):
-            return "no plan-gate activity yet (no ledger records, no OI-PLAN blockers)"
-        return (
+        if not any(raw.get(k) for k in _ACTIVITY_KEYS):
+            return "no plan-gate activity yet (no ledger records, no OI-PLAN blockers, no seat records)"
+        parts = [
             f"{raw['ledger_total']} plan-gate-pass record(s) "
-            f"({raw['ledger_attest_count']} via manual attest); "
+            f"({raw['ledger_attest_count']} via manual attest)",
             f"{raw['oi_plan_unresolved']} unresolved OI-PLAN blocker(s) "
             f"({raw['oi_plan_stale_unresolved']} stale >{STALE_DAYS}d), "
-            f"{raw['oi_plan_resolved']} resolved"
-        )
+            f"{raw['oi_plan_resolved']} resolved",
+        ]
+        if raw["seat_total"]:
+            parts.append(
+                f"{raw['seat_total']} seat record(s) "
+                f"({raw['seat_responded']} responded, {raw['seat_abstain']} abstained, "
+                f"{raw['seat_pass']} pass/{raw['seat_revise']} revise/{raw['seat_block']} block)"
+            )
+        parts.append("VNX_PLAN_GATE_COMPLEX_ONLY read-site MISSING (no scope-skip signal to probe)")
+        return "; ".join(parts)
 
     def health(self, raw: Dict[str, Any]) -> str:
-        if not any(raw.values()):
+        if not any(raw.get(k) for k in _ACTIVITY_KEYS):
             return "unknown"
         if raw["oi_plan_stale_unresolved"] > 0:
             return "degraded"
-        if raw["ledger_total"] > 0 and raw["ledger_attest_count"] == raw["ledger_total"] and raw["oi_plan_resolved"] > 0:
+        if raw["ledger_total"] > 0 and raw["ledger_attest_count"] == raw["ledger_total"]:
+            # OI-888: every gate on record was resolved by manual attest, so the
+            # panel itself never converged unassisted. This must fire regardless of
+            # how many OI-PLAN blockers are currently resolved — the ledger is the
+            # durable record of whether the panel converged organically.
             return "degraded"
         return "ok"
 
 
-__all__ = ["PlanGateEffectivenessProbe", "LEDGER_RELPATH", "COORDINATION_DB_FILENAME", "STALE_DAYS"]
+__all__ = [
+    "PlanGateEffectivenessProbe",
+    "LEDGER_RELPATH",
+    "SEAT_LEDGER_RELPATH",
+    "COORDINATION_DB_FILENAME",
+    "STALE_DAYS",
+]

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -23,6 +23,11 @@ Every lane routes through ``provider_dispatch.py``, so the provider constraints 
 enforced by construction (kimi-via-cli-only, zai-via-openrouter-only,
 no-anthropic-sdk) and each panelist emits a governed report -> receipt: the gate
 that gates everything is itself in the audit trail.
+
+Per-seat verdicts are appended to ``.vnx-attest/plan-gate-seats.ndjson`` (the same
+append-only, hash-chained ledger pattern as the ``plan_gate_pass`` evidence record)
+so the effectiveness probe can see whether every seat responded and what each one
+said — previously only the final resolved record survived the run (OI-888).
 """
 from __future__ import annotations
 
@@ -34,12 +39,19 @@ import sys
 import tempfile
 import uuid
 from dataclasses import dataclass, field
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional
 
 HERE = Path(__file__).resolve().parent
 PROVIDER_DISPATCH = HERE / "provider_dispatch.py"
 TMUX_INTERACTIVE_DISPATCH = HERE / "tmux_interactive_dispatch.py"
+
+# Per-seat verdict ledger (OI-888): one append-only, hash-chained record per
+# panelist per run, under the repo's .vnx-attest/ dir next to the plan_gate_pass
+# evidence ledger. Read by the plan-gate effectiveness probe.
+SEAT_LEDGER_RELPATH = ".vnx-attest/plan-gate-seats.ndjson"
+SEAT_RECORD_TYPE = "plan_gate_seat"
 
 # Claude is NOT a provider-lane provider — provider_dispatch refuses it. Claude lanes
 # route via the TMUX-SPAWN lane (interactive `claude` in an ephemeral isolated worktree),
@@ -371,6 +383,7 @@ def parse_verdict(report_text: str) -> Dict[str, Any]:
 class PanelistResult:
     label: str
     provider: str
+    model: str = ""                  # the model_arg the panelist was dispatched with
     verdict: str = "revise"          # pass | revise | block
     blocking_findings: List[str] = field(default_factory=list)
     rationale: str = ""
@@ -663,18 +676,95 @@ def _dispatch_one(
     """
     try:
         report_text = dispatcher(member["provider"], member["model_arg"], instruction, dispatch_id)
-    except Exception as exc:  # dispatch / report-read failure -> no verdict
+    except Exception as exc:  # vnx-silent-except: dispatch/report-read failure -> no verdict, recorded as abstain
         return PanelistResult(
             label=member["label"], provider=member["provider"],
+            model=member.get("model_arg", ""),
             dispatched=False, error=str(exc), report_path=dispatch_id,
         )
     parsed = parse_verdict(report_text)
     return PanelistResult(
         label=member["label"], provider=member["provider"],
+        model=member.get("model_arg", ""),
         verdict=parsed["verdict"], blocking_findings=parsed["blocking_findings"],
         rationale=parsed["rationale"], parse_error=parsed["parse_error"],
         dispatched=True, report_path=dispatch_id,
     )
+
+
+def _find_repo_root(start: Path) -> Optional[Path]:
+    """Walk ``start`` and its parents for a ``.git`` marker (dir or file).
+
+    Subprocess-free mirror of ``project_root.resolve_project_root``'s git
+    resolution: a worktree's ``.git`` is a FILE, a normal checkout's is a
+    directory — ``exists()`` covers both. The canonical helper is not used here
+    because it shells out through ``subprocess.run``, which the dispatcher-env
+    tests mock and count (they assert exactly one subprocess call per panel).
+    """
+    for d in [start, *start.parents]:
+        if (d / ".git").exists():
+            return d
+    return None
+
+
+def _resolve_seat_ledger_path(data_dir: Optional[str]) -> Optional[Path]:
+    """Resolve the per-seat verdict ledger path, or ``None`` with no repo anchor.
+
+    The governed path (``planning_cli plan-gate run`` -> ``run_panel``) always
+    passes ``data_dir``; the repo root is resolved by the ``.git`` marker so the
+    seat ledger lands next to the ``plan-gates.ndjson`` evidence ledger under
+    ``.vnx-attest/``. A caller with no ``data_dir`` (e.g. a test injecting a
+    dispatcher) gets ``None`` and skips persistence unless it passes
+    ``seat_ledger_path`` explicitly (OI-888).
+    """
+    if not data_dir:
+        return None
+    root = _find_repo_root(Path(__file__).resolve().parent) or _find_repo_root(Path.cwd())
+    if root is None:
+        return None
+    return root / SEAT_LEDGER_RELPATH
+
+
+def _emit_seat_records(
+    results: List[PanelistResult],
+    *,
+    track_id: str,
+    project_id: str,
+    seat_ledger_path: Optional[Path],
+) -> None:
+    """Append one append-only, hash-chained ``plan_gate_seat`` record per panelist.
+
+    Best-effort and non-raising: seat persistence must never break the gate it
+    hangs off (same contract as ``plan_gate_evidence.emit_plan_gate_pass``). Each
+    record carries the panelist id, model, the effective verdict (``abstain`` for
+    a non-scoring lane), and whether a report was returned at all — the durable
+    per-seat signal the effectiveness probe reads. Previously nothing survived
+    beyond the single resolved ``plan_gate_pass`` record (OI-888).
+    """
+    if not seat_ledger_path or not results:
+        return
+    try:
+        from ndjson_hash_chain import append_chained_entry  # noqa: PLC0415
+        now = datetime.now(timezone.utc).isoformat()
+        for result in results:
+            effective_verdict = (
+                result.verdict
+                if (result.dispatched and not result.parse_error)
+                else "abstain"
+            )
+            append_chained_entry(seat_ledger_path, {
+                "type": SEAT_RECORD_TYPE,
+                "track_id": track_id,
+                "project_id": project_id,
+                "panelist_id": result.label,
+                "model": result.model,
+                "verdict": effective_verdict,
+                "responded": result.dispatched,
+                "parse_error": result.parse_error,
+                "run_at": now,
+            })
+    except Exception:  # vnx-silent-except: seat persistence must never break the gate
+        return
 
 
 def run_panel(
@@ -686,6 +776,7 @@ def run_panel(
     dispatcher: Optional[DispatcherFn] = None,
     data_dir: Optional[str] = None,
     timeout_seconds: int = 900,
+    seat_ledger_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Run the plan-first panel over ``doc_path`` and return the verdict.
 
@@ -717,6 +808,11 @@ def run_panel(
         results.append(result)
 
     summary = apply_panel_rule(results)
+    if seat_ledger_path is None:
+        seat_ledger_path = _resolve_seat_ledger_path(data_dir)
+    _emit_seat_records(
+        results, track_id=track_id, project_id=project_id, seat_ledger_path=seat_ledger_path,
+    )
     if doc_truncation["truncated"]:
         # The gate must never certify a verdict while silently hiding that it only read
         # PART of the plan — fold an explicit, quantified note into the rationale (the one

--- a/tests/test_plan_gate_effectiveness_probe_oi888.py
+++ b/tests/test_plan_gate_effectiveness_probe_oi888.py
@@ -1,0 +1,192 @@
+"""OI-888 regression + coverage for plan_gate_effectiveness_probe.py.
+
+Gap 1 (regression, red on origin/main): the all-manual-attest degraded clause
+required ``oi_plan_resolved > 0``, so the real state — 55 ledger records, all
+``attest``, zero resolved OI-PLAN blockers — reported ``ok``. ``degraded`` must
+fire whenever every gate on record was resolved by manual attest, regardless of
+the OI-PLAN resolution count.
+
+Gap 2 (readability): the probe now reads the per-seat verdict ledger
+``.vnx-attest/plan-gate-seats.ndjson`` (persisted by plan_gate_panel.run_panel).
+
+Gap 3 (visibility): the probe reports that the ``VNX_PLAN_GATE_COMPLEX_ONLY``
+scope-skip read-site is missing instead of staying silent.
+"""
+from __future__ import annotations
+
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+from ndjson_hash_chain import append_chained_entry  # noqa: E402
+from plan_gate_effectiveness_probe import (  # noqa: E402
+    COORDINATION_DB_FILENAME,
+    PlanGateEffectivenessProbe,
+)
+
+
+def _ledger_path(repo_root: Path) -> Path:
+    return repo_root / ".vnx-attest" / "plan-gates.ndjson"
+
+
+def _seat_ledger_path(repo_root: Path) -> Path:
+    return repo_root / ".vnx-attest" / "plan-gate-seats.ndjson"
+
+
+def _make_db(state_dir: Path, rows) -> None:
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / COORDINATION_DB_FILENAME))
+    conn.execute(
+        "CREATE TABLE track_open_items (track_id TEXT, project_id TEXT, oi_id TEXT, "
+        "link_type TEXT, linked_at TEXT, resolved_at TEXT)"
+    )
+    conn.executemany(
+        "INSERT INTO track_open_items "
+        "(track_id, project_id, oi_id, link_type, linked_at, resolved_at) VALUES (?,?,?,?,?,?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_attest_ledger(repo_root: Path, count: int = 55) -> None:
+    ledger = _ledger_path(repo_root)
+    for i in range(count):
+        append_chained_entry(ledger, {
+            "type": "plan_gate_pass", "track_id": f"t{i}", "resolver": "attest",
+        })
+
+
+# ---------------------------------------------------------------------------
+# Gap 1 — the real 55/55/0 state must be degraded (regression, red on origin/main)
+# ---------------------------------------------------------------------------
+
+def test_all_attest_zero_resolved_blockers_is_degraded(tmp_path):
+    """The measured real state (55 ledger records, 55 attest, 0 resolved OI-PLAN
+    blockers) must read as degraded — the panel never converged unassisted."""
+    _seed_attest_ledger(tmp_path, count=55)
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [("t0", "p", "OI-PLAN-t0", "blocks", now, None)])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.detail["ledger_total"] == 55
+    assert result.detail["ledger_attest_count"] == 55
+    assert result.detail["oi_plan_resolved"] == 0
+    assert result.status == "degraded"
+
+
+def test_all_attest_with_no_db_at_all_is_degraded(tmp_path):
+    """All-attest is degraded even when there are no OI-PLAN rows at all — the
+    ledger itself is the durable record that every gate needed a manual override."""
+    _seed_attest_ledger(tmp_path, count=3)
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert result.detail["ledger_total"] == 3
+    assert result.detail["ledger_attest_count"] == 3
+    assert result.status == "degraded"
+
+
+def test_all_attest_after_fix_still_degraded_with_resolved_backlog(tmp_path):
+    """The pre-existing 'all attest with resolved items' scenario stays degraded."""
+    _seed_attest_ledger(tmp_path, count=1)
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [("t1", "p", "OI-PLAN-t1", "blocks", now, now)])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "degraded"
+
+
+def test_mixed_resolvers_with_no_stale_backlog_still_ok(tmp_path):
+    """A single organic run keeps health ok — the panel does converge sometimes."""
+    ledger = _ledger_path(tmp_path)
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t1", "resolver": "run"})
+    append_chained_entry(ledger, {"type": "plan_gate_pass", "track_id": "t2", "resolver": "attest"})
+    state_dir = tmp_path / "state"
+    now = datetime.now(timezone.utc).isoformat()
+    _make_db(state_dir, [
+        ("t1", "p", "OI-PLAN-t1", "blocks", now, now),
+        ("t2", "p", "OI-PLAN-t2", "blocks", now, now),
+    ])
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=state_dir).run()
+
+    assert result.status == "ok"
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 — the probe reads the per-seat verdict ledger
+# ---------------------------------------------------------------------------
+
+def test_probe_reads_seat_ledger(tmp_path):
+    seat_ledger = _seat_ledger_path(tmp_path)
+    append_chained_entry(seat_ledger, {
+        "type": "plan_gate_seat", "panelist_id": "opus", "model": "opus",
+        "verdict": "pass", "responded": True, "parse_error": False,
+    })
+    append_chained_entry(seat_ledger, {
+        "type": "plan_gate_seat", "panelist_id": "kimi", "model": "kimi-k3",
+        "verdict": "abstain", "responded": False, "parse_error": False,
+    })
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert result.detail["seat_total"] == 2
+    assert result.detail["seat_responded"] == 1
+    assert result.detail["seat_abstain"] == 1
+    assert result.detail["seat_pass"] == 1
+    assert result.detail["seat_revise"] == 0
+    assert result.detail["seat_block"] == 0
+
+
+def test_probe_signal_includes_seat_counts_when_present(tmp_path):
+    seat_ledger = _seat_ledger_path(tmp_path)
+    append_chained_entry(seat_ledger, {
+        "type": "plan_gate_seat", "panelist_id": "opus", "model": "opus",
+        "verdict": "pass", "responded": True, "parse_error": False,
+    })
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert "1 seat record(s)" in result.signal
+    assert "1 responded" in result.signal
+
+
+# ---------------------------------------------------------------------------
+# Gap 3 — the missing scope-skip read-site is reported, not silent
+# ---------------------------------------------------------------------------
+
+def test_probe_reports_missing_scope_skip_read_site_in_detail(tmp_path):
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert result.detail.get("scope_skip_read_site") == "missing"
+
+
+def test_probe_signal_mentions_missing_scope_skip_read_site(tmp_path):
+    append_chained_entry(_ledger_path(tmp_path), {
+        "type": "plan_gate_pass", "track_id": "t1", "resolver": "run",
+    })
+
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert "VNX_PLAN_GATE_COMPLEX_ONLY read-site MISSING" in result.signal
+
+
+def test_unknown_state_still_reported_when_nothing_exists(tmp_path):
+    result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
+
+    assert result.status == "unknown"
+    assert "no plan-gate activity yet" in result.signal
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/tests/test_plan_gate_seat_ledger.py
+++ b/tests/test_plan_gate_seat_ledger.py
@@ -1,0 +1,166 @@
+"""Per-seat verdict persistence for the plan-gate panel (OI-888).
+
+``run_panel`` appends one append-only, hash-chained ``plan_gate_seat`` record
+per panelist per run, so the per-seat outcome (panelist id, model, effective
+verdict incl. abstain, and whether a report was returned) survives for the
+effectiveness probe — previously only the single resolved ``plan_gate_pass``
+record was durable. These tests drive the persist layer with a realistic panel
+verdict and read the rows back (the panel itself takes an injectable dispatcher,
+so no live model is needed).
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import plan_gate_panel as pgp  # noqa: E402
+from ndjson_hash_chain import walk_chain  # noqa: E402
+
+
+def _report(verdict_json: str) -> str:
+    return f"# review\n\nsome prose\n\n```{pgp.VERDICT_FENCE}\n{verdict_json}\n```\n"
+
+
+def _fake_dispatcher(verdict_by_provider):
+    def _dispatch(provider, model_arg, instruction, dispatch_id):
+        return _report(verdict_by_provider[provider])
+    return _dispatch
+
+
+def _run(tmp_path, *, verdict_by_provider, seat_ledger_path, track="feat-seats"):
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    return pgp.run_panel(
+        doc,
+        track_id=track,
+        project_id="p1",
+        dispatcher=_fake_dispatcher(verdict_by_provider),
+        seat_ledger_path=seat_ledger_path,
+    )
+
+
+def test_run_panel_persists_one_row_per_seat(tmp_path):
+    """Every scoring seat lands a hash-chained row carrying its verdict + model."""
+    seat_ledger = tmp_path / "plan-gate-seats.ndjson"
+    verdicts = {m["provider"]: '{"verdict": "pass"}' for m in pgp.DEFAULT_PANEL}
+    out = _run(tmp_path, verdict_by_provider=verdicts, seat_ledger_path=seat_ledger)
+
+    assert out["decision"] == "PASS"
+    rows = list(walk_chain(seat_ledger))
+    assert len(rows) == len(pgp.DEFAULT_PANEL)
+
+    by_label = {m["label"]: m for m in pgp.DEFAULT_PANEL}
+    for _line_no, rec, _hash in rows:
+        assert rec["type"] == "plan_gate_seat"
+        assert rec["track_id"] == "feat-seats"
+        assert rec["project_id"] == "p1"
+        member = by_label[rec["panelist_id"]]
+        assert rec["model"] == member["model_arg"]
+        assert rec["verdict"] == "pass"
+        assert rec["responded"] is True
+        assert rec["parse_error"] is False
+        assert rec["run_at"]
+
+
+def test_run_panel_persists_abstain_for_unresponsive_seat(tmp_path):
+    """A lane that never returns a report is recorded as abstain, not dropped."""
+    seat_ledger = tmp_path / "plan-gate-seats.ndjson"
+
+    def _flaky(provider, model_arg, instruction, dispatch_id):
+        if provider == "kimi":
+            raise RuntimeError("kimi cli not installed")
+        return _report('{"verdict": "pass"}')
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    out = pgp.run_panel(
+        doc, track_id="feat-flaky", project_id="p1",
+        dispatcher=_flaky, seat_ledger_path=seat_ledger,
+    )
+
+    rows = {rec["panelist_id"]: rec for _ln, rec, _h in walk_chain(seat_ledger)}
+    assert out["decision"] == "PASS"  # 2 readable voices meet quorum
+    kimi = rows["kimi"]
+    assert kimi["verdict"] == "abstain"
+    assert kimi["responded"] is False
+    assert kimi["parse_error"] is False
+    opus = rows["opus"]
+    assert opus["verdict"] == "pass"
+    assert opus["responded"] is True
+
+
+def test_run_panel_persists_abstain_for_parse_error_seat(tmp_path):
+    """A report whose verdict fence does not parse is a non-scoring abstain row."""
+    seat_ledger = tmp_path / "plan-gate-seats.ndjson"
+
+    def _garbled(provider, model_arg, instruction, dispatch_id):
+        if provider == "glm-harness":
+            return "# review\n\nno verdict fence here\n"
+        return _report('{"verdict": "pass"}')
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    out = pgp.run_panel(
+        doc, track_id="feat-garbled", project_id="p1",
+        dispatcher=_garbled, seat_ledger_path=seat_ledger,
+    )
+
+    rows = {rec["panelist_id"]: rec for _ln, rec, _h in walk_chain(seat_ledger)}
+    assert out["decision"] == "PASS"
+    assert rows["glm-5.2-harness"]["verdict"] == "abstain"
+    assert rows["glm-5.2-harness"]["responded"] is True
+    assert rows["glm-5.2-harness"]["parse_error"] is True
+
+
+def test_run_panel_panelist_rows_carry_model(tmp_path):
+    """The panelists in the returned result expose the model they were dispatched with."""
+    verdicts = {m["provider"]: '{"verdict": "pass"}' for m in pgp.DEFAULT_PANEL}
+    out = _run(tmp_path, verdict_by_provider=verdicts,
+               seat_ledger_path=tmp_path / "seats.ndjson")
+    by_label = {p["label"]: p for p in out["panelists"]}
+    for member in pgp.DEFAULT_PANEL:
+        assert by_label[member["label"]]["model"] == member["model_arg"]
+
+
+def test_emit_seat_records_never_raises_on_bad_path(tmp_path):
+    """Best-effort contract: a path that cannot be created yields no exception."""
+    bad = tmp_path / "afile"
+    bad.write_text("x")
+    results = [pgp.PanelistResult(label="opus", provider="claude", model="opus")]
+    pgp._emit_seat_records(results, track_id="t", project_id="p1", seat_ledger_path=bad)
+
+
+def test_resolve_seat_ledger_path_none_without_data_dir():
+    """No data_dir -> no seat persistence unless a path is passed explicitly."""
+    assert pgp._resolve_seat_ledger_path(None) is None
+
+
+def test_find_repo_root_walks_to_git_marker(tmp_path):
+    (tmp_path / ".git").mkdir()
+    nested = tmp_path / "a" / "b" / "c"
+    nested.mkdir(parents=True)
+    assert pgp._find_repo_root(nested) == tmp_path
+
+
+def test_find_repo_root_handles_worktree_git_file(tmp_path):
+    (tmp_path / ".git").write_text("gitdir: /somewhere/main/.git\n", encoding="utf-8")
+    nested = tmp_path / "x"
+    nested.mkdir()
+    assert pgp._find_repo_root(nested) == tmp_path
+
+
+def test_find_repo_root_none_without_marker(tmp_path):
+    assert pgp._find_repo_root(tmp_path) is None
+
+
+def test_seat_ledger_constants_are_repo_relative():
+    assert pgp.SEAT_LEDGER_RELPATH.endswith("plan-gate-seats.ndjson")
+    assert pgp.SEAT_LEDGER_RELPATH.startswith(".vnx-attest/")
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The plan-gate effectiveness probe could not go off in exactly the state it was built to detect (OI-888). The all-manual-attest degraded clause required `oi_plan_resolved > 0`, so the real ledger — 55 `plan_gate_pass` records, all `attest`, 0 resolved OI-PLAN blockers — reported `ok` while 25/26 objectives sat blocked behind a gate that never converged organically.

Three gaps, all fixed:

**Gap 1 — the alarm was unreachable.** `health()`'s third clause required `oi_plan_resolved > 0`; in the real state that is zero (the objectives are blocked, i.e. unresolved), so the exact state the docstring calls `degraded` reported `ok`. Removed the `oi_plan_resolved > 0` requirement: "every gate on record was resolved by manual attest" is now `degraded` regardless of the OI-PLAN resolution count. The ledger is the durable record of whether the panel converged organically; the OI-PLAN count measures backlog staleness, which the stale clause already covers. The two axes are orthogonal, so the coupling was the bug.

**Gap 2 — per-seat verdicts now persist.** `plan_gate_panel.run_panel` appends one append-only, hash-chained `plan_gate_seat` record per panelist per run (panelist id, model, effective verdict incl. abstain, responded, parse_error) to `.vnx-attest/plan-gate-seats.ndjson`, alongside the existing `plan_gate_pass` evidence ledger. The probe reads it (`seat_total/responded/abstain/pass/revise/block`). Previously only the final resolved record survived — a degraded seat (3 of 5 responding) was only visible during a live run.

**Gap 3 — the missing scope-skip read-site is reported, not silent.** `VNX_PLAN_GATE_COMPLEX_ONLY` has no read-site (deferred to review-floor-enforcer). The probe now reports `scope_skip_read_site: "missing"` in its raw detail and names it in the signal, instead of the docstring being the only trace.

## Changes

- `scripts/lib/plan_gate_effectiveness_probe.py`: drop `oi_plan_resolved > 0` from the all-attest degraded clause; read the seat ledger; report `scope_skip_read_site: "missing"`; add `SEAT_LEDGER_RELPATH`; `_ACTIVITY_KEYS` for the unknown-vs-anything split (the constant `"missing"` string is excluded from the activity check).
- `scripts/lib/plan_gate_panel.py`: add `SEAT_LEDGER_RELPATH`/`SEAT_RECORD_TYPE`, `model` field on `PanelistResult`, `_find_repo_root` (subprocess-free `.git` marker walk), `_resolve_seat_ledger_path`, `_emit_seat_records` (best-effort, never raises), and wire it into `run_panel`.
- `tests/test_plan_gate_effectiveness_probe_oi888.py` (new): regression + readability + visibility tests.
- `tests/test_plan_gate_seat_ledger.py` (new): persistence tests feeding a realistic panel verdict and reading the rows back.

## Verification

**Gap 1 evidence (real ledger values, origin/main vs fix):**
- Before (origin/main): `probe()` → `{ledger_total: 55, ledger_attest_count: 55, oi_plan_unresolved: 0, oi_plan_stale_unresolved: 0, oi_plan_resolved: 0}`, `health()` → `ok`.
- After: same input → `health()` → `degraded`; signal names the missing read-site.
- Regression test `test_all_attest_zero_resolved_blockers_is_degraded` (55 attest + 0 resolved) fails on origin/main (`'ok' == 'degraded'`) and passes with the fix.

**Gap 2 evidence:** a panel run with an injected dispatcher (kimi flaked, glm returned an unparseable report) produced: `opus pass / kimi abstain (responded=false) / glm-5.2-harness abstain (parse_error=true) / deepseek pass / codex pass` — five persisted rows read back via the hash chain.

**Test run:** `tests/test_plan_gate_panel.py`, `tests/test_plan_gate_evidence.py`, `tests/test_plan_gate_effectiveness_probe.py`, `tests/test_plan_gate_effectiveness_probe_oi888.py`, `tests/test_plan_gate_seat_ledger.py` → 100 passed. Ruff clean on all four touched files. `ci_lint_patterns.py --scan-stdin` on added lines → 0 findings.

Note: `tests/test_plan_gate_enforcement.py` has 2 pre-existing failures (`test_default_is_advisory`, `test_resolution[-advisory]`) caused by the persisted `VNX_PLAN_GATE_ENFORCE=required` config in the central store — unrelated to this change (none of these files import the touched modules).

Dispatch-ID: 20260731-oi888-plangate-probe-clause

🤖 Generated with [Claude Code](https://claude.com/claude-code)