### PR TITLE
fix(dispatch): scope the tmux paste buffer per dispatch (OI-1126, OI-1124)

### DIFF
--- a/scripts/hooks/tmux_signal_prompt_received.sh
+++ b/scripts/hooks/tmux_signal_prompt_received.sh
@@ -17,6 +17,20 @@
 # instead of letting the dispatch run to a deadline against content that isn't its
 # own. Best-effort: jq missing or prompt unparseable -> skip the check, never block.
 #
+# OI-1126 round 3: the extraction is scoped to the APPENDED completion-protocol
+# block, not the whole delivered prompt. dispatch() in tmux_interactive_dispatch.py
+# always assembles body = <context/instruction> + <completion protocol> + <trailer>,
+# so the protocol block — and its code-guaranteed dispatch_id — is always the LAST
+# occurrence, never the first. Grepping the whole prompt and taking the first match
+# picked up any earlier dispatch_id-shaped text the operator's own instruction
+# happened to quote (a JSON receipt fragment, a ledger excerpt — VNX dispatch
+# instructions do this routinely, since the fabric's own open items are ABOUT
+# receipts and identifiers), which both false-killed healthy dispatches and could
+# mask a genuine crossing behind an earlier, coincidentally-matching foreign value.
+# Anchoring on the protocol block's own fixed heading (see _build_completion_protocol's
+# "## Completion Protocol (interactive lane)" heading) survives the append order
+# changing, since that's an implementation detail of a different file.
+#
 # Scoped HARD to tmux-spawn workers: fires ONLY when BOTH VNX_TMUX_SIGNAL_DIR and
 # VNX_DISPATCH_ID are set. For any normal T0/interactive session (env unset) it
 # drains stdin and exits 0 — completely no-op, no behavior change.
@@ -41,9 +55,19 @@ if command -v jq >/dev/null 2>&1; then
   # level. Strip backslashes first so one plain-quote pattern matches both the
   # escaped (\"dispatch_id\") and unescaped ("dispatch_id") forms.
   CLEAN_PROMPT="$(printf '%s' "$PROMPT_TEXT" | tr -d '\\')"
-  DELIVERED_ID="$(printf '%s' "$CLEAN_PROMPT" \
+  # Scope to the appended protocol block: everything FROM its fixed heading
+  # onward. Empty when the heading isn't present (e.g. VNX_BENCH_EQUAL_CONTEXT=1,
+  # which delivers only the context body with no protocol appended at all) —
+  # that correctly falls through to "no embedded value -> skip the check" below.
+  PROTOCOL_BLOCK="$(printf '%s' "$CLEAN_PROMPT" \
+    | sed -n '/## Completion Protocol (interactive lane)/,$p')"
+  # Last match within the scoped block (not the whole prompt): the protocol
+  # markdown embeds the dispatch_id twice, once per ready-made done/failed
+  # command, both identical, so "last" vs "first" here is just belt-and-braces
+  # against the block itself ever growing a second, non-identical occurrence.
+  DELIVERED_ID="$(printf '%s' "$PROTOCOL_BLOCK" \
     | grep -oE '"dispatch_id"[[:space:]]*:[[:space:]]*"[^"]+"' \
-    | head -1 | sed -E 's/.*"([^"]+)"$/\1/' || true)"
+    | tail -1 | sed -E 's/.*"([^"]+)"$/\1/' || true)"
   if [ -n "$DELIVERED_ID" ] && [ "$DELIVERED_ID" != "$VNX_DISPATCH_ID" ]; then
     {
       mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null

--- a/scripts/hooks/tmux_signal_prompt_received.sh
+++ b/scripts/hooks/tmux_signal_prompt_received.sh
@@ -6,18 +6,52 @@
 # dispatch instruction was actually submitted via the stable HOOK CONTRACT,
 # instead of inferring it from version-specific TUI pane scraping.
 #
+# OI-1126 worker-side detectability: also checks whether the delivered prompt
+# actually belongs to THIS dispatch. Every tmux-lane body carries a
+# "dispatch_id": "<id>" field inside the completion-protocol JSON that
+# _build_completion_protocol() unconditionally appends (tmux_interactive_dispatch.py)
+# — a code-guaranteed marker, independent of how the raw instruction bundle happens
+# to be formatted. If that embedded id disagrees with $VNX_DISPATCH_ID (set
+# race-free at spawn/launch time, never via the shared tmux paste buffer that OI-1126
+# found racy), a "dispatch_id_mismatch" sentinel is written so the lane fails loud
+# instead of letting the dispatch run to a deadline against content that isn't its
+# own. Best-effort: jq missing or prompt unparseable -> skip the check, never block.
+#
 # Scoped HARD to tmux-spawn workers: fires ONLY when BOTH VNX_TMUX_SIGNAL_DIR and
 # VNX_DISPATCH_ID are set. For any normal T0/interactive session (env unset) it
 # drains stdin and exits 0 — completely no-op, no behavior change.
 #
 # Atomic write (.tmp then mv). Never blocks. Any error -> exit 0.
 
-# Drain stdin so the hook caller never blocks on an unread pipe.
-cat >/dev/null 2>&1 || true
+# Read stdin once (this also serves as draining it so the hook caller never
+# blocks on an unread pipe, guard or no guard).
+INPUT="$(cat 2>/dev/null || true)"
 
 # ── Guard: only fire for tmux-spawn workers ──────────────────────────────────
 if [ -z "${VNX_TMUX_SIGNAL_DIR:-}" ] || [ -z "${VNX_DISPATCH_ID:-}" ]; then
   exit 0
+fi
+
+# ── OI-1126: does the delivered prompt actually belong to this dispatch? ─────
+if command -v jq >/dev/null 2>&1; then
+  PROMPT_TEXT="$(printf '%s' "$INPUT" | jq -r '.prompt // ""' 2>/dev/null || echo "")"
+  # The completion-protocol JSON is embedded as shell-escaped bash-command text
+  # (_make_receipt_json backslash-escapes its inner quotes so the WORKER's later
+  # `bash` execution parses them correctly) — it is not raw JSON at the markdown-text
+  # level. Strip backslashes first so one plain-quote pattern matches both the
+  # escaped (\"dispatch_id\") and unescaped ("dispatch_id") forms.
+  CLEAN_PROMPT="$(printf '%s' "$PROMPT_TEXT" | tr -d '\\')"
+  DELIVERED_ID="$(printf '%s' "$CLEAN_PROMPT" \
+    | grep -oE '"dispatch_id"[[:space:]]*:[[:space:]]*"[^"]+"' \
+    | head -1 | sed -E 's/.*"([^"]+)"$/\1/' || true)"
+  if [ -n "$DELIVERED_ID" ] && [ "$DELIVERED_ID" != "$VNX_DISPATCH_ID" ]; then
+    {
+      mkdir -p "$VNX_TMUX_SIGNAL_DIR" 2>/dev/null
+      _mtmp="$VNX_TMUX_SIGNAL_DIR/dispatch_id_mismatch.$$.tmp"
+      printf 'expected=%s delivered=%s\n' "$VNX_DISPATCH_ID" "$DELIVERED_ID" >"$_mtmp" 2>/dev/null \
+        && mv -f "$_mtmp" "$VNX_TMUX_SIGNAL_DIR/dispatch_id_mismatch" 2>/dev/null
+    } || true
+  fi
 fi
 
 # Best-effort atomic sentinel write.

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1400,10 +1400,24 @@ class TmuxInteractiveDispatch:
         )
         return False
 
