### PR TITLE
fix(tests): disarm time-bomb in test_attest_override — absolute timestamps vervangen door relatieve offsets

### DIFF
--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -481,6 +481,13 @@ class TestBudgetEnforcement:
     def test_write_override_record_refuses_when_exhausted(self, ephemeral_key_dir, monkeypatch):
         """write_override_record enforces the budget itself (finding 4)."""
         monkeypatch.setenv("VNX_ATTEST_OVERRIDE_BUDGET", "1")
+
+        # Timestamps relative to now — both stay inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees them.
+        now = datetime.now(timezone.utc)
+        ts_first = (now - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ts_second = (now - timedelta(days=1)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -491,7 +498,7 @@ class TestBudgetEnforcement:
             write_override_record(
                 content_key=ck_a, reason="first", dispatch_id="D-1",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts_first,
                 key_path=ephemeral_key_dir["key_path"], repo_root=repo,
                 allowed_signers=ephemeral_key_dir["allowed_signers"],
             )
@@ -502,7 +509,7 @@ class TestBudgetEnforcement:
                 write_override_record(
                     content_key=ck_b, reason="second", dispatch_id="D-2",
                     signer_identity=ephemeral_key_dir["identity"],
-                    timestamp="2026-07-05T11:00:00Z",
+                    timestamp=ts_second,
                     key_path=ephemeral_key_dir["key_path"], repo_root=repo,
                     allowed_signers=ephemeral_key_dir["allowed_signers"],
                 )
@@ -657,6 +664,13 @@ class TestVerifyPRWithOverride:
         """A validly-signed override past the rolling budget is REJECTED by the gate (finding 3)."""
         from attest_override import build_override_manifest
         from attestation import sign_manifest
+
+        # Timestamps relative to now — both stay inside the 30-day OVERRIDE_WINDOW
+        # regardless of the wall-clock date, so the test cannot become a time bomb.
+        now = datetime.now(timezone.utc)
+        ts_current = (now - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ts_older = (now - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -668,7 +682,7 @@ class TestVerifyPRWithOverride:
             write_override_record(
                 content_key=ck, reason="current", dispatch_id="D-cur",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T11:00:00Z",
+                timestamp=ts_current,
                 key_path=ephemeral_key_dir["key_path"], repo_root=repo,
                 allowed_signers=ephemeral_key_dir["allowed_signers"],
             )
@@ -677,7 +691,7 @@ class TestVerifyPRWithOverride:
             m2 = build_override_manifest(
                 content_key="other-key", reason="older override",
                 dispatch_id="D-old", signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T09:00:00Z",
+                timestamp=ts_older,
             )
             append_chained_entry(trail, sign_manifest(m2, ephemeral_key_dir["key_path"]))
             # Budget of 1 — the gate must reject even a validly-signed override.


### PR DESCRIPTION
## Wat er aan de hand was

`main` stond rood sinds 09:10 UTC vandaag. `tests/test_attest_override.py::TestVerifyPRWithOverride::test_override_past_budget_rejected_by_gate` faalde omdat de absolute tijdstempels `2026-07-05T11:00:00Z` en `2026-07-05T09:00:00Z` niet meer binnen het rollende 30-dagen-venster vielen. De oudste (`09:00:00Z`) overschreed exact om 09:00 UTC de grens, waardoor de override-count van 2 naar 1 zakte en niet meer boven budget=1 uitkwam.

**Geen merge-regressie.** Vier PR's landden vlak voor de fout (#1377, #1379, #1382, #1383) en geen van vier raakt attest/override/budget-code.

## Wat deze PR doet

- **`test_override_past_budget_rejected_by_gate`**: tijdstempels worden nu berekend als `datetime.now(timezone.utc) - timedelta(days=3)` en `... - timedelta(days=5)`, zodat beide gegarandeerd binnen het 30-dagen-venster vallen.
- **`test_write_override_record_refuses_when_exhausted`**: zelfde fix (preventief — deze zou op 5 augustus om 10:00 UTC zijn gaan falen).

Beide tests behouden exact dezelfde asserties. Geen verzwakking.

## Sweep-resultaat

Volledige audit van `scripts/lib/` op venster/timedelta/drempel-consumenten:

| Module | Window | Tests | Bom? |
|---|---|---|---|
| `attest_override.py` | 30d OVERRIDE_WINDOW | `test_attest_override.py` | ✅ Gefixt |
| `contract_invalid_window.py` | 14d staleness | `test_contract_invalid_window.py` | ❌ Veilig (gebruikt `now=_NOW`) |
| `outcome_signals.py` | 14d RECENCY_WINDOW | `test_outcome_signals.py`, `test_context_resume_certification.py` | ❌ Veilig (gebruikt `cutoff=NOW`) |
| `recommendation_tracker.py` | 7d outcome window | `test_recommendation_tracker.py` | ❌ Veilig (relatieve timestamps) |
| `f57_insights_reader.py` | variabele window | `test_f57_insights_reader.py` | ❌ Veilig (relatieve timestamps) |

Geen andere tijd-bommen gevonden.

## Verificatie

- **Rood eerst**: bevestigd — 1 faler in de suite
- **Groen na fix**: 29/29 passed
- **Tijdreis-toets**: tests slagen met klok bevroren op september **2126** (100 jaar vooruit)
- **Bug-reintroductie**: met budgetcontrole uitgeschakeld faalt de test met `exit_code == 0 != 1` — hij meet wat hij claimt

🤖 Generated with [Claude Code](https://claude.com/claude-code)