### PR TITLE
fix(scripts): f0-ronde2 — één lib-dir-mechanisme + test die echt rood kan (dispatch 20260802-f0r2)

### DIFF
--- a/scripts/refactor_surface.py
+++ b/scripts/refactor_surface.py
@@ -25,6 +25,12 @@ Gebruik:
         --names    _parse_pr_number,_parse_pr_numbers,_git_toplevel
 
 Exit 0 = oppervlak intact. Exit 1 = minstens een naam ontbreekt of wijst naar een ander object.
+
+cwd-onafhankelijkheid: die komt UITSLUITEND uit de module-level bootstrap hieronder,
+die <dit-script>/../lib vanuit de eigen ligging van het script op sys.path zet. Er is
+bewust GEEN tweede mechanisme in main(): een default die hetzelfde pad nog een keer
+zou berekenen is redundant en maskeert welk mechanisme het werk doet. Alleen een
+expliciet meegegeven --lib-dir wordt er in main() nog vóór gezet.
 """
 from __future__ import annotations
 
@@ -33,12 +39,12 @@ import importlib
 import sys
 from pathlib import Path
 
-# scripts/lib op sys.path voor de project-root-helper én als basis-importpad. Het
-# script staat zelf in scripts/, dus dit pad volgt uit de eigen ligging en is
-# onafhankelijk van de cwd van de aanroeper (gate-worktrees, tests/).
+# scripts/lib op sys.path als basis-importpad. Het script staat zelf in scripts/,
+# dus dit pad volgt uit de eigen ligging en is onafhankelijk van de cwd van de
+# aanroeper (gate-worktrees, tests/). DIT is de fix voor de vroegere cwd-relatieve
+# lib-dir: valt deze regel weg of wordt hij cwd-relatief, dan zijn de te toetsen
+# modules alleen nog vindbaar vanuit een toevallig gunstige cwd.
 sys.path.insert(0, str(Path(__file__).resolve().parent / "lib"))
-
-from project_root import resolve_project_root  # noqa: E402
 
 
 def _module_name(path: str) -> str:
@@ -53,16 +59,13 @@ def main() -> int:
     p.add_argument(
         "--lib-dir",
         default=None,
-        help="dir om op sys.path te zetten (default: <project-root>/scripts/lib, "
-             "opgelost via scripts/lib/project_root.py, nooit cwd-relatief)",
+        help="extra dir om vóórop sys.path te zetten (default: geen — de sibling "
+             "lib/-dir staat al op sys.path via de module-level bootstrap)",
     )
     args = p.parse_args()
 
     if args.lib_dir is not None:
-        lib_dir = Path(args.lib_dir).resolve()
-    else:
-        lib_dir = resolve_project_root(__file__) / "scripts" / "lib"
-    sys.path.insert(0, str(lib_dir))
+        sys.path.insert(0, str(Path(args.lib_dir).resolve()))
 
     names = [n.strip() for n in args.names.split(",") if n.strip()]
     if not names:

--- a/tests/test_refactor_surface.py
+++ b/tests/test_refactor_surface.py
@@ -9,6 +9,7 @@ geen gedeelde --basetemp geforceerd.
 """
 from __future__ import annotations
 
+import os
 import subprocess
 import sys
 from pathlib import Path
@@ -103,22 +104,28 @@ def test_niet_importeerbare_module_faalt_met_zichtbare_importfout(tmp_path: Path
 
 
 def test_lib_dir_default_werkt_vanuit_andere_cwd(tmp_path: Path) -> None:
-    """Regressie op mankement 3: de default mag niet cwd-relatief zijn.
+    """Regressie op mankement 3: de tool moet cwd-onafhankelijk kunnen draaien.
 
-    Draait vanuit een lege tmp-cwd ZONDER --lib-dir tegen een echt re-export-paar
-    in de repo (data_dir_guard re-exporteert resolve_project_id uit project_root).
-    De ongefixte tool loste 'scripts/lib' tegen de cwd op en faalde met een
-    misleidende 'originele module niet importeerbaar'.
+    De cwd-onafhankelijkheid komt van de module-level bootstrap in
+    refactor_surface.py (die <script>/../lib vanuit de eigen ligging op sys.path
+    zet) — dat is het enige mechanisme, er is geen tweede default in main().
+    Deze test draait het script in een subprocess vanuit een lege tmp-cwd ZONDER
+    --lib-dir tegen een echt re-export-paar in de repo (data_dir_guard
+    re-exporteert resolve_project_id uit project_root). PYTHONPATH wordt uit de
+    omgeving gescrubd zodat alleen de bootstrap de modules kan leveren: valt
+    de bootstrap weg of wordt hij cwd-relatief, dan is scripts/lib onvindbaar
+    en gaat deze test rood.
     """
     vreemde_cwd = tmp_path / "ergens-anders"
     vreemde_cwd.mkdir()
+    env = {k: v for k, v in os.environ.items() if k != "PYTHONPATH"}
     args = [
         sys.executable, str(TOOL),
         "--original", "data_dir_guard.py",
         "--new", "project_root.py",
         "--names", "resolve_project_id",
     ]
-    r = subprocess.run(args, cwd=vreemde_cwd, capture_output=True, text=True)
+    r = subprocess.run(args, cwd=vreemde_cwd, capture_output=True, text=True, env=env)
     assert r.returncode == 0, r.stderr
     assert "OK          resolve_project_id" in r.stdout
 


### PR DESCRIPTION
## Samenvatting

Ronde-2 dispatch op PR #1325 (`dff68577`). Ronde-1-mankement 3 was niet getoetst: de module-level bootstrap (`sys.path.insert(0, <script>/../lib)`) was het echte cwd-onafhankelijkheidsmechanisme en de `resolve_project_root`-default in `main()` was een redundante tak die exact hetzelfde pad nog eens berekende. Daardoor kon `test_lib_dir_default_werkt_vanuit_andere_cwd` niet rood (T0 nagemeten: default-tak teruggedraaid → 8 passed, 0 rood).

## Wijzigingen (Optie A)

- `scripts/refactor_surface.py`: redundante default-tak uit `main()` weg; alleen een expliciete `--lib-dir` wordt nog op `sys.path` gezet. Import `resolve_project_root` verwijderd. Docstring/commentaar documenteren dat de bootstrap hét mechanisme is — bewust geen tweede.
- `tests/test_refactor_surface.py`: alleen `test_lib_dir_default_werkt_vanuit_andere_cwd` aangepast — PYTHONPATH gescrubd uit de subprocess-omgeving zodat alleen de bootstrap `scripts/lib` kan leveren. Overige 15 tests onaangeroerd.

## Verificatie

- `python3 -m pytest tests/test_refactor_equivalence.py tests/test_refactor_surface.py -q` → **16 passed**, exit 0.
- **Rood-bewijs**: bootstrap-regel éénmalig verwijderd → `pytest tests/test_refactor_surface.py::test_lib_dir_default_werkt_vanuit_andere_cwd` → **exit 1**, `AssertionError: [surface] FAAL: originele module niet importeerbaar: No module named 'data_dir_guard'`; fix teruggezet → weer 16 passed.
- De niet-reproduceerbare ronde-1-rapportclaim (Verification 2, mankement 3) is gerectificeerd in `$VNX_DATA_DIR/unified_reports/20260802-f0-refactor-proof-tools.md`; volledige meting in `20260802-f0r2-proof-tools-round2.md`.

Dispatch-ID: 20260802-f0r2-proof-tools-round2