### PR TITLE
fix(migrate): make apply_0033 idempotent against version downgrade (OI-1197)

### DIFF
--- a/scripts/lib/migrations/apply_0033.py
+++ b/scripts/lib/migrations/apply_0033.py
@@ -7,7 +7,13 @@ ADR-007: additive column on tracks, whose composite PRIMARY KEY
 (track_id, project_id) already satisfies ADR-007 (migration 0024). No new index
 (decision_ref is read via the existing PK lookup, never queried by its own value).
 
-Idempotent: PRAGMA user_version >= 33 → skip entirely.
+Idempotent: PRAGMA user_version >= 33 → skip entirely, AND the column-existence
+state guard below — a store can carry tracks.decision_ref while user_version < 33
+(reconcile_user_version downgrades a v33 store that fails a manifest invariant,
+then the re-walk leaves the additive column in place). Re-running ALTER TABLE ADD
+COLUMN would raise "duplicate column name: decision_ref", so the guard tests the
+schema STATE, not just the version label.
+
 Atomicity: apply_script_if_below wraps all statements in a SAVEPOINT.
 Applied by: scripts/lib/migrations/auto_apply.py
 """
@@ -23,18 +29,42 @@ _LIB_DIR = Path(__file__).resolve().parent.parent
 if str(_LIB_DIR) not in sys.path:
     sys.path.insert(0, str(_LIB_DIR))
 
-from schema_migration import apply_script_if_below
+from schema_migration import apply_script_if_below, get_user_version
 
 log = logging.getLogger(__name__)
 
 
+def _column_exists(conn: sqlite3.Connection, table: str, column: str) -> bool:
+    """Return True if *column* exists in *table* (via PRAGMA table_info)."""
+    rows = conn.execute(f"PRAGMA table_info('{table}')").fetchall()
+    return any(r[1] == column for r in rows)
+
+
 def apply_migration(db_path: Path, migration_sql_path: Path) -> bool:
-    """Returns True if applied, False if skipped (already at target version)."""
+    """Returns True if applied, False if skipped (already at target version).
+
+    Idempotent against a version downgrade: if tracks.decision_ref is already
+    present but user_version < 33, the ALTER is skipped and only the version
+    stamp is advanced (the schema is already at v33 shape for this column).
+    """
     sql = migration_sql_path.read_text()
 
     conn = sqlite3.connect(str(db_path))
     conn.isolation_level = None  # autocommit — required for SAVEPOINT semantics
     try:
+        if _column_exists(conn, "tracks", "decision_ref"):
+            # State guard (OI-1197): the column is already there. Advance the
+            # version stamp WITHOUT re-running the non-idempotent ALTER TABLE
+            # ADD COLUMN, which would raise "duplicate column name: decision_ref".
+            if get_user_version(conn) < 33:
+                conn.execute("PRAGMA user_version = 33")
+                log.info(
+                    "apply_0033: tracks.decision_ref already present; "
+                    "advanced user_version → 33 (skipped ALTER)"
+                )
+            else:
+                log.debug("apply_0033: already at user_version >= 33; skipped")
+            return False
         applied = apply_script_if_below(conn, 33, sql)
     finally:
         conn.close()

--- a/tests/test_migration_decision_ref.py
+++ b/tests/test_migration_decision_ref.py
@@ -273,3 +273,32 @@ def test_apply_0033_runner_idempotent(tmp_path):
     assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is True
     # Already at user_version >= 33 → skipped, not an error.
     assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is False
+
+
+def test_apply_0033_skips_alter_when_column_present_below_version(tmp_path):
+    """Regression (OI-1197): a store that ALREADY carries tracks.decision_ref but
+    whose user_version was set below 33 (the reconcile_user_version downgrade case,
+    e.g. a v33 store downgraded to 24 then re-walked) must NOT re-run the
+    non-idempotent ALTER TABLE ADD COLUMN — that raises
+    "duplicate column name: decision_ref". The runner advances the version stamp
+    without re-adding the column."""
+    db_path = tmp_path / "runtime_coordination.db"
+    conn = _base_v29_db(tmp_path)
+    _apply_0033(conn)  # add decision_ref + stamp user_version 33
+    conn.close()
+
+    # Simulate the reconcile downgrade: column present, version pushed below 33.
+    conn = sqlite3.connect(str(db_path))
+    conn.execute("PRAGMA user_version = 29")
+    conn.commit()
+    conn.close()
+
+    # Must skip the ALTER (not raise) and converge the version stamp back to 33.
+    assert apply_migration(db_path, _MIGRATIONS / "0033_track_decision_ref.sql") is False
+
+    conn = sqlite3.connect(str(db_path))
+    try:
+        assert "decision_ref" in _cols(conn, "tracks")
+        assert schema_migration.get_user_version(conn) == 33
+    finally:
+        conn.close()


### PR DESCRIPTION
## Blocker OI-1197: `vnx migrate` kapot op main

`vnx migrate` faalt met `rc=1` en `error: future-system migration failed: duplicate column name: decision_ref`. Ingebracht door #1493 (OI-1190), waarvan de CI groen was.

### Oorzaak (gemeten, niet alleen code gelezen)

Reproductie op een verse store:

```
[reconcile] user_version 33 → 24: claimed version failed its manifest; re-walk will re-apply.
first violations: ["dispatches: missing column 'output_ref'", "dispatches: missing column 'output_kind'"]
```

De keten:

1. `_bootstrap_runtime_dbs` roept `auto_apply` aan, dat 0032/0033 toepast (die hebben een runner), maar 0027-0031 **niet** (geen runner). De verse store claimt dus `user_version=33` met `tracks.decision_ref` aanwezig, maar mist `dispatches.output_ref/output_kind` (v27).
2. `reconcile_user_version` ziet die inconsistentie en verlaagt terecht 33 → 24.
3. De numbered walk (0027-0031) herstelt output_ref/output_kind/horizon/etc., maar laat `decision_ref` (additief) staan.
4. `auto_apply` draait 0033 opnieuw: `ALTER TABLE tracks ADD COLUMN decision_ref` → **duplicate column**.

De diagnose "v33-manifest klopt niet voor wat 0033 achterlaat" bleek onjuist: 0033 laat exact achter wat het manifest verwacht (`decision_ref TEXT nullable`). De downgrade wordt getriggerd door de pre-existente bootstrap-gap (auto_apply past 0032/0033 toe terwijl 0027-0031 niet draaien), niet door 0033 zelf. Die gap bestond al bij 0032, maar werd gedragen omdat 0032 `CREATE TABLE IF NOT EXISTS` gebruikt.

### Fix

`apply_0033` toetst nu de schema-**toestand**, niet alleen het `user_version`-label: als `tracks.decision_ref` al bestaat, wordt de `ALTER` overgeslagen en alleen de versiestempel naar 33 gezet.

### CI-dekkingsgat

`tests/test_init_migrate_bootstrap.py` (met `test_migrate_returns_zero`, dat de verse-bootstrap-reproduceert) staat in `scripts/ci/test_exclusions.txt` (regel 117, OI-1133). Daarom ving CI #1493 niet. De door #1493 toegevoegde `test_migration_decision_ref.py` testte alleen 0033 op een v29-store + label-idempotentie, nooit de downgrade-toestand (kolom aanwezig + `user_version < 33`). Die ontbrekende test is nu toegevoegd en staat **niet** in de exclusion-list, dus hij draait mee in CI.

### Verificatie

- Reproductie met uitvoer (zie hierboven).
- `pytest tests/test_init_migrate_bootstrap.py -k migrate`: 32 passed (was 4 failed, 28 passed).
- `pytest tests/test_migration_decision_ref.py`: 13 passed.
- Nieuwe test `test_apply_0033_skips_alter_when_column_present_below_version` faalt zonder de fix met `duplicate column name: decision_ref` en slaagt ermee.

### Open Items

- **Bootstrap-gap (tweede defect, buiten deze PR):** `_bootstrap_runtime_dbs` past via `auto_apply` de runners 0032/0033 toe terwijl 0027-0031 (geen runners) niet draaien. Daardoor claimt elke verse store `user_version=33` met een v24+v32/v33-vorm en forceert `reconcile_user_version` op elke verse `vnx migrate` een overbodige downgrade 33→24 + re-walk. Pre-existent (bestond al bij 0032), nu onschadelijk gemaakt door deze fix. Structurele reparatie: de bootstrap de numbered walk (0027-0031) laten draaien vóór auto_apply, of 0027-0031 runners geven — eigen dispatch waard.
- `tests/migrations/test_auto_apply.py`: 2 pre-existente rood (`no such table: dispatches`), al opgenomen in `test_exclusions.txt`. Niet door deze PR geraakt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)