### PR TITLE
fix(doctor): wire hook-pin check into SessionStart, fix silent-swallow bug (OI-1123)

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -108,6 +108,16 @@
             "timeout": 5000
           }
         ]
+      },
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)/scripts/hooks/hookpin_check.sh\"'",
+            "timeout": 5000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/scripts/hooks/hookpin_check.sh
+++ b/scripts/hooks/hookpin_check.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+# hookpin_check.sh — SessionStart hook: verify every hook path this project's
+# own .claude/settings.json points at still resolves to a real file.
+#
+# OI-1123: a hook pinned to a fabric version/path that stopped existing fails
+# SILENTLY — Claude Code prints "Stop hook error: ... No such file or
+# directory" to the pane, nobody reads that, and the governed report/guard
+# that hook was supposed to provide simply never runs. A doctor-time-only
+# check would have caught the install-time state but not this: the pin was
+# valid when it was written and only orphaned later, when the fabric version
+# it pointed at was retired. Re-checking on every SessionStart is what turns
+# that drift into something visible on the very next session instead of
+# whenever a human happens to notice a stray pane error.
+#
+# Fail-soft by contract: this hook NEVER fails the session (always exit 0)
+# and does not block the SessionStart budget on a healthy machine.
+set -u
+
+cat >/dev/null 2>&1 || true
+
+# The checker itself is engine-anchored (resolved relative to THIS script's
+# own location) — correct for every layout: central install, embedded, and
+# this repo's own dev checkout. The project being audited is git-toplevel —
+# always the consumer's own root, never the engine's.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+CHECKER="$SCRIPT_DIR/../lib/hookpin_check.py"
+[ -f "$CHECKER" ] || exit 0
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+[ -f "$ROOT/.claude/settings.json" ] || exit 0
+
+PY="$ROOT/.venv/bin/python"
+[ -x "$PY" ] || PY="python3"
+
+RESULT="$("$PY" "$CHECKER" --project-root "$ROOT" --json 2>/dev/null)" || exit 0
+
+# Surface a warning into the session context only when a pin is actually dead.
+case "$RESULT" in
+  *'"status": "missing"'*)
+    "$PY" - "$RESULT" <<'PYEOF' 2>/dev/null || true
+import json, sys
+try:
+    findings = json.loads(sys.argv[1])
+except (ValueError, IndexError):
+    sys.exit(0)
+missing = [f for f in findings if f.get("status") == "missing"]
+if not missing:
+    sys.exit(0)
+parts = ["%s (%s): %s" % (f.get("event", "?"), f.get("matcher") or "*", f.get("raw_path", "?"))
+         for f in missing]
+msg = ("%d configured hook path(s) do NOT resolve to a real file — that hook "
+       "is silently NOT running: %s. Run `vnx doctor` for detail, then "
+       "`vnx regen-settings --merge` (or fix .claude/settings.json directly)."
+       % (len(missing), "; ".join(parts)))
+print(json.dumps({"hookSpecificOutput": {"hookEventName": "SessionStart",
+                                         "additionalContext": msg}}))
+PYEOF
+    ;;
+esac
+
+exit 0

--- a/scripts/hooks/hookpin_check.sh
+++ b/scripts/hooks/hookpin_check.sh
@@ -13,7 +13,13 @@
 # whenever a human happens to notice a stray pane error.
 #
 # Fail-soft by contract: this hook NEVER fails the session (always exit 0)
-# and does not block the SessionStart budget on a healthy machine.
+# and does not block the SessionStart budget on a healthy machine. Trade-off,
+# accepted: if this checker's own logic regresses (crash, bad exit, timeout),
+# the SessionStart surface goes silent instead of warning — the same failure
+# shape OI-1123 is about, one layer up. Hooks must never fail a session, so a
+# checker-level self-check would need to live outside this hook (e.g. as a
+# separate `vnx doctor` assertion that the SessionStart wiring itself is
+# intact), not inside it.
 set -u
 
 cat >/dev/null 2>&1 || true
@@ -32,7 +38,13 @@ ROOT="$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
 PY="$ROOT/.venv/bin/python"
 [ -x "$PY" ] || PY="python3"
 
-RESULT="$("$PY" "$CHECKER" --project-root "$ROOT" --json 2>/dev/null)" || exit 0
+# NOTE: do NOT gate this capture on the checker's exit code. --json mode
+# exits 1 precisely when it found a dead pin — that is the signal this hook
+# exists to surface, not a crash. An `|| exit 0` here would silently
+# swallow the positive case on every run. An empty/unparseable RESULT (a
+# genuine crash) is already a no-op below: the case pattern will not match
+# and the python heredoc's own try/except no-ops on bad JSON.
+RESULT="$("$PY" "$CHECKER" --project-root "$ROOT" --json 2>/dev/null)"
 
 # Surface a warning into the session context only when a pin is actually dead.
 case "$RESULT" in

