### PR TITLE
fix(triage): OI-908/916/918/919/925 — ronde-8 meetronde, 5 kleine fixes

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -662,7 +662,9 @@ def _verification_from_report(report_path: Optional[Path]) -> Dict[str, Any]:
         return _unknown_verification()
 
 
-def _archive_dispatch_events(terminal: Optional[str], dispatch_id: str) -> Optional[str]:
+def _archive_dispatch_events(
+    terminal: Optional[str], dispatch_id: str
+) -> "tuple[Optional[str], bool]":
     """Archive the live event stream under ``dispatch_id`` (end-of-dispatch teardown).
 
     The envelope path previously never archived the per-dispatch ring buffer at
@@ -671,17 +673,26 @@ def _archive_dispatch_events(terminal: Optional[str], dispatch_id: str) -> Optio
     boundary guard (EventStore.append, #1276) rotated the previous stream, so the
     LAST dispatch in a series leaked its events into the live file.
 
-    Returns the archive path (str) when archived, else None.  Guards against
-    mislabeling: when the live file holds a DIFFERENT dispatch's events (this
-    dispatch never wrote to the stream — e.g. a pre-spawn failure), the file is
-    left untouched for the boundary guard of the next dispatch; archiving it here
-    would mislabel the previous dispatch's events under our id.
+    Returns ``(events_path, clear_ok)``:
+    - ``events_path`` is the archive path (str) when archived, else None.
+    - ``clear_ok`` tells the caller whether the live stream may be truncated
+      afterwards. It is False ONLY when the archive step itself raised and the
+      live file still holds this dispatch's events — clearing then would destroy
+      exactly the events that failed to archive (OI-918). It is True when the
+      archive succeeded, when there was nothing to archive (empty/missing file),
+      or when the live file holds a DIFFERENT dispatch's events (the caller's own
+      clear guard already refuses to wipe a foreign stream).
+
+    Guards against mislabeling: when the live file holds a DIFFERENT dispatch's
+    events (this dispatch never wrote to the stream — e.g. a pre-spawn failure),
+    the file is left untouched for the boundary guard of the next dispatch;
+    archiving it here would mislabel the previous dispatch's events under our id.
 
     Best-effort — a failure never breaks the dispatch (mirrors the
     ``_emit_governance`` archive contract in provider_dispatch).
     """
     if not terminal or not dispatch_id:
-        return None
+        return None, True
     try:
         from event_store import EventStore  # noqa: PLC0415
 
@@ -694,17 +705,18 @@ def _archive_dispatch_events(terminal: Optional[str], dispatch_id: str) -> Optio
                 "holds %r, not %s (left for the next dispatch's boundary guard)",
                 terminal, last_dispatch, dispatch_id,
             )
-            return None
+            return None, True
         archived = store.archive(terminal, dispatch_id)
         if archived is not None:
             logger.info("envelope: end-dispatch archived %s -> %s", terminal, archived)
-        return str(archived) if archived is not None else None
+        return (str(archived) if archived is not None else None), True
     except Exception as exc:  # noqa: BLE001 — teardown must never break the dispatch
         logger.warning(
-            "envelope: end-dispatch event archive failed terminal=%s dispatch=%s (non-fatal): %s",
+            "envelope: end-dispatch event archive failed terminal=%s dispatch=%s "
+            "(non-fatal, live file left for the next dispatch's boundary guard): %s",
             terminal, dispatch_id, exc,
         )
-        return None
+        return None, False
 
 
 def _clear_dispatch_events(terminal: Optional[str], dispatch_id: str) -> None:
