### PR TITLE
fix(gate): read-only dispatches en het grootboek beoordelen in plaats van surrogaatsignalen (OI-1087, OI-1088)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -70,29 +70,55 @@ def _injection_probe_health(state_dir: Path) -> str:
 def _check_receipt_completeness(
     data_root: Path, max_age_hours: int = 48
 ) -> tuple[bool, str]:
-    """GAP-7 preflight: verify recent processed receipts exist and are not stale.
+    """GAP-7 preflight: verify recent receipts arrived in the t0 ledger.
 
-    Checks {data_root}/receipts/processed/ for any file modified within max_age_hours.
-    Returns (True, "ok") when fresh receipts are found, (False, reason) otherwise.
+    OI-1088: reads the append-only ledger ``state/t0_receipts.ndjson`` under the
+    resolved data root — the source of truth for receipt arrivals — instead of
+    ``receipts/processed/``. That directory is the delivery lane's staging area,
+    not the ledger: it stopped receiving files (receipts/pending/ drained for the
+    last time on 2026-07-23) while the ledger kept appending, so this preflight
+    measured a dead mailbox and silently skipped every cycle for weeks even
+    though no receipt was ever missing.
+
+    The check's meaning is unchanged: "are there receipts from the last
+    max_age_hours". Only the source moved. Three distinct failure states, each
+    with its own reason string: ledger absent, ledger without a single parseable
+    receipt timestamp, ledger present but stale.
+
+    Returns (True, "ok") when a fresh receipt is found, (False, reason) otherwise.
     """
-    processed_dir = data_root / "receipts" / "processed"
-    if not processed_dir.exists():
-        return False, f"receipts/processed directory absent: {processed_dir}"
+    ledger_path = data_root / "state" / "t0_receipts.ndjson"
+    if not ledger_path.exists():
+        return False, f"receipts ledger absent: {ledger_path}"
 
-    files = list(processed_dir.iterdir())
-    if not files:
-        return False, "receipts/processed is empty — no dispatch receipts found"
+    newest: "datetime | None" = None
+    with ledger_path.open("r", encoding="utf-8") as fh:
+        for raw_line in fh:
+            line = raw_line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue  # skip a torn/partial append; one bad line never fails the check
+            ts_raw = record.get("timestamp")
+            if not ts_raw:
+                continue
+            try:
+                ts = datetime.fromisoformat(str(ts_raw).replace("Z", "+00:00"))
+            except ValueError:
+                continue
+            if ts.tzinfo is None:
+                ts = ts.replace(tzinfo=timezone.utc)  # ledger timestamps are UTC
+            if newest is None or ts > newest:
+                newest = ts
+
+    if newest is None:
+        return False, "receipts ledger empty — no dispatch receipts found"
 
     cutoff = datetime.now(timezone.utc) - timedelta(hours=max_age_hours)
-    fresh = [
-        f for f in files
-        if datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc) >= cutoff
-    ]
-    if not fresh:
-        most_recent_ts = max(
-            datetime.fromtimestamp(f.stat().st_mtime, tz=timezone.utc) for f in files
-        )
-        age_h = (datetime.now(timezone.utc) - most_recent_ts).total_seconds() / 3600
+    if newest < cutoff:
+        age_h = (datetime.now(timezone.utc) - newest).total_seconds() / 3600
         return (
             False,
             f"all receipts stale (newest {age_h:.1f}h ago, threshold {max_age_hours}h)",

--- a/scripts/lib/envelope_adapters_provider.py
+++ b/scripts/lib/envelope_adapters_provider.py
@@ -494,6 +494,12 @@ class ProviderAdapter:
                 # longer deadline (e.g. stage_spec_bundle's 3600s default) was previously
                 # silently capped short (memory: provider-lane-900s-deadline-kills-builds).
                 total_deadline=float(plan.deadline_seconds),
+                # OI-1087: hand the plan's task_class to the spawn so the fabrication
+                # guard can exempt positively-known read-only classes (review/analysis):
+                # for those, an unchanged worktree is the intended outcome, not proof
+                # of fabrication. Four review dispatches false-failed on 2026-08-07
+                # because this signal never left the adapter.
+                task_class=plan.task_class,
             )
         except BrokenPipeError as exc:
             return _AdapterResult(

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -2112,6 +2112,14 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
             terminal_id=args.terminal_id,
             event_writer=event_store.append if event_store is not None else None,
             cwd=worker_cwd,
+            # OI-1087: same read-only exemption as the envelope-adapter path — the
+            # explicit --task-class flag first, then the VNX_TASK_CLASS env the door
+            # exports (the same value append_receipt records on the receipt).
+            # Unknown/empty keeps the fabrication guard armed.
+            task_class=(
+                (getattr(args, "task_class", "") or "").strip()
+                or (os.environ.get("VNX_TASK_CLASS", "") or "").strip()
+            ) or None,
         )
         end_time = datetime.now(timezone.utc)
 

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -68,6 +68,11 @@ if _LIB_DIR not in sys.path:
 
 from _streaming_drainer import StreamingDrainerMixin, _kill_process, coerce_chunk_stall  # noqa: E402
 from canonical_event import CanonicalEvent  # noqa: E402
+# OI-1087: the read-only task-class list lives in ONE place — phantom_guard's
+# REVIEW_TASK_CLASSES is the fabric's SSOT for "a verdict, not a diff, is the
+# expected deliverable". The fabrication guard below keys off the same list so
+# the two guards can never drift apart.
+from phantom_guard import REVIEW_TASK_CLASSES  # noqa: E402
 
 logger = logging.getLogger(__name__)
 
@@ -1031,6 +1036,7 @@ def _finalize_kimi_result(
     raw_samples: Optional[list] = None,
     saw_tool_calls: bool = False,
     worktree: Optional[Any] = None,
+    task_class: Optional[str] = None,
 ) -> KimiSpawnResult:
     """Wait for process exit and return a KimiSpawnResult.
 
