### PR TITLE
fix(init): install gate-obligation-runner launchd plist during vnx init (OI-917)

### DIFF
--- a/scripts/launchd/com.vnx.gate-obligation-runner.plist
+++ b/scripts/launchd/com.vnx.gate-obligation-runner.plist
@@ -10,28 +10,31 @@
     declaring gate=<name>: resolves the dispatch's PR and runs the declared
     gate via review_gate_manager, or records a loud not_executable outcome.
 
-    Replace __VNX_REPO_ROOT__ with the repo checkout path at install time
-    (same placeholder pattern as com.vnx.producer-freshness-monitor.plist):
-
-      sed "s|__VNX_REPO_ROOT__|$HOME/Development/vnx-orchestration|g" \
-        com.vnx.gate-obligation-runner.plist > ~/Library/LaunchAgents/
-      launchctl load -w ~/Library/LaunchAgents/com.vnx.gate-obligation-runner.plist
+    Installed automatically by vnx init for the VNX orchestration repo.
+    Also installable manually via reload_plist.sh:
+      bash scripts/launchd/reload_plist.sh com.vnx.gate-obligation-runner
 
     Exit 11 (obligations still pending) is captured into job_exits.ndjson by
     the producer-freshness monitor's launchd harvest; obligations pending
     longer than a day are flagged per gate key by the same monitor's
-    review_gate_obligations producer — a runner that dies cannot hide behind
-    silence.
+    review_gate_obligations producer.
   -->
   <key>ProgramArguments</key>
   <array>
     <string>/bin/bash</string>
     <string>-c</string>
-    <string>cd __VNX_REPO_ROOT__ &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
+    <string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>
   </array>
   <key>StartInterval</key>
   <integer>900</integer>
   <key>StandardOutPath</key><string>/tmp/vnx-gate-obligation-runner.log</string>
   <key>StandardErrorPath</key><string>/tmp/vnx-gate-obligation-runner.err</string>
+  <key>EnvironmentVariables</key>
+  <dict>
+    <key>VNX_HOME</key>
+    <string>${VNX_HOME}</string>
+    <key>PATH</key>
+    <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin</string>
+  </dict>
 </dict>
 </plist>

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -8,6 +8,7 @@ root CLAUDE.md, FEATURE_PLAN.md, and safety/idempotency semantics.
 import argparse
 import sys
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -439,3 +440,283 @@ class TestVnxInitAttestDelivery:
         assert workflow.read_text() == "# custom workflow content", (
             "Re-init must not clobber an existing workflow"
         )
