### PR TITLE
fix(dispatch): anchor fabric hook artifacts at the fabric install root (OI-1089)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -65,7 +65,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/build_t0_state_hook.sh\"'"
+            "command": "bash -c 'if [ -n \"${VNX_HOME:-}\" ] && [ -f \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\" ]; then exec bash \"${VNX_HOME}/scripts/hooks/build_t0_state_hook.sh\"; else printf \"[vnx] build_t0_state_hook artifact MISSING (VNX_HOME unset or hook absent); t0_state.json will not refresh\\n\" >&2; exit 0; fi'"
           }
         ]
       },

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -346,7 +346,10 @@ def _sanitize_session_name(raw: str) -> str:
 # tool call and the guard did nothing (OI-1089 finding 1). The command bakes in
 # the fabric-absolute path (resolved via vnx_paths._resolve_vnx_home) and fails
 # LOUD when the artifact is missing while still exiting 0, so a broken install is
-# visible but never blocks a tool call.
+# visible but never blocks a tool call. The path travels to the inner shell via
+# the VNX_WORKER_SCOPE_HOOK environment variable (shlex.quoted at the export),
+# never through bash -c string interpolation, so shell metacharacters in the
+# fabric path cannot alter the executed command (PR #1413).
 _WORKER_SCOPE_HOOK_MATCHER = "Bash|Write|Edit|MultiEdit"
 
 
@@ -354,16 +357,24 @@ def _worker_scope_hook_command() -> str:
     """The PreToolUse hook command, anchored at the fabric install root.
 
     The hook path is embedded at registration time so the command needs no
-    git/consumer-relative lookup at fire time. The fail-loud guard keeps the
-    hook non-blocking (exit 0) but makes a missing artifact unmistakable.
+    git/consumer-relative lookup at fire time. It is handed to the inner shell
+    via an environment variable rather than interpolated into the bash -c body:
+    a fabric path containing shell metacharacters (space, ``;``, ``$(...)``) is
+    passed literally and can never change what the command executes. The value
+    is shlex.quoted at the export assignment so it survives the outer shell
+    parse intact. The fail-loud guard keeps the hook non-blocking (exit 0) but
+    makes a missing artifact unmistakable.
     """
     hook = _resolve_vnx_home() / "scripts" / "hooks" / "pretooluse_worker_scope_enforce.sh"
-    hook_str = str(hook)
+    quoted_hook = shlex.quote(str(hook))
     return (
-        "bash -c 'if [ -f \"{hook}\" ]; then exec bash \"{hook}\"; else "
-        "printf \"[vnx] worker-scope hook artifact MISSING at {hook}; "
-        "worker-scope guard is NOT enforcing\\n\" >&2; exit 0; fi'"
-    ).format(hook=hook_str)
+        "export VNX_WORKER_SCOPE_HOOK={quoted_hook}; "
+        "bash -c 'if [ -f \"$VNX_WORKER_SCOPE_HOOK\" ]; then "
+        "exec bash \"$VNX_WORKER_SCOPE_HOOK\"; else "
+        "printf \"[vnx] worker-scope hook artifact MISSING at %s; "
+        "worker-scope guard is NOT enforcing\\n\" \"$VNX_WORKER_SCOPE_HOOK\" >&2; "
+        "exit 0; fi'"
+    ).format(quoted_hook=quoted_hook)
 
 
 def _worker_scope_hook_entry() -> dict:

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -41,6 +41,7 @@ logger = logging.getLogger(__name__)
 from tmux_worktree import WorktreeAllocateError, WorktreeHandle, allocate, classify, reap  # noqa: E402
 from pr_enforcement import PrEnforcementResult  # noqa: E402
 from worker_pane_classifier import classify_worker_pane  # noqa: E402
+from vnx_paths import _resolve_vnx_home  # noqa: E402
 
 # Work-started gate outcome codes (OI-863): a worker blocked on a permission
 # prompt is ALIVE and recoverable — one relayed answer saves it — so it must not