--- a/scripts/lib/hookpin_check.py
+++ b/scripts/lib/hookpin_check.py
@@ -1,0 +1,234 @@
+#!/usr/bin/env python3
+"""Verify every configured Claude Code hook command path resolves to a real file.
+
+OI-1123: a hook pinned to a fabric version/path that no longer exists fails
+SILENTLY. Claude Code prints "Stop hook error: ... No such file or directory"
+to the pane and nothing else — the hook simply never runs, no report is
+written, no receipt lands, and (for a PreToolUse guard) no protection is
+applied. Nothing today verifies that a deployed hook path actually resolves;
+this module is that check.
+
+Only a hook path that is CONFIGURED in .claude/settings.json is in scope. A
+hook event with no entries at all is absent by design — not a defect — and
+produces no findings.
+
+Path resolution handles every idiom observed across the live fleet
+(vnx-orchestration, mission-control, SEOcrawler_v2, sales-copilot):
+  - literal absolute paths                          (mission-control, SEOcrawler, sales-copilot)
+  - ``~/...``                                        (home-relative)
+  - ``$(git rev-parse --show-toplevel ...)/rel``      (this repo's own settings.json)
+  - ``$CLAUDE_PROJECT_DIR/rel`` / ``$PROJECT_ROOT/rel``  (Claude Code / VNX project-root vars)
+  - ``${VNX_HOME}/rel`` / ``$VNX_HOME/rel``           (engine-relative)
+
+A token that cannot be deterministically resolved (references an unrecognized
+env var, or ``VNX_HOME`` with no candidate base found) is reported as
+"unresolved", never "missing" — guessing wrong would produce a false FAIL,
+and a check that cries wolf on healthy projects is worse than no check.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import sys
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Tuple
+
+STATUS_OK = "ok"
+STATUS_MISSING = "missing"
+STATUS_UNRESOLVED = "unresolved"
+
+_GITROOT_SENTINEL = "\x00GITROOT\x00"
+_GIT_TOPLEVEL_RE = re.compile(r"\$\(git rev-parse --show-toplevel[^)]*\)")
+_PATH_TOKEN_RE = re.compile(
+    r"(?:"
+    + re.escape(_GITROOT_SENTINEL)
+    + r"|\$\{[A-Z_][A-Z0-9_]*\}|\$[A-Z_][A-Z0-9_]*|~|/)"
+    r'[^\s"\'\)]*\.(?:sh|py|mjs|js)'
+)
+_VAR_RE = re.compile(r"^\$\{?([A-Z_][A-Z0-9_]*)\}?(.*)$")
+
+# Vars that mean "this project's own root" — resolved directly, deterministically.
+_PROJECT_RELATIVE_VARS = {"CLAUDE_PROJECT_DIR", "PROJECT_ROOT"}
+
+# Observed fleet convention (SEOcrawler_v2): a matcher value engineered to never
+# match a real Claude Code tool name is a deliberate off-switch, not a live
+# hook. Absent-by-design — skip it, don't check its path. A differently-named
+# disable sentinel would not be caught by this; see module docstring.
+_DISABLED_MATCHER_MARKERS = ("disabled", "never_match")
+
+
+def _matcher_is_disabled(matcher: str) -> bool:
+    lowered = matcher.lower()
+    return any(marker in lowered for marker in _DISABLED_MATCHER_MARKERS)
+
+
+@dataclass
+class HookPinFinding:
+    event: str
+    matcher: str
+    raw_path: str
+    resolved_path: Optional[str]
+    status: str
+    detail: str = ""
+
+
+def iter_hook_commands(settings: dict) -> Iterator[Tuple[str, str, str]]:
+    """Yield (event, matcher, command) for every configured command-type hook."""
+    hooks = settings.get("hooks")
+    if not isinstance(hooks, dict):
+        return
+    for event, entries in hooks.items():
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            matcher = entry.get("matcher", "") or ""
+            if _matcher_is_disabled(matcher):
+                continue
+            sub_hooks = entry.get("hooks", [])
+            if not isinstance(sub_hooks, list):
+                continue
+            for h in sub_hooks:
+                if not isinstance(h, dict) or h.get("type") != "command":
+                    continue
+                command = h.get("command")
+                if isinstance(command, str) and command.strip():
+                    yield event, matcher, command
+
+
+def extract_path_tokens(command: str) -> List[str]:
+    """Extract candidate script-path tokens from a hook command string, deduped."""
+    masked = _GIT_TOPLEVEL_RE.sub(_GITROOT_SENTINEL, command)
+    seen: List[str] = []
+    for token in _PATH_TOKEN_RE.findall(masked):
+        if token not in seen:
+            seen.append(token)
+    return seen
+
+
+def _vnx_home_candidates(project_root: Path) -> List[Path]:
+    """Best-effort bases for $VNX_HOME, tried in the order a live session would."""
+    candidates: List[Path] = []
+    env_home = os.environ.get("VNX_HOME")
+    if env_home:
+        candidates.append(Path(env_home).expanduser())
+    current_symlink = Path.home() / ".vnx-system" / "current"
+    if current_symlink.exists():
+        candidates.append(current_symlink)
+    candidates.append(project_root / ".vnx")
+    candidates.append(project_root / ".claude" / "vnx-system")
+    candidates.append(project_root)  # standalone-dev checkout: VNX_HOME == PROJECT_ROOT
+    return candidates
+
+
+def resolve_token(token: str, project_root: Path) -> Tuple[Optional[Path], str]:
+    """Resolve one extracted token to (path, status). Never raises."""
+    if token.startswith(_GITROOT_SENTINEL):
+        rel = token[len(_GITROOT_SENTINEL):].lstrip("/")
+        path = (project_root / rel) if rel else project_root
+        return path, (STATUS_OK if path.exists() else STATUS_MISSING)
+
+    if token.startswith("$"):
+        m = _VAR_RE.match(token)
+        if not m:
+            return None, STATUS_UNRESOLVED
+        var, rel = m.group(1), m.group(2).lstrip("/")
+        if var in _PROJECT_RELATIVE_VARS:
+            path = (project_root / rel) if rel else project_root
+            return path, (STATUS_OK if path.exists() else STATUS_MISSING)
+        if var == "VNX_HOME":
+            for base in _vnx_home_candidates(project_root):
+                path = (base / rel) if rel else base
+                if path.exists():
+                    return path, STATUS_OK
+            return None, STATUS_UNRESOLVED
+        return None, STATUS_UNRESOLVED
+
+    if token.startswith("~"):
+        path = Path(os.path.expanduser(token))
+        return path, (STATUS_OK if path.exists() else STATUS_MISSING)
+
+    if token.startswith("/"):
+        path = Path(token)
+        return path, (STATUS_OK if path.exists() else STATUS_MISSING)
+
+    return None, STATUS_UNRESOLVED
+
+
+def check_project_hook_pins(project_root: Path) -> List[HookPinFinding]:
+    """Check every hook path configured in <project_root>/.claude/settings.json.
+
+    Returns an empty list when there is no settings.json or no hooks section —
+    that is "absent by design", not a defect, and produces no findings.
+    """
+    settings_file = project_root / ".claude" / "settings.json"
+    if not settings_file.is_file():
+        return []
+
+    try:
+        settings = json.loads(settings_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError) as exc:
+        return [HookPinFinding(
+            event="<settings.json>", matcher="", raw_path=str(settings_file),
+            resolved_path=None, status=STATUS_UNRESOLVED,
+            detail=f"Cannot parse settings.json: {exc}",
+        )]
+
+    findings: List[HookPinFinding] = []
+    seen = set()
+    for event, matcher, command in iter_hook_commands(settings):
+        for token in extract_path_tokens(command):
+            key = (event, matcher, token)
+            if key in seen:
+                continue
+            seen.add(key)
+            resolved, status = resolve_token(token, project_root)
+            display = token.replace(_GITROOT_SENTINEL, "$(git rev-parse --show-toplevel)")
+            findings.append(HookPinFinding(
+                event=event, matcher=matcher, raw_path=display,
+                resolved_path=str(resolved) if resolved is not None else None,
+                status=status,
+            ))
+    return findings
+
+
+def main() -> int:
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Verify every configured Claude Code hook path resolves to a real file."
+    )
+    parser.add_argument("--project-root", required=True)
+    parser.add_argument("--json", action="store_true")
+    args = parser.parse_args()
+
+    project_root = Path(args.project_root).expanduser().resolve()
+    findings = check_project_hook_pins(project_root)
+    missing = [f for f in findings if f.status == STATUS_MISSING]
+
+    if args.json:
+        print(json.dumps([asdict(f) for f in findings], indent=2))
+        return 1 if missing else 0
+
+    if not findings:
+        print(f"[hookpin-check] {project_root}: no hooks configured — nothing to check")
+        return 0
+
+    for f in findings:
+        icon = {STATUS_OK: "OK  ", STATUS_MISSING: "DEAD", STATUS_UNRESOLVED: "SKIP"}[f.status]
+        print(f"  [{icon}] {f.event} ({f.matcher or '*'}): {f.raw_path} -> {f.resolved_path or '?'}")
+
+    if missing:
+        print(f"\n{len(missing)} dead hook pin(s) in {project_root}/.claude/settings.json")
+    else:
+        print(f"\nAll configured hook pins resolve in {project_root}/.claude/settings.json")
+
+    return 1 if missing else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/hookpin_check.py
+++ b/scripts/lib/hookpin_check.py
@@ -23,7 +23,23 @@ Path resolution handles every idiom observed across the live fleet
 A token that cannot be deterministically resolved (references an unrecognized
 env var, or ``VNX_HOME`` with no candidate base found) is reported as
 "unresolved", never "missing" — guessing wrong would produce a false FAIL,
-and a check that cries wolf on healthy projects is worse than no check.
+and a check that cries wolf on healthy projects is worse than no check. An
+unresolved token is NOT proof of coverage either: both the CLI output and
+``vnx_doctor.py::check_hook_pins()`` say explicitly how many pins were
+actually checked versus skipped, rather than letting an unresolved-only run
+read as a clean "all pins verified" PASS.
+
+Scope note (OI-1123 follow-up): the original brief also asked whether a hook
+pin should resolve through the current-version symlink
+(``~/.vnx-system/current``) rather than a literal version path. This module
+is detection-only — it reads whatever command is already configured in
+``.claude/settings.json`` and reports whether it resolves — and never
+touches pin EMISSION. Pin emission lives in ``vnx_init.py::bootstrap_hooks()``
+and ``templates/settings_vnx_keys.json.tmpl``, both of which already emit
+``{{VNX_HOME}}``-relative commands rather than a literal version path, so the
+symlink question is primarily about hand-edited or historical pins, not
+anything this module or the current template emits. Not addressed here;
+tracked separately (OI-1123) if literal-version pins are found in the wild.
 """
 
 from __future__ import annotations
