### PR TITLE
feat(gate): add backfill-reason and reblock plan-gate disposition verbs

### DIFF
--- a/scripts/lib/tracks.py
+++ b/scripts/lib/tracks.py
@@ -787,11 +787,22 @@ def unlink_open_item(
     actor: str = "operator",
     conn: Optional[sqlite3.Connection] = None,
     event_sink: Optional[list] = None,
+    backfill: bool = False,
 ) -> None:
     """Close a track↔OI link non-destructively (resolved_at + reason; row kept).
+
     Requires migration 0030. A caller ``conn`` (owns=False) defers BOTH commit AND
-    the ``track_oi_closed`` event — ``event_sink`` REQUIRED, conn must target the
-    state_dir DB (D3; C3-N1/C3-N2). Raises TrackNotFoundError/ValueError/RuntimeError."""
+    the event — ``event_sink`` REQUIRED, conn must target the state_dir DB
+    (D3; C3-N1/C3-N2). Raises TrackNotFoundError/ValueError/RuntimeError.
+
+    ``backfill=True`` turns this into the retroactive-fill form (plan-gate
+    backfill-reason): the row must ALREADY be resolved and only
+    ``resolution_reason`` is written (``resolved_at`` is left untouched), emitting
+    ``track_oi_reason_backfilled`` instead of ``track_oi_closed``. The caller
+    decides whether overwriting an existing reason is legitimate (the
+    ``plan-gate backfill-reason`` verb refuses a non-empty one; a reblock composes
+    the prior reason into the new value). This stays the single write path to
+    ``resolution_reason`` — a second path is what drifted before."""
     valid_link_types = frozenset({"blocks", "warns", "related"})
     if link_type not in valid_link_types:
         raise ValueError(f"Invalid link_type: {link_type!r}. Must be one of {sorted(valid_link_types)}")
@@ -822,20 +833,38 @@ def unlink_open_item(
                 f"Open item not found: track={track_id!r} project={project_id!r} "
                 f"oi_id={oi_id!r} link_type={link_type!r}"
             )
-        if row["resolved_at"] is not None:
-            raise ValueError(
-                f"Open item already resolved: track={track_id!r} oi_id={oi_id!r} "
-                f"link_type={link_type!r} (resolved_at={row['resolved_at']!r})"
+        if backfill:
+            if row["resolved_at"] is None:
+                raise ValueError(
+                    f"Open item not yet resolved: track={track_id!r} oi_id={oi_id!r} "
+                    f"link_type={link_type!r} (resolved_at is NULL); backfill only "
+                    "fills a reason on an already-resolved row"
+                )
+            _conn.execute(
+                "UPDATE track_open_items SET resolution_reason = ? "
+                "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = ?",
+                (reason.strip(), track_id, project_id, oi_id, link_type),
             )
-        _conn.execute(
-            "UPDATE track_open_items SET resolved_at = ?, resolution_reason = ? "
-            "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = ?",
-            (_now_utc(), reason.strip(), track_id, project_id, oi_id, link_type),
-        )
-        _emit_or_defer(
-            event_sink, state_dir, "track_oi_closed", track_id, project_id, actor,
-            {"oi_id": oi_id, "link_type": link_type, "reason": reason},
-        )
+            _emit_or_defer(
+                event_sink, state_dir, "track_oi_reason_backfilled", track_id,
+                project_id, actor,
+                {"oi_id": oi_id, "link_type": link_type, "reason": reason},
+            )
+        else:
+            if row["resolved_at"] is not None:
+                raise ValueError(
+                    f"Open item already resolved: track={track_id!r} oi_id={oi_id!r} "
+                    f"link_type={link_type!r} (resolved_at={row['resolved_at']!r})"
+                )
+            _conn.execute(
+                "UPDATE track_open_items SET resolved_at = ?, resolution_reason = ? "
+                "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = ?",
+                (_now_utc(), reason.strip(), track_id, project_id, oi_id, link_type),
+            )
+            _emit_or_defer(
+                event_sink, state_dir, "track_oi_closed", track_id, project_id, actor,
+                {"oi_id": oi_id, "link_type": link_type, "reason": reason},
+            )
         if owns:
             _conn.commit()
     except Exception:

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1769,12 +1769,20 @@ def _plan_gate_supported(conn: sqlite3.Connection) -> bool:
     )
 
 
-def _seed_plan_blocker(state_dir: Path, track_id: str, project_id: str) -> bool:
+def _seed_plan_blocker(
+    state_dir: Path, track_id: str, project_id: str, reason: Optional[str] = None
+) -> bool:
     """Seed the synthetic OI-PLAN-<track> blocker so the track is born plan-gated.
 
     Idempotent (INSERT OR IGNORE on the track_open_items PK). Returns True once the
     blocker exists and the track reconciles to blocked; False on a DB that predates
     the plan-gate schema (graceful no-op).
