### PR TITLE
docs(dispatch): verbied de volledige suite in de worker-conventie (OI-1046)

### DIFF
--- a/.claude/skills/backend-developer/SKILL.md
+++ b/.claude/skills/backend-developer/SKILL.md
@@ -86,7 +86,9 @@ These patterns recur in codex_gate findings. Apply preemptively.
 - [ ] **Negative-path test**: every new function has at least one test for malformed/missing/error input. Crashing > silently-succeeding.
 
 ### Worker Convention
-- [ ] **Run pytest before push**: `pytest <test files> -x` succeeds. Don't push if any test red.
+- [ ] **Run pytest before push — TARGETED ONLY**: `pytest <the test files you touched> -x` succeeds. Don't push if any test red.
+- [ ] **NEVER run the full suite.** `pytest tests/` is ~19.400 tests, serial, and takes longer than a dispatch lives. CI Profile A already sweeps the whole tree on every PR — that run has an owner and it is not you. Measured 2026-08-05: three dispatches started a full-suite run before committing, all three died mid-run, and two lost every line of their work (OI-1046). Test what you touched plus its direct neighbours, then commit.
+- [ ] **Commit and push BEFORE any long-running verification.** A pushed branch with a red suite is an ordinary PR state; uncommitted work in a reaped worktree is loss. Order: targeted tests green → commit → push → anything slower.
 - [ ] **`bash -n` on shell changes**: every modified `.sh` file must pass syntax check.
 - [ ] **No TODO/FIXME**: full implementation only. If something's not done, escalate, don't comment.
 

--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -408,6 +408,8 @@ Every dispatch instruction MUST include the following footer (codified — don't
 - DO NOT add TODO/FIXME — full implementation
 - DO NOT modify .vnx-data/ runtime state directly
 - DO NOT bypass tests with --no-verify
+- DO NOT run the full suite (`pytest tests/`) — test ONLY the files you touched plus their direct neighbours. CI Profile A sweeps the whole tree on every PR; that run is not yours to duplicate
+- Order is: targeted tests green → COMMIT → PUSH → anything slower. A pushed branch with a red suite is an ordinary PR state; uncommitted work in a reaped worktree is loss
 - DO NOT abort if first sub-task succeeds — continue with rest
 - After commit: PUSH and CREATE PR (or update if existing) — dispatch is INCOMPLETE without PR
 - DO NOT suppress with `# noqa:` — the Lint Patterns gate rejects it. Use a PLAIN marker comment on the line: `# vnx-silent-except: <reason>` (silent except) / `# vnx-atomic-write: <reason>` (non-atomic state write)


### PR DESCRIPTION
## Waarom

De conventie schreef **al** gericht testen voor. `.claude/skills/backend-developer/SKILL.md`:

> Run pytest before push: `pytest <test files> -x` succeeds.

Dat is `<test files>`, niet `pytest tests/`. En `.claude/terminals/T1/CLAUDE.md` zegt alleen
"pytest for testing", zonder enige eis over volledigheid.

**Niemand droeg workers op de volledige suite te draaien. Ze deden het uit zichzelf.**

## Wat dat kostte, gemeten

5 augustus: drie dispatches startten `pytest tests/` (circa 19.400 tests, serieel) vóór hun
commit. Alle drie stierven halverwege die run.

- `20260805-oi1043-receipt-isolation` — alles ongecommit, gered door T0
- `20260805-oi1044-heartbeat-r2` — 420 regels ongecommit in de hoofdcheckout, gered door T0
- `20260805-glm52-doc-sweep` — **overleefde**, want die had de omgekeerde volgorde opgedragen
  gekregen en pushte eerst

Diezelfde faalvorm is de bron van **OI-1052**: 31 van de 53 worktrees staan vergrendeld met
`vnx preserve`, omdat de reaper een vuile worktree bewaart in plaats van hem te verwijderen.
Elke dispatch die vroeg eindigt eindigt vuil.

## Wat er verandert

Twee bestanden, vijf regels. Geen versoepeling: een aanscherping van wat er al stond, plus een
expliciet verbod, want "run tests before push" blijkt vanzelf maximaal geïnterpreteerd te worden.

- **`.claude/skills/backend-developer/SKILL.md`** — de Worker Convention verbiedt de volledige
  suite en schrijft de volgorde voor
- **`.claude/terminals/T0/role-orchestrator.md`** — dezelfde twee regels in de Critical-rules-footer
  die elke dispatch-instructie meekrijgt

De regel: **toets wat je raakt plus de directe buren, commit, push, en laat het trage werk aan CI.**

CI Profile A doet die volledige sweep al bij elke PR, met een expliciete toelichting in de
workflow ("Full-suite sweep: pytest tests/ at directory level so every test file is exercised").
Die run heeft dus een eigenaar, en dat is de worker niet.

## De afweging, hardop

Een worker die alleen zijn eigen bestanden toetst kan iets pushen dat elders breekt. Dat vangt
PR-CI, en de branch staat op dat moment al veilig. Dat is precies de afweging die de conventie
oorspronkelijk al maakte; deze PR maakt hem alleen afdwingbaar.

## Verificatie

Identieke selectie op branch en main:

```
pytest -k "role or skill_valid or worker_convention or dispatch_standard"
  branch: 1 failed, 1 error, 302 passed
  main:   1 failed, 1 error, 302 passed   (dezelfde namen)
```

Pre-existing, niet door deze PR veroorzaakt.

## Herkomst

Door T0 direct gemaakt in plaats van via een dispatch. Drie van de vier dispatches op 5 augustus
leverden geen enkele regel code op, en dit is prozawijziging die al in de dispatch-instructies
van gisteren stond. `role-orchestrator.md` synct vloot-breed via `vnx role sync`, dus de
wijziging hoort langs review — vandaar deze PR in plaats van een directe commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WUCscZ8vsNRfNwwFoyrPkH