### PR TITLE
fix(dispatch): central-state-dir worktree claims (OI-861) + awaiting_permission detection (OI-863)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -18,8 +18,8 @@ worker's own dispatch id fails loud instead of running for 25 minutes on the
 wrong identity.
 
 The claim REGISTRY lives under the canonical state root resolved by
-``vnx_paths.resolve_paths()["VNX_STATE_DIR"]`` — the ADR-026 SSOT, not a
-per-checkout ``<repo>/.vnx-data/state``.  A claim map that must serialize two
+``vnx_paths.resolve_data_root(project_root) / "state"`` — the ADR-026 SSOT, not
+a per-checkout ``<repo>/.vnx-data/state``.  A claim map that must serialize two
 concurrent dispatches has to be visible from BOTH racing contexts (the main
 checkout and the dispatch worktree); a repo-local pin would fork the registry
 exactly as far apart as the racing worktrees are, and the OI-861 race would

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -4,16 +4,38 @@ Feature-flag gated: only active when VNX_ISOLATED_WORKTREE=1.
 Each dispatch gets a fresh worktree rooted at origin/main under
 .vnx-data/worktrees/dispatch-{safe_id}/.  The worktree is removed
 (success OR failure) so no state leaks between dispatches.
+
+Dispatch-identity binding (OI-861):
+A worktree's path is derived from the dispatch id, but the path alone does
+not prove identity.  Two dispatches fired back-to-back on the same lane can
+cross: one worker ends up in the other's worktree and — worst case — one
+completion reaps the other's still-live worktree.  Every worktree created
+here is therefore STAMPED with an atomic dispatch-id claim (O_EXCL), keyed on
+the SAFE dispatch id, mirroring ``dispatch_process_registry``.
+``verify_worktree_identity()`` is the hard refusal a worker must call before
+doing any work in an offered worktree: a stamped id that differs from the
+worker's own dispatch id fails loud instead of running for 25 minutes on the
+wrong identity.
+
+The claim REGISTRY lives under the canonical state root resolved by
+``vnx_paths.resolve_paths()["VNX_STATE_DIR"]`` — the ADR-026 SSOT, not a
+per-checkout ``<repo>/.vnx-data/state``.  A claim map that must serialize two
+concurrent dispatches has to be visible from BOTH racing contexts (the main
+checkout and the dispatch worktree); a repo-local pin would fork the registry
+exactly as far apart as the racing worktrees are, and the OI-861 race would
+run straight through it (PR #1274 review).
 """
 
 from __future__ import annotations
 
 import fcntl
+import json
 import logging
 import os
 import re
 import shutil
 import subprocess
+import time
 from contextlib import contextmanager
 from pathlib import Path
 from typing import Optional
@@ -43,6 +65,29 @@ class CentralInstallWorktreeError(RuntimeError):
     """
 
 
+class WorktreeClaimError(RuntimeError):
+    """Base class for dispatch-worktree identity/claim failures (OI-861)."""
+
+
+class WorktreeIdentityConflict(WorktreeClaimError):
+    """The worktree is already claimed by a DIFFERENT dispatch id.
+
+    This is the OI-861 crossing: a worker being offered a worktree that is
+    stamped for another dispatch.  The worker MUST stop — running on the wrong
+    identity delivers nothing and can have its worktree reaped mid-flight by
+    the other dispatch's completion.
+    """
+
+
+class WorktreeIdentityMissing(WorktreeClaimError):
+    """The worktree carries no dispatch-id claim at all.
+
+    Identity cannot be verified, so a worker must not operate in it.  A missing
+    claim means the worktree predates the stamping mechanism or was created by
+    a lane that does not stamp — either way it is not provably this dispatch's.
+    """
+
+
 def _is_central_install_path(path: Path) -> bool:
     try:
         path.resolve().relative_to(_CENTRAL_INSTALL_ROOT.resolve())
@@ -68,6 +113,235 @@ def _dispatch_worktree_dir(project_root: Path, dispatch_id: str) -> Path:
     if root_override:
         return Path(root_override).expanduser().resolve() / f"dispatch-{safe_id}"
     return project_root / ".vnx-data" / "worktrees" / f"dispatch-{safe_id}"
+
+
+# ---------------------------------------------------------------------------
+# Dispatch-id claim registry (OI-861)
+#
+# A worktree's identity is its CLAIM, not its path.  One JSON entry per
+# sanitized dispatch id under the canonical state root
+# (``vnx_paths.resolve_data_root(project_root) / "state"`` /
+# ``dispatch_worktree_claims``) — the ADR-026 SSOT, shared by every checkout
+# and worktree of a project.  The claim is created with O_EXCL so exactly one
+# dispatch ever wins a given slot; every later reader compares the stamped
+# dispatch_id against its own before operating in or removing the worktree.
+# The registry must live OUTSIDE any single repo root: two racing dispatches
+# resolve their project roots to DIFFERENT checkouts, and a per-checkout claim
+# map serializes nothing between them — that fork is exactly the OI-861
+# crossing (PR #1274 review).  Anchoring on the project root via vnx_paths
+# keeps the claim map at the project's central state dir in production while
+# letting tests pin it to one shared temp dir with VNX_DATA_DIR_EXPLICIT=1.
+# ---------------------------------------------------------------------------
+
+def _claim_dir(project_root: Path) -> Path:
+    """Return the SHARED dispatch-worktree claim registry directory.
+
+    Resolved via ``vnx_paths.resolve_data_root(project_root)`` — the canonical
+    state-root resolver anchored on the given project root (ADR-026 SSOT), not
+    a hardcoded ``<repo>/.vnx-data/state``.  Honors ``VNX_DATA_DIR_EXPLICIT=1``
+    + ``VNX_DATA_DIR`` for tests and CI, so two simulated worktrees can share
+    one temp claim map.
+    """
+    from vnx_paths import resolve_data_root  # noqa: PLC0415
+    data_dir = Path(resolve_data_root(project_root))
+    return data_dir / "state" / "dispatch_worktree_claims"
+
+
+def _claim_path(safe_id: str, project_root: Path) -> Path:
+    return _claim_dir(project_root) / f"{safe_id}.json"
+
+
+def _read_claim_entry(safe_id: str, project_root: Path) -> "dict | None":
+    """Read the claim for *safe_id*; None when absent or corrupt (never raises)."""
+    path = _claim_path(safe_id, project_root)
+    try:
+        raw = path.read_text(encoding="utf-8")
+        entry = json.loads(raw)
+        if not isinstance(entry, dict):
+            return None
+        return entry
+    except FileNotFoundError:
+        return None
+    except (OSError, json.JSONDecodeError) as exc:
+        log.warning(
+            "dispatch_worktree_isolation: unreadable claim %s: %s — "
+            "treating as absent",
+            path,
+            exc,
+        )
+        return None
+
+
+def _read_claim(dispatch_id: str, project_root: Path) -> "dict | None":
+    return _read_claim_entry(_sanitize_dispatch_id(dispatch_id), project_root)
+
+
+def _write_claim_atomic(
+    dispatch_id: str,
+    *,
+    worktree_path: Path,
+    project_root: Path,
+) -> dict:
+    """Claim *worktree_path* for *dispatch_id* with an O_EXCL write.
+
+    This is the load-bearing atomicity of the identity binding: if the claim
+    file already exists the write fails and the caller must decide whether the
+    existing claim is the same dispatch (idempotent re-entry) or a different
+    one (OI-861 crossing → WorktreeIdentityConflict).
+    """
+    safe_id = _sanitize_dispatch_id(dispatch_id)
+    path = _claim_path(safe_id, project_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    claim = {
+        "dispatch_id": dispatch_id,
+        "safe_id": safe_id,
+        "worktree_path": str(Path(worktree_path).resolve()),
+        "claimed_at": time.time(),
+    }
+    try:
+        with open(path, "x", encoding="utf-8") as fh:
+            json.dump(claim, fh, indent=2, sort_keys=True)
+            fh.write("\n")
+    except FileExistsError:
+        raise WorktreeClaimError(
+            f"claim already exists for dispatch {dispatch_id!r} ({path})"
+        ) from None
+    log.info(
+        "dispatch worktree claimed: %s -> dispatch %s",
+        claim["worktree_path"],
+        dispatch_id,
+    )
+    return claim
+
+
+def _clear_claim(dispatch_id: str, project_root: Path) -> None:
+    """Remove the claim for *dispatch_id*.  Idempotent, never raises."""
+    try:
+        _claim_path(_sanitize_dispatch_id(dispatch_id), project_root).unlink(missing_ok=True)
+    except OSError as exc:
+        log.debug(
+            "dispatch_worktree_isolation: clear claim failed for %s: %s",
+            dispatch_id,
+            exc,
+        )
+
+
+def _claim_belongs_to_or_raise(
+    dispatch_id: str,
+    claim: dict,
+    worktree_path: Path,
+) -> None:
+    """Raise WorktreeIdentityConflict when *claim* is not *dispatch_id*'s.
+
+    The single canonical OI-861 refusal: a worktree already claimed by another
+    dispatch identity must never be reused — not by a second create, not by a
+    worker's verification, not by a teardown.
+    """
+    stamped_id = claim.get("dispatch_id")
+    if stamped_id != dispatch_id:
+        raise WorktreeIdentityConflict(
+            f"worktree {worktree_path} is already claimed by dispatch "
+            f"{stamped_id!r}, not {dispatch_id!r}; refusing — a worktree must "
+            f"never be shared by two dispatch identities"
+        )
+    recorded_path = claim.get("worktree_path")
+    if recorded_path:
+        recorded = Path(recorded_path).resolve()
+        if recorded != Path(worktree_path).resolve():
+            raise WorktreeClaimError(
+                f"worktree {worktree_path} is claimed by {dispatch_id!r} but "
+                f"the claim points at {recorded}; refusing"
+            )
+
+
+def _repo_root_from_worktree_path(worktree_path: Path) -> Path:
+    """Derive the project root from a standard dispatch-worktree path.
+
+    ``<root>/.vnx-data/worktrees/dispatch-<safe>`` → ``<root>``.  Worktrees
+    living under ``VNX_BENCH_WORKTREE_ROOT`` carry no structural marker, so
+    their callers must pass ``project_root`` explicitly.
+    """
+    resolved = Path(worktree_path).resolve()
+    if resolved.parent.name == "worktrees" and resolved.parent.parent.name == ".vnx-data":
+        return resolved.parent.parent.parent
+    raise WorktreeClaimError(
+        f"cannot derive the project root from worktree path {resolved}; "
+        f"pass project_root explicitly (the worktree may live under "
+        f"VNX_BENCH_WORKTREE_ROOT)"
+    )
+
+
+def verify_worktree_identity(
+    dispatch_id: str,
+    worktree_path: Path,
+    *,
+    project_root: "Optional[Path]" = None,
+) -> dict:
+    """Verify that *worktree_path* is stamped for *dispatch_id*.  Fail-loud.
+
+    A worker that is offered a worktree MUST call this before doing any work.
+    Operating in a worktree whose stamped dispatch id differs from its own is
+    the exact OI-861 failure that ran for 25 minutes and delivered nothing.
+
+    The claim is looked up by the safe id carved out of the WORKTREE'S OWN NAME
+    (``dispatch-<safe>``), not the caller's dispatch id — so a worker offered
+    the wrong worktree reads the owner's claim and gets a truthful
+    ``WorktreeIdentityConflict`` instead of a misleading "no claim".
+
+    Args:
+        project_root: the project root to anchor the claim-dir resolution on.
+            Defaults to the root derived from a standard dispatch-worktree
+            path (``<root>/.vnx-data/worktrees/dispatch-<safe>``).  Either way
+            the registry resolves to the project's canonical state dir, so a
+            worker in the worktree reads the same map the dispatcher wrote.
+
+    Raises:
+        WorktreeIdentityMissing: the worktree carries no dispatch-id claim.
+        WorktreeIdentityConflict: the worktree is stamped for a different
+            dispatch id (or the offered path is not a dispatch worktree).
+        WorktreeClaimError: the claim is corrupt or points at another path.
+
+    Returns the claim dict on success.
+    """
+    resolved_wt = Path(worktree_path).resolve()
+    if project_root is not None:
+        root = _resolve_project_root(project_root)
+    else:
+        root = _repo_root_from_worktree_path(resolved_wt)
+
+    name = resolved_wt.name
+    path_safe_id = (
+        name[len("dispatch-"):] if name.startswith("dispatch-") else ""
+    )
+    claim = (
+        _read_claim_entry(path_safe_id, root)
+        if path_safe_id
+        else _read_claim(dispatch_id, root)
+    )
+
+    if claim is None:
+        raise WorktreeIdentityMissing(
+            f"worktree {resolved_wt} carries no dispatch-id claim; refusing to "
+            f"operate in an unclaimed worktree (expected dispatch "
+            f"{dispatch_id!r})"
+        )
+
+    stamped_id = claim.get("dispatch_id")
+    if stamped_id != dispatch_id:
+        raise WorktreeIdentityConflict(
+            f"worktree {resolved_wt} is stamped for dispatch {stamped_id!r}, "
+            f"not {dispatch_id!r}; refusing to operate on the wrong identity"
+        )
+
+    recorded_path = claim.get("worktree_path")
+    if recorded_path:
+        recorded = Path(recorded_path).resolve()
+        if recorded != resolved_wt:
+            raise WorktreeClaimError(
+                f"worktree {resolved_wt} is claimed by {dispatch_id!r} but the "
+                f"claim points at {recorded}; refusing"
+            )
+    return claim
 
 
 def _resolve_project_root(project_root: Optional[Path]) -> Path:
@@ -177,8 +451,21 @@ def create_dispatch_worktree(
                 base_ref, (exc.stderr or "").strip(),
             )
 
-    try:
-        with _worktree_lock(root):
+    with _worktree_lock(root):
+        # OI-861 identity check BEFORE creating: if this worktree already exists
+        # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
+        # same-id re-entry (double-fire/retry) is idempotent and returns the
+        # existing, correctly-stamped worktree.
+        existing = _read_claim(dispatch_id, root)
+        if existing is not None:
+            _claim_belongs_to_or_raise(dispatch_id, existing, wt_path)
+            log.info(
+                "dispatch worktree already exists (claimed by %s): %s",
+                dispatch_id, wt_path,
+            )
+            return wt_path.resolve()
+
+        try:
             subprocess.run(
                 [
                     "git", "worktree", "add",
@@ -191,10 +478,28 @@ def create_dispatch_worktree(
                 capture_output=True,
                 text=True,
             )
-    except subprocess.CalledProcessError as exc:
-        raise RuntimeError(
-            f"create_dispatch_worktree failed for {dispatch_id!r}: {(exc.stderr or '').strip()}"
-        ) from exc
+        except subprocess.CalledProcessError as exc:
+            # A concurrent dispatch collided on this slot between our identity
+            # check and the git add.  Re-read the claim: a different stamped id
+            # is the OI-861 crossing — fail loud with the identity error.
+            raced = _read_claim(dispatch_id, root)
+            if raced is not None:
+                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+            raise RuntimeError(
+                f"create_dispatch_worktree failed for {dispatch_id!r}: "
+                f"{(exc.stderr or '').strip()}"
+            ) from exc
+
+        # Claim the freshly-created worktree atomically (O_EXCL).  From here on
+        # the worktree's identity is bound to dispatch_id and no other dispatch
+        # may reuse it.
+        try:
+            _write_claim_atomic(dispatch_id, worktree_path=wt_path, project_root=root)
+        except WorktreeClaimError:
+            raced = _read_claim(dispatch_id, root)
+            if raced is not None:
+                _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
+            raise
 
     log.info("dispatch worktree created: %s (branch %s)", wt_path, branch_name)
     return wt_path.resolve()
@@ -220,8 +525,18 @@ def remove_dispatch_worktree(
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
 
     if not wt_path.exists():
+        # Nothing to remove.  Drop any stale claim so a later dispatch mapping
+        # to this safe id can claim cleanly (idempotent, never raises).
+        _clear_claim(dispatch_id, root)
         log.debug("remove_dispatch_worktree: already absent: %s", wt_path)
         return
+
+    # OI-861 hard refusal on teardown: never reap a worktree that is stamped
+    # for a DIFFERENT dispatch id.  This is the "one's worktree reaped
+    # mid-flight by the other's completion" half of the race.
+    claim = _read_claim(dispatch_id, root)
+    if claim is not None:
+        _claim_belongs_to_or_raise(dispatch_id, claim, wt_path)
 
     # OI-873: kill processes still running inside this worktree BEFORE
     # attempting removal.  A zombie hook (bash + python child) will hold
@@ -291,6 +606,10 @@ def remove_dispatch_worktree(
             )
         except subprocess.CalledProcessError as exc:
             log.warning("git worktree prune failed: %s", (exc.stderr or "").strip())
+
+        # The worktree is gone — release its identity claim so a later dispatch
+        # mapping to the same safe id can claim cleanly.
+        _clear_claim(dispatch_id, root)
 
     # Best-effort: delete the local dispatch branch (it lives on origin).
     safe_id = _sanitize_dispatch_id(dispatch_id)

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
 from pr_enforcement import PrEnforcementResult  # noqa: E402
+from worker_pane_classifier import classify_worker_pane  # noqa: E402
+
+# Work-started gate outcome codes (OI-863): a worker blocked on a permission
+# prompt is ALIVE and recoverable — one relayed answer saves it — so it must not
+# be fast-aborted as no_progress.  The gate returns one of these.
+WORK_START_WORKING = "working"
+WORK_START_AWAITING_PERMISSION = "awaiting_permission"
+WORK_START_NO_PROGRESS = "no_progress"
 
 # Capability scoping (interim, per WORKER-CAPABILITY-SCOPING-DESIGN.md §4.4/§5):
 # detached ephemeral spawns run under the blanket --dangerously-skip-permissions
@@ -415,6 +423,43 @@ class TmuxInteractiveDispatch:
         )
         # P0-1: mtime stability cache for report backstop.
         self._report_mtime_cache: dict[str, float] = {}
+        # OI-863: dispatch ids for which the awaiting-permission detection event
+        # has already been emitted (one event per dispatch, not one per poll).
+        self._awaiting_permission_emitted: set[str] = set()
+
+    # -- OI-863 pane classification ----------------------------------------
+    def _classify_pane(self, pane_id: str):
+        """Capture *pane_id* and classify it (never raises).
+
+        Returns a ``WorkerPaneState``; a failed capture classifies as unknown
+        so a tmux error never takes down the lane.
+        """
+        cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
+        content = cap.stdout if cap.returncode == 0 else ""
+        return classify_worker_pane(content)
+
+    def _emit_awaiting_permission(
+        self,
+        dispatch_id: str,
+        label: str,
+        pane_id: str,
+        reason: str,
+    ) -> None:
+        """Emit ``interactive_awaiting_permission`` at most once per dispatch.
+
+        The event is the detection surface T0 uses to answer the prompt (one
+        keystroke) instead of letting the worker burn its whole deadline.
+        """
+        if dispatch_id in self._awaiting_permission_emitted:
+            return
+        self._awaiting_permission_emitted.add(dispatch_id)
+        self._emit_event(
+            "interactive_awaiting_permission",
+            dispatch_id=dispatch_id,
+            label=label,
+            reason=reason,
+            metadata={"pane_id": pane_id},
+        )
 
     @staticmethod
     def _resolve_project_root() -> Path:
@@ -1396,7 +1441,7 @@ class TmuxInteractiveDispatch:
         baseline_pending_ids: "frozenset[str]",
         completion_statuses: "frozenset[str]",
         label: str,
-    ) -> bool:
+    ) -> str:
         """Confirm the worker actually STARTED working after a verified submit.
 
         ``_verify_submit`` confirms the input box is no longer staged, but under
@@ -1408,23 +1453,30 @@ class TmuxInteractiveDispatch:
         This bounded watchdog polls for a real work signal — the UserPromptSubmit
         sentinel, a version-robust working indicator (``_looks_working``), or a fresh
         receipt — and re-nudges ONCE with a guarded Enter if the instruction is still
-        staged (never a stray Enter into a running session). It returns True as soon as
-        work is observed; False if no work appears within the window, so the caller can
-        FAST-ABORT (retryable in seconds) instead of burning the full deadline.
+        staged (never a stray Enter into a running session).
+
+        Returns one of WORK_START_*:
+
+        * ``WORK_START_WORKING`` — work observed (or gate disabled); proceed to the
+          receipt wait.
+        * ``WORK_START_AWAITING_PERMISSION`` — no work within the window AND the pane
+          shows a permission prompt (OI-863).  The worker is ALIVE and one keystroke
+          saves it; the caller must NOT fast-abort it as no_progress.
+        * ``WORK_START_NO_PROGRESS`` — no work and no permission prompt; the caller can
+          FAST-ABORT (retryable in seconds) instead of burning the full deadline.
 
         Gate is on by default; set ``VNX_TMUX_WORK_START_GATE=0`` to restore the prior
         proceed-straight-to-receipt-wait behavior.
 
-        Known limitation: a worker blocked on an interactive permission prompt shows no
-        working indicator, so for an attended/permissioned session enable the permission
-        relay (``VNX_PERMISSION_RELAY=1``) so the prompt is answered before the window
-        elapses. Autonomous (skip-permissions) workers — the benchmark and headless lanes
-        — are unaffected.
+        A worker blocked on a permission prompt is now detected (not a silent
+        no-progress); an attended/permissioned session should still enable the
+        permission relay (``VNX_PERMISSION_RELAY=1``) so the prompt is ANSWERED rather
+        than merely detected.
         """
         if os.environ.get("VNX_TMUX_WORK_START_GATE", "1").strip().lower() in (
             "0", "false", "no", "off"
         ):
-            return True
+            return WORK_START_WORKING
 
         timeout = float(os.environ.get("VNX_TMUX_WORK_START_TIMEOUT", "120"))
         poll = float(os.environ.get("VNX_TMUX_WORK_START_POLL", "3"))
@@ -1469,7 +1521,7 @@ class TmuxInteractiveDispatch:
         nudged = False
         while time.monotonic() < deadline:
             if _work_observed():
-                return True
+                return WORK_START_WORKING
             # Guarded hand-deliver: re-submit ONCE, and only while the instruction is
             # still staged AND not working as of this instant (both re-checked right
             # before the send) — never a stray Enter into a session that just started.
@@ -1484,7 +1536,17 @@ class TmuxInteractiveDispatch:
                 self._runner.run(["send-keys", "-t", pane_id, "Enter"])
                 nudged = True
             time.sleep(poll)
-        return _work_observed()
+        # Gate window elapsed without work.  Classify the pane: a permission prompt is
+        # a RECOVERABLE state — one relayed answer saves the worker — so it must NOT
+        # fast-abort as no_progress (OI-863).
+        final = self._classify_pane(pane_id)
+        if final.is_awaiting_permission:
+            self._emit_awaiting_permission(
+                dispatch_id, label, pane_id,
+                "permission prompt at work-start gate; not fast-aborting",
+            )
+            return WORK_START_AWAITING_PERMISSION
+        return WORK_START_NO_PROGRESS
 
     def _paste(self, pane_id: str, content: str, max_inline: int = 50000) -> bool:
         """Load *content* into a tmux buffer and paste it into the pane."""
@@ -1769,6 +1831,8 @@ class TmuxInteractiveDispatch:
         baseline_count: int = 0,
         baseline_pending_ids: "frozenset[str] | None" = None,
         baseline_backstop: "bool | None" = None,
+        pane_id: "str | None" = None,
+        label: "str | None" = None,
     ) -> "dict | None":
         """Poll signals 1–3 until a NEW completion appears beyond the baseline.
 
@@ -1777,6 +1841,12 @@ class TmuxInteractiveDispatch:
           When None, falls back to legacy combined position-based baseline (backward compat).
         *baseline_backstop* guards signal 3 (True if report was backstop-active at baseline).
           When None, captured at call time (conservative default).
+
+        *pane_id* (optional): when provided, the loop classifies the pane on each
+          poll and emits ``interactive_awaiting_permission`` the first time the
+          worker is seen blocked on a permission prompt (OI-863) — so a worker
+          that hangs on a prompt MID-RUN is surfaced long before the deadline,
+          instead of burning the full ``deadline_seconds`` invisible.
 
         Priority: signal 1 (canonical) > signal 2 (pending) > signal 3 (backstop).
         Returns the best matching receipt, or None on deadline.
@@ -1831,6 +1901,17 @@ class TmuxInteractiveDispatch:
             else:
                 if time.monotonic() >= deadline:
                     return None
+                # OI-863: mid-wait permission-prompt detection.  A detached worker
+                # blocked on a prompt produces no receipt; surface it the moment the
+                # pane betrays it (at most once per dispatch) instead of waiting the
+                # full deadline invisible.
+                if pane_id is not None:
+                    _pane_state = self._classify_pane(pane_id)
+                    if _pane_state.is_awaiting_permission and label is not None:
+                        self._emit_awaiting_permission(
+                            dispatch_id, label, pane_id,
+                            "permission prompt during receipt wait",
+                        )
                 time.sleep(poll_interval)
                 continue
 
@@ -2496,7 +2577,7 @@ class TmuxInteractiveDispatch:
             # Fast-abort (retryable in seconds) instead of burning deadline_seconds.
             # baseline / baseline_pending_ids are the PRE-DELIVERY snapshot (step 5),
             # so a pre-existing/stale receipt is never miscounted as fresh progress.
-            if not self._await_work_started(
+            _work_start = self._await_work_started(
                 pane_id,
                 dispatch_id,
                 signal_dir=signal_dir,
@@ -2504,7 +2585,18 @@ class TmuxInteractiveDispatch:
                 baseline_pending_ids=baseline_pending_ids,
                 completion_statuses=completion_statuses,
                 label=label,
-            ):
+            )
+            if _work_start == WORK_START_AWAITING_PERMISSION:
+                # OI-863: the worker is ALIVE, blocked on one permission prompt.  Do
+                # NOT fast-abort — a single relayed answer saves it.  Fall through to
+                # the relay (answers it when a window is open) and the receipt wait
+                # (whose deadline path re-classifies the pane if nothing resolves it).
+                logger.warning(
+                    "interactive: dispatch %s worker awaiting permission at work-start; "
+                    "proceeding to relay+wait instead of fast-aborting",
+                    dispatch_id,
+                )
+            if _work_start == WORK_START_NO_PROGRESS:
                 # Capture the pane tail so operators can see WHY no work was observed
                 # (idle prompt, permission prompt, error) and tune the heuristic.
                 _pane_tail = ""
@@ -2561,9 +2653,26 @@ class TmuxInteractiveDispatch:
                 baseline_count=baseline,
                 baseline_pending_ids=baseline_pending_ids,
                 baseline_backstop=baseline_backstop,
+                pane_id=pane_id,
+                label=label,
             )
 
             if receipt is None:
+                # OI-863: classify the pane at deadline.  A worker STILL blocked on a
+                # permission prompt is not a plain deadline — record it distinctly as
+                # awaiting_permission so the audit trail shows a recoverable state,
+                # not a silent hang.
+                _deadline_state = self._classify_pane(pane_id)
+                _deadline_reason = (
+                    "tmux_awaiting_permission"
+                    if _deadline_state.is_awaiting_permission
+                    else "tmux_receipt_deadline_exceeded"
+                )
+                if _deadline_state.is_awaiting_permission:
+                    self._emit_awaiting_permission(
+                        dispatch_id, label, pane_id,
+                        "still awaiting permission at receipt deadline",
+                    )
                 self._govern_report(
                     dispatch_id=dispatch_id,
                     terminal_id=label,
@@ -2573,6 +2682,7 @@ class TmuxInteractiveDispatch:
                     base_sha=worktree_handle.base_sha if worktree_handle else None,
                     worktree_path=worktree_handle.path if worktree_handle else None,
                     model=model,
+                    failure_reason=_deadline_reason,
                     role=role,
                     session_id=session_uuid,
                 )
@@ -2584,7 +2694,11 @@ class TmuxInteractiveDispatch:
                     label=label,
                     window_id=window_id,
                     pane_id=pane_id,
-                    failure_reason="receipt deadline exceeded",
+                    failure_reason=(
+                        "awaiting_permission"
+                        if _deadline_state.is_awaiting_permission
+                        else "receipt deadline exceeded"
+                    ),
                     duration_seconds=time.monotonic() - start_time,
                     worktree_state=_wt_state[0],
                     worktree_path=str(worktree_handle.path) if worktree_handle else None,

--- a/scripts/lib/worker_pane_classifier.py
+++ b/scripts/lib/worker_pane_classifier.py
@@ -1,0 +1,120 @@
+"""worker_pane_classifier.py — classify a detached worker's tmux pane (OI-863).
+
+A DETACHED tmux worker has no human to answer a Claude Code permission prompt.
+When it hits one, the pane shows the permission box ("Permission rule
+Bash(...) requires confirmation ... Do you want to proceed?") and the worker
+silently waits: no event, no receipt, no exit — only the pane betrays it.  The
+dispatch deadline (hours) is the only thing that would otherwise fire.
+
+This module classifies a SINGLE pane capture into a small set of worker
+states.  The load-bearing distinction (OI-863): ``awaiting_permission`` is a
+RECOVERABLE state — one keystroke (a relay send-keys answer) saves the worker —
+and must never be conflated with a dead/stalled worker, which a monitor would
+be justified in killing.  Classification is a pure function of the pane text so
+it is trivially testable and lane-agnostic.
+
+The prompt markers mirror ``worker_permission_relay.PROMPT_MARKERS`` (the
+active-responder twin).  A drift here means the detector stops seeing a prompt
+the relay would answer — or vice versa; a parity test guards against it.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from typing import Optional
+
+# Keep in parity with worker_permission_relay.PROMPT_MARKERS.  Matched
+# case-insensitively and kept tolerant: never pinned to one Claude Code
+# version's exact wording (the lane has been burned by version-specific TUI
+# scraping before).
+PROMPT_MARKERS = (
+    "do you want to proceed",
+    "do you want to make this edit",
+    "do you want to create",
+    "requires confirmation",
+    "requires your permission",
+)
+
+# Version-robust "Claude is actively working" indicators (mirrors
+# TmuxInteractiveDispatch._looks_working): the structural token-counter shape
+# the TUI prints during a turn ("(18s · ↓ 739 tokens)"), plus tolerant legacy
+# literals ("esc to interrupt").
+_WORKING_TOKEN_RE = re.compile(r"\(\s*\d+\s*s\b[^)\n]*tokens?\b", re.IGNORECASE)
+_WORKING_LITERALS = ("esc to interrupt", "to interrupt")
+
+# Idle-at-input-prompt markers (bottom of the pane when Claude is ready for
+# input).  The glyph/tail is checked AFTER the working indicators so a pane
+# that shows both ("? for shortcuts" plus a running token counter) classifies
+# as working, not idle.
+_IDLE_GLYPHS = ("❯",)
+_IDLE_MARKERS = ("for shortcuts", "welcome to claude")
+
+# State labels — deliberately a small, closed set so consumers can switch on
+# them without string drift.
+STATE_AWAITING_PERMISSION = "awaiting_permission"
+STATE_WORKING = "working"
+STATE_AWAITING_INPUT = "awaiting_input"
+STATE_STALLED = "stalled"
+STATE_DEAD = "dead"
+STATE_UNKNOWN = "unknown"
+
+
+@dataclass(frozen=True)
+class WorkerPaneState:
+    """The classification of one pane capture."""
+
+    state: str
+    matched_marker: Optional[str] = None
+    detail: str = ""
+
+    @property
+    def is_awaiting_permission(self) -> bool:
+        return self.state == STATE_AWAITING_PERMISSION
+
+
+def classify_worker_pane(content: str) -> WorkerPaneState:
+    """Classify a single tmux pane capture into a worker state.
+
+    Priority order (a pane can satisfy several; the first wins):
+
+      1. ``awaiting_permission`` — a permission prompt marker is visible.
+         Highest priority because it is the RECOVERABLE state: the worker is
+         alive and waiting on exactly one input; killing it would discard a
+         rescueable dispatch.
+      2. ``working`` — active-work indicators (token counter / legacy literal).
+      3. ``awaiting_input`` — idle at the Claude input prompt (ready for a new
+         prompt, not blocked).
+      4. ``dead`` — the capture is empty/whitespace (session or process gone).
+      5. ``stalled`` — content present but none of the above signals.
+
+    Returns ``WorkerPaneState`` — never raises on malformed input.
+    """
+    if content is None:
+        return WorkerPaneState(STATE_UNKNOWN, detail="no pane content provided")
+    if not content.strip():
+        return WorkerPaneState(STATE_DEAD, detail="empty pane capture")
+
+    lowered = content.lower()
+    for marker in PROMPT_MARKERS:
+        if marker in lowered:
+            return WorkerPaneState(
+                STATE_AWAITING_PERMISSION,
+                matched_marker=marker,
+                detail="permission prompt visible on pane",
+            )
+
+    if _WORKING_TOKEN_RE.search(content):
+        return WorkerPaneState(STATE_WORKING, detail="token-counter working indicator")
+    if any(lit in lowered for lit in _WORKING_LITERALS):
+        return WorkerPaneState(STATE_WORKING, detail="working literal present")
+
+    lines = [ln for ln in content.splitlines() if ln.strip()]
+    tail = lines[-1] if lines else ""
+    tail_low = tail.lower()
+    if any(glyph in tail for glyph in _IDLE_GLYPHS) or any(
+        m in tail_low for m in _IDLE_MARKERS
+    ):
+        return WorkerPaneState(STATE_AWAITING_INPUT, detail="idle at input prompt")
+
+    return WorkerPaneState(STATE_STALLED, detail="content but no prompt/working/idle signal")

--- a/tests/test_dispatch_worktree_identity_race.py
+++ b/tests/test_dispatch_worktree_identity_race.py
@@ -1,0 +1,424 @@
+"""test_dispatch_worktree_identity_race.py — OI-861 dispatch-identity crossing.
+
+Two dispatches fired back-to-back on the same lane must never share a worktree
+or inherit each other's identity.  This exercises the dispatch-id-keyed atomic
+claim in dispatch_worktree_isolation:
+
+  1. Concurrent claims on the SAME worktree slot (two dispatch ids that
+     sanitize to the same safe id): exactly one wins, the loser gets a clean
+     WorktreeIdentityConflict — never a silent shared worktree.
+  2. The claim REGISTRY lives under the canonical state root (ADR-026 SSOT),
+     NOT under any repo root.  A repo-local pin forks the map exactly as far
+     apart as the racing worktrees are, and the OI-861 crossing runs straight
+     through it (PR #1274 review).  test_claim_dir_is_not_under_repo_root and
+     test_claims_from_different_project_roots_share_one_map guard this.
+  3. Hard refusal: a worker offered a worktree stamped for a different dispatch
+     id gets a fail-loud WorktreeIdentityConflict via verify_worktree_identity.
+  4. Teardown refusal: remove_dispatch_worktree refuses to reap a worktree it
+     does not own.
+  5. Same-dispatch re-entry is idempotent; remove clears the claim so the slot
+     can be claimed again.
+
+The concurrency is REAL: every iteration spawns two threads behind a barrier
+that both fire create_dispatch_worktree at the same instant on the same slot.
+A retry loop that re-ran the same call N times would re-hit the same serialized
+window and prove nothing; this test exercises genuine simultaneous claims.
+
+Every test pins the claim registry to a shared temp state root
+(VNX_DATA_DIR_EXPLICIT=1 + VNX_DATA_DIR + VNX_STATE_DIR) so the ambient
+central store (~/.vnx-data/...) is never written and two simulated worktrees
+serialize on one map.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+import threading
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+
+def _set_shared_claim_dir(monkeypatch, tmp_path: Path) -> Path:
+    """Point the claim registry at a SHARED temp state root.
+
+    ``_claim_dir`` resolves via ``vnx_paths.resolve_paths()["VNX_STATE_DIR"]``
+    (the canonical state root), so the test pins both ``VNX_DATA_DIR``
+    (explicit override) and ``VNX_STATE_DIR`` to one temp dir that every
+    simulated "worktree" resolves to.  Without this, tests would either write
+    to the ambient central store or fork the map per checkout — the exact
+    defect OI-861 is about.
+    """
+    data_dir = tmp_path / "shared-data"
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(data_dir / "state"))
+    return data_dir
+
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a real git repo on branch main with one committed seed file."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q", "-b", "main", str(repo)], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "race-test@vnx"], check=True
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "VNX Race Test"], check=True
+    )
+    (repo / "seed.txt").write_text("seed\n", encoding="utf-8")
+    subprocess.run(["git", "-C", str(repo), "add", "."], check=True)
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-q", "-m", "seed"], check=True
+    )
+    return repo
+
+
+def _colliding_dispatch_ids(index: int) -> "tuple[str, str]":
+    """Two dispatch ids that sanitize to the SAME safe id.
+
+    ``dispatch_worktree_isolation._sanitize_dispatch_id`` collapses ``.`` to
+    ``-``, so ``-lock.reclaim.timeout`` and ``-lock-reclaim-timeout`` both land
+    on ``-lock-reclaim-timeout`` → the same worktree path and branch.  This is
+    the narrowest way to make two *different* dispatch identities contend for
+    one slot, which is exactly the OI-861 crossing.
+    """
+    stem = f"20260730-race{index}"
+    return f"{stem}-lock-reclaim-timeout", f"{stem}.lock.reclaim.timeout"
+
+
+def _run_concurrent_claim(
+    repo_a: Path,
+    repo_b: Path,
+    id_a: str,
+    id_b: str,
+) -> "tuple[dict, dict]":
+    """Fire two create_dispatch_worktree calls simultaneously.
+
+    The two calls run against DIFFERENT project roots (``repo_a`` / ``repo_b``)
+    — simulating the main checkout and a dispatch worktree — but must collide on
+    the SAME shared claim map.  Both threads wait on a barrier so they enter at
+    the same instant.  Returns (outcome_a, outcome_b) where each is
+    {"status": "ok", "path": Path} or {"status": "err", "exc": Exception}.
+    """
+    from dispatch_worktree_isolation import create_dispatch_worktree
+
+    barrier = threading.Barrier(2)
+    outcomes: dict[str, dict] = {}
+
+    def _claim(dispatch_id: str, repo: Path, key: str) -> None:
+        try:
+            barrier.wait(timeout=30)
+            path = create_dispatch_worktree(dispatch_id, project_root=repo)
+            outcomes[key] = {"status": "ok", "path": path}
+        except Exception as exc:  # noqa: BLE001 — the test must observe the raw error
+            outcomes[key] = {"status": "err", "exc": exc}
+
+    threads = [
+        threading.Thread(target=_claim, args=(id_a, repo_a, "a")),
+        threading.Thread(target=_claim, args=(id_b, repo_b, "b")),
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=90)
+    assert not any(t.is_alive() for t in threads), "claim thread hung"
+    return outcomes["a"], outcomes["b"]
+
+
+# ─── the claim registry lives in the canonical state root (PR #1274 review) ─
+
+class TestClaimRegistryLocation:
+    def test_claim_dir_is_not_under_repo_root(self, tmp_path, monkeypatch):
+        """The claim map must NEVER be built under a repo root.
+
+        This is the PR #1274 rejection point: the repo-local
+        ``<repo>/.vnx-data/state/dispatch_worktree_claims`` fork serializes
+        nothing between two racing checkouts.  If someone regresses to a
+        repo-local pin, this assertion fails red.
+        """
+        data_dir = _set_shared_claim_dir(monkeypatch, tmp_path)
+        from dispatch_worktree_isolation import _claim_dir
+
+        repo = tmp_path / "repo"
+        repo.mkdir()
+        claim = _claim_dir(repo).resolve()
+
+        assert not claim.is_relative_to(repo.resolve()), (
+            f"claim registry {claim} must not live under the repo root {repo}"
+        )
+        assert claim == (data_dir / "state" / "dispatch_worktree_claims"), (
+            f"claim registry {claim} must live under the canonical state root "
+            f"(VNX_STATE_DIR), got a different path"
+        )
+
+    def test_claims_from_different_project_roots_share_one_map(
+        self, tmp_path, monkeypatch
+    ):
+        """Two simultaneous claims from DIFFERENT worktrees see each other.
+
+        Two project roots (main checkout vs dispatch worktree) resolve to the
+        SAME shared claim map and serialize on it — exactly the property the
+        repo-local pin broke.  On a repo-local implementation both threads
+        would write distinct per-checkout claim files and BOTH would succeed;
+        this test requires exactly one winner.
+        """
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        from dispatch_worktree_isolation import (
+            WorktreeClaimError,
+            _write_claim_atomic,
+        )
+
+        # Two distinct project roots simulating main checkout + worktree.
+        root_a = tmp_path / "wt_a"
+        root_b = tmp_path / "wt_b"
+        wt_path_a = root_a / ".vnx-data" / "worktrees" / "dispatch-same"
+        wt_path_b = root_b / ".vnx-data" / "worktrees" / "dispatch-same"
+        wt_path_a.parent.mkdir(parents=True)
+        wt_path_b.parent.mkdir(parents=True)
+
+        id_a, id_b = _colliding_dispatch_ids(99)  # same safe id, different identity
+        barrier = threading.Barrier(2)
+        outcomes: dict[str, dict] = {}
+
+        def _claim(dispatch_id: str, wt_path: Path, root: Path, key: str) -> None:
+            try:
+                barrier.wait(timeout=30)
+                _write_claim_atomic(
+                    dispatch_id, worktree_path=wt_path, project_root=root
+                )
+                outcomes[key] = {"status": "ok"}
+            except Exception as exc:  # noqa: BLE001
+                outcomes[key] = {"status": "err", "exc": exc}
+
+        threads = [
+            threading.Thread(target=_claim, args=(id_a, wt_path_a, root_a, "a")),
+            threading.Thread(target=_claim, args=(id_b, wt_path_b, root_b, "b")),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=90)
+        assert not any(t.is_alive() for t in threads), "claim thread hung"
+
+        ok = [k for k in ("a", "b") if outcomes[k]["status"] == "ok"]
+        err = [k for k in ("a", "b") if outcomes[k]["status"] == "err"]
+        assert len(ok) == 1 and len(err) == 1, (
+            f"expected exactly one winner across two worktrees, got "
+            f"ok={len(ok)} err={len(err)} "
+            f"(a={outcomes['a']['status']}, b={outcomes['b']['status']})"
+        )
+        loser_exc = outcomes[err[0]]["exc"]
+        assert isinstance(loser_exc, WorktreeClaimError), (
+            f"loser must fail with the claim error family, got "
+            f"{type(loser_exc).__name__}: {loser_exc}"
+        )
+        # The winner's claim must be readable from the OTHER worktree's context.
+        from dispatch_worktree_isolation import _read_claim
+
+        winner_id = id_a if ok[0] == "a" else id_b
+        winner_root = root_a if ok[0] == "a" else root_b
+        claim = _read_claim(winner_id, winner_root)
+        assert claim is not None
+        assert claim["dispatch_id"] == winner_id
+
+
+# ─── the race: two concurrent claims on one slot ────────────────────────────
+
+class TestConcurrentClaimRace:
+    def test_exactly_one_winner_per_slot(self, tmp_path, monkeypatch):
+        """Concurrent same-slot claims: one winner, one clean identity conflict.
+
+        Repeated across 12 fresh slots so the outcome is shown to be stable,
+        not a one-off — every iteration is a genuine barrier-synchronized pair
+        of claims fired from two different project roots.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+
+        for i in range(12):
+            id_a, id_b = _colliding_dispatch_ids(i)
+            outcome_a, outcome_b = _run_concurrent_claim(repo, repo, id_a, id_b)
+
+            ok = [o for o in (outcome_a, outcome_b) if o["status"] == "ok"]
+            err = [o for o in (outcome_a, outcome_b) if o["status"] == "err"]
+            assert len(ok) == 1, (
+                f"iteration {i}: expected exactly one winner, got {len(ok)} "
+                f"(a={outcome_a['status']}, b={outcome_b['status']})"
+            )
+            assert len(err) == 1, (
+                f"iteration {i}: expected exactly one loser, got {len(err)}"
+            )
+
+            loser_exc = err[0]["exc"]
+            assert isinstance(loser_exc, WorktreeIdentityConflict), (
+                f"iteration {i}: loser must fail with WorktreeIdentityConflict, "
+                f"got {type(loser_exc).__name__}: {loser_exc}"
+            )
+            assert "claimed by dispatch" in str(loser_exc), (
+                f"iteration {i}: loser error must name the conflict, got: {loser_exc}"
+            )
+
+            winner_id = id_a if outcome_a["status"] == "ok" else id_b
+            loser_id = id_b if outcome_a["status"] == "ok" else id_a
+            winner_path = ok[0]["path"]
+
+            # The winner's worktree is provably the winner's...
+            claim = verify_worktree_identity(winner_id, winner_path)
+            assert claim["dispatch_id"] == winner_id
+            # ...and the loser is hard-refused on the very same worktree.
+            with pytest.raises(WorktreeIdentityConflict, match="stamped for dispatch"):
+                verify_worktree_identity(loser_id, winner_path)
+
+    def test_same_dispatch_second_create_is_idempotent(self, tmp_path, monkeypatch):
+        """Double-fire of the SAME dispatch id reuses its own claimed worktree."""
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-sfp1b-lock-reclaim-timeout"
+
+        first = create_dispatch_worktree(dispatch_id, project_root=repo)
+        second = create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        assert first == second
+        assert first.exists()
+        verify_worktree_identity(dispatch_id, first)
+
+
+# ─── hard refusal: worker offered the wrong worktree ────────────────────────
+
+class TestVerifyWorktreeIdentity:
+    def test_owner_verifies(self, tmp_path, monkeypatch):
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-owner-dispatch"
+        wt = create_dispatch_worktree(dispatch_id, project_root=repo)
+
+        claim = verify_worktree_identity(dispatch_id, wt)
+        assert claim["dispatch_id"] == dispatch_id
+        assert claim["worktree_path"] == str(wt.resolve())
+
+    def test_other_dispatch_is_rejected(self, tmp_path, monkeypatch):
+        """A worker offered a worktree stamped for another dispatch fails loud.
+
+        This is the literal OI-861 measurement: the sfp1b session was handed
+        sfp2b's worktree.  With the stamp in place the sfp1b worker's identity
+        check must reject it before doing any work.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            create_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        owner = "20260730-sfp2b-failclosed-tenant"
+        intruder = "20260730-sfp1b-lock-reclaim-timeout"
+
+        wt = create_dispatch_worktree(owner, project_root=repo)
+
+        with pytest.raises(WorktreeIdentityConflict) as excinfo:
+            verify_worktree_identity(intruder, wt)
+        message = str(excinfo.value)
+        assert owner in message
+        assert intruder in message
+        assert "stamped for dispatch" in message
+
+    def test_unclaimed_worktree_is_rejected(self, tmp_path, monkeypatch):
+        """No stamp → identity cannot be verified → hard refusal."""
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityMissing,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        worktrees_dir = repo / ".vnx-data" / "worktrees"
+        unclaimed = worktrees_dir / "dispatch-20260730-no-claim"
+        unclaimed.mkdir(parents=True)
+
+        with pytest.raises(WorktreeIdentityMissing, match="no dispatch-id claim"):
+            verify_worktree_identity("20260730-no-claim", unclaimed, project_root=repo)
+
+
+# ─── teardown refusal: never reap a worktree you do not own ─────────────────
+
+class TestRemoveRefusal:
+    def test_remove_refuses_other_dispatch_worktree(self, tmp_path, monkeypatch):
+        """remove() must not reap a worktree stamped for a different dispatch.
+
+        This is the "one's worktree reaped mid-flight by the other's
+        completion" half of the OI-861 race.
+        """
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityConflict,
+            _dispatch_worktree_dir,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        owner = "20260730-owner-remove"
+        intruder = "20260730.owner.remove"  # sanitizes identically to owner
+
+        wt = create_dispatch_worktree(owner, project_root=repo)
+
+        with pytest.raises(WorktreeIdentityConflict, match="already claimed by dispatch"):
+            remove_dispatch_worktree(intruder, project_root=repo)
+
+        # The worktree survives and is still verifiable by its owner.
+        assert _dispatch_worktree_dir(repo, owner).exists()
+        verify_worktree_identity(owner, wt)
+
+    def test_remove_clears_claim_then_recreate(self, tmp_path, monkeypatch):
+        """After a legit remove, the slot is free for a fresh claim."""
+        from dispatch_worktree_isolation import (
+            WorktreeIdentityMissing,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            verify_worktree_identity,
+        )
+
+        _set_shared_claim_dir(monkeypatch, tmp_path)
+        repo = _init_git_repo(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "main")
+        dispatch_id = "20260730-recreate-cycle"
+
+        first = create_dispatch_worktree(dispatch_id, project_root=repo)
+        remove_dispatch_worktree(dispatch_id, project_root=repo)
+        assert not first.exists()
+
+        # Claim is gone → the stale path no longer verifies for anyone.
+        with pytest.raises(WorktreeIdentityMissing):
+            verify_worktree_identity(dispatch_id, first)
+
+        second = create_dispatch_worktree(dispatch_id, project_root=repo)
+        assert second.exists()
+        verify_worktree_identity(dispatch_id, second)

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -66,6 +66,7 @@ class FakeTmux:
         receipt_status: str = "done",
         ready_content: str = "Welcome to Claude\n? for shortcuts",
         post_paste_capture_seq: "list[str] | None" = None,
+        post_paste_content: "str | None" = None,
     ) -> None:
         self.receipts_file = receipts_file
         self.dispatch_id = dispatch_id
@@ -77,6 +78,10 @@ class FakeTmux:
         self._receipt_status = receipt_status
         self._ready_content = ready_content
         self._post_paste_seq: list[str] = list(post_paste_capture_seq or [])
+        # OI-863: persistent content for capture-pane calls AFTER the submit
+        # (once post_paste_capture_seq is exhausted), e.g. a pane that stays on
+        # a permission prompt.  None → fall back to ready_content.
+        self._post_paste_content = post_paste_content
         self.commands: list[list[str]] = []
         self.pasted: list[str] = []
         self.killed_sessions: list[str] = []
@@ -101,9 +106,14 @@ class FakeTmux:
             return TmuxResult(0, "@1\n")
 
         if cmd == "capture-pane":
-            # Post-paste: consume the staged-response queue (FIFO).
-            if self._paste_fired and self._post_paste_seq:
-                return TmuxResult(0, self._post_paste_seq.pop(0))
+            # Post-paste: consume the staged-response queue (FIFO) first, then
+            # fall back to persistent post-paste content (OI-863 permission
+            # prompts), then to ready_content.
+            if self._paste_fired:
+                if self._post_paste_seq:
+                    return TmuxResult(0, self._post_paste_seq.pop(0))
+                if self._post_paste_content is not None:
+                    return TmuxResult(0, self._post_paste_content)
             return TmuxResult(0, self._ready_content)
 
         if cmd == "load-buffer":
@@ -723,7 +733,8 @@ class TestWorkStartedGate(_LaneTestCase):
     def test_hand_deliver_renudges_when_still_staged(self):
         """Unit test of the gate directly: when no work is observed AND the instruction
         is still staged in the input region, the gate sends ONE guarded re-nudge Enter
-        and emits interactive_hand_deliver, then returns False (no work)."""
+        and emits interactive_hand_deliver, then returns WORK_START_NO_PROGRESS (the
+        staged idle pane carries no permission prompt)."""
         # Persistent staged content (would trip _verify_submit in a full dispatch, so we
         # exercise the gate method directly): capture-pane always shows the paste
         # annotation and no working indicator.
@@ -738,6 +749,7 @@ class TestWorkStartedGate(_LaneTestCase):
             "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
             "VNX_TMUX_WORK_START_POLL": "0.02",
         }):
