### PR TITLE
fix(hooks): bind reconcile worker to session lifetime via VNX_STATE_DIR (OI-873, OI-877)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -39,6 +39,11 @@
         "hooks": [
           {
             "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/session_reconcile_cleanup.sh\"'",
+            "timeout": 5000
+          },
+          {
+            "type": "command",
             "command": "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && python3 \"$ROOT/scripts/build_current_state.py\" 2>/dev/null && python3 \"$ROOT/scripts/build_doc_indexes.py\" 2>/dev/null; exit 0'"
           }
         ]

--- a/docs/core/HORIZON_LIFECYCLE.md
+++ b/docs/core/HORIZON_LIFECYCLE.md
@@ -120,6 +120,15 @@ Two ticks run `reconcile --apply` so merged tracks close on their own:
   interactive operator session (it has keychain `gh` auth that a headless launchd
   context lacks). **Auto-close is ON by default** (`VNX_AUTO_CLOSE` defaults to `1`;
   opt out with `VNX_AUTO_CLOSE=0` → advisory CHECK).
+
+The SessionStart worker is **bound to the session's lifetime** (OI-873/OI-877):
+it records its pid in a per-session marker under `$VNX_STATE_DIR/session_reconcile/`
+(resolved via `vnx_paths` — the central store is the SSOT, never a repo-local
+`.vnx-data/state`), and the **SessionEnd hook**
+(`scripts/hooks/session_reconcile_cleanup.sh`) kills the worker's process tree when
+the session ends. A reconcile can therefore never outlive its session and hold the
+coordination DB write lock fleet-wide. The 900s runtime bound and the flock
+singleton stay as further backstops, not replacements.
 - **Supervisor tick** (`dispatcher_supervisor_ticks.sh`, `VNX_SUPERVISOR_MODE=unified`)
   — same policy, throttled by `VNX_OBJECTIVE_RECONCILE_INTERVAL`.
 

--- a/scripts/hooks/session_reconcile_autoclose.sh
+++ b/scripts/hooks/session_reconcile_autoclose.sh
@@ -53,8 +53,14 @@
 # kernel atomically releases the lock the instant a dead holder's last fd
 # closes, so the very next non-blocking flock attempt simply succeeds.
 
-# Drain the hook's stdin JSON so the caller never blocks.
-cat >/dev/null 2>&1 || true
+# Capture the hook payload (best-effort) so this session's id is known — the
+# detached reconcile worker below is bound to the session's lifetime, and the
+# SessionEnd hook (session_reconcile_cleanup.sh) uses that id to kill it when
+# the session ends (OI-873/OI-877 second defense line: a reconcile must never
+# outlive its session holding the coordination DB write lock).  `cat` returns
+# at EOF, so capturing never blocks the caller.  Parsing happens inside the
+# subshell with the resolved interpreter (jq is not guaranteed on this fleet).
+STDIN_JSON="$(cat 2>/dev/null)" || STDIN_JSON=""
 
 # ── Guard: skip tmux-spawn workers; only the interactive session ticks ───────
 if [ -n "${VNX_DISPATCH_ID:-}" ]; then
@@ -128,6 +134,48 @@ mkdir -p "$(dirname "$LOCK_FILE")" 2>/dev/null || true
         TIMEOUT_BIN="timeout"
     elif command -v gtimeout >/dev/null 2>&1; then
         TIMEOUT_BIN="gtimeout"
