### PR TITLE
fix(gate): tiebreaker reports no-answer vs parse failure + routes deepseek (OI-1219)

### DIFF
--- a/configs/plan_gate_panel.yaml
+++ b/configs/plan_gate_panel.yaml
@@ -48,11 +48,20 @@ version: 1
 # literal. ``provider`` + ``model`` below name a wave7_models.yaml entry; the
 # tiebreaker resolver validates the pair against the registry and fails LOUD on
 # an unknown provider/model (the same fail-loud contract the static router
-# uses). Default fable-5 (the top reasoning rung) via the anthropic section.
+# uses). ``provider`` is the registry SECTION key (deepseek_harness), which the
+# resolver maps to its dispatch enum (deepseek-harness) for the lane.
+#
+# OI-1219 (2026-08-15): the default used to be fable-5 via the anthropic
+# section, which routes to the claude/tmux lane. That lane was caught three
+# times on the same day delivering-without-content: a 741-token empty run
+# (OI-1211), a placeholder receipt that stayed failed (OI-1202), and a
+# tiebreaker timeout that governance synthesized into a body the parser then
+# reported as "parse failure". deepseek-harness / deepseek-v4-pro delivered
+# 100% of its dispatches that same day, so the tiebreaker now runs there.
 tiebreaker:
   max_rounds: 2
-  provider: anthropic
-  model: fable-5
+  provider: deepseek_harness
+  model: deepseek-v4-pro
 # Minimum meaningful characters (whitespace-stripped) a track's goal_state must
 # carry to stand in for the plan when `plan-gate run` is invoked WITHOUT --doc.
 # The length is measured AFTER stripping whitespace, so a goal of 200 spaces is

--- a/scripts/lib/plan_gate_tiebreaker.py
+++ b/scripts/lib/plan_gate_tiebreaker.py
@@ -39,6 +39,7 @@ from __future__ import annotations
 
 import json
 import os
+import re
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
@@ -122,6 +123,41 @@ class TiebreakerParseError(ValueError):
         self.raw = raw
 
 
+class TiebreakerNoAnswerError(Exception):
+    """The lane produced no model answer; governance synthesized the report.
+
+    Distinct from ``TiebreakerParseError``: a parse failure means the model DID
+    answer but the answer failed the strict contract. This means there was no
+    answer to parse at all — the lane timed out / errored / never authored a
+    report, so the governance layer fabricated the body (which carries
+    ``SYNTHESIZED_REPORT_MARKER``). Carries the lane ``status`` (timeout / error
+    / unknown) so the caller names the actual state instead of blaming the
+    parser. Both keep the track blocked; only the reported reason differs.
+    """
+
+    def __init__(self, status: str = "unknown", *, raw: str = "") -> None:
+        super().__init__(
+            f"tiebreaker lane delivered no answer (status={status}); "
+            "governance synthesized the report"
+        )
+        self.status = status
+        self.raw = raw
+
+
+# The synthesized body carries the lane status on a ``- Status: <status>`` line
+# (see dispatch_govern._synthesize). Extracted so the no-answer reason names the
+# actual state (timeout / error) rather than a bare "no answer".
+_SYNTH_STATUS_RE = re.compile(r"^\s*-\s*Status:\s*(.+?)\s*$", re.MULTILINE)
+
+
+def _extract_synthesized_status(report_text: str) -> str:
+    """The lane status from a synthesized report's ``- Status:`` line, else "unknown"."""
+    match = _SYNTH_STATUS_RE.search(report_text or "")
+    if match:
+        return match.group(1).strip() or "unknown"
+    return "unknown"
+
+
 # ---------------------------------------------------------------------------
 # Config loading
 # ---------------------------------------------------------------------------
@@ -154,8 +190,12 @@ def load_tiebreaker_config(
         # dispatch path (ADR-036). These defaults are only the config fallback
         # when the YAML block is absent; resolve_tiebreaker_model still
         # validates them against the registry and fails loud on drift.
-        "provider": "anthropic",
-        "model": "fable-5",
+        # deepseek_harness/deepseek-v4-pro is the same choice the shipped
+        # configs/plan_gate_panel.yaml makes (OI-1219): the claude/tmux lane
+        # repeatedly delivered-no-answer (timeout/placeholder), while
+        # deepseek-harness delivered 100% of its dispatches on 2026-08-15.
+        "provider": "deepseek_harness",
+        "model": "deepseek-v4-pro",
     }
     if not path.is_file():
         return dict(fallback)
