### PR TITLE
fix(dispatch,update): route receipts to active project store + reference-safe prune (OI-900, OI-912)

### DIFF
--- a/scripts/check_no_file_derived_data_paths.py
+++ b/scripts/check_no_file_derived_data_paths.py
@@ -179,10 +179,15 @@ GRANDFATHERED: Dict[str, Set[str]] = {
 # plan-gate datadir dispatch, 2026-07-31); the sites below are grandfathered so
 # the gate can block NEW occurrences while each is migrated in follow-up work.
 # Assessment per site (kept deliberately, with rationale):
-#   - tmux_interactive_dispatch / staging_validator / lease_sweep: dispatch-door
-#     lane code with its own governed test surface; the door threads explicit
-#     dirs in the governed path and these fallbacks fire only on the un-threaded
-#     path. Migrating them belongs with the door owners, not the plan-gate fix.
+#   - tmux_interactive_dispatch: MIGRATED in OI-900 (#1308). _resolve_state_dir
+#     no longer feeds __file__ to the resolver; it honors the explicit
+#     VNX_DATA_DIR override and otherwise anchors on the invocation project root
+#     via vnx_paths.resolve_state_dir. Dropped from the list, as the gate
+#     requires of a migrated site.
+#   - staging_validator / lease_sweep: dispatch-door lane code with its own
+#     governed test surface; the door threads explicit dirs in the governed path
+#     and these fallbacks fire only on the un-threaded path. Migrating them
+#     belongs with the door owners, not the plan-gate fix.
 #   - worker_permission_relay: last-resort except-branch AFTER vnx_paths.ensure_env()
 #     (the VNX_HOME+marker-aware resolver) failed — mirrors the grandfathered
 #     defensive-fallback pattern above.
@@ -194,9 +199,6 @@ GRANDFATHERED: Dict[str, Set[str]] = {
 # mkdirs events/ per dispatch — so it was fixed in the same dispatch instead of
 # grandfathered: it now mirrors provider_dispatch._resolve_data_dir.)
 GRANDFATHERED_RESOLVER_ANCHORS: Dict[str, Set[str]] = {
-    "scripts/lib/tmux_interactive_dispatch.py": {
-        "resolve_state_dir(caller_file=__file__)",
-    },
     "scripts/lib/staging_validator.py": {
         "resolve_data_dir(caller_file=__file__)",
     },

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -96,12 +96,23 @@ def _resolve_data_dir() -> Path:
     VNX_DATA_DIR override is honored ONLY when VNX_DATA_DIR_EXPLICIT=1 is also set
     (same guard as project_root.resolve_data_dir) to prevent cross-project pollution
     from inherited shell environments. Fixes OI-126.
+
+    The project_id comes from the canonical resolver (VNX_PROJECT_ID env >
+    nearest ``.vnx-project-id`` marker > git remote), never a hardcoded default.
+    The old ``os.environ.get("VNX_PROJECT_ID", "vnx-dev")`` silently routed every
+    dispatch that did not export VNX_PROJECT_ID into the vnx-dev store, while the
+    event stream (event_store._events_dir) resolved the same context marker-aware
+    — the OI-900 split that polluted ``~/.vnx-data/vnx-dev/unified_reports`` with
+    21 mission-control plan-gate receipts/reports. An unresolvable project fails
+    closed (raises) rather than guessing (ADR-007), matching
+    ``dispatch_cli._resolve_project_id``.
     """
     explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
     explicit_val = os.environ.get("VNX_DATA_DIR", "")
     if explicit_flag and explicit_val:
         return Path(explicit_val).resolve()
-    project_id = os.environ.get("VNX_PROJECT_ID", "vnx-dev")
+    from project_root import resolve_project_id  # noqa: PLC0415
+    project_id = resolve_project_id()
     return Path.home() / ".vnx-data" / project_id
 
 
@@ -2346,7 +2357,7 @@ def main(argv: list[str] | None = None) -> int:
             )
             return 1
         _ctx = _dm.DispatchContext(
-            project_id=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+            project_id=_resolve_data_dir().name,
             session_id=getattr(args, "session_id", None) or os.environ.get("VNX_SESSION_ID"),
             task_class=getattr(args, "task_class", None) or None,
             dispatch_id=args.dispatch_id,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2716,9 +2716,31 @@ class TmuxInteractiveDispatch:
 # CLI — single-shot dispatch entry point
 # ---------------------------------------------------------------------------
 def _resolve_state_dir() -> Path:
-    """Delegate to canonical project_root resolver; ensures lane and append_receipt share the same state dir."""
-    from project_root import resolve_state_dir
-    return resolve_state_dir(caller_file=__file__)
+    """Resolve the lane's runtime state dir, honoring the explicit override and
+    otherwise anchoring on the INVOCATION project root — never the lane code's
+    on-disk location.
+
+    In central-install mode the lane code lives under
+    ``~/.vnx-system/versions/<v>/scripts/lib/``. Deriving the state root from
+    ``__file__`` collapsed every plan-gate receipt/report into the version-dir's
+    local ``.vnx-data`` (OI-900) — a tree ``vnx update`` later pruned (OI-912),
+    destroying the audit trail.
+
+    Resolution order:
+      1. ``VNX_DATA_DIR_EXPLICIT=1`` + ``VNX_DATA_DIR`` — explicit override
+         (test isolation / CI / worktree isolation), same two-key contract as
+         ``project_root.resolve_state_dir``.
+      2. The invocation project root (VNX_PROJECT_ROOT shim > CWD git > lane
+         repo — the same chain as ``_resolve_invocation_project_root``) is the
+         operator's project, so its ``.vnx-data/state`` is the correct runtime
+         root and matches what ``append_receipt`` resolves from that context.
+    """
+    explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
+    explicit_val = os.environ.get("VNX_DATA_DIR", "")
+    if explicit_flag and explicit_val:
+        return Path(explicit_val).expanduser().resolve() / "state"
+    from vnx_paths import resolve_state_dir as resolve_vnx_state_dir
+    return resolve_vnx_state_dir(_resolve_invocation_project_root())
 
 
 def _resolve_invocation_project_root() -> Path:

--- a/tests/test_provider_dispatch_governance_integration.py
+++ b/tests/test_provider_dispatch_governance_integration.py
@@ -456,12 +456,50 @@ def test_resolve_data_dir_explicit_flag_honors_vnx_data_dir(tmp_path, monkeypatc
     assert result == (tmp_path / "override").resolve()
 
 
-def test_resolve_data_dir_default_project_id(monkeypatch):
-    """_resolve_data_dir defaults to project_id='vnx-dev' when VNX_PROJECT_ID unset."""
+def test_resolve_data_dir_marker_aware_no_vnx_project_id(tmp_path, monkeypatch):
+    """_resolve_data_dir must resolve the ACTIVE project from the .vnx-project-id
+    marker, never hardcode vnx-dev when VNX_PROJECT_ID is unset.
+
+    Regression for OI-900: the plan-gate panel runs provider_dispatch in a
+    subprocess that inherits no VNX_PROJECT_ID. With a mission-control marker in
+    the invocation CWD the old resolver returned ~/.vnx-data/vnx-dev — the
+    cross-project split that polluted the vnx-dev store with 21 mission-control
+    plan-gate receipts — while the event stream (event_store, marker-aware)
+    correctly landed in ~/.vnx-data/mission-control.
+    """
+    project = tmp_path / "mission-control"
+    project.mkdir()
+    (project / ".vnx-project-id").write_text("mission-control\n")
+
+    monkeypatch.chdir(project)
     monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
     monkeypatch.delenv("VNX_DATA_DIR", raising=False)
     monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
 
     result = provider_dispatch._resolve_data_dir()
 
-    assert result == Path.home() / ".vnx-data" / "vnx-dev"
+    expected = Path.home() / ".vnx-data" / "mission-control"
+    assert result == expected, (
+        f"Expected central store {expected}, got {result}. "
+        "OI-900: provider_dispatch must route reports/receipts to the ACTIVE "
+        "project's store, not the vnx-dev default."
+    )
+
+
+def test_resolve_data_dir_no_project_context_fails_closed(tmp_path, monkeypatch):
+    """With no VNX_PROJECT_ID and no resolvable project context, _resolve_data_dir
+    must raise instead of silently defaulting to vnx-dev (ADR-007 fail-closed).
+
+    The old hardcoded default could not distinguish 'the vnx-dev project' from
+    'no project context at all', so a stray headless run in a bare directory
+    contaminated the vnx-dev store (OI-900)."""
+    bare = tmp_path / "bare"
+    bare.mkdir()
+
+    monkeypatch.chdir(bare)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    with pytest.raises(RuntimeError, match="Cannot resolve project_id"):
+        provider_dispatch._resolve_data_dir()

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -33,7 +33,6 @@ from tmux_interactive_dispatch import (
     _default_launch_command,
     _resolve_invocation_project_root,
     _resolve_state_dir,
-    _sanitize_session_name,
     main,
 )
 from tmux_worktree import ReapResult, WorktreeAllocateError, WorktreeHandle
@@ -910,7 +909,7 @@ class TestCompletionProtocolIntegration(_LaneTestCase):
             # Both blocks must have the correct env prefix and python3 path.
             for block_idx, expected_status in ((0, "done"), (1, "failed")):
                 block = _extract_protocol_block(protocol, block_idx)
-                self.assertIn(f"VNX_STATE_DIR=", block)
+                self.assertIn("VNX_STATE_DIR=", block)
                 self.assertIn(str(state_dir), block)
                 self.assertIn(str(tmp_path), block)
 
@@ -1023,6 +1022,54 @@ class TestStateDirMatchesCanonical(unittest.TestCase):
             lane_path,
             f"MISMATCH: lane={lane_path!r} != canonical={canonical_path!r}",
         )
+
+
+class TestStateDirInvocationAware(unittest.TestCase):
+    """Central-mode guard: _resolve_state_dir must follow the INVOCATION project
+    root, not the lane code's __file__.
+
+    In central-install mode the lane code lives under
+    ~/.vnx-system/versions/<v>/scripts/lib/. Deriving the state root from
+    __file__ collapsed every plan-gate receipt/report into the version-dir's
+    local .vnx-data (OI-900) — a tree 'vnx update' later pruned (OI-912),
+    destroying the audit trail.
+    """
+
+    def setUp(self) -> None:
+        self._saved_env = {
+            k: os.environ.get(k)
+            for k in ("VNX_PROJECT_ROOT", "VNX_PROJECT_ID", "VNX_DATA_DIR",
+                      "VNX_DATA_DIR_EXPLICIT", "VNX_STATE_DIR")
+        }
+        for k in ("VNX_PROJECT_ROOT", "VNX_PROJECT_ID", "VNX_DATA_DIR",
+                  "VNX_DATA_DIR_EXPLICIT", "VNX_STATE_DIR"):
+            os.environ.pop(k, None)
+        self._cwd = Path.cwd()
+
+    def tearDown(self) -> None:
+        os.chdir(self._cwd)
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_state_dir_follows_vnx_project_root_not_file(self):
+        """VNX_PROJECT_ROOT (central-install shim export) must anchor the lane
+        state dir — even though the lane code's __file__ lives in the shared
+        engine tree (a git repo whose top-level is NOT the operator's project)."""
+        with tempfile.TemporaryDirectory() as tmp:
+            project = Path(tmp).resolve()
+            os.environ["VNX_PROJECT_ROOT"] = str(project)
+
+            resolved = _resolve_state_dir()
+
+            self.assertEqual(
+                resolved,
+                (project / ".vnx-data" / "state").resolve(),
+                "central-mode lane state dir must resolve from the invocation "
+                "project root, never the lane code's __file__ location",
+            )
 
 
 class TestInvocationProjectRootResolution(unittest.TestCase):
@@ -1806,7 +1853,6 @@ class TestSharedPrepareWiringTmux(unittest.TestCase):
 
     def test_shared_prepare_1_smart_context_prepended(self):
         """VNX_SHARED_PREPARE=1: smart_context is prepended before the prepare() body."""
-        from dispatch_prepare import _WORKER_RULES_FOOTER_SENTINEL
         lane = self._make_lane()
         fake_skill = "SKILL_BODY"
         fake_perm = "PREAMBLE\n---\n\n" + fake_skill
@@ -2728,7 +2774,6 @@ class TestSubmitVerify(_LaneTestCase):
 
     def test_settle_and_retry_timeouts_read_from_env(self):
         """VNX_TMUX_PASTE_SETTLE_SECONDS / SUBMIT_RETRY_DELAY / SUBMIT_VERIFY_TIMEOUT read from env."""
-        import time as _time
         fake = FakeTmux(
             receipts_file=self.receipts_file,
             dispatch_id=self.DISPATCH_ID,

--- a/tests/test_vnx_cli_update.py
+++ b/tests/test_vnx_cli_update.py
@@ -885,6 +885,109 @@ def test_prune_protection_ignores_malformed_entries(tmp_path, monkeypatch, capsy
     assert "malformed protected version" in captured.err
 
 
+# ---------------------------------------------------------------------------
+# OI-912: prune must not silently delete a version-dir something still points at
+# (pip-install / symlink references), even when no .vnx-version pin exists.
+# ---------------------------------------------------------------------------
+
+def test_prune_protects_pip_editable_direct_url(tmp_path, monkeypatch):
+    """A pip editable install whose direct_url.json names the version dir must
+    protect it from prune — the OI-912 incident (global vnx_cli console script
+    was `pip install -e versions/edge`; pruning edge broke `vnx --version`)."""
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    fake_site = tmp_path / "fake-site-packages"
+    dist_info = fake_site / "vnx_orchestration-1.3.0.dist-info"
+    dist_info.mkdir(parents=True)
+    (dist_info / "direct_url.json").write_text(
+        json.dumps(
+            {
+                "dir_info": {"editable": True},
+                "url": f"file://{tmp_path}/versions/v1.0.1",
+            }
+        ),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(update_module, "_iter_site_packages_dirs", lambda: [fake_site])
+
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    output = buf.getvalue()
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    # v1.0.1 referenced by the pip editable install -> protected, NOT pruned.
+    assert remaining == ["v1.0.1", "v1.0.3", "v1.0.4", "v1.0.5"]
+    assert "Protected from prune" in output
+    assert "pip install vnx_orchestration-1.3.0.dist-info" in output
+
+    events = _audit_events(audit_log)
+    protected = [
+        e for e in events if e["event_type"] == "central_install_prune_protected"
+    ]
+    assert len(protected) == 1
+    assert protected[0]["protected_version"] == "v1.0.1"
+    assert any("pip install" in r for r in protected[0]["reasons"])
+
+
+def test_prune_protects_pip_editable_pth(tmp_path, monkeypatch):
+    """A *.pth / __editable__ finder whose content names the version dir must
+    protect it — the second shape a pip -e install leaves in site-packages."""
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    fake_site = tmp_path / "fake-site-packages"
+    fake_site.mkdir(parents=True)
+    (fake_site / "__editable__.vnx_orchestration-1.3.0.pth").write_text(
+        "import __editable___vnx_orchestration_1_3_0_finder; "
+        "__editable___vnx_orchestration_1_3_0_finder.install()",
+        encoding="utf-8",
+    )
+    (fake_site / "__editable___vnx_orchestration_1_3_0_finder.py").write_text(
+        f"MAPPING = {{'vnx_cli': '{tmp_path}/versions/v1.0.1'}}\n",
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(update_module, "_iter_site_packages_dirs", lambda: [fake_site])
+
+    _prune_old_versions(tmp_path, keep_last=3, dry_run=False)
+
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == ["v1.0.1", "v1.0.3", "v1.0.4", "v1.0.5"]
+
+
+def test_prune_protects_symlink_reference(tmp_path, monkeypatch):
+    """A symlink under the central install root that points into a version dir
+    must protect it — a bin/ shim or legacy alias must not dangle after prune."""
+    _empty_registry(tmp_path, monkeypatch)
+    names = ["v1.0.1", "v1.0.2", "v1.0.3", "v1.0.4", "v1.0.5"]
+    _version_dirs(tmp_path, names)
+
+    (tmp_path / "bin").mkdir()
+    (tmp_path / "bin" / "vnx").symlink_to(tmp_path / "versions" / "v1.0.1")
+
+    audit_log = tmp_path / "events" / "central_install.ndjson"
+    buf = io.StringIO()
+    with redirect_stdout(buf):
+        _prune_old_versions(tmp_path, keep_last=3, dry_run=False, audit_log=audit_log)
+
+    output = buf.getvalue()
+    remaining = sorted(d.name for d in (tmp_path / "versions").iterdir())
+    assert remaining == ["v1.0.1", "v1.0.3", "v1.0.4", "v1.0.5"]
+    assert "symlink" in output
+
+    events = _audit_events(audit_log)
+    protected = [
+        e for e in events if e["event_type"] == "central_install_prune_protected"
+    ]
+    assert len(protected) == 1
+    assert protected[0]["protected_version"] == "v1.0.1"
+    assert any("symlink" in r for r in protected[0]["reasons"])
+
+
 def test_collect_protected_versions_normalizes_v_prefix(tmp_path, monkeypatch):
     _empty_registry(tmp_path, monkeypatch)
     protected = _collect_protected_versions(tmp_path, protect_pins="v1.3.0,1.2.3")

--- a/vnx_cli/commands/update.py
+++ b/vnx_cli/commands/update.py
@@ -428,6 +428,153 @@ def _collect_protected_versions(
     return protected
 
 
+def _iter_site_packages_dirs() -> list:
+    """Candidate site-packages roots to scan for pip-install pointers.
+
+    Covers the interpreter's global + user site-packages, plus any ``sys.path``
+    entry whose basename is ``site-packages``/``dist-packages`` (venvs, extra
+    prefixes). Deduplicated, resolved, best-effort — an import failure returns
+    an empty list so a prune never fails on an exotic interpreter.
+    """
+    try:
+        import site as _site
+
+        candidates = list(_site.getsitepackages())
+        user = _site.getusersitepackages()
+        if user:
+            candidates.append(user)
+    except Exception:  # vnx-silent-except: site introspection is best-effort
+        candidates = []
+    for entry in sys.path:
+        if Path(entry).name in ("site-packages", "dist-packages"):
+            candidates.append(entry)
+    seen = set()
+    out = []
+    for raw in candidates:
+        try:
+            resolved = str(Path(raw).expanduser().resolve())
+        except OSError:
+            continue
+        if resolved not in seen:
+            seen.add(resolved)
+            out.append(Path(resolved))
+    return out
+
+
+_PATH_TOKEN_RE = re.compile(r"/[^\s'\"()<>\[\]{}]+")
+
+
+def _text_references_dir(text: str, version_dir: Path) -> bool:
+    """True when ``text`` mentions a path that resolves to ``version_dir``.
+
+    Handles raw absolute paths, ``~/``-forms and ``file://`` URLs, and tolerates
+    symlink aliasing (macOS ``/tmp`` -> ``/private/tmp``): the comparison is
+    done on ``Path.resolve()`` of both sides, never on the raw string.
+    """
+    vdir = version_dir.resolve()
+    try:
+        from urllib.parse import unquote, urlparse
+
+        for m in re.finditer(r"file://([^\s'\"()<>\[\]{}]+)", text):
+            raw = unquote(urlparse(m.group(1)).path)
+            try:
+                if Path(raw).expanduser().resolve() == vdir:
+                    return True
+            except OSError:
+                continue
+    except ImportError:
+        pass
+    for m in _PATH_TOKEN_RE.finditer(text):
+        token = m.group(0)
+        if token == "/" or ".." in token:
+            continue
+        try:
+            if Path(token).expanduser().resolve() == vdir:
+                return True
+        except OSError:
+            continue
+    return False
+
+
+def _pip_install_references_to(version_dir: Path) -> list:
+    """Reasons a pip install in the current interpreter maps into ``version_dir``.
+
+    Scans site-packages for the three shapes a pip install leaves behind when it
+    targets a version dir:
+      1. ``<pkg>-*.dist-info/direct_url.json`` — pip records ``url`` pointing at
+         the install source; an editable install keeps the ORIGINAL source dir
+         (OI-912: the global ``vnx_cli`` console script was ``pip install -e
+         versions/edge`` and ``direct_url.json`` still named ``versions/edge``
+         after the dir was pruned).
+      2. ``*.pth`` files whose content mentions the dir (path-based installs).
+      3. ``__editable__*.py`` finder modules whose MAPPING mentions the dir.
+
+    Pruning a dir any of these reference breaks the install silently — that is
+    the exact silent-catastrophe the GC-protect protection set exists to avoid.
+    """
+    reasons = []
+    for site in _iter_site_packages_dirs():
+        if not site.is_dir():
+            continue
+        # 1. dist-info direct_url.json
+        try:
+            dist_infos = list(site.glob("*.dist-info"))
+        except OSError:
+            dist_infos = []
+        for di in dist_infos:
+            direct_url = di / "direct_url.json"
+            if not direct_url.is_file():
+                continue
+            try:
+                data = json.loads(direct_url.read_text(encoding="utf-8"))
+            except (OSError, UnicodeDecodeError, json.JSONDecodeError):
+                continue
+            url = (data or {}).get("url", "") or ""
+            if _text_references_dir(url, version_dir):
+                reasons.append(f"pip install {di.name} -> {url}")
+        # 2. + 3. .pth files and __editable__ finder modules
+        try:
+            pth_files = list(site.glob("*.pth")) + list(site.glob("__editable__*.py"))
+        except OSError:
+            continue
+        for pth in pth_files:
+            try:
+                text = pth.read_text(encoding="utf-8")
+            except (OSError, UnicodeDecodeError):
+                continue
+            if _text_references_dir(text, version_dir):
+                reasons.append(f"pip editable {pth.name} references {version_dir}")
+    return reasons
+
+
+def _symlink_references_to(root: Path, version_dir: Path) -> list:
+    """Reasons a symlink under the central install root points into ``version_dir``.
+
+    Walks the central install tree (``~/.vnx-system``) WITHOUT following symlinks
+    and records any symlink whose resolved target is the version dir or sits
+    inside it. ``current`` is handled separately by ``_prune_old_versions`` (it
+    is never a prune candidate), but a bin/ shim or a legacy alias symlink that
+    points at a version dir must protect it too (OI-912).
+    """
+    reasons = []
+    vdir = version_dir.resolve()
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            for name in list(dirnames) + list(filenames):
+                entry = Path(dirpath) / name
+                try:
+                    if not entry.is_symlink():
+                        continue
+                    target = entry.resolve()
+                    if target == vdir or vdir in target.parents:
+                        reasons.append(f"symlink {entry} -> {target}")
+                except OSError:
+                    continue
+    except OSError:
+        pass
+    return reasons
+
+
 def _prune_old_versions(
     root: Path,
     keep_last: int,
@@ -472,7 +619,15 @@ def _prune_old_versions(
     for version_dir in to_prune:
         if current and version_dir.resolve() == current.resolve():
             continue
-        reasons = sorted(protected.get(_normalize_version(version_dir.name), ()))
+        reasons = set(protected.get(_normalize_version(version_dir.name), ()))
+        # OI-912: a pip-install or symlink that maps into this version dir is a
+        # live reference — pruning it silently breaks that install (the global
+        # vnx_cli console script died with ModuleNotFoundError when update
+        # removed versions/edge). Fail-loud is too blunt (the update to the NEW
+        # version is fine); protect the referenced dir with a clear message.
+        reasons.update(_pip_install_references_to(version_dir))
+        reasons.update(_symlink_references_to(root, version_dir))
+        reasons = sorted(reasons)
         if reasons:
             reason_text = "; ".join(reasons)
             if dry_run:


### PR DESCRIPTION
## OI-900 — cross-project receipt pollution, LIVE

21 plan-gate receipts landed in `~/.vnx-data/vnx-dev/unified_reports/` and 29 in `versions/edge/.vnx-data/` because two receipt writers resolved the runtime root **without the active project context**:

- **`provider_dispatch._resolve_data_dir()`** hardcoded a `"vnx-dev"` fallback when `VNX_PROJECT_ID` was unset, while `event_store._events_dir()` resolved the same invocation context marker-aware. Measured: with a `mission-control` `.vnx-project-id` marker in CWD and `VNX_PROJECT_ID` unset, `project_root.resolve_project_id()` returns `mission-control` but the old resolver returned `~/.vnx-data/vnx-dev`. It now delegates to `resolve_project_id()` (env > marker > git remote) and fails closed (ADR-007), matching `dispatch_cli._resolve_project_id`.
- **`tmux_interactive_dispatch._resolve_state_dir()`** derived the state root from `__file__`, which in central-install mode is the shared `~/.vnx-system/versions/<v>/` tree. It now honors the explicit `VNX_DATA_DIR` override and otherwise anchors on the invocation project root (the same chain already used for the lane's `project_root`).

## OI-912 — prune must not delete a referenced version dir

`vnx update --to v1.4.1` deleted `versions/edge` + `versions/v1.3.0` while the global `vnx_cli` console script still pointed at `edge` via a pip editable install — `vnx --version` died with `ModuleNotFoundError`. `_prune_old_versions` now scans each prune candidate for live pip-install references (`dist-info/direct_url.json`, `*.pth`, `__editable__` finders) and symlinks under the central install root, and protects the referenced dir with a clear message + audit event.

## Verification

- Six new tests, all **red on origin/main**, green here.
- OI-912 scratch-pad demo on a rebuilt structure (`/tmp`, never `~/.vnx-system/`): pip-referenced and symlink-referenced version dirs both survived the prune.
- `tests/test_vnx_cli_update.py`: 71 passed.
- The 18 `test_provider_dispatch_governance_integration.py` failures are byte-identical to the origin/main baseline (pre-existing); zero new failures introduced.
- `ruff check` on changed source files: clean.
- `~/.vnx-system/` and the real central stores untouched (read-only; `central_install.ndjson` mtime unchanged).

## Open Items (operator)

- The 21 receipts in `~/.vnx-data/vnx-dev/unified_reports/` must be relocated/re-attributed to mission-control (not deleted); quarantine backup at `~/.vnx-data/_quarantine/edge-unique-20260731/` preserves the version-dir receipts.
- `dispatch_envelope.py:1462` still hardcodes `project_id="vnx-dev"` for the local-gemma provider (out of the measured leak, flagged for follow-up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)