### PR TITLE
fix(init): refuse launchd agent install on worktree roots + pytest guard (OI-1117)

### DIFF
--- a/scripts/lib/vnx_paths.py
+++ b/scripts/lib/vnx_paths.py
@@ -383,6 +383,43 @@ def refuse_real_central_store_write_under_pytest(resolved: Path) -> None:
         )
 
 
+def refuse_real_launch_agents_write_under_pytest(dest_dir: Path) -> None:
+    """Fail loud when code is ABOUT TO WRITE under the real
+    ``~/Library/LaunchAgents`` while running under pytest
+    (OI-1117 / launchd-test-isolation class guard).
+
+    Call this from write surfaces right before any plist or file gets
+    created in ``~/Library/LaunchAgents``. The guard is placed at the write
+    surface, not inside a generic path resolver: the LaunchAgents dir is a
+    legitimate production write target outside of tests; only an imminent
+    WRITE to it during pytest is the isolation hazard.
+
+    Production is unaffected: pytest is never in ``sys.modules`` outside a
+    test run.
+
+    Pattern mirrors ``refuse_real_central_store_write_under_pytest`` — the
+    two guards share the same shape so the class of test-isolation guard is
+    recognisable as a single idiom across the codebase.
+    """
+    if os.environ.get("PYTEST_CURRENT_TEST") is None and "pytest" not in _sys.modules:
+        return
+    real_la = (
+        Path(os.path.expanduser("~")) / "Library" / "LaunchAgents"
+    ).resolve()
+    resolved = dest_dir.resolve()
+    sep = os.sep
+    if str(resolved) == str(real_la) or str(resolved).startswith(
+        str(real_la) + sep
+    ):
+        raise TestIsolationGuardError(
+            f"[TEST ISOLATION GUARD] about to write under the real "
+            f"LaunchAgents dir '{resolved}' while running under pytest. "
+            "A test lost its isolation. Mock Path.home to a tmp_path-based "
+            "fake home before calling code that installs launchd plists, "
+            "or monkeypatch subprocess.run to intercept launchctl calls."
+        )
+
+
 def _resolve_state_root(project_id: Optional[str], project_root: Path) -> Path:
     """Resolve the VNX runtime data root (the ``.vnx-data`` equivalent).
 

--- a/tests/test_cli_init.py
+++ b/tests/test_cli_init.py
@@ -556,6 +556,12 @@ class TestGateObligationRunnerInstall:
             init_cmd._engine, "engine_root", lambda: engine_root,
         )
 
+        # OI-1117: the LaunchAgents guard checks the real Path.home(); mock
+        # it to a fake home so the guard does not fire.
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(Path, "home", lambda: fake_home)
+
         # Restore permissions in teardown so tmp_path cleanup works.
         try:
             with pytest.raises((OSError, PermissionError)):
@@ -642,10 +648,23 @@ class TestGateObligationRunnerInstall:
         """vnx_init in the VNX orchestration repo must install the
         gate-obligation-runner launchd plist (OI-917 core fix).
 
