### PR TITLE
fix(oi): close three silent failures (OI-1207, OI-1168, OI-1182)

### DIFF
--- a/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
+++ b/docs/governance/decisions/ADR-003-oauth-only-claude-routing.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-09
 **Decided by:** Operator (Vincent van Deth)
-**Resolves:** Codification of M6 (CLI-OAuth Claude routing) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+**Resolves:** Codification of M6 (CLI-OAuth Claude routing) from `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4
 
 ## Context
 
@@ -11,7 +11,7 @@ VNX drives Claude through `claude -p --output-format stream-json` invoked as a s
 
 Three industry signals in Q2 2026 push toward adopting the Anthropic Python SDK or the new Claude Agent SDK at the transport layer:
 
-1. The **Claude Agent SDK** (`claude-agent-sdk` Python package) now ships typed `HookEventMessage` events, `atexit`-based orphan cleanup, and a control-protocol message bus that re-implements much of `subprocess_adapter.py` natively (~600 LOC of VNX duplication per `claudedocs/2026-05-09-vnx-industry-research.md` Topic 2).
+1. The **Claude Agent SDK** (`claude-agent-sdk` Python package) now ships typed `HookEventMessage` events, `atexit`-based orphan cleanup, and a control-protocol message bus that re-implements much of `subprocess_adapter.py` natively (~600 LOC of VNX duplication per `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` Topic 2).
 2. **Anthropic Managed Agents** (launched 2026-04-08) is the hosted execution path that the SDK is the natural client for.
 3. Strategic-replan synthesis (Topic 2) initially proposed migrating the transport layer to the SDK as a "REPLACE" verdict.
 
@@ -70,7 +70,7 @@ VNX's value proposition depends on a Claude credential model the operator alread
 
 ## Amendment (2026-05-15): API-key + CLI explicitly permitted
 
-After the June 15 2026 Anthropic Agent SDK credit changes, the operator commissioned strategic research (`claudedocs/agent-sdk-vs-claude-p-cli-strategic-comparison-2026-05-15.md`) comparing Agent SDK direct-API usage against `claude -p` subprocess on the same API key. The verdict: stay with `claude -p` subprocess for the governed worker dispatch path; Agent SDK can be a follow-up provider option for non-governed use cases.
+After the June 15 2026 Anthropic Agent SDK credit changes, the operator commissioned strategic research (`claudedocs/archive/agent-sdk-vs-claude-p-cli-strategic-comparison-2026-05-15.md`) comparing Agent SDK direct-API usage against `claude -p` subprocess on the same API key. The verdict: stay with `claude -p` subprocess for the governed worker dispatch path; Agent SDK can be a follow-up provider option for non-governed use cases.
 
 This amendment makes the routing matrix explicit:
 
@@ -92,6 +92,6 @@ The Wave 4.6 finalization PR may introduce Agent SDK as an opt-in fifth provider
 - `CLAUDE.md` (project root) — "Subprocess Adapter Feature Flag" section
 - `scripts/lib/subprocess_adapter.py` — canonical Claude transport
 - `scripts/lib/subprocess_dispatch.py` — canonical dispatch entry point
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M6) — strategic-moat justification
-- `claudedocs/2026-05-09-vnx-industry-research.md` Topic 2 — the rejected SDK-adoption recommendation
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M6) — strategic-moat justification
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` Topic 2 — the rejected SDK-adoption recommendation
 - Memory: `feedback_avoid_claude_sdk_use_cli_oauth.md` — operator licensing-constraint feedback

