### PR TITLE
fix(gate): gate worktree lock dir in linked worktrees + PR head branch (OI-904, OI-905)

### DIFF
--- a/scripts/commands/gate.sh
+++ b/scripts/commands/gate.sh
@@ -11,6 +11,25 @@ _g_current_branch() {
   git -C "${PROJECT_ROOT:-$(pwd)}" rev-parse --abbrev-ref HEAD 2>/dev/null || printf ''
 }
 
+_g_pr_head_branch() {
+  # Resolve the PR's head ref from GitHub, not from the local checkout. T0
+  # routinely runs `vnx gate` from main; the local branch is then 'main' while
+  # the branch under review is the PR's headRefName. Passing the local branch
+  # to the gate worktree checks out the wrong tree for the diff being reviewed
+  # (OI-904). The diff itself is fetched via `gh pr diff`, but the gate agent's
+  # own file reads (sed/rg/cat) resolve against the worktree cwd, which must
+  # match the PR branch.
+  local pr="$1"
+  [ -n "$pr" ] || return 1
+  local head_ref
+  head_ref="$(gh pr view "$pr" --json headRefName --jq .headRefName 2>/dev/null || true)"
+  if [ -n "$head_ref" ]; then
+    printf '%s' "$head_ref"
+    return 0
+  fi
+  return 1
+}
+
 _g_required_gates() {
   # Read governance_enforcement.yaml and return comma-separated gate names
   # that are level >= 2 (soft_mandatory or hard_mandatory).
@@ -208,12 +227,22 @@ HELP
     return 0
   fi
 
-  # Auto-detect branch
+  # Auto-detect branch. Prefer the PR's head ref (gh pr view headRefName) so
+  # the gate worktree matches the diff under review; fall back to the local
+  # checkout branch only when no PR number is available or gh cannot resolve
+  # the head ref.
   local branch
-  branch=$(_g_current_branch)
-  if [ -z "$branch" ]; then
-    err "[gate] Could not determine current git branch"
-    return 1
+  if [ -n "$pr_number" ] && branch="$(_g_pr_head_branch "$pr_number")"; then
+    log "[gate] Resolved PR $pr_number head branch: $branch"
+  else
+    branch=$(_g_current_branch)
+    if [ -z "$branch" ]; then
+      err "[gate] Could not determine current git branch"
+      return 1
+    fi
+    if [ -n "$pr_number" ]; then
+      log "[gate] WARNING: could not resolve PR $pr_number head branch via gh pr view; fell back to local branch '$branch'"
+    fi
   fi
 
   local gate_script="$VNX_HOME/scripts/review_gate_manager.py"

--- a/scripts/lib/gate_worktree.py
+++ b/scripts/lib/gate_worktree.py
@@ -87,15 +87,48 @@ def _validate_branch(branch: str, *, gate: str, identifier: str) -> None:
         )
 
 
+def _git_common_dir(root: Path) -> Path:
+    """Resolve the shared git dir for a repo, handling linked worktrees.
+
+    In a linked git worktree ``.git`` is a ~89-byte ASCII file pointing at the
+    real gitdir, not a directory — deriving a lock path from ``root / ".git"``
+    would raise ``NotADirectoryError`` (OI-905). ``git rev-parse
+    --git-common-dir`` returns the shared git dir in both a main checkout and a
+    linked worktree (the output may be relative to cwd or absolute).
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "--git-common-dir"],
+            capture_output=True, text=True, timeout=15, check=True,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        detail = getattr(exc, "stderr", "") or str(exc)
+        raise GateWorktreeError(
+            f"git rev-parse --git-common-dir failed in {root}: {detail}"
+        ) from exc
+    common = proc.stdout.strip()
+    if not common:
+        raise GateWorktreeError(
+            f"git rev-parse --git-common-dir returned empty in {root}"
+        )
+    path = Path(common)
+    if not path.is_absolute():
+        path = root / path
+    return path.resolve()
+
+
 @contextmanager
 def _worktree_lock(root: Path):
     """Serialize `git worktree` add/remove via an exclusive fcntl lock.
 
     Uses the SAME lock path as dispatch_worktree_isolation / tmux_worktree
