### PR TITLE
fix(paths): project-id guard on project_root.resolve_data_dir (OI-899)

### DIFF
--- a/scripts/lib/project_root.py
+++ b/scripts/lib/project_root.py
@@ -60,6 +60,38 @@ def resolve_project_root(caller_file: str | None = None) -> Path:
     )
 
 
+def _run_explicit_data_dir_guard(resolved: Path) -> None:
+    """Run the data-dir/project-id guard on an explicitly pinned data-dir.
+
+    Signal only: this never changes the returned path. In the default
+    (``warn``) mode it emits ``VNXDataDirMismatchWarning`` when the pinned
+    dir does not belong to the active project_id; ``enforce`` raises and
+    ``off`` skips (see ``scripts/lib/data_dir_guard.py``).
+
+    Only the explicit branch (VNX_DATA_DIR + VNX_DATA_DIR_EXPLICIT=1) is
+    guarded — that is the branch the fleet-wide mitigation tells every
+    project to use, and the one that was measured silently accepting a
+    foreign project's data root (OI-900). The default branch is
+    deliberately NOT guarded: it returns the repo-local
+    ``root / ".vnx-data"``, which is legitimately not under
+    ``~/.vnx-data/<project_id>``, so guarding it would flag every ordinary
+    in-repo resolution in every checkout as a mismatch and flood normal
+    use with warnings.
+
+    Deferred import: ``data_dir_guard`` imports ``project_root`` at module
+    level, so a module-level import here would create an import cycle.
+    ``project_root`` is the lowest-level path module in the repo and must
+    stay importable standalone, so a missing guard module fails open.
+    """
+    try:
+        import data_dir_guard
+    except ImportError:  # vnx-silent-except: guard is advisory-only; project_root must stay importable when scripts/lib is not on sys.path
+        return
+    # project_id=None: the guard resolves the ambient id itself and treats
+    # an unresolvable id as "cannot verify" (silent), per its contract.
+    data_dir_guard.check_data_dir_project_id_guard(resolved, None)
+
+
 def resolve_data_dir(caller_file: str | None = None) -> Path:
     """Resolve VNX_DATA_DIR: $PROJECT_ROOT/.vnx-data by default.
 
@@ -70,7 +102,12 @@ def resolve_data_dir(caller_file: str | None = None) -> Path:
     explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
     explicit_val = os.environ.get("VNX_DATA_DIR")
     if explicit_flag and explicit_val:
-        return Path(explicit_val).resolve()
+        resolved = Path(explicit_val).resolve()
+        # Guard fires here, once per resolution; resolve_state_dir /
+        # resolve_dispatch_dir call resolve_data_dir and add no signal of
+        # their own, so one resolution produces at most one guard signal.
+        _run_explicit_data_dir_guard(resolved)
+        return resolved
 
     if explicit_val and not explicit_flag:
         warnings.warn(

--- a/tests/test_project_root_resolution.py
+++ b/tests/test_project_root_resolution.py
@@ -5,12 +5,15 @@ explicit override, multi-worktree isolation.
 """
 from __future__ import annotations
 
+import os
 import subprocess
+import sys
 import warnings
 from pathlib import Path
 
 import pytest
 
