### PR TITLE
refactor(closure): derive _KNOWN_GATES from Gate enum, table-drive _check_single_gate (OI-1094)

### DIFF
--- a/scripts/closure_verifier.py
+++ b/scripts/closure_verifier.py
@@ -27,6 +27,7 @@ from review_contract import ReviewContract
 from codex_final_gate import enforce_codex_gate
 from codex_severity_translator import translate_findings as translate_codex_findings
 from gate_status import is_pass as gate_is_pass, is_terminal as gate_is_terminal
+from dispatch_spec import Gate
 
 
 @dataclass(frozen=True)
@@ -41,12 +42,25 @@ class CheckResult:
 # fail for it, so it is reported as UNVERIFIED and any result file found for it
 # is ignored. This closes the leak where an unknown gate passed on file
 # presence alone.
-_KNOWN_GATES = frozenset({
-    "claude_github_optional",
-    "codex_gate",
-    "gemini_review",
-    "ci_gate",
-})
+#
+# Derived from the canonical Gate enum (scripts/lib/dispatch_spec.py, OI-845),
+# not a second hand-written list. A gate that the enum declares but the closure
+# verifier does not implement lives in _GATES_NOT_IMPLEMENTED_BY_CLOSURE with a
+# reason — a derived subset with a rationale, so the two collections can never
+# silently drift (pinned by test_closure_verifier_gate_enum_drift).
+#
+# wiring_gate is intentionally excluded: it is in the Gate enum (and in
+# gate_request_handler / gate_recorder), but it does not emit a terminal
+# result-record carrying contract_hash + report_path, so the generic known-gate
+# handling could not honestly attest it. Keeping it outside _KNOWN_GATES also
+# preserves OI-1093 (#1422): records for gates NOT in _KNOWN_GATES must carry a
+# producer identity (dispatch_id). Pulling wiring_gate in would drop that
+# requirement. When in doubt, the side with more verification wins.
+_GATES_NOT_IMPLEMENTED_BY_CLOSURE = frozenset({"wiring_gate"})
+_KNOWN_GATES = frozenset(
+    g.value for g in Gate
+    if g.value not in _GATES_NOT_IMPLEMENTED_BY_CLOSURE
+)
 
 
 def _is_test_run_record(data: Dict[str, Any]) -> bool:
@@ -454,6 +468,173 @@ def _check_contract_fields(contract: ReviewContract) -> List[CheckResult]:
     )]
 
 
