### PR TITLE
fix(kimi-lane): reap one-shot session dir post-dispatch (OI-812)

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -52,6 +52,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -507,6 +508,108 @@ def _harvest_session_token_usage(
                 _shutil.rmtree(zip_path.parent, ignore_errors=True)
             except Exception:  # vnx-silent-except: cleanup must never raise
                 pass
+
+
+# kimi-cli persists one resumable session dir per invocation with no auto-GC,
+# TTL, or no-persist flag. One-shot --print dispatches are never resumed, so
+# without an explicit reap the session dirs (wire.jsonl + context.jsonl +
+# state.json) accrue unbounded (543 dirs / 697MB on 2026-07-28, manually
+# cleaned to 316M). OI-812: after the token harvest (which still needs the
+# export), the dead session is reaped.
+_SESSION_ID_VALUE_RE = re.compile(r"[0-9a-fA-F-]+\Z")
+
+
+def _kimi_share_dir(env: Dict[str, str]) -> Path:
+    """Resolve the kimi share dir exactly as kimi-cli 1.46.0 does.
+
+    ``kimi_cli/share.py::get_share_dir`` returns ``KIMI_SHARE_DIR`` when set,
+    else ``~/.kimi``. The reap must resolve the SAME dir the spawned kimi wrote
+    to, so it reads the env the subprocess was launched with, not the ambient
+    process env.
+    """
+    override = (env or {}).get("KIMI_SHARE_DIR")
+    if override:
+        return Path(override).expanduser()
+    return Path.home() / ".kimi"
+
+
+def _find_kimi_session_dir(session_id: str, env: Dict[str, str]) -> Optional[Path]:
+    """Locate the on-disk session dir for *session_id*, or None.
+
+    Sessions live at ``<share_dir>/sessions/<work_dir_md5>/<session_id>/``.
+    The outer bucket is the md5 of the work-dir path, which the resume id alone
+    cannot tell us, so every bucket under ``sessions/`` is scanned for a
+    directory named exactly *session_id*. Returns None when the session is not
+    on disk (already reaped, or the share dir has no sessions subtree).
+    """
+    if not session_id or not _SESSION_ID_VALUE_RE.match(session_id):
+        return None
+    sessions_root = _kimi_share_dir(env) / "sessions"
+    if not sessions_root.is_dir():
+        return None
+    try:
+        for bucket in sessions_root.iterdir():
+            if not bucket.is_dir():
+                continue
+            candidate = bucket / session_id
+            if candidate.is_dir():
+                return candidate
+    except OSError as exc:
+        logger.debug("kimi_spawn: session-dir scan failed (fail-open): %s", exc)
+        return None
+    return None
+
+
+def _reap_kimi_session(session_id: str, env: Dict[str, str]) -> bool:
+    """Remove the on-disk session dir of a one-shot kimi dispatch.
+
+    One-shot dispatches are never resumed, so after the token harvest the
+    session dir is dead weight: reap it. Best-effort — a reap failure (or a
+    session already gone) must never break an otherwise-clean dispatch, so this
+    returns False instead of raising.
+
+    Safety: only a directory whose path is exactly
+    ``<share_dir>/sessions/<bucket>/<session_id>`` is ever removed — the leaf
+    must equal *session_id* and sit two levels under the sessions subtree, the
+    layout kimi's ``WorkDirMeta.sessions_dir`` always produces. Anything else
+    (the sessions root, a bucket dir, a depth-1 dir, a path outside the tree)
+    is refused with a warning.
+    """
+    if not session_id or not _SESSION_ID_VALUE_RE.match(session_id):
+        return False
+    share_dir = _kimi_share_dir(env)
+    sessions_root = share_dir / "sessions"
+    session_dir = _find_kimi_session_dir(session_id, env)
+    if session_dir is None:
+        return False
+    try:
+        resolved = session_dir.resolve()
+        root_resolved = sessions_root.resolve()
+    except OSError as exc:
+        logger.warning("kimi_spawn: could not resolve reap path %s: %s", session_dir, exc)
+        return False
+    try:
+        rel = resolved.relative_to(root_resolved)
+    except ValueError:
+        logger.warning(
+            "kimi_spawn: refusing to reap %s (outside kimi sessions tree %s)",
+            resolved, root_resolved,
+        )
+        return False
+    if len(rel.parts) != 2 or rel.parts[1] != session_id:
+        logger.warning(
+            "kimi_spawn: refusing to reap %s (not a two-level session dir under %s)",
+            resolved, root_resolved,
+        )
+        return False
+    try:
+        shutil.rmtree(resolved, ignore_errors=True)
+    except Exception:  # vnx-silent-except: reap must never break the dispatch
+        return False
+    reaped = not resolved.exists()
+    if reaped:
+        logger.debug("kimi_spawn: reaped one-shot kimi session dir %s", resolved)
+    return reaped
 
 
 def _worktree_has_changes(worktree: Any, base_ref: str = "origin/main") -> Optional[bool]:
@@ -995,4 +1098,11 @@ def spawn_kimi(
             harvested = _harvest_session_token_usage(session_id, env, cwd_str)
             if harvested:
                 result.token_usage = harvested
+            # OI-812: one-shot dispatches are never resumed, so the session dir
+            # (wire.jsonl + context.jsonl + state.json) is dead weight after the
+            # harvest (which already exported the token data). Reap it. Runs
+            # regardless of whether the harvest yielded tokens — a failed export
+            # still leaves a session dir behind. Best-effort: a reap failure
+            # must never break an otherwise-clean dispatch.
+            _reap_kimi_session(session_id, env)
     return result

--- a/tests/test_kimi_session_reap.py
+++ b/tests/test_kimi_session_reap.py
@@ -1,0 +1,250 @@
+"""Tests for kimi one-shot session reaping (OI-812).
+
+kimi-cli persists a resumable session dir per invocation with no auto-GC, TTL,
+or no-persist flag. One-shot ``--print`` dispatches are never resumed, so
+without an explicit reap the session dirs (wire.jsonl + context.jsonl +
+state.json) accrue unbounded (543 dirs / 697MB on 2026-07-28, manually cleaned
+to 316M). These tests cover:
+
+  * ``_find_kimi_session_dir`` — locating the session dir by scanning buckets;
+  * ``_reap_kimi_session``     — guarded removal confined to the sessions tree;
+  * ``spawn_kimi`` wiring      — a clean one-shot run reaps the session dir
+    after the token harvest; a run without a resume line or a failed dispatch
+    leaves on-disk sessions untouched.
+
+Every test runs against a throwaway ``KIMI_SHARE_DIR`` so the real ``~/.kimi``
+tree is never touched.
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import sys
+import tempfile
+import threading
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+_LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
+if _LIB_DIR not in sys.path:
+    sys.path.insert(0, _LIB_DIR)
+
+from provider_spawns.kimi_spawn import (  # noqa: E402
+    _find_kimi_session_dir,
+    _reap_kimi_session,
+    spawn_kimi,
+)
+
+_SESSION_ID = "c2f1ae72-7d30-46e0-8b41-ca8938a13b89"
+
+
+def _make_session_dir(share_dir: Path, session_id: str, bucket: str = "bucket1") -> Path:
+    """Create a kimi-style session dir the way the CLI lays it out on disk."""
+    session_dir = share_dir / "sessions" / bucket / session_id
+    session_dir.mkdir(parents=True, exist_ok=True)
+    (session_dir / "wire.jsonl").write_text('{"type": "metadata", "protocol_version": "1.10"}\n')
+    (session_dir / "context.jsonl").write_text("")
+    (session_dir / "state.json").write_text("{}")
+    return session_dir
+
+
+def _make_proc_with_stderr(events: list, returncode: int = 0, stderr_text: str = "") -> MagicMock:
+    """Fake Popen with a real-pipe stdout (drain_stream needs fileno()) and a
+    BytesIO stderr carrying the kimi resume line."""
+    data = b"".join((json.dumps(e) + "\n").encode() for e in events)
+    read_fd, write_fd = os.pipe()
+
+    def _writer():
+        try:
+            os.write(write_fd, data)
+        finally:
+            os.close(write_fd)
+
+    writer_thread = threading.Thread(target=_writer, daemon=True)
+    writer_thread.start()
+
+    fake_proc = MagicMock()
+    fake_proc.returncode = returncode
+    fake_proc.poll.return_value = returncode
+    fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+    fake_proc.stderr = io.BytesIO(stderr_text.encode())
+    fake_proc.wait = MagicMock(return_value=returncode)
+    fake_proc.kill = MagicMock()
+    fake_proc._writer_thread = writer_thread
+    return fake_proc
+
+
+class TestFindKimiSessionDir(unittest.TestCase):
+    def test_finds_session_across_buckets(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            session_dir = _find_kimi_session_dir(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)})
+            self.assertIsNotNone(session_dir)
+            self.assertEqual(session_dir.name, _SESSION_ID)
+            self.assertTrue(session_dir.is_dir())
+
+    def test_returns_none_when_absent(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            _make_session_dir(share, "11111111-2222-3333-4444-555555555555", bucket="bucket1")
+            self.assertIsNone(_find_kimi_session_dir(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+
+    def test_returns_none_when_sessions_root_missing(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            self.assertIsNone(_find_kimi_session_dir(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+
+    def test_returns_none_when_share_dir_missing(self) -> None:
+        share = Path(tempfile.gettempdir()) / "kimi-reap-test-absent-share"
+        self.assertIsNone(_find_kimi_session_dir(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+
+    def test_depth_one_dir_is_not_a_session(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            # A dir directly under sessions/ (the legacy file bucket, not a
+            # session) must never be treated as a session dir.
+            (share / "sessions" / _SESSION_ID).mkdir(parents=True)
+            self.assertIsNone(_find_kimi_session_dir(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+
+    def test_rejects_path_traversal_session_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            self.assertIsNone(_find_kimi_session_dir("../../etc", {"KIMI_SHARE_DIR": str(share)}))
+
+
+class TestReapKimiSession(unittest.TestCase):
+    def test_removes_session_dir_keeps_bucket(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            session_dir = _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            self.assertTrue(session_dir.is_dir())
+            self.assertTrue(_reap_kimi_session(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+            self.assertFalse(session_dir.exists())
+            # The bucket (work-dir md5 dir) survives — only the session is dead.
+            self.assertTrue((share / "sessions" / "bucket1").is_dir())
+
+    def test_returns_false_when_not_found(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            self.assertFalse(_reap_kimi_session(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+
+    def test_returns_false_on_invalid_session_id(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            # A path-traversal id must be refused before any path is touched.
+            self.assertFalse(_reap_kimi_session("../../etc", {"KIMI_SHARE_DIR": str(share)}))
+            self.assertTrue((share / "sessions" / "bucket1" / _SESSION_ID).is_dir())
+
+    def test_refuses_to_reap_bucket_dirs(self) -> None:
+        # If a regressed finder ever returned a bucket dir (depth 1 under the
+        # sessions tree), the reap must refuse — only two-level session dirs are
+        # ever removed.
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            bucket = share / "sessions" / "bucket1"
+            bucket.mkdir(parents=True)
+            with patch("provider_spawns.kimi_spawn._find_kimi_session_dir", return_value=bucket):
+                self.assertFalse(_reap_kimi_session(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+            self.assertTrue(bucket.is_dir())
+
+    def test_refuses_to_reap_outside_sessions_tree(self) -> None:
+        # A finder regression pointing outside the kimi sessions subtree must be
+        # refused before anything is deleted.
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            outside = Path(tmp) / "outside" / _SESSION_ID
+            outside.mkdir(parents=True)
+            with patch("provider_spawns.kimi_spawn._find_kimi_session_dir", return_value=outside):
+                self.assertFalse(_reap_kimi_session(_SESSION_ID, {"KIMI_SHARE_DIR": str(share)}))
+            self.assertTrue(outside.is_dir())
+
+
+class TestSpawnKimiReapsSession(unittest.TestCase):
+    """End-to-end through spawn_kimi: a clean one-shot run reaps the session dir."""
+
+    _ANSWER_EVENTS = [
+        {"role": "assistant", "content": [{"type": "text", "text": "okay"}]},
+    ]
+    _STDERR = "\nTo resume this session: kimi -r %s\n" % _SESSION_ID
+
+    def _run(self, events, returncode=0, stderr_text="", share_dir=None, harvest_return=None):
+        fake_proc = _make_proc_with_stderr(events, returncode=returncode, stderr_text=stderr_text)
+        extra_env = {}
+        if share_dir is not None:
+            extra_env["KIMI_SHARE_DIR"] = str(share_dir)
+        try:
+            with patch("provider_spawns.kimi_spawn._start_kimi_subprocess") as mock_start, \
+                    patch("provider_spawns.kimi_spawn._harvest_session_token_usage",
+                          return_value=harvest_return) as mock_harvest:
+                mock_start.return_value = (fake_proc, None)
+                result = spawn_kimi(
+                    "prompt", dispatch_id="d-reap", terminal_id="T2", extra_env=extra_env,
+                )
+        finally:
+            fake_proc._writer_thread.join(timeout=5)
+        return result, mock_harvest
+
+    def test_clean_run_reaps_session_dir(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            session_dir = _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            result, mock_harvest = self._run(
+                self._ANSWER_EVENTS, returncode=0, stderr_text=self._STDERR,
+                share_dir=share, harvest_return=None,
+            )
+            self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+            self.assertEqual(result.returncode, 0)
+            # The harvest runs (it needs the export before the dir is gone).
+            mock_harvest.assert_called_once()
+            self.assertFalse(
+                session_dir.exists(), "one-shot session dir must be reaped post-dispatch"
+            )
+            self.assertTrue((share / "sessions" / "bucket1").is_dir())
+
+    def test_clean_run_reaps_even_when_harvest_yields_tokens(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            session_dir = _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            result, _ = self._run(
+                self._ANSWER_EVENTS, returncode=0, stderr_text=self._STDERR,
+                share_dir=share,
+                harvest_return={"input_tokens": 1, "output_tokens": 1, "cache_read_tokens": 0},
+            )
+            self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+            self.assertFalse(
+                session_dir.exists(), "one-shot session dir must be reaped even with tokens"
+            )
+
+    def test_no_resume_line_leaves_session_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            session_dir = _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            result, mock_harvest = self._run(
+                self._ANSWER_EVENTS, returncode=0, stderr_text="kimi exited normally",
+                share_dir=share,
+            )
+            self.assertIsNone(result.error, f"unexpected error: {result.error!r}")
+            mock_harvest.assert_not_called()
+            self.assertTrue(session_dir.exists())
+
+    def test_failed_dispatch_leaves_session_untouched(self) -> None:
+        with tempfile.TemporaryDirectory() as tmp:
+            share = Path(tmp)
+            session_dir = _make_session_dir(share, _SESSION_ID, bucket="bucket1")
+            events = [{"event_type": "error", "message": "rate limit exceeded"}]
+            result, mock_harvest = self._run(
+                events, returncode=0, stderr_text=self._STDERR, share_dir=share,
+            )
+            self.assertIsNotNone(result.error)
+            self.assertNotEqual(result.returncode, 0)
+            mock_harvest.assert_not_called()
+            self.assertTrue(session_dir.exists())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

OI-812: kimi-cli persists a resumable session dir per invocation with no auto-GC/TTL or no-persist flag. One-shot `--print` dispatches are never resumed, so without an explicit reap the session dirs (`wire.jsonl` + `context.jsonl` + `state.json`) accrue unbounded — 543 dirs / 697MB on 2026-07-28, manually cleaned to 316M.

## Fix

After the post-run token harvest in `spawn_kimi`, reap the one-shot session dir:

- `_kimi_share_dir(env)` — resolve the kimi share dir exactly as kimi-cli 1.46.0 does (`KIMI_SHARE_DIR` else `~/.kimi`), read from the subprocess env so the same dir the spawned kimi wrote to is targeted.
- `_find_kimi_session_dir(session_id, env)` — locate the session by scanning `sessions/<work_dir_md5>/<session_id>` buckets (the resume id alone can't tell us the bucket).
- `_reap_kimi_session(session_id, env)` — remove it, guarded so only a directory whose path is exactly `<share_dir>/sessions/<bucket>/<session_id>` is ever deleted. Anything else (sessions root, a bucket dir, a depth-1 dir, a path outside the tree) is refused. Best-effort: never raises, never breaks a clean dispatch.

The reap runs inside the existing clean-run block in `spawn_kimi`, after the token harvest (which still needs the export), and regardless of whether the harvest yielded tokens.

## Tests

New `tests/test_kimi_session_reap.py` (15 tests):

- Red first: `test_clean_run_reaps_session_dir` and `test_clean_run_reaps_even_when_harvest_yields_tokens` failed against unmodified code (session dir survived); green after.
- Negative paths: no resume line / failed dispatch leave on-disk sessions untouched; absent session, invalid id, missing share dir, depth-1 dir, bucket dir, outside-tree target all refuse.
- All tests run against a throwaway `KIMI_SHARE_DIR` — the real `~/.kimi` tree is never touched.

Existing suites: 292 passed across the kimi spawn / provider-dispatch / token-capture / model-resolver / constraint-enforcer tests.

## Open Items

- Failed dispatches still leave a session dir (the session id is only extracted on the clean path). The original filing mentions a global-process-cleanup-loop; a periodic sweep of stale kimi session dirs would cover that residual accrual and any crash-orphaned sessions.
- Other provider lanes (codex, gemini, deepseek) may persist similar resumable sessions — out of scope for this kimi-specific item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)