+from data_dir_guard import VNXDataDirMismatchWarning
 from scripts.lib.project_root import (
     resolve_data_dir,
     resolve_dispatch_dir,
@@ -258,6 +261,232 @@ class TestDeprecationWarningRegression:
         assert result == override_dir.resolve()
         dep_warnings = [w for w in caught if issubclass(w.category, DeprecationWarning)]
         assert len(dep_warnings) == 0, f"Expected no DeprecationWarnings, got: {dep_warnings}"
+
+
+def _fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` to a temp directory for the test."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+class TestResolveDataDirProjectIdGuard:
+    """OI-899: the explicit VNX_DATA_DIR branch of resolve_data_dir must be
+    covered by the data-dir/project-id guard.
+
+    The guard adds a *signal* only — every path returned before the fix must
+    still be returned byte-identical after it.
+    """
+
+    def _pin_explicit(self, monkeypatch: pytest.MonkeyPatch, data_dir: Path, pid: str | None) -> None:
+        if pid is None:
+            monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        else:
+            monkeypatch.setenv("VNX_PROJECT_ID", pid)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    def test_explicit_foreign_root_warns(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The measured live case (OI-900): foreign data root pinned via the
+        fleet-wide mitigation env vars (VNX_DATA_DIR + VNX_DATA_DIR_EXPLICIT=1)
+        must produce a mismatch signal for the active project_id."""
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        home = _fake_home(tmp_path, monkeypatch)
+        (home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        foreign = tmp_path / "mission-control-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, "vnx-dev")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_data_dir()
+
+        assert result == foreign.resolve()
+        mismatch = [w for w in caught if issubclass(w.category, VNXDataDirMismatchWarning)]
+        assert len(mismatch) == 1
+        assert "vnx-dev" in str(mismatch[0].message)
+        assert str(foreign.resolve()) in str(mismatch[0].message)
+
+    def test_explicit_foreign_root_enforce_raises(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        home = _fake_home(tmp_path, monkeypatch)
+        (home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        foreign = tmp_path / "mission-control-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, "vnx-dev")
+
+        with pytest.raises(RuntimeError, match="VNX data-dir mismatch"):
+            resolve_data_dir()
+
+    @pytest.mark.parametrize("mode", ["off", "warn", "enforce"])
+    def test_explicit_matching_central_dir_is_silent(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch, mode: str
+    ) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", mode)
+        home = _fake_home(tmp_path, monkeypatch)
+        central = home / ".vnx-data" / "vnx-dev"
+        central.mkdir(parents=True)
+        self._pin_explicit(monkeypatch, central, "vnx-dev")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_data_dir()
+
+        assert result == central.resolve()
+        assert len(caught) == 0
+
+    def test_guard_off_is_silent_on_mismatch(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        _fake_home(tmp_path, monkeypatch)
+        foreign = tmp_path / "mission-control-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, "vnx-dev")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_data_dir()
+
+        assert result == foreign.resolve()
+        assert len(caught) == 0
+
+    def test_unresolvable_project_id_stays_silent(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """An unresolvable project_id means 'cannot verify' — no mismatch may
+        be fabricated and resolution must not raise, even in enforce mode."""
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "enforce")
+        _fake_home(tmp_path, monkeypatch)
+        foreign = tmp_path / "some-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, None)
+        # No .vnx-project-id marker and no git repo anywhere up from cwd.
+        monkeypatch.chdir(tmp_path)
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_data_dir()
+
+        assert result == foreign.resolve()
+        assert len(caught) == 0
+
+    def test_return_values_invariant_across_guard_modes(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Return-value invariance: the guard is signal-only. For every guard
+        mode the three resolvers must return the exact paths they returned
+        before the guard existed."""
+        home = _fake_home(tmp_path, monkeypatch)
+        (home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        foreign = tmp_path / "mission-control-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, "vnx-dev")
+
+        expected_data = foreign.resolve()
+        expected_state = expected_data / "state"
+        expected_dispatch = expected_data / "dispatches"
+
+        for mode in ("off", "warn"):  # enforce is covered separately (raises by design)
+            monkeypatch.setenv("VNX_DATA_DIR_GUARD", mode)
+            with warnings.catch_warnings(record=True):
+                warnings.simplefilter("always")
+                assert resolve_data_dir() == expected_data
+                assert resolve_state_dir() == expected_state
+                assert resolve_dispatch_dir() == expected_dispatch
+
+    def test_resolve_state_dir_fires_guard_at_most_once(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """No double-fire: callers in the resolution chain must not multiply
+        the guard signal — one resolution produces at most one warning."""
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        home = _fake_home(tmp_path, monkeypatch)
+        (home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        foreign = tmp_path / "mission-control-root"
+        foreign.mkdir()
+        self._pin_explicit(monkeypatch, foreign, "vnx-dev")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_state_dir()
+
+        assert result == foreign.resolve() / "state"
+        mismatch = [w for w in caught if issubclass(w.category, VNXDataDirMismatchWarning)]
+        assert len(mismatch) == 1
+
+    def test_default_branch_is_not_guarded(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        """The repo-local default ($PROJECT_ROOT/.vnx-data) is legitimately not
+        under ~/.vnx-data/<pid>; guarding it would flood every ordinary
+        resolution. It must stay silent even in warn mode."""
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "warn")
+        _fake_home(tmp_path, monkeypatch)
+        repo = tmp_path / "plainrepo"
+        repo.mkdir()
+        _git_init(repo)
+        monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        caller = repo / "script.py"
+        caller.write_text("# s\n")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            result = resolve_data_dir(caller_file=str(caller))
+
+        assert result == (repo / ".vnx-data").resolve()
+        mismatch = [w for w in caught if issubclass(w.category, VNXDataDirMismatchWarning)]
+        assert len(mismatch) == 0
+
+    def test_project_root_imports_standalone_no_cycle(self) -> None:
+        """project_root must stay importable standalone (deferred guard import
+        must not create an import cycle), even with a clean sys.modules."""
+        lib_dir = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.path.insert(0, sys.argv[1]); "
+                "import project_root; print('standalone-ok')",
+                str(lib_dir),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+        )
+        assert proc.returncode == 0, f"stderr: {proc.stderr}"
+        assert "standalone-ok" in proc.stdout
+
+    def test_guard_import_failure_fails_open(self, tmp_path: Path) -> None:
+        """When scripts/lib is not on sys.path the deferred ``import
+        data_dir_guard`` fails; resolve_data_dir must still return the
+        explicit path without raising (project_root stays usable standalone)."""
+        repo_root = Path(__file__).resolve().parent.parent
+        foreign = tmp_path / "foreign-root"
+        foreign.mkdir()
+        env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
+        env.update(
+            {
+                "VNX_DATA_DIR": str(foreign),
+                "VNX_DATA_DIR_EXPLICIT": "1",
+                "VNX_PROJECT_ID": "vnx-dev",
+                "VNX_DATA_DIR_GUARD": "warn",
+            }
+        )
+        proc = subprocess.run(
+            [
+                sys.executable,
+                "-c",
+                "import sys; sys.path.insert(0, sys.argv[1]); "
+                "from scripts.lib import project_root; "
+                "print(project_root.resolve_data_dir())",
+                str(repo_root),
+            ],
+            capture_output=True,
+            text=True,
+            env=env,
+            cwd=str(tmp_path),
+        )
+        assert proc.returncode == 0, f"stderr: {proc.stderr}"
+        assert str(foreign.resolve()) in proc.stdout
 
 
 class TestWorktreeIsolation:


### PR DESCRIPTION
## OI-899: project-id guard on `project_root.resolve_data_dir`

The repo has two data-dir resolvers; the project-id guard only sat on one. `scripts/lib/vnx_paths.py` guards `resolve_data_dir_for_project_root` (line 355) and `resolve_paths` (line 379), but `scripts/lib/project_root.py::resolve_data_dir` had **zero** guard calls. Measured live (OI-900): with `VNX_DATA_DIR` pointed at a foreign project's root + `VNX_DATA_DIR_EXPLICIT=1` + `VNX_PROJECT_ID=vnx-dev`, `resolve_data_dir` returned the foreign path **without a single warning** — and that explicit path is exactly the one the fleet-wide mitigation tells every project to use.

## What changed

`resolve_data_dir` now calls `data_dir_guard.check_data_dir_project_id_guard(resolved, None)` on the **explicit branch only**, via a helper `_run_explicit_data_dir_guard`:

- **Signal-only.** Resolution behavior is unchanged — every path returned before is returned byte-identical after (proven below). `warn` (default) emits `VNXDataDirMismatchWarning`, `enforce` raises `RuntimeError`, `off` skips. No new hard failure by default.
- **Circular import handled by a function-local deferred import** (`import data_dir_guard` inside the function), fail-open on `ImportError` with `# vnx-silent-except:` — `data_dir_guard` imports `project_root` at module level, and `project_root` must stay importable standalone.
- **No double-fire.** `resolve_state_dir` / `resolve_dispatch_dir` call `resolve_data_dir` and add no signal of their own, so one resolution produces at most one guard signal (tested).

## Decision on the default (repo-local) branch

**The default branch is deliberately NOT guarded.** It returns the repo-local `root / ".vnx-data"`, which is legitimately *not* under `~/.vnx-data/<project_id>`; `data_dir_guard._is_under_central_dir` would call every ordinary in-repo resolution in every repo checkout a mismatch, flooding normal use with warnings. The explicit branch is the one the fleet-wide mitigation routes everyone through and the one measured accepting a foreign root — that is the branch that must be guarded. This rationale is written in the code (docstring of `_run_explicit_data_dir_guard`), not just here. A `test_default_branch_is_not_guarded` test pins the behavior.

Unresolvable `project_id` stays silent ("cannot verify"), matching the existing guard contract — `project_id=None` lets the guard resolve the ambient id itself and skip silently on failure.

## Required proof — red against main

### Step 1: new tests FAIL on the clean `origin/main` resolver (guard does not fire today)

`python3 -m pytest tests/test_project_root_resolution.py -k TestResolveDataDirProjectIdGuard -v` with the tests in place but **before** the fix to `scripts/lib/project_root.py`:

```
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_warns FAILED [  8%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_enforce_raises FAILED [ 16%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[off] PASSED [ 25%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[warn] PASSED [ 33%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[enforce] PASSED [ 41%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_guard_off_is_silent_on_mismatch PASSED [ 50%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_unresolvable_project_id_stays_silent PASSED [ 58%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_return_values_invariant_across_guard_modes PASSED [ 66%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_resolve_state_dir_fires_guard_at_most_once FAILED [ 75%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_default_branch_is_not_guarded PASSED [ 83%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_project_root_imports_standalone_no_cycle PASSED [ 91%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_guard_import_failure_fails_open PASSED [100%]

______ TestResolveDataDirProjectIdGuard.test_explicit_foreign_root_warns _______
...
        mismatch = [w for w in caught if issubclass(w.category, VNXDataDirMismatchWarning)]
>       assert len(mismatch) == 1
E       assert 0 == 1
E        +  where 0 = len([])

tests/test_project_root_resolution.py:307: AssertionError
__ TestResolveDataDirProjectIdGuard.test_explicit_foreign_root_enforce_raises __
...
>       with pytest.raises(RuntimeError, match="VNX data-dir mismatch"):
E       Failed: DID NOT RAISE <class 'RuntimeError'>

tests/test_project_root_resolution.py:319: Failed
_ TestResolveDataDirProjectIdGuard.test_resolve_state_dir_fires_guard_at_most_once _
...
>       assert len(mismatch) == 1
E       assert 0 == 1
E        +  where 0 = len([])

tests/test_project_root_resolution.py:413: AssertionError
=========================== short test summary info ============================
FAILED tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_warns
FAILED tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_enforce_raises
FAILED tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_resolve_state_dir_fires_guard_at_most_once
================== 3 failed, 9 passed, 14 deselected in 0.26s ==================
```

### Step 2: the same tests PASS with the fix

```
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_warns PASSED [  8%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_foreign_root_enforce_raises PASSED [ 16%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[off] PASSED [ 25%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[warn] PASSED [ 33%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_explicit_matching_central_dir_is_silent[enforce] PASSED [ 41%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_guard_off_is_silent_on_mismatch PASSED [ 50%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_unresolvable_project_id_stays_silent PASSED [ 58%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_return_values_invariant_across_guard_modes PASSED [ 66%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_resolve_state_dir_fires_guard_at_most_once PASSED [ 75%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_default_branch_is_not_guarded PASSED [ 83%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_project_root_imports_standalone_no_cycle PASSED [ 91%]
tests/test_project_root_resolution.py::TestResolveDataDirProjectIdGuard::test_guard_import_failure_fails_open PASSED [100%]

====================== 12 passed, 14 deselected in 0.22s =======================
```

### Step 3: live reproduction of the measured case, by hand, before → after

Command (identical in both runs), run from the worktree with the resolver on `PYTHONPATH`:

```
VNX_DATA_DIR=/tmp/oi899-proof/foreign-root VNX_DATA_DIR_EXPLICIT=1 VNX_PROJECT_ID=vnx-dev \
VNX_DATA_DIR_GUARD=warn PYTHONPATH=scripts/lib python3 -W always -c "
from project_root import resolve_data_dir, resolve_state_dir, resolve_dispatch_dir
print('data_dir    :', resolve_data_dir())
print('state_dir   :', resolve_state_dir())
print('dispatch_dir:', resolve_dispatch_dir())
"
```

**BEFORE (unguarded resolver) — no warning at all:**

```
data_dir    : /private/tmp/oi899-proof/foreign-root
state_dir   : /private/tmp/oi899-proof/foreign-root/state
dispatch_dir: /private/tmp/oi899-proof/foreign-root/dispatches
--- end (any guard warning would appear above this line, on stderr) ---
```

**AFTER (with fix) — guard fires, returned paths byte-identical:**

```
.../scripts/lib/project_root.py:92: VNXDataDirMismatchWarning: VNX data-dir mismatch: resolved data-dir /private/tmp/oi899-proof/foreign-root does not belong to project 'vnx-dev' (expected central dir /Users/vincentvandeth/.vnx-data/vnx-dev). Running with the wrong data directory can write receipts/state into another project's store or a stray repo-local tree. Fix: ensure VNX_PROJECT_ID matches the intended project, add a .vnx-project-id marker in the project root, or stop pinning a repo-local VNX_DATA_DIR / VNX_STATE_DIR. Set VNX_DATA_DIR_GUARD=enforce to abort on this condition, or =off to silence this warning.
  data_dir_guard.check_data_dir_project_id_guard(resolved, None)
(×3 — one per resolution call: resolve_data_dir, resolve_state_dir, resolve_dispatch_dir)
data_dir    : /private/tmp/oi899-proof/foreign-root
state_dir   : /private/tmp/oi899-proof/foreign-root/state
dispatch_dir: /private/tmp/oi899-proof/foreign-root/dispatches
--- end (guard warning appears above this line, on stderr) ---
```

Returned paths are byte-identical before and after: `/private/tmp/oi899-proof/foreign-root{,/state,/dispatches}`. (The 3 warnings in the AFTER run are 3 separate resolution calls — one signal per resolution, not a double-fire within one call; the single-call case is pinned by `test_resolve_state_dir_fires_guard_at_most_once`.)

### Step 4: full suite counts

`python3 -m pytest tests/test_project_root_resolution.py tests/test_data_dir_guard.py tests/test_central_mode_path_resolution.py tests/test_path_resolution_regression.py -q`

- **Before (clean `origin/main` resolver + new tests):** `3 failed, 99 passed, 2 warnings in 1.95s` — the 3 failures are exactly the new red tests above; **no pre-existing failures** in any of the four suites.
- **After (with fix):** `102 passed, 2 warnings in 2.48s`

The `2 warnings` are identical in both runs and pre-existing/intentional: a `VNXDataDirMismatchWarning` asserted by `test_data_dir_guard.py::test_warn_mode_does_not_abort` and a `DeprecationWarning` asserted by `test_path_resolution_regression.py::test_data_dir_not_inherited_from_wrong_project`.

Lint gate (`scripts/ci_lint_patterns.py --files-from-stdin` on `scripts/lib/project_root.py`): exit 0 — the silent `except ImportError` carries `# vnx-silent-except:`, not `# noqa:`.

## Hard-constraint compliance

- Did **not** touch `dispatch_sidedoor_audit.py`, `check_no_file_derived_data_paths.py`, `plan_gate_panel.py`, `provider_costs.py`.
- Did **not** change `vnx_paths.py`'s existing guard calls, `resolve_central_data_dir`, `resolve_project_id`, or `resolve_project_root`.
- No receipts or runtime state moved or deleted.
- Diff: `scripts/lib/project_root.py` (+39/−1) and `tests/test_project_root_resolution.py` (+229) only.
