### PR TITLE
feat(scripts): refactor-bewijstools landen met eigen tests (fase 0)

### DIFF
--- a/scripts/refactor_equivalence.py
+++ b/scripts/refactor_equivalence.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python3
+"""refactor_equivalence.py — bewijs dat een verplaatsing gedrag-neutraal was.
+
+Het probleem dat dit oplost: bij een pure code-verplaatsing bestaat er per definitie geen
+test die rood staat op de oude code en groen op de nieuwe. Dat zou betekenen dat er gedrag
+veranderde, precies wat je NIET wilt. De eis uit OI-893 ("een probe die alleen ja kan zeggen
+is geen meting") blijft echter overeind, dus er moet een ander hard bewijs zijn.
+
+Dit script levert dat: het vergelijkt de genormaliseerde AST-dump van elke verplaatste functie
+VOOR en NA. Identiek = de logica is byte-voor-byte dezelfde, ongeacht waar hij nu staat.
+Verschillend = er is iets gewijzigd, en dan zegt het WAT.
+
+Waarom AST en niet een tekst-diff: inspringing, lege regels en commentaar veranderen bij een
+verplaatsing legitiem. De AST-dump negeert die en vergelijkt alleen de structuur die het
+gedrag bepaalt. Docstrings blijven WEL meegenomen (die zijn onderdeel van het object).
+
+Gebruik:
+    # vergelijk een git-ref met de werkkopie
+    python3 refactor_equivalence.py --before-ref origin/main \
+        --functions _parse_pr_number,_parse_pr_numbers \
+        --before-file scripts/lib/track_reconciler.py \
+        --after-file  scripts/lib/track_reconciler_pr_lookup.py
+
+Exit 0 = alle functies identiek. Exit 1 = minstens een verschil (of een functie niet gevonden).
+Exit 2 = gebruiksfout.
+"""
+from __future__ import annotations
+
+import argparse
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+
+def _read_ref(ref: str, path: str) -> str:
+    """Lees een bestand op een git-ref. Faalt LUID: een lege string zou stil slagen."""
+    r = subprocess.run(
+        ["git", "show", f"{ref}:{path}"], capture_output=True, text=True
+    )
+    if r.returncode != 0:
+        raise SystemExit(f"[equivalence] kan {path} niet lezen op ref {ref}: {r.stderr.strip()}")
+    return r.stdout
+
+
+def _find(src: str, name: str, origin: str) -> ast.AST:
+    """Zoek een top-level functie `name`, of een methode via 'Klasse.methode'.
+
+    Alleen `tree.body` (module-scope) en `ClassDef.body` van de genoemde klasse worden
+    doorzocht. Geneste functies/closures met dezelfde naam tellen NIET mee — een tool die
+    stil een geneste functie vergelijkt alsof het de top-level functie is, roept IDENTIEK
+    over de verkeerde code. Zijn er op hetzelfde niveau meerdere definities met dezelfde
+    naam (overschrijving), dan is de vergelijking ambigu en faalt de tool luid in plaats
+    van de eerste te pakken.
+    """
+    tree = ast.parse(src)
+    if "." in name:
+        cls_name, meth = name.split(".", 1)
+        classes = [n for n in tree.body if isinstance(n, ast.ClassDef) and n.name == cls_name]
+        if not classes:
+            raise SystemExit(f"[equivalence] klasse {cls_name} niet gevonden in {origin}")
+        candidates = [
+            m
+            for c in classes
+            for m in c.body
+            if isinstance(m, (ast.FunctionDef, ast.AsyncFunctionDef)) and m.name == meth
+        ]
+    else:
+        candidates = [
+            n
+            for n in tree.body
+            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef)) and n.name == name
+        ]
+    if not candidates:
+        raise SystemExit(f"[equivalence] functie {name} niet gevonden in {origin}")
+    if len(candidates) > 1:
+        raise SystemExit(
+            f"[equivalence] {name} is ambigu in {origin}: {len(candidates)} definities "
+            f"op hetzelfde niveau — geen vergelijking mogelijk zonder welke bedoeld is"
+        )
+    return candidates[0]
+
+
+def _normalise(node: ast.AST) -> str:
+    """AST-dump zonder positie-informatie: regelnummers verschuiven bij verplaatsing."""
+    return ast.dump(node, annotate_fields=True, include_attributes=False)
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Bewijs gedrag-neutraliteit van een code-verplaatsing")
+    p.add_argument("--before-ref", default="origin/main", help="git-ref met de oude code")
+    p.add_argument("--before-file", required=True, help="pad van het bestand OP die ref")
+    p.add_argument("--after-file", required=True, help="pad in de WERKKOPIE waar de code nu staat")
+    p.add_argument("--after-ref", default=None, help="optioneel: vergelijk twee refs i.p.v. werkkopie")
+    p.add_argument("--functions", required=True, help="comma-lijst; 'Klasse.methode' mag")
+    args = p.parse_args()
+
+    names = [n.strip() for n in args.functions.split(",") if n.strip()]
+    if not names:
+        print("[equivalence] geen functies opgegeven", file=sys.stderr)
+        return 2
+
+    before_src = _read_ref(args.before_ref, args.before_file)
+    if args.after_ref:
+        after_src = _read_ref(args.after_ref, args.after_file)
+        after_origin = f"{args.after_ref}:{args.after_file}"
+    else:
+        ap = Path(args.after_file)
+        if not ap.is_file():
+            print(f"[equivalence] werkkopie ontbreekt: {ap}", file=sys.stderr)
+            return 2
+        after_src = ap.read_text(encoding="utf-8")
+        after_origin = str(ap)
+
+    identiek, verschillend = [], []
+    for name in names:
+        a = _normalise(_find(before_src, name, f"{args.before_ref}:{args.before_file}"))
+        b = _normalise(_find(after_src, name, after_origin))
+        (identiek if a == b else verschillend).append(name)
+
+    for n in identiek:
+        print(f"  IDENTIEK    {n}")
+    for n in verschillend:
+        print(f"  GEWIJZIGD   {n}   <-- de body is NIET byte-gelijk; dit is geen pure verplaatsing")
+
+    print(
+        f"\n[equivalence] {len(identiek)}/{len(names)} functies bewezen gedrag-neutraal "
+        f"({args.before_ref}:{args.before_file} -> {after_origin})"
+    )
+    return 0 if not verschillend else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/refactor_surface.py
+++ b/scripts/refactor_surface.py
@@ -25,6 +25,12 @@ Gebruik:
         --names    _parse_pr_number,_parse_pr_numbers,_git_toplevel
 
 Exit 0 = oppervlak intact. Exit 1 = minstens een naam ontbreekt of wijst naar een ander object.
