### PR TITLE
feat(gate): enforce dispatch_paths as file_write_scope (OI-1196)

### DIFF
--- a/docs/operations/WORKER_PERMISSIONS.md
+++ b/docs/operations/WORKER_PERMISSIONS.md
@@ -1,7 +1,8 @@
 # Worker Permissions
 
 > Status: current as of 2026-08-15 (scoped worker-mode is the fabric default,
-> with the `mcp__` tool namespace denied explicitly; revising the 03-08
+> with the `mcp__` tool namespace denied explicitly, and `dispatch_paths`
+> narrowing `file_write_scope` per dispatch (OI-1196); revising the 03-08
 > blanket-skip ratification and the 14-08 mcp-scoped-default flip).
 > Covers the two dispatch lanes that spawn a headless/detached Claude worker:
 > the tmux-spawn lane (`tmux_interactive_dispatch.py`) and the subprocess lane
@@ -80,15 +81,18 @@ Project SSOT for scoped-mode profiles. Each role under `profiles:` declares:
 | Key | Meaning | Enforced how |
 |---|---|---|
 | `allowed_tools` / `denied_tools` | Claude Code tool allow/deny list | **Hard-enforced** via `--allowedTools`/`--disallowedTools` — scoped mode is the default, so this binds unless the dispatch explicitly opts out (`VNX_WORKER_BLANKET_SKIP=1` or falsy `VNX_WORKER_SCOPED`) |
-| `bash_allow_patterns` / `bash_deny_patterns` | Shell glob patterns describing expected/forbidden Bash commands | **Advisory only** — rendered into the instruction preamble via `generate_permission_preamble()`; `match_bash_deny()` exists (`scripts/lib/worker_permissions.py:320-328`) but nothing in the dispatch path calls it at Bash-tool time, so it is not a real-time gate |
-| `file_write_scope` | Glob patterns for where the role may write | **Advisory only** — same preamble-only path; `match_file_write_scope()` (`scripts/lib/worker_permissions.py:331-338`) is unused outside tests |
+| `bash_allow_patterns` / `bash_deny_patterns` | Shell glob patterns describing expected/forbidden Bash commands | Rendered into the instruction preamble via `generate_permission_preamble()` (always) **and** real-time-gated via `match_bash_deny()` in the PreToolUse hook (`scripts/hooks/pretooluse_worker_scope_enforce.py`) — but that hook is a no-op unless `VNX_ENFORCE_WORKER_PERMISSIONS=1` (default **OFF**), so outside that opt-in the preamble is the only effect |
+| `file_write_scope` | Glob patterns for where the role may write | Same preamble-only-by-default story as above, via `match_file_write_scope()` (`scripts/lib/worker_permissions.py`) in the same hook — real-time-gated, `VNX_ENFORCE_WORKER_PERMISSIONS=1` required. OI-1196 (15-08): the hook also narrows this to a dispatch's own declared `dispatch_paths` when present (never wider than the role — see below); previously `dispatch_paths` had no enforcement channel at all, only the `_scope_note()` prompt text |
 | `mcp_servers` | Per-role allowlist of named MCP servers | **Hard-enforced** via a scoped `--mcp-config` (`resolve_role_mcp_config()`) — takes effect in scoped mode (the default), and only when `requires_mcp=False`. An empty list (the default; no shipped role currently declares one) keeps the `{"mcpServers":{}}` posture. A named server not defined in the ambient global config (`~/.claude.json`, or `VNX_GLOBAL_MCP_CONFIG_PATH` override) is skipped and logged, never fabricated |
 | `terminal_assignments` | `T1`/`T2`/`T3` → expected role | Checked by `validate_dispatch_permissions()`, called from `subprocess_dispatch_internals/skill_injection.py:_inject_permission_profile` — a mismatch only **logs a warning**, it does not block the dispatch |
 
 Current profiles (`.vnx/worker_permissions.yaml`): `backend-developer`,
