### PR TITLE
feat(gate): accept goal_state as the plan, refuse thin goals loud

### DIFF
--- a/configs/plan_gate_panel.yaml
+++ b/configs/plan_gate_panel.yaml
@@ -32,6 +32,12 @@
 
 version: 1
 
+# Minimum meaningful characters (whitespace-stripped) a track's goal_state must
+# carry to stand in for the plan when `plan-gate run` is invoked WITHOUT --doc.
+# The length is measured AFTER stripping whitespace, so a goal of 200 spaces is
+# still refused. Read by scripts/lib/plan_gate_panel.py::load_goal_min_chars.
+goal_min_chars: 200
+
 seats:
   - label: opus
     provider: claude

--- a/docs/core/HORIZON_LIFECYCLE.md
+++ b/docs/core/HORIZON_LIFECYCLE.md
@@ -53,8 +53,14 @@ the plan passes.
 Two ways to resolve the `OI-PLAN` blocker (both call `_resolve_plan_blocker`, which
 stamps `resolved_at` and reconciles):
 
-- **`vnx horizon plan-gate run <track> --doc <plan-doc>`** — runs the plan-first panel
-  over a plan document; on PASS the blocker resolves. The intended default path.
+- **`vnx horizon plan-gate run <track>`** — runs the plan-first panel over the plan
+  text; on PASS the blocker resolves. `--doc <plan-doc>` names a plan document and is
+  the intended default when one exists; without it the track's `goal_state` is the
+  plan. A `goal_state` under `goal_min_chars` meaningful characters
+  (whitespace-stripped, `configs/plan_gate_panel.yaml`) is refused loud (exit 2) naming
+  the measured length, the threshold, and the remediation (fill the goal or pass
+  `--doc`). When both are present, `--doc` wins explicitly and the output names the
+  ignored goal.
 - **`vnx horizon plan-gate attest <track> --reason R --approval-id T`** — the operator
   escape-hatch: attest the gate as passed without re-running the panel. Human-gated
   (reason + approval-id both required); the deviation is recorded, never silent.

--- a/docs/core/HORIZON_PLANNING.md
+++ b/docs/core/HORIZON_PLANNING.md
@@ -55,7 +55,7 @@ Nested under `vnx horizon plan-gate <verb>`:
 | Verb | Purpose |
 |---|---|
 | `seed` | Seed the `OI-PLAN-<track>` blocker so the track is born plan-gated. |
-| `run` | Run the plan-first panel over a plan doc; on PASS the blocker resolves. |
+| `run` | Run the plan-first panel over the plan text; on PASS the blocker resolves. The plan text comes from `--doc <path>` when given, otherwise from the track's `goal_state`. A `goal_state` under `goal_min_chars` meaningful characters (whitespace-stripped, `configs/plan_gate_panel.yaml`) is refused loud; `--doc` wins explicitly over a present goal, and the output names which source the gate judged. |
 | `status` | Show a track's plan-gate state + `derived_status`. |
 | `attest` | Operator escape-hatch: attest the gate as passed without re-running the panel; requires `--reason` and `--approval-id`. |
 | `missing-reasons` | Read-only audit: list resolved plan-gate blockers that carry no `resolution_reason`. |

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -70,6 +70,13 @@ except Exception:  # vnx-silent-except: keep the panel importable without govern
 # as a well-formed seat.
 _SEAT_KEYS: tuple[str, ...] = ("label", "provider", "model_arg")
 
+# Minimum meaningful characters (whitespace-stripped) a track's goal_state must
+# carry to stand in for the plan when `plan-gate run` is invoked WITHOUT --doc.
+# The value is overridable in configs/plan_gate_panel.yaml (`goal_min_chars`),
+# never hardcoded at the call site — a fixed literal here would let the config
+# drift silently (see load_goal_min_chars).
+DEFAULT_GOAL_MIN_CHARS = 200
+
 # Per-seat verdict ledger (OI-888): one append-only, hash-chained record per
 # panelist per run, under the repo's .vnx-attest/ dir next to the plan_gate_pass
 # evidence ledger. Read by the plan-gate effectiveness probe.
