### PR TITLE
fix(gate): don't flag argparse help= prose as raw claude spawn (OI-1220)

### DIFF
--- a/scripts/lib/dispatch_sidedoor_audit.py
+++ b/scripts/lib/dispatch_sidedoor_audit.py
@@ -70,6 +70,27 @@ _RAW_CLAUDE_PATTERNS = [
     re.compile(r"""["']binary["']\s*:\s*["']claude["']"""),
 ]
 
+# OI-1220: an argparse `help=` value is DOCUMENTATION, not a spawn. A `claude -p` mention
+# inside help prose (e.g. the `--allow-headless` flag's "opt into the claude_headless lane
+# (claude -p)" text) must not trip the scan, while a real argv list or subprocess call
+# elsewhere still must. This is finer than the G5-8 "never line-suppress a quoted string"
+# rule: a `help=` string is a documentation binding (argparse renders it, nothing executes
+# it), whereas `subprocess.run("claude -p", shell=True)` is an executable string and stays
+# matched because it is not bound to `help=`. Two shapes are blanked: a bare literal
+# (`help="..."` / `help='...'` / triple-quoted) and a parenthesized group of adjacent
+# literals (`help=("..." "...")`, possibly multi-line). The group arm tolerates one level
+# of nested parens so prose like `("... (claude -p). ...")` is blanked whole instead of
+# stopping at the first `)`.
+_HELP_LITERAL_RE = re.compile(
+    r"""\bhelp\s*=\s*
+        (?:
+            \( (?P<group> [^()]* (?: \( [^()]* \) [^()]* )* ) \)
+            | (?P<q>["']{1,3}) (?P<lit> .*? ) (?P=q)
+        )
+    """,
+    re.VERBOSE | re.DOTALL,
+)
+
 # Audited NON-delivery raw-claude callers: haiku/deepseek classifiers, weekly digest, headless
 # T0 orchestration, conversation analysis, benchmark/replay harnesses. A scanned file outside
 # this set that spawns `claude -p` is a NEW receipt-bypass side door and fails the gate until
@@ -172,6 +193,19 @@ def _code_lines(text: str):
         yield line
 
 
+def _blank_help_literals(text: str) -> str:
+    """Return `text` with `help=`-bound string literals blanked (newlines preserved).
+
+    Applied by the raw-claude scan so a flag's help prose is not read as the invocation of
+    the primitive it documents (OI-1220).
+    """
+
+    def _blank(match: "re.Match[str]") -> str:
+        return "\n".join(" " * len(line) for line in match.group(0).split("\n"))
+
+    return _HELP_LITERAL_RE.sub(_blank, text)
+
+
 def scan_delivery_callers(root: Path | None = None) -> Set[str]:
     """Return repo-relative paths of files that invoke a lane script as a delivery path."""
     root = root or _repo_root()
@@ -230,7 +264,10 @@ def scan_raw_claude_spawns(root: Path | None = None) -> Set[str]:
             # only MENTION the primitive (a "claude -p" keyword literal, help text) still match — they
             # are AUDITED in KNOWN_RAW_CLAUDE_CALLERS, not line-suppressed: suppressing a quoted
             # "claude -p" would also hide a real `subprocess.run("claude -p", shell=True)` (codex G5-8).
-            code_text = "\n".join(_code_lines(text))
+            # The one exception is a `help=`-bound string (argparse documentation): it is blanked by
+            # `_blank_help_literals`, because a help string is never executed, whereas an executable
+            # string spawn is never bound to `help=` (OI-1220).
+            code_text = _blank_help_literals("\n".join(_code_lines(text)))
             if any(p.search(code_text) for p in _RAW_CLAUDE_PATTERNS):
                 callers.add(rel)
     return callers

--- a/tests/test_dispatch_sidedoor_audit.py
+++ b/tests/test_dispatch_sidedoor_audit.py
@@ -203,3 +203,112 @@ def test_raw_scan_covers_extensionless_shebang_scripts(tmp_path):
     # an extensionless NON-shebang data file is not scanned as a script
     (binp / "data").write_text('claude -p something\n', encoding="utf-8")
     assert "bin/data" not in audit_mod.scan_raw_claude_spawns(root=tmp_path)
