### PR TITLE
fix(kimi): route kimi_exec through the model resolver; set heartbeat kill-flag at decision time (OI-1077, OI-1082)

### DIFF
--- a/scripts/dream/consolidator.py
+++ b/scripts/dream/consolidator.py
@@ -221,7 +221,12 @@ Patterns to consolidate:
 def _dispatch_kimi_consolidation(
     patterns_input: dict, project_id: str, timeout: float = _DEFAULT_KIMI_TIMEOUT
 ) -> dict:
-    """Dispatch kimi K2.6 cheap-lane for pattern consolidation and parse the result.
+    """Dispatch the kimi cheap-lane for pattern consolidation and parse the result.
+
+    No explicit model: kimi_exec resolves the registry default
+    (``kimi_cli.default_model`` in wave7_models.yaml, currently kimi-k3) and
+    pins it via ``-m`` — what runs is recorded in VNX, not left to whatever
+    ``~/.kimi/config.toml`` defaults to (OI-1077).
 
     Raises subprocess.TimeoutExpired if kimi does not respond within ``timeout`` seconds.
     """

--- a/scripts/lib/kimi_wrapper.py
+++ b/scripts/lib/kimi_wrapper.py
@@ -28,7 +28,13 @@ if _LIB_DIR not in sys.path:
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_KIMI_MODEL = "kimi-k2.6"
+# Mirror of the registry default (kimi_cli.default_model in wave7_models.yaml).
+# Retained ONLY for the 90-day backward-compat import surface
+# (providers/provider_lanes/kimi.py re-exports it); the exec path never reads
+# it — model resolution goes through provider_dispatch's kimi resolver, so a
+# registry change cannot silently drift past this constant (OI-1077: the old
+# hardcoded "kimi-k2.6" default outlived the model itself).
+DEFAULT_KIMI_MODEL = "kimi-k3"
 DEFAULT_TIMEOUT = 300.0
 
 
@@ -70,26 +76,49 @@ def _parse_kimi_token_usage(stdout: str) -> Optional[dict]:
 
 def kimi_exec(
     prompt: str,
-    model: str = DEFAULT_KIMI_MODEL,
+    model: Optional[str] = None,
     dispatch_id: Optional[str] = None,
     project_id: Optional[str] = None,
     timeout: float = DEFAULT_TIMEOUT,
 ) -> str:
-    """Spawn `kimi --print --output-format stream-json --yolo -p <prompt>`.
+    """Spawn `kimi --print --output-format stream-json --yolo -m <model> -p <prompt>`.
+
+    Model resolution (OI-1077) goes through the SAME resolver chain the provider
+    lane uses (provider_dispatch): ``_kimi_resolve_requested_key`` applies the
+    explicit-model -> VNX_KIMI_MODEL env -> registry-default precedence, and
+    ``_kimi_resolve_cli_model_arg`` maps the registry key to the CLI arg form
+    (kimi-cli 1.46.0 wants slash-form managed ids like ``kimi-code/k3``; raw
+    registry keys fail with rc=1 "LLM not set"). The resolved arg is ALWAYS
+    passed via ``-m`` so what runs is pinned by the VNX registry, not by
+    whatever ``~/.kimi/config.toml`` happens to default to.
 
     stdin=DEVNULL per cli-headless-subprocess-pattern (prevents interactive hang).
     Kimi is subscription-flat: cost_usd_estimate=None, billing_mode=subscription.
 
-    Emits a provider cost event via emit_provider_cost() and returns captured stdout.
+    Emits a provider cost event via emit_provider_cost() (labeled with the
+    resolved registry key, same label the provider lane emits) and returns
+    captured stdout.
 
+    Raises KimiModelResolutionError (a ValueError) when the requested model is
+    unknown or disabled in the registry — fail-loud, no silent substitution.
     Raises subprocess.TimeoutExpired on timeout.
     Raises RuntimeError on non-zero exit.
     """
     from provider_costs import emit_provider_cost  # noqa: PLC0415
+    # Lazy import: keeps this wrapper light at import time and cycle-safe
+    # (provider_lanes.kimi imports this module at module level).
+    from provider_dispatch import (  # noqa: PLC0415
+        _kimi_resolve_cli_model_arg,
+        _kimi_resolve_requested_key,
+    )
 
