### PR TITLE
feat(worktree): governed release path for locked worktrees (OI-1052)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -326,6 +326,8 @@ Worktree commands:
   worktree-stop      Merge intelligence back to main and clean up
   worktree-refresh   Update intelligence snapshot from main
   worktree-status    Show worktree isolation status
+  worktree-release   Governed release path for locked worktrees (OI-1052)
+                     Dry-run default; --apply to unlock, rescue, and remove
 
 Pool commands (elastic worker pool management):
   pool status [--project <id>] [--pool-id <p>] [--json]  Show pool state
@@ -2468,6 +2470,9 @@ main() {
       ;;
     worktree-status)
       cmd_worktree_status
+      ;;
+    worktree-release)
+      cmd_worktree_release "$@"
       ;;
     snapshot)
       cmd_snapshot "$@"

--- a/scripts/commands/release_worktree.sh
+++ b/scripts/commands/release_worktree.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# VNX Command: worktree-release
+# Governed release path for locked worktrees (OI-1052).
+#
+# Re-classifies every locked worktree, rescues committable/unpushed work
+# to origin branches, then unlocks and removes the worktree.
+# Default is dry-run: nothing is deleted without --apply.
+#
+# This file is sourced by bin/vnx's command loader. All functions and variables
+# from the main script (log, err, PROJECT_ROOT, VNX_HOME, etc.)
+# are available when this runs.
+
+cmd_worktree_release() {
+  local apply=0
+  local json_output=0
+
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --apply)
+        apply=1; shift ;;
+      --dry-run)
+        apply=0; shift ;;
+      --json)
+        json_output=1; shift ;;
+      -h|--help)
+        cat <<HELP
+Usage: vnx worktree-release [options]
+
+Re-classify every locked git worktree, rescue committable/unpushed work to
+origin branches, then unlock and remove the worktree.
+
+The default is dry-run: report what would happen without changing anything.
+Pass --apply to actually unlock, rescue, and remove.
+
+Options:
+  --apply          Execute the release (default: dry-run only)
+  --dry-run        Report only, make no changes (default)
+  --json           Machine-readable JSON output
+  -h, --help       Show this help
+
+Classification:
+  releasable       Clean working tree, all commits pushed — safe to remove
+  committable      Uncommitted changes, no local-only commits — auto-commit
+                   to a vnx-release/<branch> rescue branch on origin
+  unpushed_commits Local commits not on origin — push the existing branch
+  both             Both uncommitted changes AND unpushed commits — commit
+                   then push
+  unreachable      Worktree directory does not exist — skip
+  error            Git operation failed — skip, leave locked
+
+Safety:
+  - Dry-run is the DEFAULT. Nothing is deleted without --apply.
+  - A worktree whose work cannot be rescued remains locked.
+  - Rescue pushes to origin (vnx-release/<branch> for salvage commits);
+    the original local branch is deleted after successful push.
+
+Examples:
+  vnx worktree-release                    # dry-run: see what would happen
+  vnx worktree-release --apply            # actually release all locked worktrees
+  vnx worktree-release --json             # machine-readable dry-run
+HELP
+        return 0
+        ;;
+      -*)
+        err "[worktree-release] Unknown option: $1"
+        return 1
+        ;;
+      *)
+        err "[worktree-release] Unexpected argument: $1"
+        return 1
+        ;;
+    esac
+  done
+
+  # Resolve the Python script
+  local release_py="$VNX_HOME/scripts/lib/worktree_release.py"
+  if [ ! -f "$release_py" ]; then
+    err "[worktree-release] Python module not found: $release_py"
+    return 1
+  fi
+
+  # Resolve the Python interpreter
+  local python_bin="${VNX_PYTHON:-python3}"
+  if ! command -v "$python_bin" >/dev/null 2>&1; then
+    err "[worktree-release] Python interpreter not found: $python_bin"
+    return 1
+  fi
+
+  # Ensure scripts/lib is on the path
+  local lib_dir="$VNX_HOME/scripts/lib"
+
+  local -a py_args=("$release_py" "--repo-root" "$PROJECT_ROOT")
+  if [ "$apply" -eq 1 ]; then
+    py_args+=("--apply")
+  fi
+  if [ "$json_output" -eq 1 ]; then
+    py_args+=("--json")
+  fi
+
+  PYTHONPATH="$lib_dir:${PYTHONPATH:-}" "$python_bin" "${py_args[@]}"
+  local rc=$?
+
+  if [ "$apply" -eq 1 ] && [ $rc -eq 0 ]; then
+    log "[worktree-release] Release complete. Report saved in: $VNX_REPORTS_DIR"
+  fi
+
+  return $rc
+}

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -60,7 +60,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
 TIER_OPERATOR_ONLY: FrozenSet[str] = frozenset({
     "start", "stop", "restart", "jump", "ps", "cleanup",
     "new-worktree", "finish-worktree", "worktree-start", "worktree-stop",
-    "worktree-refresh", "worktree-status", "merge-preflight",
+    "worktree-refresh", "worktree-status", "worktree-release", "merge-preflight",
     "smoke", "package-check", "fabric-audit", "subsystems",
     "dispatch", "gate", "dream",
     "snapshot", "restore", "quiesce-check", "pause", "resume",

--- a/scripts/lib/worktree_release.py
+++ b/scripts/lib/worktree_release.py
@@ -31,7 +31,8 @@ logger = logging.getLogger(__name__)
 #   * releasable    — clean (no changes, no local-only commits) or pushed
 
 ReleaseClass = Literal[
-    "releasable", "committable", "unpushed_commits", "both", "unreachable", "error"
+    "releasable", "committable", "unpushed_commits", "both",
+    "detached", "unreachable", "error",
 ]
 
 _UNSAFE_BRANCH_CHARS = re.compile(r"[^A-Za-z0-9._/@-]")
@@ -49,6 +50,12 @@ class ReleaseEntry:
     rescue_branch: str = ""
     rescue_commit: str = ""
     removed: bool = False
+    # OI-1109: the post-removal local branch delete is a separate step from
+    # worktree removal. A worktree can be gone while its branch survives
+    # (e.g. checked out in another worktree). The outcome of that delete MUST
+    # be visible in the entry and the report, not swallowed silently.
+    branch_deleted: bool = False
+    branch_delete_error: str = ""
     error: str = ""
 
 
@@ -152,6 +159,11 @@ def classify_for_release(wt_path: str, branch: str) -> tuple[ReleaseClass, str]:
     - ``committable`` — uncommitted changes but no local-only commits
     - ``unpushed_commits`` — local commits not on origin, working tree clean
     - ``both`` — both uncommitted changes AND local-only commits
+    - ``detached`` — detached HEAD (no branch). The rescue path keys on a
+      branch name; a detached worktree has none, so fabricating a pseudo-branch
+      from a commit prefix would produce a confusing ``vnx-release/refs/heads/<sha8>``
+      rescue name. A detached worktree is reported as such and left for the
+      operator to handle explicitly rather than silently pseudo-branching it.
     - ``unreachable`` — worktree path doesn't exist
     - ``error`` — git operations failed
     """
@@ -162,6 +174,14 @@ def classify_for_release(wt_path: str, branch: str) -> tuple[ReleaseClass, str]:
     # Check if this is a git directory at all
     if not (wt / ".git").exists() and not (wt / ".git").is_file():
         return ("unreachable", "not a git worktree (no .git)")
+
+    # 0. Detached HEAD? The rescue path keys on a branch name; a detached
+    #    worktree has none. Rather than fabricate a pseudo-branch from a commit
+    #    prefix (which produced confusing ``vnx-release/refs/heads/<sha8>``
+    #    rescue names), report it explicitly and leave it for the operator.
+    symref = _run(["git", "-C", str(wt), "rev-parse", "--abbrev-ref", "HEAD"])
+    if symref.returncode == 0 and symref.stdout.strip() == "HEAD":
+        return ("detached", "detached HEAD — no branch to rescue; handle manually")
 
     # 1. Working tree status — dirty?
     status_result = _run(
@@ -415,9 +435,12 @@ def release_locked_worktrees(
 
     for rec in locked:
         wt_path = rec.get("worktree", "")
+        # A detached worktree carries no branch ref. Previously the code
+        # fabricated ``refs/heads/<sha8>`` from a commit prefix, which produced
+        # a confusing ``vnx-release/refs/heads/<sha8>`` rescue name. Detached
+        # worktrees are now classified explicitly and left for the operator, so
+        # there is no branch name to fabricate here.
         branch = rec.get("branch", "")
-        if not branch:
-            branch = f"refs/heads/{rec.get('HEAD', 'unknown')[:8]}"
 
         entry = ReleaseEntry(
             worktree=wt_path,
@@ -431,8 +454,12 @@ def release_locked_worktrees(
         entry.classification = cls
         entry.detail = detail
 
-        if cls in ("unreachable", "error"):
-            entry.error = detail
+        if cls in ("unreachable", "error", "detached"):
+            # detached/unreachable/error: nothing to rescue or remove here.
+            # detached carries no branch and is left for the operator; the
+            # others already record their reason as the entry error/detail.
+            if cls in ("unreachable", "error"):
+                entry.error = detail
             report.entries.append(entry)
             continue
 
@@ -449,11 +476,7 @@ def release_locked_worktrees(
                 report.entries.append(entry)
                 continue
 
-        # 3. Unlock + remove (unreachable worktrees skip removal)
-        if cls == "unreachable":
-            report.entries.append(entry)
-            continue
-
+        # 3. Unlock + remove (detached/unreachable/error skip removal above)
         if dry_run:
             entry.removed = False  # Would remove
         else:
@@ -466,8 +489,38 @@ def release_locked_worktrees(
             ok, err = _remove_worktree(root, wt_path)
             if ok:
                 entry.removed = True
-                # Delete the local branch too (it's been rescued to origin if needed)
-                _run(["git", "-C", str(root), "branch", "-D", branch])
+                # Delete the local branch too (it's been rescued to origin if
+                # needed). OI-1109: this is a SEPARATE step from worktree
+                # removal — a branch can survive its worktree (e.g. checked out
+                # in another worktree). Read the outcome and record it; never
+                # let a failed branch delete pass silently under removed=True.
+                #
+                # ``git branch -D`` wants the short branch name, but porcelain
+                # reports the full ref (``refs/heads/<name>``). Strip the prefix
+                # — without this, ``-D`` silently failed on every release
+                # (``branch 'refs/heads/...' not found``) and the old code never
+                # noticed because the returncode was never read.
+                branch_to_delete = branch.replace("refs/heads/", "") if branch else ""
+                if not branch_to_delete:
+                    # No branch ref to delete (e.g. a branchless worktree that
+                    # slipped past classification). Record it rather than crash.
+                    entry.branch_deleted = False
+                    entry.branch_delete_error = (
+                        "worktree removed but no branch ref recorded to delete"
+                    )
+                else:
+                    branch_result = _run(
+                        ["git", "-C", str(root), "branch", "-D", branch_to_delete]
+                    )
+                    if branch_result.returncode == 0:
+                        entry.branch_deleted = True
+                    else:
+                        msg = (branch_result.stderr.strip()
+                               or "unknown branch -D error")
+                        entry.branch_deleted = False
+                        entry.branch_delete_error = (
+                            f"worktree removed but branch -D failed: {msg}"
+                        )
             else:
                 entry.error = f"failed to remove: {err}"
 
@@ -494,7 +547,8 @@ def format_report(report: ReleaseReport) -> str:
     # Distribution summary
     counts = report.counts
     lines.append("Classification distribution:")
-    for cls in ("releasable", "committable", "unpushed_commits", "both", "unreachable", "error"):
+    for cls in ("releasable", "committable", "unpushed_commits", "both",
+                "detached", "unreachable", "error"):
         n = counts.get(cls, 0)
         if n > 0:
             lines.append(f"  {cls:<25} {n}")
@@ -502,6 +556,7 @@ def format_report(report: ReleaseReport) -> str:
 
     # Per-worktree detail
     rescued_count = 0
+    partial_count = 0
     for e in report.entries:
         status = _status_char(e)
         lines.append(f"  [{status}] {Path(e.worktree).name}")
@@ -512,8 +567,23 @@ def format_report(report: ReleaseReport) -> str:
             lines.append(f"       rescued:    yes → {e.rescue_branch} ({e.rescue_commit})")
         if e.removed:
             lines.append(f"       removed:    yes")
+        # OI-1109: surface a half-finished cleanup — worktree gone, branch
+        # survived — explicitly rather than letting removed=True hide it.
+        if e.branch_delete_error:
+            partial_count += 1
+            lines.append(f"       removed:    yes (worktree)")
+            lines.append(f"       branch:     NOT deleted — {e.branch_delete_error}")
+        elif e.removed and e.branch_deleted:
+            lines.append(f"       branch:     deleted")
         if e.error:
             lines.append(f"       error:      {e.error}")
+        lines.append("")
+
+    if partial_count:
+        lines.append(
+            f"WARNING: {partial_count} worktree(s) removed but branch delete failed — "
+            "check branch list for survivors."
+        )
         lines.append("")
 
     if rescued_count:
@@ -535,6 +605,10 @@ def _status_char(entry: ReleaseEntry) -> str:
         return " "
     if entry.classification == "unreachable":
         return "?"
+    if entry.classification == "detached":
+        return "D"
+    if entry.branch_delete_error:
+        return "!"  # partial cleanup — worktree gone, branch survived
     if entry.rescued or entry.classification in ("committable", "unpushed_commits", "both"):
         return "~"
     return " "
@@ -625,6 +699,8 @@ Examples:
                     "rescue_branch": e.rescue_branch,
                     "rescue_commit": e.rescue_commit,
                     "removed": e.removed,
+                    "branch_deleted": e.branch_deleted,
+                    "branch_delete_error": e.branch_delete_error,
                     "error": e.error,
                 }
                 for e in report.entries
@@ -636,9 +712,13 @@ Examples:
         if report_path:
             print(f"\nReport written: {report_path}")
 
-    # Return non-zero if any errors
-    errors = sum(1 for e in report.entries if e.error)
-    return 1 if errors > 0 else 0
+    # Return non-zero if any errors OR partial cleanups (OI-1109): a worktree
+    # removed while its branch survived is a half-finished release, not a
+    # success, and must surface as a non-zero exit so callers notice.
+    problems = sum(
+        1 for e in report.entries if e.error or e.branch_delete_error
+    )
+    return 1 if problems > 0 else 0
 
 
 if __name__ == "__main__":

--- a/scripts/lib/worktree_release.py
+++ b/scripts/lib/worktree_release.py
@@ -1,0 +1,645 @@
+#!/usr/bin/env python3
+"""worktree_release.py — Governed release path for locked worktrees (OI-1052).
+
+Provides a dry-run-first, classification-driven release pipeline for locked git
+worktrees: re-classify each one, rescue committable/unpushed work to origin
+branches, then unlock and remove the worktree. Nothing is deleted without an
+explicit ``--apply`` flag — the default is a dry-run report.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Literal
+
+logger = logging.getLogger(__name__)
+
+# ── release-specific classification ──────────────────────────────────────
+# The four release classifications, mapped from classify_path's
+# {dirty, clean, committed, pushed} with an extra distinction inside "dirty":
+#   * committable   — unstaged/staged changes, no local-only commits
+#   * unpushed      — local commits not on origin, working tree clean
+#   * both          — both uncommitted changes AND local-only commits
+#   * releasable    — clean (no changes, no local-only commits) or pushed
+
+ReleaseClass = Literal[
+    "releasable", "committable", "unpushed_commits", "both", "unreachable", "error"
+]
+
+_UNSAFE_BRANCH_CHARS = re.compile(r"[^A-Za-z0-9._/@-]")
+
+
+@dataclass
+class ReleaseEntry:
+    """Outcome for a single locked worktree."""
+    worktree: str
+    branch: str
+    locked: bool
+    classification: ReleaseClass
+    detail: str = ""
+    rescued: bool = False
+    rescue_branch: str = ""
+    rescue_commit: str = ""
+    removed: bool = False
+    error: str = ""
+
+
+@dataclass
+class ReleaseReport:
+    """Aggregate outcome of a release run."""
+    entries: list[ReleaseEntry] = field(default_factory=list)
+    dry_run: bool = True
+    timestamp: str = ""
+
+    @property
+    def counts(self) -> dict[str, int]:
+        counts: dict[str, int] = {}
+        for e in self.entries:
+            counts[e.classification] = counts.get(e.classification, 0) + 1
+        return counts
+
+
+# ── git porcelain helpers ──────────────────────────────────────────────────
+
+def _run(args: list[str], **kwargs) -> subprocess.CompletedProcess:
+    return subprocess.run(args, capture_output=True, text=True, **kwargs)
+
+
+def _git_common_dir(repo_root: Path) -> Path:
+    result = _run(["git", "-C", str(repo_root), "rev-parse", "--git-common-dir"])
+    if result.returncode == 0:
+        raw = result.stdout.strip()
+        p = Path(raw)
+        return p if p.is_absolute() else (repo_root / p).resolve()
+    return (repo_root / ".git").resolve()
+
+
+def _resolve_repo_root() -> Path:
+    """Resolve the git repo root from cwd or env."""
+    env_root = os.environ.get("PROJECT_ROOT", "")
+    if env_root:
+        p = Path(env_root)
+        if p.is_dir():
+            return p.resolve()
+    result = _run(["git", "rev-parse", "--show-toplevel"])
+    if result.returncode == 0:
+        return Path(result.stdout.strip()).resolve()
+    return Path.cwd().resolve()
+
+
+# ── worktree listing ──────────────────────────────────────────────────────
+
+def list_locked_worktrees(repo_root: Path | None = None) -> list[dict]:
+    """Return porcelain records for every LOCKED worktree in the repo.
+
+    Each record: {'worktree': str, 'HEAD': str, 'branch': str | None,
+                  'locked': True, 'lock_reason': str | None}
+    """
+    root = repo_root or _resolve_repo_root()
+    result = _run(["git", "-C", str(root), "worktree", "list", "--porcelain"])
+    if result.returncode != 0:
+        logger.warning("git worktree list failed: %s", result.stderr.strip())
+        return []
+
+    records: list[dict] = []
+    current: dict = {}
+    for line in result.stdout.splitlines():
+        if not line.strip():
+            if current:
+                records.append(current)
+                current = {}
+            continue
+        if line.startswith("worktree "):
+            current["worktree"] = line[9:].strip()
+        elif line.startswith("HEAD "):
+            current["HEAD"] = line[5:].strip()
+        elif line.startswith("branch "):
+            current["branch"] = line[7:].strip()
+        elif line == "detached":
+            current["detached"] = True
+        elif line == "locked":
+            current["locked"] = True
+        elif line.startswith("locked "):
+            # locked followed by the reason is rare but possible in newer git
+            current["locked"] = True
+        elif line.startswith("prunable "):
+            current["prunable"] = line[9:].strip()
+
+    if current:
+        records.append(current)
+
+    return [r for r in records if r.get("locked")]
+
+
+# ── release classification ────────────────────────────────────────────────
+
+def classify_for_release(wt_path: str, branch: str) -> tuple[ReleaseClass, str]:
+    """Classify a worktree for release purposes.
+
+    Returns ``(classification, detail)`` where ``detail`` is a human-readable
+    explanation of the state (e.g. "1 unpushed commit", "3 modified files").
+
+    The classification distinguishes five states:
+    - ``releasable`` — clean working tree, all commits pushed (or no commits)
+    - ``committable`` — uncommitted changes but no local-only commits
+    - ``unpushed_commits`` — local commits not on origin, working tree clean
+    - ``both`` — both uncommitted changes AND local-only commits
+    - ``unreachable`` — worktree path doesn't exist
+    - ``error`` — git operations failed
+    """
+    wt = Path(wt_path)
+    if not wt.exists():
+        return ("unreachable", "worktree directory does not exist")
+
+    # Check if this is a git directory at all
+    if not (wt / ".git").exists() and not (wt / ".git").is_file():
+        return ("unreachable", "not a git worktree (no .git)")
+
+    # 1. Working tree status — dirty?
+    status_result = _run(
+        [
+            "git", "-c", "core.fileMode=false", "-c", "core.autocrlf=input",
+            "-C", str(wt), "status", "--porcelain",
+        ]
+    )
+    has_changes = False
+    change_detail = ""
+    if status_result.returncode == 0 and status_result.stdout.strip():
+        has_changes = True
+        lines = [l for l in status_result.stdout.strip().splitlines() if l.strip()]
+        change_detail = f"{len(lines)} uncommitted change(s)"
+
+    # 2. Local HEAD
+    head_result = _run(["git", "-C", str(wt), "rev-parse", "HEAD"])
+    if head_result.returncode != 0:
+        return ("error", f"git rev-parse HEAD failed: {head_result.stderr.strip()}")
+    local_sha = head_result.stdout.strip()
+
+    # 3. Check for local-only commits: compare HEAD vs merge-base with origin/main
+    mb_result = _run(
+        ["git", "-C", str(wt), "merge-base", "origin/main", "HEAD"]
+    )
+    if mb_result.returncode != 0:
+        # Can't determine base — if there are changes, report them
+        if has_changes:
+            return ("committable", f"{change_detail} (base unresolvable)")
+        return ("releasable", "base unresolvable; treating as clean")
+
+    base_sha = mb_result.stdout.strip()
+
+    has_commits = local_sha != base_sha
+
+    # 4. If commits exist, check remote
+    commit_detail = ""
+    if has_commits:
+        count_result = _run(
+            ["git", "-C", str(wt), "rev-list", "--count", f"{base_sha}..HEAD"]
+        )
+        if count_result.returncode == 0:
+            n = count_result.stdout.strip()
+            commit_detail = f"{n} local commit(s)"
+
+        # Check if these commits are on origin
+        remote_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
+        try:
+            ls_result = _run(
+                ["git", "-C", str(wt), "ls-remote", "origin", remote_ref],
+                timeout=10,
+            )
+            remote_output = ls_result.stdout.strip() if ls_result.returncode == 0 else ""
+        except (subprocess.TimeoutExpired, Exception):
+            remote_output = ""
+
+        if remote_output:
+            remote_sha = remote_output.split()[0]
+            if remote_sha == local_sha:
+                has_commits = False  # Already pushed
+
+    # 5. Determine classification
+    if has_changes and has_commits:
+        parts = [change_detail, commit_detail] if commit_detail else [change_detail]
+        detail = "; ".join(parts)
+        return ("both", detail)
+    if has_changes:
+        return ("committable", change_detail)
+    if has_commits:
+        return ("unpushed_commits", commit_detail)
+    return ("releasable", "clean")
+
+
+# ── rescue ────────────────────────────────────────────────────────────────
+
+def _sanitize_branch_name(name: str) -> str:
+    """Replace unsafe characters in a branch name segment."""
+    return _UNSAFE_BRANCH_CHARS.sub("-", name)
+
+
+def rescue_worktree(
+    wt_path: str,
+    branch: str,
+    classification: ReleaseClass,
+    *,
+    dry_run: bool = True,
+) -> tuple[bool, str, str]:
+    """Rescue work from a worktree to origin.
+
+    Returns ``(success, rescue_branch, rescue_commit)``.
+
+    - *committable*: stages everything, commits with a salvage message,
+      pushes to ``vnx-release/<branch>`` on origin.
+    - *unpushed_commits*: pushes the existing branch to origin.
+    - *both*: commits uncommitted changes first, then pushes the branch.
+    - *releasable*/*unreachable*/*error*: no-op, returns (True, "", "").
+    """
+    if classification in ("releasable", "unreachable", "error"):
+        return (True, "", "")
+
+    wt = Path(wt_path)
+
+    if dry_run:
+        if classification == "committable":
+            safe = _sanitize_branch_name(branch.replace("refs/heads/", ""))
+            return (True, f"vnx-release/{safe}", "[would create]")
+        if classification == "unpushed_commits":
+            return (True, branch, "[would push]")
+        if classification == "both":
+            return (True, branch, "[would commit+push]")
+        return (True, "", "")
+
+    # ── apply mode ──────────────────────────────────────────────────────
+    try:
+        if classification == "committable":
+            # Stage everything, commit, push to rescue branch
+            add = _run(["git", "-C", str(wt), "add", "-A"])
+            if add.returncode != 0:
+                return (False, "", f"git add failed: {add.stderr.strip()}")
+
+            ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+            safe = _sanitize_branch_name(branch.replace("refs/heads/", ""))
+            rescue_branch = f"vnx-release/{safe}"
+
+            commit = _run(
+                [
+                    "git", "-C", str(wt),
+                    "-c", "user.email=vnx@vnx-orchestration.local",
+                    "-c", "user.name=VNX Worktree Release",
+                    "commit", "-m",
+                    f"vnx release: salvage uncommitted changes from {branch} [{ts}]",
+                ]
+            )
+            if commit.returncode != 0:
+                return (False, "", f"git commit failed: {commit.stderr.strip()}")
+
+            rescue_commit = _run(
+                ["git", "-C", str(wt), "rev-parse", "HEAD"]
+            ).stdout.strip()
+
+            push = _run(
+                [
+                    "git", "-C", str(wt),
+                    "push", "origin", f"HEAD:refs/heads/{rescue_branch}",
+                ]
+            )
+            if push.returncode != 0:
+                return (False, "", f"git push to {rescue_branch} failed: {push.stderr.strip()}")
+
+            return (True, rescue_branch, rescue_commit[:8])
+
+        if classification == "unpushed_commits":
+            push = _run(
+                ["git", "-C", str(wt), "push", "-u", "origin", branch]
+            )
+            if push.returncode != 0:
+                return (False, "", f"git push failed: {push.stderr.strip()}")
+
+            rescue_commit = _run(
+                ["git", "-C", str(wt), "rev-parse", "HEAD"]
+            ).stdout.strip()
+            return (True, branch, rescue_commit[:8])
+
+        if classification == "both":
+            # Check if there are uncommitted changes to stage
+            status = _run(
+                [
+                    "git", "-c", "core.fileMode=false",
+                    "-C", str(wt), "status", "--porcelain",
+                ]
+            )
+            if status.returncode == 0 and status.stdout.strip():
+                add = _run(["git", "-C", str(wt), "add", "-A"])
+                if add.returncode != 0:
+                    return (False, "", f"git add failed: {add.stderr.strip()}")
+
+                ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+                commit = _run(
+                    [
+                        "git", "-C", str(wt),
+                        "-c", "user.email=vnx@vnx-orchestration.local",
+                        "-c", "user.name=VNX Worktree Release",
+                        "commit", "-m",
+                        f"vnx release: salvage uncommitted changes from {branch} [{ts}]",
+                    ]
+                )
+                if commit.returncode != 0:
+                    return (False, "", f"git commit failed: {commit.stderr.strip()}")
+
+            push = _run(
+                ["git", "-C", str(wt), "push", "-u", "origin", branch]
+            )
+            if push.returncode != 0:
+                return (False, "", f"git push failed: {push.stderr.strip()}")
+
+            rescue_commit = _run(
+                ["git", "-C", str(wt), "rev-parse", "HEAD"]
+            ).stdout.strip()
+            return (True, branch, rescue_commit[:8])
+
+        return (True, "", "")
+
+    except Exception as exc:
+        return (False, "", str(exc))
+
+
+# ── remove worktree ───────────────────────────────────────────────────────
+
+def _unlock_worktree(repo_root: Path, wt_path: str) -> bool:
+    """Unlock a locked worktree. Returns True on success."""
+    result = _run(
+        ["git", "-C", str(repo_root), "worktree", "unlock", str(wt_path)]
+    )
+    return result.returncode == 0
+
+
+def _remove_worktree(repo_root: Path, wt_path: str) -> tuple[bool, str]:
+    """Remove a worktree with --force, retry once. Returns (success, error)."""
+    result = _run(
+        ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(wt_path)]
+    )
+    if result.returncode != 0:
+        time.sleep(0.3)
+        result2 = _run(
+            ["git", "-C", str(repo_root), "worktree", "remove", "--force", str(wt_path)]
+        )
+        if result2.returncode != 0:
+            return (False, result2.stderr.strip())
+    return (True, "")
+
+
+# ── main orchestrator ─────────────────────────────────────────────────────
+
+def release_locked_worktrees(
+    *,
+    repo_root: Path | None = None,
+    dry_run: bool = True,
+) -> ReleaseReport:
+    """Release all locked worktrees in the repository.
+
+    The default is dry-run: classify, report what would be done, do nothing.
+    Pass ``dry_run=False`` to actually rescue, unlock, and remove.
+
+    Returns a ``ReleaseReport`` with one ``ReleaseEntry`` per locked worktree.
+    """
+    root = repo_root or _resolve_repo_root()
+    locked = list_locked_worktrees(root)
+    ts = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())
+
+    report = ReleaseReport(dry_run=dry_run, timestamp=ts)
+
+    for rec in locked:
+        wt_path = rec.get("worktree", "")
+        branch = rec.get("branch", "")
+        if not branch:
+            branch = f"refs/heads/{rec.get('HEAD', 'unknown')[:8]}"
+
+        entry = ReleaseEntry(
+            worktree=wt_path,
+            branch=branch,
+            locked=rec.get("locked", False),
+            classification="error",
+        )
+
+        # 1. Classify
+        cls, detail = classify_for_release(wt_path, branch)
+        entry.classification = cls
+        entry.detail = detail
+
+        if cls in ("unreachable", "error"):
+            entry.error = detail
+            report.entries.append(entry)
+            continue
+
+        # 2. Rescue if needed
+        if cls in ("committable", "unpushed_commits", "both"):
+            success, rescue_branch, rescue_commit = rescue_worktree(
+                wt_path, branch, cls, dry_run=dry_run,
+            )
+            entry.rescued = success
+            entry.rescue_branch = rescue_branch
+            entry.rescue_commit = rescue_commit
+            if not success:
+                entry.error = rescue_commit  # error message in rescue_commit on failure
+                report.entries.append(entry)
+                continue
+
+        # 3. Unlock + remove (unreachable worktrees skip removal)
+        if cls == "unreachable":
+            report.entries.append(entry)
+            continue
+
+        if dry_run:
+            entry.removed = False  # Would remove
+        else:
+            unlocked = _unlock_worktree(root, wt_path)
+            if not unlocked:
+                entry.error = "failed to unlock worktree"
+                report.entries.append(entry)
+                continue
+
+            ok, err = _remove_worktree(root, wt_path)
+            if ok:
+                entry.removed = True
+                # Delete the local branch too (it's been rescued to origin if needed)
+                _run(["git", "-C", str(root), "branch", "-D", branch])
+            else:
+                entry.error = f"failed to remove: {err}"
+
+        report.entries.append(entry)
+
+    # Prune stale references
+    _run(["git", "-C", str(root), "worktree", "prune"])
+
+    return report
+
+
+# ── reporting ─────────────────────────────────────────────────────────────
+
+def format_report(report: ReleaseReport) -> str:
+    """Format a ReleaseReport as a human-readable string."""
+    lines: list[str] = []
+    mode = "[DRY-RUN]" if report.dry_run else "[APPLY]"
+    lines.append(f"=== Worktree Release {mode} ===")
+    lines.append(f"Timestamp: {report.timestamp}")
+    lines.append(f"Repository: {_resolve_repo_root()}")
+    lines.append(f"Total locked worktrees found: {len(report.entries)}")
+    lines.append("")
+
+    # Distribution summary
+    counts = report.counts
+    lines.append("Classification distribution:")
+    for cls in ("releasable", "committable", "unpushed_commits", "both", "unreachable", "error"):
+        n = counts.get(cls, 0)
+        if n > 0:
+            lines.append(f"  {cls:<25} {n}")
+    lines.append("")
+
+    # Per-worktree detail
+    rescued_count = 0
+    for e in report.entries:
+        status = _status_char(e)
+        lines.append(f"  [{status}] {Path(e.worktree).name}")
+        lines.append(f"       branch:     {e.branch}")
+        lines.append(f"       class:      {e.classification}  ({e.detail})")
+        if e.rescued:
+            rescued_count += 1
+            lines.append(f"       rescued:    yes → {e.rescue_branch} ({e.rescue_commit})")
+        if e.removed:
+            lines.append(f"       removed:    yes")
+        if e.error:
+            lines.append(f"       error:      {e.error}")
+        lines.append("")
+
+    if rescued_count:
+        lines.append(f"Work rescued: {rescued_count} worktree(s)")
+    else:
+        lines.append("No worktrees required rescue.")
+
+    if report.dry_run:
+        lines.append("")
+        lines.append("DRY-RUN: nothing was changed. Re-run with --apply to release.")
+
+    return "\n".join(lines)
+
+
+def _status_char(entry: ReleaseEntry) -> str:
+    if entry.error:
+        return "!"
+    if entry.classification == "releasable":
+        return " "
+    if entry.classification == "unreachable":
+        return "?"
+    if entry.rescued or entry.classification in ("committable", "unpushed_commits", "both"):
+        return "~"
+    return " "
+
+
+def write_report_file(report: ReleaseReport, data_dir: str | None = None) -> Path:
+    """Write the release report to the governed reports directory.
+
+    Returns the path to the written report file.
+    """
+    if data_dir is None:
+        data_dir = os.environ.get("VNX_DATA_DIR", "")
+    if not data_dir:
+        root = _resolve_repo_root()
+        data_dir = str(root / ".vnx-data")
+
+    reports_dir = Path(data_dir) / "unified_reports"
+    reports_dir.mkdir(parents=True, exist_ok=True)
+
+    ts = time.strftime("%Y%m%d-%H%M%S")
+    filename = f"worktree-release-{ts}.md"
+    path = reports_dir / filename
+
+    content = format_report(report)
+    path.write_text(content + "\n", encoding="utf-8")
+    return path
+
+
+# ── CLI entry point ───────────────────────────────────────────────────────
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Release locked git worktrees (OI-1052)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog="""
+Examples:
+  python3 scripts/lib/worktree_release.py           # dry-run (default)
+  python3 scripts/lib/worktree_release.py --apply   # actually release
+  python3 scripts/lib/worktree_release.py --json    # machine-readable dry-run
+""",
+    )
+    parser.add_argument(
+        "--apply", action="store_true",
+        help="Actually unlock, rescue, and remove worktrees (default: dry-run)",
+    )
+    parser.add_argument(
+        "--json", action="store_true",
+        help="Output machine-readable JSON instead of human-readable text",
+    )
+    parser.add_argument(
+        "--repo-root", type=str, default=None,
+        help="Path to the git repository root (default: auto-detect)",
+    )
+
+    args = parser.parse_args(argv)
+    dry_run = not args.apply
+    repo_root = Path(args.repo_root) if args.repo_root else None
+
+    # Safety: refuse to apply without an explicit flag
+    if dry_run and args.apply:
+        pass  # handled above
+
+    report = release_locked_worktrees(
+        repo_root=repo_root,
+        dry_run=dry_run,
+    )
+
+    # Write report file (always, unless it fails)
+    report_path = ""
+    try:
+        report_path = str(write_report_file(report))
+    except Exception as exc:
+        logger.warning("Could not write report file: %s", exc)
+
+    if args.json:
+        output = {
+            "dry_run": report.dry_run,
+            "timestamp": report.timestamp,
+            "counts": report.counts,
+            "report_path": report_path,
+            "entries": [
+                {
+                    "worktree": e.worktree,
+                    "branch": e.branch,
+                    "classification": e.classification,
+                    "detail": e.detail,
+                    "rescued": e.rescued,
+                    "rescue_branch": e.rescue_branch,
+                    "rescue_commit": e.rescue_commit,
+                    "removed": e.removed,
+                    "error": e.error,
+                }
+                for e in report.entries
+            ],
+        }
+        print(json.dumps(output, indent=2))
+    else:
+        print(format_report(report))
+        if report_path:
+            print(f"\nReport written: {report_path}")
+
+    # Return non-zero if any errors
+    errors = sum(1 for e in report.entries if e.error)
+    return 1 if errors > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_worktree_release.py
+++ b/tests/test_worktree_release.py
@@ -608,3 +608,183 @@ def test_release_report_counts():
     assert counts["releasable"] == 2
     assert counts["committable"] == 1
     assert counts["unpushed_commits"] == 1
