### PR TITLE
fix(dispatch): name tmux buffers per delivery + carry main-checkout permissions into worktree (OI-1144, OI-1161)

### DIFF
--- a/scripts/heartbeat_ack_monitor.py
+++ b/scripts/heartbeat_ack_monitor.py
@@ -622,9 +622,22 @@ class HeartbeatACKMonitor:
                 tmp.write(notification)
                 tmp_path = tmp.name
 
+            # OI-1144: named buffer (pid + dispatch_id) instead of tmux's
+            # anonymous "most recent buffer" stack, so two simultaneous ACKs
+            # can't cross each other's content (same TOCTOU-on-shared-state
+            # mechanism fixed in tmux_adapter OI-1136 and
+            # tmux_interactive_dispatch OI-1126). Deleted after use so a
+            # long-running monitor never accumulates one named buffer per ACK.
+            buffer_name = f"vnx-ack-{os.getpid()}-{re.sub(r'[^A-Za-z0-9_]', '_', dispatch_id)}"
+
             # Load buffer and paste to T0
-            subprocess.run(['tmux', 'load-buffer', tmp_path], check=True, capture_output=True)
-            subprocess.run(['tmux', 'paste-buffer', '-t', t0_pane], check=True, capture_output=True)
+            try:
+                subprocess.run(['tmux', 'load-buffer', '-b', buffer_name, tmp_path], check=True, capture_output=True)
+                subprocess.run(['tmux', 'paste-buffer', '-b', buffer_name, '-t', t0_pane], check=True, capture_output=True)
+            finally:
+                # Best-effort cleanup: never let a delete error mask the paste
+                # outcome already computed above.
+                subprocess.run(['tmux', 'delete-buffer', '-b', buffer_name], capture_output=True)
 
             # Press Enter twice to submit (handle bracketed paste)
             # Added delay to ensure CLI processes the text before Enter

--- a/scripts/lib/dispatch_deliver.sh
+++ b/scripts/lib/dispatch_deliver.sh
@@ -14,18 +14,32 @@ tmux_send_best_effort() {
     return 0
 }
 
+# OI-1144: unique-per-delivery tmux buffer name. pid + sanitized dispatch_id.
+# pid alone already separates two concurrent dispatcher processes racing to
+# load+paste (the exact crossing the anonymous buffer stack allowed); the
+# dispatch_id keeps the name unique across deliveries within one process and
+# greppable in `tmux list-buffers`.
+_ddt_buffer_name() {
+    local dispatch_id="$1"
+    local sanitized="${dispatch_id//[^a-zA-Z0-9_]/_}"
+    printf 'vnx-deliver-%s-%s' "$$" "$sanitized"
+}
+
 # Large-payload tmux buffer loading via temp file to avoid silent truncation.
