### PR TITLE
fix(cli): read VERSION before pip metadata so --version tracks the running code

### DIFF
--- a/tests/test_vnx_cli_version_source.py
+++ b/tests/test_vnx_cli_version_source.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""Tests for vnx_cli.__init__._read_version() version-source order.
+
+The root VERSION file must win over pip package metadata. In the
+editable-install + `current` symlink deployment model the dist-info
+metadata is stamped once at install time and goes stale as the code
+underneath moves; the VERSION file moves with the code and is the
+source of truth. Metadata is only a fallback for real wheel installs
+where VERSION may be absent.
+"""
+
+import sys
+from importlib.metadata import PackageNotFoundError
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+import vnx_cli
+
+
+def _relocate_version_file(monkeypatch, tmp_path, content=None):
+    """Point vnx_cli.__file__ into tmp_path so _read_version() looks for
+    VERSION at tmp_path / "VERSION". Returns the VERSION path."""
+    fake_init = tmp_path / "pkg" / "vnx_cli" / "__init__.py"
+    fake_init.parent.mkdir(parents=True)
+    fake_init.touch()
+    monkeypatch.setattr(vnx_cli, "__file__", str(fake_init))
+    version_path = tmp_path / "pkg" / "VERSION"
+    if content is not None:
+        version_path.write_text(content, encoding="utf-8")
+    return version_path
+
+
+def test_version_file_wins_over_metadata(monkeypatch, tmp_path):
+    """Live case: VERSION=1.4.1 next to stale dist-info metadata=1.3.0
+    must yield 1.4.1."""
+    _relocate_version_file(monkeypatch, tmp_path, "1.4.1\n")
+    monkeypatch.setattr(vnx_cli, "_pkg_version", lambda name: "1.3.0")
+    assert vnx_cli._read_version() == "1.4.1"
+
+
+def test_metadata_fallback_when_version_file_absent(monkeypatch, tmp_path):
+    """No VERSION file (real wheel install) -> package metadata answers."""
+    _relocate_version_file(monkeypatch, tmp_path, content=None)
+    monkeypatch.setattr(vnx_cli, "_pkg_version", lambda name: "1.3.0")
+    assert vnx_cli._read_version() == "1.3.0"
+
+
+def test_unknown_sentinel_when_both_absent(monkeypatch, tmp_path):
+    """No VERSION file and no package metadata -> 0.0.0+unknown."""
+    _relocate_version_file(monkeypatch, tmp_path, content=None)
+
+    def _not_found(name):
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(vnx_cli, "_pkg_version", _not_found)
+    assert vnx_cli._read_version() == "0.0.0+unknown"
+
+
+def test_empty_version_file_falls_through_to_metadata(monkeypatch, tmp_path):
+    """Empty/whitespace VERSION must not produce an empty version string;
+    fall through to package metadata."""
+    _relocate_version_file(monkeypatch, tmp_path, "   \n")
+    monkeypatch.setattr(vnx_cli, "_pkg_version", lambda name: "1.3.0")
+    assert vnx_cli._read_version() == "1.3.0"
+
+
+def test_empty_version_file_and_no_metadata_yields_sentinel(monkeypatch, tmp_path):
+    """Empty VERSION plus missing metadata -> 0.0.0+unknown, never ''."""
+    _relocate_version_file(monkeypatch, tmp_path, "")
+
+    def _not_found(name):
+        raise PackageNotFoundError(name)
+
+    monkeypatch.setattr(vnx_cli, "_pkg_version", _not_found)
+    result = vnx_cli._read_version()
+    assert result == "0.0.0+unknown"
+    assert result != ""

--- a/vnx_cli/__init__.py
+++ b/vnx_cli/__init__.py
@@ -1,10 +1,12 @@
 """VNX CLI package.
 
