### PR TITLE
fix(pre-merge-gate): --pr gates the resolved PR head, not the working copy (OI-1141)

### DIFF
--- a/scripts/pre_merge_gate.py
+++ b/scripts/pre_merge_gate.py
@@ -14,9 +14,10 @@ Exit codes:
   40 - Unexpected internal error
 
 Usage:
-  python pre_merge_gate.py --pr PR-6
-  python pre_merge_gate.py --pr PR-6 --json
-  python pre_merge_gate.py --pr PR-6 --output-file gate_result.json
+  python pre_merge_gate.py --pr 1522
+  python pre_merge_gate.py --pr 1522 --json
+  python pre_merge_gate.py --pr 1522 --output-file gate_result.json
+  python pre_merge_gate.py                # gate the local working copy (HEAD)
 """
 
 from __future__ import annotations
@@ -29,7 +30,7 @@ import os
 import subprocess
 import sys
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, NamedTuple, Optional
 
 _LOG = logging.getLogger(__name__)
 
@@ -80,6 +81,106 @@ SKIPPED_UNVERIFIED = "SKIPPED_UNVERIFIED"
 
 def _utc_now_iso() -> str:
     return dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat().replace("+00:00", "Z")
+
+
+# ---------------------------------------------------------------------------
+# PR reference resolution
+# ---------------------------------------------------------------------------
+
+class PRRefResolutionError(Exception):
+    """Raised when ``--pr`` cannot be resolved to a real PR head.
+
+    The gate must stop with a non-zero exit in every one of these cases —
+    missing ``gh``, a non-zero ``gh pr view`` exit, unparseable output, a
+    missing ``headRefOid``, or no resolvable merge-base. Silently falling
+    back to HEAD would reproduce the exact OI-1141 bug this guards against.
+    """
+
+
+class ResolvedPRRef(NamedTuple):
+    """A ``--pr`` reference resolved against GitHub, ready for diff checks."""
+
+    pr_ref: str
+    head_ref: str       # headRefOid — the commit the PR head points at
+    head_ref_name: str  # headRefName — the PR's source branch
+    merge_base: str     # git merge-base origin/main <head_ref>
+
+
+def resolve_pr_ref(pr_ref: str, project_root: Path) -> ResolvedPRRef:
+    """Resolve ``--pr <pr_ref>`` to the PR's real head and its merge-base.
+
+    The head comes from GitHub (``gh pr view <pr_ref> --json
+    headRefName,headRefOid``), never from the local checkout — the local
+    branch for this PR may lag behind or not exist at all. The comparison
+    target is ``git merge-base origin/main <head>`` (then ``origin/master``
+    as fallback), never the tip of ``origin/main``: a tip-vs-tip diff makes a
+    PR that simply hasn't rebased look like a revert (OI-1141).
+
+    Raises :class:`PRRefResolutionError` on every failure mode. Callers must
+    let it propagate — catching it and falling back to HEAD is the bug.
+    """
+    try:
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_ref, "--json", "headRefName,headRefOid"],
+            cwd=str(project_root),
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+    except FileNotFoundError:
+        raise PRRefResolutionError(
+            f"gh CLI not available — cannot resolve --pr {pr_ref} to its head"
+        )
+    except subprocess.TimeoutExpired:
+        raise PRRefResolutionError(
+            f"gh pr view {pr_ref} timed out — cannot resolve the PR head"
+        )
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        reason = stderr[:200] if stderr else f"exit code {result.returncode}"
+        raise PRRefResolutionError(
+            f"gh pr view {pr_ref} failed: {reason}"
+        )
+
+    try:
+        payload = json.loads(result.stdout)
+    except json.JSONDecodeError:
+        raise PRRefResolutionError(
+            f"gh pr view {pr_ref} returned unparseable output — cannot resolve the PR head"
+        )
+
+    head_ref = (payload.get("headRefOid") or "").strip()
+    head_ref_name = (payload.get("headRefName") or "").strip()
+    if not head_ref:
+        raise PRRefResolutionError(
+            f"gh pr view {pr_ref} returned no headRefOid — cannot resolve the PR head"
+        )
+
+    for base_ref in ("origin/main", "origin/master"):
+        try:
+            mb = subprocess.run(
+                ["git", "merge-base", base_ref, head_ref],
+                cwd=str(project_root),
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.TimeoutExpired, FileNotFoundError):
+            continue
+        if mb.returncode == 0 and mb.stdout.strip():
+            return ResolvedPRRef(
+                pr_ref=pr_ref,
+                head_ref=head_ref,
+                head_ref_name=head_ref_name,
+                merge_base=mb.stdout.strip(),
+            )
+
+    raise PRRefResolutionError(
+        f"could not resolve a merge-base for {head_ref[:12]}: neither "
+        "origin/main nor origin/master is available locally — fetch the "
+        f"base branch before gating --pr {pr_ref}"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -496,6 +597,8 @@ def check_pr_size(
             "lines_added": None,
             "lines_removed": None,
             "lines_changed": None,
+            "head_ref": head_ref,
+            "merge_base": None,
         }
 
     totals = _diff_numstat_totals(project_root, merge_base, head_ref)
@@ -507,6 +610,8 @@ def check_pr_size(
             "lines_added": None,
             "lines_removed": None,
             "lines_changed": None,
+            "head_ref": head_ref,
+            "merge_base": merge_base,
         }
 
     total_added, total_removed = totals
@@ -529,6 +634,8 @@ def check_pr_size(
         "lines_added": total_added,
         "lines_removed": total_removed,
         "lines_changed": total,
+        "head_ref": head_ref,
+        "merge_base": merge_base,
     }
 
 
@@ -666,7 +773,7 @@ def check_shell_syntax(project_root: Path) -> Dict[str, Any]:
     }
 
 
-def check_net_deletion(project_root: Path) -> Dict[str, Any]:
+def check_net_deletion(project_root: Path, head_ref: str = "HEAD") -> Dict[str, Any]:
     """Check for mass file deletion and large net line deletion in the PR diff.
 
     Two independent sub-checks run in parallel:
