### PR TITLE
fix(pool): retry WAL journal_mode conversion instead of racing it

### DIFF
--- a/scripts/lib/pool_state_repo.py
+++ b/scripts/lib/pool_state_repo.py
@@ -20,6 +20,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Dict, List, Optional
 
+from coordination_retry import is_lock_timeout_error
 from pool_decision_engine import (
     POOL_HEARTBEAT_STALE_SECONDS,
     Membership,
@@ -29,6 +30,12 @@ from pool_decision_engine import (
 )
 
 log = logging.getLogger(__name__)
+
+# How long _ensure_wal() retries the journal_mode=WAL conversion before giving
+# up and raising loud. Only the very first connection(s) ever opened against a
+# given DB file hit this path — once one connection succeeds, the mode is
+# persisted in the file header and every later connection sees 'wal' already.
+_WAL_CONVERT_DEADLINE_SECONDS = 5.0
 
 
 # ---------------------------------------------------------------------------
@@ -91,13 +98,55 @@ class PoolStateRepository:
         # our explicit BEGIN IMMEDIATE calls when two threads race on the same DB.
         conn = sqlite3.connect(str(self.db_path), timeout=30.0, isolation_level=None)
         conn.row_factory = sqlite3.Row
-        conn.execute("PRAGMA journal_mode = WAL")
         # Belt-and-suspenders: set busy_timeout via PRAGMA in addition to the connect-level
         # timeout so SQLite retries on SQLITE_BUSY regardless of how the busy handler was
         # previously configured on this connection.
         conn.execute("PRAGMA busy_timeout = 30000")
+        self._ensure_wal(conn)
         conn.execute("PRAGMA foreign_keys = ON")
         return conn
+
+    def _ensure_wal(self, conn: sqlite3.Connection) -> None:
+        """Switch *conn* to WAL journal mode, tolerating the transient BUSY that
+        the conversion pragma can raise under concurrency.
+
+        Measured (dispatch 20260803-215135): ``PRAGMA journal_mode = WAL`` does
+        NOT go through SQLite's busy-handler — two connections racing to
+        convert a freshly created (still rollback-journal) DB file get an
+        immediate ``sqlite3.OperationalError: database is locked`` in well
+        under a millisecond, regardless of ``busy_timeout``. That is what
+        made ``test_concurrent_ticks_dont_double_scale`` /
+        ``test_concurrent_reap_idempotent`` flake: the very first tick() on a
+        brand-new pool DB, racing across two threads, both hit this pragma
+        before either has converted the file.
+
+        Once one connection succeeds, WAL is persisted in the file header and
+        every later connection already sees 'wal' — the cheap read-only check
+        below skips the exclusive-lock-requiring conversion entirely for the
+        overwhelming majority of calls, so this only ever retries during that
+        one-time first-conversion race.
+        """
+        mode = conn.execute("PRAGMA journal_mode").fetchone()[0]
+        if str(mode).lower() == "wal":
+            return
+
+        deadline = time.monotonic() + _WAL_CONVERT_DEADLINE_SECONDS
+        delay = 0.005
+        while True:
+            try:
+                mode = conn.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+            except sqlite3.OperationalError as exc:
+                if not is_lock_timeout_error(exc) or time.monotonic() >= deadline:
+                    raise
+                time.sleep(delay)
+                delay = min(delay * 2, 0.2)
+                continue
+            if str(mode).lower() != "wal":
+                log.warning(
+                    "pool_state_repo: journal_mode=WAL not honored for %s (got %r)",
+                    self.db_path, mode,
+                )
+            return
 
     # ------------------------------------------------------------------
     # Read methods

--- a/tests/test_pool_manager_integration.py
+++ b/tests/test_pool_manager_integration.py
@@ -343,8 +343,14 @@ def test_concurrent_ticks_dont_double_scale(tmp_path):
     t2 = threading.Thread(target=run_tick)
     t1.start()
     t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
+    # join timeout must exceed PoolStateRepository's busy_timeout (30s, see
+    # pool_state_repo.py _connect()) — a shorter join lets the test inspect
+    # `errors` while a thread is still legitimately blocked on the SQLite busy
+    # handler, which is a false pass (thread hasn't appended its error yet)
+    # every bit as much as it risks a false failure.
+    t1.join(timeout=35)
+    t2.join(timeout=35)
+    assert not t1.is_alive() and not t2.is_alive(), "tick() thread did not finish within 35s"
 
     assert not errors, f"Thread errors: {errors}"
     count = _active_count(db)

--- a/tests/test_pool_tick_reap_decide_execute.py
+++ b/tests/test_pool_tick_reap_decide_execute.py
@@ -224,8 +224,14 @@ def test_concurrent_reap_idempotent(tmp_path):
     t2 = threading.Thread(target=run_tick)
     t1.start()
     t2.start()
-    t1.join(timeout=10)
-    t2.join(timeout=10)
+    # join timeout must exceed PoolStateRepository's busy_timeout (30s, see
+    # pool_state_repo.py _connect()) — a shorter join lets the test inspect
+    # `errors` while a thread is still legitimately blocked on the SQLite busy
+    # handler, which is a false pass (thread hasn't appended its error yet)
+    # every bit as much as it risks a false failure.
+    t1.join(timeout=35)
+    t2.join(timeout=35)
+    assert not t1.is_alive() and not t2.is_alive(), "tick() thread did not finish within 35s"
 
     assert not errors, f"Concurrent tick errors: {errors}"
 


### PR DESCRIPTION
## Summary

`tests/test_pool_manager_integration.py::test_concurrent_ticks_dont_double_scale` and `tests/test_pool_tick_reap_decide_execute.py::test_concurrent_reap_idempotent` flake intermittently on unmodified `main` (measured 9/50 = 18% locally, matching the dispatch's 12-16% baseline) with `AssertionError: [OperationalError('database is locked')]`. This is pre-existing on the commit before #1344, not introduced by it.

## Root cause (measured, not guessed)

`PoolStateRepository._connect()` (`scripts/lib/pool_state_repo.py`) calls `PRAGMA journal_mode = WAL` unconditionally on every single connection. Instrumented repro (see report) shows this pragma does **not** go through SQLite's busy-handler at all: two connections racing to convert a freshly created (still rollback-journal) pool DB file get an immediate `sqlite3.OperationalError: database is locked` (`SQLITE_BUSY`) in ~0.15-0.2ms — regardless of `busy_timeout=30000`. That immediate, sub-millisecond failure is exactly what the dispatch instruction flagged as suspicious given the test's `join(timeout=10)`.

Neither of the two hypothesised candidates was quite right:
- `journal_mode` **does** end up `'wal'` (not silently stuck on `'delete'`) — but only on the connection that wins the race; the loser gets an unhandled exception instead of retrying.
- It's not a reader→writer snapshot-upgrade conflict (`BEGIN IMMEDIATE` in the write methods already starts immediate, with no prior read on the same connection).

The real defect: the mode-conversion pragma is a documented SQLite special case that bypasses the normal busy-handler retry loop, and the code never checked its return value or retried on failure.

## Fix

`_ensure_wal()`:
1. Reads the current `journal_mode` first (a lock-free read) — once the DB has been converted once (persisted in the file header), every later connection just sees `'wal'` and returns immediately. This is the overwhelming majority of calls.
2. Only when still in rollback-journal mode does it attempt the conversion, with a manual retry loop (classified via the existing `coordination_retry.is_lock_timeout_error`) bounded by a 5s deadline — since `busy_timeout` doesn't apply here, SQLite's built-in handler can't do this for us.

Also fixed the test's own bug the dispatch called out: `join(timeout=10)` was shorter than `PoolStateRepository`'s `busy_timeout=30000`, making the test unreliable in both directions (a still-blocked thread's `errors` list could be inspected before it had a chance to append — a false pass). Both tests now join with `timeout=35` (safely above the 30s busy_timeout) and assert the threads actually finished.

## Changes

- `scripts/lib/pool_state_repo.py` — new `_ensure_wal()` helper; `_connect()` calls it instead of the unconditional pragma; imports `is_lock_timeout_error` from `coordination_retry.py`.
- `tests/test_pool_manager_integration.py`, `tests/test_pool_tick_reap_decide_execute.py` — join timeout 10s → 35s + explicit `is_alive()` assertion.

## Verification

Dispatch's own loop (`test_concurrent_ticks_dont_double_scale` + `test_concurrent_reap_idempotent`, 50 runs):
- Before fix: 9/50 failed (18%)
- After fix: 0/50 failed

Full pool suite:
- `test_pool_manager_integration.py`: 14 passed
- `test_pool_tick_reap_decide_execute.py`: 10 passed
- `test_pool_reaper.py`: 25 passed
- `test_worker_heartbeat.py`: 20 passed, 1 pre-existing failure (`test_list_members_pid_none_when_not_set`, FK constraint) — reproduced identically on unmodified `main` via `git stash`, unrelated to this fix, and already excluded from CI via `scripts/ci/test_exclusions.txt`.

No schema changes — ADR-007 does not apply.

## Test plan

- [x] Ran the dispatch's 50-iteration loop before and after the fix
- [x] Ran all four pool test files individually with exact pass counts
- [x] Verified the pre-existing `test_worker_heartbeat.py` failure via `git stash` A/B comparison
- [x] `py_compile` + `ruff check` on changed files (no new lint issues; pre-existing unrelated issues left untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)