### PR TITLE
fix(install): fresh vnx init no longer writes dead hook pins (OI-1139)

### DIFF
--- a/scripts/vnx_settings_merge.py
+++ b/scripts/vnx_settings_merge.py
@@ -32,6 +32,20 @@ import shutil
 import sys
 from datetime import datetime, timezone
 
+# Deferred (merge-time) template placeholder token for the VNX_HOME slot in
+# settings_vnx_keys.json.tmpl. Built by concatenation on purpose, NOT written
+# out as a literal "{{VNX_HOME}}" string: install.sh's own INSTALL-TIME
+# placeholder substitution (_substitute_install_templates) scans every
+# shipped .py file for that exact 12-character spelling and sed-replaces it
+# with the current install's path (see install.sh's INSTALL_TIME_PLACEHOLDERS
+# vocabulary). A literal occurrence here collides with that vocabulary and
+# gets permanently clobbered the moment this file ships via `install.sh`,
+# silently turning this search pattern into a no-op against the (correctly
+# un-substituted, .tmpl-protected) placeholder in the real template — see
+# OI-1139. PROJECT_ROOT does not collide (install.sh's token is
+# VNX_PROJECT_ROOT, a different spelling) so it is left as a normal literal.
+_VNX_HOME_TOKEN = "{{" + "VNX_HOME" + "}}"
+
 
 def find_vnx_home(project_root: str) -> str:
     """Resolve VNX_HOME: prefer .vnx/ layout, fall back to legacy layout."""
@@ -50,8 +64,82 @@ def find_vnx_home(project_root: str) -> str:
     return vnx_primary  # default expectation
 
 
