### PR TITLE
feat(planning): persist plan-gate decision_ref onto tracks (OI-1190)

### DIFF
--- a/schemas/migrations/0033_track_decision_ref.sql
+++ b/schemas/migrations/0033_track_decision_ref.sql
@@ -1,0 +1,44 @@
+-- 0033_track_decision_ref.sql
+-- OI-1190: make the plan-gate decision findable from the track.
+--
+-- Purpose: add tracks.decision_ref — a nullable TEXT column holding a JSON
+--          payload that points at the plan-gate report(s) plus the rejected
+--          alternatives with their reasons. The plan-gate panel writes 820
+--          reports to unified_reports/ over 50 unique tracks, previously only
+--          findable via the name pattern plan-gate-<track_id>-<label>-<hash>.md.
+--          The durable half of a plan decision (why this approach, what was
+--          rejected and why) was therefore not reachable from the track. This
+--          column carries that pointer; the perishable half (the steps) stays
+--          generated just-in-time and is deliberately NOT stored here.
+--
+-- Payload shape (written by plan_gate_panel.build_decision_ref):
+--     {
+--       "reports": ["unified_reports/plan-gate-<track>-<label>-<hash>.md", ...],
+--       "decision": "PASS" | "REVISE" | "BLOCK" | "INFRA_FAIL",
+--       "rejected_alternatives": [
+--         {"panelist": "<label>", "verdict": "block|revise",
+--          "findings": [...], "rationale": "..."}, ...
+--       ],
+--       "set_at": "<ISO-8601>",
+--       "source": "plan-gate" | "backfill"
+--     }
+--
+-- ADR-007 binding: additive column on an existing table whose composite PRIMARY
+--          KEY (track_id, project_id) already satisfies ADR-007 (migration 0024).
+--          No index is added — decision_ref is read via the existing PK lookup
+--          (get_track), never queried by its own value, so a single-column index
+--          (which would omit project_id and violate ADR-007) is never needed.
+--
+-- Target DB: runtime_coordination.db
+-- Applied by: scripts/lib/migrations/apply_0033.py (via auto_apply.py)
+-- Tested by:  tests/test_migration_decision_ref.py
+--
+-- Idempotency: ALTER TABLE ADD COLUMN is not idempotent in SQLite, but
+--              apply_script_if_below skips the whole script when user_version >= 33.
+--
+-- Pre-migration state  (v32): tracks has no decision_ref column.
+-- Post-migration state (v33): tracks.decision_ref exists, NULL on every row.
+
+ALTER TABLE tracks ADD COLUMN decision_ref TEXT;
+
+PRAGMA user_version = 33;

