### PR TITLE
fix(review-gates): wire declared gates to evidence via obligations (OI-876/OI-881)

### DIFF
--- a/configs/producer_freshness.yaml
+++ b/configs/producer_freshness.yaml
@@ -48,6 +48,23 @@ producers:
       timestamp_field: timestamp
       label: dispatch_register events
 
+  # --- Review-gate obligations (OI-876/OI-881, 2026-07-31) -------------------
+  # One obligation per door-accepted dispatch that declares gate=<name>
+  # (scripts/lib/gate_obligations.py, written by the dispatch door; fulfilled
+  # by scripts/gate_obligation_runner.py). Key = gate name. A key goes stale
+  # when its OLDEST pending declaration exceeds cadence: a declared gate that
+  # produced no request/result record is a finding, per sleutel — a live
+  # sibling gate can no longer hide a dead one behind directory-level mtime.
+  - name: review_gate_obligations
+    type: gate_obligations
+    path: "{state_dir}/review_gates/obligations"
+    cadence_seconds: 86400
+    demand:
+      type: ndjson_events
+      path: "{state_dir}/dispatch_register.ndjson"
+      timestamp_field: timestamp
+      label: dispatch_register events
+
   # --- Dispatch producers in runtime_coordination.db -----------------------
   # Key = producer prefix of dispatch_id (text before the first '-').
   # expected_keys makes a producer that writes NOTHING visible: an absent

--- a/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
+++ b/docs/operations/PRODUCER_FRESHNESS_MONITOR.md
@@ -22,6 +22,7 @@ de `dlv-`-producent terwijl de dispatch-deur sinds 16-07 niets meer schreef).
 | — | Sweep-CLI + heartbeat | `scripts/producer_freshness_monitor.py` |
 | — | Domme tripwire (bash + `find -mmin` only) | `hooks/monitor_tripwire.sh` |
 | — | Dagelijkse scheduling | `scripts/launchd/com.vnx.producer-freshness-monitor.plist` |
+| 5 | Gate-obligaties: declaratie ↔ bewijs (OI-876/OI-881) | `scripts/lib/gate_obligations.py` + `scripts/gate_obligation_runner.py` + `scripts/launchd/com.vnx.gate-obligation-runner.plist` |
 
 ## 1. Per-sleutel versheidsdiff
 
@@ -43,6 +44,30 @@ Output is NDJSON (`<state_dir>/producer_freshness.ndjson`): één
 `producer_freshness_sweep`-samenvatting plus één `producer_freshness_finding` per
 stille/missende sleutel. NDJSON houdt ADR-007 (composite UNIQUE/PK voor nieuwe
 centrale-DB-tabellen) buiten schot — de monitor opent geen centrale-DB-schrijfpad.
+
+## 1b. Gate-obligaties (OI-876/OI-881)
+
+De derde producentgroep in de registry, `review_gate_obligations`
+(type `gate_obligations`), toetst elke **gedeclareerde** gate aan een
+**daadwerkelijk resultaat** — de duurzame fix voor het incident van 31-07:
+
+1. **De deur registreert.** `dispatch_cli.run_dispatch` schrijft voor elke
+   geaccepteerde dispatch met `gate=<naam>` één obligatie
+   (`<state_dir>/review_gates/obligations/<dispatch_id>.json`, status
+   `pending`). Vóór deze fix overleefde `spec.gate` de `load_spec` niet — de
+   declaratie verdween zonder dat iets hem las.
+2. **De runner vervult.** `scripts/gate_obligation_runner.py` (launchd, elke
+   15 min) resolveert de PR van de dispatch (obligatie → `dispatch_metadata`
+   → `gh pr list --head dispatch/<id>`) en draait exact de gedeclareerde gate
+   via `review_gate_manager.request_and_execute`. Kan de gate niet draaien,
+   dan is dat een **luide, geregistreerde uitkomst**: request- én
+   result-record met status `not_executable` plus skip-rationale-audit.
+   Stilte is geen eindtoestand meer.
+3. **De monitor toetst per sleutel.** De scanner groepeert obligaties op
+   gate-naam: `last_seen` = de oudste nog-pendende declaratie (of, als alles
+   vervuld is, de nieuwste resolutie). Een declaratie zonder resultaat binnen
+   cadans → stale-finding voor díé gate — een levende zuster-gate maskeert een
+   dode niet meer (de les uit OI-881).
 
 ## 2. Exit-status-capture
 

