### PR TITLE
fix(cost): normalize model names before cost lookup so ledger-stored GLM variants resolve (OI-977)

### DIFF
--- a/scripts/lib/cost_loader.py
+++ b/scripts/lib/cost_loader.py
@@ -3,13 +3,24 @@
 Provides enrich_candidates() to fill in null cost_usd_per_call fields in
 routing_recommendations.yaml candidates. Single source of truth stays in
 wave7_models.yaml; this module reads it at call time so costs stay in sync.
+
+Model names are normalized via ``providers.model_normalizer`` before the cost
+lookup so that ledger-stored variants (e.g. ``openrouter/z-ai/glm-5.2``,
+``glm-5.2``) resolve to the same cost as the canonical registry key.
+Deprecated model variants (e.g. ``glm-4.5``, ``glm-5.1``) resolve to their
+successor's cost via the ``deprecated_models`` lists in wave7_models.yaml.
 """
 from __future__ import annotations
 
+import logging
 from pathlib import Path
 from typing import Optional
 
 import yaml
+
+from providers.model_normalizer import normalize_model_name
+
+_log = logging.getLogger(__name__)
 
 _WAVE7_PATH = Path(__file__).parent / "providers" / "wave7_models.yaml"
 
@@ -17,7 +28,12 @@ _WAVE7_PATH = Path(__file__).parent / "providers" / "wave7_models.yaml"
 _AVG_INPUT_TOKENS = 5_000
 _AVG_OUTPUT_TOKENS = 2_000
 
-# Maps routing_recommendations model_id → (provider_key, model_key) in wave7_models.yaml.
+# Maps model_id → (provider_key, model_key) in wave7_models.yaml.
+#
+# Keys are the canonical registry model key (e.g. ``glm-5.2``, ``deepseek-v4-pro``).
+# Legacy dash-form keys (``glm-5-1``, ``glm-5-2``) and routing_recommendations
+# model_ids are kept ADDITIVELY for backward compat — callers that haven't been
+# normalized to canonical form still resolve through these entries.
 #
 # 2026-07-22 model-registry-refresh: routing_recommendations.yaml model_ids were bumped to
 # current (claude-sonnet-4-6 -> claude-sonnet-5, glm-5-1 -> glm-5-2; claude-opus-4-6 already
@@ -30,6 +46,10 @@ _AVG_OUTPUT_TOKENS = 2_000
 # fable-5) are now the canonical spellings; the current model_ids resolve to them, and the
 # missing claude-opus-5 / claude-fable-5 cost lookups are added so a smart_router decision
 # on the 5-series is not cost-blind.
+#
+# 2026-08-04 OI-977: canonical dot-form GLM keys added alongside legacy dash-form keys
+# so that ledger-stored names (glm-5.2) resolve. normalize_model_name() is called before
+# the lookup; deprecated variants (glm-4.5, glm-5.1) resolve via _deprecated_map.
 _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     "claude-sonnet-4-6": ("anthropic", "sonnet"),
     "claude-sonnet-5": ("anthropic", "sonnet-5"),
@@ -41,11 +61,79 @@ _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     "claude-haiku-4-5": ("anthropic", "haiku"),
     "deepseek-v4-flash": ("deepseek", "deepseek-v4-flash"),
     "deepseek-v4-pro": ("deepseek", "deepseek-v4-pro"),
+    # GLM — canonical dot-form keys (OI-977: what the ledger stores)
+    "glm-5.2": ("zai", "glm-5.2"),
+    # GLM — legacy dash-form keys (routing_recommendations / test backward compat)
     "glm-5-1": ("zai", "glm-5.2"),
     "glm-5-2": ("zai", "glm-5.2"),
+    # Kimi
     "kimi-k2-0905": ("kimi_cli", "kimi-default"),
     "kimi-k2-6": ("kimi_cli", "kimi-k2-6"),
 }
+
+# Cache: deprecated model name → current canonical model key.
+# Built from the deprecated_models lists in wave7_models.yaml.
+_deprecated_map_cache: Optional[dict[str, str]] = None
+
+
+def _load_deprecated_map(
+    path: Optional[Path] = None,
+) -> dict[str, str]:
+    """Return {deprecated_model_name: canonical_model_key} from wave7_models.yaml.
+
+    Reads every model's ``deprecated_models`` list and maps each entry to the
+    canonical model key of its parent.  E.g. ``glm-4.5`` → ``glm-5.2``.
+    """
+    global _deprecated_map_cache  # noqa: PLW0603
+    if _deprecated_map_cache is not None:
+        return _deprecated_map_cache
+    yaml_path = path or _WAVE7_PATH
+    result: dict[str, str] = {}
+    if not yaml_path.exists():
+        _deprecated_map_cache = result
+        return result
+    raw = yaml.safe_load(yaml_path.read_text(encoding="utf-8"))
+    for _provider_key, pdata in (raw.get("providers") or {}).items():
+        for model_key, mdata in (pdata.get("models") or {}).items():
+            for deprecated in mdata.get("deprecated_models") or []:
+                dep_norm = str(deprecated).strip().lower()
+                if dep_norm:
+                    result.setdefault(dep_norm, model_key)
+    _deprecated_map_cache = result
+    return result
+
+
+def _resolve_model_for_cost(
+    model_id: str,
+    *,
+    wave7_path: Optional[Path] = None,
+) -> Optional[str]:
+    """Resolve a model identifier to a canonical key for cost lookup.
+
+    Pipeline:
+      1. ``normalize_model_name()`` (handles provider-prefixed, litellm_name aliases).
+      2. If the result still contains ``/``, strip the provider prefix and retry.
+      3. Check the deprecated-model map from wave7_models.yaml.
+      4. Return the resolved canonical key, or None if unresolvable.
+    """
+    # Step 1: normalize_model_name
+    resolved = normalize_model_name(model_id)
+
+    # Step 2: if the result still has a provider prefix, strip and retry
+    if "/" in resolved:
+        stripped = resolved.rsplit("/", 1)[-1]
+        stripped_normalized = normalize_model_name(stripped)
+        if stripped_normalized != stripped:
+            resolved = stripped_normalized
+        else:
+            resolved = stripped
+
+    # Step 3: check deprecated model map
+    deprecated_map = _load_deprecated_map(wave7_path)
+    if resolved.lower() in deprecated_map:
+        resolved = deprecated_map[resolved.lower()]
+
+    return resolved if resolved else None
 
 
 def _load_wave7_costs(
@@ -78,17 +166,39 @@ def compute_cost_per_call(
 ) -> Optional[float]:
     """Return estimated USD cost per dispatch call for model_id using wave7 rates.
 
