### PR TITLE
fix(hooks): stop path-parity split-brain and false-positive tripwire

### DIFF
--- a/scripts/hooks/path_parity_check.sh
+++ b/scripts/hooks/path_parity_check.sh
@@ -1,10 +1,18 @@
 #!/bin/bash
-# path_parity_check.sh — SessionStart hook: foreground vs background python3 parity.
+# path_parity_check.sh — SessionStart hook: real launchd/cron consumers vs
+# this project's requires-python range.
 #
 # OI-852 (Homebrew relink broke the background PATH-resolved python3 while the
 # foreground shell kept working) contaminated the diagnosis of every other
 # silent failure. The issue is closed; this check stays so the NEXT relink is
 # caught at session start instead of after days of confusion.
+#
+# The check itself (scripts/lib/path_parity.py) scans real launchd agents and
+# crontab entries and only alarms when one of them actually resolves an
+# out-of-range interpreter — a bare foreground/background PATH probe is kept
+# as diagnostic info only, never the alarm (see that module's docstring for
+# why: a minimal PATH on a CLT-less Mac always resolves Xcode's old python3,
+# which is a property of macOS, not a defect anyone can fix).
 #
 # Fail-soft by contract: this hook NEVER fails the session (always exit 0) and
 # takes well under the 5s SessionStart budget on a healthy machine.
@@ -19,24 +27,54 @@ if [ ! -f "$CHECKER" ]; then
   exit 0
 fi
 
-STATE_DIR="${VNX_STATE_DIR:-$ROOT/.vnx-data/state}"
+# ── Resolve the CENTRAL state dir (ADR-026), not a repo-local fallback ──────
+# git-toplevel-relative (the old `${VNX_STATE_DIR:-$ROOT/.vnx-data/state}`
+# fallback) splits the store: VNX_STATE_DIR is unset in a normal session, and
+# inside a dispatch worktree BOTH bash resolvers in this repo
+# (vnx_resolve_root.sh's git-toplevel walk, and vnx_paths.sh's explicit
+# worktree override) deliberately re-derive to that worktree's own
+# `.vnx-data` — correct for dispatch isolation, wrong for a SessionStart
+# artifact that must land in the one central per-project store every reader
+# expects. build_t0_state_hook.sh hit the identical trap (OI-859) and fixed
+# it the same way: shell out to the Python resolver (vnx_paths.resolve_paths),
+# which keeps the store central regardless of worktree, and only fall back to
+# a repo-local path if that resolution itself fails (no working interpreter).
+PY="$ROOT/.venv/bin/python"
+[ -x "$PY" ] || PY="/opt/homebrew/opt/python@3.12/bin/python3.12"
+[ -x "$PY" ] || PY="python3"
+
+STATE_DIR="$("$PY" -c "
+import sys
+sys.path.insert(0, '$ROOT/scripts/lib')
+from vnx_paths import resolve_paths
+print(resolve_paths()['VNX_STATE_DIR'])
+" 2>/dev/null)"
+[ -n "$STATE_DIR" ] || STATE_DIR="${VNX_STATE_DIR:-$ROOT/.vnx-data/state}"
 OUT="$STATE_DIR/path_parity.json"
 
-RESULT="$(python3 "$CHECKER" --write "$OUT" --no-fail 2>/dev/null)" || exit 0
+RESULT="$("$PY" "$CHECKER" --write "$OUT" --no-fail --repo-root "$ROOT" 2>/dev/null)" || exit 0
 
-# Surface a warning into the session context only when parity is broken.
+# Surface a warning into the session context only when a real consumer is broken.
 case "$RESULT" in
   *'"parity": false'*)
-    python3 - "$RESULT" <<'PYEOF' 2>/dev/null || true
+    "$PY" - "$RESULT" <<'PYEOF' 2>/dev/null || true
 import json, sys
 try:
     result = json.loads(sys.argv[1])
 except ValueError:
     sys.exit(0)
-kinds = ", ".join(m.get("kind", "?") for m in result.get("mismatches", []))
-msg = ("PATH/interpreter parity BROKEN (%s). Foreground and background "
-       "(launchd/cron) python3 diverge — background jobs may be failing while "
-       "the foreground looks healthy (OI-852 class). Details: path_parity.json" % kinds)
+parts = []
+for m in result.get("mismatches", []):
+    parts.append("%s -> %s (%s, needs %s)" % (
+        m.get("consumer", "?"), m.get("interpreter", "?"),
+        m.get("version", "?"), m.get("requires_python", "?"),
+    ))
+if not parts:
+    sys.exit(0)
+msg = ("PATH/interpreter parity BROKEN: %s. This launchd/cron consumer "
+       "resolves a python3 outside this project's requires-python range — "
+       "it may be failing silently in the background while the foreground "
+       "looks healthy (OI-852 class). Details: path_parity.json" % "; ".join(parts))
 print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart",
                                          "additionalContext": msg}}))
 PYEOF

--- a/scripts/lib/path_parity.py
+++ b/scripts/lib/path_parity.py
@@ -13,10 +13,24 @@ The check probes ``python3`` twice:
   background — a scrubbed environment with the launchd/cron default PATH
                (``/usr/bin:/bin:/usr/sbin:/sbin``), no aliases, no profile.
 