+
+
+class TestGateObligationRunnerInstall:
+    """OI-917: gate-obligation-runner launchd plist installation.
+
+    The install function (_install_gate_obligation_runner) is tested directly
+    with fake engine roots; integration through vnx_init uses the real engine
+    root (which has the plist template) and mocks only Path.home + subprocess.
+    """
+
+    PLIST_NAME = "com.vnx.gate-obligation-runner"
+
+    # ------------------------------------------------------------------
+    # Direct function tests
+    # ------------------------------------------------------------------
+
+    def test_install_writes_plist_and_loads(self, tmp_path, monkeypatch):
+        from vnx_cli.commands import init_cmd
+
+        engine_root = tmp_path / "engine"
+        launchd_dir = engine_root / "scripts" / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / f"{self.PLIST_NAME}.plist").write_text(
+            '<?xml version="1.0"?><plist><dict>'
+            "<key>Label</key><string>com.vnx.gate-obligation-runner</string>"
+            "<key>ProgramArguments</key><array>"
+            "<string>/bin/bash</string><string>-c</string>"
+            "<string>cd ${VNX_HOME} &amp;&amp; exec python3 scripts/gate_obligation_runner.py</string>"
+            "</array>"
+            "</dict></plist>",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: engine_root,
+        )
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        launchctl_calls = []
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stderr = ""
+            if cmd == ["launchctl", "list"]:
+                m.stdout = f"{self.PLIST_NAME}\n"
+            else:
+                m.stdout = ""
+            launchctl_calls.append(cmd)
+            return m
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+        result = init_cmd._install_gate_obligation_runner(
+            str(engine_root)
+        )
+        assert result is True
+
+        # Plist written to fake LaunchAgents dir.
+        dest = (
+            fake_home / "Library" / "LaunchAgents"
+            / f"{self.PLIST_NAME}.plist"
+        )
+        assert dest.is_file(), (
+            f"Plist not written to {dest} — OI-917: runner was never installed"
+        )
+
+        content = dest.read_text(encoding="utf-8")
+        assert "${VNX_HOME}" not in content, (
+            "Placeholder must be substituted with the actual engine root path"
+        )
+        assert str(engine_root) in content, (
+            f"Plist must contain the engine root path {engine_root}"
+        )
+
+        # launchctl unload + load + list called.
+        cmds = [" ".join(c) for c in launchctl_calls]
+        assert any("unload" in c for c in cmds), "launchctl unload not called"
+        assert any("load" in c for c in cmds), "launchctl load not called"
+        assert any("list" in c for c in cmds), "launchctl list not called"
+
+    def test_install_returns_false_when_template_missing(self, tmp_path, monkeypatch):
+        from vnx_cli.commands import init_cmd
+
+        engine_root = tmp_path / "engine"
+        # No scripts/launchd/ directory at all.
+        engine_root.mkdir()
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: engine_root,
+        )
+
+        result = init_cmd._install_gate_obligation_runner(
+            str(engine_root)
+        )
+        assert result is False, (
+            "Must return False when plist template is absent — "
+            "non-VNX-orchestration projects should silently skip"
+        )
+
+    def test_install_raises_on_template_unreadable(self, tmp_path, monkeypatch):
+        from vnx_cli.commands import init_cmd
+        import stat
+
+        engine_root = tmp_path / "engine"
+        launchd_dir = engine_root / "scripts" / "launchd"
+        launchd_dir.mkdir(parents=True)
+        plist_path = launchd_dir / f"{self.PLIST_NAME}.plist"
+        plist_path.write_text("content", encoding="utf-8")
+        # Remove read permission.
+        plist_path.chmod(0o000)
+
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: engine_root,
+        )
+
+        # Restore permissions in teardown so tmp_path cleanup works.
+        try:
+            with pytest.raises((OSError, PermissionError)):
+                init_cmd._install_gate_obligation_runner(str(engine_root))
+        finally:
+            plist_path.chmod(0o644)
+
+    def test_install_raises_on_launchctl_load_failure(self, tmp_path, monkeypatch):
+        from vnx_cli.commands import init_cmd
+
+        engine_root = tmp_path / "engine"
+        launchd_dir = engine_root / "scripts" / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / f"{self.PLIST_NAME}.plist").write_text(
+            "mock plist with ${VNX_HOME}",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: engine_root,
+        )
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stderr = ""
+            m.stdout = ""
+            if "load" in cmd and "unload" not in cmd:
+                m.returncode = 1
+                m.stderr = "launchctl: service already loaded"
+            return m
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+        with pytest.raises(RuntimeError, match="launchctl load failed"):
+            init_cmd._install_gate_obligation_runner(str(engine_root))
+
+    def test_install_verify_warns_when_agent_not_in_list(self, tmp_path, monkeypatch, capsys):
+        from vnx_cli.commands import init_cmd
+
+        engine_root = tmp_path / "engine"
+        launchd_dir = engine_root / "scripts" / "launchd"
+        launchd_dir.mkdir(parents=True)
+        (launchd_dir / f"{self.PLIST_NAME}.plist").write_text(
+            "mock plist with ${VNX_HOME}",
+            encoding="utf-8",
+        )
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: engine_root,
+        )
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stderr = ""
+            m.stdout = ""  # launchctl list is empty
+            return m
+
+        monkeypatch.setattr(init_cmd.subprocess, "run", fake_run)
+
+        result = init_cmd._install_gate_obligation_runner(
+            str(engine_root)
+        )
+        assert result is True
+
+        out = capsys.readouterr().out
+        assert "warning" in out.lower(), (
+            "A load that produces no launchctl list entry must warn — OI-895"
+        )
+        assert self.PLIST_NAME in out
+
+    # ------------------------------------------------------------------
+    # Integration: vnx_init calls _install_gate_obligation_runner
+    # ------------------------------------------------------------------
+
+    def test_init_installs_runner_when_template_exists(self, tmp_path, monkeypatch):
+        """vnx_init in the VNX orchestration repo must install the
+        gate-obligation-runner launchd plist (OI-917 core fix).
+
+        Uses the real engine root (worktree) which has the plist template;
+        only mock Path.home() and subprocess.run to avoid touching the
+        real ~/Library/LaunchAgents/.
+        """
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        launchctl_calls = []
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            m.returncode = 0
+            m.stderr = ""
+            if cmd == ["launchctl", "list"]:
+                m.stdout = f"{self.PLIST_NAME}\n"
+            else:
+                m.stdout = ""
+            launchctl_calls.append(cmd)
+            return m
+
+        monkeypatch.setattr(
+            "vnx_cli.commands.init_cmd.subprocess.run",
+            fake_run,
+        )
+
+        rc = vnx_init(_args(tmp_path / "project"))
+        assert rc == 0
+
+        # Plist written to fake LaunchAgents dir.
+        dest = (
+            fake_home / "Library" / "LaunchAgents"
+            / f"{self.PLIST_NAME}.plist"
+        )
+        assert dest.is_file(), (
+            f"vnx init must install {self.PLIST_NAME}.plist — "
+            "OI-917: the runner was never installed"
+        )
+
+        content = dest.read_text(encoding="utf-8")
+        assert "${VNX_HOME}" not in content, (
+            "Placeholder must be substituted"
+        )
+
+        cmds = [" ".join(c) for c in launchctl_calls]
+        assert any("unload" in c for c in cmds), "launchctl unload not called"
+        assert any("load" in c for c in cmds), "launchctl load not called"
+
+    def test_init_continues_on_launchctl_failure(self, tmp_path, monkeypatch, capsys):
+        """If launchctl load fails, vnx_init must print a warning and
+        continue — the scaffold is still valid."""
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+        def fake_run(cmd, **kwargs):
+            m = MagicMock()
+            if "load" in cmd and "unload" not in cmd:
+                m.returncode = 1
+                m.stderr = "launchctl: service already loaded"
+                m.stdout = ""
+            else:
+                m.returncode = 0
+                m.stderr = ""
+                m.stdout = "com.vnx.gate-obligation-runner\n" if cmd == ["launchctl", "list"] else ""
+            return m
+
+        monkeypatch.setattr(
+            "vnx_cli.commands.init_cmd.subprocess.run",
+            fake_run,
+        )
+
+        rc = vnx_init(_args(tmp_path / "project"))
+        assert rc == 0, (
+            "launchctl failure must not abort init"
+        )
+        out = capsys.readouterr().out
+        assert "warning" in out.lower()
+        assert "gate-obligation-runner" in out

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -15,6 +15,7 @@ pin, root CLAUDE.md and FEATURE_PLAN.md via Jinja2 templates (default/minimal).
 
 import os
 import re
