### PR TITLE
test(envelope): gegenereerde koppelingscensus + karakteriseringssuite (PR-0)

### DIFF
--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -1,0 +1,819 @@
+{
+  "couplings": [
+    {
+      "file": "tests/test_dispatch_cli.py",
+      "line": 186,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_cli.py",
+      "line": 753,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_cli.py",
+      "line": 756,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 33,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeGovernError"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 34,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 35,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "LaneRouter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 36,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 236,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 237,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 360,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "CodexAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 365,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 557,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 591,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 593,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_receipt_exists_for_dispatch"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 784,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 866,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 891,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 926,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 947,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope.py",
+      "line": 962,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_annotations_resolve.py",
+      "line": 26,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_annotations_resolve.py",
+      "line": 27,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 12,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 51,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 51,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 234,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 235,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 237,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 245,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 273,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 274,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 275,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 278,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 299,
+      "mechanism": "logger-name",
+      "module_target": "dispatch_envelope",
+      "symbol": ""
+    },
+    {
+      "file": "tests/test_dispatch_envelope_characterization.py",
+      "line": 301,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_receipt_exists_for_dispatch"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_fail_loud.py",
+      "line": 32,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_fail_loud.py",
+      "line": 32,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_fail_loud.py",
+      "line": 243,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 28,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 31,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_headless_plan"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 32,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 166,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 167,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 204,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 204,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 206,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 257,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 257,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_field_propagation.py",
+      "line": 259,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeGovernError"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 31,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 32,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "LaneRouter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 33,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 34,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 35,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 36,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 166,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 167,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 396,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 433,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 472,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "CodexAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 478,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "CodexAdapter"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 478,
+      "mechanism": "monkeypatch",
+      "module_target": "dispatch_envelope",
+      "symbol": "CodexAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 483,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 522,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 523,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 550,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 578,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_dispatch_envelope_plan.py",
+      "line": 579,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 45,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 46,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 47,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 48,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 49,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
+      "line": 239,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
+      "file": "tests/test_envelope_role_propagation.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_envelope_role_propagation.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_envelope_role_propagation.py",
+      "line": 75,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_failclass_registry.py",
+      "line": 736,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_failclass_registry.py",
+      "line": 768,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_final_prompt_integrity.py",
+      "line": 374,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_glm_harness_normalization.py",
+      "line": 97,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_kimi_model_resolver.py",
+      "line": 418,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_kimi_model_resolver.py",
+      "line": 432,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_kimi_model_resolver.py",
+      "line": 446,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_kimi_model_resolver.py",
+      "line": 460,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 122,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 172,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 229,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 271,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 317,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_branch_fallback.py",
+      "line": 385,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_fix_forward.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_phantom_guard_fix_forward.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_fix_forward_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_oi869_oi870.py",
+      "line": 101,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_oi869_oi870.py",
+      "line": 172,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_oi869_oi870.py",
+      "line": 234,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_oi869_oi870.py",
+      "line": 283,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_phantom_guard_oi869_oi870.py",
+      "line": 340,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_resolve_phantom_diff"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 66,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 83,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 101,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 141,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 141,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 183,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_provider_deadline_passthrough.py",
+      "line": 183,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_receipt_v2_pr4_wiring.py",
+      "line": 398,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_receipt_v2_pr4_wiring.py",
+      "line": 398,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope"
+    },
+    {
+      "file": "tests/test_receipt_v2_pr4_wiring.py",
+      "line": 453,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_verification_from_report"
+    },
+    {
+      "file": "tests/test_role_applied_provider_lane.py",
+      "line": 46,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_role_applied_provider_lane.py",
+      "line": 46,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_role_applied_provider_lane.py",
+      "line": 211,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_archive_dispatch_events"
+    },
+    {
+      "file": "tests/test_role_applied_provider_lane.py",
+      "line": 212,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_clear_dispatch_events"
+    },
+    {
+      "file": "tests/test_role_applied_provider_lane.py",
+      "line": 217,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    }
+  ],
+  "family": [
+    "dispatch_envelope"
+  ]
+}

