### PR TITLE
fix(bridge): OI-929 — plan-gate blockers survive the OI bridge obsolete-sweep

### DIFF
--- a/scripts/import_open_items_to_tracks.py
+++ b/scripts/import_open_items_to_tracks.py
@@ -35,6 +35,14 @@ Contracts implemented:
   * R4.2 load ALL links by (project_id, oi_id) and supersede/resolve every
     now-obsolete active link, including CLOSURE when there is no current
     mapping (the OI was closed or became unmappable).
+  * OI-929 plan-gate carve-out: synthetic ``OI-PLAN-<track>`` blockers (the
+    plan-first gate, seeded by ``planning_cli._seed_plan_blocker``) are
+    excluded from the R4.2 obsolete-sweep ENTIRELY. They belong to the plan-gate
+    lifecycle, never to the open-items store, and never map to ``open_items.json``
+    — the sweep would otherwise close every one of them on a run. The bridge
+    neither closes nor reopens them (unresolved stays unresolved, resolved stays
+    resolved); the count is reported in ``plan_gate_links_skipped``, never
+    folded into ``unmappable`` (that tally is reserved for real open items).
   * R4.3 require the full resolution schema (migration 0030
     ``resolved_at`` / ``resolution_reason``); a pre-0030 DB fails CLOSED with
     an explicit error (CLI exit 5) and NEVER reports success.
@@ -107,6 +115,7 @@ if str(_LIB) not in sys.path:
     sys.path.insert(0, str(_LIB))
 
 import tracks  # noqa: E402  (single-writer primitives — D1)
+from plan_gate_enforcement import PLAN_OI_PREFIX  # noqa: E402  (synthetic plan-gate OI prefix — canonical home)
 from vnx_ids import PROJECT_ID_RE  # noqa: E402  (canonical project-id format — ADR-007)
 
 DB_FILENAME = "runtime_coordination.db"
@@ -169,6 +178,10 @@ class BridgeResult:
     skipped_malformed: List[str] = field(default_factory=list)
     errors: List[str] = field(default_factory=list)
     ledger_failed: bool = False
+    # OI-929: synthetic OI-PLAN-<track> blocker rows the bridge deliberately
+    # EXCLUDED from the obsolete-sweep. NOT a mutation counter — it counts rows
+    # the bridge chose not to touch, so it survives a run-level rollback as-is.
+    plan_gate_links_skipped: int = 0
 
     @property
     def ok(self) -> bool:
@@ -592,7 +605,25 @@ def import_open_items_to_tracks(
         # C4-N1: a MALFORMED item is untrustworthy input — exclude its oi_id so its
         # existing links are neither closed nor relinked (non-destructive; surfaced).
         malformed = set(result.skipped_malformed)
-        all_oi_ids = sorted((set(desired) | set(existing_by_oi)) - malformed)
+        # OI-929: synthetic plan-gate blockers (OI-PLAN-<track>) belong to the
+        # plan-first gate lifecycle (planning_cli._seed_plan_blocker /
+        # _resolve_plan_blocker), never to the open-items store — their ids never
+        # appear in open_items.json, so the R4.2 obsolete-sweep would close every
+        # one of them on a run. The bridge has no authority over the plan gate:
+        # exclude them from the sweep ENTIRELY (an unresolved blocker stays
+        # unresolved, a resolved one stays resolved) and count the excluded rows
+        # honestly instead of folding them into the unmappable tally.
+        plan_gate_ids = {
+            oi_id for oi_id in set(desired) | set(existing_by_oi)
+            if oi_id.startswith(PLAN_OI_PREFIX)
+        }
+        result.plan_gate_links_skipped = sum(
+            len(existing_by_oi[oi_id]) for oi_id in plan_gate_ids
+            if oi_id in existing_by_oi
+        )
+        all_oi_ids = sorted(
+            (set(desired) | set(existing_by_oi)) - malformed - plan_gate_ids
+        )
         _run_mutations(
             state_dir, conn, project_id, all_oi_ids,
             desired, existing_by_oi, link_source, result,
@@ -738,6 +769,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         f"reopened={result.reopened} unlinked={result.unlinked} "
         f"skipped={result.skipped} unmappable={len(result.unmappable)} "
         f"skipped_malformed={len(result.skipped_malformed)} "
+        f"plan_gate_links_skipped={result.plan_gate_links_skipped} "
         f"ledger_failed={result.ledger_failed}"
     )
     if result.ledger_failed:

--- a/tests/test_oi_track_bridge.py
+++ b/tests/test_oi_track_bridge.py
@@ -177,6 +177,26 @@ def _events(state_dir, event_type):
     return out
 
 
+def _plan_blocker(state_dir, track_id, *, resolved=False):
+    """Insert a synthetic OI-PLAN-<track> plan-gate blocker row directly.
+
+    Mirrors the row ``planning_cli._seed_plan_blocker`` creates (blocks/manual),
+    optionally pre-resolved as a gate that already passed. The track must exist
+    (the 0024 composite FK (track_id, project_id) → tracks is enforced)."""
+    db = state_dir / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "INSERT INTO track_open_items "
+        "(track_id, project_id, oi_id, link_type, link_source, resolved_at) "
+        "VALUES (?, ?, ?, 'blocks', 'manual', ?)",
+        (track_id, PROJECT_ID, f"OI-PLAN-{track_id}",
+         "2026-07-01T00:00:00Z" if resolved else None),
+    )
+    conn.commit()
+    conn.close()
+
+
 # ---------------------------------------------------------------------------
 # R4.3 / R8.3 — require resolution schema (pre-0030 fails)
 # ---------------------------------------------------------------------------
