### PR TITLE
feat(reconciler): read delivery markings — fail-closed hold + visible reason (OI-1098)

### DIFF
--- a/scripts/lib/objective_reconcile.py
+++ b/scripts/lib/objective_reconcile.py
@@ -9,6 +9,10 @@ Steps per run (executed in order):
                         track in the project (both check and apply modes).
   3. Nomination       — tracks with non-empty pr_ref, declared phase not in
                         {done, parked}.  Does NOT gate on derived_status.
+                        OI-1098: a track with ANY currently-linked PR
+                        explicitly marked delivery_kind != 'complete' is held
+                        (verdict 'delivery_hold', with reason) — never
+                        nominated, never silently dropped.
   4. Verification     — ``gh pr view <n> --json state,mergedAt`` per PR number.
                         MERGED results cached persistently (pr_state_cache.json);
                         non-MERGED states are re-checked on every run.
@@ -901,6 +905,7 @@ def run_reconcile(
             "counts": {k: 0 for k in (
                 "tracks", "nominated", "confirmed", "closed",
                 "closed_sibling", "open_pr", "unverified", "deferred", "stale",
+                "delivery_hold",
             )},
             "per_track": [],
         }
@@ -938,46 +943,69 @@ def run_reconcile(
     all_tracks = tracks_lib.list_tracks(state_dir, project_id)
     candidates: List[Dict[str, Any]] = []
     guarded_tracks: List[Dict[str, Any]] = []
-    for t in all_tracks:
-        phase = (t.get("phase") or "").strip()
-        pr_ref = (t.get("pr_ref") or "").strip()
-        if not pr_ref or phase in _SKIP_PHASES:
-            continue
-        pr_numbers = _parse_pr_numbers(pr_ref)
-        if not pr_numbers:
-            continue
+    held_tracks: List[Dict[str, Any]] = []
+    # OI-1098: one shared read-only connection for the per-track delivery-hold
+    # check (the nomination loop previously did no DB reads of its own).
+    hold_conn = track_reconciler._get_conn(state_dir)
+    try:
+        for t in all_tracks:
+            phase = (t.get("phase") or "").strip()
+            pr_ref = (t.get("pr_ref") or "").strip()
+            if not pr_ref or phase in _SKIP_PHASES:
+                continue
+            pr_numbers = _parse_pr_numbers(pr_ref)
+            if not pr_numbers:
+                continue
 
-        # Re-close guard: if a done→active reopen history row exists, compare
-        # its stamped pr_ref against the current pr_ref.
-        reopen_hist = _get_latest_done_to_active_history(state_dir, t["track_id"], project_id)
-        if reopen_hist is not None:
-            stamped_pr_ref = _parse_reopen_stamp(reopen_hist.get("reason") or "")
-            if stamped_pr_ref is None:
-                # Unparseable stamp — fail-closed.
-                guarded_tracks.append({
+            # OI-1098 fail-closed + visible: an explicit non-'complete'
+            # delivery marking on ANY currently-linked PR vetoes the
+            # nomination — and the track must stay VISIBLE in the report with
+            # the reason, never silently drop out of the candidate set.
+            hold = track_reconciler._delivery_hold(
+                hold_conn, t["track_id"], project_id, pr_ref
+            )
+            if hold is not None:
+                held_tracks.append({
                     "track_id": t["track_id"],
-                    "verdict": "reopened_guard",
+                    "verdict": "delivery_hold",
                     "pr_ref": pr_ref,
-                    "reason": "unparseable_reopen_stamp",
+                    "reason": hold["reason"],
                 })
                 continue
-            if stamped_pr_ref == pr_ref:
-                # pr_ref unchanged since reopen — skip.
-                guarded_tracks.append({
-                    "track_id": t["track_id"],
-                    "verdict": "reopened_guard",
-                    "pr_ref": pr_ref,
-                    "reason": "pr_ref_unchanged_since_reopen",
-                })
-                continue
-            # pr_ref changed — re-armed; fall through to normal nomination.
 
-        candidates.append({
-            "track_id": t["track_id"],
-            "pr_ref": pr_ref,
-            "pr_numbers": pr_numbers,
-            "phase": phase,
-        })
+            # Re-close guard: if a done→active reopen history row exists,
+            # compare its stamped pr_ref against the current pr_ref.
+            reopen_hist = _get_latest_done_to_active_history(state_dir, t["track_id"], project_id)
+            if reopen_hist is not None:
+                stamped_pr_ref = _parse_reopen_stamp(reopen_hist.get("reason") or "")
+                if stamped_pr_ref is None:
+                    # Unparseable stamp — fail-closed.
+                    guarded_tracks.append({
+                        "track_id": t["track_id"],
+                        "verdict": "reopened_guard",
+                        "pr_ref": pr_ref,
+                        "reason": "unparseable_reopen_stamp",
+                    })
+                    continue
+                if stamped_pr_ref == pr_ref:
+                    # pr_ref unchanged since reopen — skip.
+                    guarded_tracks.append({
+                        "track_id": t["track_id"],
+                        "verdict": "reopened_guard",
+                        "pr_ref": pr_ref,
+                        "reason": "pr_ref_unchanged_since_reopen",
+                    })
+                    continue
+                # pr_ref changed — re-armed; fall through to normal nomination.
+
+            candidates.append({
+                "track_id": t["track_id"],
+                "pr_ref": pr_ref,
+                "pr_numbers": pr_numbers,
+                "phase": phase,
+            })
+    finally:
+        hold_conn.close()
 
     nominated = len(candidates)
 
@@ -998,12 +1026,13 @@ def run_reconcile(
                 "reason": gh_health,
             }
             for c in candidates
-        ] + guarded_tracks
+        ] + guarded_tracks + held_tracks
         counts = {
             "tracks": total_tracks, "nominated": nominated, "confirmed": 0,
             "closed": 0, "closed_sibling": 0, "open_pr": 0,
             "unverified": len(candidates), "deferred": 0, "stale": 0,
             "reopened_guard": len(guarded_tracks),
+            "delivery_hold": len(held_tracks),
         }
         summary = {
             "run_id": run_id, "project_id": project_id, "mode": mode,
@@ -1028,6 +1057,7 @@ def run_reconcile(
         "closed": 0, "closed_sibling": 0, "open_pr": 0,
         "unverified": 0, "deferred": 0, "stale": 0,
         "reopened_guard": len(guarded_tracks),
+        "delivery_hold": len(held_tracks),
     }
     confirmed_candidates: List[Dict[str, Any]] = []
     per_track: List[Dict[str, Any]] = []
@@ -1169,8 +1199,11 @@ def run_reconcile(
             elif action == "stale_candidate":
                 counts["stale"] += 1
 
-    # Add re-close guarded tracks to the per-track report.
+    # Add re-close guarded and delivery-held tracks to the per-track report.
+    # OI-1098: held tracks MUST stay visible — a track that silently drops
+    # out of the report is as wrong as one that closes too early.
     per_track.extend(guarded_tracks)
+    per_track.extend(held_tracks)
 
     # ------------------------------------------------------------------ step 6
     # Summary + history.

--- a/scripts/lib/track_reconciler.py
+++ b/scripts/lib/track_reconciler.py
@@ -68,6 +68,104 @@ def _parse_pr_numbers(pr_ref: Optional[str]) -> FrozenSet[int]:
     return frozenset(nums)
 
 
+def _delivery_hold(
+    conn: sqlite3.Connection,
+    track_id: str,
+    project_id: str,
+    pr_ref: Optional[str],
+) -> Optional[Dict[str, Any]]:
+    """OI-1098: delivery-marking hold for the done-derivation and nomination.
+
+    Returns None when the track is NOT held; otherwise a dict::
+
+        {"held": True, "partial": N, "complete": C, "unmarked": U,
+         "total": M, "reason": "<operator-readable>"}
+
+    Rule (fail-closed, decision taken in OI-1098): a track is held when ANY
+    PR in its CURRENT pr_ref has an explicit track_pr_delivery row whose
+    delivery_kind is not 'complete' — one explicit 'partial' marking vetoes
+    every PR-evidence-based 'done' derivation and the reconcile nomination.
+
+    Legacy handling (measured on the vnx-dev tracks DB, 2026-08-09): the only
+    delivery_kind values in practice are 'partial' (29 rows) and 'complete'
+    (4 rows), enforced by the 0032 CHECK constraint. A PR with NO row is NOT
+    the same as an explicit 'partial': planning_cli's link path writes a row
+    for EVERY PR in the call (``--delivery`` defaults to 'partial'), so a
+    missing row can only mean the PR was linked before migration 0032 existed.
+    Treating such unmarked legacy PRs as 'partial' would silently freeze
+    every pre-0032 track — the same invisible-drop failure this fix exists to
+    prevent, at fleet scale. So: unmarked PRs do NOT hold; only explicit
+    non-'complete' markings do.
+
+    Fail-closed edges (mirror close_track_if_done's OI-829 gate):
+      - An unrecognized delivery_kind on an existing row is logged at ERROR
+        and treated as a hold (never silently read as 'complete').
+      - When the track_pr_delivery table is absent (pre-0032 DB), there is
+        nothing explicit to hold on: returns None (legacy behaviour).
+
+    Only rows whose pr_number is in the CURRENT pr_ref count — a stale row
+    left behind by an unlinked PR must not hold the track.
+    """
+    nums = _parse_pr_numbers(pr_ref)
+    if not nums:
+        return None
+    has_table = bool(
+        conn.execute(
+            "SELECT 1 FROM sqlite_master WHERE type='table' AND name='track_pr_delivery'"
+        ).fetchone()
+    )
+    if not has_table:
+        return None  # migration 0032 not applied to this DB — no explicit markings exist
+    rows = conn.execute(
+        "SELECT pr_number, delivery_kind FROM track_pr_delivery "
+        "WHERE track_id = ? AND project_id = ?",
+        (track_id, project_id),
+    ).fetchall()
+    partial = 0
+    complete = 0
+    corrupt = 0
+    for row in rows:
+        try:
+            pn = int(row["pr_number"])
+        except (TypeError, ValueError):
+            continue
+        if pn not in nums:
+            continue  # stale row from an unlinked PR — must not hold
+        kind = row["delivery_kind"]
+        if kind == "complete":
+            complete += 1
+        elif kind == "partial":
+            partial += 1
+        else:
+            corrupt += 1
+            log.error(
+                "track_pr_delivery: unrecognized delivery_kind %r for "
+                "project_id=%r track_id=%r pr_number=%r — failing closed "
+                "(delivery hold), not raising: this runs inside sweep loops "
+                "with no per-track try/except",
+                kind, project_id, track_id, row["pr_number"],
+            )
+    held_count = partial + corrupt
+    if held_count == 0:
+        return None
+    total = len(nums)
+    unmarked = total - partial - complete - corrupt
+    reason = (
+        f"delivery hold: {held_count} of {total} linked PRs not marked "
+        f"'complete' ({partial} explicit 'partial')"
+    )
+    if corrupt:
+        reason += f"; {corrupt} unrecognized delivery_kind (fail-closed)"
+    return {
+        "held": True,
+        "partial": partial,
+        "complete": complete,
+        "unmarked": unmarked,
+        "total": total,
+        "reason": reason,
+    }
+
+
 def _load_merged_prs_from_gh(state_path: Path, ttl_seconds: int = 600) -> FrozenSet[int]:
     """Opt-in git-grounded merged-PR source. Cache-first (``pr_merged_cache.json``,
     TTL ~10 min) so the SessionStart hot path rarely shells out; network call is
@@ -447,7 +545,7 @@ def reconcile_track(
         conn.commit()
 
         track_row = conn.execute(
-            "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+            "SELECT phase, pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
             (track_id, project_id),
         ).fetchone()
         declared = track_row["phase"] if track_row else None
@@ -463,6 +561,15 @@ def reconcile_track(
         }
         if derived == "blocked":
             result["blocking_detail"] = _blocking_detail(conn, track_id, project_id)
+        elif derived != "done":
+            # OI-1098: a withheld nomination must be VISIBLE. When the track
+            # did not derive 'done' and an explicit delivery marking holds it,
+            # carry the operator-readable reason in the result.
+            hold = _delivery_hold(
+                conn, track_id, project_id, track_row["pr_ref"] if track_row else None
+            )
+            if hold is not None:
+                result["delivery_hold"] = hold
         return result
     finally:
         conn.close()
@@ -504,7 +611,7 @@ def peek_derived_status(
         )
         derived = _compute_derived_status(conn, track_id, project_id, merged)
         track_row = conn.execute(
-            "SELECT phase FROM tracks WHERE track_id = ? AND project_id = ?",
+            "SELECT phase, pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
             (track_id, project_id),
         ).fetchone()
         declared = track_row["phase"] if track_row else None
@@ -517,6 +624,13 @@ def peek_derived_status(
         }
         if derived == "blocked":
             result["blocking_detail"] = _blocking_detail(conn, track_id, project_id)
+        elif derived != "done":
+            # OI-1098: same visibility contract as reconcile_track.
+            hold = _delivery_hold(
+                conn, track_id, project_id, track_row["pr_ref"] if track_row else None
+            )
+            if hold is not None:
+                result["delivery_hold"] = hold
         return result
     finally:
         conn.close()
@@ -571,6 +685,12 @@ def reconcile_all_tracks(
             hint = format_blocking_hint(result.get("blocking_detail"))
             if hint:
                 log.info("track_blocked: track=%s project=%s\n%s", track_id, project_id, hint)
+        hold = result.get("delivery_hold")
+        if hold:
+            log.info(
+                "track_delivery_hold: track=%s project=%s %s",
+                track_id, project_id, hold["reason"],
+            )
 
     log.info(
         "track_reconciler: project=%s tracks=%d drifted=%d",

--- a/scripts/lib/track_reconciler_status.py
+++ b/scripts/lib/track_reconciler_status.py
@@ -91,6 +91,14 @@ def _compute_derived_status(
     track_pr_ref = track_row["pr_ref"] if track_row else None
     track_phase = track_row["phase"] if track_row else None
 
+    # OI-1098: delivery hold. One explicit non-'complete' delivery marking on
+    # any currently-linked PR vetoes every PR-EVIDENCE-based 'done' below
+    # (merged coordination event, pr_ref merged-subset). Declared-phase
+    # evidence is NOT vetoed: a human-declared 'done' stays authoritative, and
+    # the no-pr_ref path has nothing to mark. Unmarked legacy PRs (no row)
+    # do not hold — see _delivery_hold for the measured motivation.
+    hold = _delivery_hold(conn, track_id, project_id, track_pr_ref)
+
     # 4. Dispatch state aggregation.
     dispatches = conn.execute(
         "SELECT dispatch_id, state FROM dispatches WHERE track = ? AND project_id = ?",
@@ -105,7 +113,7 @@ def _compute_derived_status(
         # confirmed merged via all evidence sources, derive 'done' without a
         # dispatch match. ALL parsed PRs must be merged; partial merge = not done.
         nums = _parse_pr_numbers(track_pr_ref)
-        if nums and nums <= merged_pr_numbers:
+        if nums and nums <= merged_pr_numbers and hold is None:
             return "done"
         # Absence of evidence is not evidence of queued. Historical dispatches may
         # be archived, so defer to declared phase (2026-06-15 migration panel).
@@ -138,7 +146,7 @@ def _compute_derived_status(
             """,
             dispatch_ids,
         ).fetchone()
-        if merged_event:
+        if merged_event and hold is None:
             return "done"
 
         # Declared-done stability: a declared-done track with all terminal dispatches
@@ -151,10 +159,11 @@ def _compute_derived_status(
         # evidence sources (NDJSON / ROADMAP / git) — same as the no-dispatch path.
         # ALL parsed PRs must be merged; partial merge = not done.
         nums = _parse_pr_numbers(track_pr_ref)
-        if nums and nums <= merged_pr_numbers:
+        if nums and nums <= merged_pr_numbers and hold is None:
             return "done"
 
-        # All dispatches terminal but PR not confirmed merged yet.
+        # All dispatches terminal but PR not confirmed merged yet (or a
+        # delivery hold vetoed the PR-evidence 'done' — OI-1098).
         return "in_progress"
 
     # Some dispatches still in flight.
@@ -171,6 +180,7 @@ def _compute_derived_status(
 from track_reconciler import (  # noqa: E402
     IN_FLIGHT_DISPATCH_STATES,
     TERMINAL_DISPATCH_STATES,
+    _delivery_hold,
     _has_col,
     _parse_pr_numbers,
 )

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -431,6 +431,19 @@ def _drift_reason(
                 return f"blocked by dependency: {unmet[0]}"
             return "blocked"
 
+        # OI-1098: a delivery-held track (explicit non-'complete' marking on
+        # a linked PR) must NAME that hold as the drift reason — never let it
+        # read as a generic "dispatches in flight" / "no evidence".
+        track_row = conn.execute(
+            "SELECT pr_ref FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        hold = track_reconciler._delivery_hold(
+            conn, track_id, project_id, track_row["pr_ref"] if track_row else None
+        )
+        if hold is not None and derived != "done":
+            return hold["reason"]
+
         count = conn.execute(
             "SELECT COUNT(*) FROM dispatches WHERE track = ? AND project_id = ?",
             (track_id, project_id),
@@ -502,6 +515,7 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
         f"  unverified={c.get('unverified', 0)}"
         f"  deferred={c.get('deferred', 0)}"
         f"  reopened_guard={c.get('reopened_guard', 0)}"
+        f"  delivery_hold={c.get('delivery_hold', 0)}"
     )
 
     per_track = summary.get("per_track", [])
@@ -511,7 +525,11 @@ def cmd_objective_reconcile(args: argparse.Namespace) -> int:
             verdict = pt.get("verdict", "?")
             cr = pt.get("close_result", "")
             suffix = f" -> {cr}" if cr else ""
-            print(f"  {pt['track_id']:<32} {verdict}{suffix}  (pr_ref: {pt.get('pr_ref', '-')})")
+            reason = f"  — {pt['reason']}" if pt.get("reason") else ""
+            print(
+                f"  {pt['track_id']:<32} {verdict}{suffix}  (pr_ref: {pt.get('pr_ref', '-')})"
+                f"{reason}"
+            )
 
     if exit_code == 0 and mode == "apply" and c.get("closed", 0):
         print(f"\n  [ok] closed {c['closed']} track(s)")

--- a/tests/test_reconciler_delivery_hold.py
+++ b/tests/test_reconciler_delivery_hold.py
@@ -1,0 +1,484 @@
+"""tests/test_reconciler_delivery_hold.py — OI-1098 delivery-hold.
+
+The reconciler used to WRITE the per-PR ``delivery`` marking (planning_cli
+``--delivery``) but never READ it: a track linked with ``--delivery partial``
+was still nominated CONFIRMED-done by ``vnx horizon reconcile``.
+
+This file pins the decided contract (fail-closed AND visible):
+
+- Derivation: one explicit non-'complete' marking on ANY currently-linked PR
+  vetoes every PR-evidence-based 'done' (merged coordination event, pr_ref
+  merged-subset, no-dispatch pr_ref path). Declared 'done' stays authoritative.
+- Visibility: reconcile_track/peek_derived_status carry a ``delivery_hold``
+  dict with an operator-readable reason; run_reconcile reports the track as
+  verdict 'delivery_hold' instead of nominating it (and never consults gh
+  for it).
+- Legacy (measured on the real vnx-dev tracks DB, 2026-08-09: only 'partial'
+  and 'complete' values exist): a PR with NO track_pr_delivery row is NOT an
+  explicit 'partial' — post-0032 links always write a row (--delivery
+  defaults to 'partial'), so a missing row means pre-0032 legacy and does
+  NOT hold. A DB without the 0032 table behaves as before.
+- Fail-closed edge: an unrecognized delivery_kind holds (and logs), never
+  reads as 'complete'.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for _p in (_LIB, _SCRIPTS):
+    if str(_p) not in sys.path:
+        sys.path.insert(0, str(_p))
+
+import objective_reconcile  # noqa: E402
+import schema_migration  # noqa: E402
+import track_reconciler  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
+PROJECT_ID = "test-delivery-hold"
+
+
+@pytest.fixture(autouse=True)
+def _clear_schema_preflight_hooks():
+    """Isolate schema_migration._PREFLIGHT_HOOKS (mirrors test_objective_reconcile)."""
+    import importlib
+
+    sm = None
+    try:
+        sm = importlib.import_module("schema_migration")
+        saved = {k: list(v) for k, v in sm._PREFLIGHT_HOOKS.items()}
+        sm._PREFLIGHT_HOOKS.clear()
+    except (ImportError, AttributeError):
+        saved = None
+    yield
+    if saved is not None and sm is not None:
+        sm._PREFLIGHT_HOOKS.clear()
+        sm._PREFLIGHT_HOOKS.update(saved)
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+def _build_db(tmp_path: Path, *, with_delivery_table: bool = True) -> Path:
+    """State dir with migrations 0022+0024+0027+0028+0030 (+0032 unless told otherwise)."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True)
+    (state_dir.parent / "events").mkdir(parents=True, exist_ok=True)
+
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.execute("""
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL,
+            project_id TEXT
+        )
+    """)
+    conn.commit()
+
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    migrations = [
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+    ]
+    if with_delivery_table:
+        migrations.append((32, "0032_track_pr_delivery.sql"))
+    for ver, fname in migrations:
+        schema_migration.apply_script_if_below(
+            conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8")
+        )
+        conn.commit()
+
+    conn.close()
+    return state_dir
+
+
+def _set_delivery(
+    state_dir: Path, track_id: str, pr_number: int, kind: str, *, set_by: str = "operator"
+) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    if kind not in ("partial", "complete"):
+        conn.execute("PRAGMA ignore_check_constraints = 1")
+    conn.execute(
+        "INSERT INTO track_pr_delivery (project_id, track_id, pr_number, delivery_kind, set_by) "
+        "VALUES (?,?,?,?,?)",
+        (PROJECT_ID, track_id, pr_number, kind, set_by),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_track(
+    state_dir: Path,
+    track_id: str,
+    *,
+    phase: str = "active",
+    pr_ref: Optional[str] = None,
+) -> None:
+    tracks_lib.create_track(
+        state_dir, track_id, PROJECT_ID,
+        title=f"Track {track_id}",
+        goal_state=f"ship {track_id}",
+        phase=phase,
+        pr_ref=pr_ref,
+    )
+
+
+def _seed_dispatch(
+    state_dir: Path, dispatch_id: str, track_id: str, *, state: str = "completed"
+) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO dispatches (dispatch_id, project_id, state, track) VALUES (?,?,?,?)",
+        (dispatch_id, PROJECT_ID, state, track_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pr_merged_event(state_dir: Path, dispatch_id: str) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "INSERT INTO coordination_events "
+        "(event_id, event_type, entity_type, entity_id, occurred_at, project_id) "
+        "VALUES (?,?,?,?,strftime('%Y-%m-%dT%H:%M:%fZ','now'),?)",
+        (f"ev-{dispatch_id}", "pr_merged", "dispatch", dispatch_id, PROJECT_ID),
+    )
+    conn.commit()
+    conn.close()
+
+
+def _seed_pr_merged_ndjson(state_dir: Path, pr_number: int) -> None:
+    events_dir = state_dir.parent / "events"
+    events_dir.mkdir(parents=True, exist_ok=True)
+    with open(events_dir / "pr_merged.ndjson", "a", encoding="utf-8") as fh:
+        fh.write(json.dumps({"event_type": "pr_merged", "pr_number": pr_number}) + "\n")
+
+
+# ---------------------------------------------------------------------------
+# gh subprocess mock (same shape as tests/test_objective_reconcile.py)
+# ---------------------------------------------------------------------------
+
+_MERGED_AT = "2026-08-01T12:00:00Z"
+
+
+def _make_gh_mock(pr_responses: Dict[int, Any], call_log: Optional[list] = None):
+    def fake_run(cmd, **kwargs):
+        if call_log is not None:
+            call_log.append(list(cmd))
+        if not isinstance(cmd, (list, tuple)) or not cmd:
+            return subprocess.CompletedProcess(cmd, 1, "", "bad cmd")
+        cmd0 = os.path.basename(str(cmd[0]))
+        if cmd0 == "gh" and len(cmd) >= 2 and cmd[1] == "auth":
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        if cmd0 == "gh" and len(cmd) >= 3 and cmd[1] == "pr" and cmd[2] == "view":
+            pr_num = int(cmd[3])
+            resp = pr_responses.get(pr_num)
+            if resp is None:
+                return subprocess.CompletedProcess(cmd, 1, "", "not found")
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(resp), "")
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    return fake_run
+
+
+def _merged_pr(number: int) -> Dict[str, str]:
+    return {"state": "MERGED", "mergedAt": _MERGED_AT}
+
+
+def _is_gh_pr_view(cmd: list) -> bool:
+    return (
+        len(cmd) >= 3
+        and os.path.basename(str(cmd[0])) == "gh"
+        and cmd[1] == "pr"
+        and cmd[2] == "view"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derivation tests (track_reconciler.reconcile_track / peek_derived_status)
+# ---------------------------------------------------------------------------
+
+def test_all_complete_markings_derives_done_unchanged(tmp_path):
+    """All linked PRs explicitly 'complete' → PR-evidence 'done' (unchanged behaviour)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-complete", phase="active", pr_ref="#100,#101")
+    _seed_dispatch(sd, "D-complete", "T-complete", state="completed")
+    _seed_pr_merged_event(sd, "D-complete")
+    _set_delivery(sd, "T-complete", 100, "complete")
+    _set_delivery(sd, "T-complete", 101, "complete")
+
+    result = track_reconciler.reconcile_track(sd, "T-complete", PROJECT_ID)
+
+    assert result["derived_status"] == "done"
+    assert "delivery_hold" not in result
+
+
+def test_one_partial_pr_vetoes_done_and_reason_visible(tmp_path):
+    """OI-1098 core: ONE explicit 'partial' among the linked PRs vetoes the
+    PR-evidence 'done' — and the hold + reason ride the result dict (visible)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-partial", phase="active", pr_ref="#100,#101")
+    _seed_dispatch(sd, "D-partial", "T-partial", state="completed")
+    _seed_pr_merged_event(sd, "D-partial")
+    _set_delivery(sd, "T-partial", 100, "partial")
+    _set_delivery(sd, "T-partial", 101, "complete")
+
+    result = track_reconciler.reconcile_track(sd, "T-partial", PROJECT_ID)
+
+    assert result["derived_status"] == "in_progress"  # terminal dispatches, done vetoed
+    hold = result.get("delivery_hold")
+    assert hold is not None
+    assert hold["partial"] == 1
+    assert hold["complete"] == 1
+    assert hold["total"] == 2
+    assert "1 of 2" in hold["reason"]
+
+    # peek (read-only dry-run path) carries the same visibility contract.
+    peeked = track_reconciler.peek_derived_status(sd, "T-partial", PROJECT_ID)
+    assert peeked["derived_status"] == "in_progress"
+    assert peeked.get("delivery_hold", {}).get("reason") == hold["reason"]
+
+
+def test_unmarked_legacy_pr_derives_done(tmp_path):
+    """Legacy choice (pinned): a linked PR with NO track_pr_delivery row is
+    not an explicit 'partial' — pre-0032 links never had the chance to be
+    marked, and post-0032 links always write a row. Unmarked ⇒ no hold."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-legacy", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-legacy", "T-legacy", state="completed")
+    _seed_pr_merged_event(sd, "D-legacy")
+
+    result = track_reconciler.reconcile_track(sd, "T-legacy", PROJECT_ID)
+
+    assert result["derived_status"] == "done"
+    assert "delivery_hold" not in result
+
+
+def test_pre0032_db_without_table_derives_done(tmp_path):
+    """A DB without migration 0032 has no explicit markings at all → no hold."""
+    sd = _build_db(tmp_path, with_delivery_table=False)
+    _seed_track(sd, "T-pre32", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-pre32", "T-pre32", state="completed")
+    _seed_pr_merged_event(sd, "D-pre32")
+
+    result = track_reconciler.reconcile_track(sd, "T-pre32", PROJECT_ID)
+
+    assert result["derived_status"] == "done"
+    assert "delivery_hold" not in result
+
+
+def test_declared_done_with_partial_marking_stays_done(tmp_path):
+    """Declared phase is authoritative: the hold vetoes PR-EVIDENCE paths only,
+    never a human-declared 'done' (declared-done stability is unchanged)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-declared", phase="done", pr_ref="#100")
+    _seed_dispatch(sd, "D-declared", "T-declared", state="completed")
+    _set_delivery(sd, "T-declared", 100, "partial")
+
+    result = track_reconciler.reconcile_track(sd, "T-declared", PROJECT_ID)
+
+    assert result["derived_status"] == "done"
+    assert "delivery_hold" not in result
+
+
+def test_no_dispatch_prref_evidence_partial_not_done(tmp_path):
+    """No-dispatch pr_ref evidence path: merged pr_ref would derive 'done', but
+    the explicit 'partial' marking vetoes it (declared=active → in_progress)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-nodispatch", phase="active", pr_ref="#100")
+    _seed_pr_merged_ndjson(sd, 100)
+    _set_delivery(sd, "T-nodispatch", 100, "partial")
+
+    result = track_reconciler.reconcile_track(sd, "T-nodispatch", PROJECT_ID)
+
+    assert result["derived_status"] == "in_progress"
+    assert result.get("delivery_hold") is not None
+
+
+def test_stale_row_from_unlinked_pr_does_not_hold(tmp_path):
+    """A delivery row for a PR no longer in the current pr_ref is stale and
+    must NOT hold the track (only currently-linked PRs count)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-stale-row", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-stale-row", "T-stale-row", state="completed")
+    _seed_pr_merged_event(sd, "D-stale-row")
+    _set_delivery(sd, "T-stale-row", 100, "complete")
+    _set_delivery(sd, "T-stale-row", 999, "partial")  # unlinked leftover
+
+    result = track_reconciler.reconcile_track(sd, "T-stale-row", PROJECT_ID)
+
+    assert result["derived_status"] == "done"
+    assert "delivery_hold" not in result
+
+
+def test_corrupt_delivery_kind_fails_closed(tmp_path, caplog):
+    """An unrecognized delivery_kind on an existing row holds (fail-closed)
+    and logs at ERROR — never silently reads as 'complete'."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-corrupt", phase="active", pr_ref="#100")
+    _seed_dispatch(sd, "D-corrupt", "T-corrupt", state="completed")
+    _seed_pr_merged_event(sd, "D-corrupt")
+    _set_delivery(sd, "T-corrupt", 100, "corrupted")
+
+    with caplog.at_level("ERROR", logger="track_reconciler"):
+        result = track_reconciler.reconcile_track(sd, "T-corrupt", PROJECT_ID)
+
+    assert result["derived_status"] == "in_progress"
+    hold = result.get("delivery_hold")
+    assert hold is not None
+    assert "unrecognized" in hold["reason"]
+    assert any("unrecognized delivery_kind" in r.message for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Nomination tests (objective_reconcile.run_reconcile)
+# ---------------------------------------------------------------------------
+
+def test_partial_track_not_nominated_but_visible(tmp_path, monkeypatch):
+    """Fail-closed AND visible at nomination: the held track is not a
+    candidate (gh is never consulted for it) but appears in per_track with
+    verdict 'delivery_hold' and a readable reason. Exit stays 0 (a hold is
+    not a degradation)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-hold", phase="active", pr_ref="#100,#101")
+    _seed_pr_merged_ndjson(sd, 100)
+    _seed_pr_merged_ndjson(sd, 101)
+    _set_delivery(sd, "T-hold", 100, "partial")
+    _set_delivery(sd, "T-hold", 101, "partial")
+
+    call_log: list = []
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run",
+        _make_gh_mock({100: _merged_pr(100), 101: _merged_pr(101)}, call_log),
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+
+    assert code == 0
+    assert summary["counts"]["nominated"] == 0
+    assert summary["counts"]["confirmed"] == 0
+    assert summary["counts"]["delivery_hold"] == 1
+
+    per = summary["per_track"]
+    assert len(per) == 1
+    assert per[0]["track_id"] == "T-hold"
+    assert per[0]["verdict"] == "delivery_hold"
+    assert "2 of 2" in per[0]["reason"]
+
+    # gh was never asked about the held track's PRs.
+    assert not any(_is_gh_pr_view(cmd) for cmd in call_log)
+
+
+def test_complete_track_nominated_and_confirmed_unchanged(tmp_path, monkeypatch):
+    """Track with all linked PRs 'complete' → nominated + CONFIRMED (unchanged)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-ship", phase="active", pr_ref="#100")
+    _seed_pr_merged_ndjson(sd, 100)
+    _set_delivery(sd, "T-ship", 100, "complete")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run", _make_gh_mock({100: _merged_pr(100)})
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+
+    assert code == 0
+    assert summary["counts"]["nominated"] == 1
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["delivery_hold"] == 0
+    assert summary["per_track"][0]["verdict"] == "CONFIRMED"
+
+
+def test_unmarked_legacy_track_nominated(tmp_path, monkeypatch):
+    """Legacy track with pr_ref but zero delivery rows → still nominated
+    (grandfathered; pinning the step-1 measurement choice)."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-old", phase="active", pr_ref="#100")
+    _seed_pr_merged_ndjson(sd, 100)
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run", _make_gh_mock({100: _merged_pr(100)})
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=False,
+    )
+
+    assert code == 0
+    assert summary["counts"]["nominated"] == 1
+    assert summary["counts"]["confirmed"] == 1
+    assert summary["counts"]["delivery_hold"] == 0
+
+
+def test_apply_mode_does_not_close_held_track(tmp_path, monkeypatch):
+    """--apply: the held track is never nominated, so no close is attempted;
+    declared phase is untouched and the hold is reported."""
+    sd = _build_db(tmp_path)
+    _seed_track(sd, "T-no-close", phase="active", pr_ref="#100")
+    _seed_pr_merged_ndjson(sd, 100)
+    _set_delivery(sd, "T-no-close", 100, "partial")
+
+    monkeypatch.setattr(
+        objective_reconcile.subprocess, "run", _make_gh_mock({100: _merged_pr(100)})
+    )
+
+    summary, code = objective_reconcile.run_reconcile(
+        sd, PROJECT_ID, repo_root=tmp_path, apply=True,
+    )
+
+    assert code == 0
+    assert summary["counts"]["closed"] == 0
+    assert summary["counts"]["delivery_hold"] == 1
+    assert summary["per_track"][0]["verdict"] == "delivery_hold"
+
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    phase = conn.execute(
+        "SELECT phase FROM tracks WHERE track_id=? AND project_id=?",
+        ("T-no-close", PROJECT_ID),
+    ).fetchone()[0]
+    conn.close()
+    assert phase == "active"


### PR DESCRIPTION
## Probleem (gemeten)

`planning_cli.py` SCHREEF het `delivery`-veld (4 plekken), `track_reconciler.py` las het 0 keer. Gevolg: een track gekoppeld met `--delivery partial` werd alsnog genomineerd als CONFIRMED done. Gereproduceerd op de echte vnx-dev-staat (check mode tegen een staat-kopie):

- **voor:** `nominated=2, confirmed=2` — `dispatch-lane-integrity-cluster` (#1414,#1415) en `review-gate-kimi-codex-glm` (#1410) allebei CONFIRMED terwijl alle markings `partial` zijn.
- **na:** `nominated=0, confirmed=0, delivery_hold=2` — beide tracks zichtbaar met reden: `delivery hold: 2 of 2 linked PRs not marked 'complete' (2 explicit 'partial')`.

## Implementatie (beide helften, zoals besloten)

**Fail-closed** — één expliciete niet-`complete` marking op een *huidig* gekoppelde PR:
- vetoot elke PR-evidence-gebaseerde `done`-afleiding in `_compute_derived_status` (merged coordination event, pr_ref merged-subset, no-dispatch pr_ref-pad);
- vetoot de nominatie in `run_reconcile` stap 3 (gh wordt niet eens geraadpleegd);
- declared `done` blijft autoritatief (human-declaratie wordt nooit overschreven); het no-pr_ref-pad is ongemoeid.

**Zichtbaar** — een vastgehouden track valt nooit stil weg:
- `reconcile_track`/`peek_derived_status` dragen een `delivery_hold`-dict met leesbare reden;
- `run_reconcile` rapporteert verdict `delivery_hold` + reden in `per_track` en telt `counts.delivery_hold`;
- de CLI print de reden per track en noemt de hold als drift-reden in `vnx horizon drift`.

## Legacy-keuze (stap 1, gemeten op de echte DB)

Enige waarden in de praktijk: `partial` (29 rijen) en `complete` (4 rijen), CHECK-enforced door migratie 0032. Een PR **zonder** rij is niet hetzelfde als expliciet `partial`: elke post-0032 koppeling schrijft een rij (`--delivery` default is `partial`), dus een ontbrekende rij betekent pre-0032 legacy → **houdt niet** (anders zou elke legacy-track stil bevriezen — precies de onzichtbaar-wegval-fout op vleet-schaal). DB zonder 0032-tabel: ongewijzigd gedrag. Onbekende `delivery_kind`: fail-closed (hold + ERROR-log), zoals de OI-829 close-gate.

## Verificatie

- `tests/test_reconciler_delivery_hold.py` (nieuw, 12 tests): all-complete → done (ongewijzigd); één partial → niet done + reden zichtbaar; unmarked legacy → done (vastgepinde keuze); pre-0032 DB → done; declared-done + partial → done; no-dispatch pr_ref + partial → niet done; stale rij van ontkoppelde PR → geen hold; corrupte kind → fail-closed; nominatie: partial-track niet genomineerd + zichtbaar + geen gh-call; complete/unmarked → genomineerd; --apply sluit held-track niet.
- Buren: `test_track_reconciler.py`, `test_track_reconciler_prref_evidence.py`, `test_close_track_if_done.py`, `test_deliverable_reconciliation.py`, `test_objective_reconcile.py`, `test_objective_close.py`, `test_planning_turnon.py`, `test_planning_cli.py`, `test_planning_cli_objective.py` → **243 passed, 2 failed** — die 2 (`test_objective_list_renders`, `test_objective_list_json`) falen ook op de base commit (pre-existing, geverifieerd via `git stash`).

Dispatch-ID: 20260809-oi1098-reconciler-delivery