### PR TITLE
fix(govern): validate role/terminal_id slugs against path traversal in _candidate_sources (OI-932)

### DIFF
--- a/scripts/lib/role_application.py
+++ b/scripts/lib/role_application.py
@@ -103,15 +103,41 @@ def _normalize_ws(text: str) -> str:
     return _WS_RE.sub(" ", text).strip()
 
 
+def _validate_slug(name: str, context: str) -> None:
+    """Raise ValueError if *name* contains '..' or path separators.
+
+    Path traversal via ``role`` or ``terminal_id`` slugs would let a dispatch
+    escape the intended directory trees (agents/, .claude/skills/,
+    prompt_assembler prompts, .claude/terminals/) and read arbitrary files.
+    This guard rejects such slugs before any path is constructed (OI-932).
+    """
+    if not name or not name.strip():
+        raise ValueError(f"{context} must not be empty")
+    stripped = name.strip()
+    if ".." in stripped:
+        raise ValueError(
+            f"{context} contains path traversal '..': {stripped!r}"
+        )
+    if "/" in stripped or "\\" in stripped:
+        raise ValueError(
+            f"{context} contains path separator: {stripped!r}"
+        )
+
+
 def _candidate_sources(terminal_id: str, role: str, project_root: Path):
-    """Yield (tier, path) candidates in the injector's resolution precedence."""
+    """Yield (tier, path) candidates in the injector's resolution precedence.
+
+    Slugs are validated against path traversal before path construction (OI-932).
+    """
     _prompts_dir = Path(__file__).resolve().parent / "prompts" / "roles"
     if role:
+        _validate_slug(role, "role")
         yield TIER_PROMPT_ASSEMBLER, _prompts_dir / f"{role}.md"
     if role:
         yield TIER_AGENTS, project_root / "agents" / role / "CLAUDE.md"
     if role:
         yield TIER_SKILLS, project_root / ".claude" / "skills" / role / "CLAUDE.md"
+    _validate_slug(terminal_id, "terminal_id")
     yield TIER_TERMINAL, project_root / ".claude" / "terminals" / terminal_id / "CLAUDE.md"
 
 

--- a/tests/test_role_applied_provider_lane.py
+++ b/tests/test_role_applied_provider_lane.py
@@ -44,7 +44,7 @@ import dispatch_envelope
 import provider_dispatch
 import skill_context
 from dispatch_envelope import EnvelopeSpec, _AdapterResult
-from role_application import verify_role_applied
+from role_application import _validate_slug, verify_role_applied
 
 REPO_ROOT = Path(__file__).resolve().parent.parent
 
@@ -306,3 +306,112 @@ def test_role_applied_true_when_resolved_source_present():
     assert verdict.role_applied is True
     assert verdict.tier == "agents"
     assert verdict.reason is None
