### PR TITLE
fix(dream): maak geïnstalleerde scheduler-job draaibaar onder launchd/cron (OI-895)

### DIFF
--- a/scripts/dream/install_scheduler.py
+++ b/scripts/dream/install_scheduler.py
@@ -20,7 +20,11 @@ import tempfile
 from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
-from project_root import resolve_project_root  # noqa: E402
+from project_root import resolve_central_data_dir, resolve_project_root  # noqa: E402
+
+# Fallback PATH for the scheduled job when the installer itself runs with an
+# empty PATH. Covers the standard macOS locations for git/kimi/vnx.
+_DEFAULT_PATH_ENV = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
 
 def _render_plist(template_path: Path, ctx: dict[str, str]) -> str:
@@ -63,11 +67,19 @@ def main() -> None:
         else resolve_project_root(__file__)
     )
 
+    # ADR-026: logs belong in the central data dir (resolve_central_data_dir),
+    # never repo-local .vnx-data. launchd does not create missing log
+    # directories, so create it here, before the operator loads the agent.
+    log_dir = resolve_central_data_dir(args.project_id) / "events" / "dream"
+    log_dir.mkdir(parents=True, exist_ok=True)
+
     template_path = Path(__file__).resolve().parent / "templates" / "com.vnx.auto-dream.plist.j2"
     ctx = {
         "vnx_bin_path": vnx_bin,
         "project_id": args.project_id,
         "project_root": str(project_root),
+        "path_env": os.environ.get("PATH") or _DEFAULT_PATH_ENV,
+        "log_dir": str(log_dir),
     }
     rendered = _render_plist(template_path, ctx)
 

--- a/scripts/dream/scheduler.py
+++ b/scripts/dream/scheduler.py
@@ -18,10 +18,33 @@ from pathlib import Path
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "lib"))
 import vnx_paths as _vnx_paths
+from project_root import resolve_central_data_dir
 
 _PLIST_LABEL = "com.vnx.auto-dream"
 _PLIST_NAME = f"{_PLIST_LABEL}.plist"
 _CRON_MARKER = f"# vnx-auto-dream:{_PLIST_LABEL}"
+
+# Fallback PATH for the scheduled job when the installer itself runs with an
+# empty PATH. Covers the standard macOS/Linux locations for git/kimi/vnx.
+_DEFAULT_PATH_ENV = "/usr/local/bin:/opt/homebrew/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+
+def _path_env() -> str:
+    """PATH snapshot for the scheduled job.
+
+    launchd/cron start with a minimal PATH; the install-time PATH is the best
+    available record of where vnx/git/kimi actually live on this machine.
+    """
+    return os.environ.get("PATH") or _DEFAULT_PATH_ENV
+
+
+def _central_log_dir(project_id: str) -> Path:
+    """Log dir for scheduler stdout/stderr, under the central data dir.
+
+    ADR-026: resolve_central_data_dir(project_id) is the SSOT for runtime
+    state — never the repo-local .vnx-data, which would fork state.
+    """
+    return resolve_central_data_dir(project_id) / "events" / "dream"
 
 
 def _render_plist(template_path: Path, ctx: dict) -> str:
@@ -40,12 +63,19 @@ def _install_macos(project_id: str, project_root: Path, vnx_bin: str) -> str:
     template_path = (
         Path(__file__).resolve().parent / "templates" / "com.vnx.auto-dream.plist.j2"
     )
+    log_dir = _central_log_dir(project_id)
     ctx = {
         "vnx_bin_path": vnx_bin,
         "project_id": project_id,
         "project_root": str(project_root),
+        "path_env": _path_env(),
+        "log_dir": str(log_dir),
     }
     rendered = _render_plist(template_path, ctx)
+
+    # Create the log dir before launchd is asked to write to it — launchd
+    # does not create missing StandardOutPath/StandardErrorPath directories.
+    log_dir.mkdir(parents=True, exist_ok=True)
 
     out_dir = Path.home() / "Library" / "LaunchAgents"
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -86,12 +116,31 @@ def _uninstall_macos() -> str:
     return f"Unloaded and removed: {out_path}"
 
 
