### PR TITLE
fix(init): resolve state root to canonical central dir, not XDG (OI-1055)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -43,7 +43,7 @@ def _resolve_data_root(data_root: "Path | None") -> Path:
     """Return canonical VNX data root.
 
     Uses vnx_paths so central installs resolve to ~/.vnx-data/<project_id> (or
-    VNX_DATA_HOME / XDG) rather than resolve_project_root(__file__)/.vnx-data.
+    VNX_DATA_HOME / default) rather than resolve_project_root(__file__)/.vnx-data.
     ADR-007: project_id-scoped canonical paths.
     """
     if data_root is not None:

--- a/scripts/lib/context_rotation.py
+++ b/scripts/lib/context_rotation.py
@@ -105,7 +105,7 @@ def _validate_terminal(terminal: str) -> str:
 # anchored on `project_root`. This deliberately does NOT hardcode
 # ~/.vnx-data/<project_id>: that central path is only used when this project
 # ALREADY resolves there (existing central install). For a project that
-# currently lives in project-local or XDG state, forcing the central path
+# currently lives in project-local state, forcing the central path
 # would create ~/.vnx-data/<project_id> as a side effect of the FIRST
 # rotation call — after which vnx_paths' existence-gated central branch
 # would prefer that now-existing (but empty) dir over the project's real
