### PR TITLE
fix(dispatch): scale chunk stall to the spec deadline and preserve partial output on SIGTERM (OI-903)

### DIFF
--- a/scripts/lib/_streaming_drainer.py
+++ b/scripts/lib/_streaming_drainer.py
@@ -39,6 +39,46 @@ _COMPLETE_TYPES = frozenset({"complete", "result"})
 # Default bounded queue size — large enough to buffer burst, small enough to apply backpressure
 _DEFAULT_QUEUE_MAXSIZE = 256
 
+# Stall floor for the per-chunk timeout, as a fraction of the total deadline.
+#
+# OI-903: a kimi worker with deadline_seconds=3600 was SIGTERM'd at 1890.6s by the
+# 1200s chunk timeout after a legitimate 1200s silent thinking phase — the chunk
+# timeout sat FAR below the deadline, so it (not the deadline) became the binding
+# constraint. The chunk timeout measures silence, so a fixed value far under a long
+# deadline kills legitimate long-think work and makes the deadline decorative.
+#
+# The relationship is now explicit: the effective chunk timeout is clamped into the
+# band [total_deadline * _STALL_FLOOR_FRACTION, total_deadline]:
+#   - never above the total deadline (a stall longer than the whole budget IS the
+#     deadline),
+#   - never below half the deadline (a worker that produces nothing for half its
+#     budget is genuinely stalled; anything shorter stays legitimate).
+#
+# Explicit env-var overrides (VNX_CHUNK_TIMEOUT and the per-provider
+# VNX_*_STALL_THRESHOLD vars) retain top precedence and are never floored — an
+# operator who sets a stall threshold deliberately keeps it.
+_STALL_FLOOR_FRACTION = 0.5
+
+
+def coerce_chunk_stall(chunk_timeout: float, total_deadline: float) -> float:
+    """Return *chunk_timeout* coerced into the stall band relative to *total_deadline*.
+
+    The returned value satisfies::
+
+        min(total_deadline * _STALL_FLOOR_FRACTION, chunk_timeout)
+        <= value <= total_deadline
+
+    when total_deadline > 0 and chunk_timeout > 0; otherwise *chunk_timeout* is
+    returned unchanged (a non-positive deadline means the loop below fires
+    immediately anyway, and a non-positive chunk timeout is an explicit
+    "no stall tolerance" signal). See the module constant block for the
+    rationale (OI-903).
+    """
+    if total_deadline <= 0 or chunk_timeout <= 0:
+        return chunk_timeout
+    chunk_timeout = min(chunk_timeout, total_deadline)
+    return max(chunk_timeout, total_deadline * _STALL_FLOOR_FRACTION)
+
 
 class StreamingDrainerMixin:
     """Mixin that drains provider subprocess stdout into CanonicalEvent objects.
@@ -117,6 +157,14 @@ class StreamingDrainerMixin:
             total_deadline = float(os.environ.get("VNX_TOTAL_DEADLINE", total_deadline))
         except (TypeError, ValueError):
             pass
+
+        # OI-903: tie the chunk (stall) timeout to the total deadline so a long
+        # deadline is the binding constraint, not a fixed stall value far below it.
+        # Skipped when VNX_CHUNK_TIMEOUT is set explicitly — env overrides retain
+        # top precedence (the per-provider stall env vars are handled upstream in
+        # each spawn, which then passes already-resolved values here).
+        if "VNX_CHUNK_TIMEOUT" not in os.environ:
+            chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
         result_queue: queue.Queue = queue.Queue(maxsize=_queue_maxsize)
         seen_complete = threading.Event()

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -663,7 +663,10 @@ def _govern(
 
     duration = (end_time - start_time).total_seconds()
 
-    # REPORT first — idempotent: worker-written file is preserved, not overwritten
+    # REPORT first — idempotent: worker-written file is preserved, not overwritten.
+    # OI-903: on failure/timeout, a killed worker's partial report is preserved
+    # under a .partial.md sidecar so the canonical report stays contract-compliant
+    # while the partial output remains retrievable.
     report_path: Optional[Path] = None
     try:
         report_path = emit_unified_report(
@@ -675,6 +678,7 @@ def _govern(
             findings=[],
             duration_seconds=duration,
             data_dir=spec.data_dir,
+            preserve_partial=adapter_result.status != "success",
         )
     except Exception as exc:
         logger.error(

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -43,6 +43,7 @@ from append_receipt_internals.receipt_finalize import (
 )
 from append_receipt_internals.validation import _validate_receipt
 from receipt_schema import ReceiptV2
+from report_body_contract import validate_body
 from token_harvest import CLAUDE_HARNESS_PROVIDERS
 
 logger = logging.getLogger(__name__)
@@ -351,6 +352,7 @@ def emit_unified_report(
     frontmatter: Optional[Dict[str, Any]] = None,
     body_override: Optional[str] = None,
     overwrite: bool = False,
+    preserve_partial: bool = False,
 ) -> Path:
     """Atomic write to unified_reports/<dispatch_id>.md. Returns path.
 