-``__version__`` is single-sourced from the root ``VERSION`` file. In an
-installed wheel it comes back through package metadata (which setuptools
-stamps from ``VERSION`` via ``[tool.setuptools.dynamic]``); in a dev checkout
-the package is not installed, so we read ``VERSION`` directly. One source of
-truth, no 0.9.0/rc3 drift.
+``__version__`` is single-sourced from the root ``VERSION`` file, which is
+read first. In a real wheel install VERSION ships inside the package and
+matches the metadata anyway; in the editable-install deployment (one install,
+code swapped underneath via the ``current`` symlink) the pip metadata is
+stamped once at install time and goes stale as the code moves, so it must
+NOT win. Package metadata is the fallback for installs where VERSION is
+genuinely absent, with ``0.0.0+unknown`` as the last resort.
 """
 
 from importlib.metadata import PackageNotFoundError, version as _pkg_version
@@ -12,15 +14,17 @@ from pathlib import Path
 
 
 def _read_version() -> str:
+    version_file = Path(__file__).resolve().parent.parent / "VERSION"
+    try:
+        text = version_file.read_text(encoding="utf-8").strip()
+    except OSError:
+        text = ""
+    if text:
+        return text
     try:
         return _pkg_version("vnx-orchestration")
     except PackageNotFoundError:
-        version_file = Path(__file__).resolve().parent.parent / "VERSION"
-        try:
-            text = version_file.read_text(encoding="utf-8").strip()
-        except OSError:
-            return "0.0.0+unknown"
-        return text or "0.0.0+unknown"
+        return "0.0.0+unknown"
 
 
 __version__ = _read_version()


### PR DESCRIPTION
## The defect

`vnx_cli/__init__.py::_read_version()` asked `importlib.metadata` first. That held for the original deployment model (wheel per release, setuptools stamping metadata from VERSION). It broke when deployment became **one editable install, code swapped underneath via the `current` symlink**: the dist-info metadata is written once at install time and never again, while the code it points at keeps moving.

Measured on the live install:

```
vnx_cli.__version__                  = 1.3.0
~/.vnx-system/current/VERSION        = 1.4.1
site-packages/vnx_orchestration-1.3.0.dist-info   <- where 1.3.0 comes from
```

## Why a two-line change is worth a PR — two concrete consequences

1. **Rollout verification is broken.** `vnx --version` reports a version that has nothing to do with the running code — and that is exactly the command an operator runs to verify a rollout.
2. **`vnx init` pins new projects to a dead version.** `init_cmd.py` calls `_write_vnx_version(project_dir, __version__, ...)`, so a project created today gets `.vnx-version = 1.3.0` — and `~/.vnx-system/versions/v1.3.0` was pruned. A brand-new project starts pinned to a directory that does not exist.

The bug is the source, not the caller: once `__version__` is correct, `init_cmd.py` is correct untouched.

## The fix

Invert the order in `_read_version()`: read the root `VERSION` file first; fall back to `importlib.metadata` only when the file is absent, unreadable, or empty; keep `"0.0.0+unknown"` as the last resort. Correct in both deployment models — in a real wheel install VERSION ships inside the package and matches the metadata anyway. Module docstring updated to describe what the code actually does (the old text stated an invariant the code did not hold, which is how this survived).

## Proof — failing before, passing after

**Before (clean origin/main + new tests only):**

```
tests/test_vnx_cli_version_source.py::test_version_file_wins_over_metadata FAILED [ 20%]
tests/test_vnx_cli_version_source.py::test_metadata_fallback_when_version_file_absent PASSED [ 40%]
tests/test_vnx_cli_version_source.py::test_unknown_sentinel_when_both_absent PASSED [ 60%]
tests/test_vnx_cli_version_source.py::test_empty_version_file_falls_through_to_metadata PASSED [ 80%]
tests/test_vnx_cli_version_source.py::test_empty_version_file_and_no_metadata_yields_sentinel PASSED [100%]

=================================== FAILURES ===================================
_____________________ test_version_file_wins_over_metadata _____________________
>       assert vnx_cli._read_version() == "1.4.1"
E       AssertionError: assert '1.3.0' == '1.4.1'
E         - 1.4.1
E         + 1.3.0
========================= 1 failed, 4 passed in 0.15s ==========================
```

**After the fix:**

```
tests/test_vnx_cli_version_source.py::test_version_file_wins_over_metadata PASSED [ 20%]
tests/test_vnx_cli_version_source.py::test_metadata_fallback_when_version_file_absent PASSED [ 40%]
tests/test_vnx_cli_version_source.py::test_unknown_sentinel_when_both_absent PASSED [ 60%]
tests/test_vnx_cli_version_source.py::test_empty_version_file_falls_through_to_metadata PASSED [ 80%]
tests/test_vnx_cli_version_source.py::test_empty_version_file_and_no_metadata_yields_sentinel PASSED [100%]

============================== 5 passed in 0.12s ===============================
```

**Full test files** (`test_vnx_cli_version_source.py` + `test_vnx_cli_version.py` + `test_cli_json_output.py`):

```
tests/test_vnx_cli_version_source.py .....                               [ 20%]
tests/test_vnx_cli_version.py ...............                            [ 83%]
tests/test_cli_json_output.py ....                                       [100%]

============================== 24 passed in 0.59s ==============================
```

## Tests added (`tests/test_vnx_cli_version_source.py`)

1. VERSION present + readable wins even when metadata disagrees — the exact live case: metadata `1.3.0` next to VERSION `1.4.1` yields `1.4.1`.
2. VERSION absent → falls back to package metadata (wheel-install path).
3. Both absent → `"0.0.0+unknown"`.
4. VERSION present but empty/whitespace → never returns `""`; falls through to metadata, and to the sentinel when metadata is also absent.

All metadata interaction is monkeypatched (`vnx_cli._pkg_version`); the real environment is untouched.

## Scope

Touched: `vnx_cli/__init__.py`, `tests/test_vnx_cli_version_source.py`. Nothing else — `init_cmd.py`, `_reexec.py`, `.vnx-version` files, `VERSION`, and the install tree are all untouched by design.