### PR TITLE
feat(learning): approve/dismiss disposition verbs for pending_archival (OI-1076, OI-1038)

### DIFF
--- a/scripts/learning_loop.py
+++ b/scripts/learning_loop.py
@@ -5,6 +5,7 @@ Tracks pattern usage, adjusts confidence scores, and optimizes intelligence deli
 Runs daily at 18:00 to analyze receipts and update pattern effectiveness.
 """
 
+import fcntl
 import hashlib
 import json
 import logging
@@ -12,6 +13,7 @@ import os
 import sqlite3
 import time
 import sys
+import uuid
 from pathlib import Path
 from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Optional
@@ -1220,6 +1222,356 @@ class LearningLoop:
             log.debug("HealthBeacon heartbeat skipped: %s", e)
 
         return report
+
+
+# ---------------------------------------------------------------------------
+# Operator disposition verbs (OI-1076 / OI-1038)
+# ---------------------------------------------------------------------------
+# The proposal tier writes candidates to pending_archival.json but nothing
+# consumed that file — the operator gate the design calls for did not exist,
+# so proposals stacked up with no route to execution (the loop reads as
+# dormant for exactly this reason). These module-level functions are the
+# missing consumer: `vnx learning approve <id>` / `vnx learning dismiss <id>`
+# call apply_archival_decision() to carry out the disposition.
+#
+# Form follows the existing human-gated verbs in the fabric (horizon close /
+# objective reopen): --approval-id is the operator's gate token, --reason is
+# mandatory. The audit trail is the existing governed NDJSON log
+# (intelligence_usage.ndjson) — no second logging mechanism.
+
+# Valid approver identities, mirroring regulated_strict_approval.VALID_APPROVERS
+# so the disposition verbs accept the same human-gate vocabulary fleet-wide.
+_DISPOSITION_VALID_APPROVERS = frozenset({"operator", "T0"})
+
+
+class ArchivalDispositionError(RuntimeError):
+    """Raised for malformed state or I/O failures during a disposition."""
+
+
+class CandidateNotFoundError(LookupError):
+    """Raised when the requested candidate id is not in pending_archival.json."""
+
+
+class CandidateAlreadyHandledError(RuntimeError):
+    """Raised when the candidate is no longer pending (already approved/dismissed)."""
+
+
+def load_pending_archival(state_dir: Path) -> List[Dict[str, Any]]:
+    """Read pending_archival.json under state_dir, returning the candidate list.
+
+    Returns an empty list when the file is absent or malformed (fail-open on
+    read; a malformed queue is reported by `review`/`status`, not fatal here).
+    """
+    pending_path = state_dir / "pending_archival.json"
+    if not pending_path.exists():
+        return []
+    try:
+        data = json.loads(pending_path.read_text(encoding="utf-8"))
+    except (json.JSONDecodeError, OSError):
+        return []
+    candidates = data.get("pending_archival", [])
+    return candidates if isinstance(candidates, list) else []
+
+
+def _save_pending_archival_atomic(
+    state_dir: Path, candidates: List[Dict[str, Any]]
+) -> None:
+    """Write pending_archival.json atomically (tmp + os.replace).
+
+    Uses fcntl.flock on the canonical file across the read-rewrite cycle the
+    callers perform, so two concurrent disposition verbs cannot lose a write.
+    """
+    pending_path = state_dir / "pending_archival.json"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    tmp_path = pending_path.with_suffix(".json.tmp")
+    payload = json.dumps(
+        {"pending_archival": candidates}, indent=2, ensure_ascii=False
+    )
+    # Lock the canonical file for the duration of the rewrite. Create it if
+    # absent so the lock handle exists; the atomic rename lands on the same path.
+    lock_fh = open(pending_path, "a", encoding="utf-8")  # vnx-atomic-write: pending_archival.json
+    try:
+        fcntl.flock(lock_fh.fileno(), fcntl.LOCK_EX)
+        tmp_path.write_text(payload, encoding="utf-8")
+        os.replace(tmp_path, pending_path)
+    finally:
+        try:
+            fcntl.flock(lock_fh.fileno(), fcntl.LOCK_UN)
+        except OSError:
+            pass
+        lock_fh.close()
+
+
+def _emit_archival_decision_event(
+    state_dir: Path,
+    *,
+    pattern_id: str,
+    decision: str,
+    approved_by: str,
+    approval_id: str,
+    reason: str,
+    action: str,
+    source_table: str,
+    db_applied: bool,
+) -> None:
+    """Append an archival_decision audit event to intelligence_usage.ndjson.
+
+    This is the governed audit trail (G-L7), the same NDJSON stream
+    _log_confidence_change writes to. fcntl-locked append, matching
+    gather_intelligence._record_injection_why_event's convention.
+    """
+    usage_log = state_dir / "intelligence_usage.ndjson"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    event = {
+        "event_type": "archival_decision",
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "pattern_id": pattern_id,
+        "decision": decision,
+        "action": action,
+        "source_table": source_table,
+        "approved_by": approved_by,
+        "approval_id": approval_id,
+        "reason": reason,
+        "db_applied": db_applied,
+    }
+    line = json.dumps(event, separators=(",", ":")) + "\n"
+    with open(usage_log, "a", encoding="utf-8") as fh:
+        fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+        try:
+            fh.write(line)
+            fh.flush()
+        finally:
+            fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+
+
+def _validate_disposition_inputs(
+    approved_by: str, approval_id: str, reason: str
+) -> None:
+    """Enforce the human-gate invariants shared by approve and dismiss.
+
+    Mirrors RA-1 (non-empty rationale) and RA-2 (valid approver) from
+    regulated_strict_approval. approval_id is the operator gate token the
+    horizon-close form requires.
+    """
+    if not approval_id or not approval_id.strip():
+        raise ArchivalDispositionError(
+            "--approval-id is required (the operator's gate token). "
+            "No disposition made."
+        )
+    if not reason or not reason.strip():
+        raise ArchivalDispositionError(
+            "--reason is required for every archival disposition. "
+            "No disposition made."
+        )
+    if approved_by not in _DISPOSITION_VALID_APPROVERS:
+        raise ArchivalDispositionError(
+            f"approved_by must be one of {sorted(_DISPOSITION_VALID_APPROVERS)}, "
+            f"got {approved_by!r}. Automated dispositions are forbidden."
+        )
+
+
+def _find_candidate(
+    candidates: List[Dict[str, Any]], pattern_id: str, source_table: Optional[str]
+) -> Dict[str, Any]:
+    """Locate the pending candidate matching pattern_id (and source_table if given).
+
+    Raises CandidateNotFoundError when no candidate carries that id at all, or
+    CandidateAlreadyHandledError when the only match is already non-pending.
+    """
+    matches = [
+        c for c in candidates
+        if str(c.get("pattern_id", "")) == str(pattern_id)
+        and (source_table is None
+             or str(c.get("source_table", "")) == str(source_table))
+    ]
+    if not matches:
+        raise CandidateNotFoundError(
+            f"No pending_archival candidate found for pattern_id={pattern_id!r}"
+            + (f", source_table={source_table!r}" if source_table else "")
+            + ". Run `vnx learning review --mode archival` to list current candidates."
+        )
+    pending = [c for c in matches if c.get("status") == "pending"]
+    if not pending:
+        handled = matches[0]
+        raise CandidateAlreadyHandledError(
+            f"Candidate pattern_id={pattern_id!r} is already "
+            f"{handled.get('status', 'unknown')!r} (decided at "
+            f"{handled.get('decided_at', '?')}). No second disposition applied."
+        )
+    return pending[0]
+
+
+def _apply_supersede(
+    conn: sqlite3.Connection, pattern_id: str, source_table: str, now_iso: str
+) -> bool:
+    """Set valid_until on the superseded row, idempotent on valid_until IS NULL.
+
+    Returns True when a row was updated, False when it was already superseded
+    (a concurrent disposition won the race). The WHERE clause makes the update
+    idempotent: a second approve on the same id updates zero rows.
+    """
+    if source_table not in ("success_patterns", "prevention_rules"):
+        # Unknown source table for supersede — record the decision but do not
+        # mutate a table we cannot vouch for. db_applied stays False.
+        return False
+    cur = conn.execute(
+        f"UPDATE {source_table} SET valid_until = ? "
+        f"WHERE id = ? AND valid_until IS NULL",
+        (now_iso, pattern_id),
+    )
+    return cur.rowcount > 0
+
+
+def _apply_archive(
+    conn: sqlite3.Connection, pattern_id: str, source_table: Optional[str], now_iso: str
+) -> bool:
+    """Carry out an archival (DELETE) disposition.
+
+    archive candidates (action omitted or 'archive') originate from the
+    pattern_usage table's low-confidence/stale set. They carry no
+    source_table. The pattern_usage row is removed; a missing row is a no-op
+    (idempotent). Returns True when a row was deleted.
+    """
+    cur = conn.execute(
+        "DELETE FROM pattern_usage WHERE pattern_id = ?", (pattern_id,)
+    )
+    return cur.rowcount > 0
+
+
+def apply_archival_decision(
+    state_dir: Path,
+    pattern_id: str,
+    decision: str,
+    *,
+    approval_id: str,
+    reason: str,
+    approved_by: str = "operator",
+    source_table: Optional[str] = None,
+    db_path: Optional[Path] = None,
+) -> Dict[str, Any]:
+    """Carry out an operator-approved disposition on a pending_archival candidate.
+
+    This is the consumer the proposal tier was missing (OI-1076). It:
+
+      1. Validates the human-gate inputs (--approval-id, --reason, approver).
+      2. Loads pending_archival.json and locates the pending candidate.
+      3. Carries out the action:
+         - approve + action="supersede" → set valid_until on the DB row
+           (idempotent via ``WHERE valid_until IS NULL``).
+         - approve + action="archive" (or omitted) → DELETE the pattern_usage
+           row (idempotent).
+         - dismiss (any action) → no DB mutation; the candidate is removed from
+           the queue without effect. Used to reject a proposal the operator
+           does not want to act on.
+      4. Marks the candidate decided (status=approved|dismissed, decided_at,
+         decided_by, approval_id, decision_reason) and rewrites
+         pending_archival.json atomically.
+      5. Appends an archival_decision audit event to intelligence_usage.ndjson.
+
+    Idempotency: a candidate that is no longer pending raises
+    CandidateAlreadyHandledError with a clear message — no silent no-op and no
+    double DB mutation. A supersede whose row already has valid_until set
+    updates zero rows and is recorded with db_applied=False.
+
+    Args:
+        state_dir:     VNX state directory (pending_archival.json lives here).
+        pattern_id:    The candidate pattern_id to act on.
+        decision:      "approve" or "dismiss".
+        approval_id:   Operator gate token (REQUIRED).
+        reason:        Non-empty rationale (REQUIRED).
+        approved_by:   "operator" (default) or "T0".
+        source_table:  Optional disambiguator when two candidates share a
+                       pattern_id across tables (e.g. an id present in both
+                       success_patterns and prevention_rules).
+        db_path:       quality_intelligence.db path. Defaults to
+                       state_dir/quality_intelligence.db.
+
+    Returns a result dict: {decision, pattern_id, action, source_table,
+    db_applied, status, candidate}.
+
+    Raises:
+        ArchivalDispositionError:    missing approval_id/reason or invalid approver.
+        CandidateNotFoundError:      pattern_id not in the queue.
+        CandidateAlreadyHandledError: candidate already decided.
+        ArchivalDispositionError:    DB or write failure.
+    """
+    if decision not in ("approve", "dismiss"):
+        raise ArchivalDispositionError(
+            f"decision must be 'approve' or 'dismiss', got {decision!r}"
+        )
+    _validate_disposition_inputs(approved_by, approval_id, reason)
+
+    candidates = load_pending_archival(state_dir)
+    candidate = _find_candidate(candidates, pattern_id, source_table)
+    action = candidate.get("action", "archive")
+    cand_source_table = candidate.get("source_table")
+    now_iso = datetime.now(timezone.utc).isoformat()
+
+    db_applied = False
+    if decision == "approve":
+        resolved_db = db_path or (state_dir / "quality_intelligence.db")
+        try:
+            conn = sqlite3.connect(str(resolved_db), timeout=10.0)
+        except sqlite3.Error as exc:
+            raise ArchivalDispositionError(
+                f"could not open quality_intelligence.db at {resolved_db}: {exc}"
+            )
+        try:
+            if action == "supersede":
+                db_applied = _apply_supersede(
+                    conn, pattern_id, str(cand_source_table or ""), now_iso
+                )
+            else:
+                db_applied = _apply_archive(
+                    conn, pattern_id, cand_source_table, now_iso
+                )
+            conn.commit()
+        except sqlite3.Error as exc:
+            try:
+                conn.rollback()
+            except sqlite3.Error:
+                pass
+            raise ArchivalDispositionError(
+                f"DB mutation failed for {decision} on {pattern_id!r}: {exc}"
+            )
+        finally:
+            conn.close()
+    # dismiss: no DB mutation by design.
+
+    # Rewrite the candidate as decided. It stays in pending_archival.json with
+    # a non-pending status so `status`/`review` stop surfacing it (they filter
+    # on status == "pending") and the audit trail is reconstructable from the
+    # file itself, not just the NDJSON event.
+    candidate["status"] = "approved" if decision == "approve" else "dismissed"
+    candidate["decided_at"] = now_iso
+    candidate["decided_by"] = approved_by
+    candidate["approval_id"] = approval_id
+    candidate["decision_reason"] = reason
+    candidate["db_applied"] = db_applied
+
+    _save_pending_archival_atomic(state_dir, candidates)
+
+    _emit_archival_decision_event(
+        state_dir,
+        pattern_id=pattern_id,
+        decision=decision,
+        approved_by=approved_by,
+        approval_id=approval_id,
+        reason=reason,
+        action=action,
+        source_table=str(cand_source_table or ""),
+        db_applied=db_applied,
+    )
+
+    return {
+        "decision": decision,
+        "pattern_id": pattern_id,
+        "action": action,
+        "source_table": cand_source_table,
+        "db_applied": db_applied,
+        "status": candidate["status"],
+        "candidate": candidate,
+    }
 
 
 def main():

--- a/tests/test_learning_archival_disposition.py
+++ b/tests/test_learning_archival_disposition.py
@@ -1,0 +1,587 @@
+#!/usr/bin/env python3
+"""tests/test_learning_archival_disposition.py — operator disposition verbs
+(OI-1076 / OI-1038).
+
+Covers the consumer the proposal tier was missing: `vnx learning approve`
+and `vnx learning dismiss` carry out a disposition on a
+pending_archival.json candidate, audit it to intelligence_usage.ndjson, and
+remove the candidate from the actionable queue so `status`/`review` stop
+resurfacing it (the OI-1038 complaint).
+
+All candidates are constructed in-test. No writes to the production store:
+every test runs against a tmp_path state dir and a tmp quality_intelligence.db.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sqlite3
+import sys
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+sys.path.insert(0, str(_REPO_ROOT))
+
+import learning_loop as ll  # noqa: E402
+from vnx_cli.commands import learning  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Schema + candidate helpers
+# ---------------------------------------------------------------------------
+
+def _bootstrap_schema(db_path: Path) -> None:
+    """Create the minimal quality_intelligence.db schema the dispositions touch."""
+    db_path.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_path))
+    conn.executescript("""
+        CREATE TABLE IF NOT EXISTS pattern_usage (
+            pattern_id TEXT PRIMARY KEY,
+            pattern_title TEXT NOT NULL,
+            pattern_hash TEXT NOT NULL,
+            used_count INTEGER DEFAULT 0,
+            ignored_count INTEGER DEFAULT 0,
+            success_count INTEGER DEFAULT 0,
+            failure_count INTEGER DEFAULT 0,
+            last_used TIMESTAMP,
+            last_offered TIMESTAMP,
+            confidence REAL DEFAULT 1.0,
+            created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+            updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+        );
+        CREATE TABLE IF NOT EXISTS success_patterns (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            title TEXT,
+            pattern_data TEXT,
+            category TEXT,
+            confidence_score REAL DEFAULT 0.5,
+            valid_from DATETIME DEFAULT (datetime('now')),
+            valid_until DATETIME DEFAULT NULL,
+            usage_count INTEGER DEFAULT 0,
+            source_dispatch_ids TEXT DEFAULT '[]',
+            tags TEXT DEFAULT '[]'
+        );
+        CREATE TABLE IF NOT EXISTS prevention_rules (
+            id INTEGER PRIMARY KEY AUTOINCREMENT,
+            tag_combination TEXT,
+            rule_type TEXT,
+            description TEXT,
+            recommendation TEXT,
+            confidence REAL DEFAULT 0.5,
+            created_at TEXT,
+            triggered_count INTEGER DEFAULT 0,
+            valid_from DATETIME DEFAULT (datetime('now')),
+            valid_until DATETIME DEFAULT NULL
+        );
+    """)
+    conn.commit()
+    conn.close()
+
+
+def _write_pending_archival(state_dir: Path, candidates: list[dict]) -> Path:
+    path = state_dir / "pending_archival.json"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    path.write_text(
+        json.dumps({"pending_archival": candidates}, indent=2, ensure_ascii=False),
+        encoding="utf-8",
+    )
+    return path
+
+
+def _read_pending_archival(state_dir: Path) -> list[dict]:
+    path = state_dir / "pending_archival.json"
+    return json.loads(path.read_text(encoding="utf-8")).get("pending_archival", [])
+
+
+def _read_audit_events(state_dir: Path) -> list[dict]:
+    path = state_dir / "intelligence_usage.ndjson"
+    if not path.exists():
+        return []
+    return [json.loads(l) for l in path.read_text().splitlines() if l.strip()]
+
+
+def _archive_candidate(pattern_id: str = "pat-archive-1", **extra) -> dict:
+    base = {
+        "pattern_id": pattern_id,
+        "title": f"Test archive {pattern_id}",
+        "last_used": (datetime.now(timezone.utc) - timedelta(days=40)).isoformat(),
+        "confidence": 0.2,
+        "used_count": 0,
+        "ignored_count": 5,
+        "reason": "Unused for 30+ days with confidence < 0.3",
+        "queued_at": "2026-08-09T08:00:00Z",
+        "status": "pending",
+    }
+    base.update(extra)
+    return base
+
+
+def _supersede_candidate(pattern_id: str = "42", source_table: str = "success_patterns",
+                         **extra) -> dict:
+    base = {
+        "pattern_id": pattern_id,
+        "title": "Stale success pattern",
+        "confidence": 0.2,
+        "source_table": source_table,
+        "action": "supersede",
+        "reason": "confidence_score < 0.3, older than 30 days",
+        "queued_at": "2026-08-09T08:30:00Z",
+        "status": "pending",
+    }
+    base.update(extra)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# 1. approve (archive): pattern_usage row removed, candidate marked, audited
+# ---------------------------------------------------------------------------
+
+class TestApproveArchive:
+    def test_approve_archive_deletes_pattern_usage_row(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "confidence) VALUES ('pat-archive-1', 'T', 'h', 0.2)"
+        )
+        conn.commit()
+        conn.close()
+
+        _write_pending_archival(state_dir, [_archive_candidate()])
+        before = _read_pending_archival(state_dir)
+        assert before[0]["status"] == "pending"
+
+        result = ll.apply_archival_decision(
+            state_dir, "pat-archive-1", "approve",
+            approval_id="appr-test-1", reason="operator reviewed and approved archival",
+        )
+
+        assert result["decision"] == "approve"
+        assert result["action"] == "archive"
+        assert result["db_applied"] is True
+        assert result["status"] == "approved"
+
+        # The candidate is marked decided, no longer pending.
+        after = _read_pending_archival(state_dir)
+        assert len(after) == 1
+        assert after[0]["status"] == "approved"
+        assert after[0]["approval_id"] == "appr-test-1"
+        assert after[0]["decision_reason"] == "operator reviewed and approved archival"
+
+        # DB row removed.
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT COUNT(*) FROM pattern_usage WHERE pattern_id = 'pat-archive-1'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == 0
+
+        # Audit event in the governed NDJSON stream.
+        events = _read_audit_events(state_dir)
+        archival_events = [e for e in events if e["event_type"] == "archival_decision"]
+        assert len(archival_events) == 1
+        ev = archival_events[0]
+        assert ev["decision"] == "approve"
+        assert ev["pattern_id"] == "pat-archive-1"
+        assert ev["approval_id"] == "appr-test-1"
+        assert ev["approved_by"] == "operator"
+        assert ev["db_applied"] is True
+
+    def test_approve_archive_when_row_already_absent_is_idempotent(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        # No pattern_usage row exists for this candidate.
+        _write_pending_archival(state_dir, [_archive_candidate("pat-gone")])
+
+        result = ll.apply_archival_decision(
+            state_dir, "pat-gone", "approve",
+            approval_id="appr-2", reason="approved",
+        )
+        assert result["db_applied"] is False  # nothing to delete
+        assert result["status"] == "approved"
+        # Candidate still marked decided.
+        assert _read_pending_archival(state_dir)[0]["status"] == "approved"
+
+
+# ---------------------------------------------------------------------------
+# 2. approve (supersede): valid_until set, idempotent on second call
+# ---------------------------------------------------------------------------
+
+class TestApproveSupersede:
+    def _seed_success_pattern(self, db_path: Path, *, title="stale", confidence=0.1) -> int:
+        conn = sqlite3.connect(str(db_path))
+        old_date = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        conn.execute(
+            "INSERT INTO success_patterns "
+            "(title, pattern_data, category, confidence_score, valid_from, valid_until) "
+            "VALUES (?, '{}', 'general', ?, ?, NULL)",
+            (title, confidence, old_date),
+        )
+        conn.commit()
+        row = conn.execute(
+            "SELECT id FROM success_patterns WHERE title = ?", (title,)
+        ).fetchone()
+        conn.close()
+        return row[0]
+
+    def test_approve_supersede_sets_valid_until(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        pat_id = self._seed_success_pattern(db_path)
+
+        _write_pending_archival(state_dir, [_supersede_candidate(str(pat_id))])
+
+        result = ll.apply_archival_decision(
+            state_dir, str(pat_id), "approve",
+            approval_id="appr-sup-1", reason="supersede approved",
+            source_table="success_patterns",
+        )
+        assert result["action"] == "supersede"
+        assert result["db_applied"] is True
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT valid_until FROM success_patterns WHERE id = ?", (pat_id,)
+        ).fetchone()
+        conn.close()
+        assert row[0] is not None, "valid_until must be set on approve"
+
+        events = _read_audit_events(state_dir)
+        ev = [e for e in events if e["event_type"] == "archival_decision"][0]
+        assert ev["action"] == "supersede"
+        assert ev["source_table"] == "success_patterns"
+
+    def test_approve_supersede_prevention_rules(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        old = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        conn.execute(
+            "INSERT INTO prevention_rules "
+            "(tag_combination, rule_type, description, confidence, valid_from, valid_until) "
+            "VALUES ('T1', 'failure_prevention', 'rule', 0.1, ?, NULL)",
+            (old,),
+        )
+        conn.commit()
+        rule_id = conn.execute(
+            "SELECT id FROM prevention_rules WHERE description = 'rule'"
+        ).fetchone()[0]
+        conn.close()
+
+        _write_pending_archival(
+            state_dir, [_supersede_candidate(str(rule_id), source_table="prevention_rules")]
+        )
+
+        result = ll.apply_archival_decision(
+            state_dir, str(rule_id), "approve",
+            approval_id="appr-pr-1", reason="approved",
+            source_table="prevention_rules",
+        )
+        assert result["db_applied"] is True
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT valid_until FROM prevention_rules WHERE id = ?", (rule_id,)
+        ).fetchone()
+        conn.close()
+        assert row[0] is not None
+
+
+# ---------------------------------------------------------------------------
+# 3. dismiss: no DB mutation, candidate removed from queue
+# ---------------------------------------------------------------------------
+
+class TestDismiss:
+    def test_dismiss_no_db_mutation(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "confidence) VALUES ('pat-dismiss-1', 'T', 'h', 0.2)"
+        )
+        conn.commit()
+        conn.close()
+
+        _write_pending_archival(state_dir, [_archive_candidate("pat-dismiss-1")])
+
+        result = ll.apply_archival_decision(
+            state_dir, "pat-dismiss-1", "dismiss",
+            approval_id="appr-d-1", reason="operator rejects this proposal",
+        )
+        assert result["decision"] == "dismiss"
+        assert result["db_applied"] is False
+        assert result["status"] == "dismissed"
+
+        # pattern_usage row must still exist — dismiss does not mutate the DB.
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT COUNT(*) FROM pattern_usage WHERE pattern_id = 'pat-dismiss-1'"
+        ).fetchone()
+        conn.close()
+        assert row[0] == 1
+
+        after = _read_pending_archival(state_dir)
+        assert after[0]["status"] == "dismissed"
+
+        ev = _read_audit_events(state_dir)
+        archival = [e for e in ev if e["event_type"] == "archival_decision"][0]
+        assert archival["decision"] == "dismiss"
+        assert archival["db_applied"] is False
+
+    def test_dismiss_supersede_no_valid_until_set(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        old = (datetime.now(timezone.utc) - timedelta(days=40)).isoformat()
+        conn.execute(
+            "INSERT INTO success_patterns "
+            "(title, pattern_data, category, confidence_score, valid_from, valid_until) "
+            "VALUES ('dismiss-sup', '{}', 'g', 0.1, ?, NULL)",
+            (old,),
+        )
+        conn.commit()
+        pat_id = conn.execute(
+            "SELECT id FROM success_patterns WHERE title = 'dismiss-sup'"
+        ).fetchone()[0]
+        conn.close()
+
+        _write_pending_archival(
+            state_dir, [_supersede_candidate(str(pat_id), source_table="success_patterns")]
+        )
+
+        ll.apply_archival_decision(
+            state_dir, str(pat_id), "dismiss",
+            approval_id="appr-ds-1", reason="not superseding",
+            source_table="success_patterns",
+        )
+
+        conn = sqlite3.connect(str(db_path))
+        row = conn.execute(
+            "SELECT valid_until FROM success_patterns WHERE id = ?", (pat_id,)
+        ).fetchone()
+        conn.close()
+        assert row[0] is None, "dismiss must not set valid_until"
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency: second approve/dismiss on same id does not double-act
+# ---------------------------------------------------------------------------
+
+class TestIdempotency:
+    def test_second_approve_is_rejected_not_doubled(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "confidence) VALUES ('pat-idem-1', 'T', 'h', 0.2)"
+        )
+        conn.commit()
+        conn.close()
+        _write_pending_archival(state_dir, [_archive_candidate("pat-idem-1")])
+
+        first = ll.apply_archival_decision(
+            state_dir, "pat-idem-1", "approve",
+            approval_id="appr-i-1", reason="first approve",
+        )
+        assert first["db_applied"] is True
+
+        with pytest.raises(ll.CandidateAlreadyHandledError) as exc_info:
+            ll.apply_archival_decision(
+                state_dir, "pat-idem-1", "approve",
+                approval_id="appr-i-2", reason="second approve",
+            )
+        assert "already" in str(exc_info.value).lower()
+
+        # Only ONE audit event for this pattern_id.
+        events = [e for e in _read_audit_events(state_dir)
+                  if e["event_type"] == "archival_decision"
+                  and e["pattern_id"] == "pat-idem-1"]
+        assert len(events) == 1
+
+    def test_second_dismiss_after_approve_rejected(self, tmp_path):
+        state_dir = tmp_path / "state"
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        _write_pending_archival(state_dir, [_archive_candidate("pat-idem-2")])
+
+        ll.apply_archival_decision(
+            state_dir, "pat-idem-2", "approve",
+            approval_id="appr-a", reason="approved",
+        )
+        with pytest.raises(ll.CandidateAlreadyHandledError):
+            ll.apply_archival_decision(
+                state_dir, "pat-idem-2", "dismiss",
+                approval_id="appr-b", reason="try dismiss later",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 5. status & review hide handled candidates
+# ---------------------------------------------------------------------------
+
+class TestStatusAndReviewHideHandled:
+    def _make_args(self, project_dir, mode="all"):
+        ns = argparse.Namespace()
+        ns.project_dir = str(project_dir)
+        ns.mode = mode
+        return ns
+
+    def test_review_omits_handled_candidates(self, tmp_path, capsys, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        _write_pending_archival(state_dir, [
+            _archive_candidate("pat-live"),
+            _archive_candidate("pat-done", status="approved"),
+        ])
+        monkeypatch.setattr(learning, "_resolve_state_dir", lambda _pd: state_dir)
+
+        rc = learning._cmd_review(self._make_args(tmp_path, mode="archival"))
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        assert "pat-live" in out
+        assert "pat-done" not in out
+
+    def test_status_counts_handled_separately(self, tmp_path, capsys, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        _write_pending_archival(state_dir, [
+            _archive_candidate("pat-live"),
+            _archive_candidate("pat-done", status="approved"),
+            _supersede_candidate("7", status="dismissed"),
+        ])
+        monkeypatch.setattr(learning, "_resolve_state_dir", lambda _pd: state_dir)
+
+        rc = learning._cmd_status(self._make_args(tmp_path))
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        assert "Pending archival candidates:                1" in out
+        assert "Handled (approved/dismissed, out of queue): 2" in out
+
+
+# ---------------------------------------------------------------------------
+# 6. Human-gate validation
+# ---------------------------------------------------------------------------
+
+class TestHumanGateValidation:
+    def test_missing_approval_id_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_pending_archival(state_dir, [_archive_candidate()])
+        with pytest.raises(ll.ArchivalDispositionError):
+            ll.apply_archival_decision(
+                state_dir, "pat-archive-1", "approve",
+                approval_id="", reason="ok",
+            )
+
+    def test_missing_reason_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_pending_archival(state_dir, [_archive_candidate()])
+        with pytest.raises(ll.ArchivalDispositionError):
+            ll.apply_archival_decision(
+                state_dir, "pat-archive-1", "approve",
+                approval_id="appr", reason="",
+            )
+
+    def test_invalid_approver_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_pending_archival(state_dir, [_archive_candidate()])
+        with pytest.raises(ll.ArchivalDispositionError):
+            ll.apply_archival_decision(
+                state_dir, "pat-archive-1", "approve",
+                approval_id="appr", reason="ok", approved_by="worker",
+            )
+
+    def test_unknown_pattern_id_raises(self, tmp_path):
+        state_dir = tmp_path / "state"
+        _write_pending_archival(state_dir, [_archive_candidate()])
+        with pytest.raises(ll.CandidateNotFoundError):
+            ll.apply_archival_decision(
+                state_dir, "does-not-exist", "approve",
+                approval_id="appr", reason="ok",
+            )
+
+
+# ---------------------------------------------------------------------------
+# 7. CLI verbs end-to-end (argparse → library)
+# ---------------------------------------------------------------------------
+
+class TestCliVerbs:
+    def _approve_args(self, project_dir, pattern_id):
+        ns = argparse.Namespace()
+        ns.project_dir = str(project_dir)
+        ns.pattern_id = pattern_id
+        ns.approval_id = "appr-cli"
+        ns.reason = "cli approve"
+        ns.source_table = None
+        ns.learning_subcommand = "approve"
+        return ns
+
+    def _dismiss_args(self, project_dir, pattern_id):
+        ns = argparse.Namespace()
+        ns.project_dir = str(project_dir)
+        ns.pattern_id = pattern_id
+        ns.approval_id = "appr-cli"
+        ns.reason = "cli dismiss"
+        ns.source_table = None
+        ns.learning_subcommand = "dismiss"
+        return ns
+
+    def test_cli_approve_returns_zero_and_marks_candidate(self, tmp_path, capsys, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        db_path = state_dir / "quality_intelligence.db"
+        _bootstrap_schema(db_path)
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            "INSERT INTO pattern_usage (pattern_id, pattern_title, pattern_hash, "
+            "confidence) VALUES ('pat-cli-1', 'T', 'h', 0.2)"
+        )
+        conn.commit()
+        conn.close()
+        _write_pending_archival(state_dir, [_archive_candidate("pat-cli-1")])
+        monkeypatch.setattr(learning, "_resolve_state_dir", lambda _pd: state_dir)
+
+        rc = learning.vnx_learning(self._approve_args(tmp_path, "pat-cli-1"))
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        assert "approved: pattern_id=pat-cli-1" in out
+        assert _read_pending_archival(state_dir)[0]["status"] == "approved"
+
+    def test_cli_dismiss_returns_zero_and_marks_candidate(self, tmp_path, capsys, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        _write_pending_archival(state_dir, [_archive_candidate("pat-cli-2")])
+        monkeypatch.setattr(learning, "_resolve_state_dir", lambda _pd: state_dir)
+
+        rc = learning.vnx_learning(self._dismiss_args(tmp_path, "pat-cli-2"))
+        assert rc == 0
+        out, _ = capsys.readouterr()
+        assert "dismissed: pattern_id=pat-cli-2" in out
+        assert _read_pending_archival(state_dir)[0]["status"] == "dismissed"
+
+    def test_cli_second_approve_returns_nonzero(self, tmp_path, capsys, monkeypatch):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        _bootstrap_schema(state_dir / "quality_intelligence.db")
+        _write_pending_archival(state_dir, [_archive_candidate("pat-cli-3")])
+        monkeypatch.setattr(learning, "_resolve_state_dir", lambda _pd: state_dir)
+
+        assert learning.vnx_learning(self._approve_args(tmp_path, "pat-cli-3")) == 0
+        rc = learning.vnx_learning(self._approve_args(tmp_path, "pat-cli-3"))
+        assert rc != 0
+        _, err = capsys.readouterr()
+        assert "already handled" in err

--- a/tests/test_learning_archival_disposition.py
+++ b/tests/test_learning_archival_disposition.py
@@ -14,6 +14,7 @@ every test runs against a tmp_path state dir and a tmp quality_intelligence.db.
 from __future__ import annotations
 
 import argparse
+import importlib
 import json
 import sqlite3
 import sys
@@ -27,8 +28,50 @@ sys.path.insert(0, str(_REPO_ROOT / "scripts"))
 sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
 sys.path.insert(0, str(_REPO_ROOT))
 
-import learning_loop as ll  # noqa: E402
+# OI-1051 / OI-1076: guard against a stubbed sys.modules["learning_loop"].
+# Other suites (notably test_intelligence_daemon_paths._install_stub_modules
+# and test_governance_digest_certification) replace sys.modules["learning_loop"]
+# with a types.ModuleType stub carrying only LearningLoop, and never restore
+# it. In collection order that stub wins: a bare `import learning_loop` (and
+# the lazy `import learning_loop as ll` inside vnx_cli/commands/learning.py)
+# then returns the stub, which lacks apply_archival_decision /
+# ArchivalDispositionError — the three TestCliVerbs cases fail.
+#
+# We pop any stale cache entry and re-import the genuine module via the normal
+# import mechanism (NOT spec_from_file_location, which creates a second module
+# object and trips isinstance/__module__ identity in sibling learning tests).
+# This is the same sys.modules-pop idiom test_append_receipt_identity uses to
+# force a re-import. No teardown: leaving the real module cached is the
+# correct end state — the stub installers re-stub on their own next use, so we
+# do not pollute them, and every other learning test wants the real module.
+_cached = sys.modules.get("learning_loop")
+if _cached is None or not hasattr(_cached, "apply_archival_decision"):
+    sys.modules.pop("learning_loop", None)
+    import learning_loop as ll  # noqa: E402
+else:
+    ll = _cached
+
 from vnx_cli.commands import learning  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def _ensure_real_learning_loop_module():
+    """Re-import the real learning_loop if a prior test stubbed sys.modules.
+
+    The module-level guard above covers collection time. But a sibling test in
+    the same session can re-stub sys.modules["learning_loop"] between our tests
+    (the stub installers have no teardown). The CLI verb does a lazy
+    `import learning_loop as ll` at call time, so it would pick up a re-stub.
+    This fixture guarantees the cached entry is the real module before each
+    test in this file runs. It leaves the real module cached on exit — the
+    correct end state for every downstream learning test.
+    """
+    _mod = sys.modules.get("learning_loop")
+    if _mod is None or not hasattr(_mod, "apply_archival_decision"):
+        sys.modules.pop("learning_loop", None)
+        sys.modules["learning_loop"] = importlib.import_module("learning_loop")
+    yield
+
 
 
 # ---------------------------------------------------------------------------

--- a/vnx_cli/commands/learning.py
+++ b/vnx_cli/commands/learning.py
@@ -84,21 +84,25 @@ def _cmd_status(args) -> int:
     # Pending archival / supersede
     pending_archival = 0
     pending_supersede = 0
+    handled_archival = 0
     if pending_archival_path.exists():
         try:
             data = json.loads(pending_archival_path.read_text(encoding="utf-8"))
             candidates = data.get("pending_archival", [])
             for c in candidates:
-                if c.get("status") != "pending":
-                    continue
-                if c.get("action") == "supersede":
-                    pending_supersede += 1
+                if c.get("status") == "pending":
+                    if c.get("action") == "supersede":
+                        pending_supersede += 1
+                    else:
+                        pending_archival += 1
                 else:
-                    pending_archival += 1
+                    # approved/dismissed — no longer in the actionable queue
+                    handled_archival += 1
         except (json.JSONDecodeError, OSError):
             pass
     print(f"  Pending archival candidates:                {pending_archival}")
-    print(f"  Pending supersede candidates (G-L4 gated): {pending_supersede}")
+    print(f"  Pending supersede candidates (G-L4 gated):  {pending_supersede}")
+    print(f"  Handled (approved/dismissed, out of queue): {handled_archival}")
 
     # Skill refinements
     pending_skill_refinements_path = state_dir / "pending_skill_refinements.json"
@@ -114,6 +118,8 @@ def _cmd_status(args) -> int:
     print(f"  Pending skill refinements:                  {pending_refinements}")
     print()
     print("To review proposals: vnx learning review")
+    print("To approve a candidate:   vnx learning approve <id> --approval-id <id> --reason <text>")
+    print("To dismiss a candidate:    vnx learning dismiss <id> --approval-id <id> --reason <text>")
     print("To review skill refinements: vnx learning skill-review")
     return 0
 
@@ -159,6 +165,8 @@ def _cmd_review(args) -> int:
                 candidates = [c for c in data.get("pending_archival", []) if c.get("status") == "pending"]
                 if not candidates:
                     print("No pending archival/supersede candidates.")
+                    print("  (Handled candidates stay in pending_archival.json but are")
+                    print("   marked approved/dismissed and no longer listed here.)")
                 else:
                     print(f"Pending archival/supersede candidates ({len(candidates)}):")
                     for c in candidates:
@@ -168,6 +176,10 @@ def _cmd_review(args) -> int:
                         print(f"    Title: {(c.get('title') or '')[:80]}")
                         print(f"    Reason: {c.get('reason', '')}")
                         print()
+                    print("Approve: vnx learning approve <pattern_id>"
+                          " --approval-id <id> --reason <text>")
+                    print("Dismiss: vnx learning dismiss <pattern_id>"
+                          " --approval-id <id> --reason <text>")
             except (json.JSONDecodeError, OSError) as exc:
                 print(f"error reading pending_archival.json: {exc}", file=sys.stderr)
                 return 1
@@ -616,6 +628,89 @@ def _cmd_grounding_shadow(args) -> int:
 
 
 
+def _cmd_disposition(args, decision: str) -> int:
+    """Shared body for `vnx learning approve` and `vnx learning dismiss`.
+
+    Carries out an operator-approved disposition on a pending_archival.json
+    candidate. Mirrors the human-gated verb form used by `horizon close` /
+    `objective reopen`: --approval-id is the gate token, --reason mandatory.
+    The audit trail is the existing governed NDJSON stream
+    (intelligence_usage.ndjson) via learning_loop.apply_archival_decision.
+
+    Idempotent: a second call on an already-decided candidate prints a clear
+    message and exits non-zero without a double DB mutation.
+    """
+    project_dir = Path(getattr(args, "project_dir", "."))
+    pattern_id = getattr(args, "pattern_id", "")
+    approval_id = getattr(args, "approval_id", "") or ""
+    reason = getattr(args, "reason", "") or ""
+    source_table = getattr(args, "source_table", None)
+
+    if not pattern_id:
+        print("error: <pattern_id> is required.", file=sys.stderr)
+        return 2
+
+    state_dir = _resolve_state_dir(project_dir)
+
+    import learning_loop as ll  # type: ignore[import]
+    try:
+        result = ll.apply_archival_decision(
+            state_dir,
+            pattern_id,
+            decision,
+            approval_id=approval_id,
+            reason=reason,
+            approved_by="operator",
+            source_table=source_table,
+        )
+    except ll.ArchivalDispositionError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ll.CandidateNotFoundError as exc:
+        print(f"error: {exc}", file=sys.stderr)
+        return 2
+    except ll.CandidateAlreadyHandledError as exc:
+        # Idempotent second call: clear message, no double action.
+        print(f"already handled: {exc}", file=sys.stderr)
+        return 2
+
+    action = result.get("action", "archive")
+    db_applied = result.get("db_applied")
+    if decision == "approve":
+        applied_note = (
+            f"DB row superseded (valid_until set)" if action == "supersede" and db_applied
+            else "pattern_usage row archived" if action != "supersede" and db_applied
+            else "no DB row matched (already applied or absent)"
+        )
+        print(f"approved: pattern_id={pattern_id} action={action} — {applied_note}")
+    else:
+        print(f"dismissed: pattern_id={pattern_id} (no DB mutation)")
+    print(f"  decision={result['status']}  approved_by=operator"
+          f"  approval_id={approval_id}")
+    print(f"  reason: {reason}")
+    print(f"  audit: archival_decision event appended to intelligence_usage.ndjson")
+    return 0
+
+
+def _cmd_approve(args) -> int:
+    """Approve a pending_archival candidate (operator-gated, audited).
+
+    For action=supersede candidates: sets valid_until on the success_patterns
+    or prevention_rules row (idempotent). For action=archive candidates:
+    removes the pattern_usage row.
+    """
+    return _cmd_disposition(args, "approve")
+
+
+def _cmd_dismiss(args) -> int:
+    """Dismiss a pending_archival candidate (operator-gated, audited).
+
+    Removes the candidate from the actionable queue without any DB mutation.
+    Use when the operator decides NOT to act on a proposal.
+    """
+    return _cmd_disposition(args, "dismiss")
+
+
 def vnx_learning(args) -> int:
     sub = getattr(args, "learning_subcommand", None)
     dispatch = {
@@ -626,8 +721,10 @@ def vnx_learning(args) -> int:
         "tagger-ab": _cmd_tagger_ab,
         "skill-refine": _cmd_skill_refine,
         "skill-review": _cmd_skill_review,
+        "approve": _cmd_approve,
+        "dismiss": _cmd_dismiss,
     }
     if sub in dispatch:
         return dispatch[sub](args)
-    print("Usage: vnx learning {run|status|review|grounding-shadow|tagger-ab|skill-refine|skill-review}")
+    print("Usage: vnx learning {run|status|review|approve|dismiss|grounding-shadow|tagger-ab|skill-refine|skill-review}")
     return 1

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -876,6 +876,74 @@ def _register_learning_subparser(subparsers: argparse.Action) -> None:
         help="display the full unified diff for each proposal",
     )
 
+    # Operator disposition verbs (OI-1076 / OI-1038): the consumer the proposal
+    # tier was missing. Form mirrors horizon close / objective reopen —
+    # --approval-id is the gate token, --reason is mandatory.
+    lr_approve = learning_subs.add_parser(
+        "approve",
+        help=(
+            "approve a pending_archival/supersede candidate (operator-gated). "
+            "supersede → sets valid_until on the DB row; archive → removes the "
+            "pattern_usage row."
+        ),
+    )
+    lr_approve.add_argument("pattern_id", metavar="PATTERN_ID",
+                            help="candidate pattern_id from `vnx learning review`")
+    lr_approve.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_approve.add_argument(
+        "--approval-id",
+        dest="approval_id",
+        default="",
+        required=True,
+        help="operator approval token (REQUIRED — the human gate)",
+    )
+    lr_approve.add_argument(
+        "--reason",
+        dest="reason",
+        default="",
+        required=True,
+        help="non-empty rationale for the approval (REQUIRED)",
+    )
+    lr_approve.add_argument(
+        "--source-table",
+        dest="source_table",
+        default=None,
+        choices=["success_patterns", "prevention_rules"],
+        help="disambiguate when the same id appears in two tables",
+    )
+
+    lr_dismiss = learning_subs.add_parser(
+        "dismiss",
+        help=(
+            "dismiss a pending_archival/supersede candidate (operator-gated). "
+            "Removes the candidate from the queue without a DB mutation."
+        ),
+    )
+    lr_dismiss.add_argument("pattern_id", metavar="PATTERN_ID",
+                            help="candidate pattern_id from `vnx learning review`")
+    lr_dismiss.add_argument("--project-dir", default=".", metavar="DIR")
+    lr_dismiss.add_argument(
+        "--approval-id",
+        dest="approval_id",
+        default="",
+        required=True,
+        help="operator approval token (REQUIRED — the human gate)",
+    )
+    lr_dismiss.add_argument(
+        "--reason",
+        dest="reason",
+        default="",
+        required=True,
+        help="non-empty rationale for the dismissal (REQUIRED)",
+    )
+    lr_dismiss.add_argument(
+        "--source-table",
+        dest="source_table",
+        default=None,
+        choices=["success_patterns", "prevention_rules"],
+        help="disambiguate when the same id appears in two tables",
+    )
+
 
 def _register_dream_subparser(subparsers: argparse.Action) -> None:
     dream_parser = subparsers.add_parser(


### PR DESCRIPTION
## What

The self-learning proposal tier wrote candidates to `pending_archival.json` but **nothing consumed that file** — the operator gate the design calls for did not exist, so proposals stacked up with no route to execution. That is why the loop reads as dormant (OI-1076), and why handled candidates kept resurfacing in `status`/`review` (OI-1038).

This adds the missing consumer.

## Changes

- **`vnx learning approve <pattern_id>`** and **`vnx learning dismiss <pattern_id>`** carry out a disposition on a `pending_archival.json` candidate. Form mirrors the existing human-gated verbs (`horizon close` / `objective reopen`): `--approval-id` is the operator's gate token (required), `--reason` is mandatory.
- `approve` + `action=supersede` → sets `valid_until` on the `success_patterns` / `prevention_rules` row (idempotent via `WHERE valid_until IS NULL`).
- `approve` + `action=archive` → removes the `pattern_usage` row.
- `dismiss` → removes the candidate from the queue **without** a DB mutation.
- **Audit:** an `archival_decision` event is appended to the existing governed NDJSON stream (`intelligence_usage.ndjson`) — no second logging mechanism.
- **Idempotent:** a candidate no longer pending raises a clear message; no silent no-op and no double DB mutation.
- `status`/`review` stop resurfacing handled candidates (they filter on `status == "pending"`); `status` now also reports a handled count.

## Files

- `scripts/learning_loop.py` — `apply_archival_decision()` + helpers (`load_pending_archival`, `_save_pending_archival_atomic`, `_emit_archival_decision_event`, `_find_candidate`, `_apply_supersede`, `_apply_archive`).
- `vnx_cli/commands/learning.py` — `_cmd_approve` / `_cmd_dismiss` (shared `_cmd_disposition`), wired into `vnx_learning`; `status`/`review` updated.
- `vnx_cli/main.py` — `approve` / `dismiss` subparsers registered.
- `tests/test_learning_archival_disposition.py` — 17 tests (approve archive/supersede, dismiss, idempotency, status/review hide handled, human-gate validation, CLI verbs end-to-end).

## Verification

Tests construct their own candidates and write to a tmp state dir — **no writes to the production store** (the four testfixtures are left alone per the dispatch).

```
pytest tests/test_learning_archival_disposition.py tests/test_learning_d3_proposal.py tests/test_learning_feature.py tests/test_learning_loop_gate.py tests/test_learning_proposals_api.py
→ 66 passed, 1 skipped (the skipped one needs the real receipt trail)

pytest tests/test_learning_loop_certification.py tests/test_learning_loop_crap_signal.py tests/test_learning_loop_degraded_no_activate.py tests/test_learning_loop_exception_handling.py
→ 43 passed
```

End-to-end library smoke (constructed candidate): pending → approved, `pattern_usage` row removed, `archival_decision` audit event in `intelligence_usage.ndjson`, second `approve` idempotent-rejected.

## Not in scope

- The four testfixtures (`naive_pat`, `null_pat`, `naive_test`, `null_test`) are **not** removed from the production store — that is a separate operator decision.
- The loop is not enabled and thresholds are not moved. Only the disposition gap is closed.

Dispatch-ID: 20260809f-w6-learning-actiepad

🤖 Generated with [Claude Code](https://claude.com/claude-code)