### PR TITLE
fix(smart-router): price kimi-k2-7-code + codex candidates, specialist role dominates classification (OI-1143)

### DIFF
--- a/scripts/lib/cost_loader.py
+++ b/scripts/lib/cost_loader.py
@@ -50,6 +50,13 @@ _AVG_OUTPUT_TOKENS = 2_000
 # 2026-08-04 OI-977: canonical dot-form GLM keys added alongside legacy dash-form keys
 # so that ledger-stored names (glm-5.2) resolve. normalize_model_name() is called before
 # the lookup; deprecated variants (glm-4.5, glm-5.1) resolve via _deprecated_map.
+#
+# 2026-08-11 OI-1143: routing_recommendations carries kimi-k2-7-code (the kimi-cli
+# "kimi-for-coding" model = registry key kimi_cli/kimi-k2-7) and codex-gpt-5-4 /
+# codex-gpt-5-5 (the codex CLI lane running openai gpt-5.4 / gpt-5.5 — API-metered at
+# $1.25/$10 per Mtok, measured 2026-06-06, see routing_policy.yaml cost reference).
+# None of these had a map entry, so enrich_candidates() warned "unknown candidate model"
+# and the router weighed them cost-blind (cost_usd_per_call stayed None).
 _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     "claude-sonnet-4-6": ("anthropic", "sonnet"),
     "claude-sonnet-5": ("anthropic", "sonnet-5"),
@@ -69,6 +76,13 @@ _ROUTING_MODEL_MAP: dict[str, tuple[str, str]] = {
     # Kimi
     "kimi-k2-0905": ("kimi_cli", "kimi-default"),
     "kimi-k2-6": ("kimi_cli", "kimi-k2-6"),
+    # kimi-cli "kimi-for-coding" (registry key kimi-k2-7); kimi-k2-7-code is the
+    # routing_recommendations model_id for the same model (OI-1143)
+    "kimi-k2-7": ("kimi_cli", "kimi-k2-7"),
+    "kimi-k2-7-code": ("kimi_cli", "kimi-k2-7"),
+    # Codex CLI lane — runs openai gpt-5.4 / gpt-5.5, API-metered (OI-1143)
+    "codex-gpt-5-4": ("openai", "gpt-5.4"),
+    "codex-gpt-5-5": ("openai", "gpt-5.5"),
 }
 
 # Cache: deprecated model name → current canonical model key.

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -121,13 +121,21 @@ ROLE_TO_TASK_CLASS: Dict[str, str] = {
     "test-engineer": "01_code_generation",
     "quality-engineer": "02_code_review",
     "reviewer": "02_code_review",
+    "code-reviewer": "02_code_review",  # OI-1143: real fleet role (phantom_guard REVIEW_ROLES) was unmapped
     "security-engineer": "02_code_review",
     "architect": "06_design",
+    "system-architect": "06_design",  # OI-1143: fleet role string alongside the short form
     "planner": "06_design",
     "technical-writer": "04_documentation",
     "debugger": "05_debugging",
     "performance-profiler": "05_debugging",
 }
+
+# The classifier's fallthrough class. Roles mapping HERE carry no discriminating
+# signal (builder roles do refactors/debugging/docs in the same lane, and
+# "backend-developer" is additionally the fabric's no-role-resolved sentinel —
+# dispatch_govern._FAKE_DEFAULT_ROLE), so for them the instruction text decides.
+_DEFAULT_TASK_CLASS = "01_code_generation"
 
 
 # ---------------------------------------------------------------------------
