### PR TITLE
fix(triage): close OI-678, OI-679, OI-684 with red-on-main lint guards (#1299-style)

### DIFF
--- a/hooks/sessionstart.sh
+++ b/hooks/sessionstart.sh
@@ -15,28 +15,19 @@ set -euo pipefail
 
 # ── Detect terminal from working directory ───────────────────────────
 TERMINAL=""
-ROLE=""
-TRACK=""
 
 case "$PWD" in
   */terminals/T0|*/T0)
     TERMINAL="T0"
-    ROLE="orchestrator"
     ;;
   */terminals/T1|*/T1)
     TERMINAL="T1"
-    ROLE="worker"
-    TRACK="A"
     ;;
   */terminals/T2|*/T2)
     TERMINAL="T2"
-    ROLE="worker"
-    TRACK="B"
     ;;
   */terminals/T3|*/T3)
     TERMINAL="T3"
-    ROLE="worker"
-    TRACK="C"
     ;;
   *)
     # Not a VNX terminal directory — exit silently
@@ -44,14 +35,6 @@ case "$PWD" in
     exit 0
     ;;
 esac
-
-# ── Also check environment variables (set by vnx start) ─────────────
-if [ -n "${CLAUDE_ROLE:-}" ]; then
-  ROLE="$CLAUDE_ROLE"
-fi
-if [ -n "${CLAUDE_TRACK:-}" ]; then
-  TRACK="$CLAUDE_TRACK"
-fi
 
 # ── Resolve project root from directory structure ────────────────────
 # Walk up from terminal dir to find project root

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -140,8 +140,7 @@ _psr_extract_terminal() {
 _psr_parse_receipt_json() {
     local report_path="$1" report_name="$2"
     local receipt_json
-    receipt_json=$(python3 "$SCRIPTS_DIR/report_parser.py" "$report_path" 2>/dev/null)
-    if [ $? -ne 0 ] || [ -z "$receipt_json" ]; then
+    if ! receipt_json=$(python3 "$SCRIPTS_DIR/report_parser.py" "$report_path" 2>/dev/null) || [ -z "$receipt_json" ]; then
         log_structured_failure "receipt_parse_failed" "report_parser.py failed to generate receipt JSON" "report=$report_name"
         log "ERROR" "Failed to parse report: $report_name"
         return 1
@@ -258,7 +257,8 @@ _psr_record_adoption() {
 # Process a single report — orchestrates extracted sub-functions.
 process_single_report() {
     local report_path="$1"
-    local report_name=$(basename "$report_path")
+    local report_name
+    report_name=$(basename "$report_path")
 
     log "INFO" "Processing: $report_name"
 
@@ -345,7 +345,8 @@ _ppr_process_rate_limited() {
 
 # Process all pending reports with flood protection and rate limiting.
 process_pending_reports() {
-    local cutoff=$(get_cutoff_time)
+    local cutoff
+    cutoff=$(get_cutoff_time)
     log "INFO" "Scanning for reports newer than: $cutoff"
     _ppr_collect_pending
     if ! check_flood_protection "$_PPR_QUEUE_COUNT"; then
@@ -409,10 +410,12 @@ _poll_new_reports() {
 # Process any reports from the last 10 minutes created while the processor was down.
 _mnr_startup_catchup() {
     local catchup_count=0
-    local now=$(date +%s)
+    local now
+    now=$(date +%s)
     for report in "$UNIFIED_REPORTS"/*.md "$HEADLESS_REPORTS"/*.md; do
         [ -f "$report" ] || continue
-        local mtime=$(stat -f%m "$report" 2>/dev/null || stat -c%Y "$report" 2>/dev/null || echo 0)
+        local mtime
+        mtime=$(stat -f%m "$report" 2>/dev/null || stat -c%Y "$report" 2>/dev/null || echo 0)
         local age_secs=$(( now - mtime ))
         if [ "$age_secs" -le 600 ] && should_process_report "$report"; then
             log "INFO" "Startup catchup: processing $( basename "$report" ) (age: ${age_secs}s)"

--- a/tests/test_receipt_processor_sc2155.py
+++ b/tests/test_receipt_processor_sc2155.py
@@ -1,0 +1,40 @@
+"""OI-679: receipt_processor.sh must not declare-and-assign with substitution.
+
+shellcheck SC2155 ("Declare and assign separately to avoid masking return
+values") fires on ``local x="$(cmd)"`` / ``export x=$(cmd)``: the declared
+variable captures the command's exit status instead of the shell's, so a
+failing substitution is silently masked. The finding flagged four lines in
+scripts/receipt_processor.sh (report_name, cutoff, now, mtime).
+
+This test encodes the exact SC2155 rule as a static scan so it needs no
+shellcheck binary in CI and fails deterministically on the pre-fix code.
+Same rule as tests/test_dispatch_sh_sc2155.py (OI-268).
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_RECEIPT_PROCESSOR_SH = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+# shellcheck SC2155: declare/export/assign in one statement whose RHS contains
+# a command substitution. ``local x`` followed by ``x=$(...)`` on a SEPARATE
+# line is the compliant idiom and must not match. ``$((...))`` arithmetic
+# expansion is NOT a command substitution (shellcheck does not flag it), so
+# ``$`` must be followed by ``(`` whose next char is not ``(``.
+_SC2155_RE = re.compile(
+    r"(?:\b(?:local|export|declare)\s+[A-Za-z_][A-Za-z0-9_]*\s*=\s*.*?\$\((?!\())"
+)
+
+
+def test_no_sc2155_declare_assign_in_receipt_processor():
+    assert _RECEIPT_PROCESSOR_SH.exists(), f"receipt_processor.sh missing at {_RECEIPT_PROCESSOR_SH}"
+    hits: list[tuple[int, str]] = []
+    for lineno, line in enumerate(_RECEIPT_PROCESSOR_SH.read_text(encoding="utf-8").splitlines(), 1):
+        if _SC2155_RE.search(line):
+            hits.append((lineno, line.strip()))
+    assert not hits, (
+        "shellcheck SC2155 declare-and-assign patterns (masked return values) at:\n"
+        + "\n".join(f"  {ln}: {text}" for ln, text in hits)
+    )

--- a/tests/test_receipt_processor_sc2181.py
+++ b/tests/test_receipt_processor_sc2181.py
@@ -1,0 +1,36 @@
+"""OI-678: receipt_processor.sh must not check exit status via $?.
+
+shellcheck SC2181 ("Check exit code directly with e.g. 'if ! mycmd;', not
+indirectly with $?") fires when a command's exit status is inspected through
+``$?`` in a separate test expression instead of testing the command directly
+(``if ! cmd`` / ``if cmd``). The finding flagged the report_parser.py call in
+_psr_parse_receipt_json (scripts/receipt_processor.sh).
+
+This test encodes the rule as a static scan so it needs no shellcheck binary
+in CI and fails deterministically on the pre-fix code.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_RECEIPT_PROCESSOR_SH = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+# SC2181: a test expression ``[ $? ... ]`` (also ``[$?``) is an indirect
+# exit-status check. Escaped ``\$?`` matches the literal two-character ``$?``
+# sequence so ordinary ``$var`` tests (e.g. ``[ $append_rc -eq 1 ]``) are not
+# flagged.
+_SC2181_RE = re.compile(r"\[\s*\$\?")
+
+
+def test_no_indirect_exit_code_check_in_receipt_processor():
+    assert _RECEIPT_PROCESSOR_SH.exists(), f"receipt_processor.sh missing at {_RECEIPT_PROCESSOR_SH}"
+    hits: list[tuple[int, str]] = []
+    for lineno, line in enumerate(_RECEIPT_PROCESSOR_SH.read_text(encoding="utf-8").splitlines(), 1):
+        if _SC2181_RE.search(line):
+            hits.append((lineno, line.strip()))
+    assert not hits, (
+        "shellcheck SC2181 indirect $? exit-code checks at:\n"
+        + "\n".join(f"  {ln}: {text}" for ln, text in hits)
+    )

--- a/tests/test_sessionstart_hook_dead_vars.py
+++ b/tests/test_sessionstart_hook_dead_vars.py
@@ -1,0 +1,38 @@
+"""OI-684: hooks/sessionstart.sh must not carry dead ROLE/TRACK assignments.
+
+shellcheck SC2034 ("ROLE appears unused") fired on hooks/sessionstart.sh: ROLE
+and TRACK were assigned from the terminal-directory case and from the
+CLAUDE_ROLE/CLAUDE_TRACK env overrides, but never read anywhere. The hook's
+only output is the JSON additionalContext built from ADDITIONAL_CONTEXT;
+ROLE/TRACK are not exported and never reach that output, so they are dead.
+
+The fix removed the assignments (and the now-dead env-override block). This
+test is a static scan asserting no ``ROLE=`` / ``TRACK=`` variable assignment
+remains. ``CLAUDE_ROLE=`` / ``CLAUDE_TRACK=`` env READS are also gone; "Role:"
+prose inside the additionalContext text is not an assignment and must not
+match.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_SESSIONSTART_SH = Path(__file__).resolve().parent.parent / "hooks" / "sessionstart.sh"
+
+# A variable assignment ``ROLE=...`` / ``TRACK=...``. The word-boundary before
+# the name keeps ``CLAUDE_ROLE`` (env read) from matching — the char before
+# "ROLE" there is ``_``, a word char, so ``\b`` does not hold.
+_ROLE_TRACK_ASSIGN_RE = re.compile(r"\b(?:ROLE|TRACK)\s*=")
+
+
+def test_no_dead_role_track_assignments_in_sessionstart():
+    assert _SESSIONSTART_SH.exists(), f"sessionstart.sh missing at {_SESSIONSTART_SH}"
+    hits: list[tuple[int, str]] = []
+    for lineno, line in enumerate(_SESSIONSTART_SH.read_text(encoding="utf-8").splitlines(), 1):
+        if _ROLE_TRACK_ASSIGN_RE.search(line):
+            hits.append((lineno, line.strip()))
+    assert not hits, (
+        "dead ROLE/TRACK assignments (shellcheck SC2034, OI-684) at:\n"
+        + "\n".join(f"  {ln}: {text}" for ln, text in hits)
+    )


### PR DESCRIPTION
## Triage-ronde OI-677..OI-698

Triage van 12 maanden oude open-items op een verse worktree vanaf origin/main. Meten eerst, fixen alleen waar klein.

**Uitkomst (12 items):** 7 ACHTERHAALD, 3 BESTAAT-KLEIN (gefixt), 2 BESTAAT-GROOT (bewust niet).

### Gefixt
- **OI-678** (SC2181): `if [ $? -ne 0 ]` -> `if ! receipt_json=$(...)` in `scripts/receipt_processor.sh`
- **OI-679** (SC2155): 4× `local x="$(cmd)"` gesplitst in declare + assign
- **OI-684** (SC2034): dode `ROLE`/`TRACK`-assignments uit `hooks/sessionstart.sh` verwijderd

Elke fix heeft een statische scan-test die op de pre-fix code rood stond (geverifieerd via `git stash`).

### ACHTERHAALD (bewijs in rapport)
- OI-677/680/681/689: shellcheck false positives (source-pad niet volgbaar / bewust idioom / bewuste single quotes)
- OI-683: shellcheck -x nu exit 0 op de test
- OI-696: edge/.vnx-data weg, event_store rout naar centrale store (#1023)
- OI-697: pip-CLI honoreert pins via re-exec (`vnx_cli/_reexec.py`)

### BESTAAT-GROOT
- **OI-695**: `vnx init --force` clobbert settings.json nog (init_cmd.py:333); merge-engine bestaat maar is niet gewired — ontwerpkeuze
- **OI-698**: dual-install conditie reproduceert in SEOcrawler_v2 (doctor `install:dual`); fix is gedelegeerd aan SEO's eigen T0 live-sessie

Volledige triage-tabel: `unified_reports/20260801-t11-oi-triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)