@@ -209,18 +249,23 @@ def resolve_tiebreaker_model(
     *,
     registry_path: Optional[Path] = None,
 ) -> Tuple[str, str, str]:
-    """Resolve the tiebreaker's (provider_key, model_key, dispatch_model_arg).
+    """Resolve the tiebreaker's (provider, model_key, dispatch_model_arg).
 
     Model identity comes from the registry (``wave7_models.yaml``), never a
     Python literal on the dispatch path (ADR-036). The provider+model pair from
     the config is validated against the registry: the provider section must
-    exist and be enabled, and the model key must exist under it. An unknown
-    provider or model raises ``RegistryLookupError`` naming what was missing and
-    where it was looked for — the same fail-loud contract the static router
-    uses (``provider_registry._resolve_step``). Never a silent None.
+    exist, be enabled, and carry a ``dispatch_enum``; the model key must exist
+    under it. An unknown provider or model raises ``RegistryLookupError`` naming
+    what was missing and where it was looked for — the same fail-loud contract
+    the static router uses (``provider_registry._resolve_step``). Never a silent
+    None.
 
-    Returns ``(provider_key, model_key, cli_model_arg)``:
-      - ``provider_key`` is the registry section key (e.g. ``anthropic``).
+    Returns ``(provider, model_key, cli_model_arg)``:
+      - ``provider`` is the DISPATCH enum the lane consumes
+        (``pcfg.dispatch_enum``) — e.g. ``claude`` for the ``anthropic``
+        section, ``deepseek-harness`` for the ``deepseek_harness`` section. This
+        is what ``_make_default_dispatcher`` keys its lane split on; it is NOT
+        the registry section key (that is the config INPUT).
       - ``model_key`` is the registry model key (e.g. ``fable-5``).
       - ``cli_model_arg`` is the ``cli_model_arg`` the registry carries for that
         model (the string handed to the dispatch lane), falling back to the