@@ -141,28 +149,40 @@ def classify_task(
 ) -> str:
     """Classify a dispatch instruction into one of the 7 task classes.
 
-    Priority:
-      1. Instruction text matched against heuristic regex patterns (first match wins,
-         ordered by task class number — code_gen checked before review, etc.)
-      2. Role-based fallback if no regex matches
-      3. Default: 01_code_generation (safest default — most dispatches are code work)
+    Priority (OI-1143 — role signal dominates verb-guessing when present):
+      1. A role mapping to a NON-default task class (code-reviewer, debugger,
+         architect, ...) is an explicit operator signal and wins outright — a
+         review dispatched to a code-reviewer stays a review even when the
+         instruction text happens to trip a code-gen verb pattern.
+      2. Instruction text matched against heuristic regex patterns (first match
+         wins, ordered by task class number).
+      3. Role-based fallback for default-class (builder) roles. Builder roles map
+         to the classifier's own default, so step 1 skipping them changes nothing
+         for a no-regex-match instruction — and keeps the instruction text
+         deciding for the no-role-resolved sentinel ("backend-developer").
+      4. Default: 01_code_generation (safest default — most dispatches are code work)
 
     dispatch_paths is reserved for future signal enrichment (e.g. docs-only paths
     → documentation class) but not used in the heuristic yet.
     """
     normalized = (instruction or "").strip()
 
+    mapped: Optional[str] = None
+    if role:
+        role_key = role.strip().lstrip("/").lower()
+        mapped = ROLE_TO_TASK_CLASS.get(role_key)
+
+    if mapped and mapped != _DEFAULT_TASK_CLASS:
+        return mapped
+
     for task_class, pattern in _TASK_CLASS_PATTERNS:
         if pattern.search(normalized):
             return task_class
 
-    if role:
-        role_key = role.strip().lstrip("/").lower()
-        mapped = ROLE_TO_TASK_CLASS.get(role_key)
-        if mapped:
-            return mapped
+    if mapped:
+        return mapped
 
-    return "01_code_generation"
+    return _DEFAULT_TASK_CLASS
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_cost_loader.py
+++ b/tests/test_cost_loader.py
@@ -122,7 +122,9 @@ class TestOI1143CandidateModelsResolve:
         assert cost is not None and cost > 0
 
     def test_kimi_k2_7_registry_key_same_cost(self):
-        assert compute_cost_per_call("kimi-k2-7") == compute_cost_per_call("kimi-k2-7-code")
+        cost = compute_cost_per_call("kimi-k2-7")
+        assert cost is not None  # not vacuously equal via None == None
+        assert cost == compute_cost_per_call("kimi-k2-7-code")
 
     def test_codex_gpt_5_4_has_cost(self):
         # codex CLI lane running openai gpt-5.4 — API-metered ($1.25/$10 per

--- a/tests/test_cost_loader.py
+++ b/tests/test_cost_loader.py
@@ -108,6 +108,53 @@ class TestExistingMapFormNames:
 
 
 # ---------------------------------------------------------------------------
+# OI-1143: routing_recommendations candidates missing from the cost register
+# ---------------------------------------------------------------------------
+
+class TestOI1143CandidateModelsResolve:
+    """kimi-k2-7-code and codex-gpt-5-4/-5-5 are routing_recommendations
+    candidates; smart_router.decide() logged 'unknown candidate model' for them
+    and weighed them cost-blind (cost_usd_per_call stayed None)."""
+
+    def test_kimi_k2_7_code_has_cost(self):
+        # kimi-cli "kimi-for-coding" — registry key kimi_cli/kimi-k2-7
+        cost = compute_cost_per_call("kimi-k2-7-code")
+        assert cost is not None and cost > 0
+
+    def test_kimi_k2_7_registry_key_same_cost(self):
+        assert compute_cost_per_call("kimi-k2-7") == compute_cost_per_call("kimi-k2-7-code")
+
+    def test_codex_gpt_5_4_has_cost(self):
+        # codex CLI lane running openai gpt-5.4 — API-metered ($1.25/$10 per
+        # Mtok, routing_policy.yaml cost reference, measured 2026-06-06)
+        cost = compute_cost_per_call("codex-gpt-5-4")
+        assert cost is not None and cost > 0
+
+    def test_codex_gpt_5_5_has_cost(self):
+        cost = compute_cost_per_call("codex-gpt-5-5")
+        assert cost is not None and cost > 0
+
+    def test_enrich_candidates_no_unknown_warning(self, caplog):
+        """enrich_candidates must fill the cost without the unknown-candidate
+        warning for every routing_recommendations model_id of these lanes."""
+        import logging
+        from types import SimpleNamespace
+
+        from cost_loader import enrich_candidates
+
+        candidates = [
+            SimpleNamespace(model_id=m, cost_usd_per_call=None)
+            for m in ("kimi-k2-7-code", "codex-gpt-5-4", "codex-gpt-5-5")
+        ]
+        with caplog.at_level(logging.WARNING, logger="cost_loader"):
+            enrich_candidates(candidates)
+        assert "unknown candidate model" not in caplog.text
+        for candidate in candidates:
+            assert candidate.cost_usd_per_call is not None, candidate.model_id
+            assert candidate.cost_usd_per_call > 0, candidate.model_id
+
+
+# ---------------------------------------------------------------------------
 # Negative-path: unknown models
 # ---------------------------------------------------------------------------
 

