### PR TITLE
feat(gate): make the plan-gate panel composition configurable (OI-1057)

### DIFF
--- a/configs/plan_gate_panel.yaml
+++ b/configs/plan_gate_panel.yaml
@@ -1,0 +1,50 @@
+# VNX plan-gate panel composition — the ordered seat list the PM plan-first
+# gate dispatches before any implementation begins.
+#
+# See scripts/lib/plan_gate_panel.py (load_panel_seats) for the loader. Every
+# field here mirrors the keys DEFAULT_PANEL used historically so this file is a
+# behaviour-neutral externalisation of that constant on the day it shipped:
+# edit this file to change which seats run, leave it and the code falls back to
+# DEFAULT_PANEL.
+#
+# Each seat has the SAME three keys the in-code DEFAULT_PANEL uses:
+#   label      — the panelist identifier (stable, used by --panel-seats filtering
+#                and the per-seat verdict ledger)
+#   provider   — a member of the closed Provider enum in
+#                scripts/lib/dispatch_spec.py (claude, kimi, glm-harness,
+#                deepseek-harness, codex, ...). An unknown value fails loud at
+#                load time naming the offending seat and the valid providers.
+#   model_arg  — the model string handed to the lane (opus, kimi-k3, glm-5.2,
+#                ...). Not validated here; the lane rejects an unrunnable model.
+#
+# One panelist per provider family (Anthropic / Moonshot / Zhipu / DeepSeek /
+# OpenAI) so a plan is reviewed from five independent vantage points before any
+# code is written. A panelist that flakes (a down proxy, an uninstalled CLI,
+# an unparseable verdict) is RETRIED once and then ABSTAINS as a non-scoring
+# lane instead of vetoing — see apply_panel_rule's liveness quorum. Keep every
+# provider here runnable anyway; the retry only rescues transient flakes.
+# glm-harness requires the local litellm proxy on :4141.
+#
+# NOTE: gemini is intentionally omitted until the `gemini` CLI is installed —
+# an unrunnable panelist emits no verdict, which the fail-safe rule turns into an
+# unconditional REVISE. Adding a seat here is an operator decision, not a code
+# change; the default composition is whatever this file declares.
+
+version: 1
+
+seats:
+  - label: opus
+    provider: claude
+    model_arg: opus
+  - label: kimi
+    provider: kimi
+    model_arg: kimi-k3
+  - label: glm-5.2-harness
+    provider: glm-harness
+    model_arg: glm-5.2
+  - label: deepseek
+    provider: deepseek-harness
+    model_arg: deepseek-v4-pro
+  - label: codex
+    provider: codex
+    model_arg: gpt-5.5

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -48,6 +48,13 @@ from typing import Any, Callable, Dict, List, Optional
 HERE = Path(__file__).resolve().parent
 PROVIDER_DISPATCH = HERE / "provider_dispatch.py"
 TMUX_INTERACTIVE_DISPATCH = HERE / "tmux_interactive_dispatch.py"
+_SCRIPTS_DIR = HERE.parent
+PANEL_CONFIG_RELATIVE_PATH = Path("configs") / "plan_gate_panel.yaml"
+
+# The three keys every seat declares. Kept as a tuple so the loader and its
+# validation stay in lock-step — a drift here would silently change what counts
+# as a well-formed seat.
+_SEAT_KEYS: tuple[str, ...] = ("label", "provider", "model_arg")
 
 # Per-seat verdict ledger (OI-888): one append-only, hash-chained record per
 # panelist per run, under the repo's .vnx-attest/ dir next to the plan_gate_pass
@@ -80,6 +87,116 @@ DEFAULT_PANEL: List[Dict[str, str]] = [
 ]
 
 VERDICT_FENCE = "vnx-plan-verdict"
