### PR TITLE
feat(permissions): close rol-te-smal role-scope gap (backend/quality/security)

### DIFF
--- a/.vnx/worker_permissions.yaml
+++ b/.vnx/worker_permissions.yaml
@@ -74,6 +74,24 @@ profiles:
       - "scripts/**"
       - "tests/**"
       - "dashboard/**"
+      # --- role-scope-parity (20260815-opsch-w2-rolescope-fix): rol-te-smal own-work.
+      # Each added rule below is backend-developer's OWN runtime work (per the
+      # ownership map in scripts/analysis/role_scope_outside_triage.py), evidenced
+      # by the 48 rol-te-smal dispatches that wrote these paths outside the old
+      # scope. Counts = outside path-occurrences in that bucket. No blanket
+      # docs/**: docs/core|governance/decisions|manifesto stay system-architect's.
+      - "vnx_cli/**"            # 51 — CLI package (runtime implementation)
+      - "bin/**"                # 5  — runtime entrypoints (bin/vnx)
+      - "hooks/**"              # 1  — runtime hooks (monitor_tripwire.sh)
+      - "configs/**"            # 3  — runtime config (plan_gate_panel/producer_freshness)
+      - "docs/applications/**"  # 3  — feature docs
+      - "docs/operations/**"    # 4  — ops docs (overlaps security's WORKER_PERMISSIONS.md)
+      - "docs/MIGRATION_GUIDE.md"  # 1  — root feature doc (literal: a docs/*.md glob would span / into docs/core, docs/governance/decisions, docs/manifesto)
+      - "VERSION"               # 5  — root build/release file
+      - "CHANGELOG.md"          # 4  — root build/release file
+      - "pyproject.toml"        # 1  — root build/release file
+      - "uv.lock"               # 1  — root build/release file
+      - "requirements.txt"      # 1  — root build/release file
 
   quality-engineer:
     # Build role — default_instruction: "commit and push a dispatch branch".
@@ -96,6 +114,15 @@ profiles:
     file_write_scope:
       - "tests/**"
       - "scripts/check_*"
+      # --- role-scope-parity (20260815-opsch-w2-rolescope-fix): rol-te-smal own-work.
+      # Test-harness / CI / review-gate infra is quality-engineer's own work per
+      # the ownership map, evidenced by 4 rol-te-smal dispatches. Counts = outside
+      # path-occurrences in that bucket.
+      - "scripts/benchmark/**"    # 5  — benchmark runners (bench-v2-smart-lanes, oi-224)
+      - "scripts/refactor_*.py"   # 2  — equivalence tooling (proof-tools-round2)
+      - "scripts/lib/gate_*.py"   # 3  — review-gate infra (gate-tests-fixforward)
+      - "scripts/commands/gate.sh" # 1 — review-gate infra
+      - "scripts/review_gate_manager.py" # 1 — review-gate infra
 
   frontend-developer:
     # Build role — default_instruction: "commit and push a dispatch branch".
@@ -165,6 +192,14 @@ profiles:
     file_write_scope:
       - "scripts/**"
       - "tests/**"
+      # --- role-scope-parity (20260815-opsch-w2-rolescope-fix): rol-te-smal own-work.
+      # Permission posture / key provisioning docs are security-engineer's own work
+      # per the ownership map, evidenced by 5 rol-te-smal dispatches. Narrow file
+      # grants only — NOT docs/** or scripts/lib/** (scripts/** above is the
+      # pre-existing remediation surface, unchanged). Counts = outside
+      # path-occurrences in that bucket.
+      - "docs/operations/WORKER_PERMISSIONS.md"  # 4  — permission docs
+      - "docs/governance/KEY_PROVISIONING.md"     # 1  — key provisioning doc
 
   # Read roles — default_instruction says "Do not modify code" (code-reviewer) or
   # carries governance_profile: light (research-analyst). They deny code-mutation

