### PR TITLE
fix(autoclose): treat indeterminate age and malformed counts as degraded (OI-928)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -1921,9 +1921,12 @@ def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, 
     verify (unverified > 0 with nominated_not_closed > 0 — this is the stuck
     backlog, distinct from guard-declined closes like stale_candidate which
     keep nominated_not_closed > 0 on healthy runs), OR the last run is older
-    than _AUTOCLOSE_STALE_HOURS. A missing summary is itself a degraded signal:
-    it means the auto-close reconciler has never written a summary, and the
-    block is still emitted rather than omitted.
+    than _AUTOCLOSE_STALE_HOURS, OR the last-run age cannot be determined
+    (missing or unparseable finished_at), OR the counts block is malformed
+    (non-numeric values or wrong type in an otherwise valid JSON). A missing
+    summary is itself a degraded signal: it means the auto-close reconciler
+    has never written a summary, and the block is still emitted rather than
+    omitted.
     """
     now = now or datetime.now(timezone.utc)
     summary_path = store / _RECONCILE_SUMMARY_FILENAME
@@ -1940,11 +1943,6 @@ def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, 
         }
 
     gh_health = (summary.get("evidence_source_health") or {}).get("gh")
-    counts = summary.get("counts") or {}
-    nominated = int(counts.get("nominated", 0) or 0)
-    closed = int(counts.get("closed", 0) or 0)
-    unverified = int(counts.get("unverified", 0) or 0)
-    nominated_not_closed = nominated - closed
 
     finished_raw = summary.get("finished_at")
     finished_dt = _parse_reconcile_timestamp(finished_raw)
@@ -1953,9 +1951,27 @@ def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, 
     else:
         age_hours = None
 
+    try:
+        counts = summary.get("counts") or {}
+        nominated = int(counts.get("nominated", 0) or 0)
+        closed = int(counts.get("closed", 0) or 0)
+        unverified = int(counts.get("unverified", 0) or 0)
+    except (ValueError, TypeError, AttributeError):
+        return {
+            "last_reconcile_at": finished_raw or None,
+            "last_reconcile_age_hours": age_hours,
+            "gh_health": gh_health,
+            "nominated_not_closed": None,
+            "autoclose_degraded": True,
+            "autoclose_reason": "malformed_counts",
+        }
+
+    nominated_not_closed = nominated - closed
+
     gh_bad = gh_health != "ok"
     stuck = unverified > 0 and nominated_not_closed > 0
     stale = age_hours is not None and age_hours > _AUTOCLOSE_STALE_HOURS
+    indeterminate_age = age_hours is None
 
     if gh_bad:
         reason = "gh_absent" if gh_health == "absent" else f"gh_{gh_health or 'unknown'}"
@@ -1963,6 +1979,8 @@ def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, 
         reason = "nominated_not_closed"
     elif stale:
         reason = "stale"
+    elif indeterminate_age:
+        reason = "indeterminate_age"
     else:
         reason = "ok"
 
@@ -1971,7 +1989,7 @@ def _autoclose_health(store: Path, now: Optional[datetime] = None) -> Dict[str, 
         "last_reconcile_age_hours": age_hours,
         "gh_health": gh_health,
         "nominated_not_closed": nominated_not_closed,
-        "autoclose_degraded": gh_bad or stuck or stale,
+        "autoclose_degraded": gh_bad or stuck or stale or indeterminate_age,
         "autoclose_reason": reason,
     }
 

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -300,6 +300,78 @@ def test_autoclose_degraded_true_when_last_run_stale(tmp_path):
     assert health["autoclose_reason"] == "stale"
 
 
+def test_autoclose_degraded_when_finished_at_indeterminate(tmp_path):
+    """Missing or unparseable finished_at → degraded with reason=indeterminate_age.
+
+    Red on old code: age_hours=None → stale=False, and with gh=ok and no stuck
+    backlog the probe returned autoclose_degraded=False, reason=ok — falsely
+    healthy when the last-run age cannot be determined.
+    """
+    now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+
+    # Unparseable finished_at (present but not valid ISO).
+    state_dir = tmp_path / "unparseable"
+    state_dir.mkdir(parents=True)
+    (state_dir / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "not-a-valid-iso-timestamp",
+        "evidence_source_health": {"gh": "ok"},
+        "counts": {"nominated": 0, "closed": 0, "unverified": 0},
+    }), encoding="utf-8")
+    health = bts._autoclose_health(state_dir, now=now)
+    assert health["autoclose_degraded"] is True
+    assert health["autoclose_reason"] == "indeterminate_age"
+    assert health["last_reconcile_age_hours"] is None
+
+    # Missing finished_at entirely.
+    state_dir2 = tmp_path / "missing_ts"
+    state_dir2.mkdir(parents=True)
+    (state_dir2 / "reconcile_summary.json").write_text(json.dumps({
+        "evidence_source_health": {"gh": "ok"},
+        "counts": {"nominated": 0, "closed": 0, "unverified": 0},
+    }), encoding="utf-8")
+    health2 = bts._autoclose_health(state_dir2, now=now)
+    assert health2["autoclose_degraded"] is True
+    assert health2["autoclose_reason"] == "indeterminate_age"
+    assert health2["last_reconcile_age_hours"] is None
+
+
+def test_autoclose_degraded_when_counts_malformed(tmp_path):
+    """Non-numeric counts in a valid JSON → degraded with reason=malformed_counts.
+
+    Red on old code: int('not-a-number') raised ValueError outside the try/except
+    that only guards json.loads.  A list counts block raised AttributeError.
+    """
+    now = datetime(2026, 8, 4, 10, 0, tzinfo=timezone.utc)
+
+    # Non-numeric string value inside counts.
+    state_dir = tmp_path / "bad_string"
+    state_dir.mkdir(parents=True)
+    (state_dir / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "2026-08-04T08:00:00Z",
+        "evidence_source_health": {"gh": "ok"},
+        "counts": {"nominated": "not-a-number", "closed": 0, "unverified": 0},
+    }), encoding="utf-8")
+    health = bts._autoclose_health(state_dir, now=now)
+    assert health["autoclose_degraded"] is True
+    assert health["autoclose_reason"] == "malformed_counts"
+    assert health["nominated_not_closed"] is None
+    # Timestamp info should still be propagated even when counts are malformed.
+    assert health["last_reconcile_at"] == "2026-08-04T08:00:00Z"
+    assert health["last_reconcile_age_hours"] == 2.0
+
+    # Counts is a list instead of a dict.
+    state_dir2 = tmp_path / "bad_list"
+    state_dir2.mkdir(parents=True)
+    (state_dir2 / "reconcile_summary.json").write_text(json.dumps({
+        "finished_at": "2026-08-04T08:00:00Z",
+        "evidence_source_health": {"gh": "ok"},
+        "counts": [1, 2, 3],
+    }), encoding="utf-8")
+    health2 = bts._autoclose_health(state_dir2, now=now)
+    assert health2["autoclose_degraded"] is True
+    assert health2["autoclose_reason"] == "malformed_counts"
+
+
 # ---------------------------------------------------------------------------
 # SessionStart hook command (F5: a quoting bug here breaks every session start)
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Fixes OI-928: two advisory findings from the codex gate on PR #1314 where `_autoclose_health` could report false-positive healthy state.

### Finding 1 — Indeterminate age = false healthy

When `finished_at` is missing or unparseable, `age_hours` stays `None`. The stale check `age_hours is not None and age_hours > _AUTOCLOSE_STALE_HOURS` evaluates to `False`. With `gh_health=ok` and no stuck backlog, the probe returned `autoclose_degraded=False, reason=ok` — falsely healthy when the last-run age cannot be determined.

**Fix:** `age_hours is None` is now a degraded signal with reason `indeterminate_age`.

### Finding 2 — Malformed counts throws

`int(counts.get("nominated", 0) or 0)` and siblings assume counts values are numeric. A syntactically valid but semantically malformed `reconcile_summary.json` (e.g., `"nominated": "not-a-number"` or `"counts": [1,2,3]`) raised `ValueError` / `AttributeError` outside the try/except block.

**Fix:** counts parsing is wrapped in `try/except (ValueError, TypeError, AttributeError)`, returning `autoclose_degraded=True, reason=malformed_counts` with timestamp info preserved.

## Tests

Two new tests in `tests/test_build_t0_state_freshness.py`:
- `test_autoclose_degraded_when_finished_at_indeterminate` — covers unparseable and missing `finished_at`
- `test_autoclose_degraded_when_counts_malformed` — covers non-numeric string and list-type counts blocks

Full suite: 12/12 freshness tests pass, 57/57 objective_reconcile tests pass.

## Why

A health probe that can only say yes is not a measurement (OI-893).

Dispatch-ID: 20260804-m08-oi928

🤖 Generated with [Claude Code](https://claude.com/claude-code)