### PR TITLE
fix(analytics): link token rows to dispatches + price provider-lane receipts (OI-872, OI-882)

### DIFF
--- a/scripts/conversation_analyzer/parser.py
+++ b/scripts/conversation_analyzer/parser.py
@@ -14,8 +14,22 @@ from .models import (
 class SessionParser:
     """Parse a Claude Code JSONL session into structured metrics."""
 
+    # How many initial user messages are scanned for a dispatch ID. A governed
+    # worker session always carries its own dispatch ID in the initial prompt
+    # (the Dispatch Metadata footer), so a bounded window is enough. The window
+    # is generous (10) to cover sessions where the real ID lands in a slightly
+    # later user message (measured: msg 6), while deliberately NOT scanning the
+    # full transcript — long-lived T0 orchestration sessions reference many
+    # other dispatches later on, and attributing the whole session to one of
+    # them would be wrong.
+    MAX_DISPATCH_SCAN_MESSAGES = 10
+
     DISPATCH_TABLE_RE = re.compile(r'\|\s*\*\*Dispatch-ID\*\*\s*\|\s*([^\|]+?)\s*\|')
-    DISPATCH_HEADER_RE = re.compile(r'Dispatch-ID:\s*(\S+)')
+    # Optional bold markers around the label ("**Dispatch-ID:** value") are
+    # tolerated so bold-styled mentions are captured instead of yielding the
+    # asterisks as the candidate. The closing "**" sits AFTER the colon in the
+    # bold form ("**Dispatch-ID:** value"), hence the trailing optional group.
+    DISPATCH_HEADER_RE = re.compile(r'(?:\*\*)?Dispatch-ID\s*:\s*(?:\*\*)?\s*(\S+)')
     # Placeholder pattern: <any-text> — template placeholders like <dispatch_id>
     # must never be treated as real IDs.
     PLACEHOLDER_RE = re.compile(r'^<[^>]+>$')
@@ -23,6 +37,10 @@ class SessionParser:
     # minimum validation that rejects template placeholders, empty strings,
     # and free-form text while accepting all real dispatch ID formats.
     VALID_DISPATCH_ID_RE = re.compile(r'^\d{8}-')
+    # Trailing prose punctuation that commonly follows an inline dispatch ID in
+    # free text ("Dispatch-ID: 20260613-852rev-deepseek.") — never part of the
+    # ID itself, stripped before the date-prefix check.
+    TRAILING_PUNCT_RE = re.compile(r'[.,;:!?)\]}\'"]+$')
 
     @staticmethod
     def session_id_from_path(jsonl_path: Path) -> str:
@@ -129,34 +147,64 @@ class SessionParser:
         Returns the trimmed string when it looks like a real dispatch ID,
         or None when the value is a template placeholder, empty, or
         otherwise not a valid ID.
+
+        Normalisation strips markdown bold markers (``**id**``) and trailing
+        prose punctuation (``Dispatch-ID: 20260613-x.``) that an inline mention
+        picks up from the surrounding sentence.
         """
         if not raw:
             return None
         candidate = raw.strip()
-        if not candidate:
-            return None
+        if candidate.startswith("**") and candidate.endswith("**"):
+            candidate = candidate[2:-2].strip()
         # Reject template placeholders: <dispatch_id>, <any-text>, etc.
         if cls.PLACEHOLDER_RE.match(candidate):
+            return None
+        # Strip trailing sentence punctuation (never part of a dispatch ID).
+        candidate = cls.TRAILING_PUNCT_RE.sub("", candidate)
+        if not candidate:
             return None
         # Require the YYYYMMDD- date-prefix that every real dispatch ID carries.
         if not cls.VALID_DISPATCH_ID_RE.match(candidate):
             return None
         return candidate
 
+    @classmethod
+    def _extract_dispatch_id(cls, text: str) -> Optional[str]:
+        """Return the first VALID dispatch ID found in *text*, or None.
+
+        Scans every Dispatch-ID mention (table cell or header) in document
+        order and returns the first candidate that passes validation.  A
+        template placeholder (``<dispatch_id>``) earlier in the text no longer
+        blocks extraction of a real ID that appears later in the same message:
+        the worker-context template carries the placeholder in its Commit
+        Convention section before the Dispatch Metadata footer holds the real
+        ID, so first-match-only extraction silently lost 96.7% of sessions
+        (OI-872).
+        """
+        candidates = []
+        for m in cls.DISPATCH_TABLE_RE.finditer(text):
+            candidates.append((m.start(), m.group(1)))
+        for m in cls.DISPATCH_HEADER_RE.finditer(text):
+            candidates.append((m.start(), m.group(1)))
+        candidates.sort(key=lambda pair: pair[0])
+        for _, raw in candidates:
+            validated = cls._validate_dispatch_id(raw)
+            if validated:
+                return validated
+        return None
+
     def _process_user(self, record: dict, metrics: SessionMetrics):
         metrics.user_message_count += 1
-        if not metrics.dispatch_id and metrics.user_message_count <= 3:
-            content = record.get("message", {}).get("content", "")
-            text = content if isinstance(content, str) else " ".join(
-                b.get("text", "") for b in content if isinstance(b, dict)
-            ) if isinstance(content, list) else ""
-            m = self.DISPATCH_TABLE_RE.search(text)
-            if not m:
-                m = self.DISPATCH_HEADER_RE.search(text)
-            if m:
-                validated = self._validate_dispatch_id(m.group(1))
-                if validated:
-                    metrics.dispatch_id = validated
+        if metrics.dispatch_id or metrics.user_message_count > self.MAX_DISPATCH_SCAN_MESSAGES:
+            return
+        content = record.get("message", {}).get("content", "")
+        text = content if isinstance(content, str) else " ".join(
+            b.get("text", "") for b in content if isinstance(b, dict)
+        ) if isinstance(content, list) else ""
+        dispatch_id = self._extract_dispatch_id(text)
+        if dispatch_id:
+            metrics.dispatch_id = dispatch_id
 
     @staticmethod
     def _parse_timestamp(ts_str: str) -> Optional[datetime]:

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -97,6 +97,12 @@ class _AdapterResult:
     # local transcript when the spawn itself reported none. None for adapters
     # with no session concept (e.g. codex).
     session_id: Optional[str] = None
+    # Actual model the spawn resolved and executed (e.g. deepseek-harness
+    # resolves "default"/"sonnet" -> "deepseek-v4-pro"). Used for cost
+    # computation in _govern so the receipt's cost_usd prices the model that
+    # actually ran, not a placeholder from the dispatch spec. None when the
+    # adapter did not resolve a distinct model (caller falls back to spec.model).
+    model: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -161,6 +167,7 @@ class CodexAdapter:
                 token_usage=token_usage,
                 error=result.error,
                 event_writer_failures=result.event_writer_failures,
+                model=spec.model,
             )
         if result.timed_out:
             return _AdapterResult(
@@ -170,6 +177,7 @@ class CodexAdapter:
                 token_usage=token_usage,
                 timed_out=True,
                 event_writer_failures=result.event_writer_failures,
+                model=spec.model,
             )
         status = "success" if result.returncode == 0 else "failure"
         return _AdapterResult(
@@ -178,6 +186,7 @@ class CodexAdapter:
             status=status,
             token_usage=token_usage,
             event_writer_failures=result.event_writer_failures,
+            model=spec.model,
         )
 
 
@@ -230,6 +239,7 @@ class ClaudeSubprocessAdapter:
                     raw_usage.get("cache_read_input_tokens", 0) or 0
                 ),
             }
+        model_used = getattr(result, "model", None) or spec.model
 
         if result.error:
             return _AdapterResult(
@@ -239,6 +249,7 @@ class ClaudeSubprocessAdapter:
                 token_usage=token_usage,
                 error=result.error,
                 session_id=result.session_id,
+                model=model_used,
             )
         if result.timed_out:
             return _AdapterResult(
@@ -248,6 +259,7 @@ class ClaudeSubprocessAdapter:
                 token_usage=token_usage,
                 timed_out=True,
                 session_id=result.session_id,
+                model=model_used,
             )
         if result.stopped_early:
             return _AdapterResult(
@@ -256,6 +268,7 @@ class ClaudeSubprocessAdapter:
                 status="success",
                 token_usage=token_usage,
                 session_id=result.session_id,
+                model=model_used,
             )
         status = "success" if result.returncode == 0 else "failure"
         return _AdapterResult(
@@ -264,6 +277,7 @@ class ClaudeSubprocessAdapter:
             status=status,
             token_usage=token_usage,
             session_id=result.session_id,
+            model=model_used,
         )
 
 
@@ -663,6 +677,23 @@ def _govern(
 
     duration = (end_time - start_time).total_seconds()
 
+    # OI-882: the envelope previously hardcoded cost_usd=None even though
+    # adapter_result.token_usage carried real tokens and wave7_models.yaml has
+    # the per-provider prices. Compute the estimate the same way
+    # provider_dispatch._emit_governance does, using the actual model the spawn
+    # resolved (falling back to the spec model). Non-fatal: an unresolvable
+    # price leaves cost_usd None instead of failing the receipt.
+    cost_usd: Optional[float] = None
+    _cost_model = getattr(adapter_result, "model", None) or spec.model
+    try:
+        from provider_dispatch import _compute_cost  # noqa: PLC0415
+        cost_usd = _compute_cost(spec.provider, _cost_model, adapter_result.token_usage)
+    except Exception as _cost_exc:  # noqa: BLE001 — cost must never break receipt emission
+        logger.debug(
+            "envelope._govern: cost compute failed dispatch=%s provider=%s (non-fatal): %s",
+            spec.dispatch_id, spec.provider, _cost_exc,
+        )
+
     # REPORT first — idempotent: worker-written file is preserved, not overwritten.
     # OI-903: on failure/timeout, a killed worker's partial report is preserved
     # under a .partial.md sidecar so the canonical report stays contract-compliant
@@ -764,11 +795,46 @@ def _govern(
                         exc_info=True,
                     )
 
+            # ADR-005: emit cost event BEFORE receipt write. provider_dispatch
+            # and recovery raise on failure (fail-loud); the envelope is the
+            # third receipt path and matches them, but wraps in try/except so a
+            # cost-log failure never breaks the fail-closed receipt contract.
+            try:
+                from provider_costs import emit_provider_cost  # noqa: PLC0415
+                from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
+                _cost_pid = ""
+                try:
+                    _cost_pid = resolve_stamp_project_id(
+                        db_path=str(spec.state_dir / "quality_intelligence.db")
+                    )
+                except TenantUnresolved:
+                    pass  # emit falls back to env; cost-audit must not lose the event
+                emit_provider_cost(
+                    provider=spec.provider,
+                    model=_cost_model,
+                    input_tokens=(
+                        adapter_result.token_usage.get("input")
+                        if adapter_result.token_usage else None
+                    ),
+                    output_tokens=(
+                        adapter_result.token_usage.get("output")
+                        if adapter_result.token_usage else None
+                    ),
+                    cost_usd_estimate=cost_usd,
+                    dispatch_id=spec.dispatch_id,
+                    project_id=_cost_pid,
+                )
+            except Exception as _cost_event_exc:  # noqa: BLE001 — cost event must not break receipt
+                logger.warning(
+                    "envelope._govern: cost event emit failed dispatch=%s (non-fatal): %s",
+                    spec.dispatch_id, _cost_event_exc,
+                )
+
             receipt_path = emit_dispatch_receipt(
                 dispatch_id=spec.dispatch_id,
                 terminal_id=spec.terminal_id,
                 provider=spec.provider,
-                model=spec.model,
+                model=_cost_model,
                 pr_id=spec.pr_id,
                 status=adapter_result.status,
                 completion_pct=100 if adapter_result.status == "success" else 0,
@@ -776,7 +842,7 @@ def _govern(
                 findings=[],
                 duration_seconds=duration,
                 token_usage=adapter_result.token_usage,
-                cost_usd=None,
+                cost_usd=cost_usd,
                 state_dir=spec.state_dir,
                 report_path=str(report_path) if report_path else None,
                 final_prompt_path=getattr(integrity, "final_prompt_path", None),
@@ -973,7 +1039,9 @@ def _fail_loud_on_empty_success(
     return status, returncode, None
 
 
-def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
+def _map_generic_spawn_result(
+    result: Any, provider_str: str, model: Optional[str] = None
+) -> _AdapterResult:
     """Map codex/kimi/gemini/litellm:* spawn result to _AdapterResult.
 
     Normalises token fields via _extract_token_usage from provider_dispatch.
@@ -994,6 +1062,7 @@ def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
             token_usage=token_usage,
             error=result.error,
             event_writer_failures=ewf,
+            model=model,
         )
     if result.timed_out:
         return _AdapterResult(
@@ -1003,6 +1072,7 @@ def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
             token_usage=token_usage,
             timed_out=True,
             event_writer_failures=ewf,
+            model=model,
         )
     completion_text = result.completion_text or ""
     status = "success" if result.returncode == 0 else "failure"