--- a/claudedocs/role-scope-outside-triage.md
+++ b/claudedocs/role-scope-outside-triage.md
@@ -1,0 +1,307 @@
+# Role-scope-outside triage — nulmeting en hermeting na scope-reparatie
+
+Datum: 2026-08-15. Dispatch `20260815-opsch-w2-rolescope-fix`, track `role-scope-parity`,
+punten 11+12 van het OPSCHALING-cluster plus de restschuld van punt 10 (dit rapport).
+
+Dit document is de restschuld van #1516: de triage in drie buckets bestond al als script,
+maar het rapport met de tellingen was nooit geschreven. Hier staan de nulmeting, de
+scope-reparatie met de per-regel onderbouwing, en de hermeting na de reparatie.
+
+De telling is gegenereerd uit script-output, nooit uit het hoofd. Beide commando's en de
+ruwe output staan onderaan.
+
+---
+
+## De drie buckets
+
+`role_scope_outside_triage.py` splitst de dispatches die buiten hun eigen rol-scope
+schreven (`role_scope_only__outside`) in drie elkaar uitsluitende buckets, op de ownership-map
+(`OWNERSHIP_RULES`, eerste match wint, fnmatch):
+
+| bucket | betekenis | te fixen via scope? |
+|---|---|---|
+| `rol-te-smal` | elk buiten-pad is het EIGEN werk van de rol; de scope is te smal, routing was goed | ja |
+| `verkeerd-gerouteerd` | elk buiten-pad hoort bij één ANDERE rol; de dispatch zat op de verkeerde rol | nee, routing |
+| `onbeslisbaar` | mix van eigen en ander werk, meerdere andere rollen, of geen ownership-regel | nee |
+
+Hard control: de drie buckets moeten de gemeten populatie exact partitioneren.
+`sum(3 buckets) == role_scope_only__outside`, bij mismatch exit 1.
+
+---
+
+## Resultaat in één tabel
+
+| maat | nulmeting (main YAML) | hermeting (gerepareerde YAML) | delta |
+|---|---:|---:|---:|
+| `role_scope_only__outside` | 144 | 86 | **-58** |
+| `rol-te-smal` | 57 | 0 | -57 |
+| `verkeerd-gerouteerd` | 42 | 61 | +19 |
+| `onbeslisbaar` | 45 | 25 | -20 |
+| `in_scope` | 211 | 269 | +58 |
+| `unlinked` | 372 | 372 | 0 |
+| `sum_check_ok` | true | true | |
+
+De daling 144 → 86 is het beoogde resultaat. De dispatch noemde een daling van 142 naar
+~90; de nulmeting op de huidige pending-dir is 144, niet 142. Dat verschil van 2 komt doordat
+er sinds #1516 (die "140" in zijn docstring noemde) nieuwe dispatches in de pending-dir zijn
+bijgekomen. De gemeten 144 is leidend.
+
+De daling naar 86 is GEEN alarmsignaal: `role_scope_only__outside` ging naar 86, niet naar 0.
+Alleen de `rol-te-smal`-bucket ging naar 0, en dat is precies de bedoeling: al het eigen werk
+dat de scope vergat, zit nu binnen de scope.
+
+De schuif binnen de buiten-populatie is verklaarbaar en verwacht. `verkeerd-gerouteerd` steeg
+42 → 61 en `onbeslisbaar` daalde 45 → 25. Dat is herclassificatie, geen nieuw fout-routen.
+Een dispatch die voorheen "eigen werk + andermans werk" buiten zijn scope schreef
+(onbeslisbaar), verliest zijn eigen-werk-helft aan de verruimde scope. Wat overblijft is een
+puur verkeerd-gerouteerd pad. Dus: onbeslisbaar → verkeerd-gerouteerd.
+
+---
+
+## Per-role verdeling
+
+### Nulmeting
+
+| rol | rol-te-smal | verkeerd-gerouteerd | onbeslisbaar |
+|---|---:|---:|---:|
+| backend-developer | 48 | 34 | 37 |
+| security-engineer | 5 | 4 | 5 |
+| quality-engineer | 4 | 2 | 2 |
+| research-analyst | 0 | 1 | 1 |
+| system-architect | 0 | 1 | 0 |
+
+### Hermeting
+
+| rol | rol-te-smal | verkeerd-gerouteerd | onbeslisbaar |
+|---|---:|---:|---:|
+| backend-developer | 0 | 52 | 18 |
+| security-engineer | 0 | 5 | 4 |
+| quality-engineer | 0 | 2 | 2 |
+| research-analyst | 0 | 1 | 1 |
+| system-architect | 0 | 1 | 0 |
+
+Drie rollen hadden `rol-te-smal`-eigen werk (backend 48, security 5, quality 4).
+`system-architect` had 0 `rol-te-smal`: die schreef nooit zijn eigen werk buiten zijn scope,
+dus zijn scope is NIET gewijzigd. `research-analyst` evenmin (0).
+
+---
+
+## Vijf zwaarste cases per bucket (nulmeting)
+
+### rol-te-smal
+
+| dispatch | rol | # | paden |
+|---|---|---:|---|
+| 20260814q-a-gate-tests-fixforward | quality-engineer | 5 | scripts/commands/gate.sh, scripts/lib/gate_executor.py, scripts/lib/gate_recorder.py, scripts/lib/gate_status.py, scripts/review_gate_manager.py |
+| 20260709-085020-otel-retire | backend-developer | 4 | docs/operations/OTEL_EXPORT.md, docs/operations/PACKAGE_BUILD.md, pyproject.toml, requirements.txt |
+| 20260711-163120-bench-v2-smart-lanes | quality-engineer | 3 | scripts/benchmark/field-tests/README.md, scripts/benchmark/field-tests/lane_calibration.yaml, scripts/benchmark/field-tests/runners/lane_calibration.py |
+| 20260713-085536-docs-applications | backend-developer | 3 | docs/applications/README.md, docs/applications/coding-agents.md, docs/applications/finance.md |
+| 20260717-vnx-pin-robustness | backend-developer | 3 | vnx_cli/_engine.py, vnx_cli/commands/init_cmd.py, vnx_cli/main.py |
+
+### verkeerd-gerouteerd
+
+| dispatch | rol | # | paden |
+|---|---|---:|---|
+| 20260730-skillscope-paths | backend-developer | 4 | .claude/skills/control-centre/SKILL.md, .claude/skills/horizon/SKILL.md, .claude/skills/planner/SKILL.md, skills/horizon/SKILL.md |
+| D-horizon-d2-skillrename | backend-developer | 4 | .claude/skills/featureplan-kickoff/SKILL.md, .claude/skills/horizon/SKILL.md, .claude/skills/planner/SKILL.md, .claude/skills/pm/SKILL.md |
+| 20260709-080633-fabricdoor-consumer | backend-developer | 3 | .claude/terminals/T0/role-orchestrator.md, examples/backend-developer/CLAUDE.md, examples/backend-developer/config.yaml |
+| 20260802-w19c-test-store-isolation | quality-engineer | 3 | scripts/lib/vnx_mode.py, scripts/lib/vnx_paths.py, scripts/pr_queue_manager.py |
+| 20260807-102859-state-writer-install-artifact | backend-developer | 3 | templates/init/default/settings.json.j2, templates/init/minimal/settings.json.j2, templates/settings_vnx_keys.json.tmpl |
+
+### onbeslisbaar
+
+| dispatch | rol | # | paden |
+|---|---|---:|---|
+| D-retire-featureplan-prqueue | backend-developer | 12 | .claude/skills/featureplan-kickoff, planner, pm/SKILL.md; .claude/terminals/T0/CLAUDE.md; FEATURE_PLAN.md; PR_QUEUE.md; agents/orchestrator/CLAUDE.md; docs/contracts/f36-r12-rpc-schemas/query_pr_queue-{request,response}.json; templates/{DOMAIN_FEATURE_PLAN_TEMPLATE,FEATURE_PLAN_TEMPLATE,PR_QUEUE_TEMPLATE}.md |
+| 20260712-190957-cockpit-pr11 | backend-developer | 10 | docs/DOCS_INDEX.md; docs/_archive/*; docs/comparisons/*; docs/manifesto/HEADLESS_TRANSITION.md |
+| 20260716-f1-t0-startup-import | backend-developer | 9 | .claude/settings.json; .claude/skills/featureplan-kickoff/SKILL.md; .claude/terminals/T0/{CLAUDE.md,role-orchestrator.md}; bin/vnx; hooks/sessionstart.sh; templates/init/default/{claude_md.j2,terminals/T0_claude_md.j2}; templates/terminals/T0.md |
+| 20260716-ff-1174-r3-wireup | backend-developer | 9 | idem |
+| 20260716-ff-1174-r4-testfix | backend-developer | 9 | idem |
+
+Na de reparatie is `rol-te-smal` leeg. De `verkeerd-gerouteerd`-top-5 is ongewijzigd (routing,
+geen scope). In `onbeslisbaar` krimpt de `t0-startup-import`/`ff-1174`-familie van 9 naar 7
+paden: `bin/vnx` en `hooks/sessionstart.sh` vallen nu binnen de backend-scope en verdwijnen
+uit de buiten-paden. Concreet bewijs dat de scope-reparatie precies de eigen-werk-paden vangt.
+
+---
+
+## Scope-reparatie — wat er per rol is toegevoegd en waarom
+
+Onderbouwd, nooit blanket. Elke regel noemt het pad en het aantal buiten-pad-voorkomens in de
+`rol-te-smal`-bucket dat hij oplost. Een regel die niets oplost hoort er niet in.
+
+### backend-developer (48 rol-te-smal)
+
+| regel | # | waarom |
+|---|---:|---|
+| `vnx_cli/**` | 51 | CLI-package, runtime-implementatie |
+| `bin/**` | 5 | runtime-entrypoints (bin/vnx) |
+| `hooks/**` | 1 | runtime-hooks (monitor_tripwire.sh) |
+| `configs/**` | 3 | runtime-config (plan_gate_panel, producer_freshness) |
+| `docs/applications/**` | 3 | feature-docs |
+| `docs/operations/**` | 4 | ops-docs (overlapt security's WORKER_PERMISSIONS.md) |
+| `docs/MIGRATION_GUIDE.md` | 1 | root feature-doc, letterlijk pad |
+| `VERSION` | 5 | root build/release |
+| `CHANGELOG.md` | 4 | root build/release |
+| `pyproject.toml` | 1 | root build/release |
+| `uv.lock` | 1 | root build/release |
+| `requirements.txt` | 1 | root build/release |
+
+`docs/MIGRATION_GUIDE.md` is bewust een letterlijk pad in plaats van een `docs/*.md`-glob.
+fnmatch's `*` matcht `/` op Unix, dus `docs/*.md` zou ook `docs/core/DISPATCH_RULES.md`,
+`docs/governance/decisions/ADR-*.md` en `docs/manifesto/*` vangen. Dat is system-architect-
+terrein. Het letterlijke pad sluit alleen het eigen werk.
+
+### quality-engineer (4 rol-te-smal)
+
+| regel | # | waarom |
+|---|---:|---|
+| `scripts/benchmark/**` | 5 | benchmark-runners |
+| `scripts/refactor_*.py` | 2 | equivalentie-tooling |
+| `scripts/lib/gate_*.py` | 3 | review-gate-infra |
+| `scripts/commands/gate.sh` | 1 | review-gate-infra |
+| `scripts/review_gate_manager.py` | 1 | review-gate-infra |
+
+### security-engineer (5 rol-te-smal)
+
+| regel | # | waarom |
+|---|---:|---|
+| `docs/operations/WORKER_PERMISSIONS.md` | 4 | permission-docs |
+| `docs/governance/KEY_PROVISIONING.md` | 1 | key-provisioning-doc |
+
+Twee smalle bestands-grants, geen `docs/**` of `scripts/lib/**`. De test
+`test_scope_additions_are_narrow_doc_grants_not_broad_surface` pint dit af.
+
+### Niet gewijzigd
+
+`system-architect` en `research-analyst` hadden 0 `rol-te-smal`, dus hun scope is onaangeraakt.
+`Makefile` is bewust NIET toegevoegd aan backend-developer, ondanks dat het eigen werk is: het
+kwam in de `rol-te-smal`-bucket niet als buiten-pad voor (0 voorkomens). Een regel die niets
+oplost hoort er niet in.
+
+---
+
+## Verkeerd-gerouteerd: het routing-patroon (niet gefixt via scope)
+
+42 (nu 61) dispatches zaten op de verkeerde rol. Dat is geen scope-probleem maar een
+routing-probleem, en een scope-verruiming lost het niet op. Het patroon is specifiek:
+
+De dominante vorm is **backend-developer die system-architect-werk doet** op `.claude/skills/**`,
+`.claude/terminals/**`, `templates/**`, `agents/**`, `examples/**` en `docs/manifesto/**`.
+De ownership-map wijst die paden toe aan system-architect. De reden dat juist backend-developer
+deze paden zo vaak raakt, is de sentinel-default: wanneer de rol niet oplost, valt de worker
+terug op `_FAKE_DEFAULT_ROLE = _IDENTITY_UNRESOLVED = "identity_unresolved"`
+(`scripts/lib/dispatch_identity.py:40`), en die rol valt via `resolve_worker_profile` terug op
+het code-worker-fallbackprofiel. In de spec-administratie leest zo'n onopgeloste dispatch als
+"backend-developer", terwijl de inhoud system-architect-werk is.
+
+De tweede vorm is kwaliteit-werk (`tests/**`, `scripts/check_*`, `.github/**`) dat bij
+backend-developer of een andere rol terechtkomt, en omgekeerd backend-werk
+(`scripts/lib/vnx_mode.py`, `scripts/lib/vnx_paths.py`, `scripts/pr_queue_manager.py`) dat bij
+quality-engineer terechtkomt.
+
+Deze bucket wordt niet opgelost door scope te verruimen. De verruiming die hier is gedaan
+(backend's eigen runtime-paden) verandert het aantal verkeerd-gerouteerde dispatches niet
+inhoudelijk; het getal stijgt alleen door de herclassificatie van voorheen-onbeslisbare
+dispatches.
+
+---
+
+## Onbeslisbaar: blijft onbeslisbaar
+
+25 dispatches (was 45) blijven onbeslisbaar. De zwaarste is `D-retire-featureplan-prqueue`
+met 12 buiten-paden die eigen werk, andermans werk en paden zonder ownership-regel mengen
+(`FEATURE_PLAN.md`, `PR_QUEUE.md`, `CLAUDE.md` hebben bewust geen eigenaar). Die kunnen per
+constructie niet uit spec + changed files worden beslist, en horen ook niet in een scope-regel.
+
+---
+
+## Conclusie: OI-1209 — de scope-reparatie wordt pas actief na role-propagatie
+
+De aangepaste scopes zijn correct en getest, maar ze worden pas actief zodra de rol daadwerkelijk
+bij de enforcement-hook aankomt. Dat is vandaag niet het geval op de provider-lane.
+
+De enforcement-hook leest de rol uit `VNX_WORKER_ROLE`
+(`scripts/hooks/pretooluse_worker_scope_enforce.py:177`). Die variabele wordt alleen gezet in
+`scripts/lib/tmux_interactive_dispatch.py:1439`, de claude/tmux-lane. De provider-lane
+(`provider_dispatch.py`, dominant sinds de kimi-flip) zet hem NIET. Met
+`VNX_ENFORCE_WORKER_PERMISSIONS` aan krijgt elke provider-lane-worker daardoor het restrictieve
+code-worker-fallbackprofiel, ongeacht zijn echte rol.
+
+De consequentie is dubbel:
+
+1. Vandaag (enforcement uit) heeft deze scope-reparatie geen runtime-effect. De meting hier is
+   een voorspelling van wat er gebeurt zodra de rol goed doorkomt.
+2. Enforcement aanzetten vóór de role-propagatie is gerepareerd, blokkeert de hele
+   provider-lane. Dat is punt 13 van het OPSCHALING-cluster en een T0-beslissing; deze dispatch
+   zet de flag NIET aan.
+
+Het voorbeeld uit de dispatch-opdracht bevestigt de richting: een system-architect die
+`docs/core/**` schrijft is zijn eigen werk (scope te smal), geen verkeerde routing. Dat geval
+is de reden dat `docs/core/**` in `OWNERSHIP_RULES` aan system-architect hangt en dat de
+backend-scope NIET met een `docs/*.md`-glob is verruimd.
+
+---
+
+## Commando's en ruwe output
+
+Beide metingen draaien beide scripts. Het verschil zit in de YAML die de resolver leest.
+De resolver (`_resolve_permissions_yaml`) geeft voorrang aan `$VNX_PROJECT_ROOT`/`$PROJECT_ROOT`
+boven de sibling-YAML. In deze shell wijzen die env-vars naar de MAIN-repo, dus:
+
+- nulmeting = default env (leest main's ongewijzigde YAML);
+- hermeting = `env -u PROJECT_ROOT -u VNX_PROJECT_ROOT -u VNX_HOME` (leest de worktree-YAML).
+
+```
+# nulmeting
+python3 scripts/analysis/worker_scope_enforcement_measure.py
+python3 scripts/analysis/role_scope_outside_triage.py
+
+# hermeting
+env -u PROJECT_ROOT -u VNX_PROJECT_ROOT -u VNX_HOME \
+  python3 scripts/analysis/worker_scope_enforcement_measure.py
+env -u PROJECT_ROOT -u VNX_PROJECT_ROOT -u VNX_HOME \
+  python3 scripts/analysis/role_scope_outside_triage.py
+```
+
+### role_scope_outside_triage.py — summary (nulmeting)
+
+```json
+{
+  "role_scope_only__outside": 144,
+  "unlinked": 372,
+  "linked_no_files": 0,
+  "in_scope": 211,
+  "rol_te_smal": 57,
+  "verkeerd_gerouteerd": 42,
+  "onbeslisbaar": 45,
+  "sum_check_ok": true
+}
+```
+
+### role_scope_outside_triage.py — summary (hermeting)
+
+```json
+{
+  "role_scope_only__outside": 86,
+  "unlinked": 372,
+  "linked_no_files": 0,
+  "in_scope": 269,
+  "rol_te_smal": 0,
+  "verkeerd_gerouteerd": 61,
+  "onbeslisbaar": 25,
+  "sum_check_ok": true
+}
+```
+
+### worker_scope_enforcement_measure.py — kernvelden
+
+| veld | nulmeting | hermeting |
+|---|---:|---:|
+| dispatch_specs_total | 727 | 727 |
+| linked_to_commit | 355 | 355 |
+| would_be_blocked_by_flip | 155 | 112 |
+| blocked_no_dispatch_paths__role_scope_only | 110 | 73 |
+| blocked_with_paths__also_outside_role_scope | 34 | 13 |
+| role_scope_only__outside | 144 | 86 |
+| role_scope_only__inside | 211 | 269 |

--- a/tests/test_role_scope_outside_triage.py
+++ b/tests/test_role_scope_outside_triage.py
@@ -134,12 +134,15 @@ def _specs():
 
 def _did2files():
     return {
-        # vnx_cli / bin are outside backend-developer's scope and are its own work.
-        "D1-too-narrow": {"vnx_cli/main.py", "bin/vnx"},
+        # Makefile is backend-developer's own work (root build file, per the
+        # ownership map) but still outside its scope — vnx_cli/** and bin/**
+        # moved inside in dispatch 20260815-opsch-w2-rolescope-fix, so a
+        # root build file is the remaining "own work outside scope" fixture.
+        "D1-too-narrow": {"Makefile"},
         # docs/core belongs to system-architect — single other role.
         "D2-misrouted": {"docs/core/SUBSYSTEMS.md"},
-        # own work + another role's work — undecidable.
-        "D3-mixed": {"vnx_cli/main.py", "docs/core/SUBSYSTEMS.md"},
+        # own work (Makefile) + another role's work (docs/core) — undecidable.
+        "D3-mixed": {"Makefile", "docs/core/SUBSYSTEMS.md"},
         # no ownership rule — undecidable.
         "D4-unknown": {"CLAUDE.md"},
         # scripts/** is inside backend-developer's scope — not outside.

--- a/tests/test_worker_permissions_role_scope.py
+++ b/tests/test_worker_permissions_role_scope.py
@@ -1,0 +1,162 @@
+"""Role-scope parity tests for the 20260815-opsch-w2-rolescope-fix scope changes.
+
+Pins the file_write_scope additions made in dispatch 20260815-opsch-w2-rolescope-fix
+(track ``role-scope-parity``, points 11+12 of the OPSCHALING cluster). The additions
+close the ``rol-te-smal`` gap measured by scripts/analysis/role_scope_outside_triage.py:
+dispatches that did their OWN role's work on a path their scope did not cover.
+
+These tests measure the BEHAVIOR of the scope resolver (resolve_worker_profile +
+match_file_write_scope), never the YAML text. Each changed role has:
+
+  * one case that fell OUTSIDE the scope before the change and now falls INSIDE;
+  * one case that STILL falls outside (proof the scope was not blanket-opened).
+
+security-engineer additionally pins that it did not gain a broad scripts/lib/**
+(or docs/**) surface — the scope change is two narrow permission-doc file grants.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+REPO_PERMISSIONS_YAML = REPO_ROOT / ".vnx" / "worker_permissions.yaml"
+
+sys.path.insert(0, str(REPO_ROOT / "scripts" / "lib"))
+
+from worker_permissions import (
+    match_file_write_scope,
+    resolve_worker_profile,
+)
+
+
+def _profile(role: str):
+    """Resolve *role* from the worktree-local YAML (bypasses env steering so the
+    test reads exactly the file this PR edits, regardless of PROJECT_ROOT)."""
+    profile = resolve_worker_profile(role, REPO_PERMISSIONS_YAML)
+    assert not profile.is_fallback, f"{role} resolved to the code-worker fallback"
+    return profile
+
+
+# ---------------------------------------------------------------------------
+# backend-developer — its own runtime work is now in scope
+# ---------------------------------------------------------------------------
+
+class TestBackendDeveloperRoleScope:
+    def test_runtime_paths_now_in_scope(self):
+        """vnx_cli / bin / hooks / configs are backend-developer's own runtime
+        implementation — previously outside, now inside."""
+        p = _profile("backend-developer")
+        for path in (
+            "vnx_cli/main.py",
+            "vnx_cli/commands/doctor.py",
+            "bin/vnx",
+            "hooks/monitor_tripwire.sh",
+            "configs/plan_gate_panel.yaml",
+        ):
+            assert match_file_write_scope(path, p, None) is True, path
+
+    def test_own_docs_and_root_build_files_now_in_scope(self):
+        p = _profile("backend-developer")
+        for path in (
+            "docs/applications/README.md",
+            "docs/operations/OTEL_EXPORT.md",
+            "docs/MIGRATION_GUIDE.md",
+            "VERSION",
+            "CHANGELOG.md",
+            "pyproject.toml",
+            "uv.lock",
+            "requirements.txt",
+        ):
+            assert match_file_write_scope(path, p, None) is True, path
+
+    def test_system_architect_territory_still_out_of_scope(self):
+        """docs/core, docs/governance/decisions and docs/manifesto stay
+        system-architect's — backend must NOT blanket-open docs (fnmatch `*`
+        spans `/`, so this pins the fix against a naive docs/*.md glob)."""
+        p = _profile("backend-developer")
+        for path in (
+            "docs/core/DISPATCH_RULES.md",
+            "docs/core/technical/x.md",
+            "docs/governance/decisions/ADR-001.md",
+            "docs/manifesto/HEADLESS_TRANSITION.md",
+            "schemas/quality_intelligence.sql",
+            "templates/FEATURE_PLAN_TEMPLATE.md",
+            ".vnx/worker_permissions.yaml",
+        ):
+            assert match_file_write_scope(path, p, None) is False, path
+
+
+# ---------------------------------------------------------------------------
+# quality-engineer — test-harness / CI / review-gate infra is now in scope
+# ---------------------------------------------------------------------------
+
+class TestQualityEngineerRoleScope:
+    def test_gate_and_benchmark_infra_now_in_scope(self):
+        """Review-gate, benchmark and refactor tooling is quality-engineer's own
+        work — previously outside (scope was tests/**, scripts/check_*), now inside."""
+        p = _profile("quality-engineer")
+        for path in (
+            "scripts/benchmark/field-tests/runners/run_field_tests.py",
+            "scripts/refactor_equivalence.py",
+            "scripts/lib/gate_executor.py",
+            "scripts/commands/gate.sh",
+            "scripts/review_gate_manager.py",
+        ):
+            assert match_file_write_scope(path, p, None) is True, path
+
+    def test_backend_script_surface_still_out_of_scope(self):
+        """quality-engineer did NOT gain broad scripts/lib — a backend runtime
+        module stays outside its scope."""
+        p = _profile("quality-engineer")
+        for path in (
+            "scripts/lib/worker_permissions.py",
+            "scripts/lib/dispatch_govern.py",
+            "vnx_cli/main.py",
+            "dashboard/index.html",
+            "docs/x.md",
+        ):
+            assert match_file_write_scope(path, p, None) is False, path
+
+
+# ---------------------------------------------------------------------------
+# security-engineer — permission docs now in scope, nothing else broadened
+# ---------------------------------------------------------------------------
+
+class TestSecurityEngineerRoleScope:
+    def test_permission_docs_now_in_scope(self):
+        """The permission-posture and key-provisioning docs are security-engineer's
+        own work — previously outside, now inside."""
+        p = _profile("security-engineer")
+        assert match_file_write_scope("docs/operations/WORKER_PERMISSIONS.md", p, None) is True
+        assert match_file_write_scope("docs/governance/KEY_PROVISIONING.md", p, None) is True
+
+    def test_other_ops_docs_still_out_of_scope(self):
+        """A narrow file grant, not docs/operations/** — a neighbouring backend ops
+        doc stays outside security's scope."""
+        p = _profile("security-engineer")
+        assert match_file_write_scope("docs/operations/CONTEXT_ROTATION.md", p, None) is False
+        assert match_file_write_scope("docs/operations/RECEIPT_PIPELINE.md", p, None) is False
+
+    def test_scope_additions_are_narrow_doc_grants_not_broad_surface(self):
+        """security-engineer must NOT have suddenly gained a broad scripts/lib/**
+        (or docs/**) surface. The change is exactly the two permission-doc file
+        grants on top of the pre-existing scripts/** + tests/** remediation
+        surface — pinned both as a list delta and behaviourally."""
+        p = _profile("security-engineer")
+        new = [s for s in p.file_write_scope if s not in ("scripts/**", "tests/**")]
+        assert new == [
+            "docs/operations/WORKER_PERMISSIONS.md",
+            "docs/governance/KEY_PROVISIONING.md",
+        ]
+        assert "scripts/lib/**" not in p.file_write_scope
+        assert "docs/**" not in p.file_write_scope
+        # Behavioural: backend/system-architect territory stays closed.
+        for path in (
+            "vnx_cli/main.py",
+            "docs/core/DISPATCH_RULES.md",
+            "docs/operations/CONTEXT_ROTATION.md",
+        ):
+            assert match_file_write_scope(path, p, None) is False, path


### PR DESCRIPTION
## Samenvatting

Track `role-scope-parity` (punten 11+12 OPSCHALING-cluster + restschuld punt 10): de `rol-te-smal`-bucket van de role-scope-triage wordt gesloten door de eigen-werk-paden van drie rollen aan hun `file_write_scope` toe te voegen.

**Hermeting: `role_scope_only__outside` 144 -> 86, `rol-te-smal` 57 -> 0.**

## Changes

- `.vnx/worker_permissions.yaml` — scope-verruiming voor backend-developer, quality-engineer en security-engineer. Elke regel noemt het pad en het aantal buiten-pad-voorkomens dat hij oplost. Geen blanket: `docs/MIGRATION_GUIDE.md` is een letterlijk pad, geen `docs/*.md`-glob (fnmatch `*` matcht `/`, zou system-architect-terrein vangen). system-architect en research-analyst hadden 0 `rol-te-smal`, dus ongewijzigd.
- `tests/test_worker_permissions_role_scope.py` (nieuw) — per gewijzigde rol: één pad dat voorheen buiten en nu binnen viel, plus één pad dat nog steeds buiten valt (bewijs: geen blanket). security-engineer krijgt expliciet geen `scripts/lib/**`/`docs/**`.
- `tests/test_role_scope_outside_triage.py` — fixtures gecorrigeerd (`vnx_cli/**`/`bin/**` vielen na de verruiming binnen scope; vervangen door `Makefile`, nog steeds buiten).
- `claudedocs/role-scope-outside-triage.md` (nieuw) — het ontbrekende rapport uit #1516: nulmeting + hermeting, per-role verdeling, vijf zwaarste cases per bucket, beide commando's en ruwe output, het routing-patroon en de OI-1209-conclusie.

## Wat bewust NIET is gefixt

- `verkeerd-gerouteerd` (42 -> 61) is een routing-fout, geen scope-fout. Patroon: backend-developer als sentinel-default voor onopgeloste rollen (`_FAKE_DEFAULT_ROLE`, `scripts/lib/dispatch_identity.py:40`). De stijging 42 -> 61 is herclassificatie van voorheen-onbeslisbare dispatches, geen nieuw fout-routen.
- `onbeslisbaar` (45 -> 25) blijft onbeslisbaar: mengvormen en paden zonder ownership-regel kunnen niet uit spec + changed files worden beslist.

## OI-1209 (conclusie)

De enforcement-hook leest de rol uit `VNX_WORKER_ROLE` (`scripts/hooks/pretooluse_worker_scope_enforce.py:177`), alleen gezet in `scripts/lib/tmux_interactive_dispatch.py:1439`. De provider-lane zet hem niet. De aangepaste scopes worden dus pas actief nadat role-propagatie op de provider-lane is gerepareerd. `VNX_ENFORCE_WORKER_PERMISSIONS` is in deze dispatch NIET aangezet (punt 13, T0-beslissing).

## Verification

- `python3 -m pytest tests/test_worker_permissions_role_scope.py tests/test_role_scope_outside_triage.py tests/test_worker_permissions.py tests/test_worker_permissions_merge.py tests/test_worker_scoped_default.py tests/test_worker_permission_enforcement_flag.py tests/test_pretooluse_worker_scope_enforce.py -q` -> 186 passed.
- Hermeting (beide scripts, worktree-YAML via `env -u PROJECT_ROOT -u VNX_PROJECT_ROOT -u VNX_HOME`): `role_scope_only__outside` 86, `rol-te-smal` 0, `sum_check_ok` true.

Dispatch-ID: 20260815-opsch-w2-rolescope-fix