@@ -1042,6 +1048,14 @@ def _finalize_kimi_result(
     approval defaults again). ``worktree=None`` (no isolation worktree known,
     e.g. non-worktree dispatches) skips the check gracefully — there is nothing
     to diff against.
+
+    OI-1087: ``task_class`` exempts POSITIVELY-KNOWN read-only classes (the
+    phantom_guard REVIEW_TASK_CLASSES SSOT: review/analysis/research_structured/
+    ...) from that invariant — for a read-only dispatch an unchanged worktree IS
+    the intended outcome (the report is the deliverable; the dispatch forbids
+    commits). Fail-safe direction: an empty or unknown ``task_class`` keeps the
+    guard armed exactly as before; only a recognized read-only class suppresses
+    it.
     """
     try:
         proc.wait(timeout=10)
@@ -1052,9 +1066,18 @@ def _finalize_kimi_result(
 
     empty_extraction = not (completion_text or "").strip()
 
+    _normalized_class = (task_class or "").strip().lower()
+    read_only_class = bool(_normalized_class) and _normalized_class in REVIEW_TASK_CLASSES
+
     worktree_unchanged = False
-    if saw_tool_calls and worktree is not None:
+    if saw_tool_calls and worktree is not None and not read_only_class:
         worktree_unchanged = _worktree_has_changes(worktree) is False
+    elif saw_tool_calls and worktree is not None and read_only_class:
+        logger.info(
+            "kimi_spawn: fabrication guard not applied for read-only task_class=%r "
+            "— an unchanged worktree is the expected outcome for this class",
+            task_class,
+        )
 
     if errors_captured:
         error: Optional[str] = "\n".join(errors_captured)
@@ -1118,6 +1141,7 @@ def spawn_kimi(
     chunk_timeout: float = 1200.0,
     total_deadline: float = 900.0,
     event_store: Optional[Any] = None,
+    task_class: Optional[str] = None,
     **kwargs: Any,
 ) -> KimiSpawnResult:
     """Spawn ``kimi --print --output-format stream-json --yolo -p <prompt>``.