-def _cron_line(vnx_bin: str, project_id: str) -> str:
-    return f"0 3 * * * {vnx_bin} dream run --project-id {project_id}  {_CRON_MARKER}"
+def _cron_line(
+    vnx_bin: str,
+    project_id: str,
+    project_root: Path,
+    log_dir: Path,
+    path_env: str,
+) -> str:
+    # cron starts the job with a minimal environment and cwd=$HOME — outside
+    # any project. Same gaps as the launchd plist (OI-895): arm the scheduler
+    # gate, pin the project root, and redirect output to the central log dir
+    # (ADR-026) instead of letting it vanish into cron mail.
+    return (
+        f"0 3 * * * cd {project_root} && "
+        f"VNX_DREAM_SCHEDULER_ENABLED=1 "
+        f"VNX_CANONICAL_ROOT={project_root} "
+        f"PATH={path_env} "
+        f"{vnx_bin} dream run --project-id {project_id} "
+        f">> {log_dir}/cron.out.log 2>&1  {_CRON_MARKER}"
+    )
 
 
-def _install_linux(project_id: str, vnx_bin: str) -> str:
-    new_line = _cron_line(vnx_bin, project_id)
+def _install_linux(project_id: str, project_root: Path, vnx_bin: str) -> str:
+    log_dir = _central_log_dir(project_id)
+    log_dir.mkdir(parents=True, exist_ok=True)
+    new_line = _cron_line(vnx_bin, project_id, project_root, log_dir, _path_env())
     result = subprocess.run(["crontab", "-l"], capture_output=True, text=True)
     existing = result.stdout if result.returncode == 0 else ""
     lines = [ln for ln in existing.splitlines() if _CRON_MARKER not in ln]