@@ -338,14 +339,31 @@ def _sanitize_session_name(raw: str) -> str:
 # Worker-scope PreToolUse enforcement hook wiring (spike E1/E2; default OFF)
 # ---------------------------------------------------------------------------
 
-# Command resolves the hook relative to the worktree it fires in (git rev-parse
-# returns the worktree root there) — same pattern as the existing spawn-blocker
-# hooks in .claude/settings.json.
-_WORKER_SCOPE_HOOK_COMMAND = (
-    "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
-    "/scripts/hooks/pretooluse_worker_scope_enforce.sh\"'"
-)
+# Command anchors the hook at the FABRIC install root, never the worktree or
+# consumer root. The worker-scope enforcement script ships only with the fabric;
+# a dispatch worktree created from a consumer repo has no scripts/hooks/, so the
+# old git-rev-parse command failed with a silent "No such file or directory" per
+# tool call and the guard did nothing (OI-1089 finding 1). The command bakes in
+# the fabric-absolute path (resolved via vnx_paths._resolve_vnx_home) and fails
+# LOUD when the artifact is missing while still exiting 0, so a broken install is
+# visible but never blocks a tool call.
 _WORKER_SCOPE_HOOK_MATCHER = "Bash|Write|Edit|MultiEdit"
+
+
+def _worker_scope_hook_command() -> str:
+    """The PreToolUse hook command, anchored at the fabric install root.
+
+    The hook path is embedded at registration time so the command needs no
+    git/consumer-relative lookup at fire time. The fail-loud guard keeps the
+    hook non-blocking (exit 0) but makes a missing artifact unmistakable.
+    """
+    hook = _resolve_vnx_home() / "scripts" / "hooks" / "pretooluse_worker_scope_enforce.sh"
+    hook_str = str(hook)
+    return (
+        "bash -c 'if [ -f \"{hook}\" ]; then exec bash \"{hook}\"; else "
+        "printf \"[vnx] worker-scope hook artifact MISSING at {hook}; "
+        "worker-scope guard is NOT enforcing\\n\" >&2; exit 0; fi'"
+    ).format(hook=hook_str)
 
 
 def _worker_scope_hook_entry() -> dict:
@@ -355,7 +373,7 @@ def _worker_scope_hook_entry() -> dict:
         "hooks": [
             {
                 "type": "command",
-                "command": _WORKER_SCOPE_HOOK_COMMAND,
+                "command": _worker_scope_hook_command(),
                 "timeout": 5000,
             }
         ],
@@ -398,7 +416,7 @@ def _write_worker_scope_hook_settings(worktree_root: Path) -> Path:
         isinstance(entry, dict)
         and any(
             isinstance(hook, dict)
-            and hook.get("command") == _WORKER_SCOPE_HOOK_COMMAND
+            and hook.get("command") == _worker_scope_hook_command()
             for hook in entry.get("hooks", [])
         )
         for entry in pre_tool_use

--- a/tests/test_pretooluse_worker_scope_enforce.py
+++ b/tests/test_pretooluse_worker_scope_enforce.py
@@ -348,10 +348,11 @@ class TestSubprocessLaneMarker(HookTestCase):
          ``--settings`` flag, so a headless ``claude -p`` spawn falls back to the
          same cwd-based settings discovery that the spike proved live for the
          tmux lane (E1/E2) — the discovery mechanism is identical by construction.
-      2. The registration written at worktree allocation resolves the hook via
-         ``git rev-parse --show-toplevel`` from the process cwd, so ANY lane whose
-         cwd is the dispatch worktree discovers the same hook — no tmux-specific
-         machinery is involved in the hook path.
+      2. The registration written at worktree allocation anchors the hook at the
+         FABRIC install root (OI-1089 finding 1): the worker-scope script ships
+         only with the fabric, so the command bakes in the fabric-absolute path
+         (vnx_paths._resolve_vnx_home) and never resolves against a
+         consumer/worktree git top-level that lacks ``scripts/hooks/``.
       3. The hook assets the registration points at exist and are executable.
 
     What remains DEFERRED (explicit, per spike E4 recommendation): a live-fire
