### PR TITLE
fix(tests): disarm fixture drift — census line stability, schema SSOT, attest timestamps (OI-1019, OI-1021, OI-1033)

### DIFF
--- a/tests/fixtures/dispatches_schema_fixture.py
+++ b/tests/fixtures/dispatches_schema_fixture.py
@@ -1,0 +1,62 @@
+"""dispatches_schema_fixture.py — canonical dispatches schema from schema_manifest (OI-1021).
+
+Two helpers:
+  - ``dispatches_ddl()`` — full CREATE TABLE DDL for fresh databases.
+  - ``ensure_dispatches_columns(conn)`` — idempotently add any columns declared
+    in the canonical schema that are missing from an existing dispatches table.
+    Use this in place of hand-written ``ALTER TABLE dispatches ADD COLUMN …``
+    statements that must be kept in sync with every schema change.
+
+Before: every new dispatches column (e.g. output_ref/output_kind in v27)
+required ALTER TABLE patches in every test fixture that touched the table.
+After: adding a column to the schema manifest updates every test automatically.
+"""
+
+import sqlite3
+import sys
+from pathlib import Path
+
+_SCRIPTS_LIB = Path(__file__).resolve().parent.parent.parent / "scripts" / "lib"
+if str(_SCRIPTS_LIB) not in sys.path:
+    sys.path.insert(0, str(_SCRIPTS_LIB))
+
+from schema_manifest import TERMINAL_VERSION, table_at
+
+
+def dispatches_ddl() -> str:
+    """Generate the canonical dispatches CREATE TABLE DDL from schema_manifest.
+
+    Indexes are omitted — they are performance artifacts the fixtures' queries
+    do not depend on.
+    """
+    tbl = table_at(TERMINAL_VERSION, "dispatches")
+    assert tbl is not None, "schema_manifest must declare the dispatches table"
+    body: list[str] = []
+    for col in tbl.columns.values():
+        notnull = " NOT NULL" if col.notnull else ""
+        body.append(f"    {col.name} {col.affinity}{notnull}")
+    body.append(f"    PRIMARY KEY ({', '.join(tbl.pk)})")
+    for uk in tbl.unique_keys:
+        body.append(f"    UNIQUE ({', '.join(uk)})")
+    return "CREATE TABLE dispatches (\n" + ",\n".join(body) + "\n);"
+
+
+def ensure_dispatches_columns(conn: sqlite3.Connection) -> list[str]:
+    """Idempotently add any columns the canonical schema declares that are
+    missing from the dispatches table.
+
+    Returns the list of column names that were added (empty on subsequent calls).
+    Use this in place of hand-written ``ALTER TABLE dispatches ADD COLUMN …``
+    statements — when a new column lands in the canonical manifest, every test
+    that calls this function gets it automatically instead of silently breaking
+    (OI-1021).
+    """
+    tbl = table_at(TERMINAL_VERSION, "dispatches")
+    assert tbl is not None, "schema_manifest must declare the dispatches table"
+    existing = {row[1] for row in conn.execute("PRAGMA table_info('dispatches')")}
+    added = []
+    for col in tbl.columns.values():
+        if col.name not in existing:
+            conn.execute(f"ALTER TABLE dispatches ADD COLUMN {col.name} {col.affinity}")
+            added.append(col.name)
+    return added