-Parity fails when the background interpreter is unrunnable, or when its
-major.minor version differs from the foreground's. An executable-PATH
-difference alone is informational (macOS jobs legitimately resolve a
-different binary than a brewed shell) — it is recorded, not flagged.
+That bare probe is diagnostic only (``raw_probe``, always ``info``): a
+minimal PATH on a macOS host without Xcode Command Line Tools legitimately
+resolves Xcode's bundled ``/usr/bin/python3`` (3.9.x on this fleet), which no
+real background job ever runs on — every scheduled consumer pins its own
+interpreter (see ``discover_launchd_consumers``/``discover_crontab_consumers``
+below). Comparing the bare probes can therefore never reach parity on this
+kind of machine, which is a property of macOS, not a defect anyone can fix —
+so it never drives ``parity``.
+
+``parity`` is instead driven by a **consumer scan**: it enumerates the
+launchd agents (``~/Library/LaunchAgents/com.vnx.*.plist``) and crontab
+entries that actually run on this machine, statically resolves (no
+execution unless the version cannot be inferred from the path) what
+interpreter each one would use, and fails only when a real consumer's
+interpreter falls outside this project's ``requires-python`` range
+(``pyproject.toml``). Consumers that invoke a script outside this repo, or a
+non-Python program, are recorded but never flagged — this project's
+``requires-python`` bound is not their bound to police.
 
 The library is pure/injectable for tests; the CLI is used by
 scripts/hooks/path_parity_check.sh at SessionStart.
@@ -27,10 +41,13 @@ import argparse
 import json
 import logging
 import os
+import re
+import shlex
+import shutil
 import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 _LOG = logging.getLogger(__name__)
 
@@ -109,7 +126,12 @@ def _major_minor(version: Optional[str]) -> Optional[str]:
 
 
 def compare_parity(foreground: Dict[str, Any], background: Dict[str, Any]) -> Dict[str, Any]:
-    """Decide parity from two probe results. Pure — no I/O, fully testable."""
+    """Decide raw parity from two probe results. Pure — no I/O, fully testable.
+
+    This is the bare foreground/background comparison. It is diagnostic only
+    (see module docstring) — callers surface its output as ``info``, never as
+    something that drives the check's overall ``parity`` verdict.
+    """
     mismatches = []
     info = []
 
@@ -151,33 +173,447 @@ def compare_parity(foreground: Dict[str, Any], background: Dict[str, Any]) -> Di
     }
 
 
