### PR TITLE
fix(isolation): worktree isolation default-on, HEAD-jump detector, teardown-test root-cause fix (OI-1090, OI-975, round 4)

### DIFF
--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -1,6 +1,6 @@
 """dispatch_worktree_isolation.py — per-dispatch ephemeral git worktree.
 
-Feature-flag gated: only active when VNX_ISOLATED_WORKTREE=1.
+Always active (default-on since OI-1090, 2026-08-10).
 Each dispatch gets a fresh worktree rooted at origin/main under
 .vnx-data/worktrees/dispatch-{safe_id}/.  The worktree is removed
 (success OR failure) so no state leaks between dispatches.
@@ -184,6 +184,7 @@ def _write_claim_atomic(
     base_sha: str = "",
     base_ref: str = "",
     branch: str = "",
+    main_head_sha: str = "",
 ) -> dict:
     """Claim *worktree_path* for *dispatch_id* with an O_EXCL write.
 
@@ -196,6 +197,10 @@ def _write_claim_atomic(
     (L3 provider-lane reap): the claim carries enough metadata to construct a
     ``WorktreeHandle`` for ``tmux_worktree.classify()`` without re-deriving
     values that may have shifted since the worktree was created.
+
+    *main_head_sha* is the main checkout's HEAD captured before worktree
+    creation (OI-975): compared against the current HEAD at teardown to detect
+    unexpected checkout jumps during a dispatch.
     """
     safe_id = _sanitize_dispatch_id(dispatch_id)
     path = _claim_path(safe_id, project_root)
@@ -208,6 +213,7 @@ def _write_claim_atomic(
         "base_sha": base_sha,
         "base_ref": base_ref,
         "branch": branch,
+        "main_head_sha": main_head_sha,
     }
     try:
         with open(path, "x", encoding="utf-8") as fh:
@@ -517,6 +523,24 @@ def create_dispatch_worktree(
             f"{(exc.stderr or '').strip()}"
         ) from exc
 
+    # OI-975: capture the main checkout HEAD BEFORE worktree creation so
+    # teardown can detect unexpected checkout jumps during the dispatch.
+    # Best-effort — a failed capture logs a warning and the field defaults
+    # to "" in the claim, which skips the comparison at teardown.
+    _main_head_sha = ""
+    try:
+        _main_head_result = subprocess.run(
+            ["git", "-C", str(root), "rev-parse", "HEAD"],
+            check=True, capture_output=True, text=True,
+        )
+        _main_head_sha = _main_head_result.stdout.strip()
+    except subprocess.CalledProcessError:
+        log.warning(
+            "create_dispatch_worktree: cannot resolve HEAD for %s; "
+            "HEAD-jump detection skipped (OI-975)",
+            dispatch_id,
+        )
+
     with _worktree_lock(root):
         # OI-861 identity check BEFORE creating: if this worktree already exists
         # and is claimed by a DIFFERENT dispatch id, refuse immediately.  A
@@ -561,6 +585,7 @@ def create_dispatch_worktree(
         # may reuse it.  The claim carries base_sha + base_ref + branch so
         # teardown (L3 provider-lane reap) can construct a WorktreeHandle for
         # classification without re-deriving values that may have shifted.
+        # main_head_sha is the OI-975 pre-dispatch HEAD snapshot.
         try:
             _write_claim_atomic(
                 dispatch_id,
@@ -569,6 +594,7 @@ def create_dispatch_worktree(
                 base_sha=base_sha,
                 base_ref=base_ref,
                 branch=branch_name,
+                main_head_sha=_main_head_sha,
             )
         except WorktreeClaimError:
             raced = _read_claim(dispatch_id, root)
@@ -616,6 +642,38 @@ def remove_dispatch_worktree(
     claim = _read_claim(dispatch_id, root)
     if claim is not None:
         _claim_belongs_to_or_raise(dispatch_id, claim, wt_path)
+
+    # ── OI-975: detect HEAD jumps in the main checkout ─────────────────────
+    # Compare the main checkout HEAD captured at worktree creation against the
+    # current HEAD.  A difference means something (or someone) ran `git checkout`
+    # in the main checkout during this dispatch — a governance break because the
+    # main checkout's checked-out branch no longer matches what the dispatch was
+    # launched against.  This check is DEFAULT-PATH (no flag), best-effort
+    # (never raises), and namedrops the dispatch_id so the warning is traceable.
+    _claim_main_head = (claim or {}).get("main_head_sha", "")
+    if _claim_main_head:
+        try:
+            _current_head_result = subprocess.run(
+                ["git", "-C", str(root), "rev-parse", "HEAD"],
+                check=True, capture_output=True, text=True,
+            )
+            _current_head = _current_head_result.stdout.strip()
+            if _current_head and _current_head != _claim_main_head:
+                log.warning(
+                    "OI-975 HEAD-JUMP DETECTED: main checkout HEAD changed "
+                    "during dispatch %s: was %s, now %s — something ran "
+                    "'git checkout' in the main checkout while this dispatch "
+                    "was active",
+                    dispatch_id,
+                    _claim_main_head[:12],
+                    _current_head[:12],
+                )
+        except subprocess.CalledProcessError:
+            log.debug(
+                "remove_dispatch_worktree: cannot resolve current HEAD for %s; "
+                "HEAD-jump check skipped",
+                dispatch_id,
+            )
 
     # ── L3: classify before removing ──────────────────────────────────────
     # Build a WorktreeHandle from the claim so we can call the single

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1348,6 +1348,14 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         )
         end_time = datetime.now(timezone.utc)
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error or result.timed_out:
             status = "timeout" if result.timed_out else "failure"
             _emit_governance(
@@ -1368,8 +1376,13 @@ def _dispatch_claude_benchmark(args: argparse.Namespace) -> int:
         )
         return 0
     finally:
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_claude(args: argparse.Namespace) -> int:
@@ -1613,6 +1626,14 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         )
         end_time = datetime.now(timezone.utc)
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, "codex", model, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_codex failed: {result.error}", file=sys.stderr)
@@ -1634,10 +1655,13 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         _emit_governance(args, "codex", model, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        # Safety net: archive+clear when an unexpected exception bypassed
-        # _emit_governance (idempotent after a normal emit — see helper).
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_codex_via_envelope(args: argparse.Namespace) -> int:
@@ -2063,6 +2087,14 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
             )
         end_time = datetime.now(timezone.utc)
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, args.provider, model, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_litellm failed: {result.error}", file=sys.stderr)
@@ -2084,10 +2116,13 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         _emit_governance(args, args.provider, model, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        # Safety net: archive+clear when an unexpected exception bypassed
-        # _emit_governance (idempotent after a normal emit — see helper).
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_kimi(args: argparse.Namespace) -> int:
@@ -2158,6 +2193,14 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         )
         end_time = datetime.now(timezone.utc)
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, "kimi", model_label, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_kimi failed: {result.error}", file=sys.stderr)
@@ -2179,10 +2222,13 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         _emit_governance(args, "kimi", model_label, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        # Safety net: archive+clear when an unexpected exception bypassed
-        # _emit_governance (idempotent after a normal emit — see helper).
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
@@ -2275,6 +2321,14 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         end_time = datetime.now(timezone.utc)
         model_used = result.model or model
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, "deepseek-harness", model_used, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_deepseek_harness failed: {result.error}", file=sys.stderr)
@@ -2289,10 +2343,13 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         _emit_governance(args, "deepseek-harness", model_used, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        # Safety net: archive+clear when an unexpected exception bypassed
-        # _emit_governance (idempotent after a normal emit — see helper).
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_glm_harness(args: argparse.Namespace) -> int:
@@ -2338,6 +2395,15 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         )
         end_time = datetime.now(timezone.utc)
         model_used = result.model or model
+
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, "glm-harness", model_used, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_glm_harness failed: {result.error}", file=sys.stderr)
@@ -2352,8 +2418,13 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         _emit_governance(args, "glm-harness", model_used, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 def _dispatch_gemini(args: argparse.Namespace) -> int:
@@ -2404,6 +2475,14 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         )
         end_time = datetime.now(timezone.utc)
 
+        # OI-1090 teardown coupling: reap the worktree BEFORE _emit_governance
+        # so the provider_teardown_worktree event is archived with THIS
+        # dispatch (archive -> receipt -> clear) instead of straggling into
+        # the live ring buffer after the clear.  None marks it reaped so the
+        # finally path does not remove it twice.
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        isolation_worktree = None
+
         if result.error:
             _emit_governance(args, "gemini", model, result, start_time, end_time, "failure", event_store=event_store)
             print(f"spawn_gemini failed: {result.error}", file=sys.stderr)
@@ -2425,10 +2504,13 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         _emit_governance(args, "gemini", model, result, start_time, end_time, "success", event_store=event_store)
         return 0
     finally:
-        # Safety net: archive+clear when an unexpected exception bypassed
-        # _emit_governance (idempotent after a normal emit — see helper).
-        _event_store_safety_net(event_store, args)
+        # Reap the worktree FIRST (its provider_teardown_worktree event lands
+        # in the live buffer), then the safety net archives+clears — the ring
+        # buffer ends empty even when an unexpected exception bypassed
+        # _emit_governance.  Both calls are no-ops after a normal emit (the
+        # worktree was already reaped above; the live file is truncated).
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
+        _event_store_safety_net(event_store, args)
 
 
 _MLX_MODEL_MAP: dict[str, str] = {

--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1377,6 +1377,9 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
 
     Produces byte-identical NDJSON + receipt as direct subprocess_dispatch
     invocation — the delegation preserves all argument semantics unchanged.
+
+    OI-1090: always creates an isolated worktree so the worker never runs in
+    the main checkout, even when called outside the dispatch door.
     """
     # Benchmark mode (VNX_BENCH_SEED_MATERIALIZE=1): route claude through the
     # materialized-cell `claude -p` path so the benchmark scores it like the provider
@@ -1385,61 +1388,79 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
         return _dispatch_claude_benchmark(args)
 
     import subprocess_dispatch as sd
+    from subprocess_dispatch_internals.git_helpers import _set_active_worktree  # noqa: PLC0415
 
-    # OI-1107: fall back to Role: header in instruction, then to documented default.
-    role = args.role
-    if role is None:
-        role = sd._extract_role_from_instruction(args.instruction) or sd._ROLE_FALLBACK
-
-    dispatch_paths: list[str] | None = None
-    if args.dispatch_paths.strip():
-        dispatch_paths = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
-
-    start_time = datetime.now(timezone.utc)
-    ok = sd.deliver_with_recovery(
-        terminal_id=args.terminal_id,
-        instruction=args.instruction,
-        model=args.model,
-        dispatch_id=args.dispatch_id,
-        role=role,
-        max_retries=args.max_retries,
-        auto_commit=not args.no_auto_commit,
-        gate=args.gate,
-        dispatch_paths=dispatch_paths,
-        pr_id=args.pr_id,
-        total_deadline=float(args.deadline_seconds),
-    )
-    end_time = datetime.now(timezone.utc)
-
-    # Read token_usage and completion_text from delivery side-channels (populated by spawn_claude).
-    # recovery._resolve_token_usage_and_cost uses .get() to leave the entry
-    # available for this governance-receipt path; we .pop() here to clean up.
-    _claude_token_usage = None
-    _claude_completion_text = ""
+    # OI-1090: always create an isolated worktree before delegating to
+    # deliver_with_recovery, which resolves its CWD via _get_active_worktree().
+    isolation_worktree = None
     try:
-        from subprocess_dispatch_internals.delivery import (
-            _dispatch_completion_text as _ct_cache,
-            _dispatch_token_usage as _tu_cache,
+        isolation_worktree, _ = _prepare_provider_workdir(args)
+        _set_active_worktree(isolation_worktree)
+    except RuntimeError:
+        logger.error(
+            "claude dispatch isolation failed for %s — aborting", args.dispatch_id,
         )
-        _claude_token_usage = _tu_cache.pop(args.dispatch_id, None)
-        _claude_completion_text = _ct_cache.pop(args.dispatch_id, "")
-    except Exception as _tu_exc:
-        logger.debug("_dispatch_claude: side-channel read failed: %s", _tu_exc)
+        return 1
 
-    class _ClaudeResult:
-        completion_text = _claude_completion_text
-        token_usage = _claude_token_usage
+    try:
+        # OI-1107: fall back to Role: header in instruction, then to documented default.
+        role = args.role
+        if role is None:
+            role = sd._extract_role_from_instruction(args.instruction) or sd._ROLE_FALLBACK
 
-    status = "success" if ok else "failure"
-    _emit_governance(args, "claude", args.model, _ClaudeResult(), start_time, end_time, status)
-    return 0 if ok else 1
+        dispatch_paths: list[str] | None = None
+        if args.dispatch_paths.strip():
+            dispatch_paths = [p.strip() for p in args.dispatch_paths.split(",") if p.strip()]
+
+        start_time = datetime.now(timezone.utc)
+        ok = sd.deliver_with_recovery(
+            terminal_id=args.terminal_id,
+            instruction=args.instruction,
+            model=args.model,
+            dispatch_id=args.dispatch_id,
+            role=role,
+            max_retries=args.max_retries,
+            auto_commit=not args.no_auto_commit,
+            gate=args.gate,
+            dispatch_paths=dispatch_paths,
+            pr_id=args.pr_id,
+            total_deadline=float(args.deadline_seconds),
+        )
+        end_time = datetime.now(timezone.utc)
+
+        # Read token_usage and completion_text from delivery side-channels (populated by spawn_claude).
+        # recovery._resolve_token_usage_and_cost uses .get() to leave the entry
+        # available for this governance-receipt path; we .pop() here to clean up.
+        _claude_token_usage = None
+        _claude_completion_text = ""
+        try:
+            from subprocess_dispatch_internals.delivery import (
+                _dispatch_completion_text as _ct_cache,
+                _dispatch_token_usage as _tu_cache,
+            )
+            _claude_token_usage = _tu_cache.pop(args.dispatch_id, None)
+            _claude_completion_text = _ct_cache.pop(args.dispatch_id, "")
+        except Exception as _tu_exc:
+            logger.debug("_dispatch_claude: side-channel read failed: %s", _tu_exc)
+
+        class _ClaudeResult:
+            completion_text = _claude_completion_text
+            token_usage = _claude_token_usage
+
+        status = "success" if ok else "failure"
+        _emit_governance(args, "claude", args.model, _ClaudeResult(), start_time, end_time, status)
+        return 0 if ok else 1
+    finally:
+        _set_active_worktree(None)
+        _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
 def _create_provider_worktree(dispatch_id: str) -> Path:
     """Create an isolated worktree for a provider dispatch.
 
-    Only called when VNX_ISOLATED_WORKTREE=1.  Returns the worktree Path on
-    success, raises RuntimeError on failure — no shared-checkout fallback.
+    Always called (isolation default-on since OI-1090).  Returns the worktree
+    Path on success, raises RuntimeError on failure — no shared-checkout
+    fallback.
 
     Resolves the CONSUMER project root explicitly (dispatch_worktree_isolation.
     resolve_consumer_project_root) and threads it into create_dispatch_worktree
@@ -1461,26 +1482,28 @@ def _create_provider_worktree(dispatch_id: str) -> Path:
 def _prepare_provider_workdir(
     args: argparse.Namespace,
 ) -> tuple[Optional[Path], Optional[Path]]:
-    """Create isolation and, for benchmark cells, materialize the seed at CWD."""
-    isolation_worktree: Optional[Path] = None
-    if os.environ.get("VNX_ISOLATED_WORKTREE") == "1":
-        isolation_worktree = _create_provider_worktree(args.dispatch_id)
+    """Create isolation and, for benchmark cells, materialize the seed at CWD.
 
+    Always creates an isolated worktree (default-on since OI-1090).
+    Raises RuntimeError on failure — no shared-checkout fallback.
+    """
+    isolation_worktree = _create_provider_worktree(args.dispatch_id)
+
+    # VNX_BENCH_REQUIRE_ISOLATION: the benchmark's fail-closed assertion that
+    # isolation must be active.  Since isolation is now unconditional, this
+    # check is a belt-and-suspenders guard — it only fires when _create_provider_worktree
+    # returned without raising but somehow produced None (an invariant violation).
     if (
         os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1"
         and isolation_worktree is None
     ):
         raise RuntimeError(
-            "benchmark provider isolation required but worktree creation failed; "
-            "refusing shared main checkout"
+            "benchmark provider isolation required but worktree creation returned None; "
+            "refusing shared main checkout (invariant violation)"
         )
 
     worker_cwd = isolation_worktree
     if os.environ.get("VNX_BENCH_SEED_MATERIALIZE") == "1":
-        if isolation_worktree is None:
-            raise RuntimeError(
-                "benchmark seed materialization requires an isolated provider worktree"
-            )
         from benchmark_worker_isolation import materialize_benchmark_seed  # noqa: PLC0415
 
         worker_cwd = materialize_benchmark_seed(
@@ -1488,10 +1511,7 @@ def _prepare_provider_workdir(
             _resolve_dispatch_paths(args.dispatch_paths),
         )
 
-    if (
-        isolation_worktree is not None
-        and os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1"
-    ):
+    if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
         print(f"VNX_PROVIDER_WORKDIR={isolation_worktree}", file=sys.stderr)
     return isolation_worktree, worker_cwd
 
@@ -1575,7 +1595,7 @@ def _dispatch_codex(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )
@@ -2006,7 +2026,7 @@ def _dispatch_litellm(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )
@@ -2112,7 +2132,7 @@ def _dispatch_kimi(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )
@@ -2236,7 +2256,7 @@ def _dispatch_deepseek_harness(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )
@@ -2299,7 +2319,7 @@ def _dispatch_glm_harness(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )
@@ -2366,7 +2386,7 @@ def _dispatch_gemini(args: argparse.Namespace) -> int:
         if os.environ.get("VNX_BENCH_REQUIRE_ISOLATION") == "1":
             raise
         logger.error(
-            "isolation required (VNX_ISOLATED_WORKTREE=1) but worktree creation failed "
+            "isolation required but worktree creation failed "
             "for %s: %s - aborting dispatch; no shared-checkout fallback",
             args.dispatch_id, _wt_exc,
         )

--- a/scripts/lib/subprocess_dispatch.py
+++ b/scripts/lib/subprocess_dispatch.py
@@ -718,46 +718,45 @@ if __name__ == "__main__":
     from subprocess_dispatch_internals.runtime_overrides import complexity_timeout_defaults
     _chunk_timeout, _total_deadline = complexity_timeout_defaults(args.complexity)
 
-    # VNX_ISOLATED_WORKTREE=1: create a per-dispatch ephemeral worktree so
-    # concurrent workers operate on independent file trees and never share HEAD.
-    # Default (unset): no change — proven path runs exactly as before.
-    _isolated = os.environ.get("VNX_ISOLATED_WORKTREE") == "1"
+    # OI-1090: always create a per-dispatch ephemeral worktree — isolation is
+    # default-on since 2026-08-10.  Every worker runs in its own checkout so
+    # concurrent dispatches never share HEAD and a worker can never write to the
+    # main checkout.  Fail-loud on creation failure: no shared-checkout fallback.
     _isolation_wt_path = None
     _isolation_project_root = None
-    if _isolated:
-        try:
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).info(
-                "VNX_ISOLATED_WORKTREE=1: creating dispatch worktree for %s",
-                args.dispatch_id,
-            )
-            from dispatch_worktree_isolation import (
-                create_dispatch_worktree as _create_wt,
-                remove_dispatch_worktree as _remove_wt,
-                resolve_consumer_project_root as _resolve_consumer_root,
-            )
-            # Resolve the CONSUMER project root (VNX_PROJECT_ROOT / CWD-git,
-            # never __file__) so a central-install consumer gets its worktree
-            # under ITS OWN project — not the shared ~/.vnx-system checkout
-            # this lane code lives under in a central install (P0
-            # provider-worktree-root-fix). Any resolution failure is handled
-            # by the same fail-loud abort below as a worktree-creation failure.
-            _isolation_project_root = _resolve_consumer_root()
-            _isolation_wt_path = _create_wt(
-                args.dispatch_id,
-                project_root=_isolation_project_root,
-            )
-            _set_active_worktree(_isolation_wt_path)
-        except Exception as _wt_exc:
-            import logging as _log_mod
-            _log_mod.getLogger(__name__).error(
-                "VNX_ISOLATED_WORKTREE=1 worktree creation failed for %s: %s — "
-                "aborting dispatch; no shared-checkout fallback",
-                args.dispatch_id, _wt_exc,
-            )
-            _hb_stop.set()
-            _hb_thread.join(timeout=5)
-            sys.exit(1)
+    try:
+        import logging as _log_mod
+        _log_mod.getLogger(__name__).info(
+            "creating dispatch worktree for %s (isolation default-on, OI-1090)",
+            args.dispatch_id,
+        )
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree as _create_wt,
+            remove_dispatch_worktree as _remove_wt,
+            resolve_consumer_project_root as _resolve_consumer_root,
+        )
+        # Resolve the CONSUMER project root (VNX_PROJECT_ROOT / CWD-git,
+        # never __file__) so a central-install consumer gets its worktree
+        # under ITS OWN project — not the shared ~/.vnx-system checkout
+        # this lane code lives under in a central install (P0
+        # provider-worktree-root-fix). Any resolution failure is handled
+        # by the same fail-loud abort below as a worktree-creation failure.
+        _isolation_project_root = _resolve_consumer_root()
+        _isolation_wt_path = _create_wt(
+            args.dispatch_id,
+            project_root=_isolation_project_root,
+        )
+        _set_active_worktree(_isolation_wt_path)
+    except Exception as _wt_exc:
+        import logging as _log_mod
+        _log_mod.getLogger(__name__).error(
+            "worktree creation failed for %s: %s — "
+            "aborting dispatch; no shared-checkout fallback (isolation default-on, OI-1090)",
+            args.dispatch_id, _wt_exc,
+        )
+        _hb_stop.set()
+        _hb_thread.join(timeout=5)
+        sys.exit(1)
 
     try:
         ok = deliver_with_recovery(
@@ -779,14 +778,14 @@ if __name__ == "__main__":
     finally:
         _hb_stop.set()
         _hb_thread.join(timeout=5)
-        if _isolated and _isolation_wt_path is not None:
+        if _isolation_wt_path is not None:
             _set_active_worktree(None)
             try:
                 _remove_wt(args.dispatch_id, project_root=_isolation_project_root, terminal_id=args.terminal_id)
             except Exception as _rm_exc:
                 import logging as _log_mod
                 _log_mod.getLogger(__name__).warning(
-                    "VNX_ISOLATED_WORKTREE: worktree cleanup failed: %s", _rm_exc,
+                    "worktree cleanup failed: %s", _rm_exc,
                 )
 
     sys.exit(0 if ok else 1)

--- a/tests/test_provider_dispatch_event_rotation.py
+++ b/tests/test_provider_dispatch_event_rotation.py
@@ -80,6 +80,12 @@ def _make_spawn_result(*, error=None, timed_out=False, returncode=0, event_write
     return r
 
 
+# OI-1090: isolation is default-on, so every _dispatch_* call below now creates
+# a real git worktree unless _create_provider_worktree/_remove_provider_worktree
+# are mocked — these tests exercise ring-buffer rotation, not worktree lifecycle
+# (that's test_provider_dispatch_worktree_isolation.py's job), so fake the seam.
+_FAKE_PROVIDER_WT_PATH = Path("/tmp/fake-event-rotation-worktree")
+
 # Patch targets for governance sinks so tests don't need real DB / receipts.
 # We mock at the governance_emit module level (where the functions are defined),
 # not at the provider_dispatch import level, so _emit_governance can run for real.
@@ -121,7 +127,9 @@ class TestCodexEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_codex(args)
 
         assert rc == 0
@@ -146,7 +154,9 @@ class TestCodexEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_codex(args)
 
         assert rc == 1
@@ -176,7 +186,9 @@ class TestGeminiEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_gemini(args)
 
         assert rc == 0
@@ -201,7 +213,9 @@ class TestGeminiEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_gemini(args)
 
         assert rc == 1
@@ -231,7 +245,9 @@ class TestKimiEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_kimi(args)
 
         assert rc == 0
@@ -256,7 +272,9 @@ class TestKimiEventRotation:
              patch("governance_emit.emit_dispatch_receipt", return_value=Path("/tmp/fake.ndjson")), \
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
-             patch("provider_dispatch._record_provider_metadata"):
+             patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"):
             rc = provider_dispatch._dispatch_kimi(args)
 
         assert rc == 1
@@ -297,6 +315,8 @@ class TestLitellmEventRotation:
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
              patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"), \
              patch.dict("os.environ", {"DEEPSEEK_API_KEY": "test-key"}):
             rc = provider_dispatch._dispatch_litellm(args)
 
@@ -319,6 +339,8 @@ class TestLitellmEventRotation:
              patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake.md")), \
              patch("provider_costs.emit_provider_cost"), \
              patch("provider_dispatch._record_provider_metadata"), \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_PROVIDER_WT_PATH), \
+             patch("provider_dispatch._remove_provider_worktree"), \
              patch.dict("os.environ", {"DEEPSEEK_API_KEY": "test-key"}):
             rc = provider_dispatch._dispatch_litellm(args)
 

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -1,13 +1,13 @@
-"""test_provider_dispatch_worktree_isolation.py — VNX_ISOLATED_WORKTREE for providers.
+"""test_provider_dispatch_worktree_isolation.py — provider dispatch isolation (default-on since OI-1090).
 
-Verifies (PR-PROVIDER-ISO / PR-7):
-1. With VNX_ISOLATED_WORKTREE=1, each provider dispatch (codex/kimi/gemini/litellm):
+Verifies:
+1. Every provider dispatch (codex/kimi/gemini/litellm) always creates a worktree:
    - calls create_dispatch_worktree with the dispatch_id
    - passes the worktree path as cwd to the spawn function
    - calls remove_dispatch_worktree after (success and failure paths)
-2. Without VNX_ISOLATED_WORKTREE, spawn functions receive cwd=None (no isolation).
-3. create_dispatch_worktree failure (VNX_ISOLATED_WORKTREE=1): dispatch ABORTS (returns 1),
-   spawn NOT called — no silent shared-checkout fallback (PR-7 fail-loud).
+2. Worktree is created even without VNX_ISOLATED_WORKTREE set (default-on).
+3. create_dispatch_worktree failure: dispatch ABORTS (returns 1),
+   spawn NOT called — no silent shared-checkout fallback.
 """
 
 from __future__ import annotations
@@ -125,7 +125,8 @@ class TestCodexIsolation:
         mock_remove.assert_called_once_with("iso-codex-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
-    def test_no_isolation_when_env_unset(self):
+    def test_isolation_without_env_var(self):
+        """Isolation is default-on: worktree created even without VNX_ISOLATED_WORKTREE."""
         env = {k: v for k, v in __import__("os").environ.items() if k != "VNX_ISOLATED_WORKTREE"}
         result = _make_spawn_result()
         captured = {}
@@ -144,16 +145,16 @@ class TestCodexIsolation:
              patch("provider_dispatch._resolve_codex_model", return_value="gpt-test"), \
              patch("event_store.EventStore", return_value=mock_event_store), \
              patch("provider_spawns.codex_spawn.spawn_codex", side_effect=fake_spawn), \
-             patch("provider_dispatch._create_provider_worktree") as mock_create, \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
              patch("provider_dispatch._remove_provider_worktree") as mock_remove:
 
-            args = provider_dispatch._build_parser().parse_args(_base_argv("codex", "no-iso-codex"))
+            args = provider_dispatch._build_parser().parse_args(_base_argv("codex", "default-iso-codex"))
             exit_code = provider_dispatch._dispatch_codex(args)
 
         assert exit_code == 0
-        mock_create.assert_not_called()
-        mock_remove.assert_not_called()
-        assert captured.get("cwd") is None
+        mock_create.assert_called_once_with("default-iso-codex")
+        mock_remove.assert_called_once_with("default-iso-codex", terminal_id="T1")
+        assert captured.get("cwd") == _FAKE_WT_PATH
 
     def test_worktree_removed_on_spawn_failure(self):
         """remove_dispatch_worktree must be called even when spawn raises."""
@@ -210,7 +211,8 @@ class TestGeminiIsolation:
         mock_remove.assert_called_once_with("iso-gemini-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
-    def test_no_isolation_when_env_unset(self):
+    def test_isolation_without_env_var(self):
+        """Isolation is default-on: worktree created even without VNX_ISOLATED_WORKTREE."""
         captured = {}
         result = _make_spawn_result()
 
@@ -227,16 +229,16 @@ class TestGeminiIsolation:
              patch("provider_dispatch._enrich_instruction", return_value="noop"), \
              patch("event_store.EventStore", return_value=mock_event_store), \
              patch("provider_spawns.gemini_spawn.spawn_gemini", side_effect=fake_spawn), \
-             patch("provider_dispatch._create_provider_worktree") as mock_create, \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
              patch("provider_dispatch._remove_provider_worktree") as mock_remove:
 
-            args = provider_dispatch._build_parser().parse_args(_base_argv("gemini", "no-iso-gemini"))
+            args = provider_dispatch._build_parser().parse_args(_base_argv("gemini", "default-iso-gemini"))
             exit_code = provider_dispatch._dispatch_gemini(args)
 
         assert exit_code == 0
-        mock_create.assert_not_called()
-        mock_remove.assert_not_called()
-        assert captured.get("cwd") is None
+        mock_create.assert_called_once_with("default-iso-gemini")
+        mock_remove.assert_called_once_with("default-iso-gemini", terminal_id="T1")
+        assert captured.get("cwd") == _FAKE_WT_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -273,7 +275,8 @@ class TestKimiIsolation:
         mock_remove.assert_called_once_with("iso-kimi-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
-    def test_no_isolation_when_env_unset(self):
+    def test_isolation_without_env_var(self):
+        """Isolation is default-on: worktree created even without VNX_ISOLATED_WORKTREE."""
         captured = {}
         result = _make_spawn_result()
 
@@ -291,16 +294,16 @@ class TestKimiIsolation:
              patch("provider_dispatch._resolve_kimi_model_label", return_value="kimi-default"), \
              patch("event_store.EventStore", return_value=mock_event_store), \
              patch("provider_spawns.kimi_spawn.spawn_kimi", side_effect=fake_spawn), \
-             patch("provider_dispatch._create_provider_worktree") as mock_create, \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
              patch("provider_dispatch._remove_provider_worktree") as mock_remove:
 
-            args = provider_dispatch._build_parser().parse_args(_base_argv("kimi", "no-iso-kimi"))
+            args = provider_dispatch._build_parser().parse_args(_base_argv("kimi", "default-iso-kimi"))
             exit_code = provider_dispatch._dispatch_kimi(args)
 
         assert exit_code == 0
-        mock_create.assert_not_called()
-        mock_remove.assert_not_called()
-        assert captured.get("cwd") is None
+        mock_create.assert_called_once_with("default-iso-kimi")
+        mock_remove.assert_called_once_with("default-iso-kimi", terminal_id="T1")
+        assert captured.get("cwd") == _FAKE_WT_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -342,7 +345,8 @@ class TestLiteLLMIsolation:
         mock_remove.assert_called_once_with("iso-litellm-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
-    def test_no_isolation_when_env_unset(self):
+    def test_isolation_without_env_var(self):
+        """Isolation is default-on: worktree created even without VNX_ISOLATED_WORKTREE."""
         captured = {}
         result = _make_spawn_result()
 
@@ -363,18 +367,18 @@ class TestLiteLLMIsolation:
              patch("provider_dispatch._enrich_instruction", return_value="noop"), \
              patch("event_store.EventStore", return_value=mock_event_store), \
              patch("provider_spawns.litellm_spawn.spawn_litellm", side_effect=fake_spawn), \
-             patch("provider_dispatch._create_provider_worktree") as mock_create, \
+             patch("provider_dispatch._create_provider_worktree", return_value=_FAKE_WT_PATH) as mock_create, \
              patch("provider_dispatch._remove_provider_worktree") as mock_remove:
 
             args = provider_dispatch._build_parser().parse_args(
-                _base_argv("litellm:deepseek", "no-iso-litellm")
+                _base_argv("litellm:deepseek", "default-iso-litellm")
             )
             exit_code = provider_dispatch._dispatch_litellm(args)
 
         assert exit_code == 0
-        mock_create.assert_not_called()
-        mock_remove.assert_not_called()
-        assert captured.get("cwd") is None
+        mock_create.assert_called_once_with("default-iso-litellm")
+        mock_remove.assert_called_once_with("default-iso-litellm", terminal_id="T1")
+        assert captured.get("cwd") == _FAKE_WT_PATH
 
 
 # ---------------------------------------------------------------------------
@@ -436,12 +440,12 @@ class TestResolveConsumerProjectRoot:
 
 
 # ---------------------------------------------------------------------------
-# PR-7: fail-loud — VNX_ISOLATED_WORKTREE=1 + create failure → ABORT, no spawn
+# PR-7: fail-loud — create failure → ABORT, no spawn
 # ---------------------------------------------------------------------------
 
 class TestCodexIsolationFailLoud:
     def test_isolation_create_failure_aborts_dispatch(self):
-        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        """Worktree creation failure: return 1, spawn NOT called."""
         spawn_called = []
 
         def fake_spawn(*a, **kw):
@@ -470,7 +474,7 @@ class TestCodexIsolationFailLoud:
 
 class TestGeminiIsolationFailLoud:
     def test_isolation_create_failure_aborts_dispatch(self):
-        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        """Worktree creation failure: return 1, spawn NOT called."""
         spawn_called = []
 
         def fake_spawn(*a, **kw):
@@ -498,7 +502,7 @@ class TestGeminiIsolationFailLoud:
 
 class TestKimiIsolationFailLoud:
     def test_isolation_create_failure_aborts_dispatch(self):
-        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        """Worktree creation failure: return 1, spawn NOT called."""
         spawn_called = []
 
         def fake_spawn(*a, **kw):
@@ -527,7 +531,7 @@ class TestKimiIsolationFailLoud:
 
 class TestLiteLLMIsolationFailLoud:
     def test_isolation_create_failure_aborts_dispatch(self):
-        """VNX_ISOLATED_WORKTREE=1 + create failure: return 1, spawn NOT called."""
+        """Worktree creation failure: return 1, spawn NOT called."""
         spawn_called = []
 
         def fake_spawn(*a, **kw):

--- a/tests/test_subprocess_dispatch_worktree_isolation.py
+++ b/tests/test_subprocess_dispatch_worktree_isolation.py
@@ -1,17 +1,18 @@
-"""test_subprocess_dispatch_worktree_isolation.py — VNX_ISOLATED_WORKTREE tests.
+"""test_subprocess_dispatch_worktree_isolation.py — worktree isolation tests (default-on since OI-1090).
 
 Verifies:
-1. When VNX_ISOLATED_WORKTREE unset: _repo_root() uses file-based path (no .vnx-data).
-2. _set_active_worktree / _get_active_worktree / _repo_root() override mechanism.
-3. create_dispatch_worktree runs git fetch + worktree add, returns correct path.
-4. remove_dispatch_worktree calls git worktree remove --force + prune; idempotent.
-5. Failure path: worktree is removed even when dispatch raises.
-6. Two concurrent dispatch IDs → distinct worktree paths (no shared HEAD/index).
-7. delivery._resolve_agent_cwd_and_log_profile returns worktree path when active.
+1. _set_active_worktree / _get_active_worktree / _repo_root() override mechanism.
+2. create_dispatch_worktree runs git fetch + worktree add, returns correct path.
+3. remove_dispatch_worktree classifies before removal; idempotent.
+4. Failure path: worktree is removed even when dispatch raises.
+5. Two concurrent dispatch IDs → distinct worktree paths (no shared HEAD/index).
+6. delivery._resolve_agent_cwd_and_log_profile returns worktree path when active.
+7. OI-975: HEAD-jump detection stores main_head_sha in claim and warns on mismatch.
 """
 
 from __future__ import annotations
 
+import subprocess
 import sys
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
@@ -37,7 +38,12 @@ class TestGitHelpersWorktreeOverride:
         from subprocess_dispatch_internals.git_helpers import _repo_root
         result = _repo_root()
         assert result.is_absolute()
-        assert ".vnx-data" not in str(result)
+        # _repo_root() resolves to a git-managed directory (may include
+        # .vnx-data when running from a worktree — the dispatch worktree is
+        # also a git checkout, so the assertion below holds regardless).
+        assert (result / ".git").exists(), (
+            f"_repo_root() must resolve to a git root; got {result}"
+        )
 
     def test_set_worktree_changes_repo_root(self, tmp_path):
         from subprocess_dispatch_internals.git_helpers import (
@@ -112,6 +118,8 @@ class TestCreateDispatchWorktree:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
+            r.stdout = ""
             return r
 
         with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
@@ -139,6 +147,7 @@ class TestCreateDispatchWorktree:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
             return r
 
         with pytest.raises(RuntimeError, match="create_dispatch_worktree failed"):
@@ -161,6 +170,7 @@ class TestCreateDispatchWorktree:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
             return r
 
         with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
@@ -210,7 +220,10 @@ class TestCentralInstallGuard:
 
 
 class TestRemoveDispatchWorktree:
-    def test_calls_remove_force_and_prune(self, tmp_path):
+    def test_remove_delegates_to_tmux_worktree_reap(self, tmp_path):
+        """remove_dispatch_worktree delegates to tmux_worktree.classify()+reap()
+        (L3 provider-lane reap, 2026-08-08).  The reap call invokes
+        git worktree remove --force for clean/pushed/committed classifications."""
         from dispatch_worktree_isolation import remove_dispatch_worktree, _dispatch_worktree_dir
 
         dispatch_id = "20260529-test-remove"
@@ -224,26 +237,38 @@ class TestRemoveDispatchWorktree:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
             return r
 
         with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
             remove_dispatch_worktree(dispatch_id, project_root=tmp_path)
 
         cmd_strs = [" ".join(c) for c in called_cmds]
-        assert any("remove" in s and "--force" in s for s in cmd_strs), (
-            f"git worktree remove --force not called; got: {cmd_strs}"
-        )
-        assert any("prune" in s for s in cmd_strs), (
-            f"git worktree prune not called; got: {cmd_strs}"
+        assert any("worktree remove" in s and "--force" in s for s in cmd_strs), (
+            f"git worktree remove --force not called (via reap); got: {cmd_strs}"
         )
 
     def test_idempotent_when_worktree_absent(self, tmp_path):
+        """remove_dispatch_worktree exits early without git calls when worktree
+        is absent.  Verifies the function completes without raising."""
         from dispatch_worktree_isolation import remove_dispatch_worktree
 
-        with patch("dispatch_worktree_isolation.subprocess.run") as mock_run:
-            remove_dispatch_worktree("nonexistent-dispatch", project_root=tmp_path)
+        # The absent-worktree early-exit path goes through _clear_claim →
+        # vnx_paths.resolve_data_root, which internally calls subprocess.
+        # Patch subprocess.run in dispatch_worktree_isolation to return a
+        # well-formed CompletedProcess so the vnx_paths resolver (which uses
+        # subprocess.check_output → subprocess.run) doesn't choke on a
+        # MagicMock.
+        def fake_run(cmd, **kwargs):
+            r = MagicMock()
+            r.returncode = 128  # not a git repo → non-zero
+            r.stderr = "fatal: not a git repository"
+            r.stdout = ""
+            return r
 
-        mock_run.assert_not_called()
+        with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
+            # Must not raise — idempotent when worktree is absent
+            remove_dispatch_worktree("nonexistent-dispatch", project_root=tmp_path)
 
 
 # ─── delivery._resolve_agent_cwd_and_log_profile ─────────────────────────────
@@ -327,6 +352,7 @@ class TestIsolationLifecycle:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
             return r
 
         with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
@@ -364,6 +390,7 @@ class TestIsolationLifecycle:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
+            r.stdout = ""
             return r
 
         with patch("dispatch_worktree_isolation.subprocess.run", side_effect=fake_run):
@@ -389,3 +416,176 @@ class TestIsolationLifecycle:
         assert path_a.resolve() != path_b.resolve()
         # Each worktree has its own HEAD/index — no shared state possible.
         assert str(path_a) != str(path_b)
+
+
+# ─── OI-975 HEAD-jump detection ──────────────────────────────────────────────
+
+
+class TestHeadJumpDetection:
+    """OI-975: detect when the main checkout HEAD changes during a dispatch.
+
+    The claim stores main_head_sha at creation time; teardown compares the
+    current main checkout HEAD against it and logs a loud WARNING when they
+    differ, naming the dispatch-id so the event is traceable.
+    """
+
+    def test_main_head_sha_stored_in_claim(self, tmp_path):
+        """create_dispatch_worktree stores main_head_sha in the claim."""
+        import json
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            _sanitize_dispatch_id,
+            _claim_path,
+        )
+
+        local = self._init_repo(tmp_path)
+        dispatch_id = "head-jump-store-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        safe_id = _sanitize_dispatch_id(dispatch_id)
+        claim_path = _claim_path(safe_id, local)
+        claim = json.loads(claim_path.read_text())
+
+        assert "main_head_sha" in claim, (
+            "OI-975: claim must include main_head_sha"
+        )
+        main_head_sha = claim["main_head_sha"]
+        assert len(main_head_sha) == 40, (
+            f"main_head_sha must be a full SHA, got {main_head_sha!r}"
+        )
+        # Must match the actual HEAD of the main checkout.
+        actual_head = subprocess.check_output(
+            ["git", "-C", str(local), "rev-parse", "HEAD"], text=True
+        ).strip()
+        assert main_head_sha == actual_head
+
+    def test_remove_detects_head_jump(self, tmp_path, caplog):
+        """remove_dispatch_worktree logs WARNING when main checkout HEAD changed."""
+        import logging
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            _sanitize_dispatch_id,
+            _claim_path,
+        )
+        import json
+
+        local = self._init_repo(tmp_path)
+        dispatch_id = "head-jump-detect-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Simulate a HEAD jump: change the claim's main_head_sha to a different
+        # (but valid) SHA that doesn't match the current HEAD.
+        safe_id = _sanitize_dispatch_id(dispatch_id)
+        claim_path = _claim_path(safe_id, local)
+        claim = json.loads(claim_path.read_text())
+        # Use a fake SHA that is 40 hex chars — definitely not the current HEAD.
+        claim["main_head_sha"] = "0" * 40
+        claim_path.write_text(json.dumps(claim) + "\n")
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_worktree_isolation"):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        head_jump_logs = [
+            r for r in caplog.records
+            if "HEAD-JUMP DETECTED" in (r.message or "")
+        ]
+        assert len(head_jump_logs) == 1, (
+            f"OI-975: expected exactly 1 HEAD-JUMP warning, got {len(head_jump_logs)}"
+        )
+        assert dispatch_id in head_jump_logs[0].message, (
+            "HEAD-JUMP warning must include the dispatch_id"
+        )
+
+    def test_no_warning_when_head_unchanged(self, tmp_path, caplog):
+        """No false alarm: when HEAD hasn't changed, no HEAD-JUMP warning is logged."""
+        import logging
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+        )
+
+        local = self._init_repo(tmp_path)
+        dispatch_id = "head-jump-clean-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_worktree_isolation"):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        head_jump_logs = [
+            r for r in caplog.records
+            if "HEAD-JUMP DETECTED" in (r.message or "")
+        ]
+        assert len(head_jump_logs) == 0, (
+            "no HEAD-JUMP warning when HEAD is unchanged"
+        )
+
+    def test_missing_main_head_sha_skips_check(self, tmp_path, caplog):
+        """Pre-existing claims without main_head_sha do not trigger a warning."""
+        import logging
+        import json
+        from dispatch_worktree_isolation import (
+            create_dispatch_worktree,
+            remove_dispatch_worktree,
+            _sanitize_dispatch_id,
+            _claim_path,
+        )
+
+        local = self._init_repo(tmp_path)
+        dispatch_id = "head-jump-old-claim-1"
+        wt_path = create_dispatch_worktree(dispatch_id, project_root=local)
+
+        # Remove main_head_sha to simulate a pre-OI-975 claim.
+        safe_id = _sanitize_dispatch_id(dispatch_id)
+        claim_path = _claim_path(safe_id, local)
+        claim = json.loads(claim_path.read_text())
+        del claim["main_head_sha"]
+        claim_path.write_text(json.dumps(claim) + "\n")
+
+        with caplog.at_level(logging.WARNING, logger="dispatch_worktree_isolation"):
+            remove_dispatch_worktree(dispatch_id, project_root=local, terminal_id="T1")
+
+        head_jump_logs = [
+            r for r in caplog.records
+            if "HEAD-JUMP DETECTED" in (r.message or "")
+        ]
+        assert len(head_jump_logs) == 0, (
+            "no HEAD-JUMP warning when claim has no main_head_sha field"
+        )
+
+    @staticmethod
+    def _init_repo(tmp_path: Path) -> Path:
+        """Create a bare origin + local clone with an initial commit."""
+        bare = tmp_path / "origin.git"
+        bare.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+            check=True, capture_output=True,
+        )
+        local = tmp_path / "local"
+        subprocess.run(
+            ["git", "clone", str(bare), str(local)],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.name", "Test"],
+            check=True, capture_output=True,
+        )
+        (local / "README.md").write_text("init\n")
+        subprocess.run(
+            ["git", "-C", str(local), "add", "README.md"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "commit", "-m", "initial"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "push", "-u", "origin", "main"],
+            check=True, capture_output=True,
+        )
+        return local

--- a/tests/test_subprocess_dispatch_worktree_isolation.py
+++ b/tests/test_subprocess_dispatch_worktree_isolation.py
@@ -118,7 +118,12 @@ class TestCreateDispatchWorktree:
             r = MagicMock()
             r.returncode = 0
             r.stderr = ""
-            r.stdout = ""
+            # stdout must be a real string: patching subprocess.run patches the
+            # actual stdlib function, and subprocess.check_output is implemented
+            # in terms of run() — so the claim-path's check_output call (via
+            # resolve_data_root -> _project_id_from_git_remote) collects THIS
+            # mock's .stdout too. Left as an auto-MagicMock it breaks .strip()
+            # downstream with a TypeError unrelated to what this test exercises.
             r.stdout = ""
             return r
 


### PR DESCRIPTION
## Supersedes

Supersedes #1441 (`dispatch/20260810b-c-isolatie-default`). #1441's content is
fully merged into this branch (commits `b3cf2916`, `d28ea8d6`) plus one salvaged
adjustment from round 3 (`bfd3ee76`, event-rotation test scaffolding) plus this
round's own fix. T0: please close #1441 referencing this PR.

This is round 4 of OI-1090 + OI-975. Round 3 (`dispatch/20260810g-f-isolatie-r3`)
was killed by the heartbeat monitor before it could write its report; T0 salvaged
its work as the branch base for this round. This PR supplies the justification
round 3 never got to write, plus one small cleanup commit.

## What

**OI-1090**: worktree isolation is default-on. Zero `VNX_ISOLATED_WORKTREE`
opt-in checks remain in `provider_dispatch.py` / `subprocess_dispatch.py`
(confirmed via grep — see Verification). Fixes `_dispatch_claude`, which had
no isolation at all before this change.

**OI-975**: HEAD-jump detector in `dispatch_worktree_isolation.py`. The claim
now stores `main_head_sha` at worktree-creation time; teardown compares it
against the current main-checkout HEAD and logs a loud, dispatch-id-tagged
WARNING on mismatch.

**Round 4 (this PR)**: root-caused and justified the 7 tests that were red on
`origin/main` for these two files, and fixed a leftover duplicate line from
round 3's interrupted session.

## Why the 7 main-red tests are not a default-on regression

`origin/main` fails 7 of the 56 tests in these two files, in both a worktree
checkout and the real main checkout (I measured both — identical result).
**This is a pre-existing bug on main, unrelated to isolation being default-on.**

Root cause: `patch("dispatch_worktree_isolation.subprocess.run", ...)` patches
the real stdlib `subprocess.run` (not a local alias), and CPython's
`subprocess.check_output` is implemented internally in terms of `run()`. Once
`create_dispatch_worktree`/`remove_dispatch_worktree` started reading/writing a
claim file (`resolve_data_root` → `_project_id_from_git_remote` →
`subprocess.check_output`) — a mechanism already on `main`, unrelated to this
PR — every test that patches `subprocess.run` without giving the mock a real
`.stdout` string collateral-mocks that unrelated `check_output` call too. The
mock's `.stdout` becomes an auto-generated `MagicMock`, and
`_project_id_from_git_remote`'s `.strip()` / `.split()` / regex match blow up
with `TypeError: expected string or bytes-like object, got 'MagicMock'`.

Fix: give every affected mock a real `r.stdout = ""`. This does not touch any
behavioral assertion — each test still asserts exactly what it asserted before
(fetch called, worktree add called with the right branch, worktree removed on
failure, HEAD-jump storage, idempotent removal). Proof (reverted the fix on
this branch, ran, restored, ran again):

```
RED  (stdout fix reverted): 7 failed, 19 passed in 1.79s — identical TypeError/traceback to main
GREEN (stdout fix restored): 26 passed in 1.87s
```

## Two other assertion changes — audited with proof

**`test_repo_root_no_override`**: old assertion `".vnx-data" not in str(result)`
encoded an "opt-in" assumption — that dispatch work runs from the shared main
checkout, not from inside a `.vnx-data/worktrees/...` path. In the default-on
world every dispatch (including the one that ran this test suite) runs from
inside such a path, so the substring check is now systematically false there
even though `_repo_root()` is working correctly. New assertion
`(result / ".git").exists()` checks the actual invariant. Verified directly in
this dispatch's own worktree:

```
resolved repo_root: .../.vnx-data/worktrees/dispatch-20260810g-j-isolatie-r4
OLD assertion (".vnx-data" not in str(result)): False   <- would fail here
NEW assertion ((result/.git).exists()): True            <- correctly passes
```

**`test_remove_delegates_to_tmux_worktree_reap`** (renamed from
`test_calls_remove_force_and_prune`): dropped the `assert any("prune" in s ...)`
check. `remove_dispatch_worktree` has delegated to `tmux_worktree.classify()` +
`reap()` since #1417/#1424 (2026-08-08, already on `main`, unrelated to this
PR). Reading `tmux_worktree._remove_worktree_with_fallback`: `git worktree
prune` is only invoked in the double-failure fallback branch, never in the
happy path this test exercises. Re-added the old assertion locally (fix still
applied) and reproduced the failure with real command output —
`git worktree prune` is genuinely never called:

```
AssertionError: git worktree prune not called; got: [... 'git ... worktree remove --force ...', 'git ... remote get-url origin']
```

i.e. the old assertion was already testing stale behavior predating this PR.

## Runtime claim from the original round-3 brief — does not hold up

The original brief hypothesized the branch was "8x slower" than main on these
tests (real worktree creation during tests). I measured directly: the 7
affected tests take main 0.71s (fails fast, before doing any real work) vs the
branch's fixed equivalent 0.29s. Full 56/52-test suite: branch 6.35s vs main's
partial 6.34s (45 pass + 7 fast-fail). No 8x gap in either direction — that
framing was based on a stale/different measurement and doesn't apply to the
current code.

## OI-1124 pointer (not fixed here, per T0's brief)

`create_dispatch_worktree` acquires `_worktree_lock(root)` (a per-repo
exclusive `fcntl` lock over `.git/worktrees/.vnx-lock`) before calling `git
worktree add`. `remove_dispatch_worktree` does **not** acquire that same lock
before calling into the reap/classify path that runs `git worktree remove`.
Both mutate the same shared `.git/worktrees/` metadata directory for the repo.
Two dispatches firing ~2s apart — one tearing down (unlocked) while another is
being created (locked, but only serialized against other creates) — is exactly
the kind of unserialized concurrent mutation of shared worktree-admin state
that could produce a mis-attributed/mis-formed branch name. This is a
plausible lead, not a confirmed root cause — did not chase further per the
brief's instruction to leave this as a pointer.

## Changes

- `scripts/lib/dispatch_worktree_isolation.py`: main_head_sha claim field, OI-975 capture/compare (from #1441, inherited)
- `scripts/lib/subprocess_dispatch.py`, `scripts/lib/provider_dispatch.py`: unconditional isolation, env-var gate removed, `_dispatch_claude` gap fixed (from #1441, inherited)
- `tests/test_subprocess_dispatch_worktree_isolation.py`: HEAD-jump tests, updated remove/idempotent/repo-root tests (inherited) + this round's fix: dedupe a leftover duplicate `r.stdout = ""` line from round 3's interrupted session, add a comment documenting the collateral-mock root cause
- `tests/test_provider_dispatch_worktree_isolation.py`: default-on test expectations (from #1441, inherited)
- `tests/test_provider_dispatch_event_rotation.py`: worktree-seam stubs so ring-buffer tests don't hit real git (round-3 salvage commit, inherited, reviewed this round — additive only, no assertions changed)

Diff size (566 insertions / 181 deletions across 6 files) exceeds the usual
150-300 line guideline. This is inherited, already-reviewed content from #1441
("good content... deliberately NOT merged" per the dispatch brief) plus one
small round-3 salvage commit; the brief's explicit instruction was to build on
the salvaged branch rather than redo or split it. This round's own new
contribution is the verification/diagnosis above plus a 6-line cleanup commit
(`08ba7be6`).

## Verification

- `git ls-remote --heads origin dispatch/20260810g-j-isolatie-r4` → `08ba7be68ff5953753524a1aeea3b200a5c7918b refs/heads/dispatch/20260810g-j-isolatie-r4`
- `python3 -m pytest tests/test_subprocess_dispatch_worktree_isolation.py tests/test_provider_dispatch_worktree_isolation.py -v` → **56 passed** in 6.35s (this branch, this worktree)
- Control: same two files, `origin/main`, main checkout (non-worktree) → **7 failed, 45 passed** in 6.34s (reproduced exactly)
- Control: same two files, `origin/main`, worktree checkout → **7 failed, 45 passed** in 5.93s (reproduced exactly, rules out "worktree gives false reds")
- Neighbours: `tests/test_provider_dispatch_event_rotation.py` + `tests/test_dispatch_cli.py` (merged-in main commit #1448 touches this) → **148 passed**
- `grep -n "VNX_ISOLATED_WORKTREE" scripts/lib/provider_dispatch.py scripts/lib/subprocess_dispatch.py` → no matches (zero opt-in checks remain)
- litellm:deepseek pre-existing registry-constraint failures the brief flagged as out of scope: not present anywhere in either of my two target files, on either branch or main (0 deepseek-related failures observed in my scope); left untouched per instruction
- Full out/red/in/green proof pairs for all three assertion changes: pasted in the PR body above with real command output, not thought experiments

## Open Items

- OI-1124 (wrong-form branch id on concurrent dispatch): pointer given above (`remove_dispatch_worktree` missing `_worktree_lock`), not fixed — flagged as a separate item per the dispatch brief.
- The litellm:deepseek pre-existing registry-constraint failures mentioned in the brief were not located inside my two target files or their direct neighbours; confirmed absent from my scope but not independently re-verified elsewhere, since the brief scopes that item to "not yours."

🤖 Generated with [Claude Code](https://claude.com/claude-code)