### PR TITLE
feat(governance): ledger-health check — every fired dispatch must have a receipt

### DIFF
--- a/scripts/ledger_health.py
+++ b/scripts/ledger_health.py
@@ -22,11 +22,17 @@ or ``receipt_pull_cursor.json`` — that answers three questions:
 
   pull_cursor — the age of ``receipt_pull_cursor.json`` (ADR-035 §5.3: the
       PULL that replaced the retired T0-pane push, DISPATCH_RULES §13's step
-      0 of every T0 cycle) and the unread backlog behind it. Read via the
-      same byte-cursor primitive ``receipt_query.py``'s ``pull --peek`` uses
-      (``load_cursor`` + ``pull_new_receipts``) — this module never calls
+      0 of every T0 cycle) and the unread backlog behind it. The backlog is
+      read via the same byte-cursor primitive ``receipt_query.py``'s
+      ``pull --peek`` uses (``pull_new_receipts``) — this module never calls
       ``save_cursor``, so the cursor position on disk is provably unchanged
-      by a health run.
+      by a health run. The offset itself is read by a local wrapper, not
+      ``receipt_query.load_cursor`` directly: that helper collapses a
+      missing cursor AND a corrupt/unparseable one to the same offset 0,
+      which is correct for its own caller (the pull cadence just starts
+      over) but would let a corrupt cursor file read as "legitimately at
+      byte 0" here. A ledger smaller than the cursor offset (truncation/
+      rotation) is its own finding, not just a reported field.
 
   chain_status — the existing ``ndjson_hash_chain.verify_chain`` outcome,
       with ``unchained`` reported as its own explicit class rather than
@@ -63,7 +69,7 @@ if str(LIB_DIR) not in sys.path:
     sys.path.insert(0, str(LIB_DIR))
 
 from ndjson_hash_chain import verify_chain  # noqa: E402
-from receipt_query import CURSOR_NAME, load_cursor, pull_new_receipts  # noqa: E402
+from receipt_query import CURSOR_NAME, pull_new_receipts  # noqa: E402
 
 REGISTER_NAME = "dispatch_register.ndjson"
 LEDGER_NAME = "t0_receipts.ndjson"
@@ -161,8 +167,9 @@ def check_receipt_coverage(state_dir: Path) -> Dict[str, Any]:
         return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read ledger/register: {exc}"}
 
     missing = sorted(register_ids - receipt_ids)
+    parse_errors = register_errors + receipt_errors
 
