### PR TITLE
refactor(provenance): rename chain_status 'complete' -> 'receipt_and_commit', remove dead has_pr/has_fp

### DIFF
--- a/schemas/runtime_coordination_v6.sql
+++ b/schemas/runtime_coordination_v6.sql
@@ -5,7 +5,7 @@
 --
 -- Design notes:
 --   - provenance_registry tracks the bidirectional chain per dispatch
---   - Chain status: complete | incomplete | broken
+--   - Chain status: receipt_and_commit | incomplete | broken
 --   - Gaps stored as JSON array for flexible gap type tracking
 --   - One row per dispatch_id (dispatch is the provenance anchor)
 --
@@ -24,8 +24,10 @@ PRAGMA foreign_keys = ON;
 -- One row per dispatch_id — updated as links are discovered.
 --
 -- Chain status values:
---   complete   — all links (dispatch -> receipt -> commit -> PR) present and valid
---   incomplete — one or more links missing, no contradictions
+--   receipt_and_commit — receipt plus commit link present and valid (the minimum
+--                        chain that can be detected from stored data alone; a PR
+--                        link is not required for this status)
+--   incomplete         — one or more links missing, no contradictions
 --   broken     — a link contradicts another (e.g., receipt points to wrong dispatch)
 --
 -- Invariants:

--- a/scripts/lib/coordination_db.py
+++ b/scripts/lib/coordination_db.py
@@ -429,6 +429,25 @@ def _migrate_v11_composite_keys_down(conn: sqlite3.Connection) -> None:
             logger.warning("composite-keys: failed to drop %s — %s", index_name, exc)
 
 
+def _migrate_chain_status_complete_rename(conn: sqlite3.Connection) -> None:
+    """OI-830: Rename chain_status 'complete' -> 'receipt_and_commit' in provenance_registry.
+
+    Idempotent: after the first run, no rows match the WHERE clause and the
+    statement is a no-op. Only touches rows that actually have the old value.
+    The provenance_registry table may not exist yet on fresh installs — skip
+    silently when it's absent.
+    """
+    if not conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='provenance_registry'"
+    ).fetchone():
+        return
+    conn.execute(
+        "UPDATE provenance_registry SET chain_status = 'receipt_and_commit' "
+        "WHERE chain_status = 'complete'"
+    )
+    conn.commit()
+
+
 def _rc_project_id_present(conn: sqlite3.Connection) -> bool:
     """Return True if at least one ADR-007 target table exists and has project_id."""
     for table, _ in _RC_COMPOSITE_KEYS:
@@ -483,6 +502,10 @@ def init_schema(state_dir: str | Path, schema_sql_path: Optional[Path] = None) -
         # will apply V11 after adding the column.
         if _rc_project_id_present(conn):
             schema_migration.apply_if_below(conn, 11, _migrate_v11_composite_keys)
+
+        # OI-830: rename chain_status value 'complete' -> 'receipt_and_commit'.
+        # Idempotent — after the first run no rows match the WHERE clause.
+        _migrate_chain_status_complete_rename(conn)
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/receipt_provenance.py
+++ b/scripts/lib/receipt_provenance.py
@@ -52,7 +52,7 @@ GAP_MISSING_RECEIPT = "missing_receipt"
 GAP_BROKEN_CHAIN = "broken_chain"
 GAP_CMD_ID_FALLBACK = "cmd_id_fallback"
 
-CHAIN_STATUS_COMPLETE = "complete"
+CHAIN_STATUS_COMPLETE = "receipt_and_commit"
 CHAIN_STATUS_INCOMPLETE = "incomplete"
 CHAIN_STATUS_BROKEN = "broken"
 
@@ -89,7 +89,7 @@ class ProvenanceValidation:
     trace_token: Optional[str]
     pr_number: Optional[int]
     feature_plan_pr: Optional[str]