@@ -118,7 +118,7 @@ def _validate_terminal(terminal: str) -> str:
 
 def _project_data_root(project_id: str, project_root: Optional[Path] = None) -> Path:
     """Resolve the data root THIS project already uses (central, project-local,
-    or XDG) — never forces ~/.vnx-data/<project_id> into existence when the
+    or project-local) — never forces ~/.vnx-data/<project_id> into existence when the
     project doesn't already resolve there. `project_root` defaults to the
     current working directory (matching checkpoint()'s own default) when not
     supplied.

--- a/scripts/lib/vnx_mode.py
+++ b/scripts/lib/vnx_mode.py
@@ -208,7 +208,7 @@ def _guard_mode_write_target(target_dir: Path) -> None:
     try:
         rel = target.relative_to(home_vnx)
     except ValueError:
-        return  # repo-local / scratch / XDG — not a central-store path
+        return  # repo-local / scratch — not a central-store path
 
     from project_root import resolve_project_id
     from vnx_paths import refuse_real_central_store_write_under_pytest

--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -358,7 +358,7 @@ def refuse_real_central_store_write_under_pytest(resolved: Path) -> None:
     ``build_t0_state._pytest_db_isolation_guard`` /
     ``migrate_future_system._pytest_db_isolation_guard``): callers of this
     function have their own legitimate no-explicit-flag paths (fresh-install
-    / XDG / project-local fallbacks all resolve safely without it), so the
+    / project-local fallbacks all resolve safely without it), so the
     flag itself is not the invariant. Landing a WRITE in the real
     ``~/.vnx-data`` is.
 
@@ -394,14 +394,17 @@ def _resolve_state_root(project_id: Optional[str], project_root: Path) -> Path:
          existing central installs to their current location.
       4. ``<project_root>/.vnx-data`` *if it already exists*  — keep resolving
          existing dev checkouts / pre-migration installs in place.
-      5. XDG default  — ``${XDG_DATA_HOME:-~/.local/share}/vnx/<project_id>``
-         for a fresh, clean-footprint install.
+      5. Fresh install — ``~/.vnx-data/<project_id>``, the single canonical
+         central data directory for all installs (parity with
+         ``resolve_central_data_dir``).
 
-    The existence-gated legacy branches (3, 4) are checked *before* the XDG
+    The existence-gated legacy branches (3, 4) are checked *before* the fresh
     default so that the existing dev checkouts and central installs keep
     resolving to where their state already lives (per PR-PIP-2: "breek de
     bestaande dev-checkout/central resolutie NIET"). A fresh install has
-    neither legacy dir and lands on the XDG user-data-dir.
+    neither legacy dir and lands on the canonical central dir — same path
+    as ``resolve_central_data_dir``, so the data-dir guard never warns on a
+    freshly-initialised project (OI-1055).
 
     Collision-safety: a per-project directory is only ever formed from a
     *resolved* project_id. When project_id is None we never substitute a shared
@@ -432,10 +435,9 @@ def _resolve_state_root(project_id: Optional[str], project_root: Path) -> Path:
     if local.is_dir():
         return local.resolve()
 
-    # 5. Fresh install (clean footprint): XDG user-data-dir.
+    # 5. Fresh install: central per-project data directory.
     if pid:
-        xdg_base = os.environ.get("XDG_DATA_HOME") or str(Path.home() / ".local" / "share")
-        return (Path(xdg_base).expanduser() / "vnx" / pid).resolve()
+        return (Path.home() / ".vnx-data" / pid).resolve()
 
     # Collision-safety: no resolvable project_id and no existing layout — never
     # guess a shared id. Stay project-local rather than collide projects.
@@ -447,7 +449,7 @@ def resolve_data_root(project_root) -> Path:
 
     Honors the same ordered resolution as :func:`resolve_paths` (explicit
     override > ``VNX_DATA_HOME`` > existing ``~/.vnx-data/<id>`` > existing
-    project-local ``.vnx-data`` > XDG default), but anchored on the *given*
+    project-local ``.vnx-data`` > fresh default), but anchored on the *given*
     project_root rather than the env/VNX_HOME-resolved one. The project_id is
     resolved leniently from that root (env, ``.vnx-project-id`` marker, or
     identity chain). Used by the pip console-script commands (``vnx_cli``)

--- a/scripts/lib/vnx_paths.sh
+++ b/scripts/lib/vnx_paths.sh
@@ -78,7 +78,7 @@ _vnx_state_project_id() {
 # Step 1 (explicit VNX_DATA_DIR_EXPLICIT) is handled by the caller before this
 # runs. Prints the resolved data root. Always returns 0.
 _vnx_resolve_state_root() {
-  local pid="$1" proot="$2" xdg
+  local pid="$1" proot="$2"
   # 2. VNX_DATA_HOME — operator-chosen data home, per-project subdir.
   if [ -n "${VNX_DATA_HOME:-}" ] && [ -n "$pid" ]; then
     printf '%s/%s' "${VNX_DATA_HOME%/}" "$pid"
@@ -94,10 +94,9 @@ _vnx_resolve_state_root() {
     printf '%s/.vnx-data' "$proot"
     return 0
   fi
-  # 5. Fresh install (clean footprint): XDG user-data-dir.
+  # 5. Fresh install: central per-project data directory.
   if [ -n "$pid" ]; then
-    xdg="${XDG_DATA_HOME:-$HOME/.local/share}"
-    printf '%s/vnx/%s' "${xdg%/}" "$pid"
+    printf '%s/.vnx-data/%s' "$HOME" "$pid"
     return 0
   fi
   # Collision-safety: no resolvable project_id → stay project-local, never guess.
@@ -253,7 +252,7 @@ export VNX_CANONICAL_ROOT="${VNX_CANONICAL_ROOT:-$VNX_CANONICAL_ROOT_DEFAULT}"
 
 # Data directory (runtime root). PR-PIP-2: when not explicitly set, resolve via
 # the ordered state-root resolver (explicit > VNX_DATA_HOME > ~/.vnx-data/<id>
-# if exists > project-local if exists > XDG default). Lockstep with vnx_paths.py.
+# if exists > project-local if exists > fresh default). Lockstep with vnx_paths.py.
 if [ -z "${VNX_DATA_DIR:-}" ]; then
   _vnx_state_pid="$(_vnx_state_project_id "$PROJECT_ROOT")"
   VNX_DATA_DIR="$(_vnx_resolve_state_root "$_vnx_state_pid" "$PROJECT_ROOT")"

--- a/scripts/test_wheel_install.sh
+++ b/scripts/test_wheel_install.sh
@@ -13,7 +13,7 @@
 # Then, in a PRISTINE HOME (no ~/.vnx-system, no ~/.vnx-data), proves the
 # pip-native state layout (PR-PIP-2):
 #   4. `vnx init` creates NO project-local .vnx-data/ (in-project footprint < 10 KB)
-#   5. runtime state lands in the XDG user-data-dir (~/.local/share/vnx/<id>)
+#   5. runtime state lands in the central data dir (~/.vnx-data/<id>)
 #   6. `vnx doctor` reports a RECOGNIZED packaged install (not "no install
 #      detected"), with state resolved OUTSIDE the package, and exits 0
 #
@@ -233,7 +233,7 @@ mkdir -p "$CLEAN_HOME" "$CLEAN_PROJECT"
 
 # Pristine env: like clean_env, but also pins HOME to an empty scratch dir and
 # strips the user-data-dir + project-id inputs so resolution is driven only by
-# the clean HOME (→ XDG default ~/.local/share/vnx/<id>).
+# the clean HOME (→ central default ~/.vnx-data/<id>).
 pip2_env() {
     env -u PYTHONPATH -u VNX_HOME -u VNX_BIN -u VNX_EXECUTABLE \
         -u VNX_DATA_DIR -u VNX_STATE_DIR -u VNX_DATA_DIR_EXPLICIT \
@@ -266,15 +266,15 @@ PYEOF
     || fail "in-project footprint ${FOOT_BYTES} bytes >= 10 KB (expected clean footprint)"
 ok "in-project footprint ${FOOT_BYTES} bytes (< 10 KB)"
 
-# Resolve the project_id init wrote, derive the expected XDG state root.
+# Resolve the project_id init wrote, derive the expected central state root.
 PID2="$(head -1 "$CLEAN_PROJECT/.vnx-project-id" 2>/dev/null | tr -d '[:space:]')"
 [ -n "$PID2" ] || fail "vnx init did not write a .vnx-project-id marker"
-EXPECT_STATE="$CLEAN_HOME/.local/share/vnx/$PID2"
+EXPECT_STATE="$CLEAN_HOME/.vnx-data/$PID2"
 
-# Assertion 3: state landed in the XDG user-data-dir, populated with the tree.
+# Assertion 3: state landed in the central data dir, populated with the tree.
 [ -d "$EXPECT_STATE/dispatches/pending" ] \
-    || fail "runtime state not at XDG dir $EXPECT_STATE (dispatches/pending missing)"
-ok "runtime state at XDG user-data-dir: $EXPECT_STATE"
+    || fail "runtime state not at central dir $EXPECT_STATE (dispatches/pending missing)"
+ok "runtime state at central data dir: $EXPECT_STATE"
 
 # Assertion 4: doctor reports a RECOGNIZED (packaged) install + state outside
 # the package, and exits 0. Parse the structured --json output.
@@ -326,10 +326,10 @@ if data_root_chk is None:
     die("doctor emitted no dir:data-root check")
 if data_root_chk["status"] != "PASS":
     die(f"dir:data-root not PASS: {data_root_chk['detail']}")
-# The reported data root must be the XDG dir, never inside the project map.
+# The reported data root must be the central dir, never inside the project map.
 resolved = data_root_chk["detail"]
 if Path(resolved).resolve() != Path(expect_state).resolve():
-    die(f"data root {resolved!r} != expected XDG dir {expect_state!r}")
+    die(f"data root {resolved!r} != expected central dir {expect_state!r}")
 if Path(resolved).resolve().is_relative_to(Path(project_dir).resolve()):
     die(f"data root {resolved!r} resolved INSIDE the project map {project_dir!r}")
 

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -709,7 +709,7 @@ def check_state_root_location(paths: Dict[str, str]) -> List[CheckResult]:
 
     PR-PIP-2 parity with the vnx_cli doctor: a pip-installed engine must not
     write runtime state under site-packages or VNX_HOME. If VNX_DATA_DIR lands
-    there, point the operator at VNX_DATA_HOME / the XDG default. Always WARN,
+    there, point the operator at VNX_DATA_HOME / the central default. Always WARN,
     never FAIL — an operator may deliberately override paths.
     """
     data_dir = Path(paths["VNX_DATA_DIR"]).resolve()
