### PR TITLE
fix(providers): enforce zai constraint allowlists by registry key (OI-1217, OI-1205)

### DIFF
--- a/scripts/lib/constraint_enforcer.py
+++ b/scripts/lib/constraint_enforcer.py
@@ -44,6 +44,52 @@ def _load_yaml(path: Path) -> Dict[str, Any]:
     return data
 
 
+def _registry_key_for(provider: Optional[str], sub_provider: Optional[str]) -> Optional[str]:
+    """Resolve a provider string to its wave7_models.yaml registry key.
+
+    Mirrors providers.constraint_enforcer._registry_key_for (ADR-036): provider
+    identity is read from the registry, never from a literal string match, so an
+    allowlist on provider cannot be sidestepped by a different provider string
+    that routes to the same models (OI-1217 — glm-harness/litellm:zai -> zai).
+    """
+    raw = (provider or "").strip().lower()
+    if raw.startswith("litellm:"):
+        parts = raw.split(":", 2)
+        base, sub = "litellm", (parts[1] if len(parts) > 1 and parts[1] else sub_provider)
+    else:
+        base, sub = raw, sub_provider
+    base_norm = (base or "").lower()
+    sub_norm = (sub or "").lower()
+    if base_norm == "claude":
+        return "anthropic"
+    if base_norm == "codex":
+        return "openai"
+    if base_norm == "gemini":
+        return "google"
+    if base_norm == "kimi":
+        return "kimi_cli"
+    if base_norm in ("deepseek-harness", "deepseek_harness"):
+        return "deepseek_harness"
+    if base_norm in ("glm-harness", "glm_harness"):
+        return "zai"
+    if base_norm == "litellm":
+        return sub_norm or None
+    return base_norm.replace("-", "_") or None
+
+
+def _provider_identity_matches(
+    provider: Optional[str],
+    sub_provider: Optional[str],
+    spec_provider: str,
+) -> bool:
+    """Match provider identity by registry key, not literal string (see above)."""
+    spec_key = _registry_key_for(str(spec_provider), None)
+    actual_key = _registry_key_for(provider, sub_provider)
+    if spec_key is None or actual_key is None:
+        return False
+    return actual_key == spec_key
+
+
 class ConstraintEnforcer:
     """Loads and enforces provider constraints at dispatch pre-flight."""
 
@@ -103,7 +149,7 @@ class ConstraintEnforcer:
                     logger.warning("[%s] %s", cid, msg)
 
             elif rule == "require_route":
-                if self._check_require_route(c, provider, sub_provider, model, terminal_id, role):
+                if self._check_require_route(c, provider, sub_provider, model, terminal_id, role, via):
                     if self._is_overridden(c):
                         logger.warning("Constraint %s overridden by env var", cid)
                         continue
@@ -157,6 +203,7 @@ class ConstraintEnforcer:
         model: Optional[str],
         terminal_id: Optional[str],
         role: Optional[str],
+        via: Optional[str],
     ) -> bool:
         """Return True if the constraint is violated (required route NOT met)."""
         rr = constraint.get("required_route", {})
@@ -165,19 +212,20 @@ class ConstraintEnforcer:
 
         spec_provider = rr.get("provider")
         if spec_provider:
-            if provider and provider.lower() in self._NATIVE_CLI_PROVIDERS:
-                if not self._match_value(provider, spec_provider):
-                    return False
-            else:
-                effective_provider = sub_provider or provider
-                if not self._match_value(effective_provider, spec_provider):
-                    return False
+            if not _provider_identity_matches(provider, sub_provider, str(spec_provider)):
+                return False
 
         spec_role = rr.get("role")
         if spec_role:
             effective_role = terminal_id or role
             if not self._match_value(effective_role, spec_role):
                 return False
+
+        spec_via = rr.get("via")
+        # Enforced only when the caller declares a via: an absent via is "route
+        # unspecified", not the forbidden direct route the allowlist refuses.
+        if spec_via and via is not None and not self._match_value(via, spec_via):
+            return True
 
         spec_model = rr.get("model")
         if spec_model:

--- a/scripts/lib/providers/constraint_enforcer.py
+++ b/scripts/lib/providers/constraint_enforcer.py
@@ -97,6 +97,28 @@ def _effective_provider(provider: Optional[str], sub_provider: Optional[str]) ->
     return sub or base
 
 