--- a/tests/test_smart_router.py
+++ b/tests/test_smart_router.py
@@ -214,6 +214,50 @@ class TestClassifyRoleFallback:
 
 
 # ---------------------------------------------------------------------------
+# classify_task — specialist-role dominance (OI-1143)
+# ---------------------------------------------------------------------------
+
+class TestClassifySpecialistRoleDominance:
+    """A role mapping to a non-default task class is an explicit signal and wins
+    over instruction verb-guessing (OI-1143). Builder roles (mapping to the
+    default class, incl. the no-role-resolved sentinel backend-developer) keep
+    instruction-first behavior."""
+
+    def test_code_reviewer_role_classifies_review_instruction(self):
+        # The exact OI-1143 measurement: this returned 01_code_generation because
+        # "code-reviewer" was unmapped and the instruction trips no review regex
+        # ("Review the diff" — "diff" is not in the pattern's object alternation).
+        assert classify_task(
+            "Review the diff on PR 1455 for correctness", role="code-reviewer",
+        ) == "02_code_review"
+
+    def test_code_reviewer_role_dominates_code_gen_verb(self):
+        # "implement" trips the 01_code_generation regex, but a dispatch to a
+        # code-reviewer is review work — the role signal dominates.
+        assert classify_task(
+            "Check whether they implement the retry contract correctly",
+            role="code-reviewer",
+        ) == "02_code_review"
+
+    def test_debugger_role_dominates_code_gen_verb(self):
+        assert classify_task(
+            "Implement a fix once you find it", role="debugger",
+        ) == "05_debugging"
+
+    def test_system_architect_role_maps_to_design(self):
+        assert classify_task(
+            "Think through the module boundaries", role="system-architect",
+        ) == "06_design"
+
+    def test_builder_role_still_instruction_first(self):
+        # backend-developer maps to the default class → carries no discriminating
+        # signal; the instruction text keeps deciding (guards the sentinel case).
+        assert classify_task(
+            "debug the flaky lease test", role="backend-developer",
+        ) == "05_debugging"
+
+
+# ---------------------------------------------------------------------------
 # classify_task — edge cases
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Fixes both defects T0 measured in OI-1143 during the smart-router-auto-usable verification (11-08).

## Mechanism — why it was broken

**1. Cost register drift.** `routing_recommendations.yaml` carries three candidate model_ids that had no entry in `cost_loader._ROUTING_MODEL_MAP`:

- `kimi-k2-7-code` — the kimi-cli "kimi-for-coding" model, registry key `kimi_cli/kimi-k2-7` in `wave7_models.yaml` (rates 0.60/2.50 per Mtok, already in the register)
- `codex-gpt-5-4` / `codex-gpt-5-5` — the codex CLI lane running openai gpt-5.4/5.5, API-metered at $1.25/$10 per Mtok (the `openai` section of `wave7_models.yaml`; matches the measured cost reference in `routing_policy.yaml`, 2026-06-06)

`normalize_model_name()` passes all three through unchanged, so `enrich_candidates()` hit the `mapping is None` branch, logged `unknown candidate model`, and left `cost_usd_per_call = None` — the router weighed these candidates cost-blind on every decide().

