### PR TITLE
fix(gate): require producer identity on non-KNOWN_GATES evidence (OI-1093)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -440,28 +440,6 @@ def _apply_codex_severity_policy(result: Dict[str, Any]) -> Dict[str, Any]:
     return new_result
 
 
-def _gate_terminal_status(result: Dict[str, Any]) -> str:
-    """Return canonical terminal status ("pass"/"fail") for a gate result, or empty when non-terminal.
-
-    Two persisted formats are recognised so completed Claude reviews cannot bypass enforcement:
-    - Standard gates persist ``{"status": ...}`` or ``{"verdict": ...}``.
-    - claude_github_optional persists ``{"state": "completed", "result_status": "pass"|"fail"}``
-      and does not write top-level ``status``/``verdict``. Without this branch, terminal-failure
-      and report-path enforcement skip a completed Claude review with ``result_status="fail"``.
-    """
-    status = (result.get("status") or "").lower()
-    if status in ("pass", "fail"):
-        return status
-    verdict = (result.get("verdict") or "").lower()
-    if verdict in ("pass", "fail"):
-        return verdict
-    if (result.get("state") or "").lower() == "completed":
-        rs = (result.get("result_status") or "").lower()
-        if rs in ("pass", "fail"):
-            return rs
-    return ""
-
-
 def _check_contract_fields(contract: ReviewContract) -> List[CheckResult]:
     """Validate required contract fields. Returns a single FAIL on missing field (caller should return early), or a PASS."""
     if not contract.pr_id:
@@ -968,8 +946,9 @@ def _detect_gate_report_contradictions(
 
         # Use gate_is_pass so all PASS_STATES (completed, approve, passed, pass)
         # are treated as a positive gate outcome for contradiction purposes.
-        # _gate_terminal_status only returns "pass"/"fail"/""  — it misses
-        # status="completed" and status="approve" which are valid pass states.
+        # A narrower check that only recognises literal "pass"/"fail" would
+        # miss status="completed" and status="approve", which are valid pass
+        # states too.
         passed, _ = gate_is_pass(result)
         gate_blocking = result.get("blocking_count", 0)
         if not isinstance(gate_blocking, int):

--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -34,6 +34,7 @@ SCRIPT_DIR = Path(__file__).resolve().parent
 sys.path.insert(0, str(SCRIPT_DIR / "lib"))
 
 from plan_gate_panel import _make_default_dispatcher  # governed provider_dispatch lane
+from gate_recorder import record_terminal_result
 
 _VALID_VERDICTS = {"pass", "fail", "blocked"}
 
@@ -178,11 +179,10 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if data_dir:
         results_dir = Path(data_dir) / "state" / "review_gates" / "results"
-        results_dir.mkdir(parents=True, exist_ok=True)
         out = results_dir / f"pr-{args.pr}-kimi_gate.json"
-        tmp = out.with_suffix(".json.tmp")
-        tmp.write_text(json.dumps(record, indent=2), encoding="utf-8")
-        tmp.replace(out)
+        record_terminal_result(
+            gate="kimi_gate", pr_id=record["pr_id"], result_path=out, payload=record,
+        )
         print(f"kimi_gate: wrote {out}", file=sys.stderr)
 
     if args.json:

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -126,6 +126,46 @@ def write_skip_rationale(
 # ---------------------------------------------------------------------------
 
 
+def record_terminal_result(
+    *,
+    gate: str,
+    pr_id: str,
+    result_path: Path,
+    payload: Dict[str, Any],
+) -> Path:
+    """Atomically persist a terminal (pass/fail) gate result at an explicit path.
+
+    Single write path for gates outside the built-in review_gate_manager
+    pipeline (codex_gate/gemini_review/ci_gate/claude_github_optional
+    already enforce contract_hash + report_path at write time via
+    gate_result_parser._validate_and_persist_result). A free-form gate like
+    kimi_gate had no such enforcement, so nothing stopped a hand-authored
+    JSON from landing in review_gates/results/ indistinguishable from a real
+    run (OI-1093: three such records surfaced in mission-control's store).
+    Refusing to write a terminal result without producer identity closes
+    that gap for every future writer that routes through this function.
+
+    Non-terminal payloads (pending/running/queued) are not gate evidence
+    yet, so they are not held to this requirement. The caller
+    resolves ``result_path`` itself — gate writers use different filename
+    conventions (legacy ``pr-N-gate.json`` vs. ``{slug}-gate-contract.json``)
+    and this function does not need to know which.
+    """
+    from gate_status import is_terminal, has_producer_identity  # noqa: PLC0415
+
+    if is_terminal(payload) and not has_producer_identity(payload):
+        raise ValueError(
+            f"{gate} result for pr_id={pr_id!r} has a terminal status "
+            f"({payload.get('status')!r}) but no producer identity "
+            f"(dispatch_id) — refusing to write unauthenticated gate evidence"
+        )
+    result_path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = result_path.with_suffix(".json.tmp")
+    tmp.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+    tmp.replace(result_path)
+    return result_path
+
+
 def record_not_executable(
     *,
     gate: str,

--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -101,3 +101,23 @@ def canonical_status(result: Dict[str, Any]) -> str:
     """
     status, _ = _coerce_status(result)
     return status
+
+
+def has_producer_identity(result: Dict[str, Any]) -> bool:
+    """True when a gate result carries a producer identity (OI-1093).
+
+    Requires a non-empty ``dispatch_id``. That field is the one that ties a
+    result back to a real governed dispatch in the audit trail — every
+    process that writes through the fleet's single-entry dispatch door
+    produces one. ``provider``/``model`` alone are not sufficient: they are
+    free-text values a hand-authored JSON can carry just as easily as a real
+    writer, with no corroborating trail to check them against.
+
+    This is deliberately narrower than "is this a valid gate result" — a
+    record can be well-formed (status, contract_hash, report_path all
+    present) and still have no producer identity, e.g. a result written by
+    hand rather than by a governed gate run. Callers decide what to do with
+    that distinction; this function only answers the identity question.
+    """
+    dispatch_id = result.get("dispatch_id")
+    return isinstance(dispatch_id, str) and bool(dispatch_id.strip())

--- a/scripts/roadmap_manager.py
+++ b/scripts/roadmap_manager.py
@@ -23,8 +23,8 @@ sys.path.insert(0, str(SCRIPT_DIR))
 from vnx_paths import ensure_env
 from governance_receipts import emit_governance_receipt, utc_now_iso
 from pr_queue_manager import PRQueueManager
-from closure_verifier import verify_closure, _find_gate_result
-from gate_status import is_pass as gate_is_pass
+from closure_verifier import verify_closure, _find_gate_result, _KNOWN_GATES
+from gate_status import is_pass as gate_is_pass, has_producer_identity as gate_has_producer_identity
 from project_scope import current_project_id
 from vnx_worktree import worktree_start
 
@@ -412,6 +412,17 @@ Implement the minimum blocking fix required before the roadmap may advance.
                 if not report_path or not Path(report_path).exists():
                     return True
                 if not contract_hash:
+                    return True
+                # OI-1093: gates in _KNOWN_GATES go through review_gate_manager's
+                # record_result(), which refuses to write a pass/fail result without
+                # contract_hash + report_path already (gate_result_parser._validate_and_
+                # persist_result) — that write-time check is the compensating control
+                # for those four gates. A free-form gate name outside _KNOWN_GATES (e.g.
+                # kimi_gate) has no such writer-side enforcement, so a hand-authored JSON
+                # with a plausible contract_hash and an existing report_path would
+                # otherwise satisfy this check with zero trace of who produced it.
+                # Require producer identity as the compensating control for those.
+                if gate not in _KNOWN_GATES and not gate_has_producer_identity(result):
                     return True
 
         return False

--- a/tests/test_gate_recorder_provenance.py
+++ b/tests/test_gate_recorder_provenance.py
@@ -1,0 +1,90 @@
+"""Tests for gate_recorder.record_terminal_result (OI-1093).
+
+record_terminal_result is the single write path a hand-authored JSON cannot
+route through unnoticed: it refuses to persist a terminal (pass/fail) gate
+result that carries no producer identity (dispatch_id).
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_recorder import record_terminal_result
+
+
+def test_terminal_pass_without_dispatch_id_is_refused(tmp_path):
+    payload = {
+        "gate": "kimi_gate",
+        "pr_id": "378",
+        "status": "passed",
+        "contract_hash": "abc123",
+        "report_path": "/tmp/report.md",
+    }
+    with pytest.raises(ValueError, match="producer identity"):
+        record_terminal_result(
+            gate="kimi_gate", pr_id="378",
+            result_path=tmp_path / "pr-378-kimi_gate.json",
+            payload=payload,
+        )
+    assert not (tmp_path / "pr-378-kimi_gate.json").exists(), (
+        "refused write must not leave a partial file behind"
+    )
+
+
+def test_terminal_fail_without_dispatch_id_is_refused(tmp_path):
+    payload = {"gate": "kimi_gate", "pr_id": "378", "status": "fail"}
+    with pytest.raises(ValueError, match="producer identity"):
+        record_terminal_result(
+            gate="kimi_gate", pr_id="378",
+            result_path=tmp_path / "pr-378-kimi_gate.json",
+            payload=payload,
+        )
+
+
+def test_terminal_result_with_dispatch_id_writes_unchanged(tmp_path):
+    payload = {
+        "gate": "kimi_gate",
+        "pr_id": "904",
+        "status": "pass",
+        "provider": "kimi",
+        "model": "kimi-k2-7-code",
+        "dispatch_id": "kimi-gate-pr904-1782239641",
+    }
+    out = tmp_path / "pr-904-kimi_gate.json"
+    result_path = record_terminal_result(
+        gate="kimi_gate", pr_id="904", result_path=out, payload=payload,
+    )
+    assert result_path == out
+    assert json.loads(out.read_text(encoding="utf-8")) == payload
+
+
+def test_non_terminal_result_without_dispatch_id_is_not_held_to_identity(tmp_path):
+    """A non-terminal status (e.g. pending) is not gate evidence yet, so it is
+    not required to carry producer identity."""
+    payload = {"gate": "kimi_gate", "pr_id": "1", "status": "pending"}
+    out = tmp_path / "pr-1-kimi_gate.json"
+    record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=payload)
+    assert json.loads(out.read_text(encoding="utf-8")) == payload
+
+
+def test_write_is_atomic_no_tmp_file_left_behind(tmp_path):
+    payload = {"gate": "kimi_gate", "pr_id": "905", "status": "pass", "dispatch_id": "kimi-gate-pr905-1"}
+    out = tmp_path / "pr-905-kimi_gate.json"
+    record_terminal_result(gate="kimi_gate", pr_id="905", result_path=out, payload=payload)
+    assert out.exists()
+    assert not (tmp_path / "pr-905-kimi_gate.json.tmp").exists()
+
+
+def test_creates_parent_directory(tmp_path):
+    out = tmp_path / "nested" / "results" / "pr-1-kimi_gate.json"
+    payload = {"gate": "kimi_gate", "pr_id": "1", "status": "pass", "dispatch_id": "kimi-gate-pr1-1"}
+    record_terminal_result(gate="kimi_gate", pr_id="1", result_path=out, payload=payload)
+    assert out.exists()

--- a/tests/test_gate_status_schema.py
+++ b/tests/test_gate_status_schema.py
@@ -24,6 +24,7 @@ from gate_status import (
     INCOMPLETE_STATES,
     PASS_STATES,
     canonical_status,
+    has_producer_identity,
     is_pass,
     is_terminal,
 )
@@ -158,6 +159,58 @@ def test_pass_states_disjoint_from_fail_and_incomplete() -> None:
     assert PASS_STATES.isdisjoint(FAIL_STATES)
     assert PASS_STATES.isdisjoint(INCOMPLETE_STATES)
     assert FAIL_STATES.isdisjoint(INCOMPLETE_STATES)
+
+
+# ---------------------------------------------------------------------------
+# has_producer_identity (OI-1093): dispatch_id is the sole required field
+# ---------------------------------------------------------------------------
+
+
+def test_has_producer_identity_true_with_dispatch_id() -> None:
+    """A record with a non-empty dispatch_id carries producer identity."""
+    result = {"provider": "kimi", "model": "kimi-k2-7-code", "dispatch_id": "kimi-gate-pr904-1782239641"}
+    assert has_producer_identity(result) is True
+
+
+def test_has_producer_identity_false_without_dispatch_id() -> None:
+    """No dispatch_id at all → no producer identity, even with other fields present.
+
+    Mirrors the three hand-authored mission-control kimi_gate records: they
+    carry contract_hash/report_path/recorded_at/branch but no dispatch_id.
+    """
+    result = {
+        "status": "passed",
+        "contract_hash": "c6c11d38c872a2081495b2dbe326f44c96c1e9742a94ae090e37cbb2a2f2af18",
+        "report_path": "/tmp/report.md",
+        "residual_risk": "None",
+        "recorded_at": "2026-06-23T15:10:51Z",
+        "branch": "golf-a/deadcode-linkedin-engine",
+    }
+    assert has_producer_identity(result) is False
+
+
+def test_has_producer_identity_false_with_empty_dispatch_id() -> None:
+    assert has_producer_identity({"dispatch_id": ""}) is False
+    assert has_producer_identity({"dispatch_id": "   "}) is False
+
+
+def test_has_producer_identity_false_with_non_string_dispatch_id() -> None:
+    assert has_producer_identity({"dispatch_id": None}) is False
+    assert has_producer_identity({"dispatch_id": 12345}) is False
+
+
+def test_has_producer_identity_provider_and_model_alone_are_not_sufficient() -> None:
+    """provider+model without dispatch_id is not identity — both are free-text.
+
+    A hand-authored record can set provider="kimi", model="kimi-k2.7" just as
+    easily as a real writer; only dispatch_id ties back to a real dispatch.
+    """
+    result = {"provider": "kimi", "model": "kimi-k2.7"}
+    assert has_producer_identity(result) is False
+
+
+def test_has_producer_identity_false_on_empty_result() -> None:
+    assert has_producer_identity({}) is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_kimi_gate_provenance.py
+++ b/tests/test_kimi_gate_provenance.py
@@ -1,0 +1,69 @@
+"""kimi_gate.py write-path tests (OI-1093).
+
+kimi_gate.py used to json.dump its result record directly. It now routes
+through gate_recorder.record_terminal_result, the shared write path that
+refuses a terminal result without producer identity. These tests prove the
+refactor did not change kimi_gate's own output (it always sets provider/
+model/dispatch_id, so it never trips the new guard) and that the file it
+writes satisfies gate_status.has_producer_identity.
+
+_make_default_dispatcher is patched on the kimi_gate module namespace, not
+on plan_gate_panel where it is defined — `from X import Y` binds the name at
+import time, so patching the source module would not affect kimi_gate's
+already-bound reference.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import kimi_gate
+from gate_status import has_producer_identity
+
+
+_FAKE_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+
+def test_main_writes_result_with_producer_identity(tmp_path, monkeypatch):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text("diff --git a/x b/x\n+ok\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: lambda *a2, **k2: _FAKE_REPORT)
+
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+
+    assert rc == 0
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    assert out.exists()
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["status"] == "pass"
+    assert has_producer_identity(record) is True
+    assert not out.with_suffix(".json.tmp").exists()
+
+
+def test_main_offline_run_is_stamped_test_run(tmp_path, monkeypatch):
+    """--diff-file runs are test_run:true regardless of the recorder refactor —
+    closure_verifier must still refuse them as evidence for a real PR."""
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text("diff --git a/x b/x\n+ok\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: lambda *a2, **k2: _FAKE_REPORT)
+
+    kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8"))
+    assert record["test_run"] is True

--- a/tests/test_roadmap_manager.py
+++ b/tests/test_roadmap_manager.py
@@ -597,6 +597,113 @@ def test_gates_incomplete_branch_less_result(roadmap_env, monkeypatch):
     assert result["verdict"] == "gates_incomplete", "branch-less result must be rejected as stale"
 
 
+def _write_roadmap_with_kimi_gate(project_root: Path) -> Path:
+    """A feature whose review_stack includes a gate outside closure_verifier's
+    _KNOWN_GATES — reuses feature-a's FEATURE_PLAN.md (same single PR-0)."""
+    roadmap_file = project_root / "ROADMAP_KIMI.yaml"
+    roadmap_file.write_text(
+        """features:
+  - feature_id: feature-kimi
+    title: Feature Kimi
+    plan_path: roadmap/features/feature-a/FEATURE_PLAN.md
+    branch_name: feature/a
+    risk_class: low
+    merge_policy: conditional_auto
+    review_stack: [kimi_gate]
+    depends_on: []
+    status: planned
+""",
+        encoding="utf-8",
+    )
+    return roadmap_file
+
+
+def _write_kimi_gate_result(gate_results_dir: Path, *, dispatch_id: str = "") -> None:
+    """Write a kimi_gate result shaped like the OI-1093 mission-control records:
+    contract_hash + report_path + branch + project_id all present. Only
+    dispatch_id varies between the hand-authored and real-writer shapes."""
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    report_file = gate_results_dir / "pr0-kimi_gate-report.md"
+    report_file.write_text("# kimi_gate report for PR-0\n", encoding="utf-8")
+    data = {
+        "pr_id": "PR-0",
+        "gate": "kimi_gate",
+        "status": "passed",
+        "project_id": "vnx-dev",
+        "branch": "feature/a",
+        "report_path": str(report_file),
+        "contract_hash": "c6c11d38c872a2081495b2dbe326f44c96c1e9742a94ae090e37cbb2a2f2af18",
+    }
+    if dispatch_id:
+        data["dispatch_id"] = dispatch_id
+    (gate_results_dir / "pr0-kimi_gate-contract.json").write_text(
+        json.dumps(data), encoding="utf-8",
+    )
+
+
+def test_gates_incomplete_unknown_gate_without_producer_identity(roadmap_env, monkeypatch):
+    """OI-1093: a kimi_gate result with contract_hash + report_path but no
+    dispatch_id must NOT satisfy advance — mirrors the three hand-authored
+    mission-control records that had every field except producer identity."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(_write_roadmap_with_kimi_gate(roadmap_env["project_root"]))
+    manager.load_feature("feature-kimi")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    _write_kimi_gate_result(gate_results_dir, dispatch_id="")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "gates_incomplete", (
+        "a gate result with no producer identity must not satisfy advance"
+    )
+
+
+def test_advance_unknown_gate_with_producer_identity_satisfies(roadmap_env, monkeypatch):
+    """OI-1093: the same record shape, but with a real dispatch_id, satisfies
+    advance unchanged — mirrors the nine real vnx-dev kimi_gate writes."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(_write_roadmap_with_kimi_gate(roadmap_env["project_root"]))
+    manager.load_feature("feature-kimi")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    _write_kimi_gate_result(gate_results_dir, dispatch_id="kimi-gate-pr0-1782239641")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "pass", (
+        "a gate result with a real dispatch_id must satisfy advance unchanged"
+    )
+
+
+def test_known_gates_unaffected_by_missing_producer_identity(roadmap_env, monkeypatch):
+    """OI-1093 must not touch _KNOWN_GATES: gemini_review/codex_gate results
+    written without any dispatch_id (today's real shape) still satisfy advance."""
+    manager = rm.RoadmapManager()
+    manager.init_roadmap(roadmap_env["roadmap_file"])
+    manager.load_feature("feature-a")
+    monkeypatch.setattr(
+        rm, "verify_closure",
+        lambda **kwargs: {"verdict": "pass", "pr": {"mergeCommit": {"oid": "abc123"}}},
+    )
+
+    gate_results_dir = roadmap_env["state_dir"] / "review_gates" / "results"
+    gate_results_dir.mkdir(parents=True, exist_ok=True)
+    _write_gate_result(gate_results_dir, "PR-0", "gemini_review", branch="feature/a")
+    _write_gate_result(gate_results_dir, "PR-0", "codex_gate", branch="feature/a")
+
+    result = manager.reconcile()
+    assert result["verdict"] == "pass", (
+        "_KNOWN_GATES results carry no dispatch_id today and must not regress"
+    )
+
+
 def test_advance_fully_valid_gate_result_proceeds(roadmap_env, monkeypatch):
     """Fully-valid result (status pass + report on disk + contract_hash + matching project_id + branch) → advance proceeds."""
     manager = rm.RoadmapManager()


### PR DESCRIPTION
## Samenvatting

Een gate-resultaatrecord voor een gate **buiten** `closure_verifier`'s `_KNOWN_GATES` (zoals `kimi_gate`) moet nu een `dispatch_id` dragen om `roadmap_manager`'s gate-volledigheidscontrole te bevredigen.

## Het gemeten lek zat ergens anders dan de OI beschrijft

OI-1093 wees naar `closure_verifier`. Dat bleek niet te kloppen: de unknown-gate-tak van `_check_single_gate` geeft al **onvoorwaardelijk** `UNVERIFIED` zodra een gate niet in `_KNOWN_GATES` zit, ongeacht inhoud. Dat pad was al fail-closed.

Het echte, exploiteerbare gat zit in `scripts/roadmap_manager.py::_gates_incomplete()`. Die loopt over **elke** gate in de `review_stack` (niet gefilterd op `_KNOWN_GATES`) en accepteert een record zodra:

1. `gate_is_pass(result)` waar is,
2. `report_path` op schijf bestaat,
3. `contract_hash` niet leeg is.

Nul identiteitscontrole. Empirisch getoetst tegen de echte bestanden:

| Records | contract_hash | Zou de gate sluiten? |
|---|---|---|
| 9 echte `vnx-dev` kimi_gate-records | ontbreekt volledig | nee, faalt op stap 3 |
| 3 handgeschreven `mission-control`-records | 64-hex aanwezig, rapport bestaat | **ja** |

Die drie zijn op 2026-06-23 met de hand weggeschreven door een agent-sessie (vastgelegd in de burn-in-log van die repo). Ze dragen geen enkel veld dat zegt wie ze schreef.

## Waarom de scope beperkt is

`has_producer_identity()` eist **`dispatch_id`** specifiek, niet `provider`/`model`. Die twee zijn vrije tekst die een handgeschreven record net zo goed kan dragen; `dispatch_id` koppelt terug aan een echte governed dispatch in de audit trail.

De eis geldt bewust **alleen** voor gates buiten `_KNOWN_GATES`. Echte `codex_gate`- en `gemini_review`-records, geschreven door `review_gate_manager.record_result()`, dragen vandaag helemaal geen identiteitsvelden. Een brede eis zou vrijwel alle historische evidence met terugwerkende kracht laten falen. De vier `_KNOWN_GATES` krijgen hun contract_hash/report_path-dwang al bij schrijftijd via `gate_result_parser._validate_and_persist_result`.

## Wijzigingen

- `scripts/lib/gate_status.py` — `has_producer_identity(result)`, canonieke predicate met de keuze voor `dispatch_id` gemotiveerd in de docstring.
- `scripts/roadmap_manager.py` — `_gates_incomplete()` eist de identiteit voor niet-`_KNOWN_GATES`. Een record zonder identiteit geeft "incomplete", nooit een stille PASS en nooit een crash.
- `scripts/lib/gate_recorder.py` — `record_terminal_result()`: één schrijfweg, atomair, weigert een terminale payload zonder identiteit. Niet-terminale payloads (pending/running) vallen er buiten, want dat is nog geen bewijs.
- `scripts/kimi_gate.py` — gebruikt die schrijfweg in plaats van een eigen `json.dump`. Gedragsneutraal vandaag (kimi_gate zet die velden al), structureel van waarde: een volgende bewerking erft de eis.
- `scripts/closure_verifier.py` — `_gate_terminal_status` verwijderd. Nul aanroepers, en het was een tweede statusvocabulaire naast de canonieke die `failed`/`errored`/`blocked` als "nog geen oordeel" las.

**Bestaande records worden niet herschreven.** Het grootboek blijft append-only; alleen de interpretatie bij een toekomstige lezing verandert.

## Verificatie

17 nieuwe tests. Narrow set 153 → **170 passed**, wide set 317 → **334 passed**, met de 27 pre-existing falers byte-voor-byte identiek voor en na (geverifieerd via `git stash`-diff).

## Herkomst

Werk uitgevoerd op claude/sonnet via de tmux-subscription-lane onder een operator-goedgekeurde `VNX_OVERRIDE_WORKER_CLAUDE` (kimi-quota uitgeput mid-run). De worker heeft de branch niet gepusht; T0 heeft het werk uit de worktree gered en gecommit voordat de reaper langskwam. Dat is precies de faalmodus die OI-1011 beschrijft en die PR #1419 dicht.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BKKmcvkMaXpRGvLrLMSK8o