### PR TITLE
fix(govern): emit ADR-005 ledger event on role backfill UPDATE (OI-930)

### DIFF
--- a/scripts/lib/intelligence_backfill.py
+++ b/scripts/lib/intelligence_backfill.py
@@ -17,6 +17,7 @@ Usage:
 from __future__ import annotations
 
 import argparse
+import datetime as dt
 import json
 import logging
 import os
@@ -24,7 +25,7 @@ import re
 import sqlite3
 import sys
 from pathlib import Path
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 _SCRIPTS_LIB = Path(__file__).resolve().parent
 if str(_SCRIPTS_LIB) not in sys.path:
@@ -154,11 +155,32 @@ def _load_receipt_roles(receipts_file: Path) -> Dict[str, str]:
     return roles
 
 
+def _write_role_backfill_events(
+    events_file: Path, events: List[Dict[str, Any]]
+) -> None:
+    """Append role-backfill ledger events to *events_file* (ADR-005).
+
+    Best-effort: a write failure is logged but does not roll back the DB
+    commit — the DB is the authoritative record, matching the at-most-once
+    pattern of the open-item→track bridge (ADR-005 amendment 2026-06-14).
+    """
+    try:
+        with events_file.open("a", encoding="utf-8") as fh:
+            for ev in events:
+                fh.write(json.dumps(ev, ensure_ascii=False) + "\n")
+    except OSError as exc:
+        logger.warning(
+            "role backfill: failed to write %d events to %s: %s",
+            len(events), events_file, exc,
+        )
+
+
 def backfill_dispatch_metadata_roles(
     conn: sqlite3.Connection,
     receipts_file: Optional[Path],
     *,
     dry_run: bool = False,
+    events_file: Optional[Path] = None,
 ) -> Tuple[int, int]:
     """Backfill dispatch_metadata.role for rows with NULL/empty/fake role.
 
@@ -167,11 +189,15 @@ def backfill_dispatch_metadata_roles(
     resolver stamps ``identity_unresolved`` for them. Idempotent: once a real
     role is stamped the row no longer matches the selection.
 
+    When *events_file* is provided (and this is not a dry-run), each UPDATE
+    emits an ADR-005 ledger event recording old role, new role, and reason
+    so a reader can reconstruct the provenance of every role value.
+
     Returns (checked, updated) counts.
     """
     try:
         rows = conn.execute(
-            "SELECT id, dispatch_id FROM dispatch_metadata "
+            "SELECT id, dispatch_id, role FROM dispatch_metadata "
             "WHERE role IS NULL OR role = '' OR role = ?",
             (_FAKE_DEFAULT_ROLE,),
         ).fetchall()
