### PR TITLE
feat(gate): build VNX_PLAN_GATE_COMPLEX_ONLY scope read-site, emit run-resolver passes

### DIFF
--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -27,7 +27,7 @@ This document is the single source of truth for which VNX subsystems are live, p
 | injection-effectiveness-eval-loop | Instrument WHY patterns are ignored before tuning generation. | `VNX_INJECTION_WHY_ENABLED` | ACTIVATE-and-measure | unknown — probe not built yet |
 | cross-project-federation | Cross-project intelligence federation (not yet implemented). | `VNX_USE_FEDERATION` | ACTIVATE-and-measure | unknown — no probe yet |
 | plan-gate-panel | 5-model deliberation panel for plan-first enforcement. | `VNX_PLAN_GATE_ENFORCE` | SCOPE | works — panel runs, verdicts recorded |
-| plan-gate-task-class-scope | Restrict panel to complex features; skip trivial tracks. Enforcement deferred to review-floor-enforcer. | `VNX_PLAN_GATE_COMPLEX_ONLY` | SCOPE | unknown — read-site deferred |
+| plan-gate-task-class-scope | Restrict panel to complex features; run trivial tracks on a reduced 2-seat panel (scope read-site: plan_gate_enforcement.plan_gate_scope). | `VNX_PLAN_GATE_COMPLEX_ONLY` | SCOPE | works — scope read-site present (light plans run 2 seats) |
 | subsystem-cockpit | SUBSYSTEMS.md + config_registry + vnx subsystems + dashboard tile. | — | COCKPIT | degraded — SSOT exists, probes partial |
 | effectiveness-probe-framework | Generic "does it produce crap?" probes per subsystem. | — | COCKPIT | unknown — framework not built yet |
 

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -163,8 +163,9 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         subsystem="injection-effectiveness-eval-loop", status="ACTIVATE"),
     "VNX_PLAN_GATE_COMPLEX_ONLY": _e(
         "VNX_PLAN_GATE_COMPLEX_ONLY", "bool", "0", "gate",
-        "Restrict the plan-gate panel to complex features (display metadata only; "
-        "the scope-skip read-site is deferred to review-floor-enforcer).",
+        "Restrict the plan-gate panel to complex features: a LIGHT-scope plan "
+        "(read-site in plan_gate_enforcement.plan_gate_scope) runs the reduced "
+        "2-seat panel; HEAVY plans keep the full 5-seat panel.",
         # subsystem matches the docs/core/SUBSYSTEMS.md seed row
         # "plan-gate-task-class-scope" (framework-status-audit-and-cockpit PR-3
         # fix) — distinct from "plan-gate-panel" (VNX_PLAN_GATE_ENFORCE), so the

--- a/scripts/lib/plan_gate_effectiveness_probe.py
+++ b/scripts/lib/plan_gate_effectiveness_probe.py
@@ -30,11 +30,11 @@ OI-PLAN resolution count, because the ledger is the durable record of whether
 the panel converged (OI-888). Both read as "panel verdicts disagree" in the
 PRD's vocabulary.
 
-Scope-skip signal (OI-888): whether complex tracks skip the panel
-(``VNX_PLAN_GATE_COMPLEX_ONLY``) has NO read-site yet — it is deferred to
-``review-floor-enforcer``. The probe reports that explicitly
-(``scope_skip_read_site: "missing"``) instead of staying silent about a signal
-it cannot see.
+Scope-skip signal (OI-888): the ``VNX_PLAN_GATE_COMPLEX_ONLY`` read-site now
+exists in ``plan_gate_enforcement.plan_gate_scope`` + ``complex_only_active``
+(2026-08-08 dispatch) — a LIGHT-scope plan under the flag runs the reduced
+2-seat panel. The probe reports that explicitly (``scope_skip_read_site:
+"present"``) instead of staying silent about the signal.
 """
 from __future__ import annotations
 
@@ -171,7 +171,7 @@ class PlanGateEffectivenessProbe(EffectivenessProbe):
             "seat_pass": seat_pass,
             "seat_revise": seat_revise,
             "seat_block": seat_block,
-            "scope_skip_read_site": "missing",
+            "scope_skip_read_site": "present",
         }
 
     def signal(self, raw: Dict[str, Any]) -> str:
@@ -190,7 +190,7 @@ class PlanGateEffectivenessProbe(EffectivenessProbe):
                 f"({raw['seat_responded']} responded, {raw['seat_abstain']} abstained, "
                 f"{raw['seat_pass']} pass/{raw['seat_revise']} revise/{raw['seat_block']} block)"
             )
-        parts.append("VNX_PLAN_GATE_COMPLEX_ONLY read-site MISSING (no scope-skip signal to probe)")
+        parts.append("VNX_PLAN_GATE_COMPLEX_ONLY scope-skip read-site present (light plans run a reduced panel)")
         return "; ".join(parts)
 
     def health(self, raw: Dict[str, Any]) -> str:

--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -25,8 +25,10 @@ gate-shaped result, but both share this one truth.
 from __future__ import annotations
 
 import os
+import re
 import sqlite3
 from pathlib import Path
+from typing import Iterable
 
 PLAN_OI_PREFIX = "OI-PLAN-"
 
@@ -68,6 +70,159 @@ def enforce_mode() -> str:
 def override_active() -> bool:
     """True when the operator set ``VNX_OVERRIDE_PLAN_GATE`` to an affirmative value."""
     return (os.environ.get("VNX_OVERRIDE_PLAN_GATE") or "").strip().lower() in _TRUTHY
+
+
+# --- Scope read-site (VNX_PLAN_GATE_COMPLEX_ONLY) ----------------------------
+#
+# The operator's dividing line for plan-gate scope (2026-08-08): a plan is HEAVY
+# when it touches the dispatch-lane, store-resolution, a review-gate, or a
+# central-DB schema (ADR-007); LIGHT in all other cases. Signals are derived
+# from data that already exists on the plan — per-deliverable task_class and
+# complexity tags, and the file paths it names — never a new manual scope field.
+# Fail-closed: a plan we cannot judge resolves to HEAVY, never LIGHT.
+
+HEAVY = "heavy"
+LIGHT = "light"
+
+# The reduced panel a LIGHT-scope plan runs when VNX_PLAN_GATE_COMPLEX_ONLY is
+# on: two diverse families (Anthropic + Moonshot), the smallest panel that can
+# still certify a pass (apply_panel_rule needs >= 2 readable verdicts). Matches
+# the observed 2-seat convergences on main; an unknown label fails LOUD in
+# filter_panel_seats, so a config drift can never silently shrink the panel.
+LIGHT_PANEL_LABELS: tuple[str, ...] = ("opus", "kimi")
+
+# Substrings for the four heavy domains, matched case-insensitively against the
+# plan text + the paths it names. Deliberately module/area-specific: a generic
+# plan (add an endpoint, tweak a view) hits none of them and reads LIGHT.
+_HEAVY_MARKERS: tuple[str, ...] = (
+    # dispatch-lane
+    "dispatch_cli",
+    "provider_dispatch",
+    "tmux_interactive_dispatch",
+    "subprocess_dispatch",
+    "dispatch_bridge",
+    "dispatch-lane",
+    "dispatch lane",
+    "routing_policy",
+    "smart_router",
+    "dispatch_spec",
+    # store-resolution
+    "resolve_state_dir",
+    "resolve_data_dir",
+    "resolve_central_data_dir",
+    "project_root",
+    "vnx_paths",
+    "central store",
+    "vnx_data_dir",
+    # review-gate
+    "review-gate",
+    "review_gate",
+    "review_floor",
+    "review-floor",
+    "evidence_bound_gate",
+    "codex_gate",
+    "gemini_review",
+    "verify_pr",
+    "merge gate",
+    "merge-gate",
+    "plan_gate_evidence",
+    "phantom_guard",
+    # central-DB schema (ADR-007)
+    "adr-007",
+    "central-db",
+    "central_db",
+    "track_open_items",
+    "runtime_coordination.db",
+    "schema migration",
+    "schema change",
+    "composite key",
+    "unique constraint",
+)
+
+# task_class values that are HEAVY by construction: a code-review plan IS a
+# review-gate touchpoint, the first of the four domains. The other classes are
+# judged by what the plan actually names, not by their label.
+_HEAVY_TASK_CLASSES: frozenset[str] = frozenset({"02_code_review"})
+
+# Per-deliverable complexity levels that force HEAVY even with no domain
+# marker — a plan explicitly rated complex keeps the full panel.
+_HEAVY_COMPLEXITY: frozenset[str] = frozenset({"high", "critical", "complex"})
+
+# The `[^\n:=]*` between the label and the separator tolerates markdown bold
+# (``**Task class**: 02_code_review``) while never crossing a line break — a tag
+# belongs to one deliverable line. ``[:=]`` is required so a bare mention of the
+# word "complexity" in prose does not capture a value.
+_TASK_CLASS_RE = re.compile(r"(?i)\btask[\s_-]?class\b[^\n:=]*[:=]\s*(\d{2}_[a-z_]+)")
+_COMPLEXITY_RE = re.compile(r"(?i)\bcomplexity\b[^\n:=]*[:=]\s*([a-z][a-z0-9]*)")
+
+
+def plan_gate_scope(
+    plan_text: "str | None" = None,
+    *,
+    task_class: "str | None" = None,
+    complexity: "str | None" = None,
+    paths: "Iterable[str] | None" = None,
+) -> str:
+    """Classify a plan as HEAVY or LIGHT for the plan-first gate.
+
+    Heavy when the plan touches the dispatch-lane, store-resolution, a
+    review-gate, or a central-DB schema (ADR-007); light in all other cases.
+    Derivation order: an explicit heavy task_class/complexity, then domain
+    markers in the plan text and the paths it names, then inline per-deliverable
+    tags in the doc.
+
+    Fail-closed: a plan we cannot judge (no text, no task_class, no complexity,
+    no paths) resolves to HEAVY — a silent fallback to the cheap panel would
+    downgrade exactly the plans we failed to size.
+    """
+    if (task_class or "").strip().lower() in _HEAVY_TASK_CLASSES:
+        return HEAVY
+    if (complexity or "").strip().lower() in _HEAVY_COMPLEXITY:
+        return HEAVY
+
+    text = (plan_text or "").strip()
+    path_text = "\n".join(p for p in (paths or []) if p)
+    haystack = "\n".join(t for t in (text, path_text) if t).lower()
+
+    # Fail-closed: with NO signal at all (no plan text, no touched paths, no
+    # explicit complexity rating) we cannot judge -> HEAVY. task_class alone does
+    # not count: 01_code_generation is the classifier's catch-all default and is
+    # no evidence of lightness. An explicit non-heavy complexity rating IS a
+    # signal — the caller sized it, so fall through to LIGHT absent any marker.
+    if not haystack and not (complexity or "").strip():
+        return HEAVY
+
+    for marker in _HEAVY_MARKERS:
+        if marker in haystack:
+            return HEAVY
+
+    for tag in _TASK_CLASS_RE.findall(text):
+        if tag.lower() in _HEAVY_TASK_CLASSES:
+            return HEAVY
+    for tag in _COMPLEXITY_RE.findall(text):
+        if tag.lower() in _HEAVY_COMPLEXITY:
+            return HEAVY
+
+    return LIGHT
+
+
+def complex_only_active() -> bool:
+    """True when VNX_PLAN_GATE_COMPLEX_ONLY is set to an affirmative value.
+
+    Precedence mirrors enforce_mode: the process env var (a per-session
+    override) wins; then the persisted config-plane value via config_runtime
+    (the ``/operator/config`` surface, audited + revertible); then the registry
+    default (off). The config lookup is best-effort — a missing store leaves
+    the env/default behaviour unchanged.
+    """
+    raw = os.environ.get("VNX_PLAN_GATE_COMPLEX_ONLY")
+    if raw:
+        return raw.strip().lower() in _TRUTHY
+    try:
+        import config_runtime  # noqa: PLC0415
+        return bool(config_runtime.get_bool("VNX_PLAN_GATE_COMPLEX_ONLY"))
+    except Exception:
+        return False
 
 
 def _has_table(conn: sqlite3.Connection, name: str) -> bool:

--- a/scripts/lib/plan_gate_evidence.py
+++ b/scripts/lib/plan_gate_evidence.py
@@ -46,10 +46,15 @@ def emit_plan_gate_pass(
     reason: Optional[str] = None,
     signer_identity: Optional[str] = None,
     key_path: "str | Path | None" = None,
+    seats: Optional[int] = None,
+    scope: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Append a ``plan_gate_pass`` record for a track to the repo-committed ledger.
 
-    Signed when ``key_path`` + ``signer_identity`` are provided (tamper-proof);
+    ``seats`` carries how many panel seats decided a ``run``-resolver pass and
+    ``scope`` whether it was a light or heavy run — a light pass is a REAL pass,
+    so its record must state the reduced panel size that certified it. Signed
+    when ``key_path`` + ``signer_identity`` are provided (tamper-proof);
     otherwise appended unsigned but hash-chained (tamper-evident). Best-effort:
     returns the appended record on success, ``None`` on any failure (never raises).
     """
@@ -63,6 +68,10 @@ def emit_plan_gate_pass(
             "resolver": resolver,
             "resolved_at": timestamp,
         }
+        if seats is not None:
+            record["seats"] = seats
+        if scope:
+            record["scope"] = scope
         if approval_id:
             record["approval_id"] = approval_id
         if reason:

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1795,13 +1795,17 @@ def _emit_plan_gate_pass_record(
                 ).strip() or str(Path.cwd())
             except Exception:  # noqa: BLE001
                 root = str(Path.cwd())
-        plan_gate_evidence.emit_plan_gate_pass(
+        record = plan_gate_evidence.emit_plan_gate_pass(
             repo_root=root, track_id=track_id, project_id=project_id,
             resolver=resolver, timestamp=_now_utc(),
             approval_id=approval_id, reason=reason,
             seats=seats, scope=scope,
         )
-        return True
+        # emit_plan_gate_pass returns the appended record on success, None on any
+        # failure (it never raises), so the try/except above cannot catch a failed
+        # write - the return value IS the failure signal. None means "not written"
+        # and must surface as a False, not as a silent success.
+        return record is not None
     except Exception:  # vnx-silent-except: evidence emission must never break the gate
         return False
 
@@ -2267,11 +2271,19 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
             # attest` ever wrote a record, so the ledger was all-attest and the
             # effectiveness probe read every gate as manually overridden even when
             # the panel had actually converged (light and heavy alike).
-            _emit_plan_gate_pass_record(
+            wrote = _emit_plan_gate_pass_record(
                 repo_root=getattr(args, "repo_root", None),
                 track_id=args.track_id, project_id=args.project_id, resolver="run",
                 seats=len(panel), scope=scope,
             )
+            if not wrote:
+                print(
+                    f"WARNING: plan_gate_pass evidence NOT written for track "
+                    f"{args.track_id} (resolver=run, seats={len(panel)}, scope={scope}). "
+                    "The plan blocker IS resolved, but the durable pass record is "
+                    "missing - the merge gate may not recognize this pass.",
+                    file=sys.stderr,
+                )
         print(
             f"PASS — plan gate cleared. {_plan_blocker_oi(args.track_id)} "
             f"resolved={resolved}; track derived_status={derived}."
@@ -2412,11 +2424,18 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
     # record so the pass is verifiable at PR/merge time (the front link of the
     # requirements-traceability chain). Best-effort, unsigned bootstrap — the
     # runtime event above stays the authoritative audit; this never blocks attest.
-    _emit_plan_gate_pass_record(
+    wrote = _emit_plan_gate_pass_record(
         repo_root=getattr(args, "repo_root", None),
         track_id=track_id, project_id=project_id, resolver="attest",
         approval_id=approval_id, reason=reason,
     )
+    if not wrote:
+        print(
+            f"WARNING: plan_gate_pass evidence NOT written for track {track_id} "
+            "(resolver=attest). The plan blocker IS resolved, but the durable pass "
+            "record is missing - the merge gate may not recognize this attest.",
+            file=sys.stderr,
+        )
 
     post = tracks_lib.get_track(state_dir, track_id, project_id)
     derived = post.get("derived_status") if isinstance(post, dict) else None

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1764,6 +1764,48 @@ def _resolve_plan_blocker(state_dir: Path, track_id: str, project_id: str) -> bo
     return rowcount > 0
 
 
+def _emit_plan_gate_pass_record(
+    *,
+    repo_root: Optional[str],
+    track_id: str,
+    project_id: str,
+    resolver: str,
+    approval_id: Optional[str] = None,
+    reason: Optional[str] = None,
+    seats: Optional[int] = None,
+    scope: Optional[str] = None,
+) -> bool:
+    """Best-effort durable ``plan_gate_pass`` record (ADR-030 primitive).
+
+    Shared by ``plan-gate run`` (resolver="run", with the seat count + scope that
+    certified the pass) and ``plan-gate attest`` (resolver="attest"). Resolves the
+    repo root from ``args.repo_root`` when the CLI passes one, else ``git
+    rev-parse``, else cwd. Never raises — a record failure must never break the
+    plan-gate resolution it hangs off (the runtime audit trail stays authoritative).
+    """
+    try:
+        import subprocess as _sp  # noqa: PLC0415
+        import plan_gate_evidence  # noqa: PLC0415
+        root = repo_root
+        if not root:
+            try:
+                root = _sp.check_output(
+                    ["git", "rev-parse", "--show-toplevel"],
+                    text=True, stderr=_sp.DEVNULL,
+                ).strip() or str(Path.cwd())
+            except Exception:  # noqa: BLE001
+                root = str(Path.cwd())
+        plan_gate_evidence.emit_plan_gate_pass(
+            repo_root=root, track_id=track_id, project_id=project_id,
+            resolver=resolver, timestamp=_now_utc(),
+            approval_id=approval_id, reason=reason,
+            seats=seats, scope=scope,
+        )
+        return True
+    except Exception:  # vnx-silent-except: evidence emission must never break the gate
+        return False
+
+
 def cmd_objective_add(args: argparse.Namespace) -> int:
     """Add an ad-hoc objective (track) without a ROADMAP edit.
 
@@ -2116,6 +2158,7 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
     1 = infra error (doc/track missing, panel could not run).
     """
     import plan_gate_panel
+    import plan_gate_enforcement as _pge
 
     state_dir = _resolve_state_dir(args.state_dir)
     doc = Path(args.doc)
@@ -2129,16 +2172,33 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
 
     data_dir = os.environ.get("VNX_DATA_DIR") or str(Path(state_dir).parent)
 
+    # Scope read-site (VNX_PLAN_GATE_COMPLEX_ONLY): classify the plan light/heavy
+    # from the plan doc itself (fail-closed to HEAVY on anything unjudgeable). A
+    # LIGHT plan under the flag runs the reduced panel; its PASS is still a REAL
+    # pass — it resolves the blocker AND writes a durable plan_gate_pass with
+    # resolver=run and the seat count that decided it. An unreadable doc is an
+    # infra error, never a scope decision.
+    try:
+        doc_text = doc.read_text(encoding="utf-8")
+    except OSError as exc:
+        print(f"plan doc unreadable: {doc}: {exc}", file=sys.stderr)
+        return 1
+    scope = _pge.plan_gate_scope(doc_text)
+
     # Resolve the panel composition from configs/plan_gate_panel.yaml (falling
-    # back to DEFAULT_PANEL when absent), then filter to --panel-seats for this
-    # single run. Both an invalid config and an unknown seat label fail LOUD
-    # here — a dropped seat reads as an abstention and turns into a REVISE via
-    # the fail-safe rule, so misconfiguration must surface before the panel runs.
+    # back to DEFAULT_PANEL when absent). An explicit --panel-seats always wins;
+    # otherwise a LIGHT-scope plan under VNX_PLAN_GATE_COMPLEX_ONLY runs the
+    # reduced 2-seat panel automatically. Both an invalid config and an unknown
+    # seat label fail LOUD here — a dropped seat reads as an abstention and
+    # turns into a REVISE via the fail-safe rule, so misconfiguration must
+    # surface before the panel runs.
     try:
         panel = plan_gate_panel.load_panel_seats()
         if args.panel_seats:
             requested = [s.strip() for s in args.panel_seats.split(",") if s.strip()]
             panel = plan_gate_panel.filter_panel_seats(panel, requested)
+        elif _pge.complex_only_active() and scope == _pge.LIGHT:
+            panel = plan_gate_panel.filter_panel_seats(panel, list(_pge.LIGHT_PANEL_LABELS))
     except Exception as exc:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
         return 1
@@ -2200,6 +2260,18 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
                 file=sys.stderr,
             )
             return 2
+        if resolved:
+            # A PASS that CLEARS the gate is a real pass for both scopes: write the
+            # durable, hash-chained plan_gate_pass record with resolver="run" and the
+            # seat count + scope that certified it. Before this, only `plan-gate
+            # attest` ever wrote a record, so the ledger was all-attest and the
+            # effectiveness probe read every gate as manually overridden even when
+            # the panel had actually converged (light and heavy alike).
+            _emit_plan_gate_pass_record(
+                repo_root=getattr(args, "repo_root", None),
+                track_id=args.track_id, project_id=args.project_id, resolver="run",
+                seats=len(panel), scope=scope,
+            )
         print(
             f"PASS — plan gate cleared. {_plan_blocker_oi(args.track_id)} "
             f"resolved={resolved}; track derived_status={derived}."
@@ -2340,25 +2412,11 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
     # record so the pass is verifiable at PR/merge time (the front link of the
     # requirements-traceability chain). Best-effort, unsigned bootstrap — the
     # runtime event above stays the authoritative audit; this never blocks attest.
-    try:
-        import subprocess as _sp  # noqa: PLC0415
-        import plan_gate_evidence  # noqa: PLC0415
-        _repo_root = getattr(args, "repo_root", None)
-        if not _repo_root:
-            try:
-                _repo_root = _sp.check_output(
-                    ["git", "rev-parse", "--show-toplevel"],
-                    text=True, stderr=_sp.DEVNULL,
-                ).strip() or str(Path.cwd())
-            except Exception:  # noqa: BLE001
-                _repo_root = str(Path.cwd())
-        plan_gate_evidence.emit_plan_gate_pass(
-            repo_root=_repo_root, track_id=track_id, project_id=project_id,
-            resolver="attest", timestamp=_now_utc(),
-            approval_id=approval_id, reason=reason,
-        )
-    except Exception:  # vnx-silent-except: evidence emission must never break attest
-        pass
+    _emit_plan_gate_pass_record(
+        repo_root=getattr(args, "repo_root", None),
+        track_id=track_id, project_id=project_id, resolver="attest",
+        approval_id=approval_id, reason=reason,
+    )
 
     post = tracks_lib.get_track(state_dir, track_id, project_id)
     derived = post.get("derived_status") if isinstance(post, dict) else None

--- a/tests/test_plan_gate_effectiveness_probe_oi888.py
+++ b/tests/test_plan_gate_effectiveness_probe_oi888.py
@@ -9,8 +9,9 @@ the OI-PLAN resolution count.
 Gap 2 (readability): the probe now reads the per-seat verdict ledger
 ``.vnx-attest/plan-gate-seats.ndjson`` (persisted by plan_gate_panel.run_panel).
 
-Gap 3 (visibility): the probe reports that the ``VNX_PLAN_GATE_COMPLEX_ONLY``
-scope-skip read-site is missing instead of staying silent.
+Gap 3 (visibility): the probe reports the ``VNX_PLAN_GATE_COMPLEX_ONLY``
+scope-skip read-site state instead of staying silent. Once the read-site exists
+(plan_gate_enforcement.plan_gate_scope, 2026-08-08) it reports ``present``.
 """
 from __future__ import annotations
 
@@ -162,23 +163,23 @@ def test_probe_signal_includes_seat_counts_when_present(tmp_path):
 
 
 # ---------------------------------------------------------------------------
-# Gap 3 — the missing scope-skip read-site is reported, not silent
+# Gap 3 — the scope-skip read-site state is reported, not silent
 # ---------------------------------------------------------------------------
 
-def test_probe_reports_missing_scope_skip_read_site_in_detail(tmp_path):
+def test_probe_reports_scope_skip_read_site_present_in_detail(tmp_path):
     result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
 
-    assert result.detail.get("scope_skip_read_site") == "missing"
+    assert result.detail.get("scope_skip_read_site") == "present"
 
 
-def test_probe_signal_mentions_missing_scope_skip_read_site(tmp_path):
+def test_probe_signal_mentions_scope_skip_read_site_present(tmp_path):
     append_chained_entry(_ledger_path(tmp_path), {
         "type": "plan_gate_pass", "track_id": "t1", "resolver": "run",
     })
 
     result = PlanGateEffectivenessProbe(repo_root=tmp_path, state_dir=tmp_path / "state").run()
 
-    assert "VNX_PLAN_GATE_COMPLEX_ONLY read-site MISSING" in result.signal
+    assert "VNX_PLAN_GATE_COMPLEX_ONLY scope-skip read-site present" in result.signal
 
 
 def test_unknown_state_still_reported_when_nothing_exists(tmp_path):

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -26,6 +26,8 @@ import tracks  # noqa: E402
 import track_reconciler  # noqa: E402
 import planning_cli  # noqa: E402
 import plan_gate_panel as pgp  # noqa: E402
+import plan_gate_enforcement as pge  # noqa: E402
+from ndjson_hash_chain import walk_chain  # noqa: E402
 
 
 # --------------------------------------------------------------------------
@@ -1882,3 +1884,88 @@ def test_cmd_plan_gate_run_rejects_unknown_panel_seat_label(tmp_path, monkeypatc
     rc = planning_cli.cmd_plan_gate_run(args)
     assert rc == 1
     assert run_called["n"] == 0  # the panel never ran
+
+
+def _fake_pass_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+    """A run_panel stub that always certifies PASS with the panel it was given."""
+    return {
+        "track_id": track_id, "project_id": project_id, "decision": "PASS",
+        "summary": {"decision": "PASS", "pass_count": len(panel),
+                    "revise_count": 0, "block_count": 0, "rationale": "ok"},
+        "panelists": [], "doc_truncation": {"truncated": False},
+    }
+
+
+def test_cmd_plan_gate_run_light_plan_runs_fewer_seats_than_heavy(tmp_path, monkeypatch):
+    """VNX_PLAN_GATE_COMPLEX_ONLY=1: a LIGHT plan runs the reduced 2-seat panel
+    while a HEAVY plan keeps the full panel — the scope read-site sizes the gate."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "1")
+    seen_panels: list = []
+
+    def _capturing_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+        seen_panels.append(panel)
+        return _fake_pass_run_panel(doc_path, track_id=track_id, project_id=project_id,
+                                    panel=panel, data_dir=data_dir, **kw)
+
+    monkeypatch.setattr(pgp, "run_panel", _capturing_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-light", "p1", "t", "shipped", phase="queued")
+    tracks.create_track(state_dir, "feat-heavy", "p1", "t", "shipped", phase="queued")
+
+    light_doc = tmp_path / "light.md"
+    light_doc.write_text("## Approach\nAdd a rename button to the dashboard view.\n", encoding="utf-8")
+    heavy_doc = tmp_path / "heavy.md"
+    heavy_doc.write_text("## Approach\nTouch dispatch_cli.py and a schema migration.\n", encoding="utf-8")
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-light", project_id="p1", state_dir=str(state_dir),
+        doc=str(light_doc), json=False, panel_seats=None,
+    ))
+    assert rc == 0
+    assert [s["label"] for s in seen_panels[0]] == list(pge.LIGHT_PANEL_LABELS)
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-heavy", project_id="p1", state_dir=str(state_dir),
+        doc=str(heavy_doc), json=False, panel_seats=None,
+    ))
+    assert rc == 0
+    assert [s["label"] for s in seen_panels[1]] == [m["label"] for m in pgp.DEFAULT_PANEL]
+
+
+def test_cmd_plan_gate_run_light_pass_writes_run_evidence_with_seats(tmp_path, monkeypatch):
+    """A successful LIGHT run writes a durable plan_gate_pass with resolver=run
+    carrying the seat count + scope that certified it — a light pass is a real pass."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "1")
+    monkeypatch.setattr(pgp, "run_panel", _fake_pass_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-light", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "light.md"
+    doc.write_text("## Approach\nAdd a rename button to the dashboard view.\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        track_id="feat-light", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None, repo_root=str(tmp_path),
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 0
+
+    ledger = tmp_path / ".vnx-attest" / "plan-gates.ndjson"
+    assert ledger.exists()
+    records = [rec for _ln, rec, _h in walk_chain(ledger)]
+    assert len(records) == 1
+    rec = records[0]
+    assert rec["type"] == "plan_gate_pass"
+    assert rec["track_id"] == "feat-light"
+    assert rec["resolver"] == "run"
+    assert rec["seats"] == len(pge.LIGHT_PANEL_LABELS)
+    assert rec["scope"] == "light"

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -1969,3 +1969,33 @@ def test_cmd_plan_gate_run_light_pass_writes_run_evidence_with_seats(tmp_path, m
     assert rec["resolver"] == "run"
     assert rec["seats"] == len(pge.LIGHT_PANEL_LABELS)
     assert rec["scope"] == "light"
+
+
+def test_cmd_plan_gate_run_pass_with_failed_evidence_is_loud_not_silent(tmp_path, monkeypatch, capsys):
+    """A PASS whose durable plan_gate_pass write fails must stay a PASS (exit 0)
+    but say so loudly on stderr - a light pass is only a real pass when the record
+    lands (the merge gate checks it), so a dropped write must not be quiet."""
+    import argparse
+    import plan_gate_evidence
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    monkeypatch.setattr(pgp, "run_panel", _fake_pass_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    # The evidence write fails (returns None) while the gate itself passes.
+    monkeypatch.setattr(plan_gate_evidence, "emit_plan_gate_pass", lambda **kw: None)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-ev", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nAdd a button to the dashboard.\n", encoding="utf-8")
+
+    args = argparse.Namespace(
+        track_id="feat-ev", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None, repo_root=str(tmp_path),
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 0  # gate resolution is NOT broken by the failed evidence write
+    captured = capsys.readouterr()
+    assert "plan_gate_pass evidence NOT written" in captured.err
+    # Nothing durable landed in the repo ledger.
+    assert not (tmp_path / ".vnx-attest" / "plan-gates.ndjson").exists()

--- a/tests/test_plan_gate_scope.py
+++ b/tests/test_plan_gate_scope.py
@@ -1,0 +1,125 @@
+"""The plan-gate scope read-site (VNX_PLAN_GATE_COMPLEX_ONLY, 2026-08-08).
+
+``plan_gate_enforcement.plan_gate_scope`` classifies a plan HEAVY or LIGHT from
+the operator's dividing line: HEAVY when the plan touches the dispatch-lane,
+store-resolution, a review-gate, or a central-DB schema (ADR-007); LIGHT in all
+other cases. Signals are derived from existing plan data (task_class tags,
+per-deliverable complexity, named paths), never a new manual field.
+
+Fail-closed: a plan we cannot judge (no text, no task_class, no complexity, no
+paths) resolves to HEAVY — a silent fallback to the cheap panel is exactly the
+failure this read-site exists to prevent.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import plan_gate_enforcement as pge  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: unknown / missing scope input resolves to HEAVY, never LIGHT
+# ---------------------------------------------------------------------------
+
+class TestFailClosed:
+    def test_none_plan_is_heavy(self):
+        assert pge.plan_gate_scope(None) == pge.HEAVY
+
+    def test_empty_plan_is_heavy(self):
+        assert pge.plan_gate_scope("") == pge.HEAVY
+        assert pge.plan_gate_scope("   \n  ") == pge.HEAVY
+
+    def test_missing_every_signal_is_heavy(self):
+        assert pge.plan_gate_scope(None, task_class=None, complexity=None, paths=[]) == pge.HEAVY
+
+    def test_unclassified_task_with_empty_plan_is_heavy(self):
+        # A task_class that is NOT inherently heavy still has no plan text to
+        # judge — fail-closed to heavy, never downgraded to light.
+        assert pge.plan_gate_scope(None, task_class="01_code_generation") == pge.HEAVY
+
+
+# ---------------------------------------------------------------------------
+# LIGHT: the operator's "all other cases"
+# ---------------------------------------------------------------------------
+
+class TestLight:
+    def test_generic_feature_plan_is_light(self):
+        plan = (
+            "## Problem\nUsers cannot rename widgets.\n"
+            "## Approach\nAdd a rename button to the dashboard view.\n"
+            "## Deliverables\n- **Task class**: 01_code_generation\n"
+        )
+        assert pge.plan_gate_scope(plan) == pge.LIGHT
+
+    def test_docs_plan_is_light(self):
+        plan = (
+            "## Problem\nThe README is stale.\n"
+            "## Approach\nUpdate the README and add a changelog entry.\n"
+            "**Task class**: 04_documentation\n"
+        )
+        assert pge.plan_gate_scope(plan) == pge.LIGHT
+
+    def test_light_plan_with_light_paths(self):
+        assert pge.plan_gate_scope(None, paths=["src/ui/dashboard.py"]) == pge.LIGHT
+
+    def test_low_complexity_is_light(self):
+        assert pge.plan_gate_scope(None, complexity="low") == pge.LIGHT
+
+
+# ---------------------------------------------------------------------------
+# HEAVY: touches the dispatch-lane, store-resolution, a review-gate, or a
+# central-DB schema (ADR-007)
+# ---------------------------------------------------------------------------
+
+class TestHeavy:
+    @pytest.mark.parametrize("marker", [
+        # dispatch-lane
+        "dispatch_cli", "provider_dispatch", "tmux_interactive_dispatch",
+        "subprocess_dispatch", "dispatch_bridge", "dispatch-lane", "dispatch lane",
+        "routing_policy", "smart_router", "dispatch_spec",
+        # store-resolution
+        "resolve_state_dir", "resolve_data_dir", "resolve_central_data_dir",
+        "project_root", "vnx_paths", "central store", "vnx_data_dir",
+        # review-gate
+        "review-gate", "review_gate", "review_floor", "review-floor",
+        "evidence_bound_gate", "codex_gate", "gemini_review", "verify_pr",
+        "merge gate", "merge-gate", "plan_gate_evidence", "phantom_guard",
+        # central-DB schema (ADR-007)
+        "adr-007", "central-db", "central_db", "track_open_items",
+        "runtime_coordination.db", "schema migration", "schema change",
+        "composite key", "unique constraint",
+    ])
+    def test_domain_marker_is_heavy(self, marker):
+        assert pge.plan_gate_scope(f"## Approach\nTouch {marker}.\n") == pge.HEAVY
+
+    def test_task_class_review_is_heavy(self):
+        assert pge.plan_gate_scope(None, task_class="02_code_review") == pge.HEAVY
+
+    def test_task_class_inline_in_doc_is_heavy(self):
+        plan = "## Deliverables\n- **Task class**: 02_code_review\n"
+        assert pge.plan_gate_scope(plan) == pge.HEAVY
+
+    def test_high_complexity_is_heavy(self):
+        assert pge.plan_gate_scope(None, complexity="high") == pge.HEAVY
+        assert pge.plan_gate_scope(None, complexity="critical") == pge.HEAVY
+
+    def test_complexity_inline_in_doc_is_heavy(self):
+        plan = "## Deliverables\n- **Complexity**: High\n"
+        assert pge.plan_gate_scope(plan) == pge.HEAVY
+
+    def test_paths_hitting_dispatch_lane_is_heavy(self):
+        assert pge.plan_gate_scope(None, paths=["scripts/lib/dispatch_cli.py"]) == pge.HEAVY
+
+    def test_case_insensitive_marker_match(self):
+        assert pge.plan_gate_scope("## Approach\nTouch Dispatch_CLI.\n") == pge.HEAVY
+
+
+if __name__ == "__main__":
+    sys.exit(__import__("pytest").main([__file__, "-v"]))

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -594,3 +594,60 @@ def test_plan_gate_attest_still_blocked_reports_plainly(tmp_path, capsys):
     assert _derived_status(sd, "T") == "blocked"  # but still blocked by the dependency
     assert len(_track_events(sd, "T", "plan_gate_attest")) == 1
     assert "STILL" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# _emit_plan_gate_pass_record return-value contract
+# ---------------------------------------------------------------------------
+
+def test_emit_plan_gate_pass_record_returns_false_when_evidence_not_written(tmp_path, monkeypatch):
+    """emit_plan_gate_pass returning None (a failed write, which never raises)
+    must surface as False - the old code ignored the return and always True.
+
+    Regression for the PR #1412 codex finding: emit_plan_gate_pass is documented
+    to return the appended record on success and None on any failure, so the
+    try/except around it cannot catch a failed write. None IS the failure signal.
+    """
+    import plan_gate_evidence
+    monkeypatch.setattr(plan_gate_evidence, "emit_plan_gate_pass", lambda **kw: None)
+
+    ok = planning_cli._emit_plan_gate_pass_record(
+        repo_root=str(tmp_path),
+        track_id="T", project_id="p1", resolver="run", seats=2, scope="light",
+    )
+    assert ok is False
+
+
+def test_emit_plan_gate_pass_record_returns_true_when_record_appended(tmp_path, monkeypatch):
+    """A successful append (a record comes back) reports True."""
+    import plan_gate_evidence
+    monkeypatch.setattr(
+        plan_gate_evidence, "emit_plan_gate_pass",
+        lambda **kw: {"type": "plan_gate_pass", "track_id": kw["track_id"]},
+    )
+
+    ok = planning_cli._emit_plan_gate_pass_record(
+        repo_root=str(tmp_path),
+        track_id="T", project_id="p1", resolver="run", seats=2, scope="light",
+    )
+    assert ok is True
+
+
+def test_plan_gate_attest_failed_evidence_write_is_loud_not_silent(tmp_path, capsys, monkeypatch):
+    """A failed durable write must not break attest (exit 0, blocker resolved)
+    but must be reported loudly on stderr - never a silent success."""
+    import plan_gate_evidence
+    monkeypatch.setattr(plan_gate_evidence, "emit_plan_gate_pass", lambda **kw: None)
+
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="shipped", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    assert _derived_status(sd, "T") == "blocked"
+
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="shipped pre-gate", approval_id="APR-2")
+    )
+    assert rc == 0  # gate resolution not broken by the failed evidence write
+    assert _plan_oi_resolved_at(sd, "T") is not None
+    captured = capsys.readouterr()
+    assert "plan_gate_pass evidence NOT written" in captured.err