-        Uses the real engine root (worktree) which has the plist template;
-        only mock Path.home() and subprocess.run to avoid touching the
-        real ~/Library/LaunchAgents/.
+        Mock engine_root() to a tmp_path-based non-worktree location that
+        symlinks the real templates/ and scripts/ trees, so the OI-1117
+        worktree guard does not fire while the scaffold still has access
+        to all its required templates.
         """
+        import os as _os
+        from vnx_cli.commands import init_cmd
+
+        real_engine = init_cmd._engine.engine_root()
+        fake_engine_root = tmp_path / "fake-vnx-engine"
+        fake_engine_root.mkdir()
+        for d in ("templates", "scripts", "schemas"):
+            _os.symlink(real_engine / d, fake_engine_root / d, target_is_directory=True)
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: fake_engine_root,
+        )
+
         fake_home = tmp_path / "fake-home"
         fake_home.mkdir()
         monkeypatch.setattr(Path, "home", lambda: fake_home)
@@ -692,6 +711,19 @@ class TestGateObligationRunnerInstall:
     def test_init_continues_on_launchctl_failure(self, tmp_path, monkeypatch, capsys):
         """If launchctl load fails, vnx_init must print a warning and
         continue — the scaffold is still valid."""
+        import os as _os
+        from vnx_cli.commands import init_cmd
+
+        # OI-1117: mock engine_root() to a non-worktree location via symlinks.
+        real_engine = init_cmd._engine.engine_root()
+        fake_engine_root = tmp_path / "fake-vnx-engine"
+        fake_engine_root.mkdir()
+        for d in ("templates", "scripts", "schemas"):
+            _os.symlink(real_engine / d, fake_engine_root / d, target_is_directory=True)
+        monkeypatch.setattr(
+            init_cmd._engine, "engine_root", lambda: fake_engine_root,
+        )
+
         fake_home = tmp_path / "fake-home"
         fake_home.mkdir()
         monkeypatch.setattr(Path, "home", lambda: fake_home)

--- a/tests/test_vnx_data_dir_real_store_guard.py
+++ b/tests/test_vnx_data_dir_real_store_guard.py
@@ -159,3 +159,67 @@ class TestWriteModeGuard:
         data_dir.mkdir()
         vnx_mode.write_mode(vnx_mode.VNXMode.OPERATOR, str(data_dir))
         assert (data_dir / "mode.json").exists()
+
+
+class TestRefuseRealLaunchAgentsWriteUnderPytest:
+    """OI-1117: the launchd-test-isolation guard refuses writes to the real
+    ``~/Library/LaunchAgents`` while running under pytest, following the
+    same pattern as ``refuse_real_central_store_write_under_pytest``."""
+
+    def test_refuses_write_under_launch_agents(self, tmp_path, monkeypatch):
+        fake_home = tmp_path / "home"
+        target = fake_home / "Library" / "LaunchAgents" / "subdir"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            vnx_paths.refuse_real_launch_agents_write_under_pytest(target)
+
+    def test_refuses_write_directly_in_launch_agents(self, tmp_path, monkeypatch):
+        """The guard must also fire when the target IS the LaunchAgents dir
+        itself, not just a subdir."""
+        fake_home = tmp_path / "home"
+        target = fake_home / "Library" / "LaunchAgents"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        with pytest.raises(RuntimeError, match="TEST ISOLATION GUARD"):
+            vnx_paths.refuse_real_launch_agents_write_under_pytest(target)
+
+    def test_allows_write_under_tmp_path(self, tmp_path, monkeypatch):
+        """A target outside ~/Library/LaunchAgents must not trigger the guard."""
+        target = tmp_path / "isolated" / "LaunchAgents"
+        target.mkdir(parents=True)
+        # Must not raise.
+        vnx_paths.refuse_real_launch_agents_write_under_pytest(target)
+
+    def test_allows_write_to_other_home_subdir(self, tmp_path, monkeypatch):
+        """A target elsewhere under HOME (e.g. ~/Documents) must not trigger
+        the guard — the guard only protects LaunchAgents specifically."""
+        fake_home = tmp_path / "home"
+        target = fake_home / "Documents"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+        # Must not raise.
+        vnx_paths.refuse_real_launch_agents_write_under_pytest(target)
+
+    def test_guard_noop_outside_pytest(self, tmp_path, monkeypatch):
+        """Outside pytest the guard is a no-op: the write surface check
+        relies on ``PYTEST_CURRENT_TEST`` or ``pytest`` in ``sys.modules``.
+        When neither signal is present, the guard returns silently and the
+        write proceeds — this is the correct production behaviour."""
+        import sys
+        fake_home = tmp_path / "home"
+        target = fake_home / "Library" / "LaunchAgents"
+        target.mkdir(parents=True)
+        monkeypatch.setenv("HOME", str(fake_home))
+
+        # Remove pytest from sys.modules to simulate production.
+        saved = sys.modules.pop("pytest", None)
+        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+        try:
+            # Must NOT raise — the guard thinks we are not under pytest.
+            vnx_paths.refuse_real_launch_agents_write_under_pytest(target)
+        finally:
+            if saved is not None:
+                sys.modules["pytest"] = saved

--- a/vnx_cli/commands/init_cmd.py
+++ b/vnx_cli/commands/init_cmd.py
@@ -738,11 +738,39 @@ def _install_gate_obligation_runner(vnx_home: str) -> bool:
     Raises OSError if the template exists but is unreadable.
     """
     plist_name = "com.vnx.gate-obligation-runner"