-    def _deliver_instruction(self, pane_id: str, body: str) -> bool:
+    def _verify_pane_identity(self, pane_id: str, session: str) -> bool:
+        """OI-1126 defense-in-depth: assert *pane_id* still belongs to *session*.
+
+        Pane addressing was measured stable (a captured pane_id never drifts to a
+        different session within a live tmux server — 0 mismatches across repeated
+        concurrent-spawn trials), but this check is the difference between "delivery
+        to the wrong pane is unlikely" and "delivery to the wrong pane is impossible":
+        called immediately before every send-keys/paste that carries dispatch content,
+        so a future addressing regression fails loud here instead of silently
+        delivering into a sibling dispatch's pane.
+        """
+        check = self._runner.run(["display-message", "-p", "-t", pane_id, "#{session_name}"])
+        return check.returncode == 0 and check.stdout.strip() == session
+
+    def _deliver_instruction(self, pane_id: str, body: str, dispatch_id: str) -> bool:
         """Clear input, paste the instruction body, settle, then submit with Enter."""
         self._runner.run(["send-keys", "-t", pane_id, "C-u"])
-        if not self._paste(pane_id, body):
+        if not self._paste(pane_id, body, dispatch_id):
             return False
         # Settle after bracketed paste so the pane has fully received the content.
         # Scale with body size: +1s per 50k chars, capped at +2s. Large bodies need
@@ -1669,29 +1683,54 @@ class TmuxInteractiveDispatch:
             return WORK_START_AWAITING_PERMISSION
         return WORK_START_NO_PROGRESS
 
-    def _paste(self, pane_id: str, content: str, max_inline: int = 50000) -> bool:
-        """Load *content* into a tmux buffer and paste it into the pane."""
-        if len(content) > max_inline:
-            tmp_path = ""
-            try:
-                with tempfile.NamedTemporaryFile(
-                    mode="w", suffix=".vnx_int_buf", delete=False, encoding="utf-8"
-                ) as fh:
-                    fh.write(content)
-                    tmp_path = fh.name
-                rc = self._runner.run(["load-buffer", tmp_path]).returncode
-            finally:
-                if tmp_path:
-                    try:
-                        os.unlink(tmp_path)
-                    except OSError:
-                        pass
-        else:
-            rc = self._runner.run(["load-buffer", "-"], input_text=content).returncode
-        if rc != 0:
-            logger.warning("interactive: load-buffer failed for %s", pane_id)
-            return False
-        return self._runner.run(["paste-buffer", "-t", pane_id]).returncode == 0
+    def _paste(self, pane_id: str, content: str, dispatch_id: str, max_inline: int = 50000) -> bool:
+        """Load *content* into a PER-DISPATCH NAMED tmux buffer and paste it into the pane.
+
+        OI-1126: ``load-buffer``/``paste-buffer`` without ``-b <name>`` operate on the
+        tmux SERVER's single shared "most recent buffer" slot, not on data scoped to
+        this call. Two dispatches racing to load+paste concurrently (fired close
+        together, e.g. via the door) can have dispatch A's ``paste-buffer`` retrieve
+        dispatch B's just-loaded content instead of its own — a TOCTOU race on shared
+        global state. Measured: 0/25 crossings with a 2-dispatch, 2s-staggered load, but
+        15/15 (100%) with 4 dispatches racing with no stagger at all — see the dispatch
+        report for the full reproduction. This was NOT a pane-addressing bug: pane_id
+        always stayed correctly bound to its own session (also measured, 0 mismatches
+        across 3x4-way spawn-only trials); the race was purely in the shared buffer.
+        A dispatch-id-scoped buffer name makes load+paste immune to any concurrently
+        running sibling dispatch, because no two dispatches ever touch the same buffer.
+        """
+        buffer_name = f"vnx-paste-{_sanitize_session_name(dispatch_id)}"
+        try:
+            if len(content) > max_inline:
+                tmp_path = ""
+                try:
+                    with tempfile.NamedTemporaryFile(
+                        mode="w", suffix=".vnx_int_buf", delete=False, encoding="utf-8"
+                    ) as fh:
+                        fh.write(content)
+                        tmp_path = fh.name
+                    rc = self._runner.run(["load-buffer", "-b", buffer_name, tmp_path]).returncode
+                finally:
+                    if tmp_path:
+                        try:
+                            os.unlink(tmp_path)
+                        except OSError:
+                            pass
+            else:
+                rc = self._runner.run(
+                    ["load-buffer", "-b", buffer_name, "-"], input_text=content
+                ).returncode
+            if rc != 0:
+                logger.warning("interactive: load-buffer failed for %s", pane_id)
+                return False
+            return self._runner.run(
+                ["paste-buffer", "-b", buffer_name, "-t", pane_id]
+            ).returncode == 0
+        finally:
+            # Best-effort cleanup: a long-running fleet must not accumulate one
+            # named buffer per dispatch forever. Failure here never affects the
+            # paste outcome already computed above.
+            self._runner.run(["delete-buffer", "-b", buffer_name])
 
     # -- worker-permission relay (governance, flag-gated) ------------------
     def _maybe_start_permission_relay(self, session: str, dispatch_id: str):
