### PR TITLE
fix(dispatch): OI-921 — role validation is enforced, not a silent default

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -98,6 +98,11 @@ vnx_orchestration = [
     "configs/**/*",
     "hooks/**/*",
     "examples/**/*",
+    # OI-921: the agents/ role registry must ship with the engine — the worker
+    # resolves its role profile from agents/<role>/CLAUDE.md and compile_plan's
+    # role-registry check reads the same dir. Without this glob a pip install
+    # fails closed on every role (empty registry → all roles rejected).
+    "agents/**/*",
 ]
 
 # Exclude build artifacts, caches, and non-runtime content from the wheel.

--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -223,7 +223,12 @@ def stage_spec_bundle(
         "dispatch_id": dispatch_id,
         "staging_id": staging_id,
         "instruction_file": str(instruction_file.resolve()),
-        "role": role or "backend-developer",
+        # OI-921: never silently fill the backend-developer sentinel. An empty role
+        # is staged as an explicit "" so the door's validate() Rule 7 rejects it
+        # loud (bad-role) — the caller MUST choose a real role. The distinction
+        # between "no role chosen" (empty) and a conscious "backend-developer"
+        # (a valid agents/ role) is preserved on the spec.
+        "role": (role or "").strip(),
         "target_slot": target_slot,
         "gate": _canonical_gate(gate),
         "dispatch_paths": [
@@ -316,7 +321,10 @@ def deliver_via_door(
         return bridge_dispatch(
             instruction_text=instruction_text,
             dispatch_id=dispatch_id,
-            role=role or "backend-developer",
+            # OI-921: pass the caller's role through unchanged — never inject the
+            # backend-developer sentinel here. stage_spec_bundle writes "" for an
+            # unset role so the door rejects it loud instead of silently defaulting.
+            role=role,
             target_slot=target_slot,
             provider=provider,
             model=model,
@@ -340,7 +348,9 @@ def main(argv: Optional[list] = None) -> int:
     parser = argparse.ArgumentParser(description="VNX legacy→door dispatch bridge (PR-12)")
     parser.add_argument("--dispatch-id", required=True)
     parser.add_argument("--terminal", required=True, dest="target_slot")
-    parser.add_argument("--role", default="backend-developer")
+    # OI-921: NO sentinel default — a caller that omits --role must fail loud at the
+    # door (validate Rule 7) rather than silently dispatch as backend-developer.
+    parser.add_argument("--role", default="")
     parser.add_argument("--provider", default="claude")
     parser.add_argument("--model", default=None)
     parser.add_argument("--gate", default="")

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -928,6 +928,26 @@ def _via_for_provider(provider_value: str, sub_provider: Optional[str]) -> Optio
     return None
 
 
+def _discover_valid_roles(agents_dir: Path) -> frozenset[str]:
+    """Return the set of role names that exist in the agents/ registry.
+
+    A role is valid when ``<agents_dir>/<role>/CLAUDE.md`` exists — the same role
+    file the worker loads as its profile. Missing or unreadable registry → EMPTY
+    set, so compile_plan's OI-921 membership check rejects every role (fail-closed):
+    an undiscoverable registry must never silently accept an arbitrary role string.
+    """
+    try:
+        if not agents_dir.is_dir():
+            return frozenset()
+        return frozenset(
+            entry.name
+            for entry in agents_dir.iterdir()
+            if entry.is_dir() and (entry / "CLAUDE.md").is_file()
+        )
+    except OSError:
+        return frozenset()
+
+
 def build_runtime_snapshot(
     vspec: ValidatedSpec,
     *,
@@ -939,6 +959,7 @@ def build_runtime_snapshot(
     P0-1: instruction_text + check_registry=True (FAIL-CLOSED); effective model; SDK scan (warn via constraint engine).
     P0-2: staging binding verified via spec_file containment check.
     P1-#3: model_pins from provider_constraints.yaml SSOT.
+    OI-921: valid_roles discovered from the engine's agents/ registry (fail-closed).
     """
     from providers.constraint_enforcer import check_constraints as _constraint_check  # noqa: PLC0415
     from staging_validator import _exists_in_dir as _staging_exists  # noqa: PLC0415
@@ -1169,12 +1190,18 @@ def build_runtime_snapshot(
             slot: pin for slot, pin in model_pin_specs.items() if slot != spec.target_slot
         }
 
+    # OI-921: role-registry — the set of roles that exist in agents/ (the engine's
+    # repo root, resolved exactly as run_dispatch does for validate). Empty set when
+    # the registry is missing → compile_plan rejects every role (fail-closed).
+    valid_roles = _discover_valid_roles(_resolve_repo_root() / "agents")
+
     return RuntimeSnapshot(
         constraint_verdicts=constraint_verdicts,
         staging_promoted=staging_promoted,
         target_health=target_health,
         target_capable=target_capable,
         model_pins=snapshot_model_pins,
+        valid_roles=valid_roles,
     )
 
 

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -61,6 +61,13 @@ class RuntimeSnapshot:
     target_capable: Mapping[str, bool] = field(default_factory=dict)  # target_id -> capability match
     model_pins: Mapping[str, ModelPin] = field(default_factory=dict)  # target_slot -> pin (model + semantics)
     claude_serial_enabled: bool = True
+    # OI-921: the set of role names that exist in the agents/ registry. None =
+    # registry not provided (direct/test callers that pre-date the field) —
+    # compile_plan skips the membership check so their behavior is unchanged. A
+    # non-None frozenset (the door always provides one, possibly EMPTY) ENFORCES
+    # membership: an empty set rejects every role, so an undiscoverable registry
+    # fails closed instead of silently accepting anything.
+    valid_roles: Optional[frozenset[str]] = None
 
 
 # ---------------------------------------------------------------------------
@@ -163,6 +170,21 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
     if not snapshot.staging_promoted:
         return Reject("ADR-006", "dispatch rejected: staging not promoted (ADR-006 gate)")
     fired.append("D11")
+
+    # OI-921 — role-registry check: the validation dispatch_spec Rule 7 defers here.
+    # dispatch_bridge no longer silently fills the backend-developer sentinel, so a
+    # non-empty role must now name a role that actually exists in agents/. A
+    # consciously chosen "backend-developer" IS valid (it is a real agents/ role);
+    # only the SILENT default was the defect. snapshot.valid_roles=None (registry
+    # not provided) skips — the door always passes a frozenset (possibly empty =
+    # fail-closed, every role rejected).
+    if snapshot.valid_roles is not None and spec.role not in snapshot.valid_roles:
+        valid = ", ".join(sorted(snapshot.valid_roles))
+        return Reject(
+            "unknown-role",
+            f"role {spec.role!r} is not a known agent role; "
+            f"valid roles: {valid or '(none discovered — agents/ registry unavailable)'}",
+        )
 
     # D3 — constraint verdicts; blocking → Reject immediately; warn → collect
     for v in snapshot.constraint_verdicts:

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -242,8 +242,11 @@ def validate(
     # falsely reject legitimate instructions that discuss CLI invocation patterns.
 
     # Rule 7 — role non-empty.
-    # Tight role/skill validation (against the installed skill registry) is deferred to
-    # compile_plan, which has access to runtime paths. Here we only require non-empty.
+    # Tight role/skill validation (against the agents/ registry) is deferred to
+    # compile_plan (OI-921: compile_plan enforces membership against
+    # RuntimeSnapshot.valid_roles, discovered from the agents/ dir by the door's
+    # build_runtime_snapshot). Here we only require non-empty — an unset role is
+    # itself a Reject, so a dispatch MUST carry an explicit role.
     if not spec.role or not spec.role.strip():
         return Reject("bad-role", "role must be a non-empty string")
 

--- a/tests/test_dispatch_oi921_role_validation.py
+++ b/tests/test_dispatch_oi921_role_validation.py
@@ -1,0 +1,218 @@
+"""test_dispatch_oi921_role_validation.py — OI-921: role validation is enforced, not a silent default.
+
+Closes the closed non-enforcement chain end to end:
+  1. dispatch_bridge.stage_spec_bundle must NOT silently fill the backend-developer
+     sentinel — an unset role is staged as an explicit "" so the door rejects it
+     loud, and the distinction with a conscious "backend-developer" is preserved.
+  2. compile_plan implements the registry validation dispatch_spec Rule 7 defers:
+     the role must exist in agents/ (unknown-role Reject otherwise).
+  3. A consciously chosen "backend-developer" (a real agents/ role) still passes —
+     only the SILENT default was the defect, never the value itself.
+
+Tests 1 and 2 are red on origin/main (main silently defaults / never validates).
+Test 3 is green on main and stays green here — it guards against overreach.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import dispatch_bridge  # noqa: E402
+import dispatch_cli  # noqa: E402
+from dispatch_plan import RuntimeSnapshot, compile_plan  # noqa: E402
+from dispatch_spec import (  # noqa: E402
+    DispatchSpec,
+    Provider,
+    Reject,
+    ValidatedSpec,
+)
+
+_REPO_ROOT = _LIB.parents[1]
+_GOOD_ID = "20260801-120000-oi921"
+
+# The registry-discovery helper is new in OI-921; on origin/main the symbol does not
+# exist, so its tests are skipped there (the red-on-main proof for this item is the
+# bridge-no-silent-default and compile_plan-unknown-role tests, not discovery).
+_DISCOVER_VALID_ROLES = getattr(dispatch_cli, "_discover_valid_roles", None)
+
+
+def _stage(tmp_path, **over):
+    """Stage a spec bundle under an isolated tmp_path data root."""
+    base = dict(
+        instruction_text="do the thing", dispatch_id=_GOOD_ID, role="",
+        target_slot="T1", project_id="p1", provider="claude", data_dir=tmp_path,
+    )
+    base.update(over)
+    return dispatch_bridge.stage_spec_bundle(**base)
+
+
+def _snapshot(valid_roles: frozenset[str]) -> RuntimeSnapshot:
+    """Build a promoted RuntimeSnapshot carrying the role registry.
+
+    Compatible with origin/main, where RuntimeSnapshot has no ``valid_roles`` field:
+    a TypeError there falls back to a plain snapshot, so the red-on-main proof for
+    the unknown-role test is the assertion failure ("main does not reject"), not a
+    collection/kwarg error.
+    """
+    try:
+        return RuntimeSnapshot(staging_promoted=True, valid_roles=valid_roles)
+    except TypeError:  # origin/main: no valid_roles field
+        return RuntimeSnapshot(staging_promoted=True)
+
+
+def _make_vspec(role: str, *, tmp_path: Path) -> ValidatedSpec:
+    """Build a ValidatedSpec for compile_plan with the given role."""
+    ifile = tmp_path / "instruction.md"
+    ifile.write_text("# Do the work\n", encoding="utf-8")
+    spec = DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="oi921-test-dispatch",
+        staging_id="oi921-test-staging",
+        instruction_file=ifile,
+        role=role,
+        target_slot="T1",
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        model=None,
+    )
+    text = ifile.read_text(encoding="utf-8")
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Bridge: an unset role is never silently defaulted to backend-developer
+# ---------------------------------------------------------------------------
+
+class TestBridgeDoesNotSilentlyDefaultRole:
+    def test_empty_role_staged_as_explicit_empty(self, tmp_path):
+        """Red on main: main writes role='backend-developer' for an empty role."""
+        payload = json.loads(_stage(tmp_path, role="").read_text(encoding="utf-8"))
+        assert payload["role"] == ""
+        assert payload["role"] != "backend-developer"
+
+    def test_none_role_staged_as_explicit_empty(self, tmp_path):
+        """Red on main: main writes role='backend-developer' for a None role."""
+        payload = json.loads(_stage(tmp_path, role=None).read_text(encoding="utf-8"))
+        assert payload["role"] == ""
+
+    def test_whitespace_role_staged_as_explicit_empty(self, tmp_path):
+        """A whitespace-only role is indistinguishable from no role — stays empty."""
+        payload = json.loads(_stage(tmp_path, role="   ").read_text(encoding="utf-8"))
+        assert payload["role"] == ""
+
+    def test_conscious_backend_developer_is_preserved(self, tmp_path):
+        """The VALUE is never the problem — a conscious choice passes through verbatim."""
+        payload = json.loads(
+            _stage(tmp_path, role="backend-developer").read_text(encoding="utf-8")
+        )
+        assert payload["role"] == "backend-developer"
+
+    def test_other_explicit_role_is_preserved(self, tmp_path):
+        """A non-default explicit role is preserved, not coerced."""
+        payload = json.loads(
+            _stage(tmp_path, role="system-architect").read_text(encoding="utf-8")
+        )
+        assert payload["role"] == "system-architect"
+
+    def test_an_empty_role_fails_the_door_loud(self, tmp_path, monkeypatch):
+        """End-to-end bridge → door: an unset role is rejected (bad-role), not silently run."""
+        monkeypatch.setenv("VNX_SINGLE_ENTRY_DISPATCH", "1")
+        rc = dispatch_bridge.bridge_dispatch(
+            instruction_text="x", dispatch_id=_GOOD_ID, role="",
+            target_slot="T1", project_id="p1", data_dir=tmp_path, dry_run=True,
+        )
+        assert rc == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. compile_plan: the deferred registry validation is actually built
+# ---------------------------------------------------------------------------
+
+class TestCompilePlanRoleRegistry:
+    def test_unknown_role_is_rejected(self, tmp_path):
+        """Red on main: main compiles a plan for ANY non-empty role."""
+        vspec = _make_vspec("not-a-real-role", tmp_path=tmp_path)
+        result = compile_plan(
+            vspec,
+            _snapshot(frozenset({
+                "backend-developer", "code-reviewer", "system-architect",
+            })),
+        )
+        assert isinstance(result, Reject)
+        assert result.code == "unknown-role"
+        assert "backend-developer" in result.reason
+
+    def test_every_agent_role_is_accepted(self, tmp_path):
+        """Each real agents/ role compiles a plan when the registry lists it."""
+        roles = {
+            "backend-developer", "blog-writer", "code-reviewer", "frontend-developer",
+            "linkedin-writer", "orchestrator", "quality-engineer", "research-analyst",
+            "security-engineer", "system-architect",
+        }
+        for role in roles:
+            vspec = _make_vspec(role, tmp_path=tmp_path)
+            result = compile_plan(vspec, _snapshot(frozenset(roles)))
+            assert not isinstance(result, Reject), f"role {role!r} rejected: {result}"
+
+    def test_empty_registry_fails_closed(self, tmp_path):
+        """An empty valid_roles set (undiscoverable agents/ dir) rejects EVERY role."""
+        vspec = _make_vspec("backend-developer", tmp_path=tmp_path)
+        result = compile_plan(vspec, _snapshot(frozenset()))
+        assert isinstance(result, Reject)
+        assert result.code == "unknown-role"
+
+    def test_without_valid_roles_keeps_legacy_behavior(self, tmp_path):
+        """valid_roles=None (registry not provided) skips the check — direct callers
+        and pre-OI-921 tests keep working unchanged."""
+        vspec = _make_vspec("backend-developer", tmp_path=tmp_path)
+        result = compile_plan(vspec, RuntimeSnapshot(staging_promoted=True))
+        assert not isinstance(result, Reject)
+
+    def test_conscious_backend_developer_passes_with_registry(self, tmp_path):
+        """Green on main AND here: a consciously chosen backend-developer is valid."""
+        vspec = _make_vspec("backend-developer", tmp_path=tmp_path)
+        result = compile_plan(
+            vspec,
+            _snapshot(frozenset({"backend-developer", "code-reviewer"})),
+        )
+        assert not isinstance(result, Reject)
+
+
+# ---------------------------------------------------------------------------
+# 3. dispatch_cli: the door's snapshot carries the agents/ registry
+# ---------------------------------------------------------------------------
+
+class TestDiscoverValidRoles:
+    pytestmark = pytest.mark.skipif(
+        _DISCOVER_VALID_ROLES is None,
+        reason="OI-921 registry discovery not present on this source revision",
+    )
+
+    def test_discovers_real_agents_registry(self):
+        """The engine agents/ dir yields exactly the ten documented roles."""
+        roles = _DISCOVER_VALID_ROLES(_REPO_ROOT / "agents")
+        assert {
+            "backend-developer", "blog-writer", "code-reviewer", "frontend-developer",
+            "linkedin-writer", "orchestrator", "quality-engineer", "research-analyst",
+            "security-engineer", "system-architect",
+        }.issubset(roles)
+        assert "backend-developer" in roles
+
+    def test_missing_agents_dir_is_empty(self, tmp_path):
+        """A missing registry dir → empty set (compile_plan fails closed)."""
+        assert _DISCOVER_VALID_ROLES(tmp_path / "no-agents-here") == frozenset()


### PR DESCRIPTION
## OI-921: de rolvalidatie is een gesloten niet-handhavingsketen

De keten was gesloten en niet-handhavend: `dispatch_bridge` vulde elke ontbrekende rol stil met `backend-developer`, `dispatch_spec` Rule 7 stelde de echte check uit naar `compile_plan`, en `compile_plan` implementeerde die check nooit. Meten: 20 van de 20 dispatches op 2026-08-01 droegen `backend-developer`.

## Wat er verandert

1. **`dispatch_bridge`** (`stage_spec_bundle`, `deliver_via_door`, CLI): stopt met het stil invullen van de sentinel. Een ontbrekende rol wordt gestaged als expliciete `""`, zodat de deur luid faalt (`bad-role`) en het onderscheid met een bewuste keuze bewaard blijft.
2. **`compile_plan`**: de uitgestelde registry-check is nu echt gebouwd. `RuntimeSnapshot` krijgt `valid_roles` (ontdekt uit `agents/` door `build_runtime_snapshot`); een rol buiten de registry faalt met `unknown-role`. Een lege registry faalt closed (alle rollen afgewezen).
3. **Bewust gekozen `backend-developer` blijft geldig** — de waarde was nooit het probleem, alleen de stille default.
4. **Packaging**: `agents/**/*` gaat mee in de wheel, zodat de registry ook in pip-installaties beschikbaar is (de worker resolvet rollen al uit dezelfde map).

## Verificatie

`tests/test_dispatch_oi921_role_validation.py` (13 cases):
- Spec zonder rol → niet meer stil `backend-developer` (**rood op main**).
- Spec met niet-bestaande rol → afgewezen (`unknown-role`, **rood op main**).
- Spec met bewuste `backend-developer` → gaat door (**groen op main én hier**).

Bestaande dispatch-suites blijven groen: 260 + 197 + 54 tests passend (alleen pre-existente, omgevingsafhankelijke failures op main zijn ongewijzigd).

## Files

- `scripts/lib/dispatch_bridge.py`
- `scripts/lib/dispatch_plan.py`
- `scripts/lib/dispatch_cli.py`
- `scripts/lib/dispatch_spec.py`
- `pyproject.toml`
- `tests/test_dispatch_oi921_role_validation.py`

🤖 Generated with [Claude Code](https://claude.com/claude-code)