-    template = _engine.engine_root() / "scripts" / "launchd" / f"{plist_name}.plist"
+
+    # --- OI-1117: refuse launchd agent install on an unstable root -----------
+    # When vnx init runs from an ephemeral worktree (dispatch/PR isolation),
+    # engine_root() resolves to a directory under .vnx-data/worktrees/. A
+    # launchd agent pointing at that path becomes stale the moment the worktree
+    # is reaped — and worse, writes to the HOST ~/Library/LaunchAgents from
+    # what should be an isolated workspace. Refuse silently (return False)
+    # like the missing-template case: non-main-checkout callers should not
+    # install host-wide agents. The operator can install manually via
+    # reload_plist.sh from the main checkout.
+    engine_root = _engine.engine_root().resolve()
+    engine_parts = engine_root.parts
+    for i, part in enumerate(engine_parts):
+        if part == ".vnx-data" and i + 1 < len(engine_parts) and engine_parts[i + 1] == "worktrees":
+            print(
+                f"  skipped {plist_name} launchd agent — engine root is under "
+                f".vnx-data/worktrees/ ({engine_root}); launchd agents must be "
+                "installed from the main checkout, not an ephemeral worktree. "
+                "Run: bash scripts/launchd/reload_plist.sh "
+                f"{plist_name}"
+            )
+            return False
+
+    template = engine_root / "scripts" / "launchd" / f"{plist_name}.plist"
     if not template.is_file():
         return False
 
+    # --- OI-1117: test-isolation guard — refuse write to host LaunchAgents ---
+    # vnx_paths is importable because _engine.resolve_data_root() already
+    # called ensure_engine_on_path() during _vnx_init_scaffold.
+    from vnx_paths import refuse_real_launch_agents_write_under_pytest
     dest_dir = Path.home() / "Library" / "LaunchAgents"
+    refuse_real_launch_agents_write_under_pytest(dest_dir)
     dest_dir.mkdir(parents=True, exist_ok=True)
     dest = dest_dir / f"{plist_name}.plist"
 


### PR DESCRIPTION
## What

Two guards against a host-level test-isolation escape where `vnx init` from a worktree wrote a launchd plist pointing at an ephemeral dispatch-worktree into `~/Library/LaunchAgents/`.

### 1. Worktree guard

`_install_gate_obligation_runner` now refuses to install the launchd agent when `engine_root()` resolves under `.vnx-data/worktrees/`. A host-wide launchd plist pointing at an ephemeral worktree path becomes stale the moment the worktree is reaped. The function returns `False` (silent skip) with a clear message pointing to `reload_plist.sh` for manual install from the main checkout.

### 2. LaunchAgents pytest guard

`refuse_real_launch_agents_write_under_pytest` in `vnx_paths.py` follows the exact same shape as the existing `refuse_real_central_store_write_under_pytest`. Called from `_install_gate_obligation_runner` before any `mkdir`/`write` to `~/Library/LaunchAgents`, it raises `TestIsolationGuardError` when a test that forgot to mock `Path.home` tries to write to the host LaunchAgents.

The two guards share one form — one class of test-isolation guard across the codebase.

### Template verification

The template substitution (`content.replace('\${VNX_HOME}', vnx_home)`) already preserves the full template including `EnvironmentVariables` — verified in the RED-proof output (579 bytes, `EnvironmentVariables` block intact, `VNX_HOME` substituted).

## RED/GREEN proof

- **RED** (guard disabled): a test wrote a full plist (579 bytes, `EnvironmentVariables` block intact) to a fake LaunchAgents dir — proving the guard is the sole barrier between test code and the host filesystem.
- **GREEN** (guard enabled): the same write is blocked with `TestIsolationGuardError`.

## Tests

- 7/7 `TestGateObligationRunnerInstall` — all pass
- 5/5 `TestRefuseRealLaunchAgentsWriteUnderPytest` (new) — all pass
- 7/7 existing `TestRefuseRealCentralStoreWriteUnderPytest` + `TestPrQueueManagerWriteGuard` + `TestWriteModeGuard` — all pass
- 1/1 `TestInitDoctorDataDirConsistency` — passes
- 41/41 `test_cli_init.py` full suite — all pass

## Files changed

| File | Change |
|---|---|
| `scripts/lib/vnx_paths.py` | +37: new `refuse_real_launch_agents_write_under_pytest` guard |
| `vnx_cli/commands/init_cmd.py` | +30: worktree check + guard call in `_install_gate_obligation_runner` |
| `tests/test_cli_init.py` | +38/-4: fix integration tests for worktree guard |
| `tests/test_vnx_data_dir_real_store_guard.py` | +64: 5 new guard tests |

Dispatch-ID: 20260810c-b-launchd-isolatie

🤖 Generated with [Claude Code](https://claude.com/claude-code)