### PR TITLE
fix(observability): register kimi/glm/deepseek as Tier-1 adapters

### DIFF
--- a/scripts/lib/observability_tier.py
+++ b/scripts/lib/observability_tier.py
@@ -16,8 +16,11 @@ Governance defaults:
 """
 from __future__ import annotations
 
+import logging
 import os
 from typing import Literal
+
+logger = logging.getLogger(__name__)
 
 ObservabilityTier = Literal[1, 2, 3]
 
@@ -29,6 +32,23 @@ ADAPTER_DEFAULT_TIERS: dict[str, int] = {
     "gemini": 1,   # Tier 1 when VNX_GEMINI_STREAM=1 (streaming); Tier 3 otherwise
     "litellm": 1,  # Tier 1 when streaming SSE works; Tier 2 when only [DONE]
     "ollama": 2,   # Tier 2 baseline (text-only); Tier 1 when tool_use detected
+    # kimi streams per-event content-block messages over stream-json with full
+    # tool_use/tool_result parity: kimi_spawn.py::normalize_kimi_event tags every
+    # CanonicalEvent observability_tier=1 and _KimiNormalizerHost declares
+    # provider_observability_tier=1. Tier 1 (live per-event streaming).
+    "kimi": 1,
+    # glm-harness and deepseek-harness ride the full claude CLI harness (tools +
+    # agentic loop + live stream-json): both glm_harness_spawn.spawn_glm_harness
+    # and deepseek_harness_spawn.spawn_deepseek_harness delegate transport to
+    # provider_spawns.claude_spawn.spawn_claude (claude_adapter OBSERVABILITY_TIER=1).
+    # Tier 1. The bare names ("glm"/"deepseek") are the registry keys
+    # provider_dispatch._PROVIDER_TO_REGISTRY_KEY uses; the "-harness" spellings
+    # are the receipt provider strings the harness lanes write via
+    # frontmatter_fields(). Both spellings resolve to the same tier.
+    "glm": 1,
+    "deepseek": 1,
+    "glm-harness": 1,
+    "deepseek-harness": 1,
 }
 
 # Per-adapter guaranteed minimum tiers (worst-case).
@@ -38,6 +58,16 @@ ADAPTER_MINIMUM_TIERS: dict[str, int] = {
     "gemini": 3,   # Legacy path (VNX_GEMINI_STREAM=0) emits single synthetic result
     "litellm": 2,  # Fallback when streaming SSE unavailable
     "ollama": 2,   # Text-only baseline for non-tool-trained models
+    # kimi has no final-only fallback path: _build_kimi_cmd always passes
+    # `--output-format stream-json`, and even the legacy event_type stream
+    # (pre-1.44) emits per-event streaming. Worst case is still Tier 1.
+    "kimi": 1,
+    # glm/deepseek harness lanes always ride spawn_claude's live stream-json
+    # transport; there is no legacy synthetic-result path. Worst case Tier 1.
+    "glm": 1,
+    "deepseek": 1,
+    "glm-harness": 1,
+    "deepseek-harness": 1,
 }
 
 # Governance variant minimum tier requirements.
@@ -56,7 +86,9 @@ def resolve_effective_tier(provider: str, *, streaming_enabled: bool = True) -> 
     """Return the effective observability tier for a provider given runtime config.
 
     For Gemini: checks VNX_GEMINI_STREAM env var when streaming_enabled is True.