@@ -781,7 +793,7 @@ def _govern(
     # envelope path never rotated the ring buffer at end-of-dispatch — only the
     # NEXT dispatch's write-side boundary guard did, so the LAST dispatch in a
     # series leaked its events into the live file.
-    events_path = _archive_dispatch_events(spec.terminal_id, spec.dispatch_id)
+    events_path, _events_archive_ok = _archive_dispatch_events(spec.terminal_id, spec.dispatch_id)
 
     # REPORT first — idempotent: worker-written file is preserved, not overwritten.
     # OI-903: on failure/timeout, a killed worker's partial report is preserved
@@ -979,7 +991,19 @@ def _govern(
     finally:
         # OI-878/OI-902: truncate the live event stream now that the archive
         # (top of _govern) and the receipt write are complete. Best-effort.
-        _clear_dispatch_events(spec.terminal_id, spec.dispatch_id)
+        # OI-918: only when the archive step actually succeeded (or had nothing
+        # to archive) — clearing after a FAILED archive would destroy exactly
+        # the events we wanted to preserve. On an archive failure the live file
+        # is left in place for the next dispatch's write-side boundary guard
+        # (#1276) to rotate, which is the second line of defence it exists for.
+        if _events_archive_ok:
+            _clear_dispatch_events(spec.terminal_id, spec.dispatch_id)
+        else:
+            logger.warning(
+                "envelope: end-dispatch clear skipped terminal=%s dispatch=%s — "
+                "archive failed; live file left for the next dispatch's boundary guard",
+                spec.terminal_id, spec.dispatch_id,
+            )
 
     if adapter_result.status != "success":
         # Fail-loud: a failure/timeout/empty-completion receipt must never be silent.
@@ -1133,6 +1157,22 @@ def _fail_loud_on_empty_success(
                 f"provider={provider_str} returned an empty completion with "
                 f"returncode={returncode} — refusing to report a silent empty "
                 f"success (raw spawn result: {raw_result!r})"
+            ),
+        )
+    if status != "success" and not (completion_text or "").strip():
+        # OI-925 (restant van OI-866): a NON-success spawn with a blank
+        # completion and no captured error previously surfaced in the
+        # dispatch_cli log line as "(no error captured)" even though the
+        # receipt classified it as empty_completion. Give the operator a
+        # diagnosable message instead of a silent blank. (Deepseek-harness:
+        # a returncode!=0 spawn with empty text and error=None lands here —
+        # _coerce_empty_completion_to_retryable only rewrites the rc=0 case.)
+        return (
+            status,
+            returncode or 1,
+            (
+                f"provider={provider_str} returned an empty completion with "
+                f"returncode={returncode} — no error captured by spawn"
             ),
         )
     return status, returncode, None

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,6 +46,11 @@ def pytest_configure(config: pytest.Config) -> None:
         "markers",
         "integration: end-to-end integration tests (slower; opt-in via -m integration)",
     )
