### PR TITLE
feat(worker-scope): deny mcp__ namespace to close extension-bridge leak

### DIFF
--- a/docs/operations/WORKER_PERMISSIONS.md
+++ b/docs/operations/WORKER_PERMISSIONS.md
@@ -1,7 +1,8 @@
 # Worker Permissions
 
-> Status: current as of 2026-08-14 (scoped worker-mode is the fabric default,
-> revising the 03-08 blanket-skip ratification).
+> Status: current as of 2026-08-15 (scoped worker-mode is the fabric default,
+> with the `mcp__` tool namespace denied explicitly; revising the 03-08
+> blanket-skip ratification and the 14-08 mcp-scoped-default flip).
 > Covers the two dispatch lanes that spawn a headless/detached Claude worker:
 > the tmux-spawn lane (`tmux_interactive_dispatch.py`) and the subprocess lane
 > (`subprocess_adapter.py`). Module: `scripts/lib/worker_permissions.py`.
@@ -32,7 +33,45 @@ With no opt-out (the default), the worker launches with
 `build_claude_scope_args(...)` — `--permission-mode acceptEdits`,
 `--mcp-config '{"mcpServers":{}}' --strict-mcp-config` (unless
 `requires_mcp=True`), plus `--allowedTools`/`--disallowedTools` from the role's
-profile.
+profile. The `--disallowedTools` list also carries `mcp__*` (unless
+`requires_mcp=True`) to deny the whole MCP tool namespace — see the
+extension-bridge gap below.
+
+## The extension-bridge gap: the empty `--mcp-config` is not enough
+
+The empty `--mcp-config '{"mcpServers":{}}'` only reaches the `mcpServers`
+group. An extension bridge surfaces `mcp__` tools WITHOUT appearing in
+`claude mcp list`, so it is out of `--mcp-config`'s reach. Measured 2026-08-15
+(dispatch `20260815-mcp-surface-probe`): a scoped worker whose argv carried
+`--mcp-config '{"mcpServers":{}}' --strict-mcp-config --allowedTools ...` still
+loaded four working `mcp__claude-in-chrome__*` tool schemas via ToolSearch
+(`navigate`, `tabs_close_mcp`, `tabs_context_mcp`, `tabs_create_mcp`). The seven
+servers from `claude mcp list` (Gmail, Google Drive, Google Calendar, Notion,
+Excalidraw, Similarweb, perplexity) were correctly blocked; the extension bridge
+was not. A worker in an isolated worktree could therefore reach the web with the
+operator's logged-in Chrome session — the worktree bounds the filesystem,
+`--strict-mcp-config` bounds the `mcpServers` configuration, and neither bounds
+an extension bridge.
+
+`--allowedTools` does not close the gap either: it is an allow-list of built-in
+tools and does not restrict the `mcp__` namespace (verified: a session launched
+with `--allowedTools Read,Write,Edit,MultiEdit,Bash,Grep,Glob` still saw its
+ambient `mcp__` tool).
+
+The fix is an explicit namespace deny. `build_claude_scope_args(...)` appends
+`mcp__*` to `--disallowedTools` (constant `MCP_NAMESPACE_DENY` in
+`scripts/lib/worker_permissions.py`). Every MCP tool is namespaced
+`mcp__<server>__<tool>` regardless of whether it came from `mcpServers` or an
+extension bridge, so the `mcp__*` glob covers both. The glob form was measured,
+not assumed: `claude 2.1.233` accepts `mcp__*` (and `mcp__<server>` /
+`mcp__<server>__*`) in `--disallowedTools`, and a live session's tool surface
+drops to empty with it. Repeatable measurement:
+`scripts/analysis/mcp_namespace_probe.py` (control vs scoped run of the real CLI).
+
+As with the empty `--mcp-config`, the `mcp__*` deny is skipped when
+`requires_mcp=True`, so a dispatch that declares it needs MCP keeps its `mcp__`
+tools. The tmux-lane import-fault fallback in `tmux_interactive_dispatch.py`
+carries the same deny so an import failure never silently reopens the namespace.
 
 ## `.vnx/worker_permissions.yaml` — role profiles
 