@@ -1357,3 +1377,66 @@ class TestPerItemFieldHardening:
         assert "OI-x" in res.unmappable
         assert res.linked == 0
         assert _rows(state_dir, "OI-x") == []
+
+
+# ---------------------------------------------------------------------------
+# OI-929 — the bridge must NOT close the synthetic OI-PLAN-<track> plan-gate
+# blockers. They belong to the plan-first gate lifecycle
+# (planning_cli._seed_plan_blocker / _resolve_plan_blocker), never to the
+# open-items store, and never map to open_items.json — so the R4.2 obsolete-
+# sweep would close every one of them. The carve-out is per-sweep: a genuinely
+# obsolete OI-xxx link still closes, and a resolved plan blocker never reopens.
+# ---------------------------------------------------------------------------
+
+class TestPlanGateBlockersPreserved:
+    def test_unresolved_plan_blocker_survives_bridge_run(self, state_dir):
+        """OI-929 regression: an unresolved OI-PLAN-<track> blocker must NOT be
+        closed by the obsolete-sweep — it never maps to open_items.json and is
+        owned by the plan-first gate, not the open-items store."""
+        _mk_track(state_dir, "feat-a")
+        _plan_blocker(state_dir, "feat-a")
+        assert _rows(state_dir, "OI-PLAN-feat-a")[0]["resolved_at"] is None
+
+        res = bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID,
+            open_items=[_oi("OI-1", pr_id="#404")],  # unrelated real OI (unmappable)
+        )
+        row = _rows(state_dir, "OI-PLAN-feat-a")[0]
+        assert row["resolved_at"] is None          # NOT closed by the sweep
+        assert row["resolution_reason"] is None
+        assert res.unlinked == 0                    # nothing destroyed
+        assert "OI-PLAN-feat-a" not in res.unmappable  # not a fake "unmappable" tally
+        assert res.plan_gate_links_skipped == 1     # counted honestly instead
+
+    def test_genuinely_obsolete_oi_link_still_closed(self, state_dir):
+        """The plan-gate carve-out must NOT disable the whole sweep: a real,
+        genuinely obsolete OI-xxx link with no current mapping still closes."""
+        _mk_track(state_dir, "feat-a", pr_ref="#100")
+        _plan_blocker(state_dir, "feat-a")
+        bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID, open_items=[_oi("OI-1", pr_id="#100")])
+        assert _active_blocks(state_dir) == 2  # real OI-1 + plan blocker
+
+        res = bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID,
+            open_items=[_oi("OI-1", status="done", pr_id="#100")])
+        # The genuinely obsolete OI-1 link closes...
+        assert res.unlinked == 1
+        assert _rows(state_dir, "OI-1")[0]["resolved_at"] is not None
+        # ...but the plan blocker survives untouched.
+        assert _rows(state_dir, "OI-PLAN-feat-a")[0]["resolved_at"] is None
+        assert _active_blocks(state_dir) == 1
+        assert res.plan_gate_links_skipped == 1
+
+    def test_resolved_plan_blocker_stays_resolved(self, state_dir):
+        """A plan blocker the gate already resolved stays resolved — the bridge
+        neither reopens it nor unlinks it (the carve-out is not a wipe-and-recreate)."""
+        _mk_track(state_dir, "feat-a")
+        _plan_blocker(state_dir, "feat-a", resolved=True)
+        assert _rows(state_dir, "OI-PLAN-feat-a")[0]["resolved_at"] is not None
+
+        res = bridge.import_open_items_to_tracks(state_dir, PROJECT_ID, open_items=[])
+        assert res.reopened == 0
+        assert res.unlinked == 0
+        assert res.linked == 0
+        assert _rows(state_dir, "OI-PLAN-feat-a")[0]["resolved_at"] is not None