@@ -729,8 +729,8 @@ def check_state_root_location(paths: Dict[str, str]) -> List[CheckResult]:
         return [CheckResult(
             "state", WARN,
             f"Runtime data root inside package/VNX_HOME: {data_dir}",
-            remediation="Set VNX_DATA_HOME or rely on the XDG default "
-                        "(~/.local/share/vnx/<project_id>) to keep state out of the wheel",
+            remediation="Set VNX_DATA_HOME or the default "
+                        "(~/.vnx-data/<project_id>) to keep state out of the wheel",
         )]
     return [CheckResult("state", PASS, f"Runtime data root outside package: {data_dir}")]
 

--- a/scripts/vnx_init.py
+++ b/scripts/vnx_init.py
@@ -85,8 +85,9 @@ def ensure_runtime_layout(paths: Dict[str, str]) -> StepResult:
 
     PR-PIP-2: VNX_DATA_DIR is resolved by vnx_paths (explicit override >
     VNX_DATA_HOME > existing ~/.vnx-data/<id> > existing project-local
-    .vnx-data > XDG user-data-dir), so a fresh install lands outside the
-    project map while existing dev checkouts keep their project-local tree.
+    .vnx-data > central default ~/.vnx-data/<id>), so a fresh install lands
+    outside the project map while existing dev checkouts keep their
+    project-local tree.
     """
     data_dir = Path(paths["VNX_DATA_DIR"])
     dispatch_dir = Path(paths["VNX_DISPATCH_DIR"])

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -170,7 +170,7 @@ def _vnx_data_dir_isolation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> 
     This is the "point the store at tmp_path" half of the class-wide guard
     (w19c/OI-934). It is NOT itself the backstop: a test that opts out of the
     explicit flag (or a subprocess that loses it) still has a legitimate
-    no-flag resolution path (fresh-install / XDG / project-local fallbacks),
+    no-flag resolution path (fresh-install / project-local fallbacks),
     so this fixture cannot unconditionally refuse — and neither can the
     resolver itself (``vnx_paths.resolve_paths()`` / ``_resolve_state_root()``
     are pure computations with plenty of legitimate read-only callers that

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -58,7 +58,7 @@ class TestVnxInitCli:
         assert (local_data / "events").is_dir()
         assert (local_data / "unified_reports").is_dir()
 
-    def test_init_no_local_vnx_data_when_xdg(self, tmp_path, tmp_path_factory, monkeypatch):
+    def test_init_no_local_vnx_data_when_external_root(self, tmp_path, tmp_path_factory, monkeypatch):
         # When data_root is outside the project dir, vnx init must NOT create
         # a local .vnx-data/ — that would cause the resolver to prefer the
         # local dir on the next call, contradicting the config (PR-PIP-2).
@@ -74,7 +74,7 @@ class TestVnxInitCli:
 
     def test_init_reported_path_matches_resolver(self, tmp_path, tmp_path_factory, monkeypatch):
         # Core consistency invariant: what init writes into config.yml must
-        # equal what resolve_data_root returns post-init (no XDG-vs-local drift).
+        # equal what resolve_data_root returns post-init (no drift).
         external_data = tmp_path_factory.mktemp("external_data")
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
         monkeypatch.setenv("VNX_DATA_DIR", str(external_data))
@@ -720,3 +720,75 @@ class TestGateObligationRunnerInstall:
         out = capsys.readouterr().out
         assert "warning" in out.lower()
         assert "gate-obligation-runner" in out
+
+
+# ---------------------------------------------------------------------------
+# OI-1055: init→doctor no-divergence invariant
+# ---------------------------------------------------------------------------
+
+class TestInitDoctorDataDirConsistency:
+    """vnx init and vnx doctor must agree on the data-dir resolution.
+
+    OI-1055: init wrote state to ~/.local/share/vnx/<id> (the old XDG
+    default) while resolve_central_data_dir and the data-dir guard expect
+    ~/.vnx-data/<id>. After the fix, both resolve to the single canonical
+    central dir, so a fresh init→doctor round-trip must emit zero
+    VNXDataDirMismatchWarning warnings.
+    """
+
+    def test_init_then_doctor_no_mismatch_warning(
+        self, tmp_path, tmp_path_factory, monkeypatch
+    ):
+        """vnx init followed by vnx doctor must not warn about data-dir mismatch."""
+        import warnings
+        from vnx_cli.commands.doctor import vnx_doctor
+        from data_dir_guard import VNXDataDirMismatchWarning
+
+        # Isolate HOME so the test never touches the real ~/.vnx-data/.
+        fake_home = tmp_path_factory.mktemp("home")
+        monkeypatch.setattr(Path, "home", classmethod(lambda cls: fake_home))
+
+        # Clean env: let the resolver's default branch drive the result.
+        for key in (
+            "VNX_DATA_DIR", "VNX_DATA_DIR_EXPLICIT",
+            "VNX_DATA_HOME", "XDG_DATA_HOME",
+            "VNX_STATE_DIR", "VNX_PROJECT_ID",
+        ):
+            monkeypatch.delenv(key, raising=False)
+
+        # vnx init with default resolution — state lands at
+        # fake_home/.vnx-data/<project_id> (the canonical central dir).
+        project_dir = tmp_path_factory.mktemp("project")
+        rc = vnx_init(_args(project_dir))
+        assert rc == 0, "vnx init must succeed"
+
+        # vnx doctor — must complete without VNXDataDirMismatchWarning.
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            drc = vnx_doctor(argparse.Namespace(
+                project_dir=str(project_dir),
+                json=False,
+                strict=False,
+            ))
+        assert drc == 0, "vnx doctor must exit 0"
+
+        mismatch_warnings = [
+            w for w in caught
+            if issubclass(w.category, VNXDataDirMismatchWarning)
+        ]
+        assert len(mismatch_warnings) == 0, (
+            f"vnx doctor must not warn about data-dir mismatch after vnx init; "
+            f"got {len(mismatch_warnings)}: "
+            f"{[str(w.message) for w in mismatch_warnings]}"
+        )
+
+        # Also verify: the data dir init reported must be the central dir.
+        version_pin = project_dir / ".vnx-version"
+        assert version_pin.is_file(), "init must write .vnx-version"
+        marker = project_dir / ".vnx-project-id"
+        assert marker.is_file(), "init must write .vnx-project-id"
+        pid = marker.read_text(encoding="utf-8").splitlines()[0].strip()
+        central = fake_home / ".vnx-data" / pid
+        assert central.is_dir(), (
+            f"init must create state at canonical central dir {central}"
+        )

--- a/tests/test_context_rotation.py
+++ b/tests/test_context_rotation.py
@@ -391,7 +391,7 @@ class TestCheckpoint:
 class TestRotationUsesCanonicalDataRoot:
     """A prior version hardcoded resolve_central_data_dir(project_id) in the
     rotation path helpers. For a project that doesn't already have a central
