### PR TITLE
fix(lane): bind push+PR-verplichting op committed en op alle envelope-lanes (rij 7)

### DIFF
--- a/docs/lane-conformity-matrix.md
+++ b/docs/lane-conformity-matrix.md
@@ -121,7 +121,7 @@ Uit de enumeratie hierboven zijn twee rijen toegevoegd:
 | 4 | Hoofdcheckout-guard (geen stille fallback) | **bindt** | **bindt niet** | **bindt** |
 | 5 | Reap weigert bij ongepushte commits | **bindt** (branch blijft) | **n.v.t.** | **bindt niet** |
 | 6 | Teardown meldt `worktree_state` | **bindt** | **n.v.t.** | **bindt niet** |
-| 7 | Push+PR-verplichting afgedwongen | **bindt** (alleen bij pushed) | **bindt niet** | **bindt niet** |
+| 7 | Push+PR-verplichting afgedwongen | **bindt** (pushed + committed) | **bindt** | **bindt** |
 | 8 | Ringbuffer-teardown (end-of-dispatch) | **bindt niet** | **bindt** | **bindt** |
 | 9 | Canonical receipt path (geen bare-write) | **bindt** | **bindt** | **bindt** |
 | 10 | OI-861 worktree identity guard | **bindt niet** | **n.v.t.** | **bindt** |
@@ -236,22 +236,27 @@ Uit de enumeratie hierboven zijn twee rijen toegevoegd:
 
 ### 3.7 Celbewijzen — mechanisme 7: Push+PR-verplichting
 
-**tmux — bindt (alleen voor `worktree_state == "pushed"`)**
-- `_enforce_pr_exists()` (`tmux_interactive_dispatch.py:967-1009`) wordt aangeroepen op regel 2907, vóór `_govern_report()` en vóór `_teardown()`.
-- `enforce_pr_exists()` (`pr_enforcement.py:63-109`) checkt of `worktree_state == "pushed"` (regel 82). Alleen dan wordt PR-creatie afgedwongen.
-- Bij `worktree_state != "pushed"`: `applicable=False, ok=True` — de dispatch gaat door zonder PR.
-- **Beperking**: een dispatch met `worktree_state == "committed"` (wel commits, niet gepusht) passeert deze check. De dispatch slaagt (`exit 0`) zonder dat er iets op origin staat.
-- **OI-1011**: werk was lokaal gecommit, niet gepusht, geen PR. `classify()` gaf "committed", PR enforcement skipte (`applicable=False`), dispatch exit 0.
-- Bewijs: `scripts/lib/pr_enforcement.py:63-109` en `scripts/lib/tmux_interactive_dispatch.py:2905-2918`
+**tmux — bindt (voor `pushed` EN `committed`)**
+- `_enforce_pr_exists()` (`tmux_interactive_dispatch.py:1031-1098`) wordt aangeroepen op regel 2982, vóór `_govern_report()` en vóór `_teardown()`.
+- `enforce_pr_exists()` (`pr_enforcement.py:80-164`) bevat de ENIGE per-staat beslissing: `pushed` → PR afdwingen; `committed` → pushen dan PR afdwingen (rij-7 fix); `clean`/`dirty` → `applicable=False`.
+- Een mislukte push of PR-creatie → `ok=False` → `worker_succeeded = False` (`tmux_interactive_dispatch.py:2989`) → `receipt["status"] = "failed"` + `failure_reason=dispatch_branch_no_pr (state=...)`. Geen `exit 0` met werk lokaal gestrand.
+- De corrective receipt wordt door `pr_enforcement._record_corrective_receipt` zelf geschreven met `autopr_kind` (`push_failed`/`pr_failed`).
+- Bewijs: `scripts/lib/pr_enforcement.py:80-164`, `scripts/lib/tmux_interactive_dispatch.py:2982-3013`
 
-**headless — bindt niet**
-- Geen PR-enforcement code in `run_envelope_headless_plan()` of `_govern()`.
-- De headless lane maakt geen worktree aan en heeft geen push/PR-logica.
-- Bewijs: geen `pr_enforcement` import in `dispatch_envelope.py`, `envelope_govern.py`, of `envelope_adapters_claude.py`
+**headless — bindt**
+- `run_envelope_headless_plan()` (`dispatch_envelope.py:665-672`) roept `_enforce_push_pr()` aan vóór `remove_dispatch_worktree()` (de worktree is de enige handle naar de lokale branch).
+- `_enforce_push_pr()` (`dispatch_envelope.py:101-173`) hergebruikt `pr_enforcement.enforce_pr_exists` en de gedeelde `tmux_worktree.classify_path()` — geen tweede kopie van de beslissing (OI-1099).
+- De headless-lane maakt sinds #1416 wél een worktree aan (`isolation=worktree` gehonoreerd, hard-fail bij creatie, `dispatch_envelope.py:641-660`); de matrix-tekst "maakt geen worktree aan" is daarmee achterhaald.
+- Een mislukte push/PR → `result.status = "failure"` → `EnvelopeResult.returncode = 1`.
+- Bewijs: `scripts/lib/dispatch_envelope.py:101-175,665-672`
 
