### PR TITLE
refactor(scripts): _compute_derived_status verhuist naar track_reconciler_status.py (fase 1 PR 1)

### DIFF
--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -225,152 +225,6 @@ def _has_col(conn: sqlite3.Connection, table: str, col: str) -> bool:
     return any(r[1] == col for r in conn.execute(f"PRAGMA table_info({table})"))
 
 
-def _compute_derived_status(
-    conn: sqlite3.Connection,
-    track_id: str,
-    project_id: str,
-    merged_pr_numbers: FrozenSet[int] = frozenset(),
-) -> str:
-    """Compute derived_status for one track. Pure read — writes nothing.
-
-    Returns one of: 'done', 'blocked', 'in_progress', 'queued'.
-
-    merged_pr_numbers: confirmed-merged PR numbers from local sources. Used in
-    the additive pr_ref evidence path — derives 'done' for tracks where the
-    dispatch join yields no rows (historical dispatches used 'A'/'B'/'C' track
-    labels instead of feature track_ids). The existing dispatch-based derivation
-    is unchanged; this path only fires when dispatches is empty.
-    """
-    # 1. Blocker open-item check: any link_type='blocks' row with resolved_at IS NULL → blocked.
-    #    Migration 0030 adds resolved_at; when present, only unresolved rows are counted.
-    #    Pre-0030 databases have no resolved_at column — fall back to presence-only check.
-    has_project_id_col = _has_col(conn, "track_open_items", "project_id")
-    has_resolved_at_col = _has_col(conn, "track_open_items", "resolved_at")
-    if has_project_id_col and has_resolved_at_col:
-        blocker = conn.execute(
-            """
-            SELECT 1 FROM track_open_items
-            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
-              AND resolved_at IS NULL
-            LIMIT 1
-            """,
-            (track_id, project_id),
-        ).fetchone()
-    elif has_project_id_col:
-        blocker = conn.execute(
-            """
-            SELECT 1 FROM track_open_items
-            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
-            LIMIT 1
-            """,
-            (track_id, project_id),
-        ).fetchone()
-    else:
-        blocker = conn.execute(
-            "SELECT 1 FROM track_open_items WHERE track_id = ? AND link_type = 'blocks' LIMIT 1",
-            (track_id,),
-        ).fetchone()
-    if blocker:
-        return "blocked"
-
-    # 2. Dependency check: any dependency whose declared phase is not 'done' blocks this track.
-    #    Uses declared phase (authoritative) to avoid circular dependency on derived_status.
-    dep_phases = conn.execute(
-        """
-        SELECT t.phase
-        FROM track_dependencies td
-        JOIN tracks t
-          ON t.track_id = td.to_track_id AND t.project_id = td.to_project_id
-        WHERE td.from_track_id = ? AND td.from_project_id = ?
-        """,
-        (track_id, project_id),
-    ).fetchall()
-    for row in dep_phases:
-        if row[0] != "done":
-            return "blocked"
-
-    # 3. Fetch track's pr_ref and declared phase once (reused below).
-    track_row = conn.execute(
-        "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
-        (track_id, project_id),
-    ).fetchone()
-    track_pr_ref = track_row["pr_ref"] if track_row else None
-    track_phase = track_row["phase"] if track_row else None
-
-    # 4. Dispatch state aggregation.
-    dispatches = conn.execute(
-        "SELECT dispatch_id, state FROM dispatches WHERE track = ? AND project_id = ?",
-        (track_id, project_id),
-    ).fetchall()
-
-    if not dispatches:
-        # pr_ref evidence path: covers tracks with no matching dispatches.
-        # Historical dispatches stored 'A'/'B'/'C' in the track column instead of
-        # feature track_ids, so the join above is empty for all pre-1.0 tracks.
-        # If the track's own pr_ref (single or a '#911,#912' multi-PR list) is
-        # confirmed merged via all evidence sources, derive 'done' without a
-        # dispatch match. ALL parsed PRs must be merged; partial merge = not done.
-        nums = _parse_pr_numbers(track_pr_ref)
-        if nums and nums <= merged_pr_numbers:
-            return "done"
-        # Absence of evidence is not evidence of queued. Historical dispatches may
-        # be archived, so defer to declared phase (2026-06-15 migration panel).
-        if track_phase == "done":
-            return "done"
-        if track_phase == "active":
-            return "in_progress"
-        return "queued"
-
-    states = [d[0] for d in dispatches]  # d is (dispatch_id, state); note row_factory gives dict
-    # With row_factory = sqlite3.Row, index by name or position:
-    dispatch_ids = [row["dispatch_id"] for row in dispatches]
-    state_values = [row["state"] for row in dispatches]
-
-    all_terminal = all(s in TERMINAL_DISPATCH_STATES for s in state_values)
-
-    if all_terminal:
-        if not track_pr_ref:
-            # No PR to verify — all work terminal → done.
-            return "done"
-
-        # Check for a pr_merged coordination event on any dispatch in this track.
-        placeholders = ",".join("?" * len(dispatch_ids))
-        merged_event = conn.execute(
-            f"""
-            SELECT 1 FROM coordination_events
-            WHERE event_type = 'pr_merged'
-              AND entity_id IN ({placeholders})
-            LIMIT 1
-            """,
-            dispatch_ids,
-        ).fetchone()
-        if merged_event:
-            return "done"
-
-        # Declared-done stability: a declared-done track with all terminal dispatches
-        # stays done even when PR evidence is incomplete (partial multi-PR merge or
-        # no coordination event). Blocker/dependency checks still win (run above).
-        if track_phase == "done":
-            return "done"
-
-        # Also accept the track's own pr_ref being confirmed merged via all
-        # evidence sources (NDJSON / ROADMAP / git) — same as the no-dispatch path.
-        # ALL parsed PRs must be merged; partial merge = not done.
-        nums = _parse_pr_numbers(track_pr_ref)
-        if nums and nums <= merged_pr_numbers:
-            return "done"
-
-        # All dispatches terminal but PR not confirmed merged yet.
-        return "in_progress"
-
-    # Some dispatches still in flight.
-    if any(s in IN_FLIGHT_DISPATCH_STATES for s in state_values):
-        return "in_progress"
-
-    # Remaining dispatches are in planned states (proposed, ready).
-    return "queued"
-
-
 def _blocking_detail(
     conn: sqlite3.Connection,
     track_id: str,
@@ -1141,3 +995,12 @@ def close_track_if_done(
     payload["action"] = "closed"
     payload["applied"] = True
     return payload
+
+
+# Re-export (fase 1 PR 1, track file-size-refactor-debt): _compute_derived_status
+# moved unchanged to track_reconciler_status.py. This late import keeps the old
+# import location working for every consumer, and its position at the bottom of
+# the module breaks the import cycle: track_reconciler_status imports its
+# helpers (_has_col, _parse_pr_numbers, the dispatch-state constants) from THIS
+# module, so those must be defined before this import runs.
+from track_reconciler_status import _compute_derived_status  # noqa: E402,F401

--- a/scripts/lib/track_reconciler_status.py
+++ b/scripts/lib/track_reconciler_status.py
@@ -1,0 +1,176 @@
+#!/usr/bin/env python3
+"""track_reconciler_status.py — derived-status computation for a single track.
+
+Pure move (fase 1 PR 1, track file-size-refactor-debt): _compute_derived_status
+lived in track_reconciler.py (lines 228-371 on main) and moved here unchanged.
+track_reconciler.py re-exports the name so no consumer has to change.
+
+The helper imports sit at the BOTTOM of this module, after the function
+definition, to break the import cycle with track_reconciler.py (which imports
+this module for the re-export). Function globals resolve at call time, not at
+definition time, so the names need not exist while this module is first being
+imported — only when _compute_derived_status is actually called, by which
+point track_reconciler is fully initialised.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from typing import FrozenSet
+
+
+def _compute_derived_status(
+    conn: sqlite3.Connection,
+    track_id: str,
+    project_id: str,
+    merged_pr_numbers: FrozenSet[int] = frozenset(),
+) -> str:
+    """Compute derived_status for one track. Pure read — writes nothing.
+
+    Returns one of: 'done', 'blocked', 'in_progress', 'queued'.
+
+    merged_pr_numbers: confirmed-merged PR numbers from local sources. Used in
+    the additive pr_ref evidence path — derives 'done' for tracks where the
+    dispatch join yields no rows (historical dispatches used 'A'/'B'/'C' track
+    labels instead of feature track_ids). The existing dispatch-based derivation
+    is unchanged; this path only fires when dispatches is empty.
+    """
+    # 1. Blocker open-item check: any link_type='blocks' row with resolved_at IS NULL → blocked.
+    #    Migration 0030 adds resolved_at; when present, only unresolved rows are counted.
+    #    Pre-0030 databases have no resolved_at column — fall back to presence-only check.
+    has_project_id_col = _has_col(conn, "track_open_items", "project_id")
+    has_resolved_at_col = _has_col(conn, "track_open_items", "resolved_at")
+    if has_project_id_col and has_resolved_at_col:
+        blocker = conn.execute(
+            """
+            SELECT 1 FROM track_open_items
+            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
+              AND resolved_at IS NULL
+            LIMIT 1
+            """,
+            (track_id, project_id),
+        ).fetchone()
+    elif has_project_id_col:
+        blocker = conn.execute(
+            """
+            SELECT 1 FROM track_open_items
+            WHERE track_id = ? AND project_id = ? AND link_type = 'blocks'
+            LIMIT 1
+            """,
+            (track_id, project_id),
+        ).fetchone()
+    else:
+        blocker = conn.execute(
+            "SELECT 1 FROM track_open_items WHERE track_id = ? AND link_type = 'blocks' LIMIT 1",
+            (track_id,),
+        ).fetchone()
+    if blocker:
+        return "blocked"
+
+    # 2. Dependency check: any dependency whose declared phase is not 'done' blocks this track.
+    #    Uses declared phase (authoritative) to avoid circular dependency on derived_status.
+    dep_phases = conn.execute(
+        """
+        SELECT t.phase
+        FROM track_dependencies td
+        JOIN tracks t
+          ON t.track_id = td.to_track_id AND t.project_id = td.to_project_id
+        WHERE td.from_track_id = ? AND td.from_project_id = ?
+        """,
+        (track_id, project_id),
+    ).fetchall()
+    for row in dep_phases:
+        if row[0] != "done":
+            return "blocked"
+
+    # 3. Fetch track's pr_ref and declared phase once (reused below).
+    track_row = conn.execute(
+        "SELECT pr_ref, phase FROM tracks WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchone()
+    track_pr_ref = track_row["pr_ref"] if track_row else None
+    track_phase = track_row["phase"] if track_row else None
+
+    # 4. Dispatch state aggregation.
+    dispatches = conn.execute(
+        "SELECT dispatch_id, state FROM dispatches WHERE track = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchall()
+
+    if not dispatches:
+        # pr_ref evidence path: covers tracks with no matching dispatches.
+        # Historical dispatches stored 'A'/'B'/'C' in the track column instead of
+        # feature track_ids, so the join above is empty for all pre-1.0 tracks.
+        # If the track's own pr_ref (single or a '#911,#912' multi-PR list) is
+        # confirmed merged via all evidence sources, derive 'done' without a
+        # dispatch match. ALL parsed PRs must be merged; partial merge = not done.
+        nums = _parse_pr_numbers(track_pr_ref)
+        if nums and nums <= merged_pr_numbers:
+            return "done"
+        # Absence of evidence is not evidence of queued. Historical dispatches may
+        # be archived, so defer to declared phase (2026-06-15 migration panel).
+        if track_phase == "done":
+            return "done"
+        if track_phase == "active":
+            return "in_progress"
+        return "queued"
+
+    states = [d[0] for d in dispatches]  # d is (dispatch_id, state); note row_factory gives dict
+    # With row_factory = sqlite3.Row, index by name or position:
+    dispatch_ids = [row["dispatch_id"] for row in dispatches]
+    state_values = [row["state"] for row in dispatches]
+
+    all_terminal = all(s in TERMINAL_DISPATCH_STATES for s in state_values)
+
+    if all_terminal:
+        if not track_pr_ref:
+            # No PR to verify — all work terminal → done.
+            return "done"
+
+        # Check for a pr_merged coordination event on any dispatch in this track.
+        placeholders = ",".join("?" * len(dispatch_ids))
+        merged_event = conn.execute(
+            f"""
+            SELECT 1 FROM coordination_events
+            WHERE event_type = 'pr_merged'
+              AND entity_id IN ({placeholders})
+            LIMIT 1
+            """,
+            dispatch_ids,
+        ).fetchone()
+        if merged_event:
+            return "done"
+
+        # Declared-done stability: a declared-done track with all terminal dispatches
+        # stays done even when PR evidence is incomplete (partial multi-PR merge or
+        # no coordination event). Blocker/dependency checks still win (run above).
+        if track_phase == "done":
+            return "done"
+
+        # Also accept the track's own pr_ref being confirmed merged via all
+        # evidence sources (NDJSON / ROADMAP / git) — same as the no-dispatch path.
+        # ALL parsed PRs must be merged; partial merge = not done.
+        nums = _parse_pr_numbers(track_pr_ref)
+        if nums and nums <= merged_pr_numbers:
+            return "done"
+
+        # All dispatches terminal but PR not confirmed merged yet.
+        return "in_progress"
+
+    # Some dispatches still in flight.
+    if any(s in IN_FLIGHT_DISPATCH_STATES for s in state_values):
+        return "in_progress"
+
+    # Remaining dispatches are in planned states (proposed, ready).
+    return "queued"
+
+
+# Late binding of the helpers this function uses from its old home module.
+# Deliberately after the function definition (see module docstring): importing
+# them at the top would deadlock the re-export cycle with track_reconciler.py.
+from track_reconciler import (  # noqa: E402
+    IN_FLIGHT_DISPATCH_STATES,
+    TERMINAL_DISPATCH_STATES,
+    _has_col,
+    _parse_pr_numbers,
+)


### PR DESCRIPTION
## Wat

Pure verplaatsing van `_compute_derived_status` (144 regels) uit `scripts/lib/track_reconciler.py` naar de nieuwe platte module `scripts/lib/track_reconciler_status.py`, met een re-export op de oude plek. Eerste PR van track **file-size-refactor-debt** (SSOT: `claudedocs/REFACTOR_PLAN.md` §3 bewijslast, §4.1 dit bestand). Geen regel logica gewijzigd.

## Vorm

- **Plat bestand**, geen package — een package `track_reconciler/` naast `track_reconciler.py` schaduwt de module en breekt elke consumer stil (gemeten in de T0-droogloop, plan §4.1).
- De re-export staat **onderaan** `track_reconciler.py` en de helper-imports **onderaan** de nieuwe module. Functie-globals resolven pas bij aanroep, dus zo is de import-cyclus in beide import-volgordes dood (getest: `import track_reconciler` eerst én `import track_reconciler_status` eerst — beide geven hetzelfde object).
- Geen consumer gewijzigd (`git diff --stat`: alleen de twee lib-bestanden).

## Bewijslast (zes bewijzen, plan §3.2)

1. **Size-gate**: `track_reconciler.py` 1143 → 1006 regels; vóór én na `severity=warning` (drempels 500/1200). Nieuwe module 176 regels, onder de warning-drempel. Geen allowlist nodig.
2. **AST-equivalentie**: `refactor_equivalence.py` → `IDENTIEK`, exit 0.
3. **Import-oppervlak**: `refactor_surface.py` → `OK` met identiteitscontrole (re-export wijst naar hetzelfde object), exit 0.
4. **Tests directe consumenten, vóór én na**: `5 failed, 515 passed` → `5 failed, 515 passed`. De 5 failures zijn pre-existing op main (zie hieronder), identiek vóór en na.
5. **`git diff --stat` raakt geen consumer-bestand** — alleen `scripts/lib/track_reconciler.py` en `scripts/lib/track_reconciler_status.py`.
6. **T0-state**: `build_t0_state.py` vóór en na op dezelfde staat → structureel identiek (3191 paden, 0 verschillen) na filtering van één live-toevoeging aan `human_gate_queue` (vreemde dispatch `20260802-w16-oi933-mockfix`, aangemaakt 11:39:53 lokaal, tussen de twee runs in — geen effect van deze wijziging). `track_freshness` identiek: `derived_refreshed=true, tracks=246, drifted=82`.

## Pre-existing failures (ongewijzigd, staan ook op main rood)

- `test_track_reconciler.py::test_blocking_detail_plan_oi_yields_plan_gate_hint` — test verwacht oude hint-tekst `vnx plan-gate run …`; code zegt `vnx horizon plan-gate …` (horizon-rename).
- `test_track_oi_lifecycle.py::TestStatusTracks` (4×) — `vnx_cli/commands/status.py:14` gebruikt `str | None` op Python 3.9 zonder `from __future__ import annotations`.

## Bewust NIET gedaan

- `close_track_if_done` niet aangeraakt (PR 2).
- Module-docstring niet aangepast: de "writes ONLY derived_status"-claim is op main feitelijk onjuist (via `close_track_if_done` → `transition_phase`), maar wordt pas in PR 2 weer waar voor het achterblijvende bestand.
- Kleine parsers (`_parse_pr_number`, `_git_toplevel`, `_load_merged_prs_from_gh`) blijven staan (plan §4.1).

Dispatch-ID: 20260802-f1pr1-track-reconciler-status