### PR TITLE
fix(governance): propagate staged spec.role into envelope/provider receipts

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -821,17 +821,20 @@ def _govern(
             receipt_path = ndjson_path
         else:
             try:
-                # receipt-quality PR-1: resolve dispatch identity (role) from
-                # dispatch_metadata just before the emit. FAIL-OPEN — a resolver
-                # error must never break receipt emission.
+                # receipt-quality PR-1 + W7 fix: resolve dispatch identity
+                # (role) just before the emit. The shared resolver prefers the
+                # genuinely-set spec role (never the fake backend-developer
+                # default), falls back to dispatch_metadata, then stamps
+                # identity_unresolved. FAIL-OPEN — a resolver error must never
+                # break receipt emission.
                 try:
-                    from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+                    from dispatch_identity import resolve_effective_role  # noqa: PLC0415
                     _project_id = getattr(spec, "project_id", None)
                     if not _project_id:
                         from dispatch_cli import _resolve_project_id  # noqa: PLC0415
                         _project_id = _resolve_project_id()
-                    _role = resolve_dispatch_role(
-                        spec.dispatch_id, _project_id, state_dir=spec.state_dir,
+                    _role = resolve_effective_role(
+                        spec.role, spec.dispatch_id, _project_id, state_dir=spec.state_dir,
                     )
                 except Exception:  # noqa: BLE001 — identity join is fail-open
                     logger.debug(
@@ -839,8 +842,7 @@ def _govern(
                         spec.dispatch_id,
                         exc_info=True,
                     )
-                    _role = None
-                _role = _role or "identity_unresolved"
+                    _role = "identity_unresolved"
 
                 # receipt-quality PR-B2 fix-forward (Finding C): aggregate
                 # PreToolUse-hook tool-call signals for this dispatch

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -46,12 +46,10 @@ logger = logging.getLogger(__name__)
 # since the tmux dispatch.sh sets PYTHONPATH to scripts/lib only (not scripts/).
 _SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
 
-# The fake default stamped by writers that never resolved a real role. The
-# receipt trail must never propagate it (mirrors dispatch_identity).
-_FAKE_DEFAULT_ROLE = "backend-developer"
-
 # Stamped when no real role is resolvable — NEVER "unknown", NEVER the fake
-# backend-developer default (receipt-quality track).
+# backend-developer default (receipt-quality track). The fake-default guard
+# itself lives in dispatch_identity.resolve_effective_role, the shared resolver
+# every emit path uses.
 _IDENTITY_UNRESOLVED = "identity_unresolved"
 
 # The plan-gate's own role — a worker report ending in a ```vnx-plan-verdict``` fence.
@@ -71,8 +69,8 @@ def _resolve_govern_role(spec: "GovernSpec") -> str:
     """Resolve the dispatch's real role for govern-emitted receipts/frontmatter.
 
     Receipt-quality PR-2: propagate dispatch identity into the GOVERN-
-    SYNTHESIZED emit path via the same resolver PR-1 added for the v2 emit
-    path (``dispatch_identity.resolve_dispatch_role``).
+    SYNTHESIZED emit path via the shared resolver
+    (``dispatch_identity.resolve_effective_role``).
 
     Order:
       1. ``spec.role`` when genuinely set (never the fake default).
@@ -83,23 +81,18 @@ def _resolve_govern_role(spec: "GovernSpec") -> str:
     FAIL-OPEN: never raises — receipt/report emission must not break on the
     identity join.
     """
-    spec_role = (spec.role or "").strip()
-    if spec_role and spec_role != _FAKE_DEFAULT_ROLE:
-        return spec_role
-    resolved: Optional[str] = None
     try:
-        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        from dispatch_identity import resolve_effective_role  # noqa: PLC0415
         from dispatch_cli import _resolve_project_id  # noqa: PLC0415
-        resolved = resolve_dispatch_role(
-            spec.dispatch_id, _resolve_project_id(), state_dir=spec.state_dir,
+        return resolve_effective_role(
+            spec.role, spec.dispatch_id, _resolve_project_id(), state_dir=spec.state_dir,
         )
     except Exception:  # noqa: BLE001 — identity join is fail-open
         logger.debug(
             "govern: role resolution failed open dispatch=%s",
             spec.dispatch_id, exc_info=True,
         )
-        resolved = None
-    return resolved or _IDENTITY_UNRESOLVED
+        return _IDENTITY_UNRESOLVED
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/dispatch_identity.py
+++ b/scripts/lib/dispatch_identity.py
@@ -29,6 +29,10 @@ logger = logging.getLogger(__name__)
 # trail must stop propagating it — treated as "no real role".
 _FAKE_DEFAULT_ROLE = "backend-developer"
 
+# Stamped when no real role is resolvable — NEVER "unknown", NEVER the fake
+# backend-developer default (receipt-quality track).
+_IDENTITY_UNRESOLVED = "identity_unresolved"
+
 # Receipt-quality PR-4: instruction-header source used by the write-time
 # capture-gap backfill (mirrors subprocess_dispatch._ROLE_HEADER_RE).
 _ROLE_HEADER_RE = re.compile(r"^Role:\s*(\S+)", re.MULTILINE)
@@ -164,3 +168,33 @@ def resolve_dispatch_role(
             exc_info=True,
         )
         return None
+
+
+def resolve_effective_role(
+    role: Optional[str],
+    dispatch_id: str,
+    project_id: str,
+    state_dir: Optional[Path] = None,
+) -> str:
+    """Resolve the dispatch's real role for receipt/report emission.
+
+    The single canonical resolution shared by every emit path
+    (``dispatch_govern._resolve_govern_role``, ``dispatch_envelope._govern``,
+    ``provider_dispatch._emit_governance``, ``report_to_receipt_converter``).
+
+    Order:
+      1. A genuinely-set caller role (never the fake ``backend-developer``
+         default, which writers stamp when they never resolved a real role).
+      2. ``dispatch_metadata`` via the ADR-007 composite key
+         (``dispatch_id``, ``project_id``) — the fallback for writers that
+         never carried a real role on the spec.
+      3. ``"identity_unresolved"``.
+
+    FAIL-OPEN: never raises — receipt/report emission must not break on the
+    identity join (mirrors ``resolve_dispatch_role``'s contract).
+    """
+    candidate = (role or "").strip()
+    if candidate and candidate != _FAKE_DEFAULT_ROLE:
+        return candidate
+    resolved = resolve_dispatch_role(dispatch_id, project_id, state_dir=state_dir)
+    return resolved or _IDENTITY_UNRESOLVED

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -651,17 +651,19 @@ def _emit_governance(
     # auto-vivified Mock child.
     _integrity = vars(args).get("_final_prompt_integrity")
 
-    # receipt-quality PR-1: resolve dispatch identity (role) from
-    # dispatch_metadata just before the emit. FAIL-OPEN — a resolver error
-    # must never break receipt emission.
+    # receipt-quality PR-1 + W7 fix: resolve dispatch identity (role) just
+    # before the emit. The shared resolver prefers the genuinely-set --role
+    # (never the fake backend-developer default), falls back to
+    # dispatch_metadata, then stamps identity_unresolved. FAIL-OPEN — a
+    # resolver error must never break receipt emission.
     try:
-        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        from dispatch_identity import resolve_effective_role  # noqa: PLC0415
         _project_id = vars(args).get("project_id")
         if not _project_id:
             from dispatch_cli import _resolve_project_id  # noqa: PLC0415
             _project_id = _resolve_project_id()
-        _role = resolve_dispatch_role(
-            args.dispatch_id, _project_id, state_dir=state_dir,
+        _role = resolve_effective_role(
+            getattr(args, "role", None), args.dispatch_id, _project_id, state_dir=state_dir,
         )
     except Exception:  # noqa: BLE001 — identity join is fail-open
         logger.debug(
@@ -669,8 +671,7 @@ def _emit_governance(
             getattr(args, "dispatch_id", "?"),
             exc_info=True,
         )
-        _role = None
-    _role = _role or "identity_unresolved"
+        _role = "identity_unresolved"
 
     # receipt-quality PR-B2: aggregate PreToolUse-hook tool-call signals for
     # this dispatch (scripts/lib/toolcall_signals.py). FAIL-OPEN — an

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -181,7 +181,12 @@ def _load_route_decision(dispatch_id: str, state_dir: Path) -> Optional[Dict[str
 def _resolve_report_role(
     dispatch_id: str, merged: Dict[str, Any], state_dir: Optional[Path]
 ) -> str:
-    """Resolve the dispatch's real role from dispatch_metadata (PR-4).
+    """Resolve the dispatch's real role for the converter receipt.
+
+    W7 fix: the shared resolver prefers the report's OWN stamped ``role``
+    (frontmatter/body — the author's resolved identity) over the
+    dispatch_metadata join, matching every other emit path. The metadata join
+    remains the fallback for reports whose author never stamped a role.
 
     FAIL-OPEN contract (mirrors PR-1/PR-2): any resolution error, missing DB,
     missing row, null/empty role, or the fake ``backend-developer`` default
@@ -190,12 +195,14 @@ def _resolve_report_role(
     """
     role: Optional[str] = None
     try:
-        from dispatch_identity import resolve_dispatch_role  # noqa: PLC0415
+        from dispatch_identity import resolve_effective_role  # noqa: PLC0415
         project_id = merged.get("project_id") or None
         if not project_id:
             from dispatch_cli import _resolve_project_id  # noqa: PLC0415
             project_id = _resolve_project_id()
-        role = resolve_dispatch_role(dispatch_id, project_id, state_dir=state_dir)
+        role = resolve_effective_role(
+            merged.get("role"), dispatch_id, project_id, state_dir=state_dir,
+        )
     except Exception:  # noqa: BLE001 — identity join is fail-open
         logger.debug(
             "report_to_receipt_converter: role resolution failed open dispatch=%s",

--- a/tests/test_envelope_role_propagation.py
+++ b/tests/test_envelope_role_propagation.py
@@ -1,0 +1,170 @@
+"""test_envelope_role_propagation.py — spec.role must reach the envelope receipt.
+
+Dispatch-20260801-w7: the envelope/provider-lane GOVERN path resolved the receipt
+``role`` from ``dispatch_metadata`` ONLY and ignored ``spec.role``, so a dispatch
+staged with a genuine role (e.g. ``system-architect``) still landed as
+``identity_unresolved``. These tests pin the propagation contract:
+
+1. A spec with ``role=X`` produces a receipt with ``role=X`` (two different roles).
+2. A spec role wins over a ``dispatch_metadata`` row (the plan's own staged role
+   is the authoritative source; the DB join is a fallback for writers that never
+   staged a role).
+3. Sentinel protection: an absent role (None) or the fake ``backend-developer``
+   default NEVER lands verbatim in the receipt — it resolves to
+   ``identity_unresolved`` or the DB row, exactly like ``dispatch_govern``.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+from dispatch_envelope import EnvelopeSpec, _AdapterResult
+
+
+def _make_spec(tmp_path: Path, *, role, dispatch_id="role-prop-001") -> EnvelopeSpec:
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    (data_dir / "unified_reports").mkdir(parents=True)
+    return EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction="implement the feature",
+        role=role,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+def _make_metadata_db(state_dir: Path, rows):
+    """Create a minimal quality_intelligence.db with dispatch_metadata rows."""
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "quality_intelligence.db"))
+    conn.execute(
+        "CREATE TABLE dispatch_metadata ("
+        " id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        " dispatch_id TEXT NOT NULL,"
+        " project_id TEXT NOT NULL,"
+        " role TEXT"
+        ")"
+    )
+    for dispatch_id, project_id, role in rows:
+        conn.execute(
+            "INSERT INTO dispatch_metadata (dispatch_id, project_id, role) VALUES (?, ?, ?)",
+            (dispatch_id, project_id, role),
+        )
+    conn.commit()
+    conn.close()
+
+
+def _run_govern(spec: EnvelopeSpec) -> dict:
+    """Run the envelope GOVERN and return the emitted receipt line as a dict."""
+    result = _AdapterResult(returncode=0, completion_text="all good", status="success")
+    start = end = datetime.now(timezone.utc)
+    _report_path, receipt_path = dispatch_envelope._govern(spec, result, start, end)
+    assert receipt_path is not None and receipt_path.exists(), "receipt must be emitted"
+    lines = [l for l in receipt_path.read_text(encoding="utf-8").splitlines() if l.strip()]
+    assert lines, "receipt ledger must not be empty"
+    # The last line for this dispatch is the one GOVERN just wrote.
+    receipt = json.loads(lines[-1])
+    assert receipt["dispatch_id"] == spec.dispatch_id, "unexpected receipt line"
+    return receipt
+
+
+def test_envelope_spec_role_system_architect_propagates_to_receipt(
+    tmp_path, monkeypatch,
+):
+    """A spec staged with role='system-architect' must land in the receipt verbatim."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+
+    spec = _make_spec(tmp_path, role="system-architect")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") == "system-architect", (
+        f"spec.role did not reach the receipt; got role={receipt.get('role')!r}"
+    )
+
+
+def test_envelope_spec_role_second_role_propagates_to_receipt(
+    tmp_path, monkeypatch,
+):
+    """Generality: a second distinct role also propagates (not a one-value fluke)."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+
+    spec = _make_spec(tmp_path, role="security-reviewer", dispatch_id="role-prop-002")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") == "security-reviewer", (
+        f"spec.role did not reach the receipt; got role={receipt.get('role')!r}"
+    )
+
+
+def test_envelope_spec_role_wins_over_db_metadata(tmp_path, monkeypatch):
+    """The plan's staged role is authoritative; a DB row must not override it."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    _make_metadata_db(tmp_path / "state", [("role-prop-003", "vnx-dev", "debugger")])
+
+    spec = _make_spec(tmp_path, role="plan-reviewer", dispatch_id="role-prop-003")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") == "plan-reviewer", (
+        f"spec.role should win over dispatch_metadata; got role={receipt.get('role')!r}"
+    )
+
+
+def test_envelope_db_fallback_when_no_spec_role(tmp_path, monkeypatch):
+    """No spec role -> the dispatch_metadata DB join supplies the role."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    _make_metadata_db(tmp_path / "state", [("role-prop-004", "vnx-dev", "debugger")])
+
+    spec = _make_spec(tmp_path, role=None, dispatch_id="role-prop-004")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") == "debugger", (
+        f"DB fallback role did not propagate; got role={receipt.get('role')!r}"
+    )
+
+
+def test_envelope_no_role_never_stamps_backend_developer(tmp_path, monkeypatch):
+    """Sentinel protection: role=None must NOT become the fake backend-developer."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+
+    spec = _make_spec(tmp_path, role=None, dispatch_id="role-prop-005")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") != "backend-developer", (
+        "absent role silently stamped the fake backend-developer default"
+    )
+    assert receipt.get("role") == "identity_unresolved", (
+        f"expected identity_unresolved, got role={receipt.get('role')!r}"
+    )
+
+
+def test_envelope_sentinel_spec_role_falls_through_to_db(tmp_path, monkeypatch):
+    """A spec role of the literal fake default must fall through to the DB, not propagate."""
+    monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    _make_metadata_db(tmp_path / "state", [("role-prop-006", "vnx-dev", "reviewer")])
+
+    spec = _make_spec(tmp_path, role="backend-developer", dispatch_id="role-prop-006")
+    receipt = _run_govern(spec)
+
+    assert receipt.get("role") == "reviewer", (
+        f"fake default should fall through to the DB row; got role={receipt.get('role')!r}"
+    )


### PR DESCRIPTION
## Problem

`spec.role` never reaches the receipt on the envelope/provider-lane paths. T0 staged a dispatch with `role="system-architect"` (a valid role from `agents/`) and the receipt carried `identity_unresolved`. Fleet-wide: **21,095 of 21,779 receipts carry no role**, only 117 carry a real role (plan-reviewer 55, debugger 34, reviewer 17, deliberation-panelist 11).

## Root cause

The 117 real-role receipts all route through `dispatch_govern`, whose `_resolve_govern_role` checks `spec.role` **first**. The envelope/provider-lane GOVERN paths (`dispatch_envelope._govern`, `provider_dispatch._emit_governance`) resolved the receipt role from `dispatch_metadata` **only** and ignored the spec/args role. Whenever that DB join came up empty, they stamped `identity_unresolved` — over a genuinely staged role.

Non-enforcement chain behind why this could arise (measured by T0, reported in Open Items):
1. `dispatch_bridge.py:226` silently fills an empty role with the `backend-developer` sentinel.
2. `dispatch_spec.py` Rule 7 only checks non-empty; real validation is "deferred to compile_plan".
3. `dispatch_plan.py` has zero role validation — the deferred check was never built.
4. The governance layer strips the sentinel, so an empty role became `identity_unresolved`.

## Fix

One shared resolver — `dispatch_identity.resolve_effective_role` — with the same precedence `dispatch_govern` already used:
1. caller role when genuinely set (**never** the fake `backend-developer` sentinel),
2. `dispatch_metadata` via the ADR-007 composite key,
3. `identity_unresolved`.

Wired into `dispatch_envelope._govern`, `provider_dispatch._emit_governance`, and `report_to_receipt_converter` (which now also prefers the report's own stamped role). `dispatch_govern._resolve_govern_role` delegates to it — behavior unchanged.

Sentinel protection intact: an absent role or the fake default resolves to `identity_unresolved` (or the DB row), never `backend-developer`, on every emit path.

## Verification

New `tests/test_envelope_role_propagation.py` — **RED on origin/main** (shown explicitly in the dispatch report):
- staged `role="system-architect"` → receipt `identity_unresolved` (was broken)
- staged `role="security-reviewer"` → receipt `identity_unresolved` (was broken)
- staged `plan-reviewer` + DB row `debugger` → receipt `debugger` (DB won over spec — was broken)

GREEN after the fix: 6/6 pass, including sentinel protection (`None` and `backend-developer` never land verbatim).

Related suites: 224 passed across the receipt/identity/govern/envelope suites. The only failures are 4 pre-existing `TestFlagGateClaude` cases that also fail on clean `origin/main` (`workers-kimi-pinned` routing constraint, unrelated).

## Open Items

See the dispatch report `## Open Items` for chain links 1 and 3 (sentinel fill in `dispatch_bridge.py`, missing role validation in `dispatch_plan.py`) and the fleet re-measurement after this ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)