### PR TITLE
feat(hook): ship t0_state builder as an install artefact (OI-1073)

### DIFF
--- a/scripts/build_t0_state.py
+++ b/scripts/build_t0_state.py
@@ -286,6 +286,77 @@ def compute_staleness_seconds(
         return 0.0
 
 
+def describe_freshness(
+    state: Optional[Dict[str, Any]],
+    now: Optional[datetime] = None,
+) -> str:
+    """Human-readable age of a t0_state snapshot (OI-1073 defect 3).
+
+    The projection carries its own build timestamp in ``generated_at`` (an
+    ISO-8601 UTC string written at build time). A reader built on a file
+    nobody writes is the actual complaint: this helper turns that timestamp
+    into a self-evident age string so "nobody wrote this since June" is
+    impossible to miss. ``None`` / a dict with no ``generated_at`` reports
+    "never built" rather than a misleading "0 seconds".
+
+    Returns one of:
+      - "never built"          — state is None or lacks a generated_at stamp
+      - "built <human age> ago" — e.g. "built 5 minutes ago", "built 3 days ago"
+      - "built just now"        — under 2 seconds old
+      - "built (age unknown)"   — generated_at present but unparseable
+
+    ``state`` is a full t0_state.json dict or the lighter t0_index.json dict
+    (both carry generated_at/timestamp); callers that only have a path should
+    load it first (see ``state_freshness_for_file``).
+    """
+    if not isinstance(state, dict):
+        return "never built"
+    ts_raw = str(state.get("generated_at") or state.get("timestamp") or "").strip()
+    if not ts_raw:
+        return "never built"
+    try:
+        ts = datetime.fromisoformat(ts_raw.replace("Z", "+00:00"))
+        if ts.tzinfo is None:
+            ts = ts.replace(tzinfo=timezone.utc)
+    except (ValueError, AttributeError, TypeError):
+        return "built (age unknown)"
+    actual_now = now if now is not None else _now_utc()
+    seconds = max(0.0, (actual_now - ts).total_seconds())
+    return f"built {_humanize_age(seconds)} ago"
+
+
+def _humanize_age(seconds: float) -> str:
+    """Render a duration in seconds as a short human-readable age."""
+    s = int(seconds)
+    if s < 2:
+        return "just now"
+    if s < 60:
+        return f"{s} seconds"
+    if s < 3600:
+        return f"{s // 60} minute{'s' if s // 60 != 1 else ''}"
+    if s < 86400:
+        return f"{s // 3600} hour{'s' if s // 3600 != 1 else ''}"
+    days = s // 86400
+    return f"{days} day{'s' if days != 1 else ''}"
+
+
+def state_freshness_for_file(
+    path: Path,
+    now: Optional[datetime] = None,
+) -> str:
+    """Read a t0_state.json / t0_index.json file and return its freshness.
+
+    Returns "never built" when the file is absent (the real complaint behind
+    OI-1073: a reader on a file nobody writes). A malformed file reports
+    "built (age unknown)" rather than raising — freshness is advisory.
+    """
+    try:
+        data = _safe_json(path)
+    except (OSError, json.JSONDecodeError):
+        return "built (age unknown)" if path.exists() else "never built"
+    return describe_freshness(data, now=now)
+
+
 # ---------------------------------------------------------------------------
 # Step 1: Schema init (absorbed from runtime_coordination_init.py)
 # ---------------------------------------------------------------------------

--- a/scripts/hooks/build_t0_state_hook.sh
+++ b/scripts/hooks/build_t0_state_hook.sh
@@ -8,16 +8,47 @@
 # hook forced the output to a repo-local state path (while every other write
 # went central) — the split-brain that left the guard reading an absent file.
 #
+# OI-1073: this hook ships as an INSTALL ARTEFACT, not a fabric source path.
+# It is registered in consumer repos via the install templates
+# (templates/settings_vnx_keys.json.tmpl + templates/init/*/settings.json.j2)
+# as an engine-relative path, and the wheel ships it at
+#   <site-packages>/vnx_orchestration/scripts/hooks/build_t0_state_hook.sh
+# The builder is resolved through the INSTALLED ENGINE (the same tree this
+# hook lives in), never through a repo-relative `scripts/` path — a consumer
+# (pip install) has no `scripts/` next to its project root, so a
+# `$PROJECT_ROOT/scripts/build_t0_state.py` reference would be a dead link
+# and the projection would silently never refresh (the bug this fixes).
+#
+# Failure visibility (OI-1073 defect 2): a broken build must be VISIBLE, not
+# silent. The hook writes a one-line failure to its OWN stderr, which the
+# harness surfaces on the session that fired it, while still exiting 0 so a
+# stale state file never blocks a session from starting. The full builder
+# traceback still goes to the central logs dir for diagnosis.
+#
 # Uses an explicit interpreter: bare `python3` can be relinked out from under
 # the hook (OI-852/OI-857) — repo venv > pinned homebrew 3.12 > bare python3.
-# Never blocks the session: stderr is captured to the central logs dir and the
-# hook always exits 0.
 
 set -u
 
-ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+# ── Resolve the INSTALLED ENGINE root (this hook's own tree) ───────────
+# This hook lives at <engine>/scripts/hooks/build_t0_state_hook.sh, so the
+# engine root is two levels up from the script's real location (symlink-
+# resolved). That is the same tree the `vnx` binary resolves its scripts/
+# from, so the builder reached here is the one the running engine ships —
+# never a repo-relative `scripts/` path that may not exist in a consumer.
+HOOK_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+ENGINE_ROOT="$(cd "$HOOK_DIR/../.." && pwd -P)"
 
-PY="$ROOT/.venv/bin/python"
+# Sanity guard: refuse to run a stale/missing builder rather than silently
+# doing nothing. If the engine tree is somehow broken the failure must be
+# visible (OI-1073 defect 2), not swallowed.
+if [ ! -f "$ENGINE_ROOT/scripts/build_t0_state.py" ]; then
+    printf '[vnx] build_t0_state_hook: builder not found under engine %s (t0_state.json not refreshed)\n' \
+        "$ENGINE_ROOT" >&2
+    exit 0
+fi
+
+PY="$ENGINE_ROOT/.venv/bin/python"
 [ -x "$PY" ] || PY="/opt/homebrew/opt/python@3.12/bin/python3.12"
 [ -x "$PY" ] || PY="python3"
 
@@ -25,14 +56,37 @@ PY="$ROOT/.venv/bin/python"
 # The bash resolver (vnx_paths.sh) applies a worktree override that points at
 # the repo-local `.vnx-data`; the python resolver keeps the store central,
 # which is what the guard reads — so resolve through python.
-PATHS="$("$PY" -c "import sys; sys.path.insert(0, '$ROOT/scripts/lib'); from vnx_paths import ensure_env; p=ensure_env(); print(p['VNX_STATE_DIR']); print(p['VNX_LOGS_DIR'])" 2>/dev/null)"
+PATHS="$("$PY" -c "import sys; sys.path.insert(0, '$ENGINE_ROOT/scripts/lib'); from vnx_paths import ensure_env; p=ensure_env(); print(p['VNX_STATE_DIR']); print(p['VNX_LOGS_DIR'])" 2>/dev/null)"
 STATE="$(printf '%s\n' "$PATHS" | sed -n 1p)"
 LOG="$(printf '%s\n' "$PATHS" | sed -n 2p)"
-[ -n "$STATE" ] || STATE="$ROOT/.vnx-data/state"
-[ -n "$LOG" ] || LOG="${STATE%/state}/logs"
+[ -n "$STATE" ] || STATE="$ENGINE_ROOT/.vnx-data/state"
+[ -n "$LOG" ]   || LOG="${STATE%/state}/logs"
 
 mkdir -p "$LOG" 2>/dev/null || true
-PYTHONPATH="$ROOT/scripts/lib:${PYTHONPATH:-}" \
-    "$PY" "$ROOT/scripts/build_t0_state.py" --output "$STATE/t0_state.json" \
-    2>"$LOG/build_t0_state.err"
+
+# ── Run the builder: visible failure, non-blocking exit ───────────────
+# Capture the full builder stderr to the central log for diagnosis, but tee
+# a concise failure line to the hook's OWN stderr so it lands on the session
+# that fired the hook (the mechanism the harness actually surfaces). The
+# hook still exits 0: a stale/broken state file must never block a session.
+ERR_LOG="$LOG/build_t0_state.err"
+BUILD_RC=0
+PYTHONPATH="$ENGINE_ROOT/scripts/lib:${PYTHONPATH:-}" \
+    "$PY" "$ENGINE_ROOT/scripts/build_t0_state.py" --output "$STATE/t0_state.json" \
+    2>"$ERR_LOG" || BUILD_RC=$?
+
+if [ "$BUILD_RC" -ne 0 ]; then
+    # Surface the failure on the session's own output. Keep it to the last
+    # line of the builder's stderr so it is concise but carries the real
+    # cause (the full traceback stays in $ERR_LOG for follow-up).
+    _last_err="$(tail -n 1 "$ERR_LOG" 2>/dev/null | tr -d '\r')"
+    if [ -n "$_last_err" ]; then
+        printf '[vnx] build_t0_state_hook FAILED (rc=%s): t0_state.json not refreshed. %s (full output: %s)\n' \
+            "$BUILD_RC" "$_last_err" "$ERR_LOG" >&2
+    else
+        printf '[vnx] build_t0_state_hook FAILED (rc=%s): t0_state.json not refreshed (full output: %s)\n' \
+            "$BUILD_RC" "$ERR_LOG" >&2
+    fi
+fi
+
 exit 0

--- a/templates/init/default/settings.json.j2
+++ b/templates/init/default/settings.json.j2
@@ -51,6 +51,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "terminals/T0",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"{{ engine_root }}/scripts/hooks/build_t0_state_hook.sh\"'"
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/init/minimal/settings.json.j2
+++ b/templates/init/minimal/settings.json.j2
@@ -45,6 +45,17 @@
           }
         ]
       }
