### PR TITLE
fix(receipts): stop one poisoned report from killing the whole receipt scan (OI-997, OI-998)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,6 +42,8 @@ Your report MUST contain these exact headings (aliases accepted):
 
 `## Summary` must be at least 50 non-whitespace characters. `## Open Items` may contain "None" explicitly. Include your dispatch ID as a plain-text or bold field (e.g. `Dispatch-ID: 20260601-213416-myfeature`). Full contract: `scripts/lib/report_body_contract.py`.
 
+**A dispatch report also needs an identity block, or its receipt never lands.** The table above (`validate_body()`) does not require Model or Provider — but the receipt-converter fail-closed model check does (`scripts/lib/append_receipt_internals/validation.py::_validate_model_present`): any dispatch-lane report without a real Model is REFUSED at receipt-write time, silently as far as the report contract is concerned (it can still pass `validate_body()` cleanly). Include a `Model:`/`Provider:` bold-field or frontmatter pair (e.g. `**Model**: sonnet`, `**Provider**: claude`) alongside your Dispatch-ID so the receipt actually gets written — see the fail-closed check itself (`_validate_model_present`) for the rationale, and `scripts/lib/report_to_receipt_converter.py` for how the refusal is logged (WARNING, dispatch-id + reason) and surfaced (`health/report_to_receipt_converter.json`).
+
 ## Dispatch lanes
 
 Two lanes ship on main; T0 picks per task. Full decision rule, provider strings, concurrency, and failure modes live in **`docs/core/DISPATCH_RULES.md`** (tmux-spawn lane detail: `docs/operations/TMUX_SPAWN_LANE.md`).

--- a/scripts/lib/report_body_contract.py
+++ b/scripts/lib/report_body_contract.py
@@ -2,6 +2,23 @@
 
 T1 ships: build_directive() — the required-sections directive workers receive.
 T2 ships: validate_body() — the heading-scan validator with alias acceptance.
+
+Contract gap (documented, not enforced here — dispatch-20260804-064708-pra-
+converter-resilience / OI-998): this module's contract requires Summary,
+Changes, Verification, Open Items, and a Dispatch-ID. It does NOT require a
+Model or Provider field. But scripts/lib/append_receipt_internals/validation.py
+(``_validate_model_present``) fail-closed-refuses to WRITE a receipt for any
+dispatch-lane report that lacks a real Model — a report can pass
+``validate_body()`` here cleanly and still never produce a receipt. That
+refusal is intentional (a worker dispatch receipt must name the model that
+ran) and is logged loudly by the converter (WARNING, dispatch-id + reason;
+scripts/lib/report_to_receipt_converter.py), not silently. The fix for the
+gap is documentation, not validation: ``validate_body()`` is deliberately
+NOT made to enforce Model/Provider, since that would break every existing
+report producer that predates the fail-closed check. A dispatch-lane report
+therefore needs an identity block (Model + Provider, bold-field or
+frontmatter) IN ADDITION TO the sections below — see the CLAUDE.md "Mandatory
+Report Contract" section, which documents both.
 """
 
 from __future__ import annotations

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -36,8 +36,9 @@ import logging
 import os
 import re
 import sys
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -134,7 +135,12 @@ def _extract_body_fields(text: str) -> Dict[str, Any]:
     fields: Dict[str, Any] = {}
     for m in _BOLD_KV_RE.finditer(text[:3000]):
         key = m.group(1).strip().lower().replace("-", "_").replace(" ", "_")
-        val = m.group(2).strip().splitlines()[0].strip()
+        # A bold key whose value is whitespace-only (e.g. truncated at the
+        # text[:3000] scan boundary, or genuinely empty in the source report)
+        # strips down to "" — splitlines() on "" is [], so index [0] would
+        # raise IndexError. Guard it: no non-empty first line means no value.
+        value_lines = m.group(2).strip().splitlines()
+        val = value_lines[0].strip() if value_lines else ""
         if key and val:
             fields.setdefault(key, val)
     if "dispatch_id" not in fields:
@@ -325,6 +331,93 @@ def build_receipt_from_report(
 # Single-report converter
 # ---------------------------------------------------------------------------
 
+# Outcome tags returned by _convert_one_detailed(), consumed by
+# scan_and_convert() for per-scan counting (OI-998):
+#   "appended"  — new receipt written.
+#   "duplicate" — idempotent re-send, no new receipt.
+#   "rejected"  — fail-closed refusal by append_receipt_payload's own
+#                 validation (e.g. missing Model — see AppendReceiptError
+#                 code "missing_model" in append_receipt_internals/validation.py).
+#                 A WARNING is logged here with dispatch_id + reason so the
+#                 refusal is loud, not silent.
+#   "malformed" — file unreadable, or no dispatch_id resolvable at all.
+#   "error"     — anything else: a crash while parsing/building the receipt,
+#                 or an append failure other than the fail-closed rejection.
+
+def _convert_one_detailed(
+    report_path: Path,
+    *,
+    receipts_file: Optional[str] = None,
+    cache_window_seconds: int = 300,
+) -> Tuple[Optional[Any], str]:  # (Optional[AppendResult], outcome_tag)
+    """Convert one report file to a governed receipt; classify the outcome.
+
+    Never raises — every failure mode (unreadable file, unparseable body,
+    fail-closed model rejection, append failure) is caught here and turned
+    into a (None, outcome_tag) result so a single poisoned report can never
+    propagate an exception into a caller's batch loop.
+    """
+    # Import through append_receipt.py (scripts/ root) so the facade is
+    # registered before append_receipt_payload() is called.
+    sys.path.insert(0, str(_SCRIPTS_DIR))
+    sys.path.insert(0, str(_LIB_DIR))
+    try:
+        import append_receipt  # registers facade as side effect
+        append_receipt_payload = append_receipt.append_receipt_payload
+        AppendReceiptError = append_receipt.AppendReceiptError
+    except Exception as exc:
+        logger.warning("report_to_receipt_converter: cannot import append_receipt: %s", exc)
+        return None, "error"
+
+    try:
+        text = report_path.read_text(encoding="utf-8")
+    except OSError as exc:
+        logger.warning("report_to_receipt_converter: cannot read %s: %s", report_path.name, exc)
+        return None, "malformed"
+
+    state_dir_for_route = Path(receipts_file).parent if receipts_file else None
+    try:
+        receipt = build_receipt_from_report(report_path, text, state_dir=state_dir_for_route)
+    except Exception as exc:
+        # build_receipt_from_report() is documented "never raises" but a
+        # single poisoned report must never be trusted to honor that on its
+        # own (OI-997): one crashed report must not end the batch.
+        logger.error(
+            "report_to_receipt_converter: build_receipt_from_report crashed for %s: %s: %s",
+            report_path.name, type(exc).__name__, exc,
+        )
+        return None, "error"
+    if receipt is None:
+        return None, "malformed"
+
+    try:
+        result = append_receipt_payload(
+            receipt,
+            receipts_file=receipts_file,
+            cache_window_seconds=cache_window_seconds,
+            skip_enrichment=True,  # converter receipts skip quality advisory
+        )
+        return result, result.status
+    except AppendReceiptError as exc:
+        if exc.code == "missing_model":
+            logger.warning(
+                "report_to_receipt_converter: REJECTED (fail-closed) dispatch=%s file=%s reason=%s",
+                receipt.get("dispatch_id"), report_path.name, exc.message,
+            )
+            return None, "rejected"
+        logger.warning(
+            "report_to_receipt_converter: append failed for %s: %s",
+            report_path.name, exc,
+        )
+        return None, "error"
+    except Exception as exc:
+        logger.warning(
+            "report_to_receipt_converter: append failed for %s: %s",
+            report_path.name, exc,
+        )
+        return None, "error"
+
+
 def convert_report_to_receipt(
     report_path: Path,
     *,
@@ -334,55 +427,106 @@ def convert_report_to_receipt(
     """Convert one report file to a governed receipt.
 
     Returns AppendResult (status="appended" | "duplicate") on success,