-    cmd = ["kimi", "--print", "--output-format", "stream-json", "--yolo", "-p", prompt]
-    if model and model != DEFAULT_KIMI_MODEL:
-        cmd.extend(["-m", model])
+    model_key = _kimi_resolve_requested_key(model)
+    cli_model_arg = _kimi_resolve_cli_model_arg(model_key)
+
+    cmd = [
+        "kimi", "--print", "--output-format", "stream-json", "--yolo",
+        "-m", cli_model_arg, "-p", prompt,
+    ]
 
     with open(os.devnull, "r") as devnull:
         proc = subprocess.Popen(
@@ -113,7 +142,7 @@ def kimi_exec(
             proc.wait()
             logger.error(
                 "kimi_exec timed out after %.0fs (model=%s dispatch=%s)",
-                timeout, model, dispatch_id,
+                timeout, model_key, dispatch_id,
             )
             raise
 
@@ -125,7 +154,7 @@ def kimi_exec(
     # Kimi is subscription-flat: no per-token billing
     emit_provider_cost(
         provider="kimi",
-        model=model,
+        model=model_key,
         input_tokens=input_tokens,
         output_tokens=output_tokens,
         cost_usd_estimate=None,

--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -840,6 +840,14 @@ def _heartbeat_monitor_loop(
             "threshold=%.0fs) — killing worker",
             dispatch_id, verdict.silence_seconds, verdict.threshold_seconds,
         )
+        # OI-1082: flag the kill DECISION before executing it. _kill_process
+        # blocks worst-case ~10s (SIGTERM wait + SIGKILL wait) and the report
+        # write adds more, while spawn_kimi joins this thread with a 5s cap —
+        # setting the event last meant the reader could see False after a real
+        # kill and downgrade the receipt's failure_reason to a generic
+        # "kimi exited with code -9". The event marks the decision, not the
+        # completion; the kill below is unconditional once we reach here.
+        killed_event.set()
         _kill_process(proc)
         try:
             report = build_heartbeat_failure_report(
@@ -858,7 +866,6 @@ def _heartbeat_monitor_loop(
                 "kimi_spawn: heartbeat failure report write failed for %s: %s",
                 dispatch_id, exc,
             )
-        killed_event.set()
         return
 
 

--- a/tests/test_kimi_spawn_heartbeat.py
+++ b/tests/test_kimi_spawn_heartbeat.py
@@ -282,6 +282,77 @@ class TestHeartbeatMonitorLoopKillsSilentWorker(unittest.TestCase):
                 proc.wait(timeout=2.0)
 
 
+class TestHeartbeatKilledEventSetAtKillDecision(unittest.TestCase):
+    """OI-1082: killed_event must be set at the kill DECISION, before
+    _kill_process (worst-case ~10s SIGTERM+SIGKILL waits) and the report
+    write. spawn_kimi joins the monitor thread with a 5s cap and then reads
+    the event — setting it last meant a slow kill left the flag reading False
+    after a real kill, downgrading the receipt's failure_reason to a generic
+    'kimi exited with code -9'."""
+
+    def setUp(self):
+        self._env_patch = {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.2"}
+        self._saved_env = {k: os.environ.get(k) for k in self._env_patch}
+        os.environ.update(self._env_patch)
+        self._tmpdir = tempfile.TemporaryDirectory()
+
+    def tearDown(self):
+        self._tmpdir.cleanup()
+        for k, v in self._saved_env.items():
+            if v is None:
+                os.environ.pop(k, None)
+            else:
+                os.environ[k] = v
+
+    def test_killed_event_visible_while_kill_still_in_flight(self):
+        import provider_spawns.kimi_spawn as kimi_spawn_mod
+
+        # Silent tee file that exists but never grows.
+        log_path = Path(self._tmpdir.name) / "silent.log"
+        log_path.write_text("")
+
+        kill_started = threading.Event()
+        release_kill = threading.Event()
+
+        def _slow_kill(proc):
+            # Models a worker that ignores SIGTERM: _kill_process blocks in its
+            # SIGTERM-wait + SIGKILL-wait windows (~10s worst case).
+            kill_started.set()
+            release_kill.wait(timeout=5.0)
+
+        stop_event = threading.Event()
+        killed_event = threading.Event()
+        proc = MagicMock()
+
+        with patch.object(kimi_spawn_mod, "_kill_process", side_effect=_slow_kill), \
+             patch.object(kimi_spawn_mod, "_write_heartbeat_report"):
+            thread = threading.Thread(
+                target=kimi_spawn_mod._heartbeat_monitor_loop,
+                args=(proc, log_path, "dispatch-oi1082-race", "T1", "kimi-k3",
+                      stop_event, killed_event),
+                kwargs={"poll_interval": 0.05},
+                daemon=True,
+            )
+            thread.start()
+            try:
+                self.assertTrue(
+                    kill_started.wait(timeout=5.0),
+                    "precondition: heartbeat must reach its kill decision",
+                )
+                # The kill is still blocked in _slow_kill. This is exactly the
+                # window in which spawn_kimi's 5s-capped join expires and reads
+                # the flag — it must already be True HERE.
+                self.assertTrue(
+                    killed_event.wait(timeout=1.0),
+                    "killed_event must be set at kill-decision time, not after "
+                    "the kill + report write complete",
+                )
+            finally:
+                release_kill.set()
+                stop_event.set()
+                thread.join(timeout=3.0)
+
+
 class TestHeartbeatMonitorLoopFalsePositiveGuard(unittest.TestCase):
     """The calibration finding that MUST NOT regress: a worker producing
     periodic read-only tool-call activity (no file writes, but a steady

--- a/tests/test_kimi_wrapper.py
+++ b/tests/test_kimi_wrapper.py
@@ -102,17 +102,20 @@ class TestKimiExec:
 
     def test_emit_called_with_subscription_flat(self, monkeypatch):
         monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
         mock_proc = _make_popen_result()
 
         with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc), \
              patch("provider_costs.emit_provider_cost") as mock_emit:
 
-            kimi_wrapper.kimi_exec("prompt", model="kimi-k2.6", dispatch_id="d-k004")
+            kimi_wrapper.kimi_exec("prompt", model="kimi-k3", dispatch_id="d-k004")
 
         mock_emit.assert_called_once()
         kwargs = mock_emit.call_args.kwargs
         assert kwargs["provider"] == "kimi"
-        assert kwargs["model"] == "kimi-k2.6"
+        # Emit carries the resolved registry KEY (same label the provider lane
+        # emits), never the raw CLI arg.
+        assert kwargs["model"] == "kimi-k3"
         assert kwargs["cost_usd_estimate"] is None
         assert kwargs["dispatch_id"] == "d-k004"
 
@@ -174,6 +177,88 @@ class TestKimiExec:
 
             with pytest.raises(RuntimeError, match="kimi_exec failed"):
                 kimi_wrapper.kimi_exec("prompt", dispatch_id="d-k005")
+
+
+# ---------------------------------------------------------------------------
+# Model resolution (OI-1077)
+# ---------------------------------------------------------------------------
+
+class TestKimiModelResolution:
+    """kimi_exec routes model resolution through provider_dispatch's kimi
+    resolver — the same chain the provider lane uses — instead of the old
+    hardcoded 'kimi-k2.6' default that passed raw registry keys to the CLI
+    (rc=1 'LLM not set' on kimi-cli 1.46.0)."""
+
+    def test_resolver_is_consulted(self, monkeypatch):
+        """Both resolver stages run, and the CLI arg the resolver returns is
+        what lands in argv. kimi_exec imports the resolver lazily inside the
+        call, so patching the provider_dispatch module namespace intercepts
+        the call-time binding."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost"), \
+             patch("provider_dispatch._kimi_resolve_requested_key",
+                   return_value="resolved-key") as mock_key, \
+             patch("provider_dispatch._kimi_resolve_cli_model_arg",
+                   return_value="managed/cli-arg") as mock_cli:
+
+            kimi_wrapper.kimi_exec("prompt", model="anything", dispatch_id="d-k010")
+
+        mock_key.assert_called_once_with("anything")
+        mock_cli.assert_called_once_with("resolved-key")
+        cmd = mock_popen.call_args.args[0]
+        m_idx = cmd.index("-m")
+        assert cmd[m_idx + 1] == "managed/cli-arg"
+
+    def test_default_model_resolves_registry_default(self, monkeypatch):
+        """No explicit model -> registry default key (kimi_cli.default_model)
+        resolved to its slash-form CLI arg, ALWAYS passed via -m (the old code
+        omitted -m and silently rode ~/.kimi/config.toml's default)."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        monkeypatch.delenv("VNX_KIMI_MODEL", raising=False)
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost") as mock_emit:
+
+            kimi_wrapper.kimi_exec("prompt", dispatch_id="d-k011")
+
+        cmd = mock_popen.call_args.args[0]
+        assert "-m" in cmd
+        m_idx = cmd.index("-m")
+        assert cmd[m_idx + 1] == "kimi-code/k3"
+        assert mock_emit.call_args.kwargs["model"] == "kimi-k3"
+
+    def test_explicit_registry_key_maps_to_cli_arg(self, monkeypatch):
+        """A registry key ('kimi-k3') never reaches the CLI raw — it maps to
+        the cli_model_arg form the CLI actually accepts."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        mock_proc = _make_popen_result()
+
+        with patch("kimi_wrapper.subprocess.Popen", return_value=mock_proc) as mock_popen, \
+             patch("provider_costs.emit_provider_cost"):
+
+            kimi_wrapper.kimi_exec("prompt", model="kimi-k3", dispatch_id="d-k012")
+
+        cmd = mock_popen.call_args.args[0]
+        m_idx = cmd.index("-m")
+        assert cmd[m_idx + 1] == "kimi-code/k3"
+        assert "kimi-k3" not in cmd
+
+    def test_dead_model_fails_loud_before_spawn(self, monkeypatch):
+        """The retired 'kimi-k2.6' (the module's OWN old default) is refused by
+        the resolver before any subprocess is spawned — fail-loud, no silent
+        pass-through of a stale string the CLI rejects with 'LLM not set'."""
+        monkeypatch.setenv("VNX_PROJECT_ID", "test-proj")
+        from provider_dispatch import KimiModelResolutionError
+
+        with patch("kimi_wrapper.subprocess.Popen") as mock_popen:
+            with pytest.raises(KimiModelResolutionError):
+                kimi_wrapper.kimi_exec("prompt", model="kimi-k2.6", dispatch_id="d-k013")
+
+        mock_popen.assert_not_called()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Mechanism (why it was broken)

**OI-1077 (scripts/lib/kimi_wrapper.py):** `kimi_exec` carried a hardcoded `DEFAULT_KIMI_MODEL = "kimi-k2.6"` and only appended `-m <model>` when the caller's model differed from that default, passing the string RAW to the CLI. Two failure modes, both measured in the OI (kimi-cli 1.46.0):
1. Any explicit model in registry-key form (`kimi-k3`, `kimi-k2.6`, ...) reached the CLI raw and failed rc=1 `LLM not set` (the CLI wants slash-form managed ids like `kimi-code/k3`).
2. The no-model path omitted `-m` entirely and silently rode whatever `~/.kimi/config.toml` defaults to, so what the only live consumer (DREAM consolidator) actually ran was recorded in no VNX file and drifted with the user's CLI config. The default `kimi-k2.6` itself is retired (`dispatch_allowed: false` in the registry).

The provider lane already had the correct machinery (`provider_dispatch._kimi_resolve_requested_key` + `_kimi_resolve_cli_model_arg`, fail-loud, registry-backed); `kimi_exec` just never used it.

**OI-1082 race (scripts/lib/provider_spawns/kimi_spawn.py):** `_heartbeat_monitor_loop` ran `_kill_process(proc)` (worst-case ~10s: ~5s SIGTERM-wait + ~5s SIGKILL-wait in `_kill_process`), then built and wrote the failure report, and only THEN set `killed_event`. The reader in `spawn_kimi` joins the monitor thread with a 5.0s cap and immediately reads `_hb_killed` to rewrite the receipt's `failure_reason`. A worker slow to die left the flag reading False after a real kill, so the receipt kept the generic `kimi exited with code -9` instead of the heartbeat-specific reason that read-out exists to guarantee.

## Fix

- `kimi_exec` now resolves the model through the exact chain the provider lane uses (lazy import, cycle-safe): `_kimi_resolve_requested_key` (explicit model -> `VNX_KIMI_MODEL` env -> registry default) then `_kimi_resolve_cli_model_arg` (registry key -> CLI arg, fail-loud `KimiModelResolutionError` on unknown/disabled models). The resolved arg is ALWAYS pinned via `-m`; the cost event is labeled with the resolved registry key (same label the lane emits). `DEFAULT_KIMI_MODEL` is corrected to `kimi-k3` and retained only for the 90-day backward-compat import surface (`providers/provider_lanes/kimi.py`); the exec path never reads it, so it cannot drift again.
- DREAM consolidator docstring now states what actually runs (registry default `kimi_cli.default_model`, currently kimi-k3) instead of the false "kimi K2.6".
- `_heartbeat_monitor_loop` sets `killed_event` at the kill DECISION, before `_kill_process` and the report write. The event marks the decision, not the completion; the kill is unconditional once that line is reached, so no ordering guarantee is lost.

## OI-1082 "rarely fires" half: refuted by measurement, no change made

The OI claimed the drainer's stall guard always preempts the heartbeat in default config, citing `_streaming_drainer.py`'s signature default `chunk_timeout=300.0`. That default is never used on the kimi path: every kimi call site passes `chunk_timeout` explicitly (`kimi_spawn.py:954`, `:1275`), and `spawn_kimi`'s default has been 1200s since f9337c28 (2026-07-23, i.e. before the OI was filed), coerced by `coerce_chunk_stall` to >= 900s (direct lane: min(1200,900)=900; envelope lane: >= max(1200, deadline/2)). The heartbeat threshold default is 600s (`worker_heartbeat.py:41`), so the heartbeat is the FIRST-firing silence guard in every default configuration. Operational confirmation: the heartbeat fired on 4 of 5 dispatches on 10/11-08 at the default 600s (the fleet now runs dispatches with `VNX_WORKER_HEARTBEAT_SILENCE_SECONDS=1800` because it fires too eagerly, not too rarely). Making it fire earlier would be harmful.

## Negative-control evidence (new tests vs unfixed origin/main source, plain clone)

`git checkout origin/main -- scripts/lib/kimi_wrapper.py scripts/lib/provider_spawns/kimi_spawn.py scripts/dream/consolidator.py`, branch tests kept:

```
>       assert "-m" in cmd
E       AssertionError: assert '-m' in ['kimi', '--print', '--output-format', 'stream-json', '--yolo', '-p', ...]

E               AssertionError: False is not true : killed_event must be set at kill-decision time, not after the kill + report write complete

FAILED tests/test_kimi_wrapper.py::TestKimiModelResolution::test_resolver_is_consulted
FAILED tests/test_kimi_wrapper.py::TestKimiModelResolution::test_default_model_resolves_registry_default
FAILED tests/test_kimi_wrapper.py::TestKimiModelResolution::test_explicit_registry_key_maps_to_cli_arg
FAILED tests/test_kimi_wrapper.py::TestKimiModelResolution::test_dead_model_fails_loud_before_spawn
FAILED tests/test_kimi_spawn_heartbeat.py::TestHeartbeatKilledEventSetAtKillDecision::test_killed_event_visible_while_kill_still_in_flight
5 failed, 13 passed in 1.52s
```

## Green test output (fix branch, plain clone)

```
$ python3 -m pytest tests/test_kimi_wrapper.py tests/test_kimi_spawn_heartbeat.py tests/test_backward_compat_imports.py tests/test_kimi_spawn.py tests/test_kimi_model_resolver.py tests/test_provider_dispatch_kimi.py tests/test_dream_consolidator.py -q
251 passed in 14.34s
```

Note: 8 of these tests (test_provider_dispatch_kimi.py, test_kimi_model_resolver.py) FALSE-FAIL when run inside a nested git worktree (`NotADirectoryError: .git/worktrees`) with and without this change; the plain-clone run above is the valid environment, per the measured footgun.

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1077 + OI-1082.
🤖 Generated with [Claude Code](https://claude.com/claude-code)