--- a/scripts/analysis/mcp_namespace_probe.py
+++ b/scripts/analysis/mcp_namespace_probe.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python3
+"""Measure whether a scoped worker's argv actually removes the whole mcp__ namespace.
+
+Dispatch 20260815-mcp-surface-probe found that the scoped default shipped in
+#1503 (`--mcp-config '{"mcpServers":{}}' --strict-mcp-config --allowedTools ...`)
+did NOT reach the ``mcp__`` tools surfaced by an extension bridge
+(claude-in-chrome): those tools appear outside ``mcpServers``, so the empty
+``--mcp-config`` leaves them connected and ``--allowedTools`` (an allow-list of
+built-in tools) does not restrict the ``mcp__`` namespace either. This script is
+the repeatable form of that measurement, plus the fix verification.
+
+It drives the REAL claude CLI (``claude -p``) with the exact scope argv that
+``worker_permissions.build_claude_scope_args`` assembles, and asks the session to
+report every tool whose name begins with ``mcp__``. Two runs, always:
+
+  1. CONTROL — ``requires_mcp=True``: no empty ``--mcp-config`` and no ``mcp__*``
+     deny, so the ambient MCP surface stays connected. This proves the probe CAN
+     see ``mcp__`` tools when they are present (a scoped result of NONE is only
+     meaningful against a control that is non-empty).
+  2. SCOPED — the fabric default: empty ``--mcp-config`` + ``--strict-mcp-config``
+     + ``--disallowedTools WebSearch,WebFetch,mcp__*``. Expected surface: NONE.
+
+The verdict is BEHAVIORAL: it compares the tool surface the session reports, not
+whether a flag string appears in argv. A flag in argv is the label; the tool list
+the session actually sees is the behavior.
+
+Exit code 0 on a clean scoped result (control non-empty, scoped empty). Exit 1
+if the scoped run still surfaces any ``mcp__`` tool. Exit 2 if the control is
+empty (the scoped NONE is then not independently meaningful), or on any spawn
+failure. No hardcoded paths: the lib dir resolves relative to this file.
+
+NOTE: the nested ``claude -p`` inherits this process's env, so under the
+DeepSeek harness (ANTHROPIC_BASE_URL set) it routes to DeepSeek; the
+``--disallowedTools``/``--mcp-config`` filtering happens client-side in the
+claude CLI regardless of backend, so the tool-surface measurement is valid.
+"""
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from pathlib import Path
+
+_HERE = Path(__file__).resolve().parent
+_LIB_DIR = _HERE.parent / "lib"
+if str(_LIB_DIR) not in sys.path:
+    sys.path.insert(0, str(_LIB_DIR))
+
+from worker_permissions import (  # noqa: E402
+    MCP_NAMESPACE_DENY,
+    build_claude_scope_args,
+    default_code_worker_profile,
+)
+
+_PROMPT = (
+    "List every tool available to you whose name begins with the exact prefix "
+    "mcp__. Output only the exact tool names, one per line, nothing else. If "
+    "there are none, output the single word NONE."
+)
+
+
+def _run(scope_args: list[str], timeout: int) -> tuple[int, str, str]:
+    """Spawn ``claude -p`` with *scope_args* and return (rc, stdout, stderr).
+
+    The prompt is placed BEFORE the scope flags: ``--allowedTools`` /
+    ``--disallowedTools`` are variadic and would otherwise swallow the prompt.
+    """
+    cmd = ["claude", "-p", _PROMPT, *scope_args]
+    proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    return proc.returncode, proc.stdout, proc.stderr
+
+
+def _surface(stdout: str) -> list[str]:
+    """Parse the reported mcp__ tool surface out of the session's stdout."""
+    text = stdout.strip()
+    if not text:
+        return []
+    if text.upper() == "NONE":
+        return []
+    return [ln.strip() for ln in text.splitlines() if ln.strip().startswith("mcp__")]
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--timeout",
+        type=int,
+        default=150,
+        help="per-session timeout in seconds (default: 150)",
+    )
+    args = parser.parse_args()
+
+    profile = default_code_worker_profile()
+
+    # CONTROL: requires_mcp=True keeps the ambient MCP config (no empty
+    # --mcp-config, no mcp__* deny). Whatever mcp tools this sees is the
+    # ambient surface the scoped run is supposed to remove.
+    control_args = build_claude_scope_args(profile, requires_mcp=True)
+    rc_c, out_c, err_c = _run(control_args, args.timeout)
+    control_surface = _surface(out_c)
+
+    scoped_args = build_claude_scope_args(profile)
+    rc_s, out_s, err_s = _run(scoped_args, args.timeout)
+    scoped_surface = _surface(out_s)
+
+    print("=" * 72)
+    print("CONTROL (requires_mcp=True) — ambient MCP surface")
+    print("argv: claude -p <prompt> " + " ".join(control_args))
+    print(f"rc: {rc_c}")
+    print(f"mcp__ tools seen: {control_surface if control_surface else 'NONE'}")
+    if err_c.strip():
+        print(f"stderr: {err_c.strip()[:400]}")
+    print("=" * 72)
+    print("SCOPED (fabric default) — scoped surface")
+    print("argv: claude -p <prompt> " + " ".join(scoped_args))
+    print(f"rc: {rc_s}")
+    print(f"mcp__ tools seen: {scoped_surface if scoped_surface else 'NONE'}")
+    if err_s.strip():
+        print(f"stderr: {err_s.strip()[:400]}")
+    print("=" * 72)
+
+    if rc_c != 0 or rc_s != 0:
+        print("VERDICT: spawn failure (non-zero rc) — measurement invalid")
+        return 2
+
+    if not control_surface:
+        print(
+            "VERDICT: control is empty — no ambient mcp__ tools were detected, "
+            "so the scoped NONE is not independently meaningful."
+        )
+        return 2
+
+    if scoped_surface:
+        print(
+            f"VERDICT: LEAK — the scoped session still surfaces mcp__ tools "
+            f"({', '.join(scoped_surface)}). The mcp__ namespace is NOT closed."
+        )
+        return 1
+
+    print(
+        f"VERDICT: closed — control saw {len(control_surface)} ambient mcp__ "
+        f"tool(s), the scoped session saw none. {MCP_NAMESPACE_DENY!r} deny "
+        "removes the whole namespace."
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -75,6 +75,11 @@ _RAW_CLAUDE_PATTERNS = [
 # this set that spawns `claude -p` is a NEW receipt-bypass side door and fails the gate until
 # audited here (or routed via a governed lane).
 KNOWN_RAW_CLAUDE_CALLERS = frozenset({
+    # read-only measurement probe: spawns claude -p to measure the mcp__ tool surface of a SCOPED
+    # session. That surface is only observable from inside a session; `claude mcp list` reads the
+    # stored config and demonstrably ignores the scoping flags, so it measures configuration, not
+    # the session. Delivers no work and produces no receipt-obligated output.
+    "scripts/analysis/mcp_namespace_probe.py",
     "scripts/conversation_analyzer/deep_analyzer.py",
     "scripts/f39/replay_harness/single_replay.py",
     "scripts/headless_trigger.py",

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -214,7 +214,14 @@ constraints:
       Drive) still connected from a dispatch worktree without opt-in. The
       binding enforcement lives in worker_permissions.build_claude_scope_args
       (empty --mcp-config unless requires_mcp=True), not in the door router;
-      this entry records the decision in the SSOT. VNX_WORKER_BLANKET_SKIP=1
+      this entry records the decision in the SSOT. EXTENSION-BRIDGE GAP
+      (2026-08-15, mcp-namespace-leak): the empty --mcp-config only reaches
+      the mcpServers group, not extension bridges (claude-in-chrome) that
+      surface mcp__ tools outside `claude mcp list` — measured: a scoped
+      worker still loaded four mcp__claude-in-chrome__* tool schemas via
+      ToolSearch. Closed by an explicit --disallowedTools mcp__* namespace
+      deny (worker_permissions.MCP_NAMESPACE_DENY, verified against claude
+      2.1.233), skipped under requires_mcp=True. VNX_WORKER_BLANKET_SKIP=1
       (or falsy VNX_WORKER_SCOPED) is the explicit per-dispatch opt back into
       the blanket --dangerously-skip-permissions posture.
     enforcement: code_warn

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -121,8 +121,16 @@ except Exception:  # pragma: no cover - sibling import is available in-tree
             "Bash(git:*),Bash(gh:*),Bash(python3:*),Bash(pytest:*),"
             "Bash(pip:*),Bash(rm:*),Bash(chmod:*),Bash(mkdir:*)",
         ]
+        disallowed = []
+        if not requires_mcp:
+            # Parity with worker_permissions.MCP_NAMESPACE_DENY: the empty
+            # --mcp-config above does not reach extension bridges
+            # (claude-in-chrome), so deny the whole mcp__ namespace explicitly.
+            disallowed.append("mcp__*")
         if working_tree_only:
-            args += ["--disallowedTools", "Bash(git commit),Bash(git commit:*),Bash(git push),Bash(git push:*)"]
+            disallowed += ["Bash(git commit)", "Bash(git commit:*)", "Bash(git push)", "Bash(git push:*)"]
+        if disallowed:
+            args += ["--disallowedTools", ",".join(disallowed)]
         return args
 
     def _wp_resolve_worker_profile(role):  # type: ignore[misc]

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -76,6 +76,17 @@ FALLBACK_FILE_WRITE_SCOPE = [
 # n8n, Gmail, etc.) — the core security win of the interim capability scoping.
 EMPTY_MCP_CONFIG = json.dumps({"mcpServers": {}}, separators=(",", ":"))
 
+# Deny pattern for the entire MCP tool namespace, added to `--disallowedTools`
+# in scoped mode. The empty `--mcp-config` above only reaches the ``mcpServers``
+# group: an extension bridge (claude-in-chrome) surfaces ``mcp__…`` tools WITHOUT
+# appearing in ``claude mcp list``, so it falls outside `--mcp-config`'s reach
+# (measured 2026-08-15, dispatch 20260815-mcp-surface-probe). Every MCP tool is
+# namespaced ``mcp__<server>__<tool>`` regardless of source, so the ``mcp__*``
+# glob closes the gap for both groups. Verified against claude 2.1.233: a live
+# ``--disallowedTools mcp__*`` removes the whole namespace (see
+# scripts/analysis/mcp_namespace_probe.py).
+MCP_NAMESPACE_DENY = "mcp__*"
+
 
 def _resolve_permissions_yaml() -> Path:
     """Resolve worker_permissions.yaml with project-override-first priority.
@@ -395,9 +406,14 @@ def build_claude_scope_args(
         allowlist does not apply in that case (Open Item: reconcile the two).
       - ``--allowedTools`` / ``--disallowedTools`` — the profile's tool allow/deny
         lists (the previously-dead :func:`generate_claude_settings`, now live).
+        The whole MCP tool namespace (``mcp__*``) is denied here as well when
+        ``requires_mcp=False`` — the empty ``--mcp-config`` above only reaches
+        the ``mcpServers`` group, not extension bridges (see
+        :data:`MCP_NAMESPACE_DENY`).
 
     ``requires_mcp``: when True, the ``--mcp-config ... --strict-mcp-config`` pair
-    is omitted so the worker's normal ambient MCP config is used instead.
+    AND the ``mcp__*`` namespace deny are both omitted, so the worker's normal
+    ambient MCP config (and its MCP tools) are used instead.
     """
     settings = generate_claude_settings(profile)
     allowed = settings.get("allowedTools", [])
@@ -419,6 +435,13 @@ def build_claude_scope_args(
     if allowed:
         args += ["--allowedTools", ",".join(allowed)]
     disallowed = list(profile.denied_tools)
+    if not requires_mcp:
+        # The empty --mcp-config above only kills the mcpServers group; it does
+        # not reach extension bridges (claude-in-chrome) that surface mcp__ tools
+        # without appearing in `claude mcp list`. Deny the whole namespace
+        # explicitly via --disallowedTools so both groups are blocked.
+        if MCP_NAMESPACE_DENY not in disallowed:
+            disallowed.append(MCP_NAMESPACE_DENY)
     if working_tree_only:
         # Working-tree-only dispatches (plan-review / plan-write) must not mutate
         # git history. Deny commit/push at the tool-permission layer — the SLOT —

--- a/tests/test_worker_permissions.py
+++ b/tests/test_worker_permissions.py
@@ -15,6 +15,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "scripts" / "lib"))
 from worker_permissions import (
     DEFAULT_CODE_WORKER_TOOLS,
     EMPTY_MCP_CONFIG,
+    MCP_NAMESPACE_DENY,
     PermissionProfile,
     build_claude_scope_args,
     classify_permission_posture,
@@ -372,6 +373,53 @@ class TestBuildClaudeScopeArgsMcpServers:
         )
         assert "--strict-mcp-config" not in args
         assert "--mcp-config" not in args
+
+
+class TestMcpNamespaceDeny:
+    """The mcp__ namespace is denied via --disallowedTools, not only the empty
+    --mcp-config (dispatch 20260815-mcp-namespace-leak).
+
+    The empty --mcp-config only reaches the mcpServers group; extension bridges
+    (claude-in-chrome) surface mcp__ tools without appearing in `claude mcp
+    list`. The `mcp__*` glob closes the gap for the whole namespace. Verified
+    against claude 2.1.233 (see scripts/analysis/mcp_namespace_probe.py).
+    """
+
+    def test_mcp_namespace_denied_by_default(self) -> None:
+        args = build_claude_scope_args(default_code_worker_profile())
+        denied = args[args.index("--disallowedTools") + 1].split(",")
+        assert MCP_NAMESPACE_DENY in denied
+
+    def test_mcp_namespace_deny_alongside_websearch_deny(self) -> None:
+        # The existing WebSearch/WebFetch deny must remain alongside mcp__*.
+        args = build_claude_scope_args(default_code_worker_profile())
+        denied = args[args.index("--disallowedTools") + 1].split(",")
+        assert "WebSearch" in denied
+        assert "WebFetch" in denied
+        assert MCP_NAMESPACE_DENY in denied
+
+    def test_requires_mcp_true_keeps_mcp_namespace(self) -> None:
+        # requires_mcp=True keeps the worker's MCP tools — the namespace deny
+        # must NOT be added (only WebSearch/WebFetch from the profile remain).
+        args = build_claude_scope_args(default_code_worker_profile(), requires_mcp=True)
+        denied = args[args.index("--disallowedTools") + 1].split(",")
+        assert MCP_NAMESPACE_DENY not in denied
+
+    def test_mcp_namespace_deny_combined_with_working_tree_only_git_deny(self) -> None:
+        args = build_claude_scope_args(default_code_worker_profile(), working_tree_only=True)
+        denied = args[args.index("--disallowedTools") + 1].split(",")
+        assert MCP_NAMESPACE_DENY in denied
+        assert "Bash(git commit)" in denied
+        assert "Bash(git push)" in denied
+
+    def test_deny_not_duplicated_when_profile_declares_it(self) -> None:
+        # A role that already declares mcp__* in denied_tools must not get it twice.
+        profile = PermissionProfile(
+            role="r", allowed_tools=["Read"], denied_tools=[MCP_NAMESPACE_DENY, "WebSearch"]
+        )
+        args = build_claude_scope_args(profile)
+        denied = args[args.index("--disallowedTools") + 1].split(",")
+        assert denied.count(MCP_NAMESPACE_DENY) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_worker_scoped_default.py
+++ b/tests/test_worker_scoped_default.py
@@ -119,3 +119,7 @@ class TestImportFallbackStubScoped:
         assert "--permission-mode" in cmd_line
         assert "--allowedTools" in cmd_line
         assert cmd_line.index("--mcp-config") < cmd_line.index("--strict-mcp-config")
+        # The import-fault fallback must also deny the whole mcp__ namespace
+        # (extension bridges are out of the empty --mcp-config's reach).
+        assert "--disallowedTools" in cmd_line
+        assert "mcp__*" in cmd_line


### PR DESCRIPTION
## The gap

PR #1503 made scoped worker-mode the default: every worker starts with
`--mcp-config '{"mcpServers":{}}' --strict-mcp-config`. Measured 2026-08-15:
that combination leaves the `mcp__` namespace of extension bridges open.

The seven servers from `claude mcp list` were blocked correctly.
`claude-in-chrome` is not in that list (an extension bridge, not an
`mcpServers`-spawned process), so the empty `--mcp-config` does not reach it.
The probe saw four working `mcp__claude-in-chrome__*` tool schemas via
ToolSearch. `--allowedTools` does not close the gap either: it is an
allow-list of built-in tools and does not restrict the `mcp__` namespace.

## What changes

- `build_claude_scope_args` appends `mcp__*` to `--disallowedTools`
  (constant `MCP_NAMESPACE_DENY`), skipped under `requires_mcp=True`.
- The tmux-lane import-fault fallback carries the same deny.
- `docs/operations/WORKER_PERMISSIONS.md` and `provider_constraints.yaml`
  (`worker-no-ambient-mcp`) make the mcpServers-vs-extension-bridge
  distinction explicit.

## Evidence the flag works (behavior, not the label)

The glob form is measured against `claude 2.1.233`, not assumed.
`--disallowedTools mcp__*` removes the whole namespace:

| Run | argv | `mcp__` surface |
|---|---|---|
| control (`requires_mcp=True`) | no empty `--mcp-config`, no deny | `mcp__mcp-perplexity-search__chat_completion` |
| scoped (default) | empty config + `mcp__*` deny | NONE |

Repeatable: `scripts/analysis/mcp_namespace_probe.py` (control vs scoped,
drives the real CLI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
