### PR TITLE
fix(dispatch): triage-r3 four small OI fixes (OI-695, OI-775, OI-796, OI-798)

### DIFF
--- a/scripts/lib/append_receipt_internals/enrichment.py
+++ b/scripts/lib/append_receipt_internals/enrichment.py
@@ -39,7 +39,9 @@ def _enrich_session_metadata(enriched: Dict[str, Any], state_dir: Path) -> None:
     fields in the v2 canonical shape (§3) — not session state — so they are
     promoted directly onto the receipt here instead of nested under a
     (now-removed) session{} object. Caller-supplied values are never
-    overwritten. The rest of the session's state (liveness, terminal
+    overwritten; a falsy (null/blank) session_id is REPLACED with the
+    resolved value (OI-796) — setdefault would otherwise preserve the
+    null/blank. The rest of the session's state (liveness, terminal
     heartbeat) is resolved by session_id against runtime_coordination.db at
     read time, not carried on the immutable receipt line.
     """
@@ -54,7 +56,13 @@ def _enrich_session_metadata(enriched: Dict[str, Any], state_dir: Path) -> None:
             "provider": "unknown",
         }
 
-    enriched.setdefault("session_id", session_meta.get("session_id", "unknown"))
+    # OI-796: setdefault would PRESERVE a null/blank caller-supplied session_id
+    # instead of replacing it. Only overwrite a falsy value — a valid
+    # caller-supplied session_id is returned verbatim by the resolver
+    # (priority 1), so this never clobbers it, and a resolver crash (the
+    # fallback session_meta above) still honours a valid caller-supplied value.
+    if not enriched.get("session_id"):
+        enriched["session_id"] = session_meta.get("session_id") or "unknown"
     if not enriched.get("terminal"):
         enriched["terminal"] = session_meta.get("terminal", "unknown")
     enriched.setdefault("model", session_meta.get("model", "unknown"))

--- a/scripts/lib/dispatcher_supervisor_ticks.sh
+++ b/scripts/lib/dispatcher_supervisor_ticks.sh
@@ -40,7 +40,7 @@ _maybe_runtime_supervise() {
     local log_file="$VNX_LOGS_DIR/runtime_supervise.log"
     mkdir -p "$(dirname "$log_file")"
     python3 "$VNX_DIR/scripts/lib/runtime_supervise.py" >> "$log_file" 2>&1 || true
-    echo "$now" > "$state_file"
+    printf '%s' "$now" > "$state_file.tmp.$$" && mv -f "$state_file.tmp.$$" "$state_file"
 }
 
 # _maybe_auto_seed_tracks — flag-gated planning auto-seed tick.
@@ -110,7 +110,11 @@ _maybe_oi_bridge_tick() {
         printf '%s' "0" > "$fresh_file.tmp.$$" && mv -f "$fresh_file.tmp.$$" "$fresh_file"
         log "V-OI-BRIDGE WARN: OI bridge tick failed (exit $rc); see $log_file — reconcile-apply is gated this cycle until the next successful bridge run"
     fi
-    echo "$now" > "$state_file"
+    # OI-798: atomic tmp+rename for the timestamp marker too — same pattern as
+    # the freshness write above. A truncating echo> leaves a torn marker if the
+    # supervisor dies mid-write, which would delay the next bridge tick by a
+    # full interval (the throttle reads this file on every tick).
+    printf '%s' "$now" > "$state_file.tmp.$$" && mv -f "$state_file.tmp.$$" "$state_file"
 }
 
 # _maybe_objective_reconcile — throttled git-grounded reconcile tick (D4).
@@ -165,7 +169,7 @@ _maybe_objective_reconcile() {
         fi
     fi
     "${cmd[@]}" >> "$log_file" 2>&1 || true
-    echo "$now" > "$state_file"
+    printf '%s' "$now" > "$state_file.tmp.$$" && mv -f "$state_file.tmp.$$" "$state_file"
 }
 
 # _maybe_learning_cycle — throttled daily learning cycle tick (D3).
@@ -191,7 +195,7 @@ _maybe_learning_cycle() {
     local log_file="$VNX_LOGS_DIR/learning_cycle.log"
     mkdir -p "$(dirname "$log_file")"
     python3 "$VNX_DIR/scripts/learning_loop.py" run >> "$log_file" 2>&1 || true
-    echo "$now" > "$state_file"
+    printf '%s' "$now" > "$state_file.tmp.$$" && mv -f "$state_file.tmp.$$" "$state_file"
 }
 
 # _unified_supervisor_lease_sweep_tick — throttled lease_sweep tick (SUP-PR2).
@@ -214,6 +218,6 @@ _unified_supervisor_lease_sweep_tick() {
         mkdir -p "$VNX_LOGS_DIR" "$(dirname "$state_file")"
         python3 "$SCRIPT_DIR/lib/lease_sweep.py" \
             >> "$VNX_LOGS_DIR/lease_sweep.log" 2>&1 || true
-        echo "$now" > "$state_file"
+        printf '%s' "$now" > "$state_file.tmp.$$" && mv -f "$state_file.tmp.$$" "$state_file"
     fi
 }

--- a/scripts/lib/terminal_snapshot.py
+++ b/scripts/lib/terminal_snapshot.py
@@ -113,6 +113,12 @@ def get_terminal_state_from_files(state_dir: Path) -> Dict[str, TerminalState]:
                         # Enrich with model/provider (don't overwrite status from more reliable sources)
                         states[terminal].provider = term_data.get("provider") or states[terminal].provider
                         states[terminal].model = term_data.get("model") or states[terminal].model
+                        # OI-775: claimed_by/lease_expires_at were dropped here —
+                        # a dashboard-only terminal (no terminal_state.json /
+                        # terminal_status.ndjson) silently lost its claim info.
+                        # Fill them the same way as provider/model.
+                        states[terminal].claimed_by = term_data.get("claimed_by") or states[terminal].claimed_by
+                        states[terminal].lease_expires_at = term_data.get("lease_expires_at") or states[terminal].lease_expires_at
                         if not states[terminal].last_activity or states[terminal].last_activity == "never":
                             states[terminal].last_activity = term_data.get("last_update", states[terminal].last_activity)
         except (OSError, json.JSONDecodeError):

--- a/tests/test_append_receipt.py
+++ b/tests/test_append_receipt.py
@@ -136,6 +136,30 @@ def test_append_receipt_session_id_explicit_top_level_survives_enrichment(tmp_pa
     assert stored["session_id"] == "explicit-caller-session"
 
 
+def test_append_receipt_session_id_blank_replaced_by_resolved(tmp_path: Path):
+    """OI-796: a receipt that carries a BLANK top-level session_id must have
+    it REPLACED by the resolved session metadata, not preserved by
+    `setdefault`. `_enrich_session_metadata` used setdefault, so a null/blank
+    value survived enrichment unchanged. A blank must fall through to the
+    resolver (here: the CLAUDE_SESSION_ID env var)."""
+    receipt = _build_receipt(index=25)
+    receipt["session_id"] = ""
+
+    result = _run_append(
+        tmp_path,
+        json.dumps(receipt),
+        extra_env={"CLAUDE_SESSION_ID": "env-session-resolved-abc"},
+    )
+    assert result.returncode == 0
+
+    receipts_file = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    stored = json.loads(receipts_file.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert stored["session_id"] == "env-session-resolved-abc", (
+        f"blank session_id must be replaced by the resolved value, "
+        f"got {stored['session_id']!r}"
+    )
+
+
 def test_append_receipt_session_id_falls_back_to_gemini_current_file(tmp_path: Path, monkeypatch):
     receipt = _build_receipt(index=22)
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -135,6 +135,29 @@ class TestVnxInitCli:
         assert rc == 0
         assert version_file.read_text().strip() == "v1.3.0"
 
+    def test_init_force_preserves_customized_settings(self, tmp_path):
+        # OI-695: settings.json is project-owned (custom env, permissions,
+        # hooks). `vnx init --force` must NOT clobber it with the scaffold
+        # template — same contract as the .vnx-version pin. Operators refresh
+        # the VNX-owned keys via `vnx regen-settings --merge`.
+        import json
+
+        rc = vnx_init(_args(tmp_path))
+        assert rc == 0
+        settings_path = tmp_path / ".claude" / "settings.json"
+        custom = json.loads(settings_path.read_text(encoding="utf-8"))
+        custom.setdefault("env", {})["PYTHONPATH"] = "/custom/venv"
+        custom["permissions"]["allow"] = custom["permissions"]["allow"] + ["Bash(custom-tool)"]
+        custom["myCustomKey"] = "keep-me"
+        settings_path.write_text(json.dumps(custom, indent=2), encoding="utf-8")
+
+        rc = vnx_init(_args(tmp_path, force=True))
+        assert rc == 0
+        after = json.loads(settings_path.read_text(encoding="utf-8"))
+        assert after.get("myCustomKey") == "keep-me", "project-owned key clobbered by --force"
+        assert after.get("env", {}).get("PYTHONPATH") == "/custom/venv"
+        assert "Bash(custom-tool)" in after["permissions"]["allow"]
+
     def test_init_force_without_set_version_never_writes_running_version(self, tmp_path):
         vnx_init(_args(tmp_path))
         version_file = tmp_path / ".vnx-version"

--- a/tests/test_oi_bridge_supervisor_tick.py
+++ b/tests/test_oi_bridge_supervisor_tick.py
@@ -319,6 +319,50 @@ def test_bridge_tick_failure_writes_freshness_via_atomic_rename_too(tmp_path):
     assert stray_tmp == [], f"tmp file(s) left behind after rename: {stray_tmp}"
 
 
+def test_bridge_tick_writes_timestamp_marker_via_atomic_rename(tmp_path):
+    """OI-798: the `.last_oi_bridge_ts` throttle marker must use the same
+    atomic tmp+rename as the freshness file. A truncating `echo >` leaves a
+    torn marker if the supervisor dies mid-write, which would delay the next
+    bridge tick by a full interval (the throttle reads this file every tick).
+    The marker write is UNCONDITIONAL (runs on both the fresh and not-fresh
+    branches), so the tick's exit code must not gate it."""
+    source = TICKS_SH.read_text()
+    match = re.search(
+        r"^_maybe_oi_bridge_tick\(\) \{\n.*?^\}\n", source, re.MULTILINE | re.DOTALL,
+    )
+    assert match, "could not locate _maybe_oi_bridge_tick() in dispatcher_supervisor_ticks.sh"
+    body = match.group(0)
+
+    # The old truncating pattern must be gone from this tick.
+    assert 'echo "$now" > "$state_file"' not in body
+
+    # The new pattern must be present: write to a tmp sibling, then rename.
+    assert '"$state_file.tmp.$$"' in body, "timestamp marker must land on a tmp sibling first"
+    assert "mv -f" in body, "timestamp marker must complete via an atomic rename"
+
+    # Functional check: a real tick writes the marker with no stray tmp behind.
+    state_dir = tmp_path / "state"
+    _build_db_v30(state_dir)
+
+    env = _base_env(state_dir, tmp_path)
+    env["VNX_OI_BRIDGE_INTERVAL"] = "0"
+    (tmp_path / "logs").mkdir(parents=True, exist_ok=True)
+    env["VNX_LOG_CAPTURE"] = str(tmp_path / "log_capture.txt")
+
+    proc = _run_bash("_maybe_oi_bridge_tick", env)
+    assert proc.returncode == 0, proc.stderr
+
+    ts_file = state_dir / ".last_oi_bridge_ts"
+    assert ts_file.exists(), "timestamp marker was not written"
+    assert ts_file.read_text().strip().isdigit(), (
+        f"timestamp marker must be a bare epoch-seconds integer, "
+        f"got {ts_file.read_text().strip()!r}"
+    )
+
+    stray_tmp = list(state_dir.glob(".last_oi_bridge_ts.tmp.*"))
+    assert stray_tmp == [], f"tmp file(s) left behind after rename: {stray_tmp}"
+
+
 # ---------------------------------------------------------------------------
 # Reconcile freshness gate: --apply withheld unless bridge signal == "1"
 # ---------------------------------------------------------------------------

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -330,7 +330,11 @@ def _scaffold_claude_dir(project_dir: Path, tmpl_root: Path, ctx: dict, force: b
         print(f"  exists  {skills_dir.relative_to(project_dir)}/")
 
     settings_path = claude_dir / "settings.json"
-    if not settings_path.exists() or force:
+    # settings.json is project-owned (custom env, permissions, hooks): scaffolded
+    # only when absent, ALWAYS preserved under --force — the same contract as the
+    # .vnx-version pin (OI-695). Operators refresh the VNX-owned keys via
+    # `vnx regen-settings --merge`, not by clobbering the project file.
+    if not settings_path.exists():
         _atomic_write(settings_path, _render_template(tmpl_root / "settings.json.j2", ctx), project_dir)
         print(f"  created {settings_path.relative_to(project_dir)}")
     else:

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -172,7 +172,9 @@ def _register_init_subparser(subparsers: argparse.Action) -> None:
         "--force",
         action="store_true",
         help="overwrite existing scaffold files (allows reinitialisation); "
-             "never resets an existing .vnx-version pin — use --set-version for that",
+             "never resets an existing .vnx-version pin — use --set-version for that; "
+             "never clobbers an existing .claude/settings.json (project-owned) — "
+             "use `vnx regen-settings --merge` to refresh the VNX-owned keys",
     )
     init_parser.add_argument(
         "--set-version",


### PR DESCRIPTION
## Triage-ronde 3 — OI-695..OI-799

Verse worktree vanaf `origin/main` 2f0fe2f1. Meet-opdracht: 12 items gereproduceerd, niet geredeneerd vanuit item-tekst. Geen enkel item overgeslagen.

**Uitkomst: 4 ACHTERHAALD, 4 BESTAAT-KLEIN (alle vier gefixt), 4 BESTAAT-GROOT.**

### Gefixt (BESTAAT-KLEIN)

- **OI-695** — `vnx init --force` clobberde een customized `.claude/settings.json`. Nu: settings.json wordt altijd gepreserveerd als hij bestaat (zelfde contract als de `.vnx-version` pin). VNX-owned keys ververst de operator via `vnx regen-settings --merge`. Test: `test_init_force_preserves_customized_settings` (rood op main).
- **OI-775** (deel b) — `test_snapshot_terminal_fields` faalde met `assert None == 'task-123'`. Root-cause: `get_terminal_state_from_files` verrijkte `claimed_by`/`lease_expires_at` niet uit `dashboard_status.json`. Gefixt; bestaande test was al rood op main.
- **OI-796** — receipt-enrichment gebruikte `setdefault("session_id", ...)`, dat een null/blank preserveert. Nu truthiness-guard die alleen falsy vervangt door de geresolveerde waarde. Test: `test_append_receipt_session_id_blank_replaced_by_resolved` (rood op main). NB: de letterlijke fix uit de bevinding (unconditional assignment) is bewust niet toegepast — die zou in de resolver-crash-pad een geldige caller-supplied waarde clobberen en de bestaande `test_append_receipt_session_id_explicit_top_level_survives_enrichment` breken.
- **OI-798** — `.last_oi_bridge_ts` (en de vier zuster-timestamp-markers) schreven met truncating `echo >`. Nu allemaal atomic tmp+rename, gelijk aan de freshness-write. Test: `test_bridge_tick_writes_timestamp_marker_via_atomic_rename` (rood op main).

### ACHTERHAALD (met gemeten bewijs)

- **OI-789** — `git_provenance` parst paden nu uit `git status --porcelain` (staged+unstaged+untracked); comment noemt de fix.
- **OI-797** — `reconcile_oi_pending` telt/escaaleert/surfact failures; `digest` toont `oi_pending_escalated_count`. Docstring: "codex finding folded in from PR-7".
- **OI-799** — `__version__` leest package-lokale VERSION (1.4.1), niet stale metadata (1.3.0, gemeten).
- **OI-710** — residual werd in de bevinding zelf als low-impact geaccepteerd; patroon spiegelt `dispatch_worktree_isolation` 1:1 en is repo-accepted.

### BESTAAT-GROOT (niet gefixt, bewijs + waarom)

- **OI-698** — gemeten: SEOcrawler embedded `.claude/vnx-system/scripts` bestaat nog naast central → doctor FAIL reproduceert; operationele actie voor SEO T0, geen code-fix in dit repo.
- **OI-704** — `provider_dispatch.py` heeft 0 `base_ref`-referenties; provider-lane bouwt altijd op origin/main. Vraagt cross-module threading + ontwerpkeuze.
- **OI-765** — `assign_destination` (74L) en `_validate_warning_entry` (99L) overschrijden de 70L-advisory nog; stijl-only, refactor-keuze.
- **OI-790** — geen FAIL-banner/non-zero exit bij all-seats-failure; scoped-out verbetering die een usable/failed-contract + sign-off vraagt.

### Pre-existente failures (niet van deze PR)

`TestFlagGateClaude` (permanent rood, per opdracht niet van mij), `test_pool_default_db_path_honors_vnx_data_dir` (env-dependent), 2× `test_receipt_instruction_hash` (manifest-waarschuwingstekst). Alle geverifieerd op main zonder deze wijzigingen.

Volledig rapport: `$VNX_DATA_DIR/unified_reports/20260801-r3-oi-triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)