### PR TITLE
fix(doctor): resolve symlinks before dual-install conflict check (OI-1075)

### DIFF
--- a/tests/test_vnx_doctor_strict.py
+++ b/tests/test_vnx_doctor_strict.py
@@ -241,6 +241,7 @@ class TestCentralMode:
 
 class TestDualInstall:
     def test_dual_install_is_fail(self, tmp_path, monkeypatch):
+        """Real embedded dir (own scripts/) distinct from central -> FAIL."""
         project = _make_project(tmp_path)
         (project / ".claude" / "vnx-system" / "scripts").mkdir(parents=True)
         central = tmp_path / "home" / ".vnx-system" / "current"
@@ -254,8 +255,11 @@ class TestDualInstall:
         assert "dual install" in result.detail
         assert "embedded" in result.detail
         assert "central" in result.detail
+        # OI-1075: the destructive advice is correct only in the genuine-conflict case
+        assert "remove embedded install" in result.detail
 
     def test_dual_install_strict_exit_1(self, tmp_path, monkeypatch, capsys):
+        """Real embedded dir distinct from central -> --strict returns exit 1."""
         project = _make_project(tmp_path)
         (project / ".claude" / "vnx-system" / "scripts").mkdir(parents=True)
         central = tmp_path / "home" / ".vnx-system" / "current"
@@ -270,6 +274,7 @@ class TestDualInstall:
         assert "dual install" in out
 
     def test_no_dual_install_passes(self, tmp_path, monkeypatch):
+        """Embedded-only (no central) -> PASS."""
         project = _make_project(tmp_path)
         (project / ".claude" / "vnx-system" / "scripts").mkdir(parents=True)
 
@@ -278,6 +283,101 @@ class TestDualInstall:
         result = _check_dual_install(project)
 
         assert result.status == PASS
+
+    def test_no_embedded_path_passes(self, tmp_path, monkeypatch):
+        """No embedded path at all -> PASS."""
+        project = _make_project(tmp_path)
+        central = tmp_path / "home" / ".vnx-system" / "current"
+        (central / "scripts").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_dual_install(project)
+
+        assert result.status == PASS
+        assert "no dual install conflict" in result.detail
+
+    def test_symlink_into_central_passes_names_version(self, tmp_path, monkeypatch):
+        """Symlink into the central store -> PASS, detail names resolved version.
+
+        OI-1075: the intended central-mode arrangement. A naive is_dir() test
+        followed the symlink and saw the same scripts/ twice, falsely FAILing.
+        """
+        project = _make_project(tmp_path)
+        central_root = tmp_path / "home" / ".vnx-system"
+        version_dir = central_root / "versions" / "v1.4.5"
+        (version_dir / "scripts").mkdir(parents=True)
+        (central_root / "current").symlink_to(version_dir)
+        (project / ".claude").mkdir(parents=True)
+        (project / ".claude" / "vnx-system").symlink_to(central_root / "current")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_dual_install(project)
+
+        assert result.status == PASS
+        assert "v1.4.5" in result.detail
+        assert "central store" in result.detail
+
+    def test_dangling_symlink_is_warn_not_crash(self, tmp_path, monkeypatch):
+        """Dangling symlink -> WARN, non-crashing.
+
+        Chosen verdict: WARN (not FAIL). A dangling embedded symlink is not a
+        dual-install conflict (there is no second tree), but central mode is
+        broken until the link is repaired, so it must not pass silently either.
+        """
+        project = _make_project(tmp_path)
+        central = tmp_path / "home" / ".vnx-system" / "current"
+        (central / "scripts").mkdir(parents=True)
+        (project / ".claude").mkdir(parents=True)
+        (project / ".claude" / "vnx-system").symlink_to(project / "missing-target")
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_dual_install(project)
+
+        assert result.status == WARN
+        assert "dangling" in result.detail
+        assert "missing-target" in result.detail
+
+    def test_symlink_outside_central_is_fail(self, tmp_path, monkeypatch):
+        """Symlink pointing outside ~/.vnx-system entirely -> FAIL (genuine 2nd install)."""
+        project = _make_project(tmp_path)
+        outside = tmp_path / "outside-install"
+        (outside / "scripts").mkdir(parents=True)
+        central = tmp_path / "home" / ".vnx-system" / "current"
+        (central / "scripts").mkdir(parents=True)
+        (project / ".claude").mkdir(parents=True)
+        (project / ".claude" / "vnx-system").symlink_to(outside)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_dual_install(project)
+
+        assert result.status == FAIL
+        assert "dual install" in result.detail
+        assert "remove embedded install" in result.detail
+
+    def test_fabric_repo_real_dir_no_scripts_passes(self, tmp_path, monkeypatch):
+        """Fabric source repo: real .claude/vnx-system dir WITHOUT scripts/ -> PASS.
+
+        The fabric repo carries a real (non-symlink) .claude/vnx-system by
+        design, holding hooks/ and security_reports/ but no scripts/. This is
+        NOT a consumer dual install and must not be flagged. Preserves the
+        pre-OI-1075 behaviour verified on the live fabric repo.
+        """
+        project = _make_project(tmp_path)
+        (project / ".claude" / "vnx-system" / "hooks").mkdir(parents=True)
+        (project / ".claude" / "vnx-system" / "security_reports").mkdir(parents=True)
+        central = tmp_path / "home" / ".vnx-system" / "current"
+        (central / "scripts").mkdir(parents=True)
+
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path / "home"))
+
+        result = _check_dual_install(project)
+
+        assert result.status == PASS
+        assert "no dual install conflict" in result.detail
 
 
 # ---------------------------------------------------------------------------

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -312,27 +312,96 @@ def _check_state_root_location(data_root: Path) -> Check:
 
 
 def _check_dual_install(project_dir: Path) -> Check:
-    """Fail if both embedded and central installs are present with a scripts/ tree."""
+    """Fail only on a genuine dual install: two DISTINCT real install trees.
+
+    In a correctly configured central-mode consumer, ``.claude/vnx-system`` is a
+    symlink into the central store (``~/.vnx-system/current`` -> a version dir).
+    ``Path.is_dir()`` follows the symlink, so a naive "both have scripts/" test
+    sees the SAME tree twice and reports a conflict that does not exist — and
+    then advises a destructive repair that would delete the very symlink that
+    makes central mode work (OI-1075).
+
+    Resolution is the fix: resolve both sides to real paths and compare. A real
+    embedded copy (a directory that is NOT a symlink into the central store,
+    carrying its own ``scripts/``) still resolves to a distinct directory and
+    still FAILs with the existing, correct advice.
+    """
     embedded_path = project_dir / ".claude" / "vnx-system"
     central_path = Path.home() / ".vnx-system" / "current"
 
     embedded_active = (embedded_path / "scripts").is_dir()
     central_active = (central_path / "scripts").is_dir()
 
-    if embedded_active and central_active:
+    if not embedded_active:
+        # No embedded scripts/ tree is reachable. Distinguish a genuinely absent
+        # embedded path from a dangling symlink so the operator gets a useful
+        # verdict either way; neither is a dual-install conflict.
+        if embedded_path.is_symlink() and not embedded_path.exists():
+            resolved = embedded_path.resolve(strict=False)
+            return Check(
+                name="install:dual",
+                status=WARN,
+                detail=(
+                    f"embedded symlink {embedded_path} is dangling "
+                    f"(target {resolved} missing) — not a dual install conflict, "
+                    "but central mode is broken until the link is repaired"
+                ),
+            )
+        return Check(
+            name="install:dual",
+            status=PASS,
+            detail="no dual install conflict",
+        )
+
+    if not central_active:
+        return Check(
+            name="install:dual",
+            status=PASS,
+            detail="no dual install conflict",
+        )
+
+    # Both sides have a reachable scripts/ tree. The embedded path may be a
+    # symlink into the central store (the intended central-mode arrangement) or
+    # a real second install. Resolve both to real directories and compare.
+    try:
+        embedded_resolved = embedded_path.resolve(strict=False)
+        central_resolved = central_path.resolve(strict=False)
+    except OSError as exc:
+        # Pathological resolution failure — surface it rather than silently
+        # passing; resolution is the basis of the comparison.
         return Check(
             name="install:dual",
             status=FAIL,
             detail=(
-                f"dual install conflict: embedded at {embedded_path} "
-                f"AND central at {central_path} — "
-                "remove embedded install before using central mode"
+                f"dual install conflict: could not resolve paths to compare ({exc}) "
+                f"— embedded at {embedded_path}, central at {central_path}"
             ),
         )
