### PR TITLE
fix(dispatch): thread base_ref through provider-lane worktree isolation (OI-1176)

### DIFF
--- a/scripts/lib/provider_dispatch.py
+++ b/scripts/lib/provider_dispatch.py
@@ -1266,6 +1266,16 @@ def _build_parser() -> argparse.ArgumentParser:
         "--deadline-seconds", type=int, default=900,
         help="Total deadline in seconds for the dispatch (default 900, matches spawn_claude default).",
     )
+    parser.add_argument(
+        "--base-ref", default=None, dest="base_ref",
+        help=(
+            "Base ref for the isolated dispatch worktree (mirrors the tmux lane's "
+            "--base-ref and the dispatch spec's plan.base_ref). Threads the spec value "
+            "into create_dispatch_worktree so a fix-forward or PR-base dispatch is "
+            "isolated on the correct merge-base. Unset -> origin/main (or "
+            "VNX_BENCH_WORKTREE_BASE_REF for the benchmark harness)."
+        ),
+    )
     return parser
 
 
@@ -1468,12 +1478,19 @@ def _dispatch_claude(args: argparse.Namespace) -> int:
         _finish_provider_worktree(args.dispatch_id, isolation_worktree, terminal_id=args.terminal_id)
 
 
-def _create_provider_worktree(dispatch_id: str) -> Path:
+def _create_provider_worktree(dispatch_id: str, base_ref: Optional[str] = None) -> Path:
     """Create an isolated worktree for a provider dispatch.
 
     Always called (isolation default-on since OI-1090).  Returns the worktree
     Path on success, raises RuntimeError on failure — no shared-checkout
     fallback.
+
+    *base_ref* (the dispatch spec's ``plan.base_ref``) is threaded straight into
+    create_dispatch_worktree so the provider lane isolates on the same merge-base
+    the tmux lane honors.  None lets create_dispatch_worktree apply its own
+    precedence (VNX_BENCH_WORKTREE_BASE_REF, then origin/main).  An unresolvable
+    explicit base_ref fails LOUD inside create_dispatch_worktree — there is no
+    silent fallback to origin/main.
 
     Resolves the CONSUMER project root explicitly (dispatch_worktree_isolation.
     resolve_consumer_project_root) and threads it into create_dispatch_worktree
@@ -1487,7 +1504,7 @@ def _create_provider_worktree(dispatch_id: str) -> Path:
         resolve_consumer_project_root,
     )
     project_root = resolve_consumer_project_root()
-    wt_path = create_dispatch_worktree(dispatch_id, project_root=project_root)
+    wt_path = create_dispatch_worktree(dispatch_id, project_root=project_root, base_ref=base_ref)
     logger.info("provider isolation: worktree created at %s (dispatch=%s)", wt_path, dispatch_id)
     return wt_path
 
@@ -1499,8 +1516,16 @@ def _prepare_provider_workdir(
 
     Always creates an isolated worktree (default-on since OI-1090).
     Raises RuntimeError on failure — no shared-checkout fallback.
+
+    OI-1176: threads args.base_ref (the dispatch spec's plan.base_ref) into
+    _create_provider_worktree.  Every provider lane goes through here, so a
+    fix-forward dispatch isolated on origin/<branch> keeps that branch instead
+    of silently falling back to origin/main.
     """
-    isolation_worktree = _create_provider_worktree(args.dispatch_id)
+    base_ref = getattr(args, "base_ref", None)
+    if not isinstance(base_ref, str):
+        base_ref = None
+    isolation_worktree = _create_provider_worktree(args.dispatch_id, base_ref=base_ref)
 
     # VNX_BENCH_REQUIRE_ISOLATION: the benchmark's fail-closed assertion that
     # isolation must be active.  Since isolation is now unconditional, this

--- a/tests/test_provider_dispatch_worktree_isolation.py
+++ b/tests/test_provider_dispatch_worktree_isolation.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import json
 import subprocess
 import sys
