### PR TITLE
docs(plan-gate): align docs+skill with 15-08 code, replace unsafe self-accept route

### DIFF
--- a/docs/core/HORIZON_PLANNING.md
+++ b/docs/core/HORIZON_PLANNING.md
@@ -54,9 +54,52 @@ Nested under `vnx horizon plan-gate <verb>`:
 
 | Verb | Purpose |
 |---|---|
-| `seed` | Seed the plan-gate open-item for a track. |
-| `run` | Run the plan-first panel for a track. |
-| `status` | Show a track's plan-gate state. |
+| `seed` | Seed the `OI-PLAN-<track>` blocker so the track is born plan-gated. |
+| `run` | Run the plan-first panel over a plan doc; on PASS the blocker resolves. |
+| `status` | Show a track's plan-gate state + `derived_status`. |
+| `attest` | Operator escape-hatch: attest the gate as passed without re-running the panel; requires `--reason` and `--approval-id`. |
+| `missing-reasons` | Read-only audit: list resolved plan-gate blockers that carry no `resolution_reason`. |
+| `backfill-reason` | Record the missing `resolution_reason` on an already-resolved row; refuses an unresolved row and refuses to overwrite an existing reason. |
+| `reblock` | Put back a wrongly-lifted blocker (track is blocked again); the reversal stays visible in `resolution_reason`. |
+
+## Plan-gate weight — the seat ladder (since #1507)
+
+The plan-gate does not run the full panel on every plan. The panel SIZE derives
+from a governance variant, which is a deterministic function of which paths the
+work touches, not a model judgment about how risky the plan "feels". Two
+functions define the ladder, both recomputable from the code:
+
+- **`scripts/lib/smart_router.py::derive_governance_variant`** classifies each
+  dispatch path into `core` / `code` / `business` / `docs`, and the STRICTEST
+  category across all touched paths wins (`_CATEGORY_RANK`). Irreversibility
+  forces the heaviest class no matter what the paths say: a schema migration
+  (`scripts/migrations/`, `schemas/migrations/`), a fleet default
+  (`.claude/terminals/`, `.claude/skills/`, `agents/`, `skills/`), the
+  append-only receipt/ledger format, or an explicit `irreversible` flag on the
+  spec all resolve to `coding-strict`. A new feature
+  (`task_class == 01_code_generation`) is an INDEPENDENT axis: it is carried as
+  `is_new_feature` and always gets the full panel, regardless of the
+  path-derived variant.
+- **`scripts/lib/plan_gate_panel.py::GOVERNANCE_VARIANT_SEAT_LABELS`** maps the
+  variant to an ordered seat prefix of `configs/plan_gate_panel.yaml`:
+
+  | variant | derived from | seats |
+  |---|---|---|
+  | `minimal` | docs content, reversible | 0 (no panel runs) |
+  | `business-light` / `light` | non-code deliverables | 1 (`opus`) |
+  | `default` | code | 2 (`opus`, `kimi`) |
+  | `coding-strict` | core paths / irreversible | 3 (`opus`, `kimi`, `glm-5.2-harness`) |
+  | new feature | `task_class 01_code_generation` | full panel (5 seats), regardless of variant |
+
+The derived weight, the chosen weight, and the direction of an operator override
+all land in the trace, so an override is never silent. On the review-gate axis
+(`smart_router.resolve_gate`) the result is a `GateWeightResolution` carrying
+`governance_variant` (derived), `gate` (chosen), and `override_direction`
+(`""` | `upgrade` | `downgrade` | `strict-downgrade`). The plan-gate panel
+mirrors this on the seat-count axis (`plan_gate_panel.seat_override_direction`).
+`strict-downgrade` is the one separately-marked move: lightening a
+`coding-strict` derivation, chosen exactly at irreversible work. It is marked,
+not blocked, so a later sweep can find the most dangerous override.
 
 ## Tenant-safe resolution (critical)
 
@@ -98,9 +141,20 @@ top-level alias — it is reached only through `vnx horizon plan-gate`.
 Objectives added through `vnx horizon add` live in the tracks database in the
 central per-project store (ADR-026), not in a checked-in roadmap file. A track
 enters `queued` and is plan-gated: it stays blocked until the plan-first panel