@@ -2558,6 +2597,31 @@ class TmuxInteractiveDispatch:
                     f"VNX_DISPATCH_ID={shlex.quote(dispatch_id)}; {launch_cmd}"
                 )
 
+            # OI-1126: verify the captured pane_id still belongs to THIS dispatch's
+            # session immediately before the first content is delivered to it. Cheap
+            # (~one tmux round-trip) defense-in-depth on top of the per-dispatch named
+            # buffer fix below — makes delivery to a sibling dispatch's pane impossible
+            # to do silently, not merely unlikely.
+            if not self._verify_pane_identity(pane_id, session):
+                self._emit_event(
+                    "interactive_pane_identity_mismatch",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="pane_id no longer bound to this dispatch's session before launch",
+                    metadata={"session": session, "pane_id": pane_id},
+                )
+                _teardown("pane_identity_mismatch")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="pane_identity_mismatch_before_launch",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
             if not self._launch_claude(pane_id, launch_cmd):
                 self._emit_event(
                     "interactive_launch_failed",
@@ -2746,7 +2810,30 @@ class TmuxInteractiveDispatch:
                 reason="send-keys dispatch instruction",
                 metadata={"session": session, "pane_id": pane_id},
             )
-            if not self._deliver_instruction(pane_id, body):
+            # OI-1126: re-verify identity right before the instruction payload itself
+            # goes out — this is the delivery the reproduction showed was actually at
+            # risk (via the shared tmux paste buffer, now fixed below in _paste()).
+            if not self._verify_pane_identity(pane_id, session):
+                self._emit_event(
+                    "interactive_pane_identity_mismatch",
+                    dispatch_id=dispatch_id,
+                    label=label,
+                    reason="pane_id no longer bound to this dispatch's session before instruction delivery",
+                    metadata={"session": session, "pane_id": pane_id},
+                )
+                _teardown("pane_identity_mismatch")
+                return InteractiveDispatchResult(
+                    success=False,
+                    dispatch_id=dispatch_id,
+                    session=session,
+                    label=label,
+                    window_id=window_id,
+                    pane_id=pane_id,
+                    failure_reason="pane_identity_mismatch_before_deliver",
+                    duration_seconds=time.monotonic() - start_time,
+                )
+
+            if not self._deliver_instruction(pane_id, body, dispatch_id):
                 self._emit_event(
                     "interactive_deliver_failed",
                     dispatch_id=dispatch_id,
@@ -2801,6 +2888,56 @@ class TmuxInteractiveDispatch:
                     duration_seconds=time.monotonic() - start_time,
                     worktree_state=_wt_state[0],
                 )
+
+            # 7b-alt. OI-1126 worker-side detectability: the UserPromptSubmit hook
+            # (tmux_signal_prompt_received.sh) independently compares the dispatch_id
+            # embedded in the delivered prompt's completion-protocol JSON against
+            # VNX_DISPATCH_ID (set race-free at spawn/launch time, never via the shared
+            # paste buffer) and drops a "dispatch_id_mismatch" sentinel when they
+            # disagree. The worker's own pane is the last line of defence against a
+            # delivery bug anywhere upstream of it — fail loud immediately rather than
+            # let the dispatch run out its deadline against content that isn't its own.
+            if signal_dir is not None:
+                _mismatch_sentinel = signal_dir / "dispatch_id_mismatch"
+                if _mismatch_sentinel.exists():
+                    _mismatch_detail = ""
+                    try:
+                        _mismatch_detail = _mismatch_sentinel.read_text(encoding="utf-8").strip()
+                    except OSError:
+                        pass
+                    self._emit_event(
+                        "interactive_dispatch_id_mismatch",
+                        dispatch_id=dispatch_id,
+                        label=label,
+                        reason=_mismatch_detail or "worker-side dispatch id mismatch detected",
+                        metadata={"session": session, "pane_id": pane_id},
+                    )
+                    self._govern_report(
+                        dispatch_id=dispatch_id,
+                        terminal_id=label,
+                        instruction=instruction,
+                        receipt=None,
+                        duration_seconds=time.monotonic() - start_time,
+                        base_sha=worktree_handle.base_sha if worktree_handle else None,
+                        worktree_path=worktree_handle.path if worktree_handle else None,
+                        model=model,
+                        failure_reason="dispatch_id_mismatch_detected",
+                        role=role,
+                        session_id=session_uuid,
+                        permission_posture=permission_posture,
+                    )
+                    _teardown("dispatch_id_mismatch_detected")
+                    return InteractiveDispatchResult(
+                        success=False,
+                        dispatch_id=dispatch_id,
+                        session=session,
+                        label=label,
+                        window_id=window_id,
+                        pane_id=pane_id,
+                        failure_reason="dispatch_id_mismatch_detected",
+                        duration_seconds=time.monotonic() - start_time,
+                        worktree_state=_wt_state[0],
+                    )
 
             # 7b-bis. Confirm the worker actually STARTED working. A verified submit can
             # still clear the input box without the worker progressing under subscription

