### PR TITLE
fix(dispatch): authenticate reachability probe + propagate HTTP status to receipts (OI-893, OI-866)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -238,9 +238,12 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
 
     Checks performed:
     - litellm-proxy lanes: HTTP GET http://127.0.0.1:4141/v1/models with
-      short timeout.  401/403 → hard warning (auth broken).  Connection
+      short timeout.  Carries Authorization: Bearer $LITELLM_API_KEY when that
+      env is set (OI-893) so an auth-gated proxy is probed the way the lane
+      actually talks to it.  401/403 → hard warning (auth broken).  Connection
       refused/timeout → soft warning (proxy may be down).
-    - deepseek-harness: HTTP GET to api.deepseek.com baseline check.
+    - deepseek-harness: HTTP GET to api.deepseek.com/v1/models with
+      Authorization: Bearer $DEEPSEEK_API_KEY (OI-893).
     - Other lanes: skipped (no cheap endpoint check available; claude-tmux
       has no network endpoint, codex/kimi have ephemeral auth).
     """
@@ -260,8 +263,17 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
             "http://127.0.0.1:4141",
         )
         models_url = f"{proxy_url.rstrip('/')}/v1/models"
+        # OI-893: the probe must carry the proxy's Authorization header — an
+        # unauthenticated GET to an auth-gated /v1/models returns HTTP 401 by
+        # construction, so the OK branch would be unreachable whenever the proxy
+        # enforces a key. Add the header when LITELLM_API_KEY is present; when it
+        # is absent, the 401 the proxy returns is genuine and is reported as
+        # AUTH REJECTED with a "key not set" hint, never as an OK.
+        litellm_key = os.environ.get("LITELLM_API_KEY", "").strip()
         try:
             req = urllib.request.Request(models_url)
+            if litellm_key:
+                req.add_header("Authorization", f"Bearer {litellm_key}")
             resp = urllib.request.urlopen(req, timeout=5)
             body = resp.read().decode("utf-8", errors="replace")
             # A 200 with an empty model list is suspicious but not a hard
@@ -297,11 +309,20 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
             except Exception:  # vnx-silent-except: body read is best-effort; empty case caught by `body or str(exc)` below
                 pass
             if status in (401, 403):
+                if not litellm_key:
+                    auth_hint = (
+                        "LITELLM_API_KEY is not set — ANY dispatch on this "
+                        "lane will fail silently."
+                    )
+                else:
+                    auth_hint = (
+                        "The proxy API key (LITELLM_API_KEY) is missing or "
+                        "invalid — ANY dispatch on this lane will fail silently."
+                    )
                 print(
                     f"[dispatch_cli] [WARN] litellm proxy AUTH REJECTED "
                     f"(HTTP {status}) at {models_url}. Evidence: {body or str(exc)}. "
-                    f"The proxy API key is missing or invalid — ANY dispatch on this "
-                    f"lane will fail silently.",
+                    f"{auth_hint}",
                     file=sys.stderr,
                 )
             else:
@@ -324,8 +345,16 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
         "deepseek-harness", "deepseek_harness",
     ):
         ds_url = "https://api.deepseek.com/v1/models"
+        # OI-893: the probe must carry the API key. An unauthenticated GET to
+        # api.deepseek.com/v1/models returns HTTP 401 by construction, so the
+        # OK branch was unreachable. With DEEPSEEK_API_KEY set the probe now
+        # exercises the same auth the lane uses; when it is absent the 401 is
+        # genuine and is reported as AUTH REJECTED with a "key not set" hint.
+        ds_key = os.environ.get("DEEPSEEK_API_KEY", "").strip()
         try:
             req = urllib.request.Request(ds_url)
+            if ds_key:
+                req.add_header("Authorization", f"Bearer {ds_key}")
             urllib.request.urlopen(req, timeout=5)
             print(
                 f"[dispatch_cli] [reachability] deepseek API OK: {ds_url}",
@@ -333,10 +362,15 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
             )
         except urllib.error.HTTPError as exc:
             if exc.code in (401, 403):
+                if not ds_key:
+                    auth_hint = "DEEPSEEK_API_KEY is not set."
+                elif exc.code == 403:
+                    auth_hint = "the API key is missing permissions."
+                else:
+                    auth_hint = "the API key is missing, invalid, or expired."
                 print(
                     f"[dispatch_cli] [WARN] deepseek API AUTH REJECTED "
-                    f"(HTTP {exc.code}) at {ds_url}. The API key may be missing "
-                    f"or expired.",
+                    f"(HTTP {exc.code}) at {ds_url}. {auth_hint}",
                     file=sys.stderr,
                 )
             else:

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -102,7 +102,18 @@ def normalize_litellm_event(
 
     error_type = chunk.get("error_type")
     if error_type:
-        return make("error", {"error_type": error_type, "message": chunk.get("message", "")})
+        # OI-866: carry the HTTP status through to the canonical event so the
+        # spawn-result error string (and the receipt failure_reason it feeds)
+        # can name the status code instead of dropping it. The runner emits
+        # status_code for proxy/provider HTTP errors; normalizing it here is the
+        # only place the field survives the drainer.
+        data: Dict[str, Any] = {"error_type": error_type, "message": chunk.get("message", "")}
+        status_code = chunk.get("status_code")
+        if isinstance(status_code, str) and status_code.isdigit():
+            status_code = int(status_code)
+        if isinstance(status_code, int) and 100 <= status_code <= 599:
+            data["status_code"] = status_code
+        return make("error", data)
 
     if chunk.get("event_type") == "usage_complete":
         return make("usage_complete", {"usage": chunk.get("usage") or {}})
@@ -380,11 +391,22 @@ def _finalize_litellm_result(
         etype = first_error_event.get("error_type", "")
         message = first_error_event.get("message", "")
         status_code = first_error_event.get("status_code")
-        parts = [f"litellm/{etype}"]
+        reason = first_error_event.get("reason", "")
+        parts = []
+        if etype:
+            parts.append(f"litellm/{etype}")
         if status_code is not None:
             parts.append(f"HTTP {status_code}")
         if message:
             parts.append(message)
+        # OI-866: the drainer's synthetic error event (subprocess exited
+        # non-zero with no structured error) carries only a "reason" — without
+        # this fallback the derived error collapsed to the bare "litellm/" and
+        # the receipt classified it as unknown with no diagnostic content.
+        if not parts and reason:
+            parts.append(reason)
+        if not parts:
+            parts.append(f"runner exited with code {rc} and no error detail")
         derived_error = ": ".join(parts)
 
     return LiteLLMSpawnResult(

--- a/tests/test_failclass_registry.py
+++ b/tests/test_failclass_registry.py
@@ -19,6 +19,7 @@ import json
 import os
 import sys
 import tempfile
+import urllib.error
 from pathlib import Path
 from unittest import mock
 
@@ -491,3 +492,297 @@ class TestEndToEndClassification:
         )
         assert auth_result["failure_class"] == "auth_rejected"
         assert empty_result["failure_class"] == "empty_completion"
+
+
+# ===========================================================================
+# OI-893: reachability probe authenticates the way the lane does
+# ===========================================================================
+
+class TestReachabilityAuthHeaders:
+    """OI-893: the dry-run reachability probe must send the lane's own
+    Authorization header. An unauthenticated probe against an auth-gated
+    endpoint returns 401 by construction, so the OK branch was unreachable and
+    every healthy keyed route looked dead. Each test here fails on origin/main
+    (no header is set) and passes on this branch."""
+
+    @staticmethod
+    def _plan(provider_value, lane="provider"):
+        from unittest.mock import MagicMock
+
+        plan = MagicMock()
+        plan.provider.value = provider_value
+        plan.lane = lane
+        plan.dispatch_id = "test-reach-auth"
+        return plan
+
+    def test_deepseek_probe_sends_auth_header(self):
+        """The deepseek-harness probe must send Authorization: Bearer $DEEPSEEK_API_KEY."""
+        from dispatch_cli import _check_reachability
+
+        captured = {}
+
+        def _fake_urlopen(req, timeout=5):
+            captured["headers"] = {k: v for k, v in req.header_items()}
+            raise urllib.error.HTTPError("http://x", 401, "Unauthorized", None, None)
+
+        plan = self._plan("deepseek-harness")
+        with mock.patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-probe-valid"}, clear=False), \
+                mock.patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            _check_reachability(plan, mock.MagicMock())
+
+        auth = captured["headers"].get("Authorization")
+        assert auth == "Bearer sk-probe-valid", (
+            f"probe must authenticate with DEEPSEEK_API_KEY; got header {auth!r}"
+        )
+
+    def test_litellm_probe_sends_auth_header_when_key_set(self):
+        """The litellm-proxy probe must send Authorization: Bearer $LITELLM_API_KEY when set."""
+        from dispatch_cli import _check_reachability
+
+        captured = {}
+
+        class _Resp:
+            status = 200
+
+            def read(self):
+                return json.dumps({"data": [{"id": "m1"}]}).encode()
+
+        def _fake_urlopen(req, timeout=5):
+            captured["headers"] = {k: v for k, v in req.header_items()}
+            return _Resp()
+
+        plan = self._plan("litellm:deepseek")
+        with mock.patch.dict("os.environ", {"LITELLM_API_KEY": "sk-litellm-probe"}, clear=False), \
+                mock.patch("urllib.request.urlopen", side_effect=_fake_urlopen):
+            _check_reachability(plan, mock.MagicMock())
+
+        auth = captured["headers"].get("Authorization")
+        assert auth == "Bearer sk-litellm-probe", (
+            f"litellm probe must authenticate with LITELLM_API_KEY; got header {auth!r}"
+        )
+
+    def test_deepseek_401_is_auth_rejected_not_unreachable(self, capsys):
+        """A 401 from the deepseek endpoint must be classified as AUTH REJECTED,
+        never as 'unreachable' — an auth failure and a dead endpoint are
+        different diagnostics."""
+        from dispatch_cli import _check_reachability
+
+        def _fake_401(req, timeout=5):
+            raise urllib.error.HTTPError("http://x", 401, "Unauthorized", None, None)
+
+        plan = self._plan("deepseek-harness")
+        with mock.patch.dict("os.environ", {"DEEPSEEK_API_KEY": "sk-wrong"}, clear=False), \
+                mock.patch("urllib.request.urlopen", side_effect=_fake_401):
+            _check_reachability(plan, mock.MagicMock())
+
+        captured = capsys.readouterr()
+        assert "AUTH REJECTED" in captured.err
+        assert "unreachable" not in captured.err
+
+    def test_litellm_401_without_key_names_the_missing_key(self, capsys):
+        """When LITELLM_API_KEY is unset and the proxy 401s, the probe must
+        report AUTH REJECTED with a 'key not set' hint — not OK, not unreachable."""
+        from dispatch_cli import _check_reachability
+
+        def _fake_401(req, timeout=5):
+            raise urllib.error.HTTPError("http://x", 401, "Unauthorized", None, None)
+
+        plan = self._plan("litellm:deepseek")
+        with mock.patch.dict("os.environ", {}, clear=True), \
+                mock.patch("urllib.request.urlopen", side_effect=_fake_401):
+            _check_reachability(plan, mock.MagicMock())
+
+        captured = capsys.readouterr()
+        assert "AUTH REJECTED" in captured.err
+        assert "LITELLM_API_KEY is not set" in captured.err
+        assert "unreachable" not in captured.err
+
+    def test_litellm_probe_ok_with_key_and_models(self, capsys):
+        """A 200 with a non-empty model list must print the OK branch — the
+        branch that was unreachable before the auth header existed."""
+        from dispatch_cli import _check_reachability
+
+        class _Resp:
+            status = 200
+
+            def read(self):
+                return json.dumps({"data": [{"id": "m1"}, {"id": "m2"}]}).encode()
+
+        plan = self._plan("litellm:deepseek")
+        with mock.patch.dict("os.environ", {"LITELLM_API_KEY": "sk-litellm-probe"}, clear=False), \
+                mock.patch("urllib.request.urlopen", return_value=_Resp()):
+            _check_reachability(plan, mock.MagicMock())
+
+        captured = capsys.readouterr()
+        assert "litellm proxy OK: 2 models" in captured.err
+
+
+# ===========================================================================
+# OI-866: HTTP status survives the litellm normalization chain
+# ===========================================================================
+
+class TestLiteLLMStatusPropagation:
+    """OI-866: the runner emits an HTTP status_code for a proxy/provider HTTP
+    error. It must survive normalize_litellm_event and _finalize_litellm_result
+    so the receipt failure_reason names the status code instead of collapsing
+    to a bare 'litellm/' prefix."""
+
+    def test_normalize_litellm_event_preserves_status_code(self):
+        from provider_spawns.litellm_spawn import normalize_litellm_event
+
+        ev = normalize_litellm_event(
+            {"error_type": "credentials_missing", "message": "Invalid API key", "status_code": 401},
+            "T1", "d-status",
+        )
+        assert ev.event_type == "error"
+        assert ev.data["error_type"] == "credentials_missing"
+        assert ev.data["status_code"] == 401
+
+    def test_normalize_litellm_event_ignores_bogus_status(self):
+        from provider_spawns.litellm_spawn import normalize_litellm_event
+
+        ev = normalize_litellm_event(
+            {"error_type": "completion_error", "message": "boom", "status_code": "not-a-number"},
+            "T1", "d-status",
+        )
+        assert ev.data["error_type"] == "completion_error"
+        assert "status_code" not in ev.data
+
+    def test_finalize_litellm_result_includes_http_status(self):
+        from provider_spawns.litellm_spawn import _finalize_litellm_result
+
+        class _FakeProc:
+            returncode = 1
+
+            def wait(self, timeout=10):
+                return 1
+
+        result = _finalize_litellm_result(
+            _FakeProc(), "", 1, False, False,
+            first_error_event={
+                "error_type": "credentials_missing",
+                "message": "Invalid API key",
+                "status_code": 401,
+            },
+        )
+        assert result.error is not None
+        assert "HTTP 401" in result.error
+        assert "credentials_missing" in result.error
+
+    def test_finalize_litellm_result_synthetic_error_is_not_bare_prefix(self):
+        """The drainer's synthetic error (reason only) must not collapse to the
+        bare 'litellm/' prefix — it must carry the exit reason so classification
+        has content instead of 'unknown' with a meaningless reason."""
+        from provider_spawns.litellm_spawn import _finalize_litellm_result
+
+        class _FakeProc:
+            returncode = 1
+
+            def wait(self, timeout=10):
+                return 1
+
+        result = _finalize_litellm_result(
+            _FakeProc(), "", 0, False, False,
+            first_error_event={"reason": "subprocess exited with code 1 before complete event"},
+        )
+        assert result.error is not None
+        assert result.error != "litellm/"
+        assert "subprocess exited with code 1" in result.error
+
+    def test_spawn_litellm_derives_401_error_from_error_event(self):
+        """The real spawn chain (normalize -> consume -> finalize) derives a
+        classified error from a status_code-carrying error event."""
+        from provider_spawns.litellm_spawn import normalize_litellm_event, spawn_litellm
+
+        error_event = normalize_litellm_event(
+            {"error_type": "credentials_missing", "message": "Invalid API key", "status_code": 401},
+            "T1", "d-spawn-401",
+        )
+
+        proc = mock.MagicMock()
+        proc.pid = 99
+        proc.returncode = 1
+        proc.wait = mock.MagicMock(return_value=1)
+        proc.poll = mock.MagicMock(return_value=1)
+        proc.stdin = mock.MagicMock()
+
+        with mock.patch("provider_spawns.litellm_spawn.subprocess.Popen", return_value=proc), \
+                mock.patch(
+                    "provider_spawns.litellm_spawn._LiteLLMNormalizerHost.drain_stream",
+                    return_value=iter([error_event]),
+                ):
+            result = spawn_litellm(
+                prompt="test", model="deepseek/v3.2",
+                dispatch_id="d-spawn-401", terminal_id="T1",
+            )
+
+        assert result.error is not None
+        assert "HTTP 401" in result.error
+        assert result.returncode != 0
+
+
+# ===========================================================================
+# OI-866 end-to-end: provider-lane 401 -> receipt carries classified reason
+# ===========================================================================
+
+class Test401ProviderLaneReceipt:
+    """OI-866: a provider-lane 401 failure must land in the receipt as a
+    classified auth_rejected failure_reason — never '(no error captured)'."""
+
+    def test_run_envelope_plan_401_receipt_has_classified_reason(self, tmp_path):
+        """Drive run_envelope_plan with a spawn that reports a 401 and assert
+        the emitted receipt carries failure_class=auth_rejected and the HTTP
+        status in failure_reason."""
+        from dispatch_envelope import run_envelope_plan
+        from dispatch_internal import issue_permit
+        from dispatch_spec import Provider
+        from provider_spawns.litellm_spawn import LiteLLMSpawnResult
+        from test_dispatch_envelope_fail_loud import _make_provider_plan
+
+        plan = _make_provider_plan(
+            tmp_path, provider=Provider.LITELLM_DEEPSEEK, model="default",
+            dispatch_id="test-401-provider-lane",
+        )
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_wt = tmp_path / "wt"
+        fake_wt.mkdir()
+
+        failed_spawn = LiteLLMSpawnResult(
+            returncode=1,
+            completion_text="",
+            events_written=1,
+            session_id=None,
+            timed_out=False,
+            error="litellm/credentials_missing: HTTP 401: AuthenticationError: Invalid API key",
+            token_usage=None,
+        )
+
+        with mock.patch("provider_spawns.litellm_spawn.spawn_litellm", return_value=failed_spawn), \
+                mock.patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=fake_wt), \
+                mock.patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+                mock.patch("dispatch_envelope._resolve_phantom_diff", return_value=None):
+            result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
+
+        assert result.status == "failure"
+        assert result.error is not None
+        assert "HTTP 401" in result.error
+
+        receipt_file = state_dir / "t0_receipts.ndjson"
+        assert receipt_file.exists(), "t0_receipts.ndjson must be written for a provider-lane failure"
+        lines = [ln for ln in receipt_file.read_text().splitlines() if ln.strip()]
+        assert lines, "receipt ledger must not be empty"
+
+        data = json.loads(lines[0])
+        assert data["dispatch_id"] == "test-401-provider-lane"
+        assert data["status"] == "failure"
+        assert data["failure_class"] == "auth_rejected", (
+            f"a 401 must classify as auth_rejected, got {data.get('failure_class')!r}"
+        )
+        assert "HTTP 401" in data["failure_reason"], (
+            f"failure_reason must name the HTTP status, got {data.get('failure_reason')!r}"
+        )

--- a/tests/test_token_extraction_per_provider.py
+++ b/tests/test_token_extraction_per_provider.py
@@ -66,7 +66,7 @@ class TestLiteLLMUsageCompleteEvent:
         host_mock = MagicMock(spec=_LiteLLMNormalizerHost)
         host_mock.drain_stream.return_value = iter([usage_event])
 
-        text, events_written, timed_out, stopped_early, ew_failures, token_usage = _consume_litellm_stream(
+        text, events_written, timed_out, stopped_early, ew_failures, token_usage, first_error_event = _consume_litellm_stream(
             proc=proc_mock,
             host=host_mock,
             on_event=None,
@@ -81,6 +81,9 @@ class TestLiteLLMUsageCompleteEvent:
 
         assert token_usage == usage_payload
         assert events_written == 1
+        # The 7th return value (OI-866 first-error-event capture) stays None on a
+        # clean usage_complete stream.
+        assert first_error_event is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Two blockers in the provider-lane diagnostics, one theme: a lane that cannot say what went wrong.

## OI-893 — a probe that could never report OK
`_check_reachability` in `scripts/lib/dispatch_cli.py` sent an **unauthenticated** request to auth-gated endpoints:
- deepseek-harness → `https://api.deepseek.com/v1/models`
- litellm proxy → `http://127.0.0.1:4141/v1/models`

An unauthenticated GET to a keyed endpoint returns HTTP 401 by construction, so the OK branch was unreachable and every healthy route looked dead. Verified against the live endpoint: no key → 401, `$DEEPSEEK_API_KEY` → 200.

**Fix:** the probe now carries `Authorization: Bearer` from the lane's own key env — `DEEPSEEK_API_KEY` for deepseek-harness, `LITELLM_API_KEY` (when set) for the litellm proxy. A 401 is reported as **AUTH REJECTED** with a hint naming the missing/invalid key, never as "unreachable".

## OI-866 — a 401 that left no trace
`normalize_litellm_event` dropped the `status_code` the runner emits for proxy/provider HTTP errors, and the drainer's synthetic error (subprocess exit with no structured error) collapsed to a bare `"litellm/"` prefix. Both left the receipt without a usable classified reason.

**Fix:** `status_code` now survives the normalize → consume → finalize chain, so the derived error string and the receipt `failure_reason` name `HTTP 401`, and `failure_class` is `auth_rejected` — never `(no error captured)`.

## Dead-route registry
The reachability probe output does **not** feed the dead-route registry. The registry (`wave7_models.yaml` via `provider_registry.load()`) is static config; the probe only prints to stderr for the operator. The probe's misleading 401 was the only way a healthy route could look dead, which is what OI-893 removes.

## Verification
- Real probe call with valid key → `deepseek API OK`
- Invalid key → `AUTH REJECTED (HTTP 401)`, not unreachable
- End-to-end provider-lane 401 → receipt carries `failure_class: auth_rejected` and `failure_reason: litellm-proxy: litellm/credentials_missing: HTTP 401: ...`
- New tests fail on origin/main (header absent, status_code dropped)

## Tests
- `tests/test_failclass_registry.py`: reachability auth-header tests, status-code propagation unit tests, end-to-end 401 receipt test (34 → 40 tests in file)
- `tests/test_token_extraction_per_provider.py`: fixed pre-existing 6-tuple unpack (7th return value added by #1264)

🤖 Generated with [Claude Code](https://claude.com/claude-code)