+
+
+# ---------------------------------------------------------------------------
+# 7. path-traversal hardening (OI-932): role/terminal_id slugs must not contain
+#    '..' or path separators that would escape the intended directory trees
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_sources_rejects_path_traversal_in_role():
+    """role='../../.claude/terminals/T0' must NOT resolve to a file outside
+    agents/ / .claude/skills/ / prompts/roles/.
+
+    RED on current (unpatched) code: _candidate_sources pastes the raw role
+    string into Path components, so the '..' segments escape the intended
+    directories and a CLAUDE.md outside the role tree can be read.
+    """
+    verdict = verify_role_applied(
+        "some prompt body content that does not match anything",
+        "T1",
+        "../../.claude/terminals/T0",
+    )
+    assert verdict.role_applied is False
+    assert verdict.tier == "none", (
+        f"expected tier='none' (validation rejected the slug before tier resolution), "
+        f"got tier='{verdict.tier}'"
+    )
+    assert verdict.reason is not None
+    # The reason must mention the validation failure, not a "resolved" tier.
+    assert "path" in verdict.reason.lower() or "slug" in verdict.reason.lower() or (
+        "invalid" in verdict.reason.lower()
+    ), f"reason must mention path/slug validation, got: {verdict.reason}"
+
+
+def test_candidate_sources_rejects_path_traversal_in_terminal_id():
+    """terminal_id='../../agents/quality-engineer' must NOT resolve to a file
+    outside .claude/terminals/.
+
+    RED on current (unpatched) code: the terminal tier escapes into agents/.
+    """
+    verdict = verify_role_applied(
+        "some prompt body content that does not match anything",
+        "../../agents/quality-engineer",
+        "nonexistent-role-xyz",
+    )
+    assert verdict.role_applied is False
+    assert verdict.tier == "none", (
+        f"expected tier='none' (validation rejected the slug before tier resolution), "
+        f"got tier='{verdict.tier}'"
+    )
+    assert verdict.reason is not None
+    assert "path" in verdict.reason.lower() or "slug" in verdict.reason.lower() or (
+        "invalid" in verdict.reason.lower()
+    ), f"reason must mention path/slug validation, got: {verdict.reason}"
+
+
+def test_candidate_sources_accepts_valid_slugs():
+    """Valid role/terminal_id slugs (no '..', no path separators) must still work
+    and resolve normally — the validation must not reject legitimate values."""
+    agents_body = (REPO_ROOT / "agents" / "quality-engineer" / "CLAUDE.md").read_text()
+    final_prompt = f"{agents_body}\n\n---\n\nimplement the change"
+
+    verdict = verify_role_applied(final_prompt, "T1", "quality-engineer")
+
+    assert verdict.role_applied is True
+    assert verdict.tier == "agents"
+    assert verdict.reason is None
+
+
+# ---------------------------------------------------------------------------
+# 8. _validate_slug unit tests — direct edge-case coverage
+# ---------------------------------------------------------------------------
+
+
+class TestValidateSlug:
+    """Direct unit tests for the slug validation guard (OI-932)."""
+
+    def test_accepts_hyphenated_role(self):
+        _validate_slug("quality-engineer", "role")  # must not raise
+
+    def test_accepts_terminal_id(self):
+        _validate_slug("T1", "terminal_id")  # must not raise
+
+    def test_accepts_dotted_slug(self):
+        _validate_slug("backend.developer", "role")  # must not raise
+
+    def test_rejects_dot_dot(self):
+        import pytest
+        with pytest.raises(ValueError, match="path traversal"):
+            _validate_slug("../../.claude/terminals/T0", "role")
+
+    def test_rejects_forward_slash(self):
+        import pytest
+        with pytest.raises(ValueError, match="path separator"):
+            _validate_slug("agents/quality-engineer", "role")
+
+    def test_rejects_backslash(self):
+        import pytest
+        with pytest.raises(ValueError, match="path separator"):
+            _validate_slug("agents\\quality-engineer", "role")
+
+    def test_rejects_empty(self):
+        import pytest
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_slug("", "role")
+
+    def test_rejects_whitespace_only(self):
+        import pytest
+        with pytest.raises(ValueError, match="must not be empty"):
+            _validate_slug("   ", "role")


### PR DESCRIPTION
## OI-932 — Path traversal hardening in role_application._candidate_sources

`_candidate_sources` previously interpolated unvalidated `role` and `terminal_id` strings directly into Path components. A role value like `../../.claude/terminals/T0` escaped the `agents/` / `.claude/skills/` trees and resolved to an arbitrary CLAUDE.md outside the intended directories. A malicious `terminal_id` could likewise escape `.claude/terminals/`.

### Fix

Add `_validate_slug()` guard that rejects slugs containing `..` (path traversal) or `/` / `\` (path separators) before any Path is constructed. The guard runs in `_candidate_sources` on every `role` (when non-empty) and `terminal_id`. Invalid slugs raise `ValueError`, which `verify_role_applied`'s existing try/except catches and degrades to `role_applied=False` with `tier='none'` — verification must never break a dispatch.

### Tests

- 11 new tests (3 integration + 8 unit) cover traversal rejection and valid-slug acceptance
- Full existing suite (9 tests) passes unchanged: 20 passed, 0 failed

### Threat model

No live exploit path: role/terminal_id values come from the T0-staged dispatch spec, not from untrusted input. This is defense-in-depth hardening against future exposure to less-trusted dispatch inputs.

### Dispatch-ID

20260804-m10-oi932

🤖 Generated with [Claude Code](https://claude.com/claude-code)