### PR TITLE
fix(tests): fail-closed guard tegen schrijfacties naar de echte centrale store onder pytest

### DIFF
--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -155,7 +155,7 @@ def read_mode(data_dir: Optional[str] = None) -> Optional[VNXMode]:
 def _guard_mode_write_target(target_dir: Path) -> None:
     """Fail loud when a mode.json write would land outside the active project store.
 
-    Two checks (OI-911):
+    Three checks (OI-911 + w19c/OI-934):
 
     1. Divergence guard. When ``VNX_DATA_DIR`` is set WITHOUT
        ``VNX_DATA_DIR_EXPLICIT=1``, the two-key contract treats it as inherited
@@ -163,12 +163,21 @@ def _guard_mode_write_target(target_dir: Path) -> None:
        that fallback diverges from the env value, the process was configured for
        a different data dir and writing mode.json to the fallback store is
        exactly the OI-911 test-run incident. Refuse.
-    2. Cross-project guard. A write target under ``~/.vnx-data/<other>`` while
+    2. Test-isolation guard (w19c/OI-934). Under pytest, refuse a write into
+       the REAL central store outright — even with NO env override at all
+       (nothing to "diverge" from) and even when the resolved project_id
+       happens to match, which is exactly the gap the divergence check above
+       cannot see: a completely clean test env resolves to this repo's own
+       real ``~/.vnx-data/vnx-dev`` "correctly", and correctly is still wrong
+       for a test. This is what let a suite-wide pytest run flip the live
+       mode.json from operator to starter with no divergence to catch.
+    3. Cross-project guard. A write target under ``~/.vnx-data/<other>`` while
        the resolved project_id is not ``<other>`` is a cross-project write.
 
     When no project_id is resolvable the cross-project half cannot verify and
-    stays silent (same contract as ``data_dir_guard``); the divergence half is
-    env-verifiable and always runs.
+    stays silent (same contract as ``data_dir_guard``); the divergence and
+    test-isolation halves are verifiable independent of project_id and always
+    run.
     """
     try:
         target = Path(target_dir).expanduser().resolve()
@@ -204,6 +213,14 @@ def _guard_mode_write_target(target_dir: Path) -> None:
         return
     expected = home_vnx / pid
     if target == expected or str(target).startswith(str(expected) + os.sep):
