### PR TITLE
fix(triage): OI-547 + OI-558 function-size splits with red-on-main guards

### DIFF
--- a/dashboard/api_operator.py
+++ b/dashboard/api_operator.py
@@ -778,26 +778,9 @@ def _load_session_store_entries() -> "dict[str, dict]":
         return {}
 
 
-def _operator_get_sessions() -> dict:
-    """GET /api/operator/sessions -- read-only live session observability tile.
-
-    Composes tmux session liveness (name, project, idle/busy, activity age) with
-    the persistent session-store state (provider session_id, last dispatch_id).
-    No control actions are exposed here; Part B restart panel is out of scope.
-    """
-    now = datetime.now(_UTC)
-    degraded = False
-    degraded_reasons: list[str] = []
+def _tmux_sessions_to_map(tmux_sessions: list) -> dict:
+    """Seed the name-keyed session map from tmux liveness rows (session_id None)."""
     sessions_by_name: dict[str, dict] = {}
-
-    try:
-        tmux_sessions, tmux_reasons = _list_tmux_sessions(now)
-        degraded_reasons.extend(tmux_reasons)
-    except Exception as exc:
-        tmux_sessions = []
-        degraded = True
-        degraded_reasons.append(f"tmux enumeration failed: {exc}")
-
     for s in tmux_sessions:
         sessions_by_name[s["name"]] = {
             "name": s["name"],
@@ -809,14 +792,11 @@ def _operator_get_sessions() -> dict:
             "dispatch_id": None,
             "remote_control_url": None,
         }
+    return sessions_by_name
 
-    try:
-        store_entries = _load_session_store_entries()
-    except Exception as exc:
-        store_entries = {}
-        degraded = True
-        degraded_reasons.append(f"session store read failed: {exc}")
 
+def _merge_session_store_entries(sessions_by_name: dict, store_entries: dict, now: datetime) -> None:
+    """Merge session-store state into the tmux-backed map (mutates the map in place)."""
     for terminal_id, entry in store_entries.items():
         name = terminal_id
         session_id = entry.get("session_id") or None
@@ -848,6 +828,37 @@ def _operator_get_sessions() -> dict:
                 "dispatch_id": dispatch_id,
                 "remote_control_url": None,
             }
