### PR TITLE
fix(cli): make `vnx horizon` work through both entrances (OI-1084, OI-1060)

### DIFF
--- a/bin/vnx
+++ b/bin/vnx
@@ -346,6 +346,8 @@ Gate commands (pre-merge verification):
   roadmap <sub>       Roadmap orchestration and auto-next feature loading
 
 Planning commands (strategic-layer read surface):
+  horizon <verb>     Planning layer: objectives, deliverables, plan-gate
+                        (canonical spelling; objective is a backward-compat alias)
   objective list      List objectives (tracks) grouped by horizon (now/next/later)
                         Options: --horizon, --phase, --json
   objective show <id> Show one objective: phase/horizon/deps/pr_ref
@@ -861,6 +863,21 @@ except ModeGateError as e:
     return $?
   fi
   return 0
+}
+
+# ── Name-drift hint (OI-1084 / OI-1060) ───────────────────────────────────
+# A refused name that exists as an alias or sub-verb of a working command
+# should point at the working form instead of only "Unknown command". Mirrors
+# vnx_mode._suggest_working_form (single source of truth in scripts/lib/vnx_mode.py).
+_suggest_working_form() {
+  local cmd="$1"
+  if command -v "$VNX_PYTHON" >/dev/null 2>&1; then
+    VNX_SUGGEST_CMD="$cmd" PYTHONPATH="$VNX_HOME/scripts/lib:${PYTHONPATH:-}" "$VNX_PYTHON" -c "
+import os
+from vnx_mode import _suggest_working_form
+print(_suggest_working_form(os.environ.get('VNX_SUGGEST_CMD', '')), end='')
+" 2>/dev/null
+  fi
 }
 
 cmd_init_db() {
@@ -2505,6 +2522,9 @@ main() {
     objective)
       "$VNX_PYTHON" "$VNX_HOME/scripts/planning_cli.py" objective "$@"
       ;;
+    horizon)
+      "$VNX_PYTHON" "$VNX_HOME/scripts/planning_cli.py" horizon "$@"
+      ;;
     deliverable)
       "$VNX_PYTHON" "$VNX_HOME/scripts/planning_cli.py" deliverable "$@"
       ;;
@@ -2587,7 +2607,13 @@ main() {
       usage
       ;;
     *)
-      err "Unknown command: $cmd"
+      local hint
+      hint="$(_suggest_working_form "$cmd")"
+      if [ -n "$hint" ]; then
+        err "Unknown command: $cmd. $hint"
+      else
+        err "Unknown command: $cmd"
+      fi
       usage
       exit 1
       ;;

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -52,7 +52,7 @@ TIER_STARTER_OPERATOR: FrozenSet[str] = frozenset({
     "bootstrap-terminals", "bootstrap-hooks", "regen-settings", "regen-worker-permissions",
     "skills", "role",
     "patch-agent-files", "register", "list-projects", "unregister",
-    "roadmap", "insights", "objective", "deliverable",
+    "roadmap", "insights", "objective", "horizon", "deliverable",
     "install-git-hooks", "uninstall-git-hooks", "install-shell-helper",
     "init-db",
 })
@@ -282,6 +282,48 @@ def read_mode_raw(data_dir: Optional[str] = None) -> Optional[Dict[str, Any]]:
 # Command gating
 # ---------------------------------------------------------------------------
 
