### PR TITLE
fix(salvage): wire tmux lane wt_path + salvage untracked non-gitignored files (OI-1127, OI-1128)

### DIFF
--- a/scripts/lib/pr_enforcement.py
+++ b/scripts/lib/pr_enforcement.py
@@ -29,7 +29,9 @@ Per-state decision (one binding site, never duplicated across lanes):
   ok=True, applicable=False. The latter is a delivery failure exactly like an
   unpushed ``committed`` branch (the reaper destroys it the same way): loud,
   receipt-visible (ok=False, corrective receipt), AND — when ``wt_path`` is
-  supplied — salvaged: the tracked changes are committed onto *branch* under an
+  supplied — salvaged: the tracked changes, plus any untracked non-gitignored
+  files sitting next to them (OI-1128: a worker's genuinely new file that
+  never saw ``git add``), are committed onto *branch* under an
   unmistakable ``[SALVAGED, UNREVIEWED]`` marker, pushed, and (unless
   ``skip_pr``) opened as a **draft** PR so it can never be mistaken for a
   worker-vouched, ready-for-review delivery. See ``_classify_dirty_worktree``
@@ -146,10 +148,20 @@ def _check_containment(*, branch: str, old_head: str, repo_root: Path) -> "tuple
 @dataclass(frozen=True)
 class _DirtyClassification:
     """Verdict of _classify_dirty_worktree(): whether a ``dirty`` tree carries
-    real (tracked) uncommitted work, or only untracked scratch."""
+    real (tracked) uncommitted work, or only untracked scratch.
+
+    ``untracked_paths`` (OI-1128): the ``??`` paths ``git status --porcelain``
+    listed. git status respects .gitignore natively, so ignored junk
+    (.DS_Store, build artefacts covered by .gitignore) never appears here.
+    When the tree is substantive, these ride along in the salvage — on
+    2026-08-10 two of the three hand-rescued files were ``??`` (a worker
+    that creates a NEW file and never runs ``git add`` leaves it exactly
+    here), so excluding them re-creates the OI-1119 loss in the
+    new-file variant."""
     substantive: bool
     evidence: str
     tracked_paths: "tuple[str, ...]" = ()
+    untracked_paths: "tuple[str, ...]" = ()
 
 
 def _classify_dirty_worktree(*, wt_path: "Path | str") -> _DirtyClassification:
@@ -157,14 +169,22 @@ def _classify_dirty_worktree(*, wt_path: "Path | str") -> _DirtyClassification:
 
     Rule, evidence-based: a change is substantive when git already knows the
     path — modified, staged, deleted, renamed, copied, or conflicted (any
-    ``git status --porcelain`` code other than ``??``). Untracked paths are
-    scratch files, editor droppings, and generated artefacts by definition:
-    they were never part of the branch's tracked history and a targeted
-    ``git add`` never staged them, so their mere presence is not evidence a
-    worker left real work behind. This re-derives file-level detail from the
-    same git flags tmux_worktree.classify_path uses for its yes/no verdict,
-    without duplicating that verdict itself — classify_path still owns
-    clean/committed/pushed/dirty; this only refines what "dirty" means.
+    ``git status --porcelain`` code other than ``??``). A tree with ONLY
+    untracked paths stays non-substantive: their mere presence is not evidence
+    a worker left real work behind, and going loud on every stray scratch file
+    would turn ordinary dispatches into false failures. This re-derives
+    file-level detail from the same git flags tmux_worktree.classify_path uses
+    for its yes/no verdict, without duplicating that verdict itself —
+    classify_path still owns clean/committed/pushed/dirty; this only refines
+    what "dirty" means.
+
+    OI-1128 refinement: once a tree IS substantive, the untracked (``??``)
+    paths are collected too and salvaged alongside the tracked ones. The
+    distinguishing signal between "new source file the worker forgot to add"
+    and "editor droppings" is .gitignore — ``git status`` already applies it,
+    so anything the repo declares junk never shows up. ``-uall`` lists files
+    inside new directories individually (a new ``tests/foo/`` otherwise
+    collapses to one directory entry), so the receipt names the actual files.
 
     Never raises: a git failure degrades to substantive=False (the existing
     safe not-applicable behaviour) — a broken git invocation must never turn
@@ -175,7 +195,7 @@ def _classify_dirty_worktree(*, wt_path: "Path | str") -> _DirtyClassification:
             [
                 "git", "-c", "core.fileMode=false", "-c", "core.autocrlf=input",
                 "-c", "core.quotePath=false",
-                "-C", str(wt_path), "status", "--porcelain",
+                "-C", str(wt_path), "status", "--porcelain", "-uall",
             ],
             capture_output=True, text=True, timeout=15,
         )
@@ -193,13 +213,15 @@ def _classify_dirty_worktree(*, wt_path: "Path | str") -> _DirtyClassification:
         )
 
     tracked_paths: "list[str]" = []
-    untracked = 0
+    untracked_paths: "list[str]" = []
     for line in proc.stdout.splitlines():
         if len(line) < 4:
             continue
         code, path_part = line[:2], line[3:]
         if code == "??":
-            untracked += 1
+            path = path_part.strip()
+            if path:
+                untracked_paths.append(path)
             continue
         path = path_part.split(" -> ")[-1].strip()
         if path:
@@ -209,21 +231,32 @@ def _classify_dirty_worktree(*, wt_path: "Path | str") -> _DirtyClassification:
         return _DirtyClassification(
             substantive=False,
             evidence=(
-                f"dirty worktree has only untracked paths ({untracked} file(s)) — "
+                f"dirty worktree has only untracked paths ({len(untracked_paths)} file(s)) — "
                 "no tracked source/test changes; treated as scratch/non-substantive"
             ),
+            untracked_paths=tuple(untracked_paths),
         )
 
     shown = tracked_paths[:10]
     more = len(tracked_paths) - len(shown)
     listing = ", ".join(shown) + (f", +{more} more" if more else "")
+    evidence = (
+        f"dirty worktree has {len(tracked_paths)} tracked file(s) with uncommitted "
+        f"changes the worker never committed: {listing}"
+    )
+    if untracked_paths:
+        u_shown = untracked_paths[:10]
+        u_more = len(untracked_paths) - len(u_shown)
+        u_listing = ", ".join(u_shown) + (f", +{u_more} more" if u_more else "")
+        evidence += (
+            f"; plus {len(untracked_paths)} untracked non-gitignored file(s) "
+            f"salvaged alongside (OI-1128): {u_listing}"
+        )
     return _DirtyClassification(
         substantive=True,
-        evidence=(
-            f"dirty worktree has {len(tracked_paths)} tracked file(s) with uncommitted "
-            f"changes the worker never committed: {listing}"
-        ),
+        evidence=evidence,
         tracked_paths=tuple(tracked_paths),
+        untracked_paths=tuple(untracked_paths),
     )
 
 
@@ -302,7 +335,9 @@ def enforce_pr_exists(
         return _handle_dirty_substantive(
             dispatch_id=dispatch_id, branch=branch, wt_path=Path(wt_path),
             repo_root=repo_root, receipts_file=receipts_file,
-            tracked_paths=classification.tracked_paths, evidence=classification.evidence,
+            tracked_paths=classification.tracked_paths,
+            untracked_paths=classification.untracked_paths,
+            evidence=classification.evidence,
             pr_title=pr_title, pr_body=pr_body, skip_pr=skip_pr,
         )
 
@@ -394,6 +429,7 @@ def _handle_dirty_substantive(
     pr_title: str,
     pr_body: str,
     skip_pr: bool,
+    untracked_paths: "tuple[str, ...]" = (),
 ) -> PrEnforcementResult:
     """OI-1119: a ``dirty`` tree with substantive uncommitted work — loud AND salvaged.
 
