### PR TITLE
feat(plan-gate): size panel from governance variant (zwaarte)

### DIFF
--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -106,6 +106,13 @@ class DispatchSpec:
     model: Optional[str] = None
     skill: Optional[str] = None
     task_class: Optional[str] = None
+    # Operator-declared irreversibility (plan-gate weight ladder, 2026-08-15):
+    # a deletion/rename or a big architecture refactor cannot be walked back, so
+    # it forces the strictest governance variant. Path-derivable irreversible
+    # categories (schema migrations, fleet defaults, the receipt/ledger format)
+    # need no flag; this field covers the two that are NOT path-derivable. It is
+    # a declaration by the caller, never derived from instruction text or role.
+    irreversible: bool = False
     pr_id: Optional[str] = None
     track_id: Optional[str] = None  # structural link to a tracks-table row (TL-D1); validated at the door
     # Chain-link (dispatch-20260802-model-ssot-en-ketenlink): the predecessor

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -257,6 +257,30 @@ def seat_labels_for_governance_variant(
             f"known variants: {sorted(GOVERNANCE_VARIANT_SEAT_LABELS)}"
         )
     return list(labels)
+
+
+def seat_override_direction(
+    derived_variant: str, derived_count: int, chosen_count: int,
+) -> str:
+    """Direction of an operator seat override vs the variant-derived seat count.
+
+    Returns "" when the counts match (no override), "upgrade" when the operator
+    added seats, "downgrade" when they removed seats, or "strict-downgrade" when
+    they removed seats from a coding-strict derivation — the heaviest variant
+    class, where a lighter panel must be findable by a later sweep. Mirrors
+    ``smart_router``'s gate override direction on the seat-count axis: the seat
+    COUNT is the override axis, not the label set (a same-count relabel is not
+    an override).
+    """
+    if chosen_count == derived_count:
+        return ""
+    if chosen_count > derived_count:
+        return "upgrade"
+    if derived_variant == "coding-strict":
+        return "strict-downgrade"
+    return "downgrade"
+
+
 _OPEN_FENCE = "```" + VERDICT_FENCE
 _VALID_VERDICTS = {"pass", "revise", "block"}
 

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -211,6 +211,52 @@ def filter_panel_seats(
     # panel composition stays stable and auditable against the config.
     wanted = set(labels)
     return [s for s in seats if s["label"] in wanted]
+
+
+# ---------------------------------------------------------------------------
+# Governance-variant seat ladder (operator ladder, 2026-08-15). The panel SIZE
+# derives from the governance variant, not a flat "every plan gets the full
+# panel". The ladder, from lightest to heaviest:
+#   minimal (docs, reversible)           -> 0 seats (no panel runs at all)
+#   business-light / light               -> 1 seat  (opus)
+#   default (code)                       -> 2 seats (opus, kimi)
+#   coding-strict (core / irreversible)  -> 3 seats (opus, kimi, glm-5.2-harness)
+#   new feature (task_class 01_code_generation) -> full panel, regardless of variant
+# Labels are ordered to match DEFAULT_PANEL so filter_panel_seats keeps the
+# configured (auditable) order; the tuple length IS the seat count, so there is
+# no second count dict to drift.
+# ---------------------------------------------------------------------------
+GOVERNANCE_VARIANT_SEAT_LABELS: Dict[str, tuple[str, ...]] = {
+    "minimal": (),
+    "business-light": ("opus",),
+    "light": ("opus",),
+    "default": ("opus", "kimi"),
+    "coding-strict": ("opus", "kimi", "glm-5.2-harness"),
+}
+
+
+def seat_labels_for_governance_variant(
+    seats: List[Dict[str, str]], variant: str, *, is_new_feature: bool = False
+) -> List[str]:
+    """The seat labels a governance variant entitles a plan to, for one run.
+
+    A new feature (``is_new_feature``) always gets every configured seat — the
+    full diverse-family panel — because a new feature is the highest
+    blast-radius code change and must never be sized down by a coincidentally
+    light path. Otherwise the variant selects an ordered prefix of the
+    configured panel (``minimal`` selects none). Fail-loud on an unknown
+    variant: a variant the ladder does not know must never silently shrink to
+    zero seats.
+    """
+    if is_new_feature:
+        return [s["label"] for s in seats]
+    labels = GOVERNANCE_VARIANT_SEAT_LABELS.get(variant)
+    if labels is None:
+        raise ValueError(
+            f"plan-gate panel: unknown governance variant {variant!r}; "
+            f"known variants: {sorted(GOVERNANCE_VARIANT_SEAT_LABELS)}"
+        )
+    return list(labels)
 _OPEN_FENCE = "```" + VERDICT_FENCE
 _VALID_VERDICTS = {"pass", "revise", "block"}
 

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -58,6 +58,10 @@ class GovernanceVariantResult:
     reason: str        # why this variant was chosen (deterministic rule fired)
     gate: str          # the review-gate weight this variant resolves to
     direction: str     # "up" | "unchanged" | "down" vs the codex_gate baseline
+    # Independent axis (plan-gate weight ladder): True when task_class is
+    # 01_code_generation. A new feature runs the full panel regardless of the
+    # path-derived variant, so the plan-gate needs this carried alongside.
+    is_new_feature: bool = False
 
 
 @dataclass(frozen=True)
@@ -587,6 +591,49 @@ _CATEGORY_TO_VARIANT: dict[str, str] = {
 # silent downgrade.
 _CATEGORY_RANK: dict[str, int] = {"docs": 0, "business": 1, "code": 2, "core": 3}
 
+# Irreversible change categories (operator ladder, 2026-08-15). The three
+# PATH-DERIVABLE categories classify to the strictest variant (coding-strict)
+# no matter what the reversible ladder above would say, because a change that
+# cannot be walked back never gets a lighter gate:
+#   (1) schema migrations (scripts/migrations/, schemas/migrations/),
+#   (2) fleet defaults written by `vnx role sync` / `vnx init`
+#       (.claude/terminals/, .claude/skills/, agents/, skills/),
+#   (3) the append-only receipt/ledger format (ndjson_hash_chain, ndjson_io,
+#       receipt_schema, append_receipt_internals).
+# The other two (deletions/renames, big architecture refactors) are NOT
+# path-derivable — a rename looks like a normal edit — and need the spec's
+# explicit ``irreversible`` flag instead. Each entry maps a path prefix to the
+# human category name for the trace. Note agents/ and skills/ also appear in
+# _BUSINESS_PREFIXES; the irreversible check runs FIRST so the fleet-default
+# meaning wins over the reversible "non-code deliverable" meaning.
+_IRREVERSIBLE_PREFIXES: tuple[tuple[str, str], ...] = (
+    ("scripts/migrations/", "schema-migration"),
+    ("schemas/migrations/", "schema-migration"),
+    (".claude/terminals/", "fleet-default"),
+    (".claude/skills/", "fleet-default"),
+    ("agents/", "fleet-default"),
+    ("skills/", "fleet-default"),
+    ("scripts/lib/append_receipt_internals/", "receipt-format"),
+    ("scripts/lib/ndjson_hash_chain.py", "receipt-format"),
+    ("scripts/lib/ndjson_io.py", "receipt-format"),
+    ("scripts/lib/receipt_schema.py", "receipt-format"),
+)
+
+
+def _irreversible_path_category(path: str) -> Optional[str]:
+    """Return the irreversible category name a path falls under, else None.
+
+    First-match wins; deterministic. Called before the reversible category
+    ladder so an irreversible change is never silently sized down.
+    """
+    p = str(path).strip().lstrip("./")
+    if not p:
+        return None
+    for prefix, category in _IRREVERSIBLE_PREFIXES:
+        if _matches_prefix(p, prefix):
+            return category
+    return None
+
 
 def _matches_prefix(path: str, prefix: str) -> bool:
     """True when ``path`` equals the prefix's bare dir or lives under it."""
@@ -664,6 +711,7 @@ def derive_governance_variant(
     dispatch_paths: Optional[Sequence[str]] = None,
     *,
     task_class: Optional[str] = None,
+    irreversible: bool = False,
 ) -> GovernanceVariantResult:
     """Derive a governance variant from the signals the router already has.
 
@@ -673,8 +721,41 @@ def derive_governance_variant(
     role are deliberately NOT signals here: path + task_class already pin the
     risk class deterministically, and text/role guessing is exactly the
     ambiguity a model would be for; this rule has none.
+
+    Irreversibility overrides the reversible ladder: an explicit ``irreversible``
+    flag, or any path under an irreversible category (schema migrations, fleet
+    defaults, the append-only receipt/ledger format), forces coding-strict — a
+    change that cannot be walked back never gets a lighter gate. ``is_new_feature``
+    is an INDEPENDENT axis (task_class == 01_code_generation) carried on the
+    result so the plan-gate can size its panel to the full seat set for a new
+    feature regardless of the path-derived variant.
     """
+    is_new_feature = task_class == "01_code_generation"
     paths = [p for p in (dispatch_paths or []) if p and str(p).strip()]
+
+    irreversible_hit: Optional[str] = None
+    for p in paths:
+        irreversible_hit = _irreversible_path_category(str(p))
+        if irreversible_hit:
+            break
+
+    if irreversible or irreversible_hit:
+        if irreversible:
+            reason = "explicit irreversible=true on spec"
+            if irreversible_hit:
+                reason += f"; also path-derived {irreversible_hit}"
+        else:
+            reason = f"irreversible path category={irreversible_hit!r}"
+        variant = "coding-strict"
+        gate = GOVERNANCE_VARIANT_GATE[variant]
+        return GovernanceVariantResult(
+            variant=variant,
+            reason=reason,
+            gate=gate,
+            direction=_direction_for(gate),
+            is_new_feature=is_new_feature,
+        )
+
     if paths:
         category = max(
             (_path_category(str(p)) for p in paths),
@@ -694,6 +775,7 @@ def derive_governance_variant(
         reason=reason,
         gate=gate,
         direction=_direction_for(gate),
+        is_new_feature=is_new_feature,
     )
 
 
@@ -702,6 +784,7 @@ def resolve_gate(
     *,
     dispatch_paths: Optional[Sequence[str]] = None,
     task_class: Optional[str] = None,
+    irreversible: bool = False,
 ) -> GateWeightResolution:
     """Resolve the review-gate weight for a dispatch.
 
@@ -722,6 +805,7 @@ def resolve_gate(
     derived = derive_governance_variant(
         dispatch_paths=dispatch_paths,
         task_class=task_class,
+        irreversible=irreversible,
     )
     return GateWeightResolution(
         gate=derived.gate,

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -68,14 +68,25 @@ class GovernanceVariantResult:
 class GateWeightResolution:
     """Final review-gate weight for a dispatch.
 
-    ``source`` is "explicit" when the spec declared a gate (router never
-    overrides) or "derived" when the router filled a silent spec.
-    ``governance_variant`` is "" on the explicit path (no derivation ran).
+    ``source`` is "explicit" when the spec declared a gate (the router never
+    overrides it) or "derived" when the router filled a silent spec. On BOTH
+    paths ``governance_variant`` carries the variant the path derivation
+    produced, so an explicit gate is never a silent override of an unknown
+    weight — the trace always names what it replaced.
+
+    ``override_direction`` is "" when the chosen gate matches the derived gate
+    (or the path was derived with no explicit gate), else "upgrade",
+    "downgrade", or "strict-downgrade". "strict-downgrade" marks the one move
+    the mechanism treats as its most dangerous: an override that lightens a
+    coding-strict derivation (the heaviest variant class, picked exactly at
+    irreversible work). It is not blocked, only marked, so a later sweep can
+    find it.
     """
     gate: str
     source: str
     governance_variant: str
     reason: str
+    override_direction: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -779,6 +790,28 @@ def derive_governance_variant(
     )
 
 
+def _gate_override_direction(derived: GovernanceVariantResult, explicit_gate: str) -> str:
+    """Direction of an explicit gate vs the gate the derivation produced.
+
+    Uses ``_GATE_WEIGHT`` (the heaviness ladder over the closed Gate enum) so
+    "upgrade"/"downgrade" have a defined meaning, not a feeling. Returns ""
+    when the two weights are equal (no override) or either gate is unknown
+    (no false direction claim). "strict-downgrade" marks the special case: an
+    override that lightens a coding-strict derivation — the heaviest variant
+    class, chosen exactly at irreversible work — so a later sweep can find the
+    most dangerous move distinctly from an ordinary downgrade.
+    """
+    derived_weight = _GATE_WEIGHT.get(derived.gate)
+    chosen_weight = _GATE_WEIGHT.get(explicit_gate)
+    if derived_weight is None or chosen_weight is None:
+        return ""
+    if chosen_weight > derived_weight:
+        return "upgrade"
+    if chosen_weight < derived_weight:
+        return "strict-downgrade" if derived.variant == "coding-strict" else "downgrade"
+    return ""
+
+
 def resolve_gate(
     explicit_gate: str = "",
     *,
@@ -789,24 +822,43 @@ def resolve_gate(
     """Resolve the review-gate weight for a dispatch.
 
     An explicit gate on the spec always wins: the router fills in, it never
-    overrides (worker-provider-free-choice, pin_semantics=default). When the spec
-    is silent, the router derives a governance_variant and maps it to a gate
+    overrides (worker-provider-free-choice, pin_semantics=default). But the
+    derivation still runs on the explicit path so the trace names what the
+    override replaced: ``governance_variant`` carries the derived variant, and
+    ``reason``/``override_direction`` say whether the explicit gate is heavier
+    or lighter than it — an override is never silent about its direction, and a
+    coding-strict -> lighter override is marked distinctly. When the spec is
+    silent, the router derives a governance_variant and maps it to a gate
     weight; the variant, direction and reason are carried in ``reason`` so the
     trace is never silent about a lighter-than-baseline gate.
     """
     gate = (explicit_gate or "").strip()
-    if gate:
-        return GateWeightResolution(
-            gate=gate,
-            source="explicit",
-            governance_variant="",
-            reason=f"gate={gate} declared on spec; router did not override",
-        )
     derived = derive_governance_variant(
         dispatch_paths=dispatch_paths,
         task_class=task_class,
         irreversible=irreversible,
     )
+    if gate:
+        direction = _gate_override_direction(derived, gate)
+        if direction:
+            reason = (
+                f"gate={gate} declared on spec; OVERRIDES derived "
+                f"governance_variant={derived.variant!r} (gate={derived.gate}) "
+                f"- {direction.upper()}; {derived.reason}"
+            )
+        else:
+            reason = (
+                f"gate={gate} declared on spec; matches derived "
+                f"governance_variant={derived.variant!r} (gate={derived.gate}); "
+                f"router did not override"
+            )
+        return GateWeightResolution(
+            gate=gate,
+            source="explicit",
+            governance_variant=derived.variant,
+            reason=reason,
+            override_direction=direction,
+        )
     return GateWeightResolution(
         gate=derived.gate,
         source="derived",

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2329,17 +2329,30 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
         return 1
 
+    # Seat-override direction (operator ladder, 2026-08-15): when the operator
+    # sizes the panel away from the derived seat count, the trace names the
+    # derived count, the chosen count, and the direction — a downgrade from
+    # coding-strict is marked STRICT-DOWNGRADE so a later sweep can find it.
+    # The same count derived vs chosen is NOT an override (a same-count relabel
+    # keeps the panel's heft, so the direction is empty and no override is
+    # claimed).
+    override_direction = ""
+    if chosen_by == "operator":
+        override_direction = plan_gate_panel.seat_override_direction(
+            gov.variant, len(derived_labels), len(panel),
+        )
+
     gov_trace = (
         f"weight={gov.variant} new_feature={gov.is_new_feature} "
         f"-> {len(panel)} seat(s) by {chosen_by}"
     )
-    if chosen_by == "operator":
-        if len(derived_labels) != len(panel):
-            print(
-                f"plan-gate override: derived {len(derived_labels)} seat(s) "
-                f"({gov.variant}); operator chose {len(panel)} seat(s).",
-                file=sys.stderr,
-            )
+    if override_direction:
+        gov_trace += (
+            f"; OVERRIDES derived {len(derived_labels)} seat(s) "
+            f"({gov.variant}) - {override_direction.upper()}"
+        )
+    if override_direction:
+        print(f"plan-gate override: {gov_trace}.", file=sys.stderr)
     else:
         print(f"plan-gate seats: {gov_trace}.", file=sys.stderr)
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2270,7 +2270,7 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
     1 = infra error (doc/track missing, panel could not run).
     """
     import plan_gate_panel
-    import plan_gate_enforcement as _pge
+    import smart_router
 
     state_dir = _resolve_state_dir(args.state_dir)
     doc = Path(args.doc)
@@ -2284,36 +2284,119 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
 
     data_dir = os.environ.get("VNX_DATA_DIR") or str(Path(state_dir).parent)
 
-    # Scope read-site (VNX_PLAN_GATE_COMPLEX_ONLY): classify the plan light/heavy
-    # from the plan doc itself (fail-closed to HEAVY on anything unjudgeable). A
-    # LIGHT plan under the flag runs the reduced panel; its PASS is still a REAL
-    # pass — it resolves the blocker AND writes a durable plan_gate_pass with
-    # resolver=run and the seat count that decided it. An unreadable doc is an
-    # infra error, never a scope decision.
+    # An unreadable doc is an infra error, never a weight decision.
     try:
-        doc_text = doc.read_text(encoding="utf-8")
+        doc.read_text(encoding="utf-8")
     except OSError as exc:
         print(f"plan doc unreadable: {doc}: {exc}", file=sys.stderr)
         return 1
-    scope = _pge.plan_gate_scope(doc_text)
+
+    # Governance-weight read-site (operator ladder, 2026-08-15): the panel size
+    # derives from the governance variant (dispatch paths + task_class +
+    # irreversibility), not a flat "every plan gets the full panel". The derived
+    # weight is computed BEFORE seat selection so the trace can always show
+    # "derived X -> chose Y, by operator/derived" — an override is never silent.
+    raw_paths = getattr(args, "dispatch_paths", None)
+    dispatch_paths = None
+    if raw_paths:
+        dispatch_paths = [p.strip() for p in raw_paths.split(",") if p.strip()]
+    gov = smart_router.derive_governance_variant(
+        dispatch_paths=dispatch_paths,
+        task_class=getattr(args, "task_class", None),
+        irreversible=bool(getattr(args, "irreversible", False)),
+    )
 
     # Resolve the panel composition from configs/plan_gate_panel.yaml (falling
-    # back to DEFAULT_PANEL when absent). An explicit --panel-seats always wins;
-    # otherwise a LIGHT-scope plan under VNX_PLAN_GATE_COMPLEX_ONLY runs the
-    # reduced 2-seat panel automatically. Both an invalid config and an unknown
-    # seat label fail LOUD here — a dropped seat reads as an abstention and
-    # turns into a REVISE via the fail-safe rule, so misconfiguration must
-    # surface before the panel runs.
+    # back to DEFAULT_PANEL when absent). An explicit --panel-seats always wins
+    # (heavier OR lighter than the derived size); otherwise the governance
+    # variant sizes the panel. Both an invalid config and an unknown seat label
+    # fail LOUD here — a dropped seat reads as an abstention and turns into a
+    # REVISE via the fail-safe rule, so misconfiguration must surface before the
+    # panel runs.
     try:
         panel = plan_gate_panel.load_panel_seats()
+        derived_labels = plan_gate_panel.seat_labels_for_governance_variant(
+            panel, gov.variant, is_new_feature=gov.is_new_feature,
+        )
         if args.panel_seats:
             requested = [s.strip() for s in args.panel_seats.split(",") if s.strip()]
             panel = plan_gate_panel.filter_panel_seats(panel, requested)
-        elif _pge.complex_only_active() and scope == _pge.LIGHT:
-            panel = plan_gate_panel.filter_panel_seats(panel, list(_pge.LIGHT_PANEL_LABELS))
+            chosen_by = "operator"
+        else:
+            panel = plan_gate_panel.filter_panel_seats(panel, derived_labels)
+            chosen_by = "derived"
     except Exception as exc:
         print(f"plan-gate run failed: {exc}", file=sys.stderr)
         return 1
+
+    gov_trace = (
+        f"weight={gov.variant} new_feature={gov.is_new_feature} "
+        f"-> {len(panel)} seat(s) by {chosen_by}"
+    )
+    if chosen_by == "operator":
+        if len(derived_labels) != len(panel):
+            print(
+                f"plan-gate override: derived {len(derived_labels)} seat(s) "
+                f"({gov.variant}); operator chose {len(panel)} seat(s).",
+                file=sys.stderr,
+            )
+    else:
+        print(f"plan-gate seats: {gov_trace}.", file=sys.stderr)
+
+    # 0 seats: the derived weight requires no panel. Resolve the blocker with a
+    # reason that names the category — a plan-gate blocker is never cleared
+    # silently, and "no gate needed" is itself a recorded decision.
+    if not panel:
+        reason = (
+            f"derived weight={gov.variant} requires no panel "
+            f"(category not gated); no panel ran"
+        )
+        try:
+            resolved = _resolve_plan_blocker(
+                state_dir, args.track_id, args.project_id,
+                reason=reason, resolver="derived",
+            )
+            post = tracks_lib.get_track(state_dir, args.track_id, args.project_id)
+        except Exception as exc:
+            print(
+                f"derived no-panel pass, but unblocking track {args.track_id} failed: {exc}. "
+                "Track state unchanged — investigate before promoting.",
+                file=sys.stderr,
+            )
+            return 1
+        derived = post.get("derived_status") if isinstance(post, dict) else None
+        if derived == "blocked":
+            print(
+                f"derived no-panel pass, but track {args.track_id} is STILL blocked "
+                f"(plan blocker resolved={resolved}; another blocker or hard dependency "
+                "remains). Promote stays refused — clear the remaining blocker first.",
+                file=sys.stderr,
+            )
+            return 2
+        if resolved:
+            _emit_plan_gate_pass_record(
+                repo_root=getattr(args, "repo_root", None),
+                track_id=args.track_id, project_id=args.project_id, resolver="run",
+                seats=0, scope=gov.variant, reason=gov_trace,
+            )
+        if args.json:
+            print(json.dumps({
+                "decision": "PASS",
+                "derived_weight": gov.variant,
+                "seats": 0,
+                "summary": {
+                    "pass_count": 0, "revise_count": 0, "block_count": 0,
+                    "rationale": reason,
+                },
+                "panelists": [],
+            }, indent=2))
+        else:
+            print(
+                f"PASS — plan gate cleared (derived weight={gov.variant} needs no panel). "
+                f"{_plan_blocker_oi(args.track_id)} resolved={resolved}; "
+                f"track derived_status={derived}."
+            )
+        return 0
 
     try:
         result = plan_gate_panel.run_panel(
@@ -2403,21 +2486,21 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
             )
             return 2
         if resolved:
-            # A PASS that CLEARS the gate is a real pass for both scopes: write the
-            # durable, hash-chained plan_gate_pass record with resolver="run" and the
-            # seat count + scope that certified it. Before this, only `plan-gate
-            # attest` ever wrote a record, so the ledger was all-attest and the
-            # effectiveness probe read every gate as manually overridden even when
-            # the panel had actually converged (light and heavy alike).
+            # A PASS that CLEARS the gate is a real pass: write the durable,
+            # hash-chained plan_gate_pass record with resolver="run" and the seat
+            # count + derived weight (scope=governance variant) that certified it.
+            # Before this, only `plan-gate attest` ever wrote a record, so the
+            # ledger was all-attest and the effectiveness probe read every gate as
+            # manually overridden even when the panel had actually converged.
             wrote = _emit_plan_gate_pass_record(
                 repo_root=getattr(args, "repo_root", None),
                 track_id=args.track_id, project_id=args.project_id, resolver="run",
-                seats=len(panel), scope=scope,
+                seats=len(panel), scope=gov.variant, reason=gov_trace,
             )
             if not wrote:
                 print(
                     f"WARNING: plan_gate_pass evidence NOT written for track "
-                    f"{args.track_id} (resolver=run, seats={len(panel)}, scope={scope}). "
+                    f"{args.track_id} (resolver=run, seats={len(panel)}, scope={gov.variant}). "
                     "The plan blocker IS resolved, but the durable pass record is "
                     "missing - the merge gate may not recognize this pass.",
                     file=sys.stderr,
@@ -2926,6 +3009,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="per-seat deadline in seconds before a panelist times out and books a "
              "fabricated abstention (OI-1068). Defaults to VNX_PLAN_GATE_SEAT_TIMEOUT "
              "(default 900) — the same env-var-knob style as VNX_PANEL_RETRY.",
+    )
+    p_prun.add_argument(
+        "--dispatch-paths",
+        dest="dispatch_paths",
+        default=None,
+        help="comma-separated repo paths the plan touches; drives the governance "
+             "weight (variant) that sizes the panel (operator ladder). Default: no "
+             "paths (task_class or the code baseline).",
+    )
+    p_prun.add_argument(
+        "--task-class",
+        dest="task_class",
+        default=None,
+        help="task class for the plan from the smart-router closed set "
+             "(e.g. 01_code_generation marks a NEW FEATURE, which always runs the "
+             "full panel).",
+    )
+    p_prun.add_argument(
+        "--irreversible",
+        dest="irreversible",
+        action="store_true",
+        help="declare the change irreversible (deletion/rename/big architecture "
+             "refactor); forces coding-strict (3 seats).",
     )
     p_prun.set_defaults(func=cmd_plan_gate_run)
 

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -26,7 +26,6 @@ import tracks  # noqa: E402
 import track_reconciler  # noqa: E402
 import planning_cli  # noqa: E402
 import plan_gate_panel as pgp  # noqa: E402
-import plan_gate_enforcement as pge  # noqa: E402
 from ndjson_hash_chain import walk_chain  # noqa: E402
 
 
@@ -1889,6 +1888,43 @@ def test_filter_panel_seats_rejects_unknown_label_listing_configured():
         assert lbl in msg
 
 
+# --------------------------------------------------------------------------
+# Governance-variant seat ladder (operator ladder, 2026-08-15): the panel size
+# derives from the variant, not a flat full panel. Asserts on the ordered label
+# prefix per rung and on the full-panel behaviour for a new feature.
+# --------------------------------------------------------------------------
+
+def test_seat_labels_minimal_is_empty():
+    assert pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "minimal") == []
+
+
+def test_seat_labels_default_is_opus_kimi():
+    labels = pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "default")
+    assert labels == ["opus", "kimi"]
+
+
+def test_seat_labels_coding_strict_is_three_families():
+    labels = pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "coding-strict")
+    assert labels == ["opus", "kimi", "glm-5.2-harness"]
+
+
+def test_seat_labels_light_is_single_opus_seat():
+    assert pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "light") == ["opus"]
+    assert pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "business-light") == ["opus"]
+
+
+def test_seat_labels_new_feature_is_full_panel_regardless_of_variant():
+    labels = pgp.seat_labels_for_governance_variant(
+        pgp.DEFAULT_PANEL, "minimal", is_new_feature=True,
+    )
+    assert labels == [s["label"] for s in pgp.DEFAULT_PANEL]
+
+
+def test_seat_labels_unknown_variant_fails_loud():
+    with pytest.raises(ValueError, match="unknown governance variant"):
+        pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "not-a-variant")
+
+
 def test_cmd_plan_gate_run_passes_filtered_panel_to_run_panel(tmp_path, monkeypatch):
     """--panel-seats filters the configured panel and run_panel receives exactly
     those seats. Asserts on the dispatcher mock's calls (the seats it was
@@ -1977,13 +2013,15 @@ def _fake_pass_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **k
     }
 
 
-def test_cmd_plan_gate_run_light_plan_runs_fewer_seats_than_heavy(tmp_path, monkeypatch):
-    """VNX_PLAN_GATE_COMPLEX_ONLY=1: a LIGHT plan runs the reduced 2-seat panel
-    while a HEAVY plan keeps the full panel — the scope read-site sizes the gate."""
+def test_cmd_plan_gate_run_ladder_sizes_panel_from_variant(tmp_path, monkeypatch):
+    """The governance variant sizes the panel: default (code) -> 2 seats
+    (opus+kimi), coding-strict (core) -> 3 seats (opus, kimi, glm-5.2-harness),
+    and a new feature (task_class 01_code_generation) -> the full 5-seat panel
+    even on a docs path. Asserts on the actual providers dispatched, not just
+    the seat count."""
     import argparse
 
     monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
-    monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "1")
     seen_panels: list = []
 
     def _capturing_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
@@ -1993,29 +2031,120 @@ def test_cmd_plan_gate_run_light_plan_runs_fewer_seats_than_heavy(tmp_path, monk
 
     monkeypatch.setattr(pgp, "run_panel", _capturing_run_panel)
     monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
 
     state_dir = _bootstrap(tmp_path)
-    tracks.create_track(state_dir, "feat-light", "p1", "t", "shipped", phase="queued")
-    tracks.create_track(state_dir, "feat-heavy", "p1", "t", "shipped", phase="queued")
+    tracks.create_track(state_dir, "feat-default", "p1", "t", "shipped", phase="queued")
+    tracks.create_track(state_dir, "feat-core", "p1", "t", "shipped", phase="queued")
+    tracks.create_track(state_dir, "feat-new", "p1", "t", "shipped", phase="queued")
 
-    light_doc = tmp_path / "light.md"
-    light_doc.write_text("## Approach\nAdd a rename button to the dashboard view.\n", encoding="utf-8")
-    heavy_doc = tmp_path / "heavy.md"
-    heavy_doc.write_text("## Approach\nTouch dispatch_cli.py and a schema migration.\n", encoding="utf-8")
-
-    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
-        track_id="feat-light", project_id="p1", state_dir=str(state_dir),
-        doc=str(light_doc), json=False, panel_seats=None,
-    ))
-    assert rc == 0
-    assert [s["label"] for s in seen_panels[0]] == list(pge.LIGHT_PANEL_LABELS)
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
 
     rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
-        track_id="feat-heavy", project_id="p1", state_dir=str(state_dir),
-        doc=str(heavy_doc), json=False, panel_seats=None,
+        track_id="feat-default", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+        dispatch_paths="scripts/lib/some_utility.py",
     ))
     assert rc == 0
-    assert [s["label"] for s in seen_panels[1]] == [m["label"] for m in pgp.DEFAULT_PANEL]
+    assert [s["provider"] for s in seen_panels[0]] == ["claude", "kimi"]
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-core", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+        dispatch_paths="scripts/lib/dispatch_cli.py",
+    ))
+    assert rc == 0
+    assert [s["provider"] for s in seen_panels[1]] == ["claude", "kimi", "glm-harness"]
+
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-new", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+        dispatch_paths="docs/operations/foo.md", task_class="01_code_generation",
+    ))
+    assert rc == 0
+    assert [s["provider"] for s in seen_panels[2]] == [
+        "claude", "kimi", "glm-harness", "deepseek-harness", "codex",
+    ]
+
+
+def test_cmd_plan_gate_run_operator_override_wins_both_directions(tmp_path, monkeypatch):
+    """--panel-seats overrides the derived weight in BOTH directions: a minimal
+    (0-seat) plan can be forced heavier, and a coding-strict (3-seat) plan can
+    be forced lighter."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    seen_panels: list = []
+
+    def _capturing_run_panel(doc_path, *, track_id, project_id, panel, data_dir, **kw):
+        seen_panels.append(panel)
+        return _fake_pass_run_panel(doc_path, track_id=track_id, project_id=project_id,
+                                    panel=panel, data_dir=data_dir, **kw)
+
+    monkeypatch.setattr(pgp, "run_panel", _capturing_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-ov1", "p1", "t", "shipped", phase="queued")
+    tracks.create_track(state_dir, "feat-ov2", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nGeneric widget fix.\n", encoding="utf-8")
+
+    # HEAVIER: minimal (docs) derives 0 seats, operator forces 2.
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-ov1", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats="opus,kimi",
+        dispatch_paths="docs/operations/dispatch-rules.md",
+    ))
+    assert rc == 0
+    assert [s["provider"] for s in seen_panels[0]] == ["claude", "kimi"]
+
+    # LIGHTER: coding-strict (core) derives 3 seats, operator forces 1.
+    rc = planning_cli.cmd_plan_gate_run(argparse.Namespace(
+        track_id="feat-ov2", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats="opus",
+        dispatch_paths="scripts/lib/dispatch_cli.py",
+    ))
+    assert rc == 0
+    assert [s["provider"] for s in seen_panels[1]] == ["claude"]
+
+
+def test_cmd_plan_gate_run_minimal_variant_resolves_without_panel(tmp_path, monkeypatch):
+    """A minimal (docs) plan derives 0 seats: no panel runs, and the blocker is
+    resolved with a non-empty reason naming the derived weight/category."""
+    import argparse
+
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    run_called = {"n": 0}
+    monkeypatch.setattr(pgp, "run_panel", lambda *a, **k: run_called.__setitem__("n", run_called["n"] + 1))
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-docs", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nUpdate the README.\n", encoding="utf-8")
+
+    captured = {}
+
+    def _fake_resolve(state_dir, track_id, project_id, *, reason, resolver, approval_id=None):
+        captured["reason"] = reason
+        captured["resolver"] = resolver
+        return True
+
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", _fake_resolve)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+    args = argparse.Namespace(
+        track_id="feat-docs", project_id="p1", state_dir=str(state_dir),
+        doc=str(doc), json=False, panel_seats=None,
+        dispatch_paths="docs/operations/dispatch-rules.md",
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    assert rc == 0
+    assert run_called["n"] == 0  # no panel ran
+    assert captured["resolver"] == "derived"
+    assert "minimal" in captured["reason"]
 
 
 def test_cmd_plan_gate_run_passes_seat_timeout_flag_to_run_panel(tmp_path, monkeypatch):
