### PR TITLE
feat(glm): enforce glm-5.2 as the only allowed GLM version

### DIFF
--- a/docs/core/110_SMART_ROUTER_DESIGN.md
+++ b/docs/core/110_SMART_ROUTER_DESIGN.md
@@ -165,7 +165,7 @@ A model must clear all three to actually get recommended and dispatched: it must
 
 ### 4.4 Current models (as of this refresh)
 
-The registry's current, non-deprecated model set: `claude-opus-4-8` (T0-tier), `claude-sonnet-5` (worker-tier), `glm-5.2` (preferred GLM; `glm-5.1` remains available for explicit override), `kimi-k2-7` (via `kimi_cli`, OAuth), `deepseek-v4-pro` (and `deepseek-v4-flash`, cheaper/faster). `provider_constraints.yaml` is the authority on which of these are actually pinned for T0/worker roles — this document describes routing *recommendations*, not the pin policy itself.
+The registry's current, non-deprecated model set: `claude-opus-4-8` (T0-tier), `claude-sonnet-5` (worker-tier), `glm-5.2` (only allowed GLM version; `glm-5.1` and base `glm-5` are blocked by deprecated-glm-models constraint per operator directive 2026-08-03), `kimi-k2-7` (via `kimi_cli`, OAuth), `deepseek-v4-pro` (and `deepseek-v4-flash`, cheaper/faster). `provider_constraints.yaml` is the authority on which of these are actually pinned for T0/worker roles — this document describes routing *recommendations*, not the pin policy itself.
 
 ---
 

--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -86,17 +86,17 @@ Two model tiers available under `--provider litellm:moonshot`:
 - Missing `MOONSHOT_API_KEY` → immediate exit(64) before subprocess spawn
 - Context: 8,192 tokens (both models); streaming + tool calls supported
 
-## GLM-5.1 via OpenRouter / Z.AI (PR-7.3)
+## GLM-5.2 via OpenRouter / Z.AI (PR-7.3)
 
-GLM-5.1 routes through OpenRouter as `openrouter/z-ai/glm-5`:
+GLM-5.2 routes through OpenRouter as `openrouter/z-ai/glm-5.2`:
 
 | Alias | LiteLLM name | Input/MTok | Output/MTok | Task classes |
 |---|---|---|---|---|
-| glm-5.1-default | openrouter/z-ai/glm-5 | $0.50 | $2.50 | coding, review |
+| glm-5.2 | openrouter/z-ai/glm-5.2 | $0.60 | $1.92 | coding, review |
 
-- Dispatch: `--provider litellm:zai`
+- Dispatch: `--provider litellm:zai` (defaults to glm-5.2) or `--provider glm-harness` (claude-CLI harness via local litellm proxy)
 - Missing `OPENROUTER_API_KEY` → immediate exit(64) before subprocess spawn
-- Deprecated models GLM-4.5 and GLM-4.6 → ValueError on dispatch (explicit legacy guard)
+- Deprecated models GLM-4.5, GLM-4.6, GLM-5 (base), GLM-5.1 → blocked by deprecated-glm-models constraint (operator directive 2026-08-03)
 - Context: 8,192 tokens; streaming + tool calls supported
 - Direct Zhipu integration deferred to Wave 7.3.1 (see `z_ai_custom_provider.py`)
 

