### PR TITLE
fix(smart-router): close tier-mid/high enum gap and make availability a runtime signal

### DIFF
--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1043,7 +1043,7 @@ def _discover_valid_roles(agents_dir: Path) -> frozenset[str]:
         return frozenset()
 
 
-def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[tuple[Provider, str, str]]":
+def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[DoorRouteResult]":
     """Run the smart router on a DispatchSpec BEFORE validate().
 
     OI-962: the router must resolve provider+model BEFORE validate() tests
@@ -1051,9 +1051,11 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[tuple[Provider
     (including the empty/None→auto bridge alias), this reads the instruction
     file and consults the tier-routing engine.
 
-    Returns (provider, model, route_reason) when the router has a
-    recommendation, or None when routing should be skipped (T0, router
-    disabled, or router error).
+    Returns a DoorRouteResult carrying (provider, model, route_reason) when the
+    router has a recommendation, or a decline_reason (+ tier when the
+    classifier ran) when routing should be skipped (T0, router disabled,
+    provider-not-mapped, classifier error). Returns None on an unexpected
+    error outside the router (e.g. an unreadable instruction file).
 
     Fail-open: never raises — returns None on any error.
     """
@@ -1073,13 +1075,41 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[tuple[Provider
             instruction_text=instruction_text,
             file_paths=file_paths,
         )
-    except Exception:
+    except Exception as exc:
         logger.warning(
             "smart-router pre-validate: router call failed, dispatch "
             "falls through to default lane (fail-open). Error: %s",
+            exc,
             exc_info=True,
         )
         return None
+
+
+# OI-1187: tier-aware fallback for a router decline. Keys are the canonical
+# cost_tier constants (TIER_HIGH / TIER_MID) kept as literals here because
+# dispatch_cli avoids a module-level import of the smart_router package (the
+# router is imported lazily inside _resolve_router_pre_validate). A tier-high
+# decline must land on opus-5 (equal class), never silently on sonnet.
+_TIER_FALLBACK_MODEL: dict[str, str] = {
+    "tier-high": "opus-5",
+    "tier-mid": "sonnet-5",
+}
+
+
+def _tier_aware_fallback_model(tier: Optional[str], spec_model: Optional[str]) -> str:
+    """Pick the claude-lane fallback model when the router declines to route.
+
+    An explicit spec.model always wins. Otherwise the fallback is tier-aware:
+    a tier-high dispatch the classifier could not route lands on opus-5 (equal
+    class) and tier-mid on sonnet-5, never silently a class down (OI-1187).
+    A tier the classifier did not determine (None) keeps the historical
+    "sonnet" last resort.
+    """
+    if spec_model:
+        return spec_model
+    if tier:
+        return _TIER_FALLBACK_MODEL.get(tier, "sonnet")
+    return "sonnet"
 
 
 def build_runtime_snapshot(
@@ -1668,16 +1698,16 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
     # then validate() tests the resolved values against constraints.  This
     # keeps governance intact: a route that violates constraints is still
     # rejected by the full validation chain — only the order changed.
-    # Deterministic fallback: when the router returns None (T0, disabled,
-    # tier-mid/high routing to claude), AUTO resolves to CLAUDE so
+    # Deterministic fallback: when the router declines (T0, disabled,
+    # provider-not-mapped, classifier error), AUTO resolves to CLAUDE so
     # compile_plan never sees an unresolved AUTO.  This is the same
     # hard-default the old bridge alias provided, now applied AFTER the
     # router had its chance to fill in a cheaper provider.
     door_route_reason: Optional[str] = None
     if spec.provider == Provider.AUTO:
         result = _resolve_router_pre_validate(spec)
-        if result is not None:
-            new_provider, new_model, route_reason = result
+        if result is not None and result.route is not None:
+            new_provider, new_model, route_reason = result.route
             spec = dataclasses.replace(spec, provider=new_provider, model=new_model)
             door_route_reason = route_reason
         else:
@@ -1685,18 +1715,28 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
             # a classifier/resolver exception, or a tier whose TierRoute.provider
             # has no _TIER_PROVIDER_TO_ENUM entry) — fall back to CLAUDE. OI-1050:
             # this must set provider AND model TOGETHER, in the same replace() call
-            # that resolves the router's own success path above (line 1550-1552).
-            # Setting provider alone previously left spec.model=None, and the
-            # workers-kimi-pinned "default" pin semantics then filled effective_model
-            # from ITS OWN pin (kimi-k3) whenever spec.model was empty — producing a
-            # spec with provider=claude and model=kimi-k3, which kimi-via-cli-only
-            # correctly rejects. Defaulting model here, in the same statement as the
-            # provider, makes that half-filled combination unreachable rather than
-            # merely unlikely — spec.model is only used when the caller already set
-            # one; otherwise it lands on the same "sonnet" default every other
-            # claude-lane fallback in this function already uses.
-            spec = dataclasses.replace(spec, provider=Provider.CLAUDE, model=spec.model or "sonnet")
-            door_route_reason = "smart-router:no-route,fallback=claude"
+            # that resolves the router's own success path above. Setting provider
+            # alone previously left spec.model=None, and the workers-kimi-pinned
+            # "default" pin semantics then filled effective_model from ITS OWN pin
+            # (kimi-k3) whenever spec.model was empty — producing a spec with
+            # provider=claude and model=kimi-k3, which kimi-via-cli-only correctly
+            # rejects.
+            #
+            # OI-1187: the fallback model is tier-aware. A tier-high dispatch whose
+            # routing failed must never silently land on sonnet (a quality class
+            # drop); it falls back to opus-5 (equal class) instead. Only when the
+            # classifier did not determine a tier (or the router returned None on an
+            # unexpected error) does the historical "sonnet" default apply.
+            tier = result.tier if result is not None else None
+            fallback_model = _tier_aware_fallback_model(tier, spec.model)
+            spec = dataclasses.replace(spec, provider=Provider.CLAUDE, model=fallback_model)
+            decline_reason = result.decline_reason if result is not None else None
+            if decline_reason:
+                door_route_reason = (
+                    f"smart-router:no-route,reason={decline_reason},fallback={fallback_model}"
+                )
+            else:
+                door_route_reason = f"smart-router:no-route,fallback={fallback_model}"
 
     vspec = validate(spec, project_id=project_id, repo_root=repo_root)
     if isinstance(vspec, Reject):

--- a/scripts/lib/incident_taxonomy.py
+++ b/scripts/lib/incident_taxonomy.py
@@ -93,6 +93,14 @@ class IncidentClass(str, Enum):
     Detected by: generation mismatch error, InvalidTransitionError on lease ops.
     Scope: single terminal lease."""
 
+    # -- External dependency-level incidents --
+    PROVIDER_OUTAGE = "provider_outage"
+    """A provider lane (Claude, Kimi, GLM, DeepSeek, Codex) failed on quota,
+    auth (403/429), or is otherwise unavailable at decision or execution time.
+    Detected by: a lane failure recorded by the smart-router availability layer
+    (record_lane_failure) or a provider-dispatch error.
+    Scope: a provider lane across dispatches until its cooldown budget clears."""
+
     # -- Workflow-level incidents --
     RESUME_FAILED = "resume_failed"
     """A dispatch that was recovered and re-queued failed again on its next
@@ -361,6 +369,32 @@ RECOVERY_CONTRACTS: Dict[IncidentClass, RecoveryContract] = {
             "One reconciliation attempt permitted to resolve stale lease. "
             "Automatic recovery halted until operator confirms resolution. "
             "Dispatch is NOT dead-lettered — ownership is resolved first."
+        ),
+    ),
+
+    IncidentClass.PROVIDER_OUTAGE: RecoveryContract(
+        incident_class=IncidentClass.PROVIDER_OUTAGE,
+        default_severity=Severity.WARNING,
+        retry_budget=RetryBudget(
+            max_retries=3,
+            cooldown_seconds=3600,
+            backoff_factor=2.0,
+            max_cooldown_seconds=14400,
+        ),
+        escalation=EscalationRule(
+            escalate_after_retries=2,
+            escalate_to="T0",
+            halt_auto_recovery=False,
+            dead_letter_eligible=False,
+        ),
+        permitted_actions=(
+            RecoveryAction.ESCALATE_TO_OPERATOR,
+        ),
+        description=(
+            "A provider lane failed on quota, auth (403/429), or availability. "
+            "Cooldown the lane for one hour, doubling on repeat up to four hours. "
+            "Escalate to T0 after the second consecutive failure. "
+            "The lane re-engages automatically once its cooldown budget clears."
         ),
     ),
 

--- a/scripts/lib/providers/smart_router/__init__.py
+++ b/scripts/lib/providers/smart_router/__init__.py
@@ -11,6 +11,12 @@ from __future__ import annotations
 import os as _os
 from typing import Optional
 
+from .availability import (  # noqa: F401
+    cooldown_seconds,
+    lane_available,
+    lane_cooldown_remaining,
+    record_lane_failure,
+)
 from .classifier import (  # noqa: F401
     RouteCandidate,
     RouteDecision,
@@ -34,6 +40,10 @@ __all__ = [
     "classify_dispatch",
     "TierRoute",
     "resolve_tier_route",
+    "lane_available",
+    "lane_cooldown_remaining",
+    "cooldown_seconds",
+    "record_lane_failure",
     "route_dispatch",
 ]
 

--- a/scripts/lib/providers/smart_router/availability.py
+++ b/scripts/lib/providers/smart_router/availability.py
@@ -1,0 +1,253 @@
+"""availability.py — Decision-time lane availability + cooldown for the smart router.
+
+Until now the smart router encoded provider availability as source comments: a
+lane that hit quota was commented out and only came back via a second code edit
+plus a release (OI-940 commented out the kimi route; the kimi quota has since
+been restored and the router still cannot select it). This module replaces that
+with an explicit availability layer that runs at decision time and is cheap:
+
+  - required env vars present   (deepseek: DEEPSEEK_API_KEY — existing behaviour)
+  - required CLI on PATH        (kimi: kimi CLI — kimi-via-cli-only)
+  - not in cooldown             (a prior quota/auth failure marks the lane
+                                 inactive for an env-configurable period)
+
+Cooldown state lives in the central state dir, resolved via the existing
+``vnx_paths.resolve_state_dir`` helper (never a hardcoded ``.vnx-data/`` path)
+and is written atomically via ``atomic_io.atomic_write_json``.
+
+Fail-open by design: a broken availability layer never blocks a dispatch. Any
+unexpected error is logged loudly and the lane is treated as available, so the
+router falls through to its existing behaviour.
+
+``record_lane_failure`` is the producer side of the cooldown contract:
+lane-execution paths call it when a lane fails on quota/auth
+(403/429/quota-exhausted). Wiring those call sites is the fallback-chain op;
+this module provides the mechanism and the decision-time check.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COOLDOWN_SECONDS = 3600  # 60 minutes
+COOLDOWN_ENV = "VNX_ROUTER_COOLDOWN_SECONDS"
+
+# Lane names this module understands. Values are provider strings the
+# tier-routing engine emits; the regex keeps the per-lane state filename safe.
+_LANE_RE = re.compile(r"^[a-z][a-z0-9-]{0,63}$")
+
+LOCAL_GEMMA_DISABLED_REASON = (
+    "local models skipped per operator decision 2026-08-02; reactivate when "
+    "gemma-4-12b-integration ships"
+)
+
+
+@dataclass(frozen=True)
+class LaneCheck:
+    """Static availability requirements for one lane.
+
+    env_vars / cli_names are the cheap, decision-time gates. disabled_reason
+    marks a lane intentionally out of service (explicit, inspectable) instead
+    of a commented-out route block.
+    """
+
+    lane: str
+    env_vars: tuple = ()
+    cli_names: tuple = ()
+    disabled_reason: Optional[str] = None
+
+
+# The lanes the tier-routing engine can emit. deepseek and kimi are the two
+# cheap lanes actually gated at decision time; claude and codex are deliberately
+# ungated (claude is the subscription floor / t0-opus-only, codex is the
+# last-resort vangnet). local-gemma is explicitly disabled via this layer.
+_LANE_CHECKS: dict[str, LaneCheck] = {
+    "deepseek": LaneCheck(lane="deepseek", env_vars=("DEEPSEEK_API_KEY",)),
+    "kimi": LaneCheck(lane="kimi", cli_names=("kimi",)),
+    "codex": LaneCheck(lane="codex"),
+    "claude": LaneCheck(lane="claude"),
+    "local-gemma": LaneCheck(lane="local-gemma", disabled_reason=LOCAL_GEMMA_DISABLED_REASON),
+}
+
+
+def _validate_lane(lane: str) -> None:
+    if not isinstance(lane, str) or not _LANE_RE.match(lane):
+        raise ValueError(f"invalid lane name: {lane!r}")
+
+
+def _cooldown_dir(state_dir: Path) -> Path:
+    return Path(state_dir) / "router_lane_cooldown"
+
+
+def _cooldown_file(state_dir: Path, lane: str) -> Path:
+    return _cooldown_dir(state_dir) / f"{lane}.json"
+
+
+def _resolve_state_dir() -> Path:
+    """Resolve the central state dir via the existing data-dir helper."""
+    from vnx_paths import resolve_state_dir  # noqa: PLC0415
+
+    return resolve_state_dir()
+
+
+def _now() -> float:
+    return time.time()
+
+
+def cooldown_seconds(env: Optional[dict] = None) -> int:
+    """Return the configured lane-cooldown duration in seconds.
+
+    Default 60 minutes (3600s), overridable via VNX_ROUTER_COOLDOWN_SECONDS.
+    Invalid or negative values fall back to the default with a loud log.
+    """
+    _env = env if env is not None else dict(os.environ)
+    raw = str(_env.get(COOLDOWN_ENV, "")).strip()
+    if not raw:
+        return DEFAULT_COOLDOWN_SECONDS
+    try:
+        value = int(float(raw))
+    except (TypeError, ValueError):
+        logger.warning(
+            "smart-router: invalid %s=%r; using default %ds",
+            COOLDOWN_ENV, raw, DEFAULT_COOLDOWN_SECONDS,
+        )
+        return DEFAULT_COOLDOWN_SECONDS
+    if value < 0:
+        logger.warning(
+            "smart-router: %s=%d is negative; using default %ds",
+            COOLDOWN_ENV, value, DEFAULT_COOLDOWN_SECONDS,
+        )
+        return DEFAULT_COOLDOWN_SECONDS
+    return value
+
+
+def record_lane_failure(
+    lane: str,
+    reason: str,
+    *,
+    state_dir: Optional[Path] = None,
+    duration_seconds: Optional[int] = None,
+    now: Optional[float] = None,
+) -> None:
+    """Mark a lane as in cooldown after a quota/auth failure.
+
+    Best-effort and fail-open: a failure to persist cooldown state is logged and
+    swallowed — cooldown bookkeeping must never break a dispatch.
+    """
+    try:
+        _validate_lane(lane)
+        sd = Path(state_dir) if state_dir is not None else _resolve_state_dir()
+        # New write surface: fail loud if this would write the live central
+        # store under pytest (test-store-isolation guard, w19c/OI-934).
+        from vnx_paths import refuse_real_central_store_write_under_pytest  # noqa: PLC0415
+
+        refuse_real_central_store_write_under_pytest(sd)
+        duration = duration_seconds if duration_seconds is not None else cooldown_seconds()
+        until = (now if now is not None else _now()) + duration
+        from atomic_io import atomic_write_json  # noqa: PLC0415
+
+        atomic_write_json(
+            _cooldown_file(sd, lane),
+            {"lane": lane, "reason": reason, "until": until},
+        )
+        logger.info(
+            "smart-router: lane %r entered cooldown for %ds (reason=%s)",
+            lane, duration, reason,
+        )
+    except Exception as exc:  # vnx-silent-except: cooldown bookkeeping must never break a dispatch
+        logger.warning(
+            "smart-router: failed to record lane %r cooldown (reason=%s): %s",
+            lane, reason, exc,
+        )
+
+
+def lane_cooldown_remaining(
+    lane: str,
+    *,
+    state_dir: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> float:
+    """Return seconds of cooldown remaining for a lane (0.0 when active).
+
+    Fail-open: an unreadable/corrupt state file reads as not-in-cooldown so a
+    broken cooldown reader never removes a lane from service.
+    """
+    try:
+        _validate_lane(lane)
+        sd = Path(state_dir) if state_dir is not None else _resolve_state_dir()
+        state_file = _cooldown_file(sd, lane)
+        if not state_file.is_file():
+            return 0.0
+        data = json.loads(state_file.read_text(encoding="utf-8"))
+        until = float(data.get("until", 0.0))
+        return max(0.0, until - (now if now is not None else _now()))
+    except Exception as exc:  # vnx-silent-except: unreadable cooldown state reads as not-in-cooldown (fail-open)
+        logger.warning(
+            "smart-router: failed to read lane %r cooldown state; treating as "
+            "not-in-cooldown (fail-open): %s",
+            lane, exc,
+        )
+        return 0.0
+
+
+def lane_available(
+    lane: str,
+    *,
+    env: Optional[dict] = None,
+    state_dir: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """Return (available, reason) for a lane at decision time.
+
+    Cheap gates only — no network call in the hot path: env vars, CLI presence
+    on PATH, and cooldown state. Fail-open: any unexpected error treats the lane
+    as available and logs loudly so the router never declines because its own
+    availability layer is broken.
+    """
+    _env = env if env is not None else dict(os.environ)
+    check = _LANE_CHECKS.get(lane)
+    if check is None:
+        # Unknown lane: not gated here — do not remove a lane the router may
+        # legitimately emit that this layer has no requirements for.
+        return True, "no availability requirements for lane"
+    try:
+        if check.disabled_reason is not None:
+            return False, check.disabled_reason
+        for var in check.env_vars:
+            if not _env.get(var):
+                return False, f"missing required env var {var}"
+        for cli in check.cli_names:
+            if shutil.which(cli) is None:
+                return False, f"required CLI {cli!r} not on PATH"
+        remaining = lane_cooldown_remaining(lane, state_dir=state_dir, now=now)
+        if remaining > 0:
+            return False, f"lane in cooldown ({remaining:.0f}s remaining)"
+        return True, "available"
+    except Exception as exc:  # vnx-silent-except: broken availability layer must fail open, never decline a lane
+        logger.warning(
+            "smart-router: availability check for lane %r failed; treating as "
+            "available (fail-open): %s",
+            lane, exc,
+        )
+        return True, f"availability check failed; fail-open ({exc})"
+
+
+__all__ = [
+    "DEFAULT_COOLDOWN_SECONDS",
+    "COOLDOWN_ENV",
+    "LOCAL_GEMMA_DISABLED_REASON",
+    "LaneCheck",
+    "cooldown_seconds",
+    "record_lane_failure",
+    "lane_cooldown_remaining",
+    "lane_available",
+]

--- a/scripts/lib/providers/smart_router/availability.py
+++ b/scripts/lib/providers/smart_router/availability.py
@@ -9,11 +9,18 @@ with an explicit availability layer that runs at decision time and is cheap:
   - required env vars present   (deepseek: DEEPSEEK_API_KEY — existing behaviour)
   - required CLI on PATH        (kimi: kimi CLI — kimi-via-cli-only)
   - not in cooldown             (a prior quota/auth failure marks the lane
-                                 inactive for an env-configurable period)
+                                 inactive for the provider-outage cooldown,
+                                 sourced from the incident taxonomy)
 
 Cooldown state lives in the central state dir, resolved via the existing
 ``vnx_paths.resolve_state_dir`` helper (never a hardcoded ``.vnx-data/`` path)
 and is written atomically via ``atomic_io.atomic_write_json``.
+
+The cooldown duration is NOT owned here (OI-1188): ``cooldown_seconds()``
+delegates to ``incident_taxonomy.get_cooldown_seconds`` for the
+``PROVIDER_OUTAGE`` incident class, so the router lane cooldown and the
+supervisor retry budget share one clock and one retry contract. There is no
+second duration constant, env override, or backoff arithmetic in this module.
 
 Fail-open by design: a broken availability layer never blocks a dispatch. Any
 unexpected error is logged loudly and the lane is treated as available, so the
@@ -37,9 +44,6 @@ from pathlib import Path
 from typing import Optional, Tuple
 
 logger = logging.getLogger(__name__)
-
-DEFAULT_COOLDOWN_SECONDS = 3600  # 60 minutes
-COOLDOWN_ENV = "VNX_ROUTER_COOLDOWN_SECONDS"
 
 # Lane names this module understands. Values are provider strings the
 # tier-routing engine emits; the regex keeps the per-lane state filename safe.
@@ -103,31 +107,17 @@ def _now() -> float:
     return time.time()
 
 
-def cooldown_seconds(env: Optional[dict] = None) -> int:
-    """Return the configured lane-cooldown duration in seconds.
+def cooldown_seconds() -> int:
+    """Return the provider-outage lane-cooldown duration in seconds.
 
-    Default 60 minutes (3600s), overridable via VNX_ROUTER_COOLDOWN_SECONDS.
-    Invalid or negative values fall back to the default with a loud log.
+    Single cooldown clock (OI-1188): delegates to the canonical incident
+    taxonomy's ``get_cooldown_seconds`` for ``IncidentClass.PROVIDER_OUTAGE`` at
+    retry 0. This module performs no duration, env-override, or backoff
+    arithmetic of its own — the recovery contract is the one source of truth.
     """
-    _env = env if env is not None else dict(os.environ)
-    raw = str(_env.get(COOLDOWN_ENV, "")).strip()
-    if not raw:
-        return DEFAULT_COOLDOWN_SECONDS
-    try:
-        value = int(float(raw))
-    except (TypeError, ValueError):
-        logger.warning(
-            "smart-router: invalid %s=%r; using default %ds",
-            COOLDOWN_ENV, raw, DEFAULT_COOLDOWN_SECONDS,
-        )
-        return DEFAULT_COOLDOWN_SECONDS
-    if value < 0:
-        logger.warning(
-            "smart-router: %s=%d is negative; using default %ds",
-            COOLDOWN_ENV, value, DEFAULT_COOLDOWN_SECONDS,
-        )
-        return DEFAULT_COOLDOWN_SECONDS
-    return value
+    from incident_taxonomy import IncidentClass, get_cooldown_seconds  # noqa: PLC0415
+
+    return get_cooldown_seconds(IncidentClass.PROVIDER_OUTAGE, 0)
 
 
 def record_lane_failure(
@@ -135,10 +125,12 @@ def record_lane_failure(
     reason: str,
     *,
     state_dir: Optional[Path] = None,
-    duration_seconds: Optional[int] = None,
     now: Optional[float] = None,
 ) -> None:
     """Mark a lane as in cooldown after a quota/auth failure.
+
+    The cooldown duration comes from the single cooldown clock
+    (``cooldown_seconds`` → incident taxonomy PROVIDER_OUTAGE contract).
 
     Best-effort and fail-open: a failure to persist cooldown state is logged and
     swallowed — cooldown bookkeeping must never break a dispatch.
@@ -151,7 +143,7 @@ def record_lane_failure(
         from vnx_paths import refuse_real_central_store_write_under_pytest  # noqa: PLC0415
 
         refuse_real_central_store_write_under_pytest(sd)
-        duration = duration_seconds if duration_seconds is not None else cooldown_seconds()
+        duration = cooldown_seconds()
         until = (now if now is not None else _now()) + duration
         from atomic_io import atomic_write_json  # noqa: PLC0415
 
@@ -242,8 +234,6 @@ def lane_available(
 
 
 __all__ = [
-    "DEFAULT_COOLDOWN_SECONDS",
-    "COOLDOWN_ENV",
     "LOCAL_GEMMA_DISABLED_REASON",
     "LaneCheck",
     "cooldown_seconds",

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -33,6 +33,7 @@ _TIER_PROVIDER_TO_ENUM: dict[str, Provider] = {
     "deepseek": Provider.DEEPSEEK_HARNESS,
     "codex": Provider.CODEX,
     "kimi": Provider.KIMI,
+    "claude": Provider.CLAUDE,
     "local-gemma": Provider.LOCAL_GEMMA,
 }
 
@@ -91,11 +92,21 @@ def resolve_door_route(
 
         provider_enum = _TIER_PROVIDER_TO_ENUM.get(route.provider)
         if provider_enum is None:
-            # Unmapped provider — e.g. a future tier-mid or tier-high returning
-            # claude, which the door handles via its own lane resolution.
+            # A decline is still possible (an unmapped provider string), but it
+            # must be visible, not silent: the door falls through to its own
+            # lane resolution, and the reason is logged so a drift in the tier
+            # map is diagnosable.
+            logger.warning(
+                "smart-router door routing: provider %r for tier=%s is not in "
+                "_TIER_PROVIDER_TO_ENUM; declining route (fail-open to default lane)",
+                route.provider,
+                tier,
+            )
             return None
 
         route_reason = f"smart-router:tier={tier},provider={route.provider},model={route.model},lane={route.lane}"
+        if route.reason:
+            route_reason += f";{route.reason}"
         return provider_enum, route.model, route_reason
     except Exception:
         # Fail-open: a broken classifier or resolver must never block a dispatch.

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -5,9 +5,15 @@ provider (provider=AUTO). Resolves the dispatch to a concrete provider + model
 via the cost-tier classifier and tier-routing engine, then hands back a
 Provider enum + model string that compile_plan can consume.
 
-Fail-open by design: a broken router returns None and the door falls through
-to the existing behaviour. T0 is never routed (t0-opus-only is a floor, not
-an advisory). The router is default-on since 2026-08-02.
+Fail-open by design: a broken router returns a declined result with a reason
+and the door falls through to the existing behaviour. T0 is never routed
+(t0-opus-only is a floor, not an advisory). The router is default-on since
+2026-08-02.
+
+Every decline path carries an explicit reason (OI-1187) so a no-route is
+distinguishable in the dry-run output and receipt. Before this, a T0 skip, an
+explicit provider, the kill-switch, the enum gap and a classifier crash all
+returned a bare None and were indistinguishable in the audit trail.
 
 Constraints:
 - No imports from dispatch_cli or dispatch_plan (avoid circular deps).
@@ -19,11 +25,21 @@ from __future__ import annotations
 import dataclasses
 import logging
 import os
-from typing import Optional, Tuple, Union
+from typing import Optional, Tuple
 
 from dispatch_spec import Provider, ValidatedSpec  # noqa: PLC0415 — sibling package, no cycle
 
 logger = logging.getLogger(__name__)
+
+
+# Decline reasons — one per distinct no-route cause (OI-1187). Each is a stable
+# string surfaced in the dry-run output and receipt, so a decline is diagnosable
+# instead of an anonymous None.
+DECLINE_T0_NEVER_ROUTES = "t0-never-routes"
+DECLINE_EXPLICIT_PROVIDER = "explicit-provider"
+DECLINE_ROUTER_DISABLED = "router-disabled"
+DECLINE_PROVIDER_NOT_MAPPED = "provider-not-mapped"
+DECLINE_CLASSIFIER_ERROR = "classifier-error"
 
 
 # TierRoute.provider string -> Provider enum.
@@ -38,6 +54,22 @@ _TIER_PROVIDER_TO_ENUM: dict[str, Provider] = {
 }
 
 
+@dataclasses.dataclass(frozen=True)
+class DoorRouteResult:
+    """Outcome of resolve_door_route.
+
+    Exactly one of ``route`` / ``decline_reason`` is populated. ``tier`` carries
+    the classifier's tier whenever classification ran, so the door can make a
+    tier-aware fallback when a route cannot be applied after a successful
+    classification (OI-1187): a tier-high decline must never silently land on
+    the sonnet default.
+    """
+
+    route: Optional[Tuple[Provider, str, str]] = None
+    decline_reason: Optional[str] = None
+    tier: Optional[str] = None
+
+
 def resolve_door_route(
     spec_provider: Provider,
     spec_model: Optional[str],
@@ -46,12 +78,14 @@ def resolve_door_route(
     file_paths: Optional[list[str]] = None,
     loc_estimate: int = 0,
     env: Optional[dict] = None,
-) -> Optional[Tuple[Provider, str, str]]:
+) -> DoorRouteResult:
     """Resolve a concrete provider + model for a dispatch without an explicit one.
 
-    Returns (provider, model, route_reason) when the router has a recommendation,
-    or None when routing should be skipped (T0, explicit provider, router
-    disabled, or router error).
+    Returns a DoorRouteResult: either ``route=(provider, model, route_reason)``
+    when the router has a recommendation, or a ``decline_reason`` naming why
+    routing was skipped (T0, explicit provider, router disabled, an unmapped
+    provider string, or a classifier error). ``tier`` is populated whenever the
+    classifier ran so the door can fall back tier-aware instead of blindly.
 
     Args:
         spec_provider: The spec's provider enum value (check Provider.AUTO before calling).
@@ -64,23 +98,23 @@ def resolve_door_route(
     """
     # Gate 1: T0 never routes. t0-opus-only is a floor, not an advisory.
     if target_slot == "T0":
-        return None
+        return DoorRouteResult(decline_reason=DECLINE_T0_NEVER_ROUTES)
 
     # Gate 2: Only fill in when the spec is silent. An explicit provider wins
     # undiminished (worker-provider-free-choice, pin_semantics=default).
     if spec_provider != Provider.AUTO:
-        return None
+        return DoorRouteResult(decline_reason=DECLINE_EXPLICIT_PROVIDER)
 
     _env = env if env is not None else dict(os.environ)
 
     # Gate 3: VNX_SMART_ROUTER_DISABLE=1 disables the router entirely.
     if _env.get("VNX_SMART_ROUTER_DISABLE", "").strip().lower() in ("1", "true", "yes", "on"):
-        return None
+        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED)
 
     # Backward compat: VNX_AUTO_ROUTE=0/false/off also disables.
     auto_route = _env.get("VNX_AUTO_ROUTE", "").strip().lower()
     if auto_route in ("0", "false", "no", "off"):
-        return None
+        return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED)
 
     try:
         from .cost_tier import classify_dispatch  # noqa: PLC0415
@@ -95,20 +129,27 @@ def resolve_door_route(
             # A decline is still possible (an unmapped provider string), but it
             # must be visible, not silent: the door falls through to its own
             # lane resolution, and the reason is logged so a drift in the tier
-            # map is diagnosable.
+            # map is diagnosable. The classified tier is carried so the door can
+            # fall back at the same quality class instead of one lower.
             logger.warning(
                 "smart-router door routing: provider %r for tier=%s is not in "
                 "_TIER_PROVIDER_TO_ENUM; declining route (fail-open to default lane)",
                 route.provider,
                 tier,
             )
-            return None
+            return DoorRouteResult(
+                decline_reason=DECLINE_PROVIDER_NOT_MAPPED,
+                tier=tier,
+            )
 
         route_reason = f"smart-router:tier={tier},provider={route.provider},model={route.model},lane={route.lane}"
         if route.reason:
             route_reason += f";{route.reason}"
-        return provider_enum, route.model, route_reason
-    except Exception:
+        return DoorRouteResult(
+            route=(provider_enum, route.model, route_reason),
+            tier=tier,
+        )
+    except Exception as exc:
         # Fail-open: a broken classifier or resolver must never block a dispatch.
         # The door falls through to its existing behaviour.
         # A failing router that is silent is indistinguishable from a correctly
@@ -117,9 +158,10 @@ def resolve_door_route(
         logger.warning(
             "smart-router door routing: classifier/resolver failed, dispatch "
             "falls through to default lane (fail-open). Error: %s",
+            exc,
             exc_info=True,
         )
-        return None
+        return DoorRouteResult(decline_reason=DECLINE_CLASSIFIER_ERROR)
 
 
 def apply_door_route(
@@ -131,11 +173,12 @@ def apply_door_route(
     Single call site for dispatch_cli.run_dispatch(). Returns (vspec, route_reason)
     where vspec is either the original (router skipped/disabled/failed) or a new
     ValidatedSpec with the resolved provider + model. route_reason is a
-    human-readable string for the dry-run output and receipt, or None when the
-    router did not apply.
+    human-readable string for the dry-run output and receipt: the router's
+    recommendation when routed, or the decline reason (prefixed "smart-router:")
+    when the router skipped — never a bare None for a decline (OI-1187).
 
     Fail-open: never raises. A broken router returns the original vspec unchanged
-    with route_reason=None.
+    with a decline reason.
     """
     spec = vspec.spec
     if spec.provider != Provider.AUTO:
@@ -154,11 +197,12 @@ def apply_door_route(
         file_paths=file_paths,
         env=_env,
     )
-    if result is None:
-        return vspec, None
+    if result.route is None:
+        if result.decline_reason is None:
+            return vspec, None
+        return vspec, f"smart-router:no-route,reason={result.decline_reason}"
 
-    new_provider, new_model, route_reason = result
+    new_provider, new_model, route_reason = result.route
     new_spec = dataclasses.replace(spec, provider=new_provider, model=new_model)
     new_vspec = dataclasses.replace(vspec, spec=new_spec)
     return new_vspec, route_reason
-

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -3,11 +3,9 @@
 Tier→provider mappings (honoring provider_constraints.yaml):
   tier-zero → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
                (DEEPSEEK_API_KEY required); fallback Codex via provider lane.
-               Local-gemma route preserved but unused — reactivate when
-               gemma-4-12b-integration ships.
   tier-low  → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
-               (DEEPSEEK_API_KEY required); fallback Codex via provider lane
-               (kimi quota exhausted 2026-08-02, OI-940)
+               (DEEPSEEK_API_KEY required); runtime fallback Kimi CLI
+               (kimi-k3, kimi-via-cli-only) then Codex.
   tier-mid  → sonnet-5  (canonical registry key — see wave7_models.yaml)
   tier-high → opus-5    (canonical registry key — see wave7_models.yaml)
 
@@ -17,6 +15,15 @@ identity (dispatch-20260802-model-ssot-en-ketenlink). The previous 4-series
 ids (claude-sonnet-4-6 / claude-opus-4-8) were not registry keys and would
 reject with model-not-in-current-registry the moment tier-mid/tier-high
 actually routed; the fleet now runs the 5-series.
+
+Availability is a runtime signal, not a code comment. Each non-Claude lane is
+gated by ``availability.lane_available`` (env vars, CLI presence, cooldown) at
+decision time. A lane that fails on quota/auth is recorded by
+``availability.record_lane_failure`` and auto-recovers after its cooldown
+period — no code edit or release required to bring it back. Kimi is a regular
+route in the tier map again (through the availability check), and local-gemma
+stays disabled via the availability layer's explicit reason, not as a
+commented-out block.
 
 Constraint references (provider_constraints.yaml):
   kimi-via-cli-only: Kimi must use lane='kimi_cli', never via=api/moonshot
@@ -29,6 +36,7 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass, field
+from pathlib import Path
 from typing import Optional
 
 from .cost_tier import TIER_ZERO, TIER_LOW, TIER_MID, TIER_HIGH
@@ -44,41 +52,48 @@ class TierRoute:
     lane: str
     env_requirements: tuple = field(default_factory=tuple)
     fallback: Optional["TierRoute"] = None
+    reason: Optional[str] = None  # why this route was chosen over its primary
 
 
-# ── tier-zero / tier-low routes ──
-# DeepSeek flash via claude-harness is the primary route for both entry tiers
-# (operator decision 2026-08-02: skip local models for now).  When
-# DEEPSEEK_API_KEY is absent, both fall back to Codex via provider lane
-# (kimi quota exhausted 2026-08-02, OI-940).  resolve_tier_route() creates
-# routes on the fly so the tier field is correct in every return value.
+def _codex_route(tier: str, reason: Optional[str] = None) -> TierRoute:
+    """Codex vangnet — the last-resort provider lane (OI-940)."""
+    return TierRoute(
+        tier=tier,
+        provider="codex",
+        model="gpt-5.5",
+        lane="provider",
+        reason=reason,
+    )
 
-# Preserved but unused: local Gemma route. Reactivate when gemma-4-12b-integration
-# ships (queued track). The Gemma chain (primary + Ollama fallback) is intact below
-# but never returned by resolve_tier_route.
-# _ROUTE_LOCAL_GEMMA_FALLBACK = TierRoute(
-#     tier=TIER_ZERO,
-#     provider="ollama",
-#     model="gemma:4b",
-#     lane="ollama",
-# )
-# _ROUTE_LOCAL_GEMMA = TierRoute(
-#     tier=TIER_ZERO,
-#     provider="local-gemma",
-#     model="gemma-4b-e4b-mlx",
-#     lane="mlx",
-#     fallback=_ROUTE_LOCAL_GEMMA_FALLBACK,
-# )
 
-# Preserved but unused: Kimi CLI route (kimi-via-cli-only constraint).  Kimi quota
-# was exhausted 2026-08-02 (OI-940); Codex is the active fallback.  Reactivate when
-# quota is restored or a new Kimi model tier is added.
-# _ROUTE_KIMI = TierRoute(
-#     tier=TIER_LOW,
-#     provider="kimi",
-#     model="kimi-k2",
-#     lane="kimi_cli",
-# )
+def _deepseek_route(tier: str) -> TierRoute:
+    """DeepSeek flash via claude-harness key-auth (deepseek-chat discontinued
+    2026-07-24)."""
+    return TierRoute(
+        tier=tier,
+        provider="deepseek",
+        model="deepseek-v4-flash",
+        lane="claude_harness_keyed",
+        env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
+        fallback=_codex_route(tier),
+    )
+
+
+def _kimi_route(tier: str, reason: Optional[str] = None) -> TierRoute:
+    """Kimi CLI route (kimi-via-cli-only: never via=api/moonshot).
+
+    kimi-k3 is the canonical registry key (kimi_cli.default_model in
+    wave7_models.yaml). Codex remains the vangnet behind it.
+    """
+    return TierRoute(
+        tier=tier,
+        provider="kimi",
+        model="kimi-k3",
+        lane="kimi_cli",
+        fallback=_codex_route(tier),
+        reason=reason,
+    )
+
 
 _ROUTE_MID = TierRoute(
     tier=TIER_MID,
@@ -95,48 +110,75 @@ _ROUTE_HIGH = TierRoute(
 )
 
 
-def _deepseek_available(env: dict) -> bool:
-    """DeepSeek harness is allowed only when DEEPSEEK_API_KEY is present.
+def _deepseek_has_key(env: dict) -> bool:
+    """True when DEEPSEEK_API_KEY is present (static check, no cooldown).
 
-    Implements deepseek-harness-subscription-blocked: own key + hardening required;
-    routing through the production OAuth subscription is blocked.
+    Kept separate from the full availability check so the missing-key case
+    preserves the pre-existing behaviour (codex fallback, kimi NOT consulted)
+    while the key-present-but-in-cooldown case can fall through to kimi.
+    Implements deepseek-harness-subscription-blocked: own key + hardening
+    required; routing through the production OAuth subscription is blocked.
     """
     return bool(env.get("DEEPSEEK_API_KEY"))
 
 
-def resolve_tier_route(tier: str, env: Optional[dict] = None) -> TierRoute:
+def resolve_tier_route(
+    tier: str,
+    env: Optional[dict] = None,
+    state_dir: Optional[Path] = None,
+    now: Optional[float] = None,
+) -> TierRoute:
     """Resolve a cost tier to a TierRoute.
 
-    For tier-zero and tier-low: prefers DeepSeek claude-harness (key-auth) when
-    DEEPSEEK_API_KEY is present; falls back to Codex via provider lane (kimi quota
-    exhausted 2026-08-02, OI-940; local models skipped until gemma-4-12b-integration
-    ships). Unknown tier strings default to tier-high.
+    Entry tiers (zero/low) prefer DeepSeek claude-harness when DEEPSEEK_API_KEY
+    is present; a missing key falls back to Codex (existing behaviour). When
+    DeepSeek has a key but is in cooldown after a quota/auth failure, the router
+    falls back to Kimi CLI (kimi-via-cli-only) and then Codex — availability is
+    read at decision time so a restored lane rejoins without a release. Unknown
+    tier strings default to tier-high.
     """
     _env = env if env is not None else dict(os.environ)
 
     if tier in (TIER_ZERO, TIER_LOW):
-        if _deepseek_available(_env):
-            return TierRoute(
-                tier=tier,
-                provider="deepseek",
-                model="deepseek-v4-flash",  # deepseek-chat discontinued 2026-07-24
-                lane="claude_harness_keyed",
-                env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
-                fallback=TierRoute(
-                    tier=tier,
-                    provider="codex",
-                    model="gpt-5.5",
-                    lane="provider",
-                ),
-            )
-        return TierRoute(
-            tier=tier,
-            provider="codex",
-            model="gpt-5.5",
-            lane="provider",
-        )
+        return _resolve_entry_tier_route(tier, _env, state_dir, now)
 
     if tier == TIER_MID:
         return _ROUTE_MID
 
     return _ROUTE_HIGH
+
+
+def _resolve_entry_tier_route(
+    tier: str,
+    env: dict,
+    state_dir: Optional[Path],
+    now: Optional[float],
+) -> TierRoute:
+    from .availability import lane_available  # noqa: PLC0415
+
+    deepseek_ok, deepseek_reason = lane_available(
+        "deepseek", env=env, state_dir=state_dir, now=now,
+    )
+    if deepseek_ok:
+        return _deepseek_route(tier)
+
+    if _deepseek_has_key(env):
+        # Key present but DeepSeek is in cooldown → try Kimi before the vangnet.
+        kimi_ok, kimi_reason = lane_available(
+            "kimi", env=env, state_dir=state_dir, now=now,
+        )
+        if kimi_ok:
+            return _kimi_route(
+                tier,
+                reason=f"deepseek unavailable ({deepseek_reason}); using kimi",
+            )
+        return _codex_route(
+            tier,
+            reason=(
+                f"deepseek unavailable ({deepseek_reason}); "
+                f"kimi unavailable ({kimi_reason}); using codex"
+            ),
+        )
+
+    # Missing key → existing behaviour: Codex vangnet (kimi not consulted).
+    return _codex_route(tier)

--- a/tests/smart_router/test_availability.py
+++ b/tests/smart_router/test_availability.py
@@ -3,7 +3,8 @@
 Covers:
 - decision-time gates: env vars, CLI presence, disabled lanes, unknown lanes
 - cooldown lifecycle: record → active → re-engage after the period
-- env-configurable cooldown duration with invalid-value fallback
+- cooldown duration sourced from the incident taxonomy (PROVIDER_OUTAGE),
+  no own duration/backoff/override math (OI-1188)
 - fail-open: corrupt cooldown state reads as not-in-cooldown; best-effort
   record_lane_failure never raises
 """
@@ -87,7 +88,7 @@ class TestCooldownLifecycle:
         now = 1_000.0
         record_lane_failure(
             "deepseek", "429 quota-exhausted", state_dir=state_dir,
-            duration_seconds=3600, now=now,
+            now=now,
         )
         assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now) == pytest.approx(3600.0)
         assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now + 3600) == 0.0
@@ -95,7 +96,7 @@ class TestCooldownLifecycle:
     def test_lane_available_respects_cooldown(self, state_dir):
         now = 2_000.0
         record_lane_failure(
-            "deepseek", "403 auth", state_dir=state_dir, duration_seconds=3600, now=now,
+            "deepseek", "403 auth", state_dir=state_dir, now=now,
         )
         ok, reason = lane_available(
             "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
@@ -114,13 +115,13 @@ class TestCooldownLifecycle:
 
         now = 3_000.0
         record_lane_failure(
-            "kimi", "quota", state_dir=state_dir, duration_seconds=600, now=now,
+            "kimi", "quota", state_dir=state_dir, now=now,
         )
         cooldown_file = state_dir / "router_lane_cooldown" / "kimi.json"
         assert cooldown_file.is_file()
         data = json.loads(cooldown_file.read_text(encoding="utf-8"))
         assert data["lane"] == "kimi"
-        assert data["until"] == pytest.approx(now + 600)
+        assert data["until"] == pytest.approx(now + 3600)
 
     def test_no_cooldown_file_means_active(self, state_dir):
         assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=0.0) == 0.0
@@ -132,17 +133,38 @@ class TestCooldownLifecycle:
 
 class TestCooldownSeconds:
 
+    def test_delegates_to_incident_taxonomy(self):
+        """cooldown_seconds() must lean on the canonical incident taxonomy
+        (PROVIDER_OUTAGE contract), not carry its own duration (OI-1188)."""
+        from incident_taxonomy import IncidentClass, get_cooldown_seconds
+
+        assert cooldown_seconds() == get_cooldown_seconds(IncidentClass.PROVIDER_OUTAGE, 0)
+
     def test_default_is_one_hour(self):
-        assert cooldown_seconds({}) == 3600
+        """The PROVIDER_OUTAGE base cooldown is one hour (3600s)."""
+        assert cooldown_seconds() == 3600
 
-    def test_env_override(self):
-        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "120"}) == 120
+    def test_no_own_time_arithmetic(self, monkeypatch):
+        """cooldown_seconds() returns get_cooldown_seconds verbatim — it does no
+        duration, env-override, or backoff math of its own (OI-1188)."""
+        import incident_taxonomy
 
-    def test_invalid_value_falls_back(self):
-        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "garbage"}) == 3600
+        captured = {}
 