+def _provider_identity_matches(
+    provider: Optional[str],
+    sub_provider: Optional[str],
+    spec_provider: str,
+) -> bool:
+    """Match provider identity by wave7_models.yaml registry key, not literal string.
+
+    A provider string that routes to a known registry provider (glm-harness -> zai,
+    litellm:zai -> zai) must count as that provider even when it is not the exact
+    string the constraint names — otherwise an allowlist on provider+model is
+    sidestepped by presenting a different provider string that routes to the same
+    models (OI-1217). Resolving both sides through _registry_key_for is the
+    fail-closed form: every string that routes to the provider is covered, and a
+    new alias cannot silently slide past the allowlist.
+    """
+    spec_key = _registry_key_for(str(spec_provider), None)
+    actual_key = _registry_key_for(provider, sub_provider)
+    if spec_key is None or actual_key is None:
+        return _match_value(_effective_provider(provider, sub_provider), spec_provider)
+    return actual_key == spec_key
+
+
 def _route_forbidden(
     constraint: Mapping[str, Any],
     provider: Optional[str],
@@ -131,6 +153,7 @@ def _required_route_missing(
     model: Optional[str],
     terminal_id: Optional[str],
     role: Optional[str],
+    via: Optional[str],
 ) -> bool:
     required = constraint.get("required_route") or {}
     if not isinstance(required, Mapping):
@@ -138,7 +161,7 @@ def _required_route_missing(
 
     spec_provider = required.get("provider")
     if spec_provider:
-        if not _match_value(_effective_provider(provider, sub_provider), spec_provider):
+        if not _provider_identity_matches(provider, sub_provider, str(spec_provider)):
             return False
 
     spec_role = required.get("role")
@@ -146,6 +169,14 @@ def _required_route_missing(
         effective_role = terminal_id or role
         if not _match_value(effective_role, spec_role):
             return False
+
+    spec_via = required.get("via")
+    # A required via is enforced only when the caller declares one: an absent via
+    # is "route unspecified", not the forbidden direct route this allowlist exists
+    # to refuse. Production always stamps via (_via_for_provider /
+    # _constraint_via_for_provider), so this guard only relaxes direct test calls.
+    if spec_via and via is not None and not _match_value(via, spec_via):
+        return True
 
     spec_model = required.get("model")
     if spec_model and not _model_matches(model, spec_model):
@@ -527,7 +558,7 @@ class ConstraintEnforcer:
                         override_applied=override_applied,
                     )
             elif rule == "require_route":
-                if _required_route_missing(constraint, provider, sub_provider, model, terminal_id, role):
+                if _required_route_missing(constraint, provider, sub_provider, model, terminal_id, role, via):
                     violation = _violation_from_constraint(
                         constraint,
                         "Required route not met",

--- a/scripts/lib/providers/provider_constraints.yaml
+++ b/scripts/lib/providers/provider_constraints.yaml
@@ -14,7 +14,11 @@
 #                    keys: provider, model (str|list), role (str|list),
 #                          task_class (str|list), via (str)
 #   required_route   optional, used with rule=require_route
-#                    keys: provider, model, role (str|list)
+#                    keys: provider, model, role (str|list), via (str|list)
+#                    provider is a wave7_models.yaml registry key: the enforcer
+#                    resolves the incoming provider string to that key, so every
+#                    alias routing to the same provider (glm-harness, litellm:zai
+#                    -> zai) is covered without repeating the set in the YAML.
 #   forbidden_import optional, used with rule=forbid_import
 #                    keys: patterns (list of substrings or simple regex)
 #   reason           human-readable justification (cite memory ref or ADR)
@@ -107,16 +111,21 @@ constraints:
     override_allowed: false
 
   - id: zai-via-openrouter-only
-    rule: forbid_route
-    forbidden_route:
+    rule: require_route
+    required_route:
       provider: zai
-      via: direct
+      via: [openrouter, claude_harness_openrouter]
     reason: >-
       Native Zhipu integration is deferred. Wave 7 PR-7.3 routes GLM through
       OpenRouter; direct Zhipu API calls bypass the cost-tracking pipeline and
-      the fallback chain configured in routing_policy.yaml. Only GLM-5.2 is an
-      allowed version (deprecated-glm-models, operator directive 2026-08-03:
-      GLM-4.5/4.6/5/5.1 blocked).
+      the fallback chain configured in routing_policy.yaml. This is an allowlist,
+      not a blocklist: the zai provider may only reach OpenRouter via an approved
+      route (the plain openrouter runner or the claude-harness openrouter lane),
+      and the direct Zhipu API route is refused. A blocklist of one forbidden
+      route (via=direct) lets every route never listed through; routes are
+      structurally open-ended, so only an allowlist enforces the
+      one-approved-route decision. Admitting another route is a deliberate
+      one-line operator change to this via list.
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false
@@ -137,6 +146,10 @@ constraints:
       listed through; model versions are structurally open-ended, so only an
       allowlist enforces the one-approved-version decision. Admitting a newer
       version is a deliberate one-line operator change to this model value.
+      `provider: zai` is the wave7_models.yaml registry identity: the enforcer
+      resolves every provider string that routes to it (zai, litellm:zai,
+      glm-harness) to that key, so the allowlist cannot be sidestepped by
+      presenting a different provider string for the same models (OI-1217).
     enforcement: code_raise
     audit_severity: blocking
     override_allowed: false

--- a/tests/test_constraint_enforcer.py
+++ b/tests/test_constraint_enforcer.py
@@ -6,7 +6,7 @@ Covers every constraint in provider_constraints.yaml:
   - t0-opus-only            (require_route, warn, override)
   - workers-kimi-pinned     (require_route, warn, override)
   - no-anthropic-sdk        (forbid_import — warning at runtime)
-  - zai-via-openrouter-only (forbid_route, blocking)
+  - zai-via-openrouter-only (require_route allowlist, blocking)
   - deprecated-glm-models   (require_route allowlist, blocking)
   - deepseek-harness-subscription-blocked (forbid_route, blocking)
 
@@ -160,7 +160,7 @@ class TestNoAnthropicSdk:
 
 
 # ---------------------------------------------------------------------------
-# zai-via-openrouter-only — forbid_route provider=zai via=direct
+# zai-via-openrouter-only — require_route allowlist provider=zai via=[openrouter, claude_harness_openrouter]
 # ---------------------------------------------------------------------------
 
 class TestZaiViaOpenrouterOnly:
@@ -170,7 +170,7 @@ class TestZaiViaOpenrouterOnly:
             real_enforcer.enforce(provider="zai", via="direct")
 
     def test_zai_via_openrouter_allowed(self, real_enforcer: ConstraintEnforcer, monkeypatch):
-        # zai-via-openrouter-only permits openrouter (it forbids only DIRECT). The newer
+        # zai-via-openrouter-only is an allowlist over via: openrouter clears. The newer
         # glm-via-harness-only constraint would otherwise block plain litellm:zai entirely
         # (GLM must run via glm-harness); set its benchmark/legacy override to isolate the
         # constraint under test here. model=glm-5.2 clears the deprecated-glm-models
@@ -227,6 +227,92 @@ class TestDeprecatedGlmModels:
         """The allowlist is scoped to provider zai; a glm-named model on another
         provider is not this constraint's concern."""
         real_enforcer.enforce(provider="claude", model="glm-5.3")
+
+
+# ---------------------------------------------------------------------------
+# OI-1217 — the deprecated-glm-models allowlist must cover EVERY provider string
+# that routes to the zai registry provider (resolved via _registry_key_for), not
+# just the literal "zai" string named in the constraint.
+# ---------------------------------------------------------------------------
+
+ZAI_ROUTES = [
+    ("zai", None),
+    ("litellm:zai", None),
+    ("litellm", "zai"),
+    ("glm-harness", None),
+    ("glm-harness", "zai"),
+]
+
+
+class TestDeprecatedGlmModelsCoverAllZaiRoutes:
+
+    @pytest.mark.parametrize("provider,sub_provider", ZAI_ROUTES)
+    def test_deprecated_model_refused_on_every_zai_route(
+        self, real_enforcer: ConstraintEnforcer, provider, sub_provider
+    ):
+        """A non-allowed GLM version must be refused no matter which provider
+        string routes to zai (OI-1217)."""
+        for bad_model in ("glm-4.5", "glm-5", "glm-5.1", "glm-5.3"):
+            with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+                real_enforcer.enforce(
+                    provider=provider, sub_provider=sub_provider, model=bad_model
+                )
+
+    @pytest.mark.parametrize("provider,sub_provider", ZAI_ROUTES)
+    def test_glm52_allowed_on_every_zai_route(
+        self, real_enforcer: ConstraintEnforcer, provider, sub_provider
+    ):
+        """glm-5.2 stays allowed on every route to zai."""
+        violations = real_enforcer.check_constraints(
+            provider=provider, sub_provider=sub_provider, model="glm-5.2"
+        )
+        blocking = [v for v in violations if v.severity == "blocking"]
+        assert not [v for v in blocking if v.code == "deprecated-glm-models"], blocking
+
+    def test_glm_harness_without_sub_provider_fails_loud(self, real_enforcer: ConstraintEnforcer):
+        """Fail-closed test (OI-1217): glm-harness is a Provider enum member that
+        routes to zai but is not the literal string named in the constraint. It
+        must NOT silently pass a deprecated model."""
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="glm-harness", model="glm-5")
+        with pytest.raises(HardConstraintViolation, match="deprecated-glm-models"):
+            real_enforcer.enforce(provider="glm-harness", model="glm-5.1")
+
+
+# ---------------------------------------------------------------------------
+# OI-1205 — zai-via-openrouter-only is an allowlist over via, not a blocklist.
+# ---------------------------------------------------------------------------
+
+class TestZaiViaOpenrouterOnlyAllowlist:
+
+    def test_direct_route_refused(self, real_enforcer: ConstraintEnforcer):
+        with pytest.raises(HardConstraintViolation, match="zai-via-openrouter-only"):
+            real_enforcer.enforce(provider="zai", via="direct")
+
+    def test_openrouter_route_allowed(self, real_enforcer: ConstraintEnforcer, monkeypatch):
+        monkeypatch.setenv("VNX_OVERRIDE_GLM_VIA_HARNESS_ONLY", "1")
+        real_enforcer.enforce(
+            provider="litellm", sub_provider="zai", model="glm-5.2", via="openrouter"
+        )
+
+    def test_harness_openrouter_route_allowed(self, real_enforcer: ConstraintEnforcer):
+        """The production glm-harness lane (via=claude_harness_openrouter) clears
+        the allowlist — it fronts OpenRouter, never the direct Zhipu API."""
+        real_enforcer.enforce(
+            provider="glm-harness", sub_provider="zai",
+            model="glm-5.2", via="claude_harness_openrouter",
+        )
+
+    def test_reason_matches_rule(self, real_enforcer: ConstraintEnforcer):
+        """The YAML reason and rule say the same thing: an allowlist over via."""
+        constraint = next(
+            c for c in real_enforcer._constraints if c.get("id") == "zai-via-openrouter-only"
+        )
+        assert constraint["rule"] == "require_route"
+        assert constraint["required_route"]["via"] == ["openrouter", "claude_harness_openrouter"]
+        reason = constraint.get("reason", "")
+        assert "allowlist" in reason
+        assert "not a blocklist" in reason
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two constraint-allowlist fixes in `provider_constraints.yaml`:

- **OI-1217** — `deprecated-glm-models` named `provider: zai`, but `glm-harness` (a `Provider` enum member routing to the same Zhipu models) bypassed it. The enforcer now resolves provider identity via `_registry_key_for` (ADR-036), so every provider string that routes to zai (`zai`, `litellm:zai`, `glm-harness`) is covered without repeating the set in the YAML. A provider string routing to a known provider but not named in the constraint fails loudly (fail-closed).
- **OI-1205** — `zai-via-openrouter-only` had an allowlist-style reason but a `forbid_route`/`via: direct` blocklist rule. Converted to a `require_route` allowlist over `via: [openrouter, claude_harness_openrouter]`, making the reason and the rule say the same thing.

## Changes

- `scripts/lib/providers/constraint_enforcer.py` — `_provider_identity_matches` (registry-key resolution) + `via` enforcement in `_required_route_missing`.
- `scripts/lib/constraint_enforcer.py` — mirrored `_registry_key_for` / `_provider_identity_matches` + `via` in `_check_require_route`.
- `scripts/lib/providers/provider_constraints.yaml` — schema comment; `zai-via-openrouter-only` allowlist conversion; `deprecated-glm-models` reason extended.
- `tests/test_constraint_enforcer.py` — new coverage for every-zai-route refusal, glm-5.2 allowed on every route, fail-closed glm-harness, and reason-matches-rule.

## Verification

- `tests/test_constraint_enforcer.py`: 72 passed, 1 skipped.
- Neighbours (`test_constraint_enforcer_kimi_valid.py`, `test_glm_harness_normalization.py`, `test_dispatch_enforcement.py`, `test_routing_policy.py`, `test_wave7_glm_smoke.py`, `test_provider_dispatch_deepseek_harness.py`, `test_pr10_provider_string_canon.py`): green except 3 pre-existing failures unrelated to this change (confirmed failing at baseline via stash):
  - `test_pr10_provider_string_canon.py` deepseek-harness registry-key assertions (expect `deepseek`, actual `deepseek_harness` per OI-867).
  - `test_provider_dispatch_deepseek_harness.py::test_handler_missing_key_emits_governance_receipt` (governance emit serialization, pre-existing).

## Open Items

None.

Dispatch-ID: 20260815-opsch-w5-constraint-allowlists