### PR TITLE
fix(dispatch): close pr_id and chain-link field drops between ExecutionPlan and EnvelopeSpec (OI-982, OI-985)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -1739,7 +1739,7 @@ def run_envelope_plan(
         model=plan.model,
         instruction=instruction,
         role=plan.role,  # F2 (codex): carry the role so the phantom-guard review-exemption applies
-        pr_id=None,
+        pr_id=plan.pr_id,
         state_dir=state_dir,
         data_dir=data_dir,
         deadline_seconds=plan.deadline_seconds,
@@ -1926,10 +1926,16 @@ def run_envelope_headless_plan(
         model=plan.model,
         instruction=instruction,
         role=role,
-        pr_id=None,
+        pr_id=plan.pr_id,
         state_dir=state_dir,
         data_dir=data_dir,
         deadline_seconds=plan.deadline_seconds,
+        # Chain-link (OI-985): same four fields as run_envelope_plan —
+        # without these, every claude_headless dispatch drops the chain.
+        parent_dispatch=plan.parent_dispatch,
+        task_class=plan.task_class,
+        tier_from=plan.tier_from,
+        tier_to=plan.tier_to,
     )
 
     enriched_instruction = _prepare(spec)
@@ -1944,6 +1950,10 @@ def run_envelope_headless_plan(
         state_dir=spec.state_dir,
         data_dir=spec.data_dir,
         deadline_seconds=spec.deadline_seconds,
+        parent_dispatch=spec.parent_dispatch,
+        task_class=spec.task_class,
+        tier_from=spec.tier_from,
+        tier_to=spec.tier_to,
     )
 
     # INTEGRITY — persist the enriched final prompt + verify reconstruction

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -109,6 +109,9 @@ class ExecutionPlan:
     role: Optional[str] = None          # carried from DispatchSpec for the phantom-guard review
                                         # exemption (codex P0.2 F2). NOT in digest() — advisory only,
                                         # must not perturb the permit fingerprint.
+    pr_id: Optional[str] = None         # OI-982: carried from DispatchSpec so the fix-forward
+                                        # diff fallback in _resolve_fix_forward_diff works.
+                                        # NOT in digest() — advisory only.
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): advisory receipt
     # metadata, NOT in digest() — like ``role``, it must not perturb the permit
     # fingerprint. parent_dispatch / tier_from / tier_to / task_class.
@@ -355,6 +358,7 @@ def compile_plan(vspec: ValidatedSpec, snapshot: RuntimeSnapshot) -> ExecutionPl
         instruction_file=spec.instruction_file,
         route_reason=",".join(fired),
         role=spec.role,
+        pr_id=spec.pr_id,
         # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): copied from the
         # door-computed snapshot so the receipt can say which dispatch this one
         # continues and on which tier.