-    (``<repo>/.git/worktrees/.vnx-lock``) so gate execution never races other
-    lanes' concurrent ``git worktree add/remove`` against this repo.
+    (``<git-common-dir>/worktrees/.vnx-lock``) so gate execution never races
+    other lanes' concurrent ``git worktree add/remove`` against this repo. The
+    common dir is resolved via ``git rev-parse --git-common-dir`` (see
+    ``_git_common_dir``) so this works from a linked worktree where ``.git``
+    is a file, not a directory.
     """
-    lock_dir = (root / ".git").resolve() / "worktrees"
+    lock_dir = _git_common_dir(root) / "worktrees"
     lock_dir.mkdir(parents=True, exist_ok=True)
     lock_path = lock_dir / ".vnx-lock"
     with open(lock_path, "a") as lf:

--- a/tests/test_gate_pr_branch_resolution.py
+++ b/tests/test_gate_pr_branch_resolution.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""OI-904 — `vnx gate` must derive --branch from the PR's headRefName, not the
+local checkout branch.
+
+T0 routinely runs `vnx gate <pr>` from main; the local checkout branch is then
+'main' while the branch under review is the PR's head branch. Passing the local
+branch to review_gate_manager made create_gate_worktree checkout origin/main
+instead of the PR branch, so the gate agent's own file reads (sed/rg/cat)
+missed the diff under review.
+
+These tests run cmd_gate from scripts/commands/gate.sh with a mocked `gh`
+binary (headRefName resolution) and a capturing fake review_gate_manager.py to
+prove --branch carries the PR head ref — and that the local branch is only used
+as an explicitly-logged fallback when gh cannot resolve the PR.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+GATE_SH = REPO_ROOT / "scripts" / "commands" / "gate.sh"
+
+PR_HEAD = "dispatch/20260801-oi898c-sidedoor-detector-exclusion"
+
+
+def _write_script(path: Path, content: str) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(content, encoding="utf-8")
+    path.chmod(0o755)
+    return path
+
+
+@pytest.fixture
+def env(tmp_path):
+    """Build a self-contained harness: fake `gh`, a capturing fake
+    review_gate_manager.py, a real git repo (for the local-branch fallback),
+    and a bash driver that sources gate.sh and calls cmd_gate."""
+    harness = tmp_path / "harness"
+    fake_bin = harness / "bin"
+    fake_home = harness / "vnx-home"
+    (fake_home / "scripts").mkdir(parents=True)
+    fake_state = harness / "state"
+    (fake_state / "review_gates" / "results").mkdir(parents=True)
+    project = harness / "project"
+
+    # A real git repo on main, so the local-branch fallback is deterministic.
+    subprocess.run(["git", "init", "-q", "-b", "main", str(project)], check=True)
+    subprocess.run(
+        ["git", "-C", str(project), "config", "user.email", "test@example.invalid"],
+        check=True,
+    )
+    subprocess.run(["git", "-C", str(project), "config", "user.name", "Test"], check=True)
+    (project / "file.txt").write_text("base\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(project), "add", "file.txt"], check=True)
+    subprocess.run(["git", "-C", str(project), "commit", "-qm", "base"], check=True)
+
+    # Fake gh: answer `pr view <n> --json headRefName --jq .headRefName` for
+    # the known PR, fail loudly for any other PR number.
+    _write_script(
+        fake_bin / "gh",
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+if [ "$#" -ge 3 ] && [ "$1" = "pr" ] && [ "$2" = "view" ]; then
+  pr="$3"
+  if [ "$pr" = "1281" ]; then
+    printf '%s' '{PR_HEAD}'
+    exit 0
+  fi
+  echo "gh: pr $pr not found" >&2
+  exit 1
+fi
+echo "gh: unexpected args: $*" >&2
+exit 1
+""",
+    )
+
+    # Capturing fake review_gate_manager.py: persist argv, exit 0.
+    capture = harness / "captured_args.json"
+    _write_script(
+        fake_home / "scripts" / "review_gate_manager.py",
+        f"""#!/usr/bin/env python3
+import json, sys
+json.dump(sys.argv[1:], open({str(capture)!r}, "w"))
+print(json.dumps({{"has_required_failure": False, "gates": []}}))
+""",
+    )
+
+    return {
+        "fake_bin": fake_bin,
+        "fake_home": fake_home,
+        "fake_state": fake_state,
+        "project": project,
+        "capture": capture,
+    }
+
+
+def _run_cmd_gate(env, *args: str) -> subprocess.CompletedProcess:
+    """Source gate.sh (stubbing the bin/vnx-provided log/err helpers), then call
+    cmd_gate with the mocked environment on PATH."""
+    driver = env["fake_home"].parent / "run_gate.sh"
+    driver.write_text(
+        f"""#!/usr/bin/env bash
+set -euo pipefail
+log() {{ printf '%s\\n' "$*"; }}
+err() {{ printf 'ERROR: %s\\n' "$*" >&2; }}
+export VNX_HOME={env['fake_home']}
+export VNX_STATE_DIR={env['fake_state']}
+export PROJECT_ROOT={env['project']}
+export PATH={env['fake_bin']}:$PATH
+source {GATE_SH}
+cmd_gate "$@"
+""",
+        encoding="utf-8",
+    )
+    driver.chmod(0o755)
+    return subprocess.run(
+        ["bash", str(driver), *args],
+        capture_output=True, text=True, timeout=30,
+    )
+
+
+def _captured_branch(env) -> str:
+    captured = json.loads(env["capture"].read_text(encoding="utf-8"))
+    assert "--branch" in captured
+    return captured[captured.index("--branch") + 1]
+
+
+class TestGateBranchDerivation:
+    def test_branch_is_pr_head_ref_not_local_branch(self, env):
+        """`vnx gate 1281` must pass --branch <headRefName>, never 'main'."""
+        result = _run_cmd_gate(env, "1281", "--only", "codex")
+        assert result.returncode == 0, result.stderr
+        assert _captured_branch(env) == PR_HEAD
+
+    def test_resolution_logged_explicitly(self, env):
+        """The headRefName-derived branch is reported on stdout."""
+        result = _run_cmd_gate(env, "1281", "--only", "gemini")
+        assert result.returncode == 0, result.stderr
+        assert "Resolved PR 1281 head branch" in result.stdout
+        assert PR_HEAD in result.stdout
+
+    def test_falls_back_to_local_branch_when_gh_fails(self, env):
+        """When gh cannot resolve the PR, --branch must be the local checkout
+        branch and the fallback is logged explicitly."""
+        result = _run_cmd_gate(env, "9999", "--only", "codex")
+        assert result.returncode == 0, result.stderr
+        assert "WARNING" in result.stdout
+        assert "fell back to local branch" in result.stdout
+        assert _captured_branch(env) == "main"
+
+    def test_head_ref_wins_even_when_local_branch_differs(self, env):
+        """Regression guard: on a non-main local branch, the PR head ref must
+        still win over the local branch name."""
+        subprocess.run(
+            ["git", "-C", str(env["project"]), "checkout", "-q", "-b", "feature/x"],
+            check=True,
+        )
+        result = _run_cmd_gate(env, "1281", "--only", "codex")
+        assert result.returncode == 0, result.stderr
+        assert _captured_branch(env) == PR_HEAD