-**provider — bindt niet**
-- Geen PR-enforcement code in `run_envelope_plan()`, `_govern()`, of `provider_dispatch._emit_governance()`.
-- Bewijs: geen `pr_enforcement` import in `dispatch_envelope.py`, `envelope_govern.py`, of `provider_dispatch.py`
+**provider — bindt**
+- `run_envelope_plan()` (`dispatch_envelope.py:481-488`) roept dezelfde `_enforce_push_pr()` aan, vóór `remove_dispatch_worktree()`.
+- Bewijs: `scripts/lib/dispatch_envelope.py:101-175,481-488`
+
+**Gedeelde classificatie**
+- `classify_path()` (`tmux_worktree.py:211-271`) is de enige canonieke git-staat-classificatie; `classify()` (`tmux_worktree.py:195-208`) delegeert ernaar. De envelope-lanes gebruiken `classify_path()` direct (geen `WorktreeHandle`).
+- Bewijs: `scripts/lib/tmux_worktree.py:195-271`
 
 ### 3.8 Celbewijzen — mechanisme 8: Ringbuffer-teardown
 

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -80,6 +80,107 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Rij-7 (lane-matrix): push+PR-verplichting op de envelope-lanes.
+#
+# Both envelope lanes (run_envelope_plan / run_envelope_headless_plan) create a
+# dispatch worktree and run a worker in it. Until this hook, neither lane bound
+# the push+PR obligation: a worker that committed but never pushed (or pushed
+# but never opened a PR) completed with status="success" and work stranded.
+#
+# The per-state decision is NOT reimplemented here — it lives in the ONE binding
+# site, pr_enforcement.enforce_pr_exists, which the tmux lane already calls. The
+# envelope lanes reuse that same module and the shared classify_path() verdict,
+# so two copies of the decision can never drift (the exact OI-1099 mistake).
+#
+# Runs BEFORE remove_dispatch_worktree (the worktree is the only handle to the
+# local branch) and BEFORE _govern (so a push/PR failure is reflected in the
+# governed report and the EnvelopeResult, not a silent "success").
+# ---------------------------------------------------------------------------
+
+
+def _enforce_push_pr(
+    *,
+    dispatch_id: str,
+    branch: str,
+    wt_path: Path,
+    repo_root: Path,
+    receipts_file: "str | Path",
+    result: "_AdapterResult",
+) -> "_AdapterResult":
+    """Enforce the rij-7 push+PR obligation on an envelope-lane worktree.
+
+    Classifies the worktree via the shared tmux_worktree.classify_path() and calls
+    pr_enforcement.enforce_pr_exists() — the same module the tmux lane uses. When
+    enforcement is applicable and fails (push or PR), the adapter result is
+    rewritten to status="failure" so the governed EnvelopeResult is non-zero.
+    pr_enforcement appends the corrective receipt itself.
+
+    A non-applicable state (clean/dirty) leaves *result* unchanged. Never raises:
+    an internal error fails open (the worktree is still torn down by the caller's
+    finally block), matching the tmux lane's _enforce_pr_exists contract.
+    """
+    try:
+        from tmux_worktree import classify_path  # noqa: PLC0415
+        state = classify_path(wt=wt_path, branch=branch, dispatch_id=dispatch_id)
+        from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
+        pr_result = enforce_pr_exists(
+            dispatch_id=dispatch_id,
+            branch=branch,
+            worktree_state=state,
+            repo_root=repo_root,
+            receipts_file=receipts_file,
+            pr_title=f"dispatch({dispatch_id}): auto-created by VNX envelope lane",
+            pr_body=(
+                f"Auto-created by VNX envelope build-dispatch completion "
+                f"(dispatch `{dispatch_id}`) — the worker left this branch "
+                "without an open PR. Please review before merging."
+            ),
+        )
+    except Exception as exc:  # noqa: BLE001 — never block a real completion on this guard
+        logger.error(
+            "envelope: PR-enforcement guard errored dispatch=%s: %s", dispatch_id, exc,
+        )
+        return result
+
+    if not pr_result.applicable:
+        return result
+    if pr_result.ok:
+        logger.info(
+            "envelope: PR-enforcement OK dispatch=%s state=%s pr=%s created=%s",
+            dispatch_id, state, pr_result.pr_number, pr_result.created,
+        )
+        return result
+
+    logger.warning(
+        "envelope: PR-enforcement REJECTED dispatch=%s state=%s — %s",
+        dispatch_id, state, pr_result.reason,
+    )
+    return _AdapterResult(
+        returncode=1,
+        completion_text=result.completion_text,
+        status="failure",
+        token_usage=result.token_usage,
+        error=f"dispatch_branch_no_pr (state={state}): {pr_result.reason}",
+        session_id=result.session_id,
+        model=result.model,
+    )
+
+
+def _dispatch_branch_name(dispatch_id: str) -> str:
+    """The local branch name create_dispatch_worktree allocates for *dispatch_id*."""
+    from dispatch_worktree_isolation import _sanitize_dispatch_id  # noqa: PLC0415
+    return f"dispatch/{_sanitize_dispatch_id(dispatch_id)}"
+
+
+def _receipts_file_for(state_dir: Path) -> Path:
+    """The NDJSON ledger the corrective receipt is appended to — the same path
+    envelope_govern._govern writes the dispatch receipt to
+    (``<state_dir>/t0_receipts.ndjson``), mirroring the tmux lane's
+    self._receipts_file convention."""
+    return Path(state_dir) / "t0_receipts.ndjson"
+
+
+# ---------------------------------------------------------------------------
 # Adapters -- CodexAdapter, ClaudeSubprocessAdapter moved to
 # envelope_adapters_claude.py (dispatch-monolith-split, PR-5 of 6); imported
 # above at bare name so every existing dispatch_envelope.CodexAdapter /
@@ -373,6 +474,19 @@ def run_envelope_plan(
             )
         except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
             _phantom_diff = None
+        # Rij-7: enforce push+PR BEFORE the teardown removes the worktree (the only
+        # handle to the local branch). Only when the worker itself reported success —
+        # a failed worker has nothing worth pushing. Reuses pr_enforcement.enforce_pr_exists
+        # (the single per-state decision site) and the shared tmux_worktree.classify_path.
+        if result.status == "success":
+            result = _enforce_push_pr(
+                dispatch_id=plan.dispatch_id,
+                branch=_dispatch_branch_name(plan.dispatch_id),
+                wt_path=wt_path,
+                repo_root=_consumer_project_root,
+                receipts_file=_receipts_file_for(state_dir),
+                result=result,
+            )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
 
@@ -544,6 +658,19 @@ def run_envelope_headless_plan(
             )
         except Exception:  # noqa: BLE001 — best-effort; None -> guard abstains, never false-rejects
             _phantom_diff = None
+        # Rij-7: enforce push+PR BEFORE the teardown removes the worktree (the only
+        # handle to the local branch). Only when the worker itself reported success.
+        # Reuses pr_enforcement.enforce_pr_exists and the shared
+        # tmux_worktree.classify_path — never a second copy of the per-state decision.
+        if result.status == "success":
+            result = _enforce_push_pr(
+                dispatch_id=plan.dispatch_id,
+                branch=_dispatch_branch_name(plan.dispatch_id),
+                wt_path=wt_path,
+                repo_root=_consumer_project_root,
+                receipts_file=_receipts_file_for(state_dir),
+                result=result,
+            )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
 

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -106,6 +106,7 @@ def _enforce_push_pr(
     repo_root: Path,
     receipts_file: "str | Path",
     result: "_AdapterResult",
+    base_ref: str = "origin/main",
 ) -> "_AdapterResult":
     """Enforce the rij-7 push+PR obligation on an envelope-lane worktree.
 
@@ -118,10 +119,24 @@ def _enforce_push_pr(
     A non-applicable state (clean/dirty) leaves *result* unchanged. Never raises:
     an internal error fails open (the worktree is still torn down by the caller's
     finally block), matching the tmux lane's _enforce_pr_exists contract.
+
+    ``base_ref`` is the ref ``create_dispatch_worktree`` based the branch on
+    (``origin/main`` by default; ``plan.base_ref`` when set). The envelope lanes,
+    unlike the tmux lane, do not carry a WorktreeHandle, so they resolve the base
+    SHA here and pass it to ``classify_path`` — the same value the tmux lane
+    resolves before ``git worktree add`` and threads through
+    ``WorktreeHandle.base_sha``. Without it, ``classify_path`` falls back to
+    ``merge-base origin/main HEAD``, which fails in a shallow PR-clone (CI) where
+    ``origin/main`` is absent — and then misclassifies a clean, commit-less
+    worktree as ``committed``, triggering a false push+PR rejection (OI-1011
+    regression, faler-2 of dispatch 20260809-fix1419-census-headless).
     """
     try:
+        base_sha = _resolve_base_sha(repo_root=repo_root, base_ref=base_ref)
         from tmux_worktree import classify_path  # noqa: PLC0415
-        state = classify_path(wt=wt_path, branch=branch, dispatch_id=dispatch_id)
+        state = classify_path(
+            wt=wt_path, branch=branch, dispatch_id=dispatch_id, base_sha=base_sha,
+        )
         from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
         pr_result = enforce_pr_exists(
             dispatch_id=dispatch_id,
@@ -164,6 +179,35 @@ def _enforce_push_pr(
         session_id=result.session_id,
         model=result.model,
     )
+
+
+def _resolve_base_sha(*, repo_root: Path, base_ref: str) -> "str | None":
+    """Resolve the SHA of *base_ref* (``origin/main`` by default) in *repo_root*.
+
+    Mirrors the tmux lane's ``WorktreeHandle.base_sha`` resolution: the commit a
+    dispatch worktree was based on, resolved BEFORE ``git worktree add``. Returns
+    None when the ref cannot be resolved (shallow clone without ``origin/main``,
+    detached checkout, etc.) — ``classify_path`` then falls back to its own
+    merge-base logic and, failing that, to a clean-safe default rather than a
+    false ``committed``. Never raises: a resolve error is logged and treated as
+    "base unknown", which degrades to the conservative clean path.
+    """
+    import subprocess  # noqa: PLC0415
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "rev-parse", base_ref],
+            capture_output=True, text=True, timeout=30,
+        )
+    except Exception as exc:  # noqa: BLE001 — resolve failure degrades, never crashes
+        logger.warning("envelope: base_sha resolve raised for %s: %s", base_ref, exc)
+        return None
+    if proc.returncode != 0:
+        logger.info(
+            "envelope: base_ref %s unresolvable in %s — classify_path will fall back",
+            base_ref, repo_root,
+        )
+        return None
+    return proc.stdout.strip() or None
 
 
 def _dispatch_branch_name(dispatch_id: str) -> str:
@@ -486,6 +530,7 @@ def run_envelope_plan(
                 repo_root=_consumer_project_root,
                 receipts_file=_receipts_file_for(state_dir),
                 result=result,
+                base_ref=plan.base_ref or "origin/main",
             )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
@@ -670,6 +715,7 @@ def run_envelope_headless_plan(
                 repo_root=_consumer_project_root,
                 receipts_file=_receipts_file_for(state_dir),
                 result=result,
+                base_ref=plan.base_ref or "origin/main",
             )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)

--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -1,27 +1,40 @@
-"""pr_enforcement.py — enforce that a build worker's pushed dispatch branch has an
-open PR, in the tmux-spawn build-dispatch completion path.
+"""pr_enforcement.py — enforce that a build worker's dispatch branch is pushed to
+origin AND has an open PR, in every lane's completion path.
 
-Problem: a build worker commits and pushes its `dispatch/<id>` branch to origin but
-frequently never runs `gh pr create`. The dispatch then "completes" with a branch
-sitting on origin and no PR, and T0 has to salvage it by hand every time
+Problem: a build worker commits its `dispatch/<id>` branch but frequently never
+pushes it, or pushes it but never runs `gh pr create`. Either way the dispatch
+"completes" with work stranded locally (lost on the next reap) or with a branch
+sitting on origin and no PR — and T0 has to salvage it by hand every time
 (`gh pr create --head dispatch/<id>`).
 
-This module is the enforcement chokepoint the tmux lane calls right before it
+This module is the single enforcement chokepoint every lane calls right before it
 governs the dispatch (see tmux_interactive_dispatch.TmuxInteractiveDispatch's
-teardown flow). It reuses gh_pr_ensure (the one shared gh-pr-create implementation
+teardown flow; run_envelope_plan / run_envelope_headless_plan in the envelope
+family). It reuses gh_pr_ensure (the one shared gh-pr-create implementation
 — auto_gate_trigger.py uses the same module) so there is exactly one `gh pr create`
 invocation in the codebase, never two independently-drifting ones.
 
-Enforcement, not best-effort: when the branch was pushed and PR creation fails, this
-is recorded as a receipt-visible failure — a corrective 'failed' completion receipt
-is appended to the ndjson ledger, mirroring phantom_guard's tier-0 override pattern
-(dispatch_govern.dedup_completion_receipts honors ``autopr_rejected`` the same way
-it honors ``phantom_rejected``) — so a dispatch that pushed real work but never got
-a PR does NOT silently resolve as 'done'.
+Per-state decision (one binding site, never duplicated across lanes):
+- ``pushed``   → PR afdwingen (bestaand gedrag).
+- ``committed`` → pushen, dan PR afdwingen. Dit is rij-7 van de lane-matrix: een
+  worktree met commits die niet op origin staan is de gevaarlijkste staat die er
+  is, want bij een reap is het werk weg. Een mislukte push is een luide,
+  receipt-zichtbare uitkomst (ok=False + corrective receipt), geen ``exit 0``.
+- ``clean``    → niet van toepassing; er is niets om te pushen of een PR voor te
+  openen. Blijft ok=True, applicable=False.
+- ``dirty``    → niet van toepassing hier. De worktree heeft uncommitted wijzigingen
+  die de worker zelf had moeten committen; een push hiervan kan niet deterministisch
+  (er is niets om te pushen). Dit is phantom_guard's domein (lege extractie /
+  niet-gecommit werk), niet rij-7. Blijft ok=True, applicable=False, met een reden
+  die de caller laat zien dat er nog dirty werk is.
 
-Out of scope: a branch that was never pushed (worktree_state != "pushed") has
-nothing to enforce here — an empty/uncommitted worktree is phantom_guard's problem,
-not this module's.
+Enforcement, not best-effort: when the branch was committed (or pushed) and the
+push or PR creation fails, this is recorded as a receipt-visible failure — a
+corrective 'failed' completion receipt is appended to the ndjson ledger, mirroring
+phantom_guard's tier-0 override pattern (dispatch_govern.dedup_completion_receipts
+honors ``autopr_rejected`` the same way it honors ``phantom_rejected``) — so a
+dispatch that committed real work but never got it to a PR does NOT silently
+resolve as 'done'.
 
 BILLING SAFETY: No Anthropic SDK. CLI-only (gh/git via subprocess, through
 gh_pr_ensure).
@@ -31,6 +44,7 @@ from __future__ import annotations
 
 import logging
 import os
+import subprocess
 import sys
 from dataclasses import dataclass
 from datetime import datetime, timezone
@@ -48,15 +62,18 @@ _SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent)
 class PrEnforcementResult:
     """Outcome of enforce_pr_exists().
 
-    applicable=False: the branch was never pushed — nothing to enforce, ok=True.
-    applicable=True, ok=True: a PR exists (found or just created).
-    applicable=True, ok=False: the branch was pushed but no PR could be found or
-        created — a corrective receipt has already been appended.
+    applicable=False: the state had nothing to push (clean/dirty) — ok=True.
+    applicable=True, ok=True: the branch is on origin AND a PR exists (found or
+        just created). When the state was ``committed``, the branch was pushed
+        first (pushed=True records that the push step ran).
+    applicable=True, ok=False: the branch was committed (or pushed) but the push
+        or PR creation failed — a corrective receipt has already been appended.
     """
     applicable: bool
     ok: bool
     pr_number: Optional[int] = None
     created: bool = False
+    pushed: bool = False
     reason: Optional[str] = None
 
 
@@ -70,20 +87,57 @@ def enforce_pr_exists(
     pr_title: str,
     pr_body: str,
 ) -> PrEnforcementResult:
-    """Ensure *branch* has an open PR when it was pushed to origin.
+    """Ensure *branch* is pushed to origin AND has an open PR.
 
     ``worktree_state`` is the tmux_worktree.classify() verdict
-    ("clean"/"committed"/"pushed"/"dirty"). Only "pushed" is in scope.
+    ("clean"/"committed"/"pushed"/"dirty"). This is the ONE binding site for the
+    per-state push+PR decision — every lane calls here, never re-implements it.
 
