### PR TITLE
fix(triage): r6 — OI-839 raw lane output on parse-error + OI-846 kimi test staleness

### DIFF
--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -393,6 +393,9 @@ class PanelistResult:
     dispatched: bool = False         # did the dispatch + report read succeed
     parse_error: bool = False
     error: str = ""
+    raw_text: str = ""               # OI-839: the lane's raw report, kept ONLY on
+                                     # parse_error so the unparseable output survives
+                                     # for diagnosis instead of vanishing with the tempfile
 
 
 def _decision(decision: str, block: int, revise: int, passes: int, rationale: str) -> Dict[str, Any]:
@@ -740,12 +743,17 @@ def _dispatch_one(
             dispatched=False, error=str(exc), report_path=dispatch_id,
         )
     parsed = parse_verdict(report_text)
+    # OI-839: on parse_error the raw lane output is the ONLY diagnostic that tells
+    # us WHAT failed to parse (trailing comma, prose-bleed, nested fence). Keep it
+    # on the result so _emit_seat_records can persist it into the hash-chained
+    # seat ledger — previously it vanished with the temporary report file.
     return PanelistResult(
         label=member["label"], provider=member["provider"],
         model=member.get("model_arg", ""),
         verdict=parsed["verdict"], blocking_findings=parsed["blocking_findings"],
         rationale=parsed["rationale"], parse_error=parsed["parse_error"],
         dispatched=True, report_path=dispatch_id,
+        raw_text=report_text if parsed["parse_error"] else "",
     )
 
 
@@ -809,7 +817,7 @@ def _emit_seat_records(
                 if (result.dispatched and not result.parse_error)
                 else "abstain"
             )