-passes, or the operator manually accepts it. There is no automatic round-cap
-escape in the panel — a self-accept is a manual operator action: unlink the
-plan-gate open-item (`tracks.unlink_open_item`) and reconcile. Merged-PR
+passes, or the operator accepts it manually. There is no automatic round-cap
+escape in the panel — a self-accept is a manual operator action with an
+approval token:
+
+    vnx horizon plan-gate attest <track_id> --reason "..." --approval-id ...
+
+`attest` clears the `OI-PLAN-<track>` blocker through `_resolve_plan_blocker`,
+which (since #1502) requires a non-empty `resolution_reason` and fails closed
+otherwise. The reason is required because a gate lift without one is
+indistinguishable from a mistake: the pre-fix write path dropped the reason on
+87 of 109 lifted blockers (measured 2026-08-15 with
+`vnx horizon plan-gate missing-reasons`; the count falls as `backfill-reason`
+runs). Do NOT clear the blocker by hand via `tracks.unlink_open_item`. That
+raw path writes the row directly and bypasses the reason requirement. Merged-PR
 evidence closes tracks through `reconcile`, so declared status is grounded in
 git reality rather than a hand-edited list.
 

--- a/skills/horizon/SKILL.md
+++ b/skills/horizon/SKILL.md
@@ -7,9 +7,10 @@ description: >
   into now/next/later horizons, break a feature into deliverables, set the routing FLOOR, or
   run the plan-gate on a feature. The tracks DB (`vnx horizon`, alias `vnx objective`) is the
   source of truth; the repo ROADMAP.yaml is a generic example, not the SSOT. Plans and gates
-  only: never dispatches, never closes open-items. The heavy multi-model plan-gate panel runs
-  only on an explicit plan-gate step. (Renamed from `pm` 2026-07-05 — `/pm`/`@pm` still resolve
-  via the backward-compat alias in `.claude/skills/pm/SKILL.md`.)
+  only: never dispatches, never closes open-items. The plan-gate panel is proportional (0-5
+  seats, by governance weight) and runs only on an explicit plan-gate step. (Renamed from
+  `pm` 2026-07-05 — `/pm`/`@pm` still resolve via the backward-compat alias in
+  `.claude/skills/pm/SKILL.md`.)
 user-invocable: true
 allowed-tools: [Read, Grep, Glob, Bash]
 ---
@@ -45,8 +46,9 @@ trust the silent `vnx-dev` default in a multi-project context).
    launch) — do NOT `vnx horizon sync` against it; sync would seed example data into the live
    store. A feature = one track, `horizon` in {now, next, later}; the queue *is* the horizon
    ordering.
-2. **Plan-first GATE (hard, see below)** — produce the plan doc, run the 5-family panel,
-   revise until pass. No deliverable promotes until this passes.
+2. **Plan-first GATE (hard, see below)** — produce the plan doc, run the plan panel (size
+   derived from the governance weight), revise until pass. No deliverable promotes until
+   this passes.
 3. **Deliverables** — `vnx horizon deliverable add --objective <track> --output-kind
    {pr,doc,...} --title "..."` (alias: `vnx deliverable add`) per planned output. Each lands
    `proposed`. The human gate `vnx horizon deliverable promote` is the only path to `ready` —
@@ -59,19 +61,24 @@ trust the silent `vnx-dev` default in a multi-project context).
 5. **Drift watch** — `vnx horizon drift` (alias: `vnx objective drift`, advisory) is your live
    "is this actually done" signal before closeout.
 
-## The plan-first gate (always multi-model)
+## The plan-first gate (proportional panel)
 
 Every feature is preceded by an architect/plan phase. The PLAN (not the code) is reviewed by
-a diverse-family panel BEFORE any implementation.
+a diverse-family panel BEFORE any implementation, sized to the plan's governance weight.
 
 - **Plan doc** (linked from the track, output_kind `doc`): `## Problem`, `## Approach`,
   `## Deliverables` (each tagged task_class + complexity), `## Risks`, `## Model-routing plan`
   (the FLOOR per deliverable, not a hand-picked lane), `## Open questions`.
