### PR TITLE
fix(reconcile): resolve gh absolute path + track_freshness autoclose health

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -13,13 +13,20 @@ With --format brief: schema 1.0 backward-compat (t0_brief.json format)
 
 Schema 2.2 changes (fabric-freshness):
   - Additive, backward-compatible: a top-level ``track_freshness`` marker
-    {reconciled, tracks, drifted, drifted_tracks, reason, seconds, store}.
+    {derived_refreshed, tracks, drifted, drifted_tracks, reason, seconds,
+    store, last_reconcile_at, last_reconcile_age_hours, gh_health,
+    nominated_not_closed, autoclose_degraded, autoclose_reason}.
     Before projecting, the builder runs the advisory track reconciler against
     the central tracks SSOT and records declared-vs-derived drift here, so the
-    SessionStart snapshot carries its own freshness. A compact form
-    {reconciled, drifted, tracks, reason} is also surfaced in t0_index.json
-    (the always-loaded cold-start file). Consumers that predate 2.2 ignore the
-    new key (no removals/renames).
+    SessionStart snapshot carries its own freshness. ``derived_refreshed``
+    (renamed from ``reconciled``, which over-claimed) reports ONLY the
+    derived-status refresh. The auto-close reconciler's real health — last run
+    time/age, gh health, nominated-but-not-closed backlog, and the
+    ``autoclose_degraded`` boolean — is read from reconcile_summary.json, so a
+    downed auto-close reconciler is visible instead of reading as green. A
+    compact form {derived_refreshed, drifted, tracks, reason,
+    autoclose_degraded, autoclose_reason} is also surfaced in t0_index.json
+    (the always-loaded cold-start file).
 
 Schema 2.2 addition (OI-896, auto-dream reviews):
   - Additive, backward-compatible: a top-level ``dream_reviews`` section
@@ -1871,6 +1878,104 @@ def _resolve_tracks_store(state_dir: Path, project_id: str) -> Path:
     return state_dir
 
 