@@ -222,10 +238,24 @@ def main() -> int:
         icon = {STATUS_OK: "OK  ", STATUS_MISSING: "DEAD", STATUS_UNRESOLVED: "SKIP"}[f.status]
         print(f"  [{icon}] {f.event} ({f.matcher or '*'}): {f.raw_path} -> {f.resolved_path or '?'}")
 
+    unresolved = [f for f in findings if f.status == STATUS_UNRESOLVED]
+    settings_ref = f"{project_root}/.claude/settings.json"
+
+    # An unresolved pin is neither proven live nor proven dead — a clean run
+    # must say so, not present itself as full coverage (OI-1123 finding 2).
     if missing:
-        print(f"\n{len(missing)} dead hook pin(s) in {project_root}/.claude/settings.json")
+        print(f"\n{len(missing)} dead hook pin(s) in {settings_ref}")
+        if unresolved:
+            print(f"({len(unresolved)} more pin(s) unresolved — not checked, see [SKIP] above)")
+    elif unresolved:
+        checked_ok = len(findings) - len(unresolved)
+        print(
+            f"\n{checked_ok} of {len(findings)} configured hook pin(s) confirmed resolving in "
+            f"{settings_ref}; {len(unresolved)} unresolved (not checked — see [SKIP] above), "
+            "not confirmed dead"
+        )
     else:
-        print(f"\nAll configured hook pins resolve in {project_root}/.claude/settings.json")
+        print(f"\nAll {len(findings)} configured hook pin(s) resolve in {settings_ref}")
 
     return 1 if missing else 0
 

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -399,6 +399,47 @@ def check_hooks(paths: Dict[str, str]) -> List[CheckResult]:
 
 
 # ---------------------------------------------------------------------------
+# Hook pin check
+# ---------------------------------------------------------------------------
+
+def check_hook_pins(paths: Dict[str, str]) -> List[CheckResult]:
+    """Verify every hook command path in .claude/settings.json resolves.
+
+    OI-1123: a hook pinned to a fabric version/path that no longer exists
+    fails SILENTLY (the error goes to the pane's stderr, never to a report).
+    A dead pin means the hook simply never runs — no report, no receipt, no
+    PreToolUse guard. Absent-by-design (a hook event nobody configured, or a
+    deliberately-disabled matcher) is not a defect; only a configured path
+    that fails to resolve is.
+    """
+    project_root = Path(paths["PROJECT_ROOT"])
+    if not (project_root / ".claude" / "settings.json").is_file():
+        return []
+
+    try:
+        from hookpin_check import check_project_hook_pins, STATUS_MISSING
+    except ImportError:
+        return [CheckResult("hookpin", WARN, "hookpin_check module not importable; skipped")]
+
+    findings = check_project_hook_pins(project_root)
+    if not findings:
+        return []
+
+    missing = [f for f in findings if f.status == STATUS_MISSING]
+    if missing:
+        details = [f"{f.event} ({f.matcher or '*'}): {f.raw_path} -> {f.resolved_path}"
+                   for f in missing]
+        return [CheckResult(
+            "hookpin", FAIL,
+            f"{len(missing)} configured hook path(s) do not resolve to a real file",
+            "Re-run `vnx regen-settings --merge` (or `vnx init`) to refresh the pin, "
+            "or fix the path directly in .claude/settings.json",
+            details=details,
+        )]
+    return [CheckResult("hookpin", PASS, f"All {len(findings)} configured hook path(s) resolve")]
+
+
+# ---------------------------------------------------------------------------
 # Database check
 # ---------------------------------------------------------------------------
 
@@ -882,6 +923,7 @@ def run_doctor(paths: Dict[str, str], *,
     results.extend(check_templates(paths))
     results.extend(check_hooks(paths))
     results.extend(check_settings(paths))
+    results.extend(check_hook_pins(paths))
     results.extend(check_database(paths))
     results.append(check_write_access(paths))
     results.extend(check_worktree(paths))

--- a/scripts/vnx_doctor.py
+++ b/scripts/vnx_doctor.py
@@ -417,7 +417,7 @@ def check_hook_pins(paths: Dict[str, str]) -> List[CheckResult]:
         return []
 
     try:
-        from hookpin_check import check_project_hook_pins, STATUS_MISSING
+        from hookpin_check import check_project_hook_pins, STATUS_MISSING, STATUS_UNRESOLVED
     except ImportError:
         return [CheckResult("hookpin", WARN, "hookpin_check module not importable; skipped")]
 
@@ -426,9 +426,16 @@ def check_hook_pins(paths: Dict[str, str]) -> List[CheckResult]:
         return []
 
     missing = [f for f in findings if f.status == STATUS_MISSING]
+    unresolved = [f for f in findings if f.status == STATUS_UNRESOLVED]
+
     if missing:
         details = [f"{f.event} ({f.matcher or '*'}): {f.raw_path} -> {f.resolved_path}"
                    for f in missing]
+        if unresolved:
+            details.append(
+                f"(+{len(unresolved)} more pin(s) unresolved, not checked — "
+                "run hookpin_check.py --json for detail)"
+            )
         return [CheckResult(
             "hookpin", FAIL,
             f"{len(missing)} configured hook path(s) do not resolve to a real file",
@@ -436,6 +443,24 @@ def check_hook_pins(paths: Dict[str, str]) -> List[CheckResult]:
             "or fix the path directly in .claude/settings.json",
             details=details,
         )]
+
+    # No confirmed-dead pin, but an unresolved token is NOT a confirmed-live
+    # pin either — it means this checker's resolver has a blind spot (e.g. a
+    # locally-assigned $ROOT). A clean PASS here would claim full coverage
+    # that was never actually checked (OI-1123 finding 2); WARN instead so
+    # the gap is visible without failing `vnx doctor` on an unproven case.
+    if unresolved:
+        details = [f"{f.event} ({f.matcher or '*'}): {f.raw_path}" for f in unresolved]
+        checked_ok = len(findings) - len(unresolved)
+        return [CheckResult(
+            "hookpin", WARN,
+            f"{checked_ok} of {len(findings)} configured hook path(s) confirmed resolving; "
+            f"{len(unresolved)} could not be checked (unresolved token)",
+            "These pins use a token this checker does not resolve (e.g. a locally-assigned "
+            "$ROOT); confirm manually or extend hookpin_check.resolve_token()",
+            details=details,
+        )]
+
     return [CheckResult("hookpin", PASS, f"All {len(findings)} configured hook path(s) resolve")]
 
 

--- a/templates/settings_vnx_keys.json.tmpl
+++ b/templates/settings_vnx_keys.json.tmpl
@@ -86,6 +86,16 @@
             "command": "bash -c 'exec bash \"{{VNX_HOME}}/scripts/hooks/build_t0_state_hook.sh\"'"
           }
         ]
