### PR TITLE
fix(receipt-converter): scope phantom guard to dispatch reports, accept list-item Dispatch-ID (OI-1120 part 1)

### DIFF
--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -57,7 +57,28 @@ _WATERMARK_FILENAME = "report_to_receipt_processed.txt"
 _BASH_WATERMARK_FILENAME = "processed_receipts.txt"
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
-_BOLD_KV_RE = re.compile(r"\*\*([^*]+)\*\*:\s*(.+)", re.MULTILINE)
+# OI-1125: workers also write the colon INSIDE the closing markers
+# (`**Dispatch-ID:** value`), not just after them (`**Dispatch-ID**: value`).
+# Two alternatives, one per colon placement — Python's re has no branch-reset
+# groups, so group 1/2 hold the outer-colon form and group 3/4 the
+# inner-colon form; exactly one pair is non-None per match.
+#
+# The inner-colon alternative is anchored to line start (optional [-*]
+# marker, mirroring _DISPATCH_PLAIN_RE) — unlike the pre-existing outer-colon
+# alternative, which is a bare substring search with no anchor at all. This
+# is not cosmetic: the unanchored form was measured against the real
+# unified_reports/ corpus (4015 files) and produced a genuine false positive
+# — a report's OWN changelog prose, `` `**Dispatch-ID:**` labels (closing
+# `**` sits after the colon) ``, quoting the exact inner-colon shape as an
+# example, matched as if it were a field declaration and its trailing prose
+# became the "value", shadowing (via fields.setdefault order) the report's
+# real bare Dispatch-ID line earlier in the same file. Anchoring closes this
+# without touching the outer form's existing (unrelated, pre-#1445) lack of
+# anchoring, which is out of scope here. Neither alternative matches bold
+# text with no colon at all (e.g. `**note** text`).
+_BOLD_KV_RE = re.compile(
+    r"\*\*([^*]+)\*\*:\s*(.+)|^\s*(?:[-*]\s+)?\*\*([^*]+):\*\*\s*(.+)", re.MULTILINE
+)
 # OI-1120: the report contract tells workers to stamp the id "as a plain-text
 # or bold field" — a markdown list item (`- Dispatch-ID: x`) is plainly within
 # that instruction, so the optional leading marker must be tolerated. `+` is
@@ -67,11 +88,28 @@ _BOLD_KV_RE = re.compile(r"\*\*([^*]+)\*\*:\s*(.+)", re.MULTILINE)
 # included, which is not a real id stamp. `-`/`*` cover every genuine
 # list-item occurrence observed in the corpus (grep across 4411 real reports:
 # 5 genuine `- Dispatch-ID:` stamps, 0 false positives) with no such collision.
+#
+# OI-1120 round 2: `-` is ALSO the unified-diff REMOVAL prefix, and the first
+# cut (leading `\s*` + `[-*]\s+`) treated it as symmetric with a genuine list
+# item, so `-        dispatch_id: str,` (a pasted removed function signature)
+# and `-    Dispatch-ID: old-value` (a pasted removed id stamp) both matched —
+# the second one is dangerous: a report quoting a diff that REMOVES a
+# Dispatch-ID line would adopt the OLD value as the receipt identity. Anchored
+# at `^` with no leading `\s*`, and the marker is followed by exactly one
+# literal space (`[-*] `, not `[-*]\s+`): a genuine list item is always
+# "marker, single space, label" with nothing else preceding it on the line,
+# while a diff-removal line has arbitrary reindentation whitespace after the
+# `-` that no longer lines up with a single space. This also stops matching
+# an indented line (the shape a fenced/indented code block produces),
+# closing the "code block placeholder" gap the round-1 test recorded as a
+# known pre-existing hole. Blast-radius re-measured across all 4015 reports
+# in unified_reports/ (2026-08-10): 0 reports whose only Dispatch-ID form is
+# indented — nothing regresses from dropping the leading `\s*`.
 _DISPATCH_PLAIN_RE = re.compile(
-    r"^\s*(?:[-*]\s+)?Dispatch-ID:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+    r"^(?:[-*] )?Dispatch-ID:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
 )
 _DISPATCH_ID_KEY_RE = re.compile(
-    r"^\s*(?:[-*]\s+)?dispatch_id:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+    r"^(?:[-*] )?dispatch_id:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
 )
 
 
@@ -344,12 +382,15 @@ def _extract_body_fields(text: str) -> Dict[str, Any]:
     """Extract **Key**: value fields + plain-text Dispatch-ID fallback from body."""
     fields: Dict[str, Any] = {}
     for m in _BOLD_KV_RE.finditer(text[:3000]):
-        key = m.group(1).strip().lower().replace("-", "_").replace(" ", "_")
+        raw_key, raw_val = (
+            (m.group(1), m.group(2)) if m.group(1) is not None else (m.group(3), m.group(4))
+        )
+        key = raw_key.strip().lower().replace("-", "_").replace(" ", "_")
         # A bold key whose value is whitespace-only (e.g. truncated at the
         # text[:3000] scan boundary, or genuinely empty in the source report)
         # strips down to "" — splitlines() on "" is [], so index [0] would
         # raise IndexError. Guard it: no non-empty first line means no value.
-        value_lines = m.group(2).strip().splitlines()
+        value_lines = raw_val.strip().splitlines()
         val = value_lines[0].strip() if value_lines else ""
         if key and val:
             fields.setdefault(key, val)
