### PR TITLE
fix(horizon): close pip-CLI/engine flag drift, make parity suite block CI (OI-1065)

### DIFF
--- a/scripts/ci/test_exclusions.txt
+++ b/scripts/ci/test_exclusions.txt
@@ -91,7 +91,11 @@ tests/test_governance_digest_certification.py
 tests/test_governance_digest_runner.py
 tests/test_headless_dispatch_daemon_wave5.py
 tests/test_headless_inspect.py
-tests/test_horizon_parity.py
+# tests/test_horizon_parity.py — REPAIRED (OI-1065): the pip-CLI/engine flag drift
+# (vnx horizon add --lane-hint, close --attest/--pr/--max-gh-calls, plan-gate
+# attest delegation) was the red this exclusion hid. Suite is 85/85 green and
+# now rejoins the Profile A sweep so new drift fails the PR, not a red suite
+# nobody reads. No heavy-dep stack (sqlite3 + in-repo modules only).
 tests/test_horizon_schema_migration_fix.py
 tests/test_horizon_skill_alias.py  # OI-951: doc/content drift the test already asserts against, red on main too
 tests/test_init_migrate_bootstrap.py

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -330,6 +330,7 @@ _PLAN_GATE_ARGV = {
     "seed": ["delegate-track"],
     "run": ["delegate-track", "--doc", "some/plan-doc.md"],
     "status": ["delegate-track"],
+    "attest": ["delegate-track", "--reason", "operator override", "--approval-id", "token-xyz"],
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -509,6 +509,7 @@ def _register_track_subparser(subparsers: argparse.Action) -> None:
 _HORIZON_CHOICES = ("now", "next", "later")
 _PHASE_CHOICES = ("queued", "active", "parked", "done")
 _OUTPUT_KIND_CHOICES = ("pr", "post", "deal", "doc")
+_LANE_HINT_CHOICES = ("direct", "governed", "unset")
 
 
 def _common_horizon_args(p: argparse.ArgumentParser) -> None:
@@ -533,6 +534,11 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     p_add.add_argument("goal_state", metavar="GOAL_STATE", help="what 'done' looks like")
     p_add.add_argument("--horizon", choices=_HORIZON_CHOICES, default=None)
     p_add.add_argument("--priority", default=None)
+    p_add.add_argument(
+        "--lane-hint", choices=_LANE_HINT_CHOICES, default=None, dest="lane_hint",
+        metavar="LANE_HINT",
+        help="descriptive dispatch-routing hint (governed|direct|unset); default unset",
+    )
 
     p_list = subs.add_parser("list", help="list objectives grouped by horizon")
     _common_horizon_args(p_list)
@@ -624,6 +630,24 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
         help="project repo root for the ROADMAP.yaml (Source-3) evidence "
              "(default: resolved --project-dir)",
     )