-    For all others: returns ADAPTER_DEFAULT_TIERS[provider] or tier 2 (safe default).
+    For all others: returns ADAPTER_DEFAULT_TIERS[provider]. An unregistered
+    provider falls back to tier 2 (safe default) and logs a WARNING with the
+    provider name so a missing entry is never silent.
     """
     provider = provider.lower()
 
@@ -72,7 +104,18 @@ def resolve_effective_tier(provider: str, *, streaming_enabled: bool = True) -> 
         # Ollama baseline is Tier 2; Tier 1 detected at runtime when tool_use fires
         return ADAPTER_DEFAULT_TIERS.get("ollama", 2)
 
-    return ADAPTER_DEFAULT_TIERS.get(provider, 2)
+    tier = ADAPTER_DEFAULT_TIERS.get(provider)
+    if tier is None:
+        # A missing provider must never be a silent Tier-2 default: log it so the
+        # next unregistered provider is visible instead of latent. This is what
+        # made kimi/glm/deepseek fall through to Tier 2 unnoticed until wired.
+        logger.warning(
+            "observability_tier: provider %r has no registered tier — defaulting "
+            "to tier 2 (limited streaming); add it to ADAPTER_DEFAULT_TIERS",
+            provider,
+        )
+        return 2
+    return tier
 
 
 def get_governance_min_tier(governance_variant: str) -> int:

--- a/tests/test_gate_stack_resolver.py
+++ b/tests/test_gate_stack_resolver.py
@@ -70,6 +70,32 @@ class TestTierAdmissionAllow:
         result = check_tier_admission("claude", "default")
         assert result.is_allowed() is True
 
+    def test_kimi_allowed_under_coding_strict(self):
+        result = check_tier_admission("kimi", "coding-strict")
+        assert result.decision == "allow"
+        assert result.adapter_tier == 1
+        assert result.required_tier == 1
+
+    def test_glm_allowed_under_coding_strict(self):
+        result = check_tier_admission("glm", "coding-strict")
+        assert result.decision == "allow"
+        assert result.adapter_tier == 1
+
+    def test_deepseek_allowed_under_coding_strict(self):
+        result = check_tier_admission("deepseek", "coding-strict")
+        assert result.decision == "allow"
+        assert result.adapter_tier == 1
+
+    def test_glm_harness_allowed_under_coding_strict(self):
+        result = check_tier_admission("glm-harness", "coding-strict")
+        assert result.decision == "allow"
+        assert result.adapter_tier == 1
+
+    def test_deepseek_harness_allowed_under_coding_strict(self):
+        result = check_tier_admission("deepseek-harness", "coding-strict")
+        assert result.decision == "allow"
+        assert result.adapter_tier == 1
+
 
 class TestTierAdmissionReject:
     def test_ollama_rejected_under_coding_strict(self):

--- a/tests/test_observability_tier_gating.py
+++ b/tests/test_observability_tier_gating.py
@@ -10,6 +10,7 @@ Covers:
 """
 from __future__ import annotations
 
+import logging
 import sys
 from pathlib import Path
 
@@ -26,7 +27,10 @@ from observability_tier import (
 )
 
 
-EXPECTED_ADAPTERS = {"claude", "codex", "gemini", "litellm", "ollama"}
+EXPECTED_ADAPTERS = {
+    "claude", "codex", "gemini", "litellm", "ollama",
+    "kimi", "glm", "deepseek", "glm-harness", "deepseek-harness",
+}
 
 
 class TestAdapterTierRegistry:
@@ -75,6 +79,32 @@ class TestAdapterTierRegistry:
         # Worst case is legacy path (no streaming)
         assert ADAPTER_MINIMUM_TIERS["gemini"] == 3
 
+    def test_kimi_default_is_tier_1(self):
+        # kimi_cli stream-json emits per-event content blocks (text/thinking/
+        # tool_use/tool_result) with observability_tier=1 — live streaming.
+        assert ADAPTER_DEFAULT_TIERS["kimi"] == 1
+
+    def test_kimi_minimum_is_tier_1(self):
+        # No final-only fallback path for kimi; worst case still streams.
+        assert ADAPTER_MINIMUM_TIERS["kimi"] == 1
+
+    def test_glm_default_is_tier_1(self):
+        # glm-harness rides the full claude CLI streaming harness.
+        assert ADAPTER_DEFAULT_TIERS["glm"] == 1
+
+    def test_deepseek_default_is_tier_1(self):
+        # deepseek-harness rides the full claude CLI streaming harness.
+        assert ADAPTER_DEFAULT_TIERS["deepseek"] == 1
+
+    def test_harness_spellings_default_is_tier_1(self):
+        # The receipt provider strings are "glm-harness"/"deepseek-harness".
+        assert ADAPTER_DEFAULT_TIERS["glm-harness"] == 1
+        assert ADAPTER_DEFAULT_TIERS["deepseek-harness"] == 1
+
+    def test_harness_spellings_minimum_is_tier_1(self):
+        assert ADAPTER_MINIMUM_TIERS["glm-harness"] == 1
+        assert ADAPTER_MINIMUM_TIERS["deepseek-harness"] == 1
+
 
 class TestResolveEffectiveTier:
     def test_claude_returns_tier_1(self):