-    ~/.vnx-data/<project_id> (i.e. it resolves to project-local or XDG
+    ~/.vnx-data/<project_id> (i.e. it resolves to project-local
     state), the FIRST checkpoint() call would nonetheless CREATE
     ~/.vnx-data/<project_id> as a side effect (via state_dir.mkdir()) —
     after which vnx_paths._resolve_state_root's existence-gated central
@@ -407,7 +407,7 @@ class TestRotationUsesCanonicalDataRoot:
     ) -> None:
         # Opt out of the autouse VNX_DATA_DIR_EXPLICIT override (see the
         # comment in test_project_id_scoped_across_two_projects above) — this
-        # test exercises the default central/local/XDG resolution, which the
+        # test exercises the default central/local resolution, which the
         # explicit override would otherwise short-circuit.
         monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
 
@@ -421,15 +421,16 @@ class TestRotationUsesCanonicalDataRoot:
 
         repo = tmp_path / "repo"
         _make_git_repo(repo)
-        project_id = "xdg-only-project"
+        project_id = "fresh-only-project"
 
         central_dir = Path.home() / ".vnx-data" / project_id
         assert not central_dir.exists()
 
         expected_root = vnx_paths._resolve_state_root(project_id, repo)
-        # Sanity check on the fixture: with no existing central/local store,
-        # the canonical resolver itself lands on the XDG default, not central.
-        assert not str(expected_root).startswith(str(Path.home() / ".vnx-data"))
+        # OI-1055: with no existing central/local store, a fresh project
+        # resolves to the canonical central dir — same as
+        # resolve_central_data_dir, preventing split-brain from the start.
+        assert str(expected_root).startswith(str(Path.home() / ".vnx-data"))
 
         policy = _enabled_policy(min_boundaries_between_rotations=0, respawn="off")
         out = cr.checkpoint(project_id=project_id, policy=policy, project_root=str(repo))