+def _relative_suffixes(raw: str, token: str) -> list[str]:
+    """Return the literal text following each ``token`` occurrence in ``raw``,
+    up to the next ``"`` (the JSON string terminator). Used to know what a
+    correctly-rendered value must be followed by, so the render can be
+    verified structurally instead of just hoped for.
+    """
+    suffixes = []
+    start = 0
+    while True:
+        idx = raw.find(token, start)
+        if idx == -1:
+            break
+        after = idx + len(token)
+        end = raw.find('"', after)
+        suffixes.append(raw[after:end] if end != -1 else raw[after:after + 80])
+        start = after
+    return suffixes
+
+
+def _assert_rendered_cleanly(raw: str, rendered: str, vnx_home: str, project_root: str,
+                              template_path: str) -> None:
+    """Guard against OI-1139: a render that silently drops the install root.
+
+    A rendered hook command must never contain an unresolved ``{{...}}``
+    placeholder, and every VNX_HOME/PROJECT_ROOT-relative path the raw
+    template declares must actually appear prefixed by the real (non-empty)
+    value in the output — not as a bare path rooted at ``/``. Checking the
+    real value is present (rather than just "no placeholder left") also
+    catches a corrupted search pattern that turns the substitution into a
+    silent no-op, which is exactly how this regression manifested: the
+    template's own placeholder was untouched, but the *code* rendering it had
+    been mangled to search for the wrong string.
+    """
+    if "{{" in rendered:
+        print(
+            f"ERROR: {template_path} rendered with an unresolved template "
+            "placeholder still present in the output — refusing to write dead "
+            "hook pins",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
+    for label, token, value in (
+        ("VNX_HOME", _VNX_HOME_TOKEN, vnx_home),
+        ("PROJECT_ROOT", "{{PROJECT_ROOT}}", project_root),
+    ):
+        for suffix in _relative_suffixes(raw, token):
+            if suffix and (value + suffix) not in rendered:
+                print(
+                    f"ERROR: {template_path} — {label} substitution did not "
+                    f"produce the expected path (value + {suffix!r}) in the "
+                    "rendered output; a hook would resolve to a path rooted "
+                    "at '/' instead of the install root — refusing to write "
+                    "dead hook pins",
+                    file=sys.stderr,
+                )
+                sys.exit(1)
+
+
 def load_template(vnx_home: str, project_root: str) -> dict:
     """Load and render the VNX settings template."""
+    if not vnx_home:
+        print(
+            "ERROR: vnx_home is empty — refusing to render hook commands "
+            "rooted at '/' instead of the install root",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+    if not project_root:
+        print(
+            "ERROR: project_root is empty — refusing to render hook commands "
+            "rooted at '/' instead of the project root",
+            file=sys.stderr,
+        )
+        sys.exit(1)
+
     template_path = os.path.join(vnx_home, "templates", "settings_vnx_keys.json.tmpl")
     if not os.path.isfile(template_path):
         print(f"ERROR: VNX settings template not found: {template_path}", file=sys.stderr)
@@ -64,10 +152,12 @@ def load_template(vnx_home: str, project_root: str) -> dict:
     # tree actually lives (embedded: a hidden dir under the project's .claude/,
     # central: the shared per-machine install, dev checkout: the repo itself)
     # — distinct from PROJECT_ROOT, which only equals VNX_HOME in the
-    # dev-checkout case. A hook command that hardcodes {{PROJECT_ROOT}}/scripts/... breaks in
+    # dev-checkout case. A hardcoded VNX_HOME-relative hook command breaks in
     # embedded and central installs. See #1023.
-    rendered = raw.replace("{{VNX_HOME}}", vnx_home)
+    rendered = raw.replace(_VNX_HOME_TOKEN, vnx_home)
     rendered = rendered.replace("{{PROJECT_ROOT}}", project_root)
+
+    _assert_rendered_cleanly(raw, rendered, vnx_home, project_root, template_path)
 
     try:
         return json.loads(rendered)

--- a/tests/test_wave4_regen_settings_target.py
+++ b/tests/test_wave4_regen_settings_target.py
@@ -21,6 +21,7 @@ import json
 import os
 import shutil
 import subprocess
+import sys
 from pathlib import Path
 
 import pytest
@@ -192,6 +193,76 @@ def test_regen_guard_skipped_for_validate():
     result = _run_regen_unit("--validate", guard_returns=1)
     # --validate is read-only and must not consult the write guard at all.
     assert "GUARD_CALLED" not in result.stderr
+
+
+# ── OI-1139: a fresh install must not ship dead hook pins ─────────────────────
+# install.sh's own install-time placeholder substitution (_substitute_install_
+# templates) scans every shipped .py file for the literal string "{{VNX_HOME}}"
+# and rewrites it in place. vnx_settings_merge.py used that exact spelling as
+# its OWN (deferred, merge-time) search pattern for rendering
+# settings_vnx_keys.json.tmpl — so a real `install.sh` run clobbered the
+# search-pattern string literal inside the *installed copy* of
+# vnx_settings_merge.py, turning its .replace() call into a silent no-op. The
+# real placeholder in the template (protected only by its .tmpl extension)
+# then survived un-substituted into settings.json, and hookpin_check's path-
+# token regex (which recognizes /, ~, $VAR but not {{...}}) picked up the
+# "/scripts/hooks/....sh" tail as a bare, filesystem-root-relative path,
+# reporting it as a dead pin.
+#
+# This drives the REAL install.sh against a REAL fresh target directory, then
+# the REAL (installed) vnx_settings_merge.py --full — no reimplementation of
+# either — and asserts every rendered hook command resolves to a real file,
+# exactly mirroring the "vnx doctor smoke" CI job.
+def test_fresh_install_render_produces_no_dead_hook_pins(tmp_path):
+    sys.path.insert(0, str(_REPO_ROOT / "scripts" / "lib"))
+    import hookpin_check  # noqa: E402  (local import — path only needed here)
+
+    target = tmp_path / "fresh-project"
+    target.mkdir()
+    install_result = subprocess.run(
+        ["bash", str(_REPO_ROOT / "install.sh"), str(target)],
+        capture_output=True, text=True, env=_clean_env(),
+    )
+    assert install_result.returncode == 0, (
+        "install.sh failed:\n" + install_result.stdout + install_result.stderr
+    )
+
+    vnx_home = target / ".vnx"
+    merge_script = vnx_home / "scripts" / "vnx_settings_merge.py"
+    assert merge_script.is_file(), f"install.sh did not ship {merge_script}"
+
+    # Mirror scripts/vnx_init.py::bootstrap_hooks(), which deploys
+    # sessionstart.sh into the project BEFORE triggering the settings render —
+    # its {{PROJECT_ROOT}}-relative pin only resolves once this file exists.
+    hooks_dir = target / ".claude" / "hooks"
+    hooks_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(str(vnx_home / "hooks" / "sessionstart.sh"), str(hooks_dir / "sessionstart.sh"))
+
+    render_result = subprocess.run(
+        [sys.executable, str(merge_script),
+         "--full", "--project-root", str(target), "--vnx-home", str(vnx_home),
+         "--no-backup"],
+        capture_output=True, text=True, env=_clean_env(),
+    )
+    assert render_result.returncode == 0, (
+        "vnx_settings_merge.py --full failed against a fresh install layout:\n"
+        + render_result.stdout + render_result.stderr
+    )
+
+    settings_path = target / ".claude" / "settings.json"
+    assert settings_path.is_file(), "settings.json was not created"
+    raw_settings = settings_path.read_text(encoding="utf-8")
+    assert "{{" not in raw_settings, (
+        "settings.json contains an unrendered template placeholder — the "
+        "install-root substitution silently failed:\n" + raw_settings
+    )
+
+    findings = hookpin_check.check_project_hook_pins(target)
+    assert findings, "expected at least one configured hook pin to check"
+    dead = [f for f in findings if f.status == hookpin_check.STATUS_MISSING]
+    assert not dead, "dead hook pin(s) after a fresh install render:\n" + "\n".join(
+        f"  {f.event} ({f.matcher}): {f.raw_path} -> {f.resolved_path}" for f in dead
+    )
 
 
 if __name__ == "__main__":  # pragma: no cover


### PR DESCRIPTION
## Summary

`main` has been red on **VNX Public CI**'s `vnx doctor smoke` job since `bcefe2ad`. Root cause found and fixed: `install.sh`'s install-time placeholder substitution corrupts `scripts/vnx_settings_merge.py`'s own source code.

## Root cause

`install.sh`'s `_substitute_install_templates()` scans every shipped `.py`/`.sh`/`.json`/`.yml`/`.md` file for the literal strings `{{USER_HOME}}`, `{{VNX_PROJECT_ROOT}}`, `{{VNX_HOME}}` and sed-replaces them install-wide.

`scripts/vnx_settings_merge.py` (a `.py` file, so in scope for that scan) used the **identical spelling** `"{{VNX_HOME}}"` as its own search pattern for a *separate, deferred* (merge-time) substitution applied later against `templates/settings_vnx_keys.json.tmpl` — a file protected from install.sh's scan only by its `.tmpl` extension (`-name '*.json'` doesn't match `*.json.tmpl`).

Because both use the same token spelling, a real `install.sh` run rewrites the **literal source string inside `vnx_settings_merge.py` itself**, replacing the search pattern `"{{VNX_HOME}}"` with the current install's own resolved path. This permanently turns `.replace("{{VNX_HOME}}", vnx_home)` into a silent no-op against the (correctly un-substituted) template placeholder — proven via `inspect.getsource()` on the installed copy, not assumed.

`settings.json` then ships with `{{VNX_HOME}}/scripts/hooks/...` literally in five hook commands. `hookpin_check.py`'s path-token regex recognizes `/`, `~`, `$VAR` prefixes but not `{{...}}`, so it matches the `/scripts/hooks/....sh` tail as a standalone bare-root path — exactly the CI failure symptom.

Note: `{{PROJECT_ROOT}}` does **not** collide — install.sh's token is `{{VNX_PROJECT_ROOT}}`, a different spelling — confirmed via grep, so PROJECT_ROOT rendering was never affected.

## Changes

- `scripts/vnx_settings_merge.py`:
  - Build the VNX_HOME placeholder token via string concatenation (`"{{" + "VNX_HOME" + "}}"`) so the literal 12-char substring never appears in the `.py` source — install.sh's `grep -qF`/`sed` pass then finds no match and leaves the file untouched.
  - `load_template()` now fails loud (clear stderr message + exit 1) if `vnx_home` or `project_root` is empty, instead of silently rendering a path rooted at `/`.
  - New `_assert_rendered_cleanly()` guard runs after every render: fails if any `{{...}}` placeholder survives, and fails if any known VNX_HOME/PROJECT_ROOT-relative path isn't actually prefixed by the real value in the output (catches both an empty value and a corrupted search pattern).
- `tests/test_wave4_regen_settings_target.py`: new regression test `test_fresh_install_render_produces_no_dead_hook_pins` that runs the **real** `install.sh` into a fresh target, deploys `sessionstart.sh` (mirroring `bootstrap_hooks()`), runs the **real** installed `vnx_settings_merge.py --full`, and asserts every hook command resolves via `hookpin_check.check_project_hook_pins()` — no reimplementation of either script.

## Verification

**Which code path actually writes the settings** (per dispatch instruction, proven not assumed): `bin/vnx init` → `scripts/vnx_init.py::run_init()` → `bootstrap_hooks()` → subprocess `<VNX_HOME>/bin/vnx regen-settings --merge --no-backup` → `scripts/commands/regen_settings.sh::cmd_regen_settings` → `python3 scripts/vnx_settings_merge.py --merge --vnx-home "$VNX_HOME" ...` → `load_template()`. The pip-CLI `vnx_cli/commands/init_cmd.py` path (Jinja2 `settings.json.j2`) is a **different, unrelated** code path only used for pip installs — not what `bin/vnx init` (the path CI exercises) invokes.

**Failing test output (before fix)**, `pytest tests/test_wave4_regen_settings_target.py::test_fresh_install_render_produces_no_dead_hook_pins -q`:
```
assert '{{' not in '{\n  "env":...."\n  }\n}\n'
  '{{' is contained here:
    d": "bash {{VNX_HOME}}/scripts/hooks/pretooluse_block_raw_claude_spawn.sh",
1 failed in 6.52s
```

**Passing test output (after fix)**:
```
tests/test_hookpin_check.py .......................... [ 61%]
tests/test_wave4_regen_settings_target.py ................ [100%]
42 passed in 7.19s
```

**End-to-end manual reproduction** (mirrors the CI job exactly — `./install.sh <tmp> && <tmp>/.vnx/bin/vnx init && <tmp>/.vnx/bin/vnx doctor`):
- Before fix: `settings.json` hook commands contained literal `{{VNX_HOME}}/...`; `hookpin_check` reported dead pins matching the CI symptom.
- After fix: `vnx doctor` → `[PASS] hookpin: All 6 configured hook path(s) resolve`, full run `PASSED with warnings — 44 passed, 3 warnings` (the 3 warnings are pre-existing/unrelated: python venv, worktree `.vnx-data`, data-dir project-id mismatch from testing outside the real project tree).

Also ran `tests/test_installer_no_template_leak.py` as an extra sanity check (not required by dispatch scope): 6 passed, 1 skipped (macOS), 2 pre-existing failures unrelated to this change (a hardcoded `/Users/vincentvandeth` path in `docs/operations/RUNTIME_LIVENESS.md`, untouched by this PR) — confirms this fix doesn't clash with the existing "no unsubstituted install-time placeholder" leak test.

## Open Items

None.