### PR TITLE
fix(kimi-gate): book provider outages as 'unavailable', never as review 'fail' (OI-1142)

### DIFF
--- a/scripts/kimi_gate.py
+++ b/scripts/kimi_gate.py
@@ -17,7 +17,14 @@ Usage:
     python3 scripts/kimi_gate.py --pr 378 --data-dir ~/.vnx-data/<project>
     python3 scripts/kimi_gate.py --diff-file /tmp/x.diff --pr 0   # offline diff source
 
-Exit codes: 0 = pass, 2 = fail/blocked, 1 = infra error (no diff / dispatch failed).
+Exit codes: 0 = pass, 2 = fail/blocked (a REAL parsed review verdict), 1 = infra
+error / provider unavailable (no diff, dispatch failed, or no readable verdict).
+
+Provider outages are NOT review verdicts (OI-1142): when the kimi CLI dies on a
+quota-403/429/auth error, times out, or returns output without a verdict block,
+the result status is ``unavailable`` — never ``fail``. Eleven quota-403 outages
+were once booked as eleven rejected PRs because the no-verdict path defaulted to
+"fail"; absence of evidence must surface as absence, not as a rejection.
 """
 from __future__ import annotations
 
@@ -105,7 +112,14 @@ def _get_diff(pr: str, diff_file: "str | None") -> "str | None":
 
 
 def _verdict_to_status(verdict: dict) -> "tuple[str, list, str]":
-    """Map the extracted verdict to (status, blocking_findings, residual_risk)."""
+    """Map the extracted verdict to (status, blocking_findings, residual_risk).
+
+    OI-1142: an empty ``verdict`` means the provider produced no readable verdict
+    at all — the kimi CLI hit a quota-403/429/auth error, was cut off, or emitted
+    output without the contract's JSON block. That is a tool outage, not a review
+    outcome, and it maps to ``unavailable``. Only a REAL parsed verdict may ever
+    produce ``fail``.
+    """
     v = (verdict.get("verdict") or "").strip().lower() if verdict else ""
     findings = verdict.get("findings") or [] if verdict else []
     blocking = [
@@ -117,7 +131,19 @@ def _verdict_to_status(verdict: dict) -> "tuple[str, list, str]":
         return "pass", [], residual
     if v in {"fail", "blocked"} or blocking:
         return "fail", blocking, residual or "kimi gate reported blocking findings"
-    return "fail", [], residual or "kimi gate produced no readable verdict"
+    return (
+        "unavailable",
+        [],
+        residual
+        or "kimi produced no readable verdict (provider outage/quota/truncation) — not a review outcome",
+    )
+
+
+def _status_summary(status: str, blocking: list) -> str:
+    """Summary line for the result record — outage vs verdict must be unmistakable."""
+    if status == "unavailable":
+        return "kimi gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)"
+    return f"kimi gate: {status} ({len(blocking)} blocking finding(s))"
 
 
 def main(argv: "list[str] | None" = None) -> int:
@@ -142,16 +168,27 @@ def main(argv: "list[str] | None" = None) -> int:
     dispatcher = _make_default_dispatcher(data_dir, args.timeout)
 
     start = time.monotonic()
+    report_text = ""
+    dispatch_error = ""
     try:
         # Governed lane: provider_dispatch runs kimi, writes a unified report, returns its text.
         report_text = dispatcher("kimi", args.model, _build_prompt(diff, args.pr), dispatch_id)
     except Exception as exc:  # noqa: BLE001 — dispatch/report-read failure
+        # OI-1142: do NOT bail without a record — a required gate that cannot fire
+        # must surface as ``unavailable`` in the results dir, not vanish.
+        dispatch_error = str(exc)
         print(f"kimi_gate: governed kimi dispatch failed: {exc}", file=sys.stderr)
-        return 1
     duration = time.monotonic() - start
 
-    verdict = _extract_verdict(report_text or "")
-    status, blocking, residual = _verdict_to_status(verdict)
+    if dispatch_error:
+        verdict: dict = {}
+        status, blocking = "unavailable", []
+        residual = f"governed kimi dispatch failed: {dispatch_error[:400]}"
+        reason = "dispatch_error"
+    else:
+        verdict = _extract_verdict(report_text or "")
+        status, blocking, residual = _verdict_to_status(verdict)
+        reason = "verdict" if verdict else "no_verdict"
 
     record = {
         "gate": "kimi_gate",
@@ -162,9 +199,9 @@ def main(argv: "list[str] | None" = None) -> int:
         # closure verifier refuses records with test_run: true.
         "test_run": bool(args.diff_file),
         "status": status,
-        "reason": "verdict" if verdict else "no_verdict",
+        "reason": reason,
         "duration_seconds": round(duration, 3),
-        "summary": f"kimi gate: {status} ({len(blocking)} blocking finding(s))",
+        "summary": _status_summary(status, blocking),
         "provider": "kimi",
         "model": args.model,
         "dispatch_id": dispatch_id,
@@ -187,12 +224,17 @@ def main(argv: "list[str] | None" = None) -> int:
 
     if args.json:
         print(json.dumps(record, indent=2))
+    elif status == "unavailable":
+        print("VERDICT: UNAVAILABLE  (provider outage/no verdict — NOT a review fail)")
     else:
         print(f"VERDICT: {status.upper()}  ({len(blocking)} blocking)")
         for f in blocking:
             print(f"  · [{f.get('severity')}] {f.get('message')}")
 
-    return 0 if status == "pass" else 2
+    # 0 = pass, 2 = a REAL parsed fail/blocked verdict, 1 = unavailable/infra.
+    if status == "pass":
+        return 0
+    return 2 if status == "fail" else 1
 
 
 if __name__ == "__main__":

--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -18,8 +18,14 @@ from typing import Any, Dict, Tuple
 PASS_STATES = frozenset({"approve", "completed", "pass", "passed"})
 FAIL_STATES = frozenset({"failed", "errored", "fail", "blocked"})
 INCOMPLETE_STATES = frozenset({"pending", "running", "queued", "requested"})
+# OI-1142: the provider/tool could not produce a verdict at all (quota-403, 429,
+# auth failure, timeout, empty output). Absence of evidence: never a pass, never
+# a fail, and not terminal — a retry against a healthy provider can still decide.
+UNAVAILABLE_STATES = frozenset({"unavailable"})
 
-ALL_KNOWN_STATES = PASS_STATES | FAIL_STATES | INCOMPLETE_STATES | frozenset({"not_executable"})
+ALL_KNOWN_STATES = (
+    PASS_STATES | FAIL_STATES | INCOMPLETE_STATES | UNAVAILABLE_STATES | frozenset({"not_executable"})
+)
 
 
 def _coerce_status(result: Dict[str, Any]) -> Tuple[str, bool]:
@@ -75,6 +81,8 @@ def is_pass(result: Dict[str, Any]) -> Tuple[bool, str]:
         return False, f"blocking_count: {blocking_count}"
     if status in INCOMPLETE_STATES:
         return False, f"incomplete: {status}"
+    if status in UNAVAILABLE_STATES:
+        return False, "unavailable: provider outage — no verdict evidence (not a review fail)"
     if status == "not_executable":
         return False, "status: not_executable"
     if not status:
@@ -88,7 +96,10 @@ def is_terminal(result: Dict[str, Any]) -> bool:
     Used by closure verifier to decide whether to enforce report_path on
     a result (pass/fail must carry evidence; in-flight states must not).
     ``not_executable`` is treated as terminal because the gate has been
-    finally classified even though no execution happened.
+    finally classified even though no execution happened. ``unavailable``
+    (OI-1142) is deliberately NOT terminal: the provider was down, no verdict
+    exists, and a rerun can still decide — closure must stay blocked on
+    "incomplete evidence", not read the outage as a decided outcome.
     """
     status, _ = _coerce_status(result)
     return status in PASS_STATES or status in FAIL_STATES or status == "not_executable"