@@ -440,10 +441,14 @@ class TestRotationUsesCanonicalDataRoot:
         assert str(out.handoff_path.resolve()).startswith(str(expected_root.resolve()))
         assert str(out.marker_path.resolve()).startswith(str(expected_root.resolve()))
 
-        # The P1 bug: checkpoint() must NEVER create a competing
-        # ~/.vnx-data/<project_id> rotation/state tree as a side effect when
-        # the project doesn't already resolve there.
-        assert not central_dir.exists()
+        # OI-1055: since the resolver now lands on ~/.vnx-data/<id> for fresh
+        # installs (same as resolve_central_data_dir), checkpoint() legitimately
+        # creates the central dir under the same path the rest of VNX uses —
+        # there is no "competing" store to worry about. What matters is that
+        # the handoff landed under expected_root, not a hardcoded path.
+        assert central_dir.exists(), (
+            "checkpoint must create state under the resolved root (now central)"
+        )
 
         # The store the rest of VNX sees for this project is unchanged
         # before/after the rotation call.
@@ -454,15 +459,15 @@ class TestRotationUsesCanonicalDataRoot:
     ) -> None:
         """The handoff's horizon section must read tracks from the SAME
         store checkpoint()/write_t0_handoff() resolves to — not a
-        hardcoded central dir the project never actually uses (the exact
-        failure mode described in the P1 finding: the handoff missed the
-        real NOW/NEXT tracks because it read from the wrong, freshly-created
-        empty central store)."""
+        hardcoded central dir the project never actually uses. OI-1055:
+        since a fresh project resolves to the central dir (~/.vnx-data/<id>),
+        the handoff writes there legitimately — the invariant is that the
+        resolver and the writer agree, not that central stays absent."""
         monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
 
         repo = tmp_path / "repo"
         _make_git_repo(repo)
-        project_id = "xdg-horizon-project"
+        project_id = "fresh-horizon-project"
 
         resolved_root = vnx_paths._resolve_state_root(project_id, repo)
         assert not resolved_root.exists()
@@ -471,10 +476,10 @@ class TestRotationUsesCanonicalDataRoot:
         handoff_path = cr.write_t0_handoff(logdir=logdir, project_root=repo, project_id=project_id)
 
         # write_t0_handoff must have looked for tracks under resolved_root
-        # (which it just created via mkdir-on-demand inside tracks setup, or
-        # left absent if tracks lazily no-ops) — never under a central dir
-        # this project doesn't use.
-        assert not (Path.home() / ".vnx-data" / project_id).exists()
+        # (which it just created via mkdir-on-demand inside tracks setup).
+        # OI-1055: a fresh project resolves to ~/.vnx-data/<id>, so the
+        # handoff writes there — what matters is that the writer and resolver
+        # agree, not that the central path stays empty.
         assert handoff_path.is_file()
 
 

--- a/tests/test_init_migrate_bootstrap.py
+++ b/tests/test_init_migrate_bootstrap.py
@@ -191,7 +191,7 @@ class TestInitBootstrapsDb:
 
         db = tmp_path / ".vnx-data" / "state" / "runtime_coordination.db"
         if not db.exists():
-            # XDG path — look under the env-set path
+            # look under the env-set path
             db = Path(tmp_path / ".vnx-data") / "state" / "runtime_coordination.db"
 
         assert db.exists(), "runtime_coordination.db not created by vnx init"
@@ -303,20 +303,20 @@ class TestPoolStatusErrorMessage:
 # ---------------------------------------------------------------------------
 
 # ---------------------------------------------------------------------------
-# Fresh pip install: data root outside project dir (XDG / VNX_DATA_HOME)
+# Fresh pip install: data root outside project dir
 # ---------------------------------------------------------------------------
 
 class TestFreshInstallPathResolution:
     """track list and pool_manager must use the canonical data root, not hardcoded .vnx-data/.
 