+    ],
+    "SessionStart": [
+      {
+        "matcher": "terminals/T0",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"{{ engine_root }}/scripts/hooks/build_t0_state_hook.sh\"'"
+          }
+        ]
+      }
     ]
   }
 }

--- a/templates/settings_vnx_keys.json.tmpl
+++ b/templates/settings_vnx_keys.json.tmpl
@@ -77,6 +77,15 @@
             "timeout": 3000
           }
         ]
+      },
+      {
+        "matcher": "terminals/T0",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"{{VNX_HOME}}/scripts/hooks/build_t0_state_hook.sh\"'"
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/tests/test_build_t0_state_freshness.py
+++ b/tests/test_build_t0_state_freshness.py
@@ -9,7 +9,10 @@ hot-path advisory reconcile that keeps the t0_state projection fresh:
 - the compact index summary mirrors the full marker
 - autoclose_degraded is read from reconcile_summary.json (true when gh is
   absent, false for a healthy summary, true when the summary is missing)
-- the SessionStart hook command is valid bash, de-swallows stderr, keeps exit 0
+- the SessionStart hook command is valid bash, surfaces a failed build
+  visibly on the session's own stderr while keeping a non-blocking exit 0
+  (OI-1073: the hook ships as an install artefact and no longer swallows
+  failures into a 0-byte log nobody opens)
 """
 
 from __future__ import annotations
@@ -376,6 +379,8 @@ def test_autoclose_degraded_when_counts_malformed(tmp_path):
 
 # ---------------------------------------------------------------------------
 # SessionStart hook command (F5: a quoting bug here breaks every session start)
+# OI-1073: the hook ships as an INSTALL ARTEFACT (engine-relative), surfaces a
+# failed build visibly, and stays non-blocking.
 # ---------------------------------------------------------------------------
 
 def _t0_sessionstart_command() -> str:
@@ -399,7 +404,7 @@ def _t0_sessionstart_wrapper() -> str:
     raise AssertionError("T0 SessionStart hook not found")
 
 
-def test_sessionstart_hook_is_valid_bash_and_de_swallows():
+def test_sessionstart_hook_is_valid_bash_and_visible_failure():
     cmd = _t0_sessionstart_command()
     # 1) the whole command tokenizes (no unbalanced quotes)
     shlex.split(cmd)
@@ -412,16 +417,31 @@ def test_sessionstart_hook_is_valid_bash_and_de_swallows():
     wrapper = _t0_sessionstart_wrapper()
     rc = subprocess.run(["bash", "-n", "-c", wrapper], capture_output=True, text=True)
     assert rc.returncode == 0, f"wrapper is not valid bash: {rc.stderr}"
-    # 4) the BUILDER's stderr is captured to a log (not /dev/null), the output
-    #    lands in the CENTRAL store via the resolved $STATE (not the repo-local
-    #    .vnx-data split-brain, OI-859), an explicit interpreter is used, and
-    #    the hook never blocks.
+    # 4) the builder is resolved through the INSTALLED ENGINE via BASH_SOURCE
+    #    (HOOK_DIR/../.. -> ENGINE_ROOT), never through a repo-relative
+    #    $PROJECT_ROOT/scripts path that is absent in a pip consumer (OI-1073
+    #    defect 1). The output lands in the CENTRAL store via the resolved
+    #    $STATE (not the repo-local .vnx-data split-brain, OI-859), an explicit
+    #    interpreter is used, and the hook never blocks (exit 0).
+    assert "BASH_SOURCE" in wrapper, "hook must resolve the engine via BASH_SOURCE, not a hardcoded path"
+    assert "$ENGINE_ROOT/scripts/build_t0_state.py" in wrapper
+    assert "ENGINE_ROOT" in wrapper and '"$ROOT/scripts/' not in wrapper
     assert 'build_t0_state.py" --output "$STATE/t0_state.json"' in wrapper
     assert '"$ROOT/.vnx-data/state/t0_state.json"' not in wrapper
-    assert '2>"$LOG/build_t0_state.err"' in wrapper
-    assert "build_t0_state.err" in wrapper
-    assert "exit 0" in wrapper
+    assert "build_t0_state.err" in wrapper, "builder stderr must go to the central log, not /dev/null"
+    assert "exit 0" in wrapper, "a broken state file must never block a session (non-fatal)"
     assert ".venv/bin/python" in wrapper or "python3.12" in wrapper
+    # 5) OI-1073 defect 2: a FAILED build is VISIBLE, not swallowed. The hook
+    #    surfaces the failure to its own stderr (the mechanism the harness
+    #    surfaces on the session that fired it), not only into a 0-byte log
+    #    nobody opens. The old hook did `exit 0` UNCONDITIONALLY with no signal.
+    assert "build_t0_state_hook FAILED" in wrapper, (
+        "hook must surface a failed build visibly (OI-1073 defect 2), not swallow it"
+    )
+    assert ">&2" in wrapper, "failure message must go to the hook's own stderr"
+    # The conditional: the failure line is only printed when BUILD_RC != 0,
+    # so the hook does not noise up a healthy session.
+    assert "BUILD_RC" in wrapper
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_build_t0_state_hook_install.py
+++ b/tests/test_build_t0_state_hook_install.py
@@ -1,0 +1,269 @@
+#!/usr/bin/env python3
+"""tests/test_build_t0_state_hook_install.py — OI-1073: ship the state builder
+hook as an install artefact.
+
+The hook (scripts/hooks/build_t0_state_hook.sh) must work from a CONSUMER
+install, where there is no repo-relative ``scripts/`` tree. It resolves the
+builder through the installed engine (the tree this hook lives in), surfaces
+a failed build visibly on the hook's own stderr, and never blocks a session
+(exit 0). These tests build a throwaway fake engine root and invoke the real
+hook as a subprocess — they do NOT reimplement the hook logic.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+HOOK = REPO / "scripts" / "hooks" / "build_t0_state_hook.sh"
+
+# The hook resolves the central state dir via vnx_paths.ensure_env(), which
+# honors VNX_DATA_DIR_EXPLICIT + VNX_DATA_DIR. We pin those at a tmp tree so
+# the hook never touches the live ~/.vnx-data store.
+_VNX_ENV_KEYS = (
+    "VNX_HOME",
+    "VNX_PROJECT_ROOT",
+    "PROJECT_ROOT",
+    "VNX_CANONICAL_ROOT",
+    "VNX_DATA_DIR",
+    "VNX_DATA_DIR_EXPLICIT",
+    "VNX_STATE_DIR",
+    "VNX_DISPATCH_DIR",
+    "VNX_LOGS_DIR",
+    "VNX_PROJECT_ID",
+)
+
+
+def _clean_env(extra: dict | None = None) -> dict:
+    env = {k: v for k, v in os.environ.items() if k not in _VNX_ENV_KEYS}
+    if extra:
+        env.update(extra)
+    return env
+
+
+def _make_fake_engine(
+    tmp_path: Path,
+    *,
+    builder_source: str,
+) -> Path:
+    """Build a fake installed-engine tree the hook can run from.
+
+    The engine ships the hook at <engine>/scripts/hooks/ and the builder at
+    <engine>/scripts/build_t0_state.py — exactly the layout a wheel installs
+    (and a dev checkout uses). ``builder_source`` is the body of the builder
+    script, so a test can make it succeed or fail.
+    """
+    engine = tmp_path / "engine"
+    (engine / "scripts" / "hooks").mkdir(parents=True)
+    (engine / "scripts" / "lib").mkdir(parents=True)
+    shutil.copy(HOOK, engine / "scripts" / "hooks" / "build_t0_state_hook.sh")
+    os.chmod(engine / "scripts" / "hooks" / "build_t0_state_hook.sh", 0o755)
+    (engine / "scripts" / "build_t0_state.py").write_text(builder_source, encoding="utf-8")
+    # Minimal vnx_paths stub: ensure_env() returning the pinned dirs, so the
+    # hook resolves the central store without the full engine on sys.path.
+    (engine / "scripts" / "lib" / "vnx_paths.py").write_text(
+        "import os\n"
+        "def ensure_env():\n"
+        "    d = os.environ\n"
+        "    state = d.get('VNX_STATE_DIR') or os.path.join(d['VNX_DATA_DIR'], 'state')\n"
+        "    logs = d.get('VNX_LOGS_DIR') or os.path.join(d['VNX_DATA_DIR'], 'logs')\n"
+        "    return {'VNX_STATE_DIR': state, 'VNX_LOGS_DIR': logs}\n",
+        encoding="utf-8",
+    )
+    return engine
+
+
+def _run_hook(engine: Path, data_dir: Path) -> subprocess.CompletedProcess:
+    env = _clean_env(
+        {
+            "VNX_DATA_DIR_EXPLICIT": "1",
+            "VNX_DATA_DIR": str(data_dir),
+        }
+    )
+    return subprocess.run(
+        ["bash", str(engine / "scripts" / "hooks" / "build_t0_state_hook.sh")],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+
+
+# ── the builder is resolved through the installed engine, not scripts/ ────────
+
+def test_hook_resolves_builder_via_engine_not_repo_relative(tmp_path: Path) -> None:
+    """The hook invokes <engine>/scripts/build_t0_state.py via BASH_SOURCE,
+    never a $PROJECT_ROOT/scripts path. A consumer (no scripts/ next to its
+    project root) must still run the builder. Assert on the resolved command
+    the hook actually executes, not on a log line."""
+    called: list[str] = []
+
+    builder = (
+        "#!/usr/bin/env python3\n"
+        "import sys, os, json\n"
+        "out = sys.argv[sys.argv.index('--output') + 1]\n"
+        "os.makedirs(os.path.dirname(out), exist_ok=True)\n"
+        "# record the builder path the hook invoked so we can assert on it\n"
+        "with open(os.path.join(os.path.dirname(out), 'invoked_builder.txt'), 'w') as f:\n"
+        "    f.write(sys.argv[0])\n"
+        "with open(out, 'w') as f:\n"
+        "    json.dump({'generated_at': '2026-08-07T00:00:00+00:00', 'schema_version': '2.2'}, f)\n"
+    )
+    engine = _make_fake_engine(tmp_path, builder_source=builder)
+    data_dir = tmp_path / "data"
+
+    r = _run_hook(engine, data_dir)
+    assert r.returncode == 0, r.stdout + r.stderr
+
+    invoked = (data_dir / "state" / "invoked_builder.txt").read_text(encoding="utf-8")
+    # The hook MUST have invoked the builder under the ENGINE tree, not some
+    # repo-relative scripts/ path. This is the resolved-command assertion.
+    assert invoked == str(engine / "scripts" / "build_t0_state.py"), (
+        f"hook invoked builder from {invoked!r}, expected the engine path"
+    )
+    assert (engine / "scripts" / "build_t0_state.py").exists()
+
+
+def test_hook_runs_in_consumer_layout_without_scripts_dir(tmp_path: Path) -> None:
+    """Consumer-shaped layout: the CWD/project has NO scripts/ directory at
+    all (a pip-installed consumer). The hook still resolves and runs the
+    builder through the installed engine, independent of CWD."""
+    builder = (
+        "#!/usr/bin/env python3\n"
+        "import sys, os, json\n"
+        "out = sys.argv[sys.argv.index('--output') + 1]\n"
+        "os.makedirs(os.path.dirname(out), exist_ok=True)\n"
+        "with open(out, 'w') as f:\n"
+        "    json.dump({'generated_at': '2026-08-07T00:00:00+00:00'}, f)\n"
+    )
+    engine = _make_fake_engine(tmp_path, builder_source=builder)
+
+    # A consumer project dir with no scripts/ — run the hook from inside it.
+    consumer = tmp_path / "consumer-project"
+    consumer.mkdir()
+    (consumer / "README.md").write_text("a consumer", encoding="utf-8")
+    data_dir = tmp_path / "data"
+    env = _clean_env({"VNX_DATA_DIR_EXPLICIT": "1", "VNX_DATA_DIR": str(data_dir)})
+
+    r = subprocess.run(
+        ["bash", str(engine / "scripts" / "hooks" / "build_t0_state_hook.sh")],
+        capture_output=True, text=True, env=env, cwd=str(consumer),
+    )
+    assert r.returncode == 0, r.stdout + r.stderr
+    assert (data_dir / "state" / "t0_state.json").is_file(), (
+        "consumer with no scripts/ must still get a built t0_state.json"
+    )
+    # The consumer project must NOT have sprouted a scripts/ tree.
+    assert not (consumer / "scripts").exists()
+
+
+# ── a failing build is visible AND non-blocking ──────────────────────────────
+
+def test_failing_build_is_visible_and_does_not_block(tmp_path: Path) -> None:
+    """A deliberately broken build produces a VISIBLE failure signal on the
+    hook's own stderr, and the hook still exits 0 so the session is not
+    blocked."""
+    builder = (
+        "#!/usr/bin/env python3\n"
+        "import sys\n"
+        "sys.stderr.write('cannot import coordination_db: missing module\\n')\n"
+        "raise SystemExit(3)\n"
+    )
+    engine = _make_fake_engine(tmp_path, builder_source=builder)
+    data_dir = tmp_path / "data"
+
+    r = _run_hook(engine, data_dir)
+    # Non-blocking: the hook MUST exit 0 even when the builder fails.
+    assert r.returncode == 0, "a broken state file must not block the session"
+    # Visible: the failure surfaces on the hook's own stderr (not only a log).
+    assert "build_t0_state_hook FAILED" in r.stderr, (
+        f"failed build must be visible on stderr, got stderr={r.stderr!r}"
+    )
+    assert "rc=3" in r.stderr
+    # The real cause line is carried to the session output too.
+    assert "missing module" in r.stderr
+    # No state file was written by a failed build.
+    assert not (data_dir / "state" / "t0_state.json").exists()
+    # The full traceback still lands in the central log for diagnosis.
+    err_log = data_dir / "logs" / "build_t0_state.err"
+    assert err_log.is_file(), "full builder stderr must still go to the central log"
+    assert "missing module" in err_log.read_text(encoding="utf-8")
+
+
+def test_failing_build_visible_when_builder_missing(tmp_path: Path) -> None:
+    """If the engine tree is somehow broken (no builder under it), the hook
+    reports it visibly instead of silently doing nothing."""
+    builder = "# placeholder\n"
+    engine = _make_fake_engine(tmp_path, builder_source=builder)
+    # Remove the builder to simulate a broken engine install.
+    (engine / "scripts" / "build_t0_state.py").unlink()
+    data_dir = tmp_path / "data"
+
+    r = _run_hook(engine, data_dir)
+    assert r.returncode == 0, "still non-blocking"
+    assert "builder not found under engine" in r.stderr
+    assert "not refreshed" in r.stderr
+
+
+# ── a succeeding build writes the file and stamps the build timestamp ────────
+
+def test_succeeding_build_writes_file_and_stamps_timestamp(tmp_path: Path) -> None:
+    """A succeeding build writes t0_state.json carrying its own build
+    timestamp (generated_at), so staleness is self-evident (OI-1073 defect 3)."""
+    stamp = "2026-08-07T09:42:11+00:00"
+    builder = (
+        "#!/usr/bin/env python3\n"
+        "import sys, os, json\n"
+        "out = sys.argv[sys.argv.index('--output') + 1]\n"
+        "os.makedirs(os.path.dirname(out), exist_ok=True)\n"
+        "with open(out, 'w') as f:\n"
+        f"    json.dump({{'generated_at': {stamp!r}, 'schema_version': '2.2'}}, f)\n"
+    )
+    engine = _make_fake_engine(tmp_path, builder_source=builder)
+    data_dir = tmp_path / "data"
+
+    r = _run_hook(engine, data_dir)
+    assert r.returncode == 0, r.stdout + r.stderr
+    state_path = data_dir / "state" / "t0_state.json"
+    assert state_path.is_file(), "succeeding build must write t0_state.json"
+    import json as _json
+    payload = _json.loads(state_path.read_text(encoding="utf-8"))
+    assert payload["generated_at"] == stamp, "payload must carry its build timestamp"
+    # No failure signal on a healthy build (the hook does not noise it up).
+    assert "FAILED" not in r.stderr
+    assert r.stderr == ""
+
+
+def test_describe_freshness_reports_age_for_written_state(tmp_path: Path) -> None:
+    """The reader-facing helper turns the stamped generated_at into a
+    self-evident age string, including the never-built case."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    sys.path.insert(0, str(REPO / "scripts" / "lib"))
+    import build_t0_state as bts  # noqa: E402
+    from datetime import datetime, timezone, timedelta  # noqa: E402
+
+    now = datetime(2026, 8, 7, 10, 0, 0, tzinfo=timezone.utc)
+    # never built
+    assert bts.describe_freshness(None, now=now) == "never built"
+    assert bts.describe_freshness({}, now=now) == "never built"
+    # built 5 minutes ago
+    ts = (now - timedelta(minutes=5)).isoformat()
+    assert bts.describe_freshness({"generated_at": ts}, now=now) == "built 5 minutes ago"
+    # built 3 days ago
+    ts2 = (now - timedelta(days=3)).isoformat()
+    assert bts.describe_freshness({"generated_at": ts2}, now=now) == "built 3 days ago"
+    # index.json shape carries the timestamp under "timestamp"
+    assert bts.describe_freshness({"timestamp": ts}, now=now) == "built 5 minutes ago"
+    # unparseable stamp -> age unknown, not a crash
+    assert bts.describe_freshness({"generated_at": "garbage"}, now=now) == "built (age unknown)"
+    # file reader: absent file -> never built
+    assert bts.state_freshness_for_file(tmp_path / "absent.json", now=now) == "never built"
+
+
+if __name__ == "__main__":  # pragma: no cover
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## Summary

The `t0_state.json` projection was frozen across every consumer repo (mission-control 24 June, SEOcrawler 27 June, sales-copilot 27 June, pacompany ABSENT) because the SessionStart hook that builds it only existed in the fabric source layout. Consumers (pip installs) have no repo-relative `scripts/` tree, so the hook was a dead link — and a fail-open `exit 0` hid the failure in a 0-byte log nobody opens.

Three defects fixed (OI-1073), matching the install-artifact pattern the fabric already uses for hooks/skills/role files:

- **Defect 1 — reachability.** `scripts/hooks/build_t0_state_hook.sh` now resolves the builder through the INSTALLED ENGINE via `BASH_SOURCE` (the tree this hook lives in), not a repo-relative `scripts/` path. Registered in the consumer install templates (`settings_vnx_keys.json.tmpl` + `init/{default,minimal}/settings.json.j2`) as an engine-relative `SessionStart` matcher `terminals/T0`, matching the existing stop/pretooluse delivery pattern (`{{VNX_HOME}}` / `{{ engine_root }}`).
- **Defect 2 — fail-open.** A broken build now surfaces on the hook's own stderr (the mechanism the harness surfaces on the session that fired it) while still exiting 0 so a stale state file never blocks a session. The full traceback still lands in the central log. A missing builder is reported visibly instead of silently doing nothing.
- **Defect 3 — staleness.** New reader-facing `describe_freshness()` / `state_freshness_for_file()` turn the `generated_at` build timestamp into a self-evident age string, including the never-built case. `generated_at` is already written by the builder; no computed field changed.

## Changes

- `scripts/hooks/build_t0_state_hook.sh` — engine-relative builder resolution; visible + non-blocking failure surfacing.
- `templates/settings_vnx_keys.json.tmpl` — register `SessionStart` `terminals/T0` build_t0_state hook (bash `vnx regen-settings`).
- `templates/init/default/settings.json.j2`, `templates/init/minimal/settings.json.j2` — register the same hook (pip `vnx init`).
- `scripts/build_t0_state.py` — add `describe_freshness`, `_humanize_age`, `state_freshness_for_file` (pure readers; no computed field changed).
- `tests/test_build_t0_state_freshness.py` — update the SessionStart hook contract test for the new visible-failure behaviour (was asserting the old fail-open swallow).
- `tests/test_build_t0_state_hook_install.py` — new: hook resolves builder via engine not repo-relative; failing build visible + non-blocking; succeeding build stamps timestamp; consumer-shaped layout (no `scripts/`) still runs.

## Verification

Targeted tests only (no full suite), per dispatch scope:

```
pytest tests/test_build_t0_state_hook_install.py tests/test_build_t0_state_freshness.py \
  tests/test_wave4_regen_settings_target.py tests/test_cli_init.py tests/test_vnx_init.py \
  tests/test_sessionstart_hook.py tests/test_skill_preapprove_settings.py \
  tests/test_sessionstart_hook_dead_vars.py -q
-> 139 passed
```

- New install-artefact suite: 6 passed.
- Updated freshness suite: 15 passed (incl. the rewritten visible-failure contract test).
- Template/init neighbours: 92 passed (regen-settings target, cli init, vnx init bootstrap, sessionstart hook).

`bash -n scripts/hooks/build_t0_state_hook.sh` and `py_compile scripts/build_t0_state.py` clean.

## Open Items

- `tests/test_context_rotation.py::test_project_id_scoped_across_two_projects` fails on this branch, but it is PRE-EXISTING: reproduced on the base commit with my changes stashed. It is a worktree-path issue unrelated to this PR (the test resolves to the worktree `.vnx-data` and two project_ids collapse onto one dir). Not in scope; not touched by this PR.
- Scope boundary respected: did NOT change what `build_t0_state.py` computes, did NOT touch mission-control's repo, did NOT change `terminals/T0` matcher semantics.
- Existing consumer repos need a `vnx regen-settings --merge` (bash) or `vnx init` re-scaffold (pip) to pick up the new `SessionStart` registration — that is an operator sync step, not a code change.

**Dispatch-ID**: 20260807-102859-state-writer-install-artifact
**Model**: glm-5.2
**Provider**: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)