@@ -1016,6 +1086,7 @@ def _map_generic_spawn_result(result: Any, provider_str: str) -> _AdapterResult:
         token_usage=token_usage,
         error=guard_error,
         event_writer_failures=ewf,
+        model=model,
     )
 
 
@@ -1079,7 +1150,7 @@ class ProviderAdapter:
                     returncode=1, completion_text="", status="failure",
                     error=f"codex spawn BrokenPipeError: {exc}",
                 )
-            return _map_generic_spawn_result(result, pv.value)
+            return _map_generic_spawn_result(result, pv.value, model=model)
 
         # ---- kimi ----
         if pv == Provider.KIMI:
@@ -1108,7 +1179,7 @@ class ProviderAdapter:
                     returncode=1, completion_text="", status="failure",
                     error=f"gemini spawn BrokenPipeError: {exc}",
                 )
-            return _map_generic_spawn_result(result, pv.value)
+            return _map_generic_spawn_result(result, pv.value, model=model)
 
         # ---- litellm:deepseek | litellm:zai | litellm:moonshot ----
         if pv in (Provider.LITELLM_DEEPSEEK, Provider.LITELLM_ZAI, Provider.LITELLM_MOONSHOT):
@@ -1141,7 +1212,7 @@ class ProviderAdapter:
                     returncode=1, completion_text="", status="failure",
                     error=f"litellm spawn BrokenPipeError: {exc}",
                 )
