### PR TITLE
fix(close): thread gh-confirmed merge evidence into the close verb (OI-1071)

### DIFF
--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -491,6 +491,194 @@ def _parse_reopen_stamp(reason: str) -> Optional[str]:
 
 
 # ---------------------------------------------------------------------------
+# Close-evidence gathering (shared by run_reconcile and the close verb)
+# ---------------------------------------------------------------------------
+#
+# OI-1071: PR #1402 (OI-1064) threaded gh-confirmed merge evidence into the
+# ``reconcile --apply`` close path (run_reconcile step 4c + close_track_if_done),
+# but the operator-facing ``objective close`` verb did NOT call that path — it
+# peeked/reconciled with the local-only set, fell back to _load_merged_pr_numbers
+# (whose gh source is opt-in behind VNX_RECONCILE_GIT, OFF by default), and
+# re-derived 'queued' for a track whose PRs merged via a bare ``gh pr merge``.
+#
+# The two helpers below are the SINGLE source of the evidence set both code
+# paths consume, so the bulk reconcile sweep and the standalone close verb
+# cannot drift apart:
+#
+#   merge_evidence_pr_numbers — the UNION primitive. Takes a set of
+#     gh-confirmed MERGED PR numbers and returns the union with the
+#     locally-loaded set (NDJSON + ROADMAP). run_reconcile calls this after its
+#     own gh sweep; gather_close_evidence calls this after the per-track sweep.
+#
+#   gather_close_evidence — the per-track gather the close verb uses. Resolves
+#     the track's pr_ref, fetches only THAT track's PRs (bounded by max_gh_calls,
+#     cache-first), and returns the union set + a health report so the verb can
+#     degrade honestly when gh is unreachable.
+
+def merge_evidence_pr_numbers(
+    gh_confirmed_merged: "FrozenSet[int]",
+    state_dir: Path,
+    repo_root: Optional[Path] = None,
+) -> FrozenSet[int]:
+    """Return the UNION of gh-confirmed MERGED PR numbers and the local set.
+
+    gh evidence is additive: it never replaces local NDJSON/ROADMAP evidence,
+    only adds what a bare ``gh pr merge`` never wrote locally. This is the
+    exact union run_reconcile builds (step 4c) — extracted so the standalone
+    close verb and the bulk sweep reach it through the SAME function and
+    cannot drift.
+
+    Local loading reuses track_reconciler._load_merged_pr_numbers (sources
+    1-3 are local and deterministic; source 4 is the opt-in VNX_RECONCILE_GIT
+    path, OFF by default, so it does NOT double-call gh here).
+    """
+    local_merged = track_reconciler._load_merged_pr_numbers(state_dir, repo_root)
+    return frozenset(set(gh_confirmed_merged) | set(local_merged))
+
+
+def gather_close_evidence(
+    state_dir: Path,
+    project_id: str,
+    track_id: str,
+    *,
+    repo_root: Optional[Path] = None,
+    max_gh_calls: int = 50,
+    pr_ref: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Gather the same merge evidence run_reconcile does, for ONE track.
+
+    Returns::
+
+        {
+          "merged_pr_numbers": FrozenSet[int],  # gh-confirmed UNION local
+          "gh_health": "ok" | "absent" | "auth_failed" | "timeout",
+          "consulted_gh": bool,                  # False when gh unreachable / no PRs
+          "pr_results": List[Dict],              # per-PR {number, state, mergedAt}
+          "pr_ref": str,                          # the pr_ref resolved for the track
+          "pr_numbers": FrozenSet[int],           # parsed PR numbers from pr_ref
+        }
+
+    Resolves the track's ``pr_ref`` (unless ``pr_ref`` is passed), fetches only
+    that track's PRs through the per-PR cache (so a PR already verified this run
+    or recently cached is not re-fetched), and bounds live gh calls by
+    ``max_gh_calls``. When gh is absent/unauthenticated/timed out OR the track
+    has no pr_ref, falls back to the local-only set and reports
+    ``consulted_gh=False`` so the caller can SAY it could not reach GitHub
+    rather than silently behaving as if it checked.
+
+    Never raises; gh failures degrade to local-only.
+    """
+    # Resolve the track's pr_ref from the DB when the caller did not pass it.
+    if pr_ref is None:
+        try:
+            lib = tracks_lib.get_track(state_dir, track_id, project_id)
+            if lib is not None:
+                pr_ref = (lib.get("pr_ref") or "").strip()
+        except Exception:  # vnx-silent-except: best-effort pr_ref resolve
+            pr_ref = None
+    pr_ref = (pr_ref or "").strip()
+    pr_numbers: FrozenSet[int] = _parse_pr_numbers(pr_ref) if pr_ref else frozenset()
+
+    pr_results: List[Dict[str, Any]] = []
+    gh_confirmed_merged: set = set()
+
+    # No PRs to verify → nothing to fetch; the union is the local set alone.
+    # repo_root is left as-is (possibly None) so the local loader resolves it
+    # exactly as the pre-OI-1071 peek/reconcile path did — no eager git probe.
+    if not pr_numbers:
+        return {
+            "merged_pr_numbers": merge_evidence_pr_numbers(frozenset(), state_dir, repo_root),
+            "gh_health": "ok",
+            "consulted_gh": False,
+            "pr_results": [],
+            "pr_ref": pr_ref,
+            "pr_numbers": pr_numbers,
+        }
+
+    # gh probes need a concrete repo root for cwd=. Resolve once, only when
+    # there are PRs to fetch (the no-pr_ref hot path above skips this).
+    if repo_root is None:
+        repo_root = _resolve_effective_repo_root()
+
+    gh_binary = _resolve_gh_binary()
+    gh_health = _detect_gh(repo_root, gh_binary)
+    if gh_health != "ok":
+        # gh unavailable: degrade honestly to local-only. Caller MUST surface
+        # that gh could not be consulted instead of pretending it checked.
+        return {
+            "merged_pr_numbers": merge_evidence_pr_numbers(frozenset(), state_dir, repo_root),
+            "gh_health": gh_health,
+            "consulted_gh": False,
+            "pr_results": [],
+            "pr_ref": pr_ref,
+            "pr_numbers": pr_numbers,
+        }
+
+    # Cache-first fetch, bounded by max_gh_calls. Reuses the same per-PR cache
+    # run_reconcile uses so a PR already verified this run is not re-fetched.
+    repo_key = _get_repo_key(repo_root)
+    pr_cache = _load_pr_state_cache(state_dir, repo_key)
+    gh_calls_used = 0
+
+    per_pr: Dict[int, Optional[Dict[str, Any]]] = {}
+    prs_to_fetch: List[int] = []
+    for pn in pr_numbers:
+        cached = pr_cache.get(str(pn))
+        if cached and _is_merged(cached):
+            per_pr[pn] = cached
+        else:
+            prs_to_fetch.append(pn)
+
+    # Bound live calls. A single close handles ONE track, so the cap is the
+    # track's PR count at most; if the cap is lower than that, fetch what fits
+    # and report the rest as unverified (consulted_gh stays True — gh WAS
+    # reached, just budget-capped).
+    uncapped_remainder: List[int] = []
+    if len(prs_to_fetch) > max_gh_calls:
+        uncapped_remainder = prs_to_fetch[max_gh_calls:]
+        prs_to_fetch = prs_to_fetch[:max_gh_calls]
+
+    for pn in prs_to_fetch:
+        gh_calls_used += 1
+        data = _gh_pr_view(pn, repo_root, gh_binary=gh_binary)
+        per_pr[pn] = data
+        if data is not None and _is_merged(data):
+            pr_cache[str(pn)] = data
+
+    # Persist any newly cached MERGED results.
+    _save_pr_state_cache(state_dir, repo_key, pr_cache)
+
+    # Build the per-PR result list and the gh-confirmed MERGED set, mirroring
+    # run_reconcile step 4c's extraction.
+    for pn in sorted(pr_numbers):
+        data = per_pr.get(pn)
+        if data is None:
+            if pn in uncapped_remainder:
+                pr_results.append({"number": pn, "state": None, "mergedAt": None})
+            else:
+                pr_results.append({"number": pn, "state": None, "mergedAt": None})
+            continue
+        pr_results.append({
+            "number": pn,
+            "state": data.get("state"),
+            "mergedAt": data.get("mergedAt"),
+        })
+        if _is_merged(data):
+            gh_confirmed_merged.add(pn)
+
+    return {
+        "merged_pr_numbers": merge_evidence_pr_numbers(
+            frozenset(gh_confirmed_merged), state_dir, repo_root
+        ),
+        "gh_health": gh_health,
+        "consulted_gh": True,
+        "pr_results": pr_results,
+        "pr_ref": pr_ref,
+        "pr_numbers": pr_numbers,
+    }
+
+
+# ---------------------------------------------------------------------------
 # Decision logic
 # ---------------------------------------------------------------------------
 
@@ -921,9 +1109,11 @@ def run_reconcile(
                     gh_confirmed_merged.add(int(pr["number"]))
                 except (TypeError, ValueError, KeyError):
                     pass
-    local_merged = track_reconciler._load_merged_pr_numbers(state_dir, repo_root)
-    evidence_merged_pr_numbers: FrozenSet[int] = frozenset(
-        gh_confirmed_merged | set(local_merged)
+    # OI-1071: the UNION of gh-confirmed MERGED PR numbers and the local set is
+    # built by the shared primitive so the standalone close verb and this bulk
+    # sweep consume the SAME function and cannot drift apart.
+    evidence_merged_pr_numbers: FrozenSet[int] = merge_evidence_pr_numbers(
+        frozenset(gh_confirmed_merged), state_dir, repo_root
     )
 
     # Re-derive the confirmed tracks so the bulk-pass-derived_status (which ran

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -474,6 +474,7 @@ def peek_derived_status(
     project_id: str,
     *,
     repo_root: "str | Path | None" = None,
+    _merged_pr_numbers: Optional[FrozenSet[int]] = None,
 ) -> Dict[str, Any]:
     """READ-ONLY: compute derived_status for one track WITHOUT persisting it.
 