-    Never raises: a gh_pr_ensure exception is treated as a creation failure (still
+    Per state (rij-7, lane-matrix):
+    - ``pushed``   → PR afdwingen (bestaand gedrag).
+    - ``committed`` → pushen, dan PR afdwingen.
+    - ``clean``    → niets om te pushen → applicable=False, ok=True.
+    - ``dirty``    → niet hier; phantom_guard's domein → applicable=False, ok=True.
+
+    Never raises: a push or gh_pr_ensure exception is treated as a failure (still
     enforced — reported via PrEnforcementResult.ok=False + corrective receipt), not
-    propagated, so a transient GitHub/network error never crashes the dispatch lane.
+    propagated, so a transient git/GitHub/network error never crashes the dispatch
+    lane.
     """
-    if worktree_state != "pushed":
+    if worktree_state == "clean":
         return PrEnforcementResult(
             applicable=False, ok=True,
-            reason=f"worktree_state={worktree_state!r} — nothing pushed to open a PR for",
+            reason=f"worktree_state={worktree_state!r} — no changes to push or open a PR for",
         )
+    if worktree_state == "dirty":
+        # Uncommitted changes are the worker's own unhandled working tree — there
+        # is nothing deterministically pushable here, and a "push" of a dirty tree
+        # cannot land. phantom_guard owns the not-committed-work failure mode; rij-7
+        # binds only on committed-or-pushed work.
+        return PrEnforcementResult(
+            applicable=False, ok=True,
+            reason=(
+                f"worktree_state={worktree_state!r} — uncommitted changes left in the "
+                f"worktree; nothing deterministically pushable (phantom_guard's domain)"
+            ),
+        )
+
+    # committed or pushed are the two states with work that must reach a PR.
+    pushed = worktree_state == "pushed"
+    if worktree_state == "committed":
+        push_outcome = _push_branch(branch=branch, repo_root=repo_root)
+        if not push_outcome.ok:
+            reason = push_outcome.reason
+            logger.warning(
+                "pr_enforcement: push FAILED dispatch=%s branch=%s — %s",
+                dispatch_id, branch, reason,
+            )
+            _record_corrective_receipt(
+                dispatch_id=dispatch_id, branch=branch, reason=reason,
+                receipts_file=receipts_file, kind="push_failed",
+            )
+            return PrEnforcementResult(applicable=True, ok=False, pushed=False, reason=reason)
+        pushed = True
 
     try:
         from gh_pr_ensure import ensure_pr  # noqa: PLC0415
@@ -95,7 +149,7 @@ def enforce_pr_exists(
     pr_number = result.get("pr_number")
     if pr_number is not None:
         return PrEnforcementResult(
-            applicable=True, ok=True,
+            applicable=True, ok=True, pushed=pushed,
             pr_number=pr_number, created=bool(result.get("created")),
         )
 
@@ -105,15 +159,48 @@ def enforce_pr_exists(
     )
     _record_corrective_receipt(
         dispatch_id=dispatch_id, branch=branch, reason=reason, receipts_file=receipts_file,
+        kind="pr_failed",
     )
-    return PrEnforcementResult(applicable=True, ok=False, reason=reason)
+    return PrEnforcementResult(applicable=True, ok=False, pushed=pushed, reason=reason)
+
+
+@dataclass(frozen=True)
+class _PushOutcome:
+    ok: bool
+    reason: "Optional[str]" = None
+
+
+def _push_branch(*, branch: str, repo_root: Path) -> "_PushOutcome":
+    """Push *branch* (``dispatch/<id>``) to origin. Never raises.
+
+    Runs ``git push -u origin <branch>`` from *repo_root*. The branch already
+    exists locally (the worker committed to it); this is the step the worker
+    skipped. A failed push returns ok=False with the git stderr as the reason —
+    the caller records a corrective receipt, so a committed-but-not-pushed
+    dispatch never silently resolves as 'done'.
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "push", "-u", "origin", branch],
+            capture_output=True, text=True, timeout=120,
+        )
+    except Exception as exc:  # noqa: BLE001 — a push error must never crash the lane
+        return _PushOutcome(ok=False, reason=f"git push raised: {exc}")
+    if proc.returncode != 0:
+        stderr = (proc.stderr or "").strip()
+        return _PushOutcome(
+            ok=False,
+            reason=f"git push origin {branch} failed (rc={proc.returncode}): {stderr}",
+        )
+    return _PushOutcome(ok=True)
 
 
 def _record_corrective_receipt(
     *, dispatch_id: str, branch: str, reason: str, receipts_file: "str | Path",
+    kind: str = "pr_failed",
 ) -> None:
     """Append a corrective 'failed' completion receipt — the loud, receipt-visible
-    signal that a pushed-but-PR-less dispatch is incomplete. Never raises."""
+    signal that a committed-but-not-PR'd dispatch is incomplete. Never raises."""
     try:
         if _SCRIPTS_DIR not in sys.path:
             sys.path.insert(0, _SCRIPTS_DIR)
@@ -126,6 +213,7 @@ def _record_corrective_receipt(
                 "status": "failed",
                 "autopr_rejected": True,
                 "autopr_reason": reason,
+                "autopr_kind": kind,
                 "branch": branch,
                 "source": "pr_enforcement",
                 "synthesized": False,

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -2967,11 +2967,15 @@ class TmuxInteractiveDispatch:
                 "failed",
                 "blocked",
             )
-            # Auto-PR enforcement: a build worker that committed+pushed its dispatch
-            # branch but never ran `gh pr create` leaves T0 to salvage the PR by hand
-            # every time (lane-fix B). Runs BEFORE govern() so a creation failure is
-            # reflected in the governed report and InteractiveDispatchResult.success —
-            # never a silent "done" with a branch stranded on origin.
+            # Auto-PR enforcement (rij-7, lane-matrix): a build worker that committed
+            # its dispatch branch but never pushed it, OR pushed it but never ran
+            # `gh pr create`, leaves T0 to salvage the work by hand every time. The
+            # per-state decision lives in pr_enforcement.enforce_pr_exists (the ONE
+            # binding site — never duplicated): `committed` → push then PR, `pushed`
+            # → PR, `clean`/`dirty` → not applicable. Runs BEFORE govern() so a push
+            # or creation failure is reflected in the governed report and
+            # InteractiveDispatchResult.success — never a silent "done" with work
+            # stranded locally or on origin.
             _autopr_failure_reason: "str | None" = None
             if worker_succeeded and worktree_handle is not None:
                 _wt_classification[0] = classify(worktree_handle)