@@ -138,7 +187,7 @@ def install_scheduler(
     if sys_platform == "Darwin":
         return _install_macos(project_id, project_root, vnx_bin)
     elif sys_platform == "Linux":
-        return _install_linux(project_id, vnx_bin)
+        return _install_linux(project_id, project_root, vnx_bin)
     else:
         raise RuntimeError(
             f"Unsupported platform: {sys_platform}. Only macOS and Linux supported."

--- a/scripts/dream/templates/com.vnx.auto-dream.plist.j2
+++ b/scripts/dream/templates/com.vnx.auto-dream.plist.j2
@@ -12,6 +12,20 @@
         <string>--project-id</string>
         <string>{{ project_id }}</string>
     </array>
+    <!-- launchd runs the job with a minimal environment outside any project:
+         arm the PR-17 scheduler gate, provide a usable PATH, and pin the
+         project root so `vnx dream run` can resolve the project (OI-895). -->
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>VNX_DREAM_SCHEDULER_ENABLED</key>
+        <string>1</string>
+        <key>VNX_CANONICAL_ROOT</key>
+        <string>{{ project_root }}</string>
+        <key>PATH</key>
+        <string>{{ path_env }}</string>
+    </dict>
+    <key>WorkingDirectory</key>
+    <string>{{ project_root }}</string>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key>
@@ -19,9 +33,12 @@
         <key>Minute</key>
         <integer>0</integer>
     </dict>
+    <!-- Logs live in the central data dir (resolve_central_data_dir), the
+         ADR-026 SSOT — never repo-local .vnx-data, which would fork state.
+         The installer creates this directory before the agent is loaded. -->
     <key>StandardOutPath</key>
-    <string>{{ project_root }}/.vnx-data/events/dream/launchd.out.log</string>
+    <string>{{ log_dir }}/launchd.out.log</string>
     <key>StandardErrorPath</key>
-    <string>{{ project_root }}/.vnx-data/events/dream/launchd.err.log</string>
+    <string>{{ log_dir }}/launchd.err.log</string>
 </dict>
 </plist>

--- a/tests/test_dream_scheduler.py
+++ b/tests/test_dream_scheduler.py
@@ -143,7 +143,7 @@ class TestUninstallSchedulerMacOS:
 
 
 class TestInstallSchedulerLinux:
-    def test_cron_entry_added(self):
+    def test_cron_entry_added(self, tmp_path):
         """install_scheduler on Linux adds crontab entry with project_id."""
         existing_cron = "30 6 * * * /usr/bin/backup\n"
 
@@ -160,6 +160,7 @@ class TestInstallSchedulerLinux:
 
         with (
             patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.Path.home", return_value=tmp_path),
             patch("scheduler.subprocess.run", side_effect=mock_run),
         ):
             result = scheduler.install_scheduler("vnx-dev", vnx_bin="/usr/bin/vnx")
@@ -168,7 +169,7 @@ class TestInstallSchedulerLinux:
         assert "vnx-auto-dream" in captured["new"]
         assert "# vnx-auto-dream" in result or "Cron entry" in result
 
-    def test_cron_idempotent(self):
+    def test_cron_idempotent(self, tmp_path):
         """Re-installing replaces existing auto-dream cron line (no duplicates)."""
         existing = "0 3 * * * /usr/bin/vnx dream run --project-id vnx-dev  # vnx-auto-dream:com.vnx.auto-dream\n"
         captured = {}
@@ -184,6 +185,7 @@ class TestInstallSchedulerLinux:
 
         with (
             patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.Path.home", return_value=tmp_path),
             patch("scheduler.subprocess.run", side_effect=mock_run),
         ):
             scheduler.install_scheduler("vnx-dev", vnx_bin="/usr/bin/vnx")

--- a/tests/test_dream_scheduler_plist.py
+++ b/tests/test_dream_scheduler_plist.py
@@ -1,0 +1,172 @@
+"""Rendered-output tests for the auto-dream scheduler installers (OI-895).
+
+These tests assert on the *rendered* plist/crontab, not on intent: a fresh
+``vnx dream install-scheduler`` must produce a job that can actually run under
+launchd/cron:
+
+- Gebrek 1: EnvironmentVariables with VNX_DREAM_SCHEDULER_ENABLED=1 + usable PATH
+- Gebrek 2: WorkingDirectory + VNX_CANONICAL_ROOT (launchd/cron run outside any
+  project; without them root resolution fails with "not in a VNX project")
+- Gebrek 3: StandardOutPath/StandardErrorPath under the *central* data dir
+  (resolve_central_data_dir, ADR-026 SSOT), never repo-local .vnx-data — and the
+  log directory must exist before launchd tries to write to it.
+
+The Linux/cron path has the same gaps measured the same way: no feature-flag in
+the environment, cwd=$HOME outside any project, and no log redirection at all.
+"""
+from __future__ import annotations
+
+import plistlib
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "dream"))
+
+import scheduler
+
+
+PROJECT_ID = "vnx-dev"
+VNX_BIN = "/usr/local/bin/vnx"
+
+
+def _install_macos(tmp_path: Path) -> tuple[Path, Path, list]:
+    """Run install_scheduler on a mocked Darwin; return (plist, log_dir, run_calls)."""
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    central = tmp_path / ".vnx-data" / PROJECT_ID
+    log_dir = central / "events" / "dream"
+
+    ok = MagicMock(returncode=0, stderr="", stdout="")
+
+    with (
+        patch("scheduler.platform.system", return_value="Darwin"),
+        patch("scheduler.Path.home", return_value=tmp_path),
+        patch("scheduler.subprocess.run", return_value=ok) as mock_run,
+    ):
+        scheduler.install_scheduler(
+            project_id=PROJECT_ID,
+            project_root=project_root,
+            vnx_bin=VNX_BIN,
+        )
+
+    plist_path = tmp_path / "Library" / "LaunchAgents" / "com.vnx.auto-dream.plist"
+    return plist_path, log_dir, mock_run.call_args_list
+
+
+class TestRenderedPlistMacOS:
+    """Assertions on the plist bytes actually written to ~/Library/LaunchAgents."""
+
+    def test_plist_is_valid_xml(self, tmp_path):
+        plist_path, _, _ = _install_macos(tmp_path)
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist["Label"] == "com.vnx.auto-dream"
+        assert plist["ProgramArguments"] == [
+            VNX_BIN, "dream", "run", "--project-id", PROJECT_ID,
+        ]
+
+    def test_feature_flag_and_path_in_environment(self, tmp_path):
+        """Gebrek 1: launchd gets VNX_DREAM_SCHEDULER_ENABLED=1 + usable PATH."""
+        plist_path, _, _ = _install_macos(tmp_path)
+        plist = plistlib.loads(plist_path.read_bytes())
+        env = plist.get("EnvironmentVariables", {})
+        assert env.get("VNX_DREAM_SCHEDULER_ENABLED") == "1"
+        assert env.get("PATH"), "PATH missing from EnvironmentVariables"
+
+    def test_working_directory_and_canonical_root(self, tmp_path):
+        """Gebrek 2: job runs inside the project even though launchd starts in /."""
+        project_root = tmp_path / "project"
+        plist_path, _, _ = _install_macos(tmp_path)
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist.get("WorkingDirectory") == str(project_root)
+        env = plist.get("EnvironmentVariables", {})
+        assert env.get("VNX_CANONICAL_ROOT") == str(project_root)
+
+    def test_log_paths_under_central_data_dir(self, tmp_path):
+        """Gebrek 3: logs go to resolve_central_data_dir(project_id), ADR-026."""
+        project_root = tmp_path / "project"
+        plist_path, log_dir, _ = _install_macos(tmp_path)
+        plist = plistlib.loads(plist_path.read_bytes())
+        assert plist.get("StandardOutPath") == str(log_dir / "launchd.out.log")
+        assert plist.get("StandardErrorPath") == str(log_dir / "launchd.err.log")
+        repo_local = str(project_root / ".vnx-data")
+        assert not plist["StandardOutPath"].startswith(repo_local)
+        assert not plist["StandardErrorPath"].startswith(repo_local)
+
+    def test_log_dir_created_before_launchctl_load(self, tmp_path):
+        """The log dir must exist before launchd can write to it."""
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        central = tmp_path / ".vnx-data" / PROJECT_ID
+        log_dir = central / "events" / "dream"
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock(returncode=0, stderr="", stdout="")
+            if "load" in cmd and "unload" not in cmd:
+                assert log_dir.is_dir(), (
+                    "log dir must be created before `launchctl load`"
+                )
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Darwin"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            scheduler.install_scheduler(
+                project_id=PROJECT_ID, project_root=project_root, vnx_bin=VNX_BIN
+            )
+
+        assert log_dir.is_dir()
+
+
+class TestRenderedCronLinux:
+    """The cron path has the same gaps: no flag, no project root, no logs."""
+
+    def _install_linux(self, tmp_path: Path) -> tuple[str, Path]:
+        project_root = tmp_path / "project"
+        project_root.mkdir()
+        log_dir = tmp_path / ".vnx-data" / PROJECT_ID / "events" / "dream"
+        captured: dict[str, str] = {}
+
+        def mock_run(cmd, **kwargs):
+            m = MagicMock(returncode=0, stderr="", stdout="")
+            if cmd == ["crontab", "-l"]:
+                m.stdout = "30 6 * * * /usr/bin/backup\n"
+            elif cmd == ["crontab", "-"]:
+                captured["new"] = kwargs.get("input", "")
+            return m
+
+        with (
+            patch("scheduler.platform.system", return_value="Linux"),
+            patch("scheduler.Path.home", return_value=tmp_path),
+            patch("scheduler.subprocess.run", side_effect=mock_run),
+        ):
+            scheduler.install_scheduler(
+                project_id=PROJECT_ID, project_root=project_root, vnx_bin=VNX_BIN
+            )
+
+        lines = [ln for ln in captured["new"].splitlines() if "vnx-auto-dream" in ln]
+        assert len(lines) == 1, "expected exactly one auto-dream cron line"
+        return lines[0], log_dir
+
+    def test_cron_line_sets_feature_flag(self, tmp_path):
+        line, _ = self._install_linux(tmp_path)
+        assert "VNX_DREAM_SCHEDULER_ENABLED=1" in line
+
+    def test_cron_line_runs_inside_project(self, tmp_path):
+        project_root = tmp_path / "project"
+        line, _ = self._install_linux(tmp_path)
+        assert f"VNX_CANONICAL_ROOT={project_root}" in line
+        assert f"cd {project_root}" in line
+
+    def test_cron_line_logs_to_central_data_dir(self, tmp_path):
+        line, log_dir = self._install_linux(tmp_path)
+        assert str(log_dir / "cron.out.log") in line
+        assert "2>&1" in line
+        assert log_dir.is_dir(), "log dir must be created at install time"


