### PR TITLE
feat(smart-router): per-tier AUTO-staging with deterministic canary + nulmeting

### DIFF
--- a/docs/core/SUBSYSTEMS.md
+++ b/docs/core/SUBSYSTEMS.md
@@ -15,6 +15,7 @@ This document is the single source of truth for which VNX subsystems are live, p
 | horizon-planning | Autonomous roadmap auto-next loading (starts work unattended). | `VNX_ROADMAP_AUTOPILOT` | LIVE | unknown — no probe yet |
 | headless-dispatch-routing | Headless dispatch routing mode selector. | `VNX_HEADLESS_ROUTING` | LIVE | unknown — no probe yet |
 | central-db-routing | Central-DB read mode for the runtime coordination store (per-project vs central vs shadow). | `VNX_USE_CENTRAL_DB` | LIVE | unknown — no probe yet |
+| smart-router-staging | Phased smart-router AUTO routing rollout (per-tier enable + deterministic canary fraction). | `VNX_SMART_ROUTER_CANARY_PCT` | LIVE | unknown — no probe yet |
 | migration-mechanisms | Schema-evolution surfaces (42 SQL files + 6 appliers). Consolidation PARKed pending inventory-lock. | `VNX_MIGRATION_SYSTEM` | PARK-with-trigger | degraded — 42 SQL files + 6 appliers; consolidation PARKed pending inventory-lock (`scripts/lib/migration_inventory.py`, PR-8) |
 | within-db-tenancy | Composite (project_id, id) keys inside per-project DBs. Removal PARKed pending per-table central-DB safety proof. | — | PARK-with-trigger | degraded — keys present; drop deferred (central-store/dual-write/ADR-026 interaction) |
 | docs-bloat | Comparisons, stale archive, marketing docs inflating docs/ count. | — | CUT | degraded — ~288 markdown files, large `_archive/` |

--- a/scripts/lib/config_registry.py
+++ b/scripts/lib/config_registry.py
@@ -187,6 +187,33 @@ CONFIG_REGISTRY: Dict[str, ConfigEntry] = {
         "migration-consolidation-and-tenancy-cut trigger.",
         writable=False,
         subsystem="migration-mechanisms", status="PARK"),
+
+    # AUTO-staging per tier + canary (dispatch 20260814s-a): phased rollout of
+    # smart-router AUTO routing. Defaults OFF so the rollout starts from zero —
+    # operator-config ramps it up per tier + a deterministic canary fraction.
+    # subsystem is a NEW flag-backed name (disjoint from the flag-less
+    # "provider-routing"), so the cockpit never double-represents one subsystem.
+    "VNX_SMART_ROUTER_TIER_ZERO": _e(
+        "VNX_SMART_ROUTER_TIER_ZERO", "bool", "0", "dispatch",
+        "Route tier-zero (trivial reformat) dispatches through the smart router.",
+        subsystem="smart-router-staging", status="LIVE"),
+    "VNX_SMART_ROUTER_TIER_LOW": _e(
+        "VNX_SMART_ROUTER_TIER_LOW", "bool", "0", "dispatch",
+        "Route tier-low (script edit) dispatches through the smart router.",
+        subsystem="smart-router-staging", status="LIVE"),
+    "VNX_SMART_ROUTER_TIER_MID": _e(
+        "VNX_SMART_ROUTER_TIER_MID", "bool", "0", "dispatch",
+        "Route tier-mid (multi-file/design) dispatches through the smart router.",
+        subsystem="smart-router-staging", status="LIVE"),
+    "VNX_SMART_ROUTER_TIER_HIGH": _e(
+        "VNX_SMART_ROUTER_TIER_HIGH", "bool", "0", "dispatch",
+        "Route tier-high (architectural/security) dispatches through the smart router.",
+        subsystem="smart-router-staging", status="LIVE"),
+    "VNX_SMART_ROUTER_CANARY_PCT": _e(
+        "VNX_SMART_ROUTER_CANARY_PCT", "string", "0", "dispatch",
+        "Canary fraction (0-100) of an enabled tier's traffic routed via the smart "
+        "router; the rest follows the legacy path. Deterministic per dispatch.",
+        subsystem="smart-router-staging", status="LIVE"),
 }
 
 # Flag-LESS subsystems from the cockpit ledger (docs/core/SUBSYSTEMS.md) — kernel/meta subsystems

--- a/scripts/lib/providers/smart_router/door_routing.py
+++ b/scripts/lib/providers/smart_router/door_routing.py
@@ -11,7 +11,11 @@ the existing behaviour — a routing *bug* must never block a dispatch. But an
 unknown provider/model (a provider string the registry does not know) is drift
 between the router and the registry, and raises RegistryLookupError naming what
 was missing and where it was looked for. T0 is never routed (t0-opus-only is a
-floor, not an advisory). The router is default-on since 2026-08-02.
+floor, not an advisory). Routing is gated by the staging layer (``.staging``)
+since 2026-08-14: after the kill-switch, a per-tier enable flag and a
+deterministic canary fraction decide whether the router hands back a route or
+declines to the legacy path — the rollout starts from zero and ramps up via
+operator-config, never in one leap.
 
 Every decline path carries an explicit reason (OI-1187) so a no-route is
 distinguishable in the dry-run output and receipt. Before this, a T0 skip, an
