### PR TITLE
fix(triage): OI-645 F821 + meet-rapport OI-561..655 (T9)

### DIFF
--- a/docs/investigations/20260801-t9-oi-triage-ledger-existence.md
+++ b/docs/investigations/20260801-t9-oi-triage-ledger-existence.md
@@ -1,0 +1,29 @@
+# OI-Triage 20260801-T9 — bestaansrecht OI-561, OI-562, OI-563, OI-564, OI-579, OI-621, OI-628, OI-629, OI-636, OI-645, OI-653, OI-655
+
+Dispatch-ID: 20260801-t9-oi-triage
+
+## Summary
+
+Twaalf open items getoetst op een verse worktree vanaf origin/main, elk gereproduceerd tegen de huidige code. Uitkomst: 2 ACHTERHAALD met betekeniswijziging (OI-628, OI-655), 1 BESTAAT-KLEIN (OI-645, gefixt), 9 BESTAAT-GROOT. Eén code-wijziging: OI-645 module-level import + rood-op-main-test. Volledige bewijslast per item staat in het unified report (`unified_reports/20260801-t9-oi-triage.md`); deze doc is de repo-side samenvatting.
+
+## Verdicts
+
+- **OI-628 | ACHTERHAALD** — lokale sidecar-anchor vervangen door ADR-034 git-anchor (implementatie aanwezig, nog niet geactiveerd: VNX_CHAIN_RECEIPTS default-off, governance/ nog niet gevuld). De 3 codex-holes (deletion-fallback, append-forgery-last-match, seal-race) zijn structureel dicht.
+- **OI-655 | ACHTERHAALD** — contract-injectie live sinds 2026-06-23; post-OI (07-17 window, 07-27/28 govern-synthese + SynthesizedLaneReceipt) dicht de resterende gap. De 36x-telling zelf is alleen in de SEOcrawler-v2 store te her-meten (buiten scope).
+- **OI-645 | BESTAAT-KLEIN** — F821 `PrEnforcementResult` gereproduceerd (ruff + `get_type_hints` NameError); gefixt met module-level import; test `tests/test_tmux_pr_enforcement_annotation_resolves.py` rood op main, groen na fix.
+- **OI-561, OI-562 | BESTAAT-GROOT** — evidence-bound gate blijft advisory-default, signed-delegation blijft default-off (beide gemeten). Review-bij-flip-moment staat nog uit; operatorbeslissing.
+- **OI-563 | BESTAAT-GROOT** — gereproduceerd: `apply_if_below(27, _migrate_v27)` stamt user_version=27 terwijl `ux_success_patterns_pid` ontbreekt; geen durable marker voor de quality-DB (probe leest alleen runtime_coordination.db).
+- **OI-564 | BESTAAT-GROOT** — `_seed_default_pool_config` (nu init_cmd.py:433-505) gebruikt nog impliciete transactie; explicit-BEGIN is optionele design-wijziging.
+- **OI-579, OI-636, OI-653 | BESTAAT-GROOT** — planning_cli.py 2593L, tmux_interactive_dispatch.py 2865L, test_tmux_interactive_dispatch.py 4648L; alle drie nog over de advisory-grens; monoliet-splitsing is grote refactor.
+- **OI-621 | BESTAAT-GROOT** — geen continue content-convergentie-assertie voor role-orchestrator.md; bouwstenen (registry-iteratie in t0_role_audit.sh, cmp in cmd_role_sync) bestaan wel.
+- **OI-629 | BESTAAT-GROOT** — merge-flow-codificatie + role escape-hatch afwezig in de canonieke role; MC/SC-delen in andere repos, hier niet te verifiëren.
+
+## Changes
+
+- `scripts/lib/tmux_interactive_dispatch.py`: module-level `from pr_enforcement import PrEnforcementResult`; redundante deferred import in `_enforce_pr_exists` verwijderd.
+- `tests/test_tmux_pr_enforcement_annotation_resolves.py`: nieuw, OI-288-patroon.
+
+## Open Items
+
+- OI-561, OI-562, OI-563, OI-564, OI-579, OI-621, OI-629, OI-636, OI-653 blijven open als BESTAAT-GROOT.
+- Pre-bestaande test-failures op main (niet door deze dispatch): `test_open_items_gate_certification.py::test_read_gate_config_returns_dict` (T8), `test_tmux_adapter_interface.py::test_shutdown_is_noop` + `test_no_direct_tmux_in_protected_modules` (geverifieerd pre-existent via stash-revert).

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -39,6 +39,10 @@ if sys_path_dir not in sys.path:
 logger = logging.getLogger(__name__)
 
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
+# OI-645: PrEnforcementResult must be a module-level binding — the
+# _enforce_pr_exists return annotation resolves it at introspection time
+# (get_type_hints), not only on the deferred-import exception path.
+from pr_enforcement import PrEnforcementResult  # noqa: E402
 
 # Capability scoping (interim, per WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4/§5):
 # detached ephemeral spawns run under the blanket --dangerously-skip-permissions
