### PR TITLE
feat(cli): expose gate-check on the pip CLI so consumers can run the documented pre-merge gate (OI-1135)

### DIFF
--- a/tests/test_vnx_cli_gate_check.py
+++ b/tests/test_vnx_cli_gate_check.py
@@ -1,0 +1,201 @@
+"""tests/test_vnx_cli_gate_check.py — pin `vnx gate-check` on the pip CLI (OI-1135).
+
+The docs prescribe `vnx gate-check --pr <ID>` to consumers, but the command
+existed only on the fabric repo's `bin/vnx` (a one-line delegation to
+scripts/pre_merge_gate.py). Consumer repos hold the pip-installed vnx_cli,
+which refused the name with "invalid choice: 'gate-check'". The gate script
+itself ships in the wheel (pyproject package-data carries scripts/**/*), so
+the pip CLI now exposes the same machinery: resolve the engine root, exec
+the packaged scripts/pre_merge_gate.py as a subprocess.
+
+Red-against-main measurement: every test fails on origin/main. The new
+module vnx_cli/commands/gate_check.py does not exist there (ImportError),
+_register_gate_check_subparser is absent from vnx_cli.main
+(AttributeError), and _dispatch_command has no gate-check branch (falls
+through to print_help + exit 0). Imports of new symbols happen inside each
+test so collection itself does not abort on main.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+
+def _build_parser():
+    """Build the pip-CLI parser exactly as vnx_cli.main.main() does, minus
+    the .vnx-version re-exec (irrelevant for parsing)."""
+    import vnx_cli.main as m
+
+    parser = m._SuggestionArgumentParser(prog="vnx")
+    subparsers = parser.add_subparsers(dest="command", metavar="COMMAND")
+    m._register_gate_check_subparser(subparsers)
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# 1. Registration: the pip CLI accepts the documented invocation
+# ---------------------------------------------------------------------------
+
+def test_gate_check_subparser_parses_documented_form():
+    """`vnx gate-check --pr 1449` must parse — on main the registration
+    helper does not exist and the name is an invalid choice."""
+    parser = _build_parser()
+    args = parser.parse_args(["gate-check", "--pr", "1449"])
+    assert args.command == "gate-check"
+    assert args.pr == "1449"
+    # Defaults mirror pre_merge_gate.py's own parser.
+    assert args.project_root is None
+    assert args.json is False
+    assert args.output_file is None
+    assert args.skip_pytest is False
+    assert args.store is True
+
+
+def test_gate_check_subparser_accepts_full_flag_surface():
+    parser = _build_parser()
+    args = parser.parse_args([
+        "gate-check", "--pr", "PR-6",
+        "--project-root", "/tmp/proj",
+        "--json",
+        "--output-file", "/tmp/out.json",
+        "--skip-pytest",
+        "--no-store",
+    ])
+    assert args.pr == "PR-6"
+    assert args.project_root == "/tmp/proj"
+    assert args.json is True
+    assert args.output_file == "/tmp/out.json"
+    assert args.skip_pytest is True
+    assert args.store is False
+
+
+def test_gate_check_requires_pr():
+    parser = _build_parser()
+    with pytest.raises(SystemExit):
+        parser.parse_args(["gate-check"])
+
+
+# ---------------------------------------------------------------------------
+# 2. Argv translation: subprocess sees the same argv bin/vnx would forward
+# ---------------------------------------------------------------------------
+
+def test_build_gate_check_argv_minimal():
+    from vnx_cli.commands.gate_check import build_gate_check_argv
+
+    ns = SimpleNamespace(pr="1449", project_root=None, json=False,
+                         output_file=None, skip_pytest=False, store=True)
+    assert build_gate_check_argv(ns) == ["--pr", "1449"]
+
+
+def test_build_gate_check_argv_full():
+    from vnx_cli.commands.gate_check import build_gate_check_argv
+
+    ns = SimpleNamespace(pr="PR-6", project_root="/tmp/proj", json=True,
+                         output_file="/tmp/out.json", skip_pytest=True,
+                         store=False)
+    assert build_gate_check_argv(ns) == [
+        "--pr", "PR-6",
+        "--project-root", "/tmp/proj",
+        "--json",
+        "--output-file", "/tmp/out.json",
+        "--skip-pytest",
+        "--no-store",
+    ]
+
+
+# ---------------------------------------------------------------------------
+# 3. Execution: the command runs the packaged engine script
+# ---------------------------------------------------------------------------
+
+def test_vnx_gate_check_invokes_packaged_engine_script(tmp_path, monkeypatch):
+    import vnx_cli.commands.gate_check as gc
+
+    engine = tmp_path / "engine"
+    (engine / "scripts").mkdir(parents=True)
+    script = engine / "scripts" / "pre_merge_gate.py"
+    script.write_text("# stand-in for the packaged gate script\n")
+
+    monkeypatch.setattr(gc._engine, "engine_root", lambda: engine)
+
+    captured = {}
+
+    def fake_run(cmd, **kwargs):
+        captured["cmd"] = cmd
+        return SimpleNamespace(returncode=1)  # HOLD
+
+    monkeypatch.setattr(gc.subprocess, "run", fake_run)
+
+    ns = SimpleNamespace(pr="1449", project_root=None, json=True,
+                         output_file=None, skip_pytest=True, store=True)
+    rc = gc.vnx_gate_check(ns)
+
+    assert rc == 1, "exit code must propagate the gate verdict (1 = HOLD)"
+    assert captured["cmd"][0] == sys.executable
+    assert captured["cmd"][1] == str(script)
+    assert captured["cmd"][2:] == ["--pr", "1449", "--json", "--skip-pytest"]
+
+
+def test_vnx_gate_check_missing_script_fails_with_io_exit(tmp_path, monkeypatch, capsys):
+    """An incomplete install must fail loudly with the gate's I/O exit code,
+    never silently succeed."""
+    import vnx_cli.commands.gate_check as gc
+
+    monkeypatch.setattr(gc._engine, "engine_root", lambda: tmp_path)
+
+    ns = SimpleNamespace(pr="1449", project_root=None, json=False,
+                         output_file=None, skip_pytest=False, store=True)
+    rc = gc.vnx_gate_check(ns)
+
+    assert rc == 20
+    err = capsys.readouterr().err
+    assert "pre_merge_gate.py not found" in err
+
+
+# ---------------------------------------------------------------------------
+# 4. Dispatch wiring: main routes gate-check to the command module
+# ---------------------------------------------------------------------------
+
+def test_dispatch_command_routes_gate_check(monkeypatch):
+    """On main the elif branch is absent: _dispatch_command falls through to
+    print_help + exit 0, so the sentinel exit code below never appears."""
+    import vnx_cli.main as m
+    import vnx_cli.commands.gate_check as gc
+
+    monkeypatch.setattr(gc, "vnx_gate_check", lambda args: 42)
+
+    parser = argparse.ArgumentParser(prog="vnx")
+    ns = argparse.Namespace(command="gate-check", pr="1449",
+                            project_root=None, json=False, output_file=None,
+                            skip_pytest=False, store=True)
+    with pytest.raises(SystemExit) as exc:
+        m._dispatch_command(ns, parser)
+    assert exc.value.code == 42
+
+
+def test_main_registers_gate_check_in_full_parser():
+    """The real registration list in main() must include gate-check —
+    registering the helper but forgetting the call would still strand
+    consumers."""
+    import inspect
+
+    import vnx_cli.main as m
+
+    src = inspect.getsource(m.main)
+    assert "_register_gate_check_subparser(subparsers)" in src
+
+
+def test_documented_gate_script_ships_in_package_data():
+    """The wheel must actually carry the machinery this command runs:
+    pyproject's package-data glob scripts/**/* under vnx_orchestration."""
+    pyproject = (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    assert 'scripts/**/*' in pyproject
+    assert (REPO_ROOT / "scripts" / "pre_merge_gate.py").is_file()

--- a/tests/test_vnx_cli_gate_check.py
+++ b/tests/test_vnx_cli_gate_check.py
@@ -128,7 +128,7 @@ def test_vnx_gate_check_invokes_packaged_engine_script(tmp_path, monkeypatch):
 
     captured = {}
 
-    def fake_run(cmd, **kwargs):
+    def fake_run(cmd, **_kwargs):
         captured["cmd"] = cmd
         return SimpleNamespace(returncode=1)  # HOLD
 

--- a/vnx_cli/commands/gate_check.py
+++ b/vnx_cli/commands/gate_check.py
@@ -1,0 +1,73 @@
+"""vnx gate-check — deterministic pre-merge gate (GO/HOLD) on the pip CLI.
+
+The fabric repo's ``bin/vnx gate-check`` is a one-line delegation to
+``scripts/pre_merge_gate.py`` (bin/vnx: ``"$VNX_PYTHON"
+"$VNX_HOME/scripts/pre_merge_gate.py" "$@"``). Consumer repos have no
+``bin/`` — they hold the pip-installed ``vnx``, which until OI-1135 lacked
+the command entirely while the docs prescribed it (the pip-CLI-vs-scripts
+surface split). The gate script itself ships in the wheel — pyproject's
+``[tool.setuptools.package-data]`` carries ``scripts/**/*`` under the
+``vnx_orchestration`` namespace package — so the pip CLI can run the exact
+same machinery: resolve the engine root and execute the packaged
+``scripts/pre_merge_gate.py`` as a subprocess, mirroring the repo form.
+
+Subprocess, not import: ``pre_merge_gate.main()`` parses ``sys.argv``
+directly and the script self-bootstraps ``scripts/lib`` from its own
+location (``SCRIPT_DIR / "lib"``), so a child process keeps a single launch
+path for both entrances and inherits the script's own exit-code contract
+(0 GO, 1 HOLD, 10 bad args, 20 I/O error, 40 internal error).
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import List
+
+from vnx_cli import _engine
+
+# Mirror of pre_merge_gate.py's I/O-error exit code — used when the engine
+# install is missing the gate script (the closest failure class).
+_EXIT_IO_ERROR = 20
+
+
+def build_gate_check_argv(args) -> List[str]:
+    """Translate the parsed vnx_cli namespace into pre_merge_gate.py argv.
+
+    Only non-default flags are forwarded, so the subprocess sees the same
+    argv a direct ``bin/vnx gate-check`` invocation would have carried.
+    """
+    argv = ["--pr", str(args.pr)]
+    if getattr(args, "project_root", None):
+        argv += ["--project-root", str(args.project_root)]
+    if getattr(args, "json", False):
+        argv.append("--json")
+    if getattr(args, "output_file", None):
+        argv += ["--output-file", str(args.output_file)]
+    if getattr(args, "skip_pytest", False):
+        argv.append("--skip-pytest")
+    if not getattr(args, "store", True):
+        argv.append("--no-store")
+    return argv
+
+
+def resolve_gate_script(root: Path | None = None) -> Path:
+    """Return the packaged pre_merge_gate.py path for the resolved engine."""
+    root = root or _engine.engine_root()
+    return root / "scripts" / "pre_merge_gate.py"
+
+
+def vnx_gate_check(args) -> int:
+    """Run the pre-merge gate for a PR via the packaged engine script."""
+    script = resolve_gate_script()
+    if not script.is_file():
+        print(
+            f"vnx gate-check: pre_merge_gate.py not found at {script} — "
+            "the installed engine is incomplete "
+            "(reinstall: pip install --force-reinstall vnx-orchestration)",
+            file=sys.stderr,
+        )
+        return _EXIT_IO_ERROR
+    cmd = [sys.executable, str(script), *build_gate_check_argv(args)]
+    return subprocess.run(cmd).returncode

--- a/vnx_cli/commands/gate_check.py
+++ b/vnx_cli/commands/gate_check.py
@@ -32,6 +32,59 @@ from vnx_cli import _engine
 _EXIT_IO_ERROR = 20
 
 
+def register_gate_check_subparser(subparsers) -> None:
+    """Register the `vnx gate-check` subparser.
+
+    Lives here rather than in vnx_cli/main.py so the oversized main module
+    only carries a thin delegate (main.py already exceeds the
+    quality-advisory file-size ceiling on main). Flag surface mirrors
+    pre_merge_gate.py's own parser one-to-one.
+    """
+    import argparse
+
+    gc_parser = subparsers.add_parser(
+        "gate-check",
+        help="run deterministic pre-merge gate checks for a PR (GO/HOLD verdict)",
+    )
+    gc_parser.add_argument(
+        "--pr",
+        required=True,
+        metavar="PR_ID",
+        help="PR identifier (e.g. 1449 or PR-6)",
+    )
+    gc_parser.add_argument(
+        "--project-root",
+        dest="project_root",
+        default=None,
+        metavar="DIR",
+        help="project root (default: auto-detect)",
+    )
+    gc_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="output JSON only",
+    )
+    gc_parser.add_argument(
+        "--output-file",
+        dest="output_file",
+        default=None,
+        metavar="FILE",
+        help="write results to file",
+    )
+    gc_parser.add_argument(
+        "--skip-pytest",
+        dest="skip_pytest",
+        action="store_true",
+        help="skip pytest execution (useful for CI or fast checks)",
+    )
+    gc_parser.add_argument(
+        "--store",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="store results in the state directory (default: true)",
+    )
+
+
 def build_gate_check_argv(args) -> List[str]:
     """Translate the parsed vnx_cli namespace into pre_merge_gate.py argv.
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -1195,49 +1195,10 @@ def _register_attest_subparser(subparsers: argparse.Action) -> None:
 def _register_gate_check_subparser(subparsers: argparse.Action) -> None:
     """`vnx gate-check` — same machinery as the fabric repo's `bin/vnx
     gate-check` (scripts/pre_merge_gate.py), exposed on the pip CLI so the
-    documented invocation works in consumer repos too (OI-1135). Flag
-    surface mirrors pre_merge_gate.py's own parser."""
-    gc_parser = subparsers.add_parser(
-        "gate-check",
-        help="run deterministic pre-merge gate checks for a PR (GO/HOLD verdict)",
-    )
-    gc_parser.add_argument(
-        "--pr",
-        required=True,
-        metavar="PR_ID",
-        help="PR identifier (e.g. 1449 or PR-6)",
-    )
-    gc_parser.add_argument(
-        "--project-root",
-        dest="project_root",
-        default=None,
-        metavar="DIR",
-        help="project root (default: auto-detect)",
-    )
-    gc_parser.add_argument(
-        "--json",
-        action="store_true",
-        help="output JSON only",
-    )
-    gc_parser.add_argument(
-        "--output-file",
-        dest="output_file",
-        default=None,
-        metavar="FILE",
-        help="write results to file",
-    )
-    gc_parser.add_argument(
-        "--skip-pytest",
-        dest="skip_pytest",
-        action="store_true",
-        help="skip pytest execution (useful for CI or fast checks)",
-    )
-    gc_parser.add_argument(
-        "--store",
-        action=argparse.BooleanOptionalAction,
-        default=True,
-        help="store results in the state directory (default: true)",
-    )
+    documented invocation works in consumer repos too (OI-1135). Parser
+    definition lives in the command module to keep this file thin."""
+    from vnx_cli.commands.gate_check import register_gate_check_subparser
+    register_gate_check_subparser(subparsers)
 
 
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -1192,6 +1192,54 @@ def _register_attest_subparser(subparsers: argparse.Action) -> None:
                      help="repository root (default: current directory)")
 
 
+def _register_gate_check_subparser(subparsers: argparse.Action) -> None:
+    """`vnx gate-check` — same machinery as the fabric repo's `bin/vnx
+    gate-check` (scripts/pre_merge_gate.py), exposed on the pip CLI so the
+    documented invocation works in consumer repos too (OI-1135). Flag
+    surface mirrors pre_merge_gate.py's own parser."""
+    gc_parser = subparsers.add_parser(
+        "gate-check",
+        help="run deterministic pre-merge gate checks for a PR (GO/HOLD verdict)",
+    )
+    gc_parser.add_argument(
+        "--pr",
+        required=True,
+        metavar="PR_ID",
+        help="PR identifier (e.g. 1449 or PR-6)",
+    )
+    gc_parser.add_argument(
+        "--project-root",
+        dest="project_root",
+        default=None,
+        metavar="DIR",
+        help="project root (default: auto-detect)",
+    )
+    gc_parser.add_argument(
+        "--json",
+        action="store_true",
+        help="output JSON only",
+    )
+    gc_parser.add_argument(
+        "--output-file",
+        dest="output_file",
+        default=None,
+        metavar="FILE",
+        help="write results to file",
+    )
+    gc_parser.add_argument(
+        "--skip-pytest",
+        dest="skip_pytest",
+        action="store_true",
+        help="skip pytest execution (useful for CI or fast checks)",
+    )
+    gc_parser.add_argument(
+        "--store",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help="store results in the state directory (default: true)",
+    )
+
+
 def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser) -> None:
     if args.command == "init":
         from vnx_cli.commands.init_cmd import vnx_init
@@ -1273,6 +1321,10 @@ def _dispatch_command(args: argparse.Namespace, parser: argparse.ArgumentParser)
         from vnx_cli.commands.horizon import vnx_deliverable
         sys.exit(vnx_deliverable(args))
 
+    elif args.command == "gate-check":
+        from vnx_cli.commands.gate_check import vnx_gate_check
+        sys.exit(vnx_gate_check(args))
+
     else:
         parser.print_help()
         sys.exit(0)
@@ -1316,6 +1368,7 @@ def main() -> None:
     _register_horizon_subparser(subparsers)
     _register_objective_subparser(subparsers)
     _register_deliverable_subparser(subparsers)
+    _register_gate_check_subparser(subparsers)
 
     args = parser.parse_args()
     _dispatch_command(args, parser)


### PR DESCRIPTION
## Mechanism (why it was broken)

The docs prescribe `vnx gate-check --pr <ID>` (docs/DISPATCH_GUIDE.md:254, docs/core/00_VNX_ARCHITECTURE.md:722, docs/operations/AUTONOMOUS_PRODUCTION_GUIDE.md:930, docs/contracts/PRODUCTIZATION_CONTRACT.md:118, plus the `./bin/vnx` forms in QUICKSTART/MIGRATION_GUIDE/ONBOARDING). The command only existed on the fabric repo's `bin/vnx`, where it is a one-line delegation:

```
gate-check)
  "$VNX_PYTHON" "$VNX_HOME/scripts/pre_merge_gate.py" "$@"
