### PR TITLE
fix(govern): never git-inspect the main checkout when no worktree exists (OI-1008)

### DIFF
--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -728,22 +728,45 @@ def _synthesize(spec: GovernSpec, raw: GovernRaw) -> str:
     return body
 
 
-def _git_summary(spec: GovernSpec, status: str) -> str:
-    """Return git log subject + body for the worker commit, or a fallback message."""
-    cwd = str(spec.worktree_path) if spec.worktree_path else None
+class _NoWorktreeError(Exception):
+    """Raised by _run_worktree_git when spec.worktree_path is None."""
+
+
+def _run_worktree_git(spec: GovernSpec, args: list, timeout: float) -> Optional[str]:
+    """Run `git <args>` scoped to spec.worktree_path and return stripped stdout, or None.
+
+    Refuses to run when spec.worktree_path is unset (OI-1008): a git call with
+    no explicit cwd inherits the dispatcher process's own working directory —
+    the main checkout — and would report on someone else's commits/diff
+    instead of this dispatch's. Every git invocation in this module MUST go
+    through this helper so that guarantee holds everywhere, not just at the
+    two call sites known today.
+    """
+    if not spec.worktree_path:
+        raise _NoWorktreeError(spec.dispatch_id)
     try:
         result = subprocess.run(
-            ["git", "log", "-1", "--format=%s%n%b"],
+            ["git", *args],
             capture_output=True,
             text=True,
-            timeout=10,
-            cwd=cwd,
+            timeout=timeout,
+            cwd=str(spec.worktree_path),
         )
-        msg = result.stdout.strip()
-        if msg:
-            return f"{msg}\n\nWorker status: {status}. Body synthesized by governance layer (no worker report file)."
     except (subprocess.TimeoutExpired, OSError, FileNotFoundError) as exc:
-        logger.debug("govern._git_summary: git log failed for %s: %s", spec.dispatch_id, exc)
+        logger.debug("govern._run_worktree_git: git %s failed for %s: %s", args, spec.dispatch_id, exc)
+        return None
+    return result.stdout.strip() or None
+
+
+def _git_summary(spec: GovernSpec, status: str) -> str:
+    """Return git log subject + body for the worker commit, or a fallback message."""
+    try:
+        msg = _run_worktree_git(spec, ["log", "-1", "--format=%s%n%b"], timeout=10)
+    except _NoWorktreeError:
+        msg = None
+
+    if msg:
+        return f"{msg}\n\nWorker status: {status}. Body synthesized by governance layer (no worker report file)."
 
     return (
         f"No commit on branch; worker emitted status={status}. "
@@ -753,37 +776,22 @@ def _git_summary(spec: GovernSpec, status: str) -> str:
 
 def _git_changes(spec: GovernSpec) -> str:
     """Return git diff --stat between base_sha and HEAD, or a fallback message."""
-    cwd = str(spec.worktree_path) if spec.worktree_path else None
     base = spec.base_sha
 
-    if base:
-        try:
-            result = subprocess.run(
-                ["git", "diff", "--stat", f"{base}..HEAD"],
-                capture_output=True,
-                text=True,
-                timeout=15,
-                cwd=cwd,
-            )
-            stat = result.stdout.strip()
+    try:
+        if base:
+            stat = _run_worktree_git(spec, ["diff", "--stat", f"{base}..HEAD"], timeout=15)
             if stat:
                 return stat
-        except (subprocess.TimeoutExpired, OSError, FileNotFoundError) as exc:
-            logger.debug("govern._git_changes: git diff failed for %s: %s", spec.dispatch_id, exc)
 
-    # Fallback: no base_sha or git failed.
-    try:
-        result = subprocess.run(
-            ["git", "diff", "--stat", "HEAD~1..HEAD"],
-            capture_output=True,
-            text=True,
-            timeout=15,
-            cwd=cwd,
-        )
-        stat = result.stdout.strip()
+        # Fallback: no base_sha or the base_sha diff was empty.
+        stat = _run_worktree_git(spec, ["diff", "--stat", "HEAD~1..HEAD"], timeout=15)
         if stat:
             return f"(no base_sha; showing HEAD~1..HEAD)\n\n{stat}"
-    except (subprocess.TimeoutExpired, OSError, FileNotFoundError):
-        pass
+    except _NoWorktreeError:
+        return (
+            "Diff unavailable: lane produced no worker report and no worktree "
+            "was provisioned for this dispatch."
+        )
 
     return "No git diff available — worktree path or base SHA not provided."

--- a/tests/test_dispatch_govern.py
+++ b/tests/test_dispatch_govern.py
@@ -23,6 +23,8 @@ from dispatch_govern import (
     ensure_receipt,
     govern,
     _synthesize,
+    _git_changes,
+    _git_summary,
 )
 from report_body_contract import validate_body
 
@@ -1298,3 +1300,143 @@ print("OK")
         f"stdout: {result.stdout!r}\nstderr: {result.stderr!r}"
     )
     assert "OK" in result.stdout, f"Expected OK, got: {result.stdout!r}"