-def check_parity(runner: Any = None) -> Dict[str, Any]:
-    """Probe foreground + background and decide parity."""
+# ─────────────────────────────────────────────────────────────────────────
+# Consumer scan — what real launchd/cron jobs would actually resolve.
+# ─────────────────────────────────────────────────────────────────────────
+
+DEFAULT_LAUNCHAGENTS_DIR = Path.home() / "Library" / "LaunchAgents"
+_LAUNCHD_LABEL_GLOB = "com.vnx.*.plist"
+
+_VERSION_IN_PATH_RE = re.compile(r"python(?:3)?[@.]?(\d+)\.(\d+)")
+_PINNED_PATH_RE = re.compile(r"(?:\"|'|\s|^)(/[\w./@-]*python3(?:\.\d+)?)\b")
+_REQUIRES_PYTHON_RE = re.compile(r'(?m)^requires-python\s*=\s*"([^"]+)"')
+_CLAUSE_RE = re.compile(r"(>=|<=|==|!=|>|<)\s*(\d+)\.(\d+)")
+
+
+def parse_requires_python(pyproject_path: Path) -> Optional[str]:
+    """Read the raw ``requires-python`` specifier string from pyproject.toml.
+
+    Returns None if the file is unreadable or the key is absent — callers
+    must treat that as "cannot judge range", not as "everything is fine".
+    """
+    try:
+        text = Path(pyproject_path).read_text(encoding="utf-8")
+    except OSError:
+        return None
+    match = _REQUIRES_PYTHON_RE.search(text)
+    return match.group(1) if match else None
+
+
+def _version_tuple(version: str) -> tuple:
+    parts = version.split(".")
+    return (int(parts[0]), int(parts[1]))
+
+
+def version_in_range(version: str, requires_python: str) -> Optional[bool]:
+    """Check a ``major.minor`` version string against a requires-python specifier.
+
+    Supports the comma-joined ``>=``/``<=``/``==``/``!=``/``>``/``<`` clauses
+    that ``requires-python`` values actually use (PEP 440 in full is not
+    needed here). Returns None — "cannot judge" — when either input is
+    unparseable, so callers never mistake "couldn't check" for "in range".
+    """
+    if not version or not requires_python:
+        return None
+    try:
+        v = _version_tuple(version)
+    except (ValueError, IndexError):
+        return None
+    clauses = [c.strip() for c in requires_python.split(",") if c.strip()]
+    if not clauses:
+        return None
+    for clause in clauses:
+        m = _CLAUSE_RE.match(clause)
+        if not m:
+            continue
+        op, major, minor = m.group(1), int(m.group(2)), int(m.group(3))
+        bound = (major, minor)
+        if op == ">=" and not v >= bound:
+            return False
+        if op == "<=" and not v <= bound:
+            return False
+        if op == "==" and not v == bound:
+            return False
+        if op == "!=" and not v != bound:
+            return False
+        if op == ">" and not v > bound:
+            return False
+        if op == "<" and not v < bound:
+            return False
+    return True
+
+
+def _version_from_path(path: str) -> Optional[str]:
+    """Infer major.minor from an interpreter path without executing it.
+
+    Covers both ``.../python@3.12/bin/python3.12`` and ``.../python3.12``
+    shapes. Returns None when the path doesn't encode a version (e.g. a bare
+    ``.venv/bin/python`` symlink) — the caller must then run ``--version``.
+    """
+    match = _VERSION_IN_PATH_RE.search(path)
+    if not match:
+        return None
+    return f"{match.group(1)}.{match.group(2)}"
+
+
+def resolve_interpreter_version(
+    path: str,
+    runner: Any = None,
+    cache: Optional[Dict[str, Optional[str]]] = None,
+) -> Optional[str]:
+    """Resolve an interpreter's major.minor version.
+
+    Infers it from the path when possible (no execution). Otherwise runs
+    ``--version`` once and caches the result by path — a fleet with several
+    consumers sharing one interpreter (e.g. the pinned python@3.12) never
+    re-executes it per consumer.
+    """
+    inferred = _version_from_path(path)
+    if inferred:
+        return inferred
+
+    cache = cache if cache is not None else {}
+    if path in cache:
+        return cache[path]
+
+    run = runner or subprocess.run
+    version: Optional[str] = None
+    try:
+        proc = run(
+            [path, "-c", "import sys;print(sys.version.split()[0])"],
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=5,
+        )
+        if proc.returncode == 0:
+            raw = proc.stdout.strip().splitlines()[-1]
+            version = _major_minor(raw)
+    except (OSError, subprocess.TimeoutExpired, IndexError):
+        version = None
+    cache[path] = version
+    return version
+
+
+def discover_launchd_consumers(agents_dir: Path, runner: Any = None) -> List[Dict[str, Any]]:
+    """Enumerate ``com.vnx.*.plist`` launchd agents as ``{label, argv, source}``.
+
+    Uses ``plutil -convert json`` (always present on macOS) instead of hand
+    parsing XML. Never raises — an unreadable or malformed plist is skipped,
+    not fatal to the scan.
+    """
+    run = runner or subprocess.run
+    agents_dir = Path(agents_dir)
+    consumers: List[Dict[str, Any]] = []
+    if not agents_dir.is_dir():
+        return consumers
+    for plist in sorted(agents_dir.glob(_LAUNCHD_LABEL_GLOB)):
+        try:
+            proc = run(
+                ["plutil", "-convert", "json", "-o", "-", str(plist)],
+                capture_output=True,
+                text=True,
+                check=False,
+                timeout=5,
+            )
+        except (OSError, subprocess.TimeoutExpired):
+            continue
+        if proc.returncode != 0:
+            continue
+        try:
+            data = json.loads(proc.stdout)
+        except ValueError:
+            continue
+        argv = data.get("ProgramArguments")
+        if not argv:
+            continue
+        consumers.append(
+            {
+                "label": data.get("Label") or plist.stem,
+                "argv": list(argv),
+                "source": str(plist),
+                "search_path": BACKGROUND_PATH,
+            }
+        )
+    return consumers
+
+
+_CRON_ENV_ASSIGN_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*=")
+
+
+def read_crontab(runner: Any = None) -> str:
+    """Return the current user's ``crontab -l`` output, or "" if none/absent."""
+    run = runner or subprocess.run
+    try:
+        proc = run(["crontab", "-l"], capture_output=True, text=True, check=False, timeout=5)
+    except (OSError, subprocess.TimeoutExpired):
+        return ""
+    if proc.returncode != 0:
+        return ""
+    return proc.stdout or ""
+
+
+def discover_crontab_consumers(crontab_text: str) -> List[Dict[str, Any]]:
+    """Parse ``crontab -l`` output into ``{label, argv, source, search_path}`` entries.
+
+    Honors a leading ``PATH=`` assignment as the search path for any bare
+    (unqualified) command those cron lines invoke — cron does not inherit the
+    interactive shell's PATH, so this is the PATH a bare ``python3`` in a cron
+    line would actually resolve against.
+    """
+    search_path = BACKGROUND_PATH
+    consumers: List[Dict[str, Any]] = []
+    idx = 0
+    for line in crontab_text.splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if _CRON_ENV_ASSIGN_RE.match(stripped):
+            key, _, value = stripped.partition("=")
+            if key.strip() == "PATH":
+                search_path = value.strip()
+            continue
+        try:
+            tokens = shlex.split(stripped)
+        except ValueError:
+            continue
+        if not tokens:
+            continue
+        if tokens[0].startswith("@"):
+            argv = tokens[1:]
+        else:
+            argv = tokens[5:]
+        if not argv:
+            continue
+        consumers.append(
+            {
+                "label": f"crontab#{idx}",
+                "argv": argv,
+                "source": "crontab",
+                "search_path": search_path,
+            }
+        )
+        idx += 1
+    return consumers
+
+
+_SHELL_BASENAMES = {"bash", "sh", "zsh"}
+
+
+def _extract_pinned_python_path(text: str) -> Optional[str]:
+    for match in _PINNED_PATH_RE.finditer(text):
+        candidate = match.group(1)
+        if Path(candidate).exists():
+            return candidate
+    return None
+
+
+def resolve_consumer_interpreter(
+    argv: List[str],
+    repo_root: Path,
+    search_path: str = BACKGROUND_PATH,
+) -> Dict[str, Any]:
+    """Statically determine the python interpreter a consumer's argv resolves to.
+
+    Never executes the target script. Returns
+    ``{interpreter, relevant, reason}`` — ``relevant`` is False for anything
+    this project's ``requires-python`` bound has no business judging: a
+    non-Python program, or a script outside ``repo_root`` (a different
+    project with its own, possibly different, supported-version range).
+    """
+    repo_root = Path(repo_root).resolve()
+    if not argv:
+        return {"interpreter": None, "relevant": False, "reason": "empty argv"}
+
+    exe = argv[0]
+    basename = Path(exe).name
+
+    if basename.startswith("python3") or "python@3" in exe:
+        return {"interpreter": exe, "relevant": True, "reason": "direct interpreter invocation"}
+
+    if basename == "vnx":
+        return {
+            "interpreter": None,
+            "relevant": False,
+            "reason": "vnx binary resolves its own interpreter (VNX_PYTHON, #1247)",
+        }
+
+    if basename not in _SHELL_BASENAMES:
+        return {"interpreter": None, "relevant": False, "reason": f"non-python consumer ({basename})"}
+
+    # Shell wrapper: either `bash -c "<inline text>"` or `bash /path/to/script`.
+    if len(argv) >= 3 and argv[1] == "-c":
+        text = argv[2]
+        script_desc = "inline -c script"
+        in_repo = str(repo_root) in text
+    else:
+        script_path = next((Path(a) for a in argv[1:] if a.endswith((".sh", ".py"))), None)
+        if script_path is None:
+            return {"interpreter": None, "relevant": False, "reason": "shell wrapper, no script argument"}
+        if not script_path.is_absolute():
+            script_path = (repo_root / script_path).resolve()
+        script_desc = script_path.name
+        try:
+            in_repo = script_path.resolve().is_relative_to(repo_root)
+        except AttributeError:  # pragma: no cover - Python <3.9 fallback, unreachable on this fleet
+            try:
+                script_path.resolve().relative_to(repo_root)
+                in_repo = True
+            except ValueError:
+                in_repo = False
+        if not in_repo:
+            return {
+                "interpreter": None,
+                "relevant": False,
+                "reason": f"{script_desc}: outside {repo_root.name} — not this project's requires-python to judge",
+            }
+        try:
+            text = script_path.read_text(encoding="utf-8", errors="replace")
+        except OSError:
+            return {"interpreter": None, "relevant": False, "reason": f"{script_desc}: unreadable"}
+
+    if not in_repo:
+        return {
+            "interpreter": None,
+            "relevant": False,
+            "reason": f"{script_desc}: outside {repo_root.name} — not this project's requires-python to judge",
+        }
+
+    venv_python = repo_root / ".venv" / "bin" / "python"
+    if ".venv/bin/python" in text and venv_python.exists():
+        return {"interpreter": str(venv_python), "relevant": True, "reason": f"{script_desc}: repo venv"}
+
+    pinned = _extract_pinned_python_path(text)
+    if pinned:
+        return {"interpreter": pinned, "relevant": True, "reason": f"{script_desc}: pinned interpreter path"}
+
+    if re.search(r"(?<![./\w])python3\b", text):
+        found = shutil.which("python3", path=search_path)
+        return {
+            "interpreter": found,
+            "relevant": found is not None,
+            "reason": f"{script_desc}: bare python3 via {'declared PATH' if search_path != BACKGROUND_PATH else 'background PATH'}",
+        }
+
+    return {"interpreter": None, "relevant": False, "reason": f"{script_desc}: no python invocation found"}
+
+
+def scan_consumers(
+    consumers: List[Dict[str, Any]],
+    repo_root: Path,
+    requires_python: Optional[str],
+    runner: Any = None,
+) -> Dict[str, Any]:
+    """Resolve every consumer's interpreter and check it against requires_python.
+
+    Pure aside from the interpreter-version execution inside
+    ``resolve_interpreter_version`` (injectable via ``runner``, cached by
+    path). ``parity`` here is what drives the check's overall verdict.
+    """
+    version_cache: Dict[str, Optional[str]] = {}
+    resolved: List[Dict[str, Any]] = []
+    mismatches: List[Dict[str, Any]] = []
+
+    for consumer in consumers:
+        outcome = resolve_consumer_interpreter(
+            consumer["argv"], repo_root, consumer.get("search_path", BACKGROUND_PATH)
+        )
+        entry: Dict[str, Any] = {
+            "label": consumer.get("label"),
+            "source": consumer.get("source"),
+            **outcome,
+        }
+        if outcome["relevant"] and outcome["interpreter"]:
+            version = resolve_interpreter_version(outcome["interpreter"], runner=runner, cache=version_cache)
+            entry["version"] = version
+            in_range = version_in_range(version, requires_python) if version else None
+            entry["in_range"] = in_range
+            if in_range is False:
+                mismatches.append(
+                    {
+                        "kind": "consumer_interpreter_out_of_range",
+                        "consumer": consumer.get("label"),
+                        "source": consumer.get("source"),
+                        "interpreter": outcome["interpreter"],
+                        "version": version,
+                        "requires_python": requires_python,
+                    }
+                )
+        resolved.append(entry)
+
+    return {
+        "parity": not mismatches,
+        "requires_python": requires_python,
+        "consumers": resolved,
+        "mismatches": mismatches,
+    }
+
+
+def _default_repo_root() -> Path:
+    try:
+        out = subprocess.check_output(
+            ["git", "rev-parse", "--show-toplevel"], stderr=subprocess.DEVNULL, text=True, timeout=5
+        ).strip()
+        if out:
+            return Path(out)
+    except (subprocess.CalledProcessError, FileNotFoundError, OSError, subprocess.TimeoutExpired):
+        pass
+    return Path.cwd()
+
+
+def check_parity(runner: Any = None, repo_root: Optional[Path] = None) -> Dict[str, Any]:
+    """Probe foreground/background (diagnostic) and scan real consumers (authoritative)."""
+    repo_root = Path(repo_root) if repo_root is not None else _default_repo_root()
+
     foreground = probe_interpreter(runner=runner)
     background = probe_interpreter(runner=runner, env=background_env())