@@ -935,7 +939,6 @@ class TmuxInteractiveDispatch:
             logger.error(
                 "interactive: PR-enforcement guard errored dispatch=%s: %s", dispatch_id, exc,
             )
-            from pr_enforcement import PrEnforcementResult  # noqa: PLC0415
             return PrEnforcementResult(applicable=False, ok=True, reason=f"guard error: {exc}")
 
         if not result.applicable:

--- a/tests/test_tmux_pr_enforcement_annotation_resolves.py
+++ b/tests/test_tmux_pr_enforcement_annotation_resolves.py
@@ -1,0 +1,31 @@
+"""OI-645: _enforce_pr_exists return annotation must resolve.
+
+The F821 undefined-name finding on ``PrEnforcementResult`` (ruff,
+scripts/lib/tmux_interactive_dispatch.py) was not just lint noise:
+``typing.get_type_hints`` on the affected signature raised ``NameError``
+because the name was only imported on a deferred exception path inside the
+function body, never bound at module scope. Any introspection of the
+signature (docs, dispatch-door type checks) would crash.
+
+Fails on the pre-fix code (get_type_hints -> NameError) and passes once the
+module-level import of PrEnforcementResult lands in
+scripts/lib/tmux_interactive_dispatch.py.
+"""
+
+from __future__ import annotations
+
+import typing
+
+import pytest
+
+import tmux_interactive_dispatch  # type: ignore[import-not-found]
+
+
+def test_enforce_pr_exists_return_annotation_resolves():
+    """get_type_hints on the OI-645-flagged signature must resolve."""
+    func = tmux_interactive_dispatch.TmuxInteractiveDispatch._enforce_pr_exists
+    try:
+        hints = typing.get_type_hints(func)
+    except NameError as exc:  # unresolved annotation name (pre-fix failure)
+        pytest.fail(f"_enforce_pr_exists: unresolved annotation name: {exc}")
+    assert hints["return"] is not None


### PR DESCRIPTION
## Wat dit is

Triage-ronde T9: twaalf oude open items (OI-561, 562, 563, 564, 579, 621, 628, 629, 636, 645, 653, 655) getoetst op een verse worktree vanaf `origin/main`. Dit is primair een meet-opdracht: per item gereproduceerd of het beschreven gedrag er nog is, met bewijs.

## Verdicts

- **OI-645 | BESTAAT-KLEIN → gefixt**: F821 `PrEnforcementResult` (ruff) + `get_type_hints` NameError op `_enforce_pr_exists`. Fix: module-level import + test die rood staat op main (`tests/test_tmux_pr_enforcement_annotation_resolves.py`, OI-288-patroon).
- **OI-628 | ACHTERHAALD** (betekenis gewijzigd): lokale sidecar-anchor is vervangen door de ADR-034 git-anchor (implementatie aanwezig, `fabric_audit.py:373` draait de anchor-aware verify; nog niet geactiveerd — VNX_CHAIN_RECEIPTS default-off).
- **OI-655 | ACHTERHAALD** (betekenis gewijzigd): contract-injectie live (06-23), post-OI 07-17 staleness-window + 07-27/28 govern-synthese (SynthesizedLaneReceipt) dichten de resterende gap. De 36x-telling is alleen in de SEOcrawler-v2 store te her-meten.
- **OI-561, 562, 563, 564, 579, 621, 629, 636, 653 | BESTAAT-GROOT**: gemeten en gelaten. Operator/ontwerpbeslissingen (gate-flip, durable marker voor ux_*_pid, convergentie-checker, monoliet-splitsing, fleet-follow-ups).

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`: module-level `from pr_enforcement import PrEnforcementResult`, redundante deferred import verwijderd.
- `tests/test_tmux_pr_enforcement_annotation_resolves.py`: nieuw, rood-op-main-test.
- `docs/investigations/20260801-t9-oi-triage-ledger-existence.md`: repo-side triage-samenvatting.

Volledige bewijslast: `unified_reports/20260801-t9-oi-triage.md`.

## Verification

- `ruff check scripts/lib/tmux_interactive_dispatch.py` → All checks passed (was: F821).
- `get_type_hints(TmuxInteractiveDispatch._enforce_pr_exists)` → resolveert (was: NameError).
- Nieuwe test: rood op main (verifieerd via stash-revert), groen na fix. 10/10 in test_pr_enforcement + nieuwe test.
- Geen nieuwe test-breuken door deze change: 2 failures in `test_tmux_adapter_interface.py` zijn pre-existent op main (verifieerd via stash-revert).
- Pre-bestaande (niet gerelateerde) main-failure elders: `test_open_items_gate_certification.py::test_read_gate_config_returns_dict` (zie T8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)