### PR TITLE
fix(panel): pass VNX_DATA_DIR to seat subprocess + refuse thin synthesis (OI-1153, OI-1154)

### DIFF
--- a/configs/plan_gate_panel.yaml
+++ b/configs/plan_gate_panel.yaml
@@ -59,6 +59,16 @@ tiebreaker:
 # still refused. Read by scripts/lib/plan_gate_panel.py::load_goal_min_chars.
 goal_min_chars: 200
 
+# Coverage floor for the DELIBERATION panel's synthesis stage (OI-1154): below
+# this many DELIVERED seat reports the synthesis refuses LOUDLY instead of
+# silently building a report from a handful of seats (e.g. 1 of 5). The refusal
+# names delivered and expected seats, and decides on the SAME present/total
+# count the coverage line already shows (OI-1150) — never its own tally. The
+# operator can consciously proceed below the floor with `vnx panel --allow-degraded`.
+# Read by scripts/lib/plan_gate_panel.py::load_synthesis_min_seats.
+# Default 3: a majority of the five-seat deliberation roster.
+synthesis_min_seats: 3
+
 seats:
   - label: opus
     provider: claude

--- a/scripts/lib/deliberation_panel.py
+++ b/scripts/lib/deliberation_panel.py
@@ -128,6 +128,10 @@ class DeliberationResult:
     # silently degraded. Populated by run_deliberation right after the fan-out completes.
     present_lenses: List[str] = field(default_factory=list)
     failed_seats: List[Dict[str, str]] = field(default_factory=list)  # {provider, lens}
+    # Coverage gate (OI-1154): below the configured seat minimum the synthesis is
+    # refused, recorded here so to_report() renders it loudly, never silently.
+    synthesis_refused_reason: str = ""   # non-empty => synthesis refused (coverage floor)
+    degraded_synthesis: bool = False     # synthesis ran below the floor (--allow-degraded)
 
     @property
     def coverage(self) -> str:
@@ -146,8 +150,18 @@ class DeliberationResult:
             f"# Deliberation panel — {self.mode}",
             f"\n**Question:** {self.question}\n",
             f"**Coverage:** {self.coverage}\n",
