### PR TITLE
fix(governance): datetime-aware event sort + NoneType guard in append receipt chain (OI-948, OI-949)

### DIFF
--- a/scripts/append_receipt.py
+++ b/scripts/append_receipt.py
@@ -177,6 +177,14 @@ def main(argv: Optional[List[str]] = None) -> int:
         _emit("ERROR", "unexpected_error", message=str(exc))
         return EXIT_UNEXPECTED_ERROR
 
+    # OI-948: defensive — append_receipt_payload is annotated -> AppendResult
+    # and every code path returns one.  If this fires, the invariant was
+    # broken in a way that escaped the type annotation; surface it clearly.
+    if result is None:
+        _emit("ERROR", "internal_null_result",
+              message="append_receipt_payload returned None — invariant violation")
+        return EXIT_UNEXPECTED_ERROR
+
     if result.status == "duplicate":
         _emit(
             "INFO",

--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -122,6 +122,25 @@ def _now_iso() -> str:
     return _now_utc().isoformat()
 
 
+def _parse_iso(ts: str) -> Optional[datetime]:
+    """Parse ISO-8601 UTC timestamp tolerating both microsecond and second
+    precision and a trailing ``Z`` suffix. Returns ``None`` on failure.
+
+    OI-949: needed for datetime-aware event sorting so mixed-precision
+    timestamps (e.g. "…00.123456Z" vs "…00Z") are ordered by actual time,
+    not by lexicographic collation where "." sorts before "Z".
+    """
+    if not ts:
+        return None
+    s = ts
+    if s.endswith("Z"):
+        s = s[:-1] + "+00:00"
+    try:
+        return datetime.fromisoformat(s)
+    except (TypeError, ValueError):
+        return None
+
+
 def _safe_json(path: Path) -> Optional[Dict[str, Any]]:
     """Load JSON from path. Returns None on OSError (absent file).
     Raises json.JSONDecodeError if the file exists but contains malformed JSON (R7.3)."""
@@ -801,7 +820,10 @@ def _build_feature_state(state_dir: Optional[Path] = None) -> Dict[str, Any]:
 
     dispatch_records: Dict[str, Any] = {}
     for did, events in by_dispatch.items():
-        events_sorted = sorted(events, key=lambda e: e.get("timestamp", ""))
+        events_sorted = sorted(
+            events,
+            key=lambda e: (_parse_iso(e.get("timestamp", "")) or datetime.min, e.get("timestamp", "")),
+        )
         latest = events_sorted[-1]
         latest_event = latest.get("event", "")
         status = _EVENT_TO_STATUS.get(latest_event, "unknown")
@@ -1509,7 +1531,11 @@ def _build_recent_receipts(
                 best_by_dispatch[did] = view
 
     recs = list(best_by_dispatch.values()) + no_dispatch_recs
-    return sorted(recs, key=lambda x: str(x.get("timestamp") or ""), reverse=True)[:limit]
+    return sorted(
+        recs,
+        key=lambda x: (_parse_iso(str(x.get("timestamp") or "")) or datetime.min, str(x.get("timestamp") or "")),
+        reverse=True,
+    )[:limit]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/append_receipt_internals/payload.py
+++ b/scripts/lib/append_receipt_internals/payload.py
@@ -14,6 +14,7 @@ from .common import (
     AppendResult,
     EXIT_IO_ERROR,
     EXIT_INVALID_INPUT,
+    EXIT_UNEXPECTED_ERROR,
     REPO_ROOT,
     SCRIPTS_DIR,
     _emit,
@@ -442,6 +443,21 @@ def append_receipt_payload(
         cache_window_seconds,
         pre_write_hook=commit_receipt_v2_fields,
     )
+
+    # OI-948: _write_receipt_under_lock is annotated -> AppendResult and
+    # every code path returns an AppendResult instance.  A None here would
+    # mean a silent implicit return slipped in (e.g. a broad except that
+    # swallows the raise without replacing it).  Fail closed with a precise
+    # message so the source is traceable instead of surfacing downstream as
+    # "'NoneType' object has no attribute 'status'" at payload.py:446.
+    if result is None:
+        raise AppendReceiptError(
+            "internal_null_result",
+            EXIT_UNEXPECTED_ERROR,
+            "payload.py: _write_receipt_under_lock returned None — "
+            "this is a framework-internal invariant violation; "
+            "the append lock path exited without a result object",
+        )
 
     if result.status == "appended":
         # Phase 6 P3 dual-write: drain persisted mirror debt before attempting

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -533,7 +533,15 @@ def read_events(*, since_iso: Optional[str] = None, state_dir: Optional[Path] = 
     for ev in central_events:
         key = _merge_dedup_key(ev)
         merged[key] = ev  # central overwrites primary on same key
-    return sorted(merged.values(), key=lambda e: e.get("timestamp", ""))
+    # OI-949: sort datetime-aware to avoid lexicographic misordering of
+    # mixed-precision timestamps (e.g. "…00.123456Z" sorts before "…00Z"
+    # under str-collation because "." (0x2E) < "Z" (0x5A)).
+    # Fallback: unparseable timestamps land on _dt.datetime.min (year 1) so
+    # they sort before any real event rather than interleaving spuriously.
+    return sorted(
+        merged.values(),
+        key=lambda e: (_parse_iso(e.get("timestamp", "")) or _dt.datetime.min, e.get("timestamp", "")),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -151,6 +151,33 @@ class TestReadEventsOrder:
             "dispatch_started",
         ]
 
+    def test_mixed_precision_timestamps_sorted_by_datetime_not_lexicographic(
+        self, isolated_data_dir,
+    ):
+        """OI-949: mixed-precision timestamps must sort by actual time.
+
+        Lexicographic collation would put ``…00.123456Z`` BEFORE ``…00Z``
+        because ``.`` (0x2E) sorts before ``Z`` (0x5A), even though the
+        microsecond timestamp is 123456 µs later.  Datetime-aware sort
+        fixes this.
+        """
+        reg = _reg_path(isolated_data_dir)
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        # Chronological order: first (second-precision), second (microsecond)
+        # Lexicographic would reverse these because '.123456Z' < 'Z'
+        first_ts = "2026-07-01T10:00:00Z"
+        second_ts = "2026-07-01T10:00:00.123456Z"
+        reg.write_text(
+            json.dumps({"timestamp": first_ts, "event": "first", "dispatch_id": "d-1"}) + "\n"
+            + json.dumps({"timestamp": second_ts, "event": "second", "dispatch_id": "d-2"}) + "\n"
+        )
+        events = read_events()
+        assert len(events) == 2
+        # Datetime-aware: first (earlier) then second (later)
+        assert [e["event"] for e in events] == ["first", "second"], (
+            f"Expected ['first', 'second'] (datetime order), got {[e['event'] for e in events]}"
+        )
+
 
 # ---------------------------------------------------------------------------
 # 6. read_events since_iso filter


### PR DESCRIPTION
## What

### OI-949 — Lexicographic sort of ISO timestamps

`read_events()` in `dispatch_register.py` and two sort sites in `build_t0_state.py` used plain string collation for ISO-8601 timestamps. Under lexicographic sort, `.` (0x2E) sorts before `Z` (0x5A), so a microsecond-precision timestamp like `2026-08-04T10:00:00.123456Z` sorts BEFORE a coarser `2026-08-04T10:00:00Z` — even though it is 123456 µs later.

**Fix:** Use `_parse_iso()` (`datetime.fromisoformat`) as the sort key with a `datetime.min` fallback for unparseable values. Applied to:
- `dispatch_register.py:536` — `read_events()` merge-and-sort
- `build_t0_state.py:823` — `_build_feature_state()` event ordering
- `build_t0_state.py:1534` — `_build_recent_receipts()` recency ordering

### OI-948 — Defensive null guard on AppendResult

Added null guards at the two sites that access `result.status` on the return of `_write_receipt_under_lock` / `append_receipt_payload`:
- `payload.py:446` — raises `AppendReceiptError` with file:line
- `append_receipt.py:180` — returns `EXIT_UNEXPECTED_ERROR`

Every code path currently returns an `AppendResult`, but a future regression (e.g. a broad except that swallows a raise) could silently return None. The guard surfaces the invariant violation with a precise location instead of an opaque `'NoneType' object has no attribute 'status'`.

## Files changed

- `scripts/lib/dispatch_register.py` — datetime-aware sort in `read_events()`
- `scripts/build_t0_state.py` — `_parse_iso()` helper + datetime-aware sort in two sites
- `scripts/lib/append_receipt_internals/payload.py` — null guard + import fix
- `scripts/append_receipt.py` — null guard
- `tests/test_dispatch_register.py` — regression test for mixed-precision ordering

## Verification

```
340 passed, 1 warning in 22.42s
```

All existing tests pass. New regression test verifies datetime-aware ordering of mixed-precision timestamps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)