### PR TITLE
fix(ci,tests): rejoin three OI-953 CI-sweep reds (build dep, recs global leak, ambient tenant)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -42,7 +42,10 @@ jobs:
           # nx.pagerank crashes on the missing numpy — measured 2026-08-02:
           # test_repo_map_provider_coverage.py (green on main) fails 2 tests with
           # networkx present, passes 11/11 without it.
-          pip install pytest pyyaml pytest-timeout jsonschema psutil watchdog hypothesis jinja2
+          # build is required by tests/test_wheel_build.py::test_wheel_builds
+          # (python -m build --wheel); without it that test fails in this image
+          # with "No module named build" (OI-953).
+          pip install pytest pyyaml pytest-timeout jsonschema psutil watchdog hypothesis jinja2 build
 
       - name: Prepare expected repo layout
         run: |

--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -103,7 +103,6 @@ tests/test_learning_loop_exception_handling.py  # OI-947: learning_loop.ensure_e
 tests/test_learning_loop_tz.py  # OI-947: learning_loop.ensure_env AttributeError, red on main too
 tests/test_litellm_agentic_runner.py
 tests/test_llm_decision_router.py
-tests/test_migrate_0022_preflight.py  # OI-953: misc independent red, confirmed red on main too
 tests/test_migrate_future_system.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_migrate_pool_seed.py  # OI-946: DB/migration precondition chain (init/migrate/track bootstrap) red on main too
 tests/test_observability_linkage.py
@@ -121,7 +120,6 @@ tests/test_pool_provider_mix_integration.py
 tests/test_pool_state_repo.py
 tests/test_pr10_provider_string_canon.py
 tests/test_pr2_requeue_clear_context.py
-tests/test_pr_recommendation_integration.py  # OI-953: misc independent red, confirmed red on main too
 tests/test_project_status_hook.py
 tests/test_provider_dispatch_contract_integration.py
 tests/test_provider_dispatch_deepseek_harness.py
@@ -195,7 +193,6 @@ tests/test_wave4_write_guard.py  # OI-950: wave4 central-install assumes GH Acti
 tests/test_wave7_deepseek_smoke.py
 tests/test_wave7_fixes.py
 tests/test_week_1_skills.py
-tests/test_wheel_build.py  # OI-953: misc independent red, confirmed red on main too
 tests/test_wheel_install.py
 tests/test_wiring_completeness.py
 tests/test_worker_heartbeat.py

--- a/tests/test_migrate_0022_preflight.py
+++ b/tests/test_migrate_0022_preflight.py
@@ -28,6 +28,23 @@ if str(_SCRIPTS) not in sys.path:
 import schema_migration
 
 
