### PR TITLE
fix(role): canonical role names identity_unresolved as the no-role-resolved sentinel (OI-1212)

### DIFF
--- a/.claude/terminals/T0/role-orchestrator.md
+++ b/.claude/terminals/T0/role-orchestrator.md
@@ -85,7 +85,7 @@ DELIVERABLE = a proposed dispatch created with `vnx deliverable add --objective 
 
 **Role selection (hard):**
 
-- `backend-developer` is the sentinel default for "no role resolved" (`_FAKE_DEFAULT_ROLE`, `scripts/lib/dispatch_govern.py:51`) and is stripped from the receipt trail — never choose it out of convenience. Pick a role deliberately; if none fits, motivate that in the dispatch.
+- `identity_unresolved` is the sentinel default for "no role resolved" (`_IDENTITY_UNRESOLVED` / `_FAKE_DEFAULT_ROLE`, `scripts/lib/dispatch_identity.py:39-40`) and is stripped from the receipt trail — never choose it out of convenience. Pick a role deliberately; if none fits, motivate that in the dispatch.
 - The role follows the work, not the terminal.
 
 | Work | Role |

--- a/scripts/lib/smart_router.py
+++ b/scripts/lib/smart_router.py
@@ -175,9 +175,10 @@ ROLE_TO_TASK_CLASS: Dict[str, str] = {
 }
 
 # The classifier's fallthrough class. Roles mapping HERE carry no discriminating
-# signal (builder roles do refactors/debugging/docs in the same lane, and
-# "backend-developer" is additionally the fabric's no-role-resolved sentinel —
-# dispatch_govern._FAKE_DEFAULT_ROLE), so for them the instruction text decides.
+# signal (builder roles do refactors/debugging/docs in the same lane), so for
+# them the instruction text decides. The no-role-resolved sentinel is
+# "identity_unresolved" (dispatch_identity._IDENTITY_UNRESOLVED) — unmapped, so
+# it reaches the same instruction-text fallthrough.
 _DEFAULT_TASK_CLASS = "01_code_generation"
 
 
@@ -202,7 +203,7 @@ def classify_task(
       3. Role-based fallback for default-class (builder) roles. Builder roles map
          to the classifier's own default, so step 1 skipping them changes nothing
          for a no-regex-match instruction — and keeps the instruction text
-         deciding for the no-role-resolved sentinel ("backend-developer").
+         deciding for the no-role-resolved sentinel ("identity_unresolved").
       4. Default: 01_code_generation (safest default — most dispatches are code work)
 
     dispatch_paths is reserved for future signal enrichment (e.g. docs-only paths

--- a/tests/test_role_orchestrator_sentinel.py
+++ b/tests/test_role_orchestrator_sentinel.py
@@ -1,0 +1,68 @@
+#!/usr/bin/env python3
+"""Pin the canonical T0 role's "no role resolved" sentinel to the code's truth.
+
+Dispatch-ID: 20260815-nn-w1-canonieke-rol-sentinel
+
+The canonical orchestrator role (``.claude/terminals/T0/role-orchestrator.md``)
+is synced fleet-wide by ``vnx role sync``, so a wrong sentinel claim there
+propagates to every project. This test pins the role's "Role selection (hard)"
+section to the sentinel actually defined in ``scripts/lib/dispatch_identity.py``
+and guards against the pre-OI-981 drift that described ``backend-developer`` as
+the sentinel (and cited a definition site, ``dispatch_govern.py:51``, that never
+held one).
+
+The source of truth is ``dispatch_identity.py``; the role file must agree with
+it. A content pin, not a behaviour test.
+"""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parent.parent
+ROLE_FILE = REPO / ".claude" / "terminals" / "T0" / "role-orchestrator.md"
+
+sys.path.insert(0, str(REPO / "scripts" / "lib"))
+
+import dispatch_identity
+
+
+def _role_text() -> str:
+    return ROLE_FILE.read_text()
+
+
+def test_canonical_role_names_the_code_sentinel():
+    """The role's sentinel line must name the value dispatch_identity defines as
+    ``_IDENTITY_UNRESOLVED`` / ``_FAKE_DEFAULT_ROLE`` (``identity_unresolved``)."""
+    text = _role_text()
+    assert (
+        f"`{dispatch_identity._IDENTITY_UNRESOLVED}` is the sentinel default"
+        in text
+    )
+
+
+def test_canonical_role_cites_the_definition_site():
+    """The reference must point at dispatch_identity.py:39-40, where the sentinel
+    is defined — not the old, wrong ``dispatch_govern.py:51``."""
+    text = _role_text()
+    assert "scripts/lib/dispatch_identity.py:39-40" in text
+    assert "scripts/lib/dispatch_govern.py:51" not in text
+
+
+def test_canonical_role_never_calls_backend_developer_the_sentinel():
+    """Pre-OI-981 drift: the role described ``backend-developer`` as the sentinel.
+    It is a real deliberate role now; the sentinel line must not name it as such."""
+    text = _role_text()
+    assert "`backend-developer` is the sentinel default" not in text
+
+
+def test_backend_developer_remains_a_deliberate_role_choice():
+    """Positive control: the role table's ``backend-developer (deliberate choice)``
+    row is a real role, not a sentinel, and must stay."""
+    text = _role_text()
+    assert "`backend-developer` (deliberate choice)" in text
+
+
+if __name__ == "__main__":
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/test_smart_router.py
+++ b/tests/test_smart_router.py
@@ -220,8 +220,8 @@ class TestClassifyRoleFallback:
 class TestClassifySpecialistRoleDominance:
     """A role mapping to a non-default task class is an explicit signal and wins
     over instruction verb-guessing (OI-1143). Builder roles (mapping to the
-    default class, incl. the no-role-resolved sentinel backend-developer) keep
-    instruction-first behavior."""
+    default class) keep instruction-first behavior, as does the no-role-resolved
+    sentinel "identity_unresolved" (unmapped)."""
 
     def test_code_reviewer_role_classifies_review_instruction(self):
         # The exact OI-1143 measurement: this returned 01_code_generation because
@@ -251,7 +251,8 @@ class TestClassifySpecialistRoleDominance:
 
     def test_builder_role_still_instruction_first(self):
         # backend-developer maps to the default class → carries no discriminating
-        # signal; the instruction text keeps deciding (guards the sentinel case).
+        # signal; the instruction text keeps deciding (a real builder role, not
+        # the identity_unresolved sentinel).
         assert classify_task(
             "debug the flaky lease test", role="backend-developer",
         ) == "05_debugging"


### PR DESCRIPTION
## Summary

The canonical T0 orchestrator role (`.claude/terminals/T0/role-orchestrator.md`, synced fleet-wide by `vnx role sync`) described the wrong sentinel for "no role resolved". It named `backend-developer` as the sentinel (`_FAKE_DEFAULT_ROLE`, `scripts/lib/dispatch_govern.py:51`). Both facts are stale:

1. The sentinel is `identity_unresolved`, defined once at `scripts/lib/dispatch_identity.py:39-40` (`_IDENTITY_UNRESOLVED` / `_FAKE_DEFAULT_ROLE`).
2. `dispatch_govern.py:51` holds no sentinel definition — `dispatch_govern.py` only imports `_IDENTITY_UNRESOLVED`.
3. `backend-developer` has been a real, deliberate role since OI-981 (dispatch-20260804-190000), not a sentinel.

## Changes

- `.claude/terminals/T0/role-orchestrator.md` — "Role selection (hard)" now names `identity_unresolved` as the sentinel and cites `scripts/lib/dispatch_identity.py:39-40`. The role-table row `backend-developer (deliberate choice)` is left untouched (a real role, not a sentinel).
- `scripts/lib/smart_router.py` — two stale comments/docstring lines that asserted `backend-developer` was the no-role-resolved sentinel (and cited the nonexistent `dispatch_govern._FAKE_DEFAULT_ROLE`) now name `identity_unresolved` / `dispatch_identity._IDENTITY_UNRESOLVED`.
- `tests/test_smart_router.py` — two stale docstrings/comments updated to match.
- `tests/test_role_orchestrator_sentinel.py` — new content pin: fails on the old text, passes on the new.

## Verification

- `python3 -m pytest tests/test_role_orchestrator_sentinel.py -v` — 4 passed (3 failed + 1 passed against the old text before the fix).
- `python3 -m pytest tests/test_role_orchestrator_sentinel.py tests/test_smart_router.py tests/test_smart_router_governance_variant.py tests/test_dispatch_identity.py -q` — 139 passed.
- `python3 -m pytest tests/test_role_sync.py tests/test_t0_role_audit_static.py -q` — 53 passed.

## Open Items

None.