+
+    ``reason`` turns this into the RE-BLOCK form (plan-gate reblock): the existing
+    resolved row's ``resolved_at`` is cleared in the SAME UPDATE that records the
+    reversal ``resolution_reason``, so the history that the gate was once lifted
+    is preserved on the row instead of being silently wiped. Same path as ``seed``
+    — reblock must not grow a second write path to ``track_open_items``.
     """
     conn = _db_conn(state_dir)
     try:
@@ -1792,11 +1800,18 @@ def _seed_plan_blocker(state_dir: Path, track_id: str, project_id: str) -> bool:
         # Re-seed must RE-block: clear resolved_at so a track whose plan gate
         # previously passed is gated again (e.g. a mid-flight plan change). Without
         # this, INSERT OR IGNORE silently no-ops on the resolved row.
-        conn.execute(
-            "UPDATE track_open_items SET resolved_at = NULL "
-            "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
-            (track_id, project_id, oi),
-        )
+        if reason is None:
+            conn.execute(
+                "UPDATE track_open_items SET resolved_at = NULL "
+                "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+                (track_id, project_id, oi),
+            )
+        else:
+            conn.execute(
+                "UPDATE track_open_items SET resolved_at = NULL, resolution_reason = ? "
+                "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+                (reason, track_id, project_id, oi),
+            )
         conn.commit()
     finally:
         conn.close()
@@ -1813,9 +1828,31 @@ def _compose_plan_resolution_reason(
     tell a panel pass from an operator attestation without parsing free text:
     ``[panel] PASS (2 pass / 0 revise / 0 block, 3 seats)`` vs
     ``[attest:APR-1] already shipped+merged pre-gate``.
+
+    The backfill and reblock verbs reuse this with resolver tags ``backfill`` and
+    ``reblock`` respectively, so a later reader can tell a reason recorded at
+    resolution time (``panel``/``attest``) from one added after the fact.
     """
     tag = f"{resolver}:{approval_id}" if approval_id else resolver
     return f"[{tag}] {reason.strip()}"
