### PR TITLE
fix(dispatch): fill dispatch_register at door fire time (OI-1120 part 2)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1411,6 +1411,75 @@ def _execute_claude_headless(
 
 
 # ---------------------------------------------------------------------------
+# OI-1120 part 2 — dispatch register fill (the guard's reference source)
+# ---------------------------------------------------------------------------
+
+def _register_dispatch_created(
+    plan: ExecutionPlan,
+    permit: ExecutionPermit,
+    spec: DispatchSpec,
+    *,
+    state_dir: Path,
+) -> None:
+    """Emit ``dispatch_created`` to the register at the moment the door
+    commits to firing (permit issued, about to invoke the lane).
+
+    OI-1105/OI-1120: none of the four lanes (tmux-spawn, provider, envelope,
+    subprocess adapter) ever wrote this event, so
+    ``report_to_receipt_converter._is_known_dispatch`` — the guard that cross-
+    checks a report's dispatch_id against the register — had almost nothing
+    to check against. One write site here, before the lane branch, covers
+    every lane (``provider``, ``claude_tmux_subscription``, ``claude_headless``)
+    so a future lane inherits the register entry for free instead of needing
+    its own hook.
+
+    Idempotent via ``dispatch_register.append_event_idempotent`` and never
+    blocks the door: a register-write failure is an observability gap, not a
+    reason to refuse work. The one exception is ``TestIsolationGuardError``
+    (OI-1079), which must propagate so a test that lost its isolation fails
+    loudly instead of silently writing into the real central store — the
+    same contract ``dispatch_register.append_event`` already enforces
+    internally; this call site must not re-swallow it.
+
+    Deliberately omits ``project_id`` (no cross-project central-mirror
+    write): ``state_dir`` here is already the door's own ADR-026-resolved
+    per-project authority (``_resolve_data_dir`` / ``_authority_from_spec_path``),
+    the same single write target ``_persist_route_decision`` and
+    ``_persist_dispatch_row`` use. Passing ``project_id`` would additionally
+    ask the register to mirror into ``~/.vnx-data/<project_id>`` — redundant
+    in production (that IS ``state_dir`` there, so the mirror's own
+    cutover guard no-ops it) and, under pytest with an isolated tmp
+    ``state_dir``, indistinguishable from the exact leak class OI-1079
+    closed even though this write was never headed to production.
+    """
+    from vnx_paths import TestIsolationGuardError  # noqa: PLC0415
+    try:
+        import dispatch_register  # noqa: PLC0415
+        from gate_obligations import pr_number_from_pr_id  # noqa: PLC0415
+        dispatch_register.append_event_idempotent(
+            "dispatch_created",
+            dispatch_id=plan.dispatch_id,
+            pr_number=pr_number_from_pr_id(spec.pr_id),
+            terminal=spec.target_slot,
+            gate=spec.gate,
+            extra={
+                "lane": plan.lane,
+                "provider": plan.provider.value,
+                "model": plan.model,
+                "permit_fingerprint": f"{permit.plan_digest[:12]}-{permit.dispatch_id}",
+            },
+            state_dir=state_dir,
+        )
+    except TestIsolationGuardError:  # vnx-silent-except: OI-1079 — must fail the test loudly, never swallowed here
+        raise
+    except Exception as exc:  # vnx-silent-except: register bookkeeping must never block the door; dispatch_created is observability, not a gate
+        logger.warning(
+            "[dispatch_cli] WARN dispatch_created register emit failed for dispatch=%s: %s",
+            plan.dispatch_id, exc,
+        )
+
+
+# ---------------------------------------------------------------------------
 # OI-849 — route decision persistence
 # ---------------------------------------------------------------------------
 
@@ -1653,8 +1722,11 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
         # OI-849: persist the full canonical routing decision alongside the
         # permit fingerprint so "which model got this task and why" is
         # answerable after the fact. Best-effort — never blocks the door.
+        # OI-1120 part 2: fill the register's dispatch_created event here too —
+        # same "door commits to firing" moment, one write site for every lane.
         if not dry_run:
             _persist_route_decision(plan, permit, state_dir=state_dir)
+            _register_dispatch_created(plan, permit, vspec.spec, state_dir=state_dir)
 
         if dry_run:
             _print_plan(plan, fp)

--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -71,14 +71,25 @@ VALID_EVENTS = {
 }
 
 
-def _register_path() -> Path:
+def _register_path(state_dir: Optional[Path] = None) -> Path:
     """Resolve dispatch_register.ndjson via canonical vnx_paths resolver.
 
-    Fallback precedence (when canonical resolver unavailable):
+    ``state_dir``, when given, is authoritative and skips ambient resolution
+    entirely — mirrors the override ``read_events`` already accepts (OI-1120
+    part 2), so a caller that has already resolved its own state_dir (e.g. the
+    dispatch door, which derives it from the staged bundle's physical
+    location per ADR-026) writes to the exact same path it reads from,
+    instead of risking a second, independent ambient resolution drifting
+    from the first.
+
+    Fallback precedence (when state_dir is not given and the canonical
+    resolver is unavailable):
     1. VNX_STATE_DIR (if set) — use directly as state dir
     2. VNX_DATA_DIR + state subdir (only when VNX_DATA_DIR_EXPLICIT=1)
     3. Repo-relative .vnx-data/state
     """
+    if state_dir is not None:
+        return Path(state_dir) / "dispatch_register.ndjson"
     try:
         scripts_lib = str(_REPO_ROOT / "scripts" / "lib")
         if scripts_lib not in sys.path:
@@ -123,8 +134,8 @@ def _parse_iso(ts: str) -> Optional[_dt.datetime]:
         return None
 
 
-def _resolve_register_path() -> Path:
-    path = _register_path()
+def _resolve_register_path(state_dir: Optional[Path] = None) -> Path:
+    path = _register_path(state_dir=state_dir)
     path.parent.mkdir(parents=True, exist_ok=True)
     return path
 
@@ -312,11 +323,13 @@ def append_event(
     project_id: Optional[str] = None,
     orchestrator_id: Optional[str] = None,
     agent_id: Optional[str] = None,
+    state_dir: Optional[Path] = None,
 ) -> bool:
     """Append a lifecycle event. Returns True on success, False on any failure.
 
-    Best-effort: never raises. Intended for use as a fire-and-forget hook
-    where caller flow must not break on register write failure.
+    Best-effort: never raises (except ``TestIsolationGuardError`` — see
+    below). Intended for use as a fire-and-forget hook where caller flow
+    must not break on register write failure.
 
     Optional ``operator_id`` / ``project_id`` / ``orchestrator_id`` /
     ``agent_id`` arguments stamp a four-tuple identity onto the event.
@@ -324,6 +337,10 @@ def append_event(
     if resolution fails the event is written without those fields (legacy
     behaviour). Existing callers that pass none of these arguments continue
     to work unchanged.
+
+    ``state_dir``, when given, overrides ambient path resolution for the
+    primary write (see ``_register_path``) — the same override ``read_events``
+    already accepts.
     """
     if event not in VALID_EVENTS:
         return False
@@ -347,7 +364,7 @@ def append_event(
         agent_id=agent_id,
     )
     try:
-        primary_path = _resolve_register_path()
+        primary_path = _resolve_register_path(state_dir=state_dir)
         _write_event_locked(primary_path, record)
         _mirror_to_decision_log(event, record, extra=extra)
         # Phase 6 P3 dual-write: mirror to central when project_id is known
@@ -361,6 +378,74 @@ def append_event(
         raise
     except Exception:
         return False
+
+
+def _event_identity(event: dict) -> tuple[str, str, str]:
+    """The non-timestamp portion of ``_merge_dedup_key``.
+
+    Two records sharing this identity describe the same real-world
+    occurrence regardless of when each was written — the timestamp is the
+    only field ``_merge_dedup_key`` includes that a retry naturally varies.
+    """
+    return _merge_dedup_key(event)[1:]
+
+
+def append_event_idempotent(
+    event: str,
+    *,
+    dispatch_id: str = "",
+    pr_number: Optional[int] = None,
+    feature_id: str = "",
+    terminal: str = "",
+    gate: str = "",
+    extra: Optional[dict] = None,
+    operator_id: Optional[str] = None,
+    project_id: Optional[str] = None,
+    orchestrator_id: Optional[str] = None,
+    agent_id: Optional[str] = None,
+    state_dir: Optional[Path] = None,
+) -> bool:
+    """``append_event``, but a no-op when an equivalent event already exists.
+
+    OI-1120 part 2: a retry or fix-forward that fires the same dispatch_id
+    twice through the door must not create a second ``dispatch_created``
+    record — that would give ``report_to_receipt_converter._is_known_dispatch``
+    two rows to reconcile per id instead of one. Reuses the identity
+    ``_merge_dedup_key`` already defines for read-side merge-dedup
+    (event, dispatch_id, pr_number, feature_id), evaluated at write time
+    instead of read time, rather than inventing a second dedup scheme.
+
+    The pre-check is best-effort: a failed read falls through to the normal
+    ``append_event`` attempt (better a possible duplicate than a lost event).
+    Returns True when the event is present after the call — whether it was
+    already there or newly written — False only on a genuine write failure.
+    """
+    identity = _event_identity({
+        "event": event,
+        "dispatch_id": dispatch_id,
+        "pr_number": pr_number,
+        "feature_id": feature_id,
+    })
+    try:
+        for existing in read_events(state_dir=state_dir):
+            if _event_identity(existing) == identity:
+                return True
+    except Exception:  # vnx-silent-except: pre-check is best-effort; fall through to the real append attempt
+        pass
+    return append_event(
+        event,
+        dispatch_id=dispatch_id,
+        pr_number=pr_number,
+        feature_id=feature_id,
+        terminal=terminal,
+        gate=gate,
+        extra=extra,
+        operator_id=operator_id,
+        project_id=project_id,
+        orchestrator_id=orchestrator_id,
+        agent_id=agent_id,
+        state_dir=state_dir,
+    )
 
 
 def _log_dispatch_created(log_fn, record: dict, extra_dict: dict) -> None:

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -31,6 +31,7 @@ from dispatch_cli import (
     _load_model_pins_from_yaml,
     _persist_route_decision,
     _persist_track_id,
+    _register_dispatch_created,
     _tracks_db_path,
     build_runtime_snapshot,
     fingerprint,
@@ -2781,6 +2782,152 @@ class TestPersistRouteDecision:
         assert record["decision"]["provider"] == "codex"
         assert record["decision"]["lane"] == "provider"
         assert record["decision"]["billing"] == "provider_metered"
+
+
+# ---------------------------------------------------------------------------
+# OI-1120 part 2 — dispatch register fill (the guard's reference source)
+# ---------------------------------------------------------------------------
+
+class TestRegisterDispatchCreated:
+    """_register_dispatch_created fills the register at the moment the door
+    commits to firing — the fix for the vacuous _is_known_dispatch guard."""
+
+    def _reg_lines(self, state_dir: Path) -> list[dict]:
+        reg = state_dir / "dispatch_register.ndjson"
+        if not reg.exists():
+            return []
+        return [json.loads(ln) for ln in reg.read_text(encoding="utf-8").splitlines() if ln.strip()]
+
+    def _make_spec(self, plan: ExecutionPlan, **overrides) -> DispatchSpec:
+        kwargs = dict(
+            schema_version=1, project_id="vnx-dev", dispatch_id=plan.dispatch_id,
+            staging_id="s", instruction_file=Path("/tmp/i.md"), role="backend-developer",
+            target_slot="T1", gate="human-promoted", dispatch_paths=(),
+        )
+        kwargs.update(overrides)
+        return DispatchSpec(**kwargs)
+
+    def test_writes_dispatch_created_record(self, tmp_path):
+        """Direct-drive proof: a real write lands on disk, not just a call."""
+        plan = _make_minimal_plan(dispatch_id="20260810-oi1120-direct")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+
+        _register_dispatch_created(plan, permit, self._make_spec(plan), state_dir=state_dir)
+
+        recs = self._reg_lines(state_dir)
+        assert len(recs) == 1
+        assert recs[0]["event"] == "dispatch_created"
+        assert recs[0]["dispatch_id"] == "20260810-oi1120-direct"
+        assert recs[0]["terminal"] == "T1"
+        assert recs[0]["extra"]["lane"] == "claude_tmux_subscription"
+        assert recs[0]["extra"]["provider"] == "claude"
+        assert recs[0]["extra"]["model"] == "sonnet"
+        assert recs[0]["extra"]["permit_fingerprint"] == f"{permit.plan_digest[:12]}-{permit.dispatch_id}"
+
+    def test_idempotent_across_two_calls(self, tmp_path):
+        """Proof of idempotency at the door-hook level: firing the same
+        dispatch id twice (retry / fix-forward) holds one created-event."""
+        plan = _make_minimal_plan(dispatch_id="20260810-oi1120-retry")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+        spec = self._make_spec(plan)
+
+        _register_dispatch_created(plan, permit, spec, state_dir=state_dir)
+        _register_dispatch_created(plan, permit, spec, state_dir=state_dir)
+
+        recs = [r for r in self._reg_lines(state_dir) if r["dispatch_id"] == "20260810-oi1120-retry"]
+        assert len(recs) == 1, f"expected exactly one record, got {len(recs)}: {recs}"
+
+    def test_write_failure_does_not_raise(self, caplog):
+        """A register-write problem is an observability gap, not a reason to
+        refuse work — the door must proceed regardless."""
+        import logging
+
+        plan = _make_minimal_plan(dispatch_id="20260810-oi1120-fail")
+        permit = issue_permit(plan)
+
+        with patch("dispatch_register.append_event_idempotent", side_effect=OSError("disk full")):
+            with caplog.at_level(logging.WARNING):
+                _register_dispatch_created(
+                    plan, permit, self._make_spec(plan), state_dir=Path("/nonexistent"),
+                )
+
+        assert any("dispatch_created register emit failed" in rec.message for rec in caplog.records), (
+            "write failure must log a WARN — silence hides the same class of "
+            "gap OI-1105 already found once"
+        )
+
+    def test_called_during_run_dispatch_claude_lane(self, tmp_path, monkeypatch):
+        """run_dispatch (non-dry-run, claude_tmux_subscription lane) fires the
+        register hook and a real record lands under the door's own state_dir."""
+        data_dir, spec_file = _make_bundle_spec(
+            tmp_path,
+            instruction_text="# Register fill test\n\nDo something safe.\n",
+            staging_id="20260810-staging-oi1120",
+            dispatch_id="20260810-oi1120-integration",
+            target_slot="T0",
+        )
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_exec:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0
+        mock_exec.assert_called_once()
+        recs = self._reg_lines(data_dir / "state")
+        created = [r for r in recs if r["event"] == "dispatch_created"
+                   and r["dispatch_id"] == "20260810-oi1120-integration"]
+        assert len(created) == 1
+
+    def test_run_dispatch_completes_when_register_write_fails(self, tmp_path, monkeypatch):
+        """A broken register write must not fail the dispatch itself — the
+        lane still runs and run_dispatch still returns 0."""
+        data_dir, spec_file = _make_bundle_spec(
+            tmp_path,
+            instruction_text="# Register fill failure test\n\nDo something safe.\n",
+            staging_id="20260810-staging-oi1120-fail",
+            dispatch_id="20260810-oi1120-write-fail",
+            target_slot="T0",
+        )
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with patch("dispatch_register.append_event_idempotent", side_effect=OSError("disk full")):
+            with patch("dispatch_cli._execute_claude", return_value=0) as mock_exec:
+                rc = run_dispatch(spec_file)
+
+        assert rc == 0, "a register-write failure must not block the dispatch"
+        mock_exec.assert_called_once()
+
+    def test_provider_lane_also_registers(self, tmp_path):
+        """Lane-agnostic: a provider-lane (codex) dispatch registers too — the
+        write site sits before the lane branch, not inside one lane's code."""
+        plan = _make_minimal_plan(provider=Provider.CODEX, dispatch_id="20260810-oi1120-codex")
+        permit = issue_permit(plan)
+        state_dir = tmp_path / "state"
+
+        _register_dispatch_created(
+            plan, permit, self._make_spec(plan, provider=Provider.CODEX), state_dir=state_dir,
+        )
+
+        recs = self._reg_lines(state_dir)
+        assert len(recs) == 1
+        assert recs[0]["extra"]["lane"] == "provider"
+        assert recs[0]["extra"]["provider"] == "codex"
+
+    def test_not_called_during_dry_run(self, tmp_path):
+        """Dry-run dispatches must NOT write a register entry — only live
+        dispatches should persist state (mirrors _persist_route_decision)."""
+        spec_file = _make_spec_file(tmp_path, provider="claude")
+
+        with patch("dispatch_cli.build_runtime_snapshot", return_value=_clean_snapshot()):
+            with patch("dispatch_cli._register_dispatch_created") as mock_register:
+                rc = run_dispatch(spec_file, dry_run=True)
+
+        assert rc == 0
+        mock_register.assert_not_called()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -427,6 +427,71 @@ class TestAppendEventIdRequirement:
 
 
 # ---------------------------------------------------------------------------
+# OI-1120 part 2 — append_event_idempotent + state_dir override
+# ---------------------------------------------------------------------------
+
+class TestAppendEventStateDirOverride:
+    """``state_dir`` bypasses ambient resolution for both write and read."""
+
+    def test_writes_to_explicit_state_dir_not_ambient(self, isolated_data_dir, tmp_path):
+        """An explicit state_dir writes there, NOT to the env-resolved ambient path."""
+        explicit_dir = tmp_path / "explicit-state"
+        result = append_event("dispatch_created", dispatch_id="d-explicit", state_dir=explicit_dir)
+        assert result is True
+        assert (explicit_dir / "dispatch_register.ndjson").exists()
+        assert not _reg_path(isolated_data_dir).exists()
+
+
+class TestAppendEventIdempotent:
+    """append_event_idempotent: a retry for the same identity is a no-op."""
+
+    def test_first_call_writes(self, isolated_data_dir):
+        result = dispatch_register.append_event_idempotent(
+            "dispatch_created", dispatch_id="d-idem-001",
+        )
+        assert result is True
+        reg = _reg_path(isolated_data_dir)
+        assert len(reg.read_text().splitlines()) == 1
+
+    def test_second_call_same_dispatch_id_is_noop(self, isolated_data_dir):
+        """OI-1120: firing the same dispatch id twice must not create a
+        duplicate dispatch_created record — this IS the idempotency proof."""
+        first = dispatch_register.append_event_idempotent(
+            "dispatch_created", dispatch_id="d-idem-002",
+        )
+        second = dispatch_register.append_event_idempotent(
+            "dispatch_created", dispatch_id="d-idem-002",
+        )
+        assert first is True
+        assert second is True
+        reg = _reg_path(isolated_data_dir)
+        lines = reg.read_text().splitlines()
+        assert len(lines) == 1, f"expected exactly one record, got {len(lines)}: {lines}"
+        rec = json.loads(lines[0])
+        assert rec["dispatch_id"] == "d-idem-002"
+
+    def test_different_dispatch_id_writes_separately(self, isolated_data_dir):
+        """Idempotency is per-identity, not global — a different dispatch_id
+        still gets its own record."""
+        dispatch_register.append_event_idempotent("dispatch_created", dispatch_id="d-idem-a")
+        dispatch_register.append_event_idempotent("dispatch_created", dispatch_id="d-idem-b")
+        reg = _reg_path(isolated_data_dir)
+        ids = {json.loads(line)["dispatch_id"] for line in reg.read_text().splitlines()}
+        assert ids == {"d-idem-a", "d-idem-b"}
+
+    def test_precheck_read_failure_falls_through_to_append(self, isolated_data_dir):
+        """A broken pre-check read must not block the write — better a
+        possible duplicate than a lost event."""
+        with patch("dispatch_register.read_events", side_effect=OSError("boom")):
+            result = dispatch_register.append_event_idempotent(
+                "dispatch_created", dispatch_id="d-idem-preread-fail",
+            )
+        assert result is True
+        reg = _reg_path(isolated_data_dir)
+        assert len(reg.read_text().splitlines()) == 1
+
+
+# ---------------------------------------------------------------------------
 # Wave 1 shadow-mode tests — VNX_USE_CENTRAL_DB flag (PR-W1.4)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dispatch_register_state_writer_integration.py
+++ b/tests/test_dispatch_register_state_writer_integration.py
@@ -19,7 +19,7 @@ def test_append_event_delegates_to_state_writer(
     path = tmp_path / "dispatch_register.ndjson"
     captured: list[tuple[Path, dict]] = []
 
-    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda: path)
+    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda state_dir=None: path)
     monkeypatch.setattr(dispatch_register, "_resolve_identity_for_register", lambda: {})
     monkeypatch.setattr(dispatch_register, "_mirror_to_decision_log", lambda *args, **kwargs: None)
     monkeypatch.setattr(
@@ -45,7 +45,7 @@ def test_dispatch_register_public_api_preserved(
 ) -> None:
     path = tmp_path / "dispatch_register.ndjson"
 
-    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda: path)
+    monkeypatch.setattr(dispatch_register, "_resolve_register_path", lambda state_dir=None: path)
     monkeypatch.setattr(dispatch_register, "_resolve_identity_for_register", lambda: {})
     monkeypatch.setattr(dispatch_register, "_mirror_to_decision_log", lambda *args, **kwargs: None)
 
@@ -63,6 +63,8 @@ def test_dispatch_register_public_api_preserved(
     lines = path.read_text(encoding="utf-8").splitlines()
     assert len(lines) == 1
     record = json.loads(lines[0])
+    record_id = record.pop("record_id", None)
+    assert isinstance(record_id, str) and record_id
     assert record == {
         "timestamp": record["timestamp"],
         "event": "gate_passed",


### PR DESCRIPTION
## Summary

`report_to_receipt_converter._is_known_dispatch` treats `dispatch_register.ndjson` as
authoritative, but no lane the single-entry door can select ever wrote `dispatch_created`
to it. Measured today (read-only, against the real central register/ledger): 260 unique
dispatch ids in the register vs. 6010 unique ids in the receipt ledger (~4.3% coverage,
matching the worker's independent measurement in the dispatch instruction almost exactly).
Of the register's 81 existing `dispatch_created` rows, **all 81** share the same synthetic
smoke-test id `d-001` (2026-05-07 through 2026-08-09) — real coverage is 0%, not 81 events'
worth.

## What changed

- `scripts/lib/dispatch_register.py`: `_register_path`/`_resolve_register_path`/`append_event`
  gain an optional `state_dir` override (mirrors the override `read_events` already had), and a
  new `append_event_idempotent` wrapper reuses `_merge_dedup_key`'s identity (event,
  dispatch_id, pr_number, feature_id — timestamp dropped) to skip a duplicate write on retry.
- `scripts/lib/dispatch_cli.py`: new `_register_dispatch_created`, called once in `run_dispatch`
  right after the permit is issued and before the lane branch — covers every lane
  (`provider`, `claude_tmux_subscription`, `claude_headless`) from one site. Never blocks the
  door (broad except + WARN log), except `TestIsolationGuardError` (OI-1079), which propagates.
  Deliberately does not pass `project_id` (no central-mirror write) — `state_dir` is already the
  door's own ADR-026-resolved authority, and passing `project_id` tripped the OI-1079 guard on
  ~40 existing tests for a write that was never headed to production.

## Verification

- Targeted suite: 252 passed (`test_dispatch_cli.py`, all `test_dispatch_register*.py`).
- `python3 scripts/check_no_file_derived_data_paths.py` — PASS.
- `python3 scripts/ci_lint_patterns.py` (added lines) — 0 findings.
- RED→GREEN: reverted the two source files, new tests failed (ImportError /
  AttributeError), reapplied, all green.
- Idempotency proven at both layers (`append_event_idempotent` unit test, `_register_dispatch_created`
  integration test): firing the same dispatch_id twice leaves exactly one `dispatch_created` row.
- Failure-resilience proven at both layers: register write raises → `run_dispatch` still returns 0
  and the lane executor still runs.
- Real `bin/vnx dispatch <id> --dry-run` against a throwaway staged bundle: exit 0, register file
  never created — confirms the write is fire-time only, not dry-run. Fire-time path proven via
  `run_dispatch(spec_file)` (non-dry-run, lane executor mocked) reading the real NDJSON afterward.

## Note for reviewer

The worktree this dispatch was assigned (`dispatch-20260810g-d-provider-auto`) does not match
this dispatch's own id (`20260810g-b-register-fill`). A separate, dedicated worktree/branch
(`dispatch-20260810g-b-register-fill`) already exists with a **different, uncommitted**
implementation of the same fix (uses `append_event_once` instead of `append_event_idempotent`,
threads `project_id` through, converts `plan.pr_id` via bare `int()`). That worktree was left
untouched — no writes, no cherry-pick, no cleanup — since it's unclear whether it's stale or an
active parallel run. Flagging for T0 to reconcile/decide which implementation (or worktree)
should move forward; do not merge both.

Dispatch-ID: 20260810g-b-register-fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)