### PR TITLE
fix(lint): T3 triage OI-212..OI-288 — 2 fixes, evidence voor T0

### DIFF
--- a/scripts/commands/dispatch.sh
+++ b/scripts/commands/dispatch.sh
@@ -563,7 +563,8 @@ HELP
   instruction=$(cat "$abs_file")
 
   # Move file to active/
-  local active_path="${VNX_DISPATCH_DIR}/active/$(basename "$abs_file")"
+  local active_path
+  active_path="${VNX_DISPATCH_DIR}/active/$(basename "$abs_file")"
   mkdir -p "${VNX_DISPATCH_DIR}/active"
   cp "$abs_file" "$active_path"
 
@@ -620,7 +621,8 @@ HELP
 
   if [ "$exit_code" -eq 0 ]; then
     # Move to completed/
-    local completed_path="${VNX_DISPATCH_DIR}/completed/$(basename "$abs_file")"
+    local completed_path
+    completed_path="${VNX_DISPATCH_DIR}/completed/$(basename "$abs_file")"
     mkdir -p "${VNX_DISPATCH_DIR}/completed"
     mv "$active_path" "$completed_path" 2>/dev/null || true
     log "[dispatch] Done — dispatch $dispatch_id completed (receipt: success)"

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -34,9 +34,18 @@ import sys
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, Optional
 
 sys.path.insert(0, str(Path(__file__).parent))
+
+# ExecutionPlan / ExecutionPermit: the plan + permit types routed by the
+# adapters and run_envelope_plan. Runtime import (not TYPE_CHECKING) so
+# typing.get_type_hints() on these signatures resolves them — the F821
+# unresolved-name finding (OI-288) was hiding a get_type_hints NameError.
+# No import cycle: dispatch_plan -> dispatch_spec and dispatch_internal
+# are stdlib-only leaf modules.
+from dispatch_internal import ExecutionPermit  # noqa: E402
+from dispatch_plan import ExecutionPlan  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -1139,7 +1148,6 @@ class ProviderAdapter:
             _extract_token_usage,
             _resolve_codex_model,
             _resolve_deepseek_model,
-            _resolve_kimi_model_label,
             _resolve_moonshot_model,
             _resolve_zai_model,
         )