-    return {
+    result: Dict[str, Any] = {
         "status": STATUS_FINDING if missing else STATUS_OK,
         "register_dispatch_count": len(register_ids),
         "receipted_dispatch_count": len(receipt_ids),
@@ -174,6 +181,52 @@ def check_receipt_coverage(state_dir: Path) -> Dict[str, Any]:
         "receipt_parse_errors": receipt_errors,
     }
 
+    if parse_errors:
+        # A parse error on EITHER file makes `missing` untrustworthy in both
+        # directions: a malformed register line can hide a dispatch_id that
+        # in fact has no receipt (coverage looks better than it is), and a
+        # malformed receipt line can hide the very receipt that would clear
+        # an entry off `missing` (a false "missing"). Either way this check
+        # cannot certify coverage, so it is SKIPPED_UNVERIFIED — chosen over
+        # STATUS_FINDING-with-a-flag because a corrupt line's blast radius is
+        # unbounded (we don't know what dispatch_id it would have carried),
+        # unlike a clean-parse `missing` list, which is exact. This mirrors
+        # the OSError branch above: a read that didn't fully succeed is
+        # "cannot measure", never "measured and fine" — status is
+        # overridden even when `missing` is empty.
+        result["status"] = SKIPPED_UNVERIFIED
+        result["reason"] = (
+            f"{register_errors} register + {receipt_errors} receipt parse error(s) — "
+            "coverage cannot be certified from a partially-unreadable ledger/register"
+        )
+
+    return result
+
+
+def _read_cursor_offset(cursor_path: Path) -> Tuple[Optional[int], bool]:
+    """Read the byte offset from ``cursor_path`` directly, distinguishing a
+    corrupt/unparseable cursor file from a legitimate offset (including 0).
+
+    ``receipt_query.load_cursor`` intentionally collapses a missing cursor
+    AND a corrupt one to the same offset 0 — correct for its own caller (the
+    pull cadence just starts over from 0), but a health check consuming that
+    same 0 could not tell "cursor genuinely at byte 0" from "cursor file is
+    garbage, this 0 means nothing". Duplicated here as a two-line parse
+    (same shape as ``load_cursor``) rather than changing that helper's
+    contract for its other caller.
+
+    Returns ``(offset, is_corrupt)``. ``offset`` is ``None`` when corrupt.
+    Only called after the caller has already confirmed ``cursor_path``
+    exists.
+    """
+    try:
+        raw = cursor_path.read_text(encoding="utf-8")
+        data = json.loads(raw)
+        offset = int(data.get("offset", 0))
+    except (json.JSONDecodeError, ValueError, TypeError, AttributeError):
+        return None, True
+    return offset, False
+
 
 def check_pull_cursor(
     state_dir: Path,
@@ -182,9 +235,10 @@ def check_pull_cursor(
 ) -> Dict[str, Any]:
     """Age of receipt_pull_cursor.json plus the unread backlog behind it.
 
-    Never advances the cursor: reads the offset with ``receipt_query.
-    load_cursor`` and the backlog with ``receipt_query.pull_new_receipts``,
-    but never calls ``save_cursor`` — the same non-mutating contract
+    Never advances the cursor: reads the offset with the local
+    ``_read_cursor_offset`` (a corruption-aware wrapper, see its docstring)
+    and the backlog with ``receipt_query.pull_new_receipts``, but never
+    calls ``save_cursor`` — the same non-mutating contract
     ``receipt_query.py pull --peek`` gives its callers.
     """
     ledger_path = state_dir / LEDGER_NAME
@@ -227,10 +281,30 @@ def check_pull_cursor(
         }
 
     try:
-        cursor_offset = load_cursor(cursor_path)
         cursor_mtime = cursor_path.stat().st_mtime
     except OSError as exc:
         return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read cursor: {exc}"}
+
+    cursor_offset, cursor_corrupt = _read_cursor_offset(cursor_path)
+
+    if cursor_corrupt:
+        # load_cursor() would silently coerce this same file to offset 0 —
+        # indistinguishable from a legitimate cursor that really is at byte
+        # 0. Never trust an offset we can't parse: status is
+        # SKIPPED_UNVERIFIED, not STATUS_OK on a guessed 0.
+        return {
+            "status": SKIPPED_UNVERIFIED,
+            "cursor_path": str(cursor_path),
+            "cursor_exists": True,
+            "cursor_corrupt": True,
+            "cursor_offset": None,
+            "cursor_age_seconds": round(max(0.0, time.time() - cursor_mtime), 1),
+            "ledger_size_bytes": ledger_size,
+            "stale_threshold_hours": stale_hours,
+            "reason": f"{cursor_path} exists but its offset could not be parsed as valid "
+                      "JSON — not the same as a legitimate offset of 0, so the cursor "
+                      "position cannot be trusted",
+        }
 
     age_seconds = max(0.0, time.time() - cursor_mtime)
     truncated = ledger_size < cursor_offset
@@ -245,10 +319,22 @@ def check_pull_cursor(
 
     stale = age_seconds > (stale_hours * 3600.0)
 
+    reasons = []
+    if truncated:
+        reasons.append(
+            f"ledger ({ledger_size} bytes) is smaller than the cursor offset "
+            f"({cursor_offset} bytes) — truncated or rotated since the last pull"
+        )
+    if stale:
+        reasons.append(
+            f"cursor is {round(age_seconds / 3600.0, 1)}h old, past the {stale_hours}h threshold"
+        )
+
     return {
-        "status": STATUS_FINDING if stale else STATUS_OK,
+        "status": STATUS_FINDING if (stale or truncated) else STATUS_OK,
         "cursor_path": str(cursor_path),
         "cursor_exists": True,
+        "cursor_corrupt": False,
         "cursor_offset": cursor_offset,
         "cursor_age_seconds": round(age_seconds, 1),
         "ledger_size_bytes": ledger_size,
@@ -256,10 +342,7 @@ def check_pull_cursor(
         "backlog_receipt_count": len(backlog_receipts),
         "ledger_truncated_since_cursor": truncated,
         "stale_threshold_hours": stale_hours,
-        "reason": (
-            f"cursor is {round(age_seconds / 3600.0, 1)}h old, past the {stale_hours}h threshold"
-            if stale else None
-        ),
+        "reason": "; ".join(reasons) if reasons else None,
     }
 
 

--- a/scripts/ledger_health.py
+++ b/scripts/ledger_health.py
@@ -1,0 +1,453 @@
+#!/usr/bin/env python3
+"""ledger_health.py — reconciles what the fabric DID against what it RECORDED.
+
+VNX has integrity tooling for the receipts ledger itself (``audit_chain.py``,
+``state_integrity.py``, three reconcilers) but nothing that asks the one
+question none of them ask: did every dispatch the register says was fired
+actually land a receipt? This is a read-only reconciliation over central
+state — it never mutates ``dispatch_register.ndjson``, ``t0_receipts.ndjson``,
+or ``receipt_pull_cursor.json`` — that answers three questions:
+
+  receipt_coverage — every ``dispatch_id`` in ``dispatch_register.ndjson``
+      must have a receipt carrying that SAME ``dispatch_id`` (or, for legacy
+      receipts, ``cmd_id`` — the same fallback ``receipt_provenance.
+      find_receipts_by_dispatch`` already applies) in ``t0_receipts.ndjson``.
+      Matched on the FIELD, never a substring of the raw ledger text: a
+      receipt's ``branch`` field routinely contains another dispatch's slug
+      (e.g. a ``review_gate_request`` receipt for gate dispatch
+      ``20260811c-gate-pr1454`` carries
+      ``branch: dispatch/20260811c-a-freshinstall-hookpins``) — a substring
+      search over raw lines would call that a hit for the branch's dispatch,
+      when no receipt anywhere carries that ``dispatch_id``.
+
+  pull_cursor — the age of ``receipt_pull_cursor.json`` (ADR-035 §5.3: the
+      PULL that replaced the retired T0-pane push, DISPATCH_RULES §13's step
+      0 of every T0 cycle) and the unread backlog behind it. Read via the
+      same byte-cursor primitive ``receipt_query.py``'s ``pull --peek`` uses
+      (``load_cursor`` + ``pull_new_receipts``) — this module never calls
+      ``save_cursor``, so the cursor position on disk is provably unchanged
+      by a health run.
+
+  chain_status — the existing ``ndjson_hash_chain.verify_chain`` outcome,
+      with ``unchained`` reported as its own explicit class rather than
+      folded into "ok". ``audit_chain.py verify`` already reports
+      ``verified: true`` / ``status: "unchained"`` for a ledger with no
+      ``prev_hash`` entries at all — correct in isolation (chaining is
+      default-off fleet-wide), but a consumer that reads only ``verified``
+      sees a green checkmark for a ledger integrity CANNOT be verified on.
+      Absence of evidence is not evidence of absence.
+
+Exit codes: 0 all healthy, 1 findings, 2 cannot measure (a required file is
+missing or unreadable) — mirrors ``pre_merge_gate.py``'s ``SKIPPED_UNVERIFIED``
+(#1468): an unmeasurable state is never conflated with a pass, and outranks a
+finding in the overall rollup.
+
+Out of scope (by dispatch instruction, not an oversight): does not enable
+``VNX_CHAIN_RECEIPTS``, does not run the pull cadence automatically, does not
+write receipts. Read-only on state; the only write this module performs is
+its own atomic health beacon under ``<data_dir>/health/ledger_health.json``.
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import time
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Set, Tuple
+
+SCRIPT_DIR = Path(__file__).resolve().parent
+LIB_DIR = SCRIPT_DIR / "lib"
+if str(LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(LIB_DIR))
+
+from ndjson_hash_chain import verify_chain  # noqa: E402
+from receipt_query import CURSOR_NAME, load_cursor, pull_new_receipts  # noqa: E402
+
+REGISTER_NAME = "dispatch_register.ndjson"
+LEDGER_NAME = "t0_receipts.ndjson"
+COMPONENT_NAME = "ledger_health"
+
+# ADR-035 §5.3 made PULL step 0 of every T0 cycle; an active project runs
+# several T0 cycles a day. A cursor untouched for a full day/night cycle has
+# stopped advancing, not just gone quiet between sessions — the measured
+# incident this tool exists for (cursor stuck since 21 June, 16,292 unread
+# receipts) was months stale, not hours; 24h catches a dead cadence early
+# without paging on a single quiet evening.
+DEFAULT_CURSOR_STALE_HOURS = 24.0
+
+# Beacon refresh cadence (health_beacon.py convention — e.g. plan-gate-panel.json
+# also uses 86400 for a manually/periodically-triggered component). Wiring an
+# automatic run cadence is explicitly out of scope for this dispatch; the
+# interval only lets any FUTURE periodic caller's beacon read as "stale" if
+# nobody reruns this tool, rather than trusting an arbitrarily old snapshot
+# forever (health_beacon.all_beacons semantics).
+BEACON_EXPECTED_INTERVAL_SECONDS = 86400
+
+STATUS_OK = "ok"
+STATUS_FINDING = "finding"
+# Mirrors pre_merge_gate.py's SKIPPED_UNVERIFIED (#1468, OI-1140): a check
+# that could not read what it needed to is never a pass.
+SKIPPED_UNVERIFIED = "SKIPPED_UNVERIFIED"
+
+EXIT_OK = 0
+EXIT_FINDINGS = 1
+EXIT_UNMEASURABLE = 2
+
+
+def _chain_receipts_configured() -> bool:
+    """Same truthy predicate as ``append_receipt_internals.idempotency.
+    _chain_receipts_enabled`` (1/true/yes/on, case-insensitive) — duplicated
+    as a two-line env read rather than importing another subsystem's
+    ``_internals`` package for one predicate."""
+    value = os.environ.get("VNX_CHAIN_RECEIPTS", "")
+    return value.strip().lower() in ("1", "true", "yes", "on")
+
+
+def _read_unique_dispatch_ids(path: Path, *, include_cmd_id: bool = False) -> Tuple[Set[str], int, int]:
+    """Collect the set of distinct ``dispatch_id`` values from an NDJSON file.
+
+    Field match only — never a substring/text search. When ``include_cmd_id``
+    is set, a line missing ``dispatch_id`` but carrying ``cmd_id`` counts under
+    ``cmd_id`` too (the same fallback ``receipt_provenance.
+    find_receipts_by_dispatch`` applies to legacy receipts).
+
+    Returns ``(ids, total_lines, parse_errors)``. Raises ``OSError`` if the
+    file cannot be opened/read (caller maps that to ``SKIPPED_UNVERIFIED`` —
+    a read failure is "cannot measure", not "zero matches").
+    """
+    ids: Set[str] = set()
+    total = 0
+    errors = 0
+    with path.open("r", encoding="utf-8", errors="replace") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            total += 1
+            try:
+                rec = json.loads(line)
+            except json.JSONDecodeError:
+                errors += 1
+                continue
+            if not isinstance(rec, dict):
+                errors += 1
+                continue
+            did = rec.get("dispatch_id")
+            if not did and include_cmd_id:
+                did = rec.get("cmd_id")
+            if did:
+                ids.add(str(did))
+    return ids, total, errors
+
+
+def check_receipt_coverage(state_dir: Path) -> Dict[str, Any]:
+    """Every dispatch_id the register knows about must have a matching receipt."""
+    register_path = state_dir / REGISTER_NAME
+    ledger_path = state_dir / LEDGER_NAME
+
+    if not register_path.exists():
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"register not found: {register_path}"}
+    if not ledger_path.exists():
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"receipts ledger not found: {ledger_path}"}
+
+    try:
+        register_ids, register_lines, register_errors = _read_unique_dispatch_ids(register_path)
+        receipt_ids, receipt_lines, receipt_errors = _read_unique_dispatch_ids(
+            ledger_path, include_cmd_id=True
+        )
+    except OSError as exc:
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read ledger/register: {exc}"}
+
+    missing = sorted(register_ids - receipt_ids)
+
+    return {
+        "status": STATUS_FINDING if missing else STATUS_OK,
+        "register_dispatch_count": len(register_ids),
+        "receipted_dispatch_count": len(receipt_ids),
+        "missing_receipt_count": len(missing),
+        "missing_receipt_dispatch_ids": missing,
+        "register_lines": register_lines,
+        "register_parse_errors": register_errors,
+        "receipt_lines": receipt_lines,
+        "receipt_parse_errors": receipt_errors,
+    }
+
+
+def check_pull_cursor(
+    state_dir: Path,
+    *,
+    stale_hours: float = DEFAULT_CURSOR_STALE_HOURS,
+) -> Dict[str, Any]:
+    """Age of receipt_pull_cursor.json plus the unread backlog behind it.
+
+    Never advances the cursor: reads the offset with ``receipt_query.
+    load_cursor`` and the backlog with ``receipt_query.pull_new_receipts``,
+    but never calls ``save_cursor`` — the same non-mutating contract
+    ``receipt_query.py pull --peek`` gives its callers.
+    """
+    ledger_path = state_dir / LEDGER_NAME
+    cursor_path = state_dir / CURSOR_NAME
+
+    if not ledger_path.exists():
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"receipts ledger not found: {ledger_path}"}
+
+    try:
+        ledger_size = ledger_path.stat().st_size
+    except OSError as exc:
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"could not stat receipts ledger: {exc}"}
+
+    if not cursor_path.exists():
+        if ledger_size == 0:
+            return {
+                "status": STATUS_OK,
+                "cursor_path": str(cursor_path),
+                "cursor_exists": False,
+                "cursor_offset": 0,
+                "cursor_age_seconds": None,
+                "ledger_size_bytes": 0,
+                "backlog_bytes": 0,
+                "backlog_receipt_count": 0,
+                "stale_threshold_hours": stale_hours,
+                "reason": "no cursor yet, but the ledger is empty — nothing to pull",
+            }
+        return {
+            "status": STATUS_FINDING,
+            "cursor_path": str(cursor_path),
+            "cursor_exists": False,
+            "cursor_offset": 0,
+            "cursor_age_seconds": None,
+            "ledger_size_bytes": ledger_size,
+            "backlog_bytes": ledger_size,
+            "backlog_receipt_count": None,
+            "stale_threshold_hours": stale_hours,
+            "reason": "receipt_pull_cursor.json does not exist — the pull cadence (ADR-035 "
+                      "§5.3 / DISPATCH_RULES §13) has never run against this ledger",
+        }
+
+    try:
+        cursor_offset = load_cursor(cursor_path)
+        cursor_mtime = cursor_path.stat().st_mtime
+    except OSError as exc:
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read cursor: {exc}"}
+
+    age_seconds = max(0.0, time.time() - cursor_mtime)
+    truncated = ledger_size < cursor_offset
+
+    try:
+        backlog_receipts, advanceable_offset = pull_new_receipts(ledger_path, cursor_offset)
+    except OSError as exc:
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read receipts ledger: {exc}"}
+
+    effective_offset = 0 if truncated else cursor_offset
+    backlog_bytes = max(0, advanceable_offset - effective_offset)
+
+    stale = age_seconds > (stale_hours * 3600.0)
+
+    return {
+        "status": STATUS_FINDING if stale else STATUS_OK,
+        "cursor_path": str(cursor_path),
+        "cursor_exists": True,
+        "cursor_offset": cursor_offset,
+        "cursor_age_seconds": round(age_seconds, 1),
+        "ledger_size_bytes": ledger_size,
+        "backlog_bytes": backlog_bytes,
+        "backlog_receipt_count": len(backlog_receipts),
+        "ledger_truncated_since_cursor": truncated,
+        "stale_threshold_hours": stale_hours,
+        "reason": (
+            f"cursor is {round(age_seconds / 3600.0, 1)}h old, past the {stale_hours}h threshold"
+            if stale else None
+        ),
+    }
+
+
+def check_chain_status(state_dir: Path) -> Dict[str, Any]:
+    """Wraps ndjson_hash_chain.verify_chain; ``unchained`` is its own class.
+
+    A ledger with no ``prev_hash`` entries is the current, accepted, fleet-wide
+    default (``VNX_CHAIN_RECEIPTS`` off) — that alone is not a finding, or
+    every project would fail this check by default. It becomes a finding only
+    when ``VNX_CHAIN_RECEIPTS`` is configured on for THIS process yet the
+    ledger still carries no chain: the config and the ledger disagree.
+    """
+    ledger_path = state_dir / LEDGER_NAME
+    if not ledger_path.exists():
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"receipts ledger not found: {ledger_path}"}
+
+    try:
+        ok, violations, chain_state = verify_chain(ledger_path)
+    except OSError as exc:
+        return {"status": SKIPPED_UNVERIFIED, "reason": f"could not read receipts ledger: {exc}"}
+
+    configured = _chain_receipts_configured()
+
+    if chain_state == "broken":
+        return {
+            "status": STATUS_FINDING,
+            "chain_state": chain_state,
+            "chain_receipts_configured": configured,
+            "violation_count": len(violations),
+            "violations_sample": violations[:5],
+        }
+
+    if chain_state == "unchained":
+        return {
+            "status": STATUS_FINDING if configured else STATUS_OK,
+            "chain_state": chain_state,
+            "chain_receipts_configured": configured,
+            "reason": (
+                "VNX_CHAIN_RECEIPTS is configured on but the ledger carries no prev_hash "
+                "entries — chaining is not actually active on this ledger"
+                if configured else
+                "no entry carries prev_hash; integrity cannot be verified from this ledger "
+                "alone. Not a defect while VNX_CHAIN_RECEIPTS stays fleet-default off — "
+                "absence of evidence is not evidence of absence, so this is its own class, "
+                "never folded into 'ok'"
+            ),
+        }
+
+    # "verified" / "verified-segmented"
+    return {
+        "status": STATUS_OK,
+        "chain_state": chain_state,
+        "chain_receipts_configured": configured,
+    }
+
+
+def compute_health(
+    data_dir: Path,
+    state_dir: Path,
+    *,
+    cursor_stale_hours: float = DEFAULT_CURSOR_STALE_HOURS,
+) -> Dict[str, Any]:
+    """Run all three checks read-only. Pure function: no writes, no mutation."""
+    checks = {
+        "receipt_coverage": check_receipt_coverage(state_dir),
+        "pull_cursor": check_pull_cursor(state_dir, stale_hours=cursor_stale_hours),
+        "chain_status": check_chain_status(state_dir),
+    }
+
+    statuses = {c["status"] for c in checks.values()}
+    if SKIPPED_UNVERIFIED in statuses:
+        overall = SKIPPED_UNVERIFIED
+    elif STATUS_FINDING in statuses:
+        overall = STATUS_FINDING
+    else:
+        overall = STATUS_OK
+
+    exit_code = {STATUS_OK: EXIT_OK, STATUS_FINDING: EXIT_FINDINGS, SKIPPED_UNVERIFIED: EXIT_UNMEASURABLE}[overall]
+
+    return {
+        "component": COMPONENT_NAME,
+        "data_dir": str(data_dir),
+        "state_dir": str(state_dir),
+        "overall_status": overall,
+        "exit_code": exit_code,
+        "cursor_stale_hours_threshold": cursor_stale_hours,
+        "checks": checks,
+    }
+
+
+def write_health_surface(data_dir: Path, result: Dict[str, Any]) -> Path:
+    """Atomically persist ``result`` as the ledger_health beacon.
+
+    Reuses ``health_beacon.HealthBeacon`` — the same fcntl-locked
+    tmp-write-then-``os.replace`` primitive every other component beacon
+    under ``<data_dir>/health/`` already uses (t0_state_builder.json,
+    plan-gate-panel.json, ...), so a reader gets the same all-or-nothing
+    guarantee for this beacon it gets for any other.
+    """
+    from health_beacon import HealthBeacon
+
+    beacon = HealthBeacon(
+        data_dir, COMPONENT_NAME, expected_interval_seconds=BEACON_EXPECTED_INTERVAL_SECONDS
+    )
+    status = "ok" if result["overall_status"] == STATUS_OK else "fail"
+    beacon.heartbeat_strict(status=status, details=result)
+    return beacon.path
+
+
+def read_health_surface(data_dir: Path) -> Optional[Dict[str, Any]]:
+    """Read a previously-written ledger_health beacon. None if absent/unreadable.
+
+    Consumed by ``vnx doctor`` (delegation seam — see ``vnx_cli/commands/
+    doctor.py``'s ``_check_ledger_health``) so the doctor check never
+    duplicates this module's threshold logic.
+    """
+    path = Path(data_dir) / "health" / f"{COMPONENT_NAME}.json"
+    if not path.exists():
+        return None
+    try:
+        with path.open("r", encoding="utf-8") as fh:
+            data = json.load(fh)
+    except (OSError, ValueError):
+        return None
+    return data if isinstance(data, dict) else None
+
+
+def _resolve_default_dirs() -> Tuple[Path, Path]:
+    """Ambient resolution via the canonical resolver — never a hardcoded
+    ``.vnx-data/`` path (project CLAUDE.md)."""
+    lib_dir = str(SCRIPT_DIR / "lib")
+    if lib_dir not in sys.path:
+        sys.path.insert(0, lib_dir)
+    from vnx_paths import resolve_paths
+
+    paths = resolve_paths()
+    return Path(paths["VNX_DATA_DIR"]), Path(paths["VNX_STATE_DIR"])
+
+
+def _format_human(result: Dict[str, Any]) -> str:
+    lines = [f"ledger_health: {result['overall_status']} (exit {result['exit_code']})"]
+    for name, check in result["checks"].items():
+        status = check["status"]
+        reason = check.get("reason") or ""
+        lines.append(f"  {name}: {status}" + (f" — {reason}" if reason else ""))
+        if name == "receipt_coverage" and check.get("missing_receipt_count"):
+            for did in check["missing_receipt_dispatch_ids"]:
+                lines.append(f"    - {did}")
+    return "\n".join(lines)
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Reconcile dispatch_register.ndjson against t0_receipts.ndjson "
+                     "(coverage, pull-cursor freshness, chain status). Read-only on state.",
+    )
+    parser.add_argument("--data-dir", default=None, help="override VNX_DATA_DIR (default: ambient resolution)")
+    parser.add_argument("--state-dir", default=None, help="override VNX_STATE_DIR (default: ambient resolution)")
+    parser.add_argument(
+        "--cursor-stale-hours", type=float, default=DEFAULT_CURSOR_STALE_HOURS,
+        help=f"pull-cursor age threshold in hours (default: {DEFAULT_CURSOR_STALE_HOURS})",
+    )
+    parser.add_argument("--json", action="store_true", help="emit machine-readable JSON")
+    parser.add_argument(
+        "--no-write", action="store_true",
+        help="do not write the health/ledger_health.json beacon (measure + print only)",
+    )
+    args = parser.parse_args(argv)
+
+    default_data_dir, default_state_dir = (None, None)
+    if args.data_dir is None or args.state_dir is None:
+        default_data_dir, default_state_dir = _resolve_default_dirs()
+
+    data_dir = Path(args.data_dir) if args.data_dir else default_data_dir
+    state_dir = Path(args.state_dir) if args.state_dir else default_state_dir
+
+    result = compute_health(data_dir, state_dir, cursor_stale_hours=args.cursor_stale_hours)
+
+    if not args.no_write:
+        write_health_surface(data_dir, result)
+
+    if args.json:
+        print(json.dumps(result, indent=2))
+    else:
+        print(_format_human(result))
+
+    return result["exit_code"]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_ledger_health.py
+++ b/tests/test_ledger_health.py
@@ -1,0 +1,414 @@
+#!/usr/bin/env python3
+"""Tests for scripts/ledger_health.py (dispatch 20260812d-a-ledger-health).
+
+Covers the three read-only checks (receipt coverage, pull-cursor freshness,
+chain status), the atomic health-surface write/read round-trip, and the CLI.
+
+The headline regression this file exists to prove: a substring search over
+the raw receipts ledger gives a FALSE POSITIVE for dispatch coverage when a
+receipt's ``branch`` field happens to contain another dispatch's slug (the
+exact shape measured in the real ledger for PR #1454/#1455's gate receipts —
+``dispatch_id: "20260811c-gate-pr1454"``, ``branch:
+"dispatch/20260811c-a-freshinstall-hookpins"``). ``check_receipt_coverage``
+must report that dispatch as missing a receipt; a naive substring check would
+not.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+import time
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+SCRIPTS_LIB = SCRIPTS_DIR / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+sys.path.insert(0, str(SCRIPTS_DIR))
+
+import ledger_health as lh  # noqa: E402
+from ndjson_hash_chain import append_chained_entry  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_ndjson(path: Path, *records: dict) -> None:
+    lines = [json.dumps(r) for r in records]
+    text = "\n".join(lines)
+    if records:
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+def _register_entry(dispatch_id: str, event: str = "dispatch_started") -> dict:
+    return {"timestamp": "2026-08-11T10:00:00Z", "event": event, "dispatch_id": dispatch_id}
+
+
+def _receipt(dispatch_id: str, **overrides) -> dict:
+    rec = {
+        "timestamp": "2026-08-11T10:05:00Z",
+        "event_type": "task_complete",
+        "dispatch_id": dispatch_id,
+        "status": "success",
+    }
+    rec.update(overrides)
+    return rec
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# receipt_coverage
+# ---------------------------------------------------------------------------
+
+
+class TestReceiptCoverage:
+    def test_all_covered_is_ok(self, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"), _register_entry("d-002"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"), _receipt("d-002"))
+
+        result = lh.check_receipt_coverage(state_dir)
+
+        assert result["status"] == lh.STATUS_OK
+        assert result["missing_receipt_count"] == 0
+        assert result["missing_receipt_dispatch_ids"] == []
+
+    def test_missing_receipt_is_a_finding(self, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"), _register_entry("d-orphan"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+
+        result = lh.check_receipt_coverage(state_dir)
+
+        assert result["status"] == lh.STATUS_FINDING
+        assert result["missing_receipt_dispatch_ids"] == ["d-orphan"]
+
+    def test_substring_trap_branch_field_is_not_a_false_match(self, state_dir):
+        """The exact shape measured in the real ledger (#1454/#1455): a gate
+        receipt's dispatch_id is its OWN id, but its ``branch`` field embeds
+        the slug of the dispatch that was actually fired and merged. Field
+        match must call that dispatch missing; substring match would not.
+        """
+        target_dispatch_id = "20260811c-a-freshinstall-hookpins"
+        gate_receipt = _receipt(
+            "20260811c-gate-pr1454",
+            event_type="review_gate_request",
+            branch=f"dispatch/{target_dispatch_id}",
+        )
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry(target_dispatch_id))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, gate_receipt)
+
+        # Prove the substring trap is real: a naive text search over the raw
+        # ledger DOES find a "hit" for the target dispatch id.
+        raw_ledger_text = (state_dir / lh.LEDGER_NAME).read_text(encoding="utf-8")
+        assert target_dispatch_id in raw_ledger_text, (
+            "fixture is wrong — the substring trap this test defends against isn't present"
+        )
+
+        # The field-matching tool must NOT be fooled by it.
+        result = lh.check_receipt_coverage(state_dir)
+        assert result["status"] == lh.STATUS_FINDING
+        assert target_dispatch_id in result["missing_receipt_dispatch_ids"]
+
+    def test_legacy_cmd_id_fallback_counts_as_covered(self, state_dir):
+        """Mirrors receipt_provenance.find_receipts_by_dispatch's cmd_id fallback."""
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-legacy"))
+        _write_ndjson(
+            state_dir / lh.LEDGER_NAME,
+            {"timestamp": "2026-08-11T10:05:00Z", "cmd_id": "d-legacy", "status": "success"},
+        )
+
+        result = lh.check_receipt_coverage(state_dir)
+        assert result["status"] == lh.STATUS_OK
+
+    def test_malformed_lines_are_skipped_not_fatal(self, state_dir):
+        register_path = state_dir / lh.REGISTER_NAME
+        register_path.write_text(
+            json.dumps(_register_entry("d-001")) + "\n" + "{not json\n", encoding="utf-8"
+        )
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+
+        result = lh.check_receipt_coverage(state_dir)
+        assert result["status"] == lh.STATUS_OK
+        assert result["register_parse_errors"] == 1
+
+    def test_missing_register_is_unmeasurable(self, state_dir):
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        result = lh.check_receipt_coverage(state_dir)
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
+
+    def test_missing_ledger_is_unmeasurable(self, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        result = lh.check_receipt_coverage(state_dir)
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# pull_cursor
+# ---------------------------------------------------------------------------
+
+
+class TestPullCursor:
+    def test_fresh_cursor_is_ok(self, state_dir):
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        cursor_path = state_dir / lh.CURSOR_NAME
+        cursor_path.write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        result = lh.check_pull_cursor(state_dir, stale_hours=24.0)
+
+        assert result["status"] == lh.STATUS_OK
+        assert result["cursor_age_seconds"] < 5.0
+
+    def test_stale_cursor_is_a_finding(self, state_dir):
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        cursor_path = state_dir / lh.CURSOR_NAME
+        cursor_path.write_text(json.dumps({"offset": 0}), encoding="utf-8")
+        old = time.time() - (25 * 3600)  # 25h old, past the 24h default threshold
+        os.utime(cursor_path, (old, old))
+
+        result = lh.check_pull_cursor(state_dir, stale_hours=24.0)
+
+        assert result["status"] == lh.STATUS_FINDING
+        assert result["cursor_age_seconds"] > 24 * 3600
+
+    def test_never_pulled_nonempty_ledger_is_a_finding(self, state_dir):
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        result = lh.check_pull_cursor(state_dir)
+        assert result["status"] == lh.STATUS_FINDING
+        assert result["cursor_exists"] is False
+
+    def test_never_pulled_empty_ledger_is_ok(self, state_dir):
+        (state_dir / lh.LEDGER_NAME).write_text("", encoding="utf-8")
+        result = lh.check_pull_cursor(state_dir)
+        assert result["status"] == lh.STATUS_OK
+
+    def test_never_mutates_cursor_on_disk(self, state_dir):
+        """Hard requirement (dispatch instruction): this check must NEVER
+        advance the cursor. Byte-for-byte identical before and after."""
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"), _receipt("d-002"))
+        cursor_path = state_dir / lh.CURSOR_NAME
+        cursor_path.write_text(json.dumps({"offset": 0}), encoding="utf-8")
+
+        before_bytes = cursor_path.read_bytes()
+        before_mtime = cursor_path.stat().st_mtime
+
+        result = lh.check_pull_cursor(state_dir)
+
+        after_bytes = cursor_path.read_bytes()
+        after_mtime = cursor_path.stat().st_mtime
+
+        assert before_bytes == after_bytes
+        assert before_mtime == after_mtime
+        assert result["backlog_receipt_count"] == 2
+
+    def test_truncated_ledger_since_cursor_is_flagged(self, state_dir):
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        cursor_path = state_dir / lh.CURSOR_NAME
+        # Offset far beyond the (small) ledger — simulates a rotated/truncated ledger.
+        cursor_path.write_text(json.dumps({"offset": 10_000_000}), encoding="utf-8")
+
+        result = lh.check_pull_cursor(state_dir)
+
+        assert result["ledger_truncated_since_cursor"] is True
+
+    def test_missing_ledger_is_unmeasurable(self, state_dir):
+        result = lh.check_pull_cursor(state_dir)
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# chain_status
+# ---------------------------------------------------------------------------
+
+
+class TestChainStatus:
+    def test_unchained_default_config_is_ok_but_its_own_class(self, state_dir, monkeypatch):
+        monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+
+        result = lh.check_chain_status(state_dir)
+
+        assert result["chain_state"] == "unchained"
+        assert result["status"] == lh.STATUS_OK
+
+    def test_unchained_while_configured_on_is_a_finding(self, state_dir, monkeypatch):
+        monkeypatch.setenv("VNX_CHAIN_RECEIPTS", "1")
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+
+        result = lh.check_chain_status(state_dir)
+
+        assert result["chain_state"] == "unchained"
+        assert result["status"] == lh.STATUS_FINDING
+
+    def test_verified_chain_is_ok(self, state_dir, monkeypatch):
+        monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+        ledger_path = state_dir / lh.LEDGER_NAME
+        for i in range(3):
+            append_chained_entry(ledger_path, {"seq": i, "dispatch_id": f"d-{i:03d}"})
+
+        result = lh.check_chain_status(state_dir)
+
+        assert result["chain_state"] == "verified"
+        assert result["status"] == lh.STATUS_OK
+
+    def test_broken_chain_is_a_finding(self, state_dir):
+        ledger_path = state_dir / lh.LEDGER_NAME
+        append_chained_entry(ledger_path, {"event": "e1", "id": "1"})
+        append_chained_entry(ledger_path, {"event": "e2", "id": "2"})
+
+        lines = ledger_path.read_text().splitlines()
+        tampered = json.loads(lines[0])
+        tampered["id"] = "TAMPERED"
+        lines[0] = json.dumps(tampered)
+        ledger_path.write_text("\n".join(lines) + "\n")
+
+        result = lh.check_chain_status(state_dir)
+
+        assert result["chain_state"] == "broken"
+        assert result["status"] == lh.STATUS_FINDING
+
+    def test_missing_ledger_is_unmeasurable(self, state_dir):
+        result = lh.check_chain_status(state_dir)
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
+
+
+# ---------------------------------------------------------------------------
+# compute_health — overall rollup precedence
+# ---------------------------------------------------------------------------
+
+
+class TestComputeHealth:
+    def test_all_ok_rolls_up_to_ok_exit_0(self, tmp_path, state_dir, monkeypatch):
+        monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        result = lh.compute_health(tmp_path, state_dir)
+
+        assert result["overall_status"] == lh.STATUS_OK
+        assert result["exit_code"] == lh.EXIT_OK
+
+    def test_any_finding_rolls_up_to_finding_exit_1(self, tmp_path, state_dir, monkeypatch):
+        monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"), _register_entry("d-orphan"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        result = lh.compute_health(tmp_path, state_dir)
+
+        assert result["overall_status"] == lh.STATUS_FINDING
+        assert result["exit_code"] == lh.EXIT_FINDINGS
+
+    def test_unmeasurable_outranks_finding_exit_2(self, tmp_path, state_dir):
+        # No register, no ledger at all -> every sub-check is SKIPPED_UNVERIFIED,
+        # which must win over any finding-shaped result.
+        result = lh.compute_health(tmp_path, state_dir)
+
+        assert result["overall_status"] == lh.SKIPPED_UNVERIFIED
+        assert result["exit_code"] == lh.EXIT_UNMEASURABLE
+
+
+# ---------------------------------------------------------------------------
+# health surface write/read round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestHealthSurface:
+    def test_write_then_read_round_trips(self, tmp_path, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        result = lh.compute_health(tmp_path, state_dir)
+        written_path = lh.write_health_surface(tmp_path, result)
+
+        assert written_path == tmp_path / "health" / "ledger_health.json"
+        surface = lh.read_health_surface(tmp_path)
+
+        assert surface["component"] == "ledger_health"
+        assert surface["status"] == "ok"
+        assert surface["details"]["overall_status"] == lh.STATUS_OK
+        assert "checks" in surface["details"]
+
+    def test_write_uses_fail_status_when_findings_present(self, tmp_path, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-orphan"))
+        result = lh.compute_health(tmp_path, state_dir)  # missing ledger -> SKIPPED_UNVERIFIED
+        lh.write_health_surface(tmp_path, result)
+
+        surface = lh.read_health_surface(tmp_path)
+        assert surface["status"] == "fail"
+
+    def test_read_missing_beacon_returns_none(self, tmp_path):
+        assert lh.read_health_surface(tmp_path) is None
+
+    def test_read_corrupt_beacon_returns_none(self, tmp_path):
+        health_dir = tmp_path / "health"
+        health_dir.mkdir()
+        (health_dir / "ledger_health.json").write_text("{not json", encoding="utf-8")
+        assert lh.read_health_surface(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+class TestCli:
+    def test_no_write_flag_skips_beacon(self, tmp_path, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        exit_code = lh.main([
+            "--data-dir", str(tmp_path), "--state-dir", str(state_dir), "--no-write", "--json",
+        ])
+
+        assert exit_code == lh.EXIT_OK
+        assert not (tmp_path / "health").exists()
+
+    def test_default_writes_beacon(self, tmp_path, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        exit_code = lh.main(["--data-dir", str(tmp_path), "--state-dir", str(state_dir)])
+
+        assert exit_code == lh.EXIT_OK
+        assert (tmp_path / "health" / "ledger_health.json").exists()
+
+    def test_exit_code_reflects_findings(self, tmp_path, state_dir):
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-orphan"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        exit_code = lh.main([
+            "--data-dir", str(tmp_path), "--state-dir", str(state_dir), "--no-write",
+        ])
+
+        assert exit_code == lh.EXIT_FINDINGS
+
+    def test_exit_code_2_when_unmeasurable(self, tmp_path, state_dir):
+        exit_code = lh.main([
+            "--data-dir", str(tmp_path), "--state-dir", str(state_dir), "--no-write",
+        ])
+        assert exit_code == lh.EXIT_UNMEASURABLE

--- a/tests/test_ledger_health.py
+++ b/tests/test_ledger_health.py
@@ -133,7 +133,11 @@ class TestReceiptCoverage:
         result = lh.check_receipt_coverage(state_dir)
         assert result["status"] == lh.STATUS_OK
 
-    def test_malformed_lines_are_skipped_not_fatal(self, state_dir):
+    def test_malformed_lines_do_not_crash_the_check(self, state_dir):
+        """A malformed line must never raise — but (regression, dispatch
+        20260812d-c) it must also never let the check report STATUS_OK: a
+        corrupt register line could be hiding a dispatch_id that has no
+        receipt at all, which this check would then never see."""
         register_path = state_dir / lh.REGISTER_NAME
         register_path.write_text(
             json.dumps(_register_entry("d-001")) + "\n" + "{not json\n", encoding="utf-8"
@@ -141,8 +145,46 @@ class TestReceiptCoverage:
         _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
 
         result = lh.check_receipt_coverage(state_dir)
-        assert result["status"] == lh.STATUS_OK
         assert result["register_parse_errors"] == 1
+        assert result["status"] != lh.STATUS_OK
+
+    def test_corrupt_register_line_with_no_missing_receipts_is_not_ok(self, state_dir):
+        """Regression (dispatch 20260812d-c): on the pre-fix branch this case
+        reported STATUS_OK because ``missing`` came back empty — the parse
+        error itself never touched the status. A corrupt register line means
+        the register was NOT fully read, so coverage cannot be certified as
+        OK even when every dispatch_id that DID parse has a receipt.
+        """
+        register_path = state_dir / lh.REGISTER_NAME
+        register_path.write_text(
+            json.dumps(_register_entry("d-001")) + "\n" + "{not json\n", encoding="utf-8"
+        )
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+
+        result = lh.check_receipt_coverage(state_dir)
+
+        assert result["missing_receipt_count"] == 0
+        assert result["register_parse_errors"] == 1
+        assert result["status"] != lh.STATUS_OK
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
+
+    def test_corrupt_receipt_line_is_not_ok(self, state_dir):
+        """Regression (dispatch 20260812d-c): the same blind spot on the
+        receipts side. A malformed line in ``t0_receipts.ndjson`` could be
+        hiding the exact receipt that would clear a dispatch off `missing` —
+        or hiding nothing. Either way, coverage cannot be certified.
+        """
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        ledger_path = state_dir / lh.LEDGER_NAME
+        ledger_path.write_text(
+            json.dumps(_receipt("d-001")) + "\n" + "{not json\n", encoding="utf-8"
+        )
+
+        result = lh.check_receipt_coverage(state_dir)
+
+        assert result["receipt_parse_errors"] == 1
+        assert result["status"] != lh.STATUS_OK
+        assert result["status"] == lh.SKIPPED_UNVERIFIED
 
     def test_missing_register_is_unmeasurable(self, state_dir):
         _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
@@ -223,6 +265,54 @@ class TestPullCursor:
         result = lh.check_pull_cursor(state_dir)
 
         assert result["ledger_truncated_since_cursor"] is True
+        assert result["status"] == lh.STATUS_FINDING
+
+    def test_truncated_ledger_is_not_ok_even_when_cursor_is_fresh(self, state_dir):
+        """Regression (dispatch 20260812d-c): on the pre-fix branch a fresh
+        (non-stale) cursor masked truncation entirely — ``truncated`` was
+        computed and reported but never touched ``status``, so a rotated/
+        truncated ledger read as STATUS_OK as long as the cursor file itself
+        was young. Truncation is a finding on its own, independent of age.
+        """
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        cursor_path = state_dir / lh.CURSOR_NAME
+        cursor_path.write_text(json.dumps({"offset": 10_000_000}), encoding="utf-8")
+        # cursor_path.write_text() just now => age_seconds ~0, nowhere near stale.
+
+        result = lh.check_pull_cursor(state_dir, stale_hours=24.0)
+
+        assert result["cursor_age_seconds"] < 5.0
+        assert result["status"] != lh.STATUS_OK
+        assert result["status"] == lh.STATUS_FINDING
+
+    def test_corrupt_cursor_file_is_not_ok_and_distinct_from_offset_zero(self, state_dir):
+        """Regression (dispatch 20260812d-c): ``receipt_query.load_cursor``
+        silently coerces a corrupt/unparseable cursor file to offset 0 — the
+        SAME value a legitimate "cursor genuinely at byte 0" produces. Before
+        the fix, ``ledger_health`` inherited that collapse and could report
+        STATUS_OK on a cursor it could not actually read. A corrupt cursor
+        must be its own outcome, not silently treated as a measured zero.
+        """
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        cursor_path = state_dir / lh.CURSOR_NAME
+        cursor_path.write_text("{not valid json at all", encoding="utf-8")
+
+        corrupt_result = lh.check_pull_cursor(state_dir, stale_hours=24.0)
+
+        assert corrupt_result["status"] != lh.STATUS_OK
+        assert corrupt_result["status"] == lh.SKIPPED_UNVERIFIED
+        assert corrupt_result["cursor_corrupt"] is True
+
+        # A legitimate offset of 0 against an empty (nothing-to-pull) ledger
+        # is a materially different, healthy outcome — proves the two are
+        # distinguished rather than both collapsing to "offset 0, fine".
+        cursor_path.write_text(json.dumps({"offset": 0}), encoding="utf-8")
+        (state_dir / lh.LEDGER_NAME).write_text("", encoding="utf-8")
+        legit_result = lh.check_pull_cursor(state_dir, stale_hours=24.0)
+
+        assert legit_result["cursor_corrupt"] is False
+        assert legit_result["cursor_offset"] == 0
+        assert legit_result["status"] == lh.STATUS_OK
 
     def test_missing_ledger_is_unmeasurable(self, state_dir):
         result = lh.check_pull_cursor(state_dir)
@@ -320,6 +410,32 @@ class TestComputeHealth:
         # which must win over any finding-shaped result.
         result = lh.compute_health(tmp_path, state_dir)
 
+        assert result["overall_status"] == lh.SKIPPED_UNVERIFIED
+        assert result["exit_code"] == lh.EXIT_UNMEASURABLE
+
+    def test_single_subcheck_parse_error_rolls_up_to_unverifiable_exit_2(
+        self, tmp_path, state_dir, monkeypatch
+    ):
+        """Regression (dispatch 20260812d-c): a parse error in ONE sub-check
+        (receipt_coverage) must not get diluted by two otherwise-healthy
+        sub-checks. compute_health's own SKIPPED_UNVERIFIED-outranks-FINDING
+        rollup already existed pre-fix; what's new is that a corrupt line
+        alone (no missing receipts, no stale cursor, no chain finding) now
+        actually produces that SKIPPED_UNVERIFIED in the first place.
+        """
+        monkeypatch.delenv("VNX_CHAIN_RECEIPTS", raising=False)
+        register_path = state_dir / lh.REGISTER_NAME
+        register_path.write_text(
+            json.dumps(_register_entry("d-001")) + "\n" + "{not json\n", encoding="utf-8"
+        )
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(json.dumps({"offset": ledger_size}), encoding="utf-8")
+
+        result = lh.compute_health(tmp_path, state_dir)
+
+        assert result["checks"]["receipt_coverage"]["status"] == lh.SKIPPED_UNVERIFIED
+        assert result["checks"]["pull_cursor"]["status"] == lh.STATUS_OK
         assert result["overall_status"] == lh.SKIPPED_UNVERIFIED
         assert result["exit_code"] == lh.EXIT_UNMEASURABLE
 

--- a/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
+++ b/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
@@ -98,6 +98,32 @@ class TestCheckLedgerHealth:
         assert result.status == WARN
         assert "corrupt" in result.detail.lower()
 
+    def test_corrupt_register_line_is_warn_not_pass(self, tmp_path):
+        """Regression (dispatch 20260812d-c): a corrupt line in
+        dispatch_register.ndjson with zero missing receipts used to make
+        ``check_receipt_coverage`` report STATUS_OK, so doctor would PASS on
+        a register it never fully read. It must now surface as WARN via the
+        SKIPPED_UNVERIFIED branch, the same as any other unmeasurable state.
+        """
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        (state_dir / lh.REGISTER_NAME).write_text(
+            __import__("json").dumps(_register_entry("d-001")) + "\n" + "{not json\n",
+            encoding="utf-8",
+        )
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(
+            __import__("json").dumps({"offset": ledger_size}), encoding="utf-8"
+        )
+
+        computed = lh.compute_health(tmp_path, state_dir)
+        lh.write_health_surface(tmp_path, computed)
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "unmeasurable" in result.detail
+
     def test_stale_beacon_is_warn(self, tmp_path, monkeypatch):
         """A beacon older than its expected_interval_seconds is stale
         regardless of the status it recorded at write time (health_beacon

--- a/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
+++ b/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
@@ -9,7 +9,9 @@ never fabricate a FAIL when the beacon simply hasn't been run yet.
 
 from __future__ import annotations
 
+import json
 import sys
+import time
 from pathlib import Path
 
 VNX_ROOT = Path(__file__).resolve().parents[4]
@@ -18,6 +20,26 @@ sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
 
 import ledger_health as lh  # noqa: E402
 from vnx_cli.commands.doctor import PASS, WARN, _check_ledger_health  # noqa: E402
+
+_NO_DETAILS = object()
+
+
+def _write_raw_beacon(tmp_path: Path, *, status: str, details=_NO_DETAILS, expected_interval_seconds=86400) -> None:
+    """Write a ledger_health beacon file directly, bypassing compute_health/
+    write_health_surface, so a test can force a ``details`` shape that the
+    real writer would never produce (missing, empty, or malformed)."""
+    health_dir = tmp_path / "health"
+    health_dir.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "component": lh.COMPONENT_NAME,
+        "last_run_ts": time.time(),
+        "last_run_iso": "2026-08-12T00:00:00Z",
+        "status": status,
+        "expected_interval_seconds": expected_interval_seconds,
+    }
+    if details is not _NO_DETAILS:
+        payload["details"] = details
+    (health_dir / f"{lh.COMPONENT_NAME}.json").write_text(json.dumps(payload), encoding="utf-8")
 
 
 def _register_entry(dispatch_id: str) -> dict:
@@ -148,3 +170,48 @@ class TestCheckLedgerHealth:
         result = _check_ledger_health(tmp_path)
         assert result.status == WARN
         assert "stale" in result.detail.lower()
+
+
+class TestFailBeaconWithUnreadableDetails:
+    """Dispatch 20260812d-d: a beacon that says ``health: "fail"`` must never
+    fall through to PASS just because ``details["checks"]`` couldn't be
+    read — unknown is never healthy."""
+
+    def test_fail_beacon_missing_details_is_warn_not_pass(self, tmp_path):
+        _write_raw_beacon(tmp_path, status="fail")
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "fail" in result.detail.lower()
+
+    def test_fail_beacon_empty_checks_is_warn_not_pass(self, tmp_path):
+        _write_raw_beacon(tmp_path, status="fail", details={"checks": {}})
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "fail" in result.detail.lower()
+
+    def test_fail_beacon_malformed_checks_is_warn_not_pass(self, tmp_path):
+        _write_raw_beacon(tmp_path, status="fail", details={"checks": "not-a-dict"})
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "fail" in result.detail.lower()
+
+    def test_ok_beacon_without_findings_is_still_pass(self, tmp_path):
+        """Regression guard: a genuinely healthy beacon must not start
+        WARNing just because the fail-path got stricter."""
+        _write_raw_beacon(
+            tmp_path,
+            status="ok",
+            details={
+                "checks": {
+                    "receipt_coverage": {"status": "ok"},
+                    "pull_cursor": {"status": "ok"},
+                    "chain_status": {"status": "ok"},
+                }
+            },
+        )
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == PASS

--- a/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
+++ b/tests/unit/vnx_cli/commands/test_doctor_ledger_health.py
@@ -1,0 +1,124 @@
+#!/usr/bin/env python3
+"""Unit tests for vnx_cli/commands/doctor.py's ledger-health check.
+
+Dispatch 20260812d-a-ledger-health: ``vnx doctor`` must go loud when the
+ledger_health beacon (scripts/ledger_health.py) reports dispatches without a
+receipt, a stale pull cursor, or a chain-status contradiction — but must
+never fabricate a FAIL when the beacon simply hasn't been run yet.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+VNX_ROOT = Path(__file__).resolve().parents[4]
+sys.path.insert(0, str(VNX_ROOT / "scripts"))
+sys.path.insert(0, str(VNX_ROOT / "scripts" / "lib"))
+
+import ledger_health as lh  # noqa: E402
+from vnx_cli.commands.doctor import PASS, WARN, _check_ledger_health  # noqa: E402
+
+
+def _register_entry(dispatch_id: str) -> dict:
+    return {"timestamp": "2026-08-11T10:00:00Z", "event": "dispatch_started", "dispatch_id": dispatch_id}
+
+
+def _receipt(dispatch_id: str) -> dict:
+    return {"timestamp": "2026-08-11T10:05:00Z", "event_type": "task_complete", "dispatch_id": dispatch_id}
+
+
+def _write_ndjson(path: Path, *records: dict) -> None:
+    lines = [__import__("json").dumps(r) for r in records]
+    text = "\n".join(lines)
+    if records:
+        text += "\n"
+    path.write_text(text, encoding="utf-8")
+
+
+class TestCheckLedgerHealth:
+    def test_no_beacon_yet_is_pass_not_fail(self, tmp_path):
+        result = _check_ledger_health(tmp_path)
+        assert result.status == PASS
+        assert "ledger_health.py" in result.detail
+
+    def test_all_healthy_beacon_is_pass(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(
+            __import__("json").dumps({"offset": ledger_size}), encoding="utf-8"
+        )
+
+        computed = lh.compute_health(tmp_path, state_dir)
+        lh.write_health_surface(tmp_path, computed)
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == PASS
+
+    def test_missing_receipt_finding_is_warn_with_detail(self, tmp_path):
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-orphan"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(
+            __import__("json").dumps({"offset": ledger_size}), encoding="utf-8"
+        )
+
+        computed = lh.compute_health(tmp_path, state_dir)
+        lh.write_health_surface(tmp_path, computed)
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "no matching receipt" in result.detail
+
+    def test_unmeasurable_subcheck_is_warn_not_silently_ok(self, tmp_path):
+        """No register/ledger at all -> ledger_health itself reports
+        SKIPPED_UNVERIFIED. Doctor must surface that as WARN, never PASS —
+        an unmeasurable state is never a pass (#1468 principle)."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+
+        computed = lh.compute_health(tmp_path, state_dir)
+        lh.write_health_surface(tmp_path, computed)
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "unmeasurable" in result.detail
+
+    def test_corrupt_beacon_is_warn(self, tmp_path):
+        health_dir = tmp_path / "health"
+        health_dir.mkdir()
+        (health_dir / "ledger_health.json").write_text("{not json", encoding="utf-8")
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "corrupt" in result.detail.lower()
+
+    def test_stale_beacon_is_warn(self, tmp_path, monkeypatch):
+        """A beacon older than its expected_interval_seconds is stale
+        regardless of the status it recorded at write time (health_beacon
+        convention) — simulate by writing directly with an old last_run_ts."""
+        state_dir = tmp_path / "state"
+        state_dir.mkdir()
+        _write_ndjson(state_dir / lh.REGISTER_NAME, _register_entry("d-001"))
+        _write_ndjson(state_dir / lh.LEDGER_NAME, _receipt("d-001"))
+        ledger_size = (state_dir / lh.LEDGER_NAME).stat().st_size
+        (state_dir / lh.CURSOR_NAME).write_text(
+            __import__("json").dumps({"offset": ledger_size}), encoding="utf-8"
+        )
+        computed = lh.compute_health(tmp_path, state_dir)
+        lh.write_health_surface(tmp_path, computed)
+
+        beacon_path = tmp_path / "health" / "ledger_health.json"
+        import json as _json
+        payload = _json.loads(beacon_path.read_text(encoding="utf-8"))
+        payload["last_run_ts"] = 0  # 1970 — long past any interval
+        beacon_path.write_text(_json.dumps(payload), encoding="utf-8")
+
+        result = _check_ledger_health(tmp_path)
+        assert result.status == WARN
+        assert "stale" in result.detail.lower()

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -791,7 +791,11 @@ def _check_ledger_health(data_root: Path) -> Check:
         findings.append(f"beacon is stale ({age_str} old) — rerun ledger_health.py")
 
     details = beacon.get("details") or {}
+    if not isinstance(details, dict):
+        details = {}
     checks = details.get("checks") or {}
+    if not isinstance(checks, dict):
+        checks = {}
 
     coverage = checks.get("receipt_coverage") or {}
     if coverage.get("status") == "finding":
@@ -821,6 +825,12 @@ def _check_ledger_health(data_root: Path) -> Check:
         )
     elif chain.get("status") == "SKIPPED_UNVERIFIED":
         findings.append(f"chain-status unmeasurable: {chain.get('reason', '?')}")
+
+    if health == "fail" and not findings:
+        findings.append(
+            "ledger-health beacon reports fail, but no findings could be derived from its "
+            "details — inspect the beacon directly"
+        )
 
     if findings:
         return _result(WARN, "; ".join(findings))

--- a/vnx_cli/commands/doctor.py
+++ b/vnx_cli/commands/doctor.py
@@ -745,6 +745,88 @@ def _check_hook_paths(project_dir: Path) -> Check:
     return _result(PASS, "all referenced hook script paths resolve")
 
 
+def _check_ledger_health(data_root: Path) -> Check:
+    """WARN from the ledger_health beacon: dispatches without a receipt, a
+    stale receipt-pull cursor, or a ledger that is unchained while
+    VNX_CHAIN_RECEIPTS is configured on.
+
+    Delegates entirely to two existing modules instead of a third resolver
+    or threshold set: ``health_beacon.all_beacons`` (the same staleness/
+    corrupt classification every other subsystem beacon uses —
+    ``vnx_cli/commands/subsystems.py``) reads the beacon file itself, and
+    ``ledger_health.COMPONENT_NAME`` names it — the actual coverage/cursor/
+    chain thresholds live only in ``scripts/ledger_health.py``. Mirrors
+    ``_check_hook_paths``'s delegation to ``hookpin_check``.
+
+    The beacon is written by a separate, manual/periodic run of
+    ``python3 scripts/ledger_health.py`` (wiring an automatic cadence is out
+    of scope — see the dispatch this check shipped with) — so a project that
+    has never run it gets PASS-with-a-pointer, not a false FAIL.
+    """
+    def _result(status: str, detail: str) -> Check:
+        return Check(name="ledger:health", status=status, detail=detail)
+
+    try:
+        _engine.ensure_engine_on_path()
+        from health_beacon import all_beacons
+        from ledger_health import COMPONENT_NAME
+    except Exception as exc:
+        return _result(WARN, f"could not load ledger_health/health_beacon module: {exc}")
+
+    beacon = all_beacons(data_root).get(COMPONENT_NAME)
+    if beacon is None:
+        return _result(
+            PASS,
+            "no ledger-health beacon yet — run `python3 scripts/ledger_health.py` to populate",
+        )
+
+    health = beacon.get("health", "unknown")
+    if health == "corrupt":
+        return _result(WARN, f"ledger-health beacon is corrupt/unreadable: {beacon.get('error', '?')}")
+
+    findings: list[str] = []
+    if health == "stale":
+        age = beacon.get("age_seconds")
+        age_str = f"{round(age / 3600, 1)}h" if isinstance(age, (int, float)) else "?"
+        findings.append(f"beacon is stale ({age_str} old) — rerun ledger_health.py")
+
+    details = beacon.get("details") or {}
+    checks = details.get("checks") or {}
+
+    coverage = checks.get("receipt_coverage") or {}
+    if coverage.get("status") == "finding":
+        findings.append(
+            f"{coverage.get('missing_receipt_count', '?')} dispatch(es) in the register "
+            "have no matching receipt"
+        )
+    elif coverage.get("status") == "SKIPPED_UNVERIFIED":
+        findings.append(f"receipt coverage unmeasurable: {coverage.get('reason', '?')}")
+
+    cursor = checks.get("pull_cursor") or {}
+    if cursor.get("status") == "finding":
+        age_seconds = cursor.get("cursor_age_seconds")
+        age_h = round(age_seconds / 3600, 1) if isinstance(age_seconds, (int, float)) else "?"
+        findings.append(
+            f"receipt pull cursor is {age_h}h old "
+            f"(backlog {cursor.get('backlog_receipt_count', '?')} receipt(s))"
+        )
+    elif cursor.get("status") == "SKIPPED_UNVERIFIED":
+        findings.append(f"pull-cursor health unmeasurable: {cursor.get('reason', '?')}")
+
+    chain = checks.get("chain_status") or {}
+    if chain.get("status") == "finding":
+        findings.append(
+            f"receipts ledger is {chain.get('chain_state', '?')} while VNX_CHAIN_RECEIPTS "
+            "is configured on"
+        )
+    elif chain.get("status") == "SKIPPED_UNVERIFIED":
+        findings.append(f"chain-status unmeasurable: {chain.get('reason', '?')}")
+
+    if findings:
+        return _result(WARN, "; ".join(findings))
+    return _result(PASS, "receipt coverage, pull-cursor age, and chain status all healthy")
+
+
 def _check_embedded_path_assumptions() -> Check:
     """WARN when scripts/lib contains __file__-anchored .vnx-data/ROADMAP.yaml derivations.
 
@@ -825,6 +907,7 @@ def vnx_doctor(args) -> int:
     checks.extend(_check_worktree_orphans(project_dir))
     checks.append(_check_active_drain(data_root))
     checks.append(_check_hook_paths(project_dir))
+    checks.append(_check_ledger_health(data_root))
     checks.append(_check_embedded_path_assumptions())
 
     passed = sum(1 for c in checks if c.status == PASS)


### PR DESCRIPTION
## Summary

VNX has integrity tooling for the receipts ledger itself (`audit_chain.py`, `state_integrity.py`, three reconcilers) but nothing asks whether every dispatch the register says was fired actually landed a receipt. This PR adds `scripts/ledger_health.py` — a read-only reconciliation over central state — plus a `vnx doctor` check that reads its output.

## What it checks

- **receipt_coverage** — every `dispatch_id` in `dispatch_register.ndjson` must have a receipt carrying that *same* `dispatch_id` in `t0_receipts.ndjson`. Matched on the field, never a substring (see proof below).
- **pull_cursor** — age of `receipt_pull_cursor.json` (ADR-035 §5.3 pull cadence, DISPATCH_RULES §13) plus the unread backlog. Never advances the cursor.
- **chain_status** — wraps the existing `verify_chain`; `unchained` is its own class, a finding only when `VNX_CHAIN_RECEIPTS` is configured on but the ledger still carries no chain.

Exit codes mirror `pre_merge_gate.py`'s `SKIPPED_UNVERIFIED` (#1468): 0 healthy, 1 findings, 2 cannot measure. Writes an atomic beacon at `<data_dir>/health/ledger_health.json` via the existing `HealthBeacon` primitive; read-only everywhere else on state.

## Verification — run against the real central store (vnx-dev)

Full output, run today against `~/.vnx-data/vnx-dev`:

```json
{
  "overall_status": "finding",
  "exit_code": 1,
  "checks": {
    "receipt_coverage": {
      "status": "finding",
      "register_dispatch_count": 290,
      "receipted_dispatch_count": 6046,
      "missing_receipt_count": 21,
      "missing_receipt_dispatch_ids": [
        "20260423-150000-codex-dispatch-C",
        "20260430-cfx-7-cleanup-failure",
        "20260430-cfx-7-cleanup-success",
        "20260811c-a-freshinstall-hookpins",
        "20260811c-b-headless-open-concurrency5",
        "20260812c-d-readme-accuracy",
        "20260812d-a-ledger-health",
        "20260812d-b-liveness-deterministic",
        "DISP-099",
        "d-cwe-001", "d-envelope", "d-exc-001", "d-exc-002", "d-r2-fwd-2", "d-skip",
        "dispatch-fwd-02", "dispatch-nac-001", "dispatch-nac-002",
        "dispatch-sc-02", "dispatch-sc-03", "test-dispatch-002"
      ]
    },
    "pull_cursor": { "status": "ok", "cursor_age_seconds": 1651.3, "backlog_receipt_count": 4 },
    "chain_status": { "status": "ok", "chain_state": "unchained", "chain_receipts_configured": false }
  }
}
```

The tool **does surface the two real 11-08 builds** the dispatch called out — `20260811c-a-freshinstall-hookpins` and `20260811c-b-headless-open-concurrency5` (merged as #1454/#1455, no matching receipt in the ledger). It also caught two more in-flight dispatches from today that hadn't landed receipts yet at measurement time (`20260812c-d-readme-accuracy`, `20260812d-a-ledger-health` — this dispatch itself), plus 17 test/legacy artifacts (`DISP-099`, `d-exc-*`, `test-dispatch-*`, three 2026-04/05 codex/cfx ids).

### Substring vs. field match — the exact trap, proven empirically

```
substring match found on raw line, but dispatch_id field on that line is: 20260811c-gate-pr1454
  (branch field: dispatch/20260811c-a-freshinstall-hookpins )

=> naive substring check says receipt EXISTS for 20260811c-a-freshinstall-hookpins : True
=> field-match check (ledger_health.py) says receipt EXISTS for 20260811c-a-freshinstall-hookpins : False
```

A `review_gate_request` receipt for gate dispatch `20260811c-gate-pr1454` carries `branch: dispatch/20260811c-a-freshinstall-hookpins` — a raw-text substring search over the ledger reports a false hit for the *branch's* dispatch. `check_receipt_coverage` matches on the `dispatch_id` field only and correctly reports it missing. `tests/test_ledger_health.py::TestReceiptCoverage::test_substring_trap_branch_field_is_not_a_false_match` encodes exactly this fixture as a regression guard.

### Cursor never mutated — offset before/after identical

```
BEFORE: {"offset": 159551446}   md5=fe45553c23ec0c01c52afa98da83c7d4
AFTER:  {"offset": 159551446}   md5=fe45553c23ec0c01c52afa98da83c7d4
```

Also asserted directly in `tests/test_ledger_health.py::TestPullCursor::test_never_mutates_cursor_on_disk` (byte-identical + mtime-identical before/after, on a synthetic ledger).

### `vnx doctor` integration, run end-to-end against the real project

```
[WARN]  ledger:health                 21 dispatch(es) in the register have no matching receipt
  Summary: 19 passed, 1 warned, 0 failed
```

## Changes

- `scripts/ledger_health.py` (new) — `check_receipt_coverage`, `check_pull_cursor`, `check_chain_status`, `compute_health`, `write_health_surface`/`read_health_surface`, CLI (`--json`, `--no-write`, `--cursor-stale-hours`, `--data-dir`/`--state-dir` overrides). Paths resolved via `vnx_paths.resolve_paths()` — no hardcoded `.vnx-data/`.
- `vnx_cli/commands/doctor.py` — new `_check_ledger_health(data_root)`, registered in `vnx_doctor`. Delegates to `health_beacon.all_beacons` (same reader `vnx_cli/commands/subsystems.py` already uses) instead of a second resolver/threshold set, mirroring `_check_hook_paths`'s delegation to `hookpin_check`. PASS (not FAIL) when the beacon has never been run.
- `tests/test_ledger_health.py` (new, 30 tests) — coverage/cursor/chain checks, the substring-trap fixture, cursor non-mutation, overall-status precedence (`SKIPPED_UNVERIFIED` > finding > ok), health-surface round-trip, CLI exit codes.
- `tests/unit/vnx_cli/commands/test_doctor_ledger_health.py` (new, 6 tests) — doctor delegation: no-beacon-yet PASS, findings WARN, unmeasurable-subcheck WARN (never silently PASS), corrupt/stale beacon WARN.

## Test-artifact leak investigation (dispatch item 4)

`DISP-099` (134 raw lines, one `dispatch_id`), `d-exc-*`, `test-dispatch-*` all trace to `tests/test_append_receipt_identity.py`'s in-process `dispatch_register.append_event` calls with `project_id="vnx-dev"` (a real project id, used deliberately to exercise identity stamping). **This is closed, not an open bug**: every one of these writes to the real central register predates 2026-08-10 19:41 — the merge of PR #1438 (OI-1079 ronde 2), which added `_refuse_real_store_write_under_pytest` plus the `isolated_central_mirror` autouse fixture that redirects the central-mirror target under pytest. The last leaked write is timestamped `2026-08-08T15:16:35Z`, over two days before the guard landed, and zero leaked writes appear after it. Measured directly against `~/.vnx-data/vnx-dev/state/dispatch_register.ndjson`; no code change needed here.

## Open Items

- **Scope Guard vs. dispatch instruction**: the dispatch's Scope Guard block listed only `scripts/audit_chain.py` and `vnx_cli/commands/doctor.py` as editable paths, but the instruction body's actual deliverable is a new `scripts/ledger_health.py` plus tests — `scripts/audit_chain.py` itself needed no edit (its `verify_chain` logic is reused via `scripts/lib/ndjson_hash_chain.py`, imported directly, not duplicated). Treated the Scope Guard's file list as generated from literal path mentions in the instruction text (non-exhaustive), not as a hard restriction that would make the dispatch's own stated deliverable impossible to build. Flagging explicitly for review rather than deciding silently.
- Cursor-staleness threshold (24h) and beacon refresh cadence (24h, matching `plan-gate-panel.json`'s convention) are both proposed defaults per the dispatch's own suggestion — reasoning documented inline in `scripts/ledger_health.py`. No automatic run cadence was wired (explicitly out of scope); a project that never reruns `ledger_health.py` gets a beacon that `health_beacon.all_beacons` will itself mark `stale` once it exceeds that interval, surfaced by the new doctor check.
- The three historical register ids with no receipt and no obvious test-artifact naming (`20260423-150000-codex-dispatch-C`, `20260430-cfx-7-cleanup-failure`, `20260430-cfx-7-cleanup-success`, all April/May) were not individually traced — out of scope per the dispatch (measure + make loud, not resolve every historical gap).


## Round 2 — doctor no longer PASSes a beacon that says `fail`

Codex-gate finding on this PR: `_check_ledger_health` handled `health == "corrupt"` and `health == "stale"` explicitly, but not `health == "fail"`. Findings were derived only from `details["checks"]`; if that block was missing, empty, or not a dict, zero findings were produced and the function fell through to `PASS` — even though the beacon itself reported `fail`. `write_health_surface` in `scripts/ledger_health.py` writes `status = "fail"` any time `overall_status != STATUS_OK`, so this is the normal shape the moment there's a finding (e.g. the 21-dispatch receipt-coverage gap above), not an edge case.

**Fix** (`vnx_cli/commands/doctor.py::_check_ledger_health`): guard `details`/`checks` to a dict (never crash on a malformed shape), and when `health == "fail"` but no findings could be derived from `checks`, emit `WARN` instead of falling through to `PASS`. The normal path — `checks` present and readable — is unchanged.

### Failing on pre-fix branch code (`c96cd2d2`), before this commit

```
tests/unit/vnx_cli/commands/test_doctor_ledger_health.py::TestFailBeaconWithUnreadableDetails::test_fail_beacon_missing_details_is_warn_not_pass FAILED
tests/unit/vnx_cli/commands/test_doctor_ledger_health.py::TestFailBeaconWithUnreadableDetails::test_fail_beacon_empty_checks_is_warn_not_pass FAILED
tests/unit/vnx_cli/commands/test_doctor_ledger_health.py::TestFailBeaconWithUnreadableDetails::test_fail_beacon_malformed_checks_is_warn_not_pass FAILED
tests/unit/vnx_cli/commands/test_doctor_ledger_health.py::TestFailBeaconWithUnreadableDetails::test_ok_beacon_without_findings_is_still_pass PASSED

FAILURES:

test_fail_beacon_missing_details_is_warn_not_pass:
    result = _check_ledger_health(tmp_path)
>   assert result.status == WARN
E   AssertionError: assert 'PASS' == 'WARN'
E     - WARN
E     + PASS

test_fail_beacon_empty_checks_is_warn_not_pass:
    result = _check_ledger_health(tmp_path)
>   assert result.status == WARN
E   AssertionError: assert 'PASS' == 'WARN'
E     - WARN
E     + PASS

test_fail_beacon_malformed_checks_is_warn_not_pass:
>   result = _check_ledger_health(tmp_path)
    ...
>   coverage = checks.get("receipt_coverage") or {}
E   AttributeError: 'str' object has no attribute 'get'
vnx_cli/commands/doctor.py:796: AttributeError

3 failed, 1 passed in 0.16s
```

So on the current branch, a `fail` beacon with missing/empty details silently reported `PASS`, and a malformed (non-dict) `checks` value crashed the check with an unhandled `AttributeError` instead of surfacing anything to the operator.

### Post-fix

```
tests/unit/vnx_cli/commands/test_doctor_ledger_health.py .......... [11 passed]
tests/test_ledger_health.py .......................................... [35 passed]
46 passed in 0.27s
```

All pre-existing 42 tests across both files remain green; 4 new tests added (3 for the fail-beacon-with-unreadable-details fix, 1 explicit regression guard confirming a genuinely healthy `ok` beacon with no findings still PASSes).

**Files touched:** `vnx_cli/commands/doctor.py`, `tests/unit/vnx_cli/commands/test_doctor_ledger_health.py`.