--- a/scripts/gate_obligation_runner.py
+++ b/scripts/gate_obligation_runner.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""gate_obligation_runner.py — fulfil declared review-gate obligations.
+
+OI-876 / OI-881: a dispatch spec that declares ``gate=<name>`` must produce a
+review-gate request record AND a result record. The dispatch door registers
+one obligation per such dispatch (``scripts/lib/gate_obligations.py``); this
+runner fulfils them:
+
+  1. Resolve the dispatch's PR number — from the obligation itself (rework
+     dispatches carry spec.pr_id), from the dispatch_metadata row the receipt
+     pipeline stamps, or from GitHub by head branch (``dispatch/<id>``).
+  2. Invoke ``review_gate_manager.request_and_execute`` for exactly the
+     declared gate — the same path ``vnx gate`` / ``t0_gate_enforcement.sh``
+     use — so the request record and the result record land in
+     ``review_gates/requests`` / ``review_gates/results``.
+  3. If the gate cannot run, that is a LOUD, REGISTERED outcome:
+     ``gate_recorder.record_not_executable`` writes both records with status
+     ``not_executable`` plus a skip-rationale audit entry. Silence is not an
+     end state.
+  4. If no PR exists yet the obligation stays ``pending`` — and the producer
+     freshness monitor (``review_gate_obligations`` producer) flags the gate
+     key once the oldest pending declaration exceeds cadence.
+
+Scheduling: launchd ``com.vnx.gate-obligation-runner.plist`` (StartInterval
+900s); also safe to run manually at any time — fulfilment is idempotent
+(terminal obligations are never re-run).
+
+Exit codes: 0 = no pending obligations remain after this run;
+11 = one or more obligations still pending (PR unresolved);
+20 = state dir / configuration error.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import shutil
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+
+from gate_obligations import (  # noqa: E402
+    STATUS_FULFILLED,
+    STATUS_NOT_EXECUTABLE,
+    STATUS_PENDING,
+    TERMINAL_STATUSES,
+    iter_obligations,
+    pr_number_from_pr_id,
+    update_obligation,
+)
+
+_LOG = logging.getLogger("gate_obligation_runner")
+
+_GH_TIMEOUT_SECONDS = 20
+
+
+def utc_now_iso() -> str:
+    from datetime import datetime, timezone  # noqa: PLC0415
+
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+# ---------------------------------------------------------------------------
+# PR / branch resolution
+# ---------------------------------------------------------------------------
+
+
+def _pr_from_dispatch_metadata(state_dir: Path, dispatch_id: str) -> Optional[int]:
+    """Read the pr_id the receipt pipeline stamped for this dispatch (read-only)."""
+    db_path = Path(state_dir) / "quality_intelligence.db"
+    if not db_path.exists():
+        return None
+    try:
+        conn = sqlite3.connect(f"file:{db_path}?mode=ro", uri=True, timeout=5.0)
+        try:
+            row = conn.execute(
+                "SELECT pr_id FROM dispatch_metadata "
+                "WHERE dispatch_id = ? AND pr_id IS NOT NULL AND pr_id != '' "
+                "ORDER BY id DESC LIMIT 1",
+                (dispatch_id,),
+            ).fetchone()
+        finally:
+            conn.close()
+    except sqlite3.Error as exc:
+        _LOG.debug("dispatch_metadata lookup failed for %s: %s", dispatch_id, exc)
+        return None
+    if not row:
+        return None
+    return pr_number_from_pr_id(str(row[0]))
+
+
+def _gh_json(args: List[str]) -> Optional[Any]:
+    """Run a gh CLI command, returning parsed JSON or None on any failure."""
+    if shutil.which("gh") is None:
+        return None
+    try:
+        proc = subprocess.run(
+            ["gh", *args],
+            capture_output=True, text=True, timeout=_GH_TIMEOUT_SECONDS, check=False,
+        )
+    except (subprocess.TimeoutExpired, OSError) as exc:
+        _LOG.debug("gh %s failed: %s", args[:2], exc)
+        return None
+    if proc.returncode != 0 or not proc.stdout.strip():
+        return None
+    try:
+        return json.loads(proc.stdout)
+    except json.JSONDecodeError:
+        return None
+
+
+def _pr_from_github(dispatch_id: str) -> Optional[int]:
+    """Find the open/merged PR whose head branch is dispatch/<dispatch_id>."""
+    data = _gh_json(
+        ["pr", "list", "--state", "all", "--head", f"dispatch/{dispatch_id}",
+         "--json", "number", "--limit", "1"]
+    )
+    if isinstance(data, list) and data:
+        number = data[0].get("number")
+        if isinstance(number, int):
+            return number
+    return None
+
+
+def _branch_from_github(pr_number: int) -> Optional[str]:
+    data = _gh_json(["pr", "view", str(pr_number), "--json", "headRefName"])
+    if isinstance(data, dict):
+        branch = data.get("headRefName")
+        if isinstance(branch, str) and branch.strip():
+            return branch.strip()
+    return None
+
+
+def resolve_pr_number(state_dir: Path, record: Dict[str, Any]) -> Optional[int]:
+    """Resolve the obligation's PR number from every available source."""
+    pr_number = record.get("pr_number")
+    if isinstance(pr_number, int) and pr_number > 0:
+        return pr_number
+    dispatch_id = str(record.get("dispatch_id") or "")
+    if not dispatch_id:
+        return None
+    return (
+        _pr_from_dispatch_metadata(state_dir, dispatch_id)
+        or _pr_from_github(dispatch_id)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fulfilment
+# ---------------------------------------------------------------------------
+
+
+def _build_manager(state_dir: Path):
+    """Construct a ReviewGateManager pinned to the runner's state dir.
+
+    ensure_env() only fills MISSING env keys, so pinning VNX_DATA_DIR /
+    VNX_STATE_DIR before the import-time path resolution makes the manager
+    write into exactly the store this runner was pointed at — never into an
+    ambient default store.
+    """
+    state_dir = Path(state_dir)
+    # VNX_STATE_DIR is honored directly by resolve_paths(); VNX_DATA_DIR only
+    # via the explicit-override pair. Pin both so a runner pointed at store X
+    # can never scatter request/result/report paths across an ambient store.
+    os.environ["VNX_STATE_DIR"] = str(state_dir)
+    os.environ["VNX_DATA_DIR"] = str(state_dir.parent)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
+    from review_gate_manager import ReviewGateManager  # noqa: PLC0415
+
+    return ReviewGateManager()
+
+
+def _record_loud_not_executable(
+    state_dir: Path,
+    *,
+    gate: str,
+    pr_number: int,
+    dispatch_id: str,
+    reason: str,
+    reason_detail: str,
+) -> Dict[str, Any]:
+    """Write the loud request+result records for a gate that could not run."""
+    from gate_recorder import record_not_executable  # noqa: PLC0415
+
+    # The manager's own __init__ normally creates these, but we land here
+    # precisely when the manager could not run — never let a missing dir turn
+    # the loud failure path into a silent one.
+    requests_dir = Path(state_dir) / "review_gates" / "requests"
+    results_dir = Path(state_dir) / "review_gates" / "results"
+    requests_dir.mkdir(parents=True, exist_ok=True)
+    results_dir.mkdir(parents=True, exist_ok=True)
+
+    request_payload: Dict[str, Any] = {
+        "gate": gate,
+        "pr_number": pr_number,
+        "dispatch_id": dispatch_id,
+        "mode": "per_pr",
+        "origin": "gate_obligation_runner",
+        "requested_at": utc_now_iso(),
+    }
+    return record_not_executable(
+        gate=gate,
+        pr_number=pr_number,
+        pr_id="",
+        reason=reason,
+        reason_detail=reason_detail,
+        request_payload=request_payload,
+        requests_dir=requests_dir,
+        results_dir=results_dir,
+        state_dir=Path(state_dir),
+    )
+
+
+def fulfill_obligation(state_dir: Path, path: Path, record: Dict[str, Any]) -> Dict[str, Any]:
+    """Attempt fulfilment of one pending obligation.
+
+    Returns a per-obligation outcome dict. Never raises: every failure mode
+    is either recorded loudly (gate unreachable → not_executable records) or
+    leaves the obligation pending for the freshness monitor to flag.
+    """
+    state_dir = Path(state_dir)
+    dispatch_id = str(record.get("dispatch_id") or path.stem)
+    gate = str(record.get("gate") or "")
+    outcome: Dict[str, Any] = {
+        "dispatch_id": dispatch_id,
+        "gate": gate,
+        "action": "pending",
+    }
+    if not gate:
+        outcome["action"] = "error"
+        outcome["detail"] = "obligation has no gate"
+        return outcome
+
+    attempts = int(record.get("attempts") or 0) + 1
+    now = utc_now_iso()
+
+    pr_number = resolve_pr_number(state_dir, record)
+    if pr_number is None:
+        update_obligation(path, attempts=attempts, last_attempt_at=now)
+        outcome["detail"] = "no PR resolvable yet — stays pending for the freshness monitor"
+        return outcome
+
+    branch = (
+        str(record.get("branch") or "").strip()
+        or (_branch_from_github(pr_number) or "")
+        or f"dispatch/{dispatch_id}"
+    )
+
+    # Scope context for the reviewers: best-effort diff; an unresolvable
+    # branch degrades to an empty changed-files list, never to a skip.
+    changed_files: List[str] = []
+    try:
+        from review_gate_manager import _compute_changed_files  # noqa: PLC0415
+
+        changed_files = _compute_changed_files(branch)
+    except Exception as exc:  # noqa: BLE001 — degraded scope, not silence
+        _LOG.info("changed-files unavailable for %s: %s", branch, exc)
+
+    try:
+        manager = _build_manager(state_dir)
+        result = manager.request_and_execute(
+            pr_number=pr_number,
+            branch=branch,
+            review_stack=[gate],
+            risk_class="medium",
+            changed_files=changed_files,
+            mode="per_pr",
+            dispatch_id=dispatch_id,
+        )
+        result_file = manager._result_path(gate, pr_number)
+        # Mirror the recorded outcome: a gate the manager could not execute
+        # leaves a loud not_executable/failed RESULT record — the obligation
+        # must tell the same truth, not a cosmetic "fulfilled".
+        result_status = ""
+        try:
+            if result_file.exists():
+                result_status = str(json.loads(result_file.read_text(encoding="utf-8")).get("status") or "")
+        except (OSError, json.JSONDecodeError) as exc:
+            _LOG.debug("result status unreadable for pr-%s-%s: %s", pr_number, gate, exc)
+        terminal = result_status if result_status in TERMINAL_STATUSES else STATUS_FULFILLED
+        updated = update_obligation(
+            path,
+            status=terminal,
+            pr_number=pr_number,
+            branch=branch,
+            attempts=attempts,
+            last_attempt_at=now,
+            resolved_at=utc_now_iso(),
+            request_path=str(manager._request_path(gate, pr_number)),
+            result_path=str(result_file),
+            reason=None if not result.get("has_required_failure") else "required_failure",
+            reason_detail=None if terminal == STATUS_FULFILLED else f"result status: {result_status}",
+        )
+        outcome["action"] = "fulfilled"
+        outcome["request_path"] = updated.get("request_path")
+        outcome["result_path"] = updated.get("result_path")
+        outcome["has_required_failure"] = bool(result.get("has_required_failure"))
+        return outcome
+    except Exception as exc:  # noqa: BLE001 — a gate that cannot run is a loud registered outcome
+        result_payload = _record_loud_not_executable(
+            state_dir,
+            gate=gate,
+            pr_number=pr_number,
+            dispatch_id=dispatch_id,
+            reason="runner_error",
+            reason_detail=f"{type(exc).__name__}: {exc}",
+        )
+        update_obligation(
+            path,
+            status=STATUS_NOT_EXECUTABLE,
+            pr_number=pr_number,
+            branch=branch,
+            attempts=attempts,
+            last_attempt_at=now,
+            resolved_at=utc_now_iso(),
+            result_path=str(
+                Path(state_dir) / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+            ),
+            reason="runner_error",
+            reason_detail=result_payload.get("reason_detail"),
+        )
+        outcome["action"] = "not_executable"
+        outcome["detail"] = result_payload.get("reason_detail")
+        return outcome
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def run(state_dir: Path, *, write: bool = True) -> Dict[str, Any]:
+    """Fulfil every pending obligation under ``state_dir``. Returns a summary."""
+    state_dir = Path(state_dir)
+    outcomes: List[Dict[str, Any]] = []
+    pending_after = 0
+    try:
+        obligations = list(iter_obligations(state_dir))
+    except ValueError as exc:
+        # An unreadable obligation is surfaced, not skipped — same contract
+        # as the freshness monitor's source_unreadable finding.
+        return {
+            "state_dir": str(state_dir),
+            "error": str(exc),
+            "outcomes": [],
+            "pending_after": -1,
+        }
+    for path, record in obligations:
+        if record.get("status", STATUS_PENDING) in TERMINAL_STATUSES:
+            continue
+        if not write:
+            outcomes.append(
+                {
+                    "dispatch_id": record.get("dispatch_id") or path.stem,
+                    "gate": record.get("gate"),
+                    "action": "would_fulfill",
+                }
+            )
+            pending_after += 1
+            continue
+        outcome = fulfill_obligation(state_dir, path, record)
+        outcomes.append(outcome)
+        if outcome["action"] == "pending":
+            pending_after += 1
+    return {
+        "state_dir": str(state_dir),
+        "timestamp": utc_now_iso(),
+        "obligations_seen": len(obligations),
+        "outcomes": outcomes,
+        "pending_after": pending_after,
+    }
+
+
+def _default_state_dir() -> Path:
+    from vnx_paths import ensure_env  # noqa: PLC0415
+
+    return Path(ensure_env()["VNX_STATE_DIR"])
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--state-dir", type=Path, default=None,
+        help="VNX state dir (default: resolved via vnx_paths ensure_env)",
+    )
+    parser.add_argument(
+        "--no-write", action="store_true",
+        help="Dry run: report pending obligations without fulfilling them",
+    )
+    parser.add_argument("--json", action="store_true", help="Machine-readable output")
+    parser.add_argument("--verbose", action="store_true")
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.WARNING,
+        format="%(name)s: %(levelname)s: %(message)s",
+    )
+
+    state_dir = args.state_dir or _default_state_dir()
+    if not Path(state_dir).is_dir():
+        print(f"ERROR: state dir not found: {state_dir}", file=sys.stderr)
+        return 20
+
+    summary = run(state_dir, write=not args.no_write)
+    if args.json:
+        print(json.dumps(summary, indent=2))
+    else:
+        if summary.get("error"):
+            print(f"ERROR: {summary['error']}", file=sys.stderr)
+        for outcome in summary["outcomes"]:
+            line = f"{outcome['action']}: {outcome.get('dispatch_id')} gate={outcome.get('gate')}"
+            if outcome.get("request_path"):
+                line += f" request={outcome['request_path']}"
+            if outcome.get("result_path"):
+                line += f" result={outcome['result_path']}"
+            if outcome.get("detail"):
+                line += f" ({outcome['detail']})"
+            print(line)
+        print(
+            f"obligations={summary['obligations_seen']} "
+            f"pending_after={summary['pending_after']}"
+        )
+
+    if summary.get("error"):
+        return 20
+    return 11 if summary["pending_after"] > 0 else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN"
+  "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>Label</key><string>com.vnx.gate-obligation-runner</string>
+  <!--
+    Review-gate obligation fulfilment (OI-876/OI-881). Every 15 minutes,
+    fulfils pending gate obligations the dispatch door registered for specs
+    declaring gate=<name>: resolves the dispatch's PR and runs the declared
+    gate via review_gate_manager, or records a loud not_executable outcome.
+
+    Replace __VNX_REPO_ROOT__ with the repo checkout path at install time
+    (same placeholder pattern as com.vnx.producer-freshness-monitor.plist):
+
+      sed "s|__VNX_REPO_ROOT__|$HOME/Development/vnx-orchestration|g" \
+        com.vnx.gate-obligation-runner.plist > ~/Library/LaunchAgents/
+      launchctl load -w ~/Library/LaunchAgents/com.vnx.gate-obligation-runner.plist
+
+    Exit 11 (obligations still pending) is captured into job_exits.ndjson by
+    the producer-freshness monitor's launchd harvest; obligations pending
+    longer than a day are flagged per gate key by the same monitor's
+    review_gate_obligations producer — a runner that dies cannot hide behind
+    silence.
+  -->
+  <key>ProgramArguments</key>
+  <array>
+    <string>/bin/bash</string>
+    <string>-c</string>
+    <string>cd __VNX_REPO_ROOT__ &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
+  </array>
+  <key>StartInterval</key>
+  <integer>900</integer>
+  <key>StandardOutPath</key><string>/tmp/vnx-gate-obligation-runner.log</string>
+  <key>StandardErrorPath</key><string>/tmp/vnx-gate-obligation-runner.err</string>
+</dict>
+</plist>

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -787,6 +787,37 @@ def _persist_dispatch_row(spec: DispatchSpec, *, state_dir: Path) -> None:
         logger.debug("[dispatch_cli] dispatch row persist skipped: %s", exc)
 
 