--- a/docs/governance/decisions/ADR-004-vnx-as-managed-agents-alternative.md
+++ b/docs/governance/decisions/ADR-004-vnx-as-managed-agents-alternative.md
@@ -9,7 +9,7 @@
 
 On 2026-04-08 Anthropic launched **Claude Managed Agents** — a serverless agent runtime where each agent runs in a gVisor-isolated container on Anthropic infrastructure, with default-deny network egress, scoped filesystem (`/workspace` writable, `/source` read-only), built-in OAuth for user-delegated actions, and pricing at $0.08/session-hour plus standard token costs. Notion, Rakuten, and Sentry are in production on it ([Anthropic Managed Agents InfoQ](https://www.infoq.com/news/2026/04/anthropic-managed-agents/)). Three feature updates shipped by 2026-05-07.
 
-Industry-research synthesis in `claudedocs/2026-05-09-vnx-industry-research.md` (Topic 12) initially recommended "ADOPT alongside — Managed Agents is the right substrate for *production* agent execution; VNX's local-first 4-terminal model remains correct for *development* and *governance experimentation*." The closing 250-word summary went further: "VNX should pivot to a **thin governance layer over Claude Agent SDK + MCP + Managed Agents** — keep the audit/gate/review IP, drop the subprocess plumbing."
+Industry-research synthesis in `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` (Topic 12) initially recommended "ADOPT alongside — Managed Agents is the right substrate for *production* agent execution; VNX's local-first 4-terminal model remains correct for *development* and *governance experimentation*." The closing 250-word summary went further: "VNX should pivot to a **thin governance layer over Claude Agent SDK + MCP + Managed Agents** — keep the audit/gate/review IP, drop the subprocess plumbing."
 
 The operator has rejected this pivot framing explicitly. VNX's strategic purpose is to be a **self-hosted alternative** to Managed Agents — same coordination + governance + audit goals, but on operator hardware, with Claude Code OAuth login (no per-session billing), no vendor lock-in, and full visibility into the runtime. "Just use Managed Agents" defeats the purpose of building VNX. Per the operator's memory (`project_vnx_is_alternative_not_layer.md`), Managed Agents is "the commoditization VNX is competing with, not a target to converge onto."
 
@@ -48,7 +48,7 @@ The combined effect: VNX's strategic moat is not "we built it ourselves" — it 
 
 ### Accepted
 
-- The Wave 5 differentiation features in `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §7.3 are the active development priority once Waves 0-4 close: (1) 3-Layer Trigger System + HTTP/webhook receiver, (2) optional Docker/Podman sandbox isolation, (3) `vnx init` PyPI quickstart. Each closes a parity gap with Managed Agents while preserving VNX's structural advantages.
+- The Wave 5 differentiation features in `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §7.3 are the active development priority once Waves 0-4 close: (1) 3-Layer Trigger System + HTTP/webhook receiver, (2) optional Docker/Podman sandbox isolation, (3) `vnx init` PyPI quickstart. Each closes a parity gap with Managed Agents while preserving VNX's structural advantages.
 - A differentiation table is maintained in the public-facing PRD-UH-002 v1.0 (per strategic-replan §10 D3 / D4) showing "what Managed Agents does well that VNX matches" vs "what Managed Agents structurally can't do that VNX uniquely offers."
 - The VNX public narrative shifts from "universal headless harness" (PRD-UH-001 v1.3) to "self-hosted alternative to Managed Agents with full glass-box governance" (PRD-UH-002 v1.0 framing, per strategic-replan §10 D4 default = clean break).
 - Industry research that surfaces Managed Agents (or any vendor-managed agent runtime — Cloudflare Workers AI agents, Vercel AI runtime, Replit Agent, etc.) as a "platform shift to adopt" is reframed as **competitive/commoditization signal** that informs *what VNX must beat or differentiate from*, not a migration target.
@@ -56,7 +56,7 @@ The combined effect: VNX's strategic moat is not "we built it ourselves" — it 
 
 ### Rejected
 
-- "Pivot to thin governance layer over Managed Agents" — the closing recommendation of `claudedocs/2026-05-09-vnx-industry-research.md` §250-word summary.
+- "Pivot to thin governance layer over Managed Agents" — the closing recommendation of `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` §250-word summary.
 - "Wrap Managed Agents with our gating" patterns — VNX governance does not sit downstream of a hosted Claude execution; it sits over the operator's own subprocess execution.
 - "Consume Managed Agents service" as a deployment target. VNX's deployment target is the operator's own hardware (or a future PyPI-installable footprint per Wave 5 candidate 3), not Anthropic's runtime.
 - Cloudflare Dynamic Workers, Daytona, E2B, Fly Machines, Vercel Sandbox, or other hosted Agent SDK substrates as the VNX runtime layer. These are valid for projects whose requirements differ; they are not valid for VNX given M6 + this ADR.
@@ -65,7 +65,7 @@ The combined effect: VNX's strategic moat is not "we built it ourselves" — it 
 ## Implementation note
 
 - `CLAUDE.md` (project root) is updated in Wave 0 to add a Q2 2026 platform-shift note pointing at this ADR and ADR-003.
-- The differentiation table in §7.1 / §7.2 of `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` is the canonical reference until PRD-UH-002 v1.0 supersedes it.
+- The differentiation table in §7.1 / §7.2 of `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` is the canonical reference until PRD-UH-002 v1.0 supersedes it.
 - Wave 5 candidate selection (operator decision D5 in the strategic replan) is the next concrete output of this positioning.
 
 ## See also
@@ -73,7 +73,7 @@ The combined effect: VNX's strategic moat is not "we built it ourselves" — it 
 - ADR-003 — OAuth-only Claude routing via `claude -p` subprocess
 - ADR-005 — Append-only NDJSON audit ledger as primary observability surface
 - ADR-006 — Staging→promote with mandatory human approval gate
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §1, §4, §7 — strategic positioning
-- `claudedocs/2026-05-09-vnx-industry-research.md` Topic 12, Topic 15, §250-word summary — the rejected pivot framing
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §1, §4, §7 — strategic positioning
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` Topic 12, Topic 15, §250-word summary — the rejected pivot framing
 - Memory: `project_vnx_is_alternative_not_layer.md` — operator strategic-intent feedback
 - Memory: `project_vnx_strategic_direction.md` — VNX evolution from governance-first to multi-manager system

--- a/docs/governance/decisions/ADR-005-ndjson-audit-ledger-primary.md
+++ b/docs/governance/decisions/ADR-005-ndjson-audit-ledger-primary.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-09
 **Decided by:** Operator (Vincent van Deth)
-**Resolves:** Codification of M1 (NDJSON audit ledger) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+**Resolves:** Codification of M1 (NDJSON audit ledger) from `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4
 
 ## Amendments
 
@@ -20,7 +20,7 @@ VNX records every dispatch lifecycle event, receipt, gate outcome, and lease/hea
 1. **Append-only NDJSON ledger files** — `.vnx-data/state/t0_receipts.ndjson`, `.vnx-data/dispatch_register.ndjson`, `.vnx-data/events/T{n}.ndjson` (per-terminal ring buffer with archive in `.vnx-data/events/archive/{terminal}/{dispatch_id}.ndjson`), `.vnx-data/state/review_gates/results/*.json` (one file per gate result).
 2. **SQLite tables** — `.vnx-data/state/runtime_coordination.db` (leases, heartbeats, incident log), `.vnx-data/quality_intelligence.db` (cross-project intelligence, dispatch tracker projections), `.vnx-data/dispatch_tracker.db` (per-dispatch state).
 
-Both surfaces have grown organically. Several recent PRs have proposed shifting writes to SQLite-first for query performance (e.g. "we have the DB now, why log NDJSON?") or dropping the ledger entirely. Industry-research synthesis (`claudedocs/2026-05-09-vnx-industry-research.md` Topic 14) noted that OpenTelemetry GenAI semantic conventions + CloudEvents are the emerging structured-event standard, which raised a separate question of replacing NDJSON with an OTel-shaped wire format.
+Both surfaces have grown organically. Several recent PRs have proposed shifting writes to SQLite-first for query performance (e.g. "we have the DB now, why log NDJSON?") or dropping the ledger entirely. Industry-research synthesis (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` Topic 14) noted that OpenTelemetry GenAI semantic conventions + CloudEvents are the emerging structured-event standard, which raised a separate question of replacing NDJSON with an OTel-shaped wire format.
 
 The operator has consistently reaffirmed the NDJSON ledger as canonical. The strategic-replan §4 lists M1 (NDJSON audit ledger) as a non-negotiable VNX moat: "Managed Agents has no audit ledger; SDK has no provenance stamping; nobody else stamps git ref + dirty flag + cost per dispatch." This ADR codifies that the ledger is the primary surface and SQLite is downstream.
 
@@ -89,7 +89,7 @@ A note on the ring-buffer pattern: `.vnx-data/events/T{n}.ndjson` is per-dispatc
 - ADR-004 — VNX as alternative to Managed Agents (glass-box observability is the moat)
 - ADR-006 — Staging→promote human gate (the gate's evidence trail is the ledger)
 - ADR-023 — Receipt hash-chain (the tamper-evidence implementation behind reason #2; see Amendments)
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M1) — strategic-moat justification
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M1) — strategic-moat justification
 - `CLAUDE.md` "Event Streams" section — ring-buffer + archive convention
 - Memory: `project_ndjson_ring_buffer.md` — per-terminal NDJSON is ring buffer, durable archive in `.vnx-data/events/archive/{terminal}/`
 - `.vnx-data/state/t0_receipts.ndjson`, `.vnx-data/dispatch_register.ndjson`, `.vnx-data/events/archive/` — canonical ledger surfaces

--- a/docs/governance/decisions/ADR-006-staging-promote-human-gate.md
+++ b/docs/governance/decisions/ADR-006-staging-promote-human-gate.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-09
 **Decided by:** Operator (Vincent van Deth)
-**Resolves:** Codification of M2 (staging→promote gate) from `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4
+**Resolves:** Codification of M2 (staging→promote gate) from `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4
 
 ## Context
 
@@ -16,7 +16,7 @@ There is no architectural path from "worker requests a follow-up task" or "T0 pl
 
 This pattern has been challenged from several directions in 2026:
 
-- Industry-research synthesis (`claudedocs/2026-05-09-vnx-industry-research.md` Topic 1, Topic 9) noted that Anthropic's experimental Agent Teams ships `TaskCreated` / `TaskCompleted` / `TeammateIdle` hooks — but **no architectural human-approval gate** between team-lead decision and teammate execution. Microsoft Agent Framework v1.0 has the primitive but is Azure-coupled.
+- Industry-research synthesis (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-industry-research.md` Topic 1, Topic 9) noted that Anthropic's experimental Agent Teams ships `TaskCreated` / `TaskCompleted` / `TeammateIdle` hooks — but **no architectural human-approval gate** between team-lead decision and teammate execution. Microsoft Agent Framework v1.0 has the primitive but is Azure-coupled.
 - Operator memories `feedback_dispatch_via_pending.md` and `feedback_no_manager_block_output.md` document recurring proposals to "auto-drain pending → active" or "skip the promote for low-risk dispatches." Each such proposal has been rejected and the memory updated.
 - Recent T0 orchestrator behavior in autonomous mode (per `feature kickoff checklist` and the F60 / overnight-feature workflow) has tightened toward longer autonomous chains, which raises a recurring question: should we relax the human gate when the operator is asleep?
 
@@ -39,7 +39,7 @@ Concrete rules:
 
 Five reinforcing reasons for the mandatory human gate:
 
-1. **The human gate is the moat.** Per `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2): "Agent Teams has `TaskCreated` hooks but no architectural approval gate; MAF v1.0 has the primitive but is Azure-coupled." No competing system — Managed Agents, Agent Teams, CrewAI, smolagents, OpenCode/CAO — ships a mandatory human gate on every dispatch. VNX's distinguishing structural feature is exactly this gate. Removing it would erase the principal differentiator versus Managed Agents (per ADR-004).
+1. **The human gate is the moat.** Per `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2): "Agent Teams has `TaskCreated` hooks but no architectural approval gate; MAF v1.0 has the primitive but is Azure-coupled." No competing system — Managed Agents, Agent Teams, CrewAI, smolagents, OpenCode/CAO — ships a mandatory human gate on every dispatch. VNX's distinguishing structural feature is exactly this gate. Removing it would erase the principal differentiator versus Managed Agents (per ADR-004).
 
 2. **The audit trail only means something with consent.** Per ADR-005, the NDJSON ledger records every dispatch's lifecycle. The semantic content of "this dispatch was approved" is encoded by the `pending/` → `active/` transition — without the human action, the ledger only records "the system wanted to do this." With the human action, it records "the operator authorized this." For a glass-box governance system per ADR-004, that distinction is the entire point of having an audit trail.
 
@@ -81,7 +81,7 @@ A note on the F28 gate-enforcement failure (memory `feedback_gate_enforcement_fa
 - ADR-003 — OAuth-only Claude routing (the gate sits between operator-consent and Claude execution)
 - ADR-004 — VNX as alternative to Managed Agents (the gate is the moat)
 - ADR-005 — Append-only NDJSON audit ledger (the ledger records consent points)
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2) — strategic-moat justification
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2) — strategic-moat justification
 - `CLAUDE.md` (project root) "Workflow" + "Rules" sections — codified gate references
 - `.claude/terminals/T0/CLAUDE.md` "Worker Dispatch Standards", "Permissions and Hard Guardrails" — gate enforcement at the orchestrator layer
 - Memory: `feedback_dispatch_via_pending.md` — pending/ vs staging/ vs tmux

--- a/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
+++ b/docs/governance/decisions/ADR-007-multitenant-project-id-stamping.md
@@ -9,9 +9,9 @@
 
 VNX began as a single-tenant orchestration system: one operator, one project (`vnx-roadmap-autopilot`), one local SQLite stack under `.vnx-data/state/`. By Q1 2026 the operator was running **four** distinct VNX deployments (`vnx-dev`, `mc`, `sales-copilot`, `seocrawler-v2`) totaling ~17.6 GB of `.vnx-data/`, each with its own per-project `quality_intelligence.db` and `runtime_coordination.db`. Patterns learned in `mission-control` could not inform a dispatch in `sales-copilot`. Cross-project learning was structurally impossible.
 
-`claudedocs/2026-04-30-single-vnx-migration-plan.md` proposed Model B: separate repos, central VNX install, **central data dir namespaced by `project_id`**. Phase 0 (PR #410) added `project_id` columns to seven hot tables; Phase 4 (PR #432) imported all four projects' data into the central DBs and stamped every row with its source `project_id`.
+`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-04-30-single-vnx-migration-plan.md` proposed Model B: separate repos, central VNX install, **central data dir namespaced by `project_id`**. Phase 0 (PR #410) added `project_id` columns to seven hot tables; Phase 4 (PR #432) imported all four projects' data into the central DBs and stamped every row with its source `project_id`.
 
-The migration ran for **nine codex review rounds**. Each round surfaced new instances of the same root pattern: tables, indexes, or constraints that assumed single-tenancy. The lessons doc at `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` Section 1.3 documents how `INSERT OR IGNORE` against a single-column UNIQUE constraint silently dropped re-stamped rows because the existing `DEFAULT 'vnx-dev'` rows already occupied the PK slot. Section 4.2 codifies the fix: composite uniqueness as the default.
+The migration ran for **nine codex review rounds**. Each round surfaced new instances of the same root pattern: tables, indexes, or constraints that assumed single-tenancy. The lessons doc at `claudedocs/archive/2026-05-09-p4-migration-architecture-lessons.md` Section 1.3 documents how `INSERT OR IGNORE` against a single-column UNIQUE constraint silently dropped re-stamped rows because the existing `DEFAULT 'vnx-dev'` rows already occupied the PK slot. Section 4.2 codifies the fix: composite uniqueness as the default.
 
 This ADR captures the resulting pattern as a binding architectural rule for all future central-DB tables.
 
@@ -25,13 +25,13 @@ The pattern has three concrete rules:
 
 2. **Constraint rule.** Where a table previously had `UNIQUE(natural_key)`, the central form is `UNIQUE(natural_key, project_id)` (or the inverse — order does not matter for SQLite UNIQUE semantics, but the convention places `project_id` last). Single-column UNIQUE constraints on tenant-scoped natural keys are a smell that requires per-table justification recorded in the migration file.
 
-3. **Identifier-rewrite rule.** Where two source projects can mint the same identifier (e.g., `dispatches.id=1`, `terminal_leases.id=1`), the importer prefix-rewrites with `<project_id>:<source_id>` for shared identifier columns. This is the same rule applied successfully to `pattern_usage.pattern_id` (which fixed the pre-existing single-project synthetic-id explosion as a bonus side effect, per `claudedocs/2026-04-30-single-vnx-migration-plan.md` §5.2).
+3. **Identifier-rewrite rule.** Where two source projects can mint the same identifier (e.g., `dispatches.id=1`, `terminal_leases.id=1`), the importer prefix-rewrites with `<project_id>:<source_id>` for shared identifier columns. This is the same rule applied successfully to `pattern_usage.pattern_id` (which fixed the pre-existing single-project synthetic-id explosion as a bonus side effect, per `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-04-30-single-vnx-migration-plan.md` §5.2).
 
 The structural test in `tests/test_migrate_dry_run.py` parses migration `0015_complete_project_id.sql` at CI time and asserts every multi-tenant table conforms. New migrations that introduce tenant-scoped tables MUST extend this test.
 
 ## Reasoning
 
-1. **The whole value proposition rests on this.** The single-VNX move (`claudedocs/2026-04-30-single-vnx-migration-plan.md` §1.2 "Why B over A") chose Model B specifically because column-namespacing gives strong-via-column isolation while keeping reversible per-project rollback paths. Without `project_id` stamping there is no Model B — there is only Model A (monorepo) or Model C (read-only federation). The operator rejected both. `project_id` is therefore not a tactical column, it is the identity layer of the entire central system.
+1. **The whole value proposition rests on this.** The single-VNX move (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-04-30-single-vnx-migration-plan.md` §1.2 "Why B over A") chose Model B specifically because column-namespacing gives strong-via-column isolation while keeping reversible per-project rollback paths. Without `project_id` stamping there is no Model B — there is only Model A (monorepo) or Model C (read-only federation). The operator rejected both. `project_id` is therefore not a tactical column, it is the identity layer of the entire central system.
 
 2. **It also fixes a latent single-project bug.** The `pattern_usage.pattern_id` synthetic-id explosion (codex finding §2.12, referenced in migration plan §5.2) was a single-project bug masked by single-project assumptions. Composite-key namespacing fixes it as a free side effect — every centralized table inherits stable per-project identity.
 
@@ -43,7 +43,7 @@ The structural test in `tests/test_migrate_dry_run.py` parses migration `0015_co
 
 6. **The composite UNIQUE pattern is itself a contract with the importer.** `INSERT OR IGNORE` is safe only when the UNIQUE constraint already encodes the intended dedup semantics (lessons doc T2). Without `project_id` in the UNIQUE, IGNORE collapses cross-tenant rows. With it, IGNORE preserves per-tenant uniqueness while still allowing replay-safe imports. The constraint and the conflict policy are not independent design decisions — they are paired.
 
-7. **MCP / cross-project learning depends on it.** The strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4) calls out: "MCP has no canonical multi-tenant pattern for SQLite. RLS is Postgres-only. We are state of the art." Wave 4 of that plan exposes central DBs as MCP servers; the MCP server must filter on `project_id` from the session header. If the column does not exist or is not authoritative, MCP cannot safely federate across the operator's projects.
+7. **MCP / cross-project learning depends on it.** The strategic replan (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4) calls out: "MCP has no canonical multi-tenant pattern for SQLite. RLS is Postgres-only. We are state of the art." Wave 4 of that plan exposes central DBs as MCP servers; the MCP server must filter on `project_id` from the session header. If the column does not exist or is not authoritative, MCP cannot safely federate across the operator's projects.
 
 ## Consequences
 
@@ -68,7 +68,7 @@ The structural test in `tests/test_migrate_dry_run.py` parses migration `0015_co
 The `dispatches` table (`runtime_coordination.db`) is now brought into this ADR's
 composite-key pattern, and the supporting version-reconciliation machinery is
 implemented. This is the database-engineer-led future-state batch (PRD
-`claudedocs/PRD-future-state-reconciliation-v1.1.md`), distinct from the still-
+`claudedocs/_archive/2026-06/prd-future-state-reconciliation-v1.1.md`), distinct from the still-
 planned broader SPC/intelligence-table batch (#864).
 
 - **PR-A1 (#859) — in-place `dispatches` rebuild.** `scripts/migrate_future_system.py`
@@ -172,11 +172,11 @@ See `skills/intelligence-engineer/references/quality-intelligence-schema.md` for
 ## Cross-references
 
 - ADR-009 — Schema-first migrations via PRAGMA introspection (the implementation discipline that keeps this ADR enforceable across future migrations)
-- `claudedocs/2026-04-30-single-vnx-migration-plan.md` §3 (identity layer), §4 (schema migration), §5.2 (ID collisions)
-- `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` §1.3, §2 (bug taxonomy T1/T3/T6), §4.2 (composite uniqueness as default)
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4 (multi-tenant project_id stamping)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-04-30-single-vnx-migration-plan.md` §3 (identity layer), §4 (schema migration), §5.2 (ID collisions)
+- `claudedocs/archive/2026-05-09-p4-migration-architecture-lessons.md` §1.3, §2 (bug taxonomy T1/T3/T6), §4.2 (composite uniqueness as default)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M4 (multi-tenant project_id stamping)
 - PR #410 (Phase 0 column add), PR #412/#416 (verifier), PR #431/#432 (P4 data import), open items OI-1375 + OI-1376
 - `schemas/migrations/0010_add_project_id.sql`, `schemas/migrations/0015_complete_project_id.sql`, `schemas/migrations/0016_rebuild_fts5.sql`
 - `scripts/migrate_to_central_vnx.py`, `scripts/verify_central_vnx.py`, `tests/test_migrate_dry_run.py`
-- 1.0.1 future-state batch: `scripts/migrate_future_system.py` (PR-A1 #859), `scripts/lib/schema_manifest.py` (PR-A2 #861), `scripts/build_t0_state.py` (PR-B #863), `scripts/import_open_items_to_tracks.py` + `scripts/lib/tracks.py` (PR-C #862), `scripts/roadmap_manager.py` (PR-D #871), and the PRD `claudedocs/PRD-future-state-reconciliation-v1.1.md`
+- 1.0.1 future-state batch: `scripts/migrate_future_system.py` (PR-A1 #859), `scripts/lib/schema_manifest.py` (PR-A2 #861), `scripts/build_t0_state.py` (PR-B #863), `scripts/import_open_items_to_tracks.py` + `scripts/lib/tracks.py` (PR-C #862), `scripts/roadmap_manager.py` (PR-D #871), and the PRD `claudedocs/_archive/2026-06/prd-future-state-reconciliation-v1.1.md`
 - Operator runbook: `docs/MIGRATION_GUIDE.md` §6 (runtime migration, human-gated)

--- a/docs/governance/decisions/ADR-008-dual-llm-adversarial-review.md
+++ b/docs/governance/decisions/ADR-008-dual-llm-adversarial-review.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-VNX dispatches code through one or more worker terminals (T1/T2/T3) and accumulates each PR through a series of gates before merge. Anthropic shipped native Code Review on 2026-03-09, and the strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §1) names the question explicitly: "do we still need a custom review pipeline now that the platform vendor ships one?"
+VNX dispatches code through one or more worker terminals (T1/T2/T3) and accumulates each PR through a series of gates before merge. Anthropic shipped native Code Review on 2026-03-09, and the strategic replan (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §1) names the question explicitly: "do we still need a custom review pipeline now that the platform vendor ships one?"
 
 The answer is yes — but the reasoning is structural, not feature-driven. Anthropic Code Review reviews **Claude work using Claude.** The reviewer and the author share the same model family, the same training cutoff, and the same blind spots. Empirically through the spring 2026 PR chains:
 
@@ -87,7 +87,7 @@ Concretely:
 - Operator memory `feedback_gate_enforcement_failure_f28` (prior incident)
 - Operator memory `feedback_codex_findings_must_be_parsed`, `feedback_codex_5_2_structured_findings` (codex_gate parsing details)
 - Operator memory `feedback_review_gate_full_lifecycle` (request→execute→report→record→verify)
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M3, §5 (no replacement by Anthropic Code Review)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M3, §5 (no replacement by Anthropic Code Review)
 - T0 `.claude/terminals/T0/CLAUDE.md` §"Headless Review Enforcement", §"Operator Policies" A1/B1-B4
 - `scripts/review_gate_manager.py`, `scripts/closure_verifier.py`, `scripts/lib/codex_parser.py`
 - `.vnx-data/state/review_gates/{requests,results}/`, `$VNX_DATA_DIR/unified_reports/headless/`

--- a/docs/governance/decisions/ADR-009-schema-first-migrations.md
+++ b/docs/governance/decisions/ADR-009-schema-first-migrations.md
@@ -7,7 +7,7 @@
 
 ## Context
 
-The P4 data migration (PR #432, `scripts/migrate_to_central_vnx.py` ~1757 LOC) consolidated four per-project SQLite stores into the central VNX state DBs. It took **nine codex review rounds** and three `--apply` attempts to converge. The full reflection lives in `claudedocs/2026-05-09-p4-migration-architecture-lessons.md`.
+The P4 data migration (PR #432, `scripts/migrate_to_central_vnx.py` ~1757 LOC) consolidated four per-project SQLite stores into the central VNX state DBs. It took **nine codex review rounds** and three `--apply` attempts to converge. The full reflection lives in `claudedocs/archive/2026-05-09-p4-migration-architecture-lessons.md`.
 
 A pattern emerged across rounds 7, 8, and 9: each round surfaced a different instance of the **same bug class** — a hardcoded column list, table tuple, or index projection that should have been derived from schema introspection.
 
@@ -83,7 +83,7 @@ Concretely:
 ## Cross-references
 
 - ADR-007 — Multi-tenant `project_id` stamping pattern (the constraint pattern that depends on schema-first migrations to stay maintainable)
-- `claudedocs/2026-05-09-p4-migration-architecture-lessons.md` §1.2, §1.3, §2 (T1+T3+T6 bug patterns), §4.1 (schema-first beats imperative-first), §4.2 (composite uniqueness as default), §7 (action items)
+- `claudedocs/archive/2026-05-09-p4-migration-architecture-lessons.md` §1.2, §1.3, §2 (T1+T3+T6 bug patterns), §4.1 (schema-first beats imperative-first), §4.2 (composite uniqueness as default), §7 (action items)
 - PR #432 (round-6 `_rebuild_one_table_dynamic` introduction; rounds 7/8/9 fix-forward)
 - Open items OI-1375 + OI-1376 (post-432 rewrite required for migration 0016)
 - `scripts/migrate_to_central_vnx.py` (canonical helpers `_rebuild_one_table_dynamic`, `_collect_columns`, `_collect_indexes`)

--- a/docs/governance/decisions/ADR-010-subprocess-adapter-claude-routing.md
+++ b/docs/governance/decisions/ADR-010-subprocess-adapter-claude-routing.md
@@ -20,7 +20,7 @@ The canonical implementation is `scripts/lib/subprocess_dispatch.py`. The first 
 - Lines 13-19: Success-path call order (receipt → pattern confidence → dispatch outcome) with per-dispatch event archival in a finally block.
 - Lines 41-99: Imports from `subprocess_adapter`, `headless_context_tracker`, `worker_health_monitor`, plus internals for delivery, recovery, manifest, pattern confidence, receipt writing, skill injection, state paths, and git helpers.
 
-The strategic replan (`claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6) calls this out as **the** licensing-critical decision: "Claude Agent SDK with OAuth Code credential = third-party-API risk (opencode/openclaw precedent). Non-negotiable. Lock this in `subprocess_adapter.py`; pin via `CLAUDE.md` rule 'No Anthropic SDK is used'; CI gate to block accidental SDK imports."
+The strategic replan (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6) calls this out as **the** licensing-critical decision: "Claude Agent SDK with OAuth Code credential = third-party-API risk (opencode/openclaw precedent). Non-negotiable. Lock this in `subprocess_adapter.py`; pin via `CLAUDE.md` rule 'No Anthropic SDK is used'; CI gate to block accidental SDK imports."
 
 This ADR codifies the implementation as binding architecture and the SDK-ban as a CI-enforced rule.
 
@@ -89,11 +89,11 @@ Concretely:
 
 - ADR-003 (architectural direction this ADR implements)
 - ADR-005 (NDJSON ledger — downstream consumer of subprocess events)
-- Strategic replan `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6 (OAuth-only Claude routing, never SDK), §5 A5 (LiteLLM scope)
+- Strategic replan `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 moat M6 (OAuth-only Claude routing, never SDK), §5 A5 (LiteLLM scope)
 - Operator memory `project_hybrid_interactive_headless` (tmux retained permanently)
 - Operator memory `project_ndjson_ring_buffer` (per-terminal NDJSON archival contract)
 - Operator memory `feedback_t3_input_mode_probe` (tmux-specific failure mode subprocess avoids)
-- `claudedocs/2026-04-30-single-vnx-migration-plan.md` §3.5 (identity propagation via subprocess env)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-04-30-single-vnx-migration-plan.md` §3.5 (identity propagation via subprocess env)
 - `scripts/lib/subprocess_dispatch.py` (canonical implementation), `scripts/lib/subprocess_adapter.py` (delivery primitive)
 - Project root `CLAUDE.md` "Subprocess Adapter Feature Flag" section
 - F32 (subprocess opt-in introduction), F36 (T0 migration), W7-A PR #411 (canonical event schema)

--- a/docs/governance/decisions/ADR-011-manager-worker-hierarchy.md
+++ b/docs/governance/decisions/ADR-011-manager-worker-hierarchy.md
@@ -1,6 +1,6 @@
 # ADR-011 — Manager+Worker Hierarchy with Explicit Depth>1 (vs Subagents Depth-1)
 
-**Status:** Accepted (primary architecture decision) — with a **Conditional / Pilot** sub-decision (2026-05-09 amendment) for tactical subagent use inside VNX workers, narrowed to read-only parallel-fanout via `VNX_T1_TACTICAL_SUBAGENTS=1` flag. The original Tentative section has been resolved by the Wave 0.5 subagent research dispatch (`claudedocs/2026-05-09-vnx-subagent-tactical-research.md`).
+**Status:** Accepted (primary architecture decision) — with a **Conditional / Pilot** sub-decision (2026-05-09 amendment) for tactical subagent use inside VNX workers, narrowed to read-only parallel-fanout via `VNX_T1_TACTICAL_SUBAGENTS=1` flag. The original Tentative section has been resolved by the Wave 0.5 subagent research dispatch (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-subagent-tactical-research.md`).
 **Date:** 2026-05-09
 **Decided by:** Operator (Vincent van Deth)
 **Cross-references:** ADR-003 (OAuth-only Claude routing, no SDK), ADR-010 (subprocess adapter), ADR-012 (hybrid interactive + headless)
