### PR TITLE
feat(smart-router): registry-driven tier map, walked fallback chain, per-class cooldown

### DIFF
--- a/scripts/benchmark/field-tests/lane_calibration.yaml
+++ b/scripts/benchmark/field-tests/lane_calibration.yaml
@@ -60,11 +60,14 @@ cases:
     expected_lane: provider
     matches_human_tier: true
     note: >
-      tier-zero without DEEPSEEK_API_KEY falls back to Codex. Local Gemma route
-      preserved but unused until gemma-4-12b-integration ships (operator decision
-      2026-08-02). When DEEPSEEK_API_KEY is present, the route is deepseek-v4-flash
-      via claude_harness_keyed. See test_lane_calibration_field_test.py for explicit
-      coverage of both env branches.
+      tier-zero without DEEPSEEK_API_KEY walks the fallback chain (OI-1185): kimi
+      when the kimi CLI is on PATH, else the codex terminal vangnet. The runner
+      pins kimi absent for determinism, so this case calibrates the static tier map
+      (codex vangnet); the kimi branch is unit-tested in tests/smart_router/. Local
+      Gemma route preserved but unused until gemma-4-12b-integration ships (operator
+      decision 2026-08-02). When DEEPSEEK_API_KEY is present, the route is
+      deepseek-v4-flash via claude_harness_keyed. See test_lane_calibration_field_test.py
+      for explicit coverage of both env branches.
 
   - task_id: "04_scorer_task"
     tier: t2_medium

--- a/scripts/benchmark/field-tests/runners/lane_calibration.py
+++ b/scripts/benchmark/field-tests/runners/lane_calibration.py
@@ -67,6 +67,21 @@ def load_calibration_cases(field_tests_dir: Path = FIELD_TESTS) -> list[dict]:
     return cfg["cases"]
 
 
