### PR TITLE
feat(gate): refuse post-merge verification on a stale local checkout (OI-1214)

### DIFF
--- a/scripts/lib/dispatch_bridge.py
+++ b/scripts/lib/dispatch_bridge.py
@@ -173,6 +173,7 @@ def stage_spec_bundle(
     requires_mcp: bool = False,
     allow_headless: bool = False,
     headless_reason: Optional[str] = None,
+    post_merge_verification: bool = False,
     pr_id: Optional[str] = None,
     tags: tuple[str, ...] = (),
     data_dir: Optional[Path] = None,
@@ -286,6 +287,7 @@ def stage_spec_bundle(
         "instruction_sha256": instruction_sha256,
         "allow_headless": bool(allow_headless),
         "headless_reason": norm_reason,
+        "post_merge_verification": bool(post_merge_verification),
     }
     spec_file = bundle_dir / "dispatch-spec.json"
     atomic_write_json(spec_file, spec_payload)
@@ -456,6 +458,13 @@ def main(argv: Optional[list] = None) -> int:
     parser.add_argument("--requires-mcp", action="store_true", dest="requires_mcp")
     parser.add_argument("--allow-headless", action="store_true", dest="allow_headless")
     parser.add_argument("--headless-reason", default=None, dest="headless_reason")
+    parser.add_argument(
+        "--post-merge-verification",
+        action="store_true",
+        dest="post_merge_verification",
+        help="Mark this dispatch as a post-merge verification: the door fails "
+             "closed (refuses) while the local main checkout lags origin/main.",
+    )
     parser.add_argument("--target-id-override", default=None, dest="target_id_override")
     parser.add_argument("--dry-run", action="store_true", dest="dry_run")
     parser.add_argument(
@@ -507,6 +516,7 @@ def main(argv: Optional[list] = None) -> int:
         requires_mcp=args.requires_mcp,
         allow_headless=args.allow_headless,
         headless_reason=args.headless_reason,
+        post_merge_verification=args.post_merge_verification,
         target_id_override=args.target_id_override,
         dry_run=args.dry_run,
     )

--- a/scripts/lib/dispatch_cli.py
+++ b/scripts/lib/dispatch_cli.py
@@ -16,6 +16,7 @@ import hashlib
 import json
 import logging
 import os
+import subprocess
 import sys
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
@@ -198,6 +199,7 @@ def load_spec(spec_file: Path) -> DispatchSpec:
         instruction_sha256=(raw.get("instruction_sha256") or None),
         allow_headless=raw.get("allow_headless") is True,
         headless_reason=_sanitize_headless_reason(raw.get("headless_reason")),
+        post_merge_verification=raw.get("post_merge_verification") is True,
     )
 
 
@@ -1161,6 +1163,81 @@ def _resolve_gate_via_router(vspec: ValidatedSpec) -> "tuple[ValidatedSpec, Opti
     return new_vspec, f"smart-router:{resolution.reason}"
 
 