### PR DESCRIPTION
## OI-929 — de OI→track brug wist de complete plan-first gate

### Het defect (gemeten, niet vermoed)

Eén run van `import_open_items_to_tracks` resolvet elke plan-gate-blokkade. Gemeten tegen een kopie van de productie-DB:

```
voor:  OI-PLAN onopgelost = 70   echte OI-links = 0
run :  python3 scripts/import_open_items_to_tracks.py --project-id vnx-dev --state-dir <kopie>
uit :  [bridge] linked=8 reopened=0 unlinked=70 skipped=0 unmappable=114
na  :  OI-PLAN onopgelost = 0    echte OI-links = 8
```

Keten in de code:

- `_load_links_grouped` leest ALLE `track_open_items`-rijen, incl. de synthetische `OI-PLAN-<track>`-blokkades.
- `_sync_one_oi` roept `_close_obsolete_links` onvoorwaardelijk aan. `OI-PLAN`-ids bestaan per definitie niet in `open_items.json`, dus hun `desired` is altijd `None` en de sweep sluit ze.

De `OI-PLAN`-blokkade IS de plan-first gate (`planning_cli._seed_plan_blocker`). De supervisor-tick (`_maybe_oi_bridge_tick`) draait deze brug automatisch vóór de reconcile-tick zodra `VNX_SUPERVISOR_MODE=unified` staat. Vandaag staat de vlag uit. Wie hem morgen volgens de docs aanzet, wist bij de eerste tick de plan-gate van elke track.

### De fix

Sluit het `OI-PLAN-`-namespace volledig uit van de sweep in `import_open_items_to_tracks`:

- de brug raakt plan-gate-links nooit aan (onopgelost blijft onopgelost, opgelost blijft opgelost);
- teller `plan_gate_links_skipped` telt de uitgesloten rijen eerlijk; ze worden NIET als `unmappable` geboekt (dat is een oneerlijke telling);
- de carve-out is per-sweep: een echt obsolete `OI-xxx`-link wordt nog steeds gesloten.

### Constante-keuze (gevraagd)

`PLAN_OI_PREFIX` wordt geïmporteerd uit `scripts/lib/plan_gate_enforcement.py`, de publieke, bewust dependency-vrije module die de plan-gate-regel op één plek huisvest. Dat is "importeer de bestaande definitie" in plaats van een extra losse kopie. `planning_cli.py`, `track_reconciler.py` en `plan_gate_effectiveness_probe.py` behouden hun private `_PLAN_OI_PREFIX`; consolidatie daarvan is een aparte refactor en valt bewust buiten deze PR (kleine, zelfstandig deploybare PR).

### Verificatie

Nieuwe regressietests (3) in `tests/test_oi_track_bridge.py`:

1. onopgeloste `OI-PLAN`-link overleeft een brugrun: **rood** op pre-fix (`resolved_at` werd gevuld), groen na fix;
2. echte obsolete `OI-xxx`-link wordt wél gesloten: **rood** op pre-fix (de plan-blocker werd al in de eerste brugrun gewist), groen na fix;
3. opgeloste `OI-PLAN`-link blijft opgelost (geen heropening): guard tegen de fix.

Suite:

- `tests/test_oi_track_bridge.py`: 110 passed
- `tests/test_oi_bridge_supervisor_tick.py`: 11 passed
- `tests/test_planning_cli.py`: 22 passed
- `tests/test_plan_gate_enforcement.py` + `tests/test_track_reconciler.py`: 3 pre-existente failures op main (env/config-afhankelijk + hint-format-drift), niet van deze PR
- Lint: 0 nieuwe ruff-findings (de 7 die `ruff` meldt bestaan identiek op main)

🤖 Generated with [Claude Code](https://claude.com/claude-code)