### PR TITLE
feat(provider): classify before reap, preserve unpushed work (L3 lane-conformity rows 5/6)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -374,7 +374,7 @@ def run_envelope_plan(
         except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
             _phantom_diff = None
     finally:
-        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root, terminal_id=plan.target_id)
 
     report_path, receipt_path = _govern(
         enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,
@@ -545,7 +545,7 @@ def run_envelope_headless_plan(
         except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
             _phantom_diff = None
     finally:
-        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+        remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root, terminal_id=plan.target_id)
 
     report_path, receipt_path = _govern(
         enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -181,6 +181,9 @@ def _write_claim_atomic(
     *,
     worktree_path: Path,
     project_root: Path,
+    base_sha: str = "",
+    base_ref: str = "",
+    branch: str = "",
 ) -> dict:
     """Claim *worktree_path* for *dispatch_id* with an O_EXCL write.
 
@@ -188,6 +191,11 @@ def _write_claim_atomic(
     file already exists the write fails and the caller must decide whether the
     existing claim is the same dispatch (idempotent re-entry) or a different
     one (OI-861 crossing → WorktreeIdentityConflict).
+
+    *base_sha*, *base_ref*, and *branch* are stored for teardown classification
+    (L3 provider-lane reap): the claim carries enough metadata to construct a
+    ``WorktreeHandle`` for ``tmux_worktree.classify()`` without re-deriving
+    values that may have shifted since the worktree was created.
     """
     safe_id = _sanitize_dispatch_id(dispatch_id)
     path = _claim_path(safe_id, project_root)
@@ -197,6 +205,9 @@ def _write_claim_atomic(
         "safe_id": safe_id,
         "worktree_path": str(Path(worktree_path).resolve()),
         "claimed_at": time.time(),
+        "base_sha": base_sha,
+        "base_ref": base_ref,
+        "branch": branch,
     }
     try:
         with open(path, "x", encoding="utf-8") as fh:
@@ -451,6 +462,20 @@ def create_dispatch_worktree(
                 base_ref, (exc.stderr or "").strip(),
             )
 
+    # Resolve base_sha BEFORE adding the worktree — needed for teardown
+    # classification (L3 provider-lane reap).  Mirrors tmux_worktree.allocate().
+    try:
+        sha_result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", base_ref],
+            check=True, capture_output=True, text=True,
+        )
+        base_sha = sha_result.stdout.strip()
+    except subprocess.CalledProcessError as exc:
+        raise RuntimeError(
+            f"create_dispatch_worktree: cannot resolve {base_ref!r}: "
+            f"{(exc.stderr or '').strip()}"
+        ) from exc
+
     with _worktree_lock(root):
         # OI-861 identity check BEFORE creating: if this worktree already exists
         # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
@@ -492,9 +517,18 @@ def create_dispatch_worktree(
 
         # Claim the freshly-created worktree atomically (O_EXCL).  From here on
         # the worktree's identity is bound to dispatch_id and no other dispatch
-        # may reuse it.
+        # may reuse it.  The claim carries base_sha + base_ref + branch so
+        # teardown (L3 provider-lane reap) can construct a WorktreeHandle for
+        # classification without re-deriving values that may have shifted.
         try:
-            _write_claim_atomic(dispatch_id, worktree_path=wt_path, project_root=root)
+            _write_claim_atomic(
+                dispatch_id,
+                worktree_path=wt_path,
+                project_root=root,
+                base_sha=base_sha,
+                base_ref=base_ref,
+                branch=branch_name,
+            )
         except WorktreeClaimError:
             raced = _read_claim(dispatch_id, root)
             if raced is not None:
@@ -509,118 +543,161 @@ def remove_dispatch_worktree(
     dispatch_id: str,
     *,
     project_root: Optional[Path] = None,
+    terminal_id: str = "",
 ) -> None:
     """Remove the ephemeral dispatch worktree.  Idempotent.
 
-    Called on both success and failure paths — the worker's pushed branch
-    survives on origin; only the local working tree is removed.
+    **L3 provider-lane reap (2026-08-08):** the worktree is CLASSIFIED before
+    removal using the shared ``tmux_worktree.classify()`` — the same single
+    implementation the tmux lane uses.  The classification determines whether
+    the branch must be preserved (``committed`` → local branch kept, ``dirty``
+    → entire worktree locked).  A failed remote check (ls-remote timeout,
+    network error) is fail-closed: the classification falls back to
+    ``committed`` and the branch survives.
 
-    Before removing the worktree, kills any processes still running inside it
-    (OI-873): a SessionStart hook spawned from the worktree can survive the
-    dispatch and hold the coordination DB write lock, blocking every fleet-wide
-    track write.  Process cleanup happens OUTSIDE the worktree lock so it never
-    blocks concurrent worktree creation.
+    When *terminal_id* is provided, a ``provider_teardown_worktree`` event is
+    emitted via ``EventStore`` with the same metadata fields
+    (``worktree_state``, ``branch_kept_local``, ``branch_kept_remote``,
+    ``preserved_path``) as the tmux lane's ``interactive_teardown_worktree``.
+
+    Called on both success and failure paths.  Best-effort — never raises.
     """
     root = _resolve_project_root(project_root)
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
 
     if not wt_path.exists():
-        # Nothing to remove.  Drop any stale claim so a later dispatch mapping
-        # to this safe id can claim cleanly (idempotent, never raises).
         _clear_claim(dispatch_id, root)
         log.debug("remove_dispatch_worktree: already absent: %s", wt_path)
         return
 
     # OI-861 hard refusal on teardown: never reap a worktree that is stamped
-    # for a DIFFERENT dispatch id.  This is the "one's worktree reaped
-    # mid-flight by the other's completion" half of the race.
+    # for a DIFFERENT dispatch id.
     claim = _read_claim(dispatch_id, root)
     if claim is not None:
         _claim_belongs_to_or_raise(dispatch_id, claim, wt_path)
 
-    # OI-873: kill processes still running inside this worktree BEFORE
-    # attempting removal.  A zombie hook (bash + python child) will hold
-    # the coordination DB lock and its CWD under the worktree path;
-    # lsof +D catches both.
-    try:
-        from worktree_process_cleanup import kill_worktree_processes  # noqa: PLC0415
-        kill_worktree_processes(wt_path)
-    except Exception as _proc_exc:
-        log.warning(
-            "remove_dispatch_worktree: process cleanup failed for %s: %s — "
-            "continuing with worktree removal",
-            dispatch_id, _proc_exc,
-        )
+    # ── L3: classify before removing ──────────────────────────────────────
+    # Build a WorktreeHandle from the claim so we can call the single
+    # canonical classify() in tmux_worktree — no duplicate classification.
+    # Fall back to safe defaults when the claim predates the L3 fields.
+    safe_id = _sanitize_dispatch_id(dispatch_id)
+    _claim_base_sha = (claim or {}).get("base_sha", "")
+    _claim_branch = (claim or {}).get("branch", "") or f"dispatch/{safe_id}"
+    _claim_base_ref = (claim or {}).get("base_ref", "") or "origin/main"
 
-    # OI-877: also reap process groups recorded for this dispatch at spawn
-    # time.  A dispatch process whose repo-root resolved to the MAIN checkout
-    # has nothing open inside the worktree, so the lsof scan cannot see it —
-    # the recorded PGID is the only handle that still reaches it (even after
-    # it was reparented to launchd / PPID 1).  Keep the worktree scan above;
-    # this is a second membership source, not a replacement.
-    try:
-        from dispatch_process_registry import (  # noqa: PLC0415
-            clear_dispatch_pgids,
-            kill_dispatch_pgids,
-        )
-        kill_dispatch_pgids(dispatch_id, repo_root=root)
-        clear_dispatch_pgids(dispatch_id, repo_root=root)
-    except Exception as _pgid_exc:
-        log.warning(
-            "remove_dispatch_worktree: pgid-based process cleanup failed for "
-            "%s: %s — continuing with worktree removal",
-            dispatch_id, _pgid_exc,
-        )
-
-    with _worktree_lock(root):
+    # If the claim is missing base_sha (pre-L3 claim), derive it from the
+    # base ref at teardown time.  This is a fallback: the base ref may have
+    # advanced since the worktree was created, but a stale base_sha is still
+    # safer than skipping classification entirely.
+    if not _claim_base_sha:
         try:
-            subprocess.run(
-                ["git", "worktree", "remove", "--force", str(wt_path)],
-                cwd=str(root),
-                check=True,
-                capture_output=True,
-                text=True,
+            sha_result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", _claim_base_ref],
+                check=True, capture_output=True, text=True,
             )
-            log.info("dispatch worktree removed: %s", wt_path)
-        except subprocess.CalledProcessError as exc:
+            _claim_base_sha = sha_result.stdout.strip()
+        except subprocess.CalledProcessError:
             log.warning(
-                "git worktree remove failed: %s; falling back to shutil.rmtree",
-                (exc.stderr or "").strip(),
+                "remove_dispatch_worktree: cannot resolve base_ref %r for %s; "
+                "treating as dirty (fail-closed)",
+                _claim_base_ref, dispatch_id,
             )
-            resolved = wt_path.resolve()
-            # Safety: refuse to rmtree a path outside the project root.
-            resolved.relative_to(root)
-            if wt_path.is_symlink():
-                raise RuntimeError(
-                    f"refusing rmtree: {wt_path} is a symlink"
-                )
-            shutil.rmtree(str(resolved), ignore_errors=True)
+            _claim_base_sha = ""
 
+    from tmux_worktree import WorktreeHandle, classify, reap  # noqa: PLC0415
+
+    handle = WorktreeHandle(
+        path=wt_path,
+        branch=_claim_branch,
+        base_sha=_claim_base_sha,
+        base_ref=_claim_base_ref,
+        dispatch_id=safe_id,
+    )
+
+    classification = classify(handle)
+    log.info(
+        "remove_dispatch_worktree: classified %s as %s (branch=%s base_sha=%s)",
+        dispatch_id, classification, _claim_branch,
+        _claim_base_sha[:8] if _claim_base_sha else "?",
+    )
+
+    # ── OI-873 / OI-877: process cleanup ─────────────────────────────────
+    # Kill processes still running inside this worktree BEFORE removal.
+    # Only needed when the worktree WILL be removed (clean/pushed/committed);
+    # dirty worktrees are preserved — their processes may still be useful.
+    if classification in ("clean", "pushed", "committed"):
         try:
-            subprocess.run(
-                ["git", "worktree", "prune"],
-                cwd=str(root),
-                check=True,
-                capture_output=True,
-                text=True,
+            from worktree_process_cleanup import kill_worktree_processes  # noqa: PLC0415
+            kill_worktree_processes(wt_path)
+        except Exception as _proc_exc:
+            log.warning(
+                "remove_dispatch_worktree: process cleanup failed for %s: %s — "
+                "continuing with worktree removal",
+                dispatch_id, _proc_exc,
             )
-        except subprocess.CalledProcessError as exc:
-            log.warning("git worktree prune failed: %s", (exc.stderr or "").strip())
+        try:
+            from dispatch_process_registry import (  # noqa: PLC0415
+                clear_dispatch_pgids,
+                kill_dispatch_pgids,
+            )
+            kill_dispatch_pgids(dispatch_id, repo_root=root)
+            clear_dispatch_pgids(dispatch_id, repo_root=root)
+        except Exception as _pgid_exc:
+            log.warning(
+                "remove_dispatch_worktree: pgid-based process cleanup failed for "
+                "%s: %s — continuing with worktree removal",
+                dispatch_id, _pgid_exc,
+            )
 
-        # The worktree is gone — release its identity claim so a later dispatch
-        # mapping to the same safe id can claim cleanly.
+    # ── L3: reap per classification ───────────────────────────────────────
+    reap_result = reap(handle, classification)
+
+    # Clear the claim when the worktree was removed (clean/pushed/committed).
+    # A dirty worktree stays claimed so a later dispatch mapping to the same
+    # safe id knows this slot is occupied.
+    if reap_result.removed:
         _clear_claim(dispatch_id, root)
 
-    # Best-effort: delete the local dispatch branch (it lives on origin).
-    safe_id = _sanitize_dispatch_id(dispatch_id)
-    branch_name = f"dispatch/{safe_id}"
-    try:
-        subprocess.run(
-            ["git", "branch", "-D", branch_name],
-            cwd=str(root),
-            capture_output=True,
-            text=True,
-        )
-        log.debug("dispatch branch deleted locally: %s", branch_name)
-    except Exception as exc:
-        log.debug("branch deletion failed for %s: %s", branch_name, exc)
+    # ── L3: emit worktree_state event ─────────────────────────────────────
+    if terminal_id:
+        try:
+            from event_store import EventStore  # noqa: PLC0415
+            store = EventStore()
+            store.append(
+                terminal_id,
+                {
+                    "type": "provider_teardown_worktree",
+                    "dispatch_id": dispatch_id,
+                    "data": {
+                        "worktree_state": classification,
+                        "branch_kept_local": reap_result.branch_kept_local,
+                        "branch_kept_remote": reap_result.branch_kept_remote,
+                        "preserved_path": str(reap_result.preserved_path)
+                        if reap_result.preserved_path
+                        else None,
+                    },
+                },
+            )
+            if classification == "dirty":
+                store.append(
+                    terminal_id,
+                    {
+                        "type": "provider_teardown_preserved",
+                        "dispatch_id": dispatch_id,
+                        "data": {
+                            "preserved_path": str(reap_result.preserved_path)
+                            if reap_result.preserved_path
+                            else None,
+                        },
+                    },
+                )
+            log.info(
+                "remove_dispatch_worktree: emitted provider_teardown_worktree "
+                "state=%s for %s",
+                classification, dispatch_id,
+            )
+        except Exception as _event_exc:
+            log.warning(
+                "remove_dispatch_worktree: event emission failed for %s: %s",
+                dispatch_id, _event_exc,
+            )

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1363,7 +1363,7 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         return 0
     finally:
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_claude(args: argparse.Namespace) -> int:
@@ -1490,19 +1490,26 @@ def _prepare_provider_workdir(
     return isolation_worktree, worker_cwd
 
 
-def _remove_provider_worktree(dispatch_id: str) -> None:
+def _remove_provider_worktree(dispatch_id: str, *, terminal_id: str = "") -> None:
     """Remove the isolated worktree for a provider dispatch.  Best-effort; idempotent.
 
     Resolves the same consumer project_root as _create_provider_worktree —
     otherwise the __file__ fallback would try to remove a worktree that was
     never created there (in a central install), silently leaking the real one.
+
+    When *terminal_id* is provided, a ``provider_teardown_worktree`` event is
+    emitted via EventStore (L3 provider-lane reap).
     """
     try:
         from dispatch_worktree_isolation import (  # noqa: PLC0415
             remove_dispatch_worktree,
             resolve_consumer_project_root,
         )
-        remove_dispatch_worktree(dispatch_id, project_root=resolve_consumer_project_root())
+        remove_dispatch_worktree(
+            dispatch_id,
+            project_root=resolve_consumer_project_root(),
+            terminal_id=terminal_id,
+        )
         logger.info("provider isolation: worktree removed (dispatch=%s)", dispatch_id)
     except Exception as exc:
         logger.warning(
@@ -1514,6 +1521,8 @@ def _remove_provider_worktree(dispatch_id: str) -> None:
 def _finish_provider_worktree(
     dispatch_id: str,
     isolation_worktree: Optional[Path],
+    *,
+    terminal_id: str = "",
 ) -> None:
     """Remove normal provider worktrees while preserving benchmark output."""
     if isolation_worktree is None:
@@ -1525,7 +1534,7 @@ def _finish_provider_worktree(
             dispatch_id,
         )
         return
-    _remove_provider_worktree(dispatch_id)
+    _remove_provider_worktree(dispatch_id, terminal_id=terminal_id)
 
 
 def _dispatch_codex(args: argparse.Namespace) -> int:
@@ -1602,7 +1611,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         # Safety net: archive+clear when an unexpected exception bypassed
         # _emit_governance (idempotent after a normal emit — see helper).
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
@@ -2052,7 +2061,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         # Safety net: archive+clear when an unexpected exception bypassed
         # _emit_governance (idempotent after a normal emit — see helper).
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_kimi(args: argparse.Namespace) -> int:
@@ -2147,7 +2156,7 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         # Safety net: archive+clear when an unexpected exception bypassed
         # _emit_governance (idempotent after a normal emit — see helper).
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
@@ -2257,7 +2266,7 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         # Safety net: archive+clear when an unexpected exception bypassed
         # _emit_governance (idempotent after a normal emit — see helper).
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_glm_harness(args: argparse.Namespace) -> int:
@@ -2318,7 +2327,7 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         return 0
     finally:
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _dispatch_gemini(args: argparse.Namespace) -> int:
@@ -2393,7 +2402,7 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         # Safety net: archive+clear when an unexpected exception bypassed
         # _emit_governance (idempotent after a normal emit — see helper).
         _event_store_safety_net(event_store, args)
-        _finish_provider_worktree(args.dispatch_id, isolation_worktree)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 _MLX_MODEL_MAP: dict[str, str] = {

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -782,7 +782,7 @@ if __name__ == "__main__":
         if _isolated and _isolation_wt_path is not None:
             _set_active_worktree(None)
             try:
-                _remove_wt(args.dispatch_id, project_root=_isolation_project_root)
+                _remove_wt(args.dispatch_id, project_root=_isolation_project_root, terminal_id=args.terminal_id)
             except Exception as _rm_exc:
                 import logging as _log_mod
                 _log_mod.getLogger(__name__).warning(

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -545,7 +545,11 @@ class TestEnvelopeWorktreeIsolation:
         assert adapter_calls[0]["cwd"] == _FAKE_WT_PATH, (
             f"expected cwd={_FAKE_WT_PATH}, got cwd={adapter_calls[0]['cwd']}"
         )
-        mock_remove.assert_called_once_with("wt-cwd-test", project_root=_fake_consumer_root)
+        # teardown carries terminal_id=plan.target_id (dispatch_envelope.py) —
+        # pin the full call contract, not a hardcoded 'T1' that happens to match.
+        mock_remove.assert_called_once_with(
+            "wt-cwd-test", project_root=_fake_consumer_root, terminal_id=plan.target_id
+        )
 
     def test_worktree_removed_on_spawn_failure(self, tmp_path):
         """remove_dispatch_worktree is called even when ProviderAdapter.run raises."""
@@ -567,7 +571,11 @@ class TestEnvelopeWorktreeIsolation:
             with pytest.raises(RuntimeError, match="spawn exploded"):
                 run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
 
-        mock_remove.assert_called_once_with("wt-rm-fail-test", project_root=_fake_consumer_root)
+        # teardown carries terminal_id=plan.target_id (dispatch_envelope.py) —
+        # pin the full call contract, not a hardcoded 'T1' that happens to match.
+        mock_remove.assert_called_once_with(
+            "wt-rm-fail-test", project_root=_fake_consumer_root, terminal_id=plan.target_id
+        )
 
     def test_worktree_creation_failure_aborts_dispatch(self, tmp_path):
         """Worktree creation failure → dispatch aborts (status=failure, rc!=0), spawn NOT called."""

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -12,6 +12,8 @@ Verifies (PR-PROVIDER-ISO / PR-7):
 
 from __future__ import annotations
 
+import json
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
@@ -120,7 +122,7 @@ class TestCodexIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-codex-001")
-        mock_remove.assert_called_once_with("iso-codex-001")
+        mock_remove.assert_called_once_with("iso-codex-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_no_isolation_when_env_unset(self):
@@ -172,7 +174,7 @@ class TestCodexIsolation:
                 with pytest.raises(RuntimeError, match="simulated"):
                     provider_dispatch._dispatch_codex(args)
 
-        mock_remove.assert_called_once_with("fail-codex")
+        mock_remove.assert_called_once_with("fail-codex", terminal_id="T1")
 
 
 # ---------------------------------------------------------------------------
@@ -205,7 +207,7 @@ class TestGeminiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-gemini-001")
-        mock_remove.assert_called_once_with("iso-gemini-001")
+        mock_remove.assert_called_once_with("iso-gemini-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_no_isolation_when_env_unset(self):
@@ -268,7 +270,7 @@ class TestKimiIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-kimi-001")
-        mock_remove.assert_called_once_with("iso-kimi-001")
+        mock_remove.assert_called_once_with("iso-kimi-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_no_isolation_when_env_unset(self):
@@ -337,7 +339,7 @@ class TestLiteLLMIsolation:
 
         assert exit_code == 0
         mock_create.assert_called_once_with("iso-litellm-001")
-        mock_remove.assert_called_once_with("iso-litellm-001")
+        mock_remove.assert_called_once_with("iso-litellm-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
     def test_no_isolation_when_env_unset(self):
@@ -405,7 +407,7 @@ class TestProviderWorktreeHelpers:
         with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=consumer_root), \
              patch("dispatch_worktree_isolation.remove_dispatch_worktree") as mock_remove:
             provider_dispatch._remove_provider_worktree("remove-ok-test")
-        mock_remove.assert_called_once_with("remove-ok-test", project_root=consumer_root)
+        mock_remove.assert_called_once_with("remove-ok-test", project_root=consumer_root, terminal_id="")
 
     def test_remove_best_effort_when_resolver_raises(self):
         """A resolver failure must also be swallowed — remove is best-effort end-to-end."""
@@ -555,3 +557,417 @@ class TestLiteLLMIsolationFailLoud:
         assert exit_code == 1
         mock_create.assert_called_once_with("fail-loud-litellm")
         assert spawn_called == [], "spawn_litellm must NOT be called when worktree creation fails"
+
+
+# ---------------------------------------------------------------------------
+# L3 provider-lane reap: classification, branch preservation, event emission
+# ---------------------------------------------------------------------------
+
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    """Create a bare origin + local clone with an initial commit.
+
+    Returns the local clone path (the project root).
+    Mirrors the fixture in test_tmux_worktree.py.
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(bare), str(local)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "main"],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(
+        ["git", "-C", str(local), "add", "README.md"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "commit", "-m", "initial"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+class TestProviderLaneReapClassification:
+    """L3: remove_dispatch_worktree must classify before removing, using the
+    single canonical classify() from tmux_worktree — no duplicate logic.
+    """
+
+    def test_committed_work_survives_teardown(self, tmp_path, monkeypatch):
+        """Provider worktree with local unpushed commits: branch preserved.
+
+        Without the L3 fix, remove_dispatch_worktree unconditionally force-deletes
+        the local branch (git branch -D).  With the fix, classify() detects local
+        commits not on origin → 'committed' → reap() keeps the branch.
+        """
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "l3-committed-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Make a local commit (not pushed).
+        (wt_path / "work.txt").write_text("unpushed work\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "work.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "worker commit"],
+            check=True, capture_output=True,
+        )
+
+        safe_id = dwi._sanitize_dispatch_id(dispatch_id)
+        branch_name = f"dispatch/{safe_id}"
+
+        # Verify the branch exists before teardown.
+        branches_before = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branch_name in branches_before
+
+        remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Worktree directory is gone.
+        assert not wt_path.exists()
+
+        # Branch is STILL THERE (committed → kept locally).
+        branches_after = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branch_name in branches_after, (
+            f"L3 FAIL: branch {branch_name} was deleted — unpushed commits lost"
+        )
+
+    def test_dirty_worktree_is_preserved(self, tmp_path, monkeypatch):
+        """Provider worktree with uncommitted changes: worktree locked, not removed.
+
+        Without the L3 fix, remove_dispatch_worktree would force-remove the worktree
+        (git worktree remove --force), losing uncommitted changes.
+        """
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "l3-dirty-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Leave an uncommitted change (dirty state).
+        (wt_path / "dirty.txt").write_text("uncommitted\n")
+
+        assert wt_path.is_dir()
+        remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Worktree directory MUST still exist (dirty → preserved).
+        assert wt_path.is_dir(), (
+            "L3 FAIL: dirty worktree was removed — uncommitted changes lost"
+        )
+
+    def test_classification_reuses_single_implementation(self, tmp_path, monkeypatch):
+        """classify() is imported from tmux_worktree — no duplicate classification.
+
+        This test asserts that remove_dispatch_worktree calls the canonical
+        tmux_worktree.classify(), not a copy or reimplementation.
+        Verifies via a clean worktree: classify() returns 'clean'.
+        """
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "l3-clean-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+        safe_id = "l3-clean-1"
+        branch_name = f"dispatch/{safe_id}"
+
+        remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Clean worktree: directory gone, branch gone.
+        assert not wt_path.exists()
+        branches = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branches == ""
+
+    def test_worktree_state_event_emitted(self, tmp_path, monkeypatch):
+        """Teardown emits provider_teardown_worktree event via EventStore.
+
+        The event must carry worktree_state, branch_kept_local,
+        branch_kept_remote, and preserved_path — the same fields as the
+        tmux lane's interactive_teardown_worktree.
+        """
+        from unittest.mock import MagicMock, patch
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        mock_store = MagicMock()
+        mock_store.append = MagicMock()
+
+        dispatch_id = "l3-event-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        with patch("event_store.EventStore", return_value=mock_store):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Verify two append calls: provider_teardown_worktree + (not provider_teardown_preserved for clean)
+        append_calls = mock_store.append.call_args_list
+        assert len(append_calls) >= 1, "L3 FAIL: no event emitted"
+
+        # First call: provider_teardown_worktree
+        first_call_args = append_calls[0][0]
+        terminal = first_call_args[0]
+        event = first_call_args[1]
+        assert terminal == "T1"
+        assert event["type"] == "provider_teardown_worktree"
+        assert "worktree_state" in event["data"]
+        assert "branch_kept_local" in event["data"]
+        assert "branch_kept_remote" in event["data"]
+        assert "preserved_path" in event["data"]
+
+    def test_dirty_worktree_emits_preserved_event(self, tmp_path, monkeypatch):
+        """Dirty worktree emits both provider_teardown_worktree AND
+        provider_teardown_preserved events.
+        """
+        from unittest.mock import MagicMock, patch
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        mock_store = MagicMock()
+        mock_store.append = MagicMock()
+
+        dispatch_id = "l3-dirty-event-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Leave an uncommitted change.
+        (wt_path / "unsaved.txt").write_text("pending\n")
+
+        with patch("event_store.EventStore", return_value=mock_store):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        append_calls = mock_store.append.call_args_list
+        event_types = [call[0][1]["type"] for call in append_calls]
+        assert "provider_teardown_worktree" in event_types
+        assert "provider_teardown_preserved" in event_types, (
+            "L3 FAIL: dirty worktree must emit provider_teardown_preserved"
+        )
+
+        # The teardown_worktree event must have worktree_state == "dirty"
+        teardown_event = next(
+            c[0][1] for c in append_calls
+            if c[0][1]["type"] == "provider_teardown_worktree"
+        )
+        assert teardown_event["data"]["worktree_state"] == "dirty"
+        assert teardown_event["data"]["preserved_path"] is not None
+        assert teardown_event["data"]["branch_kept_local"] is False
+        assert teardown_event["data"]["branch_kept_remote"] is False
+
+    def test_committed_worktree_emits_correct_metadata(self, tmp_path, monkeypatch):
+        """Committed worktree: event carries branch_kept_local=True."""
+        from unittest.mock import MagicMock, patch
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        mock_store = MagicMock()
+        mock_store.append = MagicMock()
+
+        dispatch_id = "l3-committed-event-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        (wt_path / "committed.txt").write_text("local only\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "committed.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "local commit"],
+            check=True, capture_output=True,
+        )
+
+        with patch("event_store.EventStore", return_value=mock_store):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Find the teardown event.
+        teardown_events = [
+            c[0][1] for c in mock_store.append.call_args_list
+            if c[0][1]["type"] == "provider_teardown_worktree"
+        ]
+        assert len(teardown_events) == 1
+        event = teardown_events[0]
+        assert event["data"]["worktree_state"] == "committed"
+        assert event["data"]["branch_kept_local"] is True
+        assert event["data"]["branch_kept_remote"] is False
+        assert event["data"]["preserved_path"] is None
+
+    def test_pushed_worktree_keeps_remote_branch(self, tmp_path, monkeypatch):
+        """Pushed worktree: worktree removed, branch deleted locally, remote ref intact."""
+        import dispatch_worktree_isolation as dwi
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "l3-pushed-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Make + push a commit.
+        (wt_path / "pushed.txt").write_text("pushed\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "pushed.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "pushed work"],
+            check=True, capture_output=True,
+        )
+        safe_id = dwi._sanitize_dispatch_id(dispatch_id)
+        branch_name = f"dispatch/{safe_id}"
+        subprocess.run(
+            ["git", "-C", str(wt_path), "push", "-u", "origin", branch_name],
+            check=True, capture_output=True,
+        )
+
+        remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Worktree gone.
+        assert not wt_path.exists()
+        # Local branch gone.
+        local_branches = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert local_branches == ""
+        # Remote ref still present.
+        remote_refs = subprocess.check_output(
+            ["git", "-C", str(local), "ls-remote", "origin", branch_name],
+            text=True,
+        ).strip()
+        assert branch_name in remote_refs
+
+    def test_fail_closed_on_missing_base_sha(self, tmp_path, monkeypatch):
+        """When the claim is missing base_sha (pre-L3), derive it or treat as dirty.
+
+        Fail-closed: a control that defaults to 'proceed' on uncertainty is no
+        control at all.  Missing base_sha → fail-safe (treat as dirty).
+        """
+        from unittest.mock import patch
+        from dispatch_worktree_isolation import (
+            _sanitize_dispatch_id,
+            _claim_path,
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        dispatch_id = "l3-no-basesha-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Strip base_sha from the claim to simulate a pre-L3 claim.
+        safe_id = _sanitize_dispatch_id(dispatch_id)
+        claim_path = _claim_path(safe_id, local)
+        import json
+        claim = json.loads(claim_path.read_text())
+        del claim["base_sha"]
+        claim_path.write_text(json.dumps(claim) + "\n")
+
+        # Make a local commit so this isn't trivially clean.
+        (wt_path / "work.txt").write_text("unpushed work\n")
+        subprocess.run(
+            ["git", "-C", str(wt_path), "add", "work.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(wt_path), "commit", "-m", "worker commit"],
+            check=True, capture_output=True,
+        )
+
+        # With base_sha derived from origin/main (success), classify should work.
+        remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        # Worktree should be gone (committed → disk removed).
+        assert not wt_path.exists()
+        # Branch should survive.
+        branch_name = f"dispatch/{safe_id}"
+        branches = subprocess.check_output(
+            ["git", "-C", str(local), "branch", "--list", branch_name],
+            text=True,
+        ).strip()
+        assert branch_name in branches, (
+            "L3 FAIL: branch was deleted — missing base_sha must fail-closed"
+        )


### PR DESCRIPTION
## What

Provider lane `remove_dispatch_worktree()` now classifies worktree state before removal — using the single canonical `tmux_worktree.classify()`, no duplicate implementation.

## Changes

### Core (dispatch_worktree_isolation.py)
- **`create_dispatch_worktree()`**: stores `base_sha`, `base_ref`, `branch` in the OI-861 claim so teardown can construct a `WorktreeHandle` without re-deriving stale values
- **`remove_dispatch_worktree()`** (rewritten):
  1. Classifies via `tmux_worktree.classify()` before removal
  2. Handles per class with tmux semantics: `committed` keeps branch, `dirty` locks worktree
  3. Fail-closed: remote check failure defaults to `committed` (preserves branch)
  4. Emits `provider_teardown_worktree` events with `worktree_state` metadata
  5. Process cleanup (OI-873/OI-877) only runs when worktree will be removed

### Callers
- `dispatch_envelope.py`, `provider_dispatch.py`, `subprocess_dispatch.py`: pass `terminal_id` to enable event emission

### Tests
- 8 new integration tests in `test_provider_dispatch_worktree_isolation.py` (TestProviderLaneReapClassification):
  - committed work survives teardown with branch preserved
  - dirty worktree is locked/preserved
  - clean worktree removes both worktree and branch
  - pushed worktree keeps remote ref intact
  - worktree_state event emitted with correct fields
  - dirty worktree emits preserved event
  - committed worktree emits correct metadata (branch_kept_local=True)
  - fail-closed on missing base_sha (pre-L3 claims)

## Verification
- All 51 tests pass (24 tmux_worktree + 27 provider_dispatch_worktree_isolation)
- Also verified: 14 tests in test_envelope_ringbuffer_teardown_oi902 + test_dispatch_worktree_identity_race
- Tmux lane behavior unchanged (its classify/reap are the canonical implementation being reused)

## Lane-conformity matrix
Closes rows 5 and 6 for the provider lane:
| # | Mechanism | provider (before) | provider (after) |
|---|---|---|---|
| 5 | Reap refuses unpushed commits | bindt niet | **bindt** |
| 6 | Teardown reports worktree_state | bindt niet | **bindt** |

Dispatch-ID: 20260808-ds-l3-provider-reap

🤖 Generated with [Claude Code](https://claude.com/claude-code)