### PR TITLE
fix(tmux-adapter): scope the paste buffer per call, mirroring #1451 (OI-1136)

### DIFF
--- a/scripts/lib/tmux_adapter.py
+++ b/scripts/lib/tmux_adapter.py
@@ -8,6 +8,7 @@ Feature flags: VNX_TMUX_ADAPTER_ENABLED, VNX_ADAPTER_PRIMARY.
 
 from __future__ import annotations
 
+import itertools
 import json
 import logging
 import os
@@ -163,25 +164,61 @@ def _tmux_send_keys(pane_id: str, *keys: str, literal: bool = False) -> int:
     return result.returncode
 
 
+# Monotonic per-process counter for paste-buffer names. Combined with the pid it
+# yields a buffer name that is never shared between two deliveries: distinct
+# processes differ in pid, distinct calls within one process differ in counter.
+_paste_buffer_counter = itertools.count()
+
+
+def _next_paste_buffer_name() -> str:
+    """Unique-per-call tmux buffer name (pid + module counter, never shared)."""
+    return f"vnx-adapter-paste-{os.getpid()}-{next(_paste_buffer_counter)}"
+
+
 def _tmux_load_and_paste(pane_id: str, content: str, max_inline: int = 50000) -> int:
-    """Load content into tmux buffer and paste to pane."""
-    if len(content) > max_inline:
-        with tempfile.NamedTemporaryFile(mode="w", suffix=".vnx_buf", delete=False, encoding="utf-8") as f:
-            f.write(content)
-            tmp_path = f.name
-        try:
-            rc = subprocess.run(["tmux", "load-buffer", tmp_path], capture_output=True, timeout=10).returncode
-        finally:
+    """Load content into a PER-CALL NAMED tmux buffer and paste it to pane.
+
+    OI-1136 — same mechanism as OI-1126 fixed in the tmux-spawn lane (#1451,
+    see tmux_interactive_dispatch._paste): ``load-buffer``/``paste-buffer``
+    without ``-b <name>`` operate on the tmux SERVER's single shared "most
+    recent buffer" slot, not on data scoped to this call. Two deliveries
+    racing to load+paste concurrently can have delivery A's ``paste-buffer``
+    retrieve delivery B's just-loaded content — a TOCTOU race on shared
+    global state (measured in the spawn lane: 15/20 instruction crossings at
+    4 concurrent, 0/20 after scoping). The call-sites here carry no
+    dispatch_id, so the buffer name is derived per call (pid + counter);
+    what matters is that no two deliveries ever touch the same buffer.
+    """
+    buffer_name = _next_paste_buffer_name()
+    try:
+        if len(content) > max_inline:
+            with tempfile.NamedTemporaryFile(mode="w", suffix=".vnx_buf", delete=False, encoding="utf-8") as f:
+                f.write(content)
+                tmp_path = f.name
             try:
-                os.unlink(tmp_path)
-            except OSError:
-                pass
-    else:
-        rc = subprocess.run(["tmux", "load-buffer", "-"], input=content,
-            capture_output=True, text=True, timeout=10).returncode
-    if rc != 0:
-        return rc
-    return _run_tmux("paste-buffer", "-t", pane_id).returncode
+                rc = subprocess.run(
+                    ["tmux", "load-buffer", "-b", buffer_name, tmp_path],
+                    capture_output=True, timeout=10,
+                ).returncode
+            finally:
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+        else:
+            rc = subprocess.run(["tmux", "load-buffer", "-b", buffer_name, "-"], input=content,
+                capture_output=True, text=True, timeout=10).returncode
+        if rc != 0:
+            return rc
+        return _run_tmux("paste-buffer", "-b", buffer_name, "-t", pane_id).returncode
+    finally:
+        # Best-effort cleanup: a long-running fleet must not accumulate one
+        # named buffer per delivery forever. Failure here never affects the
+        # paste outcome already computed above.
+        try:
+            _run_tmux("delete-buffer", "-b", buffer_name)
+        except Exception:  # vnx-silent-except: best-effort buffer cleanup must never mask the paste outcome
+            pass
 
 
 class TmuxAdapter:

--- a/tests/test_tmux_adapter.py
+++ b/tests/test_tmux_adapter.py
@@ -587,5 +587,113 @@ class TestAdapterCliResolveCommand(unittest.TestCase):
         self.assertIn("primary_path", data)
 
 
