### PR TITLE
fix(headless): honor isolation from the spec and never no-op an isolation guarantee (OI-1158)

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -242,6 +242,56 @@ def _print_plan(plan: ExecutionPlan, fp: str) -> None:
         print(f"  [WARN] {w}")
 
 
+_HEADLESS_ISOLATION_WARNING = (
+    "OI-1158: claude_headless lane isolation is NOT structurally verified by "
+    "the door. Every ExecutionPlan claims isolation=worktree (dispatch_plan.py's "
+    "D6 rule — Isolation.WORKTREE is the only legal member), but the door has no "
+    "check that the CHOSEN LANE actually delivers it. The claude_tmux_subscription "
+    "lane's isolation is enforced one call away via tmux_worktree.allocate(); the "
+    "claude_headless lane's isolation lives in a parallel code path "
+    "(dispatch_envelope.py -> dispatch_worktree_isolation.py) this module never "
+    "inspects or cross-checks. Treat this dispatch as isolation-UNVERIFIED by the "
+    "door until a structural check replaces this warning — do not assume the "
+    "worktree guarantee held just because the plan says isolation=worktree."
+)
+
+
+def _headless_isolation_guard(plan: "ExecutionPlan") -> "Optional[str]":
+    """Return a loud isolation-guarantee warning for a claude_headless plan.
+
+    OI-1158 (peer-measured 2026-08-12, pacompany-engine): two headless
+    dispatches, both staged with ``isolation: worktree`` in the spec, both
+    ended up sharing the SAME tree — the project's own main checkout — on the
+    branch of whichever dispatch fired first. The door printed nothing: the
+    ExecutionPlan's ``isolation`` field always reads ``Isolation.WORKTREE``
+    (it is the only legal enum member — see dispatch_spec.Isolation), so a
+    caller reading the plan sees an isolation guarantee that the door itself
+    never verifies the LANE actually implements. A silent no-op on an
+    isolation guarantee is the most dangerous form: the caller believes they
+    are protected.
+
+    Deliberately WARNS rather than REFUSES: the headless lane is a live,
+    relied-upon lane (opened 2026-08-11 by explicit operator directive,
+    ``docs/core/DISPATCH_RULES.md`` §8), and a hard door-level refusal would
+    block dispatches that run successfully today. A refusal belongs on the
+    lane's OWN fail-closed gate (``_execute_claude_headless`` already has one
+    via ``lane_safety.headless_block``) — not duplicated here as a second,
+    coarser gate that can't distinguish "isolation is broken" from "isolation
+    is merely unverified by this door". The warning plus the receipt-visible
+    field (``_persist_route_decision``'s ``isolation_note``) is the minimum
+    bar this dispatch closes: never silent again, escalate to a hard door
+    gate only once the real enforcement gap it flags is closed.
+
+    Returns None for every lane other than ``claude_headless`` — the tmux
+    lane's isolation is verified structurally (``tmux_worktree.allocate()``
+    is one call away from ``_execute_claude`` and asserts the worktree's own
+    branch, OI-1124), so it earns no warning here.
+    """
+    if plan.lane != "claude_headless":
+        return None
+    return _HEADLESS_ISOLATION_WARNING
+
+
 def _check_reachability(plan: "ExecutionPlan", spec: "DispatchSpec") -> None:
     """Verify the selected lane's endpoint is reachable (OI-867).
 
@@ -1488,6 +1538,7 @@ def _persist_route_decision(
     permit: ExecutionPermit,
     *,
     state_dir: Path,
+    isolation_note: "Optional[str]" = None,
 ) -> None:
     """Persist the canonical routing decision alongside the permit fingerprint.
 
