### PR TITLE
OI-934: plan-gate hint-test toetst op betekenis i.p.v. dode commandovorm

### DIFF
--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -520,8 +520,15 @@ def test_blocking_detail_plan_oi_yields_plan_gate_hint(tmp_path):
     assert detail["blocking_ois"] == [{"oi_id": "OI-PLAN-T-hint-plan"}]
 
     hint = track_reconciler.format_blocking_hint(detail)
-    assert "vnx plan-gate run T-hint-plan --doc" in hint
-    assert "vnx plan-gate attest T-hint-plan --reason" in hint
+    # Assert on meaning, not on a literal command string: the hint must name
+    # BOTH recovery routes (panel re-run + operator attest) for the track id
+    # derived from the oi_id, the attest route must carry the human-approval
+    # token flag, and the dead oi-close command must never appear. The exact
+    # CLI prefix (`vnx` vs `vnx horizon`) and wording are deliberately NOT
+    # pinned, so the test survives command renames without going vacuous.
+    assert "plan-gate run" in hint
+    assert "plan-gate attest" in hint
+    assert "T-hint-plan" in hint
     assert "--approval-id" in hint
     assert "vnx track oi-close" not in hint
 


### PR DESCRIPTION
## OI-934: een test die een commandovorm toetst die niet meer bestaat

Dispatch-ID: 20260802-w18-oi934-stale-hint

`tests/test_track_reconciler.py::test_blocking_detail_plan_oi_yields_plan_gate_hint` stond rood op `origin/main` (1 failed, 23 passed in dit bestand): de test assertte de letterlijke string `vnx plan-gate run T-hint-plan --doc`, terwijl `format_blocking_hint` inmiddels de horizon-vorm produceert (`vnx horizon plan-gate run/attest ...`). Rood op een vervangen mechanisme, niet op een defect.

## Keuze

De assertie is **op betekenis gelegd** in plaats van meebewegend naar de nieuwe letterlijke tekst: de hint moet beide herstelroutes noemen (`plan-gate run` + `plan-gate attest`), de uit de oi_id afgeleide track-id bevatten, de attest-route met `--approval-id` tonen, en het dode `oi-close`-commando nooit noemen. De exacte CLI-prefix en formulering zijn bewust niet vastgepind — robuuster tegen de volgende hernoeming, zonder vaag te worden.

## Verificatie

- Vóór: `python3 -m pytest tests/test_track_reconciler.py -q` → **1 failed, 23 passed**, exit-code 1
- Na: zelfde commando → **24 passed**, exit-code 0
- Falend-bewijs: hint-tekst in `format_blocking_hint` tijdelijk gewijzigd (`attest` → `confirm`) → test rood, exit-code 1; daarna teruggedraaid
- `git diff --stat`: alleen `tests/test_track_reconciler.py` (9 insertions, 2 deletions); `format_blocking_hint` ongemoeid gelaten