### PR TITLE
fix(govern): stamp real model instead of unknown on frontmatter (OI-1001)

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -573,7 +573,12 @@ def _govern_impl(spec: GovernSpec, raw: GovernRaw, lane: str) -> GovernedOutcome
     # Partial frontmatter raises SchemaViolation under VNX_SCHEMA_STRICT=1 and
     # blocks the atomic write, leaving a stale placeholder on disk.
     receipt_data = raw.receipt or {}
-    _model = (receipt_data.get("model") or "unknown")
+    # Same source order as the synthesized-receipt path above (line ~205):
+    # worker-authored receipt first, then spec.model (the real dispatch value,
+    # e.g. "sonnet"/"opus"), and only "unknown" when neither is set. Before this
+    # fix, a worker receipt with no "model" key fell straight to "unknown" even
+    # though spec.model carried the real value — OI-1001.
+    _model = receipt_data.get("model") or spec.model or "unknown"
     _exit_code = int(receipt_data.get("exit_code", 0) or 0)
     _raw_token = receipt_data.get("token_usage") or raw.token_usage or {}
     _token_usage = {

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -22,6 +22,7 @@ from dispatch_govern import (
     dedup_completion_receipts,
     ensure_receipt,
     govern,
+    _split_yaml_frontmatter,
     _synthesize,
 )
 from report_body_contract import validate_body
@@ -208,6 +209,83 @@ def test_govern_authored_preserves_worker_body(tmp_data, tmp_state, monkeypatch)
     assert "## Open Items" in content
     # Worker's specific text content must be preserved.
     assert "Implemented the feature correctly" in content
+
+
+# ---------------------------------------------------------------------------
+# OI-1001: frontmatter "model" must fall back to spec.model, not "unknown",
+# when the worker receipt carries no model field. Mirrors the source order
+# ensure_receipt() already used for the synthesized-receipt path.
+# ---------------------------------------------------------------------------
+
+def test_govern_frontmatter_model_falls_back_to_spec_model(tmp_data, tmp_state, monkeypatch):
+    """A worker receipt with no "model" key must not stamp frontmatter model:
+    "unknown" when spec.model carries the real value — the receipt_data lookup
+    must fall back to spec.model before defaulting to "unknown"."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, model="sonnet")
+    # Worker receipt with no "model" key — the exact shape a real worker-authored
+    # completion receipt has when it never stamped a model.
+    raw = _make_raw(receipt={"status": "done"})
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    content = report_file.read_text(encoding="utf-8")
+    parsed, _ = _split_yaml_frontmatter(content)
+    assert parsed["model"] == "sonnet", (
+        f"expected model to fall back to spec.model='sonnet', got {parsed.get('model')!r}"
+    )
+
+
+def test_govern_frontmatter_model_prefers_worker_receipt_over_spec(tmp_data, tmp_state, monkeypatch):
+    """A worker receipt that DOES carry a model must still win over spec.model —
+    the fallback only applies when the worker receipt is silent on model."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, model="sonnet")
+    raw = _make_raw(receipt={"status": "done", "model": "opus"})
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    content = report_file.read_text(encoding="utf-8")
+    parsed, _ = _split_yaml_frontmatter(content)
+    assert parsed["model"] == "opus", (
+        f"worker-receipt model must take precedence over spec.model, got {parsed.get('model')!r}"
+    )
+
+
+def test_govern_frontmatter_route_decision_selected_model_matches_model(tmp_data, tmp_state, monkeypatch):
+    """route_decision.selected_model must carry the same value as the top-level
+    model field — both are stamped from the same resolved _model variable."""
+    monkeypatch.setenv("VNX_SHARED_GOVERN", "1")
+
+    reports_dir = tmp_data / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    report_file = reports_dir / "test-govern-001.md"
+    report_file.write_text(_valid_body(), encoding="utf-8")
+
+    spec = _make_spec(tmp_data, tmp_state, model="sonnet")
+    raw = _make_raw(receipt={"status": "done"})
+    outcome = govern(spec, raw, lane="tmux_interactive")
+
+    assert outcome.contract_status == "authored"
+    content = report_file.read_text(encoding="utf-8")
+    parsed, _ = _split_yaml_frontmatter(content)
+    assert parsed["model"] == "sonnet"
+    assert parsed["route_decision"]["selected_model"] == "sonnet", (
+        "route_decision.selected_model must match the resolved model, not 'unknown'"
+    )
+    assert parsed["route_decision"]["selected_model"] == parsed["model"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Closes OI-1001. The claude-lane frontmatter-emit path in `dispatch_govern.py::_govern_impl()` stamped `model: unknown` whenever the worker receipt carried no `model` field — even though `spec.model` already carried the real dispatch value (`sonnet`/`opus`). Measured: 165 reports in the central store carried `model: unknown`, all `provider: claude`, all from the tmux-subscription lane since 2026-06-15.

## Changes

- `scripts/lib/dispatch_govern.py:576` — `_model` now resolves `receipt_data.get("model") or spec.model or "unknown"`, the same source order `ensure_receipt()` already used for the synthesized-receipt path (line 205). `route_decision.selected_model` (line 620) reuses `_model` so it is corrected automatically — no separate fix needed there.
- `tests/test_dispatch_govern.py` — three new tests:
  - `test_govern_frontmatter_model_falls_back_to_spec_model` — worker receipt with no `model` key + `spec.model="sonnet"` → frontmatter `model: sonnet`, not `unknown`.
  - `test_govern_frontmatter_model_prefers_worker_receipt_over_spec` — worker receipt WITH `model: opus` still wins over `spec.model="sonnet"`.
  - `test_govern_frontmatter_route_decision_selected_model_matches_model` — `route_decision.selected_model` matches the top-level `model` field.

## Third-location check

Searched the claude-lane for other `model -> "unknown"` fallback sites (`dispatch_govern.py`, `report_to_receipt_converter.py`, `append_receipt_internals/payload.py`). No third site found:
- `report_to_receipt_converter.py:294` defaults to `""` (empty string), not `"unknown"` — it passes through whatever the frontmatter says, which was the actual bug source.
- `append_receipt_internals/payload.py::_stamp_model_identity()` only *normalizes* an existing model string; it returns early (no default stamp) when the model is empty/None.
- `provider_dispatch.py`/`smart_router.py` `selected_model` usages are provider-lane only (kimi/glm/deepseek), out of scope per `CLAUDE.md`'s provider→lane rule — claude never routes through there.

Per the dispatch's explicit "do not touch" list: `report_to_receipt_converter.py:238`'s frontmatter-wins merge order was left untouched, and no identity-block-in-body approach was attempted.

## Verification

Red-state demonstration (fix stashed, fix-only diff reverted):
```
python3 -m pytest tests/test_dispatch_govern.py -k "test_govern_frontmatter_model_falls_back_to_spec_model or test_govern_frontmatter_model_prefers_worker_receipt_over_spec or test_govern_frontmatter_route_decision_selected_model_matches_model" -v
```
Result: 2 failed (`falls_back_to_spec_model`, `route_decision_selected_model_matches_model`), 1 passed (`prefers_worker_receipt_over_spec` — receipt already carried a model, unaffected by the bug). Failures: `assert 'unknown' == 'sonnet'`.

Green-state (fix restored), same command:
```
3 passed
```

Full regression sweep with fix applied:
```
python3 -m pytest tests/test_dispatch_govern.py tests/test_subprocess_dispatch_govern.py -v
```
Result: `70 passed`.

```
python3 -m pytest tests/test_receipt_schema.py tests/test_plan_gate_panel.py tests/test_phantom_guard_inline.py tests/test_tmux_interactive_dispatch_metadata.py tests/test_runtime_adapter_certification.py tests/test_receipt_processor_autopr_rejected_mirror.py tests/test_envelope_role_propagation.py tests/test_tmux_interactive_dispatch.py tests/test_dispatch_metadata_lock_timeout.py -q
```
Result: `356 passed`.

`tests/test_provider_dispatch_governance_integration.py` has 18 pre-existing failures (`MagicMock` not JSON-serializable in `provider_dispatch.py`'s `mandate_id` field) — confirmed unrelated by re-running with this PR's diff fully reverted: identical 18 failures. Not touched by this PR.

## Open Items

None.

Dispatch-ID: 20260804-071202-prb-model-stamp