### PR TITLE
fix(horizon): one batched ls-remote instead of 5571 per-dispatch calls (OI-1078)

### DIFF
--- a/scripts/lib/dispatch_outcome_classifier.py
+++ b/scripts/lib/dispatch_outcome_classifier.py
@@ -411,23 +411,86 @@ def _is_active_or_orphaned(data_dir: Path, dispatch_id: str) -> bool:
     return (data_dir / "dispatches" / "active" / dispatch_id / "manifest.json").is_file()
 
 
-def _origin_branch_has_commits(repo_root: Optional[Path], dispatch_id: str) -> bool:
+# Sentinel for the run-scoped branch batch (OI-1078): distinguishes "no
+# batch supplied — single-dispatch caller, fetch on demand" from "the batch
+# ran and FAILED" (None). A failed batch and a successful-but-empty batch are
+# two different states that would otherwise both look like an empty set.
+_BATCH_NOT_PROVIDED = object()
+
+
+def _fetch_remote_dispatch_branches(repo_root: Optional[Path]) -> Optional[FrozenSet[str]]:
+    """Fetch every ``origin/dispatch/*`` branch in ONE batched ls-remote.
+
+    OI-1078: the salvage-branch check used to spawn one ``git ls-remote``
+    (one network round-trip, ~0.53s measured) per dispatch-id. With 5571
+    dispatch-ids in ``dispatch_outcomes`` that is 30–50 minutes of strictly
+    sequential network calls per reconcile run. One refspec-patterned call
+    (``git ls-remote --heads origin 'refs/heads/dispatch/*'``) returns all of
+    them at once (~0.4s measured on this repo, 2026-08-07); afterwards each
+    per-dispatch check is a set-membership test.
+
+    Returns the dispatch-id set on success — an EMPTY frozenset is a valid,
+    meaningful result (origin genuinely has no dispatch branches). Returns
+    None on ANY git/subprocess failure: the fail-safe direction of
+    :func:`_origin_branch_has_commits` (a salvage check that can't run must
+    not claim salvage exists) maps failure to False for every id, and the
+    warning logged here keeps a failed batch observable instead of silently
+    indistinguishable from a successful empty result.
+    """
+    if repo_root is None:
+        return None
+    try:
+        result = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-remote", "--heads", "origin",
+             "refs/heads/dispatch/*"],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except (subprocess.SubprocessError, OSError) as exc:
+        logger.warning(
+            "dispatch_outcome_classifier: batched ls-remote failed (%s); "
+            "treating every dispatch-id as having no origin branch", exc,
+        )
+        return None
+    if result.returncode != 0:
+        logger.warning(
+            "dispatch_outcome_classifier: batched ls-remote exited %d (%s); "
+            "treating every dispatch-id as having no origin branch",
+            result.returncode, (result.stderr or "").strip(),
+        )
+        return None
+    prefix = "refs/heads/dispatch/"
+    ids = set()
+    for line in result.stdout.splitlines():
+        parts = line.split()
+        if len(parts) == 2 and parts[1].startswith(prefix):
+            ids.add(parts[1][len(prefix):])
+    return frozenset(ids)
+
+
+def _origin_branch_has_commits(
+    repo_root: Optional[Path],
+    dispatch_id: str,
+    remote_branches: Any = _BATCH_NOT_PROVIDED,
+) -> bool:
     """True iff ``origin/dispatch/<id>`` exists — the salvage-branch naming
     convention ``tmux_worktree.py`` uses (``f"dispatch/{dispatch_id}"``).
     Best-effort: any git/subprocess failure yields False (fail-safe — a
-    salvage check that can't run must not claim salvage exists)."""
-    if repo_root is None:
-        return False
-    try:
-        result = subprocess.run(
-            ["git", "-C", str(repo_root), "ls-remote", "origin", f"dispatch/{dispatch_id}"],
-            capture_output=True, text=True, timeout=10, check=False,
-        )
-    except (subprocess.SubprocessError, OSError):
-        return False
-    if result.returncode != 0:
-        return False
-    return bool(result.stdout.strip())
+    salvage check that can't run must not claim salvage exists).
+
+    ``remote_branches``: run-scoped batch result from
+    :func:`_fetch_remote_dispatch_branches` (OI-1078). The bulk reconciler
+    fetches it ONCE per run and shares it across every per-dispatch check, so
+    N dispatch-ids cost one network call, not N. None means the batch FAILED
+    (or there is no repo) — fail-safe False for every id; an empty frozenset
+    means the batch succeeded and origin has no dispatch branches at all.
+    When omitted (single-dispatch callers), the batch is fetched on demand —
+    same one-call cost as the old per-dispatch probe.
+    """
+    if remote_branches is _BATCH_NOT_PROVIDED:
+        if repo_root is None:
+            return False
+        remote_branches = _fetch_remote_dispatch_branches(repo_root)
+    return remote_branches is not None and dispatch_id in remote_branches
 
 
 def _load_dispatch_row(
@@ -559,6 +622,7 @@ def load_evidence(
     now: Optional[datetime] = None,
     receipts_index: Optional[Dict[str, List[Dict[str, Any]]]] = None,
     merged_pr_numbers: Optional[FrozenSet[int]] = None,
+    remote_dispatch_branches: Any = _BATCH_NOT_PROVIDED,
 ) -> DispatchOutcomeEvidence:
     """Load all raw evidence for one dispatch. I/O; never raises.
 
