### PR TITLE
fix(triage): close 5 small OI-ledger findings with red-on-main tests (OI-003/004/015/017)

### DIFF
--- a/scripts/index_adrs.py
+++ b/scripts/index_adrs.py
@@ -109,8 +109,10 @@ def _extract_bullets(text: str) -> list[str]:
 
 
 def _write_ndjson_event(events_file: Path, adr: dict) -> None:
+    # Include project_id so identical ADR content across projects gets distinct
+    # record_ids instead of colliding (ADR rows are keyed by (adr_id, project_id)). (OI-004)
     record_id = hashlib.sha256(
-        f"{adr['adr_id']}:{adr['source_hash']}".encode()
+        f"{adr['project_id']}:{adr['adr_id']}:{adr['source_hash']}".encode()
     ).hexdigest()
     event = {
         "record_id": record_id,

--- a/scripts/lib/pool_manager.py
+++ b/scripts/lib/pool_manager.py
@@ -15,7 +15,6 @@ import signal
 import subprocess
 import sys
 import time
-import uuid
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Callable, List, Optional, Tuple
@@ -122,10 +121,13 @@ def _spawn_via_provider_dispatch(
         ]
 
     try:
+        # OI-017: the pool never reads the child's stdout/stderr, so holding PIPE
+        # buffers lets a chatty worker fill the OS pipe (~64KB) and block forever.
+        # Redirect to DEVNULL instead of risking a pipe-buffer deadlock.
         proc = subprocess.Popen(
             cmd,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
             start_new_session=True,
             cwd=str(worktree_path),
         )

--- a/scripts/lib/runtime_state_machine.py
+++ b/scripts/lib/runtime_state_machine.py
@@ -315,9 +315,10 @@ def claim_next_queued_dispatch(
     isolation_level=None (required for explicit BEGIN IMMEDIATE) commits
     any pending implicit transaction on the connection.
     """
+    prev_isolation_level = conn.isolation_level
     conn.isolation_level = None  # autocommit mode for manual BEGIN IMMEDIATE control
-    conn.execute("BEGIN IMMEDIATE")
     try:
+        conn.execute("BEGIN IMMEDIATE")
         row = conn.execute(
             """
             SELECT dispatch_id FROM dispatches
@@ -386,6 +387,9 @@ def claim_next_queued_dispatch(
         except sqlite3.Error:
             pass
         raise
+    finally:
+        # Restore the caller's isolation mode — don't leave it in autocommit. (OI-015)
+        conn.isolation_level = prev_isolation_level
 
 
 def update_attempt(

--- a/scripts/traceability_audit.py
+++ b/scripts/traceability_audit.py
@@ -20,7 +20,7 @@ import re
 import sqlite3
 import subprocess
 import sys
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Dict, Iterator, List, Optional, Set, Tuple
 
@@ -604,7 +604,10 @@ def gap_prs_without_receipt(
         # Strategy 2b: direct pr_number field match — only pr_merged events close the gap
         if not linked and pr.number:
             for r in receipts:
-                if r.raw.get("event_type") == "pr_merged" and r.raw.get("pr_number") == pr.number:
+                # Compare the normalized event_type (which also accepts the legacy
+                # 'event: pr_merged' alias) rather than the raw key, so backfilled
+                # pre-cutover receipts are still traceable. (OI-003)
+                if r.event_type == "pr_merged" and r.raw.get("pr_number") == pr.number:
                     linked = True
                     break
 
@@ -619,14 +622,17 @@ def gap_prs_without_receipt(
         # Split branch into tokens, require >=2 tokens of >=4 chars to match
         # within a receipt dispatch_id. E.g. "feat/my-feature" → ["feat", "my", "feature"]
         # → a dispatch_id containing "my-feature" or "feat-my" matches.
+        # Require at least 2 significant tokens AND 2 matches so a lone
+        # conventional-commit prefix like "feat" cannot attach an unrelated
+        # dispatch. (OI-003)
         if not linked and pr.branch:
             branch_raw = pr.branch.lower().replace("/", "-").replace("_", "-")
             branch_tokens = [t for t in re.split(r"[-]+", branch_raw) if len(t) >= 4]
-            if branch_tokens:
+            if len(branch_tokens) >= 2:
                 for did in receipt_dispatch_ids:
                     did_lower = did.lower()
                     matches = sum(1 for tok in branch_tokens if tok in did_lower)
-                    if matches >= max(1, len(branch_tokens) // 2):
+                    if matches >= 2:
                         linked = True
                         break
 

--- a/tests/test_claim_next_queued_dispatch.py
+++ b/tests/test_claim_next_queued_dispatch.py
@@ -170,6 +170,15 @@ class TestClaimBasic(_DbTestCase):
             result = claim_next_queued_dispatch(c, "T1", "test-proj")
         self.assertEqual(result, "d-p1")
 
+    def test_claim_restores_conn_isolation_level(self):
+        """OI-015: claim must not leave the caller's connection in autocommit mode."""
+        self._insert_queued("d-iso-001")
+        with self.conn() as c:
+            before = c.isolation_level
+            result = claim_next_queued_dispatch(c, "T1", "test-proj")
+            self.assertEqual(result, "d-iso-001")
+            self.assertEqual(c.isolation_level, before)
+
 
 class TestClaimCrossProjectIsolation(_DbTestCase):
     """ADR-007: project-A claimer must never see project-B queued rows."""

--- a/tests/test_index_adrs.py
+++ b/tests/test_index_adrs.py
@@ -164,6 +164,21 @@ class TestIndexAdrs:
         # record_id must be a 64-char hex sha256
         assert len(event["record_id"]) == 64
 
+    def test_record_id_differs_across_projects(self, tmp_path):
+        """OI-004: identical ADR content in different projects must not collide on record_id."""
+        db_path = _setup_db(tmp_path)
+        adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)
+        events_file = tmp_path / "events" / "adr_index.ndjson"
+
+        index_adrs(db_path, adr_dir, events_file, project_id="proj-a")
+        index_adrs(db_path, adr_dir, events_file, project_id="proj-b")
+
+        lines = [l for l in events_file.read_text().splitlines() if l.strip()]
+        record_ids = {json.loads(l)["record_id"] for l in lines}
+        assert len(record_ids) == 2, (
+            f"same-content ADRs across projects must get distinct record_ids, got {record_ids}"
+        )
+
     def test_raises_on_event_write_failure(self, tmp_path):
         db_path = _setup_db(tmp_path)
         adr_dir = _write_adr(tmp_path, "ADR-007-multitenant.md", _FIXTURE_ADR)

--- a/tests/test_pool_manager_real_spawn.py
+++ b/tests/test_pool_manager_real_spawn.py
@@ -21,6 +21,7 @@ from __future__ import annotations
 import os
 import signal
 import sqlite3
+import subprocess
 import sys
 import time
 from pathlib import Path
@@ -336,3 +337,27 @@ class TestSpawnFailureModeNeverFakesSuccess:
             assert len(result.errors) > 0, (
                 "Spawn failures must appear in ExecResult.errors"
             )
+
+
+class TestSpawnPipeHandling:
+    """OI-017: spawn must not hold un-drained stdout/stderr PIPE buffers."""
+
+    def test_spawn_redirects_worker_pipes_to_devnull(self, tmp_path):
+        """The pool never reads child output — PIPE buffers risk a deadlock."""
+        with patch("pool_worktree_manager.create_worker_worktree", return_value=tmp_path):
+            with patch("pool_manager.subprocess.Popen") as mock_popen:
+                mock_proc = type("FakeProc", (), {"pid": 4242})()
+                mock_popen.return_value = mock_proc
+                with patch("pool_manager.os.kill"):
+                    result = _spawn_via_provider_dispatch(
+                        "vnx-dev", "default", "T-pipe", "claude", "backend-developer"
+                    )
+
+        assert result.success is True
+        _, kwargs = mock_popen.call_args
+        assert kwargs["stdout"] is subprocess.DEVNULL, (
+            "stdout must be DEVNULL, not an un-drained PIPE"
+        )
+        assert kwargs["stderr"] is subprocess.DEVNULL, (
+            "stderr must be DEVNULL, not an un-drained PIPE"
+        )

--- a/tests/test_traceability_audit.py
+++ b/tests/test_traceability_audit.py
@@ -248,6 +248,43 @@ class TestCategoryC:
         report = gap_prs_without_receipt(prs, receipts, dispatches)
         assert report.gap_count == 0
 
+    def test_legacy_event_alias_pr_merged_traced(self):
+        """OI-003: legacy 'event: pr_merged' alias (no raw event_type key) must be traced."""
+        prs = [_pr(number=777, branch="feat/x")]
+        receipts = [
+            ReceiptRecord(
+                dispatch_id="20260101-legacy-impl",
+                pr_id="",
+                event_type="pr_merged",  # normalized from raw 'event' alias
+                status="success",
+                timestamp="2026-01-15T10:00:00Z",
+                commit_hash="",
+                terminal="T1",
+                source_file="test.ndjson",
+                raw={"event": "pr_merged", "pr_number": 777},
+            )
+        ]
+        dispatches: list[DispatchRecord] = []
+        report = gap_prs_without_receipt(prs, receipts, dispatches)
+        assert report.gap_count == 0, f"legacy pr_merged alias should be traced: {report.examples}"
+
+    def test_single_feat_token_does_not_attach_unrelated_dispatch(self):
+        """OI-003: a lone 'feat' branch token must not attach an unrelated dispatch."""
+        prs = [_pr(number=301, branch="feat/foo")]
+        receipts = [_receipt("20260101-feat-bar-impl", event_type="task_complete")]
+        dispatches: list[DispatchRecord] = []
+        report = gap_prs_without_receipt(prs, receipts, dispatches)
+        assert report.gap_count == 1, "single conventional-commit token must not link"
+        assert report.traced == 0
+
+    def test_branch_requires_two_significant_token_matches(self):
+        """OI-003: two significant branch tokens must both match to link."""
+        prs = [_pr(number=302, branch="feature/dispatch-audit")]
+        receipts = [_receipt("20260101-dispatch-audit-impl", event_type="task_complete")]
+        dispatches: list[DispatchRecord] = []
+        report = gap_prs_without_receipt(prs, receipts, dispatches)
+        assert report.gap_count == 0, f"two-token branch should link: {report.examples}"
+
     def test_unlinked_pr_is_gap(self):
         """PR with no linkage at all → gap."""
         prs = [_pr(number=999, title="chore: cleanup", branch="chore/cleanup")]


### PR DESCRIPTION
## Triage-ronde OI-ledger (20260801-t1-oi-triage)

Meet-opdracht: 12 maanden-oude OI-items op current main beoordeeld met bewijs, niet vanuit de item-tekst.

### Resultaat per item (12 beoordeeld)

- **ACHTERHAALD (7):** OI-006, OI-008, OI-013, OI-014, OI-020, OI-021, plus OI-003(3)
- **BESTAAT-GROOT (2):** OI-005 (3 functies >70 regels, refactor), OI-007 (5 legacy dashboard parity-besluiten = operator-beslissing)
- **BESTAAT-KLEIN (3 items / 5 sub-fixes, gefixt):** OI-003(1)+(2), OI-004(2), OI-015(2), OI-017

### Fixes in deze PR

| Bestand | Fix | OI |
|---|---|---|
| `scripts/traceability_audit.py` | Strategy 2b gebruikt genormaliseerde `event_type` (legacy `event: pr_merged` alias traceerbaar) | OI-003 |
| `scripts/traceability_audit.py` | Strategy 4 vereist ≥2 significante tokens + ≥2 matches (`feat`-alleen kan geen dispatch meer attach-en) | OI-003 |
| `scripts/index_adrs.py` | ADR `record_id`-hash bevat `project_id` (einde van cross-project-collision) | OI-004 |
| `scripts/lib/runtime_state_machine.py` | `claim_next_queued_dispatch` herstelt caller `isolation_level` in `finally` | OI-015 |
| `scripts/lib/pool_manager.py` | Spawn Popen `stdout/stderr` → `DEVNULL` (geen ongedraineerde PIPE-buffer-deadlock) | OI-017 |

Elke fix heeft een test die op de oude code rood staat (geverifieerd via source-only `git stash`).

### Testresultaten

```
tests/test_traceability_audit.py tests/test_index_adrs.py tests/test_claim_next_queued_dispatch.py
# 95 passed
tests/test_pool_manager_real_spawn.py
# 9 passed, 1 pre-existente FK-fout (faalt ook op schone boom)
```

Volledige triage met bewijs per item: `~/.vnx-data/vnx-dev/unified_reports/20260801-t1-oi-triage.md` (niet gecommit — runtime state).

### Niet gefixt (bewust)

- OI-005: functie-splitsing is een refactor/ontwerpkeuze
- OI-007: parity-besluiten op 5 legacy dashboard-features zijn voor T0/Vincent
- OI-015(1): `Path(db_path).parent.parent`-arithmetica — klein maar raakt migration-bootstrap, resolver-keuze nodig

🤖 Generated with [Claude Code](https://claude.com/claude-code)