@@ -481,6 +482,12 @@ def peek_derived_status(
     OIs, dependency tracks, and the merged-PR evidence path) but writes nothing —
     so a dry-run preview never mutates DB state. Returns the same dict shape as
     reconcile_track (track_id, project_id, derived_status, declared_phase, drifted).
+
+    _merged_pr_numbers: optional pre-established merged-PR set (OI-1071). When
+    provided, used in place of the local-only set so a dry-run close that has
+    ALREADY gathered gh-confirmed merge evidence derives 'done' WITHOUT
+    VNX_RECONCILE_GIT. Same contract as reconcile_track._merged_pr_numbers.
+    When None, loads the local sources itself (the pre-OI-1071 behaviour).
 
     Raises RuntimeError if the derived_status column is absent (migration 0028).
     """
@@ -490,7 +497,11 @@ def peek_derived_status(
             raise RuntimeError(
                 "tracks.derived_status column absent; apply migration 0028 first."
             )
-        merged = _load_merged_pr_numbers(state_dir, repo_root)
+        merged = (
+            _merged_pr_numbers
+            if _merged_pr_numbers is not None
+            else _load_merged_pr_numbers(state_dir, repo_root)
+        )
         derived = _compute_derived_status(conn, track_id, project_id, merged)
         track_row = conn.execute(
             "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
@@ -753,12 +764,18 @@ def _close_evidence(
     track_id: str,
     project_id: str,
     repo_root: "str | Path | None" = None,
+    merged_pr_numbers: Optional[FrozenSet[int]] = None,
 ) -> Dict[str, Any]:
     """Summarize WHY a track derives terminal, so the operator gate is informed.
 
     The reconciler's 'done' counts ALL terminal dispatch states — including
     expired/dead_letter. A track whose every dispatch failed still derives 'done'.
     Surface the breakdown + a has_success_signal flag. Best-effort; never raises.