@@ -248,6 +293,12 @@ def resolve_tiebreaker_model(
         raise RegistryLookupError(
             f"tiebreaker provider {provider_key!r} is disabled in the registry"
         )
+    if not pcfg.dispatch_enum:
+        raise RegistryLookupError(
+            f"tiebreaker provider {provider_key!r} has no dispatch_enum in the "
+            "registry — add one (or pick a routable provider) so the tiebreaker "
+            "knows which lane to dispatch through"
+        )
     model = pcfg.models.get(model_key)
     if model is None:
         raise RegistryLookupError(
@@ -259,7 +310,10 @@ def resolve_tiebreaker_model(
     # arg the claude/tmux lane takes, e.g. "fable-5"). Fall back to the model
     # key so a registry section without cli_model_arg still resolves.
     cli_arg = model.cli_model_arg or model_key
-    return provider_key, model_key, cli_arg
+    # Route by the DISPATCH enum (claude / deepseek-harness / ...), not the
+    # registry section key (anthropic / deepseek_harness / ...) — the lane split
+    # in _make_default_dispatcher keys off the enum, not the section key.
+    return pcfg.dispatch_enum, model_key, cli_arg
 
 
 # ---------------------------------------------------------------------------
@@ -570,9 +624,9 @@ def _default_tiebreaker_dispatcher(
     """Real dispatcher for the tiebreaker — the panel's default dispatcher.
 
     The tiebreaker routes through the SAME governed lane a panel seat uses
-    (``plan_gate_panel._make_default_dispatcher``): the model comes from the
-    registry (fable-5 -> anthropic -> the claude/tmux lane, billing on the
-    subscription), so it reuses the panel's dispatcher factory rather than
+    (``plan_gate_panel._make_default_dispatcher``): the model + lane provider
+    come from the registry via ``resolve_tiebreaker_model`` (a dispatch enum +
+    cli arg, ADR-036), so it reuses the panel's dispatcher factory rather than
     growing a second dispatch path. The only difference is the instruction
     (``build_tiebreaker_instruction`` vs ``build_plan_review_instruction``),
     which the caller passes in.
@@ -614,17 +668,23 @@ def run_tiebreaker(
     Raises ``TiebreakerParseError`` when the model's answer does not satisfy
     the strict contract (no fence, wrong outcome, a findings list, more than one
     change) — the caller treats that as a loud failure, never silently filling
-    in a decision.
+    in a decision. Raises ``TiebreakerNoAnswerError`` when the lane delivered no
+    answer at all (a governance-synthesized report: timeout / error / no report
+    file) — a distinct loud failure from a parse failure, which stays reserved
+    for an answer that exists but fails the contract.
     """
     import uuid  # noqa: PLC0415
 
     # Registry-sourced model identity (ADR-036): no literal on the dispatch path.
     # When the caller passes an explicit model_arg (a test injecting a
     # dispatcher does not need a real registry resolution), it wins; otherwise
-    # the registry resolves the configured provider+model to a cli arg.
+    # the registry resolves the configured provider+model to a (lane provider,
+    # cli arg). The lane provider is the dispatch enum, not the registry section
+    # key — that is what _make_default_dispatcher keys its lane split on.
     resolved_model = model_arg
+    dispatch_provider = "claude"  # only reachable when model_arg is injected
     if resolved_model is None:
-        _provider_key, model_key, cli_arg = resolve_tiebreaker_model(config)
+        dispatch_provider, model_key, cli_arg = resolve_tiebreaker_model(config)
         resolved_model = cli_arg
 
     resolved_timeout = pgp._seat_timeout(timeout_seconds)
@@ -641,7 +701,19 @@ def run_tiebreaker(
         last_round_findings=list(last_round_findings or []),
     )
     did = f"plan-tiebreak-{track_id}-{uuid.uuid4().hex[:8]}"
-    report_text = disp("claude", resolved_model, instruction, did)
+    report_text = disp(dispatch_provider, resolved_model, instruction, did)
+    # OI-1219: a synthesized report is by definition NOT a model answer — the
+    # lane never delivered a verdict, so the governance layer fabricated the
+    # body (SYNTHESIZED_REPORT_MARKER). Detect the marker BEFORE parse_tiebreaker
+    # (which would otherwise raise TiebreakerParseError and mislabel the cause
+    # as a parse failure). A synthesized report keeps the track blocked exactly
+    # like a parse failure, but the reason names the lane state (timeout/error),
+    # not the parser. A parse failure stays reserved for an answer that IS there
+    # but fails the strict contract.
+    if pgp.SYNTHESIZED_REPORT_MARKER in (report_text or ""):
+        raise TiebreakerNoAnswerError(
+            status=_extract_synthesized_status(report_text), raw=report_text,
+        )
     result = parse_tiebreaker(report_text)
     # Stamp the model + round the parser cannot know.
     result.model = resolved_model

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -2512,6 +2512,24 @@ def _run_tiebreaker_for_track(
             timeout_seconds=seat_timeout,
             config=tb_cfg,
         )
+    except plan_gate_tiebreaker.TiebreakerNoAnswerError as exc:
+        # OI-1219: the lane delivered no answer (a governance-synthesized
+        # report: timeout / error / no report file). This is NOT a parse
+        # failure — there was no model decision to parse. The reason names the
+        # lane status so the operator sees the cause, not the parser.
+        stderr_lines.append(
+            f"plan-gate tiebreaker: the lane delivered no answer "
+            f"(status={exc.status}); the track stays blocked. The governance "
+            f"layer synthesized the report (no worker authored one: timeout, "
+            f"error, or no report file), so there is no model decision to parse."
+        )
+        return _result(
+            exit_code=1, outcome="ERROR",
+            error=(
+                f"tiebreaker lane delivered no answer (status={exc.status}); "
+                "the track stays blocked"
+            ),
+        )
     except plan_gate_tiebreaker.TiebreakerParseError as exc:
         stderr_lines.append(
             f"plan-gate tiebreaker FAILED to parse the decision: {exc}. "

--- a/tests/test_plan_gate_tiebreaker.py
+++ b/tests/test_plan_gate_tiebreaker.py
@@ -261,20 +261,84 @@ def test_parse_tiebreaker_carries_raw_text_on_failure():
 
 
 # --------------------------------------------------------------------------
+# OI-1219 — a synthesized report is a NO-ANSWER, not a parse failure
+# --------------------------------------------------------------------------
+
+def _synthesized_report(status: str = "timeout") -> str:
+    """A governance-synthesized body exactly as dispatch_govern._synthesize
+    emits it: the marker, a Status line, and NO verdict fence."""
+    return (
+        f"# Dispatch plan-tiebreak-x\n\n"
+        f"- Lane: tmux_interactive\n"
+        f"- Status: {status}\n"
+        f"- contract_status: synthesized\n"
+        f"- {pgp.SYNTHESIZED_REPORT_MARKER}\n\n"
+        f"## Summary\n\nNo commit on branch; worker emitted status={status}. "
+        f"Body synthesized by lane.\n"
+    )
+
+
+def test_run_tiebreaker_synthesized_report_raises_no_answer_not_parse_error():
+    """A synthesized report raises TiebreakerNoAnswerError with the lane status,
+    NOT TiebreakerParseError. The lane delivered nothing to parse, so the reason
+    names the lane state, not the parser. Measured by feeding the report in and
+    reading the exception type, not by grepping for a marker string in code."""
+    def _synth_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return _synthesized_report("timeout")
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n## Approach\n",
+            track_id="trk-synth", project_id="p1", round_number=3,
+            model_arg="deepseek-v4-pro", dispatcher=_synth_dispatcher,
+        )
+    assert excinfo.value.status == "timeout"
+    assert "no answer" in str(excinfo.value)
+
+
+def test_run_tiebreaker_synthesized_error_status_is_carried():
+    """The lane status from the report's Status line is carried verbatim (error,
+    not just the timeout default)."""
+    def _synth_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return _synthesized_report("error")
+
+    with pytest.raises(pgt.TiebreakerNoAnswerError) as excinfo:
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_synth_dispatcher,
+        )
+    assert excinfo.value.status == "error"
+
+
+def test_run_tiebreaker_real_answer_still_parse_failure():
+    """A REAL model answer (no marker) that fails the strict contract still
+    raises TiebreakerParseError. Parse failure stays reserved for an answer that
+    exists but does not satisfy the contract."""
+    def _bad_dispatcher(provider, model_arg, instruction, dispatch_id):
+        return f"prose\n```{pgt.TIEBREAKER_FENCE}\n{{\"outcome\": \"MAYBE\"}}\n```\n"
+
+    with pytest.raises(pgt.TiebreakerParseError, match="unknown outcome"):
+        pgt.run_tiebreaker(
+            doc_text="## Problem\n", track_id="t", project_id="p1",
+            round_number=3, model_arg="deepseek-v4-pro", dispatcher=_bad_dispatcher,
+        )
+
+
+# --------------------------------------------------------------------------
 # Punt 8 — model identity from the registry (ADR-036)
 # --------------------------------------------------------------------------
 
 def test_tiebreaker_model_resolved_from_registry():
     """The model comes from the registry, not a Python literal on the dispatch
-    path. resolve_tiebreaker_model returns the registry model key + its
-    cli_model_arg (falling back to the model key when the registry entry has no
-    cli_model_arg, as the anthropic section's models do)."""
-    provider_key, model_key, cli_arg = pgt.resolve_tiebreaker_model()
-    assert provider_key == "anthropic"
-    assert model_key == "fable-5"
-    # The anthropic registry models carry no cli_model_arg -> the model key IS
-    # the cli arg the claude/tmux lane takes.
-    assert cli_arg == "fable-5"
+    path. resolve_tiebreaker_model returns the DISPATCH enum (what the lane
+    consumes, e.g. deepseek-harness) + the registry model key + its
+    cli_model_arg."""
+    provider, model_key, cli_arg = pgt.resolve_tiebreaker_model()
+    assert provider == "deepseek-harness"
+    assert model_key == "deepseek-v4-pro"
+    # The deepseek_harness registry models carry a cli_model_arg -> it is the
+    # arg the provider lane takes.
+    assert cli_arg == "deepseek-v4-pro"
 
 
 def test_tiebreaker_unknown_model_fails_loud():
@@ -290,6 +354,11 @@ def test_tiebreaker_unknown_model_fails_loud():
     bad_cfg2 = {"max_rounds": 2, "provider": "no-such-provider", "model": "fable-5"}
     with pytest.raises(RegistryLookupError, match="no-such-provider"):
         pgt.resolve_tiebreaker_model(bad_cfg2)
+
+    # The shipped provider (deepseek_harness) with an unknown model also fails loud.
+    bad_cfg3 = {"max_rounds": 2, "provider": "deepseek_harness", "model": "nonexistent-model-xyz"}
+    with pytest.raises(RegistryLookupError, match="nonexistent-model-xyz"):
+        pgt.resolve_tiebreaker_model(bad_cfg3)
 
 
 def test_no_model_literal_on_dispatch_path():
@@ -314,7 +383,8 @@ def test_no_model_literal_on_dispatch_path():
 
     src = Path(pgt.__file__).read_text(encoding="utf-8")
     tree = ast.parse(src)
-    model_names = {"fable-5", "claude-fable-5", "opus-5", "sonnet-5", "kimi-k3"}
+    model_names = {"fable-5", "claude-fable-5", "opus-5", "sonnet-5", "kimi-k3",
+                   "deepseek-v4-pro", "deepseek-v4-flash"}
     # Functions whose string literals are config/contract, not dispatch path.
     allowed_fn_names = {"load_tiebreaker_config"}
 
@@ -614,6 +684,47 @@ def test_cmd_plan_gate_run_tiebreaker_parse_failure_stays_blocked(tmp_path, monk
     assert _resolution_reason(state_dir, "feat-fail", "p1") == ""
 
 
+def test_cmd_plan_gate_run_synthesized_tiebreaker_stays_blocked_no_answer_reason(
+    tmp_path, monkeypatch, capsys,
+):
+    """A synthesized tiebreaker report (lane delivered no answer) keeps the
+    track blocked and reports the NO-ANSWER reason naming the lane status, not
+    "parse failure". Exercised end-to-end: the REAL run_tiebreaker runs against
+    an injected synthesized dispatcher, so the marker detection is measured
+    (the report is fed in and the resulting reason read out), not mocked."""
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    state_dir = _bootstrap(tmp_path)
+    tracks.create_track(state_dir, "feat-synth", "p1", "t", "shipped", phase="queued")
+    planning_cli._seed_plan_blocker(state_dir, "feat-synth", "p1")
+    doc = tmp_path / "plan.md"
+    doc.write_text("## Problem\n## Approach\n", encoding="utf-8")
+    ledger = _isolate_seat_ledger(monkeypatch, tmp_path)
+    pgt.record_round(ledger, track_id="feat-synth", project_id="p1", round_number=1, outcome="panel")
+    pgt.record_round(ledger, track_id="feat-synth", project_id="p1", round_number=2, outcome="panel")
+
+    def _synth_factory(data_dir, timeout_seconds):
+        def _disp(provider, model_arg, instruction, dispatch_id):
+            return (
+                f"- Lane: tmux_interactive\n"
+                f"- Status: timeout\n"
+                f"- contract_status: synthesized\n"
+                f"- {pgp.SYNTHESIZED_REPORT_MARKER}\n"
+                f"No commit on branch; worker emitted status=timeout.\n"
+            )
+        return _disp
+
+    monkeypatch.setattr(pgt, "_default_tiebreaker_dispatcher", _synth_factory)
+    rc = planning_cli.cmd_plan_gate_run(_gate_args(state_dir, doc, track_id="feat-synth"))
+    captured = capsys.readouterr()
+    assert rc == 1  # loud failure, track stays blocked
+    # The reason names the lane state, not the parser.
+    assert "no answer" in captured.err
+    assert "status=timeout" in captured.err
+    assert "parse failure" not in captured.err
+    # The blocker is unresolved: no resolution_reason written.
+    assert _resolution_reason(state_dir, "feat-synth", "p1") == ""
+
+
 # --------------------------------------------------------------------------
 # Config loading
 # --------------------------------------------------------------------------
@@ -621,8 +732,8 @@ def test_cmd_plan_gate_run_tiebreaker_parse_failure_stays_blocked(tmp_path, monk
 def test_load_tiebreaker_config_defaults_when_absent(tmp_path):
     cfg = pgt.load_tiebreaker_config(tmp_path / "absent.yaml")
     assert cfg["max_rounds"] == pgt.DEFAULT_MAX_ROUNDS
-    assert cfg["provider"] == "anthropic"
-    assert cfg["model"] == "fable-5"
+    assert cfg["provider"] == "deepseek_harness"
+    assert cfg["model"] == "deepseek-v4-pro"
 
 
 def test_load_tiebreaker_config_rejects_bad_max_rounds(tmp_path):
@@ -641,11 +752,12 @@ def test_load_tiebreaker_config_rejects_max_rounds_below_one(tmp_path):
 
 def test_load_tiebreaker_config_reads_real_repo_file():
     """The shipped configs/plan_gate_panel.yaml carries the tiebreaker block
-    with max_rounds=2 and the registry-named provider/model."""
+    with max_rounds=2 and the registry-named provider/model (OI-1219: the
+    deepseek-harness lane, not the claude/tmux lane)."""
     cfg = pgt.load_tiebreaker_config()
     assert cfg["max_rounds"] == 2
-    assert cfg["provider"] == "anthropic"
-    assert cfg["model"] == "fable-5"
+    assert cfg["provider"] == "deepseek_harness"
+    assert cfg["model"] == "deepseek-v4-pro"
 
 
 # --------------------------------------------------------------------------


### PR DESCRIPTION
## Wat

De plan-gate tiebreaker meldde een governance-gesynthetiseerde timeout als `tiebreaker parse failure`, terwijl er geen modelantwoord was om te parsen.

## Reparatie 1 — onderscheid no-answer van parse-failure

`run_tiebreaker` herkent `VNX_SYNTHESIZED_REPORT_BY_GOVERNANCE` nu vóór `parse_tiebreaker`. Een gesynthetiseerd rapport (marker aanwezig, geen verdict-fence) verhoogt een eigen `TiebreakerNoAnswerError` met de lane-status uit de `- Status:` regel (timeout / error). `TiebreakerParseError` blijft gereserveerd voor een antwoord dat er wel is maar het contract niet haalt.

Beide houden de track geblokkeerd; alleen de gemelde reden wijst nu naar de oorzaak (de lane leverde niets) in plaats van naar de parser.

## Reparatie 2 — lane

De tiebreaker resolvet niet langer `fable-5` -> `anthropic` (claude/tmux-lane), maar `deepseek-v4-pro` -> `deepseek_harness` (dispatch enum `deepseek-harness`). Die lane leverde op 2026-08-15 100% van zijn dispatches; de claude/tmux-lane werd die dag drie keer betrapt op leveren-zonder-inhoud (OI-1211, OI-1202, deze timeout).

`resolve_tiebreaker_model` geeft nu de dispatch enum terug (niet de registry-section-key) zodat de lane-split in `_make_default_dispatcher` correct routeert. De resolutielogica (valideren tegen de registry, luid falen op drift) is ongewijzigd.

## Bewijsregel (sluitreden)

OI-1219: een gesynthetiseerd rapport draagt `VNX_SYNTHESIZED_REPORT_BY_GOVERNANCE` en is per definitie geen modelantwoord; de tiebreaker herkent de marker vóór de parser en meldt "tiebreaker lane delivered no answer (status=timeout)" in plaats van "parse failure", terwijl een echt maar niet-contract-conform antwoord nog steeds als parse-failure wordt gemeld.

## Tests

- `tests/test_plan_gate_tiebreaker.py` — 31 passed
- `tests/test_plan_gate_batch.py` — 9 passed
- `tests/test_planning_cli.py` — 51 passed

(5 pre-existing failures in `tests/test_plan_gate_panel.py` zijn een bekende `output_ref`-schema-gap, bevestigd identiek op de schone base.)

Dispatch-ID: 20260815-opsch-w5-tiebreaker-lane