-    def test_negative_value_falls_back(self):
-        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "-5"}) == 3600
+        def fake_get_cooldown_seconds(incident_class, retry_count):
+            captured["incident_class"] = incident_class
+            captured["retry_count"] = retry_count
+            return 4242
+
+        monkeypatch.setattr(
+            incident_taxonomy, "get_cooldown_seconds", fake_get_cooldown_seconds,
+        )
+        assert cooldown_seconds() == 4242
+
+        from incident_taxonomy import IncidentClass
+
+        assert captured["incident_class"] == IncidentClass.PROVIDER_OUTAGE
+        assert captured["retry_count"] == 0
 
 
 # ---------------------------------------------------------------------------

--- a/tests/smart_router/test_availability.py
+++ b/tests/smart_router/test_availability.py
@@ -1,0 +1,162 @@
+"""Tests for the smart-router availability + cooldown layer (dispatch-20260814a).
+
+Covers:
+- decision-time gates: env vars, CLI presence, disabled lanes, unknown lanes
+- cooldown lifecycle: record → active → re-engage after the period
+- env-configurable cooldown duration with invalid-value fallback
+- fail-open: corrupt cooldown state reads as not-in-cooldown; best-effort
+  record_lane_failure never raises
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.smart_router.availability import (
+    cooldown_seconds,
+    lane_available,
+    lane_cooldown_remaining,
+    record_lane_failure,
+)
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    d = tmp_path / "state"
+    d.mkdir()
+    return d
+
+
+# ---------------------------------------------------------------------------
+# Decision-time gates
+# ---------------------------------------------------------------------------
+
+class TestLaneGates:
+
+    def test_deepseek_requires_env_var(self, state_dir):
+        ok, reason = lane_available("deepseek", env={}, state_dir=state_dir)
+        assert ok is False
+        assert "DEEPSEEK_API_KEY" in reason
+
+    def test_deepseek_available_with_key(self, state_dir):
+        ok, _ = lane_available(
+            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir,
+        )
+        assert ok is True
+
+    def test_kimi_requires_cli_on_path(self, state_dir, monkeypatch):
+        import shutil
+
+        monkeypatch.setattr(shutil, "which", lambda name: None)
+        ok, reason = lane_available("kimi", env={}, state_dir=state_dir)
+        assert ok is False
+        assert "kimi" in reason
+
+    def test_kimi_available_when_cli_present(self, state_dir, monkeypatch):
+        import shutil
+
+        monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/kimi")
+        ok, _ = lane_available("kimi", env={}, state_dir=state_dir)
+        assert ok is True
+
+    def test_local_gemma_disabled_via_layer(self, state_dir):
+        ok, reason = lane_available("local-gemma", env={}, state_dir=state_dir)
+        assert ok is False
+        assert "operator decision 2026-08-02" in reason
+
+    def test_claude_and_codex_ungated(self, state_dir):
+        assert lane_available("claude", env={}, state_dir=state_dir)[0] is True
+        assert lane_available("codex", env={}, state_dir=state_dir)[0] is True
+
+    def test_unknown_lane_not_gated(self, state_dir):
+        ok, _ = lane_available("some-future-lane", env={}, state_dir=state_dir)
+        assert ok is True
+
+
+# ---------------------------------------------------------------------------
+# Cooldown lifecycle
+# ---------------------------------------------------------------------------
+
+class TestCooldownLifecycle:
+
+    def test_record_then_remaining_then_reengage(self, state_dir):
+        now = 1_000.0
+        record_lane_failure(
+            "deepseek", "429 quota-exhausted", state_dir=state_dir,
+            duration_seconds=3600, now=now,
+        )
+        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now) == pytest.approx(3600.0)
+        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now + 3600) == 0.0
+
+    def test_lane_available_respects_cooldown(self, state_dir):
+        now = 2_000.0
+        record_lane_failure(
+            "deepseek", "403 auth", state_dir=state_dir, duration_seconds=3600, now=now,
+        )
+        ok, reason = lane_available(
+            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+        )
+        assert ok is False
+        assert "cooldown" in reason
+
+        ok, _ = lane_available(
+            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"},
+            state_dir=state_dir, now=now + 3601,
+        )
+        assert ok is True
+
+    def test_cooldown_file_is_written_atomically(self, state_dir):
+        import json
+
+        now = 3_000.0
+        record_lane_failure(
+            "kimi", "quota", state_dir=state_dir, duration_seconds=600, now=now,
+        )
+        cooldown_file = state_dir / "router_lane_cooldown" / "kimi.json"
+        assert cooldown_file.is_file()
+        data = json.loads(cooldown_file.read_text(encoding="utf-8"))
+        assert data["lane"] == "kimi"
+        assert data["until"] == pytest.approx(now + 600)
+
+    def test_no_cooldown_file_means_active(self, state_dir):
+        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=0.0) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Cooldown duration config
+# ---------------------------------------------------------------------------
+
+class TestCooldownSeconds:
+
+    def test_default_is_one_hour(self):
+        assert cooldown_seconds({}) == 3600
+
+    def test_env_override(self):
+        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "120"}) == 120
+
+    def test_invalid_value_falls_back(self):
+        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "garbage"}) == 3600
+
+    def test_negative_value_falls_back(self):
+        assert cooldown_seconds({"VNX_ROUTER_COOLDOWN_SECONDS": "-5"}) == 3600
+
+
+# ---------------------------------------------------------------------------
+# Fail-open
+# ---------------------------------------------------------------------------
+
+class TestFailOpen:
+
+    def test_corrupt_cooldown_state_reads_as_active(self, state_dir):
+        cooldown_dir = state_dir / "router_lane_cooldown"
+        cooldown_dir.mkdir()
+        (cooldown_dir / "deepseek.json").write_text("{not valid json", encoding="utf-8")
+        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=1.0) == 0.0
+
+    def test_record_lane_failure_is_best_effort(self, state_dir):
+        # Invalid lane name raises inside the try and must be swallowed.
+        record_lane_failure("not a valid/lane", "x", state_dir=state_dir)

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -137,7 +137,7 @@ def test_tier_low_deepseek_cooldown_falls_back_to_kimi(tmp_path, monkeypatch):
     now = 1_000_000.0
     record_lane_failure(
         "deepseek", "429 quota-exhausted", state_dir=state_dir,
-        duration_seconds=3600, now=now,
+        now=now,
     )
     monkeypatch.setattr(
         _shutil, "which", lambda name: "/usr/local/bin/kimi" if name == "kimi" else None,
@@ -160,7 +160,7 @@ def test_tier_low_deepseek_cooldown_kimi_unavailable_falls_back_to_codex(tmp_pat
     state_dir = tmp_path / "state"
     now = 2_000_000.0
     record_lane_failure(
-        "deepseek", "403 auth", state_dir=state_dir, duration_seconds=3600, now=now,
+        "deepseek", "403 auth", state_dir=state_dir, now=now,
     )
     monkeypatch.setattr(_shutil, "which", lambda name: None)
     route = resolve_tier_route(
@@ -179,7 +179,7 @@ def test_tier_low_deepseek_reengages_after_cooldown(tmp_path):
     state_dir = tmp_path / "state"
     now = 3_000_000.0
     record_lane_failure(
-        "deepseek", "429", state_dir=state_dir, duration_seconds=3600, now=now,
+        "deepseek", "429", state_dir=state_dir, now=now,
     )
     route = resolve_tier_route(
         TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"},
@@ -248,7 +248,10 @@ def test_door_route_explicit_provider_overrules_router():
     """An explicit provider+model in the spec must win over the router
     (worker-provider-free-choice, pin_semantics=default)."""
     from dispatch_spec import Provider
-    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.door_routing import (
+        DECLINE_EXPLICIT_PROVIDER,
+        resolve_door_route,
+    )
 
     result = resolve_door_route(
         spec_provider=Provider.CODEX,
@@ -257,13 +260,17 @@ def test_door_route_explicit_provider_overrules_router():
         instruction_text="add a function",
         env={"DEEPSEEK_API_KEY": "sk-test"},
     )
-    assert result is None, "explicit provider must skip router entirely"
+    assert result.route is None, "explicit provider must skip router entirely"
+    assert result.decline_reason == DECLINE_EXPLICIT_PROVIDER
 
 
 def test_door_route_t0_never_routed():
     """T0 is never routed — t0-opus-only is a floor, not an advisory."""
     from dispatch_spec import Provider
-    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.door_routing import (
+        DECLINE_T0_NEVER_ROUTES,
+        resolve_door_route,
+    )
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -272,7 +279,8 @@ def test_door_route_t0_never_routed():
         instruction_text="plan a dispatch",
         env={"DEEPSEEK_API_KEY": "sk-test"},
     )
-    assert result is None, "T0 must never be routed"
+    assert result.route is None, "T0 must never be routed"
+    assert result.decline_reason == DECLINE_T0_NEVER_ROUTES
 
 
 def test_door_route_auto_fills_provider():
@@ -290,8 +298,8 @@ def test_door_route_auto_fills_provider():
         loc_estimate=50,
         env={"DEEPSEEK_API_KEY": "sk-test"},
     )
-    assert result is not None
-    provider, model, reason = result
+    assert result.route is not None
+    provider, model, reason = result.route
     assert provider == Provider.DEEPSEEK_HARNESS
     assert model == "deepseek-v4-flash"
     assert "tier=tier-low" in reason
@@ -312,8 +320,8 @@ def test_door_route_auto_fallback_codex():
         loc_estimate=50,
         env={},  # no DEEPSEEK_API_KEY
     )
-    assert result is not None
-    provider, model, reason = result
+    assert result.route is not None
+    provider, model, reason = result.route
     assert provider == Provider.CODEX, "tier-low without DEEPSEEK_API_KEY must fall back to codex"
     assert model == "gpt-5.5"
     assert "codex" in reason.lower()
@@ -322,7 +330,10 @@ def test_door_route_auto_fallback_codex():
 def test_door_route_disabled_via_flag():
     """VNX_SMART_ROUTER_DISABLE=1 suppresses the router entirely."""
     from dispatch_spec import Provider
-    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.door_routing import (
+        DECLINE_ROUTER_DISABLED,
+        resolve_door_route,
+    )
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -331,7 +342,90 @@ def test_door_route_disabled_via_flag():
         instruction_text="add a function",
         env={"VNX_SMART_ROUTER_DISABLE": "1", "DEEPSEEK_API_KEY": "sk-test"},
     )
-    assert result is None, "router must be suppressible"
+    assert result.route is None, "router must be suppressible"
+    assert result.decline_reason == DECLINE_ROUTER_DISABLED
+
+
+def test_door_route_disabled_via_legacy_flag():
+    """VNX_AUTO_ROUTE=0 (legacy opt-in default-off) also disables, with the
+    same router-disabled reason as the primary kill-switch."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import (
+        DECLINE_ROUTER_DISABLED,
+        resolve_door_route,
+    )
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a function",
+        env={"VNX_AUTO_ROUTE": "0", "DEEPSEEK_API_KEY": "sk-test"},
+    )
+    assert result.route is None
+    assert result.decline_reason == DECLINE_ROUTER_DISABLED
+
+
+def test_door_route_provider_not_mapped_declines_with_reason(monkeypatch):
+    """A tier route whose provider string has no _TIER_PROVIDER_TO_ENUM entry
+    declines with provider-not-mapped and carries the classified tier (OI-1187)."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import (
+        DECLINE_PROVIDER_NOT_MAPPED,
+        resolve_door_route,
+    )
+    from providers.smart_router.tier_routing import TierRoute
+    import providers.smart_router.tier_routing as tier_routing_module
+
+    monkeypatch.setattr(
+        tier_routing_module,
+        "resolve_tier_route",
+        lambda tier, env, state_dir=None, now=None: TierRoute(
+            tier=tier, provider="future-provider", model="future-model", lane="provider",
+        ),
+    )
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=50,
+        env={},
+    )
+    assert result.route is None
+    assert result.decline_reason == DECLINE_PROVIDER_NOT_MAPPED
+    assert result.tier is not None
+
+
+def test_door_route_classifier_error_declines_with_reason(monkeypatch):
+    """A classifier crash declines with classifier-error (fail-open) — never
+    raises, never a bare None (OI-1187)."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import (
+        DECLINE_CLASSIFIER_ERROR,
+        resolve_door_route,
+    )
+    import providers.smart_router.cost_tier as cost_tier_module
+
+    def boom(task_spec, file_paths, loc_estimate):
+        raise RuntimeError("classifier exploded")
+
+    monkeypatch.setattr(cost_tier_module, "classify_dispatch", boom)
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=50,
+        env={},
+    )
+    assert result.route is None
+    assert result.decline_reason == DECLINE_CLASSIFIER_ERROR
+    assert result.tier is None
 
 
 def test_door_route_fail_open_on_broken_input():