@@ -2080,24 +2209,25 @@ def test_cmd_plan_gate_run_no_flag_falls_back_to_env_via_run_panel(tmp_path, mon
     assert seen_timeouts == [None]
 
 
-def test_cmd_plan_gate_run_light_pass_writes_run_evidence_with_seats(tmp_path, monkeypatch):
-    """A successful LIGHT run writes a durable plan_gate_pass with resolver=run
-    carrying the seat count + scope that certified it — a light pass is a real pass."""
+def test_cmd_plan_gate_run_pass_writes_run_evidence_with_derived_weight(tmp_path, monkeypatch):
+    """A successful derived run writes a durable plan_gate_pass with resolver=run
+    carrying the seat count + derived weight (scope=governance variant) that
+    certified it — a sized-down pass is still a real pass."""
     import argparse
 
     monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
-    monkeypatch.setenv("VNX_PLAN_GATE_COMPLEX_ONLY", "1")
     monkeypatch.setattr(pgp, "run_panel", _fake_pass_run_panel)
     monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
 
     state_dir = _bootstrap(tmp_path)
-    tracks.create_track(state_dir, "feat-light", "p1", "t", "shipped", phase="queued")
-    doc = tmp_path / "light.md"
+    tracks.create_track(state_dir, "feat-default", "p1", "t", "shipped", phase="queued")
+    doc = tmp_path / "plan.md"
     doc.write_text("## Approach\nAdd a rename button to the dashboard view.\n", encoding="utf-8")
 
     args = argparse.Namespace(
-        track_id="feat-light", project_id="p1", state_dir=str(state_dir),
+        track_id="feat-default", project_id="p1", state_dir=str(state_dir),
         doc=str(doc), json=False, panel_seats=None, repo_root=str(tmp_path),
+        dispatch_paths="scripts/lib/some_utility.py",
     )
     rc = planning_cli.cmd_plan_gate_run(args)
     assert rc == 0
@@ -2108,10 +2238,10 @@ def test_cmd_plan_gate_run_light_pass_writes_run_evidence_with_seats(tmp_path, m
     assert len(records) == 1
     rec = records[0]
     assert rec["type"] == "plan_gate_pass"
-    assert rec["track_id"] == "feat-light"
+    assert rec["track_id"] == "feat-default"
     assert rec["resolver"] == "run"
-    assert rec["seats"] == len(pge.LIGHT_PANEL_LABELS)
-    assert rec["scope"] == "light"
+    assert rec["seats"] == 2
+    assert rec["scope"] == "default"
 
 
 def test_cmd_plan_gate_run_pass_with_failed_evidence_is_loud_not_silent(tmp_path, monkeypatch, capsys):

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -1925,6 +1925,23 @@ def test_seat_labels_unknown_variant_fails_loud():
         pgp.seat_labels_for_governance_variant(pgp.DEFAULT_PANEL, "not-a-variant")
 
 
+def test_seat_override_direction_upgrade_when_operator_adds_seats():
+    assert pgp.seat_override_direction("minimal", 0, 2) == "upgrade"
+
+
+def test_seat_override_direction_downgrade_when_operator_removes_seats():
+    assert pgp.seat_override_direction("default", 2, 1) == "downgrade"
+
+
+def test_seat_override_direction_strict_downgrade_from_coding_strict():
+    assert pgp.seat_override_direction("coding-strict", 3, 1) == "strict-downgrade"
+
+
+def test_seat_override_direction_empty_when_counts_match():
+    assert pgp.seat_override_direction("coding-strict", 3, 3) == ""
+    assert pgp.seat_override_direction("minimal", 0, 0) == ""
+
+
 def test_cmd_plan_gate_run_passes_filtered_panel_to_run_panel(tmp_path, monkeypatch):
     """--panel-seats filters the configured panel and run_panel receives exactly
     those seats. Asserts on the dispatcher mock's calls (the seats it was

--- a/tests/test_smart_router_governance_variant.py
+++ b/tests/test_smart_router_governance_variant.py
@@ -96,7 +96,7 @@ class TestResolveGate:
         )
         assert result.gate == "codex_gate"
         assert result.source == "explicit"
-        assert result.governance_variant == ""
+        assert result.governance_variant == "minimal"
 
     def test_explicit_gate_wins_even_when_router_would_be_stricter(self):
         result = resolve_gate(
@@ -138,6 +138,68 @@ class TestTraceVisibility:
     def test_baseline_gate_direction_is_unchanged(self):
         result = resolve_gate(dispatch_paths=["scripts/lib/some_utility.py"])
         assert "direction=unchanged" in result.reason
+
+
+class TestOverrideTrace:
+    """The explicit gate is never a silent override: the trace names the derived
+    weight, the chosen weight, and the direction. A downgrade from coding-strict
+    (the heaviest variant class) is marked distinctly from an ordinary downgrade.
+    """
+
+    def test_migration_ci_gate_override_is_strict_downgrade(self):
+        result = resolve_gate(
+            explicit_gate="ci_gate",
+            dispatch_paths=["scripts/migrations/0034_drop_column.py"],
+        )
+        assert result.gate == "ci_gate"
+        assert result.source == "explicit"
+        assert result.governance_variant == "coding-strict"
+        assert result.override_direction == "strict-downgrade"
+        assert "coding-strict" in result.reason
+        assert "STRICT-DOWNGRADE" in result.reason
+
+    def test_docs_codex_gate_override_is_upgrade(self):
+        result = resolve_gate(
+            explicit_gate="codex_gate",
+            dispatch_paths=["docs/operations/dispatch-rules.md"],
+        )
+        assert result.gate == "codex_gate"
+        assert result.source == "explicit"
+        assert result.governance_variant == "minimal"
+        assert result.override_direction == "upgrade"
+        assert "minimal" in result.reason
+        assert "codex_gate" in result.reason
+        assert "UPGRADE" in result.reason
+
+    def test_override_equal_to_derived_is_not_flagged(self):
+        result = resolve_gate(
+            explicit_gate="codex_gate",
+            dispatch_paths=["scripts/lib/some_utility.py"],
+        )
+        assert result.governance_variant == "default"
+        assert result.override_direction == ""
+        assert "OVERRIDES" not in result.reason
+        assert "did not override" in result.reason
+
+    def test_no_override_derived_path_is_unchanged(self):
+        result = resolve_gate(dispatch_paths=["scripts/lib/dispatch_cli.py"])
+        assert result.source == "derived"
+        assert result.governance_variant == "coding-strict"
+        assert result.override_direction == ""
+
+    def test_strict_downgrade_distinct_from_ordinary_downgrade(self):
+        strict = resolve_gate(
+            explicit_gate="ci_gate",
+            dispatch_paths=["scripts/migrations/0034_drop_column.py"],
+        )
+        ordinary = resolve_gate(
+            explicit_gate="ci_gate",
+            dispatch_paths=["scripts/lib/some_utility.py"],
+        )
+        assert strict.override_direction == "strict-downgrade"
+        assert ordinary.override_direction == "downgrade"
+        assert "STRICT-DOWNGRADE" in strict.reason
+        assert "STRICT-DOWNGRADE" not in ordinary.reason
 
 
 class TestVocabularyGuard:

--- a/tests/test_smart_router_governance_variant.py
+++ b/tests/test_smart_router_governance_variant.py
@@ -153,3 +153,61 @@ class TestVocabularyGuard:
     def test_baseline_gate_is_the_heaviest(self):
         assert _GATE_BASELINE == "codex_gate"
         assert _GATE_WEIGHT["codex_gate"] == max(_GATE_WEIGHT.values())
+
+
+class TestIrreversibility:
+    def test_explicit_irreversible_flag_forces_coding_strict(self):
+        result = derive_governance_variant(
+            dispatch_paths=["docs/operations/foo.md"], irreversible=True,
+        )
+        assert result.variant == "coding-strict"
+        assert result.gate == "codex_gate"
+        assert "irreversible" in result.reason
+
+    def test_schema_migration_path_is_irreversible(self):
+        result = derive_governance_variant(
+            dispatch_paths=["schemas/migrations/0034_x.sql"]
+        )
+        assert result.variant == "coding-strict"
+        assert "irreversible" in result.reason
+
+    def test_fleet_default_path_is_irreversible(self):
+        result = derive_governance_variant(dispatch_paths=["skills/foo/bar.md"])
+        assert result.variant == "coding-strict"
+
+    def test_receipt_format_path_is_irreversible(self):
+        result = derive_governance_variant(
+            dispatch_paths=["scripts/lib/ndjson_hash_chain.py"]
+        )
+        assert result.variant == "coding-strict"
+
+    def test_irreversible_path_wins_over_light_reversible_paths(self):
+        result = derive_governance_variant(
+            dispatch_paths=["docs/foo.md", "agents/t0.md"]
+        )
+        assert result.variant == "coding-strict"
+
+    def test_resolve_gate_irreversible_forces_coding_strict(self):
+        result = resolve_gate(
+            dispatch_paths=["docs/operations/foo.md"], irreversible=True,
+        )
+        assert result.gate == "codex_gate"
+        assert result.governance_variant == "coding-strict"
+
+
+class TestNewFeatureAxis:
+    def test_code_generation_task_class_is_new_feature(self):
+        result = derive_governance_variant(task_class="01_code_generation")
+        assert result.is_new_feature is True
+
+    def test_new_feature_axis_is_independent_of_path_variant(self):
+        result = derive_governance_variant(
+            dispatch_paths=["docs/operations/foo.md"],
+            task_class="01_code_generation",
+        )
+        assert result.variant == "minimal"
+        assert result.is_new_feature is True
+
+    def test_non_code_generation_is_not_new_feature(self):
+        result = derive_governance_variant(task_class="04_documentation")
+        assert result.is_new_feature is False

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -740,6 +740,29 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
              "fabricated abstention (OI-1068). Defaults to VNX_PLAN_GATE_SEAT_TIMEOUT "
              "(default 900) — the same env-var-knob style as VNX_PANEL_RETRY.",
     )
+    p_prun.add_argument(
+        "--dispatch-paths",
+        dest="dispatch_paths",
+        default=None,
+        help="comma-separated repo paths the plan touches; drives the governance "
+             "weight (variant) that sizes the panel (operator ladder). Default: no "
+             "paths (task_class or the code baseline).",
+    )
+    p_prun.add_argument(
+        "--task-class",
+        dest="task_class",
+        default=None,
+        help="task class for the plan from the smart-router closed set "
+             "(e.g. 01_code_generation marks a NEW FEATURE, which always runs the "
+             "full panel).",
+    )
+    p_prun.add_argument(
+        "--irreversible",
+        dest="irreversible",
+        action="store_true",
+        help="declare the change irreversible (deletion/rename/big architecture "
+             "refactor); forces coding-strict (3 seats).",
+    )
 
     p_pstat = subs.add_parser(
         "status", help="show a track's plan-gate state + derived_status",


### PR DESCRIPTION
## Wat

De plan-gate draait niet langer hetzelfde volle panel voor elk plan. De paneldikte komt nu uit de governance-variant.

## De ladder (operator, 15-08)

- `minimal` (docs, reversibel) -> 0 seats, geen panel; de blocker gaat dicht met een reden die de categorie noemt
- `business-light` / `light` -> 1 seat (opus)
- `default` (code) -> 2 seats (opus, kimi)
- `coding-strict` (core / irreversibel) -> 3 seats (opus, kimi, glm-5.2-harness)
- nieuw feature (`task_class = 01_code_generation`) -> vol panel, ongeacht de pad-variant

## Irreversibiliteit als nieuwe as

- Pad-afleidbaar: schema-migraties, fleet-defaults (`vnx role sync`/`vnx init`), het append-only receipt/ledger-formaat.
- Niet pad-afleidbaar (deletie/rename, grote refactor): expliciet `irreversible`-veld op de spec. Nooit afgeleid uit instructietekst of rol.

## Override

`--panel-seats` wint altijd (zwaarder én lichter), en de trace print derived vs gekozen (wie, hoeveel, welke variant). Volgt het `resolve_gate(explicit_gate=...)`-patroon.

## Bestanden

- `scripts/lib/smart_router.py` — irreversibiliteit + `is_new_feature`-as in `derive_governance_variant`/`resolve_gate`
- `scripts/lib/plan_gate_panel.py` — seat-ladder per variant
- `scripts/planning_cli.py` — `cmd_plan_gate_run` kiest seats via de variant; 0-seat pad lost de blocker op met reden
- `scripts/lib/dispatch_spec.py` — nieuw `irreversible`-veld
- `tests/` — gedragstests inclusief echte providers (2 seats = opus+kimi)

## Toetsing

163 gerichte tests groen (smart_router 29, plan_gate_panel-ladder 10, dispatch_spec 73, planning_cli 51). Geen `--no-verify`.

## Fix-forward: override trace (20260815-override-trace)

Punt 7 eist dat een override zichtbaar is met wat hij verving. De eerste versie deed dat niet: `resolve_gate` verliet vroeg op het expliciete pad met `governance_variant=""` en "router did not override", dus een schema-migratie die van `coding-strict` naar `ci_gate` ging liet geen spoor van de afgeleide zwaarte achter.

- `resolve_gate` draait `derive_governance_variant` nu ook op het expliciete pad en vult `governance_variant` met wat er afgeleid zou zijn.
- `GateWeightResolution.override_direction` = `""` / `upgrade` / `downgrade` / `strict-downgrade`, via de bestaande `_GATE_WEIGHT`-ladder. De reason noemt afgeleide + gekozen + richting.
- Een downgrade vanaf `coding-strict` (de zwaarste klasse, precies bij onomkeerbaar werk) is `STRICT-DOWNGRADE`, onderscheidbaar van een gewone `DOWNGRADE`.
- Zelfde drieslag voor de seat-override via `plan_gate_panel.seat_override_direction`.

Toetsing (aanvulling): `test_smart_router_governance_variant.py` 34 groen (5 nieuwe override-trace tests), `test_smart_router*.py` 205 groen, `test_planning_cli.py` 37 groen, `test_plan_gate_panel.py` 123 groen + 5 pre-existing fail (hetzelfde `output_ref`-gat hieronder).

## Open items

- 7 pre-existing test-failures buiten deze boundary (5 in test_plan_gate_panel.py via ontbrekende `output_ref`-kolom in de `_bootstrap`-helper, 2 in test_planning_cli_objective.py via horizon-ordering). Niet aangeraakt, buiten scope.
- 10 pre-existing ruff-meldingen in de aangeraakte bestanden (F541/F401/F841/E741). Geen enkele zit in de nieuwe code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)