### PR TITLE
feat(ci): validate workflow files in local-ci.sh via actionlint (OI-1222)

### DIFF
--- a/.github/workflows/vnx-ci.yml
+++ b/.github/workflows/vnx-ci.yml
@@ -508,13 +508,13 @@ jobs:
           else
             diff_range="HEAD^...HEAD"
           fi
-          changed=$(git diff --name-only "${diff_range}" \
+          mapfile -t changed < <(git diff --name-only "${diff_range}" \
             | grep -E '^(scripts|dashboard)/.*\.py$' || true)
-          if [ -z "$changed" ]; then
+          if [ "${#changed[@]}" -eq 0 ]; then
             echo "[skip] No Python files changed in scripts/ or dashboard/"
             exit 0
           fi
-          added=$(git diff --unified=0 "${diff_range}" -- $changed \
+          added=$(git diff --unified=0 "${diff_range}" -- "${changed[@]}" \
             | grep -E '^\+[^+]' | sed 's/^+//' || true)
           if [ -z "$added" ]; then
             echo "[skip] No added lines in target files"

--- a/scripts/check_workflows.py
+++ b/scripts/check_workflows.py
@@ -1,0 +1,181 @@
+#!/usr/bin/env python3
+"""GitHub Actions workflow validation gate (OI-1222).
+
+Lints every ``.github/workflows/*.yml`` (and ``*.yaml``) for the two failure
+classes that must not slip through local CI onto GitHub:
+
+1. YAML validity — the file parses at all.
+2. GitHub-Actions-specific shape — workflow/job/step structure, ``on:`` keys,
+   and expression/context references (``${{ ... }}``), via ``actionlint``.
+
+A YAML-valid file that GitHub still refuses (unknown context property, invalid
+``on:`` event) must fail locally too — parsing YAML alone is not enough. If
+``actionlint`` is not installed, the gate FAILS with an install instruction
+instead of silently skipping. A silently-skipped validation step is the exact
+defect this gate closes: an invalid workflow ships, GitHub produces zero runs,
+and every check that only looks for red reads that as green.
+
+See: dispatch OI-1222.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+ACTIONLINT_INSTALL_HINT = (
+    "actionlint is not installed. Install it before running local-ci, e.g.:\n"
+    "    brew install actionlint              # macOS (Homebrew)\n"
+    "    go install github.com/rhysd/actionlint/cmd/actionlint@latest\n"
+    "    or download a prebuilt binary from https://github.com/rhysd/actionlint/releases\n"
+    "The workflow-validate gate refuses to run without it: a silent skip is\n"
+    "exactly the failure mode this gate exists to close."
+)
+
+
+def workflow_files(root: Path) -> list[Path]:
+    """Return the sorted workflow files under ``.github/workflows/``."""
+    workflows_dir = root / ".github" / "workflows"
+    if not workflows_dir.is_dir():
+        return []
+    files = sorted(workflows_dir.glob("*.yml")) + sorted(workflows_dir.glob("*.yaml"))
+    seen: set[Path] = set()
+    unique: list[Path] = []
+    for f in files:
+        if f not in seen:
+            seen.add(f)
+            unique.append(f)
+    return unique
+
+
+def validate_yaml(path: Path) -> list[str]:
+    """Return YAML parse errors for a single workflow file (empty when valid)."""
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return [f"{path}: cannot read file: {exc}"]
+    try:
+        yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        return [f"{path}: invalid YAML: {exc}"]
+    return []
+
+
+def find_actionlint() -> Path | None:
+    """Return the ``actionlint`` binary path, or None when not installed."""
+    found = shutil.which("actionlint")
+    return Path(found) if found else None
+
+
+def _format_finding(obj: dict) -> str:
+    """Render one actionlint JSON finding as a single, readable string."""
+    loc = (
+        f"{obj.get('filepath', '?')}:"
+        f"{obj.get('line', '?')}:{obj.get('column', '?')}"
+    )
+    out = f"{loc}: {obj.get('message', '?')} [{obj.get('kind', '?')}]"
+    snippet = obj.get("snippet", "")
+    if snippet:
+        out += "\n" + "\n".join("      " + s for s in snippet.splitlines())
+    return out
+
+
+def run_actionlint(
+    files: list[Path], binary: Path, cwd: Path | None = None
+) -> list[str]:
+    """Run actionlint over ``files`` and return one entry per finding.
+
+    ``files`` may be relative to ``cwd`` for shorter, repo-relative output.
+    actionlint is asked for JSON (one object per finding) so the gate can
+    report an accurate count instead of one line per snippet row.
+    """
+    try:
+        result = subprocess.run(
+            [str(binary), "-format", "{{json .}}", *[str(f) for f in files]],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            stdin=subprocess.DEVNULL,
+            cwd=cwd,
+        )
+    except OSError as exc:
+        return [f"actionlint failed to run ({binary}): {exc}"]
+    except subprocess.TimeoutExpired:
+        return ["actionlint timed out after 120s"]
+
+    findings: list[str] = []
+    raw = result.stdout.strip()
+    if raw:
+        try:
+            parsed = json.loads(raw)
+        except json.JSONDecodeError:
+            # Non-JSON output (unexpected) — surface the raw lines verbatim.
+            findings.extend(
+                line.rstrip() for line in result.stdout.splitlines() if line.strip()
+            )
+        else:
+            if isinstance(parsed, list):
+                for item in parsed:
+                    if isinstance(item, dict):
+                        findings.append(_format_finding(item))
+                    else:
+                        findings.append(str(item))
+    if result.stderr.strip():
+        findings.append(f"actionlint stderr: {result.stderr.strip()}")
+    return findings
+
+
+def check_workflows(root: Path, actionlint_binary: Path | None = None) -> list[str]:
+    """Return all findings for the repo's workflows (empty when all green).
+
+    Combines the YAML parse layer with the actionlint layer. When actionlint is
+    unavailable this returns the install-instruction error so the caller
+    (``local-ci.sh``) reports a red gate instead of a silent pass.
+    """
+    files = workflow_files(root)
+    if not files:
+        return []  # nothing to validate — no workflow files in this tree
+
+    findings: list[str] = []
+    for path in files:
+        findings.extend(validate_yaml(path))
+
+    binary = actionlint_binary if actionlint_binary is not None else find_actionlint()
+    if binary is None:
+        findings.append(f"[actionlint missing] {ACTIONLINT_INSTALL_HINT}")
+        return findings
+
+    findings.extend(run_actionlint(files, binary, cwd=root))
+    return findings
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = argv if argv is not None else sys.argv[1:]
+    root = Path(args[0]).resolve() if args else Path.cwd()
+
+    if not workflow_files(root):
+        print("[workflow-validate] skip — no workflow files under .github/workflows/")
+        return 0
+
+    findings = check_workflows(root)
+
+    if not findings:
+        print(
+            "[workflow-validate] PASS — all workflow files are valid YAML "
+            "and pass actionlint."
+        )
+        return 0
+
+    print(f"[workflow-validate] FAIL — {len(findings)} finding(s):\n")
+    for finding in findings:
+        print(f"  {finding}")
+        print()
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/local-ci.sh
+++ b/scripts/local-ci.sh
@@ -8,6 +8,8 @@
 #
 # Registered gates:
 #   adr-003-no-sdk   billing-safety: no Anthropic SDK imports anywhere in-tree
+#   workflow-validate  CI-workflow validity: .github/workflows/*.yml parse as
+#                    YAML and pass actionlint (Actions shape + expressions)
 #   wheel-install    packaging acceptance: build wheel -> fresh venv -> install
 #                    -> vnx --version / vnx doctor / VNX_HOME schema resolution
 #                    (scripts/test_wheel_install.sh)
@@ -52,6 +54,9 @@ run_gate() {
 
 # --- gate: ADR-003 no-SDK import guard (billing safety) --------------------
 run_gate "adr-003-no-sdk" python3 "$REPO_ROOT/scripts/check_adr_003_no_sdk_imports.py"
+
+# --- gate: workflow validation (YAML + GitHub Actions shape) ---------------
+run_gate "workflow-validate" python3 "$REPO_ROOT/scripts/check_workflows.py" "$REPO_ROOT"
 
 # --- gate: wheel-install packaging smoke -----------------------------------
 if [ "${SKIP_WHEEL:-0}" = "1" ]; then

--- a/tests/test_workflow_validation.py
+++ b/tests/test_workflow_validation.py
@@ -1,0 +1,205 @@
+#!/usr/bin/env python3
+"""OI-1222: workflow validation gate tests.
+
+Pins the ``workflow-validate`` gate in ``scripts/local-ci.sh`` and exercises
+the ``check_workflows`` core: YAML parse layer, actionlint wiring, and the
+hard failure (with install instruction) when actionlint is missing.
+"""
+from __future__ import annotations
+
+import json
+import shlex
+import sys
+import textwrap
+from pathlib import Path
+
+import pytest
+
+TESTS_DIR = Path(__file__).resolve().parent
+VNX_ROOT = TESTS_DIR.parent
+SCRIPTS_DIR = VNX_ROOT / "scripts"
+
+sys.path.insert(0, str(SCRIPTS_DIR))
+from check_workflows import (  # noqa: E402
+    ACTIONLINT_INSTALL_HINT,
+    check_workflows,
+    find_actionlint,
+    run_actionlint,
+    validate_yaml,
+    workflow_files,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _workflow(tmp_path: Path, body: str) -> Path:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    f = wf_dir / "test.yml"
+    f.write_text(textwrap.dedent(body), encoding="utf-8")
+    return f
+
+
+def _fake_actionlint(tmp_path: Path, stdout: str, exit_code: int = 1) -> Path:
+    fake = tmp_path / "fake-actionlint"
+    lines = ["#!/usr/bin/env bash"]
+    if stdout:
+        lines.append(f"printf '%s\\n' {shlex.quote(stdout)}")
+    lines.append(f"exit {exit_code}")
+    fake.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    fake.chmod(0o755)
+    return fake
+
+
+def _finding_json(filepath: str, message: str) -> str:
+    return json.dumps(
+        [
+            {
+                "filepath": filepath,
+                "line": 1,
+                "column": 1,
+                "kind": "expression",
+                "message": message,
+                "snippet": "      - run: echo bad\n               ^~~",
+            }
+        ]
+    )
+
+
+# ---------------------------------------------------------------------------
+# YAML layer
+# ---------------------------------------------------------------------------
+
+
+def test_validate_yaml_accepts_valid(tmp_path: Path) -> None:
+    f = _workflow(
+        tmp_path,
+        """\
+        name: CI
+        on: [push]
+        jobs:
+          build:
+            runs-on: ubuntu-latest
+            steps:
+              - run: echo hi
+        """,
+    )
+    assert validate_yaml(f) == []
+
+
+def test_validate_yaml_rejects_invalid(tmp_path: Path) -> None:
+    f = _workflow(
+        tmp_path,
+        """\
+        name: CI
+        on: [push
+          broken
+        """,
+    )
+    errors = validate_yaml(f)
+    assert len(errors) == 1
+    assert "invalid YAML" in errors[0]
+
+
+def test_validate_yaml_reports_unreadable_file(tmp_path: Path) -> None:
+    f = tmp_path / ".github" / "workflows" / "missing.yml"
+    errors = validate_yaml(f)
+    assert len(errors) == 1
+    assert "cannot read file" in errors[0]
+
+
+# ---------------------------------------------------------------------------
+# Workflow file discovery
+# ---------------------------------------------------------------------------
+
+
+def test_workflow_files_finds_yml_and_yaml(tmp_path: Path) -> None:
+    wf_dir = tmp_path / ".github" / "workflows"
+    wf_dir.mkdir(parents=True)
+    (wf_dir / "a.yml").write_text("name: a\n", encoding="utf-8")
+    (wf_dir / "b.yaml").write_text("name: b\n", encoding="utf-8")
+    (wf_dir / "c.txt").write_text("not a workflow\n", encoding="utf-8")
+    names = [p.name for p in workflow_files(tmp_path)]
+    assert names == ["a.yml", "b.yaml"]
+
+
+def test_workflow_files_empty_when_dir_missing(tmp_path: Path) -> None:
+    assert workflow_files(tmp_path) == []
+
+
+def test_check_workflows_empty_when_no_workflows(tmp_path: Path) -> None:
+    assert check_workflows(tmp_path) == []
+
+
+# ---------------------------------------------------------------------------
+# actionlint wiring
+# ---------------------------------------------------------------------------
+
+
+def test_check_workflows_reports_missing_actionlint(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _workflow(tmp_path, "name: CI\non: [push]\njobs: {}\n")
+    monkeypatch.setattr("check_workflows.find_actionlint", lambda: None)
+    findings = check_workflows(tmp_path)
+    assert any("[actionlint missing]" in f for f in findings)
+    assert any("brew install actionlint" in f for f in findings)
+    assert any(ACTIONLINT_INSTALL_HINT.splitlines()[0] in f for f in findings)
+
+
+def test_run_actionlint_surfaces_findings(tmp_path: Path) -> None:
+    f = _workflow(tmp_path, "name: CI\non: [push]\njobs: {}\n")
+    fake = _fake_actionlint(
+        tmp_path, _finding_json(".github/workflows/test.yml", "fake finding")
+    )
+    findings = run_actionlint([f.relative_to(tmp_path)], fake, cwd=tmp_path)
+    assert len(findings) == 1
+    assert ".github/workflows/test.yml:1:1" in findings[0]
+    assert "fake finding" in findings[0]
+
+
+def test_run_actionlint_empty_json_is_clean(tmp_path: Path) -> None:
+    f = _workflow(tmp_path, "name: CI\non: [push]\njobs: {}\n")
+    fake = _fake_actionlint(tmp_path, "[]", exit_code=0)
+    assert run_actionlint([f.relative_to(tmp_path)], fake, cwd=tmp_path) == []
+
+
+def test_check_workflows_surfaces_actionlint_findings(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _workflow(tmp_path, "name: CI\non: [push]\njobs: {}\n")
+    fake = _fake_actionlint(
+        tmp_path, _finding_json(".github/workflows/test.yml", "fake finding")
+    )
+    monkeypatch.setattr("check_workflows.find_actionlint", lambda: fake)
+    findings = check_workflows(tmp_path)
+    assert any("fake finding" in f for f in findings)
+
+
+# ---------------------------------------------------------------------------
+# Gate registration pin (fails when the step is removed from local-ci.sh)
+# ---------------------------------------------------------------------------
+
+
+def test_local_ci_registers_workflow_validate_gate() -> None:
+    script = (VNX_ROOT / "scripts" / "local-ci.sh").read_text(encoding="utf-8")
+    assert 'run_gate "workflow-validate"' in script
+    assert "check_workflows.py" in script
+
+
+# ---------------------------------------------------------------------------
+# Repo-level scan
+# ---------------------------------------------------------------------------
+
+
+def test_repo_workflows_pass_validation() -> None:
+    if find_actionlint() is None:
+        pytest.skip("actionlint not installed")
+    findings = check_workflows(VNX_ROOT)
+    if findings:
+        pytest.fail(
+            "workflow validation finding(s) in repo:\n" + "\n".join(findings)
+        )


### PR DESCRIPTION
## Problem

Measured on main (c12b28d7): `grep -cE "workflows|actionlint|yamllint" scripts/local-ci.sh` returns **0**. An invalid `.github/workflows/*.yml` passes every local gate. On GitHub such a file yields zero runs, and zero runs read as green to any check that only tests for absence of red. A sister repo broke exactly this way.

## Change

- New gate `workflow-validate` in `scripts/local-ci.sh`, running the new `scripts/check_workflows.py` over `.github/workflows/*.yml` (and `*.yaml`).
- The gate covers both failure classes:
  - YAML validity via `pyyaml.safe_load` (the file parses at all).
  - GitHub Actions shape via `actionlint`: job/step structure, `on:` keys, and expression/context references (`${{ ... }}`). actionlint is asked for JSON so the gate reports one entry per finding, not one per snippet row.
- Missing `actionlint` is a **hard gate failure** with an install instruction (`brew install actionlint` / `go install` / prebuilt binary), not a silent skip. A silent skip is the exact defect this closes.
- Fixed one real finding the new gate surfaced in-tree: `vnx-ci.yml`'s lint job passed `$changed` unquoted to `git diff` (shellcheck SC2086). It now uses a bash array.

## Verification

- Negative case: a temp workflow referencing `github.nonexistent_property` makes `local-ci.sh` exit 1 with `1 finding(s)`; temp file removed after.
- Missing-actionlint case: the gate exits 1 with the install instruction.
- Green case: the existing 7 workflows pass `actionlint` and `local-ci.sh` exits 0.
- Tests: `tests/test_workflow_validation.py` (12 tests) plus the ADR-003 gate neighbor and workflow-surface neighbors all pass. The pin test fails when the gate registration line is removed from `local-ci.sh`.

Dispatch-ID: 20260815-nn-w3-localci-workflows