### PR TITLE
fix(enforcement): add push-containment guard and single-destination PR logic (OI-1113, OI-1115)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -98,6 +98,16 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+def _is_dispatch_branch_ref(base_ref: str) -> bool:
+    """Return True when *base_ref* names a dispatch branch on origin.
+
+    A dispatch branch has the form ``origin/dispatch/<id>``.  When the
+    dispatch's base_ref is a dispatch branch, the lane must NOT create a
+    second auto-PR alongside the existing one (OI-1115).
+    """
+    return base_ref.startswith("origin/dispatch/")
+
+
 def _enforce_push_pr(
     *,
     dispatch_id: str,
@@ -107,6 +117,8 @@ def _enforce_push_pr(
     receipts_file: "str | Path",
     result: "_AdapterResult",
     base_ref: str = "origin/main",
+    target_remote_head: "Optional[str]" = None,
+    skip_pr: bool = False,
 ) -> "_AdapterResult":
     """Enforce the rij-7 push+PR obligation on an envelope-lane worktree.
 
@@ -115,6 +127,13 @@ def _enforce_push_pr(
     enforcement is applicable and fails (push or PR), the adapter result is
     rewritten to status="failure" so the governed EnvelopeResult is non-zero.
     pr_enforcement appends the corrective receipt itself.
+
+    *target_remote_head* (OI-1113): the remote HEAD of *branch* captured BEFORE
+    the worker started.  Passed through to enforce_pr_exists for containment
+    verification after push.
+
+    *skip_pr* (OI-1115): when True, the auto-PR creation is skipped.  Set when
+    *base_ref* is a dispatch branch (the PR already exists).
 
     A non-applicable state (clean/dirty) leaves *result* unchanged. Never raises:
     an internal error fails open (the worktree is still torn down by the caller's
@@ -173,6 +192,8 @@ def _enforce_push_pr(
                 f"(dispatch `{dispatch_id}`) — the worker left this branch "
                 "without an open PR. Please review before merging."
             ),
+            target_remote_head=target_remote_head,
+            skip_pr=skip_pr,
         )
     except Exception as exc:  # noqa: BLE001 — never block a real completion on this guard
         logger.error(
@@ -519,6 +540,23 @@ def run_envelope_plan(
             error=_isolation_error,
         )
 
+    # ── OI-1113 pre-measurement: capture remote HEAD of the target branch ──
+    # BEFORE the worker runs, so we can verify after the push that the new HEAD
+    # contains this one.  For a new branch (first dispatch), there is no remote
+    # HEAD — target_remote_head stays None and containment is skipped.  The
+    # capture runs BEFORE the worker so a force-push during the run is detectable.
+    _target_branch = _dispatch_branch_name(plan.dispatch_id)
+    _target_remote_head: Optional[str] = None
+    try:
+        from pr_enforcement import _get_remote_head  # noqa: PLC0415
+        _target_remote_head = _get_remote_head(branch=_target_branch, repo_root=_consumer_project_root)
+    except Exception:  # noqa: BLE001 — best-effort; None → containment skipped
+        _target_remote_head = None
+
+    # ── OI-1115: skip auto-PR when the dispatch works on an existing branch ──
+    _base_ref = plan.base_ref or "origin/main"
+    _skip_pr = _is_dispatch_branch_ref(_base_ref)
+
     _phantom_diff: Optional[str] = None
     try:
         start = datetime.now(timezone.utc)
@@ -535,7 +573,7 @@ def run_envelope_plan(
         try:
             _phantom_diff = _resolve_phantom_diff(
                 plan.dispatch_id,
-                base_ref=plan.base_ref or "origin/main",
+                base_ref=_base_ref,
                 wt_path=wt_path,
                 repo=_consumer_project_root,
             )
@@ -548,19 +586,21 @@ def run_envelope_plan(
         if result.status == "success":
             result = _enforce_push_pr(
                 dispatch_id=plan.dispatch_id,
-                branch=_dispatch_branch_name(plan.dispatch_id),
+                branch=_target_branch,
                 wt_path=wt_path,
                 repo_root=_consumer_project_root,
                 receipts_file=_receipts_file_for(state_dir),
                 result=result,
-                base_ref=plan.base_ref or "origin/main",
+                base_ref=_base_ref,
+                target_remote_head=_target_remote_head,
+                skip_pr=_skip_pr,
             )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root, terminal_id=plan.target_id)
 
     report_path, receipt_path = _govern(
         enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,
-        base_ref=plan.base_ref or "origin/main",
+        base_ref=_base_ref,
     )
 
     return EnvelopeResult(
@@ -712,6 +752,22 @@ def run_envelope_headless_plan(
             error=_isolation_error,
         )
 
+    # ── OI-1113 pre-measurement: capture remote HEAD of the target branch ──
+    # BEFORE the worker runs, so we can verify after the push that the new HEAD
+    # contains this one.  For a new branch (first dispatch), there is no remote
+    # HEAD — target_remote_head stays None and containment is skipped.
+    _target_branch = _dispatch_branch_name(plan.dispatch_id)
+    _target_remote_head: Optional[str] = None
+    try:
+        from pr_enforcement import _get_remote_head  # noqa: PLC0415
+        _target_remote_head = _get_remote_head(branch=_target_branch, repo_root=_consumer_project_root)
+    except Exception:  # noqa: BLE001 — best-effort; None → containment skipped
+        _target_remote_head = None
+
+    # ── OI-1115: skip auto-PR when the dispatch works on an existing branch ──
+    _base_ref = plan.base_ref or "origin/main"
+    _skip_pr = _is_dispatch_branch_ref(_base_ref)
+
     _phantom_diff: Optional[str] = None
     try:
         start = datetime.now(timezone.utc)
@@ -720,7 +776,7 @@ def run_envelope_headless_plan(
         try:
             _phantom_diff = _resolve_phantom_diff(
                 plan.dispatch_id,
-                base_ref=plan.base_ref or "origin/main",
+                base_ref=_base_ref,
                 wt_path=wt_path,
                 repo=_consumer_project_root,
             )
@@ -733,19 +789,21 @@ def run_envelope_headless_plan(
         if result.status == "success":
             result = _enforce_push_pr(
                 dispatch_id=plan.dispatch_id,
-                branch=_dispatch_branch_name(plan.dispatch_id),
+                branch=_target_branch,
                 wt_path=wt_path,
                 repo_root=_consumer_project_root,
                 receipts_file=_receipts_file_for(state_dir),
                 result=result,
-                base_ref=plan.base_ref or "origin/main",
+                base_ref=_base_ref,
+                target_remote_head=_target_remote_head,
+                skip_pr=_skip_pr,
             )
     finally:
         remove_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root, terminal_id=plan.target_id)
 
     report_path, receipt_path = _govern(
         enriched_spec, result, start, end, phantom_diff=_phantom_diff, integrity=integrity,
-        base_ref=plan.base_ref or "origin/main",
+        base_ref=_base_ref,
     )
 
     return EnvelopeResult(

--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -28,6 +28,13 @@ Per-state decision (one binding site, never duplicated across lanes):
   niet-gecommit werk), niet rij-7. Blijft ok=True, applicable=False, met een reden
   die de caller laat zien dat er nog dirty werk is.
 
+Containment (OI-1113): when *target_remote_head* is provided (the remote HEAD of
+the target branch captured BEFORE the worker started), this module verifies after
+the push that the new remote HEAD contains the old one via
+``git merge-base --is-ancestor``.  A non-fast-forward replacement (force-push that
+dropped commits) is refused with a receipt-visible ``containment_failed`` corrective
+receipt — the same loud failure pattern as ``push_failed`` and ``pr_failed``.
+
 Enforcement, not best-effort: when the branch was committed (or pushed) and the
 push or PR creation fails, this is recorded as a receipt-visible failure — a
 corrective 'failed' completion receipt is appended to the ndjson ledger, mirroring
@@ -66,8 +73,9 @@ class PrEnforcementResult:
     applicable=True, ok=True: the branch is on origin AND a PR exists (found or
         just created). When the state was ``committed``, the branch was pushed
         first (pushed=True records that the push step ran).
-    applicable=True, ok=False: the branch was committed (or pushed) but the push
-        or PR creation failed — a corrective receipt has already been appended.
+    applicable=True, ok=False: the branch was committed (or pushed) but the push,
+        PR creation, or containment check failed — a corrective receipt has
+        already been appended.
     """
     applicable: bool
     ok: bool
@@ -75,6 +83,55 @@ class PrEnforcementResult:
     created: bool = False
     pushed: bool = False
     reason: Optional[str] = None
+
+
+def _get_remote_head(*, branch: str, repo_root: Path) -> "Optional[str]":
+    """Return the remote HEAD SHA of *branch* on origin, or None.
+
+    Uses ``git ls-remote origin refs/heads/<branch>``.  Returns None when the
+    branch does not exist on origin or when the lookup fails (network error,
+    timeout).  Never raises: a lookup failure is a degraded skip, not a crash.
+    """
+    remote_ref = branch if branch.startswith("refs/") else f"refs/heads/{branch}"
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "ls-remote", "origin", remote_ref],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, Exception):
+        return None
+    if proc.returncode != 0:
+        return None
+    output = proc.stdout.strip()
+    if not output:
+        return None
+    return output.split()[0]
+
+
+def _check_containment(*, branch: str, old_head: str, repo_root: Path) -> "tuple[bool, Optional[str]]":
+    """Verify *old_head* is an ancestor of the current remote HEAD of *branch*.
+
+    Returns ``(True, None)`` when containment holds (fast-forward or merge).
+    Returns ``(False, reason)`` when the check fails or the new HEAD cannot be
+    resolved.  Never raises.
+    """
+    new_head = _get_remote_head(branch=branch, repo_root=repo_root)
+    if new_head is None:
+        return False, f"cannot resolve remote HEAD of {branch!r} for containment check"
+    try:
+        proc = subprocess.run(
+            ["git", "-C", str(repo_root), "merge-base", "--is-ancestor", old_head, new_head],
+            capture_output=True, text=True, timeout=10,
+        )
+    except (subprocess.TimeoutExpired, Exception) as exc:
+        return False, f"containment check raised for {branch!r}: {exc}"
+    if proc.returncode == 0:
+        return True, None
+    return False, (
+        f"containment violated: remote HEAD of {branch!r} ({new_head[:12]}) "
+        f"does not contain the pre-worker HEAD ({old_head[:12]}) — "
+        f"the branch history was replaced (force-push detected)"
+    )
 
 
 def enforce_pr_exists(
@@ -86,6 +143,8 @@ def enforce_pr_exists(
     receipts_file: "str | Path",
     pr_title: str,
     pr_body: str,
+    target_remote_head: "Optional[str]" = None,
+    skip_pr: bool = False,
 ) -> PrEnforcementResult:
     """Ensure *branch* is pushed to origin AND has an open PR.
 
@@ -98,6 +157,20 @@ def enforce_pr_exists(
     - ``committed`` → pushen, dan PR afdwingen.
     - ``clean``    → niets om te pushen → applicable=False, ok=True.
     - ``dirty``    → niet hier; phantom_guard's domein → applicable=False, ok=True.
+
+    *target_remote_head* (OI-1113): the remote HEAD SHA of *branch* captured
+    BEFORE the worker started.  When set, containment is verified after the
+    push: the new remote HEAD must contain *target_remote_head* (fast-forward or
+    merge).  A non-fast-forward replacement is refused with a receipt-visible
+    ``containment_failed`` corrective receipt.  When ``None`` (new branch, no
+    prior remote HEAD), the containment check is skipped — there is nothing to
+    contain.
+
+    *skip_pr* (OI-1115): when ``True``, the PR creation step is skipped.  The
+    push still runs for the ``committed`` state.  This is used when the dispatch
+    operates on an existing dispatch branch (``base_ref`` starts with
+    ``origin/dispatch/``) — the PR already exists, and creating a second one is
+    a duplicate destination.
 
     Never raises: a push or gh_pr_ensure exception is treated as a failure (still
     enforced — reported via PrEnforcementResult.ok=False + corrective receipt), not
@@ -138,6 +211,40 @@ def enforce_pr_exists(
             )
             return PrEnforcementResult(applicable=True, ok=False, pushed=False, reason=reason)
         pushed = True
+
+    # ── OI-1113: containment check ──────────────────────────────────────────
+    # After the branch is on origin (our push or the worker's own), verify the
+    # new remote HEAD contains the pre-worker HEAD.  A non-fast-forward
+    # replacement means the worker (or something else) force-pushed and dropped
+    # commits — refuse with a receipt-visible failure.
+    if target_remote_head is not None:
+        contained, containment_reason = _check_containment(
+            branch=branch, old_head=target_remote_head, repo_root=repo_root,
+        )
+        if not contained:
+            logger.warning(
+                "pr_enforcement: containment FAILED dispatch=%s branch=%s — %s",
+                dispatch_id, branch, containment_reason,
+            )
+            _record_corrective_receipt(
+                dispatch_id=dispatch_id, branch=branch, reason=containment_reason,
+                receipts_file=receipts_file, kind="containment_failed",
+            )
+            return PrEnforcementResult(
+                applicable=True, ok=False, pushed=pushed, reason=containment_reason,
+            )
+
+    # ── OI-1115: skip auto-PR when the dispatch works on an existing branch ──
+    if skip_pr:
+        logger.info(
+            "pr_enforcement: PR skipped for dispatch=%s branch=%s (skip_pr=True) — "
+            "branch is on origin, no auto-PR created",
+            dispatch_id, branch,
+        )
+        return PrEnforcementResult(
+            applicable=True, ok=True, pushed=pushed, pr_number=None, created=False,
+            reason="skip_pr=True — branch pushed, auto-PR suppressed (existing dispatch branch)",
+        )
 
     try:
         from gh_pr_ensure import ensure_pr  # noqa: PLC0415

--- a/tests/test_pr_enforcement.py
+++ b/tests/test_pr_enforcement.py
@@ -319,3 +319,339 @@ def test_success_path_never_touches_append_receipt(monkeypatch):
 
     assert result.ok is True
     assert calls["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# OI-1113: containment check — verifies new HEAD contains pre-worker HEAD
+# ---------------------------------------------------------------------------
+
+
+def test_containment_is_checked_when_target_remote_head_set(monkeypatch):
+    """When target_remote_head is set, _check_containment MUST be called after push.
+
+    This test proves the containment guard is active: if the condition were
+    reversed (``target_remote_head is None`` instead of ``is not None``), the
+    containment call would be skipped and this assertion would fail — a green
+    test that cannot fail proves nothing (OI-1113 definition of done).
+    """
+    import pr_enforcement as _mod
+    containment_args = []
+
+    def _fake_check_containment(*, branch, old_head, repo_root):
+        containment_args.append({"branch": branch, "old_head": old_head})
+        return True, None
+
+    monkeypatch.setattr(_mod, "_push_branch", lambda **kw: _mod._PushOutcome(ok=True))
+    monkeypatch.setattr(_mod, "_check_containment", _fake_check_containment)
+
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 1, "created": True, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="committed", target_remote_head="abc123def")
+    )
+
+    assert len(containment_args) == 1, (
+        "_check_containment was NOT called — if the condition "
+        "'target_remote_head is not None' were reversed, this assertion would fail"
+    )
+    assert containment_args[0]["old_head"] == "abc123def"
+    assert result.ok is True
+
+
+def test_containment_skipped_when_target_remote_head_none(monkeypatch):
+    """When target_remote_head is None (new branch), containment is NOT checked."""
+    import pr_enforcement as _mod
+    containment_calls = []
+
+    def _fake_check_containment(*, branch, old_head, repo_root):
+        containment_calls.append(1)
+        return True, None
+
+    monkeypatch.setattr(_mod, "_push_branch", lambda **kw: _mod._PushOutcome(ok=True))
+    monkeypatch.setattr(_mod, "_check_containment", _fake_check_containment)
+
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 1, "created": True, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="committed")  # target_remote_head defaults to None
+    )
+
+    assert len(containment_calls) == 0, (
+        "_check_containment WAS called when target_remote_head is None — "
+        "containment should be skipped for new branches"
+    )
+    assert result.ok is True
+
+
+def test_containment_failure_is_loud(monkeypatch, tmp_path):
+    """Containment failure → ok=False + corrective receipt with kind='containment_failed'.
+
+    The failure is receipt-visible, mirroring push_failed and pr_failed.
+    PR creation must NOT be attempted after containment fails.
+    """
+    import pr_enforcement as _mod
+
+    monkeypatch.setattr(_mod, "_push_branch", lambda **kw: _mod._PushOutcome(ok=True))
+    monkeypatch.setattr(
+        _mod, "_check_containment",
+        lambda **kw: (False, "containment violated: HEAD abc was replaced by def"),
+    )
+
+    import gh_pr_ensure
+    gh_calls = {"n": 0}
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: (
+            gh_calls.__setitem__("n", gh_calls["n"] + 1),
+            {"pr_number": None, "created": False, "reason": "x"},
+        )[1],
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            receipts_file=str(tmp_path / "r.ndjson"),
+            worktree_state="committed",
+            target_remote_head="abc123",
+        )
+    )
+
+    assert result.applicable is True
+    assert result.ok is False
+    assert "containment violated" in result.reason
+    # PR creation must NOT be attempted after containment failure.
+    assert gh_calls["n"] == 0
+
+    payload = captured["payload"]
+    assert payload["status"] == "failed"
+    assert payload["autopr_rejected"] is True
+    assert payload["autopr_kind"] == "containment_failed"
+    assert payload["branch"] == "dispatch/d1"
+    assert "containment violated" in payload["autopr_reason"]
+
+
+def test_containment_failure_on_pushed_state(monkeypatch, tmp_path):
+    """Containment is checked even when worktree_state is 'pushed' (worker already pushed).
+
+    A worker that force-pushes before the lane enforcement runs would leave the
+    branch in 'pushed' state — the containment check must still run.
+    """
+    import pr_enforcement as _mod
+
+    monkeypatch.setattr(
+        _mod, "_check_containment",
+        lambda **kw: (False, "containment violated: force-push detected"),
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            receipts_file=str(tmp_path / "r.ndjson"),
+            worktree_state="pushed",
+            target_remote_head="abc123",
+        )
+    )
+
+    assert result.ok is False
+    assert "containment violated" in result.reason
+    assert captured["payload"]["autopr_kind"] == "containment_failed"
+
+
+# ---------------------------------------------------------------------------
+# OI-1115: single destination — skip auto-PR on existing dispatch branches
+# ---------------------------------------------------------------------------
+
+
+def test_skip_pr_pushes_but_creates_no_pr(monkeypatch):
+    """skip_pr=True: pushes the branch (committed state) but skips PR creation."""
+    import pr_enforcement as _mod
+    push_calls = {"n": 0}
+
+    def _fake_push(*, branch, repo_root):
+        push_calls["n"] += 1
+        return _mod._PushOutcome(ok=True)
+
+    monkeypatch.setattr(_mod, "_push_branch", _fake_push)
+
+    import gh_pr_ensure
+    gh_calls = {"n": 0}
+
+    def _boom(*a, **kw):
+        gh_calls["n"] += 1
+        raise AssertionError("ensure_pr must NOT be called when skip_pr=True")
+
+    monkeypatch.setattr(gh_pr_ensure, "ensure_pr", _boom)
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="committed", skip_pr=True)
+    )
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pushed is True
+    assert result.pr_number is None
+    assert result.created is False
+    assert "skip_pr=True" in result.reason
+    assert push_calls["n"] == 1
+    assert gh_calls["n"] == 0
+
+
+def test_skip_pr_pushed_state_noop(monkeypatch):
+    """skip_pr=True + pushed state: no push needed, no PR created — just reports ok."""
+    import gh_pr_ensure
+    gh_calls = {"n": 0}
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: (
+            gh_calls.__setitem__("n", gh_calls["n"] + 1),
+            {"pr_number": None, "created": False, "reason": "x"},
+        )[1],
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(worktree_state="pushed", skip_pr=True)
+    )
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pushed is True
+    assert result.pr_number is None
+    assert "skip_pr=True" in result.reason
+    assert gh_calls["n"] == 0
+
+
+def test_pr_still_created_when_skip_pr_false(monkeypatch):
+    """skip_pr=False (default): PR is created normally — existing behavior unchanged."""
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": 42, "created": True, "reason": None},
+    )
+
+    result = pe.enforce_pr_exists(**_kwargs(worktree_state="pushed", skip_pr=False))
+
+    assert result.applicable is True
+    assert result.ok is True
+    assert result.pr_number == 42
+    assert result.created is True
+
+
+# ---------------------------------------------------------------------------
+# OI-1113/OI-1115 combined: containment + skip_pr together
+# ---------------------------------------------------------------------------
+
+
+def test_containment_checked_before_skip_pr(monkeypatch):
+    """Containment runs before the skip_pr short-circuit.
+
+    When both target_remote_head is set AND skip_pr is True, containment must
+    still be checked — a force-push on an existing dispatch branch is just as
+    bad as on a new one.
+    """
+    import pr_enforcement as _mod
+    containment_calls = []
+
+    monkeypatch.setattr(_mod, "_push_branch", lambda **kw: _mod._PushOutcome(ok=True))
+    monkeypatch.setattr(
+        _mod, "_check_containment",
+        lambda **kw: containment_calls.append(1) or (True, None),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            worktree_state="committed",
+            target_remote_head="abc123",
+            skip_pr=True,
+        )
+    )
+
+    assert len(containment_calls) == 1, (
+        "containment must be checked BEFORE skip_pr — "
+        "skipping PR does not mean skipping containment"
+    )
+    assert result.ok is True
+    assert result.pushed is True
+    assert result.pr_number is None  # PR skipped
+
+
+# ---------------------------------------------------------------------------
+# Existing behaviors: push_failed and pr_failed still work with new params
+# ---------------------------------------------------------------------------
+
+
+def test_push_failed_still_works_with_new_params(monkeypatch, tmp_path):
+    """push_failed is still recorded when push fails, new params passed but ignored."""
+    import pr_enforcement as _mod
+    monkeypatch.setattr(
+        _mod.subprocess, "run",
+        lambda *a, **kw: _CompletedRC(128, err="fatal: remote rejected"),
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            receipts_file=str(tmp_path / "r.ndjson"),
+            worktree_state="committed",
+            target_remote_head="abc123",
+            skip_pr=False,
+        )
+    )
+
+    assert result.ok is False
+    assert "remote rejected" in result.reason
+    assert captured["payload"]["autopr_kind"] == "push_failed"
+
+
+def test_pr_failed_still_works_with_new_params(monkeypatch, tmp_path):
+    """pr_failed is still recorded when ensure_pr fails, new params passed."""
+    import gh_pr_ensure
+    monkeypatch.setattr(
+        gh_pr_ensure, "ensure_pr",
+        lambda *a, **kw: {"pr_number": None, "created": False, "reason": "gh rate limited"},
+    )
+
+    import append_receipt
+    captured = {}
+    monkeypatch.setattr(
+        append_receipt, "append_receipt_payload",
+        lambda payload, **kw: captured.update(payload=payload),
+    )
+
+    result = pe.enforce_pr_exists(
+        **_kwargs(
+            receipts_file=str(tmp_path / "r.ndjson"),
+            worktree_state="pushed",
+            target_remote_head=None,
+            skip_pr=False,
+        )
+    )
+
+    assert result.ok is False
+    assert "gh rate limited" in result.reason
+    assert captured["payload"]["autopr_kind"] == "pr_failed"


### PR DESCRIPTION
## What

Two defects from the same event on 9 August, repaired.

### OI-1113 — Containment control

The lane now captures the remote HEAD of the target branch BEFORE the worker starts. After the push, it verifies via `git merge-base --is-ancestor` that the new HEAD contains the old one. A non-fast-forward replacement (force-push that dropped commits) is refused with a receipt-visible `containment_failed` corrective receipt.

**When containment is NOT applicable:**
- New branch (no prior remote HEAD) — nothing to contain, check skipped
- `origin/main` or `origin/master` as base_ref — constantly moving, check skipped (the capture runs on the target `dispatch/<id>` branch, not on main)

### OI-1115 — Single destination

When `base_ref` names a dispatch branch (`origin/dispatch/*`), the lane skips auto-PR creation. The PR already exists for that branch. The push still runs for the committed state (so work is not stranded).

Detected via `_is_dispatch_branch_ref()` helper. A normal dispatch from `origin/main` still gets its auto-PR — the vangnet-functie is preserved.

## Changes

| File | Change |
|---|---|
| `scripts/lib/pr_enforcement.py` | `_get_remote_head`, `_check_containment` helpers; `enforce_pr_exists` gains `target_remote_head` and `skip_pr` params; containment check runs after push, before PR |
| `scripts/lib/dispatch_envelope.py` | `_is_dispatch_branch_ref` guard; `_enforce_push_pr` passes new params through; `run_envelope_plan` and `run_envelope_headless_plan` capture remote HEAD before worker, detect dispatch-branch base_ref |
| `tests/test_pr_enforcement.py` | 10 new tests: containment pass/fail/skip, skip_pr push/PR behavior, combined containment+skip_pr, existing push_failed/pr_failed with new params |

## Verification

- 21/21 pr_enforcement tests pass
- 16/16 lane matrix tests pass (envelope lane integration)
- 10/10 phantom guard + branch resolution tests pass
- Reverse-check: confirmed that flipping the containment condition makes the test fail (proves the guard is active)
- `_is_dispatch_branch_ref` manually verified for dispatch/non-dispatch branch patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>