+
+
+# ---------------------------------------------------------------------------
+# OI-1109 — branch-delete outcome must be visible (entry + report)
+# ---------------------------------------------------------------------------
+
+def test_release_apply_clean_records_branch_deleted(tmp_path):
+    """A successful apply records branch_deleted=True (regression guard for OI-1109).
+
+    Before the fix, the ``git branch -D`` returncode was never read and
+    ``branch_deleted`` did not exist, so a clean release left no trace that the
+    branch was (or was not) deleted. This pins that the outcome is recorded.
+    """
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "branch-deleted-wt"
+    _make_worktree(local, "feature/branch-del-1", wt)
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.removed is True
+    assert entry.branch_deleted is True
+    assert entry.branch_delete_error == ""
+
+    # The local branch must actually be gone.
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", "feature/branch-del-1"],
+        text=True,
+    ).strip()
+    assert branches == ""
+
+
+def test_release_apply_branch_delete_failure_is_visible(tmp_path, monkeypatch):
+    """A failed branch -D surfaces in the entry and the report (OI-1109).
+
+    Reproduces the fail scenario: the worktree is removed, but the local branch
+    cannot be deleted (e.g. still referenced elsewhere). Before the fix the code
+    ran ``git branch -D`` with no returncode check, so removed=True was reported
+    with no trace of the half-finished cleanup.
+
+    We drive the real ``release_locked_worktrees`` and only stub the git boundary
+    (``_run``) so the ``branch -D`` call returns non-zero. Everything else —
+    classify, rescue, unlock, remove — runs against the real repo.
+    """
+    import worktree_release as mod
+
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "partial-wt"
+    _make_worktree(local, "feature/partial-1", wt)
+    _lock_worktree(local, str(wt))
+
+    real_run = mod._run
+
+    def failing_run(args, **kwargs):
+        # Intercept only the branch -D step; let every other git call through.
+        if len(args) >= 4 and args[:3] == ["git", "-C", str(local)] and args[3:5] == ["branch", "-D"]:
+            return subprocess.CompletedProcess(
+                args=args, returncode=1,
+                stdout="", stderr="error: branch checked out in another worktree",
+            )
+        return real_run(args, **kwargs)
+
+    monkeypatch.setattr(mod, "_run", failing_run)
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    # Worktree IS gone...
+    assert entry.removed is True
+    assert not wt.exists()
+    # ...but the branch survived and the failure is recorded, not swallowed.
+    assert entry.branch_deleted is False
+    assert entry.branch_delete_error != ""
+    assert "branch -D failed" in entry.branch_delete_error
+
+    # The local branch must still exist (the delete failed).
+    branches = subprocess.check_output(
+        ["git", "-C", str(local), "branch", "--list", "feature/partial-1"],
+        text=True,
+    ).strip()
+    assert "feature/partial-1" in branches
+
+    # And it must be visible in the human-readable report.
+    text = format_report(report)
+    assert "NOT deleted" in text
+    assert "branch -D failed" in text
+
+
+def test_format_report_shows_branch_delete_warning():
+    """format_report surfaces a WARNING when a branch delete failed (OI-1109)."""
+    report = ReleaseReport(
+        entries=[
+            ReleaseEntry(
+                worktree="/tmp/wt1",
+                branch="feature/survivor-1",
+                locked=True,
+                classification="releasable",
+                detail="clean",
+                removed=True,
+                branch_deleted=False,
+                branch_delete_error=(
+                    "worktree removed but branch -D failed: "
+                    "error: branch checked out elsewhere"
+                ),
+            ),
+        ],
+        dry_run=False,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    text = format_report(report)
+    assert "WARNING" in text
+    assert "branch delete failed" in text
+    assert "NOT deleted" in text
+
+
+# ---------------------------------------------------------------------------
+# OI-1109 — detached HEAD reported explicitly, not pseudo-branched
+# ---------------------------------------------------------------------------
+
+def test_classify_detached_head(tmp_path):
+    """A detached-HEAD worktree classifies as 'detached', not pseudo-branched."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "detached-wt"
+    # Create a worktree in detached HEAD state.
+    subprocess.run(
+        ["git", "-C", str(local), "fetch", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    main_sha = subprocess.check_output(
+        ["git", "-C", str(local), "rev-parse", "origin/main"], text=True
+    ).strip()
+    subprocess.run(
+        ["git", "-C", str(local), "worktree", "add", "--detach", str(wt), main_sha],
+        check=True, capture_output=True,
+    )
+
+    cls, detail = classify_for_release(str(wt), "")
+    assert cls == "detached"
+    assert "detached" in detail
+
+
+def test_release_detached_head_not_removed_and_no_pseudo_branch(tmp_path):
+    """A locked detached worktree is reported, not removed, and gets no fabricated branch.
+
+    Before the fix the code fabricated ``refs/heads/<sha8>`` for a branchless
+    worktree, which would have produced a confusing ``vnx-release/refs/heads/<sha8>``
+    rescue name. Now it is classified ``detached`` and left for the operator.
+    """
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "detached-locked-wt"
+    subprocess.run(
+        ["git", "-C", str(local), "fetch", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    main_sha = subprocess.check_output(
+        ["git", "-C", str(local), "rev-parse", "origin/main"], text=True
+    ).strip()
+    subprocess.run(
+        ["git", "-C", str(local), "worktree", "add", "--detach", str(wt), main_sha],
+        check=True, capture_output=True,
+    )
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    detached_entries = [e for e in report.entries if "detached-locked-wt" in e.worktree]
+    assert len(detached_entries) == 1
+    entry = detached_entries[0]
+    assert entry.classification == "detached"
+    assert entry.removed is False
+    # No fabricated refs/heads/<sha8> branch name.
+    assert entry.branch == ""
+    assert not entry.rescue_branch.startswith("vnx-release/refs/heads/")
+
+    # Worktree is still there — not removed.
+    assert wt.exists()
+

--- a/tests/test_worktree_release.py
+++ b/tests/test_worktree_release.py
@@ -1,0 +1,610 @@
+"""test_worktree_release.py — Tests for governed worktree release path (OI-1052).
+
+Covers: list_locked_worktrees, classify_for_release, rescue_worktree,
+release_locked_worktrees, dry-run-safety.
+
+Uses real git repos in tempdir fixtures, mirroring test_tmux_worktree.py.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB_DIR = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from worktree_release import (
+    ReleaseEntry,
+    ReleaseReport,
+    _run,
+    _resolve_repo_root,
+    classify_for_release,
+    format_report,
+    list_locked_worktrees,
+    release_locked_worktrees,
+    rescue_worktree,
+)
+
+
+# ---------------------------------------------------------------------------
+# Real-git-repo fixtures — mirror test_tmux_worktree.py pattern
+# ---------------------------------------------------------------------------
+
+def _init_git_repo_with_origin(tmp_path: Path) -> Path:
+    """Create a bare origin + local clone with an initial commit."""
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(bare), str(local)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "main"],
+        capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+
+    readme = local / "README.md"
+    readme.write_text("init\n")
+    subprocess.run(
+        ["git", "-C", str(local), "add", "README.md"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "commit", "-m", "initial"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+def _make_worktree(repo_root: Path, branch: str, wt_path: Path) -> None:
+    """Create a worktree on a new branch from origin/main."""
+    subprocess.run(
+        ["git", "-C", str(repo_root), "fetch", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        [
+            "git", "-C", str(repo_root), "worktree", "add",
+            "-b", branch, str(wt_path), "origin/main",
+        ],
+        check=True, capture_output=True,
+    )
+
+
+def _lock_worktree(repo_root: Path, wt_path: str, reason: str = "vnx preserve test") -> None:
+    """Lock a worktree via git."""
+    subprocess.run(
+        [
+            "git", "-C", str(repo_root), "worktree", "lock",
+            str(wt_path), "--reason", reason,
+        ],
+        check=True, capture_output=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# list_locked_worktrees
+# ---------------------------------------------------------------------------
+
+def test_list_locked_worktrees_empty(tmp_path):
+    """No locked worktrees returns empty list."""
+    local = _init_git_repo_with_origin(tmp_path)
+    result = list_locked_worktrees(local)
+    assert result == []
+
+
+def test_list_locked_worktrees_with_locked(tmp_path):
+    """A locked worktree is detected."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "locked-wt"
+    _make_worktree(local, "feature/locked-1", wt)
+    _lock_worktree(local, str(wt))
+
+    result = list_locked_worktrees(local)
+    assert len(result) == 1
+    assert result[0]["locked"] is True
+    assert "locked-wt" in result[0]["worktree"]
+
+
+def test_list_locked_worktrees_skips_unlocked(tmp_path):
+    """Only locked worktrees are listed."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt_locked = tmp_path / "locked-wt"
+    _make_worktree(local, "feature/locked-1", wt_locked)
+    _lock_worktree(local, str(wt_locked))
+
+    wt_unlocked = tmp_path / "unlocked-wt"
+    _make_worktree(local, "feature/unlocked-1", wt_unlocked)
+
+    result = list_locked_worktrees(local)
+    assert len(result) == 1
+    assert "locked-wt" in result[0]["worktree"]
+
+
+# ---------------------------------------------------------------------------
+# classify_for_release
+# ---------------------------------------------------------------------------
+
+def test_classify_releasable_clean(tmp_path):
+    """Clean worktree classifies as releasable."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "clean-wt"
+    _make_worktree(local, "feature/clean-1", wt)
+
+    cls, detail = classify_for_release(str(wt), "feature/clean-1")
+    assert cls == "releasable"
+    assert "clean" in detail
+
+
+def test_classify_releasable_pushed(tmp_path):
+    """Worktree with pushed commits classifies as releasable."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "pushed-wt"
+    _make_worktree(local, "feature/pushed-1", wt)
+
+    # Make a commit and push it
+    (wt / "work.txt").write_text("pushed work\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "pushed commit"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "push", "-u", "origin", "feature/pushed-1"],
+        check=True, capture_output=True,
+    )
+
+    cls, detail = classify_for_release(str(wt), "feature/pushed-1")
+    assert cls == "releasable"
+
+
+def test_classify_committable(tmp_path):
+    """Uncommitted changes only classifies as committable."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "dirty-wt"
+    _make_worktree(local, "feature/dirty-1", wt)
+
+    (wt / "dirty.txt").write_text("uncommitted\n")
+
+    cls, detail = classify_for_release(str(wt), "feature/dirty-1")
+    assert cls == "committable"
+    assert "uncommitted" in detail
+
+
+def test_classify_unpushed_commits(tmp_path):
+    """Local commits not on origin classifies as unpushed_commits."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "committed-wt"
+    _make_worktree(local, "feature/committed-1", wt)
+
+    (wt / "work.txt").write_text("local work\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "local only"],
+        check=True, capture_output=True,
+    )
+
+    cls, detail = classify_for_release(str(wt), "feature/committed-1")
+    assert cls == "unpushed_commits"
+    assert "local commit" in detail
+
+
+def test_classify_both(tmp_path):
+    """Both uncommitted changes and local commits classifies as both."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "both-wt"
+    _make_worktree(local, "feature/both-1", wt)
+
+    # Make a local commit
+    (wt / "committed.txt").write_text("committed\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "committed.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "local commit"],
+        check=True, capture_output=True,
+    )
+
+    # Then make an uncommitted change
+    (wt / "dirty.txt").write_text("uncommitted too\n")
+
+    cls, detail = classify_for_release(str(wt), "feature/both-1")
+    assert cls == "both"
+    assert "uncommitted" in detail
+    assert "local commit" in detail
+
+
+def test_classify_unreachable(tmp_path):
+    """Non-existent path classifies as unreachable."""
+    cls, detail = classify_for_release("/tmp/does-not-exist-xyz", "ghost-branch")
+    assert cls == "unreachable"
+
+
+# ---------------------------------------------------------------------------
+# rescue_worktree
+# ---------------------------------------------------------------------------
+
+def test_rescue_dry_run_committable(tmp_path):
+    """Dry-run rescue for committable worktree doesn't actually commit/push."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "rescue-dry-wt"
+    _make_worktree(local, "feature/rescue-dry-1", wt)
+
+    (wt / "new.txt").write_text("should not be committed\n")
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/rescue-dry-1", "committable", dry_run=True,
+    )
+    assert success is True
+    assert branch.startswith("vnx-release/")
+    assert commit == "[would create]"
+
+    # Verify nothing was actually committed
+    status = subprocess.check_output(
+        ["git", "-C", str(wt), "status", "--porcelain"],
+        text=True,
+    )
+    assert "new.txt" in status  # Still uncommitted
+
+
+def test_rescue_dry_run_unpushed(tmp_path):
+    """Dry-run rescue for unpushed_commits reports what would be pushed."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "rescue-unpushed-wt"
+    _make_worktree(local, "feature/rescue-unpushed-1", wt)
+
+    (wt / "work.txt").write_text("local work\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "local"],
+        check=True, capture_output=True,
+    )
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/rescue-unpushed-1", "unpushed_commits", dry_run=True,
+    )
+    assert success is True
+    assert branch == "feature/rescue-unpushed-1"
+    assert commit == "[would push]"
+
+
+def test_rescue_apply_committable(tmp_path):
+    """Apply rescue for committable worktree commits and pushes to rescue branch."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "rescue-apply-wt"
+    _make_worktree(local, "feature/rescue-apply-1", wt)
+
+    (wt / "salvage.txt").write_text("rescue me\n")
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/rescue-apply-1", "committable", dry_run=False,
+    )
+    assert success is True
+    assert branch.startswith("vnx-release/")
+    assert len(commit) == 8  # Short SHA
+
+    # Verify the branch exists on origin
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", branch],
+        text=True,
+    ).strip()
+    assert branch in remote_refs
+
+
+def test_rescue_apply_unpushed(tmp_path):
+    """Apply rescue for unpushed_commits pushes the branch to origin."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "rescue-push-wt"
+    _make_worktree(local, "feature/rescue-push-1", wt)
+
+    (wt / "work.txt").write_text("push me\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "to push"],
+        check=True, capture_output=True,
+    )
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/rescue-push-1", "unpushed_commits", dry_run=False,
+    )
+    assert success is True
+    assert branch == "feature/rescue-push-1"
+    assert len(commit) == 8
+
+    # Verify on origin
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", "feature/rescue-push-1"],
+        text=True,
+    ).strip()
+    assert "feature/rescue-push-1" in remote_refs
+
+
+def test_rescue_apply_both(tmp_path):
+    """Apply rescue for 'both': commits uncommitted changes, then pushes."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "rescue-both-wt"
+    _make_worktree(local, "feature/rescue-both-1", wt)
+
+    # First make a committed change
+    (wt / "committed.txt").write_text("already committed\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "committed.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "first commit"],
+        check=True, capture_output=True,
+    )
+
+    # Then make an uncommitted change
+    (wt / "uncommitted.txt").write_text("not yet committed\n")
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/rescue-both-1", "both", dry_run=False,
+    )
+    assert success is True
+    assert branch == "feature/rescue-both-1"
+    assert len(commit) == 8
+
+    # Verify on origin
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", "feature/rescue-both-1"],
+        text=True,
+    ).strip()
+    assert "feature/rescue-both-1" in remote_refs
+
+
+def test_rescue_releasable_noop(tmp_path):
+    """Rescue for releasable worktree is a no-op."""
+    local = _init_git_repo_with_origin(tmp_path)
+    wt = tmp_path / "noop-wt"
+    _make_worktree(local, "feature/noop-1", wt)
+
+    success, branch, commit = rescue_worktree(
+        str(wt), "feature/noop-1", "releasable", dry_run=False,
+    )
+    assert success is True
+    assert branch == ""
+    assert commit == ""
+
+
+# ---------------------------------------------------------------------------
+# release_locked_worktrees (integration)
+# ---------------------------------------------------------------------------
+
+def test_release_dry_run_no_changes(tmp_path):
+    """Dry-run release_locked_worktrees makes no changes to locked worktrees."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    # Create a locked worktree with uncommitted changes
+    wt = tmp_path / "release-dry-wt"
+    _make_worktree(local, "feature/release-dry-1", wt)
+    (wt / "data.txt").write_text("precious data\n")
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=True)
+
+    assert report.dry_run is True
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.classification == "committable"
+    assert entry.rescued is True  # Dry-run rescue "succeeds"
+    assert entry.removed is False  # Not actually removed
+
+    # Verify the worktree still exists and is still locked
+    result = list_locked_worktrees(local)
+    assert len(result) == 1
+    assert wt.is_dir()
+
+    # Verify data is still there
+    assert (wt / "data.txt").read_text() == "precious data\n"
+
+
+def test_release_apply_clean(tmp_path):
+    """Apply release removes a locked clean worktree."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = tmp_path / "release-clean-wt"
+    _make_worktree(local, "feature/release-clean-1", wt)
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    assert report.dry_run is False
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.classification == "releasable"
+    assert entry.removed is True
+
+    # Verify worktree is gone
+    assert not wt.exists()
+
+    # Verify no more locked worktrees
+    remaining = list_locked_worktrees(local)
+    assert len(remaining) == 0
+
+
+def test_release_apply_committable_rescues_then_removes(tmp_path):
+    """Apply release rescues committable work, then removes the worktree."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = tmp_path / "release-committable-wt"
+    _make_worktree(local, "feature/release-comm-1", wt)
+    (wt / "vital.txt").write_text("vital data\n")
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.classification == "committable"
+    assert entry.rescued is True
+    assert entry.removed is True
+    assert entry.rescue_branch.startswith("vnx-release/")
+
+    # Verify worktree removed
+    assert not wt.exists()
+
+    # Verify rescue branch exists on origin
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", entry.rescue_branch],
+        text=True,
+    ).strip()
+    assert entry.rescue_branch in remote_refs
+
+
+def test_release_apply_unpushed_rescues_then_removes(tmp_path):
+    """Apply release pushes unpushed commits, then removes the worktree."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    wt = tmp_path / "release-unpushed-wt"
+    _make_worktree(local, "feature/release-unp-1", wt)
+    (wt / "work.txt").write_text("pushed work\n")
+    subprocess.run(
+        ["git", "-C", str(wt), "add", "work.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(wt), "commit", "-m", "release me"],
+        check=True, capture_output=True,
+    )
+    _lock_worktree(local, str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    assert len(report.entries) == 1
+    entry = report.entries[0]
+    assert entry.classification == "unpushed_commits"
+    assert entry.rescued is True
+    assert entry.removed is True
+
+    # Verify worktree removed
+    assert not wt.exists()
+
+    # Verify branch exists on origin
+    remote_refs = subprocess.check_output(
+        ["git", "-C", str(local), "ls-remote", "origin", "feature/release-unp-1"],
+        text=True,
+    ).strip()
+    assert "feature/release-unp-1" in remote_refs
+
+
+def test_release_unreachable_left_alone(tmp_path):
+    """An unreachable worktree is reported but not removed."""
+    local = _init_git_repo_with_origin(tmp_path)
+
+    # Create a worktree, lock it, then delete the directory
+    wt = tmp_path / "ghost-wt"
+    _make_worktree(local, "feature/ghost-1", wt)
+    _lock_worktree(local, str(wt))
+
+    # Remove the directory but leave the lock metadata
+    import shutil
+    shutil.rmtree(str(wt))
+
+    report = release_locked_worktrees(repo_root=local, dry_run=False)
+
+    # The ghost worktree should still appear
+    ghost_entries = [e for e in report.entries if "ghost-wt" in e.worktree]
+    assert len(ghost_entries) == 1
+    assert ghost_entries[0].classification == "unreachable"
+    assert ghost_entries[0].removed is False
+
+
+# ---------------------------------------------------------------------------
+# format_report
+# ---------------------------------------------------------------------------
+
+def test_format_report_dry_run():
+    """format_report includes DRY-RUN marker when dry_run is True."""
+    report = ReleaseReport(
+        entries=[
+            ReleaseEntry(
+                worktree="/tmp/wt1",
+                branch="feature/test-1",
+                locked=True,
+                classification="releasable",
+                detail="clean",
+            ),
+        ],
+        dry_run=True,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    output = format_report(report)
+    assert "[DRY-RUN]" in output
+    assert "DRY-RUN: nothing was changed" in output
+
+
+def test_format_report_apply():
+    """format_report includes APPLY marker when dry_run is False."""
+    report = ReleaseReport(
+        entries=[
+            ReleaseEntry(
+                worktree="/tmp/wt1",
+                branch="feature/test-1",
+                locked=True,
+                classification="releasable",
+                detail="clean",
+                removed=True,
+            ),
+        ],
+        dry_run=False,
+        timestamp="2026-01-01T00:00:00Z",
+    )
+    output = format_report(report)
+    assert "[APPLY]" in output
+    assert "DRY-RUN" not in output
+
+
+# ---------------------------------------------------------------------------
+# ReleaseReport count
+# ---------------------------------------------------------------------------
+
+def test_release_report_counts():
+    """ReleaseReport.counts aggregates classifications correctly."""
+    report = ReleaseReport(entries=[
+        ReleaseEntry(worktree="w1", branch="b1", locked=True, classification="releasable", detail=""),
+        ReleaseEntry(worktree="w2", branch="b2", locked=True, classification="releasable", detail=""),
+        ReleaseEntry(worktree="w3", branch="b3", locked=True, classification="committable", detail=""),
+        ReleaseEntry(worktree="w4", branch="b4", locked=True, classification="unpushed_commits", detail=""),
+    ])
+    counts = report.counts
+    assert counts["releasable"] == 2
+    assert counts["committable"] == 1
+    assert counts["unpushed_commits"] == 1


### PR DESCRIPTION
## What

A governed release path for locked git worktrees. Each locked worktree is re-classified on the spot, committable/unpushed work is rescued to origin branches, then the worktree is unlocked and removed.

## Why

The repo has 33 locked worktrees. The existing reaper's dirty-tak preserves uncommitted work correctly by locking the worktree, but there was no release path — "preserve" meant "forever." This closes that gap.

## How

- **`vnx worktree-release`** (dry-run default) — new CLI command
- **`scripts/lib/worktree_release.py`** — core logic: list locked worktrees, classify per worktree (releasable / committable / unpushed_commits / both), rescue via auto-commit + push to origin, unlock, remove
- **`scripts/commands/release_worktree.sh`** — bash CLI wrapper following the existing `_load_command` pattern

## Dry-run over the real 33 locked worktrees

| Classification | Count |
|---|---|
| releasable (clean) | 7 |
| committable (uncommitted changes only) | 9 |
| unpushed_commits (local commits not on origin) | 14 |
| both (changes + commits) | 3 |

No worktree was actually modified — dry-run is the default.

## Tests

23 tests using real temp git repos: classification (clean, committable, unpushed, both, unreachable), rescue dry-run and apply, full release pipeline, format_report, report counts.

All existing worktree tests (26 in test_tmux_worktree.py) and report contract tests (58) also pass.

## Safety

- Dry-run is the default — nothing is deleted without `--apply`
- A worktree whose work cannot be rescued remains locked
- Rescue pushes to `vnx-release/<branch>` for salvage commits
- The dirty-tak of the existing reaper is NOT modified

Dispatch-ID: 20260809d-w3-worktree-vrijgavepad

🤖 Generated with [Claude Code](https://claude.com/claude-code)