### PR TITLE
feat(gate): add ci_workflow check — distinguish never-ran, failed, passed (OI-931)

### DIFF
--- a/scripts/pre_merge_gate.py
+++ b/scripts/pre_merge_gate.py
@@ -684,6 +684,188 @@ def check_net_deletion(project_root: Path) -> Dict[str, Any]:
     }
 
 
+def check_ci_workflow(
+    project_root: Path,
+    *,
+    branch: Optional[str] = None,
+    head_sha: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Check that the VNX CI workflow ran successfully on this exact commit.
+
+    Three states are distinguished sharply:
+      - Never ran:   no VNX CI run for this commit → HOLD, with explicit
+                     "workflow not run" message independent of failure.
+      - Ran + failed: run exists but conclusion is not "success" → HOLD.
+      - Ran + passed: run exists with conclusion "success" → GO.
+
+    Uses ``gh run list`` to query workflow runs.  Degrades gracefully to GO
+    (skip) when the gh CLI is unavailable, unauthenticated, or the branch/HEAD
+    SHA cannot be resolved from git — the check cannot determine state in those
+    cases and must not block.
+
+    OI-931: ``gh pr checks`` can show all-green while the mandatory VNX CI
+    workflow never ran.  This check reads the workflow conclusion directly —
+    never the check-names — so the three states are distinguishable.
+    """
+    # ── Resolve head SHA ──────────────────────────────────────────────────
+    if head_sha is None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "HEAD"],
+                cwd=str(project_root),
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode != 0:
+                return {
+                    "check": "ci_workflow",
+                    "status": "GO",
+                    "detail": "could not resolve HEAD SHA — skipping CI workflow check",
+                    "ci_conclusion": None,
+                    "ci_ran_on_sha": False,
+                }
+            head_sha = result.stdout.strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return {
+                "check": "ci_workflow",
+                "status": "GO",
+                "detail": "could not resolve HEAD SHA — skipping CI workflow check",
+                "ci_conclusion": None,
+                "ci_ran_on_sha": False,
+            }
+
+    if branch is None:
+        try:
+            result = subprocess.run(
+                ["git", "rev-parse", "--abbrev-ref", "HEAD"],
+                cwd=str(project_root),
+                capture_output=True, text=True, timeout=10,
+            )
+            if result.returncode != 0:
+                return {
+                    "check": "ci_workflow",
+                    "status": "GO",
+                    "detail": "could not resolve branch name — skipping CI workflow check",
+                    "ci_conclusion": None,
+                    "ci_ran_on_sha": False,
+                }
+            branch = result.stdout.strip()
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            return {
+                "check": "ci_workflow",
+                "status": "GO",
+                "detail": "could not resolve branch name — skipping CI workflow check",
+                "ci_conclusion": None,
+                "ci_ran_on_sha": False,
+            }
+
+    # ── Query gh for workflow runs ─────────────────────────────────────────
+    try:
+        result = subprocess.run(
+            [
+                "gh", "run", "list",
+                "--branch", branch,
+                "--workflow", "VNX CI",
+                "--limit", "10",
+                "--json", "conclusion,headSha,status,databaseId",
+            ],
+            cwd=str(project_root),
+            capture_output=True, text=True, timeout=15,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return {
+            "check": "ci_workflow",
+            "status": "GO",
+            "detail": "gh CLI not available — skipping CI workflow check",
+            "ci_conclusion": None,
+            "ci_ran_on_sha": False,
+        }
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        return {
+            "check": "ci_workflow",
+            "status": "GO",
+            "detail": f"gh run list failed — skipping CI workflow check: {stderr[:120]}",
+            "ci_conclusion": None,
+            "ci_ran_on_sha": False,
+        }
+
+    try:
+        runs = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        return {
+            "check": "ci_workflow",
+            "status": "GO",
+            "detail": "gh output unparseable — skipping CI workflow check",
+            "ci_conclusion": None,
+            "ci_ran_on_sha": False,
+        }
+
+    # ── Match run to HEAD SHA ──────────────────────────────────────────────
+    for run in runs:
+        if run.get("headSha") == head_sha:
+            conclusion = run.get("conclusion") or ""
+            if conclusion == "success":
+                return {
+                    "check": "ci_workflow",
+                    "status": "GO",
+                    "detail": (
+                        f"VNX CI succeeded on {head_sha[:12]} "
+                        f"(run {run.get('databaseId')})"
+                    ),
+                    "ci_conclusion": conclusion,
+                    "ci_ran_on_sha": True,
+                    "ci_head_sha": head_sha,
+                    "ci_run_id": run.get("databaseId"),
+                }
+            return {
+                "check": "ci_workflow",
+                "status": "HOLD",
+                "detail": (
+                    f"VNX CI conclusion is '{conclusion}' on {head_sha[:12]} "
+                    f"(run {run.get('databaseId')}) — must be 'success'"
+                ),
+                "ci_conclusion": conclusion,
+                "ci_ran_on_sha": True,
+                "ci_head_sha": head_sha,
+                "ci_run_id": run.get("databaseId"),
+            }
+
+    # No run matched the HEAD SHA — distinguish "ran on different SHA" from
+    # "never ran at all" so the two failure modes get distinct messages.
+    if runs:
+        latest_run = runs[0]
+        latest_sha = (latest_run.get("headSha") or "")[:12]
+        latest_conclusion = latest_run.get("conclusion") or "unknown"
+        return {
+            "check": "ci_workflow",
+            "status": "HOLD",
+            "detail": (
+                f"VNX CI workflow has NOT run on HEAD ({head_sha[:12]}). "
+                f"Latest run on branch '{branch}' was on {latest_sha} "
+                f"(conclusion: {latest_conclusion}). "
+                "The PR may show green checks from a prior run — re-run CI."
+            ),
+            "ci_conclusion": None,
+            "ci_ran_on_sha": False,
+            "ci_head_sha": head_sha,
+            "ci_latest_run_sha": latest_sha,
+        }
+    return {
+        "check": "ci_workflow",
+        "status": "HOLD",
+        "detail": (
+            f"VNX CI workflow has NEVER run on branch '{branch}'. "
+            f"No runs found for HEAD {head_sha[:12]}. "
+            "PR checks may show green from other workflows — "
+            "this is the 'green-lie' that OI-931 guards against."
+        ),
+        "ci_conclusion": None,
+        "ci_ran_on_sha": False,
+        "ci_head_sha": head_sha,
+    }
+
+
 # ---------------------------------------------------------------------------
 # Helpers
 # ---------------------------------------------------------------------------
@@ -881,6 +1063,7 @@ def run_gate_checks(
     checks.append(check_artifacts(pr_id, dispatch_dir, project_root))
     checks.append(check_shell_syntax(project_root))
     checks.append(check_net_deletion(project_root))
+    checks.append(check_ci_workflow(project_root))
 
     if not skip_pytest:
         checks.append(check_pytest(project_root))

--- a/tests/test_pre_merge_gate.py
+++ b/tests/test_pre_merge_gate.py
@@ -30,6 +30,7 @@ from pre_merge_gate import (
     check_artifacts,
     check_shell_syntax,
     check_net_deletion,
+    check_ci_workflow,
     run_gate_checks,
     store_gate_result,
     format_human_readable,
@@ -678,6 +679,7 @@ class TestRunGateChecks:
         assert "artifact_verification" in check_names
         assert "shell_syntax" in check_names
         assert "net_deletion" in check_names
+        assert "ci_workflow" in check_names
 
     def test_pytest_included_when_not_skipped(self, state_dir, dispatch_dir, tmp_path):
         result = run_gate_checks(
@@ -823,3 +825,151 @@ class TestCheckPRSize:
         assert result["status"] == "GO"
         assert result["lines_changed"] == 4
         assert "origin/master" in result["detail"]
+
+
+# ---------------------------------------------------------------------------
+# check_ci_workflow — OI-931
+# ---------------------------------------------------------------------------
+
+class TestCheckCIWorkflow:
+    """OI-931: three-way CI state — never ran, ran+failed, ran+succeeded.
+
+    check_ci_workflow makes three subprocess calls in order:
+      1. git rev-parse HEAD       → head_sha
+      2. git rev-parse --abbrev-ref HEAD → branch
+      3. gh run list ...          → CI workflow runs
+
+    Each test provides three MagicMock results matching that order.
+    """
+
+    @staticmethod
+    def _git_head_mock(sha: str) -> MagicMock:
+        return MagicMock(returncode=0, stdout=sha + "\n", stderr="")
+
+    @staticmethod
+    def _git_branch_mock(branch: str = "feature-branch") -> MagicMock:
+        return MagicMock(returncode=0, stdout=branch + "\n", stderr="")
+
+    @staticmethod
+    def _gh_run_output(conclusion, head_sha, status="completed", database_id=12345):
+        """Build gh run list JSON output for one run."""
+        runs = [{
+            "conclusion": conclusion,
+            "headSha": head_sha,
+            "status": status,
+            "databaseId": database_id,
+        }]
+        return MagicMock(returncode=0, stdout=json.dumps(runs), stderr="")
+
+    @staticmethod
+    def _gh_empty_output():
+        """gh run list returns no runs."""
+        return MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
+
+    def test_ci_succeeded(self, tmp_path):
+        """Workflow ran on HEAD with conclusion=success → GO."""
+        sha = "a" * 40
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            self._gh_run_output("success", sha),
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "GO"
+        assert result["ci_conclusion"] == "success"
+        assert result["ci_ran_on_sha"] is True
+
+    def test_ci_failed(self, tmp_path):
+        """Workflow ran on HEAD but conclusion=failure → HOLD."""
+        sha = "b" * 40
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            self._gh_run_output("failure", sha),
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "HOLD"
+        assert result["ci_conclusion"] == "failure"
+        assert result["ci_ran_on_sha"] is True
+        assert "must be 'success'" in result["detail"]
+
+    def test_ci_never_ran(self, tmp_path):
+        """No runs exist on the branch at all → HOLD with distinct message."""
+        sha = "c" * 40
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            self._gh_empty_output(),
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "HOLD"
+        assert result["ci_conclusion"] is None
+        assert result["ci_ran_on_sha"] is False
+        assert "NEVER run" in result["detail"]
+
+    def test_ci_ran_on_different_sha(self, tmp_path):
+        """Runs exist on the branch but not on HEAD → HOLD with SHA-mismatch detail."""
+        sha = "d" * 40
+        different_sha = "e" * 40
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            self._gh_run_output("success", different_sha, database_id=99999),
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "HOLD"
+        assert result["ci_ran_on_sha"] is False
+        assert result["ci_head_sha"] == sha
+        assert "NOT run on HEAD" in result["detail"]
+        assert result["ci_latest_run_sha"] == different_sha[:12]
+
+    def test_ci_conclusion_cancelled_is_hold(self, tmp_path):
+        """Cancelled workflow conclusion is not 'success' → HOLD."""
+        sha = "f" * 40
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            self._gh_run_output("cancelled", sha),
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "HOLD"
+        assert result["ci_conclusion"] == "cancelled"
+
+    def test_gh_not_available_skips(self, tmp_path):
+        """gh CLI missing → GO (skip, do not block)."""
+        sha = "g" * 40
+        git_head = self._git_head_mock(sha)
+        git_branch = self._git_branch_mock()
+        mocks = [git_head, git_branch, FileNotFoundError("gh not found")]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "GO"
+        assert "not available" in result["detail"]
+        assert result["ci_conclusion"] is None
+
+    def test_gh_run_list_fails_skips(self, tmp_path):
+        """gh run list non-zero exit → GO (skip)."""
+        sha = "h" * 40
+        gh_fail = MagicMock(returncode=1, stdout="", stderr="HTTP 403")
+        mocks = [
+            self._git_head_mock(sha),
+            self._git_branch_mock(),
+            gh_fail,
+        ]
+        with patch("pre_merge_gate.subprocess.run", side_effect=mocks):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "GO"
+        assert "gh run list failed" in result["detail"]
+
+    def test_git_head_fails_skips(self, tmp_path):
+        """git rev-parse HEAD fails → GO (skip, cannot determine SHA)."""
+        git_fail = MagicMock(returncode=128, stdout="", stderr="fatal: not a git repository")
+        with patch("pre_merge_gate.subprocess.run", side_effect=[git_fail]):
+            result = check_ci_workflow(tmp_path)
+        assert result["status"] == "GO"
+        assert "could not resolve HEAD SHA" in result["detail"]


### PR DESCRIPTION
## What

Adds `check_ci_workflow()` to the pre-merge gate that queries the VNX CI workflow conclusion directly via `gh run list --workflow "VNX CI"` — never through `gh pr checks` which can show all-green on stale data.

## Why (OI-931)

`gh pr checks` can list all individual check-runs as green while the VNX CI workflow never ran on the current commit. T0 caught this manually today across 3 of 7 PRs. This check makes that verification automatic.

## Three states, sharply distinguished

| State | Signal | Detail message |
|---|---|---|
| **Never ran** | HOLD | "VNX CI workflow has NEVER run on branch '...'" |
| **Ran + failed** | HOLD | "VNX CI conclusion is 'failure' — must be 'success'" |
| **Ran + succeeded** | GO | "VNX CI succeeded on \<sha\>" |

SHA mismatch (ran on a different commit) is its own distinct message within the HOLD category.

## Graceful degradation

When `gh` is unavailable, `git rev-parse` fails, or the API returns an error, the check returns GO with a clear skip message. It only blocks when it can positively determine the workflow state.

## Changes

- `scripts/pre_merge_gate.py`: +183 lines (new `check_ci_workflow()` + wires into `run_gate_checks()`)
- `tests/test_pre_merge_gate.py`: +150 lines (8 new tests in `TestCheckCIWorkflow` class)

## Verification

- 62/62 tests pass (54 existing + 8 new)
- Covers: success GO, failure HOLD, never-ran HOLD, SHA-mismatch HOLD, cancelled HOLD, gh missing GO, gh error GO, git failure GO

Dispatch-ID: 20260804-133004-ci-groen-leugen

🤖 Generated with [Claude Code](https://claude.com/claude-code)