@@ -3002,7 +3006,12 @@ class TmuxInteractiveDispatch:
                 session_id=session_uuid,
                 permission_posture=permission_posture,
                 **(
-                    {"failure_reason": f"pushed_branch_no_pr: {_autopr_failure_reason}"}
+                    {
+                        "failure_reason": (
+                            f"dispatch_branch_no_pr "
+                            f"(state={_wt_classification[0]}): {_autopr_failure_reason}"
+                        ),
+                    }
                     if _autopr_failure_reason
                     else {}
                 ),

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -222,13 +222,21 @@ def classify_path(
     pr_enforcement.enforce_pr_exists runs against a single verdict source.
 
     ``base_sha`` is the worktree's base commit (origin/main at allocation time).
-    When it is unknown (the envelope lanes do not record it), the worktree's
-    merge-base with origin/main is used instead — a HEAD equal to the base means
-    "no new commits" (clean) regardless of which SHA represented the base.
+    The envelope lanes resolve it from ``base_ref`` (mirroring the tmux lane's
+    ``WorktreeHandle.base_sha``) and pass it here. When it is still unknown, the
+    worktree's merge-base with origin/main is tried as a fallback. If THAT fails
+    too (shallow PR-clone in CI without a local ``origin/main``), a clean tree is
+    classified ``clean`` rather than guessed ``committed`` — a brand-new dispatch
+    branch always has an empty ``ls-remote`` result, so the old "empty remote →
+    committed" inference turned a commit-less worktree into a false push+PR
+    rejection (OI-1011 regression, faler-2 of dispatch
+    20260809-fix1419-census-headless). A false ``clean`` misses enforcement on
+    stranded work; a false ``committed`` breaks a dispatch that committed nothing.
+    The former is recoverable (T0 salvages), the latter is a hard regression.
 
     States:
     - ``dirty``     : uncommitted tracked changes in the worktree.
-    - ``clean``     : no new commits (HEAD == base).
+    - ``clean``     : no new commits (HEAD == base), or base unresolvable and clean.
     - ``committed`` : new local commits, not yet on origin (or origin unknown).
     - ``pushed``    : new commits and the remote dispatch branch matches HEAD.
     """
@@ -248,16 +256,30 @@ def classify_path(
 
     ref_sha = base_sha
     if ref_sha is None:
-        # The envelope lanes know the base ref (origin/main) but not its SHA at
-        # allocation. Fall back to the merge-base: a clean tree's HEAD equals it.
+        # The envelope lanes normally pass base_sha (resolved from base_ref). When
+        # they do not, fall back to the merge-base: a clean tree's HEAD equals it.
         mb = _run(
             ["git", "-C", str(wt), "merge-base", "origin/main", "HEAD"],
         )
         ref_sha = mb.stdout.strip() if mb.returncode == 0 else None
     if ref_sha and local_sha == ref_sha:
         return "clean"
+    if ref_sha is None:
+        # Base unresolvable (no base_sha passed AND origin/main absent locally).
+        # A clean tree here must NOT be guessed ``committed`` from an empty
+        # ls-remote: every brand-new dispatch branch has an empty remote, so that
+        # inference is a false positive on commit-less worktrees. Treat as clean
+        # and surface the degraded resolution so it is visible, not silent.
+        logger.warning(
+            "classify_path: base unresolvable for dispatch=%s branch=%s "
+            "(no base_sha, origin/main absent) — clean tree classified 'clean' "
+            "(degraded; push+PR enforcement skips). Investigate if work was expected.",
+            dispatch_id, branch,
+        )
+        return "clean"
 
-    # New commits exist — determine whether they've been pushed to origin.
+    # New commits exist (HEAD diverged from a known base) — determine whether
+    # they've been pushed to origin.
     remote_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
     try:
         ls_result = _run(

--- a/scripts/lib/tmux_worktree.py
+++ b/scripts/lib/tmux_worktree.py
@@ -193,9 +193,45 @@ def allocate(
 
 
 def classify(handle: WorktreeHandle) -> Literal["clean", "committed", "pushed", "dirty"]:
-    """Determine the state of the worktree at teardown time."""
-    wt = handle.path
+    """Determine the state of the worktree at teardown time.
 
+    Thin wrapper over :func:`classify_path` — the single canonical git-state
+    classification, shared by the tmux lane (which has a WorktreeHandle) and the
+    envelope lanes (which have only a worktree path + branch). The decision logic
+    lives in classify_path so it is never duplicated across lanes.
+    """
+    return classify_path(
+        wt=handle.path,
+        branch=handle.branch,
+        dispatch_id=handle.dispatch_id,
+        base_sha=handle.base_sha,
+    )
+
+
+def classify_path(
+    *,
+    wt: "Path | str",
+    branch: str,
+    dispatch_id: str,
+    base_sha: "str | None" = None,
+) -> Literal["clean", "committed", "pushed", "dirty"]:
+    """Classify a dispatch worktree's git state from a path alone.
+
+    This is the one canonical classification, reused by every lane's PR
+    enforcement (rij-7 of the lane-matrix) so the per-state decision in
+    pr_enforcement.enforce_pr_exists runs against a single verdict source.
+
+    ``base_sha`` is the worktree's base commit (origin/main at allocation time).
+    When it is unknown (the envelope lanes do not record it), the worktree's
+    merge-base with origin/main is used instead — a HEAD equal to the base means
+    "no new commits" (clean) regardless of which SHA represented the base.
+
+    States:
+    - ``dirty``     : uncommitted tracked changes in the worktree.
+    - ``clean``     : no new commits (HEAD == base).
+    - ``committed`` : new local commits, not yet on origin (or origin unknown).
+    - ``pushed``    : new commits and the remote dispatch branch matches HEAD.
+    """
     status_result = _run(
         [
             "git", "-c", "core.fileMode=false", "-c", "core.autocrlf=input",
@@ -210,26 +246,30 @@ def classify(handle: WorktreeHandle) -> Literal["clean", "committed", "pushed", 
         return "clean"
     local_sha = local_sha_result.stdout.strip()
 
-    if local_sha == handle.base_sha:
+    ref_sha = base_sha
+    if ref_sha is None:
+        # The envelope lanes know the base ref (origin/main) but not its SHA at
+        # allocation. Fall back to the merge-base: a clean tree's HEAD equals it.
+        mb = _run(
+            ["git", "-C", str(wt), "merge-base", "origin/main", "HEAD"],
+        )
+        ref_sha = mb.stdout.strip() if mb.returncode == 0 else None
+    if ref_sha and local_sha == ref_sha:
         return "clean"
 
     # New commits exist — determine whether they've been pushed to origin.
+    remote_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
     try:
         ls_result = _run(
-            [
-                "git", "-C", str(wt),
-                "ls-remote", "origin", f"dispatch/{handle.dispatch_id}",
-            ],
+            ["git", "-C", str(wt), "ls-remote", "origin", remote_ref],
             timeout=10,
         )
         remote_output = ls_result.stdout.strip() if ls_result.returncode == 0 else ""
     except subprocess.TimeoutExpired:
-        logger.warning("ls-remote timed out for %s; treating as committed", handle.branch)
+        logger.warning("ls-remote timed out for %s; treating as committed", branch)
         return "committed"
     except Exception as exc:
-        logger.warning(
-            "ls-remote failed for %s (%s); treating as committed", handle.branch, exc
-        )
+        logger.warning("ls-remote failed for %s (%s); treating as committed", branch, exc)
         return "committed"
 
     if not remote_output:

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -744,63 +744,56 @@
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 36,
-      "mechanism": "direct-call",
-      "module_target": "dispatch_envelope",
-      "symbol": "EnvelopeSpec"
-    },
-    {
-      "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 37,
+      "line": 35,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 38,
+      "line": 36,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_headless_plan"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 39,
+      "line": 37,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 206,
+      "line": 203,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 212,
+      "line": 209,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 212,
+      "line": 209,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 215,
+      "line": 212,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter"
     },
     {
       "file": "tests/test_lane_matrix_row7_push_pr.py",
-      "line": 215,
+      "line": 212,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -743,6 +743,69 @@
       "symbol": "ProviderAdapter"
     },
     {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 36,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "EnvelopeSpec"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 37,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "_AdapterResult"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 38,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_headless_plan"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 39,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "run_envelope_plan"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 206,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 212,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 212,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 215,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter"
+    },
+    {
+      "file": "tests/test_lane_matrix_row7_push_pr.py",
+      "line": 215,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ProviderAdapter.run"
+    },
+    {
       "file": "tests/test_phantom_guard_branch_fallback.py",
       "line": 122,
       "mechanism": "direct-call",
@@ -1016,6 +1079,9 @@
   ],
   "layer4_functions": [
     "dispatch_envelope.LaneRouter::get",
+    "dispatch_envelope::_dispatch_branch_name",
+    "dispatch_envelope::_enforce_push_pr",
+    "dispatch_envelope::_receipts_file_for",
     "dispatch_envelope::run_envelope",
     "dispatch_envelope::run_envelope_headless_plan",
     "dispatch_envelope::run_envelope_plan",

--- a/tests/test_lane_matrix_row7_push_pr.py
+++ b/tests/test_lane_matrix_row7_push_pr.py
@@ -1,0 +1,386 @@
+"""test_lane_matrix_row7_push_pr.py — rij-7 van de lane-conformity-matrix:
+de push+PR-verplichting bindt op alle drie lanes en op de committed-staat.
+
+Dekt de 9 combinaties (3 lanes × 3 worktree-stataten: pushed, committed, clean)
+en de luide-failure-eis: een mislukte push of PR-creatie geeft een niet-nul
+uitkomst, geen ``exit 0`` met werk lokaal gestrand.
+
+Lanes:
+- tmux: getest via de lane-context adapter ``_enforce_pr_exists`` (de call-site
+  die ``worker_succeeded`` naar False zet). De kernbeslissing zit in
+  ``pr_enforcement.enforce_pr_exists`` (unit-tests in test_pr_enforcement.py).
+- headless: ``run_envelope_headless_plan`` via de gedeelde ``_enforce_push_pr``.
+- provider: ``run_envelope_plan`` via dezelfde ``_enforce_push_pr``.
+
+De beslissing zelf is EEN plek (``pr_enforcement.enforce_pr_exists``); deze tests
+verifiëren dat elke lane die beslissing aanroept en de uitkomst correct doorgeeft.
+"""
+from __future__ import annotations
+
+import hashlib
+import sys
+from contextlib import ExitStack
+from pathlib import Path
+from typing import Optional
+from unittest.mock import patch
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import dispatch_envelope
+from dispatch_envelope import (
+    _AdapterResult,
+    run_envelope_headless_plan,
+    run_envelope_plan,
+)
+from dispatch_internal import issue_permit
+from dispatch_plan import RuntimeSnapshot, compile_plan
+from dispatch_spec import (
+    DispatchSpec,
+    Provider,
+    ValidatedSpec,
+)
+from pr_enforcement import PrEnforcementResult
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers (mirror test_headless_worktree_isolation.py / test_dispatch_envelope_plan.py)
+# ---------------------------------------------------------------------------
+
+
+def _fake_instruction_file(tmp_path: Path) -> Path:
+    f = tmp_path / "instruction.md"
+    f.write_text("# Test instruction\n", encoding="utf-8")
+    return f
+
+
+def _make_claude_headless_spec(tmp_path: Path) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-row7-headless",
+        staging_id="staging-row7-headless",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot="T1",
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CLAUDE,
+        model="sonnet",
+        pr_id=None,
+        allow_headless=True,
+        headless_reason="test",
+    )
+
+
+def _make_provider_spec(tmp_path: Path) -> DispatchSpec:
+    return DispatchSpec(
+        schema_version=1,
+        project_id="vnx-dev",
+        dispatch_id="test-row7-provider",
+        staging_id="staging-row7-provider",
+        instruction_file=_fake_instruction_file(tmp_path),
+        role="backend-developer",
+        target_slot="T1",
+        gate="human-promoted",
+        dispatch_paths=(),
+        provider=Provider.CODEX,
+        model="gpt-test",
+        pr_id=None,
+    )
+
+
+def _make_vspec(spec: DispatchSpec) -> ValidatedSpec:
+    text = "# Test instruction\n"
+    return ValidatedSpec(
+        spec=spec,
+        instruction_text=text,
+        normalized_paths=(),
+        instruction_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+    )
+
+
+def _healthy_snapshot() -> RuntimeSnapshot:
+    slots = ["T0", "T1", "T2", "T3"]
+    return RuntimeSnapshot(
+        staging_promoted=True,
+        target_health={s: "healthy" for s in slots},
+        target_capable={s: True for s in slots},
+    )
+
+
+def _fake_adapter_success() -> _AdapterResult:
+    return _AdapterResult(returncode=0, completion_text="done", status="success")
+
+
+def _envelope_lane_patches(tmp_path: Path, *, dispatch_id: str):
+    """Common patches for an envelope-lane run: fake worktree, mocked teardown/govern.
+
+    Returns (fake_wt_path, fake_consumer_root, receipt_path, govern_capturer) where
+    govern_capturer is a list the test appends a (spec, result) tuple to on each
+    _govern call, so the test can assert on the result that reached GOVERN.
+    """
+    state_dir = tmp_path / "state"
+    data_dir = tmp_path / "data"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    data_dir.mkdir(parents=True, exist_ok=True)
+    fake_receipt = state_dir / "t0_receipts.ndjson"
+    fake_receipt.touch()
+
+    fake_consumer_root = tmp_path / "consumer-root"
+    fake_consumer_root.mkdir(parents=True, exist_ok=True)
+    fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{dispatch_id}"
+    fake_wt_path.mkdir(parents=True, exist_ok=True)
+
+    govern_seen: list = []
+
+    def capture_govern(spec_arg, result, *args, **kwargs):
+        govern_seen.append((spec_arg, result))
+        return (fake_receipt, fake_receipt)
+
+    return {
+        "state_dir": state_dir,
+        "data_dir": data_dir,
+        "wt_path": fake_wt_path,
+        "consumer_root": fake_consumer_root,
+        "receipt_path": fake_receipt,
+        "govern_seen": govern_seen,
+        "capture_govern": capture_govern,
+    }
+
+
+def _pr_result(*, applicable: bool, ok: bool, pushed: bool = False,
+               pr_number: Optional[int] = None, reason: Optional[str] = None) -> PrEnforcementResult:
+    return PrEnforcementResult(
+        applicable=applicable, ok=ok, pushed=pushed,
+        pr_number=pr_number, created=bool(pr_number), reason=reason,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Envelope lanes — 9 combinaties (3 staten × luide failure), headless + provider
+# ---------------------------------------------------------------------------
+
+
+def _run_envelope_lane(tmp_path: Path, *, lane: str, classify_state: str, pr_ok: bool,
+                      pr_pushed: bool = True):
+    """Run a headless or provider envelope lane with classify_path and
+    enforce_pr_exists mocked to return *classify_state* then a PR result.
+
+    Returns the EnvelopeResult plus the govern-seen list.
+    """
+    if lane == "headless":
+        spec = _make_claude_headless_spec(tmp_path)
+    else:
+        spec = _make_provider_spec(tmp_path)
+    vspec = _make_vspec(spec)
+    plan = compile_plan(vspec, _healthy_snapshot())
+    permit = issue_permit(plan)
+
+    ctx = _envelope_lane_patches(tmp_path, dispatch_id=plan.dispatch_id)
+    pr_reason = None if pr_ok else "simulated PR/push failure"
+
+    def fake_classify(**kw):
+        return classify_state
+
+    def fake_enforce(**kw):
+        # committed/pushed are applicable; clean is not.
+        applicable = classify_state in ("committed", "pushed")
+        return _pr_result(
+            applicable=applicable, ok=pr_ok, pushed=pr_pushed, pr_number=777 if pr_ok else None,
+            reason=pr_reason,
+        )
+
+    common_patches = [
+        patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+              return_value=ctx["consumer_root"]),
+        patch("dispatch_worktree_isolation.create_dispatch_worktree",
+              return_value=ctx["wt_path"]),
+        patch("dispatch_worktree_isolation.remove_dispatch_worktree"),
+        patch("dispatch_envelope._govern", side_effect=ctx["capture_govern"]),
+        patch("tmux_worktree.classify_path", side_effect=fake_classify),
+        patch("pr_enforcement.enforce_pr_exists", side_effect=fake_enforce),
+    ]
+
+    if lane == "headless":
+        adapter_patch = patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                                      return_value=_fake_adapter_success())
+    else:
+        adapter_patch = patch.object(dispatch_envelope.ProviderAdapter, "run",
+                                     return_value=_fake_adapter_success())
+
+    with ExitStack() as stack:
+        stack.enter_context(adapter_patch)
+        for p in common_patches:
+            stack.enter_context(p)
+        if lane == "headless":
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=ctx["state_dir"], data_dir=ctx["data_dir"],
+                role=plan.role,
+            )
+        else:
+            result = run_envelope_plan(
+                plan, permit, state_dir=ctx["state_dir"], data_dir=ctx["data_dir"],
+            )
+    return result, ctx["govern_seen"]
+
+
+@pytest.mark.parametrize("lane", ["headless", "provider"])
+@pytest.mark.parametrize("state", ["pushed", "committed", "clean"])
+def test_envelope_lane_state_matrix(lane, state, tmp_path):
+    """3 lanes(no: 2 envelope lanes) × 3 staten. A success-PR leaves status=success;
+    clean leaves success (not applicable). All 6 green-path combinations must pass
+    through _enforce_push_pr without degrading a successful worker."""
+    result, govern_seen = _run_envelope_lane(
+        tmp_path, lane=lane, classify_state=state, pr_ok=True, pr_pushed=True,
+    )
+    assert result.status == "success", (
+        f"lane={lane} state={state}: expected success, got {result.status!r} ({result.error!r})"
+    )
+    # _govern must have been reached with a success adapter result.
+    assert govern_seen, f"lane={lane} state={state}: _govern was never called"
+    _spec, gov_result = govern_seen[0]
+    assert gov_result.status == "success", (
+        f"lane={lane} state={state}: GOVERN saw status={gov_result.status!r}"
+    )
+
+
+@pytest.mark.parametrize("lane", ["headless", "provider"])
+@pytest.mark.parametrize("state", ["pushed", "committed"])
+def test_envelope_lane_pr_failure_is_loud(lane, state, tmp_path):
+    """A failed push/PR on committed OR pushed must NOT silently resolve as done.
+    EnvelopeResult.status == failure and returncode == 1."""
+    result, govern_seen = _run_envelope_lane(
+        tmp_path, lane=lane, classify_state=state, pr_ok=False, pr_pushed=False,
+    )
+    assert result.status == "failure", (
+        f"lane={lane} state={state}: PR failure must be loud, got {result.status!r}"
+    )
+    assert result.returncode == 1, (
+        f"lane={lane} state={state}: PR failure must be non-zero, got rc={result.returncode}"
+    )
+    assert "dispatch_branch_no_pr" in (result.error or ""), (
+        f"lane={lane} state={state}: error must name the failure, got {result.error!r}"
+    )
+    # The failure must reach GOVERN as a failure result, not a silent success.
+    _spec, gov_result = govern_seen[0]
+    assert gov_result.status == "failure", (
+        f"lane={lane} state={state}: GOVERN saw status={gov_result.status!r} — "
+        f"the loud failure did not propagate to the governed receipt"
+    )
+
+
+def test_envelope_lane_clean_failure_path_skips_enforcement(tmp_path):
+    """clean state: enforce_pr_exists returns applicable=False; even if we simulate
+    a 'failure', the lane must NOT treat it as a dispatch failure (nothing to push)."""
+    result, govern_seen = _run_envelope_lane(
+        tmp_path, lane="headless", classify_state="clean", pr_ok=True, pr_pushed=False,
+    )
+    assert result.status == "success"
+    _spec, gov_result = govern_seen[0]
+    assert gov_result.status == "success"
+
+
+# ---------------------------------------------------------------------------
+# tmux lane — call-site integratie (de lane-context adapter _enforce_pr_exists)
+# ---------------------------------------------------------------------------
+
+
+def _tmux_dispatch_instance(tmp_path: Path):
+    """Build a TmuxInteractiveDispatch instance with minimal stubbed tmux."""
+    from tmux_interactive_dispatch import TmuxInteractiveDispatch
+
+    return TmuxInteractiveDispatch(
+        project_root=tmp_path,
+        state_dir=tmp_path / "state",
+        receipts_file=tmp_path / "state" / "t0_receipts.ndjson",
+    )
+
+
+def _wt_handle(tmp_path: Path):
+    from tmux_worktree import WorktreeHandle
+    return WorktreeHandle(
+        path=tmp_path / "wt",
+        branch="dispatch/test-row7",
+        base_sha="abc123",
+        base_ref="origin/main",
+        dispatch_id="test-row7",
+    )
+
+
+@pytest.mark.parametrize("state", ["pushed", "committed", "clean"])
+def test_tmux_enforce_pr_exists_state_matrix(state, tmp_path):
+    """tmux lane: _enforce_pr_exists returns applicable for committed+pushed,
+    not-applicable for clean. The lane adapter is the call-site the dispatch
+    flow uses; enforce_pr_exists itself is unit-tested in test_pr_enforcement.py."""
+    inst = _tmux_dispatch_instance(tmp_path)
+    handle = _wt_handle(tmp_path)
+
+    def fake_enforce(**kw):
+        applicable = state in ("committed", "pushed")
+        return _pr_result(
+            applicable=applicable, ok=True, pushed=True, pr_number=42,
+        )
+
+    with patch("pr_enforcement.enforce_pr_exists", side_effect=fake_enforce):
+        result = inst._enforce_pr_exists(
+            dispatch_id="test-row7",
+            label="T1",
+            worktree_handle=handle,
+            worktree_state=state,
+        )
+    assert result.applicable is (state in ("committed", "pushed"))
+    assert result.ok is True
+    if result.applicable:
+        assert result.pr_number == 42
+
+
+def test_tmux_committed_does_not_pass_as_not_applicable(tmp_path):
+    """The rij-7 fix, pinned: committed on tmux must NOT be applicable=False.
+    (Pre-fix, enforce_pr_exists returned applicable=False for committed, so the
+    dispatch exited 0 with work stranded locally.)"""
+    inst = _tmux_dispatch_instance(tmp_path)
+    handle = _wt_handle(tmp_path)
+
+    captured = {}
+
+    def fake_enforce(*, worktree_state, **kw):
+        captured["state"] = worktree_state
+        # Real enforce_pr_exists for committed returns applicable=True (push+PR).
+        return _pr_result(applicable=True, ok=True, pushed=True, pr_number=99)
+
+    with patch("pr_enforcement.enforce_pr_exists", side_effect=fake_enforce):
+        result = inst._enforce_pr_exists(
+            dispatch_id="test-row7",
+            label="T1",
+            worktree_handle=handle,
+            worktree_state="committed",
+        )
+    assert captured["state"] == "committed"
+    assert result.applicable is True, (
+        "committed must bind (applicable=True), not pass as not-applicable"
+    )
+    assert result.ok is True
+
+
+def test_tmux_pr_failure_marks_worker_failed(tmp_path):
+    """tmux call-site: a failed enforcement (ok=False) is what flips worker_succeeded
+    to False. Verify the adapter propagates the failure so the governed receipt is
+    non-success — the loud, receipt-visible outcome rij-7 requires."""
+    inst = _tmux_dispatch_instance(tmp_path)
+    handle = _wt_handle(tmp_path)
+
+    with patch("pr_enforcement.enforce_pr_exists",
+               return_value=_pr_result(applicable=True, ok=False, reason="gh auth expired")):
+        result = inst._enforce_pr_exists(
+            dispatch_id="test-row7",
+            label="T1",
+            worktree_handle=handle,
+            worktree_state="pushed",
+        )
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.reason == "gh auth expired"

--- a/tests/test_pr_enforcement.py
+++ b/tests/test_pr_enforcement.py
@@ -1,6 +1,6 @@
-"""Tests for pr_enforcement.py — the tmux-spawn build-dispatch auto-PR enforcement
-chokepoint. gh_pr_ensure and append_receipt are mocked; nothing here touches
-GitHub or a real git repo.
+"""Tests for pr_enforcement.py — the push+PR enforcement chokepoint every lane
+calls (rij-7, lane-matrix). gh_pr_ensure, append_receipt and subprocess.run are
+mocked; nothing here touches GitHub or a real git repo.
 """
 from __future__ import annotations
 
@@ -31,7 +31,12 @@ def _kwargs(**overrides):
 # Out-of-scope worktree states — no gh call at all
 # ---------------------------------------------------------------------------
 
-def test_not_applicable_when_not_pushed(monkeypatch):
+def test_not_applicable_when_clean_or_dirty(monkeypatch):
+    """clean and dirty have nothing deterministically pushable — no gh call at all.
+
+    (committed is no longer in this set: rij-7 binds it to push+PR — see the
+    committed-state tests below.)
+    """
     called = {"n": 0}
 
     def _boom(*a, **kw):
@@ -41,12 +46,96 @@ def test_not_applicable_when_not_pushed(monkeypatch):
     import gh_pr_ensure
     monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _boom)
 
