### PR TITLE
fix(headless): honor isolation=worktree, hard-fail on worktree creation (OI-1045)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -495,11 +495,62 @@ def run_envelope_headless_plan(
         bundle_dir=Path(plan.instruction_file).parent,
     )
 
-    start = datetime.now(timezone.utc)
-    result = ClaudeSubprocessAdapter().run(enriched_spec)
-    end = datetime.now(timezone.utc)
+    from dispatch_worktree_isolation import (  # noqa: PLC0415
+        create_dispatch_worktree,
+        remove_dispatch_worktree,
+        resolve_consumer_project_root,
+    )
 
-    report_path, receipt_path = _govern(enriched_spec, result, start, end, integrity=integrity)
+    wt_path: Optional[Path] = None
+    try:
+        _consumer_project_root = resolve_consumer_project_root()
+        wt_path = create_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+    except Exception as _wt_exc:
+        _isolation_error = (
+            f"isolation required but worktree creation failed "
+            f"for {plan.dispatch_id}: {_wt_exc} — aborting; no shared-checkout fallback"
+        )
+        logger.error("run_envelope_headless_plan: %s", _isolation_error)
+        _fail_result = _AdapterResult(
+            returncode=1,
+            completion_text="",
+            status="failure",
+            error=_isolation_error,
+        )
+        _fail_start = _fail_end = datetime.now(timezone.utc)
+        report_path, receipt_path = _govern(
+            enriched_spec, _fail_result, _fail_start, _fail_end, integrity=integrity
+        )
+        return EnvelopeResult(
+            status="failure",
+            returncode=1,
+            report_path=report_path,
+            receipt_path=receipt_path,
+            completion_text="",
+            error=_isolation_error,
+        )
+
+    _phantom_diff: Optional[str] = None
+    try:
+        start = datetime.now(timezone.utc)
+        result = ClaudeSubprocessAdapter().run(enriched_spec, cwd=wt_path)
+        end = datetime.now(timezone.utc)
+        try:
+            _phantom_diff = _resolve_phantom_diff(
+                plan.dispatch_id,
+                base_ref=plan.base_ref or "origin/main",
+                wt_path=wt_path,
+                repo=_consumer_project_root,
+            )
+        except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
+            _phantom_diff = None
+    finally:
+        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+
+    report_path, receipt_path = _govern(
+        enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,
+        base_ref=plan.base_ref or "origin/main",
+    )
 
     return EnvelopeResult(
         status=result.status,

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -415,77 +415,77 @@
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 396,
+      "line": 412,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 433,
+      "line": 449,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 472,
+      "line": 488,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 478,
+      "line": 494,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 478,
+      "line": 494,
       "mechanism": "monkeypatch",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 483,
+      "line": 499,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 522,
+      "line": 538,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 523,
+      "line": 539,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 550,
+      "line": 566,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 578,
+      "line": 594,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 579,
+      "line": 595,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -580,6 +580,90 @@
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 29,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 30,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 31,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_headless_plan"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 145,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 145,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 147,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 204,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 204,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 206,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 263,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 263,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 265,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
     },
     {
       "file": "tests/test_kimi_model_resolver.py",

--- a/tests/test_headless_worktree_isolation.py
+++ b/tests/test_headless_worktree_isolation.py
@@ -1,0 +1,275 @@
+"""test_headless_worktree_isolation.py — OI-1045: headless lane honors isolation=worktree.
+
+Verifies that:
+1. run_envelope_headless_plan creates a dispatch worktree and passes cwd=wt_path
+   to ClaudeSubprocessAdapter — the worker runs inside the worktree, not the
+   main checkout.
+2. Failed worktree creation hard-aborts the headless dispatch — no silent
+   fallback to the main checkout (the exact OI-1045 failure mode).
+
+These tests MUST fail on the pre-fix code (origin/main) and go green on the
+fix branch. Pure unit assertions — no worker spawn.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from dataclasses import replace
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+import dispatch_envelope
+from dispatch_envelope import (
+    EnvelopeSpec,
+    _AdapterResult,
+    run_envelope_headless_plan,
+)
+from dispatch_internal import issue_permit
+from dispatch_plan import ExecutionPlan, RuntimeSnapshot, compile_plan
+from dispatch_spec import (
+    DispatchPath,
+    DispatchSpec,
+    Isolation,
+    Provider,
+    ValidatedSpec,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _fake_instruction_file(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text("# Test instruction\n", encoding="utf-8")
+    return f
+
+
+def _make_headless_spec(
+    *,
+    tmp_path: Path,
+    pr_id: Optional[str] = None,
+    target_slot: str = "T1",
+    model: str = "sonnet",
+) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-headless-wt",
+        staging_id="staging-headless-wt",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot=target_slot,
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        model=model,
+        pr_id=pr_id,
+        allow_headless=True,
+        headless_reason="test",
+    )
+
+
+def _make_vspec_from_spec(spec: DispatchSpec) -> ValidatedSpec:
+    instruction_text = "# Test instruction\n"
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=instruction_text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(instruction_text.encode("utf-8")).hexdigest(),
+    )
+
+
+def _healthy_snapshot() -> RuntimeSnapshot:
+    all_slots = ["T0", "T1", "T2", "T3"]
+    return RuntimeSnapshot(
+        staging_promoted=True,
+        target_health={slot: "healthy" for slot in all_slots},
+        target_capable={slot: True for slot in all_slots},
+    )
+
+
+def _fake_adapter_success() -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — worktree created and cwd passed to adapter
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessWorktreeIsolation:
+    """OI-1045: headless lane must create a worktree and run the adapter inside it."""
+
+    def test_worktree_created_and_cwd_passed_to_adapter(self, tmp_path: Path) -> None:
+        """run_envelope_headless_plan creates a worktree and passes cwd to the adapter."""
+        spec = _make_headless_spec(tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless", f"Expected claude_headless, got {plan.lane}"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+        fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{plan.dispatch_id}"
+        fake_wt_path.mkdir(parents=True)
+
+        captured_cwd: list = []
+
+        def capture_adapter_run(spec_arg, cwd=None, **kwargs):
+            captured_cwd.append(cwd)
+            return _fake_adapter_success()
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_receipt, fake_receipt)
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=fake_wt_path), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          side_effect=capture_adapter_run), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        assert result.status == "success", (
+            f"Expected success, got status={result.status!r} error={result.error!r}"
+        )
+        assert captured_cwd, (
+            "ClaudeSubprocessAdapter.run() was never called — cwd not captured"
+        )
+        passed_cwd = captured_cwd[0]
+        assert passed_cwd is not None, (
+            "cwd was not passed to ClaudeSubprocessAdapter.run() — "
+            "worker would run in the main checkout"
+        )
+        assert passed_cwd == fake_wt_path, (
+            f"Expected cwd={fake_wt_path} (the dispatch worktree), "
+            f"got cwd={passed_cwd} — worker runs in the wrong directory"
+        )
+
+    def test_failed_worktree_creation_aborts_headless_dispatch(self, tmp_path: Path) -> None:
+        """When create_dispatch_worktree raises, the headless dispatch fails hard."""
+        spec = _make_headless_spec(tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+
+        adapter_called = []
+
+        def refuse_create(*args, **kwargs):
+            raise RuntimeError("simulated worktree creation failure")
+
+        def capture_adapter_run(*args, **kwargs):
+            adapter_called.append(True)
+            return _fake_adapter_success()
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_receipt, fake_receipt)
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   side_effect=refuse_create), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          side_effect=capture_adapter_run), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        # OI-1045 core assertion: the dispatch must FAIL, not silently continue.
+        assert result.status == "failure", (
+            f"Expected status='failure' when worktree creation fails, "
+            f"got status={result.status!r} — the dispatch fell through to "
+            f"the adapter without a worktree (the exact OI-1045 bug)"
+        )
+        assert not adapter_called, (
+            "ClaudeSubprocessAdapter.run() was called despite worktree creation "
+            "failure — the adapter should never be reached on a failed worktree"
+        )
+        assert result.error is not None, (
+            "result.error must carry the isolation error message"
+        )
+        assert "worktree creation failed" in result.error, (
+            f"Error message should mention worktree creation failure, got: {result.error!r}"
+        )
+
+    def test_worktree_removed_after_successful_dispatch(self, tmp_path: Path) -> None:
+        """The worktree is torn down (remove_dispatch_worktree called) after a successful dispatch."""
+        spec = _make_headless_spec(tmp_path=tmp_path)
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+        fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{plan.dispatch_id}"
+        fake_wt_path.mkdir(parents=True)
+
+        remove_calls = []
+
+        def capture_remove(*args, **kwargs):
+            remove_calls.append(True)
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_receipt, fake_receipt)
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=fake_wt_path), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree",
+                   side_effect=capture_remove), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        assert result.status == "success"
+        assert remove_calls, (
+            "remove_dispatch_worktree was never called — teardown is missing; "
+            "the worktree would leak on every headless dispatch"
+        )


### PR DESCRIPTION
## What

`run_envelope_headless_plan()` now creates a dispatch worktree via `create_dispatch_worktree()`, passes `cwd=wt_path` to `ClaudeSubprocessAdapter`, and hard-aborts (not silently falls back to the main checkout) when worktree creation fails. The worktree is torn down in a `finally` block, mirroring the provider-path pattern in `run_envelope_plan()`.

## Why

The headless lane ignored `isolation=worktree` — the worker ran in the main checkout instead of the dispatch worktree. Measured on dispatch `20260805-oi1044-heartbeat-r2` (OI-1045): 420 lines over 4 files + 1 new test written to the main checkout while the worktree sat empty, then got reaped.

Root cause: `run_envelope_headless_plan()` at `dispatch_envelope.py:499` called `ClaudeSubprocessAdapter().run(enriched_spec)` without `cwd`, and no worktree was ever created. The adapter accepts `cwd` (line 120 of `envelope_adapters_claude.py`) but the headless path never passed it.

## Changes

- **`scripts/lib/dispatch_envelope.py`**: `run_envelope_headless_plan()` now:
  1. Imports `create_dispatch_worktree` / `remove_dispatch_worktree` / `resolve_consumer_project_root`
  2. Creates a dispatch worktree before the adapter call
  3. Hard-fails (returns failure `EnvelopeResult`) when worktree creation raises — no silent fallback
  4. Passes `cwd=wt_path` to `ClaudeSubprocessAdapter().run()`
  5. Tears down the worktree in a `finally` block
  6. Captures phantom diff before teardown (parity with provider path)

- **`tests/test_headless_worktree_isolation.py`** (new): 3 unit tests
  1. `test_worktree_created_and_cwd_passed_to_adapter` — asserts `cwd=wt_path` reaches the adapter
  2. `test_failed_worktree_creation_aborts_headless_dispatch` — asserts hard-fail (status=failure, adapter never called)
  3. `test_worktree_removed_after_successful_dispatch` — asserts teardown runs

- **`tests/data/dispatch_envelope_census.json`**: regenerated for the new test file

## Verification

59/59 tests pass:
- `tests/test_headless_worktree_isolation.py`: 3 passed
- `tests/test_dispatch_envelope_field_propagation.py`: 4 passed
- `tests/test_dispatch_envelope_characterization.py`: 52 passed

## What stays the same

- Tmux lane (`claude_tmux_subscription`): unchanged — already binds via its own worktree mechanism
- Provider lane (`run_envelope_plan`): unchanged — already bound correctly

Dispatch-ID: 20260808-ds-l4-headless-worktree

🤖 Generated with [Claude Code](https://claude.com/claude-code)