### PR TITLE
fix(plan-gate): data-dir uit centrale store i.p.v. module-locatie (fleet-blokkade)

### DIFF
--- a/docs/project-root-resolution.md
+++ b/docs/project-root-resolution.md
@@ -55,6 +55,19 @@ dispatch_dir = resolve_dispatch_dir(caller_file=__file__)
 
 All functions accept `caller_file: str | None`. Passing `__file__` is strongly recommended — it anchors resolution to the script's own git repo, avoiding CWD surprises.
 
+> **Central-install caveat (2026-07-31):** the `caller_file=__file__` recommendation
+> holds for scripts that live INSIDE the project's own repo. It is **wrong for shared
+> library code under `scripts/lib/`**: in a central install that code physically lives
+> in the (read-only) `~/.vnx-system/versions/<v>/` tree, so step-1 git resolution
+> anchors to the keystone and `resolve_data_dir(caller_file=__file__)` returns
+> `~/.vnx-system/versions/<v>/.vnx-data` — every state write dies with `EACCES`
+> (this blocked every plan-gate fleet-wide). For data/state/dispatch dirs in
+> `scripts/lib/`, resolve the central store instead (`vnx_paths.resolve_paths()` /
+> `resolve_central_data_dir(project_id)`); the central-mode path gate
+> (`scripts/check_no_file_derived_data_paths.py`) blocks new
+> `resolve_*dir(caller_file=__file__)` occurrences there. `resolve_project_root`
+> (a REPO root, not a data dir) is unaffected by that gate.
+
 ### Return values
 
 | Function | Returns |

--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -19,13 +19,25 @@ data/roadmap paths must route through ``vnx_paths.resolve_*`` /
 
 Detection
 ---------
-AST-based, so comments and docstrings never trip it: a violation is a
-``.vnx-data`` / ``ROADMAP.yaml`` string constant that sits inside a path-join
-(``/`` BinOp) or ``Path(...)`` call whose expression also references
-``__file__`` *or* a module-/function-level name that is itself bound to a
-``__file__``-anchored expression (``_REPO_ROOT``, ``_THIS_DIR``, ``here``,
-``script_dir``, ...). A ``state_dir.parent.parent`` built from a resolved
-runtime Path parameter is NOT flagged — only ``__file__``-anchored derivations.
+AST-based, so comments and docstrings never trip it. Two violation shapes:
+
+1. OUTPUT side — a ``.vnx-data`` / ``ROADMAP.yaml`` string constant that sits
+   inside a path-join (``/`` BinOp) or ``Path(...)`` call whose expression also
+   references ``__file__`` *or* a module-/function-level name that is itself
+   bound to a ``__file__``-anchored expression (``_REPO_ROOT``, ``_THIS_DIR``,
+   ``here``, ``script_dir``, ...). A ``state_dir.parent.parent`` built from a
+   resolved runtime Path parameter is NOT flagged — only ``__file__``-anchored
+   derivations.
+2. INPUT side — a call to a canonical data/state-dir resolver
+   (``resolve_data_dir`` / ``resolve_state_dir`` / ``resolve_dispatch_dir``,
+   bare or attribute form) fed a ``__file__``-anchored argument, e.g.
+   ``resolve_data_dir(caller_file=__file__)``. This is the same keystone bug
+   entering through the resolver's front door: the resolver honors its
+   ``caller_file`` anchor FIRST (git-from-physical-location), so in a central
+   install it resolves the read-only ``~/.vnx-system/versions/<v>/.vnx-data``
+   even though the caller used the canonical helper. This exact construct in
+   ``plan_gate_panel.py`` blocked every plan-gate fleet-wide (2026-07-31) while
+   passing shape-1 detection — the gate tested the mechanism, not the input.
 
 Scope
 -----
@@ -162,6 +174,74 @@ GRANDFATHERED: Dict[str, Set[str]] = {
     },
 }
 