+def _register_gate_obligation(spec: DispatchSpec, *, state_dir: Path) -> None:
+    """Best-effort: register the review-gate obligation for a door-accepted dispatch.
+
+    OI-876/OI-881: before this hook, ``spec.gate`` was read exactly once (by
+    ``load_spec``) and then never consumed — a dispatch could declare
+    ``gate=codex_gate`` and produce zero request/result records while looking
+    identical to one whose gate ran. The obligation record (one JSON file per
+    dispatch under ``state/review_gates/obligations/``) is what
+    ``scripts/gate_obligation_runner.py`` fulfils and what the producer
+    freshness monitor asserts per gate key: declaration without evidence
+    becomes visible instead of silent.
+
+    Never raises: bookkeeping must never block the door (same contract as
+    ``_persist_dispatch_row``).
+    """
+    gate = (spec.gate or "").strip()
+    if not gate:
+        return
+    try:
+        from gate_obligations import pr_number_from_pr_id, register_obligation
+        register_obligation(
+            state_dir,
+            dispatch_id=spec.dispatch_id,
+            gate=gate,
+            project_id=spec.project_id,
+            pr_number=pr_number_from_pr_id(spec.pr_id),
+        )
+    except Exception as exc:  # noqa: BLE001 — door bookkeeping must never raise
+        logger.debug("[dispatch_cli] gate obligation register skipped: %s", exc)
+
+
 def _persist_track_id(spec: DispatchSpec, *, state_dir: Path) -> None:
     """Best-effort: attach spec.track_id to an EXISTING dispatches row (UPDATE-only).
 
@@ -1306,6 +1337,12 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             # (retry/fix-forward safe), state='proposed' (invisible to the
             # claim/stuck/ghost sweeps), best-effort — never blocks the door.
             _persist_dispatch_row(vspec.spec, state_dir=state_dir)
+
+            # OI-876/OI-881: a declared gate is an obligation, not decoration.
+            # Registered here — right after the dispatch is irrevocably
+            # accepted — so every accepted dispatch with gate=<name> has a
+            # checkable evidence trail from this point on.
+            _register_gate_obligation(vspec.spec, state_dir=state_dir)
 
             # TL-D1: export the resolved track_id alongside VNX_CURRENT_DISPATCH_ID and
             # persist it onto the dispatch tracker row so D2 can propagate it to

--- a/scripts/lib/gate_obligations.py
+++ b/scripts/lib/gate_obligations.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""gate_obligations.py — review-gate obligations: the durable link between a
+``gate=<name>`` declaration in a dispatch spec and actual review-gate evidence.
+
+OI-876 / OI-881 (2026-07-31): the dispatch spec carried ``gate=codex_gate`` all
+the way into the staged bundle, but after ``dispatch_cli.load_spec`` read the
+field nothing consumed it — nine dispatches and ten merged PRs produced zero
+request records and zero result records while every one of them declared a
+gate. A dispatch whose declared gate never ran was indistinguishable from one
+whose gate did run.
+
+This module is the registry half of the fix:
+
+  1. The dispatch door (``dispatch_cli.run_dispatch``) calls
+     :func:`register_obligation` for every accepted dispatch whose spec
+     declares a gate. One obligation record per dispatch, written to
+     ``<state_dir>/review_gates/obligations/<dispatch_id>.json``.
+  2. ``scripts/gate_obligation_runner.py`` fulfils pending obligations: it
+     resolves the dispatch's PR and invokes ``review_gate_manager`` so the
+     request record AND the result record actually land — or, when the gate
+     cannot run, records a loud ``not_executable``/``failed`` outcome via
+     ``gate_recorder`` (which also writes both records). Silence is no longer
+     a possible end state.
+  3. ``producer_freshness.scan_gate_obligations`` groups obligations per gate
+     key and flags a key whose oldest pending declaration exceeds cadence —
+     declaration without evidence becomes a finding, per sleutel, never per
+     directory.
+
+Design notes:
+  - Best-effort at the door: :func:`register_obligation` never raises; the
+    door must never be blocked by bookkeeping (same contract as
+    ``_persist_dispatch_row``).
+  - Idempotent: re-registering an existing obligation (retry / fix-forward
+    with the same dispatch_id) leaves the existing record untouched — a
+    fulfilled obligation is never reset to pending.
+  - Atomic writes: tmp-file + ``os.replace`` (lint pattern B).
+  - No central-DB write path: plain JSON files under the state dir, keeping
+    ADR-007 out of scope exactly like the review_gates requests/results
+    directories themselves.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterator, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+OBLIGATIONS_SUBDIR = Path("review_gates") / "obligations"
+
+STATUS_PENDING = "pending"
+STATUS_FULFILLED = "fulfilled"
+STATUS_NOT_EXECUTABLE = "not_executable"
+STATUS_FAILED = "failed"
+
+TERMINAL_STATUSES = frozenset({STATUS_FULFILLED, STATUS_NOT_EXECUTABLE, STATUS_FAILED})
+
+# Whole-string match: bare digits, or the PR-<digits> family. Contract slugs
+# like "pr-4d" must NOT resolve to PR 4 — they are not GitHub PRs.
+_PR_NUMBER_RE = re.compile(r"^(?:#|PR[- ]?#?)?(\d+)$", re.IGNORECASE)
+
+
+def obligations_dir(state_dir: Path) -> Path:
+    return Path(state_dir) / OBLIGATIONS_SUBDIR
+
+
+def obligation_path(state_dir: Path, dispatch_id: str) -> Path:
+    return obligations_dir(state_dir) / f"{dispatch_id}.json"
+
+
+def pr_number_from_pr_id(pr_id: Optional[str]) -> Optional[int]:
+    """Extract an integer PR number from a pr_id string.
+
+    Accepts the shapes the fabric actually uses: ``"879"``, ``"PR-879"``,
+    ``"pr879"``, ``"#879"``. Returns None when no digits are present (e.g.
+    contract slugs like ``pr-4d`` — those are not GitHub PRs).
+    """
+    if not pr_id:
+        return None
+    match = _PR_NUMBER_RE.match(str(pr_id).strip())
+    if match is None:
+        return None
+    try:
+        return int(match.group(1))
+    except ValueError:
+        return None
+
+
+def _utc_now_iso() -> str:
+    # Stdlib-only on purpose: this module is imported by the dispatch door,
+    # which must never fail on a transitive scripts/-side import chain.
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp_name = tempfile.mkstemp(dir=str(path.parent), prefix=path.name, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(payload, indent=2))
+            fh.write("\n")
+        os.replace(tmp_name, path)
+    except BaseException:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            logger.debug("gate_obligations: tmp cleanup failed for %s", tmp_name)
+        raise
+
+
+def register_obligation(
+    state_dir: Path,
+    *,
+    dispatch_id: str,
+    gate: str,
+    project_id: str = "",
+    pr_number: Optional[int] = None,
+    branch: Optional[str] = None,
+) -> Optional[Path]:
+    """Register the review-gate obligation for a door-accepted dispatch.
+
+    Returns the obligation path, or None when the registration was skipped
+    (empty gate/dispatch_id, or an OS error — this function NEVER raises;
+    obligation bookkeeping must never block the door).
+
+    Idempotent: an existing obligation for the same dispatch_id is left
+    untouched, so a retry never resets a fulfilled obligation to pending.
+    """
+    gate = (gate or "").strip()
+    dispatch_id = (dispatch_id or "").strip()
+    if not gate or not dispatch_id:
+        return None
+    try:
+        path = obligation_path(state_dir, dispatch_id)
+        if path.exists():
+            return path
+        record: Dict[str, Any] = {
+            "schema_version": 1,
+            "kind": "review_gate_obligation",
+            "dispatch_id": dispatch_id,
+            "gate": gate,
+            "project_id": project_id or "",
+            "declared_at": _utc_now_iso(),
+            "pr_number": pr_number,
+            "branch": branch,
+            "status": STATUS_PENDING,
+            "attempts": 0,
+            "last_attempt_at": None,
+            "resolved_at": None,
+            "request_path": None,
+            "result_path": None,
+            "reason": None,
+            "reason_detail": None,
+        }
+        _atomic_write_json(path, record)
+        return path
+    except OSError as exc:
+        logger.warning(
+            "gate_obligations: registration failed for dispatch=%s gate=%s (non-fatal): %s",
+            dispatch_id, gate, exc,
+        )
+        return None
+
+
+def iter_obligations(state_dir: Path) -> Iterator[Tuple[Path, Dict[str, Any]]]:
+    """Yield (path, record) for every readable obligation, sorted by name.
+
+    Unreadable files raise ValueError — an obligation that cannot be read is
+    exactly the class of silent-evidence failure this mechanism exists to
+    expose, so callers (the freshness scanner) surface it as a finding
+    instead of skipping it.
+    """
+    root = obligations_dir(state_dir)
+    if not root.is_dir():
+        return
+    for entry in sorted(root.glob("*.json")):
+        if not entry.is_file():
+            continue
+        try:
+            record = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"unreadable gate obligation {entry.name}: {exc}") from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"gate obligation {entry.name} is not a JSON object")
+        yield entry, record
+
+
+def update_obligation(path: Path, **fields: Any) -> Dict[str, Any]:
+    """Atomically merge ``fields`` into an existing obligation record.
+
+    Returns the updated record. Raises OSError/ValueError on unreadable or
+    malformed existing content — the runner treats that as a loud failure,
+    never a skip.
+    """
+    path = Path(path)
+    try:
+        record = json.loads(path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        raise ValueError(f"cannot update unreadable gate obligation {path.name}: {exc}") from exc
+    if not isinstance(record, dict):
+        raise ValueError(f"gate obligation {path.name} is not a JSON object")
+    record.update(fields)
+    _atomic_write_json(path, record)
+    return record
+
+
+__all__ = [
+    "OBLIGATIONS_SUBDIR",
+    "STATUS_PENDING",
+    "STATUS_FULFILLED",
+    "STATUS_NOT_EXECUTABLE",
+    "STATUS_FAILED",
+    "TERMINAL_STATUSES",
+    "obligations_dir",
+    "obligation_path",
+    "pr_number_from_pr_id",
+    "register_obligation",
+    "iter_obligations",
+    "update_obligation",
+]

--- a/scripts/lib/producer_freshness.py
+++ b/scripts/lib/producer_freshness.py
@@ -198,9 +198,67 @@ def scan_sqlite(spec: Dict[str, Any], *, now: float) -> Dict[str, Optional[float
     return out
 
 
+def scan_gate_obligations(spec: Dict[str, Any], *, now: float) -> Dict[str, Optional[float]]:
+    """Group review-gate obligations by gate name (OI-876/OI-881).
+
+    An obligation is one JSON file per door-accepted dispatch that declared
+    ``gate=<name>`` (scripts/lib/gate_obligations.py). The key is the gate
+    name — per sleutel, never per directory, so one live gate cannot hide a
+    dead sibling.
+
+    Per-key ``last_seen`` semantics — declaration checked against evidence:
+
+      - if any obligation for the key is still ``pending``, last_seen = the
+        OLDEST pending declaration. A declared gate that produced no result
+        within cadence then reads as stale: exactly the 2026-07-31 incident
+        (nine dispatches declared codex_gate, zero ran, nothing noticed).
+      - otherwise last_seen = the NEWEST terminal resolution (fulfilled /
+        not_executable / failed) — loud non-execution counts as evidence.
+
+    An unreadable obligation raises ValueError so the caller records a
+    source_unreadable finding: a corrupted evidence trail must never read as
+    "nothing to do".
+    """
+    root = Path(spec["path"])
+    out: Dict[str, Optional[float]] = {}
+    if not root.is_dir():
+        return out
+    pending_oldest: Dict[str, float] = {}
+    resolved_newest: Dict[str, float] = {}
+    for entry in sorted(root.glob("*.json")):
+        if not entry.is_file():
+            continue
+        try:
+            record = json.loads(entry.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as exc:
+            raise ValueError(f"unreadable gate obligation {entry.name}: {exc}") from exc
+        if not isinstance(record, dict):
+            raise ValueError(f"gate obligation {entry.name} is not a JSON object")
+        key = str(record.get("gate") or entry.stem)
+        status = record.get("status", "pending")
+        if status == "pending":
+            ts = _parse_ts(record.get("declared_at"))
+            if ts is None:
+                ts = entry.stat().st_mtime
+            prev = pending_oldest.get(key)
+            if prev is None or ts < prev:
+                pending_oldest[key] = ts
+        else:
+            ts = _parse_ts(record.get("resolved_at"))
+            if ts is None:
+                ts = entry.stat().st_mtime
+            prev = resolved_newest.get(key)
+            if prev is None or ts > prev:
+                resolved_newest[key] = ts
+    for key in set(pending_oldest) | set(resolved_newest):
+        out[key] = pending_oldest.get(key, resolved_newest.get(key))
+    return out
+
+
 _SCANNERS: Dict[str, Callable[..., Dict[str, Optional[float]]]] = {
     "directory": scan_directory,
     "sqlite": scan_sqlite,
+    "gate_obligations": scan_gate_obligations,
 }
 
 
@@ -434,6 +492,7 @@ __all__ = [
     "load_registry",
     "scan_directory",
     "scan_sqlite",
+    "scan_gate_obligations",
     "count_demand_events",
     "evaluate_producer",
     "run_sweep",

--- a/tests/test_gate_obligations.py
+++ b/tests/test_gate_obligations.py
@@ -1,0 +1,389 @@
+"""test_gate_obligations.py — OI-876/OI-881: a declared gate must leave evidence.
+
+Root cause under test: the dispatch spec carries ``gate=<name>`` all the way
+into the staged bundle, but after ``dispatch_cli.load_spec`` reads the field
+NOTHING consumes it — between 2026-07-28 and 2026-07-31 at least nine
+dispatches declared ``gate=codex_gate`` and ten PRs merged with zero
+request records and zero result records. A dispatch whose declared gate
+never ran was indistinguishable from one whose gate ran.
+
+The fix has three parts, each pinned by tests here:
+
+  1. The door registers a gate obligation per accepted dispatch with a
+     declared gate (``dispatch_cli._register_gate_obligation`` →
+     ``gate_obligations.register_obligation``). RED on origin/main: no code
+     there reads ``spec.gate`` after ``load_spec``, so no obligation exists.
+  2. ``scripts/gate_obligation_runner.py`` fulfils obligations: request +
+     result records via review_gate_manager, or a LOUD not_executable
+     outcome (both records, registered) when the gate cannot run.
+  3. ``producer_freshness.scan_gate_obligations`` groups obligations PER
+     GATE KEY: a key whose oldest pending declaration exceeds cadence is
+     stale — a live sibling gate can no longer hide a dead one (OI-881).
+
+Tests run against throwaway dirs under tmp_path — never the live store.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+import time
+import types
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import gate_obligation_runner as runner
+import producer_freshness
+from dispatch_cli import run_dispatch
+from gate_obligations import (
+    STATUS_FULFILLED,
+    STATUS_NOT_EXECUTABLE,
+    STATUS_PENDING,
+    obligation_path,
+    pr_number_from_pr_id,
+    register_obligation,
+    update_obligation,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    state_dir = tmp_path / "vnx-data" / "state"
+    (state_dir / "review_gates" / "requests").mkdir(parents=True, exist_ok=True)
+    (state_dir / "review_gates" / "results").mkdir(parents=True, exist_ok=True)
+    return state_dir
+
+
+def _make_bundle(tmp_path: Path, *, staging_id: str, dispatch_id: str, gate: str):
+    """A promoted-style staged bundle (spec + instruction inside the bundle dir)."""
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True, exist_ok=True)
+    instruction = bundle_dir / "instruction.md"
+    instruction.write_text("Do something useful.", encoding="utf-8")
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(instruction),
+        "role": "backend-developer",
+        "target_slot": "T0",
+        "gate": gate,
+        "dispatch_paths": [],
+        "provider": "claude",
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+def _read_obligation(state_dir: Path, dispatch_id: str) -> dict:
+    return json.loads(obligation_path(state_dir, dispatch_id).read_text(encoding="utf-8"))
+
+
+class _FakeManager:
+    """Stands in for ReviewGateManager: writes the request+result records the
+    real manager's request_and_execute produces, without running any gate."""
+
+    def __init__(self, state_dir: Path, *, boom: bool = False) -> None:
+        self.state_dir = Path(state_dir)
+        self.boom = boom
+        self.calls = []
+
+    def _request_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "requests" / f"pr-{pr_number}-{gate}.json"
+
+    def _result_path(self, gate: str, pr_number: int) -> Path:
+        return self.state_dir / "review_gates" / "results" / f"pr-{pr_number}-{gate}.json"
+
+    def request_and_execute(self, *, pr_number, branch, review_stack, risk_class,
+                            changed_files, mode, dispatch_id=""):
+        self.calls.append(
+            {"pr_number": pr_number, "branch": branch, "review_stack": list(review_stack)}
+        )
+        if self.boom:
+            raise RuntimeError("codex CLI exploded")
+        for gate in review_stack:
+            self._request_path(gate, pr_number).write_text(
+                json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
+                encoding="utf-8",
+            )
+            self._result_path(gate, pr_number).write_text(
+                json.dumps({"gate": gate, "pr_number": pr_number, "status": "completed"}),
+                encoding="utf-8",
+            )
+        return {"pr_number": pr_number, "branch": branch, "gates": [], "has_required_failure": False}
+
+
+def _patch_manager(monkeypatch, manager: "_FakeManager") -> None:
+    """Hermetic patch: no git, no gh, no real gate — only the fake manager."""
+    monkeypatch.setattr(runner, "_build_manager", lambda state_dir: manager)
+    monkeypatch.setattr(runner, "_branch_from_github", lambda pr: None)
+    fake_rgm = types.ModuleType("review_gate_manager")
+    fake_rgm._compute_changed_files = lambda branch: ["scripts/lib/foo.py"]
+    monkeypatch.setitem(sys.modules, "review_gate_manager", fake_rgm)
+
+
+# ---------------------------------------------------------------------------
+# 1. The door registers an obligation for a declared gate (RED on main).
+# ---------------------------------------------------------------------------
+
+
+def test_door_registers_obligation_for_declared_gate(tmp_path, monkeypatch):
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi876-gate",
+        dispatch_id="20260731-oi876-declared-gate",
+        gate="codex_gate",
+    )
+    _make_state_dir(tmp_path)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+    assert rc == 0
+
+    path = obligation_path(data_dir / "state", "20260731-oi876-declared-gate")
+    assert path.exists(), (
+        "a dispatch whose spec declares gate=codex_gate must leave a registered "
+        "gate obligation — on origin/main nothing reads spec.gate after load_spec"
+    )
+    record = json.loads(path.read_text(encoding="utf-8"))
+    assert record["gate"] == "codex_gate"
+    assert record["status"] == STATUS_PENDING
+    assert record["dispatch_id"] == "20260731-oi876-declared-gate"
+
+
+def test_door_without_gate_registers_no_obligation(tmp_path, monkeypatch):
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260731-staging-oi876-nogate",
+        dispatch_id="20260731-oi876-no-gate",
+        gate="",
+    )
+    _make_state_dir(tmp_path)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+    assert rc == 0
+    assert not obligation_path(data_dir / "state", "20260731-oi876-no-gate").exists()
+
+
+def test_register_obligation_never_resets_fulfilled(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="d-1", gate="codex_gate", project_id="vnx-dev"
+    )
+    assert path is not None
+    update_obligation(path, status=STATUS_FULFILLED, resolved_at="2026-07-31T00:00:00Z")
+
+    again = register_obligation(
+        state_dir, dispatch_id="d-1", gate="codex_gate", project_id="vnx-dev"
+    )
+    assert again == path
+    assert _read_obligation(state_dir, "d-1")["status"] == STATUS_FULFILLED, (
+        "a retry/fix-forward must never reset a fulfilled obligation to pending"
+    )
+
+
+def test_pr_number_from_pr_id_shapes():
+    assert pr_number_from_pr_id("879") == 879
+    assert pr_number_from_pr_id("PR-879") == 879
+    assert pr_number_from_pr_id("#879") == 879
+    assert pr_number_from_pr_id(None) is None
+    assert pr_number_from_pr_id("") is None
+    assert pr_number_from_pr_id("pr-4d") is None  # contract slug, not a GitHub PR
+
+
+# ---------------------------------------------------------------------------
+# 2. The runner fulfils obligations — or fails LOUD, never silent.
+# ---------------------------------------------------------------------------
+
+
+def test_runner_fulfills_obligation_with_request_and_result_records(tmp_path, monkeypatch):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260731-oi876-fulfill", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1253,
+    )
+    manager = _FakeManager(state_dir)
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260731-oi876-fulfill")
+    assert record["status"] == STATUS_FULFILLED
+    assert record["pr_number"] == 1253
+    # Exactly the declared gate ran — not the default stack.
+    assert manager.calls[0]["review_stack"] == ["codex_gate"]
+    # The datapath proof: both records exist on disk at the recorded paths.
+    assert record["request_path"].endswith("review_gates/requests/pr-1253-codex_gate.json")
+    assert record["result_path"].endswith("review_gates/results/pr-1253-codex_gate.json")
+    assert Path(record["request_path"]).exists()
+    assert Path(record["result_path"]).exists()
+
+
+def test_runner_gate_failure_is_loud_and_registered(tmp_path, monkeypatch):
+    """A gate that cannot run must produce not_executable request+result
+    records — a loud, registered outcome, not silence."""
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260731-oi876-broken-gate", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1254,
+    )
+    _patch_manager(monkeypatch, _FakeManager(state_dir, boom=True))
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    record = _read_obligation(state_dir, "20260731-oi876-broken-gate")
+    assert record["status"] == STATUS_NOT_EXECUTABLE
+    assert record["reason"] == "runner_error"
+
+    request_file = state_dir / "review_gates" / "requests" / "pr-1254-codex_gate.json"
+    result_file = state_dir / "review_gates" / "results" / "pr-1254-codex_gate.json"
+    assert request_file.exists(), "loud failure must still write the request record"
+    assert result_file.exists(), "loud failure must still write the result record"
+    assert json.loads(request_file.read_text())["status"] == "not_executable"
+    assert json.loads(result_file.read_text())["status"] == "not_executable"
+    # And the skip-rationale audit trail carries the same loud signal.
+    audit = state_dir / "gate_execution_audit.ndjson"
+    assert audit.exists()
+    assert "gate_skip_rationale" in audit.read_text(encoding="utf-8")
+
+
+def test_runner_leaves_pending_when_pr_unresolvable(tmp_path, monkeypatch):
+    state_dir = _make_state_dir(tmp_path)
+    register_obligation(
+        state_dir, dispatch_id="20260731-oi876-no-pr", gate="codex_gate",
+        project_id="vnx-dev",
+    )
+    monkeypatch.setattr(runner, "_pr_from_dispatch_metadata", lambda sd, did: None)
+    monkeypatch.setattr(runner, "_pr_from_github", lambda did: None)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 1
+    record = _read_obligation(state_dir, "20260731-oi876-no-pr")
+    assert record["status"] == STATUS_PENDING
+    assert record["attempts"] == 1
+
+
+def test_runner_never_refires_terminal_obligations(tmp_path, monkeypatch):
+    state_dir = _make_state_dir(tmp_path)
+    path = register_obligation(
+        state_dir, dispatch_id="20260731-oi876-done", gate="codex_gate",
+        project_id="vnx-dev", pr_number=1255,
+    )
+    update_obligation(path, status=STATUS_FULFILLED, resolved_at="2026-07-31T00:00:00Z")
+    manager = _FakeManager(state_dir)
+    _patch_manager(monkeypatch, manager)
+
+    summary = runner.run(state_dir)
+
+    assert summary["pending_after"] == 0
+    assert manager.calls == [], "a fulfilled obligation must never re-fire the gate"
+
+
+# ---------------------------------------------------------------------------
+# 3. The freshness scanner: per sleutel, declaration checked against result.
+# ---------------------------------------------------------------------------
+
+
+def _write_obligation(state_dir: Path, dispatch_id: str, gate: str, **fields) -> None:
+    register_obligation(state_dir, dispatch_id=dispatch_id, gate=gate)
+    if fields:
+        update_obligation(obligation_path(state_dir, dispatch_id), **fields)
+
+
+def test_scan_groups_per_gate_key_not_per_directory(tmp_path):
+    """OI-881: a directory can look alive because ONE key still writes. The
+    scanner must expose each gate separately."""
+    state_dir = _make_state_dir(tmp_path)
+    old = "2026-07-06T15:33:32Z"      # 25 days of silence shape
+    recent = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+    _write_obligation(state_dir, "d-old", "gemini_review", declared_at=old)
+    _write_obligation(
+        state_dir, "d-fresh", "codex_gate",
+        status=STATUS_FULFILLED, resolved_at=recent,
+    )
+
+    spec = {"path": str(state_dir / "review_gates" / "obligations")}
+    seen = producer_freshness.scan_gate_obligations(spec, now=time.time())
+
+    assert set(seen) == {"gemini_review", "codex_gate"}
+    # codex_gate resolved just now; gemini_review's oldest pending is 25 days old.
+    assert time.time() - seen["codex_gate"] < 3600
+    assert time.time() - seen["gemini_review"] > 20 * 86400
+
+
+def test_evaluate_flags_declaration_without_result(tmp_path):
+    """The OI-876 shape: a declared gate that produced no result within
+    cadence is a stale finding for THAT gate key — with demand evidence."""
+    state_dir = _make_state_dir(tmp_path)
+    old = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(time.time() - 3 * 86400))
+    _write_obligation(state_dir, "d-1", "codex_gate", declared_at=old)
+    # A second gate fulfilled recently must NOT mask the stale one.
+    _write_obligation(
+        state_dir, "d-2", "kimi_gate",
+        status=STATUS_FULFILLED,
+        resolved_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+    )
+
+    spec = {
+        "name": "review_gate_obligations",
+        "type": "gate_obligations",
+        "path": str(state_dir / "review_gates" / "obligations"),
+        "cadence_seconds": 86400,
+    }
+    section = producer_freshness.evaluate_producer(spec, now=time.time())
+
+    assert section["status"] == "stale"
+    stale_keys = {f["key"] for f in section["findings"]}
+    assert stale_keys == {"codex_gate"}, (
+        "only the gate with an unfulfilled declaration may be flagged — "
+        "the fulfilled sibling must stay green (per sleutel, not per tabel)"
+    )
+    finding = section["findings"][0]
+    assert finding["kind"] == "stale"
+    assert finding["silence_seconds"] >= 3 * 86400
+
+
+def test_evaluate_unreadable_obligation_is_source_unreadable(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    bad = state_dir / "review_gates" / "obligations" / "broken.json"
+    bad.parent.mkdir(parents=True, exist_ok=True)
+    bad.write_text("{not json", encoding="utf-8")
+
+    spec = {
+        "name": "review_gate_obligations",
+        "type": "gate_obligations",
+        "path": str(bad.parent),
+        "cadence_seconds": 86400,
+    }
+    section = producer_freshness.evaluate_producer(spec, now=time.time())
+
+    assert section["status"] == "error"
+    assert section["findings"][0]["kind"] == "source_unreadable"
+
+
+def test_real_config_loads_with_obligations_producer():
+    config = Path(__file__).resolve().parent.parent / "configs" / "producer_freshness.yaml"
+    registry = producer_freshness.load_registry(config)
+    by_name = {p["name"]: p for p in registry}
+    assert "review_gate_obligations" in by_name
+    assert by_name["review_gate_obligations"]["type"] == "gate_obligations"

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -150,7 +150,14 @@ def _findings_by(report: dict, producer: str) -> dict:
 def test_real_config_loads() -> None:
     registry = pf.load_registry(REPO_ROOT / "configs" / "producer_freshness.yaml")
     names = [p["name"] for p in registry]
-    assert names == ["review_gate_requests", "review_gate_results", "dispatches_table", "governance_metrics"]
+    assert names == [
+        "review_gate_requests",
+        "review_gate_results",
+        # OI-876/OI-881: declared-gate obligations, grouped per gate key
+        "review_gate_obligations",
+        "dispatches_table",
+        "governance_metrics",
+    ]
 
 
 def test_sweep_finds_silent_review_gate_keys(fake_state: Path) -> None:


### PR DESCRIPTION
# OI-876 + OI-881 — De review-gate-laag produceert geen bewijs terwijl specs een gate declareren

## 1. Waar de gate-aanroep verdwijnt (de meting, vooraf gedaan)

Het `gate`-veld overleeft de staging (`dispatch_bridge.py:228` schrijft het in
`dispatch-spec.json`) en wordt daarna **exact één keer** gelezen:

- **`scripts/lib/dispatch_cli.py:178`** — `load_spec()` leest `gate=str(raw.get("gate",""))`.

Daarna sterft het veld: `spec.gate` heeft nul usages in `scripts/`,
`ExecutionPlan` (`dispatch_plan.py`) dropt het, `_persist_dispatch_row` persist
het niet, en geen enkele lane-executor of receipt-hook leest het. De enige
gate-invokers waren out-of-band en manueel (`t0_gate_enforcement.sh`, `vnx gate`,
`kimi_gate.py`) of legacy (`auto_gate_trigger` alleen via de oude
`headless_orchestrator`-loop). Toen T0 ophield met manueel draaien ging de laag
stil — en niets las die afwezigheid.

## 2. De reparatie: declaratie → obligatie → vervulling

- **Deur** (`dispatch_cli.py`, `_register_gate_obligation`, aangeroepen direct na
  `_persist_dispatch_row`): elke geaccepteerde dispatch met `gate=<naam>`
  registreert één obligatie in `state/review_gates/obligations/<dispatch_id>.json`
  (`scripts/lib/gate_obligations.py`). Best-effort (blokkeert de deur nooit),
  idempotent (een retry reset een vervulde obligatie nooit).
- **Runner** (`scripts/gate_obligation_runner.py`, launchd elke 15 min):
  resolveert de PR (obligatie → `dispatch_metadata.pr_id` →
  `gh pr list --head dispatch/<id>`) en draait **exact de gedeclareerde gate** via
  `review_gate_manager.request_and_execute` — hetzelfde pad als `vnx gate`.
  Kan de gate niet draaien, dan is dat een **luide, geregistreerde uitkomst**:
  request- én result-record met status `not_executable` plus skip-rationale-audit
  (`gate_recorder.record_not_executable`). Stilte is geen eindtoestand meer.

## 3+4. De blinde vlek gesloten, per sleutel

Nieuwe producer `review_gate_obligations` (type `gate_obligations`) in de
producer-freshness-monitor (#1267): de scanner groepeert obligaties op
**gate-naam**, met `last_seen` = de oudste nog-pendende declaratie (of, als alles
vervuld is, de nieuwste resolutie). Een declaratie zonder resultaat binnen cadans
→ stale-finding voor díé gate-sleutel. Een levende zuster-gate maskeert een dode
niet meer — de expliciete les uit OI-881.

## 5. Bewijs met het datapad

Regressietest `tests/test_gate_obligations.py` (12 tests): de deur-test
(`test_door_registers_obligation_for_declared_gate`) is **rood op origin/main**
(daar wordt geen obligatie geregistreerd — geverifieerd door `dispatch_cli.py`
te revert'en en de test opnieuw te draaien) en groen op deze branch.

Live end-to-end tegen een demo-store (echte CLI, geen mocks op de writers):

```
$ python3 scripts/gate_obligation_runner.py --state-dir /tmp/vnx-gate-demo/vnx-data/state
fulfilled: 20260731-demo-declared-gate gate=gemini_review \
  request=/tmp/vnx-gate-demo/vnx-data/state/review_gates/requests/pr-1260-gemini_review.json \
  result=/tmp/vnx-gate-demo/vnx-data/state/review_gates/results/pr-1260-gemini_review.json
```

Result-record: `status: not_executable, reason: provider_not_installed` —
luid en geregistreerd, precies de productie-failroute. De runner resolveerde
de branch zelf via `gh` (`dispatch/20260731-clusterA-r3`).

Monitor, live (3 dagen oude pendende `codex_gate`-declaratie naast een recent
vervulde `gemini_review`):

```
FINDING: review_gate_obligations | key: codex_gate | kind: stale | silence_days: 3.0
```

Alleen de dode sleutel wordt geflagd; de vervulde blijft groen.

## Verificatie

- `pytest tests/test_gate_obligations.py tests/test_producer_freshness.py tests/test_dispatch_door_row.py tests/test_dispatch_cli.py tests/test_dispatch_spec.py tests/test_monitor_tripwire.py tests/dispatch` — **241 passed**
- `pytest tests/test_gate_evidence_enforcement.py tests/test_gate_evidence_certification.py tests/test_headless_review_receipt.py` — **56 passed**
- `scripts/ci_lint_patterns.py` op gewijzigde bestanden — schoon (geen `# noqa:`; geen silent excepts)
- `ruff check` op nieuwe/gewijzigde bestanden — schoon

## Installatie (na merge)

```
sed "s|__VNX_REPO_ROOT__|$HOME/Development/vnx-orchestration|g" \
  scripts/launchd/com.vnx.gate-obligation-runner.plist > ~/Library/LaunchAgents/
launchctl load -w ~/Library/LaunchAgents/com.vnx.gate-obligation-runner.plist
```
