### PR TITLE
fix(tmux-lane): distinguish a thinking worker from a dead one with a deterministic liveness check

### DIFF
--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -226,6 +226,42 @@ class TmuxCommandRunner:
 
 
 # ---------------------------------------------------------------------------
+# Deterministic worker liveness (OI-1130 follow-up)
+# ---------------------------------------------------------------------------
+def _process_alive(pid: int) -> bool:
+    """``os.kill(pid, 0)`` liveness probe. True unless *pid* is provably gone.
+
+    ``ProcessLookupError`` means the pid no longer exists in the OS process
+    table -> dead. ``PermissionError`` means the pid exists but is owned by a
+    different user -> still alive, just not signalable by us. Any other
+    ``OSError`` is unexpected and propagates so the caller's fail-open guard
+    classifies the result as unknown rather than guessing dead.
+    """
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    return True
+
+
+@dataclass(frozen=True)
+class WorkerLiveness:
+    """Verdict of the tmux-lane deterministic liveness probe.
+
+    ``alive`` is TRI-STATE: ``True``/``False`` are deterministic verdicts;
+    ``None`` means the probe could not establish liveness (a tmux error, an
+    unparseable pane_pid, an unexpected exception) and the caller MUST fail
+    open — "cannot measure" is never read as "dead" (mirrors the fail-closed
+    check's own fail-open guard in ``pre_merge_gate.py``, #1468).
+    """
+
+    alive: "bool | None"
+    reason: str
+
+
+# ---------------------------------------------------------------------------
 # Result types
 # ---------------------------------------------------------------------------
 @dataclass
@@ -472,6 +508,9 @@ class TmuxInteractiveDispatch:
         # OI-863: dispatch ids for which the awaiting-permission detection event
         # has already been emitted (one event per dispatch, not one per poll).
         self._awaiting_permission_emitted: set[str] = set()
+        # OI-1130: dispatch ids for which the "silent but confirmed alive"
+        # thinking-worker event has already been emitted (one per dispatch).
+        self._thinking_silent_emitted: set[str] = set()
 
     # -- OI-863 pane classification ----------------------------------------
     def _classify_pane(self, pane_id: str):
@@ -483,6 +522,77 @@ class TmuxInteractiveDispatch:
         cap = self._runner.run(["capture-pane", "-t", pane_id, "-p"])
         content = cap.stdout if cap.returncode == 0 else ""
         return classify_worker_pane(content)