+
+
+# ---------------------------------------------------------------------------
+# OI-1008: a failed dispatch (no worktree yet) must never git-inspect the
+# dispatcher's own checkout and claim another dispatch's commit/diff as its own.
+# ---------------------------------------------------------------------------
+
+def test_git_changes_with_worktree_calls_subprocess_scoped_to_cwd(tmp_data, tmp_state):
+    """Positive control: proves patching dispatch_govern.subprocess.run actually
+    intercepts the call _git_changes makes, so the negative (no-worktree) test
+    below can trust assert_not_called() instead of it passing vacuously because
+    the patch target missed the real call site."""
+    worktree = tmp_data / "worktree"
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=worktree, base_sha="deadbeef")
+
+    fake = subprocess.CompletedProcess(["git"], 0, stdout="foo.py | 2 ++\n", stderr="")
+    with patch("dispatch_govern.subprocess.run", return_value=fake) as mock_run:
+        result = _git_changes(spec)
+
+    assert mock_run.called, "patch on dispatch_govern.subprocess.run did not intercept _git_changes' call"
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("cwd") == str(worktree)
+    assert result == "foo.py | 2 ++"
+
+
+def test_git_changes_no_worktree_never_calls_subprocess(tmp_data, tmp_state):
+    """RED before the fix: with worktree_path=None, _git_changes must not shell
+    out to git at all. A git call with no explicit cwd inherits the dispatcher
+    process's own working directory (the main checkout) — which is exactly how
+    a failed dispatch's synthesized report ended up carrying another dispatch's
+    diff (OI-1008)."""
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=None, base_sha="deadbeef")
+
+    with patch("dispatch_govern.subprocess.run") as mock_run:
+        result = _git_changes(spec)
+        mock_run.assert_not_called()
+
+    assert "no worktree was provisioned" in result
+    assert "|" not in result  # no leaked `git diff --stat` style content
+
+
+def test_git_summary_with_worktree_calls_subprocess_scoped_to_cwd(tmp_data, tmp_state):
+    """Positive control for _git_summary — see test_git_changes_with_worktree_... above."""
+    worktree = tmp_data / "worktree"
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=worktree)
+
+    fake = subprocess.CompletedProcess(["git"], 0, stdout="feat: add foo\n", stderr="")
+    with patch("dispatch_govern.subprocess.run", return_value=fake) as mock_run:
+        result = _git_summary(spec, status="done")
+
+    assert mock_run.called, "patch on dispatch_govern.subprocess.run did not intercept _git_summary's call"
+    _, kwargs = mock_run.call_args
+    assert kwargs.get("cwd") == str(worktree)
+    assert "feat: add foo" in result
+
+
+def test_git_summary_no_worktree_never_calls_subprocess(tmp_data, tmp_state):
+    """RED before the fix: with worktree_path=None, _git_summary must not shell
+    out to git either — it must fall back to the same "no commit on branch"
+    text already used when a worktree exists but git has no commit yet, not a
+    commit message read out of the dispatcher's own (main) checkout."""
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=None)
+
+    with patch("dispatch_govern.subprocess.run") as mock_run:
+        result = _git_summary(spec, status="failed")
+        mock_run.assert_not_called()
+
+    assert "No commit on branch" in result
+    assert "worker emitted status=failed" in result
+
+
+def test_synthesize_no_worktree_report_has_no_foreign_diff_or_commit(tmp_data, tmp_state):
+    """Integration reproduction of the exact OI-1008 symptom: mission-control's
+    D-a239cfec.md carried PR 763's diff (scripts/cron/leads_pipe.py,
+    src/linkedin_engine/claude_cli.py) from an unrelated, earlier dispatch.
+    Even if git WOULD return that foreign content when run without an explicit
+    cwd, the guard must stop the call before it ever reaches subprocess — so
+    the fake below returning foreign content proves the guard is what's
+    keeping it out, not mere absence of test data."""
+    spec = _make_spec(tmp_data, tmp_state, worktree_path=None, base_sha="deadbeef")
+    raw = _make_raw(receipt={"status": "failed"})
+
+    foreign_diff = "scripts/cron/leads_pipe.py | 20 ++++\nsrc/linkedin_engine/claude_cli.py | 15 ++"
+    foreign_commit = "feat(leads): unrelated PR from a different dispatch entirely"
+
+    def _fake_run(args, **kwargs):
+        if "log" in args:
+            return subprocess.CompletedProcess(args, 0, stdout=foreign_commit, stderr="")
+        return subprocess.CompletedProcess(args, 0, stdout=foreign_diff, stderr="")
+
+    with patch("dispatch_govern.subprocess.run", side_effect=_fake_run) as mock_run:
+        body = _synthesize(spec, raw)
+
+    mock_run.assert_not_called()
+    assert foreign_diff not in body
+    assert foreign_commit not in body
+    assert "leads_pipe.py" not in body
+    assert "claude_cli.py" not in body
+
+
+def test_git_summary_and_changes_with_real_worktree_unchanged(tmp_path):
+    """The normal path — worktree_path set — must be unchanged by the OI-1008
+    guard. Uses a real git repo (not mocks) so a regression in the refactored
+    call site (wrong cwd, dropped args) shows up as a real failure."""
+    repo = tmp_path / "worktree"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=repo, check=True)
+    subprocess.run(["git", "config", "user.name", "Test"], cwd=repo, check=True)
+    (repo / "foo.py").write_text("print('hi')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: add foo"], cwd=repo, check=True)
+
+    spec = GovernSpec(
+        dispatch_id="real-worktree-001",
+        terminal_id="T1",
+        instruction="Do the thing.",
+        data_dir=tmp_path / "data",
+        state_dir=tmp_path / "state",
+        worktree_path=repo,
+        model="sonnet",
+    )
+
+    summary = _git_summary(spec, status="done")
+    assert "feat: add foo" in summary
+    assert "Worker status: done" in summary
+
+    # No base_sha and only one commit -> honest "no diff" fallback, not an
+    # error and not a foreign diff.
+    changes = _git_changes(spec)
+    assert "No git diff available" in changes
+
+    # A second commit makes the HEAD~1..HEAD fallback produce a real stat.
+    (repo / "foo.py").write_text("print('hi again')\n", encoding="utf-8")
+    subprocess.run(["git", "add", "foo.py"], cwd=repo, check=True)
+    subprocess.run(["git", "commit", "-q", "-m", "feat: tweak foo"], cwd=repo, check=True)
+
+    changes2 = _git_changes(spec)
+    assert "foo.py" in changes2
+    assert "(no base_sha; showing HEAD~1..HEAD)" in changes2