--- a/scripts/backfill_track_decision_ref.py
+++ b/scripts/backfill_track_decision_ref.py
@@ -1,0 +1,447 @@
+#!/usr/bin/env python3
+"""backfill_track_decision_ref.py — populate tracks.decision_ref from historical
+plan-gate reports (OI-1190).
+
+WHY THIS EXISTS
+  The plan-gate panel writes one governed report per seat to
+  ``<data_dir>/unified_reports/plan-gate-<track_id>-<label>-<hash>.md``. The durable
+  half of a plan decision — which reports certified it, and which approaches were
+  rejected with what reasons — was only reachable by name-pattern-matching those
+  files; it was NOT reachable from the track. Migration 0033 added
+  ``tracks.decision_ref`` so that pointer lives on the track. This backfill maps the
+  EXISTING reports back onto their tracks so the 50 tracks that already have
+  plan-gate history are not left empty.
+
+  The payload is built by ``plan_gate_panel.build_decision_ref`` (the SAME builder
+  the live plan-gate uses) from each report's ``vnx-plan-verdict`` fence, so the
+  backfilled shape is identical to a live write — only ``source`` differs
+  ("backfill" vs "plan-gate").
+
+WHAT IT NEVER DOES
+  - Never overwrites an existing non-empty ``tracks.decision_ref`` (a live plan-gate
+    write is more authoritative than a reconstructed backfill). Idempotent: a second
+    run is a no-op for every already-filled track.
+  - Never writes ROADMAP.yaml, never promotes, never touches declared phase.
+  - Never invents a decision for a track that has no report files.
+
+MODES (mirror the other scripts/backfill_*.py tools):
+  DIAGNOSE (always, read-only): before-state counts (tracks total, reports found).
+  DRY-RUN (DEFAULT, no --apply): copy the live DB to a temp dir, run the backfill on
+    the COPY, report what WOULD be filled. The live DB is never written.
+  --apply: run against the live store via tracks.set_decision_ref (the single-writer),
+    report filled/already-filled/not-filled counts with reasons.
+
+Safety rules:
+  - Default = dry-run on a copy.
+  - Additive + idempotent only: fills empty decision_ref; never overwrites.
+  - All writes go through the tracks.py API (set_decision_ref), never raw SQL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import json
+import os
+import re
+import shutil
+import sqlite3
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Optional
+
+# ---------------------------------------------------------------------------
+# Bootstrap sys.path so lib modules resolve regardless of cwd
+# ---------------------------------------------------------------------------
+
+_HERE = Path(__file__).resolve().parent
+_LIB = _HERE / "lib"
+if str(_LIB) not in sys.path:
+    sys.path.insert(0, str(_LIB))
+
+import tracks  # noqa: E402
+import plan_gate_panel as pgp  # noqa: E402
+
+DB_FILENAME = "runtime_coordination.db"
+REPORTS_DIRNAME = "unified_reports"
+_REPORT_PREFIX = "plan-gate-"
+_HASH_RE = re.compile(r"[0-9a-f]{8}$")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _utc_iso() -> str:
+    return datetime.datetime.now(datetime.timezone.utc).strftime("%Y-%m-%dT%H:%M:%fZ")
+
+
+def _known_labels() -> list[str]:
+    """The closed set of plan-gate seat labels used to parse report filenames.
+
+    Union of the shipped DEFAULT_PANEL labels and the current config's labels, so a
+    label that was later removed from the config (or a historical default) still
+    parses. Sorted longest-first so the right-anchored match tries the most specific
+    label first.
+    """
+    labels: set[str] = {s["label"] for s in pgp.DEFAULT_PANEL}
+    try:
+        labels.update(s["label"] for s in pgp.load_panel_seats())
+    except Exception:  # vnx-silent-except: config load failure must not break the backfill
+        pass
+    return sorted(labels, key=len, reverse=True)
+
+
+@dataclass(frozen=True)
+class ReportFile:
+    filename: str       # e.g. plan-gate-<track>-<label>-<hash>.md
+    track_id: str
+    label: str
+    hash: str
+    mtime: float
+
+
+def _parse_report_filename(filename: str, labels: list[str]) -> Optional[ReportFile]:
+    """Parse ``plan-gate-<track_id>-<label>-<hash>.md`` into its parts.
+
+    Right-anchored: the trailing ``-<8-hex-hash>`` is stripped first, then the
+    ``-<label>`` (longest label wins), and everything before is the track_id. This is
+    unambiguous even when a track_id itself contains dashes or a label-shaped suffix,
+    because the real split is always the LAST ``-<label>-<hash>``.
+    """
+    stem = filename
+    if stem.endswith(".md"):
+        stem = stem[:-3]
+    if not stem.startswith(_REPORT_PREFIX):
+        return None
+    stem = stem[len(_REPORT_PREFIX):]
+    if not stem:
+        return None
+
+    m = _HASH_RE.search(stem)
+    if not m:
+        return None
+    hash_part = m.group(0)
+    label_and_track = stem[:m.start()].rstrip("-")
+    if not label_and_track:
+        return None
+
+    for label in labels:
+        suffix = f"-{label}"
+        if label_and_track.endswith(suffix):
+            track_id = label_and_track[: -len(suffix)]
+            if not track_id:
+                return None
+            return ReportFile(
+                filename=filename,
+                track_id=track_id,
+                label=label,
+                hash=hash_part,
+                mtime=0.0,
+            )
+    return None
+
+
+def discover_reports(reports_dir: Path) -> list[ReportFile]:
+    """Scan ``reports_dir`` for ``plan-gate-*.md`` files, parsing each filename.
+
+    Files whose name does not parse (not a plan-gate report, unknown label, no hash)
+    are skipped silently — they are out of scope for this backfill, not an error.
+    """
+    labels = _known_labels()
+    found: list[ReportFile] = []
+    if not reports_dir.is_dir():
+        return found
+    for path in sorted(reports_dir.glob(f"{_REPORT_PREFIX}*.md")):
+        parsed = _parse_report_filename(path.name, labels)
+        if parsed is None:
+            continue
+        try:
+            mtime = path.stat().st_mtime
+        except OSError:
+            mtime = 0.0
+        found.append(ReportFile(
+            filename=parsed.filename,
+            track_id=parsed.track_id,
+            label=parsed.label,
+            hash=parsed.hash,
+            mtime=mtime,
+        ))
+    return found
+
+
+def _latest_per_label(reports: list[ReportFile]) -> list[ReportFile]:
+    """Dedupe a track's reports to one per seat label (latest mtime wins).
+
+    A flaked seat is retried under a fresh dispatch id, so one label can leave
+    several report files behind. Only the latest per label represents the seat's
+    most recent read; older retry files are noise for the decision reconstruction.
+    """
+    best: dict[str, ReportFile] = {}
+    for r in reports:
+        cur = best.get(r.label)
+        if cur is None or r.mtime > cur.mtime:
+            best[r.label] = r
+    return sorted(best.values(), key=lambda r: r.label)
+
+
+def build_payload_for_track(
+    reports_dir: Path,
+    track_id: str,
+    report_files: list[ReportFile],
+    *,
+    source: str,
+    set_at: str,
+) -> str:
+    """Reconstruct a track's decision_ref payload from its report files.
+
+    Reads each (latest-per-label) report, parses its ``vnx-plan-verdict`` fence via
+    ``plan_gate_panel.parse_verdict``, re-derives the decision with ``apply_panel_rule``
+    (the same rule the live gate uses), and renders the payload with
+    ``build_decision_ref`` — so the backfilled shape matches a live write exactly.
+    """
+    results: list[pgp.PanelistResult] = []
+    for f in report_files:
+        try:
+            text = (reports_dir / f.filename).read_text(encoding="utf-8")
+        except OSError:
+            text = ""
+        parsed = pgp.parse_verdict(text)
+        results.append(pgp.PanelistResult(
+            label=f.label,
+            provider="",
+            model="",
+            verdict=parsed["verdict"],
+            blocking_findings=parsed["blocking_findings"],
+            rationale=parsed["rationale"],
+            report_path=f.filename[: -3] if f.filename.endswith(".md") else f.filename,
+            dispatched=True,
+            parse_error=parsed["parse_error"],
+            no_verdict=False,
+        ))
+    decision = pgp.apply_panel_rule(results)["decision"]
+    return pgp.build_decision_ref(
+        decision,
+        [r.__dict__ for r in results],
+        source=source,
+        set_at=set_at,
+    )
+
+
+def _track_decision_ref(state_dir: Path, track_id: str, project_id: str) -> Optional[str]:
+    t = tracks.get_track(state_dir, track_id, project_id)
+    return (t or {}).get("decision_ref")
+
+
+# ---------------------------------------------------------------------------
+# BACKFILL (applied via the tracks.py API — never raw SQL)
+# ---------------------------------------------------------------------------
+
+
+def apply_backfill(
+    state_dir: Path,
+    reports_dir: Path,
+    project_id: str,
+    *,
+    set_at: str,
+    source: str = "backfill",
+) -> dict:
+    """Fill empty tracks.decision_ref for every track that has plan-gate reports.
+
+    Idempotent + additive: only tracks whose decision_ref is currently empty are
+    written; an already-filled track is counted as ``already_filled`` and left alone.
+    Returns a report dict.
+    """
+    report: dict = {
+        "tracks_total": 0,
+        "tracks_with_reports": 0,
+        "filled": [],
+        "already_filled": [],
+        "orphan_reports": [],      # (track_id, filename) — report for a track not in the DB
+        "errors": [],
+    }
+
+    conn = sqlite3.connect(str(state_dir / DB_FILENAME))
+    conn.row_factory = sqlite3.Row
+    try:
+        report["tracks_total"] = conn.execute(
+            "SELECT COUNT(*) FROM tracks WHERE project_id = ?", (project_id,)
+        ).fetchone()[0]
+        db_track_ids = {
+            r[0] for r in conn.execute(
+                "SELECT track_id FROM tracks WHERE project_id = ?", (project_id,)
+            ).fetchall()
+        }
+    finally:
+        conn.close()
+
+    reports = discover_reports(reports_dir)
+    by_track: dict[str, list[ReportFile]] = {}
+    for r in reports:
+        by_track.setdefault(r.track_id, []).append(r)
+
+    for track_id, files in by_track.items():
+        if track_id not in db_track_ids:
+            report["orphan_reports"].extend((track_id, f.filename) for f in files)
+            continue
+        report["tracks_with_reports"] += 1
+
+        current = _track_decision_ref(state_dir, track_id, project_id)
+        if current:
+            report["already_filled"].append(track_id)
+            continue
+
+        try:
+            payload = build_payload_for_track(
+                reports_dir, track_id, _latest_per_label(files),
+                source=source, set_at=set_at,
+            )
+            tracks.set_decision_ref(state_dir, track_id, project_id, payload, actor="system")
+            report["filled"].append(track_id)
+        except tracks.DecisionRefColumnMissingError:
+            report["errors"].append(
+                f"{track_id}: tracks.decision_ref column absent — run `vnx migrate` first"
+            )
+            break
+        except Exception as exc:  # vnx-silent-except: one bad track must not abort the run
+            report["errors"].append(f"{track_id}: {exc}")
+
+    return report
+
+
+def print_report(report: dict, file=None) -> None:
+    out = file or sys.stdout
+    total = report["tracks_total"]
+    with_reports = report["tracks_with_reports"]
+    filled = len(report["filled"])
+    already = len(report["already_filled"])
+    orphan = len(report["orphan_reports"])
+    # Orphan REPORTS are files whose track_id is not a track row at all, so they
+    # do not reduce "tracks without reports" — that number is purely tracks-in-DB
+    # that have no matching report.
+    without_reports = max(0, total - with_reports)
+
+    print(f"\n{'='*64}", file=out)
+    print(f"  DECISION_REF BACKFILL REPORT", file=out)
+    print(f"{'='*64}", file=out)
+    print(f"  tracks total                         : {total}", file=out)
+    print(f"  tracks with plan-gate report(s)      : {with_reports}", file=out)
+    print(f"    filled (decision_ref was empty)    : {filled}", file=out)
+    for t in report["filled"]:
+        print(f"      {t}", file=out)
+    print(f"    already filled (skipped, untouched): {already}", file=out)
+    print(f"  orphan reports (no matching track)   : {orphan}", file=out)
+    for track_id, filename in report["orphan_reports"]:
+        print(f"      {track_id:<32} <- {filename}", file=out)
+    print(f"  tracks without plan-gate reports     : {without_reports}", file=out)
+    print(f"    reason: no plan-gate-*.md report exists for this track", file=out)
+    if report["errors"]:
+        print(f"  ERRORS:", file=out)
+        for e in report["errors"]:
+            print(f"    - {e}", file=out)
+    print(f"{'='*64}\n", file=out)
+
+
+# ---------------------------------------------------------------------------
+# DRY-RUN (default) — backfill a temp COPY, never touch the live DB
+# ---------------------------------------------------------------------------
+
+
+def dry_run(state_dir: Path, reports_dir: Path, project_id: str) -> int:
+    print(f"\n  DRY-RUN MODE — operating on a temp copy of: {state_dir / DB_FILENAME}")
+    tmp_dir = Path(tempfile.mkdtemp(prefix="vnx_decision_ref_dryrun_"))
+    tmp_state = tmp_dir / "state"
+    tmp_state.mkdir(parents=True)
+    try:
+        shutil.copy2(str(state_dir / DB_FILENAME), str(tmp_state / DB_FILENAME))
+        report = apply_backfill(
+            tmp_state, reports_dir, project_id, set_at=_utc_iso(),
+        )
+        print_report(report)
+
+        # Assert the live DB was NOT mutated by this dry-run.
+        live = sqlite3.connect(str(state_dir / DB_FILENAME), timeout=30.0)
+        live.execute("PRAGMA query_only = ON")
+        try:
+            live_total = live.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+        finally:
+            live.close()
+        untouched = live_total == report["tracks_total"]
+        print(f"  Live-DB untouched assertion: {'[ok]' if untouched else '[!] LIVE DB CHANGED'}")
+        if not untouched:
+            print("    [FATAL] dry-run mutated the live DB — this is a bug.", file=sys.stderr)
+            return 1
+        print("\n  Dry-run successful. Review the projection, then run --apply.")
+        return 0
+    finally:
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+def apply_to_live(state_dir: Path, reports_dir: Path, project_id: str) -> int:
+    print(f"\n  --APPLY MODE — backfilling live store: {state_dir / DB_FILENAME}")
+    report = apply_backfill(state_dir, reports_dir, project_id, set_at=_utc_iso())
+    print_report(report)
+    print("  Backfill complete.")
+    return 0
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Backfill tracks.decision_ref from historical plan-gate reports "
+        "(dry-run default; --apply writes via the tracks API).",
+    )
+    parser.add_argument(
+        "--apply",
+        action="store_true",
+        help="Apply the backfill to the LIVE store (default: dry-run on a temp copy).",
+    )
+    parser.add_argument(
+        "--data-dir",
+        type=Path,
+        default=None,
+        help="Central data dir containing unified_reports/ and state/ (default: resolve "
+        "from VNX_DATA_DIR_EXPLICIT+VNX_DATA_DIR, else ~/.vnx-data/<project-id>).",
+    )
+    parser.add_argument(
+        "--project-id",
+        default=os.environ.get("VNX_PROJECT_ID", "vnx-dev"),
+        help="Project id to scope the backfill (default: env VNX_PROJECT_ID or 'vnx-dev').",
+    )
+    args = parser.parse_args(argv)
+
+    if args.data_dir:
+        data_dir = args.data_dir.expanduser().resolve()
+    elif os.environ.get("VNX_DATA_DIR_EXPLICIT") == "1" and os.environ.get("VNX_DATA_DIR"):
+        data_dir = Path(os.environ["VNX_DATA_DIR"]).expanduser().resolve()
+    else:
+        from vnx_paths import resolve_central_data_dir
+        try:
+            data_dir = resolve_central_data_dir(args.project_id)
+        except ValueError as exc:
+            print(f"  [ERROR] {exc}", file=sys.stderr)
+            return 1
+
+    state_dir = data_dir / "state"
+    reports_dir = data_dir / REPORTS_DIRNAME
+
+    if not (state_dir / DB_FILENAME).exists():
+        print(f"  [ERROR] Database not found: {state_dir / DB_FILENAME}", file=sys.stderr)
+        return 1
+    if not reports_dir.is_dir():
+        print(f"  [WARNING] unified_reports dir not found: {reports_dir} — nothing to backfill.")
+
+    if args.apply:
+        return apply_to_live(state_dir, reports_dir, args.project_id)
+    return dry_run(state_dir, reports_dir, args.project_id)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/lib/migrations/apply_0033.py
+++ b/scripts/lib/migrations/apply_0033.py
@@ -1,0 +1,46 @@
+"""apply_0033.py — tracks.decision_ref migration (OI-1190 plan decision findability).
+
+Adds: tracks.decision_ref (nullable TEXT) holding a JSON payload that points at
+the plan-gate report(s) plus the rejected alternatives with their reasons.
+
+ADR-007: additive column on tracks, whose composite PRIMARY KEY
+(track_id, project_id) already satisfies ADR-007 (migration 0024). No new index
+(decision_ref is read via the existing PK lookup, never queried by its own value).
+
+Idempotent: PRAGMA user_version >= 33 → skip entirely.
+Atomicity: apply_script_if_below wraps all statements in a SAVEPOINT.
+Applied by: scripts/lib/migrations/auto_apply.py
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import sys
+from pathlib import Path
+
+_LIB_DIR = Path(__file__).resolve().parent.parent
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from schema_migration import apply_script_if_below
+
+log = logging.getLogger(__name__)
+
+
+def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
+    """Returns True if applied, False if skipped (already at target version)."""
+    sql = migration_sql_path.read_text()
+
+    conn = sqlite3.connect(str(db_path))
+    conn.isolation_level = None  # autocommit — required for SAVEPOINT semantics
+    try:
+        applied = apply_script_if_below(conn, 33, sql)
+    finally:
+        conn.close()
+
+    if applied:
+        log.info("apply_0033: tracks.decision_ref applied (user_version → 33)")
+    else:
+        log.debug("apply_0033: already at user_version >= 33; skipped")
+    return applied

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -1176,3 +1176,53 @@ def run_panel(
         "panelists": [r.__dict__ for r in results],
         "doc_truncation": doc_truncation,
     }
