### PR TITLE
fix(freshness): surface dream reviews in t0_state + dream_cycles producer (OI-896)

### DIFF
--- a/configs/producer_freshness.yaml
+++ b/configs/producer_freshness.yaml
@@ -90,3 +90,21 @@ producers:
     key_column: metric_name
     timestamp_column: last_ts
     cadence_seconds: 259200
+
+  # --- Auto-dream consolidation cycles (ADR-019 / OI-896) -------------------
+  # Key = cycle status, never table level (OI-881). The stream that matters is
+  # status='completed': a cycle finished consolidation and is awaiting T0
+  # review (ADR-019 §3 — mandatory within 30 days). A completed cycle that sits
+  # unreviewed past cadence reads as stale (a review gate silently skipped),
+  # and a scheduler that NEVER ran surfaces via expected_keys — absence is
+  # asserted, not observed. `reviewed`/`rejected` are separate keys, so an
+  # active review pipeline cannot hide a dead consolidation one.
+  - name: dream_cycles
+    type: sqlite
+    db: "{state_dir}/quality_intelligence.db"
+    query: "SELECT status, MAX(COALESCE(completed_at, started_at)) AS last_ts FROM dream_cycles GROUP BY status"
+    key_column: status
+    timestamp_column: last_ts
+    cadence_seconds: 86400
+    expected_keys:
+      - completed

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -21,6 +21,13 @@ Schema 2.2 changes (fabric-freshness):
     (the always-loaded cold-start file). Consumers that predate 2.2 ignore the
     new key (no removals/renames).
 
+Schema 2.2 addition (OI-896, auto-dream reviews):
+  - Additive, backward-compatible: a top-level ``dream_reviews`` section
+    {available, pending_count, oldest_age_seconds, pending_reviews} surfacing
+    auto-dream (ADR-019) consolidation cycles awaiting mandatory T0 review.
+    Mirrored to t0_detail/dream_reviews.json. The zero-pending case is
+    explicitly reported so an absent review queue is as visible as a full one.
+
 Schema 2.1 changes (W4E / OI-1199):
   - feature_state union-merges register-canonical aggregation with the
     FEATURE_PLAN.md fallback fields (current_pr/next_task/assigned_track/
@@ -596,6 +603,100 @@ def _build_human_gate_queue(state_dir: Path, project_id: str) -> List[Dict[str, 
             "created_at": row.get("created_at"),
         })
     return queue
+
+
+# ---------------------------------------------------------------------------
+# Auto-dream review queue (ADR-019 / OI-896)
+# ---------------------------------------------------------------------------
+#
+# ADR-019 §3 makes T0 review mandatory for every auto-dream consolidation
+# cycle in its first 30 days. The consolidator writes a pending-review.json
+# per completed cycle, but before this reader NOTHING in the fabric consumed
+# it (grep for list_pending_reviews hit only scripts/dream/ itself). A
+# mandatory human gate without a notification is skipped by construction.
+# This section surfaces the queue at every SessionStart — and the zero case
+# explicitly (pending_count: 0), because an absent review queue is as much a
+# signal as a populated one.
+
+def _resolve_dream_data_root(state_dir: Path) -> Path:
+    """Resolve the data root that owns the dream/ state subtree.
+
+    Central installs keep dream reviews under the central data root
+    (``~/.vnx-data/<project_id>/state/dream``); repo-local installs under
+    ``<data>/state/dream`` where ``state_dir`` is ``<data>/state``.
+    """
+    central = _central_state_dir_for(state_dir)
+    if central is not None:
+        return central.parent
+    return state_dir.parent if state_dir.name == "state" else state_dir
+
+
+def _build_dream_reviews(state_dir: Path, project_id: str) -> Dict[str, Any]:
+    """Pending auto-dream consolidation reviews awaiting T0 approval (OI-896).
+
+    Best-effort and never raises: an unavailable identity, an import failure,
+    or an unreadable review dir degrades to ``available=False`` with a visible
+    ``pending_count: 0`` rather than blocking SessionStart.
+
+    Returned shape:
+      - ``available``: True when the reader ran (even for a zero queue).
+      - ``pending_count``: number of cycles awaiting operator review.
+      - ``oldest_age_seconds``: age of the oldest waiting review, or None
+        when the queue is empty.
+      - ``pending_reviews``: per-cycle summary (cycle_id, input_count,
+        created_at, age_seconds).
+    """
+    empty: Dict[str, Any] = {
+        "available": False,
+        "pending_count": 0,
+        "oldest_age_seconds": None,
+        "pending_reviews": [],
+    }
+    pid = (project_id or "").strip()
+    if not pid:
+        return empty
+    try:
+        if str(_SCRIPT_DIR) not in sys.path:
+            sys.path.insert(0, str(_SCRIPT_DIR))
+        from dream.review_gate import list_pending_reviews
+    except Exception:
+        return empty
+    try:
+        pending = list_pending_reviews(pid, _resolve_dream_data_root(state_dir)) or []
+    except Exception:
+        return empty
+    if not pending:
+        return {**empty, "available": True}
+
+    now = _now_utc()
+    reviews: List[Dict[str, Any]] = []
+    oldest_age: Optional[float] = None
+    for r in pending:
+        created_raw = (r.get("created_at") or "").strip()
+        age: Optional[float] = None
+        if created_raw:
+            try:
+                dt = datetime.fromisoformat(created_raw.replace("Z", "+00:00"))
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=timezone.utc)
+                age = max(0.0, (now - dt).total_seconds())
+            except ValueError:
+                age = None
+        reviews.append({
+            "cycle_id": r.get("cycle_id"),
+            "input_count": r.get("input_count"),
+            "created_at": created_raw,
+            "age_seconds": age,
+        })
+        if age is not None and (oldest_age is None or age > oldest_age):
+            oldest_age = age
+
+    return {
+        "available": True,
+        "pending_count": len(reviews),
+        "oldest_age_seconds": oldest_age,
+        "pending_reviews": reviews,
+    }
 
 
 # ---------------------------------------------------------------------------
