### PR TITLE
fix(config): four stale-truth corrections (OI-1112, OI-1081, OI-1083)

### DIFF
--- a/configs/producer_freshness.yaml
+++ b/configs/producer_freshness.yaml
@@ -79,6 +79,11 @@ producers:
     key_transform: prefix
     timestamp_column: created_at
     cadence_seconds: 604800
+    kind: one_shot  # OI-1112: keys are date prefixes (key_transform: prefix), each
+    # date is a one-shot family — once a day passes no new dispatch carries that
+    # prefix, so cadence-based staleness flags every past date forever. Same defect
+    # class as OI-1041 (per-PR artefacts), growing one key per day instead of two
+    # per PR. Only expected_keys (dlv, DISP) that never wrote are reported.
     expected_keys:
       - dlv
       - DISP

--- a/docs/core/10_JSON_DISPATCH_FORMAT.md
+++ b/docs/core/10_JSON_DISPATCH_FORMAT.md
@@ -246,7 +246,7 @@ echo '{
   },
   "content": {
     "title": "Run E2E Tests",
-    "instructions": "Execute full test suite and validate results"
+    "instructions": "Run the touched test files plus their direct neighbours, validate results"
   }
 }'
 ```

--- a/docs/operations/PROVIDER_API_KEYS.md
+++ b/docs/operations/PROVIDER_API_KEYS.md
@@ -9,7 +9,7 @@ Each provider requires an API key set as an env var before dispatch.
 | DeepSeek | DEEPSEEK_API_KEY | platform.deepseek.com | V4-Pro $0.435/$0.87, V4-Flash $0.14/$0.28 | Wave 7 PR-7.1 |
 | Kimi CLI | *(OAuth via `kimi login`)* | — | K2.6 / K2-0905 (free tier via CLI) | Wave 7 PR-7.7 |
 | Moonshot (Kimi) via LiteLLM | MOONSHOT_API_KEY | platform.moonshot.cn | K2-0905 $0.60/$2.50 | Wave 7 PR-7.2 |
-| Z.AI (GLM) via OpenRouter | OPENROUTER_API_KEY | openrouter.ai | GLM-5.2 $0.60/$1.92 (pass-through) | Wave 7 PR-7.3 |
+| Z.AI (GLM) via OpenRouter | OPENROUTER_API_KEY | openrouter.ai | GLM-5.2 $0.76/$2.42 (pass-through) | Wave 7 PR-7.3 |
 
 **Note on GLM legacy versions:** GLM-4.5, GLM-4.6, GLM-5 (base), and GLM-5.1 are
 deprecated. Only GLM-5.2 is accepted by the `litellm:zai` route (`deprecated-glm-models`
@@ -93,7 +93,7 @@ GLM-5.2 routes through OpenRouter as `openrouter/z-ai/glm-5.2`:
 
 | Alias | LiteLLM name | Input/MTok | Output/MTok | Task classes |
 |---|---|---|---|---|
-| glm-5.2 | openrouter/z-ai/glm-5.2 | $0.60 | $1.92 | coding, review |
+| glm-5.2 | openrouter/z-ai/glm-5.2 | $0.76 | $2.42 | coding, review |
 
 - Dispatch: `--provider litellm:zai` (defaults to glm-5.2) or `--provider glm-harness` (claude-CLI harness via local litellm proxy)
 - Missing `OPENROUTER_API_KEY` → immediate exit(64) before subprocess spawn

--- a/scripts/benchmark/models.yaml
+++ b/scripts/benchmark/models.yaml
@@ -73,8 +73,8 @@ models:
   - id: glm-5-2
     provider: litellm:zai:glm-5.2   # GLM-5.2 (2026-06-16) → openrouter/z-ai/glm-5.2; satisfies zai-via-openrouter-only
     model_arg: glm-5.2
-    cost_input_mtok: 0.60
-    cost_output_mtok: 1.92
+    cost_input_mtok: 0.76   # OI-1083: re-measured 2026-08-10 against live OpenRouter /api/v1/models
+    cost_output_mtok: 2.42
 
   # GLM-harness lane: GLM-5.2 driven by the FULL claude-CLI harness (tools/agentic loop) via
   # a local litellm proxy → OpenRouter. glm-5 and glm-5.1 harness entries removed 2026-08-03
@@ -83,8 +83,8 @@ models:
   - id: glm-5-2-harness
     provider: glm-harness
     model_arg: glm-5.2
-    cost_input_mtok: 0.60
-    cost_output_mtok: 1.92
+    cost_input_mtok: 0.76   # OI-1083: re-measured 2026-08-10 against live OpenRouter /api/v1/models
+    cost_output_mtok: 2.42
     notes: "GLM-5.2 via full claude-CLI harness. Compare vs glm-5-2 (litellm tool-loop)."
 
   - id: codex-gpt-5-4

--- a/scripts/lib/provider_costs.py
+++ b/scripts/lib/provider_costs.py
@@ -62,7 +62,7 @@ _PROVIDER_RATES: dict[tuple[str, str], tuple[float, float, bool]] = {
     ("litellm:deepseek", "deepseek-v4-pro"):   (0.14,  0.28,  False),
     ("litellm:moonshot", "kimi-k2-0905-default"): (0.0, 0.0,  True),
     ("litellm:moonshot", "kimi-k2-0905-preview"):  (0.0, 0.0,  True),
-    ("litellm:zai", "glm-5.2"):        (0.60,  1.92,  False),
+    ("litellm:zai", "glm-5.2"):        (0.76,  2.42,  False),  # re-measured 2026-08-10 against live OpenRouter /api/v1/models
     ("litellm:ollama", "llama3"):              (0.0,   0.0,   True),
     # openrouter-arbitrary lane (PR-1 skeleton) — the one proven model
     # (openrouter/openai/gpt-4o-mini); OpenRouter pass-through pricing.

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -112,10 +112,11 @@ constraints:
       provider: zai
       via: direct
     reason: >-
-      Native Zhipu integration is deferred. Wave 7 PR-7.3 routes GLM (GLM-5.2
-      current, GLM-5.1 available) through OpenRouter; direct Zhipu API calls
-      bypass the cost-tracking pipeline and the fallback chain configured in
-      routing_policy.yaml.
+      Native Zhipu integration is deferred. Wave 7 PR-7.3 routes GLM through
+      OpenRouter; direct Zhipu API calls bypass the cost-tracking pipeline and
+      the fallback chain configured in routing_policy.yaml. Only GLM-5.2 is an
+      allowed version (deprecated-glm-models, operator directive 2026-08-03:
+      GLM-4.5/4.6/5/5.1 blocked).
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -222,8 +222,8 @@ providers:
     models:
       glm-5.2:
         litellm_name: "openrouter/z-ai/glm-5.2"  # GLM-5.2 (released 2026-06-16)
-        cost_input_per_mtok: 0.60
-        cost_output_per_mtok: 1.92
+        cost_input_per_mtok: 0.76   # re-measured 2026-08-10 against live OpenRouter /api/v1/models
+        cost_output_per_mtok: 2.42
         max_tokens: 8192
         supports_streaming: true
         supports_tool_calls: true

--- a/tests/test_cost_loader.py
+++ b/tests/test_cost_loader.py
@@ -148,8 +148,8 @@ class TestGlmConsistency:
             costs.append(cost)
 
         # All variants must return the same glm-5.2 cost
-        # input: 5000 * 0.60/1M + output: 2000 * 1.92/1M = 0.003 + 0.00384 = 0.00684
-        expected = 0.00684
+        # OI-1083: re-measured 2026-08-10 — input: 5000 * 0.76/1M + output: 2000 * 2.42/1M = 0.0038 + 0.00484 = 0.00864
+        expected = 0.00864
         for name, cost in zip(variants, costs):
             assert abs(cost - expected) < 1e-9, (
                 f"Variant {name!r}: expected {expected}, got {cost}"

--- a/tests/test_wave7_glm_smoke.py
+++ b/tests/test_wave7_glm_smoke.py
@@ -207,8 +207,8 @@ class TestGlmModelAliasResolution:
         assert model.litellm_name == "openrouter/z-ai/glm-5.2", (
             f"unexpected litellm_name: {model.litellm_name!r}"
         )
-        assert model.cost_input_per_mtok == pytest.approx(0.60)
-        assert model.cost_output_per_mtok == pytest.approx(1.92)
+        assert model.cost_input_per_mtok == pytest.approx(0.76)  # OI-1083: re-measured 2026-08-10
+        assert model.cost_output_per_mtok == pytest.approx(2.42)
         assert model.max_tokens == 8192
         assert model.supports_streaming is True
         assert model.supports_tool_calls is True


### PR DESCRIPTION
## Summary

Four independent stale-value corrections. None needs new design; each is a stored value that drifted behind reality.

### 1. dispatches_table one_shot kind (OI-1112)
PR #1429 gave the two per-PR gate producers `kind: one_shot`, but `dispatches_table` was left on cadence-based staleness. Its keys are date prefixes (`key_transform: prefix`), so each past date goes stale 7 days after its date and stays that forever — one new finding per day. Same defect class as OI-1041, growing one key/day instead of two per PR.

Fix: added `kind: one_shot` to `dispatches_table`, same form as the two existing one_shot producers. Only `expected_keys` that never wrote are reported.

Freshness findings measured before/after (read-only sweep, `--no-write`):
- before: **12 findings** total; `dispatches_table` had 4 (three date-prefix STALE + DISP MISSING)
- after: **9 findings** total; `dispatches_table` has 1 (DISP MISSING only)

`expected_keys` behaviour holds: `dlv` writes so it is silent; `DISP` never wrote so it stays MISSING — correct for a one_shot producer.

### 2. zai-via-openrouter-only reason-string (OI-1081 part 1)
`provider_constraints.yaml` said "GLM-5.2 current, GLM-5.1 available" while `deprecated-glm-models` (same file, operator directive 2026-08-03) blocks GLM-5.1. No runtime effect (behaviour sits in `forbidden_route`), but the same self-contradiction PR #1396 fixed in `PROVIDER_API_KEYS.md`. Corrected the reason-string: only GLM-5.2 is allowed.

### 3. Doc example violating worker convention (OI-1081 part 2)
`docs/core/10_JSON_DISPATCH_FORMAT.md` example instruction was "Execute full test suite and validate results", which violates the worker convention codified in #1398 (workers must NOT run the full suite). Replaced with a targeted-tests instruction so a T0 copying the template produces a conforming dispatch.

### 4. GLM-5.2 price (OI-1083)
T0 re-measured the live OpenRouter `/api/v1/models` endpoint on 2026-08-10: GLM-5.2 is $0.76 input / $2.42 output per MTok (was $0.60 / $1.92). Independent re-measurement of the number OI-1083 named; it matches exactly.

Updated all sites where the old price lived:
- `scripts/lib/providers/wave7_models.yaml` (registry SSOT)
- `scripts/lib/provider_costs.py` (rate table — a third site the dispatch asked me to find)
- `docs/operations/PROVIDER_API_KEYS.md` (two places: summary table + GLM section table)
- `scripts/benchmark/models.yaml` (two entries: glm-5-2, glm-5-2-harness)

Grep confirming the old price is gone:
```
$ grep -rn "glm-5" --include=*.yaml --include=*.md --include=*.py . | grep -E "0\.60|1\.92"
(no output)
$ grep -rn "1\.92" --include=*.yaml --include=*.md --include=*.py . | grep -iv kimi/moonshot/gpt/claude/opus/sonnet/deepseek/gemini/haiku/fable
(no output)
```

Tests asserting the old price updated:
- `tests/test_wave7_glm_smoke.py` — price assertions → 0.76 / 2.42
- `tests/test_cost_loader.py` — expected GLM cost 0.00684 → 0.00864 (5000 in + 2000 out tokens)

## Changes

| File | Change |
|---|---|
| `configs/producer_freshness.yaml` | `dispatches_table` + `kind: one_shot` (OI-1112) |
| `scripts/lib/providers/provider_constraints.yaml` | zai reason-string corrected (OI-1081 p1) |
| `docs/core/10_JSON_DISPATCH_FORMAT.md` | example instruction no longer says "full test suite" (OI-1081 p2) |
| `scripts/lib/providers/wave7_models.yaml` | GLM-5.2 price 0.60/1.92 → 0.76/2.42 (OI-1083) |
| `scripts/lib/provider_costs.py` | GLM-5.2 rate table 0.60/1.92 → 0.76/2.42 (OI-1083, third site) |
| `docs/operations/PROVIDER_API_KEYS.md` | GLM-5.2 price in 2 tables → 0.76/2.42 (OI-1083) |
| `scripts/benchmark/models.yaml` | GLM-5.2 price 2 entries → 0.76/2.42 (OI-1083) |
| `tests/test_wave7_glm_smoke.py` | price assertions updated |
| `tests/test_cost_loader.py` | expected GLM cost updated |

## Verification

Targeted tests (touched files + direct neighbours), not the full suite (CI Profile A owns that):
```
pytest tests/test_producer_freshness.py tests/test_wave7_glm_smoke.py \
  tests/test_cost_loader.py tests/test_provider_aware_intelligence.py \
  tests/test_provider_costs.py tests/test_benchmark_suite.py -q