+# Cross-entrance name drift. The two VNX entrances (`bin/vnx` in the fabric
+# repo and the pip-installed `vnx_cli`) expose the same surface under
+# different spellings. A refused top-level name that exists as an alias or a
+# sub-verb of a working command should point the user at the working form
+# instead of only saying "requires a different mode" (OI-1084 / OI-1060).
+#
+# - ALIASES: ``vnx <name>`` is a working command in one entrance but only an
+#   alias of ``ALIASES[name]`` in the other. ``dispatch`` works in ``bin/vnx``
+#   but is ``dispatch-agent`` in the pip CLI (the pip CLI's ``dispatch`` is
+#   reserved for a future direct-SDK lane that is not wired yet).
+# - SUB_VERBS: ``vnx <name>`` is not a top-level command at all in either
+#   entrance, but it is a sub-verb of ``SUB_VERBS[name]`` (e.g.
+#   ``plan-gate`` lives under ``vnx horizon plan-gate``).
+ALIASES: Dict[str, str] = {
+    "dispatch": "dispatch-agent",
+    "dispatch-agent": "dispatch",
+}
+
+SUB_VERBS: Dict[str, str] = {
+    "plan-gate": "horizon",
+}
+
+
+def _suggest_working_form(command: str) -> str:
+    """Return a human-readable hint naming the working form of a refused
+    command, or ``""`` when no known alias/sub-verb matches.
+
+    The suggestion is entrance-agnostic on purpose: it names both spellings so
+    the user can pick whichever entrance they are in, instead of assuming a
+    specific CLI. ``plan-gate`` -> ``vnx horizon plan-gate``; ``dispatch`` ->
+    note that the pip CLI spells it ``dispatch-agent``.
+    """
+    if command in SUB_VERBS:
+        parent = SUB_VERBS[command]
+        return (f"'{command}' is a sub-verb of 'vnx {parent}' "
+                f"(try: vnx {parent} {command}).")
+    if command in ALIASES:
+        return (f"'{command}' is spelled '{ALIASES[command]}' in the other "
+                "VNX entrance (the fabric `bin/vnx` vs the pip `vnx`).")
+    return ""
+
+
 class ModeGateError(Exception):
     """Raised when a command is not available in the current mode."""
 
@@ -292,8 +334,10 @@ class ModeGateError(Exception):
             upgrade = "Run 'vnx init --operator' to upgrade."
         else:
             upgrade = ""
+        suggestion = _suggest_working_form(command)
+        suffix = f" {suggestion}" if suggestion else ""
         super().__init__(
-            f"'{command}' requires a different mode (current: {current_mode}). {upgrade}".strip()
+            f"'{command}' requires a different mode (current: {current_mode}).{suffix} {upgrade}".strip()
         )
 
 

