### PR TITLE
fix(triage): OI-804 + OI-817 small fixes, r4 triage evidence (12 items)

### DIFF
--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -55,6 +55,15 @@ def _utc_now_iso() -> str:
     return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
+# OI-817 (kimi_gate nitpick on PR-B0): ``schema_version`` / ``event_type`` are
+# part of the v2 contract's identity (ADR-035 §3.2.1/§7.1 r2 — never keyed on
+# status; always ``task_complete``), not caller data. ``ReceiptV2.__post_init__``
+# forces these constants so a future emit site cannot bypass them by stamping a
+# non-v2 receipt or a different event_type.
+RECEIPT_V2_SCHEMA_VERSION = 2
+RECEIPT_V2_EVENT_TYPE = "task_complete"
+
+
 @dataclass
 class ReceiptV2:
     """The ADR-035 v2 dispatch receipt emitted by ``governance_emit``.
@@ -90,9 +99,10 @@ class ReceiptV2:
     report_path: Optional[str] = None
     events_path: Optional[str] = None
     cost_usd: Optional[float] = None
-    # Stamped from the contract's own defaults; overridable for tests.
-    event_type: str = "task_complete"
-    schema_version: int = 2
+    # Contract identity — forced to the module constants in __post_init__
+    # (OI-817), never caller-overridable.
+    event_type: str = RECEIPT_V2_EVENT_TYPE
+    schema_version: int = RECEIPT_V2_SCHEMA_VERSION
     timestamp: Optional[str] = None  # None -> stamped with now at construction
     # Conditionally stamped.
     permission_enforcement: Optional[str] = None
@@ -128,6 +138,11 @@ class ReceiptV2:
         self.receipt_kind = validate_receipt_kind(self.receipt_kind)
         # Same normalization the pre-PR-B0 literal applied at build time.
         self.duration_seconds = round(float(self.duration_seconds), 3)
+        # OI-817: schema_version/event_type are contract identity — force the
+        # constants regardless of what a caller passed (a future emit site must
+        # not be able to bypass them).
+        self.schema_version = RECEIPT_V2_SCHEMA_VERSION
+        self.event_type = RECEIPT_V2_EVENT_TYPE
         if self.timestamp is None:
             self.timestamp = _utc_now_iso()
 

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2123,6 +2123,22 @@ class TmuxInteractiveDispatch:
                 # failed write must never abort the dispatch.
                 try:
                     _write_worker_scope_hook_settings(Path(cwd))
+                    # OI-804 (ADR-005 audit gap): a successful state mutation —
+                    # the settings.local.json registration — emits a coordination
+                    # event so the write lands in the audit trail. Best-effort
+                    # like the write itself: an emit failure must never abort the
+                    # dispatch.
+                    self._emit_event(
+                        "hook_settings_written",
+                        dispatch_id=dispatch_id,
+                        label=label,
+                        reason="worker-scope PreToolUse hook registered in worktree",
+                        metadata={
+                            "settings_path": str(
+                                Path(cwd) / ".claude" / "settings.local.json"
+                            )
+                        },
+                    )
                 except Exception as exc:  # noqa: BLE001 - hook wiring is best-effort
                     logger.warning(
                         "interactive: worker-scope hook settings write failed "

--- a/tests/test_receipt_schema.py
+++ b/tests/test_receipt_schema.py
@@ -213,6 +213,17 @@ def test_receipt_v2_defaults_schema_version_event_type_and_timestamp():
     assert receipt["timestamp"]  # auto-stamped
 
 
+def test_receipt_v2_schema_version_event_type_not_overridable():
+    """OI-817: schema_version/event_type are contract identity — a caller
+    cannot stamp a non-v2 receipt or a different event_type by passing them."""
+    kw = _v2_kwargs_minimal()
+    kw["schema_version"] = 99
+    kw["event_type"] = "forged"
+    receipt = ReceiptV2(**kw).to_dict()
+    assert receipt["schema_version"] == 2
+    assert receipt["event_type"] == "task_complete"
+
+
 def test_receipt_v2_duration_rounded_three_decimals():
     kw = _v2_kwargs_minimal()
     kw["duration_seconds"] = 3.456789

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -4760,6 +4760,22 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
             any("pretooluse_worker_scope_enforce.sh" in c for c in commands),
             f"hook command not found in written settings: {commands}",
         )
+        # OI-804 (ADR-005 audit gap): the successful settings write must emit a
+        # hook_settings_written coordination event so the mutation is audited.
+        with get_connection(self.state_dir) as conn:
+            hook_events = get_events(
+                conn, entity_id=self.DISPATCH_ID, event_type="hook_settings_written"
+            )
+        self.assertTrue(
+            hook_events,
+            "successful worker-scope hook settings write must emit "
+            "hook_settings_written",
+        )
+        self.assertIn(
+            str(settings_path),
+            hook_events[0].get("metadata_json", ""),
+            "event metadata must record the settings path written",
+        )
 
     def test_dispatch_hook_settings_write_failure_does_not_abort(self):
         """Best-effort wiring: a failing settings write must never abort the dispatch."""


### PR DESCRIPTION
## Triage-ronde 4 — 20260801-r4-oi-triage

Alle 12 items gemeten tegen de code op main. Uitkomst: 2 achterhaald, 2 kleine fixes (deze PR), 8 bestaan nog als ontwerp- of operatorkwestie.

### Fixes in deze PR
- **OI-804** (ADR-005 audit-gap): tmux-lane emitteert nu `hook_settings_written` na een succesvolle worker-scope `settings.local.json`-schrijf.
- **OI-817** (kimi_gate nitpick PR-B0): `ReceiptV2.__post_init__` forceert `schema_version=2` / `event_type="task_complete"`. Future callers kunnen de contract-identiteit niet meer bypassen.

### Bewijs
Beide tests stonden rood op main:
- `test_receipt_v2_schema_version_event_type_not_overridable`: `assert 99 == 2` op oude code.
- `test_dispatch_writes_hook_settings_into_allocated_worktree`: geen `hook_settings_written` event op oude code.

### Oordelen (alle 12)
| OI | Oordeel |
|---|---|
| OI-800 | BESTAAT-GROOT — divergentie gemeten; shim dekt scenario nu af |
| OI-803 | ACHTERHAALD — `vnx version` = 1.4.1 (VERSION-file), niet pip-metadata 1.3.0 |
| OI-804 | BESTAAT-KLEIN — gefixt |
| OI-806 | BESTAAT-GROOT — re-audit PR #1229 niet uitgevoerd, codex nu beschikbaar |
| OI-807 | BESTAAT-GROOT — re-audit PR #1230 niet uitgevoerd |
| OI-808 | BESTAAT-GROOT — re-audit PR #1231 niet uitgevoerd |
| OI-812 | BESTAAT-GROOT — kimi sessie-reap ontbreekt nog |
| OI-813 | BESTAAT-GROOT — track-FSM mist shipped/awaiting-activation |
| OI-814 | ACHTERHAALD — drift-badge in objective list + verbose drift output |
| OI-815 | BESTAAT-GROOT — re-audit PR #1232 niet uitgevoerd |
| OI-816 | BESTAAT-GROOT — re-audit PR #1233 niet uitgevoerd |
| OI-817 | BESTAAT-KLEIN — gefixt |

Unified report: `~/.vnx-data/vnx-dev/unified_reports/20260801-r4-oi-triage.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)