@@ -1498,6 +1549,14 @@ def _persist_route_decision(
     The stored canonical dict is the same one digest() hashes, so the fingerprint
     can be verified against it later — a stored decision that can't be linked to
     its permit would repeat the same problem one layer higher (OI-849).
+
+    ``isolation_note`` (OI-1158): an optional loud isolation-guarantee warning
+    (see ``_headless_isolation_guard``) stored as a SIBLING of ``decision``, not
+    inside it — ``canonical_dict()``/``digest()`` deliberately excludes advisory
+    fields, so this never perturbs the permit fingerprint. This is the
+    "receipt-visible field" half of OI-1158's fix: the audit trail this door
+    writes for every dispatch, closest in spirit to a receipt for callers who
+    only have write access to this module.
 
     Never blocks the door: any failure logs a WARN and the dispatch continues.
     """
@@ -1516,6 +1575,8 @@ def _persist_route_decision(
             "plan_digest": permit.plan_digest,
             "decision": canonical,
         }
+        if isolation_note:
+            record["isolation_warning"] = isolation_note
 
         # 1. Append to shared NDJSON under the sentinel + data-file locks.
         ndjson_path = state_dir / "route_decisions.ndjson"
@@ -1659,6 +1720,19 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                 route_reason=f"{door_route_reason};{plan.route_reason}",
             )
 
+        # OI-1158: loud isolation-guarantee warning for lanes the door cannot
+        # structurally verify (currently: claude_headless). Merged onto
+        # plan.warnings — the same mechanism door_route_reason and the D4
+        # model-tier warnings already use — so it surfaces in dry-run output
+        # via _print_plan AND is available below for the real-execution print
+        # and the route-decision receipt field. None for every other lane.
+        headless_isolation_warning = _headless_isolation_guard(plan)
+        if headless_isolation_warning:
+            plan = dataclasses.replace(
+                plan,
+                warnings=plan.warnings + (headless_isolation_warning,),
+            )
+
         # Scout pre-pass (opt-in VNX_SCOUT_PREPASS, fail-open): a cheap key-auth
         # model ranks the deterministic anchors into a sidecar BEFORE the permit
         # is issued. It reads vspec.instruction_text in-memory and writes a
@@ -1736,7 +1810,10 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
         # OI-1120 part 2: fill the register's dispatch_created event here too —
         # same "door commits to firing" moment, one write site for every lane.
         if not dry_run:
-            _persist_route_decision(plan, permit, state_dir=state_dir)
+            _persist_route_decision(
+                plan, permit, state_dir=state_dir,
+                isolation_note=headless_isolation_warning,
+            )
             _register_dispatch_created(plan, permit, vspec.spec, state_dir=state_dir)
 
         if dry_run:
@@ -1772,6 +1849,16 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
                     role=vspec.spec.role,
                 )
             elif plan.lane == "claude_headless":
+                # OI-1158: the door never printed anything about isolation on a
+                # real (non-dry-run) fire — _print_plan's warnings loop only
+                # runs under --dry-run. Surface the same warning here, loud, so
+                # a live headless dispatch is never silent about the gap.
+                if headless_isolation_warning:
+                    logger.warning("[dispatch_cli] %s", headless_isolation_warning)
+                    print(
+                        f"[dispatch_cli] [WARN] {headless_isolation_warning}",
+                        file=sys.stderr,
+                    )
                 return _execute_claude_headless(
                     plan,
                     permit,

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,14 +2,14 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 759,
+      "line": 760,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 762,
+      "line": 763,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
@@ -310,42 +310,42 @@
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 204,
+      "line": 214,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 204,
+      "line": 214,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 206,
+      "line": 221,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 257,
+      "line": 279,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 257,
+      "line": 279,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 259,
+      "line": 286,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -401,119 +401,119 @@
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 166,
+      "line": 178,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 167,
+      "line": 179,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 412,
+      "line": 436,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 449,
+      "line": 473,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 514,
+      "line": 538,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 560,
+      "line": 584,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 603,
+      "line": 627,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 643,
+      "line": 667,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 678,
+      "line": 702,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 684,
+      "line": 708,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 684,
+      "line": 708,
       "mechanism": "monkeypatch",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 689,
+      "line": 713,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 728,
+      "line": 752,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 729,
+      "line": 753,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 760,
+      "line": 784,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 792,
+      "line": 816,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 793,
+      "line": 817,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -660,84 +660,105 @@
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 29,
+      "line": 30,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "EnvelopeSpec"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 30,
+      "line": 31,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 31,
+      "line": 32,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_headless_plan"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 145,
+      "line": 146,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 145,
+      "line": 146,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 147,
+      "line": 148,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 204,
+      "line": 205,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 204,
+      "line": 205,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 206,
+      "line": 207,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 263,
+      "line": 264,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 263,
+      "line": 264,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 265,
+      "line": 266,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 340,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 340,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 342,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -968,35 +989,35 @@
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1032,
+      "line": 1036,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1032,
+      "line": 1036,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1123,
+      "line": 1127,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1123,
+      "line": 1127,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1139,
+      "line": 1143,
       "mechanism": "logger-name",
       "module_target": "dispatch_envelope",
       "symbol": ""
@@ -1137,6 +1158,7 @@
     "dispatch_envelope.LaneRouter::get",
     "dispatch_envelope::_dispatch_branch_name",
     "dispatch_envelope::_enforce_push_pr",
+    "dispatch_envelope::_is_dispatch_branch_ref",
     "dispatch_envelope::_receipts_file_for",
     "dispatch_envelope::_resolve_base_sha",
     "dispatch_envelope::run_envelope",

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -1764,6 +1764,154 @@ def test_legacy_env_vars_do_not_bypass_headless_gate(tmp_path, monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# OI-1158 — headless isolation guard: never silent on isolation=worktree
+# ---------------------------------------------------------------------------
+
+class TestHeadlessIsolationGuard:
+    """The door must never no-op on isolation=worktree for a lane it cannot
+    structurally verify (currently: claude_headless).
+
+    Peer-measured 2026-08-12 (pacompany-engine, OI-1158): two headless
+    dispatches, both staged with isolation:'worktree' in the spec, ended up
+    sharing one tree with zero warning anywhere in the door. These tests must
+    fail on pre-fix code (no _headless_isolation_guard, no warning surfaced
+    anywhere, no receipt field) and pass on the fix.
+    """
+
+    def test_guard_flags_headless_lane(self, tmp_path):
+        """_headless_isolation_guard returns a non-empty warning for claude_headless."""
+        from dispatch_cli import _headless_isolation_guard
+
+        spec_file = _make_spec_file(tmp_path, provider="claude", extra={
+            "allow_headless": True,
+            "headless_reason": "unit test",
+        })
+        spec = load_spec(spec_file)
+        vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+        assert not isinstance(vspec, Reject), f"spec must validate cleanly, got {vspec}"
+        plan = compile_plan(vspec, _clean_snapshot())
+        assert not isinstance(plan, Reject), f"plan must compile cleanly, got {plan}"
+        assert plan.lane == "claude_headless"
+
+        warning = _headless_isolation_guard(plan)
+        assert warning, "headless lane must get a non-empty isolation warning"
+        assert "OI-1158" in warning
+        assert "isolation" in warning.lower()
+
+    def test_guard_returns_none_for_tmux_lane(self, tmp_path):
+        """The tmux lane's isolation is structurally verified elsewhere — no warning."""
+        from dispatch_cli import _headless_isolation_guard
+
+        spec_file = _make_spec_file(tmp_path, provider="claude")
+        spec = load_spec(spec_file)
+        vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+        plan = compile_plan(vspec, _clean_snapshot())
+        assert plan.lane == "claude_tmux_subscription"
+
+        assert _headless_isolation_guard(plan) is None
+
+    def test_guard_returns_none_for_provider_lane(self, tmp_path):
+        """A provider (non-claude) lane also gets no headless-specific warning."""
+        from dispatch_cli import _headless_isolation_guard
+
+        spec_file = _make_spec_file(tmp_path, provider="codex")
+        spec = load_spec(spec_file)
+        vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+        plan = compile_plan(vspec, _clean_snapshot())
+        assert plan.lane == "provider"
+
+        assert _headless_isolation_guard(plan) is None
+
+    @patch("dispatch_cli.build_runtime_snapshot")
+    def test_dry_run_surfaces_isolation_warning_for_headless(self, mock_snapshot, tmp_path, capsys):
+        """--dry-run on a headless spec must print the isolation warning — never silent."""
+        mock_snapshot.return_value = _clean_snapshot()
+        spec_file = _make_spec_file(tmp_path, provider="claude", extra={
+            "allow_headless": True,
+            "headless_reason": "unit test",
+        })
+
+        rc = run_dispatch(spec_file, dry_run=True)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OI-1158" in out, (
+            f"dry-run on a headless spec must surface the isolation warning; got:\n{out}"
+        )
+
+    @patch("dispatch_cli.build_runtime_snapshot")
+    def test_dry_run_default_claude_has_no_isolation_warning(self, mock_snapshot, tmp_path, capsys):
+        """Regression pin: a normal (tmux-lane) dry-run must NOT print the OI-1158 warning."""
+        mock_snapshot.return_value = _clean_snapshot()
+        spec_file = _make_spec_file(tmp_path, provider="claude")
+
+        rc = run_dispatch(spec_file, dry_run=True)
+
+        assert rc == 0
+        out = capsys.readouterr().out
+        assert "OI-1158" not in out, (
+            f"tmux-lane dispatch must not carry the headless isolation warning; got:\n{out}"
+        )
+
+    @patch("dispatch_cli.build_runtime_snapshot")
+    def test_real_headless_dispatch_prints_warning_and_stamps_receipt_field(
+        self, mock_snapshot, tmp_path, capsys
+    ):
+        """A live (non-dry-run) headless fire must print the warning to stderr AND
+        pass a non-empty isolation_note through to _persist_route_decision — the
+        receipt-visible half of OI-1158's fix."""
+        mock_snapshot.return_value = _clean_snapshot()
+        spec_file = _make_spec_file(tmp_path, provider="claude", extra={
+            "allow_headless": True,
+            "headless_reason": "unit test",
+        })
+
+        with patch("dispatch_cli._execute_claude_headless", return_value=0) as mock_headless, \
+             patch("dispatch_cli._persist_route_decision") as mock_persist, \
+             patch.dict(os.environ, {"VNX_OVERRIDE_CLAUDE_HEADLESS": "1"}):
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0
+        mock_headless.assert_called_once()
+
+        err = capsys.readouterr().err
+        assert "OI-1158" in err, (
+            f"live headless fire must print the isolation warning to stderr; got:\n{err}"
+        )
+
+        mock_persist.assert_called_once()
+        _, persist_kwargs = mock_persist.call_args
+        assert persist_kwargs.get("isolation_note"), (
+            "the route-decision receipt must carry a non-empty isolation_note "
+            "for a headless dispatch"
+        )
+        assert "OI-1158" in persist_kwargs["isolation_note"]
+
+    def test_real_tmux_dispatch_has_no_isolation_note(self, tmp_path, monkeypatch):
+        """Regression pin: a tmux-lane dispatch's route-decision must carry
+        isolation_note=None — the warning is headless-specific."""
+        data_dir, spec_file = _make_bundle_spec(
+            tmp_path,
+            instruction_text="# OI-1158 tmux regression\n\nDo something safe.\n",
+            staging_id="20260812-staging-oi1158-tmux",
+            dispatch_id="20260812-oi1158-tmux",
+            target_slot="T0",
+        )
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        with patch("dispatch_cli._execute_claude", return_value=0) as mock_exec, \
+             patch("dispatch_cli._persist_route_decision") as mock_persist:
+            rc = run_dispatch(spec_file)
+
+        assert rc == 0
+        mock_exec.assert_called_once()
+        mock_persist.assert_called_once()
+        _, persist_kwargs = mock_persist.call_args
+        assert persist_kwargs.get("isolation_note") is None
+
+
+# ---------------------------------------------------------------------------
 # HIGH-1 — load_spec strict bool coercion for allow_headless / requires_mcp
 # ---------------------------------------------------------------------------
 