--- a/tests/test_cli_naamdrift.py
+++ b/tests/test_cli_naamdrift.py
@@ -1,0 +1,207 @@
+"""tests/test_cli_naamdrift.py — pin cross-entrance name-drift fixes (OI-1084, OI-1060).
+
+The two VNX entrances (`bin/vnx` in the fabric repo and the pip-installed
+`vnx_cli`) disagreed on the planning layer's name: `vnx horizon` worked in
+the pip CLI but was refused by the fabric mode gate, while `vnx objective`
+was the only spelling the gate let through. A dispatch instruction that
+prescribed `vnx horizon reconcile` failed in the fabric repo on the mode
+port, and the error read like a permission problem rather than a naming one.
+
+These tests pin the three fixes:
+
+1. ``horizon`` is in the shared operator/starter tier, so the fabric mode
+   gate lets the canonical spelling through (``objective`` stays as an
+   alias). Both entrances accept ``horizon``.
+2. A refused name that exists as a sub-verb or alias now names the working
+   form in the error, in both entrances:
+   - ``plan-gate`` -> ``vnx horizon plan-gate``
+   - ``dispatch`` <-> ``dispatch-agent`` (cross-entrance alias)
+3. The pip-CLI invalid-choice message carries the same hint.
+
+Red-against-main measurement: every test fails on main (horizon is absent
+from every tier; the suggest helpers and the pip-CLI suggestion parser do
+not exist) and passes on this branch. The new-symbol imports are done
+inside each test so the collection itself does not abort — on main the
+tests fail individually with ImportError/AttributeError or assertion
+failure, which is the red signal.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = REPO_ROOT / "scripts" / "lib"
+for _p in (str(REPO_ROOT), str(_LIB)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import vnx_mode  # noqa: E402
+
+
+def _pip_main():
+    """Import the pip-CLI main lazily so a missing helper surfaces as a
+    per-test failure, not a collection error."""
+    from vnx_cli.main import main as vnx_main
+    return vnx_main
+
+
+def _pip_suggest(command: str) -> str:
+    from vnx_cli.main import _suggest_working_form
+    return _suggest_working_form(command)
+
+
+# ---------------------------------------------------------------------------
+# 1. horizon is in the shared tier (both entrances)
+# ---------------------------------------------------------------------------
+
+def test_horizon_is_in_starter_operator_tier():
+    """The canonical spelling must be gate-allowed in both modes, not just
+    operator. On main `horizon` is absent from every tier and refused."""
+    assert "horizon" in vnx_mode.TIER_STARTER_OPERATOR
+
+
+def test_horizon_passes_mode_gate_in_both_modes():
+    for mode in (vnx_mode.VNXMode.STARTER, vnx_mode.VNXMode.OPERATOR):
+        # Must not raise — horizon is gate-allowed.
+        vnx_mode.check_command_allowed("horizon", mode)
+
+
+def test_objective_alias_still_gate_allowed():
+    """The backward-compat alias must not have been broken by adding horizon."""
+    assert "objective" in vnx_mode.TIER_STARTER_OPERATOR
+    for mode in (vnx_mode.VNXMode.STARTER, vnx_mode.VNXMode.OPERATOR):
+        vnx_mode.check_command_allowed("objective", mode)
+
+
+# ---------------------------------------------------------------------------
+# 2. ModeGateError names the working form for alias/sub-verb names (fabric)
+# ---------------------------------------------------------------------------
+
+def test_mode_gate_plan_gate_names_working_form():
+    """`plan-gate` is a sub-verb of `vnx horizon`, not a mode problem. The
+    error must point at `vnx horizon plan-gate` rather than only saying
+    'requires a different mode'."""
+    with pytest.raises(vnx_mode.ModeGateError) as exc:
+        vnx_mode.check_command_allowed("plan-gate", vnx_mode.VNXMode.OPERATOR)
+    msg = str(exc.value)
+    assert "plan-gate" in msg
+    assert "vnx horizon plan-gate" in msg
+
+
+def test_mode_gate_dispatch_names_cross_entrance_alias():
+    """`dispatch` (fabric) is `dispatch-agent` (pip). The suggestion helper
+    must name the other spelling."""
+    suggestion = vnx_mode._suggest_working_form("dispatch")
+    assert "dispatch-agent" in suggestion
+
+
+def test_mode_gate_dispatch_agent_names_cross_entrance_alias():
+    suggestion = vnx_mode._suggest_working_form("dispatch-agent")
+    assert "dispatch" in suggestion
+
+
+def test_mode_gate_unknown_name_gives_no_hint():
+    """A genuinely unknown name gets no false suggestion."""
+    assert vnx_mode._suggest_working_form("totallybogus") == ""
+
+
+# ---------------------------------------------------------------------------
+# 3. pip-CLI invalid-choice message carries the same hint
+# ---------------------------------------------------------------------------
+
+def _run_pip(monkeypatch, capsys, argv):
+    vnx_main = _pip_main()
+    monkeypatch.setattr(sys, "argv", ["vnx", *argv])
+    with pytest.raises(SystemExit) as exc:
+        vnx_main()
+    out = capsys.readouterr()
+    return exc.value.code, out.out, out.err
+
+
+def test_pip_plan_gate_error_names_working_form(monkeypatch, capsys):
+    rc, _, err = _run_pip(monkeypatch, capsys, ["plan-gate"])
+    assert rc == 2
+    assert "invalid choice" in err
+    assert "vnx horizon plan-gate" in err
+
+
+def test_pip_dispatch_error_names_cross_entrance_alias(monkeypatch, capsys):
+    rc, _, err = _run_pip(monkeypatch, capsys, ["dispatch"])
+    assert rc == 2
+    assert "invalid choice" in err
+    assert "dispatch-agent" in err
+
+
+def test_pip_bogus_command_no_false_hint(monkeypatch, capsys):
+    rc, _, err = _run_pip(monkeypatch, capsys, ["totallybogus"])
+    assert rc == 2
+    assert "invalid choice" in err
+    # No drift hint attached for an unknown name.
+    assert "sub-verb of" not in err
+    assert "spelled" not in err
+
+
+def test_pip_suggest_matches_mode_suggest():
+    """Both entrances compute the same hint for the same name (SSOT parity)."""
+    for name in ("plan-gate", "dispatch", "dispatch-agent"):
+        assert _pip_suggest(name) == vnx_mode._suggest_working_form(name)
+
+
+def test_pip_horizon_and_objective_both_accepted(monkeypatch, capsys):
+    """Both spellings must parse in the pip CLI (horizon canonical, objective
+    alias). Parity assertion guards regressions in either direction."""
+    for cmd in ("horizon", "objective"):
+        rc, out, _ = _run_pip(monkeypatch, capsys, [cmd, "--help"])
+        assert rc == 0
+        assert "list" in out  # the verb surface is rendered
+
+
+# ---------------------------------------------------------------------------
+# 4. bin/vnx delegates `horizon` to the planning engine (fabric entrance)
+# ---------------------------------------------------------------------------
+
+def test_bin_vnx_horizon_help_works():
+    """`./bin/vnx horizon --help` must return a working help text, not the
+    mode-gate refusal. This is the exact faalscenario from OI-1084: a
+    dispatch prescribing `vnx horizon ...` failed in the fabric repo."""
+    result = subprocess.run(
+        [str(REPO_ROOT / "bin" / "vnx"), "horizon", "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    # The refusal message must be gone.
+    assert "requires a different mode" not in result.stdout
+    assert "requires a different mode" not in result.stderr
+    # A real planning verb is rendered.
+    assert "list" in result.stdout
+
+
+def test_bin_vnx_objective_alias_still_works():
+    """The `objective` alias must still work through bin/vnx after adding the
+    horizon branch."""
+    result = subprocess.run(
+        [str(REPO_ROOT / "bin" / "vnx"), "objective", "--help"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode == 0, result.stderr
+    assert "list" in result.stdout
+
+
+def test_bin_vnx_plan_gate_error_names_working_form():
+    """`./bin/vnx plan-gate` (no sub-verb) is refused and the refusal must
+    name `vnx horizon plan-gate` (OI-1060: a name that exists as a sub-verb
+    but not as a top-level command). Covers both refusal paths: the mode gate
+    (operator mode) and the unknown-command fallback (pre-init)."""
+    result = subprocess.run(
+        [str(REPO_ROOT / "bin" / "vnx"), "plan-gate"],
+        capture_output=True, text=True, timeout=30,
+    )
+    assert result.returncode != 0
+    combined = result.stdout + result.stderr
+    assert "plan-gate" in combined
+    assert "vnx horizon plan-gate" in combined

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -7,6 +7,70 @@ import sys
 from vnx_cli import __version__
 
 
+# Cross-entrance name-drift mapping (OI-1084 / OI-1060). Same shape as the
+# tables in scripts/lib/vnx_mode.py (the fabric-side mode gate). vnx_mode is
+# the SSOT when importable (it is, via the scripts/lib path injection both
+# entrances share); this local copy is the fallback so a pip install with a
+# broken path injection still names the working form instead of only
+# "invalid choice". Keep these two in sync — vnx_mode.ALIASES/SUB_VERBS is
+# authoritative, this mirrors it.
+_FALLBACK_ALIASES = {
+    "dispatch": "dispatch-agent",
+    "dispatch-agent": "dispatch",
+}
+_FALLBACK_SUB_VERBS = {
+    "plan-gate": "horizon",
+}
+
+
+def _name_drift_tables() -> tuple[dict, dict]:
+    """Return (aliases, sub_verbs), preferring vnx_mode (SSOT) when importable."""
+    try:
+        from vnx_mode import ALIASES, SUB_VERBS  # type: ignore
+        if ALIASES and SUB_VERBS is not None:
+            return dict(ALIASES), dict(SUB_VERBS)
+    except Exception:
+        pass
+    return dict(_FALLBACK_ALIASES), dict(_FALLBACK_SUB_VERBS)
+
+
+def _suggest_working_form(command: str) -> str:
+    """Return a hint naming the working form of a refused command, or "".
+    Mirrors vnx_mode._suggest_working_form so both entrances give the same
+    hint for the same name."""
+    aliases, sub_verbs = _name_drift_tables()
+    if command in sub_verbs:
+        parent = sub_verbs[command]
+        return (f"'{command}' is a sub-verb of 'vnx {parent}' "
+                f"(try: vnx {parent} {command}).")
+    if command in aliases:
+        return (f"'{command}' is spelled '{aliases[command]}' in the other "
+                "VNX entrance (the fabric `bin/vnx` vs the pip `vnx`).")
+    return ""
+
+
+class _SuggestionArgumentParser(argparse.ArgumentParser):
+    """ArgumentParser that appends a working-form hint to an invalid-choice
+    error when the refused name is a known alias or sub-verb (OI-1060).
+
+    argparse's default message only lists the valid choices; for a name like
+    ``plan-gate`` or ``dispatch`` that exists under a different spelling, the
+    user is left to guess. This appends ``_suggest_working_form(command)`` to
+    the error line so the working form is named in place."""
+
+    def error(self, message: str) -> None:  # type: ignore[override]
+        # argparse formats the invalid-choice line as:
+        #   argument COMMAND: invalid choice: 'plan-gate' (choose from ...)
+        # Augment only that case — leave every other error shape untouched.
+        if message.startswith("argument ") and "invalid choice: " in message:
+            _, _, rest = message.partition("invalid choice: '")
+            cmd, _, _ = rest.partition("'")
+            hint = _suggest_working_form(cmd)
+            if hint:
+                message = f"{message} {hint}"
+        super().error(message)
+
+
 def _register_doctor_subparser(subparsers: argparse.Action) -> None:
     doctor_parser = subparsers.add_parser(
         "doctor",
@@ -1121,7 +1185,7 @@ def main() -> None:
 
     maybe_reexec_pinned()
 
-    parser = argparse.ArgumentParser(
+    parser = _SuggestionArgumentParser(
         prog="vnx",
         description="VNX — governance-first multi-agent orchestration for AI CLI workers",
     )


### PR DESCRIPTION
## Summary

De twee VNX-ingangen (`bin/vnx` in de fabric-repo en de pip-`vnx`) waren het oneens over de naam van de planningslaag. `vnx horizon` werkte in de pip-CLI maar werd door de fabric mode-gate geweigerd; alleen de alias `vnx objective` kwam door de gate. Een dispatch die `vnx horizon reconcile` voorschrijft faalde in de fabric-repo met een melding die als permissieprobleem las in plaats van als naamkwestie. Dezelfde klasse trof `plan-gate` (een sub-verb, geen top-commando) en `dispatch` vs `dispatch-agent` (cross-entrance alias).

## Changes

- **`scripts/lib/vnx_mode.py`**: `horizon` toegevoegd aan `TIER_STARTER_OPERATOR` (canonieke spelling nu gate-allowed in beide modes; `objective` blijft als alias). `ALIASES`/`SUB_VERBS` tabellen + `_suggest_working_form` toegevoegd zodat een geweigerde naam die als alias of sub-verb bestaat de werkende vorm noemt in `ModeGateError`.
- **`bin/vnx`**: `horizon)` case-branch die delegate naar `planning_cli.py horizon` (dat `horizon` al als alias van het `objective`-domein accepteert). `_suggest_working_form` bash-helper + verrijkte unknown-command fallback met dezelfde hint. Help-tekst bijgewerkt.
- **`vnx_cli/main.py`**: `_SuggestionArgumentParser` die de invalid-choice foutmelding verrijkt met de werkende vorm, met `vnx_mode` als SSOT (fallback lokaal voor gebroken path-injection).
- **`tests/test_cli_naamdrift.py`**: 15 nieuwe tests die de drie fixes pinnen.

## Verification

**Voor/na meting (vandaag, op main vs branch):**

| Ingang | Voor (main) | Na (branch) |
|---|---|---|
| `./bin/vnx horizon --help` | `Error: 'horizon' requires a different mode (current: operator).` | werkende hulptekst (`usage: vnx objective ...`) |
| `vnx horizon --help` (pip) | werkte al | blijft werken |
| `./bin/vnx objective --help` | werkt | werkt nog (alias niet gesneuveld) |
| `./bin/vnx plan-gate` | `Error: 'plan-gate' requires a different mode (current: operator).` | `... 'plan-gate' is a sub-verb of 'vnx horizon' (try: vnx horizon plan-gate).` |
| `vnx plan-gate` (pip) | `invalid choice: 'plan-gate' (choose from ...)` | `... 'plan-gate' is a sub-verb of 'vnx horizon' (try: vnx horizon plan-gate).` |

**Rood-tegen-main meting** (`tests/test_cli_naamdrift.py`):
- Op main: **10 failed, 5 passed** (horizon niet in tier; suggest-helpers bestaan niet; geen hints in foutmeldingen).
- Op branch: **15 passed**.

**Buren-tests (geen nieuwe falers):**

| Testbestand | Branch |
|---|---|
| `tests/test_cli_naamdrift.py` | 15 passed |
| `tests/test_horizon_cli.py` | 26 passed |
| `tests/test_horizon_parity.py` | 7 failed, 78 passed |
| `tests/test_vnx_mode.py` | 30 passed |
| `tests/test_vnx_cli.py` | 14 passed |
| `tests/test_planning_cli.py` | 25 passed |
| `tests/test_cli_engine_bootstrap.py` | 13 passed |

De 7 falers in `test_horizon_parity.py` zijn de bekende OI-1065-breuk, buiten scope. De telling is identiek aan main (7 failed, 104 passed over de twee horizon-files samen). `test_cli_flag_forwarding.py::test_rgm_request_auto_computes_changed_files_when_blank` faalt pre-existing op main (niet door deze PR).

**Inventarisatie naam-drift klasse:**

| Naam | Werkt via `bin/vnx` | Werkt via pip-`vnx` | Opgelost |
|---|---|---|---|
| `horizon` | nee (mode-gate weigerde) → ja | ja | ja |
| `objective` (alias) | ja | ja | ja (alias behouden) |
| `plan-gate` (sub-verb) | nee (geen top-commando) | nee (geen top-commando) | ja (foutmelding noemt `vnx horizon plan-gate`) |
| `dispatch` | ja | nee (`dispatch-agent`) | ja (foutmelding noemt alias) |
| `dispatch-agent` | ja (via `_load_command` script) | ja | ja (foutmelding noemt alias) |

## Open Items

- **`dispatch` vs `dispatch-agent` als alias doorvoeren** (niet alleen foutmelding): in de pip-CLI is `dispatch` gereserveerd voor een toekomstige direct-SDK lane; in `bin/vnx` is `dispatch` het single-entry-deur-commando. Een echte alias draaien vraagt een architectuurbeslissing (welke spelling is canoniek voor de deur?), buiten de mechaniek van deze PR. De foutmelding noemt nu de werkende vorm.
- **`dispatch-agent` via `bin/vnx` geeft stille exit 1**: `scripts/commands/dispatch-agent.sh` is een standalone script dat via `_load_command` wordt gesourced en bij lege args `exit 1` doet vóór de case-match, zodat de `*)` hint niet wordt getoond. Pre-existing, niet door deze PR. Eigen oplossing vereist (script als case-branch draaien of `_load_command` args doorgeven).
- **Oppervlak-asymmetrie (geen naam-drift)**: `bin/vnx` heeft ~60 operator-commando's (`start`/`stop`/`ps`/`cleanup`/`worktree-*`/etc.) die de pip-CLI niet exposeert; de pip-CLI heeft `track`/`handoff`/`learning`/`release`/`attest`/`version` die `bin/vnx` niet heeft. Bewuste subset-keuze per ingang, geen naam-drift. Niet in deze PR.
- **`horizon --help` toont `usage: vnx objective`** in `bin/vnx`: argparse toont de hoofdnaam van de subparser (`objective`), niet de alias waarmee het werd aangeroepen. Cosmetisch; functioneel werkt `horizon`. Oplossing vereist prog-detectie in `planning_cli._build_parser`.

Dispatch-ID: 20260809e-w7-cli-naamdrift
**Model**: sonnet
**Provider**: claude

🤖 Generated with [Claude Code](https://claude.com/claude-code)