### PR TITLE
fix(skills): lift target-only improvements into skill canon (OI-1195)

### DIFF
--- a/skills/api-developer/SKILL.md
+++ b/skills/api-developer/SKILL.md
@@ -2,6 +2,7 @@
 name: api-developer
 description: API developer specializing in clean, well-documented REST APIs
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite]
+paths: ["scripts/**", "tests/**"]
 ---
 
 # API Developer
@@ -12,7 +13,7 @@ Specialize in clean, well-documented REST APIs with consistent contracts.
 - Define resource model and relationships
 - Design URL structure following REST conventions
 - Implement request/response validation
-- Add comprehensive error handling
+- Add error handling for validation failures, auth errors, not-found, and server faults
 - Generate OpenAPI documentation
 - Write integration tests
 

--- a/skills/architect/SKILL.md
+++ b/skills/architect/SKILL.md
@@ -1,12 +1,14 @@
 ---
 name: architect
-description: System architecture specialist for designing robust, scalable solutions
+description: System architecture specialist for designing scalable solutions that handle complexity and evolve under change
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
+disable-model-invocation: true
+paths: ["claudedocs/**"]
 ---
 
 # System Architect
 
-Design robust, scalable solutions following a three-phase architectural approach.
+Design scalable solutions that handle complexity and evolve under change, following a three-phase architectural approach.
 
 ## Core Responsibilities
 - Analyze existing architectural patterns

--- a/skills/backend-developer/SKILL.md
+++ b/skills/backend-developer/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: backend-developer
-description: Backend developer creating robust, scalable server-side solutions
+description: Backend developer creating fault-tolerant, scalable server-side solutions
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+paths: ["scripts/**", "tests/**"]
 ---
 
 # Backend Developer
 
-Create robust, scalable server-side solutions with focus on reliability and security.
+Create fault-tolerant, scalable server-side solutions with focus on reliability and security.
 
 ## Core Responsibilities
 - Design data models and schemas
@@ -54,6 +55,42 @@ Create robust, scalable server-side solutions with focus on reliability and secu
 - Update API documentation
 - No breaking changes without versioning
 - Follow existing patterns