+        # No divergence, no cross-project mismatch — by OI-911's own checks
+        # this write is "correct". Still refuse it under pytest (w19c/OI-934):
+        # a completely clean test env resolving "correctly" to this repo's
+        # real ~/.vnx-data/vnx-dev is exactly the gap those two checks can't
+        # see, since there is neither a divergence nor a project mismatch to
+        # catch.
+        from vnx_paths import refuse_real_central_store_write_under_pytest
+        refuse_real_central_store_write_under_pytest(target)
         return
     raise RuntimeError(
         f"mode.json write target {target} is {rel.parts[0]!r}'s central store, "

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -165,19 +165,26 @@ def _guard_mode_write_target(target_dir: Path) -> None:
        exactly the OI-911 test-run incident. Refuse.
     2. Test-isolation guard (w19c/OI-934). Under pytest, refuse a write into
        the REAL central store outright — even with NO env override at all
-       (nothing to "diverge" from) and even when the resolved project_id
-       happens to match, which is exactly the gap the divergence check above
-       cannot see: a completely clean test env resolves to this repo's own
-       real ``~/.vnx-data/vnx-dev`` "correctly", and correctly is still wrong
-       for a test. This is what let a suite-wide pytest run flip the live
-       mode.json from operator to starter with no divergence to catch.
+       (nothing to "diverge" from), even when the resolved project_id happens
+       to match (the gap the divergence check above cannot see: a completely
+       clean test env resolves to this repo's own real ``~/.vnx-data/vnx-dev``
+       "correctly", and correctly is still wrong for a test — this is what let
+       a suite-wide pytest run flip the live mode.json from operator to
+       starter with no divergence to catch), and even when project_id is NOT
+       resolvable at all (w22/PR#1333: a subprocess with a cleaned env has no
+       ``VNX_PROJECT_ID``, no reachable ``.vnx-project-id`` marker, and often
+       no git remote either — ``resolve_project_id()`` raising is exactly the
+       scenario this guard exists for, not a reason to skip it).
     3. Cross-project guard. A write target under ``~/.vnx-data/<other>`` while
        the resolved project_id is not ``<other>`` is a cross-project write.
 
-    When no project_id is resolvable the cross-project half cannot verify and
-    stays silent (same contract as ``data_dir_guard``); the divergence and
-    test-isolation halves are verifiable independent of project_id and always
-    run.
+    When no project_id is resolvable the cross-project half cannot verify a
+    mismatch and stays silent about THAT specifically (same contract as
+    ``data_dir_guard``) — but the test-isolation half does not need a
+    project_id at all, so it still runs and still refuses a central-store
+    write under pytest even when project_id resolution fails or returns
+    empty. The divergence half is likewise independent of project_id and
+    always runs.
     """
     try:
         target = Path(target_dir).expanduser().resolve()
@@ -204,12 +211,20 @@ def _guard_mode_write_target(target_dir: Path) -> None:
         return  # repo-local / scratch / XDG — not a central-store path
 
     from project_root import resolve_project_id
+    from vnx_paths import refuse_real_central_store_write_under_pytest
     try:
         pid = resolve_project_id()
     except RuntimeError:
-        return  # cannot verify against a project_id — allow
+        # Cannot verify the cross-project half without a project_id, but the
+        # test-isolation half (w19c/OI-934) does not depend on one: a
+        # subprocess with a cleaned env is exactly the scenario where
+        # resolve_project_id() fails, and exactly the scenario this guard
+        # exists for (w22/PR#1333). Run it before allowing the write.
+        refuse_real_central_store_write_under_pytest(target)
+        return
     pid = pid.strip()
     if not pid:
+        refuse_real_central_store_write_under_pytest(target)
         return
     expected = home_vnx / pid
     if target == expected or str(target).startswith(str(expected) + os.sep):
@@ -219,7 +234,6 @@ def _guard_mode_write_target(target_dir: Path) -> None:
         # real ~/.vnx-data/vnx-dev is exactly the gap those two checks can't
         # see, since there is neither a divergence nor a project mismatch to
         # catch.
-        from vnx_paths import refuse_real_central_store_write_under_pytest
         refuse_real_central_store_write_under_pytest(target)
         return
     raise RuntimeError(

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -313,6 +313,64 @@ def _project_id_from_git_remote(project_root: Path) -> Optional[str]:
     return None
 
 
+def refuse_real_central_store_write_under_pytest(resolved: Path) -> None:
+    """Fail loud when code is ABOUT TO WRITE under the real central store
+    while running under pytest (w19c / test-store-isolation class guard).
+
+    Call this from write surfaces — a manager class's ``__init__``, a
+    ``write_*`` function — right before any file/dir gets created, NOT from
+    generic path resolvers. ``vnx_paths.resolve_paths()`` /
+    ``_resolve_state_root()`` are pure computations used by plenty of
+    legitimate read-only tests that inspect resolution logic without ever
+    touching disk (e.g. ``tests/test_path_resolution_regression.py`` calling
+    ``resolve_paths()`` with a deliberately clean env to assert on shape, not
+    on where it points) — those must keep resolving to wherever production
+    would, even ``~/.vnx-data/vnx-dev``, without failing. Only an imminent
+    WRITE into that path is the actual hazard.
+
+    ``_resolve_state_root``'s branch 3 ("existing central install — keep
+    resolving to ``~/.vnx-data/<id>``") is correct for production, but a
+    landmine when something is about to write there during THIS repo's own
+    test suite: vnx-orchestration IS a real, governed central-store project
+    (``~/.vnx-data/vnx-dev``), so a test that loses its isolation — a
+    stripped ``VNX_DATA_DIR_EXPLICIT``, a leaked ``VNX_PROJECT_ID``, a
+    subprocess with a cleaned env — silently resolves right back to that
+    live store. That is exactly how ``tests/test_pr_dispatch_integration.py``
+    wrote real dispatch-staging files into production governance state, and
+    how ``vnx_mode.write_mode()``'s resolver fallback can flip the live
+    ``mode.json`` from operator to starter, closing the governance door for
+    ``vnx dispatch``.
+
+    Deliberately checks the ACTUAL resolved value rather than requiring
+    ``VNX_DATA_DIR_EXPLICIT=1`` (contrast with the precedent in
+    ``build_t0_state._pytest_db_isolation_guard`` /
+    ``migrate_future_system._pytest_db_isolation_guard``): callers of this
+    function have their own legitimate no-explicit-flag paths (fresh-install
+    / XDG / project-local fallbacks all resolve safely without it), so the
+    flag itself is not the invariant. Landing a WRITE in the real
+    ``~/.vnx-data`` is.
+
+    Production is unaffected: pytest is never in ``sys.modules`` outside a
+    test run.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None and "pytest" not in _sys.modules:
+        return
+    real_home_vnx_data = (Path(os.path.expanduser("~")) / ".vnx-data").resolve()
+    resolved = resolved.resolve()
+    sep = os.sep
+    if str(resolved) == str(real_home_vnx_data) or str(resolved).startswith(
+        str(real_home_vnx_data) + sep
+    ):
+        raise RuntimeError(
+            f"[TEST ISOLATION GUARD] about to write under the real central "
+            f"store '{resolved}' while running under pytest. A test lost its "
+            "isolation. Set VNX_DATA_DIR_EXPLICIT=1 with a tmp_path-based "
+            "VNX_DATA_DIR before this code runs, or ensure the "
+            "tests/conftest.py _vnx_data_dir_isolation autouse fixture is "
+            "active for this test."
+        )
+
+
 def _resolve_state_root(project_id: Optional[str], project_root: Path) -> Path:
     """Resolve the VNX runtime data root (the ``.vnx-data`` equivalent).
 

--- a/scripts/pr_queue_manager.py
+++ b/scripts/pr_queue_manager.py
@@ -20,6 +20,7 @@ if _lib_dir not in sys.path:
     sys.path.insert(0, _lib_dir)
 
 from vnx_paths import resolve_paths as _resolve_vnx_paths
+from vnx_paths import refuse_real_central_store_write_under_pytest as _refuse_real_store_write
 from pr_queue_state_snapshot import build_vnx_state_snapshot
 from project_scope import current_project_id as _current_project_id
 from result_contract import (
@@ -81,6 +82,14 @@ class PRQueueManager:
         self.dispatch_dir = Path(vnx_paths["VNX_DISPATCH_DIR"])
         self.vnx_state_dir = Path(vnx_paths["VNX_STATE_DIR"]).expanduser().resolve()
         self.legacy_state_dir = (vnx_root / "state").resolve()
+
+        # w19c/OI-934: PRQueueManager exists to write PR queue state and
+        # dispatch-staging files — construction is the earliest point that
+        # reliably signals an imminent write. Refuses loudly instead of
+        # silently landing in the real central store under a leaked/lost
+        # test isolation (see tests/test_pr_dispatch_integration.py history).
+        _refuse_real_store_write(self.vnx_state_dir)
+        _refuse_real_store_write(self.dispatch_dir)
         rollback_flag = _rollback_mode_flag()
         self.rollback_mode = bool(rollback_flag)
         dual_write_flag = _env_flag("VNX_PR_QUEUE_DUAL_WRITE_LEGACY")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -101,6 +101,26 @@ def _vnx_data_dir_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     monkeypatch.setenv — the last setenv wins within the same function scope.
     Tests that need the fallback behaviour (no explicit flag) can monkeypatch
     delenv("VNX_DATA_DIR_EXPLICIT") to undo this guard for that test only.
+
+    This is the "point the store at tmp_path" half of the class-wide guard
+    (w19c/OI-934). It is NOT itself the backstop: a test that opts out of the
+    explicit flag (or a subprocess that loses it) still has a legitimate
+    no-flag resolution path (fresh-install / XDG / project-local fallbacks),
+    so this fixture cannot unconditionally refuse — and neither can the
+    resolver itself (``vnx_paths.resolve_paths()`` / ``_resolve_state_root()``
+    are pure computations with plenty of legitimate read-only callers that
+    must keep resolving to wherever production would, real central store
+    included, without failing).
+
+    The "fail loud when about to WRITE into the real ~/.vnx-data" half lives
+    at the actual write surfaces instead:
+    ``vnx_paths.refuse_real_central_store_write_under_pytest`` is called from
+    ``PRQueueManager.__init__`` (scripts/pr_queue_manager.py) and from
+    ``vnx_mode._guard_mode_write_target`` (scripts/lib/vnx_mode.py, alongside
+    the existing OI-911 divergence/cross-project checks). New write surfaces
+    should call it too — see that function's docstring in
+    scripts/lib/vnx_paths.py. Regression tests:
+    tests/test_vnx_data_dir_real_store_guard.py.
     """
     isolated = tmp_path / "_vnx_test_data"
     isolated.mkdir(parents=True, exist_ok=True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -15,19 +15,50 @@ from pathlib import Path
 
 import pytest
 
+# Subsystem dirs that scripts/lib/vnx_paths.py's resolve_paths() honors as
+# LITERAL env-var overrides — independent of VNX_DATA_DIR/VNX_DATA_DIR_EXPLICIT.
+# A worker/T0 process inherits these pointed at the real central store
+# (~/.vnx-data/<project>/state, .../dispatches, ...), so pinning VNX_DATA_DIR
+# alone leaves isolation half-done: resolve_paths() still resolves these
+# straight back to production regardless of what VNX_DATA_DIR is set to
+# (w22/PR#1333 — this bit test_pr_dispatch_integration.py and
+# test_pr_recommendation_integration.py, whose own fixtures had the same gap,
+# and it bit the module-level pin below too: scripts/generate_t0_recommendations.py
+# resolves and caches VNX_STATE_DIR/VNX_DISPATCH_DIR at import time, so an
+# ambient-polluted env leaks into its cached paths for the rest of the
+# session unless this pin closes the gap before any test module is collected).
+_VNX_SUBSYSTEM_DIRS = {
+    "VNX_STATE_DIR": "state",
+    "VNX_DISPATCH_DIR": "dispatches",
+    "VNX_LOGS_DIR": "logs",
+    "VNX_PIDS_DIR": "pids",
+    "VNX_LOCKS_DIR": "locks",
+    "VNX_SOCKETS_DIR": "sockets",
+    "VNX_REPORTS_DIR": "unified_reports",
+    "VNX_DB_DIR": "database",
+    "VNX_HEADLESS_REPORTS_DIR": "unified_reports/headless",
+}
+
 # ---------------------------------------------------------------------------
 # Module-level isolation pin (import-time / collection-time guard)
 # ---------------------------------------------------------------------------
 # _pytest_db_isolation_guard detects pytest via sys.modules (active from
 # collection onward, before PYTEST_CURRENT_TEST is set). This pin ensures
-# VNX_DATA_DIR_EXPLICIT=1 and a temp VNX_DATA_DIR are in place from the
-# moment conftest loads, so any module-level run() call during collection
-# hits the guard instead of touching ~/.vnx-data.
+# VNX_DATA_DIR_EXPLICIT=1 and a temp VNX_DATA_DIR (+ every subsystem dir
+# resolve_paths() honors directly) are in place from the moment conftest
+# loads, so any module-level run() call during collection — or any
+# module-level path caching, like generate_t0_recommendations.py's
+# STATE_DIR/DISPATCHES_DIR constants — hits the isolated tmp tree instead of
+# ~/.vnx-data, regardless of what the ambient shell environment set before
+# pytest started.
 # Per-module (_fsr_migration_module_isolation) and per-test (_vnx_data_dir_isolation)
 # fixtures re-pin to tighter tmp dirs; this is the fallback floor.
 _CONFTEST_ISOLATION_TMP = tempfile.mkdtemp(prefix="vnx_conftest_")
 os.environ["VNX_DATA_DIR_EXPLICIT"] = "1"
 os.environ["VNX_DATA_DIR"] = _CONFTEST_ISOLATION_TMP
+for _env_key, _subdir in _VNX_SUBSYSTEM_DIRS.items():
+    os.environ[_env_key] = str(Path(_CONFTEST_ISOLATION_TMP) / _subdir)
+del _env_key, _subdir
 # Keep the new data-dir guard from emitting warnings during normal tests.
 # Tests that exercise the guard override this explicitly.
 os.environ.setdefault("VNX_DATA_DIR_GUARD", "off")
@@ -91,10 +122,28 @@ def _fsr_migration_module_isolation(tmp_path_factory: pytest.TempPathFactory):
 # Production events-dir contamination guard
 # ---------------------------------------------------------------------------
 
+def pin_vnx_data_dir(monkeypatch: pytest.MonkeyPatch, data_dir: Path) -> None:
+    """Pin VNX_DATA_DIR and every subsystem dir resolve_paths() derives from it.
+
+    Sets VNX_DATA_DIR_EXPLICIT=1 plus VNX_DATA_DIR, and ALSO pins
+    VNX_STATE_DIR / VNX_DISPATCH_DIR / etc. (see _VNX_SUBSYSTEM_DIRS) to the
+    same isolated tree. Without the subsystem pins, an ambient
+    VNX_STATE_DIR/VNX_DISPATCH_DIR inherited from a real worker/T0 shell
+    environment wins outright in resolve_paths() — VNX_DATA_DIR alone does
+    not shadow it. Shared by the module-level isolation fixture below and by
+    tests/test_pr_dispatch_integration.py + tests/test_pr_recommendation_integration.py,
+    which need the same full pin for their own PRQueueManager() writes.
+    """
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    for env_key, subdir in _VNX_SUBSYSTEM_DIRS.items():
+        monkeypatch.setenv(env_key, str(data_dir / subdir))
+
+
 @pytest.fixture(autouse=True)
 def _vnx_data_dir_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Redirect VNX_DATA_DIR so EventStore() without an explicit events_dir
-    cannot write to ~/.vnx-data during any test run.
+    """Redirect VNX_DATA_DIR (+ subsystem dirs) so EventStore() without an
+    explicit events_dir cannot write to ~/.vnx-data during any test run.
 
     Sets VNX_DATA_DIR_EXPLICIT=1 so the explicit-path branch in _events_dir()
     is taken. Tests that need a specific value can override via their own
@@ -124,8 +173,7 @@ def _vnx_data_dir_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     """
     isolated = tmp_path / "_vnx_test_data"
     isolated.mkdir(parents=True, exist_ok=True)
-    monkeypatch.setenv("VNX_DATA_DIR", str(isolated))
-    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    pin_vnx_data_dir(monkeypatch, isolated)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pr_dispatch_integration.py
+++ b/tests/test_pr_dispatch_integration.py
@@ -6,15 +6,44 @@ Tests PR 2.5 implementation
 
 import os
 import sys
+import tempfile
 import time
 from pathlib import Path
+
+import pytest
 
 VNX_HOME = Path(os.environ.get("VNX_HOME", Path(__file__).resolve().parents[1]))
 
 # Add parent to path
 sys.path.insert(0, str(Path(__file__).parent))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
 
 from pr_queue_manager import PRQueueManager
+
+
+@pytest.fixture(autouse=True)
+def _isolate_vnx_data_dir(monkeypatch):
+    """PRQueueManager() resolves VNX_STATE_DIR/VNX_DISPATCH_DIR from
+    VNX_DATA_DIR and writes real staging dispatches + queue state there.
+    Without an explicit, isolated VNX_DATA_DIR these tests land in the real
+    central store (~/.vnx-data/<project>) instead of a throwaway tmp dir
+    (w19c/OI-934: this file previously had zero isolation and repeatedly
+    wrote staging files into production governance state).
+
+    PROJECT_ROOT is isolated too: PRQueueManager.update_markdown() writes
+    PR_QUEUE.md to project_root, and project_root resolves via vnx_paths'
+    git-toplevel walk regardless of VNX_DATA_DIR — left unpinned, every run
+    overwrites this repo's own git-tracked PR_QUEUE.md.
+
+    Module-level autouse (not a test-function parameter) so the file still
+    runs standalone via ``python3 tests/test_pr_dispatch_integration.py``
+    (main() calls the test functions directly, with no pytest fixture
+    injection) exactly as it did before.
+    """
+    isolated = tempfile.mkdtemp(prefix="test_pr_dispatch_integration_")
+    monkeypatch.setenv("VNX_DATA_DIR", isolated)
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_PROJECT_ROOT", tempfile.mkdtemp(prefix="test_pr_dispatch_project_root_"))
 
 
 def test_pr_dispatch_creation():

--- a/tests/test_pr_dispatch_integration.py
+++ b/tests/test_pr_dispatch_integration.py
@@ -12,6 +12,8 @@ from pathlib import Path
 
 import pytest
 
+from conftest import pin_vnx_data_dir
+
 VNX_HOME = Path(os.environ.get("VNX_HOME", Path(__file__).resolve().parents[1]))
 
 # Add parent to path
@@ -30,6 +32,14 @@ def _isolate_vnx_data_dir(monkeypatch):
     (w19c/OI-934: this file previously had zero isolation and repeatedly
     wrote staging files into production governance state).
 
+    pin_vnx_data_dir (tests/conftest.py) pins VNX_DATA_DIR *and* the
+    VNX_STATE_DIR/VNX_DISPATCH_DIR/etc. subsystem overrides that
+    resolve_paths() honors directly — pinning VNX_DATA_DIR alone left a gap
+    (w22/PR#1333): a worker/T0 shell that already has VNX_STATE_DIR pointed
+    at the real central store overrides the isolated VNX_DATA_DIR outright,
+    and PRQueueManager()'s own real-store-under-pytest guard then refuses
+    the write with RuntimeError instead of landing in the tmp dir.
+
     PROJECT_ROOT is isolated too: PRQueueManager.update_markdown() writes
     PR_QUEUE.md to project_root, and project_root resolves via vnx_paths'
     git-toplevel walk regardless of VNX_DATA_DIR — left unpinned, every run
@@ -41,8 +51,7 @@ def _isolate_vnx_data_dir(monkeypatch):
     injection) exactly as it did before.
     """
     isolated = tempfile.mkdtemp(prefix="test_pr_dispatch_integration_")
-    monkeypatch.setenv("VNX_DATA_DIR", isolated)
-    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    pin_vnx_data_dir(monkeypatch, Path(isolated))
     monkeypatch.setenv("VNX_PROJECT_ROOT", tempfile.mkdtemp(prefix="test_pr_dispatch_project_root_"))
 
 

--- a/tests/test_pr_recommendation_integration.py
+++ b/tests/test_pr_recommendation_integration.py
@@ -12,23 +12,46 @@ from pathlib import Path
 
 import pytest
 
+from conftest import pin_vnx_data_dir
+
 # Add scripts dir to path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
 sys.path.insert(0, str(SCRIPTS_DIR))
 
 from pr_queue_manager import PRQueueManager
-from generate_t0_recommendations import RecommendationEngine, PR_QUEUE_STATE_FILE
+from generate_t0_recommendations import (
+    RecommendationEngine,
+    PR_QUEUE_STATE_FILE,
+    STATE_DIR as _RECS_STATE_DIR,
+    DISPATCHES_DIR as _RECS_DISPATCHES_DIR,
+)
 
 
 @pytest.fixture(autouse=True)
 def _isolate_vnx_data_dir(monkeypatch):
     """Sibling of tests/test_pr_dispatch_integration.py — same PRQueueManager
     write surface, same w19c/OI-934 isolation requirement. See that file's
-    fixture docstring for the full incident writeup.
+    fixture docstring for the full incident writeup, and pin_vnx_data_dir's
+    docstring (tests/conftest.py) for why VNX_DATA_DIR alone is not enough
+    (w22/PR#1333).
+
+    Unlike test_pr_dispatch_integration.py, VNX_STATE_DIR/VNX_DISPATCH_DIR
+    are NOT re-pinned to a fresh tmp dir here: generate_t0_recommendations
+    resolves and caches STATE_DIR/DISPATCHES_DIR at import time (module-level
+    constants, scripts/generate_t0_recommendations.py), so RecommendationEngine
+    reads/writes through those frozen paths for the rest of the session. A
+    fresh-per-test VNX_STATE_DIR would desync PRQueueManager() (resolves
+    fresh every call) from RecommendationEngine (frozen at import) and break
+    every assertion that reads back what the other wrote. Re-asserting the
+    SAME already-resolved dirs here keeps both aligned; conftest.py's own
+    module-level pin (run before this module is even imported) is what keeps
+    that cached value isolated from the real central store in the first
+    place, including under an ambient-polluted VNX_STATE_DIR.
     """
     isolated = tempfile.mkdtemp(prefix="test_pr_recommendation_integration_")
-    monkeypatch.setenv("VNX_DATA_DIR", isolated)
-    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    pin_vnx_data_dir(monkeypatch, Path(isolated))
+    monkeypatch.setenv("VNX_STATE_DIR", str(_RECS_STATE_DIR))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(_RECS_DISPATCHES_DIR))
     monkeypatch.setenv("VNX_PROJECT_ROOT", tempfile.mkdtemp(prefix="test_pr_recommendation_project_root_"))
 
 

--- a/tests/test_pr_recommendation_integration.py
+++ b/tests/test_pr_recommendation_integration.py
@@ -6,8 +6,11 @@ Tests: State loading, dependency recommendations, blocked PR detection
 
 import os
 import sys
+import tempfile
 import yaml
 from pathlib import Path
+
+import pytest
 
 # Add scripts dir to path
 SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
@@ -15,6 +18,18 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 
 from pr_queue_manager import PRQueueManager
 from generate_t0_recommendations import RecommendationEngine, PR_QUEUE_STATE_FILE
+
+
+@pytest.fixture(autouse=True)
+def _isolate_vnx_data_dir(monkeypatch):
+    """Sibling of tests/test_pr_dispatch_integration.py — same PRQueueManager
+    write surface, same w19c/OI-934 isolation requirement. See that file's
+    fixture docstring for the full incident writeup.
+    """
+    isolated = tempfile.mkdtemp(prefix="test_pr_recommendation_integration_")
+    monkeypatch.setenv("VNX_DATA_DIR", isolated)
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+    monkeypatch.setenv("VNX_PROJECT_ROOT", tempfile.mkdtemp(prefix="test_pr_recommendation_project_root_"))
 
 
 def test_pr_queue_state_loading():

--- a/tests/test_vnx_data_dir_real_store_guard.py
+++ b/tests/test_vnx_data_dir_real_store_guard.py
@@ -1,0 +1,161 @@
+#!/usr/bin/env python3
+"""Regression tests for the w19c / OI-934 test-store-isolation class guard.
+
+Incident: tests/test_pr_dispatch_integration.py had zero isolation of its
+own (no tmp_path/monkeypatch/VNX_DATA_DIR reference) and, whenever a broad
+pytest sweep made ``pr_queue_manager`` importable (sys.path pollution from
+an earlier-collected test module), it silently resolved VNX_DATA_DIR through
+``vnx_paths._resolve_state_root``'s branch 3 ("existing central install —
+keep resolving to ~/.vnx-data/<id>") straight to the REAL production central
+store, writing real dispatch-staging files and (via the same resolver,
+through ``vnx_mode._mode_file_path``'s fallback) flipping the live
+``mode.json`` from operator to starter.
+
+The guard lives at the WRITE surfaces (``PRQueueManager.__init__``,
+``vnx_mode._guard_mode_write_target``), not inside the generic path
+resolver: ``vnx_paths.resolve_paths()`` / ``_resolve_state_root()`` are pure
+computations with plenty of legitimate read-only callers (e.g.
+tests/test_path_resolution_regression.py asserting on resolution shape with
+a deliberately clean env) that must keep resolving to wherever production
+would — including the real ``~/.vnx-data/vnx-dev`` — without failing. Only an
+imminent WRITE into that path is the actual hazard; see
+``vnx_paths.refuse_real_central_store_write_under_pytest``.
+
+Before this fix, neither write surface refused a completely clean-env
+resolution that happened to land on the real central store (OI-911's
+divergence guard only catches a DIVERGING env override, not "no override at
+all"). After this fix, both refuse loudly instead.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import vnx_paths
+import vnx_mode
+
+
+def _clean_env(monkeypatch):
+    # Full VNX_* path key set (mirrors tests/test_context_rotation.py's
+    # _clean_env). Several of these — VNX_STATE_DIR, VNX_DISPATCH_DIR,
+    # PROJECT_ROOT, ... — get permanently pinned into os.environ the first
+    # time any module calls vnx_paths.ensure_env() at IMPORT time (it uses
+    # os.environ.setdefault, so whichever value was active at COLLECTION
+    # time sticks for the rest of the session, unaffected by a later test's
+    # VNX_DATA_DIR override). Leaving any of these unset here makes this
+    # test's resolution depend on test collection order across the whole
+    # suite instead of on what this test actually configures.
+    for key in (
+        "VNX_HOME", "VNX_BIN", "VNX_EXECUTABLE", "PROJECT_ROOT",
+        "VNX_DATA_DIR", "VNX_DATA_DIR_EXPLICIT", "VNX_STATE_DIR",
+        "VNX_DISPATCH_DIR", "VNX_LOGS_DIR", "VNX_PIDS_DIR", "VNX_LOCKS_DIR",
+        "VNX_REPORTS_DIR", "VNX_DB_DIR", "VNX_SKILLS_DIR",
+        "VNX_CANONICAL_ROOT", "VNX_INTELLIGENCE_DIR",
+        "VNX_DATA_HOME", "XDG_DATA_HOME", "VNX_PROJECT_ID", "VNX_PROJECT_ROOT",
+        "VNX_OPERATOR_ID", "VNX_ORCHESTRATOR_ID", "VNX_AGENT_ID",
+        "VNX_DATA_DIR_GUARD",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+class TestRefuseRealCentralStoreWriteUnderPytest:
+    """The low-level guard function itself: refuses a write target under the
+    real (as resolved via HOME) ~/.vnx-data, allows everything else."""
+
+    def test_refuses_write_under_home_central_store(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        target = fake_home / ".vnx-data" / "some-project"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            vnx_paths.refuse_real_central_store_write_under_pytest(target)
+
+    def test_allows_write_under_tmp_path(self, tmp_path, monkeypatch):
+        target = tmp_path / "isolated" / "some-project"
+        target.mkdir(parents=True)
+        # Must not raise.
+        vnx_paths.refuse_real_central_store_write_under_pytest(target)
+
+    def test_read_only_resolution_is_unaffected(self, tmp_path, monkeypatch):
+        """resolve_paths()/_resolve_state_root() must keep resolving to the
+        real store when asked to — the guard only fires at write surfaces,
+        never inside the resolver itself (that was the over-broad first
+        version of this fix, reverted after it broke
+        tests/test_path_resolution_regression.py's read-only assertions)."""
+        _clean_env(monkeypatch)
+        fake_home = tmp_path / "home"
+        (fake_home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+        result = vnx_paths._resolve_state_root("vnx-dev", tmp_path / "proj")
+        assert result == (fake_home / ".vnx-data" / "vnx-dev").resolve()
+
+        paths = vnx_paths.resolve_paths()
+        assert paths["VNX_DATA_DIR"] == str((fake_home / ".vnx-data" / "vnx-dev").resolve())
+
+
+class TestPrQueueManagerWriteGuard:
+    """PRQueueManager() construction is the earliest reliable signal of an
+    imminent write — the guard fires there, mirroring the w19c incident."""
+
+    def test_construction_refuses_when_it_would_land_in_real_central_store(
+        self, tmp_path, monkeypatch
+    ):
+        _clean_env(monkeypatch)
+        fake_home = tmp_path / "home"
+        (fake_home / ".vnx-data" / "vnx-dev").mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+        import pr_queue_manager
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            pr_queue_manager.PRQueueManager()
+
+    def test_construction_allowed_when_properly_isolated(self, tmp_path, monkeypatch):
+        _clean_env(monkeypatch)
+        monkeypatch.setenv("VNX_DATA_DIR", str(tmp_path / "data"))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        import pr_queue_manager
+        manager = pr_queue_manager.PRQueueManager()
+        assert str(manager.vnx_state_dir).startswith(str(tmp_path))
+
+
+class TestWriteModeGuard:
+    """vnx_mode.write_mode()'s target guard must refuse a completely clean
+    env that resolves (correctly, per production semantics) to the real
+    central store — the exact gap OI-911's divergence check cannot see,
+    since a clean env has nothing to diverge from."""
+
+    def test_write_mode_refuses_clean_env_real_store_resolution(
+        self, tmp_path, monkeypatch
+    ):
+        _clean_env(monkeypatch)
+        fake_home = tmp_path / "home"
+        central = fake_home / ".vnx-data" / "vnx-dev"
+        central.mkdir(parents=True)
+        (central / "mode.json").write_text(
+            '{"mode": "operator", "schema_version": 1}\n', encoding="utf-8"
+        )
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            vnx_mode.write_mode(vnx_mode.VNXMode.STARTER)
+
+        # The (fake) production mode.json must be untouched.
+        assert '"operator"' in (central / "mode.json").read_text(encoding="utf-8")
+
+    def test_write_mode_allowed_with_explicit_data_dir(self, tmp_path, monkeypatch):
+        _clean_env(monkeypatch)
+        data_dir = tmp_path / "data"
+        data_dir.mkdir()
+        vnx_mode.write_mode(vnx_mode.VNXMode.OPERATOR, str(data_dir))
+        assert (data_dir / "mode.json").exists()

--- a/tests/test_vnx_mode.py
+++ b/tests/test_vnx_mode.py
@@ -166,6 +166,44 @@ class TestModeWriteGuard:
         with pytest.raises(RuntimeError, match="another project"):
             write_mode(VNXMode.STARTER, str(other))
 
+    def test_test_isolation_guard_fires_when_project_id_unresolvable(
+        self, tmp_path, monkeypatch
+    ):
+        """w22/PR#1333: the test-isolation guard must fire even when
+        resolve_project_id() cannot resolve a project_id at all — exactly the
+        subprocess-with-a-cleaned-env scenario the guard exists for (no
+        VNX_PROJECT_ID, no reachable .vnx-project-id marker, no git remote).
+
+        Before the fix, ``_guard_mode_write_target`` returned on the
+        ``except RuntimeError: return`` branch before ever calling
+        ``refuse_real_central_store_write_under_pytest``, silently allowing
+        the write to land under the (mocked) real central store. RED on
+        43600f56.
+        """
+        fake_home = tmp_path / "home"
+        fake_home.mkdir()
+        no_git_cwd = tmp_path / "no_git_cwd"
+        no_git_cwd.mkdir()
+        central = fake_home / ".vnx-data" / "vnx-dev"
+        central.mkdir(parents=True)
+
+        monkeypatch.setenv("HOME", str(fake_home))
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+        monkeypatch.setenv("VNX_DATA_DIR_GUARD", "off")
+        monkeypatch.chdir(no_git_cwd)
+
+        # Sanity: this scenario really makes resolve_project_id() fail —
+        # otherwise this test would pass for the wrong reason (hitting a
+        # different guard branch instead of the RuntimeError-early-return gap).
+        from project_root import resolve_project_id
+        with pytest.raises(RuntimeError):
+            resolve_project_id()
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            write_mode(VNXMode.STARTER, str(central))
+
+        assert not (central / "mode.json").exists()
+
     def test_cleaned_env_subprocess_does_not_write_real_store(self, tmp_path):
         """OI-911 regression: a subprocess that loses VNX_DATA_DIR_EXPLICIT must
         not write mode.json into the resolved central store.

--- a/tests/test_vnx_setup.py
+++ b/tests/test_vnx_setup.py
@@ -5,7 +5,6 @@ Tests the setup flow: prereq check → init → doctor → register → next-ste
 """
 
 import json
-import os
 import sys
 from pathlib import Path
 from unittest.mock import patch, MagicMock
@@ -31,7 +30,7 @@ from vnx_setup import (
 # ---------------------------------------------------------------------------
 
 @pytest.fixture
-def vnx_env(tmp_path):
+def vnx_env(tmp_path, monkeypatch):
     """Create a minimal VNX project structure with paths dict."""
     project_root = tmp_path / "project"
     project_root.mkdir()
@@ -55,15 +54,16 @@ def vnx_env(tmp_path):
         "VNX_DB_DIR": str(data_dir / "database"),
     }
 
-    # Set env vars for vnx_mode to work
+    # Set env vars for vnx_mode to work. monkeypatch (not raw os.environ)
+    # so teardown restores whatever conftest's autouse isolation had pinned
+    # instead of deleting it outright — a raw os.environ.pop() here used to
+    # strip VNX_STATE_DIR for the rest of the session, causing later tests
+    # (e.g. tests/test_pr_recommendation_integration.py) to resolve a
+    # different state dir than their module-level frozen path expected.
     for k, v in paths.items():
-        os.environ[k] = v
+        monkeypatch.setenv(k, v)
 
     yield paths
-
-    # Cleanup env
-    for k in paths:
-        os.environ.pop(k, None)
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wat dit oplost

Twee tests schreven rechtstreeks naar de productie-store `~/.vnx-data/vnx-dev/`:

- `test_pr_dispatch_integration.py` zette staging-dispatches in `dispatches/staging/` (14 vervuilde bestanden staan daar nu)
- `vnx_mode.write_mode()` kon via zijn resolver-fallback de live `mode.json` van `operator` naar `starter` flippen, wat `dispatch`, `gate` en `dream` fleet-breed weggate-t

## De aanpak

`vnx_paths.refuse_real_central_store_write_under_pytest()` faalt luid wanneer code onder pytest op het punt staat naar de echte centrale store te schrijven.

Bewust aan te roepen vanaf **write-surfaces** vlak voor een schrijfactie, niet vanaf padresolvers: zuivere resolutie moet naar de echte store kunnen blijven wijzen (read-only tests toetsen dat), alleen een op handen zijnde WRITE is het gevaar. Overgenomen in `vnx_mode` en `pr_queue_manager`, plus een autouse-fixture in `tests/conftest.py`.

## Verificatie (door T0 nagemeten, niet uit het rapport overgenomen)

Op een verse worktree van `origin/main`:

| Meting | Uitkomst |
|---|---|
| `test_vnx_data_dir_real_store_guard.py` op kaal main | **4 failed**, 3 passed |
| Zelfde test met de fix | **7 passed** |
| De twee lekkende tests met de fix | 7 passed |
| `dispatches/staging/` voor en na die run | 14 -> 14 (onveranderd) |
| `mode.json` na die run | `operator` |

## Open punten

- Een brede `pytest tests/ --ignore=tests/f39` veiligheidssweep was nog niet klaar toen de worker eindigde. Guard-beschermd, dus geen veiligheidsrisico, alleen volledigheid.
- 259 van 927 testbestanden dragen geen isolatie-marker. Niet allemaal een risico (veel zijn pure logica), maar de klasse-brede guard vangt elk geval dat wél een echte writer construeert.
- OI-941 (resolver valt fail-open terug op vnx-dev vanuit een projectmap) is bewust buiten scope: dat is productie-resolutie, niet test-isolatie.

Gecommit door T0. De worker leverde een volledig rapport maar eindigde zonder commit, push of PR.

Dispatch-ID: 20260802-w19c-test-store-isolation