-            "## Synthesis (cited)\n",
-            self.synthesis or "_(no synthesis)_",
+        ]
+        if self.synthesis_refused_reason:
+            lines.append(f"**Synthesis:** REFUSED — {self.synthesis_refused_reason}\n")
+        if self.degraded_synthesis:
+            lines.append(f"**Synthesis:** ran DEGRADED (--allow-degraded) — {self.coverage}\n")
+        lines.append("## Synthesis (cited)\n")
+        lines.append(
+            "_(synthesis refused — see above)_"
+            if self.synthesis_refused_reason
+            else (self.synthesis or "_(no synthesis)_")
+        )
+        lines += [
             "\n---\n## Contrarian / red-team\n",
             self.contrarian or "_(none)_",
             "\n---\n## Verification pass\n",
@@ -325,10 +339,21 @@ def run_deliberation(
     roster: Optional[List[Tuple[str, str]]] = None,
     context: str = "",
     max_workers: int = 5,
+    min_seats: Optional[int] = None,
+    allow_degraded: bool = False,
 ) -> DeliberationResult:
     """Run the 4-stage deliberation. ``dispatcher(provider, model, prompt, dispatch_id)`` runs
     one panelist and returns its report text (governed lane). ``context`` is optional extra
-    grounding (a diff, a file list, a brief) injected into every stage."""
+    grounding (a diff, a file list, a brief) injected into every stage.
+
+    ``min_seats`` (OI-1154) is the coverage floor for the SYNTHESIS stage: when fewer than
+    ``min_seats`` DELIVERED seats (the same present/total count ``DeliberationResult.coverage``
+    reports — never a second, drifting tally) produced a usable report, the synthesis is
+    REFUSED and ``result.synthesis_refused_reason`` carries the delivered/expected counts.
+    ``None`` (the default) disables the floor entirely — callers that already bound coverage
+    their own way stay unaffected. ``allow_degraded`` is the operator escape: with it True the
+    synthesis proceeds below the floor, and ``result.degraded_synthesis`` marks that choice so
+    the report renders it, never silently."""
     spec = MODES.get(mode)
     if spec is None:
         raise ValueError(f"unknown mode {mode!r}; choose one of {sorted(MODES)}")
@@ -374,6 +399,33 @@ def run_deliberation(
             ", ".join(f"{fo['provider']} ({fo['lens']})" for fo in failed_fan_out),
             result.coverage,
         )
+
+    # ── Coverage floor for the synthesis (OI-1154) ──────────────────────────
+    # Decide on the SAME present/total count `coverage` reports (OI-1150), never a
+    # second tally. Below `min_seats` delivered seats the synthesis is refused
+    # LOUDLY with both counts in the message; `allow_degraded` is the conscious
+    # operator escape, and the choice is stamped on the result so the report
+    # renders it (degraded_synthesis) instead of it vanishing.
+    present = len(result.present_lenses)
+    total = len(result.fan_out)
+    if min_seats is not None and present < min_seats:
+        if allow_degraded:
+            result.degraded_synthesis = True
+            logger.warning(
+                "panel: proceeding with DEGRADED synthesis (--allow-degraded) at "
+                "%d/%d lenses delivered (minimum %d)",
+                present, total, min_seats,
+            )
+        else:
+            result.synthesis_refused_reason = (
+                f"refusing synthesis: {present}/{total} lenses delivered (minimum {min_seats})"
+            )
+            logger.error(
+                "panel: synthesis refused — %d/%d lenses delivered (minimum %d); "
+                "re-run with --allow-degraded to proceed with degraded coverage",
+                present, total, min_seats,
+            )
+            return result
 
     digest = _digest(present_fan_out)
     coverage_note = (

--- a/scripts/lib/plan_gate_panel.py
+++ b/scripts/lib/plan_gate_panel.py
@@ -229,6 +229,51 @@ def load_goal_min_chars(config_path: Optional[Path] = None) -> int:
     return raw
 
 
+# Minimum number of DELIVERED seat reports the deliberation panel's synthesis
+# stage requires before it will synthesize (OI-1154). Below this floor the
+# synthesis refuses loudly rather than silently reporting over a handful of
+# seats. The value is overridable in configs/plan_gate_panel.yaml
+# (`synthesis_min_seats`), never hardcoded at the call site — a fixed literal in
+# Python would let the config drift silently (see load_synthesis_min_seats). The
+# consumer is the deliberation panel (`scripts/panel.py` wires it into
+# run_deliberation), which is why this lives beside the other plan_gate_panel.yaml
+# loaders even though the gate itself is in deliberation_panel.py.
+DEFAULT_SYNTHESIS_MIN_SEATS = 3
+
+
+def load_synthesis_min_seats(config_path: Optional[Path] = None) -> int:
+    """The synthesis coverage floor, read from ``configs/plan_gate_panel.yaml``.
+
+    Reads ``synthesis_min_seats`` from the same file and path resolution as
+    ``load_panel_seats``/``load_goal_min_chars``. Falls back to
+    ``DEFAULT_SYNTHESIS_MIN_SEATS`` when the file is absent/unreadable or the key
+    is missing (a pre-existing config never breaks the panel). A present-but-
+    invalid value (non-int, bool, or <= 0) fails LOUD: a silently-wrong floor
+    would either refuse every synthesis (<= 0 never satisfies) or never refuse
+    at all — both silent governance drifts, so misconfiguration must surface
+    here, matching ``load_goal_min_chars``.
+    """
+    path = Path(config_path) if config_path is not None else _default_panel_config_path()
+    if not path.is_file():
+        return DEFAULT_SYNTHESIS_MIN_SEATS
+    try:
+        import yaml  # noqa: PLC0415
+        loaded = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return DEFAULT_SYNTHESIS_MIN_SEATS
+    if not isinstance(loaded, dict):
+        return DEFAULT_SYNTHESIS_MIN_SEATS
+    raw = loaded.get("synthesis_min_seats")
+    if raw is None:
+        return DEFAULT_SYNTHESIS_MIN_SEATS
+    if isinstance(raw, bool) or not isinstance(raw, int) or raw <= 0:
+        raise ValueError(
+            f"plan_gate_panel: {path} 'synthesis_min_seats' must be a positive int, "
+            f"got {raw!r}"
+        )
+    return raw
+
+
 def filter_panel_seats(
     seats: List[Dict[str, str]], labels: List[str]
 ) -> List[Dict[str, str]]:
@@ -891,6 +936,17 @@ def _make_default_dispatcher(
 
     def _dispatch(provider: str, model_arg: str, instruction: str, dispatch_id: str) -> str:
         env = dict(os.environ)
+        # OI-1153: pin the seat subprocess to the SAME data dir this dispatcher
+        # resolved (`base`), or the lane re-resolves its own. provider_dispatch /
+        # tmux_interactive_dispatch both honor the two-key VNX_DATA_DIR +
+        # VNX_DATA_DIR_EXPLICIT=1 contract (see their _resolve_data_dir/
+        # _resolve_state_dir); without it the seat's report write path can land
+        # outside the dir _read_report reads back from (e.g. the legacy
+        # ~/.vnx-data/unified_reports root), and the seat report is silently
+        # never found. This applies to BOTH lanes: the claude/tmux branch below
+        # and the provider branch.
+        env["VNX_DATA_DIR"] = str(base)
+        env["VNX_DATA_DIR_EXPLICIT"] = "1"
         _tmp_doc_path: Optional[str] = None
         try:
             if provider in _CLAUDE_PROVIDERS:

--- a/scripts/panel.py
+++ b/scripts/panel.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """`vnx panel` runner — multi-provider deliberation panel for complex, multi-view questions.
 
-    python3 scripts/panel.py <mode> "<question>" [--context-file F] [--timeout S] [--out F] [--seats LIST]
+    python3 scripts/panel.py <mode> "<question>" [--context-file F] [--timeout S] [--out F] [--seats LIST] [--allow-degraded]
 
 Modes: sweep | research | architecture | strategy. Runs the 4-stage deliberation
 (diverge → contrarian → verify → synthesis) via the governed review-lane dispatcher, then
@@ -60,6 +60,12 @@ def main(argv: "list[str] | None" = None) -> int:
     parser.add_argument("--timeout", type=int, default=900, help="per-panelist timeout seconds")
     parser.add_argument("--out", default=None, help="write the report here (default: unified_reports/)")
     parser.add_argument("--seats", default=None, help="comma-list of seats to run; default = full fleet")
+    parser.add_argument(
+        "--allow-degraded",
+        action="store_true",
+        help="proceed with the synthesis even when fewer than the configured "
+             "minimum seats delivered a report (the choice is stamped on the report)",
+    )
     args = parser.parse_args(argv)
 
     try:
@@ -76,7 +82,10 @@ def main(argv: "list[str] | None" = None) -> int:
             print(f"panel: cannot read --context-file: {exc}", file=sys.stderr)
             return 2
 
-    from plan_gate_panel import _make_default_dispatcher  # noqa: PLC0415
+    from plan_gate_panel import (  # noqa: PLC0415
+        _make_default_dispatcher,
+        load_synthesis_min_seats,
+    )
     # Pass a REAL data_dir: the claude/tmux lane writes each report to
     # <data_dir>/unified_reports/<id>.md and _read_report falls back to that path. With
     # data_dir=None the claude-lane reports (fan-out + synthesis) are written but never found
@@ -90,12 +99,20 @@ def main(argv: "list[str] | None" = None) -> int:
     # which a plan-reviewer-role worker correctly rejected as not a plan, corrupting the
     # panel stage.
     dispatcher = _make_default_dispatcher(data_dir, args.timeout, role="deliberation-panelist")
+    # OI-1154: the synthesis coverage floor comes from the config, never a Python literal.
+    min_seats = load_synthesis_min_seats()
 
     print(f"[panel] mode={args.mode} — running 4-stage deliberation across the fleet ...", file=sys.stderr)
     if roster is None:
-        result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context)
+        result = run_deliberation(
+            args.mode, args.question, dispatcher=dispatcher, context=context,
+            min_seats=min_seats, allow_degraded=args.allow_degraded,
+        )
     else:
-        result = run_deliberation(args.mode, args.question, dispatcher=dispatcher, context=context, roster=roster)
+        result = run_deliberation(
+            args.mode, args.question, dispatcher=dispatcher, context=context, roster=roster,
+            min_seats=min_seats, allow_degraded=args.allow_degraded,
+        )
     report = result.to_report()
 
     out = Path(args.out) if args.out else (_resolve_reports_dir() / f"panel-{args.mode}-{uuid.uuid4().hex[:8]}.md")
@@ -106,6 +123,9 @@ def main(argv: "list[str] | None" = None) -> int:
         print(f"panel: could not write report: {exc}", file=sys.stderr)
 
     print(report)
+    if result.synthesis_refused_reason:
+        print(f"[panel] SYNTHESIS REFUSED: {result.synthesis_refused_reason}", file=sys.stderr)
+        return 1
     return 0
 
 

--- a/tests/test_deliberation_panel.py
+++ b/tests/test_deliberation_panel.py
@@ -485,3 +485,97 @@ class TestCoverageAwareDegradation:
             dp.run_deliberation("sweep", "q", dispatcher=flaky, roster=ROSTER, max_workers=3)
         warnings = [r for r in caplog.records if "usable report" in r.message]
         assert warnings, "a failed seat must be logged loudly, never silently"