+# First arg is the NAMED buffer to load into (see _ddt_buffer_name); load+paste
+# must address the same named buffer or they fall back to the anonymous stack.
 tmux_load_buffer_safe() {
-    local content="$1"
+    local buffer_name="$1"
+    local content="$2"
     local payload_size=${#content}
     if [ "$payload_size" -gt "$VNX_DISPATCH_MAX_INLINE" ]; then
         mkdir -p "$VNX_DISPATCH_PAYLOAD_DIR"
         local tmpfile="$VNX_DISPATCH_PAYLOAD_DIR/payload_$$.txt"
         printf '%s' "$content" > "$tmpfile"
         log "V8 DELIVERY: Large payload (${payload_size}B > ${VNX_DISPATCH_MAX_INLINE}B), using temp file"
-        if tmux load-buffer "$tmpfile"; then rm -f "$tmpfile"; return 0; else rm -f "$tmpfile"; return 1; fi
+        if tmux load-buffer -b "$buffer_name" "$tmpfile"; then rm -f "$tmpfile"; return 0; else rm -f "$tmpfile"; return 1; fi
     else
-        printf '%s' "$content" | tmux load-buffer -
+        printf '%s' "$content" | tmux load-buffer -b "$buffer_name" -
     fi
 }
 
@@ -424,28 +438,35 @@ ${_prompt_ref}"
 # Returns 0 on success, 1 on failure.
 _DDT_FAILED_SUBSTEP=""
 _ddt_send_content() {
-    local target_pane="$1" provider="$2" skill_command="$3" complete_prompt="$4"
+    local target_pane="$1" provider="$2" skill_command="$3" complete_prompt="$4" dispatch_id="$5"
     _DDT_FAILED_SUBSTEP=""
 
+    # OI-1144: one named buffer per delivery, shared by load+paste, deleted on
+    # every exit path so the buffer stack never accumulates. Retries re-address
+    # the SAME name, so a retry can never pick up another delivery's content.
+    local buf_name
+    buf_name=$(_ddt_buffer_name "$dispatch_id")
+
     if [[ "$provider" == "codex_cli" || "$provider" == "codex" ]]; then
-        if ! tmux_retry 3 tmux_load_buffer_safe "${skill_command}${complete_prompt}"; then
-            _DDT_FAILED_SUBSTEP="load_buffer"; log "V8 ERROR: Failed to load prompt to tmux buffer (3 attempts)"; return 1
+        if ! tmux_retry 3 tmux_load_buffer_safe "$buf_name" "${skill_command}${complete_prompt}"; then
+            _DDT_FAILED_SUBSTEP="load_buffer"; log "V8 ERROR: Failed to load prompt to tmux buffer (3 attempts)"; tmux delete-buffer -b "$buf_name" 2>/dev/null || true; return 1
         fi
-        if ! tmux_retry 3 tmux paste-buffer -t "$target_pane"; then
-            _DDT_FAILED_SUBSTEP="paste_buffer"; log "V8 ERROR: Failed to paste prompt to terminal $target_pane"; return 1
+        if ! tmux_retry 3 tmux paste-buffer -b "$buf_name" -t "$target_pane"; then
+            _DDT_FAILED_SUBSTEP="paste_buffer"; log "V8 ERROR: Failed to paste prompt to terminal $target_pane"; tmux delete-buffer -b "$buf_name" 2>/dev/null || true; return 1
         fi
     else
         if ! tmux_retry 3 tmux_send_best_effort "$target_pane" -l "$skill_command"; then
-            _DDT_FAILED_SUBSTEP="send_skill"; log "V8 ERROR: Failed to send skill command to terminal $target_pane"; return 1
+            _DDT_FAILED_SUBSTEP="send_skill"; log "V8 ERROR: Failed to send skill command to terminal $target_pane"; tmux delete-buffer -b "$buf_name" 2>/dev/null || true; return 1
         fi
         sleep 0.5
-        if ! tmux_retry 3 tmux_load_buffer_safe "$complete_prompt"; then
-            _DDT_FAILED_SUBSTEP="load_buffer"; log "V8 ERROR: Failed to load prompt to tmux buffer (3 attempts)"; return 1
+        if ! tmux_retry 3 tmux_load_buffer_safe "$buf_name" "$complete_prompt"; then
+            _DDT_FAILED_SUBSTEP="load_buffer"; log "V8 ERROR: Failed to load prompt to tmux buffer (3 attempts)"; tmux delete-buffer -b "$buf_name" 2>/dev/null || true; return 1
         fi
-        if ! tmux_retry 3 tmux paste-buffer -t "$target_pane"; then
-            _DDT_FAILED_SUBSTEP="paste_buffer"; log "V8 ERROR: Failed to paste prompt to terminal $target_pane"; return 1
+        if ! tmux_retry 3 tmux paste-buffer -b "$buf_name" -t "$target_pane"; then
+            _DDT_FAILED_SUBSTEP="paste_buffer"; log "V8 ERROR: Failed to paste prompt to terminal $target_pane"; tmux delete-buffer -b "$buf_name" 2>/dev/null || true; return 1
         fi
     fi
+    tmux delete-buffer -b "$buf_name" 2>/dev/null || true
     return 0
 }
 
@@ -575,7 +596,7 @@ deliver_dispatch_to_terminal() {
 
     log "V8 DISPATCH: Activating skill '${skill_command}' + pasting instruction"
 
-    if ! _ddt_send_content "$target_pane" "$provider" "$skill_command" "$complete_prompt"; then
+    if ! _ddt_send_content "$target_pane" "$provider" "$skill_command" "$complete_prompt" "$dispatch_id"; then
         _ddt_handle_failure "$dispatch_file" "$dispatch_id" "$terminal_id" "$provider" "$_DDT_FAILED_SUBSTEP"
         return 1
     fi

--- a/scripts/lib/receipt_processor/rp_delivery.sh
+++ b/scripts/lib/receipt_processor/rp_delivery.sh
@@ -50,17 +50,29 @@ _rpd_paste_and_verify() {
     local message="$2"
     local log_label="$3"
 
+    # OI-1144: named buffer (pid + delivery label) instead of tmux's anonymous
+    # "most recent buffer" stack. Two simultaneous deliveries racing to
+    # load-buffer/paste-buffer otherwise cross each other's content (a TOCTOU
+    # on shared server state — same mechanism fixed in tmux_adapter OI-1136 and
+    # tmux_interactive_dispatch OI-1126). pid alone already separates concurrent
+    # processes; the sanitized label keeps the name unique across dispatches
+    # within one process and makes it greppable. The buffer is deleted after
+    # use so a long-running processor never accumulates one per delivery.
+    local buf_name="rpd_$$_${log_label//[^a-zA-Z0-9_]/_}"
+
     # finding 1a: check every tmux call's exit code. A failed load-buffer or
     # send-keys means the paste never happened (or Enter never landed) — the
     # item must stay pending, not fall through to submit-verify on a no-op.
-    if ! echo "$message" | tmux load-buffer - 2>/dev/null; then
+    if ! echo "$message" | tmux load-buffer -b "$buf_name" - 2>/dev/null; then
         log "ERROR" "Failed to load-buffer for T0 pane $t0_pane ($log_label)"
         return 1
     fi
-    if ! tmux paste-buffer -t "$t0_pane" 2>/dev/null; then
+    if ! tmux paste-buffer -b "$buf_name" -t "$t0_pane" 2>/dev/null; then
+        tmux delete-buffer -b "$buf_name" 2>/dev/null || true
         log "ERROR" "Failed to paste to T0 pane $t0_pane ($log_label)"
         return 1
     fi
+    tmux delete-buffer -b "$buf_name" 2>/dev/null || true
 
     sleep 1
     if ! tmux send-keys -t "$t0_pane" Enter 2>/dev/null; then

--- a/scripts/lib/tmux_interactive_dispatch.py
+++ b/scripts/lib/tmux_interactive_dispatch.py
@@ -14,6 +14,7 @@ binary. No Anthropic SDK is imported anywhere in this module.
 
 from __future__ import annotations
 
+import copy
 import json
 import logging
 import os
@@ -446,7 +447,78 @@ def _worker_scope_hook_entry() -> dict:
     }
 
 
-def _write_worker_scope_hook_settings(worktree_root: Path) -> Path:
+def _permissions_from_file(settings_file: Path) -> "dict | None":
+    """Return the ``permissions`` block of *settings_file*, or None.
+
+    Fail-open: an unreadable or malformed main-checkout settings file must not
+    abort the hook write — the hook is fail-open anyway, so a corrupt source
+    degrades to "nothing to merge" with a warning.
+    """
+    if not settings_file.exists():
+        return None
+    try:
+        data = json.loads(settings_file.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        logger.warning(
+            "interactive: worker-scope hook settings: could not read %s for "
+            "permissions merge; skipping",
+            settings_file,
+        )
+        return None
+    if not isinstance(data, dict):
+        return None
+    permissions = data.get("permissions")
+    return copy.deepcopy(permissions) if isinstance(permissions, dict) else None
+
+
+def _merge_permissions_into(target: dict, source: dict) -> None:
+    """Deep-merge *source* into *target* in place (source supplements target).
+
+    Rule lists (allow/deny/ask) are UNIONed target-first; nested dicts recurse;
+    any other value is taken from *source* (local overrides tracked). Used to
+    fold the gitignored settings.local.json permissions over the tracked
+    settings.json permissions in the main checkout.
+    """
+    for key, value in source.items():
+        if key not in target:
+            target[key] = copy.deepcopy(value)
+            continue
+        existing = target[key]
+        if isinstance(existing, list) and isinstance(value, list):
+            for item in value:
+                if item not in existing:
+                    existing.append(item)
+        elif isinstance(existing, dict) and isinstance(value, dict):
+            _merge_permissions_into(existing, value)
+        else:
+            target[key] = copy.deepcopy(value)
+
+
+def _read_main_checkout_permissions(main_checkout_root: Path) -> "dict | None":
+    """Collect the main checkout's project ``permissions`` block (OI-1161).
+
+    A fresh dispatch worktree receives the tracked ``.claude/settings.json`` via
+    ``git worktree add`` but NOT the gitignored ``.claude/settings.local.json``.
+    Both are folded together (local supplements tracked) so the worktree worker
+    keeps every permission it would have had in the main checkout. Returns None
+    when neither file carries a ``permissions`` block, so the write degrades to
+    hook-only.
+    """
+    merged: "dict | None" = None
+    for filename in ("settings.json", "settings.local.json"):
+        perms = _permissions_from_file(main_checkout_root / ".claude" / filename)
+        if perms is None:
+            continue
+        if merged is None:
+            merged = copy.deepcopy(perms)
+        else:
+            _merge_permissions_into(merged, perms)
+    return merged
+
+
+def _write_worker_scope_hook_settings(
+    worktree_root: Path, main_checkout_root: "Path | None" = None
+) -> Path:
     """Register the worker-scope PreToolUse enforcement hook in a dispatch worktree.
 
     Writes/merges ``.claude/settings.local.json`` (gitignored; spike-proven to be
@@ -461,6 +533,13 @@ def _write_worker_scope_hook_settings(worktree_root: Path) -> Path:
 
     Idempotent: an identical hook command is never registered twice. Existing
     unrelated keys and hook entries in the file are preserved.
+
+    OI-1161: also carries over the ``permissions`` block from
+    *main_checkout_root* (None → hook-only, the pre-fix behaviour) so a worktree
+    worker keeps the project permissions it would have in the main checkout. The
+    hook configuration written here wins: main-checkout permissions only fill in
+    when the worktree file does not already define ``permissions``, and a key
+    present in both is surfaced via a warning rather than silently resolved.
 
     Returns the settings file path written.
     """
@@ -489,6 +568,20 @@ def _write_worker_scope_hook_settings(worktree_root: Path) -> Path:
     )
     if not already_registered:
         pre_tool_use.append(_worker_scope_hook_entry())
+
+    # OI-1161: fill in the main checkout's permissions (hook wins on conflict).
+    if main_checkout_root is not None:
+        main_permissions = _read_main_checkout_permissions(main_checkout_root)
+        if main_permissions is not None:
+            if "permissions" in data:
+                logger.warning(
+                    "interactive: worker-scope hook settings: 'permissions' exists "
+                    "in both the worktree settings.local.json and the main "
+                    "checkout; keeping the worktree value (hook wins) and NOT "
+                    "merging the main-checkout permissions"
+                )
+            else:
+                data["permissions"] = main_permissions
 
     settings_path.parent.mkdir(parents=True, exist_ok=True)
     tmp_path = settings_path.with_suffix(settings_path.suffix + ".tmp")
@@ -2630,7 +2723,10 @@ class TmuxInteractiveDispatch:
                 # from the first tool call. Best-effort: the hook is fail-open
                 # anyway, so a failed write must never abort the dispatch.
                 try:
-                    _write_worker_scope_hook_settings(Path(cwd))
+                    # OI-1161: pass the main checkout root so the worktree's
+                    # settings.local.json also carries the project permissions a
+                    # worker would have had in the main checkout.
+                    _write_worker_scope_hook_settings(Path(cwd), self._project_root)
                     # OI-804 (ADR-005 audit gap): a successful state mutation —
                     # the settings.local.json registration — emits a coordination
                     # event so the write lands in the audit trail. Best-effort

--- a/tests/test_dispatch_deliver_named_buffer.sh
+++ b/tests/test_dispatch_deliver_named_buffer.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+# OI-1144: _ddt_send_content / tmux_load_buffer_safe must address a NAMED tmux
+# buffer (pid + dispatch_id) and delete it afterwards, so two simultaneous
+# deliveries can never cross on tmux's anonymous "most recent buffer" stack.
+#
+# NOTE: this asserts the ARGV the functions build (a unique -b <name> shared by
+# load+paste and removed by delete-buffer), NOT a live two-process tmux race —
+# a shell function is sequential, so the crossing can't be reproduced in-process.
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+PASS_COUNT=0
+FAIL_COUNT=0
+pass() { echo "PASS: $1"; PASS_COUNT=$((PASS_COUNT + 1)); }
+fail() { echo "FAIL: $1 — $2"; FAIL_COUNT=$((FAIL_COUNT + 1)); }
+assert_eq() {
+    local expected="$1" actual="$2" msg="$3"
+    if [ "$expected" = "$actual" ]; then pass "$msg"; else fail "$msg" "expected='$expected' actual='$actual'"; fi
+}
+
+TMP_ROOT=$(mktemp -d)
+MOCK_ARGV_LOG="$TMP_ROOT/mock_argv"
+touch "$MOCK_ARGV_LOG"
+
+# Runtime deps of tmux_load_buffer_safe / _ddt_send_content.
+VNX_DISPATCH_MAX_INLINE=50000
+VNX_DISPATCH_PAYLOAD_DIR="$TMP_ROOT/payload"
+
+log() { :; }
+tmux_retry() { local max_attempts="$1"; shift; "$@"; }
+tmux_send_best_effort() { return 0; }
+
+# tmux mock: record the full argv of every call; always succeed.
+tmux() {
+    echo "$*" >> "$MOCK_ARGV_LOG"
+    return 0
+}
+
+# shellcheck disable=SC1091
+source "$PROJECT_ROOT/scripts/lib/dispatch_deliver.sh"
+
+_buf_name() {
+    sed -n 's/.*-b \([^ ]*\).*/\1/p'
+}
+
+# ===========================================================================
+# Test 1: codex path — one named buffer, same name on load+paste, deleted after
+# ===========================================================================
+_ddt_send_content "pane1" "codex" "/model" "hello" "dispatch-1144"
+
+assert_eq "1" "$(grep -c '^load-buffer ' "$MOCK_ARGV_LOG")" \
+    "D1 (OI-1144): codex path loads exactly once"
+assert_eq "1" "$(grep -c '^paste-buffer ' "$MOCK_ARGV_LOG")" \
+    "D1 (OI-1144): codex path pastes exactly once"
+LOAD_NAME=$(grep '^load-buffer ' "$MOCK_ARGV_LOG" | _buf_name)
+PASTE_NAME=$(grep '^paste-buffer ' "$MOCK_ARGV_LOG" | _buf_name)
+assert_eq "$LOAD_NAME" "$PASTE_NAME" \
+    "D1 (OI-1144): load and paste address the SAME named buffer"
+assert_eq "1" "$(grep -c "^delete-buffer -b ${LOAD_NAME}" "$MOCK_ARGV_LOG")" \
+    "D1 (OI-1144): buffer is deleted after use"
+assert_eq "0" "$(grep -c '^load-buffer -$' "$MOCK_ARGV_LOG")" \
+    "D1 (OI-1144): no fallback to the anonymous '-' stack"
+
+# ===========================================================================
+# Test 2: non-codex path — same named-buffer discipline after the skill send
+# ===========================================================================
+: > "$MOCK_ARGV_LOG"
+_ddt_send_content "pane2" "claude_code" "/skill" "body" "dispatch-1144"
+
+LOAD_NAME2=$(grep '^load-buffer ' "$MOCK_ARGV_LOG" | _buf_name)
+PASTE_NAME2=$(grep '^paste-buffer ' "$MOCK_ARGV_LOG" | _buf_name)
+assert_eq "1" "$(grep -c '^load-buffer ' "$MOCK_ARGV_LOG")" \
+    "D2 (OI-1144): claude path loads exactly once"
+assert_eq "$LOAD_NAME2" "$PASTE_NAME2" \
+    "D2 (OI-1144): claude path load+paste share the named buffer"
+assert_eq "1" "$(grep -c "^delete-buffer -b ${LOAD_NAME2}" "$MOCK_ARGV_LOG")" \
+    "D2 (OI-1144): claude path deletes the buffer after use"
+
+# ===========================================================================
+# Test 3: two deliveries with distinct dispatch ids build DISTINCT buffer names
+# (argv evidence that simultaneous crossings are structurally impossible)
+# ===========================================================================
+: > "$MOCK_ARGV_LOG"
+_ddt_send_content "paneA" "claude_code" "/skill" "body-A" "dispatch-A"
+_ddt_send_content "paneB" "claude_code" "/skill" "body-B" "dispatch-B"
+
+DISTINCT_NAMES=$(grep '^load-buffer ' "$MOCK_ARGV_LOG" | _buf_name | sort -u)
+assert_eq "2" "$(printf '%s\n' "$DISTINCT_NAMES" | wc -l | tr -d ' ')" \
+    "D3 (OI-1144): two deliveries build two DISTINCT buffer names (argv, not a live race)"
+
+# --- Cleanup ---
+rm -rf "$TMP_ROOT"
+
+echo ""
+echo "=== dispatch_deliver named-buffer test results: $PASS_COUNT passed, $FAIL_COUNT failed ==="
+[ "$FAIL_COUNT" -eq 0 ] || exit 1

--- a/tests/test_heartbeat_ack_named_buffer.py
+++ b/tests/test_heartbeat_ack_named_buffer.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+"""OI-1144 regression: heartbeat_ack_monitor._notify_t0_ack must use a NAMED
+tmux buffer (pid + dispatch_id) and delete it afterwards, so two simultaneous
+ACKs can't cross on tmux's anonymous "most recent buffer" stack.
+
+This asserts the argv built for ``tmux load-buffer`` / ``paste-buffer`` /
+``delete-buffer`` (a unique ``-b <name>`` shared by load+paste and removed by
+delete), not a live two-process tmux race.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest.mock import patch
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPTS_DIR))
+sys.path.insert(0, str(SCRIPTS_DIR / "lib"))
+
+
+def _make_monitor():
+    from heartbeat_ack_monitor import HeartbeatACKMonitor
+
+    monitor = object.__new__(HeartbeatACKMonitor)
+    monitor._get_t0_pane_id = lambda: "%0"
+    return monitor
+
+
+def _run_notify(monitor, dispatch_id):
+    """Run _notify_t0_ack once, returning the recorded tmux argv list."""
+    import heartbeat_ack_monitor as ham
+
+    calls = []
+
+    class _Result:
+        returncode = 0
+
+    def fake_run(cmd, **kwargs):
+        calls.append(list(cmd))
+        return _Result()
+
+    with patch.object(ham.subprocess, "run", side_effect=fake_run), patch.object(
+        ham.time, "sleep"
+    ):
+        monitor._notify_t0_ack(
+            {"terminal": "T1", "dispatch_id": dispatch_id},
+            signals=[],
+        )
+    return calls
+
+
+def _name(cmd):
+    assert "-b" in cmd, f"expected -b named-buffer flag in {cmd}"
+    return cmd[cmd.index("-b") + 1]
+
+
+def test_notify_t0_ack_uses_named_buffer_and_deletes_it():
+    monitor = _make_monitor()
+    calls = _run_notify(monitor, "dispatch-A")
+
+    loads = [c for c in calls if c[1] == "load-buffer"]
+    pastes = [c for c in calls if c[1] == "paste-buffer"]
+    deletes = [c for c in calls if c[1] == "delete-buffer"]
+    assert len(loads) == 1
+    assert len(pastes) == 1
+    assert len(deletes) == 1
+    # Load, paste and delete must address the SAME named buffer.
+    assert _name(loads[0]) == _name(pastes[0]) == _name(deletes[0])
+    # The sanitized dispatch_id is folded into the name, so two dispatches
+    # cannot collide even within one process.
+    assert "dispatch_A" in _name(loads[0])
+
+
+def test_two_acks_build_distinct_buffer_names():
+    monitor = _make_monitor()
+    names = []
+    for dispatch_id in ("dispatch-A", "dispatch-B"):
+        calls = _run_notify(monitor, dispatch_id)
+        loads = [c for c in calls if c[1] == "load-buffer"]
+        names.append(_name(loads[0]))
+    assert names[0] != names[1]

--- a/tests/test_rp_delivery_gates.sh
+++ b/tests/test_rp_delivery_gates.sh
@@ -50,16 +50,17 @@ mkdir -p "$STATE_DIR" "$RECEIPTS_PENDING_DIR" "$RECEIPTS_PROCESSED_DIR"
 touch "$PROCESSING_LOG"
 
 MOCK_CALL_LOG="$TMP_ROOT/mock_calls"
+MOCK_ARGV_LOG="$TMP_ROOT/mock_argv"
 MOCK_LOADED_BUFFER="$TMP_ROOT/mock_loaded_buffer"
 MOCK_PASTE_FAIL_FLAG="$TMP_ROOT/mock_paste_fail"
 MOCK_LOADBUFFER_FAIL_FLAG="$TMP_ROOT/mock_loadbuffer_fail"
 MOCK_CAPTURE_RESPONSE_FILE="$TMP_ROOT/mock_capture_response"
-touch "$MOCK_CALL_LOG" "$MOCK_CAPTURE_RESPONSE_FILE"
+touch "$MOCK_CALL_LOG" "$MOCK_ARGV_LOG" "$MOCK_CAPTURE_RESPONSE_FILE"
 
 reset_mocks() {
-    rm -f "$MOCK_CALL_LOG" "$MOCK_LOADED_BUFFER" "$MOCK_PASTE_FAIL_FLAG" "$MOCK_LOADBUFFER_FAIL_FLAG"
+    rm -f "$MOCK_CALL_LOG" "$MOCK_ARGV_LOG" "$MOCK_LOADED_BUFFER" "$MOCK_PASTE_FAIL_FLAG" "$MOCK_LOADBUFFER_FAIL_FLAG"
     : > "$MOCK_CAPTURE_RESPONSE_FILE"
-    touch "$MOCK_CALL_LOG"
+    touch "$MOCK_CALL_LOG" "$MOCK_ARGV_LOG"
     rm -rf "${RECEIPTS_PENDING_DIR:?}"/* "${RECEIPTS_PROCESSED_DIR:?}"/* 2>/dev/null
     unset VNX_RECEIPT_T0_PUSH VNX_RECEIPT_DIGEST_THRESHOLD VNX_RECEIPT_VERIFY_MAX_RETRIES
 }
@@ -87,6 +88,11 @@ get_pane_id_smart() { echo "test:0.0"; }
 tmux() {
     local subcmd="$1"
     echo "$subcmd" >> "$MOCK_CALL_LOG"
+    # Full argv log (OI-1144): lets the named-buffer tests assert that
+    # load-buffer/paste-buffer carry the SAME -b <name> and that delete-buffer
+    # removes it, without disturbing the existing subcommand-only $MOCK_CALL_LOG
+    # assertions elsewhere in this file.
+    echo "$*" >> "$MOCK_ARGV_LOG"
     case "$subcmd" in
         load-buffer)
             if [ -f "$MOCK_LOADBUFFER_FAIL_FLAG" ]; then
@@ -378,6 +384,50 @@ for n in 1 2 3 4 5 6; do
 done
 assert_eq "1" "$IDLIST_ALL_PRESENT" \
     "T10: digest message lists all 6 pending dispatch_ids (under the 10-id cap)"
+
+# ===========================================================================
+# Test 11 (OI-1144, push=1): load-buffer/paste-buffer address a NAMED buffer,
+# the same name on both, and delete-buffer removes it afterwards
+# ===========================================================================
+reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
+write_pending "d-1144-1.json" "d-1144"
+set_capture_response ""
+_retry_pending_receipts
+
+assert_eq "1" "$(grep -c '^load-buffer -b ' "$MOCK_ARGV_LOG")" \
+    "T11 (OI-1144): load-buffer carries a -b <name>"
+assert_eq "1" "$(grep -c '^paste-buffer -b ' "$MOCK_ARGV_LOG")" \
+    "T11 (OI-1144): paste-buffer carries a -b <name>"
+
+LOAD_BUF_NAME=$(grep '^load-buffer ' "$MOCK_ARGV_LOG" | sed -n 's/.*-b \([^ ]*\).*/\1/p')
+PASTE_BUF_NAME=$(grep '^paste-buffer ' "$MOCK_ARGV_LOG" | sed -n 's/.*-b \([^ ]*\).*/\1/p')
+assert_eq "$LOAD_BUF_NAME" "$PASTE_BUF_NAME" \
+    "T11 (OI-1144): load and paste address the SAME buffer name"
+assert_eq "1" "$(grep -c "^delete-buffer -b ${LOAD_BUF_NAME}" "$MOCK_ARGV_LOG")" \
+    "T11 (OI-1144): buffer is deleted after use (no stack accumulation)"
+unset VNX_RECEIPT_T0_PUSH
+
+# ===========================================================================
+# Test 12 (OI-1144, argv-opbouw): two deliveries build two DISTINCT buffer
+# names, so a simultaneous crossing is structurally impossible. NOTE: this
+# asserts the argv (distinct names), NOT a live tmux race — the shell can't
+# run two deliveries truly concurrently in one process.
+# ===========================================================================
+reset_mocks
+export VNX_RECEIPT_T0_PUSH=1
+write_pending "d-a-1.json" "dispatch-A"
+write_pending "d-b-1.json" "dispatch-B"
+set_capture_response ""
+_retry_pending_receipts
+
+DISTINCT_LOAD_NAMES=$(grep '^load-buffer ' "$MOCK_ARGV_LOG" | sed -n 's/.*-b \([^ ]*\).*/\1/p' | sort -u)
+assert_eq "2" "$(printf '%s\n' "$DISTINCT_LOAD_NAMES" | wc -l | tr -d ' ')" \
+    "T12 (OI-1144): two deliveries build two DISTINCT buffer names (argv, not a live race)"
+# Every load-buffer carries an explicit -b: none may fall back to the anonymous stack.
+assert_eq "0" "$(grep -c '^load-buffer -$' "$MOCK_ARGV_LOG")" \
+    "T12 (OI-1144): no load-buffer falls back to the anonymous '-' stack"
+unset VNX_RECEIPT_T0_PUSH
 
 # --- Cleanup ---
 rm -rf "$TMP_ROOT"

--- a/tests/test_tmux_interactive_dispatch.py
+++ b/tests/test_tmux_interactive_dispatch.py
@@ -5700,6 +5700,105 @@ class TestWorkerScopeHookSettingsWiring(_LaneTestCase):
         ]
         self.assertEqual(len(ours), 1, "hook must be registered exactly once (idempotent)")
 
+    def test_write_hook_settings_carries_main_checkout_permissions(self):
+        """OI-1161: the worktree settings.local.json carries the main checkout's
+        permissions block alongside the worker-scope hook."""
+        from tmux_interactive_dispatch import _write_worker_scope_hook_settings
+
+        main = self.state_dir / "main-checkout"
+        (main / ".claude").mkdir(parents=True)
+        (main / ".claude" / "settings.json").write_text(
+            json.dumps(
+                {
+                    "permissions": {
+                        "allow": ["Skill(database-engineer)", "Skill(debugger)"],
+                        "ask": ["Bash(git push:*)"],
+                    }
+                }
+            ),
+            encoding="utf-8",
+        )
+
+        wt = self.state_dir / "wt-perm"
+        wt.mkdir()
+        settings_path = _write_worker_scope_hook_settings(wt, main)
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        # Hook still registered.
+        hook_commands = [
+            h.get("command", "")
+            for e in data["hooks"]["PreToolUse"]
+            for h in e.get("hooks", [])
+        ]
+        self.assertTrue(
+            any("pretooluse_worker_scope_enforce.sh" in c for c in hook_commands)
+        )
+        # Permissions carried over verbatim.
+        self.assertEqual(
+            data["permissions"]["allow"],
+            ["Skill(database-engineer)", "Skill(debugger)"],
+        )
+        self.assertEqual(data["permissions"]["ask"], ["Bash(git push:*)"])
+
+    def test_write_hook_settings_hook_wins_on_permissions_conflict(self):
+        """OI-1161: a permissions key present in BOTH the worktree settings and
+        the main checkout → the worktree (hook) value wins and the conflict is
+        surfaced via a warning, never silently resolved."""
+        from tmux_interactive_dispatch import _write_worker_scope_hook_settings
+
+        main = self.state_dir / "main-checkout"
+        (main / ".claude").mkdir(parents=True)
+        (main / ".claude" / "settings.json").write_text(
+            json.dumps({"permissions": {"allow": ["Skill(main-only)"]}}),
+            encoding="utf-8",
+        )
+
+        wt = self.state_dir / "wt-conflict"
+        (wt / ".claude").mkdir(parents=True)
+        (wt / ".claude" / "settings.local.json").write_text(
+            json.dumps({"permissions": {"allow": ["Skill(worktree-only)"]}}),
+            encoding="utf-8",
+        )
+
+        with self.assertLogs("tmux_interactive_dispatch", level="WARNING") as cm:
+            settings_path = _write_worker_scope_hook_settings(wt, main)
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        # Worktree (hook) side wins: main's entry is not merged in.
+        self.assertEqual(data["permissions"]["allow"], ["Skill(worktree-only)"])
+        self.assertNotIn("Skill(main-only)", data["permissions"]["allow"])
+        # The conflict is visible in the log output.
+        self.assertTrue(
+            any("permissions" in msg and "hook wins" in msg for msg in cm.output),
+            f"conflict warning not emitted: {cm.output}",
+        )
+
+    def test_write_hook_settings_main_without_permissions_is_hook_only(self):
+        """OI-1161: a main checkout with no permissions block → hook-only, no
+        crash (the pre-fix behaviour is preserved)."""
+        from tmux_interactive_dispatch import _write_worker_scope_hook_settings
+
+        main = self.state_dir / "main-empty"
+        (main / ".claude").mkdir(parents=True)
+        (main / ".claude" / "settings.json").write_text(
+            '{"someOtherKey": true}', encoding="utf-8"
+        )
+
+        wt = self.state_dir / "wt-hookonly"
+        wt.mkdir()
+        settings_path = _write_worker_scope_hook_settings(wt, main)
+
+        data = json.loads(settings_path.read_text(encoding="utf-8"))
+        self.assertNotIn("permissions", data)
+        hook_commands = [
+            h.get("command", "")
+            for e in data["hooks"]["PreToolUse"]
+            for h in e.get("hooks", [])
+        ]
+        self.assertTrue(
+            any("pretooluse_worker_scope_enforce.sh" in c for c in hook_commands)
+        )
+
     def test_write_hook_settings_corrupt_file_raises(self):
         from tmux_interactive_dispatch import _write_worker_scope_hook_settings
 


### PR DESCRIPTION
## Summary

Sluit twee spawn-adjacente gaten.

**OI-1144** — `rp_delivery.sh`, `dispatch_deliver.sh` en `heartbeat_ack_monitor.py` gebruikten tmux's anonieme `load-buffer`/`paste-buffer`-stack. Twee gelijktijdige leveringen konden elkaars content plakken (TOCTOU op gedeelde server-state). Elke gebruiker leidt nu een unieke named buffer af (pid + gesanitiseerde dispatch-id) en ruimt die na gebruik op.

**OI-1161** — `_write_worker_scope_hook_settings` draagt nu het `permissions`-blok van de main checkout over naar de `settings.local.json` van de worktree. Hook-config wint bij conflict (zichtbaar via een warning, nooit stil opgelost); main-permissions vullen alleen in als de worktree de key niet heeft. Verkleint maar sluit niet OI-1208 (scoped worker hangt op onbeantwoordbare permission-prompt).

## Changes

- `scripts/lib/receipt_processor/rp_delivery.sh` — `_rpd_paste_and_verify` gebruikt `rpd_$$_<label>` als named buffer, delete na gebruik (succes en faalpad).
- `scripts/lib/dispatch_deliver.sh` — `_ddt_buffer_name` (pid + dispatch-id), `tmux_load_buffer_safe` adresseert de named buffer, `_ddt_send_content` delete op elk exitpad.
- `scripts/heartbeat_ack_monitor.py` — `_notify_t0_ack` gebruikt `vnx-ack-<pid>-<dispatch_id>`, delete in `finally`.
- `scripts/lib/tmux_interactive_dispatch.py` — `_permissions_from_file`, `_merge_permissions_into`, `_read_main_checkout_permissions`; `_write_worker_scope_hook_settings` krijgt `main_checkout_root` en merged permissions (hook wint, conflict wordt gelogd).
- Tests toegevoegd/uitgebreid in `tests/test_rp_delivery_gates.sh`, `tests/test_dispatch_deliver_named_buffer.sh` (nieuw), `tests/test_heartbeat_ack_named_buffer.py` (nieuw), `tests/test_tmux_interactive_dispatch.py`.

## Verification

- `bash tests/test_rp_delivery_gates.sh` — 48 passed, 0 failed
- `bash tests/test_dispatch_deliver_named_buffer.sh` — 9 passed, 0 failed
- `python3 -m pytest tests/test_heartbeat_ack_named_buffer.py tests/test_tmux_interactive_dispatch.py::TestWorkerScopeHookSettingsWiring -q` — 14 passed

De named-buffer-tests toetsen de argv-opbouw (unieke `-b <name>` gedeeld door load+paste, verwijderd door delete), niet een live twee-process tmux-race: een shell-functie is sequentieel, dus de crossing is niet in-process reproduceerbaar.

## Open Items

Pre-existing failures, buiten scope van deze dispatch (bevestigd via `git show HEAD`, niet door deze diff):

- `tests/test_tmux_interactive_dispatch.py` — 3 failures (`name 'model' is not defined` in `_wait_for_receipt`, `build_process_gone_failure_report(model=model, ...)` staat al op HEAD).
- `tests/test_tmux_adapter.py` — 3 failures (`ModuleNotFoundError: No module named 'tmux_adapter_cli'`).

OI-1208 (scoped worker hangt op onbeantwoordbare permission-prompt) is verkleind maar niet gesloten: de merge vult nu de project-permissions aan, maar het permission-prompt-hangen zelf is een apart defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)