### PR TITLE
fix(cli): honor pin by install identity, align doctor pin reporting (OI-892, OI-914)

### DIFF
--- a/tests/test_vnx_cli_reexec.py
+++ b/tests/test_vnx_cli_reexec.py
@@ -161,6 +161,68 @@ def test_pin_without_v_resolves_v_prefixed_dir(central_store, execv_spy, tmp_pat
     assert len(execv_spy) == 1
 
 
+def test_pin_not_satisfied_by_same_version_different_install(
+    central_store, execv_spy, tmp_path, monkeypatch
+):
+    """OI-892: a rolling dir claiming the SAME VERSION must not impersonate the
+    pinned install.
+
+    The running engine root is ``versions/edge``, whose VERSION file says
+    1.3.0 but which carries a different commit than the real
+    ``versions/v1.3.0`` (the exact doubleganger measured during the v1.4.0
+    cut). A pin on v1.3.0 must re-exec to ``versions/v1.3.0``, not trust
+    edge's VERSION string. RED on the old code: it compared VERSION strings
+    and returned early.
+    """
+    pinned = central_store / "v1.3.0"
+    (pinned / "COMMIT_SHA").write_text("6129a327\n", encoding="utf-8")
+
+    imposter = central_store / "edge"
+    (imposter / "vnx_cli").mkdir(parents=True)
+    (imposter / "vnx_cli" / "__init__.py").write_text("", encoding="utf-8")
+    (imposter / ".vnx-install-mode").write_text("central\n", encoding="utf-8")
+    (imposter / "VERSION").write_text("1.3.0\n", encoding="utf-8")  # claims the SAME version
+    (imposter / "COMMIT_SHA").write_text("d74e0691\n", encoding="utf-8")
+
+    monkeypatch.setattr(_engine, "engine_root", lambda: imposter)
+    _pin(tmp_path, "v1.3.0")
+
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+
+    assert len(execv_spy) == 1
+    _, args = execv_spy[0]
+    assert os.environ["PYTHONPATH"].split(os.pathsep)[0] == str(pinned)
+
+
+def test_pin_v140_with_running_v141_reexecs(central_store, execv_spy, tmp_path):
+    """OI-892/OI-914: a v1.4.0 pin with a v1.4.1 engine running must re-exec
+    to v1.4.0 — the exact drift measured on all three consumers after the
+    v1.4.1 rollout (`cat .vnx-version` said v1.4.0 while v1.4.1 loaded)."""
+    pinned = _add_version(central_store, "v1.4.0", "1.4.0")
+    _add_version(central_store, "v1.4.1", "1.4.1")
+    _pin(tmp_path, "v1.4.0")
+    _reexec.maybe_reexec_pinned(["--project-dir", str(tmp_path)])
+
+    assert len(execv_spy) == 1
+    _, args = execv_spy[0]
+    assert os.environ["PYTHONPATH"].split(os.pathsep)[0] == str(pinned)
+
+
+def test_running_edge_reports_dir_name_not_stale_version(central_store, tmp_path):
+    """OI-892: a rolling dir (edge) whose VERSION lags is reported by its dir
+    name, never by a stale VERSION — it cannot present itself as a released
+    version."""
+    edge = central_store / "edge"
+    edge.mkdir()
+    (edge / "VERSION").write_text("1.3.0\n", encoding="utf-8")
+    assert _reexec._running_version(edge) == "edge"
+
+
+def test_running_version_reads_version_file(central_store):
+    """A released version dir is still reported by its VERSION file."""
+    assert _reexec._running_version(central_store / "v1.3.0") == "1.3.0"
+
+
 def test_existing_pythonpath_preserved_after_pinned_paths(central_store, execv_spy, tmp_path, monkeypatch):
     pinned = _add_version(central_store, "v1.2.0", "1.2.0")
     _pin(tmp_path, "v1.2.0")

--- a/tests/test_vnx_cli_version.py
+++ b/tests/test_vnx_cli_version.py
@@ -69,6 +69,18 @@ def test_read_version_file_falls_back_when_no_version_file(tmp_path, monkeypatch
     assert _read_version_file() == __version__
 
 
+def test_read_version_file_reports_rolling_dir_by_name(tmp_path, monkeypatch):
+    """OI-892: a rolling dir (edge) whose VERSION lags is reported by its dir
+    name, never by a stale released version — it must not present itself as a
+    version it is not pinned to."""
+    import vnx_cli._engine as _engine
+    rolling = tmp_path / "edge"
+    rolling.mkdir()
+    (rolling / "VERSION").write_text("1.3.0\n", encoding="utf-8")  # stale
+    monkeypatch.setattr(_engine, "engine_root", lambda: rolling)
+    assert _read_version_file() == "edge"
+
+
 # ---------------------------------------------------------------------------
 # _read_pin
 # ---------------------------------------------------------------------------

--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -8,6 +8,7 @@ from unittest.mock import patch
 
 import pytest
 
+from vnx_cli import _engine
 from vnx_cli.commands.doctor import (
     FAIL, PASS, WARN,
     _check_active_drain,
@@ -71,8 +72,10 @@ def _make_coordination_db(state_dir: Path, active_count: int = 0, schema_version
 # ---------------------------------------------------------------------------
 
 class TestEmbeddedMode:
-    def test_embedded_mode_detected(self, tmp_path):
+    def test_embedded_mode_detected(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
+        # Hermetic home: the operator's real ~/.vnx-system must not leak in.
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
         embedded = project / ".claude" / "vnx-system" / "scripts"
         embedded.mkdir(parents=True)
 
@@ -82,8 +85,14 @@ class TestEmbeddedMode:
         assert "mode: embedded" in result.detail
         assert "vnx-system" in result.detail
 
-    def test_no_install_warns(self, tmp_path):
+    def test_no_install_warns(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+        # No central/embedded install AND no visible source/packaged engine
+        # tree: the dev-checkout repo root must not leak in as a source install.
+        empty_root = tmp_path / "empty-engine"
+        empty_root.mkdir()
+        monkeypatch.setattr(_engine, "engine_root", lambda: empty_root)
 
         result = _check_install_mode(project)
 
@@ -92,18 +101,20 @@ class TestEmbeddedMode:
 
 
 # ---------------------------------------------------------------------------
-# Test 2: central-mode install detected with pin
+# Test 2: central-mode install detected with pin vs active
 # ---------------------------------------------------------------------------
 
 class TestCentralMode:
     def test_central_mode_detected(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
-        central = tmp_path / "home" / ".vnx-system" / "current"
-        central_scripts = central / "scripts"
-        central_scripts.mkdir(parents=True)
-        version_file = central / "VERSION"
-        version_file.write_text("1.0.0-rc2\n")
-        (central / ".vnx-install-mode").write_text("central\n")
+        # Project pin: the value `cat .vnx-version` shows.
+        (project / ".vnx-version").write_text("v1.0.0-rc2\n")
+        version_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.0.0-rc2"
+        (version_dir / "scripts").mkdir(parents=True)
+        (version_dir / "VERSION").write_text("1.0.0-rc2\n")
+        (version_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(version_dir)
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
@@ -111,8 +122,8 @@ class TestCentralMode:
 
         assert result.status == PASS
         assert "mode: central" in result.detail
-        assert "pin:" in result.detail
-        assert "1.0.0-rc2" in result.detail
+        assert "pin: v1.0.0-rc2" in result.detail
+        assert "active: v1.0.0-rc2" in result.detail
 
     def test_central_mode_pin_unset_when_no_version_file(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
@@ -126,41 +137,65 @@ class TestCentralMode:
 
         assert result.status == PASS
         assert "pin: unset" in result.detail
+        assert "active: current" in result.detail
 
     def test_central_mode_pin_error_on_read_failure(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
+        pin_file = project / ".vnx-version"
+        pin_file.write_text("1.0.0-rc2\n")
+        pin_file.chmod(0o000)
         central = tmp_path / "home" / ".vnx-system" / "current"
         (central / "scripts").mkdir(parents=True)
-        version_file = central / "VERSION"
-        version_file.write_text("1.0.0-rc2\n")
-        version_file.chmod(0o000)
+        (central / ".vnx-install-mode").write_text("central\n")
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
         try:
             result = _check_install_mode(project)
         finally:
-            version_file.chmod(0o644)
+            pin_file.chmod(0o644)
 
         assert result.status == WARN
         assert "pin: error" in result.detail
 
     def test_central_mode_error_pin_causes_strict_exit_1(self, tmp_path, monkeypatch):
         project = _make_project(tmp_path)
+        pin_file = project / ".vnx-version"
+        pin_file.write_text("1.0.0-rc2\n")
+        pin_file.chmod(0o000)
         central = tmp_path / "home" / ".vnx-system" / "current"
         (central / "scripts").mkdir(parents=True)
-        version_file = central / "VERSION"
-        version_file.write_text("1.0.0-rc2\n")
-        version_file.chmod(0o000)
+        (central / ".vnx-install-mode").write_text("central\n")
 
         monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
 
         try:
             exit_code = vnx_doctor(_make_args(str(project), strict=True))
         finally:
-            version_file.chmod(0o644)
+            pin_file.chmod(0o644)
 
         assert exit_code == 1
+
+    def test_central_mode_pin_and_active_agree_with_pin_file(self, tmp_path, monkeypatch):
+        """OI-914: doctor's pin line and `cat .vnx-version` must agree. A
+        project pinning v1.4.0 while v1.4.1 is active is reported as BOTH —
+        the drift is visible, not silently reported as a single value that
+        matches neither."""
+        project = _make_project(tmp_path)
+        (project / ".vnx-version").write_text("v1.4.0\n")
+        active_dir = tmp_path / "home" / ".vnx-system" / "versions" / "v1.4.1"
+        (active_dir / "scripts").mkdir(parents=True)
+        (active_dir / ".vnx-install-mode").write_text("central\n")
+        current = tmp_path / "home" / ".vnx-system" / "current"
+        current.symlink_to(active_dir)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_install_mode(project)
+
+        assert result.status == PASS
+        assert "pin: v1.4.0" in result.detail
+        assert "active: v1.4.1" in result.detail
 
     def test_central_mode_missing_marker_warns(self, tmp_path, monkeypatch):
         """The active `current` resolves to a version dir with no
@@ -180,7 +215,8 @@ class TestCentralMode:
 
         assert result.status == WARN
         assert "mode: central" in result.detail
-        assert "pin: edge" in result.detail
+        assert "pin: unset" in result.detail
+        assert "active: edge" in result.detail
         assert "install-mode marker missing" in result.detail
 
     def test_central_mode_invalid_marker_content_warns(self, tmp_path, monkeypatch):
@@ -253,7 +289,7 @@ class TestSchemaVersions:
         project = _make_project(tmp_path)
         _make_coordination_db(project / ".vnx-data" / "state", schema_version=10)
 
-        results = _check_schema_versions(project)
+        results = _check_schema_versions(project / ".vnx-data")
 
         coord_check = next(r for r in results if "runtime_coordination" in r.name)
         assert coord_check.status == PASS
@@ -263,7 +299,7 @@ class TestSchemaVersions:
         project = _make_project(tmp_path)
         _make_coordination_db(project / ".vnx-data" / "state", schema_version=5)
 
-        results = _check_schema_versions(project)
+        results = _check_schema_versions(project / ".vnx-data")
 
         coord_check = next(r for r in results if "runtime_coordination" in r.name)
         assert coord_check.status == WARN
@@ -281,7 +317,7 @@ class TestSchemaVersions:
     def test_missing_db_warns_not_fails(self, tmp_path):
         project = _make_project(tmp_path)
 
-        results = _check_schema_versions(project)
+        results = _check_schema_versions(project / ".vnx-data")
 
         for r in results:
             assert r.status != FAIL
@@ -303,7 +339,7 @@ class TestSchemaVersions:
         conn.commit()
         conn.close()
 
-        results = _check_schema_versions(project)
+        results = _check_schema_versions(project / ".vnx-data")
 
         coord_check = next(r for r in results if "runtime_coordination" in r.name)
         assert coord_check.status == PASS
@@ -326,7 +362,7 @@ class TestSchemaVersions:
         conn.commit()
         conn.close()
 
-        results = _check_schema_versions(project)
+        results = _check_schema_versions(project / ".vnx-data")
 
         coord_check = next(r for r in results if "runtime_coordination" in r.name)
         assert coord_check.status == PASS
@@ -396,7 +432,7 @@ class TestSkillCoverage:
     def test_no_dispatches_passes(self, tmp_path):
         project = _make_project(tmp_path)
 
-        result = _check_skill_coverage(project)
+        result = _check_skill_coverage(project, project / ".vnx-data")
 
         assert result.status == PASS
 
@@ -405,7 +441,7 @@ class TestSkillCoverage:
         dispatch = project / ".vnx-data" / "dispatches" / "pending" / "test.md"
         dispatch.write_text("Role: backend-developer\n\nDo some work.\n")
 
-        result = _check_skill_coverage(project)
+        result = _check_skill_coverage(project, project / ".vnx-data")
 
         assert result.status == PASS
 
@@ -414,7 +450,7 @@ class TestSkillCoverage:
         dispatch = project / ".vnx-data" / "dispatches" / "pending" / "test.md"
         dispatch.write_text("Role: my-custom-nonexistent-skill\n\nDo some work.\n")
 
-        result = _check_skill_coverage(project)
+        result = _check_skill_coverage(project, project / ".vnx-data")
 
         assert result.status == WARN
         assert "my-custom-nonexistent-skill" in result.detail
@@ -427,7 +463,7 @@ class TestSkillCoverage:
         dispatch = project / ".vnx-data" / "dispatches" / "pending" / "test.md"
         dispatch.write_text("Role: my-custom-skill\n\nDo some work.\n")
 
-        result = _check_skill_coverage(project)
+        result = _check_skill_coverage(project, project / ".vnx-data")
 
         assert result.status == PASS
 
@@ -438,7 +474,7 @@ class TestSkillCoverage:
         dispatch.chmod(0o000)
 
         try:
-            result = _check_skill_coverage(project, strict=False)
+            result = _check_skill_coverage(project, project / ".vnx-data", strict=False)
         finally:
             dispatch.chmod(0o644)
 
@@ -452,7 +488,7 @@ class TestSkillCoverage:
         dispatch.chmod(0o000)
 
         try:
-            result = _check_skill_coverage(project, strict=True)
+            result = _check_skill_coverage(project, project / ".vnx-data", strict=True)
         finally:
             dispatch.chmod(0o644)
 
@@ -469,7 +505,7 @@ class TestActiveDrain:
         project = _make_project(tmp_path)
         _make_coordination_db(project / ".vnx-data" / "state", active_count=0)
 
-        result = _check_active_drain(project)
+        result = _check_active_drain(project / ".vnx-data")
 
         assert result.status == PASS
         assert "no active" in result.detail
@@ -478,7 +514,7 @@ class TestActiveDrain:
         project = _make_project(tmp_path)
         _make_coordination_db(project / ".vnx-data" / "state", active_count=3)
 
-        result = _check_active_drain(project)
+        result = _check_active_drain(project / ".vnx-data")
 
         assert result.status == WARN
         assert "3" in result.detail
@@ -487,7 +523,7 @@ class TestActiveDrain:
     def test_missing_db_passes(self, tmp_path):
         project = _make_project(tmp_path)
 
-        result = _check_active_drain(project)
+        result = _check_active_drain(project / ".vnx-data")
 
         assert result.status == PASS
 

--- a/vnx_cli/_reexec.py
+++ b/vnx_cli/_reexec.py
@@ -42,6 +42,13 @@ INSTALL_MODE_VALUE = "central"
 # and `vnx init --set-version`. Forbids '/' and shell metacharacters.
 _PIN_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 
+# Rolling (living-checkout) version dir names. `vnx update --to edge` materializes
+# main as ``versions/edge``; such a dir carries arbitrary commits while its VERSION
+# file can lag behind the released versions. Its VERSION must never be treated as a
+# released version (OI-892 doubleganger), so ``_running_version`` reports the dir
+# name instead of the stale VERSION file.
+_ROLLING_DIR_RE = re.compile(r"^(?:edge|latest)$", re.IGNORECASE)
+
 
 def _warn(msg: str) -> None:
     print(f"[vnx-reexec] WARNING: {msg}", file=sys.stderr)
@@ -122,7 +129,15 @@ def _is_central_install(engine_root: Path) -> bool:
 
 
 def _running_version(engine_root: Path) -> Optional[str]:
-    """The version of the code this process actually loaded (its VERSION file)."""
+    """The version of the code this process actually loaded.
+
+    For a central version dir this is its VERSION file. A rolling dir
+    (``edge``/``latest``) is reported by its dir NAME: its VERSION file is not
+    authoritative and can impersonate a released version it is not running
+    (OI-892) — the dir name is the honest identity.
+    """
+    if _ROLLING_DIR_RE.match(engine_root.name):
+        return engine_root.name
     try:
         text = (engine_root / "VERSION").read_text(encoding="utf-8").strip()
     except OSError:
@@ -209,18 +224,27 @@ def _maybe_reexec_pinned(argv: List[str]) -> None:
     if not _is_central_install(engine_root):
         return  # dev checkout / non-central install: never re-exec
 
-    running = _running_version(engine_root)
-    if running is not None and _normalize_version(running) == _normalize_version(pin):
-        return  # already running the pinned version
-
     versions_dir = _versions_dir(engine_root)
     pinned_dir = _resolve_pinned_dir(versions_dir, pin)
     if pinned_dir is None:
+        running = _running_version(engine_root)
         _warn(
             f"pinned version {pin!r} is not installed under {versions_dir}; "
             f"running current version ({running or 'unknown'})"
         )
         return
+
+    # OI-892: compare install IDENTITY (the resolved dir), not the VERSION
+    # string. A rolling dir like versions/edge carries arbitrary commits while
+    # its VERSION file stays behind, so a VERSION-string match would let it
+    # impersonate the pin and silently skip the re-exec forever. Re-exec
+    # whenever the running engine root is not the pinned dir itself.
+    try:
+        running_is_pinned = engine_root.resolve() == pinned_dir.resolve()
+    except OSError:
+        running_is_pinned = False
+    if running_is_pinned:
+        return  # already running the pinned install
 
     if not (pinned_dir / "vnx_cli" / "__init__.py").is_file():
         _warn(

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -14,6 +14,7 @@ from pathlib import Path
 from typing import NamedTuple
 
 from vnx_cli import _engine
+from vnx_cli._reexec import PIN_FILE_NAME
 
 logger = logging.getLogger(__name__)
 
@@ -134,25 +135,41 @@ def _check_agents(project_dir: Path) -> Check:
     )
 
 
-def _resolve_central_pin(central_path: Path) -> str:
-    """Resolve the version pin for a central install directory."""
+def _read_project_pin(project_dir: Path) -> str:
+    """Read the project's ``.vnx-version`` pin file (the operator's pin intent).
+
+    This is the SAME file ``vnx_cli._reexec`` honors at startup, so doctor's
+    ``pin`` field and ``cat .vnx-version`` agree (OI-914). Returns the raw
+    first line when present and non-empty, ``"unset"`` when there is no usable
+    pin, or ``"error"`` when a pin file exists but cannot be read.
+    """
+    pin_file = project_dir / PIN_FILE_NAME
+    if not pin_file.is_file():
+        return "unset"
+    try:
+        first = pin_file.read_text(encoding="utf-8").strip().splitlines()[0]
+    except OSError as exc:
+        logger.warning("doctor: cannot read pin file %s: %s", pin_file, exc)
+        return "error"
+    if not first:
+        return "unset"
+    return first
+
+
+def _resolve_active_version(central_path: Path) -> str:
+    """The version dir the ``current`` symlink actually points at.
+
+    This is what loads absent a pin re-exec — NOT the project's ``.vnx-version``
+    pin intent. Reported separately from ``pin`` so a pin that is not honored is
+    visible instead of the two silently disagreeing under one label.
+    """
     try:
         if central_path.is_symlink():
             return central_path.resolve().name
-    except OSError as e:
-        logger.warning("doctor: cannot resolve central_path symlink: %s", e)
-        return "error"
-    for fname in ("VERSION", "version.txt", ".vnx-version"):
-        vf = central_path / fname
-        if vf.is_file():
-            try:
-                first = vf.read_text(encoding="utf-8").strip().splitlines()[0]
-                if first:
-                    return first
-            except OSError as e:
-                logger.warning("doctor: cannot read version file %s: %s", vf, e)
-                return "error"
-    return "unset"
+    except OSError as exc:
+        logger.warning("doctor: cannot resolve central_path symlink: %s", exc)
+        return "unresolved"
+    return central_path.name
 
 
 def _check_central_install_marker(central_path: Path) -> "str | None":
@@ -182,7 +199,16 @@ def _check_central_install_marker(central_path: Path) -> "str | None":
 
 
 def _check_install_mode(project_dir: Path) -> Check:
-    """Detect embedded vs central VNX install mode and report the active pin."""
+    """Detect embedded vs central VNX install mode and report pin vs active.
+
+    In central mode the check reports two values that OI-914 found conflated
+    under one "pin" label:
+      * ``pin`` — the project's ``.vnx-version`` file (the pin the startup
+        re-exec honors; matches ``cat .vnx-version``);
+      * ``active`` — the version dir the ``current`` symlink resolves to
+        (what actually runs absent a re-exec).
+    Reporting both makes a pin that is not honored visible.
+    """
     embedded_path = project_dir / ".claude" / "vnx-system"
     central_path = Path.home() / ".vnx-system" / "current"
 
@@ -190,24 +216,28 @@ def _check_install_mode(project_dir: Path) -> Check:
     embedded_active = (embedded_path / "scripts").is_dir()
 
     if central_active:
-        pin = _resolve_central_pin(central_path)
+        pin = _read_project_pin(project_dir)
+        active = _resolve_active_version(central_path)
+        marker_issue = _check_central_install_marker(central_path)
         if pin == "error":
             return Check(
                 name="install:mode",
                 status=WARN,
-                detail="mode: central, pin: error (cannot read version file — check permissions)",
+                detail=(
+                    f"mode: central, pin: error (cannot read "
+                    f"{project_dir / PIN_FILE_NAME} — check permissions), active: {active}"
+                ),
             )
-        marker_issue = _check_central_install_marker(central_path)
         if marker_issue is not None:
             return Check(
                 name="install:mode",
                 status=WARN,
-                detail=f"mode: central, pin: {pin}, {marker_issue}",
+                detail=f"mode: central, pin: {pin}, active: {active}, {marker_issue}",
             )
         return Check(
             name="install:mode",
             status=PASS,
-            detail=f"mode: central, pin: {pin}",
+            detail=f"mode: central, pin: {pin}, active: {active}",
         )
     if embedded_active:
         return Check(

--- a/vnx_cli/commands/version.py
+++ b/vnx_cli/commands/version.py
@@ -7,6 +7,8 @@ import subprocess
 import sys
 from pathlib import Path
 
+from vnx_cli._reexec import _ROLLING_DIR_RE
+
 
 def _read_version_file() -> str:
     # Read the version from the RESOLVED engine's VERSION file, not the pip
@@ -15,9 +17,17 @@ def _read_version_file() -> str:
     # =1.1.0 while the dist-info is still ...-1.0.0); the metadata then lies.
     # The engine's VERSION file is authoritative for the code that actually
     # loads. Fall back to package metadata only if VERSION is unreadable.
+    #
+    # OI-892: a ROLLING dir (edge/latest) is reported by its dir NAME instead.
+    # Its VERSION file is a git-tracked checkout of main that can lag the
+    # released versions, so it would claim a version the rolling code is not
+    # pinned to. The dir name is the honest identity.
     try:
         from vnx_cli import _engine
-        version_file = _engine.engine_root() / "VERSION"
+        engine_root = _engine.engine_root()
+        if _ROLLING_DIR_RE.match(engine_root.name):
+            return engine_root.name
+        version_file = engine_root / "VERSION"
         if version_file.is_file():
             v = version_file.read_text(encoding="utf-8").strip()
             if v:


### PR DESCRIPTION
## OI-892 + OI-914: versie-pin honoreert install-identiteit + doctor rapporteert pin en active apart

### OI-892 — de pin wordt vervuld door een dubbelganger

`_maybe_reexec_pinned` vergeleek de VERSION-string van de draaiende engine-root met de pin. Een rollende dir zoals `versions/edge` draagt willekeurige commits terwijl zijn VERSION achterblijft, dus hij kon een v1.3.0-pin voor altijd vervullen zonder ooit de echte `versions/v1.3.0` te laden.

**Fix:** de vergelijking gaat nu over de resolved install-dir (path-identiteit), niet over de VERSION-string. Re-exec volgt wanneer de draaiende root niet het gepinde dir zelf is, ook bij gelijke VERSION. Daarnaast rapporteert `_running_version` en `vnx version` een rollende dir (edge/latest) op zijn naam, nooit op een verouderde VERSION.

### OI-914 — doctor's "pin" en het pin-bestand spraken elkaar tegen

Doctor las de versie uit de `current`-symlink (de actieve dir) en noemde dat "pin", terwijl `.vnx-version` iets anders zei. Na de v1.4.1-uitrol meldde doctor `pin: v1.4.1` terwijl `cat .vnx-version` `v1.4.0` gaf.

**Fix:** `install:mode` meldt nu twee velden:
- `pin` — de project `.vnx-version` (hetzelfde bestand dat de re-exec honoreert);
- `active` — de dir waar de `current`-symlink naartoe wijst.

Doctor's pin-regel komt daarmee overeen met `cat .vnx-version`, en een niet-gehonoreerde pin wordt zichtbaar als `pin` ≠ `active`.

### Verificatie
- Nieuwe test is rood op de oude code en groen op de nieuwe: twee install-dirs met dezelfde VERSION maar andere commit → de pin kiest het juiste dir.
- Pin v1.4.0 met draaiende v1.4.1 → re-exec naar v1.4.0 (getest).
- Doctor's pin-regel == `cat .vnx-version` (getest: `pin: v1.4.0, active: v1.4.1`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)