### PR TITLE
fix(audit): side-door delivery scan skips pattern-definition guards (OI-898)

### DIFF
--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -107,6 +107,7 @@ _EXCLUDE_SUBSTR = (
     "/lane_adapter.py",                 # benchmark adapter
     "/benchmark/", "/benchmarks/",      # benchmark harnesses test the lanes directly
     "/provider_spawns/", "/providers/", # provider_dispatch's own spawn machinery
+    "/check_no_file_derived_data_paths.py",  # path-guard: holds lane/path literals as DETECTION patterns, never delivers (OI-898)
 )
 _EXCLUDE_BASENAMES = {f"{n}.py" for n in _LANES}
 

--- a/tests/test_dispatch_sidedoor_audit.py
+++ b/tests/test_dispatch_sidedoor_audit.py
@@ -66,6 +66,50 @@ def test_process_cleanup_detector_is_not_flagged_as_raw_claude_spawn():
     )
 
 
+def test_check_no_file_derived_data_paths_guard_is_not_flagged_as_delivery_caller():
+    # Regression (OI-898): check_no_file_derived_data_paths.py holds lane/path literals as
+    # DETECTION patterns for its path-guard scan; it never delivers a dispatch and must not
+    # be flagged as a delivery caller (same shape as process_cleanup.py on the raw side).
+    found = audit_mod.scan_delivery_callers()
+    assert "scripts/check_no_file_derived_data_paths.py" not in found, (
+        "check_no_file_derived_data_paths.py is a pattern-definition guard, not a delivery "
+        "caller; it should be excluded from the delivery scan"
+    )
+
+
+def test_delivery_exclusion_does_not_blind_scanner_to_real_new_caller(tmp_path):
+    # the exclusion is scoped to the guard file: a genuinely NEW delivery caller (different
+    # basename) under the same tree IS still returned, proving the scanner is not blind.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "new_side_door.py").write_text(
+        'subprocess.run(["python3", "scripts/lib/subprocess_dispatch.py", "--deliver"])\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_delivery_callers(root=tmp_path)
+    assert "scripts/new_side_door.py" in found, (
+        "scanner went blind: a real new delivery caller is no longer detected"
+    )
+
+
+def test_delivery_exclusion_is_anchored_on_guard_basename(tmp_path):
+    # the rule is substring-anchored on the basename path, not on incidental content: a
+    # planted file NAMED check_no_file_derived_data_paths.py holding a lane literal is
+    # excluded, while the identical content under another name is flagged.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    content = 'LANE = "scripts/lib/subprocess_dispatch.py"\n'
+    (scripts / "check_no_file_derived_data_paths.py").write_text(content, encoding="utf-8")
+    (scripts / "other_guard.py").write_text(content, encoding="utf-8")
+    found = audit_mod.scan_delivery_callers(root=tmp_path)
+    assert "scripts/check_no_file_derived_data_paths.py" not in found, (
+        "basename-anchored exclusion did not apply to the planted guard-named file"
+    )
+    assert "scripts/other_guard.py" in found, (
+        "exclusion leaked beyond the guard basename — identical content must still be flagged"
+    )
+
+
 def test_scan_detects_known_raw_claude_spawns():
     found = audit_mod.scan_raw_claude_spawns()
     for caller in (


### PR DESCRIPTION
## Problem

PR #1280 (`dispatch/20260731-oi898b-plangate-datadir-in-package`) fails VNX CI Profile A: the side-door audit flags `scripts/check_no_file_derived_data_paths.py` as a new delivery caller. That file is a **path-guard** — it holds lane/path literals as DETECTION patterns to scan the tree for forbidden constructs. It never delivers a dispatch and never calls a lane script. `scan_delivery_callers` cannot tell a pattern *definition* from a pattern *use*.

## Fix

Same treatment the raw scan already gives `process_cleanup.py` (#1029) and `hooks/pretooluse_*`: added `"/check_no_file_derived_data_paths.py"` to `_EXCLUDE_SUBSTR` with a rationale comment.

Deliberately **not** added to `KNOWN_DELIVERY_CALLERS` — that set means "audited, sanctioned side door wired through dispatch_bridge"; this file is not a side door at all, so recording it there would be a false governance statement.

## Red-against-the-real-input proof

Measured against PR #1280's actual guard file (`git show origin/dispatch/20260731-oi898b-plangate-datadir-in-package:scripts/check_no_file_derived_data_paths.py`).

**BEFORE the fix** (`python3 scripts/lib/dispatch_sidedoor_audit.py`, exit=1):

```
FAIL: 1 unaudited delivery caller(s); audit + wire through dispatch_bridge before flipping VNX_SINGLE_ENTRY_DISPATCH.
delivery callers found: 9
  scripts/check_no_file_derived_data_paths.py  [UNAUDITED — new side door]
  scripts/commands/dispatch-agent.sh
  scripts/commands/dispatch.sh
  scripts/lib/adapters/claude_adapter.py
  scripts/lib/dispatch_deliver.sh
  scripts/lib/headless_dispatch_daemon.py
  scripts/lib/plan_gate_panel.py
  scripts/lib/pool_worker_runner.py
  vnx_cli/commands/dispatch_agent.py

raw claude -p/--print spawns found: 17
  scripts/benchmark/field-tests/runners/harvest_t6_reviews.py
  scripts/benchmark/field-tests/runners/scorer.py
  scripts/benchmark/judge_quality.py
  scripts/commands/dispatch.sh
  scripts/conversation_analyzer/deep_analyzer.py
  scripts/f39/replay_harness/single_replay.py
  scripts/headless_trigger.py
  scripts/lib/classifier_providers/deepseek_provider.py
  scripts/lib/classifier_providers/haiku_provider.py
  scripts/lib/headless_adapter.py
  scripts/lib/llm_decision_router.py
  scripts/lib/report_classifier.py
  scripts/lib/subprocess_adapter.py
  scripts/lib/t0_decision_summarizer.py
  scripts/lib/vnx_tag_vocabulary.py
  scripts/llm_benchmark.py
  scripts/weekly_digest.py
exit=1
```

**AFTER the fix** (same command, same guard file in place, exit=0):

```
delivery callers found: 8
  scripts/commands/dispatch-agent.sh
  scripts/commands/dispatch.sh
  scripts/lib/adapters/claude_adapter.py
  scripts/lib/dispatch_deliver.sh
  scripts/lib/headless_dispatch_daemon.py
  scripts/lib/plan_gate_panel.py
  scripts/lib/pool_worker_runner.py
  vnx_cli/commands/dispatch_agent.py

raw claude -p/--print spawns found: 17
  scripts/benchmark/field-tests/runners/harvest_t6_reviews.py
  scripts/benchmark/field-tests/runners/scorer.py
  scripts/benchmark/judge_quality.py
  scripts/commands/dispatch.sh
  scripts/conversation_analyzer/deep_analyzer.py
  scripts/f39/replay_harness/single_replay.py
  scripts/headless_trigger.py
  scripts/lib/classifier_providers/deepseek_provider.py
  scripts/lib/classifier_providers/haiku_provider.py
  scripts/lib/headless_adapter.py
  scripts/lib/llm_decision_router.py
  scripts/lib/report_classifier.py
  scripts/lib/subprocess_adapter.py
  scripts/lib/t0_decision_summarizer.py
  scripts/lib/vnx_tag_vocabulary.py
  scripts/llm_benchmark.py
  scripts/weekly_digest.py

OK: no unaudited delivery callers and no unaudited raw claude spawns — exhaustiveness holds.
exit=0
```

The PR #1280 guard file was restored afterwards (`git checkout`) — it is **not** part of this diff.

## Tests

Three new tests in `tests/test_dispatch_sidedoor_audit.py`:

1. `test_check_no_file_derived_data_paths_guard_is_not_flagged_as_delivery_caller` — the real guard file is not returned by `scan_delivery_callers()`.
2. `test_delivery_exclusion_does_not_blind_scanner_to_real_new_caller` — a planted new delivery caller (different basename) under `tmp_path` IS still returned, proving the scanner is not blind.
3. `test_delivery_exclusion_is_anchored_on_guard_basename` — a planted file named `check_no_file_derived_data_paths.py` holding a lane literal is excluded, while identical content under another name is flagged (substring-anchored on the basename, not incidental content).

Suite: **18 passed** (15 existing + 3 new). The guard itself: `python3 scripts/check_no_file_derived_data_paths.py` → `PASS — no __file__-derived data-path literals.` Negative check: with the audit fix stashed, `test_delivery_exclusion_is_anchored_on_guard_basename` fails as expected.

## Constraints honored

- No changes to `_DELIVERY_PATTERNS`, `KNOWN_DELIVERY_CALLERS`, `scan_raw_claude_spawns`, `_RAW_SCAN_EXCLUDE_SUBSTR`.
- No relaxation/xfail/deletion of the failing assertion — a real new caller still trips the gate (proven by test 2).
- No changes to `check_no_file_derived_data_paths.py` itself or anything else in PR #1280's diff.