-    Regression for: fresh pip install where data root is the XDG path
-    (~/.local/share/vnx/<project_id>/) rather than <project_dir>/.vnx-data/.
-    Both vnx track list and vnx pool status were looking in the hardcoded
-    project-local path and failing with "unable to open database file".
+    Regression for: fresh pip install where data root is outside the project map
+    rather than <project_dir>/.vnx-data/. Both vnx track list and vnx pool status
+    were looking in the hardcoded project-local path and failing with
+    "unable to open database file".
     """
 
     def test_track_list_returns_empty_when_data_root_outside_project(self, tmp_path, monkeypatch):
-        """vnx track list must not error when the DB is at an XDG-style data root."""
+        """vnx track list must not error when the DB is at an external data root."""
         xdg_data_root = tmp_path / "xdg_data"
         project_dir = tmp_path / "my_project"
         project_dir.mkdir()

--- a/tests/test_open_items_state_dir_resolution.py
+++ b/tests/test_open_items_state_dir_resolution.py
@@ -71,7 +71,7 @@ def test_state_dir_resolves_from_cwd_project_id(tmp_path: Path, monkeypatch):
 
     # Pre-create a project-local .vnx-data/state so _resolve_state_root
     # branch 4 (existing dev checkout) returns it rather than falling
-    # through to XDG.
+    # through to the fresh default.
     (project_dir / ".vnx-data" / "state").mkdir(parents=True)
 
     # Strip the conftest's module-scoped VNX_DATA_DIR_EXPLICIT / VNX_DATA_DIR

--- a/tests/test_path_resolution_regression.py
+++ b/tests/test_path_resolution_regression.py
@@ -309,7 +309,7 @@ class TestStateRootResolver:
     """PR-PIP-2: _resolve_state_root ordered resolution + collision-safety.
 
     Each branch is exercised in isolation with a real (tmp) HOME so the live