--- a/tests/test_dispatch_envelope_field_propagation.py
+++ b/tests/test_dispatch_envelope_field_propagation.py
@@ -1,0 +1,280 @@
+"""test_dispatch_envelope_field_propagation.py — OI-982 + OI-985: ExecutionPlan → EnvelopeSpec field propagation.
+
+Verifies that:
+1. pr_id flows from DispatchSpec → ExecutionPlan → EnvelopeSpec in both
+   run_envelope_plan (provider lane) and run_envelope_headless_plan.
+2. Chain-link fields (parent_dispatch, task_class, tier_from, tier_to) flow
+   from ExecutionPlan → EnvelopeSpec in run_envelope_headless_plan.
+
+These tests MUST fail on the pre-fix code (origin/main) and go green on the
+fix branch. Pure unit assertions — no worker spawn.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import replace
+from pathlib import Path, PurePosixPath
+from typing import Any, Optional
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+from dispatch_envelope import (
+    EnvelopeSpec,
+    ProviderAdapter,
+    _AdapterResult,
+    run_envelope_headless_plan,
+    run_envelope_plan,
+)
+from dispatch_internal import issue_permit
+from dispatch_plan import (
+    ExecutionPlan,
+    RuntimeSnapshot,
+    compile_plan,
+)
+from dispatch_spec import (
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    Provider,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_instruction_file(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text("# Test instruction\n", encoding="utf-8")
+    return f
+
+
+def _make_spec_with_pr_id(
+    *,
+    pr_id: Optional[str],
+    provider: Provider = Provider.CODEX,
+    target_slot: str = "T1",
+    model: str | None = None,
+    allow_headless: bool = False,
+    tmp_path: Path,
+) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-prid-prop",
+        staging_id="staging-prid",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=provider,
+        model=model,
+        pr_id=pr_id,
+        allow_headless=allow_headless,
+        headless_reason="test" if allow_headless else None,
+    )
+
+
+def _make_vspec_from_spec(spec: DispatchSpec) -> ValidatedSpec:
+    instruction_text = "# Test instruction\n"
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+    )
+
+
+def _healthy_snapshot(
+    *,
+    parent_dispatch: Optional[str] = None,
+    task_class: Optional[str] = None,
+    tier_from: Optional[str] = None,
+    tier_to: Optional[str] = None,
+) -> RuntimeSnapshot:
+    all_slots = ["T0", "T1", "T2", "T3"]
+    return RuntimeSnapshot(
+        staging_promoted=True,
+        target_health={slot: "healthy" for slot in all_slots},
+        target_capable={slot: True for slot in all_slots},
+        parent_dispatch=parent_dispatch,
+        task_class=task_class,
+        tier_from=tier_from,
+        tier_to=tier_to,
+    )
+
+
+def _fake_adapter_success() -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — pr_id propagation: DispatchSpec → ExecutionPlan → EnvelopeSpec
+# ---------------------------------------------------------------------------
+
+
+class TestPrIdPropagation:
+    """OI-982: pr_id must flow from DispatchSpec through both envelope entry points."""
+
+    def test_pr_id_in_compiled_plan(self, tmp_path: Path) -> None:
+        """compile_plan copies pr_id from DispatchSpec onto ExecutionPlan."""
+        spec = _make_spec_with_pr_id(pr_id="123", provider=Provider.CODEX, tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert isinstance(plan, ExecutionPlan)
+        assert plan.pr_id == "123", (
+            f"Expected plan.pr_id='123', got {plan.pr_id!r}"
+        )
+
+    def test_pr_id_from_plan_to_envelope_spec_via_run_envelope_plan(
+        self, tmp_path: Path
+    ) -> None:
+        """run_envelope_plan passes plan.pr_id to EnvelopeSpec (provider lane)."""
+        spec = _make_spec_with_pr_id(pr_id="123", provider=Provider.CODEX, tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        captured_specs: list = []
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            captured_specs.append(spec_arg)
+            return (None, fake_receipt)
+
+        _fake_consumer_root = tmp_path / "consumer-root"
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=_fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=tmp_path / "fake-wt"), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(ProviderAdapter, "run", return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir
+            )
+
+        assert result.status == "success"
+        assert captured_specs, "_govern was not called — EnvelopeSpec never constructed"
+        assert captured_specs[0].pr_id == "123", (
+            f"run_envelope_plan: expected EnvelopeSpec.pr_id='123', "
+            f"got {captured_specs[0].pr_id!r}"
+        )
+
+    def test_pr_id_from_plan_to_envelope_spec_via_run_envelope_headless_plan(
+        self, tmp_path: Path
+    ) -> None:
+        """run_envelope_headless_plan passes plan.pr_id to EnvelopeSpec (headless lane)."""
+        spec = _make_spec_with_pr_id(
+            pr_id="123", provider=Provider.CLAUDE, allow_headless=True, tmp_path=tmp_path
+        )
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless", f"Expected claude_headless, got {plan.lane}"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        captured_specs: list = []
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            captured_specs.append(spec_arg)
+            return (None, fake_receipt)
+
+        with patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        assert result.status == "success"
+        assert captured_specs, "_govern was not called — EnvelopeSpec never constructed"
+        assert captured_specs[0].pr_id == "123", (
+            f"run_envelope_headless_plan: expected EnvelopeSpec.pr_id='123', "
+            f"got {captured_specs[0].pr_id!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — chain-link field propagation through run_envelope_headless_plan
+# ---------------------------------------------------------------------------
+
+
+class TestChainLinkPropagationHeadless:
+    """OI-985: chain-link fields must flow to EnvelopeSpec in the headless lane."""
+
+    def test_chainlink_fields_in_headless_envelope_spec(self, tmp_path: Path) -> None:
+        """All four chain-link fields reach EnvelopeSpec via run_envelope_headless_plan."""
+        spec = _make_spec_with_pr_id(
+            pr_id=None, provider=Provider.CLAUDE, allow_headless=True, tmp_path=tmp_path
+        )
+        vspec = _make_vspec_from_spec(spec)
+        snapshot = _healthy_snapshot(
+            parent_dispatch="20260801-000000-parent-dispatch",
+            task_class="build",
+            tier_from="T1",
+            tier_to="T2",
+        )
+        plan = compile_plan(vspec, snapshot)
+        assert plan.lane == "claude_headless"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        captured_specs: list = []
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            captured_specs.append(spec_arg)
+            return (None, fake_receipt)
+
+        with patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        assert result.status == "success"
+        assert captured_specs, "_govern was not called"
+
+        env_spec = captured_specs[0]
+        assert env_spec.parent_dispatch == "20260801-000000-parent-dispatch", (
+            f"Expected parent_dispatch on EnvelopeSpec, got {env_spec.parent_dispatch!r}"
+        )
+        assert env_spec.task_class == "build", (
+            f"Expected task_class='build', got {env_spec.task_class!r}"
+        )
+        assert env_spec.tier_from == "T1", (
+            f"Expected tier_from='T1', got {env_spec.tier_from!r}"
+        )
+        assert env_spec.tier_to == "T2", (
+            f"Expected tier_to='T2', got {env_spec.tier_to!r}"
+        )


### PR DESCRIPTION
## What

Sluit twee veld-drops tussen `ExecutionPlan` en `EnvelopeSpec` die ertoe leiden dat velden die de deur accepteert en valideert nooit bij de uitvoering aankomen.

### OI-982 (blocker): `pr_id` ontbreekt volledig in `ExecutionPlan`

- `ExecutionPlan` had **nul** keer de tekenreeks `pr_id` — het veld bestond niet
- `compile_plan` kopieerde `DispatchSpec.pr_id` nergens naar het plan
- `run_envelope_plan` en `run_envelope_headless_plan` codeerden allebei hard `pr_id=None`

**Governance-impact:** `_resolve_fix_forward_diff` (dispatch_envelope.py:507-509) checkt `spec.pr_id` om de pushed-branch diff op te halen voor fix-forward dispatches. Zonder `pr_id` is `own_diff` leeg voor werk dat wel degelijk gepusht is op de PR-branch, `phantom_guard` heeft geen terugval, en afgerond werk kan als verzonnen worden aangemerkt.

### OI-985: ketenlink-velden ontbreken in `run_envelope_headless_plan`

- `run_envelope_plan` geeft `parent_dispatch`, `task_class`, `tier_from`, `tier_to` netjes door
- `run_envelope_headless_plan` construeert zijn `EnvelopeSpec` **zonder een van die vier**
- Elke `claude_headless`-dispatch dropt de ketenlink — First-Pass Yield niet te berekenen

## Changes

| File | Change |
|---|---|
| `scripts/lib/dispatch_plan.py` | `pr_id: Optional[str] = None` toegevoegd aan `ExecutionPlan` (advisory, NOT in digest); `compile_plan` kopieert `spec.pr_id` |
| `scripts/lib/dispatch_envelope.py` | `pr_id=None` → `pr_id=plan.pr_id` in beide envelope-functies; ketenlink-velden toegevoegd aan beide `EnvelopeSpec`-constructies in `run_envelope_headless_plan` |
| `tests/test_dispatch_envelope_field_propagation.py` | 4 nieuwe tests (nieuw bestand) |

## Verification

- `grep -c pr_id scripts/lib/dispatch_plan.py` = **2** (was 0)
- `grep -n "pr_id=None" scripts/lib/dispatch_envelope.py` = **0 treffers** (was 2)
- **4/4 nieuwe tests rood op `origin/main`** (bevestigd)
- **4/4 nieuwe tests groen op fix-branch** (bevestigd)
- **162/162 volledige suite over 6 testbestanden groen** (`test_dispatch_plan.py`, `test_dispatch_envelope.py`, `test_dispatch_envelope_plan.py`, `test_dispatch_envelope_annotations_resolve.py`, `test_dispatch_envelope_fail_loud.py`, `test_dispatch_envelope_field_propagation.py`)

## Open Items

- `role_applied` (OI-983): staat in dezelfde bestanden, is bewust niet aangeraakt (apart issue).

🤖 Generated with [Claude Code](https://claude.com/claude-code)