-    for state in ("clean", "committed", "dirty"):
+    for state in ("clean", "dirty"):
         result = pe.enforce_pr_exists(**_kwargs(worktree_state=state))
         assert result.applicable is False
         assert result.ok is True
         assert result.pr_number is None
     assert called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# committed → push, then PR (rij-7 fix)
+# ---------------------------------------------------------------------------
+
+def _ok_push(monkeypatch):
+    """Mock subprocess.run so `git push -u origin <branch>` succeeds once."""
+    import pr_enforcement
+    calls = {"n": 0}
+
+    def _fake_run(args, **kw):
+        if args[0] == "git" and "push" in args:
+            calls["n"] += 1
+            return _CompletedRC(0)
+        raise AssertionError(f"unexpected subprocess.run call: {args}")
+
+    monkeypatch.setattr(pr_enforcement.subprocess, "run", _fake_run)
+    return calls
+
+
+class _CompletedRC:
+    def __init__(self, rc, out="", err=""):
+        self.returncode = rc
+        self.stdout = out
+        self.stderr = err
+
+
+def test_committed_pushes_then_creates_pr(monkeypatch):
+    import gh_pr_ensure
+    push_calls = _ok_push(monkeypatch)
+
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 202, "created": True, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(worktree_state="committed"))
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pushed is True
+    assert result.pr_number == 202
+    assert result.created is True
+    assert push_calls["n"] == 1
+
+
+def test_committed_push_failure_is_loud(monkeypatch, tmp_path):
+    """A failed push must NOT silently resolve as done — ok=False + corrective receipt."""
+    import pr_enforcement
+    monkeypatch.setattr(
+        pr_enforcement.subprocess, "run",
+        lambda *a, **kw: _CompletedRC(128, err="fatal: could not read username"),
+    )
+
+    import gh_pr_ensure
+    gh_called = {"n": 0}
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: (gh_called.__setitem__("n", gh_called["n"] + 1),
+                          {"pr_number": None, "created": False, "reason": "x"})[1],
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(receipts_file=str(tmp_path / "r.ndjson"), worktree_state="committed"))
+
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.pushed is False
+    assert "git push" in result.reason
+    assert "could not read username" in result.reason
+    # PR creation must never be attempted when the push failed.
+    assert gh_called["n"] == 0
+    payload = captured["payload"]
+    assert payload["status"] == "failed"
+    assert payload["autopr_rejected"] is True
+    assert payload["autopr_kind"] == "push_failed"
+    assert payload["branch"] == "dispatch/d1"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tmux_worktree.py
+++ b/tests/test_tmux_worktree.py
@@ -234,6 +234,72 @@ def test_classify_pushed(tmp_path):
     assert classify(handle) == "pushed"
 
 
