### PR TITLE
fix(dispatch): persist target_slot and worker_claude_override_reason on dispatch row (OI-943)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -749,7 +749,12 @@ def _check_track_link_verdict(spec: DispatchSpec, *, state_dir: Path) -> Optiona
     )
 
 
-def _persist_dispatch_row(spec: DispatchSpec, *, state_dir: Path) -> None:
+def _persist_dispatch_row(
+    spec: DispatchSpec,
+    *,
+    state_dir: Path,
+    worker_claude_override_reason: Optional[str] = None,
+) -> None:
     """Best-effort: create the dispatches tracker row for a door-accepted dispatch.
 
     The door is the single entry point for dispatches, yet historically never
@@ -776,6 +781,11 @@ def _persist_dispatch_row(spec: DispatchSpec, *, state_dir: Path) -> None:
     Idempotent per ADR-007's composite UNIQUE(dispatch_id, project_id): a retry
     or fix-forward with the same id finds the existing row and leaves it
     untouched. Never raises: tracker bookkeeping must never block the door.
+
+    OI-943: persists target_slot and worker_claude_override_reason so the audit
+    trail can distinguish ported from unported claude dispatches. target_slot is
+    always present (required in DispatchSpec); worker_claude_override_reason is
+    only present when a build-worker override was applied.
     """
     db_path = _tracks_db_path(state_dir)
     if not db_path.exists():
@@ -817,6 +827,25 @@ def _persist_dispatch_row(spec: DispatchSpec, *, state_dir: Path) -> None:
             if track_id:
                 cols.append("track_id")
                 vals.append(track_id)
+            # OI-943: persist target_slot (always present) and the worker-claude
+            # override reason (only when an override was applied) so the audit
+            # trail can distinguish ported from unported claude dispatches.
+            target_slot = spec.target_slot.strip()
+            if target_slot and not _has_col(conn, "dispatches", "target_slot"):
+                conn.execute("ALTER TABLE dispatches ADD COLUMN target_slot TEXT")
+                conn.commit()
+            if target_slot:
+                cols.append("target_slot")
+                vals.append(target_slot)
+            override_reason = (worker_claude_override_reason or "").strip()
+            if override_reason:
+                if not _has_col(conn, "dispatches", "worker_claude_override_reason"):
+                    conn.execute(
+                        "ALTER TABLE dispatches ADD COLUMN worker_claude_override_reason TEXT"
+                    )
+                    conn.commit()
+                cols.append("worker_claude_override_reason")
+                vals.append(override_reason)
             now = datetime.now(timezone.utc).isoformat(timespec="milliseconds").replace(
                 "+00:00", "Z"
             )
@@ -1244,6 +1273,7 @@ def build_runtime_snapshot(
         task_class=chain_task_class,
         tier_from=chain_tier_from,
         tier_to=chain_tier_to,
+        worker_claude_override_reason=worker_claude_override_reason,
     )
 
 
@@ -1439,7 +1469,11 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             # the TL-D2 pr_ref propagation all have a row to read. Idempotent
             # (retry/fix-forward safe), state='proposed' (invisible to the
             # claim/stuck/ghost sweeps), best-effort — never blocks the door.
-            _persist_dispatch_row(vspec.spec, state_dir=state_dir)
+            _persist_dispatch_row(
+                vspec.spec,
+                state_dir=state_dir,
+                worker_claude_override_reason=snapshot.worker_claude_override_reason,
+            )
 
             # OI-876/OI-881: a declared gate is an obligation, not decoration.
             # Registered here — right after the dispatch is irrevocably

--- a/scripts/lib/dispatch_plan.py
+++ b/scripts/lib/dispatch_plan.py
@@ -76,6 +76,9 @@ class RuntimeSnapshot:
     task_class: Optional[str] = None
     tier_from: Optional[str] = None
     tier_to: Optional[str] = None
+    # OI-943: worker-claude-override gate outcome, threaded from build_runtime_snapshot
+    # so the door can persist target_slot + override reason onto the dispatch row.
+    worker_claude_override_reason: Optional[str] = None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_door_row.py
+++ b/tests/test_dispatch_door_row.py
@@ -29,7 +29,7 @@ import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
 
-from dispatch_cli import _persist_track_id, load_spec, run_dispatch
+from dispatch_cli import _persist_dispatch_row, _persist_track_id, load_spec, run_dispatch
 
 
 # ---------------------------------------------------------------------------