+    fi
+
+    # ── Session lifetime binding (OI-873/OI-877, second defense line) ────────
+    # Record this worker's own pid in a per-session marker so the SessionEnd
+    # hook can kill EXACTLY this worker's process tree when the session that
+    # fired it ends.  The kill releases this worker's flock (FD 200) with it,
+    # so a reconcile can never outlive its session and block fleet-wide DB
+    # writes.  The 900s deadline and the flock below stay — this is a third
+    # bound, not a replacement.
+    #
+    # Marker location: VNX_STATE_DIR via vnx_paths (ADR-026 SSOT — the central
+    # store, never a repo-local .vnx-data/state).  The harness exports
+    # VNX_STATE_DIR in every real session; fall back to the canonical resolver
+    # when it is absent.  No resolver and no env → no marker (fail-safe): the
+    # deadline + flock singleton still bound us, and SessionEnd has nothing to
+    # clean up.
+    SESSION_ID=""
+    if [ -n "$STDIN_JSON" ]; then
+        SESSION_ID="$(printf '%s' "$STDIN_JSON" | "$PY" -c 'import sys,json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("session_id") or "")
+except Exception:
+    print("")' 2>/dev/null)"
+    fi
+    STATE_DIR="${VNX_STATE_DIR:-}"
+    if [ -z "$STATE_DIR" ] && [ -f "$ROOT/scripts/lib/vnx_paths.sh" ]; then
+        # shellcheck source=/dev/null
+        source "$ROOT/scripts/lib/vnx_paths.sh"
+        STATE_DIR="${VNX_STATE_DIR:-}"
+    fi
+    MARKER=""
+    if [ -n "$SESSION_ID" ] && [ -n "$STATE_DIR" ]; then
+        SAFE_SID="$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9_-' '-')"
+        SESSION_RECONCILE_DIR="$STATE_DIR/session_reconcile"
+        mkdir -p "$SESSION_RECONCILE_DIR" 2>/dev/null || true
+        MARKER="$SESSION_RECONCILE_DIR/$SAFE_SID.pid"
+        printf '%s\n' "$SELF_PID" >"$MARKER" 2>/dev/null || true
+        # Remove the marker on ANY exit path of this worker — normal
+        # completion, the 900s deadline, or a lock-busy early exit — so the
+        # SessionEnd hook finds nothing to kill for a finished run.
+        trap 'rm -f "$MARKER"' EXIT
     fi
 
     STAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"