@@ -1147,6 +1171,15 @@ def spawn_kimi(
     both. ``event_store`` is forwarded to drain_stream (writes via drainer);
     ``event_writer`` is called per-event in _consume_kimi_stream. Passing both
     causes every event to be written twice.
+
+    ``task_class`` (OI-1087) is an EXPLICIT keyword — deliberately not silently
+    absorbed by ``**kwargs``: the four review-dispatch false-failures of
+    2026-08-07 happened precisely because this signal never left the adapter.
+    A visible, typed parameter is greppable, typo-safe (a misspelled kwarg in
+    **kwargs vanishes silently), and shows up in the signature for every future
+    caller. Forwarded to _finalize_kimi_result, where a positively-known
+    read-only class exempts the dispatch from the worktree-changed fabrication
+    guard. Unknown/empty keeps the guard armed.
     """
     if event_store is not None and event_writer is not None:
         raise ValueError("Pass either event_store OR event_writer, not both")
@@ -1257,6 +1290,7 @@ def spawn_kimi(
         raw_samples=raw_samples,
         saw_tool_calls=saw_tool_calls,
         worktree=cwd,
+        task_class=task_class,
     )
     if _hb_killed.is_set():
         # The heartbeat already wrote the terminal failure report — replace the

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -736,6 +736,99 @@ def check_state_root_location(paths: Dict[str, str]) -> List[CheckResult]:
 
 
 # ---------------------------------------------------------------------------
+# Dream-cycle health check
+# ---------------------------------------------------------------------------
+
+def _parse_dream_event_ts(value: object) -> Optional[datetime]:
+    """Parse a dream-event timestamp; None on missing/unparseable input."""
+    if not value:
+        return None
+    try:
+        ts = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if ts.tzinfo is None:
+        ts = ts.replace(tzinfo=timezone.utc)
+    return ts
+
+
+def check_dream_cycle(paths: Dict[str, str]) -> List[CheckResult]:
+    """Surface the latest dream-cycle event so a silently-skipping scheduled job
+    becomes visible where the operator actually looks.
+
+    OI-1088: the consolidator skips cleanly (stale ledger, probe not ok,
+    scheduler disabled) and records every skip as an NDJSON event under
+    events/dream/ — but nothing surfaced those events, so a preflight that
+    measured the wrong directory no-opt'd for six weeks before anyone noticed.
+    The event stream already exists; this check is the cheapest possible reader:
+    it reports the most recent dream event and WARNs on any skip that is not the
+    deliberate scheduler_disabled arm-switch.
+    """
+    events_dir = Path(paths["VNX_DATA_DIR"]) / "events" / "dream"
+    if not events_dir.is_dir():
+        return [CheckResult("dream", PASS,
+                            "No dream events recorded (dream scheduler has not run yet)")]
+
+    latest: Optional[dict] = None
+    latest_ts: Optional[datetime] = None
+    fallback: Optional[dict] = None  # last parseable line of the newest file, ts or not
+    for event_file in sorted(events_dir.glob("*.ndjson")):
+        try:
+            lines = event_file.read_text(encoding="utf-8").splitlines()
+        except OSError:
+            continue
+        for line in lines:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            fallback = event
+            ts = _parse_dream_event_ts(event.get("timestamp"))
+            if ts is not None and (latest_ts is None or ts > latest_ts):
+                latest_ts = ts
+                latest = event
+
+    if latest is None:
+        latest = fallback
+    if latest is None:
+        return [CheckResult("dream", PASS,
+                            "No dream events recorded (dream scheduler has not run yet)")]
+
+    event_type = str(latest.get("event_type") or "unknown")
+    reason = str(latest.get("reason") or "")
+    detail = str(latest.get("detail") or "")
+    cycle_id = str(latest.get("cycle_id") or "")
+    age = ""
+    if latest_ts is not None:
+        age_h = (datetime.now(timezone.utc) - latest_ts).total_seconds() / 3600
+        age = f", {age_h:.1f}h ago"
+
+    if event_type == "dream_cycle_skipped":
+        if reason == "scheduler_disabled":
+            return [CheckResult(
+                "dream", PASS,
+                f"Dream scheduler deliberately disabled (VNX_DREAM_SCHEDULER_ENABLED=0{age})",
+            )]
+        return [CheckResult(
+            "dream", WARN,
+            f"Latest dream cycle SKIPPED: {reason} — {detail} (cycle {cycle_id}{age})",
+            "A scheduled job that keeps no-op'ing must not stay invisible. "
+            f"Inspect {events_dir} for the skip history and fix the stated reason.",
+        )]
+    if event_type in ("dream_cycle_timeout", "dream_cycle_failed"):
+        return [CheckResult(
+            "dream", WARN,
+            f"Latest dream cycle {event_type.replace('dream_cycle_', '').upper()}: "
+            f"{detail or latest.get('error') or reason} (cycle {cycle_id}{age})",
+            f"Inspect {events_dir} for details.",
+        )]
+    return [CheckResult("dream", PASS, f"Latest dream event: {event_type} ({cycle_id}{age})")]
+
+
+# ---------------------------------------------------------------------------
 # Runtime checks (delegates to vnx_doctor_runtime.py)
 # ---------------------------------------------------------------------------
 
@@ -796,6 +889,7 @@ def run_doctor(paths: Dict[str, str], *,
     results.extend(check_path_hygiene(paths))
     results.extend(check_contamination(paths))
     results.extend(check_state_root_location(paths))
+    results.extend(check_dream_cycle(paths))
 
     if package_check:
         vnx_home = Path(paths["VNX_HOME"])

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -289,6 +289,22 @@ def test_provider_adapter_kimi_honors_plan_deadline(tmp_path, stubbed_provider_s
     assert stubbed_provider_spawns.calls["kimi"]["kwargs"]["total_deadline"] == 1800.0
 
 
+def test_provider_adapter_kimi_passes_plan_task_class(tmp_path, stubbed_provider_spawns):
+    """OI-1087: the plan's task_class must reach spawn_kimi so the fabrication
+    guard can exempt positively-known read-only classes. The 2026-08-07
+    false-failures happened because this signal died at the adapter — pin the
+    wiring, not just the guard. The stub is bound where the name is USED
+    (provider_spawns.kimi_spawn.spawn_kimi — _run_kimi imports it at call time)
+    and the assert proves the call actually happened."""
+    adapter = ProviderAdapter()
+    plan = _make_provider_plan(tmp_path, provider=Provider.KIMI, model="default")
+    plan = dataclasses.replace(plan, task_class="review")
+    r = adapter.run(plan, "prompt")
+    assert r.status == "success", f"kimi: {r}"
+    assert "kimi" in stubbed_provider_spawns.calls, "spawn_kimi was never called"
+    assert stubbed_provider_spawns.calls["kimi"]["kwargs"]["task_class"] == "review"
+
+
 def test_provider_adapter_routes_gemini(tmp_path, stubbed_provider_spawns):
     """gemini routes to spawn_gemini; no _dispatch_* wrapper invoked."""
     adapter = ProviderAdapter()

--- a/tests/test_dream_consolidator.py
+++ b/tests/test_dream_consolidator.py
@@ -19,6 +19,7 @@ import sqlite3
 import subprocess
 import sys
 import tempfile
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -239,11 +240,24 @@ class TestExtractKimiText:
         assert consolidator._extract_kimi_text(stdout) == ""
 
 
-def _make_fresh_receipts(data_root: Path) -> None:
-    """Create a fresh processed receipt so the GAP-7 preflight passes."""
-    processed = data_root / "receipts" / "processed"
-    processed.mkdir(parents=True, exist_ok=True)
-    (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+def _make_fresh_receipts(data_root: Path, *, age_hours: float = 0) -> None:
+    """Append a receipt line to the t0 ledger so the GAP-7 preflight passes.
+
+    OI-1088: the preflight reads state/t0_receipts.ndjson (the append-only
+    ledger), NOT receipts/processed/ (the delivery lane's staging dir, which no
+    longer receives files). Tests must seed the same source the code reads.
+    """
+    state_dir = data_root / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    ledger = state_dir / "t0_receipts.ndjson"
+    ts = datetime.now(timezone.utc) - timedelta(hours=age_hours)
+    receipt = {
+        "dispatch_id": "test-dispatch",
+        "status": "success",
+        "timestamp": ts.isoformat(),
+    }
+    with ledger.open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(receipt) + "\n")
 
 
 def _seed_pattern(db_path: Path) -> None:
@@ -362,46 +376,90 @@ class TestDryRun:
 
 
 class TestCheckReceiptCompleteness:
-    def test_missing_processed_dir_returns_false(self, tmp_path):
-        """No receipts/processed dir → incomplete."""
+    """OI-1088: the preflight reads the t0 ledger (state/t0_receipts.ndjson),
+    not receipts/processed/. Behavior pinned: absent / empty / fresh / stale.
+    """
+
+    def test_missing_ledger_returns_false(self, tmp_path):
+        """No state/t0_receipts.ndjson → incomplete (source absent)."""
         data_root = tmp_path / ".vnx-data"
         ok, reason = consolidator._check_receipt_completeness(data_root)
         assert not ok
         assert "absent" in reason
 
-    def test_empty_processed_dir_returns_false(self, tmp_path):
-        """Empty receipts/processed dir → incomplete."""
-        (tmp_path / ".vnx-data" / "receipts" / "processed").mkdir(parents=True)
-        ok, reason = consolidator._check_receipt_completeness(tmp_path / ".vnx-data")
+    def test_empty_ledger_returns_false(self, tmp_path):
+        """A zero-byte ledger → incomplete (source empty)."""
+        data_root = tmp_path / ".vnx-data"
+        (data_root / "state").mkdir(parents=True)
+        (data_root / "state" / "t0_receipts.ndjson").write_text("", encoding="utf-8")
+        ok, reason = consolidator._check_receipt_completeness(data_root)
+        assert not ok
+        assert "empty" in reason
+
+    def test_ledger_without_parseable_timestamps_returns_false(self, tmp_path):
+        """Ledger lines that carry no usable timestamp count as empty."""
+        data_root = tmp_path / ".vnx-data"
+        (data_root / "state").mkdir(parents=True)
+        (data_root / "state" / "t0_receipts.ndjson").write_text(
+            '{"dispatch_id": "d1"}\nnot-json-at-all\n{"timestamp": "garbage"}\n',
+            encoding="utf-8",
+        )
+        ok, reason = consolidator._check_receipt_completeness(data_root)
         assert not ok
         assert "empty" in reason
 
     def test_fresh_receipt_returns_true(self, tmp_path):
-        """A recently modified receipt file → complete."""
-        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
-        processed.mkdir(parents=True)
-        (processed / "receipt-001.ndjson").write_text("{}", encoding="utf-8")
-        ok, reason = consolidator._check_receipt_completeness(tmp_path / ".vnx-data")
+        """A recent receipt line in the ledger → complete."""
+        data_root = tmp_path / ".vnx-data"
+        _make_fresh_receipts(data_root)
+        ok, reason = consolidator._check_receipt_completeness(data_root)
         assert ok
         assert reason == "ok"
 
-    def test_stale_receipts_return_false(self, tmp_path):
-        """All receipts older than max_age_hours → incomplete."""
-        import time
-        processed = tmp_path / ".vnx-data" / "receipts" / "processed"
-        processed.mkdir(parents=True)
-        old_file = processed / "receipt-old.ndjson"
-        old_file.write_text("{}", encoding="utf-8")
-        # Set mtime to 200 hours ago
-        old_ts = time.time() - (200 * 3600)
-        import os
-        os.utime(str(old_file), (old_ts, old_ts))
+    def test_fresh_ledger_passes_with_processed_dir_absent(self, tmp_path):
+        """REGRESSION (OI-1088): fresh ledger line must pass even when
+        receipts/processed/ does not exist at all — the exact production
+        situation that skipped every cycle for six weeks while the ledger
+        kept growing."""
+        data_root = tmp_path / ".vnx-data"
+        _make_fresh_receipts(data_root)
+        assert not (data_root / "receipts" / "processed").exists()
+        ok, reason = consolidator._check_receipt_completeness(data_root)
+        assert ok
+        assert reason == "ok"
 
+    def test_fresh_ledger_passes_with_processed_dir_empty(self, tmp_path):
+        """REGRESSION (OI-1088): an EMPTY receipts/processed/ dir must not
+        influence the verdict either — the ledger is the only source."""
+        data_root = tmp_path / ".vnx-data"
+        (data_root / "receipts" / "processed").mkdir(parents=True)
+        _make_fresh_receipts(data_root)
+        ok, reason = consolidator._check_receipt_completeness(data_root)
+        assert ok
+        assert reason == "ok"
+
+    def test_stale_ledger_returns_false(self, tmp_path):
+        """Newest ledger receipt older than max_age_hours → incomplete."""
+        data_root = tmp_path / ".vnx-data"
+        _make_fresh_receipts(data_root, age_hours=200)
         ok, reason = consolidator._check_receipt_completeness(
-            tmp_path / ".vnx-data", max_age_hours=48
+            data_root, max_age_hours=48
         )
         assert not ok
         assert "stale" in reason
+
+    def test_z_suffixed_timestamp_parsed(self, tmp_path):
+        """The ledger writes Z-suffixed UTC timestamps — they must parse."""
+        data_root = tmp_path / ".vnx-data"
+        (data_root / "state").mkdir(parents=True)
+        ts = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+        (data_root / "state" / "t0_receipts.ndjson").write_text(
+            json.dumps({"dispatch_id": "d1", "timestamp": ts}) + "\n",
+            encoding="utf-8",
+        )
+        ok, reason = consolidator._check_receipt_completeness(data_root)
+        assert ok
+        assert reason == "ok"
 
 
 class TestRunDreamCycleReceiptPreflight:
@@ -502,9 +560,7 @@ def _make_db_with_receipts(tmp_path: Path, *, with_patterns: bool = False) -> tu
     conn.close()
 
     data_root = tmp_path / ".vnx-data"
-    processed = data_root / "receipts" / "processed"
-    processed.mkdir(parents=True, exist_ok=True)
-    (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+    _make_fresh_receipts(data_root)
     return db_path, data_root
 
 

--- a/tests/test_kimi_spawn.py
+++ b/tests/test_kimi_spawn.py
@@ -19,6 +19,7 @@ _LIB_DIR = str(Path(__file__).resolve().parents[1] / "scripts" / "lib")
 if _LIB_DIR not in sys.path:
     sys.path.insert(0, _LIB_DIR)
 
+from phantom_guard import REVIEW_TASK_CLASSES  # noqa: E402
 from provider_spawns.kimi_spawn import (  # noqa: E402
     KimiSpawnResult,
     _build_kimi_cmd,
@@ -508,6 +509,7 @@ class TestSpawnKimiSubprocess(unittest.TestCase):
 
 def _spawn_kimi_with_events(
     events: list, returncode: int = 0, cwd=None, event_writer=None,
+    task_class=None,
 ) -> KimiSpawnResult:
     """Run spawn_kimi with a real-pipe-backed fake process emitting the given events.
 
@@ -540,7 +542,7 @@ def _spawn_kimi_with_events(
             mock_start.return_value = (fake_proc, None)
             result = spawn_kimi(
                 "prompt", dispatch_id="d1", terminal_id="T1", cwd=cwd,
-                event_writer=event_writer,
+                event_writer=event_writer, task_class=task_class,
             )
     finally:
         writer_thread.join(timeout=5)
@@ -1266,6 +1268,133 @@ class TestFabricationInvariant(unittest.TestCase):
         self.assertIsNone(result.error)
         self.assertEqual(result.returncode, 0)
 
+    # ------------------------------------------------------------------
+    # OI-1087: read-only task classes exempt from the fabrication guard
+    # ------------------------------------------------------------------
+
+    def test_read_only_task_class_unchanged_worktree_passes(self) -> None:
+        """OI-1087 regression: a review dispatch whose deliverable IS the report
+        leaves the worktree unchanged BY DESIGN — that must not read as
+        fabrication. Four review dispatches false-failed on 2026-08-07 because
+        the guard did not know the read-only class."""
+        with patch("provider_spawns.kimi_spawn._worktree_has_changes") as mock_check:
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="## Review report\n\nFindings: ...",
+                events_written=5,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path("/tmp/fake-worktree"),
+                task_class="review",
+            )
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+        # The git probe is not even consulted for a known read-only class.
+        mock_check.assert_not_called()
+
+    def test_every_known_read_only_class_suppresses_guard(self) -> None:
+        """The exemption keys off phantom_guard.REVIEW_TASK_CLASSES (SSOT) —
+        every member of that list must suppress the guard, so the two guards
+        cannot drift apart."""
+        for read_only_class in sorted(REVIEW_TASK_CLASSES):
+            with self.subTest(task_class=read_only_class):
+                with patch(
+                    "provider_spawns.kimi_spawn._worktree_has_changes", return_value=False
+                ):
+                    result = _finalize_kimi_result(
+                        proc=self._mock_proc(0),
+                        completion_text="Analysis complete.",
+                        events_written=3,
+                        token_usage=None,
+                        timed_out=False,
+                        stopped_early=False,
+                        event_writer_failures=0,
+                        errors_captured=[],
+                        saw_stream_output=True,
+                        raw_samples=[],
+                        saw_tool_calls=True,
+                        worktree=Path("/tmp/fake-worktree"),
+                        task_class=read_only_class,
+                    )
+                self.assertIsNone(result.error)
+                self.assertEqual(result.returncode, 0)
+
+    def test_writing_task_class_unchanged_worktree_still_fails(self) -> None:
+        """A class whose behavior is to MODIFY the worktree keeps the guard:
+        unchanged worktree + tool calls = fabrication, exactly as before."""
+        with patch("provider_spawns.kimi_spawn._worktree_has_changes", return_value=False):
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="I fixed the bug and wrote the file.",
+                events_written=3,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path("/tmp/fake-worktree"),
+                task_class="implementation",
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_unknown_task_class_unchanged_worktree_still_fails(self) -> None:
+        """Fail-safe direction: an UNRECOGNIZED task_class must be treated as
+        writing — the guard exists to catch fabrication, so doubt never
+        disables it."""
+        with patch("provider_spawns.kimi_spawn._worktree_has_changes", return_value=False):
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="I fixed the bug and wrote the file.",
+                events_written=3,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path("/tmp/fake-worktree"),
+                task_class="never-heard-of-this-class",
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
+
+    def test_empty_task_class_unchanged_worktree_still_fails(self) -> None:
+        """Fail-safe direction: an empty task_class string behaves like a
+        missing one — the guard stays armed."""
+        with patch("provider_spawns.kimi_spawn._worktree_has_changes", return_value=False):
+            result = _finalize_kimi_result(
+                proc=self._mock_proc(0),
+                completion_text="I fixed the bug and wrote the file.",
+                events_written=3,
+                token_usage=None,
+                timed_out=False,
+                stopped_early=False,
+                event_writer_failures=0,
+                errors_captured=[],
+                saw_stream_output=True,
+                raw_samples=[],
+                saw_tool_calls=True,
+                worktree=Path("/tmp/fake-worktree"),
+                task_class="",
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
+
     def test_no_tool_calls_skips_check_even_with_known_worktree(self) -> None:
         """A pure-text response (no tool_calls) never triggers the git check —
         it only guards the specific completion-without-execution pattern."""
@@ -1328,6 +1457,30 @@ class TestKimiFabricationInvariantEndToEnd(unittest.TestCase):
         result = _spawn_kimi_with_events(self._TOOL_CALL_EVENTS, cwd=None)
         self.assertIsNone(result.error)
         self.assertEqual(result.returncode, 0)
+
+    def test_read_only_task_class_threaded_end_to_end(self) -> None:
+        """OI-1087: task_class must survive the full spawn_kimi() ->
+        _consume_kimi_stream() -> _finalize_kimi_result() wiring — a review
+        dispatch with tool calls and an unchanged REAL git worktree passes."""
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
+            result = _spawn_kimi_with_events(
+                self._TOOL_CALL_EVENTS, cwd=tmp, task_class="review",
+            )
+        self.assertIsNone(result.error)
+        self.assertEqual(result.returncode, 0)
+
+    def test_writing_task_class_threaded_end_to_end_still_fails(self) -> None:
+        """OI-1087 other leg: a writing class through the same wiring with an
+        unchanged REAL git worktree still trips the fabrication guard."""
+        with tempfile.TemporaryDirectory() as tmp:
+            subprocess.run(["git", "init", "-q"], cwd=tmp, check=True)
+            result = _spawn_kimi_with_events(
+                self._TOOL_CALL_EVENTS, cwd=tmp, task_class="implementation",
+            )
+        self.assertIsNotNone(result.error)
+        self.assertIn("fabrication", result.error.lower())
+        self.assertNotEqual(result.returncode, 0)
 
 
 class TestSpawnKimiChunkStallFloor(unittest.TestCase):

--- a/tests/test_selflearn_path_unification.py
+++ b/tests/test_selflearn_path_unification.py
@@ -103,9 +103,23 @@ def _make_db(path: Path, *, n_patterns: int = 0) -> Path:
 
 
 def _make_fresh_receipts(data_root: Path) -> None:
-    processed = data_root / "receipts" / "processed"
-    processed.mkdir(parents=True, exist_ok=True)
-    (processed / "receipt-fresh.ndjson").write_text("{}", encoding="utf-8")
+    """Append a fresh receipt line to the t0 ledger.
+
+    OI-1088: the dream preflight reads state/t0_receipts.ndjson (the ledger),
+    not receipts/processed/ (the delivery lane's staging dir). Seed the same
+    source the code reads.
+    """
+    from datetime import datetime, timezone
+
+    state_dir = data_root / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    receipt = {
+        "dispatch_id": "test-dispatch",
+        "status": "success",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    with (state_dir / "t0_receipts.ndjson").open("a", encoding="utf-8") as fh:
+        fh.write(json.dumps(receipt) + "\n")
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +245,17 @@ class TestWriterReaderCanonicalPathAgreement:
 
 class TestDreamCycleConsolidatesSeededPatterns:
     """Seed N>=threshold patterns in the canonical db, run dream cycle → consolidates."""
+
+    @pytest.fixture(autouse=True)
+    def _dream_activation_gate_open(self, monkeypatch):
+        """PR-17 added an activation gate that defaults closed; these tests exercise
+        consolidation mechanics, so arm the scheduler and stub the probe to 'ok' —
+        the same posture as test_dream_consolidator.py's autouse fixture."""
+        monkeypatch.setenv("VNX_DREAM_SCHEDULER_ENABLED", "1")
+        import consolidator
+        monkeypatch.setattr(
+            consolidator, "_injection_probe_health", lambda state_dir: "ok"
+        )
 
     def test_seeded_patterns_cause_consolidation_not_skip(self, tmp_path):
         """N>=1 success_patterns in db → dream cycle status is NOT skipped."""

--- a/tests/test_vnx_doctor.py
+++ b/tests/test_vnx_doctor.py
@@ -31,6 +31,7 @@ from vnx_doctor import (
     check_write_access,
     check_worktree,
     check_path_resolution,
+    check_dream_cycle,
     run_doctor,
 )
 
@@ -293,6 +294,113 @@ class TestPathResolution:
         intel = [r for r in results if "Intelligence dir" in r.message]
         assert intel, "Intelligence dir check missing"
         assert ".vnx-intelligence" in intel[0].message
+
+
+# ---------------------------------------------------------------------------
+# Dream-cycle health check (OI-1088)
+# ---------------------------------------------------------------------------
+
+def _write_dream_events(vnx_env, events, filename="2026-08-08.ndjson"):
+    """Write dream events as NDJSON lines under <data>/events/dream/."""
+    events_dir = Path(vnx_env["VNX_DATA_DIR"]) / "events" / "dream"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    with (events_dir / filename).open("a", encoding="utf-8") as fh:
+        for event in events:
+            fh.write(json.dumps(event) + "\n")
+    return events_dir
+
+
+class TestDreamCycleCheck:
+    """OI-1088: a dream cycle that keeps skipping must surface in `vnx doctor`
+    with its reason — the six-week silent no-op must not be repeatable."""
+
+    def test_no_events_dir_passes(self, vnx_env):
+        results = check_dream_cycle(vnx_env)
+        assert len(results) == 1
+        assert results[0].status == PASS
+
+    def test_latest_skip_warns_with_reason(self, vnx_env):
+        """The exact production failure shape: preflight keeps skipping on
+        'incomplete_data' — doctor must WARN and carry the reason + detail."""
+        _write_dream_events(vnx_env, [{
+            "event_type": "dream_cycle_skipped",
+            "cycle_id": "dream-20260808-010005-x",
+            "project_id": "vnx-dev",
+            "reason": "incomplete_data",
+            "detail": "all receipts stale (newest 400.0h ago, threshold 48h)",
+            "timestamp": "2026-08-08T01:00:05+00:00",
+        }])
+        results = check_dream_cycle(vnx_env)
+        assert len(results) == 1
+        assert results[0].status == WARN
+        assert "incomplete_data" in results[0].message
+        assert "stale" in results[0].message
+
+    def test_scheduler_disabled_skip_passes(self, vnx_env):
+        """scheduler_disabled is the deliberate arm-switch state — not a WARN."""
+        _write_dream_events(vnx_env, [{
+            "event_type": "dream_cycle_skipped",
+            "cycle_id": "dream-x",
+            "reason": "scheduler_disabled",
+            "detail": "VNX_DREAM_SCHEDULER_ENABLED=0",
+            "timestamp": "2026-08-08T01:00:05+00:00",
+        }])
+        results = check_dream_cycle(vnx_env)
+        assert results[0].status == PASS
+        assert "disabled" in results[0].message
+
+    def test_completed_cycle_passes(self, vnx_env):
+        _write_dream_events(vnx_env, [{
+            "event_type": "dream_cycle_completed",
+            "cycle_id": "dream-ok",
+            "timestamp": "2026-08-08T01:00:05+00:00",
+        }])
+        results = check_dream_cycle(vnx_env)
+        assert results[0].status == PASS
+        assert "dream_cycle_completed" in results[0].message
+
+    def test_latest_event_wins_by_timestamp(self, vnx_env):
+        """An older completed cycle followed by a newer skip must WARN — the
+        verdict tracks the LATEST event, not the nicest one."""
+        _write_dream_events(vnx_env, [
+            {
+                "event_type": "dream_cycle_completed",
+                "cycle_id": "dream-old",
+                "timestamp": "2026-08-07T01:00:05+00:00",
+            },
+            {
+                "event_type": "dream_cycle_skipped",
+                "cycle_id": "dream-new",
+                "reason": "probe_not_ok",
+                "detail": "injection-effectiveness probe health=produces_crap",
+                "timestamp": "2026-08-08T01:00:05+00:00",
+            },
+        ])
+        results = check_dream_cycle(vnx_env)
+        assert results[0].status == WARN
+        assert "probe_not_ok" in results[0].message
+
+    def test_timeout_event_warns(self, vnx_env):
+        _write_dream_events(vnx_env, [{
+            "event_type": "dream_cycle_timeout",
+            "cycle_id": "dream-slow",
+            "timeout_seconds": 180,
+            "timestamp": "2026-08-08T01:00:05+00:00",
+        }])
+        results = check_dream_cycle(vnx_env)
+        assert results[0].status == WARN
+
+    def test_malformed_lines_do_not_crash(self, vnx_env):
+        """Negative path: torn NDJSON lines are skipped, valid ones still read."""
+        events_dir = _write_dream_events(vnx_env, [{
+            "event_type": "dream_cycle_completed",
+            "cycle_id": "dream-ok",
+            "timestamp": "2026-08-08T01:00:05+00:00",
+        }])
+        with (events_dir / "2026-08-08.ndjson").open("a", encoding="utf-8") as fh:
+            fh.write("not-json\n{broken\n")
+        results = check_dream_cycle(vnx_env)
+        assert results[0].status == PASS
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## OI-1087 — fabrication guard kent nu read-only dispatches

Vier review-dispatches leverden op 2026-08-07 volledige, geverifieerde rapporten en staan in het grootboek als `status=failure`, `verdict=reject`: de kimi fabrication guard las "onveranderde werkmap" als fabricage, terwijl nul git-wijzigingen de *bedoelde* uitkomst was (het rapport IS de levering).

**Fix:**
- `task_class` stroomt nu expliciet van `ExecutionPlan` → `ProviderAdapter._run_kimi` → `spawn_kimi` → `_finalize_kimi_result`. Bewust een **expliciete keyword-parameter** gekozen boven stille `**kwargs`-absorptie: dit signaal is al één keer onzichtbaar verdwenen; een getypeerde parameter is greppable, typo-veilig en zichtbaar in de signatuur.
- De `worktree_unchanged`-tak vuurt alleen nog voor klassen die de werkmap behoren te wijzigen. De read-only lijst is **één plek**: `phantom_guard.REVIEW_TASK_CLASSES` (bestaande SSOT — `review`, `analysis`, `code_review`, `02_code_review`, `research_structured`), zodat fabrication guard en phantom guard nooit uit elkaar lopen.
- **Veilige richting bij onbekend**: lege of onbekende `task_class` houdt de poort volledig armed (bestaande tests voor dat pad ongewijzigd groen).
- Zelfde fix op de legacy `_dispatch_kimi`-laag (`--task-class` / `VNX_TASK_CLASS`) — geen asymmetrische handlers.

## OI-1088 — DREAM-preflight meet het grootboek, niet de bezorgmap

`_check_receipt_completeness` keek naar `receipts/processed/` — dood sinds 2026-07-23 — terwijl `state/t0_receipts.ndjson` gewoon doorliep. Gevolg: elke cyclus no-optte wekenlang onzichtbaar.

**Fix:**
- De preflight leest nu `state/t0_receipts.ndjson` onder de geresolvde data-root (bestaande `_resolve_data_root`/vnx_paths-keten, niets hardcoded). Betekenis ongewijzigd: "receipts van de laatste 48 uur"; drempel ongemoeid. Drie onderscheiden faaltoestanden behouden: bron afwezig / bron leeg / bron verouderd, elk met eigen reden-string.
- **Overslaan is zichtbaar**: `vnx doctor` krijgt `check_dream_cycle` — leest de bestaande `events/dream/*.ndjson`-stroom (geen nieuw meldkanaal) en WARNt op elke niet-opzettelijke skip met reden, detail en leeftijd. `scheduler_disabled` (de bewuste arm-switch) blijft PASS.

**Meting tegen de echte data-roots (2026-08-08 ~10:45):**

| project | preflight na fix |
|---|---|
| vnx-dev | ✅ ok (was: stil geskipt sinds 23 juli) |
| mission-control | ✅ ok (schreef vanmorgen 10:27 nog een receipt; DREAM skipte 6 weken) |
| seocrawler-v2 | ✅ ok |
| sales-copilot | ✅ correct **stale** (65h > 48h) — de check verliest zijn betekenis niet |

Live `vnx doctor`-output toont nu: `WARN | Latest dream cycle SKIPPED: probe_not_ok — injection-effectiveness probe health=produces_crap (…, 7.9h ago)` — een reële, tot nu toe onzichtbare operationele toestand.

## Tests

- `tests/test_kimi_spawn.py` — 104 passed (incl. 7 nieuwe: read-only onderdrukt / schrijvend vuurt / onbekend vuurt / leeg vuurt / end-to-end threading)
- `tests/test_dream_consolidator.py` — 49 passed (preflight-tests herschreven naar het grootboek; regressietest: vers grootboek + afwezige/lege `receipts/processed/` → ok)
- `tests/test_vnx_doctor.py` — 35 passed (7 nieuwe `check_dream_cycle`-tests)
- `tests/test_dispatch_envelope_plan.py` — 18 passed (nieuwe adapter-doorgave-test: mock gebonden op de gebruiksplek, assert op daadwerkelijke call)
- `tests/test_selflearn_path_unification.py` — 22 passed (helper gemigreerd naar het grootboek + PR-17-gate gearmd; 5 pre-existing reds nu groen)
- Buren (dream_cli, scheduler_plist, memory_consolidator, provider_dispatch_kimi, phantom_guard ×2, doctor ×5, envelope_field_propagation): 206 passed

Geen bestaande receipts aangepast; het grootboek is ongemoeid (append-only, correctie leeft in OI-1087 zelf).

Dispatch-ID: 20260808-020000-guards-judge-the-thing