--- a/tests/test_bench_equal_context.py
+++ b/tests/test_bench_equal_context.py
@@ -152,11 +152,21 @@ def test_equal_context_matches_tmux_and_provider_assembly(monkeypatch, tmp_path)
 def test_tmux_equal_context_delivers_only_the_benchmark_prompt(monkeypatch, tmp_path):
     runner = Mock()
     runner.available.return_value = True
+    # OI-1126: tracks the -s value from the last new-session call so
+    # display-message '#{session_name}' echoes back the REAL session that was
+    # spawned (matching real tmux), instead of a hardcoded stand-in — otherwise
+    # _verify_pane_identity() sees it disagree with dispatch()'s own `session`
+    # variable and aborts before delivery even in the success path.
+    last_session_name: dict[str, str] = {}
 
     def run_tmux(args, **kwargs):
         if args[0] == "new-session":
+            if "-s" in args:
+                last_session_name["value"] = args[args.index("-s") + 1]
             return TmuxResult(0, "%1\n", "")
         if args[0] == "display-message":
+            if args[-1] == "#{session_name}":
+                return TmuxResult(0, f"{last_session_name.get('value', '')}\n", "")
             return TmuxResult(0, "@1\n", "")
         if args[0] == "capture-pane":
             return TmuxResult(0, "Welcome to Claude\n? for shortcuts", "")
