### PR TITLE
feat(oi864): surface actual spawn-time permission posture in the receipt

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -188,6 +188,12 @@ def ensure_receipt(
 
     # ADR-012 worker-permission enforcement audit marker (only when flag ON).
     worker_enforcement = "enforced" if worker_permission_enforcement_enabled() else None
+    # OI-864: the real spawn-time posture, classified from the actual launch
+    # flags by the caller (see tmux_interactive_dispatch.dispatch()) — never
+    # re-derived from env vars here. spec.permission_posture is None when the
+    # caller does not compute it, in which case these three fields stay
+    # omitted exactly as before this change.
+    _posture = spec.permission_posture or {}
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the spec carries
     # the fields when the door threaded them; otherwise the door's env vars the
     # tmux pane inherited (the worker-authored receipt path reads the same env in
@@ -210,6 +216,9 @@ def ensure_receipt(
         tier_to=spec.tier_to or os.environ.get("VNX_TIER_TO") or None,
         worker_permission_enforcement=worker_enforcement,
         report_path=str(report_path) if report_path is not None else None,
+        permission_posture=_posture.get("permission_posture"),
+        permission_profile=_posture.get("permission_profile"),
+        permission_allow_pattern_count=_posture.get("permission_allow_pattern_count"),
     ).to_dict()
 
     try:
@@ -258,6 +267,13 @@ class GovernSpec:
     task_class: Optional[str] = None
     tier_from: Optional[str] = None
     tier_to: Optional[str] = None
+    # OI-864: the actual spawn-time permission posture — the dict returned by
+    # worker_permissions.classify_permission_posture() from the REAL launch
+    # flags. The tmux lane computes this once per dispatch (from launch_cmd)
+    # and threads it in; None when the caller does not compute it (e.g. other
+    # govern() callers), in which case ensure_receipt() omits the fields
+    # exactly as before this change (no default-changing behavior).
+    permission_posture: Optional[dict] = None
 
 
 @dataclass

--- a/scripts/lib/governance_emit.py
+++ b/scripts/lib/governance_emit.py
@@ -108,6 +108,9 @@ def emit_dispatch_receipt(
     task_class: Optional[str] = None,
     tier_from: Optional[str] = None,
     tier_to: Optional[str] = None,
+    permission_posture: Optional[str] = None,
+    permission_profile: Optional[str] = None,
+    permission_allow_pattern_count: Optional[int] = None,
 ) -> Path:
     """Atomic-append to t0_receipts.ndjson via the shared append primitive
     (ADR-035 §7.1) — same lock file, hash-chain stamping, and validator Path 2
@@ -191,6 +194,15 @@ def emit_dispatch_receipt(
     stamped when the dispatch failed so the receipt carries a distinguishable
     reason instead of a silent "(no error captured)" log line. Conditionally
     stamped (omitted on success).
+
+    ``permission_posture`` / ``permission_profile`` / ``permission_allow_
+    pattern_count``: OI-864 — the ACTUAL spawn-time permission posture
+    (``"blanket-skip"`` | ``"scoped-allowlist"`` | ``"attached-interactive"``),
+    classified by the caller from the real launch flags/argv (see
+    ``worker_permissions.classify_permission_posture``), never re-derived from
+    env vars in this function. ``permission_profile`` / ``_allow_pattern_
+    count`` are only meaningful for ``"scoped-allowlist"``. Conditionally
+    stamped (None omits).
 
     Raises:
         ValueError: provider field doesn't match required pattern, or
@@ -285,6 +297,9 @@ def emit_dispatch_receipt(
         task_class=task_class,
         tier_from=tier_from,
         tier_to=tier_to,
+        permission_posture=permission_posture,
+        permission_profile=permission_profile,
+        permission_allow_pattern_count=permission_allow_pattern_count,
     ).to_dict()
 
     receipt_path = Path(state_dir) / "t0_receipts.ndjson"

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -38,6 +38,7 @@ try:
     from worker_permissions import (
         worker_permission_enforcement_enabled,
         worker_scoped_enabled,
+        classify_permission_posture,
     )
 except Exception:  # pragma: no cover - sibling import is available in-tree
     def worker_permission_enforcement_enabled() -> bool:  # type: ignore[misc]
@@ -49,6 +50,24 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
         return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
             "1", "true", "yes", "on",
         )
+
+    def classify_permission_posture(argv, role=None):  # type: ignore[misc]
+        # OI-864 fallback: classify from actual argv tokens, not env re-reads.
+        if "--dangerously-skip-permissions" in argv:
+            return {"permission_posture": "blanket-skip"}
+        if "--permission-mode" in argv or "--allowedTools" in argv:
+            allow_count = 0
+            if "--allowedTools" in argv:
+                idx = argv.index("--allowedTools")
+                if idx + 1 < len(argv):
+                    allow_count = len([p for p in argv[idx + 1].split(",") if p.strip()])
+            return {
+                "permission_posture": "scoped-allowlist",
+                "permission_profile": role or "code-worker",
+                "permission_allow_pattern_count": allow_count,
+            }
+        return {"permission_posture": "attached-interactive"}
+
 
 # Providers whose spawn handlers exist.
 _IMPLEMENTED_PROVIDERS = {"claude", "codex", "gemini", "kimi", "litellm", "deepseek-harness", "glm-harness", "local-gemma"}
@@ -634,8 +653,17 @@ def _emit_governance(
     status: str,
     *,
     event_store: "Optional[Any]" = None,
+    permission_posture: "Optional[Dict[str, Any]]" = None,
 ) -> None:
     """Emit dispatch receipt + unified report after every spawn handler call.
+
+    ``permission_posture`` (OI-864): optional dict from
+    ``worker_permissions.classify_permission_posture()``, computed by the
+    caller from the ACTUAL spawn flags/argv (e.g. the claude-benchmark path
+    in ``_dispatch_claude_benchmark``). When provided, its fields are stamped
+    onto the receipt alongside (not instead of) the existing
+    ``permission_enforcement`` marker below — which stays derived exactly as
+    before for every other caller/provider that does not pass this.
 
     When *event_store* is provided the function archives the live event stream
     (terminal → events/archive/{terminal}/{dispatch_id}.ndjson) BEFORE writing
@@ -810,6 +838,15 @@ def _emit_governance(
                 events_path=events_path,
                 permission_enforcement=(
                     "enforced" if worker_permission_enforcement_enabled() else None
+                ),
+                permission_posture=(
+                    (permission_posture or {}).get("permission_posture")
+                ),
+                permission_profile=(
+                    (permission_posture or {}).get("permission_profile")
+                ),
+                permission_allow_pattern_count=(
+                    (permission_posture or {}).get("permission_allow_pattern_count")
                 ),
                 mandate_id=getattr(args, "mandate_id", None),
                 final_prompt_path=getattr(_integrity, "final_prompt_path", None) if _integrity is not None else None,
@@ -1236,6 +1273,25 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         skip_permissions = not (
             worker_permission_enforcement_enabled() or worker_scoped_enabled()
         )
+        # OI-864: classify the REAL posture from the actual argv
+        # SubprocessAdapter.deliver() will build for this spawn (same
+        # requires_mcp/role inputs), instead of a third independent read of
+        # VNX_ENFORCE_WORKER_PERMISSIONS/VNX_WORKER_SCOPED (which can diverge
+        # from `skip_permissions` above — e.g. VNX_WORKER_SCOPED=1 alone).
+        # Best-effort: a classification failure must never break the benchmark.
+        _permission_posture: "Optional[dict]" = None
+        try:
+            from subprocess_adapter import _build_worker_scope_args  # noqa: PLC0415
+            _scope_argv = _build_worker_scope_args(
+                role, requires_mcp=getattr(args, "requires_mcp", False)
+            )
+            _permission_posture = classify_permission_posture(_scope_argv, role)
+        except Exception as _posture_exc:  # noqa: BLE001
+            logger.debug(
+                "_dispatch_claude_benchmark: permission posture classification "
+                "failed for dispatch=%s (non-fatal): %s",
+                args.dispatch_id, _posture_exc,
+            )
         result = spawn_claude(
             prompt=instruction,
             model=args.model,
@@ -1252,13 +1308,22 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
 
         if result.error or result.timed_out:
             status = "timeout" if result.timed_out else "failure"
-            _emit_governance(args, "claude", args.model, result, start_time, end_time, status, event_store=event_store)
+            _emit_governance(
+                args, "claude", args.model, result, start_time, end_time, status,
+                event_store=event_store, permission_posture=_permission_posture,
+            )
             print(f"spawn_claude failed: {result.error or 'timeout'}", file=sys.stderr)
             return 1
         if result.returncode != 0:
-            _emit_governance(args, "claude", args.model, result, start_time, end_time, "failure", event_store=event_store)
+            _emit_governance(
+                args, "claude", args.model, result, start_time, end_time, "failure",
+                event_store=event_store, permission_posture=_permission_posture,
+            )
             return 1
-        _emit_governance(args, "claude", args.model, result, start_time, end_time, "success", event_store=event_store)
+        _emit_governance(
+            args, "claude", args.model, result, start_time, end_time, "success",
+            event_store=event_store, permission_posture=_permission_posture,
+        )
         return 0
     finally:
         _event_store_safety_net(event_store, args)

--- a/scripts/lib/receipt_schema.py
+++ b/scripts/lib/receipt_schema.py
@@ -154,6 +154,16 @@ class ReceiptV2:
     task_class: Optional[str] = None
     tier_from: Optional[str] = None
     tier_to: Optional[str] = None
+    # OI-864: the ACTUAL spawn-time permission posture, classified from the
+    # real launch flags (worker_permissions.classify_permission_posture) —
+    # never from re-reading VNX_ENFORCE_WORKER_PERMISSIONS/VNX_WORKER_SCOPED.
+    # One of "blanket-skip" | "scoped-allowlist" | "attached-interactive".
+    # permission_profile / permission_allow_pattern_count are only meaningful
+    # (and only stamped) for "scoped-allowlist". Conditionally stamped (None
+    # omits), same as the other optional fields.
+    permission_posture: Optional[str] = None
+    permission_profile: Optional[str] = None
+    permission_allow_pattern_count: Optional[int] = None
 
     def __post_init__(self) -> None:
         # Receipt-quality PR-3: the closed-set lint lives in the contract now
@@ -245,6 +255,12 @@ class ReceiptV2:
             receipt["tier_from"] = self.tier_from
         if self.tier_to is not None:
             receipt["tier_to"] = self.tier_to
+        if self.permission_posture is not None:
+            receipt["permission_posture"] = self.permission_posture
+        if self.permission_profile is not None:
+            receipt["permission_profile"] = self.permission_profile
+        if self.permission_allow_pattern_count is not None:
+            receipt["permission_allow_pattern_count"] = self.permission_allow_pattern_count
         return receipt
 
 
@@ -287,6 +303,12 @@ class SynthesizedLaneReceipt:
     # Conditionally stamped (is-not-None).
     worker_permission_enforcement: Optional[str] = None
     report_path: Optional[str] = None
+    # OI-864: see ReceiptV2 for semantics — same fields, same classification
+    # source (worker_permissions.classify_permission_posture from the actual
+    # spawn flags), stamped on the lane-synthesized fallback receipt too.
+    permission_posture: Optional[str] = None
+    permission_profile: Optional[str] = None
+    permission_allow_pattern_count: Optional[int] = None
 
     def __post_init__(self) -> None:
         self.receipt_kind = validate_receipt_kind(self.receipt_kind)
@@ -329,6 +351,12 @@ class SynthesizedLaneReceipt:
             receipt["tier_from"] = self.tier_from
         if self.tier_to is not None:
             receipt["tier_to"] = self.tier_to
+        if self.permission_posture is not None:
+            receipt["permission_posture"] = self.permission_posture
+        if self.permission_profile is not None:
+            receipt["permission_profile"] = self.permission_profile
+        if self.permission_allow_pattern_count is not None:
+            receipt["permission_allow_pattern_count"] = self.permission_allow_pattern_count
         return receipt
 
 

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -64,11 +64,30 @@ try:
         worker_permission_enforcement_enabled,
         build_claude_scope_args as _wp_build_claude_scope_args,
         resolve_worker_profile as _wp_resolve_worker_profile,
+        classify_permission_posture,
     )
     _WP_AVAILABLE = True
 except Exception:  # pragma: no cover - sibling import is available in-tree
     EMPTY_MCP_CONFIG = '{"mcpServers":{}}'
     _WP_AVAILABLE = False
+
+    def classify_permission_posture(argv, role=None):  # type: ignore[misc]
+        # OI-864 fallback: classify from the actual argv tokens, never by
+        # re-reading env vars. Mirrors worker_permissions.classify_permission_posture.
+        if "--dangerously-skip-permissions" in argv:
+            return {"permission_posture": "blanket-skip"}
+        if "--permission-mode" in argv or "--allowedTools" in argv:
+            allow_count = 0
+            if "--allowedTools" in argv:
+                idx = argv.index("--allowedTools")
+                if idx + 1 < len(argv):
+                    allow_count = len([p for p in argv[idx + 1].split(",") if p.strip()])
+            return {
+                "permission_posture": "scoped-allowlist",
+                "permission_profile": role or "code-worker",
+                "permission_allow_pattern_count": allow_count,
+            }
+        return {"permission_posture": "attached-interactive"}
 
     def worker_scoped_enabled() -> bool:  # type: ignore[misc]
         return os.environ.get("VNX_WORKER_SCOPED", "0").strip().lower() in (
@@ -760,6 +779,7 @@ class TmuxInteractiveDispatch:
         token_usage: "dict | None" = None,
         role: "str | None" = None,
         session_id: "str | None" = None,
+        permission_posture: "dict | None" = None,
     ) -> "Path | None":
         """Emit governance unified_report via the shared govern() step.
 
@@ -775,6 +795,11 @@ class TmuxInteractiveDispatch:
 
         ``session_id``: pre-assigned worker session UUID (F1.1), threaded through to
         the dispatch_metadata stamp.
+
+        ``permission_posture`` (OI-864): forwarded to GovernSpec so a
+        lane-synthesized fallback receipt (worker never emitted its own,
+        ``ensure_receipt``) still carries the real spawn-time posture instead
+        of omitting it or re-deriving it from env vars a second time.
         """
         try:
             from dispatch_govern import GovernRaw, GovernSpec, govern  # noqa: PLC0415
@@ -796,6 +821,7 @@ class TmuxInteractiveDispatch:
             worktree_path=worktree_path,
             model=model,
             role=role,
+            permission_posture=permission_posture,
         )
         raw = GovernRaw(
             receipt=receipt,
@@ -1008,7 +1034,13 @@ class TmuxInteractiveDispatch:
         return result
 
     def _build_completion_protocol(
-        self, dispatch_id: str, label: str, model: str = "unknown", *, integrity=None
+        self,
+        dispatch_id: str,
+        label: str,
+        model: str = "unknown",
+        *,
+        integrity=None,
+        permission_posture: "dict | None" = None,
     ) -> str:
         """Footer instructing the worker to emit a clean receipt directly.
 
@@ -1021,6 +1053,15 @@ class TmuxInteractiveDispatch:
         - ``timestamp`` is NOT generated at body-assembly time: each command uses
           shell ``$(date -u +%Y-%m-%dT%H:%M:%SZ)`` so the timestamp records the
           execution moment, not when the dispatch was launched.
+
+        ``permission_posture`` (OI-864): the dict returned by
+        ``classify_permission_posture()`` from the ACTUAL flags assembled for
+        this spawn's ``launch_cmd`` — never re-derived from env vars here.
+        Baked in as ``permission_posture`` / ``permission_profile`` /
+        ``permission_allow_pattern_count`` alongside the other spawn
+        properties (model/lane/terminal) this receipt already carries. Only
+        stamped when provided, so callers that do not compute it (e.g. direct
+        unit tests of this method) keep a byte-identical receipt shape.
         """
         append_receipt = self._project_root / "scripts" / "append_receipt.py"
         # report_path is deterministic — include it so the receipt->report linkage
@@ -1065,6 +1106,24 @@ class TmuxInteractiveDispatch:
             # Only emitted when the flag is ON so flag-off receipts are byte-identical.
             if worker_permission_enforcement_enabled():
                 receipt_dict["permission_enforcement"] = "enforced"
+            # OI-864: the actual spawn-time permission posture, derived from the
+            # real launch flags (see classify_permission_posture). Distinct from
+            # (and more precise than) permission_enforcement above, which only
+            # ever says "enforced" or omits itself — it cannot show blanket-skip
+            # vs scoped-allowlist, and re-reads the env independently of what
+            # flags this spawn actually used.
+            if permission_posture:
+                receipt_dict["permission_posture"] = permission_posture.get(
+                    "permission_posture"
+                )
+                if permission_posture.get("permission_profile") is not None:
+                    receipt_dict["permission_profile"] = permission_posture[
+                        "permission_profile"
+                    ]
+                if permission_posture.get("permission_allow_pattern_count") is not None:
+                    receipt_dict["permission_allow_pattern_count"] = permission_posture[
+                        "permission_allow_pattern_count"
+                    ]
             # Input-side audit closure (final_prompt_integrity). Only baked in when
             # integrity was computed so the receipt shape stays byte-identical
             # otherwise. The worker echoes these back verbatim in its receipt.
@@ -2335,6 +2394,21 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                 )
 
+            # OI-864: classify the permission posture from the REAL flags this
+            # spawn is about to launch with — not by re-reading
+            # VNX_ENFORCE_WORKER_PERMISSIONS/VNX_WORKER_SCOPED a second time (two
+            # independent env reads can diverge from what the builder actually
+            # assembled). Computed once here from the guard-validated launch_cmd
+            # and threaded to both the completion-protocol receipt (worker-authored
+            # path) and every govern()/ensure_receipt call (synthesized fallback
+            # path) below, so both receipt paths agree on the same single source
+            # of truth.
+            try:
+                _launch_tokens = shlex.split(launch_cmd)
+            except ValueError:
+                _launch_tokens = launch_cmd.split()
+            permission_posture = classify_permission_posture(_launch_tokens, role)
+
             # Inject hook-signal env so the worker's SessionStart/UserPromptSubmit/Stop
             # hooks fire (they are guarded by these two vars). Prepended as an export
             # so it applies across the whole compound command (source …; claude …),
@@ -2405,6 +2479,7 @@ class TmuxInteractiveDispatch:
                     failure_reason="interactive_ready_timeout",
                     role=role,
                     session_id=session_uuid,
+                    permission_posture=permission_posture,
                 )
                 _teardown("ready_timeout")
                 return InteractiveDispatchResult(
@@ -2509,7 +2584,8 @@ class TmuxInteractiveDispatch:
                 body = (
                     _context_body
                     + self._build_completion_protocol(
-                        dispatch_id, label, model=model, integrity=_integrity
+                        dispatch_id, label, model=model, integrity=_integrity,
+                        permission_posture=permission_posture,
                     )
                     + f"\n\n{_TRAILER}\n"
                 )
@@ -2519,7 +2595,8 @@ class TmuxInteractiveDispatch:
                     _context_body
                     + self._scope_note(dispatch_paths)
                     + self._build_completion_protocol(
-                        dispatch_id, label, model=model, integrity=_integrity
+                        dispatch_id, label, model=model, integrity=_integrity,
+                        permission_posture=permission_posture,
                     )
                 )
 