@@ -620,6 +661,7 @@ def build_receipt_from_report(
     """
     sys.path.insert(0, str(_LIB_DIR))
     from report_body_contract import validate_body
+    from dispatch_spec import _ID_RE  # OI-1122: single shape definition, shared with staging
     from datetime import datetime, timezone
 
     fm = parse_frontmatter(text)
@@ -631,9 +673,20 @@ def build_receipt_from_report(
     # A filename-derived dispatch_id is NOT authoritative and is treated as a
     # contract violation — it must not produce a clean task_complete receipt.
     content_dispatch_id: Optional[str] = merged.get("dispatch_id") or None
+    # OI-1122: a growing deny-list ("unknown"/"none"/"null") never covers a
+    # template placeholder echoed back verbatim (`Dispatch-ID: <dispatch_id>`)
+    # — the literal string isn't in the list, so it was adopted as the real
+    # receipt identity, starving the actual dispatch of a closing receipt.
+    # Validate the shape instead: dispatch_spec._ID_RE is the SAME rule
+    # staging already enforces for a legal id, so a value that fails it can
+    # never have been a real dispatch_id to begin with. A shape failure is
+    # treated identically to a missing id — it falls through to the filename
+    # fallback and the existing OI-1102 register cross-check below, not a
+    # new rejection path of its own.
     content_id_valid = bool(
         content_dispatch_id
         and content_dispatch_id.lower() not in ("unknown", "none", "null")
+        and _ID_RE.match(content_dispatch_id)
     )
 
     # Validate body against the report body contract.

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -58,12 +58,73 @@ _BASH_WATERMARK_FILENAME = "processed_receipts.txt"
 
 _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 _BOLD_KV_RE = re.compile(r"\*\*([^*]+)\*\*:\s*(.+)", re.MULTILINE)
+# OI-1120: the report contract tells workers to stamp the id "as a plain-text
+# or bold field" — a markdown list item (`- Dispatch-ID: x`) is plainly within
+# that instruction, so the optional leading marker must be tolerated. `+` is
+# deliberately excluded from the marker class: it is also the unified-diff
+# addition prefix, and reports routinely quote diffs in their body — e.g.
+# `+        dispatch_id: str,` (a pasted function signature) matched with `+`
+# included, which is not a real id stamp. `-`/`*` cover every genuine
+# list-item occurrence observed in the corpus (grep across 4411 real reports:
+# 5 genuine `- Dispatch-ID:` stamps, 0 false positives) with no such collision.
 _DISPATCH_PLAIN_RE = re.compile(
-    r"^\s*Dispatch-ID:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+    r"^\s*(?:[-*]\s+)?Dispatch-ID:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
 )
 _DISPATCH_ID_KEY_RE = re.compile(
-    r"^\s*dispatch_id:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
+    r"^\s*(?:[-*]\s+)?dispatch_id:\s*(\S+)\s*$", re.MULTILINE | re.IGNORECASE
 )
+
+
+# ---------------------------------------------------------------------------
+# OI-1120: non-dispatch report classification — scope the register
+# cross-check to dispatch reports only
+# ---------------------------------------------------------------------------
+
+# Producer-controlled: review_gate_manager.headless_reports_dir is set from
+# VNX_HEADLESS_REPORTS_DIR, which defaults to <reports_dir>/headless
+# (vnx_paths.py:543-544) and is the ONLY directory review_gate_manager writes
+# HEADLESS-*.md reports into (review_gate_manager.py:61, :129-141). scan_and_
+# convert() / main() already walk this directory as a dedicated scan target
+# (this module, main()) alongside the top-level unified_reports/ — a report
+# living there is, by construction, never a dispatch report.
+_HEADLESS_REPORTS_DIRNAME = "headless"
+
+# Producer-controlled: panel.py and worktree_release.py both write into the
+# top-level unified_reports/ directory (same directory real dispatch reports
+# land in), so directory placement cannot distinguish them. Each prefix below
+# is the literal filename template the writer hardcodes for every report it
+# produces — not a guessed shape:
+#   scripts/panel.py:101           f"panel-{args.mode}-{uuid4().hex[:8]}.md"
+#   scripts/lib/worktree_release.py:632  f"worktree-release-{ts}.md"
+# Neither writer ever emits a Dispatch-ID/dispatch_id field or the dispatch
+# report body-contract headings (## Summary/## Changes/## Verification/
+# ## Open Items) — both are tool-output reports, not dispatch reports, and a
+# filename prefix owned by the producer is the only signal available to key
+# on. Measured against the live dead-letter directory (2026-08-10, 221
+# files): 3 panel-*.md + 5 worktree-release-*.md, both prefixes fully
+# disjoint from the 15 real dispatch report filenames present in that corpus.
+_NON_DISPATCH_FILENAME_PREFIXES = (
+    "panel-",
+    "worktree-release-",
+)
+
+
+def _classify_non_dispatch_report(report_path: Path) -> Optional[str]:
+    """Return a skip reason when *report_path* is a known non-dispatch report.
+
+    Returns None when the report is a dispatch-report candidate and must go
+    through the normal pipeline (including the register cross-check below).
+    A non-None return means: this file was never a dispatch report to begin
+    with, so it must never be judged against the dispatch register and must
+    never be dead-lettered as ``unknown_dispatch``.
+    """
+    if report_path.parent.name == _HEADLESS_REPORTS_DIRNAME:
+        return "headless_gate_report"
+    name = report_path.name
+    for prefix in _NON_DISPATCH_FILENAME_PREFIXES:
+        if name.startswith(prefix):
+            return "non_dispatch_tool_output"
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -749,6 +810,9 @@ def build_receipt_from_report(
 #   "malformed" — file unreadable, or no dispatch_id resolvable at all.
 #   "error"     — anything else: a crash while parsing/building the receipt,
 #                 or an append failure other than the fail-closed rejection.
+#   "skipped_non_dispatch" — OI-1120: report classified as a known non-dispatch
+#                 producer (HEADLESS gate report, panel output, worktree-release
+#                 output) — never a receipt candidate, never dead-lettered.
 
 def _convert_one_detailed(
     report_path: Path,
@@ -763,6 +827,18 @@ def _convert_one_detailed(
     into a (None, outcome_tag) result so a single poisoned report can never
     propagate an exception into a caller's batch loop.
     """
+    # OI-1120: classify BEFORE any receipt-building work. A known non-dispatch
+    # report (HEADLESS gate output, panel output, worktree-release output) is
+    # never a receipt candidate — it must not reach the register cross-check
+    # in build_receipt_from_report() and must not be dead-lettered.
+    skip_reason = _classify_non_dispatch_report(report_path)
+    if skip_reason is not None:
+        logger.info(
+            "report_to_receipt_converter: skipping non-dispatch report %s (reason=%s)",
+            report_path.name, skip_reason,
+        )
+        return None, "skipped_non_dispatch"
+
     # Import through append_receipt.py (scripts/ root) so the facade is
     # registered before append_receipt_payload() is called.
     sys.path.insert(0, str(_SCRIPTS_DIR))
@@ -923,6 +999,12 @@ class ScanStats:
     rejected_count: int = 0
     malformed_count: int = 0
     error_count: int = 0
+    # OI-1120: reports classified as known non-dispatch producer output
+    # (HEADLESS gate, panel, worktree-release) — deliberately excluded from
+    # attempted_count below. A scan cycle can legitimately see ONLY
+    # non-dispatch reports (the headless/ directory is scanned every cycle),
+    # and that must read as healthy, not as "attempted with zero success".
+    skipped_non_dispatch_count: int = 0
 
     @property
     def attempted_count(self) -> int:
@@ -973,6 +1055,7 @@ def _write_scan_heartbeat(state_dir: Path, stats: ScanStats) -> None:
             "rejected_count": stats.rejected_count,
             "malformed_count": stats.malformed_count,
             "error_count": stats.error_count,
+            "skipped_non_dispatch_count": stats.skipped_non_dispatch_count,
         },
     )
 