+
+
+# --- OI-1220: an argparse `help=` string documents the flag, it does not invoke it. ---
+# PR #1531 added a `--allow-headless` flag whose help prose mentions "(claude -p)"; the raw
+# scan flagged `vnx_cli/main.py` even though the full diff was two `add_argument` calls. The
+# help-string exemption below fixes that false positive WITHOUT blinding the gate to a real
+# spawn: a spawn is an argv list or a subprocess/shell call, never a `help=`-bound string.
+
+
+def test_help_string_with_claude_p_is_not_flagged(tmp_path):
+    # OI-1220: the exact PR #1531 shape — a parenthesized, multi-line help string — must not trip.
+    scripts = tmp_path / "vnx_cli"
+    scripts.mkdir()
+    (scripts / "main.py").write_text(
+        'dispatch_parser.add_argument(\n'
+        '    "--allow-headless",\n'
+        '    action="store_true",\n'
+        '    help=(\n'
+        '        "opt into the claude_headless lane (claude -p). Requires "\n'
+        '        "--headless-reason and a claude provider. The lane runs on the "\n'
+        '        "subscription unless an own ANTHROPIC_API_KEY / ANTHROPIC_BASE_URL "\n'
+        '        "is present."\n'
+        '    ),\n'
+        ')\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "vnx_cli/main.py" not in found, (
+        "help= string with 'claude -p' false-flagged as raw claude spawn (OI-1220)"
+    )
+
+
+def test_single_line_help_string_with_claude_p_is_not_flagged(tmp_path):
+    # OI-1220: a bare one-line help= literal is the same documentation channel.
+    scripts = tmp_path / "vnx_cli"
+    scripts.mkdir()
+    (scripts / "main.py").write_text(
+        'parser.add_argument("--allow-headless", help="opt into the claude -p lane")\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "vnx_cli/main.py" not in found, (
+        "single-line help= string with 'claude -p' false-flagged as raw claude spawn"
+    )
+
+
+def test_docstring_with_claude_p_is_not_flagged(tmp_path):
+    # OI-1220: the docstring channel is already skipped by _code_lines; pin it explicitly.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "prose.py").write_text(
+        '"""Documents the claude -p primitive without ever spawning it.\n'
+        'The raw receipt-bypass primitive is `claude -p` / `claude --print`.\n'
+        '"""\n'
+        'def describe():\n'
+        '    return "headless lane"\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "scripts/prose.py" not in found, (
+        "docstring-only mention of claude -p false-flagged as raw claude spawn"
+    )
+
+
+def test_argv_list_spawn_in_same_file_as_help_string_is_flagged(tmp_path):
+    # OI-1220 negative: the help-string exemption must NOT blind the gate to a real argv spawn
+    # in the same file.
+    scripts = tmp_path / "vnx_cli"
+    scripts.mkdir()
+    (scripts / "main.py").write_text(
+        'parser.add_argument("--allow-headless", help="opt into the claude -p lane")\n'
+        'cmd = ["claude", "--model", m, "--print", p]\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "vnx_cli/main.py" in found, (
+        "help-string exemption blinded the gate to a real argv spawn in the same file"
+    )
+
+
+def test_subprocess_run_spawn_in_same_file_as_help_string_is_flagged(tmp_path):
+    # OI-1220 negative: an argv subprocess.run spawn next to a help string is still a spawn.
+    scripts = tmp_path / "vnx_cli"
+    scripts.mkdir()
+    (scripts / "main.py").write_text(
+        'parser.add_argument("--allow-headless", help="opt into the claude -p lane")\n'
+        'subprocess.run(["claude", "-p", "--verbose"])\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "vnx_cli/main.py" in found, (
+        "help-string exemption blinded the gate to a real subprocess argv spawn"
+    )
+
+
+def test_shell_string_spawn_is_not_treated_as_help_string(tmp_path):
+    # OI-1220: the executable-string distinction is the whole point — a shell-string spawn is
+    # NOT bound to `help=`, so it must still be flagged even though it is a quoted string.
+    scripts = tmp_path / "scripts"
+    scripts.mkdir()
+    (scripts / "runner.py").write_text(
+        'parser.add_argument("--allow-headless", help="opt into the claude -p lane")\n'
+        'subprocess.run("claude -p", shell=True)\n',
+        encoding="utf-8",
+    )
+    found = audit_mod.scan_raw_claude_spawns(root=tmp_path)
+    assert "scripts/runner.py" in found, (
+        "shell-string spawn false-negatived as if it were a help= documentation string"
+    )


### PR DESCRIPTION
## Wat

PR #1531 is ROOD op `test_no_unaudited_raw_claude_spawns`. Zijn volledige diff op `vnx_cli/main.py` is twee `add_argument`-aanroepen; de enige treffer is de tekenreeks `(claude -p)` binnen een `help=`-string. De detector meet de aanwezigheid van een tekenreeks in de bron, niet of er iets wordt aangeroepen.

## Reparatie — Route 1 (duurzaam)

De raw-scan blankt nu `help=`-gebonden string-literals vóór het matchen. Een `help=`-waarde is argparse-documentatie: argparse rendert hem, niets voert hem uit. Een echte argv-lijst of subprocess-aanroep is nooit aan `help=` gebonden en matcht dus nog steeds.

Twee vormen worden geblankt: een kale literal (`help="..."` / triple-quoted) en een parenthesized groep van aangrenzende literals (de multi-line vorm uit de PR), met één niveau geneste haakjes zodat proza als `"(claude -p)"` in één keer wordt geblankt.

Niet Route 2 (een genoemde vrijstelling op `vnx_cli/main.py`): een basenaam-vrijstelling verblindt de gate voor een echte spawn die later in dat bestand landt. De negatieve tests hieronder bewijzen dat de gate preciezer is, niet losser.

## Bewijsregel (sluitreden)

OI-1220: een `help=`-string is documentatie van de vlag, geen aanroep ervan. De raw-scan blankt `help=`-gebonden literals en blijft flaggen op een argv-lijst (`cmd = ["claude", "--model", m, "--print", p]`) of subprocess-aanroep (`subprocess.run(["claude", "-p", ...])`) in datzelfde bestand.

## Tests

`tests/test_dispatch_sidedoor_audit.py` — 24 passed (6 nieuwe OI-1220-tests + 18 bestaande). Standalone `python3 scripts/lib/dispatch_sidedoor_audit.py` exit 0, 18 raw-spawns gedetecteerd, 0 unaudited.

Dispatch-ID: 20260815-opsch-w6-sidedoor-helptekst