+
+
+FIVE_ROSTER = [
+    ("codex", "gpt-5.5"),
+    ("kimi", "k2"),
+    ("claude", "sonnet"),
+    ("glm-harness", "glm-5.2"),
+    ("deepseek-harness", "deepseek-v4-pro"),
+]
+
+
+class TestSynthesisCoverageGate:
+    """OI-1154: below a minimum number of DELIVERED seats the synthesis refuses
+    LOUDLY — naming delivered AND expected — instead of silently synthesizing
+    over a handful of seats (e.g. 1 of 5). The gate decides on the SAME
+    present/total count ``coverage`` reports (OI-1150), never its own tally."""
+
+    def test_synthesis_refuses_below_min_seats_with_both_counts(self):
+        def one_of_five(provider, model, prompt, did):
+            if provider != "codex":
+                return "[dispatch error: down]"
+            return "ok"
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=one_of_five, roster=FIVE_ROSTER,
+            max_workers=5, min_seats=3,
+        )
+        assert res.synthesis_refused_reason, "a 1-of-5 synthesis must be refused"
+        assert "refusing synthesis" in res.synthesis_refused_reason
+        assert "1/5" in res.synthesis_refused_reason  # delivered/expected both named
+        assert "minimum 3" in res.synthesis_refused_reason
+        # nothing was synthesized, and the downstream stages were skipped
+        assert res.synthesis == ""
+        assert res.contrarian == "" and res.factcheck == ""
+
+    def test_synthesis_proceeds_at_min_seats(self):
+        def three_of_five(provider, model, prompt, did):
+            if provider in ("kimi", "deepseek-harness"):
+                return "[dispatch error: down]"
+            return f"ok-{provider}"
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=three_of_five, roster=FIVE_ROSTER,
+            max_workers=5, min_seats=3,
+        )
+        assert res.synthesis_refused_reason == ""
+        assert not res.degraded_synthesis
+        assert res.synthesis  # exactly at the floor, the synthesis runs
+
+    def test_allow_degraded_lets_one_of_five_through_visibly(self):
+        def one_of_five(provider, model, prompt, did):
+            if provider != "codex":
+                return "[dispatch error: down]"
+            return f"ok-{provider}"
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=one_of_five, roster=FIVE_ROSTER,
+            max_workers=5, min_seats=3, allow_degraded=True,
+        )
+        assert res.synthesis_refused_reason == ""
+        assert res.degraded_synthesis is True
+        assert res.synthesis  # the escape lets the synthesis run degraded
+        report = res.to_report()
+        assert "--allow-degraded" in report  # the choice is visible in the output
+
+    def test_refusal_is_rendered_in_report(self):
+        def one_of_five(provider, model, prompt, did):
+            if provider != "codex":
+                return "[dispatch error: down]"
+            return "ok"
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=one_of_five, roster=FIVE_ROSTER,
+            max_workers=5, min_seats=3,
+        )
+        report = res.to_report()
+        assert "REFUSED" in report
+        assert "1/5" in report
+
+    def test_no_gate_when_min_seats_is_none(self):
+        """min_seats=None (the default) keeps the pre-gate behaviour: no refusal,
+        no degraded flag — existing callers that bound coverage their own way are
+        unaffected."""
+        def one_of_five(provider, model, prompt, did):
+            if provider != "codex":
+                return "[dispatch error: down]"
+            return f"ok-{provider}"
+
+        res = dp.run_deliberation(
+            "sweep", "q", dispatcher=one_of_five, roster=FIVE_ROSTER, max_workers=5,
+        )
+        assert res.synthesis_refused_reason == ""
+        assert not res.degraded_synthesis
+        assert res.synthesis