+
+    # -- OI-1130 deterministic liveness -------------------------------------
+    def _check_worker_liveness(self, pane_id: str, session: str) -> WorkerLiveness:
+        """Deterministic liveness probe for the worker behind *pane_id*/*session*.
+
+        Distinguishes a worker that is silently THINKING (the pane log has
+        stalled but the process is still there) from one that is genuinely
+        DEAD (its tmux session/pane — and the OS pid behind it — are gone).
+        The pane-log heartbeat alone cannot make this distinction: it only
+        ever sees SILENCE, never the process itself, so a slow-thinking
+        worker and a dead one look identical to it (OI-1130: 4 of 5 deep-
+        thinking dispatches were killed on exactly this confusion).
+
+        Scope (deliberate — see the dispatch report for the full rationale):
+        this checks whether the worker's tmux home (session, pane, and the
+        shell pid tmux spawned it with) still exists. That is the dominant
+        real death mode for an ephemeral single-shot tmux dispatch — a tmux
+        server crash, an externally killed session, an OOM/SIGKILL that took
+        the whole process group with it. It deliberately does NOT walk the
+        process tree looking for a child ``claude`` process that exited while
+        the wrapping shell survives: that would need either a full-system
+        ``ps`` scan on every poll interval (explicitly too expensive — this
+        probe must stay cheap enough to run every poll) or a second pane-TEXT
+        heuristic, which is exactly the kind of guess this check exists to
+        replace. That residual gap stays bounded by the unchanged
+        ``deadline_seconds``.
+
+        Fail-open: ANY ambiguity (a tmux error, an unparseable pane_pid, a
+        surprising probe exception) returns ``alive=None`` — never ``False``.
+        "Cannot measure" must never be read as "dead" (mirrors the fail-open
+        guard #1468 put in ``pre_merge_gate.py`` for the same principle).
+        """
+        try:
+            has = self._runner.run(["has-session", "-t", session])
+        except Exception as exc:  # noqa: BLE001 — probe must never raise into the poll loop
+            return WorkerLiveness(
+                alive=None, reason=f"has_session_probe_error:{exc.__class__.__name__}"
+            )
+        if has.returncode != 0:
+            return WorkerLiveness(alive=False, reason="tmux_session_gone")
+
+        try:
+            res = self._runner.run(
+                ["display-message", "-p", "-t", pane_id, "#{pane_dead}\t#{pane_pid}"]
+            )
+        except Exception as exc:  # noqa: BLE001
+            return WorkerLiveness(
+                alive=None, reason=f"pane_probe_error:{exc.__class__.__name__}"
+            )
+        if res.returncode != 0 or not (res.stdout or "").strip():
+            return WorkerLiveness(alive=False, reason="tmux_pane_gone")
+
+        parts = res.stdout.strip().split("\t")
+        if len(parts) != 2:
+            return WorkerLiveness(alive=None, reason="tmux_pane_info_unparseable")
+        dead_flag, pid_str = parts[0].strip(), parts[1].strip()
+        if dead_flag == "1":
+            return WorkerLiveness(alive=False, reason="tmux_pane_dead_flag")
+        if not pid_str.isdigit() or int(pid_str) <= 0:
+            return WorkerLiveness(alive=None, reason="tmux_pane_pid_unparseable")
+
+        pid = int(pid_str)
+        try:
+            alive = _process_alive(pid)
+        except Exception as exc:  # noqa: BLE001 — fail open, never guess dead on a probe crash
+            return WorkerLiveness(
+                alive=None, reason=f"pid_probe_error:{exc.__class__.__name__}"
+            )
+        if alive:
+            return WorkerLiveness(alive=True, reason="pane_pid_alive")
+        return WorkerLiveness(alive=False, reason="pane_pid_gone")
 
     def _emit_awaiting_permission(
         self,
@@ -2028,7 +2138,20 @@ class TmuxInteractiveDispatch:
           fallback (permission-prompt detection) is the only guard.
 
         *session*: tmux session name, required when raw_log_path is provided so
-          the heartbeat can kill the session on silence timeout.
+          the heartbeat can kill the session on silence timeout. Also required
+          (together with *pane_id*) for the OI-1130 deterministic liveness probe
+          below; when either is missing the probe reports "unknown" every poll
+          and every decision falls open to the pre-OI-1130 heartbeat-only
+          behavior.
+
+        OI-1130 deterministic liveness (see ``_check_worker_liveness``): each
+        poll, independent of heartbeat silence, the worker's tmux session/pane
+        is probed for a confirmed-dead verdict. A confirmed-dead worker is
+        killed immediately (reason ``worker_process_gone``) without waiting out
+        the silence threshold. A confirmed-ALIVE worker is never killed on
+        silence alone — silence plus alive means "thinking", not "stuck" — only
+        ``deadline_seconds`` still bounds that wait. An "unknown" verdict (fail
+        open) reproduces the exact pre-OI-1130 heartbeat-silence-kill behavior.
 
         Priority: signal 1 (canonical) > signal 2 (pending) > signal 3 (backstop).
         Returns the best matching receipt, or None on deadline.
@@ -2113,17 +2236,120 @@ class TmuxInteractiveDispatch:
                             dispatch_id, label, pane_id,
                             "permission prompt during receipt wait",
                         )
