### PR TITLE
feat(providers): model-identiteit op één SSOT + de ketenlink op receipts

### DIFF
--- a/scripts/benchmark/field-tests/lane_calibration.yaml
+++ b/scripts/benchmark/field-tests/lane_calibration.yaml
@@ -48,8 +48,14 @@ cases:
     tier: t1_trivial
     n_files: 1
     expected_tier: tier-zero
-    expected_provider: local-gemma
-    expected_lane: mlx
+    expected_provider: codex
+    expected_lane: provider
+    note: >
+      tier-zero without DEEPSEEK_API_KEY falls back to Codex. Local Gemma route
+      preserved but unused until gemma-4-12b-integration ships (operator decision
+      2026-08-02). When DEEPSEEK_API_KEY is present, the route is deepseek-v4-flash
+      via claude_harness_keyed. See test_lane_calibration_field_test.py for explicit
+      coverage of both env branches.
 
   - task_id: "04_scorer_task"
     tier: t2_medium

--- a/scripts/lib/adapters/gemini_adapter.py
+++ b/scripts/lib/adapters/gemini_adapter.py
@@ -202,7 +202,7 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
                 start_new_session=True,
             )
         except OSError as exc:
-            yield {"type": "error", "data": {"reason": str(exc)}}
+            yield {"type": "error", "event_type": "error", "data": {"reason": str(exc)}}
             return
 
         if proc.stdin:
@@ -210,7 +210,7 @@ class GeminiAdapter(StreamingDrainerMixin, ProviderAdapter):
                 proc.stdin.write(prompt.encode("utf-8"))
                 proc.stdin.close()
             except BrokenPipeError:
-                yield {"type": "error", "data": {"reason": "stdin write failed (BrokenPipeError)"}}
+                yield {"type": "error", "event_type": "error", "data": {"reason": "stdin write failed (BrokenPipeError)"}}
                 return
 
         for canonical_event in self.drain_stream(

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -322,6 +322,44 @@ def _stamp_identity(receipt: Dict[str, Any], *, identity_cwd: Optional[Path] = N
         receipt["agent_id"] = identity.agent_id
 
 
+_CHAIN_LINK_ENV_FIELDS = (
+    ("VNX_PARENT_DISPATCH", "parent_dispatch"),
+    ("VNX_TASK_CLASS", "task_class"),
+    ("VNX_TIER_FROM", "tier_from"),
+    ("VNX_TIER_TO", "tier_to"),
+)
+
+
+def _stamp_model_identity(receipt: Dict[str, Any]) -> None:
+    """Normalize model to the canonical wave7_models.yaml key + chain-link env fallback.
+
+    dispatch-20260802-model-ssot-en-ketenlink: the door exports the chain-link
+    fields (parent_dispatch / task_class / tier_from / tier_to) as env vars that
+    the tmux worker pane inherits, so a worker-authored receipt lands the same
+    values the plan carried. Explicit caller-supplied fields are never
+    overwritten. The model string is normalized to its canonical registry key
+    (deepseek/deepseek-v4-pro -> deepseek-v4-pro, kimi-code/k3 -> kimi-k3,
+    claude-sonnet-5 -> sonnet-5, ...) so the ledger is groupable per model.
+    Best-effort: a normalizer failure leaves the raw string for the fail-closed
+    validator to judge.
+    """
+    for env_name, field in _CHAIN_LINK_ENV_FIELDS:
+        if receipt.get(field):
+            continue
+        env_val = (os.environ.get(env_name) or "").strip()
+        if env_val:
+            receipt[field] = env_val
+    raw = receipt.get("model")
+    if raw is None or str(raw).strip() == "":
+        return
+    try:
+        sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+        from providers.model_normalizer import normalize_model_name  # noqa: PLC0415
+        receipt["model"] = normalize_model_name(raw)
+    except Exception:  # noqa: BLE001 — normalization is best-effort; fail-closed validation still runs
+        log.debug("payload: model normalization skipped: %s", raw, exc_info=True)
+
+
 def _stamp_ingested_at(receipt: Dict[str, Any]) -> None:
     """Stamp the authoritative ingest time — ALWAYS set to now by this append
     layer, never preserved from a caller-supplied value.
@@ -370,6 +408,12 @@ def append_receipt_payload(
     receipts_file = _maybe_reroute_to_gate_stream(receipt, receipts_file)
     # Keep the resolved receipt path aligned with any gate-stream reroute.
     receipt_path = _resolve_receipts_file(receipts_file).expanduser().resolve()
+
+    # dispatch-20260802-model-ssot-en-ketenlink: normalize model to the
+    # canonical registry key + stamp the door's chain-link fields before the
+    # shared validator sees the receipt (the fail-closed model check runs in
+    # _validate_receipt).
+    _stamp_model_identity(receipt)
 
     # ADR-035 §9 PR-4 (fix-r1): pure classification of warnings[] (no side
     # effects — no OI-store writes, no counter increments) before the shared

--- a/scripts/lib/append_receipt_internals/validation.py
+++ b/scripts/lib/append_receipt_internals/validation.py
@@ -286,6 +286,10 @@ def _validate_receipt(receipt: Dict[str, Any]) -> str:
                 "Missing required key: dispatch_id",
             )
 
+    # dispatch-20260802-model-ssot-en-ketenlink: fail-closed model check —
+    # a worker dispatch-terminal receipt must name the model that ran.
+    _validate_model_present(receipt)
+
     _warn_if_review_gate_missing_dispatch_id(event_name, receipt)
 
     return event_name
@@ -300,6 +304,65 @@ def _is_completion_event(receipt: Dict[str, Any]) -> bool:
         "complete",
         "subprocess_completion",
     )
+
+
+# dispatch-20260802-model-ssot-en-ketenlink (fail-closed model): a DISPATCH
+# receipt (receipt_kind in the worker-dispatch set) must name a real model. The
+# old silent ``model: unknown`` (368 of the last 1019 receipts) made per-model
+# confidence impossible. Receipts whose producer has no model concept by
+# construction are explicitly exempt (measured: 133 of those 1019), never
+# silently blanked.
+#
+# Gated on ``receipt_kind`` — the closed set dispatch_identity.RECEIPT_KINDS —
+# not on event_type: the dispatch worker writers (governance_emit Path 1,
+# report_to_receipt_converter, SynthesizedLaneReceipt) all stamp kind
+# "dispatch"/"sub_dispatch" and are the writers that know the model field and
+# leave it "unknown". Non-dispatch kinds (test, state_mutation, review_gate,
+# ...) keep the old tolerance.
+_MODEL_REQUIRED_RECEIPT_KINDS = frozenset({"dispatch", "sub_dispatch"})
+
+# Sources that have no model concept by construction and must never be
+# silently blanked. The three measured producers from the dispatch
+# (vnx_governance / vnx_state / context_rotation) plus the two governance
+# CORRECTIVE writers (phantom_guard / pr_enforcement): their receipts override
+# a worker's false completion claim — dropping them on a missing model would
+# lose the rejection signal, which is worse than the fail-closed gain. They
+# still carry the dispatch model when the door exported one (best-effort).
+_MODEL_EXEMPT_SOURCES = frozenset({
+    "vnx_governance",
+    "vnx_state",
+    "context_rotation",
+    "phantom_guard",
+    "pr_enforcement",
+})
+
+
+def _validate_model_present(receipt: Dict[str, Any]) -> None:
+    """Fail closed on a dispatch receipt without a real model.
+
+    Mirrors the #1312 role-validation style: no model -> no receipt, raised
+    BEFORE anything is written. Sources with no model concept by construction
+    (vnx_governance / vnx_state / context_rotation) are exempt — the exemption
+    is explicit, never an empty ``model`` value.
+    """
+    receipt_kind = str(receipt.get("receipt_kind") or "").strip()
+    if receipt_kind not in _MODEL_REQUIRED_RECEIPT_KINDS:
+        return
+    source = str(receipt.get("source") or "").strip().lower()
+    if source in _MODEL_EXEMPT_SOURCES:
+        return
+    model = receipt.get("model")
+    if model is None or not str(model).strip() or str(model).strip().lower() in {
+        "unknown", "null", "none", "n/a", "na", "unset", "-",
+    }:
+        raise AppendReceiptError(
+            "missing_model",
+            EXIT_VALIDATION_ERROR,
+            f"receipt_kind={receipt_kind!r} source={source!r} carries no real "
+            "model; refusing to write (fail-closed — a worker dispatch receipt "
+            "must name the model that ran). Set model, or set source to one of "
+            f"{sorted(_MODEL_EXEMPT_SOURCES)} for a model-less producer.",
+        )
 
 
 def _is_subprocess_intermediate_completion(receipt: Dict[str, Any]) -> bool:

--- a/scripts/lib/cost_loader.py
+++ b/scripts/lib/cost_loader.py
@@ -25,12 +25,19 @@ _AVG_OUTPUT_TOKENS = 2_000
 # tests/test_smart_router_cost_aware.py calls compute_cost_per_call() with these exact retired
 # strings directly against the real wave7_models.yaml and must keep resolving. New keys for the
 # current model_ids are added alongside so real enrichment doesn't silently break post-rename.
+#
+# 2026-08-02 model-ssot-en-ketenlink: the 5-series registry keys (sonnet-5 / opus-5 /
+# fable-5) are now the canonical spellings; the current model_ids resolve to them, and the
+# missing claude-opus-5 / claude-fable-5 cost lookups are added so a smart_router decision
+# on the 5-series is not cost-blind.
 _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     "claude-sonnet-4-6": ("anthropic", "sonnet"),
-    "claude-sonnet-5": ("anthropic", "sonnet"),
+    "claude-sonnet-5": ("anthropic", "sonnet-5"),
     "claude-opus-4-6": ("anthropic", "opus"),
     "claude-opus-4-7": ("anthropic", "opus"),
-    "claude-opus-4-8": ("anthropic", "opus"),
+    "claude-opus-4-8": ("anthropic", "opus-4-8"),
+    "claude-opus-5": ("anthropic", "opus-5"),
+    "claude-fable-5": ("anthropic", "fable-5"),
     "claude-haiku-4-5": ("anthropic", "haiku"),
     "deepseek-v4-flash": ("deepseek", "deepseek-v4-flash"),
     "deepseek-v4-pro": ("deepseek", "deepseek-v4-pro"),

--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -165,6 +165,13 @@ def stage_spec_bundle(
     pr_id: Optional[str] = None,
     tags: tuple[str, ...] = (),
     data_dir: Optional[Path] = None,
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor
+    # this dispatch continues, the tier escalation, and the smart_router task
+    # class. Carried verbatim onto the spec; the door passes them to the receipt.
+    parent_dispatch: Optional[str] = None,
+    task_class: Optional[str] = None,
+    tier_from: Optional[str] = None,
+    tier_to: Optional[str] = None,
 ) -> Path:
     """Write a non-forgeable staged spec bundle; return the dispatch-spec.json path.
 
@@ -242,6 +249,11 @@ def stage_spec_bundle(
         "provider": _canonical_provider(provider).value,
         "model": model or None,
         "pr_id": pr_id or None,
+        # Chain-link fields (dispatch-20260802-model-ssot-en-ketenlink).
+        "task_class": (task_class or "").strip() or None,
+        "parent_dispatch": (parent_dispatch or "").strip() or None,
+        "tier_from": (tier_from or "").strip() or None,
+        "tier_to": (tier_to or "").strip() or None,
         "deadline_seconds": int(deadline_seconds),
         "base_ref": base_ref or "origin/main",
         "isolation": "worktree",
@@ -355,6 +367,10 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--model", default=None)
     parser.add_argument("--gate", default="")
     parser.add_argument("--pr-id", default=None, dest="pr_id")
+    parser.add_argument("--parent-dispatch", default=None, dest="parent_dispatch")
+    parser.add_argument("--task-class", default=None, dest="task_class")
+    parser.add_argument("--tier-from", default=None, dest="tier_from")
+    parser.add_argument("--tier-to", default=None, dest="tier_to")
     parser.add_argument("--deadline-seconds", type=int, default=3600, dest="deadline_seconds")
     parser.add_argument("--requires-mcp", action="store_true", dest="requires_mcp")
     parser.add_argument("--allow-headless", action="store_true", dest="allow_headless")
@@ -389,6 +405,10 @@ def main(argv: Optional[list] = None) -> int:
         model=args.model,
         gate=args.gate,
         pr_id=args.pr_id,
+        parent_dispatch=args.parent_dispatch,
+        task_class=args.task_class,
+        tier_from=args.tier_from,
+        tier_to=args.tier_to,
         deadline_seconds=args.deadline_seconds,
         requires_mcp=args.requires_mcp,
         allow_headless=args.allow_headless,

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -183,6 +183,10 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         task_class=(raw.get("task_class") or None),
         pr_id=(raw.get("pr_id") or None),
         track_id=(raw.get("track_id") or None),
+        # Chain-link (dispatch-20260802-model-ssot-en-ketenlink).
+        parent_dispatch=(raw.get("parent_dispatch") or None),
+        tier_from=(raw.get("tier_from") or None),
+        tier_to=(raw.get("tier_to") or None),
         deadline_seconds=int(raw.get("deadline_seconds", 3600)),
         base_ref=str(raw.get("base_ref", "origin/main")),
         isolation=Isolation(raw.get("isolation", "worktree")),
@@ -225,6 +229,14 @@ def _print_plan(plan: ExecutionPlan, fp: str) -> None:
     print(f"  billing:      {plan.billing}")
     print(f"  requires_mcp: {plan.requires_mcp}")
     print(f"  route_reason: {plan.route_reason}")
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): printed so a dry-run
+    # proves the spec fields landed on the plan.
+    if plan.parent_dispatch:
+        print(f"  parent_dispatch: {plan.parent_dispatch}")
+    if plan.task_class:
+        print(f"  task_class:   {plan.task_class}")
+    if plan.tier_from or plan.tier_to:
+        print(f"  tier:         {plan.tier_from or '-'} -> {plan.tier_to or '-'}")
     for w in plan.warnings:
         print(f"  [WARN] {w}")
 
@@ -401,7 +413,10 @@ def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
 # ---------------------------------------------------------------------------
 
 _DEFAULT_MODEL_PINS: dict[str, ModelPin] = {
-    "T0": ModelPin(model="opus", semantics="floor"),
+    # T0 falls back to the canonical opus-5 registry key (model-ssot-en-ketenlink);
+    # the provider_constraints.yaml t0-opus-only pin is the live SSOT and overrides
+    # this when readable.
+    "T0": ModelPin(model="opus-5", semantics="floor"),
     "T1": ModelPin(model="kimi-k3", semantics="default"),
     "T2": ModelPin(model="kimi-k3", semantics="default"),
     "T3": ModelPin(model="kimi-k3", semantics="default"),
@@ -1195,6 +1210,29 @@ def build_runtime_snapshot(
     # the registry is missing → compile_plan rejects every role (fail-closed).
     valid_roles = _discover_valid_roles(_resolve_repo_root() / "agents")
 
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): computed here,
+    # door-side (I/O + imports allowed), and passed through the snapshot so
+    # compile_plan stays pure. task_class comes from the spec when set, else the
+    # smart_router deterministic classifier (the existing vocabulary — never a
+    # second one). tier_to falls back to the model->tier reverse map so a
+    # dispatch that did not declare a tier still carries an escalation signal.
+    chain_task_class = (spec.task_class or "").strip() or None
+    if chain_task_class is None:
+        try:
+            from smart_router import classify_task  # noqa: PLC0415
+            chain_task_class = classify_task(vspec.instruction_text, spec.role)
+        except Exception:  # noqa: BLE001 — classifier is best-effort; default class is the safe fallback
+            chain_task_class = "01_code_generation"
+    chain_parent = (spec.parent_dispatch or "").strip() or None
+    chain_tier_from = (spec.tier_from or "").strip() or None
+    chain_tier_to = (spec.tier_to or "").strip() or None
+    if chain_tier_to is None:
+        try:
+            from providers.model_normalizer import tier_for_model  # noqa: PLC0415
+            chain_tier_to = tier_for_model(effective_model)
+        except Exception:  # noqa: BLE001 — tier reverse-map is best-effort
+            chain_tier_to = None
+
     return RuntimeSnapshot(
         constraint_verdicts=constraint_verdicts,
         staging_promoted=staging_promoted,
@@ -1202,6 +1240,10 @@ def build_runtime_snapshot(
         target_capable=target_capable,
         model_pins=snapshot_model_pins,
         valid_roles=valid_roles,
+        parent_dispatch=chain_parent,
+        task_class=chain_task_class,
+        tier_from=chain_tier_from,
+        tier_to=chain_tier_to,
     )
 
 
@@ -1411,6 +1453,24 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             if vspec.spec.track_id:
                 os.environ["VNX_CURRENT_TRACK_ID"] = vspec.spec.track_id
                 _persist_track_id(vspec.spec, state_dir=state_dir)
+
+            # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): export the
+            # resolved fields so the tmux worker pane (and any worker-authored
+            # receipt) inherits them — the receipt writers read these env vars as
+            # a fallback when the caller did not pass explicit values. Only set
+            # when present, so unrelated dispatches keep a clean env.
+            if plan.parent_dispatch:
+                os.environ["VNX_PARENT_DISPATCH"] = plan.parent_dispatch
+            if plan.task_class:
+                os.environ["VNX_TASK_CLASS"] = plan.task_class
+            if plan.tier_from:
+                os.environ["VNX_TIER_FROM"] = plan.tier_from
+            if plan.tier_to:
+                os.environ["VNX_TIER_TO"] = plan.tier_to
+            # The resolved model is exported too, so governance corrective
+            # receipts (phantom_guard / pr_enforcement) can record the model the
+            # dispatch ran without threading a parameter through every call site.
+            os.environ["VNX_CURRENT_MODEL"] = plan.model
 
         permit = issue_permit(plan)
         try:

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -69,6 +69,13 @@ class EnvelopeSpec:
     state_dir: Path
     data_dir: Path
     deadline_seconds: int = 900
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): threaded from the
+    # plan onto the receipt so the provider lane stamps the same values the
+    # door computed.
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
 
 
 @dataclass
@@ -1029,6 +1036,12 @@ def _govern(
                     deadline_seconds=spec.deadline_seconds,
                     failure_reason=_classification.get("failure_reason"),
                     failure_class=_classification.get("failure_class"),
+                    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink):
+                    # the door's values flow plan -> EnvelopeSpec -> receipt.
+                    parent_dispatch=spec.parent_dispatch,
+                    task_class=spec.task_class,
+                    tier_from=spec.tier_from,
+                    tier_to=spec.tier_to,
                 )
             except Exception as exc:
                 raise EnvelopeGovernError(
@@ -1152,6 +1165,11 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
         state_dir=spec.state_dir,
         data_dir=spec.data_dir,
         deadline_seconds=spec.deadline_seconds,
+        # Chain-link — carried through PREPARE unchanged.
+        parent_dispatch=spec.parent_dispatch,
+        task_class=spec.task_class,
+        tier_from=spec.tier_from,
+        tier_to=spec.tier_to,
     )
 
     # INTEGRITY — persist the enriched final prompt + verify raw+injections reconstruct it
@@ -1725,6 +1743,12 @@ def run_envelope_plan(
         state_dir=state_dir,
         data_dir=data_dir,
         deadline_seconds=plan.deadline_seconds,
+        # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): from the plan,
+        # which the door computed from the spec.
+        parent_dispatch=plan.parent_dispatch,
+        task_class=plan.task_class,
+        tier_from=plan.tier_from,
+        tier_to=plan.tier_to,
     )
 
     enriched_instruction = _prepare(spec)
@@ -1739,6 +1763,10 @@ def run_envelope_plan(
         state_dir=spec.state_dir,
         data_dir=spec.data_dir,
         deadline_seconds=spec.deadline_seconds,
+        parent_dispatch=spec.parent_dispatch,
+        task_class=spec.task_class,
+        tier_from=spec.tier_from,
+        tier_to=spec.tier_to,
     )
 
     # INTEGRITY — the bundle dir is the pending/<id>/ that hosts instruction.md.

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -188,6 +188,11 @@ def ensure_receipt(
 
     # ADR-012 worker-permission enforcement audit marker (only when flag ON).
     worker_enforcement = "enforced" if worker_permission_enforcement_enabled() else None
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the spec carries
+    # the fields when the door threaded them; otherwise the door's env vars the
+    # tmux pane inherited (the worker-authored receipt path reads the same env in
+    # append_receipt_internals.payload._stamp_model_identity). The model string
+    # is left for the append primitive to normalize.
     synthesized_receipt = SynthesizedLaneReceipt(
         dispatch_id=spec.dispatch_id,
         terminal_id=spec.terminal_id,
@@ -197,6 +202,12 @@ def ensure_receipt(
         contract_status=contract_status,
         permission_enforcement=permission_enforcement,
         role=_resolve_govern_role(spec),
+        parent_dispatch=(
+            spec.parent_dispatch or os.environ.get("VNX_PARENT_DISPATCH") or None
+        ),
+        task_class=spec.task_class or os.environ.get("VNX_TASK_CLASS") or None,
+        tier_from=spec.tier_from or os.environ.get("VNX_TIER_FROM") or None,
+        tier_to=spec.tier_to or os.environ.get("VNX_TIER_TO") or None,
         worker_permission_enforcement=worker_enforcement,
         report_path=str(report_path) if report_path is not None else None,
     ).to_dict()
@@ -239,6 +250,14 @@ class GovernSpec:
     # receipt-quality PR-2: a genuinely-set spec role also threads through into
     # govern-emitted receipts and report frontmatter (see _resolve_govern_role).
     role: Optional[str] = None
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): which dispatch
+    # this one continues, the tier escalation, and the task class. The tmux lane
+    # does not know these (the worker pane inherits them from the door's env);
+    # ensure_receipt falls back to the env when the spec does not carry them.
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
 
 
 @dataclass
@@ -549,6 +568,12 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         ),
     }
     _cost_usd = float(receipt_data.get("cost_usd") or 0.0)
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): resolve from the
+    # spec first, then the door's env vars (the tmux pane inherits them).
+    _parent_dispatch = spec.parent_dispatch or os.environ.get("VNX_PARENT_DISPATCH") or None
+    _task_class = spec.task_class or os.environ.get("VNX_TASK_CLASS") or None
+    _tier_from = spec.tier_from or os.environ.get("VNX_TIER_FROM") or None
+    _tier_to = spec.tier_to or os.environ.get("VNX_TIER_TO") or None
     frontmatter = {
         "schema_version": 1,
         "dispatch_id": dispatch_id,
@@ -560,7 +585,9 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         # receipt-quality PR-2: resolved dispatch identity, not the hardcoded
         # fake default the converter would otherwise drop/misread.
         "role": _resolve_govern_role(spec),
-        "task_class": "implementation",
+        # dispatch-20260802-model-ssot-en-ketenlink: real task class instead of
+        # the old unconditional "implementation"; chain-link stamped when known.
+        "task_class": _task_class or "implementation",
         "pr_id": spec.pr_id or "none",
         "duration_seconds": float(raw.duration_seconds),
         "exit_code": _exit_code,
@@ -578,6 +605,12 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
         "contract_status": contract_status,
         "permission_enforcement": permission_enforcement,
     }