@@ -339,8 +433,8 @@ def test_door_route_fail_open_on_broken_input():
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
 
-    # Empty instruction text and zero LOC still classifies (tier-zero or tier-low),
-    # but the router must not raise.
+    # Empty instruction text and zero LOC still classifies (tier-zero or tier-low);
+    # the router returns a DoorRouteResult either way, never raises.
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
         spec_model=None,
@@ -348,9 +442,7 @@ def test_door_route_fail_open_on_broken_input():
         instruction_text="",
         env={},
     )
-    # Empty instruction with 0 LOC classifies to tier-low; we get a route or
-    # fail-open.
-    assert result is not None or result is None  # never raises
+    assert result is not None
 
 
 def test_door_route_tier_mid_resolves_claude():
@@ -367,8 +459,8 @@ def test_door_route_tier_mid_resolves_claude():
         loc_estimate=200,
         env={},
     )
-    assert result is not None
-    provider, model, reason = result
+    assert result.route is not None
+    provider, model, reason = result.route
     assert provider == Provider.CLAUDE
     assert model == "sonnet-5"
     assert "tier=tier-mid" in reason
@@ -388,8 +480,8 @@ def test_door_route_tier_high_resolves_claude():
         loc_estimate=350,
         env={},
     )
-    assert result is not None
-    provider, model, reason = result
+    assert result.route is not None
+    provider, model, reason = result.route
     assert provider == Provider.CLAUDE
     assert model == "opus-5"
     assert "tier=tier-high" in reason
