### PR TITLE
fix(dispatch): fail-closed VNX CI-run check in merge-preflight (OI-1216)

### DIFF
--- a/scripts/commands/merge_preflight.sh
+++ b/scripts/commands/merge_preflight.sh
@@ -36,6 +36,7 @@ Checks performed:
   2. Open items (blockers and warnings from open_items_manager)
   3. PR queue status (incomplete PRs associated with this worktree)
   4. Active processes (VNX orchestration still running in worktree)
+  5. VNX CI run for the exact HEAD SHA (fail-closed: no successful run = NO-GO)
 HELP
         return 0
         ;;
@@ -268,6 +269,38 @@ print('|'.join(holds))
     unmerged_reports="$(find "$wt_data/unified_reports" -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')"
     if [ "$unmerged_reports" -gt 0 ]; then
       details="${details}\n  INFO: $unmerged_reports report(s) in worktree unified_reports/"
+    fi
+  fi
+
+  # ── Check 6: VNX CI run for HEAD SHA (OI-1216) ─────────────────────────
+  # Fail-closed: er moet een VNX CI-workflow-run met conclusion=success bestaan
+  # voor de exacte head-SHA. Nul runs is een NO-GO, geen stilzwijgende GO, en
+  # ook in_progress is een NO-GO. Logica leeft in het testbare python-hulpbestand
+  # merge_preflight_ci_check.py; hier alleen de aanroep en de verdict-wiring.
+  local ci_check="$VNX_HOME/scripts/lib/merge_preflight_ci_check.py"
+  if [ ! -f "$ci_check" ] || ! command -v python3 &>/dev/null; then
+    verdict="NO-GO"
+    blockers=$((blockers + 1))
+    details="${details}\n  BLOCKER: VNX CI-check niet uitvoerbaar (python3/helper ontbreekt): deze merge is niet toetsbaar"
+  else
+    local ci_json
+    ci_json="$(python3 "$ci_check" --project-root "$wt_dir" --json 2>/dev/null)" || true
+    local ci_verdict
+    local ci_msg
+    if [ -n "$ci_json" ]; then
+      ci_verdict="$(printf '%s' "$ci_json" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("verdict",""))' 2>/dev/null)"
+      ci_msg="$(printf '%s' "$ci_json" | python3 -c 'import sys,json; print(json.load(sys.stdin).get("message",""))' 2>/dev/null)"
+    fi
+    if [ "$ci_verdict" = "GO" ]; then
+      details="${details}\n  INFO: ${ci_msg:-VNX CI geslaagd}"
+    elif [ "$ci_verdict" = "NO-GO" ]; then
+      verdict="NO-GO"
+      blockers=$((blockers + 1))
+      details="${details}\n  BLOCKER: ${ci_msg:-VNX CI-check gaf NO-GO: deze merge is niet toetsbaar}"
+    else
+      verdict="NO-GO"
+      blockers=$((blockers + 1))
+      details="${details}\n  BLOCKER: VNX CI-check gaf geen leesbaar antwoord: deze merge is niet toetsbaar"
     fi
   fi
 