-            return _map_generic_spawn_result(result, pv.value)
+            return _map_generic_spawn_result(result, pv.value, model=model)
 
         # ---- deepseek-harness ----
         if pv == Provider.DEEPSEEK_HARNESS:
@@ -1177,6 +1248,7 @@ class ProviderAdapter:
                     status="failure",
                     token_usage=token_usage,
                     error=result.error,
+                    model=model,
                 )
             if result.timed_out:
                 return _AdapterResult(
@@ -1185,6 +1257,7 @@ class ProviderAdapter:
                     status="timeout",
                     token_usage=token_usage,
                     timed_out=True,
+                    model=model,
                 )
             if getattr(result, "stopped_early", False):
                 return _AdapterResult(
@@ -1192,6 +1265,7 @@ class ProviderAdapter:
                     completion_text=(result.completion_text or ""),
                     status="success",
                     token_usage=token_usage,
+                    model=model,
                 )
             _dh_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
@@ -1204,6 +1278,7 @@ class ProviderAdapter:
                 status=status,
                 token_usage=token_usage,
                 error=_dh_err,
+                model=model,
             )
 
         # ---- glm-harness ---- (codex flip-PR F2: the door normalizes GLM -> glm-harness, so the
@@ -1241,6 +1316,7 @@ class ProviderAdapter:
                     status="failure",
                     token_usage=token_usage,
                     error=result.error,