+            from tmux_interactive_dispatch import WORK_START_NO_PROGRESS
             observed = lane._await_work_started(
                 "%1",
                 self.DISPATCH_ID,
@@ -748,7 +760,7 @@ class TestWorkStartedGate(_LaneTestCase):
                 label="T1",
             )
 
-        self.assertFalse(observed, "no work was ever observed")
+        self.assertEqual(observed, WORK_START_NO_PROGRESS, "no work was ever observed")
         enters = [
             c for c in fake.commands
             if c[:1] == ["send-keys"] and c[-1] == "Enter"
@@ -757,6 +769,98 @@ class TestWorkStartedGate(_LaneTestCase):
         with get_connection(self.state_dir) as conn:
             events = get_events(conn, entity_id=self.DISPATCH_ID)
         self.assertIn("interactive_hand_deliver", {e["event_type"] for e in events})
+
+
+# The literal OI-863 pane: sfp1c stuck on a Bash(chmod:*) permission rule.
+_PERMISSION_PANE_TEXT = (
+    "Permission rule Bash(chmod:*) requires confirmation for this command.\n"
+    "\n"
+    "Do you want to proceed?\n"
+    "  1. Yes\n"
+    "  2. Yes, and don't ask again for this project\n"
+    "  3. No\n"
+)
+
+
+class TestAwaitingPermission(_LaneTestCase):
+    def test_permission_prompt_is_not_fast_aborted(self):
+        """OI-863: a worker blocked on a permission prompt at work-start must NOT be
+        fast-aborted as interactive_no_progress.  The lane proceeds to the receipt
+        wait, emits interactive_awaiting_permission, and fails at deadline with the
+        distinct awaiting_permission reason — never killing a worker one keystroke
+        would save."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            post_paste_content=_PERMISSION_PANE_TEXT,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, deadline_seconds=0.3, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_reason, "awaiting_permission")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        event_types = {e["event_type"] for e in events}
+        self.assertIn("interactive_awaiting_permission", event_types)
+        self.assertNotIn("interactive_no_progress", event_types)
+
+    def test_working_worker_still_fails_as_deadline_not_permission(self):
+        """A genuinely working worker (token counter, no prompt) must NOT be
+        classified awaiting_permission — the deadline stays a plain deadline."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content=_READY_AND_WORKING,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, deadline_seconds=0.2, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertIn("deadline", result.failure_reason)
+        self.assertNotEqual(result.failure_reason, "awaiting_permission")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertNotIn(
+            "interactive_awaiting_permission",
+            {e["event_type"] for e in events},
+        )
+
+    def test_mid_wait_permission_prompt_emits_event(self):
+        """OI-863: a permission prompt raised MID receipt-wait (after the worker had
+        started) is surfaced via interactive_awaiting_permission on the first poll
+        that sees it, well before the deadline."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            # Direct wait-loop call: the pane ALREADY shows the permission prompt
+            # (ready_content, since no paste precedes the call in this unit test).
+            ready_content=_PERMISSION_PANE_TEXT,
+        )
+        lane = self._make_lane(fake)
+        # baseline_backstop=True so a report left by an earlier test in the shared
+        # /var/folders temp root is treated as baseline, not fresh completion.
+        result = lane._wait_for_receipt(
+            self.DISPATCH_ID,
+            deadline_seconds=0.15,
+            poll_interval=0.02,
+            completion_statuses=DEFAULT_COMPLETION_STATUSES,
+            baseline_count=0,
+            baseline_pending_ids=frozenset(),
+            baseline_backstop=True,
+            pane_id="%1",
+            label="T1",
+        )
+        self.assertIsNone(result, "no receipt ever arrives on a blocked worker")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn(
+            "interactive_awaiting_permission",
+            {e["event_type"] for e in events},
+        )
 
 
 class TestHeadlessGuard(_LaneTestCase):

--- a/tests/test_worker_pane_classifier.py
+++ b/tests/test_worker_pane_classifier.py
@@ -1,0 +1,128 @@
+"""test_worker_pane_classifier.py — OI-863 pane classification.
+
+A detached tmux worker blocked on a permission prompt shows no event, no
+receipt, no exit — only the pane betrays it.  This tests the classifier that
+detects the prompt and labels the state ``awaiting_permission``, DISTINCT from
+a dead worker (which a monitor would be justified in killing).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from worker_pane_classifier import (
+    STATE_AWAITING_INPUT,
+    STATE_AWAITING_PERMISSION,
+    STATE_DEAD,
+    STATE_STALLED,
+    STATE_UNKNOWN,
+    STATE_WORKING,
+    classify_worker_pane,
+)
+
+
+# The literal OI-863 measurement: sfp1c stuck on a Bash(chmod:*) permission rule.
+PERMISSION_PANE = (
+    "Permission rule Bash(chmod:*) requires confirmation for this command.\n"
+    "\n"
+    "Do you want to proceed?\n"
+    "  1. Yes\n"
+    "  2. Yes, and don't ask again for this project\n"
+    "  3. No\n"
+)
+
+
+class TestAwaitingPermission:
+    def test_permission_prompt_is_awaiting_permission(self):
+        """The exact OI-863 pane shape classifies as awaiting_permission."""
+        result = classify_worker_pane(PERMISSION_PANE)
+        assert result.state == STATE_AWAITING_PERMISSION
+        assert result.is_awaiting_permission
+
+    def test_requires_your_permission_variant(self):
+        result = classify_worker_pane(
+            "● Tool call: Edit(file)\n"
+            "This tool requires your permission to proceed.\n"
+            "Do you want to make this edit?"
+        )
+        assert result.state == STATE_AWAITING_PERMISSION
+
+    def test_matched_marker_is_recorded(self):
+        result = classify_worker_pane(PERMISSION_PANE)
+        # The pane contains several markers; the classifier records the first
+        # one in its priority tuple ("do you want to proceed" precedes
+        # "requires confirmation").
+        assert result.matched_marker == "do you want to proceed"
+        assert result.matched_marker in (
+            "do you want to proceed",
+            "requires confirmation",
+        )
+
+
+class TestDistinctFromDeadWorker:
+    """The load-bearing OI-863 distinction: awaiting_permission != dead."""
+
+    def test_permission_pane_is_not_dead(self):
+        result = classify_worker_pane(PERMISSION_PANE)
+        assert result.state != STATE_DEAD
+
+    def test_empty_pane_is_dead(self):
+        result = classify_worker_pane("")
+        assert result.state == STATE_DEAD
+
+    def test_whitespace_pane_is_dead(self):
+        result = classify_worker_pane("   \n  \n")
+        assert result.state == STATE_DEAD
+
+    def test_none_is_unknown_not_dead(self):
+        # A None capture means the caller failed to read the pane — unknown,
+        # not a confident "dead" (and certainly not awaiting_permission).
+        result = classify_worker_pane(None)
+        assert result.state == STATE_UNKNOWN
+        assert not result.is_awaiting_permission
+
+    def test_stale_content_is_stalled_not_awaiting(self):
+        # Content, but no prompt, no working indicator, no input glyph.
+        result = classify_worker_pane("some stale log text\nthat is not a prompt")
+        assert result.state == STATE_STALLED
+        assert not result.is_awaiting_permission
+
+
+class TestOtherStates:
+    def test_working_token_counter(self):
+        result = classify_worker_pane(
+            "? for shortcuts\n✢ Working… (3s · ↓ 120 tokens) · esc to interrupt"
+        )
+        assert result.state == STATE_WORKING
+
+    def test_working_legacy_literal(self):
+        result = classify_worker_pane("… still thinking · esc to interrupt")
+        assert result.state == STATE_WORKING
+
+    def test_idle_at_input_prompt(self):
+        result = classify_worker_pane("Welcome to Claude\n? for shortcuts\n❯")
+        assert result.state == STATE_AWAITING_INPUT
+
+    def test_idle_marker_without_glyph(self):
+        result = classify_worker_pane("? for shortcuts")
+        assert result.state == STATE_AWAITING_INPUT
+
+
+class TestMarkerParity:
+    """The classifier's prompt markers must stay in parity with the relay's.
+
+    The relay (worker_permission_relay.PROMPT_MARKERS) is the active responder;
+    this classifier is the passive detector.  A drift means one stops seeing a
+    prompt the other would answer.
+    """
+
+    def test_prompt_markers_match_relay(self):
+        import worker_permission_relay
+
+        from worker_pane_classifier import PROMPT_MARKERS
+
+        assert set(PROMPT_MARKERS) == set(worker_permission_relay.PROMPT_MARKERS)


### PR DESCRIPTION
## What

Two OI findings on the claude/sonnet tmux lane, fixed from `origin/main` (PR #1274 for OI-861 was rejected and is NOT rebuilt on).

**OI-861 — dispatch-identiteitskruising.** Two dispatches fired ~10s apart crossed identities: the sfp1b session ran on its own branch but was handed the sfp2b worktree, and sfp2b's completion reaped sfp1b's still-live worktree (0 changed files after 25 min). The staged bundles were verified correct — the crossing is in delivery/slot allocation. Fix: every isolated worktree is now stamped with an atomic **O_EXCL dispatch-id claim**, with hard refusals on identity mismatch at create, verify, and teardown.

**OI-863 — worker die onzichtbaar stilstaat.** The sfp1c worker sat on a `Permission rule Bash(chmod:*) requires confirmation` prompt with no event, no deadline-trigger, no receipt, no exit — only `tmux capture-pane` showed it, and the 7200s deadline fires only after two hours. Fix: a pure pane classifier labels the worker `awaiting_permission` (recoverable — one relayed answer saves it), distinct from a dead worker, and the lane surfaces it at the work-start gate, mid receipt-wait, and at deadline.

## Changes

- `scripts/lib/dispatch_worktree_isolation.py` — OI-861: atomic claim registry under the canonical state root (`vnx_paths.resolve_data_root(project_root) / "state"`, ADR-026 SSOT). `create_dispatch_worktree` claims the fresh worktree; `verify_worktree_identity` is the fail-loud worker refusal; `remove_dispatch_worktree` refuses to reap a worktree claimed by another dispatch.
- `scripts/lib/worker_pane_classifier.py` — OI-863: pure pane classifier (`awaiting_permission` / `working` / `awaiting_input` / `stalled` / `dead`), marker-parity with `worker_permission_relay.PROMPT_MARKERS`.
- `scripts/lib/tmux_interactive_dispatch.py` — OI-863: work-start gate returns `WORK_START_AWAITING_PERMISSION` instead of fast-aborting; receipt wait classifies the pane each poll and emits `interactive_awaiting_permission` (once per dispatch); deadline path records `tmux_awaiting_permission` instead of `tmux_receipt_deadline_exceeded`.
- Tests: `test_dispatch_worktree_identity_race.py` (new), `test_worker_pane_classifier.py` (new), `test_tmux_interactive_dispatch.py` (`TestAwaitingPermission` + FakeTmux `post_paste_content` hook).

## Verification

- **OI-861**: 9/9 tests green; the race test ran 8 separate times, all green (one winner per slot, one clean `WorktreeIdentityConflict` naming the conflict — never a silent shared worktree). **Red on `origin/main`** (all 9 fail, ImportError). Cross-worktree regression (the #1274 review point): `test_claims_from_different_project_roots_share_one_map` proves two simultaneous claims from different project roots serialize on ONE shared map; `test_claim_dir_is_not_under_repo_root` fails as soon as the claim path is built under a repo root. Existing worktree-isolation suites stay green; no claim files leak into the ambient central store.
- **OI-863**: classifier 13/13 green — the literal OI-863 pane → `awaiting_permission`, an empty pane → `dead`, working/idle/stalled each distinct. Lane integration 3/3 green: permission prompt at work-start is NOT fast-aborted, emits `interactive_awaiting_permission`, fails at deadline with `awaiting_permission`; a genuinely working worker still fails as a plain deadline; a mid-wait prompt emits the detection event. **Red on `origin/main`** (classifier module absent → collection error).
- Lint: `ruff check` clean on all changed library files.

## Taken from the #1274 review

The atomic-claim design was kept (O_EXCL, `verify_worktree_identity`, teardown refusal) as the review approved it. What was FIXED: the claim registry must not be repo-local — a per-checkout map serializes nothing between racing worktrees — so it now resolves via `vnx_paths` into the canonical state root. Added the two tests the review explicitly asked for: one that fails as soon as the claim path is built under a repo root, and one that proves two simultaneous claims from different worktrees see each other.

## Open Items

- `test_repo_root_no_override` and `test_no_progress_fast_aborts_before_deadline` fail only when the suite runs from inside a `.vnx-data/worktrees/...` path (reproduced on clean `origin/main` / pre-OI-863 commit). Pre-existing environmental.
- OI-864 (permission-houding fleet-breed) is deliberately NOT addressed — operator decision, PR #1252. This PR only detects + distinguishes `awaiting_permission`.
- Detection surfaces the prompt (event + distinct failure reason) but does not auto-answer it; the operator/T0 or the flag-gated permission relay sends the one keystroke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)