--- a/scripts/lib/merge_preflight_ci_check.py
+++ b/scripts/lib/merge_preflight_ci_check.py
@@ -1,0 +1,293 @@
+#!/usr/bin/env python3
+"""Fail-closed CI-run check for ``vnx merge-preflight`` (OI-1216).
+
+Determines whether the configured CI workflow has a *successful* run for the
+exact HEAD SHA being merged. The check toetst op het BESTAAN van een geslaagde
+run voor die head, niet op de afwezigheid van een gefaalde run:
+
+  - zero runs for the head            -> NO-GO ("niet toetsbaar")
+  - run with conclusion != "success"  -> NO-GO (in_progress is NO-GO too)
+  - success but for a DIFFERENT sha   -> NO-GO (an older commit does not count)
+  - success for the exact head        -> GO
+
+Every unverifiable state (``gh`` missing, ``gh`` not authenticated, ``gh run
+list`` failing or unparseable, HEAD/branch unresolvable) is a NO-GO with its
+own message. A missing tool never passes as "no red found".
+
+This is the merge-preflight counterpart to ``pre_merge_gate.check_ci_workflow``
+(OI-931), which enforces the same invariant at gate time. The two share the
+same ``gh run list`` invocation shape and the same workflow-name resolution
+order (explicit arg > ``VNX_CI_WORKFLOW_NAME`` > "VNX CI"); they differ in
+verdict vocabulary (GO/NO-GO here) and messaging (merge-preflight terms).
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+# CI workflow name queried via `gh run list --workflow`. Overridable per repo
+# via VNX_CI_WORKFLOW_NAME — same resolution order as pre_merge_gate.
+DEFAULT_CI_WORKFLOW_NAME = "VNX CI"
+CI_WORKFLOW_NAME_ENV_VAR = "VNX_CI_WORKFLOW_NAME"
+
+# How many recent runs to pull per branch. Matching is by exact head SHA, so a
+# head older than the limit on a busy branch would read as "not run". The same
+# limit is used by pre_merge_gate.check_ci_workflow.
+RUN_LIST_LIMIT = 10
+
+# Subprocess timeouts (seconds). Fail closed on expiry.
+GH_AUTH_TIMEOUT = 10
+GH_RUN_LIST_TIMEOUT = 15
+GIT_TIMEOUT = 10
+
+
+def _resolve_workflow_name(workflow_name: Optional[str]) -> str:
+    """Resolve the workflow name: explicit arg > env var > fabric default.
+
+    Mirrors pre_merge_gate._resolve_ci_workflow_name() — keep the two in sync.
+    """
+    if workflow_name:
+        return workflow_name
+    env_name = os.environ.get(CI_WORKFLOW_NAME_ENV_VAR)
+    if env_name:
+        return env_name
+    return DEFAULT_CI_WORKFLOW_NAME
+
+
+def _capture(argv: List[str], *, timeout: int, cwd: Optional[str] = None) -> Tuple[Optional[subprocess.CompletedProcess], Optional[str]]:
+    """Run a command and return (result, error_tag).
+
+    error_tag is one of "missing" (binary not found), "timeout", or None. A
+    non-zero exit is *not* an error_tag: the caller inspects ``returncode`` so
+    it can distinguish "authenticated" from "command failed".
+    """
+    try:
+        result = subprocess.run(argv, capture_output=True, text=True, timeout=timeout, cwd=cwd)
+        return result, None
+    except FileNotFoundError:
+        return None, "missing"
+    except subprocess.TimeoutExpired:
+        return None, "timeout"
+
+
+def _git(project_root: Path, args: List[str]) -> Optional[str]:
+    """Resolve a git value inside project_root; None when unresolvable."""
+    result, err = _capture(["git", *args], timeout=GIT_TIMEOUT, cwd=str(project_root))
+    if err is not None or result is None or result.returncode != 0:
+        return None
+    return result.stdout.strip()
+
+
+def _no_go(message: str, **extra: Any) -> Dict[str, Any]:
+    base: Dict[str, Any] = {
+        "verdict": "NO-GO",
+        "message": message,
+        "ci_conclusion": None,
+        "ran_on_sha": False,
+        "head_sha": None,
+        "ci_run_id": None,
+    }
+    base.update(extra)
+    return base
+
+
+def check_ci_run_for_head(
+    project_root: Path,
+    *,
+    branch: Optional[str] = None,
+    head_sha: Optional[str] = None,
+    gh_bin: str = "gh",
+    workflow_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """Fail-closed check: a VNX CI run with conclusion=success must exist for head_sha.
+
+    Returns {"verdict": "GO"|"NO-GO", "message": str, ...}. ``project_root`` is
+    the directory whose HEAD is being merged (the worktree under preflight).
+    """
+    resolved_workflow = _resolve_workflow_name(workflow_name)
+
+    # ── gh availability ────────────────────────────────────────────────────
+    if shutil.which(gh_bin) is None:
+        return _no_go(
+            "gh CLI niet beschikbaar: deze merge is niet toetsbaar",
+            workflow_name=resolved_workflow,
+        )
+
+    # ── Resolve HEAD SHA ───────────────────────────────────────────────────
+    if head_sha is None:
+        head_sha = _git(project_root, ["rev-parse", "HEAD"])
+        if not head_sha:
+            return _no_go(
+                "HEAD-SHA kon niet worden bepaald: deze merge is niet toetsbaar",
+                workflow_name=resolved_workflow,
+            )
+
+    # ── Resolve branch ─────────────────────────────────────────────────────
+    if branch is None:
+        branch = _git(project_root, ["rev-parse", "--abbrev-ref", "HEAD"])
+        if not branch:
+            return _no_go(
+                "branch kon niet worden bepaald: deze merge is niet toetsbaar",
+                head_sha=head_sha,
+                workflow_name=resolved_workflow,
+            )
+
+    # ── gh authentication ──────────────────────────────────────────────────
+    auth, auth_err = _capture([gh_bin, "auth", "status"], timeout=GH_AUTH_TIMEOUT)
+    if auth_err == "missing":
+        return _no_go(
+            "gh CLI niet beschikbaar: deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+    if auth_err == "timeout":
+        return _no_go(
+            "gh auth status liep vast: deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+    if auth is None or auth.returncode != 0:
+        return _no_go(
+            "gh is niet geauthenticeerd (gh auth status faalde): deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+
+    # ── Query workflow runs ────────────────────────────────────────────────
+    run_list, run_err = _capture(
+        [
+            gh_bin, "run", "list",
+            "--branch", branch,
+            "--workflow", resolved_workflow,
+            "--limit", str(RUN_LIST_LIMIT),
+            "--json", "conclusion,headSha,status,databaseId",
+        ],
+        timeout=GH_RUN_LIST_TIMEOUT,
+        cwd=str(project_root),
+    )
+    if run_err == "missing":
+        return _no_go(
+            "gh CLI niet beschikbaar: deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+    if run_err == "timeout":
+        return _no_go(
+            f"gh run list liep vast voor workflow '{resolved_workflow}': deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+    if run_list is None or run_list.returncode != 0:
+        stderr = (run_list.stderr if run_list else "").strip()
+        return _no_go(
+            f"gh run list faalde voor workflow '{resolved_workflow}': deze merge is niet toetsbaar"
+            + (f" ({stderr[:120]})" if stderr else ""),
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+
+    try:
+        runs = json.loads(run_list.stdout)
+    except json.JSONDecodeError:
+        return _no_go(
+            f"gh-uitvoer niet te parsen voor workflow '{resolved_workflow}': deze merge is niet toetsbaar",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+
+    # ── Match a run to the exact HEAD SHA ──────────────────────────────────
+    for run in runs:
+        if run.get("headSha") != head_sha:
+            continue
+        conclusion = run.get("conclusion") or ""
+        status = run.get("status") or ""
+        run_id = run.get("databaseId")
+        if conclusion == "success":
+            return {
+                "verdict": "GO",
+                "message": (
+                    f"{resolved_workflow} geslaagd op {head_sha[:12]} "
+                    f"(run {run_id})"
+                ),
+                "ci_conclusion": conclusion,
+                "ran_on_sha": True,
+                "head_sha": head_sha,
+                "ci_run_id": run_id,
+                "workflow_name": resolved_workflow,
+            }
+        if status in ("in_progress", "queued"):
+            return _no_go(
+                f"{resolved_workflow} draait nog op {head_sha[:12]} (status: {status}): "
+                "deze merge is niet toetsbaar tot de run op 'success' eindigt",
+                ci_conclusion=None,
+                ran_on_sha=True,
+                head_sha=head_sha,
+                ci_run_id=run_id,
+                workflow_name=resolved_workflow,
+            )
+        return _no_go(
+            f"{resolved_workflow} conclusion is '{conclusion or status}' op {head_sha[:12]}: "
+            "deze merge is niet toetsbaar",
+            ci_conclusion=conclusion or None,
+            ran_on_sha=True,
+            head_sha=head_sha,
+            ci_run_id=run_id,
+            workflow_name=resolved_workflow,
+        )
+
+    # No run matched the HEAD SHA — distinguish "ran on a different SHA" from
+    # "never ran at all" so the two failure modes get distinct messages.
+    if runs:
+        latest_run = runs[0]
+        latest_sha = (latest_run.get("headSha") or "")[:12]
+        return _no_go(
+            f"{resolved_workflow} heeft niet gedraaid op HEAD {head_sha[:12]}; "
+            f"laatste run op '{branch}' was op {latest_sha}: "
+            "deze merge is niet toetsbaar (een run op een oudere commit telt niet)",
+            head_sha=head_sha,
+            workflow_name=resolved_workflow,
+        )
+    return _no_go(
+        f"Geen VNX CI-run gevonden voor {head_sha[:12]}: deze merge is niet toetsbaar",
+        head_sha=head_sha,
+        workflow_name=resolved_workflow,
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        prog="merge_preflight_ci_check",
+        description="Fail-closed check: does VNX CI have a successful run for the exact HEAD SHA?",
+    )
+    parser.add_argument("--project-root", required=True, help="Directory whose HEAD is being merged")
+    parser.add_argument("--branch", help="Branch name (defaults to git rev-parse --abbrev-ref HEAD)")
+    parser.add_argument("--head-sha", help="Exact HEAD SHA (defaults to git rev-parse HEAD)")
+    parser.add_argument("--workflow", help="CI workflow name (default: VNX_CI_WORKFLOW_NAME or 'VNX CI')")
+    parser.add_argument("--gh-bin", default="gh", help="Path/name of the gh binary")
+    parser.add_argument("--json", action="store_true", help="Emit the full result as JSON")
+    args = parser.parse_args(argv)
+
+    result = check_ci_run_for_head(
+        Path(args.project_root),
+        branch=args.branch,
+        head_sha=args.head_sha,
+        gh_bin=args.gh_bin,
+        workflow_name=args.workflow,
+    )
+
+    if args.json:
+        print(json.dumps(result))
+    else:
+        print(result["message"])
+    return 0 if result["verdict"] == "GO" else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_merge_preflight_ci_check.py
+++ b/tests/test_merge_preflight_ci_check.py
@@ -1,0 +1,259 @@
+#!/usr/bin/env python3
+"""Tests for the fail-closed VNX CI-run check (OI-1216).
+
+Covers the four required states from the dispatch, each with a stubbed ``gh``
+outcome (no network):
+  (a) successful run for the exact head SHA            -> GO
+  (b) zero runs                                        -> NO-GO
+  (c) run with conclusion=failure for the exact head   -> NO-GO
+  (d) success but for a DIFFERENT sha on the branch    -> NO-GO
+
+plus the fail-closed edges the dispatch names: gh missing, gh not
+authenticated, and a still-running (in_progress) run.
+"""
+
+import json
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+SCRIPT_DIR = Path(__file__).resolve().parent.parent / "scripts"
+sys.path.insert(0, str(SCRIPT_DIR / "lib"))
+sys.path.insert(0, str(SCRIPT_DIR))
+
+import merge_preflight_ci_check as mpci
+from merge_preflight_ci_check import (
+    check_ci_run_for_head,
+    DEFAULT_CI_WORKFLOW_NAME,
+    CI_WORKFLOW_NAME_ENV_VAR,
+)
+
+
+def _git_head_mock(sha: str) -> MagicMock:
+    return MagicMock(returncode=0, stdout=sha + "\n", stderr="")
+
+
+def _git_branch_mock(branch: str = "feature-branch") -> MagicMock:
+    return MagicMock(returncode=0, stdout=branch + "\n", stderr="")
+
+
+def _gh_auth_ok() -> MagicMock:
+    return MagicMock(returncode=0, stdout="", stderr="")
+
+
+def _gh_auth_fail(stderr: str = "You are not logged into any GitHub hosts.") -> MagicMock:
+    return MagicMock(returncode=1, stdout="", stderr=stderr)
+
+
+def _gh_run_output(conclusion, head_sha, status="completed", database_id=12345):
+    runs = [{
+        "conclusion": conclusion,
+        "headSha": head_sha,
+        "status": status,
+        "databaseId": database_id,
+    }]
+    return MagicMock(returncode=0, stdout=json.dumps(runs), stderr="")
+
+
+def _gh_empty_output():
+    return MagicMock(returncode=0, stdout=json.dumps([]), stderr="")
+
+
+def _subprocess_mocks(head_sha, branch="feature-branch"):
+    """git head -> git branch -> gh auth (ok) -> gh run list."""
+    return [
+        _git_head_mock(head_sha),
+        _git_branch_mock(branch),
+        _gh_auth_ok(),
+    ]
+
+
+GH_PRESENT = "/usr/local/bin/gh"
+
+
+class TestCheckCIRunForHead:
+    def test_ci_succeeded_for_exact_head(self, tmp_path):
+        """(a) successful run for the exact head SHA -> GO."""
+        sha = "a" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "GO"
+        assert result["ci_conclusion"] == "success"
+        assert result["ran_on_sha"] is True
+        assert result["head_sha"] == sha
+        assert "geslaagd" in result["message"]
+
+    def test_zero_runs_is_no_go(self, tmp_path):
+        """(b) zero runs -> NO-GO with a message that names the consequence."""
+        sha = "b" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_empty_output()]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert result["ran_on_sha"] is False
+        assert "Geen VNX CI-run gevonden" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_failure_conclusion_is_no_go(self, tmp_path):
+        """(c) run with conclusion=failure for the exact head -> NO-GO."""
+        sha = "c" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("failure", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert result["ci_conclusion"] == "failure"
+        assert result["ran_on_sha"] is True
+        assert "conclusion is 'failure'" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_success_on_different_sha_is_no_go(self, tmp_path):
+        """(d) success but for a DIFFERENT sha on the branch -> NO-GO."""
+        sha = "d" * 40
+        other = "e" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", other, database_id=99999)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert result["ran_on_sha"] is False
+        assert result["head_sha"] == sha
+        assert "heeft niet gedraaid op HEAD" in result["message"]
+        assert "oudere commit telt niet" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_in_progress_run_is_no_go(self, tmp_path):
+        """A still-running (in_progress) run for the exact head is NO-GO, not GO."""
+        sha = "f" * 40
+        mocks = _subprocess_mocks(sha) + [
+            _gh_run_output(None, sha, status="in_progress")
+        ]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert result["ran_on_sha"] is True
+        assert "draait nog" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_gh_not_available_is_no_go(self, tmp_path):
+        """gh missing -> NO-GO with a distinct message, never a silent GO."""
+        with patch("merge_preflight_ci_check.shutil.which", return_value=None):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "gh CLI niet beschikbaar" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_gh_not_authenticated_is_no_go(self, tmp_path):
+        """gh present but auth status fails -> NO-GO with a distinct message."""
+        sha = "g" * 40
+        mocks = [
+            _git_head_mock(sha),
+            _git_branch_mock(),
+            _gh_auth_fail(),
+        ]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "niet geauthenticeerd" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_gh_run_list_failure_is_no_go(self, tmp_path):
+        """gh run list non-zero exit -> NO-GO, never GO."""
+        sha = "h" * 40
+        run_fail = MagicMock(returncode=1, stdout="", stderr="HTTP 403")
+        mocks = _subprocess_mocks(sha) + [run_fail]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "gh run list faalde" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_gh_output_unparseable_is_no_go(self, tmp_path):
+        """gh emits non-JSON -> NO-GO, never a silent pass."""
+        sha = "i" * 40
+        bad_json = MagicMock(returncode=0, stdout="not json", stderr="")
+        mocks = _subprocess_mocks(sha) + [bad_json]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "niet te parsen" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_git_head_unresolvable_is_no_go(self, tmp_path):
+        """git rev-parse HEAD fails -> NO-GO, never a silent pass."""
+        git_fail = MagicMock(returncode=128, stdout="", stderr="fatal: not a git repository")
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=[git_fail]), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "NO-GO"
+        assert "HEAD-SHA kon niet worden bepaald" in result["message"]
+        assert "niet toetsbaar" in result["message"]
+
+    def test_uses_default_workflow_name(self, tmp_path):
+        """The gh run list call uses the default workflow name 'VNX CI'."""
+        sha = "j" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks) as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "GO"
+        gh_call_args = mock_run.call_args_list[3].args[0]
+        workflow_idx = gh_call_args.index("--workflow")
+        assert gh_call_args[workflow_idx + 1] == DEFAULT_CI_WORKFLOW_NAME
+
+    def test_explicit_workflow_name_wins(self, tmp_path):
+        """An explicit workflow_name argument is used verbatim."""
+        sha = "k" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks) as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path, workflow_name="CI/CD Pipeline")
+        assert result["verdict"] == "GO"
+        gh_call_args = mock_run.call_args_list[3].args[0]
+        workflow_idx = gh_call_args.index("--workflow")
+        assert gh_call_args[workflow_idx + 1] == "CI/CD Pipeline"
+
+    def test_env_workflow_name_override(self, tmp_path, monkeypatch):
+        """VNX_CI_WORKFLOW_NAME is used when no explicit argument is given."""
+        monkeypatch.setenv(CI_WORKFLOW_NAME_ENV_VAR, "CI/CD Pipeline")
+        sha = "l" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks) as mock_run, \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            result = check_ci_run_for_head(tmp_path)
+        assert result["verdict"] == "GO"
+        gh_call_args = mock_run.call_args_list[3].args[0]
+        workflow_idx = gh_call_args.index("--workflow")
+        assert gh_call_args[workflow_idx + 1] == "CI/CD Pipeline"
+
+
+class TestCLI:
+    def test_cli_json_go_exits_zero(self, tmp_path, capsys):
+        sha = "m" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_run_output("success", sha)]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            rc = mpci.main(["--project-root", str(tmp_path), "--json"])
+        assert rc == 0
+        out = json.loads(capsys.readouterr().out)
+        assert out["verdict"] == "GO"
+
+    def test_cli_json_no_go_exits_nonzero(self, tmp_path, capsys):
+        sha = "n" * 40
+        mocks = _subprocess_mocks(sha) + [_gh_empty_output()]
+        with patch("merge_preflight_ci_check.subprocess.run", side_effect=mocks), \
+             patch("merge_preflight_ci_check.shutil.which", return_value=GH_PRESENT):
+            rc = mpci.main(["--project-root", str(tmp_path), "--json"])
+        assert rc == 1
+        out = json.loads(capsys.readouterr().out)
+        assert out["verdict"] == "NO-GO"
+        assert "niet toetsbaar" in out["message"]


### PR DESCRIPTION
## OI-1216: nul CI-runs leest als "niets roods"

`scripts/commands/merge_preflight.sh` toetste nooit of er een geslaagde VNX
CI-run bestond voor de head die gemerged wordt. Gemeten op main (c12b28d7):
318 regels, nul treffers op `conclusion`, `gh run` en `VNX CI`. Een check die
toetst op de afwezigheid van rood geeft groen op een lege verzameling.

### Wat er verandert

- Nieuw testbaar python-hulpbestand `scripts/lib/merge_preflight_ci_check.py`
  dat fail-closed toetst op het BESTAAN van een geslaagde run voor de exacte
  head-SHA. Nul runs, `in_progress`, een gefaalde run, en een run op een
  oudere commit op dezelfde branch zijn allemaal NO-GO. De melding noemt de
  consequentie: "deze merge is niet toetsbaar".
- `merge_preflight.sh` krijgt een Check 6 die de helper aanroept en de
  verdict-wiring doet. Ontbrekende of niet-geauthenticeerde `gh` faalt dicht
  met een eigen melding; een onleesbaar antwoord van de helper is ook NO-GO.

### Keuze: python-helper boven inline bash

De CI-check doet subprocess naar `gh`, JSON-parsing en fail-closed branching.
Dat is in pure bash foutgevoelig; de repo heeft precies deze logica al in
`pre_merge_gate.check_ci_workflow` (OI-931) om die reden in Python staan. De
helper deelt dezelfde `gh run list`-invocatie en workflow-naam-resolutie
(`VNX_CI_WORKFLOW_NAME` > "VNX CI") als die gate-check, maar met GO/NO-GO
vocabulaire en merge-preflight-messaging.

### Tests

`tests/test_merge_preflight_ci_check.py` dekt de vier vereiste gevallen met
gestubde `gh`-uitkomsten (geen netwerk): (a) success exact head -> GO,
(b) nul runs -> NO-GO, (c) conclusion=failure -> NO-GO, (d) success andere
sha -> NO-GO. Plus de fail-closed randen: `gh` missing, `gh` niet
geauthenticeerd, `in_progress`, onparseerbare output, en workflow-naam-resolutie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)