### PR TITLE
fix(ci): full history for profile-a checkout so check_pr_size resolves pinned SHAs (OI-838)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -13,6 +13,14 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        # Full history (fetch-depth: 0): the profile-a suite includes
+        # test_pre_merge_gate.py::TestCheckPRSize, which pins real commit
+        # SHAs (9e0813e2..5ab8fe8c) to verify merge-base range counting
+        # (OI-838). A depth-1 clone cannot resolve those refs and the test
+        # fails with a loud HOLD. Same pattern as the trace-token-check and
+        # slug-match-check jobs below.
+        with:
+          fetch-depth: 0
 
       - name: Setup Python
         uses: actions/setup-python@v5

--- a/tests/test_codex_adapter_prompt_assembly.py
+++ b/tests/test_codex_adapter_prompt_assembly.py
@@ -35,12 +35,13 @@ def _mock_collect(payload: dict, subprocess_run=None) -> str:
 
 def test_codex_build_prompt_uses_assembler_when_role_given(adapter: CodexAdapter) -> None:
     """When role= is given, _build_prompt must route through PromptAssembler."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("codex_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Fix the parser",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert isinstance(result, str)
     assert len(result) > len("Fix the parser"), "Assembler should expand prompt with L1+L2 context"
     assert "DISPATCH INSTRUCTION:" in result
@@ -52,11 +53,12 @@ def test_codex_build_prompt_uses_assembler_when_role_given(adapter: CodexAdapter
 
 def test_codex_build_prompt_fallback_to_raw_when_no_role(adapter: CodexAdapter) -> None:
     """When role= is None and dispatch_metadata is absent, _build_prompt returns raw instruction."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("codex_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Fix the parser",
             changed_files=[],
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert result == "Fix the parser"
 
 
@@ -66,12 +68,13 @@ def test_codex_build_prompt_fallback_to_raw_when_no_role(adapter: CodexAdapter) 
 
 def test_codex_prompt_includes_base_worker_rules(adapter: CodexAdapter) -> None:
     """Assembled codex prompt must include Layer 1 base worker rules (billing safety)."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("codex_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Do work",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     content_lower = result.lower()
     assert "billing" in content_lower or "anthropic" in content_lower, \
         "Layer 1 billing safety must appear in assembled codex prompt"
@@ -83,11 +86,12 @@ def test_codex_prompt_includes_base_worker_rules(adapter: CodexAdapter) -> None:
 
 def test_codex_prompt_includes_role_context(adapter: CodexAdapter) -> None:
     """Assembled codex prompt must include role-specific context for 'backend-developer'."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("codex_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Do work",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert "backend" in result.lower() or "backend-developer" in result.lower(), \
         "Role context for backend-developer must appear in assembled codex prompt"

--- a/tests/test_gemini_adapter_prompt_assembly.py
+++ b/tests/test_gemini_adapter_prompt_assembly.py
@@ -36,12 +36,13 @@ def _mock_collect(payload: dict, subprocess_run=None) -> str:
 
 def test_gemini_build_prompt_uses_assembler_when_role_given(adapter: GeminiAdapter) -> None:
     """When role= is given, _build_prompt must route through PromptAssembler."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("gemini_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Review the PR",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert isinstance(result, str)
     assert len(result) > len("Review the PR"), "Assembler should expand prompt with L1+L2 context"
     assert "---" in result
@@ -53,11 +54,12 @@ def test_gemini_build_prompt_uses_assembler_when_role_given(adapter: GeminiAdapt
 
 def test_gemini_build_prompt_fallback_to_raw_when_no_role(adapter: GeminiAdapter) -> None:
     """When role= is None and dispatch_metadata is absent, _build_prompt returns raw instruction."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("gemini_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Review the PR",
             changed_files=[],
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert result == "Review the PR"
 
 
@@ -67,12 +69,13 @@ def test_gemini_build_prompt_fallback_to_raw_when_no_role(adapter: GeminiAdapter
 
 def test_gemini_prompt_includes_base_worker_rules(adapter: GeminiAdapter) -> None:
     """Assembled gemini prompt must include Layer 1 base worker rules (billing safety)."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("gemini_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Do work",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     content_lower = result.lower()
     assert "billing" in content_lower or "anthropic" in content_lower, \
         "Layer 1 billing safety must appear in assembled gemini prompt"
@@ -84,11 +87,12 @@ def test_gemini_prompt_includes_base_worker_rules(adapter: GeminiAdapter) -> Non
 
 def test_gemini_prompt_includes_role_context(adapter: GeminiAdapter) -> None:
     """Assembled gemini prompt must include role-specific context for 'backend-developer'."""
-    with patch("vertex_ai_runner.collect_file_contents", side_effect=_mock_collect):
+    with patch("gemini_adapter.collect_file_contents", side_effect=_mock_collect) as m:
         result = adapter._build_prompt(
             instruction="Do work",
             changed_files=[],
             role="backend-developer",
         )
+    assert m.called, "collect_file_contents mock must fire (patch target is the consumer namespace)"
     assert "backend" in result.lower() or "backend-developer" in result.lower(), \
         "Role context for backend-developer must appear in assembled gemini prompt"


### PR DESCRIPTION
## Diagnose

`main` is rood sinds vanmiddag. Beide rode runs (`gh run list --branch main --workflow "VNX CI"` op 2026-08-02: 14:41 en 13:12 failure) falen op precies één test:

```
FAILED tests/test_pre_merge_gate.py::TestCheckPRSize::test_reports_lines_matching_real_merged_pr
AssertionError: assert 'HOLD' == 'GO'
```

De test pint historische SHA's (`check_pr_size(VNX_ROOT, base_ref="9e0813e2", head_ref="5ab8fe8c")`) en verwacht `GO` met 110 toegevoegde regels. `.github/workflows/vnx-ci.yml:15` gebruikte `actions/checkout@v4` zonder `fetch-depth` (depth 1). In die shallow clone bestaan de gepinde SHA's niet, de merge-base is niet te resolven, en `check_pr_size` geeft terecht `HOLD` in plaats van een stil verkeerd getal. Lokaal is de test groen en bestaan beide SHA's.

## Fix

`fetch-depth: 0` op de Profile A-checkout in `.github/workflows/vnx-ci.yml`, hetzelfde patroon als de `trace-token-check`- en `slug-match-check`-jobs in dat bestand.

## Weging checkout-kosten

- Voor (shallow, rode run `30752652284`): checkout-stap ~2s (14:41:14 → 14:41:16).
- Na (deze PR, full clone): gemeten uit de groene CI-run van deze PR (zie rapport).

Het extra payload van een full clone is de repo-pack (~47 MiB op deze machine). Meer dan 60s extra? Dan stel ik in het rapport een alternatief voor (`fetch-depth: 0` alleen op de test-job of gerichte `git fetch` van de twee SHA's) zonder dat nu door te voeren.

## Overige git-historie-afhankelijke tests

De verplichte grep over `tests/` leverde één test op die echte repo-historie pin: `tests/test_pre_merge_gate.py:770`. De andere hits bouwen eigen tmp-repos of stubben subprocess en zijn niet afhankelijk van de CI-checkout-diepte.

## Verificatie

- `pytest tests/test_pre_merge_gate.py` → 54 passed
- `pytest` over git-historie-adjacente files → 134 passed
- YAML-validatie: `yaml.safe_load` OK, profile-a checkout heeft `fetch-depth: 0`
- Deze PR moet een groene VNX CI-workflowconclusie halen (niet alleen groene vinkjes)