-    result = compare_parity(foreground, background)
-    result.update(
-        {
-            "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    raw = compare_parity(foreground, background)
+
+    requires_python = parse_requires_python(repo_root / "pyproject.toml")
+    consumers = discover_launchd_consumers(DEFAULT_LAUNCHAGENTS_DIR, runner=runner)
+    consumers += discover_crontab_consumers(read_crontab(runner=runner))
+    consumer_scan = scan_consumers(consumers, repo_root, requires_python, runner=runner)
+
+    return {
+        "checked_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "parity": consumer_scan["parity"],
+        "mismatches": consumer_scan["mismatches"],
+        "consumer_scan": consumer_scan,
+        "raw_probe": {
+            "level": "info",
             "foreground": foreground,
             "background": background,
             "background_path": BACKGROUND_PATH,
-        }
-    )
-    return result
+            "mismatches": raw["mismatches"],
+            "info": raw["info"],
+        },
+    }
 
 
 def main(argv: Optional[list] = None) -> int:
-    parser = argparse.ArgumentParser(description="Foreground/background python3 parity check")
+    parser = argparse.ArgumentParser(description="PATH/interpreter parity check: real consumers vs requires-python")
     parser.add_argument("--write", default=None, help="Write the result JSON to this path")
     parser.add_argument("--no-fail", action="store_true", help="Always exit 0 (hook mode)")
+    parser.add_argument("--repo-root", default=None, help="Project root to scope the consumer scan to")
     args = parser.parse_args(argv)
 