--- a/tests/test_attest_override.py
+++ b/tests/test_attest_override.py
@@ -249,6 +249,9 @@ class TestGetOverrideBudget:
 class TestWriteAndVerifyOverride:
     def test_roundtrip_exact_diff_passes(self, ephemeral_key_dir):
         """A signed override for the exact diff verifies as 'override'."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -262,7 +265,7 @@ class TestWriteAndVerifyOverride:
                 reason="approved by architect — prod incident",
                 dispatch_id="D-override-test",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -283,6 +286,9 @@ class TestWriteAndVerifyOverride:
 
     def test_override_for_different_diff_fails(self, ephemeral_key_dir):
         """An override signed for diff A does not verify for diff B."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -297,7 +303,7 @@ class TestWriteAndVerifyOverride:
                 reason="override for diff A",
                 dispatch_id="D-override-a",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -315,6 +321,9 @@ class TestWriteAndVerifyOverride:
 
     def test_rogue_key_override_fails(self, ephemeral_key_dir, rogue_key_dir):
         """An override signed with an unknown key fails signature check."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -329,7 +338,7 @@ class TestWriteAndVerifyOverride:
                 reason="unauthorized override attempt",
                 dispatch_id="D-rogue",
                 signer_identity=rogue_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=rogue_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -344,6 +353,9 @@ class TestWriteAndVerifyOverride:
 
     def test_trail_is_appended(self, ephemeral_key_dir):
         """Each write_override_record appends one entry to the trail."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -359,7 +371,7 @@ class TestWriteAndVerifyOverride:
                 reason="test trail append",
                 dispatch_id="D-trail",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -372,6 +384,11 @@ class TestWriteAndVerifyOverride:
 
     def test_record_count_derived_from_trail(self, ephemeral_key_dir):
         """Override count comes from the trail; count is accurate after two writes."""
+        # Timestamps relative to now — both stay inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees them.
+        now = datetime.now(timezone.utc)
+        ts_first = (now - timedelta(days=5)).strftime("%Y-%m-%dT%H:%M:%SZ")
+        ts_second = (now - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -387,7 +404,7 @@ class TestWriteAndVerifyOverride:
                 reason="first override",
                 dispatch_id="D-1",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-04T10:00:00Z",
+                timestamp=ts_first,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -404,7 +421,7 @@ class TestWriteAndVerifyOverride:
                 reason="second override",
                 dispatch_id="D-2",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-04T11:00:00Z",
+                timestamp=ts_second,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -420,6 +437,9 @@ class TestWriteAndVerifyOverride:
 class TestBudgetEnforcement:
     def test_budget_count_exhausted_scenario(self, ephemeral_key_dir, monkeypatch):
         """Budget logic: used >= budget should block the caller from writing."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=2)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -441,7 +461,7 @@ class TestBudgetEnforcement:
                     reason=f"override {i}",
                     dispatch_id=f"D-budget-{i}",
                     signer_identity=ephemeral_key_dir["identity"],
-                    timestamp="2026-07-04T10:00:00Z",
+                    timestamp=ts,
                     key_path=ephemeral_key_dir["key_path"],
                     repo_root=repo,
                 )
@@ -522,6 +542,9 @@ class TestBudgetEnforcement:
 class TestVerifyPRWithOverride:
     def test_valid_override_returns_override_verdict(self, ephemeral_key_dir):
         """verify_pr returns (0, ...'override'...) when a valid override exists."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -535,7 +558,7 @@ class TestVerifyPRWithOverride:
                 reason="prod incident — SLA breach imminent",
                 dispatch_id="D-vpr-override",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -556,6 +579,9 @@ class TestVerifyPRWithOverride:
 
     def test_override_for_wrong_diff_fails(self, ephemeral_key_dir):
         """verify_pr fails when the override was signed for a different diff."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -569,7 +595,7 @@ class TestVerifyPRWithOverride:
                 reason="override for diff A only",
                 dispatch_id="D-wrong-diff",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -588,6 +614,9 @@ class TestVerifyPRWithOverride:
 
     def test_rogue_key_override_fails_in_verify_pr(self, ephemeral_key_dir, rogue_key_dir):
         """verify_pr rejects an override signed by a key not in allowed_signers."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -602,7 +631,7 @@ class TestVerifyPRWithOverride:
                 reason="unauthorized override",
                 dispatch_id="D-rogue",
                 signer_identity=rogue_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=rogue_key_dir["key_path"],
                 repo_root=repo,
             )
@@ -705,6 +734,9 @@ class TestVerifyPRWithOverride:
 
     def test_override_record_without_trail_entry_rejected(self, ephemeral_key_dir):
         """A record file present without a matching trail entry is rejected (round-3: audit-ledger bypass)."""