+
+## Codex Defense Checklist (mandatory before commit)
+
+These patterns recur in codex_gate findings. Apply preemptively.
+
+### File I/O
+- [ ] **Atomic writes**: any rewrite of a persistent file (YAML, NDJSON, JSON config, schema files) MUST write to `<path>.tmp` then `os.replace(tmp, path)`. Never `open(path, 'w')` directly on canonical state.
+- [ ] **fcntl.flock for shared NDJSON**: any read-then-rewrite of an NDJSON file consumed by live appenders MUST acquire `fcntl.flock(fd, fcntl.LOCK_EX)` on the same lock the appenders use. Hold through atomic rename.
+- [ ] **Subprocess stdin writes**: wrap `proc.stdin.write()` in `try: ... except BrokenPipeError: return AdapterResult(status='failed', ...)`. Provider startup-failures must surface as structured failures, not raised exceptions.
+
+### Defensive Reads
+- [ ] **Null guards on string ops**: `(value or '').lower()`, `(value or {}).get(...)`. Especially for fields from external/legacy sources or DB columns that could be NULL.
+- [ ] **Strict-load by default**: parse-and-validate functions auto-validate. If parse-only mode is needed, add `strict=True` keyword and default to `True`.
+- [ ] **Schema version checks**: when loading versioned files, explicitly check version. `if v != EXPECTED: raise UnsupportedVersionError`. No silent accept.
+
+### Cross-cutting Consistency
+- [ ] **Same fix to all handlers**: if the bug exists in Handler A (e.g. `gemini_review`), grep for the equivalent code in Handler B (e.g. `codex_gate`) and apply the same fix. Don't ship asymmetric handlers.
+- [ ] **All call sites use the helper**: when introducing a helper (e.g. `_get_project_id()`), grep for ALL inline equivalents and replace them. Partial migration = silent skip in untouched paths.
+- [ ] **Documented contracts enforced**: if docstring says "raises X on invalid", make sure code actually raises X with a test asserting it. Drift between contract and implementation is a primary codex finding.
+
+### State Stores & Mirroring
+- [ ] **No double-write on cross-store mirror**: before writing to a secondary store, check `if primary_path.resolve() != secondary_path.resolve()`. Required for any dual-write pattern.
+- [ ] **State dir override**: when reading state, derive path from explicit argument, NOT ambient env (`VNX_STATE_DIR`, `_central_state_dir()`). Tests/migrations/debugging must be able to override.
+- [ ] **Idempotency on cross-store writes**: events written to multiple stores need per-event idempotency keys (e.g. `event_id` + `target_store`). Re-runs must not double-write.
+
+### Tests Run Real Code
+- [ ] **Don't reimplement in tests**: a Bash test runs the actual Bash via subprocess; a Python test runs the actual function. Reimplementing the logic in the test = passing tests with broken code.
+- [ ] **Each fix has a regression test**: every bug fixed by this PR has a test that fails before the fix and passes after. Not just unit tests for happy path.
+- [ ] **Negative-path test**: every new function has at least one test for malformed/missing/error input. Crashing > silently-succeeding.
+
+### Worker Convention
+- [ ] **Run pytest before push — TARGETED ONLY**: `pytest <the test files you touched> -x` succeeds. Don't push if any test red.
+- [ ] **NEVER run the full suite.** `pytest tests/` is ~19.400 tests, serial, and takes longer than a dispatch lives. CI Profile A already sweeps the whole tree on every PR — that run has an owner and it is not you. Measured 2026-08-05: three dispatches started a full-suite run before committing, all three died mid-run, and two lost every line of their work (OI-1046). Test what you touched plus its direct neighbours, then commit.
+- [ ] **Commit and push BEFORE any long-running verification.** A pushed branch with a red suite is an ordinary PR state; uncommitted work in a reaped worktree is loss. Order: targeted tests green → commit → push → anything slower.
+- [ ] **`bash -n` on shell changes**: every modified `.sh` file must pass syntax check.
+- [ ] **No TODO/FIXME**: full implementation only. If something's not done, escalate, don't comment.
 
 ## Output Instructions
 See `template.md` for report format and output location.

--- a/skills/data-analyst/SKILL.md
+++ b/skills/data-analyst/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: data-analyst
 description: SEO data analysis, pattern identification, and actionable insights generation
+paths: ["claudedocs/**"]
 ---
 
 # @data-analyst - SEO Data Analysis & Insights Specialist
@@ -21,7 +22,7 @@ Transform raw crawl data into meaningful insights through statistical analysis, 
 1. **Data Collection**
    - Query Supabase for relevant datasets
    - Aggregate metrics across crawls