@@ -679,9 +786,13 @@ def check_net_deletion(project_root: Path) -> Dict[str, Any]:
     and is SKIPPED_UNVERIFIED — a merge gate that can't see the diff must
     not assume it's small (OI-1140). The two sub-checks are independent, so
     one failing does not skip evaluation of the other.
+
+    ``head_ref`` defaults to HEAD (gate the working copy); pass the resolved
+    PR head OID when gating a remote PR so the diff measures the PR, not the
+    local checkout (OI-1141).
     """
-    deleted = _get_deleted_files(project_root)
-    net_line = _get_net_line_deletion(project_root)
+    deleted = _get_deleted_files(project_root, head_ref)
+    net_line = _get_net_line_deletion(project_root, head_ref)
 
     # Determine file-deletion verdict
     if deleted is None:
@@ -1006,12 +1117,17 @@ def _is_artifact_path(path: str) -> bool:
     return lower.endswith(".pdf") or lower.endswith(".xlsx") or lower.endswith(".xls")
 
 
-def _get_deleted_files(project_root: Path) -> Optional[List[str]]:
-    """Return list of files deleted in current PR branch vs base. None on failure."""
+def _get_deleted_files(project_root: Path, head_ref: str = "HEAD") -> Optional[List[str]]:
+    """Return list of files deleted in current PR branch vs base. None on failure.
+
+    ``head_ref`` defaults to HEAD (gate the working copy); pass the resolved
+    PR head OID when gating a remote PR so the diff measures the PR, not the
+    local checkout (OI-1141).
+    """
     for base_ref in ("origin/main", "origin/master"):
         try:
             result = subprocess.run(
-                ["git", "diff", "--diff-filter=D", "--name-only", f"{base_ref}...HEAD"],
+                ["git", "diff", "--diff-filter=D", "--name-only", f"{base_ref}...{head_ref}"],
                 cwd=str(project_root),
                 capture_output=True,
                 text=True,
@@ -1024,7 +1140,7 @@ def _get_deleted_files(project_root: Path) -> Optional[List[str]]:
 
     try:
         result = subprocess.run(
-            ["git", "diff", "--diff-filter=D", "--name-only", "HEAD~1", "HEAD"],
+            ["git", "diff", "--diff-filter=D", "--name-only", f"{head_ref}~1", head_ref],
             cwd=str(project_root),
             capture_output=True,
             text=True,
@@ -1056,15 +1172,16 @@ def _parse_numstat_net(numstat_output: str) -> int:
     return total_removed - total_added
 
 
-def _get_net_line_deletion(project_root: Path) -> Optional[int]:
+def _get_net_line_deletion(project_root: Path, head_ref: str = "HEAD") -> Optional[int]:
     """Return net lines deleted (removed - added) for current PR vs origin/main.
 