+        # Timestamp relative to now — stays inside the 30-day OVERRIDE_WINDOW
+        # so the budget check in write_override_record actually sees it.
+        ts = (datetime.now(timezone.utc) - timedelta(days=3)).strftime("%Y-%m-%dT%H:%M:%SZ")
         with tempfile.TemporaryDirectory() as tmpdir:
             repo = _init_repo(Path(tmpdir))
             base_sha = _head_sha(repo)
@@ -715,7 +747,7 @@ class TestVerifyPRWithOverride:
             write_override_record(
                 content_key=ck, reason="incident", dispatch_id="D-x",
                 signer_identity=ephemeral_key_dir["identity"],
-                timestamp="2026-07-05T10:00:00Z",
+                timestamp=ts,
                 key_path=ephemeral_key_dir["key_path"], repo_root=repo,
                 allowed_signers=ephemeral_key_dir["allowed_signers"],
             )

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -36,6 +36,8 @@ import build_t0_state as bts  # noqa: E402
 import schema_migration  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-proj"
 _MARKER_KEYS = {
     "derived_refreshed", "tracks", "drifted", "drifted_tracks", "reason", "seconds",
@@ -91,8 +93,7 @@ def _build_tracks_db(tmp_path: Path) -> Path:
             conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
         )
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     for ver, fname in (

--- a/tests/test_close_track_if_done.py
+++ b/tests/test_close_track_if_done.py
@@ -28,6 +28,8 @@ import schema_migration  # noqa: E402
 import track_reconciler  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-close-proj"
 
 
@@ -76,8 +78,7 @@ def _build_db(tmp_path: Path) -> Path:
         )
         conn.commit()
 
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 

--- a/tests/test_deliverable_reconciliation.py
+++ b/tests/test_deliverable_reconciliation.py
@@ -30,6 +30,8 @@ import schema_migration
 import track_reconciler
 import tracks as tracks_lib
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 PROJECT_ID = "test-oi840"
 
 
@@ -87,8 +89,7 @@ def _build_db(tmp_path: Path) -> Path:
         )
         conn.commit()
 
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 

--- a/tests/test_dispatch_envelope_characterization.py
+++ b/tests/test_dispatch_envelope_characterization.py
@@ -142,17 +142,57 @@ class TestLayer1ImportSurface:
 # ---------------------------------------------------------------------------
 
 
+def _coupling_key(c: Coupling) -> tuple:
+    """Stable identity key for a coupling — (file, mechanism, module_target, symbol).
+
+    Line number is NOT part of the identity because it shifts when test files
+    are edited (a new line pushes every coupling below it down by one, and the
+    census went red even though no coupling actually changed — OI-1019). The
+    line number is still stored in the fixture for diagnostics, but the census
+    comparison matches on this key, not on the full Coupling object.
+    """
+    return (c.file, c.mechanism, c.module_target, c.symbol)
+
+
 def _census_diff(live: list, expected: list) -> str:
-    live_set, expected_set = set(live), set(expected)
-    added = sorted(live_set - expected_set)
-    removed = sorted(expected_set - live_set)
+    """Compare live census against expected using stable coupling keys.
+
+    Uses Counter on coupling keys so that duplicate couplings (same file,
+    mechanism, module_target, symbol on different lines) are counted
+    correctly — a file with two patches of the same symbol should survive
+    a line-number shift just as well as a file with one.
+    """
+    from collections import Counter
+    live_counts = Counter(_coupling_key(c) for c in live)
+    expected_counts = Counter(_coupling_key(c) for c in expected)
+    all_keys = sorted(set(live_counts) | set(expected_counts))
+
+    # Build a representative Coupling for each key (for diagnostic line numbers).
+    live_repr = {}
+    for c in live:
+        k = _coupling_key(c)
+        live_repr.setdefault(k, c)
+    expected_repr = {}
+    for c in expected:
+        k = _coupling_key(c)
+        expected_repr.setdefault(k, c)
+
     lines = ["census mismatch vs tests/data/dispatch_envelope_census.json"]