@@ -404,14 +440,17 @@ def _handle_dirty_substantive(
     review boundary (the dispatch still resolves ok=False, exactly like a
     failed push) while preventing the data loss T0 was hand-salvaging.
 
-    Salvage commits ONLY the tracked paths this call already classified as
-    substantive (never ``git add -A`` — that would sweep in the same
-    untracked scratch the classifier just excluded), under a commit message
-    unmistakably marked ``[SALVAGED, UNREVIEWED]`` (mirrors the existing
-    fleet convention, e.g. PR #1444), pushes it, and — unless ``skip_pr``
-    (an existing PR already covers this branch) — opens a **draft** PR with a
-    title/body banner saying the same thing, so it can never be mistaken for
-    a normal, ready-for-review delivery.
+    Salvage commits ONLY the explicit paths this call already classified
+    (never ``git add -A``): the tracked paths that made the tree substantive,
+    plus — OI-1128 — the untracked non-gitignored paths ``git status`` listed
+    next to them. A worker's genuinely NEW file (created, never ``git add``ed)
+    is ``??`` by definition and was previously left to the reaper; .gitignore
+    is the junk filter, applied by git itself before the paths ever reach this
+    function. The commit is unmistakably marked ``[SALVAGED, UNREVIEWED]``
+    (mirrors the existing fleet convention, e.g. PR #1444), pushed, and —
+    unless ``skip_pr`` (an existing PR already covers this branch) — opened as
+    a **draft** PR with a title/body banner saying the same thing, so it can
+    never be mistaken for a normal, ready-for-review delivery.
 
     Never raises: every git/gh step is wrapped; a failure at any stage still
     reaches the corrective receipt below (kind="dirty_substantive_unsalvaged")
@@ -424,7 +463,7 @@ def _handle_dirty_substantive(
 
     try:
         add_proc = subprocess.run(
-            ["git", "-C", str(wt_path), "add", "--", *tracked_paths],
+            ["git", "-C", str(wt_path), "add", "--", *tracked_paths, *untracked_paths],
             capture_output=True, text=True, timeout=30,
         )
     except Exception as exc:  # noqa: BLE001 — degrade to unsalvaged, still loud
@@ -498,6 +537,9 @@ def _handle_dirty_substantive(
             "dirty_substantive": True,
             "dirty_files": list(tracked_paths[:25]),
             "dirty_file_count": len(tracked_paths),
+            # OI-1128: the ?? (untracked, non-gitignored) paths salvaged alongside.
+            "salvaged_untracked_files": list(untracked_paths[:25]),
+            "salvaged_untracked_count": len(untracked_paths),
             "salvaged": pushed,
             "salvage_pr_number": pr_number,
         },

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1052,12 +1052,22 @@ class TmuxInteractiveDispatch:
         try:
             from pr_enforcement import enforce_pr_exists  # noqa: PLC0415
 
+            # OI-1127: hand the worktree path through so a "dirty" verdict is
+            # split into substantive vs scratch and substantive work is
+            # salvaged (OI-1119) — without wt_path this lane kept the old
+            # lose-everything behaviour while the envelope lane was already
+            # fixed. Verified to still exist at this moment rather than
+            # assumed: this runs before _teardown's reap(), but a vanished
+            # directory (external cleanup, crash-restart) must degrade to the
+            # back-compat path, not feed a dead path into git.
+            _wt_path = worktree_handle.path if worktree_handle.path.is_dir() else None
             result = enforce_pr_exists(
                 dispatch_id=dispatch_id,
                 branch=worktree_handle.branch,
                 worktree_state=worktree_state,
                 repo_root=self._project_root,
                 receipts_file=self._receipts_file,
+                wt_path=_wt_path,
                 pr_title=f"dispatch({dispatch_id}): auto-created by VNX tmux-spawn lane",
                 pr_body=(
                     f"Auto-created by VNX tmux-spawn build-dispatch completion "
@@ -3107,7 +3117,8 @@ class TmuxInteractiveDispatch:
             # `gh pr create`, leaves T0 to salvage the work by hand every time. The
             # per-state decision lives in pr_enforcement.enforce_pr_exists (the ONE
             # binding site — never duplicated): `committed` → push then PR, `pushed`
-            # → PR, `clean`/`dirty` → not applicable. Runs BEFORE govern() so a push
+            # → PR, `clean` → not applicable, `dirty` → split into substantive
+            # (salvaged + loud, OI-1119/OI-1127) vs scratch. Runs BEFORE govern() so a push
             # or creation failure is reflected in the governed report and
             # InteractiveDispatchResult.success — never a silent "done" with work
             # stranded locally or on origin.

--- a/tests/test_pr_enforcement_dirty_substantive.py
+++ b/tests/test_pr_enforcement_dirty_substantive.py
@@ -57,8 +57,13 @@ def _init_git_repo_with_origin(tmp_path: Path) -> Path:
     )
     for name in ("alpha.py", "beta.py", "gamma.py", "delta.py", "epsilon.py"):
         (local / name).write_text(f"# {name}\nprint('{name}')\n")
+    # Mirrors the real repo: .DS_Store is gitignored, so git status never even
+    # lists it — .gitignore is the junk filter the OI-1128 untracked salvage
+    # relies on.
+    (local / ".gitignore").write_text(".DS_Store\n")
     subprocess.run(
-        ["git", "-C", str(local), "add", "alpha.py", "beta.py", "gamma.py", "delta.py", "epsilon.py"],
+        ["git", "-C", str(local), "add", ".gitignore",
+         "alpha.py", "beta.py", "gamma.py", "delta.py", "epsilon.py"],
         check=True, capture_output=True,
     )
     subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
@@ -127,18 +132,40 @@ def test_classify_non_substantive_untracked_only(tmp_path):
     assert "untracked" in result.evidence
 
 
-def test_classify_mixed_ignores_untracked_counts_only_tracked(tmp_path):
-    """A tracked edit plus scratch junk: substantive, but only the tracked file
-    is reported — scratch never pollutes the evidence or the salvage set."""
+def test_classify_mixed_gitignored_junk_stays_out(tmp_path):
+    """A tracked edit plus GITIGNORED junk: substantive, and the junk never
+    reaches the salvage set — .gitignore is the scratch filter (OI-1128),
+    applied by git itself before classification sees the paths."""
     local = _init_git_repo_with_origin(tmp_path)
     handle = _allocate(local, "cls-mixed-1")
     (handle.path / "alpha.py").write_text("# edited\n")
-    (handle.path / ".DS_Store").write_text("junk\n")
+    (handle.path / ".DS_Store").write_text("junk\n")  # gitignored in the fixture
 
     result = pe._classify_dirty_worktree(wt_path=handle.path)
 
     assert result.substantive is True
     assert result.tracked_paths == ("alpha.py",)
+    assert result.untracked_paths == ()
+
+
+def test_classify_untracked_new_file_joins_salvage_set(tmp_path):
+    """OI-1128: a tracked edit plus a genuinely NEW file the worker never
+    `git add`ed — the new file is ?? and must be in the salvage set, including
+    a file inside a brand-new directory (porcelain -uall lists it by file)."""
+    local = _init_git_repo_with_origin(tmp_path)
+    handle = _allocate(local, "cls-newfile-1")
+    (handle.path / "alpha.py").write_text("# edited\n")
+    (handle.path / "test_new_feature.py").write_text("def test_x():\n    assert True\n")
+    (handle.path / "newdir").mkdir()
+    (handle.path / "newdir" / "module.py").write_text("VALUE = 1\n")
+
+    result = pe._classify_dirty_worktree(wt_path=handle.path)
+
+    assert result.substantive is True
+    assert result.tracked_paths == ("alpha.py",)
+    assert set(result.untracked_paths) == {"test_new_feature.py", "newdir/module.py"}
+    assert "untracked" in result.evidence
+    assert "test_new_feature.py" in result.evidence
 
 
 def test_classify_degrades_safe_on_git_failure(tmp_path):
@@ -206,6 +233,55 @@ def test_case2_five_tracked_files_zero_commits_is_loud_and_receipt_visible(tmp_p
     assert kwargs_used["draft"] is True
     assert kwargs_used["title"].startswith("[SALVAGED-UNVOUCHED]")
     assert "No worker committed" in kwargs_used["body"]
+
+
+# ---------------------------------------------------------------------------
+# OI-1128 end-to-end: a modified tracked file AND a new never-added file are
+# BOTH salvaged; gitignored junk stays out of the commit.
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_tracked_and_untracked_both_salvaged_end_to_end(tmp_path):
+    """The 2026-08-10 loss shape: of the hand-rescued files, most were ``??``.
+    A tracked edit plus a new untracked file must BOTH land in the salvage
+    commit on origin; the gitignored .DS_Store must not."""
+    local = _init_git_repo_with_origin(tmp_path)
+    handle = _allocate(local, "oi1128-mixed")
+    (handle.path / "alpha.py").write_text("# edited\nprint('edited')\n")
+    (handle.path / "test_new_feature.py").write_text("def test_x():\n    assert True\n")
+    (handle.path / ".DS_Store").write_text("junk\n")  # gitignored in the fixture
+
+    assert tmux_worktree.classify(handle) == "dirty"
+
+    captured_receipt = {}
+    with patch("gh_pr_ensure.ensure_pr",
+               return_value={"pr_number": 910, "created": True, "reason": None}), \
+         patch("append_receipt.append_receipt_payload",
+               side_effect=lambda payload, **kw: captured_receipt.update(payload)):
+        result = pe.enforce_pr_exists(**_kwargs(handle, local))
+
+    # Still loud — untracked inclusion changes what is saved, not the verdict.
+    assert result.applicable is True
+    assert result.ok is False
+    assert result.pushed is True
+
+    # Both files are in the salvage commit on origin; the gitignored junk is not.
+    committed_files = subprocess.run(
+        ["git", "-C", str(local), "show", f"origin/{handle.branch}",
+         "--name-only", "--format="],
+        capture_output=True, text=True,
+    ).stdout.split()
+    assert "alpha.py" in committed_files
+    assert "test_new_feature.py" in committed_files
+    assert ".DS_Store" not in committed_files
+
+    # Receipt-visible: the untracked salvage is named, not implied.
+    assert captured_receipt["autopr_kind"] == "dirty_substantive_salvaged"
+    assert captured_receipt["dirty_file_count"] == 1
+    assert captured_receipt["dirty_files"] == ["alpha.py"]
+    assert captured_receipt["salvaged_untracked_count"] == 1
+    assert captured_receipt["salvaged_untracked_files"] == ["test_new_feature.py"]
+    assert captured_receipt["salvaged"] is True
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -12,6 +12,7 @@ import json
 import os
 import re
 import shlex
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -1981,6 +1982,56 @@ class TestAutoPrEnforcement(_WorktreeTestCase):
         self.assertEqual(result.receipt.get("status"), "failed")
         self.assertTrue(result.receipt.get("autopr_rejected"))
         self.assertEqual(result.receipt.get("autopr_reason"), "gh auth expired")
+
+    def test_enforcement_receives_wt_path_when_worktree_exists(self):
+        """OI-1127: the tmux lane hands its worktree path to enforce_pr_exists,
+        so a dirty tree can be split substantive-vs-scratch and salvaged — the
+        envelope lane already did; without wt_path this lane kept the old
+        lose-everything behaviour (dirty → silently not-applicable)."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock(
+            return_value=PrEnforcementResult(applicable=False, ok=True, reason="scratch only")
+        )
+
+        with patch("tmux_interactive_dispatch.allocate", return_value=handle):
+            with patch("tmux_interactive_dispatch.classify", return_value="dirty"):
+                with patch(
+                    "tmux_interactive_dispatch.reap",
+                    return_value=ReapResult(removed=False, preserved_path=handle.path),
+                ):
+                    with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+                        self._fast_dispatch(lane, isolated_worktree=True)
+
+        mock_enforce.assert_called_once()
+        self.assertEqual(mock_enforce.call_args.kwargs["wt_path"], handle.path)
+
+    def test_enforcement_wt_path_none_when_worktree_dir_gone(self):
+        """OI-1127 existence check: a worktree directory that vanished between
+        spawn and completion degrades to wt_path=None (the pre-OI-1119
+        back-compat path) instead of feeding a dead path into git. Tested on
+        the adapter directly — through dispatch() the spawn plumbing recreates
+        the cwd, so the vanished-dir state cannot be staged end-to-end."""
+        handle = self._make_handle()
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        mock_enforce = MagicMock(
+            return_value=PrEnforcementResult(applicable=False, ok=True, reason="no wt_path")
+        )
+        shutil.rmtree(handle.path)  # externally cleaned up mid-dispatch
+
+        with patch("pr_enforcement.enforce_pr_exists", mock_enforce):
+            result = lane._enforce_pr_exists(
+                dispatch_id=self.DISPATCH_ID,
+                label="T1",
+                worktree_handle=handle,
+                worktree_state="dirty",
+            )
+
+        mock_enforce.assert_called_once()
+        self.assertIsNone(mock_enforce.call_args.kwargs["wt_path"])
+        self.assertFalse(result.applicable)
 
     def test_pr_enforcement_skipped_when_worker_already_failed(self):
         """A worker that self-reported failure is never PR-enforced (nothing to enforce)."""


### PR DESCRIPTION
## Mechanism

Two measured gaps in the OI-1119 worktree salvage (#1446):

**OI-1127** — the salvage only ran on the envelope lane. `enforce_pr_exists` deliberately keeps the pre-fix behaviour (`applicable=False, ok=True`) when `wt_path` is not supplied, and the tmux-spawn lane's adapter (`tmux_interactive_dispatch._enforce_pr_exists`) never passed it. That lane is the default for every claude/Opus/Sonnet worker, and it is the lane that lost ~363 lines on 2026-08-10 (`20260810g-b-register-fill`: report written, zero commits, four modified files, hand-salvaged by T0). #1446 would not have caught that case.

**OI-1128** — the salvage classified every `??` path as scratch and excluded it. A worker that creates a NEW file and never runs `git add` leaves it exactly there: on 10-08 two of the three hand-rescued files were `??`.

## Fix

- `tmux_interactive_dispatch._enforce_pr_exists` now passes `wt_path=worktree_handle.path` — verified to still exist at that moment (`is_dir()`), per the OI's instruction to check rather than assume; a vanished directory degrades to the back-compat path instead of feeding a dead path into git. The call runs before `_teardown`'s `reap()`, mirroring the envelope lane's try/finally ordering.
- `_classify_dirty_worktree` collects `??` paths (`-uall` so files inside new directories are listed individually) and `_handle_dirty_substantive` stages them alongside the tracked paths — still an explicit path list, never `git add -A`. **.gitignore is the junk filter**: `git status` applies it natively, so ignored droppings (.DS_Store etc.) never reach the salvage.
- Untracked-ONLY trees stay non-substantive (unchanged): going loud on every stray scratch file would turn ordinary dispatches into false failures. The residual gap (worker creates ONLY new files, no tracked edits) is listed under Open items below.
- Receipt gains `salvaged_untracked_files` / `salvaged_untracked_count` so the untracked salvage is named, not implied.

Edits are confined to the teardown/salvage region (`_enforce_pr_exists` adapter, lines ~1050, and the call-site comment ~3110) — no overlap with the heartbeat-monitor region another agent is editing.

## Negative control (new tests vs unfixed origin/main source)

```
$ git checkout origin/main -- scripts/lib/pr_enforcement.py scripts/lib/tmux_interactive_dispatch.py
$ python3 -m pytest <4 new tests> -q
E       AttributeError: '_DirtyClassification' object has no attribute 'untracked_paths'. Did you mean: 'tracked_paths'?
E       AssertionError: assert 'test_new_feature.py' in ['alpha.py']
E       KeyError: 'wt_path'
E       KeyError: 'wt_path'
FAILED tests/test_pr_enforcement_dirty_substantive.py::test_classify_untracked_new_file_joins_salvage_set
FAILED tests/test_pr_enforcement_dirty_substantive.py::test_mixed_tracked_and_untracked_both_salvaged_end_to_end
FAILED tests/test_tmux_interactive_dispatch.py::TestAutoPrEnforcement::test_enforcement_receives_wt_path_when_worktree_exists
FAILED tests/test_tmux_interactive_dispatch.py::TestAutoPrEnforcement::test_enforcement_wt_path_none_when_worktree_dir_gone
4 failed in 1.26s
```

## Green test output (fixed source)

```
$ python3 -m pytest tests/test_pr_enforcement_dirty_substantive.py tests/test_tmux_interactive_dispatch.py::TestAutoPrEnforcement -q
19 passed in 4.46s
$ python3 -m pytest tests/test_tmux_interactive_dispatch.py -q
213 passed in 40.68s
$ python3 -m pytest tests/test_pr_enforcement.py tests/test_lane_matrix_row7_push_pr.py tests/test_tmux_dispatch_pr_enforcement_annotation.py -q
38 passed in 1.82s
$ python3 -m pytest tests/test_dispatch_envelope.py -q
35 passed in 1.07s
```

(Run inside a nested worktree; no false-reds appeared, so no plain-clone control rerun was needed.)

## Open items

- Untracked-ONLY trees (worker created new files but touched no tracked file) remain non-substantive and are still lost on reap. OI-1128's own text flags that closing this needs a sharper signal (dispatch scope, report mention) or explicit ratification as accepted residual risk — that decision is T0/operator's, not taken unilaterally here.

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1127 + OI-1128.
🤖 Generated with [Claude Code](https://claude.com/claude-code)