+class TestLoadAndPasteUsesPerCallNamedBuffer(unittest.TestCase):
+    """OI-1136 regression: _tmux_load_and_paste() must never use tmux's shared
+    default buffer.
+
+    Same mechanism as OI-1126 in the tmux-spawn lane (#1451): unnamed
+    load-buffer/paste-buffer operate on the tmux server's single "most recent
+    buffer" slot, so two deliveries racing can paste each other's content
+    (measured there: 15/20 instruction crossings at 4 concurrent, 0/20 after
+    scoping). These tests fail if delivery is ever addressed by the bare/
+    shared buffer again.
+    """
+
+    def _recording_run(self, recorded, *, load_rc=0, paste_rc=0):
+        def fake_run(cmd, **kwargs):
+            recorded.append(list(cmd))
+            result = MagicMock()
+            if "load-buffer" in cmd:
+                result.returncode = load_rc
+            elif "paste-buffer" in cmd:
+                result.returncode = paste_rc
+            else:
+                result.returncode = 0
+            return result
+        return fake_run
+
+    def _buffer_name(self, cmd):
+        """Extract the -b <name> argument from a recorded tmux command."""
+        self.assertIn("-b", cmd, f"expected -b named-buffer flag in {cmd}")
+        return cmd[cmd.index("-b") + 1]
+
+    def _cmds(self, recorded, subcommand):
+        return [c for c in recorded if subcommand in c]
+
+    def test_load_and_paste_use_the_same_named_buffer(self):
+        import tmux_adapter
+        recorded = []
+        with patch.object(tmux_adapter.subprocess, "run", self._recording_run(recorded)):
+            rc = tmux_adapter._tmux_load_and_paste("%1", "hello world")
+
+        self.assertEqual(rc, 0)
+        loads = self._cmds(recorded, "load-buffer")
+        pastes = self._cmds(recorded, "paste-buffer")
+        self.assertEqual(len(loads), 1)
+        self.assertEqual(len(pastes), 1)
+        # Old behavior (regression target): ["tmux", "load-buffer", "-"] /
+        # ["tmux", "paste-buffer", "-t", pane]. New behavior: both carry an
+        # explicit -b buffer name, and it is the SAME name on both.
+        self.assertEqual(self._buffer_name(loads[0]), self._buffer_name(pastes[0]))
+        self.assertIn("-t", pastes[0])
+        self.assertEqual(pastes[0][pastes[0].index("-t") + 1], "%1")
+
+    def test_two_calls_never_share_a_buffer_name(self):
+        """The exact condition behind OI-1126/OI-1136: two deliveries around the
+        same time must be structurally unable to collide on buffer identity."""
+        import tmux_adapter
+        recorded = []
+        with patch.object(tmux_adapter.subprocess, "run", self._recording_run(recorded)):
+            tmux_adapter._tmux_load_and_paste("%1", "content for A")
+            tmux_adapter._tmux_load_and_paste("%2", "content for B")
+
+        pastes = self._cmds(recorded, "paste-buffer")
+        self.assertEqual(len(pastes), 2)
+        self.assertNotEqual(
+            self._buffer_name(pastes[0]), self._buffer_name(pastes[1]),
+            "two deliveries must never paste from the same buffer name",
+        )
+
+    def test_large_body_tmp_file_path_uses_named_buffer(self):
+        """Large bodies (>50k chars) go through the tmp-file load path — must
+        also use a per-call named buffer, not the bare default."""
+        import tmux_adapter
+        recorded = []
+        with patch.object(tmux_adapter.subprocess, "run", self._recording_run(recorded)):
+            rc = tmux_adapter._tmux_load_and_paste("%1", "x" * 60000, max_inline=50000)
+
+        self.assertEqual(rc, 0)
+        loads = self._cmds(recorded, "load-buffer")
+        pastes = self._cmds(recorded, "paste-buffer")
+        self.assertEqual(len(loads), 1)
+        self.assertNotIn("-", loads[0], "large body must load from tmp file, not stdin")
+        self.assertEqual(self._buffer_name(loads[0]), self._buffer_name(pastes[0]))
+
+    def test_buffer_is_deleted_after_paste(self):
+        """Cleanup: a long-running fleet must not accumulate one named buffer
+        per delivery forever."""
+        import tmux_adapter
+        recorded = []
+        with patch.object(tmux_adapter.subprocess, "run", self._recording_run(recorded)):
+            tmux_adapter._tmux_load_and_paste("%1", "hello")
+
+        loads = self._cmds(recorded, "load-buffer")
+        deletes = self._cmds(recorded, "delete-buffer")
+        self.assertEqual(len(deletes), 1)
+        self.assertEqual(self._buffer_name(deletes[0]), self._buffer_name(loads[0]))
+
+    def test_buffer_is_deleted_even_when_load_fails(self):
+        import tmux_adapter
+        recorded = []
+        with patch.object(
+            tmux_adapter.subprocess, "run", self._recording_run(recorded, load_rc=1)
+        ):
+            rc = tmux_adapter._tmux_load_and_paste("%1", "hello")
+
+        self.assertEqual(rc, 1)
+        self.assertEqual(len(self._cmds(recorded, "paste-buffer")), 0)
+        self.assertEqual(len(self._cmds(recorded, "delete-buffer")), 1)
+
+
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Mechanism

