### PR TITLE
fix(tests): make dry-run envelope mock live on the consumer (OI-968)

### DIFF
--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,21 +2,14 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 186,
-      "mechanism": "patch-string",
-      "module_target": "dispatch_envelope",
-      "symbol": "run_envelope_plan"
-    },
-    {
-      "file": "tests/test_dispatch_cli.py",
-      "line": 753,
+      "line": 758,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 756,
+      "line": 761,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -21,6 +21,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
+import dispatch_cli
 from dispatch_cli import (
     _check_track_link_verdict,
     _DEFAULT_MODEL_PINS,
@@ -183,10 +184,14 @@ def _make_minimal_plan(
 # ---------------------------------------------------------------------------
 
 @patch("dispatch_cli.build_runtime_snapshot")
-@patch("dispatch_envelope.run_envelope_plan")
+@patch("dispatch_cli.run_envelope_plan")
 @patch("tmux_interactive_dispatch.TmuxInteractiveDispatch.dispatch")
 def test_dry_run_prints_plan_no_spawn(mock_tmux, mock_envelope, mock_snapshot, tmp_path, capsys):
     """--dry-run prints plan + fingerprint and calls NO executor."""
+    # OI-968: the envelope mock must replace dispatch_cli's bound reference.
+    # dispatch_cli.py does `from dispatch_envelope import run_envelope_plan`, so
+    # patching the source module leaves the consumer pointing at the original.
+    assert dispatch_cli.run_envelope_plan is mock_envelope
     mock_snapshot.return_value = _clean_snapshot()
     spec_file = _make_spec_file(tmp_path, provider="claude")
 


### PR DESCRIPTION
## Summary
Closes OI-968. `test_dry_run_prints_plan_no_spawn` patched `dispatch_envelope.run_envelope_plan`, but `scripts/lib/dispatch_cli.py:52` does `from dispatch_envelope import run_envelope_plan` at module level. A from-import binds the name in the consumer namespace at import time, so patching the source module leaves `dispatch_cli.run_envelope_plan` pointing at the original function. The mock was dead: `assert_not_called()` still passed because `--dry-run` never reaches the envelope, so the dead mock was undetectable through the existing assertion.

The fix retargets the patch to `dispatch_cli.run_envelope_plan` (the consumer namespace) — the same correct form the file already uses at lines 290 and 2565 — and adds a guard assertion that `dispatch_cli.run_envelope_plan is mock_envelope`, so a revert to the source-module target fails loudly.

## Changes
- `tests/test_dispatch_cli.py`:
  - `@patch("dispatch_envelope.run_envelope_plan")` → `@patch("dispatch_cli.run_envelope_plan")` in `test_dry_run_prints_plan_no_spawn`.
  - Added `import dispatch_cli` so the test can assert the consumer reference.
  - Added regression assertion `assert dispatch_cli.run_envelope_plan is mock_envelope`.

## Verification
- RED demonstration against pre-fix code (old dead target + new assertion): `1 failed` — `AssertionError: assert <function run_envelope_plan ...> is <MagicMock ...>`, showing the consumer still held the original function.
- After fix: `test_dry_run_prints_plan_no_spawn` → `1 passed`.
- `python3 -m pytest tests/test_dispatch_cli.py -q` → **120 passed**.
- `python3 -m pytest tests/test_dispatch_cli.py tests/test_final_prompt_integrity.py tests/test_failclass_registry.py -q` → **176 passed**.

## Test plan
- [x] Regression assertion RED against pre-fix code, GREEN after
- [x] Full `test_dispatch_cli.py` suite green (120 passed)
- [x] Envelope-adjacent suites green (176 passed)
- [x] Grep confirms no other `@patch("dispatch_envelope.run_envelope_plan")` targets in `tests/` or `scripts/`