### PR TITLE
fix(gate): book infra failures as unavailable, never roll up non-run gates as PASS

### DIFF
--- a/scripts/commands/gate.sh
+++ b/scripts/commands/gate.sh
@@ -104,6 +104,8 @@ _g_show_results() {
 
   python3 -c "
 import json, os, glob, sys
+sys.path.insert(0, '$VNX_HOME/scripts/lib')
+from gate_status import has_complete_evidence, is_pass
 
 gate_dir = '$gate_dir'
 pr = '$pr'
@@ -121,6 +123,7 @@ for f in glob.glob(os.path.join(gate_dir, '*.json')):
             'blocking': len(d.get('blocking_findings', [])),
             'summary': d.get('summary', '')[:60],
             'recorded_at': d.get('recorded_at', '?')[:19],
+            'detail': d,
         })
     except Exception:
         pass
@@ -134,8 +137,20 @@ fmt = '  {:<20} {:<8} {:<10} {:<8} {}'
 print(fmt.format('Gate', 'PR', 'Status', 'Blocking', 'Recorded'))
 print('  ' + '-'*68)
 for r in results:
+    d = r['detail']
     status = r['status']
-    marker = 'PASS' if status == 'completed' else 'FAIL' if status == 'failed' else status[:8]
+    # OI-1178: a gate that never ran must never read as PASS. Classify the
+    # canonical statuses explicitly and fall back to is_pass() + evidence so a
+    # hand-authored or drifting record cannot masquerade as a decided pass.
+    if status == 'unavailable':
+        marker = 'UNAVAIL'
+    elif status in ('not_executable', 'not_configured'):
+        marker = 'NOEXEC'
+    elif status in ('failed', 'fail', 'blocked'):
+        marker = 'FAIL'
+    else:
+        passed, _ = is_pass(d)
+        marker = 'PASS' if (passed and has_complete_evidence(d)) else status[:8]
     print(fmt.format(str(r['gate'])[:19], str(r['pr'])[:7], marker, str(r['blocking']), r['recorded_at']))
 "
 }
@@ -288,7 +303,7 @@ HELP
     if [ "$exit_code" -eq 0 ]; then
       log "[gate] Gate '$only_gate': PASS"
     else
-      err "[gate] Gate '$only_gate': FAIL (exit $exit_code)"
+      err "[gate] Gate '$only_gate': did not PASS (exit $exit_code)"
     fi
     return "$exit_code"
 
@@ -317,7 +332,7 @@ HELP
     if [ "$exit_code" -eq 0 ]; then
       log "[gate] All gates PASS for PR $pr_number"
     else
-      err "[gate] One or more gates FAILED for PR $pr_number (exit $exit_code)"
+      err "[gate] One or more gates did not PASS for PR $pr_number (exit $exit_code)"
     fi
     return "$exit_code"
   fi

--- a/scripts/lib/gate_executor.py
+++ b/scripts/lib/gate_executor.py
@@ -351,6 +351,8 @@ class GateExecutorMixin:
         gates: List[Dict[str, Any]] = []
         has_required_failure = False
 
+        from gate_status import has_complete_evidence, is_pass
+
         for req in request_result.get("requested", []):
             gate_name = req.get("gate", "")
             req_status = req.get("status", "")
@@ -360,14 +362,26 @@ class GateExecutorMixin:
                     gate=gate_name,
                     pr_number=pr_number,
                 )
+                passed, pass_reason = is_pass(exec_result)
+                # A gate is decided PASS only when it both passed semantically
+                # AND carried a complete evidence trail. An infra failure books
+                # ``unavailable`` (never ``failed``) and carries no contract_hash
+                # or report_path; either missing means "did not run", which must
+                # never sum up to a PASS (OI-1178).
+                decided_pass = bool(passed) and has_complete_evidence(exec_result)
                 gates.append({
                     "gate": gate_name,
                     "request_status": req_status,
                     "execution_status": exec_result.get("status", "unknown"),
+                    "passed": decided_pass,
+                    "pass_reason": pass_reason,
                     "report_path": exec_result.get("report_path", ""),
                     "contract_hash": exec_result.get("contract_hash", ""),
                     "detail": exec_result,
                 })