--- a/scripts/hooks/session_reconcile_cleanup.sh
+++ b/scripts/hooks/session_reconcile_cleanup.sh
@@ -1,0 +1,153 @@
+#!/usr/bin/env bash
+# VNX SessionEnd reconcile cleanup — kill the session's detached reconcile worker.
+#
+# session_reconcile_autoclose.sh (SessionStart) detaches a reconcile worker so
+# session start never blocks on `gh` network calls.  That worker is bound to the
+# session's lifetime: it writes its own pid to a per-session marker under
+# $VNX_STATE_DIR/session_reconcile/<session_id>.pid (resolved via vnx_paths —
+# ADR-026 SSOT, the central store, never a repo-local .vnx-data/state).  This
+# SessionEnd hook finds that marker and kills the worker's whole process tree.
+#
+# WHY (OI-873 / OI-877, second defense line — measured 2026-07-31): a
+# `planning_cli.py objective reconcile` spawned by a main-checkout session
+# survived the session's end (reparented to PPID 1) and held the coordination
+# DB write lock for 15+ minutes, blocking every fleet-wide track write.  The
+# worktree-scoped lsof scan (#1260 worktree_process_cleanup.py) and the
+# spawn-time PGID registry cannot reach it: it is the interactive session's OWN
+# process group, which both mechanisms deliberately never signal.  Killing it
+# here, bound to the session it came from, closes that gap.
+#
+# The kill is scoped HARD to the recorded process tree: only the recorded
+# worker pid and its descendants are signalled, never the session's own process
+# group (the group this hook itself runs in).  The recorded command is verified
+# before any signal, so a recycled pid is never touched.  Best-effort, never
+# blocks, always exits 0.
+
+# ── Guard: tmux-spawn workers never start a reconcile worker (the SessionStart
+# hook is a no-op for them), so there is nothing to clean.  Interactive
+# sessions only.
+if [ -n "${VNX_DISPATCH_ID:-}" ]; then
+    exit 0
+fi
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+
+PY=""
+if [ -x "$ROOT/.venv/bin/python" ]; then
+    PY="$ROOT/.venv/bin/python"
+elif [ -x "/opt/homebrew/opt/python@3.12/bin/python3.12" ]; then
+    PY="/opt/homebrew/opt/python@3.12/bin/python3.12"
+else
+    PY="python3"
+fi
+
+# ── Session id from the hook payload (best-effort) ───────────────────────────
+STDIN_JSON="$(cat 2>/dev/null)" || STDIN_JSON=""
+SESSION_ID=""
+if [ -n "$STDIN_JSON" ]; then
+    SESSION_ID="$(printf '%s' "$STDIN_JSON" | "$PY" -c 'import sys,json
+try:
+    d = json.load(sys.stdin)
+    print(d.get("session_id") or "")
+except Exception:
+    print("")' 2>/dev/null)"
+fi
+[ -n "$SESSION_ID" ] || exit 0
+
+SAFE_SID="$(printf '%s' "$SESSION_ID" | tr -c 'A-Za-z0-9_-' '-')"
+
+# ── Marker location: VNX_STATE_DIR via vnx_paths (ADR-026 SSOT) — the SAME
+# resolution the SessionStart hook used to write the marker, so both hooks can
+# never disagree about where it lives.  Never fall back to a repo-local
+# .vnx-data/state — that split-brain is the defect this protocol exists to
+# avoid.  No resolver and no env → nothing to clean.
+STATE_DIR="${VNX_STATE_DIR:-}"
+if [ -z "$STATE_DIR" ] && [ -f "$ROOT/scripts/lib/vnx_paths.sh" ]; then
+    # shellcheck source=/dev/null
+    source "$ROOT/scripts/lib/vnx_paths.sh"
+    STATE_DIR="${VNX_STATE_DIR:-}"
+fi
+[ -n "$STATE_DIR" ] || exit 0
+
+MARKER="$STATE_DIR/session_reconcile/$SAFE_SID.pid"
+LOCK_FILE="$ROOT/.vnx-data/locks/session_reconcile_autoclose.lock"
+[ -f "$MARKER" ] || exit 0
+
+RECONCILE_PID="$(cat "$MARKER" 2>/dev/null | tr -d '[:space:]')"
+if [ -z "$RECONCILE_PID" ] || ! [[ "$RECONCILE_PID" =~ ^[0-9]+$ ]]; then
+    rm -f "$MARKER" 2>/dev/null || true
+    exit 0
+fi
+
+# ── Identity guard: only signal a live process that is still our worker.  A
+# dead pid, or a recycled pid now running something else, is never touched.
+if ! kill -0 "$RECONCILE_PID" 2>/dev/null; then
+    rm -f "$MARKER" 2>/dev/null || true
+    exit 0
+fi
+WORKER_CMD="$(ps -p "$RECONCILE_PID" -o command= 2>/dev/null || true)"
+case "$WORKER_CMD" in
+    *session_reconcile_autoclose*)
+        ;;
+    *)
+        # Recycled pid, or the worker already exited on its own — nothing of
+        # ours to kill.  Drop the stale marker and move on.
+        rm -f "$MARKER" 2>/dev/null || true
+        exit 0
+        ;;
+esac
+
+# ── Kill the worker's process tree (never the session's own group) ───────────
+# The worker root, the reconcile, the watchdog AND every descendant of the
+# watchdog inherit the flock fd (200) from vnx_flock_acquire, so the flock is
+# only released once every last holder dies.  The recorded root's PGID is the
+# SESSION's own group — captured up front so the final sweep below can scope
+# by it without accidentally touching another session's worker.
+SESSION_PGID="$(ps -o pgid= -p "$RECONCILE_PID" 2>/dev/null | tr -d ' ' || true)"
+
+_collect_descendants() {
+    local parent="$1"
+    local child
+    for child in $(pgrep -P "$parent" 2>/dev/null || true); do
+        _collect_descendants "$child"
+        DESCENDANTS+=("$child")
+    done
+}
+
+DESCENDANTS=()
+_collect_descendants "$RECONCILE_PID"
+
+# Phase 1: SIGTERM descendants (deepest first from the post-order walk), then
+# the worker root — mirrors the SIGTERM-then-SIGKILL grace period used by
+# worktree_process_cleanup / dispatch_process_registry.
+for pid in "${DESCENDANTS[@]}"; do
+    kill -TERM "$pid" 2>/dev/null || true
+done
+kill -TERM "$RECONCILE_PID" 2>/dev/null || true
+sleep 0.3
+
+# Phase 2: SIGKILL any survivor of the recorded tree.
+for pid in "${DESCENDANTS[@]}"; do
+    kill -KILL "$pid" 2>/dev/null || true
+done
+kill -KILL "$RECONCILE_PID" 2>/dev/null || true
+
+# Phase 3 (race closer): the watchdog's `sleep 1` can be spawned between the
+# descendant collection and the kill above, escaping the tree scan with an
+# inherited flock fd (measured 2026-08-01).  Sweep the lock file and SIGKILL
+# any remaining holder — the ONLY way a process holds this exclusive flock is
+# as part of the worker tree, and scoping by the session's PGID guarantees a
+# concurrent session's worker is never touched.  A leftover `sleep` would
+# self-release within a second (and the DB busy_timeout would absorb it), but
+# freeing it now is the point of this hook.
+if [ -n "$SESSION_PGID" ] && command -v lsof >/dev/null 2>&1; then
+    for holder in $(lsof -t "$LOCK_FILE" 2>/dev/null || true); do
+        holder_pgid="$(ps -o pgid= -p "$holder" 2>/dev/null | tr -d ' ' || true)"
+        if [ -n "$holder_pgid" ] && [ "$holder_pgid" = "$SESSION_PGID" ]; then
+            kill -KILL "$holder" 2>/dev/null || true
+        fi
+    done
+fi
+
+rm -f "$MARKER" 2>/dev/null || true
+exit 0