@@ -175,7 +185,7 @@ def test_tmux_equal_context_delivers_only_the_benchmark_prompt(monkeypatch, tmp_
     monkeypatch.setattr(
         lane,
         "_deliver_instruction",
-        lambda pane_id, body: delivered.append(body) or False,
+        lambda pane_id, body, dispatch_id: delivered.append(body) or False,
     )
 
     lane.dispatch(

--- a/tests/test_bench_worker_isolation.py
+++ b/tests/test_bench_worker_isolation.py
@@ -184,6 +184,12 @@ class _TmuxRunner:
         self.dispatch_id = dispatch_id
         self.cwd: Path | None = None
         self.pending_paste = False
+        # OI-1126: tracks the -s value from the last new-session call so
+        # display-message '#{session_name}' echoes back the REAL session that was
+        # spawned (matching real tmux), instead of a hardcoded stand-in — otherwise
+        # _verify_pane_identity() sees it disagree with dispatch()'s own `session`
+        # variable and aborts before delivery even in the success path.
+        self._last_session_name: str | None = None
 
     def available(self) -> bool:
         return True
@@ -191,8 +197,12 @@ class _TmuxRunner:
     def run(self, args, **kwargs) -> TmuxResult:
         if args[0] == "new-session":
             self.cwd = Path(args[args.index("-c") + 1])
+            if "-s" in args:
+                self._last_session_name = args[args.index("-s") + 1]
             return TmuxResult(0, "%1\n", "")
         if args[0] == "display-message":
+            if args[-1] == "#{session_name}":
+                return TmuxResult(0, f"{self._last_session_name or ''}\n", "")
             return TmuxResult(0, "@1\n", "")
         if args[0] == "capture-pane":
             return TmuxResult(0, "Welcome to Claude\n? for shortcuts", "")

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -67,16 +67,29 @@ class FakeTmux:
         ready_content: str = "Welcome to Claude\n? for shortcuts",
         post_paste_capture_seq: "list[str] | None" = None,
         post_paste_content: "str | None" = None,
+        session_name_override: "str | None" = None,
+        simulate_dispatch_id_mismatch: bool = False,
     ) -> None:
         self.receipts_file = receipts_file
         self.dispatch_id = dispatch_id
         self._available = available
         self._spawn_ok = spawn_ok
+        # OI-1126 test hook: simulates the UserPromptSubmit hook
+        # (tmux_signal_prompt_received.sh) having detected a dispatch_id mismatch and
+        # dropped its sentinel — exercised by parsing VNX_TMUX_SIGNAL_DIR out of the
+        # launch command (the same way the real pane env carries it) so the sentinel
+        # lands in the SAME directory dispatch() itself polls.
+        self._simulate_dispatch_id_mismatch = simulate_dispatch_id_mismatch
         self._launch_ok = launch_ok
         self._deliver_ok = deliver_ok
         self._emit_receipt = emit_receipt
         self._receipt_status = receipt_status
         self._ready_content = ready_content
+        # OI-1126 test hook: when set, display-message '#{session_name}' always
+        # returns THIS value regardless of which session was actually spawned —
+        # simulates a pane whose identity no longer matches this dispatch by the
+        # time delivery is about to happen.
+        self._session_name_override = session_name_override
         self._post_paste_seq: list[str] = list(post_paste_capture_seq or [])
         # OI-863: persistent content for capture-pane calls AFTER the submit
         # (once post_paste_capture_seq is exhausted), e.g. a pane that stays on
@@ -89,6 +102,15 @@ class FakeTmux:
         self._paste_fired = False  # True after first Enter following paste-buffer
         self._literal_send_attempted = False
         self.receipts_written = 0
+        # OI-1126: tracks the -s value from the last new-session call so
+        # display-message '#{session_name}' echoes back the REAL session that was
+        # spawned (matching real tmux), instead of a hardcoded stand-in — otherwise
+        # _verify_pane_identity() would see it disagree with dispatch()'s own
+        # `session` variable and every success-path test would spuriously abort.
+        self._last_session_name: "str | None" = None
+        self.loaded_buffer_names: list[str] = []
+        self.pasted_buffer_names: list[str] = []
+        self.deleted_buffer_names: list[str] = []
 
     def available(self) -> bool:
         return self._available
@@ -100,9 +122,15 @@ class FakeTmux:
         if cmd == "new-session":
             if not self._spawn_ok:
                 return TmuxResult(1, "", "session create failed")
+            if "-s" in args:
+                self._last_session_name = args[args.index("-s") + 1]
             return TmuxResult(0, "%1\n")
 
         if cmd == "display-message":
+            if args and args[-1] == "#{session_name}":
+                if self._session_name_override is not None:
+                    return TmuxResult(0, f"{self._session_name_override}\n")
+                return TmuxResult(0, f"{self._last_session_name or ''}\n")
             return TmuxResult(0, "@1\n")
 
         if cmd == "capture-pane":
@@ -117,6 +145,8 @@ class FakeTmux:
             return TmuxResult(0, self._ready_content)
 
         if cmd == "load-buffer":
+            if "-b" in args:
+                self.loaded_buffer_names.append(args[args.index("-b") + 1])
             if not self._deliver_ok:
                 return TmuxResult(1, "", "load-buffer failed")
             if input_text is not None:
@@ -129,7 +159,14 @@ class FakeTmux:
             return TmuxResult(0)
 
         if cmd == "paste-buffer":
+            if "-b" in args:
+                self.pasted_buffer_names.append(args[args.index("-b") + 1])
             self._pending_paste = True
+            return TmuxResult(0)
+
+        if cmd == "delete-buffer":
+            if "-b" in args:
+                self.deleted_buffer_names.append(args[args.index("-b") + 1])
             return TmuxResult(0)
 
         if cmd == "send-keys":
@@ -138,6 +175,19 @@ class FakeTmux:
                 self._literal_send_attempted = True
                 if not self._launch_ok:
                     return TmuxResult(1, "", "send-keys literal failed")
+                if self._simulate_dispatch_id_mismatch:
+                    # The launch command exports VNX_TMUX_SIGNAL_DIR=<path> — parse it
+                    # out the same way the real pane env carries it, and drop the
+                    # sentinel there, simulating tmux_signal_prompt_received.sh having
+                    # detected a mismatch on the (would-be) delivered prompt.
+                    m = re.search(r"VNX_TMUX_SIGNAL_DIR=(\S+)", args[-1])
+                    if m:
+                        sig_dir = Path(m.group(1).strip("'\""))
+                        sig_dir.mkdir(parents=True, exist_ok=True)
+                        (sig_dir / "dispatch_id_mismatch").write_text(
+                            "expected=this-dispatch delivered=some-other-dispatch\n",
+                            encoding="utf-8",
+                        )
             # First Enter after paste-buffer → simulate worker completing.
             if args[-1] == "Enter" and self._pending_paste:
                 self._pending_paste = False
@@ -546,6 +596,163 @@ class TestDeliverFailureTeardown(_LaneTestCase):
         self.assertTrue(fake.killed_sessions, "kill-session must be called on deliver failure")
         handle_path = self.state_dir / "tmux_interactive" / f"{self.DISPATCH_ID}.json"
         self.assertFalse(handle_path.exists())
+
+
+class TestPasteUsesPerDispatchNamedBuffer(_LaneTestCase):
+    """OI-1126 regression: _paste() must never use tmux's shared/default buffer.
+
+    Reproduction (see the dispatch report): with the OLD unnamed load-buffer/
+    paste-buffer pair, 4 dispatches racing with no stagger crossed content
+    100% of the time (15/15 trials) even though pane_id addressing itself was
+    always correct — the race was in tmux's server-global "most recent buffer"
+    slot, not in which pane was targeted. This is the test that fails if
+    delivery is ever addressed by an unstable/shared handle again.
+    """
+
+    def test_paste_uses_named_buffer_for_this_dispatch(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        ok = lane._paste("%1", "hello world", self.DISPATCH_ID)
+
+        self.assertTrue(ok)
+        # Old behavior (regression target): ["load-buffer", "-"] / ["paste-buffer", "-t", pane].
+        # New behavior: every load/paste/delete call carries an explicit -b buffer name
+        # that is derived from THIS dispatch's id — never the bare/default buffer.
+        self.assertEqual(len(fake.loaded_buffer_names), 1)
+        self.assertEqual(len(fake.pasted_buffer_names), 1)
+        self.assertEqual(fake.loaded_buffer_names[0], fake.pasted_buffer_names[0])
+        self.assertIn(self.DISPATCH_ID, fake.loaded_buffer_names[0])
+        # Buffer is cleaned up after use so a long-running fleet never accumulates one
+        # named buffer per dispatch forever.
+        self.assertEqual(fake.deleted_buffer_names, [fake.loaded_buffer_names[0]])
+
+    def test_two_dispatches_never_share_a_buffer_name(self):
+        """The exact condition that caused OI-1126: two dispatches delivering around
+        the same time must be structurally unable to collide on buffer identity."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        lane._paste("%1", "content for A", "dispatch-a")
+        lane._paste("%2", "content for B", "dispatch-b")
+
+        self.assertEqual(len(fake.pasted_buffer_names), 2)
+        self.assertNotEqual(
+            fake.pasted_buffer_names[0], fake.pasted_buffer_names[1],
+            "two different dispatches must never paste from the same buffer name",
+        )
+
+    def test_paste_uses_named_buffer_for_large_body_tmp_file_path(self):
+        """Large bodies (>50k chars) go through the tmp-file load path — must also
+        use a per-dispatch named buffer, not the bare default."""
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+
+        ok = lane._paste("%1", "x" * 60000, self.DISPATCH_ID, max_inline=50000)
+
+        self.assertTrue(ok)
+        self.assertEqual(len(fake.loaded_buffer_names), 1)
+        self.assertIn(self.DISPATCH_ID, fake.loaded_buffer_names[0])
+
+
+class TestVerifyPaneIdentity(_LaneTestCase):
+    """OI-1126: _verify_pane_identity() is the pre-delivery identity check."""
+
+    def test_returns_true_when_pane_belongs_to_expected_session(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        fake._last_session_name = "vnx-my-dispatch"
+        lane = self._make_lane(fake)
+
+        self.assertTrue(lane._verify_pane_identity("%1", "vnx-my-dispatch"))
+
+    def test_returns_false_when_pane_belongs_to_a_different_session(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        fake._last_session_name = "vnx-someone-elses-dispatch"
+        lane = self._make_lane(fake)
+
+        self.assertFalse(lane._verify_pane_identity("%1", "vnx-my-dispatch"))
+
+    def test_returns_false_when_display_message_fails(self):
+        class _FailingRunner:
+            def available(self):
+                return True
+
+            def run(self, args, *, timeout=10, input_text=None):
+                return TmuxResult(1, "", "no such pane")
+
+        lane = TmuxInteractiveDispatch(
+            self.state_dir,
+            runner=_FailingRunner(),
+            receipts_file=self.receipts_file,
+            project_root=self.state_dir,
+        )
+        self.assertFalse(lane._verify_pane_identity("%1", "vnx-my-dispatch"))
+
+
+class TestMismatchedPaneIdentityFailsLoud(_LaneTestCase):
+    """OI-1126: a mismatched pane/session identity must fail loud instead of
+    delivering — this is the test that catches a future addressing regression
+    even though the OI-1126 root cause (shared paste buffer) is fixed separately."""
+
+    def test_dispatch_fails_loud_when_pane_identity_mismatched_before_launch(self):
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            # Simulate a pane_id that (for whatever reason) no longer resolves to
+            # THIS dispatch's own session by the time delivery is about to happen.
+            session_name_override="vnx-some-other-dispatch",
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_reason, "pane_identity_mismatch_before_launch")
+        # Nothing was ever delivered to the (potentially wrong) pane.
+        self.assertEqual(fake.pasted, [], "instruction must never be pasted when identity is unverified")
+        self.assertFalse(
+            any("-l" in cmd for cmd in fake.commands if cmd and cmd[0] == "send-keys"),
+            "the claude launch line must never be sent when identity is unverified",
+        )
+        self.assertTrue(fake.killed_sessions, "kill-session must be called on identity mismatch")
+
+
+class TestWorkerSideDispatchIdMismatchDetection(_LaneTestCase):
+    """OI-1126 Part 3: the worker's own pane is the last line of defence. When the
+    UserPromptSubmit hook (tmux_signal_prompt_received.sh) drops a
+    dispatch_id_mismatch sentinel, dispatch() must fail loud immediately rather than
+    run out its deadline waiting on a receipt for content that isn't its own."""
+
+    def test_dispatch_fails_loud_on_worker_side_mismatch_sentinel(self):
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            simulate_dispatch_id_mismatch=True,
+            emit_receipt=False,  # the worker never gets to run its own instruction
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, deadline_seconds=1.0, poll_interval=0.02)
+
+        self.assertFalse(result.success)
+        self.assertEqual(result.failure_reason, "dispatch_id_mismatch_detected")
+        self.assertTrue(fake.killed_sessions, "kill-session must be called on mismatch detection")
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn(
+            "interactive_dispatch_id_mismatch",
+            {e["event_type"] for e in events},
+        )
+
+    def test_dispatch_succeeds_when_no_mismatch_sentinel_present(self):
+        """Control: identical setup minus the mismatch sentinel completes normally."""
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            simulate_dispatch_id_mismatch=False,
+        )
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane)
+
+        self.assertTrue(result.success, result.failure_reason)
 
 
 class TestNoDashP(_LaneTestCase):
