### PR TITLE
fix(dispatch): thread VNX_WORKER_ROLE into provider-lane spawn env (OI-1215)

### DIFF
--- a/scripts/lib/envelope_adapters_provider.py
+++ b/scripts/lib/envelope_adapters_provider.py
@@ -170,9 +170,18 @@ class ProviderAdapter:
             _resolve_deepseek_model,
             _resolve_moonshot_model,
             _resolve_zai_model,
+            _worker_role_env,
         )
 
         pv: "Provider" = plan.provider  # type: ignore[assignment]
+
+        # OI-1215: the provider-lane envelope calls the spawn_* functions DIRECTLY
+        # (it never goes through provider_dispatch._dispatch_* wrappers), so the
+        # VNX_WORKER_ROLE overlay must be built HERE from plan.role and threaded into
+        # each spawn's extra_env. Without it, every provider-lane worker resolves to
+        # the restrictive code-worker fallback in pretooluse_worker_scope_enforce.py
+        # even when the spec carried a genuine role.
+        role_env = _worker_role_env(plan.role)
 
         # ---- codex ----
         if pv == Provider.CODEX:
@@ -188,6 +197,7 @@ class ProviderAdapter:
                     dispatch_id=plan.dispatch_id,
                     terminal_id=plan.target_id,
                     event_writer=event_writer,
+                    extra_env=role_env,
                     cwd=cwd,
                 )
             except BrokenPipeError as exc:
@@ -217,6 +227,7 @@ class ProviderAdapter:
                     dispatch_id=plan.dispatch_id,
                     terminal_id=plan.target_id,
                     event_writer=event_writer,
+                    extra_env=role_env,
                     cwd=cwd,
                 )
             except BrokenPipeError as exc:
@@ -250,6 +261,7 @@ class ProviderAdapter:
                     event_writer=event_writer,
                     sub_provider=base_sub,
                     lane=lane_key,
+                    extra_env=role_env,
                     cwd=cwd,
                 )
             except BrokenPipeError as exc:
@@ -277,6 +289,7 @@ class ProviderAdapter:
                     dispatch_id=plan.dispatch_id,
                     terminal_id=plan.target_id,
                     event_writer=event_writer,
+                    extra_env=role_env,
                     cwd=cwd,
                     total_deadline=float(plan.deadline_seconds),
                 )
@@ -345,6 +358,7 @@ class ProviderAdapter:
                     dispatch_id=plan.dispatch_id,
                     terminal_id=plan.target_id,
                     event_writer=event_writer,
+                    extra_env=role_env,
                     cwd=cwd,
                     total_deadline=float(plan.deadline_seconds),
                 )
@@ -405,7 +419,7 @@ class ProviderAdapter:
             result = spawn_local_gemma(
                 instruction=instruction,
                 model=canonical_model,
-                role=None,
+                role=plan.role,
                 deadline_seconds=300,
                 dispatch_id=plan.dispatch_id,
                 project_id="vnx-dev",
@@ -468,6 +482,7 @@ class ProviderAdapter:
             KimiModelResolutionError,
             _kimi_resolve_cli_model_arg,
             _kimi_resolve_requested_key,
+            _worker_role_env,
         )
 
         # Shared resolver (20260721-kimi-lane-hardening): args.model/plan.model >
@@ -488,6 +503,7 @@ class ProviderAdapter:
                 dispatch_id=plan.dispatch_id,
                 terminal_id=plan.target_id,
                 event_writer=event_writer,
+                extra_env=_worker_role_env(plan.role),
                 cwd=cwd,
                 # worker-provider-kimi-flip (20260723): honor the spec's staged deadline
                 # instead of spawn_kimi's own hardcoded 900s default — a caller staging a

