### PR TITLE
feat(dispatch): heartbeat voor de provider-lane + co-death root cause (OI-1044)

### DIFF
--- a/scripts/lib/_streaming_drainer.py
+++ b/scripts/lib/_streaming_drainer.py
@@ -18,6 +18,7 @@ import select
 import subprocess
 import threading
 import time
+from pathlib import Path
 from typing import Any, Callable, Dict, Iterator, List, Optional, TYPE_CHECKING
 
 if TYPE_CHECKING:
@@ -126,6 +127,7 @@ class StreamingDrainerMixin:
         chunk_timeout: float = 300.0,
         total_deadline: float = 900.0,
         _queue_maxsize: int = _DEFAULT_QUEUE_MAXSIZE,
+        raw_tee_path: Optional[Path] = None,
     ) -> Iterator[CanonicalEvent]:
         """Drain process stdout line-by-line, yielding CanonicalEvents.
 
@@ -148,6 +150,12 @@ class StreamingDrainerMixin:
             chunk_timeout: Max seconds between consecutive output lines.
             total_deadline: Max total seconds for the entire drain.
             _queue_maxsize: Bounded queue capacity (default 256 events).
+            raw_tee_path: OI-1044 — when provided, every raw byte chunk read from
+              the subprocess stdout pipe is also appended to this file, so an
+              external FileProgressHeartbeat can observe activity independently
+              of NDJSON-line parsing (mirrors the tmux-spawn lane's pipe-pane
+              capture). None (default) disables the tee — no behavior change for
+              existing callers.
         """
         try:
             chunk_timeout = float(os.environ.get("VNX_CHUNK_TIMEOUT", chunk_timeout))
@@ -185,6 +193,7 @@ class StreamingDrainerMixin:
                     timed_out=timed_out,
                     normalize_fn=self._normalize,
                     provider_name=self.provider_name,