--- a/vnx_cli/commands/subsystems.py
+++ b/vnx_cli/commands/subsystems.py
@@ -75,8 +75,8 @@ SUBSYSTEM_DESCRIPTIONS: Dict[str, str] = {
     ),
     "plan-gate-panel": "5-model deliberation panel for plan-first enforcement.",
     "plan-gate-task-class-scope": (
-        "Restrict panel to complex features; skip trivial tracks. Enforcement "
-        "deferred to review-floor-enforcer."
+        "Restrict panel to complex features; run trivial tracks on a reduced "
+        "2-seat panel (scope read-site: plan_gate_enforcement.plan_gate_scope)."
     ),
     "cheap-recon-scout": "Cheap-model scout recon pre-pass in the dispatch door (fail-open).",
     "horizon-planning": "Autonomous roadmap auto-next loading (starts work unattended).",


### PR DESCRIPTION
## What

Builds the missing "licht/zwaar" (light/heavy) read-site for the plan-gate. `VNX_PLAN_GATE_COMPLEX_ONLY` was registered in `config_registry` and the panel-seat filtering machinery existed (`filter_panel_seats`, `--panel-seats`), but nothing read the flag — every plan ran the full 5-seat panel.

## Dividing line (operator decision)

A plan is **HEAVY** when it touches the dispatch-lane, store-resolution, a review-gate, or a central-DB schema (ADR-007); **LIGHT** in all other cases. Signals derive from data that already exists on the plan — per-deliverable `task_class` tags, complexity fields, and the paths it names — never a new manual scope field. **Fail-closed**: unknown/missing scope resolves to HEAVY, never LIGHT.