-   - Join related tables for comprehensive view
+   - Join related tables for a full cross-table view
 
 2. **Statistical Analysis**
    ```python

--- a/skills/database-engineer/SKILL.md
+++ b/skills/database-engineer/SKILL.md
@@ -2,6 +2,7 @@
 name: database-engineer
 description: SQLite database expertise for migrations, multi-tenant patterns, transactional safety, FTS5 virtual tables, and schema evolution. Use this skill for ANY work involving schema changes, data migrations, INSERT/UPSERT semantics, FTS5 rebuilds, transaction rollback design, multi-tenant data isolation, or SQLite performance tuning. Triggers include: writing migration SQL, modifying `_import_table`-style importers, designing UNIQUE/PK constraints, adding indexes for JOINs, debugging "rows missing" / "wrong count" / "stuck for hours" symptoms in SQLite-backed systems.
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+paths: ["schemas/**", "scripts/**", "tests/**"]
 ---
 
 # Database Engineer

--- a/skills/debugger/SKILL.md
+++ b/skills/debugger/SKILL.md
@@ -2,6 +2,7 @@
 name: debugger
 description: Systematic debugging specialist focused on root cause analysis
 allowed-tools: [Read, Grep, Glob, Bash, TodoWrite, Edit]
+paths: ["claudedocs/**", "scripts/**"]
 ---
 
 # Debugger

--- a/skills/excel-reporter/SKILL.md
+++ b/skills/excel-reporter/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: excel-reporter
-description: Comprehensive formatted Excel report generation with Dutch market compatibility
+description: Full-coverage formatted Excel report generation with Dutch market compatibility
+paths: ["claudedocs/**"]
 ---
 
 # @excel-reporter - Excel Report Generation Specialist
 
-You are an Excel Reporter specialized in creating comprehensive, formatted Excel reports from SEOcrawler V2 data with Dutch market compatibility.
+You are an Excel Reporter specialized in creating multi-sheet, formatted Excel reports from SEOcrawler V2 data with Dutch market compatibility.
 
 ## Core Mission
 Transform crawl data into professional Excel reports with charts, formatting, and insights tailored for business stakeholders.

--- a/skills/fabric-reference/SKILL.md
+++ b/skills/fabric-reference/SKILL.md
@@ -86,6 +86,11 @@ vnx horizon plan-gate ...           # multi-model panel reviews a plan before an
 - **`vnx start --help` runs start:** it spawns the daemon set (footgun); SIGKILL the supervisor root if triggered.
 - **Central-mode paths:** embedded-layout path assumptions can break central-mode resolution (fleet burn-in) — resolve via the helpers, never hardcode `.vnx-data/` literals.
 
+### Known issues (tracked, active)
+
+- **An empty provider completion is usually a TRANSIENT lane issue, not a structural door bug:** if `bin/vnx dispatch <id>` for a provider lane (kimi/glm/deepseek) lands an empty completion, check the lane's health FIRST — kimi OAuth/quota, glm proxy on `:4141` — not the envelope. The door's provider path works end-to-end; a blank completion is now downgraded to a loud `failure` (embedding the raw spawn result) for ALL provider spawns as of #1107, and the door surfaces `EnvelopeResult.error` instead of a bare exit code, so the real cause is visible.
+- **The plan-gate panel can score on fewer than 5 seats (`plan-gate-panel-seat-robustness`):** in `plan_gate_panel.py` (NOT the `/panel` skill) the **opus seat NO-VERDICTs reliably** on a `data_dir=None` report-resolution miss (#1102 class: `staging_validator: unstaged dispatch override`), and the codex + glm seats can **intermittently** abstain on unparseable verdict JSON (codex abstained in one round, scored the next). A verdict may rest on as few as 2 seats (kimi + deepseek) or as many as 4 — **confirm the real scoring-seat count in the log before trusting a plan-gate PASS/REVISE**.
+
 ## Where the source of truth lives
 
 - Dispatch mechanics, lanes, failure modes: `docs/core/DISPATCH_RULES.md`

--- a/skills/frontend-developer/SKILL.md
+++ b/skills/frontend-developer/SKILL.md
@@ -2,6 +2,7 @@
 name: frontend-developer
 description: Frontend specialist creating distinctive, production-grade interfaces
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob, WebFetch]
+paths: ["dashboard/**", "tests/**"]
 ---
 
 # Frontend Developer

--- a/skills/intelligence-engineer/SKILL.md
+++ b/skills/intelligence-engineer/SKILL.md
@@ -2,6 +2,7 @@
 name: intelligence-engineer
 description: VNX-specific domain expertise for the intelligence system, central state databases, and dispatch lifecycle. Use when working on quality_intelligence.db / runtime_coordination.db / dispatch_tracker.db, code_snippets FTS5, snippet_metadata linkage, success_patterns / antipatterns, T0 state projection (t0_state.json), intelligence_injections lifecycle, dispatch → receipt → events → archive flow, central state architecture, project_id propagation across VNX, or any code that reads/writes VNX governance state. Triggers include: editing intelligence injection code, querying central DB for cross-project insights, debugging "intelligence not appearing in T0 state", modifying schema in `schemas/quality_intelligence.sql` or `schemas/runtime_coordination_v*.sql`, working with `scripts/quality_db_init.py` or `scripts/lib/coordination_db.py`.
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob]
+paths: ["schemas/**", "scripts/**", "tests/**"]
 ---
 
 # Intelligence Engineer

--- a/skills/monitoring-specialist/SKILL.md
+++ b/skills/monitoring-specialist/SKILL.md
@@ -1,11 +1,12 @@
 ---
 name: monitoring-specialist
 description: System monitoring, alerting, and observability implementation
+paths: ["claudedocs/**", "scripts/**"]
 ---
 
 # @monitoring-specialist - System Monitoring & Observability Expert
 
-You are a Monitoring Specialist focused on implementing comprehensive monitoring, alerting, and observability for the SEOcrawler V2 project.
+You are a Monitoring Specialist focused on implementing metrics collection, alerting, and observability across browser pool, API, and storage layers for the SEOcrawler V2 project.
 
 ## Core Mission
 Ensure system health through proactive monitoring, intelligent alerting, and actionable dashboards that provide real-time insights.

--- a/skills/performance-profiler/SKILL.md
+++ b/skills/performance-profiler/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: performance-profiler
 description: System bottleneck identification, resource optimization, and performance analysis
+paths: ["claudedocs/**"]
 ---
 
 # @performance-profiler - System Performance Analysis Specialist

--- a/skills/planner/SKILL.md
+++ b/skills/planner/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: planner
-description: Planning specialist for PR-based feature breakdown and FEATURE_PLAN.md generation
+description: >
+  Planning specialist that breaks a VNX feature or track into small, independently-shippable
+  PRs with dependencies and per-PR task-class routing. USE THIS when the user wants to break a
+  feature down into PRs, sequence the work, or turn a plan into a PR queue. Delegated to by
+  @horizon (formerly @pm — @pm still resolves via alias). Works from Horizon's tracks DB
+  (`vnx horizon`, alias `vnx objective`); the repo FEATURE_PLAN.md is a generated generic
+  example, not the source.
 allowed-tools: [Read, Write, Edit, Bash, Grep, Glob]
 ---
 

--- a/skills/python-optimizer/SKILL.md
+++ b/skills/python-optimizer/SKILL.md
@@ -2,6 +2,7 @@
 name: python-optimizer
 description: Python code performance optimization specialist
 user-invocable: true
+paths: ["scripts/**", "tests/**"]
 ---
 
 # @python-optimizer - Python Code Performance Optimization Specialist
@@ -14,7 +15,7 @@ Optimize Python code to meet strict performance requirements: <150MB memory usag
 ## Optimization Principles
 - **Memory First**: Prioritize memory efficiency
 - **Algorithmic Efficiency**: O(n) over O(n²)
-- **Pythonic Code**: Leverage Python's strengths
+- **Pythonic Code**: Use Python's built-in features and idioms
 - **Measurable Impact**: Profile before/after
 
 ## Optimization Workflow

--- a/skills/quality-engineer/SKILL.md
+++ b/skills/quality-engineer/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: quality-engineer
-description: Comprehensive quality validation specialist ensuring production readiness through evidence-based testing.
+description: Quality validation specialist covering functional, performance, and security testing to ensure production readiness through evidence-based testing.
 allowed-tools: [Read, Grep, Glob, Bash, Write]
+paths: ["tests/**", "claudedocs/**"]
 ---
 
-# Quality Engineer - Comprehensive Quality Validation Specialist
+# Quality Engineer - Quality Validation Specialist
 
-You are a Quality Engineer specialized in comprehensive quality validation and systematic testing for the SEOcrawler V2 project.
+You are a Quality Engineer specialized in functional, performance, and security validation through systematic testing for the SEOcrawler V2 project.
 
 ## Core Mission
 Ensure production readiness through evidence-based validation. Break everything that can be broken to guarantee system reliability.

--- a/skills/reviewer/SKILL.md
+++ b/skills/reviewer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: reviewer
-description: Senior engineer conducting thorough, constructive code reviews
+description: Senior engineer conducting thorough, constructive code reviews. Round-2+ reviews use adversarial framing to find missed cases and convergent failure modes.
 allowed-tools: [Read, Grep, Glob, Bash, TodoWrite]
+paths: ["claudedocs/**"]
 ---
 
 # Code Reviewer
@@ -75,6 +76,30 @@ Conduct thorough, constructive code reviews with focus on quality and knowledge 
 - Explain the "why" behind feedback
 - Offer alternative approaches
 - Acknowledge good practices
+
+## Adversarial Review Mode
+
+For round-2+ reviews of any PR, switch to adversarial framing:
+
+- **Challenge assumptions** — what does the patch take for granted that may not hold?
+- **Find missed cases** — what edge cases, error paths, or data states are not exercised?
+- **Look for what's NOT there** — what should be in the diff but isn't? (missing tests, missing validation, missing migration step)
+- **Test for invariant coverage** — does the spec or test docstring claim coverage that the test body doesn't enforce? (the "test header lies to itself" pattern from FUT-2A)
+- **Probe the convergence claim** — if the PR says "round-N fixes round-(N-1) findings", verify each finding was actually fixed AND no NEW class of issue was introduced
+
+## When to use adversarial mode
+
+- Mandatory for round-2+ of any PR review
+- Mandatory if prior round found ≥3 blocking findings (B3.1 territory)
+- Mandatory if cumulative blockers across all rounds ≥6 with ≥1 NEW this round (B3.2 territory — see `@t0-orchestrator` §3 B3.2)
+- Optional but recommended for first review of any schema/migration/multi-tenant code
+
+## Convergent failure mode awareness
+
+Always consider: am I patching individual bugs or solving a class?
+If the same bug-class appears in multiple files/lines, recommend architect-reflection instead of fix-forward.
+
+Reference: `claudedocs/FUT-2A-ARCHITECT-REFLECTION-2026-05-29.md` §3 (convergent failure mode pattern).
 
 ## Output Instructions
 

--- a/skills/security-engineer/SKILL.md
+++ b/skills/security-engineer/SKILL.md
@@ -1,7 +1,8 @@
 ---
 name: security-engineer
-description: SEOcrawler security vulnerability scanner and hardening specialist for comprehensive security audits.
+description: SEOcrawler security vulnerability scanner and hardening specialist covering code analysis, dependency audits, and infrastructure review.
 allowed-tools: [Read, Grep, Glob, Bash]
+paths: ["claudedocs/**"]
 ---
 
 # Security Engineer - SEOcrawler Vulnerability Scanner
@@ -9,7 +10,7 @@ allowed-tools: [Read, Grep, Glob, Bash]
 You are a Security Engineer specialized in vulnerability assessment and security hardening for the SEOcrawler V2 project.
 
 ## Core Mission
-Conduct comprehensive security audits to identify and remediate vulnerabilities before they can be exploited.
+Identify and remediate vulnerabilities across code, dependencies, and infrastructure before they can be exploited.
 
 ## Vulnerability Scanning Focus Areas
 
@@ -69,7 +70,7 @@ Skipping STEP 0 is a process violation, not a shortcut. The FUT-1 chain (2026-05
 Generate report: `.claude/vnx-system/security_reports/SECURITY_AUDIT_[date].md`
 
 ## When Activated
-- Run comprehensive security scan of entire codebase
+- Scan entire codebase for vulnerabilities across code, deps, and infrastructure
 - Focus on production-critical paths first
 - Check recent commits for new vulnerabilities
 - Verify all external dependencies are secure

--- a/skills/supabase-expert/SKILL.md
+++ b/skills/supabase-expert/SKILL.md
@@ -2,6 +2,7 @@
 name: supabase-expert
 description: Supabase database optimization specialist
 user-invocable: true
+paths: ["schemas/**", "scripts/**"]
 ---
 
 # @supabase-expert - Supabase Database Optimization Specialist

--- a/skills/test-engineer/SKILL.md
+++ b/skills/test-engineer/SKILL.md
@@ -1,12 +1,13 @@
 ---
 name: test-engineer
-description: Test engineer ensuring quality through comprehensive testing strategies
+description: Test engineer ensuring quality through unit, integration, and E2E testing strategies
 allowed-tools: [Read, Write, Edit, MultiEdit, Bash, Grep, Glob, TodoWrite]
+paths: ["tests/**"]
 ---
 
 # Test Engineer
 
-Ensure quality through comprehensive testing strategies and risk-based test planning.
+Ensure quality through unit, integration, and E2E test coverage with risk-based test planning.
 
 ## Core Responsibilities
 - Analyze requirements for testability

--- a/skills/vnx-manager/SKILL.md
+++ b/skills/vnx-manager/SKILL.md
@@ -2,6 +2,7 @@
 name: vnx-manager
 description: VNX orchestration infrastructure guardian - maintains dispatcher, smart tap, receipt processor, intelligence systems, and documentation.
 allowed-tools: [Read, Write, Edit, Grep, Glob, Bash]
+paths: ["scripts/**", ".vnx/**", "claudedocs/**"]
 ---
 
 # VNX System Manager


### PR DESCRIPTION
## OI-1195 — skill-drift hersteld: doelwit-inhoud naar de canon

**Blocker.** 21 van de 22 skills die zowel een canon (`skills/`) als een doelwit (`.claude/skills/`) hebben waren niet identiek, en de drift liep de verkeerde kant op: het doelwit droeg inhoud die de canon mist. De eerstvolgende `vnx init`/`vnx update` rsyncet de canon eroverheen en wist dat stil.

### Wat er gebeurt in deze PR

Per skill een `diff` gedraaid, richting bepaald, en doelwit-verbeteringen naar de canon getild. Nooit andersom.

**Naar canon getild:**
- `paths:`-frontmatter in 19 skills (governance-grens, geen cosmetiek)
- `disable-model-invocation: true` bij architect
- Codex Defense Checklist (36 regels) bij backend-developer
- Adversarial Review Mode (24 regels) bij reviewer
- Known-issues-blok bij fabric-reference
- multiline-description bij planner
- rijkere descriptions/wordingen elders

**Bewust in canon behouden (canon liep voor, niet overschreven):**
- generiek memory-pad `<your-project>` (doelwit draagt een machine-specifiek githost-lek)
- `example_db` in supabase-expert (doelwit: `seocrawler_db`, project-lek)
- release-docs-regel in vnx-manager (`CHANGELOG.md`/`FEATURE_PLAN.md`; doelwit: `PROJECT_STATUS.md` bestaat niet in deze repo)
- `VNX_STATE_DIR`-wording in fabric-reference
- de skill-activeringsemoji (canon-conventie)
- t0-orchestrator in zijn geheel (vandaag hersteld door #1492)

**Niet aangeraakt:** `.claude/skills/` (geen enkel bestand), de vier doelwit-only skills zonder canon (`control-centre`, `featureplan-kickoff`, `panel`, `pm`).

### Verificatie

- `python3 scripts/validate_skill.py --list` → exit 0 (26 skills)
- `python3 scripts/validate_skill.py --check-disk` → exit 0
- `python3 -m pytest tests/test_skills_sync.py tests/test_vnx_init.py -q` → 43 passed
- `git status` op `.claude/skills/` → leeg
- 4 pre-existing failures in `test_init_migrate_bootstrap.py` (`duplicate column name: decision_ref`, OI-1190-migratie) — bevestigd pre-existing via `git stash`, buiten deze change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)