### PR TITLE
fix(migration): durably track unexpected composite-key index failures (OI-563)

### DIFF
--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -248,6 +248,113 @@ _RC_COMPOSITE_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("worker_pool_membership", ("project_id", "id")),
 )
 
+# Durable record of tables whose ux_<table>_pid index could not be created due to
+# an UNEXPECTED (non-IntegrityError) sqlite3 error. user_version still advances
+# (the migration is non-destructive and non-aborting), so this marker — plus
+# composite_index_audit() — is what surfaces the under-enforcement (OI-563).
+_COMPOSITE_KEY_FAILURES_TABLE = "composite_key_failures"
+
+
+def _record_composite_index_failure(
+    conn: sqlite3.Connection,
+    table: str,
+    cols: tuple[str, ...],
+    error: sqlite3.Error,
+) -> None:
+    """Durably record an unexpected composite UNIQUE index creation failure.
+
+    Upserts one row per table (latest error wins) into
+    ``composite_key_failures``. Best-effort by design: the migration stays
+    non-destructive even if the marker write itself fails — the original error
+    is still ERROR-logged by the caller. Stale rows for tables that later get
+    their index are filtered out by ``composite_index_audit``.
+    """
+    try:
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {_COMPOSITE_KEY_FAILURES_TABLE} ("
+            "table_name TEXT PRIMARY KEY, "
+            "index_name TEXT NOT NULL, "
+            "columns TEXT NOT NULL, "
+            "error TEXT NOT NULL, "
+            "occurred_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            f"INSERT OR REPLACE INTO {_COMPOSITE_KEY_FAILURES_TABLE} "
+            "(table_name, index_name, columns, error, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            (table, f"ux_{table}_pid", ", ".join(cols), str(error), _now_utc()),
+        )
+    except sqlite3.Error as exc:
+        logger.error(
+            "composite-keys: failed to record durable failure marker for %s — %s",
+            table, exc,
+        )
+
+
+def composite_index_audit(conn: sqlite3.Connection) -> Dict[str, Any]:
+    """Return ADR-007 composite UNIQUE index coverage for the coordination DB.
+
+    A table counts as under-enforced when it exists in the schema but has no
+    ``ux_<table>_pid`` index attached to it — either absent, or shadowed by an
+    index of the same name on a different table (which ``CREATE UNIQUE INDEX IF
+    NOT EXISTS`` silently accepts as a no-op). Durable failure markers recorded
+    by ``_migrate_v11_composite_keys`` for unexpected per-table errors are
+    surfaced for tables still missing their index, so past under-enforcement
+    stays visible even after user_version has advanced (OI-563).
+
+    Returns:
+      {
+        "missing":  [{"table", "index", "columns"}, ...],
+        "failures": [{"table", "index", "columns", "error", "occurred_at"}, ...],
+        "tables_checked": int,
+      }
+    """
+    missing: List[Dict[str, str]] = []
+    tables_checked = 0
+    for table, cols in _RC_COMPOSITE_KEYS:
+        if not conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone():
+            continue
+        tables_checked += 1
+        index_name = f"ux_{table}_pid"
+        row = conn.execute(
+            "SELECT tbl_name FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()
+        owner = None if row is None else (
+            row[0] if not isinstance(row, sqlite3.Row) else row["tbl_name"]
+        )
+        if owner != table:
+            missing.append({"table": table, "index": index_name, "columns": ", ".join(cols)})
+
+    failures: List[Dict[str, str]] = []
+    missing_tables = {m["table"] for m in missing}
+    try:
+        marker_rows = conn.execute(
+            f"SELECT table_name, index_name, columns, error, occurred_at "
+            f"FROM {_COMPOSITE_KEY_FAILURES_TABLE} ORDER BY occurred_at DESC"
+        ).fetchall()
+    except sqlite3.Error:
+        marker_rows = []
+    for row in marker_rows:
+        table_name = row[0] if not isinstance(row, sqlite3.Row) else row["table_name"]
+        if table_name not in missing_tables:
+            # Stale marker: the table has its index again — don't surface it.
+            continue
+        failures.append({
+            "table": table_name,
+            "index": row[1] if not isinstance(row, sqlite3.Row) else row["index_name"],
+            "columns": row[2] if not isinstance(row, sqlite3.Row) else row["columns"],
+            "error": row[3] if not isinstance(row, sqlite3.Row) else row["error"],
+            "occurred_at": row[4] if not isinstance(row, sqlite3.Row) else row["occurred_at"],
+        })
+
+    return {
+        "missing": missing,
+        "failures": failures,
+        "tables_checked": tables_checked,
+    }
+
 
 def _migrate_v11_composite_keys(conn: sqlite3.Connection) -> None:
     """V11: ADR-007 composite UNIQUE indexes over project_id (non-destructive).
@@ -257,6 +364,11 @@ def _migrate_v11_composite_keys(conn: sqlite3.Connection) -> None:
     try/except: a missing column or existing duplicate rows in a given table only
     skips that one table and logs a clear warning. The migration never aborts,
     never deletes rows, and never rewrites data.
+
+    An UNEXPECTED per-table error (non-IntegrityError) is ERROR-logged and
+    durably recorded via ``_record_composite_index_failure`` so the missing
+    index — which user_version still advances past — surfaces through
+    ``composite_index_audit()`` instead of being silently dropped (OI-563).
     """
     for table, cols in _RC_COMPOSITE_KEYS:
         if not conn.execute(
@@ -294,12 +406,13 @@ def _migrate_v11_composite_keys(conn: sqlite3.Connection) -> None:
             )
         except sqlite3.Error as exc:
             # Unexpected (e.g. a migration bug / bad column) — must NOT be swallowed as a
-            # data-violation skip. Surface at ERROR level so it is investigated; still do
-            # not abort the whole migration run.
+            # data-violation skip. Surface at ERROR level AND durably so it is investigated
+            # even though user_version advances; still do not abort the whole migration run.
             logger.error(
                 "composite-keys: UNEXPECTED error on %s — index NOT created; investigate (%s)",
                 table, exc,
             )
+            _record_composite_index_failure(conn, table, cols, exc)
 
 
 def _migrate_v11_composite_keys_down(conn: sqlite3.Connection) -> None:

--- a/scripts/lib/vnx_doctor_checks.py
+++ b/scripts/lib/vnx_doctor_checks.py
@@ -445,6 +445,68 @@ def check_incident_pressure(state_dir: Path) -> CheckResult:
 
 
 # ---------------------------------------------------------------------------
+# Check: ADR-007 composite UNIQUE index coverage
+# ---------------------------------------------------------------------------
+
+def check_composite_index_coverage(state_dir: Path) -> CheckResult:
+    """Validate ADR-007 composite UNIQUE index coverage (ux_<table>_pid).
+
+    Flags any ADR-007 target table that exists but lacks its ux_*_pid index
+    (absent, or shadowed by an index of the same name on a different table),
+    plus any durable failure markers recorded for unexpected migration errors
+    (OI-563). Under-enforcement is surfaced as WARN — indexes are a governance
+    hardening, not a data-loss condition.
+    """
+    db_path = state_dir / DB_FILENAME
+    if not db_path.exists():
+        return CheckResult(
+            name="composite_index_coverage",
+            status=FAIL,
+            message="Runtime coordination database not found",
+            details=[f"Expected: {db_path}"],
+        )
+
+    try:
+        with get_connection(state_dir) as conn:
+            from coordination_db import composite_index_audit
+
+            audit = composite_index_audit(conn)
+            missing = audit["missing"]
+            failures = audit["failures"]
+
+            if not missing:
+                return CheckResult(
+                    name="composite_index_coverage",
+                    status=PASS,
+                    message=(
+                        f"ADR-007 composite UNIQUE indexes present on "
+                        f"{audit['tables_checked']} table(s)"
+                    ),
+                )
+
+            details = [
+                f"Missing index: {m['table']}.{m['index']} on columns {m['columns']}"
+                for m in missing
+            ]
+            details.extend(
+                f"Unexpected failure on {f['table']} ({f['occurred_at']}): {f['error']}"
+                for f in failures
+            )
+            return CheckResult(
+                name="composite_index_coverage",
+                status=WARN,
+                message=f"{len(missing)} table(s) missing their ux_*_pid index",
+                details=details,
+            )
+    except Exception as exc:
+        return CheckResult(
+            name="composite_index_coverage",
+            status=FAIL,
+            message=f"Composite index coverage check error: {exc}",
+        )
+
+
+# ---------------------------------------------------------------------------
 # Check: tmux session profile consistency
 # ---------------------------------------------------------------------------
 

--- a/scripts/lib/vnx_doctor_runtime.py
+++ b/scripts/lib/vnx_doctor_runtime.py
@@ -38,6 +38,7 @@ from vnx_doctor_checks import (  # noqa: F401
     check_incident_pressure,
     check_tmux_profile,
     check_lease_dispatch_coherence,
+    check_composite_index_coverage,
     compute_recovery_preflight,
 )
 
@@ -105,6 +106,7 @@ def run_runtime_checks(state_dir: str | Path) -> DoctorReport:
 
     # Only run deeper checks if schema is available
     if report.checks[0].status != FAIL:
+        report.checks.append(check_composite_index_coverage(sd))
         report.checks.append(check_lease_health(sd))
         report.checks.append(check_queue_health(sd))
         report.checks.append(check_incident_pressure(sd))

--- a/scripts/quality_db_init.py
+++ b/scripts/quality_db_init.py
@@ -13,7 +13,7 @@ import sqlite3
 import shutil
 import sys
 from pathlib import Path
-from datetime import datetime
+from datetime import datetime, timezone
 from typing import Callable
 import json
 
@@ -1098,6 +1098,114 @@ _QI_COMPOSITE_KEYS: tuple[tuple[str, tuple[str, ...]], ...] = (
     ("dream_pattern_archives", ("project_id", "archive_id")),
 )
 
+# Durable record of tables whose ux_<table>_pid index could not be created due to
+# an UNEXPECTED (non-IntegrityError) sqlite3 error. user_version still advances
+# (the migration is non-destructive and non-aborting), so this marker — plus
+# composite_index_audit() — is what surfaces the under-enforcement (OI-563).
+_COMPOSITE_KEY_FAILURES_TABLE = "composite_key_failures"
+
+
+def _now_utc() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f") + "Z"
+
+
+def _record_composite_index_failure(
+    conn: sqlite3.Connection,
+    table: str,
+    cols: tuple[str, ...],
+    error: sqlite3.Error,
+) -> None:
+    """Durably record an unexpected composite UNIQUE index creation failure.
+
+    Upserts one row per table (latest error wins) into
+    ``composite_key_failures``. Best-effort by design: the migration stays
+    non-destructive even if the marker write itself fails — the original error
+    is still ERROR-logged by the caller. Stale rows for tables that later get
+    their index are filtered out by ``composite_index_audit``.
+    """
+    try:
+        conn.execute(
+            f"CREATE TABLE IF NOT EXISTS {_COMPOSITE_KEY_FAILURES_TABLE} ("
+            "table_name TEXT PRIMARY KEY, "
+            "index_name TEXT NOT NULL, "
+            "columns TEXT NOT NULL, "
+            "error TEXT NOT NULL, "
+            "occurred_at TEXT NOT NULL)"
+        )
+        conn.execute(
+            f"INSERT OR REPLACE INTO {_COMPOSITE_KEY_FAILURES_TABLE} "
+            "(table_name, index_name, columns, error, occurred_at) VALUES (?, ?, ?, ?, ?)",
+            (table, f"ux_{table}_pid", ", ".join(cols), str(error), _now_utc()),
+        )
+    except sqlite3.Error as exc:
+        log('ERROR', f'composite-keys: failed to record durable failure marker for {table} — {exc}')
+
+
+def composite_index_audit(conn: sqlite3.Connection) -> dict:
+    """Return ADR-007 composite UNIQUE index coverage for the quality DB.
+
+    A table counts as under-enforced when it exists in the schema but has no
+    ``ux_<table>_pid`` index attached to it — either absent, or shadowed by an
+    index of the same name on a different table (which ``CREATE UNIQUE INDEX IF
+    NOT EXISTS`` silently accepts as a no-op). Durable failure markers recorded
+    by ``_migrate_v27`` for unexpected per-table errors are surfaced for tables
+    still missing their index, so past under-enforcement stays visible even
+    after user_version has advanced (OI-563).
+
+    Returns:
+      {
+        "missing":  [{"table", "index", "columns"}, ...],
+        "failures": [{"table", "index", "columns", "error", "occurred_at"}, ...],
+        "tables_checked": int,
+      }
+    """
+    missing = []
+    tables_checked = 0
+    for table, cols in _QI_COMPOSITE_KEYS:
+        if not conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name=?", (table,)
+        ).fetchone():
+            continue
+        tables_checked += 1
+        index_name = f"ux_{table}_pid"
+        row = conn.execute(
+            "SELECT tbl_name FROM sqlite_master WHERE type='index' AND name=?",
+            (index_name,),
+        ).fetchone()
+        owner = None if row is None else (
+            row[0] if not isinstance(row, sqlite3.Row) else row["tbl_name"]
+        )
+        if owner != table:
+            missing.append({"table": table, "index": index_name, "columns": ", ".join(cols)})
+
+    failures = []
+    missing_tables = {m["table"] for m in missing}
+    try:
+        marker_rows = conn.execute(
+            f"SELECT table_name, index_name, columns, error, occurred_at "
+            f"FROM {_COMPOSITE_KEY_FAILURES_TABLE} ORDER BY occurred_at DESC"
+        ).fetchall()
+    except sqlite3.Error:
+        marker_rows = []
+    for row in marker_rows:
+        table_name = row[0] if not isinstance(row, sqlite3.Row) else row["table_name"]
+        if table_name not in missing_tables:
+            # Stale marker: the table has its index again — don't surface it.
+            continue
+        failures.append({
+            "table": table_name,
+            "index": row[1] if not isinstance(row, sqlite3.Row) else row["index_name"],
+            "columns": row[2] if not isinstance(row, sqlite3.Row) else row["columns"],
+            "error": row[3] if not isinstance(row, sqlite3.Row) else row["error"],
+            "occurred_at": row[4] if not isinstance(row, sqlite3.Row) else row["occurred_at"],
+        })
+
+    return {
+        "missing": missing,
+        "failures": failures,
+        "tables_checked": tables_checked,
+    }
+
 
 def _migrate_v27(conn: sqlite3.Connection) -> None:
     """V27: ADR-007 composite UNIQUE indexes over project_id (non-destructive).
@@ -1107,6 +1215,11 @@ def _migrate_v27(conn: sqlite3.Connection) -> None:
     try/except: a missing column or existing duplicate rows in a given table only
     skips that one table and logs a clear warning. The migration never aborts,
     never deletes rows, and never rewrites data.
+
+    An UNEXPECTED per-table error (non-IntegrityError) is ERROR-logged and
+    durably recorded via ``_record_composite_index_failure`` so the missing
+    index — which user_version still advances past — surfaces through
+    ``composite_index_audit()`` instead of being silently dropped (OI-563).
 
     The version stamp is advanced only after the best-effort pass, so re-runs
     are no-ops via ``IF NOT EXISTS``.
@@ -1138,8 +1251,10 @@ def _migrate_v27(conn: sqlite3.Connection) -> None:
             log('WARNING', f'composite-keys: skipped {table} — duplicate rows for {col_list}, dedup needed ({exc})')
         except sqlite3.Error as exc:
             # Unexpected (migration bug / bad column) — must NOT be swallowed as a data-violation
-            # skip. Surface at ERROR level so it is investigated; still do not abort the run.
+            # skip. Surface at ERROR level AND durably so it is investigated even though
+            # user_version advances; still do not abort the run.
             log('ERROR', f'composite-keys: UNEXPECTED error on {table} — index NOT created; investigate ({exc})')
+            _record_composite_index_failure(conn, table, cols, exc)
 
 
 def _migrate_v27_down(conn: sqlite3.Connection) -> None:

--- a/tests/test_adr007_composite_keys.py
+++ b/tests/test_adr007_composite_keys.py
@@ -407,3 +407,120 @@ class TestRcCompositeKeysDown:
         for table, _ in _RC_TABLES_AND_KEYS:
             assert not _rc_index_exists(conn, table)
         conn.close()
+
+
+# ---------------------------------------------------------------------------
+# OI-563: unexpected per-table error must be durably tracked (not just ERROR-logged)
+# ---------------------------------------------------------------------------
+
+class TestRcCompositeKeysUnexpectedError:
+    def test_unexpected_error_is_durably_tracked(self, tmp_path, caplog):
+        """An unexpected (non-IntegrityError) per-table error must leave a durable
+        marker — user_version advancing must not silently drop the missing index."""
+        db_path = tmp_path / "rc.db"
+        conn = _make_rc_with_project_id(db_path)
+        # A table whose name collides with the would-be index makes
+        # CREATE UNIQUE INDEX raise sqlite3.OperationalError (a sqlite3.Error,
+        # NOT an IntegrityError) — the unexpected-error path of the migration.
+        conn.execute("CREATE TABLE ux_incident_log_pid (x INTEGER)")
+        conn.commit()
+
+        with caplog.at_level(logging.ERROR, logger="coordination_db"):
+            schema_migration.apply_if_below(conn, 11, _migrate_v11_composite_keys)
+
+        # The migration still does not abort (existing non-destructive design).
+        assert schema_migration.get_user_version(conn) == 11
+        # The index on incident_log is genuinely missing (shadowed by a table).
+        assert not _rc_index_exists(conn, "incident_log")
+        # ...but the failure IS durably recorded.
+        failures = conn.execute(
+            "SELECT table_name, index_name, columns FROM composite_key_failures"
+        ).fetchall()
+        assert [(r[0], r[1]) for r in failures] == [("incident_log", "ux_incident_log_pid")]
+        conn.close()
+
+    def test_audit_surfaces_under_enforcement(self, tmp_path):
+        db_path = tmp_path / "rc.db"
+        conn = _make_rc_with_project_id(db_path)
+        conn.execute("CREATE TABLE ux_incident_log_pid (x INTEGER)")
+        conn.commit()
+
+        schema_migration.apply_if_below(conn, 11, _migrate_v11_composite_keys)
+
+        from coordination_db import composite_index_audit
+        audit = composite_index_audit(conn)
+        missing_tables = {m["table"] for m in audit["missing"]}
+        assert "incident_log" in missing_tables
+        # The unaffected tables still got their index.
+        assert "coordination_events" not in missing_tables
+        assert "intelligence_injections" not in missing_tables
+        # The durable marker is surfaced by the audit.
+        assert any(f["table"] == "incident_log" for f in audit["failures"])
+        conn.close()
+
+
+class TestRcCompositeKeysAudit:
+    def test_clean_db_has_no_missing_indexes(self, tmp_path):
+        db_path = tmp_path / "rc.db"
+        conn = _make_rc_with_project_id(db_path)
+        schema_migration.apply_if_below(conn, 11, _migrate_v11_composite_keys)
+
+        from coordination_db import composite_index_audit
+        audit = composite_index_audit(conn)
+        assert audit["missing"] == []
+        assert audit["tables_checked"] == 3
+        conn.close()
+
+    def test_detects_index_shadowed_on_wrong_table(self, tmp_path):
+        """IF NOT EXISTS silently no-ops when an index of the same name already
+        sits on a different table — the audit must catch that shadowed state."""
+        db_path = tmp_path / "rc.db"
+        conn = _make_rc_with_project_id(db_path)
+        conn.execute("CREATE TABLE other (x INTEGER)")
+        conn.execute("CREATE UNIQUE INDEX ux_coordination_events_pid ON other (x)")
+        conn.commit()
+
+        schema_migration.apply_if_below(conn, 11, _migrate_v11_composite_keys)
+
+        from coordination_db import composite_index_audit
+        audit = composite_index_audit(conn)
+        missing_tables = {m["table"] for m in audit["missing"]}
+        assert "coordination_events" in missing_tables
+        conn.close()
+
+
+# ---------------------------------------------------------------------------
+# OI-563 (QI mirror): unexpected per-table error must be durably tracked
+# ---------------------------------------------------------------------------
+
+class TestQiCompositeKeysUnexpectedError:
+    def test_unexpected_error_is_durably_tracked(self, tmp_path):
+        db_path = tmp_path / "qi.db"
+        conn = _make_qi_v26_with_project_id(db_path)
+        conn.execute("CREATE TABLE ux_success_patterns_pid (x INTEGER)")
+        conn.commit()
+
+        schema_migration.apply_if_below(conn, 27, qdi._migrate_v27)
+
+        assert schema_migration.get_user_version(conn) == 27
+        assert not _qi_index_exists(conn, "success_patterns")
+        failures = conn.execute(
+            "SELECT table_name, index_name FROM composite_key_failures"
+        ).fetchall()
+        assert [(r[0], r[1]) for r in failures] == [("success_patterns", "ux_success_patterns_pid")]
+        conn.close()
+
+    def test_audit_surfaces_under_enforcement(self, tmp_path):
+        db_path = tmp_path / "qi.db"
+        conn = _make_qi_v26_with_project_id(db_path)
+        conn.execute("CREATE TABLE ux_success_patterns_pid (x INTEGER)")
+        conn.commit()
+
+        schema_migration.apply_if_below(conn, 27, qdi._migrate_v27)
+
+        from quality_db_init import composite_index_audit as qi_audit
+        audit = qi_audit(conn)
+        missing_tables = {m["table"] for m in audit["missing"]}
+        assert "success_patterns" in missing_tables
+        assert "dispatch_experiments" not in missing_tables
+        conn.close()


### PR DESCRIPTION
## OI-563 — composite-keys migration: unexpected per-table error bumps user_version without durable tracking

### Defect (verified on main)
`_migrate_v11_composite_keys` (coordination_db.py) and `_migrate_v27` (quality_db_init.py) catch an unexpected per-table `sqlite3.Error` and ERROR-log it, but `apply_if_below` still advances `user_version`. A table whose `ux_*_pid` index could not be created was therefore never retried and left **no durable record**.

### Fix
1. **Durable failure marker**: the unexpected-error path now upserts a row into a `composite_key_failures` table (created idempotently) with table, index, columns, error, timestamp. Best-effort — the migration stays non-aborting/non-destructive.
2. **Fabric-audit check**: `composite_index_audit(conn)` reports any ADR-007 target table missing its `ux_*_pid` index (absent, or shadowed by an index of the same name on another table), plus the durable failure markers. Mirrored for both runtime_coordination.db and quality_intelligence.db.
3. **Operational surface**: new `vnx doctor` check `composite_index_coverage` surfaces the under-enforcement (WARN).

### Tests
- New tests in `tests/test_adr007_composite_keys.py` (6) exercise the unexpected-error path with a real OperationalError (a table name colliding with the index name) and the audit. All 6 fail on unmodified code (no marker table / audit absent) and pass after the fix.
- Related suites: **217 passed** (ADR-007, doctor runtime/strict/template/standalone, central quality bootstrap, wave4 contamination, doctor CLI, schema idempotency, project_id migration, worker_pid selfheal, quality tenant reconcile).

### Pre-existing failures (unrelated, reproduced on unmodified main)
- `tests/test_horizon_schema_migration_fix.py::test_pre27_store_migrates_to_horizon` (assert `_uv(db_path) < 27`, store bootstraps at v32)
- `tests/test_init_migrate_bootstrap.py::test_pool_default_db_path_honors_vnx_data_dir` (path-resolution assertion)

🤖 Generated with [Claude Code](https://claude.com/claude-code)