### PR TITLE
feat(gate): enforce glm-5.2 allowlist (not blocklist) for zai

### DIFF
--- a/scripts/lib/constraint_enforcer.py
+++ b/scripts/lib/constraint_enforcer.py
@@ -103,7 +103,7 @@ class ConstraintEnforcer:
                     logger.warning("[%s] %s", cid, msg)
 
             elif rule == "require_route":
-                if self._check_require_route(c, model, terminal_id, role):
+                if self._check_require_route(c, provider, sub_provider, model, terminal_id, role):
                     if self._is_overridden(c):
                         logger.warning("Constraint %s overridden by env var", cid)
                         continue
@@ -152,6 +152,8 @@ class ConstraintEnforcer:
     def _check_require_route(
         self,
         constraint: Dict[str, Any],
+        provider: Optional[str],
+        sub_provider: Optional[str],
         model: Optional[str],
         terminal_id: Optional[str],
         role: Optional[str],
@@ -160,6 +162,16 @@ class ConstraintEnforcer:
         rr = constraint.get("required_route", {})
         if not rr:
             return False
+
+        spec_provider = rr.get("provider")
+        if spec_provider:
+            if provider and provider.lower() in self._NATIVE_CLI_PROVIDERS:
+                if not self._match_value(provider, spec_provider):
+                    return False
+            else:
+                effective_provider = sub_provider or provider
+                if not self._match_value(effective_provider, spec_provider):
+                    return False
 
         spec_role = rr.get("role")
         if spec_role:

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -126,6 +126,8 @@ def _route_forbidden(
 
 def _required_route_missing(
     constraint: Mapping[str, Any],
+    provider: Optional[str],
+    sub_provider: Optional[str],
     model: Optional[str],
     terminal_id: Optional[str],
     role: Optional[str],
@@ -133,6 +135,11 @@ def _required_route_missing(
     required = constraint.get("required_route") or {}
     if not isinstance(required, Mapping):
         return False
+
+    spec_provider = required.get("provider")
+    if spec_provider:
+        if not _match_value(_effective_provider(provider, sub_provider), spec_provider):
+            return False
 
     spec_role = required.get("role")
     if spec_role:
@@ -520,7 +527,7 @@ class ConstraintEnforcer:
                         override_applied=override_applied,
                     )
             elif rule == "require_route":
-                if _required_route_missing(constraint, model, terminal_id, role):
+                if _required_route_missing(constraint, provider, sub_provider, model, terminal_id, role):
                     violation = _violation_from_constraint(
                         constraint,
                         "Required route not met",
@@ -531,7 +538,6 @@ class ConstraintEnforcer:
                 violations.append(violation)
 
         base, sub = _provider_parts(provider, sub_provider)
-        effective = _effective_provider(base, sub)
         model_norm = _norm(model)
         if _norm(base) != "kimi" and "kimi" in model_norm:
             violations.append(ConstraintViolation(
@@ -545,13 +551,6 @@ class ConstraintEnforcer:
                 code="deepseek-harness-subscription-blocked",
                 severity="blocking",
                 message="Route forbidden: litellm:deepseek requires DEEPSEEK_API_KEY; subscription redirect is blocked.",
-            ))
-
-        if _norm(effective) == "zai" and model_norm in {"glm-4.5", "glm-4.6", "glm-5", "glm-5.1"}:
-            violations.append(ConstraintViolation(
-                code="deprecated-glm-models",
-                severity="blocking",
-                message=f"Route forbidden: {model} is deprecated; use glm-5.2.",
             ))
 
         if check_registry and model:

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -122,14 +122,21 @@ constraints:
     override_allowed: false
 
   - id: deprecated-glm-models
-    rule: forbid_route
-    forbidden_route:
+    rule: require_route
+    required_route:
       provider: zai
-      model: [glm-4.5, glm-4.6, glm-5, glm-5.1]
+      model: glm-5.2
     reason: >-
-      GLM-4.5 and GLM-4.6 are retired; base GLM-5 (Feb 2026) and GLM-5.1 are
-      superseded by GLM-5.2 (released 2026-06-16). Only GLM-5.2 is allowed for
-      new dispatches. Operator directive 2026-08-03: geen oudere 5-varianten.
+      Only glm-5.2 is allowed for provider zai. This is an allowlist, not a
+      blocklist: exactly one GLM version is approved for new dispatches, and
+      every other model (including any not-yet-released version such as
+      glm-5.3) is refused until an operator decision admits it. GLM-4.5 and
+      GLM-4.6 are retired; base GLM-5 (Feb 2026) and GLM-5.1 are superseded by
+      GLM-5.2 (released 2026-06-16). Operator directive 2026-08-03: geen oudere
+      5-varianten. A blocklist of four names lets every name that was never
+      listed through; model versions are structurally open-ended, so only an
+      allowlist enforces the one-approved-version decision. Admitting a newer
+      version is a deliberate one-line operator change to this model value.
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -7,7 +7,7 @@ Covers every constraint in provider_constraints.yaml:
   - workers-kimi-pinned     (require_route, warn, override)
   - no-anthropic-sdk        (forbid_import — warning at runtime)
   - zai-via-openrouter-only (forbid_route, blocking)
-  - deprecated-glm-models   (forbid_route, blocking)
+  - deprecated-glm-models   (require_route allowlist, blocking)
   - deepseek-harness-subscription-blocked (forbid_route, blocking)
 
 Plus: file-not-found, bad version, override env var, non-matching routes.
@@ -77,7 +77,7 @@ class TestKimiViaCliOnly:
 
 
 # ---------------------------------------------------------------------------
-# t0-opus-only — require_route role=T0 model=claude-opus-4-8
+# t0-opus-only — require_route role=T0 model=opus-5
 # ---------------------------------------------------------------------------
 
 class TestT0OpusOnly:
@@ -89,7 +89,7 @@ class TestT0OpusOnly:
 
     def test_t0_with_opus_allowed(self, real_enforcer: ConstraintEnforcer, caplog):
         with caplog.at_level("WARNING"):
-            real_enforcer.enforce(terminal_id="T0", model="claude-opus-4-8")
+            real_enforcer.enforce(terminal_id="T0", model="opus-5")
         assert "t0-opus-only" not in caplog.text
 
     def test_t0_override_env(self, real_enforcer: ConstraintEnforcer, caplog, monkeypatch):
@@ -173,13 +173,14 @@ class TestZaiViaOpenrouterOnly:
         # zai-via-openrouter-only permits openrouter (it forbids only DIRECT). The newer
         # glm-via-harness-only constraint would otherwise block plain litellm:zai entirely
         # (GLM must run via glm-harness); set its benchmark/legacy override to isolate the
-        # constraint under test here.
+        # constraint under test here. model=glm-5.2 clears the deprecated-glm-models
+        # allowlist (a zai route must declare the single approved GLM version).
         monkeypatch.setenv("VNX_OVERRIDE_GLM_VIA_HARNESS_ONLY", "1")
-        real_enforcer.enforce(provider="litellm", sub_provider="zai", via="openrouter")
+        real_enforcer.enforce(provider="litellm", sub_provider="zai", model="glm-5.2", via="openrouter")
 
 
 # ---------------------------------------------------------------------------
-# deprecated-glm-models — forbid_route provider=zai model=[glm-4.5, glm-4.6]
+# deprecated-glm-models — require_route allowlist provider=zai model=glm-5.2
 # ---------------------------------------------------------------------------
 
 class TestDeprecatedGlmModels:
@@ -206,6 +207,26 @@ class TestDeprecatedGlmModels:
 
     def test_glm52_allowed(self, real_enforcer: ConstraintEnforcer):
         real_enforcer.enforce(provider="zai", model="glm-5.2")
+
+    def test_glm53_blocked(self, real_enforcer: ConstraintEnforcer):
+        """A not-yet-released version is blocked: the allowlist admits only glm-5.2."""
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="zai", model="glm-5.3")
+
+    def test_glm99_blocked(self, real_enforcer: ConstraintEnforcer):
+        """A nonexistent future version is blocked, not merely unlisted."""
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="zai", model="glm-9.9")
+
+    def test_glm_block_message_names_allowed_version(self, real_enforcer: ConstraintEnforcer):
+        violations = real_enforcer.check_constraints(provider="zai", model="glm-5.3")
+        glm_v = next(v for v in violations if v.code == "deprecated-glm-models")
+        assert "glm-5.2" in glm_v.message
+
+    def test_non_zai_provider_with_glm_model_unaffected(self, real_enforcer: ConstraintEnforcer):
+        """The allowlist is scoped to provider zai; a glm-named model on another
+        provider is not this constraint's concern."""
+        real_enforcer.enforce(provider="claude", model="glm-5.3")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_constraint_enforcer_kimi_valid.py
+++ b/tests/test_constraint_enforcer_kimi_valid.py
@@ -106,5 +106,7 @@ class TestExistingConstraintsNotRegressed:
     def test_zai_via_openrouter_allowed(self, enforcer: ConstraintEnforcer, monkeypatch):
         # glm-via-harness-only now blocks plain litellm:zai entirely (GLM must run via
         # glm-harness); override it to isolate the zai-via-openrouter-only behavior under test.
+        # model=glm-5.2 clears the deprecated-glm-models allowlist (a zai route must declare
+        # the single approved GLM version).
         monkeypatch.setenv("VNX_OVERRIDE_GLM_VIA_HARNESS_ONLY", "1")
-        enforcer.enforce(provider="litellm", sub_provider="zai", via="openrouter")
+        enforcer.enforce(provider="litellm", sub_provider="zai", model="glm-5.2", via="openrouter")


### PR DESCRIPTION
## Summary

Fixes a governance form-error in the `deprecated-glm-models` constraint: its `reason` says "only glm-5.2 is allowed" but it was implemented as a four-name `forbid_route` blocklist (`glm-4.5/4.6/5/5.1`). A blocklist of names lets every version never listed through; model versions are structurally open-ended, so a future `glm-5.3` would silently pass.

This flips it to a `require_route` allowlist pinning provider `zai` to model `glm-5.2`. Every other model, including `glm-5.3` and `glm-9.9`, is now blocked, with a message naming the allowed version.

## Changes

- `scripts/lib/providers/provider_constraints.yaml`: `deprecated-glm-models` → `require_route` allowlist (`provider: zai`, `model: glm-5.2`); `reason` rewritten to explain the allowlist decision.
- `scripts/lib/providers/constraint_enforcer.py` (active): `_required_route_missing` now scopes by `provider`; dropped the hardcoded GLM blocklist (strict YAML duplicate, alias-blind exact-name matching, ADR-036).
- `scripts/lib/constraint_enforcer.py` (legacy, loads the same YAML): `_check_require_route` gained provider scoping mirroring its own `_check_forbid_route`.
- Tests: 4 new cases (glm-5.3 blocked, glm-9.9 blocked, message names allowed version, non-zai provider unaffected); existing zai tests now declare `model="glm-5.2"`. Also corrected a pre-existing stale `t0-opus-only` test pinned to the retired `claude-opus-4-8` string.

## Verification

- `tests/test_constraint_enforcer.py` + `tests/test_constraint_enforcer_kimi_valid.py`: 76 passed, 1 skipped.
- Neighbour files (`test_routing_policy.py`, `test_dispatch_enforcement.py`, `test_dispatch_cli.py -k "glm or constraint or require_route or opus or kimi"`, `test_glm_harness_normalization.py`, `test_constraint_enforcer_kimi_bare_alias.py`, `test_failclass_registry.py`): all green.
- 3 unrelated failures in `test_pr10_provider_string_canon.py` + `test_provider_dispatch_deepseek_harness.py` are pre-existing on `main` (verified via stash).

## Open Items

- Human SSOT `~/.claude/rules/provider-constraints.md` (outside repo) carries the same blocklist wording and needs the same allowlist text — out of repo scope, reported for the operator.
- `zai-via-openrouter-only` reason still says "Only GLM-5.2 is an allowed version" while its rule is a `via: direct` blocklist — a form-error finding for the operator, deliberately not fixed in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)