### PR TITLE
fix(governance): decouple work fate from receipt fate; fail loud on read-only version store

### DIFF
--- a/scripts/lib/data_dir_resolution.py
+++ b/scripts/lib/data_dir_resolution.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Fail-loud VNX data-dir resolution shared by event_store and the headless
+dispatch daemon (OI-1179 + OI-1172).
+
+Two defects, one class: a data-dir resolver lands on the *read-only* pinned
+version store ``~/.vnx-system/versions/<v>/.vnx-data`` and the caller then
+tries to write there.
+
+  * ``event_store._events_dir`` ignored a set ``VNX_DATA_DIR`` unless
+    ``VNX_DATA_DIR_EXPLICIT=1`` was also set (the "two-flag trap"), then fell
+    back to the canonical resolver which — in a central install — can resolve
+    the keystone (see #1023).
+  * ``headless_dispatch_daemon._default_data_dir`` fell back to a
+    ``_repo_root() / ".vnx-data"`` walk when the canonical resolver returned
+    None, which resolves the keystone.
+
+The read-only version store is never a valid data dir. This module resolves
+env-first (a set ``VNX_DATA_DIR`` is honored directly, no explicit flag
+required) and then FAILS LOUD — raising ``DataDirResolutionError`` naming the
+resolution chain — if the result lands under the version store.
+
+BILLING SAFETY: No Anthropic SDK imports. Local filesystem resolution only.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+class DataDirResolutionError(RuntimeError):
+    """Raised when the resolved data dir is a read-only pinned version store."""
+
+
+def _version_store_roots() -> "list[Path]":
+    """Roots that are never valid VNX data dirs.
+
+    ``~/.vnx-system/versions/`` holds the read-only pinned version dirs
+    (vX.Y.Z) that ``vnx_version_ro`` locks after install. ``current`` is the
+    symlink shim: resolving through it lands on a version dir, which the
+    ``versions`` root already covers once ``.resolve()`` follows the symlink —
+    but keeping ``current`` here also catches a non-symlinked ``current``
+    layout so no install shape slips through.
+    """
+    home = Path.home()
+    return [
+        home / ".vnx-system" / "versions",
+        home / ".vnx-system" / "current",
+    ]
+
+
+def _is_under_version_store(resolved: Path) -> bool:
+    sep = os.sep
+    for root in _version_store_roots():
+        try:
+            r = root.resolve()
+        except OSError:
+            r = root.expanduser()
+        if resolved == r or str(resolved).startswith(str(r) + sep):
+            return True
+    return False
+
+
+def refuse_version_store(resolved: "Path | str", chain: str) -> Path:
+    """Return ``resolved`` unchanged unless it is a read-only version store.
+
+    Raises ``DataDirResolutionError`` — naming the resolution chain that
+    produced the path — when ``resolved`` sits under
+    ``~/.vnx-system/versions/`` (or resolves through ``~/.vnx-system/current``
+    into it). A read-only version store is never a valid VNX data dir.
+    """
+    resolved = Path(resolved).expanduser().resolve()
+    if _is_under_version_store(resolved):
+        raise DataDirResolutionError(
+            "resolved VNX data dir is a read-only version store: "
+            f"{resolved} (resolution chain: {chain}). A pinned version store "
+            "under ~/.vnx-system/versions/ is never a valid data dir — writing "
+            "there is forbidden. Set VNX_DATA_DIR to a writable project store, "
+            "or ensure VNX_PROJECT_ID / a .vnx-project-id marker resolves the "
+            "project store (~/.vnx-data/<project_id>)."
+        )
+    return resolved
+
+
+def resolve_data_dir_fail_loud() -> Path:
+    """Resolve the VNX data dir env-first, failing loud on the version store.
+
+    Resolution order (a set ``VNX_DATA_DIR`` is honored directly; the
+    ``VNX_DATA_DIR_EXPLICIT`` flag is no longer required — OI-1179):
+      1. ``VNX_DATA_DIR`` set           -> that dir (resolved).
+      2. ``VNX_PROJECT_ID`` set         -> ``~/.vnx-data/<project_id>``.
+      3. canonical resolver             -> ``vnx_paths.resolve_paths()["VNX_DATA_DIR"]``.
+
+    Every step is refused when it lands on the read-only version store; the
+    refusal names the chain that produced the path.
+    """
+    vnx_data = os.environ.get("VNX_DATA_DIR", "")
+    if vnx_data:
+        return refuse_version_store(
+            vnx_data, f"VNX_DATA_DIR={vnx_data!r}"
+        )
+
+    project_id = os.environ.get("VNX_PROJECT_ID", "")
+    if project_id:
+        return refuse_version_store(
+            Path.home() / ".vnx-data" / project_id,
+            f"VNX_PROJECT_ID={project_id!r} -> ~/.vnx-data/<project_id>",
+        )
+
+    from vnx_paths import resolve_paths
+
+    resolved = Path(resolve_paths()["VNX_DATA_DIR"])
+    return refuse_version_store(
+        resolved,
+        "VNX_DATA_DIR unset, VNX_PROJECT_ID unset -> "
+        "canonical vnx_paths.resolve_paths()['VNX_DATA_DIR']",
+    )

--- a/scripts/lib/dispatch_envelope.py
+++ b/scripts/lib/dispatch_envelope.py
@@ -6,9 +6,11 @@ and/or "claude-subprocess".
 
 Seams: PREPARE -> ROUTE -> EXECUTE -> GOVERN
 
-GOVERN is fail-closed: a missing receipt_path raises EnvelopeGovernError — never
-silently loses a receipt. Report is emitted before the receipt so the receipt carries
-the linkage even when the report file is new (ADR-005).
+GOVERN decouples the work fate from the receipt fate (OI-1179): a missing
+receipt_path is recorded as a proof-chain gap (loud log + trail) — never silent
+and never flipped into a `failed` work status. Report is emitted before the
+receipt so the receipt carries the linkage even when the report file is new
+(ADR-005).
 
 Per-lane dual-receipt safety: GOVERN emits both report AND receipt. When the
 receipt NDJSON already contains a line for this dispatch_id (e.g. written by
@@ -345,7 +347,11 @@ def run_envelope(spec: EnvelopeSpec, lane: str = "codex") -> EnvelopeResult:
     """Run PREPARE -> ROUTE -> EXECUTE -> GOVERN for the given lane.
 
     Returns EnvelopeResult on success / failure / timeout.
-    Raises EnvelopeGovernError when GOVERN cannot confirm a receipt (fail-closed).
+
+    OI-1179: a receipt-emit failure no longer raises — ``_govern`` records a
+    proof-chain gap (loud error log + ``receipt_emit_failures.ndjson`` trail)
+    and returns ``receipt_path=None``, so ``returncode`` still reflects whether
+    the WORK succeeded, never whether the proof landed.
     """
     # ROUTE
     router = LaneRouter()
@@ -420,7 +426,6 @@ def run_envelope_plan(
     Raises:
         PermissionError: permit was not issued by issue_permit for this plan.
         ValueError: plan.lane is not "provider".
-        EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
     """
     from dispatch_internal import is_valid_instruction_hash, require_permit  # noqa: PLC0415
 
@@ -649,7 +654,6 @@ def run_envelope_headless_plan(
     Raises:
         PermissionError: permit was not issued by issue_permit for this plan.
         ValueError: plan.lane is not "claude_headless".
-        EnvelopeGovernError: GOVERN cannot confirm receipt (fail-closed).
     """
     from dispatch_internal import is_valid_instruction_hash, require_permit  # noqa: PLC0415
 

--- a/scripts/lib/envelope_govern.py
+++ b/scripts/lib/envelope_govern.py
@@ -23,14 +23,16 @@ keeps binding unchanged.
 
 from __future__ import annotations
 
+import fcntl
+import json
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from dispatch_identity import _IDENTITY_UNRESOLVED  # single canonical sentinel (dispatch-20260804-190000)
-from envelope_types import EnvelopeGovernError, EnvelopeSpec, _AdapterResult
+from envelope_types import EnvelopeSpec, _AdapterResult
 from envelope_prepare import _verify_role_application
 from envelope_govern_support import (
     _archive_dispatch_events,
@@ -49,6 +51,89 @@ logger = logging.getLogger(__name__)
 # records) and the observable-only L2 phase (#1415, db7a6046) is superseded.
 _CONTRACT_ENFORCE_MARKER = "VNX_CONTRACT_ENFORCE_VIOLATION"
 
+# OI-1179: greppable marker for a dispatch whose WORK succeeded but whose
+# receipt could not be written (a proof-chain gap, NOT a work failure). Each
+# trail record carries this marker so governance can query the gap and claim
+# the dispatch instead of writing it off as failed.
+_RECEIPT_EMIT_FAILURE_MARKER = "VNX_RECEIPT_EMIT_FAILURE"
+
+# Trail filename: append-only NDJSON written next to the receipt ledger
+# (falling back to the data dir when the state dir is the very thing that
+# refused the write). Consumed by governance to surface proof-chain gaps.
+_RECEIPT_EMIT_FAILURES_FILENAME = "receipt_emit_failures.ndjson"
+
+
+def _record_receipt_emit_failure(
+    spec: EnvelopeSpec,
+    reason: str,
+    *,
+    work_status: str,
+) -> None:
+    """Record — loudly and durably — that a dispatch has no proof chain.
+
+    The receipt write failed, but that is a PROOF problem, not a WORK problem:
+    the dispatch's work fate is ``work_status`` regardless of whether the
+    receipt landed. This function logs an ERROR (never silent) and appends a
+    greppable NDJSON trail record so governance can claim the receiptless
+    dispatch instead of writing it off as failed.
+
+    Best-effort write: the state dir may be exactly the location that refused
+    the receipt write (a read-only version store), so the trail is attempted
+    in the state dir first and the data dir second. If neither is writable,
+    the ERROR log line remains the trail — the gap is never silent.
+    """
+    record = {
+        "marker": _RECEIPT_EMIT_FAILURE_MARKER,
+        "timestamp": datetime.now(timezone.utc).isoformat(timespec="milliseconds"),
+        "dispatch_id": spec.dispatch_id,
+        "terminal_id": spec.terminal_id,
+        "provider": spec.provider,
+        "work_status": work_status,
+        "reason": reason,
+    }
+    line = json.dumps(record, separators=(",", ":")) + "\n"
+    targets = [spec.state_dir, spec.data_dir]
+    for target in targets:
+        if target is None:
+            continue
+        try:
+            path = Path(target) / _RECEIPT_EMIT_FAILURES_FILENAME
+            path.parent.mkdir(parents=True, exist_ok=True)
+            with open(path, "a", encoding="utf-8") as fh:
+                fcntl.flock(fh.fileno(), fcntl.LOCK_EX)
+                try:
+                    fh.write(line)
+                    fh.flush()
+                finally:
+                    fcntl.flock(fh.fileno(), fcntl.LOCK_UN)
+            logger.error(
+                "envelope._govern: %s dispatch=%s work_status=%s — receipt emit "
+                "failed, proof-chain gap recorded at %s: %s",
+                _RECEIPT_EMIT_FAILURE_MARKER,
+                spec.dispatch_id,
+                work_status,
+                path,
+                reason,
+            )
+            return
+        except OSError as _trail_exc:
+            logger.warning(
+                "envelope._govern: could not write proof-chain-gap trail to %s "
+                "dispatch=%s: %s",
+                target,
+                spec.dispatch_id,
+                _trail_exc,
+            )
+    logger.error(
+        "envelope._govern: %s dispatch=%s work_status=%s — receipt emit failed "
+        "and NO proof-chain-gap trail could be written (state and data dirs "
+        "both refused): %s",
+        _RECEIPT_EMIT_FAILURE_MARKER,
+        spec.dispatch_id,
+        work_status,
+        reason,
+    )
+
 
 # ---------------------------------------------------------------------------
 # GOVERN
@@ -66,8 +151,12 @@ def _govern(
 ) -> tuple:
     """Emit unified_report then dispatch receipt. Returns (report_path, receipt_path).
 
-    Fail-closed contract: raises EnvelopeGovernError when receipt_path is None or
-    absent on disk after emit — never silently loses a receipt.
+    OI-1179: the work fate and the receipt fate are decoupled. A failed receipt
+    emit does NOT raise and does NOT flip a successful dispatch to failed —
+    instead it records a proof-chain gap (loud error log + a
+    ``receipt_emit_failures.ndjson`` trail record carrying
+    ``VNX_RECEIPT_EMIT_FAILURE``) and returns ``receipt_path=None``, so the
+    caller's status/returncode still reflect whether the WORK succeeded.
     Report is emitted first so the receipt can carry the linkage (ADR-005 ordering).
 
     Idempotent dedup: when the receipt NDJSON already contains a line for this
@@ -165,10 +254,11 @@ def _govern(
         except OSError:
             pass  # can't read report file — skip validation, don't break receipt
 
-    # RECEIPT second — fail-closed, with idempotent dedup. The end-of-dispatch
-    # event clear runs in finally so the live stream is truncated even when the
-    # fail-closed receipt emit raises EnvelopeGovernError.
+    # RECEIPT second — with idempotent dedup. A failed emit records a
+    # proof-chain gap (OI-1179) instead of raising: the end-of-dispatch event
+    # clear still runs in finally, and the caller's work status is preserved.
     receipt_path: Optional[Path] = None
+    _emit_failed = False  # OI-1179: guard so a raise and a None-return are not double-recorded
     try:
         ndjson_path = spec.state_dir / "t0_receipts.ndjson"
         if _receipt_exists_for_dispatch(ndjson_path, spec.dispatch_id):
@@ -237,7 +327,7 @@ def _govern(
                 # ADR-005: emit cost event BEFORE receipt write. provider_dispatch
                 # and recovery raise on failure (fail-loud); the envelope is the
                 # third receipt path and matches them, but wraps in try/except so a
-                # cost-log failure never breaks the fail-closed receipt contract.
+                # cost-log failure never breaks the receipt write.
                 try:
                     from provider_costs import emit_provider_cost  # noqa: PLC0415
                     from project_scope import resolve_stamp_project_id, TenantUnresolved  # noqa: PLC0415
@@ -354,20 +444,34 @@ def _govern(
                     warnings=_contract_warnings or None,
                 )
             except Exception as exc:
-                raise EnvelopeGovernError(
-                    f"envelope._govern: receipt emit raised for dispatch={spec.dispatch_id}: {exc}"
-                ) from exc
+                # OI-1179: a receipt-emit failure is a PROOF problem, not a WORK
+                # problem. Raising EnvelopeGovernError here would bubble to
+                # _dispatch_*_via_envelope and turn a successful dispatch into
+                # exit code 1 (booked as `failed`) even though the work itself
+                # succeeded. Record the proof-chain gap loudly (log + trail)
+                # and return a None receipt so the caller's status/returncode
+                # still reflect the WORK.
+                _record_receipt_emit_failure(
+                    spec, str(exc), work_status=adapter_result.status,
+                )
+                receipt_path = None
+                _emit_failed = True
 
-            if receipt_path is None:
-                raise EnvelopeGovernError(
-                    f"envelope._govern: receipt_path is None after emit "
-                    f"(fail-closed) dispatch={spec.dispatch_id}"
-                )
-            if not receipt_path.exists():
-                raise EnvelopeGovernError(
-                    f"envelope._govern: receipt file absent on disk after emit "
-                    f"path={receipt_path} dispatch={spec.dispatch_id} (fail-closed)"
-                )
+            if not _emit_failed:
+                if receipt_path is None:
+                    # emit returned nothing without raising — same proof-chain gap.
+                    _record_receipt_emit_failure(
+                        spec,
+                        "receipt_path is None after emit",
+                        work_status=adapter_result.status,
+                    )
+                elif not receipt_path.exists():
+                    _record_receipt_emit_failure(
+                        spec,
+                        f"receipt file absent on disk after emit path={receipt_path}",
+                        work_status=adapter_result.status,
+                    )
+                    receipt_path = None
     finally:
         # OI-878/OI-902: truncate the live event stream now that the archive
         # (top of _govern) and the receipt write are complete. Best-effort.

--- a/scripts/lib/event_store.py
+++ b/scripts/lib/event_store.py
@@ -14,7 +14,6 @@ from __future__ import annotations
 import fcntl
 import json
 import logging
-import os
 import shutil
 from datetime import datetime, timezone
 from pathlib import Path
@@ -37,42 +36,28 @@ _OVERSIZE_FLAG_SUFFIX = ".oversize"
 
 
 def _events_dir() -> Path:
-    """Resolve the events directory: CENTRAL ($HOME/.vnx-data/<project_id>/events) by default.
+    """Resolve the events directory, failing loud on a read-only version store.
 
-    VNX_DATA_DIR override is honored ONLY when VNX_DATA_DIR_EXPLICIT=1 is also set,
-    mirroring the guard in provider_dispatch._resolve_data_dir() (OI-126, sweep H2).
-    Without the explicit flag, an inherited VNX_DATA_DIR in the shell environment
-    would cause a tmp-worktree dispatch to write its event stream to the wrong project
-    directory while the receipt lands in the central ledger — the split that caused
-    live event-stream loss on 2026-06-10 when a provider dispatch ran from a
-    tmp-worktree and the worktree was cleaned up before the stream could be read.
+    OI-1179: the previous two-flag guard honored ``VNX_DATA_DIR`` ONLY when
+    ``VNX_DATA_DIR_EXPLICIT=1`` was also set, so an operator who set a
+    legitimate ``VNX_DATA_DIR`` (worktree/CI override) was silently ignored and
+    the fallback landed on the read-only pinned version store
+    ``~/.vnx-system/versions/<v>/.vnx-data`` — where the append then failed
+    with a permission error.
 
-    Resolution order:
-    1. VNX_DATA_DIR_EXPLICIT=1 + VNX_DATA_DIR set → VNX_DATA_DIR/events
-    2. VNX_PROJECT_ID set → $HOME/.vnx-data/<project_id>/events  (central ledger)
-    3. Fallback → .vnx-data/events relative to repo root  (backwards-compat for
-       single-project environments that never set VNX_PROJECT_ID)
+    Resolution order is now env-first and shared with
+    ``headless_dispatch_daemon._default_data_dir`` via
+    ``data_dir_resolution.resolve_data_dir_fail_loud``:
+    1. VNX_DATA_DIR set           → VNX_DATA_DIR/events
+    2. VNX_PROJECT_ID set         → $HOME/.vnx-data/<project_id>/events  (central ledger)
+    3. Fallback → canonical resolver (vnx_paths.resolve_paths()["VNX_DATA_DIR"])
+
+    Every step is refused with a ``DataDirResolutionError`` naming the chain if
+    it would land under ``~/.vnx-system/versions/`` — a read-only version store
+    is never a valid data dir.
     """
-    explicit_flag = os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1"
-    vnx_data = os.environ.get("VNX_DATA_DIR", "")
-    if vnx_data and not explicit_flag:
-        logger.warning(
-            "event_store._events_dir: VNX_DATA_DIR=%r ignored (VNX_DATA_DIR_EXPLICIT not set); "
-            "falling back to central events dir to prevent cross-project stream loss (OI-126 H2)",
-            vnx_data,
-        )
-    if explicit_flag and vnx_data:
-        return Path(vnx_data).expanduser().resolve() / "events"
-    project_id = os.environ.get("VNX_PROJECT_ID", "")
-    if project_id:
-        return Path.home() / ".vnx-data" / project_id / "events"
-    # Backwards-compat: no explicit VNX_DATA_DIR and no VNX_PROJECT_ID. Route
-    # through the canonical resolver (VNX_HOME + project-marker aware), which
-    # resolves ~/.vnx-data/<project>. A __file__ walk (script_dir.parent.parent)
-    # would resolve the keystone (~/.vnx-system/current/.vnx-data) in a central
-    # install, losing the event stream. See #1023.
-    from vnx_paths import resolve_paths
-    return Path(resolve_paths()["VNX_DATA_DIR"]) / "events"
+    from data_dir_resolution import resolve_data_dir_fail_loud
+    return resolve_data_dir_fail_loud() / "events"
 
 
 class EventStore:

--- a/scripts/lib/headless_dispatch_daemon.py
+++ b/scripts/lib/headless_dispatch_daemon.py
@@ -39,28 +39,20 @@ def _repo_root() -> Path:
     return Path(__file__).resolve().parents[2]
 
 
-def _canonical_data_dir() -> Optional[Path]:
-    """Resolve VNX_DATA_DIR via the canonical vnx_paths resolver (central-mode aware)."""
-    try:
-        lib_dir = str(Path(__file__).resolve().parent)
-        if lib_dir not in sys.path:
-            sys.path.insert(0, lib_dir)
-        from vnx_paths import resolve_paths
-        return Path(resolve_paths()["VNX_DATA_DIR"])
-    except Exception:
-        return None
-
-
 def _default_data_dir() -> Path:
-    env = os.environ.get("VNX_DATA_DIR", "")
-    if env:
-        return Path(env)
-    # A raw _repo_root() walk resolves the KEYSTONE (not the project's
-    # ~/.vnx-data/<project>) in a central install. See #1023.
-    canonical = _canonical_data_dir()
-    if canonical is not None:
-        return canonical
-    return _repo_root() / ".vnx-data"
+    """Resolve the VNX data dir, failing loud on a read-only version store.
+
+    OI-1172/OI-1179: the previous fallback walked ``_repo_root() / ".vnx-data"``
+    when the canonical resolver returned None, which resolves the keystone
+    (``~/.vnx-system/versions/<v>/.vnx-data``) in a central install — a
+    read-only pinned version store the daemon then tried to write to. The
+    shared resolver honors a set ``VNX_DATA_DIR`` directly, falls back through
+    ``VNX_PROJECT_ID`` and the canonical resolver, and raises
+    ``DataDirResolutionError`` naming the chain instead of returning a path
+    under ``~/.vnx-system/versions/``.
+    """
+    from data_dir_resolution import resolve_data_dir_fail_loud
+    return resolve_data_dir_fail_loud()
 
 
 def _default_state_dir() -> Path:

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -16,13 +16,6 @@
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 33,
-      "mechanism": "direct-call",
-      "module_target": "dispatch_envelope",
-      "symbol": "EnvelopeGovernError"
-    },
-    {
-      "file": "tests/test_dispatch_envelope.py",
       "line": 34,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
@@ -58,77 +51,77 @@
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 360,
+      "line": 390,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "CodexAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 365,
+      "line": 395,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 557,
+      "line": 611,
       "mechanism": "logger-name",
       "module_target": "envelope_govern_support",
       "symbol": ""
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 591,
+      "line": 645,
       "mechanism": "logger-name",
       "module_target": "envelope_govern_support",
       "symbol": ""
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 593,
+      "line": 647,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_receipt_exists_for_dispatch"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 784,
+      "line": 838,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "ClaudeSubprocessAdapter"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 866,
+      "line": 920,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 891,
+      "line": 945,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 926,
+      "line": 980,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 947,
+      "line": 1001,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_AdapterResult"
     },
     {
       "file": "tests/test_dispatch_envelope.py",
-      "line": 962,
+      "line": 1016,
       "mechanism": "direct-call",
       "module_target": "dispatch_envelope",
       "symbol": "_govern"
@@ -604,7 +597,7 @@
     },
     {
       "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
-      "line": 239,
+      "line": 246,
       "mechanism": "patch.object-attr",
       "module_target": "dispatch_envelope",
       "symbol": "ProviderAdapter.run"
@@ -1192,6 +1185,7 @@
     "envelope_adapters_provider::_fail_loud_on_empty_success",
     "envelope_adapters_provider::_map_generic_spawn_result",
     "envelope_govern::_govern",
+    "envelope_govern::_record_receipt_emit_failure",
     "envelope_govern_support::_archive_dispatch_events",
     "envelope_govern_support::_clear_dispatch_events",
     "envelope_govern_support::_receipt_exists_for_dispatch",

--- a/tests/test_data_dir_resolution.py
+++ b/tests/test_data_dir_resolution.py
@@ -1,0 +1,166 @@
+"""Tests for data_dir_resolution.py — the shared fail-loud data-dir resolver.
+
+Covers OI-1179 (event_store two-flag trap) and OI-1172 (headless daemon
+keystone fallback) — two defects of one class: a resolver landing on the
+read-only pinned version store ``~/.vnx-system/versions/<v>/.vnx-data``.
+
+The shared resolver:
+  1. honors a set ``VNX_DATA_DIR`` directly (no ``VNX_DATA_DIR_EXPLICIT`` required);
+  2. refuses — with a ``DataDirResolutionError`` naming the chain — any result
+     under ``~/.vnx-system/versions/`` (or resolving through
+     ``~/.vnx-system/current`` into it);
+  3. refuses a non-version-store sibling dir (prefix boundary via os.sep).
+
+Tests redirect ``Path.home()`` to a temp dir so the version-store refusal is
+exercised against a synthetic ``~/.vnx-system`` tree, never the real one.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_LIB = Path(__file__).resolve().parents[1] / "scripts" / "lib"
+sys.path.insert(0, str(SCRIPTS_LIB))
+
+from data_dir_resolution import (
+    DataDirResolutionError,
+    _is_under_version_store,
+    refuse_version_store,
+    resolve_data_dir_fail_loud,
+)
+
+
+def _fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Redirect ``Path.home()`` to a temp directory for the test."""
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setattr(Path, "home", classmethod(lambda cls: home))
+    return home
+
+
+def _clean_data_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Remove env vars that would short-circuit the resolver before the branch under test."""
+    for key in (
+        "VNX_DATA_DIR",
+        "VNX_DATA_DIR_EXPLICIT",
+        "VNX_PROJECT_ID",
+    ):
+        monkeypatch.delenv(key, raising=False)
+
+
+# ── env-first: a set VNX_DATA_DIR is honored directly ────────────────────────
+
+
+def test_vnx_data_dir_honored_without_explicit_flag(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """A set VNX_DATA_DIR is honored WITHOUT VNX_DATA_DIR_EXPLICIT=1 (OI-1179)."""
+    data_dir = tmp_path / "operator" / ".vnx-data"
+    data_dir.mkdir(parents=True)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    result = resolve_data_dir_fail_loud()
+
+    assert result == data_dir.resolve()
+
+
+# ── fail-loud: a read-only version store is never a valid data dir ───────────
+
+
+def test_vnx_data_dir_under_version_store_refuses(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """VNX_DATA_DIR landing under ~/.vnx-system/versions/ raises, naming the chain."""
+    home = _fake_home(tmp_path, monkeypatch)
+    version_data = home / ".vnx-system" / "versions" / "v1.4.7" / ".vnx-data"
+    monkeypatch.setenv("VNX_DATA_DIR", str(version_data))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    with pytest.raises(DataDirResolutionError) as excinfo:
+        resolve_data_dir_fail_loud()
+
+    assert "version store" in str(excinfo.value)
+    assert "VNX_DATA_DIR" in str(excinfo.value)
+
+
+def test_vnx_project_id_branch_never_lands_under_version_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """VNX_PROJECT_ID resolves ~/.vnx-data/<id>, never the version store."""
+    home = _fake_home(tmp_path, monkeypatch)
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+    monkeypatch.setenv("VNX_PROJECT_ID", "my-project")
+
+    result = resolve_data_dir_fail_loud()
+
+    assert result == home / ".vnx-data" / "my-project"
+
+
+def test_fallback_under_version_store_refuses(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The canonical-resolver fallback is refused too when it lands under versions/."""
+    home = _fake_home(tmp_path, monkeypatch)
+    _clean_data_env(monkeypatch)
+
+    import vnx_paths
+
+    fake = home / ".vnx-system" / "versions" / "v1.4.7" / ".vnx-data"
+    monkeypatch.setattr(vnx_paths, "resolve_paths", lambda: {"VNX_DATA_DIR": str(fake)})
+
+    with pytest.raises(DataDirResolutionError) as excinfo:
+        resolve_data_dir_fail_loud()
+
+    assert "resolve_paths" in str(excinfo.value)
+
+
+# ── prefix boundary: a sibling dir is not a version store ────────────────────
+
+
+def test_sibling_dir_is_not_refused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """~/.vnx-system/versions-other is a sibling, not under versions/ — not refused."""
+    home = _fake_home(tmp_path, monkeypatch)
+    sibling = home / ".vnx-system" / "versions-other" / "data"
+
+    assert not _is_under_version_store(sibling.resolve())
+    assert refuse_version_store(sibling, "test chain") == sibling.resolve()
+
+
+def test_version_store_root_itself_is_refused(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """The versions/ root itself (no trailing component) is refused."""
+    home = _fake_home(tmp_path, monkeypatch)
+    root = home / ".vnx-system" / "versions"
+
+    assert _is_under_version_store(root.resolve())
+
+
+# ── OI-1172: the headless daemon shares the fail-loud resolver ────────────────
+
+
+def test_headless_default_data_dir_refuses_version_store(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """headless_dispatch_daemon._default_data_dir raises on the version store (OI-1172)."""
+    home = _fake_home(tmp_path, monkeypatch)
+    version_data = home / ".vnx-system" / "versions" / "v1.4.7" / ".vnx-data"
+    monkeypatch.setenv("VNX_DATA_DIR", str(version_data))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    from headless_dispatch_daemon import _default_data_dir
+
+    with pytest.raises(DataDirResolutionError):
+        _default_data_dir()
+
+
+def test_headless_default_data_dir_honors_vnx_data_dir(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """headless_dispatch_daemon._default_data_dir honors a set VNX_DATA_DIR."""
+    data_dir = tmp_path / "daemon" / ".vnx-data"
+    data_dir.mkdir(parents=True)
+    monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
+    monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
+
+    from headless_dispatch_daemon import _default_data_dir
+
+    assert _default_data_dir() == data_dir.resolve()

--- a/tests/test_dispatch_envelope.py
+++ b/tests/test_dispatch_envelope.py
@@ -5,8 +5,8 @@ Verifies:
 2. Failure path: spawn error -> BOTH report AND receipt emitted, status "failure".
 3. Timeout path: spawn timed_out -> BOTH report AND receipt emitted, status "timeout".
 4. Stopped_early path (claude-only): spawn stopped_early -> BOTH report AND receipt, status "success".
-5. Fail-closed: receipt emit raises -> EnvelopeGovernError (non-zero, no silent loss).
-6. Fail-closed: receipt_path returns None -> EnvelopeGovernError.
+5. Receipt-emit failure -> proof-chain gap recorded, work status preserved (OI-1179).
+6. receipt_path returns None -> proof-chain gap recorded, work status preserved (OI-1179).
 7. Idempotent dedup: pre-existing receipt line -> GOVERN skips write, no double-emit.
 8. Flag-off: VNX_UNIFIED_ENVELOPE unset -> legacy dispatch called, envelope NOT invoked.
 9. Flag-on: VNX_UNIFIED_ENVELOPE=1 + lanes contains lane -> envelope invoked.
@@ -15,6 +15,7 @@ Verifies:
 
 from __future__ import annotations
 
+import json
 import os
 import sys
 from dataclasses import dataclass, field
@@ -30,7 +31,6 @@ sys.path.insert(0, str(SCRIPTS_LIB))
 import dispatch_envelope
 import provider_dispatch
 from dispatch_envelope import (
-    EnvelopeGovernError,
     EnvelopeSpec,
     LaneRouter,
     run_envelope,
@@ -257,32 +257,62 @@ class TestEnvelopeEventArchiveClear:
         mock_clear.assert_called_once_with(spec.terminal_id, spec.dispatch_id)
 
 
-class TestEnvelopeFailClosed:
-    """GOVERN must raise EnvelopeGovernError when receipt is missing — never silent."""
+class TestEnvelopeReceiptEmitFailure:
+    """OI-1179: a failed receipt emit is a proof-chain gap, not a work failure.
 
-    def test_receipt_emit_raises_fail_closed(self, spec):
+    The dispatch's WORK status is preserved (success -> returncode 0, receipt_path
+    None) and the gap is recorded loudly to receipt_emit_failures.ndjson with the
+    VNX_RECEIPT_EMIT_FAILURE marker so governance can claim it instead of writing
+    it off as failed.
+    """
+
+    def _run(self, spec, codex_result, *, receipt_side_effect=None, receipt_return=_UNSET):
         _, _, mock_report, mock_receipt = _stub_governance(
-            spec, receipt_side_effect=RuntimeError("disk full")
+            spec, receipt_side_effect=receipt_side_effect, receipt_return=receipt_return,
         )
-        codex_result = _FakeCodexResult(returncode=0)
-
         with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
              patch("governance_emit.emit_unified_report", mock_report), \
              patch("governance_emit.emit_dispatch_receipt", mock_receipt):
-            with pytest.raises(EnvelopeGovernError, match="receipt emit raised"):
-                run_envelope(spec, lane="codex")
+            return run_envelope(spec, lane="codex")
 
-    def test_none_receipt_path_fail_closed(self, spec):
-        _, _, mock_report, mock_receipt = _stub_governance(
-            spec, receipt_return=None
-        )
+    def _trail(self, spec):
+        trail = spec.state_dir / "receipt_emit_failures.ndjson"
+        assert trail.exists(), "proof-chain-gap trail must be written"
+        return [
+            json.loads(line)
+            for line in trail.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def test_receipt_emit_raises_preserves_work_status(self, spec):
         codex_result = _FakeCodexResult(returncode=0)
+        result = self._run(spec, codex_result, receipt_side_effect=RuntimeError("disk full"))
 
-        with patch("provider_spawns.codex_spawn.spawn_codex", return_value=codex_result), \
-             patch("governance_emit.emit_unified_report", mock_report), \
-             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
-            with pytest.raises(EnvelopeGovernError, match="receipt_path is None"):
-                run_envelope(spec, lane="codex")
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path is None
+
+        records = self._trail(spec)
+        assert len(records) == 1  # single record — no double-record
+        assert records[0]["marker"] == "VNX_RECEIPT_EMIT_FAILURE"
+        assert records[0]["work_status"] == "success"
+        assert records[0]["dispatch_id"] == spec.dispatch_id
+        assert "disk full" in records[0]["reason"]
+
+    def test_none_receipt_path_preserves_work_status(self, spec):
+        codex_result = _FakeCodexResult(returncode=0)
+        result = self._run(spec, codex_result, receipt_return=None)
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path is None
+
+        records = self._trail(spec)
+        assert len(records) == 1
+        assert records[0]["marker"] == "VNX_RECEIPT_EMIT_FAILURE"
+        assert records[0]["work_status"] == "success"
+        assert records[0]["dispatch_id"] == spec.dispatch_id
+        assert "receipt_path is None" in records[0]["reason"]
 
 
 # ---------------------------------------------------------------------------
@@ -441,32 +471,56 @@ class TestClaudeEnvelopeEmitsBothReportAndReceipt:
 # ---------------------------------------------------------------------------
 
 
-class TestClaudeEnvelopeFailClosed:
-    """GOVERN must raise EnvelopeGovernError when receipt is missing — never silent (claude lane)."""
+class TestClaudeEnvelopeReceiptEmitFailure:
+    """OI-1179: a failed receipt emit is a proof-chain gap, not a work failure (claude lane)."""
 
-    def test_receipt_emit_raises_fail_closed(self, spec_claude):
+    def _run(self, spec_claude, claude_result, *, receipt_side_effect=None, receipt_return=_UNSET):
         _, _, mock_report, mock_receipt = _stub_governance(
-            spec_claude, receipt_side_effect=RuntimeError("disk full")
+            spec_claude, receipt_side_effect=receipt_side_effect, receipt_return=receipt_return,
         )
-        claude_result = _FakeClaudeResult(returncode=0)
-
         with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
              patch("governance_emit.emit_unified_report", mock_report), \
              patch("governance_emit.emit_dispatch_receipt", mock_receipt):
-            with pytest.raises(EnvelopeGovernError, match="receipt emit raised"):
-                run_envelope(spec_claude, lane="claude-subprocess")
+            return run_envelope(spec_claude, lane="claude-subprocess")
 
-    def test_none_receipt_path_fail_closed(self, spec_claude):
-        _, _, mock_report, mock_receipt = _stub_governance(
-            spec_claude, receipt_return=None
-        )
+    def _trail(self, spec_claude):
+        trail = spec_claude.state_dir / "receipt_emit_failures.ndjson"
+        assert trail.exists(), "proof-chain-gap trail must be written"
+        return [
+            json.loads(line)
+            for line in trail.read_text(encoding="utf-8").splitlines()
+            if line.strip()
+        ]
+
+    def test_receipt_emit_raises_preserves_work_status(self, spec_claude):
         claude_result = _FakeClaudeResult(returncode=0)
+        result = self._run(spec_claude, claude_result, receipt_side_effect=RuntimeError("disk full"))
 
-        with patch("provider_spawns.claude_spawn.spawn_claude", return_value=claude_result), \
-             patch("governance_emit.emit_unified_report", mock_report), \
-             patch("governance_emit.emit_dispatch_receipt", mock_receipt):
-            with pytest.raises(EnvelopeGovernError, match="receipt_path is None"):
-                run_envelope(spec_claude, lane="claude-subprocess")
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path is None
+
+        records = self._trail(spec_claude)
+        assert len(records) == 1
+        assert records[0]["marker"] == "VNX_RECEIPT_EMIT_FAILURE"
+        assert records[0]["work_status"] == "success"
+        assert records[0]["dispatch_id"] == spec_claude.dispatch_id
+        assert "disk full" in records[0]["reason"]
+
+    def test_none_receipt_path_preserves_work_status(self, spec_claude):
+        claude_result = _FakeClaudeResult(returncode=0)
+        result = self._run(spec_claude, claude_result, receipt_return=None)
+
+        assert result.status == "success"
+        assert result.returncode == 0
+        assert result.receipt_path is None
+
+        records = self._trail(spec_claude)
+        assert len(records) == 1
+        assert records[0]["marker"] == "VNX_RECEIPT_EMIT_FAILURE"
+        assert records[0]["work_status"] == "success"
+        assert records[0]["dispatch_id"] == spec_claude.dispatch_id
+        assert "receipt_path is None" in records[0]["reason"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_envelope_ringbuffer_teardown_oi902.py
+++ b/tests/test_envelope_ringbuffer_teardown_oi902.py
@@ -22,8 +22,8 @@ forever.
 Fix: ``dispatch_envelope._govern`` now archives the live stream under the
 dispatch's own id BEFORE writing the receipt (so the receipt carries
 ``events_path``) and clears the live file AFTER the receipt, in a finally so the
-clear survives a fail-closed EnvelopeGovernError.  The boundary guard of #1276
-stays as the second line of defense.
+clear survives a receipt-emit failure (a proof-chain gap, OI-1179).  The
+boundary guard of #1276 stays as the second line of defense.
 
 Every test here is RED on origin/main (no end-teardown in the envelope path)
 and GREEN with the fix.
@@ -154,8 +154,13 @@ class TestGovernEndTeardown:
         assert not live.exists() or live.stat().st_size == 0
 
     def test_govern_clears_even_when_receipt_raise(self, dirs):
-        """The clear runs in finally: a fail-closed receipt failure must not leave
-        the live file holding the dispatch's events."""
+        """The clear runs in finally: a receipt-emit failure must not leave
+        the live file holding the dispatch's events.
+
+        OI-1179: the failed receipt emit is a proof-chain gap, not a raise —
+        ``_govern`` records it and returns ``receipt_path=None`` so the WORK
+        status is preserved. The end-teardown still runs.
+        """
         state_dir, data_dir, events_dir = dirs
         dispatch_id = "oi902-govern-receipt-raise"
 
@@ -167,16 +172,18 @@ class TestGovernEndTeardown:
                 "governance_emit.emit_dispatch_receipt",
                 side_effect=RuntimeError("receipt disk failure"),
             ), patch("governance_emit.emit_unified_report", return_value=Path("/tmp/fake-report.md")):
-                with pytest.raises(Exception):
-                    _govern(
-                        spec, _AdapterResult(returncode=0, completion_text="done", status="success"), start, end,
-                    )
+                _report, receipt_path = _govern(
+                    spec, _AdapterResult(returncode=0, completion_text="done", status="success"), start, end,
+                )
+
+        # OI-1179: no raise — the gap is recorded, the receipt path is None.
+        assert receipt_path is None
 
         live = events_dir / "T2.ndjson"
         archive = events_dir / "archive" / "T2" / f"{dispatch_id}.ndjson"
         # Archive happened before the receipt emit (top of _govern).
         assert archive.exists() and archive.stat().st_size > 0
-        # Clear still ran in finally despite the raised receipt write.
+        # Clear still ran in finally despite the failed receipt write.
         assert not live.exists() or live.stat().st_size == 0
 
     def test_govern_does_not_mislabel_previous_dispatch(self, dirs):

--- a/tests/test_observability_linkage.py
+++ b/tests/test_observability_linkage.py
@@ -3,7 +3,7 @@
 Covers:
 1. state-dir guard: inherited VNX_STATE_DIR without EXPLICIT flag is ignored + warning logged.
 2. state-dir guard: VNX_STATE_DIR + EXPLICIT=1 is honored.
-3. events-dir guard: inherited VNX_DATA_DIR without EXPLICIT flag is ignored + warning logged.
+3. events-dir guard: VNX_DATA_DIR without EXPLICIT flag is HONORED (OI-1179).
 4. events-dir guard: VNX_DATA_DIR + EXPLICIT=1 resolves under that dir.
 5. events-dir guard: VNX_PROJECT_ID (no EXPLICIT) resolves central path.
 6. events_path in receipt: present after a successful provider-dispatch flow with EventStore.
@@ -112,21 +112,22 @@ class TestStateDirGuard:
 # ---------------------------------------------------------------------------
 
 class TestEventsDirGuard:
-    def test_no_explicit_flag_ignores_inherited_vnx_data_dir(self, monkeypatch, tmp_path, caplog):
-        """VNX_DATA_DIR without EXPLICIT=1 is ignored; falls back to central dir."""
-        wrong = str(tmp_path / "wrong_events")
-        monkeypatch.setenv("VNX_DATA_DIR", wrong)
+    def test_vnx_data_dir_honored_without_explicit_flag(self, monkeypatch, tmp_path):
+        """OI-1179: VNX_DATA_DIR set is honored WITHOUT VNX_DATA_DIR_EXPLICIT=1.
+
+        The old two-flag trap ignored a set VNX_DATA_DIR unless
+        VNX_DATA_DIR_EXPLICIT=1 was ALSO set, silently falling back to the
+        canonical resolver and (in a central install) landing on the read-only
+        pinned version store. A set VNX_DATA_DIR must be respected directly.
+        """
+        data_dir = str(tmp_path / "operator_data")
+        monkeypatch.setenv("VNX_DATA_DIR", data_dir)
         monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
-        monkeypatch.setenv("VNX_PROJECT_ID", "my-proj")
+        monkeypatch.delenv("VNX_PROJECT_ID", raising=False)
 
-        with caplog.at_level(logging.WARNING, logger="event_store"):
-            result = _events_dir()
+        result = _events_dir()
 
-        assert str(result) != wrong + "/events"
-        assert "VNX_DATA_DIR" in caplog.text
-        assert "VNX_DATA_DIR_EXPLICIT" in caplog.text
-        # Central path via VNX_PROJECT_ID
-        assert result == Path.home() / ".vnx-data" / "my-proj" / "events"
+        assert result == Path(data_dir).expanduser().resolve() / "events"
 
     def test_with_explicit_flag_honors_vnx_data_dir(self, monkeypatch, tmp_path):
         """VNX_DATA_DIR + VNX_DATA_DIR_EXPLICIT=1 resolves to that dir/events."""


### PR DESCRIPTION
## Summary

Fixes the blocker where a receipt-write failure booked successful work as `failed`.

Two defects, one root cause:

1. **Two-flag trap** — `event_store._events_dir` honored `VNX_DATA_DIR` only when `VNX_DATA_DIR_EXPLICIT=1` was *also* set. A legitimate override was silently ignored and the fallback landed on the read-only pinned version store `~/.vnx-system/versions/<v>/.vnx-data`, where the append failed with `PermissionError`.
2. **Governance gap** — `envelope_govern._govern` raised `EnvelopeGovernError` on a failed receipt emit, flipping a successful dispatch to exit code 1 (`failed`).

## Changes

- **`scripts/lib/data_dir_resolution.py`** (new): shared fail-loud resolver. Honors a set `VNX_DATA_DIR` directly, then `VNX_PROJECT_ID`, then the canonical resolver; raises `DataDirResolutionError` naming the chain if the result lands under `~/.vnx-system/versions/`.
- **`scripts/lib/event_store.py`** + **`scripts/lib/headless_dispatch_daemon.py`**: both now delegate to the shared resolver (OI-1172 is the same class of error on the daemon path).
- **`scripts/lib/envelope_govern.py`**: a failed receipt emit records a proof-chain gap (loud `logger.error` + append-only `receipt_emit_failures.ndjson` trail carrying `VNX_RECEIPT_EMIT_FAILURE`) and returns `receipt_path=None`; the caller's status/returncode reflect whether the *work* succeeded, never whether the proof landed.
- **`scripts/lib/dispatch_envelope.py`**: docstrings updated to the decoupled contract.

## Verification

- New `tests/test_data_dir_resolution.py` (8 tests): env-first honoring, version-store refusal (VNX_DATA_DIR / fallback branches), prefix boundary, and headless daemon fail-loud.
- Updated `tests/test_dispatch_envelope.py` + `tests/test_envelope_ringbuffer_teardown_oi902.py` from "fail-closed raises" to "proof-chain gap recorded, work status preserved".
- Targeted run: **235 passed, 6 failed** — all 6 failures are pre-existing and unrelated (4 env-specific/MagicMock in `test_observability_linkage.py`, 2 `kimi-via-cli-only` provider-constraint in `test_headless_dispatch_daemon_wave5.py`, verified identical on the base commit).

## Open Items

- `EnvelopeGovernError` remains exported from `dispatch_envelope.py` (re-imported by `provider_dispatch.py`); its `except` handlers there are now unreachable for the receipt-emit path but are harmless defensive catches.
- The 4 pre-existing `test_observability_linkage.py` failures (`parts[-2]==".vnx-data"` vs `vnx-dev`; `mandate_id` MagicMock serialization) are untouched by this PR.

Dispatch-ID: 20260814f-a-receipt-emit-not-failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)