+import subprocess
 import sys
 import tempfile
 from pathlib import Path
@@ -722,6 +723,73 @@ def vnx_init(args) -> int:
         return 1
 
 
+def _install_gate_obligation_runner(vnx_home: str) -> bool:
+    """Install the gate-obligation-runner launchd plist (OI-917).
+
+    Reads the plist template from the engine root's scripts/launchd/ directory,
+    substitutes ``${VNX_HOME}`` with the resolved VNX home path, writes
+    atomically to ``~/Library/LaunchAgents/``, and loads via launchctl.
+
+    Returns True if the plist was installed or reloaded.
+    Returns False if the template does not exist (not a VNX orchestration repo
+    or central install — silently skip).
+
+    Raises RuntimeError if launchctl load fails (never silent).
+    Raises OSError if the template exists but is unreadable.
+    """
+    plist_name = "com.vnx.gate-obligation-runner"
+    template = _engine.engine_root() / "scripts" / "launchd" / f"{plist_name}.plist"
+    if not template.is_file():
+        return False
+
+    dest_dir = Path.home() / "Library" / "LaunchAgents"
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    dest = dest_dir / f"{plist_name}.plist"
+
+    content = template.read_text(encoding="utf-8")
+    content = content.replace("${VNX_HOME}", vnx_home)
+
+    fd, tmp_name = tempfile.mkstemp(dir=str(dest_dir), suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            fh.write(content)
+        os.replace(tmp_name, str(dest))
+    except Exception:
+        try:
+            os.unlink(tmp_name)
+        except OSError:
+            pass
+        raise
+
+    # Idempotent: unload any previously loaded instance before reloading.
+    subprocess.run(
+        ["launchctl", "unload", str(dest)], capture_output=True,
+    )
+    result = subprocess.run(
+        ["launchctl", "load", "-w", str(dest)],
+        capture_output=True, text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"launchctl load failed for {plist_name}: "
+            f"{result.stderr.strip() or result.stdout.strip()}"
+        )
+
+    # Verify the agent is registered.
+    verify = subprocess.run(
+        ["launchctl", "list"], capture_output=True, text=True,
+    )
+    if plist_name in (verify.stdout or ""):
+        print(f"  installed launchd agent: {plist_name}")
+    else:
+        print(
+            f"  warning: {plist_name} not found in launchctl list after load "
+            f"— check {dest}"
+        )
+
+    return True
+
+
 def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) -> int:
     """Scaffold body of vnx_init (split out so OSError refusals fail clean)."""
     # --- tracked, in-project config (tiny footprint) ----------------------
