### PR TITLE
docs(agents,t0): deterministic-first design principle + role routing table

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -83,6 +83,21 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 - `provider=claude` for a build-worker still routes through a separate gate: `VNX_OVERRIDE_WORKER_CLAUDE=1` with an audit reason (`dispatch_cli.py:691-705`). Track `worker-provider-free-choice` aims to eventually remove this remaining lock.
 - No Claude Code subagents (Task tool). Full decision rule: `docs/core/DISPATCH_RULES.md`.
 
+**Role selection (hard):**
+
+- `backend-developer` is the sentinel default for "no role resolved" (`_FAKE_DEFAULT_ROLE`, `scripts/lib/dispatch_govern.py:51`) and is stripped from the receipt trail — never choose it out of convenience. Pick a role deliberately; if none fits, motivate that in the dispatch.
+- The role follows the work, not the terminal.
+
+| Work | Role |
+|---|---|
+| Test harness, CI coverage, flaky tests, test infrastructure | `quality-engineer` |
+| Module boundaries, data model, resolver identity, ADRs | `system-architect` |
+| Permission posture, auth, secrets, sandboxing | `security-engineer` |
+| Reproduces a finding, fact-finding | `research-analyst` |
+| Review of existing code without changing it | `code-reviewer` |
+| Runtime implementation in existing modules | `backend-developer` (deliberate choice) |
+| Dashboard and UI | `frontend-developer` |
+
 ## Crash Recovery (on-demand only)
 
 Follow the full procedure in the t0-orchestrator playbook §7 (Startup / recovery / runbooks), which points to `docs/core/DISPATCH_RULES.md` §10.

--- a/agents/system-architect/CLAUDE.md
+++ b/agents/system-architect/CLAUDE.md
@@ -6,6 +6,15 @@ You are a fleet-wide system-architect worker for a single governed VNX dispatch,
 
 Design a structural change — a module boundary, a data model, an integration seam, or an ADR — for the calling project. Prefer the smallest reversible design that satisfies the requirement. When scaffolding is requested, produce it; otherwise deliver a decision record + the interfaces.
 
+## Design Principle
+
+Look at the design before you build. Resolve deterministically wherever that is possible; bring in a model only where it is genuinely required.
+
+- A design proposal names explicitly which parts are deterministic — rules, schemas, state machines, validation, parsing, routing on fixed criteria — and which parts need a model: open natural language, judgment under ambiguity, synthesis over unstructured sources.
+- For every model-backed part, say why a deterministic solution does not suffice. "It can be done with an LLM" is not a justification.
+- Prefer a deterministic alternative that covers 80% of cases over a model call that reaches 95%, unless that last 15% is demonstrably the reason the feature exists. Make that trade-off explicit in the design.
+- Deterministic parts are testable and reproducible. Model parts get a safety net: output validation, a failure path, and a receipt recording what happened.
+
 ## Input
 
 A dispatch instruction describing the change to make in the CALLING project.


### PR DESCRIPTION
## Wat en waarom

Documentatie- en governance-dispatch. De operator mat dat 20 van de 20 dispatches op 2026-08-01 `role=backend-developer` droegen — precies de sentinel-default (`_FAKE_DEFAULT_ROLE`, `dispatch_govern.py:51`) die de governance-laag uit receipts strípt. Rework-attributie en rolgebaseerde intelligentie zijn daardoor blind.

## Wijzigingen

1. **`agents/system-architect/CLAUDE.md`** — nieuwe sectie `## Design Principle`: kijk eerst naar het ontwerp, los deterministisch op waar mogelijk, zet een model alleen in waar echt nodig. Maakt het toetsbaar: benoem deterministische vs modeldelen, motiveer elk modelgebruik, verkiezen van een deterministische 80%-oplossing tenzij de laatste 15% de reden van bestaan is, en een vangnet voor modeldelen (outputvalidatie, faalpad, receipt).
2. **`.claude/terminals/T0/role-orchestrator.md`** — onder "Worker dispatch policy": `**Role selection (hard):**` met twee regels (backend-developer = sentinel-default, nooit uit gemak; rol volgt het werk, niet de terminal) en een routeringstabel werk → rol, 1-op-1 uit `agents/`.

## Bewust niet

Geen wijziging aan `_FAKE_DEFAULT_ROLE` of receipt-stempeling. Dat is runtime-gedrag en aparte scope (zie Open Items in het report).

## Verificatie

- `vnx role sync --dry-run`: exit 0; `role-orchestrator.md` blijft het canonieke bestand dat fleet-breed propageert (test `test_apply_writes_all_three_provider_surfaces` bewijst byte-identieke propagatie).
- Tests die `role-orchestrator.md` direct raken: **62 passed, 0 failed** (`test_role_sync.py` 29, `test_t0_role_audit_static.py` 24, `test_sessionstart_hook.py` 9).
- Agents-suites: `test_agent_dispatch.py` 21 passed; `test_agent_resolver.py` 26 passed. `test_dispatch_agent_default_instruction.py`: 17 passed, 2 failed — pre-existing omgevingsfout (`REJECT [project-mismatch]`, bevestigd op de schone boom via `git stash`).
- Geen content-test voor `agents/system-architect/CLAUDE.md`; dat is expliciet gerapporteerd.