### PR DESCRIPTION
## Summary
Closes OI-1008. A dispatch that fails **before** a worktree is provisioned (`spec.worktree_path is None`) had `_git_summary` and `_git_changes` in `scripts/lib/dispatch_govern.py` shell out to git with `cwd=None`. Git with no explicit cwd inherits the dispatcher process's own working directory — the main checkout — so the synthesized report picked up the last commit message and the last-merged PR's diff and presented it as this dispatch's own work. Observed in production: mission-control's `unified_reports/D-a239cfec.md` (a failed dispatch) carried PR 763's diff (`scripts/cron/leads_pipe.py`, `src/linkedin_engine/claude_cli.py`) from an unrelated dispatch two hours earlier.

The open item named only `_git_changes`; `_git_summary` has the identical bug and is arguably worse, since it stamps a foreign commit message as the report's `## Summary` heading.

## Changes
- `scripts/lib/dispatch_govern.py`:
  - Added `_run_worktree_git(spec, args, timeout)` — the single choke point for every git invocation in this module. Raises `_NoWorktreeError` when `spec.worktree_path` is unset instead of running git with an implicit cwd.
  - `_git_summary` now falls back to the existing "No commit on branch" message when there's no worktree (reuses the pre-existing fallback text, no new message needed).
  - `_git_changes` now returns a new explicit message ("Diff unavailable: lane produced no worker report and no worktree was provisioned for this dispatch.") when there's no worktree, instead of falling through to a `HEAD~1..HEAD` diff run in the main checkout.
  - Verified only one `subprocess.run` call site remains in the module (inside the new helper) — no other git invocations needed rerouting.

## Verification
- `python3 -m pytest tests/test_dispatch_govern.py -v` → **68 passed** (5 new tests added for this fix).
- New tests, RED-demonstrated against pre-fix code (`git stash` the source fix, keep tests, rerun):
  - `test_git_changes_no_worktree_never_calls_subprocess` — RED before fix (`git.run` called once with `cwd=None`), green after.
  - `test_git_summary_no_worktree_never_calls_subprocess` — RED before fix, green after.
  - `test_synthesize_no_worktree_report_has_no_foreign_diff_or_commit` — integration reproduction of the exact OI-1008 symptom (fake `subprocess.run` returns foreign diff/commit content if the guard is bypassed); RED before fix (2 calls made, foreign content would leak), green after.
  - `test_git_changes_with_worktree_calls_subprocess_scoped_to_cwd` / `test_git_summary_with_worktree_calls_subprocess_scoped_to_cwd` — positive controls proving the `dispatch_govern.subprocess.run` patch target actually intercepts the real call site, so the `assert_not_called()` in the negative tests isn't vacuous.
  - `test_git_summary_and_changes_with_real_worktree_unchanged` — real git repo (no mocks), proves the normal worktree-present path is behaviorally unchanged.
- `python3 -m pytest tests/test_tmux_interactive_dispatch.py -q` → **195 passed** (these mock `_git_summary`/`_git_changes` at the boundary, unaffected by the internal refactor).
- `python3 -c "import ast; ast.parse(open('scripts/lib/dispatch_govern.py').read())"` → OK.

## Test plan
- [x] Regression tests RED against pre-fix code, GREEN after
- [x] Full `test_dispatch_govern.py` suite green (68 passed)
- [x] `test_tmux_interactive_dispatch.py` suite green (195 passed)
- [x] Confirmed no other unguarded `subprocess.run(["git", ...])` call sites in the module

Dispatch-ID: 20260804-071945-prc-no-foreign-diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)