--- a/tests/dispatch_envelope_census_scanner.py
+++ b/tests/dispatch_envelope_census_scanner.py
@@ -1,0 +1,404 @@
+"""dispatch_envelope_census_scanner.py — census scanner for the envelope module family.
+
+Not a test module itself (no ``test_*`` functions) — imported by
+test_dispatch_envelope_characterization.py. Kept importable as a plain
+sibling module in tests/, matching the existing convention (e.g.
+test_envelope_ringbuffer_teardown_oi902.py importing from
+test_dispatch_envelope_plan.py directly).
+
+Why this exists (read before touching the matching logic below): a scanner
+that matches test-file couplings against the single literal string
+"dispatch_envelope" is wrong the moment the monolith splits — PR-1 through
+PR-6 move code into sibling ``envelope_*`` modules, and a
+``patch("envelope_govern.X")`` site is just as real a coupling as
+``patch("dispatch_envelope.X")``. The FAMILY set below is discovered fresh
+from disk on every run (never a fixed list of module names) specifically so
+a 7th module counts automatically without anyone remembering to edit this
+file.
+"""
+from __future__ import annotations
+
+import ast
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_LIB = REPO_ROOT / "scripts" / "lib"
+TESTS_DIR = REPO_ROOT / "tests"
+CENSUS_FIXTURE = Path(__file__).resolve().parent / "data" / "dispatch_envelope_census.json"
+
+# Generic family-membership pattern — NOT built by joining a fixed list of
+# discovered names. Used only as a self-check (see verify_family_pattern_gap
+# below) that the *shape* of family names ("dispatch_envelope" or
+# "envelope_<anything>") hasn't quietly been narrowed to something that
+# would miss a real envelope_*.py file on disk.
+FAMILY_NAME_PATTERN = re.compile(r"^(?:dispatch_envelope|envelope_[A-Za-z0-9_]+)$")
+
+
+def discover_family(lib_dir: Path = SCRIPTS_LIB) -> frozenset:
+    """The envelope module family: dispatch_envelope + every envelope_*.py
+    module actually present under scripts/lib/. Recomputed every call —
+    this is the census scanner's only source of truth for "which modules
+    does a coupling need to resolve against."
+    """
+    family = {"dispatch_envelope"}
+    for f in lib_dir.glob("envelope_*.py"):
+        family.add(f.stem)
+    return frozenset(family)
+
+
+def verify_family_pattern_gap(lib_dir: Path = SCRIPTS_LIB) -> list:
+    """Return violation messages for any scripts/lib/envelope_*.py file whose
+    stem does NOT match FAMILY_NAME_PATTERN.
+
+    Guards against the exact regression this scanner exists to prevent: if a
+    future edit narrows FAMILY_NAME_PATTERN (e.g. to an explicit alternation
+    of today's known module names), a genuinely-new envelope_*.py file will
+    still be found by the glob() below but will fail the pattern check —
+    loudly, instead of silently dropping out of the census.
+    """
+    violations = []
+    for f in lib_dir.glob("envelope_*.py"):
+        if not FAMILY_NAME_PATTERN.match(f.stem):
+            violations.append(
+                f"{f} matches the envelope_*.py glob but its stem {f.stem!r} "
+                f"does not match FAMILY_NAME_PATTERN {FAMILY_NAME_PATTERN.pattern!r} "
+                f"— the census scanner's family-matching logic must be widened"
+            )
+    return violations
+
+
+@dataclass(frozen=True, order=True)
+class Coupling:
+    file: str
+    line: int
+    mechanism: str
+    module_target: str
+    symbol: str
+
+    def to_dict(self) -> dict:
+        return {
+            "file": self.file,
+            "line": self.line,
+            "mechanism": self.mechanism,
+            "module_target": self.module_target,
+            "symbol": self.symbol,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "Coupling":
+        return cls(
+            file=d["file"], line=d["line"], mechanism=d["mechanism"],
+            module_target=d["module_target"], symbol=d["symbol"],
+        )
+
+
+def _dotted_name(node: ast.AST) -> Optional[str]:
+    """Reconstruct a dotted attribute chain's textual form, e.g.
+    Attribute(Attribute(Name('a'), 'b'), 'c') -> 'a.b.c'. None for anything
+    that isn't a pure Name/Attribute chain (calls, subscripts, ...)."""
+    if isinstance(node, ast.Name):
+        return node.id
+    if isinstance(node, ast.Attribute):
+        base = _dotted_name(node.value)
+        if base is None:
+            return None
+        return f"{base}.{node.attr}"
+    return None
+
+
+def _const_str(node: ast.AST) -> Optional[str]:
+    if isinstance(node, ast.Constant) and isinstance(node.value, str):
+        return node.value
+    return None
+
+
+class _FamilyBindingTracker:
+    """Shared binding-tracking logic: which local names in a module resolve
+    to a family module (via `import X` / `from X import Y`), reused by both
+    the tests/ census scan and the Layer 6 facade bind-form check.
+
+    local_name -> (family_module, symbol_or_None). symbol is None for a
+    plain module import (`import X [as alias]`) — the local name refers to
+    the MODULE, not to a specific attribute of it.
+    """
+
+    def __init__(self, family: frozenset):
+        self.family = family
+        self.bindings: dict = {}
+        self.from_imports: list = []   # (lineno, module, symbol, local_name)
+        self.module_imports: list = []  # (lineno, module, local_name)
+
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        if node.module in self.family:
+            for alias in node.names:
+                local = alias.asname or alias.name
+                self.bindings[local] = (node.module, alias.name)
+                lineno = getattr(alias, "lineno", node.lineno)
+                self.from_imports.append((lineno, node.module, alias.name, local))
+
+    def visit_Import(self, node: ast.Import):
+        for alias in node.names:
+            if alias.name in self.family:
+                local = alias.asname or alias.name
+                self.bindings[local] = (alias.name, None)
+                lineno = getattr(alias, "lineno", node.lineno)
+                self.module_imports.append((lineno, alias.name, local))
+
+    def resolve_class_ref(self, node: ast.AST):
+        """Resolve a `patch.object(<ref>, ...)` / `monkeypatch.setattr(<ref>, ...)`
+        first-argument expression to (family_module, class_or_attr_name), using
+        the bindings collected so far. None if it doesn't resolve to the family."""
+        if isinstance(node, ast.Name):
+            binding = self.bindings.get(node.id)
+            if binding is not None and binding[1] is not None:
+                return binding  # `from family_module import ClassName`
+            return None
+        if isinstance(node, ast.Attribute):
+            base = node.value
+            if isinstance(base, ast.Name):
+                binding = self.bindings.get(base.id)
+                if binding is not None and binding[1] is None:
+                    return binding[0], node.attr  # `import family_module` then `family_module.ClassName`
+            return None
+        return None
+
+
+class _CensusFileScanner(ast.NodeVisitor):
+    """Walks one test file's AST, recording every coupling to a family module."""
+
+    def __init__(self, relpath: str, family: frozenset):
+        self.relpath = relpath
+        self.family = family
+        self.couplings: list = []
+        self._tracker = _FamilyBindingTracker(family)
+
+    def _add(self, line: int, mechanism: str, module_target: str, symbol: str):
+        self.couplings.append(Coupling(self.relpath, line, mechanism, module_target, symbol))
+
+    # ---- imports -----------------------------------------------------
+    def visit_ImportFrom(self, node: ast.ImportFrom):
+        self._tracker.visit_ImportFrom(node)
+        if node.module in self.family:
+            for alias in node.names:
+                lineno = getattr(alias, "lineno", node.lineno)
+                self._add(lineno, "direct-call", node.module, alias.name)
+        self.generic_visit(node)
+
+    def visit_Import(self, node: ast.Import):
+        self._tracker.visit_Import(node)
+        self.generic_visit(node)
+
+    # ---- module.attr access (direct-call, module-alias form) ----------
+    def visit_Attribute(self, node: ast.Attribute):
+        base = node.value
+        if isinstance(base, ast.Name):
+            binding = self._tracker.bindings.get(base.id)
+            if binding is not None and binding[1] is None:
+                self._add(node.lineno, "direct-call", binding[0], node.attr)
+        self.generic_visit(node)
+
+    # ---- patch(...) / patch.object(...) / monkeypatch.setattr(...) / --
+    # ---- caplog.at_level(...) / getLogger(...) -------------------------
+    def visit_Call(self, node: ast.Call):
+        func = node.func
+        if self._is_patch_object_call(func):
+            self._handle_patch_object(node)
+        elif self._is_monkeypatch_setattr(func):
+            self._handle_monkeypatch(node)
+        elif self._is_caplog_at_level(func):
+            self._handle_caplog(node)
+        elif self._is_getlogger(func):
+            if node.args:
+                name = _const_str(node.args[0])
+                if name in self.family:
+                    self._add(node.lineno, "logger-name", name, "")
+        elif self._is_patch_call(func):
+            if node.args:
+                target = _const_str(node.args[0])
+                if target:
+                    self._maybe_family_split(node.lineno, "patch-string", target)
+        self.generic_visit(node)
+
+    # ---- predicates -----------------------------------------------------
+    @staticmethod
+    def _is_patch_call(func) -> bool:
+        if isinstance(func, ast.Name) and func.id == "patch":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "patch":
+            return True
+        return False
+
+    @staticmethod
+    def _is_patch_object_call(func) -> bool:
+        if isinstance(func, ast.Attribute) and func.attr == "object":
+            d = _dotted_name(func.value)
+            return d is not None and (d == "patch" or d.endswith(".patch"))
+        return False
+
+    @staticmethod
+    def _is_monkeypatch_setattr(func) -> bool:
+        if isinstance(func, ast.Attribute) and func.attr == "setattr":
+            return _dotted_name(func.value) == "monkeypatch"
+        return False
+
+    @staticmethod
+    def _is_caplog_at_level(func) -> bool:
+        if isinstance(func, ast.Attribute) and func.attr == "at_level":
+            return _dotted_name(func.value) == "caplog"
+        return False
+
+    @staticmethod
+    def _is_getlogger(func) -> bool:
+        if isinstance(func, ast.Name) and func.id == "getLogger":
+            return True
+        if isinstance(func, ast.Attribute) and func.attr == "getLogger":
+            return True
+        return False
+
+    # ---- handlers ---------------------------------------------------
+    def _maybe_family_split(self, lineno: int, mechanism: str, target: str):
+        if "." not in target:
+            return
+        mod, rest = target.split(".", 1)
+        if mod in self.family:
+            self._add(lineno, mechanism, mod, rest)
+
+    def _handle_patch_object(self, node: ast.Call):
+        if len(node.args) < 2:
+            return
+        resolved = self._tracker.resolve_class_ref(node.args[0])
+        attr_str = _const_str(node.args[1])
+        if resolved and attr_str:
+            module_target, class_name = resolved
+            self._add(node.lineno, "patch.object-attr", module_target, f"{class_name}.{attr_str}")
+
+    def _handle_monkeypatch(self, node: ast.Call):
+        if not node.args:
+            return
+        first = node.args[0]
+        s = _const_str(first)
+        if s is not None:
+            self._maybe_family_split(node.lineno, "monkeypatch", s)
+            return
+        resolved = self._tracker.resolve_class_ref(first)
+        if resolved and len(node.args) >= 2:
+            attr_str = _const_str(node.args[1])
+            if attr_str:
+                module_target, class_name = resolved
+                self._add(node.lineno, "monkeypatch", module_target, f"{class_name}.{attr_str}")
+
+    def _handle_caplog(self, node: ast.Call):
+        for kw in node.keywords:
+            if kw.arg == "logger":
+                val = _const_str(kw.value)
+                if val in self.family:
+                    self._add(node.lineno, "logger-name", val, "")
+                return
+        if len(node.args) >= 2:
+            val = _const_str(node.args[1])
+            if val in self.family:
+                self._add(node.lineno, "logger-name", val, "")
+
+
+# ---------------------------------------------------------------------------
+# Regex fallback — AST is authoritative; this only ADDS entries AST structurally
+# cannot see (e.g. a logger name embedded in a form the AST predicates above
+# don't recognise). Never removes or overrides an AST-found entry.
+# ---------------------------------------------------------------------------
+_LOGGER_KW_REGEX = re.compile(r'logger\s*=\s*["\']([\w.]+)["\']')
+_GETLOGGER_REGEX = re.compile(r'getLogger\(\s*["\']([\w.]+)["\']\s*\)')
+
+
+def _regex_fallback(relpath: str, text: str, family: frozenset, existing_keys: set) -> list:
+    extra = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        for regex in (_LOGGER_KW_REGEX, _GETLOGGER_REGEX):
+            for m in regex.finditer(line):
+                name = m.group(1)
+                if name not in family:
+                    continue
+                key = (relpath, i, "logger-name", name, "")
+                if key not in existing_keys:
+                    extra.append(Coupling(relpath, i, "logger-name", name, ""))
+                    existing_keys.add(key)
+    return extra
+
+
+def scan_test_file(path: Path, family: frozenset) -> list:
+    relpath = str(path.relative_to(REPO_ROOT))
+    text = path.read_text(encoding="utf-8")
+    tree = ast.parse(text, filename=str(path))
+    scanner = _CensusFileScanner(relpath, family)
+    scanner.visit(tree)
+    couplings = list(scanner.couplings)
+    existing_keys = {(c.file, c.line, c.mechanism, c.module_target, c.symbol) for c in couplings}
+    couplings.extend(_regex_fallback(relpath, text, family, existing_keys))
+    return couplings
+
+
+def scan_tests_dir(tests_dir: Path = TESTS_DIR, family: Optional[frozenset] = None) -> list:
+    if family is None:
+        family = discover_family()
+    all_couplings: list = []
+    for path in sorted(tests_dir.rglob("*.py")):
+        all_couplings.extend(scan_test_file(path, family))
+    return sorted(all_couplings)
+
+
+# ---------------------------------------------------------------------------
+# Layer 6 helpers — facade bind-form. Reuses the same binding tracker so
+# "which modules count as family" can never drift between the census (tests/)
+# side and the facade (dispatch_envelope.py) side.
+# ---------------------------------------------------------------------------
+
+
+def scan_facade_bindings(facade_path: Path, family: frozenset) -> _FamilyBindingTracker:
+    """Parse facade_path (dispatch_envelope.py) and return the tracker holding
+    every `import <envelope_*>` / `from <envelope_*> import X` statement found,
+    where family excludes 'dispatch_envelope' itself (the facade importing
+    FROM its own sibling modules, never the reverse)."""
+    submodule_family = family - {"dispatch_envelope"}
+    tree = ast.parse(facade_path.read_text(encoding="utf-8"), filename=str(facade_path))
+    tracker = _FamilyBindingTracker(submodule_family)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.ImportFrom):
+            tracker.visit_ImportFrom(node)
+        elif isinstance(node, ast.Import):
+            tracker.visit_Import(node)
+    return tracker
+
+
+def find_facade_attribute_calls(facade_path: Path, module_alias_names: frozenset) -> list:
+    """Every `<module_alias>.<attr>` access in the facade where module_alias is
+    one of the (forbidden) plain-module-import bindings — i.e. the attribute
+    -form call the facade must never use for a re-exported symbol."""
+    tree = ast.parse(facade_path.read_text(encoding="utf-8"), filename=str(facade_path))
+    hits = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Attribute) and isinstance(node.value, ast.Name):
+            if node.value.id in module_alias_names:
+                hits.append((node.lineno, node.value.id, node.attr))
+    return hits
+
+
+if __name__ == "__main__":
+    import json
+    import sys
+
+    fam = discover_family()
+    results = scan_tests_dir(family=fam)
+    gap = verify_family_pattern_gap()
+    print("FAMILY:", sorted(fam), file=sys.stderr)
+    print("TOTAL COUPLINGS:", len(results), file=sys.stderr)
+    if gap:
+        print("FAMILY PATTERN GAP:", gap, file=sys.stderr)
+    CENSUS_FIXTURE.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "family": sorted(fam),
+        "couplings": [c.to_dict() for c in results],
+    }
+    CENSUS_FIXTURE.write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    print(f"wrote {CENSUS_FIXTURE} ({len(results)} couplings)", file=sys.stderr)

