### PR TITLE
fix(gate): persist governance_variant + gov_trace into plan-gate records

### DIFF
--- a/scripts/lib/plan_gate_evidence.py
+++ b/scripts/lib/plan_gate_evidence.py
@@ -48,13 +48,25 @@ def emit_plan_gate_pass(
     key_path: "str | Path | None" = None,
     seats: Optional[int] = None,
     scope: Optional[str] = None,
+    governance_variant: Optional[str] = None,
+    gov_trace: Optional[str] = None,
 ) -> Optional[Dict[str, Any]]:
     """Append a ``plan_gate_pass`` record for a track to the repo-committed ledger.
 
     ``seats`` carries how many panel seats decided a ``run``-resolver pass and
     ``scope`` whether it was a light or heavy run — a light pass is a REAL pass,
-    so its record must state the reduced panel size that certified it. Signed
-    when ``key_path`` + ``signer_identity`` are provided (tamper-proof);
+    so its record must state the reduced panel size that certified it.
+
+    ``governance_variant`` and ``gov_trace`` (since 2026-08-15) carry the
+    governance decision that sized the pass under its own names: the variant is
+    the OUTCOME (which seat-ladder step fired) and the trace is the REASON (the
+    derivation: weight, new-feature flag, seat count, chosen-by, override
+    direction). They are written only when provided (not ``None``), because a
+    manual ``attest`` resolver performs no derivation and must not carry a
+    fabricated one. On the round record (``record_round``) the same pair is
+    always present with an empty-string default — there an empty value means
+    "no derivation for this round"; here absence means "no derivation at all".
+    Signed when ``key_path`` + ``signer_identity`` are provided (tamper-proof);
     otherwise appended unsigned but hash-chained (tamper-evident). Best-effort:
     returns the appended record on success, ``None`` on any failure (never raises).
     """