@@ -399,7 +491,10 @@ def test_door_route_t0_stays_unrouted_when_mid_tier():
     """T0 is never routed even when the classifier would land on tier-mid —
     t0-opus-only is a floor, not an advisory."""
     from dispatch_spec import Provider
-    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.door_routing import (
+        DECLINE_T0_NEVER_ROUTES,
+        resolve_door_route,
+    )
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -410,4 +505,5 @@ def test_door_route_t0_stays_unrouted_when_mid_tier():
         loc_estimate=200,
         env={},
     )
-    assert result is None, "T0 must never be routed"
+    assert result.route is None, "T0 must never be routed"
+    assert result.decline_reason == DECLINE_T0_NEVER_ROUTES

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -121,6 +121,74 @@ def test_unknown_tier_defaults_to_opus():
     assert route.model == "opus-5"
 
 
+# ---------------------------------------------------------------------------
+# Availability wiring — cooldown drives runtime fallback (Problem 2)
+# ---------------------------------------------------------------------------
+
+
+def test_tier_low_deepseek_cooldown_falls_back_to_kimi(tmp_path, monkeypatch):
+    """DeepSeek in cooldown with a key → Kimi CLI (kimi-via-cli-only) before
+    the Codex vangnet."""
+    import shutil as _shutil
+
+    from providers.smart_router.availability import record_lane_failure
+
+    state_dir = tmp_path / "state"
+    now = 1_000_000.0
+    record_lane_failure(
+        "deepseek", "429 quota-exhausted", state_dir=state_dir,
+        duration_seconds=3600, now=now,
+    )
+    monkeypatch.setattr(
+        _shutil, "which", lambda name: "/usr/local/bin/kimi" if name == "kimi" else None,
+    )
+    route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+    )
+    assert route.provider == "kimi"
+    assert route.model == "kimi-k3"
+    assert route.lane == "kimi_cli"
+    assert "deepseek unavailable" in route.reason
+
+
+def test_tier_low_deepseek_cooldown_kimi_unavailable_falls_back_to_codex(tmp_path, monkeypatch):
+    """DeepSeek in cooldown and kimi CLI absent → Codex vangnet, reason visible."""
+    import shutil as _shutil
+
+    from providers.smart_router.availability import record_lane_failure
+
+    state_dir = tmp_path / "state"
+    now = 2_000_000.0
+    record_lane_failure(
+        "deepseek", "403 auth", state_dir=state_dir, duration_seconds=3600, now=now,
+    )
+    monkeypatch.setattr(_shutil, "which", lambda name: None)
+    route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+    )
+    assert route.provider == "codex"
+    assert route.model == "gpt-5.5"
+    assert "deepseek unavailable" in route.reason
+    assert "kimi unavailable" in route.reason
+
+
+def test_tier_low_deepseek_reengages_after_cooldown(tmp_path):
+    """After the cooldown period the lane re-engages — no release required."""
+    from providers.smart_router.availability import record_lane_failure
+
+    state_dir = tmp_path / "state"
+    now = 3_000_000.0
+    record_lane_failure(
+        "deepseek", "429", state_dir=state_dir, duration_seconds=3600, now=now,
+    )
+    route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"},
+        state_dir=state_dir, now=now + 3601,
+    )
+    assert route.provider == "deepseek"
+    assert route.model == "deepseek-v4-flash"
+
+
 def test_route_dispatch_disabled_via_flag():
     """route_dispatch() returns None when VNX_SMART_ROUTER_DISABLE=1."""
     from providers.smart_router import route_dispatch