### PR DESCRIPTION
## OI-895 — repo-fix voor de kapotte DREAM-scheduler-installer

ADR-019 (2026-05-29) werd op 2026-07-31 voor het eerst geactiveerd; de geïnstalleerde job kon niets doen. Dit is de repo-fix voor de drie gemeten gebreken (de runtime-reparatie in `~/Library/LaunchAgents/` blijft lokaal).

### Gebrek → fix

| # | Gebrek (gemeten via `launchctl kickstart -k`) | Fix |
|---|---|---|
| 1 | Geen `EnvironmentVariables` → `VNX_DREAM_SCHEDULER_ENABLED` ongezet → `scheduler_disabled` no-op | Template krijgt `EnvironmentVariables` met flag=1 + install-time PATH-snapshot |
| 2 | Geen `WorkingDirectory`/`VNX_CANONICAL_ROOT` → `error: not in a VNX project` onder launchd | Beide komen in de plist; de al bekende `project_root` wordt nu daadwerkelijk ingevuld |
| 3 | Logpaden repo-lokaal (`<root>/.vnx-data/...`), map bestond niet → launchd-schrijffouten + split-brain | Logpaden via bestaande `resolve_central_data_dir(project_id)` (ADR-026 SSOT, geen `.vnx-data`-literal); installer maakt de map aan vóór laden |