@@ -1890,6 +1991,7 @@ def build_t0_state(
     tracks = _build_tracks(state_dir)
     canonical_tracks = _build_tracks_from_db(tracks_store, project_id)  # R3.2/ADR-007: tenant-scoped (central SSOT)
     human_gate_queue = _build_human_gate_queue(tracks_store, project_id)  # proposed deliverables awaiting operator promote
+    dream_reviews = _build_dream_reviews(state_dir, project_id)  # auto-dream cycles awaiting T0 review (OI-896)
     pr_progress = _build_pr_progress(dispatch_dir, state_dir)
     feature_state = _build_feature_state(state_dir=state_dir)
     open_items = _collect_open_items(project_id, state_dir)
@@ -1919,6 +2021,7 @@ def build_t0_state(
         "track_freshness": track_freshness,
         "canonical_tracks": canonical_tracks,
         "human_gate_queue": human_gate_queue,
+        "dream_reviews": dream_reviews,
         "pr_progress": pr_progress,
         "feature_state": feature_state,
         "open_items": open_items,
@@ -2017,6 +2120,7 @@ _DETAIL_SECTION_MAP: Dict[str, str] = {
     "dispatch_register_events": "dispatch_register",
     "active_chains": "active_chains",
     "intelligence": "intelligence",
+    "dream_reviews": "dream_reviews",
     # Phase 2 W-state-5: heavy strategic_state lives in a private state key
     # (``_strategic_state_heavy``) so it is excluded from t0_state.json/the
     # brief output but still mirrored to t0_detail/strategic_state.json.

--- a/scripts/dream/review_gate.py
+++ b/scripts/dream/review_gate.py
@@ -82,8 +82,26 @@ def _load_review(state_dir: Path, cycle_id: str, project_id: str) -> dict:
     return review
 
 
+def _file_created_iso(path: Path) -> str | None:
+    """ISO-8601 UTC timestamp of when the pending-review file was written.
+
+    The pending-review.json carries no timestamp field (consolidator.py writes
+    cycle_id/project_id/consolidation only), so the review age is the file's
+    mtime — the moment the cycle completed and started waiting for T0.
+    """
+    try:
+        return datetime.fromtimestamp(path.stat().st_mtime, tz=timezone.utc).isoformat()
+    except OSError:
+        return None
+
+
 def list_pending_reviews(project_id: str, data_root: Path | None = None) -> list[dict]:
-    """Return pending dream cycles awaiting operator review."""
+    """Return pending dream cycles awaiting operator review.
+
+    Each returned dict is the pending-review payload plus an additive
+    ``created_at`` key (UTC ISO from the file mtime) so readers can report the
+    age of the oldest waiting review without re-globbing the state dir.
+    """
     dr = _resolve_data_root(data_root)
     state_dir = dr / "state" / "dream"
     if not state_dir.is_dir():
@@ -95,6 +113,7 @@ def list_pending_reviews(project_id: str, data_root: Path | None = None) -> list
         except (json.JSONDecodeError, OSError):
             continue
         if data.get("project_id") == project_id and data.get("requires_operator_review"):
+            data["created_at"] = _file_created_iso(path)
             results.append(data)
     return results
 

--- a/tests/test_build_t0_state.py
+++ b/tests/test_build_t0_state.py
@@ -14,6 +14,7 @@ Plus end-to-end shadow build + p95 latency regression guard.
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import sys
 import time
@@ -577,3 +578,105 @@ def test_shadow_mode_p95_latency_within_2x_per_project(
     assert p95_shadow <= 2.0 * p95_per_project, (
         f"Shadow p95 {p95_shadow*1000:.1f}ms exceeds 2× per-project p95 {p95_per_project*1000:.1f}ms"
     )
+
+
+# ---------------------------------------------------------------------------
+# Auto-dream reviews (ADR-019 / OI-896) — dream_reviews section
+# ---------------------------------------------------------------------------
+# A consolidation cycle writes a pending-review.json and nothing in the fabric
+# reads it: a mandatory T0 review gate that is invisible is skipped by
+# construction. These tests pin the reader build_t0_state now provides — and
+# the zero case, which must be visible, not absent.
+
+_PENDING_REVIEW_BODY = {
+    "cycle_id": "dream-20260730-100000-aaaaaaaa",
+    "project_id": "test-project",
+    "input_count": 12,
+    "consolidation": {"merged": [], "dropped": [], "archived": [], "flagged": []},
+    "requires_operator_review": True,
+}
+
+
+def _write_dream_review(data_root: Path, *, cycle_id: str, age_hours: float,
+                        project_id: str = SAMPLE_PROJECT_ID) -> Path:
+    """Write a pending-review.json with an mtime ``age_hours`` in the past."""
+    review_dir = data_root / "state" / "dream"
+    review_dir.mkdir(parents=True, exist_ok=True)
+    path = review_dir / f"{cycle_id}-pending-review.json"
+    path.write_text(
+        json.dumps({**_PENDING_REVIEW_BODY, "cycle_id": cycle_id, "project_id": project_id}),
+        encoding="utf-8",
+    )
+    ts = time.time() - age_hours * 3600
+    os.utime(path, (ts, ts))
+    return path
+
+
+class TestBuildDreamReviews:
+    def test_pending_count_and_oldest_age(self, tmp_path: Path) -> None:
+        data_root = tmp_path
+        state_dir = data_root / "state"
+        state_dir.mkdir()
+        _write_dream_review(data_root, cycle_id="dream-old", age_hours=72)
+        _write_dream_review(data_root, cycle_id="dream-recent", age_hours=5)
+
+        section = bts._build_dream_reviews(state_dir, SAMPLE_PROJECT_ID)
+
+        assert section["available"] is True
+        assert section["pending_count"] == 2
+        assert section["oldest_age_seconds"] == pytest.approx(72 * 3600, abs=60)
+        by_cycle = {r["cycle_id"]: r for r in section["pending_reviews"]}
+        assert by_cycle["dream-old"]["age_seconds"] == pytest.approx(72 * 3600, abs=60)
+        assert by_cycle["dream-recent"]["age_seconds"] == pytest.approx(5 * 3600, abs=60)
+        assert by_cycle["dream-old"]["input_count"] == 12
+
+    def test_zero_pending_is_visible(self, tmp_path: Path) -> None:
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        section = bts._build_dream_reviews(state_dir, SAMPLE_PROJECT_ID)
+
+        # The zero is a signal: the key must be present, not absent.
+        assert section["available"] is True
+        assert section["pending_count"] == 0
+        assert section["oldest_age_seconds"] is None
+        assert section["pending_reviews"] == []
+
+    def test_filters_other_projects_and_resolved_reviews(self, tmp_path: Path) -> None:
+        data_root = tmp_path
+        state_dir = data_root / "state"
+        state_dir.mkdir()
+        _write_dream_review(data_root, cycle_id="mine", age_hours=5)
+        # Same project but already resolved (not awaiting review).
+        resolved = data_root / "state" / "dream" / "resolved-pending-review.json"
+        resolved.write_text(
+            json.dumps({**_PENDING_REVIEW_BODY, "cycle_id": "resolved",
+                        "requires_operator_review": False}),
+            encoding="utf-8",
+        )
+        # A different project's pending review must be excluded (ADR-007).
+        _write_dream_review(data_root, cycle_id="other", age_hours=2, project_id="other-project")
+
+        section = bts._build_dream_reviews(state_dir, SAMPLE_PROJECT_ID)
+
+        assert section["pending_count"] == 1
+        assert section["pending_reviews"][0]["cycle_id"] == "mine"
+
+    def test_full_state_includes_dream_reviews_key(self, tmp_path: Path,
+                                                  monkeypatch: pytest.MonkeyPatch) -> None:
+        """t0_state.json carries the dream key at every kickoff, even at zero."""
+        monkeypatch.setenv("VNX_PROJECT_ID", SAMPLE_PROJECT_ID)
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        dispatch_dir = tmp_path / "dispatches"
+        (dispatch_dir / "pending").mkdir(parents=True)
+        (dispatch_dir / "active").mkdir()
+        (dispatch_dir / "conflicts").mkdir()
+        _write_open_items_digest(state_dir, open_count=0, blocker_count=0)
+        _create_qi_db(state_dir / "quality_intelligence.db", dispatches=[SAMPLE_DISPATCH])
+
+        result = bts.build_t0_state(state_dir, dispatch_dir)
+
+        assert "dream_reviews" in result
+        assert result["dream_reviews"]["available"] is True
+        assert result["dream_reviews"]["pending_count"] == 0

--- a/tests/test_producer_freshness.py
+++ b/tests/test_producer_freshness.py
@@ -157,6 +157,8 @@ def test_real_config_loads() -> None:
         "review_gate_obligations",
         "dispatches_table",
         "governance_metrics",
+        # OI-896: auto-dream cycles, grouped per cycle status
+        "dream_cycles",
     ]
 
 
@@ -278,3 +280,142 @@ def test_cli_no_write_touches_nothing_and_reports(fake_state: Path, capsys, monk
     out = json.loads(capsys.readouterr().out)
     assert out["status"] == "stale"
     assert any(f["producer"] == "review_gate_results" for f in out["findings"])
+
+
+# ---------------------------------------------------------------------------
+# Auto-dream consolidation (ADR-019 / OI-896) — dream_cycles producer
+# ---------------------------------------------------------------------------
+# The key is the cycle STATUS, never table level (OI-881). status='completed'
+# means a cycle finished consolidation and is waiting on the mandatory T0
+# review gate. A completed cycle that sits unreviewed past cadence is stale —
+# a review gate skipped by construction. `expected_keys: [completed]` makes a
+# scheduler that NEVER ran visible too: absence is asserted, not observed.
+
+_DREAM_CYCLES_SPEC = {
+    "name": "dream_cycles",
+    "type": "sqlite",
+    "query": (
+        "SELECT status, MAX(COALESCE(completed_at, started_at)) AS last_ts "
+        "FROM dream_cycles GROUP BY status"
+    ),
+    "key_column": "status",
+    "timestamp_column": "last_ts",
+    "cadence_seconds": DAY,
+    "expected_keys": ["completed"],
+}
+
+
+def _make_dream_db(state_dir: Path, rows: list[tuple[str, str]]) -> None:
+    """Create quality_intelligence.db with a dream_cycles table (status, ts)."""
+    db = state_dir / "quality_intelligence.db"
+    conn = sqlite3.connect(db)
+    try:
+        conn.execute(
+            "CREATE TABLE dream_cycles ("
+            " cycle_id TEXT, project_id TEXT, started_at TEXT, completed_at TEXT,"
+            " status TEXT)"
+        )
+        for status, ts in rows:
+            completed = ts if status in ("completed", "reviewed", "rejected") else None
+            conn.execute(
+                "INSERT INTO dream_cycles (cycle_id, project_id, started_at, completed_at, status)"
+                " VALUES (?, 'vnx-dev', ?, ?, ?)",
+                (f"dream-{status}-{ts}", ts, completed, status),
+            )
+        conn.commit()
+    finally:
+        conn.close()
+
+
+def _dream_iso(days_ago: float) -> str:
+    return time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(NOW - days_ago * DAY))
+
+
+def test_dream_cycles_stale_completed_is_a_finding_per_status_key(tmp_path: Path) -> None:
+    """A completed cycle unreviewed past cadence is stale; a fresh reviewed
+    cycle must NOT hide it (per sleutel — the OI-881 lesson)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _make_dream_db(
+        state_dir,
+        [
+            ("completed", _dream_iso(3.0)),   # completed 3 days ago, never reviewed
+            ("reviewed", _dream_iso(0.1)),     # a review happened just now
+        ],
+    )
+    spec = {**_DREAM_CYCLES_SPEC, "db": str(state_dir / "quality_intelligence.db")}
+
+    section = pf.evaluate_producer(spec, now=NOW)
+
+    assert section["status"] == "stale"
+    stale_keys = {f["key"] for f in section["findings"]}
+    assert stale_keys == {"completed"}, (
+        "only the unreviewed completed stream may be flagged — the fresh "
+        "reviewed sibling stays green (per status, not per table)"
+    )
+    assert section["findings"][0]["kind"] == "stale"
+    assert section["findings"][0]["silence_seconds"] >= 3 * DAY
+
+
+def test_dream_cycles_never_ran_is_expected_key_absent(tmp_path: Path) -> None:
+    """A scheduler that never produced a cycle can only be caught by an
+    expected-key assertion — grouping existing rows finds nothing."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+    _make_dream_db(state_dir, [])  # dream_cycles exists but is empty
+    spec = {**_DREAM_CYCLES_SPEC, "db": str(state_dir / "quality_intelligence.db")}
+
+    section = pf.evaluate_producer(spec, now=NOW)
+
+    assert section["status"] == "stale"
+    assert section["findings"][0]["key"] == "completed"
+    assert section["findings"][0]["kind"] == "missing"
+    assert section["findings"][0]["expected_key_absent"] is True
+
+
+def test_real_config_sweep_knows_both_new_producers_and_flags_silence(
+    tmp_path: Path,
+) -> None:
+    """End-to-end against the REAL registry: both review_gate_obligations and
+    dream_cycles are evaluated, and a simulated silence (an unfulfilled gate
+    declaration + an unreviewed completed cycle) yields a finding each."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir()
+
+    # Obligation: codex_gate declared 3 days ago, never fulfilled.
+    (state_dir / "review_gates" / "obligations").mkdir(parents=True)
+    (state_dir / "review_gates" / "obligations" / "20260729-dispatch.json").write_text(
+        json.dumps(
+            {
+                "dispatch_id": "20260729-dispatch",
+                "gate": "codex_gate",
+                "declared_at": _dream_iso(3.0),
+                "status": "pending",
+            }
+        ),
+        encoding="utf-8",
+    )
+    # Dream: a completed cycle unreviewed for 3 days; a fresh reviewed one.
+    _make_dream_db(
+        state_dir,
+        [("completed", _dream_iso(3.0)), ("reviewed", _dream_iso(0.1))],
+    )
+    # Keep the other sqlite producers readable so the findings under test are
+    # not drowned out by source_unreadable noise. Their known stale keys
+    # (dlv > 7d cadence, fpy/rework > 3d cadence) are pre-existing producers,
+    # not the two under test.
+    _make_runtime_db(state_dir)
+    _make_quality_db(state_dir)
+
+    registry = pf.load_registry(REPO_ROOT / "configs" / "producer_freshness.yaml")
+    report = pf.run_sweep(state_dir, registry, now=NOW)
+
+    producers = {s["producer"] for s in report["producers"]}
+    assert {"review_gate_obligations", "dream_cycles"} <= producers
+
+    findings_by = {(f["producer"], f["key"]): f for f in report["findings"]}
+    assert findings_by[("review_gate_obligations", "codex_gate")]["kind"] == "stale"
+    assert findings_by[("dream_cycles", "completed")]["kind"] == "stale"
+    # Per-key: the fresh reviewed dream cycle stays green.
+    assert ("dream_cycles", "reviewed") not in findings_by
+    assert report["status"] == "stale"


### PR DESCRIPTION
## Wat en waarom

Twee stille producenten hadden geen lezer. Een stap produceert, niets leest zijn aan- of afwezigheid. Deze PR bouwt de **lezer**, zodat stilte een signaal wordt binnen een dag.

### OI-896 — DREAM-reviewwachtrij
- `build_t0_state.py`: nieuwe `dream_reviews` sectie in `t0_state.json` (`pending_count`, `oldest_age_seconds`, per-cycle `pending_reviews`). Gebruikt `dream.review_gate.list_pending_reviews`. De nul-case is expliciet zichtbaar (`pending_count: 0`, key altijd aanwezig).
- `scripts/dream/review_gate.py`: `list_pending_reviews` vult additief `created_at` (file-mtime) in, zodat lezers de leeftijd van de oudste review kunnen rapporteren.
- Gemirrord naar `t0_detail/dream_reviews.json`.

### Obligation-freshness
- `review_gate_obligations` was al geregistreerd als producent (#1279). Deze PR bevestigt dat end-to-end via een real-registry-sweep-test die gesimuleerde stilte als finding rapporteert.
- Nieuwe `dream_cycles` producent in `configs/producer_freshness.yaml`: key = cycle-status, `expected_keys=[completed]`. Een `completed`-cyclus die onbeoordeeld voorbij de cadence zit is stale; een scheduler die nooit draait is zichtbaar via de absent-key-assertie (OI-881: per sleutel, nooit op tabelniveau).

## Verificatie
- Tests rood op `origin/main` geverifieerd (6 failures op main, 0 hier): `TestBuildDreamReviews` (4x), `test_real_config_loads`, `test_real_config_sweep_knows_both_new_producers_and_flags_silence`.
- Relevante suite: 322 passed, 1 pre-existente environmental failure (`test_build_t0_state_runs_clean_on_main`, identiek rood met de wijzigingen gestashed).
- `ci_lint_patterns.py` op gewijzigde scripts: rc=0.

## Open Items
- launchd-installatie van `gate_obligation_runner.py` is een operator-actie, expliciet buiten scope van deze dispatch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)