--- a/tests/test_panel_cli.py
+++ b/tests/test_panel_cli.py
@@ -11,6 +11,8 @@ REPO_ROOT = Path(__file__).resolve().parent.parent
 
 
 class _FakeResult:
+    synthesis_refused_reason = ""
+
     def to_report(self) -> str:
         return "# fake panel report\n"
 
@@ -124,3 +126,59 @@ def test_dispatcher_factory_receives_non_plan_reviewer_role(tmp_path, monkeypatc
     assert rc == 0
     assert calls["role"] == "deliberation-panelist"
     assert calls["role"] != "plan-reviewer"
+
+
+def test_panel_passes_config_min_seats_and_allow_degraded_to_run_deliberation(tmp_path, monkeypatch):
+    """OI-1154: the synthesis coverage floor comes from the config loader (not a
+    Python literal), and the --allow-degraded escape is forwarded to the panel."""
+    panel = _load_panel_cli()
+    calls = {}
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    def fake_run_deliberation(*args, **kwargs):
+        calls["kwargs"] = kwargs
+        return _FakeResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr("plan_gate_panel.load_synthesis_min_seats", lambda config_path=None: 7)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main([
+        "sweep", "audit src/", "--seats", "codex,claude",
+        "--out", str(tmp_path / "report.md"), "--allow-degraded",
+    ])
+
+    assert rc == 0
+    assert calls["kwargs"]["min_seats"] == 7
+    assert calls["kwargs"]["allow_degraded"] is True
+
+
+def test_panel_refusal_returns_nonzero_and_loud(tmp_path, monkeypatch, capsys):
+    """A refused synthesis must not look like success: the CLI exits non-zero and
+    prints the refusal (with delivered/expected counts) to stderr."""
+    panel = _load_panel_cli()
+
+    def fake_dispatcher_factory(data_dir, timeout, role=None):
+        return lambda provider, model, prompt, dispatch_id: "ok"
+
+    class _RefusingResult:
+        synthesis_refused_reason = "refusing synthesis: 1/5 lenses delivered (minimum 3)"
+
+        def to_report(self) -> str:
+            return "# fake panel report\n"
+
+    def fake_run_deliberation(*args, **kwargs):
+        return _RefusingResult()
+
+    monkeypatch.setattr("plan_gate_panel._make_default_dispatcher", fake_dispatcher_factory)
+    monkeypatch.setattr("plan_gate_panel.load_synthesis_min_seats", lambda config_path=None: 3)
+    monkeypatch.setattr(panel, "run_deliberation", fake_run_deliberation)
+
+    rc = panel.main(["sweep", "audit src/", "--out", str(tmp_path / "report.md")])
+
+    captured = capsys.readouterr()
+    assert rc == 1
+    assert "SYNTHESIS REFUSED" in captured.err
+    assert "1/5" in captured.err

--- a/tests/test_plan_gate_panel.py
+++ b/tests/test_plan_gate_panel.py
@@ -1525,6 +1525,71 @@ def test_provider_lane_dispatcher_does_not_set_scoped_spawn_env(tmp_path, monkey
     assert "VNX_WORKER_SCOPED" not in seen_envs[0]
 
 
+# --------------------------------------------------------------------------
+# OI-1153: the seat subprocess must inherit VNX_DATA_DIR (+ VNX_DATA_DIR_EXPLICIT=1)
+# pinned to the data dir the dispatcher resolved, or the lane re-resolves its own
+# (provider_dispatch._resolve_data_dir / tmux lane _resolve_state_dir) and the seat
+# report lands outside the dir _read_report reads back from — e.g. the legacy
+# ~/.vnx-data/unified_reports root. The base env must NOT already carry the flag so a
+# pass proves the dispatcher sets it rather than an ambient leak.
+# --------------------------------------------------------------------------
+
+def test_claude_lane_dispatcher_sets_vnx_data_dir_env(tmp_path, monkeypatch):
+    """The claude/tmux-lane subprocess env must carry VNX_DATA_DIR + EXPLICIT pinned
+    to the dispatcher's resolved base so the seat writes its report where the panel
+    reads it back, not the legacy ~/.vnx-data/unified_reports root."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    seen_envs: list = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_envs.append(kwargs.get("env"))
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    import plan_gate_panel as _pgp
+    import unittest.mock as mock
+
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
+            dispatcher("claude", "sonnet", "panel prompt", "panel-sweep-diverge-0-abc123")
+
+    assert len(seen_envs) == 1
+    assert seen_envs[0] is not None
+    assert seen_envs[0].get("VNX_DATA_DIR") == str(tmp_path)
+    assert seen_envs[0].get("VNX_DATA_DIR_EXPLICIT") == "1"
+
+
+def test_provider_lane_dispatcher_sets_vnx_data_dir_env(tmp_path, monkeypatch):
+    """OI-1153 applies to provider lanes too: kimi/glm/deepseek route through
+    provider_dispatch, which resolves its OWN data dir — the env must pin it to the
+    same base so the report lands where _read_report reads."""
+    monkeypatch.delenv("VNX_DATA_DIR", raising=False)
+    monkeypatch.delenv("VNX_DATA_DIR_EXPLICIT", raising=False)
+
+    seen_envs: list = []
+
+    def _mock_subprocess_run(cmd, **kwargs):
+        seen_envs.append(kwargs.get("env"))
+        import subprocess as _sp
+        return _sp.CompletedProcess(cmd, returncode=0, stdout="", stderr="")
+
+    import plan_gate_panel as _pgp
+    import unittest.mock as mock
+
+    dispatcher = pgp._make_default_dispatcher(str(tmp_path), 60)
+    with mock.patch.object(pgp.subprocess, "run", side_effect=_mock_subprocess_run):
+        with mock.patch.object(pgp, "_read_report", return_value="panel seat analysis"):
+            dispatcher("kimi", "kimi-k3", "panel prompt", "panel-sweep-diverge-1-def456")
+
+    assert len(seen_envs) == 1
+    assert seen_envs[0] is not None
+    assert seen_envs[0].get("VNX_DATA_DIR") == str(tmp_path)
+    assert seen_envs[0].get("VNX_DATA_DIR_EXPLICIT") == "1"
+
+
 def test_claude_lane_no_report_error_surfaces_stdout_failure_reason(tmp_path):
     """The 'no report' RuntimeError must include proc.stdout, not just stderr.
 
@@ -1869,6 +1934,38 @@ def test_load_panel_seats_rejects_missing_key(tmp_path):
     ))
     with pytest.raises(ValueError, match="missing required key"):
         pgp.load_panel_seats(cfg)
