### PR TITLE
feat(horizon): expose link-pr and set-lane-hint in the pip CLI (OI-1063)

### DIFF
--- a/tests/test_horizon_cli.py
+++ b/tests/test_horizon_cli.py
@@ -345,9 +345,30 @@ def test_horizon_help_lists_full_surface(monkeypatch, capsys):
     for verb in (
         "add", "list", "show", "sync", "drift", "reconcile",
         "reconcile-review", "reconcile-streak", "close", "reopen",
+        "link-pr", "set-lane-hint",
         "deliverable", "plan-gate",
     ):
         assert verb in out, f"missing verb in `vnx horizon --help`: {verb}"
+
+
+def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
+    rc, out, _ = _run(monkeypatch, capsys, ["objective", "--help"])
+    assert rc == 0
+    for verb in (
+        "add", "list", "show", "sync", "drift", "reconcile",
+        "reconcile-review", "reconcile-streak", "close", "reopen",
+        "link-pr", "set-lane-hint",
+    ):
+        assert verb in out
+    # objective is the OBJECTIVE-domain alias only — deliverable/plan-gate stay
+    # on their own top-level surfaces, matching bin/vnx's existing split.
+    assert "deliverable" not in out
+    assert "plan-gate" not in out
+
+    rc, out, _ = _run(monkeypatch, capsys, ["deliverable", "--help"])
+    assert rc == 0
+    for verb in ("add", "list", "promote"):
+        assert verb in out
 
 
 def test_horizon_deliverable_and_plan_gate_help_list_full_surface(monkeypatch, capsys):
