### PR TITLE
fix(plan-gate): persist resolution_reason when clearing a plan blocker

### DIFF
--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1804,27 +1804,72 @@ def _seed_plan_blocker(state_dir: Path, track_id: str, project_id: str) -> bool:
     return True
 
 
-def _resolve_plan_blocker(state_dir: Path, track_id: str, project_id: str) -> bool:
-    """Resolve the OI-PLAN-<track> blocker (the plan gate passed). Returns True when a
-    row was resolved; reconciles the track so derived_status reflects the unblock."""
+def _compose_plan_resolution_reason(
+    resolver: str, reason: str, approval_id: Optional[str] = None
+) -> str:
+    """Canonical ``resolution_reason`` for a plan-gate blocker.
+
+    Prefixes the operator/panel reason with a resolver tag so a later audit can
+    tell a panel pass from an operator attestation without parsing free text:
+    ``[panel] PASS (2 pass / 0 revise / 0 block, 3 seats)`` vs
+    ``[attest:APR-1] already shipped+merged pre-gate``.
+    """
+    tag = f"{resolver}:{approval_id}" if approval_id else resolver
+    return f"[{tag}] {reason.strip()}"
+
+
+def _resolve_plan_blocker(
+    state_dir: Path,
+    track_id: str,
+    project_id: str,
+    *,
+    reason: str,
+    resolver: str,
+    approval_id: Optional[str] = None,
+) -> bool:
+    """Resolve the OI-PLAN-<track> blocker (the plan gate passed), recording WHO
+    cleared it and WHY in ``resolution_reason``.
+
+    Fail-closed: an empty/whitespace reason raises ValueError — a plan-gate
+    blocker must never be cleared without a non-empty ``resolution_reason``. This
+    is the write-layer half of the bug this fixes: the CLI demanded a reason and
+    the UPDATE dropped it, leaving 87 resolved rows with no reason.
+
+    Delegates the UPDATE to ``tracks_lib.unlink_open_item`` (the single write path
+    to ``resolution_reason``) so there is exactly one place that resolves an OI row
+    — two write paths to the same column is what caused the drift.
+
+    Returns True when a row was resolved; False when the gate is unsupported, not
+    seeded, or already resolved. Reconciles the track on success.
+    """
+    reason_text = (reason or "").strip()
+    if not reason_text:
+        raise ValueError(
+            "plan blocker resolution requires a non-empty resolution_reason "
+            f"(track {track_id!r}); refusing to clear without recording why"
+        )
     conn = _db_conn(state_dir)
-    rowcount = 0
     try:
         if not _plan_gate_supported(conn):
             return False
         oi = _plan_blocker_oi(track_id)
-        cur = conn.execute(
-            "UPDATE track_open_items SET resolved_at = ? "
-            "WHERE track_id = ? AND project_id = ? AND oi_id = ? "
-            "AND link_type = 'blocks' AND resolved_at IS NULL",
-            (_now_utc(), track_id, project_id, oi),
-        )
-        rowcount = cur.rowcount
-        conn.commit()
+        row = conn.execute(
+            "SELECT resolved_at FROM track_open_items "
+            "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+            (track_id, project_id, oi),
+        ).fetchone()
     finally:
         conn.close()
+    if row is None or row["resolved_at"] is not None:
+        # Not seeded, or already resolved: nothing to clear (honest no-op).
+        return False
+    full_reason = _compose_plan_resolution_reason(resolver, reason_text, approval_id)
+    tracks_lib.unlink_open_item(
+        state_dir, track_id, project_id, oi, "blocks",
+        reason=full_reason, actor=resolver,
+    )
     track_reconciler.reconcile_track(state_dir, track_id, project_id)