-- **Panel = the full 5-family DEFAULT_PANEL: opus + kimi + glm-harness + deepseek-harness +
-  codex** (`scripts/lib/plan_gate_panel.py`, #991; gemini omitted until a CLI exists — five
-  families -> real disagreement). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
+- **Panel size is derived, not flat.** The governance weight (`derive_governance_variant` in
+  `scripts/lib/smart_router.py`) maps the touched paths to a variant; the variant sizes the
+  panel via `GOVERNANCE_VARIANT_SEAT_LABELS` in `scripts/lib/plan_gate_panel.py`: 0 seats
+  (docs, reversible) up to 3 (core / irreversible); a new feature
+  (`task_class 01_code_generation`) gets the full 5 seats regardless of paths. The exact
+  ladder lives in `docs/core/HORIZON_PLANNING.md`; do not copy it here (a second copy drifts
+  the moment the ladder changes). A flaked/undispatched lane ABSTAINS (non-scoring, #910);
   liveness-quorum = min(2, panel size), so one flake never forces REVISE. Operational
-  preconditions: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`, kimi + codex CLIs.
+  preconditions for the heavier seats: the glm litellm proxy on :4141, `DEEPSEEK_API_KEY`,
+  kimi + codex CLIs.
 - **Run it**: `vnx horizon plan-gate run <track> --doc <plan.md> --project-id <pid>`. The
   panel runs on the **governed worker path**, and each panelist routes by its lane (the
   single-entry dispatch door decides this; until PR-12 wires/flips that door, the engine calls
@@ -95,6 +102,22 @@ a diverse-family panel BEFORE any implementation.
   to the track. While it is open the reconciler shows `derived_status: blocked` and
   `vnx horizon deliverable promote` refuses. The panel-pass closes it. A worker that never
   loaded this skill still cannot promote — the CLI rejects it.
+
+### When a heavy panel is worth it
+
+Panel size tracks ambiguity, not risk or size. The 2026-08-15 measurement
+(`scripts/analysis/plan_gate_panel_effectiveness.py`, repeatable) over 104 complete rounds:
+
+- the full panel agreed with the first seat alone in 89.4% of rounds;
+- seat 2 changed the decision in 11.7% of rounds, seat 3 in 5.1%, seat 4 and seat 5 each in
+  1.7%.
+
+When the facts determine the answer, one model with good context beats five that vote.
+Reserve the full panel for genuinely ambiguous plans: open judgment calls, competing
+architectural readings, novel blast radius. For a plan whose answer follows from the facts,
+a heavy panel burns five model calls to reproduce the first seat's verdict. The seat ladder
+encodes this in the default weight; override UP only when the plan is ambiguous, not merely
+large or risky.
 
 ## Routing FLOOR, not overrides (model selection)
 


### PR DESCRIPTION
De plan-gate is op 15-08 op drie punten veranderd (#1502 resolution_reason, #1505 disposition verbs, #1507 seat ladder). De documentatie ging niet mee. Gemeten voor deze PR:

    $ grep -rn "governance_variant|seat_labels" docs/ skills/
    (geen treffers)

## Wat deze PR doet

1. **De onveilige route weg.** `HORIZON_PLANNING.md` schreef voor om een self-accept te doen via `tracks.unlink_open_item`. Dat is precies het pad dat 87 blokkades zonder vastgelegde reden opleverde en dat #1502 heeft dichtgezet. Nu staat er de governed route (`plan-gate attest`) plus een expliciete DO NOT op het oude pad.
2. **Verb-tabel van 3 naar 7.** `attest`, `missing-reasons`, `backfill-reason` en `reblock` ontbraken.
3. **De zwaarte-ladder gedocumenteerd**, uit `derive_governance_variant` en `GOVERNANCE_VARIANT_SEAT_LABELS` gelezen.
4. **De horizon-skill draagt het oordeel**, niet de tabel: wanneer een zwaar panel de moeite waard is, onderbouwd met de ijkmeting (89,4% eensgezind met de eerste zetel over 104 rondes). De skill verwijst naar de doc in plaats van te kopiëren.

## Herkomst

Geproduceerd door dispatch `20260815-plangate-docs-parity-v2`, die het werk voltooide maar nooit committe. Gered uit de worktree door T0 voordat de reaper langskwam; anders was het verloren.

## Open item uit het worker-rapport

Het `missing-reasons`-cijfer drift terwijl er backfills draaien: 78 van 106 nu, tegen 87 van 109 op het moment van meten. De doc citeert de 15-08-meting en vermeldt dat het getal daalt naarmate `backfill-reason` draait.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0151sxmzbgcpUaxMyZXcs5gZ