@@ -76,6 +88,10 @@ def emit_plan_gate_pass(
             record["approval_id"] = approval_id
         if reason:
             record["reason"] = reason
+        if governance_variant is not None:
+            record["governance_variant"] = governance_variant
+        if gov_trace is not None:
+            record["gov_trace"] = gov_trace
         if key_path and signer_identity:
             from attestation import sign_manifest  # noqa: PLC0415
             record["signer_identity"] = signer_identity

--- a/scripts/lib/plan_gate_tiebreaker.py
+++ b/scripts/lib/plan_gate_tiebreaker.py
@@ -386,16 +386,35 @@ def record_round(
     outcome: str,
     model: str = "",
     timestamp: Optional[str] = None,
+    governance_variant: str = "",
+    gov_trace: str = "",
 ) -> bool:
     """Append a ``plan_gate_round`` record to the seat ledger.
 
     The record carries the round number, the outcome of that round
     (``panel`` for a full-panel round, ``tiebreak:START``/``tiebreak:STOP`` for
-    a tiebreaker round), and the model that decided it. Append-only and
-    hash-chained via ``append_chained_entry`` (the same primitive the seat
-    records use), so the round history is tamper-evident alongside the seat
-    verdicts. Best-effort and non-raising: round persistence must never break
-    the gate it hangs off (same contract as ``_emit_seat_records``).
+    a tiebreaker round), the model that decided it, and — since 2026-08-15 —
+    the governance decision that sized the round: ``governance_variant`` (the
+    seat-ladder variant that determined which seats the plan-gate got) and
+    ``gov_trace`` (the human-readable derivation: weight, new-feature flag,
+    seat count, chosen-by, and any operator override direction). The variant is
+    the OUTCOME; the trace is the REASON. Both are needed to reconstruct the
+    decision after the fact — a variant alone says which ladder step fired, but
+    not why (derived vs operator override, upgrade vs downgrade).
+
+    Missing-vs-empty is deliberately "always present, empty string when none":
+    both fields are written on EVERY round record, and an empty value means "no
+    governance decision was derived for this round" (a tiebreaker round carries
+    ``governance_variant="tiebreaker"`` and the panel round's trace, so only a
+    synthetic/legacy writer leaves them empty). A record MISSING the field is
+    an older-schema record, not a same-schema empty one — the distinction is
+    load-bearing for a later sweep that diffs old vs new records.
+
+    Append-only and hash-chained via ``append_chained_entry`` (the same
+    primitive the seat records use), so the round history is tamper-evident
+    alongside the seat verdicts. Best-effort and non-raising: round persistence
+    must never break the gate it hangs off (same contract as
+    ``_emit_seat_records``).
 
     Returns True when a record was appended, False when no ledger path was
     given or the append failed (the caller treats False as "not recorded" and
@@ -413,6 +432,8 @@ def record_round(
             "round": int(round_number),
             "outcome": outcome,
             "model": model,
+            "governance_variant": governance_variant,
+            "gov_trace": gov_trace,
             "recorded_at": timestamp or datetime.now(timezone.utc).isoformat(),
         }
         append_chained_entry(ledger, record)

--- a/scripts/planning_cli.py
+++ b/scripts/planning_cli.py
@@ -1921,11 +1921,15 @@ def _emit_plan_gate_pass_record(
     reason: Optional[str] = None,
     seats: Optional[int] = None,
     scope: Optional[str] = None,
+    governance_variant: Optional[str] = None,
+    gov_trace: Optional[str] = None,
 ) -> bool:
     """Best-effort durable ``plan_gate_pass`` record (ADR-030 primitive).
 
     Shared by ``plan-gate run`` (resolver="run", with the seat count + scope that
-    certified the pass) and ``plan-gate attest`` (resolver="attest"). Resolves the
+    certified the pass, plus ``governance_variant``/``gov_trace`` — the
+    governance decision that sized it) and ``plan-gate attest`` (resolver="attest",
+    which performs no derivation and therefore passes neither). Resolves the
     repo root from ``args.repo_root`` when the CLI passes one, else ``git
     rev-parse``, else cwd. Never raises — a record failure must never break the
     plan-gate resolution it hangs off (the runtime audit trail stays authoritative).
@@ -1947,6 +1951,7 @@ def _emit_plan_gate_pass_record(
             resolver=resolver, timestamp=_now_utc(),
             approval_id=approval_id, reason=reason,
             seats=seats, scope=scope,
+            governance_variant=governance_variant, gov_trace=gov_trace,
         )
         # emit_plan_gate_pass returns the appended record on success, None on any
         # failure (it never raises), so the try/except above cannot catch a failed
@@ -2554,6 +2559,7 @@ def _run_tiebreaker_for_track(
         track_id=track_id, project_id=project_id,
         round_number=round_number,
         outcome=f"tiebreak:{result.outcome}", model=result.model,
+        governance_variant="tiebreaker", gov_trace=gov_trace,
     )
 
     if result.outcome == plan_gate_tiebreaker.STOP:
@@ -2621,6 +2627,7 @@ def _run_tiebreaker_for_track(
             f"tiebreaker {result.outcome} (model={result.model}, "
             f"round={result.round})"
         ),