-    return rowcount > 0
+    return True
 
 
 def _emit_plan_gate_pass_record(
@@ -2329,8 +2374,17 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
         # away from blocked. If a second blocker (a hard dependency, another OI) or a
         # schema gap leaves it blocked, say so — never claim unblocked dishonestly. A
         # DB/reconciler failure here returns a defined exit code, not a crash.
+        summary = result["summary"]
+        panel_reason = (
+            f"{result['decision']} ({summary['pass_count']} pass / "
+            f"{summary['revise_count']} revise / {summary['block_count']} block, "
+            f"{len(panel)} seats)"
+        )
         try:
-            resolved = _resolve_plan_blocker(state_dir, args.track_id, args.project_id)
+            resolved = _resolve_plan_blocker(
+                state_dir, args.track_id, args.project_id,
+                reason=panel_reason, resolver="panel",
+            )
             post = tracks_lib.get_track(state_dir, args.track_id, args.project_id)
         except Exception as exc:
             print(
@@ -2477,7 +2531,10 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
     }
 
     try:
-        resolved = _resolve_plan_blocker(state_dir, track_id, project_id)
+        resolved = _resolve_plan_blocker(
+            state_dir, track_id, project_id,
+            reason=reason, resolver="attest", approval_id=approval_id,
+        )
     except Exception as exc:
         print(f"plan-gate attest: unexpected error resolving blocker: {exc}", file=sys.stderr)
         return 1
@@ -2546,6 +2603,64 @@ def cmd_plan_gate_attest(args: argparse.Namespace) -> int:
         print(f"\nvnx horizon plan-gate attest — {track_id} (project '{project_id}')\n")
         print(f"  attested: {reason} (approval={approval_id})")
         print(f"  plan gate cleared. derived_status={derived}.\n")
+    return 0
+
+
+def cmd_plan_gate_missing_reasons(args: argparse.Namespace) -> int:
+    """Read-only audit: list RESOLVED plan-gate blockers that carry no
+    ``resolution_reason`` (the rows the pre-fix write path dropped the reason on).
+
+    Never rewrites them — backfilling a reason after the fact is worse than an
+    empty one. Lists track-id, project-id and the resolution date so the operator
+    can dispose of each row by hand. Exit 0 with an empty list when there is
+    nothing to dispose (a clean DB is a success, not a failure).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    conn = _db_conn(state_dir)
+    rows: list[dict[str, Any]] = []
+    try:
+        if not _has_table(conn, "track_open_items"):
+            print(
+                "plan-gate missing-reasons: track_open_items absent "
+                "(apply migrations 0022+0030 first)",
+                file=sys.stderr,
+            )
+            return 1
+        if not (
+            _has_col(conn, "track_open_items", "resolved_at")
+            and _has_col(conn, "track_open_items", "resolution_reason")
+        ):
+            print(
+                "plan-gate missing-reasons: resolution_reason column absent "
+                "(apply migration 0030 first)",
+                file=sys.stderr,
+            )
+            return 1
+        cur = conn.execute(
+            "SELECT track_id, project_id, oi_id, resolved_at, linked_at "
+            "FROM track_open_items "
+            "WHERE oi_id LIKE ? AND project_id = ? AND resolved_at IS NOT NULL "
+            "AND (resolution_reason IS NULL OR TRIM(resolution_reason) = '') "
+            "ORDER BY resolved_at ASC",
+            (f"{_PLAN_OI_PREFIX}%", (args.project_id or "").strip()),
+        )
+        rows = [dict(r) for r in cur.fetchall()]
+    finally:
+        conn.close()
+
+    if args.json:
+        print(json.dumps({"unreported": rows, "count": len(rows)}, indent=2, default=str))
+    elif not rows:
+        print("no resolved plan-gate blockers without a resolution_reason")
+    else:
+        print(
+            f"{len(rows)} resolved plan-gate blocker(s) without a resolution_reason:\n"
+        )
+        for r in rows:
+            print(
+                f"  {r['track_id']}  (project {r['project_id']})  "
+                f"resolved {r['resolved_at']}"
+            )
     return 0
 
 
@@ -2833,6 +2948,13 @@ def _build_parser() -> argparse.ArgumentParser:
         help="operator approval token (REQUIRED)",
     )
     p_pattest.set_defaults(func=cmd_plan_gate_attest)
+
+    p_pmiss = pg_sub.add_parser(
+        "missing-reasons",
+        help="list resolved plan-gate blockers with no resolution_reason (read-only)",
+    )
+    _common(p_pmiss)
+    p_pmiss.set_defaults(func=cmd_plan_gate_missing_reasons)
 
     return parser
 

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -331,6 +331,7 @@ _PLAN_GATE_ARGV = {
     "run": ["delegate-track", "--doc", "some/plan-doc.md"],
     "status": ["delegate-track"],
     "attest": ["delegate-track", "--reason", "operator override", "--approval-id", "token-xyz"],
+    "missing-reasons": [],
 }
 
 

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -125,6 +125,17 @@ def _plan_oi_resolved_at(state_dir: Path, track_id: str, project_id: str = PROJE
     return row[0] if row else None
 
 
+def _plan_oi_resolution_reason(state_dir: Path, track_id: str, project_id: str = PROJECT_ID):
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    row = conn.execute(
+        "SELECT resolution_reason FROM track_open_items "
+        "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+        (track_id, project_id, f"OI-PLAN-{track_id}"),
+    ).fetchone()
+    conn.close()
+    return row[0] if row else None
+
+
 def _derived_status(state_dir: Path, track_id: str, project_id: str = PROJECT_ID):
     t = tracks_lib.get_track(state_dir, track_id, project_id)
     return t.get("derived_status") if t else None
@@ -145,6 +156,19 @@ def _plan_attest_args(
         track_id=track_id,
         reason=reason,
         approval_id=approval_id,
+        json=json,
+    )
+
+
+def _plan_missing_reasons_args(
+    state_dir: Path,
+    *,
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
         json=json,
     )
 
@@ -598,6 +622,83 @@ def test_plan_gate_attest_resolves_blocker_and_writes_audit(tmp_path):
     assert details["reason"] == "already shipped+merged pre-gate"
     assert details["approval_id"] == "APR-1"
     assert details["track_id"] == "T"
+
+
+def test_plan_gate_attest_writes_resolution_reason(tmp_path):
+    """Resolving with a reason must persist resolution_reason — measured by reading
+    the row back (not by the function's return value)."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="shipped", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+
+    rc = planning_cli.cmd_plan_gate_attest(
+        _plan_attest_args(sd, "T", reason="already shipped+merged pre-gate", approval_id="APR-1")
+    )
+    assert rc == 0
+    assert _plan_oi_resolution_reason(sd, "T") == "[attest:APR-1] already shipped+merged pre-gate"
+
+
+def test_resolve_plan_blocker_panel_reason_tag(tmp_path):
+    """The panel path tags its recorded reason with ``[panel]`` so a later audit can
+    tell a panel pass from an operator attestation."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+
+    resolved = planning_cli._resolve_plan_blocker(
+        sd, "T", PROJECT_ID,
+        reason="PASS (2 pass / 0 revise / 0 block, 3 seats)", resolver="panel",
+    )
+    assert resolved is True
+    assert _plan_oi_resolution_reason(sd, "T") == "[panel] PASS (2 pass / 0 revise / 0 block, 3 seats)"
+
+
+@pytest.mark.parametrize("bad_reason", ["", "   ", "\t\n"])
+def test_resolve_plan_blocker_empty_reason_fails_closed(tmp_path, bad_reason):
+    """A resolution without a non-empty reason must FAIL and leave resolved_at
+    untouched — the fail-closed check lives in the write layer, not the CLI."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+
+    with pytest.raises(ValueError):
+        planning_cli._resolve_plan_blocker(
+            sd, "T", PROJECT_ID, reason=bad_reason, resolver="attest", approval_id="APR-1"
+        )
+
+    assert _plan_oi_resolved_at(sd, "T") is None
+    assert _derived_status(sd, "T") == "blocked"
+
+
+def test_plan_gate_missing_reasons_lists_reasonless_row(tmp_path, capsys):
+    """The read-only report surfaces a resolved plan-gate blocker that carries no
+    resolution_reason (the pre-fix write path dropped it)."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    # Simulate a pre-fix resolution: resolved_at set, resolution_reason dropped.
+    conn = sqlite3.connect(str(sd / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE track_open_items SET resolved_at = ? "
+        "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+        ("2026-08-14T10:00:00.000000Z", "T", PROJECT_ID, "OI-PLAN-T"),
+    )
+    conn.commit()
+    conn.close()
+
+    rc = planning_cli.cmd_plan_gate_missing_reasons(_plan_missing_reasons_args(sd))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "T" in out
+    assert "2026-08-14T10:00:00.000000Z" in out
+
+
+def test_plan_gate_missing_reasons_empty_is_success(tmp_path, capsys):
+    """A DB with no reasonless rows is a clean success, not a failure (exit 0)."""
+    sd = _build_db_plan_gate(tmp_path)
+    rc = planning_cli.cmd_plan_gate_missing_reasons(_plan_missing_reasons_args(sd))
+    assert rc == 0
+    assert "no resolved plan-gate blockers" in capsys.readouterr().out
 
 
 def test_plan_gate_attest_requires_reason_and_approval_id(tmp_path):

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -268,11 +268,18 @@ def _cmd_plan_gate_attest(args: Any) -> int:
     return pc.cmd_plan_gate_attest(args)
 
 
+def _cmd_plan_gate_missing_reasons(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_missing_reasons(args)
+
+
 _PLAN_GATE_DISPATCH: dict[str, Callable[[Any], int]] = {
     "seed": _cmd_plan_gate_seed,
     "run": _cmd_plan_gate_run,
     "status": _cmd_plan_gate_status,
     "attest": _cmd_plan_gate_attest,
+    "missing-reasons": _cmd_plan_gate_missing_reasons,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -758,6 +758,12 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     p_patt.add_argument("--approval-id", dest="approval_id", default=None,
                         help="operator approval token (REQUIRED)")
 
+    p_pmiss = subs.add_parser(
+        "missing-reasons",
+        help="list resolved plan-gate blockers with no resolution_reason (read-only)",
+    )
+    _common_horizon_args(p_pmiss)
+
 
 def _register_horizon_subparser(subparsers: argparse.Action) -> None:
     horizon_parser = subparsers.add_parser(


### PR DESCRIPTION
## Problem

The plan-gate door demanded a `--reason` AND `--approval-id` at the front, but the write path (`_resolve_plan_blocker`) threw the reason away: it wrote only `resolved_at`, never `resolution_reason`.

Measured on the dev store: **87 of 109** resolved `OI-PLAN-*` blockers carry no `resolution_reason`. The operator gave a reason; the door required it; the write path dropped it.

## Changes

- **`_resolve_plan_blocker`** now takes required `reason` + `resolver` (and optional `approval_id`) and records a canonical `resolution_reason`:
  - panel pass → `[panel] PASS (2 pass / 0 revise / 0 block, 3 seats)`
  - operator attest → `[attest:APR-1] already shipped+merged pre-gate`
- **Single write path**: the UPDATE now delegates to `tracks_lib.unlink_open_item` (the existing `resolved_at + resolution_reason` writer) instead of keeping a second write path to the same column — the duplicated write path is what caused the drift.
- **Fail-closed**: an empty/whitespace reason raises `ValueError` in the write layer itself, before any write. The CLI check stays, but a bypassed CLI no longer silently clears without a reason.
- **`plan-gate missing-reasons`** (new, read-only): lists resolved plan-gate blockers that carry no `resolution_reason` (track-id + resolution date) so the operator can dispose of the 87 existing rows. It never rewrites them — a backfilled reason after the fact is worse than an empty one.
- Both callers updated: `cmd_plan_gate_attest` (resolver=attest) and `cmd_plan_gate_run` (resolver=panel, reason = verdict + seat count).

## Tests

- resolve-with-reason fills `resolution_reason` (row read back from the DB, not the return value)
- `[panel]` and `[attest:<id>]` tag forms asserted
- empty/whitespace reason fails closed, leaving `resolved_at` NULL
- `missing-reasons` finds a prepared reasonless row; empty result is exit 0

Targeted run: `pytest tests/test_planning_cli.py tests/test_horizon_parity.py tests/test_horizon_cli.py tests/test_tracks_lib.py` → **186 passed**.

(Pre-existing, unrelated failures on main, verified via stash: `test_track_oi_lifecycle.py` — 3, and `test_planning_cli_objective.py` — 2.)

Dispatch-ID: 20260814-oi-plan-resolution-reason

🤖 Generated with [Claude Code](https://claude.com/claude-code)