### PR TITLE
fix(heartbeat): raise silence default 600->1800s and make heartbeat kills failure-shaped (OI-1130)

### DIFF
--- a/scripts/lib/provider_spawns/kimi_spawn.py
+++ b/scripts/lib/provider_spawns/kimi_spawn.py
@@ -807,12 +807,13 @@ def _heartbeat_monitor_loop(
     """Poll the per-dispatch tee file for silence; kill + report if stuck.
 
     Same module (``worker_heartbeat.FileProgressHeartbeat``), same threshold
-    (``VNX_WORKER_HEARTBEAT_SILENCE_SECONDS``, default 600s), same failure-report
+    (``VNX_WORKER_HEARTBEAT_SILENCE_SECONDS``, default 1800s since OI-1130),
+    same failure-report
     shape (``build_heartbeat_failure_report``) as the tmux-spawn and subprocess
     lanes, so the audit trail is uniform regardless of which lane ran the
     dispatch (OI-944, OI-1007, OI-1044).
 
-    The 600s default tolerates kimi's measured cadence: a healthy worker can go
+    The default tolerates kimi's measured cadence: a healthy worker can go
     22 minutes between *file writes* while doing nothing but Read/Grep, but its
     stdout stream (which this tee mirrors) carries a tool_call/tool_result pair
     for every one of those reads — measured gaps between kimi's own LLM steps

--- a/scripts/lib/report_to_receipt_converter.py
+++ b/scripts/lib/report_to_receipt_converter.py
@@ -593,6 +593,13 @@ def _resolve_report_provider_model(
 # (e.g. "unknown", absent) keep the pre-existing contract-invalid semantics.
 _TERMINAL_SUCCESS_STATUSES = frozenset({"success", "done", "complete", "completed"})
 
+# Terminal failure statuses (OI-1130).  A report that DECLARES itself failed
+# (e.g. the heartbeat-kill report from worker_heartbeat.
+# build_heartbeat_failure_report, which stamps ``Status: failed`` +
+# ``Failure-Reason: heartbeat_killed``) must produce a task_failed receipt —
+# never a task_complete that downstream tooling reads as a normal completion.
+_TERMINAL_FAILURE_STATUSES = frozenset({"failed", "failure", "heartbeat_killed"})
+
 
 def _check_branch_on_origin(dispatch_id: str) -> bool:
     """Return True when ``dispatch/<dispatch_id>`` exists on origin.
@@ -821,6 +828,30 @@ def build_receipt_from_report(
                     for c in resolved.candidates_found
                 ] if resolved is not None else []
             return receipt_out
+
+    # OI-1130: a report that declares an explicit terminal FAILURE status is
+    # failure-shaped by construction.  Before this mapping, the heartbeat-kill
+    # report (which passes the body contract on purpose so the audit trail is
+    # complete) landed as task_complete with status="" — a kill dressed as
+    # success, detectable only by reading the Summary prose.  Declared failure
+    # outranks contract violations: an explicit failure signal must never
+    # degrade into the low-visibility contract_invalid bucket.
+    if status_raw in _TERMINAL_FAILURE_STATUSES:
+        receipt_out: Dict[str, Any] = {
+            **base,
+            "event_type": "task_failed",
+            "status": "failed",
+        }
+        failure_reason = str(merged.get("failure_reason") or "").strip()
+        if failure_reason:
+            receipt_out["failure_reason"] = failure_reason
+        if ambiguous_report:
+            receipt_out["ambiguous_report_path"] = True
+            receipt_out["report_path_candidates"] = [
+                {"path": str(c), "size": resolved.candidate_sizes[str(c)]}
+                for c in resolved.candidates_found
+            ] if resolved is not None else []
+        return receipt_out
 
     if contract_violations:
         logger.warning(

--- a/scripts/lib/worker_heartbeat.py
+++ b/scripts/lib/worker_heartbeat.py
@@ -7,16 +7,20 @@ it is considered stuck and a terminal failure is written.
 
 Deterministic: no model calls, pure timer + read on NDJSON or file growth.
 
-**Data-driven default (N=600s):** measured across 4.2M within-dispatch event
-gaps from 445 real dispatches (T1/T2/T3 subprocess lanes, archived + live
-streams from vnx-dev).  Distribution:
+**Data-driven default (1800s):** the original 600s default was measured
+across 4.2M within-dispatch event gaps from 445 real dispatches (T1/T2/T3
+subprocess lanes, archived + live streams from vnx-dev):
   p50=0.0s  p90=0.0s  p95=0.0s  p99=0.1s  p99.9=2.5s  max=566.3s (T2)
 
-The longest legitimate gap in a production build-worker dispatch was 389.7s
-(a plan-revise dispatch on T2).  The 600s default is ~1.5x above that tail
-and ~240x the p99.9 value, giving ample headroom for slow tool executions
-while catching truly hung workers within typical dispatch deadlines
-(3600-7200s).
+That tail does not transfer to the tmux lane.  OI-1130 (measured 2026-08-10/11):
+4 of 5 evening dispatches with deep-thinking sonnet workers were killed at
+exactly 600s of pane-log silence, each holding real uncommitted work — the
+only survivor was the most mechanical task of the five.  Thinking is quiet
+on the pane; the chatty subprocess event stream the 600s figure came from is
+not the signal the FileProgressHeartbeat watches.  The default is therefore
+1800s: slower detection of a truly hung worker (still well inside typical
+3600-7200s dispatch deadlines) in exchange for not killing exactly the deep
+work that was requested.
 
 The default is overridable via VNX_WORKER_HEARTBEAT_SILENCE_SECONDS.
 
@@ -36,9 +40,9 @@ from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
-# Default silence threshold: 600 seconds (10 minutes).
-# See module docstring for the data-driven rationale.
-_DEFAULT_SILENCE_THRESHOLD_SECONDS = 600
+# Default silence threshold: 1800 seconds (30 minutes).
+# Raised from 600s by OI-1130 — see module docstring for the rationale.
+_DEFAULT_SILENCE_THRESHOLD_SECONDS = 1800
 
 # Env var to override the default.
 _ENV_SILENCE_SECONDS = "VNX_WORKER_HEARTBEAT_SILENCE_SECONDS"
@@ -339,6 +343,13 @@ def build_heartbeat_failure_report(
 
     Returns the report text as a string.  The caller is responsible for
     writing it to the unified_reports directory.
+
+    OI-1130: the report carries a STRUCTURAL failure identity — bold-fields
+    ``Status: failed`` and ``Failure-Reason: heartbeat_killed`` — so the
+    receipt converter emits a ``task_failed`` receipt.  The report passes the
+    body contract on purpose (the audit trail needs the four headings), which
+    previously made a heartbeat kill land as a normal ``task_complete``
+    receipt, indistinguishable from success without reading the Summary prose.
     """
     from datetime import datetime as _dt
 
@@ -374,6 +385,8 @@ def build_heartbeat_failure_report(
     return f"""**Dispatch-ID**: {dispatch_id}
 **Model**: {model}
 **Provider**: {provider}
+**Status**: failed
+**Failure-Reason**: heartbeat_killed
 
 ## Summary
 
@@ -385,7 +398,9 @@ failure — the dispatch did not complete.
 
 ## Changes
 
-None.  The worker was killed before producing any committed changes.
+None recorded by the worker.  The worker was killed mid-run; any work it
+produced may still sit uncommitted in its worktree — salvage before reap
+(OI-1130).
 
 ## Verification
 

--- a/tests/test_report_to_receipt_converter.py
+++ b/tests/test_report_to_receipt_converter.py
@@ -236,6 +236,40 @@ class TestBuildReceiptFromReport:
         assert receipt is not None
         assert receipt["dispatch_id"] == "20260601-bold-field"
 
+    def test_declared_failure_status_produces_task_failed(self, tmp_path):
+        # OI-1130: a report that declares Status: failed must land as a
+        # task_failed receipt even though it passes the body contract —
+        # never as a task_complete that reads as a normal completion.
+        p = tmp_path / "20260811-declared-fail.md"
+        p.write_text(
+            "**Dispatch-ID**: 20260811-declared-fail\n"
+            "**Status**: failed\n"
+            "**Failure-Reason**: heartbeat_killed\n\n"
+            "## Summary\n\nWorker killed by heartbeat monitor after threshold breach.\n\n"
+            "## Changes\n\nNone recorded.\n\n## Verification\n\n-\n\n## Open Items\n\nNone\n",
+            encoding="utf-8",
+        )
+        receipt = build_receipt_from_report(p, p.read_text(encoding="utf-8"))
+        assert receipt is not None
+        assert receipt["event_type"] == "task_failed"
+        assert receipt["status"] == "failed"
+        assert receipt["failure_reason"] == "heartbeat_killed"
+
+    def test_declared_failure_outranks_contract_invalid(self, tmp_path):
+        # A failed-status report with missing headings must still surface as
+        # task_failed, not vanish into the contract_invalid bucket.
+        p = tmp_path / "20260811-fail-no-body.md"
+        p.write_text(
+            "**Dispatch-ID**: 20260811-fail-no-body\n"
+            "**Status**: failure\n\n"
+            "Worker died without writing a full report.\n",
+            encoding="utf-8",
+        )
+        receipt = build_receipt_from_report(p, p.read_text(encoding="utf-8"))
+        assert receipt is not None
+        assert receipt["event_type"] == "task_failed"
+        assert receipt["status"] == "failed"
+
 
 # ---------------------------------------------------------------------------
 # Part 3: convert_report_to_receipt() — single-file conversion

--- a/tests/test_worker_heartbeat_silence.py
+++ b/tests/test_worker_heartbeat_silence.py
@@ -238,29 +238,81 @@ class TestBuildFailureReport(unittest.TestCase):
         summary_text = "".join(summary_body.split())
         self.assertGreaterEqual(len(summary_text), 50)
 
+    def test_report_carries_structural_failure_status(self):
+        # OI-1130: the failure must be a parseable STATUS FIELD, not Summary
+        # prose.  Assert on the extracted fields, never on prose text.
+        from worker_heartbeat import SilenceVerdict, build_heartbeat_failure_report
+        from report_to_receipt_converter import _extract_body_fields
+        verdict = SilenceVerdict(
+            is_silent=True, silence_seconds=1900.0, threshold_seconds=1800,
+        )
+        report = build_heartbeat_failure_report(
+            "20260811-hb-kill", verdict, terminal_id="T1",
+        )
+        fields = _extract_body_fields(report)
+        self.assertEqual(fields.get("status"), "failed")
+        self.assertEqual(fields.get("failure_reason"), "heartbeat_killed")
+
+    def test_kill_report_converts_to_task_failed_receipt(self):
+        # OI-1130 end-to-end shape: the heartbeat-kill report must land as a
+        # task_failed receipt, never task_complete.  Before the fix the report
+        # passed the body contract with no status field at all -> the
+        # converter emitted event_type="task_complete", status="" — a kill
+        # indistinguishable from success without reading the Summary.
+        from worker_heartbeat import SilenceVerdict, build_heartbeat_failure_report
+        from report_to_receipt_converter import build_receipt_from_report
+        verdict = SilenceVerdict(
+            is_silent=True, silence_seconds=1900.0, threshold_seconds=1800,
+        )
+        report = build_heartbeat_failure_report(
+            "20260811-hb-kill-receipt", verdict, terminal_id="T1",
+        )
+        tmpdir = Path(tempfile.mkdtemp())
+        path = tmpdir / "20260811-hb-kill-receipt.md"
+        path.write_text(report, encoding="utf-8")
+        try:
+            receipt = build_receipt_from_report(path, report)
+        finally:
+            import shutil
+            shutil.rmtree(str(tmpdir), ignore_errors=True)
+        self.assertIsNotNone(receipt)
+        self.assertEqual(receipt["event_type"], "task_failed")
+        self.assertEqual(receipt["status"], "failed")
+        self.assertEqual(receipt.get("failure_reason"), "heartbeat_killed")
+
 
 class TestThresholdResolution(unittest.TestCase):
     """VNX_WORKER_HEARTBEAT_SILENCE_SECONDS env var resolution."""
 
     def test_default_unset(self):
+        # OI-1130: default raised 600 -> 1800.  The 600s tail was measured on
+        # the chatty subprocess event stream; deep-thinking tmux workers are
+        # legitimately silent past 600s (4 of 5 killed on 2026-08-10 with
+        # real work in their worktrees).
         with patch.dict(os.environ, {}, clear=True):
             from worker_heartbeat import _resolve_silence_threshold
-            self.assertEqual(_resolve_silence_threshold(), 600)
+            self.assertEqual(_resolve_silence_threshold(), 1800)
 
     def test_valid_env_value(self):
         with patch.dict(os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "300"}):
             from worker_heartbeat import _resolve_silence_threshold
             self.assertEqual(_resolve_silence_threshold(), 300)
 
+    def test_env_override_above_default_wins(self):
+        # The override must win in BOTH directions — 3600 > default 1800.
+        with patch.dict(os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "3600"}):
+            from worker_heartbeat import _resolve_silence_threshold
+            self.assertEqual(_resolve_silence_threshold(), 3600)
+
     def test_negative_clamps(self):
         with patch.dict(os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "-100"}):
             from worker_heartbeat import _resolve_silence_threshold
