### PR TITLE
fix(gate): remove TEMP dispatch_cli size allowlist (OI-937)

### DIFF
--- a/scripts/lib/quality_advisory.py
+++ b/scripts/lib/quality_advisory.py
@@ -55,7 +55,6 @@ FILE_SIZE_ALLOWLIST: Dict[str, str] = {
     "scripts/smart_tap_json_translator": "grandfathered shell monolith; smart-tap translator",
     "dashboard/api_intelligence": "grandfathered monolith; dashboard intelligence API",
     "dashboard/api_operator": "grandfathered monolith; dashboard operator API",
-    "scripts/lib/dispatch_cli": "TEMP allowlist — mid-refactor naar submodules, zie OI-937 (slot-PR van de extractie-reeks verwijdert deze regel weer)",
 }
 
 

--- a/tests/test_quality_advisory_pipeline.py
+++ b/tests/test_quality_advisory_pipeline.py
@@ -13,6 +13,7 @@ sys.path.insert(0, str(SCRIPT_DIR))
 
 import quality_advisory as quality_advisory_module
 from quality_advisory import (
+    FILE_SIZE_ALLOWLIST,
     QualityCheck,
     build_whole_repo_file_size_backlog,
     check_file_size,
@@ -522,6 +523,32 @@ class TestWholeRepoFileSizeBacklog:
 
         backlog = build_whole_repo_file_size_backlog(tmp_path)
         assert backlog["total_backlog"] == 0
+
+
+class TestDispatchCliAllowlistRemoval:
+    """OI-937 regression: the TEMP FILE_SIZE_ALLOWLIST entry for scripts/lib/dispatch_cli
+    must be gone. PR 0 of the dispatch_cli extraction series (never landed) added it as a
+    short-lived exemption for the 1200-line hard ceiling. Keeping it in place silently
+    grandfathers a 1500+ line monolith and defeats the size gate."""
+
+    def test_temp_allowlist_key_for_dispatch_cli_removed(self):
+        assert "scripts/lib/dispatch_cli" not in FILE_SIZE_ALLOWLIST, (
+            "TEMP allowlist entry for scripts/lib/dispatch_cli still present (OI-937)"
+        )
+
+    def test_dispatch_cli_no_longer_grandfathered_by_size_gate(self):
+        """check_file_size on the real dispatch_cli.py must not return the advisory
+        'grandfathered' finding. It is either a hard block (still over the 1200 ceiling,
+        the honest state) or a warning/no finding if the monolith was eventually split."""
+        dispatch_cli = SCRIPT_DIR / "lib" / "dispatch_cli.py"
+        assert dispatch_cli.exists(), f"test fixture path missing: {dispatch_cli}"
+
+        checks = check_file_size(dispatch_cli)
+
+        grandfathered = [c for c in checks if c.check_id == "file_size_grandfathered"]
+        assert grandfathered == [], (
+            f"dispatch_cli.py still allowlisted by the size gate: {grandfathered}"
+        )
 
 
 class TestTerminalSnapshot:


### PR DESCRIPTION
## Summary

Removes the TEMP FILE_SIZE_ALLOWLIST entry for `scripts/lib/dispatch_cli` from `scripts/lib/quality_advisory.py`, per OI-937. The entry was added by PR #1332 (PR 0 of the dispatch_cli extraction series) to unblock that series against the 1200-line hard ceiling. The series never landed: `scripts/lib/dispatch_cli.py` is still a 1577-line monolith (measured 2026-08-04), so the TEMP entry was silently grandfathering it and defeating the size gate.

After this change `dispatch_cli.py` is surfaced honestly as a `file_size_blocking` finding in the diff-scoped gate and as a `blocking` entry in the whole-repo advisory backlog until the monolith is actually split under the 1200 ceiling.

## Changes

- `scripts/lib/quality_advisory.py`: delete the `scripts/lib/dispatch_cli` TEMP allowlist entry.
- `tests/test_quality_advisory_pipeline.py`: add `TestDispatchCliAllowlistRemoval` (OI-937 regression) asserting the allowlist key is gone and `check_file_size` no longer returns `file_size_grandfathered` for the real file.

## Verification

- New regression tests run RED against unchanged code (both fail, showing the TEMP entry still grandfathering dispatch_cli), GREEN after the fix.
- `pytest tests/test_quality_advisory_pipeline.py` → 43 passed.
- `pytest tests/test_code_quality_scanner_excludes.py tests/test_reclassify_size_ois.py` → 20 passed.
- `python3 scripts/quality_advisory_scan.py` smoke test: `dispatch_cli` now `blocking` in the backlog (advisory, always exit 0).
- 5 failures in `test_receipt_instruction_hash.py` / `test_schema_init_view_ordering.py` verified pre-existing on clean base (identical with changes stashed), unrelated to this change.
- `ruff` findings on both files are pre-existing (identical on clean base); zero new lint findings.

## Open Items

- Pre-existing lint debt in `scripts/lib/quality_advisory.py` (F841 unused `start_line`) and `tests/test_quality_advisory_pipeline.py` (F401 unused `tempfile`, E402 import ordering) — out of scope for OI-937.
- `scripts/lib/dispatch_cli.py` remains a 1577-line monolith and is now a blocking size-gate finding; the dispatch_cli extraction tracked by the original series is still open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)