### PR TITLE
fix(mode): resolve mode.json through fabric resolver + fail-loud write guard (OI-911)

### DIFF
--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -82,14 +82,40 @@ MODE_FILENAME = "mode.json"
 
 
 def _mode_file_path(data_dir: Optional[str] = None) -> Path:
-    """Return path to mode.json, deriving from environment if needed."""
-    if data_dir is None:
-        data_dir = os.environ.get("VNX_DATA_DIR")
-    if not data_dir:
-        raise RuntimeError(
-            "VNX_DATA_DIR not set. Run 'vnx init' first."
-        )
-    return Path(data_dir) / MODE_FILENAME
+    """Return the path to mode.json, resolving the data dir like the rest of the fabric.
+
+    Resolution order (the same two-key contract as ``project_root.resolve_data_dir``
+    and ``vnx_paths.resolve_paths``):
+
+      1. A caller-supplied ``data_dir`` wins (callers like ``vnx_setup`` /
+         ``vnx_starter`` pass the already-resolved ``VNX_DATA_DIR``).
+      2. ``VNX_DATA_DIR`` — honored ONLY when ``VNX_DATA_DIR_EXPLICIT=1`` is also
+         set. A bare inherited ``VNX_DATA_DIR`` is pollution, not config.
+      3. The fabric-controlled store for the active project:
+         ``vnx_paths.resolve_paths()["VNX_DATA_DIR"]`` — the SAME resolver the rest
+         of the fabric uses (``vnx_init``, ``vnx_setup``, ``vnx_starter``), which
+         applies the two-key contract and the data-dir/project-id guard.
+
+    Previously this read ``os.environ["VNX_DATA_DIR"]`` raw — the fourth data-dir
+    resolver in the fabric and the only one without any protection. A suite-wide
+    test run that pinned a scratch pad with ``VNX_DATA_DIR_EXPLICIT=1`` lost the
+    flag in a cleaned-env subprocess and the write silently fell back to
+    ``~/.vnx-data/<project_id>`` (OI-911).
+    """
+    if data_dir:
+        return Path(data_dir).expanduser().resolve() / MODE_FILENAME
+
+    explicit_val = os.environ.get("VNX_DATA_DIR", "").strip()
+    if explicit_val and os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1":
+        return Path(explicit_val).expanduser().resolve() / MODE_FILENAME
+
+    # Deferred import: vnx_paths pulls in data_dir_guard / project_root, which
+    # must not be loaded at vnx_mode import time (vnx_mode is imported by the
+    # bash CLI from minimal PYTHONPATHs). resolve_paths itself warns about a bare
+    # VNX_DATA_DIR and runs the project-id guard on the resolved store.
+    from vnx_paths import resolve_paths
+    resolved = Path(resolve_paths()["VNX_DATA_DIR"]).expanduser().resolve()
+    return resolved / MODE_FILENAME
 
 
 def _atomic_write_json(path: Path, payload: Dict[str, Any]) -> None:
@@ -126,9 +152,77 @@ def read_mode(data_dir: Optional[str] = None) -> Optional[VNXMode]:
         return None
 
 
+def _guard_mode_write_target(target_dir: Path) -> None:
+    """Fail loud when a mode.json write would land outside the active project store.
+
+    Two checks (OI-911):
+
+    1. Divergence guard. When ``VNX_DATA_DIR`` is set WITHOUT
+       ``VNX_DATA_DIR_EXPLICIT=1``, the two-key contract treats it as inherited
+       pollution and the fabric resolver falls back to the resolved store. If
+       that fallback diverges from the env value, the process was configured for
+       a different data dir and writing mode.json to the fallback store is
+       exactly the OI-911 test-run incident. Refuse.
+    2. Cross-project guard. A write target under ``~/.vnx-data/<other>`` while
+       the resolved project_id is not ``<other>`` is a cross-project write.
+
+    When no project_id is resolvable the cross-project half cannot verify and
+    stays silent (same contract as ``data_dir_guard``); the divergence half is
+    env-verifiable and always runs.
+    """
+    try:
+        target = Path(target_dir).expanduser().resolve()
+    except OSError:
+        return
+
+    env_val = os.environ.get("VNX_DATA_DIR", "").strip()
+    explicit = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    if env_val and not explicit:
+        env_path = Path(env_val).expanduser().resolve()
+        if env_path != target:
+            raise RuntimeError(
+                f"mode.json write target {target} diverges from the inherited "
+                f"VNX_DATA_DIR={env_val} without VNX_DATA_DIR_EXPLICIT=1. A bare "
+                "VNX_DATA_DIR is pollution, not config: refusing to write mode.json "
+                "to a store the environment did not pin (OI-911). Set "
+                "VNX_DATA_DIR_EXPLICIT=1 to opt in explicitly."
+            )
+
+    home_vnx = Path.home() / ".vnx-data"
+    try:
+        rel = target.relative_to(home_vnx)
+    except ValueError:
+        return  # repo-local / scratch / XDG — not a central-store path
+
+    from project_root import resolve_project_id
+    try:
+        pid = resolve_project_id()
+    except RuntimeError:
+        return  # cannot verify against a project_id — allow
+    pid = pid.strip()
+    if not pid:
+        return
+    expected = home_vnx / pid
+    if target == expected or str(target).startswith(str(expected) + os.sep):
+        return
+    raise RuntimeError(
+        f"mode.json write target {target} is {rel.parts[0]!r}'s central store, "
+        f"but the active project resolves to {pid!r}. Refusing to write mode.json "
+        "into another project's store (OI-911). Set VNX_PROJECT_ID or run from "
+        "the correct project."
+    )
+
+
 def write_mode(mode: VNXMode, data_dir: Optional[str] = None) -> Path:
-    """Write mode to mode.json atomically. Returns the path written."""
+    """Write mode to mode.json atomically. Returns the path written.
+
+    Refuses (raises) when the write target is not the active project's store:
+    a write that diverges from a bare (non-explicit) ``VNX_DATA_DIR``, or that
+    lands in another project's ``~/.vnx-data/<other>``, is rejected loudly
+    (see :func:`_guard_mode_write_target`).
+    """
     path = _mode_file_path(data_dir)
+    _guard_mode_write_target(path.parent)
     payload = {
         "mode": str(mode),
         "set_at": datetime.now(timezone.utc).isoformat(),

--- a/tests/test_vnx_mode.py
+++ b/tests/test_vnx_mode.py
@@ -7,6 +7,7 @@ and backward compatibility with pre-init state.
 
 import json
 import os
+import subprocess
 import sys
 from pathlib import Path
 
@@ -39,16 +40,26 @@ from vnx_mode import (
 
 @pytest.fixture
 def data_dir(tmp_path):
-    """Create a temp .vnx-data directory and set VNX_DATA_DIR."""
+    """Create a temp .vnx-data directory and set VNX_DATA_DIR (+ explicit flag).
+
+    VNX_DATA_DIR_EXPLICIT=1 is required by the two-key contract (OI-911): a bare
+    VNX_DATA_DIR is inherited pollution and is ignored by ``_mode_file_path``.
+    """
     d = tmp_path / ".vnx-data"
     d.mkdir()
     old = os.environ.get("VNX_DATA_DIR")
+    old_explicit = os.environ.get("VNX_DATA_DIR_EXPLICIT")
     os.environ["VNX_DATA_DIR"] = str(d)
+    os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
     yield d
     if old:
         os.environ["VNX_DATA_DIR"] = old
     else:
         os.environ.pop("VNX_DATA_DIR", None)
+    if old_explicit:
+        os.environ["VNX_DATA_DIR_EXPLICIT"] = old_explicit
+    else:
+        os.environ.pop("VNX_DATA_DIR_EXPLICIT", None)
 
 
 # ---------------------------------------------------------------------------
@@ -99,6 +110,98 @@ class TestModeReadWrite:
         """read_mode() without args uses VNX_DATA_DIR from env."""
         write_mode(VNXMode.STARTER, str(data_dir))
         assert read_mode() == VNXMode.STARTER
+
+
+# ---------------------------------------------------------------------------
+# OI-911 write guard — mode.json must never land in the wrong store
+# ---------------------------------------------------------------------------
+
+class TestModeWriteGuard:
+    """mode.json writes resolve through the two-key contract and a write guard.
+
+    OI-911: ``_mode_file_path`` used to read ``os.environ["VNX_DATA_DIR"]`` raw.
+    A suite-wide test run pinned a scratch pad with ``VNX_DATA_DIR_EXPLICIT=1``;
+    a cleaned-env subprocess lost the flag and its mode.json write silently fell
+    back to the resolved central store. Every test here is RED on origin/main:
+    the raw-env resolver wrote to the guard-identified target instead of
+    refusing.
+    """
+
+    def _write_mode_script(self) -> str:
+        """Resolve the data dir through the fabric resolver, then write mode.
+
+        Mirrors ``vnx_setup.step_write_mode`` / ``vnx_starter.init_starter``:
+        ``ensure_env()`` resolves ``VNX_DATA_DIR`` (ignoring a bare env value),
+        then ``write_mode`` receives that resolved path as ``data_dir``.
+        """
+        return (
+            "import sys; sys.path.insert(0, sys.argv[1]);\n"
+            "from vnx_paths import ensure_env;\n"
+            "from vnx_mode import VNXMode, write_mode;\n"
+            "paths = ensure_env();\n"
+            "write_mode(VNXMode.STARTER, paths['VNX_DATA_DIR']);\n"
+        )
+
+    def test_write_diverges_from_bare_vnx_data_dir_raises(self, tmp_path, monkeypatch):
+        """A write target that differs from a bare inherited VNX_DATA_DIR fails loud."""
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        other = tmp_path / "other"
+        other.mkdir()
+        monkeypatch.setenv("VNX_DATA_DIR", str(scratch))
+        monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        with pytest.raises(RuntimeError, match="VNX_DATA_DIR_EXPLICIT"):
+            write_mode(VNXMode.STARTER, str(other))
+
+    def test_write_to_other_project_central_store_raises(self, tmp_path, monkeypatch):
+        """A write into ~/.vnx-data/<other> while the active project is <pid> fails loud."""
+        home = tmp_path / "home"
+        home.mkdir()
+        monkeypatch.setenv("HOME", str(home))
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        other = home / ".vnx-data" / "other-project"
+        other.mkdir(parents=True)
+        with pytest.raises(RuntimeError, match="another project"):
+            write_mode(VNXMode.STARTER, str(other))
+
+    def test_cleaned_env_subprocess_does_not_write_real_store(self, tmp_path):
+        """OI-911 regression: a subprocess that loses VNX_DATA_DIR_EXPLICIT must
+        not write mode.json into the resolved central store.
+
+        The parent test run pins a scratch pad with VNX_DATA_DIR_EXPLICIT=1 (the
+        suite-wide pytest run does this). The subprocess keeps the scratch
+        VNX_DATA_DIR but loses the EXPLICIT flag (a cleaned env), then resolves
+        its data dir through the fabric resolver, which falls back to the central
+        store. The mode.json write must NOT land there.
+        """
+        scratch = tmp_path / "scratch"
+        scratch.mkdir()
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        pid = "vnx-dev"
+        central = fake_home / ".vnx-data" / pid
+        central.mkdir(parents=True)
+        original = json.dumps({"mode": "operator", "schema_version": 1}, indent=2)
+        (central / "mode.json").write_text(original, encoding="utf-8")
+
+        env = {
+            "HOME": str(fake_home),
+            "VNX_PROJECT_ID": pid,
+            "VNX_DATA_DIR": str(scratch),  # bare — EXPLICIT deliberately removed
+            "VNX_DATA_DIR_GUARD": "off",
+            "PATH": os.environ.get("PATH", ""),
+        }
+        result = subprocess.run(
+            [sys.executable, "-c", self._write_mode_script(), str(SCRIPT_DIR / "lib")],
+            env=env, capture_output=True, text=True, timeout=60,
+        )
+        # The write must not land in the (fake) central store.
+        assert (central / "mode.json").read_text(encoding="utf-8") == original, (
+            "cleaned-env subprocess wrote mode.json into the resolved central store "
+            f"(rc={result.returncode})\nstdout: {result.stdout}\nstderr: {result.stderr}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## OI-911 ronde 2 — de fix staat er, het BEWIJS ontbreekt

`_mode_file_path` in `scripts/lib/vnx_mode.py` las `os.environ["VNX_DATA_DIR"]` rauw — de vierde data-dir-resolver in de fabric en de enige zonder twee-sleutel-contract (`VNX_DATA_DIR_EXPLICIT`) en project-id-guard. Een suite-brede pytest-run die een scratch-pad pinde met `VNX_DATA_DIR_EXPLICIT=1` verloor de flag in een subprocess met geschoonde env; de schrijfactie viel terug op `~/.vnx-data/vnx-dev` en zette mode `operator` → `starter`, waardoor de governance-deur dichtging.

## Wat deze ronde levert

1. **Resolver-fix zonder vijfde resolver.** `_mode_file_path` resolvet via `vnx_paths.resolve_paths()["VNX_DATA_DIR"]` — dezelfde fabric-resolver als `vnx_init`/`vnx_setup`/`vnx_starter`, inclusief twee-sleutel-contract en project-id-guard.
2. **Fail-loud write-guard.** `write_mode` weigert een schrijfdoel dat divergeert van een bare (niet-expliciete) `VNX_DATA_DIR`, of dat in een andere project's `~/.vnx-data/<other>` centraal-store landt.
3. **De kern: regressietests die op `origin/main` ROOD staan.** Drie tests in `TestModeWriteGuard`. De subprocess-test bouwt de incident-vorm na (scratch-pad + subprocess dat `VNX_DATA_DIR_EXPLICIT` verliest, resolvet via `ensure_env()`) en bewijst dat de centrale store niet geraakt wordt.

## Bewijs

- **Red op `origin/main`**: `3 failed, 26 passed` — subprocess schreef `starter` over `operator` heen (rc=0), exact de incident-vorm.
- **Groen op deze branch**: `29 passed`.
- **Echte centrale store na afloop**: `~/.vnx-data/vnx-dev/mode.json` zegt nog `operator` (ongewijzigd).
- Gerelateerde suites: `test_data_dir_guard` + `test_central_mode_path_*` (71 passed), `test_quickstart_validation::TestInitFlow` (3 passed, fresh-project init onregressed), `test_vnx_setup`/`test_vnx_starter`/`test_init_migrate_bootstrap`/`test_dashboard_read_model` (102 passed; 1 pre-existing failure `test_pool_default_db_path_honors_vnx_data_dir` — faalt identiek op schone main, env-`VNX_STATE_DIR`-issue).

## Files

- `scripts/lib/vnx_mode.py` — `_mode_file_path` + nieuwe `_guard_mode_write_target`.
- `tests/test_vnx_mode.py` — `data_dir`-fixture (EXPLICIT=1) + `TestModeWriteGuard` (3 regressietests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)