-            append_chained_entry(seat_ledger_path, {
+            record = {
                 "type": SEAT_RECORD_TYPE,
                 "track_id": track_id,
                 "project_id": project_id,
@@ -819,7 +827,14 @@ def _emit_seat_records(
                 "responded": result.dispatched,
                 "parse_error": result.parse_error,
                 "run_at": now,
-            })
+            }
+            # OI-839: carry the raw lane output on parse-error records so the
+            # unparseable text is preserved in the durable, hash-chained ledger
+            # for diagnosis — a later parser hardening can be built against the
+            # REAL failure mode instead of a guessed one.
+            if result.parse_error and result.raw_text:
+                record["raw_output"] = result.raw_text
+            append_chained_entry(seat_ledger_path, record)
     except Exception:  # vnx-silent-except: seat persistence must never break the gate
         return
 

--- a/tests/test_benchmark_fixes.py
+++ b/tests/test_benchmark_fixes.py
@@ -293,14 +293,22 @@ class TestModelsYamlDeduplicated:
         ids = [m["id"] for m in models]
         assert "kimi-k2-0905" not in ids
 
-    def test_kimi_k2_6_still_present(self):
+    def test_kimi_cli_lane_model_still_present(self):
+        # kimi-k2-6 was retired upstream (kimi-cli 1.46.0 has no K2.6); the
+        # canonical CLI-dispatchable model is now kimi-k2-7-code
+        # (wave7_models.yaml kimi_cli section, 20260721-kimi-lane-hardening).
         models = run_benchmark.load_models()
         ids = [m["id"] for m in models]
-        assert "kimi-k2-6" in ids
+        assert "kimi-k2-7-code" in ids
 
     def test_total_model_count_after_dedup(self):
+        # The dedup invariant is id-uniqueness, not a magic count: models.yaml
+        # grows as lanes are added (19 today), so a hardcoded number breaks on
+        # every addition. A duplicate id is the failure mode the original
+        # kimi-k2-0905 dedup removed.
         models = run_benchmark.load_models()
-        assert len(models) == 7
+        ids = [m["id"] for m in models]
+        assert len(ids) == len(set(ids)), "model ids must be unique (dedup invariant)"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_gate_seat_ledger.py
+++ b/tests/test_plan_gate_seat_ledger.py
@@ -94,7 +94,12 @@ def test_run_panel_persists_abstain_for_unresponsive_seat(tmp_path):
 
 
 def test_run_panel_persists_abstain_for_parse_error_seat(tmp_path):
-    """A report whose verdict fence does not parse is a non-scoring abstain row."""
+    """A report whose verdict fence does not parse is a non-scoring abstain row.
+
+    OI-839: the raw lane output must be preserved on the parse-error record so
+    a later parser hardening can be built against the REAL failure mode — the
+    unparseable text used to vanish with the temporary report file.
+    """
     seat_ledger = tmp_path / "plan-gate-seats.ndjson"
 
     def _garbled(provider, model_arg, instruction, dispatch_id):
@@ -114,6 +119,12 @@ def test_run_panel_persists_abstain_for_parse_error_seat(tmp_path):
     assert rows["glm-5.2-harness"]["verdict"] == "abstain"
     assert rows["glm-5.2-harness"]["responded"] is True
     assert rows["glm-5.2-harness"]["parse_error"] is True
+    # OI-839: raw output preserved for the parse-error lane, absent for readable ones.
+    assert rows["glm-5.2-harness"]["raw_output"] == "# review\n\nno verdict fence here\n"
+    for label in ("codex", "deepseek", "opus", "kimi"):
+        assert "raw_output" not in rows[label], (
+            f"{label} passed cleanly; raw_output must only appear on parse-error records"
+        )
 
 
 def test_run_panel_panelist_rows_carry_model(tmp_path):

--- a/tests/test_receipt_deterministic_fixes.py
+++ b/tests/test_receipt_deterministic_fixes.py
@@ -122,7 +122,8 @@ class TestDispatchCodexModelNonEmpty:
 
         captured_model = []
 
-        def mock_emit(args, provider, model_used, result, start, end, status):
+        def mock_emit(args, provider, model_used, result, start, end, status,
+                      event_store=None):
             captured_model.append(model_used)
 
         mock_result = MagicMock()
@@ -170,7 +171,8 @@ class TestDispatchKimiModelLabelNonEmpty:
 
         captured_model = []
 
-        def mock_emit(args, provider, model_used, result, start, end, status):
+        def mock_emit(args, provider, model_used, result, start, end, status,
+                      event_store=None):
             captured_model.append(model_used)
 
         mock_result = MagicMock()

--- a/tests/test_smart_router_multiprovider.py
+++ b/tests/test_smart_router_multiprovider.py
@@ -51,7 +51,10 @@ def recs_kimi_wins(tmp_path):
     data = {
         "routing_by_task": {
             "01_code_generation": [
-                {"model_id": "kimi-k2-0905", "composite_score": 9.0,
+                # kimi-k3 = the registered kimi_cli default (wave7_models.yaml);
+                # kimi-k2-0905 is a moonshot litellm model and fails the
+                # kimi_cli registry constraint check in provider_dispatch.
+                {"model_id": "kimi-k3", "composite_score": 9.0,
                  "avg_duration_seconds": 200.0, "cost_usd_per_call": 0.001},
                 {"model_id": "claude-sonnet-4-6", "composite_score": 8.0,
                  "avg_duration_seconds": 512.0, "cost_usd_per_call": None},
@@ -130,7 +133,7 @@ class TestG8ConstraintFiltering:
         )
 
         assert decision.primary is not None
-        assert decision.primary.model_id == "kimi-k2-0905"
+        assert decision.primary.model_id == "kimi-k3"
         assert not decision.constraints_applied
 
     def test_all_filtered_primary_is_none(self, recs_deepseek_only, monkeypatch):

--- a/tests/test_wave7_fixes.py
+++ b/tests/test_wave7_fixes.py
@@ -102,13 +102,14 @@ class TestKimiAuditGapStatus:
 
         governance_calls = []
 
-        def capture_governance(args, provider, model, res, start, end, status):
+        def capture_governance(args, provider, model, res, start, end, status,
+                               event_store=None):
             governance_calls.append(status)
 
         with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
              patch("event_store.EventStore", return_value=MagicMock(append=MagicMock())), \
              patch("provider_dispatch._emit_governance", side_effect=capture_governance), \
-             patch.dict(os.environ, {"VNX_KIMI_MODEL": "k2-test"}):
+             patch.dict(os.environ, {"VNX_KIMI_MODEL": "kimi-k3"}):
 
             from provider_dispatch import _dispatch_kimi
 
@@ -117,7 +118,7 @@ class TestKimiAuditGapStatus:
                 terminal_id="T1",
                 instruction="test instruction",
                 provider="kimi",
-                model="k2-test",
+                model="kimi-k3",
                 pr_id=None,
             )
             rc = _dispatch_kimi(args)
@@ -133,13 +134,14 @@ class TestKimiAuditGapStatus:
 
         governance_calls = []
 
-        def capture_governance(args, provider, model, res, start, end, status):
+        def capture_governance(args, provider, model, res, start, end, status,
+                               event_store=None):
             governance_calls.append(status)
 
         with patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=result), \
              patch("event_store.EventStore", return_value=MagicMock(append=MagicMock())), \
              patch("provider_dispatch._emit_governance", side_effect=capture_governance), \
-             patch.dict(os.environ, {"VNX_KIMI_MODEL": "k2-test"}):
+             patch.dict(os.environ, {"VNX_KIMI_MODEL": "kimi-k3"}):
 
             from provider_dispatch import _dispatch_kimi
 
@@ -148,7 +150,7 @@ class TestKimiAuditGapStatus:
                 terminal_id="T1",
                 instruction="test instruction",
                 provider="kimi",
-                model="k2-test",
+                model="kimi-k3",
                 pr_id=None,
             )
             rc = _dispatch_kimi(args)


### PR DESCRIPTION
## Triage-ronde 6 — 12 items gemeten

Alle twaalf items uit de ronde hebben een oordeelregel met bewijs. Volledige unified report: `~/.vnx-data/vnx-dev/unified_reports/20260801-r6-oi-triage.md`.

### Oordeel per item

| Item | Oordeel | Kort bewijs |
|---|---|---|
| OI-834 | BESTAAT-GROOT | provenance_registry nog geen project_id-kolom, PK dispatch_id alleen (schema v6 + live DB's) |
| OI-835 | BESTAAT-GROOT | FEATURE_PLAN-laag volledig intact op main; retire-poging 5a649fb4 nooit gemerged |
| OI-836 | ACHTERHAALD | beide semantiek-branches op main (dispatch_plan.py:256-269); 'override-able' weg |
| OI-837 | ACHTERHAALD | deur honoreert gate via obligations (#1249 + gate_obligation_runner) |
| OI-839 | BESTAAT-KLEIN (gefixt) | raw-output van parse-error-lane nu in hash-chained seat-ledger |
| OI-840 | BESTAAT-GROOT | deliverables nog op ready; geen ready->completed-transitie in code |
| OI-841 | BESTAAT-KLEIN (gefixt) | verwerkt in OI-839; scorende-lanes-indicator bestond al |
| OI-843 | BESTAAT-GROOT | rubric toetst nog 0x op modulariteit; zevende rubric-punt = ontwerpkeuze |
| OI-846 | BESTAAT-KLEIN (gefixt) | 5 kimi-tests waren test-vs-code drift; nu groen, full-run 5->1 |
| OI-848 | BESTAAT-GROOT | alle vier ontwerpvragen open; geen fase-1-implementatie |
| OI-849 | BESTAAT-GROOT | deur gooit plan-dict nog weg; smart_router opt-in; route_decisions afwezig |
| OI-854 | BESTAAT-GROOT | fpy/rework/gate_velocity vast op 16-06 in live data; deels gefixt (v/5/6) |

### Codewijzigingen (OI-839 + OI-846)

- `scripts/lib/plan_gate_panel.py`: parse-error-lane persisteert ruwe output als `raw_output` in het seat-ledger. Test `test_run_panel_persists_abstain_for_parse_error_seat` stond rood op oude code (KeyError).
- `tests/test_benchmark_fixes.py`: kimi-lane-model-assertie naar `kimi-k2-7-code`; count-test naar id-uniqueness.
- `tests/test_receipt_deterministic_fixes.py`: mock-handtekeningen + event_store (kimi én verborgen codex-variant).
- `tests/test_wave7_fixes.py`: k2-test -> kimi-k3; mock + event_store.
- `tests/test_smart_router_multiprovider.py`: fixture recs_kimi_wins kimi-k2-0905 -> kimi-k3.

### Open items in deze ronde

- Order-afhankelijke failing `test_kimi_auto_route_calls_dispatch_kimi` in de full `-k kimi`-suite: pre-existente cross-file test-vervuiling (GLM-route i.p.v. fixture), masked vóór deze fix. Eigen item waard.
- `test_total_model_count_after_dedup`-herdefinitie naar id-uniqueness is een bewuste keuze; T0 beslist.
- OI-854 monitor-freshness (producer_freshness_monitor stale) is een eigen diagnose-item.

Geen open items gesloten door de worker; T0 sluit op basis van het bewijs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)