### PR TITLE
fix(register): run the idempotency check inside the write lock (OI-1129)

### DIFF
--- a/scripts/lib/dispatch_register.py
+++ b/scripts/lib/dispatch_register.py
@@ -342,6 +342,48 @@ def append_event(
     primary write (see ``_register_path``) — the same override ``read_events``
     already accepts.
     """
+    return _append_event_core(
+        event,
+        dispatch_id=dispatch_id,
+        pr_number=pr_number,
+        feature_id=feature_id,
+        terminal=terminal,
+        gate=gate,
+        extra=extra,
+        operator_id=operator_id,
+        project_id=project_id,
+        orchestrator_id=orchestrator_id,
+        agent_id=agent_id,
+        state_dir=state_dir,
+        dedup=False,
+    )
+
+
+def _append_event_core(
+    event: str,
+    *,
+    dispatch_id: str,
+    pr_number: Optional[int],
+    feature_id: str,
+    terminal: str,
+    gate: str,
+    extra: Optional[dict],
+    operator_id: Optional[str],
+    project_id: Optional[str],
+    orchestrator_id: Optional[str],
+    agent_id: Optional[str],
+    state_dir: Optional[Path],
+    dedup: bool,
+) -> bool:
+    """Shared body of ``append_event`` / ``append_event_idempotent``.
+
+    ``dedup=True`` performs the duplicate check INSIDE the write's critical
+    section (``state_writer.append_locked`` with ``skip_if``): check and
+    append share one sentinel + data-file ``LOCK_EX`` hold, so two
+    concurrent callers can never both pass the check (OI-1129). On a
+    duplicate hit the mirrors (decision log, central) are skipped — the
+    equivalent event already went through them when it was first written.
+    """
     if event not in VALID_EVENTS:
         return False
     # Require at least one identifying field — register is canonical source, must be queryable
@@ -365,7 +407,20 @@ def append_event(
     )
     try:
         primary_path = _resolve_register_path(state_dir=state_dir)
-        _write_event_locked(primary_path, record)
+        if dedup:
+            event_identity = _event_identity(record)
+            appended = state_writer.append_locked(
+                primary_path,
+                record,
+                skip_if=lambda content: _content_has_identity(content, event_identity),
+            )
+            if not appended:
+                # Equivalent event already in the register: present-after-call
+                # is the contract, and the first write already fanned out to
+                # the mirrors.
+                return True
+        else:
+            _write_event_locked(primary_path, record)
         _mirror_to_decision_log(event, record, extra=extra)
         # Phase 6 P3 dual-write: mirror to central when project_id is known
         if project_id:
@@ -380,7 +435,7 @@ def append_event(
         return False
 
 
-def _event_identity(event: dict) -> tuple[str, str, str]:
+def _event_identity(event: dict) -> tuple[str, str, str, str]:
     """The non-timestamp portion of ``_merge_dedup_key``.
 
     Two records sharing this identity describe the same real-world
@@ -388,6 +443,29 @@ def _event_identity(event: dict) -> tuple[str, str, str]:
     only field ``_merge_dedup_key`` includes that a retry naturally varies.
     """
     return _merge_dedup_key(event)[1:]
+
+
+def _content_has_identity(content: bytes, identity: tuple[str, str, str, str]) -> bool:
+    """True when raw register NDJSON ``content`` holds an event with ``identity``.
+
+    Total by construction — undecodable bytes, unparseable lines, and
+    non-dict JSON are skipped, never raised on — because this runs as the
+    ``skip_if`` predicate inside ``state_writer.append_locked``'s critical
+    section: a scan failure must degrade to "no duplicate found" (append
+    proceeds; better a possible duplicate than a lost event), the same
+    direction the old pre-check fell.
+    """
+    for line in content.decode("utf-8", errors="replace").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            existing = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(existing, dict) and _event_identity(existing) == identity:
+            return True
+    return False
 
 
 def append_event_idempotent(
@@ -415,24 +493,17 @@ def append_event_idempotent(
     (event, dispatch_id, pr_number, feature_id), evaluated at write time
     instead of read time, rather than inventing a second dedup scheme.
 
-    The pre-check is best-effort: a failed read falls through to the normal
-    ``append_event`` attempt (better a possible duplicate than a lost event).
+    OI-1129: the duplicate check runs INSIDE the write's critical section
+    (``state_writer.append_locked`` with ``skip_if`` — the same
+    check-inside-the-lock discipline the receipt writer uses in
+    ``append_receipt_internals.idempotency._write_receipt_under_lock``), not
+    as a separate ``read_events`` pre-check. The original read-then-write
+    pair let two concurrent callers both miss the pre-check and both append.
+
     Returns True when the event is present after the call — whether it was
     already there or newly written — False only on a genuine write failure.
     """
-    identity = _event_identity({
-        "event": event,
-        "dispatch_id": dispatch_id,
-        "pr_number": pr_number,
-        "feature_id": feature_id,
-    })
-    try:
-        for existing in read_events(state_dir=state_dir):
-            if _event_identity(existing) == identity:
-                return True
-    except Exception:  # vnx-silent-except: pre-check is best-effort; fall through to the real append attempt
-        pass
-    return append_event(
+    return _append_event_core(
         event,
         dispatch_id=dispatch_id,
         pr_number=pr_number,
@@ -445,6 +516,7 @@ def append_event_idempotent(
         orchestrator_id=orchestrator_id,
         agent_id=agent_id,
         state_dir=state_dir,
+        dedup=True,
     )
 
 

--- a/scripts/lib/state_writer.py
+++ b/scripts/lib/state_writer.py
@@ -8,6 +8,7 @@ import os
 import tempfile
 from collections.abc import Callable
 from pathlib import Path
+from typing import Optional
 
 _SENTINEL_REGISTRY = {
     "dispatch_register.ndjson": ".state.lock",
@@ -24,8 +25,25 @@ def _sentinel_path(data_path: Path) -> Path:
     return data_path.parent / lock_name
 
 
-def append_locked(path: Path, record: dict) -> None:
-    """Append one JSON record under the shared sentinel and data-file locks."""
+def append_locked(
+    path: Path,
+    record: dict,
+    *,
+    skip_if: Optional[Callable[[bytes], bool]] = None,
+) -> bool:
+    """Append one JSON record under the shared sentinel and data-file locks.
+
+    ``skip_if``, when given, receives the file's current content INSIDE the
+    critical section; returning True skips the append. This makes
+    check-and-append one atomic operation — the same check-inside-the-lock
+    discipline the receipt writer uses
+    (``append_receipt_internals.idempotency._write_receipt_under_lock``) —
+    instead of a read-then-write pair that two concurrent callers can both
+    pass (OI-1129).
+
+    Returns True when the record was appended, False when ``skip_if``
+    skipped it. Callers without ``skip_if`` always get True.
+    """
     path.parent.mkdir(parents=True, exist_ok=True)
     sentinel = _sentinel_path(path)
     payload = (json.dumps(record, separators=(",", ":"), sort_keys=False) + "\n").encode("utf-8")
@@ -33,10 +51,15 @@ def append_locked(path: Path, record: dict) -> None:
         fcntl.flock(sentinel_fh.fileno(), fcntl.LOCK_EX)
         with path.open("a+b") as fh:
             fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+            if skip_if is not None:
+                fh.seek(0)
+                if skip_if(fh.read()):
+                    return False
             fh.seek(0, os.SEEK_END)
             fh.write(payload)
             fh.flush()
             os.fsync(fh.fileno())
+    return True
 
 
 def rewrite_locked(path: Path, new_content: bytes | Callable[[bytes], bytes]) -> None:

--- a/tests/test_dispatch_register.py
+++ b/tests/test_dispatch_register.py
@@ -479,16 +479,96 @@ class TestAppendEventIdempotent:
         ids = {json.loads(line)["dispatch_id"] for line in reg.read_text().splitlines()}
         assert ids == {"d-idem-a", "d-idem-b"}
 
-    def test_precheck_read_failure_falls_through_to_append(self, isolated_data_dir):
-        """A broken pre-check read must not block the write — better a
-        possible duplicate than a lost event."""
-        with patch("dispatch_register.read_events", side_effect=OSError("boom")):
-            result = dispatch_register.append_event_idempotent(
-                "dispatch_created", dispatch_id="d-idem-preread-fail",
-            )
-        assert result is True
+    def test_corrupt_lines_do_not_block_the_write(self, isolated_data_dir):
+        """Unparseable ledger lines must not block the write — better a
+        possible duplicate than a lost event (same direction the old
+        read_events pre-check fell)."""
         reg = _reg_path(isolated_data_dir)
-        assert len(reg.read_text().splitlines()) == 1
+        reg.parent.mkdir(parents=True, exist_ok=True)
+        reg.write_text('{"broken json\nnot json at all\n[1, 2, 3]\n')
+        result = dispatch_register.append_event_idempotent(
+            "dispatch_created", dispatch_id="d-idem-corrupt",
+        )
+        assert result is True
+        lines = reg.read_text().splitlines()
+        assert json.loads(lines[-1])["dispatch_id"] == "d-idem-corrupt"
+
+
+class TestAppendEventIdempotentRace:
+    """OI-1129: the duplicate check and the append must share ONE critical
+    section — a read-then-write pair lets two concurrent callers both pass
+    the check and both append."""
+
+    def test_race_window_interleaving_produces_single_record(self, isolated_data_dir):
+        """Deterministic simulation of the race window: both callers'
+        pre-checks saw an empty register before either wrote. ``read_events``
+        pinned to [] IS that observation. A check that runs inside the write
+        lock reads the file's actual content and is immune to the pin; the
+        old out-of-lock ``read_events`` pre-check misses both times and
+        appends twice."""
+        with patch("dispatch_register.read_events", return_value=[]):
+            first = dispatch_register.append_event_idempotent(
+                "dispatch_created", dispatch_id="d-oi1129-race",
+            )
+            second = dispatch_register.append_event_idempotent(
+                "dispatch_created", dispatch_id="d-oi1129-race",
+            )
+        assert first is True
+        assert second is True
+        reg = _reg_path(isolated_data_dir)
+        lines = reg.read_text().splitlines()
+        assert len(lines) == 1, f"expected exactly one record, got {len(lines)}: {lines}"
+        assert json.loads(lines[0])["dispatch_id"] == "d-oi1129-race"
+
+    def test_threaded_same_dispatch_single_record(self, isolated_data_dir):
+        """Genuinely concurrent registrations of the same dispatch produce
+        one record: flock serializes distinct file descriptors even within
+        one process, so every thread's check sees the winner's append."""
+        n = 6
+        barrier = threading.Barrier(n)
+        results: list[bool] = []
+        lock = threading.Lock()
+
+        def worker() -> None:
+            barrier.wait()
+            result = dispatch_register.append_event_idempotent(
+                "dispatch_created", dispatch_id="d-oi1129-threads",
+            )
+            with lock:
+                results.append(result)
+
+        threads = [threading.Thread(target=worker) for _ in range(n)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert results == [True] * n
+        reg = _reg_path(isolated_data_dir)
+        lines = reg.read_text().splitlines()
+        assert len(lines) == 1, f"expected exactly one record, got {len(lines)}: {lines}"
+
+    def test_threaded_distinct_dispatches_all_land(self, isolated_data_dir):
+        """Dedup is per-identity: concurrent registrations of DIFFERENT
+        dispatches must all land."""
+        ids = [f"d-oi1129-distinct-{i}" for i in range(4)]
+        barrier = threading.Barrier(len(ids))
+
+        def worker(dispatch_id: str) -> None:
+            barrier.wait()
+            dispatch_register.append_event_idempotent(
+                "dispatch_created", dispatch_id=dispatch_id,
+            )
+
+        threads = [threading.Thread(target=worker, args=(d,)) for d in ids]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        reg = _reg_path(isolated_data_dir)
+        written = {json.loads(line)["dispatch_id"] for line in reg.read_text().splitlines()}
+        assert written == set(ids)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_state_writer.py
+++ b/tests/test_state_writer.py
@@ -57,6 +57,41 @@ def test_append_locked_writes_single_record(tmp_path: Path):
     }
 
 
+def test_append_locked_skip_if_sees_content_inside_lock_and_skips(tmp_path: Path):
+    """OI-1129: skip_if receives the file's current bytes INSIDE the critical
+    section; True skips the append and append_locked reports False."""
+    path = tmp_path / "state.ndjson"
+    SW.append_locked(path, {"dispatch_id": "d-1"})
+    seen: list[bytes] = []
+
+    def _skip(content: bytes) -> bool:
+        seen.append(content)
+        return b"d-1" in content
+
+    result = SW.append_locked(path, {"dispatch_id": "d-1"}, skip_if=_skip)
+
+    assert result is False
+    assert seen and b'"dispatch_id":"d-1"' in seen[0]
+    assert len(path.read_text(encoding="utf-8").splitlines()) == 1
+
+
+def test_append_locked_skip_if_false_appends_and_returns_true(tmp_path: Path):
+    path = tmp_path / "state.ndjson"
+
+    result = SW.append_locked(path, {"dispatch_id": "d-2"}, skip_if=lambda content: False)
+
+    assert result is True
+    lines = path.read_text(encoding="utf-8").splitlines()
+    assert len(lines) == 1
+    assert json.loads(lines[0]) == {"dispatch_id": "d-2"}
+
+
+def test_append_locked_without_skip_if_returns_true(tmp_path: Path):
+    path = tmp_path / "state.ndjson"
+
+    assert SW.append_locked(path, {"dispatch_id": "d-3"}) is True
+
+
 def test_append_locked_concurrent_100_threads_100_writes(tmp_path: Path):
     path = tmp_path / "state.ndjson"
     start = threading.Event()


### PR DESCRIPTION
## Mechanism

`dispatch_register.append_event_idempotent` did its duplicate check as `for existing in read_events(...)` and then wrote via `append_event(...)`. The read and the write shared no critical section. Two concurrent callers both saw no existing event and both appended, producing a duplicate `dispatch_created` row per dispatch. The existing unit test called sequentially and could not find this by construction. Filed as OI-1129 at the merge of #1447, together with a second finding: the pre-check swallowed failures with a silent `except Exception: pass`.

## Fix

The duplicate check now runs INSIDE the write's critical section. `state_writer.append_locked` gains an optional `skip_if` predicate that receives the file's current bytes while the sentinel + data-file `LOCK_EX` are held; returning True skips the append. This is the same check-inside-the-lock discipline the repo's receipt writer already uses (`append_receipt_internals.idempotency._write_receipt_under_lock`) — no new locking scheme, the register's existing sentinel lock (`.state.lock`) does the serialization.

One dedup concept remains: `_event_identity`, the non-timestamp slice of `_merge_dedup_key`, now evaluated at write time under the lock (`_content_has_identity`). The racy `read_events` pre-check is gone, and with it the silent `except Exception: pass` (the OI's second finding): the in-lock scan is total by construction (undecodable bytes / unparseable lines / non-dict JSON are skipped), so a scan problem degrades to "append proceeds" — the same safe direction, without a swallowed exception. On a duplicate hit the decision-log and central mirrors are skipped, exactly as the old pre-check-hit path did, and the call still returns True (present-after-call contract).

`append_locked` now returns bool (True appended / False skipped). Existing callers ignored the previous `None` return; the positional call shape `append_locked(path, record)` is unchanged, so monkeypatching tests keep working.

## Negative control (new tests against unfixed origin/main source)

`git stash -- scripts/lib/dispatch_register.py scripts/lib/state_writer.py`, rerun:

```
>       assert len(lines) == 1, f"expected exactly one record, got {len(lines)}: {lines}"
E       AssertionError: expected exactly one record, got 2: ['{"timestamp":"2026-08-11T15:26:28.114917Z","event":"dispatch_created","dispatch_id":"d-oi1129-race","record_id":"20be39f52f5a067b"}', '{"timestamp":"2026-08-11T15:26:28.142020Z","event":"dispatch_created","dispatch_id":"d-oi1129-race","record_id":"fc16c6385e4d3007"}']
E       assert 2 == 1

FAILED tests/test_dispatch_register.py::TestAppendEventIdempotentRace::test_race_window_interleaving_produces_single_record
FAILED tests/test_dispatch_register.py::TestAppendEventIdempotentRace::test_threaded_same_dispatch_single_record
FAILED tests/test_state_writer.py::test_append_locked_skip_if_sees_content_inside_lock_and_skips
FAILED tests/test_state_writer.py::test_append_locked_skip_if_false_appends_and_returns_true
FAILED tests/test_state_writer.py::test_append_locked_without_skip_if_returns_true
5 failed, 1 passed, 6 deselected in 0.45s
```

The race-window test pins `read_events` to `[]` — exactly what both racers observe in the window — so it deterministically reproduces the duplicate on origin/main; the in-lock check reads actual file content and is immune to the pin. The threaded tests additionally drive 6 genuinely concurrent registrations of the same dispatch (one record survives) and 4 concurrent distinct dispatches (all land).

## Green test output (fixed tree)

```
tests/test_state_writer.py tests/test_dispatch_register.py tests/test_dispatch_register_state_writer_integration.py
60 passed in 28.13s

tests/test_state_writer_caller_migration.py (with the three above): 63 passed
tests/test_dispatch_register_{dual_write,exception_handling,identity_partial,path,round2_findings,round3_findings}.py: 66 passed
tests/test_dispatch_lifecycle_register_events.py tests/test_append_receipt_register_emit.py tests/test_gate_recorder_register.py tests/test_build_t0_state_register_reader.py tests/test_state_writer_compact_backfill_migration.py: 95 passed
tests/test_dispatch_cli.py -k "register or idempotent": 7 passed
```

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1129.

🤖 Generated with [Claude Code](https://claude.com/claude-code)