@@ -567,6 +631,10 @@ def load_evidence(
     the receipts file / re-resolving merged PRs per dispatch — the "bounded
     evidence load" the design requires. When omitted, loaded fresh (a single-
     dispatch call is still bounded to one file read / one merged-PR scan).
+
+    ``remote_dispatch_branches``: the bulk pass's one batched ls-remote
+    result (OI-1078) — pass it to keep the branch check a set-lookup. When
+    omitted, the branch check fetches the batch on demand for this dispatch.
     """
     now = now or datetime.now(timezone.utc)
     evidence = DispatchOutcomeEvidence(dispatch_id=dispatch_id, project_id=project_id)
@@ -634,7 +702,15 @@ def load_evidence(
     evidence.terminal_receipt_failure_reason = failure_reason
 
     evidence.is_active_or_orphaned = _is_active_or_orphaned(data_dir, dispatch_id)
-    evidence.origin_branch_has_commits = _origin_branch_has_commits(repo_root, dispatch_id)
+    # Conditional call (not an unconditional keyword pass-through) so existing
+    # two-argument monkeypatches of _origin_branch_has_commits keep working
+    # when no run-scoped batch was supplied.
+    if remote_dispatch_branches is _BATCH_NOT_PROVIDED:
+        evidence.origin_branch_has_commits = _origin_branch_has_commits(repo_root, dispatch_id)
+    else:
+        evidence.origin_branch_has_commits = _origin_branch_has_commits(
+            repo_root, dispatch_id, remote_branches=remote_dispatch_branches,
+        )
 
     return evidence
 
@@ -817,6 +893,12 @@ def reconcile_all_dispatch_outcomes(
 
     merged_pr_numbers = _load_merged_pr_numbers(state_dir, repo_root)
 
+    # OI-1078: ONE batched ls-remote for the whole run instead of one
+    # network round-trip per dispatch-id (measured ~0.53s/call; 5571 ids
+    # would otherwise take 30-50 minutes). None = batch failed or no repo —
+    # fail-safe False for every dispatch-id (warning logged by the fetch).
+    remote_dispatch_branches = _fetch_remote_dispatch_branches(repo_root)
+
     qi_db = state_dir / QI_DB_FILENAME
     qi_conn: Optional[sqlite3.Connection] = None
     if qi_db.exists():
@@ -833,6 +915,7 @@ def reconcile_all_dispatch_outcomes(
                 state_dir, data_dir, project_id, dispatch_id,
                 repo_root=repo_root, now=now,
                 receipts_index=receipts_index, merged_pr_numbers=merged_pr_numbers,
+                remote_dispatch_branches=remote_dispatch_branches,
             )
             outcome = classify_outcome(evidence)
             entry: Dict[str, Any] = {

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2451,7 +2451,9 @@ def _build_parser() -> argparse.ArgumentParser:
     p_reconcile.add_argument(
         "--max-gh-calls", type=int, default=50, dest="max_gh_calls",
         metavar="N",
-        help="cap live gh pr view calls per run (default 50; excess → deferred)",
+        help="cap live gh pr view calls per run (default 50; excess → deferred). "
+             "Bounds ONLY gh pr view calls — other git calls (the single batched "
+             "ls-remote dispatch-branch probe, OI-1078) are not counted",
     )
     p_reconcile.add_argument(
         "--repo-root", default="", dest="repo_root",

--- a/tests/test_dispatch_outcome_classifier.py
+++ b/tests/test_dispatch_outcome_classifier.py
@@ -14,6 +14,7 @@ salvage check, active/orphan check) and the FPY/rework-rate metrics query.
 from __future__ import annotations
 
 import json
+import logging
 import sqlite3
 import subprocess
 import sys
@@ -564,6 +565,108 @@ def test_origin_branch_has_commits_true_with_real_remote(tmp_path):
 
     assert doc._origin_branch_has_commits(work, "d-salvage-test") is True
     assert doc._origin_branch_has_commits(work, "d-nonexistent") is False
+
+
+# ---------------------------------------------------------------------------
+# OI-1078 — batched ls-remote: one network call per run, not one per dispatch
+# ---------------------------------------------------------------------------
+
+def _make_origin_with_branches(tmp_path: Path, branches: list[str]) -> Path:
+    """Build a work repo whose `origin` (a local bare repo) carries ``branches``."""
+    bare = tmp_path / "origin.git"
+    subprocess.run(["git", "init", "--bare", "-q", str(bare)], check=True)
+
+    work = tmp_path / "work"
+    work.mkdir()
+    subprocess.run(["git", "init", "-q", str(work)], check=True)
+    subprocess.run(["git", "-C", str(work), "config", "user.email", "t@example.com"], check=True)
+    subprocess.run(["git", "-C", str(work), "config", "user.name", "t"], check=True)
+    (work / "f.txt").write_text("hi", encoding="utf-8")
+    subprocess.run(["git", "-C", str(work), "add", "f.txt"], check=True)
+    subprocess.run(["git", "-C", str(work), "commit", "-q", "-m", "init"], check=True)
+    subprocess.run(["git", "-C", str(work), "remote", "add", "origin", str(bare)], check=True)
+    for branch in branches:
+        subprocess.run(["git", "-C", str(work), "push", "-q", "origin",
+                         f"HEAD:refs/heads/{branch}"], check=True)
+    return work
+
+
+def test_fetch_remote_dispatch_branches_parses_only_dispatch_refs(tmp_path):
+    work = _make_origin_with_branches(
+        tmp_path, ["dispatch/d-one", "dispatch/d-two", "main"],
+    )
+    assert doc._fetch_remote_dispatch_branches(work) == frozenset({"d-one", "d-two"})
+
+
+def test_fetch_remote_dispatch_branches_empty_success_is_not_failure(tmp_path):
+    """A successful batch with zero dispatch branches is an EMPTY SET, not
+    None — the two states must stay distinguishable (failed vs none-exist)."""
+    work = _make_origin_with_branches(tmp_path, ["main"])
+    assert doc._fetch_remote_dispatch_branches(work) == frozenset()
+
+
+def test_fetch_remote_dispatch_branches_failure_returns_none_and_warns(tmp_path, caplog):
+    with caplog.at_level(logging.WARNING, logger="dispatch_outcome_classifier"):
+        assert doc._fetch_remote_dispatch_branches(tmp_path / "not-a-repo") is None
+    assert any("ls-remote" in rec.message for rec in caplog.records)
+
+
+def test_origin_branch_has_commits_against_batch_set():
+    """Existing branch -> True, non-existing -> False, failed batch (None) ->
+    False for every id — the fail-safe direction, with no git call at all."""
+    batch = frozenset({"d-exists"})
+    assert doc._origin_branch_has_commits(None, "d-exists", remote_branches=batch) is True
+    assert doc._origin_branch_has_commits(None, "d-missing", remote_branches=batch) is False
+    assert doc._origin_branch_has_commits(None, "d-exists", remote_branches=None) is False
+
+
+def test_bulk_run_does_one_batched_lsremote_for_n_dispatches(tmp_path, monkeypatch):
+    """Regression guard for OI-1078: N dispatch-ids cost exactly ONE batched
+    ls-remote fetch per run, not N. Patched at the module attribute the bulk
+    pass binds the name through, and asserted to actually have been called."""
+    state_dir, data_dir = _build_state(tmp_path)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+    for i in range(5):
+        _insert_dispatch(state_dir, f"d-{i}", state="completed")
+        _write_receipt(state_dir, f"d-{i}", "done")
+
+    fetch_calls = []
+
+    def counting_fetch(repo_root):
+        fetch_calls.append(repo_root)
+        return frozenset()
+
+    monkeypatch.setattr(doc, "_fetch_remote_dispatch_branches", counting_fetch)
+    results = doc.reconcile_all_dispatch_outcomes(
+        state_dir, data_dir, PROJECT_ID, repo_root=tmp_path, now=NOW,
+    )
+    assert len(results) == 5
+    assert len(fetch_calls) == 1  # one batched call for the whole run, not 5
+
+
+def test_bulk_run_failed_batch_failsafe_false_for_every_dispatch(tmp_path, monkeypatch):
+    """A failed batch (None) must never claim salvage exists: an old,
+    receipt-less, lease-less dispatch classifies abandoned, NOT
+    preserved-no-pr — for every id. Contrast leg proves the same dispatch
+    WOULD be preserved-no-pr had the batch succeeded with its branch present."""
+    state_dir, data_dir = _build_state(tmp_path)
+    monkeypatch.setattr(doc, "_load_merged_pr_numbers", lambda sd, rr: frozenset())
+    old_ts = (NOW - timedelta(hours=48)).strftime("%Y-%m-%dT%H:%M:%S.%fZ")
+    _insert_dispatch(state_dir, "d-old", state="active", created_at=old_ts)
+
+    monkeypatch.setattr(doc, "_fetch_remote_dispatch_branches", lambda rr: None)
+    results = doc.reconcile_all_dispatch_outcomes(
+        state_dir, data_dir, PROJECT_ID, repo_root=tmp_path, now=NOW,
+    )
+    assert [r["outcome"] for r in results] == ["abandoned"]
+
+    monkeypatch.setattr(
+        doc, "_fetch_remote_dispatch_branches", lambda rr: frozenset({"d-old"}),
+    )
+    results = doc.reconcile_all_dispatch_outcomes(
+        state_dir, data_dir, PROJECT_ID, repo_root=tmp_path, now=NOW,
+    )
+    assert [r["outcome"] for r in results] == ["preserved-no-pr"]
 
 
 # ---------------------------------------------------------------------------

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -515,7 +515,9 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     )
     p_reconcile.add_argument(
         "--max-gh-calls", type=int, default=50, dest="max_gh_calls", metavar="N",
-        help="cap live gh pr view calls per run (default 50; excess -> deferred)",
+        help="cap live gh pr view calls per run (default 50; excess -> deferred). "
+             "Bounds ONLY gh pr view calls — other git calls (the single batched "
+             "ls-remote dispatch-branch probe, OI-1078) are not counted",
     )
     p_reconcile.add_argument(
         "--repo-root", default="", dest="repo_root", metavar="PATH",


### PR DESCRIPTION
## Problem (measured on main `f58ede91`)

`vnx horizon reconcile` never finished: killed after 5 and 3 minutes with zero bytes of output. Cause, measured by sampling the process: step 2b's dispatch-outcome sweep (`objective_reconcile.py` → `reconcile_all_dispatch_outcomes`) called `_origin_branch_has_commits` per dispatch-id, and each call spawned its own `git ls-remote origin dispatch/<id>` — one network round-trip (~0.53s measured), strictly sequential, `timeout=10` each, no batching, no cache. With **5571 distinct dispatch-ids** in `dispatch_outcomes`, that is 30–50 minutes of network calls in front of the nomination/close pipeline the run exists for — by a sweep explicitly marked best-effort/never-blocking.

## Fix

- **One batched call per run**: `_fetch_remote_dispatch_branches()` runs `git ls-remote --heads origin 'refs/heads/dispatch/*'` once (~0.4s measured on this repo — all 64 dispatch branches) and `_origin_branch_has_commits` becomes a set-membership test. 5571 network calls → 1.
- **Run-scoped, not module-global**: the batch is fetched once in `reconcile_all_dispatch_outcomes` and threaded down through `load_evidence` as a parameter. A module-global set would leak between runs and tests, and a long-lived process would miss branches created after process start; a parameter makes the cache lifetime exactly the run.
- **Fail-safe direction kept, made explicit**: a FAILED batch returns `None` (distinct from a successful EMPTY frozenset — two states that would otherwise both look like an empty set), logs a warning, and yields False for every dispatch-id: a salvage check that can't run never claims salvage exists.
- **`--max-gh-calls` honesty**: chose to fix the help text rather than widen the flag. After batching there is exactly one ls-remote per run, so there is nothing left to cap; the flag's counting contract is covered by existing tests (OI-1064) and widening it would change a tested semantic for zero bounding value. Help text (both `vnx_cli/main.py` and `scripts/planning_cli.py`) now states it bounds ONLY live `gh pr view` calls.

## Measured result

`vnx objective reconcile --project-id vnx-dev` (read-only; `horizon` is gated in operator mode, `objective` is the same command): **completes in 27.11s wall-clock, exit 0** — previously never finished (killed at 3–5 min, zero output).

## Tests

- `test_bulk_run_does_one_batched_lsremote_for_n_dispatches` — regression guard: N=5 dispatch-ids → exactly 1 fetch call (patched at the module binding, asserted actually called).
- `test_bulk_run_failed_batch_failsafe_false_for_every_dispatch` — failed batch → every id fail-safe False (abandoned, not preserved-no-pr); contrast leg proves the same dispatch IS preserved-no-pr when the batch succeeds with its branch present.
- `test_fetch_remote_dispatch_branches_failure_returns_none_and_warns` — failed batch → None + warning logged.
- `test_fetch_remote_dispatch_branches_parses_only_dispatch_refs` / `_empty_success_is_not_failure` / `test_origin_branch_has_commits_against_batch_set` — parsing, empty-vs-failed distinction, membership semantics (real git remotes).

`pytest tests/test_dispatch_outcome_classifier.py tests/test_objective_reconcile.py tests/test_dispatch_door_row.py`: **143 passed**.

Dispatch-ID: 20260807-190000-oi1078-lsremote-batch