### PR TITLE
fix(dispatch): guard git ops against the main checkout during a dispatch (OI-975)

### DIFF
--- a/scripts/lib/chain_origin_anchor.py
+++ b/scripts/lib/chain_origin_anchor.py
@@ -810,6 +810,13 @@ def _commit_and_push_anchor(
 
     branch_name = _seal_branch_name(identity, epoch)
 
+    # OI-975: ``git checkout -B <branch>`` creates a branch and switches to it.
+    # In a dispatch context that must happen inside the dispatch worktree, never
+    # on the main checkout — otherwise the seal parks the operator's HEAD on a
+    # chain-origin branch. Outside a dispatch context this guard is a no-op.
+    from git_target_guard import guard_git_target  # type: ignore[import]
+    project_root = guard_git_target(project_root)
+
     _git_run_checked(project_root, "checkout", "-B", branch_name)
     _git_run_checked(project_root, "add", str(ANCHOR_REL_PATH))
     _git_run_checked(

--- a/scripts/lib/dispatch_govern.py
+++ b/scripts/lib/dispatch_govern.py
@@ -749,6 +749,23 @@ def _run_worktree_git(spec: GovernSpec, args: list, timeout: float) -> Optional[
     """
     if not spec.worktree_path:
         raise _NoWorktreeError(spec.dispatch_id)
+    # OI-975: the worktree path itself must not resolve to the main checkout.
+    # A presence check alone is not enough — a bug that sets
+    # spec.worktree_path to the main checkout would otherwise pass the
+    # OI-1008 guard and report/act on the operator's checkout.
+    try:
+        from git_target_guard import (  # type: ignore[import]
+            DispatchTargetsMainCheckoutError,
+            guard_git_target,
+        )
+        guard_git_target(spec.worktree_path, dispatch_id=spec.dispatch_id)
+    except DispatchTargetsMainCheckoutError:
+        logger.error(
+            "govern._run_worktree_git: refusing git %s for dispatch %s — "
+            "worktree_path %s resolves to the main checkout (OI-975)",
+            args, spec.dispatch_id, spec.worktree_path,
+        )
+        return None
     try:
         result = subprocess.run(
             ["git", *args],

--- a/scripts/lib/git_target_guard.py
+++ b/scripts/lib/git_target_guard.py
@@ -1,0 +1,160 @@
+"""git_target_guard.py — refuse dispatch-context git operations that target the main checkout (OI-975).
+
+A dispatch must operate exclusively inside its own ephemeral worktree. A git
+call that resolves its target to the MAIN checkout (the operator's checkout)
+instead of the dispatch worktree can move the operator's HEAD onto a
+``dispatch/<id>`` / PR branch without the operator asking. A branch switch
+under the operator's hands invalidates every measurement running against the
+main checkout, and the uncommitted work the main checkout carries is at risk
+of being carried onto the wrong branch.
+
+Two failure modes are caught here:
+
+1. A dispatch-context git call with NO explicit target path inherits the
+   dispatcher process's cwd, which is the main checkout. (The OI-1008 pattern
+   that ``dispatch_govern._run_worktree_git`` already guards locally in one
+   module; this module generalises it so every dispatch-context git call can
+   enforce the same guarantee.)
+2. A dispatch-context git call given a target path that resolves to the main
+   checkout rather than to the dispatch's own worktree.
+
+The main-checkout / linked-worktree distinction is the gitdir shape: in a
+linked worktree ``.git`` is a FILE pointing at ``<common-dir>/worktrees/<name>``;
+in the main checkout ``.git`` is a DIRECTORY.  ``git rev-parse --show-toplevel``
+on any path inside either resolves to that checkout's own top-level, and the
+``.git`` shape at that top-level classifies it.
+
+This module is fail-open for everything except the exact refusal it is built
+for: an unresolvable path, a non-git path, or a path inside a linked worktree
+never triggers ``DispatchTargetsMainCheckoutError``. Only a path that provably
+resolves to the MAIN checkout of a git repo, while a dispatch context is
+active, refuses.
+
+``VNX_GIT_TARGET_GUARD=0`` (or ``off``/``false``/``no``) disables the guard for
+the current process. The test suite sets this so tmp repos (which are
+structurally main checkouts of their own repo) are not refused when a dispatch
+worker runs the suite; the guard's own tests re-enable it explicitly. A real
+dispatch lane never sets the toggle, so the guard stays armed there.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+
+class DispatchTargetsMainCheckoutError(RuntimeError):
+    """Raised when a dispatch-context git operation would target the main checkout.
+
+    A dispatch must not move the operator's checkout. Callers MUST treat this
+    as a hard failure of the operation being guarded — never catch-and-continue
+    with the main checkout as the git target.
+    """
+
+
+_DISPATCH_ID_ENV_VARS = ("VNX_CURRENT_DISPATCH_ID", "VNX_DISPATCH_ID")
+
+
+def is_dispatch_context() -> bool:
+    """True when the current process is a dispatch worker/lane.
+
+    Detected from the env vars the lanes export at spawn time:
+    ``VNX_CURRENT_DISPATCH_ID`` (tmux pane env + subprocess adapter) and
+    ``VNX_DISPATCH_ID`` (tmux launch-line prefix). Outside a dispatch these
+    are unset, and the guard is a no-op so operator/tooling git operations on
+    the main checkout keep working.
+    """
+    return any(
+        (os.environ.get(var) or "").strip() for var in _DISPATCH_ID_ENV_VARS
+    )
+
+
+def guard_enabled() -> bool:
+    """False when ``VNX_GIT_TARGET_GUARD`` explicitly disables the guard.
+
+    The guard functions consult this in addition to ``is_dispatch_context``.
+    The test suite sets ``VNX_GIT_TARGET_GUARD=0`` so isolated tmp repos (which
+    are structurally main checkouts of their own repo) are not refused when the
+    suite runs inside a dispatch worker; the guard's own tests set it back to 1.
+    """
+    return (os.environ.get("VNX_GIT_TARGET_GUARD", "") or "").strip().lower() not in (
+        "0", "off", "false", "no",
+    )
+
+
+def resolves_to_main_checkout(path: "str | Path") -> bool:
+    """True when *path* resolves to the MAIN checkout of a git repo.
+
+    ``git rev-parse --show-toplevel`` from *path* yields the checkout's own
+    top-level. A linked worktree's top-level has ``.git`` as a FILE; the main
+    checkout's top-level has ``.git`` as a DIRECTORY. Any path inside the main
+    checkout (including a subdirectory) resolves to the main top-level and is
+    therefore classified as the main checkout.
+
+    Fail-open: a path that is not inside a git repo, or from which git cannot
+    be run, returns False.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(path), "rev-parse", "--show-toplevel"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return False
+    if proc.returncode != 0:
+        return False
+    top_level = proc.stdout.strip()
+    if not top_level:
+        return False
+    return (Path(top_level).resolve() / ".git").is_dir()
+
+
+def guard_git_target(path: "str | Path", *, dispatch_id: "str | None" = None) -> Path:
+    """Guard a git target path against the main checkout in a dispatch context.
+
+    When a dispatch context is active (``VNX_CURRENT_DISPATCH_ID`` /
+    ``VNX_DISPATCH_ID`` set, or *dispatch_id* passed) and *path* resolves to
+    the main checkout of a git repo, raises
+    ``DispatchTargetsMainCheckoutError``. Otherwise returns the resolved path.
+
+    Outside a dispatch context this is a no-op: the operator may legitimately
+    run git against the main checkout.
+    """
+    resolved = Path(path).resolve()
+    active_id = dispatch_id or (os.environ.get("VNX_CURRENT_DISPATCH_ID") or "").strip() \
+        or (os.environ.get("VNX_DISPATCH_ID") or "").strip()
+    if not active_id or not guard_enabled():
+        return resolved
+    if resolves_to_main_checkout(resolved):
+        raise DispatchTargetsMainCheckoutError(
+            f"dispatch {active_id!r}: git target {resolved} resolves to the MAIN "
+            "checkout, not a dispatch worktree. A dispatch must operate inside its "
+            "own ephemeral worktree; operating on the main checkout would move the "
+            "operator's HEAD onto a PR branch. Refusing (OI-975)."
+        )
+    return resolved
+
+
+def guard_git_cwd(cwd: "str | Path | None" = None, *, dispatch_id: "str | None" = None) -> Path:
+    """Guard the cwd for a dispatch-context git call.
+
+    A git call with no explicit cwd inherits the dispatcher process's own
+    working directory — the main checkout — and would operate on the operator's
+    checkout instead of the dispatch worktree (the OI-1008 pattern). In a
+    dispatch context with no explicit cwd this raises; with an explicit cwd it
+    delegates to :func:`guard_git_target`.
+    """
+    if cwd is None:
+        active_id = dispatch_id or (os.environ.get("VNX_CURRENT_DISPATCH_ID") or "").strip() \
+            or (os.environ.get("VNX_DISPATCH_ID") or "").strip()
+        if active_id and guard_enabled():
+            raise DispatchTargetsMainCheckoutError(
+                f"dispatch {active_id!r}: git call has no explicit cwd — it would "
+                "inherit the main checkout as its target. Pass the dispatch "
+                "worktree path explicitly (OI-975/OI-1008). Refusing."
+            )
+        return Path.cwd().resolve()
+    return guard_git_target(cwd, dispatch_id=dispatch_id)

--- a/scripts/lib/regression_attribution.py
+++ b/scripts/lib/regression_attribution.py
@@ -222,6 +222,13 @@ def attribute_regression(
         RegressionAttributionError: git/bisect failed unexpectedly.
     """
     root = Path(repo_root).resolve() if repo_root is not None else Path.cwd().resolve()
+    # OI-975: attribute_regression checks out arbitrary refs (bad_sha, good_sha,
+    # bisect candidates) and restores the original ref. In a dispatch context
+    # that must happen inside the dispatch worktree, never on the main checkout
+    # — a branch switch under the operator's hands moves HEAD onto a PR branch.
+    # Outside a dispatch context (operator/tooling) this guard is a no-op.
+    from git_target_guard import guard_git_target  # type: ignore[import]
+    root = guard_git_target(root)
     _require_clean_worktree(root)
 
     good_sha = _rev_parse(root, good_ref)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -63,6 +63,13 @@ del _env_key, _subdir
 # Tests that exercise the guard override this explicitly.
 os.environ.setdefault("VNX_DATA_DIR_GUARD", "off")
 
+# OI-975 git-target guard: disabled for the suite by default. When the suite
+# runs INSIDE a dispatch worker the lanes export VNX_CURRENT_DISPATCH_ID /
+# VNX_DISPATCH_ID, and the guard would refuse every tmp repo in the suite (a
+# tmp repo is structurally the main checkout of its own repo). The guard's own
+# tests (tests/test_git_target_guard.py) set VNX_GIT_TARGET_GUARD=1 explicitly.
+os.environ.setdefault("VNX_GIT_TARGET_GUARD", "0")
+
 # Make the repo root importable for all tests. pytest's prepend import mode
 # only inserts the first non-package dir (tests/) into sys.path, so top-level
 # packages like scripts.* are unreachable when pytest is invoked on an absolute

--- a/tests/test_git_target_guard.py
+++ b/tests/test_git_target_guard.py
@@ -1,0 +1,341 @@
+"""test_git_target_guard.py — OI-975 guard against dispatch git ops on the main checkout.
+
+A dispatch must operate exclusively inside its own ephemeral worktree. A git
+call that resolves its target to the MAIN checkout (the operator's checkout)
+instead of the dispatch worktree can move the operator's HEAD onto a
+``dispatch/<id>`` / PR branch without the operator asking.
+
+This tests git_target_guard directly and its wiring into the two git-checkout
+primitives that move a checkout onto a branch:
+
+  1. ``regression_attribution.attribute_regression`` — checks out arbitrary
+     refs during bisection (scripts/lib/regression_attribution.py:224).
+  2. ``chain_origin_anchor._commit_and_push_anchor`` — ``git checkout -B
+     <branch>`` on the seal target (scripts/lib/chain_origin_anchor.py:813).
+
+Real git repos in tempdir fixtures (mirrors test_tmux_worktree.py).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+import git_target_guard
+from git_target_guard import (
+    DispatchTargetsMainCheckoutError,
+    guard_git_cwd,
+    guard_git_target,
+    is_dispatch_context,
+    resolves_to_main_checkout,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-git-repo fixtures
+# ---------------------------------------------------------------------------
+
+def _init_git_repo(tmp_path: Path) -> Path:
+    """Create a bare origin + local clone with an initial commit on main.
+
+    Returns the local clone path (the project root / main checkout).
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"], check=True, capture_output=True
+    )
+    return local
+
+
+def _add_dispatch_worktree(local: Path, dispatch_id: str) -> Path:
+    """Create a linked worktree under ``<local>/.vnx-data/worktrees/dispatch-<id>``.
+
+    Mirrors tmux_worktree.allocate's layout so the worktree path shape matches
+    production dispatch worktrees.
+    """
+    wt = local / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"
+    wt.parent.mkdir(parents=True, exist_ok=True)
+    subprocess.run(
+        ["git", "-C", str(local), "worktree", "add", "-b", f"dispatch/{dispatch_id}", str(wt), "origin/main"],
+        check=True, capture_output=True,
+    )
+    return wt
+
+
+@pytest.fixture
+def dispatch_env(monkeypatch):
+    """Simulate a dispatch worker context: the env vars the lanes export.
+
+    Explicitly re-enables the guard (conftest sets VNX_GIT_TARGET_GUARD=0 for
+    the suite) so these tests exercise the real refusal.
+    """
+    monkeypatch.setenv("VNX_CURRENT_DISPATCH_ID", "20260804-test-checkout-vastzetten")
+    monkeypatch.setenv("VNX_DISPATCH_ID", "20260804-test-checkout-vastzetten")
+    monkeypatch.setenv("VNX_GIT_TARGET_GUARD", "1")
+    return "20260804-test-checkout-vastzetten"
+
+
+@pytest.fixture
+def clean_dispatch_env(monkeypatch):
+    """Ensure no dispatch-context env vars leak into a test."""
+    monkeypatch.delenv("VNX_CURRENT_DISPATCH_ID", raising=False)
+    monkeypatch.delenv("VNX_DISPATCH_ID", raising=False)
+    monkeypatch.delenv("VNX_GIT_TARGET_GUARD", raising=False)
+
+
+# ---------------------------------------------------------------------------
+# is_dispatch_context / resolves_to_main_checkout
+# ---------------------------------------------------------------------------
+
+def test_is_dispatch_context_true_when_dispatch_env_set(dispatch_env):
+    assert is_dispatch_context() is True
+
+
+def test_is_dispatch_context_false_when_unset(clean_dispatch_env):
+    assert is_dispatch_context() is False
+
+
+def test_resolves_to_main_checkout_true_for_main_checkout(tmp_path):
+    local = _init_git_repo(tmp_path)
+    assert resolves_to_main_checkout(local) is True
+
+
+def test_resolves_to_main_checkout_true_for_subdir_of_main_checkout(tmp_path):
+    local = _init_git_repo(tmp_path)
+    subdir = local / "scripts"
+    subdir.mkdir(exist_ok=True)
+    assert resolves_to_main_checkout(subdir) is True
+
+
+def test_resolves_to_main_checkout_false_for_dispatch_worktree(tmp_path):
+    local = _init_git_repo(tmp_path)
+    wt = _add_dispatch_worktree(local, "20260804-test-checkout-vastzetten")
+    assert resolves_to_main_checkout(wt) is False
+
+
+def test_resolves_to_main_checkout_false_for_non_git_dir(tmp_path):
+    non_git = tmp_path / "not-a-repo"
+    non_git.mkdir()
+    assert resolves_to_main_checkout(non_git) is False
+
+
+# ---------------------------------------------------------------------------
+# guard_git_target
+# ---------------------------------------------------------------------------
+
+def test_guard_git_target_refuses_main_checkout_in_dispatch_context(tmp_path, dispatch_env):
+    local = _init_git_repo(tmp_path)
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        guard_git_target(local)
+
+
+def test_guard_git_target_refuses_subdir_of_main_checkout_in_dispatch_context(tmp_path, dispatch_env):
+    local = _init_git_repo(tmp_path)
+    subdir = local / "scripts"
+    subdir.mkdir(exist_ok=True)
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        guard_git_target(subdir)
+
+
+def test_guard_git_target_passes_dispatch_worktree_in_dispatch_context(tmp_path, dispatch_env):
+    local = _init_git_repo(tmp_path)
+    wt = _add_dispatch_worktree(local, "20260804-test-checkout-vastzetten")
+    assert guard_git_target(wt) == wt.resolve()
+
+
+def test_guard_git_target_passes_main_checkout_outside_dispatch_context(tmp_path, clean_dispatch_env):
+    local = _init_git_repo(tmp_path)
+    # Operator mode: the main checkout is a legitimate git target.
+    assert guard_git_target(local) == local.resolve()
+
+
+def test_guard_git_target_accepts_explicit_dispatch_id(tmp_path, monkeypatch):
+    local = _init_git_repo(tmp_path)
+    # Explicit dispatch_id + guard re-enabled (no ambient dispatch env needed).
+    monkeypatch.setenv("VNX_GIT_TARGET_GUARD", "1")
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        guard_git_target(local, dispatch_id="20260804-test-checkout-vastzetten")
+
+
+# ---------------------------------------------------------------------------
+# guard_git_cwd
+# ---------------------------------------------------------------------------
+
+def test_guard_git_cwd_no_cwd_in_dispatch_context_raises(dispatch_env):
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        guard_git_cwd(None)
+
+
+def test_guard_git_cwd_explicit_worktree_in_dispatch_context_ok(tmp_path, dispatch_env):
+    local = _init_git_repo(tmp_path)
+    wt = _add_dispatch_worktree(local, "20260804-test-checkout-vastzetten")
+    assert guard_git_cwd(wt) == wt.resolve()
+
+
+def test_guard_git_cwd_no_cwd_outside_dispatch_context_ok(tmp_path, clean_dispatch_env, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    assert guard_git_cwd(None) == tmp_path.resolve()
+
+
+# ---------------------------------------------------------------------------
+# Wiring: regression_attribution.attribute_regression
+# ---------------------------------------------------------------------------
+
+def test_attribute_regression_refuses_main_checkout_in_dispatch_context(tmp_path, dispatch_env):
+    """The branch-switching primitive must refuse the main checkout in a dispatch context."""
+    import regression_attribution
+
+    local = _init_git_repo(tmp_path)
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        regression_attribution.attribute_regression(
+            check_cmd="true",
+            good_ref="HEAD~0",
+            bad_ref="HEAD~0",
+            repo_root=local,
+        )
+
+
+def test_attribute_regression_runs_outside_dispatch_context(tmp_path, clean_dispatch_env):
+    """Same call outside a dispatch context still works (operator mode)."""
+    import regression_attribution
+
+    local = _init_git_repo(tmp_path)
+    result = regression_attribution.attribute_regression(
+        check_cmd="true",  # passes at bad_ref => inconclusive, no bisect
+        good_ref="HEAD",
+        bad_ref="HEAD",
+        repo_root=local,
+    )
+    assert result.status == "inconclusive"
+    # The main checkout must still be on main after the call.
+    head = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head == "main"
+
+
+# ---------------------------------------------------------------------------
+# Wiring: chain_origin_anchor._commit_and_push_anchor
+# ---------------------------------------------------------------------------
+
+def test_chain_origin_commit_refuses_main_checkout_in_dispatch_context(tmp_path, dispatch_env):
+    """``git checkout -B`` inside the seal path must refuse the main checkout in a dispatch context."""
+    from chain_origin_anchor import _commit_and_push_anchor
+
+    local = _init_git_repo(tmp_path)
+    with pytest.raises(DispatchTargetsMainCheckoutError):
+        _commit_and_push_anchor(
+            local,
+            "main",
+            [],
+            identity="test-identity",
+            epoch=1,
+        )
+    # Nothing must have moved: the guard fired before any checkout.
+    head = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert head == "main"
+
+
+def test_chain_origin_commit_targets_worktree_in_dispatch_context(tmp_path, dispatch_env):
+    """The same seal call against a dispatch worktree is allowed and stays on the worktree."""
+    from chain_origin_anchor import _commit_and_push_anchor
+
+    local = _init_git_repo(tmp_path)
+    wt = _add_dispatch_worktree(local, "20260804-test-checkout-vastzetten")
+
+    # Patch out the network steps (push + PR) — we only assert the guard lets
+    # the call reach the checkout against the worktree.
+    import chain_origin_anchor
+
+    pushed = {"seen": False}
+
+    def _fake_push(*args, **kwargs):
+        pushed["seen"] = True
+        return subprocess.CompletedProcess(args=(), returncode=0, stdout="", stderr="")
+
+    monkeypatch = pytest.MonkeyPatch()
+    monkeypatch.setattr(chain_origin_anchor, "_git_run_checked", _fake_push)
+    try:
+        # With a worktree target the guard passes and the checkout lands on the
+        # worktree, never on the main checkout.
+        _commit_and_push_anchor(
+            wt,
+            "main",
+            [],
+            identity="test-identity",
+            epoch=1,
+        )
+    finally:
+        monkeypatch.undo()
+
+    assert pushed["seen"] is True
+    main_head = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert main_head == "main"
+
+
+# ---------------------------------------------------------------------------
+# Green-after proof: the guarded git operation leaves the main checkout alone
+# ---------------------------------------------------------------------------
+
+def test_guarded_worktree_git_operation_leaves_main_checkout_untouched(tmp_path, dispatch_env):
+    """A dispatch-context git op on the worktree must not move the main checkout's branch."""
+    local = _init_git_repo(tmp_path)
+    wt = _add_dispatch_worktree(local, "20260804-test-checkout-vastzetten")
+
+    before = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+
+    # Guarded checkout inside the worktree (the exact op that must stay scoped).
+    guarded_wt = guard_git_target(wt)
+    subprocess.run(
+        ["git", "-C", str(guarded_wt), "checkout", "-b", "dispatch/worker-side-branch"],
+        capture_output=True, check=True,
+    )
+
+    after = subprocess.run(
+        ["git", "-C", str(local), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert before == after == "main"
+    # The worktree is the one that moved.
+    wt_head = subprocess.run(
+        ["git", "-C", str(wt), "rev-parse", "--abbrev-ref", "HEAD"],
+        capture_output=True, text=True, check=True,
+    ).stdout.strip()
+    assert wt_head == "dispatch/worker-side-branch"

--- a/tests/test_runtime_adapter_certification.py
+++ b/tests/test_runtime_adapter_certification.py
@@ -244,6 +244,9 @@ class TestDirectCouplingFreeze:
         # The set guards against NEW, unexpected coupling outside this lane.
         # context_rotation.py — T0-initiated non-destructive rotation respawn
         # (default-OFF); first-class tmux use, added 2026-07-12.
+        # git_target_guard.py — dispatch-context git target guard (OI-975);
+        # uses subprocess and references tmux in its docstring env-var
+        # explainer, added 2026-08-04.
         known_preexisting = {
             "cleanup_worker_exit.py",
             "context_rotation.py",
@@ -251,6 +254,7 @@ class TestDirectCouplingFreeze:
             "dispatch_govern.py",
             "dispatch_prepare.py",
             "dispatch_sidedoor_audit.py",
+            "git_target_guard.py",
             "governance_emit.py",
             "plan_gate_panel.py",
             "provider_dispatch.py",
@@ -273,6 +277,9 @@ class TestDirectCouplingFreeze:
         # test_no_direct_tmux_subprocess_in_protected_modules. Kept in sync with it.
         # context_rotation.py — T0-initiated non-destructive rotation respawn
         # (default-OFF); first-class tmux use, added 2026-07-12.
+        # git_target_guard.py — dispatch-context git target guard (OI-975);
+        # uses subprocess and references tmux in its docstring env-var
+        # explainer, added 2026-08-04.
         known_files = {
             "cleanup_worker_exit.py",
             "context_rotation.py",
@@ -280,6 +287,7 @@ class TestDirectCouplingFreeze:
             "dispatch_govern.py",
             "dispatch_prepare.py",
             "dispatch_sidedoor_audit.py",
+            "git_target_guard.py",
             "governance_emit.py",
             "plan_gate_panel.py",
             "provider_dispatch.py",


### PR DESCRIPTION
## OI-975 — de hoofdcheckout springt naar een PR-branch tijdens een dispatch

Een dispatch hoort uitsluitend in zijn eigen worktree te opereren. Dit PR voegt een guard toe die weigert wanneer een dispatch-context git-doel de hoofdcheckout raakt, en hardt de twee git-checkout-primitives die een checkout naar een branch kunnen verplaatsen.

## Wat er gevonden is

- **Geen live reproductie.** Geen enkele dispatch-lane draait vandaag `git checkout`/`git switch` met de repo-root als doel. De lanes gebruiken `git worktree add/remove`, `git fetch` en `git branch -D` op de root, die de hoofdcheckout niet verplaatsen. Ik kon de wissel daarom niet automatisch reproduceren en zeg dat expliciet.
- **Reflog-bewijs.** De reflog van de hoofdcheckout toont dat `dispatch/<id>`-branches (PR-branches) op 08-02/08-03 op de hoofdcheckout zijn uitgecheckt, inclusief commits daarop.
- **Twee git-checkout-op-de-root primitieven** die een checkout naar een branch kunnen zetten als ze in dispatch-context met de hoofdcheckout als target worden aangeroepen:
  - `scripts/lib/regression_attribution.py:224` (`attribute_regression`) — checkt `bad_sha`/`good_sha`/bisect-kandidaten uit en herstelt de originele ref in een `finally`.
  - `scripts/lib/chain_origin_anchor.py:813` (`_commit_and_push_anchor`) — `git checkout -B <seal-branch>` op `project_root`.

## Wat er gebouwd is

- **`scripts/lib/git_target_guard.py`** (nieuw): `guard_git_target()` / `guard_git_cwd()` weigeren (via `DispatchTargetsMainCheckoutError`) wanneer een dispatch-context git-doel naar de hoofdcheckout resolveert. Onderscheid hoofdcheckout vs werkboom: in een linked worktree is `.git` een FILE, in de hoofdcheckout een DIRECTORY. Buiten dispatch-context is de guard een no-op. `VNX_GIT_TARGET_GUARD=0` zet de guard uit (test-suite; tmp repos zijn structureel hoofdcheckouts).
- **Wiring:** beide primitieven + `dispatch_govern._run_worktree_git` (versterkt de OI-1008 presence-check met een echte main-checkout-resolutiecheck).
- **`tests/test_git_target_guard.py`** (nieuw, 19 tests): guard-semantiek, wiring, en het groen-na-bewijs dat een guarded worktree-op de hoofdcheckout ongemoeid laat (`git -C <repo-root> rev-parse --abbrev-ref HEAD` vóór/ná gelijk).

## Verificatie

- 19/19 guard-tests groen.
- 210/210 over de relevante families (`test_dispatch_govern`, `test_chain_origin_anchor`, `test_regression_attribution`, `test_tmux_worktree`, `test_dispatch_worktree_identity_race`, `test_vnx_worktree`, `test_provider_dispatch_worktree_isolation`).
- 105/105 phantom-guard + dispatch-envelope.
- Live-proef: guarded op op de worktree → hoofdcheckout blijft op `main`.
- `test_subprocess_dispatch_worktree_isolation.py` heeft 8 pre-bestaande falers (MagicMock-TypeError in `vnx_paths.py`) — gereproduceerd op de schone base-boom, niet veroorzaakt door dit PR.

## Open Items

Geen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)