### PR TITLE
fix(receipt-converter): line-anchor both bold Dispatch-ID branches (OI-1132)

### DIFF
--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -63,21 +63,34 @@ _FRONTMATTER_RE = re.compile(r"^---\s*\n(.*?)\n---\s*\n", re.DOTALL)
 # groups, so group 1/2 hold the outer-colon form and group 3/4 the
 # inner-colon form; exactly one pair is non-None per match.
 #
-# The inner-colon alternative is anchored to line start (optional [-*]
-# marker, mirroring _DISPATCH_PLAIN_RE) — unlike the pre-existing outer-colon
-# alternative, which is a bare substring search with no anchor at all. This
-# is not cosmetic: the unanchored form was measured against the real
-# unified_reports/ corpus (4015 files) and produced a genuine false positive
-# — a report's OWN changelog prose, `` `**Dispatch-ID:**` labels (closing
-# `**` sits after the colon) ``, quoting the exact inner-colon shape as an
-# example, matched as if it were a field declaration and its trailing prose
-# became the "value", shadowing (via fields.setdefault order) the report's
-# real bare Dispatch-ID line earlier in the same file. Anchoring closes this
-# without touching the outer form's existing (unrelated, pre-#1445) lack of
-# anchoring, which is out of scope here. Neither alternative matches bold
-# text with no colon at all (e.g. `**note** text`).
+# OI-1132: BOTH alternatives carry the exact anchor _DISPATCH_PLAIN_RE got
+# in #1445 — `^` with no leading `\s*`, then an optional list marker followed
+# by exactly one literal space (`[-*] `). #1445 anchored the plain-text path
+# precisely so quoted unified-diff removal lines (`-    Dispatch-ID:
+# old-value`, arbitrary reindentation after the `-`) and indented code-block
+# lines can never be adopted as identity, but left the bold branches loose:
+# the inner-colon alternative accepted `^\s*` + `[-*]\s+` (so a diff-removal
+# `-    **Dispatch-ID:** old-stale-value` and an indented
+# `    **Dispatch-ID:** quoted-example` both matched — reproduced on the
+# #1445 branch), and the outer-colon alternative had no anchor at all: a
+# bare substring search that matched mid-line, mid-prose, and inside quoted
+# diffs (it already produced a real corpus false positive — a report's OWN
+# changelog prose quoting `` `**Dispatch-ID:**` labels `` matched as a field
+# declaration, shadowing the report's genuine bare Dispatch-ID line via
+# fields.setdefault order). The value's id-shape check (dispatch_spec._ID_RE)
+# cannot save this: a stale foreign id is a perfectly legal id shape — only
+# the line anchor separates a field declaration from quoted content.
+#
+# Blast radius measured across all 4230 reports in unified_reports/
+# (2026-08-11, method as in #1445): 0 reports change dispatch_id under the
+# anchored form; 1 report changes any consumed key at all
+# (20260610-gate-kimi-pr836.md, whose old `status`="Active" was itself
+# scraped from a quoted diff context line ` **Status**: Active` — dropping
+# it is this very bug being fixed, not a regression). Neither alternative
+# matches bold text with no colon at all (e.g. `**note** text`).
 _BOLD_KV_RE = re.compile(
-    r"\*\*([^*]+)\*\*:\s*(.+)|^\s*(?:[-*]\s+)?\*\*([^*]+):\*\*\s*(.+)", re.MULTILINE
+    r"^(?:[-*] )?\*\*([^*]+)\*\*:\s*(.+)|^(?:[-*] )?\*\*([^*]+):\*\*\s*(.+)",
+    re.MULTILINE,
 )
 # OI-1120: the report contract tells workers to stamp the id "as a plain-text
 # or bold field" — a markdown list item (`- Dispatch-ID: x`) is plainly within

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -2179,3 +2179,118 @@ class TestOI1125BoldColonInsideMarkers:
         )
         fields = _extract_body_fields(text)
         assert fields.get("dispatch_id") == "20260810g-a-converter-scoping"