+
+
+def build_decision_ref(
+    decision: str,
+    panelists: List[Dict[str, Any]],
+    *,
+    reports_base: str = "unified_reports",
+    source: str = "plan-gate",
+    set_at: Optional[str] = None,
+) -> str:
+    """Render the JSON ``decision_ref`` payload for a plan-gate round (OI-1190).
+
+    ``panelists`` is ``run_panel``'s ``panelists`` list (the ``PanelistResult.__dict__``
+    form). ``reports`` collects every panelist that actually delivered a report
+    (``dispatched`` is True — a report file exists on disk); ``rejected_alternatives``
+    collects the scoring block/revise panelists with their findings + rationale, so the
+    reasons an approach was rejected survive on the track rather than only in the
+    name-pattern-matchable report files. Returns a compact JSON string (the
+    ``tracks.decision_ref`` payload written via ``tracks.set_decision_ref``).
+    """
+    reports: List[str] = []
+    rejected: List[Dict[str, Any]] = []
+    for p in panelists:
+        report_path = (p.get("report_path") or "").strip()
+        if p.get("dispatched") and report_path:
+            path = report_path if report_path.endswith(".md") else f"{report_path}.md"
+            reports.append(f"{reports_base}/{path}")
+        # A rejected alternative is a SCORING block/revise verdict: the lane actually
+        # reviewed the plan and gave concrete reasons. parse_error (fail-safe revise)
+        # and no_verdict (synthesized) lanes saw no real verdict — no reason to record.
+        if (
+            p.get("dispatched")
+            and not p.get("parse_error")
+            and not p.get("no_verdict")
+            and str(p.get("verdict", "")).lower() in ("block", "revise")
+        ):
+            rejected.append({
+                "panelist": p.get("label", ""),
+                "verdict": str(p.get("verdict", "")).lower(),
+                "findings": list(p.get("blocking_findings") or []),
+                "rationale": str(p.get("rationale", "")),
+            })
+    payload = {
+        "reports": reports,
+        "decision": decision,
+        "rejected_alternatives": rejected,
+        "set_at": set_at or datetime.now(timezone.utc).isoformat(),
+        "source": source,
+    }
+    return json.dumps(payload, sort_keys=True)

--- a/scripts/lib/schema_manifest.py
+++ b/scripts/lib/schema_manifest.py
@@ -9,7 +9,7 @@ v30 but is physically v27) SKIPS every migration and never trips them — leavin
 migrations silently un-applied (synthesis E-F, repro-confirmed).
 
 This module replaces that fragile, scattered mechanism with ONE declarative
-INVARIANT MANIFEST per schema version (v22-v31) plus a single reconciler engine:
+INVARIANT MANIFEST per schema version (v22-v33) plus a single reconciler engine:
 
   * The manifest declares, per version, the FULL expected shape: required tables;
     columns (name + affinity + nullability); PK column ordinals; composite UNIQUE
@@ -170,6 +170,9 @@ _TRACKS_COLS_V27 = {**_TRACKS_COLS_V24, **_cols(("horizon", "TEXT", False))}
 _TRACKS_COLS_V28 = {**_TRACKS_COLS_V27, **_cols(("derived_status", "TEXT", False))}
 _TRACKS_COLS_V29 = {**_TRACKS_COLS_V28,
                     **_cols(("track_type", "TEXT", True), ("next_action_owner", "TEXT", False))}
