### PR TITLE
fix(lint): resolve F821 PrEnforcementResult in tmux dispatch (OI-645) + triage OI-561..OI-655

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -39,6 +39,7 @@ if sys_path_dir not in sys.path:
 logger = logging.getLogger(__name__)
 
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
+from pr_enforcement import PrEnforcementResult  # noqa: E402
 
 # Capability scoping (interim, per WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4/§5):
 # detached ephemeral spawns run under the blanket --dangerously-skip-permissions
@@ -935,7 +936,6 @@ class TmuxInteractiveDispatch:
             logger.error(
                 "interactive: PR-enforcement guard errored dispatch=%s: %s", dispatch_id, exc,
             )
-            from pr_enforcement import PrEnforcementResult  # noqa: PLC0415
             return PrEnforcementResult(applicable=False, ok=True, reason=f"guard error: {exc}")
 
         if not result.applicable:

--- a/tests/test_tmux_dispatch_pr_enforcement_annotation.py
+++ b/tests/test_tmux_dispatch_pr_enforcement_annotation.py
@@ -1,0 +1,31 @@
+"""OI-645: tmux_interactive_dispatch PR-enforcement annotation must resolve.
+
+The F821 undefined-name finding (PrEnforcementResult in the return annotation
+of TmuxInteractiveDispatch._enforce_pr_exists) was not just lint noise:
+typing.get_type_hints() on the signature raised NameError because the name
+was only imported locally inside the function body, never into module scope.
+Any introspection of the signature (docs, dispatch-door type checks, gate
+instrumentation) would crash.
+
+Fails on the pre-fix code (get_type_hints -> NameError) and passes once the
+module-level import of PrEnforcementResult lands in
+scripts/lib/tmux_interactive_dispatch.py.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+import tmux_interactive_dispatch
+
+
+def test_pr_enforcement_signature_annotation_resolves():
+    """get_type_hints on the F821-flagged signature must resolve."""
+    func = tmux_interactive_dispatch.TmuxInteractiveDispatch._enforce_pr_exists
+    try:
+        hints = typing.get_type_hints(func)
+    except NameError as exc:  # unresolved annotation name (pre-fix failure)
+        pytest.fail(f"_enforce_pr_exists: unresolved annotation name: {exc}")
+    assert hints["return"].__name__ == "PrEnforcementResult"


### PR DESCRIPTION
## T7 triage OI-561..OI-655 — meet-opdracht

12 open items getoetst tegen origin/main. Eén code-fix; de rest is bewijs.

### Fix (OI-645, BESTAAT-KLEIN)
`tmux_interactive_dispatch.py` had een undefined name `PrEnforcementResult` in de
string-annotatie van `_enforce_pr_exists` (ruff F821, regel 902). Niet alleen lint-ruis:
`typing.get_type_hints()` faalde met `NameError` op de signature.

- Module-level `from pr_enforcement import PrEnforcementResult` toegevoegd, redundante
  lokale import in de except-handler verwijderd.
- Regressietest `tests/test_tmux_dispatch_pr_enforcement_annotation.py`: rood op
  pre-fix code (geverifieerd via stash: `unresolved annotation name`), groen na de fix.

### Verdicts (bewijs in unified report)
- **ACHTERHAALD (2):** OI-628 (ADR-034 external git-committed anchor vervangt de lokale
  sidecar; 3 codex-holes gedicht, 5 regressietests groen), OI-564 (geaccepteerde
  stijlvoorkeur, code ongewijzigd sinds de bevinding).
- **BESTAAT-GROOT (7):** OI-563 (user_version bump bij overgeslagen index
  gereproduceerd, 0 ux_*_pid manifest-invarianten), OI-579/636/653 (monoliths
  gegroeid), OI-621 (geen convergentie-checker), OI-629 (merge-flow/escape-hatch niet
  in role, deels andere repos), OI-655 (provider-lane krijgt report-contract-directive
  niet).
- **ONBEOORDEELBAAR (2):** OI-561/562 (codex-warnings nooit in de repo opgeslagen,
  niet reproduceerbaar).
- **BESTAAT-KLEIN (1):** OI-645 — gefixt.

Unified report: `~/.vnx-data/vnx-dev/unified_reports/20260801-t7-oi-triage.md`.

### Tests
- `tests/test_tmux_dispatch_pr_enforcement_annotation.py` — nieuw, 1 passed.
- `tests/test_tmux_interactive_dispatch.py -k "pr_enforce or pr_enforcement"` — 5 passed.
- `tests/test_chain_origin_anchor.py -k "t13 or t5 or t19 or t20 or read_git_anchor_fails_closed"` — 5 passed.
- `ruff check scripts/lib/tmux_interactive_dispatch.py` — clean (F821 weg).

🤖 Generated with [Claude Code](https://claude.com/claude-code)