@@ -366,6 +368,15 @@ def emit_unified_report(
     govern() passes overwrite=True for synthesized/violated bodies to replace
     stale placeholder files that would otherwise block idempotent early-return.
 
+    When *preserve_partial* is True (failure/timeout emitters) and the existing
+    report fails the report-body contract, the partial body is preserved under
+    ``<dispatch_id>.partial.md`` and the fresh structured report is written in its
+    place. OI-903: a worker SIGTERM'd mid-report leaves a partial file that would
+    otherwise block the idempotent early-return AND satisfy nothing — the
+    preserved sidecar makes the partial output retrievable while the canonical
+    report stays contract-compliant. An existing report that PASSES the contract
+    is never touched (idempotent early-return still applies).
+
     When *frontmatter* is provided, prepends a YAML frontmatter block and
     validates against unified_report_v1 schema.  Default is shadow-mode (log
     violations, do not raise).  Set VNX_SCHEMA_STRICT=1 to raise on violation.
@@ -378,7 +389,38 @@ def emit_unified_report(
 
     report_path = reports_dir / f"{dispatch_id}.md"
     if report_path.exists() and not overwrite:
-        return report_path
+        if preserve_partial:
+            try:
+                existing = report_path.read_text(encoding="utf-8", errors="replace")
+            except OSError as _read_exc:
+                logger.warning(
+                    "governance_emit: could not read existing report %s for partial check (%s); "
+                    "returning as-is",
+                    report_path, _read_exc,
+                )
+                return report_path
+            if not validate_body(existing).valid:
+                # Killed-worker artifact: preserve the partial output under a
+                # .partial.md sidecar so the work is retrievable, then let the
+                # fresh structured report (written below) take the canonical path.
+                partial_path = reports_dir / f"{dispatch_id}.partial.md"
+                try:
+                    os.replace(report_path, partial_path)
+                    logger.info(
+                        "governance_emit: preserved partial report dispatch=%s at %s",
+                        dispatch_id, partial_path,
+                    )
+                except OSError as _mv_exc:
+                    logger.warning(
+                        "governance_emit: could not preserve partial report %s as %s (%s); "
+                        "returning as-is",
+                        report_path, partial_path, _mv_exc,
+                    )
+                    return report_path
+            else:
+                return report_path
+        else:
+            return report_path
 
     if body_override is not None:
         body = body_override

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -837,6 +837,10 @@ def _emit_governance(
                 duration_seconds=duration,
                 data_dir=data_dir,
                 frontmatter=frontmatter,
+                # OI-903: on failure/timeout, preserve a killed worker's partial
+                # report under a .partial.md sidecar instead of leaving an invalid
+                # file blocking the canonical (structured) failure report.
+                preserve_partial=status != "success",
             )
             print(f"Report: {report_path}", file=sys.stderr)
             break

--- a/scripts/lib/provider_spawns/codex_spawn.py
+++ b/scripts/lib/provider_spawns/codex_spawn.py
@@ -30,7 +30,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1])
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -612,6 +612,11 @@ def spawn_codex(
         total_deadline = float(os.environ["VNX_CODEX_TIMEOUT"])
     except (KeyError, ValueError):
         pass
+    # OI-903: scale the stall timeout with the total deadline so a long deadline
+    # stays the binding constraint. Skipped when VNX_CODEX_STALL_THRESHOLD is set
+    # explicitly — env overrides retain precedence.
+    if "VNX_CODEX_STALL_THRESHOLD" not in os.environ:
+        chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
     proc, early_result = _launch_codex_proc(prompt, model, extra_env, cwd)
     if early_result is not None:

--- a/scripts/lib/provider_spawns/gemini_spawn.py
+++ b/scripts/lib/provider_spawns/gemini_spawn.py
@@ -32,7 +32,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1])
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -308,6 +308,11 @@ def spawn_gemini(
         total_deadline = float(os.environ.get("VNX_GEMINI_TIMEOUT", total_deadline))
     except (TypeError, ValueError):
         pass
+    # OI-903: scale the stall timeout with the total deadline so a long deadline
+    # stays the binding constraint. Skipped when VNX_GEMINI_STALL_THRESHOLD is set
+    # explicitly — env overrides retain precedence.
+    if "VNX_GEMINI_STALL_THRESHOLD" not in os.environ:
+        chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
     env = {**os.environ, **(extra_env or {})}
     cwd_str = str(cwd) if cwd is not None else None

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -64,7 +64,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1])
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -908,6 +908,11 @@ def spawn_kimi(
         total_deadline = float(os.environ.get("VNX_KIMI_TIMEOUT", total_deadline))
     except (TypeError, ValueError):
         pass
+    # OI-903: scale the stall timeout with the total deadline so a long spec
+    # deadline is the binding constraint, not a fixed 1200s silence. Skipped when
+    # VNX_KIMI_STALL_THRESHOLD is set explicitly — env overrides retain precedence.
+    if "VNX_KIMI_STALL_THRESHOLD" not in os.environ:
+        chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
     env = _isolate_kimi_env({**os.environ, **(extra_env or {})})
     cwd_str = str(cwd) if cwd is not None else None

--- a/scripts/lib/provider_spawns/litellm_spawn.py
+++ b/scripts/lib/provider_spawns/litellm_spawn.py
@@ -36,7 +36,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1])
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from _streaming_drainer import StreamingDrainerMixin  # noqa: E402
+from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -499,6 +499,11 @@ def spawn_litellm(
         total_deadline = float(os.environ.get("VNX_LITELLM_TIMEOUT", total_deadline))
     except (TypeError, ValueError):
         pass
+    # OI-903: scale the stall timeout with the total deadline so a long deadline
+    # stays the binding constraint. Skipped when VNX_LITELLM_STALL_THRESHOLD is set
+    # explicitly — env overrides retain precedence.
+    if "VNX_LITELLM_STALL_THRESHOLD" not in os.environ:
+        chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
 
     try:
         _validate_tool_shape(prompt, tool_call_shape)

--- a/scripts/lib/subprocess_adapter.py
+++ b/scripts/lib/subprocess_adapter.py
@@ -43,6 +43,7 @@ from adapter_types import (
     SpawnResult,
     StopResult,
 )
+from _streaming_drainer import coerce_chunk_stall  # noqa: E402 — shared stall/deadline rule (OI-903)
 
 logger = logging.getLogger(__name__)
 
@@ -624,6 +625,11 @@ class SubprocessAdapter:
             total_deadline = float(os.environ["VNX_TOTAL_DEADLINE"])
         except (KeyError, ValueError):
             pass
+        # OI-903: the chunk (stall) timeout must scale with the total deadline so a
+        # long deadline stays the binding constraint. Skipped when VNX_CHUNK_TIMEOUT
+        # is set explicitly — env overrides retain top precedence.
+        if "VNX_CHUNK_TIMEOUT" not in os.environ:
+            chunk_timeout = coerce_chunk_stall(chunk_timeout, total_deadline)
         # Clear any prior timeout flag for this terminal
         self._timed_out.discard(terminal_id)
         process = self._processes.get(terminal_id)

--- a/tests/test_governance_emit.py
+++ b/tests/test_governance_emit.py
@@ -436,6 +436,69 @@ def test_unified_report_includes_findings(tmp_data):
 
 
 # ---------------------------------------------------------------------------
+# OI-903 — preserve a killed worker's partial report via .partial.md sidecar
+# ---------------------------------------------------------------------------
+
+def _write_worker_report(data_dir, content: str) -> Path:
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    path = reports_dir / "test-dispatch-002.md"
+    path.write_text(content, encoding="utf-8")
+    return path
+
+
+def test_preserve_partial_renames_invalid_report_and_writes_fresh(tmp_data):
+    """A partial (contract-invalid) worker report is preserved as .partial.md and
+    the canonical report is rewritten as a structured body."""
+    partial_content = (
+        "Worker report cut off mid-sentence:...plus the PR round-1 changes:Po\n"
+        "## Findings: None\n"
+    )
+    _write_worker_report(tmp_data, partial_content)
+
+    path = emit_unified_report(
+        **_base_report_kwargs(tmp_data), preserve_partial=True,
+    )
+
+    # Fresh structured report at the canonical path.
+    assert path == tmp_data / "unified_reports" / "test-dispatch-002.md"
+    assert "## Response" in path.read_text()
+    # Partial output preserved and retrievable.
+    partial = tmp_data / "unified_reports" / "test-dispatch-002.partial.md"
+    assert partial.exists(), "killed-worker partial report must be preserved"
+    assert "plus the PR round-1 changes:Po" in partial.read_text()
+
+
+def test_preserve_partial_keeps_valid_worker_report(tmp_data):
+    """A contract-compliant worker report is never touched by preserve_partial."""
+    valid = (
+        "## Summary\n"
+        + ("x" * 60)
+        + "\n## Changes\n- thing\n## Verification\n- ok\n## Open Items\nNone\n"
+    )
+    _write_worker_report(tmp_data, valid)
+
+    path = emit_unified_report(
+        **_base_report_kwargs(tmp_data), preserve_partial=True,
+    )
+
+    # Idempotent early-return: the worker's valid report is preserved verbatim.
+    assert "## Summary" in path.read_text()
+    assert not (tmp_data / "unified_reports" / "test-dispatch-002.partial.md").exists()
+
+
+def test_preserve_partial_default_is_idempotent_preserve(tmp_data):
+    """Without preserve_partial (success path), the worker report is preserved as-is."""
+    partial_content = "partial body without contract headings"
+    _write_worker_report(tmp_data, partial_content)
+
+    path = emit_unified_report(**_base_report_kwargs(tmp_data))
+
+    assert path.read_text() == partial_content
+    assert not (tmp_data / "unified_reports" / "test-dispatch-002.partial.md").exists()
+
+
+# ---------------------------------------------------------------------------
 # Receipt-quality PR-1 — role + receipt_kind propagation
 # ---------------------------------------------------------------------------
 

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -1330,5 +1330,85 @@ class TestKimiFabricationInvariantEndToEnd(unittest.TestCase):
         self.assertEqual(result.returncode, 0)
 
 
+class TestSpawnKimiChunkStallFloor(unittest.TestCase):
+    """OI-903: spawn_kimi scales the chunk (stall) timeout with the total deadline."""
+
+    def _spawn_and_capture_timeouts(self, *, chunk_timeout, total_deadline):
+        """Run spawn_kimi with drain_stream stubbed to capture the effective timeouts."""
+        captured = {}
+
+        def fake_drain(
+            self, process, terminal_id, dispatch_id, event_store, *,
+            chunk_timeout, total_deadline,
+        ):
+            captured["chunk_timeout"] = chunk_timeout
+            captured["total_deadline"] = total_deadline
+            return iter(())
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.poll.return_value = 0
+        fake_proc.stdout = io.BytesIO(b"")
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=0)
+
+        # Remove the spawn-specific stall env so the default path is exercised.
+        saved = {
+            k: os.environ.pop(k)
+            for k in ("VNX_KIMI_STALL_THRESHOLD", "VNX_KIMI_TIMEOUT")
+            if k in os.environ
+        }
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start, \
+                 patch("provider_spawns.kimi_spawn._KimiNormalizerHost.drain_stream", fake_drain):
+                mock_start.return_value = (fake_proc, None)
+                spawn_kimi(
+                    "prompt", dispatch_id="d1", terminal_id="T1",
+                    chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+                )
+        finally:
+            os.environ.update(saved)
+        return captured
+
+    def test_long_deadline_floors_default_stall(self):
+        """1200s stall with a 3600s deadline is floored to 1800s at the spawn."""
+        captured = self._spawn_and_capture_timeouts(
+            chunk_timeout=1200.0, total_deadline=3600.0,
+        )
+        self.assertEqual(captured["chunk_timeout"], 1800.0)
+        self.assertEqual(captured["total_deadline"], 3600.0)
+
+    def test_spawn_specific_env_override_skips_floor(self):
+        """VNX_KIMI_STALL_THRESHOLD explicitly set retains top precedence."""
+        captured = {}
+
+        def fake_drain(
+            self, process, terminal_id, dispatch_id, event_store, *,
+            chunk_timeout, total_deadline,
+        ):
+            captured["chunk_timeout"] = chunk_timeout
+            captured["total_deadline"] = total_deadline
+            return iter(())
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.poll.return_value = 0
+        fake_proc.stdout = io.BytesIO(b"")
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=0)
+
+        with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start, \
+             patch("provider_spawns.kimi_spawn._KimiNormalizerHost.drain_stream", fake_drain), \
+             patch.dict(os.environ, {"VNX_KIMI_STALL_THRESHOLD": "30.0"}, clear=False):
+            mock_start.return_value = (fake_proc, None)
+            spawn_kimi(
+                "prompt", dispatch_id="d1", terminal_id="T1",
+                chunk_timeout=1200.0, total_deadline=3600.0,
+            )
+
+        self.assertEqual(captured["chunk_timeout"], 30.0)
+        self.assertEqual(captured["total_deadline"], 3600.0)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_streaming_drainer.py
+++ b/tests/test_streaming_drainer.py
@@ -25,6 +25,7 @@ from _streaming_drainer import (
     _make_error_event,
     _parse_line,
     _STREAMING_TIER,
+    coerce_chunk_stall,
 )
 
 