@@ -182,16 +208,17 @@ def backfill_dispatch_metadata_roles(
     receipt_roles = _load_receipt_roles(receipts_file) if receipts_file else {}
     checked = len(rows)
     updated = 0
+    events: List[Dict[str, Any]] = []
 
-    for row_id, dispatch_id in rows:
-        role = receipt_roles.get(dispatch_id)
-        if not role:
+    for row_id, dispatch_id, old_role in rows:
+        new_role = receipt_roles.get(dispatch_id)
+        if not new_role:
             continue
         if not dry_run:
             try:
                 conn.execute(
                     "UPDATE dispatch_metadata SET role = ? WHERE id = ?",
-                    (role, row_id),
+                    (new_role, row_id),
                 )
             except sqlite3.Error as exc:
                 logger.warning(
@@ -199,6 +226,15 @@ def backfill_dispatch_metadata_roles(
                     row_id, exc,
                 )
                 continue
+            if events_file is not None:
+                events.append({
+                    "timestamp": dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z"),
+                    "event_type": "role_backfill",
+                    "dispatch_id": dispatch_id,
+                    "old_role": old_role,
+                    "new_role": new_role,
+                    "reason": "backfill from t0_receipts.ndjson",
+                })
         updated += 1
 
     if not dry_run and updated > 0:
@@ -206,6 +242,8 @@ def backfill_dispatch_metadata_roles(
             conn.commit()
         except sqlite3.Error as exc:
             logger.warning("backfill_dispatch_metadata_roles: commit failed: %s", exc)
+        if events:
+            _write_role_backfill_events(events_file, events)  # type: ignore[arg-type]
 
     return checked, updated
 
@@ -232,10 +270,12 @@ def run_backfill(db_path: Path, *, dry_run: bool = False) -> Dict[str, Dict[str,
         # Receipts live next to the DB in the state dir; absent file simply
         # yields zero updates (rows stay NULL -> identity_unresolved at emit).
         receipts_file = db_path.parent / "t0_receipts.ndjson"
+        events_file = db_path.parent / "role_backfill_events.ndjson"
         checked, updated = backfill_dispatch_metadata_roles(
             conn,
             receipts_file if receipts_file.exists() else None,
             dry_run=dry_run,
+            events_file=events_file if not dry_run else None,
         )
         results["dispatch_metadata.role"] = {"checked": checked, "updated": updated}
         logger.info(

--- a/tests/test_pr4_role_capture_backfill.py
+++ b/tests/test_pr4_role_capture_backfill.py
@@ -429,6 +429,97 @@ class TestIntelligenceBackfillRoles:
         assert results["dispatch_metadata.role"] == {"checked": 1, "updated": 1}
         assert _read_role(db, "pr4-bf-8") == "debugger"
 
+    # ------------------------------------------------------------------
+    # OI-930: role backfill must emit an ADR-005 ledger event per UPDATE
+    # ------------------------------------------------------------------
+
+    def test_backfill_emits_ledger_event_per_update(self, tmp_path):
+        """OI-930: each role backfill UPDATE must produce a ledger event with
+        old role, new role, and reason — so a reader can reconstruct provenance
+        of every role value in dispatch_metadata."""
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "oi930-null", None)
+        self._seed_role(db, "oi930-fake", "backend-developer")
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "oi930-null", "role": "system-architect"},
+            {"dispatch_id": "oi930-fake", "role": "quality-engineer"},
+        ])
+        events_file = tmp_path / "role_backfill_events.ndjson"
+
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(
+            conn, receipts, events_file=events_file,
+        )
+        conn.close()
+
+        assert checked == 2
+        assert updated == 2
+        # Events file must exist and contain one line per updated row.
+        assert events_file.exists(), (
+            "OI-930 FAIL: no role_backfill_events.ndjson written — "
+            "the backfill UPDATE mutates dispatch_metadata without an ADR-005 ledger event"
+        )
+        lines = events_file.read_text(encoding="utf-8").strip().splitlines()
+        assert len(lines) == 2
+
+        events = [json.loads(line) for line in lines]
+        by_did = {e["dispatch_id"]: e for e in events}
+
+        # NULL → system-architect
+        ev = by_did["oi930-null"]
+        assert ev["event_type"] == "role_backfill"
+        assert ev["old_role"] is None
+        assert ev["new_role"] == "system-architect"
+        assert "reason" in ev
+
+        # backend-developer (fake) → quality-engineer
+        ev = by_did["oi930-fake"]
+        assert ev["event_type"] == "role_backfill"
+        assert ev["old_role"] == "backend-developer"
+        assert ev["new_role"] == "quality-engineer"
+        assert "reason" in ev
+
+    def test_backfill_dry_run_writes_no_events(self, tmp_path):
+        """Dry-run must not emit ledger events (no actual mutation occurred)."""
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "oi930-dry", None)
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "oi930-dry", "role": "debugger"},
+        ])
+        events_file = tmp_path / "role_backfill_events.ndjson"
+
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(
+            conn, receipts, dry_run=True, events_file=events_file,
+        )
+        conn.close()
+
+        assert checked == 1
+        assert updated == 1
+        assert not events_file.exists(), "dry-run must not write ledger events"
+
+    def test_backfill_no_update_writes_no_events(self, tmp_path):
+        """When no rows are updated, no events file is created."""
+        db = tmp_path / "quality_intelligence.db"
+        _make_db(db)
+        self._seed_role(db, "oi930-real", "quality-engineer")  # already has real role
+        receipts = self._write_receipts(tmp_path, [
+            {"dispatch_id": "oi930-real", "role": "debugger"},
+        ])
+        events_file = tmp_path / "role_backfill_events.ndjson"
+
+        conn = sqlite3.connect(str(db))
+        checked, updated = backfill_dispatch_metadata_roles(
+            conn, receipts, events_file=events_file,
+        )
+        conn.close()
+
+        assert checked == 0
+        assert updated == 0
+        assert not events_file.exists(), "no updates → no events file"
+
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Closes OI-930: the role backfill from PR #1232 mutated `dispatch_metadata.role` via `UPDATE` without any ADR-005 ledger event, making it impossible to reconstruct provenance of each role value.

## Fix

Each role backfill UPDATE now emits a `role_backfill` ledger event to `role_backfill_events.ndjson` in the state directory, recording:
- `old_role` — the DB value before the update (NULL, empty, or fake default)
- `new_role` — the receipt-derived genuine role
- `reason` — `"backfill from t0_receipts.ndjson"`
- `timestamp` — UTC ISO timestamp

Events are written after DB commit (at-most-once, DB-authoritative), matching the ADR-005 amendment pattern from the open-item→track bridge.

## Changes

| File | Delta |
|---|---|
| `scripts/lib/intelligence_backfill.py` | +55/-6 — SELECT now includes `role` column, new `events_file` parameter, `_write_role_backfill_events()` helper, `run_backfill()` wires events_file for non-dry-run |
| `tests/test_pr4_role_capture_backfill.py` | +82/-0 — 3 new tests: event emission, dry-run writes nothing, no-update writes nothing |

## Verification

- **Before fix (RED):** 3 new tests fail with `TypeError` — old code has no `events_file` mechanism
- **After fix (GREEN):** 19/19 pass in `test_pr4_role_capture_backfill.py`
- **Related suites:** 71/71 in `test_backfill_dispatch_metadata` + `test_dispatch_metadata_resolver` + `test_dispatch_metadata_lock_timeout`, 85/85 in 6 other backfill suites — zero regressions
- **Total:** 175 tests pass

## Design notes

- Deterministic: event emission is a pure data-recording operation, no model call needed
- Backward-compatible: `events_file` defaults to `None`; callers that don't pass it get the old behavior
- Idempotent: events are only emitted when rows are actually updated; re-running on already-backfilled rows emits nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)