+    p_close.add_argument(
+        "--attest", default=None, metavar="REASON",
+        help="operator attestation for ops-tracks with no PR evidence (requires --apply "
+             "--approval-id). Records the real PR via --pr when given, else fails open to "
+             "ops-attest:<date>",
+    )
+    p_close.add_argument(
+        "--pr", action="append", default=None, metavar="NNN",
+        help="delivering PR ref(s) as #NNN or NNN, comma-separated or repeated. Only valid "
+             "with --attest: records the real PR as pr_ref instead of ops-attest:<date>. "
+             "Without --attest, use `vnx objective link-pr` instead.",
+    )
+    p_close.add_argument(
+        "--max-gh-calls", type=int, default=50, dest="max_gh_calls", metavar="N",
+        help="cap live gh pr view calls for the track's pr_ref (default 50; a single "
+             "close handles one track so the cap is rarely reached). Bounds the "
+             "evidence gather so it is explicit rather than unbounded.",
+    )
 
     p_reopen = subs.add_parser(
         "reopen", help="reopen a done track: done -> active (operator-gated, audited)",
@@ -659,7 +683,7 @@ def _register_objective_verbs(subs: argparse.Action) -> None:
     _common_horizon_args(p_lane_hint)
     p_lane_hint.add_argument("track_id", metavar="TRACK_ID")
     p_lane_hint.add_argument(
-        "lane_hint", choices=("direct", "governed", "unset"), metavar="LANE_HINT",
+        "lane_hint", choices=_LANE_HINT_CHOICES, metavar="LANE_HINT",
         help="descriptive dispatch-routing hint (governed|direct|unset)",
     )
 


### PR DESCRIPTION
## Summary

The pip-CLI (`vnx_cli/main.py`) drifted from the engine (`scripts/planning_cli.py`). `vnx horizon add` missed `--lane-hint`, `close` missed `--attest`/`--pr`/`--max-gh-calls`, and the `plan-gate attest` delegation was untested. `tests/test_horizon_parity.py` detected all of this but stood red for months because it was in the OI-906 CI exclusion list — a signal with no reader.

This is the same drift class PR #1399 closed for `link-pr`/`set-lane-hint`, and follows that PR's form exactly.

## Changes

**Task 1 — close the drift** (`vnx_cli/main.py`, `tests/test_horizon_parity.py`):
- `add`: register `--lane-hint` (choices `direct|governed|unset`, dest `lane_hint`, default None) — mirrors engine `planning_cli.py:2642-2645`
- `close`: register `--attest`, `--pr` (append), `--max-gh-calls` (int, default 50) — mirrors engine `planning_cli.py:2577-2595`
- `set-lane-hint`: share the new `_LANE_HINT_CHOICES` constant (single source of truth; replaces the hardcoded tuple)
- parity test: add the `attest` entry to `_PLAN_GATE_ARGV` so the delegation test covers the verb that already delegated via `_cmd_plan_gate_attest` but had no table row (legitimate test-coverage fix — the delegate existed and worked; the test never exercised it)

**Task 2 — make the suite block new drift** (`scripts/ci/test_exclusions.txt`):
- remove `tests/test_horizon_parity.py` from the OI-906 CI exclusion list so Profile A (`vnx-ci.yml`) runs it on every PR. A red suite now fails the PR instead of sitting unread. The other two horizon exclusions (`test_horizon_schema_migration_fix.py`, `test_horizon_skill_alias.py`) are out of scope for this dispatch and stay.

## Verification

**Before:** `python -m pytest tests/test_horizon_parity.py -q` -> `7 failed, 78 passed`
```
test_objective_verb_flags_match_engine[add]            # missing --lane-hint
test_objective_verb_flags_match_engine[close]         # missing --attest/--pr/--max-gh-calls
test_objective_alias_verb_flags_match_engine[add]
test_objective_alias_verb_flags_match_engine[close]
test_plan_gate_verb_delegates_and_passes_through_exit_code[attest]  # missing _PLAN_GATE_ARGV entry
test_horizon_verb_help_lists_every_engine_flag[add]
test_horizon_verb_help_lists_every_engine_flag[close]
```

**After:** `7 failed, 78 passed -> 85 passed, 0 new failures`

```
python -m pytest tests/test_horizon_parity.py -q                                          # 85 passed
python -m pytest tests/test_horizon_parity.py tests/test_horizon_cli.py -q                # 111 passed
python -m pytest tests/test_horizon_parity.py tests/test_horizon_cli.py \
  tests/test_planning_cli.py tests/test_planning_cli_lane_hint.py -q                      # 150 passed
```

### Guard-binding proof (flags removed then restored)

The dispatch requires proving a guard binds by running it both ways, not by reasoning.

**Flags removed** (revert the `add`/`close` registrations + the test-table entry):
```
7 failed, 78 passed in 1.01s
```
Exact original failures return — the parity suite detects the drift.

**Flags restored**:
```
85 passed in 1.00s
```

### Exclusion-binding proof

Profile A parses `scripts/ci/test_exclusions.txt` into `--ignore` entries (strips `#` comments). Re-running that parser:
- **with** the exclusion line restored: `horizon_parity in ignore list: True` (suite skipped — signal lost)
- **after this edit** (line removed): `horizon_parity in ignore list: False` (suite runs in Profile A — new drift fails the PR)

The suite has no heavy-dep stack (`sqlite3` + in-repo modules only), so it runs in the minimal CI image.

## Open Items

None.

**Dispatch-ID**: 20260810b-e-cli-parity
**Model**: glm-5.2
**Provider**: glm-harness

🤖 Generated with [Claude Code](https://claude.com/claude-code)