@@ -324,6 +325,106 @@ class TestTierLabeling:
         events = list(adapter.drain_stream(proc, "T1", "d-001", event_store=None))
 
         assert events[0].observability_tier == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: OI-903 chunk-stall / total-deadline relationship
+# ---------------------------------------------------------------------------
+
+class TestChunkStallCoercion:
+    """The chunk (stall) timeout must scale with the total deadline."""
+
+    def test_kimi_long_deadline_stall_floor(self):
+        """1200s stall default with a 3600s deadline is floored to 1800s.
+
+        Regression for OI-903: a kimi worker was SIGTERM'd at 1890.6s by the
+        1200s chunk timeout after a legitimate 1200s silent thinking phase.
+        """
+        assert coerce_chunk_stall(1200.0, 3600.0) == 1800.0
+
+    def test_chunk_never_exceeds_total_deadline(self):
+        """A stall timeout above the deadline is capped at the deadline."""
+        assert coerce_chunk_stall(4000.0, 3600.0) == 3600.0
+        assert coerce_chunk_stall(300.0, 900.0) == 450.0
+
+    def test_positive_deadline_floor_unchanged_when_already_above(self):
+        """A chunk already above half the deadline passes through unchanged."""
+        assert coerce_chunk_stall(1800.0, 3600.0) == 1800.0
+
+    def test_nonpositive_values_unchanged(self):
+        """Non-positive deadline or chunk is left alone (loop fires immediately)."""
+        assert coerce_chunk_stall(1200.0, 0.0) == 1200.0
+        assert coerce_chunk_stall(0.0, 3600.0) == 0.0
+        assert coerce_chunk_stall(1200.0, -5.0) == 1200.0
+
+
+class TestStallSurvival:
+    """A worker silent longer than the raw chunk timeout but within its deadline
+    must NOT be killed by the stall detector (OI-903)."""
+
+    def test_long_silence_within_deadline_not_killed(self, monkeypatch):
+        """chunk_timeout=1 with a 10s deadline: the floor raises the effective
+        stall to 5s, so a 2s silent gap between lines survives.
+
+        Red on the old code: the 1s chunk timeout fires at t=1s and the worker
+        is killed before its second line (t=2s) arrives.
+        """
+        monkeypatch.delenv("VNX_CHUNK_TIMEOUT", raising=False)
+        monkeypatch.delenv("VNX_TOTAL_DEADLINE", raising=False)
+
+        script = (
+            "import sys, time\n"
+            'sys.stdout.write(\'{"type":"text","data":{"n":0}}\' + "\\n")\n'
+            "sys.stdout.flush()\n"
+            "time.sleep(2)\n"
+            'sys.stdout.write(\'{"type":"text","data":{"n":1}}\' + "\\n")\n'
+            "sys.stdout.flush()\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            start_new_session=True,  # own session so _kill_process's killpg is scoped
+        )
+        adapter = _EchoNormalizer()
+        events = list(adapter.drain_stream(
+            proc, "T1", "d-oi903", event_store=None,
+            chunk_timeout=1.0, total_deadline=10.0,
+        ))
+
+        types = [e.event_type for e in events]
+        assert types == ["text", "text"], (
+            f"expected both lines delivered, got {types} (worker was killed by "
+            f"an un-scaled chunk timeout)"
+        )
+        assert not [e for e in events if e.event_type == "error"]
+
+    def test_env_chunk_timeout_override_skips_floor(self, monkeypatch):
+        """VNX_CHUNK_TIMEOUT retains top precedence: an explicit override fires
+        fast even when far below the deadline (no floor applied)."""
+        monkeypatch.setenv("VNX_CHUNK_TIMEOUT", "0.2")
+        monkeypatch.delenv("VNX_TOTAL_DEADLINE", raising=False)
+
+        script = (
+            "import sys, time\n"
+            "sys.stdout.write('hello-not-json')\n"
+            "sys.stdout.flush()\n"
+            "time.sleep(5)\n"
+        )
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            start_new_session=True,  # own session so _kill_process's killpg is scoped
+        )
+        adapter = _EchoNormalizer()
+        t0 = time.monotonic()
+        events = list(adapter.drain_stream(
+            proc, "T1", "d-env", event_store=None,
+            chunk_timeout=30.0, total_deadline=30.0,
+        ))
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 3.0, f"env override should fire fast, got {elapsed:.2f}s"
+        assert any(e.event_type == "error" for e in events)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wat