--- a/tests/data/dispatch_envelope_census.json
+++ b/tests/data/dispatch_envelope_census.json
@@ -561,6 +561,13 @@
       "symbol": "_receipt_exists_for_dispatch"
     },
     {
+      "file": "tests/test_envelope_provider_adapter_role_env.py",
+      "line": 37,
+      "mechanism": "direct-call",
+      "module_target": "envelope_adapters_provider",
+      "symbol": "ProviderAdapter"
+    },
+    {
       "file": "tests/test_envelope_ringbuffer_teardown_oi902.py",
       "line": 45,
       "mechanism": "direct-call",

--- a/tests/test_dispatch_envelope_plan.py
+++ b/tests/test_dispatch_envelope_plan.py
@@ -410,7 +410,7 @@ def test_instruction_read_from_file(tmp_path, monkeypatch):
 
     received_prompts: list = []
 
-    def fake_codex(prompt, model, dispatch_id, terminal_id, event_writer, cwd):
+    def fake_codex(prompt, model, dispatch_id, terminal_id, event_writer, cwd, extra_env=None):
         received_prompts.append(prompt)
         return _FakeSpawnResult()
 

--- a/tests/test_envelope_provider_adapter_role_env.py
+++ b/tests/test_envelope_provider_adapter_role_env.py
@@ -1,0 +1,181 @@
+"""test_envelope_provider_adapter_role_env.py — OI-1215: the provider-lane envelope
+adapter must thread ``VNX_WORKER_ROLE`` into every provider spawn's ``extra_env``.
+
+Measured root cause (OI-1215, punt 9): the door routes provider-lane dispatches
+through ``dispatch_cli.run_dispatch -> run_envelope_plan -> ProviderAdapter.run``,
+NOT through ``provider_dispatch._dispatch_*`` wrappers. ``ProviderAdapter.run``
+called the ``spawn_*`` functions WITHOUT ``role``/``extra_env``, so the
+``VNX_WORKER_ROLE`` overlay built by ``provider_dispatch._worker_role_env`` (the
+#1522 fix, exercised at its seven ``_dispatch_*`` call sites) never reached the
+provider-lane worker env. Every provider-lane worker therefore resolved to the
+restrictive code-worker fallback in ``pretooluse_worker_scope_enforce.py``.
+
+These tests pin the fix at the ONE loss point — the adapter — by mocking each
+spawn function and asserting it receives ``extra_env={"VNX_WORKER_ROLE": <role>}``
+for a genuinely-set role and ``extra_env=None`` (no fabricated role) when absent.
+
+Pre-merge vs post-merge evidence (the dispatch's own footgun, OI-1201): these
+tests exercise the adapter DIRECTLY (no real spawn), so they are PRE-MERGE proof
+that the new code threads the overlay. The end-to-end proof — a real provider-lane
+worker whose env actually contains ``VNX_WORKER_ROLE`` — is POST-MERGE only: the
+dispatcher builds the worker argv with main-branch code, so a worker on this
+feature branch is itself launched by the OLD adapter.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_spec import Provider  # noqa: E402
+from envelope_adapters_provider import ProviderAdapter  # noqa: E402
+
+
+class _OkSpawnResult:
+    """Minimal spawn-result stub with the attributes the adapter's mapping code reads."""
+
+    returncode = 0
+    error = None
+    timed_out = False
+    stopped_early = False
+    completion_text = "done"
+    event_writer_failures = 0
+    token_usage = {"input_tokens": 1, "output_tokens": 1}
+
+
+def _plan(provider: Provider, *, role="research-analyst", model="gpt-5-codex") -> SimpleNamespace:
+    return SimpleNamespace(
+        provider=provider,
+        model=model,
+        dispatch_id="oi1215-role-env-test",
+        target_id="T1",
+        deadline_seconds=900,
+        task_class=None,
+        role=role,
+    )
+
+
+# (provider, spawn-module-dotted-path, model) — one entry per subprocess-spawning
+# provider branch in ProviderAdapter.run. local-gemma runs in-process (no env) and
+# is asserted separately.
+SUBPROCESS_PROVIDERS = [
+    ("codex", "provider_spawns.codex_spawn.spawn_codex", "gpt-5-codex"),
+    ("gemini", "provider_spawns.gemini_spawn.spawn_gemini", "gemini-2.5-pro"),
+    ("litellm-deepseek", "provider_spawns.litellm_spawn.spawn_litellm", "deepseek-v4-pro"),
+    ("deepseek-harness", "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness", "deepseek-v4-pro"),
+    ("glm-harness", "provider_spawns.glm_harness_spawn.spawn_glm_harness", "glm-5.2"),
+]
+
+
+@pytest.mark.parametrize("provider_key,spawn_path,model", SUBPROCESS_PROVIDERS)
+def test_spawn_receives_worker_role_overlay(provider_key, spawn_path, model):
+    """A genuinely-set plan.role must reach each provider spawn's extra_env.
+
+    RED on origin/main: the adapter called the spawn WITHOUT extra_env, so the
+    call carried no ``VNX_WORKER_ROLE`` key at all.
+    """
+    provider = Provider({
+        "codex": "codex",
+        "gemini": "gemini",
+        "litellm-deepseek": "litellm:deepseek",
+        "deepseek-harness": "deepseek-harness",
+        "glm-harness": "glm-harness",
+    }[provider_key])
+    plan = _plan(provider, model=model)
+
+    with patch(spawn_path, return_value=_OkSpawnResult()) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    kwargs = mock_spawn.call_args.kwargs
+    assert "extra_env" in kwargs, (
+        f"{spawn_path} was called without an extra_env kwarg — the overlay is not threaded"
+    )
+    assert kwargs["extra_env"] == {"VNX_WORKER_ROLE": "research-analyst"}, (
+        f"{spawn_path} got extra_env={kwargs['extra_env']!r}, "
+        f"expected {{'VNX_WORKER_ROLE': 'research-analyst'}}"
+    )
+
+
+def test_kimi_spawn_receives_worker_role_overlay():
+    """The kimi branch (separate _run_kimi method) threads the same overlay."""
+    plan = _plan(Provider.KIMI, model="kimi-k3")
+
+    with (
+        patch("provider_dispatch._kimi_resolve_requested_key", return_value="kimi-k3"),
+        patch("provider_dispatch._kimi_resolve_cli_model_arg", return_value="kimi-k3"),
+        patch("provider_spawns.kimi_spawn.spawn_kimi", return_value=_OkSpawnResult()) as mock_spawn,
+    ):
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    kwargs = mock_spawn.call_args.kwargs
+    assert "extra_env" in kwargs
+    assert kwargs["extra_env"] == {"VNX_WORKER_ROLE": "research-analyst"}
+
+
+def test_absent_role_threads_no_overlay():
+    """role=None must thread extra_env=None — never a fabricated default role."""
+    plan = _plan(Provider.DEEPSEEK_HARNESS, role=None)
+
+    with patch(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness",
+        return_value=_OkSpawnResult(),
+    ) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    kwargs = mock_spawn.call_args.kwargs
+    assert "extra_env" in kwargs
+    assert kwargs["extra_env"] is None, (
+        f"absent role must thread extra_env=None, got {kwargs['extra_env']!r}"
+    )
+
+
+def test_identity_unresolved_sentinel_threads_no_overlay():
+    """The canonical identity_unresolved sentinel must NOT leak into the env."""
+    plan = _plan(Provider.DEEPSEEK_HARNESS, role="identity_unresolved")
+
+    with patch(
+        "provider_spawns.deepseek_harness_spawn.spawn_deepseek_harness",
+        return_value=_OkSpawnResult(),
+    ) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    assert mock_spawn.call_args.kwargs["extra_env"] is None
+
+
+def test_local_gemma_receives_plan_role():
+    """local-gemma spawns in-process (no env), but must still receive plan.role —
+    the hardcoded role=None was the same 'role never leaves the adapter' defect."""
+    plan = _plan(Provider.LOCAL_GEMMA, model="gemma-4b-local")
+
+    with patch(
+        "provider_spawns.local_gemma_spawn.spawn_local_gemma",
+        return_value=_OkSpawnResult(),
+    ) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    assert mock_spawn.call_args.kwargs["role"] == "research-analyst"
+
+
+def test_local_gemma_absent_role_is_none():
+    """role=None for local-gemma must stay None (no fabricated default)."""
+    plan = _plan(Provider.LOCAL_GEMMA, role=None, model="gemma-4b-local")
+
+    with patch(
+        "provider_spawns.local_gemma_spawn.spawn_local_gemma",
+        return_value=_OkSpawnResult(),
+    ) as mock_spawn:
+        ProviderAdapter().run(plan, "implement the change")
+
+    mock_spawn.assert_called_once()
+    assert mock_spawn.call_args.kwargs["role"] is None


### PR DESCRIPTION
## Summary

Punt 9 (OI-1215) meetopdracht: meten WAAR `VNX_WORKER_ROLE` verdwijnt tussen de dispatch-spec en de provider-lane worker, en daarna alleen die plek repareren.

**Meting (eenduidig):** de rol verdwijnt in `envelope_adapters_provider.py::ProviderAdapter.run`.

De keten op papier klopt van spec t/m plan:
- `dispatch-spec.json` veld `role` → `load_spec` → `DispatchSpec.role`
- `compile_plan` → `ExecutionPlan.role = spec.role` (`dispatch_plan.py:400`)
- `run_envelope_plan` → `EnvelopeSpec.role = plan.role` (`dispatch_envelope.py:478`)

Maar daarna: `run_dispatch` voert de provider-lane uit via `run_envelope_plan(plan, permit, ...)` → `ProviderAdapter().run(plan, ...)`. `ProviderAdapter.run` roept elke `spawn_*`-functie aan ZONDER `role`/`extra_env`. De `VNX_WORKER_ROLE`-overlay die `provider_dispatch._worker_role_env` bouwt (de #1522-fix op zeven `_dispatch_*`-aanroeppunten) wordt dus nooit bereikt, want de deur route provider-dispatches NIET via die `_dispatch_*`-wrappers.

**Live bewijs:** mijn eigen worker (deepseek-harness, `role=research-analyst`) heeft `VNX_CURRENT_DISPATCH_ID` wél in de env (bewijst dat de env-merge in `SubprocessAdapter.deliver` draaide) maar `VNX_WORKER_ROLE` niet (bewijst dat de overlay al vóór `deliver` leeg was).

## Changes

`scripts/lib/envelope_adapters_provider.py` — in `ProviderAdapter.run` (en `_run_kimi`) wordt `role_env = _worker_role_env(plan.role)` eenmaal gebouwd en als `extra_env` meegegeven aan elke subprocess-spawn (codex/gemini/litellm/deepseek-harness/glm-harness/kimi). local-gemma (in-process, geen env) krijgt `role=plan.role` i.p.v. de hardcoded `None`.

`tests/test_envelope_provider_adapter_role_env.py` — nieuw; bewijst per provider dat `extra_env={"VNX_WORKER_ROLE": <role>}` wordt meegegeven, en dat een afwezige rol/sentinel `extra_env=None` oplevert (geen gefabriceerde rol). Faalt 9/10 op de oude code, 10/10 groen op de nieuwe.

## Pre-merge vs post-merge bewijs

- **Pre-merge (gemeten):** de unit-test draait de adapter direct (geen spawn) en toont dat de nieuwe code de overlay meethreadt. Live-meting: eigen worker-env mist `VNX_WORKER_ROLE` terwijl `VNX_CURRENT_DISPATCH_ID` aanwezig is.
- **Post-merge (niet pre-merge te meten):** een echte provider-lane dispatch met een rol in de spec moet na de merge NIET meer `resolve_worker_profile: role is None` loggen in de deur-log. De dispatcher bouwt de argv met main-code, dus deze fix wordt pas na de merge door de volgende worker uitgevoerd (OI-1201).

## Verification

- `pytest tests/test_envelope_provider_adapter_role_env.py` → 10 passed
- Rood/groen: oude code 9 failed / 1 passed, nieuwe code 10 passed
- Buren: `test_provider_lane_role_propagation.py`, `test_envelope_role_propagation.py`, `test_dispatch_envelope_field_propagation.py`, `test_dispatch_envelope.py`, `test_role_applied_provider_lane.py`, `test_provider_adapter.py` → allemaal groen

🤖 Generated with [Claude Code](https://claude.com/claude-code)