--- a/tests/test_dispatch_envelope_characterization.py
+++ b/tests/test_dispatch_envelope_characterization.py
@@ -1,0 +1,477 @@
+"""test_dispatch_envelope_characterization.py — PR-0 of the dispatch_envelope
+monolith split (dispatch-monolith-split, PR-0 of 7).
+
+scripts/lib/dispatch_envelope.py (1980 lines) is being split into
+envelope_types.py, envelope_prepare.py, envelope_govern_support.py,
+envelope_govern.py, envelope_adapters_claude.py and envelope_adapters_provider.py
+across PR-1..PR-6. dispatch_envelope.py stays the public address and
+re-exports every relocated symbol. This file is the vangnet that makes the
+resulting drift LOUD instead of silent, before any of that code moves.
+
+The rule every layer below assumes: a name-string coupling
+(`patch("dispatch_envelope.X")`, `logger="dispatch_envelope"`) resolves
+against the globals of the module the CALLER lives in, not the new home of
+the symbol X. Move the symbol but not the caller -> the facade re-export
+keeps the patch working. Move the caller -> the patch stops binding, silently,
+because dispatch_envelope's globals no longer hold the name the caller
+resolves at call time. See dispatch_envelope_census_scanner.py's module
+docstring for the concrete failure this caused across three plan-gate rounds.
+
+Six layers:
+  1. Import surface   — every name a real consumer imports stays importable.
+  2. Census scanner    — generated inventory of every coupling in tests/ to
+                          the dispatch_envelope module family, matched by a
+                          dynamically-discovered family (never a fixed list).
+  3. Site bindings      — the 6 concretely-exposed sites; each is patched,
+                          exercised, and its interception verified directly.
+  4. Annotation resolve — typing.get_type_hints on every symbol that will
+                          move, dynamically discovered.
+  5. Import graph       — no envelope_* module may import dispatch_envelope.
+  6. Facade bind-form   — re-exports must use `from X import Y` + bare-name
+                          calls, never the attribute form that silently
+                          defeats patch-string.
+
+No production code changes in this PR (test-only).
+"""
+from __future__ import annotations
+
+import ast
+import contextlib
+import inspect
+import json
+import logging
+import typing
+from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+import dispatch_envelope
+from dispatch_envelope import EnvelopeSpec, _AdapterResult
+
+from dispatch_envelope_census_scanner import (
+    CENSUS_FIXTURE,
+    SCRIPTS_LIB,
+    Coupling,
+    discover_family,
+    find_facade_attribute_calls,
+    scan_facade_bindings,
+    scan_tests_dir,
+    verify_family_pattern_gap,
+)
+
+
+def _fake_adapter_result(status: str = "success") -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="ok", status=status)
+
+
+def _make_spec(tmp_path: Path, dispatch_id: str) -> EnvelopeSpec:
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(exist_ok=True)
+    data_dir = tmp_path / "data"
+    (data_dir / "unified_reports").mkdir(parents=True, exist_ok=True)
+    return EnvelopeSpec(
+        dispatch_id=dispatch_id,
+        terminal_id="T9",
+        provider="codex",
+        model="test-model",
+        instruction="characterization probe",
+        role=None,
+        pr_id=None,
+        state_dir=state_dir,
+        data_dir=data_dir,
+    )
+
+
+@contextlib.contextmanager
+def _stub_peripheral_govern_deps(receipt_return):
+    """Stub every _govern dependency NOT under test in a given Layer 3 case,
+    so each test isolates the one coupling it verifies. receipt_return is
+    the Path emit_dispatch_receipt should report back (must already exist
+    on disk — _govern fail-closes on a missing receipt file)."""
+    with patch("governance_emit.emit_unified_report", return_value=None), \
+         patch("governance_emit.emit_dispatch_receipt", return_value=receipt_return) as mock_receipt, \
+         patch("provider_costs.emit_provider_cost"), \
+         patch("phantom_guard.record_phantom_if_any"), \
+         patch("phantom_guard.record_guard_error"):
+        yield mock_receipt
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — import surface
+# ---------------------------------------------------------------------------
+
+
+def _discover_consumer_surface() -> frozenset:
+    """Derived from the real consumers via AST — not hand-typed. Every name
+    dispatch_cli.py / provider_dispatch.py actually import from
+    dispatch_envelope today, plus the four PR-1 types (EnvelopeSpec,
+    EnvelopeResult, EnvelopeGovernError, _AdapterResult) which no consumer
+    imports today but which PR-1 moves and which the facade must re-export."""
+    names = set()
+    for consumer in ("dispatch_cli.py", "provider_dispatch.py"):
+        path = SCRIPTS_LIB / consumer
+        tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom) and node.module == "dispatch_envelope":
+                names.update(alias.name for alias in node.names)
+    names |= {"EnvelopeSpec", "EnvelopeResult", "EnvelopeGovernError", "_AdapterResult"}
+    return frozenset(names)
+
+
+CONSUMER_SURFACE = _discover_consumer_surface()
+
+
+class TestLayer1ImportSurface:
+    """dispatch_envelope.py stays the public address: every name a real
+    consumer imports today, plus the four PR-1 types, must remain importable
+    from the facade through every step of the PR-1..PR-6 split."""
+
+    @pytest.mark.parametrize("name", sorted(CONSUMER_SURFACE))
+    def test_name_importable_from_facade(self, name):
+        assert hasattr(dispatch_envelope, name), (
+            f"dispatch_envelope.{name} is no longer importable — a re-export "
+            f"was dropped in a split PR. Real consumers: "
+            f"scripts/lib/dispatch_cli.py, scripts/lib/provider_dispatch.py."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Layer 2 — census scanner
+# ---------------------------------------------------------------------------
+
+
+def _census_diff(live: list, expected: list) -> str:
+    live_set, expected_set = set(live), set(expected)
+    added = sorted(live_set - expected_set)
+    removed = sorted(expected_set - live_set)
+    lines = ["census mismatch vs tests/data/dispatch_envelope_census.json"]
+    if added:
+        lines.append(f"  + {len(added)} coupling(s) the live scan found but the fixture doesn't have:")
+        lines.extend(f"      {c.file}:{c.line} [{c.mechanism}] {c.module_target}.{c.symbol}" for c in added)
+    if removed:
+        lines.append(f"  - {len(removed)} coupling(s) the fixture has but the live scan no longer finds:")
+        lines.extend(f"      {c.file}:{c.line} [{c.mechanism}] {c.module_target}.{c.symbol}" for c in removed)
+    lines.append("  regenerate with: python3 tests/dispatch_envelope_census_scanner.py")
+    return "\n".join(lines)
+
+
+class TestLayer2Census:
+    """The census is GENERATED (tests/data/dispatch_envelope_census.json),
+    not hand-maintained — see dispatch_envelope_census_scanner.py's module
+    docstring for why a fixed module-name list is the wrong design.
+
+    THIS COMPARISON IS SUPPOSED TO GO RED when PR-3/PR-4 relocate the exposed
+    sites onto envelope_* modules. That is bedoeld gedrag, not flake:
+    regenerate the fixture in the SAME commit that moves the code, and let
+    the diff in the failure message BE the review evidence. Do not "fix" a
+    red here by loosening this comparison — that defeats the entire point of
+    this file.
+    """
+
+    def test_no_family_pattern_gap(self):
+        gap = verify_family_pattern_gap()
+        assert not gap, "\n".join(gap)
+
+    def test_every_envelope_module_in_scope(self):
+        """A scripts/lib/envelope_*.py that exists on disk must be part of
+        the discovered family. Vacuous today (glob is empty pre-PR-1); binds
+        the moment the first envelope_*.py file appears."""
+        family = discover_family()
+        for f in SCRIPTS_LIB.glob("envelope_*.py"):
+            assert f.stem in family, f"{f} exists on disk but discover_family() missed it"
+
+    def test_census_matches_fixture(self):
+        family = discover_family()
+        live = scan_tests_dir(family=family)
+        fixture = json.loads(CENSUS_FIXTURE.read_text(encoding="utf-8"))
+        assert sorted(fixture["family"]) == sorted(family), (
+            f"fixture was generated against family={sorted(fixture['family'])!r} "
+            f"but the live family is {sorted(family)!r} — regenerate the fixture"
+        )
+        expected = sorted(Coupling.from_dict(d) for d in fixture["couplings"])
+        assert live == expected, _census_diff(live, expected)
+
+
+# ---------------------------------------------------------------------------
+# Layer 3 — binding per exposed site
+# ---------------------------------------------------------------------------
+
+
+class TestLayer3ArchiveClearBinding:
+    """Sites 1, 2, 3, 4 all patch the SAME two symbols
+    (_archive_dispatch_events, _clear_dispatch_events) against the SAME
+    caller (_govern, dispatch_envelope.py lines ~840 and ~1070):
+      - site 1: tests/test_dispatch_envelope.py:236  (asserted at line 248)
+      - site 2: tests/test_dispatch_envelope.py:237  (sibling assert at 248)
+      - site 3: tests/test_role_applied_provider_lane.py:211 (NO assertion)
+      - site 4: tests/test_role_applied_provider_lane.py:212 (NO assertion)
+    Sites 3/4 are the ones that would go silently green after a relocation:
+    the patch stops binding, the REAL functions run instead, and nothing in
+    that test file notices because it only asserts role_applied fields. This
+    class supplies the missing assertion independently of whether either
+    pre-existing file keeps testing it.
+
+    SAFETY (sites 3/4's real risk): if the patch below did NOT bind, the REAL
+    _clear_dispatch_events would truncate the live event stream for
+    spec.terminal_id under whatever VNX_DATA_DIR is ambient. Every fixture
+    here uses tmp_path exclusively for state_dir/data_dir — an unbound patch
+    can only ever touch a throwaway directory, never a live
+    .vnx-data/events/T{n}.ndjson.
+    """
+
+    def test_archive_and_clear_called_via_govern(self, tmp_path):
+        spec = _make_spec(tmp_path, "layer3-archive-clear")
+        result = _fake_adapter_result()
+        start = end = datetime.now(timezone.utc)
+        receipt_file = spec.state_dir / "t0_receipts.ndjson"
+        receipt_file.touch()
+
+        mock_archive = MagicMock(return_value=(None, True))
+        mock_clear = MagicMock()
+
+        with patch("dispatch_envelope._archive_dispatch_events", mock_archive), \
+             patch("dispatch_envelope._clear_dispatch_events", mock_clear), \
+             _stub_peripheral_govern_deps(receipt_file):
+            dispatch_envelope._govern(spec, result, start, end)
+
+        mock_archive.assert_called_once_with(spec.terminal_id, spec.dispatch_id)
+        mock_clear.assert_called_once_with(spec.terminal_id, spec.dispatch_id)
+
+
+class TestLayer3Site5And6LoggerName:
+    """Sites 5 & 6 both capture via
+    `caplog.at_level(logging.WARNING, logger="dispatch_envelope")`:
+      - site 5: tests/test_dispatch_envelope.py:557 (reached via _govern)
+      - site 6: tests/test_dispatch_envelope.py:591 (direct call, dispatch_envelope.py:593)
+
+    FINDING (not corrected — see Open Items): both actually bind against
+    _receipt_exists_for_dispatch's OWN `logging.getLogger(__name__)`, i.e.
+    the SYMBOL's eventual home module — not wherever _govern (site 5's
+    caller) ends up. The PR-0 dispatch predicted site 5 breaks in "PR-3 or
+    PR-4" and site 6 in "PR-3"; since both routes execute the same
+    _receipt_exists_for_dispatch logger call, they will actually break
+    together, in whichever PR relocates _receipt_exists_for_dispatch itself.
+    """
+
+    def test_site5_via_govern_logs_under_dispatch_envelope_logger(self, tmp_path, caplog):
+        spec = _make_spec(tmp_path, "layer3-site5-logger")
+        result = _fake_adapter_result()
+        start = end = datetime.now(timezone.utc)
+
+        receipt_path = spec.state_dir / "t0_receipts.ndjson"
+        receipt_path.write_text('{"dispatch_id":"other-dispatch"}\n', encoding="utf-8")
+
+        _real_open = open
+
+        def _selective_open(path, *args, **kwargs):
+            if str(receipt_path) in str(path):
+                raise OSError("Permission denied")
+            return _real_open(path, *args, **kwargs)
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_envelope"), \
+             patch("dispatch_envelope._archive_dispatch_events", return_value=(None, True)), \
+             patch("dispatch_envelope._clear_dispatch_events"), \
+             _stub_peripheral_govern_deps(receipt_path) as mock_receipt, \
+             patch("builtins.open", side_effect=_selective_open):
+            dispatch_envelope._govern(spec, result, start, end)
+
+        # fail-closed dedup: the OSError makes _receipt_exists_for_dispatch
+        # return True, so the emit branch (and mock_receipt) is skipped.
+        mock_receipt.assert_not_called()
+        assert any(
+            "cannot read receipt ledger" in r.message and "Permission denied" in r.message
+            for r in caplog.records
+        ), f"expected a WARNING about the unreadable ledger, got: {[r.message for r in caplog.records]}"
+
+    def test_site6_direct_call_logs_under_dispatch_envelope_logger(self, tmp_path, caplog):
+        receipt_path = tmp_path / "t0_receipts.ndjson"
+        receipt_path.write_text('{"dispatch_id":"some-id"}\n', encoding="utf-8")
+
+        _real_open = open
+
+        def _raise_oserror(path, *args, **kwargs):
+            if str(receipt_path) in str(path):
+                raise OSError("Permission denied")
+            return _real_open(path, *args, **kwargs)
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_envelope"), \
+             patch("builtins.open", side_effect=_raise_oserror):
+            result = dispatch_envelope._receipt_exists_for_dispatch(receipt_path, "some-id")
+
+        assert result is True
+        assert any(
+            "cannot read receipt ledger" in r.message and "Permission denied" in r.message
+            for r in caplog.records
+        ), f"expected a WARNING about the unreadable ledger, got: {[r.message for r in caplog.records]}"
+
+
+# ---------------------------------------------------------------------------
+# Layer 4 — annotation resolution
+# ---------------------------------------------------------------------------
+
+# OI-288 (tests/test_dispatch_envelope_annotations_resolve.py) already covers
+# these four — not duplicated here.
+_OI288_COVERED = frozenset({
+    ("dispatch_envelope.ProviderAdapter", "run"),
+    ("dispatch_envelope.ProviderAdapter", "_run_kimi"),
+    ("dispatch_envelope", "run_envelope_plan"),
+    ("dispatch_envelope", "run_envelope_headless_plan"),
+})
+
+
+def _discover_module_functions() -> dict:
+    """Every function/method DEFINED in dispatch_envelope.py (not imported
+    from elsewhere), keyed by (owner_label, attr_name). get_type_hints
+    resolves against a function object's OWN __globals__ regardless of which
+    module name is used to reach it — so this stays a valid regression test
+    after the symbol relocates, as long as the facade keeps re-exporting it."""
+    found = {}
+    for name, obj in vars(dispatch_envelope).items():
+        if name.startswith("__"):
+            continue
+        if inspect.isfunction(obj) and getattr(obj, "__module__", None) == "dispatch_envelope":
+            found[("dispatch_envelope", name)] = obj
+        elif inspect.isclass(obj) and getattr(obj, "__module__", None) == "dispatch_envelope":
+            for meth_name, meth in vars(obj).items():
+                if inspect.isfunction(meth):
+                    found[(f"dispatch_envelope.{name}", meth_name)] = meth
+    return found
+
+
+def _discover_module_classes() -> dict:
+    return {
+        ("dispatch_envelope", name): obj
+        for name, obj in vars(dispatch_envelope).items()
+        if inspect.isclass(obj) and getattr(obj, "__module__", None) == "dispatch_envelope"
+    }
+
+
+_ALL_FUNCS = _discover_module_functions()
+_NEW_FUNC_KEYS = sorted(k for k in _ALL_FUNCS if k not in _OI288_COVERED)
+_ALL_CLASSES = _discover_module_classes()
+_ALL_CLASS_KEYS = sorted(_ALL_CLASSES)
+
+
+class TestLayer4AnnotationResolution:
+    """typing.get_type_hints resolves against func.__globals__ — the module a
+    symbol is DEFINED in, not wherever a facade re-exports it from. A symbol
+    that moves to a module which only imports its annotated type under
+    TYPE_CHECKING breaks introspection with NameError post-move (this is the
+    exact bug OI-288 caught for ExecutionPlan/ExecutionPermit before the
+    runtime imports at dispatch_envelope.py:47-48 existed).
+
+    Discovered dynamically (inspect.isfunction/isclass filtered to
+    __module__ == "dispatch_envelope") instead of hand-listed, so a symbol
+    added after this PR is covered automatically without editing this file.
+    """
+
+    @pytest.mark.parametrize("owner,attr", _NEW_FUNC_KEYS)
+    def test_function_annotations_resolve(self, owner, attr):
+        func = _ALL_FUNCS[(owner, attr)]
+        try:
+            typing.get_type_hints(func)
+        except NameError as exc:
+            pytest.fail(f"{owner}.{attr}: unresolved annotation name: {exc}")
+
+    @pytest.mark.parametrize("owner,name", _ALL_CLASS_KEYS)
+    def test_class_annotations_resolve(self, owner, name):
+        cls = _ALL_CLASSES[(owner, name)]
+        try:
+            typing.get_type_hints(cls)
+        except NameError as exc:
+            pytest.fail(f"{owner}.{name}: unresolved annotation name: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# Layer 5 — import graph
+# ---------------------------------------------------------------------------
+
+
+class TestLayer5ImportGraph:
+    """No envelope_* module may import dispatch_envelope — one-way traffic,
+    facade depends on siblings, never the reverse. Vacuous today (no
+    envelope_* modules exist); the >=540-line guard makes sure "empty"
+    means "nothing has moved yet", not "this check stopped looking"."""
+
+    def test_no_envelope_module_imports_the_facade(self):
+        family = discover_family()
+        submodules = sorted(family - {"dispatch_envelope"})
+        facade_path = SCRIPTS_LIB / "dispatch_envelope.py"
+        facade_lines = len(facade_path.read_text(encoding="utf-8").splitlines())
+
+        if not submodules:
+            assert facade_lines >= 540, (
+                "zero envelope_* modules exist AND the facade has already shrunk "
+                f"below 540 lines ({facade_lines}) — PR-1..PR-6 have started "
+                "moving code out but no envelope_*.py landed on disk; this check "
+                "can no longer tell 'nothing moved yet' from 'stopped looking'"
+            )
+            pytest.skip(
+                f"no envelope_* modules exist yet (facade is {facade_lines} lines) "
+                "— this test binds once the first envelope_*.py module lands"
+            )
+
+        for modname in submodules:
+            path = SCRIPTS_LIB / f"{modname}.py"
+            tree = ast.parse(path.read_text(encoding="utf-8"), filename=str(path))
+            for node in ast.walk(tree):
+                if isinstance(node, ast.ImportFrom) and node.module == "dispatch_envelope":
+                    pytest.fail(f"{modname}.py:{node.lineno} imports FROM dispatch_envelope — cycle")
+                if isinstance(node, ast.Import):
+                    for alias in node.names:
+                        if alias.name == "dispatch_envelope":
+                            pytest.fail(f"{modname}.py:{node.lineno} imports dispatch_envelope — cycle")
+
+
+# ---------------------------------------------------------------------------
+# Layer 6 — facade bind-form
+# ---------------------------------------------------------------------------
+
+
+class TestLayer6FacadeBindForm:
+    """Re-export alone is not enough. Nine patch-sites stay safe only as
+    long as the facade both re-exports a relocated symbol AND calls it by
+    BARE NAME:
+
+        from envelope_govern_support import _archive_dispatch_events   # OK: patch binds
+        import envelope_govern_support                                 # BAD: patch does NOT bind
+
+    Calling it as `envelope_govern_support._archive_dispatch_events(...)`
+    resolves through the module object, and `patch("dispatch_envelope.X")`
+    never sees it — a silent green. Vacuous today (no envelope_* modules
+    exist); binds the moment the first one appears (mirrors Layer 5).
+    """
+
+    def test_facade_reimports_use_bare_name_form(self):
+        family = discover_family()
+        facade_path = SCRIPTS_LIB / "dispatch_envelope.py"
+        submodules = sorted(family - {"dispatch_envelope"})
+
+        if not submodules:
+            facade_lines = len(facade_path.read_text(encoding="utf-8").splitlines())
+            assert facade_lines >= 540, (
+                "zero envelope_* modules exist AND the facade has already shrunk "
+                f"below 540 lines ({facade_lines}) — see TestLayer5's identical guard"
+            )
+            pytest.skip("no envelope_* modules exist yet — binds once the first one lands")
+
+        tracker = scan_facade_bindings(facade_path, family)
+
+        assert not tracker.module_imports, (
+            "dispatch_envelope.py imports an envelope_* module via the bare "
+            "`import X` (attribute-call) form — patch(\"dispatch_envelope.<name>\") "
+            f"will not bind for anything re-exported that way: {tracker.module_imports}"
+        )
+        assert tracker.from_imports, (
+            "expected at least one `from envelope_* import ...` re-export in the "
+            "facade now that envelope_* modules exist"
+        )
+
+        # Defence in depth: redundant with the module_imports check above
+        # (that's the only way such an alias could get bound today) — kept
+        # explicit so a future indirect binding mechanism doesn't slip through.
+        module_alias_names = frozenset(local for (_, _, local) in tracker.module_imports)
+        hits = find_facade_attribute_calls(facade_path, module_alias_names)
+        assert not hits, f"facade calls an envelope_* symbol via attribute form: {hits}"


### PR DESCRIPTION
Eerste van zeven PR's voor track `dispatch-monolith-split` fase 1. **Test-only, nul wijzigingen in `scripts/lib/`.**

## Wat dit doet

Bouwt het vangnet voordat er productiecode beweegt. `scripts/lib/dispatch_envelope.py` (1.980 regels) wordt in PR-1 t/m PR-6 gesplitst in `envelope_*`-modules, met de facade als publiek adres. De testsuite zit met koppelingen aan de modulenaam aan dat bestand vast, en sommige daarvan breken **stil**: de test blijft groen terwijl hij niets meer bewaakt.

Zes lagen in `tests/test_dispatch_envelope_characterization.py`:

1. Import-oppervlak, afgeleid uit de echte consumenten
2. **De gegenereerde census** over `tests/` zelf, met verwachtingsbestand
3. Binding per blootgestelde site, inclusief een negatieve variant voor de `assert_not_called`-vorm
4. Annotatie-resolutie via `get_type_hints`
5. Import-graaf: geen `envelope_*`-module importeert de facade
6. Bindvorm van de facade: kale naam, niet de attribuutvorm

## De census wordt gegenereerd, niet opgesomd

Drie plan-ronden lang claimde het bouwplan een volledige koppelingskaart, en drie keer vond een panelist uit een andere modelfamilie een mechanisme dat er niet in zat. Dat is geen telfout maar een methodefout. De scanner leest `tests/` zelf, matcht op de hele `envelope_*`-familie in plaats van op één modulenaam, en faalt met een diff zodra de verzameling wijzigt zonder dat het verwachtingsbestand is bijgewerkt. PR-3 en PR-4 werken dat bestand in dezelfde commit bij; die faalmelding is bedoeld gedrag en geen flake.

## Meting, met de afwijking verklaard

Gemeten: **116 koppelingen over 5 mechanismen in 19 bestanden**, waar de handmatige plan-schatting op 35 stond. De scanner is niet bijgesteld om op 35 uit te komen. Het verschil zit in scope (19 bestanden tegen een handvol) en in `direct-call`, dat 82 van de 116 rijen levert en per regel wordt vastgelegd.

De twee mechanismen die werkelijk breken bij een verhuizende aanroeper zijn onafhankelijk door T0 hergemeten en sluiten exact aan:

| mechanisme | op origin/main (T0) | in dit testbestand | totaal (worker) |
|---|---|---|---|
| `patch-string` | 15 | 4 | 19 |
| `logger-name` | 2 | 4 | 6 |

## Verificatie

Door de worker gedraaid en door T0 onafhankelijk gereproduceerd, alle vijf identiek:

```
tests/test_dispatch_envelope_characterization.py        47 passed, 2 skipped
tests/test_dispatch_envelope.py -k "not TestFlagGateClaude"  31 passed, 4 deselected
tests/test_dispatch_cli.py                             120 passed
tests/test_role_applied_provider_lane.py                 9 passed
tests/test_dispatch_envelope_annotations_resolve.py      4 passed
```

De 2 skips zijn laag 5 en 6, die vandaag nog niets te toetsen hebben. Ze skippen **expliciet**, met het regelaantal van de facade in de melding, en binden zodra de eerste `envelope_*`-module landt. Dat onderscheidt "leeg want er is nog niets verhuisd" van "leeg want de test kijkt niet".

Beide rood-demonstraties zijn echt gedraaid en teruggedraaid; niets daarvan is meegecommit.

Dispatch-ID: `20260803-202008-pr0-envelope-census`