@@ -188,6 +195,38 @@ def load_panel_seats(config_path: Optional[Path] = None) -> List[Dict[str, str]]
         )
     valid_providers = _valid_provider_strings()
     return [_validate_seat(s, i, valid_providers) for i, s in enumerate(raw_seats)]
+
+
+def load_goal_min_chars(config_path: Optional[Path] = None) -> int:
+    """The minimum goal length for ``plan-gate run`` invoked WITHOUT ``--doc``.
+
+    Reads ``goal_min_chars`` from ``configs/plan_gate_panel.yaml`` (the same file
+    and path resolution as ``load_panel_seats``). Falls back to
+    ``DEFAULT_GOAL_MIN_CHARS`` when the file is absent/unreadable or the key is
+    missing (a pre-existing config never breaks the gate). A present-but-invalid
+    value (non-int, bool, or <= 0) fails LOUD: a silently-wrong threshold would
+    either let a thin goal through to a panel it cannot inform or refuse every
+    goal — both silent governance drifts, so misconfiguration must surface here.
+    """
+    path = Path(config_path) if config_path is not None else _default_panel_config_path()
+    if not path.is_file():
+        return DEFAULT_GOAL_MIN_CHARS
+    try:
+        import yaml  # noqa: PLC0415
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return DEFAULT_GOAL_MIN_CHARS
+    if not isinstance(loaded, dict):
+        return DEFAULT_GOAL_MIN_CHARS
+    raw = loaded.get("goal_min_chars")
+    if raw is None:
+        return DEFAULT_GOAL_MIN_CHARS
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise ValueError(
+            f"plan_gate_panel: {path} 'goal_min_chars' must be a positive int, "
+            f"got {raw!r}"
+        )
+    return raw
 
 
 def filter_panel_seats(
@@ -1162,8 +1201,9 @@ def _emit_seat_records(
 
 
 def run_panel(
-    doc_path: str | Path,
+    doc_path: str | Path | None = None,
     *,
+    doc_text: Optional[str] = None,
     track_id: str,
     project_id: str = "vnx-dev",
     panel: Optional[List[Dict[str, str]]] = None,
@@ -1172,13 +1212,16 @@ def run_panel(
     timeout_seconds: Optional[int] = None,
     seat_ledger_path: Optional[Path] = None,
 ) -> Dict[str, Any]:
-    """Run the plan-first panel over ``doc_path`` and return the verdict.
+    """Run the plan-first panel over ``doc_path`` (or ``doc_text``) and return the verdict.
 
-    ``dispatcher`` is injectable; when omitted the governed provider_dispatch
-    dispatcher is used. Returns a dict with the overall ``decision``
-    (PASS|REVISE|BLOCK, or INFRA_FAIL when no lane produced a readable verdict —
-    an infrastructure failure, not a plan judgment), the rule ``summary``, and
-    per-panelist detail.
+    Exactly one plan source is required: ``doc_text`` when the caller already
+    holds the plan text (e.g. a track's ``goal_state`` standing in for the doc),
+    otherwise the text is read from ``doc_path``. ``doc_text`` wins when both are
+    given. ``dispatcher`` is injectable; when omitted the governed
+    provider_dispatch dispatcher is used. Returns a dict with the overall
+    ``decision`` (PASS|REVISE|BLOCK, or INFRA_FAIL when no lane produced a
+    readable verdict — an infrastructure failure, not a plan judgment), the rule
+    ``summary``, and per-panelist detail.
 
     ``timeout_seconds`` (OI-1068): the per-seat deadline a panelist has before its
     lane times out and the seat books a fabricated abstention. ``None`` (the
@@ -1190,7 +1233,10 @@ def run_panel(
     panel = panel or DEFAULT_PANEL
     resolved_timeout = _seat_timeout(timeout_seconds)
     dispatcher = dispatcher or _make_default_dispatcher(data_dir, resolved_timeout)
-    doc_text = Path(doc_path).read_text(encoding="utf-8")
+    if doc_text is None:
+        if doc_path is None:
+            raise ValueError("run_panel: a plan source is required — pass doc_path or doc_text")
+        doc_text = Path(doc_path).read_text(encoding="utf-8")
     doc_truncation = _doc_truncation_info(doc_text)
     instruction = build_plan_review_instruction(doc_text, track_id)
 

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -34,6 +34,7 @@ import os
 import sqlite3
 import sys
 import uuid
+from dataclasses import dataclass
 from datetime import date, datetime, timezone
 from pathlib import Path
 from typing import Any, Optional
@@ -2280,6 +2281,71 @@ def cmd_deliverable_promote(args: argparse.Namespace) -> int:
     return 0
 
 
+# ---------------------------------------------------------------------------
+# plan-gate plan-source resolution (OPSCHALING cluster, point 2): `--doc` is
+# optional; when absent the track's `goal_state` stands in for the plan. The
+# choice, the threshold check, and the refusal live here as a plain function so
+# a batch loop can call it directly, not only through the argparse handler.
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class PlanSource:
+    """The plan text the gate will review, plus which source supplied it."""
+    plan_text: str
+    source: str          # "doc" | "goal"
+    ignored_goal: bool = False
+
+
+class PlanRefusal(Exception):
+    """No acceptable plan text: the track's goal is too thin (or absent) and no
+    ``--doc`` was supplied.
+
+    Carries the measured length and the threshold so the caller can render a
+    refusal that names all three (length, threshold, and the remediation) —
+    never a bare exit, and never a silent pass to a panel that would burn five
+    model rounds on a plan that is not there.
+    """
+
+    def __init__(self, length: int, threshold: int) -> None:
+        self.length = length
+        self.threshold = threshold
+        super().__init__(
+            f"plan-gate refused: track goal is too thin to be a plan "
+            f"(measured {length} meaningful chars, threshold {threshold}). "
+            f"Fill in the track's goal to at least {threshold} meaningful "
+            f"characters, or pass --doc <path> with a plan document."
+        )
+
+
+def resolve_plan_source(
+    *,
+    doc_text: Optional[str],
+    goal_state: Optional[str],
+    min_goal_chars: int,
+) -> PlanSource:
+    """Resolve which plan text the gate reviews, and refuse a too-thin goal.
+
+    ``--doc`` wins explicitly: when ``doc_text`` is not None it is the plan, and
+    a non-empty ``goal_state`` is marked ``ignored_goal`` (the caller surfaces
+    that so the user never has to guess which source the gate judged). Otherwise
+    the track's ``goal_state`` is the plan, and it must carry at least
+    ``min_goal_chars`` MEANINGFUL characters — the length is measured AFTER
+    stripping whitespace, so a goal of 200 spaces is refused. A too-thin or
+    absent goal raises :class:`PlanRefusal`: a thin goal is never silently
+    passed and never silently refused.
+    """
+    if doc_text is not None:
+        return PlanSource(
+            plan_text=doc_text,
+            source="doc",
+            ignored_goal=bool((goal_state or "").strip()),
+        )
+    goal = (goal_state or "").strip()
+    if len(goal) < min_goal_chars:
+        raise PlanRefusal(length=len(goal), threshold=min_goal_chars)
+    return PlanSource(plan_text=goal, source="goal")
+
+
 def cmd_plan_gate_seed(args: argparse.Namespace) -> int:
     state_dir = _resolve_state_dir(args.state_dir)
     track = tracks_lib.get_track(state_dir, args.track_id, args.project_id)
@@ -2301,32 +2367,78 @@ def cmd_plan_gate_seed(args: argparse.Namespace) -> int:
 
 
 def cmd_plan_gate_run(args: argparse.Namespace) -> int:
-    """Run the plan-first panel over a plan doc; on PASS, resolve the OI-PLAN blocker.
+    """Run the plan-first panel over a plan; on PASS, resolve the OI-PLAN blocker.
 
-    Exit codes: 0 = PASS (track unblocked), 2 = REVISE/BLOCK (track stays blocked),
-    1 = infra error (doc/track missing, panel could not run).
+    The plan text comes from ``--doc`` (a file) when given, otherwise from the
+    track's ``goal_state``. A goal under ``goal_min_chars`` meaningful characters
+    (whitespace-stripped, configured in ``configs/plan_gate_panel.yaml``) is
+    refused loud — never silently passed to a panel it cannot inform, never
+    silently dropped. ``--doc`` wins explicitly over a present goal, and the
+    output names which source the gate judged.
+
+    Exit codes: 0 = PASS (track unblocked), 2 = REVISE/BLOCK or a too-thin goal
+    (track stays blocked), 1 = infra error (doc/track missing, panel could not run).
     """
     import plan_gate_panel
     import smart_router
 
     state_dir = _resolve_state_dir(args.state_dir)
-    doc = Path(args.doc)
-    if not doc.is_file():
-        print(f"plan doc not found: {doc}", file=sys.stderr)
-        return 1
     track = tracks_lib.get_track(state_dir, args.track_id, args.project_id)
     if not track:
         print(f"track not found: {args.track_id!r} (project {args.project_id!r})", file=sys.stderr)
         return 1
 
     data_dir = os.environ.get("VNX_DATA_DIR") or str(Path(state_dir).parent)
+    min_goal_chars = plan_gate_panel.load_goal_min_chars()
 
-    # An unreadable doc is an infra error, never a weight decision.
-    try:
-        doc.read_text(encoding="utf-8")
-    except OSError as exc:
-        print(f"plan doc unreadable: {doc}: {exc}", file=sys.stderr)
-        return 1
+    # Resolve the plan source: --doc wins explicitly over the track's goal_state;
+    # without --doc the goal_state must be thick enough to stand in for a plan.
+    doc_arg = getattr(args, "doc", None)
+    source = "goal"
+    ignored_goal = False
+    doc_path: Optional[Path] = None
+    if doc_arg:
+        doc_path = Path(doc_arg)
+        if not doc_path.is_file():
+            print(f"plan doc not found: {doc_path}", file=sys.stderr)
+            return 1
+        # An unreadable doc is an infra error, never a weight decision.
+        try:
+            plan_text = doc_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"plan doc unreadable: {doc_path}: {exc}", file=sys.stderr)
+            return 1
+        source = "doc"
+        ignored_goal = bool((track.get("goal_state") or "").strip())
+    else:
+        try:
+            resolved = resolve_plan_source(
+                doc_text=None,
+                goal_state=track.get("goal_state"),
+                min_goal_chars=min_goal_chars,
+            )
+        except PlanRefusal as exc:
+            print(str(exc), file=sys.stderr)
+            return 2
+        plan_text = resolved.plan_text
+
+    if source == "doc":
+        note = f"plan-gate source: doc {doc_path}"
+        if ignored_goal:
+            note += " (track goal_state ignored)"
+        print(note, file=sys.stderr)
+    else:
+        print(
+            f"plan-gate source: track goal_state "
+            f"({len(plan_text.strip())} meaningful chars)",
+            file=sys.stderr,
+        )
+
+    plan_source_info = {"source": source, "ignored_goal": ignored_goal}
+    if source == "doc":
+        plan_source_info["doc_path"] = str(doc_path)
+    else:
+        plan_source_info["goal_chars"] = len(plan_text.strip())
 
     # Governance-weight read-site (operator ladder, 2026-08-15): the panel size
     # derives from the governance variant (dispatch paths + task_class +
@@ -2439,6 +2551,7 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
                     "rationale": reason,
                 },
                 "panelists": [],
+                "plan_source": plan_source_info,
             }, indent=2))
         else:
             print(
@@ -2450,7 +2563,9 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
 
     try:
         result = plan_gate_panel.run_panel(
-            doc, track_id=args.track_id, project_id=args.project_id, data_dir=data_dir,
+            doc_path=doc_path,
+            doc_text=plan_text,
+            track_id=args.track_id, project_id=args.project_id, data_dir=data_dir,
             panel=panel,
             timeout_seconds=getattr(args, "seat_timeout", None),
         )
@@ -2479,7 +2594,9 @@ def cmd_plan_gate_run(args: argparse.Namespace) -> int:
         )
 
     if args.json:
-        print(json.dumps(result, indent=2))
+        out = dict(result)
+        out["plan_source"] = plan_source_info
+        print(json.dumps(out, indent=2))
     else:
         s = result["summary"]
         print(
@@ -3279,7 +3396,12 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     _common(p_prun)
     p_prun.add_argument("track_id")
-    p_prun.add_argument("--doc", required=True, help="path to the plan doc under review")
+    p_prun.add_argument(
+        "--doc", default=None,
+        help="path to the plan doc under review. Optional: when omitted, the "
+             "track's goal_state is the plan (it must carry at least "
+             "goal_min_chars meaningful characters from configs/plan_gate_panel.yaml).",
+    )
     p_prun.add_argument(
         "--panel-seats",
         dest="panel_seats",

--- a/tests/test_plan_gate_goal_state_plan.py
+++ b/tests/test_plan_gate_goal_state_plan.py
@@ -1,0 +1,273 @@
+"""tests/test_plan_gate_goal_state_plan.py — plan-gate accepts goal_state as the plan.
+
+The plan-gate (`vnx horizon plan-gate run <track>`) previously required `--doc`,
+so 66 of 80 blocked tracks whose plan already lives in their `goal_state` could
+not be gated without duplicating that text into a file. This proves the real
+`planning_cli.cmd_plan_gate_run` path:
+
+  - runs WITHOUT `--doc`, judging the track's `goal_state`, and the output names
+    that source;
+  - `--doc` wins over a present goal, and the output says the goal was ignored;
+  - a goal under the threshold is refused loud (exit != 0, length + threshold);
+  - a whitespace-only goal above the threshold length is refused too;
+  - a track with no goal and no `--doc` is refused with the same clarity;
+  - the threshold is read from config, not a hardcoded constant.
+
+Real model dispatch is out of scope (as in test_plan_gate_panel.py): `run_panel`
+is stubbed with a capture, but the argparse/source-resolution/threshold logic is
+the real `cmd_plan_gate_run`. Self-contained (tests/ has no __init__.py).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sqlite3
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+_LIB = REPO_ROOT / "scripts" / "lib"
+_SCRIPTS = REPO_ROOT / "scripts"
+_MIGRATIONS = REPO_ROOT / "schemas" / "migrations"
+for _p in (str(_LIB), str(_SCRIPTS)):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+import schema_migration  # noqa: E402
+import tracks  # noqa: E402
+import planning_cli  # noqa: E402
+import plan_gate_panel as pgp  # noqa: E402
+
+
+def _bootstrap(tmp_path: Path) -> Path:
+    """A pre-migrated store (tracks + plan-gate schema), same as
+    test_plan_gate_panel.py::_bootstrap."""
+    state_dir = tmp_path / "state"
+    state_dir.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(state_dir / "runtime_coordination.db"))
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS dispatches (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "dispatch_id TEXT NOT NULL, project_id TEXT NOT NULL DEFAULT 'vnx-dev', "
+        "state TEXT NOT NULL DEFAULT 'queued', terminal_id TEXT, track TEXT, "
+        "priority TEXT DEFAULT 'P2', pr_ref TEXT, gate TEXT, "
+        "attempt_count INTEGER NOT NULL DEFAULT 0, bundle_path TEXT, "
+        "created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "updated_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')), "
+        "expires_after TEXT, metadata_json TEXT DEFAULT '{}', "
+        "UNIQUE(dispatch_id, project_id))"
+    )
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS coordination_events (id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "event_id TEXT, event_type TEXT, entity_type TEXT, entity_id TEXT, from_state TEXT, "
+        "to_state TEXT, actor TEXT, reason TEXT, metadata_json TEXT, occurred_at TEXT, project_id TEXT)"
+    )
+    conn.commit()
+    for version, filename in [
+        (22, "0022_track_layer.sql"),
+        (24, "0024_tracks_tenant_scoping.sql"),
+        (27, "0027_planning_horizon_and_deliverable_view.sql"),
+        (28, "0028_tracks_derived_status.sql"),
+        (30, "0030_track_oi_resolved_at.sql"),
+        (33, "0033_track_decision_ref.sql"),
+    ]:
+        sql = (_MIGRATIONS / filename).read_text(encoding="utf-8")
+        schema_migration.apply_script_if_below(conn, version, sql)
+        conn.commit()
+    conn.close()
+    return state_dir
+
+
+def _pass_result(track_id: str, project_id: str, panel: list) -> dict:
+    return {
+        "track_id": track_id, "project_id": project_id, "decision": "PASS",
+        "summary": {"decision": "PASS", "pass_count": len(panel),
+                    "revise_count": 0, "block_count": 0, "rationale": "ok"},
+        "panelists": [], "doc_truncation": {"truncated": False},
+    }
+
+
+def _stub_panel(monkeypatch, tmp_path: Path, captured: list) -> None:
+    """Stub model dispatch + seat config so cmd_plan_gate_run runs end-to-end
+    against a real store without touching a live provider or the repo config."""
+    # Absent config -> load_panel_seats falls back to DEFAULT_PANEL and
+    # load_goal_min_chars falls back to DEFAULT_GOAL_MIN_CHARS (200).
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+
+    def _capture_run_panel(doc_path, *, doc_text=None, track_id, project_id, panel, data_dir, **kw):
+        captured.append({"doc_path": doc_path, "doc_text": doc_text, "panel": panel})
+        return _pass_result(track_id, project_id, panel)
+
+    monkeypatch.setattr(pgp, "run_panel", _capture_run_panel)
+    monkeypatch.setattr(planning_cli, "_resolve_plan_blocker", lambda *a, **k: True)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+
+def _run(state_dir: Path, track_id: str, *, doc=None, goal_state="", captured=None, **extra):
+    """Build a Namespace the way argparse would and run the real handler."""
+    args = argparse.Namespace(
+        track_id=track_id, project_id="p1", state_dir=str(state_dir),
+        doc=doc, json=False, panel_seats=None,
+        **extra,
+    )
+    rc = planning_cli.cmd_plan_gate_run(args)
+    return rc
+
+
+_THICK_GOAL = "Ship a coherent plan for the widget. " * 10  # 390 chars
+
+
+def test_run_without_doc_uses_goal_state_and_names_source(tmp_path, monkeypatch, capsys):
+    """A track with a thick goal gates without --doc, and the output names the
+    source. Asserts the plan text actually handed to run_panel is the goal."""
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-goal", "p1", "t", _THICK_GOAL, phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    rc = _run(state_dir, "feat-goal", goal_state=_THICK_GOAL, captured=captured)
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert len(captured) == 1
+    assert captured[0]["doc_path"] is None
+    assert captured[0]["doc_text"] == _THICK_GOAL.strip()
+    assert "plan-gate source: track goal_state" in err
+
+
+def test_run_with_doc_wins_over_goal_and_names_ignored(tmp_path, monkeypatch, capsys):
+    """When both --doc and a goal are present, the doc wins and the output says
+    the goal was ignored."""
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-docwins", "p1", "t", _THICK_GOAL, phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Approach\nFrom the doc, not the goal.\n", encoding="utf-8")
+
+    rc = _run(state_dir, "feat-docwins", doc=str(doc), goal_state=_THICK_GOAL, captured=captured)
+    err = capsys.readouterr().err
+
+    assert rc == 0
+    assert len(captured) == 1
+    assert str(captured[0]["doc_path"]) == str(doc)
+    assert "## Approach" in captured[0]["doc_text"]
+    assert "plan-gate source: doc" in err
+    assert "track goal_state ignored" in err
+
+
+def test_thin_goal_refused_with_length_and_threshold(tmp_path, monkeypatch, capsys):
+    """A goal under the threshold is refused (exit != 0) naming both the
+    measured length and the threshold."""
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-thin", "p1", "t", "too short", phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    rc = _run(state_dir, "feat-thin", goal_state="too short", captured=captured)
+    err = capsys.readouterr().err
+
+    assert rc != 0
+    assert captured == []  # the panel never ran
+    assert "measured 9 meaningful chars" in err
+    assert "threshold 200" in err
+    assert "--doc" in err  # the remediation is named
+
+
+def test_whitespace_only_goal_refused(tmp_path, monkeypatch, capsys):
+    """A goal of pure whitespace above the threshold length is refused — the
+    length is measured AFTER stripping, so 250 spaces measure 0."""
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-ws", "p1", "t", " " * 250, phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    rc = _run(state_dir, "feat-ws", goal_state=" " * 250, captured=captured)
+    err = capsys.readouterr().err
+
+    assert rc != 0
+    assert captured == []
+    assert "measured 0 meaningful chars" in err
+    assert "threshold 200" in err
+
+
+def test_no_goal_and_no_doc_refused(tmp_path, monkeypatch, capsys):
+    """A track with no goal and no --doc is refused with the same clarity
+    (length 0 + threshold + remediation), not a bare exit."""
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-none", "p1", "t", "", phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+
+    rc = _run(state_dir, "feat-none", goal_state="", captured=captured)
+    err = capsys.readouterr().err
+
+    assert rc != 0
+    assert captured == []
+    assert "measured 0 meaningful chars" in err
+    assert "threshold 200" in err
+    assert "--doc" in err
+
+
+def test_threshold_comes_from_config_not_hardcoded(tmp_path, monkeypatch, capsys):
+    """The threshold is read from configs/plan_gate_panel.yaml, not a hardcoded
+    200: with goal_min_chars=50 a 90-char goal passes (it would fail a hardcoded
+    200), and a 30-char goal is refused at 50."""
+    cfg = tmp_path / "panel.yaml"
+    cfg.write_text("version: 1\ngoal_min_chars: 50\nseats: []\n", encoding="utf-8")
+
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-ok", "p1", "t", "g" * 90, phase="queued")
+    tracks.create_track(state_dir, "feat-short", "p1", "t", "g" * 30, phase="queued")
+    captured: list = []
+    _stub_panel(monkeypatch, tmp_path, captured)
+    # Override the config path _stub_panel just set to absent.yaml: the threshold
+    # must come from this 50-char config. Seat composition is orthogonal to the
+    # threshold; keep it deterministic via DEFAULT_PANEL.
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: cfg)
+    monkeypatch.setattr(pgp, "load_panel_seats", lambda *a, **k: list(pgp.DEFAULT_PANEL))
+
+    rc_ok = _run(state_dir, "feat-ok", goal_state="g" * 90, captured=captured)
+    assert rc_ok == 0, "90 chars >= 50 must pass when the threshold is read from config"
+    assert len(captured) == 1
+
+    rc_short = _run(state_dir, "feat-short", goal_state="g" * 30, captured=captured)
+    err = capsys.readouterr().err
+    assert rc_short != 0
+    assert "threshold 50" in err
+
+
+def test_load_goal_min_chars_reads_config_key(tmp_path):
+    """The loader reads the goal_min_chars key from the YAML, and falls back to
+    the default when the key is absent."""
+    cfg = tmp_path / "panel.yaml"
+    cfg.write_text("version: 1\ngoal_min_chars: 321\nseats: []\n", encoding="utf-8")
+    assert pgp.load_goal_min_chars(cfg) == 321
+
+    no_key = tmp_path / "no_key.yaml"
+    no_key.write_text("version: 1\nseats: []\n", encoding="utf-8")
+    assert pgp.load_goal_min_chars(no_key) == pgp.DEFAULT_GOAL_MIN_CHARS
+
+    assert pgp.load_goal_min_chars(tmp_path / "absent.yaml") == pgp.DEFAULT_GOAL_MIN_CHARS
+
+
+def test_load_goal_min_chars_rejects_invalid_value(tmp_path):
+    """A present-but-invalid threshold (<= 0, non-int) fails loud rather than
+    silently disabling the refusal."""
+    for bad in ("0", "-5", "abc"):
+        cfg = tmp_path / f"bad_{bad}.yaml"
+        cfg.write_text(f"version: 1\ngoal_min_chars: {bad}\nseats: []\n", encoding="utf-8")
+        with pytest.raises(ValueError):
+            pgp.load_goal_min_chars(cfg)
+
+
+def test_run_argparse_accepts_missing_doc():
+    """`--doc` is optional at the argparse layer: `plan-gate run <track>` parses
+    with doc=None (the engine surface; the horizon surface parity is guarded by
+    tests/test_horizon_parity.py)."""
+    args = planning_cli._build_parser().parse_args(["plan-gate", "run", "track-id"])
+    assert args.doc is None
+    assert args.track_id == "track-id"

--- a/tests/test_plan_gate_goal_state_plan.py
+++ b/tests/test_plan_gate_goal_state_plan.py
@@ -70,6 +70,7 @@ def _bootstrap(tmp_path: Path) -> Path:
         (24, "0024_tracks_tenant_scoping.sql"),
         (27, "0027_planning_horizon_and_deliverable_view.sql"),
         (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
         (30, "0030_track_oi_resolved_at.sql"),
         (33, "0033_track_decision_ref.sql"),
     ]:

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -674,6 +674,7 @@ def _bootstrap(tmp_path: Path) -> Path:
         (24, "0024_tracks_tenant_scoping.sql"),
         (27, "0027_planning_horizon_and_deliverable_view.sql"),
         (28, "0028_tracks_derived_status.sql"),
+        (29, "0029_track_type_discriminator.sql"),
         (30, "0030_track_oi_resolved_at.sql"),
         (33, "0033_track_decision_ref.sql"),
     ]:

--- a/vnx_cli/main.py
+++ b/vnx_cli/main.py
@@ -723,7 +723,12 @@ def _register_plan_gate_verbs(subs: argparse.Action) -> None:
     )
     _common_horizon_args(p_prun)
     p_prun.add_argument("track_id")
-    p_prun.add_argument("--doc", required=True, help="path to the plan doc under review")
+    p_prun.add_argument(
+        "--doc", default=None,
+        help="path to the plan doc under review. Optional: when omitted, the "
+             "track's goal_state is the plan (it must carry at least "
+             "goal_min_chars meaningful characters from configs/plan_gate_panel.yaml).",
+    )
     p_prun.add_argument(
         "--panel-seats",
         dest="panel_seats",


### PR DESCRIPTION
## What

`vnx horizon plan-gate run <track>` no longer requires `--doc`. When `--doc` is
absent, the track's `goal_state` is the plan the panel reviews. When both are
present, `--doc` wins explicitly and the output names the ignored goal.

A `goal_state` under `goal_min_chars` (200, configurable in
`configs/plan_gate_panel.yaml`) meaningful whitespace-stripped characters is
refused loud (exit 2) naming the measured length, the threshold, and the
remediation (fill the goal or pass `--doc`). Whitespace is stripped before
measuring, so 200 spaces still refuse. Never a silent pass to a panel the plan
cannot inform, never a silent refusal.

## Changes

- `scripts/planning_cli.py`: `resolve_plan_source` + `PlanSource`/`PlanRefusal`
  (callable outside the argparse handler, for the upcoming batch command);
  `cmd_plan_gate_run` resolves doc-vs-goal and reports the source; `--doc` made
  optional.
- `scripts/lib/plan_gate_panel.py`: `load_goal_min_chars` reads the threshold
  from the panel config (loud on a misconfigured value); `run_panel` gains a
  `doc_text` keyword so the goal is judged without a temp file.
- `vnx_cli/main.py`: `--doc` made optional (flag-parity with `planning_cli`).
- `configs/plan_gate_panel.yaml`: `goal_min_chars: 200`.
- docs (`HORIZON_PLANNING.md`, `HORIZON_LIFECYCLE.md`) + tests
  (`tests/test_plan_gate_goal_state_plan.py`).

## Verification

- `tests/test_plan_gate_goal_state_plan.py` — 9 passed
- `tests/test_horizon_parity.py` — 94 passed
- `tests/test_plan_gate_panel.py` — 217 passed; 5 pre-existing failures (schema
  drift in the `_resolve_plan_blocker`/`track_reconciler` seed-resolve path,
  unrelated to this change)

Dispatch-ID: 20260815-opsch-w1-plangate-goalstate-r2

🤖 Generated with [Claude Code](https://claude.com/claude-code)