### PR TITLE
fix(governance): wire role context into provider prompts + deterministic role_applied check

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -324,10 +324,10 @@ def _prepare(spec: EnvelopeSpec) -> str:
     1. Repo-map layer on the RAW instruction (target-file extraction most
        accurate before any enrichment text is added).
     2. Role context + intelligence + full assembly via ``_inject_skill_context``
-       — the same injector the tmux/subprocess lanes use (dispatch-20260801-w10).
-       This closes the envelope-lane gap where the role's CLAUDE.md never reached
-       the worker. On injector failure the prompt falls back to a role label
-       header (mirrors tmux_interactive_dispatch._assemble_context).
+       — the shared lane-neutral injector used by every dispatch lane
+       (dispatch-20260801-w10). This closes the envelope-lane gap where the
+       role's CLAUDE.md never reached the worker. On injector failure the
+       prompt falls back to a role label header.
     """
     instruction = spec.instruction
 
@@ -341,7 +341,7 @@ def _prepare(spec: EnvelopeSpec) -> str:
         )
 
     try:
-        from subprocess_dispatch_internals.skill_injection import _inject_skill_context  # noqa: PLC0415
+        from skill_context import _inject_skill_context  # noqa: PLC0415
 
         dispatch_metadata: dict = {"dispatch_id": spec.dispatch_id}
         if spec.pr_id:

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -316,32 +316,20 @@ class LaneRouter:
 
 
 def _prepare(spec: EnvelopeSpec) -> str:
-    """Enrich instruction with intelligence context and repo map (best-effort).
+    """Enrich instruction with role context + intelligence and repo map (best-effort).
 
     Mirrors _enrich_instruction in provider_dispatch.py but operates on EnvelopeSpec.
-    Both layers fall back silently to the original instruction on any failure.
+    Layers fall back silently to the original instruction on any failure:
+
+    1. Repo-map layer on the RAW instruction (target-file extraction most
+       accurate before any enrichment text is added).
+    2. Role context + intelligence + full assembly via ``_inject_skill_context``
+       — the same injector the tmux/subprocess lanes use (dispatch-20260801-w10).
+       This closes the envelope-lane gap where the role's CLAUDE.md never reached
+       the worker. On injector failure the prompt falls back to a role label
+       header (mirrors tmux_interactive_dispatch._assemble_context).
     """
     instruction = spec.instruction
-
-    try:
-        from intelligence_injection import build_intelligence_section  # noqa: PLC0415
-
-        instruction = build_intelligence_section(
-            instruction=instruction,
-            dispatch_id=spec.dispatch_id,
-            role=spec.role,
-            state_dir=spec.state_dir,
-            pr_id=spec.pr_id,
-            dispatch_paths=None,
-        )
-    except ImportError:
-        logger.debug(
-            "envelope._prepare: intelligence_injection not available — skipping"
-        )
-    except Exception as exc:
-        logger.warning(
-            "envelope._prepare: intelligence injection failed (%s) — skipping", exc
-        )
 
     try:
         from dispatch_enricher import apply_repo_map_layer  # noqa: PLC0415
@@ -351,6 +339,32 @@ def _prepare(spec: EnvelopeSpec) -> str:
         logger.warning(
             "envelope._prepare: repo map layer failed (%s) — skipping", exc
         )
+
+    try:
+        from subprocess_dispatch_internals.skill_injection import _inject_skill_context  # noqa: PLC0415
+
+        dispatch_metadata: dict = {"dispatch_id": spec.dispatch_id}
+        if spec.pr_id:
+            dispatch_metadata["pr_id"] = spec.pr_id
+        instruction = _inject_skill_context(
+            spec.terminal_id,
+            instruction,
+            spec.role,
+            dispatch_metadata,
+        )
+    except Exception as exc:  # noqa: BLE001 — fallback must never break a dispatch
+        logger.warning(
+            "envelope._prepare: skill injection failed (%s); falling back to role label",
+            exc,
+        )
+        if spec.role:
+            header = f"## Role\n\nYou are operating as a **{spec.role}** worker."
+        else:
+            header = (
+                "## Worker Preamble\n\n"
+                "You are a VNX headless worker executing a dispatch instruction."
+            )
+        instruction = f"{header}\n\n{instruction}"
 
     return instruction
 
