### PR TITLE
fix(headless): honor base_ref when creating the dispatch worktree (blocks the default-lane flip)

### DIFF
--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -515,6 +515,12 @@ def run_envelope_plan(
         resolve_consumer_project_root,
     )
 
+    # Resolved BEFORE worktree creation so create_dispatch_worktree honors the
+    # plan's actual base_ref instead of silently defaulting to origin/main
+    # (OI-1170-class: a fix-forward dispatch with base_ref=origin/dispatch/<branch>
+    # was previously always built on origin/main with no signal).
+    _base_ref = plan.base_ref or "origin/main"
+
     wt_path: Optional[Path] = None
     try:
         # Resolve the CONSUMER project root explicitly (VNX_PROJECT_ROOT / CWD-git,
@@ -526,7 +532,9 @@ def run_envelope_plan(
         # Any resolution failure is handled by the same fail-loud path below as
         # a worktree-creation failure — never falls back to a shared checkout.
         _consumer_project_root = resolve_consumer_project_root()
-        wt_path = create_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+        wt_path = create_dispatch_worktree(
+            plan.dispatch_id, project_root=_consumer_project_root, base_ref=_base_ref,
+        )
     except Exception as _wt_exc:
         _isolation_error = (
             f"isolation required (require_worktree) but worktree creation failed "
@@ -566,7 +574,6 @@ def run_envelope_plan(
         _target_remote_head = None
 
     # ── OI-1115: skip auto-PR when the dispatch works on an existing branch ──
-    _base_ref = plan.base_ref or "origin/main"
     _skip_pr = _is_dispatch_branch_ref(_base_ref)
 
     _phantom_diff: Optional[str] = None
@@ -735,10 +742,17 @@ def run_envelope_headless_plan(
         resolve_consumer_project_root,
     )
 
+    # Resolved BEFORE worktree creation so create_dispatch_worktree honors the
+    # plan's actual base_ref instead of silently defaulting to origin/main —
+    # the headless-lane blocker this dispatch fixes.
+    _base_ref = plan.base_ref or "origin/main"
+
     wt_path: Optional[Path] = None
     try:
         _consumer_project_root = resolve_consumer_project_root()
-        wt_path = create_dispatch_worktree(plan.dispatch_id, project_root=_consumer_project_root)
+        wt_path = create_dispatch_worktree(
+            plan.dispatch_id, project_root=_consumer_project_root, base_ref=_base_ref,
+        )
     except Exception as _wt_exc:
         _isolation_error = (
             f"isolation required but worktree creation failed "
@@ -777,7 +791,6 @@ def run_envelope_headless_plan(
         _target_remote_head = None
 
     # ── OI-1115: skip auto-PR when the dispatch works on an existing branch ──
-    _base_ref = plan.base_ref or "origin/main"
     _skip_pr = _is_dispatch_branch_ref(_base_ref)
 
     _phantom_diff: Optional[str] = None

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -1,9 +1,9 @@
 """dispatch_worktree_isolation.py — per-dispatch ephemeral git worktree.
 
 Always active (default-on since OI-1090, 2026-08-10).
-Each dispatch gets a fresh worktree rooted at origin/main under
-.vnx-data/worktrees/dispatch-{safe_id}/.  The worktree is removed
-(success OR failure) so no state leaks between dispatches.
+Each dispatch gets a fresh worktree, rooted at the caller's explicit base_ref
+(``origin/main`` when none is given), under .vnx-data/worktrees/dispatch-{safe_id}/.
+The worktree is removed (success OR failure) so no state leaks between dispatches.
 
 Dispatch-identity binding (OI-861):
 A worktree's path is derived from the dispatch id, but the path alone does
@@ -470,34 +470,55 @@ def create_dispatch_worktree(
     dispatch_id: str,
     *,
     project_root: Optional[Path] = None,
+    base_ref: Optional[str] = None,
 ) -> Path:
-    """Create an ephemeral git worktree based on origin/main for one dispatch.
+    """Create an ephemeral git worktree for one dispatch, based on *base_ref*.
 
     Steps:
-      1. git fetch origin main  (best-effort — warns on failure)
-      2. git worktree add <path> -b dispatch/<safe_id> origin/main
+      1. git fetch origin <ref>  (best-effort — warns on failure; remote refs only)
+      2. git worktree add <path> -b dispatch/<safe_id> <resolved base ref>
+
+    The base ref actually used is resolved by precedence (highest wins):
+      1. the explicit *base_ref* argument — the caller's real intent (e.g. the
+         dispatch spec's ``plan.base_ref``, mirroring ``tmux_worktree.allocate()``).
+      2. ``VNX_BENCH_WORKTREE_BASE_REF`` — a FALLBACK for callers that never pass
+         an explicit ref at all (the provider-lane benchmark harness), so a bench
+         run can redirect every worktree at the bench checkout's HEAD without
+         threading a base_ref through that call site. It never overrides an
+         explicit *base_ref*: silently redirecting a caller's own explicit
+         request would reproduce the exact silent-wrong-base defect this
+         parameter exists to fix, just from a different source.
+      3. ``"origin/main"`` — the default when neither is given.
+
+    An unresolvable base ref (bad ref, deleted dispatch branch, etc.) fails
+    LOUD — both the ``rev-parse`` and the ``git worktree add`` step below raise
+    with the requested ref named in the message. There is no fallback to
+    origin/main on failure: a silent fallback is the one thing worse than a
+    loud error here — it would put a worker's changes on the wrong tree with
+    no signal until a human reviews an empty or conflicting diff.
 
     Returns the resolved worktree Path.
-    Raises RuntimeError when worktree creation fails.
+    Raises RuntimeError when the base ref is unresolvable or worktree creation fails.
     """
     root = _resolve_project_root(project_root)
     wt_path = _dispatch_worktree_dir(root, dispatch_id)
     safe_id = _sanitize_dispatch_id(dispatch_id)
     branch_name = f"dispatch/{safe_id}"
 
-    # VNX_BENCH_WORKTREE_BASE_REF: base the worktree on a given ref instead of origin/main.
+    # VNX_BENCH_WORKTREE_BASE_REF: see precedence note in the docstring above.
     # The benchmark sets this to the bench checkout's HEAD so worktrees carry the bench
     # branch's committed task seeds (e.g. the t4_02 SWE-bench seed) without merging WIP
     # benchmark tasks to main. Default (unset) keeps origin/main — production unchanged.
-    base_ref = os.environ.get("VNX_BENCH_WORKTREE_BASE_REF", "").strip() or "origin/main"
-    is_remote = base_ref.startswith("origin/")
+    bench_override = os.environ.get("VNX_BENCH_WORKTREE_BASE_REF", "").strip()
+    resolved_base_ref = (base_ref or "").strip() or bench_override or "origin/main"
+    is_remote = resolved_base_ref.startswith("origin/")
 
     wt_path.parent.mkdir(parents=True, exist_ok=True)
 
     if is_remote:
         try:
             subprocess.run(
-                ["git", "fetch", "origin", base_ref[len("origin/"):]],
+                ["git", "fetch", "origin", resolved_base_ref[len("origin/"):]],
                 cwd=str(root),
                 check=True,
                 capture_output=True,
@@ -506,21 +527,21 @@ def create_dispatch_worktree(
         except subprocess.CalledProcessError as exc:
             log.warning(
                 "create_dispatch_worktree: git fetch %s failed (continuing): %s",
-                base_ref, (exc.stderr or "").strip(),
+                resolved_base_ref, (exc.stderr or "").strip(),
             )
 
     # Resolve base_sha BEFORE adding the worktree — needed for teardown
     # classification (L3 provider-lane reap).  Mirrors tmux_worktree.allocate().
     try:
         sha_result = subprocess.run(
-            ["git", "-C", str(root), "rev-parse", base_ref],
+            ["git", "-C", str(root), "rev-parse", resolved_base_ref],
             check=True, capture_output=True, text=True,
         )
         base_sha = sha_result.stdout.strip()
     except subprocess.CalledProcessError as exc:
         raise RuntimeError(
-            f"create_dispatch_worktree: cannot resolve {base_ref!r}: "
-            f"{(exc.stderr or '').strip()}"
+            f"create_dispatch_worktree: cannot resolve base_ref {resolved_base_ref!r} "
+            f"for dispatch {dispatch_id!r}: {(exc.stderr or '').strip()}"
         ) from exc
 
     # OI-975: capture the main checkout HEAD BEFORE worktree creation so
@@ -561,7 +582,7 @@ def create_dispatch_worktree(
                     "git", "worktree", "add",
                     str(wt_path),
                     "-b", branch_name,
-                    base_ref,
+                    resolved_base_ref,
                 ],
                 cwd=str(root),
                 check=True,
@@ -576,8 +597,8 @@ def create_dispatch_worktree(
             if raced is not None:
                 _claim_belongs_to_or_raise(dispatch_id, raced, wt_path)
             raise RuntimeError(
-                f"create_dispatch_worktree failed for {dispatch_id!r}: "
-                f"{(exc.stderr or '').strip()}"
+                f"create_dispatch_worktree failed for {dispatch_id!r} "
+                f"(base_ref={resolved_base_ref!r}): {(exc.stderr or '').strip()}"
             ) from exc
 
         # Claim the freshly-created worktree atomically (O_EXCL).  From here on
@@ -592,7 +613,7 @@ def create_dispatch_worktree(
                 worktree_path=wt_path,
                 project_root=root,
                 base_sha=base_sha,
-                base_ref=base_ref,
+                base_ref=resolved_base_ref,
                 branch=branch_name,
                 main_head_sha=_main_head_sha,
             )

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -2,14 +2,14 @@
   "couplings": [
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 759,
+      "line": 760,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "run_envelope_plan"
     },
     {
       "file": "tests/test_dispatch_cli.py",
-      "line": 762,
+      "line": 763,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
@@ -310,42 +310,42 @@
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 204,
+      "line": 214,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 204,
+      "line": 214,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 206,
+      "line": 221,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 257,
+      "line": 279,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 257,
+      "line": 279,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_field_propagation.py",
-      "line": 259,
+      "line": 286,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -401,119 +401,119 @@
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 166,
+      "line": 178,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 167,
+      "line": 179,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 412,
+      "line": 436,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 449,
+      "line": 473,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 514,
+      "line": 538,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 560,
+      "line": 584,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 603,
+      "line": 627,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 643,
+      "line": 667,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 678,
+      "line": 702,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 684,
+      "line": 708,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 684,
+      "line": 708,
       "mechanism": "monkeypatch",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 689,
+      "line": 713,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 728,
+      "line": 752,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 729,
+      "line": 753,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 760,
+      "line": 786,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 792,
+      "line": 818,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
     },
     {
       "file": "tests/test_dispatch_envelope_plan.py",
-      "line": 793,
+      "line": 819,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -681,63 +681,84 @@
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 145,
+      "line": 147,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
-    },
-    {
-      "file": "tests/test_headless_worktree_isolation.py",
-      "line": 145,
-      "mechanism": "patch.object-attr",
-      "module_target": "dispatch_envelope",
-      "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
       "line": 147,
-      "mechanism": "patch-string",
-      "module_target": "dispatch_envelope",
-      "symbol": "_govern"
-    },
-    {
-      "file": "tests/test_headless_worktree_isolation.py",
-      "line": 204,
-      "mechanism": "direct-call",
-      "module_target": "dispatch_envelope",
-      "symbol": "ClaudeSubprocessAdapter"
-    },
-    {
-      "file": "tests/test_headless_worktree_isolation.py",
-      "line": 204,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 149,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
       "line": 206,
-      "mechanism": "patch-string",
-      "module_target": "dispatch_envelope",
-      "symbol": "_govern"
-    },
-    {
-      "file": "tests/test_headless_worktree_isolation.py",
-      "line": 263,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
-      "line": 263,
+      "line": 206,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter.run"
     },
     {
       "file": "tests/test_headless_worktree_isolation.py",
+      "line": 208,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
       "line": 265,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 265,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 267,
+      "mechanism": "patch-string",
+      "module_target": "dispatch_envelope",
+      "symbol": "_govern"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 326,
+      "mechanism": "direct-call",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 326,
+      "mechanism": "patch.object-attr",
+      "module_target": "dispatch_envelope",
+      "symbol": "ClaudeSubprocessAdapter.run"
+    },
+    {
+      "file": "tests/test_headless_worktree_isolation.py",
+      "line": 328,
       "mechanism": "patch-string",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -968,35 +989,35 @@
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1032,
+      "line": 1036,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1032,
+      "line": 1036,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1123,
+      "line": 1127,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1123,
+      "line": 1127,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_enforce_push_pr"
     },
     {
       "file": "tests/test_provider_dispatch_worktree_isolation.py",
-      "line": 1139,
+      "line": 1143,
       "mechanism": "logger-name",
       "module_target": "dispatch_envelope",
       "symbol": ""
@@ -1137,6 +1158,7 @@
     "dispatch_envelope.LaneRouter::get",
     "dispatch_envelope::_dispatch_branch_name",
     "dispatch_envelope::_enforce_push_pr",
+    "dispatch_envelope::_is_dispatch_branch_ref",
     "dispatch_envelope::_receipts_file_for",
     "dispatch_envelope::_resolve_base_sha",
     "dispatch_envelope::run_envelope",

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -754,7 +754,9 @@ class TestEnvelopeWorktreeIsolation:
             result = run_envelope_plan(plan, permit, state_dir=state_dir, data_dir=data_dir)
 
         assert result.status == "success"
-        mock_create.assert_called_once_with("wt-cwd-test", project_root=_fake_consumer_root)
+        mock_create.assert_called_once_with(
+            "wt-cwd-test", project_root=_fake_consumer_root, base_ref=plan.base_ref
+        )
         assert adapter_calls, "ProviderAdapter.run was not called"
         assert adapter_calls[0]["cwd"] == _FAKE_WT_PATH, (
             f"expected cwd={_FAKE_WT_PATH}, got cwd={adapter_calls[0]['cwd']}"

--- a/tests/test_headless_worktree_isolation.py
+++ b/tests/test_headless_worktree_isolation.py
@@ -58,6 +58,7 @@ def _make_headless_spec(
     pr_id: Optional[str] = None,
     target_slot: str = "T1",
     model: str = "sonnet",
+    base_ref: str = "origin/main",
 ) -> DispatchSpec:
     return DispatchSpec(
         schema_version=1,
@@ -72,6 +73,7 @@ def _make_headless_spec(
         provider=Provider.CLAUDE,
         model=model,
         pr_id=pr_id,
+        base_ref=base_ref,
         allow_headless=True,
         headless_reason="test",
     )
@@ -272,4 +274,66 @@ class TestHeadlessWorktreeIsolation:
         assert remove_calls, (
             "remove_dispatch_worktree was never called — teardown is missing; "
             "the worktree would leak on every headless dispatch"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — the headless-lane base_ref blocker (20260812h-a-headless-baseref)
+# ---------------------------------------------------------------------------
+
+
+class TestHeadlessWorktreeHonorsBaseRef:
+    """create_dispatch_worktree() always built on origin/main regardless of
+    plan.base_ref, because run_envelope_headless_plan never passed it through.
+    A headless dispatch fired with a non-default base_ref (e.g. a fix-forward
+    dispatch on an existing PR branch, base_ref=origin/dispatch/<branch>) got a
+    correctly ISOLATED worktree on the WRONG basis, with no signal — the
+    worker's diff then looks empty or conflicting for reasons unrelated to the
+    actual work. This test must fail on the pre-fix code (create_dispatch_worktree
+    called without a base_ref kwarg at all) and pass on the fix.
+    """
+
+    def test_plan_base_ref_is_passed_to_create_dispatch_worktree(self, tmp_path: Path) -> None:
+        spec = _make_headless_spec(
+            tmp_path=tmp_path, base_ref="origin/dispatch/some-existing-branch",
+        )
+        vspec = _make_vspec_from_spec(spec)
+        plan = compile_plan(vspec, _healthy_snapshot())
+        assert plan.lane == "claude_headless"
+        assert plan.base_ref == "origin/dispatch/some-existing-branch"
+        permit = issue_permit(plan)
+
+        state_dir = tmp_path / "state"
+        data_dir = tmp_path / "data"
+        state_dir.mkdir()
+        data_dir.mkdir()
+        fake_receipt = state_dir / "t0_receipts.ndjson"
+        fake_receipt.touch()
+
+        fake_consumer_root = tmp_path / "consumer-root"
+        fake_consumer_root.mkdir()
+        fake_wt_path = fake_consumer_root / ".vnx-data" / "worktrees" / f"dispatch-{plan.dispatch_id}"
+        fake_wt_path.mkdir(parents=True)
+
+        def capture_govern(spec_arg, *args, **kwargs):
+            return (fake_receipt, fake_receipt)
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root",
+                   return_value=fake_consumer_root), \
+             patch("dispatch_worktree_isolation.create_dispatch_worktree",
+                   return_value=fake_wt_path) as mock_create, \
+             patch("dispatch_worktree_isolation.remove_dispatch_worktree"), \
+             patch.object(dispatch_envelope.ClaudeSubprocessAdapter, "run",
+                          return_value=_fake_adapter_success()), \
+             patch("dispatch_envelope._govern", side_effect=capture_govern):
+            result = run_envelope_headless_plan(
+                plan, permit, state_dir=state_dir, data_dir=data_dir,
+                role=plan.role,
+            )
+
+        assert result.status == "success"
+        mock_create.assert_called_once_with(
+            plan.dispatch_id,
+            project_root=fake_consumer_root,
+            base_ref="origin/dispatch/some-existing-branch",
         )

--- a/tests/test_subprocess_dispatch_worktree_isolation.py
+++ b/tests/test_subprocess_dispatch_worktree_isolation.py
@@ -184,6 +184,157 @@ class TestCreateDispatchWorktree:
         assert result == expected_wt.resolve()
 
 
+# ─── explicit base_ref (dispatch 20260812h-a-headless-baseref) ───────────────
+
+
+class TestCreateDispatchWorktreeExplicitBaseRef:
+    """create_dispatch_worktree() previously always built on origin/main,
+    ignoring any base_ref the caller wanted — the headless-lane blocker this
+    dispatch fixes. Real git repos (two branches, distinct HEADs) so the
+    assertion is on the worktree's actual committed content, not a mocked
+    subprocess call. These tests fail on the pre-fix signature (no base_ref
+    kwarg accepted at all).
+    """
+
+    @staticmethod
+    def _init_repo_two_branches(tmp_path: Path) -> "tuple[Path, str, str]":
+        """Bare origin + local clone with `main` and `feature` at DIFFERENT commits.
+
+        Returns (local_checkout, main_sha, feature_sha).
+        """
+        bare = tmp_path / "origin.git"
+        bare.mkdir()
+        subprocess.run(
+            ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+            check=True, capture_output=True,
+        )
+        local = tmp_path / "local"
+        subprocess.run(["git", "clone", str(bare), str(local)], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "config", "user.name", "Test"],
+            check=True, capture_output=True,
+        )
+        (local / "README.md").write_text("init\n")
+        subprocess.run(["git", "-C", str(local), "add", "README.md"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(local), "commit", "-m", "initial"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(local), "push", "-u", "origin", "main"], check=True, capture_output=True)
+        main_sha = subprocess.check_output(
+            ["git", "-C", str(local), "rev-parse", "main"], text=True
+        ).strip()
+
+        subprocess.run(["git", "-C", str(local), "checkout", "-b", "feature"], check=True, capture_output=True)
+        (local / "feature.txt").write_text("feature work\n")
+        subprocess.run(["git", "-C", str(local), "add", "feature.txt"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(local), "commit", "-m", "feature commit"], check=True, capture_output=True)
+        subprocess.run(["git", "-C", str(local), "push", "-u", "origin", "feature"], check=True, capture_output=True)
+        feature_sha = subprocess.check_output(
+            ["git", "-C", str(local), "rev-parse", "feature"], text=True
+        ).strip()
+
+        subprocess.run(["git", "-C", str(local), "checkout", "main"], check=True, capture_output=True)
+        assert main_sha != feature_sha, "fixture bug: main and feature must diverge"
+        return local, main_sha, feature_sha
+
+    def test_explicit_base_ref_sets_worktree_on_that_ref(self, tmp_path, monkeypatch):
+        """An explicit base_ref=origin/feature builds the worktree on feature's
+        HEAD, not origin/main — the core fix this dispatch delivers."""
+        monkeypatch.delenv("VNX_BENCH_WORKTREE_BASE_REF", raising=False)
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        local, main_sha, feature_sha = self._init_repo_two_branches(tmp_path)
+
+        wt_path = create_dispatch_worktree(
+            "explicit-base-ref-test", project_root=local, base_ref="origin/feature",
+        )
+
+        wt_head = subprocess.check_output(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"], text=True
+        ).strip()
+        assert wt_head == feature_sha, (
+            f"worktree HEAD ({wt_head}) must equal the explicit base_ref's commit "
+            f"({feature_sha}, feature), not origin/main's ({main_sha}) — a dispatch "
+            f"with base_ref=origin/dispatch/<branch> must build on THAT branch"
+        )
+        assert (wt_path / "feature.txt").exists(), (
+            "worktree must contain the feature branch's file — proof it was built "
+            "on feature, not silently on main"
+        )
+
+    def test_no_explicit_base_ref_defaults_to_origin_main(self, tmp_path, monkeypatch):
+        """Omitting base_ref preserves the pre-existing default: origin/main."""
+        monkeypatch.delenv("VNX_BENCH_WORKTREE_BASE_REF", raising=False)
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        local, main_sha, _feature_sha = self._init_repo_two_branches(tmp_path)
+
+        wt_path = create_dispatch_worktree("default-base-ref-test", project_root=local)
+
+        wt_head = subprocess.check_output(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"], text=True
+        ).strip()
+        assert wt_head == main_sha
+        assert not (wt_path / "feature.txt").exists()
+
+    def test_bench_override_still_works_without_explicit_base_ref(self, tmp_path, monkeypatch):
+        """VNX_BENCH_WORKTREE_BASE_REF remains a working fallback for callers
+        that pass no explicit base_ref (the provider-lane benchmark harness)."""
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        local, _main_sha, feature_sha = self._init_repo_two_branches(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "feature")
+
+        wt_path = create_dispatch_worktree("bench-override-test", project_root=local)
+
+        wt_head = subprocess.check_output(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"], text=True
+        ).strip()
+        assert wt_head == feature_sha, (
+            "VNX_BENCH_WORKTREE_BASE_REF must still redirect the worktree when the "
+            "caller passes no explicit base_ref"
+        )
+
+    def test_explicit_base_ref_wins_over_bench_override(self, tmp_path, monkeypatch):
+        """An explicit base_ref takes priority over VNX_BENCH_WORKTREE_BASE_REF.
+
+        The bench env var is a fallback for callers with no explicit base_ref
+        (see the precedence note in create_dispatch_worktree's docstring), not an
+        override of a caller's own explicit request — silently letting the env
+        win would reproduce the exact silent-wrong-base defect this fix closes,
+        just from a different source.
+        """
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        local, main_sha, _feature_sha = self._init_repo_two_branches(tmp_path)
+        monkeypatch.setenv("VNX_BENCH_WORKTREE_BASE_REF", "feature")
+
+        wt_path = create_dispatch_worktree(
+            "explicit-wins-test", project_root=local, base_ref="origin/main",
+        )
+
+        wt_head = subprocess.check_output(
+            ["git", "-C", str(wt_path), "rev-parse", "HEAD"], text=True
+        ).strip()
+        assert wt_head == main_sha
+
+    def test_nonexistent_base_ref_fails_loud_with_ref_named(self, tmp_path, monkeypatch):
+        """A base_ref that doesn't exist raises RuntimeError naming the ref —
+        no silent fallback to origin/main (OI-class: a stale/silent fallback is
+        worse than a loud error here)."""
+        monkeypatch.delenv("VNX_BENCH_WORKTREE_BASE_REF", raising=False)
+        from dispatch_worktree_isolation import create_dispatch_worktree
+
+        local, _main_sha, _feature_sha = self._init_repo_two_branches(tmp_path)
+
+        with pytest.raises(RuntimeError, match="origin/does-not-exist"):
+            create_dispatch_worktree(
+                "bad-base-ref-test", project_root=local, base_ref="origin/does-not-exist",
+            )
+
+
 class TestCentralInstallGuard:
     """P0 provider-worktree-root-fix: a dispatch worktree must NEVER be created
     (or removed) inside the shared VNX central install tree


### PR DESCRIPTION
## Summary

`create_dispatch_worktree()` always built the worktree on `origin/main`, ignoring the caller's `plan.base_ref`. A headless (or provider-lane) dispatch fired with `base_ref=origin/dispatch/<branch>` (fix-forward on an existing PR) silently got a correctly-isolated worktree on the WRONG basis, with no signal until a human reviewed an empty or conflicting diff. This is the last hard blocker before `claude` can default to the headless lane.

## Changes

- `scripts/lib/dispatch_worktree_isolation.py`: `create_dispatch_worktree()` accepts an explicit `base_ref` kwarg. Precedence: explicit param > `VNX_BENCH_WORKTREE_BASE_REF` (fallback for callers with no explicit ref, e.g. the benchmark harness) > `"origin/main"` default. An unresolvable ref fails loud, naming the ref, at both `rev-parse` and `git worktree add` — never a silent fallback.
- `scripts/lib/dispatch_envelope.py`: both `run_envelope_plan` and `run_envelope_headless_plan` now resolve `_base_ref = plan.base_ref or "origin/main"` **before** calling `create_dispatch_worktree` and pass it through. Both lane handlers carried the identical latent bug, so both are fixed together (Codex Defense Checklist: no asymmetric handlers).
- Tests updated/added in `tests/test_headless_worktree_isolation.py`, `tests/test_subprocess_dispatch_worktree_isolation.py`, `tests/test_dispatch_envelope_plan.py`.

Part 2 (default-flip prep research, not implemented) is written up in the dispatch's completion report — concurrency-cap proposal, `headless_reason` semantics, and the report-gate gap re-check.

## Test plan

- [x] `tests/test_headless_worktree_isolation.py` — 4 passed
- [x] `tests/test_subprocess_dispatch_worktree_isolation.py` — 31 passed (5 new base_ref tests, real git repos)
- [x] `tests/test_dispatch_envelope.py` — 35 passed
- [x] `tests/test_dispatch_envelope_plan.py` — 22 passed (updated one exact-call assertion)
- [x] Cross-check: `test_dispatch_worktree_identity_race.py`, `test_provider_dispatch_worktree_isolation.py`, `test_dispatch_envelope_fail_loud.py`, `test_dispatch_envelope_field_propagation.py`, `test_lane_matrix_row7_push_pr.py`, `test_envelope_ringbuffer_teardown_oi902.py`, `test_phantom_guard_oi869_oi870.py`, `test_phantom_guard_branch_fallback.py`, `test_failclass_registry.py`, `test_tmux_worktree.py` — all green (3 pre-existing unrelated failures in `test_final_prompt_integrity.py`, reproduced identically on `HEAD~1`, caused by running tests from inside a nested dispatch worktree — matches project memory `geneste-worktree-breekt-de-dispatch-tests`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)