+                    raw_tee_path=raw_tee_path,
                 )
             except Exception:
                 logger.exception(
@@ -255,6 +264,7 @@ def _run_producer(
     timed_out: threading.Event,
     normalize_fn: Callable[[Dict[str, Any]], CanonicalEvent],
     provider_name: str,
+    raw_tee_path: Optional[Path] = None,
 ) -> None:
     """Read subprocess stdout, parse NDJSON, push events to queue."""
     if process.stdout is None:
@@ -264,90 +274,137 @@ def _run_producer(
     line_buffer = b""
     start = time.monotonic()
 
-    while True:
-        elapsed = time.monotonic() - start
-        if elapsed >= total_deadline:
-            logger.warning(
-                "_streaming_drainer: total deadline (%.0fs) exceeded for %s",
-                total_deadline, terminal_id,
-            )
-            timed_out.set()
-            _kill_process(process)
-            err = _make_error_event(
-                terminal_id=terminal_id,
-                dispatch_id=dispatch_id,
-                provider=provider_name,
-                raw=None,
-                reason=f"total deadline {total_deadline:.0f}s exceeded",
-            )
-            _append_to_store(event_store, terminal_id, err, dispatch_id)
-            result_queue.put(err)
-            return
-
-        remaining = min(chunk_timeout, total_deadline - elapsed)
+    tee_fh = None
+    if raw_tee_path is not None:
         try:
-            ready, _, _ = select.select([fd], [], [], remaining)
-        except (ValueError, OSError):
-            break  # fd closed
-
-        if not ready:
+            raw_tee_path.parent.mkdir(parents=True, exist_ok=True)
+            tee_fh = open(raw_tee_path, "ab", buffering=0)
+        except OSError as exc:
             logger.warning(
-                "_streaming_drainer: chunk timeout (%.0fs) for %s",
-                chunk_timeout, terminal_id,
+                "_streaming_drainer: raw tee open failed for %s (heartbeat disabled): %s",
+                raw_tee_path, exc,
             )
-            timed_out.set()
-            _kill_process(process)
-            err = _make_error_event(
-                terminal_id=terminal_id,
-                dispatch_id=dispatch_id,
-                provider=provider_name,
-                raw=None,
-                reason=f"chunk timeout {chunk_timeout:.0f}s exceeded",
-            )
-            _append_to_store(event_store, terminal_id, err, dispatch_id)
-            result_queue.put(err)
-            return
+            tee_fh = None
 
-        try:
-            chunk = os.read(fd, 65536)
-        except OSError:
-            break  # fd closed (process killed)
+    try:
+        while True:
+            elapsed = time.monotonic() - start
+            if elapsed >= total_deadline:
+                logger.warning(
+                    "_streaming_drainer: total deadline (%.0fs) exceeded for %s",
+                    total_deadline, terminal_id,
+                )
+                timed_out.set()
+                _kill_process(process)
+                err = _make_error_event(
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    provider=provider_name,
+                    raw=None,
+                    reason=f"total deadline {total_deadline:.0f}s exceeded",
+                )
+                _append_to_store(event_store, terminal_id, err, dispatch_id)
+                result_queue.put(err)
+                return
 
-        if not chunk:
-            # EOF — process finished cleanly
-            rc = process.poll()
-            if rc is not None:
-                pass  # returncode available for post-drain check
-            break
-
-        line_buffer += chunk
-        while b"\n" in line_buffer:
-            raw_line, line_buffer = line_buffer.split(b"\n", 1)
-            line = raw_line.decode("utf-8", errors="replace").strip()
-            if not line:
-                continue
-
-            event = _parse_line(
-                line=line,
-                terminal_id=terminal_id,
-                dispatch_id=dispatch_id,
-                provider_name=provider_name,
-                normalize_fn=normalize_fn,
-            )
-
-            # Stamp Tier-1 on all streaming events
-            object.__setattr__(event, "observability_tier", _STREAMING_TIER) if hasattr(type(event), "__dataclass_fields__") else None
-            # Dataclasses are not frozen, so direct assignment works
+            remaining = min(chunk_timeout, total_deadline - elapsed)
             try:
-                event.observability_tier = _STREAMING_TIER
-            except AttributeError:
+                ready, _, _ = select.select([fd], [], [], remaining)
+            except (ValueError, OSError):
+                break  # fd closed
+
+            if not ready:
+                # OI-1044 co-death investigation: when total_deadline is close,
+                # `remaining` is compressed below the configured chunk_timeout
+                # (see the min() above), so a `not ready` here can mean either a
+                # genuine full-length chunk_timeout stall OR a much shorter gap
+                # that only looks like a stall because the deadline capped the
+                # wait window. Reported gap := the actual seconds waited
+                # (`remaining`), so the log/receipt never blames a false Ns of
+                # silence — a worker that paused for 1s right as its deadline
+                # ran out must not be reported as "silent for chunk_timeout".
+                gap = remaining
+                deadline_compressed = remaining < chunk_timeout
+                logger.warning(
+                    "_streaming_drainer: %s (%.0fs) for %s",
+                    "deadline-compressed stall" if deadline_compressed else "chunk timeout",
+                    gap, terminal_id,
+                )
+                timed_out.set()
+                _kill_process(process)
+                reason = (
+                    f"total deadline reached during final stall window "
+                    f"({gap:.0f}s remaining, configured chunk_timeout={chunk_timeout:.0f}s not "
+                    f"fully elapsed)"
+                    if deadline_compressed
+                    else f"chunk timeout {chunk_timeout:.0f}s exceeded"
+                )
+                err = _make_error_event(
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    provider=provider_name,
+                    raw=None,
+                    reason=reason,
+                )
+                _append_to_store(event_store, terminal_id, err, dispatch_id)
+                result_queue.put(err)
+                return
+
+            try:
+                chunk = os.read(fd, 65536)
+            except OSError:
+                break  # fd closed (process killed)
+
+            if not chunk:
+                # EOF — process finished cleanly
+                rc = process.poll()
+                if rc is not None:
+                    pass  # returncode available for post-drain check
+                break
+
+            if tee_fh is not None:
+                try:
+                    tee_fh.write(chunk)
+                except OSError as exc:
+                    logger.debug(
+                        "_streaming_drainer: raw tee write failed for %s: %s",
+                        raw_tee_path, exc,
+                    )
+
+            line_buffer += chunk
+            while b"\n" in line_buffer:
+                raw_line, line_buffer = line_buffer.split(b"\n", 1)
+                line = raw_line.decode("utf-8", errors="replace").strip()
+                if not line:
+                    continue
+
+                event = _parse_line(
+                    line=line,
+                    terminal_id=terminal_id,
+                    dispatch_id=dispatch_id,
+                    provider_name=provider_name,
+                    normalize_fn=normalize_fn,
+                )
+
+                # Stamp Tier-1 on all streaming events
+                object.__setattr__(event, "observability_tier", _STREAMING_TIER) if hasattr(type(event), "__dataclass_fields__") else None
+                # Dataclasses are not frozen, so direct assignment works
+                try:
+                    event.observability_tier = _STREAMING_TIER
+                except AttributeError:
+                    pass
+
+                if event.event_type in _COMPLETE_TYPES:
+                    seen_complete.set()
+
+                _append_to_store(event_store, terminal_id, event, dispatch_id)
+                result_queue.put(event)  # blocks if queue full (backpressure)
+    finally:
+        if tee_fh is not None:
+            try:
+                tee_fh.close()
+            except OSError:
                 pass
-
-            if event.event_type in _COMPLETE_TYPES:
-                seen_complete.set()
-
-            _append_to_store(event_store, terminal_id, event, dispatch_id)
-            result_queue.put(event)  # blocks if queue full (backpressure)
 
 
 def _parse_line(

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -56,6 +56,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import threading
 import zipfile
 from dataclasses import dataclass
 from pathlib import Path
@@ -65,7 +66,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1])
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
-from _streaming_drainer import StreamingDrainerMixin, coerce_chunk_stall  # noqa: E402
+from _streaming_drainer import StreamingDrainerMixin, _kill_process, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
 
 logger = logging.getLogger(__name__)
@@ -711,6 +712,151 @@ def _isolate_kimi_env(env: Dict[str, str]) -> Dict[str, str]:
     return {k: v for k, v in env.items() if k not in _VENV_POLLUTION_VARS}
 
 
+# OI-1044: the worker-heartbeat silence detector (#1387, OI-944/OI-1007) is wired
+# into the tmux-spawn lane (FileProgressHeartbeat on the pipe-pane log) and the
+# subprocess lane (EventStreamHeartbeat on the EventStore stream) but not the
+# provider lane — kimi, the fleet-default build-worker, had no external liveness
+# signal at all. `~/.kimi/logs/kimi.log` is a single file shared by every
+# concurrent kimi dispatch, so it cannot be the signal: two dispatches running at
+# once would mask each other's death (one keeps writing while the other is gone).
+# The tee below gives each dispatch its own file (keyed by dispatch_id, the one
+# identifier guaranteed unique across concurrent dispatches — terminal_id is not,
+# since provider-lane dispatches are not necessarily terminal-pinned).
+_DISPATCH_ID_SAFE_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+# How often the monitor thread polls the tee file for growth. Matches the
+# subprocess lane's _silence_heartbeat_loop default (delivery_runtime.py).
+_HEARTBEAT_POLL_INTERVAL_SECONDS = 30.0
+
+
+def _resolve_heartbeat_log_path(dispatch_id: str) -> Optional[Path]:
+    """Per-dispatch raw-stdout tee path for the FileProgressHeartbeat (OI-1044).
+
+    Same directory convention as the tmux lane's pipe-pane capture
+    (``logs/conversations/{dispatch_id}.log`` — see
+    ``tmux_interactive_dispatch.py::_start_pipe_pane``) so a dispatch's raw
+    activity log lives in one predictable place regardless of which lane ran
+    it. Returns None (heartbeat disabled, fail-open) when dispatch_id fails
+    the same path-safety check the tmux lane applies, or when VNX_DATA_DIR
+    cannot be resolved — a missing heartbeat must never break the dispatch
+    itself, only leave it unmonitored.
+    """
+    if not dispatch_id or not _DISPATCH_ID_SAFE_RE.match(dispatch_id):
+        logger.warning(
+            "kimi_spawn: heartbeat disabled — unsafe dispatch_id %r", dispatch_id,
+        )
+        return None
+    try:
+        from vnx_paths import resolve_paths  # noqa: PLC0415
+        data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+    except Exception as exc:  # noqa: BLE001 — heartbeat setup must never break the dispatch
+        logger.warning(
+            "kimi_spawn: heartbeat disabled — VNX_DATA_DIR resolution failed: %s", exc,
+        )
+        return None
+    log_dir = data_dir / "logs" / "conversations"
+    raw_log = (log_dir / f"{dispatch_id}.log").resolve()
+    try:
+        raw_log.relative_to(log_dir.resolve())
+    except ValueError:
+        logger.warning(
+            "kimi_spawn: heartbeat disabled — log path %s escaped %s", raw_log, log_dir,
+        )
+        return None
+    return raw_log
+
+
+def _write_heartbeat_report(dispatch_id: str, report_text: str) -> None:
+    """Atomically write the heartbeat failure report to unified_reports.
+
+    The stuck worker never gets to write its own report, so the heartbeat
+    writes a substitute directly — same responsibility the tmux lane
+    (``tmux_interactive_dispatch.py::_wait_for_receipt``) and the subprocess
+    lane (``delivery_runtime.py::_silence_heartbeat_loop``) already carry.
+    ``emit_unified_report`` is idempotent (it never overwrites an existing
+    contract-valid report), so this write is safe even if it races a governance
+    emit downstream — write-tmp-then-replace so a concurrent reader never sees
+    a partial file.
+    """
+    from vnx_paths import resolve_paths  # noqa: PLC0415
+
+    data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+    reports_dir = data_dir / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+    report_path = reports_dir / f"{dispatch_id}.md"
+    tmp_path = report_path.with_suffix(report_path.suffix + ".tmp")
+    tmp_path.write_text(report_text, encoding="utf-8")
+    os.replace(tmp_path, report_path)
+
+
+def _heartbeat_monitor_loop(
+    proc: subprocess.Popen,
+    heartbeat_log_path: Path,
+    dispatch_id: str,
+    terminal_id: str,
+    model: str,
+    stop_event: threading.Event,
+    killed_event: threading.Event,
+    poll_interval: float = _HEARTBEAT_POLL_INTERVAL_SECONDS,
+) -> None:
+    """Poll the per-dispatch tee file for silence; kill + report if stuck.
+
+    Same module (``worker_heartbeat.FileProgressHeartbeat``), same threshold
+    (``VNX_WORKER_HEARTBEAT_SILENCE_SECONDS``, default 600s), same failure-report
+    shape (``build_heartbeat_failure_report``) as the tmux-spawn and subprocess
+    lanes, so the audit trail is uniform regardless of which lane ran the
+    dispatch (OI-944, OI-1007, OI-1044).
+
+    The 600s default tolerates kimi's measured cadence: a healthy worker can go
+    22 minutes between *file writes* while doing nothing but Read/Grep, but its
+    stdout stream (which this tee mirrors) carries a tool_call/tool_result pair
+    for every one of those reads — measured gaps between kimi's own LLM steps
+    topped out at 209s, well under the threshold. FileProgressHeartbeat watches
+    that raw stdout tee, not worktree file mutations, precisely so read-only
+    activity keeps counting as progress.
+
+    Liveness is verified on the real OS process throughout: the kill path
+    (``_kill_process``) uses ``os.getpgid``/``os.killpg``/``proc.wait()``, never
+    a pidfile (OI-1044 finding: a stale pidfile reads as "running" forever;
+    only the kernel's own view of the pid is trustworthy).
+    """
+    from worker_heartbeat import (  # noqa: PLC0415
+        FileProgressHeartbeat,
+        build_heartbeat_failure_report,
+    )
+
+    hb = FileProgressHeartbeat(heartbeat_log_path, dispatch_id)
+    while not stop_event.wait(timeout=poll_interval):
+        verdict = hb.check()
+        if not verdict.is_silent:
+            continue
+        logger.warning(
+            "kimi_spawn: heartbeat silence detected for %s (%.0fs silent, "
+            "threshold=%.0fs) — killing worker",
+            dispatch_id, verdict.silence_seconds, verdict.threshold_seconds,
+        )
+        _kill_process(proc)
+        try:
+            report = build_heartbeat_failure_report(
+                dispatch_id=dispatch_id,
+                verdict=verdict,
+                model=model,
+                provider="kimi",
+                terminal_id=terminal_id,
+            )
+            _write_heartbeat_report(dispatch_id, report)
+            logger.info(
+                "kimi_spawn: heartbeat failure report written for %s", dispatch_id,
+            )
+        except Exception as exc:  # noqa: BLE001 — report write must never raise past this thread
+            logger.warning(
+                "kimi_spawn: heartbeat failure report write failed for %s: %s",
+                dispatch_id, exc,
+            )
+        killed_event.set()
+        return
+
+
 def _start_kimi_subprocess(
     cmd: list,
     env: Dict[str, str],
@@ -766,6 +912,7 @@ def _consume_kimi_stream(
     event_store: Optional[Any],
     chunk_timeout: float,
     total_deadline: float,
+    heartbeat_log_path: Optional[Path] = None,
 ) -> "tuple[str, int, Optional[Dict], bool, bool, int, list, bool, list, bool]":
     """Drain the stream.
 
@@ -800,6 +947,7 @@ def _consume_kimi_stream(
     for canonical_event in host.drain_stream(
         proc, terminal_id, dispatch_id, event_store,
         chunk_timeout=chunk_timeout, total_deadline=total_deadline,
+        raw_tee_path=heartbeat_log_path,
     ):
         events_written += 1
         evt_type = canonical_event.event_type
@@ -1059,18 +1207,46 @@ def spawn_kimi(
     if err_result is not None:
         return err_result
 
+    # OI-1044: external worker heartbeat — the provider lane had no liveness
+    # signal a supervisor could observe from outside the process. The monitor
+    # thread watches the per-dispatch stdout tee (written by drain_stream below)
+    # and kills+reports a stuck worker independently of the internal
+    # chunk_timeout/total_deadline stall guard (which only fires on a fixed,
+    # deadline-scaled window and never writes the standard heartbeat report).
+    heartbeat_log_path = _resolve_heartbeat_log_path(dispatch_id)
+    _hb_stop = threading.Event()
+    _hb_killed = threading.Event()
+    _hb_thread: Optional[threading.Thread] = None
+    if heartbeat_log_path is not None:
+        _hb_thread = threading.Thread(
+            target=_heartbeat_monitor_loop,
+            args=(
+                proc, heartbeat_log_path, dispatch_id, terminal_id,
+                model or "unknown", _hb_stop, _hb_killed,
+            ),
+            daemon=True,
+            name=f"kimi-heartbeat-{dispatch_id}",
+        )
+        _hb_thread.start()
+
     host = _KimiNormalizerHost(terminal_id=terminal_id, dispatch_id=dispatch_id)
-    (
-        completion_text, events_written, token_usage, timed_out, stopped_early,
-        _event_writer_failures, errors_captured, saw_stream_output, raw_samples,
-        saw_tool_calls,
-    ) = _consume_kimi_stream(
-        proc=proc, host=host, on_event=on_event,
-        health_monitor=health_monitor, event_writer=event_writer,
-        terminal_id=terminal_id, dispatch_id=dispatch_id,
-        event_store=event_store, chunk_timeout=chunk_timeout,
-        total_deadline=total_deadline,
-    )
+    try:
+        (
+            completion_text, events_written, token_usage, timed_out, stopped_early,
+            _event_writer_failures, errors_captured, saw_stream_output, raw_samples,
+            saw_tool_calls,
+        ) = _consume_kimi_stream(
+            proc=proc, host=host, on_event=on_event,
+            health_monitor=health_monitor, event_writer=event_writer,
+            terminal_id=terminal_id, dispatch_id=dispatch_id,
+            event_store=event_store, chunk_timeout=chunk_timeout,
+            total_deadline=total_deadline, heartbeat_log_path=heartbeat_log_path,
+        )
+    finally:
+        _hb_stop.set()
+        if _hb_thread is not None:
+            _hb_thread.join(timeout=5.0)
+
     result = _finalize_kimi_result(
         proc=proc, completion_text=completion_text,
         events_written=events_written, token_usage=token_usage,
@@ -1082,6 +1258,16 @@ def spawn_kimi(
         saw_tool_calls=saw_tool_calls,
         worktree=cwd,
     )
+    if _hb_killed.is_set():
+        # The heartbeat already wrote the terminal failure report — replace the
+        # generic "kimi exited with code N" message with the real reason so the
+        # receipt's failure_reason is diagnosable without cross-referencing logs.
+        result.error = (
+            f"worker heartbeat: killed due to silence exceeding threshold "
+            f"(dispatch={dispatch_id}); see unified_reports/{dispatch_id}.md"
+        )
+        if result.returncode == 0:
+            result.returncode = 1
 
     # Post-run token harvest. stream-json carries no token accounting (measured
     # on kimi-cli 1.46.0), so on a clean run the session is exported and the

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -1339,7 +1339,7 @@ class TestSpawnKimiChunkStallFloor(unittest.TestCase):
 
         def fake_drain(
             self, process, terminal_id, dispatch_id, event_store, *,
-            chunk_timeout, total_deadline,
+            chunk_timeout, total_deadline, raw_tee_path=None,
         ):
             captured["chunk_timeout"] = chunk_timeout
             captured["total_deadline"] = total_deadline
@@ -1384,7 +1384,7 @@ class TestSpawnKimiChunkStallFloor(unittest.TestCase):
 
         def fake_drain(
             self, process, terminal_id, dispatch_id, event_store, *,
-            chunk_timeout, total_deadline,
+            chunk_timeout, total_deadline, raw_tee_path=None,
         ):
             captured["chunk_timeout"] = chunk_timeout
             captured["total_deadline"] = total_deadline

--- a/tests/test_kimi_spawn_heartbeat.py
+++ b/tests/test_kimi_spawn_heartbeat.py
@@ -1,0 +1,506 @@
+"""Tests for the provider-lane worker heartbeat (OI-1044).
+
+PR #1387 (OI-944, OI-1007) wired deterministic silence-detection into the
+tmux-spawn lane (FileProgressHeartbeat on the pipe-pane log) and the
+subprocess lane (EventStreamHeartbeat on the EventStore stream), but not the
+provider lane — kimi, the fleet-default build-worker, had no external
+liveness signal a supervisor could observe from outside the process.
+
+Covers:
+  - _resolve_heartbeat_log_path: per-dispatch path resolution + path-safety
+  - drain_stream raw_tee_path: raw stdout bytes mirrored to a per-dispatch file
+  - _heartbeat_monitor_loop: silent worker detected + killed + report written
+  - False-positive guard: periodic (read-only) activity keeps the worker alive,
+    even across a span far longer than a naive worktree-mutation check would
+    tolerate — the calibration scenario from the dispatch (22 minutes of
+    Read/Grep-only activity with tool-call gaps up to 209s, well under the
+    600s threshold)
+  - Concurrency isolation: two dispatches' heartbeats never share a signal, so
+    one dying can never mask the other's liveness
+  - Liveness is checked on the real OS process (a genuine subprocess is
+    spawned and verified dead after the kill), never a pidfile
+
+Gate: 20260805-oi1044-provider-lane-heartbeat
+"""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import unittest
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+SCRIPTS_LIB = str(Path(__file__).resolve().parent.parent / "scripts" / "lib")
+if SCRIPTS_LIB not in sys.path:
+    sys.path.insert(0, SCRIPTS_LIB)
+PROVIDER_SPAWNS = str(Path(__file__).resolve().parent.parent / "scripts" / "lib" / "provider_spawns")
+if PROVIDER_SPAWNS not in sys.path:
+    sys.path.insert(0, PROVIDER_SPAWNS)
+
+
+def _spawn_real_sleeper() -> subprocess.Popen:
+    """A real, killable OS process — mirrors kimi_spawn's own start_new_session=True."""
+    return subprocess.Popen(
+        ["sleep", "300"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        start_new_session=True,
+    )
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+        return True
+    except (OSError, ProcessLookupError):
+        return False
+
+
+class TestResolveHeartbeatLogPath(unittest.TestCase):
+    """Per-dispatch path resolution + the same path-safety guard the tmux
+    lane applies to its pipe-pane capture path (_start_pipe_pane)."""
+
+    def test_safe_dispatch_id_resolves_under_logs_conversations(self):
+        from provider_spawns.kimi_spawn import _resolve_heartbeat_log_path
+
+        path = _resolve_heartbeat_log_path("20260805-oi1044-test")
+        self.assertIsNotNone(path)
+        self.assertEqual(path.name, "20260805-oi1044-test.log")
+        self.assertEqual(path.parent.name, "conversations")
+        self.assertEqual(path.parent.parent.name, "logs")
+
+    def test_path_traversal_dispatch_id_rejected(self):
+        from provider_spawns.kimi_spawn import _resolve_heartbeat_log_path
+
+        self.assertIsNone(_resolve_heartbeat_log_path("../../etc/passwd"))
+
+    def test_empty_dispatch_id_rejected(self):
+        from provider_spawns.kimi_spawn import _resolve_heartbeat_log_path
+
+        self.assertIsNone(_resolve_heartbeat_log_path(""))
+
+    def test_shell_metacharacter_dispatch_id_rejected(self):
+        from provider_spawns.kimi_spawn import _resolve_heartbeat_log_path
+
+        self.assertIsNone(_resolve_heartbeat_log_path("d1; rm -rf /"))
+
+    def test_two_dispatches_resolve_to_distinct_files(self):
+        """Structural proof of per-dispatch isolation (not per-terminal, not
+        the shared ~/.kimi/logs/kimi.log): two dispatch_ids never collide."""
+        from provider_spawns.kimi_spawn import _resolve_heartbeat_log_path
+
+        path_a = _resolve_heartbeat_log_path("dispatch-alpha")
+        path_b = _resolve_heartbeat_log_path("dispatch-beta")
+        self.assertNotEqual(path_a, path_b)
+
+
+class TestWriteHeartbeatReport(unittest.TestCase):
+    def test_report_written_atomically_no_tmp_left_behind(self):
+        from provider_spawns.kimi_spawn import _write_heartbeat_report
+        from vnx_paths import resolve_paths
+
+        _write_heartbeat_report("dispatch-atomic-001", "## Summary\ncontent\n")
+
+        data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+        report_path = data_dir / "unified_reports" / "dispatch-atomic-001.md"
+        tmp_path = report_path.with_suffix(report_path.suffix + ".tmp")
+
+        self.assertTrue(report_path.exists())
+        self.assertFalse(tmp_path.exists())
+        self.assertEqual(report_path.read_text(encoding="utf-8"), "## Summary\ncontent\n")
+
+    def test_report_passes_body_contract(self):
+        """The heartbeat's own report must satisfy validate_body, so
+        emit_unified_report's idempotent early-return preserves it untouched
+        instead of treating it as a partial draft to replace."""
+        from provider_spawns.kimi_spawn import _write_heartbeat_report
+        from report_body_contract import validate_body
+        from worker_heartbeat import SilenceVerdict, build_heartbeat_failure_report
+
+        verdict = SilenceVerdict(is_silent=True, silence_seconds=650.0, threshold_seconds=600.0)
+        report = build_heartbeat_failure_report(
+            "dispatch-contract-001", verdict, model="kimi-k2.6", provider="kimi", terminal_id="T1",
+        )
+        _write_heartbeat_report("dispatch-contract-001", report)
+
+        from vnx_paths import resolve_paths
+        data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+        report_path = data_dir / "unified_reports" / "dispatch-contract-001.md"
+        result = validate_body(report_path.read_text(encoding="utf-8"))
+        self.assertTrue(result.valid, f"heartbeat report failed contract: {result}")
+
+
+class TestDrainStreamRawTee(unittest.TestCase):
+    """drain_stream's raw_tee_path mirrors subprocess stdout bytes to a file —
+    the same interception point the tmux lane's pipe-pane capture uses, but
+    for the provider lane's raw Popen pipe instead of a tmux pane."""
+
+    def test_bytes_mirrored_to_tee_file(self):
+        from _streaming_drainer import StreamingDrainerMixin
+        from canonical_event import CanonicalEvent
+
+        class _Host(StreamingDrainerMixin):
+            provider_name = "kimi"
+
+            def _normalize(self, raw):
+                return CanonicalEvent(
+                    dispatch_id="d1", terminal_id="T1", provider="kimi",
+                    event_type="text", data={"text": raw.get("content", "")},
+                    observability_tier=1,
+                )
+
+        payload = b'{"content": "hello"}\n{"content": "world"}\n'
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            os.write(write_fd, payload)
+            os.close(write_fd)
+
+        threading.Thread(target=_writer, daemon=True).start()
+
+        proc = MagicMock()
+        proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        proc.poll.return_value = 0
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tee_path = Path(tmpdir) / "conversations" / "d1.log"
+            host = _Host()
+            events = list(host.drain_stream(
+                proc, "T1", "d1", None,
+                chunk_timeout=5.0, total_deadline=5.0, raw_tee_path=tee_path,
+            ))
+            self.assertEqual(len(events), 2)
+            self.assertTrue(tee_path.exists())
+            self.assertEqual(tee_path.read_bytes(), payload)
+
+    def test_no_tee_path_is_a_no_op(self):
+        """Default (raw_tee_path=None) — existing codex/gemini/litellm callers
+        that never pass this param see zero behavior change."""
+        from _streaming_drainer import StreamingDrainerMixin
+        from canonical_event import CanonicalEvent
+
+        class _Host(StreamingDrainerMixin):
+            provider_name = "kimi"
+
+            def _normalize(self, raw):
+                return CanonicalEvent(
+                    dispatch_id="d1", terminal_id="T1", provider="kimi",
+                    event_type="text", data={"text": raw.get("content", "")},
+                    observability_tier=1,
+                )
+
+        payload = b'{"content": "hi"}\n'
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            os.write(write_fd, payload)
+            os.close(write_fd)
+
+        threading.Thread(target=_writer, daemon=True).start()
+
+        proc = MagicMock()
+        proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        proc.poll.return_value = 0
+
+        host = _Host()
+        events = list(host.drain_stream(proc, "T1", "d1", None, chunk_timeout=5.0, total_deadline=5.0))
+        self.assertEqual(len(events), 1)
+
+
+class TestHeartbeatMonitorLoopKillsSilentWorker(unittest.TestCase):
+    """The core OI-1044 scenario: a stuck provider-lane worker gets detected
+    and killed within the threshold, by a signal external to the process."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._env_patch = {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.2"}
+        self._saved_env = {k: os.environ.get(k) for k in self._env_patch}
+        os.environ.update(self._env_patch)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_silent_worker_killed_and_reported_within_threshold(self):
+        from provider_spawns.kimi_spawn import _heartbeat_monitor_loop
+        from vnx_paths import resolve_paths
+
+        proc = _spawn_real_sleeper()
+        pid = proc.pid
+        self.assertTrue(_pid_alive(pid), "precondition: sleeper must start alive")
+
+        # Empty tee file that never grows — the silent-worker scenario.
+        log_path = Path(self._tmpdir.name) / "silent.log"
+        log_path.write_text("")
+
+        stop_event = threading.Event()
+        killed_event = threading.Event()
+        thread = threading.Thread(
+            target=_heartbeat_monitor_loop,
+            args=(proc, log_path, "dispatch-silent-001", "T1", "kimi-k2.6", stop_event, killed_event),
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        thread.start()
+        try:
+            fired = killed_event.wait(timeout=5.0)
+            self.assertTrue(fired, "heartbeat did not fire within 5s for a 0.2s threshold")
+
+            # Item #2 (OI-1044): liveness must be verified on the real OS
+            # process, never a pidfile — prove the kernel actually reaped it.
+            deadline = time.monotonic() + 3.0
+            while _pid_alive(pid) and time.monotonic() < deadline:
+                time.sleep(0.05)
+            self.assertFalse(_pid_alive(pid), "worker process must actually be dead, not just flagged")
+
+            data_dir = Path(resolve_paths()["VNX_DATA_DIR"])
+            report_path = data_dir / "unified_reports" / "dispatch-silent-001.md"
+            self.assertTrue(report_path.exists(), "heartbeat must write the failure report directly")
+            report_text = report_path.read_text(encoding="utf-8")
+            self.assertIn("## Summary", report_text)
+            self.assertIn("## Changes", report_text)
+            self.assertIn("## Verification", report_text)
+            self.assertIn("## Open Items", report_text)
+            self.assertIn("dispatch-silent-001", report_text)
+            self.assertIn("kimi", report_text)
+        finally:
+            stop_event.set()
+            thread.join(timeout=2.0)
+            if _pid_alive(pid):
+                proc.kill()
+                proc.wait(timeout=2.0)
+
+
+class TestHeartbeatMonitorLoopFalsePositiveGuard(unittest.TestCase):
+    """The calibration finding that MUST NOT regress: a worker producing
+    periodic read-only tool-call activity (no file writes, but a steady
+    trickle of stdout bytes — Read/Grep/Bash tool_call+tool_result pairs)
+    must NOT be killed, even across a span exceeding what a naive
+    worktree-mutation-only check would tolerate."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._env_patch = {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.3"}
+        self._saved_env = {k: os.environ.get(k) for k in self._env_patch}
+        os.environ.update(self._env_patch)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_periodic_activity_within_threshold_never_killed(self):
+        from provider_spawns.kimi_spawn import _heartbeat_monitor_loop
+
+        proc = _spawn_real_sleeper()
+        log_path = Path(self._tmpdir.name) / "active.log"
+        log_path.write_text("")
+
+        stop_event = threading.Event()
+        killed_event = threading.Event()
+        thread = threading.Thread(
+            target=_heartbeat_monitor_loop,
+            args=(proc, log_path, "dispatch-active-001", "T1", "kimi-k2.6", stop_event, killed_event),
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        thread.start()
+        try:
+            # Simulate a worker whose gaps between tool calls (0.1s) stay well
+            # under the 0.3s threshold — the scaled-down analogue of kimi's
+            # measured <=209s inter-step gaps against the 600s default.
+            deadline = time.monotonic() + 1.0
+            with open(log_path, "ab", buffering=0) as fh:
+                while time.monotonic() < deadline:
+                    fh.write(b'{"type":"tool_call"}\n')
+                    time.sleep(0.1)
+
+            self.assertFalse(
+                killed_event.is_set(),
+                "false positive: a worker with sub-threshold activity gaps must not be killed",
+            )
+            self.assertTrue(_pid_alive(proc.pid), "process must still be running")
+        finally:
+            stop_event.set()
+            thread.join(timeout=2.0)
+            if _pid_alive(proc.pid):
+                proc.kill()
+                proc.wait(timeout=2.0)
+
+
+class TestHeartbeatConcurrencyIsolation(unittest.TestCase):
+    """Two concurrent dispatches must never mask each other's liveness — the
+    exact failure mode of the shared ~/.kimi/logs/kimi.log this design avoids."""
+
+    def setUp(self):
+        self._tmpdir = tempfile.TemporaryDirectory()
+        self._env_patch = {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.2"}
+        self._saved_env = {k: os.environ.get(k) for k in self._env_patch}
+        os.environ.update(self._env_patch)
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_dead_dispatch_does_not_mask_live_dispatch(self):
+        from provider_spawns.kimi_spawn import _heartbeat_monitor_loop
+
+        proc_dead = _spawn_real_sleeper()
+        proc_alive = _spawn_real_sleeper()
+
+        log_dead = Path(self._tmpdir.name) / "dead.log"
+        log_dead.write_text("")
+        log_alive = Path(self._tmpdir.name) / "alive.log"
+        log_alive.write_text("")
+
+        stop_dead, killed_dead = threading.Event(), threading.Event()
+        stop_alive, killed_alive = threading.Event(), threading.Event()
+
+        t_dead = threading.Thread(
+            target=_heartbeat_monitor_loop,
+            args=(proc_dead, log_dead, "dispatch-dead-001", "T1", "kimi-k2.6", stop_dead, killed_dead),
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        t_alive = threading.Thread(
+            target=_heartbeat_monitor_loop,
+            args=(proc_alive, log_alive, "dispatch-alive-001", "T2", "kimi-k2.6", stop_alive, killed_alive),
+            kwargs={"poll_interval": 0.05},
+            daemon=True,
+        )
+        t_dead.start()
+        t_alive.start()
+        try:
+            deadline = time.monotonic() + 1.5
+            with open(log_alive, "ab", buffering=0) as fh:
+                while time.monotonic() < deadline:
+                    fh.write(b'{"type":"tool_call"}\n')
+                    time.sleep(0.05)
+
+            self.assertTrue(killed_dead.wait(timeout=3.0), "the genuinely stuck dispatch must still be killed")
+            self.assertFalse(
+                killed_alive.is_set(),
+                "a live, concurrently-running dispatch must not be killed by another dispatch's silence",
+            )
+            self.assertFalse(_pid_alive(proc_dead.pid))
+            self.assertTrue(_pid_alive(proc_alive.pid))
+        finally:
+            stop_dead.set()
+            stop_alive.set()
+            t_dead.join(timeout=2.0)
+            t_alive.join(timeout=2.0)
+            for p in (proc_dead, proc_alive):
+                if _pid_alive(p.pid):
+                    p.kill()
+                    p.wait(timeout=2.0)
+
+
+class TestSpawnKimiHeartbeatWiring(unittest.TestCase):
+    """spawn_kimi() itself starts/stops the monitor thread and surfaces a
+    heartbeat kill as a diagnosable result.error — without needing to wait
+    out the real 30s poll interval in a test."""
+
+    def test_heartbeat_thread_started_and_stopped_around_drain(self):
+        """Real pipe (not a bare BytesIO) so the drainer's own producer thread
+        also runs concurrently — proving the heartbeat thread is tracked
+        specifically by name, not just "whichever thread was created last"."""
+        from provider_spawns import kimi_spawn
+
+        heartbeat_threads = []
+        real_thread_cls = threading.Thread
+
+        class _RecordingThread(real_thread_cls):
+            def start(self):
+                if isinstance(self._args and self._args[0], object) and str(self.name).startswith("kimi-heartbeat-"):
+                    heartbeat_threads.append(self)
+                super().start()
+
+        payload = json.dumps({"event_type": "complete"}).encode() + b"\n"
+        read_fd, write_fd = os.pipe()
+
+        def _writer():
+            os.write(write_fd, payload)
+            os.close(write_fd)
+
+        threading.Thread(target=_writer, daemon=True).start()
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.poll.return_value = 0
+        fake_proc.stdout = os.fdopen(read_fd, "rb", buffering=0)
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=0)
+
+        with patch.object(kimi_spawn, "_start_kimi_subprocess", return_value=(fake_proc, None)), \
+             patch("threading.Thread", _RecordingThread):
+            kimi_spawn.spawn_kimi("prompt", dispatch_id="dispatch-wiring-001", terminal_id="T1")
+
+        self.assertEqual(len(heartbeat_threads), 1, "exactly one heartbeat monitor thread must be started")
+        self.assertFalse(heartbeat_threads[0].is_alive(), "heartbeat thread must be stopped+joined before spawn_kimi returns")
+
+    def test_unsafe_dispatch_id_skips_heartbeat_without_crashing(self):
+        """When _resolve_heartbeat_log_path returns None, spawn_kimi must still
+        complete normally — a missing heartbeat is fail-open, not fail-closed."""
+        from provider_spawns import kimi_spawn
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = 0
+        fake_proc.poll.return_value = 0
+        fake_proc.stdout = io.BytesIO(json.dumps({"event_type": "complete"}).encode() + b"\n")
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=0)
+
+        with patch.object(kimi_spawn, "_start_kimi_subprocess", return_value=(fake_proc, None)):
+            result = kimi_spawn.spawn_kimi("prompt", dispatch_id="../unsafe", terminal_id="T1")
+
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+
+    def test_heartbeat_kill_overrides_result_error_with_diagnosable_message(self):
+        """When the monitor thread sets killed_event, spawn_kimi must replace
+        the generic 'kimi exited with code N' with a message that names the
+        heartbeat and points at the report the monitor already wrote."""
+        from provider_spawns import kimi_spawn
+
+        fake_proc = MagicMock()
+        fake_proc.returncode = -9
+        fake_proc.poll.return_value = -9
+        fake_proc.stdout = io.BytesIO(b"")
+        fake_proc.stderr = io.BytesIO(b"")
+        fake_proc.wait = MagicMock(return_value=-9)
+
+        def _fake_monitor_loop(proc, log_path, dispatch_id, terminal_id, model, stop_event, killed_event, poll_interval=30.0):
+            # Simulate an immediate silence-kill instead of waiting out a real threshold.
+            killed_event.set()
+            stop_event.wait()
+
+        with patch.object(kimi_spawn, "_start_kimi_subprocess", return_value=(fake_proc, None)), \
+             patch.object(kimi_spawn, "_heartbeat_monitor_loop", _fake_monitor_loop):
+            result = kimi_spawn.spawn_kimi("prompt", dispatch_id="dispatch-hbkill-001", terminal_id="T1")
+
+        self.assertIsNotNone(result.error)
+        self.assertIn("heartbeat", result.error)
+        self.assertIn("dispatch-hbkill-001", result.error)
+        self.assertNotEqual(result.returncode, 0)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_streaming_drainer.py
+++ b/tests/test_streaming_drainer.py
@@ -24,6 +24,7 @@ from _streaming_drainer import (
     StreamingDrainerMixin,
     _make_error_event,
     _parse_line,
+    _run_producer,
     _STREAMING_TIER,
     coerce_chunk_stall,
 )
@@ -425,6 +426,92 @@ class TestStallSurvival:
 
         assert elapsed < 3.0, f"env override should fire fast, got {elapsed:.2f}s"
         assert any(e.event_type == "error" for e in events)
+
+
+class TestDeadlineCompressedStallLabeling:
+    """OI-1044 co-death investigation: when total_deadline is close, `remaining`
+    (the actual select() wait) is compressed below the configured chunk_timeout.
+    A `not ready` in that compressed window must never be reported as
+    "chunk timeout {chunk_timeout}s exceeded" — that overstates how long the
+    worker was actually silent and mislabels a deadline-driven kill as a
+    silence-driven one, which is exactly what made a kimi dispatch look like
+    it "died right after finishing a tool call" instead of "ran out of its
+    total budget".
+
+    Tests call ``_run_producer`` directly (not the ``drain_stream`` wrapper)
+    with post-coercion values: in a real long-running dispatch, `chunk_timeout`
+    is already floored to `<= total_deadline` by `coerce_chunk_stall` at drain
+    start, and the compression this class targets only appears once `elapsed`
+    has grown close to `total_deadline` over the dispatch's lifetime — calling
+    `_run_producer` directly lets the test represent "we are already near the
+    deadline" without an actual multi-minute wait.
+    """
+
+    @staticmethod
+    def _run_and_collect(*, chunk_timeout: float, total_deadline: float, script: str):
+        proc = subprocess.Popen(
+            [sys.executable, "-c", script],
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+            start_new_session=True,
+        )
+        result_queue: queue.Queue = queue.Queue()
+        try:
+            _run_producer(
+                process=proc,
+                terminal_id="T1",
+                dispatch_id="d-labeling",
+                event_store=None,
+                chunk_timeout=chunk_timeout,
+                total_deadline=total_deadline,
+                result_queue=result_queue,
+                seen_complete=threading.Event(),
+                timed_out=threading.Event(),
+                normalize_fn=lambda raw: CanonicalEvent(
+                    dispatch_id="d-labeling", terminal_id="T1", provider="claude",
+                    event_type=raw.get("type", "text"), data=raw.get("data", {}),
+                    observability_tier=2,
+                ),
+                provider_name="claude",
+            )
+        finally:
+            proc.wait(timeout=5)
+        events = []
+        while not result_queue.empty():
+            events.append(result_queue.get_nowait())
+        return events
+
+    def test_kill_near_deadline_reports_actual_wait_not_full_chunk_timeout(self):
+        """chunk_timeout=5.0 with only 1.0s of total budget left: the select()
+        wait is compressed to ~1.0s, not the full 5.0s chunk window. The
+        synthetic error's reason must reflect the ~1s actual gap, not falsely
+        claim a full 5s chunk_timeout elapsed."""
+        events = self._run_and_collect(
+            chunk_timeout=5.0, total_deadline=1.0,
+            script="import time\ntime.sleep(3)\n",  # never writes anything
+        )
+
+        errors = [e for e in events if e.event_type == "error"]
+        assert len(errors) == 1
+        reason = errors[0].data.get("reason", "")
+        assert reason != "chunk timeout 5s exceeded", (
+            f"deadline-compressed kill must not claim the full chunk_timeout elapsed: {reason!r}"
+        )
+        assert "deadline" in reason.lower()
+        assert "1s" in reason
+
+    def test_kill_with_no_deadline_pressure_keeps_chunk_timeout_label(self):
+        """chunk_timeout=1.0 with a roomy total_deadline=30.0: remaining ==
+        chunk_timeout (not compressed), so the ORIGINAL "chunk timeout Ns
+        exceeded" label is still correct and must be unchanged."""
+        events = self._run_and_collect(
+            chunk_timeout=1.0, total_deadline=30.0,
+            script="import time\ntime.sleep(3)\n",
+        )
+
+        errors = [e for e in events if e.event_type == "error"]
+        assert len(errors) == 1
+        reason = errors[0].data.get("reason", "")
+        assert reason == "chunk timeout 1s exceeded"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Waarom

De worker-heartbeat uit #1387 was in twee lanes gewired en juist niet in de lane van de
fleet-default build-worker. Gemeten op 5 augustus: `provider_dispatch.py` (2619 regels) en
`provider_spawns/kimi_spawn.py` bevatten nul heartbeat-verwijzingen, terwijl
`tmux_interactive_dispatch.py:1941` en `subprocess_dispatch_internals/delivery_runtime.py:87`
hem wel hebben.

Gevolg in de praktijk: toen dispatch `20260805-oi1043-receipt-isolation` op deze lane draaide
was er geen enkele machinale bron om vast te stellen of de worker nog leefde. Geen
event-stream, geen actieve-dispatch-map, geen lane-log per dispatch. Het moest met de hand uit
`~/.kimi/logs/kimi.log`, een CPU-delta en `lsof`.

## Wat erin zit

- Heartbeat in de provider-lane, via dezelfde `worker_heartbeat`-module en dezelfde
  drempelconfiguratie als de twee bestaande lanes. Geen tweede implementatie ernaast.
- Een raw-tee-hook op de gedeelde drainer, additief en achterwaarts compatibel voor de andere
  providers.
- Nauwkeuriger diagnose-tekst bij een deadline-kill (zie hieronder).
- 17 nieuwe tests.

## De co-death, opgelost

De onderzoeksvraag was waarom de kimi-worker meestierf met zijn ouder terwijl
`start_new_session=True` staat. Antwoord met bestand en regel:

De provider-lane draait **in-process**. `dispatch_cli.py:1672` roept `run_envelope_plan`
direct aan, die via `envelope_adapters_provider.py:466` `spawn_kimi` importeert. Er is dus
geen apart `provider_dispatch.py`-proces: `dispatch_cli.py` is de letterlijke OS-ouder van
kimi. De watchdog-thread in `_streaming_drainer.py:463` doet
`os.killpg(os.getpgid(process.pid), SIGTERM)` op kimi's eigen procesgroep, vanuit datzelfde
proces.

`start_new_session=True` blokkeert signaalvoortplanting via de sessie van de ouder. Het doet
niets tegen de ouder die zelf besluit die procesgroep te killen. De isolatie was niet kapot,
ze is nooit in het geding geweest.

## Bijvangst: een misleidende foutmelding

`remaining = min(chunk_timeout, total_deadline - elapsed)` knijpt het wachtvenster samen
naarmate de totale deadline nadert. Een kill in dat samengeknepen venster werd gelogd als
"chunk timeout overschreden", terwijl het gewoon de deadline was. De kill zelf is correct, de
diagnose was fout. Dat is nu rechtgezet.

## Verificatie

Gerichte tests op de branch:

```
tests/test_kimi_spawn_heartbeat.py + test_streaming_drainer.py + test_kimi_spawn.py
  -> 140 passed
tests/test_claude_spawn.py + codex/claude fail_closed + deepseek_harness + classifier_providers
  -> 69 passed
```

Regressiecontrole op de gedeelde drainer, identiek commando in dezelfde omgeving:

| | branch | main (`060c28a2`) |
|---|---|---|
| `pytest -k "provider or envelope or drainer or spawn"` | 11 failed, **1817** passed | 11 failed, **1800** passed |

Dezelfde elf faalnamen op beide kanten, dus pre-existing op main en niet door deze branch
veroorzaakt. Zeventien tests erbij.

## Open punten

- De elf falers hierboven staan al op main terwijl VNX CI op `060c28a2` groen was. Ze zitten
  dus buiten de CI-poort. Aparte opruiming, niet in deze PR.
- Deze branch is door T0 uit de hoofdcheckout gered nadat de dispatch eindigde terwijl de
  worker op de volledige suite wachtte. De lane werkte in de hoofdcheckout ondanks
  `isolation: "worktree"` in de spec. Dat is de klasse van OI-975 en wordt apart gefiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUCscZ8vsNRfNwwFoyrPkH