### PR TITLE
test(reconciler): repair oi-lifecycle fixture with canonical dispatches columns (OI-1199)

### DIFF
--- a/tests/test_track_oi_lifecycle.py
+++ b/tests/test_track_oi_lifecycle.py
@@ -31,6 +31,8 @@ import schema_migration
 import tracks as tracks_lib
 import track_reconciler
 
+from fixtures.dispatches_schema_fixture import ensure_dispatches_columns
+
 PROJECT_ID = "test-proj"
 
 
@@ -77,9 +79,24 @@ def _build_db_v29(tmp_path: Path) -> Path:
     """)
     conn.commit()
 
+    # 0022 rebuilds the dispatches table (state CHECK + operator_approved_at),
+    # and 0024 rebuilds the track tables. Apply them first, then add the
+    # columns the canonical schema manifest declares (output_ref, output_kind)
+    # so they survive the rebuild. Mirrors the canonical ordering in
+    # test_track_reconciler.py / test_planning_cli.py / test_horizon_parity.py.
     for version, filename in [
         (22, "0022_track_layer.sql"),
         (24, "0024_tracks_tenant_scoping.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+
+    ensure_dispatches_columns(conn)
+    conn.execute("PRAGMA user_version = 26")
+    conn.commit()
+
+    for version, filename in [
         (27, "0027_planning_horizon_and_deliverable_view.sql"),
         (28, "0028_tracks_derived_status.sql"),
         (29, "0029_track_type_discriminator.sql"),


### PR DESCRIPTION
## Wat er mis was

De drie `TestReconcilerOiResolved`-tests bewaken of de reconciler een track terecht blocked/unblocked noemt op basis van open items. Sinds weken staan ze rood op `sqlite3.OperationalError: no such column: output_ref`, en die rood werd elke keer terecht als pre-existing weggeschreven. De enige geautomatiseerde bewaking op die logica deed dus niets.

## Oorzaak

`_build_db_v29` schreef de `dispatches`-DDL handmatig en riep nooit de canonieke `ensure_dispatches_columns` helper aan. Migration 0022 bouwt de `dispatches`-tabel opnieuw op zonder `output_ref`/`output_kind`, dus de kolommen moeten na 0022/0024 en voor 0027 toegevoegd worden. Dat is precies de volgorde die `test_track_reconciler.py`, `test_planning_cli.py` en `test_horizon_parity.py` al gebruiken.

## Fix

Gebruik de bestaande `fixtures.dispatches_schema_fixture.ensure_dispatches_columns` in plaats van een tweede opzet-pad. Enkel `tests/test_track_oi_lifecycle.py` is aangeraakt.

## Tegen-toets

Twee tijdelijke mutaties, beide teruggedraaid:
1. `AND resolved_at IS NULL` uit de blocker-query gehaald -> `test_resolved_blocker_not_counted` wordt rood (bewijst dat de resolved-filter getoetst wordt).
2. `if blocker: return "blocked"` geneutraliseerd -> alle drie de tests worden rood (bewijst dat elk van de drie echt op de blocker-detectie assert).

## Verificatie

- `python3 -m pytest tests/test_track_oi_lifecycle.py -q` -> 30 passed
- `python3 -m pytest tests/test_planning_cli.py tests/test_horizon_parity.py -q` -> 145 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)