@@ -90,6 +94,7 @@ def resolve_door_route(
     file_paths: Optional[list[str]] = None,
     loc_estimate: int = 0,
     env: Optional[dict] = None,
+    dispatch_id: Optional[str] = None,
 ) -> DoorRouteResult:
     """Resolve a concrete provider + model for a dispatch without an explicit one.
 
@@ -111,6 +116,10 @@ def resolve_door_route(
         file_paths: List of dispatch file paths (for LOC-aware classification).
         loc_estimate: Estimated LOC of the change.
         env: Process environment dict (defaults to os.environ).
+        dispatch_id: The dispatch's stable id, used to seed the deterministic
+            canary bucket when provided; the door call site does not pass it
+            yet, so the fallback is the dispatch's own content (target slot +
+            instruction + paths).
     """
     # Gate 1: T0 never routes. t0-opus-only is a floor, not an advisory.
     if target_slot == "T0":
@@ -147,6 +156,19 @@ def resolve_door_route(
             exc_info=True,
         )
         return DoorRouteResult(decline_reason=DECLINE_CLASSIFIER_ERROR)
+
+    # Staging gate — UNDER the kill-switch (checked above), so a kill-switch
+    # always wins. The rollout is per-tier + a deterministic canary fraction:
+    # a tier that is not enabled, or a dispatch that falls in the control half
+    # of the canary, declines here and follows the legacy path. The decline
+    # reason carries the tier so the control group is recognisable in the trail.
+    from .staging import dispatch_group_key, load_staging_config, staging_verdict  # noqa: PLC0415
+
+    staging_config = load_staging_config()
+    group_key = dispatch_group_key(dispatch_id, target_slot, instruction_text, file_paths)
+    staging_decline = staging_verdict(tier, group_key, staging_config)
+    if staging_decline is not None:
+        return DoorRouteResult(decline_reason=staging_decline, tier=tier)
 
     # Tier routing + provider enum — fail-loud (ADR-036 §2). The classifier
     # worked; an unknown provider/model is registry drift and must surface, not
@@ -198,6 +220,7 @@ def apply_door_route(
         instruction_text=vspec.instruction_text,
         file_paths=file_paths,
         env=_env,
+        dispatch_id=spec.dispatch_id,
     )
     if result.route is None:
         if result.decline_reason is None:

--- a/scripts/lib/providers/smart_router/staging.py
+++ b/scripts/lib/providers/smart_router/staging.py
@@ -1,0 +1,149 @@
+"""staging.py — Phased rollout gate for smart-router AUTO routing.
+
+Sits UNDER the kill-switch (``VNX_SMART_ROUTER_DISABLE`` / ``VNX_AUTO_ROUTE``)
+in ``door_routing.resolve_door_route``: the kill-switch always turns the router
+off entirely; this layer decides, per classified cost tier, whether the router
+may actually hand back a route yet. Two knobs, both operator-config
+(``project_config``):
+
+  * per-tier enable flags — ``VNX_SMART_ROUTER_TIER_{ZERO,LOW,MID,HIGH}``. A tier
+    that is not enabled declines, so tier-zero (cheap deepseek) can be rolled
+    out while tier-high (opus, the expensive/heavy lane) stays off.
+  * a canary fraction — ``VNX_SMART_ROUTER_CANARY_PCT`` (0-100). Within an
+    enabled tier only this fraction of dispatches routes; the rest follow the
+    existing (legacy) path. The split is DETERMINISTIC per dispatch, not random
+    per call: a dispatch that is re-evaluated must land in the same group or
+    the canary cannot be compared (``claudedocs`` framework research: a canary
+    without a control group measures selection bias instead of effect).
+
+The control group (canary-out) is recognisable in the trail: the decline reason
+``staging-canary-control:<tier>`` is written into the receipt, so the routed and
+non-routed halves of one tier can be separated later.
+
+Defaults are all OFF (no tier enabled, canary 0): the rollout starts from zero
+and ramps up via operator-config, matching the scout pre-pass opt-in pattern.
+Resolved through ``config_runtime`` so an operator's dashboard/operator-config
+value is honoured — not the code default alone (the scout-prepass pitfall:
+``config_runtime.get_bool()`` without the DB layer lies). Absent any value this
+reads exactly the env/default, so behaviour is preserved.
+"""
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from typing import Optional
+
+from .cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER_ZERO
+
+
+# Canonical tier -> operator-config enable flag. One flag per cost tier so the
+# rollout is independently toggleable (tier-zero on while tier-high off).
+TIER_FLAGS: dict[str, str] = {
+    TIER_ZERO: "VNX_SMART_ROUTER_TIER_ZERO",
+    TIER_LOW: "VNX_SMART_ROUTER_TIER_LOW",
+    TIER_MID: "VNX_SMART_ROUTER_TIER_MID",
+    TIER_HIGH: "VNX_SMART_ROUTER_TIER_HIGH",
+}
+
+CANARY_PCT_KEY = "VNX_SMART_ROUTER_CANARY_PCT"
+
+# Stable decline-reason prefixes (the tier is appended at the call site so a
+# decline is diagnosable per tier in the dry-run output and receipt).
+DECLINE_TIER_DISABLED = "staging-tier-disabled"
+DECLINE_CANARY_CONTROL = "staging-canary-control"
+
+
+@dataclass(frozen=True)
+class StagingConfig:
+    """Resolved staging rollout state for one process/project."""
+
+    enabled_tiers: frozenset[str] = frozenset()
+    canary_pct: int = 0
+
+
+def load_staging_config() -> StagingConfig:
+    """Resolve the staging rollout config through the operator-config facade.
+
+    Reads via ``config_runtime`` so a dashboard/operator-config (project_config)
+    DB value is honoured. Defaults are all OFF; an unparseable canary value
+    fails closed to 0 (routes nothing, never everything).
+    """
+    import config_runtime  # noqa: PLC0415 — lazy; avoid import cost at module load
+
+    enabled = frozenset(
+        tier for tier, key in TIER_FLAGS.items() if config_runtime.get_bool(key)
+    )
+    return StagingConfig(
+        enabled_tiers=enabled,
+        canary_pct=_parse_pct(config_runtime.get(CANARY_PCT_KEY)),
+    )
+
+
+def _parse_pct(raw: Optional[str]) -> int:
+    """Parse a canary percentage, failing closed: an unparseable value routes
+    NOTHING (0), never everything (100)."""
+    if raw is None:
+        return 0
+    try:
+        pct = int(str(raw).strip())
+    except (TypeError, ValueError):
+        return 0
+    if pct < 0:
+        return 0
+    if pct > 100:
+        return 100
+    return pct
+
+
+def dispatch_group_key(
+    dispatch_id: Optional[str],
+    target_slot: str,
+    instruction_text: str,
+    file_paths: Optional[list[str]] = None,
+) -> str:
+    """Stable identity string for a dispatch, used to seed the canary bucket.
+
+    The dispatch_id is the strongest identity when available. The real door call
+    site does not (yet) pass it, so the fallback is the dispatch's own content —
+    target slot + instruction text + file paths — which is immutable for a given
+    dispatch across re-evaluations.
+    """
+    parts = [
+        dispatch_id or "",
+        target_slot or "",
+        instruction_text or "",
+        "\0".join(sorted(file_paths or [])),
+    ]
+    return "\0".join(parts)
+
+
+def canary_bucket(key: str) -> int:
+    """Deterministic bucket in [0, 100) for a dispatch identity string.
+
+    Uses SHA-256, never Python's ``hash()`` — ``hash()`` is salted per process,
+    so a dispatch would fall in a different group on every run and the canary
+    could not be compared across evaluations.
+    """
+    digest = hashlib.sha256(key.encode("utf-8")).digest()
+    value = int.from_bytes(digest[:4], "big")
+    return value % 100
+
+
+def staging_verdict(tier: str, key: str, config: StagingConfig) -> Optional[str]:
+    """Decide whether a classified dispatch may route.
+
+    Returns ``None`` (route) or a decline-reason string (follow the legacy
+    path). Order: (1) the tier must be enabled, (2) the dispatch must fall
+    inside the canary fraction. Either failing declines with a reason that names
+    the tier, so the audit trail separates "tier disabled" from "canary control
+    group".
+    """
+    if tier not in config.enabled_tiers:
+        return f"{DECLINE_TIER_DISABLED}:{tier}"
+    if config.canary_pct <= 0:
+        return f"{DECLINE_CANARY_CONTROL}:{tier}"
+    if config.canary_pct >= 100:
+        return None
+    if canary_bucket(key) < config.canary_pct:
+        return None
+    return f"{DECLINE_CANARY_CONTROL}:{tier}"