@@ -89,6 +89,7 @@ def _make_bundle(
     dispatch_id: str,
     track_id: "str | None" = "oi-847-track",
     schema_version: int = 1,
+    target_slot: str = "T0",
 ) -> "tuple[Path, Path]":
     """A promoted-style staged bundle (spec + instruction inside the bundle dir).
 
@@ -106,7 +107,7 @@ def _make_bundle(
         "staging_id": staging_id,
         "instruction_file": str(instruction),
         "role": "backend-developer",
-        "target_slot": "T0",
+        "target_slot": target_slot,
         "gate": "human-promoted",
         "dispatch_paths": [],
         "provider": "claude",
@@ -278,3 +279,115 @@ def test_rejected_dispatch_creates_no_row(tmp_path, monkeypatch):
     )
     assert _read_row(db_path, "20260731-oi847-rejected") is None
     assert _read_row(db_path, "20260731-oi847-accepted") is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. OI-943: _persist_dispatch_row writes target_slot so the audit trail can
+#    distinguish ported from unported claude dispatches.
+# ---------------------------------------------------------------------------
+
+def test_oi943_persists_target_slot(tmp_path):
+    """_persist_dispatch_row must write spec.target_slot to the dispatch row."""
+    state_dir = tmp_path / "state"
+    db_path = _make_coordination_db(state_dir)
+    data_dir = tmp_path / "vnx-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260804-staging-oi943-ts",
+        dispatch_id="20260804-oi943-target-slot",
+    )
+    spec = load_spec(spec_file)
+    assert spec.target_slot == "T0", "fixture default is T0"
+
+    _persist_dispatch_row(spec, state_dir=state_dir)
+
+    row = _read_row(db_path, "20260804-oi943-target-slot")
+    assert row is not None, "door must create a dispatches row"
+    assert row["target_slot"] == "T0", (
+        "OI-943: target_slot must be persisted on the dispatch row so the audit "
+        "trail can distinguish ported from unported claude dispatches"
+    )
+
+
+def test_oi943_persists_override_reason(tmp_path):
+    """_persist_dispatch_row must write worker_claude_override_reason when provided."""
+    state_dir = tmp_path / "state"
+    db_path = _make_coordination_db(state_dir)
+    data_dir = tmp_path / "vnx-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260804-staging-oi943-or",
+        dispatch_id="20260804-oi943-override-reason",
+    )
+    spec = load_spec(spec_file)
+
+    _persist_dispatch_row(
+        spec,
+        state_dir=state_dir,
+        worker_claude_override_reason="testing override gate audit",
+    )
+
+    row = _read_row(db_path, "20260804-oi943-override-reason")
+    assert row is not None, "door must create a dispatches row"
+    assert row["target_slot"] == "T0"
+    assert row["worker_claude_override_reason"] == "testing override gate audit", (
+        "OI-943: worker_claude_override_reason must be persisted so the override "
+        "outcome is auditable"
+    )
+
+
+def test_oi943_override_reason_none_is_omitted(tmp_path):
+    """When no override is applied, the row omits worker_claude_override_reason."""
+    state_dir = tmp_path / "state"
+    db_path = _make_coordination_db(state_dir)
+    data_dir = tmp_path / "vnx-data"
+    data_dir.mkdir(parents=True, exist_ok=True)
+    _, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260804-staging-oi943-no",
+        dispatch_id="20260804-oi943-no-override",
+    )
+    spec = load_spec(spec_file)
+
+    # No override reason passed — the default None applies.
+    _persist_dispatch_row(spec, state_dir=state_dir)
+
+    row = _read_row(db_path, "20260804-oi943-no-override")
+    assert row is not None, "door must create a dispatches row"
+    assert row["target_slot"] == "T0"
+    # The column may not exist (row_factory returns None for missing columns)
+    # or it may be NULL — either way the override reason is absent.
+    try:
+        override_val = row["worker_claude_override_reason"]
+    except IndexError:
+        override_val = None
+    assert override_val is None or override_val == "", (
+        "OI-943: worker_claude_override_reason must be absent when no override was applied"
+    )
+
+
+def test_oi943_target_slot_survives_through_door(tmp_path, monkeypatch):
+    """Integration: a dispatch through the full door persists target_slot."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id="20260804-staging-oi943-int",
+        dispatch_id="20260804-oi943-integration",
+        target_slot="T0",  # T0 is a valid claude lane without override
+    )
+    db_path = _make_coordination_db(
+        data_dir / "state", tracks={"oi-847-track": "active"}
+    )
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+    with patch("dispatch_cli._execute_claude", return_value=0):
+        rc = run_dispatch(spec_file)
+
+    assert rc == 0
+    row = _read_row(db_path, "20260804-oi943-integration")
+    assert row is not None, "door must create a dispatches row"
+    assert row["target_slot"] == "T0", (
+        "OI-943: target_slot must survive the full door path"
+    )


### PR DESCRIPTION
## OI-943: Persist target_slot and worker_claude_override_reason on the dispatch row

### Defect

`_persist_dispatch_row` INSERTed dispatch_id, project_id, state, track_id, created_at, and updated_at — but never `target_slot` or `worker_claude_override_reason`. Result: all 90 dispatch rows in the live DB have `terminal_id` NULL/empty, and the audit trail cannot distinguish ported from unported claude dispatches.

### Fix

- **`dispatch_plan.py`**: Added `worker_claude_override_reason: Optional[str] = None` to `RuntimeSnapshot` so `build_runtime_snapshot` can thread the override gate outcome back to the door.
- **`dispatch_cli.py`**: 
  - `_persist_dispatch_row` now accepts `worker_claude_override_reason` and persists it (when non-None) alongside `target_slot` to the dispatches row, with `_has_col`-guarded `ALTER TABLE` for existing DBs.
  - `build_runtime_snapshot` passes `worker_claude_override_reason` into the `RuntimeSnapshot`.
  - Call site passes `snapshot.worker_claude_override_reason` to `_persist_dispatch_row`.
- **`test_dispatch_door_row.py`**: 4 new tests (3 unit + 1 integration) verifying:
  - `target_slot` is persisted on the row
  - `worker_claude_override_reason` is persisted when provided
  - Row omits the override reason when none was applied
  - Full integration: target_slot survives through `run_dispatch`

### Test Results

```
tests/test_dispatch_door_row.py ........ (8 passed)
tests/test_dispatch_cli.py ....................................................................................................................... (121 passed)
tests/test_dispatch_plan.py ............................................................................................. (93 passed)
tests/test_dispatch_door_authority.py ......... (9 passed)
```

**231 tests pass** across affected suites. No regressions.

### Verification

On the old code, `_persist_dispatch_row` INSERTs only `dispatch_id`, `project_id`, `state`, `track_id`, `created_at`, `updated_at` — grep confirms zero references to `target_slot` or `worker_claude_override_reason` in any persist/INSERT code path.

Dispatch-ID: 20260804-m12-oi943

🤖 Generated with [Claude Code](https://claude.com/claude-code)