@@ -2572,6 +2649,7 @@ class TmuxInteractiveDispatch:
                     failure_reason="submit_failed",
                     role=role,
                     session_id=session_uuid,
+                    permission_posture=permission_posture,
                 )
                 _teardown("submit_failed")
                 return InteractiveDispatchResult(
@@ -2641,6 +2719,7 @@ class TmuxInteractiveDispatch:
                     failure_reason="interactive_no_progress",
                     role=role,
                     session_id=session_uuid,
+                    permission_posture=permission_posture,
                 )
                 _teardown("no_progress")
                 return InteractiveDispatchResult(
@@ -2701,6 +2780,7 @@ class TmuxInteractiveDispatch:
                     failure_reason=_deadline_reason,
                     role=role,
                     session_id=session_uuid,
+                    permission_posture=permission_posture,
                 )
                 _teardown("timeout")
                 return InteractiveDispatchResult(
@@ -2778,6 +2858,7 @@ class TmuxInteractiveDispatch:
                 token_usage=_pane_tokens,
                 role=role,
                 session_id=session_uuid,
+                permission_posture=permission_posture,
                 **(
                     {"failure_reason": f"pushed_branch_no_pr: {_autopr_failure_reason}"}
                     if _autopr_failure_reason

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -427,6 +427,43 @@ def validate_dispatch_permissions(
     return warnings
 
 
+def classify_permission_posture(argv: "list[str]", role: Optional[str] = None) -> dict:
+    """Classify the permission posture from ACTUAL assembled ``claude`` CLI argv.
+
+    OI-864: the spawn-time posture must be derived from what really reaches the
+    command line, never by re-reading ``VNX_ENFORCE_WORKER_PERMISSIONS`` /
+    ``VNX_WORKER_SCOPED`` a second (or third) time — two independent reads of the
+    same OR-condition can diverge from the flags a given spawn actually used
+    (e.g. ``VNX_WORKER_SCOPED=1`` with the newer flag unset). Callers pass the
+    literal tokens/argv they are about to launch (or already launched); this
+    function never touches the environment itself.
+
+    Returns a dict with a ``permission_posture`` key, one of:
+      - ``"blanket-skip"`` — ``--dangerously-skip-permissions`` present.
+      - ``"scoped-allowlist"`` — ``--permission-mode`` / ``--allowedTools``
+        present. Also includes ``permission_profile`` (the profile name that
+        was applied) and ``permission_allow_pattern_count`` (the number of
+        comma-separated entries in ``--allowedTools``, 0 if absent).
+      - ``"attached-interactive"`` — neither flag present: a human-attended
+        session that answers real permission prompts (no skip, no scoping).
+    """
+    if "--dangerously-skip-permissions" in argv:
+        return {"permission_posture": "blanket-skip"}
+    if "--permission-mode" in argv or "--allowedTools" in argv:
+        allow_count = 0
+        if "--allowedTools" in argv:
+            idx = argv.index("--allowedTools")
+            if idx + 1 < len(argv):
+                allow_count = len([p for p in argv[idx + 1].split(",") if p.strip()])
+        profile = resolve_worker_profile(role)
+        return {
+            "permission_posture": "scoped-allowlist",
+            "permission_profile": profile.role,
+            "permission_allow_pattern_count": allow_count,
+        }
+    return {"permission_posture": "attached-interactive"}
+
+
 def match_bash_deny(command: str, profile: PermissionProfile) -> Optional[str]:
     """Return the first deny pattern that matches command, or None.
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -37,6 +37,7 @@ from tmux_interactive_dispatch import (
 )
 from tmux_worktree import ReapResult, WorktreeAllocateError, WorktreeHandle
 from pr_enforcement import PrEnforcementResult
+from worker_permissions import classify_permission_posture
 
 
 class FakeTmux:
@@ -1046,6 +1047,132 @@ class TestCompletionProtocolIntegration(_LaneTestCase):
                     expected_status,
                     f"block {block_idx}: status must be {expected_status!r}",
                 )
+
+
+class TestCompletionProtocolPermissionPosture(_LaneTestCase):
+    """OI-864: the completion-protocol receipt carries the ACTUAL spawn-time
+    permission posture — derived from the real launch flags, not from
+    re-reading VNX_ENFORCE_WORKER_PERMISSIONS/VNX_WORKER_SCOPED.
+    """
+
+    def test_posture_baked_into_completion_protocol_receipt(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        posture = classify_permission_posture(
+            ["claude", "--model", "sonnet", "--permission-mode", "acceptEdits",
+             "--allowedTools", "Read,Write,Edit"],
+            "backend-developer",
+        )
+        protocol = lane._build_completion_protocol(
+            self.DISPATCH_ID, "T1", model="sonnet", permission_posture=posture,
+        )
+
+        for block_idx in (0, 1):
+            receipt = _extract_protocol_receipt(protocol, block_idx)
+            self.assertEqual(receipt.get("permission_posture"), "scoped-allowlist")
+            self.assertEqual(receipt.get("permission_profile"), "backend-developer")
+            self.assertEqual(receipt.get("permission_allow_pattern_count"), 3)
+
+    def test_posture_omitted_when_not_provided(self):
+        """Byte-identical shape when permission_posture is not passed (default None) —
+        e.g. a direct unit-level call to _build_completion_protocol without the
+        real dispatch() plumbing."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        protocol = lane._build_completion_protocol(self.DISPATCH_ID, "T1", model="sonnet")
+
+        receipt = _extract_protocol_receipt(protocol, 0)
+        self.assertNotIn("permission_posture", receipt)
+        self.assertNotIn("permission_profile", receipt)
+        self.assertNotIn("permission_allow_pattern_count", receipt)
+
+
+class TestPermissionPostureReachesReceipt(_LaneTestCase):
+    """OI-864 negative test: a spawn with the scoped flag ON must classify to a
+    DIFFERENT posture than a spawn with it OFF, and that value must actually
+    reach t0_receipts.ndjson (not just a field that exists but never varies).
+
+    Uses the deadline/synthesized-fallback path (ensure_receipt) as the
+    end-to-end vehicle: the worker never emits its own receipt, so the lane's
+    lane-synthesized completion receipt is what lands in the ledger — the same
+    mechanism every other spawn property (model, lane, role) already uses.
+    """
+
+    def _dispatch_and_read_last_receipt(self, *, scoped: bool) -> dict:
+        # Distinct dispatch_id per sub-run: the append primitive's idempotency
+        # guard (scripts/lib/append_receipt_internals/idempotency.py) dedups
+        # repeat appends carrying the same dispatch_id/terminal/event_type/
+        # source within a 300s cache window — reusing one id for both halves
+        # of this comparison would silently drop the second append and make
+        # the test compare a receipt against itself. Real dispatches always
+        # get a unique id, so this mirrors production, not a workaround.
+        dispatch_id = f"{self.DISPATCH_ID}-{'scoped' if scoped else 'blanket'}"
+        env = {
+            "VNX_ENFORCE_WORKER_PERMISSIONS": "1" if scoped else "0",
+            "VNX_WORKER_SCOPED": "0",
+            # Zero-out time-sensitive env vars so this runs fast (mirrors _fast_dispatch).
+            "VNX_TMUX_PASTE_SETTLE_SECONDS": "0",
+            "VNX_TMUX_SUBMIT_RETRY_DELAY": "0",
+            "VNX_TMUX_SUBMIT_VERIFY_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_TIMEOUT": "0.1",
+            "VNX_TMUX_WORK_START_POLL": "0.02",
+        }
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=dispatch_id,
+            emit_receipt=False,  # worker never responds -> deadline -> synthesized receipt
+            ready_content=_READY_AND_WORKING,
+        )
+        lane = self._make_lane(fake)
+        with patch.dict(os.environ, env):
+            result = lane.dispatch(
+                "Do the thing.",
+                dispatch_id,
+                role="backend-developer",
+                model="sonnet",
+                deadline_seconds=0.2,
+                poll_interval=0.02,
+                warmup_timeout=0.5,
+                warmup_poll_interval=0.01,
+                isolated_worktree=False,
+            )
+        self.assertFalse(result.success)
+
+        lines = self.receipts_file.read_text(encoding="utf-8").strip().splitlines()
+        matching = [
+            json.loads(line) for line in lines
+            if json.loads(line).get("dispatch_id") == dispatch_id
+        ]
+        self.assertEqual(
+            len(matching), 1,
+            f"expected exactly one receipt for dispatch_id={dispatch_id}, found {len(matching)}",
+        )
+        return matching[0]
+
+    def test_posture_diverges_between_scoped_off_and_on(self):
+        """The required OI-864 negative test: same role, only the env flag
+        changes between the two runs — the classified/ledgered posture must
+        differ. A test that only asserts the field's presence (or a constant
+        value) would pass even if scoping were never actually wired to the
+        real launch flags; asserting the VALUE differs is what proves it.
+        """
+        receipt_off = self._dispatch_and_read_last_receipt(scoped=False)
+        receipt_on = self._dispatch_and_read_last_receipt(scoped=True)
+
+        self.assertEqual(receipt_off.get("permission_posture"), "blanket-skip")
+        self.assertEqual(receipt_on.get("permission_posture"), "scoped-allowlist")
+        self.assertNotEqual(
+            receipt_off.get("permission_posture"),
+            receipt_on.get("permission_posture"),
+            "permission_posture must differ between a scoped-off and a "
+            "scoped-on spawn — identical values here would mean the receipt "
+            "is not actually reflecting the real launch flags",
+        )
+        self.assertIn("permission_profile", receipt_on)
+        self.assertGreater(receipt_on.get("permission_allow_pattern_count", 0), 0)
+        self.assertNotIn("permission_profile", receipt_off)
 
 
 class TestCompletionProtocolPinsReceiptsFile(_LaneTestCase):

--- a/tests/test_worker_permissions.py
+++ b/tests/test_worker_permissions.py
@@ -16,6 +16,7 @@ from worker_permissions import (
     EMPTY_MCP_CONFIG,
     PermissionProfile,
     build_claude_scope_args,
+    classify_permission_posture,
     generate_claude_settings,
     generate_permission_preamble,
     load_permissions,
@@ -349,3 +350,85 @@ class TestBuildClaudeScopeArgsMcpServers:
         )
         assert "--strict-mcp-config" not in args
         assert "--mcp-config" not in args
+
+
+# ---------------------------------------------------------------------------
+# classify_permission_posture (OI-864)
+# ---------------------------------------------------------------------------
+
+class TestClassifyPermissionPosture:
+    """Posture must come from the ACTUAL assembled argv, never from re-reading
+    VNX_ENFORCE_WORKER_PERMISSIONS/VNX_WORKER_SCOPED — two independent reads of
+    that OR-condition can diverge from the flags a given spawn actually used
+    (e.g. VNX_WORKER_SCOPED=1 alone with the newer flag unset)."""
+
+    # An unknown role deterministically falls back to default_code_worker_profile()
+    # (9 allowed tools, role="code-worker") regardless of this repo's real
+    # .vnx/worker_permissions.yaml content — keeps these tests independent of
+    # that file's contents.
+    UNKNOWN_ROLE = "nonexistent-role-xyz-oi864"
+
+    def test_blanket_skip_argv(self) -> None:
+        argv = ["claude", "--model", "sonnet", "--dangerously-skip-permissions"]
+        result = classify_permission_posture(argv, self.UNKNOWN_ROLE)
+        assert result == {"permission_posture": "blanket-skip"}
+
+    def test_scoped_allowlist_argv_includes_profile_and_count(self) -> None:
+        argv = [
+            "claude", "--model", "sonnet",
+            "--permission-mode", "acceptEdits",
+            "--strict-mcp-config", "--mcp-config", EMPTY_MCP_CONFIG,
+            "--allowedTools", "Read,Write,Edit,MultiEdit,Bash,Grep,Glob,Bash(git:*),Bash(gh:*)",
+        ]
+        result = classify_permission_posture(argv, self.UNKNOWN_ROLE)
+        assert result["permission_posture"] == "scoped-allowlist"
+        assert result["permission_profile"] == "code-worker"
+        assert result["permission_allow_pattern_count"] == 9
+
+    def test_attached_interactive_argv(self) -> None:
+        """Neither flag present — a human-attended session (attach=True in the
+        tmux lane), answering real permission prompts."""
+        argv = ["claude", "--model", "sonnet"]
+        result = classify_permission_posture(argv, self.UNKNOWN_ROLE)
+        assert result == {"permission_posture": "attached-interactive"}
+
+    def test_scoped_with_empty_allowlist_counts_zero(self) -> None:
+        argv = ["claude", "--model", "sonnet", "--permission-mode", "acceptEdits"]
+        result = classify_permission_posture(argv, self.UNKNOWN_ROLE)
+        assert result["permission_posture"] == "scoped-allowlist"
+        assert result["permission_allow_pattern_count"] == 0
+
+    def test_blanket_skip_wins_even_if_scoped_flags_also_present(self) -> None:
+        # --dangerously-skip-permissions is checked first: if a caller somehow
+        # assembled both (should never happen), the actually-effective claude
+        # behavior is the skip flag, so posture must report that, not scoped.
+        argv = [
+            "claude", "--model", "sonnet",
+            "--dangerously-skip-permissions",
+            "--permission-mode", "acceptEdits", "--allowedTools", "Read",
+        ]
+        result = classify_permission_posture(argv, self.UNKNOWN_ROLE)
+        assert result["permission_posture"] == "blanket-skip"
+
+    def test_posture_diverges_between_scoped_off_and_on(self) -> None:
+        """The required OI-864 negative test: same role, only the argv differs
+        (mirroring VNX_WORKER_SCOPED/VNX_ENFORCE_WORKER_PERMISSIONS off vs on)
+        — the classified posture must differ. Asserting only that the field
+        EXISTS would still pass if the classifier always returned a constant;
+        asserting the VALUE differs is what actually proves the wiring works.
+        """
+        off_argv = ["claude", "--model", "sonnet", "--dangerously-skip-permissions"]
+        on_argv = [
+            "claude", "--model", "sonnet",
+            "--permission-mode", "acceptEdits",
+            "--allowedTools", "Read,Write,Edit",
+        ]
+        posture_off = classify_permission_posture(off_argv, "backend-developer")
+        posture_on = classify_permission_posture(on_argv, "backend-developer")
+
+        assert posture_off["permission_posture"] == "blanket-skip"
+        assert posture_on["permission_posture"] == "scoped-allowlist"
+        assert posture_off["permission_posture"] != posture_on["permission_posture"]
+        assert "permission_profile" not in posture_off
+        assert posture_on["permission_profile"] == "backend-developer"
+        assert posture_on["permission_allow_pattern_count"] == 3


### PR DESCRIPTION
## Summary

- OI-864's original premise (workers hang on permission prompts) is stale — blanket-skip-permissions is the ratified fleet default (2026-08-03). The real gap: a dispatch's receipt carries no signal of which permission posture the worker actually ran under.
- The one existing marker (`worker_permission_enforcement`) is stamped by re-reading `VNX_ENFORCE_WORKER_PERMISSIONS` independently of the flags a spawn actually used — a third such independent read existed in `provider_dispatch.py`'s claude-benchmark path too. These can silently diverge from reality (e.g. `VNX_WORKER_SCOPED=1` alone spawns scoped but stamps nothing).
- Adds `worker_permissions.classify_permission_posture(argv, role)`: derives `"blanket-skip" | "scoped-allowlist" | "attached-interactive"` from the **actual assembled CLI flags**, never by re-deriving the env OR-condition.
- Wired in at the one place each lane already knows the real flags:
  - `tmux_interactive_dispatch.py`: classified once from the guard-validated `launch_cmd`, threaded into both the completion-protocol receipt (worker-authored path) and every `govern()`/`ensure_receipt` call (synthesized fallback path).
  - `provider_dispatch.py`'s claude-benchmark exemption: classified from the actual `subprocess_adapter._build_worker_scope_args()` output instead of a third independent env read.
- New fields (`permission_posture`, `permission_profile`, `permission_allow_pattern_count`) land in `t0_receipts.ndjson` via the existing `SynthesizedLaneReceipt`/`ReceiptV2` contracts and the worker-authored completion-protocol JSON — no new persistence channel introduced.
- Purely additive: zero changes to defaults, env vars, or settings. The pre-existing `permission_enforcement`/`worker_permission_enforcement` markers are left untouched (still misleading, noted below as an Open Item — out of scope for this PR).

## Changes

- `scripts/lib/worker_permissions.py` — new `classify_permission_posture(argv, role=None)`.
- `scripts/lib/tmux_interactive_dispatch.py` — classify from `launch_cmd` at spawn time; thread through `_build_completion_protocol()` and all 5 `_govern_report()` call sites; defensive-import fallback mirrors the real function.
- `scripts/lib/dispatch_govern.py` — `GovernSpec.permission_posture` field; `ensure_receipt()` stamps the three new fields on the synthesized fallback receipt from the spec (not from re-reading env).
- `scripts/lib/receipt_schema.py` — `permission_posture` / `permission_profile` / `permission_allow_pattern_count` added to both `ReceiptV2` and `SynthesizedLaneReceipt` (conditionally stamped, byte-compatible when absent).
- `scripts/lib/governance_emit.py` — `emit_dispatch_receipt()` accepts and threads the three new fields into `ReceiptV2`.
- `scripts/lib/provider_dispatch.py` — `_dispatch_claude_benchmark` classifies posture from the real `_build_worker_scope_args()` output and threads it through `_emit_governance()` (new optional kwarg, backward compatible for every other provider).
- `tests/test_worker_permissions.py` — unit tests for `classify_permission_posture()`, including the required negative test (scoped-off vs scoped-on argv → different posture).
- `tests/test_tmux_interactive_dispatch.py` — completion-protocol baking tests + an end-to-end test proving the posture reaches `t0_receipts.ndjson` via the synthesized-fallback path, with the scoped-off/scoped-on divergence asserted on the actual ledger line.

## Verification

Ran (all green):
- `pytest tests/test_tmux_interactive_dispatch.py` — 195 passed (192 pre-existing + 3 new). **Note:** this file is on `scripts/ci/test_exclusions.txt` (OI-906) — CI does not run it; reported here as the required local result.
- `pytest tests/test_dispatch_envelope.py -k "not TestFlagGateClaude"` — 31 passed, 4 deselected.
- `pytest tests/test_worker_permissions.py` — 28 passed (22 pre-existing + 6 new).
- Broader regression net on every shared module touched (`test_governance_emit*.py`, `test_dispatch_govern.py`, `test_receipt_schema.py`, `test_receipt_v2_pr_b2/pr4/pr5*.py`, `test_worker_permission_enforcement_flag.py`, `test_emit_governance_retry.py`, `test_worker_capability_scoping.py`, `test_pretooluse_worker_scope_enforce.py`, `test_worker_permissions_merge.py`): 619 passed, 4 deselected total.
- `test_provider_dispatch_governance_integration.py` and a few sibling files show 22 pre-existing failures unrelated to this change (confirmed identical on unmodified HEAD via `git stash`/re-run before restoring) — a model-registry constraint-violation issue, nothing to do with permission posture.
- Negative-test sanity check: temporarily broke the `classify_permission_posture` branch logic and confirmed both the new unit test and the new end-to-end ledger test fail as expected, then reverted.

## Open Items

- The pre-existing `permission_enforcement` (completion-protocol JSON) and `worker_permission_enforcement` (`SynthesizedLaneReceipt`) markers still independently re-read `VNX_ENFORCE_WORKER_PERMISSIONS` at their own call sites and remain misleading in the same way OI-864 originally described (previously documented as OI-559). Left untouched per this dispatch's explicit scope (add the new accurate field; don't touch defaults/existing markers) — reconciling/deprecating them is follow-up work.
- `provider_dispatch.py`'s generic `_emit_governance()` `permission_enforcement` derivation (used by every non-claude provider) was left as-is; only the claude-benchmark call sites now also pass the new `permission_posture`.
- `skip_permissions` passed from `_dispatch_claude_benchmark` into `spawn_claude()` is dead code (confirmed via `claude_spawn.py`'s own docstring: "currently unused") — noted as a finding, not fixed here (out of scope).

Dispatch-ID: 20260804-020016-oi864-posture-receipt