+                    model=model,
                 )
             if result.timed_out:
                 return _AdapterResult(
@@ -1249,6 +1325,7 @@ class ProviderAdapter:
                     status="timeout",
                     token_usage=token_usage,
                     timed_out=True,
+                    model=model,
                 )
             if getattr(result, "stopped_early", False):
                 return _AdapterResult(
@@ -1256,6 +1333,7 @@ class ProviderAdapter:
                     completion_text=(result.completion_text or ""),
                     status="success",
                     token_usage=token_usage,
+                    model=model,
                 )
             _gh_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
@@ -1268,6 +1346,7 @@ class ProviderAdapter:
                 status=status,
                 token_usage=token_usage,
                 error=_gh_err,
+                model=model,
             )
 
         # ---- local-gemma ----
@@ -1294,6 +1373,7 @@ class ProviderAdapter:
                     status="failure",
                     token_usage=token_usage,
                     error=result.error,
+                    model=canonical_model,
                 )
             if result.timed_out:
                 return _AdapterResult(
@@ -1302,6 +1382,7 @@ class ProviderAdapter:
                     status="timeout",
                     token_usage=token_usage,
                     timed_out=True,
+                    model=canonical_model,
                 )
             _lg_text = result.completion_text or ""
             status = "success" if result.returncode == 0 else "failure"
@@ -1314,6 +1395,7 @@ class ProviderAdapter:
                 status=status,
                 token_usage=token_usage,
                 error=_lg_err,
+                model=canonical_model,
             )
 
         # Provider.CLAUDE, Provider.AUTO, or any unexpected value — programming error
@@ -1373,7 +1455,7 @@ class ProviderAdapter:
                 returncode=1, completion_text="", status="failure",
                 error=f"kimi spawn BrokenPipeError: {exc}",
             )