@@ -394,6 +408,29 @@ def _record_integrity(
         logger.error(
             "envelope: final-prompt integrity failed (non-fatal) dispatch=%s: %s",
             spec.dispatch_id,
+            exc,
+        )
+        return None
+
+
+def _verify_role_application(
+    final_prompt: str,
+    terminal_id: str,
+    role: Optional[str],
+):
+    """Best-effort: run the deterministic role-applied control for *final_prompt*.
+
+    Returns a RoleApplicationVerdict (or None on any failure — the control must
+    never break receipt emission; the fields then stay None/omitted).
+    """
+    try:
+        from role_application import verify_role_applied  # noqa: PLC0415
+        return verify_role_applied(final_prompt, terminal_id, role)
+    except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
+        logger.debug(
+            "envelope._verify_role_application: failed (non-fatal) role=%s terminal=%s: %s",
+            role,
+            terminal_id,
             exc,
         )
         return None
@@ -844,6 +881,14 @@ def _govern(
                     )
                     _role = "identity_unresolved"
 
+                # Deterministic role-applied control (dispatch-20260801-w10):
+                # did the resolved role source actually reach the enriched prompt
+                # (spec.instruction)? FAIL-OPEN — a verification error must never
+                # break receipt emission; the fields simply stay None (omitted).
+                _role_app = _verify_role_application(
+                    spec.instruction, spec.terminal_id, spec.role,
+                )
+
                 # receipt-quality PR-B2 fix-forward (Finding C): aggregate
                 # PreToolUse-hook tool-call signals for this dispatch
                 # (toolcall_signals.py), mirroring provider_dispatch._emit_
@@ -953,6 +998,18 @@ def _govern(
                     verification=_verification_from_report(report_path),
                     role=_role,
                     receipt_kind="dispatch",
+                    role_applied=(
+                        getattr(_role_app, "role_applied", None) if _role_app is not None else None
+                    ),
+                    role_tier=(
+                        getattr(_role_app, "tier", None) if _role_app is not None else None
+                    ),
+                    role_not_applied_reason=(
+                        getattr(_role_app, "reason", None) if _role_app is not None else None
+                    ),
+                    role_source_path=(
+                        getattr(_role_app, "source_path", None) if _role_app is not None else None
+                    ),
                     session_id=adapter_result.session_id,
                     tool_call_count=_toolcall_signals.get("tool_call_count"),
                     tool_call_failures=_toolcall_signals.get("tool_call_failures"),

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -100,6 +100,10 @@ def emit_dispatch_receipt(
     deadline_seconds: Optional[int] = None,
     failure_reason: Optional[str] = None,
     failure_class: Optional[str] = None,
+    role_applied: Optional[bool] = None,
+    role_tier: Optional[str] = None,
+    role_not_applied_reason: Optional[str] = None,
+    role_source_path: Optional[str] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -248,6 +252,10 @@ def emit_dispatch_receipt(
         deadline_seconds=deadline_seconds,
         failure_reason=failure_reason,
         failure_class=failure_class,
+        role_applied=role_applied,
+        role_tier=role_tier,
+        role_not_applied_reason=role_not_applied_reason,
+        role_source_path=role_source_path,
     ).to_dict()
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -249,7 +249,7 @@ def _enrich_instruction(args: argparse.Namespace) -> str:
 
     # Layer 2: role context + intelligence + full assembly via the shared injector.
     try:
-        from subprocess_dispatch_internals.skill_injection import _inject_skill_context  # noqa: PLC0415
+        from skill_context import _inject_skill_context  # noqa: PLC0415
         dispatch_metadata: dict = {"dispatch_id": args.dispatch_id}
         dispatch_paths = _resolve_dispatch_paths(getattr(args, "dispatch_paths", "") or "")
         if dispatch_paths:

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -192,51 +192,82 @@ def _record_final_prompt_integrity(
 
 
 def _enrich_instruction(args: argparse.Namespace) -> str:
-    """Prepend intelligence context and repo map to instruction for non-Claude provider paths.
+    """Prepend role context + intelligence and repo map to instruction for non-Claude provider paths.
 
     Claude dispatches are enriched inside subprocess_dispatch.deliver_with_recovery
     via skill_injection._build_intelligence_section; this function handles the
-    remaining providers (codex, gemini, litellm, kimi).
+    remaining providers (codex, gemini, litellm, kimi, deepseek-harness,
+    glm-harness, local-gemma).
 
-    Applies two layers (best-effort, each layer falls back silently on failure):
-    1. Intelligence injection (existing — ADR context, prior findings, etc.)
-    2. Repo-map layer (new — mirrors headless_dispatch_daemon's DispatchEnricher step)
+    Applies layers (best-effort, each layer falls back silently on failure):
+    1. Repo-map layer (new — mirrors headless_dispatch_daemon's DispatchEnricher
+       step; applied to the RAW instruction so target-file extraction is most
+       accurate before any enrichment text is added).
+    2. Role context + intelligence + full assembly via
+       ``_inject_skill_context`` — the SAME injector the tmux/subprocess lanes
+       use (dispatch-20260801-w10). This closes the provider-lane gap where a
+       dispatch staged with ``role=quality-engineer`` received byte-identical
+       context to ``role=system-architect`` because the role's CLAUDE.md never
+       reached the worker. On injector failure the prompt falls back to a role
+       label header (mirrors tmux_interactive_dispatch._assemble_context).
 
     Input-side audit closure: once assembled, the enriched body is persisted and
     checked for containment of the raw instruction + recorded injections
     (final_prompt_integrity). The result is stashed on ``args._final_prompt_integrity``
     (not returned — the string contract stays unchanged for existing callers) so
-    ``_emit_governance`` can stamp it onto the receipt.
+    ``_emit_governance`` can stamp it onto the receipt. The deterministic
+    role-applied verdict is stashed on ``args._role_application`` the same way.
 
     Returns the original instruction unchanged on any failure.
     """
     if os.environ.get("VNX_BENCH_EQUAL_CONTEXT") == "1":
         return args.instruction
 
-    # Layer: intelligence injection (existing)
-    try:
-        from intelligence_injection import build_intelligence_section  # noqa: PLC0415
-        enriched = build_intelligence_section(
-            instruction=args.instruction,
-            dispatch_id=args.dispatch_id,
-            role=getattr(args, "role", None),
-            state_dir=_resolve_state_dir(),
-            pr_id=getattr(args, "pr_id", None),
-            dispatch_paths=_resolve_dispatch_paths(getattr(args, "dispatch_paths", "") or ""),
-        )
-    except ImportError as exc:
-        logger.warning("_enrich_instruction: intelligence_injection unavailable (%s)", exc)
-        enriched = args.instruction
+    role = getattr(args, "role", None)
 
-    # Layer: repo map (new — extends coverage to all providers)
+    # Layer 1: repo map (on the raw instruction — mirrors dispatch_prepare.prepare).
+    enriched = args.instruction
     try:
         from dispatch_enricher import apply_repo_map_layer  # noqa: PLC0415
         enriched = apply_repo_map_layer(
             enriched,
-            {"role": getattr(args, "role", None)},
+            {"role": role},
         )
     except Exception as exc:
         logger.warning("_enrich_instruction: repo map layer failed (%s) — skipping", exc)
+
+    # Layer 2: role context + intelligence + full assembly via the shared injector.
+    try:
+        from subprocess_dispatch_internals.skill_injection import _inject_skill_context  # noqa: PLC0415
+        dispatch_metadata: dict = {"dispatch_id": args.dispatch_id}
+        dispatch_paths = _resolve_dispatch_paths(getattr(args, "dispatch_paths", "") or "")
+        if dispatch_paths:
+            dispatch_metadata["dispatch_paths"] = dispatch_paths
+        pr_id = getattr(args, "pr_id", None)
+        if pr_id:
+            dispatch_metadata["pr_id"] = pr_id
+        enriched = _inject_skill_context(
+            getattr(args, "terminal_id", ""),
+            enriched,
+            role,
+            dispatch_metadata,
+        )
+    except Exception as exc:  # noqa: BLE001 — fallback must never break a dispatch
+        logger.warning(
+            "_enrich_instruction: skill injection failed (%s); falling back to role label",
+            exc,
+        )
+        if role:
+            header = f"## Role\n\nYou are operating as a **{role}** worker."
+        else:
+            header = (
+                "## Worker Preamble\n\n"
+                "You are a VNX headless worker executing a dispatch instruction."
+            )
+        enriched = f"{header}\n\n{enriched}"
+
+    # Deterministic control: did the resolved role source actually reach the prompt?
+    args._role_application = _verify_role_application(enriched, args)
 
     args._final_prompt_integrity = _record_final_prompt_integrity(
         dispatch_id=args.dispatch_id,
@@ -245,6 +276,28 @@ def _enrich_instruction(args: argparse.Namespace) -> str:
     )
 
     return enriched
+
+
+def _verify_role_application(final_prompt: str, args: argparse.Namespace):
+    """Best-effort: run the deterministic role-applied control for *final_prompt*.
+
+    Returns a RoleApplicationVerdict (or None on any failure — the control must
+    never break a dispatch). Stashed on ``args._role_application`` so
+    ``_emit_governance`` can stamp it onto the receipt.
+    """
+    try:
+        from role_application import verify_role_applied  # noqa: PLC0415
+        return verify_role_applied(
+            final_prompt,
+            getattr(args, "terminal_id", ""),
+            getattr(args, "role", None),
+        )
+    except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
+        logger.debug(
+            "_enrich_instruction: role_applied verification failed (non-fatal): %s",
+            exc,
+        )
+        return None
 
 
 def _extract_response_text(result: Any) -> str:
@@ -651,6 +704,11 @@ def _emit_governance(
     # auto-vivified Mock child.
     _integrity = vars(args).get("_final_prompt_integrity")
 
+    # Deterministic role-applied verdict (dispatch-20260801-w10). Same guard as
+    # _integrity: only stamped when _enrich_instruction computed it; a MagicMock
+    # args that never set the attribute yields a real None via vars().get().
+    _role_app = vars(args).get("_role_application")
+
     # receipt-quality PR-1 + W7 fix: resolve dispatch identity (role) just
     # before the emit. The shared resolver prefers the genuinely-set --role
     # (never the fake backend-developer default), falls back to
@@ -765,6 +823,18 @@ def _emit_governance(
                 },
                 role=_role,
                 receipt_kind="dispatch",
+                role_applied=(
+                    getattr(_role_app, "role_applied", None) if _role_app is not None else None
+                ),
+                role_tier=(
+                    getattr(_role_app, "tier", None) if _role_app is not None else None
+                ),
+                role_not_applied_reason=(
+                    getattr(_role_app, "reason", None) if _role_app is not None else None
+                ),
+                role_source_path=(
+                    getattr(_role_app, "source_path", None) if _role_app is not None else None
+                ),
                 # receipt-quality PR-B1: threaded through so the claude-lane
                 # benchmark exemption path (the only route that reaches this
                 # provider="claude" case) can backfill token_usage from the

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -121,6 +121,18 @@ class ReceiptV2:
     # timeout, model_error, unknown). failure_reason is the human-readable detail.
     failure_reason: Optional[str] = None
     failure_class: Optional[str] = None
+    # Deterministic role-applied control (dispatch-20260801-w10): stamped by the
+    # provider/envelope GOVERN paths after the deterministic check that the
+    # resolved role source's content actually reached the assembled final prompt.
+    # role_tier is one of prompt_assembler | agents | skills | terminal | none.
+    # role_applied is False (stamped) when the resolved source content is absent
+    # from the prompt; role_not_applied_reason explains why. Conditionally stamped
+    # (None omits), so lanes that do not yet compute the verdict keep a
+    # byte-identical receipt shape.
+    role_applied: Optional[bool] = None
+    role_tier: Optional[str] = None
+    role_not_applied_reason: Optional[str] = None
+    role_source_path: Optional[str] = None
 
     def __post_init__(self) -> None:
         # Receipt-quality PR-3: the closed-set lint lives in the contract now
@@ -188,6 +200,14 @@ class ReceiptV2:
             receipt["failure_reason"] = self.failure_reason
         if self.failure_class is not None:
             receipt["failure_class"] = self.failure_class
+        if self.role_applied is not None:
+            receipt["role_applied"] = self.role_applied
+        if self.role_tier is not None:
+            receipt["role_tier"] = self.role_tier
+        if self.role_not_applied_reason is not None:
+            receipt["role_not_applied_reason"] = self.role_not_applied_reason
+        if self.role_source_path is not None:
+            receipt["role_source_path"] = self.role_source_path
         return receipt
 
 

--- a/scripts/lib/role_application.py
+++ b/scripts/lib/role_application.py
@@ -35,9 +35,12 @@ Candidate sources mirror what ``_inject_skill_context`` actually resolves:
   - ``skills``          — ``.claude/skills/<role>/CLAUDE.md`` (skill definition)
   - ``terminal``        — ``.claude/terminals/<terminal>/CLAUDE.md`` (terminal fallback)
 
-The first tier whose content is present wins. When no tier's content is present
-but a source exists, the verdict reports that tier with a "content absent"
-reason; when no source exists at all it reports ``tier="none"`` with why.
+The first EXISTING source in that order is the one the injector resolves; only
+that resolved source's content may evidence role application. When its content
+is absent from the prompt, the verdict is False even if a lower-priority
+source's content happens to be present (round-3 gate fix: terminal fallback
+content used to stamp role_applied=True while agents/<role>/CLAUDE.md was
+absent). When no source exists at all it reports ``tier="none"`` with why.
 """
 
 from __future__ import annotations
@@ -141,6 +144,29 @@ def _content_present(final_prompt: str, role_content: str) -> bool:
     return False
 
 
+def _lower_tier_present(
+    final_prompt: str,
+    candidates,
+    resolved_tier: str,
+) -> Optional[str]:
+    """Return the tier of the first lower-priority source whose content is in
+    *final_prompt*, or None.
+
+    Only sources strictly below *resolved_tier* in priority order count; the
+    resolved source itself is handled by the caller. Used to explain a
+    role_applied=False verdict when lower-tier content would have fooled a naive
+    "any tier present" check.
+    """
+    for tier, path in candidates:
+        if tier == resolved_tier:
+            continue
+        if path.is_file():
+            content = path.read_text(encoding="utf-8", errors="ignore")
+            if content.strip() and _content_present(final_prompt, content):
+                return tier
+    return None
+
+
 def verify_role_applied(
     final_prompt: str,
     terminal_id: str,
@@ -164,44 +190,62 @@ def verify_role_applied(
         role_slug = (role or "").strip()
         candidates = list(_candidate_sources(terminal_id, role_slug, project_root))
 
-        # First pass: report the first tier whose content is actually present.
-        for tier, path in candidates:
-            if path.is_file():
-                content = path.read_text(encoding="utf-8", errors="ignore")
-                if _content_present(final_prompt, content):
-                    return RoleApplicationVerdict(
-                        role_applied=True,
-                        tier=tier,
-                        reason=None,
-                        source_path=str(path),
-                    )
+        # Resolve the source the injector would actually use: the FIRST existing
+        # candidate in priority order. Only that source's content may evidence
+        # role application. Content from a lower-priority tier must never carry
+        # the verdict when a higher-priority source exists but was not injected
+        # (round-3 gate fix: terminal fallback content used to stamp
+        # role_applied=True while agents/<role>/CLAUDE.md was absent).
+        resolved = next(
+            ((tier, path) for tier, path in candidates if path.is_file()),
+            None,
+        )
+        if resolved is None:
+            return RoleApplicationVerdict(
+                role_applied=False,
+                tier=TIER_NONE,
+                reason="no role source resolved (prompt_assembler/agents/skills/terminal)",
+                source_path=None,
+            )
 
-        # Second pass: no content matched. Report the resolved tier (first
-        # existing source) with an honest reason, or "none" when no source exists.
-        for tier, path in candidates:
-            if path.is_file():
-                content = path.read_text(encoding="utf-8", errors="ignore")
-                if not content.strip():
-                    return RoleApplicationVerdict(
-                        role_applied=False,
-                        tier=tier,
-                        reason="role source resolved but its content is empty",
-                        source_path=str(path),
-                    )
-                return RoleApplicationVerdict(
-                    role_applied=False,
-                    tier=tier,
-                    reason=(
-                        "role source resolved but its content is absent from the "
-                        "final prompt"
-                    ),
-                    source_path=str(path),
-                )
+        resolved_tier, resolved_path = resolved
+        content = resolved_path.read_text(encoding="utf-8", errors="ignore")
+        if not content.strip():
+            return RoleApplicationVerdict(
+                role_applied=False,
+                tier=resolved_tier,
+                reason="role source resolved but its content is empty",
+                source_path=str(resolved_path),
+            )
+
+        if _content_present(final_prompt, content):
+            return RoleApplicationVerdict(
+                role_applied=True,
+                tier=resolved_tier,
+                reason=None,
+                source_path=str(resolved_path),
+            )
+
+        # Resolved source content is absent. Record whether a lower-priority
+        # source's content IS present — that is the exact false-positive shape a
+        # naive "any tier present" check would have matched, and the reader
+        # should not have to guess which source it was. The boolean plus the
+        # resolved tier carry the verdict; the note only explains the failure
+        # mode, it is not a new status layer.
+        lower_tier = _lower_tier_present(final_prompt, candidates, resolved_tier)
+        reason = (
+            "role source resolved but its content is absent from the final prompt"
+        )
+        if lower_tier is not None:
+            reason += (
+                f"; lower-priority {lower_tier} content IS present but cannot "
+                "evidence role application when the resolved source is absent"
+            )
         return RoleApplicationVerdict(
             role_applied=False,
-            tier=TIER_NONE,
-            reason="no role source resolved (prompt_assembler/agents/skills/terminal)",
-            source_path=None,
+            tier=resolved_tier,
+            reason=reason,
+            source_path=str(resolved_path),
         )
     except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
         logger.warning("role_application: verify_role_applied failed (non-fatal): %s", exc)

--- a/scripts/lib/role_application.py
+++ b/scripts/lib/role_application.py
@@ -1,0 +1,213 @@
+"""role_application.py — deterministic role-applied verification for the provider lane.
+
+Dispatch-20260801-w10: the provider/envelope lanes injected intelligence and a
+repo map but NEVER the role's own CLAUDE.md context — a dispatch staged with
+``role=quality-engineer`` received byte-identical context to one staged with
+``role=system-architect``. This module wires the missing piece and, crucially,
+makes the receipt truthful about whether the role context was actually USED.
+
+Part A (wiring) reuses ``_inject_skill_context`` — the same injector the tmux
+and subprocess lanes already use. Part B (this module) is the deterministic
+control: after the final prompt is assembled, it verifies that the content of
+the resolved role source actually occurs in the prompt and returns a verdict
+the caller stamps onto the dispatch receipt.
+
+Deterministic-first principle (agents/system-architect/CLAUDE.md, #1298): the
+check is a string comparison, never a model call. An LLM "judging whether the
+role looks used" is the wrong tool here — the prompt is bytes we assembled, so
+we can verify containment directly.
+
+Comparison shape (motivated):
+  - Role content is embedded with surrounding formatting, so a naive exact
+    string match is too brittle. Both sides are whitespace-normalized (every
+    whitespace run collapses to one space) before comparison.
+  - Primary check: the FULL normalized role content is a substring of the
+    normalized prompt. This is the strongest proof — the whole role document
+    reached the worker (the legacy injector prepends it verbatim).
+  - Fallback: the LONGEST non-empty line of the role content, normalized, is a
+    substring. Long sentences survive reflow/trim better than the full doc; the
+    longest line acts as a stable marker. This keeps the check truthful when a
+    future formatting change reflows the role body.
+
+Candidate sources mirror what ``_inject_skill_context`` actually resolves:
+  - ``prompt_assembler`` — ``scripts/lib/prompts/roles/<role>.md`` (PromptAssembler L2)
+  - ``agents``          — ``agents/<role>/CLAUDE.md`` (project-level agent override)
+  - ``skills``          — ``.claude/skills/<role>/CLAUDE.md`` (skill definition)
+  - ``terminal``        — ``.claude/terminals/<terminal>/CLAUDE.md`` (terminal fallback)
+
+The first tier whose content is present wins. When no tier's content is present
+but a source exists, the verdict reports that tier with a "content absent"
+reason; when no source exists at all it reports ``tier="none"`` with why.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+_LIB_DIR = Path(__file__).resolve().parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+logger = logging.getLogger(__name__)
+
+_WS_RE = re.compile(r"\s+")
+
+# Tier labels stamped on the receipt. "none" = no role source resolved.
+TIER_PROMPT_ASSEMBLER = "prompt_assembler"
+TIER_AGENTS = "agents"
+TIER_SKILLS = "skills"
+TIER_TERMINAL = "terminal"
+TIER_NONE = "none"
+
+# Longest-line fallback threshold: a candidate "stable marker" line must be at
+# least this many characters or it is too generic to prove anything.
+_MIN_MARKER_CHARS = 16
+
+
+@dataclass(frozen=True)
+class RoleApplicationVerdict:
+    """Deterministic outcome of the role-applied check, stamped on the receipt."""
+
+    role_applied: bool
+    tier: str                     # prompt_assembler | agents | skills | terminal | none
+    reason: Optional[str] = None  # why not applied, when role_applied is False
+    source_path: Optional[str] = None
+
+
+def resolve_project_root() -> Path:
+    """Resolve the project root the same way the injector's legacy path does.
+
+    Mirrors ``_legacy_claude_md_resolution`` (subprocess_dispatch.__file__ →
+    parents[2]) so the control verifies the same ``agents/`` tree the injector
+    reads. Callers may pass an explicit ``project_root`` to override (tests).
+    """
+    import subprocess_dispatch as _sd  # noqa: PLC0415
+    return _sd.Path(_sd.__file__).resolve().parents[2]
+
+
+def _normalize_ws(text: str) -> str:
+    """Collapse every whitespace run to a single space and strip the ends.
+
+    Injection rendering interleaves newlines/indentation that the role source
+    does not carry; normalizing both sides makes substring containment robust
+    to that formatting without loosening what it proves.
+    """
+    return _WS_RE.sub(" ", text).strip()
+
+
+def _candidate_sources(terminal_id: str, role: str, project_root: Path):
+    """Yield (tier, path) candidates in the injector's resolution precedence."""
+    _prompts_dir = Path(__file__).resolve().parent / "prompts" / "roles"
+    if role:
+        yield TIER_PROMPT_ASSEMBLER, _prompts_dir / f"{role}.md"
+    if role:
+        yield TIER_AGENTS, project_root / "agents" / role / "CLAUDE.md"
+    if role:
+        yield TIER_SKILLS, project_root / ".claude" / "skills" / role / "CLAUDE.md"
+    yield TIER_TERMINAL, project_root / ".claude" / "terminals" / terminal_id / "CLAUDE.md"
+
+
+def _longest_meaningful_line(content: str) -> str:
+    """Return the longest non-empty line of *content* (stripped)."""
+    best = ""
+    for line in content.splitlines():
+        stripped = line.strip()
+        if len(stripped) > len(best):
+            best = stripped
+    return best
+
+
+def _content_present(final_prompt: str, role_content: str) -> bool:
+    """Whitespace-normalized containment: full doc, then longest-line marker.
+
+    The full-content substring is the primary, strongest proof. When the role
+    body was reflowed/trimmed by surrounding formatting, the longest line (a
+    stable marker that survives reflow) is the robust fallback.
+    """
+    if not role_content or not role_content.strip():
+        return False
+    norm_prompt = _normalize_ws(final_prompt)
+    norm_full = _normalize_ws(role_content)
+    if norm_full and norm_full in norm_prompt:
+        return True
+    marker = _longest_meaningful_line(role_content)
+    if len(marker) >= _MIN_MARKER_CHARS and _normalize_ws(marker) in norm_prompt:
+        return True
+    return False
+
+
+def verify_role_applied(
+    final_prompt: str,
+    terminal_id: str,
+    role: Optional[str],
+    *,
+    project_root: Optional[Path] = None,
+) -> RoleApplicationVerdict:
+    """Deterministically verify the resolved role source reached *final_prompt*.
+
+    Resolves the role source via the same candidate order ``_inject_skill_context``
+    uses (PromptAssembler role prompt first, then the legacy 3-tier) and checks
+    whitespace-normalized containment of the resolved source's content.
+
+    Returns a ``RoleApplicationVerdict``; never raises (best-effort verification
+    must never break a dispatch). A resolution/content error degrades to
+    ``role_applied=False`` with the reason recorded.
+    """
+    try:
+        if project_root is None:
+            project_root = resolve_project_root()
+        role_slug = (role or "").strip()
+        candidates = list(_candidate_sources(terminal_id, role_slug, project_root))
+
+        # First pass: report the first tier whose content is actually present.
+        for tier, path in candidates:
+            if path.is_file():
+                content = path.read_text(encoding="utf-8", errors="ignore")
+                if _content_present(final_prompt, content):
+                    return RoleApplicationVerdict(
+                        role_applied=True,
+                        tier=tier,
+                        reason=None,
+                        source_path=str(path),
+                    )
+
+        # Second pass: no content matched. Report the resolved tier (first
+        # existing source) with an honest reason, or "none" when no source exists.
+        for tier, path in candidates:
+            if path.is_file():
+                content = path.read_text(encoding="utf-8", errors="ignore")
+                if not content.strip():
+                    return RoleApplicationVerdict(
+                        role_applied=False,
+                        tier=tier,
+                        reason="role source resolved but its content is empty",
+                        source_path=str(path),
+                    )
+                return RoleApplicationVerdict(
+                    role_applied=False,
+                    tier=tier,
+                    reason=(
+                        "role source resolved but its content is absent from the "
+                        "final prompt"
+                    ),
+                    source_path=str(path),
+                )
+        return RoleApplicationVerdict(
+            role_applied=False,
+            tier=TIER_NONE,
+            reason="no role source resolved (prompt_assembler/agents/skills/terminal)",
+            source_path=None,
+        )
+    except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
+        logger.warning("role_application: verify_role_applied failed (non-fatal): %s", exc)
+        return RoleApplicationVerdict(
+            role_applied=False,
+            tier=TIER_NONE,
+            reason=f"role-applied verification error: {exc}",
+            source_path=None,
+        )

--- a/scripts/lib/skill_context.py
+++ b/scripts/lib/skill_context.py
@@ -1,0 +1,342 @@
+"""skill_context — lane-neutral worker prompt-context injection (canonical home).
+
+Shared, lane-neutral implementation of worker prompt-context assembly used by
+every dispatch lane without any lane importing from another lane's internal
+package. The functions here were moved from
+``subprocess_dispatch_internals/skill_injection.py``; that module is now a thin
+compat re-export of this one, so existing imports and test patches at the old
+path keep resolving.
+
+Layers:
+  - _inject_skill_context        — role context + intelligence + full assembly
+  - _inject_permission_profile   — permission-profile preamble
+  - _build_intelligence_section  — intelligence items (delegates to
+                                   intelligence_injection.fetch_intelligence_section)
+  - legacy 3-tier CLAUDE.md resolution + PromptAssembler path
+
+Project-root and state-dir lookups resolve via the ``subprocess_dispatch``
+facade namespace (deferred imports inside the functions) so test monkeypatches
+at the facade keep intercepting — see the per-function docstrings.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def _inject_permission_profile(terminal_id: str, role: str | None, instruction: str) -> str:
+    """Prepend permission preamble to instruction if a profile exists for role.
+
+    Resolves the terminal's expected role from terminal_assignments when role
+    is None.  Logs a warning on role/terminal mismatch.  Returns instruction
+    unchanged when no profile is found or worker_permissions cannot be loaded.
+    """
+    try:
+        from worker_permissions import (
+            load_permissions,
+            generate_permission_preamble,
+            validate_dispatch_permissions,
+        )
+    except ImportError:
+        logger.debug("_inject_permission_profile: worker_permissions not available, skipping")
+        return instruction
+
+    effective_role = _resolve_effective_role(terminal_id, role)
+    if not effective_role:
+        return instruction
+
+    warnings = validate_dispatch_permissions(
+        {"terminal": terminal_id, "role": effective_role}
+    )
+    for w in warnings:
+        logger.warning(w)
+
+    profile = load_permissions(effective_role)
+    if not profile.allowed_tools and not profile.denied_tools and not profile.bash_deny_patterns:
+        logger.debug("_inject_permission_profile: empty profile for role '%s', skipping preamble", effective_role)
+        return instruction
+
+    preamble = generate_permission_preamble(profile)
+    logger.info(
+        "Permission profile applied: terminal=%s role=%s allowed=%s denied=%s",
+        terminal_id, effective_role,
+        profile.allowed_tools,
+        profile.denied_tools,
+    )
+    return f"{preamble}\n---\n\n{instruction}"
+
+
+def _resolve_effective_role(terminal_id: str, role: str | None) -> str | None:
+    """Resolve effective role from terminal_assignments when role is None.
+
+    Uses the project-override-first path resolution from worker_permissions so
+    central-install and embedded installs both find the project's customised
+    worker_permissions.yaml rather than the immutable VNX_HOME template.
+    """
+    if role:
+        return role
+    try:
+        from worker_permissions import _resolve_permissions_yaml  # noqa: PLC0415
+        yaml_path = _resolve_permissions_yaml()
+        import yaml  # noqa: PLC0415
+        data = yaml.safe_load(yaml_path.read_text()) or {}
+        return data.get("terminal_assignments", {}).get(terminal_id)
+    except Exception as exc:
+        logger.debug("_inject_permission_profile: could not resolve role for %s: %s", terminal_id, exc)
+        return None
+
+
+def _build_intelligence_section(
+    dispatch_id: str,
+    role: str | None,
+    *,
+    dispatch_paths: "list[str] | None" = None,
+    instruction_text: str | None = None,
+    pr_id: str | None = None,
+) -> str:
+    """Return formatted intelligence items as markdown, or empty string (best-effort).
+
+    Delegates to intelligence_injection.fetch_intelligence_section so the same
+    logic serves all provider paths (codex/gemini/litellm/kimi) via
+    provider_dispatch.py.
+
+    _default_state_dir is fetched via subprocess_dispatch namespace so test
+    monkeypatches at the facade honour this call site unchanged.
+
+    dispatch_paths, instruction_text, pr_id are forwarded to selector.select() so
+    W5 item classes (adr_relevant, code_anchor, operator_memory, schema_section,
+    prior_round_finding) can fire in production dispatches.
+    """
+    try:
+        from intelligence_injection import fetch_intelligence_section  # noqa: PLC0415
+    except ImportError as exc:
+        logger.warning("intelligence injection failed (%s); proceeding without", exc)
+        return ""
+    # Look up _default_state_dir via subprocess_dispatch namespace so test
+    # monkeypatches at the facade ("subprocess_dispatch._default_state_dir")
+    # are honoured when this helper is called directly by tests.
+    import subprocess_dispatch as _sd
+    state_dir = _sd._default_state_dir()
+    return fetch_intelligence_section(
+        dispatch_id=dispatch_id,
+        role=role,
+        state_dir=state_dir,
+        pr_id=pr_id,
+        dispatch_paths=dispatch_paths,
+        instruction_text=instruction_text,
+    )
+
+
+def _inject_skill_context(
+    terminal_id: str,
+    instruction: str,
+    role: str | None = None,
+    dispatch_metadata: "dict | None" = None,
+) -> str:
+    """Compose layered user message context for headless dispatch.
+
+    Uses PromptAssembler (3-layer architecture) when available, with fallback
+    to the legacy 3-tier CLAUDE.md resolution for backward compatibility.
+
+    Layer architecture (PromptAssembler path):
+      Layer 1 — Base worker context (universal rules, report format)
+      Layer 2 — Role context (capabilities, permissions for the role)
+      Layer 3 — Dispatch payload (passed through as instruction)
+
+    Legacy fallback (3-tier CLAUDE.md resolution):
+      1. agents/{role}/CLAUDE.md        — project-level agent override
+      2. .claude/skills/{role}/CLAUDE.md — skill definition
+      3. .claude/terminals/{terminal}/CLAUDE.md — terminal fallback
+
+    Args:
+        terminal_id:       Terminal identifier (e.g. "T1").
+        instruction:       Raw dispatch instruction text.
+        role:              Agent role (e.g. "backend-developer").
+        dispatch_metadata: Optional metadata dict forwarded to PromptAssembler
+                           for L3 enrichments (dispatch_id, gate, pr, track, model,
+                           intelligence, historical).  Merged with terminal+role.
+
+    Returns the full pipe_input string ready for `claude -p`.
+    """
+    # Gather intelligence before assembling prompt (best-effort).  Looked up via
+    # subprocess_dispatch namespace so test patches at the facade are honoured.
+    import subprocess_dispatch as _sd
+    _dispatch_id = (dispatch_metadata or {}).get("dispatch_id") or ""
+    _dispatch_paths = (dispatch_metadata or {}).get("dispatch_paths") or []
+    _instruction_text = instruction
+    _pr_id = (dispatch_metadata or {}).get("pr_id") or (dispatch_metadata or {}).get("pr")
+    intelligence_section = _sd._build_intelligence_section(
+        _dispatch_id, role,
+        dispatch_paths=_dispatch_paths,
+        instruction_text=_instruction_text,
+        pr_id=_pr_id,
+    )
+
+    assembled = _try_prompt_assembler(
+        terminal_id, instruction, role, dispatch_metadata, intelligence_section,
+    )
+    if assembled is not None:
+        return assembled
+
+    return _legacy_claude_md_resolution(
+        terminal_id, instruction, role, intelligence_section,
+    )
+
+
+def _has_prompt_assembler_role(role: str | None) -> bool:
+    """True when PromptAssembler has a role prompt for *role*.
+
+    PromptAssembler's L2 reads ``scripts/lib/prompts/roles/<role>.md`` and falls
+    back to base_worker.md when the file is missing — so two distinct roles
+    WITHOUT a prompt file (e.g. quality-engineer vs system-architect) would
+    otherwise receive byte-identical context.
+    """
+    if not role:
+        return False
+    # This module lives in scripts/lib (one level above the old
+    # subprocess_dispatch_internals home), so the prompts dir is parent/…,
+    # not parent.parent/….
+    return (Path(__file__).resolve().parent / "prompts" / "roles" / f"{role}.md").exists()
+
+
+def _has_legacy_role_source(role: str | None) -> bool:
+    """True when the legacy 3-tier has a ROLE-SPECIFIC source (agents/ or skills/).
+
+    Terminal fallback is deliberately excluded: it is generic per terminal, not
+    role context. Only role-specific sources decide the routing below.
+    """
+    if not role:
+        return False
+    import subprocess_dispatch as _sd
+    root = _sd.Path(_sd.__file__).resolve().parents[2]
+    return (
+        (root / "agents" / role / "CLAUDE.md").exists()
+        or (root / ".claude" / "skills" / role / "CLAUDE.md").exists()
+    )
+
+
+def _try_prompt_assembler(
+    terminal_id: str,
+    instruction: str,
+    role: str | None,
+    dispatch_metadata: "dict | None",
+    intelligence_section: str,
+) -> str | None:
+    """Attempt PromptAssembler path; return assembled pipe_input or None on failure.
+
+    Dispatch-20260801-w10 routing fix: when the role has a project-level
+    agents/skills source but NO PromptAssembler role prompt, return None to route
+    through the legacy 3-tier resolution. PromptAssembler would otherwise
+    silently substitute base_worker.md as L2, so a dispatch with
+    ``role=quality-engineer`` got the exact same context as one with
+    ``role=system-architect``. Roles WITH a prompt file (backend-developer,
+    test-engineer, ...) keep using PromptAssembler unchanged.
+    """
+    if _has_prompt_assembler_role(role) is False and _has_legacy_role_source(role):
+        logger.info(
+            "_inject_skill_context: role=%s has no PromptAssembler prompt but has a "
+            "legacy role source — using legacy 3-tier so agents/{role}/CLAUDE.md reaches the worker",
+            role,
+        )
+        return None
+    try:
+        from prompt_assembler import PromptAssembler  # noqa: PLC0415
+        assembler = PromptAssembler()
+        meta = dict(dispatch_metadata or {})
+        meta.setdefault("role", role or "")
+        meta.setdefault("terminal", terminal_id)
+        if intelligence_section:
+            meta.setdefault("intelligence", intelligence_section)
+        assembled = assembler.assemble(
+            dispatch_metadata=meta,
+            instruction=instruction,
+        )
+        logger.info(
+            "_inject_skill_context: assembler path — role=%s L1=%d L2=%d L3=%d chars",
+            assembled.metadata.get("role"),
+            assembled.metadata.get("layer1_chars", 0),
+            assembled.metadata.get("layer2_chars", 0),
+            assembled.metadata.get("layer3_chars", 0),
+        )
+        return assembled.to_pipe_input()
+    except Exception as exc:
+        logger.warning(
+            "_inject_skill_context: PromptAssembler failed (%s) — falling back to legacy CLAUDE.md resolution",
+            exc,
+        )
+        return None
+
+
+def _legacy_claude_md_resolution(
+    terminal_id: str,
+    instruction: str,
+    role: str | None,
+    intelligence_section: str,
+) -> str:
+    """3-tier CLAUDE.md resolution fallback.
+
+    Resolves project root via the facade's ``__file__`` (same pattern as
+    ``_resolve_agent_cwd``) so tests that patch ``subprocess_dispatch.__file__``
+    can intercept the resolution (test_skill_context_injection).
+    """
+    import subprocess_dispatch as _sd
+    project_root = _sd.Path(_sd.__file__).resolve().parents[2]
+
+    candidates: list[Path] = []
+    if role:
+        candidates.append(project_root / "agents" / role / "CLAUDE.md")
+        candidates.append(project_root / ".claude" / "skills" / role / "CLAUDE.md")
+    candidates.append(project_root / ".claude" / "terminals" / terminal_id / "CLAUDE.md")
+
+    for path in candidates:
+        if path.exists():
+            context = path.read_text()
+            if intelligence_section:
+                return (
+                    f"{context}\n\n---\n\n"
+                    f"## Relevant Intelligence (from past dispatches)\n\n"
+                    f"{intelligence_section}\n"
+                    f"---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
+                )
+            return f"{context}\n\n---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
+
+    if intelligence_section:
+        return (
+            f"## Relevant Intelligence (from past dispatches)\n\n"
+            f"{intelligence_section}\n"
+            f"---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
+        )
+    return instruction
+
+
+def _resolve_agent_cwd(role: str | None) -> Path | None:
+    """Return agents/{role}/ as Path if the directory exists, else None.
+
+    Resolves project root via the facade's ``__file__`` and ``Path`` so tests
+    that patch ``subprocess_dispatch.Path`` can intercept the resolution
+    (test_subprocess_dispatch_f34.TestDeliverCwdPropagation).
+    """
+    if not role:
+        return None
+    import subprocess_dispatch as _sd
+    candidate = _sd.Path(_sd.__file__).resolve().parents[2] / "agents" / role
+    return candidate if candidate.is_dir() else None
+
+
+def _load_agent_profile(config_path: Path) -> str:
+    """Load governance_profile from agent config.yaml.
+
+    Uses a simple line-scan so no yaml dependency is required.
+    Returns 'default' when the key is absent or the file cannot be read.
+    """
+    try:
+        for line in config_path.read_text().splitlines():
+            line = line.strip()
+            if line.startswith("governance_profile:"):
+                return line.split(":", 1)[1].strip()
+    except Exception as _exc:
+        logger.warning("Failed to read agent config %s: %s", config_path, _exc)
+    return "default"

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -1,320 +1,38 @@
-"""skill_injection — layered prompt assembly + permission profile preamble."""
+"""skill_injection — compatibility re-export (canonical home: scripts/lib/skill_context.py).
+
+The worker prompt-context injection implementation moved to the lane-neutral
+``skill_context`` module so no dispatch lane imports from another lane's
+internal package (dispatch-20260801-w11-1313-layering). This module is a thin
+compat shim re-exporting the same names; existing imports and test patches at
+``subprocess_dispatch_internals.skill_injection`` keep resolving unchanged.
+
+New code should import from ``skill_context``.
+"""
 
 from __future__ import annotations
 
-import logging
-from pathlib import Path
+from skill_context import (
+    _build_intelligence_section,
+    _has_legacy_role_source,
+    _has_prompt_assembler_role,
+    _inject_permission_profile,
+    _inject_skill_context,
+    _legacy_claude_md_resolution,
+    _load_agent_profile,
+    _resolve_agent_cwd,
+    _resolve_effective_role,
+    _try_prompt_assembler,
+)
 
-logger = logging.getLogger(__name__)
-
-
-def _inject_permission_profile(terminal_id: str, role: str | None, instruction: str) -> str:
-    """Prepend permission preamble to instruction if a profile exists for role.
-
-    Resolves the terminal's expected role from terminal_assignments when role
-    is None.  Logs a warning on role/terminal mismatch.  Returns instruction
-    unchanged when no profile is found or worker_permissions cannot be loaded.
-    """
-    try:
-        from worker_permissions import (
-            load_permissions,
-            generate_permission_preamble,
-            validate_dispatch_permissions,
-        )
-    except ImportError:
-        logger.debug("_inject_permission_profile: worker_permissions not available, skipping")
-        return instruction
-
-    effective_role = _resolve_effective_role(terminal_id, role)
-    if not effective_role:
-        return instruction
-
-    warnings = validate_dispatch_permissions(
-        {"terminal": terminal_id, "role": effective_role}
-    )
-    for w in warnings:
-        logger.warning(w)
-
-    profile = load_permissions(effective_role)
-    if not profile.allowed_tools and not profile.denied_tools and not profile.bash_deny_patterns:
-        logger.debug("_inject_permission_profile: empty profile for role '%s', skipping preamble", effective_role)
-        return instruction
-
-    preamble = generate_permission_preamble(profile)
-    logger.info(
-        "Permission profile applied: terminal=%s role=%s allowed=%s denied=%s",
-        terminal_id, effective_role,
-        profile.allowed_tools,
-        profile.denied_tools,
-    )
-    return f"{preamble}\n---\n\n{instruction}"
-
-
-def _resolve_effective_role(terminal_id: str, role: str | None) -> str | None:
-    """Resolve effective role from terminal_assignments when role is None.
-
-    Uses the project-override-first path resolution from worker_permissions so
-    central-install and embedded installs both find the project's customised
-    worker_permissions.yaml rather than the immutable VNX_HOME template.
-    """
-    if role:
-        return role
-    try:
-        from worker_permissions import _resolve_permissions_yaml  # noqa: PLC0415
-        yaml_path = _resolve_permissions_yaml()
-        import yaml  # noqa: PLC0415
-        data = yaml.safe_load(yaml_path.read_text()) or {}
-        return data.get("terminal_assignments", {}).get(terminal_id)
-    except Exception as exc:
-        logger.debug("_inject_permission_profile: could not resolve role for %s: %s", terminal_id, exc)
-        return None
-
-
-def _build_intelligence_section(
-    dispatch_id: str,
-    role: str | None,
-    *,
-    dispatch_paths: "list[str] | None" = None,
-    instruction_text: str | None = None,
-    pr_id: str | None = None,
-) -> str:
-    """Return formatted intelligence items as markdown, or empty string (best-effort).
-
-    Delegates to intelligence_injection.fetch_intelligence_section so the same
-    logic serves all provider paths (codex/gemini/litellm/kimi) via
-    provider_dispatch.py.
-
-    _default_state_dir is fetched via subprocess_dispatch namespace so test
-    monkeypatches at the facade honour this call site unchanged.
-
-    dispatch_paths, instruction_text, pr_id are forwarded to selector.select() so
-    W5 item classes (adr_relevant, code_anchor, operator_memory, schema_section,
-    prior_round_finding) can fire in production dispatches.
-    """
-    try:
-        from intelligence_injection import fetch_intelligence_section  # noqa: PLC0415
-    except ImportError as exc:
-        logger.warning("intelligence injection failed (%s); proceeding without", exc)
-        return ""
-    # Look up _default_state_dir via subprocess_dispatch namespace so test
-    # monkeypatches at the facade ("subprocess_dispatch._default_state_dir")
-    # are honoured when this helper is called directly by tests.
-    import subprocess_dispatch as _sd
-    state_dir = _sd._default_state_dir()
-    return fetch_intelligence_section(
-        dispatch_id=dispatch_id,
-        role=role,
-        state_dir=state_dir,
-        pr_id=pr_id,
-        dispatch_paths=dispatch_paths,
-        instruction_text=instruction_text,
-    )
-
-
-def _inject_skill_context(
-    terminal_id: str,
-    instruction: str,
-    role: str | None = None,
-    dispatch_metadata: "dict | None" = None,
-) -> str:
-    """Compose layered user message context for headless dispatch.
-
-    Uses PromptAssembler (3-layer architecture) when available, with fallback
-    to the legacy 3-tier CLAUDE.md resolution for backward compatibility.
-
-    Layer architecture (PromptAssembler path):
-      Layer 1 — Base worker context (universal rules, report format)
-      Layer 2 — Role context (capabilities, permissions for the role)
-      Layer 3 — Dispatch payload (passed through as instruction)
-
-    Legacy fallback (3-tier CLAUDE.md resolution):
-      1. agents/{role}/CLAUDE.md        — project-level agent override
-      2. .claude/skills/{role}/CLAUDE.md — skill definition
-      3. .claude/terminals/{terminal}/CLAUDE.md — terminal fallback
-
-    Args:
-        terminal_id:       Terminal identifier (e.g. "T1").
-        instruction:       Raw dispatch instruction text.
-        role:              Agent role (e.g. "backend-developer").
-        dispatch_metadata: Optional metadata dict forwarded to PromptAssembler
-                           for L3 enrichments (dispatch_id, gate, pr, track, model,
-                           intelligence, historical).  Merged with terminal+role.
-
-    Returns the full pipe_input string ready for `claude -p`.
-    """
-    # Gather intelligence before assembling prompt (best-effort).  Looked up via
-    # subprocess_dispatch namespace so test patches at the facade are honoured.
-    import subprocess_dispatch as _sd
-    _dispatch_id = (dispatch_metadata or {}).get("dispatch_id") or ""
-    _dispatch_paths = (dispatch_metadata or {}).get("dispatch_paths") or []
-    _instruction_text = instruction
-    _pr_id = (dispatch_metadata or {}).get("pr_id") or (dispatch_metadata or {}).get("pr")
-    intelligence_section = _sd._build_intelligence_section(
-        _dispatch_id, role,
-        dispatch_paths=_dispatch_paths,
-        instruction_text=_instruction_text,
-        pr_id=_pr_id,
-    )
-
-    assembled = _try_prompt_assembler(
-        terminal_id, instruction, role, dispatch_metadata, intelligence_section,
-    )
-    if assembled is not None:
-        return assembled
-
-    return _legacy_claude_md_resolution(
-        terminal_id, instruction, role, intelligence_section,
-    )
-
-
-def _has_prompt_assembler_role(role: str | None) -> bool:
-    """True when PromptAssembler has a role prompt for *role*.
-
-    PromptAssembler's L2 reads ``scripts/lib/prompts/roles/<role>.md`` and falls
-    back to base_worker.md when the file is missing — so two distinct roles
-    WITHOUT a prompt file (e.g. quality-engineer vs system-architect) would
-    otherwise receive byte-identical context.
-    """
-    if not role:
-        return False
-    return (Path(__file__).resolve().parent.parent / "prompts" / "roles" / f"{role}.md").exists()
-
-
-def _has_legacy_role_source(role: str | None) -> bool:
-    """True when the legacy 3-tier has a ROLE-SPECIFIC source (agents/ or skills/).
-
-    Terminal fallback is deliberately excluded: it is generic per terminal, not
-    role context. Only role-specific sources decide the routing below.
-    """
-    if not role:
-        return False
-    import subprocess_dispatch as _sd
-    root = _sd.Path(_sd.__file__).resolve().parents[2]
-    return (
-        (root / "agents" / role / "CLAUDE.md").exists()
-        or (root / ".claude" / "skills" / role / "CLAUDE.md").exists()
-    )
-
-
-def _try_prompt_assembler(
-    terminal_id: str,
-    instruction: str,
-    role: str | None,
-    dispatch_metadata: "dict | None",
-    intelligence_section: str,
-) -> str | None:
-    """Attempt PromptAssembler path; return assembled pipe_input or None on failure.
-
-    Dispatch-20260801-w10 routing fix: when the role has a project-level
-    agents/skills source but NO PromptAssembler role prompt, return None to route
-    through the legacy 3-tier resolution. PromptAssembler would otherwise
-    silently substitute base_worker.md as L2, so a dispatch with
-    ``role=quality-engineer`` got the exact same context as one with
-    ``role=system-architect``. Roles WITH a prompt file (backend-developer,
-    test-engineer, ...) keep using PromptAssembler unchanged.
-    """
-    if _has_prompt_assembler_role(role) is False and _has_legacy_role_source(role):
-        logger.info(
-            "_inject_skill_context: role=%s has no PromptAssembler prompt but has a "
-            "legacy role source — using legacy 3-tier so agents/{role}/CLAUDE.md reaches the worker",
-            role,
-        )
-        return None
-    try:
-        from prompt_assembler import PromptAssembler  # noqa: PLC0415
-        assembler = PromptAssembler()
-        meta = dict(dispatch_metadata or {})
-        meta.setdefault("role", role or "")
-        meta.setdefault("terminal", terminal_id)
-        if intelligence_section:
-            meta.setdefault("intelligence", intelligence_section)
-        assembled = assembler.assemble(
-            dispatch_metadata=meta,
-            instruction=instruction,
-        )
-        logger.info(
-            "_inject_skill_context: assembler path — role=%s L1=%d L2=%d L3=%d chars",
-            assembled.metadata.get("role"),
-            assembled.metadata.get("layer1_chars", 0),
-            assembled.metadata.get("layer2_chars", 0),
-            assembled.metadata.get("layer3_chars", 0),
-        )
-        return assembled.to_pipe_input()
-    except Exception as exc:
-        logger.warning(
-            "_inject_skill_context: PromptAssembler failed (%s) — falling back to legacy CLAUDE.md resolution",
-            exc,
-        )
-        return None
-
-
-def _legacy_claude_md_resolution(
-    terminal_id: str,
-    instruction: str,
-    role: str | None,
-    intelligence_section: str,
-) -> str:
-    """3-tier CLAUDE.md resolution fallback.
-
-    Resolves project root via the facade's ``__file__`` (same pattern as
-    ``_resolve_agent_cwd``) so tests that patch ``subprocess_dispatch.__file__``
-    can intercept the resolution (test_skill_context_injection).
-    """
-    import subprocess_dispatch as _sd
-    project_root = _sd.Path(_sd.__file__).resolve().parents[2]
-
-    candidates: list[Path] = []
-    if role:
-        candidates.append(project_root / "agents" / role / "CLAUDE.md")
-        candidates.append(project_root / ".claude" / "skills" / role / "CLAUDE.md")
-    candidates.append(project_root / ".claude" / "terminals" / terminal_id / "CLAUDE.md")
-
-    for path in candidates:
-        if path.exists():
-            context = path.read_text()
-            if intelligence_section:
-                return (
-                    f"{context}\n\n---\n\n"
-                    f"## Relevant Intelligence (from past dispatches)\n\n"
-                    f"{intelligence_section}\n"
-                    f"---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
-                )
-            return f"{context}\n\n---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
-
-    if intelligence_section:
-        return (
-            f"## Relevant Intelligence (from past dispatches)\n\n"
-            f"{intelligence_section}\n"
-            f"---\n\nDISPATCH INSTRUCTION:\n\n{instruction}"
-        )
-    return instruction
-
-
-def _resolve_agent_cwd(role: str | None) -> Path | None:
-    """Return agents/{role}/ as Path if the directory exists, else None.
-
-    Resolves project root via the facade's ``__file__`` and ``Path`` so tests
-    that patch ``subprocess_dispatch.Path`` can intercept the resolution
-    (test_subprocess_dispatch_f34.TestDeliverCwdPropagation).
-    """
-    if not role:
-        return None
-    import subprocess_dispatch as _sd
-    candidate = _sd.Path(_sd.__file__).resolve().parents[2] / "agents" / role
-    return candidate if candidate.is_dir() else None
-
-
-def _load_agent_profile(config_path: Path) -> str:
-    """Load governance_profile from agent config.yaml.
-
-    Uses a simple line-scan so no yaml dependency is required.
-    Returns 'default' when the key is absent or the file cannot be read.
-    """
-    try:
-        for line in config_path.read_text().splitlines():
-            line = line.strip()
-            if line.startswith("governance_profile:"):
-                return line.split(":", 1)[1].strip()
-    except Exception as _exc:
-        logger.warning("Failed to read agent config %s: %s", config_path, _exc)
-    return "default"
+__all__ = [
+    "_build_intelligence_section",
+    "_has_legacy_role_source",
+    "_has_prompt_assembler_role",
+    "_inject_permission_profile",
+    "_inject_skill_context",
+    "_legacy_claude_md_resolution",
+    "_load_agent_profile",
+    "_resolve_agent_cwd",
+    "_resolve_effective_role",
+    "_try_prompt_assembler",
+]

--- a/scripts/lib/subprocess_dispatch_internals/skill_injection.py
+++ b/scripts/lib/subprocess_dispatch_internals/skill_injection.py
@@ -167,6 +167,35 @@ def _inject_skill_context(
     )
 
 
+def _has_prompt_assembler_role(role: str | None) -> bool:
+    """True when PromptAssembler has a role prompt for *role*.
+
+    PromptAssembler's L2 reads ``scripts/lib/prompts/roles/<role>.md`` and falls
+    back to base_worker.md when the file is missing — so two distinct roles
+    WITHOUT a prompt file (e.g. quality-engineer vs system-architect) would
+    otherwise receive byte-identical context.
+    """
+    if not role:
+        return False
+    return (Path(__file__).resolve().parent.parent / "prompts" / "roles" / f"{role}.md").exists()
+
+
+def _has_legacy_role_source(role: str | None) -> bool:
+    """True when the legacy 3-tier has a ROLE-SPECIFIC source (agents/ or skills/).
+
+    Terminal fallback is deliberately excluded: it is generic per terminal, not
+    role context. Only role-specific sources decide the routing below.
+    """
+    if not role:
+        return False
+    import subprocess_dispatch as _sd
+    root = _sd.Path(_sd.__file__).resolve().parents[2]
+    return (
+        (root / "agents" / role / "CLAUDE.md").exists()
+        or (root / ".claude" / "skills" / role / "CLAUDE.md").exists()
+    )
+
+
 def _try_prompt_assembler(
     terminal_id: str,
     instruction: str,
@@ -174,7 +203,23 @@ def _try_prompt_assembler(
     dispatch_metadata: "dict | None",
     intelligence_section: str,
 ) -> str | None:
-    """Attempt PromptAssembler path; return assembled pipe_input or None on failure."""
+    """Attempt PromptAssembler path; return assembled pipe_input or None on failure.
+
+    Dispatch-20260801-w10 routing fix: when the role has a project-level
+    agents/skills source but NO PromptAssembler role prompt, return None to route
+    through the legacy 3-tier resolution. PromptAssembler would otherwise
+    silently substitute base_worker.md as L2, so a dispatch with
+    ``role=quality-engineer`` got the exact same context as one with
+    ``role=system-architect``. Roles WITH a prompt file (backend-developer,
+    test-engineer, ...) keep using PromptAssembler unchanged.
+    """
+    if _has_prompt_assembler_role(role) is False and _has_legacy_role_source(role):
+        logger.info(
+            "_inject_skill_context: role=%s has no PromptAssembler prompt but has a "
+            "legacy role source — using legacy 3-tier so agents/{role}/CLAUDE.md reaches the worker",
+            role,
+        )
+        return None
     try:
         from prompt_assembler import PromptAssembler  # noqa: PLC0415
         assembler = PromptAssembler()

--- a/tests/test_bench_equal_context.py
+++ b/tests/test_bench_equal_context.py
@@ -71,7 +71,7 @@ def test_provider_without_equal_context_invokes_existing_enrichers(monkeypatch):
     )
     monkeypatch.setitem(
         sys.modules,
-        "subprocess_dispatch_internals.skill_injection",
+        "skill_context",
         SimpleNamespace(_inject_skill_context=inject_skill),
     )
     monkeypatch.delenv("VNX_BENCH_EQUAL_CONTEXT", raising=False)

--- a/tests/test_bench_equal_context.py
+++ b/tests/test_bench_equal_context.py
@@ -58,28 +58,32 @@ def test_provider_equal_context_returns_instruction_byte_for_byte(monkeypatch):
 
 
 def test_provider_without_equal_context_invokes_existing_enrichers(monkeypatch):
-    intelligence = Mock(return_value="intelligence-added")
+    # dispatch-20260801-w10: _enrich_instruction now applies the repo-map layer to
+    # the RAW instruction first, then assembles via the shared injector
+    # (_inject_skill_context), which owns intelligence + role context. The
+    # intelligence_injection module is no longer called directly here.
     repo_map = Mock(return_value="repo-map-added")
-    monkeypatch.setitem(
-        sys.modules,
-        "intelligence_injection",
-        SimpleNamespace(build_intelligence_section=intelligence),
-    )
+    inject_skill = Mock(return_value="assembled")
     monkeypatch.setitem(
         sys.modules,
         "dispatch_enricher",
         SimpleNamespace(apply_repo_map_layer=repo_map),
     )
+    monkeypatch.setitem(
+        sys.modules,
+        "subprocess_dispatch_internals.skill_injection",
+        SimpleNamespace(_inject_skill_context=inject_skill),
+    )
     monkeypatch.delenv("VNX_BENCH_EQUAL_CONTEXT", raising=False)
 
     result = provider_dispatch._enrich_instruction(_provider_args())
 
-    assert result == "repo-map-added"
-    intelligence.assert_called_once()
+    assert result == "assembled"
     repo_map.assert_called_once_with(
-        "intelligence-added",
+        RAW_INSTRUCTION,
         {"role": "security-engineer"},
     )
+    inject_skill.assert_called_once()
 
 
 def test_tmux_equal_context_skips_all_context_assembly(monkeypatch, tmp_path):

--- a/tests/test_intelligence_selector.py
+++ b/tests/test_intelligence_selector.py
@@ -2527,7 +2527,7 @@ class TestInjectSkillContextEndToEnd(unittest.TestCase):
         selector.select() carrying dispatch_paths, instruction_text, and pr_id."""
         from unittest.mock import MagicMock, patch
         import importlib
-        import subprocess_dispatch_internals.skill_injection as si
+        import skill_context as si
 
         mock_result = MagicMock()
         mock_result.items = []

--- a/tests/test_provider_dispatch_intelligence.py
+++ b/tests/test_provider_dispatch_intelligence.py
@@ -118,9 +118,13 @@ class TestEnrichInstructionHelper:
         with patch.object(provider_dispatch, "_resolve_state_dir", return_value=tmp_path):
             with _patch_selector(result):
                 enriched = provider_dispatch._enrich_instruction(args)
-        assert "Relevant Intelligence" in enriched
+        # dispatch-20260801-w10: _enrich_instruction now assembles via the shared
+        # injector (L1+L2 + DISPATCH INSTRUCTION + L3). Intelligence still reaches
+        # the prompt (TestAntipattern item), the raw instruction is preserved, and
+        # the assembled prompt is wrapped by the injector.
         assert "TestAntipattern" in enriched
         assert "base instruction" in enriched
+        assert "DISPATCH INSTRUCTION:" in enriched
 
     def test_returns_original_instruction_when_no_intelligence(self, tmp_path):
         args = _make_args("gemini", instruction="original work")
@@ -128,13 +132,17 @@ class TestEnrichInstructionHelper:
         with patch.object(provider_dispatch, "_resolve_state_dir", return_value=tmp_path):
             with _patch_selector(result):
                 enriched = provider_dispatch._enrich_instruction(args)
-        assert enriched == "original work"
+        # The raw instruction survives assembly even when no intelligence items
+        # resolve; the role context is now layered around it.
+        assert "original work" in enriched
 
     def test_returns_original_on_intelligence_injection_import_failure(self):
         args = _make_args("litellm:deepseek")
         with patch.dict(sys.modules, {"intelligence_injection": None}):
             enriched = provider_dispatch._enrich_instruction(args)
-        assert enriched == "base instruction"
+        # Intelligence is best-effort inside the shared injector; an import
+        # failure must not crash enrichment or drop the instruction.
+        assert "base instruction" in enriched
 
     def test_dispatch_paths_parsed_from_args(self, tmp_path):
         args = _make_args("codex")
@@ -184,7 +192,7 @@ class TestCodexIntelligenceWiring:
                         with patch("event_store.EventStore"):
                             provider_dispatch._dispatch_codex(args)
         prompt_used = mock_spawn.call_args[1].get("prompt") or mock_spawn.call_args[0][0]
-        assert prompt_used == "plain codex task"
+        assert "plain codex task" in prompt_used
 
 
 # ---------------------------------------------------------------------------
@@ -217,7 +225,7 @@ class TestGeminiIntelligenceWiring:
                         with patch("event_store.EventStore"):
                             provider_dispatch._dispatch_gemini(args)
         prompt_used = mock_spawn.call_args[1].get("prompt") or mock_spawn.call_args[0][0]
-        assert prompt_used == "plain gemini task"
+        assert "plain gemini task" in prompt_used
 
 
 # ---------------------------------------------------------------------------
@@ -264,7 +272,7 @@ class TestLitellmIntelligenceWiring:
                                 with patch("providers.provider_registry.get_default_model", return_value=self._mock_registry().get_default_model.return_value):
                                     provider_dispatch._dispatch_litellm(args)
         prompt_used = mock_spawn.call_args[1].get("prompt") or mock_spawn.call_args[0][0]
-        assert prompt_used == "plain litellm task"
+        assert "plain litellm task" in prompt_used
 
 
 # ---------------------------------------------------------------------------
@@ -298,7 +306,7 @@ class TestKimiIntelligenceWiring:
                         with patch("event_store.EventStore"):
                             provider_dispatch._dispatch_kimi(args)
         prompt_used = mock_spawn.call_args[1].get("prompt") or mock_spawn.call_args[0][0]
-        assert prompt_used == "plain kimi task"
+        assert "plain kimi task" in prompt_used
 
     def test_kimi_enrich_called_once_no_double_enrichment(self, tmp_path):
         args = _make_args("kimi")

--- a/tests/test_role_applied_provider_lane.py
+++ b/tests/test_role_applied_provider_lane.py
@@ -36,9 +36,9 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib
 
 import dispatch_envelope
 import provider_dispatch
+import skill_context
 from dispatch_envelope import EnvelopeSpec, _AdapterResult
 from role_application import verify_role_applied
-from subprocess_dispatch_internals import skill_injection
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -84,7 +84,7 @@ def test_provider_lane_role_context_reaches_final_prompt(tmp_path):
     so no role context reached the worker at all.
     """
     args = _make_args("quality-engineer")
-    with patch.object(skill_injection, "_try_prompt_assembler", return_value=None):
+    with patch.object(skill_context, "_try_prompt_assembler", return_value=None):
         enriched = _enrich(args, tmp_path)
 
     agents_md = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()

--- a/tests/test_role_applied_provider_lane.py
+++ b/tests/test_role_applied_provider_lane.py
@@ -21,6 +21,12 @@ These tests pin the contract:
      that path unchanged — the shared injector is not regressed.
   5. the envelope GOVERN path stamps role_applied / role_tier /
      role_not_applied_reason on the receipt.
+  6. (round-3 gate fix) only the RESOLVED, highest-priority source's content may
+     evidence role application — terminal fallback content must NOT stamp
+     role_applied=True when an existing agents/<role>/CLAUDE.md is absent from
+     the final prompt (RED on round-2 code).
+  7. the genuine positive case still returns True after the round-3 fix — the
+     probe is not made stricter until it never says yes (OI-893).
 """
 
 from __future__ import annotations
@@ -242,3 +248,51 @@ def test_envelope_receipt_stamps_role_applied_false(tmp_path):
     assert receipt.get("role_applied") is False
     assert receipt.get("role_tier") == "agents"
     assert receipt.get("role_not_applied_reason") is not None
+
+
+# ---------------------------------------------------------------------------
+# 6. round-3 gate fix: only the RESOLVED (highest-priority) source may evidence
+#    role application — a lower-priority tier's presence must not stamp True
+# ---------------------------------------------------------------------------
+
+
+def test_role_applied_false_when_resolved_source_absent_but_lower_tier_present():
+    """agents/quality-engineer/CLAUDE.md EXISTS but is absent from the final
+    prompt, while terminal-fallback (T1/CLAUDE.md) content IS present.
+    role_applied must be False.
+
+    RED on dispatch-20260801-w10 (round-2 code): the first pass accepted content
+    from ANY candidate, so the terminal fallback stamped role_applied=True even
+    though the role's own source never reached the worker — the exact
+    false-positive the round-3 gate flagged.
+    """
+    terminal_body = (REPO_ROOT / ".claude" / "terminals" / "T1" / "CLAUDE.md").read_text()
+    agents_body = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()
+    # Sanity: the two bodies are distinct, otherwise the test is vacuous.
+    assert "Quality Engineer Agent" in agents_body
+    assert "Backend Developer Agent" in terminal_body
+
+    final_prompt = f"{terminal_body}\n\n---\n\nimplement the change"
+
+    verdict = verify_role_applied(final_prompt, "T1", "quality-engineer")
+
+    assert verdict.role_applied is False
+    assert verdict.tier == "agents"
+    assert verdict.reason is not None
+    assert "absent from the final prompt" in verdict.reason
+    assert "terminal" in verdict.reason  # the lower-tier presence is recorded
+
+
+def test_role_applied_true_when_resolved_source_present():
+    """The genuine positive case still holds after the round-3 fix: when the
+    resolved (highest-priority) source's content IS in the final prompt,
+    role_applied must be True — the fix must not make the probe never say yes.
+    """
+    agents_body = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()
+    final_prompt = f"{agents_body}\n\n---\n\nimplement the change"
+
+    verdict = verify_role_applied(final_prompt, "T1", "quality-engineer")
+
+    assert verdict.role_applied is True
+    assert verdict.tier == "agents"
+    assert verdict.reason is None

--- a/tests/test_role_applied_provider_lane.py
+++ b/tests/test_role_applied_provider_lane.py
@@ -1,0 +1,244 @@
+"""test_role_applied_provider_lane.py — dispatch-20260801-w10.
+
+The provider/envelope lanes previously assembled the final prompt WITHOUT the
+role's own CLAUDE.md context — a dispatch staged with ``role=quality-engineer``
+received byte-identical context to ``role=system-architect``. This dispatch:
+
+  1. wires the SAME injector the tmux/subprocess lanes use
+     (``_inject_skill_context``) into the provider/envelope assembly path, and
+  2. adds a deterministic control (``role_application.verify_role_applied``)
+     that verifies the resolved role source's content actually reached the
+     assembled prompt, then stamps ``role_applied`` / ``role_tier`` /
+     ``role_not_applied_reason`` on the receipt.
+
+These tests pin the contract:
+  1. provider-lane enrichment with role=X contains agents/X/CLAUDE.md content
+     (red on origin/main — the old code never injected the role context).
+  2. ``role_applied`` is correctly False when the role does not resolve (a
+     control that can only say "yes" is no control — OI-893).
+  3. a REAL assembly for two distinct roles produces visibly different context.
+  4. roles that have a PromptAssembler prompt (backend-developer) keep using
+     that path unchanged — the shared injector is not regressed.
+  5. the envelope GOVERN path stamps role_applied / role_tier /
+     role_not_applied_reason on the receipt.
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+import dispatch_envelope
+import provider_dispatch
+from dispatch_envelope import EnvelopeSpec, _AdapterResult
+from role_application import verify_role_applied
+from subprocess_dispatch_internals import skill_injection
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+def _make_args(role, instruction="implement the change", terminal_id="T1"):
+    return SimpleNamespace(
+        provider="litellm:deepseek",
+        dispatch_id="w10-role-applied-test",
+        terminal_id=terminal_id,
+        instruction=instruction,
+        model="deepseek-v4-pro",
+        pr_id=None,
+        dispatch_paths="",
+        role=role,
+        no_auto_commit=True,
+        max_retries=1,
+        gate="",
+        deadline_seconds=900,
+    )
+
+
+def _enrich(args, tmp_path):
+    """Run _enrich_instruction with state/data dirs redirected to tmp_path and
+    intelligence suppressed so the test is deterministic (no central DB)."""
+    with (
+        patch.object(provider_dispatch, "_resolve_state_dir", return_value=tmp_path),
+        patch.object(provider_dispatch, "_resolve_data_dir", return_value=tmp_path),
+        patch("subprocess_dispatch._build_intelligence_section", return_value=""),
+    ):
+        return provider_dispatch._enrich_instruction(args)
+
+
+# ---------------------------------------------------------------------------
+# 1. role=X -> agents/X/CLAUDE.md content reaches the final prompt
+# ---------------------------------------------------------------------------
+
+
+def test_provider_lane_role_context_reaches_final_prompt(tmp_path):
+    """A provider-lane dispatch with role='quality-engineer' must receive
+    agents/quality-engineer/CLAUDE.md content in its enriched final prompt.
+
+    RED on origin/main: the provider lane previously never called the injector,
+    so no role context reached the worker at all.
+    """
+    args = _make_args("quality-engineer")
+    with patch.object(skill_injection, "_try_prompt_assembler", return_value=None):
+        enriched = _enrich(args, tmp_path)
+
+    agents_md = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()
+    assert "Quality Engineer Agent" in enriched, (
+        "agents/quality-engineer/CLAUDE.md content must reach the provider-lane final prompt"
+    )
+    assert "Quality Engineer Agent" in agents_md  # sanity: marker comes from the role file
+    # The deterministic control agrees the role was applied, resolved via agents/.
+    assert args._role_application.role_applied is True
+    assert args._role_application.tier == "agents"
+
+
+# ---------------------------------------------------------------------------
+# 2. role_applied is correctly False when the role does not resolve
+# ---------------------------------------------------------------------------
+
+
+def test_role_applied_false_when_no_role_source(tmp_path):
+    """A role with no agents/skills/prompts/terminal source must yield
+    role_applied=False with a reason (the control can say "no")."""
+    fake_root = tmp_path / "bare_repo"
+    fake_root.mkdir()
+    (fake_root / ".claude" / "terminals").mkdir(parents=True)  # no terminal file either
+
+    verdict = verify_role_applied(
+        "some assembled prompt body", "T1", "nonexistent-role-xyz",
+        project_root=fake_root,
+    )
+
+    assert verdict.role_applied is False
+    assert verdict.tier == "none"
+    assert verdict.reason is not None
+    assert "no role source resolved" in verdict.reason
+
+
+def test_role_applied_false_when_resolved_but_content_absent(tmp_path):
+    """A role that RESOLVES (agents/ exists) but whose content never made it into
+    the prompt must yield role_applied=False with a reason — this is what catches
+    a silent role-routing layer that only moves a parameter around."""
+    verdict = verify_role_applied(
+        "a prompt that does not mention the role at all",
+        "T1",
+        "quality-engineer",  # agents/quality-engineer/CLAUDE.md exists in this repo
+    )
+
+    assert verdict.role_applied is False
+    assert verdict.tier == "agents"
+    assert verdict.reason is not None
+    assert "absent from the final prompt" in verdict.reason
+
+
+# ---------------------------------------------------------------------------
+# 3. real assembly: two distinct roles produce visibly different context
+# ---------------------------------------------------------------------------
+
+
+def test_real_assembly_two_roles_differ(tmp_path):
+    """A real assembly for quality-engineer vs system-architect must differ —
+    the proof that the role has an effect on the delivered prompt."""
+    qe_args = _make_args("quality-engineer")
+    sa_args = _make_args("system-architect")
+
+    qe_prompt = _enrich(qe_args, tmp_path)
+    sa_prompt = _enrich(sa_args, tmp_path)
+
+    assert "Quality Engineer Agent" in qe_prompt
+    assert "System Architect Agent" in sa_prompt
+    assert qe_prompt != sa_prompt, (
+        "two distinct roles must not receive byte-identical context"
+    )
+    assert qe_args._role_application.role_applied is True
+    assert qe_args._role_application.tier == "agents"
+    assert sa_args._role_application.role_applied is True
+    assert sa_args._role_application.tier == "agents"
+
+
+# ---------------------------------------------------------------------------
+# 4. shared injector unchanged for PromptAssembler-backed roles
+# ---------------------------------------------------------------------------
+
+
+def test_prompt_assembler_role_still_used(tmp_path):
+    """backend-developer has a PromptAssembler prompt (prompts/roles/) — that path
+    must keep working unchanged, reported as tier='prompt_assembler'."""
+    args = _make_args("backend-developer")
+
+    prompt = _enrich(args, tmp_path)
+
+    assert "Backend Developer" in prompt  # from prompts/roles/backend-developer.md
+    assert args._role_application.role_applied is True
+    assert args._role_application.tier == "prompt_assembler"
+
+
+# ---------------------------------------------------------------------------
+# 5. receipt stamping via the envelope GOVERN path
+# ---------------------------------------------------------------------------
+
+
+def _run_envelope_govern(tmp_path, *, instruction, role):
+    state = tmp_path / "state"
+    state.mkdir()
+    data = tmp_path / "data"
+    (data / "unified_reports").mkdir(parents=True)
+    spec = EnvelopeSpec(
+        dispatch_id="w10-receipt-stamp",
+        terminal_id="T1",
+        provider="codex",
+        model="gpt-test",
+        instruction=instruction,
+        role=role,
+        pr_id=None,
+        state_dir=state,
+        data_dir=data,
+    )
+    result = _AdapterResult(returncode=0, completion_text="all good", status="success")
+    start = end = datetime.now(timezone.utc)
+    with (
+        patch("dispatch_envelope._archive_dispatch_events", return_value=None),
+        patch("dispatch_envelope._clear_dispatch_events"),
+        patch("provider_costs.emit_provider_cost"),
+        patch("phantom_guard.record_phantom_if_any"),
+        patch("phantom_guard.record_guard_error"),
+    ):
+        dispatch_envelope._govern(spec, result, start, end)
+    receipt_path = state / "t0_receipts.ndjson"
+    assert receipt_path.exists(), "receipt must be emitted"
+    lines = [ln for ln in receipt_path.read_text(encoding="utf-8").splitlines() if ln.strip()]
+    receipt = json.loads(lines[-1])
+    assert receipt["dispatch_id"] == "w10-receipt-stamp"
+    return receipt
+
+
+def test_envelope_receipt_stamps_role_applied_true(tmp_path):
+    """When the resolved role source IS in the enriched instruction, the receipt
+    stamps role_applied=True + role_tier='agents'."""
+    role_body = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()
+    receipt = _run_envelope_govern(
+        tmp_path,
+        instruction=f"{role_body}\n\n---\n\nimplement the change",
+        role="quality-engineer",
+    )
+    assert receipt.get("role_applied") is True
+    assert receipt.get("role_tier") == "agents"
+    assert receipt.get("role_not_applied_reason") is None
+
+
+def test_envelope_receipt_stamps_role_applied_false(tmp_path):
+    """When the resolved role source is absent from the enriched instruction, the
+    receipt stamps role_applied=False + role_tier + role_not_applied_reason."""
+    receipt = _run_envelope_govern(
+        tmp_path,
+        instruction="no role context in this body at all",
+        role="quality-engineer",
+    )
+    assert receipt.get("role_applied") is False
+    assert receipt.get("role_tier") == "agents"
+    assert receipt.get("role_not_applied_reason") is not None

--- a/tests/test_skill_context_injection.py
+++ b/tests/test_skill_context_injection.py
@@ -85,7 +85,7 @@ def _call_with_fake_root(fake_root: Path, terminal_id: str, instruction: str) ->
     with (
         patch.object(subprocess_dispatch, "__file__", str(fake_file)),
         patch(
-            "subprocess_dispatch_internals.skill_injection._try_prompt_assembler",
+            "skill_context._try_prompt_assembler",
             return_value=None,
         ),
         patch.object(

--- a/tests/test_skill_injection_wave5.py
+++ b/tests/test_skill_injection_wave5.py
@@ -125,9 +125,9 @@ class TestInjectSkillContextExtractsMetadata:
         }
         instruction = "Implement the layered prompt assembler with ADR grounding"
 
-        with patch("subprocess_dispatch_internals.skill_injection._try_prompt_assembler", return_value=None):
+        with patch("skill_context._try_prompt_assembler", return_value=None):
             with patch(
-                "subprocess_dispatch_internals.skill_injection._legacy_claude_md_resolution",
+                "skill_context._legacy_claude_md_resolution",
                 return_value=instruction,
             ):
                 _inject_skill_context("T1", instruction, role="backend-developer", dispatch_metadata=metadata)

--- a/tests/test_subprocess_dispatch_f34.py
+++ b/tests/test_subprocess_dispatch_f34.py
@@ -206,7 +206,7 @@ class TestInjectSkillContextIntegration:
             return real_path_cls(*args, **kwargs)
 
         with patch("subprocess_dispatch.Path", side_effect=fake_path), \
-             patch("subprocess_dispatch_internals.skill_injection._try_prompt_assembler", return_value=None):
+             patch("skill_context._try_prompt_assembler", return_value=None):
             yield
 
     def test_inject_prepends_agents_context(self, tmp_path):


### PR DESCRIPTION
## Wat dit oplost

De provider-lane (codex/gemini/litellm/deepseek-harness/kimi) assembleerde de eindprompt zónder de rol-context van de worker. Een dispatch met `role=quality-engineer` kreeg exact dezelfde context als `role=system-architect` — `_inject_skill_context` (de injector die tmux/subprocess-lanes al gebruiken) werd op dat pad nooit aangeroepen; alleen intelligence + repo-map werden toegepast.

## Deel A — bedraden

- `provider_dispatch._enrich_instruction` en `dispatch_envelope._prepare` roepen nu de BESTAANDE `_inject_skill_context` aan, met dezelfde role-label-fallback als tmux.
- Routing-fix in `_try_prompt_assembler`: rollen zonder `prompts/roles/<role>.md` maar mét een `agents/`/`skills/`-bron (quality-engineer, system-architect, orchestrator) gaan naar de legacy 3-tier, zodat `agents/{role}/CLAUDE.md` de worker bereikt. PromptAssembler gaf die rollen anders dezelfde `base_worker.md`-context.

## Deel B — deterministische controle (operator-verzoek)

- Nieuw `role_application.py`: een stringvergelijking (géén modelaanroep) die na assemblage checkt of de inhoud van de geresolveerde rolbron in de eindprompt voorkomt. Whitespace-genormaliseerde substring: volledige inhoud primair, langste zin als robuuste marker-fallback.
- Uitkomst wordt op de receipt gestempeld: `role_applied`, `role_tier` (prompt_assembler/agents/skills/terminal/none), `role_not_applied_reason`, `role_source_path`.

## Verificatie

- `tests/test_role_applied_provider_lane.py` (nieuw, 7 tests): agents/X/CLAUDE.md bereikt de eindprompt (rood op origin/main), `role_applied` kan "nee" zeggen, echte assemblage voor quality-engineer vs system-architect verschilt, PromptAssembler-rollen onveranderd, receipt-stamping.
- Regressie: 119 + 140 + 234 getroffen tests groen. Enige rode meldingen zijn pre-existente environment-failures (registry-constraint, timing, centrale DB-intelligence) die identiek op origin/main falen.
- `ruff check` op alle gewijzigde bestanden: alleen pre-existente E402's.

## Open items

- PromptAssembler-rollen zonder prompt-bestand én zonder agents/skills-bron vallen op `base_worker.md` terug; verdict rapporteert dat eerlijk als `role_applied=False`.
- Het verdict wordt gestempeld op de provider/envelope-GOVERN-paden; de claude-delegate- en tmux-route stempelen het nog niet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)