+
+
+# ---------------------------------------------------------------------------
+# Part 17: OI-1132 — the bold branches get the same line anchor as the
+# plain-text path (#1445 residual gap, filed deliberately at merge)
+# ---------------------------------------------------------------------------
+
+class TestBoldBranchesLineAnchored:
+    """#1445 anchored _DISPATCH_PLAIN_RE at `^` (no leading \\s*, optional
+    `[-*] ` marker with exactly one space) so quoted diff-removal lines and
+    indented code-block lines can never become identity — but left both bold
+    alternatives loose: the inner-colon branch accepted `^\\s*` + `[-*]\\s+`,
+    and the outer-colon branch had no anchor at all. dispatch_spec._ID_RE
+    cannot catch this ('old-stale-value' is a perfectly legal id shape);
+    only the anchor separates a field declaration from quoted content."""
+
+    # The four reproduced-in-OI-1132 shapes that must NOT match, plus the
+    # genuine forms (both colon placements, bare + dash-list + star-list)
+    # that must keep matching.
+    @pytest.mark.parametrize("name,line,expected", [
+        # -- reproduced gap shapes (all matched before the anchor fix) --
+        ("diff_removal_inner_colon", "-    **Dispatch-ID:** old-stale-value", None),
+        ("indented_codeblock_inner_colon", "    **Dispatch-ID:** quoted-example", None),
+        ("diff_removal_outer_colon", "-    **Dispatch-ID**: old-stale-value", None),
+        ("indented_codeblock_outer_colon", "    **Dispatch-ID**: quoted-example", None),
+        # -- pre-existing-on-main outer-colon gap: bare substring, mid-line --
+        ("midline_prose_outer_colon",
+         "The report carries **Dispatch-ID**: old-stale-value in its header.",
+         None),
+        # -- genuine forms that must keep working --
+        ("bare_outer_colon", "**Dispatch-ID**: 20260810g-a-converter-scoping",
+         "20260810g-a-converter-scoping"),
+        ("bare_inner_colon", "**Dispatch-ID:** 20260810g-a-converter-scoping",
+         "20260810g-a-converter-scoping"),
+        ("dash_list_outer_colon", "- **Dispatch-ID**: 20260810e-a-seattimeout-1444",
+         "20260810e-a-seattimeout-1444"),
+        ("star_list_outer_colon", "* **Dispatch-ID**: 20260810e-a-seattimeout-1444",
+         "20260810e-a-seattimeout-1444"),
+        ("dash_list_inner_colon", "- **Dispatch-ID:** 20260810e-a-seattimeout-1444",
+         "20260810e-a-seattimeout-1444"),
+        ("star_list_inner_colon", "* **Dispatch-ID:** 20260810e-a-seattimeout-1444",
+         "20260810e-a-seattimeout-1444"),
+    ])
+    def test_bold_shapes(self, name, line, expected):
+        fields = _extract_body_fields(line + "\n\n" + _CONTRACT_BODY)
+        assert fields.get("dispatch_id") == expected, f"shape={name!r} line={line!r}"
+
+    def test_genuine_field_wins_over_quoted_foreign_bold_diff_line(self):
+        """A report that QUOTES a diff line carrying another dispatch's bold
+        Dispatch-ID while stamping its own genuine field must keep its own
+        identity — and not via setdefault ordering luck: the quoted line
+        comes FIRST here, so under the unanchored regex the foreign id would
+        win. Only the anchor rejects it."""
+        text = (
+            "Review finding quoted below:\n\n"
+            "```diff\n"
+            "-    **Dispatch-ID:** old-stale-value\n"
+            "+    **Dispatch-ID:** something-else\n"
+            "```\n\n"
+            "**Dispatch-ID**: 20260811h-b-boldanchor-1132\n\n" + _CONTRACT_BODY
+        )
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260811h-b-boldanchor-1132"
+
+    def test_only_quoted_foreign_bold_form_is_never_adopted_as_identity(self, tmp_path):
+        """A report whose ONLY bold Dispatch-ID occurrence is inside a quoted
+        diff must not adopt that foreign id: identity falls back to the
+        filename and the receipt is a contract violation, not a clean
+        task_complete carrying someone else's id."""
+        text = (
+            "## Summary\n\nThis summary has more than fifty non-whitespace "
+            "characters so the body contract validates cleanly.\n\n"
+            "## Changes\n\nDiff excerpt from the reviewed PR:\n```diff\n"
+            "-    **Dispatch-ID:** old-stale-value\n"
+            "+    **Dispatch-ID:** 20260811h-b-boldanchor-1132\n"
+            "```\n\n## Verification\n\n- none\n\n## Open Items\n\nNone\n"
+        )
+        report = tmp_path / "20260811h-b-boldanchor-1132.md"
+        report.write_text(text, encoding="utf-8")
+        receipt = build_receipt_from_report(report, text)
+        assert receipt is not None
+        assert receipt["dispatch_id"] == "20260811h-b-boldanchor-1132"
+        assert receipt["dispatch_id"] != "old-stale-value"
+        assert receipt["event_type"] == "report_contract_invalid"
+
+    def test_list_item_bold_model_field_still_extracted(self):
+        """The anchor applies to ALL bold fields, not just Dispatch-ID —
+        genuine list-item identity blocks (`- **Model**: sonnet`) must keep
+        parsing, or the fail-closed model check would start refusing valid
+        reports."""
+        text = (
+            "- **Dispatch-ID**: 20260811h-b-boldanchor-1132\n"
+            "- **Model**: sonnet\n"
+            "- **Provider**: claude\n\n" + _CONTRACT_BODY
+        )
+        fields = _extract_body_fields(text)
+        assert fields.get("dispatch_id") == "20260811h-b-boldanchor-1132"
+        assert fields.get("model") == "sonnet"
+        assert fields.get("provider") == "claude"
+
+    def test_quoted_diff_context_status_line_not_scraped(self):
+        """The one consumed-key change in the 4230-report blast-radius
+        measurement (20260610-gate-kimi-pr836.md): a quoted diff CONTEXT
+        line ` **Status**: Active` (diff's leading-space indent) was scraped
+        as the report's status field. The anchor must reject it."""
+        text = (
+            "Doc diff under review:\n\n"
+            "```diff\n"
+            " **Status**: Active\n"
+            "-**Last Updated**: 2026-04-08\n"
+            "+**Last Updated**: 2026-06-10\n"
+            "```\n\n" + _CONTRACT_BODY
+        )
+        fields = _extract_body_fields(text)
+        assert "status" not in fields