--- a/tests/test_dispatch_envelope_annotations_resolve.py
+++ b/tests/test_dispatch_envelope_annotations_resolve.py
@@ -1,0 +1,38 @@
+"""OI-288: dispatch_envelope signature annotations must resolve.
+
+The F821 undefined-name findings (ExecutionPlan x4, ExecutionPermit x2) were
+not just lint noise: typing.get_type_hints() on the affected signatures
+raised NameError because the names were never imported into the module.
+Any introspection of these signatures (docs, pydantic-style validation,
+dispatch-door type checks) would crash.
+
+Fails on the pre-fix code (get_type_hints -> NameError) and passes once the
+runtime imports of ExecutionPlan / ExecutionPermit land in
+scripts/lib/dispatch_envelope.py.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+import dispatch_envelope
+
+
+@pytest.mark.parametrize(
+    "owner, attr",
+    [
+        (dispatch_envelope.ProviderAdapter, "run"),
+        (dispatch_envelope.ProviderAdapter, "_run_kimi"),
+        (dispatch_envelope, "run_envelope_plan"),
+        (dispatch_envelope, "run_envelope_headless_plan"),
+    ],
+)
+def test_signature_annotations_resolve(owner, attr):
+    """get_type_hints on every F821-flagged signature must resolve."""
+    func = getattr(owner, attr)
+    try:
+        typing.get_type_hints(func)
+    except NameError as exc:  # unresolved annotation name (pre-fix failure)
+        pytest.fail(f"{attr}: unresolved annotation name: {exc}")

--- a/tests/test_dispatch_sh_sc2155.py
+++ b/tests/test_dispatch_sh_sc2155.py
@@ -1,0 +1,37 @@
+"""OI-268: dispatch.sh must not declare-and-assign with command substitution.
+
+shellcheck SC2155 ("Declare and assign separately to avoid masking return
+values") fires on ``local x="$(cmd)"`` / ``export x=$(cmd)``: the variable
+captures the command's exit status instead of the shell's, so a failing
+substitution is silently masked. The finding flagged two lines in
+scripts/commands/dispatch.sh (active_path, completed_path).
+
+This test encodes the exact SC2155 rule as a static scan so it needs no
+shellcheck binary in CI and fails deterministically on the pre-fix code.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_DISPATCH_SH = Path(__file__).resolve().parent.parent / "scripts" / "commands" / "dispatch.sh"
+
+# shellcheck SC2155: declare/export/assign in one statement whose RHS contains
+# a command substitution. ``local x`` followed by ``x=$(...)`` on a SEPARATE
+# line is the compliant idiom and must not match.
+_SC2155_RE = re.compile(
+    r"(?:\b(?:local|export|declare)\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*.*?\$\()"
+)
+
+
+def test_no_sc2155_declare_assign_in_dispatch_sh():
+    assert _DISPATCH_SH.exists(), f"dispatch.sh missing at {_DISPATCH_SH}"
+    hits: list[tuple[int, str]] = []
+    for lineno, line in enumerate(_DISPATCH_SH.read_text(encoding="utf-8").splitlines(), 1):
+        if _SC2155_RE.search(line):
+            hits.append((lineno, line.strip()))
+    assert not hits, (
+        "shellcheck SC2155 declare-and-assign patterns (masked return values) at:\n"
+        + "\n".join(f"  {ln}: {text}" for ln, text in hits)
+    )


### PR DESCRIPTION
## T3 triage ronde OI-212..OI-288

Verse worktree vanaf `origin/main` (HEAD `d2c2493e`). Meet-opdracht: bestaat elke bevinding nog? Twee items gaf ik een directe fix, de rest is bewijs voor T0.

### GEFIXT (BESTAAT-KLEIN)

- **OI-268** — `dispatch.sh` shellcheck SC2155 (2 regels, `local x="$(cmd)"`). Gesplitst in declare + assign. `shellcheck`: 0.
- **OI-288** — `dispatch_envelope.py` ruff F821: `ExecutionPlan`/`ExecutionPermit` nooit geïmporteerd. Nu runtime geïmporteerd (geen cycle: leaf-modules), zodat `typing.get_type_hints()` op de signatures resolveert (was NameError). Plus 2 dode F401-imports weg. `ruff check`: schoon.

Regressietests (beide rood op oude code, groen op nieuwe):
- `tests/test_dispatch_sh_sc2155.py` — statische SC2155-scan
- `tests/test_dispatch_envelope_annotations_resolve.py` — `get_type_hints` op alle 4 F821-signatures

### ACHTERHAALD (bewijs in report)

- **OI-215** — workaround weg (`HEADLESS_FORCED_MODELS` leeg), 2/3 issues gesloten, #64153 open maar andere klasse
- **OI-219 / OI-220** — skill-pariteit opgelost via `skill_prefix.build_structured_prompt` (prompt-injectie, alle lanes), niet via `--skills-dir`/AGENTS.md zoals voorgesteld
- **OI-221** — skill-pariteit + codex-lane staan in code; re-run-data niet aantoonbaar (results/ leeg)
- **OI-222** — F1 `not ip.is_global` (CGNAT) + F2 IP-pinning geïmplementeerd (#1065), expliciete CGNAT-test aanwezig

### BESTAAT-GROOT (niet gefixt, ontwerpkeuze)

- **OI-212** — judge panel nog claude+kimi; deepseek-judge vergt invocatie-lane keuze
- **OI-213** — geen replay/re-judge-modus in scorer
- **OI-223** — deels gedaan: `headless_block` LIVE, rest declaratief (bewust)
- **OI-224** — deels gedaan: F5 gefixt, F4+F8 gedeferred (1.0.1)
- **OI-225** — gedeferred naar 1.1 (pyproject exclude comment)

### Rapport

`$VNX_DATA_DIR/unified_reports/20260801-t3-oi-triage.md` — voldoet aan het report contract (`validate_body` = valid). Geen items door mij gesloten; dat doet T0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)