### PR TITLE
fix(plan-gate): seat-timeout knob + distinguish unreadable config from unset (OI-1068, OI-1096) [SALVAGED, UNREVIEWED]

### DIFF
--- a/scripts/lib/plan_gate_enforcement.py
+++ b/scripts/lib/plan_gate_enforcement.py
@@ -61,7 +61,13 @@ def enforce_mode() -> str:
         try:
             import config_runtime  # noqa: PLC0415
             raw = config_runtime.get("VNX_PLAN_GATE_ENFORCE")
-        except Exception:
+        except Exception as exc:  # vnx-silent-except: UNREADABLE config -> log + fail-soft to advisory
+            import logging  # noqa: PLC0415
+
+            logging.getLogger(__name__).warning(
+                "plan_gate_enforcement: VNX_PLAN_GATE_ENFORCE config read failed "
+                "(falling back to advisory, fail-soft direction): %s", exc
+            )
             raw = None
     raw = (raw or "advisory").strip().lower()
     return raw if raw in _ENFORCE_MODES else "off"
@@ -212,8 +218,24 @@ def complex_only_active() -> bool:
     Precedence mirrors enforce_mode: the process env var (a per-session
     override) wins; then the persisted config-plane value via config_runtime
     (the ``/operator/config`` surface, audited + revertible); then the registry
-    default (off). The config lookup is best-effort — a missing store leaves
-    the env/default behaviour unchanged.
+    default (off). The config lookup is best-effort, but best-effort has TWO
+    cases that must not be conflated: a NOT-SET flag and a UNREADABLE one.
+
+    - NOT-SET (the flag is simply absent, or the store is missing): the
+      config-plane returns False on its own and the lookup stays silent —
+      this is the legitimate default, the behaviour an un-set flag always had.
+      A missing store leaves the env/default behaviour unchanged.
+    - UNREADABLE (the import or the read itself raised — an import fault, a
+      broken row the façade did not catch): the fallback is still False, so
+      the fail-safe direction is preserved (False = the FULL panel = more
+      review, never less), but it is LOGGED. An operator who turns the flag
+      on via /operator/config and hits a config-plane fault would otherwise
+      see everything keep running heavy with no signal that the read failed —
+      hunting the scope classifier while the fault is in the config read.
+
+    The same loud-on-failure discipline the plan-gate-pass record adopted
+    (commit 9e7ad79d: a control that cannot fail reported every dropped record
+    as success); this is the second read-site of that class in this file pair.
     """
     raw = os.environ.get("VNX_PLAN_GATE_COMPLEX_ONLY")
     if raw:
@@ -221,7 +243,13 @@ def complex_only_active() -> bool:
     try:
         import config_runtime  # noqa: PLC0415
         return bool(config_runtime.get_bool("VNX_PLAN_GATE_COMPLEX_ONLY"))
-    except Exception:
+    except Exception as exc:  # vnx-silent-except: UNREADABLE config -> log + fail-closed to False (full panel)
+        import logging  # noqa: PLC0415
+
+        logging.getLogger(__name__).warning(
+            "plan_gate_enforcement: VNX_PLAN_GATE_COMPLEX_ONLY config read failed "
+            "(falling back to False = full panel, fail-safe direction): %s", exc
+        )
         return False
 
 

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -910,6 +910,37 @@ def _panel_retry_count() -> int:
         return 1
 
 
+# The per-seat deadline default. Before OI-1068 this was a bare literal (900) baked into
+# run_panel's signature with no override knob, so a seat that could not meet a 900s deadline
+# booked a fabricated abstention with no way to widen it — on mission-control the opus lane
+# hit three consecutive timeouts in one afternoon. VNX_PLAN_GATE_SEAT_TIMEOUT is the knob, in
+# the same env-var style as VNX_PANEL_RETRY; run_panel resolves to this when the caller does
+# not pass an explicit timeout (CLI flag / direct kwarg).
+DEFAULT_SEAT_TIMEOUT_SECONDS = 900
+
+
+def _seat_timeout(explicit: "int | None" = None) -> int:
+    """Resolve a panelist's per-seat deadline (``VNX_PLAN_GATE_SEAT_TIMEOUT``, default 900).
+
+    Same env-var style as ``_panel_retry_count`` (``VNX_PANEL_RETRY``): a caller that already
+    resolved a value — the CLI flag ``--seat-timeout`` — passes it as ``explicit`` and it wins
+    outright (None means "no explicit value, read the env"). The env var, when set and a valid
+    positive int, overrides the default; a malformed or non-positive value falls back to the
+    default rather than silently widening the deadline to infinity or clamping a real value
+    away. Returned value is always a positive int (>= 1).
+    """
+    if explicit is not None:
+        return max(1, int(explicit))
+    raw = os.environ.get("VNX_PLAN_GATE_SEAT_TIMEOUT", "").strip()
+    if not raw:
+        return DEFAULT_SEAT_TIMEOUT_SECONDS
+    try:
+        val = int(raw)
+    except ValueError:
+        return DEFAULT_SEAT_TIMEOUT_SECONDS
+    return val if val >= 1 else DEFAULT_SEAT_TIMEOUT_SECONDS
+
+
 def _dispatch_one(
     dispatcher: DispatcherFn, member: Dict[str, str], instruction: str, dispatch_id: str,
 ) -> PanelistResult:
@@ -1068,7 +1099,7 @@ def run_panel(
     panel: Optional[List[Dict[str, str]]] = None,
     dispatcher: Optional[DispatcherFn] = None,
     data_dir: Optional[str] = None,
-    timeout_seconds: int = 900,
+    timeout_seconds: Optional[int] = None,
     seat_ledger_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
     """Run the plan-first panel over ``doc_path`` and return the verdict.
