### PR TITLE
fix(receipts): reject prose model values, resolve kimi-for-coding alias (OI-1194)

### DIFF
--- a/scripts/lib/providers/model_normalizer.py
+++ b/scripts/lib/providers/model_normalizer.py
@@ -13,6 +13,7 @@ Canonical name = the registry key (e.g. ``opus-5``, ``sonnet-5``,
   deepseek/deepseek-v4-pro      -> deepseek-v4-pro
   moonshot/kimi-k2-0905-preview -> kimi-k2-0905-default
   kimi-code/k3                  -> kimi-k3
+  kimi-for-coding               -> kimi-k2-7
   claude-opus-4-8               -> opus-4-8
   claude-opus-5                 -> opus-5
   claude-sonnet-5               -> sonnet-5
@@ -106,9 +107,11 @@ def _build_alias_map() -> Dict[str, str]:
     For every provider/model entry, these aliases resolve to the model key:
       - the registry key itself,
       - the full ``litellm_name`` and ``cli_model_arg`` values,
-      - the part of ``litellm_name`` after the last ``/`` (so
-        ``deepseek/deepseek-v4-pro`` and ``anthropic/claude-opus-4-8`` resolve
-        without knowing the provider prefix).
+      - the part of ``litellm_name`` or ``cli_model_arg`` after the last ``/``
+        (so ``deepseek/deepseek-v4-pro`` and
+        ``anthropic/claude-opus-4-8`` resolve without knowing the provider
+        prefix, and the kimi CLI's ``kimi-code/kimi-for-coding`` resolves to
+        ``kimi-k2-7`` from its bare ``kimi-for-coding`` spelling).
     """
     alias_sets: Dict[str, list] = {}
     for cfg in _load_registry().values():
@@ -125,6 +128,8 @@ def _build_alias_map() -> Dict[str, str]:
             cli_arg = _norm(getattr(entry, "cli_model_arg", "") or "")
             if cli_arg:
                 aliases.add(cli_arg)
+                if "/" in cli_arg:
+                    aliases.add(cli_arg.rsplit("/", 1)[-1])
             for alias in aliases:
                 alias_sets.setdefault(alias, []).append(key_norm)
 

--- a/scripts/report_parser.py
+++ b/scripts/report_parser.py
@@ -19,12 +19,38 @@ from typing import Dict, List, Optional, Any
 from datetime import datetime
 
 
-# OI-1101: model-name shape validation. Real model names (sonnet, opus,
+# OI-1101 + OI-1194: model-name plausibility. Real model names (sonnet, opus,
 # kimi-k3, deepseek-v4-pro, claude-haiku-4-5-20251001) share three properties:
 # no spaces, no backticks, bounded length. The longest known model name across
 # the wave7 registry is claude-haiku-4-5-20251001 (26 chars); 64 gives generous
 # headroom while rejecting prose-sized strings (70+ chars observed in the wild).
+#
+# OI-1194 tightens "plausible" from shape-only to registry-derived: a value that
+# ``providers.model_normalizer.normalize_model_name`` cannot bring to a canonical
+# registry key AND that carries spaces, backticks, or sentence punctuation is
+# documentation text explaining how to write the Model field, not a model name.
 _MODEL_NAME_MAX_LENGTH = 64
+
+# OI-1194: sentence punctuation that never appears in a registry model id. The
+# dot is deliberately excluded: dot-form version numbers (gpt-5.5, glm-5.2,
+# kimi-k2.6) are registry-resolvable and never reach this branch, while a
+# retired dot-form token (kimi-k2.5) is a model-shaped token, not prose.
+_SENTENCE_PUNCT_RE = re.compile(r"[,;:!?()\[\]{}\"']")
+
+
+def _normalize_model_to_canonical(value: str) -> "Optional[str]":
+    """Return the canonical registry key for *value*.
+
+    Returns the canonical key when ``normalize_model_name`` resolves *value*,
+    ``""`` when the normalizer ran but could not resolve it, or ``None`` when
+    the normalizer itself is unavailable (caller falls back to shape-only).
+    """
+    try:
+        from providers.model_normalizer import canonical_model_names, normalize_model_name
+    except Exception:  # vnx-silent-except: normalizer unavailable -> shape-only fallback
+        return None
+    canonical = normalize_model_name(value)
+    return canonical if canonical in canonical_model_names() else ""
 
 
 def _is_inside_inline_code(text: str, pos: int) -> bool:
@@ -41,11 +67,18 @@ def _is_inside_inline_code(text: str, pos: int) -> bool:
     return without_blocks.count('`') % 2 == 1
 
 
-def _is_valid_model_name(value: str) -> bool:
-    """Return True when *value* looks like a real model identifier.
+def _is_plausible_model_name(value: str) -> bool:
+    """Return True when *value* is a plausible model identifier.
 
-    A valid model name contains no spaces, no backticks, is non-empty, and
-    does not exceed ``_MODEL_NAME_MAX_LENGTH`` characters.
+    A model value is plausible when it can be brought to a canonical registry
+    key by ``normalize_model_name``. A value that cannot, and that additionally
+    carries spaces, backticks, or sentence punctuation, is prose (documentation
+    that explains how to write the Model field), not a model name.
+
+    A value the normalizer cannot resolve but that carries none of those
+    markers (e.g. a retired dot-form token like ``kimi-k2.5``) is left alone:
+    it is model-shaped, and the fail-closed check downstream is the caller's
+    problem, not silently rewritten here.
     """
     v = value.strip()
     if not v:
@@ -55,6 +88,11 @@ def _is_valid_model_name(value: str) -> bool:
     if '`' in v:
         return False
     if len(v) > _MODEL_NAME_MAX_LENGTH:
+        return False
+    canonical = _normalize_model_to_canonical(v)
+    if canonical:
+        return True
+    if canonical == "" and _SENTENCE_PUNCT_RE.search(v):
         return False
     return True
 
@@ -282,6 +320,11 @@ class ReportParser:
                     continue
                 if value.lower() in _UNKNOWN_LIKE:
                     continue
+                # OI-1194: frontmatter `model:` must be plausible too — the
+                # bold-field guards below do not run for a frontmatter-only
+                # value, and prose here was accepted verbatim (measured).
+                if key == 'model' and not _is_plausible_model_name(value):
+                    continue
                 metadata[key] = value
 
         # Extract all metadata fields. OI-1101: skip matches inside inline
@@ -293,7 +336,7 @@ class ReportParser:
                 continue
             key = _normalize_meta_key(match.group(1))
             value = match.group(2).strip()
-            if key == 'model' and not _is_valid_model_name(value):
+            if key == 'model' and not _is_plausible_model_name(value):
                 continue
             metadata[key] = value
 
@@ -323,7 +366,7 @@ class ReportParser:
                     _value = m.group(1).strip()
                     if _is_inside_inline_code(content, m.start()):
                         continue
-                    if _key == 'model' and not _is_valid_model_name(_value):
+                    if _key == 'model' and not _is_plausible_model_name(_value):
                         continue
                     metadata[_key] = _value
                     break
@@ -341,7 +384,13 @@ class ReportParser:
             if not str(metadata.get(_key) or '').strip():
                 m = re.search(_pat, content[:3000], re.MULTILINE)
                 if m and m.group(1).strip().lower() not in _UNKNOWN_LIKE:
-                    metadata[_key] = m.group(1).strip()
+                    _plain_value = m.group(1).strip()
+                    # OI-1194: the plain-text `Model:` fallback captures \S+,
+                    # which can still be a backtick/punctuation-wrapped token
+                    # (e.g. `Model: \`sonnet\``); reject prose-shaped values.
+                    if _key == 'model' and not _is_plausible_model_name(_plain_value):
+                        continue
+                    metadata[_key] = _plain_value
 
         # PR #8 Fix: Extract YAML metadata block including dispatch_id
         yaml_match = re.search(r'```yaml\n(.*?)\n```', content[:2000], re.DOTALL)
@@ -353,6 +402,15 @@ class ReportParser:
                     key, value = line.split(':', 1)
                     key = _normalize_meta_key(key)
                     value = value.strip()
+                    if key == 'model':
+                        # OI-1194: a ```yaml block can echo the dispatch
+                        # envelope; its model value must be plausible and must
+                        # never clobber a valid header value already parsed
+                        # (the silent-fallback class PR #1491 removed).
+                        if str(metadata.get(key) or '').strip():
+                            continue
+                        if not _is_plausible_model_name(value):
+                            continue
                     metadata[key] = value
 
         # Dispatch assignment table fallback:

--- a/tests/test_model_ssot_and_chainlink.py
+++ b/tests/test_model_ssot_and_chainlink.py
@@ -57,6 +57,10 @@ class TestNormalizeModelName:
             ("moonshot/kimi-k2-0905-preview", "kimi-k2-0905-default"),
             ("kimi-code/k3", "kimi-k3"),
             ("kimi-k3", "kimi-k3"),
+            # OI-1194: the kimi CLI's own cli_model_arg spelling and its
+            # provider-prefix-stripped form both resolve to the kimi-k2-7 key.
+            ("kimi-code/kimi-for-coding", "kimi-k2-7"),
+            ("kimi-for-coding", "kimi-k2-7"),
             # 5-series + Fable (added to the registry by this dispatch).
             ("claude-sonnet-5", "sonnet-5"),
             ("claude-opus-5", "opus-5"),
@@ -89,6 +93,13 @@ class TestNormalizeModelName:
 
     def test_unmapped_string_passes_through(self):
         assert normalize_model_name("gpt-4-turbo") == "gpt-4-turbo"
+
+    def test_retired_kimi_spellings_stay_unresolved(self):
+        """OI-1194: the retired dot-form generation and the CLI-output label
+        must NOT be resurrected into the canon via an alias. They pass through
+        unchanged so the caller (routing/validation) can reject them loudly."""
+        assert normalize_model_name("kimi-k2.5") == "kimi-k2.5"
+        assert normalize_model_name("kimi-k2 (Kimi Code CLI)") == "kimi-k2 (Kimi Code CLI)"
 
     def test_unknown_sentinel_passes_through(self):
         assert normalize_model_name("unknown") == "unknown"

--- a/tests/test_report_parser_model_provider.py
+++ b/tests/test_report_parser_model_provider.py
@@ -554,6 +554,182 @@ def test_valid_model_passes_shape_guard(tmp_path):
 
 
 # ---------------------------------------------------------------------------
+# OI-1194: prose model values are rejected (empty field, fail-closed)
+# ---------------------------------------------------------------------------
+
+# The exact prose strings observed in the ledger's `model` field (5 receipts,
+# 3 distinct strings). Each is documentation/instruction text that explains
+# how to write the Model field, captured verbatim by an unguarded extraction
+# path instead of a real model id.
+_PROSE_MODEL_VALUES = [
+    "` / `**Provider**:`.",
+    "sonnet`). Unknown-achtige frontmatter-waarden worden overgeslagen.",
+    "` / `**Provider**:` regel. Zonder die identiteitsregels landt je receipt niet.",
+]
+
+
+def _frontmatter_model_body(model_value: str) -> str:
+    return f"""---
+schema_version: 1
+dispatch_id: 20260814-oi1194-frontmatter-prose
+provider: claude
+model: {model_value}
+---
+
+# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260814-oi1194-frontmatter-prose
+
+## Summary
+A report whose dispatch-envelope frontmatter carries documentation text as
+the model value; the parser must reject it and omit the model key.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+
+
+@pytest.mark.parametrize("prose", _PROSE_MODEL_VALUES)
+def test_frontmatter_prose_model_is_rejected(tmp_path, prose):
+    """The three observed prose strings (5 receipts) lead to an empty model
+    field, never an accepted value. The frontmatter `model:` path is the one
+    that historically accepted prose verbatim (no shape guard)."""
+    r = _parse(tmp_path, _frontmatter_model_body(prose))
+    assert "model" not in r, f"prose model value must be stripped: {prose!r}"
+
+
+_PLAIN_BACKTICK_MODEL_BODY = """# Dispatch 20260814-oi1194-plain-backtick
+
+Dispatch-ID: 20260814-oi1194-plain-backtick
+Provider: claude
+Model: `sonnet`
+Terminal: T1
+
+## Summary
+
+A plain-text header block whose model value is a backtick-wrapped token. The
+parser must reject it, not accept the backtick-bearing string as a model id.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+
+
+def test_plain_header_backtick_model_is_rejected(tmp_path):
+    """The plain-text `Model:` fallback captures \\S+ and previously accepted a
+    backtick-wrapped value without any shape check."""
+    r = _parse(tmp_path, _PLAIN_BACKTICK_MODEL_BODY)
+    assert "model" not in r
+
+
+def test_yaml_block_prose_model_is_rejected(tmp_path):
+    """A ```yaml block that echoes a prose model value must be rejected — the
+    YAML metadata path previously accepted prose without any shape check."""
+    body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260814-oi1194-yaml-prose
+
+```yaml
+model: the real model that ran this dispatch
+provider: claude
+```
+
+## Summary
+A report whose yaml metadata block carries a prose model value; the parser must
+reject it and omit the model key, leaving the fail-closed check to refuse it.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+    r = _parse(tmp_path, body)
+    assert "model" not in r
+
+
+def test_yaml_block_prose_does_not_clobber_valid_header(tmp_path):
+    """A prose model value in a ```yaml block must never clobber a valid header
+    value already parsed — the silent-fallback class PR #1491 removed."""
+    body = """# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260814-oi1194-yaml-clobber
+**Model**: sonnet
+**Provider**: claude
+
+```yaml
+model: the real model that ran this dispatch
+provider: claude
+```
+
+## Summary
+A report whose header carries a real model while a trailing yaml block echoes
+a prose placeholder; the header value must survive.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+    r = _parse(tmp_path, body)
+    assert r["model"] == "sonnet"
+
+
+@pytest.mark.parametrize(
+    "variant",
+    [
+        "deepseek/deepseek-v4-pro",
+        "kimi-code/k3",
+        "claude-sonnet-5",
+        "moonshot/kimi-k2-0905-preview",
+    ],
+)
+def test_resolvable_variant_model_accepted_unharmed(tmp_path, variant):
+    """A provider-prefixed / alias spelling that resolves through the registry
+    must be accepted intact (not rejected as prose by the plausibility guard)."""
+    body = f"""# Completion Report
+**Status**: success
+**Dispatch-ID**: 20260814-oi1194-variant
+**Model**: {variant}
+**Provider**: claude
+
+## Summary
+A report carrying a provider-prefixed model spelling that normalizes to a
+canonical registry key; the plausibility guard must accept it, not reject it.
+
+## Changes
+- none
+
+## Verification
+- none
+
+## Open Items
+None
+"""
+    r = _parse(tmp_path, body)
+    assert r["model"] == variant
+
+
+# ---------------------------------------------------------------------------
 # OI-1102: dispatch register cross-check + cross-processor dedup
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

De laatste tien niet-canonieke modelwaarden in het receipt-grootboek hadden twee scherp gescheiden oorzaken. Deze PR dicht beide.

**Oorzaak 1 — vijf proza-waarden.** Documentatietekst die uitlegt hoe je het Model-veld schrijft, werd gelezen ás het modelveld. De bestaande shape-guard (geen spaties, geen backticks, begrensde lengte) is niet genoeg: de frontmatter-, plain-text-fallback- en ````yaml`-paden accepteerden proza ongemoeid. De plausibility-check is nu registry-afgeleid: een waarde die `normalize_model_name` niet naar een canonieke registry-key kan brengen én spaties, backticks of zinspunctuatie bevat, is geen modelnaam. Die wordt gedropt naar een leeg veld, waarna de bestaande fail-closed check (`_validate_model_present`) zijn werk doet. Geen stille fallback naar een andere waarde (de klasse die PR #1491 verwijderde).

**Oorzaak 2 — vijf kimi-spellingen.** `kimi-for-coding` resolveert naar `kimi-k2-7`: de eigen `cli_model_arg` van de kimi CLI, nu symmetrisch op `/` gesplit zoals `litellm_name` al deed. `kimi-k2.5` (2x) en `kimi-k2 (Kimi Code CLI)` (2x) zijn respectievelijk een geretireerde dot-form generatie en een door de worker geschreven CLI-label met spatie en haakjes. Die blijven ongemapt zodat routing/validatie ze luid afwijst in plaats van een dood model in de canon te reanimeren.

## Changes

- `scripts/lib/providers/model_normalizer.py`: `_build_alias_map` split nu ook `cli_model_arg` op `/`, waardoor `kimi-for-coding` → `kimi-k2-7` (en `k3` → `kimi-k3`) resolveert. Docstring en voorbeelden bijgewerkt.
- `scripts/report_parser.py`: `_is_valid_model_name` hernoemd naar `_is_plausible_model_name` en uitgebreid met de registry-toets (`_normalize_model_to_canonical` + `_SENTENCE_PUNCT_RE`). Toegepast op alle vijf extractiepaden (frontmatter, bold-header-scan, mid-file bold-fallback, plain-text-fallback, ```yaml block). Het ```yaml-pad overschrijft een al geldige header-waarde niet meer.
- `tests/test_model_ssot_and_chainlink.py`: cases voor `kimi-code/kimi-for-coding` en `kimi-for-coding` → `kimi-k2-7`; test dat `kimi-k2.5` en `kimi-k2 (Kimi Code CLI)` ongemapt blijven.
- `tests/test_report_parser_model_provider.py`: proza-afwijzing op alle drie de extractiepaden, geen-clobber op het yaml-pad, en passthrough van resolvende varianten.

## Verification

- Gerichte tests: 87 passed (aangeraakte bestanden + directe buren).
- Downstream converter/receipt-tests: 151 passed.
- Hermeting over `~/.vnx-data/vnx-dev/state/t0_receipts.ndjson`, receipts sinds 2026-08-03 (1656 receipts met model), met `providers.model_normalizer` als toets:
  - **vóór:** 10 niet-canonieke modelwaarden
  - **ná:** 9 (alleen `kimi-for-coding` resolveert; de 5 proza + 2 `kimi-k2.5` + 2 `kimi-k2 (Kimi Code CLI)` blijven correct ongemapt)
- De 5 proza-waarden zijn niet retroactief te meten; die zijn met tests gedekt dat de parser exact die strings afwijst en dat een geldige modelwaarde ongemoeid doorgaat.

## Open Items

- De 5 proza-receipts en de 4 kimi-k2.5/kimi-label-receipts staan al in het grootboek met hun niet-canonieke waarde; history wordt niet herschreven (conform dispatch-instructie).
- De 5416 historische `unknown`-waarden blijven onaangetast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)