-                # OI-944 / OI-1007: heartbeat silence check.  If the pipe-pane
-                # log has stopped growing for longer than the silence threshold,
-                # the worker is stuck — kill it and write a terminal failure.
+                # Heartbeat verdict, computed at most once per poll (skipped while
+                # awaiting a permission prompt — see the OI-863 note at the kill
+                # site below). Reused by both the OI-1130 liveness cross-check and
+                # the legacy silence-kill branch so FileProgressHeartbeat.check()
+                # (which mutates its own growth timer) is never called twice in
+                # the same iteration.
+                _hb_verdict = None
+                if _heartbeat is not None and not _awaiting_permission:
+                    _hb_verdict = _heartbeat.check()
+
+                # OI-1130 follow-up: deterministic liveness probe.  Runs every
+                # poll, independent of heartbeat silence, so a genuinely DEAD
+                # worker is caught within one poll interval instead of waiting
+                # out the full silence threshold.  See _check_worker_liveness
+                # for the fail-open contract and the deliberate scope boundary.
+                _liveness = (
+                    self._check_worker_liveness(pane_id, session)
+                    if pane_id is not None and session
+                    else WorkerLiveness(alive=None, reason="no_pane_or_session")
+                )
+
+                if _liveness.alive is False:
+                    if _hb_verdict is not None and not _hb_verdict.is_silent:
+                        # "groeit + dood" is structurally impossible (a growing
+                        # pane log implies a live writer) — the process death
+                        # verdict still wins, but the contradiction is logged as
+                        # an anomaly worth investigating.
+                        logger.warning(
+                            "interactive: liveness check found worker gone for %s "
+                            "(reason=%s) while the pane log was STILL GROWING — "
+                            "anomaly, but process death wins; killing anyway",
+                            dispatch_id, _liveness.reason,
+                        )
+                    else:
+                        logger.warning(
+                            "interactive: deterministic liveness check found worker "
+                            "gone for %s (reason=%s) — killing without waiting out "
+                            "the silence threshold",
+                            dispatch_id, _liveness.reason,
+                        )
+                    # Write a failure report so the audit trail records a
+                    # confirmed-dead kill under its OWN reason — distinct from a
+                    # heartbeat-silence guess (see worker_heartbeat module docs).
+                    try:
+                        from worker_heartbeat import build_process_gone_failure_report  # noqa: PLC0415
+                        _pg_report = build_process_gone_failure_report(
+                            dispatch_id,
+                            liveness_reason=_liveness.reason,
+                            terminal_id=label or "",
+                        )
+                        _reports_dir = self._state_dir.parent / "unified_reports"
+                        _reports_dir.mkdir(parents=True, exist_ok=True)
+                        _report_path = _reports_dir / f"{dispatch_id}.md"
+                        _report_path.write_text(_pg_report, encoding="utf-8")
+                        logger.info(
+                            "interactive: worker_process_gone failure report "
+                            "written to %s",
+                            _report_path,
+                        )
+                    except Exception as _pg_write_exc:
+                        logger.warning(
+                            "interactive: worker_process_gone failure report "
+                            "write failed for %s: %s",
+                            dispatch_id,
+                            _pg_write_exc,
+                        )
+                    return None
+
+                # OI-944 / OI-1007 / OI-1130: heartbeat silence check.  If the
+                # pipe-pane log has stopped growing for longer than the silence
+                # threshold AND the liveness probe could not confirm the worker
+                # is alive (fail-open: unknown, not "alive"), the worker is
+                # treated as stuck — kill it and write a terminal failure exactly
+                # as before.  When the liveness probe DID confirm the process is
+                # alive, a silent log means the worker is THINKING, not stuck
+                # (OI-1130 regression pin: 4 of 5 deep-thinking dispatches were
+                # killed on exactly this false signal) — surface it once instead
+                # of killing, and let deadline_seconds remain the only bound.
                 # EXCEPTION (OI-863): a recoverable awaiting_permission worker is
                 # NOT a silent/stalled worker — its log has legitimately stopped
                 # growing while it waits on ONE keystroke. Killing it would discard
                 # a rescueable dispatch, so the heartbeat is skipped while the pane
                 # shows a permission prompt (which escalates instead).
