### PR TITLE
feat(ci): scope Profile A to touched paths, fail closed

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -83,7 +83,28 @@ jobs:
             exit 1
           fi
 
-      - name: Run Profile A (doctor + full test suite)
+      - name: Classify CI profile (docs-only vs full sweep)
+        id: classify-profile
+        run: |
+          set -euo pipefail
+          # Same diff-range convention as the lint-patterns job below: the
+          # three-dot range against the base ref for PRs, against the parent
+          # commit for pushes. fetch-depth: 0 above makes origin/<base> available.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            diff_range="origin/${{ github.base_ref }}...HEAD"
+          else
+            diff_range="HEAD^...HEAD"
+          fi
+          # A diff that fails (e.g. no base ref) yields an empty list, which
+          # classify_ci_profile.py maps to "heavy" — fail closed, never light.
+          git diff --name-only "$diff_range" > "$GITHUB_WORKSPACE/.vnx-ci-changed-paths.txt" 2>/dev/null || true
+          profile="$(python3 "$GITHUB_WORKSPACE/scripts/ci/classify_ci_profile.py" --paths-file "$GITHUB_WORKSPACE/.vnx-ci-changed-paths.txt")"
+          echo "CI profile: ${profile}"
+          echo "Changed paths:"
+          cat "$GITHUB_WORKSPACE/.vnx-ci-changed-paths.txt"
+          echo "profile=${profile}" >> "$GITHUB_OUTPUT"
+
+      - name: Run Profile A (doctor + scope-appropriate suite)
         env:
           VNX_HOME: ${{ github.workspace }}/.claude/vnx-system
           VNX_DATA_DIR: ${{ github.workspace }}/.vnx-data
@@ -95,7 +116,30 @@ jobs:
           else
             echo "[skip] progress_state checksum not available"
           fi
-          # Full-suite sweep: pytest tests/ at directory level so every test file
+
+          if [ "${{ steps.classify-profile.outputs.profile }}" = "light" ]; then
+            # Light profile — docs-only PR (classify_ci_profile.py returned
+            # "light"). Doctor already ran above; add only the doc link/lint
+            # checks that actually exercise documentation, then stop. Kept
+            # deliberately small and proven rather than a broad "doc-ish" sweep
+            # whose coverage nobody can bound:
+            #   * test_docs_index.py           — DOCS_INDEX.md links resolve and
+            #                                    no stale unreachable docs bloat
+            #   * test_docs_archive.py         — docs/_archive integrity and the
+            #                                    ARCHIVED_MANIFEST matches disk
+            #   * test_subsystems_md_exists.py — docs/core/SUBSYSTEMS.md SSOT
+            # All three are stdlib-only (no DB, no heavy deps) and also run in
+            # the full sweep below, so they stay green on main.
+            pytest -q \
+              "$GITHUB_WORKSPACE/tests/test_docs_index.py" \
+              "$GITHUB_WORKSPACE/tests/test_docs_archive.py" \
+              "$GITHUB_WORKSPACE/tests/test_subsystems_md_exists.py" \
+              -p no:cacheprovider
+            exit 0
+          fi
+
+          # Full-suite sweep (heavy profile — code, unclassifiable, or empty
+          # diff): pytest tests/ at directory level so every test file
           # is exercised, not the handful of explicit files listed before.
           #
           # The sweep targets $GITHUB_WORKSPACE/tests — the real checkout — NOT

