### PR TITLE
fix(gate): close unknown-gate and test-run closure passthrough

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -36,6 +36,35 @@ class CheckResult:
     detail: str
 
 
+# Gates the closure verifier implements. A gate name in a review_stack that is
+# not in this set is unverifiable: the verifier can neither attest a pass nor a
+# fail for it, so it is reported as UNVERIFIED and any result file found for it
+# is ignored. This closes the leak where an unknown gate passed on file
+# presence alone.
+_KNOWN_GATES = frozenset({
+    "claude_github_optional",
+    "codex_gate",
+    "gemini_review",
+    "ci_gate",
+})
+
+
+def _is_test_run_record(data: Dict[str, Any]) -> bool:
+    """True when a gate result/request is an offline test run, not production evidence.
+
+    Offline gate runs (e.g. ``kimi_gate --diff-file`` with a synthetic pr_id)
+    are marked ``test_run: true`` by the writer. Such records must never
+    satisfy closure for a real PR. Boolean and string forms are both recognised
+    so a non-normalising writer cannot slip a truthy marker past the check.
+    """
+    value = data.get("test_run")
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, str):
+        return value.strip().lower() in ("1", "true", "yes")
+    return False
+
+
 def _run(cmd: Sequence[str], *, cwd: Optional[Path] = None, timeout: int = 20) -> subprocess.CompletedProcess[str]:
     return subprocess.run(
         list(cmd),
@@ -233,6 +262,12 @@ def _find_gate_result(
     """
 
     def _accept(data: Dict[str, Any]) -> bool:
+        # Offline test-run records must never count as evidence for a real PR.
+        # The writer (kimi_gate --diff-file) stamps them test_run: true. Reject
+        # before any pr_id/branch matching so a synthetic pr_id (0, 1, 2)
+        # cannot align with a real contract.
+        if _is_test_run_record(data):
+            return False
         # PR-scoped AND matching: if data carries pr_id it must match the queried pr_id.
         # This prevents a result from a different PR satisfying a closure check even when
         # the filename-based lookup finds a contract for the correct PR name.
@@ -315,6 +350,10 @@ def _find_gate_request_payload(
         try:
             data = json.loads(_read_text(path))
         except (json.JSONDecodeError, OSError):
+            continue
+        # Offline test-run records must never satisfy an optional-gate closure
+        # check either — same rule as _find_gate_result._accept.
+        if _is_test_run_record(data):
             continue
         # claude_github_optional payloads must carry an explicit pr_id so that a
         # file written for one PR cannot silently satisfy another PR's closure check.
@@ -445,6 +484,26 @@ def _check_single_gate(
     branch: Optional[str],
 ) -> CheckResult:
     """Check a single gate from the review stack, returning one CheckResult."""
+    if gate not in _KNOWN_GATES:
+        # Unknown gate: the verifier does not implement this gate, so it can
+        # neither pass nor fail it. Presence of a result file is not evidence —
+        # a record for an unrecognised gate is uninterpretable. UNVERIFIED (not
+        # FAIL) keeps a governance-config gap visible instead of reading as a
+        # gate that actually rejected the change; the verdict still fails
+        # because closure requires every check to be PASS.
+        if result is not None:
+            return CheckResult(
+                f"gate_{gate}",
+                "UNVERIFIED",
+                f"gate {gate} is not implemented by the closure verifier — result present "
+                f"but uninterpretable, treated as not decided",
+            )
+        return CheckResult(
+            f"gate_{gate}",
+            "UNVERIFIED",
+            f"gate {gate} is not implemented by the closure verifier — not decided, cannot pass",
+        )
+
     if gate == "claude_github_optional":
         # Fallback: explicit-absence state for the optional gate is recorded
         # in the requests directory by gate_request_handler — not as a
@@ -572,11 +631,6 @@ def _check_single_gate(
             )
         return CheckResult(f"gate_{gate}", "FAIL", f"ci_gate not passing — {reason}")
 
-    # Unknown gate
-    if result is None:
-        return CheckResult(f"gate_{gate}", "FAIL", f"no gate result for unknown gate {gate}")
-    return CheckResult(f"gate_{gate}", "PASS", f"gate {gate} result present")
-
 
 def _check_contract_hashes(contract: ReviewContract, results_dir: Path) -> List[CheckResult]:
     """Check content hash consistency between contract and gate receipts.
@@ -586,6 +640,8 @@ def _check_contract_hashes(contract: ReviewContract, results_dir: Path) -> List[
     """
     checks: List[CheckResult] = []
     for gate in contract.review_stack:
+        if gate not in _KNOWN_GATES:
+            continue
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
         if result and contract.content_hash:
             result_hash = result.get("contract_hash") or result.get("content_hash") or ""
@@ -603,6 +659,8 @@ def _check_report_paths(contract: ReviewContract, results_dir: Path) -> List[Che
     """Validate that every terminal gate result carries a report_path pointing to a real file."""
     checks: List[CheckResult] = []
     for gate in contract.review_stack:
+        if gate not in _KNOWN_GATES:
+            continue
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
         if result is not None and gate_is_terminal(result):
             report_path = result.get("report_path", "")
@@ -883,6 +941,8 @@ def _detect_gate_report_contradictions(
     checks: List[CheckResult] = []
 
     for gate in contract.review_stack:
+        if gate not in _KNOWN_GATES:
+            continue
         result = _find_gate_result(gate, contract.pr_id, results_dir, branch=contract.branch)
         if result is None:
             continue

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -156,6 +156,10 @@ def main(argv: "list[str] | None" = None) -> int:
         "gate": "kimi_gate",
         "pr_id": str(args.pr),
         "pr_number": int(args.pr) if str(args.pr).isdigit() else None,
+        # Offline runs read the diff from a file (--diff-file) and are NOT tied
+        # to a live GitHub PR; they must never count as gate evidence. The
+        # closure verifier refuses records with test_run: true.
+        "test_run": bool(args.diff_file),
         "status": status,
         "reason": "verdict" if verdict else "no_verdict",
         "duration_seconds": round(duration, 3),

--- a/tests/test_closure_verifier_unknown_gate.py
+++ b/tests/test_closure_verifier_unknown_gate.py
@@ -1,0 +1,368 @@
+#!/usr/bin/env python3
+"""Regression tests for the closure_verifier unknown-gate and test-run holes.
+
+Dispatch 20260808-ds-d1-closure-gate. Two defects in closure_verifier:
+
+1. A gate name the verifier does not implement returned PASS as soon as a
+   result file existed — no status, contract_hash or report_path check.
+2. Offline test-run records (kimi_gate --diff-file with a synthetic pr_id like
+   0/1/2) lived in the same production results map as real gate verdicts and
+   were indistinguishable from real evidence by file presence alone.
+
+Definition of done covered here:
+- A fabricated gate name with a status: pass record does NOT pass closure.
+- A record marked test_run: true does NOT count as gate evidence for a known gate.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+from review_contract import (
+    Deliverable,
+    DeterministicFinding,
+    QualityGate,
+    ReviewContract,
+    TestEvidence,
+)
+
+
+@pytest.fixture
+def verifier_env(tmp_path, monkeypatch):
+    project_root = tmp_path / "repo"
+    project_root.mkdir(parents=True, exist_ok=True)
+    subprocess.run(["git", "init"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.email", "test@example.com"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "config", "user.name", "Test User"], cwd=project_root, check=True, capture_output=True)
+    (project_root / "README.md").write_text("hello\n", encoding="utf-8")
+    subprocess.run(["git", "add", "README.md"], cwd=project_root, check=True, capture_output=True)
+    subprocess.run(["git", "commit", "-m", "init"], cwd=project_root, check=True, capture_output=True)
+
+    data_dir = project_root / ".vnx-data"
+    dispatch_dir = data_dir / "dispatches"
+    (dispatch_dir / "staging").mkdir(parents=True, exist_ok=True)
+    state_dir = data_dir / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+
+    monkeypatch.setenv("VNX_HOME", str(VNX_ROOT))
+    monkeypatch.setenv("PROJECT_ROOT", str(project_root))
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    monkeypatch.setenv("VNX_DISPATCH_DIR", str(dispatch_dir))
+    monkeypatch.setenv("VNX_LOGS_DIR", str(data_dir / "logs"))
+    monkeypatch.setenv("VNX_PIDS_DIR", str(data_dir / "pids"))
+    monkeypatch.setenv("VNX_LOCKS_DIR", str(data_dir / "locks"))
+    monkeypatch.setenv("VNX_REPORTS_DIR", str(data_dir / "unified_reports"))
+    monkeypatch.setenv("VNX_DB_DIR", str(data_dir / "database"))
+
+    feature_plan = project_root / "FEATURE_PLAN.md"
+    feature_plan.write_text(
+        """# Feature: Demo Feature
+
+**Status**: Complete
+
+## Dependency Flow
+```text
+PR-0 (no dependencies)
+```
+
+## PR-0: Demo PR
+**Track**: C
+**Priority**: P1
+**Complexity**: Medium
+**Skill**: @architect
+**Dependencies**: []
+""",
+        encoding="utf-8",
+    )
+    pr_queue = project_root / "PR_QUEUE.md"
+    pr_queue.write_text(
+        """# PR Queue - Feature: Demo Feature
+
+## Progress Overview
+Total: 1 PRs | Complete: 1 | Active: 0 | Queued: 0 | Blocked: 0
+Progress: ██████████ 100%
+
+## Status
+
+## Dependency Flow
+```
+PR-0 (no dependencies)
+```
+""",
+        encoding="utf-8",
+    )
+    claim_file = state_dir / "closure_claim.json"
+    claim_file.write_text(
+        json.dumps({
+            "test_files": ["FEATURE_PLAN.md"],
+            "test_command": "python3 -m pytest tests/test_demo.py",
+            "parallel_assignments": [{"terminal": "T1"}, {"terminal": "T2"}],
+        }),
+        encoding="utf-8",
+    )
+
+    return {
+        "project_root": project_root,
+        "feature_plan": feature_plan,
+        "pr_queue": pr_queue,
+        "claim_file": claim_file,
+        "dispatch_dir": dispatch_dir,
+    }
+
+
+def _good_pr_payload(state="OPEN", merge_state="CLEAN"):
+    return {
+        "number": 45,
+        "url": "https://example.test/pr/45",
+        "state": state,
+        "mergeStateStatus": merge_state,
+        "statusCheckRollup": [
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+            {"__typename": "CheckRun", "status": "COMPLETED", "conclusion": "SUCCESS"},
+        ],
+        "mergeCommit": {"oid": "abc123"},
+    }
+
+
+def _make_contract(
+    pr_id="PR-0",
+    review_stack=None,
+    risk_class="medium",
+    content_hash="abcdef1234567890",
+):
+    if review_stack is None:
+        review_stack = ["gemini_review"]
+    return ReviewContract(
+        pr_id=pr_id,
+        pr_title="Demo PR",
+        feature_title="Demo Feature",
+        branch="feature/demo",
+        track="C",
+        risk_class=risk_class,
+        merge_policy="human",
+        review_stack=list(review_stack),
+        closure_stage="in_review",
+        deliverables=[Deliverable(description="test deliverable", category="implementation")],
+        non_goals=[],
+        scope_files=[],
+        changed_files=[],
+        quality_gate=QualityGate(gate_id="gate_test", checks=["check 1"]),
+        test_evidence=TestEvidence(test_files=["tests/test_demo.py"], test_command="pytest"),
+        deterministic_findings=[],
+        content_hash=content_hash,
+    )
+
+
+def _write_gate_result(results_dir, gate, pr_id, data):
+    results_dir.mkdir(parents=True, exist_ok=True)
+    pr_slug = pr_id.lower().replace("-", "")
+    path = results_dir / f"{pr_slug}-{gate}-contract.json"
+    path.write_text(json.dumps(data), encoding="utf-8")
+    return path
+
+
+def _run_closure(verifier_env, contract, results_dir, monkeypatch):
+    monkeypatch.setattr(cv, "_remote_branch_exists", lambda b, p: True)
+    monkeypatch.setattr(cv, "_find_branch_pr", lambda b: _good_pr_payload())
+    return cv.verify_closure(
+        project_root=verifier_env["project_root"],
+        feature_plan=verifier_env["feature_plan"],
+        pr_queue=verifier_env["pr_queue"],
+        branch="feature/demo",
+        mode="pre_merge",
+        claim_file=verifier_env["claim_file"],
+        review_contract=contract,
+        gate_results_dir=results_dir,
+    )
+
+
+# ---------------------------------------------------------------------------
+# DoD 1: an unknown gate must never pass, even with a status: pass record
+# ---------------------------------------------------------------------------
+
+
+class TestUnknownGateNeverPasses:
+    def test_unknown_gate_with_pass_record_does_not_pass_closure(self, verifier_env, monkeypatch, tmp_path):
+        """Fabricated gate name + status=pass record must not yield a PASS."""
+        contract = _make_contract(review_stack=["kimi_gate"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(results_dir, "kimi_gate", "PR-0", {
+            "gate": "kimi_gate",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "blocking_count": 0,
+            "contract_hash": "abcdef1234567890",
+            "report_path": "/tmp/does-not-matter.md",
+            "branch": "feature/demo",
+        })
+
+        result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
+
+        assert result["verdict"] == "fail"
+        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        assert check["status"] == "UNVERIFIED"
+        assert check["status"] != "PASS"
+
+    def test_unknown_gate_without_record_is_undecided_not_pass(self, verifier_env, monkeypatch, tmp_path):
+        """Even with no result file, an unknown gate is undecided (not silently green)."""
+        contract = _make_contract(review_stack=["kimi_gate"])
+        results_dir = tmp_path / "results"
+        results_dir.mkdir(parents=True)
+
+        result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
+
+        assert result["verdict"] == "fail"
+        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        assert check["status"] == "UNVERIFIED"
+
+    def test_production_shape_kimi_gate_record_never_passes(self, verifier_env, monkeypatch, tmp_path):
+        """A real kimi_gate result (no test_run field) for an unknown gate is still refused.
+
+        Mirrors the nine records currently in ~/.vnx-data/vnx-dev/state/review_gates/results/:
+        they carry no test_run flag but kimi_gate is unregistered, so the record
+        must be ignored, not treated as a passing gate.
+        """
+        contract = _make_contract(review_stack=["kimi_gate"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(results_dir, "kimi_gate", "PR-0", {
+            "gate": "kimi_gate",
+            "pr_id": "0",
+            "pr_number": 0,
+            "status": "pass",
+            "reason": "verdict",
+            "provider": "kimi",
+            "dispatch_id": "kimi-gate-pr0-1782546770",
+            "blocking_findings": [],
+            "advisory_findings": [],
+            "residual_risk": "",
+            "recorded_at": "2026-06-27T07:56:10Z",
+        })
+
+        result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
+
+        assert result["verdict"] == "fail"
+        check = next(c for c in result["checks"] if c["name"] == "gate_kimi_gate")
+        assert check["status"] == "UNVERIFIED"
+
+    def test_check_single_gate_unknown_returns_unverified(self, tmp_path):
+        """Direct unit check: unknown gate is UNVERIFIED regardless of record presence."""
+        contract = _make_contract(review_stack=["kimi_gate"])
+        results_dir = tmp_path / "results"
+
+        absent = cv._check_single_gate("kimi_gate", contract, None, results_dir, "feature/demo")
+        assert absent.status == "UNVERIFIED"
+
+        present = cv._check_single_gate(
+            "kimi_gate", contract,
+            {"gate": "kimi_gate", "status": "pass"},
+            results_dir, "feature/demo",
+        )
+        assert present.status == "UNVERIFIED"
+
+    def test_known_gate_still_passes(self, verifier_env, monkeypatch, tmp_path):
+        """Known gates keep their normal semantics — this fix must not break them."""
+        report_file = tmp_path / "gemini_report.md"
+        report_file.write_text("# Gemini Review\nAll clear.\n", encoding="utf-8")
+        contract = _make_contract(review_stack=["gemini_review"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(results_dir, "gemini_review", "PR-0", {
+            "gate": "gemini_review",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "blocking_count": 0,
+            "advisory_count": 0,
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+            "branch": "feature/demo",
+        })
+
+        result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
+
+        assert result["verdict"] == "pass"
+        check = next(c for c in result["checks"] if c["name"] == "gate_gemini_review")
+        assert check["status"] == "PASS"
+
+
+# ---------------------------------------------------------------------------
+# DoD 2: test-run records must not count as gate evidence
+# ---------------------------------------------------------------------------
+
+
+class TestTestRunRecordsRefused:
+    def test_test_run_record_does_not_count_for_known_gate(self, verifier_env, monkeypatch, tmp_path):
+        """A gemini_review record stamped test_run: true is refused — gate has no evidence."""
+        report_file = tmp_path / "gemini_report.md"
+        report_file.write_text("# Gemini Review\nAll clear.\n", encoding="utf-8")
+        contract = _make_contract(review_stack=["gemini_review"])
+        results_dir = tmp_path / "results"
+        _write_gate_result(results_dir, "gemini_review", "PR-0", {
+            "gate": "gemini_review",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "test_run": True,
+            "blocking_count": 0,
+            "advisory_count": 0,
+            "contract_hash": "abcdef1234567890",
+            "report_path": str(report_file),
+            "branch": "feature/demo",
+        })
+
+        result = _run_closure(verifier_env, contract, results_dir, monkeypatch)
+
+        assert result["verdict"] == "fail"
+        check = next(c for c in result["checks"] if c["name"] == "gate_gemini_review")
+        assert check["status"] == "FAIL"
+
+    def test_find_gate_result_rejects_test_run_record(self, tmp_path):
+        """_find_gate_result must return None for a test_run record even when filenames align."""
+        results_dir = tmp_path / "results"
+        _write_gate_result(results_dir, "gemini_review", "PR-0", {
+            "gate": "gemini_review",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "test_run": True,
+            "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
+        })
+
+        assert cv._find_gate_result("gemini_review", "PR-0", results_dir, branch="feature/demo") is None
+
+    def test_find_gate_result_accepts_normal_record(self, tmp_path):
+        """A non-test-run record is still found normally."""
+        results_dir = tmp_path / "results"
+        payload = {
+            "gate": "gemini_review",
+            "pr_id": "PR-0",
+            "status": "pass",
+            "test_run": False,
+            "contract_hash": "abcdef1234567890",
+            "branch": "feature/demo",
+        }
+        _write_gate_result(results_dir, "gemini_review", "PR-0", payload)
+
+        found = cv._find_gate_result("gemini_review", "PR-0", results_dir, branch="feature/demo")
+        assert found is not None
+        assert found["status"] == "pass"
+
+    def test_is_test_run_record_unit(self):
+        """Boolean and string forms are both recognised; absent is False."""
+        assert cv._is_test_run_record({"test_run": True}) is True
+        assert cv._is_test_run_record({"test_run": False}) is False
+        assert cv._is_test_run_record({"test_run": "true"}) is True
+        assert cv._is_test_run_record({"test_run": "1"}) is True
+        assert cv._is_test_run_record({"test_run": "yes"}) is True
+        assert cv._is_test_run_record({"test_run": "false"}) is False
+        assert cv._is_test_run_record({}) is False
+        assert cv._is_test_run_record({"test_run": None}) is False


### PR DESCRIPTION
## What

Closes two leaks in `scripts/closure_verifier.py` that let review-gate evidence pass closure on file presence alone.

**Leak 1 — unknown gate passed on presence.** An unrecognised gate name in a review stack returned `PASS` as soon as a result file existed, ignoring `status`, `contract_hash`, and `report_path`. All nine production `kimi_gate` records fall in this branch today. They now report `UNVERIFIED` (a distinct outcome, not `FAIL`): the verifier can neither pass nor fail a gate it does not implement, so closure still fails while the governance-config gap stays visible instead of reading as a real gate rejection.

**Leak 2 — offline test runs looked like real evidence.** `kimi_gate --diff-file` runs (synthetic `pr_id` 0/1/2) wrote into the same production results map as real verdicts. Offline runs are now stamped `test_run: true` and refused by `_find_gate_result` (and `_find_gate_request_payload`), so they can never count as gate evidence for a real PR even once `kimi_gate` is registered as a known gate.

## Motivation for the two choices

1. **UNVERIFIED instead of FAIL** for unknown gates: FAIL would read as "the gate rejected the change". An unknown gate is a verifier/governance-config gap, not a gate verdict. A third outcome keeps the two distinguishable in the closure output while still blocking closure (verdict requires every check to be `PASS`).
2. **`test_run: true` field instead of a separate directory**: surgical — one field in `kimi_gate.py` plus one refusal rule in `_find_gate_result`. It also makes the marker explicit and auditable in the record itself, and the refusal lives in the shared `_accept` filter so it covers every gate (known and unknown) consistently.

## Definition of done

- Regression test: fabricated gate name with `status: pass` record does not pass closure (fails on pre-fix code, passes after).
- Regression test: a record stamped `test_run: true` for a known gate does not count as gate evidence (fails on pre-fix code, passes after).
- Existing `closure_verifier` tests stay green; new test file `tests/test_closure_verifier_unknown_gate.py` (9 tests) all pass.

## Verification

- `pytest tests/test_closure_verifier.py tests/test_closure_verifier_evidence_contract.py tests/test_closure_verifier_unknown_gate.py tests/test_gate_kimi_ff849_fixes.py` → **94 passed**
- DoD regression tests confirmed to fail against the pre-fix `closure_verifier.py`.
- Pre-existing reds in `test_per_pr_closure.py` (9) and `test_ci_gate.py` (5) are identical on the clean base commit — not introduced here.

## Out of scope

Registering `kimi_gate` as a known gate is a separate deliverable that follows this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)