+# Pre-existing INPUT-side violations (shape 2): canonical resolver calls fed a
+# __file__ anchor. Same bug class as plan_gate_panel.py:506 (fixed in the
+# plan-gate datadir dispatch, 2026-07-31); the sites below are grandfathered so
+# the gate can block NEW occurrences while each is migrated in follow-up work.
+# Assessment per site (kept deliberately, with rationale):
+#   - tmux_interactive_dispatch / staging_validator / lease_sweep: dispatch-door
+#     lane code with its own governed test surface; the door threads explicit
+#     dirs in the governed path and these fallbacks fire only on the un-threaded
+#     path. Migrating them belongs with the door owners, not the plan-gate fix.
+#   - worker_permission_relay: last-resort except-branch AFTER vnx_paths.ensure_env()
+#     (the VNX_HOME+marker-aware resolver) failed — mirrors the grandfathered
+#     defensive-fallback pattern above.
+#   - append_receipt_internals (payload/session_resolver/warning_destination),
+#     subsystem_health, the *_effectiveness_probe modules: receipt-provenance /
+#     intelligence side paths; read-mostly, env-overridable, and outside this
+#     dispatch's blast radius.
+# (provider_costs.py was on EVERY provider lane's hot path — emit_provider_cost
+# mkdirs events/ per dispatch — so it was fixed in the same dispatch instead of
+# grandfathered: it now mirrors provider_dispatch._resolve_data_dir.)
+GRANDFATHERED_RESOLVER_ANCHORS: Dict[str, Set[str]] = {
+    "scripts/lib/tmux_interactive_dispatch.py": {
+        "resolve_state_dir(caller_file=__file__)",
+    },
+    "scripts/lib/staging_validator.py": {
+        "resolve_data_dir(caller_file=__file__)",
+    },
+    "scripts/lib/worker_permission_relay.py": {
+        "resolve_state_dir(caller_file=__file__)",
+    },
+    "scripts/lib/lease_sweep.py": {
+        "resolve_state_dir(__file__)",
+    },
+    "scripts/lib/subsystem_health.py": {
+        "project_root.resolve_data_dir(__file__)",
+    },
+    "scripts/lib/append_receipt_internals/payload.py": {
+        "facade.resolve_state_dir(__file__)",
+    },
+    "scripts/lib/append_receipt_internals/session_resolver.py": {
+        "facade.resolve_state_dir(__file__)",
+    },
+    "scripts/lib/append_receipt_internals/warning_destination.py": {
+        "resolve_state_dir(__file__)",
+    },
+    "scripts/lib/plan_gate_effectiveness_probe.py": {
+        "project_root.resolve_state_dir(__file__)",
+    },
+    "scripts/lib/migration_effectiveness_probe.py": {
+        "project_root.resolve_state_dir(__file__)",
+    },
+    "scripts/lib/injection_effectiveness_probe.py": {
+        "project_root.resolve_state_dir(__file__)",
+        "project_root.resolve_data_dir(__file__)",
+    },
+}
+
+# Canonical data/state-dir resolver entry points that must never be fed a
+# __file__-derived anchor (shape 2). Attribute form
+# (``project_root.resolve_data_dir``) and bare form (``from project_root import
+# resolve_data_dir``) are both matched. ``resolve_project_root`` is deliberately
+# NOT in this set: it resolves a REPO root (worktree/provenance semantics), not
+# a .vnx-data dir — a related but distinct concern tracked separately.
+RESOLVER_FN_NAMES = frozenset({
+    "resolve_data_dir",
+    "resolve_state_dir",
+    "resolve_dispatch_dir",
+})
+
 
 # ---------------------------------------------------------------------------
 # Core detection
@@ -292,6 +372,23 @@ def _segment(source: str, node: ast.AST) -> str:
     return " ".join(seg.split())
 
 
+def _is_resolver_call(node: ast.AST) -> bool:
+    """True for calls to a canonical resolver, bare or attribute form."""
+    if not isinstance(node, ast.Call):
+        return False
+    func = node.func
+    if isinstance(func, ast.Name):
+        return func.id in RESOLVER_FN_NAMES
+    if isinstance(func, ast.Attribute):
+        return func.attr in RESOLVER_FN_NAMES
+    return False
+
+
+def _resolver_call_args(node: ast.Call) -> List[ast.AST]:
+    """All argument expressions of a call (positional + keyword values)."""
+    return list(node.args) + [kw.value for kw in node.keywords]
+
+
 def check_source(source: str) -> List[Tuple[int, str]]:
     """Return (lineno, normalized_segment) violations for one file's source."""
     try:
@@ -305,6 +402,17 @@ def check_source(source: str) -> List[Tuple[int, str]]:
     seen: Set[Tuple[int, str]] = set()
     # Candidate path expressions: '/' path-joins and Path(...) calls.
     for node in ast.walk(tree):