--- a/scripts/ci/classify_ci_profile.py
+++ b/scripts/ci/classify_ci_profile.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Classify a set of changed paths into a CI profile: ``light`` or ``heavy``.
+
+Profile A in ``.github/workflows/vnx-ci.yml`` calls this to decide how much of
+the test sweep a PR must run.  The rule is an ALLOWLIST, not a blocklist: only
+paths that are unambiguously documentation get the light profile, and
+everything else — code, unclassifiable paths, empty input, malformed paths —
+falls through to the heavy profile.  An unknown path must never produce a
+lighter run.  This is the lesson of #1513, where a blocklist that called itself
+an allowlist let through everything it did not name.
+
+Light-profile allowlist (the complete set of things that may be light):
+
+* ``docs/**``       — anything under ``docs/``
+* ``claudedocs/**`` — anything under ``claudedocs/``
+* ``*.md`` at the repository root — a single path component ending in ``.md``
+
+Everything else is heavy.  ``skills/**`` is deliberately heavy: a skill's
+markdown drives agent behaviour, so a skill change is a code change for CI
+purposes.  ``.github/**`` (including this workflow's own YAML) is heavy.
+
+Fail-closed guards, all of which yield ``heavy``:
+
+* an empty list of changed paths (no diff is not "nothing to check", it is
+  "we could not tell what changed"),
+* a path containing whitespace or a non-ASCII character (a filename that
+  shape is abnormal enough that it must not be allowed to slip through a
+  prefix/glob match into the light profile).
+
+The classifier never crashes on malformed input and always exits 0 — it
+*reports* a profile; the caller decides what to do with it.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+PROFILE_LIGHT = "light"
+PROFILE_HEAVY = "heavy"
+
+
+def _has_whitespace_or_non_ascii(path: str) -> bool:
+    """True when *path* contains whitespace or a character outside ASCII."""
+    return any(ch.isspace() or ord(ch) > 127 for ch in path)
+
+
+def is_docs_only_path(path: str) -> bool:
+    """Return True when *path* is unambiguously documentation-only.
+
+    Matches the allowlist in the module docstring.  A path that is empty,
+    contains whitespace, or contains a non-ASCII character is never
+    documentation-only — it falls through to the heavy profile rather than
+    risking a prefix/glob match on an abnormal filename.
+    """
+    if not path:
+        return False
+    if _has_whitespace_or_non_ascii(path):
+        return False
+    if path == "docs" or path.startswith("docs/"):
+        return True
+    if path == "claudedocs" or path.startswith("claudedocs/"):
+        return True
+    # Root-level markdown: no directory component, ends in ".md".
+    if "/" not in path and path.endswith(".md"):
+        return True
+    return False
+
+
+def classify_paths(paths) -> str:
+    """Return ``PROFILE_LIGHT`` or ``PROFILE_HEAVY`` for *paths*.
+
+    *paths* is any iterable of raw path strings (typically from
+    ``git diff --name-only``).  Whitespace-only entries are treated as blank
+    lines and dropped; a path with leading/trailing whitespace is kept and
+    rejected by the whitespace guard.  The result is ``light`` only when every
+    non-blank path matches the docs-only allowlist; anything else is ``heavy``.
+    """
+    meaningful = [p for p in paths if p.strip() != ""]
+    if not meaningful:
+        return PROFILE_HEAVY
+    for path in meaningful:
+        if not is_docs_only_path(path):
+            return PROFILE_HEAVY
+    return PROFILE_LIGHT
+
+
+def _read_paths(argv: list[str]) -> list[str]:
+    """Resolve the changed-paths input from argv (``--paths-file``, positional
+    args, or stdin) into a list of raw path strings."""
+    if "--paths-file" in argv:
+        idx = argv.index("--paths-file")
+        fp = argv[idx + 1]
+        return Path(fp).read_text(encoding="utf-8").splitlines()
+    if argv:
+        return argv
+    if not sys.stdin.isatty():
+        return sys.stdin.read().splitlines()
+    return []
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+    print(classify_paths(_read_paths(args)))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_ci_profile_classification.py
+++ b/tests/test_ci_profile_classification.py
@@ -1,0 +1,144 @@
+"""Tests for scripts/ci/classify_ci_profile.py.
+
+The classification is an allowlist: only docs-only paths may be "light", and
+everything else — code, unclassifiable paths, empty input, malformed paths —
+must be "heavy" (fail closed).  These tests pin that contract, including the
+most important one: an unknown path never produces a lighter run.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_CI_DIR = Path(__file__).resolve().parent.parent / "scripts" / "ci"
+if str(_CI_DIR) not in sys.path:
+    sys.path.insert(0, str(_CI_DIR))
+
+import classify_ci_profile as classifier  # noqa: E402
+
+LIGHT = classifier.PROFILE_LIGHT
+HEAVY = classifier.PROFILE_HEAVY
+
+
+# ---------------------------------------------------------------------------
+# The light allowlist
+# ---------------------------------------------------------------------------
+
+
+def test_docs_only_paths_are_light():
+    assert classifier.classify_paths(["docs/core/DISPATCH_RULES.md"]) == LIGHT
+    assert classifier.classify_paths(["docs/governance/decisions/ADR-036.md"]) == LIGHT
+    assert classifier.classify_paths(["docs/a.md", "docs/b/c.md"]) == LIGHT
+
+
+def test_root_markdown_is_light():
+    assert classifier.classify_paths(["README.md"]) == LIGHT
+    assert classifier.classify_paths(["CHANGELOG.md", "SECURITY.md"]) == LIGHT
+
+
+def test_claudedocs_is_light():
+    assert classifier.classify_paths(["claudedocs/plan-t0-daemon-driven-lifecycle.md"]) == LIGHT
+
+
+def test_mixed_docs_only_paths_are_light():
+    # docs/** + claudedocs/** + root *.md together is still all docs.
+    assert (
+        classifier.classify_paths(
+            ["docs/a.md", "claudedocs/b.md", "README.md"]
+        )
+        == LIGHT
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fail-closed: anything that is not unambiguously docs-only is heavy
+# ---------------------------------------------------------------------------
+
+
+def test_docs_plus_one_python_file_is_heavy():
+    assert classifier.classify_paths(["docs/a.md", "scripts/foo.py"]) == HEAVY
+
+
+def test_unmatched_path_is_heavy():
+    # The fail-closed core: a path no rule recognises gets the heaviest profile.
+    assert classifier.classify_paths(["somewhere/unknown.txt"]) == HEAVY
+    assert classifier.classify_paths(["scripts/lib/project_root.py"]) == HEAVY
+
+
+def test_empty_list_is_heavy():
+    assert classifier.classify_paths([]) == HEAVY
+
+
+def test_whitespace_only_input_is_heavy():
+    assert classifier.classify_paths(["", "   ", "\t"]) == HEAVY
+
+
+def test_skill_markdown_is_heavy():
+    # skills/** markdown drives agent behaviour — a code change, not docs.
+    assert classifier.classify_paths(["skills/horizon/SKILL.md"]) == HEAVY
+
+
+def test_workflow_yaml_is_heavy():
+    assert classifier.classify_paths([".github/workflows/vnx-ci.yml"]) == HEAVY
+
+
+# ---------------------------------------------------------------------------
+# Malformed paths: heavy, never a crash
+# ---------------------------------------------------------------------------
+
+
+def test_path_with_space_is_heavy_not_crash():
+    # A leading/trailing/embedded space must not sneak a match past the
+    # allowlist, and must not crash the classifier.
+    assert classifier.classify_paths(["docs/my file.md"]) == HEAVY
+    assert classifier.classify_paths(["my file.md"]) == HEAVY
+    assert classifier.classify_paths([" docs/foo.md"]) == HEAVY
+
+
+def test_path_with_non_ascii_is_heavy_not_crash():
+    assert classifier.classify_paths(["docs/résumé.md"]) == HEAVY
+    assert classifier.classify_paths(["café.md"]) == HEAVY
+
+
+# ---------------------------------------------------------------------------
+# CLI: the logic is exercised exactly as the workflow invokes it
+# ---------------------------------------------------------------------------
+
+
+def _run_cli(*args: str, stdin_text: str | None = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        [sys.executable, str(_CI_DIR / "classify_ci_profile.py"), *args],
+        capture_output=True,
+        text=True,
+        input=stdin_text,
+    )
+
+
+def test_cli_prints_profile_from_stdin():
+    result = _run_cli(stdin_text="docs/a.md\ndocs/b.md\n")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == LIGHT
+
+
+def test_cli_prints_heavy_from_positional_args():
+    result = _run_cli("docs/a.md", "scripts/foo.py")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == HEAVY
+
+
+def test_cli_paths_file_interface(tmp_path: Path):
+    paths_file = tmp_path / "changed.txt"
+    paths_file.write_text("README.md\nclaudedocs/x.md\n", encoding="utf-8")
+    result = _run_cli("--paths-file", str(paths_file))
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == LIGHT
+
+
+def test_cli_empty_stdin_is_heavy():
+    result = _run_cli(stdin_text="")
+    assert result.returncode == 0, result.stderr
+    assert result.stdout.strip() == HEAVY


### PR DESCRIPTION
## What

Profile A now decides its sweep from the paths a PR touches, instead of always running the full suite (`.github/workflows/vnx-ci.yml`).

- **Docs-only** (`docs/**`, `claudedocs/**`, root `*.md`) → `light`: doctor + the doc link/lint checks.
- **Everything else** (code, unclassifiable, empty diff, malformed paths) → `heavy`: the full sweep, unchanged.

The classifier is an **allowlist, not a blocklist** (the #1513 lesson): only paths that are unambiguously documentation may be light; any unknown path falls through to heavy. A path no rule recognises can never produce a lighter run.

## Why a script, not YAML

The logic lives in `scripts/ci/classify_ci_profile.py` so it is unit-testable outside GitHub Actions. The workflow calls it and branches on the result. Logic that lives only in YAML cannot be tested or reproduced locally.

## Light profile contents

Doctor always runs. The light profile then adds three stdlib-only doc link/lint checks:

- `test_docs_index.py` — DOCS_INDEX.md links resolve, no stale unreachable docs bloat
- `test_docs_archive.py` — docs/_archive integrity + ARCHIVED_MANIFEST matches disk
- `test_subsystems_md_exists.py` — docs/core/SUBSYSTEMS.md SSOT exists

All three also run in the full sweep, so they stay green on main. Deliberately small and proven rather than a broad "doc-ish" sweep whose coverage nobody can bound.

## Before measurement (real output, not the handoff claim)

```
gh run list --workflow "VNX CI" --limit 60 --json databaseId,displayTitle,event,conclusion,createdAt,updatedAt
```

- **Docs-only PR #1487** (single file `docs/governance/decisions/ADR-036-model-identity-from-registry.md`) — pull_request run `31798084760`: **18m07s**.
- Successful main pushes measured over the same window: **16m36s to 19m07s** (16 runs).

So a docs-only PR pays the same ~18 minutes as a dispatch-path PR. The "after" number cannot exist until this lands on main (operator measures it post-merge with a real docs-only PR).

## Fail-closed tests

`tests/test_ci_profile_classification.py` pins the contract, including the most important case: a path that matches no rule → heavy; empty list → heavy; a path with a space or non-ASCII → heavy (not a crash).

## Not in scope

- The post-merge "na" measurement (operator does it).
- Bundling PRs to save CI runs (operator decision: dropped).