+
+
+def _default_panel_config_path() -> Path:
+    """The on-disk seat-list config resolved the same way as the other fabric
+    configs (``configs/plan_gate_panel.yaml`` at the repo root / central install
+    root), never from this module's own location — a central install pins
+    ``__file__`` inside a read-only version tree."""
+    return _SCRIPTS_DIR.parent / PANEL_CONFIG_RELATIVE_PATH
+
+
+def _valid_provider_strings() -> List[str]:
+    """The closed set of legal ``provider`` strings (members of the ``Provider``
+    enum in dispatch_spec). Resolved lazily so this module stays importable when
+    dispatch_spec is not on the path yet, and so a future enum edit is picked up
+    without touching this loader."""
+    from dispatch_spec import Provider  # noqa: PLC0415
+    return [p.value for p in Provider]
+
+
+def _validate_seat(seat: Any, index: int, valid_providers: List[str]) -> Dict[str, str]:
+    """Validate ONE seat from the config. Raises ``ValueError`` loud when the
+    seat is malformed — never silently drops it, because a dropped seat reads as
+    an abstention and turns into a REVISE via the fail-safe rule."""
+    if not isinstance(seat, dict):
+        raise ValueError(
+            f"plan-gate panel seat #{index}: expected a mapping with keys "
+            f"{list(_SEAT_KEYS)}, got {type(seat).__name__}"
+        )
+    missing = [k for k in _SEAT_KEYS if k not in seat]
+    if missing:
+        raise ValueError(
+            f"plan-gate panel seat #{index} (label={seat.get('label', '<none>')!r}): "
+            f"missing required key(s) {missing} — each seat needs {list(_SEAT_KEYS)}"
+        )
+    provider = str(seat["provider"]).strip()
+    if provider not in valid_providers:
+        raise ValueError(
+            f"plan-gate panel seat #{index} (label={seat['label']!r}): "
+            f"unknown provider {provider!r}. Valid providers: {valid_providers}"
+        )
+    return {
+        "label": str(seat["label"]),
+        "provider": provider,
+        "model_arg": str(seat["model_arg"]),
+    }
+
+
+def load_panel_seats(config_path: Optional[Path] = None) -> List[Dict[str, str]]:
+    """Load the ordered seat list from ``configs/plan_gate_panel.yaml``.
+
+    Falls back to ``DEFAULT_PANEL`` when the file is absent or unreadable (a
+    missing config never breaks the gate; the code constant is the safety net).
+    A present-but-invalid config fails LOUD: each seat must carry the three keys
+    ``label``/``provider``/``model_arg`` and ``provider`` must be a member of the
+    closed ``Provider`` enum in ``scripts/lib/dispatch_spec.py``. An invalid seat
+    is never silently dropped — a dropped seat reads as an abstention and turns
+    into a REVISE via the fail-safe rule, so misconfiguration must surface at
+    load time, not at verdict time.
+    """
+    path = Path(config_path) if config_path is not None else _default_panel_config_path()
+    if not path.is_file():
+        return list(DEFAULT_PANEL)
+    try:
+        import yaml  # noqa: PLC0415
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError) as exc:
+        warnings.warn(
+            f"plan_gate_panel: failed to load {path}: {exc} — using DEFAULT_PANEL",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return list(DEFAULT_PANEL)
+    if not isinstance(loaded, dict) or "seats" not in loaded:
+        warnings.warn(
+            f"plan_gate_panel: {path} has no 'seats' list — using DEFAULT_PANEL",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return list(DEFAULT_PANEL)
+    raw_seats = loaded["seats"]
+    if not isinstance(raw_seats, list) or not raw_seats:
+        raise ValueError(
+            f"plan_gate_panel: {path} 'seats' must be a non-empty list, got "
+            f"{type(raw_seats).__name__}"
+        )
+    valid_providers = _valid_provider_strings()
+    return [_validate_seat(s, i, valid_providers) for i, s in enumerate(raw_seats)]
+
+
+def filter_panel_seats(
+    seats: List[Dict[str, str]], labels: List[str]
+) -> List[Dict[str, str]]:
+    """Filter the configured seat list to ``labels`` for a single run.
+
+    An unknown label fails loud listing the configured labels so the operator
+    sees what is available instead of running a partial panel silently. Order
+    follows the configured list (not the requested order) so a run's panel
+    composition stays stable and auditable against the config.
+    """
+    configured = {s["label"]: s for s in seats}
+    unknown = [lbl for lbl in labels if lbl not in configured]
+    if unknown:
+        raise ValueError(
+            f"plan-gate panel: unknown --panel-seats label(s): {unknown}. "
+            f"Configured labels: {list(configured.keys())}"
+        )
+    # Order follows the configured list, not the requested order, so a run's
+    # panel composition stays stable and auditable against the config.
+    wanted = set(labels)
+    return [s for s in seats if s["label"] in wanted]
 _OPEN_FENCE = "```" + VERDICT_FENCE
 _VALID_VERDICTS = {"pass", "revise", "block"}
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2080,9 +2080,25 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
         return 1
 
     data_dir = os.environ.get("VNX_DATA_DIR") or str(Path(state_dir).parent)
+
+    # Resolve the panel composition from configs/plan_gate_panel.yaml (falling
+    # back to DEFAULT_PANEL when absent), then filter to --panel-seats for this
+    # single run. Both an invalid config and an unknown seat label fail LOUD
+    # here — a dropped seat reads as an abstention and turns into a REVISE via
+    # the fail-safe rule, so misconfiguration must surface before the panel runs.
+    try:
+        panel = plan_gate_panel.load_panel_seats()
+        if args.panel_seats:
+            requested = [s.strip() for s in args.panel_seats.split(",") if s.strip()]
+            panel = plan_gate_panel.filter_panel_seats(panel, requested)
+    except Exception as exc:
+        print(f"plan-gate run failed: {exc}", file=sys.stderr)
+        return 1
+
     try:
         result = plan_gate_panel.run_panel(
             doc, track_id=args.track_id, project_id=args.project_id, data_dir=data_dir,
+            panel=panel,
         )
     except Exception as exc:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
@@ -2558,6 +2574,13 @@ def _build_parser() -> argparse.ArgumentParser:
     _common(p_prun)
     p_prun.add_argument("track_id")
     p_prun.add_argument("--doc", required=True, help="path to the plan doc under review")
+    p_prun.add_argument(
+        "--panel-seats",
+        dest="panel_seats",
+        default="",
+        help="comma-separated seat labels to run (subset of the configured panel); "
+             "unknown labels fail loud. Defaults to the full configured panel.",
+    )
     p_prun.set_defaults(func=cmd_plan_gate_run)
 
     p_pstat = pg_sub.add_parser(

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -1482,3 +1482,158 @@ def test_claude_lane_report_path_uses_resolved_data_dir_when_none(tmp_path, monk
     assert len(seen_bases) == 1
     assert seen_bases[0] == fake_base
     assert seen_bases[0] is not None
+
+
+# --------------------------------------------------------------------------
+# OI-1057: configurable panel composition (configs/plan_gate_panel.yaml).
+# The composition moved from a code constant to a config file, threaded through
+# planning_cli's plan-gate run -> run_panel. Behaviour-neutral on this PR: the
+# seeded config reproduces DEFAULT_PANEL exactly.
+# --------------------------------------------------------------------------
+
+def _write_config(tmp_path: Path, seats_yaml: str) -> Path:
+    cfg = tmp_path / "plan_gate_panel.yaml"
+    cfg.write_text(seats_yaml, encoding="utf-8")
+    return cfg
+
+
+def test_load_panel_seats_parses_config_reproducing_default_panel(tmp_path):
+    # The shipped config under configs/ must parse to the same seat list as
+    # DEFAULT_PANEL, so the PR is behaviour-neutral by default.
+    repo_root = Path(__file__).resolve().parent.parent
+    shipped = repo_root / "configs" / "plan_gate_panel.yaml"
+    assert shipped.is_file(), "configs/plan_gate_panel.yaml must exist"
+    seats = pgp.load_panel_seats(shipped)
+    assert seats == pgp.DEFAULT_PANEL
+    # every seat carries the three documented keys
+    for s in seats:
+        assert set(s.keys()) == {"label", "provider", "model_arg"}
+
+
+def test_load_panel_seats_absent_file_falls_back_to_default_panel(tmp_path):
+    absent = tmp_path / "does-not-exist.yaml"
+    assert pgp.load_panel_seats(absent) == pgp.DEFAULT_PANEL
+
+
+def test_load_panel_seats_rejects_unknown_provider_with_naming_error(tmp_path):
+    cfg = _write_config(tmp_path, (
+        "version: 1\n"
+        "seats:\n"
+        "  - label: bogus\n"
+        "    provider: not-a-real-provider\n"
+        "    model_arg: whatever\n"
+    ))
+    with pytest.raises(ValueError) as excinfo:
+        pgp.load_panel_seats(cfg)
+    msg = str(excinfo.value)
+    # names the offending seat AND lists the valid providers
+    assert "label='bogus'" in msg or "seat #0" in msg
+    assert "not-a-real-provider" in msg
+    assert "claude" in msg and "glm-harness" in msg  # a couple of valid members
+
+
+def test_load_panel_seats_rejects_missing_key(tmp_path):
+    cfg = _write_config(tmp_path, (
+        "version: 1\n"
+        "seats:\n"
+        "  - label: incomplete\n"
+        "    provider: claude\n"
+    ))
+    with pytest.raises(ValueError, match="missing required key"):
+        pgp.load_panel_seats(cfg)
+
+
+def test_filter_panel_seats_filters_to_requested_labels():
+    seats = pgp.DEFAULT_PANEL
+    filtered = pgp.filter_panel_seats(seats, ["opus", "glm-5.2-harness"])
+    labels = [s["label"] for s in filtered]
+    assert labels == ["opus", "glm-5.2-harness"]  # configured order, not request order
+
+
+def test_filter_panel_seats_rejects_unknown_label_listing_configured():
+    configured = [s["label"] for s in pgp.DEFAULT_PANEL]
+    with pytest.raises(ValueError) as excinfo:
+        pgp.filter_panel_seats(pgp.DEFAULT_PANEL, ["opus", "ghost"])
+    msg = str(excinfo.value)
+    assert "ghost" in msg
+    # lists the configured labels so the operator sees what is available
+    for lbl in configured:
+        assert lbl in msg
+
+
+def test_cmd_plan_gate_run_passes_filtered_panel_to_run_panel(tmp_path, monkeypatch):
+    """--panel-seats filters the configured panel and run_panel receives exactly
+    those seats. Asserts on the dispatcher mock's calls (the seats it was
+    dispatched with), not on a log line."""
+    import argparse
+
+    # An on-disk config that reproduces the default so load_panel_seats is
+    # deterministic and independent of the repo-root file.
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+
+    captured_seats: list = []
+
+    def _tracking_dispatcher(provider, model_arg, instruction, dispatch_id):
+        captured_seats.append({"provider": provider, "model_arg": model_arg})
+        return _make_report_with_fence("pass")
+
+    # Patch run_panel to capture the panel argument it was called with.
+    seen_panels: list = []
+
+    def _fake_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+        seen_panels.append(panel)
+        # dispatch each requested seat through the tracker so we also assert
+        # on the dispatcher mock's calls (the seats dispatched), not a log line.
+        for seat in panel:
+            _tracking_dispatcher(seat["provider"], seat["model_arg"], "", "did")
+        return {
+            "track_id": track_id, "project_id": project_id, "decision": "PASS",
+            "summary": {"decision": "PASS", "pass_count": len(panel),
+                        "revise_count": 0, "block_count": 0, "rationale": "ok"},
+            "panelists": [], "doc_truncation": {"truncated": False},
+        }
+
+    monkeypatch.setattr(pgp, "run_panel", _fake_run_panel)
+
+    # Minimal track/DB bootstrap so cmd_plan_gate_run reaches run_panel.
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-seats", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        track_id="feat-seats", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats="opus,glm-5.2-harness",
+    )
+    # A PASS resolves the plan blocker; stub the resolver so unblock is honest.
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    rc = planning_cli.cmd_plan_gate_run(args)
+
+    assert rc == 0
+    assert len(seen_panels) == 1
+    dispatched_labels = [s["provider"] for s in captured_seats]
+    # exactly the two requested seats, in configured order
+    assert dispatched_labels == ["claude", "glm-harness"]
+    assert [s["label"] for s in seen_panels[0]] == ["opus", "glm-5.2-harness"]
+
+
+def test_cmd_plan_gate_run_rejects_unknown_panel_seat_label(tmp_path, monkeypatch):
+    """An unknown --panel-seats label fails loud (exit 1) before any panel runs."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    run_called = {"n": 0}
+    monkeypatch.setattr(pgp, "run_panel", lambda *a, **k: run_called.__setitem__("n", run_called["n"] + 1))
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-bad", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        track_id="feat-bad", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats="opus,ghost-seat",
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 1
+    assert run_called["n"] == 0  # the panel never ran

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -606,6 +606,13 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     _common_horizon_args(p_prun)
     p_prun.add_argument("track_id")
     p_prun.add_argument("--doc", required=True, help="path to the plan doc under review")
+    p_prun.add_argument(
+        "--panel-seats",
+        dest="panel_seats",
+        default="",
+        help="comma-separated seat labels to run (subset of the configured panel); "
+             "unknown labels fail loud. Defaults to the full configured panel.",
+    )
 
     p_pstat = subs.add_parser(
         "status", help="show a track's plan-gate state + derived_status",


### PR DESCRIPTION
## What

Make the plan-gate panel composition configurable (OI-1057, track `gate-panel-opus-glm-seats`).

The plan-gate panel composition was effectively hardcoded: `run_panel`'s `panel` parameter already existed, but the single caller (`planning_cli.cmd_plan_gate_run`) never passed it, so `DEFAULT_PANEL` always won. With kimi returning 403 (billing-cycle usage limit) and codex parse-erroring in 6 of 9 runs (measured 2026-08-06), every dead seat becomes an unconditional REVISE via the fail-safe rule, so the gate cannot pass regardless of the plan.

This moves the composition from a code constant to configuration and threads it through.

## Changes

- **`configs/plan_gate_panel.yaml`** (new): the ordered seat list (`label`, `provider`, `model_arg` — same three keys `DEFAULT_PANEL` uses), seeded with today's `DEFAULT_PANEL` so this PR is behaviour-neutral. Style matches `configs/context_rotation.yaml` / `configs/producer_freshness.yaml`.
- **`scripts/lib/plan_gate_panel.py`**:
  - `load_panel_seats()` reads the file and returns the seat list, falling back to `DEFAULT_PANEL` when absent/unreadable. Each seat is validated: the three keys must be present and `provider` must be a member of the closed `Provider` enum in `dispatch_spec.py`. An invalid seat fails LOUD naming the seat and the valid providers — never silently dropped, because a dropped seat reads as an abstention and turns into a REVISE.
  - `filter_panel_seats()` filters to `--panel-seats` labels for a single run; an unknown label fails loud listing the configured labels. Order follows the configured list so a run's composition stays auditable.
- **`scripts/planning_cli.py`**: `cmd_plan_gate_run` resolves the panel from config, applies the `--panel-seats` filter, and passes the resolved panel into `run_panel`. Added the `--panel-seats` CLI option on `plan-gate run`.
- **`vnx_cli/main.py`**: mirrored `--panel-seats` on `vnx horizon plan-gate run` so the horizon CLI delegate stays in flag parity with the engine (enforced by `tests/test_horizon_parity.py`).
- **`tests/test_plan_gate_panel.py`** (8 new tests): config parsed reproducing `DEFAULT_PANEL`; absent file falls back; unknown provider rejected with naming error; missing key rejected; `--panel-seats` filters and rejects unknown labels; `cmd_plan_gate_run` passes the filtered list into `run_panel` (asserts on the dispatcher mock's calls, not a log line); unknown label fails loud (exit 1) before any panel runs.

## Scope

Composition and plumbing only. `apply_panel_rule`, the verdict contract, fail-safe semantics, retry logic, and the seat ledger format are unchanged. Which seats are in the default is an operator decision made in config after this ships.

## Verification

Targeted tests only (not the full suite):
- 8 new tests: `8 passed, 78 deselected`.
- `test_plan_gate_panel.py` + direct neighbours (`test_plan_gate_enforcement`, `test_plan_gate_seat_ledger`, `test_plan_gate_evidence`): same 5 pre-existing failures, 132 passed. The 5 failures are pre-existing on `main` (`output_ref` column missing in the test's `_bootstrap` DB) — verified by `git stash` + re-run on clean main: identical 5 failures, 73 passed (81 with my 8 added).
- `test_planning_cli` / `test_horizon_cli` / `test_panel_cli`: 22 / 18 / 4 passed, all green.
- `test_horizon_parity`: 16 failed, 67 passed — identical to clean main; my change fixed `test_horizon_plan_gate_verb_help_lists_every_engine_flag[run]` (would fail without the `vnx_cli/main.py` mirror).

🤖 Generated with [Claude Code](https://claude.com/claude-code)