-    Returns None on git failure.
+    ``head_ref`` defaults to HEAD (gate the working copy); pass the resolved
+    PR head OID when gating a remote PR (OI-1141). Returns None on git failure.
     """
     for base_ref in ("origin/main", "origin/master"):
         try:
             result = subprocess.run(
-                ["git", "diff", "--numstat", f"{base_ref}...HEAD"],
+                ["git", "diff", "--numstat", f"{base_ref}...{head_ref}"],
                 cwd=str(project_root),
                 capture_output=True,
                 text=True,
@@ -1077,7 +1194,7 @@ def _get_net_line_deletion(project_root: Path) -> Optional[int]:
 
     try:
         result = subprocess.run(
-            ["git", "diff", "--numstat", "HEAD~1", "HEAD"],
+            ["git", "diff", "--numstat", f"{head_ref}~1", head_ref],
             cwd=str(project_root),
             capture_output=True,
             text=True,
@@ -1141,10 +1258,18 @@ def run_gate_checks(
     dispatch_dir: Path,
     skip_pytest: bool = False,
     ci_workflow_name: Optional[str] = None,
+    pr_head: Optional["ResolvedPRRef"] = None,
 ) -> Dict[str, Any]:
     """Run all gate checks and produce a merged verdict.
 
     Returns a structured result with per-check status and overall verdict.
+
+    ``pr_head`` is the resolved PR reference (see :func:`resolve_pr_ref`).
+    When it is set, the diff-based checks (``pr_size``, ``net_deletion``)
+    measure ``merge_base(origin/main, pr_head.head_ref)..pr_head.head_ref`` —
+    the PR as it exists on GitHub — instead of the local HEAD. When it is
+    None, the gate measures the local working copy (HEAD), the unchanged
+    default (OI-1141).
 
     A check that returns SKIPPED_UNVERIFIED (couldn't establish an answer —
     see check_ci_workflow, check_pytest) blocks the verdict exactly like