@@ -1078,9 +1109,17 @@ def run_panel(
     (PASS|REVISE|BLOCK, or INFRA_FAIL when no lane produced a readable verdict —
     an infrastructure failure, not a plan judgment), the rule ``summary``, and
     per-panelist detail.
+
+    ``timeout_seconds`` (OI-1068): the per-seat deadline a panelist has before its
+    lane times out and the seat books a fabricated abstention. ``None`` (the
+    default) resolves to ``VNX_PLAN_GATE_SEAT_TIMEOUT`` (default 900) via
+    ``_seat_timeout`` — the same env-var-knob style as ``VNX_PANEL_RETRY``. An
+    explicit kwarg (the ``--seat-timeout`` CLI flag) wins outright. Only the
+    default dispatcher consumes it; an injected ``dispatcher`` ignores it.
     """
     panel = panel or DEFAULT_PANEL
-    dispatcher = dispatcher or _make_default_dispatcher(data_dir, timeout_seconds)
+    resolved_timeout = _seat_timeout(timeout_seconds)
+    dispatcher = dispatcher or _make_default_dispatcher(data_dir, resolved_timeout)
     doc_text = Path(doc_path).read_text(encoding="utf-8")
     doc_truncation = _doc_truncation_info(doc_text)
     instruction = build_plan_review_instruction(doc_text, track_id)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2229,6 +2229,7 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
         result = plan_gate_panel.run_panel(
             doc, track_id=args.track_id, project_id=args.project_id, data_dir=data_dir,
             panel=panel,
+            timeout_seconds=getattr(args, "seat_timeout", None),
         )
     except Exception as exc:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
@@ -2732,6 +2733,15 @@ def _build_parser() -> argparse.ArgumentParser:
         default="",
         help="comma-separated seat labels to run (subset of the configured panel); "
              "unknown labels fail loud. Defaults to the full configured panel.",
+    )
+    p_prun.add_argument(
+        "--seat-timeout",
+        dest="seat_timeout",
+        type=int,
+        default=None,
+        help="per-seat deadline in seconds before a panelist times out and books a "
+             "fabricated abstention (OI-1068). Defaults to VNX_PLAN_GATE_SEAT_TIMEOUT "
+             "(default 900) — the same env-var-knob style as VNX_PANEL_RETRY.",
     )
     p_prun.set_defaults(func=cmd_plan_gate_run)
 

--- a/tests/test_plan_gate_enforcement.py
+++ b/tests/test_plan_gate_enforcement.py
@@ -219,3 +219,103 @@ class TestDoorEnforcement:
         v = _check_track_link_verdict(_spec("t"), state_dir=state)
         assert v is not None
         assert v.code == "bad-track-link"
+
+
+# --------------------------------------------------------------- complex_only_active
+class TestComplexOnlyActive:
+    """OI-1096: a NOT-SET flag stays silent; an UNREADABLE one logs.
+
+    ``complex_only_active`` must distinguish two cases that the bare
+    ``except Exception: return False`` conflated:
+
+      - NOT-SET (flag absent, store missing): the config-plane returns False on its
+        own; the lookup is silent. This is the legitimate default — an un-set flag
+        always read False.
+      - UNREADABLE (the import or read raised): the fallback is still False
+        (fail-safe: False = the FULL panel = more review, never less), but it is
+        LOGGED. An operator who turns the flag on and hits a config-plane fault
+        would otherwise see everything keep running heavy with no signal.
+    """
+
+    def test_env_true_is_true(self, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "1")
+        assert pge.complex_only_active() is True
+
+    def test_env_false_is_false(self, monkeypatch):
+        monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "0")
+        assert pge.complex_only_active() is False
+
+    def test_not_set_is_false_and_silent(self, monkeypatch, caplog):
+        """NOT-SET (no env, no raising read) -> False, NO warning logged."""
+        monkeypatch.delenv("VNX_PLAN_GATE_COMPLEX_ONLY", raising=False)
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get_bool", lambda k: False)
+        with caplog.at_level("WARNING", logger="plan_gate_enforcement"):
+            assert pge.complex_only_active() is False
+        assert not any(
+            "VNX_PLAN_GATE_COMPLEX_ONLY config read failed" in r.message
+            for r in caplog.records
+        ), "a NOT-SET flag must stay silent, not log a config-read-failure warning"
+
+    def test_unreadable_config_is_false_but_logs(self, monkeypatch, caplog):
+        """UNREADABLE (the read raises) -> False (fail-safe), AND a warning is logged.
+
+        This is the bind: without the log line, this test goes RED on the caplog
+        assertion. Fail-safe direction (False = full panel) is unchanged.
+        """
+        monkeypatch.delenv("VNX_PLAN_GATE_COMPLEX_ONLY", raising=False)
+        import config_runtime
+
+        def _boom(key):
+            raise RuntimeError("broken config row")
+
+        monkeypatch.setattr(config_runtime, "get_bool", _boom)
+        with caplog.at_level("WARNING", logger="plan_gate_enforcement"):
+            assert pge.complex_only_active() is False
+        assert any(
+            "VNX_PLAN_GATE_COMPLEX_ONLY config read failed" in r.message
+            for r in caplog.records
+        ), "an UNREADABLE config must log a warning, not fail silently"
+
+    def test_env_wins_over_unreadable_config_no_log(self, monkeypatch, caplog):
+        """Env var set -> config plane is not read at all, so no failure log."""
+        monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "true")
+        import config_runtime
+        # A raising get_bool must never be called when the env var wins.
+        monkeypatch.setattr(config_runtime, "get_bool", lambda k: (_ for _ in ()).throw(RuntimeError("x")))
+        with caplog.at_level("WARNING", logger="plan_gate_enforcement"):
+            assert pge.complex_only_active() is True
+        assert not any(
+            "config read failed" in r.message for r in caplog.records
+        )
+
+
+class TestEnforceModeFailureLogs:
+    """OI-1096 companion: enforce_mode's config read is the SAME silent-except class
+    in this file. A raising config layer still falls back to advisory (fail-soft), but
+    now logs a warning instead of swallowing the fault silently."""
+
+    def test_raising_config_logs_and_falls_back_to_advisory(self, monkeypatch, caplog):
+        monkeypatch.delenv("VNX_PLAN_GATE_ENFORCE", raising=False)
+        import config_runtime
+
+        def _boom(k):
+            raise RuntimeError("no store")
+
+        monkeypatch.setattr(config_runtime, "get", _boom)
+        with caplog.at_level("WARNING", logger="plan_gate_enforcement"):
+            assert pge.enforce_mode() == "advisory"
+        assert any(
+            "VNX_PLAN_GATE_ENFORCE config read failed" in r.message
+            for r in caplog.records
+        ), "an UNREADABLE VNX_PLAN_GATE_ENFORCE config must log, not stay silent"
+
+    def test_not_set_enforce_is_advisory_and_silent(self, monkeypatch, caplog):
+        monkeypatch.delenv("VNX_PLAN_GATE_ENFORCE", raising=False)
+        import config_runtime
+        monkeypatch.setattr(config_runtime, "get", lambda k: None)
+        with caplog.at_level("WARNING", logger="plan_gate_enforcement"):
+            assert pge.enforce_mode() == "advisory"
+        assert not any(
+            "config read failed" in r.message for r in caplog.records
+        ), "a NOT-SET enforce flag must stay silent"

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -435,6 +435,86 @@ def test_panel_retry_count_malformed_falls_back_to_one(monkeypatch):
     assert pgp._panel_retry_count() == 0
 
 
+# --------------------------------------------------------------------------
+# OI-1068: VNX_PLAN_GATE_SEAT_TIMEOUT — the per-seat deadline knob, in the
+# same env-var style as VNX_PANEL_RETRY. Before this the deadline was a bare 900
+# baked into run_panel's signature with no override, so a seat that could not
+# meet 900s booked a fabricated abstention with no way to widen it.
+# --------------------------------------------------------------------------
+
+def test_seat_timeout_default_is_900(monkeypatch):
+    monkeypatch.delenv("VNX_PLAN_GATE_SEAT_TIMEOUT", raising=False)
+    assert pgp._seat_timeout() == 900
+
+
+def test_seat_timeout_honors_env(monkeypatch):
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "1800")
+    assert pgp._seat_timeout() == 1800
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "300")
+    assert pgp._seat_timeout() == 300
+
+
+def test_seat_timeout_explicit_wins_over_env(monkeypatch):
+    """An explicit caller value (the --seat-timeout CLI flag) wins outright over the env var."""
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "1800")
+    assert pgp._seat_timeout(600) == 600
+    assert pgp._seat_timeout(1) == 1
+
+
+def test_seat_timeout_malformed_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "not-a-number")
+    assert pgp._seat_timeout() == 900
+
+
+def test_seat_timeout_nonpositive_falls_back_to_default(monkeypatch):
+    # 0 or negative would let the lane run forever / invert the deadline — fall back
+    # to the default rather than silently widening the window to infinity.
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "0")
+    assert pgp._seat_timeout() == 900
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "-30")
+    assert pgp._seat_timeout() == 900
+
+
+def test_seat_timeout_explicit_clamped_to_at_least_one(monkeypatch):
+    """A non-positive explicit value (a bad CLI flag) is clamped to 1, never 0."""
+    monkeypatch.delenv("VNX_PLAN_GATE_SEAT_TIMEOUT", raising=False)
+    assert pgp._seat_timeout(0) == 1
+    assert pgp._seat_timeout(-5) == 1
+
+
+def test_run_panel_passes_resolved_seat_timeout_to_default_dispatcher(tmp_path, monkeypatch):
+    """run_panel (no explicit timeout, no injected dispatcher) resolves the env var and
+    passes it to _make_default_dispatcher — the knob actually reaches the lane."""
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "1234")
+    seen_timeouts: list[int] = []
+
+    def _capturing_make_dispatcher(data_dir, timeout_seconds, *, role="plan-reviewer"):
+        seen_timeouts.append(timeout_seconds)
+        return lambda provider, model_arg, instruction, dispatch_id: _make_report_with_fence("pass")
+
+    monkeypatch.setattr(pgp, "_make_default_dispatcher", _capturing_make_dispatcher)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+    pgp.run_panel(doc, track_id="feat-x", project_id="p1")
+    assert seen_timeouts == [1234]
+
+
+def test_run_panel_explicit_timeout_overrides_env(tmp_path, monkeypatch):
+    """An explicit timeout_seconds kwarg wins over the env var."""
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "1234")
+    seen_timeouts: list[int] = []
+
+    def _capturing_make_dispatcher(data_dir, timeout_seconds, *, role="plan-reviewer"):
+        seen_timeouts.append(timeout_seconds)
+        return lambda provider, model_arg, instruction, dispatch_id: _make_report_with_fence("pass")
+
+    monkeypatch.setattr(pgp, "_make_default_dispatcher", _capturing_make_dispatcher)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+    pgp.run_panel(doc, track_id="feat-x", project_id="p1", timeout_seconds=700)
+    assert seen_timeouts == [700]
+
+
 def test_run_panel_first_flake_then_success_recovers(tmp_path, monkeypatch):
     # A panelist that flakes once (no verdict fence) then succeeds must recover to a SCORING
     # verdict via the single retry — the codex verdict-JSON / glm parse flake case.
@@ -1935,6 +2015,68 @@ def test_cmd_plan_gate_run_light_plan_runs_fewer_seats_than_heavy(tmp_path, monk
     ))
     assert rc == 0
     assert [s["label"] for s in seen_panels[1]] == [m["label"] for m in pgp.DEFAULT_PANEL]
+
+
+def test_cmd_plan_gate_run_passes_seat_timeout_flag_to_run_panel(tmp_path, monkeypatch):
+    """OI-1068: the --seat-timeout CLI flag (args.seat_timeout) flows through
+    cmd_plan_gate_run into run_panel's timeout_seconds — the override knob reaches
+    the lane, not just the default 900."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    monkeypatch.delenv("VNX_PLAN_GATE_SEAT_TIMEOUT", raising=False)
+    seen_timeouts: list = []
+
+    def _capturing_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+        seen_timeouts.append(kw.get("timeout_seconds"))
+        return _fake_pass_run_panel(doc_path, track_id=track_id, project_id=project_id,
+                                    panel=panel, data_dir=data_dir, **kw)
+
+    monkeypatch.setattr(pgp, "run_panel", _capturing_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-to", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-to", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None, seat_timeout=1800,
+    ))
+    assert rc == 0
+    assert seen_timeouts == [1800]
+
+
+def test_cmd_plan_gate_run_no_flag_falls_back_to_env_via_run_panel(tmp_path, monkeypatch):
+    """With no --seat-timeout flag (seat_timeout=None), cmd_plan_gate_run passes None
+    so run_panel resolves VNX_PLAN_GATE_SEAT_TIMEOUT itself (env var is the knob)."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    monkeypatch.setenv("VNX_PLAN_GATE_SEAT_TIMEOUT", "2700")
+    seen_timeouts: list = []
+
+    def _capturing_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+        seen_timeouts.append(kw.get("timeout_seconds"))
+        return _fake_pass_run_panel(doc_path, track_id=track_id, project_id=project_id,
+                                    panel=panel, data_dir=data_dir, **kw)
+
+    monkeypatch.setattr(pgp, "run_panel", _capturing_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-env", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-env", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None, seat_timeout=None,
+    ))
+    assert rc == 0
+    # cmd_plan_gate_run passes None; run_panel's _seat_timeout(None) resolves the env var.
+    assert seen_timeouts == [None]
 
 
 def test_cmd_plan_gate_run_light_pass_writes_run_evidence_with_seats(tmp_path, monkeypatch):

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -707,6 +707,15 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
         help="comma-separated seat labels to run (subset of the configured panel); "
              "unknown labels fail loud. Defaults to the full configured panel.",
     )
+    p_prun.add_argument(
+        "--seat-timeout",
+        dest="seat_timeout",
+        type=int,
+        default=None,
+        help="per-seat deadline in seconds before a panelist times out and books a "
+             "fabricated abstention (OI-1068). Defaults to VNX_PLAN_GATE_SEAT_TIMEOUT "
+             "(default 900) — the same env-var-knob style as VNX_PANEL_RETRY.",
+    )
 
     p_pstat = subs.add_parser(
         "status", help="show a track's plan-gate state + derived_status",


### PR DESCRIPTION
## Herkomst: gered werk, niet gereviewd

Dispatch `20260810b-d-plangate-knoppen` schreef een rapport van 328 regels maar liet het werk
**onvastgelegd** in zijn worktree achter: 5 bestanden, 427 regels diff, nul commits. De
push+PR-enforcement van de lane vuurde niet, omdat `pr_enforcement` een `dirty` worktree als
niet-van-toepassing behandelt (die aanname klopt bij een lege worktree, niet bij een met werk erin).

T0 heeft het vastgelegd en gepusht zodat de worktree-reaper het niet kon opruimen. Dat mechanisme is
apart gefiled als **OI-1119 (blocker)**, met deze PR als een van de drie gemeten gevallen.

**Deze PR is door T0 NIET inhoudelijk gereviewd.** Hij staat open zodat CI erop draait en de inhoud
beoordeelbaar is in plaats van onzichtbaar op een branch te blijven staan. Behandel hem als een
worker-oplevering die nog door de gate moet.

## Wat er volgens het worker-rapport in zit

- **OI-1068** — `VNX_PLAN_GATE_SEAT_TIMEOUT` als env-var in dezelfde stijl als `VNX_PANEL_RETRY`,
  doorgegeven vanaf `cmd_plan_gate_run`, zodat de zetel-deadline instelbaar wordt (stond vast op 900).
- **OI-1096** — onderscheid tussen 'niet gezet' (legitieme default, blijft stil) en 'niet leesbaar'
  (logt) bij het uitlezen van `VNX_PLAN_GATE_COMPLEX_ONLY`, in plaats van elke config-fout stil als
  `False` te lezen.

Aangeraakt: `scripts/lib/plan_gate_enforcement.py`, `scripts/lib/plan_gate_panel.py`,
`scripts/planning_cli.py`, `tests/test_plan_gate_enforcement.py`, `tests/test_plan_gate_panel.py`.

## Wat een reviewer moet controleren

- Of de claims in het rapport kloppen met de diff (het rapport is niet tegen de code gehouden).
- Of `VNX_PLAN_GATE_SEAT_TIMEOUT` echt de vorm van `VNX_PANEL_RETRY` volgt en geen tweede conventie.
- Of het onderscheid unset/onleesbaar getest is, en of de test rood wordt als je het weghaalt.
- De defaults mogen niet verschoven zijn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)