+def main_checkout_lag(project_root: Path, *, ref: str = "origin/main") -> Optional[int]:
+    """Number of commits the checkout at *project_root* is behind *ref*.
+
+    OI-1214: the door builds every dispatch from the consumer's local main
+    checkout; when that lags ``origin/main``, a post-merge verification runs the
+    OLD code and reports a false negative. This returns the count — a NUMBER, not
+    a boolean — so the door can log "3 commits behind" instead of "out of date".
+
+    ``git rev-list --count HEAD..<ref>`` counts commits reachable from *ref* but
+    not from HEAD (exactly "behind"). Returns None when the distance cannot be
+    determined (not a git repo, no ``origin`` remote, or *ref* not yet fetched),
+    so "0" always means a genuinely current checkout and "unknown" is never
+    silently read as "up to date". Never raises.
+    """
+    try:
+        out = subprocess.run(
+            ["git", "-C", str(project_root), "rev-list", "--count", f"HEAD..{ref}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+    except (subprocess.CalledProcessError, OSError):
+        return None
+    try:
+        return int(out.stdout.strip())
+    except ValueError:
+        return None
+
+
+def _post_merge_verification_lag_verdict(lag: int) -> ConstraintVerdict:
+    """Fail-closed refusal for a post-merge-verification dispatch on a stale checkout.
+
+    The message names the CONSEQUENCE (this verification would measure the old
+    code and return a false negative) and the exact command that fixes it, rather
+    than only stating the fact that the checkout lags.
+    """
+    return ConstraintVerdict(
+        code="post-merge-verification-stale-checkout",
+        severity="blocking",
+        message=(
+            f"dispatch is a post-merge verification but the local main checkout is "
+            f"{lag} commit(s) behind origin/main — this verification would measure "
+            f"the old code and report a false negative. Bring the checkout current "
+            f"first: `git pull --ff-only` (or `git fetch origin && git merge "
+            f"--ff-only origin/main`)"
+        ),
+    )
+
+
+def _log_checkout_lag(spec: DispatchSpec, lag: Optional[int]) -> None:
+    """Log the local-checkout lag at every dispatch as a NUMBER, never a flag.
+
+    OI-1214: "3 commits behind" is actionable; "out of date" is not. A lag of 0
+    (current) and a lag > 0 are both logged; only an unresolvable ref logs the
+    honest "unknown" state, which callers must not read as "up to date".
+    """
+    if lag is None:
+        logger.info(
+            "[dispatch_cli] dispatch=%s: local main checkout behind origin/main: "
+            "unknown (origin/main not resolvable — not a git repo or no origin remote)",
+            spec.dispatch_id,
+        )
+    elif lag == 0:
+        logger.info(
+            "[dispatch_cli] dispatch=%s: local main checkout is 0 commits behind origin/main",
+            spec.dispatch_id,
+        )
+    else:
+        logger.warning(
+            "[dispatch_cli] dispatch=%s: local main checkout is %d commits behind origin/main",
+            spec.dispatch_id,
+            lag,
+        )
+
+
 def build_runtime_snapshot(
     vspec: ValidatedSpec,
     *,
@@ -1436,6 +1513,27 @@ def build_runtime_snapshot(
     # door owns env reads, so compute it here and hand it to the pure compile_plan
     # via the snapshot.
     claude_api_metered = claude_auth_is_api_metered(os.environ)
+
+    # OI-1214: the door builds every dispatch from the consumer's local main
+    # checkout. Measure how far that checkout lags origin/main — a NUMBER — and
+    # fail-closed on a post-merge-verification dispatch that would run the old
+    # code. The consumer root is resolved exactly as the worktree allocator does
+    # (resolve_consumer_project_root), so the lag is measured against the same
+    # checkout the worker will actually build in. Best-effort: an unresolvable
+    # root/ref logs an unknown lag and never blocks (fail-open on unknown,
+    # fail-closed on a KNOWN lag — a door that refused on "unknown" would block
+    # every non-git consumer, which is worse than the problem it fixes).
+    checkout_lag: Optional[int] = None
+    try:
+        from dispatch_worktree_isolation import resolve_consumer_project_root  # noqa: PLC0415
+        checkout_lag = main_checkout_lag(resolve_consumer_project_root())
+    except Exception as exc:  # vnx-silent-except: lag is advisory except for the refusal below; resolution must never block the door
+        logger.debug("[dispatch_cli] checkout-lag resolution failed for dispatch=%s: %s", spec.dispatch_id, exc)
+    _log_checkout_lag(spec, checkout_lag)
+    if checkout_lag is not None and checkout_lag > 0 and spec.post_merge_verification:
+        constraint_verdicts = constraint_verdicts + (
+            _post_merge_verification_lag_verdict(checkout_lag),
+        )
 
     return RuntimeSnapshot(
         constraint_verdicts=constraint_verdicts,

--- a/scripts/lib/dispatch_spec.py
+++ b/scripts/lib/dispatch_spec.py
@@ -167,6 +167,18 @@ class DispatchSpec:
     instruction_sha256: Optional[str] = None  # P0-3: caller may pre-bind hash; validate() verifies
     allow_headless: bool = False              # PR-5: explicit opt-in to the claude_headless lane
     headless_reason: Optional[str] = None    # PR-5: mandatory non-empty reason when allow_headless=True
+    # OI-1214: a post-merge-verification dispatch measures the CURRENT checkout
+    # (proof that a just-merged PR is actually live), so it is only meaningful
+    # when the local main checkout is current. This is a typed boolean declared by
+    # the caller — the simplest form that fits the spec's existing declared fields
+    # (mirrors `irreversible` / `allow_headless` / `requires_mcp`) and cannot
+    # collide with the free-form `tags`/intelligence vocabulary the way a magic tag
+    # string would. Default False means a normal build dispatch carries NO burden:
+    # the door logs the lag number for every dispatch but only REFUSES when this
+    # flag is set AND the checkout is behind — a door that blocked everything on
+    # lag would be worse than the problem it fixes. Like `irreversible`, it is a
+    # caller declaration, never derived from instruction text or role.
+    post_merge_verification: bool = False
     # DERIVED-not-declared (deliberately absent): lane, billing, serialization_class
     # — compile_plan owns them. Do not add here.
 

--- a/scripts/lib/dispatch_worktree_isolation.py
+++ b/scripts/lib/dispatch_worktree_isolation.py
@@ -682,9 +682,10 @@ def remove_dispatch_worktree(
             if _current_head and _current_head != _claim_main_head:
                 log.warning(
                     "OI-975 HEAD-JUMP DETECTED: main checkout HEAD changed "
-                    "during dispatch %s: was %s, now %s — something ran "
-                    "'git checkout' in the main checkout while this dispatch "
-                    "was active",
+                    "during dispatch %s (was %s, now %s) — the checkout no longer "
+                    "matches what this dispatch was launched against, so any "
+                    "post-dispatch verification on this checkout may measure "
+                    "different code than the dispatch actually built",
                     dispatch_id,
                     _claim_main_head[:12],
                     _current_head[:12],

--- a/tests/test_checkout_lag_gate.py
+++ b/tests/test_checkout_lag_gate.py
@@ -1,0 +1,336 @@
+"""test_checkout_lag_gate.py — OI-1214: the door refuses a post-merge-verification
+dispatch while the local main checkout lags origin/main, and logs the lag as a
+number at every dispatch.
+
+Tests the pure lag helper, the pure verdict builder, and the door integration via
+build_runtime_snapshot + compile_plan. The git fixture builds a KNOWN lag entirely
+with local operations (side-branch commits + ``update-ref`` of the remote-tracking
+ref) — no network fetch, so every assertion is deterministic offline.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts" / "lib"))
+
+from dispatch_cli import (
+    _post_merge_verification_lag_verdict,
+    build_runtime_snapshot,
+    load_spec,
+    main_checkout_lag,
+)
+from dispatch_plan import compile_plan
+from dispatch_spec import Reject, validate
+
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+# ---------------------------------------------------------------------------
+# Local git fixtures — a real, deterministic lag with no network fetch
+# ---------------------------------------------------------------------------
+
+def _init_repo_with_origin(tmp_path: Path) -> Path:
+    """Bare origin + local clone with an initial commit on ``main``.
+
+    Returns the local clone path. Mirrors
+    ``test_provider_dispatch_worktree_isolation._init_git_repo_with_origin``.
+    """
+    bare = tmp_path / "origin.git"
+    bare.mkdir()
+    subprocess.run(
+        ["git", "init", "--bare", "--initial-branch=main", str(bare)],
+        check=True, capture_output=True,
+    )
+    local = tmp_path / "local"
+    subprocess.run(
+        ["git", "clone", str(bare), str(local)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "main"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    (local / "README.md").write_text("init\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(local), "add", "README.md"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "commit", "-m", "initial"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "push", "-u", "origin", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+def _init_repo_with_lag(tmp_path: Path, behind: int) -> Path:
+    """Local clone whose ``origin/main`` remote-tracking ref is *behind* commits
+    ahead of the checked-out ``main``.
+
+    The new commits are created on a side branch in the SAME clone, then the
+    remote-tracking ref is moved to their tip with ``update-ref`` — HEAD never
+    leaves ``main``, and nothing is fetched. ``git rev-list --count HEAD..origin/main``
+    then reports exactly *behind*.
+    """
+    local = _init_repo_with_origin(tmp_path)
+    if behind <= 0:
+        return local
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "-b", "ahead"],
+        check=True, capture_output=True,
+    )
+    for i in range(behind):
+        (local / f"ahead-{i}.txt").write_text(f"{i}\n", encoding="utf-8")
+        subprocess.run(
+            ["git", "-C", str(local), "add", f"ahead-{i}.txt"],
+            check=True, capture_output=True,
+        )
+        subprocess.run(
+            ["git", "-C", str(local), "commit", "-m", f"ahead {i}"],
+            check=True, capture_output=True,
+        )
+    tip = subprocess.check_output(
+        ["git", "-C", str(local), "rev-parse", "HEAD"],
+        text=True,
+    ).strip()
+    subprocess.run(
+        ["git", "-C", str(local), "update-ref", "refs/remotes/origin/main", tip],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(local), "checkout", "main"],
+        check=True, capture_output=True,
+    )
+    return local
+
+
+def _init_repo_without_origin(tmp_path: Path) -> Path:
+    """A local repo with a commit and no ``origin`` remote (lag is unresolvable)."""
+    repo = tmp_path / "no-origin"
+    repo.mkdir()
+    subprocess.run(
+        ["git", "init", "--initial-branch=main", str(repo)],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.email", "test@test.local"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "config", "user.name", "Test"],
+        check=True, capture_output=True,
+    )
+    (repo / "f.txt").write_text("x\n", encoding="utf-8")
+    subprocess.run(
+        ["git", "-C", str(repo), "add", "f.txt"],
+        check=True, capture_output=True,
+    )
+    subprocess.run(
+        ["git", "-C", str(repo), "commit", "-m", "init"],
+        check=True, capture_output=True,
+    )
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# Bundle + snapshot helpers
+# ---------------------------------------------------------------------------
+
+def _make_bundle(
+    tmp_path: Path,
+    *,
+    staging_id: str = "20260815-staging-lag",
+    dispatch_id: str = "20260815-lag-dispatch",
+    post_merge_verification: bool = False,
+) -> "tuple[Path, Path]":
+    """A promoted bundle (under pending/) so staging-binding passes and only the
+    lag edge under test can reject. Returns (data_dir, spec_file)."""
+    data_dir = tmp_path / "vnx-data"
+    bundle_dir = data_dir / "dispatches" / "pending" / staging_id
+    bundle_dir.mkdir(parents=True)
+    inst = bundle_dir / "instruction.md"
+    inst.write_text(
+        "# Lag gate probe\n\nRole: backend-developer\n\nVerify the merged code is live.\n",
+        encoding="utf-8",
+    )
+    spec = {
+        "schema_version": 1,
+        "project_id": "vnx-dev",
+        "dispatch_id": dispatch_id,
+        "staging_id": staging_id,
+        "instruction_file": str(inst),
+        "role": "backend-developer",
+        "target_slot": "T0",
+        "gate": "human-promoted",
+        "dispatch_paths": [],
+        "provider": "claude",
+        "model": None,
+        "deadline_seconds": 3600,
+        "isolation": "worktree",
+        "post_merge_verification": post_merge_verification,
+    }
+    spec_file = bundle_dir / "dispatch-spec.json"
+    spec_file.write_text(json.dumps(spec), encoding="utf-8")
+    return data_dir, spec_file
+
+
+def _snapshot_for_fixture(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    project_root: Path,
+    *,
+    post_merge_verification: bool = False,
+    staging_id: str = "20260815-staging-lag",
+    dispatch_id: str = "20260815-lag-dispatch",
+):
+    """Point VNX_PROJECT_ROOT at the git fixture and build the door's snapshot."""
+    data_dir, spec_file = _make_bundle(
+        tmp_path,
+        staging_id=staging_id,
+        dispatch_id=dispatch_id,
+        post_merge_verification=post_merge_verification,
+    )
+    monkeypatch.setenv("VNX_PROJECT_ROOT", str(project_root))
+    spec = load_spec(spec_file)
+    vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+    assert not isinstance(vspec, Reject)
+    return build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
+
+
+def _lag_verdicts(snapshot):
+    return [
+        v for v in snapshot.constraint_verdicts
+        if v.code == "post-merge-verification-stale-checkout"
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Pure lag helper
+# ---------------------------------------------------------------------------
+
+def test_main_checkout_lag_zero_when_current(tmp_path):
+    """A fresh clone where origin/main == HEAD reports 0, not None."""
+    local = _init_repo_with_lag(tmp_path, behind=0)
+    assert main_checkout_lag(local) == 0
+
+
+def test_main_checkout_lag_returns_exact_distance(tmp_path):
+    """The reported number is the ACTUAL commit distance, not a flag."""
+    local = _init_repo_with_lag(tmp_path, behind=3)
+    assert main_checkout_lag(local) == 3
+
+
+def test_main_checkout_lag_none_without_origin(tmp_path):
+    """An unresolvable origin/main returns None (unknown), never a false 0."""
+    repo = _init_repo_without_origin(tmp_path)
+    assert main_checkout_lag(repo) is None
+
+
+def test_main_checkout_lag_none_for_non_git_dir(tmp_path):
+    """A non-git directory returns None rather than raising."""
+    assert main_checkout_lag(tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# Pure verdict builder
+# ---------------------------------------------------------------------------
+
+def test_post_merge_verification_verdict_names_consequence_and_fix():
+    """The refusal names the consequence AND the fixing command, not just the fact."""
+    v = _post_merge_verification_lag_verdict(3)
+    assert v.code == "post-merge-verification-stale-checkout"
+    assert v.severity == "blocking"
+    assert "measure the old code" in v.message
+    assert "false negative" in v.message
+    assert "git pull --ff-only" in v.message
+    assert "3 commit(s) behind origin/main" in v.message
+
+
+# ---------------------------------------------------------------------------
+# Door integration: the four dispatch-specified behaviors
+# ---------------------------------------------------------------------------
+
+def test_zero_lag_lets_post_merge_verification_through(tmp_path, monkeypatch):
+    """Zero lag passes a verification dispatch (no blocking verdict)."""
+    local = _init_repo_with_lag(tmp_path, behind=0)
+    snapshot = _snapshot_for_fixture(
+        tmp_path, monkeypatch, local, post_merge_verification=True,
+    )
+    assert _lag_verdicts(snapshot) == []
+
+
+def test_lag_blocks_post_merge_verification_dispatch(tmp_path, monkeypatch):
+    """A known lag > 0 emits a BLOCKING verdict for a verification dispatch."""
+    local = _init_repo_with_lag(tmp_path, behind=3)
+    snapshot = _snapshot_for_fixture(
+        tmp_path, monkeypatch, local, post_merge_verification=True,
+    )
+    blocks = _lag_verdicts(snapshot)
+    assert blocks and blocks[0].severity == "blocking"
+
+
+def test_lag_blocks_verification_reaches_compile_plan_reject(tmp_path, monkeypatch):
+    """The blocking verdict flows through compile_plan D3 into a Reject."""
+    local = _init_repo_with_lag(tmp_path, behind=2)
+    data_dir, spec_file = _make_bundle(tmp_path, post_merge_verification=True)
+    monkeypatch.setenv("VNX_PROJECT_ROOT", str(local))
+    spec = load_spec(spec_file)
+    vspec = validate(spec, project_id="vnx-dev", repo_root=_REPO_ROOT)
+    assert not isinstance(vspec, Reject)
+    snapshot = build_runtime_snapshot(vspec, data_dir=data_dir, spec_file=spec_file)
+    plan = compile_plan(vspec, snapshot)
+    assert isinstance(plan, Reject)
+    assert plan.code == "post-merge-verification-stale-checkout"
+
+
+def test_lag_allows_normal_build_dispatch(tmp_path, monkeypatch):
+    """A normal build dispatch is NOT refused on lag (no burden — the marker is off)."""
+    local = _init_repo_with_lag(tmp_path, behind=3)
+    snapshot = _snapshot_for_fixture(
+        tmp_path, monkeypatch, local, post_merge_verification=False,
+    )
+    assert _lag_verdicts(snapshot) == []
+
+
+# ---------------------------------------------------------------------------
+# Logging: the number, not a flag
+# ---------------------------------------------------------------------------
+
+def test_logged_number_matches_distance(tmp_path, monkeypatch, caplog):
+    """The door logs the ACTUAL count ('3 commits behind'), never a boolean."""
+    local = _init_repo_with_lag(tmp_path, behind=3)
+    with caplog.at_level(logging.WARNING, logger="dispatch_cli"):
+        _snapshot_for_fixture(
+            tmp_path, monkeypatch, local, post_merge_verification=True,
+        )
+    assert "3 commits behind origin/main" in caplog.text
+    assert "1 commits behind origin/main" not in caplog.text
+
+
+def test_logged_zero_when_current(tmp_path, monkeypatch, caplog):
+    """A current checkout logs '0 commits behind' — the number is always present."""
+    local = _init_repo_with_lag(tmp_path, behind=0)
+    with caplog.at_level(logging.INFO, logger="dispatch_cli"):
+        _snapshot_for_fixture(
+            tmp_path, monkeypatch, local, post_merge_verification=False,
+        )
+    assert "0 commits behind origin/main" in caplog.text


### PR DESCRIPTION
## Problem

The single-entry door builds every dispatch from the local main checkout. When that checkout lags `origin/main`, a post-merge verification runs the old code and reports a false negative without warning. This happened in production: a verification ran on 9 merges of old code and produced a false negative.

## Change

- The door logs, at every dispatch, how many commits the local checkout is behind `origin/main`: a number ("3 commits behind"), never a flag ("out of date").
- A dispatch marked `post_merge_verification` is **refused** (blocking verdict, not a warning) while the checkout lags. The message names the consequence ("this verification would measure the old code") and the fix command (`git pull --ff-only`).
- The marker is a typed boolean on `DispatchSpec` (`post_merge_verification: bool = False`), mirroring `irreversible` / `allow_headless` / `requires_mcp`. A magic tag string would collide with the free-form `tags`/intelligence vocabulary; a typed field cannot. Default `False` means a normal build dispatch carries no burden: the lag is logged for every dispatch, but nothing is refused.
- Fail-open on an unresolvable `origin/main` (not a git repo, no remote), fail-closed on a known lag. Refusing on "unknown" would block every non-git consumer, which is worse than the problem this fixes.
- The OI-975 HEAD-JUMP warning now names its consequence too.

## Marker choice

A boolean field is the simplest form that fits the existing spec. `tags` is free-form and already carries intelligence vocabulary; encoding control flow in it is silent drift. The boolean is explicit, typed, and discoverable, and its default keeps every existing dispatch byte-for-byte unchanged.

## Verification

- `pytest tests/test_checkout_lag_gate.py` (11 new tests) green: zero lag passes, lag blocks a verification dispatch, lag lets a normal build dispatch through, and the logged number matches the actual distance. The git fixture builds a known lag with local operations only (side-branch commits + `update-ref`), no network fetch.
- Neighbour suites green: `test_dispatch_cli.py`, `test_dispatch_plan.py`, `test_dispatch_spec.py`, `test_dispatch_bridge_staging.py`, `test_provider_dispatch_worktree_isolation.py`, `test_dispatch_worktree_identity_race.py`, `test_subprocess_dispatch_worktree_isolation.py` (466 tests total).
- `scripts/ci_lint_patterns.py --files-from-stdin` clean on all changed files.

Dispatch-ID: 20260815-nn-w7-deur-achterstand-dicht