+                required = req.get("required", True)
+                if gate_name != "claude_github_optional" and required and not decided_pass:
+                    has_required_failure = True
             else:
                 gates.append({
                     "gate": gate_name,

--- a/scripts/lib/gate_recorder.py
+++ b/scripts/lib/gate_recorder.py
@@ -49,6 +49,8 @@ EXECUTION_FAILURE_REASONS: frozenset = frozenset({
     "empty_review_content", "validation_failed",
     # Network / auth
     "network_error", "auth_error",
+    # Vertex REST path (gemini_review) API failures (OI-1178)
+    "vertex_api_error",
 })
 
 
@@ -226,9 +228,23 @@ def record_failure(
     requests_dir: Path,
     results_dir: Path,
 ) -> Dict[str, Any]:
-    """Record a failed gate execution (timeout/stall/error)."""
+    """Record a failed gate execution (timeout/stall/error).
+
+    Execution-level failures — reasons in :data:`EXECUTION_FAILURE_REASONS`
+    — mean the gate never produced a verdict (crash, timeout, infra error).
+    Those are absence of evidence and book ``unavailable`` (OI-1178), never
+    ``failed``: a non-execution must not read as a rejected PR. A real
+    verdict failure (the gate ran and found a blockade) still books
+    ``failed``, but that path flows through
+    :func:`gate_artifacts.materialize_artifacts`, not here.
+    """
     now = utc_now_iso()
-    request_payload["status"] = "failed"
+    reason = result["reason"]
+    reason_detail = result["reason_detail"]
+    is_execution_failure = reason in EXECUTION_FAILURE_REASONS
+    status = "unavailable" if is_execution_failure else "failed"
+
+    request_payload["status"] = status
     request_payload["failed_at"] = now
     persist_request(requests_dir, gate, request_payload, pr_number=pr_number, pr_id=pr_id)
 
@@ -236,20 +252,24 @@ def record_failure(
         "gate": gate,
         "pr_id": pr_id or (str(pr_number) if pr_number else ""),
         "pr_number": pr_number,
-        "status": "failed",
-        "reason": result["reason"],
-        "reason_detail": result["reason_detail"],
+        "status": status,
+        "reason": reason,
+        "reason_detail": reason_detail,
         "duration_seconds": result["duration_seconds"],
         "partial_output_lines": result["partial_output_lines"],
         "runner_pid": result["runner_pid"],
         "killed_at": now,
-        "summary": f"Gate execution {result['reason']}: {result['reason_detail']}",
+        "summary": (
+            f"{gate} UNAVAILABLE (gate did not run — {reason}: {reason_detail}) — NOT a review fail"
+            if is_execution_failure
+            else f"Gate execution {reason}: {reason_detail}"
+        ),
         "contract_hash": request_payload.get("contract_hash", ""),
         "report_path": "",
         "blocking_findings": [],
         "advisory_findings": [],
         "required_reruns": [gate],
-        "residual_risk": f"Gate {result['reason']}. Re-run required.",
+        "residual_risk": f"Gate {reason}. Re-run required.",
         "recorded_at": now,
     }
 
@@ -259,7 +279,7 @@ def record_failure(
 
     # Emit gate_failed for codex_gate only when the gate itself reported a verdict
     # failure (not for infrastructure/execution errors like timeout or stall).
-    if gate == "codex_gate" and result["reason"] not in EXECUTION_FAILURE_REASONS:
+    if gate == "codex_gate" and reason not in EXECUTION_FAILURE_REASONS:
         try:
             from gate_register_emit import emit_codex_gate_to_register
             emit_codex_gate_to_register(

--- a/scripts/lib/gate_status.py
+++ b/scripts/lib/gate_status.py
@@ -114,6 +114,26 @@ def canonical_status(result: Dict[str, Any]) -> str:
     return status
 
 
+def has_complete_evidence(result: Dict[str, Any]) -> bool:
+    """True when a gate result carries a complete evidence trail (OI-1178).
+
+    A gate that actually ran and produced a verdict materializes BOTH a
+    non-empty ``contract_hash`` (the hashed contract it judged) and a
+    non-empty ``report_path`` (the on-disk report of its findings). An
+    infra failure booked by ``gate_recorder.record_failure`` carries
+    neither: ``report_path`` is always "" and ``contract_hash`` echoes
+    whatever the never-executed request carried, typically "". Requiring
+    BOTH non-empty separates "a gate ran and decided" from "the gate never
+    ran" — the latter must never be summed up as a PASS.
+    """
+    contract_hash = result.get("contract_hash")
+    report_path = result.get("report_path")
+    return (
+        isinstance(contract_hash, str) and bool(contract_hash.strip())
+        and isinstance(report_path, str) and bool(report_path.strip())
+    )
+
+
 def has_producer_identity(result: Dict[str, Any]) -> bool:
     """True when a gate result carries a producer identity (OI-1093).
 

--- a/scripts/review_gate_manager.py
+++ b/scripts/review_gate_manager.py
@@ -277,13 +277,20 @@ def _handle_request_and_execute(manager: ReviewGateManager, args: argparse.Names
     )
     print(json.dumps(result, indent=2))
     if result.get("has_required_failure"):
-        failed_gates = [
+        # OI-1178: surface every required gate that did not PASS, not just the
+        # not_executable/not_configured ones. An executed gate that booked
+        # ``unavailable`` (did not run) or ``failed`` (ran and found a blockade)
+        # is a non-pass and must be named here so the operator sees which gate.
+        non_pass_gates = [
             g["gate"] for g in result.get("gates", [])
-            if g.get("execution_status") in ("not_executable", "not_configured")
-            and g.get("gate") != "claude_github_optional"
+            if g.get("gate") != "claude_github_optional"
+            and (
+                g.get("passed") is False
+                or g.get("execution_status") in ("not_executable", "not_configured")
+            )
         ]
         print(
-            f"ERROR: required gates not executable: {', '.join(failed_gates)}",
+            f"ERROR: required gates did not PASS: {', '.join(non_pass_gates)}",
             file=sys.stderr,
         )
         return 1

--- a/tests/test_gate_artifacts_atomicity.py
+++ b/tests/test_gate_artifacts_atomicity.py
@@ -1,7 +1,9 @@
 """GATE-11 atomicity: orphan report cleanup on validation failure.
 
 Verifies that materialize_artifacts deletes the report file before recording
-a failed result when _validate_report_file or _validate_content fails.
+an unavailable result when _validate_report_file or _validate_content fails.
+A validation failure means the gate never produced a reviewable verdict, so
+it books ``unavailable`` (OI-1178) — absence of evidence, not a rejected PR.
 """
 from __future__ import annotations
 
@@ -68,18 +70,28 @@ def _run(env, stdout="Review line one.\nReview line two.\nReview line three.\n",
 class TestGate11Atomicity:
 
     def test_sparse_stdout_no_orphan_report(self, env):
-        """empty_review_content failure must delete report before recording failure."""
+        """empty_review_content books unavailable and deletes the orphan report.
+
+        Sparse output means the gate never produced a review verdict, so the
+        result is a non-execution (``unavailable``), not a rejected PR — yet the
+        orphan report must still be cleaned up (GATE-11 atomicity).
+        """
         sparse_stdout = "Only one line."
         result, report_file = _run(env, stdout=sparse_stdout)
 
-        assert result["status"] == "failed", f"Expected failed, got: {result}"
+        assert result["status"] == "unavailable", f"Expected unavailable, got: {result}"
         assert result["reason"] == "empty_review_content"
         assert not report_file.exists(), (
             "GATE-11 violation: orphan report file left on disk after validation failure"
         )
 
     def test_validate_report_file_failure_no_orphan(self, env):
-        """_validate_report_file returning an error must delete report before recording failure."""
+        """_validate_report_file error books unavailable and deletes the orphan report.
+
+        An empty/missing report file after write means the gate produced no
+        reviewable artifact, so this is a non-execution (``unavailable``), not a
+        rejected PR — yet the orphan report must still be cleaned up.
+        """
         result, report_file = _run(env)
 
         # Force _validate_report_file to fail by patching it to always error
@@ -113,7 +125,7 @@ class TestGate11Atomicity:
                 reports_dir=env["reports_dir"],
             )
 
-        assert result2["status"] == "failed"
+        assert result2["status"] == "unavailable"
         assert not report_file2.exists(), (
             "GATE-11 violation: orphan report left after _validate_report_file failure"
         )

--- a/tests/test_gate_execution_certification.py
+++ b/tests/test_gate_execution_certification.py
@@ -281,7 +281,7 @@ class TestTimeoutStallStructuredFailure:
              patch("gate_runner.time.monotonic", side_effect=fake_mono):
             result = runner.run(gate="gemini_review", request_payload=payload, pr_number=1)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] in ("timeout", "stall")
 
         # Structured failure fields for T0
@@ -297,13 +297,13 @@ class TestTimeoutStallStructuredFailure:
         result_file = cert_env["results_dir"] / "pr-1-gemini_review.json"
         assert result_file.exists()
         saved = json.loads(result_file.read_text(encoding="utf-8"))
-        assert saved["status"] == "failed"
+        assert saved["status"] == "unavailable"
 
-        # Request updated to failed
+        # Request updated to unavailable
         req_file = cert_env["requests_dir"] / "pr-1-gemini_review.json"
         assert req_file.exists()
         req = json.loads(req_file.read_text(encoding="utf-8"))
-        assert req["status"] == "failed"
+        assert req["status"] == "unavailable"
 
     def test_stall_failure_distinct_from_timeout(self, cert_env, monkeypatch):
         """Stall failure must be distinguishable from timeout in the result."""
@@ -341,7 +341,7 @@ class TestTimeoutStallStructuredFailure:
              patch("gate_runner.time.monotonic", side_effect=fake_mono):
             result = runner.run(gate="gemini_review", request_payload=payload, pr_number=2)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "stall"
         assert "stall threshold" in result["reason_detail"]
 
@@ -371,7 +371,7 @@ class TestTimeoutStallStructuredFailure:
              patch("gate_runner.select.select", return_value=([], [], [])):
             result = runner.run(gate="gemini_review", request_payload=payload, pr_number=3)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "exit_nonzero"
         assert "code 1" in result["reason_detail"]
 
@@ -550,14 +550,14 @@ class TestArtifactStability:
              patch("gate_runner.time.monotonic", side_effect=fake_mono):
             result = runner.run(gate="gemini_review", request_payload=payload, pr_number=31)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         # No report should exist for a timeout failure
         assert not Path(report_path).exists()
-        # Result file exists but status is failed
+        # Result file exists but status is unavailable
         result_file = cert_env["results_dir"] / "pr-31-gemini_review.json"
         assert result_file.exists()
         saved = json.loads(result_file.read_text(encoding="utf-8"))
-        assert saved["status"] == "failed"
+        assert saved["status"] == "unavailable"
         assert saved["report_path"] == ""
 
     def test_result_rollback_on_write_failure(self, cert_env, monkeypatch):
@@ -598,7 +598,7 @@ class TestArtifactStability:
              patch.object(Path, "write_text", selective_write):
             result = runner.run(gate="gemini_review", request_payload=payload, pr_number=32)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "artifact_materialization_failed"
         # Report should be cleaned up (rolled back) — GATE-11
         assert not Path(report_path).exists()

--- a/tests/test_gate_recorder_register.py
+++ b/tests/test_gate_recorder_register.py
@@ -89,7 +89,7 @@ class TestGateRecorderRegisterEmit:
             results_dir=recorder_env["results_dir"],
         )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         events = _read_register_events(recorder_env)
         assert events == [], f"Expected no register events for timeout; got: {events}"
 
@@ -135,7 +135,7 @@ class TestGateRecorderRegisterEmit:
             results_dir=recorder_env["results_dir"],
         )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         events = _read_register_events(recorder_env)
         assert events == []
 
@@ -169,7 +169,7 @@ class TestGateRecorderRegisterEmit:
             results_dir=recorder_env["results_dir"],
         )
 
-        assert out["status"] == "failed"
+        assert out["status"] == "unavailable"
         events = _read_register_events(recorder_env)
         assert events == [], (
             f"reason={reason!r} must not emit gate_failed; got: {events}"

--- a/tests/test_gate_runner.py
+++ b/tests/test_gate_runner.py
@@ -309,7 +309,7 @@ class TestTimeoutKill:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] in ("timeout", "stall")
         assert result["required_reruns"] == ["gemini_review"]
         assert mock_killpg.called or mock_proc.kill.called
@@ -364,7 +364,7 @@ class TestStallDetection:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "stall"
         assert "stall threshold" in result["reason_detail"]
         assert mock_killpg.called or mock_proc.kill.called
@@ -457,7 +457,7 @@ class TestArtifactAtomicity:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "artifact_materialization_failed"
 
     def test_no_report_path_produces_failure(self, gate_env, monkeypatch):
@@ -499,7 +499,7 @@ class TestArtifactAtomicity:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert "report_path" in result["reason_detail"].lower() or result["reason"] == "artifact_materialization_failed"
 
 
@@ -741,7 +741,7 @@ class TestCodexGateExecution:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] in ("timeout", "stall")
         assert mock_killpg.called or mock_proc.kill.called
 
@@ -946,7 +946,7 @@ class TestGateWorktreeCheckout:
              patch("gate_runner.os.killpg"):
             result = runner.run(gate="codex_gate", request_payload=payload, pr_number=1)
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] in ("timeout", "stall")
         mock_remove.assert_called_once_with(fake_worktree, project_root=None)
 
@@ -978,14 +978,14 @@ class TestGateWorktreeCheckout:
         mock_popen.assert_not_called()
         mock_remove.assert_not_called()
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "worktree_checkout_failed"
         assert "no route to host" in result["reason_detail"]
 
         result_file = gate_env["results_dir"] / "pr-1-codex_gate.json"
         assert result_file.exists()
         saved = json.loads(result_file.read_text(encoding="utf-8"))
-        assert saved["status"] == "failed"
+        assert saved["status"] == "unavailable"
         assert saved["reason"] == "worktree_checkout_failed"
 
     def test_project_root_threaded_from_gate_runner_constructor(

--- a/tests/test_gate_runner_vertex.py
+++ b/tests/test_gate_runner_vertex.py
@@ -434,7 +434,7 @@ class TestVertexRoutingInRun:
         mock_urlopen.assert_not_called()
         assert result["status"] == "completed"
 
-    def test_vertex_api_error_produces_failed_result(self, gate_env, monkeypatch):
+    def test_vertex_api_error_produces_unavailable_result(self, gate_env, monkeypatch):
         """When Vertex API raises, run() must book an unavailable record (OI-1178)."""
         monkeypatch.setenv("VNX_GEMINI_ROUTING", "vertex")
         monkeypatch.setenv("VNX_VERTEX_PROJECT", "error-test-proj")

--- a/tests/test_gate_runner_vertex.py
+++ b/tests/test_gate_runner_vertex.py
@@ -435,7 +435,7 @@ class TestVertexRoutingInRun:
         assert result["status"] == "completed"
 
     def test_vertex_api_error_produces_failed_result(self, gate_env, monkeypatch):
-        """When Vertex API raises, run() must return a failed result record."""
+        """When Vertex API raises, run() must book an unavailable record (OI-1178)."""
         monkeypatch.setenv("VNX_GEMINI_ROUTING", "vertex")
         monkeypatch.setenv("VNX_VERTEX_PROJECT", "error-test-proj")
 
@@ -458,7 +458,7 @@ class TestVertexRoutingInRun:
                 pr_number=1,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert result["reason"] == "vertex_api_error"
         assert "Connection refused" in result["reason_detail"]
 

--- a/tests/test_gate_status_schema.py
+++ b/tests/test_gate_status_schema.py
@@ -239,19 +239,23 @@ def _writer_output_gate_artifacts() -> Dict[str, Any]:
 
 
 def _writer_output_gate_recorder_failure() -> Dict[str, Any]:
-    """Shape produced by scripts/lib/gate_recorder.py:record_failure."""
+    """Shape produced by scripts/lib/gate_recorder.py:record_failure.
+
+    Execution-level reasons (timeout here) book ``unavailable``, never
+    ``failed`` (OI-1178).
+    """
     return {
         "gate": "codex_gate",
         "pr_id": "100",
         "pr_number": 100,
-        "status": "failed",
+        "status": "unavailable",
         "reason": "timeout",
         "reason_detail": "Gate exceeded 600s",
         "duration_seconds": 600.0,
         "partial_output_lines": 0,
         "runner_pid": 1234,
         "killed_at": "2026-04-29T00:00:00Z",
-        "summary": "Gate execution timeout: Gate exceeded 600s",
+        "summary": "codex_gate UNAVAILABLE (gate did not run — timeout: Gate exceeded 600s) — NOT a review fail",
         "contract_hash": "abc123",
         "report_path": "",
         "blocking_findings": [],

--- a/tests/test_gate_unavailable_rollup.py
+++ b/tests/test_gate_unavailable_rollup.py
@@ -1,0 +1,225 @@
+"""Regression tests for OI-1178: a non-executed gate must never read as PASS.
+
+The measured bug (12-08, PR #1481): a codex_gate result with
+``status="failed"``, ``summary="Gate execution exit_nonzero: Subprocess exited
+with code 1"``, empty ``contract_hash`` and empty ``report_path`` was a
+non-execution booked as a review verdict, and the CLI rollup printed
+"All gates PASS" over it while the per-gate line showed "codex_gate FAIL".
+
+These tests pin three invariants:
+
+- ``record_failure`` books execution-level reasons (``exit_nonzero``,
+  ``timeout``, …) as ``unavailable`` — absence of evidence — never ``failed``.
+- a real verdict failure (reason not in ``EXECUTION_FAILURE_REASONS``) still
+  books ``failed``.
+- ``_execute_requested_gates`` sets ``has_required_failure`` for any required
+  gate that did not pass with complete evidence, so the rollup can never sum
+  a non-run gate up as PASS.
+"""
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+VNX_ROOT = Path(__file__).resolve().parent.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+from gate_executor import GateExecutorMixin
+from gate_recorder import EXECUTION_FAILURE_REASONS, record_failure
+from gate_status import has_complete_evidence, is_pass
+
+
+# ---------------------------------------------------------------------------
+# has_complete_evidence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "result,expected",
+    [
+        ({"contract_hash": "abc", "report_path": "/tmp/r.md"}, True),
+        ({"contract_hash": "", "report_path": "/tmp/r.md"}, False),
+        ({"contract_hash": "abc", "report_path": ""}, False),
+        ({"contract_hash": "abc", "report_path": None}, False),
+        ({}, False),
+    ],
+)
+def test_has_complete_evidence_requires_hash_and_path(result, expected):
+    assert has_complete_evidence(result) is expected
+
+
+# ---------------------------------------------------------------------------
+# record_failure: execution-level reason -> unavailable, never failed
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def recorder_env(tmp_path, monkeypatch):
+    state_dir = tmp_path / "state"
+    requests_dir = state_dir / "review_gates" / "requests"
+    results_dir = state_dir / "review_gates" / "results"
+    for d in (requests_dir, results_dir):
+        d.mkdir(parents=True, exist_ok=True)
+    monkeypatch.setenv("VNX_STATE_DIR", str(state_dir))
+    return {"requests_dir": requests_dir, "results_dir": results_dir}
+
+
+def _failure_result(reason="exit_nonzero", reason_detail="Subprocess exited with code 1"):
+    return {
+        "reason": reason,
+        "reason_detail": reason_detail,
+        "duration_seconds": 1.0,
+        "partial_output_lines": 0,
+        "runner_pid": os.getpid(),
+    }
+
+
+@pytest.mark.parametrize("reason", sorted(EXECUTION_FAILURE_REASONS))
+def test_record_failure_execution_reason_books_unavailable(recorder_env, reason):
+    """Every execution-level reason books unavailable with an unmistakable summary."""
+    out = record_failure(
+        gate="codex_gate",
+        pr_number=42,
+        pr_id="",
+        result=_failure_result(reason=reason, reason_detail=f"boom: {reason}"),
+        request_payload={"gate": "codex_gate", "status": "requested"},
+        requests_dir=recorder_env["requests_dir"],
+        results_dir=recorder_env["results_dir"],
+    )
+    assert out["status"] == "unavailable", reason
+    assert "UNAVAILABLE" in out["summary"]
+    assert "NOT a review fail" in out["summary"]
+    assert out["report_path"] == ""
+    assert out["blocking_findings"] == []
+    # The non-execution is not a pass and carries no complete evidence.
+    assert is_pass(out)[0] is False
+    assert has_complete_evidence(out) is False
+
+
+def test_record_failure_non_execution_reason_still_books_failed(recorder_env):
+    """A real verdict failure (not an infra reason) must still book failed."""
+    out = record_failure(
+        gate="gemini_review",
+        pr_number=42,
+        pr_id="",
+        result=_failure_result(reason="review_verdict_blocked", reason_detail="blocked"),
+        request_payload={"gate": "gemini_review", "status": "requested"},
+        requests_dir=recorder_env["requests_dir"],
+        results_dir=recorder_env["results_dir"],
+    )
+    assert out["status"] == "failed"
+    assert "UNAVAILABLE" not in out["summary"]
+
+
+# ---------------------------------------------------------------------------
+# _execute_requested_gates: required non-pass must set has_required_failure
+# ---------------------------------------------------------------------------
+
+
+def _make_executor(exec_results):
+    mixin = GateExecutorMixin()
+
+    def fake_execute_gate(gate, pr_number, pr_id=""):
+        return exec_results[gate]
+
+    mixin.execute_gate = fake_execute_gate
+    return mixin
+
+
+def test_executed_unavailable_sets_required_failure():
+    """An executed gate that booked unavailable must block the rollup (OI-1178)."""
+    unavailable = {
+        "status": "unavailable",
+        "reason": "exit_nonzero",
+        "contract_hash": "",
+        "report_path": "",
+        "blocking_findings": [],
+    }
+    mixin = _make_executor({"codex_gate": unavailable})
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "codex_gate", "status": "requested", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is True
+    assert gates[0]["passed"] is False
+    assert "unavailable" in gates[0]["pass_reason"]
+
+
+def test_executed_real_fail_sets_required_failure():
+    """A gate that ran and found a blockade (failed) must block the rollup."""
+    failed = {
+        "status": "failed",
+        "reason": "verdict",
+        "contract_hash": "abc",
+        "report_path": "/tmp/report.md",
+        "blocking_findings": [{"severity": "error", "title": "x"}],
+    }
+    mixin = _make_executor({"codex_gate": failed})
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "codex_gate", "status": "requested", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is True
+    assert gates[0]["passed"] is False
+
+
+def test_executed_completed_pass_with_evidence_does_not_fail():
+    """A real completed pass with evidence must NOT set has_required_failure."""
+    passed = {
+        "status": "completed",
+        "contract_hash": "abc",
+        "report_path": "/tmp/report.md",
+        "blocking_findings": [],
+    }
+    mixin = _make_executor({"codex_gate": passed})
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "codex_gate", "status": "requested", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is False
+    assert gates[0]["passed"] is True
+
+
+def test_executed_pass_without_evidence_is_not_a_pass():
+    """A completed status with empty evidence must not sum up as PASS."""
+    hollow_pass = {
+        "status": "completed",
+        "contract_hash": "",
+        "report_path": "",
+        "blocking_findings": [],
+    }
+    mixin = _make_executor({"codex_gate": hollow_pass})
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "codex_gate", "status": "requested", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is True
+    assert gates[0]["passed"] is False
+
+
+def test_optional_claude_github_failure_does_not_fail():
+    """claude_github_optional stays optional: its non-pass never blocks."""
+    unavailable = {"status": "unavailable", "contract_hash": "", "report_path": ""}
+    mixin = _make_executor({"claude_github_optional": unavailable})
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "claude_github_optional", "status": "requested", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is False
+    assert gates[0]["passed"] is False
+
+
+def test_not_executable_branch_still_blocks():
+    """The pre-existing else-branch behavior for not_executable is preserved."""
+    mixin = GateExecutorMixin()
+    gates, has_required_failure = mixin._execute_requested_gates(
+        {"requested": [{"gate": "codex_gate", "status": "not_executable", "required": True}]},
+        pr_number=1481,
+    )
+    assert has_required_failure is True

--- a/tests/test_gemini_vertex_routing.py
+++ b/tests/test_gemini_vertex_routing.py
@@ -432,8 +432,13 @@ class TestVertexRunnerReturnsGateResultShape:
         assert isinstance(result["blocking_findings"], list)
         assert isinstance(result["duration_seconds"], float)
 
-    def test_vertex_failure_result_matches_failed_shape(self, gate_env, monkeypatch):
-        """Vertex API error must produce a result with status='failed' and reason field."""
+    def test_vertex_failure_result_matches_unavailable_shape(self, gate_env, monkeypatch):
+        """Vertex API error books unavailable (non-execution) with reason field.
+
+        A ConnectionError reaching the Vertex REST call means the review never
+        ran, so the result is ``unavailable`` (OI-1178), not ``failed`` — but it
+        must still carry the canonical reason/reason_detail fields.
+        """
         monkeypatch.setenv("VNX_GEMINI_ROUTING", "vertex")
         monkeypatch.setenv("VNX_VERTEX_PROJECT", "failure-shape-proj")
 
@@ -449,7 +454,7 @@ class TestVertexRunnerReturnsGateResultShape:
                 pr_number=42,
             )
 
-        assert result["status"] == "failed"
+        assert result["status"] == "unavailable"
         assert "reason" in result
         assert result["reason"] == "vertex_api_error"
         assert "Simulated Vertex quota error" in result.get("reason_detail", "")


### PR DESCRIPTION
## Problem (OI-1178)

A non-executed gate read as passed. Measured 12-08 (PR #1481): a codex_gate result with `status=failed`, `summary="Gate execution exit_nonzero: Subprocess exited with code 1"`, empty `contract_hash`, empty `report_path`, 0 findings was a non-execution booked as a review verdict — and the CLI rollup printed **"All gates PASS"** while the per-gate line showed **"codex_gate FAIL"**.

An infra failure produces no verdict: no `contract_hash`, no `report_path`, no findings. That is absence of evidence, not a rejected PR. It must surface as `unavailable`, never `failed`.

## Fix

One shared place, extended to every gate (not a third local variant):

- **`gate_recorder.record_failure`** books reasons in `EXECUTION_FAILURE_REASONS` (now including `vertex_api_error`) as `status=unavailable` with an unmistakable summary (`"... UNAVAILABLE (gate did not run — ...) — NOT a review fail"`). A real verdict failure (gate ran, found a blockade) still books `failed` — that path flows through `materialize_artifacts`.
- **`gate_status.has_complete_evidence`** (new): a result counts as evidence only with non-empty `contract_hash` AND `report_path`.
- **`gate_executor._execute_requested_gates`**: a required gate that did not pass *with complete evidence* now sets `has_required_failure`, so `request-and-execute` returns exit 1 and the rollup can no longer sum a non-run gate up as PASS.
- **`review_gate_manager._handle_request_and_execute`**: names every non-pass gate, not just `not_executable`/`not_configured`.
- **`gate.sh`**: `_g_show_results` classifies `UNAVAIL`/`NOEXEC`/`FAIL`/`PASS` via `is_pass` + `has_complete_evidence`; the final line never says "All gates PASS" over a non-run gate.

## Tests

New `tests/test_gate_unavailable_rollup.py` (28 cases): `record_failure` for every execution-level reason books `unavailable`; a non-execution reason still books `failed`; `_execute_requested_gates` blocks on unavailable/failed/hollow-pass, passes only completed-with-evidence; `has_complete_evidence` cases.

Updated neighbor assertions that pinned execution failures to `failed` → `unavailable` (`test_gate_recorder_register`, `test_gate_runner`, `test_gate_runner_vertex`, `test_gate_execution_certification`, `test_gate_status_schema`).

## Verification

`python3 -m pytest tests/test_gate_unavailable_rollup.py` — 28 passed. Touched-file + neighbor run shows **zero new failures** vs. baseline at the base commit (identical pre-existing failure set, 18 tests, all unrelated: a `_run_with_stall_detection` MagicMock `fd >= 0` issue, ADR-005 branch-matching in closure_verifier integration tests, and a `_compute_changed_files(strict=)` mock-signature mismatch).

## Open Items

- 18 pre-existing failures in neighbor files (documented above) are unrelated to this change and present at the base commit. Left untouched to keep this PR scoped.
- `scripts/lib/governance_enforcer.py::_check_gemini_review_required` checks only that a gemini result file exists — an `unavailable` gemini would read as satisfied there. Separate hardening candidate.

Dispatch-ID: 20260814l-a-gate-unavailable-rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)