+def _gate_claude_github_optional(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    gate = "claude_github_optional"
+    # Fallback: explicit-absence state for the optional gate is recorded
+    # in the requests directory by gate_request_handler — not as a
+    # separate result file — so a missing result is not by itself
+    # ambiguous.  Look there before declaring no evidence.
+    if result is None:
+        result = _find_gate_request_payload(gate, contract.pr_id, results_dir, branch=branch)
+    if result is None:
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"no evidence for optional gate {gate} — state must be explicit",
+        )
+    if (result.get("state") or "").lower() == "completed":
+        # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
+        # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
+        # gate_is_pass() handles state/result_status via gate_status._coerce_status (CFX-12).
+        passed, reason = gate_is_pass(result)
+        if passed:
+            advisory_count = int(result.get("advisory_count") or 0)
+            return CheckResult(
+                f"gate_{gate}",
+                "PASS",
+                f"{gate} completed: pass (0 blocking, {advisory_count} advisory)",
+            )
+        return CheckResult(f"gate_{gate}", "FAIL", f"{gate} completed: {reason}")
+    if result.get("was_intentionally_absent") or result.get("contributed_evidence"):
+        state = result.get("state", "unknown")
+        source = result.get("__source", "result")
+        return CheckResult(
+            f"gate_{gate}",
+            "PASS",
+            f"{gate} state explicit: {state} (source: {source})",
+        )
+    return CheckResult(
+        f"gate_{gate}",
+        "FAIL",
+        f"{gate} state is ambiguous — neither contributed evidence nor intentionally absent",
+    )
+
+
+def _gate_codex_gate(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    gate = "codex_gate"
+    enforcement = enforce_codex_gate(contract)
+    if enforcement.required:
+        if result is None:
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
+            )
+        if gate_is_terminal(result) and not result.get("report_path", ""):
+            return CheckResult(
+                f"gate_{gate}",
+                "FAIL",
+                "codex_gate result is missing required report_path field",
+            )
+        # CFX-17: demote allowlisted findings before counting blocking.
+        translated = _apply_codex_severity_policy(result)
+        passed, reason = gate_is_pass(translated)
+        demoted = len(translated.get("severity_demotions") or [])
+        if passed:
+            if demoted:
+                return CheckResult(
+                    f"gate_{gate}",
+                    "PASS",
+                    f"codex gate passed after demoting {demoted} finding(s) per severity policy",
+                )
+            return CheckResult(f"gate_{gate}", "PASS", "codex gate passed")
+        return CheckResult(f"gate_{gate}", "FAIL", f"codex gate not passing — {reason}")
+    return CheckResult(f"gate_{gate}", "PASS", "codex gate not required by risk policy")
+
+
+def _gate_gemini_review(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    gate = "gemini_review"
+    if result is None:
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"no gate result for required reviewer {gate}",
+        )
+    if gate_is_terminal(result) and not result.get("report_path", ""):
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            "gemini_review result is missing required report_path field",
+        )
+    passed, reason = gate_is_pass(result)
+    advisory_count = result.get("advisory_count", 0)
+    if passed:
+        return CheckResult(
+            f"gate_{gate}",
+            "PASS",
+            f"gemini review passed ({advisory_count} advisory, 0 blocking)",
+        )
+    return CheckResult(f"gate_{gate}", "FAIL", f"gemini review not passing — {reason}")
+
+
+def _gate_ci_gate(
+    contract: ReviewContract,
+    result: Optional[Dict[str, Any]],
+    results_dir: Path,
+    branch: Optional[str],
+) -> CheckResult:
+    gate = "ci_gate"
+    if result is None:
+        return CheckResult(f"gate_{gate}", "FAIL", "no ci_gate result found")
+    if not gate_is_terminal(result):
+        status = result.get("status", "unknown")
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            f"ci_gate checks still {status} — incomplete evidence",
+        )
+    contract_hash = result.get("contract_hash", "")
+    report_path = result.get("report_path", "")
+    if not contract_hash:
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            "ci_gate result is missing required contract_hash field",
+        )
+    if not report_path:
+        return CheckResult(
+            f"gate_{gate}",
+            "FAIL",
+            "ci_gate result is missing required report_path field",
+        )
+    passed, reason = gate_is_pass(result)
+    if passed:
+        advisory_count = result.get("advisory_count", 0)
+        return CheckResult(
+            f"gate_{gate}",
+            "PASS",
+            f"ci_gate passed ({advisory_count} advisory, 0 blocking)",
+        )
+    return CheckResult(f"gate_{gate}", "FAIL", f"ci_gate not passing — {reason}")
+
+
+# Table-driven dispatch: one entry per gate the closure verifier implements.
+# Adding a gate means adding one handler here plus (if excluded) an entry in
+# _GATES_NOT_IMPLEMENTED_BY_CLOSURE — not a new branch in _check_single_gate,
+# which is what made the function grow past its line budget (OI-1094).
+_GATE_HANDLERS: Dict[str, Any] = {
+    "claude_github_optional": _gate_claude_github_optional,
+    "codex_gate": _gate_codex_gate,
+    "gemini_review": _gate_gemini_review,
+    "ci_gate": _gate_ci_gate,
+}
+
+
 def _check_single_gate(
     gate: str,
     contract: ReviewContract,
@@ -482,132 +663,8 @@ def _check_single_gate(
             f"gate {gate} is not implemented by the closure verifier — not decided, cannot pass",
         )
 
-    if gate == "claude_github_optional":
-        # Fallback: explicit-absence state for the optional gate is recorded
-        # in the requests directory by gate_request_handler — not as a
-        # separate result file — so a missing result is not by itself
-        # ambiguous.  Look there before declaring no evidence.
-        if result is None:
-            result = _find_gate_request_payload(gate, contract.pr_id, results_dir, branch=branch)
-        if result is None:
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                f"no evidence for optional gate {gate} — state must be explicit",
-            )
-        if (result.get("state") or "").lower() == "completed":
-            # Completed Claude review: terminal outcome lives in result_status, not status/verdict.
-            # contributed_evidence=true alone must NOT mask a fail outcome or blocking findings.
-            # gate_is_pass() handles state/result_status via gate_status._coerce_status (CFX-12).
-            passed, reason = gate_is_pass(result)
-            if passed:
-                advisory_count = int(result.get("advisory_count") or 0)
-                return CheckResult(
-                    f"gate_{gate}",
-                    "PASS",
-                    f"{gate} completed: pass (0 blocking, {advisory_count} advisory)",
-                )
-            return CheckResult(f"gate_{gate}", "FAIL", f"{gate} completed: {reason}")
-        if result.get("was_intentionally_absent") or result.get("contributed_evidence"):
-            state = result.get("state", "unknown")
-            source = result.get("__source", "result")
-            return CheckResult(
-                f"gate_{gate}",
-                "PASS",
-                f"{gate} state explicit: {state} (source: {source})",
-            )
-        return CheckResult(
-            f"gate_{gate}",
-            "FAIL",
-            f"{gate} state is ambiguous — neither contributed evidence nor intentionally absent",
-        )
-
-    if gate == "codex_gate":
-        enforcement = enforce_codex_gate(contract)
-        if enforcement.required:
-            if result is None:
-                return CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    f"codex gate required ({', '.join(enforcement.reasons)}) but no result found",
-                )
-            if gate_is_terminal(result) and not result.get("report_path", ""):
-                return CheckResult(
-                    f"gate_{gate}",
-                    "FAIL",
-                    "codex_gate result is missing required report_path field",
-                )
-            # CFX-17: demote allowlisted findings before counting blocking.
-            translated = _apply_codex_severity_policy(result)
-            passed, reason = gate_is_pass(translated)
-            demoted = len(translated.get("severity_demotions") or [])
-            if passed:
-                if demoted:
-                    return CheckResult(
-                        f"gate_{gate}",
-                        "PASS",
-                        f"codex gate passed after demoting {demoted} finding(s) per severity policy",
-                    )
-                return CheckResult(f"gate_{gate}", "PASS", "codex gate passed")
-            return CheckResult(f"gate_{gate}", "FAIL", f"codex gate not passing — {reason}")
-        return CheckResult(f"gate_{gate}", "PASS", "codex gate not required by risk policy")
-
-    if gate == "gemini_review":
-        if result is None:
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                f"no gate result for required reviewer {gate}",
-            )
-        if gate_is_terminal(result) and not result.get("report_path", ""):
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                "gemini_review result is missing required report_path field",
-            )
-        passed, reason = gate_is_pass(result)
-        advisory_count = result.get("advisory_count", 0)
-        if passed:
-            return CheckResult(
-                f"gate_{gate}",
-                "PASS",
-                f"gemini review passed ({advisory_count} advisory, 0 blocking)",
-            )
-        return CheckResult(f"gate_{gate}", "FAIL", f"gemini review not passing — {reason}")
-
-    if gate == "ci_gate":
-        if result is None:
-            return CheckResult(f"gate_{gate}", "FAIL", "no ci_gate result found")
-        if not gate_is_terminal(result):
-            status = result.get("status", "unknown")
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                f"ci_gate checks still {status} — incomplete evidence",
-            )
-        contract_hash = result.get("contract_hash", "")
-        report_path = result.get("report_path", "")
-        if not contract_hash:
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                "ci_gate result is missing required contract_hash field",
-            )
-        if not report_path:
-            return CheckResult(
-                f"gate_{gate}",
-                "FAIL",
-                "ci_gate result is missing required report_path field",
-            )
-        passed, reason = gate_is_pass(result)
-        if passed:
-            advisory_count = result.get("advisory_count", 0)
-            return CheckResult(
-                f"gate_{gate}",
-                "PASS",
-                f"ci_gate passed ({advisory_count} advisory, 0 blocking)",
-            )
-        return CheckResult(f"gate_{gate}", "FAIL", f"ci_gate not passing — {reason}")
+    handler = _GATE_HANDLERS[gate]
+    return handler(contract, result, results_dir, branch)
 
 
 def _check_contract_hashes(contract: ReviewContract, results_dir: Path) -> List[CheckResult]:

--- a/tests/test_closure_verifier_gate_enum_drift.py
+++ b/tests/test_closure_verifier_gate_enum_drift.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+"""Drift pin: _KNOWN_GATES must stay derived from the Gate enum (OI-1094).
+
+Before this dispatch, closure_verifier carried a fourth hand-written list of
+gate names (_KNOWN_GATES) that drifted from the canonical Gate enum in
+scripts/lib/dispatch_spec.py: it omitted wiring_gate, which the enum, the
+gate_recorder and gate_request_handler all know about. Five places holding the
+same collection without talking to each other is drift-prone by design.
+
+_KNOWN_GATES is now derived from Gate: every enum member is either implemented
+by the closure verifier (in _KNOWN_GATES) or explicitly excluded with a reason
+(in _GATES_NOT_IMPLEMENTED_BY_CLOSURE). These tests pin that invariant so the
+two collections cannot silently drift again.
+
+Against main (commit 60601c1f / d86f132d) these tests are RED: wiring_gate is
+declared by the Gate enum but present in neither _KNOWN_GATES (it was simply
+missing) nor _GATES_NOT_IMPLEMENTED_BY_CLOSURE (that set did not exist).
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import closure_verifier as cv
+from dispatch_spec import Gate
+
+
+class TestKnownGatesDerivedFromEnum:
+    def test_known_gates_is_a_subset_of_enum_members(self):
+        """Every implemented gate must be a declared Gate enum value."""
+        enum_values = {g.value for g in Gate}
+        assert cv._KNOWN_GATES.issubset(enum_values), (
+            f"_KNOWN_GATES has values not in the Gate enum: "
+            f"{sorted(cv._KNOWN_GATES - enum_values)}"
+        )
+
+    def test_excluded_gates_is_a_subset_of_enum_members(self):
+        """Every explicitly-excluded gate must be a declared Gate enum value."""
+        enum_values = {g.value for g in Gate}
+        assert cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE.issubset(enum_values), (
+            f"_GATES_NOT_IMPLEMENTED_BY_CLOSURE has values not in the Gate enum: "
+            f"{sorted(cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE - enum_values)}"
+        )
+
+    def test_known_and_excluded_are_disjoint(self):
+        """A gate is either implemented or excluded, never both."""
+        overlap = cv._KNOWN_GATES & cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE
+        assert not overlap, (
+            f"gates in both _KNOWN_GATES and _GATES_NOT_IMPLEMENTED_BY_CLOSURE: "
+            f"{sorted(overlap)}"
+        )
+
+    def test_every_enum_member_is_accounted_for(self):
+        """No Gate enum member may fall through both collections.
+
+        This is the drift pin. On main, wiring_gate is declared by the enum
+        but in neither set, so this assertion fails there and passes here.
+        """
+        enum_values = {g.value for g in Gate}
+        accounted = cv._KNOWN_GATES | cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE
+        missing = enum_values - accounted
+        assert not missing, (
+            f"Gate enum members with no closure-verifier disposition: {sorted(missing)}. "
+            f"Add them to _KNOWN_GATES (if implemented) or to "
+            f"_GATES_NOT_IMPLEMENTED_BY_CLOSURE (with a reason)."
+        )
+
+    def test_wiring_gate_is_explicitly_excluded_not_silently_missing(self):
+        """wiring_gate must be excluded by name, with a reason, not absent.
+
+        It emits no terminal result-record with contract_hash + report_path, so
+        the generic known-gate handling cannot honestly attest it. Keeping it
+        outside _KNOWN_GATES also preserves OI-1093 (#1422): records for gates
+        not in _KNOWN_GATES must carry a producer identity (dispatch_id). When
+        in doubt, the side with more verification wins.
+        """
+        assert "wiring_gate" in cv._GATES_NOT_IMPLEMENTED_BY_CLOSURE
+        assert "wiring_gate" not in cv._KNOWN_GATES
+
+    def test_every_implemented_gate_has_a_handler(self):
+        """Every gate in _KNOWN_GATES must have a handler in the dispatch table.
+
+        A gate marked implemented but with no handler would raise KeyError at
+        runtime instead of producing a CheckResult — the table-driven design
+        must stay complete.
+        """
+        missing_handlers = cv._KNOWN_GATES - set(cv._GATE_HANDLERS.keys())
+        assert not missing_handlers, (
+            f"_KNOWN_GATES without a _GATE_HANDLERS entry: {sorted(missing_handlers)}"
+        )
+
+    def test_no_handler_for_a_gate_outside_known_gates(self):
+        """No handler may exist for a gate the verifier does not claim to implement."""
+        stray = set(cv._GATE_HANDLERS.keys()) - cv._KNOWN_GATES
+        assert not stray, (
+            f"_GATE_HANDLERS entries for gates not in _KNOWN_GATES: {sorted(stray)}"
+        )


### PR DESCRIPTION
## Wat

`closure_verifier._check_single_gate` telde **136 uitvoerbare regels** (`inspect.getsource`) tegen een drempel van **70** op `d86f132d`. De functie was een keten van per-gate takken die structureel identiek waren en alleen in gate-naam en foutteksten verschilden. Elke nieuwe gate-naam verlengt hem.

Daarnaast droeg `closure_verifier._KNOWN_GATES` de **vierde** handgeschreven lijst gate-namen in de repo, naast de `Gate`-enum, `gate_runner.GATE_BINARIES`, `gate_recorder._GATE_BINARIES` en `prior_round_injector._KNOWN_GATES`. De lijst liet `wiring_gate` weg terwijl de enum, `gate_recorder` en `gate_request_handler` hem wél kennen.

## Veranderingen

**`_KNOWN_GATES` afgeleid uit de `Gate`-enum** (`scripts/closure_verifier.py`). Geen tweede lijst ernaast. Een gate die de enum declareert maar de verifier niet implementeert, woont in `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` met een reden. Een afgeleide deelverzameling met rationale, geen handgeschreven duplicaat.

**`_check_single_gate` tabelgedreven.** De functie is nu een dispatcher die routeert naar vier per-gate handlers (`_gate_claude_github_optional`, `_gate_codex_gate`, `_gate_gemini_review`, `_gate_ci_gate`) via `_GATE_HANDLERS`. De volgende gate-naam verlengt de functie niet meer: één handler toevoegen, eventueel een uitsluitings-entry.

- `_check_single_gate`: **136 → 23 uitvoerbare regels** (`inspect.getsource`, gemeten op `d86f132d`).

## wiring_gate-afweging (motivatie)

`wiring_gate` staat in de `Gate`-enum, `gate_recorder._GATE_BINARIES`, `gate_recorder._GATE_ENV_FLAGS` en `gate_request_handler`. Toch blijft hij bewust buiten `_KNOWN_GATES`:

1. `wiring_gate.py` emit **geen** terminal result-record met `contract_hash` + `report_path`. De generieke known-gate-afhandeling kan hem niet eerlijk attesten.
2. Buiten `_KNOWN_GATES` houden behoudt **OI-1093 (#1422)**: records voor gates niet in `_KNOWN_GATES` moeten een producent-identiteit (`dispatch_id`) dragen. `wiring_gate` erin halen zou die eis laten vallen.
3. Bij twijfel wint de kant met méér verificatie, niet minder.

De uitsluiting is nu expliciet in code vastgelegd (`_GATES_NOT_IMPLEMENTED_BY_CLOSURE = frozenset({"wiring_gate"})`) met een commentaar dat naar #1422 verwijst. Op main was hij stil afwezig.

## Gedrag ongewijzigd

Refactor, geen gedragswijziging. De vier handlers behouden de exacte logica, berichtteksten en veldcontroles van de oude takken. `_KNOWN_GATES` bevat dezelfde vier waarden als voorheen (`ci_gate`, `claude_github_optional`, `codex_gate`, `gemini_review`). `wiring_gate` blijft erbuiten, zoals ook op main (toen stil, nu expliciet).

## Verificatie

- **Regeltelling**: `_check_single_gate` 136 → 23 uitvoerbare regels, zelfde teller (`inspect.getsource`), commit `d86f132d` (voor) / `b36edb68` (na).
- **Drift-pin test** (`tests/test_closure_verifier_gate_enum_drift.py`): 7 tests die pinten dat elke `Gate`-member geïmplementeerd óf expliciet uitgesloten is, de verzamelingen disjunct zijn, en elke implemented gate een handler heeft. **Rood op main** (6 failed: `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` en `_GATE_HANDLERS` bestaan niet, `wiring_gate` valt door beide mazen). **Groen op deze branch** (7 passed).
- **Directe set + buren** (`test_closure_verifier`, `test_closure_verifier_evidence_contract`, `test_closure_verifier_unknown_gate`, `test_closure_verifier_gate_enum_drift`, `test_verify_pr`, `test_per_pr_closure`, `test_dispatch_spec`, `test_prior_round_injector`, `test_chain_state_projection`, `test_ghost_receipt_filter`): **270 passed, 9 failed**. De 9 falers zitten allemaal in `test_per_pr_closure.py` en zijn **pre-existing rood op main** (zelfde commit, byte-voor-byte identiek: branch-scoping in de fixture geeft geen `branch`-veld mee, ADR-005 verwerpt de evidence).
- **Gate-buren** (`test_gate_execution_certification`, `test_gate_runner`, `test_gate_status_schema`, `test_gate_evidence_accuracy`): **73 passed, 16 failed, 1 skipped**, identiek aan main. `test_closure_verifier_reads_status_completed_as_pass` faalt op main en worktree met dezelfde assertion (`codex gate required ... but no result found`) — fixture-setup, niet deze refactor.

Geen test aangepast om groen te blijven.

## Inventaris: alle lijsten gate-namen in de repo

Stap 1 van de dispatch. Tabel met per lijst: afgeleid / subset-met-reden / bewust gescheiden semantiek.

| Bestand | Symbool | Inhoud | Status |
|---|---|---|---|
| `scripts/lib/dispatch_spec.py` | `Gate` (enum) | `gemini_review`, `codex_gate`, `claude_github_optional`, `ci_gate`, `wiring_gate` | **Canonieke bron** |
| `scripts/closure_verifier.py` | `_KNOWN_GATES` | 4 (mist `wiring_gate`) | **Deze PR: afgeleid uit enum** met `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` |
| `scripts/closure_verifier.py` | `_GATE_HANDLERS` | 4 (per-gate handlers) | **Deze PR: nieuw, tabelgedreven dispatch** |
| `scripts/gate_runner.py` | `GATE_BINARIES` | 3 (`gemini`, `codex`, `gh`) | Bewuste subset: alleen gates met een echte binary. `ci_gate`/`wiring_gate`/`claude_github_optional` draaien via `gh`. Advies: relatie expliciteren. |
| `scripts/gate_runner.py` | `GATE_CLI_ARGS` | 3 | Gekoppeld aan `GATE_BINARIES`. Advies: afleiden waar mogelijk. |
| `scripts/lib/gate_recorder.py` | `_GATE_BINARIES` | 5 (volledig) | Komt overeen met enum. Advies: afleiden uit enum. |
| `scripts/lib/gate_recorder.py` | `_GATE_ENV_FLAGS` | 5 (volledig) | Komt overeen met enum. Advies: afleiden uit enum. |
| `scripts/lib/prior_round_injector.py` | `_KNOWN_GATES` | 2 (`codex_gate`, `gemini_review`) | Bewuste subset: alleen gates die prior-findings injecteren. Advies: subset-met-reden expliciteren. |
| `scripts/lib/chain_state_projection.py` | `REQUIRED_GATES` | 2 (`gemini_review`, `codex_gate`) | Bewuste subset: vereiste gates voor chain-state. Advies: subset-met-reden. |
| `scripts/lib/auto_gate_trigger.py` | `_DEFAULT_GATE_STACK` | 2 | Bewuste subset, uit `governance_enforcement.yaml`. Advies: subset-met-reden. |
| `scripts/lib/ghost_receipt_filter.py` | `_KNOWN_GATE_NAMES` | 6 (incl. legacy aliassen) | **Bewust gescheiden semantiek**: ghost-routing-lijst, bevat `claude_github_review`, `pre_merge_gate`, `review_gate` (legacy/aliassen). Geen drift met de enum — ander doel. |
| `scripts/lib/gate_report_generator.py` | `env_flags` (inline) | 4 (mist `wiring_gate`) | Hardgecodeerd, duplicaat van `gate_recorder._GATE_ENV_FLAGS`. Advies: afleiden/hergebruiken. |

Deze PR lost de drift in `closure_verifier` op en levert de drift-pin. De overige lijsten zijn bewuste subsets of gescheiden semantiek; een vervolg-dispatch kan de explicitering per lijst oppakken. Buiten scope van deze PR om de ingreep klein en reversibel te houden.

## Open items

- De overige 10 lijsten uit de inventaris blijven onveranderd (bewuste subsets / gescheiden semantiek). Vervolg-dispatch aanbevolen voor `gate_recorder._GATE_ENV_FLAGS`/`_GATE_BINARIES` afleiden en `gate_report_generator` inline-duplicaat hergebruiken.
- `wiring_gate`-closure-ondersteuning: als `wiring_gate` ooit terminal evidence met `contract_hash`/`report_path` gaat emit, kan hij van `_GATES_NOT_IMPLEMENTED_BY_CLOSURE` naar `_KNOWN_GATES` + `_GATE_HANDLERS` verhuizen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)