-    or None on unreadable / malformed input (warning logged, no crash).
+    or None on unreadable / malformed / rejected / errored input (warning
+    or error logged, no crash). Thin wrapper over _convert_one_detailed()
+    that preserves this exact return contract for existing callers
+    (scripts/hooks/tmux_signal_stop_receipt.sh and direct-call tests) —
+    scan_and_convert() calls _convert_one_detailed() directly for its richer
+    per-outcome counts.
     """
-    # Import through append_receipt.py (scripts/ root) so the facade is
-    # registered before append_receipt_payload() is called.
-    sys.path.insert(0, str(_SCRIPTS_DIR))
-    sys.path.insert(0, str(_LIB_DIR))
-    try:
-        import append_receipt  # registers facade as side effect
-        append_receipt_payload = append_receipt.append_receipt_payload
-    except Exception as exc:
-        logger.warning("report_to_receipt_converter: cannot import append_receipt: %s", exc)
-        return None
-
-    try:
-        text = report_path.read_text(encoding="utf-8")
-    except OSError as exc:
-        logger.warning("report_to_receipt_converter: cannot read %s: %s", report_path.name, exc)
-        return None
-
-    state_dir_for_route = Path(receipts_file).parent if receipts_file else None
-    receipt = build_receipt_from_report(report_path, text, state_dir=state_dir_for_route)
-    if receipt is None:
-        return None
-
-    try:
-        return append_receipt_payload(
-            receipt,
-            receipts_file=receipts_file,
-            cache_window_seconds=cache_window_seconds,
-            skip_enrichment=True,  # converter receipts skip quality advisory
-        )
-    except Exception as exc:
-        logger.warning(
-            "report_to_receipt_converter: append failed for %s: %s",
-            report_path.name, exc,
-        )
-        return None
+    result, _outcome = _convert_one_detailed(
+        report_path,
+        receipts_file=receipts_file,
+        cache_window_seconds=cache_window_seconds,
+    )
+    return result
 
 
 # ---------------------------------------------------------------------------
 # Directory scanner
 # ---------------------------------------------------------------------------
 
+_HEALTH_COMPONENT = "report_to_receipt_converter"
+_HEALTH_EXPECTED_INTERVAL_SECONDS = 3600
+
+
+@dataclass(frozen=True)
+class ScanStats:
+    """Per-scan outcome counts, returned by scan_and_convert() (OI-998).
+
+    A scan that only tracked ``new_count`` could not distinguish "nothing to
+    do" from "reports piled up and every single one was rejected" — both
+    read as 0. The separate counters make that distinction visible to any
+    caller, and scan_and_convert() also surfaces them via a HealthBeacon
+    (see _write_scan_heartbeat) so "zero receipts" stops reading as healthy
+    when reports were actually scanned and refused.
+    """
+
+    new_count: int = 0
+    duplicate_count: int = 0
+    rejected_count: int = 0
+    malformed_count: int = 0
+    error_count: int = 0
+
+    @property
+    def attempted_count(self) -> int:
+        return (
+            self.new_count
+            + self.duplicate_count
+            + self.rejected_count
+            + self.malformed_count
+            + self.error_count
+        )
+
+
+def _write_scan_heartbeat(state_dir: Path, stats: ScanStats) -> None:
+    """Surface this scan's counts via the existing HealthBeacon channel.
+
+    Writes <state_dir>/health/report_to_receipt_converter.json — the same
+    mechanism producer_freshness_monitor.py uses for its own
+    health/producer_freshness_monitor.json heartbeat (scripts/lib/health_beacon.py),
+    auto-discovered by health_beacon.all_beacons() / beacon_summary() (consumed
+    by scripts/health_check.py, dashboard/api_health.py, vnx_cli subsystems).
+    Reusing this channel means no new monitoring surface is invented (OI-998).
+
+    status="fail" specifically for the case this dispatch closes: reports
+    were scanned this cycle (attempted_count > 0) but NONE resulted in a
+    receipt landing (new_count == duplicate_count == 0) — "zero receipts"
+    while work was actually attempted. A quiet scan with nothing new to do
+    (attempted_count == 0) stays "ok" — that is the healthy, common case.
+    Best-effort: heartbeat write failures never raise into the caller.
+    """
+    try:
+        from health_beacon import HealthBeacon  # noqa: PLC0415
+    except Exception as exc:
+        logger.warning("report_to_receipt_converter: cannot import health_beacon: %s", exc)
+        return
+
+    status = "ok"
+    if stats.attempted_count > 0 and stats.new_count == 0 and stats.duplicate_count == 0:
+        status = "fail"
+
+    beacon = HealthBeacon(
+        state_dir, _HEALTH_COMPONENT, expected_interval_seconds=_HEALTH_EXPECTED_INTERVAL_SECONDS,
+    )
+    beacon.heartbeat(  # best-effort: swallows OSError internally
+        status=status,
+        details={
+            "new_count": stats.new_count,
+            "duplicate_count": stats.duplicate_count,
+            "rejected_count": stats.rejected_count,
+            "malformed_count": stats.malformed_count,
+            "error_count": stats.error_count,
+        },
+    )
+
+
 def scan_and_convert(
     reports_dirs: List[Path],
     state_dir: Optional[Path] = None,
     *,
     cache_window_seconds: int = 300,
-) -> int:
+) -> ScanStats:
     """Scan report directories and convert unprocessed reports.
 
     Deduplication uses ONLY the converter's own watermark file