--- a/scripts/lib/router_baseline.py
+++ b/scripts/lib/router_baseline.py
@@ -1,0 +1,254 @@
+#!/usr/bin/env python3
+"""router_baseline.py — repeatable nulmeting over the dispatch receipts ledger.
+
+Measures what traffic does WITHOUT the smart router, over the existing receipt
+ledger, so a post-rollout run can be placed next to it and the two compared.
+Not a one-off script and not a number in a markdown file: the same command, run
+against the same data, yields the same output — and the same command run after
+the canary rollout yields the delta.
+
+Usage:
+  python3 scripts/lib/router_baseline.py
+  python3 scripts/lib/router_baseline.py --receipts ~/.vnx-data/vnx-dev/state/t0_receipts.ndjson
+  python3 scripts/lib/router_baseline.py --since 2026-08-03 --json
+
+Window: --since 2026-08-03 (default). Before that the model field is dirty
+(5416 `unknown` values) and poisons every distribution.
+
+Exit codes:
+  0  measurement printed
+  2  fatal (receipts file missing/unreadable, no matching receipts)
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Optional
+
+DEFAULT_RECEIPTS = "~/.vnx-data/vnx-dev/state/t0_receipts.ndjson"
+DEFAULT_SINCE = "2026-08-03"
+
+# Outcome buckets (status -> bucket). The ledger is known to carry exactly
+# these; anything else lands in "other" so a new status cannot silently inflate
+# success or failure.
+_SUCCESS = frozenset({"success", "done"})
+_FAILURE = frozenset({
+    "failed", "failure", "timeout", "contract_invalid",
+    "not_executable", "guard_error",
+})
+
+
+@dataclass
+class BaselineReport:
+    since: str
+    total: int
+    providers: dict[str, int] = field(default_factory=dict)
+    models: dict[str, int] = field(default_factory=dict)
+    outcomes: dict[str, int] = field(default_factory=dict)
+    durations_by_lane: dict[str, dict[str, float]] = field(default_factory=dict)
+
+
+def _norm_ts(ts) -> Optional[str]:
+    """Normalise a receipt timestamp to an ISO-8601 string.
+
+    The ledger mixes string timestamps and epoch numbers; both collapse to the
+    same comparable form so the ``since`` cutoff is correct either way.
+    """
+    if ts is None:
+        return None
+    if isinstance(ts, (int, float)):
+        return datetime.fromtimestamp(ts, timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    return str(ts)
+
+
+def _lane_key(record: dict) -> str:
+    """Grouping key for doorlooptijd.
+
+    The ledger split schema mid-stream: ``task_complete`` receipts carry
+    ``duration_seconds`` + ``provider`` but no ``lane``; ``subprocess_completion``
+    receipts carry ``lane`` but no duration. Group doorlooptijd by lane when
+    present, else by provider, so the duration-carrying receipts land under a
+    meaningful key instead of a shared "?".
+    """
+    return record.get("lane") or record.get("provider") or "?"
+
+
+def load_receipts(path: Path, since: str) -> list[dict]:
+    """Read the NDJSON ledger, keeping receipts with timestamp >= since.
+
+    Unparseable lines are skipped (the ledger is append-only and may carry a
+    torn last write); a missing file raises FileNotFoundError for the CLI.
+    """
+    out: list[dict] = []
+    with path.open("r", encoding="utf-8") as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                record = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            ts = _norm_ts(record.get("timestamp"))
+            if ts and ts >= since:
+                out.append(record)
+    return out
+
+
+def _outcome(status: Optional[str]) -> str:
+    s = (status or "").strip().lower()
+    if s in _SUCCESS:
+        return "success"
+    if s in _FAILURE:
+        return "failed"
+    return "other"
+
+
+def _duration_stats(values: list[float]) -> dict[str, float]:
+    values = sorted(values)
+    n = len(values)
+    p95_idx = min(n - 1, int(n * 0.95))
+    return {
+        "n": n,
+        "mean": round(sum(values) / n, 1),
+        "median": round(values[n // 2] if n % 2 else (values[n // 2 - 1] + values[n // 2]) / 2, 1),
+        "p95": round(values[p95_idx], 1),
+        "min": round(values[0], 1),
+        "max": round(values[-1], 1),
+    }
+
+
+def baseline(records: list[dict], since: str) -> BaselineReport:
+    """Aggregate the nulmeting over a window of receipts (pure, deterministic)."""
+    providers: Counter = Counter()
+    models: Counter = Counter()
+    outcomes: Counter = Counter()
+    durations: dict[str, list[float]] = defaultdict(list)
+
+    for r in records:
+        providers[r.get("provider") or "?"] += 1
+        models[r.get("model") or "?"] += 1
+        outcomes[_outcome(r.get("status"))] += 1
+        d = r.get("duration_seconds")
+        if d is not None:
+            try:
+                durations[_lane_key(r)].append(float(d))
+            except (TypeError, ValueError):
+                continue
+
+    return BaselineReport(
+        since=since,
+        total=len(records),
+        providers=dict(providers),
+        models=dict(models),
+        outcomes=dict(outcomes),
+        durations_by_lane={
+            lane: _duration_stats(vals) for lane, vals in sorted(durations.items())
+        },
+    )
+
+
+def _sorted_items(d: dict) -> list[tuple[str, int]]:
+    # Deterministic ordering: count desc, then name asc — identical every run.
+    return sorted(d.items(), key=lambda kv: (-kv[1], kv[0]))
+
+
+def render(report: BaselineReport) -> str:
+    lines = [
+        "Router baseline — nulmeting over de receipts (zonder smart router)",
+        f"window: >= {report.since} | receipts: {report.total}",
+        "",
+        "Provider distribution:",
+    ]
+    for name, count in _sorted_items(report.providers):
+        lines.append(f"  {name:<30} {count}")
+    lines += ["", "Model distribution:"]
+    for name, count in _sorted_items(report.models):
+        lines.append(f"  {name:<30} {count}")
+    lines += ["", "Outcome distribution (success/fail):"]
+    for bucket in ("success", "failed", "other"):
+        lines.append(f"  {bucket:<30} {report.outcomes.get(bucket, 0)}")
+    lines += ["", "Doorlooptijd (duration_seconds) per lane:"]
+    if not report.durations_by_lane:
+        lines.append("  (no receipts carry duration_seconds in this window)")
+    for lane, stats in report.durations_by_lane.items():
+        lines.append(
+            f"  {lane:<30} n={stats['n']:<5} mean={stats['mean']:>8}s "
+            f"median={stats['median']:>8}s p95={stats['p95']:>8}s "
+            f"min={stats['min']:>6}s max={stats['max']:>8}s"
+        )
+    lines += [
+        "",
+        "note: duration_seconds is recorded on task_complete receipts (provider-",
+        "lane dispatches, no `lane` field); subprocess_completion receipts carry a",
+        "`lane` but no duration. Grouping falls back to provider when lane is absent.",
+    ]
+    return "\n".join(lines)
+
+
+def _as_json(report: BaselineReport) -> str:
+    payload = {
+        "since": report.since,
+        "total": report.total,
+        "providers": dict(_sorted_items(report.providers)),
+        "models": dict(_sorted_items(report.models)),
+        "outcomes": {
+            "success": report.outcomes.get("success", 0),
+            "failed": report.outcomes.get("failed", 0),
+            "other": report.outcomes.get("other", 0),
+        },
+        "durations_by_lane": {
+            lane: report.durations_by_lane[lane]
+            for lane in sorted(report.durations_by_lane)
+        },
+    }
+    return json.dumps(payload, indent=2, sort_keys=True)
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="router_baseline",
+        description="Repeatable nulmeting over the dispatch receipts ledger (pre-rollout baseline).",
+    )
+    parser.add_argument(
+        "--receipts",
+        default=DEFAULT_RECEIPTS,
+        help=f"path to the receipts NDJSON (default: {DEFAULT_RECEIPTS})",
+    )
+    parser.add_argument(
+        "--since",
+        default=DEFAULT_SINCE,
+        help=f"only receipts with timestamp >= this (default: {DEFAULT_SINCE})",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="emit JSON instead of the human-readable table",
+    )
+    args = parser.parse_args(argv)
+
+    path = Path(args.receipts).expanduser()
+    if not path.is_file():
+        print(f"router_baseline: receipts file not found: {path}", file=sys.stderr)
+        return 2
+
+    records = load_receipts(path, args.since)
+    if not records:
+        print(
+            f"router_baseline: no receipts with timestamp >= {args.since} in {path}",
+            file=sys.stderr,
+        )
+        return 2
+
+    report = baseline(records, args.since)
+    print(_as_json(report) if args.json else render(report))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/smart_router/test_staging.py
+++ b/tests/smart_router/test_staging.py
@@ -1,0 +1,148 @@
+"""Tests for smart_router.staging — per-tier rollout + deterministic canary.
+
+Covers (dispatch 20260814s-a):
+- the canary bucket is deterministic per dispatch and stays in [0, 100)
+- a tier that is not enabled declines; an enabled tier at canary 0 declines;
+  canary 100 routes everything; a middle value splits deterministically
+- the config layer resolves through config_runtime (operator-config), defaults
+  all OFF, and an unparseable canary fails closed to 0
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.smart_router import staging as st
+from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER_ZERO
+
+
+@pytest.fixture(autouse=True)
+def _reset_config_state(monkeypatch):
+    """Neutralise config-registry global state so operator-config DB wiring from
+    any other test cannot leak into staging's env/default resolution here."""
+    import config_registry as cr
+    import config_runtime as crt
+
+    cr.set_db_resolver(None)
+    cr.set_default_project_id(None)
+    crt._wired_for.clear()
+    for key in list(st.TIER_FLAGS.values()) + [st.CANARY_PCT_KEY]:
+        monkeypatch.delenv(key, raising=False)
+        monkeypatch.delenv(f"VNX_OVERRIDE_{key[len('VNX_'):]}", raising=False)
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Deterministic canary bucket
+# ---------------------------------------------------------------------------
+
+def test_canary_bucket_is_deterministic_and_in_range():
+    key = "20260814s-a-auto-staging-canary:implement a feature"
+    b1 = st.canary_bucket(key)
+    b2 = st.canary_bucket(key)
+    assert b1 == b2, "same dispatch must fall in the same bucket on re-evaluation"
+    assert 0 <= b1 < 100
+
+
+def test_canary_bucket_spreads_over_the_range():
+    buckets = {st.canary_bucket(f"dispatch-{i}") for i in range(200)}
+    assert len(buckets) > 50, "the hash must spread dispatches across buckets"
+
+
+def test_dispatch_group_key_prefers_dispatch_id():
+    key_a = st.dispatch_group_key("d-1", "T1", "same instruction")
+    key_b = st.dispatch_group_key("d-2", "T1", "same instruction")
+    assert key_a != key_b, "distinct dispatch ids must produce distinct group keys"
+
+
+def test_dispatch_group_key_falls_back_to_content():
+    key_a = st.dispatch_group_key(None, "T1", "add a helper", ["src/foo.py"])
+    key_b = st.dispatch_group_key(None, "T1", "add a helper", ["src/foo.py"])
+    key_c = st.dispatch_group_key(None, "T1", "add a DIFFERENT helper", ["src/foo.py"])
+    assert key_a == key_b, "same content must produce the same key"
+    assert key_a != key_c, "different instruction must produce a different key"
+
+
+# ---------------------------------------------------------------------------
+# staging_verdict
+# ---------------------------------------------------------------------------
+
+def _cfg(tiers=(), pct=0):
+    return st.StagingConfig(enabled_tiers=frozenset(tiers), canary_pct=pct)
+
+
+def test_verdict_tier_disabled_declines():
+    verdict = st.staging_verdict(TIER_ZERO, "some-key", _cfg(tiers=()))
+    assert verdict == f"{st.DECLINE_TIER_DISABLED}:{TIER_ZERO}"
+
+
+def test_verdict_enabled_tier_canary_100_routes():
+    assert st.staging_verdict(TIER_ZERO, "k", _cfg(tiers=(TIER_ZERO,), pct=100)) is None
+
+
+def test_verdict_enabled_tier_canary_0_routes_nothing():
+    verdict = st.staging_verdict(TIER_ZERO, "k", _cfg(tiers=(TIER_ZERO,), pct=0))
+    assert verdict == f"{st.DECLINE_CANARY_CONTROL}:{TIER_ZERO}"
+
+
+def test_verdict_middle_canary_splits_deterministically():
+    config = _cfg(tiers=(TIER_ZERO,), pct=50)
+    routed = [k for k in (f"dispatch-{i}" for i in range(200))
+              if st.staging_verdict(TIER_ZERO, k, config) is None]
+    # Not a flaky assertion on the exact fraction — just that a middle value
+    # routes some and declines some, and a repeat is stable.
+    assert 0 < len(routed) < 200
+    first = st.staging_verdict(TIER_ZERO, "dispatch-42", config)
+    second = st.staging_verdict(TIER_ZERO, "dispatch-42", config)
+    assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Config resolution + parsing
+# ---------------------------------------------------------------------------
+
+def test_load_staging_config_defaults_off():
+    config = st.load_staging_config()
+    assert config.enabled_tiers == frozenset()
+    assert config.canary_pct == 0
+
+
+def test_load_staging_config_honors_env(monkeypatch):
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_HIGH", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "25")
+    config = st.load_staging_config()
+    assert config.enabled_tiers == frozenset({TIER_ZERO, TIER_HIGH})
+    assert config.canary_pct == 25
+
+
+@pytest.mark.parametrize("raw,expected", [
+    (None, 0),
+    ("", 0),
+    ("not-a-number", 0),
+    ("-5", 0),
+    ("0", 0),
+    ("5", 5),
+    ("100", 100),
+    ("150", 100),
+])
+def test_parse_pct_fails_closed(raw, expected):
+    assert st._parse_pct(raw) == expected
+
+
+def test_registry_flags_registered_default_off_with_subsystem():
+    import config_registry as cr
+
+    for tier in (TIER_ZERO, TIER_LOW, TIER_MID, TIER_HIGH):
+        key = st.TIER_FLAGS[tier]
+        entry = cr.CONFIG_REGISTRY[key]
+        assert entry.default == "0", f"{key} must default off (rollout starts from zero)"
+        assert entry.subsystem == "smart-router-staging"
+        assert entry.status == "LIVE"
+    canary = cr.CONFIG_REGISTRY[st.CANARY_PCT_KEY]
+    assert canary.default == "0"
+    assert canary.subsystem == "smart-router-staging"

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -348,11 +348,14 @@ def test_door_route_t0_never_routed():
     assert result.decline_reason == DECLINE_T0_NEVER_ROUTES
 
 