+# v33 adds decision_ref (OI-1190): nullable TEXT JSON pointer to the plan-gate
+# report(s) + rejected alternatives. Additive column — no index (read via PK).
+_TRACKS_COLS_V33 = {**_TRACKS_COLS_V29, **_cols(("decision_ref", "TEXT", False))}
 
 # track_phase_history
 _TPH_COLS_V22 = _cols(
@@ -534,6 +537,12 @@ def _build_manifest() -> Dict[int, VersionManifest]:
         32: VersionManifest(32, (
             _dispatches(_DISPATCH_COLS_V27),
             _tracks_composite(_TRACKS_COLS_V29, _TRACKS_IDX_V29),
+            *base_children_v24, _toi_composite(_TOI_COLS_V30, _OI_BLOCKER_IDX),
+            *_runtime_tables_v31(), _track_pr_delivery()),
+            (_DELIVERABLES_VIEW,)),
+        33: VersionManifest(33, (
+            _dispatches(_DISPATCH_COLS_V27),
+            _tracks_composite(_TRACKS_COLS_V33, _TRACKS_IDX_V29),
             *base_children_v24, _toi_composite(_TOI_COLS_V30, _OI_BLOCKER_IDX),
             *_runtime_tables_v31(), _track_pr_delivery()),
             (_DELIVERABLES_VIEW,)),

--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -42,9 +42,24 @@ class HorizonColumnMissingError(RuntimeError):
     pass
 
 
+class DecisionRefColumnMissingError(RuntimeError):
+    """Raised when a decision_ref write is requested but tracks.decision_ref is absent.
+
+    Fail-closed (D5): a store predating migration 0033 lacks the decision_ref column.
+    We refuse loudly and point the operator at `vnx migrate` instead of silently
+    dropping the plan-gate decision pointer.
+    """
+    pass
+
+
 def _tracks_has_horizon(conn: sqlite3.Connection) -> bool:
     """True when the tracks table carries the horizon column (migration 0027)."""
     return any(row[1] == "horizon" for row in conn.execute("PRAGMA table_info('tracks')"))
+
+
+def _tracks_has_decision_ref(conn: sqlite3.Connection) -> bool:
+    """True when the tracks table carries the decision_ref column (migration 0033)."""
+    return any(row[1] == "decision_ref" for row in conn.execute("PRAGMA table_info('tracks')"))
 
 ALLOWED_TRANSITIONS: dict[str, frozenset[str]] = {
     "queued":  frozenset({"active", "parked"}),
@@ -365,6 +380,59 @@ def update_authored_fields(
                 (*updates.values(), track_id, project_id),
             )
             conn.commit()
+
+        updated = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        return dict(updated)
+    finally:
+        conn.close()
+
+
+def set_decision_ref(
+    state_dir: str | Path,
+    track_id: str,
+    project_id: str,
+    decision_ref: str,
+    *,
+    actor: str = "system",
+) -> dict[str, Any]:
+    """Write the plan-gate decision pointer onto a track (OI-1190).
+
+    ``decision_ref`` is a JSON string (built by plan_gate_panel.build_decision_ref)
+    pointing at the plan-gate report(s) plus the rejected alternatives with their
+    reasons. It is machine-derived evidence, not authored ROADMAP content, so it has
+    its own writer rather than riding update_authored_fields. Emits a
+    ``track_decision_ref_set`` audit event (ADR-005).
+
+    Raises TrackNotFoundError if the track does not exist, and
+    DecisionRefColumnMissingError on a store predating migration 0033.
+    """
+    conn = _get_conn(state_dir)
+    try:
+        row = conn.execute(
+            "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",
+            (track_id, project_id),
+        ).fetchone()
+        if not row:
+            raise TrackNotFoundError(f"Track not found: ({track_id!r}, {project_id!r})")
+
+        if not _tracks_has_decision_ref(conn):
+            raise DecisionRefColumnMissingError(
+                f"Cannot set decision_ref on track {track_id!r}: the tracks table "
+                "has no 'decision_ref' column (store predates migration 0033). "
+                "Run `vnx migrate` to add it, then retry."
+            )
+
+        _emit_track_event(
+            state_dir, "track_decision_ref_set", track_id, project_id, actor, {}
+        )
+        conn.execute(
+            "UPDATE tracks SET decision_ref = ? WHERE track_id = ? AND project_id = ?",
+            (decision_ref, track_id, project_id),
+        )
+        conn.commit()
 
         updated = conn.execute(
             "SELECT * FROM tracks WHERE track_id = ? AND project_id = ?",

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -319,6 +319,7 @@ def cmd_objective_show(args: argparse.Namespace) -> int:
     print(f"  next_up  : {bool(track.get('next_up'))}")
     print(f"  pr_ref   : {track.get('pr_ref') or '-'}")
     print(f"  delivery : {_format_pr_delivery(delivery_entries)}")
+    print(f"  decision_ref: {_format_decision_ref(track.get('decision_ref'))}")
     print(f"  goal     : {track.get('goal_state') or '-'}")
     print(f"  depends  : {', '.join(deps) if deps else '(none)'}")
     if open_items:
@@ -1686,6 +1687,27 @@ def _format_pr_delivery(entries: list[dict[str, Any]]) -> str:
     return ", ".join(f"#{e['pr_number']} {e['delivery_kind']}" for e in entries)
 
 
+def _format_decision_ref(decision_ref: Optional[str]) -> str:
+    """Compact one-line summary of a track's decision_ref (OI-1190).
+
+    ``decision_ref`` is the JSON payload written by plan_gate_panel.build_decision_ref:
+    decision + report count + rejected-alternative count. An absent field renders '-';
+    an unparseable one is echoed raw rather than guessed at.
+    """
+    if not decision_ref:
+        return "-"
+    try:
+        payload = json.loads(decision_ref)
+    except (json.JSONDecodeError, ValueError):
+        return decision_ref
+    decision = payload.get("decision", "?")
+    reports = payload.get("reports") or []
+    rejected = payload.get("rejected_alternatives") or []
+    n_reports = len(reports) if isinstance(reports, list) else 0
+    n_rejected = len(rejected) if isinstance(rejected, list) else 0
+    return f"{decision} ({n_reports} report(s), {n_rejected} rejected alternative(s))"
+
+
 def _append_coordination_event(
     conn: sqlite3.Connection,
     *,
@@ -2257,6 +2279,26 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
     except Exception as exc:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
         return 1
+
+    # OI-1190: persist the durable half of the plan decision onto the track — the
+    # report path(s) + the rejected alternatives with their reasons — so the decision
+    # is findable from the track (previously only name-pattern-matchable from
+    # unified_reports/). Written for EVERY outcome (PASS/REVISE/BLOCK/INFRA_FAIL), not
+    # just PASS: a REVISE/BLOCK is exactly when the rejected alternatives matter most.
+    # Best-effort: a decision_ref write must never break the gate it hangs off (same
+    # contract as _emit_plan_gate_pass_record).
+    try:
+        payload = plan_gate_panel.build_decision_ref(
+            result["decision"], result["panelists"], source="plan-gate"
+        )
+        tracks_lib.set_decision_ref(
+            state_dir, args.track_id, args.project_id, payload, actor="system"
+        )
+    except Exception as exc:  # vnx-silent-except: decision_ref persistence must never break the gate
+        print(
+            f"WARNING: could not persist decision_ref for track {args.track_id}: {exc}",
+            file=sys.stderr,
+        )
 
     if args.json:
         print(json.dumps(result, indent=2))

--- a/tests/test_backfill_track_decision_ref.py
+++ b/tests/test_backfill_track_decision_ref.py
@@ -1,0 +1,305 @@
+"""tests/test_backfill_track_decision_ref.py — OI-1190 retroactive backfill.
+
+Covers the idempotent backfill that maps historical plan-gate reports back onto
+their tracks via tracks.decision_ref:
+- report-filename parsing (plan-gate-<track>-<label>-<hash>.md)
+- dedupe-by-label (latest mtime wins)
+- payload reconstruction via plan_gate_panel.build_decision_ref (source="backfill")
+- apply_backfill fills only EMPTY decision_ref, reports filled/already-filled/orphan
+- a second run is a no-op (idempotent)
+
+All tests use temporary DBs only — the live .vnx-data DB is never touched.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_ROOT = Path(__file__).resolve().parent.parent
+_LIB = _ROOT / "scripts" / "lib"
+_SCRIPTS = _ROOT / "scripts"
+_MIGRATIONS = _ROOT / "schemas" / "migrations"
+
+for p in (str(_LIB), str(_SCRIPTS)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import schema_migration  # noqa: E402
+import tracks as tracks_lib  # noqa: E402
+import plan_gate_panel as pgp  # noqa: E402
+import backfill_track_decision_ref as b  # noqa: E402
+
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _report(verdict: str, findings: list[str] | None = None, rationale: str = "ok") -> str:
+    body = json.dumps({
+        "verdict": verdict,
+        "blocking_findings": findings or [],
+        "rationale": rationale,
+    })
+    return f"# review\n\nsome prose\n\n```{pgp.VERDICT_FENCE}\n{body}\n```\n"
+
+
+def _make_state_dir(tmp_path: Path) -> Path:
+    """Build a tracks DB (22/24/27/28) + decision_ref (0033), ready for the backfill."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        """
+        CREATE TABLE dispatches (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, dispatch_id TEXT NOT NULL,
+            project_id TEXT NOT NULL DEFAULT 'vnx-dev', state TEXT NOT NULL DEFAULT 'queued',
+            terminal_id TEXT, track TEXT, priority TEXT DEFAULT 'P2', pr_ref TEXT,
+            gate TEXT, attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT,
+            created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ','now')),
+            expires_after TEXT, metadata_json TEXT DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+        """
+    )
+    conn.execute(
+        """
+        CREATE TABLE IF NOT EXISTS coordination_events (
+            id INTEGER PRIMARY KEY AUTOINCREMENT, event_id TEXT, event_type TEXT NOT NULL,
+            entity_type TEXT NOT NULL DEFAULT 'dispatch', entity_id TEXT NOT NULL,
+            from_state TEXT, to_state TEXT, actor TEXT NOT NULL DEFAULT 'runtime',
+            reason TEXT, metadata_json TEXT DEFAULT '{}', occurred_at TEXT NOT NULL, project_id TEXT
+        )
+        """
+    )
+    conn.commit()
+    for ver, fname in ((22, "0022_track_layer.sql"), (24, "0024_tracks_tenant_scoping.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for ver, fname in ((27, "0027_planning_horizon_and_deliverable_view.sql"),
+                       (28, "0028_tracks_derived_status.sql")):
+        schema_migration.apply_script_if_below(conn, ver, (_MIGRATIONS / fname).read_text(encoding="utf-8"))
+        conn.commit()
+    schema_migration.apply_script_if_below(
+        conn, 33, (_MIGRATIONS / "0033_track_decision_ref.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _decision_ref(state_dir: Path, track_id: str, project_id: str = "proj-x") -> str | None:
+    t = tracks_lib.get_track(state_dir, track_id, project_id)
+    return (t or {}).get("decision_ref")
+
+
+# ---------------------------------------------------------------------------
+# Filename parsing
+# ---------------------------------------------------------------------------
+
+def test_parse_report_filename_parses_all_default_labels():
+    labels = b._known_labels()
+    cases = {
+        "plan-gate-feat-opus-deadbeef.md": ("feat", "opus", "deadbeef"),
+        "plan-gate-feat-kimi-00ff00aa.md": ("feat", "kimi", "00ff00aa"),
+        "plan-gate-feat-glm-5.2-harness-1a2b3c4d.md": ("feat", "glm-5.2-harness", "1a2b3c4d"),
+        "plan-gate-feat-deepseek-12345678.md": ("feat", "deepseek", "12345678"),
+        "plan-gate-feat-codex-fedcba98.md": ("feat", "codex", "fedcba98"),
+    }
+    for filename, (track, label, hash_) in cases.items():
+        r = b._parse_report_filename(filename, labels)
+        assert r is not None, filename
+        assert (r.track_id, r.label, r.hash) == (track, label, hash_)
+
+
+def test_parse_report_filename_track_with_dashes():
+    labels = b._known_labels()
+    r = b._parse_report_filename("plan-gate-20260814m-a-track-decision-ref-opus-deadbeef.md", labels)
+    assert r is not None
+    assert r.track_id == "20260814m-a-track-decision-ref"
+    assert r.label == "opus"
+
+
+def test_parse_report_filename_rejects_unparseable():
+    labels = b._known_labels()
+    assert b._parse_report_filename("some-other-file.md", labels) is None
+    assert b._parse_report_filename("plan-gate-nohash.md", labels) is None
+    assert b._parse_report_filename("plan-gate--opus-deadbeef.md", labels) is None  # empty track
+    assert b._parse_report_filename("plan-gate-x-unknownlabel-deadbeef.md", labels) is None
+
+
+# ---------------------------------------------------------------------------
+# Discovery + dedupe
+# ---------------------------------------------------------------------------
+
+def test_discover_reports_and_latest_per_label(tmp_path):
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "plan-gate-feat-opus-aaaaaaaa.md").write_text(_report("pass"), encoding="utf-8")
+    # A retried kimi seat: two files, the older one is noise.
+    older = reports_dir / "plan-gate-feat-kimi-bbbbbbbb.md"
+    older.write_text(_report("revise"), encoding="utf-8")
+    newer = reports_dir / "plan-gate-feat-kimi-cccccccc.md"
+    newer.write_text(_report("pass"), encoding="utf-8")
+    import os
+    os.utime(older, (1_000_000, 1_000_000))
+    os.utime(newer, (2_000_000, 2_000_000))
+    # An out-of-scope file is ignored.
+    (reports_dir / "plan-gate-ignore-me.md").write_text("x", encoding="utf-8")
+
+    found = b.discover_reports(reports_dir)
+    by_track: dict[str, list[b.ReportFile]] = {}
+    for r in found:
+        by_track.setdefault(r.track_id, []).append(r)
+
+    assert set(by_track) == {"feat"}
+    latest = b._latest_per_label(by_track["feat"])
+    assert {r.label for r in latest} == {"opus", "kimi"}
+    kimi = next(r for r in latest if r.label == "kimi")
+    assert kimi.hash == "cccccccc"  # latest mtime wins
+
+
+# ---------------------------------------------------------------------------
+# Payload reconstruction
+# ---------------------------------------------------------------------------
+
+def test_build_payload_for_track_reconstructs_decision_and_rejected(tmp_path):
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    files = [
+        b.ReportFile("plan-gate-feat-opus-aaaaaaaa.md", "feat", "opus", "aaaaaaaa", 1.0),
+        b.ReportFile("plan-gate-feat-kimi-bbbbbbbb.md", "feat", "kimi", "bbbbbbbb", 1.0),
+    ]
+    (reports_dir / files[0].filename).write_text(
+        _report("block", ["no rollback", "ssrf"], "unsafe"), encoding="utf-8"
+    )
+    (reports_dir / files[1].filename).write_text(_report("pass"), encoding="utf-8")
+
+    payload = b.build_payload_for_track(
+        reports_dir, "feat", files, source="backfill", set_at="2026-08-14T00:00:00Z"
+    )
+    data = json.loads(payload)
+    assert data["source"] == "backfill"
+    assert data["decision"] == "REVISE"  # one block -> revise
+    assert len(data["reports"]) == 2
+    assert set(data["reports"]) == {
+        "unified_reports/plan-gate-feat-opus-aaaaaaaa.md",
+        "unified_reports/plan-gate-feat-kimi-bbbbbbbb.md",
+    }
+    rejected = data["rejected_alternatives"]
+    assert len(rejected) == 1
+    assert rejected[0]["panelist"] == "opus"
+    assert rejected[0]["verdict"] == "block"
+    assert rejected[0]["findings"] == ["no rollback", "ssrf"]
+    assert rejected[0]["rationale"] == "unsafe"
+
+
+# ---------------------------------------------------------------------------
+# apply_backfill end-to-end
+# ---------------------------------------------------------------------------
+
+def test_apply_backfill_fills_empty_skips_filled_and_counts(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+
+    tracks_lib.create_track(state_dir, "feat-a", "proj-x", "A", "shipped")
+    tracks_lib.create_track(state_dir, "feat-b", "proj-x", "B", "shipped")
+    tracks_lib.create_track(state_dir, "feat-c", "proj-x", "C", "shipped")
+
+    (reports_dir / "plan-gate-feat-a-opus-aaaaaaaa.md").write_text(_report("pass"), encoding="utf-8")
+    (reports_dir / "plan-gate-feat-b-kimi-bbbbbbbb.md").write_text(_report("pass"), encoding="utf-8")
+    # feat-b already has a (live) decision_ref — the backfill must not overwrite it.
+    tracks_lib.set_decision_ref(state_dir, "feat-b", "proj-x", '{"source":"plan-gate"}', actor="system")
+
+    report = b.apply_backfill(
+        state_dir, reports_dir, "proj-x", set_at="2026-08-14T00:00:00Z",
+    )
+
+    assert report["tracks_total"] == 3
+    assert report["tracks_with_reports"] == 2
+    assert report["filled"] == ["feat-a"]
+    assert report["already_filled"] == ["feat-b"]
+    assert report["orphan_reports"] == []
+
+    # feat-a's decision_ref is a real payload pointing at the report file.
+    payload = json.loads(_decision_ref(state_dir, "feat-a"))
+    assert payload["source"] == "backfill"
+    assert payload["reports"] == ["unified_reports/plan-gate-feat-a-opus-aaaaaaaa.md"]
+    assert (tmp_path / "unified_reports" / "plan-gate-feat-a-opus-aaaaaaaa.md").exists()
+    # feat-b's live decision_ref is untouched.
+    assert _decision_ref(state_dir, "feat-b") == '{"source":"plan-gate"}'
+    # feat-c has no report and no decision_ref.
+    assert _decision_ref(state_dir, "feat-c") is None
+
+
+def test_apply_backfill_reports_orphan_reports(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+
+    tracks_lib.create_track(state_dir, "feat-a", "proj-x", "A", "shipped")
+    (reports_dir / "plan-gate-ghost-opus-aaaaaaaa.md").write_text(_report("pass"), encoding="utf-8")
+
+    report = b.apply_backfill(
+        state_dir, reports_dir, "proj-x", set_at="2026-08-14T00:00:00Z",
+    )
+    assert report["tracks_total"] == 1
+    assert report["tracks_with_reports"] == 0
+    assert report["filled"] == []
+    assert len(report["orphan_reports"]) == 1
+    assert report["orphan_reports"][0][0] == "ghost"
+
+
+def test_print_report_without_reports_not_reduced_by_orphans(tmp_path, capsys):
+    """Orphan REPORT FILES must not shrink the 'tracks without reports' count.
+
+    A track_id that appears in a report filename but has no tracks row is an orphan
+    REPORT, not a track — so 'tracks without plan-gate reports' is tracks-in-DB with
+    no matching report, independent of how many orphan files exist.
+    """
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+
+    tracks_lib.create_track(state_dir, "feat-a", "proj-x", "A", "shipped")
+    tracks_lib.create_track(state_dir, "feat-b", "proj-x", "B", "shipped")
+    (reports_dir / "plan-gate-feat-a-opus-aaaaaaaa.md").write_text(_report("pass"), encoding="utf-8")
+    for h in ("11111111", "22222222", "33333333"):
+        (reports_dir / f"plan-gate-ghost-kimi-{h}.md").write_text(_report("pass"), encoding="utf-8")
+
+    report = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-08-14T00:00:00Z")
+    assert report["tracks_total"] == 2
+    assert report["tracks_with_reports"] == 1
+    assert len(report["orphan_reports"]) == 3  # three ghost files, not a track
+
+    b.print_report(report)
+    out = capsys.readouterr().out
+    assert "tracks without plan-gate reports     : 1" in out
+
+
+def test_apply_backfill_is_idempotent_second_run_is_noop(tmp_path):
+    state_dir = _make_state_dir(tmp_path)
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+
+    tracks_lib.create_track(state_dir, "feat-a", "proj-x", "A", "shipped")
+    (reports_dir / "plan-gate-feat-a-opus-aaaaaaaa.md").write_text(_report("pass"), encoding="utf-8")
+
+    first = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-08-14T00:00:00Z")
+    second = b.apply_backfill(state_dir, reports_dir, "proj-x", set_at="2026-08-14T00:00:01Z")
+
+    assert first["filled"] == ["feat-a"]
+    assert second["filled"] == []          # nothing left to fill
+    assert second["already_filled"] == ["feat-a"]  # the first run's write is seen

--- a/tests/test_migration_decision_ref.py
+++ b/tests/test_migration_decision_ref.py
@@ -1,0 +1,275 @@
+"""tests/test_migration_decision_ref.py — migration 0033 validation.
+
+Verifies:
+- 0033 applies cleanly on a v29-equivalent tracks table
+- tracks.decision_ref added (nullable TEXT, no DEFAULT — NULL on existing rows)
+- migration is idempotent (second apply is a no-op, version unchanged)
+- row count preserved before and after migration
+- PRAGMA integrity_check passes after migration
+- ADR-007 composite PRIMARY KEY (track_id, project_id) survives the additive change
+- the apply_0033.py runner (the auto_apply path) applies end-to-end
+
+All tests use temporary DBs only — the live .vnx-data DB is never touched.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+_LIB = Path(__file__).resolve().parent.parent / "scripts" / "lib"
+_MIGRATIONS = Path(__file__).resolve().parent.parent / "schemas" / "migrations"
+_SCRIPTS = Path(__file__).resolve().parent.parent / "scripts"
+
+for p in (str(_LIB), str(_SCRIPTS)):
+    if p not in sys.path:
+        sys.path.insert(0, p)
+
+import schema_migration  # noqa: E402
+from migrations.apply_0033 import apply_migration  # noqa: E402
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _cols(conn: sqlite3.Connection, table: str) -> list[str]:
+    return [r[1] for r in conn.execute(f"PRAGMA table_info({table})")]
+
+
+def _base_v29_db(tmp_path: Path) -> sqlite3.Connection:
+    """Build a DB in the v29-equivalent state (0022+0024+0027+0028+0029 applied).
+
+    Mirrors the `_base_v28_db` pattern from test_migration_track_type.py, then
+    applies 0029 (track_type / next_action_owner) so the tracks table is in the
+    exact pre-0033 shape.
+    """
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute("""
+        CREATE TABLE dispatches (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            dispatch_id     TEXT    NOT NULL,
+            project_id      TEXT    NOT NULL DEFAULT 'vnx-dev',
+            state           TEXT    NOT NULL DEFAULT 'queued',
+            terminal_id     TEXT,
+            track           TEXT,
+            priority        TEXT    DEFAULT 'P2',
+            pr_ref          TEXT,
+            gate            TEXT,
+            attempt_count   INTEGER NOT NULL DEFAULT 0,
+            bundle_path     TEXT,
+            created_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            updated_at      TEXT    NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+            expires_after   TEXT,
+            metadata_json   TEXT    DEFAULT '{}',
+            UNIQUE(dispatch_id, project_id)
+        )
+    """)
+    conn.commit()
+    for version, filename in (
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, version, (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    # Mirror structural-doctor additions present in the live v26 DB.
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+    for version, filename in (
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
+    ):
+        schema_migration.apply_script_if_below(
+            conn, version, (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        )
+        conn.commit()
+    return conn
+
+
+def _apply_0033(conn: sqlite3.Connection) -> bool:
+    sql = (_MIGRATIONS / "0033_track_decision_ref.sql").read_text(encoding="utf-8")
+    applied = schema_migration.apply_script_if_below(conn, 33, sql)
+    conn.commit()
+    return applied
+
+
+# ---------------------------------------------------------------------------
+# Tests: basic application
+# ---------------------------------------------------------------------------
+
+def test_0033_applies_and_bumps_version(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    assert schema_migration.get_user_version(conn) == 29
+    assert _apply_0033(conn) is True
+    assert schema_migration.get_user_version(conn) == 33
+
+
+def test_decision_ref_column_added(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)
+    assert "decision_ref" in _cols(conn, "tracks")
+
+
+def test_decision_ref_is_nullable_and_defaults_to_null(tmp_path):
+    """Existing rows get decision_ref=NULL from the additive ALTER — no data impact."""
+    conn = _base_v29_db(tmp_path)
+    conn.executemany(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) VALUES (?, ?, ?, ?)",
+        [
+            ("t1", "vnx-dev", "Alpha", "goal-a"),
+            ("t2", "proj-x", "Beta", "goal-b"),
+        ],
+    )
+    conn.commit()
+    _apply_0033(conn)
+    null_count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE decision_ref IS NULL"
+    ).fetchone()[0]
+    assert null_count == 2
+
+
+def test_rowcount_preserved(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('stable', 'vnx-dev', 'S', 'g')"
+    )
+    conn.commit()
+    count_before = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    _apply_0033(conn)
+    count_after = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_after == count_before == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: idempotency
+# ---------------------------------------------------------------------------
+
+def test_0033_idempotent(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    assert _apply_0033(conn) is True
+    # Second apply returns False (skipped — version already >= 33).
+    assert _apply_0033(conn) is False
+    assert schema_migration.get_user_version(conn) == 33
+
+
+def test_0033_idempotent_rowcount_stable(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('stable', 'vnx-dev', 'S', 'g')"
+    )
+    conn.commit()
+    _apply_0033(conn)
+    count_after_first = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    _apply_0033(conn)
+    count_after_second = conn.execute("SELECT COUNT(*) FROM tracks").fetchone()[0]
+    assert count_after_first == count_after_second == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: integrity and ADR-007 composite key
+# ---------------------------------------------------------------------------
+
+def test_integrity_check_passes(tmp_path):
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, decision_ref) "
+        "VALUES ('ic-1', 'vnx-dev', 'IC', 'g', '{}')"
+    )
+    conn.commit()
+    result = conn.execute("PRAGMA integrity_check").fetchall()
+    assert result == [("ok",)]
+
+
+def test_composite_pk_preserved(tmp_path):
+    """ADR-007: PRIMARY KEY (track_id, project_id) must survive the additive migration."""
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('dup', 'vnx-dev', 'A', 'g')"
+    )
+    conn.commit()
+    with pytest.raises(sqlite3.IntegrityError):
+        conn.execute(
+            "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+            "VALUES ('dup', 'vnx-dev', 'B', 'g')"
+        )
+
+
+def test_composite_pk_allows_same_track_id_different_project(tmp_path):
+    """Same track_id in different projects is allowed (multi-tenant scope)."""
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('shared-id', 'proj-a', 'A', 'g')"
+    )
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state) "
+        "VALUES ('shared-id', 'proj-b', 'B', 'g')"
+    )
+    conn.commit()
+    count = conn.execute(
+        "SELECT COUNT(*) FROM tracks WHERE track_id='shared-id'"
+    ).fetchone()[0]
+    assert count == 2
+
+
+def test_decision_ref_stores_arbitrary_json_text(tmp_path):
+    """decision_ref is a TEXT payload — a JSON string round-trips verbatim."""
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)
+    payload = '{"decision": "PASS", "reports": ["unified_reports/plan-gate-x-opus-abcd1234.md"]}'
+    conn.execute(
+        "INSERT INTO tracks (track_id, project_id, title, goal_state, decision_ref) "
+        "VALUES ('dr', 'vnx-dev', 'DR', 'g', ?)",
+        (payload,),
+    )
+    conn.commit()
+    row = conn.execute(
+        "SELECT decision_ref FROM tracks WHERE track_id='dr' AND project_id='vnx-dev'"
+    ).fetchone()
+    assert row[0] == payload
+
+
+# ---------------------------------------------------------------------------
+# Tests: the apply_0033.py runner (auto_apply's discovery path)
+# ---------------------------------------------------------------------------
+
+def test_apply_0033_runner_end_to_end(tmp_path):
+    """The paired runner (what auto_apply invokes) applies on a fresh connection."""
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = _base_v29_db(tmp_path)
+    assert schema_migration.get_user_version(conn) == 29
+    conn.close()
+
+    assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is True
+
+    conn2 = sqlite3.connect(str(db_path))
+    assert schema_migration.get_user_version(conn2) == 33
+    assert "decision_ref" in _cols(conn2, "tracks")
+    conn2.close()
+
+
+def test_apply_0033_runner_idempotent(tmp_path):
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = _base_v29_db(tmp_path)
+    conn.close()
+
+    assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is True
+    # Already at user_version >= 33 → skipped, not an error.
+    assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is False

--- a/tests/test_migration_inventory.py
+++ b/tests/test_migration_inventory.py
@@ -38,14 +38,14 @@ def test_sql_surface_has_at_least_42_files():
     assert all(p.endswith(".sql") for p in sql_surface.paths)
 
 
-def test_applier_surface_has_seven_runners():
+def test_applier_surface_has_eight_runners():
     surfaces = mi.build_inventory(REPO)
     applier_surface = surfaces[1]
-    assert applier_surface.file_count == 7
+    assert applier_surface.file_count == 8
     names = {Path(p).stem for p in applier_surface.paths}
     assert names == {
         "apply_0017", "apply_0019", "apply_0020",
-        "apply_0022", "apply_0024", "apply_0026", "apply_0032",
+        "apply_0022", "apply_0024", "apply_0026", "apply_0032", "apply_0033",
     }
 
 

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -676,6 +676,7 @@ def _bootstrap(tmp_path: Path) -> Path:
         (27, "0027_planning_horizon_and_deliverable_view.sql"),
         (28, "0028_tracks_derived_status.sql"),
         (30, "0030_track_oi_resolved_at.sql"),
+        (33, "0033_track_decision_ref.sql"),
     ]:
         sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
         schema_migration.apply_script_if_below(conn, version, sql)