+# ---------------------------------------------------------------------------
+# Auto-close reconciler health (reconcile_summary.json)
+# ---------------------------------------------------------------------------
+
+_RECONCILE_SUMMARY_FILENAME = "reconcile_summary.json"
+
+# A full day without a single auto-close run means the reconciler is down. The
+# measured inter-run cadence is minutes (median ~8 min, p90 ~3.2 h over 443
+# observed gaps in reconcile_history.ndjson), so 24 h flags a dead reconciler
+# (the 31 h outage that motivated this work) with a wide margin against any
+# ordinary idle period.
+_AUTOCLOSE_STALE_HOURS = 24.0
+
+
+def _parse_reconcile_timestamp(value: Any) -> Optional[datetime]:
+    """Parse a reconcile_summary ``finished_at`` ISO string to an aware datetime."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        dt = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, Any]:
+    """Read the auto-close reconciler's health from reconcile_summary.json.
+
+    Returns:
+      last_reconcile_at        — ``finished_at`` from the summary (ISO or None).
+      last_reconcile_age_hours — age of that run in hours (float or None).
+      gh_health                — ``evidence_source_health.gh`` (or None).
+      nominated_not_closed     — counts.nominated minus counts.closed.
+      autoclose_degraded       — True when auto-close is unhealthy.
+      autoclose_reason         — short human-readable reason.
+
+    Degraded means: gh is not "ok" (absent/auth_failed/timeout/unknown), OR the
+    last run has nominated-but-unverified tracks the reconciler could not
+    verify (unverified > 0 with nominated_not_closed > 0 — this is the stuck
+    backlog, distinct from guard-declined closes like stale_candidate which
+    keep nominated_not_closed > 0 on healthy runs), OR the last run is older
+    than _AUTOCLOSE_STALE_HOURS. A missing summary is itself a degraded signal:
+    it means the auto-close reconciler has never written a summary, and the
+    block is still emitted rather than omitted.
+    """
+    now = now or datetime.now(timezone.utc)
+    summary_path = store / _RECONCILE_SUMMARY_FILENAME
+    try:
+        summary = json.loads(summary_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return {
+            "last_reconcile_at": None,
+            "last_reconcile_age_hours": None,
+            "gh_health": None,
+            "nominated_not_closed": None,
+            "autoclose_degraded": True,
+            "autoclose_reason": "no_reconcile_summary",
+        }
+
+    gh_health = (summary.get("evidence_source_health") or {}).get("gh")
+    counts = summary.get("counts") or {}
+    nominated = int(counts.get("nominated", 0) or 0)
+    closed = int(counts.get("closed", 0) or 0)
+    unverified = int(counts.get("unverified", 0) or 0)
+    nominated_not_closed = nominated - closed
+
+    finished_raw = summary.get("finished_at")
+    finished_dt = _parse_reconcile_timestamp(finished_raw)
+    if finished_dt is not None:
+        age_hours = round(max(0.0, (now - finished_dt).total_seconds() / 3600.0), 1)
+    else:
+        age_hours = None
+
+    gh_bad = gh_health != "ok"
+    stuck = unverified > 0 and nominated_not_closed > 0
+    stale = age_hours is not None and age_hours > _AUTOCLOSE_STALE_HOURS
+
+    if gh_bad:
+        reason = "gh_absent" if gh_health == "absent" else f"gh_{gh_health or 'unknown'}"
+    elif stuck:
+        reason = "nominated_not_closed"
+    elif stale:
+        reason = "stale"
+    else:
+        reason = "ok"
+
+    return {
+        "last_reconcile_at": finished_raw or None,
+        "last_reconcile_age_hours": age_hours,
+        "gh_health": gh_health,
+        "nominated_not_closed": nominated_not_closed,
+        "autoclose_degraded": gh_bad or stuck or stale,
+        "autoclose_reason": reason,
+    }
+
+
 def _reconcile_tracks_fresh(
     state_dir: Path, project_id: str, *, store: Optional[Path] = None
 ) -> Dict[str, Any]:
@@ -1899,13 +2004,20 @@ def _reconcile_tracks_fresh(
     degrades to a ``precondition_unmet`` marker (safe, never raises).
     """
     marker: Dict[str, Any] = {
-        "reconciled": False,
+        "derived_refreshed": False,
         "tracks": 0,
         "drifted": 0,
         "drifted_tracks": [],
         "reason": None,
         "seconds": 0.0,
         "store": None,
+        # Auto-close reconciler health (from reconcile_summary.json).
+        "last_reconcile_at": None,
+        "last_reconcile_age_hours": None,
+        "gh_health": None,
+        "nominated_not_closed": None,
+        "autoclose_degraded": False,
+        "autoclose_reason": None,
     }
     pid = (project_id or "").strip()
     if not pid:
@@ -1916,6 +2028,9 @@ def _reconcile_tracks_fresh(
     # canonical projection); otherwise resolve it here.
     store = store if store is not None else _resolve_tracks_store(state_dir, pid)
     marker["store"] = str(store)
+    # Auto-close health is independent of the derived-status refresh below:
+    # surface it even when that refresh degrades to precondition_unmet/error.
+    marker.update(_autoclose_health(store))
     t0 = time.monotonic()
     try:
         if str(_LIB_DIR) not in sys.path:
@@ -1936,7 +2051,7 @@ def _reconcile_tracks_fresh(
 
     drifted = [r for r in results if r.get("drifted")]
     marker.update(
-        reconciled=True,
+        derived_refreshed=True,
         tracks=len(results),
         drifted=len(drifted),
         drifted_tracks=[
@@ -2173,14 +2288,17 @@ def _track_freshness_summary(tf: Optional[Dict[str, Any]]) -> Dict[str, Any]:
 
     The full marker (with per-track drift detail) lives in the state doc; the
     index carries only the cheap orientation fields so a cold-start session sees
-    whether the projection is fresh and how many tracks drifted.
+    whether the projection is fresh, how many tracks drifted, and whether the
+    auto-close reconciler is degraded.
     """
     tf = tf or {}
     return {
-        "reconciled": bool(tf.get("reconciled", False)),
+        "derived_refreshed": bool(tf.get("derived_refreshed", False)),
         "drifted": tf.get("drifted", 0),
         "tracks": tf.get("tracks", 0),
         "reason": tf.get("reason"),
+        "autoclose_degraded": bool(tf.get("autoclose_degraded", False)),
+        "autoclose_reason": tf.get("autoclose_reason"),
     }
 
 
@@ -2385,10 +2503,11 @@ def _emit_health_beacon(
     """Emit HealthBeacon heartbeat (best-effort).
 
     Carries a compact track-freshness summary so reconcile health (e.g.
-    ``reconciled=False`` with an ``error:*`` reason) is observable on the
-    beacon, not only inside the projection. A benign skip
-    (``no_project_id``/``precondition_unmet``) is reported but does NOT flip the
-    beacon to ``fail`` — only a real build/write failure does.
+    ``derived_refreshed=False`` with an ``error:*`` reason, or a degraded
+    auto-close reconciler) is observable on the beacon, not only inside the
+    projection. A benign skip (``no_project_id``/``precondition_unmet``) is
+    reported but does NOT flip the beacon to ``fail`` — only a real build/write
+    failure does.
     """
     details: Dict[str, Any] = {
         "format": fmt,
@@ -2397,9 +2516,11 @@ def _emit_health_beacon(
     }
     if track_freshness is not None:
         details["track_freshness"] = {
-            "reconciled": bool(track_freshness.get("reconciled", False)),
+            "derived_refreshed": bool(track_freshness.get("derived_refreshed", False)),
             "drifted": track_freshness.get("drifted", 0),
             "reason": track_freshness.get("reason"),
+            "autoclose_degraded": bool(track_freshness.get("autoclose_degraded", False)),
+            "autoclose_reason": track_freshness.get("autoclose_reason"),
         }
     try:
         from health_beacon import HealthBeacon

--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -28,6 +28,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sqlite3
 import subprocess
 from datetime import datetime, timezone
@@ -343,11 +344,41 @@ def _save_pr_state_cache(
 # gh helpers
 # ---------------------------------------------------------------------------
 
-def _detect_gh(repo_root: Path) -> str:
+# Absolute fallback locations for the gh binary. A launchd/cron background or a
+# minimal PATH (non-interactive shell) often omits the Homebrew bin dir even
+# though gh is installed and works in an interactive terminal. Resolving these
+# explicitly prevents a live gh from being misreported as "absent".
+_GH_FALLBACK_PATHS: Tuple[str, ...] = (
+    "/opt/homebrew/bin/gh",
+    "/usr/local/bin/gh",
+    "/usr/bin/gh",
+)
+
+
+def _resolve_gh_binary() -> Optional[str]:
+    """Resolve the gh binary to an absolute path, or None when truly absent.
+
+    First honors the calling PATH via shutil.which (interactive shells), then a
+    short list of absolute fallback paths for environments whose PATH omits the
+    gh directory. Never raises.
+    """
+    found = shutil.which("gh")
+    if found:
+        return found
+    for candidate in _GH_FALLBACK_PATHS:
+        if os.path.isfile(candidate) and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+def _detect_gh(repo_root: Path, gh_binary: Optional[str] = None) -> str:
     """Return 'ok', 'absent', 'auth_failed', or 'timeout'."""
+    gh = gh_binary or _resolve_gh_binary()
+    if not gh:
+        return "absent"
     try:
         result = subprocess.run(
-            ["gh", "auth", "status"],
+            [gh, "auth", "status"],
             capture_output=True, text=True, timeout=10,
             cwd=str(repo_root),
         )
@@ -360,11 +391,16 @@ def _detect_gh(repo_root: Path) -> str:
         return "absent"
 
 
-def _gh_pr_view(pr_number: int, repo_root: Path, timeout: int = 15) -> Optional[Dict[str, Any]]:
+def _gh_pr_view(
+    pr_number: int, repo_root: Path, timeout: int = 15, gh_binary: Optional[str] = None
+) -> Optional[Dict[str, Any]]:
     """Call ``gh pr view <n> --json state,mergedAt``. Returns dict or None on error."""
+    gh = gh_binary or _resolve_gh_binary()
+    if not gh:
+        return None
     try:
         result = subprocess.run(
-            ["gh", "pr", "view", str(pr_number), "--json", "state,mergedAt"],
+            [gh, "pr", "view", str(pr_number), "--json", "state,mergedAt"],
             capture_output=True, text=True, timeout=timeout,
             cwd=str(repo_root),
         )
@@ -759,8 +795,12 @@ def run_reconcile(
 
     # ------------------------------------------------------------------ step 4a
     # gh detection — absent / auth-failed → all unverified, exit 3.
+    # Resolve the binary once per run and reuse it for every PR lookup, so a
+    # PATH that differs from an interactive shell (launchd/cron background)
+    # cannot flip a live gh to "absent" partway through a run.
     # ------------------------------------------------------------------ step 4a
-    gh_health = _detect_gh(repo_root)
+    gh_binary = _resolve_gh_binary()
+    gh_health = _detect_gh(repo_root, gh_binary)
     if gh_health in ("absent", "auth_failed", "timeout"):
         per_track = [
             {
@@ -828,7 +868,7 @@ def run_reconcile(
         # Fetch live states; cache any MERGED results.
         for pn in prs_to_fetch:
             gh_calls_used += 1
-            data = _gh_pr_view(pn, repo_root)
+            data = _gh_pr_view(pn, repo_root, gh_binary=gh_binary)
             pr_results[pn] = data
             if data is not None and _is_merged(data):
                 pr_cache[str(pn)] = data

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -7,6 +7,8 @@ hot-path advisory reconcile that keeps the t0_state projection fresh:
 - a track whose PR merged but whose declared phase is stale -> drift surfaced
 - the reconcile resolves the CENTRAL tracks SSOT, not the ambient local store
 - the compact index summary mirrors the full marker
+- autoclose_degraded is read from reconcile_summary.json (true when gh is
+  absent, false for a healthy summary, true when the summary is missing)
 - the SessionStart hook command is valid bash, de-swallows stderr, keeps exit 0
 """
 
@@ -18,6 +20,7 @@ import shlex
 import sqlite3
 import subprocess
 import sys
+from datetime import datetime, timezone
 from pathlib import Path
 
 _ROOT = Path(__file__).resolve().parent.parent
@@ -35,7 +38,9 @@ import tracks as tracks_lib  # noqa: E402
 
 PROJECT_ID = "test-proj"
 _MARKER_KEYS = {
-    "reconciled", "tracks", "drifted", "drifted_tracks", "reason", "seconds", "store",
+    "derived_refreshed", "tracks", "drifted", "drifted_tracks", "reason", "seconds",
+    "store", "last_reconcile_at", "last_reconcile_age_hours", "gh_health",
+    "nominated_not_closed", "autoclose_degraded", "autoclose_reason",
 }
 
 
@@ -139,7 +144,7 @@ def _seed_pr_merged_event(state_dir: Path, dispatch_id: str) -> None:
 
 def test_no_project_id_is_skipped_not_an_error(tmp_path):
     marker = bts._reconcile_tracks_fresh(tmp_path, "")
-    assert marker["reconciled"] is False
+    assert marker["derived_refreshed"] is False
     assert marker["reason"] == "no_project_id"
     assert marker["drifted"] == 0
     assert set(marker) == _MARKER_KEYS
@@ -153,7 +158,7 @@ def test_pre_migration_store_reports_precondition_unmet(tmp_path, monkeypatch):
     sqlite3.connect(str(state_dir / "runtime_coordination.db")).close()
 
     marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
-    assert marker["reconciled"] is False
+    assert marker["derived_refreshed"] is False
     assert marker["reason"] == "precondition_unmet"
 
 
@@ -166,7 +171,7 @@ def test_drift_is_surfaced_when_pr_merged_but_phase_stale(tmp_path, monkeypatch)
 
     marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
 
-    assert marker["reconciled"] is True
+    assert marker["derived_refreshed"] is True
     assert marker["tracks"] >= 1
     assert marker["drifted"] >= 1
     stale = next(d for d in marker["drifted_tracks"] if d["track_id"] == "T-stale")
@@ -180,7 +185,7 @@ def test_in_sync_track_does_not_drift(tmp_path, monkeypatch):
     _seed_track(state_dir, "T-sync", phase="queued")
 
     marker = bts._reconcile_tracks_fresh(state_dir, PROJECT_ID)
-    assert marker["reconciled"] is True
+    assert marker["derived_refreshed"] is True
     assert all(d["track_id"] != "T-sync" for d in marker["drifted_tracks"])
 
 
@@ -197,7 +202,7 @@ def test_reconcile_resolves_central_store_not_ambient(tmp_path, monkeypatch):
 
     assert bts._resolve_tracks_store(ambient, PROJECT_ID) == central
     marker = bts._reconcile_tracks_fresh(ambient, PROJECT_ID)
-    assert marker["reconciled"] is True  # found the central tracks, not the empty ambient
+    assert marker["derived_refreshed"] is True  # found the central tracks, not the empty ambient
     assert marker["store"] == str(central)
 
 
@@ -207,15 +212,92 @@ def test_reconcile_resolves_central_store_not_ambient(tmp_path, monkeypatch):
 
 def test_index_summary_is_compact_and_mirrors_marker():
     full = {
-        "reconciled": True, "tracks": 47, "drifted": 18,
+        "derived_refreshed": True, "tracks": 47, "drifted": 18,
         "drifted_tracks": [{"track_id": "x"}], "reason": None, "seconds": 0.4, "store": "/s",
+        "last_reconcile_at": "2026-08-01T08:00:00Z", "last_reconcile_age_hours": 2.0,
+        "gh_health": "ok", "nominated_not_closed": 0,
+        "autoclose_degraded": False, "autoclose_reason": "ok",
     }
     summary = bts._track_freshness_summary(full)
-    assert summary == {"reconciled": True, "drifted": 18, "tracks": 47, "reason": None}
+    assert summary == {
+        "derived_refreshed": True, "drifted": 18, "tracks": 47, "reason": None,
+        "autoclose_degraded": False, "autoclose_reason": "ok",
+    }
     assert "drifted_tracks" not in summary  # heavy detail excluded from the index
 
     none = bts._track_freshness_summary(None)
-    assert none == {"reconciled": False, "drifted": 0, "tracks": 0, "reason": None}
+    assert none == {
+        "derived_refreshed": False, "drifted": 0, "tracks": 0, "reason": None,
+        "autoclose_degraded": False, "autoclose_reason": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Auto-close reconciler health (from reconcile_summary.json)
+# ---------------------------------------------------------------------------
+
+def test_autoclose_degraded_reflects_summary_health(tmp_path):
+    """gh absent in the summary → autoclose_degraded True; a healthy summary → False.
+
+    Red on old code: the auto-close health block did not exist, so no
+    autoclose_degraded field was ever produced.
+    """
+    now = datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+
+    state_dir = tmp_path / "degraded"
+    state_dir.mkdir(parents=True)
+    (state_dir / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "2026-07-31T12:45:55Z",
+        "evidence_source_health": {"gh": "absent"},
+        "counts": {"nominated": 8, "closed": 0, "unverified": 8},
+    }), encoding="utf-8")
+    degraded = bts._autoclose_health(state_dir, now=now)
+    assert degraded["autoclose_degraded"] is True
+    assert degraded["gh_health"] == "absent"
+    assert degraded["nominated_not_closed"] == 8
+    assert degraded["autoclose_reason"] == "gh_absent"
+
+    state_dir = tmp_path / "healthy"
+    state_dir.mkdir(parents=True)
+    (state_dir / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "2026-08-01T08:00:00Z",
+        "evidence_source_health": {"gh": "ok"},
+        "counts": {"nominated": 2, "closed": 0, "unverified": 0},
+    }), encoding="utf-8")
+    healthy = bts._autoclose_health(state_dir, now=now)
+    assert healthy["autoclose_degraded"] is False
+    assert healthy["gh_health"] == "ok"
+    assert healthy["nominated_not_closed"] == 2
+    assert healthy["autoclose_reason"] == "ok"
+
+
+def test_autoclose_degraded_true_when_summary_missing(tmp_path):
+    """A missing reconcile_summary.json is itself a degraded signal, never omitted."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    health = bts._autoclose_health(
+        state_dir, now=datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+    )
+    assert health["autoclose_degraded"] is True
+    assert health["autoclose_reason"] == "no_reconcile_summary"
+    assert health["last_reconcile_at"] is None
+
+
+def test_autoclose_degraded_true_when_last_run_stale(tmp_path):
+    """A healthy-but-old summary (older than the 24 h threshold) is degraded."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    # 2026-07-31T08:00Z -> 2026-08-01T10:00Z = 26 h > _AUTOCLOSE_STALE_HOURS (24).
+    (state_dir / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "2026-07-31T08:00:00Z",
+        "evidence_source_health": {"gh": "ok"},
+        "counts": {"nominated": 0, "closed": 0, "unverified": 0},
+    }), encoding="utf-8")
+    health = bts._autoclose_health(
+        state_dir, now=datetime(2026, 8, 1, 10, 0, tzinfo=timezone.utc)
+    )
+    assert health["autoclose_degraded"] is True
+    assert health["autoclose_reason"] == "stale"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -17,6 +17,7 @@ Verifies objective_reconcile.run_reconcile:
 from __future__ import annotations
 
 import json