**2. Classifier miss.** `decide('Review the diff on PR 1455 for correctness', role='code-reviewer')` returned `01_code_generation` because of two stacked gaps: `code-reviewer` (a real fleet role — it is in phantom_guard's `REVIEW_ROLES`) was missing from `ROLE_TO_TASK_CLASS` (the map only had `reviewer`), and the instruction trips no review regex ("Review the diff" — "diff" is not in the pattern's object alternation), so classification fell through to the default.

## The fix

- `cost_loader.py`: four `_ROUTING_MODEL_MAP` entries (`kimi-k2-7`, `kimi-k2-7-code` → `kimi_cli/kimi-k2-7`; `codex-gpt-5-4` → `openai/gpt-5.4`; `codex-gpt-5-5` → `openai/gpt-5.5`). Rates come from the existing wave7 register — no numbers invented.
- `smart_router.py`: added `code-reviewer` → `02_code_review` and `system-architect` → `06_design` to `ROLE_TO_TASK_CLASS`, and made a role that maps to a **non-default** task class dominate the regex verb-guess (per the OI: role signal wins when present). Builder roles that map to the default class keep instruction-first behavior — deliberately, because `backend-developer` is the fabric's no-role-resolved sentinel (`dispatch_govern._FAKE_DEFAULT_ROLE`); making it dominate would classify every sentinel-role dispatch as code_generation and neuter the classifier. This preserves the existing `test_instruction_takes_priority_over_role` contract for the sentinel.

Verified end-to-end after the fix: `decide('Review the diff on PR 1455 for correctness', role='code-reviewer')` → `task_class=02_code_review`; `compute_cost_per_call` → codex-gpt-5-4/5-5 = $0.02625, kimi-k2-7-code = $0.008; zero `unknown candidate model` warnings during decide().

## Negative control (new tests against unfixed origin/main sources)

`git checkout origin/main -- scripts/lib/cost_loader.py scripts/lib/smart_router.py`, then:

```
FAILED tests/test_cost_loader.py::TestOI1143CandidateModelsResolve::test_kimi_k2_7_code_has_cost
FAILED tests/test_cost_loader.py::TestOI1143CandidateModelsResolve::test_codex_gpt_5_4_has_cost
FAILED tests/test_cost_loader.py::TestOI1143CandidateModelsResolve::test_codex_gpt_5_5_has_cost
FAILED tests/test_cost_loader.py::TestOI1143CandidateModelsResolve::test_enrich_candidates_no_unknown_warning
FAILED tests/test_smart_router.py::TestClassifySpecialistRoleDominance::test_code_reviewer_role_classifies_review_instruction
FAILED tests/test_smart_router.py::TestClassifySpecialistRoleDominance::test_code_reviewer_role_dominates_code_gen_verb
FAILED tests/test_smart_router.py::TestClassifySpecialistRoleDominance::test_debugger_role_dominates_code_gen_verb
FAILED tests/test_smart_router.py::TestClassifySpecialistRoleDominance::test_system_architect_role_maps_to_design
8 failed, 2 passed in 0.38s
```

Sample failure (the exact OI case):

```
E       AssertionError: assert '01_code_generation' == '02_code_review'
```

The 2 that pass on main are deliberate: the builder-role guard (behavior intentionally unchanged) and the registry-key equality test (tightened in the follow-up commit to assert non-None so it cannot pass vacuously).

## Green test output (fixed branch)

```
python3 -m pytest tests/test_cost_loader.py tests/test_smart_router.py tests/test_smart_router_cost_aware.py -q
126 passed in 4.61s
```

Neighbour suites also green: `test_smart_router_e2e.py`, `test_smart_router_wiring.py`, `test_smart_router_multiprovider.py`, `test_smart_router_quality_tier.py`, `test_classifier_providers.py` (85 passed), `tests/smart_router/` (54 passed).

---
Operator-authorized burn outside the governed dispatch lanes (no receipt; audit = this PR + T0 session 11-08). Evidence for OI-1143.
🤖 Generated with [Claude Code](https://claude.com/claude-code)