+    if _parent_dispatch is not None:
+        frontmatter["parent_dispatch"] = _parent_dispatch
+    if _tier_from is not None:
+        frontmatter["tier_from"] = _tier_from
+    if _tier_to is not None:
+        frontmatter["tier_to"] = _tier_to
 
     status = (raw.receipt or {}).get("status", "unknown") if raw.receipt else "timeout"
 

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -68,6 +68,14 @@ class RuntimeSnapshot:
     # membership: an empty set rejects every role, so an undiscoverable registry
     # fails closed instead of silently accepting anything.
     valid_roles: Optional[frozenset[str]] = None
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor
+    # dispatch this one continues, the tier escalation, and the smart_router
+    # task class. Computed by the door (build_runtime_snapshot) and passed in so
+    # compile_plan stays pure — it only copies them onto the plan.
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------
@@ -101,6 +109,13 @@ class ExecutionPlan:
     role: Optional[str] = None          # carried from DispatchSpec for the phantom-guard review
                                         # exemption (codex P0.2 F2). NOT in digest() — advisory only,
                                         # must not perturb the permit fingerprint.
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): advisory receipt
+    # metadata, NOT in digest() — like ``role``, it must not perturb the permit
+    # fingerprint. parent_dispatch / tier_from / tier_to / task_class.
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
     requires_mcp: bool = False          # OI-865: True keeps the worker's ambient MCP config instead
                                         # of the force-empty scoped posture. Default False is the
                                         # choice for a MISSING spec field: DispatchSpec.requires_mcp
@@ -340,6 +355,13 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         instruction_file=spec.instruction_file,
         route_reason=",".join(fired),
         role=spec.role,
+        # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): copied from the
+        # door-computed snapshot so the receipt can say which dispatch this one
+        # continues and on which tier.
+        parent_dispatch=snapshot.parent_dispatch,
+        task_class=snapshot.task_class,
+        tier_from=snapshot.tier_from,
+        tier_to=snapshot.tier_to,
         instruction_sha256=vspec.instruction_sha256,
         warnings=tuple(warnings),
     )

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -94,6 +94,14 @@ class DispatchSpec:
     task_class: Optional[str] = None
     pr_id: Optional[str] = None
     track_id: Optional[str] = None  # structural link to a tracks-table row (TL-D1); validated at the door
+    # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor
+    # this dispatch continues (retry / fix-forward / escalation), the tier
+    # escalation signal (tier_from = parent's tier, tier_to = this tier), and
+    # the smart_router task class. All advisory — carried onto the plan and the
+    # receipt, never part of the permit fingerprint.
+    parent_dispatch: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
     deadline_seconds: int = 3600
     base_ref: str = "origin/main"
     isolation: Isolation = Isolation.WORKTREE
@@ -134,6 +142,10 @@ _ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.\-]{0,127}$")
 _BLOCKED_FIRST_COMPONENTS = frozenset({".git", ".vnx-data"})
 
 _VALID_TARGET_SLOTS = frozenset({"T0", "T1", "T2", "T3"})
+
+# Cost-tier vocabulary (mirrors providers.smart_router.cost_tier) — the
+# escalation signal on receipts must come from this closed set.
+_VALID_TIERS = frozenset({"tier-zero", "tier-low", "tier-mid", "tier-high"})
 
 
 def _validate_dispatch_path(dp: DispatchPath) -> Optional[str]:
@@ -298,6 +310,24 @@ def validate(
         _track_id = spec.track_id.strip()
         if not _track_id or not _ID_RE.match(_track_id):
             return Reject("bad-track-id", f"track_id {spec.track_id!r} does not match id regex")
+
+    # Rule 14 — chain-link format (dispatch-20260802-model-ssot-en-ketenlink).
+    # parent_dispatch must be a well-formed dispatch id when present; tier values
+    # must come from the cost-tier vocabulary so the receipt's escalation signal
+    # is joinable (never free-text).
+    if spec.parent_dispatch is not None:
+        _parent = spec.parent_dispatch.strip()
+        if not _parent or not _ID_RE.match(_parent):
+            return Reject(
+                "bad-parent-dispatch",
+                f"parent_dispatch {spec.parent_dispatch!r} does not match id regex",
+            )
+    for _tier_field, _tier_val in (("tier_from", spec.tier_from), ("tier_to", spec.tier_to)):
+        if _tier_val is not None and _tier_val.strip() not in _VALID_TIERS:
+            return Reject(
+                "bad-tier-value",
+                f"{_tier_field} {_tier_val!r} is not one of {sorted(_VALID_TIERS)}",
+            )
 
     return ValidatedSpec(
         spec=spec,

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -104,6 +104,10 @@ def emit_dispatch_receipt(
     role_tier: Optional[str] = None,
     role_not_applied_reason: Optional[str] = None,
     role_source_path: Optional[str] = None,
+    parent_dispatch: Optional[str] = None,
+    task_class: Optional[str] = None,
+    tier_from: Optional[str] = None,
+    tier_to: Optional[str] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -195,6 +199,27 @@ def emit_dispatch_receipt(
     """
     _validate_provider(provider)
 
+    # dispatch-20260802-model-ssot-en-ketenlink: model identity is normalized to
+    # the canonical wave7_models.yaml key here, at the receipt boundary — the
+    # same model can no longer land in the ledger under several spellings
+    # (deepseek/deepseek-v4-pro vs deepseek-v4-pro, kimi-code/k3 vs kimi-k3,
+    # claude-sonnet-5 vs sonnet-5). Unmapped strings pass through unchanged and
+    # are caught by the fail-closed model validator downstream.
+    try:
+        from providers.model_normalizer import normalize_model_name  # noqa: PLC0415
+        model = normalize_model_name(model)
+    except Exception:  # noqa: BLE001 — a normalizer failure must never block receipt emission
+        logger.debug("emit_dispatch_receipt: model normalization failed dispatch=%s", dispatch_id, exc_info=True)
+
+    # Chain-link fallback: the caller may not know the fields (the tmux worker
+    # path writes its own receipt via append_receipt_payload and inherits them
+    # from the door's env); the door exports them so every lane lands the same
+    # value. Explicit kwargs win over env.
+    parent_dispatch = parent_dispatch or os.environ.get("VNX_PARENT_DISPATCH") or None
+    task_class = task_class or os.environ.get("VNX_TASK_CLASS") or None
+    tier_from = tier_from or os.environ.get("VNX_TIER_FROM") or None
+    tier_to = tier_to or os.environ.get("VNX_TIER_TO") or None
+
     # Receipt-quality PR-B1: backfill token_usage for the claude-harness lanes
     # from the local Claude Code session transcript when the caller has nothing
     # usable (no live usage API on the subscription lane). Only ever tightens
@@ -256,6 +281,10 @@ def emit_dispatch_receipt(
         role_tier=role_tier,
         role_not_applied_reason=role_not_applied_reason,
         role_source_path=role_source_path,
+        parent_dispatch=parent_dispatch,
+        task_class=task_class,
+        tier_from=tier_from,
+        tier_to=tier_to,
     ).to_dict()
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"

--- a/scripts/lib/phantom_guard.py
+++ b/scripts/lib/phantom_guard.py
@@ -41,6 +41,7 @@ were spent). Reviews are exempt; a legitimate no-op delivery uses VNX_OVERRIDE_P
 from __future__ import annotations
 
 import logging
+import os
 import subprocess
 from dataclasses import dataclass
 from pathlib import Path
@@ -384,6 +385,9 @@ def record_phantom_if_any(
                     "phantom_reason": verdict.reason,
                     "source": "phantom_guard",
                     "synthesized": False,
+                    # dispatch-20260802-model-ssot-en-ketenlink: carry the dispatch
+                    # model when the door exported it (best-effort; exempt source).
+                    "model": os.environ.get("VNX_CURRENT_MODEL") or None,
                     "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
                 },
                 receipts_file=str(receipts_file),
@@ -427,6 +431,7 @@ def record_guard_error(
                 "guard_error": str(error),
                 "source": "phantom_guard",
                 "synthesized": False,
+                "model": os.environ.get("VNX_CURRENT_MODEL") or None,
                 "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             },
             receipts_file=str(receipts_file),

--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -30,6 +30,7 @@ gh_pr_ensure).
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -128,6 +129,9 @@ def _record_corrective_receipt(
                 "branch": branch,
                 "source": "pr_enforcement",
                 "synthesized": False,
+                # dispatch-20260802-model-ssot-en-ketenlink: carry the dispatch
+                # model when the door exported it (best-effort; exempt source).
+                "model": os.environ.get("VNX_CURRENT_MODEL") or None,
                 "timestamp": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
             },
             receipts_file=str(receipts_file),

--- a/scripts/lib/providers/model_normalizer.py
+++ b/scripts/lib/providers/model_normalizer.py
@@ -16,6 +16,7 @@ Canonical name = the registry key (e.g. ``opus-5``, ``sonnet-5``,
   claude-opus-4-8               -> opus-4-8
   claude-opus-5                 -> opus-5
   claude-sonnet-5               -> sonnet-5
+  claude-sonnet-4-6             -> sonnet-4-6
   claude-fable-5                -> fable-5
 
 Unknown/unmapped strings pass through unchanged — the caller decides how to
@@ -42,6 +43,16 @@ _UNKNOWN_SENTINELS = frozenset({"", "unknown", "null", "none", "n/a", "na", "uns
 # versioned key names exactly one model generation, the unversioned one names
 # a moving default.
 _VERSIONED_KEY_RE = re.compile(r"-\d")
+
+# Provider prefix "claude-<family>" for a generation the registry does not
+# carry verbatim (retired ids like claude-sonnet-4-6, or bare-family shorthand
+# like claude-sonnet): the prefix is stripped so the result takes the same
+# family-version form as claude-opus-4-8 -> opus-4-8. Explicit aliases and
+# litellm_name-derived aliases still win (claude-sonnet-5 -> sonnet-5,
+# claude-haiku-4-5 -> haiku); this regex is the final fallback, and it is
+# deliberately restricted to the known families so the legacy 3.x naming
+# (claude-3-5-sonnet) is never mangled.
+_CLAUDE_FAMILY_RE = re.compile(r"^claude-(opus|sonnet|haiku|fable)(?:-|$)")
 
 # Explicit aliases the registry cannot derive from litellm_name/cli_model_arg
 # (common shorthand the operator uses, or dated-suffix variants):
@@ -178,6 +189,20 @@ def normalize_model_name(model: Optional[str]) -> str:
             return keys[stripped]
         if stripped in aliases:
             return aliases[stripped]
+
+    # Provider-prefixed "claude-<family>..." the registry does not carry
+    # verbatim (retired generation ids): strip the prefix so claude-sonnet-4-6
+    # and claude-opus-4-8 normalize to the same family-version form (only the
+    # opus id had a registry entry to strip its prefix — sonnet-4-6 passed
+    # through intact, which is the inconsistency this fixes). Re-resolve the
+    # stripped form (claude-fable -> fable -> fable-5); fall back to it
+    # verbatim when it is not itself a registry key (sonnet-4-6 is a retired
+    # id, not a key).
+    if _CLAUDE_FAMILY_RE.match(norm):
+        stripped = norm[len("claude-"):]
+        if stripped:
+            resolved = normalize_model_name(stripped)
+            return resolved or stripped
 
     return raw
 

--- a/scripts/lib/providers/model_normalizer.py
+++ b/scripts/lib/providers/model_normalizer.py
@@ -1,0 +1,222 @@
+"""model_normalizer.py — canonical model-name SSOT resolver.
+
+One place that maps every incoming model variant to the canonical registry key
+from ``wave7_models.yaml`` (the single source of truth for model identity).
+Receipt writers and routing code call ``normalize_model_name()`` instead of
+carrying their own spelling, so the same model can no longer land in the
+ledger under three names.
+
+Canonical name = the registry key (e.g. ``opus-5``, ``sonnet-5``,
+``deepseek-v4-pro``, ``kimi-k3``). Variants are matched against registry keys,
+``litellm_name``, ``cli_model_arg``, and their provider-prefix-stripped forms:
+
+  deepseek/deepseek-v4-pro      -> deepseek-v4-pro
+  moonshot/kimi-k2-0905-preview -> kimi-k2-0905-default
+  kimi-code/k3                  -> kimi-k3
+  claude-opus-4-8               -> opus-4-8
+  claude-opus-5                 -> opus-5
+  claude-sonnet-5               -> sonnet-5
+  claude-fable-5                -> fable-5
+
+Unknown/unmapped strings pass through unchanged — the caller decides how to
+treat them (receipt validation fails closed on them; routing rejects them
+with model-not-in-current-registry).
+
+``tier_for_model()`` is the deterministic reverse map of
+``tier_routing.resolve_tier_route``: model -> cost tier. It is the
+escalation signal that stamps ``tier_to`` on a receipt when the spec did not
+carry one.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Dict, Optional
+
+_LIB_DIR_RE = __file__  # pragma: no cover — kept for symmetry with sibling modules
+
+_UNKNOWN_SENTINELS = frozenset({"", "unknown", "null", "none", "n/a", "na", "unset", "-"})
+
+# Registry keys that carry a version suffix ("opus-4-8", "sonnet-5") are the
+# canonical spelling over their unversioned alias ("opus", "sonnet"): the
+# versioned key names exactly one model generation, the unversioned one names
+# a moving default.
+_VERSIONED_KEY_RE = re.compile(r"-\d")
+
+# Explicit aliases the registry cannot derive from litellm_name/cli_model_arg
+# (common shorthand the operator uses, or dated-suffix variants):
+#   - "fable" is the operator's shorthand for claude-fable-5 (only "fable-5"
+#     exists as a key; a bare "fable" is not otherwise resolvable).
+#   - "claude-haiku-4-5" is the undated alias of
+#     anthropic/claude-haiku-4-5-20251001 (the dated full id is the only
+#     litellm_name in the registry).
+_EXPLICIT_ALIASES: Dict[str, str] = {
+    "fable": "fable-5",
+    "claude-haiku-4-5": "haiku",
+    "claude-fable-5": "fable-5",
+}
+
+_registry_cache: Optional[Dict] = None
+_alias_cache: Optional[Dict[str, str]] = None
+_keys_cache: Optional[Dict[str, str]] = None
+
+
+def _load_registry() -> Dict:
+    """Lazy-load the wave7 registry (provider_registry.load)."""
+    global _registry_cache  # noqa: PLW0603
+    if _registry_cache is None:
+        from providers import provider_registry  # noqa: PLC0415
+        _registry_cache = provider_registry.load()
+    return _registry_cache
+
+
+def _norm(value: Optional[str]) -> str:
+    return (value or "").strip().lower()
+
+
+def _best_canonical_key(alias: str, candidates: list) -> str:
+    """Pick the canonical key for an alias from a list of candidate keys.
+
+    Deterministic preference:
+      1. the alias itself when it is already a key,
+      2. a versioned key over an unversioned one (``opus-4-8`` beats ``opus``),
+      3. lexicographically smallest (stable tiebreak).
+    """
+    if alias in candidates:
+        return alias
+    versioned = [c for c in candidates if _VERSIONED_KEY_RE.search(c)]
+    pool = versioned if versioned else candidates
+    return min(pool)
+
+
+def _build_alias_map() -> Dict[str, str]:
+    """Build alias -> canonical registry key from the loaded registry.
+
+    For every provider/model entry, these aliases resolve to the model key:
+      - the registry key itself,
+      - the full ``litellm_name`` and ``cli_model_arg`` values,
+      - the part of ``litellm_name`` after the last ``/`` (so
+        ``deepseek/deepseek-v4-pro`` and ``anthropic/claude-opus-4-8`` resolve
+        without knowing the provider prefix).
+    """
+    alias_sets: Dict[str, list] = {}
+    for cfg in _load_registry().values():
+        for key, entry in (getattr(cfg, "models", None) or {}).items():
+            key_norm = _norm(key)
+            if not key_norm:
+                continue
+            aliases = {key_norm}
+            litellm = _norm(getattr(entry, "litellm_name", "") or "")
+            if litellm:
+                aliases.add(litellm)
+                if "/" in litellm:
+                    aliases.add(litellm.rsplit("/", 1)[-1])
+            cli_arg = _norm(getattr(entry, "cli_model_arg", "") or "")
+            if cli_arg:
+                aliases.add(cli_arg)
+            for alias in aliases:
+                alias_sets.setdefault(alias, []).append(key_norm)
+
+    result: Dict[str, str] = {}
+    for alias, candidates in alias_sets.items():
+        result[alias] = _best_canonical_key(alias, candidates)
+    result.update(_EXPLICIT_ALIASES)
+    return result
+
+
+def _alias_map() -> Dict[str, str]:
+    global _alias_cache  # noqa: PLW0603
+    if _alias_cache is None:
+        _alias_cache = _build_alias_map()
+    return _alias_cache
+
+
+def _key_map() -> Dict[str, str]:
+    """Registry key -> key lookup (case-insensitive)."""
+    global _keys_cache  # noqa: PLW0603
+    if _keys_cache is None:
+        keys: Dict[str, str] = {}
+        for cfg in _load_registry().values():
+            for key in (getattr(cfg, "models", None) or {}).keys():
+                keys.setdefault(_norm(key), key)
+        _keys_cache = keys
+    return _keys_cache
+
+
+def canonical_model_names() -> set:
+    """The set of canonical registry keys (case-insensitive)."""
+    return set(_key_map().values()) | set(_alias_map().values())
+
+
+def normalize_model_name(model: Optional[str]) -> str:
+    """Map a model variant to its canonical registry key.
+
+    Returns the input unchanged (trimmed) when it cannot be resolved — an
+    unknown model string is the caller's problem to reject, never silently
+    rewritten here.
+    """
+    if not model:
+        return ""
+    raw = str(model).strip()
+    norm = _norm(raw)
+    if not norm or norm in _UNKNOWN_SENTINELS:
+        return raw
+
+    keys = _key_map()
+    if norm in keys:
+        return keys[norm]
+
+    aliases = _alias_map()
+    if norm in aliases:
+        return aliases[norm]
+
+    # Provider-prefixed form the registry does not carry verbatim: retry on the
+    # part after the last "/" (mirrors constraint_enforcer._model_aliases).
+    if "/" in norm:
+        stripped = norm.rsplit("/", 1)[-1]
+        if stripped in keys:
+            return keys[stripped]
+        if stripped in aliases:
+            return aliases[stripped]
+
+    return raw
+
+
+def is_unknown_model(model: Optional[str]) -> bool:
+    """True when the model is absent or an explicit unknown sentinel.
+
+    Receipt validation uses this to fail closed on a worker receipt that does
+    not name a real model (``model: unknown`` is the current silent gap).
+    """
+    if not model:
+        return True
+    return _norm(str(model)) in _UNKNOWN_SENTINELS
+
+
+def tier_for_model(model: Optional[str]) -> Optional[str]:
+    """Reverse-map a model to its cost tier (deterministic).
+
+    Mirrors ``tier_routing.resolve_tier_route``: tier-high <- fable/opus,
+    tier-mid <- sonnet, tier-low <- deepseek/kimi, tier-zero <- local gemma.
+    Returns None for an unresolvable model string.
+    """
+    norm = _norm(model)
+    if not norm or norm in _UNKNOWN_SENTINELS:
+        return None
+    if any(token in norm for token in ("fable", "opus")):
+        return "tier-high"
+    if "sonnet" in norm:
+        return "tier-mid"
+    if any(token in norm for token in ("deepseek", "kimi")):
+        return "tier-low"
+    if any(token in norm for token in ("gemma", "ollama")):
+        return "tier-zero"
+    return None
+
+
+__all__ = [
+    "canonical_model_names",
+    "is_unknown_model",
+    "normalize_model_name",
+    "tier_for_model",
+]

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -52,11 +52,13 @@ constraints:
     rule: require_route
     required_route:
       role: T0
-      model: claude-opus-4-8
+      model: opus-5  # canonical registry key (wave7_models.yaml) — T0 runs Opus 5
     reason: >-
       T0 orchestrator performs gate evaluation across the full NDJSON ledger
       under multi-PR concurrency. Sonnet-grade reasoning regresses on missed
       gates; downgrade is only acceptable with explicit operator approval.
+      Model value updated 2026-08-02 from the stale claude-opus-4-8 string to
+      the canonical opus-5 registry key (model-ssot-en-ketenlink).
     enforcement: code_warn
     audit_severity: warn
     override_allowed: true

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -1,7 +1,10 @@
 """tier_routing.py — Map cost tiers to provider/lane routing specs.
 
 Tier→provider mappings (honoring provider_constraints.yaml):
-  tier-zero → local Gemma e4b via MLX; fallback Ollama
+  tier-zero → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
+               (DEEPSEEK_API_KEY required); fallback Codex via provider lane.
+               Local-gemma route preserved but unused — reactivate when
+               gemma-4-12b-integration ships.
   tier-low  → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
                (DEEPSEEK_API_KEY required) OR Kimi via CLI (kimi-via-cli-only
                constraint)
@@ -43,20 +46,29 @@ class TierRoute:
     fallback: Optional["TierRoute"] = None
 
 
-_ROUTE_ZERO_FALLBACK = TierRoute(
-    tier=TIER_ZERO,
-    provider="ollama",
-    model="gemma:4b",
-    lane="ollama",
-)
+# ── tier-zero route ──
+# Operator decision 2026-08-02: local models are skipped until the
+# gemma-4-12b-integration track ships — DeepSeek flash via claude-harness is
+# the tier-zero entry route, falling back to Codex via provider lane when
+# DEEPSEEK_API_KEY is absent. resolve_tier_route() builds the route on the fly
+# so the tier field is correct in every return value.
 
-_ROUTE_ZERO = TierRoute(
-    tier=TIER_ZERO,
-    provider="local-gemma",
-    model="gemma-4b-e4b-mlx",
-    lane="mlx",
-    fallback=_ROUTE_ZERO_FALLBACK,
-)
+# Preserved but unused: local Gemma route. Reactivate when gemma-4-12b-integration
+# ships (queued track). The Gemma chain (primary + Ollama fallback) is intact below
+# but never returned by resolve_tier_route.
+# _ROUTE_LOCAL_GEMMA_FALLBACK = TierRoute(
+#     tier=TIER_ZERO,
+#     provider="ollama",
+#     model="gemma:4b",
+#     lane="ollama",
+# )
+# _ROUTE_LOCAL_GEMMA = TierRoute(
+#     tier=TIER_ZERO,
+#     provider="local-gemma",
+#     model="gemma-4b-e4b-mlx",
+#     lane="mlx",
+#     fallback=_ROUTE_LOCAL_GEMMA_FALLBACK,
+# )
 
 _ROUTE_KIMI = TierRoute(
     tier=TIER_LOW,
@@ -92,13 +104,35 @@ def _deepseek_available(env: dict) -> bool:
 def resolve_tier_route(tier: str, env: Optional[dict] = None) -> TierRoute:
     """Resolve a cost tier to a TierRoute.
 
-    For tier-low: prefers DeepSeek claude-harness (key-auth) when DEEPSEEK_API_KEY
-    is present, falls back to Kimi CLI. Unknown tier strings default to tier-high.
+    For tier-zero: prefers DeepSeek claude-harness (key-auth) when DEEPSEEK_API_KEY
+    is present, falls back to Codex via provider lane (operator decision 2026-08-02:
+    local models skipped until gemma-4-12b-integration ships). For tier-low:
+    prefers DeepSeek claude-harness, falls back to Kimi CLI. Unknown tier strings
+    default to tier-high.
     """
     _env = env if env is not None else dict(os.environ)
 
     if tier == TIER_ZERO:
-        return _ROUTE_ZERO
+        if _deepseek_available(_env):
+            return TierRoute(
+                tier=tier,
+                provider="deepseek",
+                model="deepseek-v4-flash",  # deepseek-chat discontinued 2026-07-24
+                lane="claude_harness_keyed",
+                env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
+                fallback=TierRoute(
+                    tier=tier,
+                    provider="codex",
+                    model="gpt-5.5",
+                    lane="provider",
+                ),
+            )
+        return TierRoute(
+            tier=tier,
+            provider="codex",
+            model="gpt-5.5",
+            lane="provider",
+        )
 
     if tier == TIER_LOW:
         if _deepseek_available(_env):

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -5,8 +5,15 @@ Tier→provider mappings (honoring provider_constraints.yaml):
   tier-low  → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
                (DEEPSEEK_API_KEY required) OR Kimi via CLI (kimi-via-cli-only
                constraint)
-  tier-mid  → claude-sonnet-4-6
-  tier-high → claude-opus-4-8
+  tier-mid  → sonnet-5  (canonical registry key — see wave7_models.yaml)
+  tier-high → opus-5    (canonical registry key — see wave7_models.yaml)
+
+Model names here are canonical registry keys from wave7_models.yaml, never
+free-form strings: the registry is the single source of truth for model
+identity (dispatch-20260802-model-ssot-en-ketenlink). The previous 4-series
+ids (claude-sonnet-4-6 / claude-opus-4-8) were not registry keys and would
+reject with model-not-in-current-registry the moment tier-mid/tier-high
+actually routed; the fleet now runs the 5-series.
 
 Constraint references (provider_constraints.yaml):
   kimi-via-cli-only: Kimi must use lane='kimi_cli', never via=api/moonshot
@@ -61,14 +68,14 @@ _ROUTE_KIMI = TierRoute(
 _ROUTE_MID = TierRoute(
     tier=TIER_MID,
     provider="claude",
-    model="claude-sonnet-4-6",
+    model="sonnet-5",  # canonical registry key (wave7_models.yaml)
     lane="tmux_interactive",
 )
 
 _ROUTE_HIGH = TierRoute(
     tier=TIER_HIGH,
     provider="claude",
-    model="claude-opus-4-8",
+    model="opus-5",  # canonical registry key (wave7_models.yaml)
     lane="tmux_interactive",
 )
 

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -55,6 +55,39 @@ providers:
         supports_streaming: true
         supports_tool_calls: true
         task_classes: ["coding", "fast"]
+      # 5-series (dispatch-20260802-model-ssot-en-ketenlink): Sonnet 5, Opus 5 and
+      # Fable 5 now run in the fleet (operator + T0 run Opus 5; Fable 5 is the top
+      # rung of the climb) but were absent from the registry. Model ids + prices
+      # verified 2026-08-02 against the Anthropic first-party catalog: Sonnet 5
+      # $3/$15 per MTok, Opus 5 $5/$25, Fable 5 $10/$50. Context/max-output are the
+      # API ceilings (1M context / 128K output).
+      sonnet-5:
+        litellm_name: "anthropic/claude-sonnet-5"
+        cost_input_per_mtok: 3.00
+        cost_output_per_mtok: 15.00
+        max_tokens: 128000
+        context_window: 1000000
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding", "review", "analysis"]
+      opus-5:
+        litellm_name: "anthropic/claude-opus-5"
+        cost_input_per_mtok: 5.00
+        cost_output_per_mtok: 25.00
+        max_tokens: 128000
+        context_window: 1000000
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding-premium", "review", "analysis"]
+      fable-5:
+        litellm_name: "anthropic/claude-fable-5"
+        cost_input_per_mtok: 10.00
+        cost_output_per_mtok: 50.00
+        max_tokens: 128000
+        context_window: 1000000
+        supports_streaming: true
+        supports_tool_calls: true
+        task_classes: ["coding-premium", "review", "analysis"]
   openai:
     enabled: true
     api_key_env: OPENAI_API_KEY

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -143,6 +143,17 @@ class ReceiptV2:
     role_tier: Optional[str] = None
     role_not_applied_reason: Optional[str] = None
     role_source_path: Optional[str] = None
+    # dispatch-20260802-model-ssot-en-ketenlink (chain-link): the receipt says
+    # WHICH dispatch this one continues. parent_dispatch is the id of the
+    # retried/fix-forward/escalated predecessor; tier_from/tier_to record an
+    # escalation (a tier change between the predecessor and this dispatch);
+    # task_class is the deterministic smart_router class of the work. Each is
+    # stamped only when known (None omits — the ledger distinguishes "not a
+    # retry" from "retry, tier unknown").
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
 
     def __post_init__(self) -> None:
         # Receipt-quality PR-3: the closed-set lint lives in the contract now
@@ -223,6 +234,17 @@ class ReceiptV2:
             receipt["role_not_applied_reason"] = self.role_not_applied_reason
         if self.role_source_path is not None:
             receipt["role_source_path"] = self.role_source_path
+        # Chain-link stamps (dispatch-20260802-model-ssot-en-ketenlink) —
+        # conditional like the other optional fields: a non-retry receipt omits
+        # parent_dispatch entirely.
+        if self.parent_dispatch is not None:
+            receipt["parent_dispatch"] = self.parent_dispatch
+        if self.task_class is not None:
+            receipt["task_class"] = self.task_class
+        if self.tier_from is not None:
+            receipt["tier_from"] = self.tier_from
+        if self.tier_to is not None:
+            receipt["tier_to"] = self.tier_to
         return receipt
 
 
@@ -256,6 +278,12 @@ class SynthesizedLaneReceipt:
     provider: str = "claude"
     sub_provider: str = "anthropic"
     timestamp: Optional[str] = None  # None -> stamped with now at construction
+    # Chain-link fields (dispatch-20260802-model-ssot-en-ketenlink) — see
+    # ReceiptV2 for semantics. Conditionally stamped.
+    parent_dispatch: Optional[str] = None
+    task_class: Optional[str] = None
+    tier_from: Optional[str] = None
+    tier_to: Optional[str] = None
     # Conditionally stamped (is-not-None).
     worker_permission_enforcement: Optional[str] = None
     report_path: Optional[str] = None
@@ -292,6 +320,15 @@ class SynthesizedLaneReceipt:
             receipt["worker_permission_enforcement"] = self.worker_permission_enforcement
         if self.report_path is not None:
             receipt["report_path"] = self.report_path
+        # Chain-link stamps — conditional like the other optional fields.
+        if self.parent_dispatch is not None:
+            receipt["parent_dispatch"] = self.parent_dispatch
+        if self.task_class is not None:
+            receipt["task_class"] = self.task_class
+        if self.tier_from is not None:
+            receipt["tier_from"] = self.tier_from
+        if self.tier_to is not None:
+            receipt["tier_to"] = self.tier_to
         return receipt
 
 

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -16,12 +16,28 @@ from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER
 from providers.smart_router.tier_routing import TierRoute, resolve_tier_route
 
 
-def test_tier_zero_uses_local_gemma():
-    route = resolve_tier_route(TIER_ZERO, env={})
-    assert route.provider == "local-gemma"
-    assert route.lane == "mlx"
+def test_tier_zero_with_deepseek_key_uses_harness():
+    """tier-zero routes to DeepSeek flash via claude-harness with a codex vangnet
+    when DEEPSEEK_API_KEY is present (operator decision 2026-08-02: local models
+    skipped until gemma-4-12b-integration ships)."""
+    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
+    route = resolve_tier_route(TIER_ZERO, env=env)
+    assert route.provider == "deepseek"
+    assert route.model == "deepseek-v4-flash"
+    assert route.lane == "claude_harness_keyed"
+    assert "DEEPSEEK_API_KEY" in route.env_requirements
     assert route.fallback is not None
-    assert route.fallback.provider == "ollama"
+    assert route.fallback.provider == "codex"
+    assert route.fallback.model == "gpt-5.5"
+
+
+def test_tier_zero_no_key_uses_codex():
+    """Without DEEPSEEK_API_KEY, tier-zero falls back to Codex via provider lane
+    (local-gemma route is preserved but unused until gemma-4-12b-integration)."""
+    route = resolve_tier_route(TIER_ZERO, env={})
+    assert route.provider == "codex"
+    assert route.model == "gpt-5.5"
+    assert route.lane == "provider"
 
 
 def test_tier_mid_uses_sonnet():

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -27,13 +27,17 @@ def test_tier_zero_uses_local_gemma():
 def test_tier_mid_uses_sonnet():
     route = resolve_tier_route(TIER_MID, env={})
     assert route.provider == "claude"
-    assert route.model == "claude-sonnet-4-6"
+    # canonical registry key (model-ssot-en-ketenlink) — the old claude-sonnet-4-6
+    # string is not a wave7_models.yaml key and rejected with
+    # model-not-in-current-registry the moment tier-mid actually routes.
+    assert route.model == "sonnet-5"
 
 
 def test_tier_high_uses_opus():
     route = resolve_tier_route(TIER_HIGH, env={})
     assert route.provider == "claude"
-    assert route.model == "claude-opus-4-8"
+    # canonical registry key — the fleet runs Opus 5 (model-ssot-en-ketenlink).
+    assert route.model == "opus-5"
 
 
 def test_tier_low_no_key_uses_kimi_cli():
@@ -87,7 +91,7 @@ def test_deepseek_harness_fallback_is_kimi():
 def test_unknown_tier_defaults_to_opus():
     """Unknown tier strings default to tier-high (safe over silent skip)."""
     route = resolve_tier_route("tier-unknown", env={})
-    assert route.model == "claude-opus-4-8"
+    assert route.model == "opus-5"
 
 
 def test_route_dispatch_default_off():
@@ -117,4 +121,4 @@ def test_route_dispatch_high_loc():
     result = route_dispatch({"instruction": "implement feature"}, ["x.py"], 350, env=env)
     assert result is not None
     assert result.tier == TIER_HIGH
-    assert result.model == "claude-opus-4-8"
+    assert result.model == "opus-5"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1116,9 +1116,11 @@ def test_forbid_route_blocking_verdict_rejects_dispatch(tmp_path):
 def test_default_model_pins_flip_workers_to_kimi_k3():
     """_DEFAULT_MODEL_PINS must pin T1/T2/T3 to kimi-k3 post-flip; T0 stays opus.
     WPFC PR-4: worker pins carry default semantics (spec.model wins over the pin);
-    T0 stays floor (pin always wins). ModelPin, not a bare string."""
+    T0 stays floor (pin always wins). ModelPin, not a bare string.
+    dispatch-20260802-model-ssot-en-ketenlink: T0's fallback is the canonical
+    opus-5 registry key (the fleet runs Opus 5), not the bare opus alias."""
     assert _DEFAULT_MODEL_PINS == {
-        "T0": ModelPin(model="opus", semantics="floor"),
+        "T0": ModelPin(model="opus-5", semantics="floor"),
         "T1": ModelPin(model="kimi-k3", semantics="default"),
         "T2": ModelPin(model="kimi-k3", semantics="default"),
         "T3": ModelPin(model="kimi-k3", semantics="default"),
@@ -1132,7 +1134,9 @@ def test_load_model_pins_from_yaml_reads_workers_kimi_pinned():
     provider_constraints.yaml SSOT. T0 still resolves via t0-opus-only.
     WPFC PR-4: workers carry pin_semantics: default; T0 stays floor."""
     pins = _load_model_pins_from_yaml()
-    assert pins["T0"] == ModelPin(model="claude-opus-4-8", semantics="floor")
+    # dispatch-20260802-model-ssot-en-ketenlink: t0-opus-only now pins the
+    # canonical opus-5 registry key.
+    assert pins["T0"] == ModelPin(model="opus-5", semantics="floor")
     assert pins["T1"] == ModelPin(model="kimi-k3", semantics="default")
     assert pins["T2"] == ModelPin(model="kimi-k3", semantics="default")
     assert pins["T3"] == ModelPin(model="kimi-k3", semantics="default")
@@ -1238,7 +1242,7 @@ def test_load_model_pins_unreadable_yaml_fails_loud_and_falls_back(tmp_path, cap
             pins = _load_model_pins_from_yaml()
 
     assert pins == _DEFAULT_MODEL_PINS
-    assert pins["T0"] == ModelPin(model="opus", semantics="floor")
+    assert pins["T0"] == ModelPin(model="opus-5", semantics="floor")
     assert any("model-pins YAML unreadable" in rec.message for rec in caplog.records), (
         "unreadable YAML must log loudly, not silently fall back"
     )
@@ -2620,7 +2624,9 @@ def test_worker_claude_override_env_does_not_leak_into_t0_or_kimi(tmp_path, monk
     assert rc == 0
     mock_execute.assert_called_once()
     plan_arg = mock_execute.call_args[0][0]
-    assert plan_arg.model == "claude-opus-4-8", (
+    # dispatch-20260802-model-ssot-en-ketenlink: t0-opus-only pins the canonical
+    # opus-5 registry key.
+    assert plan_arg.model == "opus-5", (
         f"T0 pin (t0-opus-only) must be unaffected by the worker override (got {plan_arg.model!r})"
     )
     assert not any("worker-claude-override" in w for w in plan_arg.warnings)

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -46,6 +46,10 @@ def tmp_state(tmp_path):
 
 
 def _make_spec(data_dir: Path, state_dir: Path, **kwargs) -> GovernSpec:
+    # Default model="sonnet": dispatch-20260802-model-ssot-en-ketenlink made the
+    # synthesized receipt fail closed on a missing/unknown model, so a spec
+    # without a model no longer produces a receipt (the test that pins that
+    # behavior sets model=None explicitly and asserts the rejection).
     return GovernSpec(
         dispatch_id=kwargs.get("dispatch_id", "test-govern-001"),
         terminal_id=kwargs.get("terminal_id", "T1"),
@@ -56,6 +60,11 @@ def _make_spec(data_dir: Path, state_dir: Path, **kwargs) -> GovernSpec:
         base_sha=kwargs.get("base_sha"),
         worktree_path=kwargs.get("worktree_path"),
         role=kwargs.get("role"),
+        model=kwargs.get("model", "sonnet"),
+        parent_dispatch=kwargs.get("parent_dispatch"),
+        task_class=kwargs.get("task_class"),
+        tier_from=kwargs.get("tier_from"),
+        tier_to=kwargs.get("tier_to"),
     )
 
 
@@ -922,18 +931,21 @@ def test_ensure_receipt_carries_terminal_id(tmp_data, tmp_state):
     assert receipt.get("terminal") == "T1", f"terminal alias missing or wrong: {receipt}"
 
 
-def test_ensure_receipt_model_unknown_when_not_set(tmp_data, tmp_state):
-    """Lane-synthesized receipt uses 'unknown' for model when spec.model is not set."""
-    spec = _make_spec(tmp_data, tmp_state)
+def test_ensure_receipt_rejected_when_model_not_set(tmp_data, tmp_state):
+    """dispatch-20260802-model-ssot-en-ketenlink: a lane-synthesized dispatch
+    receipt without a real model is REJECTED (fail-closed), never written with
+    ``model: unknown``. ensure_receipt is best-effort, so the append logs and
+    the file stays absent."""
+    spec = _make_spec(tmp_data, tmp_state, model=None)
     raw = GovernRaw(receipt=None, duration_seconds=60.0)
 
     ensure_receipt(spec, raw, lane="tmux_interactive", report_path=None,
                    contract_status="synthesized", permission_enforcement="soft")
 
     receipts_file = tmp_state / "t0_receipts.ndjson"
-    receipt = json.loads(receipts_file.read_text().splitlines()[0])
-    assert receipt.get("provider") == "claude"
-    assert receipt.get("model") == "unknown"
+    assert not receipts_file.exists(), (
+        "a dispatch receipt without a model must not be appended (fail-closed)"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -1246,6 +1258,9 @@ spec = GovernSpec(
     instruction="test",
     data_dir=state_dir,
     state_dir=state_dir,
+    # A dispatch receipt must name a real model (fail-closed) — the test
+    # exercises the import path, not the model contract.
+    model="sonnet",
 )
 raw = GovernRaw(receipt=None, duration_seconds=60.0)
 

--- a/tests/test_governance_emit.py
+++ b/tests/test_governance_emit.py
@@ -159,7 +159,7 @@ def test_receipt_json_structure(tmp_state):
     assert data["dispatch_id"] == "test-dispatch-001"
     assert data["terminal_id"] == "T1"
     assert data["provider"] == "claude"
-    assert data["model"] == "claude-sonnet-4-6"
+    assert data["model"] == "sonnet-4-6"
     assert data["status"] == "success"
     assert data["completion_pct"] == 100
 

--- a/tests/test_lane_calibration_field_test.py
+++ b/tests/test_lane_calibration_field_test.py
@@ -89,3 +89,33 @@ def test_cli_json_output_is_valid():
     payload = json.loads(proc.stdout)
     assert isinstance(payload, list) and payload
     assert all(row["passed"] for row in payload)
+
+
+# ── tier-zero env-branch coverage ───────────────────────────────────────────
+# resolve_tier_route('tier-zero') returns different routes depending on whether
+# DEEPSEEK_API_KEY is in the environment. The calibration corpus pins env={},
+# which exercises the no-key codex fallback. These tests explicitly cover both
+# branches so the route is verified regardless of where the suite runs.
+
+
+def test_tier_zero_without_deepseek_key_routes_to_codex():
+    """Without DEEPSEEK_API_KEY, tier-zero -> codex / gpt-5.5 / provider lane."""
+    route = lc.resolve_tier_route("tier-zero", env={})
+    assert route.tier == "tier-zero"
+    assert route.provider == "codex"
+    assert route.model == "gpt-5.5"
+    assert route.lane == "provider"
+
+
+def test_tier_zero_with_deepseek_key_routes_to_deepseek():
+    """With DEEPSEEK_API_KEY, tier-zero -> deepseek / deepseek-v4-flash / claude_harness_keyed."""
+    route = lc.resolve_tier_route("tier-zero", env={"DEEPSEEK_API_KEY": "sk-test"})
+    assert route.tier == "tier-zero"
+    assert route.provider == "deepseek"
+    assert route.model == "deepseek-v4-flash"
+    assert route.lane == "claude_harness_keyed"
+    # Fallback is codex when the primary deepseek-harness is unavailable.
+    assert route.fallback is not None
+    assert route.fallback.provider == "codex"
+    assert route.fallback.model == "gpt-5.5"
+    assert route.fallback.lane == "provider"

--- a/tests/test_model_ssot_and_chainlink.py
+++ b/tests/test_model_ssot_and_chainlink.py
@@ -64,6 +64,8 @@ class TestNormalizeModelName:
             ("fable", "fable-5"),
             # 4-series and dated full ids.
             ("claude-opus-4-8", "opus-4-8"),
+            ("claude-sonnet-4-6", "sonnet-4-6"),
+            ("claude-opus-4-6", "opus-4-6"),
             ("claude-haiku-4-5-20251001", "haiku"),
             ("claude-haiku-4-5", "haiku"),
             # Already-canonical keys are unchanged.
@@ -75,8 +77,18 @@ class TestNormalizeModelName:
     def test_maps_variant_to_canonical(self, variant, canonical):
         assert normalize_model_name(variant) == canonical
 
+    def test_claude_prefix_stripped_for_retired_generations(self):
+        """claude-sonnet-4-6 and claude-opus-4-8 normalize to the same
+        family-version form — the claude- provider prefix is stripped for both.
+        This is the inconsistency the dispatch fixed: claude-opus-4-8 resolved
+        through its litellm_name alias, while claude-sonnet-4-6 (a retired id
+        with no registry entry) previously passed through with the prefix
+        intact, so the ledger counted the same model under two names."""
+        assert normalize_model_name("claude-sonnet-4-6") == "sonnet-4-6"
+        assert normalize_model_name("claude-opus-4-8") == "opus-4-8"
+
     def test_unmapped_string_passes_through(self):
-        assert normalize_model_name("claude-sonnet-4-6") == "claude-sonnet-4-6"
+        assert normalize_model_name("gpt-4-turbo") == "gpt-4-turbo"
 
     def test_unknown_sentinel_passes_through(self):
         assert normalize_model_name("unknown") == "unknown"

--- a/tests/test_model_ssot_and_chainlink.py
+++ b/tests/test_model_ssot_and_chainlink.py
@@ -1,0 +1,401 @@
+"""dispatch-20260802-model-ssot-en-ketenlink — model identity SSOT + chain link.
+
+Covers the two connected changes:
+
+1. Model identity on ONE source (wave7_models.yaml):
+   - ``normalize_model_name`` maps every documented variant to the canonical
+     registry key (deepseek/deepseek-v4-pro, kimi-code/k3,
+     moonshot/kimi-k2-0905-preview, claude-sonnet-5, claude-opus-5, ...).
+   - receipt writers normalize at write time and fail closed on a dispatch
+     receipt without a real model (worker source), while the three model-less
+     producers (vnx_governance / vnx_state / context_rotation) are exempt.
+2. The chain link:
+   - the dispatch spec carries parent_dispatch / task_class / tier_from /
+     tier_to; the door passes them onto the plan (dry-run proves it) and the
+     receipt writers stamp them.
+
+Dispatch-ID: 20260802-model-ssot-en-ketenlink
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+from append_receipt_internals.common import AppendReceiptError
+from append_receipt_internals.payload import append_receipt_payload
+from providers.model_normalizer import (
+    is_unknown_model,
+    normalize_model_name,
+    tier_for_model,
+)
+
+# Importing append_receipt registers the append facade used by
+# append_receipt_payload (mirrors the test_append_receipt_dual_write pattern).
+import append_receipt  # noqa: E402, F401
+
+
+# ---------------------------------------------------------------------------
+# 1. Canonical name normalization
+# ---------------------------------------------------------------------------
+
+class TestNormalizeModelName:
+    """Every variant named in the dispatch, plus the 5-series and aliases."""
+
+    @pytest.mark.parametrize(
+        "variant, canonical",
+        [
+            # The receipt variants from the dispatch measurement.
+            ("deepseek/deepseek-v4-pro", "deepseek-v4-pro"),
+            ("deepseek-v4-pro", "deepseek-v4-pro"),
+            ("moonshot/kimi-k2-0905-preview", "kimi-k2-0905-default"),
+            ("kimi-code/k3", "kimi-k3"),
+            ("kimi-k3", "kimi-k3"),
+            # 5-series + Fable (added to the registry by this dispatch).
+            ("claude-sonnet-5", "sonnet-5"),
+            ("claude-opus-5", "opus-5"),
+            ("claude-fable-5", "fable-5"),
+            ("fable", "fable-5"),
+            # 4-series and dated full ids.
+            ("claude-opus-4-8", "opus-4-8"),
+            ("claude-haiku-4-5-20251001", "haiku"),
+            ("claude-haiku-4-5", "haiku"),
+            # Already-canonical keys are unchanged.
+            ("sonnet", "sonnet"),
+            ("opus", "opus"),
+            ("haiku", "haiku"),
+        ],
+    )
+    def test_maps_variant_to_canonical(self, variant, canonical):
+        assert normalize_model_name(variant) == canonical
+
+    def test_unmapped_string_passes_through(self):
+        assert normalize_model_name("claude-sonnet-4-6") == "claude-sonnet-4-6"
+
+    def test_unknown_sentinel_passes_through(self):
+        assert normalize_model_name("unknown") == "unknown"
+        assert normalize_model_name("") == ""
+
+    def test_none_returns_empty(self):
+        assert normalize_model_name(None) == ""
+
+
+class TestIsUnknownModel:
+    def test_unknown_variants_are_unknown(self):
+        for value in ("unknown", "null", "none", "n/a", "na", "unset", "-", "", None):
+            assert is_unknown_model(value), f"{value!r} should be unknown"
+
+    def test_real_model_is_not_unknown(self):
+        assert not is_unknown_model("opus-5")
+        assert not is_unknown_model("deepseek-v4-pro")
+
+
+class TestTierForModel:
+    """Deterministic model -> cost tier reverse map (escalation signal)."""
+
+    def test_tier_high_for_opus_and_fable(self):
+        assert tier_for_model("opus-5") == "tier-high"
+        assert tier_for_model("fable-5") == "tier-high"
+        assert tier_for_model("claude-opus-4-8") == "tier-high"
+
+    def test_tier_mid_for_sonnet(self):
+        assert tier_for_model("sonnet-5") == "tier-mid"
+        assert tier_for_model("claude-sonnet-5") == "tier-mid"
+
+    def test_tier_low_for_kimi_and_deepseek(self):
+        assert tier_for_model("kimi-k3") == "tier-low"
+        assert tier_for_model("deepseek-v4-pro") == "tier-low"
+
+    def test_tier_zero_for_local(self):
+        assert tier_for_model("gemma-4b-local") == "tier-zero"
+
+    def test_unknown_returns_none(self):
+        assert tier_for_model("unknown") is None
+        assert tier_for_model(None) is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Fail-closed model on dispatch receipts
+# ---------------------------------------------------------------------------
+
+class TestFailClosedModel:
+    """No model -> no receipt for a worker dispatch source; exempt producers pass."""
+
+    def _append(self, tmp_path, receipt: dict, name: str = "t0_receipts.ndjson") -> dict:
+        rf = tmp_path / name
+        append_receipt_payload(
+            receipt,
+            receipts_file=str(rf),
+            skip_enrichment=True,
+        )
+        return json.loads(rf.read_text().splitlines()[-1])
+
+    def test_worker_dispatch_receipt_without_model_rejected(self, tmp_path):
+        receipt = {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-worker-nomodel",
+            "terminal": "T1",
+            "status": "success",
+            "receipt_kind": "dispatch",
+        }
+        with pytest.raises(AppendReceiptError) as exc_info:
+            self._append(tmp_path, receipt)
+        assert exc_info.value.code == "missing_model"
+
+    def test_worker_dispatch_receipt_model_unknown_rejected(self, tmp_path):
+        receipt = {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-worker-unknown",
+            "terminal": "T1",
+            "status": "success",
+            "receipt_kind": "dispatch",
+            "model": "unknown",
+        }
+        with pytest.raises(AppendReceiptError) as exc_info:
+            self._append(tmp_path, receipt)
+        assert exc_info.value.code == "missing_model"
+
+    def test_vnx_governance_receipt_without_model_allowed(self, tmp_path):
+        line = self._append(tmp_path, {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-governance",
+            "terminal": "T0",
+            "status": "info",
+            "source": "vnx_governance",
+            "receipt_kind": "dispatch",
+        })
+        assert line["dispatch_id"] == "d-governance"
+        assert "model" not in line or line.get("model") in ("", None)
+
+    def test_vnx_state_and_context_rotation_allowed(self, tmp_path):
+        for idx, source in enumerate(("vnx_state", "context_rotation")):
+            line = self._append(
+                tmp_path,
+                {
+                    "timestamp": "2026-08-02T00:00:00Z",
+                    "event_type": "state_mutation" if source == "vnx_state" else "context_rotation_continuation",
+                    "dispatch_id": f"d-exempt-{idx}",
+                    "terminal": "T0",
+                    "source": source,
+                },
+                name=f"exempt-{idx}.ndjson",
+            )
+            assert line["source"] == source
+
+    def test_non_dispatch_kind_without_model_still_allowed(self, tmp_path):
+        # A state_mutation receipt (receipt_kind outside the dispatch set) keeps
+        # the old tolerance — the fail-closed gate is scoped to dispatch receipts.
+        line = self._append(tmp_path, {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "state_mutation",
+            "dispatch_id": "d-state",
+            "terminal": "T0",
+            "receipt_kind": "state_mutation",
+        })
+        assert line["receipt_kind"] == "state_mutation"
+
+
+# ---------------------------------------------------------------------------
+# 3. Receipt writers normalize the model at write time
+# ---------------------------------------------------------------------------
+
+class TestReceiptModelNormalization:
+    def _append(self, tmp_path, receipt: dict) -> dict:
+        rf = tmp_path / "t0_receipts.ndjson"
+        append_receipt_payload(receipt, receipts_file=str(rf), skip_enrichment=True)
+        return json.loads(rf.read_text().splitlines()[-1])
+
+    def test_deepseek_variant_normalized(self, tmp_path):
+        line = self._append(tmp_path, {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-deepseek",
+            "terminal": "T1",
+            "status": "success",
+            "receipt_kind": "dispatch",
+            "model": "deepseek/deepseek-v4-pro",
+        })
+        assert line["model"] == "deepseek-v4-pro"
+
+    def test_kimi_cli_arg_normalized(self, tmp_path):
+        line = self._append(tmp_path, {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-kimi",
+            "terminal": "T1",
+            "status": "success",
+            "receipt_kind": "dispatch",
+            "model": "kimi-code/k3",
+        })
+        assert line["model"] == "kimi-k3"
+
+    def test_claude_5_series_normalized(self, tmp_path):
+        line = self._append(tmp_path, {
+            "timestamp": "2026-08-02T00:00:00Z",
+            "event_type": "task_complete",
+            "dispatch_id": "d-claude5",
+            "terminal": "T0",
+            "status": "success",
+            "receipt_kind": "dispatch",
+            "model": "claude-sonnet-5",
+        })
+        assert line["model"] == "sonnet-5"
+
+
+# ---------------------------------------------------------------------------
+# 4. Chain link: the door passes parent_dispatch / task_class / tier to the receipt
+# ---------------------------------------------------------------------------
+
+class TestChainLink:
+    def test_chain_link_env_vars_stamped_on_receipt(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PARENT_DISPATCH", "20260101-parent-dispatch")
+        monkeypatch.setenv("VNX_TASK_CLASS", "02_code_review")
+        monkeypatch.setenv("VNX_TIER_FROM", "tier-mid")
+        monkeypatch.setenv("VNX_TIER_TO", "tier-high")
+        rf = tmp_path / "t0_receipts.ndjson"
+        append_receipt_payload(
+            {
+                "timestamp": "2026-08-02T00:00:00Z",
+                "event_type": "task_complete",
+                "dispatch_id": "d-chain",
+                "terminal": "T1",
+                "status": "success",
+                "receipt_kind": "dispatch",
+                "model": "sonnet-5",
+            },
+            receipts_file=str(rf),
+            skip_enrichment=True,
+        )
+        line = json.loads(rf.read_text().splitlines()[-1])
+        assert line["parent_dispatch"] == "20260101-parent-dispatch"
+        assert line["task_class"] == "02_code_review"
+        assert line["tier_from"] == "tier-mid"
+        assert line["tier_to"] == "tier-high"
+
+    def test_chain_link_env_stamps_do_not_overwrite_caller_values(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("VNX_PARENT_DISPATCH", "20260101-env-parent")
+        rf = tmp_path / "t0_receipts.ndjson"
+        append_receipt_payload(
+            {
+                "timestamp": "2026-08-02T00:00:00Z",
+                "event_type": "task_complete",
+                "dispatch_id": "d-chain-explicit",
+                "terminal": "T1",
+                "status": "success",
+                "receipt_kind": "dispatch",
+                "model": "sonnet-5",
+                "parent_dispatch": "20260101-explicit-parent",
+            },
+            receipts_file=str(rf),
+            skip_enrichment=True,
+        )
+        line = json.loads(rf.read_text().splitlines()[-1])
+        assert line["parent_dispatch"] == "20260101-explicit-parent"
+
+
+# ---------------------------------------------------------------------------
+# 5. End-to-end: spec carries the chain link; the door puts it on the plan
+# ---------------------------------------------------------------------------
+
+class TestDoorChainLink:
+    def test_dry_run_parent_dispatch_lands_on_plan(self, tmp_path, monkeypatch, capsys):
+        """A staged spec carrying parent_dispatch/task_class/tier lands on the
+        plan (visible in the dry-run plan print) — the door's pass-through."""
+        from dispatch_bridge import stage_spec_bundle
+        from dispatch_cli import run_dispatch
+
+        data_dir = tmp_path / "data"
+        (data_dir / "state").mkdir(parents=True)
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_PROJECT_ID", "vnx-dev")
+
+        spec_file = stage_spec_bundle(
+            instruction_text=(
+                "# Chain-link dry run\n\n"
+                "Role: backend-developer\n\n"
+                "Review the changes and implement the fix.\n"
+            ),
+            dispatch_id="20260802-chainlink-test",
+            role="backend-developer",
+            target_slot="T0",
+            project_id="vnx-dev",
+            provider="claude",
+            data_dir=data_dir,
+            parent_dispatch="20260101-parent-dispatch",
+            task_class="02_code_review",
+            tier_from="tier-mid",
+            tier_to="tier-high",
+        )
+
+        rc = run_dispatch(spec_file, dry_run=True)
+        assert rc == 0, capsys.readouterr().err
+
+        out = capsys.readouterr().out
+        assert "DRY RUN" in out
+        assert "parent_dispatch: 20260101-parent-dispatch" in out
+        assert "task_class:   02_code_review" in out
+        assert "tier:         tier-mid -> tier-high" in out
+
+    def test_spec_rejects_bad_parent_dispatch_format(self, tmp_path):
+        from dispatch_spec import DispatchSpec, Isolation, PathAccess, Provider, validate
+        from dispatch_cli import load_spec
+        import json as _json
+
+        ifile = tmp_path / "instruction.md"
+        ifile.write_text("# T\n\nRole: backend-developer\n\nDo work.\n", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260802-bad-parent",
+            "staging_id": "20260802-bad-parent",
+            "instruction_file": str(ifile),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "parent_dispatch": "not a valid id!",
+        }
+        sf = tmp_path / "dispatch-spec.json"
+        sf.write_text(_json.dumps(spec_dict), encoding="utf-8")
+        spec = load_spec(sf)
+        result = validate(spec, project_id="vnx-dev", repo_root=Path(__file__).resolve().parent.parent)
+        assert result is not None and getattr(result, "code", None) == "bad-parent-dispatch"
+
+    def test_spec_rejects_bad_tier_value(self, tmp_path):
+        import json as _json
+        from dispatch_cli import load_spec
+        from dispatch_spec import validate
+
+        ifile = tmp_path / "instruction.md"
+        ifile.write_text("# T\n\nRole: backend-developer\n\nDo work.\n", encoding="utf-8")
+        spec_dict = {
+            "schema_version": 1,
+            "project_id": "vnx-dev",
+            "dispatch_id": "20260802-bad-tier",
+            "staging_id": "20260802-bad-tier",
+            "instruction_file": str(ifile),
+            "role": "backend-developer",
+            "target_slot": "T1",
+            "gate": "",
+            "dispatch_paths": [],
+            "provider": "claude",
+            "deadline_seconds": 3600,
+            "tier_to": "tier-ultra",
+        }
+        sf = tmp_path / "dispatch-spec.json"
+        sf.write_text(_json.dumps(spec_dict), encoding="utf-8")
+        spec = load_spec(sf)
+        result = validate(spec, project_id="vnx-dev", repo_root=Path(__file__).resolve().parent.parent)
+        assert result is not None and getattr(result, "code", None) == "bad-tier-value"

--- a/tests/test_receipt_v2_pr5_schema_cutover.py
+++ b/tests/test_receipt_v2_pr5_schema_cutover.py
@@ -164,7 +164,7 @@ def test_t11_v2_receipt_no_session_object_session_id_present(tmp_path):
     # session_id is present and IS the resolved value -- the one field §4 keeps.
     assert line["session_id"] == "sess-t11-abc123"
     # model/provider -- promoted to top-level, not lost by the collapse.
-    assert line["model"] == "claude-sonnet-4-6"
+    assert line["model"] == "sonnet-4-6"
     assert line["provider"] == "claude_code"
     assert line["schema_version"] == 2
 

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -382,7 +382,9 @@ class TestReceiptContent:
         assert r["dispatch_id"] == "20260601-content-check"
         assert r["event_type"] == "task_complete"
         assert r["terminal"] == "T2"
-        assert r["model"] == "claude-opus-4-8"
+        # dispatch-20260802-model-ssot-en-ketenlink: receipts carry the canonical
+        # wave7 registry key, not the free-form claude-* string.
+        assert r["model"] == "opus-4-8"
         assert r["status"] == "success"
         assert "timestamp" in r
         assert "report_path" in r
@@ -427,8 +429,11 @@ class TestContractValidation:
     def test_missing_content_dispatch_id_not_task_complete(self, tmp_path, state_dir):
         """Filename-only dispatch_id is a contract violation: must not be task_complete."""
         report = tmp_path / "20260601-nodid-content.md"
-        # Full valid body but no frontmatter or bold-field dispatch_id
+        # Full valid body but no frontmatter or bold-field dispatch_id. A model
+        # IS carried (fail-closed model check: dispatch receipts must name the
+        # model that ran); the contract violation is the missing dispatch_id.
         report.write_text(
+            "---\nmodel: claude-sonnet-5\n---\n\n"
             "## Summary\n\n"
             "Implemented the feature per dispatch specification. All tests pass and coverage is at target.\n\n"
             "## Changes\n\n- scripts/lib/example.py: added X\n\n"
@@ -452,9 +457,11 @@ class TestContractValidation:
     def test_body_contract_violations_not_task_complete(self, tmp_path, state_dir):
         """Content dispatch_id present but body fails contract: must not be task_complete."""
         report = tmp_path / "20260601-badbody.md"
-        # Has dispatch_id in frontmatter but missing required sections + summary too short
+        # Has dispatch_id in frontmatter but missing required sections + summary
+        # too short. A model is carried (fail-closed model check); the contract
+        # violations are the missing sections.
         report.write_text(
-            "---\ndispatch_id: 20260601-badbody\nterminal: T1\n---\n\n"
+            "---\ndispatch_id: 20260601-badbody\nterminal: T1\nmodel: claude-sonnet-5\n---\n\n"
             "## Summary\n\nShort.\n\n",
             encoding="utf-8",
         )
@@ -475,6 +482,7 @@ class TestContractValidation:
         """Both content dispatch_id and body are invalid: must not be task_complete."""
         report = tmp_path / "20260601-double-invalid.md"
         report.write_text(
+            "---\nmodel: claude-sonnet-5\n---\n\n"
             "## Summary\n\nShort.\n\n",
             encoding="utf-8",
         )
@@ -493,7 +501,7 @@ class TestContractValidation:
         """contract_invalid receipts are idempotent: second call returns duplicate."""
         report = tmp_path / "20260601-idem-invalid.md"
         report.write_text(
-            "---\ndispatch_id: 20260601-idem-invalid\n---\n\n"
+            "---\ndispatch_id: 20260601-idem-invalid\nmodel: claude-sonnet-5\n---\n\n"
             "## Summary\n\nShort.\n",
             encoding="utf-8",
         )
@@ -517,7 +525,7 @@ class TestContractValidation:
         _write_frontmatter_report(reports_dir / "20260601-sc-good.md", "20260601-sc-good")
         # Invalid report: has dispatch_id in frontmatter, body is missing sections
         (reports_dir / "20260601-sc-bad.md").write_text(
-            "---\ndispatch_id: 20260601-sc-bad\n---\n\n## Summary\n\nShort.\n",
+            "---\ndispatch_id: 20260601-sc-bad\nmodel: claude-sonnet-5\n---\n\n## Summary\n\nShort.\n",
             encoding="utf-8",
         )
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -976,7 +976,9 @@ class TestCompletionProtocolIntegration(_LaneTestCase):
         fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
         lane = self._make_lane(fake)
 
-        protocol = lane._build_completion_protocol(self.DISPATCH_ID, "T1")
+        # model passed explicitly — a dispatch receipt must name the model that
+        # ran (fail-closed), and production always passes the resolved model.
+        protocol = lane._build_completion_protocol(self.DISPATCH_ID, "T1", model="sonnet")
 
         for block_idx, expected_status in ((0, "done"), (1, "failed")):
             receipt = _extract_protocol_receipt(protocol, block_idx)
@@ -1072,7 +1074,9 @@ class TestCompletionProtocolPinsReceiptsFile(_LaneTestCase):
                 project_root=real_project_root,
             )
 
-            protocol = lane._build_completion_protocol(self.DISPATCH_ID, "T1")
+            # model passed explicitly — a dispatch receipt must name the model
+            # that ran (fail-closed).
+            protocol = lane._build_completion_protocol(self.DISPATCH_ID, "T1", model="sonnet")
 
             # Part 1: env vars and python3 path present in the done block (index 0).
             done_block = _extract_protocol_block(protocol, 0)

--- a/tests/test_tmux_lane_signals.py
+++ b/tests/test_tmux_lane_signals.py
@@ -417,6 +417,9 @@ class TestSessionIdVerifier(unittest.TestCase):
 # Stop hook: receipt-guarantee via the #788 converter (hermetic)
 # ---------------------------------------------------------------------------
 _VALID_REPORT = """\
+---
+model: sonnet
+---
 **Dispatch-ID**: {did}
 
 ## Summary


### PR DESCRIPTION
## Wat

Twee samenhangende wijzigingen onder de routing- en confidence-laag: model-identiteit op één bron (SSOT) en de ketenlink op receipts.

## Deel 1 — Model-identiteit op één SSOT

- `wave7_models.yaml` is de canonieke naamruimte. De ontbrekende 5-serie (`sonnet-5`, `opus-5`) en `fable-5` zijn toegevoegd met geverifieerde ids en prijzen (Sonnet 5 $3/$15, Opus 5 $5/$25, Fable 5 $10/$50 per MTok).
- Nieuw: `scripts/lib/providers/model_normalizer.py` — `normalize_model_name()` mapt elke variant naar de canonieke registry-key. `tier_for_model()` is de deterministische model→tier reverse map; `is_unknown_model()` voedt de fail-closed validator.
- `tier_routing.py` en `provider_constraints.yaml` dragen nu canonieke keys in plaats van 4-serie-strings die het register niet kent (latente `model-not-in-current-registry`-afwijzing is opgelost).
- Beide receipt-schrijvers normaliseren het model bij het schrijven.

## Deel 2 — De ketenlink

- `DispatchSpec` / plan dragen `parent_dispatch`, `task_class`, `tier_from`, `tier_to`. `stage_spec_bundle` schrijft ze; de deur exporteert ze als env; de receipt-schrijvers stampen ze.
- `task_class` valt deterministisch terug op de smart_router-classifier; `tier_to` op de model→tier reverse map.
- **Fail-closed op model**: een dispatch-receipt zonder echt model wordt geweigerd (stijl #1312-rolvalidatie). Expliciete uitzondering voor `vnx_governance` / `vnx_state` / `context_rotation` (de drie gemeten model-loze producers) plus `phantom_guard` / `pr_enforcement` (governance-corrective schrijvers die het rejectie-signaal nooit mogen verliezen).

## Verificatie

- `python3 -m pytest tests/ -k "routing or registry or receipt or provider" -q -p no:cacheprovider` → **2645 passed / 62 failed**. Alle 62 zijn pre-existing op `origin/main` (baseline: 65 failed / 2635 passed); deze PR introduceert nul netto-nieuwe failures.
- Nieuw testbestand `tests/test_model_ssot_and_chainlink.py` (38 cases): normalizer-varianten, tier reverse map, fail-closed worker-receipt, exempt-producers, schrijf-tijd normalisatie, ketenlink env-stamping, dry-run door de deur met `parent_dispatch` op het plan.
- Vijf-oppervlakte-tabel, normalizer-uitvoer en dry-run-bewijs staan in het unified report.

## Open items

- `input_tokens` / `output_tokens` blijven 0% (OI-872, `session_analytics` schrijft de letterlijke placeholder) — buiten scope per dispatch.
- Historische receipts zijn niet herschreven (aparte migratie).
- Pre-existing failures op `main` zijn niet door deze PR veroorzaakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)