+    config.addinivalue_line(
+        "markers",
+        "live: real headless-LLM inference (f39 replays; deselected by default — "
+        "opt in with -m live or --dry-run, OI-908)",
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/f39/conftest.py
+++ b/tests/f39/conftest.py
@@ -1,4 +1,12 @@
-"""F39 pytest configuration — registers custom CLI options."""
+"""F39 pytest configuration — registers custom CLI options.
+
+OI-908: the f39 replay tests drive REAL headless claude inference per scenario.
+A plain `pytest tests/` must stay deterministic and offline, so the replay tests
+are marked `live` and DESELECTED by default. Opt in explicitly with `-m live`
+(real inference) or `--dry-run` (fixture validation only, no LLM call). Without
+this, every default suite run paid for live LLM calls on scenarios whose
+red/green depended on a model answer instead of on the code.
+"""
 
 import pytest
 
@@ -6,3 +14,18 @@ import pytest
 def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--model", default=None, help="Claude model override for replay tests (haiku/sonnet/opus)")
     parser.addoption("--dry-run", action="store_true", default=False, help="Skip LLM calls — validate fixtures only")
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect `live`-marked replay tests unless the user opted in.
+
+    Opt-in signals: an explicit `-m` expression (e.g. `-m live`), or `--dry-run`
+    (fixture-only validation). The project has no global `addopts`, so the gate
+    lives here, scoped to tests/f39 — a plain `pytest tests/` (or `pytest tests/f39/`)
+    collects zero replay tests and stays offline.
+    """
+    if config.getoption("-m"):
+        return
+    if config.getoption("--dry-run"):
+        return
+    items[:] = [item for item in items if item.get_closest_marker("live") is None]

--- a/tests/f39/conftest.py
+++ b/tests/f39/conftest.py
@@ -9,6 +9,8 @@ red/green depended on a model answer instead of on the code.
 """
 
 import pytest
+from _pytest.mark import MarkMatcher
+from _pytest.mark.expression import Expression, ParseError
 
 
 def pytest_addoption(parser: pytest.Parser) -> None:
@@ -16,16 +18,41 @@ def pytest_addoption(parser: pytest.Parser) -> None:
     parser.addoption("--dry-run", action="store_true", default=False, help="Skip LLM calls — validate fixtures only")
 
 
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
-    """Deselect `live`-marked replay tests unless the user opted in.
+def _markexpr_selects_live(markexpr: str) -> bool:
+    """True when the user's ``-m`` expression deliberately selects the ``live`` marker.
 
-    Opt-in signals: an explicit `-m` expression (e.g. `-m live`), or `--dry-run`
-    (fixture-only validation). The project has no global `addopts`, so the gate
-    lives here, scoped to tests/f39 — a plain `pytest tests/` (or `pytest tests/f39/`)
-    collects zero replay tests and stays offline.
+    Reuses pytest's own marker-expression engine on two synthetic items: one
+    carrying the ``live`` marker and one carrying no markers. ``-m live`` matches
+    only the live item, so it is a deliberate opt-in. A broad filter such as
+    ``-m "not integration"`` matches both items and is therefore NOT an opt-in —
+    the replay tests stay deselected.
     """
-    if config.getoption("-m"):
-        return
+    live_matcher = MarkMatcher.from_markers([pytest.mark.live.mark])
+    bare_matcher = MarkMatcher.from_markers([])
+    expr = Expression.compile(markexpr)
+    return expr.evaluate(live_matcher) and not expr.evaluate(bare_matcher)
+
+
+def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:
+    """Deselect `live`-marked replay tests unless the user explicitly opted in.
+
+    Opt-in signals: an explicit `-m` expression that actually selects the `live`
+    marker (e.g. `-m live`), or `--dry-run` (fixture validation only, no LLM call).
+    The mere presence of any `-m` expression is NOT an opt-in: `-m "not integration"`
+    must keep the replay tests deselected so an unrelated filter cannot silently
+    re-enable 31 real headless-`claude -p` calls. The project has no global
+    `addopts`, so the gate lives here, scoped to tests/f39 — a plain `pytest tests/`
+    (or `pytest tests/f39/`) collects zero replay tests and stays offline.
+    """
     if config.getoption("--dry-run"):
         return
+    markexpr = config.getoption("-m")
+    if markexpr:
+        try:
+            if _markexpr_selects_live(markexpr):
+                return
+        except ParseError:
+            # Invalid expression: fail closed (keep the replay tests deselected);
+            # pytest itself reports the usage error for the same expression.
+            pass
     items[:] = [item for item in items if item.get_closest_marker("live") is None]

--- a/tests/f39/test_replay_level1.py
+++ b/tests/f39/test_replay_level1.py
@@ -70,6 +70,7 @@ _SCENARIOS = _collect_scenarios()
 # Individual scenario tests (parametrized)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 @pytest.mark.parametrize("name,scenario_path", _SCENARIOS, ids=[s[0] for s in _SCENARIOS])
 def test_level1_scenario(
     name: str,
@@ -103,6 +104,7 @@ def test_level1_scenario(
 # Aggregate gate test
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 def test_level1_aggregate_pass_rate(request: pytest.FixtureRequest) -> None:
     """Level-1 gate: ≥90% of all scenarios must produce the correct decision.
 

--- a/tests/f39/test_replay_level2.py
+++ b/tests/f39/test_replay_level2.py
@@ -72,6 +72,7 @@ _CHAIN_SCENARIOS = _collect_chain_scenarios()
 # Individual chain tests (parametrized)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 @pytest.mark.parametrize("name,scenario_path", _CHAIN_SCENARIOS, ids=[s[0] for s in _CHAIN_SCENARIOS])
 def test_level2_chain_scenario(
     name: str,
@@ -111,6 +112,7 @@ def test_level2_chain_scenario(
 # Aggregate gate test
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 def test_level2_aggregate_step_accuracy(request: pytest.FixtureRequest) -> None:
     """Level-2 gate: ≥90% of all steps across all chains must produce the correct decision.
 

--- a/tests/f39/test_replay_level3.py
+++ b/tests/f39/test_replay_level3.py
@@ -82,6 +82,7 @@ _SCENARIOS = _collect_scenarios()
 # Individual scenario tests (parametrized)
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 @pytest.mark.parametrize("name,scenario_path", _SCENARIOS, ids=[s[0] for s in _SCENARIOS])
 def test_level3_scenario(
     name: str,
@@ -114,6 +115,7 @@ def test_level3_scenario(
 # Aggregate gate test
 # ---------------------------------------------------------------------------
 
+@pytest.mark.live  # OI-908: real headless claude inference — opt in with -m live / --dry-run
 def test_level3_aggregate_pass_rate(request: pytest.FixtureRequest) -> None:
     """Level-3 gate: ≥80% of all edge case scenarios must produce the correct decision.
 

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -216,6 +216,47 @@ class TestEnvelopeEmitsBothReportAndReceipt:
 # ---------------------------------------------------------------------------
 
 
+class TestEnvelopeEventArchiveClear:
+    """OI-918: the end-of-dispatch clear must only fire when archiving succeeded.
+
+    _govern's finally unconditionally truncated the live event stream even when
+    the end-of-dispatch archive had failed — destroying exactly the events it
+    was meant to preserve. _archive_dispatch_events now returns
+    (events_path, clear_ok), and the clear is gated on clear_ok.
+    """
+
+    def _run(self, spec, codex_result, archive_return):
+        report_path, receipt_path, mock_report, mock_receipt = _stub_governance(spec)
+        mock_archive = MagicMock(return_value=archive_return)
+        mock_clear = MagicMock()
+
+        with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
+             patch("governance_emit.emit_unified_report", mock_report), \
+             patch("governance_emit.emit_dispatch_receipt", mock_receipt), \
+             patch("dispatch_envelope._archive_dispatch_events", mock_archive), \
+             patch("dispatch_envelope._clear_dispatch_events", mock_clear):
+            result = run_envelope(spec, lane="codex")
+
+        return result, mock_archive, mock_clear
+
+    def test_archive_failure_skips_clear(self, spec):
+        """archive raised (clear_ok=False) -> live stream must NOT be truncated."""
+        codex_result = _FakeCodexResult(returncode=0)
+        result, mock_archive, mock_clear = self._run(spec, codex_result, (None, False))
+
+        assert result.status == "success"
+        mock_archive.assert_called_once_with(spec.terminal_id, spec.dispatch_id)
+        mock_clear.assert_not_called()
+
+    def test_archive_success_still_clears(self, spec):
+        """archive succeeded (clear_ok=True) -> clear still fires as before."""
+        codex_result = _FakeCodexResult(returncode=0)
+        result, mock_archive, mock_clear = self._run(spec, codex_result, ("/arc/path.ndjson", True))
+
+        assert result.status == "success"
+        mock_clear.assert_called_once_with(spec.terminal_id, spec.dispatch_id)
+
+
 class TestEnvelopeFailClosed:
     """GOVERN must raise EnvelopeGovernError when receipt is missing — never silent."""
 
@@ -568,7 +609,18 @@ class TestEnvelopeIdempotentDedup:
 
 
 class TestFlagGateClaude:
-    """VNX_UNIFIED_ENVELOPE flag controls whether envelope or legacy path is used for claude."""
+    """claude via provider_dispatch is ALWAYS rejected at the door (PR-5).
+
+    The old VNX_UNIFIED_ENVELOPE flag gate for the claude lane was removed:
+    provider_dispatch is not a provider-lane for claude — the single-entry
+    dispatch door owns all claude routing (DISPATCH_RULES provider->lane rule,
+    'claude/Opus/Sonnet panelists and workers route via the tmux-spawn lane —
+    NEVER provider_dispatch'). These tests pin that the claude flag-gate no
+    longer exists: regardless of VNX_UNIFIED_ENVELOPE, claude is refused with
+    EX_USAGE and neither dispatch path is invoked. (Previously the four tests
+    here asserted a flag-gate that PR-5 deleted, leaving them permanently red
+    — OI-919.)
+    """
 
     _CLAUDE_ARGV = [
         "--provider", "claude",
@@ -577,69 +629,46 @@ class TestFlagGateClaude:
         "--instruction", "noop",
     ]
 
-    def test_flag_off_calls_legacy_dispatch_claude(self, monkeypatch):
-        """VNX_UNIFIED_ENVELOPE unset -> _dispatch_claude, envelope NOT invoked."""
+    def _assert_claude_rejected(self, monkeypatch, capsys):
+        monkeypatch.setenv("VNX_SINGLE_ENTRY_DISPATCH", "0")
+        monkeypatch.delenv("VNX_BENCH_SEED_MATERIALIZE", raising=False)
+        monkeypatch.delenv("VNX_BENCH_CLAUDE_HEADLESS", raising=False)
+
+        mock_legacy = MagicMock(return_value=0)
+        mock_via_envelope = MagicMock(return_value=0)
+
+        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
+             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
+            result = provider_dispatch.main(self._CLAUDE_ARGV)
+
+        assert result == provider_dispatch._EX_USAGE
+        mock_legacy.assert_not_called()
+        mock_via_envelope.assert_not_called()
+        assert "is not a provider-lane provider" in capsys.readouterr().err
+
+    def test_flag_off_claude_rejected_at_door(self, monkeypatch, capsys):
+        """VNX_UNIFIED_ENVELOPE unset: claude is still rejected, not legacy-routed."""
         monkeypatch.delenv("VNX_UNIFIED_ENVELOPE", raising=False)
         monkeypatch.delenv("VNX_UNIFIED_ENVELOPE_LANES", raising=False)
+        self._assert_claude_rejected(monkeypatch, capsys)
 
-        mock_legacy = MagicMock(return_value=0)
-        mock_via_envelope = MagicMock(return_value=0)
-
-        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
-             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
-            result = provider_dispatch.main(self._CLAUDE_ARGV)
-
-        mock_legacy.assert_called_once()
-        mock_via_envelope.assert_not_called()
-        assert result == 0
-
-    def test_flag_on_calls_envelope(self, monkeypatch):
-        """VNX_UNIFIED_ENVELOPE=1 + claude-subprocess in lanes -> _dispatch_claude_via_envelope."""
+    def test_flag_on_claude_rejected_at_door(self, monkeypatch, capsys):
+        """VNX_UNIFIED_ENVELOPE=1 + claude-subprocess in lanes: still rejected."""
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "claude-subprocess")
+        self._assert_claude_rejected(monkeypatch, capsys)
 
-        mock_legacy = MagicMock(return_value=0)
-        mock_via_envelope = MagicMock(return_value=0)
-
-        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
-             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
-            result = provider_dispatch.main(self._CLAUDE_ARGV)
-
-        mock_via_envelope.assert_called_once()
-        mock_legacy.assert_not_called()
-        assert result == 0
-
-    def test_flag_on_claude_alias_calls_envelope(self, monkeypatch):
-        """VNX_UNIFIED_ENVELOPE=1 + "claude" (alias) in lanes -> _dispatch_claude_via_envelope."""
+    def test_flag_on_claude_alias_rejected_at_door(self, monkeypatch, capsys):
+        """VNX_UNIFIED_ENVELOPE=1 + "claude" alias in lanes: still rejected."""
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "claude")
+        self._assert_claude_rejected(monkeypatch, capsys)
 
-        mock_legacy = MagicMock(return_value=0)
-        mock_via_envelope = MagicMock(return_value=0)
-
-        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
-             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
-            result = provider_dispatch.main(self._CLAUDE_ARGV)
-
-        mock_via_envelope.assert_called_once()
-        mock_legacy.assert_not_called()
-        assert result == 0
-
-    def test_flag_on_wrong_lane_calls_legacy(self, monkeypatch):
-        """VNX_UNIFIED_ENVELOPE=1 but claude NOT in lanes -> legacy _dispatch_claude."""
+    def test_flag_on_wrong_lane_claude_rejected_at_door(self, monkeypatch, capsys):
+        """VNX_UNIFIED_ENVELOPE=1 + claude NOT in lanes: still rejected."""
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE", "1")
         monkeypatch.setenv("VNX_UNIFIED_ENVELOPE_LANES", "codex,gemini")
-
-        mock_legacy = MagicMock(return_value=0)
-        mock_via_envelope = MagicMock(return_value=0)
-
-        with patch.object(provider_dispatch, "_dispatch_claude", mock_legacy), \
-             patch.object(provider_dispatch, "_dispatch_claude_via_envelope", mock_via_envelope):
-            result = provider_dispatch.main(self._CLAUDE_ARGV)
-
-        mock_legacy.assert_called_once()
-        mock_via_envelope.assert_not_called()
-        assert result == 0
+        self._assert_claude_rejected(monkeypatch, capsys)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_envelope_fail_loud.py
+++ b/tests/test_dispatch_envelope_fail_loud.py
@@ -181,6 +181,36 @@ def test_provider_adapter_empty_completion_is_fail_loud(
     assert "empty completion" in result.error
 
 
+def test_provider_adapter_nonzero_blank_no_error_is_diagnosable(tmp_path, monkeypatch):
+    """OI-925: a returncode!=0 spawn with a BLANK completion and NO captured
+    error must still surface a diagnosable error, not a silent
+    '(no error captured)' in the dispatch_cli log line.
+
+    The deepseek-harness empty-completion coercion in the spawn only rewrites
+    the returncode==0 case; a non-zero exit with empty text and error=None
+    previously fell through _fail_loud_on_empty_success with error=None, so the
+    receipt classified it as empty_completion while the operator-visible log
+    line said nothing. The central guard must cover the non-success case too.
+    """
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.resolve_harness_model",
+        lambda m: "deepseek-v4-test",
+    )
+    empty_result = _FakeKimiResult(returncode=1, completion_text="", error=None)
+    monkeypatch.setattr(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness",
+        lambda *a, **k: empty_result,
+    )
+
+    plan = _make_provider_plan(tmp_path, provider=Provider.DEEPSEEK_HARNESS, model="default")
+    result = ProviderAdapter().run(plan, "prompt")
+
+    assert result.status == "failure", f"expected failure, got {result.status}"
+    assert result.error, "non-success blank completion with no error must set a diagnosable error"
+    assert "empty completion" in result.error
+    assert "no error captured" in result.error
+
+
 def test_provider_adapter_nonempty_completion_still_succeeds(tmp_path, monkeypatch):
     """Guard rail: the fail-loud guard must not false-positive on real output."""
     real_result = _FakeKimiResult(returncode=0, completion_text="a real answer")

--- a/tests/test_f39_live_guard.py
+++ b/tests/test_f39_live_guard.py
@@ -1,0 +1,50 @@
+"""Regression test for OI-908 ronde 2: a non-live ``-m`` expression must not bypass f39 deselection.
+
+The collection hook in ``tests/f39/conftest.py`` deselects ``live``-marked replay
+tests unless the user opts in explicitly. Round 1 treated ANY ``-m`` expression as
+an opt-in, so ``pytest tests/f39 -m "not integration"`` silently collected all 31
+replay tests — each a real headless ``claude -p`` call. This pins the matrix:
+
+    pytest tests/f39                      -> 0 replay tests collected
+    pytest tests/f39 -m live              -> 31 replay tests collected (explicit opt-in)
+    pytest tests/f39 -m "not integration" -> 0 replay tests collected (unrelated filter)
+
+Verification uses ``--collect-only`` so the test never executes a replay scenario
+and never triggers LLM inference.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TESTS_F39 = REPO_ROOT / "tests" / "f39"
+
+
+def _collect_count(marker_expr: str | None = None) -> int:
+    """Number of f39 replay tests pytest collects for the given ``-m`` expression."""
+    cmd = [sys.executable, "-m", "pytest", str(TESTS_F39), "--collect-only", "-q"]
+    if marker_expr is not None:
+        cmd += ["-m", marker_expr]
+    proc = subprocess.run(cmd, capture_output=True, text=True, cwd=REPO_ROOT)
+    # Exit 5 = "no tests collected", the expected result for a fully deselected run.
+    assert proc.returncode in (0, 5), f"pytest collect failed:\n{proc.stdout}\n{proc.stderr}"
+    return sum(
+        1
+        for line in proc.stdout.splitlines()
+        if line.startswith("tests/f39/") and "::" in line
+    )
+
+
+def test_default_run_deselects_replay_tests() -> None:
+    assert _collect_count() == 0
+
+
+def test_explicit_live_opt_in_collects_replay_tests() -> None:
+    assert _collect_count("live") == 31
+
+
+def test_unrelated_marker_expression_does_not_bypass_deselection() -> None:
+    assert _collect_count("not integration") == 0

--- a/tests/test_session_reconcile_lifetime.sh
+++ b/tests/test_session_reconcile_lifetime.sh
@@ -116,11 +116,17 @@ flock_free_within() {
     return 1
 }
 
-# shellcheck disable=SC2034  # VNX_STATE_DIR / VNX_PROJECT_ID are consumed by the hook child process
+# OI-916: VNX_STATE_DIR / VNX_PROJECT_ID are consumed by the hook CHILD process
+# (the detached reconcile worker), so they must be EXPORTED — a bare
+# `VAR=value` assignment inside a script is not exported to child processes.
+# The hooks fall back to vnx_paths resolution when VNX_STATE_DIR is absent,
+# which would resolve the REAL central store and break this test's isolation
+# (and, worse, scatter throwaway markers into the production store).
+# shellcheck disable=SC2034  # exported for the hook child process
 run_session_start() {
     local root="$1" sid="$2"
     ( cd "$root" \
-        && VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
+        && export VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
         && printf '{"session_id":"%s","hook_event_name":"SessionStart"}' "$sid" \
         | bash "$HOOKS/session_reconcile_autoclose.sh" )
 }
@@ -128,7 +134,7 @@ run_session_start() {
 run_session_end() {
     local root="$1" sid="$2"
     ( cd "$root" \
-        && VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
+        && export VNX_STATE_DIR="$root/.vnx-data/state" VNX_PROJECT_ID="" \
         && printf '{"session_id":"%s","hook_event_name":"SessionEnd"}' "$sid" \
         | bash "$HOOKS/session_reconcile_cleanup.sh" )
 }


### PR DESCRIPTION
## Triage-ronde 8 — OI-901, OI-908, OI-909, OI-915, OI-916, OI-918, OI-919, OI-924, OI-925

**Dit is een meet-opdracht, geen fix-opdracht.** 9 open items gemeten op de verse worktree vanaf `origin/main`. Uitkomst: **0 ACHTERHAALD, 5 BESTAAT-KLEIN (gefixt), 4 BESTAAT-GROOT**.

Volledig bewijs per item: `~/.vnx-data/vnx-dev/unified_reports/20260801-r8-oi-triage.md`.

## Kleine fixes (met tests die op main rood stonden)

| OI | Fix |
|---|---|
| OI-908 | f39-replay tests gemarkeerd `@pytest.mark.live`, standaard gedeselecteerd via collection-hook in `tests/f39/conftest.py`. `pytest tests/` blijft offline; opt-in via `-m live` of `--dry-run`. |
| OI-916 | `test_session_reconcile_lifetime.sh` exporteert `VNX_STATE_DIR` (bare assignment exporteert in bash niet naar child-processen; zonder export viel de hook terug op de centrale store). |
| OI-918 | `_archive_dispatch_events` retourneert `(events_path, clear_ok)`; `_govern`'s finally wist live events alleen na een geslaagd archief. |
| OI-919 | `TestFlagGateClaude` (4 tests, permanent rood op main) herschreven naar het huidige deurcontract: provider_dispatch weigert claude (PR-5), de stale VNX_UNIFIED_ENVELOPE-flag-gate bestaat niet meer. |
| OI-925 | `_fail_loud_on_empty_success` geeft ook bij een niet-success met lege completion + geen error een beschrijvende melding i.p.v. `(no error captured)`. |

## Grote items (niet gefixt, met gemeten bewijs)

- **OI-901** — codex abstain-mechanisme + melding bestaan nog (`plan_gate_panel.py:359-381`); parser is al toleranter + retry aanwezig, maar een echte abstain vereist live codex-inference. De seat-ledger (#1275) is er maar heeft nog 0 records — meten is nu pas mogelijk.
- **OI-909** — `headless_block` staat nog `enabled: true` met de achterhaalde API-metered-reden; weghalen is **Vincents besluit** (item zegt het zelf).
- **OI-915** — `review_gate_request`-receipt op het handmatige `bin/vnx gate`-pad heeft geen `dispatch_id`/`pr_id`; de dispatch-linkage is een governance-ontwerpbesluit (dispatch-gedreven gates hebben wél `dispatch_id`, `gate_executor.py:413`).
- **OI-924** — lege completion => status=failure terwijl een volledig contract-conform report op schijf staat; de uitkomst-classificatie `completed_without_final_event` is een ontwerpkeuze.

## Verification

- `tests/test_dispatch_envelope.py` — 33 passed (was 4 failed/26 passed op main)
- `tests/test_dispatch_envelope_fail_loud.py` — 9 passed (incl. nieuwe OI-925-test, rood op oude code)
- `tests/test_dispatch_envelope.py::TestEnvelopeEventArchiveClear` — 2 passed (OI-918; `test_archive_failure_skips_clear` rood op oude code)
- `bash tests/test_session_reconcile_lifetime.sh` met `env -u VNX_STATE_DIR` — 12 passed, 0 failed (was 1 failed)
- `pytest tests/f39/` — no tests ran (deselected); `-m live --dry-run` = 14 skipped
- Geen centrale-store-vervuiling (gecontroleerd op test-session-id markers)

## Open Items

- OI-909 (Vincents besluit), OI-915, OI-924, OI-901 (meten met de nieuwe seat-ledger).
- OI-908 fix-richting (b) — f39 in CI opnemen — hoort bij OI-906.

🤖 Generated with [Claude Code](https://claude.com/claude-code)