--- a/tests/test_gate_worktree.py
+++ b/tests/test_gate_worktree.py
@@ -257,3 +257,55 @@ class TestConcurrentGatesDoNotCollide:
         finally:
             remove_gate_worktree(wt_a, project_root=local)
             remove_gate_worktree(wt_b, project_root=local)
+
+
+class TestLinkedWorktreeLockDir:
+    """OI-905: `_worktree_lock` must resolve the shared git dir via
+    `git rev-parse --git-common-dir`, not assume `<root>/.git` is a directory.
+
+    In a linked git worktree `.git` is an ASCII file pointing at the real
+    gitdir, so `mkdir` under `<root>/.git/worktrees` raises
+    NotADirectoryError before any gate can run. This suite reproduces that
+    exact layout (`git worktree add`) and requires create/remove to succeed.
+    """
+
+    def test_create_and_remove_work_in_linked_worktree(self, origin_and_local, tmp_path):
+        """create_gate_worktree/remove_gate_worktree must work when project_root
+        is itself a linked worktree (.git is a file, not a directory)."""
+        local = origin_and_local["local"]
+        linked = tmp_path / "linked-wt"
+        _run_git(["worktree", "add", "-b", "wt-branch", str(linked)], local)
+
+        # Sanity: in a linked worktree .git is a file, not a directory — the
+        # exact layout that crashed on `<root>/.git/worktrees` mkdir.
+        assert (linked / ".git").is_file()
+        assert not (linked / ".git").is_dir()
+
+        wt_path = create_gate_worktree(
+            branch="feature/oi-708", gate="codex_gate", identifier="linked",
+            project_root=linked,
+        )
+        try:
+            assert wt_path.exists()
+            assert (wt_path / "marker.txt").read_text() == "FRESH_FROM_PR_BRANCH\n"
+        finally:
+            remove_gate_worktree(wt_path, project_root=linked)
+
+        assert not wt_path.exists()
+
+    def test_worktree_lock_uses_common_git_dir_not_linked_git_file(
+        self, origin_and_local, tmp_path,
+    ):
+        """The lock file must land under the shared git dir's worktrees/, which
+        for a linked worktree is the main repo's .git/worktrees/, never under
+        the .git *file*."""
+        from gate_worktree import _git_common_dir
+
+        local = origin_and_local["local"]
+        linked = tmp_path / "linked-wt"
+        _run_git(["worktree", "add", "-b", "wt-branch", str(linked)], local)
+
+        common = _git_common_dir(linked)
+        assert common == (local / ".git").resolve()
+        assert common.is_dir()
+        assert (common / "worktrees").is_dir()