-    machine's ~/.vnx-data and ~/.local/share never leak into the assertions.
+    machine's ~/.vnx-data never leaks into the assertions.
     """
 
     def test_explicit_override_wins(self, tmp_path, monkeypatch):
@@ -348,11 +348,11 @@ class TestStateRootResolver:
         project_root = tmp_path / "checkout"
         local = project_root / ".vnx-data"
         local.mkdir(parents=True)
-        # No ~/.vnx-data/<id> exists → existing project-local dir wins over XDG.
+        # No ~/.vnx-data/<id> exists → existing project-local dir wins over fresh default.
         result = vnx_paths._resolve_state_root("vnx-dev", project_root)
         assert result == local.resolve()
 
-    def test_fresh_install_uses_xdg_default(self, tmp_path, monkeypatch):
+    def test_fresh_install_uses_central_default(self, tmp_path, monkeypatch):
         _clean_env(monkeypatch)
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -360,10 +360,11 @@ class TestStateRootResolver:
         project_root = tmp_path / "fresh"
         project_root.mkdir()
         result = vnx_paths._resolve_state_root("vnx-dev", project_root)
-        assert result == (fake_home / ".local" / "share" / "vnx" / "vnx-dev").resolve()
+        assert result == (fake_home / ".vnx-data" / "vnx-dev").resolve()
         assert not str(result).startswith(str(project_root))
 
-    def test_fresh_install_honors_xdg_data_home(self, tmp_path, monkeypatch):
+    def test_fresh_install_ignores_xdg_data_home(self, tmp_path, monkeypatch):
+        """XDG_DATA_HOME does not affect the fresh-install default (OI-1055)."""
         _clean_env(monkeypatch)
         fake_home = tmp_path / "home"
         fake_home.mkdir()
@@ -372,7 +373,8 @@ class TestStateRootResolver:
         xdg.mkdir()
         monkeypatch.setenv("XDG_DATA_HOME", str(xdg))
         result = vnx_paths._resolve_state_root("vnx-dev", tmp_path / "fresh")
-        assert result == (xdg / "vnx" / "vnx-dev").resolve()
+        # XDG_DATA_HOME is no longer honored; central default always wins.
+        assert result == (fake_home / ".vnx-data" / "vnx-dev").resolve()
 
     def test_collision_safety_no_project_id_stays_local(self, tmp_path, monkeypatch):
         """Unresolvable project_id must NEVER collapse to a shared default id."""

--- a/tests/test_state_root_lockstep.py
+++ b/tests/test_state_root_lockstep.py
@@ -114,7 +114,7 @@ def _py_resolve(monkeypatch, pid, project_root, env_overrides) -> Path:
         if v is not None:
             monkeypatch.setenv(k, v)
     # _resolve_state_root reads Path.home(); pin it to the test HOME so the
-    # live machine's ~/.vnx-data / ~/.local/share never leak in.
+    # live machine's ~/.vnx-data never leaks in.
     home = env_overrides.get("HOME")
     if home:
         monkeypatch.setattr(Path, "home", classmethod(lambda cls, h=home: Path(h)))
@@ -158,7 +158,7 @@ class TestResolverLockstep:
         py = _py_resolve(monkeypatch, "vnx-dev", proj, env)
         assert sh == py == (proj / ".vnx-data").resolve()
 
-    def test_xdg_default_branch(self, shell_lib, tmp_path, monkeypatch):
+    def test_central_default_branch(self, shell_lib, tmp_path, monkeypatch):
         home = tmp_path / "home"
         home.mkdir()
         proj = tmp_path / "fresh"
@@ -166,9 +166,10 @@ class TestResolverLockstep:
         env = {"HOME": str(home)}
         sh = _shell_resolve(shell_lib, "vnx-dev", proj, env)
         py = _py_resolve(monkeypatch, "vnx-dev", proj, env)
-        assert sh == py == (home / ".local" / "share" / "vnx" / "vnx-dev").resolve()
+        assert sh == py == (home / ".vnx-data" / "vnx-dev").resolve()
 
-    def test_xdg_data_home_override_branch(self, shell_lib, tmp_path, monkeypatch):
+    def test_xdg_data_home_ignored_branch(self, shell_lib, tmp_path, monkeypatch):
+        """XDG_DATA_HOME no longer affects fresh-install path resolution (OI-1055)."""
         home = tmp_path / "home"
         home.mkdir()
         xdg = tmp_path / "xdg"
@@ -178,7 +179,7 @@ class TestResolverLockstep:
         env = {"HOME": str(home), "XDG_DATA_HOME": str(xdg)}
         sh = _shell_resolve(shell_lib, "vnx-dev", proj, env)
         py = _py_resolve(monkeypatch, "vnx-dev", proj, env)
-        assert sh == py == (xdg / "vnx" / "vnx-dev").resolve()
+        assert sh == py == (home / ".vnx-data" / "vnx-dev").resolve()
 
     def test_collision_safety_no_pid_stays_local(self, shell_lib, tmp_path, monkeypatch):
         home = tmp_path / "home"

--- a/tests/test_vnx_paths_shell_worktree.py
+++ b/tests/test_vnx_paths_shell_worktree.py
@@ -72,12 +72,12 @@ printf 'VNX_INTELLIGENCE_DIR=%s\n' "$VNX_INTELLIGENCE_DIR"
     assert Path(lines["PROJECT_ROOT"]).resolve() == worktree_root.resolve()
     assert Path(lines["VNX_CANONICAL_ROOT"]).resolve() == canonical_root.resolve()
     # With a resolvable project_id but no local/central store, runtime resolves
-    # to the per-project data home (XDG: $HOME/.local/share/vnx/<pid>) — the
+    # to the central per-project data dir (~/.vnx-data/<pid>) — the
     # central-store model shares project state across worktrees rather than
     # keeping a separate per-worktree .vnx-data. HOME is isolated above so this
     # never touches the operator's real profile or live store.
     assert Path(lines["VNX_DATA_DIR"]).resolve() == (
-        fake_home / ".local" / "share" / "vnx" / "vnx-dev"
+        fake_home / ".vnx-data" / "vnx-dev"
     ).resolve()
     # Intelligence stays anchored to the canonical root regardless.
     assert Path(lines["VNX_INTELLIGENCE_DIR"]).resolve() == (canonical_root / ".vnx-intelligence").resolve()

--- a/vnx_cli/_engine.py
+++ b/vnx_cli/_engine.py
@@ -76,7 +76,7 @@ def resolve_data_root(project_dir) -> Path:
 
     Thin wrapper that bootstraps the engine path first, so every CLI command
     shares the ordered resolver (explicit > VNX_DATA_HOME > existing
-    ~/.vnx-data/<id> > existing project-local > XDG default).
+    ~/.vnx-data/<id> > existing project-local > fresh default).
     """
     ensure_engine_on_path()
     from vnx_paths import resolve_data_root as _resolve_data_root

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -275,7 +275,7 @@ def _check_state_root_location(data_root: Path) -> Check:
 
     PR-PIP-2 mitigation of the "state in immutable package" risk: a pip install
     must not write runtime state under site-packages or VNX_HOME. If it does,