-    result = check_parity()
+    repo_root = Path(args.repo_root) if args.repo_root else None
+    result = check_parity(repo_root=repo_root)
 
     if args.write:
         try:
             out = Path(args.write)
+            # Test-isolation backstop (w19c class guard): a no-op in production
+            # (pytest is never on sys.modules there), but catches a test that
+            # lost its isolation and is about to write into the real central
+            # store instead of a tmp_path sandbox — see the function's own
+            # docstring in this same concern's precedent, vnx_paths.py.
+            try:
+                from vnx_paths import refuse_real_central_store_write_under_pytest
+
+                refuse_real_central_store_write_under_pytest(out.parent)
+            except ImportError:
+                pass
             out.parent.mkdir(parents=True, exist_ok=True)
             out.write_text(json.dumps(result, indent=2, sort_keys=True), encoding="utf-8")
         except OSError as exc:

--- a/scripts/lib/path_parity.py
+++ b/scripts/lib/path_parity.py
@@ -41,6 +41,7 @@ import argparse
 import json
 import logging
 import os
+import plistlib
 import re
 import shlex
 import shutil
@@ -48,6 +49,7 @@ import subprocess
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
+from xml.parsers.expat import ExpatError
 
 _LOG = logging.getLogger(__name__)
 
@@ -295,34 +297,24 @@ def resolve_interpreter_version(
     return version
 
 
-def discover_launchd_consumers(agents_dir: Path, runner: Any = None) -> List[Dict[str, Any]]:
+def discover_launchd_consumers(agents_dir: Path) -> List[Dict[str, Any]]:
     """Enumerate ``com.vnx.*.plist`` launchd agents as ``{label, argv, source}``.
 
-    Uses ``plutil -convert json`` (always present on macOS) instead of hand
-    parsing XML. Never raises — an unreadable or malformed plist is skipped,
-    not fatal to the scan.
+    Uses stdlib ``plistlib`` (reads both XML and binary plists, on any
+    platform) instead of shelling out to ``plutil``, which does not exist on
+    Linux CI. Never raises — an unreadable or malformed plist is skipped, not
+    fatal to the scan.
     """
-    run = runner or subprocess.run
     agents_dir = Path(agents_dir)
     consumers: List[Dict[str, Any]] = []
     if not agents_dir.is_dir():
         return consumers
     for plist in sorted(agents_dir.glob(_LAUNCHD_LABEL_GLOB)):
         try:
-            proc = run(
-                ["plutil", "-convert", "json", "-o", "-", str(plist)],
-                capture_output=True,
-                text=True,
-                check=False,
-                timeout=5,
-            )
-        except (OSError, subprocess.TimeoutExpired):
-            continue
-        if proc.returncode != 0:
-            continue
-        try:
-            data = json.loads(proc.stdout)
-        except ValueError:
+            with open(plist, "rb") as fh:
+                data = plistlib.load(fh)
+        except (plistlib.InvalidFileException, ExpatError, OSError, ValueError):
+            # vnx-silent-except: unreadable/malformed plist is skipped, scan is fail-soft
             continue
         argv = data.get("ProgramArguments")
         if not argv:
@@ -570,7 +562,7 @@ def check_parity(runner: Any = None, repo_root: Optional[Path] = None) -> Dict[s
     raw = compare_parity(foreground, background)
 
     requires_python = parse_requires_python(repo_root / "pyproject.toml")
-    consumers = discover_launchd_consumers(DEFAULT_LAUNCHAGENTS_DIR, runner=runner)
+    consumers = discover_launchd_consumers(DEFAULT_LAUNCHAGENTS_DIR)
     consumers += discover_crontab_consumers(read_crontab(runner=runner))
     consumer_scan = scan_consumers(consumers, repo_root, requires_python, runner=runner)
 

--- a/tests/test_path_parity.py
+++ b/tests/test_path_parity.py
@@ -94,3 +94,245 @@ def test_probe_interpreter_flags_nonzero_exit() -> None:
 def test_background_env_uses_launchd_default_path() -> None:
     env = path_parity.background_env()
     assert env["PATH"] == path_parity.BACKGROUND_PATH
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# requires-python range parsing/checking
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_parse_requires_python_reads_pyproject(tmp_path) -> None:
+    pyproject = tmp_path / "pyproject.toml"
+    pyproject.write_text('[project]\nname = "x"\nrequires-python = ">=3.11,<3.14"\n')
+    assert path_parity.parse_requires_python(pyproject) == ">=3.11,<3.14"
+
+
+def test_parse_requires_python_missing_file_returns_none(tmp_path) -> None:
+    assert path_parity.parse_requires_python(tmp_path / "nope.toml") is None
+
+
+def test_version_in_range_within_bounds() -> None:
+    assert path_parity.version_in_range("3.12", ">=3.11,<3.14") is True
+
+
+def test_version_in_range_below_minimum() -> None:
+    assert path_parity.version_in_range("3.9", ">=3.11,<3.14") is False
+
+
+def test_version_in_range_at_or_above_exclusive_max() -> None:
+    assert path_parity.version_in_range("3.14", ">=3.11,<3.14") is False
+
+
+def test_version_in_range_unparseable_returns_none() -> None:
+    assert path_parity.version_in_range("", ">=3.11,<3.14") is None
+    assert path_parity.version_in_range("3.12", "") is None
+    assert path_parity.version_in_range("3.12", None) is None
+
+
+def test_version_from_path_infers_pinned_version() -> None:
+    assert path_parity._version_from_path("/opt/homebrew/opt/python@3.12/bin/python3.12") == "3.12"
+    assert path_parity._version_from_path("/opt/homebrew/opt/python@3.9/bin/python3") == "3.9"
+
+
+def test_version_from_path_none_for_unversioned_path() -> None:
+    assert path_parity._version_from_path("/repo/.venv/bin/python") is None
+
+
+def test_resolve_interpreter_version_infers_from_path() -> None:
+    assert path_parity.resolve_interpreter_version("/opt/homebrew/opt/python@3.12/bin/python3.12") == "3.12"
+
+
+def test_resolve_interpreter_version_executes_and_caches_when_unversioned() -> None:
+    calls = []
+
+    def runner(cmd, capture_output=False, text=False, check=False, timeout=None):
+        calls.append(cmd)
+        return _FakeProc(stdout="3.11.9\n")
+
+    cache: dict = {}
+    v1 = path_parity.resolve_interpreter_version("/repo/.venv/bin/python", runner=runner, cache=cache)
+    v2 = path_parity.resolve_interpreter_version("/repo/.venv/bin/python", runner=runner, cache=cache)
+    assert v1 == "3.11"
+    assert v2 == "3.11"
+    assert len(calls) == 1  # cached, not re-executed for the same interpreter path
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Consumer discovery — launchd plists + crontab
+# ─────────────────────────────────────────────────────────────────────────
+
+_FAKE_PLIST = """<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0"><dict>
+<key>Label</key><string>com.vnx.fake</string>
+<key>ProgramArguments</key><array>
+<string>/opt/homebrew/opt/python@3.12/bin/python3.12</string>
+<string>/repo/script.py</string>
+</array></dict></plist>
+"""
+
+
+def test_discover_launchd_consumers_parses_plist(tmp_path) -> None:
+    agents_dir = tmp_path / "LaunchAgents"
+    agents_dir.mkdir()
+    (agents_dir / "com.vnx.fake.plist").write_text(_FAKE_PLIST)
+    (agents_dir / "com.other.ignored.plist").write_text(_FAKE_PLIST)
+
+    consumers = path_parity.discover_launchd_consumers(agents_dir)
+    assert len(consumers) == 1
+    assert consumers[0]["label"] == "com.vnx.fake"
+    assert consumers[0]["argv"][0] == "/opt/homebrew/opt/python@3.12/bin/python3.12"
+
+
+def test_discover_launchd_consumers_missing_dir_returns_empty(tmp_path) -> None:
+    assert path_parity.discover_launchd_consumers(tmp_path / "nope") == []
+
+
+def test_discover_crontab_consumers_parses_schedule_and_declared_path() -> None:
+    text = (
+        "PATH=/opt/homebrew/bin:/usr/bin:/bin\n"
+        "0 3 * * * /opt/homebrew/bin/python3 /repo/scripts/nightly.py\n"
+        "# a comment line\n"
+        "\n"
+        "@daily python3 /repo/scripts/daily.py\n"
+    )
+    consumers = path_parity.discover_crontab_consumers(text)
+    assert len(consumers) == 2
+    assert consumers[0]["argv"] == ["/opt/homebrew/bin/python3", "/repo/scripts/nightly.py"]
+    assert consumers[0]["search_path"] == "/opt/homebrew/bin:/usr/bin:/bin"
+    assert consumers[1]["argv"] == ["python3", "/repo/scripts/daily.py"]
+
+
+def test_discover_crontab_consumers_empty_text_returns_empty() -> None:
+    assert path_parity.discover_crontab_consumers("") == []
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Static interpreter resolution — never executes the target script
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_resolve_consumer_interpreter_direct_python_invocation(tmp_path) -> None:
+    outcome = path_parity.resolve_consumer_interpreter(
+        ["/opt/homebrew/opt/python@3.12/bin/python3.12", "/repo/script.py"], tmp_path
+    )
+    assert outcome["relevant"] is True
+    assert outcome["interpreter"] == "/opt/homebrew/opt/python@3.12/bin/python3.12"
+
+
+def test_resolve_consumer_interpreter_vnx_binary_is_irrelevant(tmp_path) -> None:
+    outcome = path_parity.resolve_consumer_interpreter(["/opt/homebrew/bin/vnx", "dream", "run"], tmp_path)
+    assert outcome["relevant"] is False
+    assert "#1247" in outcome["reason"]
+
+
+def test_resolve_consumer_interpreter_non_python_binary_is_irrelevant(tmp_path) -> None:
+    outcome = path_parity.resolve_consumer_interpreter(["/usr/local/bin/node", "app.js"], tmp_path)
+    assert outcome["relevant"] is False
+
+
+def test_resolve_consumer_interpreter_finds_repo_venv_script(tmp_path) -> None:
+    (tmp_path / ".venv" / "bin").mkdir(parents=True)
+    venv_python = tmp_path / ".venv" / "bin" / "python"
+    venv_python.write_text("#!/bin/sh\n")
+    script = tmp_path / "scripts" / "nightly.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text('PY="$(dirname "$0")/../.venv/bin/python"\n"$PY" -c pass\n')
+
+    outcome = path_parity.resolve_consumer_interpreter(["/bin/bash", str(script)], tmp_path)
+    assert outcome["relevant"] is True
+    assert outcome["interpreter"] == str(venv_python)
+
+
+def test_resolve_consumer_interpreter_script_outside_repo_is_irrelevant(tmp_path) -> None:
+    other_root = tmp_path / "other-project"
+    script = other_root / "scripts" / "job.sh"
+    script.parent.mkdir(parents=True)
+    script.write_text("exec python3 -m something\n")
+    repo_root = tmp_path / "vnx-orchestration"
+    repo_root.mkdir()
+
+    outcome = path_parity.resolve_consumer_interpreter(["/bin/bash", str(script)], repo_root)
+    assert outcome["relevant"] is False
+    assert "outside" in outcome["reason"]
+
+
+def test_resolve_consumer_interpreter_inline_script_outside_repo_is_irrelevant(tmp_path) -> None:
+    outcome = path_parity.resolve_consumer_interpreter(
+        ["/bin/bash", "-c", 'exec "$SOME_OTHER_REPO/.venv/bin/python3" job.py'], tmp_path
+    )
+    assert outcome["relevant"] is False
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# Consumer scan — the counter-proof pair (DoD: must be able to fail, not
+# just report green because nothing was found).
+# ─────────────────────────────────────────────────────────────────────────
+
+def test_consumer_scan_flags_real_out_of_range_consumer(tmp_path) -> None:
+    """Negative control: a consumer pinned to a too-old interpreter MUST turn
+    the scan red. Without this, a scan that finds zero consumers would also
+    report parity=true, and a green result would be indistinguishable from a
+    blind scan that checked nothing — the exact failure mode this item exists
+    to prevent (a control that can never fail, fails silently)."""
+    consumers = [
+        {
+            "label": "com.vnx.fake-stale-job",
+            "argv": ["/opt/homebrew/opt/python@3.9/bin/python3.9", "/some/script.py"],
+            "source": "/fake/com.vnx.fake-stale-job.plist",
+            "search_path": path_parity.BACKGROUND_PATH,
+        }
+    ]
+    result = path_parity.scan_consumers(consumers, tmp_path, ">=3.11,<3.14")
+    assert result["parity"] is False
+    assert len(result["mismatches"]) == 1
+    mismatch = result["mismatches"][0]
+    assert mismatch["kind"] == "consumer_interpreter_out_of_range"
+    assert mismatch["consumer"] == "com.vnx.fake-stale-job"
+    assert mismatch["version"] == "3.9"
+    assert mismatch["interpreter"] == "/opt/homebrew/opt/python@3.9/bin/python3.9"
+
+
+def test_consumer_scan_stays_green_when_all_pinned_in_range(tmp_path) -> None:
+    """Positive control paired with the negative one above: every consumer
+    directly pins an in-range interpreter -> parity stays true, and every
+    consumer entry actually got resolved+checked (not just absent)."""
+    consumers = [
+        {
+            "label": "com.vnx.dashboard",
+            "argv": ["/opt/homebrew/opt/python@3.12/bin/python3.12", "/some/serve.py"],
+            "source": "/fake/com.vnx.dashboard.plist",
+            "search_path": path_parity.BACKGROUND_PATH,
+        },
+        {
+            "label": "com.vnx.provider-usage",
+            "argv": ["/opt/homebrew/opt/python@3.12/bin/python3.12", "/some/collect.py"],
+            "source": "/fake/com.vnx.provider-usage.plist",
+            "search_path": path_parity.BACKGROUND_PATH,
+        },
+    ]
+    result = path_parity.scan_consumers(consumers, tmp_path, ">=3.11,<3.14")
+    assert result["parity"] is True
+    assert result["mismatches"] == []
+    assert len(result["consumers"]) == 2
+    assert all(c["in_range"] for c in result["consumers"])
+
+
+def test_check_parity_raw_probe_is_informational_only(tmp_path, monkeypatch) -> None:
+    """Integration shape check: a raw foreground/background version mismatch
+    must land under raw_probe (level=info) and must NOT flip top-level
+    parity — only a real consumer out of range may do that (defect B)."""
+    (tmp_path / "pyproject.toml").write_text('[project]\nrequires-python = ">=3.11,<3.14"\n')
+    monkeypatch.setattr(path_parity, "DEFAULT_LAUNCHAGENTS_DIR", tmp_path / "no-such-dir")
+    monkeypatch.setattr(path_parity, "read_crontab", lambda runner=None: "")
+
+    def runner(cmd, capture_output=False, text=False, check=False, env=None, timeout=None):
+        version = "3.9.6" if (env or {}).get("PATH") == path_parity.BACKGROUND_PATH else "3.12.4"
+        payload = json.dumps({"executable": "/usr/bin/python3", "version": version, "prefix": "/x"})
+        return _FakeProc(stdout=payload + "\n")
+
+    result = path_parity.check_parity(runner=runner, repo_root=tmp_path)
+    assert result["raw_probe"]["level"] == "info"
+    assert result["raw_probe"]["mismatches"][0]["kind"] == "version_mismatch"
+    # No real consumers were discoverable in this sandboxed tmp_path -> nothing to flag.
+    assert result["parity"] is True
+    assert result["mismatches"] == []
+    assert result["consumer_scan"]["requires_python"] == ">=3.11,<3.14"

--- a/tests/test_path_parity_hook.py
+++ b/tests/test_path_parity_hook.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""tests/test_path_parity_hook.py — path_parity_check.sh central-store resolution.
+
+Defect A (OI-852/857-adjacent, "the hook splits the store"): the old hook
+resolved ``STATE_DIR`` as ``${VNX_STATE_DIR:-$ROOT/.vnx-data/state}`` — a
+repo-local fallback, not the central per-project store (ADR-026). In a normal
+session VNX_STATE_DIR is unset, so the old hook silently wrote a second,
+diverging copy of ``path_parity.json`` next to the repo instead of the one
+every other reader expects at ``~/.vnx-data/<project>/state/``.
+
+These tests run the real hook (bash + the real vnx_paths resolver) against
+this real repo checkout — a synthetic fake repo would have no real project
+identity to resolve against and would prove nothing about the actual bug.
+Isolation from the REAL central store (``~/.vnx-data/vnx-dev``) is via
+``VNX_DATA_HOME`` redirected at a tmp_path, not via VNX_DATA_DIR_EXPLICIT:
+the whole point is exercising the same "VNX_STATE_DIR/VNX_DATA_DIR unset"
+code path production hits, which VNX_DATA_DIR_EXPLICIT would short-circuit
+before it ever ran.
+"""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "scripts" / "hooks" / "path_parity_check.sh"
+LIB = REPO / "scripts" / "lib"
+sys.path.insert(0, str(LIB))
+
+import vnx_paths  # noqa: E402
+
+_HOOK_BUDGET_SECONDS = 5.0
+
+
+def _run_hook(env: dict) -> subprocess.CompletedProcess:
+    start = time.monotonic()
+    result = subprocess.run(
+        ["bash", str(HOOK)],
+        input="{}",
+        capture_output=True,
+        text=True,
+        cwd=str(REPO),
+        env=env,
+        timeout=10,
+    )
+    elapsed = time.monotonic() - start
+    assert elapsed < _HOOK_BUDGET_SECONDS, f"SessionStart budget exceeded: {elapsed:.2f}s"
+    assert result.returncode == 0, (
+        f"hook must always exit 0 (fail-soft contract): "
+        f"rc={result.returncode}\nstdout={result.stdout}\nstderr={result.stderr}"
+    )
+    return result
+
+
+def test_hook_resolves_central_state_dir_without_vnx_state_dir_set(tmp_path, monkeypatch):
+    """The exact defect: VNX_STATE_DIR unset (the normal-session condition)
+    must resolve to the SAME central path the canonical Python resolver
+    (vnx_paths.resolve_paths) returns — never the repo-local fallback."""
+    monkeypatch.delenv("VNX_STATE_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    isolated_home = tmp_path / "vnx-data-home"
+    monkeypatch.setenv("VNX_DATA_HOME", str(isolated_home))
+
+    expected_state_dir = Path(vnx_paths.resolve_paths()["VNX_STATE_DIR"])
+    repo_local_fallback = REPO / ".vnx-data" / "state"
+    assert expected_state_dir != repo_local_fallback, (
+        "central resolver coincides with the repo-local fallback on this "
+        "machine -- this test cannot distinguish the fix from the old bug"
+    )
+
+    env = dict(os.environ)
+    _run_hook(env)
+
+    out_path = expected_state_dir / "path_parity.json"
+    assert out_path.is_file(), f"expected the central write at {out_path}, found nothing there"
+    assert not (repo_local_fallback / "path_parity.json").exists(), (
+        "hook wrote the OLD repo-local split-brain path as well as (or instead "
+        "of) the central one"
+    )
+    data = json.loads(out_path.read_text())
+    assert "parity" in data
+    assert "consumer_scan" in data
+
+
+def test_hook_honors_explicit_vnx_state_dir(tmp_path, monkeypatch):
+    """An explicit VNX_STATE_DIR override (e.g. a dispatch worker's own
+    central per-project pin) must still be honored — the central-resolver
+    fix must not steamroll a legitimate explicit override."""
+    monkeypatch.setenv("VNX_STATE_DIR", str(tmp_path))
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    env = dict(os.environ)
+    _run_hook(env)
+
+    out_path = tmp_path / "path_parity.json"
+    assert out_path.is_file()
+    data = json.loads(out_path.read_text())
+    assert "parity" in data
+
+
+def test_hook_is_valid_bash():
+    result = subprocess.run(["bash", "-n", str(HOOK)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr


### PR DESCRIPTION
## Summary

The `path_parity_check.sh` SessionStart tripwire had two independent defects underneath the closed OI-852/OI-857 items:

- **Defect A (split-brain):** `STATE_DIR="${VNX_STATE_DIR:-$ROOT/.vnx-data/state}"` falls back to a repo-local path whenever `VNX_STATE_DIR` is unset — the normal-session case. The central per-project store (ADR-026) never sees the write. This worktree itself had a stale repo-local copy from its own SessionStart run, one minute out of sync with the central copy — direct evidence of the bug.
- **Defect B (unfixable alarm):** the check compared a bare foreground vs. background `python3` probe. On a Mac without Xcode Command Line Tools, a minimal PATH always resolves Xcode's bundled 3.9.6 — permanently failing parity regardless of whether any real background job is actually broken. It fired every session, including alongside a real tripwire, making the noise impossible to distinguish from a signal.

## Changes

- `scripts/hooks/path_parity_check.sh` — resolves `STATE_DIR` via `vnx_paths.resolve_paths()` (mirroring `build_t0_state_hook.sh`, since both bash resolvers in this repo deliberately re-derive to the worktree-local store), instead of a repo-local fallback. Rewrote the alert message to name the specific consumer + interpreter.
- `scripts/lib/path_parity.py` — added a consumer scan: enumerates real `com.vnx.*.plist` launchd agents + crontab entries, statically resolves each one's interpreter (path-inferred where possible, single cached `--version` call otherwise — never re-executing a script), and flags `parity: false` only when a real consumer resolves outside this project's `requires-python` range (read from `pyproject.toml`, not hardcoded). The raw foreground/background probe is kept as `raw_probe` (`level: info`) — diagnostic only, no longer drives the verdict. Also added a test-isolation backstop on the write path (`refuse_real_central_store_write_under_pytest`).
- `tests/test_path_parity.py` — 23 new tests: requires-python parsing/range checks, consumer discovery (launchd + crontab), static interpreter resolution (repo-venv, pinned path, bare python3, out-of-repo scoping, vnx binary, non-python), and the counter-proof pair (an artificial stale-interpreter consumer must turn the scan red; an all-pinned-in-range set must stay green).
- `tests/test_path_parity_hook.py` (new) — subprocess-level tests proving the hook's resolved `STATE_DIR` matches the canonical resolver's output with `VNX_STATE_DIR` unset, that an explicit override is still honored, and that it stays within the 5s SessionStart budget.

## Verification

```
python3 -m pytest tests/test_path_parity.py tests/test_path_parity_hook.py -q
34 passed in 0.66s
```

Combined with `tests/test_central_mode_path_resolution.py` (cross-regression check): 62 passed.

Real hook run (this session, `VNX_STATE_DIR` unset — the normal-session condition):
- Wall time: 0.196s (budget: 5s)
- No `additionalContext` emitted (parity now `true` — no real consumer is out of range on this fleet)
- Central write confirmed at `~/.vnx-data/vnx-dev/state/path_parity.json`; the repo-local path was NOT regenerated
- `raw_probe.mismatches` still shows the permanent `version_mismatch` (3.12.11 vs 3.9.6) but at `level: info`, no longer driving `parity`
- All three directly-pinned real consumers (`com.vnx.dashboard`, `com.vnx.monitor`, `com.vnx.provider-usage`) resolved to `python3.12`, `in_range: true`

## Open Items

None.