### PR TITLE
feat(providers): rebuild cost ladder as ordered tiers + quality escalation (OI-1221)

### DIFF
--- a/scripts/lib/providers/provider_registry.py
+++ b/scripts/lib/providers/provider_registry.py
@@ -83,6 +83,23 @@ class TierRouteSpec:
     fallback: tuple = ()  # tuple[TierRouteStep, ...]
 
 
+@dataclass(frozen=True)
+class TierLadderRung:
+    """One rung of the cost-ordered escalation ladder.
+
+    Carries the resolved primary (provider/model/lane) plus the primary model's
+    output cost read from the registry, so the ladder's ordering is derived from
+    the registry's own prices — never a Python literal (ADR-036).
+    """
+
+    tier: str
+    provider: str
+    model: str
+    lane: str
+    output_cost_per_mtok: float
+    fallback: tuple = ()  # tuple[TierRouteStep, ...]
+
+
 def _parse_model(data: dict) -> ProviderModel:
     context_window_raw = data.get("context_window")
     cli_model_arg_raw = data.get("cli_model_arg")
@@ -239,3 +256,76 @@ def load_tier_map(registry_path: Optional[Path] = None) -> Dict[str, TierRouteSp
             fallback=fallback,
         )
     return result
+
+
+def _output_cost_for(
+    spec: TierRouteSpec,
+    providers: Dict[str, ProviderConfig],
+    path: Path,
+) -> float:
+    """Resolve a tier's primary model output cost ($/Mtok) from the registry.
+
+    ``spec.provider`` is the dispatch enum (e.g. "claude"), not the registry
+    section key (e.g. "anthropic"); walk the sections by their dispatch_enum to
+    find the model and read its registered price. Fails loud when the model is
+    not found — the ladder must never invent a price.
+    """
+    for cfg in providers.values():
+        if cfg.dispatch_enum != spec.provider:
+            continue
+        model = cfg.models.get(spec.model)
+        if model is not None:
+            return model.cost_output_per_mtok
+    raise RegistryLookupError(
+        f"cannot resolve output cost for {spec.provider!r}/{spec.model!r} "
+        f"(tier {spec.tier!r}) in {path}"
+    )
+
+
+def load_tier_ladder(registry_path: Optional[Path] = None) -> List[TierLadderRung]:
+    """Return the escalation ladder in the tier_map's authored order, validated.
+
+    The ladder is DERIVED from the registry (ADR-036): each tier's primary model
+    cost is read from wave7_models.yaml — never a Python literal. The ``routing.
+    tier_map`` block is itself the ladder: its authored order IS the climb order
+    (tier-zero first, tier-high last), and two invariants are enforced fail-loud
+    so a drift that would make escalation a no-op surfaces at load, not silently:
+
+      1. no two tiers may resolve to the same primary (provider, model) — a
+         duplicate rung means tier_from + 1 changes nothing;
+      2. primary cost must be strictly increasing along the authored order — a
+         higher rung must actually be more expensive, otherwise "escalation" is
+         a price cut in disguise.
+    """
+    path = Path(registry_path) if registry_path is not None else _REGISTRY_PATH
+    tier_map = load_tier_map(path)
+    providers = load(path)
+    rungs: List[TierLadderRung] = []
+    seen = set()
+    for spec in tier_map.values():
+        key = (spec.provider, spec.model)
+        if key in seen:
+            raise RegistryLookupError(
+                f"routing.tier_map has duplicate rungs: {spec.provider!r}/"
+                f"{spec.model!r} appears in more than one tier ({path}); merge "
+                "them or give them a real difference"
+            )
+        seen.add(key)
+        rungs.append(
+            TierLadderRung(
+                tier=spec.tier,
+                provider=spec.provider,
+                model=spec.model,
+                lane=spec.lane,
+                output_cost_per_mtok=_output_cost_for(spec, providers, path),
+                fallback=spec.fallback,
+            )
+        )
+    for lo, hi in zip(rungs, rungs[1:]):
+        if not (lo.output_cost_per_mtok < hi.output_cost_per_mtok):
+            raise RegistryLookupError(
+                f"routing.tier_map is not a strict cost ladder: {hi.tier!r} "
+                f"({hi.model} @ {hi.output_cost_per_mtok}) is not more expensive "
+                f"than {lo.tier!r} ({lo.model} @ {lo.output_cost_per_mtok}) in {path}"
+            )
+    return rungs