+
+    if embedded_resolved == central_resolved:
+        # The embedded path is a symlink (directly or transitively) into the
+        # central store — that IS the intended central-mode arrangement, not a
+        # conflict. Name the resolved version dir for the operator.
+        return Check(
+            name="install:dual",
+            status=PASS,
+            detail=(
+                f"embedded symlink into central store: {embedded_resolved.name} "
+                f"({embedded_resolved})"
+            ),
+        )
+
+    # Genuinely distinct installs: a real embedded directory with its own
+    # scripts/, or a symlink pointing outside the central store entirely.
     return Check(
         name="install:dual",
-        status=PASS,
-        detail="no dual install conflict",
+        status=FAIL,
+        detail=(
+            f"dual install conflict: embedded at {embedded_path} "
+            f"(resolves to {embedded_resolved}) AND central at {central_path} "
+            f"(resolves to {central_resolved}) — "
+            "remove embedded install before using central mode"
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

`_check_dual_install` (`vnx_cli/commands/doctor.py`) reported a FAIL on every correctly-configured central-mode consumer and advised a destructive repair (OI-1075).

In a correct central-mode setup, `.claude/vnx-system` is a **symlink into the central store** (`~/.vnx-system/current` -> a version dir). The check used `Path.is_dir()` on both the embedded and central `scripts/` paths, which follows the symlink through, so both branches saw the **same** `scripts/` directory and reported a dual-install conflict that did not exist. The FAIL text then told the operator to "remove embedded install before using central mode" — following that advice deletes the symlink that makes central mode work.

Measured: `install:dual` was the only remaining FAIL on mission-control, SEOcrawler_v2 and sales-copilot.

## Changes

- `vnx_cli/commands/doctor.py` — `_check_dual_install` now resolves both sides to real paths via `Path.resolve()` and FAILs only when they resolve to **different** directories.
  - Embedded symlink resolving into the central store -> **PASS**, detail names the resolved version dir (e.g. `embedded symlink into central store: v1.4.5 (...)`).
  - Real embedded directory with its own `scripts/`, distinct from central -> **FAIL** with the existing (correct) advice.
  - Symlink pointing outside the central store entirely -> **FAIL** (genuine second install).
  - Dangling symlink -> **WARN** (chosen: not a dual conflict, but central mode is broken until the link is repaired — neither FAIL-calling it a conflict nor silently passing a broken link).
  - No embedded path at all -> **PASS** (unchanged).
  - Fabric source repo: real `.claude/vnx-system` dir without `scripts/` stays PASS (`embedded_active` is False), preserving the verified live behaviour.
- `tests/test_vnx_doctor_strict.py` — extended `TestDualInstall` with 5 new cases covering each edge.

## Verification

Targeted tests only (full suite not run per dispatch scope):

```
pytest tests/test_vnx_doctor.py tests/test_vnx_doctor_runtime.py tests/test_vnx_doctor_strict.py tests/test_doctor_standalone_dev.py -q
-> 113 passed
```

Live checks against real consumer repos (using the worktree module):
- mission-control: PASS `embedded symlink into central store: v1.4.5`
- SEOcrawler_v2: PASS `embedded symlink into central store: v1.4.5`
- sales-copilot: PASS `embedded symlink into central store: v1.4.5`
- fabric repo (vnx-orchestration): PASS `no dual install conflict` (preserved)
- synthetic real dual install (embedded dir + central dir): FAIL with `remove embedded install` advice (preserved)

## Open Items

None. Scope limited to `_check_dual_install` and its tests per dispatch; no other doctor check, install layout, or consumer repo touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

**Dispatch-ID**: 20260807-112458-doctor-dual-install
**Model**: glm-5.2
**Provider**: glm-harness