+def _resolve_for_calibration(tier: str):
+    """Resolve a tier route deterministically for calibration.
+
+    OI-1185 walks the fallback chain at decision time, so a no-key tier-zero/low
+    resolves to kimi when the kimi CLI is on PATH and to codex otherwise. The
+    calibration table pins the STATIC tier map (terminal vangnet), so pin kimi
+    absent here: the kimi-present branch is unit-tested in tests/smart_router/.
+    """
+    import shutil
+    from unittest import mock
+
+    with mock.patch.object(shutil, "which", return_value=None):
+        return resolve_tier_route(tier, env={})
+
+
 def run_case(case: dict, tasks_by_id: dict, field_tests_dir: Path = FIELD_TESTS) -> CalibrationResult:
     task = tasks_by_id[case["task_id"]]
     instruction = (field_tests_dir / task["folder"] / "instruction.md").read_text(
@@ -76,7 +91,7 @@ def run_case(case: dict, tasks_by_id: dict, field_tests_dir: Path = FIELD_TESTS)
     loc_estimate = task["target_loc"]
 
     actual_tier = classify_dispatch({"instruction": instruction}, file_paths, loc_estimate)
-    route = resolve_tier_route(actual_tier, env={})
+    route = _resolve_for_calibration(actual_tier)
 
     passed = (
         actual_tier == case["expected_tier"]

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -1054,13 +1054,16 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[DoorRouteResul
     Returns a DoorRouteResult carrying (provider, model, route_reason) when the
     router has a recommendation, or a decline_reason (+ tier when the
     classifier ran) when routing should be skipped (T0, router disabled,
-    provider-not-mapped, classifier error). Returns None on an unexpected
-    error outside the router (e.g. an unreadable instruction file).
+    classifier error). Returns None on an unexpected error outside the router
+    (e.g. an unreadable instruction file).
 
-    Fail-open: never raises — returns None on any error.
+    Fail-open for the classifier and other unexpected errors — but fail-loud for
+    registry drift (ADR-036 §2): a RegistryLookupError (unknown provider/model)
+    propagates so the door rejects instead of silently falling back to CLAUDE.
     """
     try:
         from providers.smart_router.door_routing import resolve_door_route  # noqa: PLC0415
+        from providers.provider_registry import RegistryLookupError  # noqa: PLC0415
 
         # Read instruction text (same logic as validate Rule 5 — the file
         # has already passed staging validation so this is a cheap re-read).
@@ -1075,6 +1078,10 @@ def _resolve_router_pre_validate(spec: DispatchSpec) -> "Optional[DoorRouteResul
             instruction_text=instruction_text,
             file_paths=file_paths,
         )
+    except RegistryLookupError:
+        # ADR-036 §2: unknown provider/model is drift, not a routing bug — the
+        # door must reject loudly rather than fall back to the default lane.
+        raise
     except Exception as exc:
         logger.warning(
             "smart-router pre-validate: router call failed, dispatch "
@@ -1699,21 +1706,32 @@ def run_dispatch(spec_file: Path, *, dry_run: bool = False) -> int:
     # keeps governance intact: a route that violates constraints is still
     # rejected by the full validation chain — only the order changed.
     # Deterministic fallback: when the router declines (T0, disabled,
-    # provider-not-mapped, classifier error), AUTO resolves to CLAUDE so
-    # compile_plan never sees an unresolved AUTO.  This is the same
-    # hard-default the old bridge alias provided, now applied AFTER the
-    # router had its chance to fill in a cheaper provider.
+    # classifier error), AUTO resolves to CLAUDE so compile_plan never sees an
+    # unresolved AUTO.  This is the same hard-default the old bridge alias
+    # provided, now applied AFTER the router had its chance to fill in a
+    # cheaper provider.
     door_route_reason: Optional[str] = None
     if spec.provider == Provider.AUTO:
-        result = _resolve_router_pre_validate(spec)
+        try:
+            from providers.provider_registry import RegistryLookupError  # noqa: PLC0415
+
+            result = _resolve_router_pre_validate(spec)
+        except RegistryLookupError as exc:
+            # ADR-036 §2: an unknown provider/model is drift between the router
+            # and the registry — reject loudly, never silently fall back to the
+            # default lane. No dispatch, no receipt of a half-run.
+            _emit_reject(Reject(
+                "router-registry-drift",
+                str(exc),
+            ))
+            return 1
         if result is not None and result.route is not None:
             new_provider, new_model, route_reason = result.route
             spec = dataclasses.replace(spec, provider=new_provider, model=new_model)
             door_route_reason = route_reason
         else:
             # Router declined or could not resolve (T0, VNX_SMART_ROUTER_DISABLE,
-            # a classifier/resolver exception, or a tier whose TierRoute.provider
-            # has no _TIER_PROVIDER_TO_ENUM entry) — fall back to CLAUDE. OI-1050:
+            # or a classifier exception) — fall back to CLAUDE. OI-1050:
             # this must set provider AND model TOGETHER, in the same replace() call
             # that resolves the router's own success path above. Setting provider
             # alone previously left spec.model=None, and the workers-kimi-pinned

--- a/scripts/lib/incident_taxonomy.py
+++ b/scripts/lib/incident_taxonomy.py
@@ -94,12 +94,31 @@ class IncidentClass(str, Enum):
     Scope: single terminal lease."""
 
     # -- External dependency-level incidents --
-    PROVIDER_OUTAGE = "provider_outage"
-    """A provider lane (Claude, Kimi, GLM, DeepSeek, Codex) failed on quota,
-    auth (403/429), or is otherwise unavailable at decision or execution time.
+    # Provider failures are split into three classes (PR-0 / OI-1185) because
+    # they have different recovery physics: a 429 clears in seconds, an
+    # exhausted quota in hours, and an auth failure (expired/revoked key) never
+    # improves by waiting. classify_provider_failure() maps a lane-failure
+    # reason to exactly one of these.
+    PROVIDER_RATE_LIMIT = "provider_rate_limit"
+    """A provider lane returned 429 (rate limited). Transient: waiting clears
+    it, so the cooldown is short (seconds) and the lane re-engages on its own.
     Detected by: a lane failure recorded by the smart-router availability layer
-    (record_lane_failure) or a provider-dispatch error.
-    Scope: a provider lane across dispatches until its cooldown budget clears."""
+    (record_lane_failure) whose reason matches the 429/rate-limit markers."""
+
+    PROVIDER_QUOTA_EXHAUSTED = "provider_quota_exhausted"
+    """A provider lane exhausted its quota or balance (402/insufficient quota).
+    Longer-lived: the cooldown is measured in hours, doubling on repeat up to
+    the cap. Re-engages automatically once the budget clears.
+    Detected by: a lane failure recorded by record_lane_failure that is neither
+    a rate limit nor an auth failure."""
+
+    PROVIDER_AUTH_FAILURE = "provider_auth_failure"
+    """A provider lane failed auth (401/403, invalid/expired/revoked key).
+    Waiting never fixes this — an expired key does not improve with time — so
+    there is no automatic recovery: the lane stays out until an operator
+    intervenes (rotates the key) and clears the cooldown state.
+    Detected by: a lane failure recorded by record_lane_failure whose reason
+    matches the auth markers."""
 
     # -- Workflow-level incidents --
     RESUME_FAILED = "resume_failed"
@@ -372,8 +391,34 @@ RECOVERY_CONTRACTS: Dict[IncidentClass, RecoveryContract] = {
         ),
     ),
 
-    IncidentClass.PROVIDER_OUTAGE: RecoveryContract(
-        incident_class=IncidentClass.PROVIDER_OUTAGE,
+    IncidentClass.PROVIDER_RATE_LIMIT: RecoveryContract(
+        incident_class=IncidentClass.PROVIDER_RATE_LIMIT,
+        default_severity=Severity.WARNING,
+        retry_budget=RetryBudget(
+            max_retries=4,
+            cooldown_seconds=60,
+            backoff_factor=2.0,
+            max_cooldown_seconds=600,
+        ),
+        escalation=EscalationRule(
+            escalate_after_retries=3,
+            escalate_to="T0",
+            halt_auto_recovery=False,
+            dead_letter_eligible=False,
+        ),
+        permitted_actions=(
+            RecoveryAction.ESCALATE_TO_OPERATOR,
+        ),
+        description=(
+            "A provider lane was rate limited (429). Transient — waiting clears "
+            "it. Cooldown the lane for a minute, doubling on repeat up to ten "
+            "minutes. Escalate to T0 after the third consecutive failure. "
+            "The lane re-engages automatically once its cooldown budget clears."
+        ),
+    ),
+
+    IncidentClass.PROVIDER_QUOTA_EXHAUSTED: RecoveryContract(
+        incident_class=IncidentClass.PROVIDER_QUOTA_EXHAUSTED,
         default_severity=Severity.WARNING,
         retry_budget=RetryBudget(
             max_retries=3,
@@ -391,10 +436,36 @@ RECOVERY_CONTRACTS: Dict[IncidentClass, RecoveryContract] = {
             RecoveryAction.ESCALATE_TO_OPERATOR,
         ),
         description=(
-            "A provider lane failed on quota, auth (403/429), or availability. "
-            "Cooldown the lane for one hour, doubling on repeat up to four hours. "
-            "Escalate to T0 after the second consecutive failure. "
+            "A provider lane exhausted its quota or balance. Long-lived — "
+            "cooldown the lane for one hour, doubling on repeat up to four "
+            "hours. Escalate to T0 after the second consecutive failure. "
             "The lane re-engages automatically once its cooldown budget clears."
+        ),
+    ),
+
+    IncidentClass.PROVIDER_AUTH_FAILURE: RecoveryContract(
+        incident_class=IncidentClass.PROVIDER_AUTH_FAILURE,
+        default_severity=Severity.ERROR,
+        retry_budget=RetryBudget(
+            max_retries=0,
+            cooldown_seconds=0,
+            backoff_factor=1.0,
+            max_cooldown_seconds=0,
+        ),
+        escalation=EscalationRule(
+            escalate_after_retries=0,
+            escalate_to="operator",
+            halt_auto_recovery=True,
+            dead_letter_eligible=False,
+        ),
+        permitted_actions=(
+            RecoveryAction.ESCALATE_TO_OPERATOR,
+        ),
+        description=(
+            "A provider lane failed auth (401/403, invalid/expired/revoked key). "
+            "Waiting never fixes this, so there is no automatic recovery: the "
+            "lane stays out until an operator rotates the key and clears the "
+            "cooldown state. Escalates to the operator immediately."
         ),
     ),
 
@@ -556,6 +627,44 @@ def get_cooldown_seconds(
     budget = contract.retry_budget
     cooldown = budget.cooldown_seconds * (budget.backoff_factor ** retry_count)
     return min(int(cooldown), budget.max_cooldown_seconds)
+
+
+# ---------------------------------------------------------------------------
+# Provider failure classification (OI-1185: one chain for all failure causes)
+# ---------------------------------------------------------------------------
+
+_AUTH_FAILURE_MARKERS = (
+    "401", "403", "unauthorized", "forbidden", "not authenticated",
+    "invalid api key", "invalid_api_key", "authentication", "auth",
+    "access denied", "bad credentials",
+)
+
+_RATE_LIMIT_MARKERS = (
+    "429", "rate limit", "rate_limit", "ratelimit", "too many requests",
+)
+
+
+def classify_provider_failure(reason: str) -> IncidentClass:
+    """Map a lane-failure reason to its provider incident class.
+
+    Deterministic keyword match, most-specific first (OI-1185): an expired key
+    never improves by waiting, so auth outranks rate-limit, and a 429 outranks
+    the quota default.
+
+      - auth markers (401/403/unauthorized/...)  -> PROVIDER_AUTH_FAILURE
+      - rate-limit markers (429/too-many-requests) -> PROVIDER_RATE_LIMIT
+      - anything else (quota/balance/402/...)    -> PROVIDER_QUOTA_EXHAUSTED
+
+    Quota is the catch-all default: the availability layer only calls this for
+    quota/auth/rate-limit failures, and an unrecognized reason is treated as
+    the long-lived (hours) class rather than the transient (seconds) one.
+    """
+    lowered = (reason or "").lower()
+    if any(marker in lowered for marker in _AUTH_FAILURE_MARKERS):
+        return IncidentClass.PROVIDER_AUTH_FAILURE
+    if any(marker in lowered for marker in _RATE_LIMIT_MARKERS):
+        return IncidentClass.PROVIDER_RATE_LIMIT
+    return IncidentClass.PROVIDER_QUOTA_EXHAUSTED
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -40,6 +40,47 @@ class ProviderConfig:
     api_key_env: str
     models: Dict[str, ProviderModel] = field(default_factory=dict)
     default_model: Optional[str] = None
+    # dispatch_enum: the dispatch Provider enum value (dispatch_spec.Provider)
+    # this registry section routes to. Sourced from YAML (ADR-036); absent for
+    # sections the static router never emits (deepseek litellm-proxy, moonshot,
+    # zai, google).
+    dispatch_enum: Optional[str] = None
+
+
+class RegistryLookupError(LookupError):
+    """A provider or model key was not found in wave7_models.yaml.
+
+    Raised on the fail-loud routing path (ADR-036 §2): the message names what
+    was missing and where it was looked for (the registry path). It is
+    intentionally NOT a silent None — a provider/model the registry does not
+    know is drift between the router and the registry, and must surface.
+    """
+
+
+@dataclass(frozen=True)
+class TierRouteStep:
+    """One resolved step in a tier's route chain (primary or fallback).
+
+    ``provider`` is the dispatch enum value (dispatch_spec.Provider), derived
+    from the registry section's ``dispatch_enum`` — NOT the registry section
+    key. ``model`` is the registry model key (validated to exist). ``lane`` is
+    the dispatch lane name.
+    """
+
+    provider: str
+    model: str
+    lane: str
+
+
+@dataclass(frozen=True)
+class TierRouteSpec:
+    """Resolved route chain for one cost tier (primary + ordered fallbacks)."""
+
+    tier: str
+    provider: str
+    model: str
+    lane: str
+    fallback: tuple = ()  # tuple[TierRouteStep, ...]
 
 
 def _parse_model(data: dict) -> ProviderModel:
@@ -65,11 +106,13 @@ def _parse_provider(data: dict) -> ProviderConfig:
     for model_key, model_data in (data.get("models") or {}).items():
         models[model_key] = _parse_model(model_data)
     default_model_raw = data.get("default_model")
+    dispatch_enum_raw = data.get("dispatch_enum")
     return ProviderConfig(
         enabled=bool(data.get("enabled", False)),
         api_key_env=str(data.get("api_key_env") or ""),
         models=models,
         default_model=str(default_model_raw) if default_model_raw is not None else None,
+        dispatch_enum=str(dispatch_enum_raw) if dispatch_enum_raw is not None else None,
     )
 
 
@@ -105,3 +148,94 @@ def get_default_model(
     if cfg is None or not cfg.enabled or not cfg.models:
         return None
     return next(iter(cfg.models.values()))
+
+
+def _resolve_step(
+    entry: dict,
+    providers: Dict[str, ProviderConfig],
+    path: Path,
+    where: str,
+) -> TierRouteStep:
+    """Resolve one tier-map step (primary or fallback) against the registry.
+
+    Validates the provider key exists and is enabled, carries a dispatch_enum,
+    and the model key exists and is dispatch_allowed. Any gap raises
+    RegistryLookupError naming what+where (ADR-036 §2).
+    """
+    provider_key = entry.get("provider")
+    model_key = entry.get("model")
+    lane = entry.get("lane")
+    cfg = providers.get(provider_key)
+    if cfg is None:
+        raise RegistryLookupError(
+            f"provider {provider_key!r} referenced by {where} is not in the registry "
+            f"(checked {path})"
+        )
+    if not cfg.enabled:
+        raise RegistryLookupError(
+            f"provider {provider_key!r} referenced by {where} is disabled in {path}"
+        )
+    if not cfg.dispatch_enum:
+        raise RegistryLookupError(
+            f"provider {provider_key!r} referenced by {where} has no dispatch_enum "
+            f"in {path}; add a dispatch_enum to the {provider_key} section"
+        )
+    model = cfg.models.get(model_key)
+    if model is None:
+        raise RegistryLookupError(
+            f"model {model_key!r} referenced by {where} is not under provider "
+            f"{provider_key!r} in {path}"
+        )
+    if not model.dispatch_allowed:
+        raise RegistryLookupError(
+            f"model {model_key!r} under {provider_key!r} (referenced by {where}) is "
+            f"dispatch_allowed=false in {path}"
+        )
+    return TierRouteStep(provider=cfg.dispatch_enum, model=model_key, lane=lane)
+
+
+def load_tier_map(registry_path: Optional[Path] = None) -> Dict[str, TierRouteSpec]:
+    """Resolve the static router's tier map from the registry (ADR-036).
+
+    Reads the top-level ``routing.tier_map`` block and resolves every referenced
+    provider/model against the ``providers`` sections. Raises RegistryLookupError
+    (naming what+where) on any unknown provider key, missing dispatch_enum, or
+    unknown/disabled model key — never a silent None. This is the fail-loud half
+    of ADR-036: a malformed registry fails at load, before any dispatch reaches
+    the lookup.
+    """
+    path = Path(registry_path) if registry_path is not None else _REGISTRY_PATH
+    try:
+        with open(path) as fh:
+            raw = yaml.safe_load(fh) or {}
+    except FileNotFoundError:
+        raise RegistryLookupError(f"registry file not found at {path}") from None
+    except yaml.YAMLError as exc:
+        raise RegistryLookupError(f"malformed registry yaml at {path}: {exc}") from exc
+
+    providers = load(path)
+    tier_map = ((raw.get("routing") or {}).get("tier_map")) or {}
+    result: Dict[str, TierRouteSpec] = {}
+    for tier, entry in tier_map.items():
+        if not isinstance(entry, dict):
+            raise RegistryLookupError(
+                f"routing.tier_map[{tier!r}] is not a mapping in {path}"
+            )
+        where = f"routing.tier_map[{tier!r}]"
+        primary = _resolve_step(entry, providers, path, where)
+        fallback: tuple = ()
+        raw_fallbacks = entry.get("fallback") or []
+        steps = []
+        for idx, fb in enumerate(raw_fallbacks):
+            steps.append(
+                _resolve_step(fb, providers, path, f"{where}.fallback[{idx}]")
+            )
+        fallback = tuple(steps)
+        result[str(tier)] = TierRouteSpec(
+            tier=str(tier),
+            provider=primary.provider,
+            model=primary.model,
+            lane=primary.lane,
+            fallback=fallback,
+        )
+    return result

--- a/scripts/lib/providers/smart_router/availability.py
+++ b/scripts/lib/providers/smart_router/availability.py
@@ -17,10 +17,14 @@ Cooldown state lives in the central state dir, resolved via the existing
 and is written atomically via ``atomic_io.atomic_write_json``.
 
 The cooldown duration is NOT owned here (OI-1188): ``cooldown_seconds()``
-delegates to ``incident_taxonomy.get_cooldown_seconds`` for the
-``PROVIDER_OUTAGE`` incident class, so the router lane cooldown and the
-supervisor retry budget share one clock and one retry contract. There is no
-second duration constant, env override, or backoff arithmetic in this module.
+delegates to ``incident_taxonomy.get_cooldown_seconds``, so the router lane
+cooldown and the supervisor retry budget share one clock and one retry
+contract. The failure class is chosen by ``incident_taxonomy.classify_provider_failure``
+(PROVIDER_RATE_LIMIT / PROVIDER_QUOTA_EXHAUSTED / PROVIDER_AUTH_FAILURE — the
+OI-1185 split): a 429 cools down in seconds, an exhausted quota in hours, and
+an auth failure never auto-recovers (an expired key does not improve by
+waiting). There is no second duration constant, env override, or backoff
+arithmetic in this module.
 
 Fail-open by design: a broken availability layer never blocks a dispatch. Any
 unexpected error is logged loudly and the lane is treated as available, so the
@@ -70,12 +74,15 @@ class LaneCheck:
     disabled_reason: Optional[str] = None
 
 
-# The lanes the tier-routing engine can emit. deepseek and kimi are the two
-# cheap lanes actually gated at decision time; claude and codex are deliberately
-# ungated (claude is the subscription floor / t0-opus-only, codex is the
-# last-resort vangnet). local-gemma is explicitly disabled via this layer.
+# The lanes the tier-routing engine can emit. Keys are the dispatch Provider
+# enum values (dispatch_spec.Provider), which the tier router reads from the
+# registry's dispatch_enum (ADR-036) — one vocabulary across the routing path.
+# deepseek-harness and kimi are the two cheap lanes actually gated at decision
+# time; claude and codex are deliberately ungated (claude is the subscription
+# floor / t0-opus-only, codex is the last-resort vangnet). local-gemma is
+# explicitly disabled via this layer.
 _LANE_CHECKS: dict[str, LaneCheck] = {
-    "deepseek": LaneCheck(lane="deepseek", env_vars=("DEEPSEEK_API_KEY",)),
+    "deepseek-harness": LaneCheck(lane="deepseek-harness", env_vars=("DEEPSEEK_API_KEY",)),
     "kimi": LaneCheck(lane="kimi", cli_names=("kimi",)),
     "codex": LaneCheck(lane="codex"),
     "claude": LaneCheck(lane="claude"),
@@ -86,6 +93,19 @@ _LANE_CHECKS: dict[str, LaneCheck] = {
 def _validate_lane(lane: str) -> None:
     if not isinstance(lane, str) or not _LANE_RE.match(lane):
         raise ValueError(f"invalid lane name: {lane!r}")
+
+
+def lane_env_vars(lane: str) -> tuple:
+    """Return the env vars the availability layer requires for a lane.
+
+    Single source for the TierRoute.env_requirements surface (ADR-036): the
+    route advertises exactly what the decision-time gate checks, so the two can
+    never drift. Unknown lanes have no requirements.
+    """
+    check = _LANE_CHECKS.get(lane)
+    if check is None:
+        return ()
+    return check.env_vars
 
 
 def _cooldown_dir(state_dir: Path) -> Path:
@@ -107,17 +127,23 @@ def _now() -> float:
     return time.time()
 
 
-def cooldown_seconds() -> int:
-    """Return the provider-outage lane-cooldown duration in seconds.
+def cooldown_seconds(failure_class: Optional[IncidentClass] = None) -> int:
+    """Return the lane-cooldown duration for a provider failure class.
 
     Single cooldown clock (OI-1188): delegates to the canonical incident
-    taxonomy's ``get_cooldown_seconds`` for ``IncidentClass.PROVIDER_OUTAGE`` at
-    retry 0. This module performs no duration, env-override, or backoff
-    arithmetic of its own — the recovery contract is the one source of truth.
+    taxonomy's ``get_cooldown_seconds`` at retry 0. The class defaults to
+    PROVIDER_QUOTA_EXHAUSTED (the long-lived default); rate-limit and auth
+    failures get their own durations from their own contracts. This module
+    performs no duration, env-override, or backoff arithmetic of its own — the
+    recovery contract is the one source of truth.
     """
-    from incident_taxonomy import IncidentClass, get_cooldown_seconds  # noqa: PLC0415
+    from incident_taxonomy import (  # noqa: PLC0415
+        IncidentClass,
+        get_cooldown_seconds,
+    )
 
-    return get_cooldown_seconds(IncidentClass.PROVIDER_OUTAGE, 0)
+    cls = failure_class if failure_class is not None else IncidentClass.PROVIDER_QUOTA_EXHAUSTED
+    return get_cooldown_seconds(cls, 0)
 
 
 def record_lane_failure(
@@ -127,10 +153,13 @@ def record_lane_failure(
     state_dir: Optional[Path] = None,
     now: Optional[float] = None,
 ) -> None:
-    """Mark a lane as in cooldown after a quota/auth failure.
+    """Mark a lane as in cooldown after a quota/auth/rate-limit failure.
 
-    The cooldown duration comes from the single cooldown clock
-    (``cooldown_seconds`` → incident taxonomy PROVIDER_OUTAGE contract).
+    The failure class is chosen by ``incident_taxonomy.classify_provider_failure``
+    (OI-1185 split) and the cooldown duration comes from that class's recovery
+    contract via the single cooldown clock (``cooldown_seconds``). An auth
+    failure is recorded as non-recoverable: it stays out until an operator
+    clears the state (an expired key does not improve by waiting).
 
     Best-effort and fail-open: a failure to persist cooldown state is logged and
     swallowed — cooldown bookkeeping must never break a dispatch.
@@ -143,17 +172,32 @@ def record_lane_failure(
         from vnx_paths import refuse_real_central_store_write_under_pytest  # noqa: PLC0415
 
         refuse_real_central_store_write_under_pytest(sd)
-        duration = cooldown_seconds()
+        from incident_taxonomy import (  # noqa: PLC0415
+            classify_provider_failure,
+            get_contract,
+            get_cooldown_seconds,
+        )
+
+        failure_class = classify_provider_failure(reason)
+        contract = get_contract(failure_class)
+        recoverable = not contract.escalation.halt_auto_recovery
+        duration = get_cooldown_seconds(failure_class, 0)
         until = (now if now is not None else _now()) + duration
         from atomic_io import atomic_write_json  # noqa: PLC0415
 
         atomic_write_json(
             _cooldown_file(sd, lane),
-            {"lane": lane, "reason": reason, "until": until},
+            {
+                "lane": lane,
+                "reason": reason,
+                "until": until,
+                "failure_class": failure_class.value,
+                "recoverable": recoverable,
+            },
         )
         logger.info(
-            "smart-router: lane %r entered cooldown for %ds (reason=%s)",
-            lane, duration, reason,
+            "smart-router: lane %r entered cooldown for %ds (class=%s, reason=%s)",
+            lane, duration, failure_class.value, reason,
         )
     except Exception as exc:  # vnx-silent-except: cooldown bookkeeping must never break a dispatch
         logger.warning(
@@ -170,6 +214,9 @@ def lane_cooldown_remaining(
 ) -> float:
     """Return seconds of cooldown remaining for a lane (0.0 when active).
 
+    A non-recoverable failure (auth — ``recoverable=false``) returns ``inf``:
+    the lane stays out until an operator clears the state, never by waiting.
+
     Fail-open: an unreadable/corrupt state file reads as not-in-cooldown so a
     broken cooldown reader never removes a lane from service.
     """
@@ -180,6 +227,8 @@ def lane_cooldown_remaining(
         if not state_file.is_file():
             return 0.0
         data = json.loads(state_file.read_text(encoding="utf-8"))
+        if data.get("recoverable") is False:
+            return float("inf")
         until = float(data.get("until", 0.0))
         return max(0.0, until - (now if now is not None else _now()))
     except Exception as exc:  # vnx-silent-except: unreadable cooldown state reads as not-in-cooldown (fail-open)
@@ -240,4 +289,5 @@ __all__ = [
     "record_lane_failure",
     "lane_cooldown_remaining",
     "lane_available",
+    "lane_env_vars",
 ]

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -5,10 +5,13 @@ provider (provider=AUTO). Resolves the dispatch to a concrete provider + model
 via the cost-tier classifier and tier-routing engine, then hands back a
 Provider enum + model string that compile_plan can consume.
 
-Fail-open by design: a broken router returns a declined result with a reason
-and the door falls through to the existing behaviour. T0 is never routed
-(t0-opus-only is a floor, not an advisory). The router is default-on since
-2026-08-02.
+Fail-open for the classifier, fail-loud for the registry (ADR-036 §2). A broken
+classifier returns a declined result with a reason and the door falls through to
+the existing behaviour — a routing *bug* must never block a dispatch. But an
+unknown provider/model (a provider string the registry does not know) is drift
+between the router and the registry, and raises RegistryLookupError naming what
+was missing and where it was looked for. T0 is never routed (t0-opus-only is a
+floor, not an advisory). The router is default-on since 2026-08-02.
 
 Every decline path carries an explicit reason (OI-1187) so a no-route is
 distinguishable in the dry-run output and receipt. Before this, a T0 skip, an
@@ -18,7 +21,8 @@ returned a bare None and were indistinguishable in the audit trail.
 Constraints:
 - No imports from dispatch_cli or dispatch_plan (avoid circular deps).
 - No I/O beyond what the smart_router submodules already do.
-- Pure decision function — never mutates, never raises.
+- Pure decision function — never mutates; never raises except for the
+  registry-drift error of ADR-036 §2.
 """
 from __future__ import annotations
 
@@ -38,20 +42,28 @@ logger = logging.getLogger(__name__)
 DECLINE_T0_NEVER_ROUTES = "t0-never-routes"
 DECLINE_EXPLICIT_PROVIDER = "explicit-provider"
 DECLINE_ROUTER_DISABLED = "router-disabled"
-DECLINE_PROVIDER_NOT_MAPPED = "provider-not-mapped"
 DECLINE_CLASSIFIER_ERROR = "classifier-error"
 
 
-# TierRoute.provider string -> Provider enum.
-# The tier-routing engine uses short provider strings; the door's compile_plan
-# needs a Provider enum. This mapping is the canonical translation layer.
-_TIER_PROVIDER_TO_ENUM: dict[str, Provider] = {
-    "deepseek": Provider.DEEPSEEK_HARNESS,
-    "codex": Provider.CODEX,
-    "kimi": Provider.KIMI,
-    "claude": Provider.CLAUDE,
-    "local-gemma": Provider.LOCAL_GEMMA,
-}
+def _provider_enum(provider_str: str) -> Provider:
+    """Map a route provider string to a Provider enum — fail-loud (ADR-036 §2).
+
+    The route's provider string is the registry's ``dispatch_enum`` (read by the
+    tier router from wave7_models.yaml). A string that is not a real dispatch
+    Provider is drift between the tier map and the registry, and must surface
+    with what+where — never a silent None.
+    """
+    try:
+        return Provider(provider_str)
+    except ValueError:
+        from providers.provider_registry import RegistryLookupError  # noqa: PLC0415
+
+        raise RegistryLookupError(
+            f"provider {provider_str!r} is not a known dispatch Provider; the "
+            f"tier map produced a provider string that the Provider enum "
+            f"(dispatch_spec) and registry (wave7_models.yaml dispatch_enum) do "
+            f"not recognize"
+        ) from None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -83,9 +95,13 @@ def resolve_door_route(
 
     Returns a DoorRouteResult: either ``route=(provider, model, route_reason)``
     when the router has a recommendation, or a ``decline_reason`` naming why
-    routing was skipped (T0, explicit provider, router disabled, an unmapped
-    provider string, or a classifier error). ``tier`` is populated whenever the
-    classifier ran so the door can fall back tier-aware instead of blindly.
+    routing was skipped (T0, explicit provider, router disabled, or a
+    classifier error). ``tier`` is populated whenever the classifier ran so the
+    door can fall back tier-aware instead of blindly.
+
+    Raises RegistryLookupError when the classifier succeeded but produced a
+    provider/model the registry does not know (ADR-036 §2 fail-loud) — the
+    door must surface that drift, not fall back.
 
     Args:
         spec_provider: The spec's provider enum value (check Provider.AUTO before calling).
@@ -116,52 +132,37 @@ def resolve_door_route(
     if auto_route in ("0", "false", "no", "off"):
         return DoorRouteResult(decline_reason=DECLINE_ROUTER_DISABLED)
 
+    # Classifier — fail-open (ADR-036 §2). A routing bug (a stale loc_estimate,
+    # an import error, a classifier crash) must never block a dispatch.
     try:
         from .cost_tier import classify_dispatch  # noqa: PLC0415
-        from .tier_routing import resolve_tier_route  # noqa: PLC0415
 
         task_spec = {"instruction": instruction_text}
         tier = classify_dispatch(task_spec, file_paths or [], loc_estimate)
-        route = resolve_tier_route(tier, _env)
-
-        provider_enum = _TIER_PROVIDER_TO_ENUM.get(route.provider)
-        if provider_enum is None:
-            # A decline is still possible (an unmapped provider string), but it
-            # must be visible, not silent: the door falls through to its own
-            # lane resolution, and the reason is logged so a drift in the tier
-            # map is diagnosable. The classified tier is carried so the door can
-            # fall back at the same quality class instead of one lower.
-            logger.warning(
-                "smart-router door routing: provider %r for tier=%s is not in "
-                "_TIER_PROVIDER_TO_ENUM; declining route (fail-open to default lane)",
-                route.provider,
-                tier,
-            )
-            return DoorRouteResult(
-                decline_reason=DECLINE_PROVIDER_NOT_MAPPED,
-                tier=tier,
-            )
-
-        route_reason = f"smart-router:tier={tier},provider={route.provider},model={route.model},lane={route.lane}"
-        if route.reason:
-            route_reason += f";{route.reason}"
-        return DoorRouteResult(
-            route=(provider_enum, route.model, route_reason),
-            tier=tier,
-        )
     except Exception as exc:
-        # Fail-open: a broken classifier or resolver must never block a dispatch.
-        # The door falls through to its existing behaviour.
-        # A failing router that is silent is indistinguishable from a correctly
-        # operating router that declined to route — always log at WARNING so
-        # drift (e.g. a TypeError on stale loc_estimate=None) is visible.
         logger.warning(
-            "smart-router door routing: classifier/resolver failed, dispatch "
-            "falls through to default lane (fail-open). Error: %s",
+            "smart-router door routing: classifier failed, dispatch falls "
+            "through to default lane (fail-open). Error: %s",
             exc,
             exc_info=True,
         )
         return DoorRouteResult(decline_reason=DECLINE_CLASSIFIER_ERROR)
+
+    # Tier routing + provider enum — fail-loud (ADR-036 §2). The classifier
+    # worked; an unknown provider/model is registry drift and must surface, not
+    # vanish as a silent None. RegistryLookupError propagates to the door.
+    from .tier_routing import resolve_tier_route  # noqa: PLC0415
+
+    route = resolve_tier_route(tier, _env)
+    provider_enum = _provider_enum(route.provider)
+
+    route_reason = f"smart-router:tier={tier},provider={route.provider},model={route.model},lane={route.lane}"
+    if route.reason:
+        route_reason += f";{route.reason}"
+    return DoorRouteResult(
+        route=(provider_enum, route.model, route_reason),
+        tier=tier,
+    )
 
 
 def apply_door_route(
@@ -177,8 +178,9 @@ def apply_door_route(
     recommendation when routed, or the decline reason (prefixed "smart-router:")
     when the router skipped — never a bare None for a decline (OI-1187).
 
-    Fail-open: never raises. A broken router returns the original vspec unchanged
-    with a decline reason.
+    Fail-open for a broken classifier (returns the original vspec unchanged
+    with a decline reason); fail-loud for registry drift (RegistryLookupError
+    propagates to the caller, ADR-036 §2).
     """
     spec = vspec.spec
     if spec.provider != Provider.AUTO:

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -1,45 +1,38 @@
 """tier_routing.py — Map cost tiers to provider/lane routing specs.
 
-Tier→provider mappings (honoring provider_constraints.yaml):
-  tier-zero → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
-               (DEEPSEEK_API_KEY required); fallback Codex via provider lane.
-  tier-low  → DeepSeek (deepseek-v4-flash) via Claude-harness key-auth
-               (DEEPSEEK_API_KEY required); runtime fallback Kimi CLI
-               (kimi-k3, kimi-via-cli-only) then Codex.
-  tier-mid  → sonnet-5  (canonical registry key — see wave7_models.yaml)
-  tier-high → opus-5    (canonical registry key — see wave7_models.yaml)
+Model identity and provider strings are read from wave7_models.yaml (ADR-036):
+there are zero model names and zero provider strings as Python literals on this
+routing path. ``provider_registry.load_tier_map()`` resolves the registry's
+``routing.tier_map`` block — a provider key to its dispatch enum, a model key to
+a validated registry model — and raises RegistryLookupError on anything the
+registry does not know. A malformed registry therefore fails at import, before
+any dispatch reaches the lookup (loud and early).
 
-Model names here are canonical registry keys from wave7_models.yaml, never
-free-form strings: the registry is the single source of truth for model
-identity (dispatch-20260802-model-ssot-en-ketenlink). The previous 4-series
-ids (claude-sonnet-4-6 / claude-opus-4-8) were not registry keys and would
-reject with model-not-in-current-registry the moment tier-mid/tier-high
-actually routed; the fleet now runs the 5-series.
-
-Availability is a runtime signal, not a code comment. Each non-Claude lane is
-gated by ``availability.lane_available`` (env vars, CLI presence, cooldown) at
-decision time. A lane that fails on quota/auth is recorded by
-``availability.record_lane_failure`` and auto-recovers after its cooldown
-period — no code edit or release required to bring it back. Kimi is a regular
-route in the tier map again (through the availability check), and local-gemma
-stays disabled via the availability layer's explicit reason, not as a
-commented-out block.
+Availability is a runtime signal, not a code comment. Each lane is gated at
+decision time by ``availability.lane_available`` (env vars, CLI presence,
+cooldown). A lane that is unavailable — missing key, CLI absent, or in cooldown
+after a quota/auth failure — is skipped and the next step in the ``fallback``
+chain takes over (OI-1185). Missing key and cooldown follow the SAME chain: the
+availability layer is the single gate, so there is no separate "missing key"
+branch. The chain terminates in an ungated lane (claude/codex), so a route is
+always returned.
 
 Constraint references (provider_constraints.yaml):
-  kimi-via-cli-only: Kimi must use lane='kimi_cli', never via=api/moonshot
-  deepseek-harness-subscription-blocked: DEEPSEEK_API_KEY required; subscription-
-    redirect blocked. Allowed only with via=claude_harness_keyed + own key.
-  zai-via-openrouter-only: GLM only via OpenRouter (no direct Zhipu API)
-  deprecated-glm-models: GLM-4.5/4.6/5/5.1 blocked; use glm-5.2 via OpenRouter
+  kimi-via-cli-only: kimi_cli lane, never via=api/moonshot
+  deepseek-harness-subscription-blocked: DEEPSEEK_API_KEY required; own key only
+  zai-via-openrouter-only / deprecated-glm-models: not routed by this static map
 """
 from __future__ import annotations
 
+import dataclasses
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from .cost_tier import TIER_ZERO, TIER_LOW, TIER_MID, TIER_HIGH
+from providers.provider_registry import RegistryLookupError, TierRouteSpec, load_tier_map
+
+from .cost_tier import TIER_HIGH
 
 
 @dataclass(frozen=True)
@@ -55,71 +48,82 @@ class TierRoute:
     reason: Optional[str] = None  # why this route was chosen over its primary
 
 
-def _codex_route(tier: str, reason: Optional[str] = None) -> TierRoute:
-    """Codex vangnet — the last-resort provider lane (OI-940)."""
+# Resolved once at import (ADR-036): a malformed registry raises
+# RegistryLookupError here, before any dispatch reaches the lookup — loud and
+# early rather than discovered mid-dispatch.
+_TIER_MAP = load_tier_map()
+
+
+def _route_from_spec(
+    spec: TierRouteSpec,
+    fallback: Optional[TierRoute],
+    reason: Optional[str] = None,
+) -> TierRoute:
+    from .availability import lane_env_vars  # noqa: PLC0415
+
     return TierRoute(
-        tier=tier,
-        provider="codex",
-        model="gpt-5.5",
-        lane="provider",
+        tier=spec.tier,
+        provider=spec.provider,
+        model=spec.model,
+        lane=spec.lane,
+        env_requirements=lane_env_vars(spec.provider),
+        fallback=fallback,
         reason=reason,
     )
 
 
-def _deepseek_route(tier: str) -> TierRoute:
-    """DeepSeek flash via claude-harness key-auth (deepseek-chat discontinued
-    2026-07-24)."""
-    return TierRoute(
-        tier=tier,
-        provider="deepseek",
-        model="deepseek-v4-flash",
-        lane="claude_harness_keyed",
-        env_requirements=("DEEPSEEK_API_KEY", "CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC"),
-        fallback=_codex_route(tier),
-    )
+def _chain_from_spec(spec: TierRouteSpec) -> TierRoute:
+    """Build the primary + fallback linked chain for a tier spec."""
+    fallback: Optional[TierRoute] = None
+    for step in reversed(spec.fallback):
+        step_spec = TierRouteSpec(
+            tier=spec.tier,
+            provider=step.provider,
+            model=step.model,
+            lane=step.lane,
+            fallback=(),
+        )
+        fallback = _route_from_spec(step_spec, fallback)
+    return _route_from_spec(spec, fallback)
 
 
-def _kimi_route(tier: str, reason: Optional[str] = None) -> TierRoute:
-    """Kimi CLI route (kimi-via-cli-only: never via=api/moonshot).
+def _fallback_reason(route: TierRoute, skipped: list[str]) -> str:
+    return f"{'; '.join(skipped)}; using {route.provider}"
 
-    kimi-k3 is the canonical registry key (kimi_cli.default_model in
-    wave7_models.yaml). Codex remains the vangnet behind it.
+
+def _walk_chain(
+    route: TierRoute,
+    env: dict,
+    state_dir: Optional[Path],
+    now: Optional[float],
+) -> TierRoute:
+    """Walk the fallback chain, skipping unavailable lanes (OI-1185).
+
+    Missing key, CLI absent, and cooldown all funnel through the same
+    ``lane_available`` gate, so they walk the same chain. The terminal lane is
+    ungated (claude/codex), so this always returns a route.
     """
-    return TierRoute(
-        tier=tier,
-        provider="kimi",
-        model="kimi-k3",
-        lane="kimi_cli",
-        fallback=_codex_route(tier),
-        reason=reason,
-    )
+    from .availability import lane_available  # noqa: PLC0415
 
-
-_ROUTE_MID = TierRoute(
-    tier=TIER_MID,
-    provider="claude",
-    model="sonnet-5",  # canonical registry key (wave7_models.yaml)
-    lane="tmux_interactive",
-)
-
-_ROUTE_HIGH = TierRoute(
-    tier=TIER_HIGH,
-    provider="claude",
-    model="opus-5",  # canonical registry key (wave7_models.yaml)
-    lane="tmux_interactive",
-)
-
-
-def _deepseek_has_key(env: dict) -> bool:
-    """True when DEEPSEEK_API_KEY is present (static check, no cooldown).
-
-    Kept separate from the full availability check so the missing-key case
-    preserves the pre-existing behaviour (codex fallback, kimi NOT consulted)
-    while the key-present-but-in-cooldown case can fall through to kimi.
-    Implements deepseek-harness-subscription-blocked: own key + hardening
-    required; routing through the production OAuth subscription is blocked.
-    """
-    return bool(env.get("DEEPSEEK_API_KEY"))
+    current: Optional[TierRoute] = route
+    last = route
+    skipped: list[str] = []
+    while current is not None:
+        last = current
+        ok, reason = lane_available(
+            current.provider, env=env, state_dir=state_dir, now=now,
+        )
+        if ok:
+            if skipped:
+                return dataclasses.replace(
+                    current, reason=_fallback_reason(current, skipped),
+                )
+            return current
+        skipped.append(f"{current.provider} unavailable ({reason})")
+        current = current.fallback
+    # Unreachable in practice: every chain terminates in an ungated lane
+    # (claude/codex). Defensive only — the door must never receive None.
+    return last
 
 
 def resolve_tier_route(
@@ -128,57 +132,20 @@ def resolve_tier_route(
     state_dir: Optional[Path] = None,
     now: Optional[float] = None,
 ) -> TierRoute:
-    """Resolve a cost tier to a TierRoute.
+    """Resolve a cost tier to a TierRoute, walking the fallback chain.
 
-    Entry tiers (zero/low) prefer DeepSeek claude-harness when DEEPSEEK_API_KEY
-    is present; a missing key falls back to Codex (existing behaviour). When
-    DeepSeek has a key but is in cooldown after a quota/auth failure, the router
-    falls back to Kimi CLI (kimi-via-cli-only) and then Codex — availability is
-    read at decision time so a restored lane rejoins without a release. Unknown
-    tier strings default to tier-high.
+    Entry tiers (zero/low) prefer DeepSeek claude-harness; an unavailable lane
+    (missing DEEPSEEK_API_KEY, CLI absent, or cooldown) is skipped and the next
+    chain step takes over (Kimi CLI, then Codex). Availability is read at
+    decision time so a restored lane rejoins without a release. Unknown tier
+    strings default to tier-high (safe over silent skip).
     """
     _env = env if env is not None else dict(os.environ)
 
-    if tier in (TIER_ZERO, TIER_LOW):
-        return _resolve_entry_tier_route(tier, _env, state_dir, now)
-
-    if tier == TIER_MID:
-        return _ROUTE_MID
-
-    return _ROUTE_HIGH
-
-
-def _resolve_entry_tier_route(
-    tier: str,
-    env: dict,
-    state_dir: Optional[Path],
-    now: Optional[float],
-) -> TierRoute:
-    from .availability import lane_available  # noqa: PLC0415
-
-    deepseek_ok, deepseek_reason = lane_available(
-        "deepseek", env=env, state_dir=state_dir, now=now,
-    )
-    if deepseek_ok:
-        return _deepseek_route(tier)
-
-    if _deepseek_has_key(env):
-        # Key present but DeepSeek is in cooldown → try Kimi before the vangnet.
-        kimi_ok, kimi_reason = lane_available(
-            "kimi", env=env, state_dir=state_dir, now=now,
+    spec = _TIER_MAP.get(tier) or _TIER_MAP.get(TIER_HIGH)
+    if spec is None:
+        raise RegistryLookupError(
+            f"tier {tier!r} (and the tier-high default) is missing from "
+            "routing.tier_map in the registry"
         )
-        if kimi_ok:
-            return _kimi_route(
-                tier,
-                reason=f"deepseek unavailable ({deepseek_reason}); using kimi",
-            )
-        return _codex_route(
-            tier,
-            reason=(
-                f"deepseek unavailable ({deepseek_reason}); "
-                f"kimi unavailable ({kimi_reason}); using codex"
-            ),
-        )
-
-    # Missing key → existing behaviour: Codex vangnet (kimi not consulted).
-    return _codex_route(tier)
+    return _walk_chain(_chain_from_spec(spec), _env, state_dir, now)

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -4,6 +4,10 @@ providers:
   anthropic:
     enabled: true
     api_key_env: ANTHROPIC_API_KEY
+    # dispatch_enum: the dispatch Provider enum value (dispatch_spec.Provider)
+    # this section routes to. ADR-036: provider identity is read from this
+    # registry, never hard-coded in Python on the routing path.
+    dispatch_enum: claude
     models:
       opus:
         litellm_name: "anthropic/claude-opus-4-8"
@@ -91,6 +95,7 @@ providers:
   openai:
     enabled: true
     api_key_env: OPENAI_API_KEY
+    dispatch_enum: codex
     models:
       gpt-5.5:
         litellm_name: "openai/gpt-5.5"
@@ -157,6 +162,7 @@ providers:
   deepseek_harness:
     enabled: true
     api_key_env: DEEPSEEK_API_KEY
+    dispatch_enum: deepseek-harness
     # OI-867: the working DeepSeek route — claude_harness_keyed, uses its own
     # API key via the Anthropic-compatible DeepSeek endpoint.  No proxy.
     models:
@@ -236,6 +242,7 @@ providers:
   local_gemma:
     enabled: true
     api_key_env: ""  # no API key; runs entirely on-device via MLX or Ollama
+    dispatch_enum: local-gemma
     models:
       gemma-4b-local:
         litellm_name: ""  # local only; not via LiteLLM
@@ -258,6 +265,7 @@ providers:
   kimi_cli:
     enabled: true
     api_key_env: ""  # no API key; OAuth via `kimi login`
+    dispatch_enum: kimi
     # WS1 (20260721-kimi-lane-hardening): explicit default, independent of YAML key
     # order — _resolve_kimi_model_label() reads this flag rather than "first dict key".
     default_model: kimi-k3
@@ -311,3 +319,47 @@ providers:
         # through — disabled here so the pre-flight registry check rejects it instead of a
         # worker silently receiving a dead `-m` string.
         dispatch_allowed: false
+
+# ---------------------------------------------------------------------------
+# Static router tier map (ADR-036) — model identity + provider strings for the
+# cost-tier router (tier_routing.py) are read from this block, never from Python
+# literals. `provider` names a registry section key above; `model` names a model
+# key under that section; `lane` is the dispatch lane. `fallback` is the ordered
+# chain the tier router walks when a lane is unavailable at decision time
+# (missing key / CLI absent / cooldown — OI-1185: all three causes walk the same
+# chain). provider_registry.load_tier_map() validates every reference and raises
+# RegistryLookupError (naming what+where) on anything this registry does not
+# know.
+# ---------------------------------------------------------------------------
+routing:
+  tier_map:
+    tier-zero:
+      provider: deepseek_harness
+      model: deepseek-v4-flash
+      lane: claude_harness_keyed
+      fallback:
+        - provider: kimi_cli
+          model: kimi-k3
+          lane: kimi_cli
+        - provider: openai
+          model: gpt-5.5
+          lane: provider
+    tier-low:
+      provider: deepseek_harness
+      model: deepseek-v4-flash
+      lane: claude_harness_keyed
+      fallback:
+        - provider: kimi_cli
+          model: kimi-k3
+          lane: kimi_cli
+        - provider: openai
+          model: gpt-5.5
+          lane: provider
+    tier-mid:
+      provider: anthropic
+      model: sonnet-5
+      lane: tmux_interactive
+    tier-high:
+      provider: anthropic
+      model: opus-5
+      lane: tmux_interactive

--- a/tests/smart_router/test_availability.py
+++ b/tests/smart_router/test_availability.py
@@ -1,10 +1,12 @@
-"""Tests for the smart-router availability + cooldown layer (dispatch-20260814a).
+"""Tests for the smart-router availability + cooldown layer.
 
 Covers:
 - decision-time gates: env vars, CLI presence, disabled lanes, unknown lanes
 - cooldown lifecycle: record → active → re-engage after the period
-- cooldown duration sourced from the incident taxonomy (PROVIDER_OUTAGE),
-  no own duration/backoff/override math (OI-1188)
+- per-class cooldown (OI-1185): a 429 cools down in seconds, an exhausted
+  quota in hours, and an auth failure never auto-recovers
+- cooldown duration sourced from the incident taxonomy (single clock,
+  OI-1188), no own duration/backoff/override math
 - fail-open: corrupt cooldown state reads as not-in-cooldown; best-effort
   record_lane_failure never raises
 """
@@ -39,13 +41,13 @@ def state_dir(tmp_path):
 class TestLaneGates:
 
     def test_deepseek_requires_env_var(self, state_dir):
-        ok, reason = lane_available("deepseek", env={}, state_dir=state_dir)
+        ok, reason = lane_available("deepseek-harness", env={}, state_dir=state_dir)
         assert ok is False
         assert "DEEPSEEK_API_KEY" in reason
 
     def test_deepseek_available_with_key(self, state_dir):
         ok, _ = lane_available(
-            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir,
+            "deepseek-harness", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir,
         )
         assert ok is True
 
@@ -87,26 +89,60 @@ class TestCooldownLifecycle:
     def test_record_then_remaining_then_reengage(self, state_dir):
         now = 1_000.0
         record_lane_failure(
-            "deepseek", "429 quota-exhausted", state_dir=state_dir,
+            "deepseek-harness", "quota exhausted", state_dir=state_dir,
             now=now,
         )
-        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now) == pytest.approx(3600.0)
-        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=now + 3600) == 0.0
+        assert lane_cooldown_remaining("deepseek-harness", state_dir=state_dir, now=now) == pytest.approx(3600.0)
+        assert lane_cooldown_remaining("deepseek-harness", state_dir=state_dir, now=now + 3600) == 0.0
 
     def test_lane_available_respects_cooldown(self, state_dir):
         now = 2_000.0
         record_lane_failure(
-            "deepseek", "403 auth", state_dir=state_dir, now=now,
+            "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
         )
         ok, reason = lane_available(
-            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+            "deepseek-harness", env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
         )
         assert ok is False
         assert "cooldown" in reason
 
         ok, _ = lane_available(
-            "deepseek", env={"DEEPSEEK_API_KEY": "sk-test"},
+            "deepseek-harness", env={"DEEPSEEK_API_KEY": "sk-test"},
             state_dir=state_dir, now=now + 3601,
+        )
+        assert ok is True
+
+    def test_auth_failure_never_auto_recovers(self, state_dir):
+        """An auth failure (403) is non-recoverable: waiting past the quota
+        window does NOT bring the lane back (operator intervention required)."""
+        now = 2_500.0
+        record_lane_failure(
+            "deepseek-harness", "403 auth", state_dir=state_dir, now=now,
+        )
+        assert lane_cooldown_remaining(
+            "deepseek-harness", state_dir=state_dir, now=now,
+        ) == float("inf")
+
+        # Even far in the future the lane stays out — an expired key does not
+        # improve by waiting (OI-1185).
+        ok, _ = lane_available(
+            "deepseek-harness", env={"DEEPSEEK_API_KEY": "sk-test"},
+            state_dir=state_dir, now=now + 999_999,
+        )
+        assert ok is False
+
+    def test_rate_limit_recovers_in_seconds(self, state_dir):
+        """A 429 cools down in seconds and the lane re-engages on its own."""
+        now = 3_500.0
+        record_lane_failure(
+            "deepseek-harness", "429 too many requests", state_dir=state_dir, now=now,
+        )
+        assert lane_cooldown_remaining(
+            "deepseek-harness", state_dir=state_dir, now=now,
+        ) == pytest.approx(60.0)
+        ok, _ = lane_available(
+            "deepseek-harness", env={"DEEPSEEK_API_KEY": "sk-test"},
+            state_dir=state_dir, now=now + 61,
         )
         assert ok is True
 
@@ -122,27 +158,44 @@ class TestCooldownLifecycle:
         data = json.loads(cooldown_file.read_text(encoding="utf-8"))
         assert data["lane"] == "kimi"
         assert data["until"] == pytest.approx(now + 3600)
+        assert data["failure_class"] == "provider_quota_exhausted"
+        assert data["recoverable"] is True
 
     def test_no_cooldown_file_means_active(self, state_dir):
-        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=0.0) == 0.0
+        assert lane_cooldown_remaining("deepseek-harness", state_dir=state_dir, now=0.0) == 0.0
 
 
 # ---------------------------------------------------------------------------
-# Cooldown duration config
+# Cooldown duration config (single clock, OI-1188)
 # ---------------------------------------------------------------------------
 
 class TestCooldownSeconds:
 
     def test_delegates_to_incident_taxonomy(self):
         """cooldown_seconds() must lean on the canonical incident taxonomy
-        (PROVIDER_OUTAGE contract), not carry its own duration (OI-1188)."""
+        (PROVIDER_QUOTA_EXHAUSTED default), not carry its own duration (OI-1188)."""
         from incident_taxonomy import IncidentClass, get_cooldown_seconds
 
-        assert cooldown_seconds() == get_cooldown_seconds(IncidentClass.PROVIDER_OUTAGE, 0)
+        assert cooldown_seconds() == get_cooldown_seconds(IncidentClass.PROVIDER_QUOTA_EXHAUSTED, 0)
 
     def test_default_is_one_hour(self):
-        """The PROVIDER_OUTAGE base cooldown is one hour (3600s)."""
+        """The quota-exhausted base cooldown is one hour (3600s)."""
         assert cooldown_seconds() == 3600
+
+    def test_rate_limit_is_seconds(self):
+        from incident_taxonomy import IncidentClass
+
+        assert cooldown_seconds(IncidentClass.PROVIDER_RATE_LIMIT) == 60
+
+    def test_quota_is_hours(self):
+        from incident_taxonomy import IncidentClass
+
+        assert cooldown_seconds(IncidentClass.PROVIDER_QUOTA_EXHAUSTED) == 3600
+
+    def test_auth_is_zero(self):
+        from incident_taxonomy import IncidentClass
+
+        assert cooldown_seconds(IncidentClass.PROVIDER_AUTH_FAILURE) == 0
 
     def test_no_own_time_arithmetic(self, monkeypatch):
         """cooldown_seconds() returns get_cooldown_seconds verbatim — it does no
@@ -163,7 +216,7 @@ class TestCooldownSeconds:
 
         from incident_taxonomy import IncidentClass
 
-        assert captured["incident_class"] == IncidentClass.PROVIDER_OUTAGE
+        assert captured["incident_class"] == IncidentClass.PROVIDER_QUOTA_EXHAUSTED
         assert captured["retry_count"] == 0
 
 
@@ -176,8 +229,8 @@ class TestFailOpen:
     def test_corrupt_cooldown_state_reads_as_active(self, state_dir):
         cooldown_dir = state_dir / "router_lane_cooldown"
         cooldown_dir.mkdir()
-        (cooldown_dir / "deepseek.json").write_text("{not valid json", encoding="utf-8")
-        assert lane_cooldown_remaining("deepseek", state_dir=state_dir, now=1.0) == 0.0
+        (cooldown_dir / "deepseek-harness.json").write_text("{not valid json", encoding="utf-8")
+        assert lane_cooldown_remaining("deepseek-harness", state_dir=state_dir, now=1.0) == 0.0
 
     def test_record_lane_failure_is_best_effort(self, state_dir):
         # Invalid lane name raises inside the try and must be swallowed.

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -1,7 +1,13 @@
-"""Tests for tier_routing — constraint enforcement and route resolution (PR-2).
+"""Tests for tier_routing — registry-driven routes and fallback-chain walking.
 
-Covers: codex-as-vangnet (OI-940), deepseek-harness-subscription-blocked,
-default-on router (2026-08-02), and route_dispatch() wiring.
+Covers (ADR-036 + OI-1185):
+- model identity and provider strings come from wave7_models.yaml (no Python
+  literals on the routing path); tier-mid/tier-high resolve to claude
+- the fallback chain is walked at decision time: a primary lane that is
+  unavailable (missing key, CLI absent, or cooldown) is skipped and the next
+  step takes over; missing key and cooldown follow the SAME chain
+- codex is the terminal vangnet; claude is the ungated mid/high lane
+- door_routing fails loud (RegistryLookupError) on an unknown provider
 """
 from __future__ import annotations
 
@@ -16,10 +22,24 @@ from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER
 from providers.smart_router.tier_routing import TierRoute, resolve_tier_route
 
 
-def test_tier_zero_uses_codex_when_no_key():
-    """tier-zero without DEEPSEEK_API_KEY falls back to Codex (was local-gemma;
-    local models skipped per operator decision 2026-08-02, pending
-    gemma-4-12b-integration)."""
+def _force_kimi(monkeypatch, present: bool):
+    """Deterministically set the kimi CLI presence on PATH."""
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        _shutil,
+        "which",
+        (lambda name: "/usr/local/bin/kimi") if present else (lambda name: None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Registry-driven provider/model identity (ADR-036)
+# ---------------------------------------------------------------------------
+
+def test_tier_zero_uses_codex_when_no_key_and_no_kimi(monkeypatch):
+    """tier-zero without DEEPSEEK_API_KEY and no kimi CLI falls back to Codex."""
+    _force_kimi(monkeypatch, present=False)
     route = resolve_tier_route(TIER_ZERO, env={})
     assert route.provider == "codex"
     assert route.model == "gpt-5.5"
@@ -30,53 +50,37 @@ def test_tier_zero_uses_deepseek_with_key():
     """tier-zero with DEEPSEEK_API_KEY uses deepseek-v4-flash via claude-harness."""
     env = {"DEEPSEEK_API_KEY": "sk-test-123"}
     route = resolve_tier_route(TIER_ZERO, env=env)
-    assert route.provider == "deepseek"
+    assert route.provider == "deepseek-harness"
     assert route.model == "deepseek-v4-flash"
     assert route.lane == "claude_harness_keyed"
     assert "DEEPSEEK_API_KEY" in route.env_requirements
     assert route.fallback is not None
-    assert route.fallback.provider == "codex"
-    assert route.fallback.model == "gpt-5.5"
-
-
-def test_tier_zero_deepseek_fallback_is_codex():
-    """tier-zero deepseek route's fallback is Codex."""
-    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
-    route = resolve_tier_route(TIER_ZERO, env=env)
-    assert route.fallback is not None
-    assert route.fallback.provider == "codex"
-    assert route.fallback.model == "gpt-5.5"
+    assert route.fallback.provider == "kimi"
+    assert route.fallback.model == "kimi-k3"
+    assert route.fallback.fallback is not None
+    assert route.fallback.fallback.provider == "codex"
+    assert route.fallback.fallback.model == "gpt-5.5"
 
 
 def test_tier_mid_uses_sonnet():
     route = resolve_tier_route(TIER_MID, env={})
     assert route.provider == "claude"
-    # canonical registry key (model-ssot-en-ketenlink) — the old claude-sonnet-4-6
-    # string is not a wave7_models.yaml key and rejected with
-    # model-not-in-current-registry the moment tier-mid actually routes.
     assert route.model == "sonnet-5"
+    assert route.lane == "tmux_interactive"
 
 
 def test_tier_high_uses_opus():
     route = resolve_tier_route(TIER_HIGH, env={})
     assert route.provider == "claude"
-    # canonical registry key — the fleet runs Opus 5 (model-ssot-en-ketenlink).
     assert route.model == "opus-5"
 
 
-def test_tier_low_no_key_uses_codex():
-    """Without DEEPSEEK_API_KEY, both tier-zero and tier-low fall back to Codex
-    (kimi quota exhausted 2026-08-02, OI-940)."""
+def test_tier_low_no_key_no_kimi_uses_codex(monkeypatch):
+    """Without DEEPSEEK_API_KEY and no kimi CLI, tier-low falls back to Codex."""
+    _force_kimi(monkeypatch, present=False)
     route = resolve_tier_route(TIER_LOW, env={})
     assert route.provider == "codex"
     assert route.model == "gpt-5.5"
-    assert route.lane == "provider"
-
-
-def test_tier_low_codex_fallback_is_provider_lane():
-    """Codex vangnet routes via the provider lane (dispatch_envelope.ProviderAdapter)."""
-    route = resolve_tier_route(TIER_LOW, env={})
-    assert route.provider == "codex"
     assert route.lane == "provider"
 
 
@@ -84,35 +88,25 @@ def test_tier_low_with_deepseek_key_uses_harness():
     """With DEEPSEEK_API_KEY, tier-low uses DeepSeek claude_harness_keyed."""
     env = {"DEEPSEEK_API_KEY": "sk-test-123"}
     route = resolve_tier_route(TIER_LOW, env=env)
-    assert route.provider == "deepseek"
+    assert route.provider == "deepseek-harness"
     assert route.lane == "claude_harness_keyed"
     assert "DEEPSEEK_API_KEY" in route.env_requirements
 
 
 def test_tier_low_deepseek_route_uses_v4_flash():
-    """tier-low DeepSeek route must use deepseek-v4-flash — deepseek-chat was
-    discontinued by the provider on 2026-07-24."""
+    """tier-low DeepSeek route must use deepseek-v4-flash."""
     env = {"DEEPSEEK_API_KEY": "sk-test-123"}
     route = resolve_tier_route(TIER_LOW, env=env)
-    assert route.provider == "deepseek"
+    assert route.provider == "deepseek-harness"
     assert route.model == "deepseek-v4-flash"
 
 
-def test_deepseek_harness_blocked_without_key():
-    """Empty DEEPSEEK_API_KEY falls back to Codex (kimi quota exhausted, OI-940)."""
+def test_deepseek_harness_blocked_without_key(monkeypatch):
+    """Empty DEEPSEEK_API_KEY falls back through the chain (kimi absent -> codex)."""
+    _force_kimi(monkeypatch, present=False)
     route = resolve_tier_route(TIER_LOW, env={"DEEPSEEK_API_KEY": ""})
     assert route.provider == "codex"
     assert route.model == "gpt-5.5"
-
-
-def test_deepseek_harness_fallback_is_codex():
-    """DeepSeek harness route's fallback is Codex (was Kimi, OI-940)."""
-    env = {"DEEPSEEK_API_KEY": "sk-test-123"}
-    route = resolve_tier_route(TIER_LOW, env=env)
-    assert route.fallback is not None
-    assert route.fallback.provider == "codex"
-    assert route.fallback.model == "gpt-5.5"
-    assert route.fallback.lane == "provider"
 
 
 def test_unknown_tier_defaults_to_opus():
@@ -122,25 +116,32 @@ def test_unknown_tier_defaults_to_opus():
 
 
 # ---------------------------------------------------------------------------
-# Availability wiring — cooldown drives runtime fallback (Problem 2)
+# Fallback-chain walking — missing key and cooldown share one chain (OI-1185)
 # ---------------------------------------------------------------------------
 
+def test_missing_key_lands_on_kimi_when_kimi_present(monkeypatch):
+    """Missing DEEPSEEK_API_KEY walks the same chain as cooldown: kimi next."""
+    _force_kimi(monkeypatch, present=True)
+    route = resolve_tier_route(TIER_LOW, env={})
+    assert route.provider == "kimi"
+    assert route.model == "kimi-k3"
+    assert route.lane == "kimi_cli"
 
-def test_tier_low_deepseek_cooldown_falls_back_to_kimi(tmp_path, monkeypatch):
-    """DeepSeek in cooldown with a key → Kimi CLI (kimi-via-cli-only) before
-    the Codex vangnet."""
-    import shutil as _shutil
 
+def test_primary_quota_failure_lands_on_fallback(tmp_path, monkeypatch):
+    """Primary lane in quota cooldown -> fallback lane takes over (OI-1185).
+
+    Without the fallback-chain walk this fails: resolve_tier_route would return
+    the primary deepseek-harness route even while it was in cooldown, because
+    nothing walked its ``fallback`` field.
+    """
     from providers.smart_router.availability import record_lane_failure
 
+    _force_kimi(monkeypatch, present=True)
     state_dir = tmp_path / "state"
     now = 1_000_000.0
     record_lane_failure(
-        "deepseek", "429 quota-exhausted", state_dir=state_dir,
-        now=now,
-    )
-    monkeypatch.setattr(
-        _shutil, "which", lambda name: "/usr/local/bin/kimi" if name == "kimi" else None,
+        "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
     )
     route = resolve_tier_route(
         TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
@@ -148,27 +149,71 @@ def test_tier_low_deepseek_cooldown_falls_back_to_kimi(tmp_path, monkeypatch):
     assert route.provider == "kimi"
     assert route.model == "kimi-k3"
     assert route.lane == "kimi_cli"
-    assert "deepseek unavailable" in route.reason
+    assert "deepseek-harness unavailable" in route.reason
+
+
+def test_missing_key_and_cooldown_follow_same_chain(tmp_path, monkeypatch):
+    """Missing key and cooldown both land on kimi — the SAME chain (OI-1185)."""
+    from providers.smart_router.availability import record_lane_failure
+
+    _force_kimi(monkeypatch, present=True)
+    state_dir = tmp_path / "state"
+    now = 5_000_000.0
+    record_lane_failure(
+        "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
+    )
+
+    cooldown_route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+    )
+    missing_key_route = resolve_tier_route(
+        TIER_LOW, env={}, state_dir=state_dir, now=now,
+    )
+
+    assert cooldown_route.provider == "kimi"
+    assert missing_key_route.provider == "kimi"
+    assert cooldown_route.lane == missing_key_route.lane
+    assert cooldown_route.model == missing_key_route.model
+
+
+def test_missing_key_and_cooldown_both_land_on_codex_when_kimi_absent(tmp_path, monkeypatch):
+    """Both causes still share one chain when kimi is absent -> codex vangnet."""
+    from providers.smart_router.availability import record_lane_failure
+
+    _force_kimi(monkeypatch, present=False)
+    state_dir = tmp_path / "state"
+    now = 6_000_000.0
+    record_lane_failure(
+        "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
+    )
+
+    cooldown_route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
+    )
+    missing_key_route = resolve_tier_route(
+        TIER_LOW, env={}, state_dir=state_dir, now=now,
+    )
+
+    assert cooldown_route.provider == "codex"
+    assert missing_key_route.provider == "codex"
 
 
 def test_tier_low_deepseek_cooldown_kimi_unavailable_falls_back_to_codex(tmp_path, monkeypatch):
-    """DeepSeek in cooldown and kimi CLI absent → Codex vangnet, reason visible."""
-    import shutil as _shutil
-
+    """DeepSeek in cooldown and kimi CLI absent -> Codex vangnet, reason visible."""
     from providers.smart_router.availability import record_lane_failure
 
+    _force_kimi(monkeypatch, present=False)
     state_dir = tmp_path / "state"
     now = 2_000_000.0
     record_lane_failure(
-        "deepseek", "403 auth", state_dir=state_dir, now=now,
+        "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
     )
-    monkeypatch.setattr(_shutil, "which", lambda name: None)
     route = resolve_tier_route(
         TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"}, state_dir=state_dir, now=now,
     )
     assert route.provider == "codex"
     assert route.model == "gpt-5.5"
-    assert "deepseek unavailable" in route.reason
+    assert "deepseek-harness unavailable" in route.reason
     assert "kimi unavailable" in route.reason
 
 
@@ -179,15 +224,37 @@ def test_tier_low_deepseek_reengages_after_cooldown(tmp_path):
     state_dir = tmp_path / "state"
     now = 3_000_000.0
     record_lane_failure(
-        "deepseek", "429", state_dir=state_dir, now=now,
+        "deepseek-harness", "quota exhausted", state_dir=state_dir, now=now,
     )
     route = resolve_tier_route(
         TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"},
         state_dir=state_dir, now=now + 3601,
     )
-    assert route.provider == "deepseek"
+    assert route.provider == "deepseek-harness"
     assert route.model == "deepseek-v4-flash"
 
+
+def test_auth_failure_keeps_lane_out_past_waiting(tmp_path, monkeypatch):
+    """An auth failure is non-recoverable: waiting past the quota window does
+    NOT bring the lane back (operator must clear the state)."""
+    from providers.smart_router.availability import record_lane_failure
+
+    _force_kimi(monkeypatch, present=True)
+    state_dir = tmp_path / "state"
+    now = 4_000_000.0
+    record_lane_failure(
+        "deepseek-harness", "403 auth", state_dir=state_dir, now=now,
+    )
+    route = resolve_tier_route(
+        TIER_LOW, env={"DEEPSEEK_API_KEY": "sk-test"},
+        state_dir=state_dir, now=now + 999_999,
+    )
+    assert route.provider == "kimi"
+
+
+# ---------------------------------------------------------------------------
+# route_dispatch wiring
+# ---------------------------------------------------------------------------
 
 def test_route_dispatch_disabled_via_flag():
     """route_dispatch() returns None when VNX_SMART_ROUTER_DISABLE=1."""
@@ -229,7 +296,7 @@ def test_route_dispatch_auto_route_enabled():
 
 
 def test_route_dispatch_high_loc():
-    """route_dispatch() with LOC=350 → tier-high → Opus."""
+    """route_dispatch() with LOC=350 -> tier-high -> Opus."""
     from providers.smart_router import route_dispatch
 
     env = {"VNX_AUTO_ROUTE": "1"}
@@ -243,10 +310,8 @@ def test_route_dispatch_high_loc():
 # door_routing — resolve_door_route / apply_door_route
 # ---------------------------------------------------------------------------
 
-
 def test_door_route_explicit_provider_overrules_router():
-    """An explicit provider+model in the spec must win over the router
-    (worker-provider-free-choice, pin_semantics=default)."""
+    """An explicit provider+model in the spec must win over the router."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import (
         DECLINE_EXPLICIT_PROVIDER,
@@ -305,11 +370,12 @@ def test_door_route_auto_fills_provider():
     assert "tier=tier-low" in reason
 
 
-def test_door_route_auto_fallback_codex():
-    """Without DEEPSEEK_API_KEY, tier-low falls back to codex, not kimi
-    (OI-940 kimi quota exhausted)."""
+def test_door_route_auto_fallback_codex(monkeypatch):
+    """Without DEEPSEEK_API_KEY and no kimi CLI, tier-low falls back to codex."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
+
+    _force_kimi(monkeypatch, present=False)
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -322,7 +388,7 @@ def test_door_route_auto_fallback_codex():
     )
     assert result.route is not None
     provider, model, reason = result.route
-    assert provider == Provider.CODEX, "tier-low without DEEPSEEK_API_KEY must fall back to codex"
+    assert provider == Provider.CODEX, "tier-low without key/kimi must fall back to codex"
     assert model == "gpt-5.5"
     assert "codex" in reason.lower()
 
@@ -347,8 +413,7 @@ def test_door_route_disabled_via_flag():
 
 
 def test_door_route_disabled_via_legacy_flag():
-    """VNX_AUTO_ROUTE=0 (legacy opt-in default-off) also disables, with the
-    same router-disabled reason as the primary kill-switch."""
+    """VNX_AUTO_ROUTE=0 (legacy opt-in default-off) also disables."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import (
         DECLINE_ROUTER_DISABLED,
@@ -366,14 +431,12 @@ def test_door_route_disabled_via_legacy_flag():
     assert result.decline_reason == DECLINE_ROUTER_DISABLED
 
 
-def test_door_route_provider_not_mapped_declines_with_reason(monkeypatch):
-    """A tier route whose provider string has no _TIER_PROVIDER_TO_ENUM entry
-    declines with provider-not-mapped and carries the classified tier (OI-1187)."""
+def test_door_route_unknown_provider_fails_loud(monkeypatch):
+    """A provider string the registry does not know raises RegistryLookupError
+    (ADR-036 §2 fail-loud) — not a silent decline."""
     from dispatch_spec import Provider
-    from providers.smart_router.door_routing import (
-        DECLINE_PROVIDER_NOT_MAPPED,
-        resolve_door_route,
-    )
+    from providers.provider_registry import RegistryLookupError
+    from providers.smart_router.door_routing import resolve_door_route
     from providers.smart_router.tier_routing import TierRoute
     import providers.smart_router.tier_routing as tier_routing_module
 
@@ -385,18 +448,16 @@ def test_door_route_provider_not_mapped_declines_with_reason(monkeypatch):
         ),
     )
 
-    result = resolve_door_route(
-        spec_provider=Provider.AUTO,
-        spec_model=None,
-        target_slot="T1",
-        instruction_text="add a helper function",
-        file_paths=["src/foo.py"],
-        loc_estimate=50,
-        env={},
-    )
-    assert result.route is None
-    assert result.decline_reason == DECLINE_PROVIDER_NOT_MAPPED
-    assert result.tier is not None
+    with pytest.raises(RegistryLookupError):
+        resolve_door_route(
+            spec_provider=Provider.AUTO,
+            spec_model=None,
+            target_slot="T1",
+            instruction_text="add a helper function",
+            file_paths=["src/foo.py"],
+            loc_estimate=50,
+            env={},
+        )
 
 
 def test_door_route_classifier_error_declines_with_reason(monkeypatch):
@@ -433,8 +494,6 @@ def test_door_route_fail_open_on_broken_input():
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
 
-    # Empty instruction text and zero LOC still classifies (tier-zero or tier-low);
-    # the router returns a DoorRouteResult either way, never raises.
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
         spec_model=None,
@@ -488,8 +547,7 @@ def test_door_route_tier_high_resolves_claude():
 
 
 def test_door_route_t0_stays_unrouted_when_mid_tier():
-    """T0 is never routed even when the classifier would land on tier-mid —
-    t0-opus-only is a floor, not an advisory."""
+    """T0 is never routed even when the classifier would land on tier-mid."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import (
         DECLINE_T0_NEVER_ROUTES,

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -3226,13 +3226,14 @@ class TestSmartRouterPreValidate:
     def test_tier_mid_auto_fallback_sets_matching_provider_and_model(self, tmp_path, monkeypatch, capsys):
         """OI-1050 regression: provider=auto classified tier-mid must not dead-end.
 
-        tier_routing.resolve_tier_route(tier-mid) returns provider="claude", which
-        has no entry in door_routing._TIER_PROVIDER_TO_ENUM, so the router declines
-        and run_dispatch's own fallback (the `else` branch right after the router
-        call) sets spec.provider=CLAUDE. Before the fix, that fallback left
-        spec.model=None; downstream, workers-kimi-pinned's "default" pin semantics
-        then filled effective_model from ITS OWN pin (kimi-k3) whenever spec.model
-        was empty — producing a provider=claude/model=kimi-k3 spec that
+        tier_routing.resolve_tier_route(tier-mid) resolves through the registry
+        (ADR-036, wave7_models.yaml routing.tier_map) to provider="claude" /
+        model="sonnet-5", so the router sets both fields together on the spec.
+        Before the enum gap was closed (20260814h), tier-mid could not be mapped
+        to a Provider enum value and the router declined; run_dispatch's fallback
+        then set spec.provider=CLAUDE but left spec.model=None, and workers-kimi-
+        pinned's "default" pin semantics filled effective_model from ITS OWN pin
+        (kimi-k3) — producing a provider=claude/model=kimi-k3 spec that
         kimi-via-cli-only correctly rejects. This exercises the REAL (unmocked)
         build_runtime_snapshot/compile_plan pipeline so the actual constraint
         check runs, not a mock that would hide the mismatch.
@@ -3263,8 +3264,8 @@ class TestSmartRouterPreValidate:
         )
         assert "REJECT" not in captured.out, f"unexpected reject:\n{captured.out}"
         assert "provider:     claude" in captured.out, captured.out
-        assert "model:        sonnet" in captured.out, (
-            f"model must be a claude-compatible default, not left empty for a "
+        assert "model:        sonnet-5" in captured.out, (
+            f"model must be the registry-resolved sonnet-5, not left empty for a "
             f"different provider's pin to fill in:\n{captured.out}"
         )
         assert "lane:         claude_tmux_subscription" in captured.out, (
@@ -3278,9 +3279,8 @@ class TestSmartRouterPreValidate:
         """OI-1050 regression, second trigger: the fallback bug was not tier-mid-
         specific — VNX_SMART_ROUTER_DISABLE=1 makes resolve_door_route return None
         via a different gate, landing on the exact same fallback line. A fix
-        that only special-cased tier-mid (e.g. adding "claude" to
-        _TIER_PROVIDER_TO_ENUM) would leave this path broken; the fallback itself
-        must set provider and model together."""
+        that only special-cased tier-mid in the tier map would leave this path
+        broken; the fallback itself must set provider and model together."""
         data_dir, spec_file = _make_bundle_spec(
             tmp_path,
             instruction_text="# Fix typo in docstring\n\nCorrect a spelling error.\n",

--- a/tests/test_incident_taxonomy.py
+++ b/tests/test_incident_taxonomy.py
@@ -34,6 +34,7 @@ from incident_taxonomy import (
     REPEATED_FAILURE_THRESHOLD,
     RetryBudget,
     Severity,
+    classify_provider_failure,
     get_contract,
     get_cooldown_seconds,
     should_dead_letter,
@@ -65,8 +66,10 @@ class TestCompleteness:
         enum_values = {ic.value for ic in IncidentClass}
         assert INCIDENT_CLASSES == enum_values
 
-    def test_eight_incident_classes(self):
-        assert len(IncidentClass) == 8
+    def test_ten_incident_classes(self):
+        # 8 original classes + the OI-1185 split of PROVIDER_OUTAGE into
+        # rate-limit / quota-exhausted / auth-failure (net +2).
+        assert len(IncidentClass) == 10
 
 
 # ---------------------------------------------------------------------------
@@ -357,6 +360,68 @@ class TestContractProperties:
                 assert has_dl, (
                     f"{ic.value}: dead-letter eligible but DEAD_LETTER_DISPATCH not permitted"
                 )
+
+
+# ---------------------------------------------------------------------------
+# Provider failure classification (OI-1185)
+# ---------------------------------------------------------------------------
+
+class TestProviderFailureClassification:
+    """A lane-failure reason maps to exactly one provider incident class."""
+
+    def test_auth_markers(self):
+        for reason in (
+            "401 unauthorized", "403 forbidden", "invalid api key",
+            "not authenticated", "access denied", "bad credentials",
+            "authentication failed",
+        ):
+            assert classify_provider_failure(reason) == IncidentClass.PROVIDER_AUTH_FAILURE, reason
+
+    def test_rate_limit_markers(self):
+        for reason in (
+            "429 too many requests", "rate limit exceeded",
+            "rate_limit hit", "ratelimited",
+        ):
+            assert classify_provider_failure(reason) == IncidentClass.PROVIDER_RATE_LIMIT, reason
+
+    def test_quota_default(self):
+        for reason in (
+            "quota exhausted", "402 payment required",
+            "insufficient balance", "some unknown failure",
+        ):
+            assert classify_provider_failure(reason) == IncidentClass.PROVIDER_QUOTA_EXHAUSTED, reason
+
+    def test_auth_outranks_rate_limit(self):
+        # "403 rate limited" is an auth failure (expired/revoked key), not a
+        # transient rate limit — most-specific marker wins.
+        assert classify_provider_failure("403 rate limited") == IncidentClass.PROVIDER_AUTH_FAILURE
+
+    def test_none_reason_defaults_to_quota(self):
+        assert classify_provider_failure(None) == IncidentClass.PROVIDER_QUOTA_EXHAUSTED
+
+
+class TestProviderContracts:
+    """OI-1185: the three provider classes carry distinct recovery physics."""
+
+    def test_auth_contract_halts_auto_recovery(self):
+        c = RECOVERY_CONTRACTS[IncidentClass.PROVIDER_AUTH_FAILURE]
+        assert c.escalation.halt_auto_recovery is True
+        assert c.escalation.escalate_to == "operator"
+        assert c.retry_budget.max_retries == 0
+        assert c.retry_budget.cooldown_seconds == 0
+        assert c.default_severity == Severity.ERROR
+
+    def test_rate_limit_contract_is_transient(self):
+        c = RECOVERY_CONTRACTS[IncidentClass.PROVIDER_RATE_LIMIT]
+        assert c.escalation.halt_auto_recovery is False
+        assert c.retry_budget.cooldown_seconds == 60
+        assert c.retry_budget.max_cooldown_seconds == 600
+
+    def test_quota_contract_is_hours(self):
+        c = RECOVERY_CONTRACTS[IncidentClass.PROVIDER_QUOTA_EXHAUSTED]
+        assert c.escalation.halt_auto_recovery is False
+        assert c.retry_budget.cooldown_seconds == 3600
+        assert c.retry_budget.max_cooldown_seconds == 14400
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_lane_calibration_field_test.py
+++ b/tests/test_lane_calibration_field_test.py
@@ -93,13 +93,18 @@ def test_cli_json_output_is_valid():
 
 # ── tier-zero env-branch coverage ───────────────────────────────────────────
 # resolve_tier_route('tier-zero') returns different routes depending on whether
-# DEEPSEEK_API_KEY is in the environment. The calibration corpus pins env={},
-# which exercises the no-key codex fallback. These tests explicitly cover both
-# branches so the route is verified regardless of where the suite runs.
+# DEEPSEEK_API_KEY is in the environment and whether the kimi CLI is on PATH
+# (OI-1185: missing key and cooldown walk the SAME chain). The calibration
+# corpus pins env={} + kimi-absent (see the runner), which exercises the codex
+# terminal vangnet. These tests cover every branch explicitly with kimi mocked
+# so the route is verified regardless of where the suite runs.
 
 
-def test_tier_zero_without_deepseek_key_routes_to_codex():
-    """Without DEEPSEEK_API_KEY, tier-zero -> codex / gpt-5.5 / provider lane."""
+def test_tier_zero_without_deepseek_key_routes_to_codex(monkeypatch):
+    """Without DEEPSEEK_API_KEY and without the kimi CLI, tier-zero -> codex."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: None)
     route = lc.resolve_tier_route("tier-zero", env={})
     assert route.tier == "tier-zero"
     assert route.provider == "codex"
@@ -107,15 +112,32 @@ def test_tier_zero_without_deepseek_key_routes_to_codex():
     assert route.lane == "provider"
 
 
+def test_tier_zero_without_key_but_kimi_present_routes_to_kimi(monkeypatch):
+    """OI-1185: a missing key walks the SAME chain as cooldown — kimi is a
+    regular step before the codex vangnet."""
+    import shutil
+
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/kimi")
+    route = lc.resolve_tier_route("tier-zero", env={})
+    assert route.tier == "tier-zero"
+    assert route.provider == "kimi"
+    assert route.model == "kimi-k3"
+    assert route.lane == "kimi_cli"
+
+
 def test_tier_zero_with_deepseek_key_routes_to_deepseek():
-    """With DEEPSEEK_API_KEY, tier-zero -> deepseek / deepseek-v4-flash / claude_harness_keyed."""
+    """With DEEPSEEK_API_KEY, tier-zero -> deepseek-harness / deepseek-v4-flash / claude_harness_keyed."""
     route = lc.resolve_tier_route("tier-zero", env={"DEEPSEEK_API_KEY": "sk-test"})
     assert route.tier == "tier-zero"
-    assert route.provider == "deepseek"
+    assert route.provider == "deepseek-harness"
     assert route.model == "deepseek-v4-flash"
     assert route.lane == "claude_harness_keyed"
-    # Fallback is codex when the primary deepseek-harness is unavailable.
+    # Fallback chain is kimi then codex (OI-1185: one chain for all causes).
     assert route.fallback is not None
-    assert route.fallback.provider == "codex"
-    assert route.fallback.model == "gpt-5.5"
-    assert route.fallback.lane == "provider"
+    assert route.fallback.provider == "kimi"
+    assert route.fallback.model == "kimi-k3"
+    assert route.fallback.lane == "kimi_cli"
+    assert route.fallback.fallback is not None
+    assert route.fallback.fallback.provider == "codex"
+    assert route.fallback.fallback.model == "gpt-5.5"
+    assert route.fallback.fallback.lane == "provider"


### PR DESCRIPTION
## Summary

Drie clusterpunten in één PR (dispatch `20260814h-a-router-registry-driven`), omdat ze dezelfde twee bestanden raken: de smart-router routing-pad en de incident-taxonomie.

### Punt 8 — nul modelliterals in Python (ADR-036)
Modelidentiteit en provider-strings komen nu uit `wave7_models.yaml` (`routing.tier_map` + `dispatch_enum`). Nul modelnamen/provider-strings als Python-literals op het routing-pad. Een onbekende provider/model faalt luid via `RegistryLookupError` die noemt wat ontbreekt en waar gezocht is (registry-pad). De deur weigert in plaats van een stille `None`. Classifier blijft fail-open; registry-drift is fail-loud — beide zichtbaar gescheiden in `door_routing.py`.

### Punt 2 — terugvalketen wordt nu gelopen (OI-1185)
`TierRoute.fallback` wordt op beslismoment afgelopen: een lane die faalt op quota/auth wordt overgeslagen en de volgende neemt over. Ontbrekende key en cooldown volgen dezelfde keten (één `lane_available`-gate). Test die faalt zonder de fix: primaire lane faalt op quota → dispatch landt op de fallback-lane, voor beide oorzaken (missing key én cooldown).

### Punt 3 — afkoeling per faalklasse (OI-1188)
`PROVIDER_OUTAGE` gesplitst in drie klassen op één klok (`get_cooldown_seconds`):
- `provider_rate_limit` (429) → seconden
- `provider_quota_exhausted` → uren
- `provider_auth_failure` → geen auto-recovery (operator-interventie)

## Verification

- `pytest tests/smart_router/ tests/test_smart_router_wiring.py tests/test_smart_router_multiprovider.py tests/test_incident_taxonomy.py tests/test_incident_log.py` → **225 passed**
- `pytest tests/test_lane_calibration_field_test.py` → **15 passed** (gefixeerd na routing-semantiekwijziging)
- Meting `resolve_door_route` over 684 echte staged bundles (`~/.vnx-data/vnx-dev/dispatches/pending/`, `provider=AUTO` geforceerd, echte `instruction.md`) → **684/684 gerouteerd (100%)**, 0 declines

## Notes

- `lane_calibration` field-test is deterministisch gemaakt (kimi-absent gepind in de runner); de kimi-present-tak is unit-getest in `tests/smart_router/`.
- Niet aangeraakt (parallel-worker-grens): `model_normalizer.py`, `report_to_receipt_converter.py`, `append_receipt_internals/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)