-                if _heartbeat is not None and not _awaiting_permission:
-                    _hb_verdict = _heartbeat.check()
-                    if _hb_verdict.is_silent:
+                if _hb_verdict is not None and _hb_verdict.is_silent:
+                    if _liveness.alive is True:
+                        if dispatch_id not in self._thinking_silent_emitted:
+                            self._thinking_silent_emitted.add(dispatch_id)
+                            logger.info(
+                                "interactive: worker %s silent for %.0fs (threshold="
+                                "%.0fs) but the liveness check confirms it is alive "
+                                "— NOT killing; deadline_seconds remains the only "
+                                "bound (OI-1130)",
+                                dispatch_id,
+                                _hb_verdict.silence_seconds,
+                                _hb_verdict.threshold_seconds,
+                            )
+                            self._emit_event(
+                                "interactive_worker_thinking_silent",
+                                dispatch_id=dispatch_id,
+                                label=label or "",
+                                reason="pane log silent but process confirmed alive",
+                                metadata={
+                                    "silence_seconds": _hb_verdict.silence_seconds,
+                                    "silence_threshold_seconds": _hb_verdict.threshold_seconds,
+                                },
+                            )
+                    else:
+                        if _liveness.alive is None:
+                            logger.debug(
+                                "interactive: liveness undeterminable for %s "
+                                "(reason=%s) — falling back to the pre-OI-1130 "
+                                "heartbeat-silence-kill behavior",
+                                dispatch_id, _liveness.reason,
+                            )
                         logger.warning(
                             "interactive: heartbeat silence detected for %s "
                             "(%.0fs silent, threshold=%.0fs) — killing worker",

--- a/scripts/lib/worker_heartbeat.py
+++ b/scripts/lib/worker_heartbeat.py
@@ -331,6 +331,66 @@ def _detect_permission_prompt(event: Dict[str, Any]) -> tuple[bool, str]:
     return False, ""
 
 
+def build_process_gone_failure_report(
+    dispatch_id: str,
+    *,
+    liveness_reason: str,
+    model: str = "unknown",
+    provider: str = "unknown",
+    terminal_id: str = "",
+) -> str:
+    """Build a terminal failure report for a worker killed on a DETERMINISTIC
+    dead-process verdict (OI-1130 follow-up), distinct from a heartbeat-silence
+    guess.
+
+    ``liveness_reason`` is the tmux-lane liveness probe's own reason code (e.g.
+    ``tmux_session_gone``, ``pane_pid_gone``) — recorded verbatim so the audit
+    trail shows exactly which signal fired, not just that *some* check failed.
+
+    Returns the report text as a string.  The caller is responsible for
+    writing it to the unified_reports directory.
+
+    Carries a STRUCTURAL failure identity — bold-fields ``Status: failed`` and
+    ``Failure-Reason: worker_process_gone`` — so the receipt converter emits a
+    ``task_failed`` receipt (mirrors ``build_heartbeat_failure_report``). Kept
+    as its OWN reason (not ``heartbeat_killed``) so the ledger can tell a
+    process that was confirmed gone apart from one killed on a silence guess —
+    the distinction the tmux-lane liveness check exists to make.
+    """
+    now_iso = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    return f"""**Dispatch-ID**: {dispatch_id}
+**Model**: {model}
+**Provider**: {provider}
+**Status**: failed
+**Failure-Reason**: worker_process_gone
+
+## Summary
+
+Worker killed by the tmux-lane deterministic liveness check: the worker's
+process was confirmed gone ({liveness_reason}), not merely silent. This is a
+terminal failure — the dispatch did not complete.
+
+## Changes
+
+None recorded by the worker. The worker's process was gone before it could
+write a receipt or a report; any work it produced may still sit uncommitted
+in its worktree — salvage before reap.
+
+## Verification
+
+- Liveness verdict: dead ({liveness_reason})
+- Detection: deterministic tmux/process probe, not a silence-duration guess
+- Terminal: {terminal_id}
+- Kill timestamp: {now_iso}
+
+## Open Items
+
+- Investigate why worker {terminal_id} process disappeared for dispatch {dispatch_id}
+- Check for an OOM kill, a crashed tmux server, or an externally killed session
+"""
+
+
 def build_heartbeat_failure_report(
     dispatch_id: str,
     verdict: SilenceVerdict,

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import sys
 import tempfile
+import time
 import unittest
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -1227,6 +1228,262 @@ class TestAwaitingPermission(_LaneTestCase):
         self.assertTrue(
             report_path.exists(),
             "a genuinely stalled worker must be heartbeat-killed (failure report)",
+        )
+
+
+# ---------------------------------------------------------------------------
+# OI-1130 follow-up: deterministic worker liveness (thinking vs dead)
+# ---------------------------------------------------------------------------
+class _LivenessFakeTmux(FakeTmux):
+    """FakeTmux extended with a controllable OI-1130 liveness-probe response.
+
+    ``has_session_ok``: return code for ``tmux has-session -t <session>`` — the
+    lane's first, cheapest liveness signal (whole session gone).
+
+    ``pane_dead_flag`` / ``pane_pid``: the two values interpolated into the
+    combined ``#{pane_dead}\\t#{pane_pid}`` display-message query the probe
+    issues once the session is confirmed to exist. ``pane_pid`` is the pid the
+    (separately monkeypatched) ``_process_alive`` probe is asked to judge —
+    this fixture never touches a real OS process, matching the dispatch's
+    "fabricated tmux-runner + controllable pid-liveness" test contract.
+    """
+
+    def __init__(
+        self,
+        *,
+        has_session_ok: bool = True,
+        pane_dead_flag: str = "0",
+        pane_pid: str = "4242",
+        **kwargs,
+    ) -> None:
+        super().__init__(**kwargs)
+        self.has_session_ok = has_session_ok
+        self.pane_dead_flag = pane_dead_flag
+        self.pane_pid = pane_pid
+        self.has_session_calls = 0
+        self.liveness_display_message_calls = 0
+
+    def run(self, args, *, timeout: int = 10, input_text=None) -> TmuxResult:
+        if args and args[0] == "has-session":
+            self.commands.append(list(args))
+            self.has_session_calls += 1
+            if self.has_session_ok:
+                return TmuxResult(0, "")
+            return TmuxResult(1, "", "can't find session")
+        if (
+            args
+            and args[0] == "display-message"
+            and args[-1] == "#{pane_dead}\t#{pane_pid}"
+        ):
+            self.commands.append(list(args))
+            self.liveness_display_message_calls += 1
+            return TmuxResult(0, f"{self.pane_dead_flag}\t{self.pane_pid}\n")
+        return super().run(args, timeout=timeout, input_text=input_text)
+
+
+class TestOI1130DeterministicLiveness(_LaneTestCase):
+    """The four quadrants of the pane-log x process-liveness decision table.
+
+    Each test calls ``_wait_for_receipt`` directly (matching the existing
+    heartbeat tests above) with a short ``deadline_seconds`` so the loop
+    resolves fast; the FakeTmux never emits a receipt, so the only way the
+    call returns before the deadline is a liveness-driven kill.
+    """
+
+    def _report_path(self) -> Path:
+        return self.state_dir.parent / "unified_reports" / f"{self.DISPATCH_ID}.md"
+
+    def _clear_report(self) -> None:
+        report_path = self._report_path()
+        if report_path.exists():
+            report_path.unlink()
+
+    def test_silent_and_alive_is_not_killed_oi1130_pin(self):
+        """Quadrant: pane log SILENT, process ALIVE -> NOT killed, even well
+        past the silence threshold. This is the OI-1130 regression pin: before
+        this dispatch, silence alone killed a thinking worker."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")  # never grows
+        fake = _LivenessFakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            has_session_ok=True,
+            pane_dead_flag="0",
+            pane_pid="4242",
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.02"}
+        ), patch("tmux_interactive_dispatch._process_alive", return_value=True):
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=0.3,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+            )
+        self.assertIsNone(result, "no receipt ever arrives; only the deadline ends the wait")
+        self.assertFalse(
+            self._report_path().exists(),
+            "a silent-but-alive worker must NOT be killed — no failure report",
+        )
+        with get_connection(self.state_dir) as conn:
+            events = get_events(conn, entity_id=self.DISPATCH_ID)
+        self.assertIn(
+            "interactive_worker_thinking_silent",
+            {e["event_type"] for e in events},
+            "the thinking-but-alive state must be surfaced via an event",
+        )
+        # The probe ran on more than one poll — proves this was a sustained
+        # wait past the silence threshold, not a lucky single check.
+        self.assertGreater(fake.has_session_calls, 1)
+
+    def test_silent_and_dead_fails_within_one_poll_worker_process_gone(self):
+        """Quadrant: pane log SILENT, process DEAD -> immediate failure with
+        reason worker_process_gone, well before deadline_seconds AND without
+        waiting out a (deliberately long) silence threshold."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = _LivenessFakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            has_session_ok=False,  # session gone -> deterministically dead
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        start = time.monotonic()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "1800"}
+        ):
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=5.0,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+            )
+        elapsed = time.monotonic() - start
+        self.assertIsNone(result)
+        self.assertLess(
+            elapsed, 1.0,
+            "a dead worker must fail within ~one poll interval, not wait out "
+            "the (long) silence threshold or the (long) deadline",
+        )
+        report_path = self._report_path()
+        self.assertTrue(report_path.exists(), "a dead worker must write a failure report")
+        from report_to_receipt_converter import _extract_body_fields
+        fields = _extract_body_fields(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(fields.get("status"), "failed")
+        self.assertEqual(
+            fields.get("failure_reason"), "worker_process_gone",
+            "a confirmed-dead kill must carry its OWN reason, not heartbeat_killed",
+        )
+
+    def test_liveness_undeterminable_falls_back_to_heartbeat_behavior(self):
+        """Quadrant: liveness cannot be established (plain FakeTmux — no
+        has-session/pane_pid support, mirroring a tmux error) -> the lane
+        falls back EXACTLY to the pre-OI-1130 heartbeat-silence-kill
+        behavior, plus a log line noting the fallback."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("some stale log line\nthat is not a prompt", encoding="utf-8")
+        fake = FakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            ready_content="some stale log line\nthat is not a prompt",
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "0.05"}
+        ), self.assertLogs("tmux_interactive_dispatch", level="DEBUG") as logs:
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=0.3,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+            )
+        self.assertIsNone(result)
+        report_path = self._report_path()
+        self.assertTrue(
+            report_path.exists(),
+            "unknown liveness must fall back to the legacy heartbeat kill",
+        )
+        from report_to_receipt_converter import _extract_body_fields
+        fields = _extract_body_fields(report_path.read_text(encoding="utf-8"))
+        self.assertEqual(
+            fields.get("failure_reason"), "heartbeat_killed",
+            "the legacy reason must be unchanged when liveness is undeterminable",
+        )
+        self.assertTrue(
+            any("liveness undeterminable" in msg for msg in logs.output),
+            "the fail-open fallback must be logged, not silent",
+        )
+
+    def test_growing_log_is_unaffected(self):
+        """Quadrant: pane log GROWING (never silent), process alive -> the
+        liveness probe runs every poll but changes nothing — no kill,
+        identical to the pre-OI-1130 behavior for a healthy worker."""
+        raw_log = self.state_dir / "raw.log"
+        raw_log.write_text("worker started\n", encoding="utf-8")
+        fake = _LivenessFakeTmux(
+            receipts_file=self.receipts_file,
+            dispatch_id=self.DISPATCH_ID,
+            emit_receipt=False,
+            has_session_ok=True,
+            pane_dead_flag="0",
+            pane_pid="4242",
+        )
+        lane = self._make_lane(fake)
+        self._clear_report()
+        # Threshold far longer than deadline_seconds => the log is, from the
+        # heartbeat's perspective, never silent — the "growing" quadrant.
+        with patch.dict(
+            os.environ, {"VNX_WORKER_HEARTBEAT_SILENCE_SECONDS": "100"}
+        ), patch("tmux_interactive_dispatch._process_alive", return_value=True):
+            result = lane._wait_for_receipt(
+                self.DISPATCH_ID,
+                deadline_seconds=0.2,
+                poll_interval=0.02,
+                completion_statuses=DEFAULT_COMPLETION_STATUSES,
+                baseline_count=0,
+                baseline_pending_ids=frozenset(),
+                baseline_backstop=True,
+                pane_id="%1",
+                label="T1",
+                raw_log_path=raw_log,
+                session=f"sess-{self.DISPATCH_ID}",
+            )
+        self.assertIsNone(result, "no receipt ever arrives; only the deadline ends the wait")
+        self.assertFalse(
+            self._report_path().exists(),
+            "a growing/healthy worker must never be killed",
+        )
+        self.assertGreater(
+            fake.has_session_calls, 0,
+            "the liveness probe must still run on a healthy worker (no regression in coverage)",
         )
 
 


### PR DESCRIPTION
## Summary

The tmux-interactive lane's `_wait_for_receipt` only ever inferred worker health from pane-log silence — it never asked the worker's tmux session/pane whether the process was actually still there. That is the root cause of OI-1130: a silent pane could mean "deep-thinking" or "dead" and the lane guessed dead every time, killing 4 of 5 real dispatches mid-thought.

This adds a second, deterministic liveness check alongside the (unchanged) heartbeat:

- `tmux has-session -t <session>` → non-zero = session gone = **dead**.
- `tmux display-message ... "#{pane_dead}\t#{pane_pid}"` → pane gone, or `pane_dead=1` = **dead**.
- Otherwise `os.kill(pid, 0)` on the pane's shell pid = **alive**/**dead**.
- Any ambiguity anywhere in that chain (tmux error, unparseable pid, unexpected exception) = **unknown → fail open**, reproducing the exact pre-change heartbeat-silence-kill behavior. "Cannot measure" is never read as "dead" (same principle #1468 put in `pre_merge_gate.py`).

New decision table inside the silent-poll branch of `_wait_for_receipt`:

| pane-log | process | verdict |
|---|---|---|
| growing | alive | unchanged — keep polling |
| silent | **alive** | **thinking** — NOT killed; only `deadline_seconds` still bounds the wait (OI-1130 regression pin) |
| silent | **dead** | **immediate failure**, reason `worker_process_gone`, no waiting out the silence threshold |
| growing | dead | impossible in practice; logged as an anomaly, process-death still wins |
| — | unknown | unchanged pre-OI-1130 heartbeat-silence-kill behavior, plus a debug log noting the fallback |

### Chosen scope (deliberate, verified before building)

The dispatch text pointed at a `_session_exists()` helper it expected to exist in `tmux_interactive_dispatch.py` around line 1425 — that function does not exist there (the nearest thing is `_verify_pane_identity`, which does something different: it checks pane→session identity, not liveness). Verified via grep before writing any code (see `[[meet-het-oppervlak-voor-je-het-plant]]`).

The check detects "the worker's tmux home (session/pane/shell pid) is gone" — the dominant real death mode for an ephemeral single-shot tmux dispatch (tmux server crash, externally killed session, an OOM/SIGKILL that took the whole process group with it). It deliberately does **not** walk the process tree for a child `claude` process that exited while the wrapping shell survives — that would need either a full-system `ps -axo` scan every poll interval (explicitly ruled out by the dispatch as too expensive) or a second pane-TEXT heuristic (exactly what this check exists to replace). That residual gap stays bounded by the unchanged `deadline_seconds`.

## Changes

- `scripts/lib/tmux_interactive_dispatch.py`
  - `_process_alive(pid)` — cheap `os.kill(pid, 0)` liveness probe.
  - `WorkerLiveness` — frozen dataclass, tri-state (`alive: bool | None`, `reason: str`).
  - `TmuxInteractiveDispatch._check_worker_liveness(pane_id, session)` — the deterministic probe described above.
  - `_wait_for_receipt`'s silent-poll branch rewritten to compute the heartbeat verdict once per poll, cross-check it against liveness, and only kill on a confirmed-dead verdict or (fail-open) an unknown one under silence. Docstring updated. No signature change, no change to `deadline_seconds` or the silence threshold, provider lane untouched.
- `scripts/lib/worker_heartbeat.py`
  - `build_process_gone_failure_report(...)` — new report builder, structurally identical contract to `build_heartbeat_failure_report` (four required headings, `Status: failed`) but with its own `Failure-Reason: worker_process_gone`, so the ledger can tell "confirmed dead" apart from "killed on a silence guess."
- `tests/test_tmux_interactive_dispatch.py`
  - `_LivenessFakeTmux` — fabricated tmux runner with controllable `has-session`/`pane_dead`/`pane_pid` responses.
  - `TestOI1130DeterministicLiveness` — the four quadrant tests (below).

## Verification

**New targeted tests (4/4 quadrants, all green):**
```
python3 -m pytest tests/test_tmux_interactive_dispatch.py -k TestOI1130DeterministicLiveness -v
```
- `test_silent_and_alive_is_not_killed_oi1130_pin` — silent pane-log + confirmed-alive process ⇒ NOT killed, even well past the silence threshold. The OI-1130 regression pin.
- `test_silent_and_dead_fails_within_one_poll_worker_process_gone` — silent + confirmed-dead ⇒ fails in well under 1s against a 5s deadline and a 1800s silence threshold, report carries `Failure-Reason: worker_process_gone` (not `heartbeat_killed`).
- `test_liveness_undeterminable_falls_back_to_heartbeat_behavior` — plain (non-liveness-aware) fake tmux ⇒ falls back exactly to the legacy heartbeat-kill (`Failure-Reason: heartbeat_killed`), plus asserts the fail-open debug log line fired.
- `test_growing_log_is_unaffected` — growing pane-log ⇒ unchanged, no kill, liveness probe still runs (no coverage regression).

**Negative control** (same 4 tests run against `git stash`-reverted, unmodified `tmux_interactive_dispatch.py`/`worker_heartbeat.py`): all 4 **fail** — 3 with `AttributeError: ... does not have the attribute '_process_alive'`, 1 (`test_silent_and_dead_...`) by timing out the full 5s deadline instead of failing in <1s. Confirms the tests exercise the new behavior, not incidental scaffolding.

**Full suite, run from a clean `git clone` of the pushed branch (not a nested worktree — `[[geneste-worktree-breekt-de-dispatch-tests]]`):**
```
python3 -m pytest tests/test_tmux_interactive_dispatch.py -q        # 217 passed (213 pre-existing + 4 new)
python3 -m pytest tests/test_worker_heartbeat_silence.py tests/test_report_to_receipt_converter.py -q   # 157 passed
```

## Open Items

None.