+
+
+def test_load_synthesis_min_seats_reads_config_key(tmp_path):
+    """The synthesis coverage floor comes from the config key, not a Python literal:
+    a changed YAML value changes the returned floor."""
+    cfg = tmp_path / "panel.yaml"
+    cfg.write_text("version: 1\nsynthesis_min_seats: 2\nseats: []\n", encoding="utf-8")
+    assert pgp.load_synthesis_min_seats(cfg) == 2
+
+    no_key = tmp_path / "no_key.yaml"
+    no_key.write_text("version: 1\nseats: []\n", encoding="utf-8")
+    assert pgp.load_synthesis_min_seats(no_key) == pgp.DEFAULT_SYNTHESIS_MIN_SEATS
+
+    assert pgp.load_synthesis_min_seats(tmp_path / "absent.yaml") == pgp.DEFAULT_SYNTHESIS_MIN_SEATS
+
+
+def test_load_synthesis_min_seats_rejects_invalid_value(tmp_path):
+    """A present-but-invalid floor (<= 0, non-int, bool) fails loud rather than
+    silently disabling or over-tightening the refusal."""
+    for bad in ("0", "-5", "abc", "true"):
+        cfg = tmp_path / f"bad_{bad}.yaml"
+        cfg.write_text(f"version: 1\nsynthesis_min_seats: {bad}\nseats: []\n", encoding="utf-8")
+        with pytest.raises(ValueError):
+            pgp.load_synthesis_min_seats(cfg)
+
+
+def test_shipped_config_synthesis_min_seats_is_positive():
+    """The shipped config must carry a positive floor so the gate is actually armed."""
+    repo_root = Path(__file__).resolve().parent.parent
+    shipped = repo_root / "configs" / "plan_gate_panel.yaml"
+    assert shipped.is_file(), "configs/plan_gate_panel.yaml must exist"
+    assert pgp.load_synthesis_min_seats(shipped) >= 1
 
 
 def test_filter_panel_seats_filters_to_requested_labels():