+import os
 import sqlite3
 import subprocess
 import sys
@@ -248,10 +249,12 @@ def _make_gh_mock(
             call_log.append(list(cmd))
         if not isinstance(cmd, (list, tuple)) or not cmd:
             return subprocess.CompletedProcess(cmd, 1, "", "bad cmd")
-        if cmd[0] == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
+        # objective_reconcile now invokes gh via its resolved absolute path.
+        cmd0 = os.path.basename(str(cmd[0]))
+        if cmd0 == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
             rc = 0 if auth_ok else 1
             return subprocess.CompletedProcess(cmd, rc, "", "")
-        if cmd[0] == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
+        if cmd0 == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
             pr_num = int(cmd[3])
             resp = pr_responses.get(pr_num)
             if resp is None:
@@ -277,6 +280,16 @@ def _open_pr() -> Dict[str, str]:
 
 def _closed_pr() -> Dict[str, str]:
     return {"state": "CLOSED", "mergedAt": ""}
+
+
+def _is_gh_pr_view(cmd: list) -> bool:
+    """True when cmd invokes ``gh pr view`` — cmd[0] may be the resolved absolute path."""
+    return (
+        len(cmd) >= 3
+        and os.path.basename(str(cmd[0])) == "gh"
+        and cmd[1] == "pr"
+        and cmd[2] == "view"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -476,6 +489,64 @@ def test_gh_absent_all_unverified_exit3_nothing_closed(tmp_path, monkeypatch):
     assert _phase(sd, "T-nogh") == "active"  # untouched
 
 
+def test_detect_gh_finds_absolute_path_when_gh_off_path(tmp_path, monkeypatch):
+    """gh absent from PATH but present at a fallback absolute path → _detect_gh "ok".
+
+    Red on old code: the old _detect_gh shells out to a bare "gh", which a
+    stripped PATH cannot resolve → FileNotFoundError → "absent" (assert fails).
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    fake_gh = tmp_path / "bin" / "gh"
+    fake_gh.parent.mkdir()
+    fake_gh.write_text("#!/bin/sh\nexit 0\n", encoding="utf-8")
+    fake_gh.chmod(0o755)
+
+    # Strip every dir that could hold gh from PATH.
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    # New-code contract: no PATH hit, fallback list points at the fake binary.
+    # On old code these attributes do not exist — guard so the behavioral
+    # assertion below still runs and fails on the old resolver.
+    if hasattr(objective_reconcile, "shutil"):
+        monkeypatch.setattr(objective_reconcile.shutil, "which", lambda name: None)
+    if hasattr(objective_reconcile, "_GH_FALLBACK_PATHS"):
+        monkeypatch.setattr(objective_reconcile, "_GH_FALLBACK_PATHS", (str(fake_gh),))
+
+    seen: list = []
+
+    def fake_run(cmd, **kwargs):
+        seen.append(list(cmd))
+        if cmd and cmd[0] == str(fake_gh):
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        raise FileNotFoundError(f"no such binary: {cmd[0] if cmd else ''}")
+
+    monkeypatch.setattr(objective_reconcile.subprocess, "run", fake_run)
+
+    assert objective_reconcile._detect_gh(repo) == "ok"
+    assert seen, "expected a gh auth status subprocess call"
+    assert seen[0][0] == str(fake_gh), "must invoke the resolved absolute path, not bare gh"
+
+
+def test_detect_gh_absent_when_binary_truly_nowhere(tmp_path, monkeypatch):
+    """_detect_gh says "absent" when the resolver finds no gh binary anywhere.
+
+    The probe must be able to say no. Red on old code: the resolver contract
+    (_resolve_gh_binary) does not exist, so the test cannot set up the no-gh
+    world and the old code resolves a live gh → "ok" instead of "absent".
+    """
+    repo = tmp_path / "repo"
+    repo.mkdir()
+
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    if hasattr(objective_reconcile, "shutil"):
+        monkeypatch.setattr(objective_reconcile.shutil, "which", lambda name: None)
+    if hasattr(objective_reconcile, "_GH_FALLBACK_PATHS"):
+        monkeypatch.setattr(objective_reconcile, "_GH_FALLBACK_PATHS", ())
+
+    assert objective_reconcile._resolve_gh_binary() is None
+    assert objective_reconcile._detect_gh(repo) == "absent"
+
+
 def test_max_gh_calls_defers_second_candidate(tmp_path, monkeypatch):
     """--max-gh-calls 1 with 2 candidates → first proceeds, second is deferred; exit 0."""
     sd = _build_db(tmp_path)
@@ -500,7 +571,7 @@ def test_max_gh_calls_defers_second_candidate(tmp_path, monkeypatch):
     assert summary["counts"]["confirmed"] + summary["counts"]["deferred"] == 2
 
     # Count pr-view calls (excluding auth call)
-    pr_view_calls = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
+    pr_view_calls = [c for c in call_log if _is_gh_pr_view(c)]
     assert len(pr_view_calls) == 1
 
 
@@ -522,7 +593,7 @@ def test_merged_cache_second_run_no_gh_pr_view(tmp_path, monkeypatch):
     )
     assert code1 == 0
     assert summary1["counts"]["confirmed"] == 1
-    pr_view_calls_1 = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
+    pr_view_calls_1 = [c for c in call_log if _is_gh_pr_view(c)]
     assert len(pr_view_calls_1) == 1
 
     # Reset log for second run
@@ -535,7 +606,7 @@ def test_merged_cache_second_run_no_gh_pr_view(tmp_path, monkeypatch):
     assert code2 == 0
     assert summary2["counts"]["confirmed"] == 1
 
-    pr_view_calls_2 = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
+    pr_view_calls_2 = [c for c in call_log if _is_gh_pr_view(c)]
     assert len(pr_view_calls_2) == 0, "second run must NOT re-fetch a cached MERGED PR"
 
 
@@ -611,13 +682,15 @@ def test_cache_is_repo_scoped(tmp_path, monkeypatch):
         call_log.append(list(cmd))
         if not isinstance(cmd, (list, tuple)) or not cmd:
             return subprocess.CompletedProcess(cmd, 1, "", "")
-        if cmd[0] == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
+        # objective_reconcile now invokes gh via its resolved absolute path.
+        cmd0 = os.path.basename(str(cmd[0]))
+        if cmd0 == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
             return subprocess.CompletedProcess(cmd, 0, "", "")
-        if cmd[0] == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
+        if cmd0 == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
             return subprocess.CompletedProcess(
                 cmd, 0, json.dumps({"state": "MERGED", "mergedAt": _MERGED_AT}), ""
             )
-        if cmd[0] == "git" and "remote" in cmd:
+        if cmd0 == "git" and "remote" in cmd:
             cwd = str(kwargs.get("cwd", ""))
             if "repo-a" in cwd:
                 return subprocess.CompletedProcess(
@@ -636,7 +709,7 @@ def test_cache_is_repo_scoped(tmp_path, monkeypatch):
         sd, PROJECT_ID, repo_root=repo_a, apply=False,
     )
     assert summary1["counts"]["confirmed"] == 1
-    pr_view_calls_1 = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
+    pr_view_calls_1 = [c for c in call_log if _is_gh_pr_view(c)]
     assert len(pr_view_calls_1) == 1, "repo-a run must fetch PR 1002 from gh"
 
     call_log.clear()
@@ -646,7 +719,7 @@ def test_cache_is_repo_scoped(tmp_path, monkeypatch):
         sd, PROJECT_ID, repo_root=repo_b, apply=False,
     )
     assert summary2["counts"]["confirmed"] == 1
-    pr_view_calls_2 = [c for c in call_log if len(c) >= 3 and c[:3] == ["gh", "pr", "view"]]
+    pr_view_calls_2 = [c for c in call_log if _is_gh_pr_view(c)]
     assert len(pr_view_calls_2) == 1, "repo-b run must trigger its own gh pr view (different repo key)"
 
 


### PR DESCRIPTION
## What

Fixes two coupled defects that let the auto-close tracks reconciler fail silently:

1. **gh resolved as a bare `"gh"` → false `"absent"`.** `_detect_gh`/`_gh_pr_view` shelled out to bare `"gh"`. Under a non-interactive PATH (launchd/cron) this is `FileNotFoundError` → `"absent"`, so every nominated track became `unverified` and nothing closed. Measured: 438 `ok` runs, then 6 `absent` runs since `2026-07-30T21:15:41Z`; 9 objectives still `queued` with merged PRs.

   Fix: `_resolve_gh_binary()` — `shutil.which("gh")` first, then absolute fallbacks (`/opt/homebrew/bin/gh`, `/usr/local/bin/gh`, `/usr/bin/gh`). Resolved once per run and reused for the auth probe + every PR lookup. Only when no binary exists anywhere is it really `"absent"`.

2. **`track_freshness.reconciled` read as green while auto-close was down.** `reconciled` measured only the derived-status refresh. Renamed to `derived_refreshed` (grep-verified all readers) and added the real auto-close health read from `reconcile_summary.json`: `last_reconcile_at`, `last_reconcile_age_hours`, `gh_health`, `nominated_not_closed`, `autoclose_degraded`. A missing summary is itself a degraded signal. The compact index summary and health beacon now surface `autoclose_degraded`/`autoclose_reason`.

## Degradation rule and threshold

`autoclose_degraded` is true when `gh_health != "ok"`, OR the last run has a stuck backlog (`unverified > 0` AND `nominated_not_closed > 0`), OR the last run is older than `_AUTOCLOSE_STALE_HOURS = 24`.

Deliberate deviation from the literal `nominated_not_closed > 0` condition: measured healthy runs regularly end with `nominated_not_closed > 0` because close guards (`stale_candidate` 857×, `noop_incomplete_delivery` 26× on healthy apply runs) decline closes on already-merged tracks. Gating on `unverified > 0` keeps the flag trustworthy — the outage produced `nominated_not_closed = 8` AND `unverified = 8`.

24 h threshold motivated by 443 measured inter-run gaps (median ~8 min, p90 ~3.2 h): a full day without a run means the reconciler is down (the 31 h outage), with wide margin over any ordinary idle period.

## Verification (hard requirement: red on old code)

Source stashed to HEAD, new tests run → all 5 RED; then run against the fix → all 5 GREEN:

| Test | Old code | New code |
|---|---|---|
| `test_detect_gh_finds_absolute_path_when_gh_off_path` | `assert 'absent' == 'ok'` | PASS |
| `test_detect_gh_absent_when_binary_truly_nowhere` | `AttributeError: _resolve_gh_binary` | PASS |
| `test_autoclose_degraded_reflects_summary_health` | `AttributeError: _autoclose_health` | PASS |
| `test_autoclose_degraded_true_when_summary_missing` | `AttributeError` | PASS |
| `test_autoclose_degraded_true_when_last_run_stale` | `AttributeError` | PASS |

Full runs: `test_objective_reconcile.py` + `test_build_t0_state_freshness.py` 67 passed; `build_t0_state*` + `test_t0_state_gc.py` 139 passed (1 pre-existing env-dependent failure reproduced on HEAD).

Live read of the production `reconcile_summary.json`: `autoclose_degraded=True`, `gh_health=absent`, `last_reconcile_age_hours=29.9`, `nominated_not_closed=8` — the outage is now visible.

## Pre-existing (reproduced on HEAD, not from this PR)

- `tests/test_build_t0_state_exception_handling.py::TestRunsClean::test_build_t0_state_runs_clean_on_main` (conftest `VNX_DATA_DIR` isolation interaction)
- `tests/test_track_reconciler.py::test_blocking_detail_plan_oi_yields_plan_gate_hint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)