--- a/tests/test_kimi_gate_unavailable.py
+++ b/tests/test_kimi_gate_unavailable.py
@@ -1,0 +1,159 @@
+"""kimi_gate provider-outage status tests (OI-1142).
+
+Eleven kimi quota-403 outages were once booked as eleven review "fail"
+records (reason "no_verdict", summary 'kimi gate: fail (0 blocking
+finding(s))') because ``_verdict_to_status`` defaulted the no-readable-verdict
+path to "fail". A provider that cannot fire produces NO verdict — that is
+absence of evidence and must surface as status ``unavailable``, never as a
+rejected PR. These tests pin:
+
+- provider-error output (403 text, empty/truncated report) -> "unavailable",
+  exit 1, a summary that is unmistakably an outage
+- a dispatcher exception still writes an ``unavailable`` record instead of
+  vanishing without a trace
+- a REAL parsed verdict (pass / fail with findings) behaves exactly as before
+- gate_status treats "unavailable" as neither pass nor fail nor terminal
+
+``_make_default_dispatcher`` is patched on the kimi_gate module namespace,
+not on plan_gate_panel where it is defined — `from X import Y` binds the name
+at import time.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+import kimi_gate
+from gate_status import (
+    ALL_KNOWN_STATES,
+    FAIL_STATES,
+    PASS_STATES,
+    is_pass,
+    is_terminal,
+)
+
+_QUOTA_403_REPORT = (
+    "Error: API request failed with status 403: "
+    '{"error":{"type":"access_terminated_error","message":'
+    '"You have reached your usage limit for this billing cycle."}}\n'
+)
+
+_REAL_FAIL_REPORT = (
+    "Reviewed the diff; found a real problem.\n\n"
+    "```json\n"
+    '{"verdict": "fail", "findings": [{"severity": "error", "message": "sql injection"}],'
+    ' "residual_risk": "unsanitized input"}\n'
+    "```\n"
+)
+
+_REAL_PASS_REPORT = (
+    "Reviewed the diff, no issues.\n\n"
+    "```json\n"
+    '{"verdict": "pass", "findings": [], "residual_risk": null}\n'
+    "```\n"
+)
+
+
+def _run_gate(tmp_path, monkeypatch, dispatcher):
+    diff_file = tmp_path / "x.diff"
+    diff_file.write_text("diff --git a/x b/x\n+ok\n", encoding="utf-8")
+    data_dir = tmp_path / "data"
+    monkeypatch.setattr(kimi_gate, "_make_default_dispatcher", lambda *a, **k: dispatcher)
+    rc = kimi_gate.main(["--pr", "0", "--diff-file", str(diff_file), "--data-dir", str(data_dir)])
+    out = data_dir / "state" / "review_gates" / "results" / "pr-0-kimi_gate.json"
+    record = json.loads(out.read_text(encoding="utf-8")) if out.exists() else None
+    return rc, record
+
+
+# ---------------------------------------------------------------------------
+# Provider outage -> unavailable, never fail
+# ---------------------------------------------------------------------------
+
+
+def test_quota_403_text_books_unavailable_not_fail(tmp_path, monkeypatch):
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _QUOTA_403_REPORT)
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "no_verdict"
+    assert rc == 1  # infra/unavailable, not the exit-2 review fail
+    assert "UNAVAILABLE" in record["summary"]
+    assert "NOT a review fail" in record["summary"]
+    assert record["blocking_findings"] == []
+
+
+def test_empty_report_books_unavailable(tmp_path, monkeypatch):
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: "")
+    assert record is not None
+    assert record["status"] == "unavailable"
+    assert rc == 1
+
+
+def test_dispatch_exception_writes_unavailable_record(tmp_path, monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("no report for kimi-gate-pr0 (rc=1): stderr: 403 access_terminated_error")
+
+    rc, record = _run_gate(tmp_path, monkeypatch, _boom)
+    assert rc == 1
+    assert record is not None, "an outage must leave an unavailable record, not vanish"
+    assert record["status"] == "unavailable"
+    assert record["reason"] == "dispatch_error"
+    assert "access_terminated_error" in record["residual_risk"]
+
+
+def test_verdict_to_status_empty_verdict_is_unavailable():
+    status, blocking, residual = kimi_gate._verdict_to_status({})
+    assert status == "unavailable"
+    assert blocking == []
+    assert "no readable verdict" in residual
+
+
+# ---------------------------------------------------------------------------
+# Real parsed verdicts: unchanged behaviour
+# ---------------------------------------------------------------------------
+
+
+def test_real_fail_verdict_still_fails_with_exit_2(tmp_path, monkeypatch):
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _REAL_FAIL_REPORT)
+    assert rc == 2
+    assert record["status"] == "fail"
+    assert record["reason"] == "verdict"
+    assert record["summary"] == "kimi gate: fail (1 blocking finding(s))"
+    assert len(record["blocking_findings"]) == 1
+
+
+def test_real_pass_verdict_still_passes(tmp_path, monkeypatch):
+    rc, record = _run_gate(tmp_path, monkeypatch, lambda *a, **k: _REAL_PASS_REPORT)
+    assert rc == 0
+    assert record["status"] == "pass"
+    assert record["summary"] == "kimi gate: pass (0 blocking finding(s))"
+
+
+# ---------------------------------------------------------------------------
+# gate_status: unavailable is neither pass nor fail nor terminal
+# ---------------------------------------------------------------------------
+
+
+def test_gate_status_unavailable_is_known_and_not_fail():
+    assert "unavailable" in ALL_KNOWN_STATES
+    assert "unavailable" not in FAIL_STATES
+    assert "unavailable" not in PASS_STATES
+
+
+def test_gate_status_unavailable_is_not_pass_with_outage_reason():
+    passed, reason = is_pass({"status": "unavailable", "blocking_findings": []})
+    assert passed is False
+    assert "unavailable" in reason
+    assert "not a review fail" in reason
+    assert "unknown" not in reason
+
+
+def test_gate_status_unavailable_is_not_terminal():
+    # Closure must treat an outage as incomplete evidence (retryable), never as
+    # a decided pass/fail outcome.
+    assert is_terminal({"status": "unavailable"}) is False


### PR DESCRIPTION
## Mechanism (why it was broken)

`scripts/kimi_gate.py::_verdict_to_status` had a three-way mapping whose fall-through was `"fail"`:

```python
return "fail", [], residual or "kimi gate produced no readable verdict"
```

When the kimi CLI dies on a quota-403 (`access_terminated_error`), a 429, an auth failure, a timeout, or returns empty/truncated output, the unified report carries no ```json``` verdict block. `_extract_verdict` returns `{}` and the fall-through booked the outage as `status: "fail"`, `reason: "no_verdict"`, `summary: 'kimi gate: fail (0 blocking finding(s))'` — exactly the eleven records seocrawler-v2 T0 reported on 11-08. Eleven tool outages read as eleven rejected PRs. A dispatcher **exception** was even worse: `return 1` with no record written at all, so the outage vanished from the results dir.

## The fix

- **kimi_gate.py**: no readable verdict → status `unavailable`, exit 1 (infra, per the existing exit-code contract), summary `kimi gate: UNAVAILABLE (provider outage/no verdict — NOT a review fail)`. A dispatcher exception now writes an `unavailable` record (`reason: dispatch_error`) instead of vanishing. A REAL parsed verdict (pass, or fail/blocked with findings) behaves exactly as before, exit codes 0/2 unchanged.
- **gate_status.py** (the single source of truth every consumer routes through — closure_verifier, headless_orchestrator, roadmap_manager, gate_recorder): `unavailable` added to `ALL_KNOWN_STATES` as its own class. `is_pass` → `(False, "unavailable: provider outage — no verdict evidence (not a review fail)")`; NOT in `FAIL_STATES`, so closure_verifier's severity-demotion fail→pass override (line 451, which only matches fail/failed/blocked) can never flip an outage to pass; `is_terminal` → False, so closure blocks on "still unavailable — incomplete evidence" and a rerun stays possible. Absence of evidence surfaces as absence.

## Negative control (new tests vs unfixed origin/main sources)

`git checkout origin/main -- scripts/kimi_gate.py scripts/lib/gate_status.py`, then:

```
>       assert record["status"] == "unavailable"
E       AssertionError: assert 'fail' == 'unavailable'
...
E       AssertionError: assert 'not a review fail' in 'unknown status: unavailable'
FAILED tests/test_kimi_gate_unavailable.py::test_quota_403_text_books_unavailable_not_fail
FAILED tests/test_kimi_gate_unavailable.py::test_empty_report_books_unavailable
FAILED tests/test_kimi_gate_unavailable.py::test_dispatch_exception_writes_unavailable_record
FAILED tests/test_kimi_gate_unavailable.py::test_verdict_to_status_empty_verdict_is_unavailable
FAILED tests/test_kimi_gate_unavailable.py::test_gate_status_unavailable_is_known_and_not_fail
FAILED tests/test_kimi_gate_unavailable.py::test_gate_status_unavailable_is_not_pass_with_outage_reason
6 failed, 3 passed in 0.19s
```

The 3 passing are the unchanged-behaviour regression pins (real pass/fail verdicts + is_terminal), which must pass on both sides.

## Green run (fixed tree)

```
$ python3 -m pytest tests/test_kimi_gate_unavailable.py tests/test_kimi_gate_provenance.py tests/test_gate_recorder_provenance.py -q
17 passed in 0.33s
```

Wider neighbour sweep (`tests/test_gate_status_schema.py`): 42 passed, 1 skipped, 1 failed — the failing `test_closure_verifier_reads_status_completed_as_pass` also fails on unmodified origin/main in this same environment ("codex gate required ... but no result found"; central-store path resolution, pre-existing, unrelated to this diff).

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