@@ -3859,7 +4066,7 @@ class TestAdaptivePasteSettle(_LaneTestCase):
 
         with patch("time.sleep", side_effect=fake_sleep):
             with patch.dict(os.environ, {"VNX_TMUX_PASTE_SETTLE_SECONDS": "0.75"}):
-                lane._deliver_instruction("pane-0", large_body)
+                lane._deliver_instruction("pane-0", large_body, self.DISPATCH_ID)
 
         # Pastes (load-buffer, paste-buffer) + settle sleep + Enter send-keys.
         # Find the settle sleep: it's the largest sleep since there may be poll sleeps too.
@@ -3889,7 +4096,7 @@ class TestAdaptivePasteSettle(_LaneTestCase):
 
         with patch("time.sleep", side_effect=fake_sleep):
             with patch.dict(os.environ, {"VNX_TMUX_PASTE_SETTLE_SECONDS": "0.75"}):
-                lane._deliver_instruction("pane-0", huge_body)
+                lane._deliver_instruction("pane-0", huge_body, self.DISPATCH_ID)
 
         self.assertTrue(sleep_calls, "time.sleep must have been called")
         settle_duration = max(sleep_calls)
@@ -3916,7 +4123,7 @@ class TestAdaptivePasteSettle(_LaneTestCase):
 
         with patch("time.sleep", side_effect=fake_sleep):
             with patch.dict(os.environ, {"VNX_TMUX_PASTE_SETTLE_SECONDS": "0.75"}):
-                lane._deliver_instruction("pane-0", small_body)
+                lane._deliver_instruction("pane-0", small_body, self.DISPATCH_ID)
 
         self.assertTrue(sleep_calls, "time.sleep must have been called")
         settle_duration = max(sleep_calls)

--- a/tests/test_tmux_lane_signals.py
+++ b/tests/test_tmux_lane_signals.py
@@ -258,7 +258,7 @@ class TestHookGuards(unittest.TestCase):
         last-line-of-defence signal that it received a sibling dispatch's content."""
         sig = self.root / "sig-mismatch"
         prompt = (
-            "## Completion Protocol\n\n```bash\n"
+            "## Completion Protocol (interactive lane)\n\n```bash\n"
             'python3 append_receipt.py --receipt "{\\"dispatch_id\\": \\"disp-OTHER\\"}"\n'
             "```\n"
         )