@@ -991,10 +1074,13 @@ def scan_and_convert(
     so a report processed by either lane is skipped by the other.
 
     Returns a ScanStats with per-outcome counts (new/duplicate/rejected/
-    malformed/error) — see ScanStats and _convert_one_detailed()'s outcome
-    tags. Only newly-appended and duplicate reports are marked processed;
-    rejected, malformed, and errored reports are NOT marked processed, so
-    they are retried on the next scan once their cause is fixed.
+    malformed/error/skipped_non_dispatch) — see ScanStats and
+    _convert_one_detailed()'s outcome tags. Newly-appended, duplicate, and
+    skipped_non_dispatch reports are marked processed (the classification
+    that produced skipped_non_dispatch is permanent — a panel-*.md report
+    never becomes a dispatch report on a later scan); rejected, malformed,
+    and errored reports are NOT marked processed, so they are retried on the
+    next scan once their cause is fixed.
 
     A single poisoned report can never abort the scan (OI-997): each
     report's conversion is wrapped in try/except here, in addition to
@@ -1024,6 +1110,7 @@ def scan_and_convert(
     rejected_count = 0
     malformed_count = 0
     error_count = 0
+    skipped_non_dispatch_count = 0
 
     for reports_dir in reports_dirs:
         if not isinstance(reports_dir, Path):
@@ -1062,10 +1149,11 @@ def scan_and_convert(
                 error_count += 1
                 continue
 
-            if outcome in ("appended", "duplicate"):
+            if outcome in ("appended", "duplicate", "skipped_non_dispatch"):
                 # Mark as processed in BOTH watermarks — no point re-scanning
                 # a report that's already in the system (OI-1102 cross-processor
-                # dedup: the Bash processor must also skip it).
+                # dedup: the Bash processor must also skip it) or that will
+                # never become a dispatch report (OI-1120 non-dispatch skip).
                 _mark_processed(file_hash, watermark_path)
                 watermark.add(file_hash)
                 _mark_processed(file_hash, bash_watermark_path)
@@ -1077,8 +1165,10 @@ def scan_and_convert(
                         result.idempotency_key[:20],
                         report_path.name,
                     )
-                else:
+                elif outcome == "duplicate":
                     duplicate_count += 1
+                else:  # "skipped_non_dispatch"
+                    skipped_non_dispatch_count += 1
             elif outcome == "rejected":
                 rejected_count += 1
             elif outcome == "malformed":
@@ -1094,6 +1184,7 @@ def scan_and_convert(
         rejected_count=rejected_count,
         malformed_count=malformed_count,
         error_count=error_count,
+        skipped_non_dispatch_count=skipped_non_dispatch_count,
     )
     _write_scan_heartbeat(state_dir, stats)
     return stats
@@ -1152,6 +1243,11 @@ def main(argv: Optional[List[str]] = None) -> int:
     stats = scan_and_convert(dirs, state_dir, cache_window_seconds=300)
     if stats.new_count:
         logger.info("report_to_receipt_converter: %d new receipt(s) emitted", stats.new_count)
+    if stats.skipped_non_dispatch_count:
+        logger.info(
+            "report_to_receipt_converter: %d non-dispatch report(s) skipped this scan",
+            stats.skipped_non_dispatch_count,
+        )
     if stats.rejected_count or stats.malformed_count or stats.error_count:
         logger.warning(
             "report_to_receipt_converter: %d rejected, %d malformed, %d error(s) this scan",

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -1986,3 +1986,196 @@ class TestListItemDispatchIdForm:
         )
         fields = _extract_body_fields(text)
         assert "dispatch_id" not in fields
+
+
+# ---------------------------------------------------------------------------
+# Part 16: PR #1445 round 2 — regex regression + OI-1122 + OI-1125
+# ---------------------------------------------------------------------------
+
+class TestPlainRegexNoLongerMatchesDiffRemovalLines:
+    """Round-1 widening (leading \\s* + [-*]\\s+) treated the unified-diff
+    REMOVAL prefix ('-') as symmetric with a genuine list-item marker. Both
+    diff-removal shapes below must stop matching; all genuine forms, and the
+    <dispatch_id> placeholder (a SEPARATE OI-1122 concern — the regex must
+    still extract it so the shape-check downstream has something to reject),
+    must keep matching."""
+
+    @pytest.mark.parametrize("name,text,expected", [
+        ("bare", "Dispatch-ID: 20260810g-a-converter-scoping", "20260810g-a-converter-scoping"),
+        ("dash_list_item", "- Dispatch-ID: 20260810e-a-seattimeout-1444", "20260810e-a-seattimeout-1444"),
+        ("star_list_item", "* Dispatch-ID: 20260810e-a-seattimeout-1444", "20260810e-a-seattimeout-1444"),
+        ("diff_removal_dispatch_id_key", "-        dispatch_id: str,", None),
+        ("diff_removal_dispatch_id_bold_label", "-    Dispatch-ID: old-value", None),
+        ("indented_codeblock_line", "    Dispatch-ID: some-value", None),
+        ("placeholder_echo", "Dispatch-ID: <dispatch_id>", "<dispatch_id>"),
+    ])
+    def test_seven_shapes(self, name, text, expected):
+        fields = _extract_body_fields(text + "\n" + _CONTRACT_BODY)
+        assert fields.get("dispatch_id") == expected, f"shape={name!r} text={text!r}"
+
+    def test_diff_removal_old_value_never_becomes_receipt_identity(self, tmp_path):
+        """The dangerous row from the finding: a report that quotes a diff
+        REMOVING a Dispatch-ID line must not adopt the old value. No genuine
+        stamp is present anywhere else in this report, so if the diff-quote
+        line matched, THAT would become the (wrong) receipt identity via the
+        filename-fallback-bypassing content path."""
+        text = (
+            "## Summary\n\nThis summary has more than fifty non-whitespace characters "
+            "so the body contract validates cleanly.\n\n"
+            "## Changes\n\nDiff excerpt:\n```diff\n"
+            "-    Dispatch-ID: old-value\n"
+            "+    Dispatch-ID: 20260810g-a-converter-scoping\n"
+            "```\n\n## Verification\n\n- none\n\n## Open Items\n\nNone\n"
+        )
+        report = tmp_path / "20260810g-a-converter-scoping.md"
+        report.write_text(text, encoding="utf-8")
+        receipt = build_receipt_from_report(report, text)
+        assert receipt is not None
+        # Neither diff-quote line is a genuine stamp (the '+' row was already
+        # excluded pre-#1445), so the id must come from the filename, not
+        # 'old-value' — and the receipt must be a contract violation, not a
+        # clean task_complete carrying a wrong id.
+        assert receipt["dispatch_id"] == "20260810g-a-converter-scoping"
+        assert receipt["dispatch_id"] != "old-value"
+        assert receipt["event_type"] == "report_contract_invalid"
+
+
+class TestDispatchIdKeyRegexNoLongerMatchesDiffRemovalLines:
+    """Same regression, same fix, applied to _DISPATCH_ID_KEY_RE (the
+    'dispatch_id:' underscore-key sibling of _DISPATCH_PLAIN_RE) — codex
+    defense checklist: same fix to all handlers."""
+
+    def test_diff_removal_underscore_key_does_not_match(self):
+        text = "-        dispatch_id: str,\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert "dispatch_id" not in fields
+
+    def test_bare_underscore_key_still_matches(self):
+        text = "dispatch_id: 20260810g-a-converter-scoping\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260810g-a-converter-scoping"
+
+
+class TestOI1122PlaceholderShapeValidation:
+    """A worker that echoes the instruction template verbatim
+    (`Dispatch-ID: <dispatch_id>`) must not have the literal placeholder
+    adopted as the receipt identity — it must be treated as no-content-id
+    and fall through to the existing filename fallback / OI-1102 register
+    cross-check, exactly like a missing id."""
+
+    def test_placeholder_falls_back_to_filename_when_registered(self, tmp_path, state_dir):
+        dispatch_id = "20260810g-x-placeholder-registered"
+        reg = state_dir / "dispatch_register.ndjson"
+        reg.write_text(
+            json.dumps({"dispatch_id": dispatch_id, "event": "dispatch_created"}) + "\n",
+            encoding="utf-8",
+        )
+        report = tmp_path / f"{dispatch_id}.md"
+        report.write_text(
+            f"**Dispatch-ID**: <dispatch_id>\n\n{_CONTRACT_BODY}**Model**: sonnet\n",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+
+        assert outcome not in ("malformed",)
+        assert not (state_dir / "receipt_deadletter").exists()
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        assert receipts[0]["dispatch_id"] == dispatch_id
+        assert receipts[0]["dispatch_id"] != "<dispatch_id>"
+        assert receipts[0]["event_type"] == "report_contract_invalid"
+
+    def test_placeholder_still_deadlettered_when_unregistered(self, tmp_path, state_dir):
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        report = tmp_path / "dispatch-20260810-placeholder-phantom.md"
+        report.write_text(
+            "**Dispatch-ID**: <dispatch_id>\n\n" + _CONTRACT_BODY, encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+
+        assert result is None
+        deadletter_dir = state_dir / "receipt_deadletter"
+        assert deadletter_dir.exists(), "unregistered placeholder-only report must still dead-letter"
+
+    def test_malformed_shape_falls_back_as_second_line_of_defense(self, tmp_path):
+        """'str,' passes the deny-list ('unknown'/'none'/'null') but fails
+        _ID_RE shape — the fix must catch it even though the regex fix
+        (Finding 1) already stops it from ever being extracted this way in
+        practice. Stamped via the BOLD form, which does not itself validate
+        value shape, to exercise the shape-check independently of Finding 1."""
+        text = "**Dispatch-ID**: str,\n\n" + _CONTRACT_BODY
+        report = tmp_path / "20260810g-x-malformed-shape.md"
+        report.write_text(text, encoding="utf-8")
+        receipt = build_receipt_from_report(report, text)
+        assert receipt is not None
+        assert receipt["dispatch_id"] == "20260810g-x-malformed-shape"
+        assert receipt["dispatch_id"] != "str,"
+        assert receipt["event_type"] == "report_contract_invalid"
+
+
+class TestOI1125BoldColonInsideMarkers:
+    """Workers also write **Dispatch-ID:** value (colon INSIDE the closing
+    markers), not just **Dispatch-ID**: value (colon after). Both placements
+    must extract identically; a bold phrase with no colon at all must still
+    not be treated as a field."""
+
+    def test_extract_body_fields_accepts_colon_inside_markers(self):
+        text = "**Dispatch-ID:** 20260810g-a-converter-scoping\n\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260810g-a-converter-scoping"
+
+    def test_extract_body_fields_still_accepts_colon_outside_markers(self):
+        """Parity guard: the pre-existing outer-colon form must not regress
+        when the inner-colon alternative is added."""
+        text = "**Dispatch-ID**: 20260810g-a-converter-scoping\n\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260810g-a-converter-scoping"
+
+    def test_bold_phrase_with_no_colon_is_not_a_false_positive(self):
+        """'**important**' with no colon anywhere must not be captured as a
+        key/value pair by either alternative of the widened pattern."""
+        text = "**important** just some bold prose, not a field.\n\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert "important" not in fields
+        assert "dispatch_id" not in fields
+
+    def test_colon_inside_markers_produces_receipt_with_correct_dispatch_id(self, tmp_path, state_dir):
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        dispatch_id = "20260810g-a-converter-scoping"
+        report = tmp_path / "some-other-report-name.md"
+        report.write_text(
+            f"**Dispatch-ID:** {dispatch_id}\n\n{_CONTRACT_BODY}**Model**: sonnet\n",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        assert result.status == "appended"
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        assert receipts[0]["dispatch_id"] == dispatch_id
+        assert not (state_dir / "receipt_deadletter").exists()
+
+    def test_midline_prose_quoting_inner_colon_shape_is_not_a_false_positive(self):
+        """Blast-radius regression pin (found scanning the real
+        unified_reports/ corpus, 2026-08-10): a report's OWN changelog prose
+        can quote the exact `**Dispatch-ID:**` shape as an example of what a
+        parser now tolerates — e.g. a line describing a fix to bold-header
+        parsing. That mid-sentence occurrence is not a field declaration and
+        must not shadow the report's real (earlier, bare-form) Dispatch-ID
+        via fields.setdefault()'s first-wins order. The inner-colon
+        alternative is anchored to line start specifically so a `**` that
+        does not begin its own line can never match."""
+        text = (
+            "Dispatch-ID: 20260810g-a-converter-scoping\n\n" + _CONTRACT_BODY +
+            "  - `DISPATCH_HEADER_RE` now tolerates bold `**Dispatch-ID:**` "
+            "labels (closing `**` sits after the colon).\n"
+        )
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260810g-a-converter-scoping"

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -32,7 +32,9 @@ sys.path.insert(0, str(SCRIPTS_LIB))
 
 from report_to_receipt_converter import (
     _WATERMARK_FILENAME,
+    _classify_non_dispatch_report,
     _compute_sha256,
+    _convert_one_detailed,
     _extract_body_fields,
     _is_known_dispatch,
     _load_route_decision,
@@ -1781,3 +1783,206 @@ class TestLaneIdentityResolution:
         # No route_decision → body is the fallback. "claude" is already canonical.
         assert receipt["provider"] == "claude"
         assert receipt["model"] == "sonnet"
+
+
+# ---------------------------------------------------------------------------
+# Part 14: OI-1120 — non-dispatch reports must never be judged against the
+# dispatch register and must never be dead-lettered as unknown_dispatch.
+# ---------------------------------------------------------------------------
+
+_CONTRACT_BODY = (
+    "## Summary\n\nThis summary has more than fifty non-whitespace characters "
+    "so the body contract validates cleanly.\n\n"
+    "## Changes\n\n- none\n\n## Verification\n\n- none\n\n## Open Items\n\nNone\n"
+)
+
+
+class TestClassifyNonDispatchReport:
+    """_classify_non_dispatch_report() — the pure classification function."""
+
+    @pytest.mark.parametrize("relpath,expected", [
+        ("unified_reports/headless/20260706-153235-HEADLESS-codex_gate-pr-1026-c77770.md", "headless_gate_report"),
+        ("panel-strategy-abcd1234.md", "non_dispatch_tool_output"),
+        ("worktree-release-20260810-120000.md", "non_dispatch_tool_output"),
+        ("20260810g-a-converter-scoping.md", None),  # real dispatch report -> candidate
+        ("dispatch-20260810-phantom-example.md", None),  # OI-1102 shape -> still a candidate
+    ])
+    def test_classification(self, tmp_path, relpath, expected):
+        p = tmp_path / relpath
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(_CONTRACT_BODY, encoding="utf-8")
+        assert _classify_non_dispatch_report(p) == expected
+
+
+class TestHeadlessReportNeverDeadlettered:
+    """A HEADLESS gate report must be skipped, not judged against the
+    dispatch register, and must never be moved into receipt_deadletter/."""
+
+    def test_headless_report_skipped_not_deadlettered(self, tmp_path, state_dir):
+        # Empty register: if the scoping check did not fire, the filename-
+        # derived id would definitely miss the register and get dead-lettered.
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+
+        headless_dir = tmp_path / "unified_reports" / "headless"
+        headless_dir.mkdir(parents=True)
+        report = headless_dir / "20260706-153235-HEADLESS-codex_gate-pr-1026-c77770.md"
+        report.write_text(
+            "codex_gate result for PR 1026: PASS\nno dispatch id here at all\n",
+            encoding="utf-8",
+        )
+
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+
+        assert outcome == "skipped_non_dispatch"
+        assert result is None
+        assert report.exists(), "HEADLESS report must not be moved"
+        assert not (state_dir / "receipt_deadletter").exists(), (
+            "HEADLESS report must never reach the dead-letter path"
+        )
+
+    def test_panel_report_skipped_not_deadlettered(self, tmp_path, state_dir):
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        report = tmp_path / "panel-strategy-abcd1234.md"
+        report.write_text(
+            "# Deliberation panel — strategy\n\n## Synthesis (cited)\n\nfoo\n",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+        assert outcome == "skipped_non_dispatch"
+        assert result is None
+        assert report.exists()
+        assert not (state_dir / "receipt_deadletter").exists()
+
+    def test_worktree_release_report_skipped_not_deadlettered(self, tmp_path, state_dir):
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        report = tmp_path / "worktree-release-20260810-120000.md"
+        report.write_text("=== Worktree Release [DRY-RUN] ===\n", encoding="utf-8")
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+        assert outcome == "skipped_non_dispatch"
+        assert result is None
+        assert report.exists()
+        assert not (state_dir / "receipt_deadletter").exists()
+
+    def test_skipped_non_dispatch_marked_processed_via_scan_and_convert(self, tmp_path, state_dir):
+        """scan_and_convert() must count it, mark it processed, and leave it
+        in place — visible via ScanStats, not silent."""
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        reports_dir = tmp_path / "unified_reports"
+        headless_dir = reports_dir / "headless"
+        headless_dir.mkdir(parents=True)
+        report = headless_dir / "20260706-153235-HEADLESS-codex_gate-pr-1026-c77770.md"
+        report.write_text("codex_gate result: PASS\n", encoding="utf-8")
+
+        stats = scan_and_convert([reports_dir, headless_dir], state_dir)
+
+        assert stats.skipped_non_dispatch_count == 1
+        assert stats.new_count == 0
+        assert stats.malformed_count == 0
+        assert report.exists()
+        assert not (state_dir / "receipt_deadletter").exists()
+        # attempted_count must NOT count skipped_non_dispatch — otherwise a
+        # scan cycle with ONLY headless reports would read as unhealthy.
+        assert stats.attempted_count == 0
+
+
+class TestOI1102PhantomStillDeadlettered:
+    """Regression guard: the guard OI-1102 was actually built for — a
+    dispatch-<id>.md report whose id exists ONLY in the filename and nowhere
+    in the content — must still be dead-lettered when unregistered."""
+
+    def test_filename_only_phantom_still_deadlettered(self, tmp_path, state_dir):
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        report = tmp_path / "dispatch-20260810-phantom-example.md"
+        report.write_text(_CONTRACT_BODY, encoding="utf-8")
+
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+        result, outcome = _convert_one_detailed(report, receipts_file=receipts_file)
+
+        assert result is None
+        deadletter_dir = state_dir / "receipt_deadletter"
+        assert deadletter_dir.exists(), "phantom report must be dead-lettered"
+        assert not report.exists(), "phantom report must be moved out of the source dir"
+        moved = list(deadletter_dir.glob("dispatch-20260810-phantom-example*.md"))
+        assert moved, f"expected a moved copy in {deadletter_dir}"
+
+
+# ---------------------------------------------------------------------------
+# Part 15: OI-1120 — markdown list-item Dispatch-ID form
+# ---------------------------------------------------------------------------
+
+class TestListItemDispatchIdForm:
+    """The report contract allows the id as a 'plain-text or bold field'; a
+    markdown list item (`- Dispatch-ID: x`) is within that instruction, so
+    the parser — not the workers — was wrong."""
+
+    @pytest.mark.parametrize("marker", ["-", "*"])
+    def test_extract_body_fields_accepts_list_item_form(self, marker):
+        text = f"{marker} Dispatch-ID: 20260810e-a-seattimeout-1444\n\n" + _CONTRACT_BODY
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260810e-a-seattimeout-1444"
+
+    def test_list_item_form_produces_receipt_with_correct_dispatch_id(self, tmp_path, state_dir):
+        # Empty register + a filename that does NOT match dispatch_id: if
+        # content extraction were still broken, the filename-derived
+        # fallback id ("some-other-report-name") would miss the empty
+        # register and get dead-lettered instead. Only a correctly
+        # extracted CONTENT dispatch_id makes this test pass — the id
+        # cannot coincidentally come from the filename.
+        (state_dir / "dispatch_register.ndjson").write_text("", encoding="utf-8")
+        dispatch_id = "20260810e-a-seattimeout-1444"
+        report = tmp_path / "some-other-report-name.md"
+        report.write_text(
+            f"- Dispatch-ID: {dispatch_id}\n\n{_CONTRACT_BODY}**Model**: sonnet\n",
+            encoding="utf-8",
+        )
+        receipts_file = str(state_dir / "t0_receipts.ndjson")
+
+        result = convert_report_to_receipt(report, receipts_file=receipts_file)
+
+        assert result is not None
+        assert result.status == "appended"
+        receipts = _receipts(state_dir)
+        assert len(receipts) == 1
+        assert receipts[0]["dispatch_id"] == dispatch_id
+        # content_id_valid is now True from the list-item form, so this must
+        # NOT be report_contract_invalid on the dispatch_id axis, and must
+        # never touch the dead-letter path.
+        assert not (state_dir / "receipt_deadletter").exists()
+
+    def test_diff_addition_line_does_not_false_positive_as_dispatch_id_key(self):
+        """A pasted unified-diff line adding a `dispatch_id: str` parameter
+        must not be mistaken for a Dispatch-ID stamp — '+' is deliberately
+        excluded from the marker class (see _DISPATCH_ID_KEY_RE comment)."""
+        text = "Some prose before.\n\n+        dispatch_id: str,\n\nMore prose after.\n"
+        fields = _extract_body_fields(text)
+        assert "dispatch_id" not in fields
+
+    def test_fenced_code_block_placeholder_is_a_known_pre_existing_gap(self):
+        """Neither regex is fence-aware — a placeholder in a ``` block already
+        matched pre-widening when unmarked (bare `Dispatch-ID: <id>`); this
+        widens WHICH shapes hit that same gap, not a new gap (fence-tracking
+        is out of scope). Regression pin, not a correctness claim — 0 real
+        collisions across 4411 reports scanned for this dispatch."""
+        text = (
+            "Example report shape:\n\n"
+            "```\n"
+            "- Dispatch-ID: <your-dispatch-id>\n"
+            "```\n\n" + _CONTRACT_BODY
+        )
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "<your-dispatch-id>"
+
+    def test_prose_sentence_mentioning_dispatch_id_does_not_match(self):
+        """A sentence that merely mentions 'Dispatch-ID' must not match —
+        the anchored ^...$ line match requires the whole line to be the
+        marker + label + value, not a substring within prose."""
+        text = (
+            "- A branch named `dispatch/<dispatch-id>`, pushed to origin.\n"
+            "- A completion report with the `Dispatch-ID` field included.\n"
+            + _CONTRACT_BODY
+        )
+        fields = _extract_body_fields(text)
+        assert "dispatch_id" not in fields


### PR DESCRIPTION
## Summary

Two fixes to `report_to_receipt_converter.py`, both scoped to OI-1120 part 1:

1. **Scope the dispatch-register cross-check to actual dispatch reports.** The
   guard that dead-letters an unrecognised `dispatch_id` never distinguished
   dispatch reports from tool output. Measured against the live dead-letter
   directory (221 files, 2026-08-10): 198 HEADLESS gate reports, 3 panel
   reports, 5 worktree-release reports — 206 of 221 — are producers that never
   carry a dispatch_id and were never dispatch reports. Classification uses
   producer-controlled evidence: HEADLESS reports live in a dedicated
   `unified_reports/headless/` directory (`review_gate_manager.headless_reports_dir`,
   set from `VNX_HEADLESS_REPORTS_DIR`); `panel.py` and `worktree_release.py`
   share the top-level directory with real dispatch reports, so their writer-owned
   filename prefixes (`panel-`, `worktree-release-`) are the only available
   signal — both are hardcoded literal templates in those writers, not guessed
   shapes. Non-dispatch reports are now skipped before the register check —
   logged, counted (new `ScanStats.skipped_non_dispatch_count`, deliberately
   excluded from `attempted_count` so an all-headless scan cycle doesn't read as
   unhealthy), left in place — never dead-lettered, no second quarantine dir.

2. **Accept the markdown list-item Dispatch-ID form.** `_DISPATCH_PLAIN_RE`
   required `Dispatch-ID:` at the start of the line, so `- Dispatch-ID: x` —
   explicitly within the report contract's "plain-text or bold field"
   instruction — never matched, sending three real, contract-clean dispatch
   reports (PRs #1441/#1443/#1444, already merged) to quarantine. Widened to
   tolerate an optional `-`/`*` list marker. `+` is deliberately excluded: it
   collided with pasted unified-diff lines in the real corpus (e.g.
   `+        dispatch_id: str,` — a function signature, not an id stamp).

## Changes

- `scripts/lib/report_to_receipt_converter.py`:
  - `_classify_non_dispatch_report()` — new pure classifier keyed on producer-
    controlled directory placement / filename prefix.
  - `_convert_one_detailed()` — classifies before any receipt-building work;
    returns a new `"skipped_non_dispatch"` outcome tag.
  - `ScanStats.skipped_non_dispatch_count` — new counter, excluded from
    `attempted_count`'s health-check sum.
  - `scan_and_convert()` — marks skipped-non-dispatch reports processed
    (the classification is permanent — a `panel-*.md` report never becomes a
    dispatch report on a later scan), surfaces the count via the health
    beacon and `main()`'s log line.
  - `_DISPATCH_PLAIN_RE` / `_DISPATCH_ID_KEY_RE` — widened to
    `^\s*(?:[-*]\s+)?Dispatch-ID:\s*(\S+)\s*$` (and lowercase `dispatch_id:`
    variant).
- `tests/test_report_to_receipt_converter.py`: new coverage for both changes
  plus an OI-1102 regression guard (see Verification).

## Verification

Targeted suite: `python3 -m pytest tests/test_report_to_receipt_converter.py tests/test_report_parser_model_provider.py tests/test_receipt_processor_deadletter.py tests/test_headless_review_receipt.py tests/test_backfill_headless_receipts.py tests/test_report_extraction.py -q`
→ **239 passed**, 1 pre-existing unrelated warning.

**Out/red/in/green — change 1 (scoping):** reverted the `_classify_non_dispatch_report`
short-circuit in `_convert_one_detailed`, ran the new `TestHeadlessReportNeverDeadlettered`
+ `TestOI1102PhantomStillDeadlettered` classes → `4 failed, 1 passed` (all three
producer types got dead-lettered as before; the OI-1102 regression test still
passed, confirming it's independent). Restored the fix → `5 passed`.

**Out/red/in/green — change 2 (regex):** reverted `_DISPATCH_PLAIN_RE`/`_DISPATCH_ID_KEY_RE`
to the unwidened pattern, ran `TestListItemDispatchIdForm` → `4 failed, 2 passed`
(list-item extraction and the receipt-production test — deliberately built so
the filename can't coincidentally supply the right id — both failed as expected).
Restored the fix → `6 passed`.

**Measured count against a copy of the real dead-letter directory**
(`~/.vnx-data/vnx-dev/state/receipt_deadletter/`, 221 files, copied — not
mutated — reconstructed into `unified_reports/` + `unified_reports/headless/`
matching each producer's actual write location, then run through the real,
current `dispatch_register.ndjson` via `scan_and_convert()`):

| outcome | count |
|---|---|
| `skipped_non_dispatch` (206 = 198 HEADLESS + 3 panel + 5 worktree-release) | 206 |
| still dead-lettered (genuinely no parseable content id + unregistered filename id — includes 8 reports using a *different*, out-of-scope `**Dispatch-ID:**` bold variant where the colon sits inside the closing markers, and reports with no id field at all) | 11 |
| correctly recognised as dispatch reports, not dead-lettered, but rejected by an *unrelated* fail-closed gate (missing Model field) — includes the 3 list-item-form reports named in the dispatch (#1441/#1443/#1444) | 4 |

206 + 11 + 4 = 221. The 3 named list-item reports are confirmed no longer
dead-lettered — they now fail a separate, pre-existing "missing model" check
instead, which is outside this PR's scope.

**OI-1102 regression** (the guard's original target: `dispatch-<id>.md` where
the id exists ONLY in the filename, nowhere in content) — confirmed still
dead-lettered when unregistered: `TestOI1102PhantomStillDeadlettered::test_filename_only_phantom_still_deadlettered` passes green.

**Regex over-matching check:** grepped the widened pattern against 4411 real
report files (unified_reports/, headless/, and the dead-letter copy). With `+`
included: 2 false positives (pasted diff lines matching as fake id stamps) —
tightened to `[-*]` only, re-ran: 0 false positives, all 5 genuine list-item
stamps in the corpus still matched. A residual, pre-existing (not newly
introduced) fence-unaware gap is documented and pinned by
`test_fenced_code_block_placeholder_is_a_known_pre_existing_gap`.

No frontmatter/merge conflicts — branch was already up to date with `origin/main`.

## Open Items

- The `**Dispatch-ID:**` bold-field variant (colon inside the closing `**`,
  e.g. `**Dispatch-ID:** value` vs. the matched `**Dispatch-ID**: value`) is a
  third, separate parsing bug affecting 8 of the 15 real dispatch reports in
  the current dead-letter corpus. Not in this dispatch's scope (only the
  list-item form was requested) — flagging for a follow-up.
- Replaying the 221 already-quarantined files is explicitly out of scope per
  the dispatch (timestamp-provenance decision, OI-1092) — left untouched.