### PR TITLE
fix(tests): align _archive_dispatch_events mock with tuple signature (OI-933)

### DIFF
--- a/tests/test_role_applied_provider_lane.py
+++ b/tests/test_role_applied_provider_lane.py
@@ -208,7 +208,7 @@ def _run_envelope_govern(tmp_path, *, instruction, role):
     result = _AdapterResult(returncode=0, completion_text="all good", status="success")
     start = end = datetime.now(timezone.utc)
     with (
-        patch("dispatch_envelope._archive_dispatch_events", return_value=None),
+        patch("dispatch_envelope._archive_dispatch_events", return_value=(None, True)),
         patch("dispatch_envelope._clear_dispatch_events"),
         patch("provider_costs.emit_provider_cost"),
         patch("phantom_guard.record_phantom_if_any"),


### PR DESCRIPTION
## Summary

Two tests on `origin/main` were red:

```
FAILED tests/test_role_applied_provider_lane.py::test_envelope_receipt_stamps_role_applied_true
FAILED tests/test_role_applied_provider_lane.py::test_envelope_receipt_stamps_role_applied_false
TypeError: cannot unpack non-iterable NoneType object   (scripts/lib/dispatch_envelope.py:833)
```

Root cause: `tests/test_role_applied_provider_lane.py:211` patched `dispatch_envelope._archive_dispatch_events` with `return_value=None`, but since #1291 (OI-878/OI-902) the function returns a tuple `(events_path, clear_ok)` which the caller at `dispatch_envelope.py:833` unpacks. Stale test mock, not broken production code.

## Fix

One line: the mock now returns `(None, True)` — the function's real "no events archived, clear ok" path (`dispatch_envelope.py:732/745`), which matches the tmp-dir scenario of these tests (no live event stream). The two tests assert only on `role_applied` / `role_tier` / `role_not_applied_reason`, which are derived from role resolution against the instruction — independent of the archive mock — so they still test exactly what they claim.

## Verification

Before: `python3 -m pytest tests/test_role_applied_provider_lane.py -q` → **2 failed, 7 passed**, exit code **1**
After: `python3 -m pytest tests/test_role_applied_provider_lane.py -q` → **9 passed**, exit code **0**

`git diff --stat`: uitsluitend `tests/test_role_applied_provider_lane.py` (1 insertion, 1 deletion). Geen productiecode aangeraakt.

Dispatch-ID: 20260802-w16-oi933-mockfix