@@ -359,25 +380,6 @@ def test_horizon_deliverable_and_plan_gate_help_list_full_surface(monkeypatch, c
     rc, out, _ = _run(monkeypatch, capsys, ["horizon", "plan-gate", "--help"])
     assert rc == 0
     for verb in ("seed", "run", "status"):
-        assert verb in out
-
-
-def test_objective_and_deliverable_alias_help(monkeypatch, capsys):
-    rc, out, _ = _run(monkeypatch, capsys, ["objective", "--help"])
-    assert rc == 0
-    for verb in (
-        "add", "list", "show", "sync", "drift", "reconcile",
-        "reconcile-review", "reconcile-streak", "close", "reopen",
-    ):
-        assert verb in out
-    # objective is the OBJECTIVE-domain alias only — deliverable/plan-gate stay
-    # on their own top-level surfaces, matching bin/vnx's existing split.
-    assert "deliverable" not in out
-    assert "plan-gate" not in out
-
-    rc, out, _ = _run(monkeypatch, capsys, ["deliverable", "--help"])
-    assert rc == 0
-    for verb in ("add", "list", "promote"):
         assert verb in out
 
 
@@ -491,3 +493,125 @@ def test_horizon_sync_reads_project_roadmap_not_central_template(project, monkey
     assert "example-feature" not in report.get("created", [])
     assert s["orphan"] == 0, report
     assert "real-track" not in report.get("orphan", [])
+
+
+# ---------------------------------------------------------------------------
+# link-pr / set-lane-hint — the two verbs planning_cli exposes that were
+# missing from the pip CLI (OI-1063). Verifies they resolve through
+# _VERB_DISPATCH, delegate to the identical cmd_* function, and round-trip
+# their arguments (multiple PR refs, --delivery default of 'partial',
+# lane_hint choices).
+# ---------------------------------------------------------------------------
+
+import planning_cli  # noqa: E402
+
+
+def test_link_pr_and_set_lane_hint_resolve_through_verb_dispatch():
+    """Both verbs are registered in _VERB_DISPATCH and delegate to the real
+    planning_cli cmd_* functions (not reimplemented)."""
+    assert _horizon._VERB_DISPATCH["link-pr"] is _horizon._cmd_link_pr
+    assert _horizon._VERB_DISPATCH["set-lane-hint"] is _horizon._cmd_set_lane_hint
+
+    # The wrappers delegate to the real planning_cli cmd_* functions.
+    assert hasattr(planning_cli, "cmd_objective_link_pr")
+    assert hasattr(planning_cli, "cmd_objective_set_lane_hint")
+
+
+def _capture_delegate(monkeypatch, name):
+    """Stub a planning_cli cmd_* function and capture the args it receives."""
+    captured = {}
+
+    def _stub(args):
+        captured["args"] = args
+        return 0
+
+    monkeypatch.setattr(planning_cli, name, _stub)
+    return captured
+
+
+def test_horizon_link_pr_round_trips_multiple_prs_and_delivery_default(project, monkeypatch, capsys):
+    """`vnx horizon link-pr <track> <pr> <pr>` parses multiple PR refs and
+    defaults --delivery to 'partial' (fail-closed)."""
+    project_dir, _ = project
+    captured = _capture_delegate(monkeypatch, "cmd_objective_link_pr")
+
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "link-pr", "feat-link", "#1234", "#1235",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+
+    args = captured["args"]
+    assert args.track_id == "feat-link"
+    assert args.pr == ["#1234", "#1235"]                 # multiple refs preserved, in order
+    assert args.delivery == "partial"                    # fail-closed default
+    assert args.project_id == "horizon-test"
+    # state_dir is the central root, resolved by _prep — not planning_cli's
+    # repo-local degraded path.
+    assert args.state_dir == str(_engine.resolve_data_root(Path(project_dir)) / "state")
+
+
+def test_horizon_link_pr_explicit_delivery_and_json_round_trip(project, monkeypatch, capsys):
+    project_dir, _ = project
+    captured = _capture_delegate(monkeypatch, "cmd_objective_link_pr")
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "link-pr", "feat-link", "#7777",
+        "--delivery", "complete", "--json",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 0, err
+    assert captured["args"].delivery == "complete"
+    assert captured["args"].json is True
+
+
+def test_horizon_link_pr_rejects_unknown_delivery(project, monkeypatch, capsys):
+    """argparse rejects a --delivery outside {partial,complete} (exit 2)."""
+    project_dir, _ = project
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "link-pr", "feat-link", "#1",
+        "--delivery", "bogus",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 2
+
+
+def test_horizon_set_lane_hint_round_trips_choices(project, monkeypatch, capsys):
+    """`vnx horizon set-lane-hint <track> <hint>` accepts governed|direct|unset
+    and round-trips lane_hint onto the delegated args."""
+    project_dir, _ = project
+    for hint in ("governed", "direct", "unset"):
+        captured = _capture_delegate(monkeypatch, "cmd_objective_set_lane_hint")
+        rc, _, err = _run(monkeypatch, capsys, [
+            "horizon", "set-lane-hint", "feat-lane", hint,
+            "--project-id", "horizon-test", "--project-dir", str(project_dir),
+        ])
+        assert rc == 0, err
+        assert captured["args"].lane_hint == hint
+        assert captured["args"].track_id == "feat-lane"
+
+
+def test_horizon_set_lane_hint_rejects_unknown_choice(project, monkeypatch, capsys):
+    project_dir, _ = project
+    rc, _, err = _run(monkeypatch, capsys, [
+        "horizon", "set-lane-hint", "feat-lane", "bogus",
+        "--project-id", "horizon-test", "--project-dir", str(project_dir),
+    ])
+    assert rc == 2
+
+
+def test_horizon_link_pr_help_matches_engine_arg_surface(monkeypatch, capsys):
+    """`vnx horizon link-pr --help` accepts the same arguments as the
+    planning_cli engine (TRACK_ID, PR with nargs='+', --delivery)."""
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "link-pr", "--help"])
+    assert rc == 0
+    assert "TRACK_ID" in out
+    assert "PR" in out
+    assert "--delivery" in out
+    assert "partial" in out and "complete" in out
+
+
+def test_horizon_set_lane_hint_help_matches_engine_arg_surface(monkeypatch, capsys):
+    rc, out, _ = _run(monkeypatch, capsys, ["horizon", "set-lane-hint", "--help"])
+    assert rc == 0
+    assert "TRACK_ID" in out
+    assert "governed" in out and "direct" in out and "unset" in out

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -318,6 +318,8 @@ _OBJECTIVE_ARGV = {
     "reconcile-streak": [],
     "close": ["delegate-track"],
     "reopen": ["delegate-track"],
+    "link-pr": ["delegate-track", "#1234", "#1235", "--delivery", "complete"],
+    "set-lane-hint": ["delegate-track", "governed"],
 }
 _DELIVERABLE_ARGV = {
     "add": ["--objective", "delegate-track", "--output-kind", "doc", "--title", "Delegate deliverable"],

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -183,6 +183,18 @@ def _cmd_reopen(args: Any) -> int:
     return pc.cmd_objective_reopen(args)
 
 
+def _cmd_link_pr(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_link_pr(args)
+
+
+def _cmd_set_lane_hint(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_objective_set_lane_hint(args)
+
+
 _VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
     "add": _cmd_add,
     "list": _cmd_list,
@@ -194,6 +206,8 @@ _VERB_DISPATCH: dict[str, Callable[[Any], int]] = {
     "reconcile-streak": _cmd_reconcile_streak,
     "close": _cmd_close,
     "reopen": _cmd_reopen,
+    "link-pr": _cmd_link_pr,
+    "set-lane-hint": _cmd_set_lane_hint,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -569,6 +569,34 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     p_reopen.add_argument("--reason", default="",
                           help="reason for reopening (REQUIRED)")
 
+    p_link_pr = subs.add_parser(
+        "link-pr",
+        help="manually link PR ref(s) to a track (retroactive/override; audited)",
+    )
+    _common_horizon_args(p_link_pr)
+    p_link_pr.add_argument("track_id", metavar="TRACK_ID")
+    p_link_pr.add_argument(
+        "pr", nargs="+", metavar="PR",
+        help="PR reference(s) as #NNN or NNN; comma-separated or repeated",
+    )
+    p_link_pr.add_argument(
+        "--delivery", choices=("partial", "complete"), default="partial",
+        help="delivery_kind for the linked PR(s): 'partial' ships a slice of the "
+             "plan, 'complete' ships the whole thing (default: partial — fail-closed; "
+             "OI-829 auto-close requires >=1 linked PR marked 'complete')",
+    )
+
+    p_lane_hint = subs.add_parser(
+        "set-lane-hint",
+        help="set the descriptive dispatch lane_hint (governed|direct|unset) on a track",
+    )
+    _common_horizon_args(p_lane_hint)
+    p_lane_hint.add_argument("track_id", metavar="TRACK_ID")
+    p_lane_hint.add_argument(
+        "lane_hint", choices=("direct", "governed", "unset"), metavar="LANE_HINT",
+        help="descriptive dispatch-routing hint (governed|direct|unset)",
+    )
+
 
 def _register_deliverable_verbs(subs: argparse.Action) -> None:
     """Register the deliverable-domain verbs shared by `vnx horizon deliverable`


### PR DESCRIPTION
## Summary

`scripts/planning_cli.py objective` exposes 12 verbs; the pip CLI (`vnx_cli/`) exposed only 10. `link-pr` and `set-lane-hint` were missing. A consumer install (mission-control, SEOcrawler_v2, sales-copilot, pa-engine) has no `scripts/` dir and runs only the pip CLI, so retroactively linking a merged PR to a track was impossible there — `objective reconcile` could never nominate that track and it could never be closed on evidence.

This exposes both verbs through the pip CLI so the consumer surface matches `planning_cli.py`.

## Changes

- `vnx_cli/commands/horizon.py` — `_cmd_link_pr` / `_cmd_set_lane_hint` thin delegates to `pc.cmd_objective_link_pr` / `pc.cmd_objective_set_lane_hint`, registered in `_VERB_DISPATCH`. `_prep` binds the central `state_dir` + resolved `project_id` as the sibling verbs do; neither verb needs `_default_repo_root`.
- `vnx_cli/main.py` — two subparsers mirroring the `planning_cli.py` argparse: `link-pr` (positional `track_id` + `pr[nargs='+']` + `--delivery {partial,complete}` default `partial`) and `set-lane-hint` (`track_id` + `lane_hint {governed,direct,unset}`). No invented flags.
- `tests/test_horizon_cli.py` — verb-dispatch resolution, argument round-trips (multiple PR refs, `--delivery` default `partial`, explicit `complete`, `--json`, `lane_hint` choices, unknown-choice rejection), and `--help` arg surface.
- `tests/test_horizon_parity.py` — add the two verbs to the delegation parametrize table so the existing parity suite covers them.

CLI surface only. No `planning_cli.py` behaviour, tracks schema, or reconcile logic changed.

## Verification

```
python3 -m pytest tests/test_horizon_cli.py tests/test_horizon_parity.py -q -k "link-pr or set-lane-hint"  # 8 passed
python3 -m pytest tests/test_horizon_cli.py -q                                                            # 26 passed
python3 -m pytest tests/test_planning_cli.py tests/test_planning_cli_lane_hint.py -q                      # 36 passed
```

`vnx horizon link-pr --help` and `python3 scripts/planning_cli.py objective link-pr --help` accept the same arguments (pip CLI exposes `--project-dir` instead of `--state-dir`, the intentional documented divergence — `state_dir` is resolved internally via the central data root).

Pre-existing failures unrelated to this change remain on `main` (`add` missing `--lane-hint`, `close` missing `--attest`, `plan-gate attest` delegation, two `planning_cli_objective` list tests) — verified by `git stash` against `ed66d8fc`. Out of scope.

## Open Items

None.

**Dispatch-ID**: 20260806-151901-horizon-cli-verbs
**Model**: glm-5.2
**Provider**: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)