### PR TITLE
fix(reconcile): thread gathered gh merge evidence into derived-status (OI-1064)

### DIFF
--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -894,8 +894,56 @@ def run_reconcile(
         else:
             counts[verdict] = counts.get(verdict, 0) + 1
 
+    # ------------------------------------------------------------------ step 4c
+    # OI-1064: thread the gh-confirmed merge evidence into the derived-status
+    # derivation so it is not discarded. The bulk pass (step 2) ran BEFORE the
+    # gh sweep, so a track whose pr_ref PRs were merged via a bare ``gh pr
+    # merge`` (no local pr_merged receipt) derived 'queued' there — even though
+    # reconcile itself just confirmed those PRs merged via gh. Threading the
+    # evidence here lets the close path re-derive 'done' WITHOUT the
+    # VNX_RECONCILE_GIT flag (which governs whether the reconciler makes its
+    # OWN network calls; this is about evidence it ALREADY gathered).
+    #
+    # The injected set is a UNION of the gh-confirmed MERGED PR numbers and the
+    # locally-loaded set (NDJSON + ROADMAP). Local evidence stays valid; gh
+    # only ADDS what a bare ``gh pr merge`` never wrote locally. No new gh
+    # calls: only MERGED results already fetched in step 4b are extracted, so
+    # the --max-gh-calls cap still holds for the whole run.
+    # ------------------------------------------------------------------ step 4c
+    gh_confirmed_merged: set = set()
+    for cc in confirmed_candidates:
+        for pr in cc["pr_results"]:
+            if isinstance(pr, dict) and _is_merged({
+                "state": pr.get("state"),
+                "mergedAt": pr.get("mergedAt"),
+            }):
+                try:
+                    gh_confirmed_merged.add(int(pr["number"]))
+                except (TypeError, ValueError, KeyError):
+                    pass
+    local_merged = track_reconciler._load_merged_pr_numbers(state_dir, repo_root)
+    evidence_merged_pr_numbers: FrozenSet[int] = frozenset(
+        gh_confirmed_merged | set(local_merged)
+    )
+
+    # Re-derive the confirmed tracks so the bulk-pass-derived_status (which ran
+    # before the gh sweep and wrote 'queued' for bare-gh-merge tracks) is
+    # corrected in the DB with the same evidence the close path will use. This
+    # is idempotent (reconcile_track rewrites derived_status) and adds zero gh
+    # calls. Non-apply mode also benefits: the derived_status persisted for
+    # reporting matches the evidence reconcile actually gathered.
+    for cc in confirmed_candidates:
+        track_reconciler.reconcile_track(
+            state_dir, cc["track_id"], project_id,
+            repo_root=repo_root,
+            _merged_pr_numbers=evidence_merged_pr_numbers,
+        )
+
     # ------------------------------------------------------------------ step 5
-    # Close confirmed candidates (--apply only).
+    # Close confirmed candidates (--apply only). The evidence set from step 4c
+    # is forwarded so reconcile_track inside close_track_if_done sees the same
+    # complete evidence (gh-confirmed UNION local) instead of falling back to
+    # the local-only set.
     # ------------------------------------------------------------------ step 5
     if apply:
         verified_at = _now_utc()
@@ -916,6 +964,7 @@ def run_reconcile(
                 evidence=evidence,
                 approval_id=f"auto-reconcile-{run_id}",
                 repo_root=repo_root,
+                merged_pr_numbers=evidence_merged_pr_numbers,
             )
             action = close_result.get("action", "")
 

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -401,9 +401,20 @@ def reconcile_track(
     Raises RuntimeError if derived_status column is absent (migration 0028
     must be applied first).
 
-    _merged_pr_numbers: internal kwarg — pre-loaded merged PR set. When None,
-    _load_merged_pr_numbers(state_dir) is called. Pass a pre-loaded set when
-    calling from reconcile_all_tracks to avoid per-track file I/O.
+    _merged_pr_numbers: pre-established merged-PR set. Serves TWO purposes:
+      (1) I/O optimisation — reconcile_all_tracks loads the local set once and
+          passes it to avoid per-track file I/O.
+      (2) Evidence-injection point (OI-1064) — a caller that has ALREADY
+          established merge state by other means (e.g. run_reconcile's live
+          ``gh pr view`` sweep) MUST pass the UNION of its gh-confirmed numbers
+          and the locally-loaded set here. Otherwise reconcile_track falls back
+          to _load_merged_pr_numbers, whose gh source (source 4) is opt-in
+          behind VNX_RECONCILE_GIT and OFF by default — so a track the caller
+          just confirmed merged via gh would re-derive as 'queued' from the
+          weaker local sources, and no close path could close it. The caller
+          performs the union (gh evidence is additive: it never replaces local
+          NDJSON/ROADMAP evidence, only adds what a bare ``gh pr merge`` never
+          wrote locally).
     repo_root: optional project repo root for the ROADMAP.yaml (Source-3)
     evidence path; falls back to the CWD git-root then the legacy layout.
     """
@@ -414,6 +425,12 @@ def reconcile_track(
                 "tracks.derived_status column absent; apply migration 0028 first."
             )
 
+        # OI-1064: _merged_pr_numbers is the evidence-injection point. A caller
+        # that already established merge state (gh sweep in run_reconcile) MUST
+        # pass the union of its gh-confirmed numbers and the locally-loaded set
+        # here — run_reconcile performs that union once so both the bulk pass
+        # and the close path see the same complete evidence. When None, the full
+        # local set is loaded here (the pre-OI-1064 behaviour).
         merged = (
             _merged_pr_numbers
             if _merged_pr_numbers is not None

--- a/scripts/lib/track_reconciler_closure.py
+++ b/scripts/lib/track_reconciler_closure.py
@@ -37,7 +37,7 @@ from __future__ import annotations
 
 import sqlite3
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, FrozenSet, List, Optional
 
 import tracks as tracks_lib  # same package; importable whenever scripts/lib/ is in sys.path
 
@@ -51,6 +51,7 @@ def close_track_if_done(
     approval_id: Optional[str] = None,
     include_parked: bool = False,
     repo_root: "str | Path | None" = None,
+    merged_pr_numbers: Optional[FrozenSet[int]] = None,
 ) -> Dict[str, Any]:
     """Attempt to close a track by walking its declared phase to 'done'.
 
@@ -97,6 +98,14 @@ def close_track_if_done(
     repo_root: optional project repo root, forwarded to the internal
     reconcile_track call for its ROADMAP.yaml (Source-3) evidence path; falls
     back to the CWD git-root then the legacy layout (see reconcile_track).
+
+    merged_pr_numbers: optional pre-established merged-PR set (OI-1064). When
+    provided, forwarded to the internal reconcile_track call so a caller that
+    has ALREADY established merge state (run_reconcile's gh sweep) does not
+    discard it — the set must be the UNION of the caller's gh-confirmed numbers
+    and the locally-loaded set (run_reconcile performs that union). Default
+    None keeps every existing caller behaviour-identical: reconcile_track loads
+    the local sources itself. See reconcile_track's _merged_pr_numbers contract.
 
     Returns a dict with keys: track_id, project_id, action, applied, declared_phase,
     derived_status, path (when applicable), evidence (when computed), error (on failure).
@@ -328,7 +337,11 @@ def close_track_if_done(
     # When _skip_derived_gate is True, reconcile_track still runs for the derived
     # refresh (persists derived_status for reporting) but its result does not gate
     # the walk — gh evidence already authorized the close.
-    result = reconcile_track(state_dir, track_id, project_id, repo_root=repo_root)
+    result = reconcile_track(
+        state_dir, track_id, project_id,
+        repo_root=repo_root,
+        _merged_pr_numbers=merged_pr_numbers,
+    )
     derived = result["derived_status"]
     declared = result["declared_phase"]
     target = "done"

--- a/tests/test_close_track_if_done.py
+++ b/tests/test_close_track_if_done.py
@@ -723,3 +723,229 @@ def test_oi829_evidence_none_path_closes_unchanged_without_any_marking(tmp_path)
     assert result["action"] == "closed"
     assert result["applied"] is True
     assert _phase(sd, "T-manual-close") == "done"
+
+
+# ---------------------------------------------------------------------------
+# OI-1064: evidence threading — merged_pr_numbers forwarded into reconcile_track
+# ---------------------------------------------------------------------------
+
+def test_close_forwards_merged_pr_numbers_into_reconcile_track(tmp_path, monkeypatch):
+    """close_track_if_done forwards a passed merged set into reconcile_track.
+
+    Asserts on the reconcile_track CALL (the kwarg value), not on a log line.
+    The merged_pr_numbers kwarg must reach reconcile_track verbatim; default
+    None keeps the old behaviour (reconcile_track loads the local set itself).
+    """
+    import track_reconciler_closure
+
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-fwd", phase="active")
+
+    captured: dict = {}
+
+    real_reconcile = track_reconciler.reconcile_track
+
+    def _spy(state_dir, track_id, project_id, **kw):
+        captured["merged_pr_numbers"] = kw.get("_merged_pr_numbers")
+        return real_reconcile(state_dir, track_id, project_id, **kw)
+
+    # Patch the name close_track_if_done resolves at call time (it imports
+    # reconcile_track from track_reconciler at module load — late binding
+    # resolves globals at call time, so patching the closure module's
+    # reference is the faithful target).
+    monkeypatch.setattr(track_reconciler_closure, "reconcile_track", _spy)
+
+    injected = frozenset({4242})
+    result = track_reconciler.close_track_if_done(
+        sd, "T-fwd", PROJECT_ID, actor="operator", approval_id="X",
+        merged_pr_numbers=injected,
+    )
+    assert result["action"] == "closed"
+    assert captured["merged_pr_numbers"] == injected
+
+
+def test_close_default_none_keeps_old_behaviour(tmp_path, monkeypatch):
+    """Without merged_pr_numbers, reconcile_track receives None (loads local itself).
+
+    Pins that the fix is the threading, not a weakened check: the default path
+    is byte-for-byte the pre-OI-1064 behaviour.
+    """
+    import track_reconciler_closure
+
+    sd = _build_db(tmp_path)
+    _seed_done_track(sd, "T-default", phase="active")
+
+    captured: dict = {}
+    real_reconcile = track_reconciler.reconcile_track
+
+    def _spy(state_dir, track_id, project_id, **kw):
+        captured["merged_pr_numbers"] = kw.get("_merged_pr_numbers")
+        return real_reconcile(state_dir, track_id, project_id, **kw)
+
+    monkeypatch.setattr(track_reconciler_closure, "reconcile_track", _spy)
+
+    track_reconciler.close_track_if_done(
+        sd, "T-default", PROJECT_ID, actor="operator", approval_id="X",
+    )
+    assert captured["merged_pr_numbers"] is None
+
+
+def test_close_with_injected_set_derives_done_and_closes(tmp_path):
+    """A track whose pr_ref PRs are ABSENT from local sources but PRESENT in
+    the injected set derives 'done' and the close succeeds — without
+    VNX_RECONCILE_GIT set.
+
+    This is the core OI-1064 case: zero dispatches, no pr_merged.ndjson, no
+    ROADMAP entry, no coordination event. The only merge evidence is the
+    injected set (the gh numbers run_reconcile gathered). Pre-fix this track
+    derived 'queued' and could not be closed.
+    """
+    import os
+    assert "VNX_RECONCILE_GIT" not in os.environ, (
+        "this test asserts the OFF-by-default behaviour; unset VNX_RECONCILE_GIT"
+    )
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T-injected", PROJECT_ID, title="injected", goal_state="y",
+        phase="active", pr_ref="#5150,#5151",
+    )
+    # Mark delivery complete so the OI-829 gate passes (#5150 ships the plan).
+    _set_delivery(sd, "T-injected", 5150, "complete")
+
+    # No local merge evidence of any kind. Inject the gh-confirmed union.
+    injected = frozenset({5150, 5151})
+    evidence = {
+        "pr_ref": "#5150,#5151",
+        "pr_results": [
+            {"number": 5150, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+            {"number": 5151, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+        ],
+        "verified_at": "2026-08-06T10:00:00Z",
+    }
+    result = track_reconciler.close_track_if_done(
+        sd, "T-injected", PROJECT_ID, actor="system", approval_id="APR-INJ",
+        evidence=evidence, merged_pr_numbers=injected,
+    )
+    assert result["action"] == "closed"
+    assert result["applied"] is True
+    assert _phase(sd, "T-injected") == "done"
+    assert _derived_status(sd, "T-injected") == "done"
+
+
+def test_close_without_injected_set_still_queued(tmp_path):
+    """Without the injected set the old behaviour is unchanged: still 'queued'.
+
+    Same track shape as above but merged_pr_numbers omitted. Pre-fix and
+    post-fix, this must stay 'queued' (not closed) — the fix is the threading,
+    not a weakened derivation rule.
+    """
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T-no-inj", PROJECT_ID, title="no inj", goal_state="y",
+        phase="queued", pr_ref="#5152,#5153",
+    )
+    _set_delivery(sd, "T-no-inj", 5152, "complete")
+
+    evidence = {
+        "pr_ref": "#5152,#5153",
+        "pr_results": [
+            {"number": 5152, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+            {"number": 5153, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+        ],
+        "verified_at": "2026-08-06T10:00:00Z",
+    }
+    result = track_reconciler.close_track_if_done(
+        sd, "T-no-inj", PROJECT_ID, actor="system", approval_id="APR-NOINJ",
+        evidence=evidence,
+    )
+    # gh evidence in pr_results authorizes the close directly via the
+    # _skip_derived_gate path, so this still closes. Assert the derived_status
+    # the close saw was the OLD one (queued) — proving the injected set was
+    # the only thing that would have changed the derivation. This mirrors the
+    # real background-job-liveness defect (phase=queued, bare gh merge).
+    assert result["derived_status"] == "queued"
+
+
+def test_injected_set_unions_with_local_evidence(tmp_path):
+    """The union is a union: a PR present locally but absent from the injected
+    gh set is still counted.
+
+    Track pr_ref='#6000,#6001'. #6000 is in local pr_merged.ndjson (local
+    evidence). #6001 is ONLY in the injected set (gh-confirmed, no local
+    receipt). The injected set (what run_reconcile would pass) is the UNION of
+    gh-confirmed {6001} and local {6000} = {6000, 6001}. Derived 'done'. Pins
+    that the caller's union preserves local evidence rather than replacing it
+    with the gh set alone — a caller that passed only the gh set {6001} would
+    leave #6000 uncounted.
+    """
+    import json
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T-union", PROJECT_ID, title="union", goal_state="y",
+        phase="active", pr_ref="#6000,#6001",
+    )
+    _set_delivery(sd, "T-union", 6000, "complete")
+    # Local evidence for #6000 only.
+    events_dir = sd.parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    (events_dir / "pr_merged.ndjson").write_text(
+        json.dumps({"event_type": "pr_merged", "pr_number": 6000}) + "\n",
+        encoding="utf-8",
+    )
+
+    # run_reconcile unions gh-confirmed {6001} with local {6000} = {6000, 6001}.
+    injected_union = frozenset({6000, 6001})
+    evidence = {
+        "pr_ref": "#6000,#6001",
+        "pr_results": [
+            {"number": 6000, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+            {"number": 6001, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+        ],
+        "verified_at": "2026-08-06T10:00:00Z",
+    }
+    result = track_reconciler.close_track_if_done(
+        sd, "T-union", PROJECT_ID, actor="system", approval_id="APR-UNION",
+        evidence=evidence, merged_pr_numbers=injected_union,
+    )
+    assert result["action"] == "closed"
+    assert result["applied"] is True
+    assert _derived_status(sd, "T-union") == "done"
+
+
+def test_injected_gh_only_set_without_union_leaves_local_pr_uncounted(tmp_path):
+    """Counter-pin for the union: passing ONLY the gh set (no union with local)
+    leaves a local-only PR uncounted → derived 'in_progress', not 'done'.
+
+    This proves the union with local evidence is load-bearing, not decorative:
+    a caller that passed only the gh-confirmed numbers (forgetting the local
+    set) would regress the defect for any track with mixed local/gh evidence.
+    """
+    import json
+    sd = _build_db(tmp_path)
+    tracks_lib.create_track(
+        sd, "T-gh-only-set", PROJECT_ID, title="gh only set", goal_state="y",
+        phase="active", pr_ref="#6002,#6003",
+    )
+    _set_delivery(sd, "T-gh-only-set", 6002, "complete")
+    events_dir = sd.parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    (events_dir / "pr_merged.ndjson").write_text(
+        json.dumps({"event_type": "pr_merged", "pr_number": 6002}) + "\n",
+        encoding="utf-8",
+    )
+    evidence = {
+        "pr_ref": "#6002,#6003",
+        "pr_results": [
+            {"number": 6002, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+            {"number": 6003, "state": "MERGED", "mergedAt": "2026-08-06T10:00:00Z"},
+        ],
+        "verified_at": "2026-08-06T10:00:00Z",
+    }
+    result = track_reconciler.close_track_if_done(
+        sd, "T-gh-only-set", PROJECT_ID, actor="system", approval_id="APR-GHONLY",
+        evidence=evidence, merged_pr_numbers=frozenset({6003}),  # gh-only, no union
+    )
+    # gh evidence bypasses the derived gate so the close still happens, but the
+    # derived_status reflects the MISSING local PR #6002 → 'in_progress'.
+    assert result["derived_status"] == "in_progress"
+

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1624,3 +1624,161 @@ class TestRunProvenanceSweepCommitFailureIsLoud:
         assert result == {"scanned": 0, "linked": 0}
         error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
         assert not error_records, "an ordinary scan miss must stay non-fatal, not escalate to error"
+
+
+# ---------------------------------------------------------------------------
+# OI-1064: reconcile reuses the gh merge evidence it already gathered.
+# ---------------------------------------------------------------------------
+
+def test_oi1064_reconcile_closes_track_without_vnx_reconcile_git(tmp_path, monkeypatch):
+    """run_reconcile derives 'done' and closes a bare-gh-merge track WITHOUT
+    VNX_RECONCILE_GIT set.
+
+    Reproduces the background-job-liveness defect in miniature: phase=queued,
+    pr_ref with multiple PRs, all verified MERGED via gh, delivery complete,
+    zero dispatches, zero local merge evidence (no pr_merged.ndjson, no
+    coordination event, no ROADMAP entry). Pre-fix the bulk pass derived
+    'queued' and close_track_if_done refused with noop_not_terminal; the
+    evidence reconcile gathered was discarded. Post-fix the gh-confirmed
+    numbers are threaded into the derivation and the close succeeds.
+    """
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-oi1064", phase="queued", pr_ref="#1246,#1247,#1248")
+    # No dispatches, no local merge evidence of any kind.
+    # Mark all three delivery complete (the plan shipped across all PRs).
+    for pn in (1246, 1247, 1248):
+        _set_delivery(sd, "T-oi1064", pn, "complete")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({
+            1246: _merged_pr(1246),
+            1247: _merged_pr(1247),
+            1248: _merged_pr(1248),
+        }),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0, f"expected exit 0, got {code}"
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 1
+    assert _phase(sd, "T-oi1064") == "done"
+    # derived_status persisted as 'done' (not 'queued') — the evidence reached
+    # both the bulk re-derivation and the close path.
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT derived_status FROM tracks WHERE track_id=? AND project_id=?",
+        ("T-oi1064", PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    assert row["derived_status"] == "done"
+
+
+def test_oi1064_check_mode_derives_done_without_closing(tmp_path, monkeypatch):
+    """Check mode (--apply absent): the same evidence threading corrects the
+    derived_status to 'done' in the DB even though the close is skipped.
+
+    Pre-fix the bulk pass wrote 'queued' and nothing corrected it. Post-fix the
+    post-gh re-derivation writes 'done'. The declared phase stays untouched in
+    check mode.
+    """
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-oi1064-check", phase="queued", pr_ref="#1300,#1301")
+    for pn in (1300, 1301):
+        _set_delivery(sd, "T-oi1064-check", pn, "complete")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1300: _merged_pr(1300), 1301: _merged_pr(1301)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+    assert code == 0
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 0  # check mode never closes
+    assert _phase(sd, "T-oi1064-check") == "queued"  # declared phase untouched
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.row_factory = sqlite3.Row
+    row = conn.execute(
+        "SELECT derived_status FROM tracks WHERE track_id=? AND project_id=?",
+        ("T-oi1064-check", PROJECT_ID),
+    ).fetchone()
+    conn.close()
+    assert row["derived_status"] == "done"
+
+
+def test_oi1064_max_gh_calls_cap_holds_across_whole_run(tmp_path, monkeypatch):
+    """The --max-gh-calls cap holds across the whole run after OI-1064.
+
+    The re-derivation + close threading must not add any gh calls beyond the
+    existing step-4b sweep. With max_gh_calls=2 and one candidate needing 3 PR
+    lookups, the candidate is deferred (3 > 2) — no gh calls for it, no
+    re-derivation, no close. The cap governs the whole run, not per phase.
+    """
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-cap", phase="queued", pr_ref="#1400,#1401,#1402")
+    for pn in (1400, 1401, 1402):
+        _set_delivery(sd, "T-cap", pn, "complete")
+
+    call_log: list = []
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock(
+            {1400: _merged_pr(1400), 1401: _merged_pr(1401), 1402: _merged_pr(1402)},
+            call_log=call_log,
+        ),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+        max_gh_calls=2,
+    )
+    assert code == 0
+    # 3 PRs needed, cap 2 → deferred. No close, no confirmed.
+    assert summary["counts"]["deferred"] == 1
+    assert summary["counts"]["confirmed"] == 0
+    assert summary["counts"]["closed"] == 0
+
+    # Only the gh auth status call ran; zero pr-view calls (deferred before fetch).
+    pr_view_calls = [c for c in call_log if _is_gh_pr_view(c)]
+    assert len(pr_view_calls) == 0, "OI-1064 threading must not add gh calls"
+    assert _phase(sd, "T-cap") == "queued"  # untouched
+
+
+def test_oi1064_evidence_unions_gh_with_local_in_run_reconcile(tmp_path, monkeypatch):
+    """run_reconcile unions the gh-confirmed numbers with the locally-loaded set.
+
+    Track pr_ref='#1500,#1501'. #1500 has local evidence (pr_merged.ndjson).
+    #1501 is gh-confirmed only. Both are fetched by gh (both MERGED). The
+    injected set is the union {1500, 1501}. Derived 'done' and closes. Pins
+    that local evidence is never discarded when the gh evidence is threaded.
+    """
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-oi1064-union", phase="queued", pr_ref="#1500,#1501")
+    _set_delivery(sd, "T-oi1064-union", 1500, "complete")
+    # Local evidence for #1500 only.
+    _seed_pr_merged_ndjson(sd, 1500)
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({1500: _merged_pr(1500), 1501: _merged_pr(1501)}),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+    assert code == 0
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["closed"] == 1
+    assert _phase(sd, "T-oi1064-union") == "done"
+


### PR DESCRIPTION
## Summary

`objective reconcile` verified PR merge state live via `gh` and reported tracks as CONFIRMED, then threw that evidence away. `derived_status` was recomputed from a weaker local-only set (the `gh` source is opt-in behind `VNX_RECONCILE_GIT`, OFF by default), so a track reconcile itself just confirmed could not close. The bulk `reconcile_all_tracks` pass ran before the gh sweep and never saw the evidence either.

Reproduced on `vnx-dev`: `background-job-liveness` (`pr_ref=#1246,#1247,#1248`, all three MERGED via gh, all delivery=complete, zero dispatches, resolved blocker) derived `queued` without `VNX_RECONCILE_GIT` and `done` with it.

This threads the evidence through the existing seam. No new mechanism, no new gh calls, no default flip.

## Changes

- **`scripts/lib/track_reconciler.py`** — widened the `reconcile_track._merged_pr_numbers` docstring: it is also the evidence-injection point, not just an I/O optimisation. A caller that has already established merge state MUST pass the union of its gh-confirmed numbers and the locally-loaded set. Behaviour unchanged.
- **`scripts/lib/track_reconciler_closure.py`** — `close_track_if_done` gains an optional `merged_pr_numbers` kwarg (default `None`) forwarded to the internal `reconcile_track` call. `None` keeps every existing caller byte-for-byte identical.
- **`scripts/lib/objective_reconcile.py`** — `run_reconcile` collects the gh-confirmed MERGED PR numbers from CONFIRMED candidates (step 4c), unions them with the locally-loaded set, re-derives the affected tracks so the bulk-derived_status is corrected, and forwards the same set into `close_track_if_done`.

**Chosen option for the bulk pass (task 4):** re-run the affected tracks' derivation after the gh sweep, rather than moving the sweep before the bulk pass. Idempotent (reconcile_track rewrites derived_status) and adds zero gh calls. The bulk pass stays a single local-evidence load; `--max-gh-calls` (default 50) holds for the whole run because only MERGED results already fetched in step 4b are extracted.

The union is load-bearing: local NDJSON / ROADMAP evidence is never replaced, gh only adds what a bare `gh pr merge` never wrote locally. Do NOT flip the `VNX_RECONCILE_GIT` default — that flag governs whether the reconciler makes its OWN network calls; this is about evidence it ALREADY gathered.

## Verification

Targeted tests (the files touched plus direct neighbours):

```
python3 -m pytest tests/test_track_reconciler_prref_evidence.py tests/test_close_track_if_done.py tests/test_objective_reconcile.py tests/test_track_reconciler.py -q
150 passed in 2.95s
```

New regression tests (10):
- `close_track_if_done` forwards a passed merged set into `reconcile_track` (asserts on the call kwarg, not a log line).
- With a track whose `pr_ref` PRs are absent from local sources but present in the injected set, `derived_status` derives `done` and the close succeeds.
- Without the injected set the old behaviour is unchanged (`derived_status == 'queued'`) — pins the fix is the threading, not a weakened check.
- The union is a union: a PR present locally but absent from the gh set is still counted; a gh-only set without the union leaves a local PR uncounted (`in_progress`).
- `run_reconcile` closes a bare-gh-merge track WITHOUT `VNX_RECONCILE_GIT` (check + apply modes).
- `--max-gh-calls` cap holds across the whole run after the change (deferred candidate, zero pr-view calls).

Acceptance on the real `vnx-dev` state (DB copied to scratch, gh mocked to serve the three MERGED PRs): `run_reconcile --apply` (check mode used to avoid mutating runtime phase) derives `done` for `background-job-liveness` without `VNX_RECONCILE_GIT`; confirmed=1. Exit 3 was from 5 other unverified tracks in the mock, unrelated to this defect.

Pre-existing, unrelated failures on `main`: `tests/test_planning_cli_objective.py::test_objective_list_json` and `::test_objective_list_renders` fail identically with this branch stashed (the `objective list` default hides done tracks; `feat-b` is done and hidden). Not caused by this change.

## Open Items

None.

**Dispatch-ID**: 20260806-215854-reconcile-evidence-thread
**Model**: glm-5.2
**Provider**: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)