-def test_door_route_auto_fills_provider():
+def test_door_route_auto_fills_provider(monkeypatch):
     """With provider=AUTO and DEEPSEEK_API_KEY present, tier-low resolves to
-    deepseek-harness."""
+    deepseek-harness (when the tier-low staging flag is on at full canary)."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_LOW", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -376,6 +379,8 @@ def test_door_route_auto_fallback_codex(monkeypatch):
     from providers.smart_router.door_routing import resolve_door_route
 
     _force_kimi(monkeypatch, present=False)
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_LOW", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -447,6 +452,8 @@ def test_door_route_unknown_provider_fails_loud(monkeypatch):
             tier=tier, provider="future-provider", model="future-model", lane="provider",
         ),
     )
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_LOW", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
     with pytest.raises(RegistryLookupError):
         resolve_door_route(
@@ -504,10 +511,13 @@ def test_door_route_fail_open_on_broken_input():
     assert result is not None
 
 
-def test_door_route_tier_mid_resolves_claude():
+def test_door_route_tier_mid_resolves_claude(monkeypatch):
     """tier-mid now maps to a concrete Provider.CLAUDE choice (enum-gap fix)."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_MID", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -525,10 +535,13 @@ def test_door_route_tier_mid_resolves_claude():
     assert "tier=tier-mid" in reason
 
 
-def test_door_route_tier_high_resolves_claude():
+def test_door_route_tier_high_resolves_claude(monkeypatch):
     """tier-high maps to Provider.CLAUDE (opus-5), not a silent decline."""
     from dispatch_spec import Provider
     from providers.smart_router.door_routing import resolve_door_route
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_HIGH", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
     result = resolve_door_route(
         spec_provider=Provider.AUTO,
@@ -565,3 +578,137 @@ def test_door_route_t0_stays_unrouted_when_mid_tier():
     )
     assert result.route is None, "T0 must never be routed"
     assert result.decline_reason == DECLINE_T0_NEVER_ROUTES
+
+
+# ---------------------------------------------------------------------------
+# door_routing — AUTO-staging gate (dispatch 20260814s-a)
+# ---------------------------------------------------------------------------
+
+def test_door_route_staging_tier_disabled_declines(monkeypatch):
+    """A classified tier that is not enabled declines, naming the tier."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.staging import DECLINE_TIER_DISABLED
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_HIGH", "1")  # tier-high on, tier-zero off
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=10,
+        env={"DEEPSEEK_API_KEY": "sk-test"},
+    )
+    assert result.route is None
+    assert result.decline_reason == f"{DECLINE_TIER_DISABLED}:tier-zero"
+    assert result.tier == "tier-zero"
+
+
+def test_door_route_staging_tier_on_others_off(monkeypatch):
+    """tier-zero on while tier-high off: the one routes, the other declines."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.staging import DECLINE_TIER_DISABLED
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
+
+    routed = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=10,
+        env={"DEEPSEEK_API_KEY": "sk-test"},
+    )
+    assert routed.route is not None
+    assert routed.tier == "tier-zero"
+
+    declined = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="implement a large feature",
+        file_paths=["src/foo.py"],
+        loc_estimate=350,
+        env={"DEEPSEEK_API_KEY": "sk-test"},
+    )
+    assert declined.route is None
+    assert declined.decline_reason == f"{DECLINE_TIER_DISABLED}:tier-high"
+    assert declined.tier == "tier-high"
+
+
+def test_door_route_canary_zero_routes_nothing(monkeypatch):
+    """An enabled tier at canary 0 declines every dispatch into the control group."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+    from providers.smart_router.staging import DECLINE_CANARY_CONTROL
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "0")
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=10,
+        env={"DEEPSEEK_API_KEY": "sk-test"},
+    )
+    assert result.route is None
+    assert result.decline_reason == f"{DECLINE_CANARY_CONTROL}:tier-zero"
+
+
+def test_door_route_kill_switch_wins_over_staging(monkeypatch):
+    """VNX_SMART_ROUTER_DISABLE wins even when staging is fully open."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import (
+        DECLINE_ROUTER_DISABLED,
+        resolve_door_route,
+    )
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
+
+    result = resolve_door_route(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=10,
+        env={"VNX_SMART_ROUTER_DISABLE": "1"},
+    )
+    assert result.route is None
+    assert result.decline_reason == DECLINE_ROUTER_DISABLED
+
+
+def test_door_route_canary_same_dispatch_same_group(monkeypatch):
+    """The same dispatch re-evaluated falls in the same canary group."""
+    from dispatch_spec import Provider
+    from providers.smart_router.door_routing import resolve_door_route
+
+    monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+    monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "50")
+
+    kwargs = dict(
+        spec_provider=Provider.AUTO,
+        spec_model=None,
+        target_slot="T1",
+        instruction_text="add a helper function",
+        file_paths=["src/foo.py"],
+        loc_estimate=10,
+        env={"DEEPSEEK_API_KEY": "sk-test"},
+    )
+    first = resolve_door_route(**kwargs)
+    second = resolve_door_route(**kwargs)
+    assert (first.route is None) == (second.route is None), (
+        "the same dispatch must fall in the same canary group on re-evaluation"
+    )
+    assert first.decline_reason == second.decline_reason
+    assert first.route == second.route

--- a/tests/test_dispatch_cli.py
+++ b/tests/test_dispatch_cli.py
@@ -3105,6 +3105,11 @@ class TestSmartRouterPreValidate:
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        # AUTO-staging (20260814s-a) defaults every tier OFF: enable tier-zero at
+        # full canary so the router resolves (else it declines and the door falls
+        # back to the claude lane, which this test does not mock).
+        monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+        monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
         with patch("dispatch_cli.build_runtime_snapshot") as mock_snapshot, \
              patch("dispatch_cli.run_envelope_plan") as mock_envelope:
@@ -3165,6 +3170,11 @@ class TestSmartRouterPreValidate:
         data_dir.mkdir(parents=True)
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        # AUTO-staging (20260814s-a) defaults every tier OFF: enable tier-zero at
+        # full canary so the router resolves a real provider (codex vangnet)
+        # instead of declining to the claude fallback this test does not mock.
+        monkeypatch.setenv("VNX_SMART_ROUTER_TIER_ZERO", "1")
+        monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
         # Simulate what dispatch_bridge.stage_spec_bundle does with provider=None.
         from dispatch_bridge import _canonical_provider
@@ -3254,6 +3264,11 @@ class TestSmartRouterPreValidate:
         )
         monkeypatch.setenv("VNX_DATA_DIR", str(data_dir))
         monkeypatch.setenv("VNX_DATA_DIR_EXPLICIT", "1")
+        # AUTO-staging (20260814s-a) defaults every tier OFF: enable tier-mid at
+        # full canary so the router actually resolves (else it declines and the
+        # fallback this test guards against fires).
+        monkeypatch.setenv("VNX_SMART_ROUTER_TIER_MID", "1")
+        monkeypatch.setenv("VNX_SMART_ROUTER_CANARY_PCT", "100")
 
         rc = run_dispatch(spec_file, dry_run=True)
         captured = capsys.readouterr()

--- a/tests/test_router_baseline.py
+++ b/tests/test_router_baseline.py
@@ -1,0 +1,128 @@
+"""Tests for router_baseline — the repeatable pre-rollout nulmeting.
+
+The key property under test: the measurement is a repeatable command, not a
+one-off script — the same data yields the same output every time, so a
+post-rollout run can be placed next to it.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
+
+import router_baseline as rb  # noqa: E402
+
+
+SINCE = "2026-08-03"
+
+
+def _rec(timestamp, provider="claude", model="sonnet", status="success", lane=None,
+         duration=None):
+    r = {
+        "timestamp": timestamp,
+        "provider": provider,
+        "model": model,
+        "status": status,
+    }
+    if lane is not None:
+        r["lane"] = lane
+    if duration is not None:
+        r["duration_seconds"] = duration
+    return r
+
+
+def test_baseline_distributions():
+    records = [
+        _rec("2026-08-04T00:00:00Z", "claude", "sonnet", "success"),
+        _rec("2026-08-04T00:01:00Z", "claude", "sonnet", "failed"),
+        _rec("2026-08-04T00:02:00Z", "deepseek-harness", "deepseek-v4-flash", "done"),
+        _rec("2026-08-04T00:03:00Z", "kimi", "kimi-k3", "unknown"),
+    ]
+    report = rb.baseline(records, SINCE)
+    assert report.total == 4
+    assert report.providers == {"claude": 2, "deepseek-harness": 1, "kimi": 1}
+    assert report.models == {"sonnet": 2, "deepseek-v4-flash": 1, "kimi-k3": 1}
+    assert report.outcomes == {"success": 2, "failed": 1, "other": 1}
+
+
+def test_outcome_buckets_cover_ledger_statuses():
+    records = [
+        _rec("2026-08-04T00:00:00Z", status="success"),
+        _rec("2026-08-04T00:00:00Z", status="done"),
+        _rec("2026-08-04T00:00:00Z", status="failed"),
+        _rec("2026-08-04T00:00:00Z", status="failure"),
+        _rec("2026-08-04T00:00:00Z", status="timeout"),
+        _rec("2026-08-04T00:00:00Z", status="contract_invalid"),
+        _rec("2026-08-04T00:00:00Z", status="not_executable"),
+        _rec("2026-08-04T00:00:00Z", status="guard_error"),
+        _rec("2026-08-04T00:00:00Z", status="requested"),
+        _rec("2026-08-04T00:00:00Z", status=""),
+    ]
+    report = rb.baseline(records, SINCE)
+    assert report.outcomes["success"] == 2
+    assert report.outcomes["failed"] == 6
+    assert report.outcomes["other"] == 2
+
+
+def test_duration_grouping_falls_back_to_provider():
+    records = [
+        _rec("2026-08-04T00:00:00Z", provider="deepseek-harness", duration=10.0),
+        _rec("2026-08-04T00:01:00Z", provider="deepseek-harness", duration=20.0),
+    ]
+    report = rb.baseline(records, SINCE)
+    stats = report.durations_by_lane["deepseek-harness"]
+    assert stats["n"] == 2
+    assert stats["mean"] == 15.0
+    assert stats["min"] == 10.0
+    assert stats["max"] == 20.0
+
+
+def test_baseline_is_deterministic_on_same_data():
+    records = [
+        _rec("2026-08-04T00:00:00Z", "claude", "sonnet", "success", duration=12.3),
+        _rec("2026-08-04T00:01:00Z", "deepseek-harness", "deepseek-v4-flash", "failed"),
+        _rec("2026-08-04T00:02:00Z", "codex", "gpt-5.5", "done", lane="tmux_interactive"),
+    ]
+    first = rb.render(rb.baseline(records, SINCE))
+    second = rb.render(rb.baseline(records, SINCE))
+    assert first == second, "the nulmeting must produce identical output on identical data"
+
+
+def test_load_receipts_cutoff_and_epoch_timestamps(tmp_path):
+    path = tmp_path / "receipts.ndjson"
+    lines = [
+        _rec("2026-08-02T23:59:59Z", provider="claude"),            # before window
+        _rec("2026-08-03T00:00:00Z", provider="claude"),            # boundary (in)
+        _rec(1785715200, provider="deepseek-harness"),              # epoch 2026-08-03T00:00:00Z (in)
+    ]
+    path.write_text("\n".join(json.dumps(r) for r in lines) + "\n", encoding="utf-8")
+    records = rb.load_receipts(path, SINCE)
+    assert len(records) == 2
+
+
+def test_main_json_and_human_outputs(tmp_path, capsys):
+    path = tmp_path / "receipts.ndjson"
+    path.write_text(
+        json.dumps(_rec("2026-08-04T00:00:00Z", "claude", "sonnet", "success")) + "\n",
+        encoding="utf-8",
+    )
+    rc = rb.main(["--receipts", str(path), "--json"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    payload = json.loads(out)
+    assert payload["total"] == 1
+    assert payload["providers"]["claude"] == 1
+
+    rc = rb.main(["--receipts", str(path)])
+    human = capsys.readouterr().out
+    assert rc == 0
+    assert "Provider distribution:" in human
+
+
+def test_main_missing_file_returns_2(tmp_path, capsys):
+    rc = rb.main(["--receipts", str(tmp_path / "nope.ndjson")])
+    assert rc == 2

--- a/vnx_cli/commands/subsystems.py
+++ b/vnx_cli/commands/subsystems.py
@@ -85,6 +85,10 @@ SUBSYSTEM_DESCRIPTIONS: Dict[str, str] = {
         "Central-DB read mode for the runtime coordination store "
         "(per-project vs central vs shadow)."
     ),
+    "smart-router-staging": (
+        "Phased smart-router AUTO routing rollout (per-tier enable + "
+        "deterministic canary fraction)."
+    ),
     "cross-project-federation": "Cross-project intelligence federation (not yet implemented).",
 }
 
@@ -105,6 +109,7 @@ _ROW_ORDER: List[str] = [
     "horizon-planning",
     "headless-dispatch-routing",
     "central-db-routing",
+    "smart-router-staging",
     # PARK-with-trigger / CUT
     "migration-mechanisms",
     "within-db-tenancy",


### PR DESCRIPTION
## Punt 9: AUTO-staging per tier, met canary en een gemeten nulmeting

Phased rollout of smart-router AUTO routing. Three properties, all delivered:

1. **Per-tier rollout** — `VNX_SMART_ROUTER_TIER_{ZERO,LOW,MID,HIGH}` toggle each cost tier independently. tier-zero→deepseek is a different risk class than tier-high→opus; both default OFF.
2. **Deterministic canary** — `VNX_SMART_ROUTER_CANARY_PCT` (0-100) routes that fraction of an *enabled* tier through the router, the rest follows the legacy path. The split is a SHA-256 bucket over a stable dispatch property (dispatch id when available, else instruction+paths+slot) — never `hash()`, never per-call random. The control group is recognisable in the trail: decline reason `staging-canary-control:<tier>` is written to the receipt.
3. **Measured baseline (nulmeting)** — `scripts/lib/router_baseline.py` is a repeatable command over `t0_receipts.ndjson`, windowed `--since 2026-08-03` (the window where the model field is clean). Same data → same output.

### Kill-switch precedence
The staging gate sits **under** `VNX_SMART_ROUTER_DISABLE` / `VNX_AUTO_ROUTE` in `door_routing.resolve_door_route` — the kill-switch always wins. No new kill-switch was added.

### Config
All knobs are operator-config (project_config), registered in `config_registry.py` under a new flag-backed subsystem `smart-router-staging` (disjoint from the flag-less `provider-routing`). Resolved via `config_runtime` (not a code default). Unparseable canary fails closed to 0 (routes nothing, never everything).

### Tests (fail without the fix)
- `tests/smart_router/test_staging.py` — canary determinism/range/spread, tier-disabled/canary-0/canary-100/middle-split, config defaults off + env honored, fail-closed parsing, registry flags default-off.
- `tests/smart_router/test_tier_routing.py` — new door_routing staging tests: tier disabled declines, tier-on-others-off routes one not the other, canary 0 routes nothing, kill-switch wins over staging, same dispatch same group.
- `tests/test_router_baseline.py` — distribution/outcome/duration grouping, determinism on same data, cutoff + epoch timestamps, CLI json/human/missing-file.
- Existing `tests/test_dispatch_cli.py` auto-routing tests updated to enable staging (defaults OFF).

Targeted run: **237 passed** (`test_staging.py`, `test_tier_routing.py`, `test_router_baseline.py`, `test_config_registry.py`, `test_dispatch_cli.py`).

### File boundary
`scripts/lib/dispatch_cli.py` was not touched (parallel dispatch). Consequence: the main door call site (`_resolve_router_pre_validate`) does not yet pass `dispatch_id`, so the canary falls back to content-hash grouping there; `apply_door_route` already passes it. See Open Items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)