@@ -9,7 +9,7 @@
 
 VNX runs as a multi-terminal orchestration system with one master orchestrator (T0) and N workers (T1, T2, T3, …). Workers are **separate Claude Code processes** with their own `CLAUDE.md`, their own tool budget, their own dispatch envelope, and their own receipt — they are not subagents in the Anthropic Task-tool sense. Workers can themselves dispatch follow-up work (e.g., T1 emitting a follow-up dispatch for T3 review, or a hypothetical sub-orchestrator pool spawning short-lived sub-workers). Hierarchy depth in VNX is therefore explicitly **greater than 1**.
 
-Claude Code natively offers a Task-tool subagent pattern. Per Perplexity verification on 2026-05-09 (`claudedocs/2026-05-09-vnx-platform-features-verification.md`, Claim 1):
+Claude Code natively offers a Task-tool subagent pattern. Per Perplexity verification on 2026-05-09 (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-platform-features-verification.md`, Claim 1):
 
 - v1.0.64 release note (2025-07-30: "Fixed unintended access to the recursive agent tool") establishes **depth-1 as the explicit, intentional architecture**.
 - Subagents return only a condensed summary (1,000–2,000 tokens) to the parent — no recursion path.
@@ -117,11 +117,11 @@ The Anthropic-documented Django parallel-search example (4 Explore subagents, 3m
 
 #### Citations
 
-- Subagent depth-1 + condensed-summary return: `code.claude.com/docs/en/sub-agents`; v1.0.64 release note (Jul 30 2025); `claudedocs/2026-05-09-vnx-platform-features-verification.md` Claim 1.
+- Subagent depth-1 + condensed-summary return: `code.claude.com/docs/en/sub-agents`; v1.0.64 release note (Jul 30 2025); `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-platform-features-verification.md` Claim 1.
 - `agent_id`/`agent_type` in hook payloads: v2.1.117 changelog (April 2026); `code.claude.com/docs/en/hooks`; `claudefa.st/blog/guide/changelog`.
 - Universal `updatedToolOutput` for all tools: v2.1.121 release notes (May 2026); `wotai.co/blog/claude-code-2-1-121`; `code.claude.com/docs/en/hooks`.
 - Parallel Explore subagents wall-clock benchmark: `code.claude.com/docs/en/sub-agents` (Django 4-fanout example, 3m40s vs 14min sequential, surfaced via `nimbalyst.com/blog/claude-code-subagents-guide` 2026 guide).
-- Companion research: `claudedocs/2026-05-09-vnx-subagent-tactical-research.md` (full Q1-Q4 analysis with sources).
+- Companion research: `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-subagent-tactical-research.md` (full Q1-Q4 analysis with sources).
 
 ## Reasoning
 
@@ -161,8 +161,8 @@ The Anthropic-documented Django parallel-search example (4 Explore subagents, 3m
 
 ## See also
 
-- `claudedocs/2026-05-09-vnx-platform-features-verification.md` — Claims 1 (subagent depth-1) and 3 (Multiagent Sessions flat coordinator)
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (moat M5) and §5 (no flatten-to-subagents adoption)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-platform-features-verification.md` — Claims 1 (subagent depth-1) and 3 (Multiagent Sessions flat coordinator)
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (moat M5) and §5 (no flatten-to-subagents adoption)
 - ADR-003 — OAuth-only Claude routing (no SDK)
 - ADR-010 — Subprocess adapter as the depth>1 spawn mechanism
 - ADR-012 — Hybrid interactive + headless execution (every depth>1 worker can run in either mode)

--- a/docs/governance/decisions/ADR-013-workers-as-configuration.md
+++ b/docs/governance/decisions/ADR-013-workers-as-configuration.md
@@ -3,7 +3,7 @@
 **Status:** Accepted — Implemented by Wave 6 (see ADR-018)
 **Date:** 2026-05-09
 **Decided by:** Operator (Vincent van Deth)
-**Resolves:** Wave 4.5 prerequisite + PRD-VNX-UH-002 §6 FR-12 + inventory finding "Workers are hardcoded T0..T3 across 25+ files" (`claudedocs/2026-05-09-vnx-replan-inventory.md`)
+**Resolves:** Wave 4.5 prerequisite + PRD-VNX-UH-002 §6 FR-12 + inventory finding "Workers are hardcoded T0..T3 across 25+ files" (`claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-replan-inventory.md`)
 **Cross-references:** ADR-010 (subprocess adapter), ADR-011 (manager+worker hierarchy), ADR-012 (hybrid interactive + headless)
 
 ## Context
@@ -78,7 +78,7 @@ Concrete contract:
 
 ## Implementation note
 
-- The migration is a Wave 4.5 task per `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §5. It is gated on Wave 4 completion (subprocess adapter feature parity) but does not block earlier waves.
+- The migration is a Wave 4.5 task per `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §5. It is gated on Wave 4 completion (subprocess adapter feature parity) but does not block earlier waves.
 - The migration order is: (1) ship `worker_registry.py` + `vnx_workers.default.yaml`, (2) switch `runtime_facade.CANONICAL_TERMINALS` to call the registry, (3) switch `decision_executor.TERMINAL_TO_TRACK` to a config-driven projection, (4) switch `vnx_doctor_checks.expected_terminals` to runtime computation, (5) migrate the long tail (intelligence, build_t0_state, pr_queue_manager, etc.) in subsequent PRs. Each step is independently mergeable.
 - The `aliases` field is the seam that lets the migration be incremental — files that have not yet been refactored continue to see the legacy IDs they expect.
 
@@ -91,9 +91,9 @@ Concrete contract:
 - ADR-016 — Unified event shape (workers emit CanonicalEvent regardless of provider)
 - ADR-018 — Elastic worker pool (Wave 6 implementation of this ADR; adds PoolManager, schema v13,
   provider-mix per pool, queue-aware scaling)
-- `claudedocs/PRD-VNX-UH-002-v1.0-DRAFT.md` §6 FR-12 — the functional requirement this ADR redeems
-- `claudedocs/2026-05-09-vnx-replan-inventory.md` — the inventory that surfaced the 77-file blast radius
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §5 (Wave 4.5) — the wave this ADR unlocks
+- `claudedocs/archive/PRD-VNX-UH-002-v1.0-DRAFT.md` §6 FR-12 — the functional requirement this ADR redeems
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-replan-inventory.md` — the inventory that surfaced the 77-file blast radius
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §5 (Wave 4.5) — the wave this ADR unlocks
 - `scripts/lib/runtime_facade.py:49,199` — the canonical authority being replaced
 - `scripts/lib/decision_executor.py:31-33` — the track-letter mapping being projected from config
 - `scripts/lib/vnx_doctor_checks.py:492` — the expected-terminals set being recomputed at runtime

--- a/docs/governance/decisions/ADR-014-autonomous-chain-dispatch.md
+++ b/docs/governance/decisions/ADR-014-autonomous-chain-dispatch.md
@@ -44,7 +44,7 @@ Chains are recorded in `.vnx-data/chains/` with three states (`approved/`, `runn
 3. **Without chain-dispatch, autonomous mode is either a slippery slope or impossible.** Two failure modes:
    - **Slippery slope.** "Just don't gate the autonomous loop" — leads to AI-to-AI handoff (a worker's follow-up dispatch auto-executes; T0's planned next step auto-executes). ADR-006 forbids this categorically. Without a formal chain primitive, every "autonomous mode" patch tends to slide here.
    - **Impossible.** "Promote every dispatch by hand even in autonomous mode" — kills the F46–F58 + 200-PR cadence the operator actually achieves. The operator runs four parallel deployments; per-step approval is not workable at that throughput.
-   Chain-dispatch is the only shape that preserves the M2 moat (mandatory human approval per `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4) while enabling the workflow operators need. It is the smallest viable resolution.
+   Chain-dispatch is the only shape that preserves the M2 moat (mandatory human approval per `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4) while enabling the workflow operators need. It is the smallest viable resolution.
 
 4. **The audit ledger's value depends on consent being explicit, not implicit.** Per ADR-005, NDJSON entries record every dispatch's lifecycle. Per ADR-006, the consent encoding is the `pending/` → `active/` transition. If autonomous mode silently skipped the gate, the ledger would record "the system did this" without the matching "the operator authorized this." Chain-dispatch keeps the consent encoding intact: the chain spec is the consent, the chain hash is its cryptographic anchor, every promote within the chain references the hash, and the operator's signature on the chain spec is auditable for years afterwards.
 
@@ -65,7 +65,7 @@ Chains are recorded in `.vnx-data/chains/` with three states (`approved/`, `runn
 - The chain spec is signed/hashed in NDJSON for replay-audit per ADR-005's append-only ledger contract. The spec itself is stored on disk under `.vnx-data/chains/`; the hash is the only thing in the ledger.
 - T0 may dispatch within the chain without operator action, **but only when the dispatch's scope matches the chain spec.** Out-of-scope dispatches (different repo, different file paths, different dispatch type) are written to `pending/` and wait for interactive promote, exactly like a non-autonomous dispatch.
 - Operator wake-up triggers (E1–E6 in T0's CLAUDE.md, plus the chain spec's `escalation_triggers`) are evaluated at every chain step. When any trigger fires, the chain transitions to `terminated/` and the operator is notified via the daily digest channel and (if configured) email.
-- Chain audit appends to the NDJSON ledger continuously; `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` Wave 0.5 lists the chain-runner observability work as a tracked deliverable.
+- Chain audit appends to the NDJSON ledger continuously; `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` Wave 0.5 lists the chain-runner observability work as a tracked deliverable.
 - `dispatcher_supervisor.sh` and the lease-sweep ticker are extended to detect chain-runner drift (e.g. a chain that has been `running/` for longer than its `max_wallclock` without a terminate event).
 
 ### Rejected
@@ -93,8 +93,8 @@ Chains are recorded in `.vnx-data/chains/` with three states (`approved/`, `runn
 - ADR-008 — Dual-LLM adversarial review (applies per-PR within a chain by default; chain spec may declare alternate gating posture)
 - ADR-010 — Subprocess adapter (chain-promoted dispatches use the same delivery primitive as interactive ones)
 - ADR-011 — Manager+worker hierarchy (a chain may dispatch across multiple workers; chain hash is shared across them)
-- `claudedocs/PRD-VNX-UH-002-v1.0-DRAFT.md` §6 FR-13 — the functional requirement this ADR redeems
-- `claudedocs/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2 moat) and §5 (Wave 0.5) — strategic context
+- `claudedocs/archive/PRD-VNX-UH-002-v1.0-DRAFT.md` §6 FR-13 — the functional requirement this ADR redeems
+- `claudedocs/_archive/2026-05-20-pre-centralisatie/2026-05-09-vnx-strategic-replan-proposal.md` §4 (M2 moat) and §5 (Wave 0.5) — strategic context
 - `.claude/terminals/T0/CLAUDE.md` — the prose specification of "full autonomous mode for the next 4-feature hardening lane" that this ADR replaces with a formal contract
 - `CLAUDE.md` (project root) "Auto Mode Active" pattern — the operator's expressed preference for continuous execution that this ADR makes governable
 - Memory: `feedback_dispatch_via_pending.md` — pending/ remains the only correct dispatch landing zone, even under chain-dispatch

--- a/docs/governance/decisions/ADR-015-wave7-litellm-path-b.md
+++ b/docs/governance/decisions/ADR-015-wave7-litellm-path-b.md
@@ -94,6 +94,6 @@ Reference: `provider_constraints.yaml` constraint `deepseek-harness-subscription
 
 ## See also
 
-- `claudedocs/wave7-litellm-bridge-deepseek-kimi-glm.md` — Wave 7 design doc
-- `claudedocs/project_deepseek_v4_pro_paths.md` (memory) — Path A/B/C/D analysis
+- `claudedocs/archive/wave7-litellm-bridge-deepseek-kimi-glm.md` — Wave 7 design doc
+- `project_deepseek_v4_pro_paths.md` (memory, formerly claudedocs/) — retracted: the Path A/B/C/D analysis is no longer present (date not determinable; the file was never git-tracked)
 - ADR-003, ADR-010, ADR-013, ADR-016

--- a/docs/governance/decisions/ADR-016-unified-event-shape.md
+++ b/docs/governance/decisions/ADR-016-unified-event-shape.md
@@ -3,7 +3,7 @@
 **Status:** Accepted
 **Date:** 2026-05-15
 **Decided by:** Operator (Vincent van Deth)
-**Resolves:** Wave 4.6 PR-4.6.6 — per `claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md` §Phase 6
+**Resolves:** Wave 4.6 PR-4.6.6 — per `claudedocs/archive/wave4.6-provider-dispatch-generalization-design-2026-05-13.md` §Phase 6
 
 ## Context
 
@@ -69,7 +69,7 @@ Concrete changes:
 
 - ADR-005 — Append-only NDJSON audit ledger (EventStore is the persistence layer this ADR extends)
 - ADR-010 — SubprocessAdapter Claude routing (source of claude events)
-- `claudedocs/wave4.6-provider-dispatch-generalization-design-2026-05-13.md` §Phase 6
+- `claudedocs/archive/wave4.6-provider-dispatch-generalization-design-2026-05-13.md` §Phase 6
 - `scripts/lib/canonical_event.py` — CanonicalEvent, EventShapeError, from_provider_event()
 - `scripts/lib/event_store.py` — EventStore.append() enforcement
 - Wave 4.6 PR-4.6.2–4.6.5 — spawn handler extraction (prereqs for this ADR)

--- a/docs/governance/decisions/ADR-017-wave5-control-centre.md
+++ b/docs/governance/decisions/ADR-017-wave5-control-centre.md
@@ -40,7 +40,7 @@ The Control Centre is one interactive Claude Code session running `@control-cent
 - Control Centre itself is a new SPOF (mitigated by stateless design — restart loses nothing)
 
 **Risk mitigation:**
-- 12-item risk register in `claudedocs/wave5-control-centre-architecture.md` §8
+- 12-item risk register in `claudedocs/archive/wave5-control-centre-architecture.md` §8
 - Multi-tenant schema migration with rollback (PR-5.3)
 - Falsifiable tests per multi-tenancy risk
 
@@ -69,7 +69,7 @@ Hard prereq: ADR-016 (Wave 4.6 PR-4.6.6 unified events) — merged.
 
 ## See also
 
-- `claudedocs/wave5-control-centre-architecture.md` — Wave 5 design doc
+- `claudedocs/archive/wave5-control-centre-architecture.md` — Wave 5 design doc
 - ADR-005, ADR-007, ADR-010, ADR-013, ADR-016
 - ADR-015 — Wave 7 LiteLLM Path B (Control Centre dispatches to all 5 providers including LiteLLM lanes)
 - ADR-018 — Elastic worker pool (Wave 6 per-project pools; PR-6.8 extends Control Centre

--- a/docs/governance/decisions/ADR-018-elastic-worker-pool.md
+++ b/docs/governance/decisions/ADR-018-elastic-worker-pool.md
@@ -217,11 +217,11 @@ whole is "done" when:
 | FM-8 | Concurrent migration 0018 | `BEGIN IMMEDIATE` with 30s timeout; per-project DBs are physically separate |
 | FM-10 | Membership race | Partial unique index `idx_pool_membership_active` blocks second active row |
 
-Full failure mode register (FM-1 through FM-12) in `claudedocs/wave6-workers-n-architecture.md` §9.
+Full failure mode register (FM-1 through FM-12) in `claudedocs/archive/wave6-workers-n-architecture.md` §9.
 
 ## References
 
-- `claudedocs/wave6-workers-n-architecture.md` — full Wave 6 design (schema, PR breakdown,
+- `claudedocs/archive/wave6-workers-n-architecture.md` — full Wave 6 design (schema, PR breakdown,
   sequencing, operator interaction model, failure modes, timeline)
 - ADR-011 — worker isolation (process-per-worker, depth>1 hierarchy)
 - ADR-013 — workers=N as configuration (design-only predecessor; implemented by Wave 6)

--- a/docs/governance/decisions/ADR-019-auto-dream-memory-consolidation.md
+++ b/docs/governance/decisions/ADR-019-auto-dream-memory-consolidation.md
@@ -82,6 +82,6 @@ T0 review-gate workflow integration (dispatch trigger on pending-review.json), o
 - ADR-007 — Multi-tenant project_id stamping (composite keys, per-project default)
 - ADR-015 — Wave 7 cheap-lane providers (kimi K2.6 as approved cheap-lane)
 - `scripts/lib/kimi_wrapper.py` — kimi subprocess infrastructure
-- `claudedocs/CC-COMMUNITY-SYNTHESIS-2026-05-29.md` §A-14 — architecture choice record
-- `claudedocs/CC-COMMUNITY-RESEARCH-OPUS-2026-05-29.md` §A4 — Boris Cherny REM-sleep analogy
+- `claudedocs/archive/CC-COMMUNITY-SYNTHESIS-2026-05-29.md` §A-14 — architecture choice record
+- `claudedocs/archive/CC-COMMUNITY-RESEARCH-OPUS-2026-05-29.md` §A4 — Boris Cherny REM-sleep analogy
 - Memory: `governance-receipt-gap` — original dormant self-learning loop record

--- a/scripts/import_open_items_to_tracks.py
+++ b/scripts/import_open_items_to_tracks.py
@@ -117,6 +117,7 @@ if str(_LIB) not in sys.path:
 import tracks  # noqa: E402  (single-writer primitives — D1)
 from plan_gate_enforcement import PLAN_OI_PREFIX  # noqa: E402  (synthetic plan-gate OI prefix — canonical home)
 from vnx_ids import PROJECT_ID_RE  # noqa: E402  (canonical project-id format — ADR-007)
+from track_reconciler import _parse_pr_numbers  # noqa: E402  (canonical multi-PR parser — OI-1207)
 
 DB_FILENAME = "runtime_coordination.db"
 OPEN_ITEMS_FILENAME = "open_items.json"
@@ -197,16 +198,6 @@ class BridgeResult:
 # ---------------------------------------------------------------------------
 # Read helpers (no track_open_items mutation lives here — D1)
 # ---------------------------------------------------------------------------
-
-def _parse_pr_number(pr_ref: Optional[str]) -> Optional[int]:
-    """Parse '#756', '756', '  #42 ' -> int. Returns None on failure."""
-    if not pr_ref:
-        return None
-    try:
-        return int(str(pr_ref).strip().lstrip("#").strip())
-    except (TypeError, ValueError):
-        return None
-
 
 def _open_conn(state_dir: str | Path) -> sqlite3.Connection:
     """Open the bridge connection used for BOTH the upfront reads and the single
@@ -300,15 +291,22 @@ def _load_open_items(state_dir: str | Path, *, path: Optional[Path] = None) -> L
 def _load_tracks_by_pr(
     conn: sqlite3.Connection, project_id: str
 ) -> Tuple[Dict[int, List[str]], set]:
-    """Return (pr_number -> [track_id...], {all track_ids}) for the tenant."""
+    """Return (pr_number -> [track_id...], {all track_ids}) for the tenant.
+
+    OI-1207: a track's ``pr_ref`` may name MULTIPLE PRs (``#1228,#1229,#1230`` —
+    a track that landed across several PRs). Parse with the canonical multi-PR
+    parser and register the track under EVERY number it names, so an open item
+    pointing at any one of them resolves. The old ``_parse_pr_number`` did
+    ``int()`` on the whole string and returned None for any multi-PR ref, which
+    silently dropped the track from the lookup (23 of 154 tracks on vnx-dev).
+    """
     by_pr: Dict[int, List[str]] = {}
     track_ids: set = set()
     for row in conn.execute(
         "SELECT track_id, pr_ref FROM tracks WHERE project_id = ?", (project_id,)
     ):
         track_ids.add(row["track_id"])
-        pr = _parse_pr_number(row["pr_ref"])
-        if pr is not None:
+        for pr in _parse_pr_numbers(row["pr_ref"]):
             by_pr.setdefault(pr, []).append(row["track_id"])
     return by_pr, track_ids
 
@@ -384,8 +382,18 @@ def _resolve_target_track(
         return None
     if explicit and explicit in track_ids:
         return (explicit, link_type)
-    pr = _parse_pr_number(oi.get("pr_id"))
-    candidates = by_pr.get(pr, []) if pr is not None else []
+    # OI-1207: parse the OI's ``pr_id`` with the multi-PR parser and consider ALL
+    # of its numbers ("alle", not "eerste"/"laatste"). The OI is a single blocking
+    # item whose ``pr_id`` names the PR(s) that resolve it; the correct choice is
+    # the UNION of candidate tracks: if every named PR maps to exactly one track
+    # it links there, if they fan out to more than one track that is genuinely
+    # ambiguous (unmappable). The old single-number parse dropped a multi-PR
+    # ``pr_id`` straight to None, which read as "unmappable" with no trace.
+    candidates: List[str] = []
+    for pr in sorted(_parse_pr_numbers(oi.get("pr_id"))):
+        for track_id in by_pr.get(pr, []):
+            if track_id not in candidates:
+                candidates.append(track_id)
     if len(candidates) == 1:
         return (candidates[0], link_type)
     result.unmappable.append(oi.get("id", "<no-id>"))

--- a/scripts/seed_tracks_from_roadmap.py
+++ b/scripts/seed_tracks_from_roadmap.py
@@ -78,6 +78,26 @@ _MILESTONE_RANK = {
     "1.x": 9,
 }
 
+# Feature-block keys the ROADMAP format supports (union of every consumer in the
+# roadmap toolchain: this seeder, build_feature_plan, build_pr_queue, and
+# pr_queue_manager). A key outside this set is a typo (e.g. ``goal_stat`` for
+# ``goal_state``) that used to vanish without a trace — the feature would be
+# seeded WITHOUT that field. OI-1168: validate strictly so a typo fails LOUD.
+#
+# ``merge_policy`` is carried by the shipped ROADMAP.yaml and read by
+# pr_queue_manager even though this seeder does not project it into a track.
+_ALLOWED_FEATURE_KEYS: frozenset = frozenset({
+    "feature_id",
+    "title",
+    "status",
+    "milestone",
+    "risk_class",
+    "merge_policy",
+    "depends_on",
+    "notes",
+    "pr_queue",
+})
+
 
 def _milestone_rank(milestone: Optional[str]) -> int:
     return _MILESTONE_RANK.get(str(milestone), 5)
@@ -175,12 +195,50 @@ def _row_matches(existing: dict[str, Any], desired: dict[str, Any]) -> bool:
     return True
 
 
+def _validate_feature(feature: dict[str, Any], index: int) -> None:
+    """Fail LOUD on a feature block with an unknown or empty key (OI-1168).
+
+    A key outside ``_ALLOWED_FEATURE_KEYS`` is a typo that used to be dropped
+    silently: ``goal_stat`` instead of ``goal_state`` seeds a track WITHOUT the
+    intended field and nothing complains. Raise with the offending key, the
+    feature that carries it, and the allowed set so the author can fix the file.
+    ``feature_id`` (the track identity) must be present AND non-empty: an empty
+    identity used to be filtered out by the old ``_load_roadmap`` list
+    comprehension, silently dropping the whole feature (fail-closed on form, not
+    just on presence).
+    """
+    name = feature.get("feature_id") or f"#<index {index}>"
+    unknown = [k for k in feature if k not in _ALLOWED_FEATURE_KEYS]
+    if unknown:
+        raise ValueError(
+            f"ROADMAP.yaml feature {name!r} has unknown key(s) {unknown}; "
+            f"allowed keys are {sorted(_ALLOWED_FEATURE_KEYS)}. Fix the key name "
+            "(a typo like `goal_stat` for `goal_state` is silently ignored by "
+            "the seeder)."
+        )
+    if not str(feature.get("feature_id") or "").strip():
+        raise ValueError(
+            f"ROADMAP.yaml feature #{index} has an empty 'feature_id' — every "
+            "feature needs a non-empty identity, otherwise it is silently "
+            "dropped from the seed."
+        )
+
+
 def _load_roadmap(roadmap_path: Path) -> list[dict[str, Any]]:
     data = yaml.safe_load(roadmap_path.read_text(encoding="utf-8")) or {}
     features = data.get("features") or []
     if not isinstance(features, list):
         raise ValueError(f"ROADMAP.yaml `features` is not a list in {roadmap_path}")
-    return [f for f in features if isinstance(f, dict) and f.get("feature_id")]
+    result: list[dict[str, Any]] = []
+    for index, feature in enumerate(features):
+        if not isinstance(feature, dict):
+            raise ValueError(
+                f"ROADMAP.yaml feature #{index} is a {type(feature).__name__} in "
+                f"{roadmap_path}, expected a mapping."
+            )
+        _validate_feature(feature, index)
+        result.append(feature)
+    return result
 
 
 def seed(
@@ -354,7 +412,13 @@ def main(argv: Optional[list[str]] = None) -> int:
         from project_root import resolve_project_root
         roadmap_path = resolve_project_root(__file__) / "ROADMAP.yaml"
 
-    report = seed(state_dir, roadmap_path, args.project_id, apply=args.apply)
+    try:
+        report = seed(state_dir, roadmap_path, args.project_id, apply=args.apply)
+    except ValueError as exc:
+        # OI-1168: a ROADMAP.yaml with an unknown/empty feature key is a loud
+        # failure, not a warning — surface it cleanly and exit non-zero.
+        print(f"[seed] ERROR: {exc}", file=sys.stderr)
+        return 1
     _print_report(report)
 
     if args.report:

--- a/tests/test_oi_track_bridge.py
+++ b/tests/test_oi_track_bridge.py
@@ -325,6 +325,78 @@ class TestMapping:
 
 
 # ---------------------------------------------------------------------------
+# OI-1207 — multi-PR pr_ref handling (single / multiple / junk / empty)
+# ---------------------------------------------------------------------------
+
+class TestMultiPrRef:
+    """OI-1207: a pr_ref naming MULTIPLE PRs must not be silently dropped.
+
+    The old ``_parse_pr_number`` did ``int()`` on the whole string, so
+    ``#1228,#1229`` parsed to None and the track vanished from the PR lookup.
+    The bridge now uses the canonical ``_parse_pr_numbers`` (via track_reconciler)
+    and registers a track under EVERY number it names, and resolves an open item
+    against the union of the tracks its PRs name.
+    """
+
+    @pytest.mark.parametrize("pr_ref,expected", [
+        ("#100", frozenset({100})),                            # single number
+        ("100", frozenset({100})),                             # single bare number
+        ("  #42  ", frozenset({42})),                          # surrounding whitespace
+        ("#1228,#1229,#1230", frozenset({1228, 1229, 1230})),  # multiple numbers
+        ("#100 junk #200, #300", frozenset({100, 200, 300})),  # junk between numbers
+        ("#908,#909", frozenset({908, 909})),                  # comma list
+        ("908 909", frozenset({908, 909})),                    # space-separated list
+        ("", frozenset()),                                     # empty string
+        (None, frozenset()),                                   # missing
+        ("not-a-pr", frozenset()),                             # entirely junk
+    ])
+    def test_parse_pr_numbers_variants(self, pr_ref, expected):
+        """Show what the parser returns per case (the behavior, not the label)."""
+        assert track_reconciler._parse_pr_numbers(pr_ref) == expected
+
+    def test_multi_pr_track_registered_under_every_number(self, state_dir):
+        """A track pr_ref '#1228,#1229,#1230' must appear under ALL three numbers."""
+        _mk_track(state_dir, "feat-multi", pr_ref="#1228,#1229,#1230")
+        conn = bridge._open_conn(state_dir)
+        try:
+            by_pr, _ = bridge._load_tracks_by_pr(conn, PROJECT_ID)
+        finally:
+            conn.close()
+        assert by_pr[1228] == ["feat-multi"]
+        assert by_pr[1229] == ["feat-multi"]
+        assert by_pr[1230] == ["feat-multi"]
+
+    def test_oi_matching_any_pr_of_multi_pr_track_links(self, state_dir):
+        """An open item pointing at ONE of a multi-PR track's numbers resolves."""
+        _mk_track(state_dir, "feat-multi", pr_ref="#1228,#1229,#1230")
+        res = bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID, open_items=[_oi("OI-1", pr_id="#1229")],
+        )
+        assert res.linked == 1 and res.ok
+        assert _rows(state_dir, "OI-1")[0]["track_id"] == "feat-multi"
+
+    def test_multi_pr_oi_matching_one_track_links(self, state_dir):
+        """An OI naming several PRs that ALL belong to one track links there."""
+        _mk_track(state_dir, "feat-multi", pr_ref="#1228,#1229,#1230")
+        res = bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID, open_items=[_oi("OI-1", pr_id="#1228,#1229")],
+        )
+        assert res.linked == 1 and res.ok
+        assert _rows(state_dir, "OI-1")[0]["track_id"] == "feat-multi"
+
+    def test_multi_pr_oi_fanning_out_to_two_tracks_is_unmappable(self, state_dir):
+        """An OI whose PRs fan out to two DIFFERENT tracks is genuinely ambiguous."""
+        _mk_track(state_dir, "feat-a", pr_ref="#100")
+        _mk_track(state_dir, "feat-b", pr_ref="#200")
+        res = bridge.import_open_items_to_tracks(
+            state_dir, PROJECT_ID, open_items=[_oi("OI-1", pr_id="#100,#200")],
+        )
+        assert "OI-1" in res.unmappable
+        assert res.linked == 0
+        assert _rows(state_dir, "OI-1") == []
+
+
+# ---------------------------------------------------------------------------
 # R4.2 — load ALL links + supersede obsolete (remap + closure)
 # ---------------------------------------------------------------------------
 

--- a/tests/test_seed_tracks_from_roadmap.py
+++ b/tests/test_seed_tracks_from_roadmap.py
@@ -29,6 +29,8 @@ for p in (_LIB, _SCRIPTS):
     if str(p) not in sys.path:
         sys.path.insert(0, str(p))
 
+import yaml
+
 import schema_migration
 import tracks as tracks_lib
 
@@ -267,3 +269,73 @@ def test_events_emitted(tmp_path, roadmap):
     lines = [json.loads(line) for line in events_file.read_text().splitlines() if line.strip()]
     types = {e["event_type"] for e in lines}
     assert "track_created" in types
+
+
+# ---------------------------------------------------------------------------
+# OI-1168 — unknown/empty feature-block keys fail LOUD instead of vanishing
+# ---------------------------------------------------------------------------
+
+def _write_roadmap(tmp_path: Path, features: list[dict]) -> Path:
+    """Write a minimal ROADMAP.yaml from a list of feature dicts."""
+    doc = yaml.safe_dump(
+        {"roadmap_id": "test", "features": features}, sort_keys=False
+    )
+    p = tmp_path / "ROADMAP.yaml"
+    p.write_text(doc, encoding="utf-8")
+    return p
+
+
+class TestKeyValidation:
+    def test_valid_block_passes(self, tmp_path):
+        p = _write_roadmap(tmp_path, [{
+            "feature_id": "feat-a", "title": "A", "risk_class": "high",
+            "depends_on": [], "milestone": "1.0", "status": "planned",
+            "merge_policy": "human", "notes": "notes", "pr_queue": [],
+        }])
+        state_dir = _make_db(tmp_path)
+        report = seeder.seed(state_dir, p, "vnx-dev", apply=False)
+        assert report["summary"]["created"] == 1
+
+    def test_unknown_key_fails_loud_with_key_and_feature(self, tmp_path):
+        p = _write_roadmap(tmp_path, [{
+            "feature_id": "feat-a", "title": "A", "goal_stat": "planned",
+        }])
+        state_dir = _make_db(tmp_path)
+        with pytest.raises(ValueError) as excinfo:
+            seeder.seed(state_dir, p, "vnx-dev", apply=False)
+        msg = str(excinfo.value)
+        assert "goal_stat" in msg              # the offending key
+        assert "feat-a" in msg                 # the feature carrying it
+        assert "allowed keys" in msg           # the list of allowed keys
+
+    def test_case_only_difference_is_unknown(self, tmp_path):
+        p = _write_roadmap(tmp_path, [{
+            "feature_id": "feat-a", "title": "A", "Goal_State": "planned",
+        }])
+        state_dir = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="Goal_State"):
+            seeder.seed(state_dir, p, "vnx-dev", apply=False)
+
+    def test_dry_run_fails_as_hard_as_apply(self, tmp_path):
+        p = _write_roadmap(tmp_path, [{
+            "feature_id": "feat-a", "title": "A", "goal_stat": "planned",
+        }])
+        state_dir = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="goal_stat"):
+            seeder.seed(state_dir, p, "vnx-dev", apply=False)
+        with pytest.raises(ValueError, match="goal_stat"):
+            seeder.seed(state_dir, p, "vnx-dev", apply=True)
+
+    def test_empty_feature_id_fails_loud(self, tmp_path):
+        """Fail-closed on form: a key that exists but is empty must be as loud
+        as a key that does not exist (the old loader silently dropped it)."""
+        p = _write_roadmap(tmp_path, [{"feature_id": "", "title": "A"}])
+        state_dir = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="feature_id"):
+            seeder.seed(state_dir, p, "vnx-dev", apply=False)
+
+    def test_non_dict_feature_element_fails_loud(self, tmp_path):
+        p = _write_roadmap(tmp_path, ["not-a-mapping"])
+        state_dir = _make_db(tmp_path)
+        with pytest.raises(ValueError, match="mapping"):
+            seeder.seed(state_dir, p, "vnx-dev", apply=False)


### PR DESCRIPTION
## Drie open items die stil falen — elk met een gemeten vindplaats

Drie losstaande fixes die hetzelfde defect delen: alle drie lieten iets stil doorgaan wat had moeten opvallen.

### OI-1207 — `_parse_pr_number` geeft None op een multi-PR pr_ref
`scripts/import_open_items_to_tracks.py` deed `int()` op de hele `pr_ref`-string. `#1228,#1229,#1230` is geen int, dus None, en de track viel stil weg uit de PR-lookup (23 van de 154 tracks). Nu de canonieke `_parse_pr_numbers` (track_reconciler) gebruikt; een track registreert onder élk nummer dat hij noemt, en een open item resolvet tegen de unie van kandidaat-tracks ("alle", gemotiveerd per callsite).

Tests: 10 parse-varianten (enkel/meervoudig/rommel/leeg) + 4 integratiegevallen.

### OI-1168 — `seed_tracks_from_roadmap` gooit onbekende sleutels stil weg
Geen sleutelvalidatie: `goal_stat` i.p.v. `goal_state` verdween zonder melding en de track seedde zonder dat veld. Nu valideert `_ALLOWED_FEATURE_KEYS` per feature-blok; een onbekende of lege sleutel is een luide `ValueError`, in dry-run én apply.

Tests: geldig blok, onbekende sleutel (melding bevat sleutel + feature + toegestane lijst), alleen-hoofdletter-verschil, dry-run faalt even hard als apply, lege `feature_id`, non-dict element.

### OI-1182 — verwijzingen naar verplaatste `claudedocs`-paden
60 verwijzingen in ADR's wezen naar `claudedocs`-paden die naar een archiefmap zijn verplaatst. Elke verwijzing wijst nu naar het echte archiefpad. Eén doel (`project_deepseek_v4_pro_paths.md`) bestaat nergens meer en is als "retracted" gemarkeerd, niet verwijderd.

Bewijs (beide uitvoeringen in het dispatch-rapport): een commando telt vóór de wijziging **60** kapotte verwijzingen over alle ADR's en erna **0**. De opdracht noemde "33" als momentopname; het reproduceerbare commando telt 60 (de 13 genoemde ADR's dragen 46, ADR-014 t/m 019 nog 14 van hetzelfde defect, die ook zijn hersteld).

## Verificatie
- `tests/test_oi_track_bridge.py` + `tests/test_seed_tracks_from_roadmap.py`: **136 passed, 3 failed**.
- De 3 falende tests (`TestReconcilerTieIn` x2, `TestPostCommitEmit`) zijn pre-existing: `sqlite3.OperationalError: no such column: output_ref` op `track_reconciler.py:772`, niet geraakt door deze dispatch (basis-commit 5e05cda0 faalt identiek).
- Nieuwe tests: 20/20 groen (OI-1207 + OI-1168).

🤖 Generated with [Claude Code](https://claude.com/claude-code)