@@ -2141,3 +2142,160 @@ def test_cmd_plan_gate_run_pass_with_failed_evidence_is_loud_not_silent(tmp_path
     assert "plan_gate_pass evidence NOT written" in captured.err
     # Nothing durable landed in the repo ledger.
     assert not (tmp_path / ".vnx-attest" / "plan-gates.ndjson").exists()
+
+
+# --------------------------------------------------------------------------
+# OI-1190: build_decision_ref — the durable half of a plan decision rendered as
+# the tracks.decision_ref JSON payload (report pointers + rejected alternatives).
+# --------------------------------------------------------------------------
+
+def test_build_decision_ref_renders_full_payload():
+    import json
+    panelists = [
+        {"label": "opus", "verdict": "pass", "blocking_findings": [], "rationale": "ok",
+         "report_path": "plan-gate-x-opus-abc12345", "dispatched": True,
+         "parse_error": False, "no_verdict": False},
+        {"label": "kimi", "verdict": "block", "blocking_findings": ["no rollback"], "rationale": "unsafe",
+         "report_path": "plan-gate-x-kimi-6789abcd", "dispatched": True,
+         "parse_error": False, "no_verdict": False},
+        {"label": "glm-5.2-harness", "verdict": "revise", "blocking_findings": [], "rationale": "",
+         "report_path": "", "dispatched": False, "parse_error": True, "no_verdict": False},
+    ]
+    payload = json.loads(pgp.build_decision_ref("REVISE", panelists))
+    assert payload["decision"] == "REVISE"
+    assert payload["source"] == "plan-gate"
+    assert payload["set_at"]  # ISO-8601 timestamp present
+    # Only dispatched seats contribute a report pointer; the undispatched glm seat does not.
+    assert set(payload["reports"]) == {
+        "unified_reports/plan-gate-x-opus-abc12345.md",
+        "unified_reports/plan-gate-x-kimi-6789abcd.md",
+    }
+    # Only the SCORING block seat is a rejected alternative (with reasons).
+    rejected = payload["rejected_alternatives"]
+    assert [r["panelist"] for r in rejected] == ["kimi"]
+    assert rejected[0]["verdict"] == "block"
+    assert rejected[0]["findings"] == ["no rollback"]
+    assert rejected[0]["rationale"] == "unsafe"
+
+
+def test_build_decision_ref_parse_error_seat_is_not_a_rejected_alternative():
+    import json
+    # A parse_error seat carries a fail-safe "revise" verdict that was never authored
+    # by the model — it must NOT read as a rejected alternative with reasons.
+    panelists = [
+        {"label": "opus", "verdict": "pass", "blocking_findings": [], "rationale": "ok",
+         "report_path": "plan-gate-x-opus-abc12345", "dispatched": True,
+         "parse_error": False, "no_verdict": False},
+        {"label": "glm-5.2-harness", "verdict": "revise", "blocking_findings": [], "rationale": "",
+         "report_path": "plan-gate-x-glm-fedcba98", "dispatched": True,
+         "parse_error": True, "no_verdict": False},
+    ]
+    payload = json.loads(pgp.build_decision_ref("PASS", panelists))
+    assert payload["rejected_alternatives"] == []
+
+
+def test_build_decision_ref_honors_source_and_set_at_overrides():
+    import json
+    payload = json.loads(pgp.build_decision_ref(
+        "INFRA_FAIL", [], source="backfill", set_at="2026-08-14T00:00:00Z",
+    ))
+    assert payload["source"] == "backfill"
+    assert payload["set_at"] == "2026-08-14T00:00:00Z"
+    assert payload["decision"] == "INFRA_FAIL"
+    assert payload["reports"] == []
+    assert payload["rejected_alternatives"] == []
+
+
+# --------------------------------------------------------------------------
+# OI-1190: the plan-gate write hook — after a plan-gate round the TRACK carries
+# decision_ref pointing at the existing report file(s). This is the test that
+# FAILS without the fix (previously the decision lived only in name-pattern-
+# matchable unified_reports/ files, unreachable from the track).
+# --------------------------------------------------------------------------
+
+def _dref_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+    return {
+        "track_id": track_id, "project_id": project_id, "decision": "REVISE",
+        "summary": {"decision": "REVISE", "pass_count": 1, "revise_count": 0,
+                    "block_count": 1, "rationale": "one block"},
+        "panelists": [
+            {"label": "opus", "verdict": "pass", "blocking_findings": [], "rationale": "ok",
+             "report_path": "plan-gate-feat-dref-opus-abc12345", "dispatched": True,
+             "parse_error": False, "no_verdict": False},
+            {"label": "kimi", "verdict": "block", "blocking_findings": ["no rollback"],
+             "rationale": "unsafe", "report_path": "plan-gate-feat-dref-kimi-6789abcd",
+             "dispatched": True, "parse_error": False, "no_verdict": False},
+        ],
+        "doc_truncation": {"truncated": False},
+    }
+
+
+def test_cmd_plan_gate_run_writes_decision_ref_to_track(tmp_path, monkeypatch):
+    import argparse
+    import json
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-dref", "p1", "t", "shipped", phase="queued")
+
+    reports_dir = tmp_path / "unified_reports"
+    reports_dir.mkdir(parents=True)
+    (reports_dir / "plan-gate-feat-dref-opus-abc12345.md").write_text(
+        _make_report_with_fence("pass"), encoding="utf-8"
+    )
+    (reports_dir / "plan-gate-feat-dref-kimi-6789abcd.md").write_text(
+        _report('{"verdict": "block", "blocking_findings": ["no rollback"], "rationale": "unsafe"}'),
+        encoding="utf-8",
+    )
+
+    monkeypatch.setattr(pgp, "run_panel", _dref_run_panel)
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+    args = argparse.Namespace(
+        track_id="feat-dref", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 2  # REVISE
+
+    decision_ref = tracks.get_track(state_dir, "feat-dref", "p1")["decision_ref"]
+    assert decision_ref, "the track must carry decision_ref after a plan-gate round"
+    payload = json.loads(decision_ref)
+    assert payload["source"] == "plan-gate"
+    assert payload["decision"] == "REVISE"
+    assert set(payload["reports"]) == {
+        "unified_reports/plan-gate-feat-dref-opus-abc12345.md",
+        "unified_reports/plan-gate-feat-dref-kimi-6789abcd.md",
+    }
+    # The pointers resolve to files that actually exist on disk.
+    for rel in payload["reports"]:
+        assert (tmp_path / rel).exists(), f"decision_ref points at missing report: {rel}"
+    assert [r["panelist"] for r in payload["rejected_alternatives"]] == ["kimi"]
+
+
+def test_cmd_plan_gate_run_decision_ref_write_failure_does_not_break_gate(tmp_path, monkeypatch, capsys):
+    """A decision_ref write failure (e.g. column missing) must never break the gate
+    verdict — it degrades to a loud WARNING, not a crash (OI-1190 best-effort)."""
+    import argparse
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-nodref", "p1", "t", "shipped", phase="queued")
+
+    def _raise(*a, **k):
+        raise tracks.DecisionRefColumnMissingError("store predates migration 0033")
+
+    monkeypatch.setattr(tracks, "set_decision_ref", _raise)
+    monkeypatch.setattr(pgp, "run_panel", _dref_run_panel)
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+    args = argparse.Namespace(
+        track_id="feat-nodref", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 2  # the gate verdict is unaffected
+    captured = capsys.readouterr()
+    assert "could not persist decision_ref" in captured.err

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -213,6 +213,27 @@ def _apply_migration_0032(state_dir: Path) -> None:
     conn.close()
 
 
+def _apply_migration_0033(state_dir: Path) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    schema_migration.apply_script_if_below(
+        conn, 33, (_MIGRATIONS / "0033_track_decision_ref.sql").read_text(encoding="utf-8")
+    )
+    conn.commit()
+    conn.close()
+
+
+def _show_args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir), project_id=project_id, track_id=track_id, json=json,
+    )
+
+
 def _close_args(
     state_dir: Path,
     track_id: str,
@@ -693,3 +714,57 @@ def test_plan_gate_attest_failed_evidence_write_is_loud_not_silent(tmp_path, cap
     assert _plan_oi_resolved_at(sd, "T") is not None
     captured = capsys.readouterr()
     assert "plan_gate_pass evidence NOT written" in captured.err
+
+
+# ---------------------------------------------------------------------------
+# OI-1190: `objective show` surfaces the track's decision_ref (text + --json).
+# ---------------------------------------------------------------------------
+
+def _set_decision_ref_raw(state_dir: Path, track_id: str, payload: str, project_id: str = PROJECT_ID) -> None:
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE tracks SET decision_ref = ? WHERE track_id = ? AND project_id = ?",
+        (payload, track_id, project_id),
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_objective_show_text_surfaces_decision_ref(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _apply_migration_0033(sd)
+    tracks_lib.create_track(sd, "feat-show", PROJECT_ID, title="t", goal_state="shipped", phase="queued")
+    _set_decision_ref_raw(
+        sd, "feat-show",
+        json.dumps({
+            "reports": ["unified_reports/plan-gate-feat-show-opus-abc12345.md",
+                        "unified_reports/plan-gate-feat-show-kimi-6789abcd.md"],
+            "decision": "PASS", "rejected_alternatives": [], "set_at": "x", "source": "plan-gate",
+        }),
+    )
+
+    assert planning_cli.cmd_objective_show(_show_args(sd, "feat-show")) == 0
+    out = capsys.readouterr().out
+    assert "decision_ref: PASS (2 report(s), 0 rejected alternative(s))" in out
+
+
+def test_objective_show_text_absent_decision_ref_renders_dash(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _apply_migration_0033(sd)
+    tracks_lib.create_track(sd, "feat-noref", PROJECT_ID, title="t", goal_state="shipped", phase="queued")
+
+    assert planning_cli.cmd_objective_show(_show_args(sd, "feat-noref")) == 0
+    out = capsys.readouterr().out
+    assert "decision_ref: -" in out
+
+
+def test_objective_show_json_includes_decision_ref(tmp_path, capsys):
+    sd = _build_db(tmp_path)
+    _apply_migration_0033(sd)
+    tracks_lib.create_track(sd, "feat-json", PROJECT_ID, title="t", goal_state="shipped", phase="queued")
+    payload = '{"decision": "PASS", "reports": [], "rejected_alternatives": [], "set_at": "x", "source": "plan-gate"}'
+    _set_decision_ref_raw(sd, "feat-json", payload)
+
+    assert planning_cli.cmd_objective_show(_show_args(sd, "feat-json", json=True)) == 0
+    out = json.loads(capsys.readouterr().out)
+    assert out["decision_ref"] == payload


### PR DESCRIPTION
## OI-1190 — de deliberatie is niet vindbaar vanaf de track

**Problem (measured 2026-08-14, over 260 tracks in vnx-dev):** `goal_state` is 100% populated, but the plan-gate writes 820 reports to `~/.vnx-data/vnx-dev/unified_reports/` over 50 unique tracks that were only findable via the name pattern `plan-gate-<track_id>-<provider>-<hash>.md`. The durable half of a plan decision (why this approach, constraints, rejected alternatives) was not reachable from the track.

### Changes
- **Migration 0033** (`schemas/migrations/0033_track_decision_ref.sql` + `scripts/lib/migrations/apply_0033.py`): adds `tracks.decision_ref` (nullable TEXT JSON pointer). ADR-007-safe — additive column on a table whose composite PK `(track_id, project_id)` already satisfies the tenant-key rule (migration 0024); no single-column index added.
- **`tracks.set_decision_ref`** writer + ADR-005 `track_decision_ref_set` audit event; fail-closed `DecisionRefColumnMissingError` on a store predating 0033.
- **`plan_gate_panel.build_decision_ref`** renders reports + rejected alternatives; `cmd_plan_gate_run` persists it for every gate outcome (PASS/REVISE/BLOCK/INFRA_FAIL), best-effort so a write failure never breaks the gate.
- **`scripts/backfill_track_decision_ref.py`**: idempotent, dry-run-default backfill for the 50 tracks with existing reports. Fills only empty `decision_ref`; never overwrites a live write.
- **`vnx objective show`** surfaces `decision_ref` (text summary + `--json`).

### Verification
- New tests: `test_migration_decision_ref.py` (12), `test_backfill_track_decision_ref.py` (8).
- Updated tests: `test_plan_gate_panel.py` (+5), `test_planning_cli.py` (+3), `test_migration_inventory.py` (7→8 runners).
- Full targeted run: 246 passed across migration, inventory, tracks, planning-cli, and plan-gate-panel suites.
- `test_migration_inventory_completeness.py` oracle green post-commit.

### Known pre-existing failures (unrelated, not touched by this PR)
- `test_plan_gate_panel.py`: 5 failures (`no such column: output_ref` in `track_reconciler._reconcile_deliverable_dispatches`) — the file's `_bootstrap` helper creates `dispatches` without `output_ref`.
- `test_planning_cli.py::test_plan_gate_attest_*`: 6 failures when `test_migration_track_type.py` runs first in the same process (module-level `import migrate_future_system` registers preflight 29 globally, and the attest DB lacks `track_type`). Reproduced via `git stash` on a clean tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)