### Linux/cron-pad — gemeten, zelfde gaten

De cron-regel was `0 3 * * * vnx dream run --project-id …`: cron start met minimale env en `cwd=$HOME`, dus gebrek 1 en 2 golden daar evenzeer, en output verdween in cron-mail. De regel is nu:

```
0 3 * * * cd <root> && VNX_DREAM_SCHEDULER_ENABLED=1 VNX_CANONICAL_ROOT=<root> PATH=<snapshot> <vnx> dream run --project-id <id> >> <central>/events/dream/cron.out.log 2>&1  # vnx-auto-dream:com.vnx.auto-dream
```

### Test op gerenderde uitvoer

`tests/test_dream_scheduler_plist.py` parst de **geschreven plist** met `plistlib` en assert flag, PATH, `WorkingDirectory`, `VNX_CANONICAL_ROOT`, centrale logpaden én dat de logmap bestaat vóór `launchctl load`; idem voor de gerenderde cron-regel. **Rood op `origin/main`** (7 failing asserts — `scripts/dream/` is identiek aan `origin/main`, geverifieerd met `git diff`), groen met deze change. Beide render-paden (jinja2 + string-fallback) geverifieerd; fallback laat geen `{{ }}`-placeholders achter.

### Randvoorwaarden

- Alleen `scripts/dream/` + testbestanden aangeraakt.
- Probe-drempels en skip-logica van `vnx dream run` ongemoeid — stoppen op `probe_not_ok` blijft correct (OI-894).
- Geen `# noqa:` toegevoegd; `scripts/ci_lint_patterns.py` exit 0 op de gewijzigde bestanden.
- Bestaande Linux-install-tests patchen nu `Path.home` zodat de nieuwe logmap-aanmaak tijdens testruns geen echte `~/.vnx-data` raakt.
- 86 dream-tests groen (`test_dream_scheduler_plist`, `test_dream_scheduler`, `test_dream_cli`, `test_dream_consolidator`).