--- a/tests/test_headless_worktree_isolation.py
+++ b/tests/test_headless_worktree_isolation.py
@@ -13,6 +13,7 @@ fix branch. Pure unit assertions — no worker spawn.
 from __future__ import annotations
 
 import hashlib
+import os
 import sys
 from dataclasses import replace
 from pathlib import Path
@@ -272,4 +273,83 @@ class TestHeadlessWorktreeIsolation:
         assert remove_calls, (
             "remove_dispatch_worktree was never called — teardown is missing; "
             "the worktree would leak on every headless dispatch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — OI-1158: the isolation boundary through the ACTUAL door entry point
+# ---------------------------------------------------------------------------
+
+
+class TestExecuteClaudeHeadlessIsolationBoundary:
+    """OI-1158 (peer-measured 2026-08-12, pacompany-engine): prove the
+    isolation boundary through ``dispatch_cli._execute_claude_headless`` — the
+    actual door entry point for the headless lane — not just
+    ``run_envelope_headless_plan`` directly (Test 1 above already covers
+    that). Fabricated runner only, no real claude spawn: ``create_dispatch_worktree``,
+    ``ClaudeSubprocessAdapter.run`` and ``_govern`` are all mocked.
+    """
+
+    def test_execute_claude_headless_worker_runs_inside_dispatch_worktree(
+        self, tmp_path: Path
+    ) -> None:
+        """_execute_claude_headless must hand the worker cwd=<dispatch worktree>,
+        never the main checkout — the exact symptom peer-measured on 2026-08-12
+        (two headless dispatches sharing one tree = the project root)."""
+        import dispatch_envelope
+        from dispatch_cli import _execute_claude_headless
+
+        spec = _make_headless_spec(tmp_path=tmp_path, target_slot="T1")
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless", f"Expected claude_headless, got {plan.lane}"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+        fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{plan.dispatch_id}"
+        fake_wt_path.mkdir(parents=True)
+
+        captured_cwd: list = []
+        captured_dispatch_ids: list = []
+
+        def capture_create(dispatch_id, **kwargs):
+            captured_dispatch_ids.append(dispatch_id)
+            return fake_wt_path
+
+        def capture_adapter_run(spec_arg, cwd=None, **kwargs):
+            captured_cwd.append(cwd)
+            return _fake_adapter_success()
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_receipt, fake_receipt)
+
+        with patch.dict(os.environ, {"VNX_OVERRIDE_CLAUDE_HEADLESS": "1"}), \
+             patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   side_effect=capture_create), \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          side_effect=capture_adapter_run), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            rc = _execute_claude_headless(
+                plan, permit, state_dir=state_dir, data_dir=data_dir, role=plan.role,
+            )
+
+        assert rc == 0, f"expected success returncode, got {rc}"
+        assert captured_dispatch_ids == [plan.dispatch_id], (
+            "the worktree must be allocated for THIS dispatch's own id, never "
+            "reused/shared from another dispatch"
+        )
+        assert captured_cwd and captured_cwd[0] == fake_wt_path, (
+            "the worker must run with cwd=<the dispatch worktree>, not the main "
+            f"checkout — the exact OI-1158 failure mode. Got cwd={captured_cwd}"
         )