-    if added:
-        lines.append(f"  + {len(added)} coupling(s) the live scan found but the fixture doesn't have:")
-        lines.extend(f"      {c.file}:{c.line} [{c.mechanism}] {c.module_target}.{c.symbol}" for c in added)
-    if removed:
-        lines.append(f"  - {len(removed)} coupling(s) the fixture has but the live scan no longer finds:")
-        lines.extend(f"      {c.file}:{c.line} [{c.mechanism}] {c.module_target}.{c.symbol}" for c in removed)
+    for k in all_keys:
+        lc = live_counts.get(k, 0)
+        ec = expected_counts.get(k, 0)
+        if lc > ec:
+            rep = live_repr.get(k)
+            lines.append(
+                f"  +{lc - ec} {rep.file}:{rep.line} [{rep.mechanism}] "
+                f"{rep.module_target}.{rep.symbol}"
+            )
+        elif ec > lc:
+            rep = expected_repr.get(k)
+            lines.append(
+                f"  -{ec - lc} {rep.file}:{rep.line} [{rep.mechanism}] "
+                f"{rep.module_target}.{rep.symbol}"
+            )
     lines.append("  regenerate with: python3 tests/dispatch_envelope_census_scanner.py")
     return "\n".join(lines)
 
@@ -183,6 +223,7 @@ class TestLayer2Census:
             assert f.stem in family, f"{f} exists on disk but discover_family() missed it"
 
     def test_census_matches_fixture(self):
+        from collections import Counter
         family = discover_family()
         live = scan_tests_dir(family=family)
         fixture = json.loads(CENSUS_FIXTURE.read_text(encoding="utf-8"))
@@ -190,8 +231,10 @@ class TestLayer2Census:
             f"fixture was generated against family={sorted(fixture['family'])!r} "
             f"but the live family is {sorted(family)!r} — regenerate the fixture"
         )
-        expected = sorted(Coupling.from_dict(d) for d in fixture["couplings"])
-        assert live == expected, _census_diff(live, expected)
+        expected = [Coupling.from_dict(d) for d in fixture["couplings"]]
+        live_key_counts = Counter(_coupling_key(c) for c in live)
+        expected_key_counts = Counter(_coupling_key(c) for c in expected)
+        assert live_key_counts == expected_key_counts, _census_diff(live, expected)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -33,6 +33,8 @@ for _p in (str(REPO_ROOT), str(_LIB), str(_SCRIPTS)):
 
 import schema_migration  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 from vnx_cli import _engine  # noqa: E402
 from vnx_cli.main import main as vnx_main  # noqa: E402
 