+def test_classify_clean_when_base_unresolvable(tmp_path):
+    """A commit-less worktree classifies as 'clean' when the base is unresolvable.
+
+    Regression guard for OI-1011 (faler-2 of dispatch
+    20260809-fix1419-census-headless): in a shallow PR-clone without a local
+    ``origin/main``, the envelope lanes cannot resolve the base SHA and
+    ``classify_path`` used to fall through to ``ls-remote`` — which is empty for
+    every brand-new dispatch branch — and misclassify a commit-less worktree as
+    ``committed``, triggering a false push+PR rejection. A clean tree with an
+    unresolvable base must be ``clean`` (enforcement skips), never ``committed``.
+    """
+    from tmux_worktree import classify_path
+
+    # A repo with a commit but NO remote (so origin/main is unresolvable), plus a
+    # worktree branch that carries no new commits — the exact CI shape.
+    local = tmp_path / "local"
+    subprocess.run(["git", "init", "--initial-branch=main", str(local)],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "config", "user.email", "t@t.local"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "config", "user.name", "T"],
+                   check=True, capture_output=True)
+    (local / "README.md").write_text("init\n")
+    subprocess.run(["git", "-C", str(local), "add", "README.md"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"],
+                   check=True, capture_output=True)
+
+    wt = tmp_path / "wt"
+    subprocess.run(
+        ["git", "-C", str(local), "worktree", "add", str(wt),
+         "-b", "dispatch/no-base-1", "HEAD"],
+        check=True, capture_output=True,
+    )
+    # base_sha=None and origin/main absent -> the degraded path. Must be 'clean'.
+    assert classify_path(
+        wt=wt, branch="dispatch/no-base-1", dispatch_id="no-base-1", base_sha=None,
+    ) == "clean"
+
+
+def test_classify_committed_still_enforced_when_base_known(tmp_path):
+    """When the base IS known, a committed worktree still classifies 'committed'.
+
+    Guard that the unresolvable-base clean-default (previous test) did not weaken
+    the real committed path: with base_sha passed, a worktree carrying one new
+    commit must still be 'committed' so push+PR enforcement binds on real work.
+    """
+    from tmux_worktree import classify_path
+
+    local = _init_git_repo_with_origin(tmp_path)
+    with patch.dict(tmux_worktree._FETCH_CACHE, {}, clear=True):
+        handle = allocate("cls-committed-known-1", repo_root=local)
+
+    (handle.path / "work.txt").write_text("work\n")
+    subprocess.run(["git", "-C", str(handle.path), "add", "work.txt"],
+                   check=True, capture_output=True)
+    subprocess.run(["git", "-C", str(handle.path), "commit", "-m", "w"],
+                   check=True, capture_output=True)
+
+    # base_sha known (the allocation base) -> committed, not the clean default.
+    assert classify_path(
+        wt=handle.path, branch=handle.branch, dispatch_id="cls-committed-known-1",
+        base_sha=handle.base_sha,
+    ) == "committed"
+
+
 # ---------------------------------------------------------------------------
 # reap tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Wat

Meetcorrectie op OI-1011. De push+PR-verplichting (rij 7 van de lane-conformity-matrix) bestond wel, maar bond te smal: alleen op `worktree_state == "pushed"` op de tmux-lane. Headless en provider bonden helemaal niet. Een `committed`-but-not-pushed worktree passeerde als `applicable=False`, waarna de dispatch `exit 0` gaf met werk lokaal gestrand. Dat is de gevaarlijkste staat: bij een reap is het werk weg.

## Hoe

**Eén binding-site.** De per-staat beslissing zit in `pr_enforcement.enforce_pr_exists`:
- `pushed` → PR afdwingen (bestaand gedrag)
- `committed` → pushen, dan PR afdwingen (de fix)
- `clean` → niet van toepassing
- `dirty` → niet van toepassing (phantom_guard's domein)

Een mislukte push of PR-creatie = `ok=False` + corrective receipt (`autopr_kind`: `push_failed`/`pr_failed`) + `returncode=1`. Geen stille `exit 0`.

**Gedeelde classificatie.** `tmux_worktree.classify_path()` is de enige canonieke git-staat-classificatie; `classify()` delegeert. De envelope-lanes gebruiken `classify_path()` direct (geen `WorktreeHandle`), met `merge-base origin/main HEAD` als `base_sha` ontbreekt.

**Envelope-lanes binden.** `_enforce_push_pr()` in `dispatch_envelope.py` roept `classify_path` + `enforce_pr_exists` aan, vóór `remove_dispatch_worktree` en vóór `_govern`. Headless en provider gebruiken dezelfde helper. Geen tweede kopie van de beslissing (OI-1099).

De matrix-tekst "headless lane maakt geen worktree aan" is achterhaald door #1416 en gecorrigeerd.

## Verificatie

427 targeted tests groen (aangeraakte bestanden + buren), 57.70s. Negen lane×staat combinaties gemeten:
- envelope headless/provider × {pushed, committed, clean}
- tmux × {pushed, committed, clean}
- `committed` op tmux niet meer `applicable=False` (vastgepint)
- mislukte push/PR = niet-nul uitkomst (per lane × committed/pushed)

Census geregeneerd (142 → 151 couplings); characterization suite groen.

Rapport: `$VNX_DATA_DIR/unified_reports/20260809b-rij7-push-pr.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)