+
+
+def _compose_plan_reblock_reason(
+    reason: str, approval_id: str, resolved_at: str, prior_reason: Optional[str]
+) -> str:
+    """Canonical ``resolution_reason`` for a re-blocked plan-gate blocker.
+
+    Records the reversal AND preserves the history that the gate was once lifted:
+    the original ``resolved_at`` and the prior ``resolution_reason`` (when it had
+    one) are embedded, so re-blocking a wrongly-lifted row never silently wipes
+    the evidence it was ever open. A reasonless prior resolution reads ``(none)``.
+    """
+    prior = (prior_reason or "").strip() or "(none)"
+    head = _compose_plan_resolution_reason("reblock", reason, approval_id)
+    return (
+        f"{head} (reversing a wrongly-lifted plan-gate blocker; "
+        f"was resolved {resolved_at}; prior reason: {prior})"
+    )
 
 
 def _resolve_plan_blocker(
@@ -2664,6 +2701,242 @@ def cmd_plan_gate_missing_reasons(args: argparse.Namespace) -> int:
     return 0
 
 
+def cmd_plan_gate_backfill_reason(args: argparse.Namespace) -> int:
+    """Operator disposition: record the missing ``resolution_reason`` on an ALREADY
+    resolved OI-PLAN blocker (the rows the pre-fix write path left reasonless).
+
+    Backfill is NOT a resolution — the gate was already cleared. This writes only
+    the reason (never ``resolved_at``) and stamps it ``[backfill:<approval-id>]``
+    so a later reader can tell it apart from a reason recorded at resolution time
+    (``[panel] ...`` / ``[attest:...] ...``).
+
+    Human-gated: --reason AND --approval-id are BOTH required. Refuses a row that
+    is NOT resolved (that is ``attest``'s job, named explicitly in the error) and
+    a row that ALREADY carries a non-empty reason (overwriting one is
+    falsification, not backfill — the existing reason is shown so the operator
+    sees what they would erase).
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    reason = (getattr(args, "reason", None) or "").strip()
+    approval_id = (getattr(args, "approval_id", None) or "").strip()
+    if not reason or not approval_id:
+        print(
+            "plan-gate backfill-reason: --reason and --approval-id are both "
+            "required (the operator's gate token). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"plan-gate backfill-reason: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = _db_conn(state_dir)
+    try:
+        if not _plan_gate_supported(conn):
+            print(
+                "plan-gate backfill-reason: plan-gate schema absent "
+                "(need track_open_items + tracks.derived_status); apply migrations "
+                "0022/0028/0030 first",
+                file=sys.stderr,
+            )
+            return 1
+        oi = _plan_blocker_oi(track_id)
+        row = conn.execute(
+            "SELECT resolved_at, resolution_reason FROM track_open_items "
+            "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+            (track_id, project_id, oi),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        print(
+            f"plan-gate backfill-reason: no plan-gate blocker seeded for track "
+            f"{track_id!r} (project {project_id!r}); nothing to backfill.",
+            file=sys.stderr,
+        )
+        return 1
+    if row["resolved_at"] is None:
+        print(
+            f"plan-gate backfill-reason: track {track_id!r} is still blocked "
+            "(the OI-PLAN blocker is unresolved). backfill fills a reason on an "
+            "already-resolved row — to resolve it now, use `plan-gate attest`.",
+            file=sys.stderr,
+        )
+        return 1
+    existing = (row["resolution_reason"] or "").strip()
+    if existing:
+        print(
+            f"plan-gate backfill-reason: track {track_id!r} already carries a "
+            f"resolution_reason; overwriting it is falsification, not backfill. "
+            f"Existing reason: {existing!r}",
+            file=sys.stderr,
+        )
+        return 1
+
+    full_reason = _compose_plan_resolution_reason("backfill", reason, approval_id)
+    try:
+        tracks_lib.unlink_open_item(
+            state_dir, track_id, project_id, oi, "blocks",
+            reason=full_reason, actor="backfill", backfill=True,
+        )
+    except Exception as exc:
+        print(f"plan-gate backfill-reason: unexpected error: {exc}", file=sys.stderr)
+        return 1
+
+    tracks_lib._emit_track_event(
+        state_dir, "plan_gate_backfill", track_id, project_id, "operator",
+        {"reason": reason, "approval_id": approval_id, "track_id": track_id},
+    )
+
+    if args.json:
+        print(json.dumps({
+            "track_id": track_id,
+            "project_id": project_id,
+            "action": "backfilled",
+            "applied": True,
+            "resolution_reason": full_reason,
+        }, indent=2, default=str))
+    else:
+        print(
+            f"\nvnx horizon plan-gate backfill-reason — {track_id} "
+            f"(project '{project_id}')\n"
+        )
+        print(f"  backfilled: {reason} (approval={approval_id})")
+        print(f"  resolution_reason: {full_reason}\n")
+    return 0
+
+
+def cmd_plan_gate_reblock(args: argparse.Namespace) -> int:
+    """Operator disposition: put back a wrongly-lifted plan-gate blocker.
+
+    For a track whose OI-PLAN blocker was cleared without a real gate pass, this
+    re-blocks it: ``resolved_at`` is cleared via the SAME path ``seed`` uses
+    (``_seed_plan_blocker``) and the reversal is recorded in ``resolution_reason``
+    with the prior resolution history embedded — the row keeps visible evidence it
+    was once lifted, plus a reason saying it was turned back.
+
+    Human-gated: --reason AND --approval-id are BOTH required. Refuses when there
+    is already an UNRESOLVED plan blocker (nothing to put back) and when no
+    blocker was ever seeded. After re-blocking, verifies ``derived_status``
+    actually reflects the block, exactly as ``seed`` does.
+    """
+    state_dir = _resolve_state_dir(args.state_dir)
+    project_id = args.project_id
+    track_id = args.track_id
+
+    reason = (getattr(args, "reason", None) or "").strip()
+    approval_id = (getattr(args, "approval_id", None) or "").strip()
+    if not reason or not approval_id:
+        print(
+            "plan-gate reblock: --reason and --approval-id are both required "
+            "(the operator's gate token). No change made.",
+            file=sys.stderr,
+        )
+        return 2
+
+    track = tracks_lib.get_track(state_dir, track_id, project_id)
+    if track is None:
+        print(
+            f"plan-gate reblock: track not found: {track_id!r} "
+            f"(project {project_id!r}). No change made.",
+            file=sys.stderr,
+        )
+        return 1
+
+    conn = _db_conn(state_dir)
+    try:
+        if not _plan_gate_supported(conn):
+            print(
+                "plan-gate reblock: plan-gate schema absent "
+                "(need track_open_items + tracks.derived_status); apply migrations "
+                "0022/0028/0030 first",
+                file=sys.stderr,
+            )
+            return 1
+        oi = _plan_blocker_oi(track_id)
+        row = conn.execute(
+            "SELECT resolved_at, resolution_reason FROM track_open_items "
+            "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+            (track_id, project_id, oi),
+        ).fetchone()
+    finally:
+        conn.close()
+
+    if row is None:
+        print(
+            f"plan-gate reblock: no plan-gate blocker seeded for track {track_id!r} "
+            f"(project {project_id!r}); nothing to put back.",
+            file=sys.stderr,
+        )
+        return 1
+    if row["resolved_at"] is None:
+        print(
+            f"plan-gate reblock: track {track_id!r} already has an unresolved "
+            "plan-gate blocker; there is nothing to put back.",
+            file=sys.stderr,
+        )
+        return 1
+
+    composed = _compose_plan_reblock_reason(
+        reason, approval_id, row["resolved_at"], row["resolution_reason"],
+    )
+    if not _seed_plan_blocker(state_dir, track_id, project_id, reason=composed):
+        print(
+            "plan-gate reblock: plan-gate schema absent (need track_open_items + "
+            "tracks.derived_status); apply migrations 0022/0028/0030 first",
+            file=sys.stderr,
+        )
+        return 1
+
+    post = tracks_lib.get_track(state_dir, track_id, project_id)
+    derived = post.get("derived_status") if isinstance(post, dict) else None
+    if derived != "blocked":
+        print(
+            f"plan-gate reblock: track {track_id!r} re-blocked (resolved_at cleared), "
+            f"but derived_status={derived!r} does not reflect the block. The "
+            "reconciler did not mark it blocked — investigate before relying on the gate.",
+            file=sys.stderr,
+        )
+        return 1
+
+    tracks_lib._emit_track_event(
+        state_dir, "plan_gate_reblock", track_id, project_id, "operator",
+        {
+            "reason": reason,
+            "approval_id": approval_id,
+            "track_id": track_id,
+            "prior_resolved_at": row["resolved_at"],
+            "prior_reason": row["resolution_reason"],
+        },
+    )
+
+    if args.json:
+        print(json.dumps({
+            "track_id": track_id,
+            "project_id": project_id,
+            "action": "reblocked",
+            "applied": True,
+            "derived_status": derived,
+            "resolution_reason": composed,
+        }, indent=2, default=str))
+    else:
+        print(f"\nvnx horizon plan-gate reblock — {track_id} (project '{project_id}')\n")
+        print(f"  reblocked: {reason} (approval={approval_id})")
+        print(f"  derived_status={derived}")
+        print(f"  resolution_reason: {composed}\n")
+    return 0
+
+
 def _build_parser() -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(prog="vnx", description="VNX planning read surface")
     sub = parser.add_subparsers(dest="domain", required=True)
@@ -2955,6 +3228,32 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _common(p_pmiss)
     p_pmiss.set_defaults(func=cmd_plan_gate_missing_reasons)
+
+    p_pbackfill = pg_sub.add_parser(
+        "backfill-reason",
+        help="record the missing resolution_reason on an already-resolved plan-gate blocker",
+    )
+    _common(p_pbackfill)
+    p_pbackfill.add_argument("track_id")
+    p_pbackfill.add_argument("--reason", default="", help="operator reason (REQUIRED)")
+    p_pbackfill.add_argument(
+        "--approval-id", default="", dest="approval_id",
+        help="operator approval token (REQUIRED)",
+    )
+    p_pbackfill.set_defaults(func=cmd_plan_gate_backfill_reason)
+
+    p_preblock = pg_sub.add_parser(
+        "reblock",
+        help="put back a wrongly-lifted plan-gate blocker (track is blocked again)",
+    )
+    _common(p_preblock)
+    p_preblock.add_argument("track_id")
+    p_preblock.add_argument("--reason", default="", help="operator reason (REQUIRED)")
+    p_preblock.add_argument(
+        "--approval-id", default="", dest="approval_id",
+        help="operator approval token (REQUIRED)",
+    )
+    p_preblock.set_defaults(func=cmd_plan_gate_reblock)
 
     return parser
 

--- a/tests/test_horizon_parity.py
+++ b/tests/test_horizon_parity.py
@@ -332,6 +332,8 @@ _PLAN_GATE_ARGV = {
     "status": ["delegate-track"],
     "attest": ["delegate-track", "--reason", "operator override", "--approval-id", "token-xyz"],
     "missing-reasons": [],
+    "backfill-reason": ["delegate-track", "--reason", "operator backfill", "--approval-id", "token-xyz"],
+    "reblock": ["delegate-track", "--reason", "operator reblock", "--approval-id", "token-xyz"],
 }
 
 

--- a/tests/test_planning_cli.py
+++ b/tests/test_planning_cli.py
@@ -173,6 +173,58 @@ def _plan_missing_reasons_args(
     )
 
 
+def _plan_backfill_args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    reason: str = "",
+    approval_id: str = "",
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        reason=reason,
+        approval_id=approval_id,
+        json=json,
+    )
+
+
+def _plan_reblock_args(
+    state_dir: Path,
+    track_id: str,
+    *,
+    reason: str = "",
+    approval_id: str = "",
+    project_id: str = PROJECT_ID,
+    json: bool = False,
+) -> argparse.Namespace:
+    return argparse.Namespace(
+        state_dir=str(state_dir),
+        project_id=project_id,
+        track_id=track_id,
+        reason=reason,
+        approval_id=approval_id,
+        json=json,
+    )
+
+
+def _lift_plan_blocker_reasonless(
+    state_dir: Path, track_id: str, resolved_at: str, project_id: str = PROJECT_ID
+) -> None:
+    """Simulate a pre-fix lift: resolved_at set, resolution_reason dropped."""
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute(
+        "UPDATE track_open_items SET resolved_at = ? "
+        "WHERE track_id = ? AND project_id = ? AND oi_id = ? AND link_type = 'blocks'",
+        (resolved_at, track_id, project_id, f"OI-PLAN-{track_id}"),
+    )
+    conn.commit()
+    conn.close()
+
+
 def _history_count(state_dir: Path, track_id: str, project_id: str = PROJECT_ID) -> int:
     conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
     n = conn.execute(
@@ -758,6 +810,187 @@ def test_plan_gate_attest_still_blocked_reports_plainly(tmp_path, capsys):
     assert _derived_status(sd, "T") == "blocked"  # but still blocked by the dependency
     assert len(_track_events(sd, "T", "plan_gate_attest")) == 1
     assert "STILL" in capsys.readouterr().out
+
+
+# ---------------------------------------------------------------------------
+# plan-gate backfill-reason
+# ---------------------------------------------------------------------------
+
+def test_plan_gate_backfill_reason_fills_reasonless_resolved_row(tmp_path):
+    """backfill records the missing resolution_reason on an already-resolved row,
+    leaving resolved_at untouched — measured by reading the row back."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="shipped", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    _lift_plan_blocker_reasonless(sd, "T", "2026-08-14T10:00:00.000000Z")
+
+    rc = planning_cli.cmd_plan_gate_backfill_reason(
+        _plan_backfill_args(sd, "T", reason="already shipped+merged pre-gate", approval_id="APR-2")
+    )
+    assert rc == 0
+    assert _plan_oi_resolution_reason(sd, "T") == "[backfill:APR-2] already shipped+merged pre-gate"
+    assert _plan_oi_resolved_at(sd, "T") == "2026-08-14T10:00:00.000000Z"  # untouched
+
+    events = _track_events(sd, "T", "plan_gate_backfill")
+    assert len(events) == 1
+    assert events[0]["details"]["reason"] == "already shipped+merged pre-gate"
+    assert events[0]["details"]["approval_id"] == "APR-2"
+
+
+def test_plan_gate_backfill_reason_unresolved_row_fails_and_leaves_row(tmp_path, capsys):
+    """backfill on a still-blocked row is refused with an explicit pointer to attest,
+    and the row is left untouched."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)  # unresolved
+
+    rc = planning_cli.cmd_plan_gate_backfill_reason(
+        _plan_backfill_args(sd, "T", reason="x", approval_id="APR-1")
+    )
+    assert rc == 1
+    assert "attest" in capsys.readouterr().err
+    assert _plan_oi_resolved_at(sd, "T") is None
+    assert _plan_oi_resolution_reason(sd, "T") is None
+    assert _track_events(sd, "T", "plan_gate_backfill") == []
+
+
+def test_plan_gate_backfill_reason_existing_reason_fails_and_preserves(tmp_path, capsys):
+    """Overwriting an existing resolution_reason is falsification: refused, the
+    existing reason is shown, and it stays put."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="shipped", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    planning_cli._resolve_plan_blocker(
+        sd, "T", PROJECT_ID, reason="shipped pre-gate", resolver="attest", approval_id="APR-9"
+    )
+    original = _plan_oi_resolution_reason(sd, "T")
+    assert original == "[attest:APR-9] shipped pre-gate"
+
+    rc = planning_cli.cmd_plan_gate_backfill_reason(
+        _plan_backfill_args(sd, "T", reason="second", approval_id="APR-2")
+    )
+    assert rc == 1
+    assert original in capsys.readouterr().err  # existing reason shown
+    assert _plan_oi_resolution_reason(sd, "T") == original  # unchanged
+
+
+def test_plan_gate_backfill_reason_no_seeded_blocker_fails(tmp_path, capsys):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_plan_gate_backfill_reason(
+        _plan_backfill_args(sd, "T", reason="x", approval_id="APR-1")
+    )
+    assert rc == 1
+    assert "nothing to backfill" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("bad_reason", ["", "   ", "\t\n"])
+def test_plan_gate_backfill_reason_empty_reason_refused(tmp_path, bad_reason):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    _lift_plan_blocker_reasonless(sd, "T", "2026-08-14T10:00:00.000000Z")
+
+    rc = planning_cli.cmd_plan_gate_backfill_reason(
+        _plan_backfill_args(sd, "T", reason=bad_reason, approval_id="APR-1")
+    )
+    assert rc == 2
+    assert _plan_oi_resolution_reason(sd, "T") is None
+    assert _track_events(sd, "T", "plan_gate_backfill") == []
+
+
+# ---------------------------------------------------------------------------
+# plan-gate reblock
+# ---------------------------------------------------------------------------
+
+def test_plan_gate_reblock_puts_back_lifted_blocker_and_blocks(tmp_path):
+    """reblock clears resolved_at again and the track reconciles back to blocked,
+    with the prior resolution history preserved in resolution_reason."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    _lift_plan_blocker_reasonless(sd, "T", "2026-08-14T10:00:00.000000Z")
+
+    # Reconcile so the (wrong) lift is reflected before we re-block — proves the
+    # reblock is what flips derived_status back to blocked.
+    planning_cli.track_reconciler.reconcile_track(sd, "T", PROJECT_ID)
+    assert _derived_status(sd, "T") != "blocked"
+
+    rc = planning_cli.cmd_plan_gate_reblock(
+        _plan_reblock_args(sd, "T", reason="gate still has work", approval_id="APR-3")
+    )
+    assert rc == 0
+    assert _plan_oi_resolved_at(sd, "T") is None  # blocking again
+    assert _derived_status(sd, "T") == "blocked"
+
+    reason = _plan_oi_resolution_reason(sd, "T")
+    assert reason.startswith("[reblock:APR-3] gate still has work")
+    assert "2026-08-14T10:00:00.000000Z" in reason  # prior resolved_at preserved
+    assert "prior reason: (none)" in reason
+
+    events = _track_events(sd, "T", "plan_gate_reblock")
+    assert len(events) == 1
+    assert events[0]["details"]["approval_id"] == "APR-3"
+    assert events[0]["details"]["prior_resolved_at"] == "2026-08-14T10:00:00.000000Z"
+
+
+def test_plan_gate_reblock_preserves_prior_reason(tmp_path):
+    """A wrongly-lifted row that DID carry a reason keeps that reason visible,
+    embedded in the reversal note — nothing is silently wiped."""
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    planning_cli._resolve_plan_blocker(
+        sd, "T", PROJECT_ID, reason="shipped pre-gate", resolver="attest", approval_id="APR-9"
+    )
+
+    rc = planning_cli.cmd_plan_gate_reblock(
+        _plan_reblock_args(sd, "T", reason="was wrong", approval_id="APR-4")
+    )
+    assert rc == 0
+    reason = _plan_oi_resolution_reason(sd, "T")
+    assert reason.startswith("[reblock:APR-4] was wrong")
+    assert "prior reason: [attest:APR-9] shipped pre-gate" in reason
+    assert _derived_status(sd, "T") == "blocked"
+
+
+def test_plan_gate_reblock_already_blocked_fails(tmp_path, capsys):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)  # already unresolved
+
+    rc = planning_cli.cmd_plan_gate_reblock(
+        _plan_reblock_args(sd, "T", reason="x", approval_id="APR-1")
+    )
+    assert rc == 1
+    assert "nothing to put back" in capsys.readouterr().err
+    assert _plan_oi_resolved_at(sd, "T") is None
+    assert _track_events(sd, "T", "plan_gate_reblock") == []
+
+
+def test_plan_gate_reblock_no_seeded_blocker_fails(tmp_path, capsys):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    rc = planning_cli.cmd_plan_gate_reblock(
+        _plan_reblock_args(sd, "T", reason="x", approval_id="APR-1")
+    )
+    assert rc == 1
+    assert "nothing to put back" in capsys.readouterr().err
+
+
+@pytest.mark.parametrize("bad_reason", ["", "   ", "\t\n"])
+def test_plan_gate_reblock_empty_reason_refused(tmp_path, bad_reason):
+    sd = _build_db_plan_gate(tmp_path)
+    tracks_lib.create_track(sd, "T", PROJECT_ID, title="x", goal_state="y", phase="queued")
+    planning_cli._seed_plan_blocker(sd, "T", PROJECT_ID)
+    _lift_plan_blocker_reasonless(sd, "T", "2026-08-14T10:00:00.000000Z")
+
+    rc = planning_cli.cmd_plan_gate_reblock(
+        _plan_reblock_args(sd, "T", reason=bad_reason, approval_id="APR-1")
+    )
+    assert rc == 2
+    assert _plan_oi_resolved_at(sd, "T") is not None  # still lifted (unchanged)
+    assert _track_events(sd, "T", "plan_gate_reblock") == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_track_oi_lifecycle.py
+++ b/tests/test_track_oi_lifecycle.py
@@ -318,6 +318,53 @@ class TestOiClose:
                 reason="should fail"
             )
 
+    def test_unlink_backfill_sets_reason_on_resolved_row(self, state_dir):
+        """backfill=True fills resolution_reason on an ALREADY-resolved row and
+        leaves resolved_at untouched (single write path for retroactive fill)."""
+        tracks_lib.create_track(state_dir, "feat-bf", PROJECT_ID, "TB", "GB", phase="active")
+        tracks_lib.link_open_item(
+            state_dir, "feat-bf", PROJECT_ID, "OI-BF", "blocks", "manual"
+        )
+        tracks_lib.unlink_open_item(
+            state_dir, "feat-bf", PROJECT_ID, "OI-BF", "blocks", reason="original"
+        )
+        db = state_dir / "runtime_coordination.db"
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        before = conn.execute(
+            "SELECT resolved_at, resolution_reason FROM track_open_items "
+            "WHERE track_id = ? AND project_id = ? AND oi_id = ?",
+            ("feat-bf", PROJECT_ID, "OI-BF"),
+        ).fetchone()
+        conn.close()
+
+        tracks_lib.unlink_open_item(
+            state_dir, "feat-bf", PROJECT_ID, "OI-BF", "blocks",
+            reason="[backfill:APR-1] later recorded", backfill=True,
+        )
+        conn = sqlite3.connect(str(db))
+        conn.row_factory = sqlite3.Row
+        after = conn.execute(
+            "SELECT resolved_at, resolution_reason FROM track_open_items "
+            "WHERE track_id = ? AND project_id = ? AND oi_id = ?",
+            ("feat-bf", PROJECT_ID, "OI-BF"),
+        ).fetchone()
+        conn.close()
+        assert after["resolved_at"] == before["resolved_at"]  # untouched
+        assert after["resolution_reason"] == "[backfill:APR-1] later recorded"
+
+    def test_unlink_backfill_unresolved_row_raises(self, state_dir):
+        """backfill=True on a still-open row raises ValueError (nothing to backfill)."""
+        tracks_lib.create_track(state_dir, "feat-bf2", PROJECT_ID, "TB2", "GB2", phase="active")
+        tracks_lib.link_open_item(
+            state_dir, "feat-bf2", PROJECT_ID, "OI-BF2", "blocks", "manual"
+        )
+        with pytest.raises(ValueError, match="not yet resolved"):
+            tracks_lib.unlink_open_item(
+                state_dir, "feat-bf2", PROJECT_ID, "OI-BF2", "blocks",
+                reason="[backfill:APR-1] later recorded", backfill=True,
+            )
+
     def test_unlink_writes_event(self, state_dir):
         tracks_lib.create_track(state_dir, "feat-7", PROJECT_ID, "T7", "G7", phase="active")
         tracks_lib.link_open_item(

--- a/vnx_cli/commands/horizon.py
+++ b/vnx_cli/commands/horizon.py
@@ -274,12 +274,26 @@ def _cmd_plan_gate_missing_reasons(args: Any) -> int:
     return pc.cmd_plan_gate_missing_reasons(args)
 
 
+def _cmd_plan_gate_backfill_reason(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_backfill_reason(args)
+
+
+def _cmd_plan_gate_reblock(args: Any) -> int:
+    pc = _require_planning_cli()
+    _prep(args)
+    return pc.cmd_plan_gate_reblock(args)
+
+
 _PLAN_GATE_DISPATCH: dict[str, Callable[[Any], int]] = {
     "seed": _cmd_plan_gate_seed,
     "run": _cmd_plan_gate_run,
     "status": _cmd_plan_gate_status,
     "attest": _cmd_plan_gate_attest,
     "missing-reasons": _cmd_plan_gate_missing_reasons,
+    "backfill-reason": _cmd_plan_gate_backfill_reason,
+    "reblock": _cmd_plan_gate_reblock,
 }
 
 

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -764,6 +764,26 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     )
     _common_horizon_args(p_pmiss)
 
+    p_pbackfill = subs.add_parser(
+        "backfill-reason",
+        help="record the missing resolution_reason on an already-resolved plan-gate blocker",
+    )
+    _common_horizon_args(p_pbackfill)
+    p_pbackfill.add_argument("track_id")
+    p_pbackfill.add_argument("--reason", default=None, help="operator reason (REQUIRED)")
+    p_pbackfill.add_argument("--approval-id", dest="approval_id", default=None,
+                             help="operator approval token (REQUIRED)")
+
+    p_preblock = subs.add_parser(
+        "reblock",
+        help="put back a wrongly-lifted plan-gate blocker (track is blocked again)",
+    )
+    _common_horizon_args(p_preblock)
+    p_preblock.add_argument("track_id")
+    p_preblock.add_argument("--reason", default=None, help="operator reason (REQUIRED)")
+    p_preblock.add_argument("--approval-id", dest="approval_id", default=None,
+                            help="operator approval token (REQUIRED)")
+
 
 def _register_horizon_subparser(subparsers: argparse.Action) -> None:
     horizon_parser = subparsers.add_parser(


### PR DESCRIPTION
## Summary

PR #1502 made `resolution_reason` mandatory when clearing an OI-PLAN blocker and shipped `vnx horizon plan-gate missing-reasons`, which surfaces 87 reasonless rows. Those rows could be found but not disposed. This PR adds the two missing disposition verbs.

## Changes

- `vnx horizon plan-gate backfill-reason <track_id>` — fills `resolution_reason` on an already-resolved OI-PLAN row.
  - `--reason` and `--approval-id` mandatory (same form as `attest`).
  - Refuses a not-resolved row (error points at `attest`).
  - Refuses a row that already has a reason (shows the existing reason; overwriting would be falsification).
  - Records it as a recognizable backfill (`[backfill:APPROVAL-ID] reason`).
- `vnx horizon plan-gate reblock <track_id>` — puts back a wrongly-lifted plan-gate block.
  - `--reason` and `--approval-id` mandatory.
  - Refuses when an unresolved OI-PLAN block already exists.
  - Re-blocks via the seed path and verifies `derived_status` reflects the block.
  - History that the block was lifted stays visible: `resolution_reason` records `[reblock:APPROVAL-ID] ... (reversing a wrongly-lifted plan-gate blocker; was resolved ...; prior reason: ...)`.
- Both verbs support `--json` and emit the same kind of audit event as `attest`/`seed`.

Both route through the single write paths PR #1502 left: `tracks_lib.unlink_open_item` (backfill, via a `backfill=True` flag) and `_seed_plan_blocker` (reblock, via a `reason=` argument). No third write path to `track_open_items`.

Registered in both the `bin/vnx` path (`scripts/planning_cli.py._build_parser`) and the pip path (`vnx_cli/commands/horizon.py` `_PLAN_GATE_DISPATCH` + `vnx_cli/main.py` `_register_plan_gate_verbs`), kept in parity via `tests/test_horizon_parity.py`.

## Verification

- `tests/test_planning_cli.py`: 51 passed (13 new tests covering backfill fill/refuse paths, reblock put-back/already-blocked/empty-reason, empty/whitespace reason on both verbs).
- `tests/test_horizon_parity.py`: 94 passed (parity introspection includes the two new verbs).
- `tests/test_track_oi_lifecycle.py`: 27 passed, 3 pre-existing unrelated failures (`TestReconcilerOiResolved` — fixture lacks `dispatches.output_ref`, a migration-0027 column; reproduced with the change stashed).

## Open Items

None — T0 disposes the 9 tracks after merge; the disposition itself is not executed here.

Dispatch-ID: 20260815-plangate-dispositie-verbs

🤖 Generated with [Claude Code](https://claude.com/claude-code)