### PR DESCRIPTION
## What

Two coupled blockers in the gate-tooling, fixed in one PR.

**OI-905** — `scripts/lib/gate_worktree.py` `_worktree_lock` assumed `<root>/.git` is a directory. In a linked git worktree `.git` is an ASCII pointer file (~89 bytes), so `mkdir` under it raises `NotADirectoryError: [Errno 20]` before any gate runs. Fix: derive the lock dir from `git rev-parse --git-common-dir`, which returns the shared git dir in both a main checkout and a linked worktree.

**OI-904** — `scripts/commands/gate.sh` passed `--branch $(_g_current_branch)` (the local checkout branch) to `review_gate_manager`. T0 runs `vnx gate` from main, so the gate worktree checked out `origin/main` instead of the PR branch — the diff was authoritative via `gh pr diff`, but the gate agent's own file reads (sed/rg/cat) resolved against the wrong tree. Fix: resolve the branch from `gh pr view <pr> --json headRefName` and fall back to the local branch only when gh cannot resolve it (explicitly logged).

Why together: OI-905 is exactly why OI-904 was never observed — the only way to run `vnx gate` was from main, where the wrong branch is picked silently. The workaround for one is blocked by the other.

## Verification

Each finding has a regression test proven red on the old code:

- OI-905: `TestLinkedWorktreeLockDir` builds a real linked worktree (`.git` as a file) and runs the full create/remove lifecycle. On old code it fails with the exact `NotADirectoryError: .../linked-wt/.git/worktrees`; with the fix it passes (21/21 in `test_gate_worktree.py`).
- OI-904: `test_gate_pr_branch_resolution.py` mocks `gh pr view` and a capturing fake `review_gate_manager.py`, running `cmd_gate 1281` from a repo on `main`. On old code `--branch` is `main`; with the fix it is the PR `headRefName` (`dispatch/20260801-oi898c-sidedoor-detector-exclusion`). 4/4 pass.
- Broad suite (`test_gate_worktree.py`, `test_gate_pr_branch_resolution.py`, `test_gate_branch_file_resolution.py`, `test_gate_runner.py`): 62 passed, 1 failed. The single failure (`TestGateTimeoutConfig::test_default_stall_threshold`, expects 60, returns 180) is pre-existing — it fails identically on base with all changes stashed and asserts on `headless_adapter.py`, untouched here.
- Live: linked-worktree demo shows old path `NotADirectoryError` → new path resolves `git-common-dir`; `vnx gate 1281 --only codex` from a repo on `main` logs `Resolved PR 1281 head branch: dispatch/...` and passes `--branch dispatch/...`.

`tests/test_v2_gate_progression.sh` (listed as relevant) is a non-hermetic operational script requiring `tests/lib/vnx_paths.sh` + a specific completed dispatch file; it cannot run in this worktree and is not affected by these changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)