@@ -281,7 +281,7 @@ class TestHookGuards(unittest.TestCase):
     def test_prompt_received_no_mismatch_sentinel_when_dispatch_id_agrees(self) -> None:
         sig = self.root / "sig-agree"
         prompt = (
-            "```bash\n"
+            "## Completion Protocol (interactive lane)\n\n```bash\n"
             'python3 append_receipt.py --receipt "{\\"dispatch_id\\": \\"disp-prompt\\"}"\n'
             "```\n"
         )
@@ -302,6 +302,91 @@ class TestHookGuards(unittest.TestCase):
             PROMPT_RECEIVED_HOOK,
             env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
             input_text=json.dumps({"prompt": "Do the thing, no protocol block here."}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse((sig / "dispatch_id_mismatch").exists())
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    # -- OI-1126 round 3: scope the extraction to the appended protocol block --
+    #
+    # Fixtures below are built the way the lane actually assembles a body:
+    # context text FIRST, completion-protocol block APPENDED LAST (matching
+    # `body = _context_body + ... + self._build_completion_protocol(...)` in
+    # tmux_interactive_dispatch.py's dispatch()). The protocol text itself
+    # comes from the real `_build_completion_protocol()` method, not a
+    # hand-typed guess, so the fixture can't drift from production shape.
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_ignores_foreign_id_quoted_earlier_in_body(self) -> None:
+        """False-kill case: a dispatch instruction that legitimately quotes a
+        different dispatch's identifier (a ledger excerpt, a JSON receipt
+        fragment — VNX dispatch instructions do this routinely, since the
+        fabric's own open items are ABOUT receipts and identifiers) must not
+        trip the mismatch guard just because that foreign value appears
+        BEFORE the code-guaranteed, always-appended-last protocol block."""
+        sig = self.root / "sig-false-kill"
+        lane = _make_lane(_CaptureRunner(), self.root)
+        context_body = (
+            "Fix the receipt converter so it stops choking on this stale ledger "
+            'excerpt: {"dispatch_id": "disp-FOREIGN-OLD", "status": "done"}\n\n'
+            "Now implement the fix and commit.\n"
+        )
+        protocol_block = lane._build_completion_protocol("disp-prompt", "disp-prompt")
+        prompt = context_body + protocol_block
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": prompt}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse(
+            (sig / "dispatch_id_mismatch").exists(),
+            "a foreign id quoted earlier in the instruction body must not "
+            "trigger a false mismatch when the appended protocol id agrees",
+        )
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_detects_real_mismatch_despite_foreign_id_in_body(self) -> None:
+        """Masking case: a foreign id earlier in the body must not hide a REAL
+        crossing carried by the appended protocol block — the recorded
+        delivered value must be the protocol's, not the body's earlier one."""
+        sig = self.root / "sig-masking"
+        lane = _make_lane(_CaptureRunner(), self.root)
+        context_body = (
+            "Ledger excerpt for reference: "
+            '{"dispatch_id": "disp-FOREIGN-OLD", "status": "done"}\n\n'
+            "Now implement the fix and commit.\n"
+        )
+        protocol_block = lane._build_completion_protocol("disp-CROSSED", "disp-CROSSED")
+        prompt = context_body + protocol_block
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": prompt}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        mismatch_path = sig / "dispatch_id_mismatch"
+        self.assertTrue(mismatch_path.is_file(), "a genuine crossing must still be caught")
+        content = mismatch_path.read_text(encoding="utf-8")
+        self.assertIn("expected=disp-prompt", content)
+        self.assertIn("delivered=disp-CROSSED", content)
+        self.assertNotIn("disp-FOREIGN-OLD", content)
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_no_mismatch_when_protocol_id_agrees_with_env(self) -> None:
+        """Baseline still holds: a realistic context body plus the appended
+        protocol block (built via the real dispatcher method) carrying the
+        correct id writes no sentinel."""
+        sig = self.root / "sig-baseline-agree"
+        lane = _make_lane(_CaptureRunner(), self.root)
+        context_body = "Implement the fix described above, then commit and push.\n"
+        protocol_block = lane._build_completion_protocol("disp-prompt", "disp-prompt")
+        prompt = context_body + protocol_block
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": prompt}),
         )
         self.assertEqual(proc.returncode, 0)
         self.assertFalse((sig / "dispatch_id_mismatch").exists())

--- a/tests/test_tmux_lane_signals.py
+++ b/tests/test_tmux_lane_signals.py
@@ -251,6 +251,63 @@ class TestHookGuards(unittest.TestCase):
         self.assertEqual(proc.returncode, 0)
 
     @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_writes_mismatch_sentinel_when_dispatch_id_disagrees(self) -> None:
+        """OI-1126 worker-side detectability: the delivered prompt's own embedded
+        dispatch_id (from the completion-protocol JSON) disagreeing with
+        VNX_DISPATCH_ID (set race-free at spawn/launch time) is the worker's own
+        last-line-of-defence signal that it received a sibling dispatch's content."""
+        sig = self.root / "sig-mismatch"
+        prompt = (
+            "## Completion Protocol\n\n```bash\n"
+            'python3 append_receipt.py --receipt "{\\"dispatch_id\\": \\"disp-OTHER\\"}"\n'
+            "```\n"
+        )
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": prompt}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        mismatch_path = sig / "dispatch_id_mismatch"
+        self.assertTrue(mismatch_path.is_file(), "mismatch sentinel must be written")
+        content = mismatch_path.read_text(encoding="utf-8")
+        self.assertIn("disp-prompt", content)
+        self.assertIn("disp-OTHER", content)
+        # The base submission signal still fires — the prompt WAS submitted, just
+        # not this dispatch's own content.
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_no_mismatch_sentinel_when_dispatch_id_agrees(self) -> None:
+        sig = self.root / "sig-agree"
+        prompt = (
+            "```bash\n"
+            'python3 append_receipt.py --receipt "{\\"dispatch_id\\": \\"disp-prompt\\"}"\n'
+            "```\n"
+        )
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": prompt}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse((sig / "dispatch_id_mismatch").exists())
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
+    def test_prompt_received_no_mismatch_sentinel_when_prompt_has_no_dispatch_id(self) -> None:
+        """A prompt with no extractable dispatch_id must never false-positive."""
+        sig = self.root / "sig-none"
+        proc = self._run_hook(
+            PROMPT_RECEIVED_HOOK,
+            env={"VNX_TMUX_SIGNAL_DIR": str(sig), "VNX_DISPATCH_ID": "disp-prompt"},
+            input_text=json.dumps({"prompt": "Do the thing, no protocol block here."}),
+        )
+        self.assertEqual(proc.returncode, 0)
+        self.assertFalse((sig / "dispatch_id_mismatch").exists())
+        self.assertTrue((sig / "prompt_received").is_file())
+
+    @unittest.skipUnless(shutil.which("jq"), "jq not available")
     def test_session_ready_captures_session_id_from_stdin(self) -> None:
         sig = self.root / "sig-sid"
         session_id = "123e4567-e89b-12d3-a456-426614174000"


### PR DESCRIPTION
## Summary

OI-1126: near-simultaneous dispatches through the door could silently deliver one dispatch's instruction into a sibling dispatch's pane. Reproduced first-hand with a harness that drives the real `_spawn_session`/`_deliver_instruction` code path against real tmux: **0/25 crossings with a 2-dispatch, 2s-staggered spawn, but 15/15 (100%) with 4 dispatches racing with no stagger.**

The root cause is **not** unstable `pane_id` addressing — that was measured stable (0/47 mismatches across spawn-only and `allocate()` concurrency trials, including 4-way zero-stagger). It's that `_paste()` called tmux's `load-buffer`/`paste-buffer` **without `-b`**, which operate on the server's single shared "most recent buffer" slot — a classic TOCTOU race when two dispatches' load+paste sequences overlap in real time.

This also explains OI-1124's "branch crossing": worktree/branch assignment via `tmux_worktree.allocate()` was always correct (0/35 crossings including 4-way zero-stagger). The worker running in its own correctly-allocated worktree simply received and reported on a sibling dispatch's mis-delivered instruction — a symptom of the same race, not a second bug.

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`
  - `_paste()` now loads/pastes/deletes a **per-dispatch named tmux buffer**, making cross-dispatch buffer collision structurally impossible instead of merely unlikely.
  - New `_verify_pane_identity()`: asserts the target pane still belongs to this dispatch's session immediately before every `send-keys`/paste that carries dispatch content (launch line + instruction body). A mismatch fails the dispatch loud (`pane_identity_mismatch_before_launch` / `pane_identity_mismatch_before_deliver`) instead of delivering.
  - `dispatch()` now checks for a worker-reported `dispatch_id_mismatch` sentinel right after submit and fails loud (`dispatch_id_mismatch_detected`) if present.
- `scripts/hooks/tmux_signal_prompt_received.sh`: compares the `dispatch_id` embedded in the delivered prompt's completion-protocol JSON against `$VNX_DISPATCH_ID` (set race-free at spawn/launch time, never via the racy shared buffer) and drops a `dispatch_id_mismatch` sentinel on disagreement — the worker's own pane as the last line of defence.
- Tests: per-dispatch buffer naming, pane-identity verification (pass/fail/RPC-failure), dispatch()-level fail-loud on mismatched identity, hook-level dispatch_id mismatch detection (agree/disagree/no-marker-present).

## Verification

**Reproduction (before fix):**
- 2-way, 2s stagger, 25 trials: 0/25 (0%) crossings
- 4-way, zero stagger, 15 trials: **15/15 (100%) crossings**
- Isolated spawn-only test (pane_id → session binding): 3×4-way = 12/12 correct, 0 mismatches
- `tmux_worktree.allocate()` concurrency: 20 trials @ 50ms gap + 15 trials @ 4-way zero-stagger = 35/35 correct, 0 crossings

**Reproduction (after fix), same 4-way zero-stagger harness:** 0/15 (0%) crossings.

**Unit tests, out(red)/in(green):**
```
$ git stash   # revert source fix, keep new tests
$ python3 -m pytest tests/test_tmux_interactive_dispatch.py -q -k "TestPasteUsesPerDispatchNamedBuffer or TestVerifyPaneIdentity or TestMismatchedPaneIdentityFailsLoud or TestWorkerSideDispatchIdMismatchDetection"
8 failed, 1 passed, 202 deselected in 0.83s

$ python3 -m pytest tests/test_tmux_lane_signals.py -q -k mismatch
1 failed, 3 passed, 27 deselected in 0.21s

$ git stash pop   # restore fix
$ python3 -m pytest tests/test_tmux_interactive_dispatch.py tests/test_tmux_lane_signals.py tests/test_tmux_interactive_dispatch_metadata.py -q
248 passed in 41.91s
```

Full targeted suite: `python3 -m pytest tests/test_tmux_interactive_dispatch.py tests/test_tmux_lane_signals.py tests/test_tmux_interactive_dispatch_metadata.py -q` → **248 passed**.

## Test plan

- [x] Reproduced OI-1126 first-hand with a real-tmux harness (out/red)
- [x] Fixed root cause (named per-dispatch buffer) + defense-in-depth (pre-delivery identity check) + worker-side detectability (hook sentinel)
- [x] Re-ran the same harness post-fix (in/green): 0% crossing rate
- [x] Regression tests added for both the buffer-naming fix and the identity-verification fail-loud path
- [x] Determined OI-1124 shares the same root cause (worktree allocation itself never raced)

🤖 Generated with [Claude Code](https://claude.com/claude-code)