### PR TITLE
fix(gate): temporary FILE_SIZE_ALLOWLIST entry for dispatch_cli (OI-937)

### DIFF
--- a/scripts/lib/quality_advisory.py
+++ b/scripts/lib/quality_advisory.py
@@ -55,6 +55,7 @@ FILE_SIZE_ALLOWLIST: Dict[str, str] = {
     "scripts/smart_tap_json_translator": "grandfathered shell monolith; smart-tap translator",
     "dashboard/api_intelligence": "grandfathered monolith; dashboard intelligence API",
     "dashboard/api_operator": "grandfathered monolith; dashboard operator API",
+    "scripts/lib/dispatch_cli": "TEMP allowlist — mid-refactor naar submodules, zie OI-937 (slot-PR van de extractie-reeks verwijdert deze regel weer)",
 }
 
 


### PR DESCRIPTION
## Summary
`scripts/lib/dispatch_cli.py` is 1517 lines, above the 1200-line blocking ceiling in `check_file_size` (`scripts/lib/quality_advisory.py`), and not grandfathered. Any PR in the upcoming extraction series — including one that shrinks the file — would fail the merge gate on this check first (chicken-and-egg). This is PR 0 of that series (plan: `claudedocs/panel-refactor-doeltoestand-20260802.md` §4): a temporary allowlist entry that unblocks the series to start.

OI-937 ("Remove TEMP FILE_SIZE_ALLOWLIST entry for scripts/lib/dispatch_cli after panel-refactor series") tracks removing this entry again once the slot-PR lands the file at ~691 lines.

## Changes
- `scripts/lib/quality_advisory.py`: added a `FILE_SIZE_ALLOWLIST` entry for `scripts/lib/dispatch_cli`, referencing OI-937, right after the `dashboard/api_operator` entry.
- No changes to `dispatch_cli.py` itself — content, line count, and behavior are untouched.

## Verification
Second gate-path check (open item from the plan, §"Open Items" line 529-532): searched the repo for any caller of `check_file_size`/`FILE_SIZE_ALLOWLIST`/`quality_advisory` besides `scripts/pre_merge_gate.py`. Found none — no pre-commit hook is installed (`.git/hooks/` has only `.sample` files), no `.github/workflows/*.yml` references `pre_merge_gate`, `quality_advisory`, or file-size checks, and the only other `_check_file_size`-named function (`scripts/open_items_manager.py`) is an unrelated regex-based OI-title re-verifier that never consults `FILE_SIZE_ALLOWLIST`. `pre_merge_gate.py` is the sole gate path; no second-path coverage needed.

Red-before / green-after, on the real gate function (`check_quality_advisory` in `scripts/pre_merge_gate.py`), via a trivial temporary touch to `dispatch_cli.py` (reverted before this commit — not part of the diff):
- **Before** (no allowlist entry): `status: HOLD`, `file_size_blocking` (blocking) on `dispatch_cli.py`, decision=`hold`.
- **After** (allowlist entry added): `status: GO`, same finding downgraded to `file_size_grandfathered` (warning), decision=`approve_with_followup`.

Test commands run:
- `python3 -m pytest tests/test_quality_advisory_pipeline.py tests/test_pre_merge_gate.py -q` → 95 passed
- `python3 -m pytest tests/ -k "quality_advisory or pre_merge_gate or gate_findings" -q` → 135 passed, 18723 deselected

## Open Items
- OI-937 (already filed, verified present in the central open-items store) tracks removing this allowlist entry once the `dispatch_cli.py` extraction series' slot-PR lands the file under 1200 lines without needing it.