@@ -377,17 +378,29 @@ class TestSubprocessLaneMarker(HookTestCase):
             "cwd-based discovery is the mechanism the worktree hook wiring relies on",
         )
 
-    def test_hook_registration_uses_cwd_relative_resolution(self):
+    def test_hook_registration_anchors_at_fabric_root(self):
         from tmux_interactive_dispatch import _worker_scope_hook_entry
 
         sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
         entry = _worker_scope_hook_entry()
         command = entry["hooks"][0]["command"]
-        self.assertIn(
-            "git rev-parse --show-toplevel",
+        # OI-1089 finding 1: the hook ships only with the fabric. The command
+        # bakes in the fabric-absolute path at registration and must never fall
+        # back to a consumer/worktree git top-level that lacks scripts/hooks/.
+        self.assertNotIn(
+            "git rev-parse",
             command,
-            "hook command must resolve from the firing process's cwd so both lanes "
-            "discover it identically",
+            "hook command must not resolve against the firing cwd's git top-level",
+        )
+        self.assertIn(
+            "scripts/hooks/pretooluse_worker_scope_enforce.sh",
+            command,
+            "hook command must point at the fabric hook artifact",
+        )
+        self.assertIn(
+            "MISSING",
+            command,
+            "a missing fabric artifact must fail loud instead of silently no-oping",
         )
         self.assertEqual(entry["matcher"], "Bash|Write|Edit|MultiEdit")
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -4895,6 +4895,45 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
         self.assertIn("pretooluse_worker_scope_enforce.sh", result.stderr)
         self.assertIn("NOT enforcing", result.stderr)
 
+    def test_hook_command_path_metachars_are_literal_not_executed(self):
+        """PR #1413 regression: a fabric path containing shell metacharacters
+        (space + ``$(touch ...)`` command substitution and a ``;``) must be passed
+        to the hook literally. The old implementation interpolated the path into
+        the bash -c body, so a ``$(...)`` in the path executed on every hook fire
+        and a ``;`` could start a second command.
+        """
+        from tmux_interactive_dispatch import _worker_scope_hook_command
+
+        injected_marker = self.state_dir / "injected-marker"
+        fabric_root = self.state_dir / f"fabric $(touch {injected_marker}); root"
+        hook = fabric_root / "scripts" / "hooks" / "pretooluse_worker_scope_enforce.sh"
+        hook.parent.mkdir(parents=True)
+        ran_marker = self.state_dir / "hook-executed"
+        hook.write_text(
+            f"#!/bin/bash\ntouch {shlex.quote(str(ran_marker))}\n", encoding="utf-8"
+        )
+
+        with patch(
+            "tmux_interactive_dispatch._resolve_vnx_home", return_value=fabric_root
+        ):
+            command = _worker_scope_hook_command()
+
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        # The hook artifact ran via the literal path, so the path resolved intact.
+        self.assertTrue(ran_marker.exists(), "hook must execute via the literal path")
+        # The $(touch ...) embedded in the path must NOT have executed. Under the
+        # pre-fix interpolation it fired on every hook run and created this file.
+        self.assertFalse(
+            injected_marker.exists(),
+            "shell metacharacters in the path must be literal, not executed",
+        )
+
     def test_t0_state_hook_registration_anchors_at_fabric_root(self):
         """OI-1089 finding 2: the fabric's own .claude/settings.json registers the
         t0_brief chain's build_t0_state_hook the same way — anchored at the fabric

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -4794,7 +4794,7 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
 
     def test_write_hook_settings_fresh_worktree(self):
         from tmux_interactive_dispatch import (
-            _WORKER_SCOPE_HOOK_COMMAND,
+            _worker_scope_hook_command,
             _write_worker_scope_hook_settings,
         )
 
@@ -4809,13 +4809,117 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
         entry = pre[0]
         self.assertEqual(entry["matcher"], "Bash|Write|Edit|MultiEdit")
         self.assertEqual(entry["hooks"][0]["type"], "command")
-        self.assertEqual(entry["hooks"][0]["command"], _WORKER_SCOPE_HOOK_COMMAND)
-        # The command resolves the hook from the worktree it fires in (cwd-based
-        # discovery), same pattern as the existing spawn-blocker hooks.
-        self.assertIn("git rev-parse --show-toplevel", entry["hooks"][0]["command"])
+        self.assertEqual(entry["hooks"][0]["command"], _worker_scope_hook_command())
+        # OI-1089 finding 1: the worker-scope script ships only with the fabric,
+        # so the command anchors at the fabric install root. It must NOT resolve
+        # against a consumer/worktree git top-level that lacks scripts/hooks/.
+        self.assertNotIn("git rev-parse", entry["hooks"][0]["command"])
         self.assertIn(
             "scripts/hooks/pretooluse_worker_scope_enforce.sh",
             entry["hooks"][0]["command"],
+        )
+        # Fail-loud guard: a missing artifact is reported, never silently ignored.
+        self.assertIn("MISSING", entry["hooks"][0]["command"])
+
+    def test_write_hook_settings_anchors_at_fabric_root_not_consumer(self):
+        """OI-1089 finding 1 regression: even when git rev-parse resolves to a
+        different (consumer) root, the hook command must fire the fabric copy."""
+        from tmux_interactive_dispatch import (
+            _worker_scope_hook_command,
+            _write_worker_scope_hook_settings,
+        )
+
+        fabric_root = self.state_dir / "fabric-root"
+        hook = fabric_root / "scripts" / "hooks" / "pretooluse_worker_scope_enforce.sh"
+        hook.parent.mkdir(parents=True)
+        hook.write_text("#!/bin/bash\n", encoding="utf-8")
+
+        # A consumer root that would have won under the old git-rev-parse lookup
+        # and does NOT contain scripts/hooks/ — the exact failure of finding 1.
+        consumer_root = self.state_dir / "consumer-worktree"
+        consumer_root.mkdir()
+
+        with patch(
+            "tmux_interactive_dispatch._resolve_vnx_home", return_value=fabric_root
+        ):
+            command = _worker_scope_hook_command()
+
+        wt = self.state_dir / "wt-anchored"
+        wt.mkdir()
+        with patch(
+            "tmux_interactive_dispatch._resolve_vnx_home", return_value=fabric_root
+        ):
+            _write_worker_scope_hook_settings(wt)
+        data = json.loads(
+            (wt / ".claude" / "settings.local.json").read_text(encoding="utf-8")
+        )
+        written = data["hooks"]["PreToolUse"][0]["hooks"][0]["command"]
+        self.assertEqual(written, command)
+        # The command points at the fabric copy even when fired from the consumer.
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            cwd=str(consumer_root),
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, result.stderr)
+        self.assertNotIn("No such file or directory", result.stderr)
+        self.assertNotIn("MISSING", result.stderr)
+        # git-rev-parse never appears in the command string.
+        self.assertNotIn("git rev-parse", command)
+
+    def test_hook_command_fails_loud_when_artifact_missing(self):
+        """OI-1089 DoD (b): a missing fabric artifact is NOT silently ignored.
+
+        The command stays non-blocking (exit 0, no block decision) but must print
+        an unmistakable [vnx] MISSING marker to stderr.
+        """
+        from tmux_interactive_dispatch import _worker_scope_hook_command
+
+        empty_fabric = self.state_dir / "fabric-empty"
+        empty_fabric.mkdir()
+        with patch(
+            "tmux_interactive_dispatch._resolve_vnx_home", return_value=empty_fabric
+        ):
+            command = _worker_scope_hook_command()
+
+        result = subprocess.run(
+            ["bash", "-c", command],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        self.assertEqual(result.returncode, 0, "fail-loud must stay non-blocking")
+        self.assertIn("MISSING", result.stderr)
+        self.assertIn("pretooluse_worker_scope_enforce.sh", result.stderr)
+        self.assertIn("NOT enforcing", result.stderr)
+
+    def test_t0_state_hook_registration_anchors_at_fabric_root(self):
+        """OI-1089 finding 2: the fabric's own .claude/settings.json registers the
+        t0_brief chain's build_t0_state_hook the same way — anchored at the fabric
+        root (VNX_HOME), never a consumer/worktree git top-level, fail-loud when
+        the artifact is missing."""
+        settings_path = SCRIPT_DIR.parent / ".claude" / "settings.json"
+        self.assertTrue(settings_path.exists(), "repo settings.json must exist")
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        hooks = data["hooks"]["SessionStart"]
+        commands = [
+            h.get("command", "")
+            for e in hooks
+            if isinstance(e, dict)
+            for h in e.get("hooks", [])
+            if "build_t0_state_hook.sh" in h.get("command", "")
+        ]
+        self.assertEqual(len(commands), 1, "exactly one build_t0_state_hook registration")
+        command = commands[0]
+        self.assertIn("${VNX_HOME:-", command, "VNX_HOME must be the primary anchor")
+        self.assertIn("scripts/hooks/build_t0_state_hook.sh", command)
+        self.assertIn("MISSING", command, "fail-loud guard must be present")
+        self.assertNotIn(
+            "git rev-parse --show-toplevel",
+            command,
+            "must not resolve against a consumer git top-level",
         )
 
     def test_write_hook_settings_merges_existing_and_is_idempotent(self):


### PR DESCRIPTION
## What

Fabric-only hook scripts were resolved against the consumer worktree via `git rev-parse --show-toplevel`, which silently no-op'd the guard whenever the dispatch worktree had no `scripts/hooks/` of its own (per-Bash-call `No such file or directory`, exit 127, treated as non-blocking by Claude Code).

## Finding 1 — worker-scope PreToolUse hook (`scripts/lib/tmux_interactive_dispatch.py`)

The registration command baked in `$(git rev-parse --show-toplevel)` at worktree allocation. In a consumer dispatch worktree that resolves to the consumer root (no `scripts/hooks/`), the fabric-only `pretooluse_worker_scope_enforce.sh` was never found, so the worker-scope guard did nothing.

Fix: the command now embeds the fabric-absolute path resolved via `vnx_paths._resolve_vnx_home()` at registration time, and fails loud (`[vnx] worker-scope hook artifact MISSING...`) while staying non-blocking (exit 0).

## Finding 2 — t0_brief's `build_t0_state_hook` SessionStart registration (`.claude/settings.json`)

The fabric's own settings.json registered `build_t0_state_hook.sh` (the t0_brief/t0_state refresh chain) with the same git-rev-parse pattern. OI-1073 (#1404) fixed the hook script and consumer templates but left this registration stale.

Fix: anchored at `${VNX_HOME}` (exported by `bin/vnx`) with the same fail-loud guard; a session without VNX_HOME reports the missing artifact instead of silently skipping the state refresh.

## Definition of done

- [x] (a) Test proving the hook resolves against the fabric root even when git rev-parse returns a different (consumer) root — `test_write_hook_settings_anchors_at_fabric_root_not_consumer` and `test_t0_state_hook_registration_anchors_at_fabric_root`
- [x] (b) Test proving a missing fabric artifact is not silently ignored — `test_hook_command_fails_loud_when_artifact_missing` + static MISSING-guard assertions
- [x] (c) Both findings covered
- [x] (d) Step-1 measurement in the dispatch report under `## Verification`

## Verification

`pytest tests/test_tmux_interactive_dispatch.py tests/test_pretooluse_worker_scope_enforce.py tests/unit/vnx_cli/commands/test_doctor.py` → 230 passed.

One pre-existing environmental failure unrelated to this change: `tests/test_context_rotation.py::TestWriteT0Handoff::test_project_id_scoped_across_two_projects` fails identically without this PR when run from a worktree (nested-worktree state-resolution artifact, documented in project memory).

Dispatch-ID: 20260808-ds-oi1089-fabric-root

🤖 Generated with [Claude Code](https://claude.com/claude-code)