@@ -1153,6 +1278,8 @@ def run_gate_checks(
     kept distinguishable in the result via ``skipped_unverified_count`` and
     per-check ``status``, even though both drive the same HOLD verdict.
     """
+    head_ref = pr_head.head_ref if pr_head is not None else "HEAD"
+
     checks: List[Dict[str, Any]] = []
 
     checks.append(check_open_items(pr_id, state_dir))
@@ -1160,10 +1287,10 @@ def run_gate_checks(
     checks.append(check_git_cleanliness(project_root))
     checks.append(check_contract_verification(pr_id, dispatch_dir, project_root, state_dir))
     checks.append(check_quality_advisory(project_root))
-    checks.append(check_pr_size(project_root))
+    checks.append(check_pr_size(project_root, head_ref=head_ref))
     checks.append(check_artifacts(pr_id, dispatch_dir, project_root))
     checks.append(check_shell_syntax(project_root))
-    checks.append(check_net_deletion(project_root))
+    checks.append(check_net_deletion(project_root, head_ref=head_ref))
     checks.append(check_ci_workflow(project_root, workflow_name=ci_workflow_name))
 
     if not skip_pytest:
@@ -1178,6 +1305,17 @@ def run_gate_checks(
 
     return {
         "pr_id": pr_id,
+        "pr_ref": (
+            {
+                "resolved": True,
+                "pr_ref": pr_head.pr_ref,
+                "head_ref": pr_head.head_ref,
+                "head_ref_name": pr_head.head_ref_name,
+                "merge_base": pr_head.merge_base,
+            }
+            if pr_head is not None
+            else {"resolved": False, "head_ref": "HEAD"}
+        ),
         "verdict": verdict,
         "checked_at": _utc_now_iso(),
         "total_checks": len(checks),
@@ -1218,6 +1356,16 @@ def format_human_readable(result: Dict[str, Any]) -> str:
     verdict_icon = "✅" if verdict == "GO" else "🚫"
     lines.append(f"\n{verdict_icon}  Gate verdict for {pr_id}: {verdict}")
     lines.append(f"   Checked at: {result.get('checked_at', '?')}")
+
+    pr_ref = result.get("pr_ref")
+    if pr_ref and pr_ref.get("resolved"):
+        lines.append(
+            f"   PR ref: head={pr_ref['head_ref'][:12]} "
+            f"branch={pr_ref['head_ref_name']} "
+            f"merge-base={pr_ref['merge_base'][:12]}"
+        )
+    elif pr_ref:
+        lines.append("   PR ref: HEAD (local working copy)")
     lines.append(
         f"   Checks: {result.get('go_count', 0)} GO, {result.get('hold_count', 0)} HOLD"
         f" ({result.get('skipped_unverified_count', 0)} unverified)\n"
@@ -1247,8 +1395,14 @@ def main() -> int:
     )
     parser.add_argument(
         "--pr",
-        required=True,
-        help="PR identifier (e.g. PR-6)",
+        required=False,
+        default=None,
+        help=(
+            "PR number (or branch/URL) to gate. Resolves the PR head via "
+            "`gh pr view --json headRefName,headRefOid` and measures the "
+            "merge-base..head range — never the local working copy. Omit to "
+            "gate the local working copy (HEAD)."
+        ),
     )
     parser.add_argument(
         "--project-root",
@@ -1298,13 +1452,22 @@ def main() -> int:
     state_dir = Path(paths["VNX_STATE_DIR"])
     dispatch_dir = Path(paths["VNX_DISPATCH_DIR"])
 
+    pr_head = None
+    if args.pr is not None:
+        try:
+            pr_head = resolve_pr_ref(args.pr, project_root)
+        except PRRefResolutionError as exc:
+            print(f"pre_merge_gate: {exc}", file=sys.stderr)
+            return 10  # invalid arguments / missing data (--pr not resolvable)
+
     result = run_gate_checks(
-        pr_id=args.pr,
+        pr_id=args.pr if args.pr is not None else "HEAD",
         project_root=project_root,
         state_dir=state_dir,
         dispatch_dir=dispatch_dir,
         skip_pytest=args.skip_pytest,
         ci_workflow_name=args.ci_workflow_name,
+        pr_head=pr_head,
     )
 
     if args.store:

--- a/tests/test_pre_merge_gate.py
+++ b/tests/test_pre_merge_gate.py
@@ -611,8 +611,8 @@ class TestCheckNetDeletion:
         """The two sub-checks are independent (per the check's own docstring):
         file-deletion resolving fine must not mask a net-line-deletion
         sub-check that failed to compute -> SKIPPED_UNVERIFIED, not GO."""
-        monkeypatch.setattr(pre_merge_gate, "_get_deleted_files", lambda project_root: [])
-        monkeypatch.setattr(pre_merge_gate, "_get_net_line_deletion", lambda project_root: None)
+        monkeypatch.setattr(pre_merge_gate, "_get_deleted_files", lambda project_root, head_ref: [])
+        monkeypatch.setattr(pre_merge_gate, "_get_net_line_deletion", lambda project_root, head_ref: None)
         result = check_net_deletion(tmp_path)
         assert result["status"] == SKIPPED_UNVERIFIED
         assert result["status"] != "GO"
@@ -623,8 +623,8 @@ class TestCheckNetDeletion:
         """HOLD from one sub-check must still win even if the other sub-check
         is unverifiable -- unverified must not water down a real HOLD."""
         many_deleted = [f"file_{i}.py" for i in range(DELETION_FILE_HOLD)]
-        monkeypatch.setattr(pre_merge_gate, "_get_deleted_files", lambda project_root: many_deleted)
-        monkeypatch.setattr(pre_merge_gate, "_get_net_line_deletion", lambda project_root: None)
+        monkeypatch.setattr(pre_merge_gate, "_get_deleted_files", lambda project_root, head_ref: many_deleted)
+        monkeypatch.setattr(pre_merge_gate, "_get_net_line_deletion", lambda project_root, head_ref: None)
         result = check_net_deletion(tmp_path)
         assert result["status"] == "HOLD"
 

--- a/tests/test_pre_merge_gate_pr_ref.py
+++ b/tests/test_pre_merge_gate_pr_ref.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Tests for ``--pr`` reference resolution in pre_merge_gate (OI-1141).
+
+Pins that ``--pr <nummer>`` makes the gate measure the PR as it exists on
+GitHub — resolved via ``gh pr view --json headRefName,headRefOid`` and
+diffed against ``merge-base(origin/main, head)`` — instead of silently
+measuring the local working copy (HEAD). And that an unresolvable PR number
+fails loudly, never falling back to HEAD.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import pre_merge_gate
+from pre_merge_gate import (
+    PRRefResolutionError,
+    ResolvedPRRef,
+    check_pr_size,
+    resolve_pr_ref,
+    run_gate_checks,
+)
+
+
+def _subprocess_result(stdout: str, returncode: int = 0, stderr: str = "") -> MagicMock:
+    return MagicMock(returncode=returncode, stdout=stdout, stderr=stderr)
+
+
+@pytest.fixture
+def state_dir(tmp_path):
+    sd = tmp_path / "state"
+    sd.mkdir()
+    return sd
+
+
+@pytest.fixture
+def dispatch_dir(tmp_path):
+    dd = tmp_path / "dispatches"
+    for sub in ("pending", "active", "completed", "staging"):
+        (dd / sub).mkdir(parents=True)
+    return dd
+
+
+# ---------------------------------------------------------------------------
+# resolve_pr_ref — the head comes from gh, never from HEAD
+# ---------------------------------------------------------------------------
+
+class TestResolvePRRef:
+
+    def test_resolves_head_oid_not_head(self, tmp_path):
+        gh_ok = _subprocess_result(
+            json.dumps({"headRefName": "feature/oi-1141", "headRefOid": "abc123"})
+        )
+        mb_ok = _subprocess_result("def456\n")
+        with patch("pre_merge_gate.subprocess.run", side_effect=[gh_ok, mb_ok]) as mock_run:
+            resolved = resolve_pr_ref("1522", tmp_path)
+
+        assert isinstance(resolved, ResolvedPRRef)
+        assert resolved.head_ref == "abc123"
+        assert resolved.head_ref != "HEAD"
+        assert resolved.head_ref_name == "feature/oi-1141"
+        assert resolved.merge_base == "def456"
+
+        # gh was really invoked with the PR number, not with a local ref.
+        gh_argv = mock_run.call_args_list[0].args[0]
+        assert gh_argv[0] == "gh"
+        assert gh_argv[1:3] == ["pr", "view"]
+        assert "1522" in gh_argv
+        assert "--json" in gh_argv
+        assert "headRefName,headRefOid" in gh_argv
+
+    def test_merge_base_falls_back_to_origin_master(self, tmp_path):
+        gh_ok = _subprocess_result(
+            json.dumps({"headRefName": "b", "headRefOid": "abc123"})
+        )
+        main_fail = _subprocess_result("", returncode=1, stderr="unknown revision")
+        master_ok = _subprocess_result("def456\n")
+        with patch(
+            "pre_merge_gate.subprocess.run",
+            side_effect=[gh_ok, main_fail, master_ok],
+        ):
+            resolved = resolve_pr_ref("9", tmp_path)
+        assert resolved.merge_base == "def456"
+
+
+# ---------------------------------------------------------------------------
+# The comparison uses merge-base, never the tip of origin/main
+# ---------------------------------------------------------------------------
+
+class TestPRSizeUsesMergeBase:
+
+    def test_diff_uses_merge_base_not_base_tip(self, tmp_path):
+        mb_ok = _subprocess_result("mb123\n")
+        numstat_ok = _subprocess_result("10\t5\tfile.py\n")
+        with patch(
+            "pre_merge_gate.subprocess.run",
+            side_effect=[mb_ok, numstat_ok],
+        ) as mock_run:
+            result = check_pr_size(tmp_path, head_ref="abc123")
+
+        assert result["status"] == "GO"
+        assert result["head_ref"] == "abc123"
+        assert result["merge_base"] == "mb123"
+
+        # The numstat diff is measured merge-base..head, not origin/main..head.
+        diff_argv = mock_run.call_args_list[1].args[0]
+        assert diff_argv[0] == "git"
+        assert diff_argv[1] == "diff"
+        assert "mb123" in diff_argv
+        assert "abc123" in diff_argv
+        assert "origin/main" not in diff_argv
+
+
+# ---------------------------------------------------------------------------
+# Fail loud — never fall back to HEAD
+# ---------------------------------------------------------------------------
+
+class TestFailsLoud:
+
+    def test_unknown_pr_number_raises_and_never_falls_back(self, tmp_path):
+        gh_fail = _subprocess_result(
+            "",
+            returncode=1,
+            stderr="Could not resolve to a Pull Request with the number of 99999.",
+        )
+        with patch(
+            "pre_merge_gate.subprocess.run", side_effect=[gh_fail]
+        ) as mock_run:
+            with pytest.raises(PRRefResolutionError) as exc:
+                resolve_pr_ref("99999", tmp_path)
+        assert "99999" in str(exc.value)
+        # Only the gh call happened — no git fallback to HEAD was attempted.
+        assert mock_run.call_count == 1
+
+    def test_gh_missing_raises(self, tmp_path):
+        with patch(
+            "pre_merge_gate.subprocess.run",
+            side_effect=FileNotFoundError("gh not found"),
+        ):
+            with pytest.raises(PRRefResolutionError) as exc:
+                resolve_pr_ref("1", tmp_path)
+        assert "gh CLI not available" in str(exc.value)
+
+    def test_unparseable_gh_output_raises(self, tmp_path):
+        gh_bad = _subprocess_result("not json")
+        with patch("pre_merge_gate.subprocess.run", side_effect=[gh_bad]):
+            with pytest.raises(PRRefResolutionError) as exc:
+                resolve_pr_ref("1", tmp_path)
+        assert "unparseable" in str(exc.value)
+
+    def test_missing_head_ref_oid_raises(self, tmp_path):
+        gh_empty = _subprocess_result(
+            json.dumps({"headRefName": "b", "headRefOid": ""})
+        )
+        with patch("pre_merge_gate.subprocess.run", side_effect=[gh_empty]):
+            with pytest.raises(PRRefResolutionError) as exc:
+                resolve_pr_ref("1", tmp_path)
+        assert "no headRefOid" in str(exc.value)
+
+    def test_no_merge_base_raises(self, tmp_path):
+        gh_ok = _subprocess_result(
+            json.dumps({"headRefName": "b", "headRefOid": "abc123"})
+        )
+        main_fail = _subprocess_result("", returncode=1, stderr="unknown revision")
+        master_fail = _subprocess_result("", returncode=1, stderr="unknown revision")
+        with patch(
+            "pre_merge_gate.subprocess.run",
+            side_effect=[gh_ok, main_fail, master_fail],
+        ):
+            with pytest.raises(PRRefResolutionError) as exc:
+                resolve_pr_ref("1", tmp_path)
+        assert "merge-base" in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# run_gate_checks threads the resolved head; HEAD stays the default
+# ---------------------------------------------------------------------------
+
+class TestRunGateChecksPRHead:
+
+    def _spy_pr_size(self, monkeypatch, captured):
+        def _spy(project_root, **kw):
+            captured.update(kw)
+            return {
+                "check": "pr_size", "status": "GO", "detail": "spy",
+                "lines_added": 0, "lines_removed": 0, "lines_changed": 0,
+            }
+
+        monkeypatch.setattr(pre_merge_gate, "check_pr_size", _spy)
+
+    def _stub_heavy(self, monkeypatch):
+        monkeypatch.setattr(
+            pre_merge_gate, "check_ci_workflow",
+            lambda project_root, **kw: {
+                "check": "ci_workflow", "status": "GO", "detail": "stub",
+                "ci_conclusion": "success", "ci_ran_on_sha": True,
+            },
+        )
+        monkeypatch.setattr(
+            pre_merge_gate, "check_net_deletion",
+            lambda project_root, **kw: {
+                "check": "net_deletion", "status": "GO", "detail": "stub",
+                "deleted_count": 0, "deleted_files": [], "net_line_deletion": 0,
+                "net_line_deletion_warn": False, "file_deletion_warn": False,
+            },
+        )
+
+    def test_without_pr_head_measures_head(self, state_dir, dispatch_dir, tmp_path, monkeypatch):
+        captured = {}
+        self._spy_pr_size(monkeypatch, captured)
+        self._stub_heavy(monkeypatch)
+
+        result = run_gate_checks(
+            pr_id="PR-6", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True,
+        )
+        assert captured.get("head_ref") == "HEAD"
+        assert result["pr_ref"] == {"resolved": False, "head_ref": "HEAD"}
+
+    def test_with_pr_head_measures_pr(self, state_dir, dispatch_dir, tmp_path, monkeypatch):
+        captured = {}
+        self._spy_pr_size(monkeypatch, captured)
+        self._stub_heavy(monkeypatch)
+        pr_head = ResolvedPRRef(
+            pr_ref="1522", head_ref="abc123", head_ref_name="feature/o", merge_base="def456",
+        )
+
+        result = run_gate_checks(
+            pr_id="1522", project_root=tmp_path, state_dir=state_dir,
+            dispatch_dir=dispatch_dir, skip_pytest=True, pr_head=pr_head,
+        )
+        assert captured.get("head_ref") == "abc123"
+        assert result["pr_ref"]["resolved"] is True
+        assert result["pr_ref"]["head_ref"] == "abc123"
+        assert result["pr_ref"]["head_ref_name"] == "feature/o"
+        assert result["pr_ref"]["merge_base"] == "def456"
+
+
+# ---------------------------------------------------------------------------
+# main() wiring: --pr resolves, unresolvable --pr exits non-zero
+# ---------------------------------------------------------------------------
+
+class TestMainPRResolution:
+
+    def _fake_env(self, tmp_path):
+        return {
+            "PROJECT_ROOT": str(tmp_path),
+            "VNX_STATE_DIR": str(tmp_path / "state"),
+            "VNX_DISPATCH_DIR": str(tmp_path / "dispatches"),
+        }
+
+    def _fake_result(self, pr_id, pr_ref):
+        return {
+            "pr_id": pr_id,
+            "pr_ref": pr_ref,
+            "verdict": "GO",
+            "checked_at": "x",
+            "total_checks": 0,
+            "go_count": 0,
+            "hold_count": 0,
+            "skipped_unverified_count": 0,
+            "checks": [],
+            "hold_reasons": [],
+        }
+
+    def test_main_unknown_pr_exits_nonzero(self, tmp_path, monkeypatch, capsys):
+        monkeypatch.setattr(pre_merge_gate, "ensure_env", lambda: self._fake_env(tmp_path))
+        monkeypatch.setattr(
+            pre_merge_gate, "resolve_pr_ref",
+            MagicMock(side_effect=PRRefResolutionError("gh pr view 99999 failed: not found")),
+        )
+        with patch("sys.argv", ["pre_merge_gate.py", "--pr", "99999"]):
+            rc = pre_merge_gate.main()
+        assert rc == 10
+        assert "99999" in capsys.readouterr().err
+
+    def test_main_with_pr_resolves_and_passes_head(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pre_merge_gate, "ensure_env", lambda: self._fake_env(tmp_path))
+        resolved = ResolvedPRRef("1522", "abc123", "feature/o", "def456")
+        monkeypatch.setattr(pre_merge_gate, "resolve_pr_ref", MagicMock(return_value=resolved))
+        captured = {}
+
+        def _fake_run(**kw):
+            captured.update(kw)
+            return self._fake_result(kw["pr_id"], {
+                "resolved": True, "pr_ref": "1522",
+                "head_ref": "abc123", "head_ref_name": "feature/o", "merge_base": "def456",
+            })
+
+        monkeypatch.setattr(pre_merge_gate, "run_gate_checks", _fake_run)
+        with patch("sys.argv", ["pre_merge_gate.py", "--pr", "1522", "--no-store"]):
+            rc = pre_merge_gate.main()
+        assert rc == 0
+        assert captured["pr_id"] == "1522"
+        assert captured["pr_head"] is resolved
+
+    def test_main_without_pr_measures_head(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(pre_merge_gate, "ensure_env", lambda: self._fake_env(tmp_path))
+        captured = {}
+
+        def _fake_run(**kw):
+            captured.update(kw)
+            return self._fake_result(kw["pr_id"], {"resolved": False, "head_ref": "HEAD"})
+
+        monkeypatch.setattr(pre_merge_gate, "run_gate_checks", _fake_run)
+        with patch("sys.argv", ["pre_merge_gate.py", "--no-store"]):
+            rc = pre_merge_gate.main()
+        assert rc == 0
+        assert captured["pr_id"] == "HEAD"
+        assert captured["pr_head"] is None


### PR DESCRIPTION
## What

`pre_merge_gate.py --pr <nummer>` measured the local working copy instead of the PR. The `head_ref: str = "HEAD"` default meant `--pr` only changed the gate's *label* while it kept diffing `HEAD` — a gate that reports "checking PR N" and actually reads your local HEAD is worse than no gate.

## What changes

- `--pr <nummer>` now resolves the PR to its real head via `gh pr view --json headRefName,headRefOid`, and measures `merge-base(origin/main, head)..head` — never the local checkout, never the tip of `origin/main` (a tip-vs-tip diff makes a PR that hasn't rebased look like a revert).
- `check_pr_size` and `check_net_deletion` thread the resolved head through their git diffs.
- Unresolvable PR numbers fail loudly (exit 10): missing `gh`, non-zero `gh pr view`, unparseable output, missing `headRefOid`, or no resolvable merge-base. No silent fallback to HEAD.
- Omitting `--pr` keeps the working-copy (HEAD) default unchanged.

## Evidence (OI-1141)

- `--pr 1522`: gate reports `head=89dad1fa81dd branch=dispatch/20260815-opsch-w2-role-propagation merge-base=081c4588baac`, matching `gh pr view 1522` (`headRefOid=89dad1fa…`, `headRefName=dispatch/20260815-opsch-w2-role-propagation`) and `git merge-base origin/main 89dad1fa` (`081c4588…`). `pr_size` reports 243 lines (242 added / 1 removed over the merge-base range); the wrong tip-vs-tip diff would report 1213.
- `--pr 999999`: exit 10 — `gh pr view 999999 failed: … Could not resolve to a PullRequest with the number of 999999`.
- No `--pr`: `PR ref: HEAD (local working copy)`.

## Tests

New `tests/test_pre_merge_gate_pr_ref.py` (resolution, merge-base comparison, fail-loud, HEAD default, main wiring). 109 tests pass across `test_pre_merge_gate_pr_ref.py` + `test_pre_merge_gate.py` + `test_pre_merge_gate_net_deletion.py`; 10 pass in `test_vnx_cli_gate_check.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)