### PR TITLE
fix(doctor): hookpin check no longer skips fabric-deployed pins (OI-1123 follow-up)

### DIFF
--- a/tests/unit/vnx_cli/commands/test_doctor.py
+++ b/tests/unit/vnx_cli/commands/test_doctor.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 
-from vnx_cli.commands.doctor import PASS, WARN, _check_agents, _check_hook_paths, _collect_dead_hook_paths
+from vnx_cli.commands.doctor import PASS, WARN, _check_agents, _check_hook_paths
 
 
 def _make_agent(base: Path, name: str, rel: str = "agents") -> Path:
@@ -72,7 +72,40 @@ class TestHookPathResolution:
         assert result.status == "WARN"
         assert "dead_hook.sh" in result.detail
         assert "live_hook.sh" not in result.detail
-        assert "canonical .claude/vnx-system/hooks/" in result.detail
+
+    def test_absolute_path_outside_project_dead_is_flagged(self, tmp_path):
+        """OI-1123 follow-up regression guard.
+
+        A fabric-deployed hook pin is ALWAYS an absolute path outside project_dir
+        by design (``~/.vnx-system/versions/<v>/...``). A prior implementation
+        skipped existence-checking any absolute path that resolved outside
+        project_dir before touching the filesystem, which reported PASS on two
+        confirmed-dead pins in mission-control (a stop-report hook and a
+        raw-claude-spawn security guard) instead of catching them. This must
+        fail again if that ``in_project`` skip is ever reintroduced.
+        """
+        project = tmp_path / "project"
+        project.mkdir()
+        # Deliberately never created — simulates a fabric version dir that
+        # vanished after a version rotation (e.g. edge -> a pinned release).
+        dead_pin = tmp_path / "outside-fabric" / "versions" / "edge" / "hooks" / "stop_report.sh"
+
+        settings = {
+            "hooks": {
+                "Stop": [
+                    {
+                        "matcher": "",
+                        "hooks": [{"type": "command", "command": f"bash {dead_pin}"}],
+                    }
+                ]
+            }
+        }
+        _write_settings(project, settings)
+
+        result = _check_hook_paths(project)
+
+        assert result.status == "WARN"
+        assert "stop_report.sh" in result.detail
 
     def test_missing_settings_is_clean(self, tmp_path):
         project = tmp_path / "project"
@@ -120,7 +153,6 @@ class TestHookPathResolution:
 
         assert result.status == "WARN"
         assert "gone.sh" in result.detail
-        assert "hardcoded absolute" in result.detail.lower()
 
     def test_all_paths_live_passes(self, tmp_path):
         project = tmp_path / "project"
@@ -137,7 +169,10 @@ class TestHookPathResolution:
                         "hooks": [
                             {
                                 "type": "command",
-                                "command": 'bash -c \'exec bash "$ROOT/scripts/hooks/present.sh"\'',
+                                "command": (
+                                    'bash -c \'exec bash '
+                                    '"$CLAUDE_PROJECT_DIR/scripts/hooks/present.sh"\''
+                                ),
                             }
                         ],
                     }
@@ -154,9 +189,11 @@ class TestHookPathResolution:
 class TestHookPathFunctionSize:
     """OI-547: _check_hook_paths must stay within the 70-line codex advisory.
 
-    The function was split into _collect_dead_hook_paths + the probe so the
-    report-shaping stays readable. AST line-count guards the advisory the same
-    way test_doctor_refactor_oi1573.py guards cmd_doctor (≤190 lines).
+    It now delegates path resolution entirely to hookpin_check.check_project_hook_pins
+    (OI-1123 consolidation) rather than maintaining a second in-repo resolver, so there
+    is no longer a separate _collect_dead_hook_paths helper to size-guard. AST
+    line-count guards the advisory the same way test_doctor_refactor_oi1573.py guards
+    cmd_doctor (≤190 lines).
     """
 
     def test_check_hook_paths_under_70_lines(self) -> None:
@@ -168,35 +205,6 @@ class TestHookPathFunctionSize:
             and n.name == "_check_hook_paths"
         )
         assert fn.end_lineno - fn.lineno + 1 <= 70
