### PR TITLE
fix(triage): r7 — OI-862 fail-closed exit code + OI-890 marker footer (6 achterhaald, 4 groot)

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -410,6 +410,7 @@ Every dispatch instruction MUST include the following footer (codified — don't
 - DO NOT bypass tests with --no-verify
 - DO NOT abort if first sub-task succeeds — continue with rest
 - After commit: PUSH and CREATE PR (or update if existing) — dispatch is INCOMPLETE without PR
+- DO NOT suppress with `# noqa:` — the Lint Patterns gate rejects it. Use a PLAIN marker comment on the line: `# vnx-silent-except: <reason>` (silent except) / `# vnx-atomic-write: <reason>` (non-atomic state write)
 
 ## Codex unavailable note
 Codex CLI rate-limited until <date>. Gemini-only review after fix.

--- a/scripts/conversation_analyzer.py
+++ b/scripts/conversation_analyzer.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from conversation_analyzer import (  # noqa: E402 (path insert above)
     ConversationAnalyzer, Colors, log,
     DB_PATH, PATHS, VNX_BASE, ANALYZER_VERSION,
+    fail_closed_exit_code,
 )
 
 
@@ -51,8 +52,9 @@ def main():
     rc = 0
     run_status = "ok"
     run_error = None
+    stats = None
     try:
-        analyzer.run(
+        stats = analyzer.run(
             max_sessions=args.max_sessions,
             deep_budget=args.deep_budget,
             dry_run=args.dry_run,
@@ -64,6 +66,16 @@ def main():
         run_status = "fail"
         run_error = str(e)
         rc = 1
+    else:
+        # OI-862: a run in which EVERY session failed must not exit 0. The
+        # runner's per-session handler counts errors but never influences the
+        # exit code, so a night where the whole pipeline failed still reported
+        # launchd status 0 — the silent-failure pattern this chain exists to catch.
+        if fail_closed_exit_code(stats):
+            log("ERROR", f"All sessions failed ({stats.errors} errors, 0 analyzed); returning non-zero exit")
+            run_status = "fail"
+            run_error = f"all sessions failed ({stats.errors} errors, 0 analyzed)"
+            rc = 1
     finally:
         analyzer.close()
         try:

--- a/scripts/conversation_analyzer/__init__.py
+++ b/scripts/conversation_analyzer/__init__.py
@@ -25,6 +25,7 @@ from .models import (
     SessionMetrics,
     SessionFlags,
     RunStats,
+    fail_closed_exit_code,
 )
 from .parser import SessionParser
 from .detector import HeuristicDetector
@@ -35,7 +36,7 @@ from .runner import ConversationAnalyzer
 __all__ = [
     "SessionParser", "SessionMetrics", "SessionFlags",
     "HeuristicDetector", "DeepAnalyzer", "DigestGenerator",
-    "ConversationAnalyzer", "RunStats", "normalize_model",
+    "ConversationAnalyzer", "RunStats", "fail_closed_exit_code", "normalize_model",
     "Colors", "log",
     "CLAUDE_PROJECTS_DIR", "SCRIPT_DIR", "PATHS",
     "VNX_BASE", "STATE_DIR", "DB_PATH", "ANALYZER_VERSION",

--- a/scripts/conversation_analyzer/models.py
+++ b/scripts/conversation_analyzer/models.py
@@ -137,3 +137,18 @@ class RunStats:
     errors: int = 0
     skipped: int = 0
     suggestions: List[dict] = field(default_factory=list)
+
+
+def fail_closed_exit_code(stats: "RunStats | None") -> int:
+    """Return a non-zero exit code when the run failed closed (OI-862).
+
+    A run whose every session errored is a failed run and must not exit 0:
+    the per-session exception handler in the runner already counted the
+    errors, and a nightly pipeline that prints "Errors: N" with no analyzed
+    session would otherwise report launchd status 0 — the same silent-failure
+    pattern this chain exists to catch. Partial runs (some sessions analyzed)
+    stay green so a single session hiccup does not alarm the nightly job.
+    """
+    if stats is not None and stats.errors > 0 and stats.sessions_analyzed == 0:
+        return 1
+    return 0

--- a/tests/test_conversation_analyzer.py
+++ b/tests/test_conversation_analyzer.py
@@ -1397,5 +1397,52 @@ class TestAtomicWrites:
                 analyzer._resolve_project_id()
 
 
+# ---------------------------------------------------------------------------
+# Fail-closed exit code (OI-862)
+# ---------------------------------------------------------------------------
+
+class TestFailClosedExitCode:
+
+    def test_fail_closed_pure_function(self):
+        """The exit-code helper fails closed only on a fully-failed run."""
+        from conversation_analyzer import fail_closed_exit_code, RunStats
+        # All sessions failed -> non-zero (the OI-862 case).
+        assert fail_closed_exit_code(RunStats(errors=2, sessions_analyzed=0)) == 1
+        # Partial runs stay green — a single session hiccup must not alarm nightly.
+        assert fail_closed_exit_code(RunStats(errors=1, sessions_analyzed=1)) == 0
+        assert fail_closed_exit_code(RunStats(errors=2, sessions_analyzed=5)) == 0
+        # Clean run -> zero.
+        assert fail_closed_exit_code(RunStats(errors=0, sessions_analyzed=3)) == 0
+        # Defensive: None stats (no run executed) -> zero.
+        assert fail_closed_exit_code(None) == 0
+
+    def test_main_returns_nonzero_when_all_sessions_fail(self):
+        """``conversation_analyzer.py`` exits non-zero when every session failed."""
+        import importlib.util
+        from unittest.mock import Mock
+
+        from conversation_analyzer import RunStats
+
+        spec = importlib.util.spec_from_file_location(
+            "conv_analyzer_main_oi862",
+            SCRIPT_DIR / "conversation_analyzer.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        fake = Mock()
+        fake.run.return_value = RunStats(errors=3, sessions_analyzed=0)
+        tmp_db = Path(tempfile.mkdtemp()) / "quality.db"
+        tmp_db.write_text("")
+
+        argv = ["conversation_analyzer.py", "--max-sessions", "5"]
+        with patch.object(sys, "argv", argv), \
+             patch.object(mod, "DB_PATH", tmp_db), \
+             patch.object(mod, "ConversationAnalyzer", return_value=fake):
+            rc = mod.main()
+
+        assert rc == 1
+
+
 if __name__ == "__main__":
     pytest.main([__file__, "-v"])

--- a/tests/test_worker_dispatch_standards.py
+++ b/tests/test_worker_dispatch_standards.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+"""Regression guard for OI-890: the Lint-Patterns marker syntax is codified.
+
+Four PRs in one day (2026-07-31) went red on the same lint form error: a worker
+suppressed a deliberate silent except with ``# noqa: BLE001``, which the Lint
+Patterns gate (scripts/ci_lint_patterns.py) rejects — the gate needs a PLAIN
+marker comment (``# vnx-silent-except: <reason>``). The gate's own error message
+states the rule; the fix codifies the rule in the canonical Worker Dispatch
+Standards footer so every dispatch carries it.
+
+These tests assert the codification stays present in the canonical T0 role.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parents[1]
+_ROLE_PATH = _PROJECT_ROOT / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+
+def _worker_dispatch_standards_section() -> str:
+    """Return the Worker Dispatch Standards section of the canonical T0 role."""
+    text = _ROLE_PATH.read_text(encoding="utf-8")
+    marker = "## Worker Dispatch Standards"
+    start = text.index(marker)
+    # The section ends at "## Cluster naming convention" (the code-fenced
+    # "## Critical rules" block inside the section is NOT a real heading).
+    end_marker = "## Cluster naming convention"
+    nxt = text.index(end_marker, start + len(marker))
+    return text[start:nxt]
+
+
+def test_role_file_exists():
+    assert _ROLE_PATH.is_file(), f"canonical T0 role missing: {_ROLE_PATH}"
+
+
+def test_marker_syntax_codified_in_worker_dispatch_standards():
+    section = _worker_dispatch_standards_section()
+    assert "# noqa:" in section, (
+        "Worker Dispatch Standards must state the noqa rejection so a worker "
+        "does not repeat the OI-890 form error."
+    )
+    assert "vnx-silent-except" in section and "vnx-atomic-write" in section, (
+        "Worker Dispatch Standards must carry the plain marker syntax for both "
+        "lint patterns (silent-except and atomic-write)."
+    )
+
+
+def test_critical_rules_footer_present():
+    section = _worker_dispatch_standards_section()
+    for required in ("DO NOT add TODO/FIXME", "DO NOT bypass tests with --no-verify"):
+        assert required in section, f"Critical-rules footer lost: {required!r}"


### PR DESCRIPTION
## Triage-ronde 7: bestaan deze bevindingen nog?

Meet-opdracht op een verse worktree vanaf origin/main (`2f0fe2f1`). Geen fix-opdracht
in de eerste plaats: 12 oude open items getoetst tegen de huidige code.

**Uitkomst: 6 ACHTERHAALD, 2 BESTAAT-KLEIN (gefixt), 4 BESTAAT-GROOT (ontwerpkeuze nodig).**

### Oordeelregels (bewijs in het unified report)

```
OI-856 | ACHTERHAALD | plan-doc weg; ledger geïmplementeerd in smart_router.py:435 (route_decisions.ndjson, PR #565)
OI-860 | BESTAAT-GROOT | beide tests nog rood; guard #805 eist reasoning_error-signaal dat nergens bestaat → functies dood
OI-862 | BESTAAT-KLEIN | gefixt: fail-closed exit-code (rc=1 bij errors>0 && analyzed==0)
OI-867 | ACHTERHAALD | dry-run roept _check_reachability aan (dispatch_cli.py:1432); registry zet dispatch_allowed:false op litellm:deepseek
OI-874 | BESTAAT-GROOT | _VALID_TARGET_SLOTS frozenset staat er nog (dispatch_spec.py:136)
OI-875 | ACHTERHAALD | code-claim klopt; root-cause-pad gesloten (central-first events dir + OI-878 boundary-detection)
OI-883 | ACHTERHAALD | attributieketen dicht (PR #1261 + backfill in link_sessions_dispatches.py:229; token_usage nu breed gevuld)
OI-885 | ACHTERHAALD | relay default-off by design; OI-863-stille-hang afgedekt door awaiting_permission-detectie (#1311); #1252 ongemerged
OI-886 | BESTAAT-GROOT | .vnx-attest/ nog untracked in deze repo, geen keuze gemaakt
OI-889 | ACHTERHAALD | timekeeper pricing.json prijst deepseek-v4-flash/pro + glm-5.2 nu (2026-08-01)
OI-890 | BESTAAT-KLEIN | gefixt: marker-syntax in Worker Dispatch Standards footer (T0-rol)
OI-891 | BESTAAT-GROOT | skip-own-group guard sluit nog de T0/operator-groep uit; wie ruimt hoofd-checkout-wezen op is open
```

### Codewijzigingen (2 kleine fixes)

1. **OI-862** — `conversation_analyzer.py::main()` ving de RunStats-return niet op;
   een nacht waarin alle sessies faalden eindigde met exit 0. Nu
   `fail_closed_exit_code()` in models.py → rc=1 + heartbeat "fail" bij een
   volledig gefaalde run. Partial runs blijven groen.
2. **OI-890** — vnx-silent-except / vnx-atomic-write marker-syntax + noqa-afwijzing
   gecodificeerd in de Worker Dispatch Standards footer van de canonieke T0-rol
   (keuze optie a uit het item; gate ongewijzigd).

### Tests

- Nieuw: `TestFailClosedExitCode` (2) + `test_worker_dispatch_standards.py` (3).
- Beide staan op de oude code rood (helper bestond niet; rol miste de syntax).
- 61/61 overige analyzer-tests, 56 rol-tests, 34 OI-867-tests groen.
- Ongewijzigd rood op main: OI-860's twee tests (BESTAAT-GROOT) + bekende
  `test_dispatch_envelope.py::TestFlagGateClaude`.

Geen van de vier BESTAAT-GROOT items is aangeraakt: ze vragen elk een
expliciete ontwerpbeslissing (OI-860 guard-signaal, OI-874 slot-cap, OI-886
attest-regime, OI-891 wees-opruiming). Bewijs per item: unified report
`20260801-r7-oi-triage.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)