-            self.assertEqual(_resolve_silence_threshold(), 600)
+            self.assertEqual(_resolve_silence_threshold(), 1800)
 
     def test_unparseable_clamps(self):
         with patch.dict(os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "abc"}):
             from worker_heartbeat import _resolve_silence_threshold
-            self.assertEqual(_resolve_silence_threshold(), 600)
+            self.assertEqual(_resolve_silence_threshold(), 1800)
 
     def test_zero_disables(self):
         with patch.dict(os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0"}):


### PR DESCRIPTION
## Mechanism (why it was broken)

Two coupled defects, measured 10/11-08 (OI-1130): 4 of 5 evening dispatches were killed at exactly 600s of pane silence, all four holding real work in their worktrees.

1. **Wrong threshold for the signal being watched.** The 600s default in `worker_heartbeat.py` was derived from 4.2M within-dispatch event gaps on the *subprocess event stream* (p99.9=2.5s, max legit gap 389.7s). The tmux lane's `FileProgressHeartbeat` watches the *pipe-pane log* instead — and a deep-thinking worker is legitimately quiet on that surface for well past 600s. The threshold punished exactly the work that was requested; the only survivor of the five was the most mechanical task.

2. **The kill left a success-shaped report.** `build_heartbeat_failure_report()` deliberately carries the four mandatory headings (audit-trail completeness) but stamped **no status field at all**. In `report_to_receipt_converter.build_receipt_from_report()`, `status_raw` resolved to `""` — not a terminal-success status, no contract violations — so the receipt landed as `event_type="task_complete"`, `status=""`. A kill indistinguishable from success unless you read the Summary prose.

## The fix

- `_DEFAULT_SILENCE_THRESHOLD_SECONDS` 600 → 1800. `VNX_WORKER_HEARTBEAT_SILENCE_SECONDS` still overrides in both directions (tested below and above the default). Every place documenting the old default updated (`worker_heartbeat.py` docstring/comment, `kimi_spawn.py` heartbeat docstrings; docs/ and other lanes never named the number).
- `build_heartbeat_failure_report()` now stamps structural bold-fields `**Status**: failed` + `**Failure-Reason**: heartbeat_killed`. One builder feeds all three lanes (tmux, subprocess `delivery_runtime`, kimi), so the shape lands everywhere.
- Converter: new `_TERMINAL_FAILURE_STATUSES = {failed, failure, heartbeat_killed}` mapped to `event_type="task_failed"`, `status="failed"`, carrying `failure_reason`. Declared failure outranks the contract-invalid bucket, so an explicit failure never degrades into the low-visibility path.

Scoped per OI-1130: heartbeat region only; no `dispatch()` restructure (that is OI-1138); pre-kill salvage (direction d) is NOT in this PR — see open findings.

## Negative control (new tests vs unfixed origin/main sources)

`git checkout origin/main -- scripts/lib/worker_heartbeat.py scripts/lib/report_to_receipt_converter.py`, then:

```
FAILED tests/test_worker_heartbeat_silence.py::TestThresholdResolution::test_default_unset
FAILED tests/test_worker_heartbeat_silence.py::TestThresholdResolution::test_negative_clamps
FAILED tests/test_worker_heartbeat_silence.py::TestThresholdResolution::test_unparseable_clamps
FAILED tests/test_worker_heartbeat_silence.py::TestBuildFailureReport::test_kill_report_converts_to_task_failed_receipt
FAILED tests/test_worker_heartbeat_silence.py::TestBuildFailureReport::test_report_carries_structural_failure_status
FAILED tests/test_report_to_receipt_converter.py::TestBuildReceiptFromReport::test_declared_failure_status_produces_task_failed
FAILED tests/test_report_to_receipt_converter.py::TestBuildReceiptFromReport::test_declared_failure_outranks_contract_invalid
7 failed, 6 passed in 0.42s
```

Key assertions on unfixed code:

```
E           AssertionError: 600 != 1800
E       AssertionError: 'task_complete' != 'task_failed'
E       AssertionError: assert 'report_contract_invalid' == 'task_failed'
```

## Green test output (fixed sources, after rebase onto latest origin/main)

Nested worktree:

```
tests/test_worker_heartbeat_silence.py tests/test_report_to_receipt_converter.py tests/test_kimi_spawn_heartbeat.py
173 passed in 17.06s
```

Plain clone verification (per the nested-worktree footgun), my branch:

```
173 passed in 8.18s
tests/test_tmux_interactive_dispatch.py -k "heartbeat or silence": 2 passed, 209 deselected
```

Pre-existing, unrelated, fails identically on origin/main in BOTH the worktree and a plain clone: `tests/test_worker_heartbeat.py::test_list_members_pid_none_when_not_set` (FOREIGN KEY constraint in `pool_state_repo.py` — worker-pool membership, not the silence heartbeat).

Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1130.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