--- a/scripts/lib/providers/smart_router/__init__.py
+++ b/scripts/lib/providers/smart_router/__init__.py
@@ -27,7 +27,13 @@ from .classifier import (  # noqa: F401
     write_route_decision,
 )
 from .cost_tier import classify_dispatch  # noqa: F401
-from .tier_routing import TierRoute, resolve_tier_route  # noqa: F401
+from .tier_routing import (  # noqa: F401
+    TierEscalation,
+    TierRoute,
+    escalate_tier,
+    next_tier,
+    resolve_tier_route,
+)
 
 __all__ = [
     "classify_task",
@@ -39,7 +45,10 @@ __all__ = [
     "RouteDecision",
     "classify_dispatch",
     "TierRoute",
+    "TierEscalation",
     "resolve_tier_route",
+    "next_tier",
+    "escalate_tier",
     "lane_available",
     "lane_cooldown_remaining",
     "cooldown_seconds",
@@ -56,7 +65,7 @@ def route_dispatch(
 ) -> Optional[TierRoute]:
     """Smart router entry point. Default-on since 2026-08-02.
 
-    Tier-low routing (deepseek-v4-flash, codex fallback) is active by default.
+    Tier-low routing (deepseek-v4-pro, codex fallback) is active by default.
     Operators can disable it with VNX_SMART_ROUTER_DISABLE=1. The old VNX_AUTO_ROUTE
     opt-in flag is still honoured for backward compat but is superseded.
 

--- a/scripts/lib/providers/smart_router/tier_routing.py
+++ b/scripts/lib/providers/smart_router/tier_routing.py
@@ -17,6 +17,16 @@ availability layer is the single gate, so there is no separate "missing key"
 branch. The chain terminates in an ungated lane (claude/codex), so a route is
 always returned.
 
+Two mechanisms live here and are deliberately opposite in intent (OI-1221):
+
+  * AVAILABILITY fallback — ``resolve_tier_route`` + ``_walk_chain``. An
+    unavailable lane is skipped and the next chain step takes over ON THE SAME
+    TIER. A safety net, never an escalation.
+  * QUALITY escalation — ``escalate_tier`` + ``next_tier``. A REJECTED result
+    fires a followup dispatch one tier UP the cost ladder (tier_to =
+    tier_from + 1), linked by parent_dispatch. It climbs; it never walks the
+    fallback list.
+
 Constraint references (provider_constraints.yaml):
   kimi-via-cli-only: kimi_cli lane, never via=api/moonshot
   deepseek-harness-subscription-blocked: DEEPSEEK_API_KEY required; own key only
@@ -30,7 +40,12 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from providers.provider_registry import RegistryLookupError, TierRouteSpec, load_tier_map
+from providers.provider_registry import (
+    RegistryLookupError,
+    TierRouteSpec,
+    load_tier_ladder,
+    load_tier_map,
+)
 
 from .cost_tier import TIER_HIGH
 
@@ -52,6 +67,60 @@ class TierRoute:
 # RegistryLookupError here, before any dispatch reaches the lookup — loud and
 # early rather than discovered mid-dispatch.
 _TIER_MAP = load_tier_map()
+
+# The cost-ordered escalation ladder (cheapest first), derived from the
+# registry's own prices. load_tier_ladder() fails loud on a duplicate rung or a
+# non-monotonic price order, so a ladder that would make escalation a no-op is
+# caught at import — same fail-early contract as _TIER_MAP above.
+_TIER_LADDER = load_tier_ladder()
+
+
+@dataclass(frozen=True)
+class TierEscalation:
+    """Quality-escalation signal for a REJECTED result (OI-1221).
+
+    This is the vertical counterpart to the availability fallback above: a
+    rejected result fires a followup dispatch one tier UP the cost ladder
+    (``tier_to = tier_from + 1``), linked back to the rejected attempt via
+    ``parent_dispatch``. ``tier_to`` is None when the ladder is already topped
+    (no rung above ``tier_from``) — a caller must then stop climbing, not wrap.
+    """
+
+    tier_from: str
+    tier_to: Optional[str]
+    parent_dispatch: str
+
+
+def next_tier(tier: str) -> Optional[str]:
+    """Return the tier one rung up the cost ladder, or None at the top.
+
+    The ladder order is read from the registry (``_TIER_LADDER``), never a
+    Python literal, so a newly registered model slots into the climb without a
+    code edit. An unknown tier returns None (fail-safe: do not escalate from a
+    rung the ladder does not know).
+    """
+    names = [rung.tier for rung in _TIER_LADDER]
+    try:
+        idx = names.index(tier)
+    except ValueError:
+        return None
+    return names[idx + 1] if idx + 1 < len(names) else None
+
+
+def escalate_tier(tier_from: str, parent_dispatch: str) -> TierEscalation:
+    """Build the quality-escalation signal for a rejected result.
+
+    Deterministic: ``tier_to`` is exactly one rung above ``tier_from`` on the
+    cost ladder, and ``parent_dispatch`` names the rejected attempt so the
+    followup is traceable in the audit trail. This is quality escalation, NOT
+    availability fallback — it never walks the tier's ``fallback`` chain and it
+    never stays on the same tier.
+    """
+    return TierEscalation(
+        tier_from=tier_from,
+        tier_to=next_tier(tier_from),
+        parent_dispatch=parent_dispatch,
+    )
 
 
 def _route_from_spec(

--- a/scripts/lib/providers/wave7_models.yaml
+++ b/scripts/lib/providers/wave7_models.yaml
@@ -330,6 +330,27 @@ providers:
 # chain). provider_registry.load_tier_map() validates every reference and raises
 # RegistryLookupError (naming what+where) on anything this registry does not
 # know.
+#
+# COST LADDER (OI-1221): the four tiers form an ordered ladder over the
+# dispatchable models, cheapest first. A tier higher is demonstrably more
+# expensive AND more capable, so a quality escalation actually climbs:
+#
+#   tier-zero  deepseek-v4-flash  $0.28/Mtok out
+#   tier-low   deepseek-v4-pro    $0.87/Mtok out   (the daily workhorse)
+#   tier-mid   sonnet-5          $15.00/Mtok out
+#   tier-high  opus-5            $25.00/Mtok out
+#
+# Two mechanisms, opposite in intent, are deliberately kept apart:
+#   * AVAILABILITY fallback (the `fallback` list below) — an unavailable lane is
+#     skipped and the next chain step takes over ON THE SAME TIER. It is a
+#     safety net, never an escalation.
+#   * QUALITY escalation (tier_routing.escalate_tier) — a REJECTED result fires
+#     a followup dispatch one tier UP (tier_to = tier_from + 1), linked by
+#     parent_dispatch. It climbs the ladder; it never walks the fallback list.
+# provider_registry.load_tier_ladder() enforces both invariants fail-loud: no
+# two tiers may resolve to the same primary (a duplicate rung escalates
+# nowhere) and primary cost must be strictly increasing (a higher rung must
+# actually be more expensive).
 # ---------------------------------------------------------------------------
 routing:
   tier_map:
@@ -346,7 +367,7 @@ routing:
           lane: provider
     tier-low:
       provider: deepseek_harness
-      model: deepseek-v4-flash
+      model: deepseek-v4-pro
       lane: claude_harness_keyed
       fallback:
         - provider: kimi_cli

--- a/tests/smart_router/test_cost_ladder.py
+++ b/tests/smart_router/test_cost_ladder.py
@@ -1,0 +1,222 @@
+"""Tests for the cost-ordered escalation ladder (OI-1221).
+
+Pins the two invariants that made the old tier map a safety net rather than a
+ladder, and the two mechanisms that must stay apart:
+
+Ladder (derived from wave7_models.yaml, never Python literals):
+  - cost is strictly increasing along the tier order (a higher rung is
+    demonstrably more expensive),
+  - no two tiers resolve to the same primary (a duplicate rung escalates
+    nowhere).
+
+Two mechanisms, opposite in intent:
+  - AVAILABILITY fallback (resolve_tier_route) skips an unavailable lane and
+    lands ON THE SAME TIER — a safety net, never an escalation.
+  - QUALITY escalation (escalate_tier) fires a followup dispatch one tier UP
+    (tier_to = tier_from + 1), linked by parent_dispatch — it climbs, never
+    walks the fallback chain.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+import yaml
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts" / "lib"))
+
+from providers.provider_registry import RegistryLookupError, load_tier_ladder
+from providers.smart_router.cost_tier import TIER_HIGH, TIER_LOW, TIER_MID, TIER_ZERO
+from providers.smart_router.tier_routing import escalate_tier, next_tier, resolve_tier_route
+
+
+def _force_kimi(monkeypatch, present: bool):
+    """Deterministically set the kimi CLI presence on PATH (mirrors tier_routing tests)."""
+    import shutil as _shutil
+
+    monkeypatch.setattr(
+        _shutil,
+        "which",
+        (lambda name: "/usr/local/bin/kimi") if present else (lambda name: None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Ladder invariants — derived from the registry
+# ---------------------------------------------------------------------------
+
+def test_ladder_cost_is_strictly_monotonic():
+    """A higher tier is demonstrably more expensive (cost strictly increasing)."""
+    ladder = load_tier_ladder()
+    costs = [rung.output_cost_per_mtok for rung in ladder]
+    assert len(costs) == len(set(costs)), f"cost ties are not a ladder: {costs}"
+    assert all(a < b for a, b in zip(costs, costs[1:])), costs
+
+
+def test_ladder_has_no_duplicate_rungs():
+    """No two tiers resolve to the same primary (provider, model)."""
+    ladder = load_tier_ladder()
+    primaries = [(rung.provider, rung.model) for rung in ladder]
+    assert len(primaries) == len(set(primaries)), primaries
+
+
+def test_ladder_tier_zero_and_low_are_distinct():
+    """tier-zero and tier-low were identical (both flash); now they differ."""
+    by_tier = {rung.tier: rung for rung in load_tier_ladder()}
+    assert by_tier[TIER_ZERO].model == "deepseek-v4-flash"
+    assert by_tier[TIER_LOW].model == "deepseek-v4-pro"
+    assert by_tier[TIER_ZERO].model != by_tier[TIER_LOW].model
+
+
+def test_ladder_order_is_cheapest_first():
+    """The authored tier order climbs from the cheapest to the most expensive."""
+    ladder = load_tier_ladder()
+    assert [rung.tier for rung in ladder] == [
+        TIER_ZERO,
+        TIER_LOW,
+        TIER_MID,
+        TIER_HIGH,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Fail-loud: a drifted registry is caught at load, not silently
+# ---------------------------------------------------------------------------
+
+def _model(out_cost: float) -> dict:
+    return {
+        "litellm_name": "m",
+        "cost_input_per_mtok": 0.1,
+        "cost_output_per_mtok": out_cost,
+        "max_tokens": 100,
+        "supports_streaming": True,
+        "supports_tool_calls": True,
+    }
+
+
+def _provider(enum: str, models: dict) -> dict:
+    return {
+        "enabled": True,
+        "api_key_env": "A",
+        "dispatch_enum": enum,
+        "models": models,
+    }
+
+
+def _write_registry(tmp_path: Path, providers: dict, tier_map: dict) -> Path:
+    path = tmp_path / "wave7_models.yaml"
+    # sort_keys=False: the tier_map dict order IS the authored ladder order under
+    # test (a sorted dump would silently reorder tier-zero/tier-low and turn the
+    # non-monotonic fixture into a valid ladder).
+    path.write_text(
+        yaml.dump(
+            {"providers": providers, "routing": {"tier_map": tier_map}},
+            sort_keys=False,
+        ),
+        encoding="utf-8",
+    )
+    return path
+
+
+def test_load_tier_ladder_fails_on_duplicate_rung(tmp_path):
+    """Two tiers resolving to the same primary raise — escalation would change nothing."""
+    providers = {
+        "pa": _provider("pa", {"cheap": _model(0.5)}),
+        "pb": _provider("pb", {"pricey": _model(5.0)}),
+    }
+    tier_map = {
+        "tier-zero": {"provider": "pa", "model": "cheap", "lane": "l"},
+        "tier-low": {"provider": "pa", "model": "cheap", "lane": "l"},
+    }
+    path = _write_registry(tmp_path, providers, tier_map)
+    with pytest.raises(RegistryLookupError, match="duplicate rungs"):
+        load_tier_ladder(registry_path=path)
+
+
+def test_load_tier_ladder_fails_on_equal_cost(tmp_path):
+    """Two distinct primaries at the same cost raise — no strict climb."""
+    providers = {
+        "pa": _provider("pa", {"cheap": _model(0.5)}),
+        "pc": _provider("pc", {"samecost": _model(0.5)}),
+    }
+    tier_map = {
+        "tier-zero": {"provider": "pa", "model": "cheap", "lane": "l"},
+        "tier-low": {"provider": "pc", "model": "samecost", "lane": "l"},
+    }
+    path = _write_registry(tmp_path, providers, tier_map)
+    with pytest.raises(RegistryLookupError, match="strict cost ladder"):
+        load_tier_ladder(registry_path=path)
+
+
+def test_load_tier_ladder_fails_on_non_monotonic_cost(tmp_path):
+    """A higher tier that is CHEAPER than the tier below raises."""
+    providers = {
+        "pa": _provider("pa", {"cheap": _model(0.5)}),
+        "pb": _provider("pb", {"pricey": _model(5.0)}),
+    }
+    tier_map = {
+        "tier-zero": {"provider": "pb", "model": "pricey", "lane": "l"},  # 5.0
+        "tier-low": {"provider": "pa", "model": "cheap", "lane": "l"},    # 0.5
+    }
+    path = _write_registry(tmp_path, providers, tier_map)
+    with pytest.raises(RegistryLookupError, match="strict cost ladder"):
+        load_tier_ladder(registry_path=path)
+
+
+# ---------------------------------------------------------------------------
+# Quality escalation — rejected result climbs one tier up
+# ---------------------------------------------------------------------------
+
+def test_escalate_rejected_result_climbs_one_tier():
+    esc = escalate_tier(TIER_LOW, "20260815-rejected-attempt")
+    assert esc.tier_from == TIER_LOW
+    assert esc.tier_to == TIER_MID
+    assert esc.parent_dispatch == "20260815-rejected-attempt"
+
+
+def test_escalate_from_zero_to_low():
+    assert escalate_tier(TIER_ZERO, "d-zero").tier_to == TIER_LOW
+
+
+def test_escalate_from_mid_to_high():
+    assert escalate_tier(TIER_MID, "d-mid").tier_to == TIER_HIGH
+
+
+def test_escalate_at_top_returns_none():
+    assert escalate_tier(TIER_HIGH, "d-top").tier_to is None
+
+
+def test_escalate_unknown_tier_returns_none():
+    assert escalate_tier("tier-unknown", "d-unknown").tier_to is None
+
+
+def test_next_tier_matches_escalate_tier():
+    assert next_tier(TIER_ZERO) == TIER_LOW
+    assert next_tier(TIER_LOW) == TIER_MID
+    assert next_tier(TIER_MID) == TIER_HIGH
+    assert next_tier(TIER_HIGH) is None
+
+
+# ---------------------------------------------------------------------------
+# The two mechanisms are opposite — availability stays, escalation climbs
+# ---------------------------------------------------------------------------
+
+def test_availability_fallback_stays_on_same_tier(monkeypatch):
+    """An unavailable lane walks the fallback chain but stays on the SAME tier."""
+    _force_kimi(monkeypatch, present=False)
+    route = resolve_tier_route(TIER_LOW, env={})  # no DEEPSEEK_API_KEY, no kimi
+    assert route.provider == "codex"   # fell back to the vangnet lane
+    assert route.tier == TIER_LOW      # but did NOT climb — availability is not escalation
+
+
+def test_quality_escalation_climbs_where_fallback_stays(monkeypatch):
+    """Availability fallback keeps the tier; quality escalation moves up one rung."""
+    _force_kimi(monkeypatch, present=False)
+    route = resolve_tier_route(TIER_LOW, env={})
+    assert route.tier == TIER_LOW
+
+    esc = escalate_tier(TIER_LOW, "d-rejected")
+    assert esc.tier_from == TIER_LOW
+    assert esc.tier_to == TIER_MID
+    assert esc.parent_dispatch == "d-rejected"

--- a/tests/smart_router/test_tier_routing.py
+++ b/tests/smart_router/test_tier_routing.py
@@ -93,12 +93,16 @@ def test_tier_low_with_deepseek_key_uses_harness():
     assert "DEEPSEEK_API_KEY" in route.env_requirements
 
 
-def test_tier_low_deepseek_route_uses_v4_flash():
-    """tier-low DeepSeek route must use deepseek-v4-flash."""
+def test_tier_low_deepseek_route_uses_v4_pro():
+    """tier-low DeepSeek route must use deepseek-v4-pro (the daily workhorse).
+
+    tier-zero and tier-low were identical (both deepseek-v4-flash) — an
+    escalation from zero to low changed nothing. tier-low now sits one rung up
+    the cost ladder on deepseek-v4-pro (OI-1221)."""
     env = {"DEEPSEEK_API_KEY": "sk-test-123"}
     route = resolve_tier_route(TIER_LOW, env=env)
     assert route.provider == "deepseek-harness"
-    assert route.model == "deepseek-v4-flash"
+    assert route.model == "deepseek-v4-pro"
 
 
 def test_deepseek_harness_blocked_without_key(monkeypatch):
@@ -231,7 +235,7 @@ def test_tier_low_deepseek_reengages_after_cooldown(tmp_path):
         state_dir=state_dir, now=now + 3601,
     )
     assert route.provider == "deepseek-harness"
-    assert route.model == "deepseek-v4-flash"
+    assert route.model == "deepseek-v4-pro"
 
 
 def test_auth_failure_keeps_lane_out_past_waiting(tmp_path, monkeypatch):
@@ -369,7 +373,7 @@ def test_door_route_auto_fills_provider(monkeypatch):
     assert result.route is not None
     provider, model, reason = result.route
     assert provider == Provider.DEEPSEEK_HARNESS
-    assert model == "deepseek-v4-flash"
+    assert model == "deepseek-v4-pro"
     assert "tier=tier-low" in reason
 
 


### PR DESCRIPTION
## Wat

De provider-kostenladder was een vangnet, geen ladder. `provider_registry.load_tier_map()` gaf vier tiers waarvan tier-zero en tier-low identiek waren (beide `deepseek-v4-flash`), en de enige `fallback` die bestond was een availability-fallback die op dezelfde tier bleef. Escaleren veranderde niets.

## Change

- **tier-low primair** van `deepseek-v4-flash` naar `deepseek-v4-pro` ($0.28 → $0.87/Mtok out): tier-zero en tier-low zijn nu twee verschillende rungs.
- **`load_tier_ladder()`** in `provider_registry.py` leidt de escalatie-volgorde af uit de prijzen in `wave7_models.yaml` (ADR-036: nul modelnamen/prijzen als Python-literals). Faalt luid op een dubbele rung of niet-strikt-stijgende kost.
- **Quality escalation** in `tier_routing.py`: `escalate_tier(tier_from, parent_dispatch)` geeft `tier_to = tier_from + 1` met `parent_dispatch` die naar de afgewezen poging wijst. `next_tier()` is de ladder-opzoeking, gelezen uit de registry.
- **Twee mechanismen expliciet gescheiden** in code + test: availability-fallback (`resolve_tier_route`) blijft op dezelfde tier (vangnet); quality-escalation (`escalate_tier`) klimt één rung omhoog.

## Registry-observatie (niet gewijzigd)

`wave7_models.yaml` is alleen gewijzigd waar een aantoonbare fout stond (tier-zero == tier-low). Twee modellen blijven bewust buiten de auto-ladder: `glm-5.2` (heeft geen `dispatch_enum` in de registry, route loopt via `litellm:zai`) en `fable-5` (alleen via expliciete override bereikbaar). Geen wijziging nodig, alleen melding.

## Tests

`tests/smart_router/test_cost_ladder.py` (nieuw): kosten strikt monotoon, geen dubbele rungs, tier-zero/tier-low verschillend, fail-loud op dubbele rung / gelijke kost / niet-monotone kost, escalation klimt één tier, availability-fallback blijft op dezelfde tier. Bestaande `test_tier_routing.py` bijgewerkt (flash → pro).

Targeted tests groen (53 + 158 + 124 = ~335 asserts, 1 warning). Twee pre-existing failures in niet-aangeraakte bestanden blijven staan (zie Open Items).

🤖 Generated with [Claude Code](https://claude.com/claude-code)