### PR TITLE
fix(parser): model/provider op report-receipts + dead-letter tegen receipt-lus (OI-1086, OI-1085)

### DIFF
--- a/scripts/lib/receipt_processor/rp_append.sh
+++ b/scripts/lib/receipt_processor/rp_append.sh
@@ -3,8 +3,9 @@
 # Sourced by scripts/receipt_processor.sh
 # Requires: log() and log_structured_failure() from rp_logging.sh,
 #           _track_pattern_usage() / _track_pattern_success_fallback() from rp_pattern.sh,
+#           record_rejection_and_maybe_deadletter() from rp_deadletter.sh,
 #           extract_timestamp() from rp_time.sh, _sha256() from main,
-#           $APPEND_RECEIPT_SCRIPT, $PROCESSING_LOG, $SCRIPTS_DIR,
+#           $APPEND_RECEIPT_SCRIPT, $PROCESSING_LOG, $SCRIPTS_DIR, $STATE_DIR,
 #           $PROCESSED_HASHES, $LAST_PROCESSED
 
 # Section B: Append receipt, track patterns, mark processed, extract OIs.
@@ -14,15 +15,29 @@ append_and_track_receipt() {
     local report_name="$2"
     local receipt_json="$3"
 
+    # OI-1085/1086: capture append_receipt.py stderr separately so the
+    # structured error code it emits ({"code":"missing_model", ...}) can be
+    # extracted for dead-letter accounting; the stderr content itself is
+    # still mirrored into the processing log exactly as before.
+    local append_err_file="$STATE_DIR/.append_stderr.$$"
     local append_output
-    append_output=$(printf '%s\n' "$receipt_json" | python3 "$APPEND_RECEIPT_SCRIPT" 2>>"$PROCESSING_LOG")
+    append_output=$(printf '%s\n' "$receipt_json" | python3 "$APPEND_RECEIPT_SCRIPT" 2>"$append_err_file")
     local append_rc=$?
 
     if [ $append_rc -ne 0 ]; then
-        log_structured_failure "receipt_append_failed" "append_receipt.py rejected receipt" "report=$report_name"
+        cat "$append_err_file" >> "$PROCESSING_LOG" 2>/dev/null || :
+        local rejection_code
+        rejection_code=$(jq -R 'fromjson? | .code // empty' "$append_err_file" 2>/dev/null | tail -1)
+        rm -f "$append_err_file"
+        # A deterministic validation refusal (e.g. missing_model) can never
+        # succeed on retry — count it and quarantine after N identical
+        # refusals instead of looping forever (OI-1085/1086).
+        record_rejection_and_maybe_deadletter "$report_path" "$report_name" "$rejection_code"
+        log_structured_failure "receipt_append_failed" "append_receipt.py rejected receipt" "report=$report_name code=${rejection_code:-unknown}"
         log "ERROR" "Failed to append receipt via append_receipt.py: $report_name"
         return 1
     fi
+    rm -f "$append_err_file"
 
     # Check if append_receipt.py flagged this as duplicate
     if echo "$append_output" | grep -q '"status"[[:space:]]*:[[:space:]]*"duplicate"'; then

--- a/scripts/lib/receipt_processor/rp_deadletter.sh
+++ b/scripts/lib/receipt_processor/rp_deadletter.sh
@@ -1,0 +1,109 @@
+# shellcheck shell=bash
+# rp_deadletter.sh - Deterministic-rejection tracking + dead-letter quarantine
+# Sourced by scripts/receipt_processor.sh (after rp_logging.sh / rp_dedup.sh).
+# Requires: log() and log_structured_failure() from rp_logging.sh,
+#           _sha256() from main, $STATE_DIR, $PROCESSED_HASHES
+#
+# OI-1085 / OI-1086: a report that append_receipt.py refuses on a
+# deterministic validation code (e.g. missing_model) can never succeed on
+# retry — the file content does not change between poll cycles. Retrying it
+# every cycle is exactly what produced the 2026-08-03..07 incident: 109
+# reports refused eleven times per 50k log lines for four days straight,
+# 386 CPU-minutes and 4.3 GB of log, ending in ENOSPC. This module counts
+# per-(report-hash, code) refusals and, after DEADLETTER_THRESHOLD identical
+# refusals, moves the report out of the scanned directory into
+# $DEADLETTER_DIR and records its hash as processed, so neither the Bash
+# lane nor the Python converter lane ever retries it.
+
+# Why N=3: validation verdicts are deterministic on content, so the SECOND
+# identical refusal already proves permanence. One extra attempt absorbs the
+# one transient look-alike — a report still being written while the first
+# append attempt runs can surface as invalid_json/empty_input and self-heal
+# on the next cycle. N=3 quarantines within ~15s at the default 5s poll
+# interval while tolerating that single mid-write race. Override via
+# VNX_RECEIPT_DEADLETTER_THRESHOLD.
+DEADLETTER_THRESHOLD="${VNX_RECEIPT_DEADLETTER_THRESHOLD:-3}"
+DEADLETTER_DIR="${VNX_RECEIPT_DEADLETTER_DIR:-$STATE_DIR/receipt_deadletter}"
+REJECTIONS_FILE="${VNX_RECEIPT_REJECTIONS_FILE:-$STATE_DIR/receipt_rejections.txt}"
+
+# Validation codes whose verdict is a pure function of the report bytes:
+# retrying the same content can never produce a different outcome. Anything
+# else (I/O failure, crash, unexpected_error, internal_null_result) is
+# treated as transient and is NOT counted — those keep the legacy
+# retry-next-cycle behaviour so a real transient fault is never quarantined.
+_is_deterministic_rejection_code() {
+    case "$1" in
+        missing_model|missing_required_key|invalid_json|invalid_receipt_type|empty_input)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+# Record one deterministic refusal of $report_path with $code.
+# Returns 0 when the report was dead-lettered by this call, 1 otherwise
+# (transient code, below threshold, or a failed quarantine move).
+record_rejection_and_maybe_deadletter() {
+    local report_path="$1"
+    local report_name="$2"
+    local code="${3:-}"
+
+    _is_deterministic_rejection_code "$code" || return 1
+
+    local report_hash
+    report_hash=$(_sha256 "$report_path")
+    if [ -z "$report_hash" ]; then
+        log "WARN" "Dead-letter: cannot hash $report_name — refusal not counted"
+        return 1
+    fi
+
+    # Current count for (hash, code); default 0. Keyed on content hash so an
+    # edited report starts a fresh count instead of inheriting a stale one.
+    local count
+    count=$(awk -v h="$report_hash" -v c="$code" '$1==h && $2==c {n=$3} END {print n+0}' "$REJECTIONS_FILE" 2>/dev/null)
+    count=$(( ${count:-0} + 1 ))
+
+    # Persist the incremented count atomically (tmp + mv, matching the
+    # watermark-write pattern in receipt_processor.sh). A failed persist
+    # must be loud: silently losing the count is exactly how the OI-1085
+    # infinite retry loop stays possible.
+    local tmp_rejections="${REJECTIONS_FILE}.tmp.$$"
+    if ! {
+        [ -f "$REJECTIONS_FILE" ] && grep -v -F "$report_hash $code " "$REJECTIONS_FILE" 2>/dev/null
+        printf '%s %s %s\n' "$report_hash" "$code" "$count"
+    } > "$tmp_rejections" || ! mv "$tmp_rejections" "$REJECTIONS_FILE" 2>/dev/null; then
+        rm -f "$tmp_rejections"
+        log "ERROR" "Dead-letter: cannot persist rejection count to $REJECTIONS_FILE — refusal NOT counted"
+        return 1
+    fi
+
+    if [ "$count" -lt "$DEADLETTER_THRESHOLD" ]; then
+        log "WARN" "Deterministic rejection ${count}/${DEADLETTER_THRESHOLD} for $report_name (code=$code) — dead-letter at ${DEADLETTER_THRESHOLD}"
+        return 1
+    fi
+
+    # Threshold reached: quarantine so no lane retries this report again.
+    if ! mkdir -p "$DEADLETTER_DIR" 2>/dev/null; then
+        log "ERROR" "Dead-letter: cannot create $DEADLETTER_DIR — $report_name NOT quarantined"
+        return 1
+    fi
+    local target="$DEADLETTER_DIR/$report_name"
+    if [ -e "$target" ]; then
+        target="$DEADLETTER_DIR/${report_name%.md}.${report_hash:0:8}.md"
+    fi
+    if mv "$report_path" "$target" 2>/dev/null; then
+        # Belt-and-braces: record the hash as processed so even a restored
+        # copy is skipped by should_process_report's hash check.
+        if ! grep -q "^${report_hash}$" "$PROCESSED_HASHES" 2>/dev/null; then
+            echo "$report_hash" >> "$PROCESSED_HASHES"
+        fi
+        printf '%s %s %s %s\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)" "$report_hash" "$code" "$report_name" >> "$DEADLETTER_DIR/INDEX.txt"
+        log_structured_failure "receipt_deadlettered" "Report quarantined after $count identical rejections" "report=$report_name code=$code target=$target"
+        log "ERROR" "DEAD-LETTERED: $report_name (code=$code, $count identical rejections) -> $target"
+        return 0
+    fi
+    log "ERROR" "Dead-letter: failed to move $report_name to $DEADLETTER_DIR (non-fatal; retried next cycle)"
+    return 1
+}

--- a/scripts/lib/receipt_processor/rp_dedup.sh
+++ b/scripts/lib/receipt_processor/rp_dedup.sh
@@ -5,6 +5,27 @@
 #           _sha256() from main, $PROCESSED_HASHES, $RECEIPT_FILE, $FLOOD_LOCKFILE,
 #           $FLOOD_LOCK_MAX_AGE, $FLOOD_THRESHOLD, get_pane_id_smart() from pane_manager
 
+# OI-1085: log-volume damping for the historical-report rescan. Every poll
+# cycle re-scans the whole reports directory, and before this damping each
+# too-old report emitted one DEBUG line PER CYCLE — measured at 93% of the
+# 4.3 GB receipt_processing.log that filled the disk on 2026-08-07. The
+# information is preserved, the repetition is not: the first skip per report
+# per process is logged with its age, later skips only bump a counter, and
+# log_too_old_cycle_summary() emits one aggregate line per scan cycle.
+# (Space-delimited memo instead of an associative array: macOS /bin/bash is
+# 3.2 and has no `declare -A`. Dispatch-generated report names never contain
+# spaces.)
+_SPR_TOO_OLD_LOGGED=" "
+_SPR_TOO_OLD_CYCLE_COUNT=0
+
+# Emit the per-cycle aggregate of suppressed too-old skips (one line per
+# scan cycle instead of one line per historical report per cycle).
+log_too_old_cycle_summary() {
+    [ "${_SPR_TOO_OLD_CYCLE_COUNT:-0}" -gt 0 ] || return 0
+    log "DEBUG" "Skipped ${_SPR_TOO_OLD_CYCLE_COUNT} too-old report(s) this cycle (per-report lines suppressed after first occurrence)"
+    _SPR_TOO_OLD_CYCLE_COUNT=0
+}
+
 # Check if report should be processed
 should_process_report() {
     local report_file="$1"
@@ -26,7 +47,15 @@ should_process_report() {
 
     if [ "$file_mtime" -lt "$cutoff_seconds" ]; then
         local age_minutes=$(( ($(date +%s) - file_mtime) / 60 ))
-        log "DEBUG" "Report too old: $report_name (age: ${age_minutes}m)"
+        case "$_SPR_TOO_OLD_LOGGED" in
+            *" $report_name "*)
+                _SPR_TOO_OLD_CYCLE_COUNT=$(( _SPR_TOO_OLD_CYCLE_COUNT + 1 ))
+                ;;
+            *)
+                _SPR_TOO_OLD_LOGGED="${_SPR_TOO_OLD_LOGGED}${report_name} "
+                log "DEBUG" "Report too old: $report_name (age: ${age_minutes}m) — first skip, further per-cycle repeats suppressed"
+                ;;
+        esac
         return 1
     fi
 

--- a/scripts/receipt_processor.sh
+++ b/scripts/receipt_processor.sh
@@ -111,6 +111,9 @@ source "$RP_LIB/rp_time.sh"
 # shellcheck source=lib/receipt_processor/rp_dedup.sh
 source "$RP_LIB/rp_dedup.sh"
 # shellcheck source-path=SCRIPTDIR
+# shellcheck source=lib/receipt_processor/rp_deadletter.sh
+source "$RP_LIB/rp_deadletter.sh"
+# shellcheck source-path=SCRIPTDIR
 # shellcheck source=lib/receipt_processor/rp_lock.sh
 source "$RP_LIB/rp_lock.sh"
 # shellcheck source-path=SCRIPTDIR
@@ -329,6 +332,7 @@ _ppr_collect_pending() {
             ((_PPR_QUEUE_COUNT++))
         fi
     done
+    log_too_old_cycle_summary
 }
 
 # Process reports (passed as "$@") with rate limiting and watermark update.
@@ -402,6 +406,7 @@ _poll_new_reports() {
                 fi
             fi
         done
+        log_too_old_cycle_summary
         # Update watermark once after the full sweep with the maximum mtime seen.
         if [ "$_poll_max_mtime" -gt 0 ]; then
             echo "$_poll_max_mtime" > "$WATERMARK_FILE"
@@ -440,6 +445,7 @@ _mnr_startup_catchup() {
             process_single_report "$report" && ((catchup_count++))
         fi
     done
+    log_too_old_cycle_summary
     [ "$catchup_count" -gt 0 ] && log "INFO" "Startup catchup complete: $catchup_count reports processed"
 }
 
@@ -543,6 +549,7 @@ cleanup() {
     release_receipt_lock  # Ensure lock is released
     rm -f "$PID_FILE"
     rm -f "$FLOOD_LOCKFILE"  # Clear flood lock on clean shutdown
+    rm -f "$STATE_DIR/.append_stderr.$$"  # Leftover append-stderr capture (rp_append.sh)
     # Clean up singleton lock (and legacy fswatch FIFO if it exists)
     rm -f "$STATE_DIR/.fswatch_fifo.$$"
     rm -rf "$VNX_LOCKS_DIR/receipt_processor.sh.lock"

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -161,11 +161,70 @@ class ReportParser:
             first_line = text.splitlines()[0].strip()
             return first_line if first_line else default
 
+        # OI-1086: parse `---` YAML frontmatter FIRST (dispatch-envelope
+        # reports stamp provider/model/role there — e.g. the headless
+        # plan-gate seats carry `model: kimi-k3` in frontmatter and no
+        # `**Model**:` body field at all). Parsed before the bold-field scan
+        # so an explicit body field always wins over the frontmatter —
+        # measured on the 2026-08-03/04 envelope series, which carries
+        # frontmatter `model: unknown` alongside a real `**Model**: sonnet`
+        # in the body. Unknown-like frontmatter scalars are skipped for the
+        # same reason: a placeholder must never shadow a real body value.
+        # Only top-level scalars are read; nested blocks (route_decision,
+        # token_usage) are not receipt metadata.
+        _UNKNOWN_LIKE = {'unknown', 'none', 'null', 'n/a', 'na', 'unset', '-'}
+        fm_match = re.match(r'^---\s*\n(.*?)\n---\s*\n', content, re.DOTALL)
+        if fm_match:
+            for line in fm_match.group(1).split('\n'):
+                if ':' not in line or line[0] in (' ', '\t', '#'):
+                    continue
+                key, value = line.split(':', 1)
+                key = _normalize_meta_key(key)
+                value = value.strip()
+                if not key or not value:
+                    continue
+                if value.lower() in _UNKNOWN_LIKE:
+                    continue
+                metadata[key] = value
+
         # Extract all metadata fields
         for match in self.metadata_pattern.finditer(content[:2000]):  # Check first 2000 chars
             key = _normalize_meta_key(match.group(1))
             value = match.group(2).strip()
             metadata[key] = value
+
+        # OI-1086 fallback: reports that embed their full dispatch
+        # instruction (the "# Dispatch <id> / ## Instruction" convention)
+        # carry the door-stamped **Model**/**Provider** block MID-FILE,
+        # outside the 2000-char header window above — measured on the
+        # 2026-08-04 m-series (e.g. 20260804-m00-oi917.md, block at line
+        # 196/282). First match wins and only fills keys the header scan did
+        # not already provide, so a prose mention later in the body can
+        # never override a real header value, and a header value always
+        # beats an embedded-instruction copy.
+        for _key, _pat in (
+            ('model', r'\*\*Model\*\*:\s*(.+)'),
+            ('provider', r'\*\*Provider\*\*:\s*(.+)'),
+        ):
+            if not str(metadata.get(_key) or '').strip():
+                m = re.search(_pat, content)
+                if m:
+                    metadata[_key] = m.group(1).strip()
+
+        # Plain-text header fallback (same convention as the Dispatch-ID
+        # plain-text fallback below): reports like the 2026-08-04 triage/m-
+        # series stamp a bare `Model: X` / `Provider: Y` block at the top.
+        # Case-sensitive on purpose: lowercase `model:` is the frontmatter
+        # form handled above, and anchoring to the header window keeps prose
+        # mentions out. Only fills keys still absent.
+        for _key, _pat in (
+            ('model', r'^\s*Model:\s*(\S+)\s*$'),
+            ('provider', r'^\s*Provider:\s*(\S+)\s*$'),
+        ):
+            if not str(metadata.get(_key) or '').strip():
+                m = re.search(_pat, content[:3000], re.MULTILINE)
+                if m and m.group(1).strip().lower() not in _UNKNOWN_LIKE:
+                    metadata[_key] = m.group(1).strip()
 
         # PR #8 Fix: Extract YAML metadata block including dispatch_id
         yaml_match = re.search(r'```yaml\n(.*?)\n```', content[:2000], re.DOTALL)
@@ -525,6 +584,27 @@ class ReportParser:
             'report_file': Path(report_path).name,  # Add filename for easier tracking
             'title': metadata.get('title', 'No title')
         }
+
+        # OI-1086: lift model/provider from extracted metadata onto the receipt.
+        # extract_metadata() already captures the `**Model**:`/`**Provider**:`
+        # bold fields, but the hand-picked key list above used to drop them —
+        # which made every report-derived receipt (receipt_kind='dispatch',
+        # no exempt source) fail append_receipt's fail-closed missing_model
+        # check (#1338) and put the receipt processor into a permanent
+        # reject-retry loop.
+        #
+        # Missing-field contract: when the report carries no model/provider,
+        # the keys are OMITTED from the receipt — never written as '' or
+        # 'unknown'. For the fail-closed validator an absent key, an empty
+        # string and 'unknown' are equivalent (all refused); omitting is the
+        # honest form because it does not imply a known-but-empty value, and
+        # it keeps the refusal reason ("carries no real model") accurate.
+        _model = str(metadata.get('model') or '').strip()
+        if _model:
+            receipt['model'] = _model
+        _provider = str(metadata.get('provider') or '').strip()
+        if _provider:
+            receipt['provider'] = _provider
 
         if any(extracted['recommendations'].values()):
             receipt['recommendations'] = extracted['recommendations']

--- a/tests/test_receipt_processor_deadletter.py
+++ b/tests/test_receipt_processor_deadletter.py
@@ -1,0 +1,219 @@
+"""Tests for OI-1085/OI-1086: receipt-processor dead-letter + log damping.
+
+Exercises the REAL receipt_processor.sh functions by sourcing the production
+script in _RP_LIB_MODE=1 against a fully sandboxed state dir — no
+reimplemented logic. Covers:
+
+- A report refused N times on the same deterministic code (missing_model) is
+  moved to the dead-letter directory and never retried again.
+- Refusals below the threshold leave the report in place (the mid-write race
+  a transient invalid_json can self-heal from).
+- Transient codes (unexpected_error) are never counted toward dead-letter.
+- A restored copy of a dead-lettered report is skipped via the processed-hash
+  record.
+- The 'Report too old' DEBUG flood is damped: one line per report per
+  process plus one aggregate line per scan cycle, instead of one line per
+  report per cycle (93% of the 4.3 GB log that triggered OI-1085).
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+import time
+from pathlib import Path
+
+RP_SCRIPT = Path(__file__).resolve().parent.parent / "scripts" / "receipt_processor.sh"
+
+ENV_PREAMBLE = """
+set -u
+export _RP_LIB_MODE=1
+export VNX_DATA_DIR="{data_dir}"
+export VNX_STATE_DIR="{state}"
+export VNX_PIDS_DIR="{pids}"
+export VNX_LOCKS_DIR="{locks}"
+export VNX_REPORTS_DIR="{unified}"
+export VNX_HEADLESS_REPORTS_DIR="{headless}"
+source "{rp_script}" || {{ echo "FATAL: source failed" >&2; exit 1; }}
+"""
+
+
+def _make_dirs(tmp: Path) -> dict:
+    # vnx_paths.sh derives VNX_STATE_DIR as $VNX_DATA_DIR/state — both must
+    # agree and exist, so state lives under data/state here.
+    data_dir = tmp / "data"
+    dirs = {
+        "unified": tmp / "unified",
+        "headless": tmp / "headless",
+        "state": data_dir / "state",
+        "pids": tmp / "pids",
+        "locks": tmp / "locks",
+        "data_dir": data_dir,
+    }
+    for d in dirs.values():
+        d.mkdir(parents=True, exist_ok=True)
+    return dirs
+
+
+def _run_bash(dirs: dict, body: str) -> subprocess.CompletedProcess:
+    cmd = ENV_PREAMBLE.format(rp_script=RP_SCRIPT, **dirs) + body
+    return subprocess.run(["bash", "-c", cmd], capture_output=True, text=True)
+
+
+def test_deadletter_after_n_identical_rejections():
+    """3 identical missing_model refusals -> report moved to dead-letter dir,
+    indexed, and its hash recorded as processed. Attempts 1 and 2 leave the
+    report in place."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        report = dirs["unified"] / "20260808-120000-A-broken-report.md"
+        report.write_text("# report with no model anywhere\n")
+
+        body = f"""
+rc1=0; record_rejection_and_maybe_deadletter "{report}" "$(basename "{report}")" missing_model || rc1=$?
+[ -f "{report}" ] && in_place_1=yes || in_place_1=no
+rc2=0; record_rejection_and_maybe_deadletter "{report}" "$(basename "{report}")" missing_model || rc2=$?
+[ -f "{report}" ] && in_place_2=yes || in_place_2=no
+rc3=0; record_rejection_and_maybe_deadletter "{report}" "$(basename "{report}")" missing_model || rc3=$?
+[ -f "{report}" ] && in_place_3=yes || in_place_3=no
+echo "rc=$rc1,$rc2,$rc3 in_place=$in_place_1,$in_place_2,$in_place_3"
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        assert "rc=1,1,0 in_place=yes,yes,no" in result.stdout, result.stdout
+
+        deadletter = dirs["state"] / "receipt_deadletter"
+        moved = deadletter / report.name
+        assert moved.is_file(), f"report not quarantined: {list(deadletter.iterdir()) if deadletter.exists() else 'no dir'}"
+        assert moved.read_text() == "# report with no model anywhere\n"
+
+        index = (deadletter / "INDEX.txt").read_text()
+        assert report.name in index and "missing_model" in index
+
+        processed = (dirs["state"] / "processed_receipts.txt").read_text().splitlines()
+        assert len(processed) == 1, "dead-lettered hash must be recorded as processed exactly once"
+
+        rejections = (dirs["state"] / "receipt_rejections.txt").read_text().strip()
+        assert rejections.endswith(" 3"), f"rejection count must reach threshold: {rejections}"
+
+
+def test_transient_code_is_never_counted():
+    """unexpected_error (crash/IO) is transient: not counted, never dead-lettered."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        report = dirs["unified"] / "20260808-120001-A-flaky.md"
+        report.write_text("# flaky\n")
+
+        body = f"""
+for i in 1 2 3 4 5; do
+  record_rejection_and_maybe_deadletter "{report}" "$(basename "{report}")" unexpected_error || :
+done
+[ -f "{report}" ] && echo "in_place=yes" || echo "in_place=no"
+[ -f "{dirs['state']}/receipt_rejections.txt" ] && echo "rejections_file=yes" || echo "rejections_file=no"
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        assert "in_place=yes" in result.stdout
+        assert "rejections_file=no" in result.stdout
+
+
+def test_distinct_codes_count_independently():
+    """A report refused on two different codes needs N of the SAME code."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        report = dirs["unified"] / "20260808-120002-A-two-codes.md"
+        report.write_text("# two codes\n")
+        name = report.name
+
+        body = f"""
+record_rejection_and_maybe_deadletter "{report}" "{name}" missing_model || :
+record_rejection_and_maybe_deadletter "{report}" "{name}" invalid_json || :
+record_rejection_and_maybe_deadletter "{report}" "{name}" missing_model || :
+[ -f "{report}" ] && echo "in_place=yes" || echo "in_place=no"
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        # 2x missing_model + 1x invalid_json — neither code reached 3.
+        assert "in_place=yes" in result.stdout
+
+
+def test_restored_copy_is_skipped_via_processed_hash():
+    """If a dead-lettered report is restored into the scan directory, the
+    processed-hash record makes should_process_report skip it (fresh content
+    hash would start a new count — same bytes stay quarantined)."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        report = dirs["unified"] / "20260808-120003-A-restored.md"
+        report.write_text("# restored\n")
+
+        body = f"""
+for i in 1 2 3; do
+  record_rejection_and_maybe_deadletter "{report}" "{report.name}" missing_model || :
+done
+cp "{dirs['state']}/receipt_deadletter/{report.name}" "{report}"
+if should_process_report "{report}"; then echo "verdict=process" ; else echo "verdict=skip"; fi
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        assert "verdict=skip" in result.stdout
+
+
+def test_too_old_log_damped_to_first_occurrence_plus_cycle_summary():
+    """The OI-1085 flood fix: repeated too-old skips of the same report emit
+    ONE per-report line (first occurrence) and the counter feeds ONE
+    aggregate line per cycle via log_too_old_cycle_summary."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        old_report = dirs["unified"] / "20260801-000000-A-ancient.md"
+        old_report.write_text("# ancient\n")
+        old_ts = int(time.time()) - 48 * 3600
+        os.utime(str(old_report), (old_ts, old_ts))
+
+        # Two full simulated scan cycles over the same old report.
+        body = f"""
+should_process_report "{old_report}" || :
+should_process_report "{old_report}" || :
+should_process_report "{old_report}" || :
+log_too_old_cycle_summary
+should_process_report "{old_report}" || :
+log_too_old_cycle_summary
+log_too_old_cycle_summary
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        out = result.stderr + result.stdout  # log() writes via tee to stderr
+
+        per_report = [ln for ln in out.splitlines() if "Report too old:" in ln]
+        assert len(per_report) == 1, f"expected exactly one per-report line, got {len(per_report)}: {per_report}"
+        assert old_report.name in per_report[0]
+        assert "age:" in per_report[0]
+
+        summaries = [ln for ln in out.splitlines() if "too-old report(s) this cycle" in ln]
+        assert len(summaries) == 2, f"expected one summary per non-empty cycle, got {len(summaries)}: {summaries}"
+        assert "Skipped 2 too-old report(s)" in summaries[0]
+        assert "Skipped 1 too-old report(s)" in summaries[1]
+
+
+def test_threshold_is_configurable_via_env():
+    """VNX_RECEIPT_DEADLETTER_THRESHOLD=1 quarantines on the first refusal."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        tmp = Path(tmpdir)
+        dirs = _make_dirs(tmp)
+        report = dirs["unified"] / "20260808-120004-A-threshold.md"
+        report.write_text("# threshold\n")
+
+        body = f"""
+export VNX_RECEIPT_DEADLETTER_THRESHOLD=1
+DEADLETTER_THRESHOLD=1
+rc=0; record_rejection_and_maybe_deadletter "{report}" "{report.name}" missing_model || rc=$?
+echo "rc=$rc"
+"""
+        result = _run_bash(dirs, body)
+        assert result.returncode == 0, f"harness failed: {result.stderr}"
+        assert "rc=0" in result.stdout
+        assert not report.exists()

--- a/tests/test_report_parser_model_provider.py
+++ b/tests/test_report_parser_model_provider.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Tests for OI-1086: report_parser must lift model/provider onto the receipt.
+
+Dispatch-ID: 20260808-170000-oi1086-parser-model-drop
+
+Regression: extract_metadata() captured `**Model**:`/`**Provider**:` (and the
+dispatch-envelope `---` frontmatter) but _build_enhanced_receipt() dropped
+both keys, so every report-derived receipt (receipt_kind='dispatch', no
+exempt source) was refused by append_receipt's fail-closed missing_model
+check (#1338) and the receipt processor looped on 109 healthy reports.
+
+These tests run the REAL parser and the REAL append_receipt CLI (subprocess,
+sandboxed state dir) — no reimplemented logic.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(REPO / "scripts"))
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+from report_parser import ReportParser  # noqa: E402
+
+REPORT_PARSER = REPO / "scripts" / "report_parser.py"
+APPEND_RECEIPT = REPO / "scripts" / "append_receipt.py"
+
+_BOLD_MODEL_BODY = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260808-oi1086-bold-model
+**Model**: opus
+**Provider**: claude
+
+## Summary
+This is a genuine completion report whose summary is comfortably longer than fifty non-whitespace
+characters so the body contract validator accepts it.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+
+_FRONTMATTER_MODEL_BODY = """---
+schema_version: 1
+dispatch_id: 20260808-oi1086-frontmatter-model
+provider: kimi
+sub_provider: moonshot
+model: kimi-k3
+terminal_id: plan-gate
+role: plan-reviewer
+---
+
+# Dispatch 20260808-oi1086-frontmatter-model
+
+- Provider: kimi
+
+## Summary
+
+Headless plan-gate seat report whose identity lives entirely in the dispatch-envelope
+frontmatter; the body carries no bold Model field at all, only prose.
+"""
+
+# Measured on the 2026-08-03/04 envelope series: frontmatter says
+# `model: unknown` while the body carries the real `**Model**: sonnet`.
+# The body value must win; the placeholder must never shadow it.
+_MIXED_BODY = """---
+schema_version: 1
+dispatch_id: 20260808-oi1086-mixed
+provider: claude
+model: unknown
+---
+
+# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260808-oi1086-mixed
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+Envelope report whose frontmatter model placeholder is unknown while the body carries the real
+model value, which must take precedence in the parsed receipt output.
+
+## Changes
+- none
+
+## Verification
+- manual inspection
+
+## Open Items
+None
+"""
+
+_NO_MODEL_BODY = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260808-oi1086-no-model
+
+## Summary
+A report that names no model anywhere — the receipt must omit the key entirely so the
+fail-closed validator still refuses it, honestly, instead of seeing a fake placeholder.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+
+# Frontmatter genuinely records model: unknown everywhere (measured:
+# 20260803-202008-pr0-envelope-census.md) — a correct fail-closed refusal.
+_FRONTMATTER_UNKNOWN_BODY = """---
+schema_version: 1
+dispatch_id: 20260808-oi1086-census
+provider: claude
+model: unknown
+route_decision:
+  selected_model: unknown
+---
+
+Dispatch-ID: 20260808-oi1086-census
+
+## Summary
+
+Census-style report with no model recorded anywhere except unknown placeholders, so the
+receipt must carry no model key and must still be refused fail-closed by append validation.
+"""
+
+# Reports that embed their full dispatch instruction carry the door-stamped
+# **Model**/**Provider** block mid-file, outside the 2000-char header window
+# (measured: 20260804-m00-oi917.md, block at line 196/282).
+_EMBEDDED_INSTRUCTION_BODY = (
+    "# Dispatch 20260808-oi1086-embedded\n\n"
+    "## Instruction\n\n"
+    + "# filler line with enough prose to push the metadata block well past the two thousand character header window that the parser scans for bold fields.\n" * 20
+    + """
+---
+
+DISPATCH INSTRUCTION:
+
+# Some open item
+
+**Dispatch-ID**: 20260808-oi1086-embedded
+**Provider**: deepseek
+**Model**: deepseek-v4-pro
+**Terminal**: T1
+
+## Summary
+
+The actual worker report body follows the embedded instruction; the model identity lives in
+the door-stamped dispatch metadata block above and must be recovered from there.
+"""
+)
+
+# Plain-text header block (measured: 20260804-065952-triage-b1-blockers.md
+# and the 2026-08-04 m-series) — no bold, no frontmatter.
+_PLAIN_HEADER_BODY = """# Dispatch 20260808-oi1086-plain
+
+Dispatch-ID: 20260808-oi1086-plain
+Provider: deepseek
+Model: deepseek-v4-flash
+Terminal: T2
+
+## Summary
+
+Triage-note style report whose identity block is plain `Key: value` lines instead of bold
+fields; the parser must still recover model and provider from it.
+"""
+
+# A header bold-field value must always win over an embedded-instruction
+# copy deeper in the file.
+_HEADER_WINS_BODY = (
+    "# Completion Report\n"
+    "**Status**: success\n"
+    "**Dispatch-ID**: 20260808-oi1086-header-wins\n"
+    "**Model**: opus\n"
+    "**Provider**: claude\n\n"
+    + "# filler line to push the embedded instruction past the header window, long enough to overflow two thousand characters of content.\n" * 20
+    + "**Model**: glm-5.2\n**Provider**: glm\n"
+)
+
+
+def _parse(tmp_path: Path, body: str, name: str = "report.md") -> dict:
+    p = tmp_path / name
+    p.write_text(body, encoding="utf-8")
+    return ReportParser().parse_report(str(p))
+
+
+def _sandbox_env(tmp_path: Path) -> dict:
+    env = os.environ.copy()
+    data_dir = tmp_path / "data"
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    env["PROJECT_ROOT"] = str(tmp_path)
+    env["VNX_DATA_DIR"] = str(data_dir)
+    env["VNX_STATE_DIR"] = str(state_dir)
+    env["VNX_HOME"] = str(REPO)
+    env["VNX_REPORTS_DIR"] = str(tmp_path)
+    return env
+
+
+def _parser_then_append(tmp_path: Path, body: str) -> tuple[dict, subprocess.CompletedProcess]:
+    """Run the REAL report_parser CLI, pipe its JSON into the REAL
+    append_receipt CLI (exactly the receipt_processor.sh pipeline shape),
+    against a fully sandboxed state dir. Returns (receipt, append_result)."""
+    report = tmp_path / "report.md"
+    report.write_text(body, encoding="utf-8")
+    env = _sandbox_env(tmp_path)
+
+    parse = subprocess.run(
+        [sys.executable, str(REPORT_PARSER), str(report)],
+        capture_output=True, text=True, env=env,
+    )
+    assert parse.returncode == 0, f"report_parser failed: {parse.stderr}"
+    receipt = json.loads(parse.stdout)
+
+    append = subprocess.run(
+        [sys.executable, str(APPEND_RECEIPT)],
+        input=json.dumps(receipt),
+        capture_output=True, text=True, env=env,
+    )
+    return receipt, append
+
+
+def test_bold_model_provider_reach_receipt(tmp_path):
+    """The exact bug case: bold **Model**/**Provider** fields must land on the receipt."""
+    r = _parse(tmp_path, _BOLD_MODEL_BODY)
+    assert r["model"] == "opus"
+    assert r["provider"] == "claude"
+    assert r["receipt_kind"] == "dispatch"
+
+
+def test_frontmatter_model_provider_reach_receipt(tmp_path):
+    """Dispatch-envelope frontmatter (headless seats) carries the identity."""
+    r = _parse(tmp_path, _FRONTMATTER_MODEL_BODY)
+    assert r["model"] == "kimi-k3"
+    assert r["provider"] == "kimi"
+
+
+def test_bold_model_wins_over_unknown_frontmatter(tmp_path):
+    """A `model: unknown` placeholder must never shadow a real body value."""
+    r = _parse(tmp_path, _MIXED_BODY)
+    assert r["model"] == "sonnet"
+    assert r["provider"] == "claude"
+
+
+def test_missing_model_omits_keys_not_empty_strings(tmp_path):
+    """Chosen contract (OI-1086 task 1): absent/placeholder model or provider
+    means the KEY IS OMITTED — never '', never 'unknown'. For the fail-closed
+    validator all three forms refuse identically; omission is the honest form
+    and keeps the refusal reason accurate."""
+    r = _parse(tmp_path, _NO_MODEL_BODY)
+    assert "model" not in r
+    assert "provider" not in r
+
+
+def test_unknown_frontmatter_model_omits_key(tmp_path):
+    r = _parse(tmp_path, _FRONTMATTER_UNKNOWN_BODY)
+    assert "model" not in r
+    # provider: claude is a real value and is kept.
+    assert r["provider"] == "claude"
+
+
+def test_embedded_dispatch_instruction_model_recovered(tmp_path):
+    """Mid-file door-stamped **Model**/**Provider** (embedded dispatch
+    instruction) must be recovered even outside the 2000-char header window."""
+    r = _parse(tmp_path, _EMBEDDED_INSTRUCTION_BODY)
+    assert r["model"] == "deepseek-v4-pro"
+    assert r["provider"] == "deepseek"
+
+
+def test_plain_header_model_recovered(tmp_path):
+    r = _parse(tmp_path, _PLAIN_HEADER_BODY)
+    assert r["model"] == "deepseek-v4-flash"
+    assert r["provider"] == "deepseek"
+
+
+def test_header_bold_model_wins_over_embedded_copy(tmp_path):
+    """Precedence: a real header value beats an embedded-instruction copy."""
+    r = _parse(tmp_path, _HEADER_WINS_BODY)
+    assert r["model"] == "opus"
+    assert r["provider"] == "claude"
+
+
+def test_end_to_end_receipt_with_model_passes_append_validation(tmp_path):
+    """End-to-end: parser output through the REAL append_receipt CLI must NOT
+    fire missing_model and must be persisted — the receipt processor's exact
+    pipeline shape, sandboxed. Without this leg we'd test the parser, not the
+    fix."""
+    receipt, append = _parser_then_append(tmp_path, _BOLD_MODEL_BODY)
+    assert append.returncode == 0, f"append_receipt refused a healthy receipt: {append.stderr}"
+    assert "missing_model" not in append.stderr
+
+    ledger = tmp_path / "data" / "state" / "t0_receipts.ndjson"
+    assert ledger.is_file(), "receipt was not persisted to the sandboxed ledger"
+    stored = json.loads(ledger.read_text(encoding="utf-8").strip().splitlines()[-1])
+    assert stored["dispatch_id"] == "20260808-oi1086-bold-model"
+    assert stored["model"], "persisted receipt must name a real model"
+    assert stored["model"].lower() not in {"unknown", "none", "null", ""}
+    assert stored["receipt_kind"] == "dispatch"
+
+
+def test_end_to_end_receipt_without_model_still_refused_fail_closed(tmp_path):
+    """The fail-closed check itself is correct and stays: a report with no
+    model anywhere must still be refused with code=missing_model (and now the
+    dead-letter path quarantines it instead of looping — see
+    tests/test_receipt_processor_deadletter.py)."""
+    _receipt, append = _parser_then_append(tmp_path, _NO_MODEL_BODY)
+    assert append.returncode != 0
+    codes = [
+        json.loads(line).get("code")
+        for line in append.stderr.splitlines()
+        if line.strip().startswith("{")
+    ]
+    assert "missing_model" in codes
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
# OI-1086 / OI-1085 — parser laat model/provider vallen + receipt-processor-lus

## Wat er kapot was

`ReportParser.extract_metadata()` haalde `**Model**:`/`**Provider**:` keurig op, maar
`_build_enhanced_receipt()` (`report_parser.py:489`) bouwde de receipt met een handgeplukte
sleutellijst waarin `model` en `provider` niet voorkwamen. Elke rapport-afgeleide receipt
(`receipt_kind='dispatch'`, geen exempt source) werd daardoor geweigerd door de fail-closed
`missing_model`-check uit #1338 — een correcte check tegen een verouderde parser. Gevolg:
109 unieke, inhoudelijk gezonde rapporten in een permanente weiger-lus (4 dagen, 386
CPU-minuten, 4,3 GB logs, ENOSPC). Daarnaast was 93% van de log `DEBUG Report too old`
— één regel per historisch rapport per poll-cyclus.

## Fix 1 — parser (OI-1086)

- `_build_enhanced_receipt` tilt `model`/`provider` nu mee naar de receipt.
  **Bewuste keuze bij ontbreken: de sleutel wordt weggelaten** — nooit `''`, nooit
  `'unknown'`. Voor de fail-closed validator zijn afwezig/leeg/'unknown' equivalent (alle
  drie geweigerd); weglaten is de eerlijke vorm en houdt de weiger-reden accuraat.
- `extract_metadata` leest nu ook `---` YAML-frontmatter (dispatch-envelope-rapporten,
  o.a. headless plan-gate-zetels met `model: kimi-k3`) vóór de bold-scan, zodat een echte
  `**Model**:`-body-waarde altijd wint van een `model: unknown`-placeholder in frontmatter
  (gemeten op de envelop-serie van 3/4 augustus).
- Twee fallback-vormen die in de geweigerde set voorkwamen: rapporten die hun volledige
  dispatch-instructie embedden (door-gestempeld `**Model**`-blok halverwege het bestand,
  first-match-wins, vult alleen afwezige sleutels) en kale `Model: X`-kopblokken
  (triage-/m-serie-conventie, zelfde vorm als de bestaande `Dispatch-ID:`-plain-fallback).

**Gemeten tegen de echte geweigerde set** (110 unieke rapporten uit
`state/receipt_processing.log`, read-only, parser direct aangeroepen): **103 leveren nu een
echt model**. De resterende 7 bevatten nergens een model (o.a. `model: unknown` overal, of
panel-rapporten) — voor die is de fail-closed weigering correct en worden ze nu
gedead-letterd in plaats van eindeloos opnieuw geprobeerd.

## Fix 2 — de lus zelf (OI-1085)

- **`rp_deadletter.sh` (nieuw):** per-(rapport-hash, code) teller voor deterministische
  validatiecodes (`missing_model`, `missing_required_key`, `invalid_json`,
  `invalid_receipt_type`, `empty_input`). Na **N=3** identieke weigeringen
  (`VNX_RECEIPT_DEADLETTER_THRESHOLD`) verhuist het rapport naar
  `$STATE_DIR/receipt_deadletter/` (+ `INDEX.txt`) en wordt de hash als verwerkt
  geregistreerd. Motivatie N=3: de tweede identieke weigering bewijst al dat de uitslag
  permanent is (validatie is deterministisch op inhoud); één extra poging vangt de enige
  transiënte look-alike op (een rapport dat nog geschreven wordt kan als `invalid_json`
  opperen en zichzelf herstellen). Transiënte codes (`unexpected_error`, I/O) tellen nooit.
- **`rp_append.sh`:** vangt append_receipt-stderr nu apart op om de gestructureerde code te
  extraheren; de stderr-inhoud wordt exact zoals voorheen in de processing-log gespiegeld.
- **`rp_dedup.sh`:** dempt de `Report too old`-vloed — één regel per rapport bij de eerste
  skip, daarna alleen een teller; `log_too_old_cycle_summary` emit één aggregaatregel per
  scan-cyclus (aangeroepen vanuit `_ppr_collect_pending`, `_poll_new_reports`,
  `_mnr_startup_catchup`).

## Taak 2 — andere vallende sleutels

Geaudit: `title`, `task_id`, `session_id`, `track`, `gate`, `status`, `terminal`, `type`,
`dispatch_id` zaten al op de receipt. `confidence` is eerder bewust verwijderd (ADR-035
§3.3, dood gewicht). `rol`/`datum` hebben geen receipt-veld met een aantoonbare consument
op dit pad — ongemoeid gelaten, zie Open Items in het completion-rapport.

## Tests

- `tests/test_report_parser_model_provider.py` (10 tests) — bold/frontmatter/embedded/plain
  extractie, precedentie, omit-on-absent-contract, plus twee **end-to-end**-poten die de
  parser-uitvoer door de echte `append_receipt.py` CLI (subprocess, gesandboxte state-dir)
  halen: `missing_model` vuurt niet meer voor gezonde rapporten en vuurt wél nog voor
  echt model-loze.
- `tests/test_receipt_processor_deadletter.py` (6 tests) — sourceert de echte
  `receipt_processor.sh` (`_RP_LIB_MODE=1`): N=3-quarantaine, transiënte codes tellen nooit,
  per-code onafhankelijk, restored-copy skip via processed-hash, too-old-demping,
  env-configureerbare drempel.
- Totaal: **129 passed, 0 failed** op alle geraakte bestanden + directe buren.
  (`tests/test_receipt_processor_bootstrap.py` en
  `tests/test_receipt_processor_autopr_rejected_mirror.py` falen 12 tests — identiek
  gereproduceerd op ongewijzigd HEAD in een tijdelijke worktree; pre-existing
  omgevingsfalen, geen regressie.)

## Expliciet buiten scope (per dispatch)

- De 109/110 rapporten alsnog verwerken — de processor blijft uit tot de operator hem aanzet.
- Het grootboek — append-only, geen amendement.
- OI-1035 nagemeten — niet gedaan.

## ⚠️ Operationele bevinding voor T0/operator

De receipt-processor **draait nog steeds** (PID 96508, gestart maandag 8-aug, 476+
CPU-minuten, vanuit de main-checkout) en schrijft actief naar
`state/receipt_processing.log` (2,85 GB, laatste write vandaag 17:10). De dispatch veronderstelde
dat hij uit stond. Ik heb hem niet aangeraakt — herstart/stop is een operator-beslissing.

Dispatch-ID: 20260808-170000-oi1086-parser-model-drop