+
+    merged_pr_numbers: optional pre-established merged-PR set (OI-1071). When
+    provided, the pr_ref subset check uses it INSTEAD of re-loading the local
+    sources, so the operator-gate evidence reflects the same gh-confirmed UNION
+    the derivation saw. When None, loads the local sources itself (pre-OI-1071).
     """
     ev: Dict[str, Any] = {
         "completed": 0, "failed_terminal": 0, "in_flight": 0,
@@ -798,10 +815,18 @@ def _close_evidence(
     except Exception as exc:
         log.debug("close evidence query failed: %s", exc)
     # ALL parsed PRs must be merged (subset check), mirroring _compute_derived_status.
+    # OI-1071: use the caller-supplied evidence set when provided so the operator
+    # gate sees the same gh-confirmed UNION the derivation did; fall back to the
+    # local-only set otherwise (pre-OI-1071 behaviour).
     try:
         if ev["pr_ref"]:
             nums = _parse_pr_numbers(ev["pr_ref"])
-            if nums and nums <= _load_merged_pr_numbers(state_dir, repo_root):
+            evidence_set = (
+                merged_pr_numbers
+                if merged_pr_numbers is not None
+                else _load_merged_pr_numbers(state_dir, repo_root)
+            )
+            if nums and nums <= evidence_set:
                 ev["pr_merged"] = True
     except Exception as exc:
         log.debug("close evidence merged-PR check failed: %s", exc)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1157,17 +1157,35 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
     if attest_reason is not None:
         return _close_with_attest(args, state_dir, track_id, project_id, attest_reason, repo_root)
 
+    # OI-1071: gather the same gh-confirmed merge evidence run_reconcile builds
+    # and thread it into every derivation step below, so a track whose PRs
+    # merged via a bare ``gh pr merge`` (no local pr_merged receipt) derives
+    # 'done' via the verb WITHOUT VNX_RECONCILE_GIT. Without this, the dry-run
+    # peek / --apply reconcile / close_track_if_done all fall back to the
+    # local-only set and re-derive 'queued', refusing the close. The helper
+    # bounds live gh calls by --max-gh-calls and reuses the per-PR cache, and
+    # degrades honestly (consulted_gh=False) when gh is unreachable.
+    max_gh_calls = int(getattr(args, "max_gh_calls", 50))
+    close_evidence = objective_reconcile.gather_close_evidence(
+        state_dir, project_id, track_id,
+        repo_root=repo_root, max_gh_calls=max_gh_calls,
+    )
+    evidence_merged_pr_numbers = close_evidence["merged_pr_numbers"]
+
     try:
         # Dry-run is READ-ONLY: peek computes derived_status without persisting.
         # --apply reconciles fresh (and persists derived_status) right before the
-        # write, so the transition acts on current state.
+        # write, so the transition acts on current state. Both paths receive the
+        # gathered evidence set so the derivation matches what the close path sees.
         if args.apply:
             result = track_reconciler.reconcile_track(
-                state_dir, track_id, project_id, repo_root=repo_root
+                state_dir, track_id, project_id, repo_root=repo_root,
+                _merged_pr_numbers=evidence_merged_pr_numbers,
             )
         else:
             result = track_reconciler.peek_derived_status(
-                state_dir, track_id, project_id, repo_root=repo_root
+                state_dir, track_id, project_id, repo_root=repo_root,
+                _merged_pr_numbers=evidence_merged_pr_numbers,
             )
     except Exception as exc:
         print(f"objective close failed: cannot reconcile {track_id}: {exc}", file=sys.stderr)
@@ -1185,6 +1203,20 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
         "action": None,
         "applied": False,
     }
+    # OI-1071: when the track has a pr_ref but gh could not be consulted, the
+    # derived_status was computed from local sources ONLY. A 'not terminal'
+    # refusal on that basis must not read as "this track is not done" — the
+    # real cause may be "could not reach GitHub". Surface it so the operator
+    # knows to re-run when gh is back (or set VNX_RECONCILE_GIT for the local
+    # gh source). consulted_gh is False both when gh was unreachable AND when
+    # the track has no pr_ref to verify; only flag the former.
+    gh_unavailable = (
+        not close_evidence["consulted_gh"]
+        and close_evidence["gh_health"] in ("absent", "auth_failed", "timeout")
+        and bool(close_evidence["pr_numbers"])
+    )
+    if gh_unavailable:
+        payload["gh_health"] = close_evidence["gh_health"]
 
     def _emit(action: str, applied: bool, message: str, rc: int) -> int:
         payload["action"] = action
@@ -1206,6 +1238,15 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
                           "(no completed dispatch, no merged PR) — likely all-failed. "
                           "Confirm this is really done before --apply.")
             print(f"  {message}\n")
+            # OI-1071: surface the gh-unavailable degradation so a 'not terminal'
+            # refusal never reads as "not done" when its real cause is "could not
+            # reach GitHub".
+            if gh_unavailable:
+                print(
+                    f"  ! NOTE: could not consult GitHub (gh={close_evidence['gh_health']}); "
+                    f"derived_status used local evidence only. If the track's PRs merged "
+                    f"via a bare `gh pr merge`, re-run when gh is reachable."
+                )
             # Surface D5's blocker hint when close is blocked (guarded: no crash
             # until D5 lands format_blocking_hint + blocking_detail).
             if action == "noop_not_terminal" and derived == "blocked":
@@ -1235,9 +1276,13 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
 
     # Surface the done-evidence so the operator gate is informed: the reconciler
     # derives 'done' from ANY terminal dispatch state, including expired/dead_letter.
-    # Thread repo_root so the dry-run merged-PR check reads the project's ROADMAP
-    # (Source-3), matching the --apply path via close_track_if_done.
-    payload["evidence"] = _close_evidence(state_dir, track_id, project_id, repo_root=repo_root)
+    # Thread the gathered evidence set so the pr_ref subset check reflects the same
+    # gh-confirmed UNION the derivation saw (OI-1071), matching the --apply path
+    # via close_track_if_done.
+    payload["evidence"] = _close_evidence(
+        state_dir, track_id, project_id, repo_root=repo_root,
+        merged_pr_numbers=evidence_merged_pr_numbers,
+    )
 
     # The state machine forbids skips (e.g. queued -> done is illegal: a track
     # must pass through 'active'). A merged track stuck at queued/parked is
@@ -1264,13 +1309,16 @@ def cmd_objective_close(args: argparse.Namespace) -> int:
 
     # Delegate the walk (and a fresh reconcile) to the shared library function.
     # close_track_if_done reconciles fresh before walking so the transition acts on
-    # current state; the second reconcile is idempotent with the one above.
+    # current state; the second reconcile is idempotent with the one above. The
+    # gathered evidence set is forwarded so the internal reconcile_track sees the
+    # same gh-confirmed UNION (OI-1071), not the local-only fallback.
     lib = track_reconciler.close_track_if_done(
         state_dir, track_id, project_id,
         actor="operator",
         approval_id=args.approval_id,
         include_parked=getattr(args, "include_parked", False),
         repo_root=repo_root,
+        merged_pr_numbers=evidence_merged_pr_numbers,
     )
     lib_action = lib.get("action")
 
@@ -2440,6 +2488,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="delivering PR ref(s) as #NNN or NNN, comma-separated or repeated. Only valid "
              "with --attest: records the real PR as pr_ref instead of ops-attest:<date>. "
              "Without --attest, use `vnx objective link-pr` instead.",
+    )
+    p_close.add_argument(
+        "--max-gh-calls", type=int, default=50, dest="max_gh_calls",
+        metavar="N",
+        help="cap live gh pr view calls for the track's pr_ref (default 50; a single "
+             "close handles one track so the cap is rarely reached). Bounds the "
+             "evidence gather so it is explicit rather than unbounded.",
     )
     p_close.set_defaults(func=cmd_objective_close)
 

--- a/tests/test_objective_reconcile.py
+++ b/tests/test_objective_reconcile.py
@@ -1430,9 +1430,12 @@ def test_objective_close_dry_run_threads_repo_root_into_evidence(tmp_path, monke
     captured = {}
     real_close_evidence = planning_cli._close_evidence
 
-    def _spy(state_dir, track_id, project_id, repo_root=None):
+    def _spy(state_dir, track_id, project_id, repo_root=None, merged_pr_numbers=None):
         captured["repo_root"] = repo_root
-        return real_close_evidence(state_dir, track_id, project_id, repo_root=repo_root)
+        return real_close_evidence(
+            state_dir, track_id, project_id, repo_root=repo_root,
+            merged_pr_numbers=merged_pr_numbers,
+        )
 
     monkeypatch.setattr(planning_cli, "_close_evidence", _spy)
 
@@ -1444,6 +1447,204 @@ def test_objective_close_dry_run_threads_repo_root_into_evidence(tmp_path, monke
     # if repo_root were dropped and the CWD-git-root roadmap read instead).
     ev = real_close_evidence(str(sd), "T-dry", PROJECT_ID, repo_root=Path(str(repo)).resolve())
     assert ev["pr_merged"] is True
+
+
+# ---------------------------------------------------------------------------
+# OI-1071 — the standalone ``objective close`` verb must use the same merge
+# evidence ``reconcile`` does. Before this fix, the verb peeked/reconciled
+# with the local-only set, fell back to _load_merged_pr_numbers (whose gh source
+# is opt-in behind VNX_RECONCILE_GIT, OFF by default), and re-derived 'queued'
+# for a track whose PRs merged via a bare ``gh pr merge``. The tests below pin
+# the shared helper + the verb's evidence threading + honest gh degradation.
+# ---------------------------------------------------------------------------
+
+
+def _close_args(state_dir, track_id, *, apply=False, approval_id="", repo_root="",
+                max_gh_calls=50, include_parked=False, json_out=False):
+    return SimpleNamespace(
+        state_dir=str(state_dir), project_id=PROJECT_ID, track_id=track_id,
+        apply=apply, approval_id=approval_id, repo_root=repo_root,
+        max_gh_calls=max_gh_calls, include_parked=include_parked,
+        json=json_out, attest=None, pr=None,
+    )
+
+
+def test_close_verb_threads_nonempty_merged_set_into_close_track_if_done(tmp_path, monkeypatch):
+    """OI-1071: cmd_objective_close passes a non-empty merged set into
+    close_track_if_done (assert on the call, not a log line)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-1071a", phase="queued", pr_ref="#770")
+    # No local merge evidence. gh pr view is the sole authority.
+    _set_delivery(sd, "T-1071a", 770, "complete")  # OI-829 gate
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({770: _merged_pr(770)}),
+    )
+
+    captured = {}
+    real_close = track_reconciler.close_track_if_done
+
+    def _spy(state_dir, track_id, project_id, **kwargs):
+        captured["merged_pr_numbers"] = kwargs.get("merged_pr_numbers")
+        captured["track_id"] = track_id
+        return real_close(state_dir, track_id, project_id, **kwargs)
+
+    monkeypatch.setattr(track_reconciler, "close_track_if_done", _spy)
+    # planning_cli references close_track_if_done via the track_reconciler module
+    # attribute, so patch the same name planning_cli sees.
+    monkeypatch.setattr(planning_cli.track_reconciler, "close_track_if_done", _spy)
+
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "T-1071a", apply=True, approval_id="APR-1071", repo_root=str(tmp_path))
+    )
+    assert rc == 0, f"expected rc 0, got {rc}"
+    assert captured["track_id"] == "T-1071a"
+    merged = captured["merged_pr_numbers"]
+    assert merged is not None, "close_track_if_done must receive merged_pr_numbers"
+    assert 770 in set(merged), f"gh-confirmed PR 770 must be in the merged set, got {merged}"
+    assert _phase(sd, "T-1071a") == "done"
+
+
+def test_close_verb_derives_done_from_gh_only_without_vnx_reconcile_git(tmp_path, monkeypatch):
+    """OI-1071: a track whose pr_ref PRs are merged but ABSENT from local
+    sources closes via the verb, WITHOUT VNX_RECONCILE_GIT set."""
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-1071b", phase="queued", pr_ref="#771")
+    # No local merge evidence at all: no dispatch, no pr_merged.ndjson, no
+    # coordination_events, no ROADMAP. gh pr view is the sole authority.
+    _set_delivery(sd, "T-1071b", 771, "complete")  # OI-829 gate
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({771: _merged_pr(771)}),
+    )
+
+    # Dry-run: must report derived=done (today it reports derived=queued).
+    import io as _io, contextlib as _ctx
+    _buf = _io.StringIO()
+    with _ctx.redirect_stdout(_buf):
+        rc = planning_cli.cmd_objective_close(
+            _close_args(sd, "T-1071b", apply=False, repo_root=str(tmp_path), json_out=True)
+        )
+    payload = json.loads(_buf.getvalue())
+    assert rc == 0
+    assert payload["derived_status"] == "done", (
+        f"expected derived=done from gh-only evidence, got {payload['derived_status']}"
+    )
+    assert payload["action"] == "dry_run"
+
+
+def test_close_verb_gh_unavailable_falls_back_and_says_so(tmp_path, monkeypatch, capsys):
+    """OI-1071: gh unavailable -> falls back to local-only, refuses as before,
+    and the output STATES that gh could not be consulted (not 'not done')."""
+    monkeypatch.delenv("VNX_RECONCILE_GIT", raising=False)
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-1071c", phase="queued", pr_ref="#772")
+    # No local merge evidence and no completed dispatch -> derived 'queued'.
+    _seed_dispatch(sd, "D-1071c", "T-1071c", state="queued")
+
+    # gh truly absent.
+    monkeypatch.setattr(objective_reconcile, "_resolve_gh_binary", lambda: None)
+    monkeypatch.setattr(objective_reconcile.shutil, "which", lambda name: None)
+    monkeypatch.setattr(objective_reconcile, "_GH_FALLBACK_PATHS", ())
+
+    rc = planning_cli.cmd_objective_close(
+        _close_args(sd, "T-1071c", apply=False, repo_root=str(tmp_path))
+    )
+    out = capsys.readouterr().out
+    assert rc == 0  # noop_not_terminal is rc 0
+    assert "not terminal" in out, "must still refuse (local-only derived 'queued')"
+    assert "could not consult GitHub" in out, (
+        "must STATE gh could not be consulted, not silently behave as if it checked"
+    )
+    assert "gh=absent" in out
+
+
+def test_close_verb_and_run_reconcile_share_the_same_union_helper(tmp_path, monkeypatch):
+    """OI-1071: the extracted helper is the SAME one run_reconcile uses.
+    Assert both call sites reach objective_reconcile.merge_evidence_pr_numbers."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-share", phase="active", pr_ref="#773")
+    _seed_dispatch(sd, "D-share", "T-share", state="completed")
+    _seed_pr_merged_ndjson(sd, 773)
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({773: _merged_pr(773)}),
+    )
+
+    call_sites: list = []
+    real_union = objective_reconcile.merge_evidence_pr_numbers
+
+    def _spy(gh_confirmed, state_dir, repo_root=None):
+        call_sites.append("called")
+        return real_union(gh_confirmed, state_dir, repo_root)
+
+    monkeypatch.setattr(objective_reconcile, "merge_evidence_pr_numbers", _spy)
+
+    # run_reconcile reaches it.
+    objective_reconcile.run_reconcile(sd, PROJECT_ID, repo_root=tmp_path, apply=False)
+    recon_calls = len(call_sites)
+    assert recon_calls >= 1, "run_reconcile must call merge_evidence_pr_numbers"
+
+    # The close verb reaches it (via gather_close_evidence).
+    call_sites.clear()
+    planning_cli.cmd_objective_close(
+        _close_args(sd, "T-share", apply=False, repo_root=str(tmp_path))
+    )
+    close_calls = len(call_sites)
+    assert close_calls >= 1, "cmd_objective_close must call merge_evidence_pr_numbers"
+
+
+def test_close_verb_per_track_gh_budget_holds(tmp_path, monkeypatch):
+    """OI-1071: a track with N PRs makes at most N uncached gh calls."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-budget", phase="queued", pr_ref="#801,#802,#803")
+    _set_delivery(sd, "T-budget", 801, "complete")  # one complete delivery satisfies the gate
+    call_log: list = []
+
+    def _fake_run(cmd, **kwargs):
+        call_log.append(list(cmd))
+        cmd0 = os.path.basename(str(cmd[0])) if cmd else ""
+        if cmd0 == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd0 == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
+            pr_num = int(cmd[3])
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(_merged_pr(pr_num)), "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(objective_reconcile.subprocess, "run", _fake_run)
+
+    planning_cli.cmd_objective_close(
+        _close_args(sd, "T-budget", apply=False, repo_root=str(tmp_path))
+    )
+    pr_view_calls = [c for c in call_log if _is_gh_pr_view(c)]
+    assert len(pr_view_calls) == 3, (
+        f"a track with 3 PRs must make exactly 3 uncached gh calls, got {len(pr_view_calls)}"
+    )
+
+
+def test_close_verb_cached_pr_not_refetched(tmp_path, monkeypatch):
+    """OI-1071: a PR already verified (cached) is not re-fetched within the run."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-cache", phase="queued", pr_ref="#810")
+    _set_delivery(sd, "T-cache", 810, "complete")
+    # Pre-seed the per-PR cache so #810 is already MERGED.
+    repo_key = objective_reconcile._get_repo_key(tmp_path)
+    objective_reconcile._save_pr_state_cache(
+        sd, repo_key, {"810": {"state": "MERGED", "mergedAt": "2026-01-01T00:00:00Z"}}
+    )
+    call_log: list = []
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({810: _merged_pr(810)}, call_log=call_log),
+    )
+    planning_cli.cmd_objective_close(
+        _close_args(sd, "T-cache", apply=False, repo_root=str(tmp_path))
+    )
+    pr_view_calls = [c for c in call_log if _is_gh_pr_view(c)]
+    assert len(pr_view_calls) == 0, (
+        f"a cached MERGED PR must not be re-fetched, got {len(pr_view_calls)} calls"
+    )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

The operator-facing `objective close` verb did not use the merge evidence `reconcile` gathers. PR #1402 (OI-1064) threaded gh-confirmed merge evidence into the `reconcile --apply` close path, but the verb a human actually types peeked/reconciled with the local-only set and re-derived `queued` for a track whose PRs merged via a bare `gh pr merge` (no local `pr_merged` receipt).

## Change

Extract the evidence-gathering `run_reconcile` added into two shared helpers in `scripts/lib/objective_reconcile.py` so the bulk sweep and the standalone verb cannot drift:

- `merge_evidence_pr_numbers` — the UNION of gh-confirmed MERGED PR numbers and the locally-loaded set. `run_reconcile` calls this after its gh sweep (step 4c).
- `gather_close_evidence` — the per-track gather the close verb uses. Resolves the track's `pr_ref`, fetches only THAT track's PRs (cache-first, bounded by `--max-gh-calls`), and returns the union set + a health report.

`cmd_objective_close` now calls `gather_close_evidence` and threads the result into the dry-run `peek_derived_status`, the `--apply` `reconcile_track`, `_close_evidence`, and `close_track_if_done`. `peek_derived_status` and `_close_evidence` gain an optional `merged_pr_numbers` kwarg mirroring `reconcile_track`'s contract — no derivation-rule changes.

Degrade honestly: when gh is absent/unauthenticated/timed out, the close falls back to local-only and SAYS so in its output (`gh=<health>`), so a `not terminal` refusal never reads as `not done` when its real cause is `could not reach GitHub`.

Add `--max-gh-calls` to the close subparser (default 50) so the per-track gather is bounded and explicit rather than unbounded.

## Tests

Targeted (no full suite). Added to `tests/test_objective_reconcile.py`:
- `cmd_objective_close` passes a non-empty merged set into `close_track_if_done` (assert on the call).
- A track whose `pr_ref` PRs are merged but absent from local sources closes via the verb, WITHOUT `VNX_RECONCILE_GIT` (dry-run reports `derived=done`).
- gh unavailable -> falls back to local-only, refuses as before, and the output states gh could not be consulted.
- The extracted helper is the SAME one `run_reconcile` uses (assert both call sites reach `merge_evidence_pr_numbers`).
- Per-track gh budget holds: a track with N PRs makes exactly N uncached calls; a cached MERGED PR is not re-fetched.

## Scope boundary

No changes to `_compute_derived_status`'s rules, the plan-first gate, the auto-close streak criterion, or the `VNX_RECONCILE_GIT` default. The close verb applies the same phase transition it would have before — this changes what evidence the derivation sees, nothing else.

Dispatch-ID: 20260807-093016-close-verb-evidence
**Model**: glm-5.2
**Provider**: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)