Een chunk-timeout van 1200s doodde een worker met een deadline van 3600s. De chunk-timeout meet
tijd **zonder output**, niet totale looptijd, dus een worker die lang nadenkt zonder te schrijven
raakt die grens terwijl zijn eigen deadline ruim genoeg is.

Gemeten op de ronde-2-dispatch van 31-07: 1890,6s gedraaid, `status=failure`,
`failure_reason='chunk timeout 1200s exceeded / subprocess exited with code -15'`. Code -15 is
SIGTERM, dus gedood en niet gecrasht. Nul commits, nul branch, nul PR. Het rapport eindigde midden
in een zin. 31 minuten inference weg.

Deze PR doet beide sporen: de stall-grens schaalt mee met de spec-deadline
(`coerce_chunk_stall`), en partiële output wordt bij een SIGTERM bewaard in plaats van weggegooid.
De andere spawns zijn meegenomen.

## Verificatie (door T0 zelf gemeten)

- 166 passed op deze branch.
- Tegen `origin/main`: **3 failed** plus een collection-error.
  - `test_governance_emit.py::test_preserve_partial_renames_invalid_report_and_writes_fresh`
  - `test_governance_emit.py::test_preserve_partial_keeps_valid_worker_report`
  - `test_kimi_spawn.py::TestSpawnKimiChunkStallFloor::test_long_deadline_floors_default_stall`
  - `test_streaming_drainer.py` faalt op main met `ImportError: cannot import name 'coerce_chunk_stall'`
    (nieuwe API, bestaat daar nog niet).

## Herkomst

De worker is extern gestopt op ~15 minuten voordat hij zijn unified report kon schrijven, dus er
is geen receipt. T0 heeft het change-set gered en zelf geverifieerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUCscZ8vsNRfNwwFoyrPkH