+
+
+def _operator_get_sessions() -> dict:
+    """GET /api/operator/sessions -- read-only live session observability tile.
+
+    Composes tmux session liveness (name, project, idle/busy, activity age) with
+    the persistent session-store state (provider session_id, last dispatch_id).
+    No control actions are exposed here; Part B restart panel is out of scope.
+    """
+    now = datetime.now(_UTC)
+    degraded = False
+    degraded_reasons: list[str] = []
+
+    try:
+        tmux_sessions, tmux_reasons = _list_tmux_sessions(now)
+        degraded_reasons.extend(tmux_reasons)
+    except Exception as exc:
+        tmux_sessions = []
+        degraded = True
+        degraded_reasons.append(f"tmux enumeration failed: {exc}")
+
+    sessions_by_name = _tmux_sessions_to_map(tmux_sessions)
+
+    try:
+        store_entries = _load_session_store_entries()
+    except Exception as exc:
+        store_entries = {}
+        degraded = True
+        degraded_reasons.append(f"session store read failed: {exc}")
+
+    _merge_session_store_entries(sessions_by_name, store_entries, now)
 
     data = sorted(
         sessions_by_name.values(),

--- a/docs/investigations/20260801-oi-triage-t6-ledger-existence.md
+++ b/docs/investigations/20260801-oi-triage-t6-ledger-existence.md
@@ -1,0 +1,45 @@
+# OI-Triage 20260801-T6 — bestaansrecht OI-105/212/213/223/224/225/546/547/557/558/559/560
+
+Dispatch-ID: 20260801-t6-oi-triage
+
+## Summary
+
+Twaalf open items (2026-06-03 t/m 2026-07-09) getoetst tegen origin/main op een verse worktree. Meet-opdracht: per item het genoemde bestand/de functie/de tabel opzoeken en het beschreven gedrag NU reproduceren, niet redeneren vanuit de tekst. Uitkomst: 3 ACHTERHAALD (OI-105 onbeoordeelbaar als runtime-incident, OI-224 betekenis gewijzigd), 2 BESTAAT-KLEIN met fix (OI-547, OI-558 restant), 7 BESTAAT-GROOT (OI-212, OI-213, OI-223 deels, OI-225, OI-546, OI-557, OI-559, OI-560). Twee kleine function-size fixes geleverd: `_check_hook_paths` (89→57 regels) in doctor.py en `_operator_get_sessions` (83→42 regels) in api_operator.py, beide met AST-grootte-guard die op de oude code rood staat. De vier function-size-advisories (OI-547/558/559/560) zijn allemaal nog levend als advisory-class; alleen de twee kleinste zijn nu binnen de 70-regel-norm. De codex-gate-runners, bench-harness en ADR-005-artifact-kwesties zijn onverminderd aanwezig maar vereisen ontwerpkeuzes, geen regeltjes-fix.
+
+## Changes
+
+- `vnx_cli/commands/doctor.py` — `_check_hook_paths` gesplitst: de per-event path-extractie + existentie-check is nu `_collect_dead_hook_paths(hooks, project_root)` (37 regels); `_check_hook_paths` zelf is 57 regels (was 89). Extern contract (Check name/status/detail) ongewijzigd.
+- `tests/unit/vnx_cli/commands/test_doctor.py` — AST-grootte-guards voor `_check_hook_paths` en `_collect_dead_hook_paths` (≤70, faalt op oude code: 89) + gedragstest voor `_collect_dead_hook_paths` (relative/absolute dead-path split).
+- `dashboard/api_operator.py` — `_operator_get_sessions` gesplitst: `_tmux_sessions_to_map` (15) + `_merge_session_store_entries` (33) + `_operator_get_sessions` (42, was 83). Gedrag identiek.
+- `tests/test_serve_dashboard_api.py` — AST-grootte-guards voor de drie sessobs-functies (≤70, faalt op oude code: 83).
+
+## Verification
+
+OI-105 | ONBEOORDEELBAAR | Runtime-incident (runner pids 75513/82267, PR #811, 2026-06-03) is niet reproduceerbaar en de root-cause is nooit vastgesteld; pids/PR-context is weg. De exit_nonzero-classificatie bestaat nog bij design (scripts/gate_runner.py:513-515), maar de gemini_review-runner heeft sindsdien stall-detection (GATE_STALL_DEFAULTS gemini_review=180s, scripts/lib/headless_adapter.py:89-92), vertex-routing (VNX_GEMINI_ROUTING=vertex, gate_runner.py:91) en cwd-pinning op een PR-branch-worktree (OI-708). Een stille 275s-exit-1 zou nu als 'stall' op ~180s worden geclassificeerd, niet als kale exit_nonzero.
+
+OI-212 | BESTAAT-GROOT | `_llm_judge_code_quality` in scripts/benchmark/field-tests/runners/scorer.py:180-221 draait nog claude(Opus)+kimi; er is geen `_judge_deepseek`. Bij kimi-quota-falen valt de panel terug op claude-only (scorer.py:212-213), dus het doel 'tweede onafhankelijke judge zonder kimi-quota-afhankelijkheid' is niet bereikt. Oplossing vereist een provider-constraint-bewuste keuze (deepseek-harness lane, eigen key + hardening-flag per deepseek-harness-subscription-blocked), geen paar regels.
+
+OI-213 | BESTAAT-GROOT | Er is geen scorer-replay/re-judge-mode: `--retry-from` (run_field_tests.py:418) her-draait DNF-cellen, geen re-judge over bestaande raw.csv. `scripts/benchmark/judge_quality.py` re-judget wel bestaande results/*.json maar met één judge (`--model`, default opus), geen 4-judge-panel (opus+kimi+deepseek+codex). Feature-ontwerp (replay-mode + multi-judge panel) ontbreekt nog.
+
+OI-223 | BESTAAT-GROOT | De loader is LIVE: `load_lane_safety()` (routing_policy.py:56) + `is_claude_headless_blocked()` (routing_policy.py:71) worden afgedwongen in dispatch_bridge.py:263-265 en dispatch_cli.py:1261-1263. `headless_block` is dus enforced, en `HEADLESS_FORCED_MODELS` is leeg (hang reproduceerde niet post-cutover). De overige 5 regels (force_headless, claude_serial_under_load, codex_retry_once, kimi_quota_fail_fast, tmux_spawn_max_runtime, haiku_receipt_nondeterminism) blijven declaratief — routing_policy.yaml:79-82 zegt expliciet "Do not rely on them as live guards". Die per regel wél afdwingen is een ontwerpkeuze per regel.
+
+OI-224 | ACHTERHAALD | Betekenis gewijzigd: 2 van 3 sub-punten opgelost, de derde bewust gedeferred. F4 (retry reset shared checkout niet): opgelost door fail-loud isolatie — lane_adapter.py zet VNX_BENCH_REQUIRE_ISOLATION=1 + VNX_ISOLATED_WORKTREE=1 voor headless én provider-lanes, downstream afgedwongen in provider_dispatch.py:1376-1379 en 1807-1810 (werkworktree per cel, seed-contaminatie-check pre/post via _main_seed_status). F5 (report-match op prefix ipv dispatch_id): gefixt in #831, run_field_tests.py:199-215 matcht nu dispatch_id exact. F8 (worktree-removal-fout niet structured): bestaat nog als gedocumenteerde known-limitation, bewust naar 1.0.1 gedeferred (run_field_tests.py:138-139) — geen live defect.
+
+OI-225 | BESTAAT-GROOT | De bench-harness staat nog steeds buiten de wheel: pyproject.toml:115-117 excludeert scripts/benchmark/**, scripts/benchmarks/** en scripts/llm_benchmark.py. Deels gegeneraliseerd (judge_quality.py heeft --tasks-dir bring-your-own-tasks), maar 'terug in de wheel als feature' is een roadmap-ontwerpkeuze (1.1), geen regeltjes-fix.
+
+OI-546 | BESTAAT-GROOT | Schrijft nog steeds het JSON-artifact naar `<state-dir>/scout_effectiveness.json` (scripts/scout_effectiveness.py:56-57 + write_artifact, regel 506-511) zonder NDJSON-ledger-event. Alleen de atomic-write is gefixt (#1072). De keuze 'naar een non-state locatie' óf 'ledger-event emitten' óf 'ADR-005-exempt codificeren' is een audit-contract-beslissing.
+
+OI-547 | BESTAAT-KLEIN | Gefixt: `_check_hook_paths` was 89 regels (vnx_cli/commands/doctor.py:660-748), nu gesplitst in `_collect_dead_hook_paths` (37) + `_check_hook_paths` (57). AST-grootte-tests in tests/unit/vnx_cli/commands/test_doctor.py faalden op oude code (89>70) en slagen nu (12/12 doctor-tests groen).
+
+OI-557 | BESTAAT-GROOT | Geen systemische resolutie: geen ADR-005-exemptie gecodificeerd, geen non-state analysis-locatie afgesproken. scout_effectiveness blijft state-dir-artifacts schrijven; de codex-advisory-class blijft dus terugkomen. Ontwerpbeslissing nodig, geen regeltjes-fix.
+
+OI-558 | BESTAAT-KLEIN | Twee van drie sub-punten al opgelost: LiveSessionsPage bestaat niet meer (dashboard is JSON-API, api_operator.py), en de panes_result-degradation is gefixt in #1295 (api_operator.py:731-738, degraded_reasons). Restant `_operator_get_sessions` was 83 regels → nu gesplitst in `_tmux_sessions_to_map` (15) + `_merge_session_store_entries` (33) + `_operator_get_sessions` (42). AST-grootte-tests in tests/test_serve_dashboard_api.py faalden op oude code (83>70), slagen nu (sessobs-tests 7/7). NB: 6 pre-bestaande failures in test_serve_dashboard_api.py (sd._read_gate_config AttributeError, module serve_dashboard heeft die functie niet) zijn niet door deze dispatch veroorzaakt.
+
+OI-559 | BESTAAT-GROOT | Beide delen nog aanwezig: (1) receipt_schema.py:247 + 256-257 schrijft nog steeds zowel `permission_enforcement` als `worker_permission_enforcement` (bewuste collision-avoidance, inconsistent); reconciliatie is een schema/consumer-ontwerpkeuze. (2) `_build_completion_protocol` is 111 regels (scripts/lib/tmux_interactive_dispatch.py:965-1075) — een substantiële refactor, geen paar regels.
+
+OI-560 | BESTAAT-GROOT | `vnx_dispatch_agent` is nog 180 regels (vnx_cli/commands/dispatch_agent.py:184-363). De CLI-entry verweeft resolver + preflight + lane-coercion + deadline-passthrough; opsplitsen is een refactor die gedrag-drift riskeert zonder toegewijde refactor-budget. Boven de 'enkele regels'-grens.
+
+## Open Items
+
+- T0 kan op basis van dit bewijs overwegen: OI-105 (ONBEOORDEELBAAR, sluiten op mitigatie), OI-224 (ACHTERHAALD, F8-deferral is bewust) en de twee function-size-items (OI-547, OI-558) te sluiten; OI-212/213/223/225/546/557/559/560 blijven open als ontwerp-/roadmap-items.
+- Pre-bestaande (niet door deze dispatch veroorzaakte) test-breuken op main: tests/test_serve_dashboard_api.py::TestOperatorKanban + TestGateTogglePost (6 tests, sd._read_gate_config AttributeError), tests/test_api_operator_dedup.py::test_no_false_dedup (kanban-dedup telt 67 i.p.v. 3). Beide apart te triagen.

--- a/tests/test_serve_dashboard_api.py
+++ b/tests/test_serve_dashboard_api.py
@@ -9,6 +9,7 @@ Covers:
 
 from __future__ import annotations
 
+import ast
 import sys
 import json
 import tempfile
@@ -670,3 +671,30 @@ class TestOperatorSessions:
         # Sessions still list (busy/idle classification degrades, not the list).
         assert len(sessions) == 1
         assert any("list-panes" in r for r in reasons)
+
+
+# ---------------------------------------------------------------------------
+# OI-558 residual: _operator_get_sessions stays within the 70-line advisory
+# ---------------------------------------------------------------------------
+
+class TestOperatorSessionsFunctionSize:
+    """sessobs #1076 residual: the sessions endpoint was split so it stays ≤70 lines."""
+
+    _API_OPERATOR = Path(__file__).parent.parent / "dashboard" / "api_operator.py"
+
+    def _function_length(self, name: str) -> int:
+        tree = ast.parse(self._API_OPERATOR.read_text(encoding="utf-8"))
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
+        )
+        return fn.end_lineno - fn.lineno + 1
+
+    def test_operator_get_sessions_under_70_lines(self) -> None:
+        assert self._function_length("_operator_get_sessions") <= 70
+
+    def test_merge_helper_under_70_lines(self) -> None:
+        assert self._function_length("_merge_session_store_entries") <= 70
+
+    def test_tmux_map_helper_under_70_lines(self) -> None:
+        assert self._function_length("_tmux_sessions_to_map") <= 70

--- a/tests/unit/vnx_cli/commands/test_doctor.py
+++ b/tests/unit/vnx_cli/commands/test_doctor.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """Unit tests for vnx_cli/commands/doctor.py hook-path probe and agent enumeration."""
 
+import ast
 import json
 from pathlib import Path
 
 import pytest
 
-from vnx_cli.commands.doctor import PASS, WARN, _check_agents, _check_hook_paths
+from vnx_cli.commands.doctor import PASS, WARN, _check_agents, _check_hook_paths, _collect_dead_hook_paths
 
 
 def _make_agent(base: Path, name: str, rel: str = "agents") -> Path:
@@ -148,6 +149,54 @@ class TestHookPathResolution:
         result = _check_hook_paths(project)
 
         assert result.status == "PASS"
+
+
+class TestHookPathFunctionSize:
+    """OI-547: _check_hook_paths must stay within the 70-line codex advisory.
+
+    The function was split into _collect_dead_hook_paths + the probe so the
+    report-shaping stays readable. AST line-count guards the advisory the same
+    way test_doctor_refactor_oi1573.py guards cmd_doctor (≤190 lines).
+    """
+
+    def test_check_hook_paths_under_70_lines(self) -> None:
+        source = Path(__file__).parent.parent.parent.parent.parent / "vnx_cli" / "commands" / "doctor.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == "_check_hook_paths"
+        )
+        assert fn.end_lineno - fn.lineno + 1 <= 70
+
+    def test_collect_dead_hook_paths_under_70_lines(self) -> None:
+        source = Path(__file__).parent.parent.parent.parent.parent / "vnx_cli" / "commands" / "doctor.py"
+        tree = ast.parse(source.read_text(encoding="utf-8"))
+        fn = next(
+            n for n in ast.walk(tree)
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and n.name == "_collect_dead_hook_paths"
+        )
+        assert fn.end_lineno - fn.lineno + 1 <= 70
+
+    def test_collect_dead_hook_paths_parts(self, tmp_path):
+        """Extracted helper keeps the relative/absolute dead-path split."""
+        project = tmp_path / "project"
+        project.mkdir()
+        hooks = {
+            "PreToolUse": [
+                {
+                    "matcher": "Bash",
+                    "hooks": [
+                        {"type": "command", "command": f"bash {project / 'scripts' / 'hooks' / 'gone.sh'}"},
+                        {"type": "command", "command": "bash scripts/hooks/relative_missing.sh"},
+                    ],
+                }
+            ]
+        }
+        dead_relative, dead_absolute = _collect_dead_hook_paths(hooks, project.resolve())
+        assert "gone.sh" in " ".join(dead_absolute)
+        assert "relative_missing.sh" in " ".join(dead_relative)
 
 
 class TestCheckAgents:

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -657,34 +657,8 @@ def _extract_hook_paths(command: str) -> list[str]:
     return candidates
 
 
-def _check_hook_paths(project_dir: Path) -> Check:
-    """WARN for hook commands in .claude/settings.json that reference missing files."""
-    settings_path = project_dir / ".claude" / "settings.json"
-    if not settings_path.is_file():
-        return Check(
-            name="hooks:path-resolution",
-            status=PASS,
-            detail="no .claude/settings.json found; skipping hook path check",
-        )
-
-    try:
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
-    except json.JSONDecodeError as exc:
-        return Check(
-            name="hooks:path-resolution",
-            status=WARN,
-            detail=f".claude/settings.json is unparseable ({exc}); hook paths cannot be audited",
-        )
-
-    hooks = settings.get("hooks")
-    if not isinstance(hooks, dict):
-        return Check(
-            name="hooks:path-resolution",
-            status=PASS,
-            detail="no hooks section in .claude/settings.json",
-        )
-
-    project_root = project_dir.resolve()
+def _collect_dead_hook_paths(hooks: dict, project_root: Path) -> "tuple[list[str], list[str]]":
+    """Return (dead_relative, dead_absolute) hook paths that reference missing files."""
     dead_relative: list[str] = []
     dead_absolute: list[str] = []
 
@@ -718,6 +692,39 @@ def _check_hook_paths(project_dir: Path) -> Check:
                         target = project_root / normalized
                         if not target.is_file():
                             dead_relative.append(normalized)
+
+    return dead_relative, dead_absolute
+
+
+def _check_hook_paths(project_dir: Path) -> Check:
+    """WARN for hook commands in .claude/settings.json that reference missing files."""
+    settings_path = project_dir / ".claude" / "settings.json"
+    if not settings_path.is_file():
+        return Check(
+            name="hooks:path-resolution",
+            status=PASS,
+            detail="no .claude/settings.json found; skipping hook path check",
+        )
+
+    try:
+        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        return Check(
+            name="hooks:path-resolution",
+            status=WARN,
+            detail=f".claude/settings.json is unparseable ({exc}); hook paths cannot be audited",
+        )
+
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return Check(
+            name="hooks:path-resolution",
+            status=PASS,
+            detail="no hooks section in .claude/settings.json",
+        )
+
+    project_root = project_dir.resolve()
+    dead_relative, dead_absolute = _collect_dead_hook_paths(hooks, project_root)
 
     if dead_relative or dead_absolute:
         parts: list[str] = []


### PR DESCRIPTION
## T6 OI-triage — meet-opdracht

Twaalf maanden-oude open items getoetst tegen `origin/main`. Per item gereproduceerd (bestand/functie/commando opgezocht), daarna ACHTERHAALD / BESTAAT-KLEIN / BESTAAT-GROOT / ONBEOORDEELBAAR.

**Uitkomst: 2 gefixt, 7 GROOT (ontwerpkeuze), 2 ACHTERHAALD, 1 ONBEOORDEELBAAR.**

### Gefixt (klein, met rood-op-main tests)
- **OI-547** — `_check_hook_paths` was 89 regels (was >70 codex-advisory). Gesplitst: `_collect_dead_hook_paths` (37) + `_check_hook_paths` (57). AST-grootte-guard faalde op oude code (89>70), slaat nu aan.
- **OI-558 (restant)** — `_operator_get_sessions` was 83 regels. Gesplitst: `_tmux_sessions_to_map` (15) + `_merge_session_store_entries` (33) + `_operator_get_sessions` (42). AST-grootte-guard faalde op oude code (83>70). LiveSessionsPage bestond al niet meer en de panes-degradation was al gefixt in #1295.

### ACHTERHAALD / ONBEOORDEELBAAR (bewijs in rapport)
- **OI-224** — F4 isolatie + F5 dispatch_id-match opgelost; F8 restant is een bewust naar 1.0.1 gedeferde known-limitation.
- **OI-105** — ONBEOORDEELBAAR: runtime-incident niet reproduceerbaar; runner heeft sindsdien stall-detection (180s), vertex-routing en cwd-pinning.

### BESTAAT-GROOT (niet gefixt — ontwerpkeuze vereist)
- **OI-212/213** — judge-panel nog claude+kimi (geen deepseek); geen scorer-replay-mode.
- **OI-223** — loader + headless_block zijn live; de overige 5 lane_safety-regels blijven declaratief (yaml zegt expliciet "not live guards").
- **OI-225** — bench-harness nog buiten de wheel (pyproject exclude).
- **OI-546/557** — scout_effectiveness schrijft nog steeds state-dir-artifact zonder NDJSON-event; geen ADR-005-exemptie gecodificeerd.
- **OI-559/560** — `_build_completion_protocol` 111 regels, `vnx_dispatch_agent` 180 regels, dual-field-naming in receipts blijft.

Volledig rapport: `docs/investigations/20260801-oi-triage-t6-ledger-existence.md` + `unified_reports/20260801-t6-oi-triage.md`.

**NB pre-bestaande test-breuken op main (niet door deze PR):** `sd._read_gate_config` AttributeError (6 tests) en `test_no_false_dedup` (kanban-dedup). Beide gereproduceerd op HEAD vóór deze wijzigingen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)