+    Model names are normalized via ``normalize_model_name()`` before the lookup
+    so that ledger-stored variants (e.g. ``openrouter/z-ai/glm-5.2``) resolve.
+
     Returns None when model_id is unknown or wave7_models.yaml is absent.
     Assumes avg_input_tokens=5000 / avg_output_tokens=2000 as typical dispatch size.
     """
     wave7_costs = _load_wave7_costs(wave7_path)
     if not wave7_costs:
         return None
-    mapping = _ROUTING_MODEL_MAP.get(model_id)
+
+    # Normalize the model name to canonical form (OI-977)
+    resolved = _resolve_model_for_cost(model_id, wave7_path=wave7_path)
+
+    # Try resolved canonical name first, then original input for backward compat
+    mapping = (
+        _ROUTING_MODEL_MAP.get(resolved or "")
+        or _ROUTING_MODEL_MAP.get(model_id)
+    )
     if mapping is None:
+        _log.warning(
+            "cost_loader: unknown model %r (normalized: %r) — no cost assigned",
+            model_id,
+            resolved,
+        )
         return None
     rates = wave7_costs.get(mapping)
     if rates is None:
+        _log.warning(
+            "cost_loader: model %r resolved to %r but no wave7 cost entry for %r",
+            model_id,
+            resolved,
+            mapping,
+        )
         return None
     inp_rate, out_rate = rates
     return (avg_input_tokens * inp_rate + avg_output_tokens * out_rate) / 1_000_000
@@ -99,14 +209,27 @@ def enrich_candidates(candidates: list, wave7_path: Optional[Path] = None) -> No
 
     Mutates the list in-place. Safe to call when wave7_models.yaml is absent —
     costs remain None and the router falls back to score-based sort.
+
+    Model names are normalized before the cost lookup (OI-977).
     """
     wave7_costs = _load_wave7_costs(wave7_path)
     if not wave7_costs:
         return
     for candidate in candidates:
         if candidate.cost_usd_per_call is None:
-            mapping = _ROUTING_MODEL_MAP.get(candidate.model_id)
+            resolved = _resolve_model_for_cost(
+                candidate.model_id, wave7_path=wave7_path,
+            )
+            mapping = (
+                _ROUTING_MODEL_MAP.get(resolved or "")
+                or _ROUTING_MODEL_MAP.get(candidate.model_id)
+            )
             if mapping is None:
+                _log.warning(
+                    "cost_loader: unknown candidate model %r (normalized: %r)",
+                    candidate.model_id,
+                    resolved,
+                )
                 continue
             rates = wave7_costs.get(mapping)
             if rates is None:

--- a/tests/test_cost_loader.py
+++ b/tests/test_cost_loader.py
@@ -1,0 +1,156 @@
+"""Tests for cost_loader — model-name normalization and cost resolution.
+
+Covers:
+- Ledger-stored GLM model names resolve to costs (OI-977)
+- normalize_model_name is applied before cost lookup
+- Deprecated GLM variants (glm-4.5, glm-5.1, etc.) resolve to glm-5.2 cost
+- Unknown models still return None
+- Existing map-form names continue to work
+
+Dispatch-ID: 20260804-m02-oi977
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from cost_loader import compute_cost_per_call
+
+
+# ---------------------------------------------------------------------------
+# GLM ledger-stored names (OI-977 — the core defect)
+# ---------------------------------------------------------------------------
+
+class TestGlmLedgerNamesResolveToCost:
+    """Every GLM model name stored in the ledger must return a cost, not None."""
+
+    def test_glm_5_2_dot_form_has_cost(self):
+        """448 receipts in the ledger use this exact spelling."""
+        cost = compute_cost_per_call("glm-5.2")
+        assert cost is not None, "glm-5.2 (dot form, as stored in ledger) must resolve to a cost"
+        assert cost > 0
+
+    def test_openrouter_z_ai_glm_5_2_has_cost(self):
+        """276 receipts in the ledger use this exact spelling."""
+        cost = compute_cost_per_call("openrouter/z-ai/glm-5.2")
+        assert cost is not None, (
+            "openrouter/z-ai/glm-5.2 (provider-prefixed, as stored in ledger) "
+            "must resolve to a cost"
+        )
+        assert cost > 0
+
+    def test_openrouter_z_ai_glm_5_1_has_cost(self):
+        """288 receipts in the ledger use this exact spelling (deprecated variant)."""
+        cost = compute_cost_per_call("openrouter/z-ai/glm-5.1")
+        assert cost is not None, (
+            "openrouter/z-ai/glm-5.1 (deprecated variant in ledger) "
+            "must resolve to glm-5.2 cost"
+        )
+        assert cost > 0
+
+    def test_openrouter_z_ai_glm_5_has_cost(self):
+        """363 receipts in the ledger use this exact spelling (bare version)."""
+        cost = compute_cost_per_call("openrouter/z-ai/glm-5")
+        assert cost is not None, (
+            "openrouter/z-ai/glm-5 (bare variant in ledger) "
+            "must resolve to glm-5.2 cost"
+        )
+        assert cost > 0
+
+    def test_glm_4_5_has_cost(self):
+        """1 receipt in the ledger uses this deprecated spelling."""
+        cost = compute_cost_per_call("glm-4.5")
+        assert cost is not None, "glm-4.5 (deprecated) must resolve to glm-5.2 cost"
+        assert cost > 0
+
+    def test_glm_4_6_has_cost(self):
+        """1 receipt in the ledger uses this deprecated spelling."""
+        cost = compute_cost_per_call("glm-4.6")
+        assert cost is not None, "glm-4.6 (deprecated) must resolve to glm-5.2 cost"
+        assert cost > 0
+
+
+# ---------------------------------------------------------------------------
+# Existing map-form names — must keep working
+# ---------------------------------------------------------------------------
+
+class TestExistingMapFormNames:
+    """Names that were already in _ROUTING_MODEL_MAP must still resolve."""
+
+    def test_glm_5_1_dash_form_has_cost(self):
+        """Legacy dash-form key used in routing_recommendations."""
+        cost = compute_cost_per_call("glm-5-1")
+        assert cost is not None
+        assert cost > 0
+
+    def test_glm_5_2_dash_form_has_cost(self):
+        """Legacy dash-form key used in routing_recommendations."""
+        cost = compute_cost_per_call("glm-5-2")
+        assert cost is not None
+        assert cost > 0
+
+    def test_deepseek_v4_pro_has_cost(self):
+        """DeepSeek models were already working."""
+        cost = compute_cost_per_call("deepseek-v4-pro")
+        assert cost is not None
+        assert cost > 0
+
+    def test_kimi_k2_0905_has_cost(self):
+        """Kimi legacy key was already working."""
+        cost = compute_cost_per_call("kimi-k2-0905")
+        assert cost is not None
+        assert cost > 0
+
+
+# ---------------------------------------------------------------------------
+# Negative-path: unknown models
+# ---------------------------------------------------------------------------
+
+class TestUnknownModelReturnsNone:
+    """Truly unknown models still return None."""
+
+    def test_future_unknown_model_returns_none(self):
+        assert compute_cost_per_call("future-unknown-model-9.9") is None
+
+    def test_missing_wave7_returns_none(self, tmp_path):
+        cost = compute_cost_per_call("claude-sonnet-4-6", wave7_path=tmp_path / "absent.yaml")
+        assert cost is None
+
+
+# ---------------------------------------------------------------------------
+# Consistency: all GLM variants resolve to the same cost
+# ---------------------------------------------------------------------------
+
+class TestGlmConsistency:
+    """All GLM variants (canonical, deprecated, provider-prefixed) resolve
+    to the same glm-5.2 cost."""
+
+    def test_all_glm_variants_same_cost(self):
+        variants = [
+            "glm-5.2",                   # canonical dot-form
+            "glm-5-1",                   # legacy dash-form
+            "glm-5-2",                   # legacy dash-form
+            "openrouter/z-ai/glm-5.2",   # provider-prefixed canonical
+            "openrouter/z-ai/glm-5.1",   # provider-prefixed deprecated
+            "openrouter/z-ai/glm-5",     # provider-prefixed bare
+            "glm-4.5",                   # deprecated
+            "glm-4.6",                   # deprecated
+        ]
+        costs = []
+        for name in variants:
+            cost = compute_cost_per_call(name)
+            assert cost is not None, f"Variant {name!r} must resolve to a cost"
+            costs.append(cost)
+
+        # All variants must return the same glm-5.2 cost
+        # input: 5000 * 0.60/1M + output: 2000 * 1.92/1M = 0.003 + 0.00384 = 0.00684
+        expected = 0.00684
+        for name, cost in zip(variants, costs):
+            assert abs(cost - expected) < 1e-9, (
+                f"Variant {name!r}: expected {expected}, got {cost}"
+            )


### PR DESCRIPTION
## What

Fixes OI-977: de kostenmap in `cost_loader.py` matchte geen enkele modelnaam die het grootboek werkelijk opslaat. 1377 GLM-receipts hadden geen kostentoerekening.

## Root cause

`_ROUTING_MODEL_MAP` gebruikte streepjes-vormen (`glm-5-1`, `glm-5-2`) die niet overeenkomen met de namen in het grootboek (`glm-5.2`, `openrouter/z-ai/glm-5.2`, etc.). `normalize_model_name()` werd nergens vóór de lookup toegepast.

## Fix

- `normalize_model_name()` wordt nu vóór de cost lookup aangeroepen
- `_resolve_model_for_cost()`: driestaps-normalisatie-pipeline (normalize → strip provider prefix → check deprecated map)
- Deprecated model map uit `wave7_models.yaml` gebouwd (`glm-4.5` → `glm-5.2`, etc.)
- Canonical dot-form key `glm-5.2` toegevoegd aan `_ROUTING_MODEL_MAP`
- Warning log bij onbekend model (stil `None` → zichtbaar)

## Before/after

| Model name | Before | After |
|---|---|---|
| `glm-5.2` | None | $0.006840 |
| `openrouter/z-ai/glm-5.2` | None | $0.006840 |
| `openrouter/z-ai/glm-5.1` | None | $0.006840 |
| `openrouter/z-ai/glm-5` | None | $0.006840 |
| `glm-4.5` | None | $0.006840 |
| `glm-4.6` | None | $0.006840 |
| `glm-5-1` (legacy dash) | $0.006840 | $0.006840 |
| `glm-5-2` (legacy dash) | $0.006840 | $0.006840 |

## Tests

- 13 nieuwe tests in `tests/test_cost_loader.py` (was 6 rood op oude code, nu 13 groen)
- 27 bestaande tests in `test_smart_router_cost_aware.py` — allemaal groen, zero regressies

Dispatch-ID: 20260804-m02-oi977

🤖 Generated with [Claude Code](https://claude.com/claude-code)