### PR DESCRIPTION
## Mechanism

`_BOLD_KV_RE` in `scripts/lib/report_to_receipt_converter.py` had two under-anchored alternatives, so a report that merely QUOTES a diff line carrying `**Dispatch-ID**` adopted that foreign id as its receipt identity:

- The **outer-colon** branch (`**Dispatch-ID**: value`) was a bare substring search with no anchor at all — it matched mid-line, mid-prose, and inside quoted diffs. Pre-existing on main before #1445.
- The **inner-colon** branch (`**Dispatch-ID:** value`, added by #1445) was anchored but in the WIDE form (`^\s*` + `[-*]\s+`), so a quoted diff-removal line `-    **Dispatch-ID:** old-stale-value` and an indented code-block line `    **Dispatch-ID:** quoted-example` both matched — reproduced in OI-1132 on the #1445 branch.

The downstream shape check (`dispatch_spec._ID_RE`) cannot catch this: a stale foreign id is a perfectly legal id shape. Only a line anchor separates a field declaration from quoted content. This is the residual gap #1445 filed deliberately at merge (OI-1132).

## Fix

Both bold alternatives now carry the exact anchor `_DISPATCH_PLAIN_RE` got in #1445: `^(?:[-*] )?` — line start, no leading `\s*`, optional `-`/`*` list marker followed by exactly one literal space.

```
old: \*\*([^*]+)\*\*:\s*(.+)|^\s*(?:[-*]\s+)?\*\*([^*]+):\*\*\s*(.+)
new: ^(?:[-*] )?\*\*([^*]+)\*\*:\s*(.+)|^(?:[-*] )?\*\*([^*]+):\*\*\s*(.+)
```

All genuine forms keep working (bare line, dash-list, star-list — both colon placements), covered by parametrized tests.

## Blast radius (measured, per the OI mandate — method as in #1445)

Old vs new regex, full `_extract_body_fields()` replica over all **4230** reports in the central `unified_reports/`:

- `dispatch_id` changes: **0**
- reports where any RECEIPT-CONSUMED key changes: **1** — `20260610-gate-kimi-pr836.md`, whose old `status`="Active" was scraped from a quoted diff CONTEXT line (` **Status**: Active`, the diff's leading-space indent, line 46 of that report). Dropping it is this very bug being fixed, not a regression; the report's real identity comes from frontmatter and is untouched.
- The other 1174 diffs are junk prose keys the unanchored regex invented from mid-line bold text (e.g. `folder_per_agent`, `spaak`, `evidence_source`) — none are keys the receipt builder reads.

## Negative control (new tests vs unfixed origin/main source)

`git stash` of the source fix only, same tests:

```
FAILED ...::TestBoldBranchesLineAnchored::test_bold_shapes[diff_removal_inner_colon--    **Dispatch-ID:** old-stale-value-None]
FAILED ...::TestBoldBranchesLineAnchored::test_bold_shapes[indented_codeblock_inner_colon-    **Dispatch-ID:** quoted-example-None]
FAILED ...::TestBoldBranchesLineAnchored::test_bold_shapes[diff_removal_outer_colon--    **Dispatch-ID**: old-stale-value-None]
FAILED ...::TestBoldBranchesLineAnchored::test_bold_shapes[indented_codeblock_outer_colon-    **Dispatch-ID**: quoted-example-None]
FAILED ...::TestBoldBranchesLineAnchored::test_bold_shapes[midline_prose_outer_colon-The report carries **Dispatch-ID**: old-stale-value in its header.-None]
FAILED ...::TestBoldBranchesLineAnchored::test_genuine_field_wins_over_quoted_foreign_bold_diff_line
FAILED ...::TestBoldBranchesLineAnchored::test_only_quoted_foreign_bold_form_is_never_adopted_as_identity
FAILED ...::TestBoldBranchesLineAnchored::test_quoted_diff_context_status_line_not_scraped
8 failed, 7 passed in 0.28s
```

(the 7 passes are the genuine-form rows, which must pass in both worlds)

Example failure detail against old code:

```
>       assert "status" not in fields
E       AssertionError: assert 'status' not in {'last_updated': '2026-04-08', 'status': 'Active'}
```

## Green run (with fix)

```
tests/test_report_to_receipt_converter.py: 126 passed in 8.75s
```

Direct neighbours (`test_report_parser_model_provider.py`, `test_runtime_adapter_certification.py`, `test_append_receipt_register_emit.py`): `113 passed in 4.27s`.

## Key scenario tests

- Body quotes a diff line with a foreign bold Dispatch-ID FIRST, genuine field later → genuine one wins (not by setdefault luck — the quoted line comes first, so only the anchor rejects it).
- ONLY the quoted foreign form present → not adopted; identity falls to filename, receipt is `report_contract_invalid`, never a clean `task_complete` with someone else's id.
- List-item bold `- **Model**: sonnet` / `- **Provider**: claude` keep parsing (the fail-closed model check must not start refusing valid reports).

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1132.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