@@ -75,8 +77,7 @@ def _bootstrap_store(state_dir: Path) -> None:
     # Preflight normally owned by migrate_future_system.py: 0027's deliverables
     # VIEW selects dispatches.output_ref/output_kind, which the minimal
     # dispatches table above doesn't carry yet.
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.commit()
     for version, filename in [
         (27, "0027_planning_horizon_and_deliverable_view.sql"),

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -46,6 +46,8 @@ for _p in (str(REPO_ROOT), str(_LIB), str(_SCRIPTS)):
 import schema_migration  # noqa: E402
 import planning_cli  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 import vnx_cli.main as vnx_main_mod  # noqa: E402
 from vnx_cli import _engine  # noqa: E402
 from vnx_cli.commands import horizon as horizon_mod  # noqa: E402
@@ -185,8 +187,7 @@ def _bootstrap_store(state_dir: Path) -> None:
         sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
         schema_migration.apply_script_if_below(conn, version, sql)
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.commit()
     for version, filename in [
         (27, "0027_planning_horizon_and_deliverable_view.sql"),

--- a/tests/test_migrate_0027_planning_horizon.py
+++ b/tests/test_migrate_0027_planning_horizon.py
@@ -33,6 +33,8 @@ if str(_SCRIPTS) not in sys.path:
 import schema_migration
 import migrate_future_system  # noqa: F401 — registers preflight hooks for v27
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 def _base_v26_db(tmp_path: Path) -> sqlite3.Connection:
     """Build a DB at the live-equivalent state: 0022 + 0024 applied, plus the
@@ -73,8 +75,7 @@ def _base_v26_db(tmp_path: Path) -> sqlite3.Connection:
     )
     conn.commit()
     # Mirror the structural-doctor additions present in the live v26 DB.
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     return conn

--- a/tests/test_migration_track_type.py
+++ b/tests/test_migration_track_type.py
@@ -35,6 +35,8 @@ if str(_SCRIPTS) not in sys.path:
 import schema_migration
 import migrate_future_system  # noqa: F401 — registers preflight hooks for v29
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -87,8 +89,7 @@ def _base_v28_db(tmp_path: Path) -> sqlite3.Connection:
     )
     conn.commit()
     # Mirror structural-doctor additions present in the live v26 DB.
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     schema_migration.apply_script_if_below(

--- a/tests/test_objective_close.py
+++ b/tests/test_objective_close.py
@@ -30,6 +30,8 @@ import planning_cli  # noqa: E402
 import schema_migration  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-proj"
 
 
@@ -67,8 +69,7 @@ def _build_db(tmp_path: Path) -> Path:
     for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
         schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     for ver, fname in ((27, "0027_planning_horizon_and_deliverable_view.sql"),

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -40,6 +40,8 @@ import schema_migration  # noqa: E402
 import track_reconciler  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-recon-proj"
 
 
@@ -111,8 +113,7 @@ def _build_db(tmp_path: Path) -> Path:
         )
         conn.commit()
 
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 

--- a/tests/test_objective_reopen.py
+++ b/tests/test_objective_reopen.py
@@ -27,6 +27,8 @@ import planning_cli  # noqa: E402
 import schema_migration  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-reopen-proj"
 
 
@@ -76,8 +78,7 @@ def _build_db(tmp_path: Path) -> Path:
             conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
         )
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     for ver, fname in (

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -29,6 +29,8 @@ import planning_cli  # noqa: E402
 import schema_migration  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 PROJECT_ID = "test-proj"
 
 
@@ -67,8 +69,7 @@ def _build_db(tmp_path: Path) -> Path:
     for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
         schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     for ver, fname in ((27, "0027_planning_horizon_and_deliverable_view.sql"),

--- a/tests/test_planning_cli_objective.py
+++ b/tests/test_planning_cli_objective.py
@@ -31,6 +31,8 @@ import seed_tracks_from_roadmap as seeder
 import planning_cli
 import tracks as tracks_lib
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 SAMPLE_ROADMAP = """
 roadmap_id: test-roadmap
@@ -85,8 +87,7 @@ def seeded_state(tmp_path: Path) -> Path:
             conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
         )
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     schema_migration.apply_script_if_below(

--- a/tests/test_planning_deliverables.py
+++ b/tests/test_planning_deliverables.py
@@ -30,6 +30,8 @@ import schema_migration
 import planning_cli
 import tracks as tracks_lib
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 PROJECT_ID = "test-proj"
 
@@ -100,8 +102,7 @@ def _build_db(tmp_path: Path) -> Path:
         conn.commit()
 
     # Pre-add output_ref + output_kind (as structural-doctor would on live DB)
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 

--- a/tests/test_planning_turnon.py
+++ b/tests/test_planning_turnon.py
@@ -35,6 +35,8 @@ import seed_tracks_from_roadmap as seeder  # noqa: E402
 import planning_cli  # noqa: E402
 import tracks as tracks_lib  # noqa: E402
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
 
 SAMPLE_ROADMAP = """
 roadmap_id: test-roadmap
@@ -88,8 +90,7 @@ def _init_schema(state_dir: Path) -> None:
             conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
         )
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     schema_migration.apply_script_if_below(

--- a/tests/test_seed_tracks_from_roadmap.py
+++ b/tests/test_seed_tracks_from_roadmap.py
@@ -31,6 +31,8 @@ for p in (_LIB, _SCRIPTS):
 
 import schema_migration
 import tracks as tracks_lib
+
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
 import seed_tracks_from_roadmap as seeder
 
 
@@ -95,8 +97,7 @@ def _make_db(tmp_path: Path) -> Path:
         conn, 24, (_MIGRATIONS / "0024_tracks_tenant_scoping.sql").read_text(encoding="utf-8")
     )
     conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     schema_migration.apply_script_if_below(

--- a/tests/test_track_reconciler.py
+++ b/tests/test_track_reconciler.py
@@ -37,6 +37,8 @@ import schema_migration
 import track_reconciler
 import tracks as tracks_lib
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 PROJECT_ID = "test-proj"
 
@@ -96,8 +98,7 @@ def _build_db(tmp_path: Path) -> Path:
         )
         conn.commit()
 
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 
@@ -411,8 +412,7 @@ def _base_v27_db(tmp_path: Path) -> tuple[sqlite3.Connection, Path]:
             conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
         )
         conn.commit()
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
     schema_migration.apply_script_if_below(

--- a/tests/test_track_reconciler_prref_evidence.py
+++ b/tests/test_track_reconciler_prref_evidence.py
@@ -37,6 +37,8 @@ import track_reconciler
 from track_reconciler import _load_merged_pr_numbers, _parse_pr_number
 import tracks as tracks_lib
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 
 PROJECT_ID = "test-ev-proj"
 
@@ -101,8 +103,7 @@ def _build_db(tmp_path: Path, *, deep: bool = False) -> Path:
         )
         conn.commit()
 
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_ref TEXT")
-    conn.execute("ALTER TABLE dispatches ADD COLUMN output_kind TEXT")
+    ensure_dispatches_columns(conn)
     conn.execute("PRAGMA user_version = 26")
     conn.commit()
 


### PR DESCRIPTION
## Summary

Three fixture-drift patterns, one fix each:

### OI-1019 — coupling census stable keys

The coupling census asserted on line numbers (`file:line`). Every PR that touched a scanned test file shifted line numbers, and the census went red even though no coupling actually changed. PR #1378 added one line and moved two couplings from 758 to 759 — pure noise.

**Fix:** Replace `(file, line, mechanism, module_target, symbol)` identity with `(file, mechanism, module_target, symbol)` stable key. Counter-based comparison preserves correct counts when a file contains multiple identical couplings on different lines.

### OI-1021 — dispatches schema SSOT

17 test fixtures hand-wrote the dispatches schema and glued v27 columns (`output_ref`/`output_kind`) onto it with `ALTER TABLE`. Every schema change required updates in every fixture.

**Fix:** Introduce `ensure_dispatches_columns(conn)` in `tests/fixtures/dispatches_schema_fixture.py` — derives the canonical dispatches columns from `schema_manifest.table_at(TERMINAL_VERSION)` and idempotently adds any missing ones. One SSOT, zero fixture drift.

### OI-1033 — attest override time-bomb disarmament

10 tests in `test_attest_override.py` wrote absolute ISO-8601 timestamps that fell outside the 30-day `OVERRIDE_WINDOW`. `write_override_record`'s internal budget check saw 0 overrides, and budget enforcement never triggered (0 < 5 always passes).

**Fix:** Follow PR #1384 pattern — compute timestamps as `(datetime.now(timezone.utc) - timedelta(days=N))` so they always land inside the rolling window.

## Verification

- **OI-1019:** Adding a blank line to a scanned test file no longer turns the census red; a genuine coupling drift (removing a coupling from the fixture) still fails loudly.
- **OI-1021:** All 17 test files pass; a new column in `schema_manifest` automatically propagates to every test using `ensure_dispatches_columns()`.
- **OI-1033:** All 29 tests pass; time-travel verified (tests pass 1 year forward); budget enforcement now sees non-zero counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>