### PR DESCRIPTION
## Summary

Two silent failures in the deliberation panel, both closed.

**OI-1153** — `_make_default_dispatcher` built the seat subprocess env from `os.environ` without `VNX_DATA_DIR`. A seat (provider lane or claude/tmux lane) re-resolved its own data dir, so its report landed outside the dir the panel reads back from — the legacy `~/.vnx-data/unified_reports/` root (never cleaned; it still holds two `panel-strategy-diverge-*.md` seat reports). Fix: pin `VNX_DATA_DIR` + `VNX_DATA_DIR_EXPLICIT=1` to the dispatcher's resolved base in the subprocess env, so the seat report lands where `_read_report` reads.

**OI-1154** — the synthesis used `_first_ok(...)` with no coverage floor, so 1-of-5 delivered seats still produced a synthesis and no one saw the four missing seats. Fix: a coverage floor — below `synthesis_min_seats` delivered seats the synthesis refuses LOUDLY with delivered/expected counts in the message. The floor decides on the same present/total count the coverage line already shows (OI-1150), never its own tally. Configurable in `configs/plan_gate_panel.yaml` (`synthesis_min_seats`, default 3); `--allow-degraded` is the explicit operator escape, stamped on the report.

## Evidence

- **OI-1153**: `test_claude_lane_dispatcher_sets_vnx_data_dir_env` + `test_provider_lane_dispatcher_sets_vnx_data_dir_env` assert the subprocess env carries `VNX_DATA_DIR` (pinned to the resolved base) + `VNX_DATA_DIR_EXPLICIT=1` for both lanes. Live command: the provider lane's `_resolve_data_dir()` under the dispatcher's env resolves to `<base>/unified_reports/demo-seat-1.md`, not the legacy root.
- **OI-1154**: `test_synthesis_refuses_below_min_seats_with_both_counts` (1/5 refused, message names `1/5` and `minimum 3`), `test_synthesis_proceeds_at_min_seats` (floor passes), `test_allow_degraded_lets_one_of_five_through_visibly` (escape runs, `--allow-degraded` visible in report), `test_load_synthesis_min_seats_reads_config_key` (floor comes from the YAML, not a Python literal).

## Tests

`pytest tests/test_deliberation_panel.py tests/test_panel_cli.py tests/test_plan_gate_panel.py -q -k "not objective_add_auto_seeds and not seed_then_resolve and not resolve_when_no_blocker and not seed_is_tenant and not reseed_after"` → 173 passed.

5 pre-existing failures in `test_plan_gate_panel.py` (`no such column: output_ref`, a schema drift in the DB blocker-lifecycle tests) fail identically on baseline and are unrelated.

Dispatch-ID: 20260815-opsch-w4-panel-gaten

🤖 Generated with [Claude Code](https://claude.com/claude-code)