## Changes

- **`plan_gate_enforcement.py`**: `plan_gate_scope()` (the read-site) + `complex_only_active()` + the reduced 2-seat LIGHT panel (opus + kimi, the smallest panel that can still certify a pass).
- **`planning_cli.py`**: `cmd_plan_gate_run` reads scope, reduces the panel for a LIGHT plan under the flag, and emits a durable `plan_gate_pass` with `resolver="run"` on a converged PASS — carrying `seats` (how many decided it) and `scope`. Previously only `plan-gate attest` wrote records, so the ledger was all-attest and the effectiveness probe read every gate as manually overridden even when the panel had converged.
- **`plan_gate_evidence.py`**: `emit_plan_gate_pass` accepts `seats` + `scope` fields.
- **`plan_gate_effectiveness_probe.py`**: `scope_skip_read_site` now reports `"present"`; the all-attest → `degraded` health clause (OI-888) is unchanged and covered by its existing test.
- **`config_registry.py` / `subsystems.py` / `SUBSYSTEMS.md`**: descriptions + status reflect the live read-site.

## Verification

- 4 fail-without-fix tests: light plan runs fewer seats than heavy; unknown/missing scope → heavy; light PASS writes `resolver="run"` with `seats`; probe `degraded` on all-attest ledger.
- Targeted suite: **226 passed**. Fail-without-fix proven by stash (50 fail with source stashed, pass when restored).
- `check_subsystems_drift.py`: OK (26 subsystems) — SUBSYSTEMS.md line 30 matches reality.
- CI lint-patterns gate: exit 0.
- 5 pre-existing failures in `test_plan_gate_panel.py` (`sqlite3 no such column: output_ref`) fail identically at clean HEAD — reported as Open Items, unrelated to this dispatch.

Dispatch-ID: `20260808-ds-plangate-scope`

🤖 Generated with [Claude Code](https://claude.com/claude-code)