@@ -283,3 +351,63 @@ def test_door_route_fail_open_on_broken_input():
     # Empty instruction with 0 LOC classifies to tier-low; we get a route or
     # fail-open.
     assert result is not None or result is None  # never raises
+
+
+def test_door_route_tier_mid_resolves_claude():
+    """tier-mid now maps to a concrete Provider.CLAUDE choice (enum-gap fix)."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="implement a medium feature",
+        file_paths=["src/foo.py"],
+        loc_estimate=200,
+        env={},
+    )
+    assert result is not None
+    provider, model, reason = result
+    assert provider == Provider.CLAUDE
+    assert model == "sonnet-5"
+    assert "tier=tier-mid" in reason
+
+
+def test_door_route_tier_high_resolves_claude():
+    """tier-high maps to Provider.CLAUDE (opus-5), not a silent decline."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="implement a large feature",
+        file_paths=["src/foo.py"],
+        loc_estimate=350,
+        env={},
+    )
+    assert result is not None
+    provider, model, reason = result
+    assert provider == Provider.CLAUDE
+    assert model == "opus-5"
+    assert "tier=tier-high" in reason
+
+
+def test_door_route_t0_stays_unrouted_when_mid_tier():
+    """T0 is never routed even when the classifier would land on tier-mid —
+    t0-opus-only is a floor, not an advisory."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T0",
+        instruction_text="implement a medium feature",
+        file_paths=["src/foo.py"],
+        loc_estimate=200,
+        env={},
+    )
+    assert result is None, "T0 must never be routed"

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -3304,6 +3304,50 @@ class TestSmartRouterPreValidate:
         assert "provider:     claude" in captured.out, captured.out
         assert "model:        sonnet" in captured.out, captured.out
 
+    def test_tier_high_routing_failure_falls_back_to_opus_not_sonnet(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """OI-1187: a tier-high dispatch whose routing fails must NOT silently
+        land on sonnet (a quality class drop). The fallback must know the tier:
+        tier-high falls back to opus-5 (equal class)."""
+        from providers.smart_router.cost_tier import TIER_HIGH
+        from providers.smart_router.door_routing import DoorRouteResult
+
+        data_dir, spec_file = _make_bundle_spec(
+            tmp_path,
+            instruction_text="# Fix typo in docstring\n\nCorrect a spelling error.\n",
+            staging_id="20260814-oi1187-high",
+            dispatch_id="20260814-oi1187-high",
+            provider="auto",
+            target_slot="T1",
+        )
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+
+        # Simulate the router classifying tier-high but failing to APPLY the
+        # route (provider-not-mapped). The door's fallback must honor the tier.
+        with patch(
+            "dispatch_cli._resolve_router_pre_validate",
+            return_value=DoorRouteResult(
+                decline_reason="provider-not-mapped",
+                tier=TIER_HIGH,
+            ),
+        ):
+            rc = run_dispatch(spec_file, dry_run=True)
+
+        captured = capsys.readouterr()
+        assert rc == 0, (
+            f"tier-high routing failure must still produce an executable plan, "
+            f"got rc={rc}\nstdout:\n{captured.out}\nstderr:\n{captured.err}"
+        )
+        assert "REJECT" not in captured.out, f"unexpected reject:\n{captured.out}"
+        assert "model:        opus-5" in captured.out, (
+            f"tier-high fallback must be opus-5 (equal class), got:\n{captured.out}"
+        )
+        assert "model:        sonnet" not in captured.out, (
+            f"tier-high fallback must not silently drop to sonnet:\n{captured.out}"
+        )
+
     def test_explicit_provider_overrides_router(self, tmp_path, monkeypatch):
         """An explicit provider+model in the spec must NOT be touched by the router
         (worker-provider-free-choice, pin_semantics=default)."""

--- a/tests/test_incident_taxonomy.py
+++ b/tests/test_incident_taxonomy.py
@@ -65,8 +65,8 @@ class TestCompleteness:
         enum_values = {ic.value for ic in IncidentClass}
         assert INCIDENT_CLASSES == enum_values
 
-    def test_seven_incident_classes(self):
-        assert len(IncidentClass) == 7
+    def test_eight_incident_classes(self):
+        assert len(IncidentClass) == 8
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two smart-router defects fixed (dispatch-20260814a):

1. **Enum gap dropped tier-mid/tier-high.** `_TIER_PROVIDER_TO_ENUM` had no `"claude"` key, so `resolve_tier_route`'s TIER_MID/TIER_HIGH routes (`provider="claude"`) resolved to `provider_enum=None` and `resolve_door_route` silently returned `None` — the door fell through to its own lane resolution instead of routing tier-mid/high to sonnet-5/opus-5. `"claude"` now maps to `Provider.CLAUDE`, any remaining unmapped provider logs a WARNING, and `route.reason` is appended to `route_reason` so a decline is visible.

2. **Availability was a code comment.** The kimi route was commented out after OI-940 (quota) and never came back. New `availability.py` layer gates each lane at decision time: required env vars, required CLI on PATH, and a cooldown window after a quota/auth failure (403/429/quota-exhausted). Cooldown is env-configurable (`VNX_ROUTER_COOLDOWN_SECONDS`, default 60m), stored in the central state dir via `vnx_paths.resolve_state_dir` (never hardcoded), written atomically via `atomic_io`. Kimi is back as a regular route (`kimi-k3` / `kimi_cli` / `kimi-via-cli-only`) reached when deepseek is in cooldown; local-gemma stays disabled via the layer's explicit reason. Fail-open throughout — a broken availability layer never blocks a dispatch.

T0 stays unrouted (`t0-opus-only` floor). `_select_dispatch_path` (fallback-chain) is untouched — lane-failure *wiring* (calling `record_lane_failure` from lane-execution paths) is a separate op; this PR ships the mechanism + decision-time check.

## Changes

- `scripts/lib/providers/smart_router/availability.py` (new) — `LaneCheck` registry, `lane_available`, `record_lane_failure`, `lane_cooldown_remaining`, `cooldown_seconds`.
- `scripts/lib/providers/smart_router/tier_routing.py` — `reason` field on `TierRoute`, factory routes, kimi re-added, deepseek→kimi→codex runtime fallback through the availability check, commented-out routes removed.
- `scripts/lib/providers/smart_router/door_routing.py` — `"claude": Provider.CLAUDE`, WARNING on unmapped provider, reason appended to `route_reason`.
- `scripts/lib/providers/smart_router/__init__.py` — export availability API.
- `tests/smart_router/test_availability.py` (new) + `tests/smart_router/test_tier_routing.py` — enum-gap, cooldown lifecycle, missing-key-preserved coverage.

## Verification

- `tests/smart_router/*` — 77 passed.
- `tests/test_smart_router*.py tests/test_routing_policy.py tests/test_lane_calibration_field_test.py` — 220 passed.
- Dry-run over 673 real staged specs × 4 LOC tiers = 2692 door decisions, **0 declines**. tier-mid → claude/sonnet-5, tier-high → claude/opus-5 (previously both returned `None`); tier-zero/low → codex without `DEEPSEEK_API_KEY` (existing behaviour preserved).

🤖 Generated with [Claude Code](https://claude.com/claude-code)