### PR TITLE
fix(sessobs): surface tmux list-panes failure via degraded_reasons (OI-558)

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -728,7 +728,15 @@ def _list_tmux_sessions(now: datetime) -> "tuple[list[dict], list[str]]":
         text=True,
         timeout=5,
     )
-    if panes_result.returncode == 0:
+    # A panes failure degrades only busy/idle classification — sessions still
+    # list. Surface it via degraded_reasons like the sessions failure path so a
+    # failing probe is observable, not silent (sessobs #1076 residual).
+    reasons: list[str] = []
+    if panes_result.returncode != 0:
+        reason = f"tmux list-panes failed (rc={panes_result.returncode})"
+        _logger.warning("session observability: %s", reason)
+        reasons.append(reason)
+    else:
         for line in panes_result.stdout.splitlines():
             parts = line.split("\t", 1)
             if len(parts) == 2:
@@ -757,7 +765,7 @@ def _list_tmux_sessions(now: datetime) -> "tuple[list[dict], list[str]]":
             "age_seconds": age_seconds,
         })
 
-    return sessions, []
+    return sessions, reasons
 
 
 def _load_session_store_entries() -> "dict[str, dict]":

--- a/tests/test_serve_dashboard_api.py
+++ b/tests/test_serve_dashboard_api.py
@@ -642,3 +642,31 @@ class TestOperatorSessions:
         assert result["degraded"] is True
         assert any("session store" in reason.lower() for reason in result["degraded_reasons"])
         assert result["data"] == []
+
+    def test_panes_failure_surfaces_degraded_reason(self) -> None:
+        """A tmux list-panes failure degrades busy/idle but sessions still list.
+
+        Matches the sessions-failure path: a failing probe must be observable,
+        not silent (sessobs #1076 residual, OI-558).
+        """
+        sessions_ok = ao.subprocess.CompletedProcess(
+            args=["tmux", "list-sessions"],
+            returncode=0,
+            stdout="vnx-demo\t1700000000\n",
+            stderr="",
+        )
+        panes_failed = ao.subprocess.CompletedProcess(
+            args=["tmux", "list-panes"],
+            returncode=1,
+            stdout="",
+            stderr="error",
+        )
+        with (
+            patch.object(ao.shutil, "which", return_value="/usr/bin/tmux"),
+            patch.object(ao.subprocess, "run", side_effect=[sessions_ok, panes_failed]),
+        ):
+            sessions, reasons = ao._list_tmux_sessions(datetime(2026, 1, 1, tzinfo=timezone.utc))
+
+        # Sessions still list (busy/idle classification degrades, not the list).
+        assert len(sessions) == 1
+        assert any("list-panes" in r for r in reasons)


### PR DESCRIPTION
## Triage-ronde 20260801-t4-oi-triage

Meet-opdracht op 12 open items (OI-546 t/m OI-621). Alle items zijn gereproduceerd tegen de
huidige code; het bewijs per item staat in het unified report
(`unified_reports/20260801-t4-oi-triage.md`).

**Uitkomst:** 0 achterhaald, 11 bestaan nog (ontwerpkeuze/refactor), 1 klein-item deels gefixt.

### Codewijziging

`_list_tmux_sessions` (`dashboard/api_operator.py`): de `panes_result`-subprocess-failure degradeerde
busy/idle-still en werd niet geëmitteerd als degraded_reason. Gefixt analoog aan de bestaande
`list-sessions`-failure-path: warning-log + degraded_reason, sessions blijven lijsten.

### Test

`test_panes_failure_surfaces_degraded_reason` — geverifieerd rood op main (via stash), groen met de fix.

### Rapport (geen codewijziging voor de overige items)

| Item | Verdict | Kern-bewijs |
|---|---|---|
| OI-546 | BESTAAT-GROOT | scout schrijft nog `state_dir/scout_effectiveness.json` zonder ledger-event |
| OI-547 | BESTAAT-GROOT | `_check_hook_paths` 82 non-blank regels; helper-split deels gedaan |
| OI-557 | BESTAAT-GROOT | geen ADR-005-exemptie voor analysis-artefacten |
| OI-558 | BESTAAT-KLEIN (gefixt) + 2 grootte-advisories | panes-degradatie gefixt; `_operator_get_sessions` 83, `LiveSessionsPage` 91 regels |
| OI-559 | BESTAAT-GROOT | `worker_permission_enforcement` vs `permission_enforcement` inconsistentie nog aanwezig |
| OI-560 | BESTAAT-GROOT | `vnx_dispatch_agent` 180 regels |
| OI-561 | BESTAAT-GROOT | gate nog advisory; review-bij-flip open |
| OI-562 | BESTAAT-GROOT | signed-delegation nog default-off; review-bij-flip open |
| OI-563 | BESTAAT-GROOT | `_migrate_v27` slikt errors, user_version bumped; geen duurzame marker |
| OI-564 | BESTAAT-GROOT | impliciete transactie; bewust gedeferred |
| OI-579 | BESTAAT-GROOT | `planning_cli.py` 2593 regels (gegroeid) |
| OI-621 | BESTAAT-GROOT | geen continue content-convergentie-assertie |

### Open item (buiten de OI-lijst)

6 pre-bestaande testfails in `tests/test_serve_dashboard_api.py`: `TestOperatorKanban` +
`TestGateTogglePost` roepen `sd._read_gate_config` aan, functie is verhuisd naar
`api_operator.py:960` en wordt niet meer gere-exporteerd.

🤖 Generated with [Claude Code](https://claude.com/claude-code)