+from contextlib import ExitStack
 from pathlib import Path
 from unittest.mock import MagicMock, patch, call
 
@@ -121,7 +122,7 @@ class TestCodexIsolation:
                 exit_code = provider_dispatch._dispatch_codex(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("iso-codex-001")
+        mock_create.assert_called_once_with("iso-codex-001", base_ref=None)
         mock_remove.assert_called_once_with("iso-codex-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
@@ -152,7 +153,7 @@ class TestCodexIsolation:
             exit_code = provider_dispatch._dispatch_codex(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("default-iso-codex")
+        mock_create.assert_called_once_with("default-iso-codex", base_ref=None)
         mock_remove.assert_called_once_with("default-iso-codex", terminal_id="T1")
         assert captured.get("cwd") == _FAKE_WT_PATH
 
@@ -207,7 +208,7 @@ class TestGeminiIsolation:
             exit_code = provider_dispatch._dispatch_gemini(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("iso-gemini-001")
+        mock_create.assert_called_once_with("iso-gemini-001", base_ref=None)
         mock_remove.assert_called_once_with("iso-gemini-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
@@ -236,7 +237,7 @@ class TestGeminiIsolation:
             exit_code = provider_dispatch._dispatch_gemini(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("default-iso-gemini")
+        mock_create.assert_called_once_with("default-iso-gemini", base_ref=None)
         mock_remove.assert_called_once_with("default-iso-gemini", terminal_id="T1")
         assert captured.get("cwd") == _FAKE_WT_PATH
 
@@ -271,7 +272,7 @@ class TestKimiIsolation:
             exit_code = provider_dispatch._dispatch_kimi(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("iso-kimi-001")
+        mock_create.assert_called_once_with("iso-kimi-001", base_ref=None)
         mock_remove.assert_called_once_with("iso-kimi-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
@@ -301,7 +302,7 @@ class TestKimiIsolation:
             exit_code = provider_dispatch._dispatch_kimi(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("default-iso-kimi")
+        mock_create.assert_called_once_with("default-iso-kimi", base_ref=None)
         mock_remove.assert_called_once_with("default-iso-kimi", terminal_id="T1")
         assert captured.get("cwd") == _FAKE_WT_PATH
 
@@ -341,7 +342,7 @@ class TestLiteLLMIsolation:
             exit_code = provider_dispatch._dispatch_litellm(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("iso-litellm-001")
+        mock_create.assert_called_once_with("iso-litellm-001", base_ref=None)
         mock_remove.assert_called_once_with("iso-litellm-001", terminal_id="T1")
         assert captured["cwd"] == _FAKE_WT_PATH
 
@@ -376,7 +377,7 @@ class TestLiteLLMIsolation:
             exit_code = provider_dispatch._dispatch_litellm(args)
 
         assert exit_code == 0
-        mock_create.assert_called_once_with("default-iso-litellm")
+        mock_create.assert_called_once_with("default-iso-litellm", base_ref=None)
         mock_remove.assert_called_once_with("default-iso-litellm", terminal_id="T1")
         assert captured.get("cwd") == _FAKE_WT_PATH
 
@@ -392,7 +393,7 @@ class TestProviderWorktreeHelpers:
              patch("dispatch_worktree_isolation.create_dispatch_worktree", return_value=tmp_path) as mock_create:
             result = provider_dispatch._create_provider_worktree("helper-create-test")
         assert result == tmp_path
-        mock_create.assert_called_once_with("helper-create-test", project_root=consumer_root)
+        mock_create.assert_called_once_with("helper-create-test", project_root=consumer_root, base_ref=None)
 
     def test_create_raises_on_runtime_error(self):
         with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=Path("/tmp/consumer")), \
@@ -468,7 +469,7 @@ class TestCodexIsolationFailLoud:
             exit_code = provider_dispatch._dispatch_codex(args)
 
         assert exit_code == 1
-        mock_create.assert_called_once_with("fail-loud-codex")
+        mock_create.assert_called_once_with("fail-loud-codex", base_ref=None)
         assert spawn_called == [], "spawn_codex must NOT be called when worktree creation fails"
 
 
@@ -496,7 +497,7 @@ class TestGeminiIsolationFailLoud:
             exit_code = provider_dispatch._dispatch_gemini(args)
 
         assert exit_code == 1
-        mock_create.assert_called_once_with("fail-loud-gemini")
+        mock_create.assert_called_once_with("fail-loud-gemini", base_ref=None)
         assert spawn_called == [], "spawn_gemini must NOT be called when worktree creation fails"
 
 
@@ -525,7 +526,7 @@ class TestKimiIsolationFailLoud:
             exit_code = provider_dispatch._dispatch_kimi(args)
 
         assert exit_code == 1
-        mock_create.assert_called_once_with("fail-loud-kimi")
+        mock_create.assert_called_once_with("fail-loud-kimi", base_ref=None)
         assert spawn_called == [], "spawn_kimi must NOT be called when worktree creation fails"
 
 
@@ -559,7 +560,7 @@ class TestLiteLLMIsolationFailLoud:
             exit_code = provider_dispatch._dispatch_litellm(args)
 
         assert exit_code == 1
-        mock_create.assert_called_once_with("fail-loud-litellm")
+        mock_create.assert_called_once_with("fail-loud-litellm", base_ref=None)
         assert spawn_called == [], "spawn_litellm must NOT be called when worktree creation fails"
 
 
@@ -1163,3 +1164,183 @@ class TestOi1106BaseFromClaimNotPlanBaseRef:
         assert any("claim" in (r.getMessage() or "").lower() for r in records), (
             "expected a loud degradation log mentioning the claim fallback"
         )
+
+
+# ---------------------------------------------------------------------------
+# OI-1176: base_ref must flow spec -> _prepare_provider_workdir ->
+# _create_provider_worktree -> create_dispatch_worktree, for EVERY provider lane.
+# Before the fix _prepare_provider_workdir called _create_provider_worktree
+# (dispatch_id) with no base_ref, so a dispatch with base_ref=origin/<branch>
+# silently isolated on origin/main. The VNX_DISPATCH_LEGACY=1 rollback routes
+# straight here, so the rollback button was also the base_ref-drop button.
+# ---------------------------------------------------------------------------
+
+
+class TestProviderBaseRefThreading:
+    def _init_diverged_repo(self, tmp_path, monkeypatch) -> Path:
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+        # Divergent feature branch so origin/feature != origin/main.
+        subprocess.run(
+            ["git", "-C", str(local), "checkout", "-b", "feature"],
+            check=True, capture_output=True,
+        )
+        (local / "feature.txt").write_text("feature\n")
+        subprocess.run(
+            ["git", "-C", str(local), "add", "feature.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "commit", "-m", "feature commit"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "push", "-u", "origin", "feature"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "checkout", "main"],
+            check=True, capture_output=True,
+        )
+        return local
+
+    def _rev_parse(self, root: Path, ref: str) -> str:
+        return subprocess.check_output(
+            ["git", "-C", str(root), "rev-parse", ref], text=True
+        ).strip()
+
+    def _run_dispatch(self, dispatch_fn, provider, argv, spawn_target, local, model_patches):
+        captured = {}
+
+        def fake_spawn(**kwargs):
+            wt = kwargs.get("cwd")
+            captured["head"] = subprocess.check_output(
+                ["git", "-C", str(wt), "rev-parse", "HEAD"], text=True
+            ).strip()
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        patches = [
+            patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=local),
+            patch("provider_dispatch._emit_governance", side_effect=_noop_governance),
+            patch("provider_dispatch._enrich_instruction", return_value="noop"),
+            patch("event_store.EventStore", return_value=mock_event_store),
+            patch(spawn_target, side_effect=fake_spawn),
+        ]
+        for target, ret in model_patches:
+            patches.append(patch(target, return_value=ret))
+
+        with ExitStack() as stack:
+            for p in patches:
+                stack.enter_context(p)
+            args = provider_dispatch._build_parser().parse_args(argv)
+            exit_code = dispatch_fn(args)
+
+        return exit_code, captured.get("head")
+
+    @pytest.mark.parametrize(
+        "provider, dispatch_fn_name, spawn_target, model_patches",
+        [
+            ("codex", "_dispatch_codex", "provider_spawns.codex_spawn.spawn_codex",
+             [("provider_dispatch._resolve_codex_model", "gpt-test")]),
+            ("kimi", "_dispatch_kimi", "provider_spawns.kimi_spawn.spawn_kimi",
+             [("provider_dispatch._kimi_resolve_requested_key", "kimi-k3"),
+              ("provider_dispatch._kimi_resolve_cli_model_arg", "kimi-k3")]),
+            ("gemini", "_dispatch_gemini", "provider_spawns.gemini_spawn.spawn_gemini",
+             []),
+        ],
+        ids=["codex", "kimi", "gemini"],
+    )
+    def test_worktree_based_on_spec_base_ref(
+        self, provider, dispatch_fn_name, spawn_target, model_patches, tmp_path, monkeypatch
+    ):
+        """A provider dispatch with --base-ref origin/feature isolates on that
+        branch, not origin/main.  Fails without the OI-1176 fix (worktree HEAD
+        would be origin/main)."""
+        local = self._init_diverged_repo(tmp_path, monkeypatch)
+        feature_sha = self._rev_parse(local, "origin/feature")
+        main_sha = self._rev_parse(local, "origin/main")
+        assert feature_sha != main_sha, "fixture: feature must diverge from main"
+
+        argv = [
+            "--provider", provider,
+            "--terminal-id", "T1",
+            "--dispatch-id", f"oi1176-{provider}",
+            "--instruction", "noop",
+            "--model", "sonnet",
+            "--base-ref", "origin/feature",
+        ]
+        dispatch_fn = getattr(provider_dispatch, dispatch_fn_name)
+        exit_code, head = self._run_dispatch(
+            dispatch_fn, provider, argv, spawn_target, local, model_patches
+        )
+
+        assert exit_code == 0
+        assert head == feature_sha, (
+            f"{provider} worktree HEAD {head!r} != spec base_ref origin/feature "
+            f"{feature_sha!r} — base_ref was dropped (silent origin/main fallback)"
+        )
+        assert head != main_sha
+
+    def test_unresolvable_base_ref_fails_loud(self, tmp_path, monkeypatch):
+        """An unresolvable base_ref raises RuntimeError from the allocator and
+        creates NO worktree — never a silent origin/main fallback."""
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        with patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=local):
+            with pytest.raises(RuntimeError, match="cannot resolve base_ref"):
+                provider_dispatch._create_provider_worktree(
+                    "oi1176-unresolvable", base_ref="origin/does-not-exist"
+                )
+
+        wt_dir = local / ".vnx-data" / "worktrees" / "dispatch-oi1176-unresolvable"
+        assert not wt_dir.exists()
+
+    def test_unresolvable_base_ref_aborts_dispatch(self, tmp_path, monkeypatch):
+        """End-to-end: _dispatch_codex with an unresolvable --base-ref aborts
+        (return 1) and never reaches spawn — the isolation guarantee never
+        silently deviates."""
+        local = _init_git_repo_with_origin(tmp_path)
+        data_dir = tmp_path / "vnx-data"
+        monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+
+        spawn_called = []
+
+        def fake_spawn(**kwargs):
+            spawn_called.append(kwargs)
+            return _make_spawn_result()
+
+        mock_event_store = MagicMock()
+        mock_event_store.append = MagicMock()
+        mock_event_store.clear = MagicMock()
+
+        argv = [
+            "--provider", "codex",
+            "--terminal-id", "T1",
+            "--dispatch-id", "oi1176-bad-ref",
+            "--instruction", "noop",
+            "--model", "sonnet",
+            "--base-ref", "origin/does-not-exist",
+        ]
+        with ExitStack() as stack:
+            stack.enter_context(patch("dispatch_worktree_isolation.resolve_consumer_project_root", return_value=local))
+            stack.enter_context(patch("provider_dispatch._emit_governance", side_effect=_noop_governance))
+            stack.enter_context(patch("provider_dispatch._enrich_instruction", return_value="noop"))
+            stack.enter_context(patch("provider_dispatch._resolve_codex_model", return_value="gpt-test"))
+            stack.enter_context(patch("event_store.EventStore", return_value=mock_event_store))
+            stack.enter_context(patch("provider_spawns.codex_spawn.spawn_codex", side_effect=fake_spawn))
+            args = provider_dispatch._build_parser().parse_args(argv)
+            exit_code = provider_dispatch._dispatch_codex(args)
+
+        assert exit_code == 1
+        assert spawn_called == [], "spawn_codex must NOT run when base_ref is unresolvable"
+        assert not (local / ".vnx-data" / "worktrees" / "dispatch-oi1176-bad-ref").exists()


### PR DESCRIPTION
## Problem

`scripts/lib/provider_dispatch.py` dropped the dispatch spec's `base_ref` for **all eight** provider lanes: `_prepare_provider_workdir` called `_create_provider_worktree(dispatch_id)` with no `base_ref`, so `create_dispatch_worktree` silently fell back to `origin/main` even when the spec named `origin/<branch>`.

This is the exact path `VNX_DISPATCH_LEGACY=1` routes to, and that flag always wins (`dispatch_flags.py`). So the rollback button was also the base_ref-drop button: a correctly isolated worktree on the wrong base, with no signal.

Six of the eight callers are non-claude — this is the complete `provider_dispatch` CLI, not a benchmark side door.

## Fix

- Add `--base-ref` to `provider_dispatch`'s parser (default `None`, preserving `create_dispatch_worktree`'s own precedence: `origin/main`, or `VNX_BENCH_WORKTREE_BASE_REF` for the benchmark harness).
- Thread `args.base_ref` through `_prepare_provider_workdir` → `_create_provider_worktree` → `create_dispatch_worktree(base_ref=...)`. All eight callers route through `_prepare_provider_workdir`, so the threading covers each of them.
- `create_dispatch_worktree` already accepted `base_ref` (it's what the tmux lane honors, and the envelope lane already threads `plan.base_ref`). It also already fails LOUD on an unresolvable base_ref — this change routes that signal through the provider lane instead of discarding the ref before it gets there.

## Verification

New regression tests (fail without the fix — verified by reverting the threading line):
- `codex`/`kimi`/`gemini` dispatch with `--base-ref origin/feature` isolates on that branch, not `main` (3 callers, all non-claude).
- an unresolvable `base_ref` raises `RuntimeError` and never spawns; no silent `origin/main` fallback.

`tests/test_provider_dispatch_worktree_isolation.py`: 35 passed.

## Open Items

Structural: there are **two allocators** for the same "create an isolated dispatch worktree from a base_ref" task:

1. `tmux_worktree.allocate()` (tmux lane, returns `WorktreeHandle` with classify/reap semantics, `flock` + branch-existence detection).
2. `dispatch_worktree_isolation.create_dispatch_worktree()` (provider lanes, returns `Path`, writes an O_EXCL claim registry entry).

Both resolve `base_ref`, run `git worktree add -b dispatch/<id>`, fail loud on unresolvable ref, and share the same lock file (`.git/worktrees/.vnx-lock`). Unifying them needs a single allocator that returns both the path and a classification-capable handle, and a reconciliation of the claim registry vs the tmux flock/branch detection — not done here to keep this PR scoped to the blocker. No third allocator added.