@@ -112,6 +142,34 @@ class TestResolveEffectiveTier:
     def test_case_insensitive_provider(self, monkeypatch):
         monkeypatch.setenv("VNX_GEMINI_STREAM", "1")
         assert resolve_effective_tier("GEMINI") == resolve_effective_tier("gemini")
+
+    def test_kimi_resolves_to_tier_1_not_generic_2(self):
+        assert resolve_effective_tier("kimi") == 1
+
+    def test_glm_resolves_to_tier_1_not_generic_2(self):
+        assert resolve_effective_tier("glm") == 1
+
+    def test_deepseek_resolves_to_tier_1_not_generic_2(self):
+        assert resolve_effective_tier("deepseek") == 1
+
+    def test_glm_harness_resolves_to_tier_1(self):
+        assert resolve_effective_tier("glm-harness") == 1
+
+    def test_deepseek_harness_resolves_to_tier_1(self):
+        assert resolve_effective_tier("deepseek-harness") == 1
+
+
+class TestUnknownProviderWarning:
+    def test_unknown_provider_logs_warning_with_name(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            tier = resolve_effective_tier("totally-unknown-provider")
+        assert tier == 2
+        assert "totally-unknown-provider" in caplog.text
+
+    def test_known_provider_does_not_log_warning(self, caplog):
+        with caplog.at_level(logging.WARNING):
+            assert resolve_effective_tier("kimi") == 1
+        assert "no registered tier" not in caplog.text
 
 
 class TestGovernanceMinTiers:


### PR DESCRIPTION
## Wat er mis was

`scripts/lib/observability_tier.py` had twee tabellen (`ADAPTER_DEFAULT_TIERS`, `ADAPTER_MINIMUM_TIERS`) zonder `kimi`, `glm` en `deepseek`. `resolve_effective_tier` eindigt op `ADAPTER_DEFAULT_TIERS.get(provider, 2)`, dus alle drie kregen stil tier 2.

Tier 2 haalt de eis van `coding-strict` (tier 1) niet. Zodra `check_tier_admission` uit `gate_stack_resolver.py` op het gate-pad aangesloten wordt, zouden kimi (fleet-default build-worker sinds 23-07), glm en deepseek geweigerd worden voor code-schrijvende dispatches. Latente val: gedrag bestaat al, aansluiting ontbreekt nog.

## Fix

1. `kimi`, `glm`, `deepseek` in beide tabellen gezet, tier 1. Onderbouwd per provider met de plek in de code:
   - kimi: `kimi_spawn.normalize_kimi_event` tagt elke `CanonicalEvent` `observability_tier=1`; `_KimiNormalizerHost.provider_observability_tier = 1`. stream-json emitteert per-event content blocks (text/thinking/tool_use/tool_result).
   - glm/deepseek: `glm_harness_spawn.spawn_glm_harness` en `deepseek_harness_spawn.spawn_deepseek_harness` delegeren transport aan `spawn_claude` (claude_adapter `OBSERVABILITY_TIER=1`), dus full live stream-json met tool_use parity.
2. Ook de receipt-providerstrings `glm-harness` / `deepseek-harness` gedekt (de harness-lanes schrijven die via `frontmatter_fields()`, niet de kale naam). Resolver gedraaid: alle vijf spellings resolven naar tier 1.
3. Geen pad weigert ze meer voor `coding-strict`: `check_tier_admission("kimi"|"glm"|"deepseek"|... , "coding-strict")` → allow. De enige andere aanroeper van `get_governance_min_tier` is `check_tier_admission` zelf; `governance_profiles.py` gebruikt zijn eigen `min_observability_tier=1` voor coding-strict/default, waar tier-1 providers doorheen komen.
4. De stille default is weg: een onbekende provider logt nu een WARNING met de providernaam.

## Verificatie

Targeted tests (bestanden die ik raakte + directe buur `test_append_receipt_observability.py`):

```
python3 -m pytest tests/test_observability_tier_gating.py tests/test_gate_stack_resolver.py tests/test_append_receipt_observability.py -q
90 passed
```

Nieuwe tests falen zonder de fix: `resolve_effective_tier("kimi"|"glm"|"deepseek")` → 1 (niet 2), coding-strict laat alle drie door, onbekende provider logt warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)