### PR TITLE
fix(intelligence): adoption reader reads DB offer junction, zero-row updates visible (OI-894)

### DIFF
--- a/scripts/gather_intelligence.py
+++ b/scripts/gather_intelligence.py
@@ -458,54 +458,92 @@ class T0IntelligenceGatherer:
             return
         now = datetime.now().isoformat()
         try:
-            self.quality_db.execute(
+            cur = self.quality_db.execute(
                 "UPDATE pattern_usage SET used_count = used_count + 1, last_used = ?, "
-                "updated_at = ? WHERE pattern_hash = ?",
-                (now, now, pattern_id),
+                "updated_at = ? WHERE pattern_hash = ? OR pattern_id = ?",
+                (now, now, pattern_id, pattern_id),
             )
             self.quality_db.commit()
+            if cur.rowcount == 0:
+                # A zero-row adoption update means the offer/adoption id spaces
+                # diverged (e.g. caller passed a pattern_hash while the live row
+                # keys on pattern_id, or the offer was never registered).  This
+                # must be visible: an invisible zero-row update is exactly how
+                # the ignore-rate measurement went stale (OI-894).
+                log.warning(
+                    "Pattern adoption for %s (dispatch=%s) matched no pattern_usage "
+                    "row — used_count NOT incremented",
+                    pattern_id, dispatch_id,
+                )
         except sqlite3.Error as e:
-            log.debug("Failed to update pattern usage for %s: %s", pattern_id, e)
+            # Recording must never break receipt processing, but a failed
+            # adoption update is a data-path failure and must be visible.
+            log.warning("Failed to update pattern usage for %s: %s", pattern_id, e)
 
     def record_adoption_from_receipt(self, dispatch_id: str, terminal: str,
                                       report_path: str) -> Dict[str, Any]:
         """Correlate a completed receipt's file changes with patterns offered for this dispatch.
 
-        Reads intelligence_usage.ndjson for offer events with this dispatch_id,
-        extracts file paths from the report, and records adoptions for matches.
+        Offers come from two sources, merged per pattern_id:
+        - ``dispatch_pattern_offered`` (quality DB) — the canonical per-dispatch
+          offer store, written by the live intelligence-injection path
+          (intelligence_sources/_recording.py).  This is the single source of
+          truth: the DB row is written unconditionally at injection time, while
+          the ndjson offer writer is guarded on a dispatch_id the primary
+          dispatcher never passes (OI-894).
+        - ``intelligence_usage.ndjson`` — legacy offer events carrying
+          ``file_path``/``title``/``content`` for filename-based correlation.
+
+        A pattern counts as adopted when the report touches its file (legacy
+        filename signal) or, for DB-sourced offers that carry no file_path,
+        when the report's token overlap with the pattern content reaches
+        ``_CONTENT_USE_THRESHOLD`` (same heuristic as the WHY path's ``used``).
 
         When VNX_INJECTION_WHY_ENABLED=1, additionally persists a per-offer
-        used/ignored-reason row (see _record_injection_why) using a stronger,
-        content-overlap signal. That path is purely additive: with the flag off
-        this method's reads/writes/return value are unchanged.
+        used/ignored-reason row (see _record_injection_why). That path is
+        purely additive: with the flag off this method's reads/writes/return
+        value are unchanged.
         """
-        usage_log = self._usage_log_path()
-        if not usage_log.exists():
-            return {"adoptions": 0, "checked": 0}
-
         # Collect offered patterns for this dispatch
         offered: Dict[str, str] = {}  # pattern_id -> file_path
         offered_titles: Dict[str, str] = {}
         offered_content: Dict[str, str] = {}
-        try:
-            with open(usage_log, encoding="utf-8") as fh:
-                for line in fh:
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        rec = json.loads(line)
-                    except json.JSONDecodeError:
-                        continue
-                    if rec.get("event_type") == "offer" and rec.get("dispatch_id") == dispatch_id:
-                        pid = rec.get("pattern_id", "")
-                        fp = rec.get("file_path", "")
-                        if pid:
-                            offered[pid] = fp
-                            offered_titles[pid] = rec.get("title", "") or ""
-                            offered_content[pid] = rec.get("content", "") or ""
-        except OSError:
-            return {"adoptions": 0, "checked": 0}
+
+        usage_log = self._usage_log_path()
+        if usage_log.exists():
+            try:
+                with open(usage_log, encoding="utf-8") as fh:
+                    for line in fh:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            rec = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        if rec.get("event_type") == "offer" and rec.get("dispatch_id") == dispatch_id:
+                            pid = rec.get("pattern_id", "")
+                            fp = rec.get("file_path", "")
+                            if pid:
+                                offered[pid] = fp
+                                offered_titles[pid] = rec.get("title", "") or ""
+                                offered_content[pid] = rec.get("content", "") or ""
+            except OSError as e:
+                log.warning("Failed to read usage log %s: %s", usage_log, e)
+
+        # Merge DB-junction offers (canonical store).  ndjson entries win on
+        # conflict because they carry the file_path needed for the filename
+        # signal; DB rows fill in offers the ndjson writer never logged.
+        for pid, meta in self._db_offers_for_dispatch(dispatch_id).items():
+            if pid not in offered:
+                offered[pid] = meta["file_path"]
+                offered_titles[pid] = meta["title"]
+                offered_content[pid] = meta["content"]
+            else:
+                if not offered_titles.get(pid):
+                    offered_titles[pid] = meta["title"]
+                if not offered_content.get(pid):
+                    offered_content[pid] = meta["content"]
 
         if not offered:
             return {"adoptions": 0, "checked": 0}
@@ -522,11 +560,23 @@ class T0IntelligenceGatherer:
             pass
 
         # Record adoption for patterns whose file_path appears in the report
+        # (filename signal) or — for offers without a file_path, i.e. the
+        # DB-junction store — whose content the report reflects (token-overlap
+        # signal, identical to the WHY path's `used` verdict).
         adoptions = 0
         for pattern_id, fp in offered.items():
             fp_lower = fp.lower() if fp else ""
-            if fp_lower and any(fp_lower.endswith(rf) or rf.endswith(fp_lower.split("/")[-1])
-                                for rf in report_files):
+            file_match = bool(fp_lower) and any(
+                fp_lower.endswith(rf) or rf.endswith(fp_lower.split("/")[-1])
+                for rf in report_files
+            )
+            content_source = offered_content.get(pattern_id) or offered_titles.get(pattern_id) or ""
+            content_match = (
+                not fp_lower
+                and bool(content_source)
+                and _token_overlap_ratio(content_source, text) >= _CONTENT_USE_THRESHOLD
+            )
+            if file_match or content_match:
                 self.record_pattern_adoption(pattern_id, terminal, dispatch_id)
                 adoptions += 1
 
@@ -544,6 +594,83 @@ class T0IntelligenceGatherer:
                 log.debug("Injection WHY instrumentation skipped for %s: %s", dispatch_id, exc)
 
         return {"adoptions": adoptions, "checked": len(offered)}
+
+    def _db_offers_for_dispatch(self, dispatch_id: str) -> Dict[str, Dict[str, str]]:
+        """Read per-dispatch offers from dispatch_pattern_offered (canonical store).
+
+        Returns ``pattern_id -> {"file_path", "title", "content"}``.  The
+        junction stores no file_path, so ``file_path`` is always empty and
+        ``content`` is resolved from the originating catalog row
+        (``intel_ap_N`` -> antipatterns.id N, ``intel_sp_N`` ->
+        success_patterns.id N) for the token-overlap adoption signal.
+        Never raises; a failed lookup is logged at WARNING because an
+        unreadable offer store silently zeroes the adoption measurement.
+        """
+        offers: Dict[str, Dict[str, str]] = {}
+        if not self.quality_db:
+            return offers
+        try:
+            table = self.quality_db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table' "
+                "AND name='dispatch_pattern_offered'"
+            ).fetchone()
+            if not table:
+                return offers
+            rows = self.quality_db.execute(
+                "SELECT pattern_id, pattern_title FROM dispatch_pattern_offered "
+                "WHERE dispatch_id = ?",
+                (dispatch_id,),
+            ).fetchall()
+        except sqlite3.Error as e:
+            log.warning("dispatch_pattern_offered lookup failed for %s: %s", dispatch_id, e)
+            return offers
+        for row in rows:
+            pid = row["pattern_id"] if isinstance(row, sqlite3.Row) else row[0]
+            title = row["pattern_title"] if isinstance(row, sqlite3.Row) else row[1]
+            if not pid:
+                continue
+            offers[pid] = {
+                "file_path": "",
+                "title": title or "",
+                "content": self._resolve_pattern_content(pid),
+            }
+        return offers
+
+    def _resolve_pattern_content(self, pattern_id: str) -> str:
+        """Resolve display content for a catalog-backed pattern_id.
+
+        Maps the intelligence-selector id space back to its source row so
+        DB-junction offers get a token-overlap signal.  Returns "" for ids
+        outside the catalog space or when the row is gone — the caller then
+        falls back to the junction's pattern_title.
+        """
+        if not self.quality_db:
+            return ""
+        table = None
+        row_key = ""
+        if pattern_id.startswith("intel_ap_"):
+            table, row_key = "antipatterns", pattern_id[len("intel_ap_"):]
+        elif pattern_id.startswith("intel_sp_"):
+            table, row_key = "success_patterns", pattern_id[len("intel_sp_"):]
+        if not table:
+            return ""
+        try:
+            row_id = int(row_key)
+        except (TypeError, ValueError):
+            return ""
+        try:
+            row = self.quality_db.execute(
+                f"SELECT title, description FROM {table} WHERE id = ?",
+                (row_id,),
+            ).fetchone()
+        except sqlite3.Error as e:
+            log.debug("Failed to resolve content for pattern %s: %s", pattern_id, e)
+            return ""
+        if row is None:
+            return ""
+        title = row["title"] if isinstance(row, sqlite3.Row) else row[0]
+        description = row["description"] if isinstance(row, sqlite3.Row) else row[1]
+        return f"{title or ''}\n{description or ''}"[:1000]
 
     def _record_injection_why(
         self,

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -240,12 +240,19 @@ _psr_verify_contract() {
 }
 
 # Record pattern adoption signals for completed dispatches (non-fatal, A-5).
+# Non-fatal by contract, but NOT silent (OI-894): a failing adoption recording
+# zeroes the injection-effectiveness measurement, so failures log at WARN with
+# the captured stderr instead of vanishing behind 2>/dev/null.
 _psr_record_adoption() {
     local dispatch_id="$1" terminal="$2" report_path="$3" event_type="$4"
     [ -n "$dispatch_id" ] && [ "$event_type" = "task_complete" ] || return 0
-    python3 "$SCRIPTS_DIR/gather_intelligence.py" record-adoption \
-        "$dispatch_id" "${terminal:-unknown}" "$report_path" 2>/dev/null \
-        || log "DEBUG" "Pattern adoption recording skipped (non-fatal)"
+    local adoption_output adoption_rc
+    adoption_output=$(python3 "$SCRIPTS_DIR/gather_intelligence.py" record-adoption \
+        "$dispatch_id" "${terminal:-unknown}" "$report_path" 2>&1)
+    adoption_rc=$?
+    if [ $adoption_rc -ne 0 ]; then
+        log "WARN" "Pattern adoption recording failed for dispatch=$dispatch_id (rc=$adoption_rc): $(echo "$adoption_output" | tail -1 | head -c 200)"
+    fi
 }
 
 # Process a single report — orchestrates extracted sub-functions.

--- a/tests/test_offer_adoption_store_split.py
+++ b/tests/test_offer_adoption_store_split.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env python3
+"""Regression tests for OI-894 — offer-writer / adoption-reader store split.
+
+The live intelligence-injection path writes per-dispatch offers to the
+``dispatch_pattern_offered`` DB junction (intelligence_sources/_recording.py),
+while ``record_adoption_from_receipt`` historically read offers only from
+``intelligence_usage.ndjson`` — a log the primary dispatcher never populates
+because its ``gather`` call passes no dispatch_id (dispatcher_minimal.sh).
+Result: adoptions could never fire and ``used_count`` stayed frozen while
+``ignored_count`` kept rising.
+
+These tests pin the repaired contract:
+  1. the adoption reader sees DB-junction offers (single source of truth),
+  2. DB and ndjson offers merge without double-counting,
+  3. an adoption UPDATE that matches zero rows is visible (WARNING),
+  4. the adoption UPDATE matches the live ``pattern_id`` space, not only
+     ``pattern_hash``.
+
+On the unfixed code every test in this file fails.
+"""
+from __future__ import annotations
+
+import hashlib
+import sqlite3
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+LIB_DIR = SCRIPT_DIR / "lib"
+sys.path.insert(0, str(SCRIPT_DIR))
+sys.path.insert(0, str(LIB_DIR))
+
+from gather_intelligence import T0IntelligenceGatherer
+
+
+def _make_gatherer(db_path: Path) -> T0IntelligenceGatherer:
+    """Gatherer wired to a real (temp) quality DB, bypassing VNX env setup."""
+    obj = object.__new__(T0IntelligenceGatherer)
+    conn = sqlite3.connect(str(db_path))
+    conn.row_factory = sqlite3.Row
+    obj.quality_db = conn
+    obj.quality_db_path = db_path
+    obj.tag_engine = None
+    obj.agent_directory = []
+    obj.vnx_path = Path("/tmp/vnx")
+    obj.project_root = Path("/tmp/project")
+    return obj
+
+
+def _create_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT,
+            pattern_hash TEXT,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            last_offered TEXT,
+            last_used TEXT,
+            created_at TEXT,
+            updated_at TEXT
+        );
+        CREATE TABLE dispatch_pattern_offered (
+            dispatch_id TEXT NOT NULL,
+            pattern_id TEXT NOT NULL,
+            pattern_title TEXT NOT NULL,
+            offered_at TEXT NOT NULL,
+            PRIMARY KEY (dispatch_id, pattern_id)
+        );
+        CREATE TABLE antipatterns (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            description TEXT
+        );
+        CREATE TABLE success_patterns (
+            id INTEGER PRIMARY KEY,
+            title TEXT,
+            description TEXT
+        );
+        """
+    )
+    conn.commit()
+
+
+def _sha1(text: str) -> str:
+    return hashlib.sha1(text.encode("utf-8")).hexdigest()
+
+
+class _Base(unittest.TestCase):
+    def setUp(self) -> None:
+        self._tmp = tempfile.TemporaryDirectory()
+        self.addCleanup(self._tmp.cleanup)
+        tmp = Path(self._tmp.name)
+        self.db_path = tmp / "quality_intelligence.db"
+        conn = sqlite3.connect(str(self.db_path))
+        _create_schema(conn)
+        conn.close()
+        self.g = _make_gatherer(self.db_path)
+        # Point the legacy ndjson log at a path that does not exist unless a
+        # test creates it — the DB junction must be sufficient on its own.
+        self.ndjson_path = tmp / "intelligence_usage.ndjson"
+        self.report_path = tmp / "report.md"
+        # The WHY instrumentation is additive and off by default; keep it off.
+        env_patch = patch.dict("os.environ", {"VNX_INJECTION_WHY_ENABLED": "0"})
+        env_patch.start()
+        self.addCleanup(env_patch.stop)
+        log_patch = patch.object(self.g, "_usage_log_path", return_value=self.ndjson_path)
+        log_patch.start()
+        self.addCleanup(log_patch.stop)
+
+    def _used_count(self, pattern_id: str) -> int:
+        row = self.g.quality_db.execute(
+            "SELECT used_count FROM pattern_usage WHERE pattern_id = ?",
+            (pattern_id,),
+        ).fetchone()
+        return row["used_count"] if row else -1
+
+
+class TestDbJunctionOffersDriveAdoption(_Base):
+    """Reader must see the offers the live writer actually wrote (DB junction)."""
+
+    def test_db_junction_offer_adopted_increments_used_count(self) -> None:
+        self.g.quality_db.execute(
+            "INSERT INTO antipatterns (id, title, description) VALUES (42, ?, ?)",
+            (
+                "Always validate hook payloads before dispatch",
+                "Unvalidated hook payloads corrupt the dispatch ledger",
+            ),
+        )
+        self.g.quality_db.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash,"
+            " used_count, ignored_count) VALUES (?, ?, ?, 0, 5)",
+            ("intel_ap_42", "Always validate hook payloads before dispatch",
+             _sha1("intel_ap_42")),
+        )
+        self.g.quality_db.execute(
+            "INSERT INTO dispatch_pattern_offered"
+            " (dispatch_id, pattern_id, pattern_title, offered_at)"
+            " VALUES ('d-1', 'intel_ap_42', 'Always validate hook payloads"
+            " before dispatch', '2026-07-31T10:00:00')",
+        )
+        self.g.quality_db.commit()
+        self.report_path.write_text(
+            "# Completion report\n"
+            "Validated the hook payloads before dispatch; the ledger stays"
+            " consistent and no corrupt payload reached dispatch.\n"
+        )
+
+        result = self.g.record_adoption_from_receipt("d-1", "T1", str(self.report_path))
+
+        # The reader must see exactly the offers the DB writer wrote ...
+        self.assertEqual(result["checked"], 1)
+        # ... and the adoption must actually land on the feedback counters.
+        self.assertEqual(result["adoptions"], 1)
+        self.assertEqual(self._used_count("intel_ap_42"), 1)
+        row = self.g.quality_db.execute(
+            "SELECT last_used FROM pattern_usage WHERE pattern_id = 'intel_ap_42'"
+        ).fetchone()
+        self.assertIsNotNone(row["last_used"])
+
+    def test_checked_counts_db_offers_without_ndjson(self) -> None:
+        for i in (1, 2, 3):
+            self.g.quality_db.execute(
+                "INSERT INTO dispatch_pattern_offered VALUES (?, ?, ?, ?)",
+                ("d-2", f"intel_ap_{i}", f"title {i}", "2026-07-31T10:00:00"),
+            )
+        self.g.quality_db.commit()
+        self.report_path.write_text("nothing adopted here\n")
+        result = self.g.record_adoption_from_receipt("d-2", "T1", str(self.report_path))
+        self.assertEqual(result["checked"], 3)
+        self.assertEqual(result["adoptions"], 0)
+
+
+class TestOfferSourcesMerge(_Base):
+    """ndjson (legacy) and DB junction merge per pattern_id — no double count."""
+
+    def test_ndjson_and_db_offers_deduped(self) -> None:
+        self.ndjson_path.write_text(
+            '{"event_type":"offer","dispatch_id":"d-3","pattern_id":"p1",'
+            '"file_path":"scripts/foo.py"}\n'
+        )
+        self.g.quality_db.execute(
+            "INSERT INTO antipatterns (id, title, description) VALUES (7, ?, ?)",
+            ("zzq qzx vwx unrelated jargon", "kqw vzx qxj more unrelated jargon"),
+        )
+        self.g.quality_db.executemany(
+            "INSERT INTO dispatch_pattern_offered VALUES (?, ?, ?, ?)",
+            [
+                ("d-3", "p1", "legacy title", "2026-07-31T10:00:00"),
+                ("d-3", "intel_ap_7", "zzq qzx vwx unrelated jargon",
+                 "2026-07-31T10:00:00"),
+            ],
+        )
+        self.g.quality_db.commit()
+        self.report_path.write_text("edited scripts/foo.py as instructed\n")
+
+        result = self.g.record_adoption_from_receipt("d-3", "T1", str(self.report_path))
+
+        # p1 appears in both stores but counts once; intel_ap_7 only in DB.
+        self.assertEqual(result["checked"], 2)
+        # Filename signal still works for the legacy offer.
+        self.assertEqual(result["adoptions"], 1)
+
+
+class TestAdoptionUpdateVisibility(_Base):
+    """Damping removal: a zero-row adoption UPDATE must be visible."""
+
+    def test_zero_row_adoption_update_logs_warning(self) -> None:
+        self.g.quality_db.execute(
+            "INSERT INTO antipatterns (id, title, description) VALUES (9, ?, ?)",
+            ("Rotate credentials before every release", "Stale credentials leak"),
+        )
+        # Offer exists in the junction but pattern_usage has NO row — the
+        # UPDATE must match zero rows and say so.
+        self.g.quality_db.execute(
+            "INSERT INTO dispatch_pattern_offered VALUES (?, ?, ?, ?)",
+            ("d-4", "intel_ap_9", "Rotate credentials before every release",
+             "2026-07-31T10:00:00"),
+        )
+        self.g.quality_db.commit()
+        self.report_path.write_text(
+            "Rotated the credentials before the release; nothing stale remains.\n"
+        )
+
+        with self.assertLogs("gather_intelligence", level="WARNING") as cm:
+            result = self.g.record_adoption_from_receipt("d-4", "T1", str(self.report_path))
+
+        self.assertEqual(result["adoptions"], 1)
+        self.assertTrue(
+            any("intel_ap_9" in line and "no pattern_usage" in line for line in cm.output),
+            f"expected zero-row adoption warning, got: {cm.output}",
+        )
+
+
+class TestAdoptionKeySpace(_Base):
+    """The adoption UPDATE must match the live pattern_id space, not only hash."""
+
+    def test_adoption_matches_pattern_id_not_only_hash(self) -> None:
+        self.g.quality_db.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash,"
+            " used_count) VALUES (?, ?, ?, 0)",
+            ("intel_ap_5", "some title", _sha1("intel_ap_5")),
+        )
+        self.g.quality_db.commit()
+
+        self.g.record_pattern_adoption("intel_ap_5", "T1", "d-5")
+
+        self.assertEqual(self._used_count("intel_ap_5"), 1)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## OI-894 — Offer-schrijver en adoptie-lezer gebruikten twee verschillende stores

### Verificatie van de guard-hypothese (opdracht: bewijs voor je fixt)

**Bewezen.** `dispatcher_minimal.sh:487` roept `gather_intelligence.py gather` aan met slechts 4 argumenten — geen `dispatch_id`. De guard `if dispatch_id and suggested_patterns:` (regel 773) slaat dus op het primaire dispatch-pad stelselmatig over, terwijl `_register_offered_patterns` onvoorwaardelijk doorschrijft. Tegen de live DB gemeten:

- `dispatch_pattern_offered`: **1238 rijen** met echte dispatch_ids, laatste offer vandaag 20:11 — dit is de levende offer-store (geschreven door `intelligence_sources/_recording.py`).
- `intelligence_usage.ndjson`: **0 offer-events** (2 adoption, 98 confidence_change).
- `pattern_usage.dispatch_id`: NULL op alle 171 rijen.
- `pattern_usage.pattern_id`-ruimte = `intel_ap_N`/`intel_sp_N`; `pattern_hash` = sha1(item_id) — een UPDATE `WHERE pattern_hash = <pattern_id>` matcht dus per constructie nul rijen (dempingslaag 3 eveneens bewezen).

### Keuze: één bron van waarheid

**De adoptie-correlatie leest de DB (`dispatch_pattern_offered`) in plaats van alleen de ndjson.** Motivatie: de live injection-schrijver schrijft de junction onvoorwaardelijk en per-dispatch geïsoleerd, en mag ik niet aanraken; de ndjson-schrijver zit achter een guard op een dispatch_id die de primaire dispatcher nooit meegeeft. De ndjson blijft een legacy, additieve bron (dedupe per pattern_id; ndjson wint omdat die `file_path` draagt).

### Wijzigingen (alleen toegestane bestanden)

`scripts/gather_intelligence.py`:
- `record_adoption_from_receipt` merget DB-junction-offers met ndjson-offers. DB-offers hebben geen `file_path`; correlatie loopt via dezelfde token-overlap-heuristiek (`_CONTENT_USE_THRESHOLD`) die het WHY-pad voor zijn `used`-verdict gebruikt, met content opgelost uit de bronrij (`intel_ap_N`→antipatterns, `intel_sp_N`→success_patterns).
- `record_pattern_adoption`: UPDATE matcht nu `pattern_hash = ? OR pattern_id = ?`, en een **zero-row update logt WARNING** (onzichtbare nul-rij-updates zijn precies hoe de meting stuk ging).
- `sqlite3.Error` op de adoptie-update: `log.debug` → `log.warning`.
- Kapotte junction-lookup en onleesbare ndjson: WARNING i.p.v. stil nul-resultaat.

`scripts/receipt_processor.sh`:
- Dempingslaag 1 weg: geen `2>/dev/null || log DEBUG` meer — stderr wordt gevangen en bij rc≠0 als WARN gelogd met de foutmelding.

### Datapad-bewijs (echte schrijver + echte CLI, sandbox state-dir)

Schrijfzijde: `record_pattern_usage` (de productie-schrijver). Leeszijde: `gather_intelligence.py record-adoption` (wat receipt_processor aanroept).

| | offers_in_db | reader ziet | adoptions | used_count |
|---|---|---|---|---|
| origin/main | 1 | **0** | 0 | 0 (blijft) |
| deze branch | 1 | **1** | 1 | **1** |

### Regressietest rood op origin/main

`tests/test_offer_adoption_store_split.py` (5 tests) naar een verse worktree op `origin/main` gekopieerd: **5 failed**. Op deze branch: 5 passed, plus alle 9 bestaande `test_gather_intelligence_exception_handling.py`-tests groen. Lint-gate (`ci_lint_patterns.py`) groen; geen `# noqa:` gebruikt.

### Wat dit NIET doet

Probe-drempel en DREAM-gate onaangeroerd. Bestaande data blijft wat het is: de historische ignore-rate van 0,983 blijft staan tot nieuwe offers/adopties de teller bijwerken — de meting is gerepareerd, niet de uitslag. Of de echte adoptie-rate boven of onder 0,90 uitkomt, wordt vanaf nu eerlijk gemeten.

Pre-existing failures (ook rood op clean main, niet door deze wijziging): 3 tests in `test_codex_pr311_findings.py`, 12 in de receipt_processor bootstrap/mirror/lease suites.