`scripts/lib/tmux_adapter.py::_tmux_load_and_paste()` did `tmux load-buffer -` followed by `paste-buffer -t <pane>` without `-b <name>` — both commands operate on the tmux SERVER's single shared "most recent buffer" slot. Two deliveries racing to load+paste concurrently can have delivery A's `paste-buffer` retrieve delivery B's just-loaded content: the exact TOCTOU race PR #1451 fixed in the tmux-spawn lane (measured there: 15/20 instruction crossings at 4 concurrent, 0/20 after scoping). This adapter is the default delivery lane for T0-pinned terminals, so the gap sat on the most-used path. Both call-sites were exposed: the codex combined paste (`:482` pre-fix) and the claude prompt paste (`:503` pre-fix).

## Fix

Mechanically mirrors `tmux_interactive_dispatch.py::_paste` (#1451): a per-call NAMED buffer on `load-buffer` AND `paste-buffer`, best-effort `delete-buffer` in a `finally`, on both the inline and the >50k tmp-file load path. The call-sites here carry no dispatch_id, so the buffer name is derived per call from pid + a module counter (`vnx-adapter-paste-<pid>-<n>`) — never shared between two deliveries: distinct processes differ in pid, distinct calls in one process differ in counter.

Tests mirror `TestPasteUsesPerDispatchNamedBuffer` from `tests/test_tmux_interactive_dispatch.py`: `-b` usage asserted on load AND paste with the same name, distinct names across two calls, tmp-file path covered, cleanup asserted on success and on load failure.

## Negative control (new tests vs unfixed origin/main source)

`git checkout origin/main -- scripts/lib/tmux_adapter.py`, then:

```
tests/test_tmux_adapter.py:617: in _buffer_name
    self.assertIn("-b", cmd, f"expected -b named-buffer flag in {cmd}")
E   AssertionError: '-b' not found in ['tmux', 'paste-buffer', '-t', '%1'] : expected -b named-buffer flag in ['tmux', 'paste-buffer', '-t', '%1']
=========================== short test summary info ============================
FAILED tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_buffer_is_deleted_after_paste
FAILED tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_buffer_is_deleted_even_when_load_fails
FAILED tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_large_body_tmp_file_path_uses_named_buffer
FAILED tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_load_and_paste_use_the_same_named_buffer
FAILED tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_two_calls_never_share_a_buffer_name
============================== 5 failed in 0.19s ===============================
```

After restoring the fixed source (`git checkout HEAD -- scripts/lib/tmux_adapter.py`):

## Green test output (fixed branch)

```
tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_buffer_is_deleted_after_paste PASSED [ 20%]
tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_buffer_is_deleted_even_when_load_fails PASSED [ 40%]
tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_large_body_tmp_file_path_uses_named_buffer PASSED [ 60%]
tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_load_and_paste_use_the_same_named_buffer PASSED [ 80%]
tests/test_tmux_adapter.py::TestLoadAndPasteUsesPerCallNamedBuffer::test_two_calls_never_share_a_buffer_name PASSED [100%]
5 passed in 0.17s
```

Full `tests/test_tmux_adapter.py`: 47 passed, 3 failed — the 3 failures are `TestAdapterCliResolveCommand` importing `tmux_adapter_cli`, a module deleted in the #205 dead-code purge; pre-existing on origin/main, untouched by this PR. Neighbours `tests/test_tmux_adapter_exception_handling.py` fully green; `tests/test_tmux_adapter_interface.py` has 2 pre-existing failures (direct-tmux-coupling violations in `context_rotation.py`/`pool_manager.py`/`pool_reaper.py`, and a `shutdown(graceful=)` signature drift) — both reproduce identically with origin/main's `tmux_adapter.py` in place.

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1136.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