--- a/scripts/benchmark/export_routing_matrix.py
+++ b/scripts/benchmark/export_routing_matrix.py
@@ -68,8 +68,6 @@ LANE = {
     "codex-gpt-5-5": ("codex-gpt-5-5", "codex-cli"),
     "codex-gpt-5-4": ("codex-gpt-5-4", "codex-cli"),
     "kimi-k2-7-code": ("kimi-k2-7-code", "kimi-cli"),
-    "glm-5": ("glm-5", "flat-runner"),
-    "glm-5-1": ("glm-5-1", "flat-runner"),
     "glm-5-2": ("glm-5-2", "flat-runner"),
     "glm-5-2-harness": ("glm-5-2", "claude-harness"),
     "deepseek-v4-flash-harness": ("deepseek-v4-flash", "claude-harness"),

--- a/scripts/benchmark/field-tests/METHODOLOGY.md
+++ b/scripts/benchmark/field-tests/METHODOLOGY.md
@@ -51,8 +51,8 @@ four families:
 |---|---|---|
 | Claude (subscription) | `claude-opus-4-8/4-7/4-6`, `claude-sonnet-4-6` | interactive `claude` CLI in an isolated worktree |
 | Codex | `codex-gpt-5-4`, `codex-gpt-5-5` | `codex exec --json` |
-| Open models (runner) | `glm-5`, `glm-5-1`, `glm-5-2`, `kimi-k2-7-code` | provider CLI / flat agentic runner |
-| Open models (harness) | `glm-5-harness`, `glm-5-1-harness`, `glm-5-2-harness`, `deepseek-v4-pro-harness`, `deepseek-v4-flash-harness` | the **full `claude` CLI harness** pointed at the model via a local proxy |
+| Open models (runner) | `glm-5-2`, `kimi-k2-7-code` | provider CLI / flat agentic runner |
+| Open models (harness) | `glm-5-2-harness`, `deepseek-v4-pro-harness`, `deepseek-v4-flash-harness` | the **full `claude` CLI harness** pointed at the model via a local proxy |
 
 The **harness-vs-runner split is deliberate and is itself a measurement.** The
 same model (e.g. GLM-5.2) is run twice: once through a thin agentic loop

--- a/scripts/benchmark/field-tests/tasks.yaml
+++ b/scripts/benchmark/field-tests/tasks.yaml
@@ -15,13 +15,9 @@ tiers:
       - codex-gpt-5-4
       - codex-gpt-5-5
       - kimi-k2-7-code
-      - glm-5          # base GLM-5 (Feb 2026) baseline
-      - glm-5-1        # real GLM-5.1 (was wrongly mapped to base glm-5)
-      - glm-5-2        # GLM-5.2 (2026-06-16)
+      - glm-5-2        # GLM-5.2 (2026-06-16), only allowed GLM version per operator directive 2026-08-03
       - deepseek-v4-pro-harness
       - deepseek-v4-flash-harness
-      - glm-5-harness    # GLM via full claude-CLI harness (litellm proxy → OpenRouter); harness-vs-runner comparison
-      - glm-5-1-harness
       - glm-5-2-harness
     n_replications: 3
 

--- a/scripts/benchmark/models.yaml
+++ b/scripts/benchmark/models.yaml
@@ -70,40 +70,16 @@ models:
     cost_input_mtok: 0.00
     cost_output_mtok: 0.00
 
-  - id: glm-5
-    provider: litellm:zai   # default alias glm-5.1-default → openrouter/z-ai/glm-5 = BASE GLM-5 (Feb 2026), baseline
-    model_arg: glm-5
-    cost_input_mtok: 0.60
-    cost_output_mtok: 1.92
-
-  - id: glm-5-1
-    provider: litellm:zai:glm-5.1   # the REAL GLM-5.1 → openrouter/z-ai/glm-5.1 (was wrongly mapped to base glm-5)
-    model_arg: glm-5.1
-    cost_input_mtok: 0.60
-    cost_output_mtok: 1.92
-
   - id: glm-5-2
     provider: litellm:zai:glm-5.2   # GLM-5.2 (2026-06-16) → openrouter/z-ai/glm-5.2; satisfies zai-via-openrouter-only
     model_arg: glm-5.2
     cost_input_mtok: 0.60
     cost_output_mtok: 1.92
 
-  # GLM-harness lanes: SAME GLM models on OpenRouter, but driven by the FULL claude-CLI
-  # harness (tools/agentic loop) via a local litellm proxy → OpenRouter. Run ALONGSIDE the
-  # litellm:zai lanes above to measure "harness vs simple tool-call" for the same model.
+  # GLM-harness lane: GLM-5.2 driven by the FULL claude-CLI harness (tools/agentic loop) via
+  # a local litellm proxy → OpenRouter. glm-5 and glm-5.1 harness entries removed 2026-08-03
+  # per operator directive (only glm-5.2 allowed).
   # zai-via-openrouter-only intact (proxy fronts OpenRouter); no-anthropic-sdk intact (CLI).
-  - id: glm-5-harness
-    provider: glm-harness
-    model_arg: glm-5
-    cost_input_mtok: 0.20
-    cost_output_mtok: 0.80
-    notes: "GLM-5 (base) via full claude-CLI harness (litellm proxy → OpenRouter). Compare vs glm-5."
-  - id: glm-5-1-harness
-    provider: glm-harness
-    model_arg: glm-5.1
-    cost_input_mtok: 0.40
-    cost_output_mtok: 1.60
-    notes: "GLM-5.1 via full claude-CLI harness. Compare vs glm-5-1 (litellm tool-loop)."
   - id: glm-5-2-harness
     provider: glm-harness
     model_arg: glm-5.2

--- a/scripts/lib/cost_loader.py
+++ b/scripts/lib/cost_loader.py
@@ -34,7 +34,7 @@ _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     "claude-haiku-4-5": ("anthropic", "haiku"),
     "deepseek-v4-flash": ("deepseek", "deepseek-v4-flash"),
     "deepseek-v4-pro": ("deepseek", "deepseek-v4-pro"),
-    "glm-5-1": ("zai", "glm-5.1-default"),
+    "glm-5-1": ("zai", "glm-5.2"),
     "glm-5-2": ("zai", "glm-5.2"),
     "kimi-k2-0905": ("kimi_cli", "kimi-default"),
     "kimi-k2-6": ("kimi_cli", "kimi-k2-6"),

--- a/scripts/lib/provider_costs.py
+++ b/scripts/lib/provider_costs.py
@@ -62,7 +62,7 @@ _PROVIDER_RATES: dict[tuple[str, str], tuple[float, float, bool]] = {
     ("litellm:deepseek", "deepseek-v4-pro"):   (0.14,  0.28,  False),
     ("litellm:moonshot", "kimi-k2-0905-default"): (0.0, 0.0,  True),
     ("litellm:moonshot", "kimi-k2-0905-preview"):  (0.0, 0.0,  True),
-    ("litellm:zai", "glm-5.1-default"):        (0.07,  0.14,  False),
+    ("litellm:zai", "glm-5.2"):        (0.60,  1.92,  False),
     ("litellm:ollama", "llama3"):              (0.0,   0.0,   True),
     # openrouter-arbitrary lane (PR-1 skeleton) — the one proven model
     # (openrouter/openai/gpt-4o-mini); OpenRouter pass-through pricing.

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -61,7 +61,7 @@ _LITELLM_SUB_PROVIDER_DEFAULTS: dict = {
     "bedrock": "bedrock/claude-sonnet-4-6",
     "deepseek": "deepseek/deepseek-v4-pro",
     "moonshot": "moonshot/kimi-k2-0905-preview",
-    "zai": "openrouter/z-ai/glm-5",
+    "zai": "openrouter/z-ai/glm-5.2",
     "ollama": "ollama/llama3",
     "anthropic": "anthropic/claude-sonnet-4-6",
     # openrouter-arbitrary lane (PR-1 skeleton): the ONE OpenAI-compat model this
@@ -79,13 +79,14 @@ _SUB_PROVIDER_KEY_REQS: dict = {
 }
 
 # GLM model names that are LEGACY — rejected on zai dispatch (PR-7.3)
-_DEPRECATED_ZAI_MODELS = frozenset({"glm-4.5", "glm-4.6"})
+# Extended 2026-08-03: glm-5 (base Feb 2026) and glm-5.1 blocked; only glm-5.2 allowed.
+_DEPRECATED_ZAI_MODELS = frozenset({"glm-4.5", "glm-4.6", "glm-5", "glm-5.1"})
 
 # Default model alias per sub-provider — used to build lane key for contract lookup
 _SUB_PROVIDER_DEFAULT_ALIAS: dict = {
     "deepseek": "deepseek-v4-pro",
     "moonshot": "kimi-k2-0905-default",
-    "zai": "glm-5.1-default",
+    "zai": "glm-5.2",
     "openrouter": "gpt-4o-mini-default",
 }
 
@@ -1756,13 +1757,13 @@ def _validate_zai_model_not_legacy(model: str) -> None:
     """Raise ValueError when model names a deprecated GLM version."""
     model_lower = (model or "").lower().strip()
     if model_lower in _DEPRECATED_ZAI_MODELS:
-        raise ValueError(f"GLM-4.5/4.6 are LEGACY, use GLM-5.1 (got: {model!r})")
+        raise ValueError(f"GLM-4.5/4.6/5/5.1 are LEGACY, use GLM-5.2 (got: {model!r})")
 
 
 def _resolve_zai_model(model_alias: "str | None" = None) -> str:
-    """Load GLM-5.1 litellm_name from registry via OpenRouter.
+    """Load GLM-5.2 litellm_name from registry via OpenRouter.
 
-    Defaults to 'glm-5.1-default' (openrouter/z-ai/glm-5) when alias is absent.
+    Defaults to 'glm-5.2' (openrouter/z-ai/glm-5.2) when alias is absent.
     Falls back to hardcoded default when registry is unavailable.
     """
     from providers import provider_registry as _reg
@@ -1774,7 +1775,7 @@ def _resolve_zai_model(model_alias: "str | None" = None) -> str:
     cfg = registry.get("zai")
     if cfg is None or not cfg.enabled or not cfg.models:
         return _LITELLM_SUB_PROVIDER_DEFAULTS["zai"]
-    target_key = model_alias or "glm-5.1-default"
+    target_key = model_alias or "glm-5.2"
     if target_key in cfg.models:
         return cfg.models[target_key].litellm_name
     return next(iter(cfg.models.values())).litellm_name

--- a/scripts/lib/providers/behavior_contracts.py
+++ b/scripts/lib/providers/behavior_contracts.py
@@ -129,7 +129,7 @@ CONTRACTS: Dict[str, BehaviorContract] = {
         max_context_tokens=128_000,
         max_output_tokens=16_384,
     ),
-    "litellm:zai:glm-5.1-default": BehaviorContract(
+    "litellm:zai:glm-5.2": BehaviorContract(
         provider="litellm",
         sub_provider="zai",
         supports_streaming=True,

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -547,11 +547,11 @@ class ConstraintEnforcer:
                 message="Route forbidden: litellm:deepseek requires DEEPSEEK_API_KEY; subscription redirect is blocked.",
             ))
 
-        if _norm(effective) == "zai" and model_norm in {"glm-4.5", "glm-4.6"}:
+        if _norm(effective) == "zai" and model_norm in {"glm-4.5", "glm-4.6", "glm-5", "glm-5.1"}:
             violations.append(ConstraintViolation(
                 code="deprecated-glm-models",
                 severity="blocking",
-                message=f"Route forbidden: {model} is deprecated; use glm-5.1.",
+                message=f"Route forbidden: {model} is deprecated; use glm-5.2.",
             ))
 
         if check_registry and model:

--- a/scripts/lib/providers/glm_harness_litellm_proxy.yaml
+++ b/scripts/lib/providers/glm_harness_litellm_proxy.yaml
@@ -5,23 +5,13 @@
 # while inference still flows through OpenRouter — so `zai-via-openrouter-only` stays
 # intact (no direct z.ai/Zhipu account) and it's the CLI not the SDK (`no-anthropic-sdk`
 # intact). The key is read from OPENROUTER_API_KEY in the proxy's env; never hardcoded.
-# Model registry refresh (2026-07-22): glm-5.2 is CURRENT/preferred — it's the default
-# glm_harness_spawn.py resolves to (DEFAULT_GLM_HARNESS_MODEL). glm-5.1 and base glm-5 stay
-# listed deliberately: provider_constraints.yaml keeps glm-5.1 "available" for explicit
-# override, and glm-5 is the intentional flat-runner baseline — neither is a stale/broken
-# route, so both remain reachable via VNX_GLM_HARNESS_MODEL.
+# 2026-08-03: glm-5.2 is the ONLY allowed GLM version per operator directive. glm-5.1
+# and base glm-5 entries removed; attempting to route them now hits the
+# deprecated-glm-models constraint in provider_constraints.yaml.
 model_list:
   - model_name: glm-5.2
     litellm_params:
       model: openrouter/z-ai/glm-5.2
-      api_key: os.environ/OPENROUTER_API_KEY
-  - model_name: glm-5.1
-    litellm_params:
-      model: openrouter/z-ai/glm-5.1
-      api_key: os.environ/OPENROUTER_API_KEY
-  - model_name: glm-5
-    litellm_params:
-      model: openrouter/z-ai/glm-5
       api_key: os.environ/OPENROUTER_API_KEY
 
 litellm_settings:

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -122,12 +122,11 @@ constraints:
     rule: forbid_route
     forbidden_route:
       provider: zai
-      model: [glm-4.5, glm-4.6]
+      model: [glm-4.5, glm-4.6, glm-5, glm-5.1]
     reason: >-
-      GLM-4.5 and GLM-4.6 are legacy and superseded by the GLM-5.x line
-      (verified 2026-05-10, project_kimi_glm_integration_paths.md). The
-      provider will retire the legacy snapshots; new dispatches use a
-      current GLM-5.x key (glm-5.2 preferred, glm-5.1 available).
+      GLM-4.5 and GLM-4.6 are retired; base GLM-5 (Feb 2026) and GLM-5.1 are
+      superseded by GLM-5.2 (released 2026-06-16). Only GLM-5.2 is allowed for
+      new dispatches. Operator directive 2026-08-03: geen oudere 5-varianten.
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -13,7 +13,7 @@ Constraint references (provider_constraints.yaml):
   deepseek-harness-subscription-blocked: DEEPSEEK_API_KEY required; subscription-
     redirect blocked. Allowed only with via=claude_harness_keyed + own key.
   zai-via-openrouter-only: GLM only via OpenRouter (no direct Zhipu API)
-  deprecated-glm-models: GLM-4.5/4.6 blocked; use glm-5.1 via OpenRouter
+  deprecated-glm-models: GLM-4.5/4.6/5/5.1 blocked; use glm-5.2 via OpenRouter
 """
 from __future__ import annotations
 

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -187,28 +187,6 @@ providers:
     api_key_env: OPENROUTER_API_KEY  # via OpenRouter, not direct Zhipu
     direct_provider_note: "Native Zhipu integration deferred; PR-7.3 uses OpenRouter fallback"
     models:
-      glm-5.1-default:
-        litellm_name: "openrouter/z-ai/glm-5"  # NB: base GLM-5 (Feb 2026), NOT 5.1 — kept as baseline
-        cost_input_per_mtok: 0.50  # OpenRouter pass-through cost
-        cost_output_per_mtok: 2.50
-        max_tokens: 8192
-        supports_streaming: true
-        supports_tool_calls: true
-        task_classes: ["coding", "review"]
-        deprecated_models:  # explicit guard against legacy
-          - "glm-4.5"
-          - "glm-4.6"
-      glm-5.1:
-        litellm_name: "openrouter/z-ai/glm-5.1"  # the real GLM-5.1 (distinct from base glm-5)
-        cost_input_per_mtok: 0.60  # OpenRouter pass-through cost
-        cost_output_per_mtok: 1.92
-        max_tokens: 8192
-        supports_streaming: true
-        supports_tool_calls: true
-        task_classes: ["coding", "review"]
-        deprecated_models:
-          - "glm-4.5"
-          - "glm-4.6"
       glm-5.2:
         litellm_name: "openrouter/z-ai/glm-5.2"  # GLM-5.2 (released 2026-06-16)
         cost_input_per_mtok: 0.60
@@ -220,6 +198,8 @@ providers:
         deprecated_models:
           - "glm-4.5"
           - "glm-4.6"
+          - "glm-5"
+          - "glm-5.1"
   local_gemma:
     enabled: true
     api_key_env: ""  # no API key; runs entirely on-device via MLX or Ollama

--- a/tests/test_behavior_contracts.py
+++ b/tests/test_behavior_contracts.py
@@ -139,7 +139,7 @@ class TestLiteLLMLanesNoCacheControl:
         assert contract.cache_control_supported is False
 
     def test_glm_no_cache_control(self):
-        contract = get_contract("litellm:zai:glm-5.1-default")
+        contract = get_contract("litellm:zai:glm-5.2")
         assert contract.cache_control_supported is False
 
     def test_all_litellm_lanes_no_cache_control(self):

--- a/tests/test_benchmark_suite.py
+++ b/tests/test_benchmark_suite.py
@@ -424,13 +424,12 @@ def test_claude_model_arg_passed_via_cmd_not_env(tmp_path: Path, tmp_prompts: Pa
 
 def test_glm_uses_zai_provider():
     models = run_benchmark.load_models()
-    glm = next((m for m in models if m["id"] == "glm-5-1"), None)
-    assert glm is not None, "glm-5-1 not found in models.yaml"
-    # glm-5-1 was corrected in models.yaml to map to the REAL GLM-5.1 (litellm:zai:glm-5.1 /
-    # model_arg glm-5.1), not the base glm-5 alias. The zai sub-provider prefix is what satisfies
-    # zai-via-openrouter-only; the :glm-5.1 suffix selects the real model.
+    glm = next((m for m in models if m["id"] == "glm-5-2"), None)
+    assert glm is not None, "glm-5-2 not found in models.yaml"
+    # glm-5-2 is the only allowed GLM version per operator directive 2026-08-03.
+    # The zai sub-provider prefix satisfies zai-via-openrouter-only.
     assert glm["provider"].startswith("litellm:zai"), f"Expected litellm:zai*, got {glm['provider']}"
-    assert glm["model_arg"] == "glm-5.1", f"Expected glm-5.1, got {glm['model_arg']}"
+    assert glm["model_arg"] == "glm-5.2", f"Expected glm-5.2, got {glm['model_arg']}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -193,11 +193,19 @@ class TestDeprecatedGlmModels:
             real_enforcer.enforce(provider="zai", model="glm-4.6")
 
     def test_deprecated_glm_blocks(self, real_enforcer: ConstraintEnforcer):
-        with pytest.raises(HardConstraintViolation, match="glm-5.1"):
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
             real_enforcer.enforce(provider="litellm:zai", model="glm-4.6")
 
-    def test_glm51_allowed(self, real_enforcer: ConstraintEnforcer):
-        real_enforcer.enforce(provider="zai", model="glm-5.1")
+    def test_glm51_blocked(self, real_enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="zai", model="glm-5.1")
+
+    def test_glm5_blocked(self, real_enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="zai", model="glm-5")
+
+    def test_glm52_allowed(self, real_enforcer: ConstraintEnforcer):
+        real_enforcer.enforce(provider="zai", model="glm-5.2")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_agent_lane_coercion.py
+++ b/tests/test_dispatch_agent_lane_coercion.py
@@ -62,7 +62,6 @@ class TestInferProviderForModel:
             ("gpt-5.5", "codex"),
             ("gemini", "gemini"),
             ("gemini-2.5-pro", "gemini"),
-            ("glm-5.1", "glm-harness"),
             ("glm-5.2", "glm-harness"),
             ("zai", "glm-harness"),
             ("deepseek-harness", "deepseek-harness"),

--- a/tests/test_failclass_registry.py
+++ b/tests/test_failclass_registry.py
@@ -335,7 +335,7 @@ class TestRegistryDeepseekRoute:
         deepseek litellm route is disabled)."""
         from providers.constraint_enforcer import _model_in_registry
 
-        result = _model_in_registry("litellm", "zai", "glm-5.1")
+        result = _model_in_registry("litellm", "zai", "glm-5.2")
         assert result is True, (
             f"Expected glm-harness/zai to still be allowed, got {result}"
         )

--- a/tests/test_pr10_provider_string_canon.py
+++ b/tests/test_pr10_provider_string_canon.py
@@ -214,10 +214,17 @@ class TestGlmRouting:
         with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
             enforcer.enforce(provider="litellm", sub_provider="zai", model="glm-4.6")
 
-    def test_glm_5_allowed_via_zai(self, enforcer):
-        """glm-5 via litellm:zai must not be blocked."""
+    def test_glm_5_blocked_via_zai(self, enforcer):
+        """glm-5 via litellm:zai must be blocked (deprecated 2026-08-03)."""
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            enforcer.enforce(
+                provider="litellm", sub_provider="zai", model="glm-5",
+            )
+
+    def test_glm_52_allowed_via_zai(self, enforcer):
+        """glm-5.2 via litellm:zai must be allowed."""
         violations = enforcer.check_constraints(
-            provider="litellm", sub_provider="zai", model="glm-5",
+            provider="litellm", sub_provider="zai", model="glm-5.2",
         )
         blocking = [v for v in violations if v.severity == "blocking"]
         assert not blocking, [v.code for v in blocking]

--- a/tests/test_provider_aware_intelligence.py
+++ b/tests/test_provider_aware_intelligence.py
@@ -127,7 +127,7 @@ def test_compute_cost_rate_table_fallback_on_registry_miss():
     """When the registry has no entry, the provider_costs rate table resolves it."""
     from provider_costs import resolve_cost_usd
     # litellm:zai is in the rate table but not necessarily resolvable via registry
-    cost = resolve_cost_usd("litellm:zai", "glm-5.1-default", 1_000_000, 1_000_000)
+    cost = resolve_cost_usd("litellm:zai", "glm-5.2", 1_000_000, 1_000_000)
     assert cost is not None and cost > 0
 
 
@@ -331,8 +331,8 @@ def test_cross_tenant_upsert_does_not_overwrite_other_project(tmp_path):
 
 @pytest.mark.parametrize("provider", [
     "litellm:deepseek:deepseek-v4-pro",
-    "litellm:zai:glm-5.1-default",
-    "litellm:openrouter:glm-5.1-default",
+    "litellm:zai:glm-5.2",
+    "litellm:openrouter:glm-5.2",
     "litellm:deepseek",
     "litellm",
 ])

--- a/tests/test_provider_dispatch_contract_integration.py
+++ b/tests/test_provider_dispatch_contract_integration.py
@@ -49,7 +49,7 @@ class TestBuildLaneKey:
         assert _build_lane_key("moonshot", "kimi-k2-6") == "litellm:moonshot:kimi-k2-6"
 
     def test_zai_default_alias(self):
-        assert _build_lane_key("zai", None) == "litellm:zai:glm-5.1-default"
+        assert _build_lane_key("zai", None) == "litellm:zai:glm-5.2"
 
     def test_unknown_sub_provider_uses_default_sentinel(self):
         result = _build_lane_key("bedrock", None)
@@ -200,6 +200,6 @@ class TestNormalizeLiteLLMEventAuditEnrichment:
     def test_provider_is_always_litellm(self):
         event = normalize_litellm_event(
             self._text_chunk(), "T1", "dispatch-001",
-            sub_provider="zai", lane="litellm:zai:glm-5.1-default",
+            sub_provider="zai", lane="litellm:zai:glm-5.2",
         )
         assert event.provider == "litellm"

--- a/tests/test_provider_dispatch_entry.py
+++ b/tests/test_provider_dispatch_entry.py
@@ -168,7 +168,7 @@ class TestProviderLitellmRouted:
 
     def test_various_litellm_sub_providers_route(self):
         """Various litellm:<sub> values all route to _dispatch_litellm."""
-        for provider_str in ("litellm:kimi-k2", "litellm:glm-5.1", "litellm:bedrock"):
+        for provider_str in ("litellm:kimi-k2", "litellm:glm-5.2", "litellm:bedrock"):
             argv = ["--provider", provider_str, "--terminal-id", "T1",
                     "--dispatch-id", "test-litellm-sub", "--instruction", "noop"]
             with patch("provider_dispatch._dispatch_litellm", return_value=0) as mock_dispatch:

--- a/tests/test_routing_policy.py
+++ b/tests/test_routing_policy.py
@@ -214,7 +214,7 @@ def test_lane_to_claude_model_mappings() -> None:
 def test_lane_to_claude_model_litellm_returns_none() -> None:
     assert lane_to_claude_model("litellm:deepseek:deepseek-v4-pro") is None
     assert lane_to_claude_model("litellm:moonshot:kimi-k2-0905-default") is None
-    assert lane_to_claude_model("litellm:zai:glm-5.1-default") is None
+    assert lane_to_claude_model("litellm:zai:glm-5.2") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_subprocess_cheap_lane.py
+++ b/tests/test_subprocess_cheap_lane.py
@@ -476,7 +476,7 @@ class TestBuildCheapLaneArgv:
         for lane in (
             "litellm:moonshot:kimi-k2-0905-default",
             "litellm:deepseek:deepseek-v4-pro",
-            "litellm:zai:glm-5.1-default",
+            "litellm:zai:glm-5.2",
             "kimi",
         ):
             argv = _build_cheap_lane_argv(_make_args(), lane)

--- a/tests/test_wave7_glm_smoke.py
+++ b/tests/test_wave7_glm_smoke.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
-"""test_wave7_glm_smoke.py — Wave 7 PR-7.3 GLM-5.1 smoke tests.
+"""test_wave7_glm_smoke.py — Wave 7 PR-7.3 GLM-5.2 smoke tests.
 
-Verifies GLM-5.1 lane via LiteLLM OpenRouter endpoint (no real API calls):
+Verifies GLM-5.2 lane via LiteLLM OpenRouter endpoint (no real API calls):
 
   test_provider_dispatch_routes_zai_via_openrouter — litellm:zai routes to
       spawn_litellm with model containing 'openrouter'
   test_zai_requires_openrouter_key                 — missing OPENROUTER_API_KEY → non-zero exit
   test_glm45_legacy_rejected                       — --model glm-4.5 raises ValueError
-  test_glm_model_alias_resolution                  — glm-5.1-default resolves to
-      openrouter/z-ai/glm-5
+  test_glm_model_alias_resolution                  — glm-5.2 resolves to
+      openrouter/z-ai/glm-5.2
 """
 
 from __future__ import annotations
@@ -143,13 +143,13 @@ class TestGlmLegacyRejected:
     def test_validate_zai_model_not_legacy_raises_for_deprecated(self):
         from provider_dispatch import _validate_zai_model_not_legacy
 
-        with pytest.raises(ValueError, match="GLM-4.5/4.6 are LEGACY"):
-            _validate_zai_model_not_legacy("glm-4.5")
+        with pytest.raises(ValueError, match="GLM-4.5/4.6/5/5.1 are LEGACY"):
+            _validate_zai_model_not_legacy("glm-5.1")
 
     def test_validate_zai_model_not_legacy_passes_for_current(self):
         from provider_dispatch import _validate_zai_model_not_legacy
 
-        _validate_zai_model_not_legacy("glm-5.1-default")
+        _validate_zai_model_not_legacy("glm-5.2")
         _validate_zai_model_not_legacy("sonnet")
         _validate_zai_model_not_legacy("")
 
@@ -161,18 +161,18 @@ class TestGlmLegacyRejected:
 class TestGlmModelAliasResolution:
     """_resolve_zai_model correctly maps aliases to litellm model strings."""
 
-    def test_default_resolves_to_openrouter_glm5(self):
+    def test_default_resolves_to_openrouter_glm52(self):
         from provider_dispatch import _resolve_zai_model
         model = _resolve_zai_model()
-        assert model == "openrouter/z-ai/glm-5", (
-            f"expected openrouter/z-ai/glm-5 as default, got {model!r}"
+        assert model == "openrouter/z-ai/glm-5.2", (
+            f"expected openrouter/z-ai/glm-5.2 as default, got {model!r}"
         )
 
-    def test_glm51_default_alias_resolves(self):
+    def test_glm52_alias_resolves(self):
         from provider_dispatch import _resolve_zai_model
-        model = _resolve_zai_model("glm-5.1-default")
-        assert model == "openrouter/z-ai/glm-5", (
-            f"glm-5.1-default should resolve to openrouter/z-ai/glm-5, got {model!r}"
+        model = _resolve_zai_model("glm-5.2")
+        assert model == "openrouter/z-ai/glm-5.2", (
+            f"glm-5.2 should resolve to openrouter/z-ai/glm-5.2, got {model!r}"
         )
 
     def test_unknown_alias_falls_back_to_first_model(self):
@@ -193,22 +193,22 @@ class TestGlmModelAliasResolution:
         assert zai.api_key_env == "OPENROUTER_API_KEY", (
             f"unexpected api_key_env: {zai.api_key_env!r}"
         )
-        assert len(zai.models) == 3, (
-            # glm-5.1-default + glm-5.1 + glm-5.2 (grew from the original 1 as GLM versions landed)
-            f"expected 3 zai models, got {len(zai.models)}"
+        assert len(zai.models) == 1, (
+            # glm-5.2 only; glm-5.1-default and glm-5.1 removed 2026-08-03
+            f"expected 1 zai model (glm-5.2), got {len(zai.models)}"
         )
 
-    def test_glm51_default_model_schema(self):
+    def test_glm52_model_schema(self):
         from providers import provider_registry
 
         registry = provider_registry.load()
-        model = registry["zai"].models["glm-5.1-default"]
+        model = registry["zai"].models["glm-5.2"]
 
-        assert model.litellm_name == "openrouter/z-ai/glm-5", (
+        assert model.litellm_name == "openrouter/z-ai/glm-5.2", (
             f"unexpected litellm_name: {model.litellm_name!r}"
         )
-        assert model.cost_input_per_mtok == pytest.approx(0.50)
-        assert model.cost_output_per_mtok == pytest.approx(2.50)
+        assert model.cost_input_per_mtok == pytest.approx(0.60)
+        assert model.cost_output_per_mtok == pytest.approx(1.92)
         assert model.max_tokens == 8192
         assert model.supports_streaming is True
         assert model.supports_tool_calls is True


### PR DESCRIPTION
## What

Removes `glm-5.1-default` and `glm-5.1` from the wave7 model registry. `glm-5.2` is now the only allowed GLM version.

## Why

The default was the **oldest** of three zai variants: `glm-5.1-default` resolved to base GLM-5 (Feb 2026), not 5.1 or 5.2. A dispatch without an explicit model ran base GLM-5 while the key name suggested 5.1 and the operator expected 5.2.

Operator directive 2026-08-03: GLM draait uitsluitend op GLM-5.2.

## Changes

| File | Change |
|---|---|
| `wave7_models.yaml` | Remove `glm-5.1-default` and `glm-5.1` entries; keep only `glm-5.2` |
| `provider_dispatch.py` | Default zai alias → `glm-5.2`; extend `_DEPRECATED_ZAI_MODELS`; update `_resolve_zai_model` |
| `cost_loader.py` | Map `glm-5-1` → `(zai, glm-5.2)` (backward compat for historical cost lookups) |
| `provider_constraints.yaml` | Extend `deprecated-glm-models` to block `glm-5` and `glm-5.1` |
| `constraint_enforcer.py` | Hardcoded check extended with `glm-5` and `glm-5.1` |
| `glm_harness_litellm_proxy.yaml` | Only `glm-5.2` in proxy model list |
| `provider_costs.py` | Rate entry updated |
| `behavior_contracts.py` | Lane key → `litellm:zai:glm-5.2` |
| Docs + benchmark + 14 test files | Swept all references |

## Verification

- Default zai model resolves to `openrouter/z-ai/glm-5.2` ✓
- `glm-5.1` and base `glm-5` blocked by constraint (both YAML + hardcoded double-gate) ✓
- `glm-5.2` passes all constraint checks ✓
- Registry has exactly 1 zai model key: `[glm-5.2]` ✓
- Cost lookup backward compat: `compute_cost_per_call(glm-5-1)` still resolves ✓
- 25 GLM-specific unit tests pass; broader sweep: 9 pre-existing failures (deepseek/kimi/auto-route), zero GLM regressions

Dispatch-ID: 20260803-glm52-enige-toegestane-versie

🤖 Generated with [Claude Code](https://claude.com/claude-code)