-        return _map_generic_spawn_result(result, Provider.KIMI.value)
+        return _map_generic_spawn_result(result, Provider.KIMI.value, model=model)
 
 
 def run_envelope_plan(

--- a/scripts/link_sessions_dispatches.py
+++ b/scripts/link_sessions_dispatches.py
@@ -9,7 +9,7 @@ Performs three linkage passes:
 """
 
 import json
-import re
+import os
 import sqlite3
 import sys
 from pathlib import Path
@@ -27,9 +27,6 @@ PATHS = ensure_env()
 STATE_DIR = Path(PATHS["VNX_STATE_DIR"])
 DB_PATH = STATE_DIR / "quality_intelligence.db"
 RECEIPTS_FILE = STATE_DIR / "t0_receipts.ndjson"
-
-DISPATCH_ID_RE = re.compile(r'\|\s*\*\*Dispatch-ID\*\*\s*\|\s*([^\|]+?)\s*\|')
-DISPATCH_HEADER_RE = re.compile(r'Dispatch-ID:\s*(\S+)')
 
 
 def link_sessions_to_dispatches(conn: sqlite3.Connection) -> int:
@@ -97,6 +94,8 @@ def link_receipts_to_dispatches(conn: sqlite3.Connection) -> int:
 
 def link_reports_to_dispatches(conn: sqlite3.Connection) -> int:
     """Extract dispatch_id from report files and update report_findings."""
+    from conversation_analyzer.parser import SessionParser  # noqa: PLC0415
+
     cur = conn.cursor()
     cur.execute("SELECT id, report_path FROM report_findings WHERE dispatch_id IS NULL")
     rows = cur.fetchall()
@@ -114,13 +113,13 @@ def link_reports_to_dispatches(conn: sqlite3.Connection) -> int:
         except OSError:
             continue
 
-        m = DISPATCH_ID_RE.search(content)
-        if not m:
-            m = DISPATCH_HEADER_RE.search(content)
-        if not m:
+        # Same OI-872 extraction as session parsing: first VALID dispatch ID in
+        # document order (skips template placeholders, strips trailing prose
+        # punctuation) instead of the old first-match-only regex.
+        dispatch_id = SessionParser._extract_dispatch_id(content)
+        if not dispatch_id:
             continue
 
-        dispatch_id = m.group(1).strip()
         cur.execute(
             "UPDATE report_findings SET dispatch_id = ? WHERE id = ?",
             (dispatch_id, row_id)
@@ -149,6 +148,82 @@ def clean_polluted_dispatch_ids(conn: sqlite3.Connection) -> int:
     if cleaned:
         conn.commit()
     return cleaned
+
+
+def backfill_session_dispatch_ids(conn: sqlite3.Connection) -> int:
+    """Re-parse transcripts of NULL-dispatch sessions and fill dispatch_id (OI-872).
+
+    The parser fix (conversation_analyzer/parser.py) recovers dispatch IDs from
+    sessions the old first-match-only extraction missed — the worker-context
+    template carries ``Dispatch-ID: <dispatch_id>`` before the Dispatch Metadata
+    footer with the real ID, so the old parser stopped at the rejected
+    placeholder and never reached the real ID. Rows already analyzed are NOT
+    re-processed by the nightly analyzer (it only imports new session_ids), so
+    this phase re-parses the existing NULL rows once using the fixed
+    ``SessionParser`` and fills ``dispatch_id``.
+
+    Only ever tightens data: a row that yields no valid ID (no dispatch text,
+    placeholder-only, T0 orchestration, bench-*) keeps NULL. Idempotent — rows
+    already linked are skipped.
+
+    Returns the count of sessions newly linked.
+    """
+    from conversation_analyzer.parser import SessionParser  # noqa: PLC0415
+
+    cur = conn.cursor()
+    cur.execute(
+        "SELECT session_id, dispatch_id FROM session_analytics "
+        "WHERE dispatch_id IS NULL OR dispatch_id = ''"
+    )
+    pending_ids = {row[0] for row in cur.fetchall()}
+
+    # Also re-parse rows whose stored ID is polluted (trailing prose punctuation
+    # like "20260613-x." that the old regex captured, e.g. 2 benchmark-review
+    # sessions). The parser now strips such punctuation on extraction.
+    cur.execute(
+        "SELECT session_id, dispatch_id FROM session_analytics "
+        "WHERE dispatch_id IS NOT NULL AND dispatch_id != ''"
+    )
+    for session_id, stored in cur.fetchall():
+        if stored and SessionParser._validate_dispatch_id(stored) != stored:
+            pending_ids.add(session_id)
+
+    if not pending_ids:
+        return 0
+
+    # Index transcripts once: session_id -> jsonl path across ~/.claude/projects/*.
+    projects_dir = Path(
+        os.environ.get(
+            "CLAUDE_PROJECTS_DIR", str(Path.home() / ".claude" / "projects")
+        )
+    )
+    transcript_by_session: dict[str, Path] = {}
+    if projects_dir.is_dir():
+        for jsonl in projects_dir.glob("*/*.jsonl"):
+            sid = jsonl.stem
+            if sid in pending_ids and sid not in transcript_by_session:
+                transcript_by_session[sid] = jsonl
+
+    if not transcript_by_session:
+        return 0
+
+    parser = SessionParser()
+    linked = 0
+    for session_id, jsonl_path in transcript_by_session.items():
+        try:
+            metrics, _ = parser.parse_file(jsonl_path)
+        except Exception as exc:  # noqa: BLE001 — a bad transcript must not abort the phase
+            print(f"  backfill_session_dispatch_ids: parse failed {session_id[:8]}...: {exc}")
+            continue
+        if metrics.dispatch_id:
+            cur.execute(
+                "UPDATE session_analytics SET dispatch_id = ? WHERE session_id = ?",
+                (metrics.dispatch_id, session_id),
+            )
+            linked += 1
+    if linked:
+        conn.commit()
+    return linked
 
 
 def backfill_receipt_token_usage(conn: sqlite3.Connection) -> int:
@@ -266,19 +341,24 @@ def main():
     cleaned = clean_polluted_dispatch_ids(conn)
     print(f"  Placeholder dispatch_ids cleaned: {cleaned}")
 
-    # Phase 2: Link sessions to dispatches (bidirectional join).
+    # Phase 2: Backfill dispatch_id for already-analyzed NULL sessions (OI-872
+    # parser fix recovery — the nightly analyzer only imports new sessions).
+    backfilled_dispatch_ids = backfill_session_dispatch_ids(conn)
+    print(f"  Session dispatch_ids backfilled from transcripts: {backfilled_dispatch_ids}")
+
+    # Phase 3: Link sessions to dispatches (bidirectional join).
     linked_sessions = link_sessions_to_dispatches(conn)
     print(f"  Sessions linked to dispatches: {linked_sessions}")
 
-    # Phase 3: Link receipt outcomes to dispatches.
+    # Phase 4: Link receipt outcomes to dispatches.
     linked_receipts = link_receipts_to_dispatches(conn)
     print(f"  Receipt outcomes linked: {linked_receipts}")
 
-    # Phase 4: Link report findings to dispatches.
+    # Phase 5: Link report findings to dispatches.
     linked_reports = link_reports_to_dispatches(conn)
     print(f"  Report findings linked: {linked_reports}")
 
-    # Phase 5: Backfill receipt token_usage from session_analytics (OI-872 chain closure).
+    # Phase 6: Backfill receipt token_usage from session_analytics (OI-872 chain closure).
     enriched = backfill_receipt_token_usage(conn)
     print(f"  Receipts enriched with token_usage: {enriched}")
 

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -811,3 +811,134 @@ class TestClaudeEnvelopeToolcallSignals:
         assert mock_receipt.call_args[1]["tool_call_count"] is None
         assert mock_receipt.call_args[1]["tool_call_failures"] is None
         assert mock_receipt.call_args[1]["tool_call_retries"] is None
+
+
+class TestEnvelopeCostUsd:
+    """OI-882: the envelope must compute cost_usd from token_usage + wave7 prices.
+
+    The envelope previously hardcoded ``cost_usd=None`` in ``_govern`` even
+    though ``adapter_result.token_usage`` carried real tokens. All 45 null-cost
+    deepseek-harness receipts in the ledger came through this path.
+    """
+
+    def _run_govern(self, spec, adapter_result, tmp_path):
+        report_path = spec.data_dir / "unified_reports" / f"{spec.dispatch_id}.md"
+        receipt_path = spec.state_dir / "t0_receipts.ndjson"
+        receipt_path.write_text("")
+        mock_report = MagicMock(return_value=report_path)
+        mock_receipt = MagicMock(return_value=receipt_path)
+        mock_cost_event = MagicMock()
+
+        from datetime import datetime, timezone
+
+        with patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt), \
+             patch("provider_costs.emit_provider_cost", mock_cost_event):
+            dispatch_envelope._govern(
+                spec,
+                adapter_result,
+                datetime.now(timezone.utc),
+                datetime.now(timezone.utc),
+            )
+        return mock_report, mock_receipt
+
+    def test_deepseek_harness_cost_usd_computed(self, tmp_path):
+        """deepseek-harness tokens + wave7 prices yield a real cost_usd on the receipt."""
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir(parents=True)
+        (data_dir / "unified_reports").mkdir(parents=True)
+        spec = EnvelopeSpec(
+            dispatch_id="oi882-test-001",
+            terminal_id="T1",
+            provider="deepseek-harness",
+            model="deepseek-v4-flash",
+            instruction="review",
+            role="backend-developer",
+            pr_id=None,
+            state_dir=state_dir,
+            data_dir=data_dir,
+        )
+        adapter_result = dispatch_envelope._AdapterResult(
+            returncode=0,
+            completion_text="done",
+            status="success",
+            token_usage={"input": 91439, "output": 38053, "cache_hit": 6087040},
+            model="deepseek-v4-flash",
+        )
+
+        _, mock_receipt = self._run_govern(spec, adapter_result, tmp_path)
+
+        mock_receipt.assert_called_once()
+        cost_usd = mock_receipt.call_args[1]["cost_usd"]
+        assert cost_usd is not None, "OI-882: cost_usd must no longer be hardcoded None"
+        assert cost_usd > 0
+        # flash = 0.14/0.28 per MTok; 91439 input + 38053 output ≈ $0.0235
+        assert abs(cost_usd - 0.0234563) < 1e-6
+        assert mock_receipt.call_args[1]["model"] == "deepseek-v4-flash"
+
+    def test_resolved_model_wins_over_placeholder(self, tmp_path):
+        """A placeholder spec.model is replaced by the adapter's resolved model for pricing."""
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir(parents=True)
+        (data_dir / "unified_reports").mkdir(parents=True)
+        spec = EnvelopeSpec(
+            dispatch_id="oi882-test-002",
+            terminal_id="T1",
+            provider="deepseek-harness",
+            model="default",  # placeholder — adapter resolves to v4-pro
+            instruction="review",
+            role="backend-developer",
+            pr_id=None,
+            state_dir=state_dir,
+            data_dir=data_dir,
+        )
+        adapter_result = dispatch_envelope._AdapterResult(
+            returncode=0,
+            completion_text="done",
+            status="success",
+            token_usage={"input": 1000, "output": 500, "cache_hit": 0},
+            model="deepseek-v4-pro",
+        )
+
+        _, mock_receipt = self._run_govern(spec, adapter_result, tmp_path)
+
+        mock_receipt.assert_called_once()
+        assert mock_receipt.call_args[1]["model"] == "deepseek-v4-pro"
+        cost_usd = mock_receipt.call_args[1]["cost_usd"]
+        assert cost_usd is not None
+        # pro = 0.435/0.87 per MTok; 1000 input + 500 output
+        assert abs(cost_usd - (0.435 * 0.001 + 0.87 * 0.0005)) < 1e-9
+
+    def test_claude_lane_cost_usd_computed(self, spec_claude):
+        """The claude lane through the envelope now carries a list-price estimate."""
+        from datetime import datetime, timezone
+
+        adapter_result = dispatch_envelope._AdapterResult(
+            returncode=0,
+            completion_text="done",
+            status="success",
+            token_usage={"input": 200, "output": 100, "cache_hit": 50},
+            model="sonnet",
+        )
+        report_path = spec_claude.data_dir / "unified_reports" / f"{spec_claude.dispatch_id}.md"
+        receipt_path = spec_claude.state_dir / "t0_receipts.ndjson"
+        receipt_path.write_text("")
+        mock_report = MagicMock(return_value=report_path)
+        mock_receipt = MagicMock(return_value=receipt_path)
+
+        with patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
+            dispatch_envelope._govern(
+                spec_claude,
+                adapter_result,
+                datetime.now(timezone.utc),
+                datetime.now(timezone.utc),
+            )
+
+        mock_receipt.assert_called_once()
+        cost_usd = mock_receipt.call_args[1]["cost_usd"]
+        assert cost_usd is not None
+        # sonnet = 3.00/15.00 per MTok
+        assert abs(cost_usd - (3.0 * 0.0002 + 15.0 * 0.0001)) < 1e-9

--- a/tests/test_session_parser_dispatch_id.py
+++ b/tests/test_session_parser_dispatch_id.py
@@ -145,16 +145,65 @@ class TestProcessUserDispatchId:
         parser._process_user(record, metrics)
         assert metrics.dispatch_id == "20260731-123456-my-feature"
 
-    def test_only_first_three_messages_checked(self, parser):
-        """After 3 user messages, the parser stops looking for a dispatch ID."""
+    def test_real_id_from_bold_header(self, parser):
+        """A dispatch ID in a bold-styled header is accepted."""
         metrics = _make_metrics()
-        # First 3 have no dispatch ID
-        for _ in range(3):
+        record = _make_user_record("**Dispatch-ID:** 20260731-123456-my-feature")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == "20260731-123456-my-feature"
+
+    def test_real_id_with_trailing_period(self, parser):
+        """A dispatch ID followed by a sentence period is cleaned before storage."""
+        metrics = _make_metrics()
+        record = _make_user_record("Dispatch-ID: 20260731-123456-my-feature.")
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == "20260731-123456-my-feature"
+
+    def test_placeholder_before_real_id_same_message(self, parser):
+        """A template placeholder before the real ID does not block extraction.
+
+        The worker-context template carries ``Dispatch-ID: <dispatch_id>`` in
+        its Commit Convention section, ahead of the Dispatch Metadata footer
+        with the real ID. First-match-only extraction lost these sessions
+        (OI-872); the parser must keep scanning and take the first VALID ID.
+        """
+        metrics = _make_metrics()
+        record = _make_user_record(
+            "Include in commit body:\n```\nDispatch-ID: <dispatch_id>\n```\n\n"
+            "### Dispatch Metadata\n\n- Dispatch-ID: 20260731-123456-my-feature\n"
+            "- Model: sonnet\n"
+        )
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == "20260731-123456-my-feature"
+
+    def test_placeholder_only_message_stays_empty(self, parser):
+        """A message with only a placeholder keeps dispatch_id empty."""
+        metrics = _make_metrics()
+        record = _make_user_record(
+            "### Dispatch Metadata\n\n- Dispatch-ID: <dispatch_id>\n"
+        )
+        parser._process_user(record, metrics)
+        assert metrics.dispatch_id == ""
+
+    def test_only_first_scan_window_messages_checked(self, parser):
+        """After MAX_DISPATCH_SCAN_MESSAGES user messages, the parser stops looking."""
+        metrics = _make_metrics()
+        # First window-size messages have no dispatch ID
+        for _ in range(parser.MAX_DISPATCH_SCAN_MESSAGES):
             parser._process_user(_make_user_record("regular message"), metrics)
-        # 4th message has a real ID but should be ignored
+        # The next message has a real ID but is outside the scan window
         parser._process_user(
             _make_user_record("| **Dispatch-ID** | 20260731-123456-real |"), metrics)
         assert metrics.dispatch_id == ""
+
+    def test_real_id_inside_scan_window(self, parser):
+        """A real ID in the 6th user message is still within the scan window."""
+        metrics = _make_metrics()
+        for _ in range(5):
+            parser._process_user(_make_user_record("regular message"), metrics)
+        parser._process_user(
+            _make_user_record("| **Dispatch-ID** | 20260731-123456-real |"), metrics)
+        assert metrics.dispatch_id == "20260731-123456-real"
 
     def test_first_id_wins(self, parser):
         """The first valid dispatch ID found is kept; later ones are ignored."""
@@ -164,3 +213,32 @@ class TestProcessUserDispatchId:
         parser._process_user(record1, metrics)
         parser._process_user(record2, metrics)
         assert metrics.dispatch_id == "20260731-123456-first"
+
+
+class TestExtractDispatchId:
+    """Tests for SessionParser._extract_dispatch_id — first-valid-in-document-order."""
+
+    def test_none_for_no_mentions(self, parser):
+        """No Dispatch-ID mention yields None."""
+        assert parser._extract_dispatch_id("no dispatch here") is None
+
+    def test_skips_placeholder_to_real_id(self, parser):
+        """A later real ID is returned even when a placeholder appears first."""
+        text = "Dispatch-ID: <dispatch_id>\n\n### Dispatch Metadata\n- Dispatch-ID: 20260731-abc-123"
+        assert parser._extract_dispatch_id(text) == "20260731-abc-123"
+
+    def test_none_for_placeholder_only(self, parser):
+        """Placeholder-only text yields None."""
+        assert parser._extract_dispatch_id("Dispatch-ID: <dispatch_id>") is None
+
+    def test_first_valid_wins(self, parser):
+        """The first VALID ID wins; an invalid first candidate is skipped."""
+        text = ("Dispatch-ID: 20260731-abc-123\n"
+                "Dispatch-ID: 20260731-xyz-789")
+        assert parser._extract_dispatch_id(text) == "20260731-abc-123"
+
+    def test_table_and_header_order(self, parser):
+        """Table and header mentions are scanned in document order."""
+        text = ("Dispatch-ID: 20260731-header-1\n"
+                "| **Dispatch-ID** | 20260731-table-2 |")
+        assert parser._extract_dispatch_id(text) == "20260731-header-1"


### PR DESCRIPTION
## What

Two open items, one broken token chain: the price was known and the usage not, or the usage known and the owner not.

**OI-872 — token rows have no dispatch owner.** `conversation_analyzer/parser.py` only inspected the first `Dispatch-ID:` match per user message, hit the `<dispatch_id>` template placeholder first (rejected by validation), and stopped. Measured 2026-08-01: 40 ECHT / 1156 NULL of 1196 token rows. The parser now scans every mention in document order and keeps the first valid `YYYYMMDD-` ID, widens the scan window from 3 to 10 user messages, and strips trailing prose punctuation. `link_sessions_dispatches.py` gains a `backfill_session_dispatch_ids` phase so already-analyzed NULL rows get re-parsed on the nightly run, and `link_reports_to_dispatches` reuses the same first-valid extraction.

**OI-882 — provider-lane receipts carry tokens but no price.** `dispatch_envelope._govern` hardcoded `cost_usd=None`, so deepseek-harness / glm-harness / kimi / codex receipts through the envelope had real `token_usage` but null cost. The chain broke on conversion, not measurement. The envelope now resolves the actual spawned model, computes cost via `_compute_cost`, emits the ADR-005 cost event, and writes `cost_usd` on the receipt.

## Verification

- OI-872 (scratch DB copy, real DB untouched): ECHT 40 → 621, NULL 1156 → 575 (581 sessions recovered). Real-transcript parse lands `20260530-103046-hyg-closure`.
- OI-882: stream-token capture on the deepseek-harness lane confirmed working (`20260801-w1-gate-tooling` carries `token_usage`). End-to-end receipt write with that exact token data now produces `cost_usd: 0.0234563`.
- Tests: 181 passed; the 6 remaining failures are pre-existing on `origin/main` (verified via stash), including 4 `TestFlagGateClaude` and 2 `test_conversation_analyzer`.

## Changes

- `scripts/conversation_analyzer/parser.py` — first-valid-in-document-order extraction, scan window 10, punctuation/bold normalization.
- `scripts/lib/dispatch_envelope.py` — `_AdapterResult.model`, cost computation + ADR-005 cost event in `_govern`.
- `scripts/link_sessions_dispatches.py` — backfill phase for NULL rows; report linkage reuses the parser.
- `tests/test_session_parser_dispatch_id.py`, `tests/test_dispatch_envelope.py` — new coverage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)