--- a/tests/test_session_reconcile_lifetime.sh
+++ b/tests/test_session_reconcile_lifetime.sh
@@ -1,0 +1,241 @@
+#!/usr/bin/env bash
+# tests/test_session_reconcile_lifetime.sh — OI-873/OI-877 session-lifetime binding.
+#
+# session_reconcile_autoclose.sh (SessionStart) detaches a reconcile worker so
+# session start never blocks on `gh`.  The worker writes its pid to a per-session
+# marker; the SessionEnd hook (session_reconcile_cleanup.sh) reads that marker
+# and kills the worker's process tree, so a reconcile can never outlive the
+# session that fired it and hold the coordination DB write lock fleet-wide
+# (measured 2026-07-31: a planning_cli.py objective reconcile reparented to
+# PPID 1 blocked every track write for 15+ minutes).
+#
+# The marker lives under VNX_STATE_DIR/session_reconcile (resolved via vnx_paths
+# in the real runtime — ADR-026 SSOT, the central store).  This test isolates by
+# pinning VNX_STATE_DIR to the throwaway root's own .vnx-data/state, never the
+# real central store.
+#
+# Runs the REAL hooks against a throwaway git root with a fake planning_cli.py
+# that stays alive for `reconcile` — proving the marker protocol and the kill
+# work end-to-end without touching the real coordination DB or `gh`.
+#
+# Run: bash tests/test_session_reconcile_lifetime.sh
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+HOOKS="$REPO_ROOT/scripts/hooks"
+LIB_DIR="$REPO_ROOT/scripts/lib"
+
+PASS=0
+FAIL=0
+
+fail() { echo "FAIL: $1"; FAIL=$((FAIL + 1)); }
+pass() { echo "PASS: $1"; PASS=$((PASS + 1)); }
+pid_alive() { kill -0 "$1" 2>/dev/null; }
+
+# ── throwaway roots are cleaned up on exit (kill leftover workers, rm -rf) ──
+declare -a _TMP_ROOTS=()
+_cleanup() {
+    local r m p
+    for r in ${_TMP_ROOTS[@]+"${_TMP_ROOTS[@]}"}; do
+        for m in "$r"/.vnx-data/state/session_reconcile/*.pid; do
+            [ -f "$m" ] || continue
+            p="$(cat "$m" 2>/dev/null | tr -d '[:space:]' || true)"
+            if [[ "$p" =~ ^[0-9]+$ ]] && pid_alive "$p"; then
+                pkill -KILL -P "$p" 2>/dev/null || true
+                pkill -KILL -f "$r/scripts/planning_cli.py" 2>/dev/null || true
+                kill -KILL "$p" 2>/dev/null || true
+            fi
+        done
+        rm -rf "$r" 2>/dev/null || true
+    done
+}
+trap _cleanup EXIT
+
+setup_root() {
+    local tmp
+    tmp="$(mktemp -d /tmp/vnx-sesslifetime.XXXXXX)"
+    git -C "$tmp" init -q
+    mkdir -p "$tmp/scripts/lib" \
+             "$tmp/.vnx-data/logs" \
+             "$tmp/.vnx-data/locks" \
+             "$tmp/.vnx-data/state"
+    ln -s "$LIB_DIR/vnx_flock_lock.sh" "$tmp/scripts/lib/vnx_flock_lock.sh"
+    ln -s "$LIB_DIR/vnx_run_bounded.sh" "$tmp/scripts/lib/vnx_run_bounded.sh"
+    ln -s "$LIB_DIR/vnx_paths.sh" "$tmp/scripts/lib/vnx_paths.sh"
+    cat > "$tmp/scripts/planning_cli.py" <<'PYEOF'
+import sys, time
+args = sys.argv[1:]
+if "reconcile-streak" in args:
+    print('{"flip_criterion_met": false}')
+    sys.exit(0)
+if "reconcile" in args:
+    time.sleep(60)   # stay alive so the SessionEnd kill is observable
+sys.exit(0)
+PYEOF
+    chmod +x "$tmp/scripts/planning_cli.py"
+    echo "$tmp"
+}
+
+# NOTE: a function called inside `$(...)` runs in a subshell, so it can never
+# mutate the main shell's _TMP_ROOTS.  Callers must append the returned path
+# themselves.  ${arr[@]+"${arr[@]}"} keeps `for` safe under `set -u` for an
+# empty array.
+
+# Marker dir the hooks resolve to in this test (VNX_STATE_DIR pinned per-root).
+marker_for() {
+    printf '%s/.vnx-data/state/session_reconcile' "$1"
+}
+
+wait_for_marker() {
+    local marker="$1" tries=0
+    while [ ! -f "$marker" ]; do
+        sleep 0.1
+        tries=$((tries + 1))
+        [ "$tries" -lt 50 ] || return 1
+    done
+    return 0
+}
+
+# Poll until the reconcile flock is free (bounded) — the SessionEnd kill frees
+# it immediately in the common case; the watchdog's `sleep 1` can straggle for
+# up to a second, which the production DB busy_timeout (10s) would absorb
+# anyway.  Asserting freedom within a few seconds is the honest contract.
+flock_free_within() {
+    local lock="$1" tries=0
+    while [ "$tries" -lt 40 ]; do
+        if ! source "$LIB_DIR/vnx_flock_lock.sh" 2>/dev/null; then
+            sleep 0.1; tries=$((tries + 1)); continue
+        fi
+        if vnx_flock_acquire "$lock" "test" "python3" 2>/dev/null; then
+            vnx_flock_release
+            return 0
+        fi
+        sleep 0.1
+        tries=$((tries + 1))
+    done
+    return 1
+}
+
+# shellcheck disable=SC2034  # VNX_STATE_DIR / VNX_PROJECT_ID are consumed by the hook child process
+run_session_start() {
+    local root="$1" sid="$2"
+    ( cd "$root" \
+        && VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
+        && printf '{"session_id":"%s","hook_event_name":"SessionStart"}' "$sid" \
+        | bash "$HOOKS/session_reconcile_autoclose.sh" )
+}
+
+run_session_end() {
+    local root="$1" sid="$2"
+    ( cd "$root" \
+        && VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
+        && printf '{"session_id":"%s","hook_event_name":"SessionEnd"}' "$sid" \
+        | bash "$HOOKS/session_reconcile_cleanup.sh" )
+}
+
+# ── 1. SessionEnd kills the session's detached reconcile worker tree ────────
+echo "[1] SessionEnd kills the session's detached reconcile worker tree"
+ROOT_A="$(setup_root)"
+_TMP_ROOTS+=("$ROOT_A")
+SID_A="800e3edd-6432-41fd-a747-372411fe7f47"
+run_session_start "$ROOT_A" "$SID_A"
+MARKER_A="$(marker_for "$ROOT_A")/$SID_A.pid"
+if ! wait_for_marker "$MARKER_A"; then
+    fail "SessionStart wrote no per-session marker ($MARKER_A)"
+else
+    pass "SessionStart wrote per-session marker"
+fi
+
+WORKER_PID="$(cat "$MARKER_A" 2>/dev/null | tr -d '[:space:]')"
+if ! pid_alive "$WORKER_PID"; then
+    fail "detached reconcile worker (pid=$WORKER_PID) not alive after SessionStart"
+else
+    pass "detached reconcile worker alive after SessionStart"
+fi
+
+# The fake reconcile child (planning_cli.py) should be running as a descendant.
+RECONCILE_PID="$(pgrep -P "$WORKER_PID" 2>/dev/null | head -1 || true)"
+if [ -z "$RECONCILE_PID" ] || ! pid_alive "$RECONCILE_PID"; then
+    fail "no running reconcile child under the worker"
+else
+    pass "reconcile child (pid=$RECONCILE_PID) running under the worker"
+fi
+
+# The worker holds the flock — prove it (a second acquire must fail).
+if source "$LIB_DIR/vnx_flock_lock.sh"; then
+    if vnx_flock_acquire "$ROOT_A/.vnx-data/locks/session_reconcile_autoclose.lock" "test" "python3"; then
+        vnx_flock_release
+        fail "worker does NOT hold the reconcile flock (acquire succeeded)"
+    else
+        pass "worker holds the reconcile flock while alive"
+    fi
+fi
+
+run_session_end "$ROOT_A" "$SID_A"
+
+if pid_alive "$WORKER_PID"; then
+    fail "worker still alive after SessionEnd (pid=$WORKER_PID)"
+else
+    pass "worker killed at SessionEnd"
+fi
+if pid_alive "$RECONCILE_PID"; then
+    fail "reconcile child still alive after SessionEnd"
+else
+    pass "reconcile child killed at SessionEnd"
+fi
+if [ -f "$MARKER_A" ]; then
+    fail "marker not removed by SessionEnd"
+else
+    pass "marker removed by SessionEnd"
+fi
+if flock_free_within "$ROOT_A/.vnx-data/locks/session_reconcile_autoclose.lock"; then
+    pass "flock released after SessionEnd kill (DB write lock freed)"
+else
+    fail "flock still held after SessionEnd kill"
+fi
+
+# ── 2. A DIFFERENT session's SessionEnd touches nothing ─────────────────────
+echo "[2] a different session's SessionEnd touches nothing"
+ROOT_B="$(setup_root)"
+_TMP_ROOTS+=("$ROOT_B")
+SID_B="aaaa-bbbb-cccc-dddd"
+run_session_start "$ROOT_B" "$SID_B"
+MARKER_B="$(marker_for "$ROOT_B")/$SID_B.pid"
+if ! wait_for_marker "$MARKER_B"; then
+    fail "SessionStart B wrote no marker"
+else
+    pass "SessionStart B wrote marker"
+fi
+WORKER_B="$(cat "$MARKER_B" 2>/dev/null | tr -d '[:space:]')"
+
+run_session_end "$ROOT_B" "other-session-id-xyz"
+if ! pid_alive "$WORKER_B"; then
+    fail "worker B killed by a different session's SessionEnd"
+else
+    pass "worker B survives a different session's SessionEnd"
+fi
+
+run_session_end "$ROOT_B" "$SID_B"
+if pid_alive "$WORKER_B"; then
+    fail "worker B not killed by its own SessionEnd"
+else
+    pass "worker B killed by its own SessionEnd"
+fi
+
+# ── 3. No marker / stale marker → no-op, never touches anything ─────────────
+echo "[3] no marker is a clean no-op"
+ROOT_C="$(setup_root)"
+_TMP_ROOTS+=("$ROOT_C")
+run_session_end "$ROOT_C" "no-such-session"
+if source "$LIB_DIR/vnx_flock_lock.sh"; then
+    if vnx_flock_acquire "$ROOT_C/.vnx-data/locks/session_reconcile_autoclose.lock" "test" "python3"; then
+        vnx_flock_release
+        pass "SessionEnd with no marker leaves the world untouched"
+    else
+        fail "unexpected lock state after no-op SessionEnd"
+    fi
+fi
+
+echo ""
+echo "== session reconcile lifetime: $PASS passed, $FAIL failed =="
+[ "$FAIL" -eq 0 ]


### PR DESCRIPTION
## What

Round 2 of the OI-873/OI-877 session-lifetime binding for the reconcile worker. Round 1 (PR #1289) was rejected by the **Legacy-path-gate** because it wrote the per-session marker under a repo-local `$ROOT/.vnx-data/state/session_reconcile/` literal — the exact ADR-026 split-brain (repo-local vs central-store SSOT) the resolver cluster keeps feeding on.

This round writes the marker under `$VNX_STATE_DIR/session_reconcile/` resolved **via `vnx_paths`** (env value in real sessions; `vnx_paths.sh` fallback; never a repo-local literal). The gate is clean — verified locally before push.

## Changes

- `scripts/hooks/session_reconcile_autoclose.sh` — SessionStart captures `session_id` from the hook payload; the detached reconcile worker writes its own pid to `$VNX_STATE_DIR/session_reconcile/<session_id>.pid` and removes it on every exit path (EXIT trap).
- `scripts/hooks/session_reconcile_cleanup.sh` (new) — SessionEnd hook. Reads the per-session marker, verifies the recorded pid is still our worker (recycled pids never touched), kills the recorded process tree (SIGTERM → SIGKILL), then closes the watchdog-sleep flock race via a PGID-scoped lsof sweep.
- `.claude/settings.json` — SessionEnd hook wired in before the existing build hooks.
- `tests/test_session_reconcile_lifetime.sh` (new) — three behaviors: worker survives **another** session's SessionEnd; worker is killed by **its own** SessionEnd; no marker is a clean no-op.
- `docs/core/HORIZON_LIFECYCLE.md` — §8 documents the binding and marker location.

## Verification

- **Three-scenario shell test:** `bash tests/test_session_reconcile_lifetime.sh` → `12 passed, 0 failed`.
- **Legacy-path-gate (local, exact CI command):** `rg '\.vnx-data/state/' scripts/` with the same exclude globs → clean. No `.vnx-data/state/` literal in scripts.
- **SSOT resolution:** `vnx_paths.sh` resolves `VNX_STATE_DIR=/Users/vincentvandeth/.vnx-data/vnx-dev/state` (central store) from the main checkout.
- **Worktree-internal variant (#1260):** `pytest tests/test_worktree_process_cleanup.py` → 4 passed; `worktree_process_cleanup.py` untouched.
- **Regression:** `test_session_reconcile_streak_pipestatus.sh` green; session-lock-race tests green.
- **Leftover processes after test run:** `ps` filtered on `session_reconcile`/`planning_cli.py` → empty.

## Open Items

`$ROOT/.vnx-data/logs` and `$ROOT/.vnx-data/locks` in `session_reconcile_autoclose.sh` stay repo-local (separate scope, explicitly out of this PR). A follow-up can move them to `VNX_LOGS_DIR`/`VNX_LOCKS_DIR` via `vnx_paths`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)