+@pytest.fixture(autouse=True)
+def _clear_ambient_project_id(monkeypatch):
+    """OI-953: keep the fail-closed tests hermetic against an ambient tenant.
+
+    tests/test_link_sessions_dispatches_cleanup.py does
+    ``os.environ.setdefault("VNX_PROJECT_ID", "vnx-dev")`` at module import and
+    never restores it, so when that module runs first in the CI sweep the
+    variable leaks for the rest of the session. run()'s ADR-007 repair then
+    resolves that ambient tenant, adds project_id to the v9 fixture, the
+    preflight passes, and run() completes instead of raising — the OI-953
+    "DID NOT RAISE RuntimeError" red. Clearing it here makes every test in this
+    module deterministically exercise the fail-closed path (no resolvable tenant
+    → RuntimeError).
+    """
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+
 FIXTURE_ROADMAP = """\
 # VNX Master Roadmap — fixture
 

--- a/tests/test_pr_queue_integration.py
+++ b/tests/test_pr_queue_integration.py
@@ -20,6 +20,15 @@ sys.path.insert(0, str(SCRIPTS_DIR))
 from pr_queue_manager import PRQueueManager
 from generate_t0_recommendations import RecommendationEngine
 
+# Capture the pristine module-global paths at import time, before any clean_state
+# fixture can reassign them. RecommendationEngine reads these globals at call
+# time, so a leak would make it read a foreign pr_queue_state.yaml for the rest
+# of the session. test_clean_state_does_not_leak_recs_module_globals asserts the
+# fixture restores them (OI-953).
+import generate_t0_recommendations as _recs
+_RECS_STATE_DIR_AT_IMPORT = _recs.STATE_DIR
+_RECS_PR_QUEUE_STATE_FILE_AT_IMPORT = _recs.PR_QUEUE_STATE_FILE
+
 
 @pytest.fixture
 def clean_state(tmp_path, monkeypatch):
@@ -36,22 +45,29 @@ def clean_state(tmp_path, monkeypatch):
     monkeypatch.setenv("VNX_STATE_SIMPLIFICATION_ROLLBACK", "0")
 
     import generate_t0_recommendations as recs
-    recs.VNX_ROOT = Path(os.environ.get("VNX_HOME", tmp_path))
-    recs.STATE_DIR = state_dir
-    recs.DISPATCHES_DIR = tmp_path / "dispatches"
-    recs.LEGACY_STATE_DIR = recs.VNX_ROOT / "state"
-    recs.LEGACY_DISPATCHES_DIR = recs.VNX_ROOT / "dispatches"
-    recs.RECEIPTS_FILE = state_dir / "t0_receipts.ndjson"
-    recs.RECOMMENDATIONS_FILE = state_dir / "t0_recommendations.json"
-    recs.ACTIVE_CONFLICTS_FILE = state_dir / "active_conflicts.json"
-    recs.PR_QUEUE_STATE_FILE = state_dir / "pr_queue_state.yaml"
-    recs.OPEN_ITEMS_DIGEST_FILE = state_dir / "open_items_digest.json"
-    recs.STAGING_SEEN_FILE = state_dir / "staging_seen.json"
-    recs.LEGACY_RECEIPTS_FILE = recs.LEGACY_STATE_DIR / "t0_receipts.ndjson"
-    recs.LEGACY_RECOMMENDATIONS_FILE = recs.LEGACY_STATE_DIR / "t0_recommendations.json"
-    recs.LEGACY_PR_QUEUE_STATE_FILE = recs.LEGACY_STATE_DIR / "pr_queue_state.yaml"
-    recs.LEGACY_OPEN_ITEMS_DIGEST_FILE = recs.LEGACY_STATE_DIR / "open_items_digest.json"
-    recs.LEGACY_STAGING_SEEN_FILE = recs.LEGACY_STATE_DIR / "staging_seen.json"
+    # OI-953: scope the module-global reassignments to this test via monkeypatch.
+    # A bare assignment persists on generate_t0_recommendations for the rest of
+    # the session, so any later module (test_pr_recommendation_integration.py)
+    # that instantiates RecommendationEngine reads the LAST clean_state tmp dir's
+    # pr_queue_state.yaml instead of its own — the OI-953 "assert 'E2E Test
+    # Feature' == 'Test Feature'" red when test_pr_queue runs first in the CI
+    # sweep. monkeypatch restores each global after the test.
+    monkeypatch.setattr(recs, "VNX_ROOT", Path(os.environ.get("VNX_HOME", tmp_path)))
+    monkeypatch.setattr(recs, "STATE_DIR", state_dir)
+    monkeypatch.setattr(recs, "DISPATCHES_DIR", tmp_path / "dispatches")
+    monkeypatch.setattr(recs, "LEGACY_STATE_DIR", recs.VNX_ROOT / "state")
+    monkeypatch.setattr(recs, "LEGACY_DISPATCHES_DIR", recs.VNX_ROOT / "dispatches")
+    monkeypatch.setattr(recs, "RECEIPTS_FILE", state_dir / "t0_receipts.ndjson")
+    monkeypatch.setattr(recs, "RECOMMENDATIONS_FILE", state_dir / "t0_recommendations.json")
+    monkeypatch.setattr(recs, "ACTIVE_CONFLICTS_FILE", state_dir / "active_conflicts.json")
+    monkeypatch.setattr(recs, "PR_QUEUE_STATE_FILE", state_dir / "pr_queue_state.yaml")
+    monkeypatch.setattr(recs, "OPEN_ITEMS_DIGEST_FILE", state_dir / "open_items_digest.json")
+    monkeypatch.setattr(recs, "STAGING_SEEN_FILE", state_dir / "staging_seen.json")
+    monkeypatch.setattr(recs, "LEGACY_RECEIPTS_FILE", recs.LEGACY_STATE_DIR / "t0_receipts.ndjson")
+    monkeypatch.setattr(recs, "LEGACY_RECOMMENDATIONS_FILE", recs.LEGACY_STATE_DIR / "t0_recommendations.json")
+    monkeypatch.setattr(recs, "LEGACY_PR_QUEUE_STATE_FILE", recs.LEGACY_STATE_DIR / "pr_queue_state.yaml")
+    monkeypatch.setattr(recs, "LEGACY_OPEN_ITEMS_DIGEST_FILE", recs.LEGACY_STATE_DIR / "open_items_digest.json")
+    monkeypatch.setattr(recs, "LEGACY_STAGING_SEEN_FILE", recs.LEGACY_STATE_DIR / "staging_seen.json")
 
     # Clean up test files
     test_files = [
@@ -696,6 +712,31 @@ class TestWorkflowIntegration:
                 dispatch_file = staging_dir / f"{dispatch_id}.md"
                 if dispatch_file.exists():
                     dispatch_file.unlink()
+
+
+def test_clean_state_does_not_leak_recs_module_globals():
+    """OI-953 regression: clean_state's generate_t0_recommendations module-global
+    reassignments must be scoped to the fixture.
+
+    Before the monkeypatch fix, the last clean_state test left STATE_DIR and
+    PR_QUEUE_STATE_FILE pointing at its tmp dir for the rest of the session.
+    test_pr_recommendation_integration.py (which runs after this file in the CI
+    sweep, and whose RecommendationEngine reads those globals at call time) then
+    read the stale 'E2E Test Feature' queue left here — the OI-953
+    "assert 'E2E Test Feature' == 'Test Feature'" red. This test runs last in
+    this file (definition order), so every clean_state test has executed and any
+    leak would already have happened.
+    """
+    import generate_t0_recommendations as recs
+
+    assert recs.STATE_DIR == _RECS_STATE_DIR_AT_IMPORT, (
+        f"recs.STATE_DIR leaked to {recs.STATE_DIR!s}; "
+        f"expected it restored to the import-time value {_RECS_STATE_DIR_AT_IMPORT!s}"
+    )
+    assert recs.PR_QUEUE_STATE_FILE == _RECS_PR_QUEUE_STATE_FILE_AT_IMPORT, (
+        "recs.PR_QUEUE_STATE_FILE leaked out of the import-time isolation tree; "
+        "a later RecommendationEngine() would read a foreign, stale queue state"
+    )
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Closes OI-953.

Three independent CI-sweep reds repaired so the files rejoin the sweep:

1. **`tests/test_wheel_build.py`** — CI image lacked the `build` package (profile-a pip install). Added `build` to `.github/workflows/vnx-ci.yml`. Verified red in a build-less venv (`No module named build`), green once installed.

2. **`tests/test_pr_recommendation_integration.py`** — order/load-dependent failure. `tests/test_pr_queue_integration.py`'s `clean_state` fixture permanently reassigned `generate_t0_recommendations` module globals; when it runs first in the sweep, a later `RecommendationEngine` reads the stale `E2E Test Feature` queue (the OI-953 fixture-title mismatch). Scoped the reassignments with `monkeypatch.setattr` and added a regression test proving no leak.

3. **`tests/test_migrate_0022_preflight.py::test_run_raises_on_v9_schema`** — DID-NOT-RAISE was real: `tests/test_link_sessions_dispatches_cleanup.py` leaks `VNX_PROJECT_ID=vnx-dev` at module import; the ambient tenant lets run()'s ADR-007 repair add `project_id`, so the preflight passes instead of raising. Cleared `VNX_PROJECT_ID` per test so the fail-closed path is exercised deterministically.

Removed all three OI-953 entries from `scripts/ci/test_exclusions.txt`.

All three files verified green in the CI alphabetical order (`40 passed` in the combined composition), plus a regression test that is red on the old fixture and green on the fixed one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)