+        # Shape 2 (input side): a canonical resolver fed a __file__ anchor.
+        if _is_resolver_call(node):
+            if any(
+                _references_file_anchor(arg, anchored)
+                for arg in _resolver_call_args(node)
+            ):
+                key = (getattr(node, "lineno", 0), _segment(source, node))
+                if key not in seen:
+                    seen.add(key)
+                    violations.append(key)
+            continue
         is_join = isinstance(node, ast.BinOp) and isinstance(node.op, ast.Div)
         is_path_call = (
             isinstance(node, ast.Call)
@@ -360,7 +468,7 @@ def scan_dir(root: Path) -> List[Tuple[str, int, str]]:
             source = py.read_text(encoding="utf-8", errors="ignore")
         except OSError:
             continue
-        allowed = GRANDFATHERED.get(rel, set())
+        allowed = GRANDFATHERED.get(rel, set()) | GRANDFATHERED_RESOLVER_ANCHORS.get(rel, set())
         for lineno, seg in _dedup_violations(source):
             if seg in allowed:
                 continue

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -8,7 +8,8 @@ implementation. This module runs that panel:
                             each via provider_dispatch (governed: report -> receipt)
                        ->  parse each panelist's structured verdict
                        ->  apply the panel pass/fail rule (PM-SKILL)
-                       ->  PASS | REVISE | BLOCK
+                       ->  PASS | REVISE | BLOCK | INFRA_FAIL (0 readable verdicts —
+                           an infrastructure outcome, never a plan judgment)
 
 The caller (``planning_cli plan-gate run``) resolves the ``OI-PLAN-<track>``
 blocker on PASS, which — via ``track_reconciler`` — flips the track's
@@ -38,6 +39,7 @@ import subprocess
 import sys
 import tempfile
 import uuid
+import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -414,6 +416,10 @@ def apply_panel_rule(results: List[PanelistResult]) -> Dict[str, Any]:
     the abstention is transparent, never silent.
 
     Over the SCORING (readable) lanes only:
+    - infra floor: ZERO readable verdicts is NOT a plan judgment — the plan was never
+      reviewed. That returns INFRA_FAIL (an infrastructure outcome, distinct from every
+      content verdict) so a fleet-wide lane breakage can never read as an inhoudelijk
+      REVISE ("revise the plan") for a plan no lane ever saw.
     - quorum: require >= 2 readable verdicts to certify (a single voice can't fold to PASS).
     - any BLOCK -> REVISE.
     - >= 2 REVISE -> REVISE.
@@ -433,6 +439,18 @@ def apply_panel_rule(results: List[PanelistResult]) -> Dict[str, Any]:
     block = sum(1 for r in scoring if r.verdict == "block")
     revise = sum(1 for r in scoring if r.verdict == "revise")
     passes = sum(1 for r in scoring if r.verdict == "pass")
+
+    if not scoring:
+        # 0 of N readable: every lane failed to dispatch or produced an unreadable
+        # verdict. The plan was NOT reviewed — this is an infrastructure failure,
+        # not a plan verdict, and must never read as "revise the plan and re-run".
+        return _decision(
+            "INFRA_FAIL", block, revise, passes,
+            f"0 readable verdicts of {len(results)} — no lane produced a verdict, so "
+            "the plan was NOT reviewed. This is an infrastructure failure, not a plan "
+            "judgment: fix the lanes and re-run the gate"
+            f"{ns_note}",
+        )
 
     # Liveness quorum: a multi-member panel must keep >= 2 readable voices to certify, so a
     # degraded 3-panel with only one readable lane can't pass on a single voice. A DELIBERATE
@@ -485,12 +503,31 @@ def _read_report(base: Optional[Path], dispatch_id: str, stderr: str) -> Optiona
 
 
 def _resolve_data_dir(data_dir: Optional[str]) -> Path:
-    """Resolve the data_dir the claude/tmux-lane report is written under and read back from.
+    """Resolve the data_dir the panel reports are written under and read back from.
 
-    A caller-supplied ``data_dir`` wins. When omitted, resolve via the SAME helper the
-    dispatch door itself uses (``project_root.resolve_data_dir``, invoked by
-    ``tmux_interactive_dispatch.py``'s ``_resolve_state_dir`` as
-    ``resolve_state_dir(caller_file=__file__).parent``) instead of degrading to ``None``.
+    Resolution order (matches the rest of the fabric):
+      1. A caller-supplied ``data_dir`` wins.
+      2. ``VNX_DATA_DIR`` — honored on the NORMAL path, and ONLY when
+         ``VNX_DATA_DIR_EXPLICIT=1`` is also set (the same two-key contract as
+         ``project_root.resolve_data_dir`` / ``vnx_paths.resolve_paths``). A bare
+         inherited ``VNX_DATA_DIR`` is pollution, not config: it is ignored with a
+         warning, never silently honored.
+      3. The central store for the ACTIVE project: ``~/.vnx-data/<project_id>`` via
+         ``project_root.resolve_project_id()`` (env > ``.vnx-project-id`` marker >
+         git remote) + ``project_root.resolve_central_data_dir()`` — the same store
+         ``provider_dispatch._resolve_data_dir`` writes the provider-lane reports to,
+         so the write path and ``_read_report``'s read-back base always agree.
+
+    The data dir must NEVER be derived from this module's own location: in a central
+    install ``__file__`` sits inside the read-only ``~/.vnx-system/versions/<v>/``
+    tree, so ``resolve_data_dir(caller_file=__file__)`` resolves the keystone and
+    every report write dies with EACCES (fleet-wide plan-gate block, 2026-07-31 —
+    latent since the lane existed; surfaced when pinned version dirs went read-only).
+
+    There is deliberately NO tempfile fallback: a gate report that must be read back
+    from a throwaway dir is a silent verdict loss, not a degradation. When no
+    project_id can be resolved this raises — loudly — instead of writing state the
+    gate will never find.
 
     A ``None`` base means ``_read_report``'s base-fallback path can never resolve the
     claude/tmux-lane report: unlike ``provider_dispatch``, that lane prints no ``Report:``
@@ -501,12 +538,32 @@ def _resolve_data_dir(data_dir: Optional[str]) -> Path:
         return Path(data_dir)
     if str(HERE) not in sys.path:
         sys.path.insert(0, str(HERE))
+
+    explicit_val = os.environ.get("VNX_DATA_DIR", "").strip()
+    if explicit_val:
+        if os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+            return Path(explicit_val).expanduser().resolve()
+        warnings.warn(
+            f"VNX_DATA_DIR env-var set ({explicit_val}) but VNX_DATA_DIR_EXPLICIT=1 "
+            "is required for it to be honored. Ignoring and resolving the central "
+            "store for the active project_id instead. "
+            "See https://github.com/Vinix24/vnx-orchestration/issues/225",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+
+    from project_root import resolve_central_data_dir, resolve_project_id  # noqa: PLC0415
     try:
-        from project_root import resolve_data_dir  # noqa: PLC0415
-        return resolve_data_dir(caller_file=__file__)
-    except Exception:
-        # Not a git repo and no VNX_CANONICAL_ROOT — last-resort fallback, same as before.
-        return Path(os.environ.get("VNX_DATA_DIR") or tempfile.gettempdir())
+        project_id = resolve_project_id()
+    except Exception as exc:
+        raise RuntimeError(
+            "plan-gate panel: cannot resolve the active project_id, so there is no "
+            "central store to write panel reports to. Set VNX_PROJECT_ID, run from a "
+            "project with a .vnx-project-id marker, or pass data_dir explicitly. "
+            "(No tempfile fallback: a gate report written to a throwaway dir is a "
+            "silently lost verdict.)"
+        ) from exc
+    return resolve_central_data_dir(project_id)
 
 
 def _make_default_dispatcher(
@@ -782,7 +839,9 @@ def run_panel(
 
     ``dispatcher`` is injectable; when omitted the governed provider_dispatch
     dispatcher is used. Returns a dict with the overall ``decision``
-    (PASS|REVISE|BLOCK), the rule ``summary``, and per-panelist detail.
+    (PASS|REVISE|BLOCK, or INFRA_FAIL when no lane produced a readable verdict —
+    an infrastructure failure, not a plan judgment), the rule ``summary``, and
+    per-panelist detail.
     """
     panel = panel or DEFAULT_PANEL
     dispatcher = dispatcher or _make_default_dispatcher(data_dir, timeout_seconds)

--- a/scripts/lib/provider_costs.py
+++ b/scripts/lib/provider_costs.py
@@ -147,9 +147,27 @@ def _make_record_id(
 
 
 def _resolve_costs_path() -> Path:
-    """Resolve .vnx-data/events/provider_costs.ndjson via project_root.py."""
-    from project_root import resolve_data_dir  # noqa: PLC0415
-    data_dir = resolve_data_dir(__file__)
+    """Resolve <central store>/events/provider_costs.ndjson.
+
+    Central store = ``$HOME/.vnx-data/<project_id>`` — mirroring
+    ``provider_dispatch._resolve_data_dir`` exactly, so the cost event lands in
+    the same tenant store as the lane's report and receipt. ``VNX_DATA_DIR`` is
+    honored ONLY together with ``VNX_DATA_DIR_EXPLICIT=1`` (OI-126 two-key
+    contract).
+
+    NEVER derive this from the module's own location: in a central install
+    ``__file__`` sits inside the read-only ``~/.vnx-system/versions/<v>/`` tree,
+    so ``resolve_data_dir(__file__)`` resolved the keystone and the mkdir in
+    ``emit_provider_cost`` died with EACCES on EVERY provider lane — the
+    2026-07-31 fleet-wide plan-gate block.
+    """
+    explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    explicit_val = os.environ.get("VNX_DATA_DIR", "")
+    if explicit_flag and explicit_val:
+        data_dir = Path(explicit_val).resolve()
+    else:
+        project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+        data_dir = Path.home() / ".vnx-data" / project_id
     return data_dir / "events" / "provider_costs.ndjson"
 
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2141,6 +2141,18 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
             f"resolved={resolved}; track derived_status={derived}."
         )
         return 0
+    if result["decision"] == "INFRA_FAIL":
+        # 0 readable verdicts: no lane reviewed the plan, so there is no plan
+        # judgment to act on. This is an infrastructure failure (exit 1, like the
+        # other infra errors above) — NOT a content REVISE. "Revise the plan and
+        # re-run" would send the operator to fix a plan no lane ever saw.
+        print(
+            "INFRA_FAIL — plan gate could not run: no lane produced a readable "
+            "verdict, so the plan was NOT reviewed. Fix the lanes (see the "
+            "per-panelist errors above) and re-run the gate. Track stays blocked.",
+            file=sys.stderr,
+        )
+        return 1
     print(
         f"{result['decision']} — plan gate NOT cleared; track stays blocked. "
         "Revise the plan and re-run."

--- a/tests/test_central_mode_path_gate.py
+++ b/tests/test_central_mode_path_gate.py
@@ -23,6 +23,7 @@ SCRIPTS_DIR = VNX_ROOT / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 from check_no_file_derived_data_paths import (  # noqa: E402
     GRANDFATHERED,
+    GRANDFATHERED_RESOLVER_ANCHORS,
     check_source,
     scan_dir,
 )
@@ -149,6 +150,113 @@ def test_docstring_mentioning_data_path_not_flagged() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Shape 2 (input side): canonical resolver fed a __file__ anchor
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_fed_caller_file_anchor_flagged() -> None:
+    # The exact plan_gate_panel.py:506 construct that blocked every plan-gate
+    # fleet-wide (2026-07-31): the canonical resolver, fed a package anchor. The
+    # old gate tested the mechanism (a __file__-derived .vnx-data literal), not
+    # the input — this case is RED on the pre-fix tree.
+    src = (
+        "from project_root import resolve_data_dir\n"
+        "def _resolve_data_dir(data_dir):\n"
+        "    if data_dir:\n"
+        "        return data_dir\n"
+        "    return resolve_data_dir(caller_file=__file__)\n"
+    )
+    violations = check_source(src)
+    assert len(violations) >= 1
+    assert any("resolve_data_dir(caller_file=__file__)" in seg for _, seg in violations)
+
+
+@pytest.mark.parametrize(
+    "src",
+    [
+        # positional anchor
+        "from project_root import resolve_state_dir\n"
+        "p = resolve_state_dir(__file__)\n",
+        # attribute form
+        "import project_root\n"
+        "p = project_root.resolve_data_dir(__file__)\n",
+        # resolve_dispatch_dir with a keyword anchor
+        "from project_root import resolve_dispatch_dir\n"
+        "p = resolve_dispatch_dir(caller_file=__file__)\n",
+        # anchor hidden behind a file-anchored local name
+        "from project_root import resolve_data_dir\n"
+        "HERE = __file__\n"
+        "p = resolve_data_dir(caller_file=HERE)\n",
+    ],
+)
+def test_resolver_fed_file_anchor_variants_flagged(src: str) -> None:
+    assert len(check_source(src)) >= 1, f"expected a violation for:\n{src}"
+
+
+def test_resolver_without_file_anchor_not_flagged() -> None:
+    # Legit uses: no args, an env-derived argument, a runtime Path parameter.
+    src = (
+        "import os\n"
+        "from project_root import resolve_data_dir, resolve_state_dir\n"
+        "a = resolve_data_dir()\n"
+        "b = resolve_state_dir()\n"
+        "def f(state_dir):\n"
+        "    c = resolve_data_dir(caller_file=state_dir)\n"
+        "    d = resolve_data_dir(caller_file=os.environ['X'])\n"
+        "    return a, b, c, d\n"
+    )
+    assert check_source(src) == []
+
+
+def test_resolver_anchor_only_flags_data_resolvers() -> None:
+    # resolve_project_root resolves a REPO root (worktree/provenance semantics),
+    # not a .vnx-data dir — deliberately out of this gate's shape-2 set.
+    src = (
+        "from project_root import resolve_project_root\n"
+        "p = resolve_project_root(__file__)\n"
+    )
+    assert check_source(src) == []
+
+
+def test_planted_resolver_anchor_in_lib_fails(tmp_path: Path) -> None:
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "planted.py").write_text(
+        "from project_root import resolve_data_dir\n"
+        "def bad():\n"
+        "    return resolve_data_dir(caller_file=__file__)\n",
+        encoding="utf-8",
+    )
+    violations = scan_dir(tmp_path)
+    assert any(rel.endswith("planted.py") for rel, _, _ in violations)
+
+
+def test_grandfathered_resolver_anchor_allows_current_but_new_line_fails(tmp_path: Path) -> None:
+    lib = tmp_path / "scripts" / "lib"
+    lib.mkdir(parents=True)
+    (lib / "staging_validator.py").write_text(
+        "from project_root import resolve_data_dir\n"
+        "def a():\n"
+        "    return resolve_data_dir(caller_file=__file__)\n"
+        "def b():\n"
+        "    return resolve_data_dir(caller_file=__file__)  # different line, same segment is fine\n",
+        encoding="utf-8",
+    )
+    # Grandfathered segment passes.
+    assert scan_dir(tmp_path) == []
+    # A NEW resolver-anchor segment in the same file still trips the gate.
+    (lib / "staging_validator.py").write_text(
+        "from project_root import resolve_state_dir\n"
+        "def a():\n"
+        "    return resolve_state_dir(caller_file=__file__)\n",
+        encoding="utf-8",
+    )
+    violations = scan_dir(tmp_path)
+    segs = {seg for _, _, seg in violations}
+    assert "resolve_state_dir(caller_file=__file__)" in segs
+
+
+# ---------------------------------------------------------------------------
 # scan_dir integration tests
 # ---------------------------------------------------------------------------
 
@@ -217,3 +325,29 @@ def test_grandfather_keys_reference_real_files() -> None:
     # Guard against stale allow-list entries drifting from the tree.
     for rel in GRANDFATHERED:
         assert (VNX_ROOT / rel).is_file(), f"grandfathered path missing: {rel}"
+    for rel in GRANDFATHERED_RESOLVER_ANCHORS:
+        assert (VNX_ROOT / rel).is_file(), f"grandfathered resolver-anchor path missing: {rel}"
+
+
+def test_grandfathered_resolver_anchors_still_present_in_tree() -> None:
+    # Each grandfathered resolver-anchor segment must still exist verbatim in its
+    # file — a migrated site must DROP its entry (forcing the list to shrink),
+    # not silently rot. Reuses the gate's own scanner: strip the allow-list and
+    # confirm every entry comes back as a violation.
+    import check_no_file_derived_data_paths as gate
+
+    found = set()
+    for py in (VNX_ROOT / "scripts" / "lib").rglob("*.py"):
+        rel = py.relative_to(VNX_ROOT).as_posix()
+        if rel not in GRANDFATHERED_RESOLVER_ANCHORS:
+            continue
+        for _, seg in gate._dedup_violations(py.read_text(encoding="utf-8")):
+            if seg in GRANDFATHERED_RESOLVER_ANCHORS[rel]:
+                found.add((rel, seg))
+    expected = {
+        (rel, seg) for rel, segs in GRANDFATHERED_RESOLVER_ANCHORS.items() for seg in segs
+    }
+    assert found == expected, (
+        "stale or missing resolver-anchor grandfather entries:\n"
+        + "\n".join(sorted(f"  {rel}: {seg}" for rel, seg in expected - found))
+    )

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -241,6 +241,44 @@ def test_rule_non_scoring_with_dissent_still_revises():
     assert d["decision"] == "REVISE"
 
 
+def test_rule_zero_readable_verdicts_is_infra_fail_not_revise():
+    # 0 of N readable: no lane reviewed the plan, so there is NO plan judgment to
+    # hand back. This is an infrastructure failure and must surface as a distinct,
+    # recognizable outcome — never as a content REVISE ("revise the plan and
+    # re-run") for a plan no lane ever saw (2026-07-31 fleet-wide lane block:
+    # 0/5 lanes crashed identically and the gate read it as a plan REVISE).
+    d = pgp.apply_panel_rule([
+        _r("a", "x", dispatched=False),
+        _r("b", "x", dispatched=False),
+        _r("c", "x", parse_error=True),
+    ])
+    assert d["decision"] == "INFRA_FAIL"
+    assert d["pass_count"] == 0 and d["revise_count"] == 0 and d["block_count"] == 0
+    assert "NOT reviewed" in d["rationale"]
+    assert "infrastructure failure" in d["rationale"]
+    assert "non-scoring (abstained): a, b, c" in d["rationale"]
+    # ... while a panel with at least one readable verdict below quorum remains a
+    # (content) REVISE — the INFRA_FAIL floor only fires at ZERO readable voices.
+    d1 = pgp.apply_panel_rule([_r("a", "pass"), _r("b", "x", dispatched=False), _r("c", "x", parse_error=True)])
+    assert d1["decision"] == "REVISE"
+
+
+def test_run_panel_all_lanes_down_returns_infra_fail(tmp_path, monkeypatch):
+    # End-to-end through run_panel: every lane raises (e.g. PermissionError on a
+    # read-only install tree) -> INFRA_FAIL, and the rationale names the lanes.
+    monkeypatch.setenv("VNX_PANEL_RETRY", "0")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+
+    def _disp(provider, model_arg, instruction, dispatch_id):
+        raise PermissionError(13, "Permission denied", "/readonly-install/.vnx-data")
+
+    out = pgp.run_panel(doc, track_id="feat-x", project_id="p1", dispatcher=_disp)
+    assert out["decision"] == "INFRA_FAIL"
+    assert "NOT reviewed" in out["summary"]["rationale"]
+    assert all(p["dispatched"] is False for p in out["panelists"])
+
+
 # --------------------------------------------------------------------------
 # run_panel with an injected dispatcher (no live model)
 # --------------------------------------------------------------------------
@@ -855,8 +893,10 @@ def test_missing_report_maps_to_parse_error_revise(tmp_path):
     )
     opus = next(p for p in out["panelists"] if p["label"] == "opus")
     assert opus["parse_error"] is True
-    # A single-panelist panel with a parse_error cannot pass (no_verdict guard).
-    assert out["decision"] == "REVISE"
+    # A single-panelist panel with a parse_error cannot pass (no_verdict guard) —
+    # and with ZERO readable verdicts the outcome is the infrastructure floor
+    # (INFRA_FAIL: the plan was not reviewed), not a content REVISE.
+    assert out["decision"] == "INFRA_FAIL"
 
 
 def test_fenceless_lane_abstains_not_counted_as_phantom_pass(tmp_path):
@@ -1346,23 +1386,59 @@ def test_resolve_data_dir_honors_explicit_value(tmp_path):
 
 
 def test_resolve_data_dir_none_resolves_to_real_path_not_none():
-    # With no caller-supplied data_dir, the resolver must fall back to the SAME helper the
-    # dispatch door uses (project_root.resolve_data_dir) rather than returning None -- a
-    # None base is exactly what broke the opus seat's report lookup (#1102 class bug).
+    # With no caller-supplied data_dir, the resolver must fall back to a real,
+    # absolute path rather than returning None -- a None base is exactly what broke
+    # the opus seat's report lookup (#1102 class bug).
     resolved = pgp._resolve_data_dir(None)
     assert resolved is not None
     assert isinstance(resolved, Path)
     assert resolved.is_absolute()
 
 
-def test_resolve_data_dir_none_matches_project_root_helper():
-    import sys
-    _lib = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
-    if _lib not in sys.path:
-        sys.path.insert(0, _lib)
-    from project_root import resolve_data_dir
+def test_resolve_data_dir_none_resolves_central_store_not_module_location(monkeypatch):
+    # The 2026-07-31 fleet-wide block: in a central install the module file sits in
+    # the read-only ~/.vnx-system/versions/<v>/ tree, so resolving the data dir from
+    # the module's own location (caller_file=__file__) makes every report write die
+    # with EACCES. The resolver must resolve the CENTRAL store for the active
+    # project_id (~/.vnx-data/<project_id>) — the same store provider_dispatch writes
+    # the provider-lane reports to — never a path derived from pgp.__file__.
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    resolved = pgp._resolve_data_dir(None)
+    assert resolved == Path.home() / ".vnx-data" / "vnx-dev"
+    assert resolved != Path(pgp.__file__).resolve().parent.parent.parent / ".vnx-data"
+    assert ".vnx-system" not in resolved.parts
 
-    assert pgp._resolve_data_dir(None) == resolve_data_dir(caller_file=pgp.__file__)
+
+def test_resolve_data_dir_env_override_requires_explicit_flag(tmp_path, monkeypatch):
+    # The two-key contract on the NORMAL path: VNX_DATA_DIR is honored ONLY together
+    # with VNX_DATA_DIR_EXPLICIT=1 (same as project_root.resolve_data_dir /
+    # vnx_paths.resolve_paths). A bare inherited VNX_DATA_DIR is pollution, not
+    # config — ignored (with a warning) in favor of the central store.
+    monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path))
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    with pytest.warns(DeprecationWarning, match="VNX_DATA_DIR_EXPLICIT"):
+        resolved = pgp._resolve_data_dir(None)
+    assert resolved == Path.home() / ".vnx-data" / "vnx-dev"
+
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    assert pgp._resolve_data_dir(None) == tmp_path.resolve()
+
+
+def test_resolve_data_dir_unresolvable_project_id_fails_loudly(tmp_path, monkeypatch):
+    # No tempfile fallback: when no project_id can be resolved the gate must fail
+    # LOUDLY — a gate report written to a throwaway dir is a silently lost verdict.
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+    # cwd with no .vnx-project-id marker walking up and no git remote ->
+    # project_root.resolve_project_id raises.
+    monkeypatch.chdir(tmp_path)
+    with pytest.raises(RuntimeError, match="cannot resolve the active project_id"):
+        pgp._resolve_data_dir(None)
 
 
 def _completed_process():


### PR DESCRIPTION
# fix(plan-gate): data-dir resolutie uit de centrale store, niet uit de module-locatie

## Probleem (fleet-brede blokkade)

Elke plan-gate op de machine crashte: 0 van 5 lanes met identieke
`PermissionError: [Errno 13]` op `mkdir` van `~/.vnx-system/versions/v1.4.0/.vnx-data`.
Oorzaak: `plan_gate_panel._resolve_data_dir` voedde de canonieke resolver een
package-anker — `resolve_data_dir(caller_file=__file__)` — en `__file__` ligt in een
centrale install ín de (sinds #1255 read-only gepinde) version-dir. #1255 is NIET
teruggedraaid: de read-only-pin is correct en maakte een latent defect zichtbaar.

## Fixes

**1. `scripts/lib/plan_gate_panel.py` — `_resolve_data_dir`**
Nieuwe volgorde, passend bij de rest van de fabric:
1. expliciet meegegeven `data_dir` wint;
2. `VNX_DATA_DIR` — nu op het **normale pad** (was: alleen in de except-tak), en alleen
   samen met `VNX_DATA_DIR_EXPLICIT=1` (het twee-sleutel-contract uit
   `project_root`/`vnx_paths`; een bare geërfde `VNX_DATA_DIR` wordt genegeerd mét warning);
3. de centrale store voor het actieve `project_id`: `~/.vnx-data/<project_id>` via
   `resolve_project_id()` + `resolve_central_data_dir()` — dezelfde store waar
   `provider_dispatch` de provider-lane-rapporten schrijft, dus schrijf- en lees-pad
   liggen altijd gelijk.

De `tempfile.gettempdir()`-fallback is weg: een gate-rapport in een wegwerpdirectory is
een stilletjes verloren verdict. Onoplosbaar `project_id` → luide `RuntimeError`.

**2. `scripts/lib/provider_costs.py` — zelfde anker op de hot path van ELKE provider-lane**
Bij het eind-tot-eind bewijs crashte de lane opnieuw — nu in
`provider_costs._resolve_costs_path` (`resolve_data_dir(__file__)`), dat per dispatch
`events/` mkdir't. Dit verklaart waarom alle 5 lanes identiek crashten. Gefixt door
`provider_dispatch._resolve_data_dir` exact te spiegelen (EXPLICIT+`VNX_DATA_DIR` >
`~/.vnx-data/<VNX_PROJECT_ID>`), zodat het cost-event in dezelfde tenant-store landt
als rapport en receipt van de lane.

**3. Guard aangescherpt — `scripts/check_no_file_derived_data_paths.py`**
De guard toetste alleen de OUTPUT-kant (een `.vnx-data`-literaal gebouwd uit een
`__file__`-expressie). Nu ook de INPUT-kant: een canonieke data/state-dir resolver
(`resolve_data_dir` / `resolve_state_dir` / `resolve_dispatch_dir`, bare of
attribute-vorm) die een `__file__`-anker gevoed krijgt. Testgeval met exact de
`plan_gate_panel.py:506`-constructie is rood op de pre-fix tree (geverifieerd:
`scan_dir` op `origin/main`'s `plan_gate_panel.py` → FAIL op regel 506).
`resolve_project_root` valt bewust buiten deze set (repo-root, geen data-dir).

**4. Quorum 0 van N → `INFRA_FAIL`, geen REVISE**
Nul leesbare verdicts is een infrastructuurfout, geen planoordeel. Nieuwe uitkomst
`INFRA_FAIL` ("the plan was NOT reviewed — fix the lanes and re-run"), in
`planning_cli` met exit 1 (infra) in plaats van exit 2 + "Revise the plan and re-run".
Eén leesbaar verdict onder quorum blijft een inhoudelijke REVISE.

## Stap-2-rapport: overige `caller_file=__file__`-plekken (beoordeeld)

**Gefixt (hier):** `plan_gate_panel.py:506`, `provider_costs.py:152` (hot path, bewezen
fleet-blocker).

**Bewust laten staan — gefgrandfathered in de guard met rationale, follow-up voorgesteld:**
- `tmux_interactive_dispatch.py:2721`, `staging_validator.py:137`, `lease_sweep.py:48` —
  dispatch-door lane-code met eigen testoppervlak; de door thread expliciete dirs op het
  governed pad. Migratie hoort bij de door-eigenaren.
- `worker_permission_relay.py:179` — last-resort except-branch ná `vnx_paths.ensure_env()`
  (de VNX_HOME+marker-aware resolver); zelfde defensive-fallback-patroon als bestaande
  grandfathered entries.
- `append_receipt_internals/` (payload, session_resolver, warning_destination),
  `subsystem_health.py`, `*_effectiveness_probe.py` — receipt-provenance/intelligence
  side-paths, read-mostly, env-overridable, buiten de blast radius van deze dispatch.
- `backfill_wt_receipts.py:24` — top-level `scripts/`, buiten de scope van deze gate
  (eenmalig migratietool, dry-run default).
- `docs/project-root-resolution.md` — bijgewerkt: de "pass `caller_file=__file__`"-
  aanbeveling draagt nu expliciet de central-install-caveat voor `scripts/lib/`.

Elke grandfathered entry heeft een test die afdwingt dat de lijst krimpt bij migratie
(`test_grandfathered_resolver_anchors_still_present_in_tree`).

## Bewijs met het datapad (echte paden)

Gesimuleerde centrale install: `/tmp/vnx-install-sim/versions/v1.4.0-{broken,fixed}`
(als git-repo, `dr-xr-xr-x` — zelfde posture als de echte v1.4.0, die onaangeroerd
bleef):

```
BROKEN resolves: /private/tmp/vnx-install-sim/versions/v1.4.0-broken/.vnx-data
BROKEN mkdir: PermissionError errno=13 on .../v1.4.0-broken/.vnx-data  <- de fleet-crash
FIXED resolves:  /Users/vincentvandeth/.vnx-data/vnx-dev
FIXED write: OK -> ~/.vnx-data/vnx-dev/unified_reports/plan-gate-datadir-fix-probe.md
```

Echte plan-gate-run (1 kimi-lane, `data_dir=None`, vanuit de read-only gesimuleerde
install, rechten van `~/.vnx-system/versions/` ongemoeid):

```
panel base (data_dir=None): /Users/vincentvandeth/.vnx-data/vnx-dev
decision: REVISE (echte inhoudelijke uitslag; lane dispatched=True, parse_error=False)
new report: /Users/vincentvandeth/.vnx-data/vnx-dev/unified_reports/plan-gate-proof-kimi-32275d1c.md (5754 bytes)
```

Niets geschreven onder de gesimuleerde version-dir; het pad valt niet meer onder
`~/.vnx-system/versions/`. Bonus: het INFRA_FAIL-pad is live gedemonstreerd (eerste run,
lane neer → "the plan was NOT reviewed ... infrastructure failure").

## Tests

- `tests/test_plan_gate_panel.py`: nieuwe resolver-contracttests (central store,
  EXPLICIT-twee-sleutel, luide failure), INFRA_FAIL-rule + run_panel-tests; 1 bestaande
  test bijgewerkt naar het nieuwe nul-verdicts-contract.
- `tests/test_central_mode_path_gate.py`: shape-2-detectietests (incl. rood-op-main
  constructie), planted-file-tests, grandfather-versheidstests.
- 157 tests groen (plan_gate_panel, central_mode_path_gate, provider_costs,
  planning_cli, project_root_resolution); guard PASS op de tree.
- `tests/test_provider_dispatch_governance_integration.py`: 18 failures — **pre-existing
  op origin/main** (geverifieerd via stash: identiek zonder deze wijziging).

## Randvoorwaarden

- Rechten van `~/.vnx-system/versions/` ongewijzigd; #1255 niet teruggedraaid.
- Geen `.vnx-data/` runtime-state handmatig aangepast (rapporten geschreven door de
  gate zelf, als bewijs).
- `gather_intelligence.py` en review-gate-code onaangeroerd.
- Let op: de v1.4.0-install zelf is read-only en bevat de oude code — de fix landt
  fleet-breed zodra een nieuwe versie geïnstalleerd wordt.