@@ -836,6 +904,16 @@ def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) ->
     print()
     print("Provisioning attestation gate workflow...")
     _provision_github_workflow(project_dir)
+
+    # --- OI-917: install gate-obligation-runner launchd agent -----------------
+    print()
+    print("Installing launchd agents...")
+    try:
+        installed = _install_gate_obligation_runner(str(_engine.engine_root()))
+        if not installed:
+            print("  skipped gate-obligation-runner (plist template not found)")
+    except (OSError, RuntimeError) as exc:
+        print(f"  warning: gate-obligation-runner install failed: {exc}")
 
     print()
     print(f"Runtime state: {data_root}")


### PR DESCRIPTION
## OI-917 — Gate-obligation-runner was never installed

### Defect

The gate-obligation-runner plist existed in the repo at `scripts/launchd/com.vnx.gate-obligation-runner.plist` but was never installed. `launchctl list | grep obligation` returned nothing, and `~/Library/LaunchAgents/` contained no `com.vnx.gate-obligation-runner.plist`.

**Consequence:** All 12 obligations remained `status=pending` with `pr_number=None`, including those for five already-merged PRs. The declared-gate enforcement from #1279 was hand-enforced by T0 running `bin/vnx gate <pr> --only codex`.

### Fix

1. **Convert plist placeholder** from `__VNX_REPO_ROOT__` to `${VNX_HOME}` — consistent with the conversation-analyzer, receipt-classifier, and `reload_plist.sh` patterns. Added `EnvironmentVariables` section.
2. **`_install_gate_obligation_runner()`** function in `init_cmd.py`: atomic write to `~/Library/LaunchAgents/`, `launchctl load -w`, and `launchctl list` verification (OI-895 lesson: verify, not just write).
3. **Called from `vnx init`** scaffold — installs the plist when the template exists under the engine root (VNX orchestration repo or central install), silently skips otherwise.
4. **launchctl failure is non-fatal** — prints warning but does not abort init.

### Verification

- 40 `test_cli_init.py` tests pass (including 7 new tests for the install function)
- 12 `test_gate_obligations.py` tests pass
- 10 `test_producer_freshness.py` tests pass

### What this does NOT fix

- The producer-freshness-monitor plist (`com.vnx.producer-freshness-monitor.plist`) has the same defect (`__VNX_REPO_ROOT__` placeholder, never installed). Deferred to a separate OI.
- The freshness monitor itself is currently silent (tripwire heartbeat >1560m). This PR does not address that — it only ensures the obligation runner is installed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)