### PR DESCRIPTION
## Summary

OI-1158, peer-measured 2026-08-12 (pacompany-engine): two headless dispatches, both staged with `isolation: worktree` in the spec, ended up sharing one tree — the project's own main checkout, on the branch of whichever fired first — with zero warning anywhere in the door. `dispatch_plan.py`'s D6 rule hardcodes `isolation=Isolation.WORKTREE` on every `ExecutionPlan` (it's the only legal enum member), but nothing in `dispatch_cli.py` ever checked whether the *chosen lane* structurally delivers that guarantee, and nothing printed anything when it couldn't verify it. A silent no-op on an isolation guarantee is the most dangerous failure mode: the caller believes they're protected.

## Changes

**Stap 1 — the door never no-ops on isolation again** (`scripts/lib/dispatch_cli.py`):
- New `_headless_isolation_guard(plan)`: returns a loud, `OI-1158`-tagged warning when `plan.lane == "claude_headless"` — the one lane whose isolation lives in a parallel code path (`dispatch_envelope.py` → `dispatch_worktree_isolation.py`) this module never inspects — and `None` for every other lane (the tmux lane's isolation is verified structurally one call away via `tmux_worktree.allocate()` + OI-1124's own-branch assertion).
- The warning is merged onto `plan.warnings` right after `compile_plan()`, so:
  - `--dry-run` surfaces it via the existing `_print_plan` warnings loop (previously the only place `plan.warnings` was ever printed — including the pre-existing "HEADLESS API-billing opted-in" warning, which was itself silent on real fires).
  - A real, non-dry-run headless fire now prints it loud too (`logger.warning` + stderr) — the door previously printed nothing about `plan.warnings` on a live fire, headless or otherwise.
  - `_persist_route_decision` gained an `isolation_note` kwarg, stamped as `record["isolation_warning"]` — a sibling of `decision` (which `canonical_dict()`/`digest()` builds), so it never perturbs the permit fingerprint. This is the receipt-visible field the dispatch asked for, using the closest thing to a receipt this module can write (the existing OI-849 route-decision audit stream).

**Decision: WARN, not REFUSE.** Headless is a live, relied-upon lane (opened 2026-08-11 by explicit operator directive, `DISPATCH_RULES.md` §8) — a hard door-level refusal would block dispatches that run successfully today. The lane already owns its own fail-closed gate (`lane_safety.headless_block`, checked in `_execute_claude_headless`); this is a second, coarser signal layered on top of that gate, not a replacement for it. If a future measurement shows the underlying isolation gap is worse than "unverified by the door," escalating this specific check to a hard refusal is a small, contained follow-up — the receipt trail this PR adds is exactly what would justify that call.

**Stap 2 — investigated, partially pre-existing, residual gap flagged (out of scope):**
Reading `dispatch_envelope.py::run_envelope_headless_plan` and `dispatch_worktree_isolation.py` (both **outside** this dispatch's scope guard — only `dispatch_cli.py` + `tmux_worktree.py` were in scope) shows the headless lane **already creates an isolated worktree and threads `cwd=<worktree>` to the adapter** (OI-1045, `9f32ae84`, already on `main`, still covered by `tests/test_headless_worktree_isolation.py`). This PR adds `TestExecuteClaudeHeadlessIsolationBoundary` in that same file, going through the *actual* door entry point (`_execute_claude_headless`, not just `run_envelope_headless_plan` directly) with a fabricated runner — no real spawn — to close that loop from this dispatch's own scope.

Given that, the peer-observed symptom (two dispatches sharing the literal project root) is very likely a **release-lag artifact** — pacompany-engine running a pinned vnx-orchestration version that predates OI-1045 — not a live bug on `main` today. It does **not**, however, make Stap 1 pointless: nothing before this PR would have caught a *regression* of OI-1045, or a future third lane skipping isolation, since the door never cross-checked the claim at all.

**Genuine residual gap found, out of scope for this dispatch's file list:** `dispatch_worktree_isolation.create_dispatch_worktree()` (`scripts/lib/dispatch_worktree_isolation.py`) does **not** accept or honor `plan.base_ref` — it always resolves `origin/main` (or the `VNX_BENCH_WORKTREE_BASE_REF` bench override), unlike `tmux_worktree.allocate()`, which takes `base_ref` explicitly and is what this dispatch's instructions pointed at as the reference behavior. A headless dispatch targeting a non-default `base_ref` (e.g. fix-forward onto an existing PR branch) gets a correctly *isolated* worktree rooted at the *wrong* base. Fixing this needs `dispatch_envelope.py` / `dispatch_worktree_isolation.py` in scope — flagged as a follow-up, not silently expanded into here.

## Verification

- `tests/test_dispatch_cli.py::TestHeadlessIsolationGuard` (new, 7 tests) — fails on pre-fix `main` (`_headless_isolation_guard` doesn't exist): proves the guard fires for `claude_headless`, stays `None` for `claude_tmux_subscription`/`provider`, surfaces in `--dry-run` output, prints to stderr + stamps `isolation_note` on a real fire, and — the regression pin — a tmux-lane dispatch's `isolation_note` stays `None`.
- `tests/test_headless_worktree_isolation.py::TestExecuteClaudeHeadlessIsolationBoundary` (new) — fabricated runner (`create_dispatch_worktree`, `ClaudeSubprocessAdapter.run`, `_govern` all mocked, no real spawn) through the actual `_execute_claude_headless` door entry point: asserts the worker's `cwd` is the dispatch worktree, never the main checkout.
- **Negative control:** `tests/test_dispatch_cli.py::TestHeadlessIsolationGuard::test_dry_run_default_claude_has_no_isolation_warning` and `::test_real_tmux_dispatch_has_no_isolation_note` assert the OI-1158 warning/field is **absent** for the tmux lane — proving the guard is lane-specific, not blanket noise.
- Full command output:
  - `python3 -m pytest tests/test_dispatch_cli.py tests/test_headless_worktree_isolation.py tests/test_dispatch_enforcement.py tests/test_dispatch_spec.py -q` → **241 passed** (run both in-worktree and again in a fresh clone).
  - `tests/test_tmux_interactive_dispatch.py` — regression pin, run in a **fresh clone** (not this nested worktree, per the known false-red issue) → **217 passed**, unchanged from `main`.

## Test plan

- [x] `_headless_isolation_guard` unit tests (headless/tmux/provider lanes)
- [x] Dry-run surfacing test (positive + negative)
- [x] Real-fire stderr + receipt-field test (positive + negative)
- [x] Isolation-boundary test through `_execute_claude_headless` (fabricated runner)
- [x] `tmux_interactive_dispatch` regression pin, 217/217 green in a fresh clone

🤖 Generated with [Claude Code](https://claude.com/claude-code)