### PR TITLE
refactor(dispatch): extract envelope_prepare.py leaf module (PR-2 monolith split)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -56,6 +56,11 @@ from envelope_types import (  # noqa: E402
     EnvelopeSpec,
     _AdapterResult,
 )
+from envelope_prepare import (  # noqa: E402
+    _prepare,
+    _record_integrity,
+    _verify_role_application,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -257,129 +262,11 @@ class LaneRouter:
 
 
 # ---------------------------------------------------------------------------
-# PREPARE
+# PREPARE — _prepare, _record_integrity, _verify_role_application moved to
+# envelope_prepare.py (dispatch-monolith-split, PR-2 of 6); imported above
+# at bare name so every existing dispatch_envelope._prepare-shaped coupling
+# keeps binding.
 # ---------------------------------------------------------------------------
-
-
-def _prepare(spec: EnvelopeSpec) -> str:
-    """Enrich instruction with role context + intelligence and repo map (best-effort).
-
-    Mirrors _enrich_instruction in provider_dispatch.py but operates on EnvelopeSpec.
-    Layers fall back silently to the original instruction on any failure:
-
-    1. Repo-map layer on the RAW instruction (target-file extraction most
-       accurate before any enrichment text is added).
-    2. Role context + intelligence + full assembly via ``_inject_skill_context``
-       — the shared lane-neutral injector used by every dispatch lane
-       (dispatch-20260801-w10). This closes the envelope-lane gap where the
-       role's CLAUDE.md never reached the worker. On injector failure the
-       prompt falls back to a role label header.
-    """
-    instruction = spec.instruction
-
-    try:
-        from dispatch_enricher import apply_repo_map_layer  # noqa: PLC0415
-
-        instruction = apply_repo_map_layer(instruction, {"role": spec.role})
-    except Exception as exc:
-        logger.warning(
-            "envelope._prepare: repo map layer failed (%s) — skipping", exc
-        )
-
-    try:
-        from skill_context import _inject_skill_context  # noqa: PLC0415
-
-        dispatch_metadata: dict = {"dispatch_id": spec.dispatch_id}
-        if spec.pr_id:
-            dispatch_metadata["pr_id"] = spec.pr_id
-        instruction = _inject_skill_context(
-            spec.terminal_id,
-            instruction,
-            spec.role,
-            dispatch_metadata,
-        )
-    except Exception as exc:  # noqa: BLE001 — fallback must never break a dispatch
-        logger.warning(
-            "envelope._prepare: skill injection failed (%s); falling back to role label",
-            exc,
-        )
-        if spec.role:
-            header = f"## Role\n\nYou are operating as a **{spec.role}** worker."
-        else:
-            header = (
-                "## Worker Preamble\n\n"
-                "You are a VNX headless worker executing a dispatch instruction."
-            )
-        instruction = f"{header}\n\n{instruction}"
-
-    return instruction
-
-
-# ---------------------------------------------------------------------------
-# Final-prompt integrity (input-side audit closure)
-# ---------------------------------------------------------------------------
-
-
-def _record_integrity(
-    spec: EnvelopeSpec,
-    enriched_instruction: str,
-    raw_instruction: str,
-    *,
-    bundle_dir: Optional[Path] = None,
-):
-    """Persist the enriched final prompt + verify raw+injections reconstruct it.
-
-    Returns a FinalPromptIntegrity (stamped onto the receipt by _govern) or None
-    when the integrity module is unavailable / persistence failed. The strict
-    (fail-closed) reconstruction raise propagates; every other error is swallowed so
-    the audit-closure step can never itself break a dispatch.
-    """
-    try:
-        from final_prompt_integrity import record_final_prompt_integrity  # noqa: PLC0415
-        from final_prompt_integrity import InjectionReconstructError  # noqa: PLC0415
-    except ImportError:
-        return None
-    try:
-        return record_final_prompt_integrity(
-            dispatch_id=spec.dispatch_id,
-            final_prompt=enriched_instruction,
-            raw_instruction=raw_instruction,
-            data_dir=spec.data_dir,
-            state_dir=spec.state_dir,
-            bundle_dir=bundle_dir,
-        )
-    except InjectionReconstructError:
-        raise
-    except Exception as exc:  # noqa: BLE001 — audit closure must never break a dispatch
-        logger.error(
-            "envelope: final-prompt integrity failed (non-fatal) dispatch=%s: %s",
-            spec.dispatch_id,
-            exc,
-        )
-        return None
-
-
-def _verify_role_application(
-    final_prompt: str,
-    terminal_id: str,
-    role: Optional[str],
-):
-    """Best-effort: run the deterministic role-applied control for *final_prompt*.
-
-    Returns a RoleApplicationVerdict (or None on any failure — the control must
-    never break receipt emission; the fields then stay None/omitted).
-    """
-    try:
-        from role_application import verify_role_applied  # noqa: PLC0415
-        return verify_role_applied(final_prompt, terminal_id, role)
-    except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
-        logger.debug(
-            "envelope._verify_role_application: failed (non-fatal) role=%s terminal=%s: %s",
-            role,
-            terminal_id,
-            exc,
-        )
-        return None
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/envelope_prepare.py
+++ b/scripts/lib/envelope_prepare.py
@@ -1,0 +1,145 @@
+"""envelope_prepare.py — PREPARE-seam functions for the dispatch_envelope
+module family.
+
+Leaf module: no imports from sibling envelope_* modules or from
+dispatch_envelope itself (the facade imports FROM here, never the reverse).
+Moved unchanged from dispatch_envelope.py as PR-2 of the dispatch-monolith-split
+(dispatch-monolith-split, PR-2 of 6) — see dispatch_envelope.py's module
+docstring for the split's seam order.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Optional
+
+from envelope_types import EnvelopeSpec
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# PREPARE
+# ---------------------------------------------------------------------------
+
+
+def _prepare(spec: EnvelopeSpec) -> str:
+    """Enrich instruction with role context + intelligence and repo map (best-effort).
+
+    Mirrors _enrich_instruction in provider_dispatch.py but operates on EnvelopeSpec.
+    Layers fall back silently to the original instruction on any failure:
+
+    1. Repo-map layer on the RAW instruction (target-file extraction most
+       accurate before any enrichment text is added).
+    2. Role context + intelligence + full assembly via ``_inject_skill_context``
+       — the shared lane-neutral injector used by every dispatch lane
+       (dispatch-20260801-w10). This closes the envelope-lane gap where the
+       role's CLAUDE.md never reached the worker. On injector failure the
+       prompt falls back to a role label header.
+    """
+    instruction = spec.instruction
+
+    try:
+        from dispatch_enricher import apply_repo_map_layer  # noqa: PLC0415
+
+        instruction = apply_repo_map_layer(instruction, {"role": spec.role})
+    except Exception as exc:
+        logger.warning(
+            "envelope._prepare: repo map layer failed (%s) — skipping", exc
+        )
+
+    try:
+        from skill_context import _inject_skill_context  # noqa: PLC0415
+
+        dispatch_metadata: dict = {"dispatch_id": spec.dispatch_id}
+        if spec.pr_id:
+            dispatch_metadata["pr_id"] = spec.pr_id
+        instruction = _inject_skill_context(
+            spec.terminal_id,
+            instruction,
+            spec.role,
+            dispatch_metadata,
+        )
+    except Exception as exc:  # noqa: BLE001 — fallback must never break a dispatch
+        logger.warning(
+            "envelope._prepare: skill injection failed (%s); falling back to role label",
+            exc,
+        )
+        if spec.role:
+            header = f"## Role\n\nYou are operating as a **{spec.role}** worker."
+        else:
+            header = (
+                "## Worker Preamble\n\n"
+                "You are a VNX headless worker executing a dispatch instruction."
+            )
+        instruction = f"{header}\n\n{instruction}"
+
+    return instruction
+
+
+# ---------------------------------------------------------------------------
+# Final-prompt integrity (input-side audit closure)
+# ---------------------------------------------------------------------------
+
+
+def _record_integrity(
+    spec: EnvelopeSpec,
+    enriched_instruction: str,
+    raw_instruction: str,
+    *,
+    bundle_dir: Optional[Path] = None,
+):
+    """Persist the enriched final prompt + verify raw+injections reconstruct it.
+
+    Returns a FinalPromptIntegrity (stamped onto the receipt by _govern) or None
+    when the integrity module is unavailable / persistence failed. The strict
+    (fail-closed) reconstruction raise propagates; every other error is swallowed so
+    the audit-closure step can never itself break a dispatch.
+    """
+    try:
+        from final_prompt_integrity import record_final_prompt_integrity  # noqa: PLC0415
+        from final_prompt_integrity import InjectionReconstructError  # noqa: PLC0415
+    except ImportError:
+        return None
+    try:
+        return record_final_prompt_integrity(
+            dispatch_id=spec.dispatch_id,
+            final_prompt=enriched_instruction,
+            raw_instruction=raw_instruction,
+            data_dir=spec.data_dir,
+            state_dir=spec.state_dir,
+            bundle_dir=bundle_dir,
+        )
+    except InjectionReconstructError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — audit closure must never break a dispatch
+        logger.error(
+            "envelope: final-prompt integrity failed (non-fatal) dispatch=%s: %s",
+            spec.dispatch_id,
+            exc,
+        )
+        return None
+
+
+def _verify_role_application(
+    final_prompt: str,
+    terminal_id: str,
+    role: Optional[str],
+):
+    """Best-effort: run the deterministic role-applied control for *final_prompt*.
+
+    Returns a RoleApplicationVerdict (or None on any failure — the control must
+    never break receipt emission; the fields then stay None/omitted).
+    """
+    try:
+        from role_application import verify_role_applied  # noqa: PLC0415
+        return verify_role_applied(final_prompt, terminal_id, role)
+    except Exception as exc:  # noqa: BLE001 — verification must never break a dispatch
+        logger.debug(
+            "envelope._verify_role_application: failed (non-fatal) role=%s terminal=%s: %s",
+            role,
+            terminal_id,
+            exc,
+        )
+        return None

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -815,6 +815,7 @@
   ],
   "family": [
     "dispatch_envelope",
+    "envelope_prepare",
     "envelope_types"
   ],
   "layer4_classes": [
@@ -838,17 +839,17 @@
     "dispatch_envelope::_fail_loud_on_empty_success",
     "dispatch_envelope::_govern",
     "dispatch_envelope::_map_generic_spawn_result",
-    "dispatch_envelope::_prepare",
     "dispatch_envelope::_receipt_exists_for_dispatch",
-    "dispatch_envelope::_record_integrity",
     "dispatch_envelope::_resolve_fix_forward_diff",
     "dispatch_envelope::_resolve_phantom_diff",
     "dispatch_envelope::_unknown_verification",
     "dispatch_envelope::_verification_from_report",
-    "dispatch_envelope::_verify_role_application",
     "dispatch_envelope::run_envelope",
     "dispatch_envelope::run_envelope_headless_plan",
     "dispatch_envelope::run_envelope_plan",
+    "envelope_prepare::_prepare",
+    "envelope_prepare::_record_integrity",
+    "envelope_prepare::_verify_role_application",
     "envelope_types.EnvelopeResult::__eq__",
     "envelope_types.EnvelopeResult::__init__",
     "envelope_types.EnvelopeResult::__repr__",


### PR DESCRIPTION
## Summary

PR-2 of the `dispatch_envelope.py` monolith split (dispatch-monolith-split track). Moves `_prepare`, `_record_integrity`, `_verify_role_application` unchanged into a new leaf module `scripts/lib/envelope_prepare.py`. `dispatch_envelope.py` re-exports and calls all three at bare name (`from envelope_prepare import ...`), so every existing `dispatch_envelope._prepare`-shaped coupling keeps binding — the callers, including `_govern`'s own call to `_verify_role_application`, stay in the facade.

Pure move: zero logic changes, zero exposed patch-sites on these three symbols (confirmed by the PR-0 census scan).

## Changes

- **New:** `scripts/lib/envelope_prepare.py` — `_prepare` (line 30), `_record_integrity` (line 89), `_verify_role_application` (line 121). Leaf module: imports only `envelope_types.EnvelopeSpec`, no import of `dispatch_envelope` or any sibling `envelope_*` module.
- **Modified:** `scripts/lib/dispatch_envelope.py` — removed the three function bodies (now imported via `from envelope_prepare import _prepare, _record_integrity, _verify_role_application` near the top, alongside the existing `envelope_types` import). All call sites (`_prepare(spec)`, `_record_integrity(...)`, `_verify_role_application(...)` — including inside `_govern`) are unchanged, since only the *definitions* moved, not the *callers*.
- **Modified:** `tests/data/dispatch_envelope_census.json` — regenerated via `python3 tests/dispatch_envelope_census_scanner.py`. Diff is additive-only: `family` gains `envelope_prepare`; the three symbols relabel from `dispatch_envelope::_prepare` etc. to `envelope_prepare::_prepare` etc. in `layer4_functions`. Total coupling count (116) is unchanged — confirms the dispatch's "0 exposed sites" prediction.

**Verified line-for-line identical** (AST-diffed against `origin/main`'s `dispatch_envelope.py`): all three function bodies are byte-identical in their new home.

## Verification

Exact commands and counts:

```
pytest tests/test_dispatch_envelope_characterization.py -v   -> 50 passed
pytest tests/test_final_prompt_integrity.py                   -> 22 passed
pytest tests/test_envelope_role_propagation.py                -> 6 passed
pytest tests/test_role_applied_provider_lane.py                -> 9 passed
pytest tests/test_dispatch_envelope.py -k "not TestFlagGateClaude"  -> 31 passed, 4 deselected
```

All match the counts the dispatch predicted. `ruff check` clean on both changed files. No behavioral red is possible here — this is a pure relocation; the evidence is the import surface (Layer 1/5/6 of the characterization suite) plus unchanged behavioral test counts, not a constructed red/green pair.

Note on line numbers: the dispatch cited line 325/384/423 from `b7c5e71b`, but PR-1 (`envelope_types.py` extraction, #1346) had already landed on `origin/main` and shifted them. Verified current locations before this PR: `_prepare` at line 264, `_record_integrity` at line 323, `_verify_role_application` at line 362 (pre-move).

## Open Items

- **OI-983** (not fixed here, by design): in `_verify_role_application` (now `scripts/lib/envelope_prepare.py:121`), `role_applied` is verified against the `role` argument, while `_govern` separately stamps a possibly-different value onto the receipt's own `role` field — the two can disagree. This PR is a pure move; the bug is left exactly as-is for OI-983 to pick up at its new location (`scripts/lib/envelope_prepare.py`, `_verify_role_application`).
- PR-2 lands successfully — PR-4 (which moves `_govern`) is unblocked to proceed; `_govern`'s call to `_verify_role_application` at `dispatch_envelope.py:733` resolves via the facade's bare-name import, same as every other caller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)