### PR TITLE
refactor(dispatch): extract envelope_adapters_claude.py leaf module (PR-5 monolith split)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -71,184 +71,20 @@ from envelope_govern_support import (  # noqa: E402
     _verification_from_report,
 )
 from envelope_govern import _govern  # noqa: E402
+from envelope_adapters_claude import (  # noqa: E402
+    ClaudeSubprocessAdapter,
+    CodexAdapter,
+)
 
 logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
-# Adapters
+# Adapters -- CodexAdapter, ClaudeSubprocessAdapter moved to
+# envelope_adapters_claude.py (dispatch-monolith-split, PR-5 of 6); imported
+# above at bare name so every existing dispatch_envelope.CodexAdapter /
+# dispatch_envelope.ClaudeSubprocessAdapter-shaped coupling keeps binding.
 # ---------------------------------------------------------------------------
-
-
-class CodexAdapter:
-    """Wraps spawn_codex — reuses existing spawn without reimplementation.
-
-    event_writer is not wired in PR-1 (no EventStore setup here); the audit
-    stream gap is documented in Open Items and closed in a later PR.
-    """
-
-    def run(
-        self,
-        spec: EnvelopeSpec,
-        event_writer: Optional[Callable] = None,
-        cwd: Optional[Path] = None,
-    ) -> _AdapterResult:
-        from provider_spawns.codex_spawn import spawn_codex  # noqa: PLC0415
-
-        try:
-            result = spawn_codex(
-                prompt=spec.instruction,
-                model=spec.model,
-                dispatch_id=spec.dispatch_id,
-                terminal_id=spec.terminal_id,
-                event_writer=event_writer,
-                cwd=cwd,
-            )
-        except BrokenPipeError as exc:
-            return _AdapterResult(
-                returncode=1,
-                completion_text="",
-                status="failure",
-                error=f"codex spawn BrokenPipeError: {exc}",
-            )
-
-        token_usage: Dict[str, int] = {}
-        raw_usage = getattr(result, "token_usage", None)
-        if isinstance(raw_usage, dict):
-            token_usage = {
-                "input": int(
-                    raw_usage.get("input_tokens", raw_usage.get("input", 0)) or 0
-                ),
-                "output": int(
-                    raw_usage.get("output_tokens", raw_usage.get("output", 0)) or 0
-                ),
-                "cache_hit": int(
-                    raw_usage.get(
-                        "cache_read_tokens", raw_usage.get("cache_hit", 0)
-                    ) or 0
-                ),
-            }
-
-        if result.error:
-            return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
-                status="failure",
-                token_usage=token_usage,
-                error=result.error,
-                event_writer_failures=result.event_writer_failures,
-                model=spec.model,
-            )
-        if result.timed_out:
-            return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
-                status="timeout",
-                token_usage=token_usage,
-                timed_out=True,
-                event_writer_failures=result.event_writer_failures,
-                model=spec.model,
-            )
-        status = "success" if result.returncode == 0 else "failure"
-        return _AdapterResult(
-            returncode=result.returncode,
-            completion_text=(result.completion_text or ""),
-            status=status,
-            token_usage=token_usage,
-            event_writer_failures=result.event_writer_failures,
-            model=spec.model,
-        )
-
-
-class ClaudeSubprocessAdapter:
-    """Wraps spawn_claude — reuses existing spawn without reimplementation.
-
-    Maps ClaudeSpawnResult fields to _AdapterResult for the envelope GOVERN
-    phase.  Worker reports remain the primary audit artifact; completion_text
-    is now also captured from spawn_claude for benchmark and utility callers
-    that need the model's raw text output.
-
-    event_writer is not wired in PR-2 (SubprocessAdapter handles EventStore
-    internally); the audit stream gap is documented in Open Items.
-    """
-
-    def run(
-        self,
-        spec: EnvelopeSpec,
-        event_writer: Optional[Callable] = None,
-        cwd: Optional[Path] = None,
-    ) -> _AdapterResult:
-        from provider_spawns.claude_spawn import spawn_claude  # noqa: PLC0415
-
-        try:
-            result = spawn_claude(
-                prompt=spec.instruction,
-                model=spec.model,
-                dispatch_id=spec.dispatch_id,
-                terminal_id=spec.terminal_id,
-                event_writer=event_writer,
-                cwd=cwd,
-                role=spec.role,
-                total_deadline=float(spec.deadline_seconds),
-            )
-        except BrokenPipeError as exc:
-            return _AdapterResult(
-                returncode=1,
-                completion_text="",
-                status="failure",
-                error=f"claude spawn BrokenPipeError: {exc}",
-            )
-
-        token_usage: Dict[str, int] = {}
-        raw_usage = result.token_usage
-        if isinstance(raw_usage, dict) and raw_usage:
-            token_usage = {
-                "input": int(raw_usage.get("input_tokens", 0) or 0),
-                "output": int(raw_usage.get("output_tokens", 0) or 0),
-                "cache_hit": int(
-                    raw_usage.get("cache_read_input_tokens", 0) or 0
-                ),
-            }
-        model_used = getattr(result, "model", None) or spec.model
-
-        if result.error:
-            return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
-                status="failure",
-                token_usage=token_usage,
-                error=result.error,
-                session_id=result.session_id,
-                model=model_used,
-            )
-        if result.timed_out:
-            return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
-                status="timeout",
-                token_usage=token_usage,
-                timed_out=True,
-                session_id=result.session_id,
-                model=model_used,
-            )
-        if result.stopped_early:
-            return _AdapterResult(
-                returncode=result.returncode,
-                completion_text=(result.completion_text or ""),
-                status="success",
-                token_usage=token_usage,
-                session_id=result.session_id,
-                model=model_used,
-            )
-        status = "success" if result.returncode == 0 else "failure"
-        return _AdapterResult(
-            returncode=result.returncode,
-            completion_text=(result.completion_text or ""),
-            status=status,
-            token_usage=token_usage,
-            session_id=result.session_id,
-            model=model_used,
-        )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/envelope_adapters_claude.py
+++ b/scripts/lib/envelope_adapters_claude.py
@@ -1,0 +1,192 @@
+"""envelope_adapters_claude.py — codex + claude-subprocess adapters for the
+dispatch_envelope module family.
+
+Leaf module: no imports from sibling envelope_* modules or from
+dispatch_envelope itself (the facade imports FROM here, never the reverse).
+Moved unchanged from dispatch_envelope.py as PR-5 of the dispatch-monolith-split
+(dispatch-monolith-split, PR-5 of 6) — see dispatch_envelope.py's module
+docstring for the split's seam order.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Callable, Dict, Optional
+
+from envelope_types import EnvelopeSpec, _AdapterResult
+
+
+# ---------------------------------------------------------------------------
+# Adapters
+# ---------------------------------------------------------------------------
+
+
+class CodexAdapter:
+    """Wraps spawn_codex — reuses existing spawn without reimplementation.
+
+    event_writer is not wired in PR-1 (no EventStore setup here); the audit
+    stream gap is documented in Open Items and closed in a later PR.
+    """
+
+    def run(
+        self,
+        spec: EnvelopeSpec,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from provider_spawns.codex_spawn import spawn_codex  # noqa: PLC0415
+
+        try:
+            result = spawn_codex(
+                prompt=spec.instruction,
+                model=spec.model,
+                dispatch_id=spec.dispatch_id,
+                terminal_id=spec.terminal_id,
+                event_writer=event_writer,
+                cwd=cwd,
+            )
+        except BrokenPipeError as exc:
+            return _AdapterResult(
+                returncode=1,
+                completion_text="",
+                status="failure",
+                error=f"codex spawn BrokenPipeError: {exc}",
+            )
+
+        token_usage: Dict[str, int] = {}
+        raw_usage = getattr(result, "token_usage", None)
+        if isinstance(raw_usage, dict):
+            token_usage = {
+                "input": int(
+                    raw_usage.get("input_tokens", raw_usage.get("input", 0)) or 0
+                ),
+                "output": int(
+                    raw_usage.get("output_tokens", raw_usage.get("output", 0)) or 0
+                ),
+                "cache_hit": int(
+                    raw_usage.get(
+                        "cache_read_tokens", raw_usage.get("cache_hit", 0)
+                    ) or 0
+                ),
+            }
+
+        if result.error:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="failure",
+                token_usage=token_usage,
+                error=result.error,
+                event_writer_failures=result.event_writer_failures,
+                model=spec.model,
+            )
+        if result.timed_out:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="timeout",
+                token_usage=token_usage,
+                timed_out=True,
+                event_writer_failures=result.event_writer_failures,
+                model=spec.model,
+            )
+        status = "success" if result.returncode == 0 else "failure"
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status=status,
+            token_usage=token_usage,
+            event_writer_failures=result.event_writer_failures,
+            model=spec.model,
+        )
+
+
+class ClaudeSubprocessAdapter:
+    """Wraps spawn_claude — reuses existing spawn without reimplementation.
+
+    Maps ClaudeSpawnResult fields to _AdapterResult for the envelope GOVERN
+    phase.  Worker reports remain the primary audit artifact; completion_text
+    is now also captured from spawn_claude for benchmark and utility callers
+    that need the model's raw text output.
+
+    event_writer is not wired in PR-2 (SubprocessAdapter handles EventStore
+    internally); the audit stream gap is documented in Open Items.
+    """
+
+    def run(
+        self,
+        spec: EnvelopeSpec,
+        event_writer: Optional[Callable] = None,
+        cwd: Optional[Path] = None,
+    ) -> _AdapterResult:
+        from provider_spawns.claude_spawn import spawn_claude  # noqa: PLC0415
+
+        try:
+            result = spawn_claude(
+                prompt=spec.instruction,
+                model=spec.model,
+                dispatch_id=spec.dispatch_id,
+                terminal_id=spec.terminal_id,
+                event_writer=event_writer,
+                cwd=cwd,
+                role=spec.role,
+                total_deadline=float(spec.deadline_seconds),
+            )
+        except BrokenPipeError as exc:
+            return _AdapterResult(
+                returncode=1,
+                completion_text="",
+                status="failure",
+                error=f"claude spawn BrokenPipeError: {exc}",
+            )
+
+        token_usage: Dict[str, int] = {}
+        raw_usage = result.token_usage
+        if isinstance(raw_usage, dict) and raw_usage:
+            token_usage = {
+                "input": int(raw_usage.get("input_tokens", 0) or 0),
+                "output": int(raw_usage.get("output_tokens", 0) or 0),
+                "cache_hit": int(
+                    raw_usage.get("cache_read_input_tokens", 0) or 0
+                ),
+            }
+        model_used = getattr(result, "model", None) or spec.model
+
+        if result.error:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="failure",
+                token_usage=token_usage,
+                error=result.error,
+                session_id=result.session_id,
+                model=model_used,
+            )
+        if result.timed_out:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="timeout",
+                token_usage=token_usage,
+                timed_out=True,
+                session_id=result.session_id,
+                model=model_used,
+            )
+        if result.stopped_early:
+            return _AdapterResult(
+                returncode=result.returncode,
+                completion_text=(result.completion_text or ""),
+                status="success",
+                token_usage=token_usage,
+                session_id=result.session_id,
+                model=model_used,
+            )
+        status = "success" if result.returncode == 0 else "failure"
+        return _AdapterResult(
+            returncode=result.returncode,
+            completion_text=(result.completion_text or ""),
+            status=status,
+            token_usage=token_usage,
+            session_id=result.session_id,
+            model=model_used,
+        )

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -815,24 +815,23 @@
   ],
   "family": [
     "dispatch_envelope",
+    "envelope_adapters_claude",
     "envelope_govern",
     "envelope_govern_support",
     "envelope_prepare",
     "envelope_types"
   ],
   "layer4_classes": [
-    "dispatch_envelope::ClaudeSubprocessAdapter",
-    "dispatch_envelope::CodexAdapter",
     "dispatch_envelope::LaneRouter",
     "dispatch_envelope::ProviderAdapter",
+    "envelope_adapters_claude::ClaudeSubprocessAdapter",
+    "envelope_adapters_claude::CodexAdapter",
     "envelope_types::EnvelopeGovernError",
     "envelope_types::EnvelopeResult",
     "envelope_types::EnvelopeSpec",
     "envelope_types::_AdapterResult"
   ],
   "layer4_functions": [
-    "dispatch_envelope.ClaudeSubprocessAdapter::run",
-    "dispatch_envelope.CodexAdapter::run",
     "dispatch_envelope.LaneRouter::get",
     "dispatch_envelope.ProviderAdapter::_run_kimi",
     "dispatch_envelope.ProviderAdapter::run",
@@ -841,6 +840,8 @@
     "dispatch_envelope::run_envelope",
     "dispatch_envelope::run_envelope_headless_plan",
     "dispatch_envelope::run_envelope_plan",
+    "envelope_adapters_claude.ClaudeSubprocessAdapter::run",
+    "envelope_adapters_claude.CodexAdapter::run",
     "envelope_govern::_govern",
     "envelope_govern_support::_archive_dispatch_events",
     "envelope_govern_support::_clear_dispatch_events",


### PR DESCRIPTION
## Summary
- PR-5 of 6 in the `dispatch_envelope.py` monolith split (dispatch-monolith-split track). Pure move, no behavior change.
- Moves `CodexAdapter` and `ClaudeSubprocessAdapter` unchanged from `dispatch_envelope.py` into a new leaf module `scripts/lib/envelope_adapters_claude.py`.
- `_AdapterResult` is imported from `envelope_types.py` (PR-1), never from the facade.
- `dispatch_envelope.py` re-exports both classes at bare name (`from envelope_adapters_claude import ClaudeSubprocessAdapter, CodexAdapter`) so every existing coupling keeps binding.

## Verified line numbers (vs. dispatch's `b7c5e71b` reference)
Line numbers had drifted from 129/209 to 83/163 (PR-1..PR-4 already reduced the file). Both classes moved from their current locations, verified via AST before the move.

## Identity check (per dispatch instruction)
```
dispatch_envelope.CodexAdapter is envelope_adapters_claude.CodexAdapter            -> True
dispatch_envelope.ClaudeSubprocessAdapter is envelope_adapters_claude.ClaudeSubprocessAdapter -> True
```
Confirmed with a control case (identity check against an unrelated decoy class fails as expected, proving the check discriminates).

## Nine attribute-form coupling sites — all green
Cross-checked against the PR-0 generated census (`tests/data/dispatch_envelope_census.json`), all nine sites resolve through `dispatch_envelope.<Class>` (test files import from the facade, not the new module):
- `tests/test_dispatch_envelope.py:360,365,784` (bare-name import + isinstance)
- `tests/test_dispatch_envelope_field_propagation.py:204,257` (`patch.object`)
- `tests/test_dispatch_envelope_plan.py:472,478` (bare-name import + `monkeypatch.setattr`)
- `tests/test_provider_deadline_passthrough.py:141,183` (bare-name import)

## Census expectation file
Regenerated via `python3 tests/dispatch_envelope_census_scanner.py`. The 116-entry `couplings` list is **unchanged** (test-side `module_target` stays `dispatch_envelope`, since tests still import from the facade). Only `family` (gains `envelope_adapters_claude`) and `layer4_classes`/`layer4_functions` (owner label for the two classes moves from `dispatch_envelope` to `envelope_adapters_claude`) changed — exactly what the split's own docstring predicts.

## Verification
```
pytest tests/test_dispatch_envelope_characterization.py -v   # 50 passed
pytest tests/test_dispatch_envelope_field_propagation.py     # 4 passed
pytest tests/test_dispatch_envelope_plan.py                  # 15 passed, 2 failed (pre-existing, unrelated)
pytest tests/test_dispatch_envelope.py -k "not TestFlagGateClaude"  # 31 passed, 4 deselected
pytest tests/test_dispatch_cli.py                             # 120 passed
```
The 2 `test_dispatch_envelope_plan.py` failures (`test_run_envelope_plan_requires_permit`, `test_instruction_read_from_file`) are a pre-existing nested-worktree artifact — confirmed identical on unmodified code in this same worktree (`git stash` + rerun before restoring). Neither failing test touches `CodexAdapter`/`ClaudeSubprocessAdapter`; none of the 9 census sites fall inside them.

`ruff check` on the new module: clean. `dispatch_envelope.py`'s 9 pre-existing F401s (intentional re-export pattern from PR-1..4) are unchanged in count.

## Test plan
- [x] `scripts/lib/envelope_adapters_claude.py` exists with both classes
- [x] `_AdapterResult` imported from `envelope_types.py`
- [x] Facade re-exports at bare name; identity check passed
- [x] All 9 attribute-form sites green
- [x] Census expectation file updated in the same commit
- [x] CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)