+        governance_variant="tiebreaker", gov_trace=gov_trace,
     )
     if not wrote:
         stderr_lines.append(
@@ -2867,6 +2874,7 @@ def run_plan_gate_for_track(
             _emit_plan_gate_pass_record(
                 repo_root=repo_root, track_id=track_id, project_id=project_id,
                 resolver="run", seats=0, scope=variant, reason=weight["gov_trace"],
+                governance_variant=variant, gov_trace=weight["gov_trace"],
             )
         stdout_json = json.dumps({
             "decision": "PASS",
@@ -2953,6 +2961,7 @@ def run_plan_gate_for_track(
             seat_ledger_path,
             track_id=track_id, project_id=project_id,
             round_number=rounds_done + 1, outcome="panel",
+            governance_variant=variant, gov_trace=weight["gov_trace"],
         )
 
     # OI-1190: persist the durable half of the plan decision onto the track — the
@@ -3055,6 +3064,7 @@ def run_plan_gate_for_track(
                 repo_root=repo_root, track_id=track_id, project_id=project_id,
                 resolver="run", seats=len(panel), scope=variant,
                 reason=weight["gov_trace"],
+                governance_variant=variant, gov_trace=weight["gov_trace"],
             )
             if not wrote:
                 stderr_lines.append(

--- a/tests/test_plan_gate_batch.py
+++ b/tests/test_plan_gate_batch.py
@@ -438,6 +438,63 @@ def test_batch_inherits_tiebreaker_after_two_panel_rounds(tmp_path, monkeypatch)
     assert "tiebreaker START" in rec["detail"]
 
 
+def test_panel_round_records_governance_variant_and_trace_to_seat_ledger(tmp_path, monkeypatch):
+    """A non-PASS panel round persists the governance decision that sized it.
+
+    ``governance_variant`` (the seat-ladder outcome) + ``gov_trace`` (the reason:
+    weight, seat count, chosen-by) used to be printed to stderr and dropped — the
+    on-disk ``plan_gate_round`` record carried the round number and outcome but
+    not WHY the round had the seats it had. This drives the REAL
+    ``run_plan_gate_for_track`` write path (only ``run_panel`` is stubbed, to a
+    REVISE so ``record_round`` fires) and reads the seat ledger back from disk,
+    so the assertion is on what LANDED, not on an in-memory dict. Fails as soon
+    as either field falls out of the ``record_round`` call in
+    ``run_plan_gate_for_track`` (or out of ``record_round``'s record dict).
+    """
+    monkeypatch.setattr(pgp, "_default_panel_config_path", lambda: tmp_path / "absent.yaml")
+    state_dir = _bootstrap(tmp_path)
+    _make_track(state_dir, "feat-gov", _THICK_GOAL)
+    _seed_blocker(state_dir, "feat-gov")
+
+    ledger = tmp_path / ".vnx-attest" / "plan-gate-seats.ndjson"
+    monkeypatch.setattr(pgp, "_resolve_seat_ledger_path", lambda data_dir: ledger)
+
+    def _revise(doc_path, *, doc_text=None, track_id, project_id, panel, data_dir, **kw):
+        return {
+            "track_id": track_id, "project_id": project_id, "decision": "REVISE",
+            "summary": {"decision": "REVISE", "pass_count": 0,
+                        "revise_count": 2, "block_count": 0,
+                        "rationale": "gaps remain"},
+            "panelists": [], "doc_truncation": {"truncated": False},
+        }
+
+    monkeypatch.setattr(pgp, "run_panel", _revise)
+    monkeypatch.setattr(planning_cli, "_emit_plan_gate_pass_record", lambda **kw: True)
+
+    summary = planning_cli._execute_batch(
+        ["feat-gov"], state_dir=str(state_dir), project_id="p1",
+        run_kwargs={}, restart=False, min_goal_chars=200,
+    )
+    assert summary["results"][0]["outcome"] == "REVISE"
+
+    from ndjson_hash_chain import walk_chain  # noqa: PLC0415
+    rounds = [
+        rec for _ln, rec, _h in walk_chain(ledger)
+        if rec.get("type") == pgt.ROUND_RECORD_TYPE
+    ]
+    assert rounds, "expected a plan_gate_round record for the REVISE panel round"
+    rec = rounds[-1]
+    assert rec["governance_variant"] == "default", (
+        "the derived seat-ladder variant must land on the round record"
+    )
+    assert "weight=default" in rec["gov_trace"], (
+        "the gov_trace must carry the derived weight"
+    )
+    assert "seat(s) by derived" in rec["gov_trace"], (
+        "the gov_trace must carry the seat count + chosen-by"
+    )
+
+
 def test_batch_renders_tally_line_and_outcome_labels(tmp_path, monkeypatch, capsys):
     """The rendered batch output carries the per-outcome tally, the per-track
     seat count, and the Dutch REFUSED_THIN label — and the tally sums to the

--- a/tests/test_plan_gate_tiebreaker.py
+++ b/tests/test_plan_gate_tiebreaker.py
@@ -172,6 +172,32 @@ def test_round_counter_is_per_track(tmp_path):
     assert pgt.read_round_count(ledger, "trk-b", "p1") == 0
 
 
+def test_record_round_always_writes_governance_fields_even_when_empty(tmp_path):
+    """A round record always carries ``governance_variant`` + ``gov_trace``.
+
+    The write path must not silently drop the pair when the writer derived
+    none: an empty string (same-schema "no derivation") is distinct from a
+    MISSING field (an older-schema record). A later sweep diffs the two, so the
+    fields must be present on every new record. Fails as soon as the fields fall
+    out of ``record_round``'s record dict.
+    """
+    ledger = tmp_path / "plan-gate-seats.ndjson"
+    assert pgt.record_round(
+        ledger, track_id="trk", project_id="p1", round_number=1, outcome="panel",
+    ) is True
+
+    rounds = [
+        rec for _ln, rec, _h in walk_chain(ledger)
+        if rec.get("type") == pgt.ROUND_RECORD_TYPE
+    ]
+    assert len(rounds) == 1
+    rec = rounds[0]
+    assert "governance_variant" in rec, "governance_variant must always be written"
+    assert "gov_trace" in rec, "gov_trace must always be written"
+    assert rec["governance_variant"] == ""
+    assert rec["gov_trace"] == ""
+
+
 def test_should_run_tiebreaker_threshold(tmp_path):
     """Below the threshold the full panel runs; at/above it the tiebreaker runs.
     Default threshold is 2 (read from the code default when no config overrides)."""


### PR DESCRIPTION
## Wat

Punt 7: `gov_trace` wordt gebouwd, geprint en weggegooid. De plan-gate bouwde een `governance_variant` en `gov_trace` om de zetel-ladder te sizen, printte de trace naar stderr, en gooide beide daarna weg. De governance-beslissing achter het aantal zetels was dus achteraf niet reconstructeerbaar.

## Aanpak

Beide velden landen nu op de duurzame records:

- **`plan_gate_round`** (`record_round`): altijd aanwezig, lege string als er geen derivatie was. Een ontbrekend veld = oud-schema-record, een lege string = zelfde-schema "geen derivatie". Deze distinctie is load-bearing voor een latere sweep die oud vs nieuw difft.
- **`plan_gate_pass`** (`emit_plan_gate_pass`): alleen geschreven wanneer meegegeven. Een handmatige `attest` resolver doet geen derivatie en mag geen verzonnen trace dragen.

De variant is de OUTCOME (welke ladder-trede afging), de trace is de REASON (gewicht, new-feature flag, zetel-aantal, chosen-by, override-richting).

## Bewijs

- `tests/test_plan_gate_tiebreaker.py`: unit-test dat `record_round` de twee velden altijd schrijft, ook leeg.
- `tests/test_plan_gate_batch.py`: integratie-test die de ECHTE `run_plan_gate_for_track` schrijfroute rijdt (alleen `run_panel` gestubd naar REVISE), het ledger terugleest van disk, en assert dat `governance_variant == "default"` en de trace de afgeleide weight + seat count bevat.

Targeted tests groen: 51 passed (test_plan_gate_tiebreaker + test_plan_gate_batch + test_plan_gate_evidence). Bekende pre-existente failures in `test_plan_gate_panel.py` (5, `sqlite3.OperationalError: no such column: output_ref`) zijn ongewijzigd en bewezen pre-existent op schone base.

Dispatch-ID: 20260815-nn-w6-govtrace-ledger