-
-    def test_collect_dead_hook_paths_under_70_lines(self) -> None:
-        source = Path(__file__).parent.parent.parent.parent.parent / "vnx_cli" / "commands" / "doctor.py"
-        tree = ast.parse(source.read_text(encoding="utf-8"))
-        fn = next(
-            n for n in ast.walk(tree)
-            if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
-            and n.name == "_collect_dead_hook_paths"
-        )
-        assert fn.end_lineno - fn.lineno + 1 <= 70
-
-    def test_collect_dead_hook_paths_parts(self, tmp_path):
-        """Extracted helper keeps the relative/absolute dead-path split."""
-        project = tmp_path / "project"
-        project.mkdir()
-        hooks = {
-            "PreToolUse": [
-                {
-                    "matcher": "Bash",
-                    "hooks": [
-                        {"type": "command", "command": f"bash {project / 'scripts' / 'hooks' / 'gone.sh'}"},
-                        {"type": "command", "command": "bash scripts/hooks/relative_missing.sh"},
-                    ],
-                }
-            ]
-        }
-        dead_relative, dead_absolute = _collect_dead_hook_paths(hooks, project.resolve())
-        assert "gone.sh" in " ".join(dead_absolute)
-        assert "relative_missing.sh" in " ".join(dead_relative)
 
 
 class TestCheckAgents:

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -4,8 +4,6 @@
 import json
 import logging
 import os
-import re
-import shlex
 import shutil
 import sqlite3
 import subprocess
@@ -692,136 +690,59 @@ def _check_active_drain(data_root: Path) -> Check:
     )
 
 
-# Hook commands frequently embed relative or absolute script paths. These rot when
-# the install mode changes (embedded -> central) or when files move.
-_HOOK_PATH_RE = re.compile(
-    r"(?:^|(?<=[\s\"'=;]))(?:\$\w+|\$\([^)]*\))?"
-    r"[A-Za-z0-9_./-]*\.(?:sh|py)(?=[\s\"';|&<>(){}]|$)",
-    re.IGNORECASE,
-)
-
-
-def _strip_shell_prefix(raw: str) -> str:
-    """Remove a leading $(...) or $VAR from a path token so it can be resolved."""
-    raw = raw.strip()
-    if raw.startswith("$(") and ")/" in raw:
-        return raw.split(")/", 1)[1]
-    if raw.startswith("${") and "}/" in raw:
-        return raw.split("}/", 1)[1]
-    if raw.startswith("$") and "/" in raw:
-        return raw[raw.find("/") + 1:]
-    return raw
-
-
-def _extract_hook_paths(command: str) -> list[str]:
-    """Return candidate file paths referenced by a hook command string."""
-    candidates: list[str] = []
-    try:
-        tokens = shlex.split(command)
-    except ValueError:
-        tokens = [command]
-    for token in tokens:
-        for match in _HOOK_PATH_RE.finditer(token):
-            candidates.append(match.group(0))
-    return candidates
-
-
-def _collect_dead_hook_paths(hooks: dict, project_root: Path) -> "tuple[list[str], list[str]]":
-    """Return (dead_relative, dead_absolute) hook paths that reference missing files."""
-    dead_relative: list[str] = []
-    dead_absolute: list[str] = []
-
-    for event, matchers in hooks.items():
-        if not isinstance(matchers, list):
-            continue
-        for matcher in matchers:
-            if not isinstance(matcher, dict):
-                continue
-            for hook in matcher.get("hooks", []):
-                if not isinstance(hook, dict):
-                    continue
-                command = hook.get("command")
-                if not isinstance(command, str):
-                    continue
-                for raw in _extract_hook_paths(command):
-                    normalized = _strip_shell_prefix(raw)
-                    if not normalized or "/" not in normalized:
-                        continue
-                    if normalized.startswith("/"):
-                        abs_path = Path(normalized)
-                        try:
-                            in_project = abs_path.resolve().is_relative_to(project_root)
-                        except OSError:
-                            in_project = False
-                        if not in_project:
-                            continue
-                        if not abs_path.is_file():
-                            dead_absolute.append(normalized)
-                    else:
-                        target = project_root / normalized
-                        if not target.is_file():
-                            dead_relative.append(normalized)
-
-    return dead_relative, dead_absolute
-
-
 def _check_hook_paths(project_dir: Path) -> Check:
-    """WARN for hook commands in .claude/settings.json that reference missing files."""
+    """WARN for hook commands in .claude/settings.json that reference missing files.
+
+    Delegates to hookpin_check.check_project_hook_pins (OI-1123) instead of a second
+    resolver. The prior in-repo version skipped existence-checking any absolute path
+    outside project_dir before touching the filesystem — scoped to the embedded-layout
+    bug it was built for (#1073), not fabric pins. A fabric hook IS an absolute path
+    outside the project by design (``~/.vnx-system/versions/<v>/...``), so that skip
+    silently exempted exactly the pins most likely to go dead on a version rotation:
+    PASS on two confirmed-dead mission-control pins instead of catching them.
+    """
+    def _result(status: str, detail: str) -> Check:
+        return Check(name="hooks:path-resolution", status=status, detail=detail)
+
     settings_path = project_dir / ".claude" / "settings.json"
     if not settings_path.is_file():