-`test-engineer`, `frontend-developer`, `architect`, `database-engineer`,
-`intelligence-engineer`, `security-engineer`. `terminal_assignments` maps
-`T1: backend-developer`, `T2: test-engineer`, `T3: frontend-developer`.
+`quality-engineer`, `frontend-developer`, `system-architect`,
+`security-engineer`, `code-reviewer`, `research-analyst` (OI-1100 renamed
+`test-engineer`→`quality-engineer` and `architect`→`system-architect`, and
+dropped the never-dispatched `database-engineer`/`intelligence-engineer`
+entries). `terminal_assignments` maps `T1: backend-developer`,
+`T2: quality-engineer`, `T3: frontend-developer`.
 
 An unknown/missing role, or a profile with no `allowed_tools`, falls back to
 `default_code_worker_profile()` (`Read, Write, Edit, MultiEdit, Bash, Grep,
@@ -100,6 +104,52 @@ empty ambient-MCP config bind on every detached dispatch unless the operator
 explicitly opts out (`VNX_WORKER_BLANKET_SKIP=1` or falsy `VNX_WORKER_SCOPED`).
 `.vnx/worker_permissions.yaml` therefore has runtime effect by default; it only
 stops mattering for a dispatch that opts back into blanket skip.
+
+## OI-1196 — `dispatch_paths` narrows `file_write_scope`, per dispatch
+
+A dispatch's own `--dispatch-paths` (tmux lane; plain strings, optionally
+suffixed `:access` where `access` is a `PathAccess` value — `read` / `write`
+/ `read_write` / `create`, default `read_write`) can narrow a role's
+`file_write_scope` further, down to just the paths that dispatch declared.
+It can only narrow, never widen: `scripts/lib/worker_permissions.py`'s
+`match_file_write_scope()` requires the role check to pass first, then —
+only when the dispatch declared paths — a second, independent check against
+the write-granting subset of those paths (entries with `access=read` are
+excluded: this mechanism enforces WRITE scope only, so `read` honestly means
+"not a write grant", not an additional read-side restriction the fabric does
+not otherwise have).
+
+Wiring: `TmuxInteractiveDispatch._spawn_session()` JSON-encodes
+`dispatch_paths` into the worker's pane as `VNX_DISPATCH_PATHS` (alongside
+the existing `VNX_WORKER_ROLE`); `pretooluse_worker_scope_enforce.py` reads
+it via `resolve_dispatch_write_scope()` and passes the result into
+`match_file_write_scope()`. No `dispatch_paths` declared → `None` → identical
+to pre-OI-1196 behavior (role scope alone). `dispatch_paths` declared but
+every entry is `access=read` → an empty (not `None`) write-scope list → every
+write is blocked, correctly reflecting "this dispatch does no writing".
+
+Fail-open, deliberately and narrowly: a missing or malformed
+`VNX_DISPATCH_PATHS` degrades to `None` (no per-dispatch narrowing) rather
+than blocking. This is safe because it only removes the EXTRA narrowing —
+the role's `file_write_scope` check runs unconditionally either way, so
+malformed dispatch-scope data can never widen a worker past its role's
+bound, only fail to apply a tightening beyond it. This mechanism inherits
+the same `VNX_ENFORCE_WORKER_PERMISSIONS` gate as `file_write_scope` above
+(default OFF): the plumbing gap described in OI-1196 is closed, but the
+fleet-wide enforcement default is a separate, already-documented decision
+this change does not alter.
+
+The typed `DispatchSpec.dispatch_paths` surface (`scripts/lib/dispatch_spec.py`,
+part of the single-entry dispatch door) has its own, independent `access`
+field on each `DispatchPath`. `dispatch_spec.write_paths()` is the first code
+that actually reads it (OI-1196) — it filters to the write-granting subset,
+mirroring the CLI-string logic above via the shared
+`WRITE_GRANTING_PATH_ACCESS` constant. It is not yet wired to the tmux lane's
+`--dispatch-paths` (that bridge is `dispatch_cli.py`/`dispatch_bridge.py`,
+outside this change) — today the two `dispatch_paths` concepts (typed
+`DispatchPath` tuples in the door's spec, and the plain path-string CLI list
+in the tmux/hook enforcement path above) are parsed independently rather than
+sharing one object.
 
 ## The fail-closed exception: `working_tree_only`
 

--- a/scripts/hooks/pretooluse_worker_scope_enforce.py
+++ b/scripts/hooks/pretooluse_worker_scope_enforce.py
@@ -9,6 +9,14 @@ worker permission SSOT (``.vnx/worker_permissions.yaml`` via
 tool call. Reuses the existing matchers verbatim — no reimplementation of
 matching logic.
 
+OI-1196: the file_write_scope check additionally narrows to this dispatch's
+own declared paths, when any were declared. ``VNX_DISPATCH_PATHS`` (a JSON
+list, exported by ``TmuxInteractiveDispatch._spawn_session`` from the
+dispatch's ``--dispatch-paths``) is resolved via
+``worker_permissions.resolve_dispatch_write_scope`` and passed to
+``match_file_write_scope`` as an additional, ANDed constraint — a dispatch
+can only narrow the role's scope, never widen it.
+
 Feasibility proven by docs/investigations/spike-worker-scope-hook-feasibility.md
 (E1-E4): PreToolUse hooks fire under --dangerously-skip-permissions, worktree-
 local settings are honored via cwd-based discovery, and config live-reloads.
@@ -66,6 +74,7 @@ try:
     from worker_permissions import (  # noqa: E402
         match_bash_deny,
         match_file_write_scope,
+        resolve_dispatch_write_scope,
         resolve_worker_profile,
         worker_permission_enforcement_enabled,
     )
@@ -122,6 +131,32 @@ def _is_within_report_dir(file_path: str) -> bool:
         return False
 
 
+def _resolve_dispatch_write_scope_from_env() -> "list[str] | None":
+    """Read ``VNX_DISPATCH_PATHS`` (JSON list, exported by
+    ``TmuxInteractiveDispatch._spawn_session``) and resolve it to a
+    write-scope narrowing via :func:`resolve_dispatch_write_scope` (OI-1196).
+
+    Fails open to ``None`` (no dispatch-level narrowing) on any parse
+    failure or missing var. This is safe, not a silent hole: ``None`` only
+    removes the EXTRA per-dispatch narrowing — the role's file_write_scope
+    check in :func:`match_file_write_scope` still applies unconditionally,
+    so a malformed/missing env var can never widen a worker past its role
+    scope. It can only fail to apply a tightening the dispatch asked for.
+    """
+    if not _DEPS_AVAILABLE:
+        return None
+    raw = os.environ.get("VNX_DISPATCH_PATHS")
+    if not raw:
+        return None
+    try:
+        paths = json.loads(raw)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(paths, list) or not all(isinstance(p, str) for p in paths):
+        return None
+    return resolve_dispatch_write_scope(paths)
+
+
 def evaluate(payload: dict) -> "tuple[str, str | None]":
     """Return (decision, reason) for one PreToolUse payload. decision is 'allow' or 'block'."""
     if not _DEPS_AVAILABLE:
@@ -163,10 +198,16 @@ def evaluate(payload: dict) -> "tuple[str, str | None]":
         cwd = payload.get("cwd")
         cwd = cwd if isinstance(cwd, str) else ""
         rel_path = _relative_to_cwd(file_path, cwd)
-        if not match_file_write_scope(rel_path, profile):
+        dispatch_write_scope = _resolve_dispatch_write_scope_from_env()
+        if not match_file_write_scope(rel_path, profile, dispatch_write_scope):
+            scope_desc = (
+                "file_write_scope narrowed by this dispatch's declared paths"
+                if dispatch_write_scope is not None
+                else "file_write_scope"
+            )
             return (
                 "block",
-                f"worker-scope: write target '{rel_path}' is outside file_write_scope "
+                f"worker-scope: write target '{rel_path}' is outside {scope_desc} "
                 f"for role '{profile.role}'",
             )
         return "allow", None

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -61,6 +61,17 @@ class PathAccess(str, Enum):
     CREATE     = "create"
 
 
+# OI-1196: which PathAccess values grant WRITE capability on a DispatchPath.
+# WRITE, READ_WRITE, and CREATE all denote intent to mutate the path; READ is
+# the one value that withholds it. This governs WRITE scope only — the fabric
+# has no separate read-scope enforcement gate (Read/Grep are unrestricted for
+# any worker with those tools allowed), so a READ-access path is honestly
+# "excluded from write scope", not "reads are additionally restricted".
+# Single source of truth: scripts/lib/worker_permissions.py imports this
+# rather than redeclaring which access values mean "write".
+WRITE_GRANTING_PATH_ACCESS = frozenset({PathAccess.WRITE, PathAccess.READ_WRITE, PathAccess.CREATE})
+
+
 # ---------------------------------------------------------------------------
 # Deadline bounds — single source of truth (deadline-passthrough)
 # ---------------------------------------------------------------------------
@@ -84,6 +95,30 @@ class DispatchPath:
     path: PurePosixPath
     access: PathAccess = PathAccess.READ_WRITE
     materialize_at_cwd: bool = False
+
+
+def write_paths(paths: "tuple[DispatchPath, ...]") -> list[str]:
+    """Return the POSIX path strings among *paths* whose access grants write.
+
+    OI-1196: this is the first place ``DispatchPath.access`` is actually
+    consulted for a decision. Before this change, ``validate()`` accepted
+    and carried the field through into ``ValidatedSpec.normalized_paths``
+    untouched, but nothing ever read it back — ``access`` was decoration
+    that suggested a rights model with no enforcement behind it. A
+    ``PathAccess.READ`` entry is excluded (see WRITE_GRANTING_PATH_ACCESS);
+    everything else is included.
+
+    Not yet wired to the tmux-lane ``--dispatch-paths`` CLI surface
+    (``scripts/lib/worker_permissions.resolve_dispatch_write_scope``, which
+    enforces the write-scope narrowing this function's output is meant to
+    feed): that surface currently carries plain path strings sourced from
+    ``dispatch_cli.py``/``dispatch_bridge.py`` (the single-entry dispatch
+    door's staging/bridge layer), which are outside this change's file
+    boundary. Once that bridge threads typed ``DispatchPath`` objects
+    through instead of bare strings, it should call this function rather
+    than re-deriving which access values mean "write".
+    """
+    return [str(dp.path) for dp in paths if dp.access in WRITE_GRANTING_PATH_ACCESS]
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -1395,6 +1395,7 @@ class TmuxInteractiveDispatch:
         dispatch_id: str = "",
         session_uuid: "str | None" = None,
         role: "str | None" = None,
+        dispatch_paths: "list[str] | None" = None,
     ) -> "tuple[str, str] | None":
         """Create a detached session; return (pane_id, window_id) or None.
 
@@ -1410,12 +1411,21 @@ class TmuxInteractiveDispatch:
         worker-scope PreToolUse enforcement hook
         (scripts/hooks/pretooluse_worker_scope_enforce.py) can resolve which
         role's permission profile to enforce (spike E3 gap).
+
+        When ``dispatch_paths`` is provided it is JSON-encoded and exported as
+        ``VNX_DISPATCH_PATHS`` (OI-1196) so the same hook can narrow the
+        role's file_write_scope to this dispatch's declared paths — never
+        wider than the role, only sharper. Before this, ``dispatch_paths``
+        only reached the worker as prose (``_scope_note()``) and
+        ``dispatch_metadata``; it had no enforcement channel at all.
         """
         args = ["new-session", "-d", "-s", session, "-c", str(cwd)]
         if dispatch_id:
             args += ["-e", f"VNX_CURRENT_DISPATCH_ID={dispatch_id}"]
         if session_uuid:
             args += ["-e", f"VNX_CLAUDE_SESSION_ID={session_uuid}"]
+        if dispatch_paths:
+            args += ["-e", f"VNX_DISPATCH_PATHS={json.dumps(list(dispatch_paths))}"]
         if role:
             args += ["-e", f"VNX_WORKER_ROLE={role}"]
         args += ["-P", "-F", "#{pane_id}"]
@@ -2727,8 +2737,20 @@ class TmuxInteractiveDispatch:
         window_id: "str | None" = None
         try:
             # 1. Spawn detached session
+            _spawn_dispatch_paths: "list[str] | None"
+            if isinstance(dispatch_paths, str):
+                _spawn_dispatch_paths = [dispatch_paths]
+            elif dispatch_paths:
+                _spawn_dispatch_paths = list(dispatch_paths)
+            else:
+                _spawn_dispatch_paths = None
             spawned = self._spawn_session(
-                session, cwd, dispatch_id, session_uuid=session_uuid, role=role
+                session,
+                cwd,
+                dispatch_id,
+                session_uuid=session_uuid,
+                role=role,
+                dispatch_paths=_spawn_dispatch_paths,
             )
             if spawned is None:
                 self._emit_event(

--- a/scripts/lib/worker_permissions.py
+++ b/scripts/lib/worker_permissions.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
+from dispatch_spec import PathAccess, WRITE_GRANTING_PATH_ACCESS
+
 logger = logging.getLogger(__name__)
 
 # Essential tools a headless code worker needs to read, write, and commit code.
@@ -70,6 +72,14 @@ FALLBACK_FILE_WRITE_SCOPE = [
     "*/*/*/*/*",   # 4 levels deep
     "*/*/*/*/*/*",  # 5 levels deep
 ]
+
+# OI-1196: which PathAccess values grant write capability, when parsing raw
+# --dispatch-paths CLI entries below. Re-exported from dispatch_spec (the
+# single source of truth for what PathAccess values mean) rather than
+# redeclared, so the CLI-string surface (this module) and the typed
+# DispatchSpec surface (dispatch_spec.write_paths) can never disagree about
+# which access values grant write.
+WRITE_GRANTING_ACCESS = WRITE_GRANTING_PATH_ACCESS
 
 # Empty ambient-MCP config string handed to `claude --mcp-config`. Paired with
 # `--strict-mcp-config` this makes a worker reach ZERO MCP servers (no Supabase,
@@ -606,7 +616,7 @@ def _check_fallback_write_scope(file_path: str, max_depth: int = 6) -> bool:
     return len(parts) <= max_depth
 
 
-def match_file_write_scope(file_path: str, profile: PermissionProfile) -> bool:
+def _match_role_scope(file_path: str, profile: PermissionProfile) -> bool:
     """Return True if file_path is within any of the profile's file_write_scope globs.
 
     An empty scope means no restriction (returns True).  The fallback
@@ -623,3 +633,77 @@ def match_file_write_scope(file_path: str, profile: PermissionProfile) -> bool:
         if fnmatch.fnmatch(file_path, scope):
             return True
     return False
+
+
+def _parse_dispatch_path_entry(raw: str) -> "tuple[str, PathAccess]":
+    """Split one raw ``--dispatch-paths`` entry into ``(path, access)``.
+
+    Accepts a bare path (e.g. ``"scripts/lib/foo.py"``), which defaults to
+    ``PathAccess.READ_WRITE`` so a dispatch declared before this change (or
+    written by a caller that never learns the suffix syntax) behaves exactly
+    as before. Optionally accepts a ``"path:access"`` suffix where ``access``
+    is a legal :class:`PathAccess` value (``read``/``write``/``read_write``/
+    ``create``). A trailing segment that is not a legal PathAccess value is
+    treated as part of the path rather than a delimiter — repo-relative
+    paths do not contain ``:`` in practice, so this is conservative rather
+    than silently misparsing a real path that happens to contain one.
+    """
+    if ":" in raw:
+        path, _, suffix = raw.rpartition(":")
+        try:
+            return path, PathAccess(suffix)
+        except ValueError:
+            pass
+    return raw, PathAccess.READ_WRITE
+
+
+def resolve_dispatch_write_scope(dispatch_paths: "list[str] | None") -> "list[str] | None":
+    """Resolve raw ``dispatch_paths`` entries into write-granting scope globs.
+
+    Returns ``None`` when *dispatch_paths* is empty/falsy — "this dispatch
+    declared no per-path scope", which callers must treat as "apply no
+    dispatch-level narrowing" (pre-OI-1196 behavior, unchanged).
+
+    Returns a list (possibly empty) otherwise. An empty list is NOT the same
+    as ``None``: it means the dispatch DID declare dispatch_paths but every
+    entry carried ``access=read`` (or another non-write access), so nothing
+    in this dispatch is in write scope. This mirrors the fabric's existing
+    "absent field is not the same as zero" convention — see
+    :func:`match_file_write_scope` for how the two are distinguished.
+    """
+    if not dispatch_paths:
+        return None
+    out: list[str] = []
+    for raw in dispatch_paths:
+        path, access = _parse_dispatch_path_entry(raw)
+        if access in WRITE_GRANTING_ACCESS:
+            out.append(path)
+    return out
+
+
+def match_file_write_scope(
+    file_path: str,
+    profile: PermissionProfile,
+    dispatch_write_scope: "list[str] | None" = None,
+) -> bool:
+    """Return True if file_path may be written under *profile*, narrowed by *dispatch_write_scope*.
+
+    Two independent checks, both of which must pass — this is intersection,
+    never union, so a dispatch-declared scope can only narrow a role's
+    file_write_scope, never widen it (OI-1196: "never wider than the role"):
+
+      1. The role check (:func:`_match_role_scope`) — unchanged from before
+         this change, always applies.
+      2. The dispatch check — only when *dispatch_write_scope* is not
+         ``None``. ``None`` means no dispatch-level scope was declared, so
+         behavior is identical to before this change. A list (including an
+         empty one — see :func:`resolve_dispatch_write_scope`) means the
+         dispatch DID declare per-path scope, and *file_path* must match one
+         of its write-granting globs; an empty list therefore blocks every
+         write, which is correct when every declared path was read-only.
+    """
+    if not _match_role_scope(file_path, profile):
+        return False
+    if dispatch_write_scope is None:
+        return True
+    return any(fnmatch.fnmatch(file_path, scope) for scope in dispatch_write_scope)

--- a/tests/test_dispatch_spec.py
+++ b/tests/test_dispatch_spec.py
@@ -22,6 +22,7 @@ from dispatch_spec import (  # noqa: E402
     Reject,
     ValidatedSpec,
     validate,
+    write_paths,
 )
 
 # ---------------------------------------------------------------------------
@@ -356,6 +357,56 @@ class TestRule10DispatchPaths:
         result = _do_validate(spec, monkeypatch)
         assert isinstance(result, ValidatedSpec)
         assert len(result.normalized_paths) == 2
+
+    def test_access_survives_validate_into_normalized_paths(self, tmp_path, monkeypatch):
+        """access is carried through validate() unchanged — it is not silently dropped."""
+        ifile = _write_instruction(tmp_path)
+        spec = _valid_spec(ifile, dispatch_paths=(
+            DispatchPath(PurePosixPath("scripts/lib/foo.py"), PathAccess.READ),
+            DispatchPath(PurePosixPath("tests/test_foo.py"), PathAccess.CREATE),
+        ))
+        result = _do_validate(spec, monkeypatch)
+        assert isinstance(result, ValidatedSpec)
+        by_path = {str(dp.path): dp.access for dp in result.normalized_paths}
+        assert by_path["scripts/lib/foo.py"] == PathAccess.READ
+        assert by_path["tests/test_foo.py"] == PathAccess.CREATE
+
+
+# ---------------------------------------------------------------------------
+# OI-1196: write_paths() — the access field's first real consumer
+# ---------------------------------------------------------------------------
+
+class TestWritePaths:
+    def test_empty_tuple_yields_empty_list(self):
+        assert write_paths(()) == []
+
+    def test_read_write_and_default_access_included(self):
+        paths = (
+            DispatchPath(PurePosixPath("a.py")),  # default is READ_WRITE
+            DispatchPath(PurePosixPath("b.py"), PathAccess.READ_WRITE),
+        )
+        assert write_paths(paths) == ["a.py", "b.py"]
+
+    def test_write_and_create_included(self):
+        paths = (
+            DispatchPath(PurePosixPath("a.py"), PathAccess.WRITE),
+            DispatchPath(PurePosixPath("b.py"), PathAccess.CREATE),
+        )
+        assert write_paths(paths) == ["a.py", "b.py"]
+
+    def test_read_access_excluded(self):
+        paths = (
+            DispatchPath(PurePosixPath("a.py"), PathAccess.READ),
+            DispatchPath(PurePosixPath("b.py"), PathAccess.WRITE),
+        )
+        assert write_paths(paths) == ["b.py"]
+
+    def test_all_read_yields_empty_list_not_everything(self):
+        """A dispatch that only declares read-access paths gets zero write paths —
+        never silently 'no restriction' (which would be the empty-list-means-
+        unrestricted convention used elsewhere for role file_write_scope)."""
+        paths = (DispatchPath(PurePosixPath("a.py"), PathAccess.READ),)
+        assert write_paths(paths) == []
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_pretooluse_worker_scope_enforce.py
+++ b/tests/test_pretooluse_worker_scope_enforce.py
@@ -442,6 +442,102 @@ class TestUnknownRoleFallback(HookTestCase):
         self.assertEqual(res.stdout.strip(), "", res.stdout)
 
 
+class TestDispatchPathsNarrowing(HookTestCase):
+    """OI-1196: VNX_DISPATCH_PATHS narrows file_write_scope, never widens it.
+
+    ROLE (quality-engineer) file_write_scope: tests/**, scripts/check_*.
+    """
+
+    def test_write_within_dispatch_scope_and_role_scope_allowed(self):
+        target = self.wt / "tests" / "test_x.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": json.dumps(["tests/test_x.py"])},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "", res.stdout)
+
+    def test_write_within_role_scope_but_outside_dispatch_scope_blocked(self):
+        """In role scope (tests/**) but not declared by this dispatch -> blocked."""
+        target = self.wt / "tests" / "test_other.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": json.dumps(["tests/test_x.py"])},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        decision = parse_block(res.stdout)
+        self.assertIn("tests/test_other.py", decision["reason"])
+        self.assertIn("narrowed by this dispatch", decision["reason"])
+
+    def test_dispatch_scope_wider_than_role_scope_never_widens(self):
+        """docs/** is outside quality-engineer's role scope entirely — declaring it
+        in dispatch_paths must NOT unlock it (OI-1196 hard rule)."""
+        target = self.wt / "docs" / "x.md"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": json.dumps(["docs/x.md"])},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        decision = parse_block(res.stdout)
+        self.assertIn("docs/x.md", decision["reason"])
+
+    def test_read_access_dispatch_path_does_not_grant_write(self):
+        """A dispatch path declared access=read must not open up write there."""
+        target = self.wt / "tests" / "test_x.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": json.dumps(["tests/test_x.py:read"])},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        decision = parse_block(res.stdout)
+        self.assertIn("tests/test_x.py", decision["reason"])
+
+    def test_no_dispatch_paths_env_var_is_unchanged_behavior(self):
+        """No VNX_DISPATCH_PATHS at all -> identical to pre-OI-1196 role-only check."""
+        target = self.wt / "tests" / "test_x.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "", res.stdout)
+
+    def test_malformed_dispatch_paths_env_fails_open_to_role_scope_only(self):
+        """Malformed VNX_DISPATCH_PATHS must not crash or widen — it degrades to
+        'no extra narrowing', with the role check still fully enforced."""
+        # In-scope write still allowed (role check alone still applies).
+        target = self.wt / "tests" / "test_x.py"
+        res = run_hook(
+            make_payload("Write", {"file_path": str(target)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": "not json"},
+        )
+        self.assertEqual(res.returncode, 0, res.stderr)
+        self.assertEqual(res.stdout.strip(), "", res.stdout)
+
+        # Out-of-role-scope write is still blocked — malformed data never widens.
+        target2 = self.wt / "docs" / "x.md"
+        res2 = run_hook(
+            make_payload("Write", {"file_path": str(target2)}, cwd=str(self.wt)),
+            enforce=True,
+            data_dir=self.data_dir,
+            extra_env={"VNX_DISPATCH_PATHS": "not json"},
+        )
+        self.assertEqual(res2.returncode, 0, res2.stderr)
+        decision = parse_block(res2.stdout)
+        self.assertIn("docs/x.md", decision["reason"])
+
+
 class TestReportPathExemption(HookTestCase):
     """Report obligation: writes to $VNX_DATA_DIR/unified_reports/ are exempt from scope."""
 

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -5450,6 +5450,49 @@ class TestWorkerRoleExport(_LaneTestCase):
         self.assertNotIn("VNX_WORKER_ROLE", " ".join(ns_cmd))
 
 
+class TestDispatchPathsExport(_LaneTestCase):
+    """OI-1196: _spawn_session exports VNX_DISPATCH_PATHS into the pane env."""
+
+    def _new_session_cmd(self, fake: FakeTmux) -> list:
+        cmds = [c for c in fake.commands if c and c[0] == "new-session"]
+        self.assertTrue(cmds, "new-session was not invoked")
+        return cmds[0]
+
+    def test_dispatch_paths_exported_as_json(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(
+            lane, role="backend-developer", dispatch_paths=["scripts/lib/foo.py", "tests/test_foo.py"]
+        )
+
+        self.assertTrue(result.success, result.failure_reason)
+        ns_cmd = self._new_session_cmd(fake)
+        self.assertIn("-e", ns_cmd)
+        expected = f'VNX_DISPATCH_PATHS={json.dumps(["scripts/lib/foo.py", "tests/test_foo.py"])}'
+        self.assertIn(expected, ns_cmd)
+
+    def test_dispatch_paths_absent_when_none(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(lane, role="backend-developer", dispatch_paths=None)
+
+        self.assertTrue(result.success, result.failure_reason)
+        ns_cmd = self._new_session_cmd(fake)
+        self.assertNotIn("VNX_DISPATCH_PATHS", " ".join(ns_cmd))
+
+    def test_dispatch_paths_str_normalized_to_single_element_list(self):
+        fake = FakeTmux(receipts_file=self.receipts_file, dispatch_id=self.DISPATCH_ID)
+        lane = self._make_lane(fake)
+        result = self._fast_dispatch(
+            lane, role="backend-developer", dispatch_paths="scripts/lib/foo.py"
+        )
+
+        self.assertTrue(result.success, result.failure_reason)
+        ns_cmd = self._new_session_cmd(fake)
+        expected = f'VNX_DISPATCH_PATHS={json.dumps(["scripts/lib/foo.py"])}'
+        self.assertIn(expected, ns_cmd)
+
+
 class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
     """Worktree-allocation seam: the worker-scope PreToolUse hook is registered
     in the fresh worktree's .claude/settings.local.json before the session spawns."""

--- a/tests/test_worker_permissions.py
+++ b/tests/test_worker_permissions.py
@@ -25,6 +25,7 @@ from worker_permissions import (
     load_permissions,
     match_bash_deny,
     match_file_write_scope,
+    resolve_dispatch_write_scope,
     resolve_role_mcp_config,
     resolve_worker_profile,
     validate_dispatch_permissions,
@@ -241,6 +242,91 @@ def test_file_write_scope_backend(yaml_file: Path) -> None:
     assert match_file_write_scope("scripts/lib/foo.py", profile) is True
     assert match_file_write_scope("tests/test_bar.py", profile) is True
     assert match_file_write_scope("dashboard/token-dashboard/app.ts", profile) is True
+
+
+# ---------------------------------------------------------------------------
+# OI-1196: dispatch_paths -> file_write_scope narrowing
+# ---------------------------------------------------------------------------
+
+class TestResolveDispatchWriteScope:
+    """resolve_dispatch_write_scope: raw --dispatch-paths entries -> write globs."""
+
+    def test_none_when_no_paths_declared(self) -> None:
+        assert resolve_dispatch_write_scope(None) is None
+        assert resolve_dispatch_write_scope([]) is None
+
+    def test_bare_path_defaults_to_read_write(self) -> None:
+        assert resolve_dispatch_write_scope(["scripts/lib/foo.py"]) == [
+            "scripts/lib/foo.py"
+        ]
+
+    def test_read_access_excluded_from_write_scope(self) -> None:
+        # Declared paths, but every one is read-only -> empty list, NOT None.
+        result = resolve_dispatch_write_scope(["docs/README.md:read"])
+        assert result == []
+
+    def test_write_and_create_and_read_write_all_grant_write(self) -> None:
+        result = resolve_dispatch_write_scope(
+            [
+                "a.py:write",
+                "b.py:read_write",
+                "c.py:create",
+                "d.py:read",
+            ]
+        )
+        assert sorted(result) == ["a.py", "b.py", "c.py"]
+
+    def test_unknown_access_suffix_treated_as_part_of_path(self) -> None:
+        # "bogus" is not a legal PathAccess value, so the whole string is the
+        # path (defaults to read_write) rather than silently misparsed.
+        result = resolve_dispatch_write_scope(["weird:bogus"])
+        assert result == ["weird:bogus"]
+
+
+class TestMatchFileWriteScopeDispatchNarrowing:
+    """match_file_write_scope's dispatch_write_scope param: intersection, never union."""
+
+    def test_no_dispatch_scope_is_unchanged_behavior(self, yaml_file: Path) -> None:
+        """dispatch_write_scope=None (not declared) must match pre-OI-1196 behavior."""
+        profile = load_permissions("backend-developer", yaml_path=yaml_file)
+        assert match_file_write_scope("scripts/lib/foo.py", profile) is True
+        assert match_file_write_scope("scripts/lib/foo.py", profile, None) is True
+        assert match_file_write_scope("docs/x.md", profile) is False
+        assert match_file_write_scope("docs/x.md", profile, None) is False
+
+    def test_dispatch_scope_narrower_than_role_is_enforced(self, yaml_file: Path) -> None:
+        """A write inside role scope but outside the dispatch's declared paths is blocked."""
+        profile = load_permissions("backend-developer", yaml_path=yaml_file)
+        dispatch_scope = resolve_dispatch_write_scope(["scripts/lib/foo.py"])
+        assert match_file_write_scope("scripts/lib/foo.py", profile, dispatch_scope) is True
+        # Also within role scope (scripts/**) but not declared by this dispatch.
+        assert match_file_write_scope("scripts/lib/bar.py", profile, dispatch_scope) is False
+
+    def test_dispatch_scope_wider_than_role_never_widens(self, yaml_file: Path) -> None:
+        """OI-1196 hard rule: a dispatch can never grant write outside the role's scope."""
+        profile = load_permissions("backend-developer", yaml_path=yaml_file)
+        # docs/** is outside backend-developer's file_write_scope entirely.
+        dispatch_scope = resolve_dispatch_write_scope(["docs/README.md"])
+        assert match_file_write_scope("docs/README.md", profile, dispatch_scope) is False
+
+    def test_all_read_access_dispatch_scope_blocks_every_write(self, yaml_file: Path) -> None:
+        """Declaring only read-access paths means the dispatch does no writing at all."""
+        profile = load_permissions("backend-developer", yaml_path=yaml_file)
+        dispatch_scope = resolve_dispatch_write_scope(["scripts/lib/foo.py:read"])
+        assert dispatch_scope == []
+        assert match_file_write_scope("scripts/lib/foo.py", profile, dispatch_scope) is False
+
+    def test_composes_with_fallback_role_profile(self) -> None:
+        """The fallback (depth-limited, non-glob) role scope still ANDs correctly."""
+        profile = default_code_worker_profile()
+        dispatch_scope = resolve_dispatch_write_scope(["src/app.py"])
+        # Within the fallback depth limit AND the declared dispatch path.
+        assert match_file_write_scope("src/app.py", profile, dispatch_scope) is True
+        # Within the fallback depth limit but NOT declared by this dispatch.
+        assert match_file_write_scope("src/other.py", profile, dispatch_scope) is False
+        # Declared by the dispatch but exceeds the fallback depth limit (7 segments).
+        deep_scope = resolve_dispatch_write_scope(["a/b/c/d/e/f/out.md"])
+        assert match_file_write_scope("a/b/c/d/e/f/out.md", profile, deep_scope) is False
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`dispatch_paths` declared a per-dispatch `access` field that suggested a rights model, but nothing enforced it: it only reached `dispatch_metadata` and the prompt's `_scope_note()` text (`tmux_interactive_dispatch.py:768-769`, `:1375`). A worker writing outside its declared paths was never blocked. This wires `dispatch_paths` into the existing (previously role-only) `match_file_write_scope()` real-time gate.

## Changes

- `scripts/lib/worker_permissions.py` — `match_file_write_scope()` now takes an optional `dispatch_write_scope` param; the role check and the dispatch check both must pass (intersection, never union — a dispatch can only narrow the role's scope). New `resolve_dispatch_write_scope()` / `_parse_dispatch_path_entry()` parse raw `--dispatch-paths` CLI entries, with an optional `path:access` suffix.
- `scripts/lib/dispatch_spec.py` — `PathAccess.access` now has a real consumer: `write_paths()` filters `DispatchPath` tuples down to the write-granting subset (`WRITE`/`READ_WRITE`/`CREATE`; `READ` excluded). Not yet wired to the tmux-lane CLI surface (`dispatch_cli.py`/`dispatch_bridge.py` are outside this change's file boundary) — documented as an explicit seam, not silently claimed.
- `scripts/lib/tmux_interactive_dispatch.py` — `_spawn_session()` JSON-encodes `dispatch_paths` into the worker pane as `VNX_DISPATCH_PATHS`, alongside the existing `VNX_WORKER_ROLE` export.
- `scripts/hooks/pretooluse_worker_scope_enforce.py` — reads `VNX_DISPATCH_PATHS`, resolves it, and passes it into `match_file_write_scope()`. Fails open to "no dispatch-level narrowing" on malformed/missing data — safe because the role check still applies unconditionally, so this can never widen past the role's bound, only fail to apply the extra tightening.
- `docs/operations/WORKER_PERMISSIONS.md` — new section documenting the mechanism; also corrected a stale claim that `match_file_write_scope()` was "unused outside tests" (it's real-time-gated behind `VNX_ENFORCE_WORKER_PERMISSIONS`, default off) and a stale role-name list (`test-engineer`/`architect` → `quality-engineer`/`system-architect` per OI-1100).

No dispatch_paths declared → behavior identical to before this change.

## Verification

Targeted tests only, per dispatch instructions (not the full suite):

```
python3 -m pytest tests/test_worker_permissions.py tests/test_worker_permissions_merge.py tests/test_dispatch_spec.py tests/test_pretooluse_worker_scope_enforce.py tests/test_worker_scoped_default.py -q
# 196 passed

python3 -m pytest tests/test_tmux_interactive_dispatch.py -k "TestWorkerRoleExport or TestWorkerScopeHookSettingsWiring or TestDispatchPathsExport or TestSubprocessLaneMarker" -q
# 14 passed
```

Also ran the full `test_tmux_interactive_dispatch.py` file once to check for regressions from the `_spawn_session()` signature change: 217 passed, 3 pre-existing failures unrelated to this change (confirmed via `git stash` against unmodified `main` — a `NameError: name 'model' is not defined` in an unrelated liveness/failure-report code path).

All 4 touched Python files + the `.sh` hook wrapper compile clean (`py_compile`, `bash -n`).

New/updated test coverage: dispatch-narrower-than-role enforced, dispatch-wider-than-role never widens, `access=read` excluded from write grant, no-`dispatch_paths` unchanged behavior, malformed `VNX_DISPATCH_PATHS` fails open to role-scope-only, composition with the depth-limited fallback role profile.

## Open Items

- The typed `DispatchSpec.dispatch_paths`/`PathAccess` surface (`dispatch_spec.write_paths()`) is not yet wired to the tmux-lane `--dispatch-paths` CLI list — that bridge (`dispatch_cli.py`/`dispatch_bridge.py`) is outside this dispatch's file boundary. The two `dispatch_paths` concepts (typed door-side, plain-string CLI-side) are parsed independently for now; documented explicitly in `WORKER_PERMISSIONS.md` rather than silently left unconnected.
- This enforcement path is gated behind `VNX_ENFORCE_WORKER_PERMISSIONS` (default OFF, pre-existing, unchanged by this PR) — flipping that fleet-wide default is a separate operator decision.