=> 116 passed
```

YAML parse validation: all four edited YAML files load and show the new values.

Freshness sweep measured before/after via `python3 scripts/producer_freshness_monitor.py --no-write --skip-job-exits`:
- before: findings_count=12, dispatches_table findings=4
- after: findings_count=9, dispatches_table findings=1 (DISP MISSING only)

Pre-existing failure on main (NOT introduced here, verified via `git stash`): `tests/test_constraint_enforcer.py::TestT0OpusOnly::test_t0_with_opus_allowed`. Unrelated to the zai reason-string change (no test asserts the old reason text).

## Open Items

- **Registry drift mechanism (OI-1083 class):** the GLM-5.2 price will drift again whenever OpenRouter changes it. The dispatch asked me not to build a registry-vs-live-API tocting mechanism now, but to name it here. A scheduled job that diffs `wave7_models.yaml` / `provider_costs.py` against the live OpenRouter `/api/v1/models` endpoint and reports mismatches would catch this class automatically. Same shape as the producer-freshness monitor, applied to pricing. Not built in this dispatch.
- The pre-existing `test_t0_with_opus_allowed` failure on main is outside this dispatch's scope (it predates these changes on `c5fd62bc`).

Dispatch-ID: 20260810a-w5-configwaarheid
Model: glm-5.2
Provider: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)