### PR TITLE
fix(receipt): lane identity wins over body for model/provider, timestamp from work time not processing (OI-1111, OI-1092)

### DIFF
--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -368,6 +368,110 @@ def _resolve_report_role(
     return role or _IDENTITY_UNRESOLVED
 
 
+# ---------------------------------------------------------------------------
+# Provider string normalization (OI-1111)
+# ---------------------------------------------------------------------------
+
+# Canonical provider names as used by dispatch lanes. Every variant found in
+# the ledger (deepseek-harness, deepseek, litellm:deepseek, kimi-k3, kimi,
+# kimi-code/k3, glm-harness) normalises to one of these.
+_CANONICAL_PROVIDER_LANE = {
+    "deepseek-harness",
+    "deepseek",
+    "kimi",
+    "glm-harness",
+    "claude",
+    "codex",
+    "gemini",
+}
+
+
+def _normalise_provider(provider_raw: str) -> str:
+    """Normalise a provider string to its canonical lane value.
+
+    Variants observed in the ledger as of 2026-08-09:
+      deepseek-harness (294), deepseek (27), ``deepseek (harness, key-auth)``
+      (one self-report), litellm:deepseek (43), kimi-k3, kimi-code/k3.
+
+    Without normalisation every cost aggregation over provider counts these as
+    separate providers. The canonical lane values are the short forms the
+    dispatch door uses.
+    """
+    if not provider_raw or not provider_raw.strip():
+        return "unknown"
+    p = provider_raw.strip()
+    pl = p.lower()
+
+    # Already a canonical lane value — pass through.
+    if pl in _CANONICAL_PROVIDER_LANE:
+        return pl
+
+    # DeepSeek variants → deepseek-harness
+    if "deepseek" in pl:
+        return "deepseek-harness"
+
+    # Kimi variants (kimi-k3, kimi-code/k3, kimi) → kimi
+    if "kimi" in pl:
+        return "kimi"
+
+    # GLM variants → glm-harness.  parse_route_model_id maps glm-* model IDs
+    # to litellm:zai (the litellm provider flag for Zhipu AI); normalise that
+    # flag back to the canonical lane name.
+    if "glm" in pl or pl == "litellm:zai":
+        return "glm-harness"
+
+    # Unknown — return as-is rather than invent a value.
+    return p
+
+
+def _resolve_report_provider_model(
+    dispatch_id: str, merged: Dict[str, Any], state_dir: Optional[Path]
+) -> Tuple[str, str]:
+    """Resolve provider and model from the lane, falling back to the body.
+
+    OI-1111: on harness lanes (GLM, DeepSeek) the worker introspects as
+    sonnet/claude because the CLI around it thinks that is what it is.  The
+    body therefore carries a false identity the worker cannot know is wrong.
+    For model and provider the LANE wins — opposite precedence from
+    ``_resolve_report_role``, where the body wins because the author's own
+    role stamp is the authoritative source.
+
+    Resolution order:
+      1. Route decision JSON (``state_dir/route_decisions/<dispatch_id>.json``)
+         — the lane's own record of which model was selected.
+      2. Report body/frontmatter fields — fallback when no route decision
+         exists (e.g. plan-gate seats that do not go through the smart router).
+    """
+    provider: Optional[str] = None
+    model: Optional[str] = None
+
+    # Lane identity first: the route decision knows which model ran.
+    if state_dir and dispatch_id:
+        route_dec = _load_route_decision(dispatch_id, state_dir)
+        if route_dec and route_dec.get("selected_model"):
+            model_id = route_dec["selected_model"]
+            try:
+                from smart_router import parse_route_model_id  # noqa: PLC0415
+                lane_provider, lane_model = parse_route_model_id(model_id)
+                provider = _normalise_provider(lane_provider)
+                model = lane_model
+            except Exception:
+                logger.debug(
+                    "report_to_receipt_converter: provider/model lane resolution "
+                    "failed for dispatch=%s model_id=%s",
+                    dispatch_id, model_id,
+                    exc_info=True,
+                )
+
+    # Body fallback: only used when lane resolution produced nothing.
+    if not provider:
+        provider = _normalise_provider(merged.get("provider", "unknown"))
+    if not model:
+        model = (merged.get("model") or "").strip()
+
+    return provider, model
+
+
 # Terminal success statuses that trigger fail-closed validation (OI-1035 et al.).
 # Any report claiming one of these statuses must pass all three fail-closed
 # checks before a success receipt is written.  Reports with other statuses
@@ -532,6 +636,16 @@ def build_receipt_from_report(
     canonical_report_path = str(resolved.path) if resolved is not None else str(report_path)
     ambiguous_report = resolved.ambiguous if resolved is not None else False
 
+    # OI-1111: provider and model come from the LANE (route decision), not
+    # from the body. On harness lanes (GLM, DeepSeek) the worker introspects
+    # as sonnet/claude; the body is a false identity the worker cannot know
+    # is wrong. The lane's route decision holds the authoritative identity.
+    # Provider strings are normalised to canonical lane values so every cost
+    # aggregation counts one provider, not four variants of the same lane.
+    _resolved_provider, _resolved_model = _resolve_report_provider_model(
+        dispatch_id, merged, state_dir,
+    )
+
     base: Dict[str, Any] = {
         "dispatch_id": dispatch_id,
         # Receipt-quality PR-3: converter receipts are dispatch-lane outcomes
@@ -542,8 +656,8 @@ def build_receipt_from_report(
         "role": _resolve_report_role(dispatch_id, merged, state_dir),
         "task_id": merged.get("task_id", "unknown"),
         "terminal": merged.get("terminal", "unknown"),
-        "provider": merged.get("provider", "unknown"),
-        "model": merged.get("model", ""),
+        "provider": _resolved_provider,
+        "model": _resolved_model,
         "timestamp": timestamp,
         "report_path": canonical_report_path,
     }

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -59,6 +59,63 @@ def _is_valid_model_name(value: str) -> bool:
     return True
 
 
+def _resolve_work_timestamp(metadata: Dict[str, str], report_path: str) -> Optional[str]:
+    """Resolve the time the work was done, not the time the report was processed.
+
+    OI-1092: a receipt processed today for work done last week must carry last
+    week's date. A processed-now timestamp silently corrupts every time series
+    that groups by date. Resolution order:
+
+      1. Explicit date field in the report (``datum``, ``date``, ``timestamp``,
+         ``recorded_at``) — already captured by ``extract_metadata``.
+      2. File mtime of the report on disk.
+      3. Fail-closed: return None when neither is determinable, so the caller
+         can refuse to emit a receipt rather than write one with a false date.
+
+    Returns an ISO-8601 timestamp string (UTC) or None.
+    """
+    # Tier 1: explicit date field from the report metadata.
+    for key in ('datum', 'date', 'timestamp', 'recorded_at', 'created_at'):
+        raw = str(metadata.get(key) or '').strip()
+        if not raw or raw.lower() in ('unknown', 'none', 'null', 'n/a', ''):
+            continue
+        try:
+            # Accept common ISO-8601 variants; normalise to full UTC form.
+            from dateutil.parser import parse as _parse_dt
+        except ImportError:
+            _parse_dt = None
+        if _parse_dt is not None:
+            try:
+                dt = _parse_dt(raw)
+                if dt.tzinfo is None:
+                    from datetime import timezone
+                    dt = dt.replace(tzinfo=timezone.utc)
+                return dt.isoformat()
+            except Exception:
+                pass
+        # Fallback: try fromisoformat for strict ISO-8601.
+        try:
+            from datetime import datetime as _datetime, timezone as _timezone
+            dt = _datetime.fromisoformat(raw)
+            if dt.tzinfo is None:
+                dt = dt.replace(tzinfo=_timezone.utc)
+            return dt.isoformat()
+        except Exception:
+            pass
+
+    # Tier 2: file modification time.
+    try:
+        from datetime import datetime as _datetime, timezone as _timezone
+        mtime = os.path.getmtime(report_path)
+        dt = _datetime.fromtimestamp(mtime, tz=_timezone.utc)
+        return dt.isoformat()
+    except OSError:
+        pass
+
+    # Tier 3: fail-closed — no receipt with a false date.
+    return None
+
+
 class ReportParser:
     """Extract structured intelligence from markdown reports"""
 
@@ -623,6 +680,21 @@ class ReportParser:
             _event_type = 'task_complete'
             _receipt_status = metadata.get('status', 'unknown')
 
+        # OI-1092: the receipt timestamp must be the time the WORK was done,
+        # not the time the report was PROCESSED. A backlog of 103 previously
+        # refused reports processed today would otherwise write 103 receipts
+        # with today's date for work done 3–7 August — worse than the gap
+        # itself, because a missing receipt is visibly absent while a receipt
+        # with the wrong date silently corrupts every time series.
+        #
+        # Resolution order:
+        #   1. Explicit date field in the report (datum, date, timestamp, recorded_at)
+        #   2. File mtime of the report on disk
+        #   3. Fail-closed: neither available → no receipt emitted
+        _work_ts = _resolve_work_timestamp(metadata, report_path)
+        if _work_ts is None:
+            return {'error': f'Cannot resolve work timestamp for: {report_path}'}
+
         # Start with comprehensive structure including all new fields
         receipt = {
             'event_type': _event_type,  # Primary field for structured processing
@@ -630,7 +702,7 @@ class ReportParser:
             # Receipt-quality PR-3: report-derived receipts are dispatch-lane
             # outcomes (closed-set kind; role propagates via PR-1/2 lanes).
             'receipt_kind': 'dispatch',
-            'timestamp': datetime.utcnow().isoformat(),  # FIX: Use UTC, not local time
+            'timestamp': _work_ts,
             'terminal': metadata.get('terminal', 'unknown'),
             'track': metadata.get('track'),  # Include track field for terminal routing
             'type': metadata.get('type', 'UNKNOWN'),

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -91,7 +91,7 @@ def _resolve_work_timestamp(metadata: Dict[str, str], report_path: str) -> Optio
                     from datetime import timezone
                     dt = dt.replace(tzinfo=timezone.utc)
                 return dt.isoformat()
-            except Exception:
+            except Exception:  # vnx-silent-except: fallback tier — a dateutil parse miss drops to the fromisoformat tier, then the file-mtime tier, and finally the explicit fail-closed return
                 pass
         # Fallback: try fromisoformat for strict ISO-8601.
         try:
@@ -100,7 +100,7 @@ def _resolve_work_timestamp(metadata: Dict[str, str], report_path: str) -> Optio
             if dt.tzinfo is None:
                 dt = dt.replace(tzinfo=_timezone.utc)
             return dt.isoformat()
-        except Exception:
+        except Exception:  # vnx-silent-except: fallback tier — a fromisoformat parse miss drops to the file-mtime tier and, if that fails too, the explicit fail-closed return
             pass
 
     # Tier 2: file modification time.

--- a/tests/test_report_parser_model_provider.py
+++ b/tests/test_report_parser_model_provider.py
@@ -753,3 +753,190 @@ def test_bash_watermark_prevents_reconversion(tmp_path: Path):
 
 if __name__ == "__main__":
     sys.exit(pytest.main([__file__, "-v"]))
+
+
+# ---------------------------------------------------------------------------
+# OI-1092: receipt timestamp = time of work, not time of processing
+# ---------------------------------------------------------------------------
+
+
+class TestWorkTimestamp:
+    """The receipt timestamp must be the time the WORK was done, not when it
+    was PROCESSED.  Resolution: explicit report date → file mtime → fail-closed.
+    """
+
+    def test_explicit_datum_field_used(self, tmp_path):
+        """A report with **Datum**: <date> uses that date."""
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260807-datum-test
+**Datum**: 2026-08-07T14:30:00Z
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+This report carries an explicit Datum field. The receipt timestamp must be
+2026-08-07T14:30:00Z, not the processing time.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        r = _parse(tmp_path, body)
+        assert "timestamp" in r
+        ts = r["timestamp"]
+        assert "2026-08-07" in ts, f"Expected work date, got: {ts}"
+
+    def test_explicit_date_field_used(self, tmp_path):
+        """A report with **Date**: <date> uses that date."""
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260806-date-test
+**Date**: 2026-08-06T10:15:00Z
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+This report carries an explicit Date field. The receipt must use 2026-08-06.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        r = _parse(tmp_path, body)
+        assert "2026-08-06" in r["timestamp"]
+
+    def test_metadata_timestamp_field_used(self, tmp_path):
+        """A report with **Timestamp**: <date> already in metadata is used."""
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260805-ts-test
+**Timestamp**: 2026-08-05T08:00:00Z
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+This report stamps its own Timestamp field. The receipt must carry that value.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        r = _parse(tmp_path, body)
+        assert "2026-08-05" in r["timestamp"]
+
+    def test_file_mtime_fallback(self, tmp_path):
+        """When no explicit date field exists, file mtime is used."""
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260804-mtime-test
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+No explicit date field — the receipt must use the file's modification time.
+This summary is comfortably longer than fifty non-whitespace characters.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        p = tmp_path / "report.md"
+        p.write_text(body, encoding="utf-8")
+        r = ReportParser().parse_report(str(p))
+        assert "timestamp" in r
+        ts = r["timestamp"]
+        # Must be parseable as ISO-8601
+        from datetime import datetime as _datetime
+        _datetime.fromisoformat(ts)
+        # Must NOT be the processing-time workaround — the mtime was just set
+        # when we wrote the file, so it should be very close to now, but the
+        # important thing is that it is parseable ISO-8601 UTC.
+
+    def test_fail_closed_no_timestamp_produces_error(self, tmp_path):
+        """When neither metadata date nor file exists, return error (fail-closed).
+
+        The report_parser must refuse to emit a receipt with a false timestamp.
+        This is the backfill guard: processing old reports with today's date
+        is worse than a gap in the ledger.
+        """
+        nonexistent = tmp_path / "does-not-exist.md"
+        r = ReportParser().parse_report(str(nonexistent))
+        assert "error" in r, f"Expected error for missing file, got: {r}"
+
+    def test_timestamp_is_not_processing_time(self, tmp_path):
+        """Prove the guard binds: the timestamp is NOT datetime.utcnow().
+
+        We write a report whose explicit **Datum** is 2026-08-03 and assert
+        the receipt timestamp CONTAINS that date.  If the fix were removed
+        (using datetime.utcnow()), the timestamp would contain today's date
+        (2026-08-10) instead — and this test would catch it.
+        """
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260803-guard-bind
+**Datum**: 2026-08-03T12:00:00Z
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+Explicit work date of 3 August. The receipt must carry 2026-08-03, not today.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        r = _parse(tmp_path, body)
+        assert r["timestamp"] == "2026-08-03T12:00:00+00:00", (
+            f"Expected 2026-08-03T12:00:00+00:00 (work time), "
+            f"got {r['timestamp']} (likely processing time — fix not active)"
+        )
+
+    def test_recorded_at_field_used(self, tmp_path):
+        """A report with **Recorded-At**: <date> uses that date."""
+        body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260802-rec-test
+**Recorded-At**: 2026-08-02T16:45:00Z
+**Model**: sonnet
+**Provider**: claude
+
+## Summary
+This report uses Recorded-At as timestamp. Receipt must carry 2026-08-02.
+
+## Changes
+- edited scripts/foo.py
+
+## Verification
+- ran pytest tests/test_foo.py; all green
+
+## Open Items
+None
+"""
+        r = _parse(tmp_path, body)
+        assert "2026-08-02" in r["timestamp"]

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -1512,3 +1512,272 @@ class TestIsKnownDispatch:
 
         result = _is_known_dispatch("good-one", state_dir)
         assert result is True, "malformed line must not prevent matching a valid record"
+
+
+# ---------------------------------------------------------------------------
+# Part 13: provider normalisation + lane-identity resolution (OI-1111)
+# ---------------------------------------------------------------------------
+
+
+class TestNormaliseProvider:
+    """_normalise_provider maps every known variant to one canonical lane value."""
+
+    def test_canonical_passthrough(self):
+        from report_to_receipt_converter import _normalise_provider
+        for canonical in ("claude", "codex", "gemini", "kimi", "deepseek-harness",
+                          "deepseek", "glm-harness"):
+            assert _normalise_provider(canonical) == canonical
+
+    def test_deepseek_variants_normalised(self):
+        from report_to_receipt_converter import _normalise_provider
+        assert _normalise_provider("litellm:deepseek") == "deepseek-harness"
+        assert _normalise_provider("deepseek (harness, key-auth)") == "deepseek-harness"
+
+    def test_kimi_variants_normalised(self):
+        from report_to_receipt_converter import _normalise_provider
+        assert _normalise_provider("kimi-k3") == "kimi"
+        assert _normalise_provider("kimi-code/k3") == "kimi"
+
+    def test_glm_variants_normalised(self):
+        from report_to_receipt_converter import _normalise_provider
+        assert _normalise_provider("glm-harness") == "glm-harness"
+        assert _normalise_provider("litellm:zai") == "glm-harness"
+
+    def test_empty_or_none_returns_unknown(self):
+        from report_to_receipt_converter import _normalise_provider
+        assert _normalise_provider("") == "unknown"
+        assert _normalise_provider("  ") == "unknown"
+
+
+class TestLaneIdentityResolution:
+    """Provider and model come from the lane (route_decision), not the body.
+
+    On harness lanes (GLM, DeepSeek) the worker introspects as sonnet/claude
+    and stamps a false identity in the body.  The lane's route decision holds
+    the authoritative identity; the body is only a fallback when no route
+    decision exists.
+    """
+
+    def _write_route_decision_for(self, state_dir: Path, dispatch_id: str,
+                                  selected_model: str) -> None:
+        import json as _json
+        rd_dir = state_dir / "route_decisions"
+        rd_dir.mkdir(parents=True, exist_ok=True)
+        (rd_dir / f"{dispatch_id}.json").write_text(_json.dumps({
+            "strategy": "smart_router",
+            "task_class": "03_bug_fix",
+            "selected_model": selected_model,
+            "timestamp": "2026-08-09T12:00:00Z",
+        }), encoding="utf-8")
+
+    def test_glm_harness_lane_wins_over_body_sonnet_claude(self, tmp_path):
+        """Core OI-1111 case: route_decision says glm-5.2, body says sonnet/claude.
+        The receipt must carry glm-harness/glm-5.2, not sonnet/claude."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        dispatch_id = "20260809d-w2-worker-permissieprofielen"
+        self._write_route_decision_for(state_dir, dispatch_id, "glm-5.2")
+
+        # Simulate the exact body the worker wrote: sonnet/claude.
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            "---\ndispatch_id: 20260809d-w2-worker-permissieprofielen\n"
+            "provider: claude\nmodel: sonnet\nstatus: success\n"
+            "terminal: T2\n---\n\n"
+            "## Summary\n\nImplemented the feature per dispatch specification. "
+            "All tests pass and coverage is at target.\n\n"
+            "## Changes\n\n- scripts/lib/example.py: added X\n\n"
+            "## Verification\n\npytest tests/ -x: 42 passed\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        # Lane identity wins — not the body's sonnet/claude
+        assert receipt["provider"] == "glm-harness", (
+            f"Expected glm-harness from lane, got {receipt.get('provider')}"
+        )
+        assert receipt["model"] == "glm-5.2", (
+            f"Expected glm-5.2 from lane, got {receipt.get('model')}"
+        )
+
+    def test_deepseek_harness_lane_wins(self, tmp_path):
+        """Route decision for deepseek-v4-pro — receipt carries deepseek-harness."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        dispatch_id = "20260809-deepseek-test"
+        self._write_route_decision_for(state_dir, dispatch_id, "deepseek-v4-pro")
+
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            "---\ndispatch_id: 20260809-deepseek-test\n"
+            "provider: claude\nmodel: sonnet\nstatus: success\nterminal: T1\n---\n\n"
+            "## Summary\n\nDeepSeek harness worker that reports as claude/sonnet. "
+            "The receipt must carry the lane identity, not the body.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        assert receipt["provider"] == "deepseek-harness", (
+            f"Expected deepseek-harness, got {receipt.get('provider')}"
+        )
+        assert receipt["model"] == "deepseek-v4-pro", (
+            f"Expected deepseek-v4-pro, got {receipt.get('model')}"
+        )
+
+    def test_body_fallback_when_no_route_decision(self, tmp_path):
+        """When no route decision JSON exists, body fields are the fallback."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        # No route_decision JSON written.
+
+        report = tmp_path / "20260601-no-rd.md"
+        report.write_text(
+            "---\ndispatch_id: 20260601-no-rd\n"
+            "provider: kimi\nmodel: kimi-k3\nstatus: success\nterminal: T2\n---\n\n"
+            "## Summary\n\nReport without route decision — body values should be "
+            "used (with normalisation).\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        # Body provider "kimi" normalises to "kimi" (already canonical).
+        assert receipt["provider"] == "kimi"
+        assert receipt["model"] == "kimi-k3"
+
+    def test_body_provider_normalised_when_fallback(self, tmp_path):
+        """When body is the fallback, provider strings are still normalised."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+
+        report = tmp_path / "20260601-body-norm.md"
+        report.write_text(
+            "---\ndispatch_id: 20260601-body-norm\n"
+            "provider: litellm:deepseek\nmodel: deepseek-v4-flash\nstatus: success\n"
+            "terminal: T1\n---\n\n"
+            "## Summary\n\nBody carries litellm:deepseek — must normalise to "
+            "deepseek-harness. Summary with sufficient length for validation.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        assert receipt["provider"] == "deepseek-harness"
+
+    def test_kimi_lane_wins_and_normalises(self, tmp_path):
+        """Route decision kimi-k3 → provider kimi, model kimi-k3."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        dispatch_id = "20260809-kimi-test"
+        self._write_route_decision_for(state_dir, dispatch_id, "kimi-k3")
+
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            "---\ndispatch_id: 20260809-kimi-test\n"
+            "provider: kimi-k3\nmodel: kimi-k3\nstatus: success\nterminal: T1\n---\n\n"
+            "## Summary\n\nKimi lane worker whose body provider kimi-k3 normalises "
+            "to kimi. The lane is authoritative even when the body is close.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        assert receipt["provider"] == "kimi"
+        assert receipt["model"] == "kimi-k3"
+
+    def test_claude_lane_model_preserved(self, tmp_path):
+        """Claude route_decision is honest — lane still wins but values match."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        dispatch_id = "20260809-claude-test"
+        self._write_route_decision_for(state_dir, dispatch_id, "claude-sonnet-4-6")
+
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            "---\ndispatch_id: 20260809-claude-test\n"
+            "provider: claude\nmodel: sonnet\nstatus: unknown\nterminal: T1\n---\n\n"
+            "## Summary\n\nClaude lane is honest — lane values match body values "
+            "for provider/model. Summary with adequate length to pass validation.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        assert receipt["provider"] == "claude"
+        # parse_route_model_id("claude-sonnet-4-6") splits on first hyphen:
+        # variant = "claude-sonnet-4-6".split("-")[1] = "sonnet"
+        assert receipt["model"] == "sonnet"
+
+    def test_dispatch_type_b_matches_this_spec(self, tmp_path):
+        """Prove the guard binds: WITHOUT route_decision the body lies."""
+        from report_to_receipt_converter import build_receipt_from_report
+
+        state_dir = tmp_path / "state"
+        state_dir.mkdir(parents=True)
+        dispatch_id = "20260809d-w2-worker-permissieprofielen"
+        # Deliberately NO route_decision written — simulate body-only path.
+        # This is the pre-fix behaviour: body says sonnet/claude, receipt
+        # believes it. The lane-resolution fix above is what corrects this.
+
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            "---\ndispatch_id: 20260809d-w2-worker-permissieprofielen\n"
+            "provider: claude\nmodel: sonnet\nstatus: success\nterminal: T2\n---\n\n"
+            "## Summary\n\nPre-fix behaviour: without route decision, body lies "
+            "unchecked. The lane fix changes this for harness dispatches where "
+            "the route decision IS present.\n\n"
+            "## Changes\n\n- scripts/lib/foo.py: edited\n\n"
+            "## Verification\n\npytest tests/ -x: all green\n\n"
+            "## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+
+        receipt = build_receipt_from_report(
+            report, report.read_text(encoding="utf-8"), state_dir=state_dir,
+        )
+        assert receipt is not None
+        # No route_decision → body is the fallback. "claude" is already canonical.
+        assert receipt["provider"] == "claude"
+        assert receipt["model"] == "sonnet"


### PR DESCRIPTION
## Wat

Twee fixes in hetzelfde overdrachtspunt (rapport → receipt).

### OI-1111 — identiteit uit de lane, niet uit de body

Op harness lanes (GLM, DeepSeek) draait de worker achter een CLI die zichzelf als sonnet/claude rapporteert. De body schrijft dus een valse identiteit die de worker niet kan weten. De converter las die blind uit de body.

**Fix:** `_resolve_report_provider_model()` haalt provider/model uit de lane (route_decision JSON), met body als fallback. Omgekeerde precedentie t.o.v. role: voor model/provider wint de lane.

**Provider-normalisatie:** `_normalise_provider()` mapt alle varianten (deepseek-harness, deepseek, litellm:deepseek, kimi-k3, kimi-code/k3, litellm:zai) naar canonieke lane-waarden.

### OI-1092 — receipt-tijd is de tijd van het werk

Het receipt kreeg `datetime.utcnow()` — de tijd van verwerking, niet van het werk. Een achterstand van ~103 eerder geweigerde rapporten zou bij backfill 103 receipts met vandaag's datum schrijven voor werk van 3-7 augustus.

**Fix:** `_resolve_work_timestamp()` leest: expliciet datumveld in rapport → file mtime → fail-closed (geen receipt).

## Tests

- 77 converter tests groen (12 nieuw)
- 33 parser tests groen (7 nieuw)
- Provider-normalisatie: 6 varianten naar 4 canonieke waarden
- Guard-bind bewezen: `test_timestamp_is_not_processing_time` toont dat een expliciet `**Datum**: 2026-08-03` in het receipt landt zonder `datetime.utcnow()`-vervuiling
- `test_dispatch_type_b_matches_this_spec`: zonder route_decision valt de converter terug op body — de pre-fix state die OI-1111 corrigeert

## Open Items

- Backfill van de ~103 eerder geweigerde rapporten is nu verantwoord mogelijk (timestamps kloppen) maar NIET in deze PR uitgevoerd
- De bestaande receipts met valse sonnet/claude-identiteit in het grootboek zijn met de huidige gegevens niet te scheiden van echte claude/sonnet receipts

🤖 Generated with [Claude Code](https://claude.com/claude-code)