+      },
+      {
+        "matcher": "*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "bash {{VNX_HOME}}/scripts/hooks/hookpin_check.sh",
+            "timeout": 3000
+          }
+        ]
       }
     ],
     "UserPromptSubmit": [

--- a/tests/test_hookpin_check.py
+++ b/tests/test_hookpin_check.py
@@ -1,0 +1,540 @@
+#!/usr/bin/env python3
+"""Tests for scripts/lib/hookpin_check.py and vnx_doctor.py::check_hook_pins() (OI-1123).
+
+Covers the case list the round-2 security audit specified plus the two
+defects found while wiring the SessionStart surface into settings.json:
+
+  1. dead / live absolute pin
+  2. no .claude directory / no hooks key (absent-by-design, not a defect)
+  3. a disabled matcher (_DISABLED_MATCHER_MARKERS)
+  4. $(git rev-parse --show-toplevel) resolution
+  5. $CLAUDE_PROJECT_DIR / $PROJECT_ROOT resolution
+  6. $VNX_HOME via the ~/.vnx-system/current symlink and via each fallback
+     candidate, plus candidate-priority ordering
+  7. the locally-assigned-$ROOT blind spot (documented-skip regression)
+  8. the CLI/doctor coverage-gap messaging fix (unresolved != resolved)
+  9. the hookpin_check.sh SessionStart wiring itself, both at the settings.json
+     level (this repo + the fleet template) and end-to-end through the real
+     shell script — including a regression test for the exit-code-gating bug
+     (--json exits 1 on a *found* dead pin; an `|| exit 0` on that capture
+     silently swallowed the positive case) found and fixed in this same PR.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+SCRIPT_DIR = REPO / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import hookpin_check  # noqa: E402
+from hookpin_check import (  # noqa: E402
+    STATUS_MISSING,
+    STATUS_OK,
+    STATUS_UNRESOLVED,
+    check_project_hook_pins,
+)
+from vnx_doctor import PASS, WARN, FAIL, check_hook_pins  # noqa: E402
+
+HOOKPIN_SH = SCRIPT_DIR / "hooks" / "hookpin_check.sh"
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _write_settings(project_root: Path, hooks: dict) -> None:
+    project_root.mkdir(parents=True, exist_ok=True)
+    claude_dir = project_root / ".claude"
+    claude_dir.mkdir(parents=True, exist_ok=True)
+    (claude_dir / "settings.json").write_text(json.dumps({"hooks": hooks}))
+
+
+def _stop_hook(command: str) -> dict:
+    return {"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": command}]}]}
+
+
+# ---------------------------------------------------------------------------
+# 1. Dead / live absolute pin
+# ---------------------------------------------------------------------------
+
+def test_dead_absolute_pin_reported_missing(tmp_path):
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"bash {tmp_path}/does-not-exist.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert len(findings) == 1
+    assert findings[0].status == STATUS_MISSING
+
+
+def test_live_absolute_pin_reported_ok(tmp_path):
+    script = tmp_path / "real.sh"
+    script.write_text("#!/bin/bash\n")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"bash {script}"))
+
+    findings = check_project_hook_pins(project)
+
+    assert len(findings) == 1
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(script)
+
+
+# ---------------------------------------------------------------------------
+# 2. Absent-by-design: no .claude dir, no hooks key
+# ---------------------------------------------------------------------------
+
+def test_no_claude_directory_returns_no_findings(tmp_path):
+    assert check_project_hook_pins(tmp_path) == []
+
+
+def test_no_hooks_key_returns_no_findings(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+    (project / ".claude").mkdir()
+    (project / ".claude" / "settings.json").write_text(json.dumps({"permissions": {}}))
+
+    assert check_project_hook_pins(project) == []
+
+
+# ---------------------------------------------------------------------------
+# 3. Disabled matcher
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("matcher", ["disabled", "DISABLED", "__never_match__"])
+def test_disabled_matcher_is_skipped(tmp_path, matcher):
+    project = tmp_path / "proj"
+    _write_settings(project, {
+        "PreToolUse": [{
+            "matcher": matcher,
+            "hooks": [{"type": "command", "command": f"bash {tmp_path}/does-not-exist.sh"}],
+        }]
+    })
+
+    assert check_project_hook_pins(project) == []
+
+
+# ---------------------------------------------------------------------------
+# 4. $(git rev-parse --show-toplevel) resolution
+# ---------------------------------------------------------------------------
+
+def test_git_toplevel_token_resolves_against_project_root(tmp_path):
+    real = tmp_path / "proj" / "scripts" / "hooks" / "real.sh"
+    real.parent.mkdir(parents=True)
+    real.write_text("#!/bin/bash\n")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(
+        "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+        "/scripts/hooks/real.sh\"'"
+    ))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(real)
+    assert findings[0].raw_path.startswith("$(git rev-parse --show-toplevel)")
+
+
+def test_git_toplevel_token_reports_dead_when_missing(tmp_path):
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(
+        "bash -c 'exec bash \"$(git rev-parse --show-toplevel 2>/dev/null || echo .)"
+        "/scripts/hooks/gone.sh\"'"
+    ))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_MISSING
+
+
+# ---------------------------------------------------------------------------
+# 5. $CLAUDE_PROJECT_DIR / $PROJECT_ROOT resolution
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("var", ["CLAUDE_PROJECT_DIR", "PROJECT_ROOT"])
+def test_project_relative_vars_resolve(tmp_path, var):
+    real = tmp_path / "proj" / "scripts" / "real.py"
+    real.parent.mkdir(parents=True)
+    real.write_text("x")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"python3 ${var}/scripts/real.py"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(real)
+
+
+@pytest.mark.parametrize("var", ["CLAUDE_PROJECT_DIR", "PROJECT_ROOT"])
+def test_project_relative_vars_braced_form_resolves(tmp_path, var):
+    real = tmp_path / "proj" / "scripts" / "real.py"
+    real.parent.mkdir(parents=True)
+    real.write_text("x")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook("python3 ${%s}/scripts/real.py" % var))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(real)
+
+
+# ---------------------------------------------------------------------------
+# 6. $VNX_HOME resolution: symlink, each fallback candidate, and priority
+# ---------------------------------------------------------------------------
+
+def test_vnx_home_resolves_via_current_symlink(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_HOME", raising=False)
+    fake_home = tmp_path / "fakehome"
+    fake_home.mkdir()
+    version_dir = tmp_path / "versions" / "1.4.2"
+    (version_dir / "scripts" / "hooks").mkdir(parents=True)
+    (version_dir / "scripts" / "hooks" / "foo.sh").write_text("x")
+    vnx_system = fake_home / ".vnx-system"
+    vnx_system.mkdir()
+    current = vnx_system / "current"
+    current.symlink_to(version_dir)
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(current / "scripts" / "hooks" / "foo.sh")
+
+
+def test_vnx_home_resolves_via_env_var(tmp_path, monkeypatch):
+    engine = tmp_path / "engine"
+    (engine / "scripts" / "hooks").mkdir(parents=True)
+    (engine / "scripts" / "hooks" / "foo.sh").write_text("x")
+    monkeypatch.setenv("VNX_HOME", str(engine))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(engine / "scripts" / "hooks" / "foo.sh")
+
+
+def test_vnx_home_resolves_via_project_dot_vnx(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    (project / ".vnx" / "scripts" / "hooks").mkdir(parents=True)
+    (project / ".vnx" / "scripts" / "hooks" / "foo.sh").write_text("x")
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(project / ".vnx" / "scripts" / "hooks" / "foo.sh")
+
+
+def test_vnx_home_resolves_via_project_claude_vnx_system(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    (project / ".claude" / "vnx-system" / "scripts" / "hooks").mkdir(parents=True)
+    (project / ".claude" / "vnx-system" / "scripts" / "hooks" / "foo.sh").write_text("x")
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(
+        project / ".claude" / "vnx-system" / "scripts" / "hooks" / "foo.sh"
+    )
+
+
+def test_vnx_home_resolves_via_project_root_itself(tmp_path, monkeypatch):
+    """Standalone-dev checkout: VNX_HOME == PROJECT_ROOT, the last-resort candidate."""
+    monkeypatch.delenv("VNX_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    (project / "scripts" / "hooks").mkdir(parents=True)
+    (project / "scripts" / "hooks" / "foo.sh").write_text("x")
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_OK
+    assert findings[0].resolved_path == str(project / "scripts" / "hooks" / "foo.sh")
+
+
+def test_vnx_home_candidate_priority_env_before_dot_vnx(tmp_path, monkeypatch):
+    """Two candidates both satisfy the token; the env var must win (first in
+    _vnx_home_candidates()'s order), not project_root/.vnx."""
+    env_dir = tmp_path / "env-engine"
+    (env_dir / "scripts" / "hooks").mkdir(parents=True)
+    (env_dir / "scripts" / "hooks" / "foo.sh").write_text("env")
+    monkeypatch.setenv("VNX_HOME", str(env_dir))
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    (project / ".vnx" / "scripts" / "hooks").mkdir(parents=True)
+    (project / ".vnx" / "scripts" / "hooks" / "foo.sh").write_text("dotvnx")
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].resolved_path == str(env_dir / "scripts" / "hooks" / "foo.sh")
+
+
+def test_vnx_home_unresolved_when_no_candidate_exists(tmp_path, monkeypatch):
+    monkeypatch.delenv("VNX_HOME", raising=False)
+    monkeypatch.setattr(Path, "home", lambda: tmp_path / "no-vnx-system-here")
+
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook("bash ${VNX_HOME}/scripts/hooks/foo.sh"))
+
+    findings = check_project_hook_pins(project)
+
+    assert findings[0].status == STATUS_UNRESOLVED
+
+
+# ---------------------------------------------------------------------------
+# 7. Locally-assigned $ROOT blind spot — documented-skip regression
+# ---------------------------------------------------------------------------
+
+def test_locally_assigned_root_var_is_unresolved_not_silently_ok_or_dead(tmp_path):
+    """OI-1123 r2 audit finding 2: resolve_token() only knows CLAUDE_PROJECT_DIR,
+    PROJECT_ROOT and VNX_HOME. A hook that assigns ROOT=$(git rev-parse
+    --show-toplevel) *locally* and references $ROOT later in the SAME command
+    string is invisible to this checker — it has no shell parser and cannot
+    see an assignment made earlier in the same string. This is the exact
+    shape of 3 of vnx-orchestration's own 15 SessionStart/SessionEnd/Stop
+    hook entries today (build_current_state.py, build_doc_indexes.py,
+    session_stop_rotation.py). The design choice (report UNRESOLVED, never
+    guess OK or MISSING) is documented in the module docstring; this test
+    pins that current behavior so a future change is deliberate, not an
+    accidental regression that starts producing false PASSes or false FAILs.
+    """
+    real = tmp_path / "proj" / "scripts" / "foo.py"
+    real.parent.mkdir(parents=True)
+    real.write_text("x")  # the file DOES exist — proves this isn't a MISSING misdetect
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(
+        "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && "
+        "python3 \"$ROOT/scripts/foo.py\"'"
+    ))
+
+    findings = check_project_hook_pins(project)
+
+    assert len(findings) == 1
+    assert findings[0].status == STATUS_UNRESOLVED, (
+        "locally-assigned $ROOT must stay UNRESOLVED (not silently OK, not "
+        "falsely DEAD) — see module docstring for the reasoning"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. CLI (main()) and vnx_doctor coverage-gap messaging
+# ---------------------------------------------------------------------------
+
+def _run_cli(monkeypatch, capsys, project_root):
+    monkeypatch.setattr(sys, "argv", ["hookpin_check.py", "--project-root", str(project_root)])
+    rc = hookpin_check.main()
+    return rc, capsys.readouterr().out
+
+
+def test_cli_all_resolve_states_full_coverage(tmp_path, monkeypatch, capsys):
+    real = tmp_path / "real.sh"
+    real.write_text("x")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"bash {real}"))
+
+    rc, out = _run_cli(monkeypatch, capsys, project)
+
+    assert rc == 0
+    assert "All 1 configured hook pin(s) resolve" in out
+
+
+def test_cli_unresolved_only_does_not_claim_full_coverage(tmp_path, monkeypatch, capsys):
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(
+        "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && bash \"$ROOT/x.sh\"'"
+    ))
+
+    rc, out = _run_cli(monkeypatch, capsys, project)
+
+    assert rc == 0, "unresolved alone must not fail the check (design: never guess)"
+    assert "unresolved" in out
+    assert "not confirmed dead" in out
+    assert "All 1 configured hook pin(s) resolve" not in out, (
+        "must not claim full coverage when a pin was never actually checked"
+    )
+
+
+def test_cli_dead_and_unresolved_reported_together(tmp_path, monkeypatch, capsys):
+    project = tmp_path / "proj"
+    _write_settings(project, {
+        "Stop": [
+            {"matcher": "", "hooks": [
+                {"type": "command", "command": f"bash {tmp_path}/gone.sh"},
+            ]},
+            {"matcher": "", "hooks": [
+                {"type": "command", "command":
+                 "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && bash \"$ROOT/x.sh\"'"},
+            ]},
+        ]
+    })
+
+    rc, out = _run_cli(monkeypatch, capsys, project)
+
+    assert rc == 1
+    assert "1 dead hook pin(s)" in out
+    assert "1 more pin(s) unresolved" in out
+
+
+def test_check_hook_pins_pass_when_all_resolve(tmp_path):
+    real = tmp_path / "real.sh"
+    real.write_text("x")
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"bash {real}"))
+
+    results = check_hook_pins({"PROJECT_ROOT": str(project)})
+
+    assert len(results) == 1
+    assert results[0].status == PASS
+
+
+def test_check_hook_pins_fail_when_dead_pin_present(tmp_path):
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(f"bash {tmp_path}/gone.sh"))
+
+    results = check_hook_pins({"PROJECT_ROOT": str(project)})
+
+    assert len(results) == 1
+    assert results[0].status == FAIL
+    assert "do not resolve" in results[0].message
+
+
+def test_check_hook_pins_warn_when_only_unresolved(tmp_path):
+    """Finding 2 fix: an unresolved-only result must not read as a clean PASS
+    — that would claim full coverage of pins this checker never actually
+    verified."""
+    project = tmp_path / "proj"
+    _write_settings(project, _stop_hook(
+        "bash -c 'ROOT=$(git rev-parse --show-toplevel 2>/dev/null) && bash \"$ROOT/x.sh\"'"
+    ))
+
+    results = check_hook_pins({"PROJECT_ROOT": str(project)})
+
+    assert len(results) == 1
+    assert results[0].status == WARN
+    assert "could not be checked" in results[0].message
+
+
+def test_check_hook_pins_empty_when_no_settings_file(tmp_path):
+    project = tmp_path / "proj"
+    project.mkdir()
+
+    assert check_hook_pins({"PROJECT_ROOT": str(project)}) == []
+
+
+# ---------------------------------------------------------------------------
+# 9a. SessionStart wiring — settings.json / template, both must reference it
+# ---------------------------------------------------------------------------
+
+def test_repo_settings_json_wires_hookpin_check_into_sessionstart():
+    """OI-1123 finding 1: without this wire, `vnx doctor` (pull, human-
+    triggered) was the ONLY live detection — the central claim that a dead
+    pin becomes loud on the very next session was not true."""
+    settings_path = REPO / ".claude" / "settings.json"
+    data = json.loads(settings_path.read_text())
+    commands = [
+        h.get("command", "")
+        for e in data.get("hooks", {}).get("SessionStart", [])
+        for h in e.get("hooks", [])
+    ]
+    assert any("hookpin_check.sh" in c for c in commands)
+
+
+def test_fleet_template_wires_hookpin_check_into_sessionstart():
+    """Same finding, fleet side: without this, `vnx bootstrap-hooks`/`vnx init`
+    never deploys the check to mission-control, SEOcrawler_v2, sales-copilot."""
+    tmpl_path = REPO / "templates" / "settings_vnx_keys.json.tmpl"
+    data = json.loads(tmpl_path.read_text())
+    commands = [
+        h.get("command", "")
+        for e in data.get("hooks", {}).get("SessionStart", [])
+        for h in e.get("hooks", [])
+    ]
+    assert any("hookpin_check.sh" in c for c in commands)
+
+
+# ---------------------------------------------------------------------------
+# 9b. hookpin_check.sh end-to-end (real subprocess, real script)
+# ---------------------------------------------------------------------------
+
+def test_hookpin_check_sh_is_valid_bash():
+    result = subprocess.run(["bash", "-n", str(HOOKPIN_SH)], capture_output=True, text=True)
+    assert result.returncode == 0, result.stderr
+
+
+def test_hookpin_check_sh_surfaces_dead_pin_as_sessionstart_json(tmp_path):
+    """Regression test for the bug found while proving the SessionStart wire:
+    --json mode exits 1 exactly when it finds a dead pin (the positive
+    case), so gating the RESULT capture with `|| exit 0` silently swallowed
+    the one case this hook exists to report. Runs the REAL script."""
+    project = tmp_path / "proj"
+    (project / ".claude").mkdir(parents=True)
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [
+        {"type": "command", "command": f"bash {tmp_path}/does-not-exist.sh"}
+    ]}]}}
+    (project / ".claude" / "settings.json").write_text(json.dumps(settings))
+
+    result = subprocess.run(
+        ["bash", str(HOOKPIN_SH)], cwd=str(project),
+        capture_output=True, text=True, timeout=10,
+    )
+
+    assert result.returncode == 0, "fail-soft contract: hook must always exit 0"
+    payload = json.loads(result.stdout)
+    ctx = payload["hookSpecificOutput"]["additionalContext"]
+    assert "does-not-exist.sh" in ctx
+    assert "do NOT resolve" in ctx
+
+
+def test_hookpin_check_sh_silent_when_all_pins_resolve(tmp_path):
+    real = tmp_path / "real.sh"
+    real.write_text("#!/bin/bash\n")
+    project = tmp_path / "proj"
+    (project / ".claude").mkdir(parents=True)
+    settings = {"hooks": {"Stop": [{"matcher": "", "hooks": [
+        {"type": "command", "command": f"bash {real}"}
+    ]}]}}
+    (project / ".claude" / "settings.json").write_text(json.dumps(settings))
+
+    result = subprocess.run(
+        ["bash", str(HOOKPIN_SH)], cwd=str(project),
+        capture_output=True, text=True, timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""
+
+
+def test_hookpin_check_sh_noop_without_settings_file(tmp_path):
+    result = subprocess.run(
+        ["bash", str(HOOKPIN_SH)], cwd=str(tmp_path),
+        capture_output=True, text=True, timeout=10,
+    )
+
+    assert result.returncode == 0
+    assert result.stdout.strip() == ""


### PR DESCRIPTION
## Summary

Finishes OI-1123 after two prior rounds (round 1: salvaged implementation on
`dispatch/20260810g-e-hookpin-verify`; round 2: read-only security audit,
`$VNX_DATA_DIR/unified_reports/20260810g-k-hookpin-r2.md`). Addresses every
finding from the round-2 audit and fixes a bug found while proving the fix
end-to-end.

- **Wires the SessionStart surface** into this repo's `.claude/settings.json`
  and the fleet-wide `templates/settings_vnx_keys.json.tmpl` (deployed via
  `vnx bootstrap-hooks`/`vnx init`/`regen-settings --merge`). Previously
  `hookpin_check.sh` existed on disk but nothing invoked it — only `vnx doctor`
  (pull, human-triggered) actually detected a dead pin.
- **Fixes a real bug found while proving the wire**: `hookpin_check.sh` gated
  its `RESULT` capture on the checker's own exit code
  (`RESULT="$(...)" || exit 0`). `--json` mode exits 1 *exactly* when it finds
  a dead pin — that's the positive case, not a crash — so the `|| exit 0`
  silently swallowed the one signal this hook exists to produce. Confirmed via
  red/green: with the bug present, a dead pin in a synthetic fixture produces
  no `additionalContext`; with the fix, it does.
- **Closes the unresolved-coverage gap** (finding 2): a resolver blind spot for
  locally-assigned `$ROOT` (e.g. `ROOT=$(git rev-parse --show-toplevel) && ...
  "$ROOT/foo.py"`) is real — 3 of this repo's own 15 hook entries hit it. The
  CLI and `vnx_doctor.py::check_hook_pins()` now say explicitly how many pins
  were checked vs. skipped, and `vnx doctor` reports WARN (not a silent PASS)
  when only unresolved-but-not-dead pins remain.
- **Documents** the current-version-symlink scope question (detection-only,
  never touches pin emission) and the fail-soft-on-its-own-bugs trade-off, both
  inline in the module/hook docstrings.
- **Adds `tests/test_hookpin_check.py`** (34 cases): dead/live absolute pins,
  absent-by-design (no `.claude`, no `hooks` key), disabled matcher,
  `$(git rev-parse --show-toplevel)`, `$CLAUDE_PROJECT_DIR`/`$PROJECT_ROOT`,
  `$VNX_HOME` via the `~/.vnx-system/current` symlink and every fallback
  candidate (plus priority ordering), the locally-assigned-`$ROOT` blind spot
  (documented-skip regression), the CLI/doctor coverage-gap messaging, the
  SessionStart wiring itself (settings.json + template), and the real
  `hookpin_check.sh` subprocess end-to-end (including a dedicated regression
  test for the exit-code bug above).

## Test plan

- [x] `pytest tests/test_hookpin_check.py` — 34/34 passed
- [x] `pytest tests/test_hookpin_check.py tests/test_vnx_doctor.py tests/test_vnx_doctor_runtime.py tests/test_doctor_refactor_oi1573.py tests/test_doctor_standalone_dev.py tests/test_vnx_doctor_strict.py tests/test_vnx_doctor_template_scan.py tests/test_structural_doctor.py tests/test_wave4_regen_settings_target.py tests/test_t0_role_audit_static.py tests/unit/vnx_cli/commands/test_doctor.py` — 233/233 passed
- [x] `bash -n scripts/hooks/hookpin_check.sh` — OK
- [x] `python3 scripts/vnx_doctor.py` against this repo — exit 0, `hookpin` shows `WARN: 13 of 16 ... resolving; 3 could not be checked`
- [x] Checker run against all 4 fleet projects (vnx-orchestration, mission-control, SEOcrawler_v2, sales-copilot) — all exit 0, mission-control's two pins now resolve (operator repointed them mid-flight), vnx-orchestration shows the exact 3-SKIP gap
- [x] Out/red/in/green proof for the SessionStart wiring (synthetic fixture) and for the exit-code bug fix — both in the completion report

🤖 Generated with [Claude Code](https://claude.com/claude-code)