@@ -390,17 +534,24 @@ def scan_and_convert(
     processed_receipts.txt is intentionally NOT consulted — the two
     systems own separate dedup stores to avoid format-conflation risk.
 
-    Returns the count of newly emitted receipts (status="appended").
-    Malformed reports are skipped with a warning; they are NOT marked as
-    processed so they will be retried on the next scan (in case they are
-    still being written).
+    Returns a ScanStats with per-outcome counts (new/duplicate/rejected/
+    malformed/error) — see ScanStats and _convert_one_detailed()'s outcome
+    tags. Only newly-appended and duplicate reports are marked processed;
+    rejected, malformed, and errored reports are NOT marked processed, so
+    they are retried on the next scan once their cause is fixed.
+
+    A single poisoned report can never abort the scan (OI-997): each
+    report's conversion is wrapped in try/except here, in addition to
+    _convert_one_detailed()'s own internal guards, so an exception from
+    ANY stage of parsing/building/appending is caught, logged once, and the
+    scan continues with the next report.
     """
     if state_dir is None:
         try:
             state_dir = _resolve_state_dir()
         except Exception as exc:
             logger.error("report_to_receipt_converter: cannot resolve state_dir: %s", exc)
-            return 0
+            return ScanStats()
 
     state_dir.mkdir(parents=True, exist_ok=True)
     receipts_file = str(state_dir / "t0_receipts.ndjson")
@@ -409,6 +560,10 @@ def scan_and_convert(
     watermark = _load_watermark(watermark_path)
 
     new_count = 0
+    duplicate_count = 0
+    rejected_count = 0
+    malformed_count = 0
+    error_count = 0
 
     for reports_dir in reports_dirs:
         if not isinstance(reports_dir, Path):
@@ -427,27 +582,58 @@ def scan_and_convert(
             if file_hash in watermark:
                 continue
 
-            result = convert_report_to_receipt(
-                report_path,
-                receipts_file=receipts_file,
-                cache_window_seconds=cache_window_seconds,
-            )
+            try:
+                result, outcome = _convert_one_detailed(
+                    report_path,
+                    receipts_file=receipts_file,
+                    cache_window_seconds=cache_window_seconds,
+                )
+            except Exception as exc:
+                # Belt-and-suspenders: _convert_one_detailed() already catches
+                # its own failure modes, but ANY report must be able to crash
+                # here without ending the scan for every report after it —
+                # that is the exact 2026-08-03 18:36 incident this closes.
+                # One ERROR line per file per scan; NOT marked processed so
+                # it is retried once the cause is fixed.
+                logger.error(
+                    "report_to_receipt_converter: unhandled exception converting %s: %s: %s",
+                    report_path.name, type(exc).__name__, exc,
+                )
+                error_count += 1
+                continue
 
-            if result is not None:
-                # Mark as processed regardless of appended/duplicate —
-                # no point re-scanning a report that's already in the system.
+            if outcome in ("appended", "duplicate"):
+                # Mark as processed — no point re-scanning a report that's
+                # already in the system.
                 _mark_processed(file_hash, watermark_path)
                 watermark.add(file_hash)
-                if result.status == "appended":
+                if outcome == "appended":
                     new_count += 1
                     logger.info(
                         "report_to_receipt_converter: receipt emitted dispatch=%s file=%s",
                         result.idempotency_key[:20],
                         report_path.name,
                     )
-            # result is None → malformed; NOT marked processed (retry on next scan)
+                else:
+                    duplicate_count += 1
+            elif outcome == "rejected":
+                rejected_count += 1
+            elif outcome == "malformed":
+                malformed_count += 1
+            else:  # "error"
+                error_count += 1
+            # rejected / malformed / error reports are NOT marked processed:
+            # retried on the next scan once the cause is fixed.
 
-    return new_count
+    stats = ScanStats(
+        new_count=new_count,
+        duplicate_count=duplicate_count,
+        rejected_count=rejected_count,
+        malformed_count=malformed_count,
+        error_count=error_count,
+    )
+    _write_scan_heartbeat(state_dir, stats)
+    return stats
 
 
 # ---------------------------------------------------------------------------
@@ -500,9 +686,14 @@ def main(argv: Optional[List[str]] = None) -> int:
             logger.error("report_to_receipt_converter: cannot resolve dirs from env: %s", exc)
             return 1
 
-    n = scan_and_convert(dirs, state_dir, cache_window_seconds=300)
-    if n:
-        logger.info("report_to_receipt_converter: %d new receipt(s) emitted", n)
+    stats = scan_and_convert(dirs, state_dir, cache_window_seconds=300)
+    if stats.new_count:
+        logger.info("report_to_receipt_converter: %d new receipt(s) emitted", stats.new_count)
+    if stats.rejected_count or stats.malformed_count or stats.error_count:
+        logger.warning(
+            "report_to_receipt_converter: %d rejected, %d malformed, %d error(s) this scan",
+            stats.rejected_count, stats.malformed_count, stats.error_count,
+        )
     return 0
 
 

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -340,7 +340,7 @@ _ppr_process_rate_limited() {
     python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
         --state-dir "$STATE_DIR" \
         "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>/dev/null \
-        || log "DEBUG" "report_to_receipt_converter catchup scan non-fatal (exit $?)"
+        || log "ERROR" "report_to_receipt_converter catchup scan FAILED non-fatal, processor continues (exit $?)"
 }
 
 # Process all pending reports with flood protection and rate limiting.
@@ -398,7 +398,7 @@ _poll_new_reports() {
             python3 "$SCRIPTS_DIR/lib/report_to_receipt_converter.py" \
                 --state-dir "$STATE_DIR" \
                 "$UNIFIED_REPORTS" "$HEADLESS_REPORTS" 2>/dev/null \
-                || log "DEBUG" "report_to_receipt_converter scan non-fatal (exit $?)"
+                || log "ERROR" "report_to_receipt_converter scan FAILED non-fatal, processor continues (exit $?)"
         fi
         if [ $(( _cycle % _retry_cycles )) -eq 0 ]; then
             _retry_pending_receipts

--- a/tests/fixtures/poisoned_reports/plangate-p0-glm-harness.md
+++ b/tests/fixtures/poisoned_reports/plangate-p0-glm-harness.md
@@ -1,0 +1,140 @@
+---
+schema_version: 1
+dispatch_id: plangate-p0-glm-harness
+provider: glm-harness
+sub_provider: zai
+model: glm-5.2
+terminal_id: T3
+pool_id: headless
+role: reviewer
+task_class: implementation
+pr_id: none
+duration_seconds: 301.139
+exit_code: 0
+token_usage:
+  input: 13953
+  output: 5983
+  cache_read: 0
+cost_usd: 0.01985916
+route_decision:
+  strategy: default
+  selected_provider: glm-harness
+  selected_model: glm-5.2
+---
+
+# Dispatch plangate-p0-glm-harness
+
+- Provider: glm-harness
+- Terminal: T3
+- Duration: 301.1s
+
+## Instruction
+
+PLAN-GATE review of a P0 bug-fix plan for vnx-orchestration. Verdict the DESIGN, not prose. Verified facts: migrate_future_system.py fails (unbalanced-parens in _matching_paren:211 + a headless_runs->dispatches FK-mismatch); vnx migrate (coordination_db.py:266-270) only applies the bootstrap ledger, not 0027/0028; sales-copilot store stuck at user_version=26 (no tracks.horizon). Assess: (1) is D1's sqlite3-introspection-instead-of-hand-parser the right call, or risks? (2) is folding 00NN into vnx migrate (D2) safe re: ordering/idempotency/ADR-007? (3) the FK-mismatch root-cause guess (ordering/foreign_keys pragma) — plausible? (4) any missing risk (data-loss, half-migrated states, the has_horizon silent-degrade)? End with exactly one line: VERDICT: PASS or VERDICT: REVISE + numbered findings.
+
+PLAN:
+# Horizon schema-migration fix — PLAN (P0)
+
+**Track:** `horizon-schema-migration-fix` (now, P0). **Escalated by:** sales-copilot (finding-doc
++ repro). **Verified against code** 2026-07-05.
+
+## Problem (two coupled, both confirmed)
+
+**Bug A — two-ledger gap.** `vnx migrate` / `init_coordination_db` (`coordination_db.py:266-270`)
+applies only the bootstrap ledger `runtime_coordination_v{2..10}.sql` (user_version-based). The
+Horizon schema lives in a SEPARATE ledger: `schemas/migrations/0027_planning_horizon_and_deliverable_view.sql`
++ `0028_tracks_derived_status.sql`, applied by `scripts/migrate_future_system.py` — which the
+fleet-sync never ran. Pre-Horizon stores (user_version<27) miss `tracks.horizon`; `vnx horizon list`
+silently degrades to UNSCHEDULED (`has_horizon`-guard, `tracks.py:~219`) — hiding the gap.
+`horizon add --horizon now` "succeeds" but the horizon is ignored. Verified: sales-copilot store
+user_version=26, no `horizon` column; MC/seo/vnx-dev at 31 (fine) — sales-copilot is the stuck
+half-cutover store.
+
+**Bug B — `migrate_future_system.py` is broken** (the only fix for A). Fails two ways:
+(1) `unbalanced parentheses in SQL` — `_matching_paren` (:211) via `_paren_group` (:260) chokes on
+the nested `CASE WHEN SUM(CASE WHEN ... IN (...))` in the 0027 deliverables VIEW (and string-literals);
+(2) a second run surfaced `foreign key mismatch - "headless_runs" referencing "dispatches"`. No
+working migration path to the Horizon schema.
+
+## Design
+
+### D1 — fix `migrate_future_system.py` (Bug B, the blocker)
+- Replace the hand-rolled paren-matcher (`_matching_paren`/`_paren_group`) with **sqlite3-based
+  introspection**: don't parse SQL by hand — apply the migration to a throwaway/attached in-memory
+  DB and read the resulting object definitions from `sqlite_master.sql`, OR use `sqlite3`'s own
+  parser to extract the view/column spec. If a hand parser is kept, it MUST balance nested parens
+  AND skip string-literals/`--` comments. Root-cause the `headless_runs→dispatches` FK-mismatch
+  (likely an ordering / `PRAGMA foreign_keys` / missing-parent-table issue during the migration
+  transaction) and fix it.
+- Idempotent + safe: guard each migration by a marker (a `schema_migrations` row or a column-exists
+  check) so re-running is a no-op; wrap in a transaction; back up before applying.
+
+### D2 — `vnx migrate` applies the 00NN ledger (Bug A)
+- After the bootstrap ledger, `init_coordination_db`/`vnx migrate` also drives the `migrate_future_system`
+  path so ONE idempotent `vnx migrate` fully migrates a store (bootstrap + future-system). Order:
+  bootstrap first (establishes the base tables the 00NN migrations depend on), then 00NN.
+- `vnx update` / fleet-sync invokes `vnx migrate` per project-store so a future sync never leaves a
+  store half-migrated again.
+
+### D3 — migrate the stuck store + prove
+- Run the fixed `vnx migrate` against sales-copilot's store (backup exists:
+  `.bak-20260705-premigrate`) → user_version reaches 31, `tracks.horizon` present, `vnx horizon list`
+  buckets its 8 tracks into now/next/later instead of UNSCHEDULED.
+
+### D4 — tests
+- A pre-27 fixture store: `vnx migrate` brings it to current with `tracks.horizon`; re-run is a no-op;
+  the 0027 deliverables VIEW is created without the paren error; the FK-mismatch does not recur.
+  `horizon add --horizon now` then lists under NOW, not UNSCHEDULED.
+
+## Guards / non-goals
+- ADR-007: migrations stay project_id-composite-key safe.
+- Do NOT unify the two ledgers in this PR (sales' option 3) — that's a larger refactor; keep this a
+  targeted fix. Note it as a follow-up.
+- Never destroy data: back up the store before migrating; the migration is additive.
+
+## Acceptance
+sales-copilot store migrates to 31 + horizon-usable (its 8 tracks schedulable); a pre-27 fixture
+migrates clean + idempotent; no paren/FK error.
+
+## Response
+
+Ik heb de code gelezen. Hier is mijn beoordeling van het ontwerp.
+
+## Analyse
+
+**Bug B(1) root-cause is verkeerd gediagnosticeerd in het PLAN.** De 0027-migratie wordt toegepast via `schema_migration.apply_script_if_below` (`migrate_future_system.py:1799`), die SQL splitst met `_split_sql_statements` — een puntkomma-splitser die strings en `--`/`/* */`-comments afhandelt (`schema_migration.py:89`). Het roept NOOIT `_matching_paren`/`_paren_group` aan. De `_matching_paren` wordt alleen gebruikt voor het parsen van de CREATE TABLE/INDEX-tekst van `sqlite_master`: de `dispatches`-rebuild op regel 604 en index-SQL op 260/485/495. De geneste `CASE WHEN SUM(CASE WHEN ... IN (...))` in de deliverables VIEW is dus niet de offender. De werkelijke errorbron is `_matching_paren` op de `dispatches` CREATE TABLE-tekst (of een index-SQL) waarbij `_mask_quoted_sql` (regel 171) strings en identifiers maskeert, maar `--`- en `/* */`-comments NIET. Een `--`-comment met een haakje in de opgeslagen CREATE-tekst gooit de teller om. D1's "vervang hand-parser door sqlite3-introspectie" is gebaseerd op een verkeerde diagnose en overschrijft het probleem.
+
+**D1 is deels onuitvoerbaar zoals geformuleerd.** Voor index-solo-detectie (260/485/495) kan introspectie werken — `PRAGMA index_xinfo` wordt daar al gebruikt; `_paren_group` is alleen een fallback voor expressie-indexen. Maar voor de `dispatches`-rebuild op regel 604 moet de CREATE TABLE-tekst worden *herschreven* (solo-UNIQUE laten vallen, project_id + composite toevoegen). Introspectie geeft kolommen, maar kan de volledige CREATE-tekst met constraints/triggers niet regenereren. De minimale, correcte fix is `_mask_quoted_sql` uitbreiden met commentaar-masking (≈5 regels), niet een introspectie-herschrijving.
+
+**Bug B(2) FK-mismatch — de gok is plausibel maar niet afgelijnd.** `0031_runtime_tenant_fk_repair.sql:60` declareert `FOREIGN KEY (dispatch_id, project_id) REFERENCES dispatches(dispatch_id, project_id)`. Met `PRAGMA foreign_keys = ON` (gezet in `run()`, regel ~2990) vereist SQLite dat de parent-tabel een UNIQUE/PK heeft op die exacte kolom-combinatie. Als de ADR-007-repair (stap A) de `dispatches` niet composite heeft gemaakt, faalt het aanmaken/inserten van de FK met "foreign key mismatch - headless_runs referencing dispatches". Dus: ontbrekende parent-UNIQUE is de echte oorzaak — geen pragma-volgorde. De plandocumentatie moet dit vastpinnen: 0031 vereist dat de ADR-007-repair volledig is uitgevoerd op dezelfde verbinding vóór 0031. De huidige `run()`-volgorde (A vóór C) suggereert dat dit zo is, maar de repair is een no-op wanneer `_dispatches_needs_adr007_repair` false retourneert — een store die composite mist maar waar de detector een false negative heeft, valt erdoorheen. De detector (`_dispatches_needs_adr007_repair`) moet worden geverifieerd voor de sales-copilot-vorm.
+
+**D2-volgorde heeft een gat.** `init_coordination_db` stamt tot `runtime_coordination_v10.sql` → user_version=10. De 00NN-walk begint bij 0022 met een preflight die `dispatches` v22-schema eist. Er is geen 11→21-brug in `vnx migrate`. Sales-copilot (user_version=26) springt schoon over het gat heen (≥22), maar een verse `vnx init` + `vnx migrate` op een lege store komt vast te zitten op de 0022-preflight. D2 moet dit expliciteren: óf de bootstrap stamt al naar ≥22 (verifieer), óf de walk heeft een 11-21-bridge. Het plan zwijgt hierover.
+
+**D2 — QI/RC coupled migration ontbreekt.** `run()` sluit af met `_run_w1_coupled_migration(db_path)` (stap E) die de Quality-Intelligence-DB samen met RC migreert. D2 laat dit weg. Een `vnx migrate` die alleen de RC-walk draait, laat de QI-DB achter. Acceptatiecriteria dekken dit niet.
+
+**D2 — fleet-sync auto-migrate is een nieuw risico.** D2 laat `vnx update`/fleet-sync per store `vnx migrate` draaien. De ADR-007-rebuild doet `DROP TABLE dispatches` + `RENAME` met `foreign_keys=OFF` op elke store die nog niet composite is. Idempotent (no-op) wanneer al composite — maar voor elke store die niet-composite is, draait een tabelrebuild tijdens een routinematige fleet-sync zonder per-store backup. D3 heeft een `.bak` voor sales-copilot; D2 zou `vnx migrate` moeten back-uppen of de no-op-voorwaarde hard moeten stellen vóór de brede uitrol.
+
+**`has_horizon` silent-degrade — niet gefixeerd, alleen gemigreerd.** `tracks.py:219` valt terug naar een INSERT zonder `horizon`-kolom wanneer `has_horizon` false is. Op een pre-27 store "slagt" `horizon add --horizon now` maar dropt de waarde stilletjes — intentie-dataloss. D3 migreert sales-copilot, maar andere fleet-stores die pre-27 staan (en er zijn er mogelijk meer) blijven stilletjes degraderen. Acceptantie zou moeten eisen: `vnx horizon add` faalt luid of waarschuwt wanneer `has_horizon` false is, in plaats van stilletjes de kolom weg te laten. Het plan noemt het symptoom maar heeft geen guard.
+
+**Half-migrated-staat bij 0031.** 0031 doet `DROP TABLE headless_runs; ALTER TABLE headless_runs_new RENAME TO headless_runs`. Als de FK-mismatch mid-0031 optreedt, rolt `apply_script_if_below`'s SAVEPOINT terug — maar verifieer dat het adaptive 0031-pad (regel 2861+) niet zelf transacties beheert buiten die SAVEPOINT. Het plan claimt "wrap in a transaction" als een D1-eis, maar controleert niet of 0031 al buiten de SAVEPOINT om commit/rollback doet. Een crash tussen DROP en RENAME laat de store zonder `headless_runs`. Acceptatie zou een 0031-crash-test moeten bevatten.
+
+**0031 vs ADR-007 R3.1-spanning.** `0031`-SQL hardcodeert `project_id TEXT NOT NULL DEFAULT 'vnx-dev'` voor `headless_runs_new` en `dispatch_attempts_new`. De R3.1-resolver in `migrate_future_system` ("NEVER default to 'vnx-dev'") is in tegenspraak met de SQL-standaardwaarde. Voor bestaande rijen is de INSERT-stamp OK (resolver leidt af uit DB-pad), maar toekomstige directe inserts die weglaten, krijgen de sentinel. De plan-guard "migrations stay project_id-composite-key safe" dekt dit niet. Volg-up, niet blocker, maar noteer het.
+
+## Conclusie
+
+De roadmap voor het oplossen van het blokkeringsprobleem is richtinggevend juist (los de parser op, vouw 00NN in `vnx migrate`, migreer de vastgelopen store), maar D1 richt zich op de verkeerde codepath en de diagnose van Bug B(1) klopt niet met de daadwerkelijke aanroeppaden. D2 mist de QI-coupled-migratie en de 11-21-bridge. De `has_horizon`-silent-degrade blijft bestaan voor de rest van de vloot. REVISE.
+
+VERDICT: REVISE
+1. Bug B(1)-diagnose is fout: 0027 loopt via `_split_sql_statements`, niet via `_matching_paren`; de haakjeserror komt van `dispatches`/index-CREATE-tekst. Herformuleer D1: uitbreiden van `_mask_quoted_sql` met `--`/`/* */`-commentaar-masking op de regel 604/260/485/495 call-sites, niet een sqlite3-introspectie-herschrijving (die de CREATE-tekst niet kan regenereren).
+2. D1 "sqlite3-introspectie" is onuitvoerbaar voor de `dispatches`-rebuild op regel 604 ( tekst moet worden herschreven, niet alleen geïnspecteerd); reserveer introspectie voor de index-detectie-fallback.
+3. Bug B(2) oorzaak vastpinnen: 0031 vereist `dispatches` composite UNIQUE(dispatch_id, project_id) op dezelfde verbinding vóór 0031; verifieer `_dispatches_needs_adr007_repair` heeft geen false negative voor de sales-copilot-vorm, anders faalt 0031 FK met "mismatch". Het is geen pragma-volgordeprobleem.
+4. D2: verifieer de 11→21 user_version-bridge — `init_coordination_db` stamt slechts tot v10; 00NN-preflight eist v22. Expliciteer of de bootstrap naar ≥22 stamt of voeg een bridge toe; anders loopt een verse `vnx init` + `migrate` vast op de 0022-preflight.
+5. D2: voeg `_run_w1_coupled_migration` (QI-DB) toe aan de `vnx migrate`-pad; acceptatie dekt nu alleen RC, waardoor QI-DB ongemigreerd achterblijft.
+6. D2: back-up of harde no-op-voorwaarde vóór fleet-sync auto-migrate; de ADR-007-rebuild doet DROP/RENAME met `foreign_keys=OFF` op elke niet-composite store tijdens routinematige sync.
+7. `has_horizon` silent-degrade fixen in `vnx horizon add` (faalt luid/waarschuwt wanneer `has_horizon` false), niet alleen sales-copilot migreren; andere pre-27 stores in de vloot degraderen anders stilletjes door.
+8. D4: voeg een 0031 crash/half-migrated-test toe — verifieer dat het adaptive 0031-pad binnen `apply_script_if_below`'s SAVEPOINT blijft (geen eigen commit/rollback buiten de savepoint), anders kan een crash tussen DROP en RENAME een store zonder `headless_runs` achterlaten.
+9. Volg-up noteren: 0031's `DEFAULT 'vnx-dev'` voor `headless_runs_new`/`dispatch_attempts_new` staat in spanning met ADR-007 R3.1 ("never default to vnx-dev"); bestaande-rij-stamp is OK, toekomstige directe inserts krijgen de sentinel.
+
+## Findings
+
+None

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -16,6 +16,8 @@ Covers:
 from __future__ import annotations
 
 import json
+import logging
+import shutil
 import sys
 from pathlib import Path
 from unittest.mock import patch
@@ -28,6 +30,7 @@ sys.path.insert(0, str(SCRIPTS_LIB))
 from report_to_receipt_converter import (
     _WATERMARK_FILENAME,
     _compute_sha256,
+    _extract_body_fields,
     _load_route_decision,
     _load_watermark,
     build_receipt_from_report,
@@ -35,6 +38,8 @@ from report_to_receipt_converter import (
     parse_frontmatter,
     scan_and_convert,
 )
+
+_POISONED_REPORT = Path(__file__).resolve().parent / "fixtures" / "poisoned_reports" / "plangate-p0-glm-harness.md"
 
 
 # ---------------------------------------------------------------------------
@@ -236,19 +241,19 @@ class TestScanAndConvert:
         _write_frontmatter_report(reports_dir / "20260601-scan-a.md", "20260601-scan-a")
         _write_frontmatter_report(reports_dir / "20260601-scan-b.md", "20260601-scan-b")
 
-        n = scan_and_convert([reports_dir], state_dir)
+        stats = scan_and_convert([reports_dir], state_dir)
 
-        assert n == 2
+        assert stats.new_count == 2
         assert _count_receipts(state_dir) == 2
 
     def test_idempotent_rescan(self, reports_dir, state_dir):
         _write_frontmatter_report(reports_dir / "20260601-rescan.md", "20260601-rescan")
 
-        n1 = scan_and_convert([reports_dir], state_dir)
-        n2 = scan_and_convert([reports_dir], state_dir)
+        stats1 = scan_and_convert([reports_dir], state_dir)
+        stats2 = scan_and_convert([reports_dir], state_dir)
 
-        assert n1 == 1
-        assert n2 == 0  # watermark prevents re-emission
+        assert stats1.new_count == 1
+        assert stats2.new_count == 0  # watermark prevents re-emission
         assert _count_receipts(state_dir) == 1
 
     def test_malformed_report_skipped_no_crash(self, reports_dir, state_dir):
@@ -256,16 +261,18 @@ class TestScanAndConvert:
         reports_dir.joinpath("unknown.md").write_text("No dispatch ID anywhere in this file.", encoding="utf-8")
         _write_frontmatter_report(reports_dir / "20260601-good.md", "20260601-good")
 
-        n = scan_and_convert([reports_dir], state_dir)
+        stats = scan_and_convert([reports_dir], state_dir)
 
-        # Only the good report is counted
-        assert n == 1
+        # Only the good report is counted as new; the malformed one is
+        # counted separately (OI-998) and not marked processed.
+        assert stats.new_count == 1
+        assert stats.malformed_count == 1
         assert _count_receipts(state_dir) == 1
 
     def test_nonexistent_dir_no_crash(self, state_dir, tmp_path):
         nonexistent = tmp_path / "does_not_exist"
-        n = scan_and_convert([nonexistent], state_dir)
-        assert n == 0
+        stats = scan_and_convert([nonexistent], state_dir)
+        assert stats.new_count == 0
 
     def test_multiple_dirs(self, tmp_path, state_dir):
         dir_a = tmp_path / "reports_a"
@@ -275,8 +282,8 @@ class TestScanAndConvert:
         _write_frontmatter_report(dir_a / "20260601-a.md", "20260601-a")
         _write_frontmatter_report(dir_b / "20260601-b.md", "20260601-b")
 
-        n = scan_and_convert([dir_a, dir_b], state_dir)
-        assert n == 2
+        stats = scan_and_convert([dir_a, dir_b], state_dir)
+        assert stats.new_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -302,8 +309,8 @@ class TestWatermarkPersistence:
 
         # Second scan with fresh in-memory state (simulates restart)
         # The watermark file on disk prevents re-processing
-        n2 = scan_and_convert([reports_dir], state_dir)
-        assert n2 == 0
+        stats2 = scan_and_convert([reports_dir], state_dir)
+        assert stats2.new_count == 0
         assert _count_receipts(state_dir) == 1
 
     def test_converter_ignores_bash_watermark(self, reports_dir, state_dir):
@@ -322,10 +329,10 @@ class TestWatermarkPersistence:
         bash_wm = state_dir / "processed_receipts.txt"
         bash_wm.write_text(file_hash + "\n", encoding="utf-8")
 
-        n = scan_and_convert([reports_dir], state_dir)
+        stats = scan_and_convert([reports_dir], state_dir)
 
         # Converter must NOT skip: it does not read the Bash watermark.
-        assert n == 1
+        assert stats.new_count == 1
         assert _count_receipts(state_dir) == 1
 
         # Converter's own watermark is now populated.
@@ -333,8 +340,8 @@ class TestWatermarkPersistence:
         assert file_hash in py_wm
 
         # Second scan: converter's own watermark prevents re-emission.
-        n2 = scan_and_convert([reports_dir], state_dir)
-        assert n2 == 0
+        stats2 = scan_and_convert([reports_dir], state_dir)
+        assert stats2.new_count == 0
         assert _count_receipts(state_dir) == 1
 
     def test_converter_does_not_read_mtime_watermark(self, reports_dir, state_dir):
@@ -351,10 +358,10 @@ class TestWatermarkPersistence:
         report = reports_dir / "20260601-mtime-isolation.md"
         _write_frontmatter_report(report, "20260601-mtime-isolation")
 
-        n = scan_and_convert([reports_dir], state_dir)
+        stats = scan_and_convert([reports_dir], state_dir)
 
         # Converter processes the report — it does not read the mtime watermark.
-        assert n == 1
+        assert stats.new_count == 1
 
         # The mtime watermark file is untouched by the converter.
         assert mtime_wm.read_text(encoding="utf-8").strip() == "9999999999"
@@ -529,10 +536,10 @@ class TestContractValidation:
             encoding="utf-8",
         )
 
-        n = scan_and_convert([reports_dir], state_dir)
+        stats = scan_and_convert([reports_dir], state_dir)
 
-        # Both get receipts emitted (appended), so n == 2
-        assert n == 2
+        # Both get receipts emitted (appended), so new_count == 2
+        assert stats.new_count == 2
         receipts = _receipts(state_dir)
         assert len(receipts) == 2
         event_types = {r["event_type"] for r in receipts}
@@ -738,3 +745,214 @@ class TestSmartRouterStrategyTag:
 
         result = _load_route_decision("bad-dispatch", state_dir)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Part 9: poisoned-report resilience (OI-997) — dispatch-20260804-064708-pra-
+# converter-resilience
+# ---------------------------------------------------------------------------
+
+class TestPoisonedReportResilience:
+    """A single crashed report must not crash the whole converter scan.
+
+    ``tests/fixtures/poisoned_reports/plangate-p0-glm-harness.md`` is a copy
+    of the real quarantined report that stopped receipt emission entirely on
+    2026-08-03 18:36: a ``**bold-key**`` whose value falls entirely inside
+    the ``text[:3000]`` scan window as trailing whitespace only —
+    ``group(2).strip()`` reduces to ``""``, and the old
+    ``.splitlines()[0]`` raised ``IndexError`` before the guard added here.
+    """
+
+    def test_poisoned_report_does_not_crash_extract_body_fields(self):
+        text = _POISONED_REPORT.read_text(encoding="utf-8")
+        fields = _extract_body_fields(text)  # must not raise
+        assert isinstance(fields, dict)
+
+    def test_poisoned_report_does_not_crash_build_receipt_from_report(self, tmp_path):
+        text = _POISONED_REPORT.read_text(encoding="utf-8")
+        dest = tmp_path / _POISONED_REPORT.name
+        dest.write_text(text, encoding="utf-8")
+
+        receipt = build_receipt_from_report(dest, text)  # must not raise
+
+        assert receipt is not None
+        assert receipt["dispatch_id"] == "plangate-p0-glm-harness"
+
+    def test_one_poisoned_report_does_not_block_the_batch(self, reports_dir, state_dir):
+        """A dir with 1 poisoned + 2 healthy reports must yield 3 receipts —
+        one per report, none dropped.
+
+        Before the OI-997 fix, the poisoned report's IndexError propagated
+        out of build_receipt_from_report() uncaught inside
+        scan_and_convert()'s loop, aborting the ENTIRE scan — every report
+        after the poisoned one in sort order was never even attempted. This
+        is the literal 2026-08-03 18:36 incident (300+ reports, 0 receipts
+        emitted until the poisoned file was quarantined by hand).
+
+        Sorted glob order places the poisoned file BEFORE both healthy
+        reports (`plangate-...` < `zzz-healthy-...`) so a regression here
+        (no try/except around the per-report conversion) reproduces the
+        original all-or-nothing failure, not a partial one.
+
+        The poisoned report itself lands as a "report_contract_invalid"
+        receipt (its body lacks the required ## Summary/## Changes/etc
+        headings — a separate, pre-existing contract check, not this
+        dispatch's concern) rather than "task_complete"; the point proven
+        here is that it no longer crashes the SCAN, so the two healthy
+        reports after it still get their receipts.
+        """
+        shutil.copy(_POISONED_REPORT, reports_dir / _POISONED_REPORT.name)
+        _write_frontmatter_report(reports_dir / "zzz-healthy-a.md", "zzz-healthy-a")
+        _write_frontmatter_report(reports_dir / "zzz-healthy-b.md", "zzz-healthy-b")
+
+        stats = scan_and_convert([reports_dir], state_dir)
+
+        assert stats.new_count == 3
+        assert stats.error_count == 0
+        assert _count_receipts(state_dir) == 3
+        receipts = _receipts(state_dir)
+        event_types = {r["event_type"] for r in receipts}
+        assert "task_complete" in event_types
+        assert "report_contract_invalid" in event_types
+
+
+class TestScanCrashGuard:
+    """OI-997 point 2: scan_and_convert()'s OWN try/except around the
+    per-report call site must survive ANY exception — not only the specific
+    IndexError fixed in _extract_body_fields() / guarded inside
+    _convert_one_detailed(). Simulates a bug that bypasses those inner
+    guards entirely to prove the outer guard in scan_and_convert() itself
+    is what is being tested here.
+    """
+
+    def test_unhandled_exception_in_one_report_does_not_abort_the_batch(
+        self, reports_dir, state_dir, monkeypatch, caplog
+    ):
+        import report_to_receipt_converter as rtc
+
+        _write_frontmatter_report(reports_dir / "20260601-outer-a.md", "20260601-outer-a")
+        _write_frontmatter_report(reports_dir / "20260601-outer-b.md", "20260601-outer-b")
+        _write_frontmatter_report(reports_dir / "20260601-outer-c.md", "20260601-outer-c")
+
+        real_convert_one = rtc._convert_one_detailed
+
+        def _boom(report_path, **kwargs):
+            if "outer-b" in report_path.name:
+                raise RuntimeError("simulated bug bypassing _convert_one_detailed's own guards")
+            return real_convert_one(report_path, **kwargs)
+
+        monkeypatch.setattr(rtc, "_convert_one_detailed", _boom)
+
+        with caplog.at_level(logging.ERROR, logger="report_to_receipt_converter"):
+            stats = rtc.scan_and_convert([reports_dir], state_dir)
+
+        assert stats.new_count == 2
+        assert stats.error_count == 1
+        assert _count_receipts(state_dir) == 2
+        assert any(
+            "unhandled exception" in r.message and "outer-b" in r.message
+            for r in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# Part 10: fail-closed rejection must be counted and loud (OI-998)
+# ---------------------------------------------------------------------------
+
+def _write_report_without_model(path: Path, dispatch_id: str) -> Path:
+    """A well-formed dispatch report that omits Model — triggers the
+    fail-closed rejection in append_receipt_internals/validation.py."""
+    path.write_text(
+        f"---\ndispatch_id: {dispatch_id}\nprovider: claude\n---\n\n"
+        "## Summary\n\nImplemented the feature per dispatch specification. "
+        "All tests pass and coverage is at target.\n\n"
+        "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+        "## Verification\n\npytest tests/ -x: 42 passed\n\n"
+        "## Open Items\n\nNone\n",
+        encoding="utf-8",
+    )
+    return path
+
+
+class TestRejectionVisibility:
+    """A fail-closed rejection (no real Model) must be counted separately
+    from malformed/errored conversions and logged loudly (WARNING with
+    dispatch-id + reason) — not disappear as a silent None."""
+
+    def test_rejected_report_counted_separately_and_logs_warning(
+        self, reports_dir, state_dir, caplog
+    ):
+        _write_report_without_model(reports_dir / "20260601-no-model.md", "20260601-no-model")
+
+        with caplog.at_level(logging.WARNING, logger="report_to_receipt_converter"):
+            stats = scan_and_convert([reports_dir], state_dir)
+
+        assert stats.rejected_count == 1
+        assert stats.new_count == 0
+        assert stats.malformed_count == 0
+        assert stats.error_count == 0
+        assert _count_receipts(state_dir) == 0
+        assert any(
+            "REJECTED" in r.message
+            and "20260601-no-model" in r.message
+            and r.levelno == logging.WARNING
+            for r in caplog.records
+        )
+
+    def test_rejected_report_retried_on_next_scan_not_watermarked(self, reports_dir, state_dir):
+        """A rejected report must NOT be marked processed — it is retried
+        every scan until the cause (missing Model) is fixed."""
+        _write_report_without_model(reports_dir / "20260601-retry-me.md", "20260601-retry-me")
+
+        stats1 = scan_and_convert([reports_dir], state_dir)
+        stats2 = scan_and_convert([reports_dir], state_dir)
+
+        assert stats1.rejected_count == 1
+        assert stats2.rejected_count == 1  # retried, not silently watermarked away
+
+    def test_convert_report_to_receipt_returns_none_for_rejected(
+        self, tmp_path, state_dir, caplog
+    ):
+        """convert_report_to_receipt() keeps its exact Optional[AppendResult]
+        contract for the 'rejected' outcome too — existing callers (the tmux
+        stop-hook, direct-call tests) need no changes for this dispatch."""
+        report = _write_report_without_model(tmp_path / "20260601-direct-reject.md", "20260601-direct-reject")
+
+        with caplog.at_level(logging.WARNING, logger="report_to_receipt_converter"):
+            result = convert_report_to_receipt(
+                report, receipts_file=str(state_dir / "t0_receipts.ndjson")
+            )
+
+        assert result is None
+        assert any("REJECTED" in r.message for r in caplog.records)
+
+    def test_zero_receipts_scan_flips_health_beacon_to_fail(self, reports_dir, state_dir):
+        """The scan's counts land on the existing HealthBeacon channel
+        (health/report_to_receipt_converter.json — health_beacon.py, the
+        same mechanism producer_freshness_monitor.py uses for its own
+        heartbeat) so a scan that attempted conversions but produced zero
+        receipts reads as unhealthy, not as a quiet no-op."""
+        _write_report_without_model(reports_dir / "20260601-no-model-2.md", "20260601-no-model-2")
+
+        scan_and_convert([reports_dir], state_dir)
+
+        beacon_path = state_dir / "health" / "report_to_receipt_converter.json"
+        assert beacon_path.exists()
+        beacon = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert beacon["status"] == "fail"
+        assert beacon["details"]["rejected_count"] == 1
+        assert beacon["details"]["new_count"] == 0
+
+    def test_scan_with_at_least_one_success_keeps_beacon_ok(self, reports_dir, state_dir):
+        """A rejection alongside a successful receipt is normal, expected,
+        contract-driven behavior — it must NOT flip the whole scan unhealthy."""
+        _write_report_without_model(reports_dir / "20260601-no-model-3.md", "20260601-no-model-3")
+        _write_frontmatter_report(reports_dir / "20260601-healthy-c.md", "20260601-healthy-c")
+
+        stats = scan_and_convert([reports_dir], state_dir)
+        assert stats.new_count == 1
+        assert stats.rejected_count == 1
+
+        beacon_path = state_dir / "health" / "report_to_receipt_converter.json"
+        beacon = json.loads(beacon_path.read_text(encoding="utf-8"))
+        assert beacon["status"] == "ok"


### PR DESCRIPTION
Sluit **OI-997** (blocker) en **OI-998** (blocker).

## Waarom

Op 3 augustus stopte de receipt-emissie om 18:36 volledig, terwijl de processor als draaiend en gezond oogde. Eén vergiftigd rapport van de 300+ liet de hele converter-scan crashen. Na quarantaine van dat ene bestand emitteerde dezelfde scan direct twaalf receipts.

## Wat er verandert

- **De IndexError is geguard.** De echte trigger bleek scherper dan het open item stelde: een bold-veld waarvan de waarde net voorbij de `text[:3000]`-afkapgrens valt, houdt één spatie over. `.strip()` maakt daar `""` van en `"".splitlines()` is `[]`.
- **Eén kapot rapport neemt de batch niet meer mee.** Elke per-rapport-conversie zit in zijn eigen `try/except`; een fout logt één ERROR-regel en de scan gaat door. Gecrashte rapporten worden niet gewatermerkt, dus ze komen terug zodra de oorzaak weg is.
- **De fail-closed weigering is luid.** Weigeringen worden apart geteld, gelogd op WARNING met dispatch-id en reden, en landen via de bestaande `HealthBeacon` in `health/report_to_receipt_converter.json`. Een scan die conversies probeert maar nul receipts oplevert, klapt naar `status=fail` in plaats van als gezond te lezen.
- **`receipt_processor.sh`** logt de niet-nul exit van de converter niet langer als DEBUG maar als ERROR. Gedrag blijft non-fataal, alleen zichtbaar.
- **Het contract-meningsverschil is gedocumenteerd, niet stilzwijgend veranderd.** `report_body_contract.py` en de CLAUDE.md-tabel eisen Model/Provider niet, terwijl de converter zonder Model fail-closed weigert. Dat staat nu expliciet in beide, zonder `validate_body()` hard te laten falen: dat zou elke bestaande producent breken en is een aparte beslissing.

## Verificatie

47 tests groen in `tests/test_report_to_receipt_converter.py` (9 nieuw). De negen nieuwe tests zijn eerst tegen de oude code gedraaid en waren daar rood.

Door T0 onafhankelijk nagetrokken op het echte gequarantainede bestand: op `main` geeft `_extract_body_fields` een `IndexError`, op deze branch niet.

Eén pre-existing rood in de bredere sweep (`test_future_state_reconciliation.py::...test_health_beacon_receives_fail_when_writes_fail`) is niet van deze PR: die faalt identiek met de wijzigingen gestasht.

Dispatch-ID: `20260804-064708-pra-converter-resilience`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUCscZ8vsNRfNwwFoyrPkH