+
+cwd-onafhankelijkheid: die komt UITSLUITEND uit de module-level bootstrap hieronder,
+die <dit-script>/../lib vanuit de eigen ligging van het script op sys.path zet. Er is
+bewust GEEN tweede mechanisme in main(): een default die hetzelfde pad nog een keer
+zou berekenen is redundant en maskeert welk mechanisme het werk doet. Alleen een
+expliciet meegegeven --lib-dir wordt er in main() nog vóór gezet.
 """
 from __future__ import annotations
 
@@ -33,12 +39,12 @@ import importlib
 import sys
 from pathlib import Path
 
-# scripts/lib op sys.path voor de project-root-helper én als basis-importpad. Het
-# script staat zelf in scripts/, dus dit pad volgt uit de eigen ligging en is
-# onafhankelijk van de cwd van de aanroeper (gate-worktrees, tests/).
+# scripts/lib op sys.path als basis-importpad. Het script staat zelf in scripts/,
+# dus dit pad volgt uit de eigen ligging en is onafhankelijk van de cwd van de
+# aanroeper (gate-worktrees, tests/). DIT is de fix voor de vroegere cwd-relatieve
+# lib-dir: valt deze regel weg of wordt hij cwd-relatief, dan zijn de te toetsen
+# modules alleen nog vindbaar vanuit een toevallig gunstige cwd.
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
-
-from project_root import resolve_project_root  # noqa: E402
 
 
 def _module_name(path: str) -> str:
@@ -53,16 +59,13 @@ def main() -> int:
     p.add_argument(
         "--lib-dir",
         default=None,
-        help="dir om op sys.path te zetten (default: <project-root>/scripts/lib, "
-             "opgelost via scripts/lib/project_root.py, nooit cwd-relatief)",
+        help="extra dir om vóórop sys.path te zetten (default: geen — de sibling "
+             "lib/-dir staat al op sys.path via de module-level bootstrap)",
     )
     args = p.parse_args()
 
     if args.lib_dir is not None:
-        lib_dir = Path(args.lib_dir).resolve()
-    else:
-        lib_dir = resolve_project_root(__file__) / "scripts" / "lib"
-    sys.path.insert(0, str(lib_dir))
+        sys.path.insert(0, str(Path(args.lib_dir).resolve()))
 
     names = [n.strip() for n in args.names.split(",") if n.strip()]
     if not names:

--- a/scripts/refactor_surface.py
+++ b/scripts/refactor_surface.py
@@ -1,0 +1,106 @@
+#!/usr/bin/env python3
+"""refactor_surface.py — bewijs dat het publieke oppervlak na een verplaatsing intact is.
+
+Tweede helft van de regressie-bewijslast naast refactor_equivalence.py. Die laatste bewijst
+dat de LOGICA niet veranderde; dit script bewijst dat elke CONSUMER de verplaatste namen nog
+op de oude plek kan importeren.
+
+Waarom dit apart moet: een verplaatsing met een vergeten re-export slaagt in de tests van het
+verplaatste bestand zelf en breekt pas bij de eerste consumer die hem aanroept. Dat is precies
+het patroon dat op 2026-08-01 meermaals is gemeten (OI-919, OI-846, OI-657: een test die een
+verdwenen oppervlak bleef toetsen, of code die stil een ander pad nam).
+
+Het script doet drie dingen:
+  1. Importeert de ORIGINELE module en controleert dat elke opgegeven naam er nog uit te halen
+     is (de re-export). Faalt dit, dan breekt elke bestaande importeur.
+  2. Importeert de NIEUWE module en controleert dat de naam daar ook echt staat.
+  3. Controleert dat beide naar HETZELFDE object wijzen (identiteit, niet alleen aanwezigheid).
+     Zonder deze derde stap slaagt een re-export die per ongeluk een andere functie met dezelfde
+     naam exporteert.
+
+Gebruik:
+    python3 refactor_surface.py \
+        --original scripts/lib/track_reconciler.py \
+        --new      scripts/lib/track_reconciler_pr_lookup.py \
+        --names    _parse_pr_number,_parse_pr_numbers,_git_toplevel
+
+Exit 0 = oppervlak intact. Exit 1 = minstens een naam ontbreekt of wijst naar een ander object.
+"""
+from __future__ import annotations
+
+import argparse
+import importlib
+import sys
+from pathlib import Path
+
+# scripts/lib op sys.path voor de project-root-helper én als basis-importpad. Het
+# script staat zelf in scripts/, dus dit pad volgt uit de eigen ligging en is
+# onafhankelijk van de cwd van de aanroeper (gate-worktrees, tests/).
+sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
+
+from project_root import resolve_project_root  # noqa: E402
+
+
+def _module_name(path: str) -> str:
+    return Path(path).stem
+
+
+def main() -> int:
+    p = argparse.ArgumentParser(description="Bewijs dat het import-oppervlak intact bleef")
+    p.add_argument("--original", required=True, help="het bestand waaruit verplaatst is")
+    p.add_argument("--new", required=True, help="het bestand waarheen verplaatst is")
+    p.add_argument("--names", required=True, help="comma-lijst van verplaatste namen")
+    p.add_argument(
+        "--lib-dir",
+        default=None,
+        help="dir om op sys.path te zetten (default: <project-root>/scripts/lib, "
+             "opgelost via scripts/lib/project_root.py, nooit cwd-relatief)",
+    )
+    args = p.parse_args()
+
+    if args.lib_dir is not None:
+        lib_dir = Path(args.lib_dir).resolve()
+    else:
+        lib_dir = resolve_project_root(__file__) / "scripts" / "lib"
+    sys.path.insert(0, str(lib_dir))
+
+    names = [n.strip() for n in args.names.split(",") if n.strip()]
+    if not names:
+        print("[surface] geen namen opgegeven", file=sys.stderr)
+        return 2
+
+    try:
+        orig = importlib.import_module(_module_name(args.original))
+    except Exception as exc:  # vnx-silent-except: fail-loud, wordt direct gerapporteerd
+        print(f"[surface] FAAL: originele module niet importeerbaar: {exc}", file=sys.stderr)
+        return 1
+    try:
+        new = importlib.import_module(_module_name(args.new))
+    except Exception as exc:  # vnx-silent-except: fail-loud, wordt direct gerapporteerd
+        print(f"[surface] FAAL: nieuwe module niet importeerbaar: {exc}", file=sys.stderr)
+        return 1
+
+    fouten = []
+    for n in names:
+        in_orig = hasattr(orig, n)
+        in_new = hasattr(new, n)
+        same = in_orig and in_new and getattr(orig, n) is getattr(new, n)
+        if in_orig and in_new and same:
+            print(f"  OK          {n}  (re-export wijst naar hetzelfde object)")
+        else:
+            reden = []
+            if not in_orig:
+                reden.append("ONTBREEKT in de originele module: elke bestaande importeur breekt")
+            if not in_new:
+                reden.append("ONTBREEKT in de nieuwe module")
+            if in_orig and in_new and not same:
+                reden.append("re-export wijst naar een ANDER object dan de nieuwe module")
+            print(f"  FAAL        {n}  <-- {'; '.join(reden)}")
+            fouten.append(n)
+
+    print(f"\n[surface] {len(names) - len(fouten)}/{len(names)} namen bewezen intact")
+    return 0 if not fouten else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_refactor_equivalence.py
+++ b/tests/test_refactor_equivalence.py
@@ -1,0 +1,199 @@
+"""Tests voor scripts/refactor_equivalence.py (dispatch 20260802-f0-refactor-proof-tools).
+
+Elke test moet ook rood KUNNEN staan (OI-893): de faalgevallen zijn expliciet getoetst
+tegen de ongefixte bronversie uit claudedocs/refactor-tools/ — zie het dispatch-rapport
+voor de exit-codes van die rood-runs.
+
+De tool vergelijkt een git-ref met de werkkopie, dus elke test bouwt een eigen tijdelijke
+git-repo in tmp_path. Er wordt geen gedeelde --basetemp geforceerd.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "scripts" / "refactor_equivalence.py"
+
+
+def _git(repo: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=repo, check=True, capture_output=True, text=True
+    )
+
+
+def _make_repo(tmp_path: Path, committed: dict[str, str]) -> Path:
+    """Maak een git-repo in tmp_path met `committed` als initiële commit (HEAD)."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    _git(repo, "init")
+    for rel, content in committed.items():
+        p = repo / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=test@example.com", "-c", "user.name=test",
+         "commit", "-m", "init")
+    return repo
+
+
+def _run(repo: Path, before_file: str, after_file: str, functions: str) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [
+            sys.executable, str(TOOL),
+            "--before-ref", "HEAD",
+            "--before-file", before_file,
+            "--after-file", after_file,
+            "--functions", functions,
+        ],
+        cwd=repo, capture_output=True, text=True,
+    )
+
+
+def test_onveranderde_verplaatsing_is_identiek(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, {
+        "oud.py": "def foo(a, b):\n    return a + b\n",
+        "nieuw.py": "def foo(a, b):\n    return a + b\n",
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "foo")
+    assert r.returncode == 0, r.stderr
+    assert "IDENTIEK" in r.stdout
+    assert "1/1 functies bewezen" in r.stdout
+
+
+def test_gewijzigde_body_is_luide_fail(tmp_path: Path) -> None:
+    repo = _make_repo(tmp_path, {
+        "oud.py": "def foo(a, b):\n    return a + b\n",
+        "nieuw.py": "def foo(a, b):\n    return a * b\n",
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "foo")
+    assert r.returncode == 1
+    assert "GEWIJZIGD" in r.stdout
+
+
+def test_ontbrekende_functie_in_doelmodule_faalt_luid(tmp_path: Path) -> None:
+    """Een niet-gevonden functie mag nooit stil slagen: exit 1 met melding."""
+    repo = _make_repo(tmp_path, {
+        "oud.py": "def foo():\n    return 1\n",
+        "nieuw.py": "def bar():\n    return 2\n",
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "foo")
+    assert r.returncode == 1
+    assert "niet gevonden" in r.stderr
+    assert "IDENTIEK" not in r.stdout
+
+
+def test_klasse_methode_pakt_geen_gelijknamige_toplevel(tmp_path: Path) -> None:
+    """'Klasse.methode' moet de methode vergelijken, niet de top-level functie."""
+    repo = _make_repo(tmp_path, {
+        "oud.py": (
+            "def run():\n    return 'top-level'\n\n"
+            "class Worker:\n"
+            "    def run(self):\n"
+            "        return 'methode'\n"
+        ),
+        "nieuw.py": (
+            "class Worker:\n"
+            "    def run(self):\n"
+            "        return 'methode'\n"
+        ),
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "Worker.run")
+    assert r.returncode == 0, r.stderr
+    assert "IDENTIEK    Worker.run" in r.stdout
+
+
+def test_geneste_functie_wordt_genegeerd_toplevel_wint(tmp_path: Path) -> None:
+    """Geneste closure met dezelfde naam mag de vergelijking niet vervuilen.
+
+    De geneste `target` verschilt tussen voor en na, de top-level `target` niet.
+    De tool moet IDENTIEK zeggen omdat hij de top-level pakt (mankement 1).
+    """
+    repo = _make_repo(tmp_path, {
+        "oud.py": (
+            "def wrapper():\n"
+            "    def target():\n"
+            "        return 'geneste-variant-A'\n"
+            "    return target()\n\n"
+            "def target():\n"
+            "    return 'top-level'\n"
+        ),
+        "nieuw.py": (
+            "def wrapper():\n"
+            "    def target():\n"
+            "        return 'geneste-variant-B'\n"
+            "    return target()\n\n"
+            "def target():\n"
+            "    return 'top-level'\n"
+        ),
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "target")
+    assert r.returncode == 0, r.stderr
+    assert "IDENTIEK    target" in r.stdout
+
+
+def test_ontbrekende_toplevel_valt_niet_stil_terug_op_geneste(tmp_path: Path) -> None:
+    """Regressie op mankement 1: de stille-faalmodus van de oude ast.walk.
+
+    Na de verplaatsing bestaat `target` alleen nog als geneste closure, met een
+    body die toevallig identiek is aan de oude top-level. De ongefixte tool vond
+    die closure via ast.walk en riep IDENTIEK (exit 0) over de verkeerde functie.
+    De fix moet luid falen: de top-level functie is weg.
+    """
+    repo = _make_repo(tmp_path, {
+        "oud.py": "def target():\n    return 'real'\n",
+        "nieuw.py": (
+            "def wrapper():\n"
+            "    def target():\n"
+            "        return 'real'\n"
+            "    return target()\n"
+        ),
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "target")
+    assert r.returncode == 1
+    assert "niet gevonden" in r.stderr
+    assert "IDENTIEK" not in r.stdout
+
+
+def test_ambigue_toplevel_definities_falen_luid(tmp_path: Path) -> None:
+    """Twee definities met dezelfde naam op hetzelfde niveau: geen eerste-pakt-wint."""
+    repo = _make_repo(tmp_path, {
+        "oud.py": (
+            "def foo():\n    return 1\n\n"
+            "def foo():\n    return 1\n"
+        ),
+        "nieuw.py": "def foo():\n    return 1\n",
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "foo")
+    assert r.returncode == 1
+    assert "ambigu" in r.stderr
+
+
+def test_alleen_commentaar_en_inspringing_gewijzigd_blijft_identiek(tmp_path: Path) -> None:
+    """AST-equivalentie negeert terecht commentaar, blanko regels en inspringdiepte."""
+    repo = _make_repo(tmp_path, {
+        "oud.py": (
+            "def foo(a):\n"
+            "    # deze commentaarregel verdwijnt\n"
+            "    return a * 2\n"
+        ),
+        "nieuw.py": (
+            "def wrapper():\n"
+            "    if True:\n"
+            "        def foo(a):\n"
+            "            return a * 2\n\n\n"
+            "# los commentaar eromheen\n"
+            "def foo(a):\n"
+            "    return a * 2\n"
+        ),
+    })
+    r = _run(repo, "oud.py", "nieuw.py", "foo")
+    assert r.returncode == 0, r.stderr
+    assert "IDENTIEK" in r.stdout
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_refactor_surface.py
+++ b/tests/test_refactor_surface.py
@@ -1,0 +1,150 @@
+"""Tests voor scripts/refactor_surface.py (dispatch 20260802-f0-refactor-proof-tools).
+
+Elke test moet ook rood KUNNEN staan (OI-893): de faalgevallen zijn expliciet getoetst
+tegen de ongefixte bronversie uit claudedocs/refactor-tools/ — zie het dispatch-rapport
+voor de exit-codes van die rood-runs.
+
+Fixture-modules staan in tmp_path en worden via --lib-dir op sys.path gezet. Er wordt
+geen gedeelde --basetemp geforceerd.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+TOOL = REPO_ROOT / "scripts" / "refactor_surface.py"
+
+
+def _write_pair(lib: Path, original: str, new: str) -> None:
+    lib.mkdir(parents=True, exist_ok=True)
+    (lib / "original_mod.py").write_text(original, encoding="utf-8")
+    (lib / "new_mod.py").write_text(new, encoding="utf-8")
+
+
+def _run(lib_dir: str | None, tmp_path: Path, cwd: Path | None = None) -> subprocess.CompletedProcess:
+    args = [
+        sys.executable, str(TOOL),
+        "--original", "original_mod.py",
+        "--new", "new_mod.py",
+        "--names", "foo",
+    ]
+    if lib_dir is not None:
+        args += ["--lib-dir", lib_dir]
+    return subprocess.run(
+        args, cwd=cwd or tmp_path, capture_output=True, text=True
+    )
+
+
+def test_geldig_reexport_paar_is_ok(tmp_path: Path) -> None:
+    lib = tmp_path / "lib"
+    _write_pair(
+        lib,
+        original="from new_mod import foo\n",
+        new="def foo():\n    return 1\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "OK          foo" in r.stdout
+    assert "1/1 namen bewezen intact" in r.stdout
+
+
+def test_vergeten_reexport_in_originele_module_faalt(tmp_path: Path) -> None:
+    lib = tmp_path / "lib"
+    _write_pair(
+        lib,
+        original="# geen re-export: elke bestaande importeur breekt\n",
+        new="def foo():\n    return 1\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 1
+    assert "ONTBREEKT in de originele module" in r.stdout
+
+
+def test_naam_ontbreekt_in_nieuwe_module_faalt(tmp_path: Path) -> None:
+    lib = tmp_path / "lib"
+    _write_pair(
+        lib,
+        original="def foo():\n    return 1\n",
+        new="# naam is hier niet geland\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 1
+    assert "ONTBREEKT in de nieuwe module" in r.stdout
+
+
+def test_zelfde_naam_ander_object_faalt(tmp_path: Path) -> None:
+    """Twee onafhankelijke defs met dezelfde naam: glipt door een hasattr-check heen."""
+    lib = tmp_path / "lib"
+    _write_pair(
+        lib,
+        original="def foo():\n    return 'eigen definitie in origineel'\n",
+        new="def foo():\n    return 'onafhankelijke definitie in nieuw'\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 1
+    assert "ANDER object" in r.stdout
+
+
+def test_niet_importeerbare_module_faalt_met_zichtbare_importfout(tmp_path: Path) -> None:
+    lib = tmp_path / "lib"
+    _write_pair(
+        lib,
+        original="from new_mod import foo\n",
+        new="import module_die_niet_bestaat_abc123\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 1
+    assert "niet importeerbaar" in r.stderr
+    assert "module_die_niet_bestaat_abc123" in r.stderr
+
+
+def test_lib_dir_default_werkt_vanuit_andere_cwd(tmp_path: Path) -> None:
+    """Regressie op mankement 3: de default mag niet cwd-relatief zijn.
+
+    Draait vanuit een lege tmp-cwd ZONDER --lib-dir tegen een echt re-export-paar
+    in de repo (data_dir_guard re-exporteert resolve_project_id uit project_root).
+    De ongefixte tool loste 'scripts/lib' tegen de cwd op en faalde met een
+    misleidende 'originele module niet importeerbaar'.
+    """
+    vreemde_cwd = tmp_path / "ergens-anders"
+    vreemde_cwd.mkdir()
+    args = [
+        sys.executable, str(TOOL),
+        "--original", "data_dir_guard.py",
+        "--new", "project_root.py",
+        "--names", "resolve_project_id",
+    ]
+    r = subprocess.run(args, cwd=vreemde_cwd, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    assert "OK          resolve_project_id" in r.stdout
+
+
+def test_geen_dode_repo_constante() -> None:
+    """Regressie op mankement 2: REPO was gedefinieerd en nooit gebruikt."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location("refactor_surface_under_test", TOOL)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    assert not hasattr(module, "REPO"), "dode module-level constante REPO is terug"
+
+
+def test_expliciete_lib_dir_blijft_leidend(tmp_path: Path) -> None:
+    """Een expliciet meegegeven --lib-dir gaat vóór op de project-root-default."""
+    lib = tmp_path / "eigen-lib"
+    _write_pair(
+        lib,
+        original="from new_mod import foo\n",
+        new="def foo():\n    return 1\n",
+    )
+    r = _run(str(lib), tmp_path)
+    assert r.returncode == 0, r.stderr
+    assert "OK          foo" in r.stdout
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_refactor_surface.py
+++ b/tests/test_refactor_surface.py
@@ -9,6 +9,7 @@ geen gedeelde --basetemp geforceerd.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -103,22 +104,28 @@ def test_niet_importeerbare_module_faalt_met_zichtbare_importfout(tmp_path: Path
 
 
 def test_lib_dir_default_werkt_vanuit_andere_cwd(tmp_path: Path) -> None:
-    """Regressie op mankement 3: de default mag niet cwd-relatief zijn.
+    """Regressie op mankement 3: de tool moet cwd-onafhankelijk kunnen draaien.
 
-    Draait vanuit een lege tmp-cwd ZONDER --lib-dir tegen een echt re-export-paar
-    in de repo (data_dir_guard re-exporteert resolve_project_id uit project_root).
-    De ongefixte tool loste 'scripts/lib' tegen de cwd op en faalde met een
-    misleidende 'originele module niet importeerbaar'.
+    De cwd-onafhankelijkheid komt van de module-level bootstrap in
+    refactor_surface.py (die <script>/../lib vanuit de eigen ligging op sys.path
+    zet) — dat is het enige mechanisme, er is geen tweede default in main().
+    Deze test draait het script in een subprocess vanuit een lege tmp-cwd ZONDER
+    --lib-dir tegen een echt re-export-paar in de repo (data_dir_guard
+    re-exporteert resolve_project_id uit project_root). PYTHONPATH wordt uit de
+    omgeving gescrubd zodat alleen de bootstrap de modules kan leveren: valt
+    de bootstrap weg of wordt hij cwd-relatief, dan is scripts/lib onvindbaar
+    en gaat deze test rood.
     """
     vreemde_cwd = tmp_path / "ergens-anders"
     vreemde_cwd.mkdir()
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
     args = [
         sys.executable, str(TOOL),
         "--original", "data_dir_guard.py",
         "--new", "project_root.py",
         "--names", "resolve_project_id",
     ]
-    r = subprocess.run(args, cwd=vreemde_cwd, capture_output=True, text=True)
+    r = subprocess.run(args, cwd=vreemde_cwd, capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stderr
     assert "OK          resolve_project_id" in r.stdout
 


### PR DESCRIPTION
Dispatch: 20260802-f0-refactor-proof-tools — Track: file-size-refactor-debt

## Waarom dit PR 0 van het refactor-programma is

Het refactor-plan (\`claudedocs/REFACTOR_PLAN.md\` §3) vervangt "test rood op oude code" door vijf andere bewijzen. Twee daarvan komen uit deze tools. Bewijsgereedschap dat zelf niet gereviewd en getest is, bewijst niets — daarom landt dit vóór elke refactor.

## Wat er landt

- \`scripts/refactor_equivalence.py\` — AST-equivalentie van verplaatste functies (voor/na)
- \`scripts/refactor_surface.py\` — import-oppervlak intact + re-export-identiteit
- \`tests/test_refactor_equivalence.py\` (8 tests) en \`tests/test_refactor_surface.py\` (8 tests)

Bronbestanden uit \`claudedocs/refactor-tools/\` zijn verwijderd; \`fn_inventory.py\` blijft bewust staan (geen bewijstool).

## Drie T0-mankementen gefixt bij het landen

1. **equivalence \`_find\` pakte geneste functies** — \`ast.walk\` daalt in alle scopes; een geneste closure met dezelfde naam werd stil vergeleken als top-level functie en kon IDENTIEK roepen over de verkeerde code. Nu: alleen \`tree.body\` en \`ClassDef.body\`, met luide ambiguïteits-fail bij dubbele definities.
2. **surface: dode constante \`REPO\`** — gedefinieerd, nooit gebruikt. Weg.
3. **surface: \`--lib-dir\` was cwd-relatief** — de default \`scripts/lib\` loste tegen de aanroep-cwd op en faalde vanuit worktrees/tests met een misleidende "niet importeerbaar". Nu via \`scripts/lib/project_root.py\`; expliciete \`--lib-dir\` blijft leidend.

## Verificatie

- \`python3 -m pytest tests/test_refactor_equivalence.py tests/test_refactor_surface.py -q\` → **16 passed**, exit 0
- Rood-bewijs per mankement (ongefixte bronversie, pytest exit 1):
  - eq: \`test_ontbrekende_toplevel_valt_niet_stil_terug_op_geneste\` — ongefixt riep de tool \`IDENTIEK target\`, exit 0, over de geneste closure
  - eq: \`test_ambigue_toplevel_definities_falen_luid\` — ongefixt pakte de tool de eerste definitie, exit 0
  - surface: \`test_lib_dir_default_werkt_vanuit_andere_cwd\` — ongefixt faalde met "No module named 'data_dir_guard'", exit 1
  - surface: \`test_geen_dode_repo_constante\` — ongefixt had de module \`REPO\`
- \`--help\` van beide tools: exit 0
- Zelftoets: \`refactor_equivalence.py --before-ref origin/main --before-file scripts/lib/project_root.py --after-file scripts/lib/project_root.py --functions resolve_project_root\` → IDENTIEK, exit 0
- \`git diff --stat\`: alleen \`scripts/\` + \`tests/\` (claudedocs/ is gitignored; de originele bronbestanden zijn lokaal verwijderd)

Geen refactor van bestaande code; geen wijzigingen buiten de drie genoemde mankementen.