-    chain_status: str  # complete | incomplete | broken
+    chain_status: str  # receipt_and_commit | incomplete | broken
     gaps: List[ProvenanceGap] = field(default_factory=list)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -669,7 +669,7 @@ def reconcile_commit_provenance(
     and register each commit's SHA against its dispatch_id in the provenance_registry.
 
     This is the merge-side half of the chain (B1 wrote dispatch_id+receipt_id at append; this writes
-    commit_sha so chain_status can reach 'complete'). Read-git + upsert-registry; best-effort — git
+    commit_sha so chain_status can reach 'receipt_and_commit'). Read-git + upsert-registry; best-effort — git
     errors yield ``{scanned: 0, linked: 0}``. Idempotent: register_provenance_link upserts per dispatch_id.
 
     D2 extension: commits that carry a PR number (``(#NNN)``) and resolve to a dispatch with a
@@ -945,8 +945,6 @@ def _calculate_chain_status(
     """Calculate chain status from merged provenance fields."""
     has_receipt = bool(merged.get("receipt_id"))
     has_commit = bool(merged.get("commit_sha"))
-    has_pr = merged.get("pr_number") is not None
-    has_fp = bool(merged.get("feature_plan_pr"))
 
     # Check for broken chains (contradictions in gaps)
     if gaps:
@@ -1171,7 +1169,7 @@ def batch_provenance_summary(
     Returns aggregate statistics and per-dispatch details.
     """
     summaries = []
-    counts = {"complete": 0, "incomplete": 0, "broken": 0}
+    counts = {"receipt_and_commit": 0, "incomplete": 0, "broken": 0}
 
     for did in dispatch_ids:
         s = provenance_summary_for_dispatch(did, receipts_path, conn)

--- a/tests/test_backfill_receipt_id.py
+++ b/tests/test_backfill_receipt_id.py
@@ -329,7 +329,7 @@ class TestApplyBackfill:
 
     def test_recalculates_chain_status_to_complete(self, tmp_path):
         """When receipt_id is filled AND commit_sha already exists,
-        chain_status must flip from 'incomplete' to 'complete'."""
+        chain_status must flip from 'incomplete' to 'receipt_and_commit'."""
         conn = _mk_db(tmp_path)
         _seed_registry_row(
             conn, "DISP-C", receipt_id=None, commit_sha="abc123",

--- a/tests/test_provenance_registry_population.py
+++ b/tests/test_provenance_registry_population.py
@@ -20,7 +20,7 @@ REPO = Path(__file__).resolve().parent.parent
 sys.path.insert(0, str(REPO / "scripts" / "lib"))
 
 from append_receipt_internals import enrichment  # noqa: E402
-from receipt_provenance import reconcile_commit_provenance  # noqa: E402
+from receipt_provenance import CHAIN_STATUS_COMPLETE, reconcile_commit_provenance  # noqa: E402
 
 _REGISTRY_SCHEMA = """
 CREATE TABLE provenance_registry (
@@ -180,7 +180,7 @@ def test_real_receipt_id_takes_priority_over_synthetic_fallback(tmp_path):
 def test_receipt_id_fallback_lets_chain_reach_complete(tmp_path):
     """End-to-end: a lane-synthesized receipt (no run_id/task_id) registers
     with the synthetic fallback, and once the merge-side commit scan fills
-    commit_sha, chain_status reaches 'complete' -- unreachable before this
+    commit_sha, chain_status reaches 'receipt_and_commit' -- unreachable before this
     fix because has_receipt could never be True for such a dispatch."""
     sd = _state_dir(tmp_path)
     dispatch_id = "20260729-seam3-complete"
@@ -202,7 +202,7 @@ def test_receipt_id_fallback_lets_chain_reach_complete(tmp_path):
     assert row is not None
     assert row[1] == f"synthetic:{dispatch_id}:subprocess_completion"
     assert row[2] is not None
-    assert row[0] == "complete"
+    assert row[0] == CHAIN_STATUS_COMPLETE
 
 
 def _git_repo_with_commit(tmp_path, body: str) -> Path:

--- a/tests/test_receipt_provenance.py
+++ b/tests/test_receipt_provenance.py
@@ -1469,3 +1469,68 @@ class TestResolveDispatchProjectIdCompositeSafety:
 
         assert receipt_provenance._resolve_dispatch_project_id(conn, "dispatch-x") is None
         conn.close()
+
+
+# ============================================================================
+# OI-830: chain_status rename verification
+# ============================================================================
+
+class TestChainStatusRename:
+    """Verify the old 'complete' value is never produced and the new
+    'receipt_and_commit' value is produced in its place."""
+
+    def test_old_value_not_produced_by_validate(self):
+        """validate_receipt_provenance never returns 'complete' as chain_status."""
+        receipt = _make_receipt(
+            trace_token="Dispatch-ID: 20260329-180606-test-task-B",
+            feature_plan_pr="PR-2",
+        )
+        validation = validate_receipt_provenance(receipt)
+        assert validation.chain_status != "complete"
+        assert validation.chain_status == CHAIN_STATUS_COMPLETE
+        assert validation.chain_status == "receipt_and_commit"
+
+    def test_old_value_not_produced_by_calculate(self):
+        """_calculate_chain_status never returns 'complete'."""
+        from receipt_provenance import _calculate_chain_status
+
+        fields = {"receipt_id": "run-001", "commit_sha": "abc123"}
+        status = _calculate_chain_status(fields)
+        assert status != "complete"
+        assert status == CHAIN_STATUS_COMPLETE
+        assert status == "receipt_and_commit"
+
+    def test_old_value_not_produced_by_register(self, conn):
+        """register_provenance_link never sets chain_status to 'complete'."""
+        link = register_provenance_link(
+            conn,
+            dispatch_id="20260804-oi830-register-verify",
+            receipt_id="run-oi830",
+            commit_sha="sha-oi830",
+        )
+        conn.commit()
+        assert link.chain_status != "complete"
+        assert link.chain_status == CHAIN_STATUS_COMPLETE
+        assert link.chain_status == "receipt_and_commit"
+
+    def test_old_value_not_produced_by_batch_summary(self, receipts_path):
+        """batch_provenance_summary never counts 'complete' category."""
+        receipts = [
+            _make_receipt(
+                dispatch_id="DISP-OI830-A",
+                trace_token="Dispatch-ID: DISP-OI830-A",
+                feature_plan_pr="PR-2",
+            ),
+        ]
+        _write_receipts(receipts_path, receipts)
+        batch = batch_provenance_summary(["DISP-OI830-A"], receipts_path)
+        assert "complete" not in batch["chain_status_counts"]
+
+    def test_has_pr_has_fp_do_not_exist(self):
+        """The dead variables has_pr and has_fp are removed from the module."""
+        import inspect
+        from receipt_provenance import _calculate_chain_status
+
+        source = inspect.getsource(_calculate_chain_status)
+        assert "has_pr" not in source
+        assert "has_fp" not in source


### PR DESCRIPTION
## OI-830: chain_status='complete' krijgt een eerlijke naam

### Wat er aan de hand was

_calculate_chain_status berekende has_pr en has_fp maar gebruikte ze nooit. De returnregel checkte alleen has_receipt and has_commit. Gevolg: chain_status='complete' betekende "receipt plus commit", terwijl de naam "volledige keten" suggereerde.

Gemeten 2026-07-29: 56 rijen 'complete' van 536, terwijl pr_number in 0 van 536 rijen gevuld was. Alle 56 waren dus compleet zonder PR-koppeling.

### Wat deze PR doet

1. Hernoemt CHAIN_STATUS_COMPLETE van "complete" naar "receipt_and_commit"
2. Verwijdert de dode has_pr en has_fp variabelen
3. Migreert alle 56 bestaande rijen in provenance_registry via een idempotente data-migratie in init_schema
4. Werkt ALLE consumenten bij: schema-comments, docstrings, batch_provenance_summary counts dict
5. Voegt 5 verificatietests toe die bewijzen dat de oude waarde nergens meer geproduceerd wordt

### Wat NIET verandert

De semantiek van de voorwaarde is onveranderd: receipt_id + commit_sha. Dezelfde 56 rijen, dezelfde voorwaarde. De statusvraag (moet pr_number deel uitmaken van 'compleet'?) is voor een volgende ronde.

### Verificatie

- 157 provenance-tests groen (3 gedeselecteerd: pre-existing env-var leak)
- Grep op "complete" in chain-status-context: 0 treffers
- Grep op has_pr/has_fp in _calculate_chain_status: 0 treffers

### Open item voor de volgende ronde

De tussenstatus die hoort tussen "receipt_and_commit" en een echte volledige keten zou "receipt_commit_no_pr" of "awaiting_pr" kunnen heten. Het voordeel van "awaiting_pr" is dat het de richting aangeeft: deze dispatch is klaar om gemerged te worden, de PR is alleen nog niet geschreven. Die naam voorkomt dat iemand denkt dat er een fout is. Maar de operator beslist.

Dispatch-ID: 20260804-104500-chainstatus-eerlijke-naam

🤖 Generated with [Claude Code](https://claude.com/claude-code)