```

Consumer repos have no `bin/` — they hold the pip-installed `vnx_cli`, which refused the name (`invalid choice: 'gate-check'`). This is the pip-CLI-vs-scripts surface split: the pip binary runs `vnx_cli/commands/*`, not repo `scripts/*`. A gate you cannot invoke is a gate that never runs — the peer project reported 12 open PRs with zero gate runs.

## The fix (option A — the machinery ships, so expose it)

Verified before choosing A: pyproject's `[tool.setuptools.package-data]` carries `scripts/**/*` under the `vnx_orchestration` namespace package, so `pre_merge_gate.py` ships in every wheel, and `vnx_cli._engine.engine_root()` already resolves that tree for both the packaged and dev-checkout layouts.

- `vnx_cli/commands/gate_check.py` (new): resolves the engine root, execs the packaged `scripts/pre_merge_gate.py` as a subprocess with the same argv `bin/vnx` would forward — same flags (`--pr`, `--project-root`, `--json`, `--output-file`, `--skip-pytest`, `--store/--no-store`), same exit-code contract (0 GO / 1 HOLD / 10 / 20 / 40). Subprocess, not import: the script parses `sys.argv` itself and self-bootstraps `scripts/lib`, so both entrances share one launch path. Missing script fails loudly with exit 20.
- `vnx_cli/main.py`: registers `gate-check` + dispatch branch. The full parser definition lives in the command module — main.py already exceeds the quality-advisory size ceiling on main (1325 > 1200, unallowlisted), so this PR keeps its footprint there to a thin delegate (+14 lines net).
- Docs: per OI-1135 ("corrigeer de vier doc-verwijzingen, of laat ze staan zodra (1) klaar is") the doc references now describe a command that exists on both surfaces; no doc churn needed.

## Negative control (tests fail against unfixed origin/main)

Clean clone at origin/main, only the new test file copied in:

```
FAILED tests/test_vnx_cli_gate_check.py::test_gate_check_subparser_parses_documented_form
FAILED tests/test_vnx_cli_gate_check.py::test_gate_check_subparser_accepts_full_flag_surface
FAILED tests/test_vnx_cli_gate_check.py::test_gate_check_requires_pr - Attrib...
FAILED tests/test_vnx_cli_gate_check.py::test_build_gate_check_argv_minimal
FAILED tests/test_vnx_cli_gate_check.py::test_build_gate_check_argv_full - Mo...
FAILED tests/test_vnx_cli_gate_check.py::test_vnx_gate_check_invokes_packaged_engine_script
FAILED tests/test_vnx_cli_gate_check.py::test_vnx_gate_check_missing_script_fails_with_io_exit
FAILED tests/test_vnx_cli_gate_check.py::test_dispatch_command_routes_gate_check
FAILED tests/test_vnx_cli_gate_check.py::test_main_registers_gate_check_in_full_parser
========================= 9 failed, 1 passed in 0.21s ==========================
```

(The 1 pass, `test_documented_gate_script_ships_in_package_data`, is the precondition pin that the wheel ships `scripts/**/*` — true on main by design; it guards the premise, not the behavior.)

And the CLI itself on origin/main:

```
$ python3 -m vnx_cli.main gate-check --pr 1449
vnx: error: argument COMMAND: invalid choice: 'gate-check' (choose from doctor, fabric-audit, version, status, subsystems, init, pool, role, update, release, dispatch-agent, track, handoff, learning, dream, migrate, attest, horizon, objective, deliverable)
```

## Green on this branch

```
$ python3 -m pytest tests/test_vnx_cli_gate_check.py -q
..........                                                               [100%]
10 passed in 0.57s
```

Live end-to-end through the pip entry point (scratch clone, scratch state dirs — the real gate machinery runs):

```
$ python3 -m vnx_cli.main gate-check --pr 1449 --skip-pytest --no-store
🚫  Gate verdict for 1449: HOLD
   Checked at: 2026-08-11T15:50:40Z
   Checks: 9 GO, 1 HOLD
  [✓] open_items....................   GO  no open items file found
  [✓] cqs_threshold.................   GO  no receipts found — skipping CQS check
  [✓] git_cleanliness...............   GO  working tree clean
  ...
```

Neighbour suites: `test_cli_naamdrift.py` + `test_cli_engine_bootstrap.py` + `test_cli_flag_forwarding.py` = 45 passed, 1 failed — the failure (`test_rgm_request_auto_computes_changed_files_when_blank`) also fails on origin/main in the same environment (verified control run), so it is pre-existing, not introduced here.

## Pre-existing findings surfaced (not fixed here)

- `vnx_cli/main.py` exceeds the quality-advisory hard size ceiling on main (1325 > 1200, no `FILE_SIZE_ALLOWLIST` entry) — any PR touching it trips a blocking `file_size_blocking` advisory.
- `tests/test_cli_flag_forwarding.py::test_rgm_request_auto_computes_changed_files_when_blank` fails on origin/main in a nested-worktree environment.

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1135.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