-        return Check(
-            name="hooks:path-resolution",
-            status=PASS,
-            detail="no .claude/settings.json found; skipping hook path check",
-        )
+        return _result(PASS, "no .claude/settings.json found; skipping hook path check")
 
     try:
-        settings = json.loads(settings_path.read_text(encoding="utf-8"))
+        json.loads(settings_path.read_text(encoding="utf-8"))
     except json.JSONDecodeError as exc:
-        return Check(
-            name="hooks:path-resolution",
-            status=WARN,
-            detail=f".claude/settings.json is unparseable ({exc}); hook paths cannot be audited",
-        )
+        return _result(WARN, f".claude/settings.json is unparseable ({exc}); hook paths cannot be audited")
 
-    hooks = settings.get("hooks")
-    if not isinstance(hooks, dict):
-        return Check(
-            name="hooks:path-resolution",
-            status=PASS,
-            detail="no hooks section in .claude/settings.json",
-        )
+    try:
+        _engine.ensure_engine_on_path()
+        from hookpin_check import check_project_hook_pins, STATUS_MISSING, STATUS_UNRESOLVED
+    except Exception as exc:
+        return _result(WARN, f"could not load hookpin_check module: {exc}")
 
-    project_root = project_dir.resolve()
-    dead_relative, dead_absolute = _collect_dead_hook_paths(hooks, project_root)
+    findings = check_project_hook_pins(project_dir.resolve())
+    missing = [f for f in findings if f.status == STATUS_MISSING]
+    unresolved = [f for f in findings if f.status == STATUS_UNRESOLVED]
 
-    if dead_relative or dead_absolute:
-        parts: list[str] = []
-        if dead_relative:
-            descriptions = "; ".join(
-                f"{p} (expected {project_root / p}; "
-                "use canonical .claude/vnx-system/hooks/ or vnx-install)"
-                for p in dead_relative
-            )
-            parts.append(f"referenced hook script(s) missing: {descriptions}")
-        if dead_absolute:
-            descriptions = "; ".join(
-                f"{p} (use canonical .claude/vnx-system/hooks/ or vnx-install, "
-                "not a hardcoded project-relative path)"
-                for p in dead_absolute
-            )
-            parts.append(f"hardcoded absolute project hook path(s) missing: {descriptions}")
-        return Check(
-            name="hooks:path-resolution",
-            status=WARN,
-            detail="; ".join(parts),
-        )
+    if missing:
+        descriptions = "; ".join(f"{f.raw_path} ({f.event}) -> {f.resolved_path}" for f in missing)
+        return _result(WARN, f"{len(missing)} referenced hook script(s) missing: {descriptions}")
 
-    return Check(
-        name="hooks:path-resolution",
-        status=PASS,
-        detail="all referenced hook script paths resolve",
-    )
+    if unresolved:
+        # A locally-assigned shell var (e.g. `ROOT=$(...)` earlier in the same command,
+        # this repo's own settings.json convention) is a real, live pin the resolver
+        # cannot verify — not a defect. PASS, not WARN: this check exists to catch
+        # confirmed-dead pins, and warning on an unprovable blind spot would make it
+        # cry wolf on every project using this idiom instead of surfacing real drift.
+        checked_ok = len(findings) - len(unresolved)
+        return _result(PASS, (
+            f"{checked_ok} of {len(findings)} configured hook pin(s) confirmed resolving; "
+            f"{len(unresolved)} unresolved (not checked, not confirmed dead)"
+        ))
+
+    if not findings:
+        return _result(PASS, "no hooks section in .claude/settings.json")
+
+    return _result(PASS, "all referenced hook script paths resolve")
 
 
 def _check_embedded_path_assumptions() -> Check:


### PR DESCRIPTION
## Summary
- `vnx_cli/commands/doctor.py::_check_hook_paths` skipped existence-checking any absolute hook path that resolved outside `project_dir` — scoped originally to the embedded-layout bug it was built for (#1073), not fabric pins. A fabric-deployed hook (`~/.vnx-system/versions/<v>/...`) is *always* outside the project by design, so that skip silently exempted exactly the pins most likely to go dead on a version rotation. `vnx doctor` PASSed on two confirmed-dead pins in mission-control (stop-report hook + raw-claude-spawn security guard) instead of catching them.
- Consolidates onto `scripts/lib/hookpin_check.py` (shipped in #1450) instead of keeping a second, weaker path resolver in `doctor.py`.
- Unresolved (not missing) pins report PASS, not WARN: a locally-assigned `$ROOT` var (this repo's own `.claude/settings.json` convention) is a real, live pin the static resolver structurally cannot verify — warning on that would make the check cry wolf on its own dogfood run instead of surfacing real drift.

## Changes
- `vnx_cli/commands/doctor.py`: removed `_HOOK_PATH_RE`, `_strip_shell_prefix`, `_extract_hook_paths`, `_collect_dead_hook_paths` (the buggy, duplicate resolver) and rewrote `_check_hook_paths` to delegate to `hookpin_check.check_project_hook_pins`, following the same `_engine.ensure_engine_on_path()` + local-import pattern already used by `_check_agents`/`_check_embedded_path_assumptions` in this file. Dropped now-unused `re`/`shlex` imports.
- `tests/unit/vnx_cli/commands/test_doctor.py`: updated hook-path tests for the new delegation, added `test_absolute_path_outside_project_dead_is_flagged` (the OI-1123 follow-up regression guard — fails if the `in_project` skip is ever reintroduced), removed the now-obsolete `_collect_dead_hook_paths` size/unit tests.

## Verification

**Regression test proves the fix, not just asserts it** — ran the new test against the pre-fix `doctor.py`:
```
$ git show HEAD:vnx_cli/commands/doctor.py > vnx_cli/commands/doctor.py   # old code
$ pytest tests/unit/vnx_cli/commands/test_doctor.py::TestHookPathResolution::test_absolute_path_outside_project_dead_is_flagged -v
...
>       assert result.status == "WARN"
E       AssertionError: assert 'PASS' == 'WARN'
FAILED ... 1 failed in 0.19s
```
Restored the fix; same test passes.

**Before / after against mission-control (read-only, not modified):**
```
# BEFORE (old doctor.py)
$ python3 -m vnx_cli.main doctor --project-dir ~/Desktop/BUSINESS/development/mission-control
  [PASS]  hooks:path-resolution         all referenced hook script paths resolve

# AFTER (fixed doctor.py)
$ python3 -m vnx_cli.main doctor --project-dir ~/Desktop/BUSINESS/development/mission-control
  [WARN]  hooks:path-resolution         2 referenced hook script(s) missing: /Users/vincentvandeth/.vnx-system/versions/edge/scripts/hooks/stop_report_hook.sh (Stop) -> ...; /Users/vincentvandeth/.vnx-system/versions/edge/scripts/hooks/pretooluse_block_raw_claude_spawn.sh (PreToolUse) -> ...
  Summary: 17 passed, 2 warned, 0 failed
```

**Stays quiet on healthy projects:**
```
$ python3 -m vnx_cli.main doctor --project-dir /Users/vincentvandeth/Development/vnx-orchestration
  [PASS]  hooks:path-resolution         12 of 15 configured hook pin(s) confirmed resolving; 3 unresolved (not checked, not confirmed dead)
  Summary: 19 passed, 0 warned, 0 failed

$ python3 -m vnx_cli.main doctor --project-dir ~/Desktop/BUSINESS/clients/vincent/pacompany/build/pa-engine
  [PASS]  hooks:path-resolution         all referenced hook script paths resolve
  Summary: 19 passed, 0 warned, 0 failed
```

**Targeted tests (201 total, all green):**
```
$ pytest tests/test_vnx_doctor_runtime.py tests/test_doctor_refactor_oi1573.py tests/test_doctor_standalone_dev.py tests/test_vnx_doctor_template_scan.py tests/test_vnx_doctor_strict.py tests/test_vnx_doctor.py tests/test_structural_doctor.py tests/unit/vnx_cli/commands/test_doctor.py tests/test_hookpin_check.py -q
201 passed in 12.32s
```

**Remote branch confirmed:**
```
$ git ls-remote --heads origin dispatch/20260811a-c-doctor-hookpath
b00a3dc2f91e5b40bed2a45ad6ae68a6d6dfbdeb	refs/heads/dispatch/20260811a-c-doctor-hookpath
```

## Test plan
- [x] Targeted pytest suite (doctor + hookpin_check, 201 tests) green
- [x] Regression test proven to fail against pre-fix code, pass against fix
- [x] Real before/after run against mission-control (read-only)
- [x] Real run against vnx-orchestration and pa-engine confirms no new noise

Dispatch-ID: 20260811a-c-doctor-hookpath