-    point the operator at VNX_DATA_HOME / the XDG default.
+    point the operator at VNX_DATA_HOME / the central default.
     """
     engine_root = _engine.engine_root()
     candidates = [engine_root]
@@ -300,8 +300,8 @@ def _check_state_root_location(data_root: Path) -> Check:
             status=WARN,
             detail=(
                 f"runtime state root resolves inside the package/VNX_HOME ({data_root}) "
-                "— set VNX_DATA_HOME or rely on the XDG default "
-                "(~/.local/share/vnx/<project_id>) to keep state writable and out of the wheel"
+                "— set VNX_DATA_HOME or the default "
+                "(~/.vnx-data/<project_id>) to keep state writable and out of the wheel"
             ),
         )
     return Check(
@@ -887,7 +887,7 @@ def vnx_doctor(args) -> int:
     strict = getattr(args, "strict", False)
 
     # PR-PIP-2: resolve the runtime data root once (explicit > VNX_DATA_HOME >
-    # existing ~/.vnx-data/<id> > existing project-local > XDG default) and
+    # existing ~/.vnx-data/<id> > existing project-local > fresh default) and
     # thread it through the runtime-tree checks so a clean (state-outside-project)
     # install validates against where state actually lives.
     data_root = _engine.resolve_data_root(project_dir)

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -872,7 +872,7 @@ def _vnx_init_scaffold(project_dir, template, force, set_version, project_id) ->
     _scaffold_claude_dir(project_dir, tmpl_root, ctx, force)
     # Only create the project-local .vnx-data/ scaffold when the resolved
     # data root is already inside the project directory. For fresh
-    # XDG/external installs the runtime dirs are under data_root (created
+    # external installs the runtime dirs are under data_root (created
     # above); silently creating a second local .vnx-data/ would cause the
     # next resolver call to prefer it (step-4 "existing dev checkout" branch),
     # contradicting the config and the init output (PR-PIP-2 clean-footprint).

--- a/vnx_cli/commands/migrate.py
+++ b/vnx_cli/commands/migrate.py
@@ -110,7 +110,7 @@ def _run_future_system_pipeline(data_root: Path, project_id: str) -> None:
     # Anchor the tenant on disk (not via a global env mutation that would leak across
     # a fleet sweep or a shared test process): write the canonical .vnx-project-id
     # marker in the data root when absent, so the fail-closed resolver in the runner
-    # resolves THIS store's project_id even for a non-central (XDG/local) layout the
+    # resolves THIS store's project_id even for a non-central (project-local) layout the
     # DB-path anchor can't cover. Never overwrites an existing marker (reconciled above).
     marker = data_root / ".vnx-project-id"
     if not marker.exists():
@@ -191,7 +191,7 @@ def vnx_migrate(args) -> int:
     """Run the full migration chain against the project's runtime DBs."""
     project_dir = Path(getattr(args, "project_dir", ".")).resolve()
 
-    # Resolve data root via canonical chain (explicit > VNX_DATA_HOME > XDG).
+    # Resolve data root via canonical chain (explicit > VNX_DATA_HOME > default).
     # ensure_engine_on_path is called inside resolve_data_root.
     try:
         data_root = _engine.resolve_data_root(project_dir)

--- a/vnx_cli/commands/track.py
+++ b/vnx_cli/commands/track.py
@@ -11,7 +11,7 @@ from vnx_cli import _engine
 
 
 def _resolve_state_dir(project_dir: str | Path) -> Path:
-    # Use canonical data-root chain (XDG-aware) so pip installs work without .vnx-data/ inside the project.
+    # Use canonical data-root chain so pip installs work without .vnx-data/ inside the project.
     return _engine.resolve_data_root(Path(project_dir).resolve()) / "state"
 
 


### PR DESCRIPTION
## What

Fixes OI-1055: `vnx init` and `resolve_central_data_dir` resolved the store path differently. Init used `~/.local/share/vnx/<id>` (XDG fallback) while the canonical central dir is `~/.vnx-data/<id>`.

## Root cause

Branch 5 of `_resolve_state_root()` fell to `XDG_DATA_HOME` for fresh installs, while `resolve_central_data_dir()` always returns `~/.vnx-data/<id>`. The XDG branch was deliberate (PR-PIP-2 "clean footprint") but incompatible with the canonical central dir. No ADR or flag documented this choice.

## Changes

- **Core fix**: `_resolve_state_root()` branch 5 (`vnx_paths.py` + `vnx_paths.sh`) now resolves to `~/.vnx-data/<id>` instead of XDG
- **XDG references removed** from 21 files (comments, docstrings, messages, remediation texts)
- **New test**: `TestInitDoctorDataDirConsistency` — runs `vnx init` then `vnx doctor`, asserts zero `VNXDataDirMismatchWarning`
- **Old-code regression confirmed**: reverting the fix makes the new test fail

## XDG projects

All 38 entries in `~/.local/share/vnx/` are pytest test artifacts (May–Jul 2026). The four named in the dispatch (`freshproj`, `gitproj`, `my-vnx-project`, `proj`) are all disposable. No real fleet projects use XDG. Left as-is per instructions.

## Verification

85 targeted tests green across the affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)